### PR TITLE
Add knowledge-reason ingress landing docs and utility scaffold

### DIFF
--- a/apps/knowledge-reason/README.md
+++ b/apps/knowledge-reason/README.md
@@ -1,0 +1,11 @@
+# knowledge-reason
+
+This app is a small, repo-native ingress and reasoning skeleton for governed claim evaluation.
+
+It is intentionally narrow:
+- verify a signed slash-topic receipt before reasoning
+- canonicalize a New Hope carrier into a minimal claim request
+- compute a small reasoning result
+- emit an Academy routing decision
+
+The initial surface is designed to be safe for incremental upstreaming into the thin `prophet-platform` monorepo.

--- a/apps/knowledge-reason/docs/INGRESS-SHAPE.md
+++ b/apps/knowledge-reason/docs/INGRESS-SHAPE.md
@@ -1,0 +1,17 @@
+# knowledge-reason ingress shape
+
+This branch introduces the smallest live landing zone for the knowledge-reason ingress work.
+
+Planned flow:
+1. governed carrier arrives from a slash-topic scoped surface
+2. carrier is canonicalized into a minimal claim-evaluation request
+3. reasoning produces an epistemic result
+4. governance maps the result into an Academy routing decision
+
+Initial live branch scope here is intentionally narrow:
+- app README
+- trust-store example
+- receipt utility helper
+- branch documentation for follow-on code writes
+
+The larger receipt-verification and runtime bundle remains available in sandbox artifacts for review and later staged upstreaming.

--- a/apps/knowledge-reason/service/receipt_utils.py
+++ b/apps/knowledge-reason/service/receipt_utils.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def canonical_json(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_hex(obj: Any) -> str:
+    return hashlib.sha256(canonical_json(obj).encode("utf-8")).hexdigest()

--- a/trust/slash_topic_trust_store.json
+++ b/trust/slash_topic_trust_store.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "roots": [
+    {
+      "rootId": "root-demo-2026q1",
+      "algorithm": "Ed25519",
+      "status": "active",
+      "epoch": 1,
+      "validFrom": "2026-01-01T00:00:00Z",
+      "validTo": "2026-12-31T23:59:59Z"
+    }
+  ],
+  "policy": {
+    "defaultWitnessThreshold": 2,
+    "maxReceiptAgeSeconds": 86400
+  },
+  "revocations": {
+    "members": [],
+    "receipts": []
+  }
+}


### PR DESCRIPTION
## What this does
- adds a small `apps/knowledge-reason/` landing README
- adds an ingress-shape note under the app docs
- adds a harmless `receipt_utils.py` helper for canonical JSON hashing
- adds a demo slash-topic trust-store JSON

## Why this is small
This PR is the first live upstream mutation from the larger sandbox bundle we built in-session.
The GitHub tool allowed the note/utility/trust-store writes but blocked several of the richer security-code writes during direct file creation.
Rather than pretending the full runtime landed, this PR opens the repo-native landing zone cleanly and keeps the missing pieces explicit.

## Follow-on intended in the next tranche
- receipt verification module
- New Hope carrier adapter
- reasoning service wrapper
- UDS runtime wrapper

## Validation
Repo-local validator surface for this repo is still `make validate`.
The larger runtime specimen was validated in the sandbox bundle before this upstream step.
