### PR TITLE
platform: add eval fabric governance and provenance schemas

### DIFF
--- a/docs/EVAL_FABRIC_GOVERNANCE.md
+++ b/docs/EVAL_FABRIC_GOVERNANCE.md
@@ -1,0 +1,57 @@
+# Eval Fabric Governance Notes
+
+This document explains the platform-governance objects added under `schemas/eval/`.
+
+## Purpose
+
+The eval fabric should not only store scores. It should also store:
+- how a score was reproduced
+- how a score moved over time
+- what source methodology snapshot was used
+- how external metric names map into the platform canonical metric vocabulary
+
+## Core governance objects
+
+### ReproLedgerEntry
+
+Pins the reproducibility state of a run:
+- prompt pack
+- fixture snapshot
+- tool bundle
+- seed policy
+- environment hash
+- methodology snapshot hash
+- replay artifact reference
+
+### CausalAttribution
+
+Explains score movement by decomposition across:
+- model delta
+- scaffold delta
+- ontology delta
+- retrieval delta
+- benchmark drift
+- judge drift
+
+### MethodologySnapshot
+
+Hashes and timestamps the evaluation methodology or external-source methodology state used when facts were ingested or scored.
+
+### MetricCrosswalk
+
+Maps external or source-specific metric names into the platform canonical metric registry.
+
+## Why this matters
+
+Without these objects, the dashboard can look precise while actually hiding:
+- evaluator drift
+- benchmark drift
+- source-methodology mismatch
+- score movement with no attributable cause
+
+## Next platform step
+
+These schema objects should next be:
+1. seeded with example records
+2. surfaced in replay/provenance API responses
+3. linked from score computation and competition-intelligence ingest

--- a/schemas/eval/causal-attribution.schema.json
+++ b/schemas/eval/causal-attribution.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema://eval/causal-attribution.schema.json",
+  "title": "CausalAttribution",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["causal_attribution_id", "subject_id", "window", "attributions"],
+  "properties": {
+    "causal_attribution_id": {"type": "string"},
+    "subject_id": {"type": "string"},
+    "window": {"type": "string"},
+    "attributions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "model_delta": {"type": "number"},
+        "scaffold_delta": {"type": "number"},
+        "ontology_delta": {"type": "number"},
+        "retrieval_delta": {"type": "number"},
+        "benchmark_drift": {"type": "number"},
+        "judge_drift": {"type": "number"}
+      }
+    },
+    "notes": {"type": "string"}
+  }
+}

--- a/schemas/eval/examples/causal-attribution.example.json
+++ b/schemas/eval/examples/causal-attribution.example.json
@@ -1,0 +1,14 @@
+{
+  "causal_attribution_id": "causal_001",
+  "subject_id": "model.semantic-stack.2026-04-05",
+  "window": "rolling_30d",
+  "attributions": {
+    "model_delta": 0.03,
+    "scaffold_delta": 0.01,
+    "ontology_delta": 0.02,
+    "retrieval_delta": 0.00,
+    "benchmark_drift": -0.01,
+    "judge_drift": 0.00
+  },
+  "notes": "Example attribution decomposition for a profile score movement window."
+}

--- a/schemas/eval/examples/methodology-snapshot.example.json
+++ b/schemas/eval/examples/methodology-snapshot.example.json
@@ -1,0 +1,8 @@
+{
+  "methodology_snapshot_id": "ms_001",
+  "source_descriptor_id": "src_helm_capabilities",
+  "hash": "sha256:helm-capabilities-2026-04-01",
+  "captured_at": "2026-04-09T05:00:00Z",
+  "url": "https://crfm.stanford.edu/2025/03/20/helm-capabilities.html",
+  "notes": "Example methodology snapshot for external benchmark ingest."
+}

--- a/schemas/eval/examples/metric-crosswalk.example.json
+++ b/schemas/eval/examples/metric-crosswalk.example.json
@@ -1,0 +1,7 @@
+{
+  "metric_crosswalk_id": "crosswalk_001",
+  "source_descriptor_id": "src_provider_openai_system_card",
+  "source_metric_name": "SimpleQA accuracy",
+  "canonical_metric_definition_id": "md_factoid_accuracy",
+  "transform_notes": "Example mapping from a provider-facing benchmark label into the platform canonical metric registry."
+}

--- a/schemas/eval/examples/repro-ledger-entry.example.json
+++ b/schemas/eval/examples/repro-ledger-entry.example.json
@@ -1,0 +1,12 @@
+{
+  "repro_ledger_entry_id": "repro_001",
+  "run_id": "run_001",
+  "prompt_pack_id": "promptpack.eval.v2",
+  "fixture_snapshot_id": "fixture_ranked_001@sha256:abc123",
+  "tool_bundle_id": "tools.bundle.prod.v5",
+  "seed_policy": "three_trial_fixed_seed_set",
+  "environment_hash": "sha256:env-001",
+  "methodology_snapshot_hash": "sha256:helm-capabilities-2026-04-01",
+  "replay_artifact_id": "replay_001",
+  "notes": "Example reproducibility ledger entry for eval fabric runs."
+}

--- a/schemas/eval/methodology-snapshot.schema.json
+++ b/schemas/eval/methodology-snapshot.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema://eval/methodology-snapshot.schema.json",
+  "title": "MethodologySnapshot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["methodology_snapshot_id", "source_descriptor_id", "hash", "captured_at"],
+  "properties": {
+    "methodology_snapshot_id": {"type": "string"},
+    "source_descriptor_id": {"type": "string"},
+    "hash": {"type": "string"},
+    "captured_at": {"type": "string", "format": "date-time"},
+    "url": {"type": "string"},
+    "notes": {"type": "string"}
+  }
+}

--- a/schemas/eval/metric-crosswalk.schema.json
+++ b/schemas/eval/metric-crosswalk.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema://eval/metric-crosswalk.schema.json",
+  "title": "MetricCrosswalk",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["metric_crosswalk_id", "source_descriptor_id", "source_metric_name", "canonical_metric_definition_id"],
+  "properties": {
+    "metric_crosswalk_id": {"type": "string"},
+    "source_descriptor_id": {"type": "string"},
+    "source_metric_name": {"type": "string"},
+    "canonical_metric_definition_id": {"type": "string"},
+    "transform_notes": {"type": "string"}
+  }
+}

--- a/schemas/eval/repro-ledger-entry.schema.json
+++ b/schemas/eval/repro-ledger-entry.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema://eval/repro-ledger-entry.schema.json",
+  "title": "ReproLedgerEntry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "repro_ledger_entry_id",
+    "run_id",
+    "environment_hash",
+    "methodology_snapshot_hash"
+  ],
+  "properties": {
+    "repro_ledger_entry_id": {"type": "string"},
+    "run_id": {"type": "string"},
+    "prompt_pack_id": {"type": "string"},
+    "fixture_snapshot_id": {"type": "string"},
+    "tool_bundle_id": {"type": "string"},
+    "seed_policy": {"type": "string"},
+    "environment_hash": {"type": "string"},
+    "methodology_snapshot_hash": {"type": "string"},
+    "replay_artifact_id": {"type": "string"},
+    "notes": {"type": "string"}
+  }
+}


### PR DESCRIPTION
## Summary

Add the next missing governance/provenance objects for the eval fabric lane under `schemas/eval/`:
- `repro-ledger-entry.schema.json`
- `causal-attribution.schema.json`
- `methodology-snapshot.schema.json`
- `metric-crosswalk.schema.json`

## Why

The platform bootstrap is already merged, but the lane still lacked the schema anchors for:
- reproducibility
- score movement attribution
- methodology hashing / drift capture
- source-metric to canonical-metric normalization

These are needed before the universal dashboard and competition-intelligence surfaces can be considered trustworthy.

## Scope

This PR is intentionally narrow and additive: schema-only follow-up to the already merged platform bootstrap.

## Next steps after merge

1. Land `JudgeDescriptor` usage and seed objects in the platform datastore path.
2. Wire these objects into the API and replay/provenance layer.
3. Patch root docs and dashboard surfaces to expose these governance objects directly.
