### PR TITLE
eval-fabric: fix pytest rootdir discovery causing CI ModuleNotFoundError

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go smoke-health validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go test-python-apps smoke smoke-health smoke-eval-fabric validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke
 
-validate: validate-repo drift-check standards-check topology-check test-go
+validate: validate-repo drift-check standards-check topology-check test-go validate-phase4 test-python-apps
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -22,14 +22,28 @@ test-go:
 	go test ./apps/api/...
 	go test ./apps/gateway/...
 
+test-python-apps:
+	cd apps/eval-fabric-api && test -d .venv || python3 -m venv .venv
+	cd apps/eval-fabric-api && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt && pytest -q tests ../knowledge-reason/tests
+
+smoke: smoke-health smoke-eval-fabric
+
 smoke-health:
 	bash tools/smoke_tritrpc_health.sh
+
+smoke-eval-fabric:
+	bash tools/smoke_eval_fabric.sh
 
 validate-phase3:
 	python3 tools/validate_phase3_contracts.py
 
 lampstand-smoke:
-	PYTHONPATH=apps/lampstand/src python3 -m prophet_platform_lampstand.main emit-receipt 	  --event-type lampstand.smoke 	  --action Smoke 	  --status succeeded 	  --subject-ref service://lampstand 	  --payload-ref artifact://smoke
+	PYTHONPATH=apps/lampstand/src python3 -m prophet_platform_lampstand.main emit-receipt \
+	  --event-type lampstand.smoke \
+	  --action Smoke \
+	  --status succeeded \
+	  --subject-ref service://lampstand \
+	  --payload-ref artifact://smoke
 
 validate-phase4:
 	python3 tools/validate_phase4_vertical_slice.py

--- a/apps/README.md
+++ b/apps/README.md
@@ -2,15 +2,17 @@
 
 `apps/` contains deployable runtime services and applications.
 
-## Current
+## Current runtime surfaces
 
-* `api`
-* `gateway`
-* `socioprophet-web`
+* `api` — internal TriTRPC bootstrap service
+* `gateway` — browser-facing ingress relay
+* `socioprophet-web` — portal shell
+* `eval-fabric-api` — platform evaluation, observability, and intelligence lane
+* `knowledge-reason` — governed claim-evaluation ingress scaffold
+* `lampstand` — local-daemon integration target with platform receipt/catalog emission
 
-## Planned imports
+## Planned imports / promotions
 
-* `lampstand`
 * `agentplane`
 * `workspace-controller`
 * `identity-prime`

--- a/apps/eval-fabric-api/README.md
+++ b/apps/eval-fabric-api/README.md
@@ -4,23 +4,36 @@ FastAPI surface for the Prophet Platform evaluation, observability, and intellig
 
 ## Canonical runtime
 
-The default runtime is now the **unified** application path:
+The default runtime is the **unified** application path:
 - `/healthz` — process liveness only
 - `/readyz` — Postgres + ClickHouse readiness
 - `/v1/frontier` — profile-score frontier view (ClickHouse)
 - `/v1/models/{model_release_id}/dossier` — model dossier facts (ClickHouse)
 - `/v1/competition/radar` — competitor radar view (Postgres)
 
-The default Dockerfile and default local compose stack should point at this runtime.
+The default Dockerfile and default local compose stack point at this runtime.
+
+## Receipt / evidence emission
+
+When `EVAL_FABRIC_EMIT_RECEIPTS=1`, business routes emit local platform artifacts:
+- payload artifact
+- `EventEnvelope`
+- `EvidenceReceipt`
+
+The API returns file refs for these artifacts in response headers:
+- `X-Payload-Ref`
+- `X-Event-Envelope-Ref`
+- `X-Evidence-Receipt-Ref`
 
 ## Retained variants
 
-The repo may still carry alternate files such as `persisted_main.py` or alternate Dockerfiles during transition, but the platform default should be the unified path, not the seeded demo path.
+The repo may still carry alternate files such as `persisted_main.py` or alternate Dockerfiles during transition, but the platform default is the unified path, not the seeded demo path.
 
 ## Tests
 
-This lane should be backed by:
+This lane is backed by:
 - route tests
 - repository parameterization tests
 - schema validation tests
+- receipt emission tests
 - a compose-backed smoke test

--- a/apps/eval-fabric-api/README.md
+++ b/apps/eval-fabric-api/README.md
@@ -1,11 +1,26 @@
 # eval-fabric-api
 
-Thin FastAPI starter for the Prophet Platform evaluation, observability, and intelligence lane.
+FastAPI surface for the Prophet Platform evaluation, observability, and intelligence lane.
 
-Current routes:
-- `/healthz`
-- `/v1/frontier`
-- `/v1/models/{model_release_id}/dossier`
-- `/v1/competition/radar`
+## Canonical runtime
 
-This app is intentionally seeded. Its job in this repo is to anchor the platform surface, container wiring, and database responsibility for the lane.
+The default runtime is now the **unified** application path:
+- `/healthz` — process liveness only
+- `/readyz` — Postgres + ClickHouse readiness
+- `/v1/frontier` — profile-score frontier view (ClickHouse)
+- `/v1/models/{model_release_id}/dossier` — model dossier facts (ClickHouse)
+- `/v1/competition/radar` — competitor radar view (Postgres)
+
+The default Dockerfile and default local compose stack should point at this runtime.
+
+## Retained variants
+
+The repo may still carry alternate files such as `persisted_main.py` or alternate Dockerfiles during transition, but the platform default should be the unified path, not the seeded demo path.
+
+## Tests
+
+This lane should be backed by:
+- route tests
+- repository parameterization tests
+- schema validation tests
+- a compose-backed smoke test

--- a/apps/eval-fabric-api/app/db.py
+++ b/apps/eval-fabric-api/app/db.py
@@ -2,30 +2,63 @@ from __future__ import annotations
 
 import os
 from typing import Any
+from urllib.parse import urlparse
 
 import clickhouse_connect
 import psycopg
 from psycopg.rows import dict_row
 
-POSTGRES_DSN = os.getenv("POSTGRES_DSN", "postgresql://prophet:prophet@localhost:5432/prophet_platform")
-CLICKHOUSE_HOST = os.getenv("CLICKHOUSE_HOST", "localhost")
-CLICKHOUSE_PORT = int(os.getenv("CLICKHOUSE_PORT", "8123"))
-CLICKHOUSE_DATABASE = os.getenv("CLICKHOUSE_DATABASE", "default")
+
+def _postgres_dsn() -> str:
+    return os.getenv("POSTGRES_DSN", "postgresql://prophet:prophet@localhost:5432/prophet_platform")
+
+
+def _clickhouse_config() -> tuple[str, int, str]:
+    dsn = os.getenv("CLICKHOUSE_DSN", "").strip()
+    default_host = os.getenv("CLICKHOUSE_HOST", "localhost")
+    default_port = int(os.getenv("CLICKHOUSE_PORT", "8123"))
+    default_db = os.getenv("CLICKHOUSE_DATABASE", "default")
+
+    if not dsn:
+        return default_host, default_port, default_db
+
+    parsed = urlparse(dsn)
+    host = parsed.hostname or default_host
+    port = parsed.port or default_port
+    database = parsed.path.lstrip("/") or default_db
+    return host, port, database
 
 
 def pg_fetch(sql: str, params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
-    with psycopg.connect(POSTGRES_DSN) as conn:
+    with psycopg.connect(_postgres_dsn()) as conn:
         with conn.cursor(row_factory=dict_row) as cur:
             cur.execute(sql, params)
             return list(cur.fetchall())
 
 
 def ch_query(sql: str, parameters: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    host, port, database = _clickhouse_config()
     client = clickhouse_connect.get_client(
-        host=CLICKHOUSE_HOST,
-        port=CLICKHOUSE_PORT,
-        database=CLICKHOUSE_DATABASE,
+        host=host,
+        port=port,
+        database=database,
     )
     result = client.query(sql, parameters=parameters or {})
     cols = list(result.column_names)
     return [dict(zip(cols, row)) for row in result.result_rows]
+
+
+def pg_health() -> dict[str, Any]:
+    try:
+        rows = pg_fetch("select 1 as ok")
+        return {"ok": len(rows) == 1}
+    except Exception as exc:  # pragma: no cover
+        return {"ok": False, "error": str(exc)}
+
+
+def ch_health() -> dict[str, Any]:
+    try:
+        rows = ch_query("select 1 as ok")
+        return {"ok": len(rows) == 1}
+    except Exception as exc:  # pragma: no cover
+        return {"ok": False, "error": str(exc)}

--- a/apps/eval-fabric-api/app/db.py
+++ b/apps/eval-fabric-api/app/db.py
@@ -1,12 +1,38 @@
 from __future__ import annotations
 
 import os
+import time
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlparse
 
 import clickhouse_connect
 import psycopg
 from psycopg.rows import dict_row
+
+# Health check results are cached for this many seconds to avoid creating
+# a new DB connection on every K8s readiness probe (default period: 5 s).
+_HEALTH_TTL: float = float(os.getenv("HEALTH_CACHE_TTL_S", "10"))
+
+# { check_name -> (monotonic_timestamp, result_dict) }
+_health_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+
+
+def clear_health_cache() -> None:
+    """Evict all cached health results. Intended for test isolation."""
+    _health_cache.clear()
+
+
+def _cached_health(key: str, fn: Callable[[], dict[str, Any]]) -> dict[str, Any]:
+    now = time.monotonic()
+    entry = _health_cache.get(key)
+    if entry is not None:
+        ts, result = entry
+        if now - ts < _HEALTH_TTL:
+            return result
+    result = fn()
+    _health_cache[key] = (now, result)
+    return result
 
 
 def _postgres_dsn() -> str:
@@ -49,16 +75,20 @@ def ch_query(sql: str, parameters: dict[str, Any] | None = None) -> list[dict[st
 
 
 def pg_health() -> dict[str, Any]:
-    try:
-        rows = pg_fetch("select 1 as ok")
-        return {"ok": len(rows) == 1}
-    except Exception as exc:  # pragma: no cover
-        return {"ok": False, "error": str(exc)}
+    def _check() -> dict[str, Any]:
+        try:
+            rows = pg_fetch("select 1 as ok")
+            return {"ok": len(rows) == 1}
+        except Exception as exc:  # pragma: no cover
+            return {"ok": False, "error": str(exc)}
+    return _cached_health("postgres", _check)
 
 
 def ch_health() -> dict[str, Any]:
-    try:
-        rows = ch_query("select 1 as ok")
-        return {"ok": len(rows) == 1}
-    except Exception as exc:  # pragma: no cover
-        return {"ok": False, "error": str(exc)}
+    def _check() -> dict[str, Any]:
+        try:
+            rows = ch_query("select 1 as ok")
+            return {"ok": len(rows) == 1}
+        except Exception as exc:  # pragma: no cover
+            return {"ok": False, "error": str(exc)}
+    return _cached_health("clickhouse", _check)

--- a/apps/eval-fabric-api/app/main.py
+++ b/apps/eval-fabric-api/app/main.py
@@ -1,76 +1,54 @@
-from fastapi import FastAPI
+from __future__ import annotations
 
-app = FastAPI(title="Prophet Platform Eval Fabric", version="0.1.0")
+from fastapi import FastAPI, Response, status
 
-_FRONTIER = {
-    "profile_id": "profile.high_assurance_enterprise_agent",
-    "subjects": [
-        {
-            "subject_id": "model.semantic-stack.2026-04-05",
-            "score": 0.782,
-            "rank": 2,
-            "quality": 0.81,
-            "safety": 0.96,
-            "latency_p95_ms": 4870,
-            "cost_per_safe_task": 1.84,
-        },
-        {
-            "subject_id": "gpt5_aug2025",
-            "score": 0.801,
-            "rank": 1,
-            "quality": 0.86,
-            "safety": 0.94,
-            "latency_p95_ms": 5200,
-            "cost_per_safe_task": 2.11,
-        },
-    ],
-}
+from . import repositories
+from .db import ch_health, pg_health
 
-_DOSSIER = {
-    "model_release_id": "model.semantic-stack.2026-04-05",
-    "summary": {
-        "denotation_accuracy": 0.84,
-        "false_allow_rate": 0.0005,
-        "latency_ms_p95": 4870,
-    },
-    "notes": [
-        "Seeded dossier payload for platform UI wiring.",
-        "Next step is persisted reads from Postgres and ClickHouse.",
-    ],
-}
+app = FastAPI(title="Prophet Platform Eval Fabric", version="0.4.0")
 
-_RADAR = {
-    "lane": "high_assurance_enterprise_agent",
-    "competitors": [
-        {
-            "provider": "openai",
-            "model_release_id": "gpt5_aug2025",
-            "strategic_relevance": "high",
-            "source_trust_class": "official_provider",
-        },
-        {
-            "provider": "google",
-            "model_release_id": "gemini_family_current",
-            "strategic_relevance": "high",
-            "source_trust_class": "official_provider",
-        },
-    ],
-}
 
 @app.get("/healthz")
 def healthz() -> dict:
-    return {"status": "ok", "service": "eval-fabric-api"}
+    return {"status": "ok", "service": "eval-fabric-api", "mode": "unified"}
+
+
+@app.get("/readyz")
+def readyz(response: Response) -> dict:
+    postgres = pg_health()
+    clickhouse = ch_health()
+    ok = postgres.get("ok") and clickhouse.get("ok")
+    response.status_code = status.HTTP_200_OK if ok else status.HTTP_503_SERVICE_UNAVAILABLE
+    return {
+        "status": "ok" if ok else "degraded",
+        "service": "eval-fabric-api",
+        "postgres": postgres,
+        "clickhouse": clickhouse,
+    }
+
 
 @app.get("/v1/frontier")
 def frontier() -> dict:
-    return _FRONTIER
+    return {
+        "profile_id": "profile.high_assurance_enterprise_agent",
+        "subjects": repositories.get_frontier(),
+        "source": "clickhouse",
+    }
+
 
 @app.get("/v1/models/{model_release_id}/dossier")
 def dossier(model_release_id: str) -> dict:
-    payload = dict(_DOSSIER)
-    payload["model_release_id"] = model_release_id
-    return payload
+    return {
+        "model_release_id": model_release_id,
+        "metrics": repositories.get_model_dossier(model_release_id),
+        "source": "clickhouse",
+    }
+
 
 @app.get("/v1/competition/radar")
 def radar() -> dict:
-    return _RADAR
+    return {
+        "lane": "high_assurance_enterprise_agent",
+        "competitors": repositories.get_competition_radar(),
+        "source": "postgres",
+    }

--- a/apps/eval-fabric-api/app/main.py
+++ b/apps/eval-fabric-api/app/main.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import FastAPI, Response, status
 
 from . import repositories
 from .db import ch_health, pg_health
+from .receipts import maybe_emit_artifacts
 
-app = FastAPI(title="Prophet Platform Eval Fabric", version="0.4.0")
+app = FastAPI(title="Prophet Platform Eval Fabric", version="0.5.0")
+
+
+def _attach_refs(response: Response, emission: Any | None) -> None:
+    if emission is None:
+        return
+    response.headers["X-Payload-Ref"] = emission.payload_ref
+    response.headers["X-Event-Envelope-Ref"] = emission.event_ref
+    response.headers["X-Evidence-Receipt-Ref"] = emission.receipt_ref
 
 
 @app.get("/healthz")
@@ -28,27 +39,63 @@ def readyz(response: Response) -> dict:
 
 
 @app.get("/v1/frontier")
-def frontier() -> dict:
-    return {
+def frontier(response: Response) -> dict:
+    payload = {
         "profile_id": "profile.high_assurance_enterprise_agent",
         "subjects": repositories.get_frontier(),
         "source": "clickhouse",
     }
+    emission = maybe_emit_artifacts(
+        event_type="eval.fabric.frontier.read",
+        action="FrontierQuery",
+        status="succeeded",
+        subject_ref=f"profile://{payload['profile_id']}",
+        payload=payload,
+        scope_ref="scope://platform/eval-fabric",
+        classifiers=["route:frontier", "source:clickhouse"],
+        metrics={"subject_count": len(payload["subjects"])}
+    )
+    _attach_refs(response, emission)
+    return payload
 
 
 @app.get("/v1/models/{model_release_id}/dossier")
-def dossier(model_release_id: str) -> dict:
-    return {
+def dossier(model_release_id: str, response: Response) -> dict:
+    payload = {
         "model_release_id": model_release_id,
         "metrics": repositories.get_model_dossier(model_release_id),
         "source": "clickhouse",
     }
+    emission = maybe_emit_artifacts(
+        event_type="eval.fabric.dossier.read",
+        action="DossierQuery",
+        status="succeeded",
+        subject_ref=f"model://{model_release_id}",
+        payload=payload,
+        scope_ref="scope://platform/eval-fabric",
+        classifiers=["route:dossier", "source:clickhouse"],
+        metrics={"metric_count": len(payload["metrics"])}
+    )
+    _attach_refs(response, emission)
+    return payload
 
 
 @app.get("/v1/competition/radar")
-def radar() -> dict:
-    return {
+def radar(response: Response) -> dict:
+    payload = {
         "lane": "high_assurance_enterprise_agent",
         "competitors": repositories.get_competition_radar(),
         "source": "postgres",
     }
+    emission = maybe_emit_artifacts(
+        event_type="eval.fabric.radar.read",
+        action="RadarQuery",
+        status="succeeded",
+        subject_ref="lane://high_assurance_enterprise_agent",
+        payload=payload,
+        scope_ref="scope://platform/eval-fabric",
+        classifiers=["route:radar", "source:postgres"],
+        metrics={"competitor_count": len(payload["competitors"])}
+    )
+    _attach_refs(response, emission)
+    return payload

--- a/apps/eval-fabric-api/app/receipts.py
+++ b/apps/eval-fabric-api/app/receipts.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SERVICE_DIR = "eval-fabric-api"
+SERVICE_REF = "apps/eval-fabric-api"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def digest_json(payload: dict[str, Any]) -> str:
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(body).hexdigest()
+
+
+def state_home() -> Path:
+    if v := os.environ.get("SOCIOPROFIT_STATE_HOME"):
+        return Path(v)
+    return Path.home() / ".local" / "state"
+
+
+def service_root() -> Path:
+    return state_home() / "prophet-platform" / SERVICE_DIR
+
+
+def payloads_root() -> Path:
+    return service_root() / "payloads"
+
+
+def events_root() -> Path:
+    return service_root() / "events"
+
+
+def receipts_root() -> Path:
+    return service_root() / "receipts"
+
+
+def ensure_dirs() -> None:
+    for p in [payloads_root(), events_root(), receipts_root()]:
+        p.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass(frozen=True)
+class Emission:
+    payload_path: Path
+    event_path: Path
+    receipt_path: Path
+    payload_ref: str
+    event_ref: str
+    receipt_ref: str
+
+
+def emit_artifacts(
+    *,
+    event_type: str,
+    action: str,
+    status: str,
+    subject_ref: str,
+    payload: dict[str, Any],
+    scope_ref: str | None = None,
+    classifiers: list[str] | None = None,
+    metrics: dict[str, Any] | None = None,
+    correlation_id: str | None = None,
+) -> Emission:
+    ensure_dirs()
+    correlation_id = correlation_id or str(uuid.uuid4())
+    created_at = utc_now()
+
+    payload_path = payloads_root() / f"{correlation_id}.payload.json"
+    payload_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    payload_ref = f"file://{payload_path.resolve()}"
+
+    envelope_id = str(uuid.uuid4())
+    receipt_id = str(uuid.uuid4())
+
+    envelope = {
+        "version": "0.1",
+        "envelope_id": envelope_id,
+        "created_at": created_at,
+        "event_type": event_type,
+        "producer": SERVICE_REF,
+        "subject_ref": subject_ref,
+        "payload_ref": payload_ref,
+        "correlation_id": correlation_id,
+    }
+    if scope_ref:
+        envelope["scope_ref"] = scope_ref
+    if classifiers:
+        envelope["classifiers"] = classifiers
+
+    envelope_hash = digest_json(envelope)
+    receipt = {
+        "version": "0.1",
+        "receipt_id": receipt_id,
+        "created_at": created_at,
+        "service_ref": SERVICE_REF,
+        "action": action,
+        "status": status,
+        "subject_ref": subject_ref,
+        "envelope_ref": f"event://{envelope_id}",
+        "policy_refs": [],
+        "evidence_refs": [],
+        "output_refs": [payload_ref],
+        "metrics": metrics or {},
+        "hash": envelope_hash,
+        "hash_algo": "sha256",
+        "correlation_id": correlation_id,
+    }
+
+    event_path = events_root() / f"{correlation_id}.event.json"
+    receipt_path = receipts_root() / f"{correlation_id}.receipt.json"
+    event_path.write_text(json.dumps({**envelope, "receipt_ref": f"receipt://{receipt_id}"}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    return Emission(
+        payload_path=payload_path,
+        event_path=event_path,
+        receipt_path=receipt_path,
+        payload_ref=payload_ref,
+        event_ref=f"file://{event_path.resolve()}",
+        receipt_ref=f"file://{receipt_path.resolve()}",
+    )
+
+
+def maybe_emit_artifacts(**kwargs: Any) -> Emission | None:
+    if os.environ.get("EVAL_FABRIC_EMIT_RECEIPTS", "0") != "1":
+        return None
+    return emit_artifacts(**kwargs)

--- a/apps/eval-fabric-api/pytest.ini
+++ b/apps/eval-fabric-api/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 testpaths = tests
+pythonpath = .

--- a/apps/eval-fabric-api/pytest.ini
+++ b/apps/eval-fabric-api/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/apps/eval-fabric-api/requirements-test.txt
+++ b/apps/eval-fabric-api/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest==8.3.5
+httpx==0.27.2
+jsonschema==4.23.0

--- a/apps/eval-fabric-api/requirements.txt
+++ b/apps/eval-fabric-api/requirements.txt
@@ -1,2 +1,4 @@
 fastapi==0.115.0
 uvicorn==0.30.6
+psycopg[binary]==3.2.1
+clickhouse-connect==0.8.6

--- a/apps/eval-fabric-api/tests/test_db.py
+++ b/apps/eval-fabric-api/tests/test_db.py
@@ -32,3 +32,41 @@ def test_clickhouse_dsn_config_is_respected(monkeypatch):
     assert seen["host"] == "clickhouse"
     assert seen["port"] == 8123
     assert seen["database"] == "default"
+
+
+def test_health_cache_serves_cached_result(monkeypatch):
+    db.clear_health_cache()
+    call_count = 0
+
+    def fake_pg_fetch(_sql, _params=()):
+        nonlocal call_count
+        call_count += 1
+        return [{"ok": 1}]
+
+    monkeypatch.setattr(db, "pg_fetch", fake_pg_fetch)
+
+    result1 = db.pg_health()
+    result2 = db.pg_health()
+
+    assert result1 == {"ok": True}
+    assert result2 == {"ok": True}
+    assert call_count == 1, "underlying fetch should only be called once within the TTL"
+
+
+def test_health_cache_refreshes_after_ttl(monkeypatch):
+    db.clear_health_cache()
+    call_count = 0
+
+    def fake_pg_fetch(_sql, _params=()):
+        nonlocal call_count
+        call_count += 1
+        return [{"ok": 1}]
+
+    monkeypatch.setattr(db, "pg_fetch", fake_pg_fetch)
+    # Override TTL to zero so every call is a cache miss
+    monkeypatch.setattr(db, "_HEALTH_TTL", 0.0)
+
+    db.pg_health()
+    db.pg_health()
+
+    assert call_count == 2, "each call should hit the DB when TTL is zero"

--- a/apps/eval-fabric-api/tests/test_db.py
+++ b/apps/eval-fabric-api/tests/test_db.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import app.db as db
+
+
+class _DummyResult:
+    column_names = ["ok"]
+    result_rows = [(1,)]
+
+
+class _DummyClient:
+    def query(self, sql, parameters=None):
+        return _DummyResult()
+
+
+def test_clickhouse_dsn_config_is_respected(monkeypatch):
+    seen = {}
+
+    def fake_get_client(**kwargs):
+        seen.update(kwargs)
+        return _DummyClient()
+
+    monkeypatch.setenv("CLICKHOUSE_DSN", "http://clickhouse:8123/default")
+    monkeypatch.delenv("CLICKHOUSE_HOST", raising=False)
+    monkeypatch.delenv("CLICKHOUSE_PORT", raising=False)
+    monkeypatch.delenv("CLICKHOUSE_DATABASE", raising=False)
+    monkeypatch.setattr(db.clickhouse_connect, "get_client", fake_get_client)
+
+    rows = db.ch_query("select 1 as ok")
+
+    assert rows == [{"ok": 1}]
+    assert seen["host"] == "clickhouse"
+    assert seen["port"] == 8123
+    assert seen["database"] == "default"

--- a/apps/eval-fabric-api/tests/test_http_main.py
+++ b/apps/eval-fabric-api/tests/test_http_main.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import app.main as main
+
+client = TestClient(main.app)
+
+
+def test_healthz_is_process_only():
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["status"] == "ok"
+    assert payload["service"] == "eval-fabric-api"
+    assert payload["mode"] == "unified"
+
+
+def test_readyz_success(monkeypatch):
+    monkeypatch.setattr(main, "pg_health", lambda: {"ok": True})
+    monkeypatch.setattr(main, "ch_health", lambda: {"ok": True})
+
+    resp = client.get("/readyz")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["status"] == "ok"
+    assert payload["postgres"]["ok"] is True
+    assert payload["clickhouse"]["ok"] is True
+
+
+def test_readyz_degraded(monkeypatch):
+    monkeypatch.setattr(main, "pg_health", lambda: {"ok": False, "error": "postgres down"})
+    monkeypatch.setattr(main, "ch_health", lambda: {"ok": True})
+
+    resp = client.get("/readyz")
+    assert resp.status_code == 503
+    payload = resp.json()
+    assert payload["status"] == "degraded"
+    assert payload["postgres"]["ok"] is False
+    assert "error" in payload["postgres"]
+
+
+def test_frontier_uses_repository(monkeypatch):
+    expected = [{"subject_id": "model.semantic-stack.2026-04-05", "score": 0.782, "rank": 2}]
+    monkeypatch.setattr(main.repositories, "get_frontier", lambda *args, **kwargs: expected)
+
+    resp = client.get("/v1/frontier")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["profile_id"] == "profile.high_assurance_enterprise_agent"
+    assert payload["subjects"] == expected
+    assert payload["source"] == "clickhouse"
+
+
+def test_dossier_uses_repository(monkeypatch):
+    expected = [{"metric_definition_id": "md_denotation_accuracy", "value_scalar": 0.84}]
+    monkeypatch.setattr(main.repositories, "get_model_dossier", lambda model_release_id, limit=50: expected)
+
+    resp = client.get("/v1/models/model.semantic-stack.2026-04-05/dossier")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["model_release_id"] == "model.semantic-stack.2026-04-05"
+    assert payload["metrics"] == expected
+    assert payload["source"] == "clickhouse"
+
+
+def test_radar_uses_repository(monkeypatch):
+    expected = [{"provider_id": "openai", "model_release_id": "gpt5_aug2025"}]
+    monkeypatch.setattr(main.repositories, "get_competition_radar", lambda limit=50: expected)
+
+    resp = client.get("/v1/competition/radar")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["lane"] == "high_assurance_enterprise_agent"
+    assert payload["competitors"] == expected
+    assert payload["source"] == "postgres"

--- a/apps/eval-fabric-api/tests/test_http_main.py
+++ b/apps/eval-fabric-api/tests/test_http_main.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
 import app.main as main
@@ -50,6 +52,22 @@ def test_frontier_uses_repository(monkeypatch):
     assert payload["profile_id"] == "profile.high_assurance_enterprise_agent"
     assert payload["subjects"] == expected
     assert payload["source"] == "clickhouse"
+
+
+def test_frontier_emits_receipt_headers(monkeypatch, tmp_path):
+    expected = [{"subject_id": "model.semantic-stack.2026-04-05", "score": 0.782, "rank": 2}]
+    monkeypatch.setenv("EVAL_FABRIC_EMIT_RECEIPTS", "1")
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.setattr(main.repositories, "get_frontier", lambda *args, **kwargs: expected)
+
+    resp = client.get("/v1/frontier")
+    assert resp.status_code == 200
+    payload_ref = resp.headers["X-Payload-Ref"]
+    event_ref = resp.headers["X-Event-Envelope-Ref"]
+    receipt_ref = resp.headers["X-Evidence-Receipt-Ref"]
+    assert Path(payload_ref.removeprefix("file://")).exists()
+    assert Path(event_ref.removeprefix("file://")).exists()
+    assert Path(receipt_ref.removeprefix("file://")).exists()
 
 
 def test_dossier_uses_repository(monkeypatch):

--- a/apps/eval-fabric-api/tests/test_receipts.py
+++ b/apps/eval-fabric-api/tests/test_receipts.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import app.receipts as receipts
+
+
+def test_maybe_emit_disabled(monkeypatch):
+    monkeypatch.delenv("EVAL_FABRIC_EMIT_RECEIPTS", raising=False)
+    result = receipts.maybe_emit_artifacts(
+        event_type="eval.fabric.frontier.read",
+        action="FrontierQuery",
+        status="succeeded",
+        subject_ref="profile://profile.high_assurance_enterprise_agent",
+        payload={"ok": True},
+    )
+    assert result is None
+
+
+def test_emit_artifacts_writes_bundle(monkeypatch, tmp_path):
+    monkeypatch.setenv("EVAL_FABRIC_EMIT_RECEIPTS", "1")
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path / "state"))
+
+    emission = receipts.maybe_emit_artifacts(
+        event_type="eval.fabric.frontier.read",
+        action="FrontierQuery",
+        status="succeeded",
+        subject_ref="profile://profile.high_assurance_enterprise_agent",
+        payload={"profile_id": "profile.high_assurance_enterprise_agent", "subjects": []},
+        scope_ref="scope://platform/eval-fabric",
+        classifiers=["route:frontier"],
+        metrics={"subject_count": 0},
+        correlation_id="test-correlation-id",
+    )
+    assert emission is not None
+    assert emission.payload_path.exists()
+    assert emission.event_path.exists()
+    assert emission.receipt_path.exists()
+
+    event = json.loads(Path(emission.event_path).read_text(encoding="utf-8"))
+    receipt = json.loads(Path(emission.receipt_path).read_text(encoding="utf-8"))
+
+    assert event["producer"] == "apps/eval-fabric-api"
+    assert event["event_type"] == "eval.fabric.frontier.read"
+    assert receipt["service_ref"] == "apps/eval-fabric-api"
+    assert receipt["status"] == "succeeded"
+    assert receipt["hash_algo"] == "sha256"

--- a/apps/eval-fabric-api/tests/test_repositories.py
+++ b/apps/eval-fabric-api/tests/test_repositories.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import app.repositories as repositories
+
+
+def test_get_frontier_is_parameterized(monkeypatch):
+    seen = {}
+    probe = "profile' OR 1=1 --"
+
+    def fake(sql, parameters=None):
+        seen["sql"] = sql
+        seen["parameters"] = parameters
+        return []
+
+    monkeypatch.setattr(repositories, "ch_query", fake)
+    repositories.get_frontier(profile_id=probe, limit=7)
+
+    assert "{profile_id:String}" in seen["sql"]
+    assert "{limit:UInt64}" in seen["sql"]
+    assert probe not in seen["sql"]
+    assert seen["parameters"] == {"profile_id": probe, "limit": 7}
+
+
+def test_get_model_dossier_is_parameterized(monkeypatch):
+    seen = {}
+    probe = "model' OR 1=1 --"
+
+    def fake(sql, parameters=None):
+        seen["sql"] = sql
+        seen["parameters"] = parameters
+        return []
+
+    monkeypatch.setattr(repositories, "ch_query", fake)
+    repositories.get_model_dossier(probe, limit=9)
+
+    assert "{model_release_id:String}" in seen["sql"]
+    assert "{limit:UInt64}" in seen["sql"]
+    assert probe not in seen["sql"]
+    assert seen["parameters"] == {"model_release_id": probe, "limit": 9}
+
+
+def test_get_competition_radar_uses_positional_params(monkeypatch):
+    seen = {}
+
+    def fake(sql, params=()):
+        seen["sql"] = sql
+        seen["params"] = params
+        return []
+
+    monkeypatch.setattr(repositories, "pg_fetch", fake)
+    repositories.get_competition_radar(limit=11)
+
+    assert "limit %s" in seen["sql"]
+    assert seen["params"] == (11,)

--- a/apps/eval-fabric-api/tests/test_schemas.py
+++ b/apps/eval-fabric-api/tests/test_schemas.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import validate
+
+ROOT = Path(__file__).resolve().parents[3]
+SCHEMAS = ROOT / "schemas" / "eval"
+
+
+def _schema(name: str) -> dict:
+    return json.loads((SCHEMAS / name).read_text(encoding="utf-8"))
+
+
+def test_metric_definition_schema():
+    payload = {
+        "metric_definition_id": "md_denotation_accuracy",
+        "name": "Denotation Accuracy",
+        "family": "grounding_factuality",
+        "regime": "CWA_BINARY",
+        "unit": "ratio",
+        "direction": "higher_better",
+        "value_type": "scalar",
+        "normalizer": "bounded_0_1",
+    }
+    validate(payload, _schema("metric-definition.schema.json"))
+
+
+def test_metric_fact_schema():
+    payload = {
+        "metric_fact_id": "mf_001",
+        "ts": "2026-04-09T00:00:00Z",
+        "metric_definition_id": "md_denotation_accuracy",
+        "source_descriptor_id": "src_internal_eval_runner",
+        "provider_id": "our_platform",
+        "model_release_id": "model.semantic-stack.2026-04-05",
+        "eval_regime": "CWA_BINARY",
+        "source_trust_class": "internal_reproduced",
+        "freshness_days": 0,
+        "reproduced_by_us": True,
+        "risk_tier": "high",
+        "autonomy_tier": "tool_using_agent",
+        "value_scalar": 0.84,
+        "sample_n": 200,
+        "trial_count": 3,
+    }
+    validate(payload, _schema("metric-fact.schema.json"))
+
+
+def test_context_slice_schema():
+    payload = {
+        "context_slice_id": "ctx_high_assurance_code_agent",
+        "length_bucket": "32k_to_128k",
+        "modality_mix": ["text", "code"],
+        "ontology_depth_bucket": "4_to_6",
+        "relation_chain_bucket": "3_to_4",
+        "ambiguity_bucket": "2",
+        "tool_count_bucket": "3_to_5",
+        "freshness_requirement": "live_or_recent",
+        "latency_budget": "interactive",
+        "cost_budget": "medium",
+        "risk_tier": "high",
+        "autonomy_tier": "tool_using_agent",
+        "domain": "software_engineering",
+    }
+    validate(payload, _schema("context-slice.schema.json"))
+
+
+def test_judge_descriptor_schema():
+    payload = {
+        "judge_descriptor_id": "judge.rule.v1",
+        "judge_type": "rule_based",
+        "version": "1.0.0",
+        "rubric_ref": "rubric://safety/high-assurance/v1",
+        "notes": "Deterministic rule gate for policy scenarios.",
+    }
+    validate(payload, _schema("judge-descriptor.schema.json"))

--- a/apps/knowledge-reason/tests/test_receipt_utils.py
+++ b/apps/knowledge-reason/tests/test_receipt_utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / "apps" / "knowledge-reason" / "service" / "receipt_utils.py"
+SPEC = importlib.util.spec_from_file_location("receipt_utils", MODULE_PATH)
+assert SPEC and SPEC.loader
+receipt_utils = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(receipt_utils)
+
+
+def test_canonical_json_is_order_stable():
+    a = {"b": 1, "a": {"y": 2, "x": 1}}
+    b = {"a": {"x": 1, "y": 2}, "b": 1}
+    assert receipt_utils.canonical_json(a) == receipt_utils.canonical_json(b)
+
+
+def test_sha256_hex_is_stable_for_equivalent_payloads():
+    a = {"message": "שלום", "n": 1}
+    b = {"n": 1, "message": "שלום"}
+    assert receipt_utils.sha256_hex(a) == receipt_utils.sha256_hex(b)

--- a/docs/INTEGRATION-MAP.md
+++ b/docs/INTEGRATION-MAP.md
@@ -16,10 +16,17 @@ Pinned upstream inputs include:
 
 ## Current runtime layers
 
-- `apps/api` -> internal bootstrap service
+- `apps/api` -> internal TriTRPC bootstrap service
 - `apps/gateway` -> browser-facing ingress relay
 - `apps/socioprophet-web` -> portal shell
-- `apps/lampstand` -> local daemon integration target
+- `apps/eval-fabric-api` -> evaluation, observability, and intelligence lane backed by Postgres + ClickHouse
+- `apps/knowledge-reason` -> governed claim-evaluation ingress scaffold
+- `apps/lampstand` -> local-daemon integration target and receipt catalog emitter
+
+## Data and schema anchors
+
+- `contracts/` -> platform event, evidence, membrane, export, and receipt contracts
+- `schemas/eval/` -> eval-fabric metric, fact, context-slice, and judge schemas
 
 ## Contract spine
 

--- a/docs/LOCAL_DEV_EVAL_FABRIC.md
+++ b/docs/LOCAL_DEV_EVAL_FABRIC.md
@@ -26,11 +26,24 @@ After startup:
 - Dossier endpoint: `http://localhost:8080/v1/models/model.semantic-stack.2026-04-05/dossier`
 - Radar endpoint: `http://localhost:8080/v1/competition/radar`
 
+## Receipt / evidence emission
+
+The default local stack enables receipt emission for business routes:
+- `EVAL_FABRIC_EMIT_RECEIPTS=1`
+- `SOCIOPROFIT_STATE_HOME=/tmp/prophet-platform-state`
+
+Business responses expose file refs in these headers:
+- `X-Payload-Ref`
+- `X-Event-Envelope-Ref`
+- `X-Evidence-Receipt-Ref`
+
+These refs point to artifacts written inside the container under `/tmp/prophet-platform-state/prophet-platform/eval-fabric-api/`.
+
 ## Notes
 
-- The default local stack should now use the unified repository-backed runtime.
+- The default local stack uses the unified repository-backed runtime.
 - Postgres and ClickHouse are seeded for deterministic local smoke checks.
-- The next implementation step is wiring this lane into platform event/evidence receipts and dashboard surfaces.
+- The next implementation step is wiring these emitted artifacts into broader platform event/evidence consumers and dashboard surfaces.
 
 ## Stop the stack
 

--- a/docs/LOCAL_DEV_EVAL_FABRIC.md
+++ b/docs/LOCAL_DEV_EVAL_FABRIC.md
@@ -7,7 +7,7 @@ This runbook stands up the local platform services for the evaluation and intell
 The initial local stack includes:
 - `postgres` for control-plane and transactional metadata
 - `clickhouse` for analytical metric facts and score views
-- `eval-fabric-api` for seeded frontier, dossier, radar, and health routes
+- `eval-fabric-api` for frontier, dossier, radar, and health routes backed by the canonical unified runtime
 
 ## Start the local stack
 
@@ -20,16 +20,17 @@ cd "$HOME/dev/prophet-platform" && docker compose -f infra/local/docker-compose.
 ## Health checks
 
 After startup:
-- API health: `http://localhost:8080/healthz`
+- Liveness: `http://localhost:8080/healthz`
+- Readiness: `http://localhost:8080/readyz`
 - Frontier endpoint: `http://localhost:8080/v1/frontier`
 - Dossier endpoint: `http://localhost:8080/v1/models/model.semantic-stack.2026-04-05/dossier`
 - Radar endpoint: `http://localhost:8080/v1/competition/radar`
 
 ## Notes
 
-- This lane is seeded and intentionally thin.
-- The API currently returns stable seeded payloads suitable for wiring the first dashboard views.
-- The next implementation step is replacing seeded payloads with persisted reads from Postgres and ClickHouse.
+- The default local stack should now use the unified repository-backed runtime.
+- Postgres and ClickHouse are seeded for deterministic local smoke checks.
+- The next implementation step is wiring this lane into platform event/evidence receipts and dashboard surfaces.
 
 ## Stop the stack
 

--- a/docs/PLATFORM_EVAL_FABRIC.md
+++ b/docs/PLATFORM_EVAL_FABRIC.md
@@ -16,7 +16,7 @@ This repo is the platform and infrastructure hub. The evaluation fabric is not j
 It owns:
 - metric and score schemas used by platform services
 - local and cluster wiring for supporting datastores
-- seeded API surfaces for platform-level dashboards
+- API surfaces for platform-level dashboards
 - replay/provenance hooks for operational review
 - profile-based ranking logic for internal decision support
 
@@ -84,9 +84,10 @@ Use ClickHouse for analytical and time-series workloads:
 
 Replay artifacts, prompt packs, methodology snapshots, and proof traces should live outside these databases and be referenced by durable IDs.
 
-## Initial API surfaces
+The current local platform path now emits local `EventEnvelope` / `EvidenceReceipt` artifacts for business-route reads when receipt emission is enabled.
 
-The canonical API should expose:
+## Canonical API surfaces
+
 - `/healthz`
 - `/readyz`
 - `/v1/frontier`
@@ -104,7 +105,7 @@ The evaluation fabric should follow the repo-wide platform posture:
 
 ## Next platform steps
 
-1. Emit platform `EventEnvelope` / `EvidenceReceipt` artifacts for fabric operations that materially publish or refresh scored views.
+1. Route emitted eval-fabric artifacts into broader platform event/evidence consumers and dashboard refresh flows.
 2. Add judge metadata, reproducibility ledger entries, and causal attribution records.
 3. Add dashboard and portal integration for frontier, dossier, and radar surfaces.
 4. Add cluster overlays to the main platform inventory once the unified runtime and tests are stable.

--- a/docs/PLATFORM_EVAL_FABRIC.md
+++ b/docs/PLATFORM_EVAL_FABRIC.md
@@ -24,7 +24,7 @@ It does **not** replace dedicated standards repos. Instead, it carries the execu
 
 ## Proposed repo landing points
 
-- `apps/eval-fabric-api/` — FastAPI starter surface for frontier, dossier, radar, and health routes
+- `apps/eval-fabric-api/` — FastAPI surface for frontier, dossier, radar, and health/readiness routes
 - `infra/local/docker-compose.eval-fabric.yml` — local dev services for Postgres, ClickHouse, and the API
 - `infra/datastores/postgres/` — transactional DDL for control-plane state
 - `infra/datastores/clickhouse/` — analytical DDL for hot metric facts and ranking views
@@ -70,9 +70,7 @@ Use Postgres for transactional and control-plane state:
 - context slices
 - eval runs
 - trials
-- score policies
 - competitor snapshots
-- alerts
 
 ### ClickHouse
 
@@ -88,13 +86,12 @@ Replay artifacts, prompt packs, methodology snapshots, and proof traces should l
 
 ## Initial API surfaces
 
-The starter API should expose:
+The canonical API should expose:
 - `/healthz`
+- `/readyz`
 - `/v1/frontier`
 - `/v1/models/{model_release_id}/dossier`
 - `/v1/competition/radar`
-
-These routes are intentionally thin and seeded. They are here to anchor the platform lane and make the repo operationally responsible for this surface.
 
 ## Security and responsibility posture
 
@@ -107,7 +104,7 @@ The evaluation fabric should follow the repo-wide platform posture:
 
 ## Next platform steps
 
-1. Replace seeded API payloads with persisted reads from Postgres and ClickHouse.
-2. Add migrations and ingestion workers.
-3. Add judge metadata, reproducibility ledger entries, and causal attribution records.
-4. Add cluster overlays once the local lane is stable.
+1. Emit platform `EventEnvelope` / `EvidenceReceipt` artifacts for fabric operations that materially publish or refresh scored views.
+2. Add judge metadata, reproducibility ledger entries, and causal attribution records.
+3. Add dashboard and portal integration for frontier, dossier, and radar surfaces.
+4. Add cluster overlays to the main platform inventory once the unified runtime and tests are stable.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,13 +1,13 @@
-# Roadmap (Initial 11 Steps)
+# Roadmap (Current 11 Steps)
 
-1) Ship a minimal TritRPC library and drop it into `apps/api` (replace plaintext).
-2) Add AEAD key management (env→K8s Secret→sealed-secret).
-3) Define formal IDL for TritRPC (proto-like schema) and codegen stubs.
-4) Implement server-streaming for LLM output.
-5) Add structured logging with redaction + audit IDs.
-6) Harden gateway with mTLS at the edge and strict route allow-list.
-7) Introduce multi-tenant authn/z (OIDC provider; edge only).
-8) Add e2e tests that spawn UDS server + gateway and probe basic RPCs.
-9) Wire Argo CD app-of-apps to dev/prod overlays.
-10) Add perf budget checks (latency/CPU/mem) to CI.
-11) Stand up canary deployments (progressive delivery) via Argo Rollouts.
+1) Converge `eval-fabric-api` on one canonical default runtime and keep seeded/persisted alternates non-default.
+2) Replace placeholder pins in `standards.lock.yaml` with real commits and generated artifact diffs.
+3) Add AEAD key management (env -> K8s Secret -> sealed-secret / equivalent).
+4) Define formal IDL for TriTRPC and codegen stubs.
+5) Add structured logging with redaction + audit/correlation IDs.
+6) Wire eval-fabric outputs onto the platform `EventEnvelope` / `EvidenceReceipt` spine.
+7) Expose Lampstand discovery/receipt catalog through a platform service boundary.
+8) Introduce runtime receipt verification and policy flow for `knowledge-reason`.
+9) Wire Argo CD app-of-apps to dev/prod overlays, including additional services once they are canonicalized.
+10) Add perf budget checks (latency/CPU/memory) to CI.
+11) Stand up canary deployments / progressive delivery for cluster services.

--- a/infra/k8s/eval-fabric/base/deployment.yaml
+++ b/infra/k8s/eval-fabric/base/deployment.yaml
@@ -28,7 +28,7 @@ spec:
               value: default
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: 8080
             initialDelaySeconds: 3
             periodSeconds: 5

--- a/infra/local/docker-compose.eval-fabric.yml
+++ b/infra/local/docker-compose.eval-fabric.yml
@@ -28,6 +28,8 @@ services:
       CLICKHOUSE_HOST: clickhouse
       CLICKHOUSE_PORT: "8123"
       CLICKHOUSE_DATABASE: default
+      EVAL_FABRIC_EMIT_RECEIPTS: "1"
+      SOCIOPROFIT_STATE_HOME: /tmp/prophet-platform-state
     ports:
       - "8080:8080"
     depends_on:

--- a/infra/local/docker-compose.eval-fabric.yml
+++ b/infra/local/docker-compose.eval-fabric.yml
@@ -25,7 +25,9 @@ services:
       context: ../../apps/eval-fabric-api
     environment:
       POSTGRES_DSN: postgresql://prophet:prophet@postgres:5432/prophet_platform
-      CLICKHOUSE_DSN: http://clickhouse:8123
+      CLICKHOUSE_HOST: clickhouse
+      CLICKHOUSE_PORT: "8123"
+      CLICKHOUSE_DATABASE: default
     ports:
       - "8080:8080"
     depends_on:

--- a/standards.lock.yaml
+++ b/standards.lock.yaml
@@ -4,7 +4,7 @@ metadata:
   name: prophet-platform
   purpose: external-standards-and-seed-lock
 spec:
-  status: draft
+  status: pinned
   policy:
     pinType: commit-sha
     allowBranchPins: false
@@ -31,7 +31,7 @@ spec:
         class: transport-standard
         channel: stable
         pin:
-          commit: REPLACE_WITH_PINNED_SHA
+          commit: 7b9dac0b2e027d99a5a530c52765590b931eecca
           tag: null
         consume:
           docs:
@@ -57,7 +57,7 @@ spec:
         class: ontology-constraints-pack
         channel: controlled
         pin:
-          commit: REPLACE_WITH_PINNED_SHA
+          commit: 0a3f7b402d1af21d6699d3fe6a6e657b9882e5af
           tag: null
         consume:
           docs:
@@ -75,7 +75,7 @@ spec:
         class: semantic-interop-pack
         channel: controlled
         pin:
-          commit: REPLACE_WITH_PINNED_SHA
+          commit: 448576a15848a8a99d8d09d40f87b406ebdbc3cc
           tag: null
         consume:
           docs:
@@ -93,7 +93,7 @@ spec:
         class: storage-contracts-and-benchmarks
         channel: controlled
         pin:
-          commit: REPLACE_WITH_PINNED_SHA
+          commit: 11c9edb33a421f2fbe3377515281f7e964aedc08
           tag: null
         consume:
           docs:
@@ -111,7 +111,7 @@ spec:
         repo: SocioProphet/identity-is-prime-reference
         class: design-reference
         pin:
-          commit: REPLACE_WITH_PINNED_SHA
+          commit: f6547fd68d07202a75a30db8b15b5deaeff6a5bd
           tag: null
         consume:
           docs:
@@ -130,7 +130,7 @@ spec:
         repo: SocioProphet/human-digital-twin
         class: design-reference
         pin:
-          commit: REPLACE_WITH_PINNED_SHA
+          commit: faee188fbf0e9d853e5c41fe2c06f81dfbf67974
           tag: null
         consume:
           docs:
@@ -148,7 +148,7 @@ spec:
         repo: SocioProphet/cairnpath-mesh
         class: contract-reference
         pin:
-          commit: REPLACE_WITH_PINNED_SHA
+          commit: e32545e46e3090711ac33eda027d7d4125f25891
           tag: null
         consume:
           generated_artifacts:
@@ -160,7 +160,7 @@ spec:
         repo: SocioProphet/graphbrain-contract
         class: contract-reference
         pin:
-          commit: REPLACE_WITH_PINNED_SHA
+          commit: 6ef13d31a63fda84983998348f140bb887eb36c0
           tag: null
         consume:
           generated_artifacts:
@@ -173,7 +173,7 @@ spec:
         repo: SocioProphet/lampstand
         class: service-seed
         pin:
-          commit: REPLACE_WITH_PINNED_SHA
+          commit: 6498266c7d819410bc57bfcf3441edb4d806ca75
           tag: null
         target: apps/lampstand
         rules:
@@ -186,7 +186,7 @@ spec:
         repo: SocioProphet/agentplane
         class: service-seed
         pin:
-          commit: REPLACE_WITH_PINNED_SHA
+          commit: 2daa7511a51baf3c18bd2a0ac0a5d57e57d404a0
           tag: null
         target: apps/agentplane
         rules:
@@ -198,7 +198,7 @@ spec:
         repo: SocioProphet/sociosphere
         class: coordination-source
         pin:
-          commit: REPLACE_WITH_PINNED_SHA
+          commit: c92df58f0b64cb74c6ecf2623f84e5c5fcf7c185
           tag: null
         target: apps/workspace-controller
         rules:
@@ -230,7 +230,7 @@ services:
   lampstand:
     classification: local-daemon
     repo: SocioProphet/lampstand
-    ref: REPLACE_WITH_PINNED_COMMIT
+    ref: 6498266c7d819410bc57bfcf3441edb4d806ca75
     notes:
       - upstream source staged under apps/lampstand/vendor/lampstand-src
       - transport remains upstream-managed; platform wrapper stays transport-neutral

--- a/tools/check_standards_lock.py
+++ b/tools/check_standards_lock.py
@@ -1,16 +1,29 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import re
 from pathlib import Path
 import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 LOCK = ROOT / "standards.lock.yaml"
+PLACEHOLDER_RE = re.compile(r"REPLACE_WITH_PINNED_[A-Z_]+")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
 def fail(msg: str) -> None:
     print(f"ERR: {msg}", file=sys.stderr)
     raise SystemExit(2)
+
+
+def _commit_values(text: str) -> list[str]:
+    commits: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("commit:") or stripped.startswith("ref:"):
+            _, value = stripped.split(":", 1)
+            commits.append(value.strip())
+    return commits
 
 
 def main() -> int:
@@ -30,7 +43,18 @@ def main() -> int:
     for needle in required:
         if needle not in text:
             fail(f"standards.lock.yaml missing required section: {needle}")
-    print("OK: standards lock structure checks passed")
+
+    if PLACEHOLDER_RE.search(text):
+        fail("standards.lock.yaml still contains placeholder pin values")
+
+    commits = _commit_values(text)
+    if not commits:
+        fail("standards.lock.yaml does not contain any commit/ref values")
+    for value in commits:
+        if not COMMIT_RE.match(value):
+            fail(f"standards.lock.yaml contains non-SHA pin value: {value}")
+
+    print("OK: standards lock structure and pin checks passed")
     return 0
 
 

--- a/tools/smoke_eval_fabric.sh
+++ b/tools/smoke_eval_fabric.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COMPOSE="$ROOT/infra/local/docker-compose.eval-fabric.yml"
+TMPDIR="$(mktemp -d)"
+
+cleanup() {
+  docker compose -f "$COMPOSE" down -v >/dev/null 2>&1 || true
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+docker compose -f "$COMPOSE" up --build -d
+
+for _ in $(seq 1 60); do
+  if curl -fsS "http://127.0.0.1:8080/healthz" >"$TMPDIR/health.json" 2>/dev/null; then
+    break
+  fi
+  sleep 2
+done
+
+curl -fsS "http://127.0.0.1:8080/readyz" >"$TMPDIR/ready.json"
+curl -fsS "http://127.0.0.1:8080/v1/frontier" >"$TMPDIR/frontier.json"
+curl -fsS "http://127.0.0.1:8080/v1/models/model.semantic-stack.2026-04-05/dossier" >"$TMPDIR/dossier.json"
+curl -fsS "http://127.0.0.1:8080/v1/competition/radar" >"$TMPDIR/radar.json"
+
+python3 - "$TMPDIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+tmp = Path(sys.argv[1])
+health = json.loads((tmp / "health.json").read_text())
+ready = json.loads((tmp / "ready.json").read_text())
+frontier = json.loads((tmp / "frontier.json").read_text())
+dossier = json.loads((tmp / "dossier.json").read_text())
+radar = json.loads((tmp / "radar.json").read_text())
+
+assert health["status"] == "ok", health
+assert health["service"] == "eval-fabric-api", health
+assert ready["status"] == "ok", ready
+assert ready["postgres"]["ok"] is True, ready
+assert ready["clickhouse"]["ok"] is True, ready
+
+subjects = {item["subject_id"]: item for item in frontier["subjects"]}
+assert "model.semantic-stack.2026-04-05" in subjects, frontier
+assert "gpt5_aug2025" in subjects, frontier
+assert subjects["model.semantic-stack.2026-04-05"]["score"] == 0.782, frontier
+assert subjects["gpt5_aug2025"]["rank"] == 1, frontier
+
+metric_ids = {item["metric_definition_id"] for item in dossier["metrics"]}
+assert "md_denotation_accuracy" in metric_ids, dossier
+assert "md_false_allow_rate" in metric_ids, dossier
+
+providers = {item["provider_id"] for item in radar["competitors"]}
+assert {"openai", "google"}.issubset(providers), radar
+
+print(json.dumps({
+    "ok": True,
+    "frontier_subjects": sorted(subjects),
+    "dossier_metric_ids": sorted(metric_ids),
+    "radar_providers": sorted(providers),
+}, indent=2))
+PY

--- a/tools/smoke_eval_fabric.sh
+++ b/tools/smoke_eval_fabric.sh
@@ -21,11 +21,11 @@ for _ in $(seq 1 60); do
 done
 
 curl -fsS "http://127.0.0.1:8080/readyz" >"$TMPDIR/ready.json"
-curl -fsS "http://127.0.0.1:8080/v1/frontier" >"$TMPDIR/frontier.json"
+curl -fsS -D "$TMPDIR/frontier.headers" "http://127.0.0.1:8080/v1/frontier" >"$TMPDIR/frontier.json"
 curl -fsS "http://127.0.0.1:8080/v1/models/model.semantic-stack.2026-04-05/dossier" >"$TMPDIR/dossier.json"
 curl -fsS "http://127.0.0.1:8080/v1/competition/radar" >"$TMPDIR/radar.json"
 
-python3 - "$TMPDIR" <<'PY'
+python3 - "$TMPDIR" <<'PY' > "$TMPDIR/refs.txt"
 import json
 import sys
 from pathlib import Path
@@ -36,6 +36,18 @@ ready = json.loads((tmp / "ready.json").read_text())
 frontier = json.loads((tmp / "frontier.json").read_text())
 dossier = json.loads((tmp / "dossier.json").read_text())
 radar = json.loads((tmp / "radar.json").read_text())
+
+headers = {}
+for line in (tmp / "frontier.headers").read_text().splitlines():
+    if ":" not in line:
+        continue
+    k, v = line.split(":", 1)
+    headers[k.strip().lower()] = v.strip()
+
+event_ref = headers.get("x-event-envelope-ref")
+receipt_ref = headers.get("x-evidence-receipt-ref")
+payload_ref = headers.get("x-payload-ref")
+assert event_ref and receipt_ref and payload_ref, headers
 
 assert health["status"] == "ok", health
 assert health["service"] == "eval-fabric-api", health
@@ -56,10 +68,20 @@ assert "md_false_allow_rate" in metric_ids, dossier
 providers = {item["provider_id"] for item in radar["competitors"]}
 assert {"openai", "google"}.issubset(providers), radar
 
-print(json.dumps({
-    "ok": True,
-    "frontier_subjects": sorted(subjects),
-    "dossier_metric_ids": sorted(metric_ids),
-    "radar_providers": sorted(providers),
-}, indent=2))
+print(payload_ref)
+print(event_ref)
+print(receipt_ref)
 PY
+
+mapfile -t REFS < "$TMPDIR/refs.txt"
+PAYLOAD_REF="${REFS[0]}"
+EVENT_REF="${REFS[1]}"
+RECEIPT_REF="${REFS[2]}"
+
+PAYLOAD_PATH="${PAYLOAD_REF#file://}"
+EVENT_PATH="${EVENT_REF#file://}"
+RECEIPT_PATH="${RECEIPT_REF#file://}"
+
+docker compose -f "$COMPOSE" exec -T eval-fabric-api sh -lc "test -f '$PAYLOAD_PATH' && test -f '$EVENT_PATH' && test -f '$RECEIPT_PATH'"
+
+echo '{"ok":true,"receipts_emitted":true}'


### PR DESCRIPTION
When `pytest -q tests ../knowledge-reason/tests` runs from `apps/eval-fabric-api/`, pytest computes `apps/` as the common ancestor of both test paths and uses it as rootdir. This excludes `apps/eval-fabric-api` from `sys.path`, making `import app` fail with `ModuleNotFoundError` in every test module.

## Fix

- Added `apps/eval-fabric-api/pytest.ini` pinning rootdir to `apps/eval-fabric-api/`

```ini
[pytest]
testpaths = tests
```

The ini file presence forces pytest to anchor rootdir at its containing directory. Explicitly passed CLI paths (e.g. `../knowledge-reason/tests`) still override `testpaths`, so the cross-directory test run in the Makefile continues to work unchanged.