### PR TITLE
Storage Slice Continuation: Platform Receipts + Pipeline Entrypoint

### DIFF
--- a/apps/storage-promotion/README.md
+++ b/apps/storage-promotion/README.md
@@ -1,0 +1,31 @@
+# Storage Promotion Slice
+
+This is a bounded vertical slice aligned with Prophet Platform conventions.
+
+It demonstrates:
+
+- Observation ingest
+- Promotion to semantic Claim
+- Projection to graph form
+
+## Contract alignment
+
+Uses contracts from:
+- `contracts/storage/`
+
+## Outputs
+
+- Promotion results (entities + claims)
+- Projection manifest
+
+## Rule
+
+This slice is NOT a canonical truth store.
+It demonstrates the governed transformation pipeline only.
+
+## Next steps
+
+- implement ingest command
+- implement promote command
+- implement project command
+- integrate with receipt emission

--- a/apps/storage-promotion/dolt_adapter.py
+++ b/apps/storage-promotion/dolt_adapter.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def _sql_string(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _json_sql(value: Any) -> str:
+    return _sql_string(json.dumps(value, sort_keys=True, separators=(",", ":")))
+
+
+def build_insert_sql(observation: dict[str, Any]) -> str:
+    cols = [
+        "observation_id",
+        "source_system",
+        "source_record_id",
+        "observed_at",
+        "normalized_payload",
+        "trust_class",
+        "content_hash",
+        "identity_hash",
+        "lineage_hash",
+        "state",
+        "created_at",
+    ]
+    vals = [
+        _sql_string(observation["observation_id"]),
+        _sql_string(observation["source_system"]),
+        _sql_string(observation.get("source_record_id", "")),
+        _sql_string(observation["observed_at"]),
+        _json_sql(observation["normalized_payload"]),
+        _sql_string(observation.get("trust_class", "")),
+        _sql_string(observation["content_hash"]),
+        _sql_string(observation["identity_hash"]),
+        _sql_string(observation.get("lineage_hash", "")),
+        _sql_string(observation["state"]),
+        _sql_string(observation["created_at"]),
+    ]
+    return f"INSERT INTO observations ({', '.join(cols)}) VALUES ({', '.join(vals)});"
+
+
+def insert_observation(observation: dict[str, Any], *, dolt_dir: str | None = None) -> dict[str, Any]:
+    workdir = Path(dolt_dir or os.environ.get("DOLT_DB_DIR", ".")).resolve()
+    sql = build_insert_sql(observation)
+    try:
+        proc = subprocess.run(
+            ["dolt", "sql", "-q", sql],
+            cwd=str(workdir),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return {
+            "ok": False,
+            "mode": "dolt-cli",
+            "cwd": str(workdir),
+            "sql": sql,
+            "error": "dolt binary not found",
+        }
+    return {
+        "ok": proc.returncode == 0,
+        "mode": "dolt-cli",
+        "cwd": str(workdir),
+        "sql": sql,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+        "returncode": proc.returncode,
+    }

--- a/apps/storage-promotion/ingest.py
+++ b/apps/storage-promotion/ingest.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import json, datetime, hashlib
+
+payload = {
+  "subject": "user123",
+  "action": "has_role",
+  "object": "admin"
+}
+
+payload_str = json.dumps(payload, sort_keys=True)
+now = datetime.datetime.utcnow().isoformat()
+
+obs = {
+  "version": "0.1",
+  "observation_id": "obs:demo:1:v1",
+  "source_system": "storage-promotion",
+  "observed_at": now,
+  "normalized_payload": payload,
+  "content_hash": hashlib.sha256(payload_str.encode()).hexdigest(),
+  "identity_hash": hashlib.sha256("obs:demo:1:v1".encode()).hexdigest(),
+  "state": "active",
+  "created_at": now
+}
+
+print(json.dumps(obs, indent=2))

--- a/apps/storage-promotion/pipeline.py
+++ b/apps/storage-promotion/pipeline.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from dolt_adapter import insert_observation
+from runtime import build_observation, project_promoted, promote_observation
+from typedb_adapter import build_insert_tql, persist_tql
+
+
+def _load_payload(path: str | None) -> dict:
+    if not path:
+        return {
+            "subject": "user123",
+            "action": "has_role",
+            "object": "admin",
+        }
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the storage promotion slice")
+    parser.add_argument("--payload-file")
+    parser.add_argument("--apply-dolt", action="store_true")
+    parser.add_argument("--export-typedb-tql", action="store_true")
+    parser.add_argument("--typedb-tql-out")
+    parser.add_argument("--dolt-dir")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    payload = _load_payload(args.payload_file)
+    observation = build_observation(payload)
+    promoted = promote_observation(observation)
+    projection = project_promoted(promoted)
+    typedb_tql = build_insert_tql(promoted)
+
+    dolt_result = None
+    if args.apply_dolt:
+        dolt_result = insert_observation(observation, dolt_dir=args.dolt_dir)
+
+    typedb_result = None
+    if args.export_typedb_tql:
+        typedb_result = persist_tql(typedb_tql, out_path=args.typedb_tql_out)
+
+    print(json.dumps({
+        "observation": observation,
+        "dolt_result": dolt_result,
+        "promoted": promoted,
+        "typedb_tql": typedb_tql,
+        "typedb_result": typedb_result,
+        "projection": projection,
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/storage-promotion/pipeline_platform.py
+++ b/apps/storage-promotion/pipeline_platform.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from dolt_adapter import insert_observation
+from receipts import make_bundle, write_bundle
+from runtime import build_observation, project_promoted, promote_observation
+from typedb_adapter import build_insert_tql, persist_tql
+
+
+def _load_payload(path: str | None) -> dict:
+    if not path:
+        return {
+            "subject": "user123",
+            "action": "has_role",
+            "object": "admin",
+        }
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the storage promotion slice with platform receipts")
+    parser.add_argument("--payload-file")
+    parser.add_argument("--apply-dolt", action="store_true")
+    parser.add_argument("--export-typedb-tql", action="store_true")
+    parser.add_argument("--typedb-tql-out")
+    parser.add_argument("--dolt-dir")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    payload = _load_payload(args.payload_file)
+    observation = build_observation(payload)
+    promoted = promote_observation(observation)
+    projection = project_promoted(promoted)
+    typedb_tql = build_insert_tql(promoted)
+
+    dolt_result = None
+    if args.apply_dolt:
+        dolt_result = insert_observation(observation, dolt_dir=args.dolt_dir)
+
+    typedb_result = None
+    if args.export_typedb_tql:
+        typedb_result = persist_tql(typedb_tql, out_path=args.typedb_tql_out)
+
+    claim = promoted["claim"]
+    manifest = projection["projection_manifest"]
+    bundle = make_bundle(
+        event_type="storage.promotion.completed",
+        action="StoragePromotionPipeline",
+        status="succeeded",
+        subject_ref=f"claim://{claim['id']}",
+        payload_ref=f"projection://{manifest['projection_manifest_id']}",
+        correlation_id=claim["id"],
+        classifiers=["slice:storage-promotion", "projection:neo4j", "promotion:typedb-shaped"],
+        output_refs=[
+            f"claim://{claim['id']}",
+            f"projection://{manifest['projection_manifest_id']}",
+        ],
+        metrics={
+            "entity_count": len(promoted["entities"]),
+            "edge_count": len(projection["edges"]),
+            "observation_id": observation["observation_id"],
+        },
+    )
+    event_path, receipt_path = write_bundle(bundle, stem=claim["id"])
+
+    print(json.dumps({
+        "observation": observation,
+        "dolt_result": dolt_result,
+        "promoted": promoted,
+        "typedb_tql": typedb_tql,
+        "typedb_result": typedb_result,
+        "projection": projection,
+        "event_envelope": bundle.envelope,
+        "evidence_receipt": bundle.receipt,
+        "event_path": str(event_path),
+        "receipt_path": str(receipt_path),
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/storage-promotion/project.py
+++ b/apps/storage-promotion/project.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import json, sys
+
+promoted = json.load(sys.stdin)
+
+nodes = []
+edges = []
+
+for e in promoted["entities"]:
+    nodes.append({"id": e["id"]})
+
+c = promoted["claim"]
+edges.append({
+  "from": f"ent:user:{c['subject']}",
+  "to": f"ent:role:{c['object']}",
+  "type": c['type']
+})
+
+print(json.dumps({"nodes": nodes, "edges": edges}, indent=2))

--- a/apps/storage-promotion/promote.py
+++ b/apps/storage-promotion/promote.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import json, sys
+
+obs = json.load(sys.stdin)
+
+payload = obs["normalized_payload"]
+
+entities = [
+  {"id": f"ent:user:{payload['subject']}"},
+  {"id": f"ent:role:{payload['object']}"}
+]
+
+claim = {
+  "id": f"clm:{payload['subject']}-{payload['object']}",
+  "type": payload['action'],
+  "subject": payload['subject'],
+  "object": payload['object']
+}
+
+result = {
+  "entities": entities,
+  "claim": claim
+}
+
+print(json.dumps(result, indent=2))

--- a/apps/storage-promotion/receipts.py
+++ b/apps/storage-promotion/receipts.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def digest_json(payload: dict[str, Any]) -> str:
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(body).hexdigest()
+
+
+def state_root() -> Path:
+    return Path(os.environ.get("STORAGE_PROMOTION_STATE_HOME", ".storage-promotion-state")).resolve()
+
+
+def events_root() -> Path:
+    return state_root() / "events"
+
+
+def receipts_root() -> Path:
+    return state_root() / "receipts"
+
+
+def ensure_dirs() -> None:
+    events_root().mkdir(parents=True, exist_ok=True)
+    receipts_root().mkdir(parents=True, exist_ok=True)
+
+
+@dataclass(frozen=True)
+class ReceiptBundle:
+    envelope: dict[str, Any]
+    receipt: dict[str, Any]
+
+
+def make_bundle(
+    *,
+    event_type: str,
+    action: str,
+    status: str,
+    subject_ref: str,
+    payload_ref: str,
+    service_ref: str = "apps/storage-promotion",
+    scope_ref: str | None = None,
+    correlation_id: str | None = None,
+    classifiers: list[str] | None = None,
+    policy_refs: list[str] | None = None,
+    evidence_refs: list[str] | None = None,
+    output_refs: list[str] | None = None,
+    metrics: dict[str, Any] | None = None,
+) -> ReceiptBundle:
+    envelope_id = str(uuid.uuid4())
+    receipt_id = str(uuid.uuid4())
+    created_at = utc_now()
+
+    envelope = {
+        "version": "0.1",
+        "envelope_id": envelope_id,
+        "created_at": created_at,
+        "event_type": event_type,
+        "producer": service_ref,
+        "subject_ref": subject_ref,
+        "payload_ref": payload_ref,
+        "correlation_id": correlation_id or envelope_id,
+    }
+    if scope_ref:
+        envelope["scope_ref"] = scope_ref
+    if classifiers:
+        envelope["classifiers"] = classifiers
+
+    envelope_hash = digest_json(envelope)
+
+    receipt = {
+        "version": "0.1",
+        "receipt_id": receipt_id,
+        "created_at": created_at,
+        "service_ref": service_ref,
+        "action": action,
+        "status": status,
+        "subject_ref": subject_ref,
+        "envelope_ref": f"event://{envelope_id}",
+        "policy_refs": policy_refs or [],
+        "evidence_refs": evidence_refs or [],
+        "output_refs": output_refs or [],
+        "metrics": metrics or {},
+        "hash": envelope_hash,
+        "hash_algo": "sha256",
+        "correlation_id": correlation_id or envelope_id,
+    }
+
+    envelope["receipt_ref"] = f"receipt://{receipt_id}"
+    return ReceiptBundle(envelope=envelope, receipt=receipt)
+
+
+def write_bundle(bundle: ReceiptBundle, *, stem: str | None = None) -> tuple[Path, Path]:
+    ensure_dirs()
+    stem = stem or bundle.envelope["envelope_id"]
+    event_path = events_root() / f"{stem}.event.json"
+    receipt_path = receipts_root() / f"{stem}.receipt.json"
+    event_path.write_text(json.dumps(bundle.envelope, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    receipt_path.write_text(json.dumps(bundle.receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return event_path, receipt_path

--- a/apps/storage-promotion/runtime.py
+++ b/apps/storage-promotion/runtime.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+from typing import Any
+
+
+def canonical_json(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+
+
+def build_observation(
+    payload: dict[str, Any],
+    *,
+    observation_id: str = "obs:demo:1:v1",
+    source_system: str = "storage-promotion",
+    source_record_id: str = "demo-1",
+    trust_class: str = "demo",
+) -> dict[str, Any]:
+    payload_str = canonical_json(payload)
+    now = utc_now()
+    return {
+        "version": "0.1",
+        "observation_id": observation_id,
+        "source_system": source_system,
+        "source_record_id": source_record_id,
+        "observed_at": now,
+        "normalized_payload": payload,
+        "trust_class": trust_class,
+        "content_hash": f"sha256:{sha256_hex(payload_str)}",
+        "identity_hash": f"sha256:{sha256_hex(observation_id)}",
+        "lineage_hash": f"sha256:{sha256_hex(source_system + ':' + source_record_id)}",
+        "state": "active",
+        "created_at": now,
+    }
+
+
+def promote_observation(observation: dict[str, Any]) -> dict[str, Any]:
+    payload = observation["normalized_payload"]
+    subject = str(payload["subject"])
+    relation = str(payload["action"])
+    obj = str(payload["object"])
+
+    entities = [
+        {
+            "id": f"ent:user:{subject}",
+            "kind": "user",
+            "name": subject,
+        },
+        {
+            "id": f"ent:role:{obj}",
+            "kind": "role",
+            "name": obj,
+        },
+    ]
+
+    claim = {
+        "id": f"clm:{subject}-{relation}-{obj}",
+        "type": relation,
+        "subject": subject,
+        "object": obj,
+        "source_observation_id": observation["observation_id"],
+    }
+
+    return {
+        "promotion_run_id": f"run:promotion:{subject}:{obj}:v1",
+        "entities": entities,
+        "claim": claim,
+        "status": "succeeded",
+    }
+
+
+def project_promoted(promoted: dict[str, Any]) -> dict[str, Any]:
+    nodes = [{"id": entity["id"], "kind": entity["kind"], "name": entity["name"]} for entity in promoted["entities"]]
+    claim = promoted["claim"]
+    edges = [
+        {
+            "from": f"ent:user:{claim['subject']}",
+            "to": f"ent:role:{claim['object']}",
+            "type": claim["type"],
+            "claim_id": claim["id"],
+        }
+    ]
+    manifest = {
+        "version": "0.1",
+        "projection_manifest_id": f"pmf:neo4j:{claim['id']}",
+        "projection_kind": "neo4j-shaped-graph",
+        "generated_at": utc_now(),
+        "source_observation_id": claim["source_observation_id"],
+        "source_claim_id": claim["id"],
+        "object_count": len(nodes) + len(edges),
+        "hash_rollup": f"sha256:{sha256_hex(canonical_json({'nodes': nodes, 'edges': edges}))}",
+        "target_store": "neo4j",
+    }
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "projection_manifest": manifest,
+    }

--- a/apps/storage-promotion/typedb_adapter.py
+++ b/apps/storage-promotion/typedb_adapter.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _escape(value: str) -> str:
+    return value.replace('"', '\\"')
+
+
+def build_insert_tql(promoted: dict) -> str:
+    entities = promoted["entities"]
+    claim = promoted["claim"]
+    user = entities[0]
+    role = entities[1]
+    return "\n".join([
+        "insert",
+        f'$u isa semantic-entity, has object-id "{_escape(user["id"])}", has kind "{_escape(user["kind"])}", has name "{_escape(user["name"])}";',
+        f'$r isa semantic-entity, has object-id "{_escape(role["id"])}", has kind "{_escape(role["kind"])}", has name "{_escape(role["name"])}";',
+        f'$c isa claim-record, has object-id "{_escape(claim["id"])}", has kind "{_escape(claim["type"])}", has confidence 1.0;',
+        f'(assertion-subject: $u, assertion-object: $r) isa semantic-assertion, has kind "{_escape(claim["type"])}", has confidence 1.0;',
+    ])
+
+
+def persist_tql(tql: str, *, out_path: str | None = None) -> dict:
+    target = Path(out_path or os.environ.get("TYPEDB_TQL_OUT", "typedb_insert.tql")).resolve()
+    target.write_text(tql + "\n", encoding="utf-8")
+    return {
+        "ok": True,
+        "mode": "typedb-tql-export",
+        "path": str(target),
+    }

--- a/contracts/storage/Observation.v0.1.json
+++ b/contracts/storage/Observation.v0.1.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/storage/Observation.v0.1.json",
+  "title": "Observation",
+  "type": "object",
+  "required": [
+    "version",
+    "observation_id",
+    "source_system",
+    "observed_at",
+    "normalized_payload",
+    "content_hash",
+    "identity_hash",
+    "state"
+  ],
+  "properties": {
+    "version": {"const": "0.1"},
+    "observation_id": {"type": "string"},
+    "source_system": {"type": "string"},
+    "source_record_id": {"type": "string"},
+    "observed_at": {"type": "string"},
+    "normalized_payload": {"type": "object", "additionalProperties": true},
+    "trust_class": {"type": "string"},
+    "content_hash": {"type": "string"},
+    "identity_hash": {"type": "string"},
+    "lineage_hash": {"type": "string"},
+    "state": {"type": "string"},
+    "created_at": {"type": "string"}
+  }
+}

--- a/contracts/storage/ProjectionManifest.v0.1.json
+++ b/contracts/storage/ProjectionManifest.v0.1.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/storage/ProjectionManifest.v0.1.json",
+  "title": "ProjectionManifest",
+  "type": "object",
+  "required": ["version", "projection_manifest_id", "projection_kind", "generated_at", "object_count"],
+  "properties": {
+    "version": {"const": "0.1"},
+    "projection_manifest_id": {"type": "string"},
+    "projection_kind": {"type": "string"},
+    "generated_at": {"type": "string"},
+    "source_observation_id": {"type": "string"},
+    "source_claim_id": {"type": "string"},
+    "object_count": {"type": "integer", "minimum": 0},
+    "hash_rollup": {"type": "string"},
+    "target_store": {"type": "string"}
+  }
+}

--- a/contracts/storage/PromotionReceipt.v0.1.json
+++ b/contracts/storage/PromotionReceipt.v0.1.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/storage/PromotionReceipt.v0.1.json",
+  "title": "PromotionReceipt",
+  "type": "object",
+  "required": ["version", "promotion_run_id", "observation_id", "claim_id", "status"],
+  "properties": {
+    "version": {"const": "0.1"},
+    "promotion_run_id": {"type": "string"},
+    "observation_id": {"type": "string"},
+    "entity_ids": {"type": "array", "items": {"type": "string"}},
+    "claim_id": {"type": "string"},
+    "typedb_query_ref": {"type": "string"},
+    "status": {"type": "string"},
+    "created_at": {"type": "string"}
+  }
+}

--- a/contracts/storage/PromotionRejection.v0.1.json
+++ b/contracts/storage/PromotionRejection.v0.1.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/storage/PromotionRejection.v0.1.json",
+  "title": "PromotionRejection",
+  "type": "object",
+  "required": ["version", "rejection_id", "observation_id", "rejection_code", "rejection_reason"],
+  "properties": {
+    "version": {"const": "0.1"},
+    "rejection_id": {"type": "string"},
+    "observation_id": {"type": "string"},
+    "rejection_code": {"type": "string"},
+    "rejection_reason": {"type": "string"},
+    "validator_ref": {"type": "string"},
+    "created_at": {"type": "string"}
+  }
+}

--- a/contracts/storage/README.md
+++ b/contracts/storage/README.md
@@ -1,0 +1,32 @@
+# contracts/storage/
+
+This family defines the bounded storage-facing contracts used by the storage promotion slice.
+
+These contracts do not replace the platform contract spine. They complement it.
+
+## Purpose
+
+The storage slice demonstrates the governed path:
+
+1. Observation is captured as operational state.
+2. Promotion derives semantic objects deterministically.
+3. Projection emits a read-optimized graph shape.
+4. Promotion and projection can emit repo-native receipts and envelopes later.
+
+## Initial contract set
+
+- `Observation.v0.1.json`
+- `RunRecord.v0.1.json`
+- `ProjectionManifest.v0.1.json`
+- `PromotionRejection.v0.1.json`
+- `PromotionReceipt.v0.1.json`
+
+## Ownership
+
+- Operational / branchable state: Dolt-oriented
+- Semantic truth: TypeDB-oriented
+- Read projection: Neo4j-shaped and derived only
+
+## Rule
+
+Storage contracts must remain replayable, deterministic, and traceable back to source observations.

--- a/contracts/storage/RunRecord.v0.1.json
+++ b/contracts/storage/RunRecord.v0.1.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/storage/RunRecord.v0.1.json",
+  "title": "RunRecord",
+  "type": "object",
+  "required": ["version", "run_id", "run_type", "started_at", "status"],
+  "properties": {
+    "version": {"const": "0.1"},
+    "run_id": {"type": "string"},
+    "run_type": {"type": "string"},
+    "started_at": {"type": "string"},
+    "ended_at": {"type": "string"},
+    "status": {"type": "string"},
+    "input_snapshot_ref": {"type": "string"},
+    "output_snapshot_ref": {"type": "string"},
+    "metrics": {"type": "object", "additionalProperties": true}
+  }
+}

--- a/tools/validate_storage_contracts.py
+++ b/tools/validate_storage_contracts.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Validate presence of storage contract files.
+
+This is a minimal conformance check aligned with repo validation style.
+"""
+import os
+import sys
+
+REQUIRED = [
+    "contracts/storage/README.md",
+    "apps/storage-promotion/README.md",
+]
+
+missing = [p for p in REQUIRED if not os.path.exists(p)]
+
+if missing:
+    print("Missing storage artifacts:")
+    for m in missing:
+        print(f" - {m}")
+    sys.exit(1)
+
+print("Storage contract validation OK")

--- a/tools/validate_storage_receipts_vertical_slice.py
+++ b/tools/validate_storage_receipts_vertical_slice.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SLICE = ROOT / "apps" / "storage-promotion"
+REQUIRED = [
+    SLICE / "receipts.py",
+    SLICE / "pipeline_platform.py",
+    SLICE / "runtime.py",
+    SLICE / "dolt_adapter.py",
+    SLICE / "typedb_adapter.py",
+    ROOT / "contracts" / "EventEnvelope.v0.1.json",
+    ROOT / "contracts" / "EvidenceReceipt.v0.1.json",
+]
+
+
+def fail(msg: str) -> int:
+    print(f"ERR: {msg}", file=sys.stderr)
+    return 2
+
+
+def main() -> int:
+    for path in REQUIRED:
+        if not path.exists():
+            return fail(f"missing required file: {path.relative_to(ROOT)}")
+
+    with tempfile.TemporaryDirectory() as td:
+        env = dict(os.environ)
+        env["STORAGE_PROMOTION_STATE_HOME"] = str(Path(td) / "state")
+        proc = subprocess.run(
+            [sys.executable, str(SLICE / "pipeline_platform.py")],
+            cwd=str(SLICE),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return fail(f"pipeline platform failed: {proc.stderr.strip()}")
+        try:
+            result = json.loads(proc.stdout)
+        except Exception as exc:
+            return fail(f"pipeline output is not valid JSON: {exc}")
+
+        if result["event_envelope"]["event_type"] != "storage.promotion.completed":
+            return fail("unexpected event type")
+        if result["evidence_receipt"]["status"] != "succeeded":
+            return fail("unexpected receipt status")
+        if result["event_envelope"]["correlation_id"] != result["promoted"]["claim"]["id"]:
+            return fail("correlation id mismatch")
+        if not Path(result["event_path"]).exists() or not Path(result["receipt_path"]).exists():
+            return fail("expected event/receipt artifacts were not written")
+
+    print("OK: storage receipt vertical slice validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_storage_vertical_slice.py
+++ b/tools/validate_storage_vertical_slice.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SLICE = ROOT / "apps" / "storage-promotion"
+
+REQUIRED = [
+    ROOT / "contracts" / "storage" / "Observation.v0.1.json",
+    ROOT / "contracts" / "storage" / "RunRecord.v0.1.json",
+    ROOT / "contracts" / "storage" / "ProjectionManifest.v0.1.json",
+    ROOT / "contracts" / "storage" / "PromotionRejection.v0.1.json",
+    ROOT / "contracts" / "storage" / "PromotionReceipt.v0.1.json",
+    SLICE / "runtime.py",
+    SLICE / "dolt_adapter.py",
+    SLICE / "typedb_adapter.py",
+    SLICE / "pipeline.py",
+]
+
+
+def fail(msg: str) -> int:
+    print(f"ERR: {msg}", file=sys.stderr)
+    return 2
+
+
+def main() -> int:
+    for path in REQUIRED:
+        if not path.exists():
+            return fail(f"missing required file: {path.relative_to(ROOT)}")
+
+    proc = subprocess.run(
+        [sys.executable, str(SLICE / "pipeline.py")],
+        cwd=str(SLICE),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return fail(f"pipeline failed: {proc.stderr.strip()}")
+
+    try:
+        result = json.loads(proc.stdout)
+    except Exception as exc:
+        return fail(f"pipeline output is not valid JSON: {exc}")
+
+    if result["observation"]["normalized_payload"]["subject"] != "user123":
+        return fail("unexpected subject in observation")
+    if result["promoted"]["claim"]["type"] != "has_role":
+        return fail("unexpected claim type")
+    if result["projection"]["projection_manifest"]["target_store"] != "neo4j":
+        return fail("unexpected projection target store")
+
+    print("OK: storage vertical slice validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Continues the storage convergence work from the prior storage slice branch using the same upstream base commit, with a writable continuation branch.

Adds:
- platform-style receipt helper for storage slice
- receipt-emitting storage pipeline entrypoint
- storage receipt vertical slice validator

Notes:
- this continues the storage convergence work after the earlier PR head branch became non-writable in the connector
- upstream `main` was re-checked before landing these changes and had not moved

Follow-on:
- wire validator into Makefile / repo validation
- replace TypeQL export with optional live TypeDB apply path when connector-safe