### PR TITLE
Add Ghost runtime governance and fracture workflow scaffold

### DIFF
--- a/.github/workflows/ghost-governance-fracture.yml
+++ b/.github/workflows/ghost-governance-fracture.yml
@@ -1,0 +1,32 @@
+name: ghost-governance-fracture
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'tools/registry_governance_ceremony_runner_v0_2.py'
+      - 'tools/combined_governance_fracture_ci_harness_v0_4.py'
+      - 'docs/ghost-runtime-governance-fracture.md'
+      - '.github/workflows/ghost-governance-fracture.yml'
+
+jobs:
+  ghost-control-plane:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run registry governance ceremony wrapper
+        run: |
+          python tools/registry_governance_ceremony_runner_v0_2.py --output registry_governance_ceremony_report.json
+      - name: Run combined governance + fracture wrapper
+        run: |
+          python tools/combined_governance_fracture_ci_harness_v0_4.py --output combined_governance_fracture_ci_report.json
+      - name: Upload reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: ghost-governance-fracture-reports
+          path: |
+            registry_governance_ceremony_report.json
+            combined_governance_fracture_ci_report.json

--- a/.github/workflows/ghost-governance-fracture.yml
+++ b/.github/workflows/ghost-governance-fracture.yml
@@ -9,6 +9,9 @@ on:
       - 'docs/ghost-runtime-governance-fracture.md'
       - '.github/workflows/ghost-governance-fracture.yml'
 
+permissions:
+  contents: read
+
 jobs:
   ghost-control-plane:
     runs-on: ubuntu-latest

--- a/docs/ghost-runtime-governance-fracture.md
+++ b/docs/ghost-runtime-governance-fracture.md
@@ -1,0 +1,19 @@
+# Ghost runtime governance and fracture integration
+
+## Purpose
+This note describes how the Ghost control-plane contracts integrate into the runtime and deployment hub.
+
+## Ownership boundaries
+- `socioprophet-standards-storage` owns schemas and standards text.
+- `TriTRPC` owns fixture contracts and transport semantics.
+- `prophet-platform` owns runtime wrappers, workflows, and deployment-facing integration.
+
+## Minimum runtime lane
+The runtime lane should be able to:
+1. run a registry-governance ceremony,
+2. run a runtime fracture lane,
+3. combine both into one CI-visible result,
+4. publish machine-readable reports as workflow artifacts.
+
+## Initial landing
+This repository adds small wrappers and a workflow so the lane is visible now and can be replaced by the concrete runtime implementations as the upstream standards and fixtures are imported.

--- a/tools/combined_governance_fracture_ci_harness_v0_4.py
+++ b/tools/combined_governance_fracture_ci_harness_v0_4.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Combined governance + fracture CI harness wrapper.
+
+This wrapper keeps the CI lane visible while the concrete harnesses are being
+ported into the runtime tree.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry-bundle", required=False)
+    parser.add_argument("--governance-manifest", required=False)
+    parser.add_argument("--fracture-demo", required=False)
+    parser.add_argument("--output", required=False, default="combined_governance_fracture_ci_report.json")
+    args = parser.parse_args()
+
+    report = {
+        "ok": True,
+        "mode": "wrapper",
+        "registry_bundle": args.registry_bundle,
+        "governance_manifest": args.governance_manifest,
+        "fracture_demo": args.fracture_demo,
+        "message": "Replace wrapper logic with the concrete combined governance + runtime fracture harness once the upstream standards and fixture packages are wired here."
+    }
+
+    Path(args.output).write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/registry_governance_ceremony_runner_v0_2.py
+++ b/tools/registry_governance_ceremony_runner_v0_2.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Registry governance ceremony runner wrapper.
+
+This wrapper is intentionally small and safe to land first. It defines the CLI
+shape and expected artifacts for a registry governance ceremony in the runtime
+hub without forcing a specific packaging layout.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--registry-bundle", required=False)
+    parser.add_argument("--governance-manifest", required=False)
+    parser.add_argument("--output", required=False, default="registry_governance_ceremony_report.json")
+    args = parser.parse_args()
+
+    report = {
+        "ok": True,
+        "mode": "wrapper",
+        "registry_bundle": args.registry_bundle,
+        "governance_manifest": args.governance_manifest,
+        "message": "Replace wrapper logic with the concrete ceremony runner once upstream standards and fixture packages are imported here."
+    }
+
+    Path(args.output).write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
This PR adds a minimal runtime/CI landing set for the Ghost control plane in `prophet-platform`.

Files added:
- `docs/ghost-runtime-governance-fracture.md`
- `tools/registry_governance_ceremony_runner_v0_2.py`
- `tools/combined_governance_fracture_ci_harness_v0_4.py`
- `.github/workflows/ghost-governance-fracture.yml`

## Why here
`prophet-platform` is the public runtime/deployment hub. This PR creates a safe first landing for:
- runtime-facing wrappers
- a visible combined governance + fracture CI lane
- artifact upload/reporting

## Upstream state check
This branch was created from current `main` head:
- `52793be79dab4afc23b4ff83cdd2c1cd1bb36411`

## Notes
These are intentionally wrappers and scaffolds so the lane is visible now without forcing a monolithic runtime refactor. The concrete implementations can replace these entry points once the standards and transport surfaces are merged and packaged for runtime consumption.