### PR TITLE
platform: add eval fabric governance follow-up and root discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,23 @@ make smoke-health
 1. `docs/ARCHITECTURE.md`
 2. `docs/TRITRPC_SPEC.md`
 3. `docs/TRITRPC_PLATFORM_BINDING.md`
-4. `contracts/`
-5. `infra/k8s/`
+4. `docs/PLATFORM_EVAL_FABRIC.md`
+5. `contracts/`
+6. `infra/k8s/`
+
+## Evaluation fabric lane
+
+The platform also carries a first-class **evaluation, observability, and competition-intelligence lane**.
+
+Start here:
+- `docs/PLATFORM_EVAL_FABRIC.md`
+- `docs/LOCAL_DEV_EVAL_FABRIC.md`
+- `docs/EVAL_FABRIC_GOVERNANCE.md`
+- `apps/eval-fabric-api/`
+- `schemas/eval/`
+- `infra/local/docker-compose.eval-fabric.unified.yml`
+
+This lane is platform responsibility, not a detached benchmark pack. It owns the container, datastore, schema, and API bootstrap for platform-level ranking, replay, and intelligence work.
 
 ## Notes on this phase
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Start here:
 - `docs/LOCAL_DEV_EVAL_FABRIC.md`
 - `docs/EVAL_FABRIC_GOVERNANCE.md`
 - `apps/eval-fabric-api/`
-- `schemas/eval/`
+- `schemas/eval/README.md` for the evaluation schema catalog, including metric/context schemas and governance/provenance schemas such as `ReproLedgerEntry`, `CausalAttribution`, `MethodologySnapshot`, and `MetricCrosswalk`
 - `infra/local/docker-compose.eval-fabric.unified.yml`
 
 This lane is platform responsibility, not a detached benchmark pack. It owns the container, datastore, schema, and API bootstrap for platform-level ranking, replay, and intelligence work.

--- a/apps/eval-fabric-api/README.md
+++ b/apps/eval-fabric-api/README.md
@@ -8,4 +8,11 @@ Current routes:
 - `/v1/models/{model_release_id}/dossier`
 - `/v1/competition/radar`
 
-This app is intentionally seeded. Its job in this repo is to anchor the platform surface, container wiring, and database responsibility for the lane.
+## Default local/runtime path
+
+The preferred local development path is now the **unified DB-backed** entrypoint:
+- container: `Dockerfile.unified`
+- compose: `infra/local/docker-compose.eval-fabric.unified.yml`
+- app entrypoint: `app/unified_main.py`
+
+Legacy seeded and intermediate persisted variants remain in the repo as bootstrap history, but the unified path is the visible default for platform work going forward.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,6 +19,24 @@ The current stable TriTRPC v1 Go port computes AEAD tags over the envelope and a
 - `apps/api`: minimal TriTRPC v1 service that accepts `platform.health.v1 / Health.Ping.REQ` and returns `Health.Ping.RES`.
 - `apps/gateway`: minimal HTTP edge that calls the internal health route over the platform TriTRPC binding.
 - `apps/socioprophet-web`: browser shell that hits the gateway.
+- `apps/eval-fabric-api`: platform evaluation, observability, and competition-intelligence API surface for frontier, dossier, radar, and health routes.
+
+## Evaluation and intelligence lane
+
+The evaluation fabric is part of platform responsibility. It is not a detached benchmark pack.
+
+Current platform landing points:
+- `apps/eval-fabric-api/`
+- `infra/datastores/postgres/`
+- `infra/datastores/clickhouse/`
+- `infra/local/docker-compose.eval-fabric.unified.yml`
+- `schemas/eval/`
+- `docs/PLATFORM_EVAL_FABRIC.md`
+
+Responsibility split:
+- **Postgres** holds transactional and control-plane state.
+- **ClickHouse** holds hot analytical metric facts and profile-score style outputs.
+- **Replay / provenance objects** are defined under `schemas/eval/` and are intended to be surfaced through API and score-pipeline work.
 
 ## Next service target
 

--- a/docs/LOCAL_DEV_EVAL_FABRIC.md
+++ b/docs/LOCAL_DEV_EVAL_FABRIC.md
@@ -4,35 +4,35 @@ This runbook stands up the local platform services for the evaluation and intell
 
 ## Services
 
-The initial local stack includes:
+The default local stack includes:
 - `postgres` for control-plane and transactional metadata
 - `clickhouse` for analytical metric facts and score views
-- `eval-fabric-api` for seeded frontier, dossier, radar, and health routes
+- `eval-fabric-api` for DB-backed frontier, dossier, radar, and health routes
 
 ## Start the local stack
 
 From the repo root:
 
 ```bash
-cd "$HOME/dev/prophet-platform" && docker compose -f infra/local/docker-compose.eval-fabric.yml up --build
+cd "$HOME/dev/prophet-platform" && docker compose -f infra/local/docker-compose.eval-fabric.unified.yml up --build
 ```
 
 ## Health checks
 
 After startup:
-- API health: `http://localhost:8080/healthz`
-- Frontier endpoint: `http://localhost:8080/v1/frontier`
-- Dossier endpoint: `http://localhost:8080/v1/models/model.semantic-stack.2026-04-05/dossier`
-- Radar endpoint: `http://localhost:8080/v1/competition/radar`
+- API health: `http://localhost:8082/healthz`
+- Frontier endpoint: `http://localhost:8082/v1/frontier`
+- Dossier endpoint: `http://localhost:8082/v1/models/model.semantic-stack.2026-04-05/dossier`
+- Radar endpoint: `http://localhost:8082/v1/competition/radar`
 
 ## Notes
 
-- This lane is seeded and intentionally thin.
-- The API currently returns stable seeded payloads suitable for wiring the first dashboard views.
-- The next implementation step is replacing seeded payloads with persisted reads from Postgres and ClickHouse.
+- The unified local path reads from Postgres and ClickHouse seed state.
+- Older compose variants remain in the repo as bootstrap history, but the unified path is the visible default going forward.
+- The next implementation step is replacing seed SQL and direct query logic with migrations, adapters, and ingestion workers.
 
 ## Stop the stack
 
 ```bash
-cd "$HOME/dev/prophet-platform" && docker compose -f infra/local/docker-compose.eval-fabric.yml down -v
+cd "$HOME/dev/prophet-platform" && docker compose -f infra/local/docker-compose.eval-fabric.unified.yml down -v
 ```

--- a/docs/PLATFORM_EVAL_FABRIC.md
+++ b/docs/PLATFORM_EVAL_FABRIC.md
@@ -25,7 +25,7 @@ It does **not** replace dedicated standards repos. Instead, it carries the execu
 ## Proposed repo landing points
 
 - `apps/eval-fabric-api/` — FastAPI starter surface for frontier, dossier, radar, and health routes
-- `infra/local/docker-compose.eval-fabric.yml` — local dev services for Postgres, ClickHouse, and the API
+- `infra/local/docker-compose.eval-fabric.unified.yml` — unified local dev services for Postgres, ClickHouse, and the API
 - `infra/datastores/postgres/` — transactional DDL for control-plane state
 - `infra/datastores/clickhouse/` — analytical DDL for hot metric facts and ranking views
 - `schemas/eval/` — canonical JSON schemas for metric definitions, metric facts, and context slices

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,4 +1,4 @@
-# Roadmap (Initial 11 Steps)
+# Roadmap (Initial 14 Steps)
 
 1) Ship a minimal TritRPC library and drop it into `apps/api` (replace plaintext).
 2) Add AEAD key management (env→K8s Secret→sealed-secret).
@@ -11,3 +11,6 @@
 9) Wire Argo CD app-of-apps to dev/prod overlays.
 10) Add perf budget checks (latency/CPU/mem) to CI.
 11) Stand up canary deployments (progressive delivery) via Argo Rollouts.
+12) Promote the eval-fabric lane from local bootstrap to migration-backed platform service.
+13) Wire provenance and governance objects into score computation, replay, and competition-intelligence ingest.
+14) Surface reproduced-vs-claimed deltas and trust/freshness-aware ranking in platform dashboards.

--- a/schemas/eval/README.md
+++ b/schemas/eval/README.md
@@ -2,9 +2,20 @@
 
 This directory holds canonical JSON schemas for the platform evaluation and intelligence fabric.
 
-Initial scope:
+## Metric and context schemas
+
 - `metric-definition.schema.json`
 - `metric-fact.schema.json`
 - `context-slice.schema.json`
 
 These schemas are intentionally narrow starter anchors. They let the platform repo own the metric vocabulary and the atomic evidence model while the broader bundle continues to evolve.
+
+## Governance and provenance schemas
+
+- `repro-ledger-entry.schema.json` — `ReproLedgerEntry`: reproducibility ledger record linking a metric fact to its eval run, judge, and replay artifact
+- `causal-attribution.schema.json` — `CausalAttribution`: causal attribution record assigning score changes to specific factors or interventions
+- `methodology-snapshot.schema.json` — `MethodologySnapshot`: point-in-time snapshot of the scoring methodology used for a given eval run
+- `metric-crosswalk.schema.json` — `MetricCrosswalk`: mapping between platform-internal metric identifiers and external benchmark or standard identifiers
+- `judge-descriptor.schema.json` — `JudgeDescriptor`: descriptor for the judge (model, human, or hybrid) used in an eval run
+
+Example payloads for each governance/provenance schema are in the `examples/` subdirectory.


### PR DESCRIPTION
## Summary

Carry the next eval-fabric follow-up onto the current `main` base.

This PR combines three tightly related pieces:

1. governance/provenance schemas under `schemas/eval/`
2. concrete example payloads and governance notes
3. root-doc discoverability and unified-local-default updates so the lane is visible from repo entrypoints

## Why

The eval-fabric bootstrap is already merged into `main`, but the next platform step needs both:
- trustworthy provenance objects (`ReproLedgerEntry`, `CausalAttribution`, `MethodologySnapshot`, `MetricCrosswalk`)
- and repo-entrypoint visibility so the lane is not buried for platform operators

## Scope

Files included:
- `README.md`
- `apps/eval-fabric-api/README.md`
- `docs/ARCHITECTURE.md`
- `docs/LOCAL_DEV_EVAL_FABRIC.md`
- `docs/ROADMAP.md`
- `docs/EVAL_FABRIC_GOVERNANCE.md`
- governance/provenance schemas under `schemas/eval/`
- example payloads under `schemas/eval/examples/`

## Notes

This PR intentionally does not yet wire these objects into runtime API responses or the score pipeline. It prepares the platform repo with the discoverability and contract layer needed for that next implementation pass.
