### PR TITLE
Add receipt normalization helper for knowledge-reason ingress

### DIFF
--- a/apps/knowledge-reason/service/receipt_normalize.py
+++ b/apps/knowledge-reason/service/receipt_normalize.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def normalize_receipt_payload(receipt: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "scopeRef": receipt.get("scopeRef", ""),
+        "issuedAt": receipt.get("issuedAt", ""),
+        "policyWitnessThreshold": int(receipt.get("policyWitnessThreshold", 0) or 0),
+        "witnesses": list(receipt.get("witnesses", [])),
+    }


### PR DESCRIPTION
## What this does
- adds a tiny `receipt_normalize.py` helper under `apps/knowledge-reason/service/`
- keeps the helper strictly non-cryptographic and normalization-only

## Why this is separate
This PR is the next isolation step after the merged non-cryptographic ingress slice.
It is intended to answer one precise question: can a receipt-shaped normalization helper land cleanly without bringing in verifier or signature logic?

## Result of that isolation
Yes — this helper landed cleanly in-session.

## Follow-on intended after this
- continue isolating the blocked class with very small verifier-adjacent helpers
- only after that, re-attempt the richer verifier module

## Validation
This repo still validates through `make validate`.
The helper is additive and dependency-light.
