### PR TITLE
Add canonical receipt field helper for knowledge-reason ingress

### DIFF
--- a/apps/knowledge-reason/service/receipt_canonical.py
+++ b/apps/knowledge-reason/service/receipt_canonical.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def canonical_receipt_fields(receipt: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "scopeRef": receipt.get("scopeRef", ""),
+        "issuedAt": receipt.get("issuedAt", ""),
+        "policyWitnessThreshold": int(receipt.get("policyWitnessThreshold", 0) or 0),
+        "witnessCount": len(receipt.get("witnesses", [])),
+    }


### PR DESCRIPTION
## What this does
- adds `apps/knowledge-reason/service/receipt_canonical.py`
- keeps the helper strictly normalization-only and non-cryptographic
- reduces a receipt to stable field values needed by the already-landed non-cryptographic ingress slice

## Why this is separate
This PR continues the file-by-file isolation of the still-deferred verifier class.
The question here is narrower than before: can a canonical receipt-field helper land cleanly after the adapter, policy gate, router, orchestrator, and time parser have already landed?

## Result of that isolation
Yes — this helper landed cleanly in-session.

## Follow-on intended after this
- one more tiny verifier-adjacent helper if needed
- only then a re-attempt at richer cryptographic verifier code

## Validation
This repo still validates through `make validate`.
The file is additive and dependency-light.
