### PR TITLE
Storage follow-up: live TypeDB mode + storage validation suite

### DIFF
--- a/apps/storage-promotion/pipeline_platform_live.py
+++ b/apps/storage-promotion/pipeline_platform_live.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from dolt_adapter import insert_observation
+from receipts import make_bundle, write_bundle
+from runtime import build_observation, project_promoted, promote_observation
+from typedb_adapter import build_insert_tql
+from typedb_live_apply import apply_tql_live
+
+
+def _load_payload(path: str | None) -> dict:
+    if not path:
+        return {
+            "subject": "user123",
+            "action": "has_role",
+            "object": "admin",
+        }
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the storage promotion slice with platform receipts and optional live TypeDB apply")
+    parser.add_argument("--payload-file")
+    parser.add_argument("--apply-dolt", action="store_true")
+    parser.add_argument("--apply-typedb-live", action="store_true")
+    parser.add_argument("--typedb-address")
+    parser.add_argument("--typedb-database")
+    parser.add_argument("--dolt-dir")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    payload = _load_payload(args.payload_file)
+    observation = build_observation(payload)
+    promoted = promote_observation(observation)
+    projection = project_promoted(promoted)
+    typedb_tql = build_insert_tql(promoted)
+
+    dolt_result = None
+    if args.apply_dolt:
+        dolt_result = insert_observation(observation, dolt_dir=args.dolt_dir)
+
+    typedb_result = None
+    if args.apply_typedb_live:
+        typedb_result = apply_tql_live(
+            typedb_tql,
+            address=args.typedb_address,
+            database=args.typedb_database,
+        )
+
+    claim = promoted["claim"]
+    manifest = projection["projection_manifest"]
+    bundle = make_bundle(
+        event_type="storage.promotion.completed",
+        action="StoragePromotionPipelineLive",
+        status="succeeded",
+        subject_ref=f"claim://{claim['id']}",
+        payload_ref=f"projection://{manifest['projection_manifest_id']}",
+        correlation_id=claim["id"],
+        classifiers=["slice:storage-promotion", "projection:neo4j", "promotion:typedb-live-optional"],
+        output_refs=[
+            f"claim://{claim['id']}",
+            f"projection://{manifest['projection_manifest_id']}",
+        ],
+        metrics={
+            "entity_count": len(promoted["entities"]),
+            "edge_count": len(projection["edges"]),
+            "observation_id": observation["observation_id"],
+            "typedb_live_requested": args.apply_typedb_live,
+            "typedb_live_ok": None if typedb_result is None else typedb_result.get("ok"),
+        },
+    )
+    event_path, receipt_path = write_bundle(bundle, stem=claim["id"] + ".live")
+
+    print(json.dumps({
+        "observation": observation,
+        "dolt_result": dolt_result,
+        "promoted": promoted,
+        "typedb_tql": typedb_tql,
+        "typedb_result": typedb_result,
+        "projection": projection,
+        "event_envelope": bundle.envelope,
+        "evidence_receipt": bundle.receipt,
+        "event_path": str(event_path),
+        "receipt_path": str(receipt_path),
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/storage-promotion/typedb_live_apply.py
+++ b/apps/storage-promotion/typedb_live_apply.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def apply_tql_live(tql: str, *, address: str | None = None, database: str | None = None) -> dict[str, Any]:
+    resolved_address = address or os.environ.get("TYPEDB_ADDRESS", "127.0.0.1:1729")
+    resolved_database = database or os.environ.get("TYPEDB_DATABASE")
+    if not resolved_database:
+        return {
+            "ok": False,
+            "mode": "typedb-live-apply",
+            "address": resolved_address,
+            "database": None,
+            "tql": tql,
+            "error": "TYPEDB_DATABASE not set",
+        }
+    try:
+        from typedb.driver import TypeDB, SessionType, TransactionType
+    except Exception as exc:
+        return {
+            "ok": False,
+            "mode": "typedb-live-apply",
+            "address": resolved_address,
+            "database": resolved_database,
+            "tql": tql,
+            "error": f"typedb-driver unavailable: {exc}",
+        }
+    try:
+        driver = TypeDB.core_driver(resolved_address)
+        with driver:
+            with driver.session(resolved_database, SessionType.DATA) as session:
+                with session.transaction(TransactionType.WRITE) as tx:
+                    tx.query.insert(tql)
+                    tx.commit()
+        return {
+            "ok": True,
+            "mode": "typedb-live-apply",
+            "address": resolved_address,
+            "database": resolved_database,
+            "tql": tql,
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "mode": "typedb-live-apply",
+            "address": resolved_address,
+            "database": resolved_database,
+            "tql": tql,
+            "error": str(exc),
+        }

--- a/tools/validate_storage_live_typedb_mode.py
+++ b/tools/validate_storage_live_typedb_mode.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SLICE = ROOT / "apps" / "storage-promotion"
+REQUIRED = [
+    SLICE / "typedb_live_apply.py",
+    SLICE / "pipeline_platform_live.py",
+]
+
+
+def fail(msg: str) -> int:
+    print(f"ERR: {msg}", file=sys.stderr)
+    return 2
+
+
+def main() -> int:
+    for path in REQUIRED:
+        if not path.exists():
+            return fail(f"missing required file: {path.relative_to(ROOT)}")
+
+    proc = subprocess.run(
+        [sys.executable, str(SLICE / "pipeline_platform_live.py"), "--apply-typedb-live"],
+        cwd=str(SLICE),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return fail(f"live pipeline failed: {proc.stderr.strip()}")
+
+    try:
+        result = json.loads(proc.stdout)
+    except Exception as exc:
+        return fail(f"pipeline output is not valid JSON: {exc}")
+
+    typedb_result = result.get("typedb_result")
+    if typedb_result is None:
+        return fail("typedb_result missing from live pipeline output")
+    if typedb_result.get("mode") != "typedb-live-apply":
+        return fail("unexpected typedb live mode marker")
+    if result["event_envelope"]["event_type"] != "storage.promotion.completed":
+        return fail("unexpected event type")
+    if result["evidence_receipt"]["status"] != "succeeded":
+        return fail("unexpected receipt status")
+
+    print("OK: storage live TypeDB mode validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_storage_suite.py
+++ b/tools/validate_storage_suite.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKS = [
+    ROOT / "tools" / "validate_storage_contracts.py",
+    ROOT / "tools" / "validate_storage_vertical_slice.py",
+    ROOT / "tools" / "validate_storage_receipts_vertical_slice.py",
+    ROOT / "tools" / "validate_storage_live_typedb_mode.py",
+]
+
+
+def main() -> int:
+    for check in CHECKS:
+        proc = subprocess.run([sys.executable, str(check)], cwd=str(ROOT), check=False)
+        if proc.returncode != 0:
+            return proc.returncode
+    print("OK: storage suite validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Follow-up to the merged storage slice work on current `main`.

Adds:
- `apps/storage-promotion/typedb_live_apply.py` — optional live TypeDB apply helper
- `apps/storage-promotion/pipeline_platform_live.py` — receipt-emitting live pipeline entrypoint
- `tools/validate_storage_live_typedb_mode.py` — validates optional live mode degrades cleanly when TypeDB is not configured
- `tools/validate_storage_suite.py` — single entrypoint for all storage validators

Important note:
- I attempted to wire this suite into `Makefile`, but the connector cannot update existing files here without a file SHA path that this surface does not expose. The suite entrypoint is present, so the repo-side hook-up is now a tiny follow-up edit rather than additional design work.

This PR is intentionally additive and low-risk against current `main`.