### PR TITLE
Add GhostEventV3 runtime scaffold

### DIFF
--- a/docs/ghost-event-v3-runtime.md
+++ b/docs/ghost-event-v3-runtime.md
@@ -1,0 +1,27 @@
+# GhostEventV3 runtime note
+
+## Purpose
+This note records the runtime implications of the Event-IR → GhostEvent interop specification.
+
+## Scope
+GhostEventV3 extends the runtime event envelope with semantic basis-binding fields:
+- `prime_registry_ref`
+- `prime_registry_state_hash`
+- `event_ir_hash`
+- `prime_vector`
+
+## Runtime expectations
+Runtime emitters SHOULD:
+- derive GhostEventV3 from canonical Event-IR
+- include registry-binding fields when prime-topic semantics are present
+- compute canonical hashes before signing
+- preserve the malformed vs blocked distinction during validation
+
+## Minimal runtime lane
+A minimal runtime lane SHOULD be able to emit:
+- `layer_touch`
+- `contradiction_fracture`
+- signed GhostEventV3 wrappers for those events
+
+## Notes
+This is a narrow second-wave runtime landing that complements the first Ghost runtime governance and fracture scaffold without forcing a large refactor.

--- a/tools/emit_ghost_event_v3_concrete.py
+++ b/tools/emit_ghost_event_v3_concrete.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Concrete GhostEventV3 emitter.
+
+This script emits a minimal GhostEventV3 JSON artifact with canonical hash
+binding. It is intentionally self-contained so the V3 runtime lane is no
+longer wrapper-only.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def canonical_json(obj: object) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_canonical_hash(event: dict) -> str:
+    clone = dict(event)
+    clone.pop("canonical_hash", None)
+    return "sha256:" + hashlib.sha256(canonical_json(clone).encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event-id", default="evt_v3_runtime_0001")
+    parser.add_argument("--event-type", default="layer_touch")
+    parser.add_argument("--run-id", default="run_v3_runtime_0001")
+    parser.add_argument("--trace-id", default="trace_v3_runtime_0001")
+    parser.add_argument("--span-id", default="span_v3_runtime_0001")
+    parser.add_argument("--timestamp", default="1970-01-01T00:00:00Z")
+    parser.add_argument("--layer-id", default="S1")
+    parser.add_argument("--prime-registry-ref", default="sp.prime_topic_registry.v1@1.1.0")
+    parser.add_argument("--prime-registry-state-hash", default="sha256:REGISTRYSTATE")
+    parser.add_argument("--event-ir-hash", default="sha256:EVENTIR")
+    parser.add_argument("--output", default="ghost_event_v3.json")
+    args = parser.parse_args()
+
+    event = {
+        "event_id": args.event_id,
+        "event_type": args.event_type,
+        "run_id": args.run_id,
+        "trace_id": args.trace_id,
+        "span_id": args.span_id,
+        "timestamp": args.timestamp,
+        "layer_id": args.layer_id,
+        "theta_ref": None,
+        "scope_ref": None,
+        "policy_ref": None,
+        "registry_ref": None,
+        "prime_registry_ref": args.prime_registry_ref,
+        "prime_registry_state_hash": args.prime_registry_state_hash,
+        "event_ir_hash": args.event_ir_hash,
+        "prime_vector": [],
+        "artifact_refs": [],
+        "canonical_hash": None,
+        "payload": {
+            "step_name": "runtime",
+            "state_ref": "state:runtime",
+            "confidence": 1.0
+        }
+    }
+
+    event["canonical_hash"] = compute_canonical_hash(event)
+    Path(args.output).write_text(json.dumps(event, indent=2) + "\n")
+    print(json.dumps({"ok": True, "output": args.output, "canonical_hash": event["canonical_hash"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/emit_ghost_event_v3_wrapper.py
+++ b/tools/emit_ghost_event_v3_wrapper.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""GhostEventV3 emitter wrapper scaffold.
+
+This wrapper keeps the runtime lane visible while the concrete Event-IR → GhostEventV3
+mapping is being wired into the platform runtime.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event-ir-hash", required=False, default="sha256:EVENTIR")
+    parser.add_argument("--prime-registry-ref", required=False, default="sp.prime_topic_registry.v1@1.1.0")
+    parser.add_argument("--prime-registry-state-hash", required=False, default="sha256:REGISTRYSTATE")
+    parser.add_argument("--output", required=False, default="ghost_event_v3.json")
+    args = parser.parse_args()
+
+    event = {
+        "event_id": "evt_v3_wrapper_0001",
+        "event_type": "layer_touch",
+        "run_id": "run_wrapper_0001",
+        "trace_id": "trace_wrapper_0001",
+        "span_id": "span_wrapper_0001",
+        "timestamp": "1970-01-01T00:00:00Z",
+        "layer_id": "S1",
+        "prime_registry_ref": args.prime_registry_ref,
+        "prime_registry_state_hash": args.prime_registry_state_hash,
+        "event_ir_hash": args.event_ir_hash,
+        "prime_vector": [],
+        "artifact_refs": [],
+        "canonical_hash": None,
+        "payload": {
+            "step_name": "wrapper",
+            "state_ref": "state:wrapper",
+            "confidence": 1.0
+        }
+    }
+
+    Path(args.output).write_text(json.dumps(event, indent=2) + "\n")
+    print(json.dumps({"ok": True, "output": args.output}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
This PR adds a small, isolated GhostEventV3 runtime landing on a fresh branch.

Files added:
- `docs/ghost-event-v3-runtime.md`
- `tools/emit_ghost_event_v3_wrapper.py`

## Why here
`prophet-platform` is the public runtime/deployment hub. This PR records the runtime implications of the Event-IR → GhostEvent interop specification and adds a minimal wrapper so the V3 lane is visible without forcing a larger runtime refactor.

## Upstream state check
This branch was created from current `main` head:
- `2f3bc2e259da845d27840317573ec92d0e214060`

## Notes
This is intentionally a narrow V3 runtime landing. The wrapper can be replaced by the concrete runtime emitter once the V3 standards and transport surfaces are merged and consumed here.
