### PR TITLE
Add GhostEventV3 runtime validation lane

### DIFF
--- a/.github/workflows/ghost-event-v3-validate.yml
+++ b/.github/workflows/ghost-event-v3-validate.yml
@@ -1,0 +1,23 @@
+name: ghost-event-v3-validate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'tools/validate_ghost_event_v3.py'
+      - 'tools/emit_ghost_event_v3_concrete.py'
+      - 'examples/ghost_event_v3.sample.json'
+      - 'docs/ghost-event-v3-runtime.md'
+      - '.github/workflows/ghost-event-v3-validate.yml'
+
+jobs:
+  validate-ghost-event-v3:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Validate sample GhostEventV3
+        run: |
+          python tools/validate_ghost_event_v3.py examples/ghost_event_v3.sample.json

--- a/.github/workflows/ghost-event-v3-validate.yml
+++ b/.github/workflows/ghost-event-v3-validate.yml
@@ -10,6 +10,9 @@ on:
       - 'docs/ghost-event-v3-runtime.md'
       - '.github/workflows/ghost-event-v3-validate.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate-ghost-event-v3:
     runs-on: ubuntu-latest

--- a/examples/ghost_event_v3.sample.json
+++ b/examples/ghost_event_v3.sample.json
@@ -1,0 +1,26 @@
+{
+  "event_id": "evt_v3_runtime_0001",
+  "event_type": "layer_touch",
+  "run_id": "run_v3_runtime_0001",
+  "trace_id": "trace_v3_runtime_0001",
+  "span_id": "span_v3_runtime_0001",
+  "timestamp": "1970-01-01T00:00:00Z",
+  "layer_id": "S1",
+  "theta_ref": null,
+  "scope_ref": null,
+  "policy_ref": null,
+  "registry_ref": null,
+  "prime_registry_ref": "sp.prime_topic_registry.v1@1.1.0",
+  "prime_registry_state_hash": "sha256:REGISTRYSTATE",
+  "event_ir_hash": "sha256:EVENTIR",
+  "prime_vector": [
+    { "basis_index": 0, "topic_id": "topic:identity_prime", "prime": 2, "exponent": 1 }
+  ],
+  "artifact_refs": [],
+  "canonical_hash": null,
+  "payload": {
+    "step_name": "runtime",
+    "state_ref": "state:runtime",
+    "confidence": 1.0
+  }
+}

--- a/tools/validate_ghost_event_v3.py
+++ b/tools/validate_ghost_event_v3.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Minimal GhostEventV3 validator scaffold.
+
+This validator is intentionally dependency-light and checks the load-bearing
+runtime invariants for the V3 event envelope.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+REQUIRED_TOP = [
+    "event_id",
+    "event_type",
+    "run_id",
+    "trace_id",
+    "span_id",
+    "timestamp",
+    "layer_id",
+    "prime_registry_ref",
+    "prime_registry_state_hash",
+    "event_ir_hash",
+    "prime_vector",
+    "payload",
+]
+
+
+def canonical_json(obj: object) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def compute_canonical_hash(event: dict) -> str:
+    clone = dict(event)
+    clone.pop("canonical_hash", None)
+    return "sha256:" + hashlib.sha256(canonical_json(clone).encode("utf-8")).hexdigest()
+
+
+def validate(event: dict) -> tuple[bool, list[str]]:
+    errors: list[str] = []
+    for key in REQUIRED_TOP:
+        if key not in event:
+            errors.append(f"missing:{key}")
+
+    pv = event.get("prime_vector")
+    if not isinstance(pv, list):
+        errors.append("prime_vector:not_list")
+    else:
+        seen = set()
+        last = -1
+        for idx, entry in enumerate(pv):
+            if not isinstance(entry, dict):
+                errors.append(f"prime_vector[{idx}]:not_object")
+                continue
+            for k in ("basis_index", "topic_id", "prime", "exponent"):
+                if k not in entry:
+                    errors.append(f"prime_vector[{idx}]:missing:{k}")
+            bi = entry.get("basis_index")
+            ex = entry.get("exponent")
+            if isinstance(bi, int):
+                if bi in seen:
+                    errors.append("prime_vector:duplicate_basis_index")
+                seen.add(bi)
+                if bi < last:
+                    errors.append("prime_vector:not_sorted")
+                last = bi
+            else:
+                errors.append(f"prime_vector[{idx}]:basis_index_type")
+            if isinstance(ex, int):
+                if ex < 0:
+                    errors.append(f"prime_vector[{idx}]:negative_exponent")
+                if ex == 0:
+                    errors.append(f"prime_vector[{idx}]:zero_exponent_forbidden")
+            else:
+                errors.append(f"prime_vector[{idx}]:exponent_type")
+
+    if event.get("canonical_hash") is not None:
+        expected = compute_canonical_hash(event)
+        if event.get("canonical_hash") != expected:
+            errors.append("canonical_hash:mismatch")
+
+    return len(errors) == 0, errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("event_file")
+    args = parser.parse_args()
+
+    data = json.loads(Path(args.event_file).read_text())
+    ok, errors = validate(data)
+    print(json.dumps({"ok": ok, "errors": errors}, indent=2))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
This PR upgrades the fresh V3 runtime branch from a note/wrapper-only landing into a concrete runtime validation lane.

Files added:
- `tools/validate_ghost_event_v3.py`
- `examples/ghost_event_v3.sample.json`
- `.github/workflows/ghost-event-v3-validate.yml`

This branch already includes:
- `docs/ghost-event-v3-runtime.md`
- `tools/emit_ghost_event_v3_concrete.py`

## Why here
`prophet-platform` is the public runtime/deployment hub. This PR makes the V3 lane concrete enough to review and exercise without forcing the full combined governance/fracture runtime refactor into the same change set.

## Upstream state check
This branch was created from current `main` head:
- `2f3bc2e259da845d27840317573ec92d0e214060`

## Notes
This is still intentionally narrow. The next runtime wave should connect this V3 event lane to the combined governance + fracture harness and the signed-event validator path.
