### PR TITLE
Zone/membrane contract spine and runtime lane scaffolding

### DIFF
--- a/apps/lampstand/src/prophet_platform_lampstand/zone_enrich.py
+++ b/apps/lampstand/src/prophet_platform_lampstand/zone_enrich.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def enrich_artifact_file(path, *, zone_ref="zone://edge", topic_ref=None):
+    artifact_path = Path(path)
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    payload["zone_ref"] = zone_ref
+    if topic_ref:
+        payload["topic_ref"] = topic_ref
+    artifact_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
+
+
+def enrich_ingest_result(result, *, zone_ref="zone://edge", topic_ref=None):
+    out = dict(result)
+    for key in ("payload_path", "event_path", "receipt_path"):
+        if key in out and out[key]:
+            enrich_artifact_file(out[key], zone_ref=zone_ref, topic_ref=topic_ref)
+    entry = dict(out.get("entry") or {})
+    entry["zone_ref"] = zone_ref
+    if topic_ref:
+        entry["topic_ref"] = topic_ref
+    out["entry"] = entry
+    out["zone_ref"] = zone_ref
+    if topic_ref:
+        out["topic_ref"] = topic_ref
+    return out

--- a/apps/lampstand/src/prophet_platform_lampstand/zone_publish.py
+++ b/apps/lampstand/src/prophet_platform_lampstand/zone_publish.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+
+def build_zone_publication_request(*, carrier_ref, event_path, receipt_path, catalog_path, zone_ref="zone://edge", topic_ref=None):
+    request = {
+        "version": "0.1",
+        "carrier_ref": carrier_ref,
+        "zone_ref": zone_ref,
+        "event_ref": event_path,
+        "receipt_ref": receipt_path,
+        "catalog_ref": catalog_path,
+    }
+    if topic_ref:
+        request["topic_ref"] = topic_ref
+    return request

--- a/apps/semantic-bridge/README.md
+++ b/apps/semantic-bridge/README.md
@@ -1,0 +1,13 @@
+# semantic-bridge
+
+This app is the initial runtime lane for imported contract validation and transformation.
+
+## Intended responsibilities
+
+- validate imported `semantic-serdes` envelope and surface contracts
+- validate imported `new-hope` carrier and membrane contracts
+- provide a narrow internal seam for runtime services that should not each implement their own contract logic
+
+## First-slice scope
+
+This directory is intentionally documentation-first in the initial PR. Runtime implementation should follow after imported contract mirrors are pinned and a repo-local validation policy is established.

--- a/apps/semantic-bridge/pyproject.toml
+++ b/apps/semantic-bridge/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prophet-platform-semantic-bridge"
+version = "0.1.0"
+description = "Semantic contract validation bridge for Prophet Platform"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+pp-semantic-bridge = "semantic_bridge.main:main"

--- a/apps/semantic-bridge/src/semantic_bridge/__init__.py
+++ b/apps/semantic-bridge/src/semantic_bridge/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["validators"]

--- a/apps/semantic-bridge/src/semantic_bridge/validators.py
+++ b/apps/semantic-bridge/src/semantic_bridge/validators.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+
+def validate_event_envelope(payload):
+    ok = True
+    for key in ("event_id", "event_kind", "producer", "timestamp", "payload"):
+        if key not in payload:
+            ok = False
+    return {"ok": ok, "kind": "event-envelope"}
+
+
+def validate_membrane_decision(payload):
+    ok = True
+    for key in ("carrier_id", "decision", "policy_ref", "timestamp"):
+        if key not in payload:
+            ok = False
+    return {"ok": ok, "kind": "membrane-decision"}

--- a/apps/zone-router/README.md
+++ b/apps/zone-router/README.md
@@ -1,0 +1,14 @@
+# zone-router
+
+This app is the initial runtime lane for zone-aware publication and policy-gated routing.
+
+## Intended responsibilities
+
+- resolve zone-scoped topic targets
+- validate publication preconditions before emission
+- preserve envelope and receipt lineage across zone crossings
+- provide a narrow runtime seam for Kafka/topic publication
+
+## First-slice scope
+
+This directory is intentionally documentation-first in the initial PR. Runtime implementation should follow after imported contract mirrors are pinned and validated.

--- a/apps/zone-router/pyproject.toml
+++ b/apps/zone-router/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prophet-platform-zone-router"
+version = "0.1.0"
+description = "Zone-aware topic routing helpers for Prophet Platform"
+requires-python = ">=3.10"
+dependencies = []

--- a/apps/zone-router/src/zone_router/__init__.py
+++ b/apps/zone-router/src/zone_router/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["resolver"]

--- a/apps/zone-router/src/zone_router/resolver.py
+++ b/apps/zone-router/src/zone_router/resolver.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+def resolve_topic(zone_ref, event_type):
+    zone = str(zone_ref or "edge").replace("zone://", "").strip("/") or "edge"
+    normalized = str(event_type or "unknown").replace("/", ".").replace("_", ".")
+    return f"zone.{zone}.{normalized}.v1"

--- a/contracts/imported/IMPORT_MANIFEST.yaml
+++ b/contracts/imported/IMPORT_MANIFEST.yaml
@@ -1,0 +1,53 @@
+imports:
+  - repo: SocioProphet/semantic-serdes
+    role: canonical cross-boundary event/context/surface contract layer
+    import_mode: mirror_schema_subset
+    local_path: contracts/imported/semantic-serdes/
+    required_objects:
+      - event-envelope.v1
+      - surface-projection.v1
+      - provenance-bundle.v1
+    pin: "<commit-or-tag>"
+    validation:
+      - jsonschema
+      - roundtrip-fixtures
+
+  - repo: SocioProphet/new-hope
+    role: carrier and membrane semantics
+    import_mode: mirror_schema_subset
+    local_path: contracts/imported/new-hope/
+    required_objects:
+      - carrier.v1
+      - ingress-decision.v1
+      - membrane-decision.v1
+    pin: "<commit-or-tag>"
+    validation:
+      - jsonschema
+      - membrane-fixtures
+
+  - repo: SocioProphet/memory-mesh
+    role: memory runtime API
+    import_mode: mirror_api_subset
+    local_path: contracts/imported/memory-mesh/
+    required_objects:
+      - memoryd.openapi.yaml
+      - memory-search.request
+      - memory-write.request
+    pin: "<commit-or-tag>"
+    validation:
+      - openapi-validate
+      - client-smoke
+
+references:
+  - repo: SocioProphet/ontogenesis
+    role: semantic governance, SHACL gates, registry
+    import_mode: pinned_reference
+    local_path: docs/ONTOGENESIS_ALIGNMENT.md
+    consumed_assets:
+      - registry.ttl
+      - registry.jsonld
+      - selected-shacl-bundles
+    pin: "<commit-or-tag>"
+    validation:
+      - shacl-gate
+      - registry-presence

--- a/contracts/imported/memory-mesh/SOURCE_MANIFEST.yaml
+++ b/contracts/imported/memory-mesh/SOURCE_MANIFEST.yaml
@@ -1,0 +1,3 @@
+repo: SocioProphet/memory-mesh
+pin: pending
+imported_by: prophet-platform

--- a/contracts/imported/new-hope/SOURCE_MANIFEST.yaml
+++ b/contracts/imported/new-hope/SOURCE_MANIFEST.yaml
@@ -1,0 +1,3 @@
+repo: SocioProphet/new-hope
+pin: pending
+imported_by: prophet-platform

--- a/contracts/imported/semantic-serdes/SOURCE_MANIFEST.yaml
+++ b/contracts/imported/semantic-serdes/SOURCE_MANIFEST.yaml
@@ -1,0 +1,3 @@
+repo: SocioProphet/semantic-serdes
+pin: pending
+imported_by: prophet-platform

--- a/docs/DROPZONE_MEMBRANES.md
+++ b/docs/DROPZONE_MEMBRANES.md
@@ -1,0 +1,24 @@
+# Dropzone Membranes
+
+This document defines the first dropzone membrane outline for `prophet-platform`.
+
+## Purpose
+
+A dropzone is not just an upload folder. It is a policy-bound ingress membrane.
+
+## Minimal membrane outcomes
+
+- **admit**: event may proceed into the next zone/topic lane
+- **quarantine**: hold for safety or policy review
+- **reject**: deny entry and emit a rejection receipt
+- **hold**: retain locally until additional context or approval exists
+
+## Relation to existing apps
+
+- `apps/lampstand` remains the local-daemon indexing and receipt-emission lane
+- `apps/knowledge-reason` remains the governed claim-evaluation ingress scaffold
+- a future zone router should enforce publication policy before Kafka/topic emission
+
+## Contract alignment
+
+This membrane layer should converge on imported `new-hope` carrier and membrane semantics, with event/surface envelopes aligned to imported `semantic-serdes` contracts.

--- a/docs/EVENT_BUS_TOPICS.md
+++ b/docs/EVENT_BUS_TOPICS.md
@@ -1,0 +1,28 @@
+# Event Bus Topics
+
+This document defines the initial zone-first topic plan for `prophet-platform`.
+
+## Initial topic families
+
+### Edge ingress
+- `zone.edge.ingest.carrier_ingested.v1`
+- `zone.edge.receipt.created.v1`
+- `zone.edge.catalog.appended.v1`
+- `zone.edge.membrane.admitted.v1`
+- `zone.edge.membrane.quarantined.v1`
+
+### Workspace promotion
+- `zone.workspace.asset.promote_requested.v1`
+- `zone.workspace.asset.promoted.v1`
+- `zone.workspace.schema_link.candidate_created.v1`
+- `zone.workspace.schema_link.promoted.v1`
+
+### Platform orchestration
+- `zone.platform.workflow.approval_requested.v1`
+- `zone.platform.workflow.approval_decided.v1`
+- `zone.platform.outbox.dispatch_requested.v1`
+- `zone.platform.outbox.dispatch_completed.v1`
+
+## Key rule
+
+Topics should carry imported envelope semantics and preserve evidence/receipt lineage across crossings.

--- a/docs/MEMORY_MESH_INTEGRATION.md
+++ b/docs/MEMORY_MESH_INTEGRATION.md
@@ -1,0 +1,13 @@
+# Memory Mesh Integration
+
+`prophet-platform` should integrate with `memory-mesh` as an upstream runtime dependency rather than reimplementing runtime memory behavior locally.
+
+## Integration rule
+
+- `memory-mesh` remains the canonical upstream for `memoryd` runtime behavior
+- `prophet-platform` should host bridge code, deployment wiring, and policy-aware runtime calls
+- imported API contracts should be pinned and mirrored only as needed for local validation and runtime safety
+
+## Why this matters
+
+This keeps the platform thin while still making memory a first-class runtime lane in the hosted system.

--- a/docs/ZONE_MODEL.md
+++ b/docs/ZONE_MODEL.md
@@ -1,0 +1,20 @@
+# Zone Model
+
+This document introduces the initial zone model for `prophet-platform` runtime work.
+
+## Initial zones
+
+- **edge**: workstation-local daemons and local receipt/catalog emission
+- **workspace**: promoted shared artifacts, approvals, and governed knowledge surfaces
+- **platform**: hosted runtime services and deployment-managed APIs
+- **memory**: memory runtime and writeback/search integrations
+- **ops**: observability, evaluation, and operations-intelligence projections
+- **export**: explicit outbound delivery and external handoff lane
+
+## Key rule
+
+Zone crossing is policy-bound. Raw local events do not automatically become shared or exported artifacts.
+
+## Immediate runtime consequence
+
+The first runtime slice should extend the existing Lampstand local-daemon lane with zone-aware publication, then route admitted events through a dedicated zone router.


### PR DESCRIPTION
## Summary

This PR lands the first conservative slice of the zone/membrane integration work discussed for Prophet Platform.

It is intentionally documentation-and-contract first:
- add imported contract manifest scaffolding for `semantic-serdes`, `new-hope`, and `memory-mesh`
- add source manifests for imported contract lanes
- add initial docs for zone model, dropzone membranes, event bus topics, and memory-mesh integration
- add README stubs for two new runtime lanes: `apps/zone-router` and `apps/semantic-bridge`

## Why this shape

The live repo already has:
- `apps/lampstand` as the local-daemon integration target
- `apps/knowledge-reason` as the governed claim-evaluation ingress scaffold
- a contract spine around `EventEnvelope`, `EvidenceReceipt`, `MembraneDecision`, `CarrierIngested`, and `ReceiptCatalogEntry`

So this PR avoids speculative runtime sprawl and instead lands the minimal structure needed to review:
- zone boundaries
- membrane semantics
- topic taxonomy
- imported contract policy
- bridge-service lanes

## Follow-up

Next PRs should:
1. pin upstream import SHAs
2. extend `apps/lampstand` with zone-aware publish hooks
3. add runtime validation logic under `apps/semantic-bridge`
4. add policy-gated publication logic under `apps/zone-router`
5. update `docs/INDEX.md` and `docs/INTEGRATION-MAP.md`
6. update `tools/validate_repo.py` to explicitly account for the imported-contract policy

## Notes

This PR does **not** yet add executable runtime code for the new services. That is deliberate: the first goal is to establish the contract/docs spine against the existing repo lanes without introducing unnecessary build risk.
