### PR TITLE
Add slash-topics platform primitives: contracts + integration docs (v0.1)

### DIFF
--- a/contracts/CapsuleOutput.v0.1.json
+++ b/contracts/CapsuleOutput.v0.1.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/CapsuleOutput.v0.1.json",
+  "title": "CapsuleOutput",
+  "type": "object",
+  "required": [
+    "version",
+    "event_id",
+    "created_at",
+    "capsule_ref",
+    "scope_ref",
+    "inputs",
+    "outputs",
+    "receipt"
+  ],
+  "properties": {
+    "version": { "const": "0.1" },
+    "event_id": { "type": "string" },
+    "created_at": { "type": "string" },
+    "capsule_ref": { "type": "string" },
+    "scope_ref": { "type": "string" },
+    "topic_pack_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional: topic packs loaded as context inputs."
+    },
+    "inputs": {
+      "type": "object",
+      "required": ["carrier_refs"],
+      "properties": {
+        "carrier_refs": { "type": "array", "items": { "type": "string" } },
+        "embedding_refs": { "type": "array", "items": { "type": "string" } },
+        "query_ref": { "type": "string" }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "required": ["artifact_refs"],
+      "properties": {
+        "artifact_refs": { "type": "array", "items": { "type": "string" } },
+        "evidence_refs": { "type": "array", "items": { "type": "string" } },
+        "decision_trace_ref": { "type": "string" }
+      }
+    },
+    "receipt": {
+      "type": "object",
+      "required": ["hash", "algo"],
+      "properties": {
+        "hash": { "type": "string" },
+        "algo": { "type": "string", "enum": ["sha256", "blake3"] }
+      }
+    }
+  }
+}

--- a/contracts/CapsuleRef.v0.1.json
+++ b/contracts/CapsuleRef.v0.1.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/CapsuleRef.v0.1.json",
+  "title": "CapsuleRef",
+  "type": "object",
+  "required": [
+    "version",
+    "capsule_id",
+    "capsule_digest",
+    "capsule_version",
+    "namespace",
+    "policy_pack_refs"
+  ],
+  "properties": {
+    "version": { "const": "0.1" },
+    "capsule_id": { "type": "string" },
+    "capsule_digest": { "type": "string" },
+    "capsule_version": { "type": "string" },
+    "namespace": { "type": "string" },
+    "policy_pack_refs": { "type": "array", "items": { "type": "string" } },
+    "signing": {
+      "type": "object",
+      "properties": {
+        "key_ref": { "type": "string" },
+        "sig_ref": { "type": "string" },
+        "algo": { "type": "string" }
+      }
+    }
+  }
+}

--- a/contracts/QueryRequest.v0.1.json
+++ b/contracts/QueryRequest.v0.1.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/QueryRequest.v0.1.json",
+  "title": "QueryRequest",
+  "type": "object",
+  "required": ["version", "event_id", "created_at", "query_text", "scope_ref", "policy_tags"],
+  "properties": {
+    "version": { "const": "0.1" },
+    "event_id": { "type": "string" },
+    "created_at": { "type": "string" },
+    "query_text": { "type": "string" },
+    "scope_ref": { "type": "string" },
+    "capsule_ref": { "type": "string" },
+    "intent": { "type": "string" },
+    "constraints": {
+      "type": "object",
+      "properties": {
+        "time_range": { "type": "string" },
+        "language": { "type": "string" },
+        "region": { "type": "string" }
+      }
+    },
+    "policy_tags": {
+      "type": "object",
+      "properties": {
+        "privacy_class": { "type": "string" },
+        "retention": { "type": "string" },
+        "redistribution": { "type": "string" }
+      }
+    }
+  }
+}

--- a/contracts/SearchResultSet.v0.1.json
+++ b/contracts/SearchResultSet.v0.1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/SearchResultSet.v0.1.json",
+  "title": "SearchResultSet",
+  "type": "object",
+  "required": ["version", "event_id", "created_at", "query_ref", "hits", "provenance"],
+  "properties": {
+    "version": { "const": "0.1" },
+    "event_id": { "type": "string" },
+    "created_at": { "type": "string" },
+    "query_ref": { "type": "string" },
+    "hits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["rank", "title", "url"],
+        "properties": {
+          "rank": { "type": "integer" },
+          "title": { "type": "string" },
+          "url": { "type": "string" },
+          "snippet": { "type": "string" },
+          "source": { "type": "string" },
+          "score": { "type": "number" }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "properties": {
+        "provider": { "type": "string" },
+        "provider_instance": { "type": "string" },
+        "timestamp": { "type": "string" }
+      }
+    },
+    "decision_trace_ref": { "type": "string" }
+  }
+}

--- a/contracts/TopicPackRef.v0.1.json
+++ b/contracts/TopicPackRef.v0.1.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/TopicPackRef.v0.1.json",
+  "title": "TopicPackRef",
+  "type": "object",
+  "required": [
+    "version",
+    "pack_id",
+    "pack_digest",
+    "pack_version",
+    "policy_bundle_id",
+    "provenance_ref",
+    "locality_class",
+    "byte_size"
+  ],
+  "properties": {
+    "version": { "const": "0.1" },
+    "pack_id": { "type": "string" },
+    "pack_digest": { "type": "string" },
+    "pack_version": { "type": "string" },
+    "policy_bundle_id": { "type": "string" },
+    "provenance_ref": { "type": "string" },
+    "locality_class": {
+      "type": "string",
+      "enum": ["hot-local", "warm-local", "shared-near", "remote-cold", "offline-archival"]
+    },
+    "byte_size": { "type": "integer", "minimum": 0 },
+    "ttl_s": { "type": "integer", "minimum": 0 },
+    "tags": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/docs/CONTRACT_MIGRATION_LENS_TO_CAPSULE.md
+++ b/docs/CONTRACT_MIGRATION_LENS_TO_CAPSULE.md
@@ -1,0 +1,24 @@
+# Contract migration note: LensOutput -> CapsuleOutput
+
+This platform repo currently contains `contracts/LensOutput.v0.1.json` as an early artifact-index contract.
+
+However, current naming direction is:
+- **Capsule** = executable slash-topic pipeline
+- **CapsuleOutput** = capsule output artifact index + receipt binding
+
+## Posture
+
+- `LensOutput.v0.1` remains present for backward compatibility.
+- New work SHOULD emit `CapsuleOutput.v0.1`.
+- When upstream callers have migrated, `LensOutput.v0.1` can be deprecated and eventually removed in a controlled change.
+
+## Minimal mapping
+
+- `lens_ref` -> `capsule_ref`
+- Everything else carries forward with the same receipt and artifact index intent.
+
+## Follow-on
+
+A follow-on PR should:
+1) update `contracts/README.md` to list `CapsuleOutput` explicitly and mark `LensOutput` as legacy
+2) update any emitting code paths to emit `CapsuleOutput`

--- a/docs/SLASH_TOPICS_INTEGRATION.md
+++ b/docs/SLASH_TOPICS_INTEGRATION.md
@@ -1,0 +1,46 @@
+# Slash topics integration (platform note)
+
+`slash-topics` is the governed context and scoping plane that revives the blekko-era "explicit scope" mechanic as modern, signed, replayable artifacts.
+
+This platform repo is where those standards become running services, receipts, and deployable app surfaces.
+
+## What the platform must support
+
+1) **Mountable topic packs**
+- topic packs are versioned, content-addressed artifacts
+- they are loaded as context inputs under policy
+- their identity must be visible in receipts
+
+2) **Executable capsules**
+- capsules are the executable form of slash topics: signed pipelines that transform queries/carriers into artifacts
+- capsule runs must emit receipts with:
+  - capsule ref
+  - scope ref
+  - topic pack refs
+  - operator chain digest
+  - policy snapshot refs
+
+3) **Contract spine**
+
+The platform materializes a small, repo-local contract family under `contracts/` so runtime services can validate payloads without reaching into multiple upstream repos.
+
+This PR introduces:
+- `TopicPackRef` (topic pack identity for receipts)
+- `CapsuleRef` (capsule identity)
+- `CapsuleOutput` (capsule output artifact index)
+- `QueryRequest` and `SearchResultSet` (typed query + candidate set stubs)
+
+## Pinning and provenance
+
+Operationally, the platform should treat `slash-topics` as a pinned upstream input (similar to other items in `standards.lock.yaml`).
+
+Until it is added to the lock file, this repo carries an explicit integration note and contracts so services can proceed without ambiguity.
+
+## Runtime placement
+
+- the authoritative spec source remains `SocioProphet/slash-topics`
+- this repo holds:
+  - platform-facing contracts
+  - service skeletons
+  - deployment wiring
+  - end-to-end smoke tests


### PR DESCRIPTION
This PR adds the minimal platform-facing primitives needed to host slash-topics/capsules as real services and UIs.

Added (docs):
- `docs/SLASH_TOPICS_INTEGRATION.md` (what the platform must support; contract spine)
- `docs/CONTRACT_MIGRATION_LENS_TO_CAPSULE.md` (naming migration note)

Added (contracts):
- `contracts/TopicPackRef.v0.1.json` (topic pack identity for receipts)
- `contracts/CapsuleRef.v0.1.json` (capsule identity)
- `contracts/CapsuleOutput.v0.1.json` (capsule output artifact index)
- `contracts/QueryRequest.v0.1.json` (typed query request)
- `contracts/SearchResultSet.v0.1.json` (candidate set)

Notes:
- This is additive and does not modify existing required files or validation scripts.
- Follow-on should pin `slash-topics` into `standards.lock.yaml` and update `contracts/README.md` to list `CapsuleOutput` + mark `LensOutput` legacy.
