### PR TITLE
Seed platform contracts validation and Wave 1 runtime stubs

### DIFF
--- a/.github/workflows/platform-contracts-check.yml
+++ b/.github/workflows/platform-contracts-check.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main, platform-contracts-stubs ]
 
+permissions:
+  contents: read
+
 jobs:
   platform-contracts-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/platform-contracts-check.yml
+++ b/.github/workflows/platform-contracts-check.yml
@@ -1,0 +1,24 @@
+name: platform-contracts-check
+
+on:
+  pull_request:
+  push:
+    branches: [ main, platform-contracts-stubs ]
+
+jobs:
+  platform-contracts-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML
+        run: python -m pip install --upgrade pip pyyaml
+
+      - name: Validate platform contracts
+        run: python tools/render_platform_contracts.py

--- a/.github/workflows/platform-wave1-stubs.yml
+++ b/.github/workflows/platform-wave1-stubs.yml
@@ -1,0 +1,24 @@
+name: platform-wave1-stubs
+
+on:
+  pull_request:
+  push:
+    branches: [ platform-contracts-stubs ]
+
+jobs:
+  wave1-stubs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip fastapi==0.115.0 uvicorn==0.30.6 pytest
+
+      - name: Run Wave 1 stub smoke tests
+        run: pytest -q tests/platform_stubs/test_wave1_stubs.py

--- a/.github/workflows/platform-wave1-stubs.yml
+++ b/.github/workflows/platform-wave1-stubs.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ platform-contracts-stubs ]
 
+permissions:
+  contents: read
+
 jobs:
   wave1-stubs:
     runs-on: ubuntu-latest

--- a/apps/dashboard-bff/main.py
+++ b/apps/dashboard-bff/main.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+
+app = FastAPI(title='dashboard-bff')
+
+@app.get('/health')
+def health() -> dict:
+    return {'service': 'dashboard-bff', 'status': 'ok'}
+
+@app.get('/v1/overview')
+def overview() -> dict:
+    return {
+        'service': 'dashboard-bff',
+        'views': ['overview', 'deepdive', 'cases'],
+    }

--- a/apps/dashboard-bff/requirements.txt
+++ b/apps/dashboard-bff/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.0
+uvicorn==0.30.6

--- a/apps/deepdive-orchestrator/main.py
+++ b/apps/deepdive-orchestrator/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+
+app = FastAPI(title='deepdive-orchestrator')
+
+@app.get('/health')
+def health() -> dict:
+    return {'service': 'deepdive-orchestrator', 'status': 'ok'}
+
+@app.get('/v1/deepdive/modes')
+def modes() -> dict:
+    return {
+        'service': 'deepdive-orchestrator',
+        'modes': [
+            'repo_deepdive_report',
+            'environment_deepdive_report',
+            'artifact_release_deepdive_report',
+            'room_controlplane_deepdive_report',
+            'case_deepdive_report',
+        ],
+    }

--- a/apps/deepdive-orchestrator/requirements.txt
+++ b/apps/deepdive-orchestrator/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.0
+uvicorn==0.30.6

--- a/apps/identity-policy/main.py
+++ b/apps/identity-policy/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+
+app = FastAPI(title='identity-policy')
+
+@app.get('/health')
+def health() -> dict:
+    return {'service': 'identity-policy', 'status': 'ok'}
+
+@app.get('/ready')
+def ready() -> dict:
+    return {'service': 'identity-policy', 'ready': True}

--- a/apps/identity-policy/requirements.txt
+++ b/apps/identity-policy/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.0
+uvicorn==0.30.6

--- a/tests/platform_stubs/test_wave1_stubs.py
+++ b/tests/platform_stubs/test_wave1_stubs.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_app(relative_path: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.app
+
+
+def test_identity_policy_app_title():
+    app = load_app('apps/identity-policy/main.py')
+    assert app.title == 'identity-policy'
+
+
+def test_dashboard_bff_app_title():
+    app = load_app('apps/dashboard-bff/main.py')
+    assert app.title == 'dashboard-bff'
+
+
+def test_deepdive_orchestrator_app_title():
+    app = load_app('apps/deepdive-orchestrator/main.py')
+    assert app.title == 'deepdive-orchestrator'


### PR DESCRIPTION
## What this changes

This PR moves `prophet-platform` from contract-only planning into the first executable platform slice.

### Added on this branch
- platform contracts validation workflow at `.github/workflows/platform-contracts-check.yml`
- minimal FastAPI stubs for:
  - `apps/identity-policy`
  - `apps/dashboard-bff`
  - `apps/deepdive-orchestrator`
- Python stub requirements for those three services

## Why

The repo already had the platform hosting model, FogStack integration docs, service catalog, deployment profile contracts, hosting boundary contracts, Wave 1/Wave 2 placeholders, and deployment overlay placeholders. This branch adds the first code-bearing runtime layer and enforces the platform contract pack through CI.

## Follow-ups after merge
- patch `Makefile` to invoke the same platform contract validation path locally
- add generated report artifact output or tests for the new helper
- begin wiring real service logic into the new Wave 1 stubs
