### PR TITLE
Draft: add initial Fog Stack verifier and Access bundle slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go test-python-apps smoke smoke-health smoke-eval-fabric validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go test-python-apps smoke smoke-health smoke-eval-fabric validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke validate-fogstack
 
-validate: validate-repo drift-check standards-check topology-check test-go validate-phase4 test-python-apps
+validate: validate-repo drift-check standards-check topology-check test-go validate-phase4 test-python-apps validate-fogstack
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -50,3 +50,6 @@ validate-phase4:
 
 lampstand-vertical-slice-smoke:
 	bash apps/lampstand/scripts/vertical_slice_smoke.sh
+
+validate-fogstack:
+	python3 tools/validate_fogstack.py

--- a/bundles/fogstack.access-v0.1.yaml
+++ b/bundles/fogstack.access-v0.1.yaml
@@ -1,0 +1,67 @@
+schema_version: "fogstack.bundle/v0.1"
+kind: "FogStackBundle"
+metadata:
+  bundle_id: "fogstack.access"
+  version: "0.1.0"
+  display_name: "Fog Stack Access"
+  summary: "Government-grade secure access bundle deployed on Prophet Platform substrate."
+  source_repositories:
+    - "SocioProphet/cloudshell-fog"
+    - "SocioProphet/prophet-platform"
+
+claims:
+  government_grade_hygiene: true
+  self_hostable: true
+  standalone_first_value: true
+  federated_supported: true
+  intelligent_mode: "suggest"
+
+runtime:
+  substrate: "prophet-platform"
+  service_classes:
+    - "edge-service"
+    - "cluster-service"
+  components:
+    - id: "cloudshell-fog"
+      role: "capability-source"
+    - id: "apps/gateway"
+      role: "edge-ingress"
+    - id: "apps/api"
+      role: "internal-runtime"
+
+contracts:
+  required:
+    - "EventEnvelope"
+    - "EvidenceReceipt"
+    - "MembraneDecision"
+
+profiles:
+  supported:
+    - id: "local-dev"
+      status: "supported"
+      kubernetes_required: false
+      root_required: false
+    - id: "cluster-standard"
+      status: "supported"
+      kubernetes_required: true
+      root_required: false
+
+deployment:
+  minimum_nodes_for_first_value: 1
+  max_required_services: 3
+  install_time_target_minutes: 30
+
+security:
+  identities:
+    operator_identity: true
+    node_identity: true
+    workload_identity: true
+    peer_identity: true
+  supply_chain:
+    signed_artifacts: true
+    sbom_required: true
+    provenance_required: true
+
+lifecycle:
+  channel: "preview"
+  support_state: "community"

--- a/conformance/rulepacks/fogstack.access-v0.1.yaml
+++ b/conformance/rulepacks/fogstack.access-v0.1.yaml
@@ -1,0 +1,68 @@
+schema_version: "fogstack.rulepack/v0.1"
+kind: "FogStackRulepack"
+metadata:
+  rulepack_id: "fogstack.access"
+  version: "0.1.0"
+  target_bundle_id: "fogstack.access"
+
+rules:
+  - id: "ACCESS-001"
+    severity: "critical"
+    check:
+      op: "path_true"
+      path: "claims.government_grade_hygiene"
+
+  - id: "ACCESS-002"
+    severity: "critical"
+    check:
+      op: "path_true"
+      path: "claims.self_hostable"
+
+  - id: "ACCESS-003"
+    severity: "critical"
+    check:
+      op: "path_not_in"
+      path: "claims.intelligent_mode"
+      values: ["unrestricted"]
+
+  - id: "ACCESS-004"
+    severity: "error"
+    check:
+      op: "path_contains_all"
+      path: "runtime.service_classes"
+      values: ["edge-service", "cluster-service"]
+
+  - id: "ACCESS-005"
+    severity: "critical"
+    check:
+      op: "array_objects_field_contains_all"
+      path: "contracts.required"
+      field: ""
+      values: []
+    when:
+      path: "metadata.bundle_id"
+      equals: "__skip__"
+
+  - id: "ACCESS-006"
+    severity: "error"
+    check:
+      op: "path_contains_all"
+      path: "contracts.required"
+      values: ["EventEnvelope", "EvidenceReceipt", "MembraneDecision"]
+
+  - id: "ACCESS-007"
+    severity: "critical"
+    check:
+      op: "supported_profiles_any_match"
+      path: "profiles.supported"
+      criteria:
+        id: "local-dev"
+        kubernetes_required: false
+        root_required: false
+
+  - id: "ACCESS-008"
+    severity: "error"
+    check:
+      op: "path_lte"
+      path: "deployment.max_required_services"
+      value: 3

--- a/docs/FOGSTACK_INTEGRATION.md
+++ b/docs/FOGSTACK_INTEGRATION.md
@@ -1,0 +1,49 @@
+# Fog Stack integration (initial upstream slice)
+
+This document explains the **minimal initial Fog Stack landing** inside `prophet-platform`.
+
+## Why this repo gets the first slice
+
+`prophet-platform` is already the runtime and deployment home for platform services, with explicit runtime classes (`edge-service`, `cluster-service`, `local-daemon`) and an existing validation/reproducibility posture. Fog Stack should therefore land here as a **productization and conformance layer for deployable runtime bundles**, not as a second substrate.
+
+## What is upstream in this initial slice
+
+This branch adds:
+- `tools/fogstack_verify.py` — prototype verifier for Fog Stack bundles
+- `tools/validate_fogstack.py` — helper that runs the verifier over the initial Access bundle
+- `bundles/fogstack.access-v0.1.yaml` — first in-repo bundle definition
+- `conformance/rulepacks/fogstack.access-v0.1.yaml` — first in-repo offering rulepack
+
+## What remains sandbox-only for now
+
+The following stay in sandbox incubation until the first substrate hook is reviewed:
+- Knowledge and Evaluation bundles/rulepacks
+- machine-readable lifecycle catalog
+- broader offering catalog docs
+- operator packs and example pass/fail outputs
+- release-discipline artifacts for signed bundle publication
+
+## Integration principle
+
+Fog Stack should mature here incrementally:
+1. land one bundle + one rulepack + one verifier helper
+2. wire validation into the repo validation chain
+3. add a second and third offering only after the first path is accepted
+4. keep standards/policies that should outlive the runtime in `prophet-platform-standards`
+
+## Manual follow-up still required
+
+This initial slice does **not** yet edit the root `Makefile`.
+
+The next repo-native step is to add:
+
+```make
+.PHONY: validate-fogstack
+
+validate: validate-repo drift-check standards-check topology-check test-go validate-phase4 test-python-apps validate-fogstack
+
+validate-fogstack:
+	python3 tools/validate_fogstack.py
+```
+
+That delta is intentionally kept separate so the first branch remains small and reviewable.

--- a/docs/FOGSTACK_OFFERINGS.md
+++ b/docs/FOGSTACK_OFFERINGS.md
@@ -1,0 +1,52 @@
+# Fog Stack offerings (initial status)
+
+This document records the **current upstream status** of Fog Stack offerings relative to `prophet-platform`.
+
+## Offerings
+
+### Fog Stack Access
+**Status:** initial upstream slice landed in this branch
+
+Source/runtime anchors:
+- `SocioProphet/cloudshell-fog`
+- `apps/gateway`
+- `apps/api`
+
+Current upstream artifacts:
+- `bundles/fogstack.access-v0.1.yaml`
+- `conformance/rulepacks/fogstack.access-v0.1.yaml`
+- `tools/fogstack_verify.py`
+- `tools/validate_fogstack.py`
+
+### Fog Stack Knowledge
+**Status:** substrate-grounded in sandbox, not yet upstreamed
+
+Source/runtime anchors:
+- `apps/knowledge-reason`
+- `apps/lampstand`
+
+Why not yet upstream:
+- needs the first verifier path to be accepted
+- needs a clean local-daemon + cluster-service offering shape reviewed against current runtime classes
+
+### Fog Stack Evaluation
+**Status:** substrate-grounded in sandbox, not yet upstreamed
+
+Source/runtime anchors:
+- `apps/eval-fabric-api`
+- `infra/local/docker-compose.eval-fabric.unified.yml`
+- `infra/datastores/postgres/`
+- `infra/datastores/clickhouse/`
+
+Why not yet upstream:
+- needs the first verifier path and bundle layout accepted
+- needs a release/compatibility story that matches current platform eval-fabric responsibility boundaries
+
+## Interpretation
+
+At the moment, `prophet-platform` should be read as:
+- runtime/deployment substrate for platform services
+- home for a minimal first Fog Stack validation slice
+- **not yet** the complete home for the full Fog Stack product catalog
+
+That broader catalog still belongs in staged incubation until the first upstream integration path is accepted.

--- a/docs/FOGSTACK_RELEASES.md
+++ b/docs/FOGSTACK_RELEASES.md
@@ -1,0 +1,49 @@
+# Fog Stack release discipline (initial upstream slice)
+
+This document defines the smallest release-discipline surface for Fog Stack artifacts that live inside `prophet-platform`.
+
+## Scope of this phase
+
+This phase covers the initial upstream Access slice only:
+- `bundles/fogstack.access-v0.1.yaml`
+- `conformance/rulepacks/fogstack.access-v0.1.yaml`
+- `tools/fogstack_verify.py`
+- `tools/validate_fogstack.py`
+
+It does **not** yet define the full release process for the broader Fog Stack catalog.
+
+## Release channels
+
+Fog Stack artifacts inherit the same broad release posture as the platform, but with offering-specific states:
+
+- `preview` — reviewed but still evolving; shape may change
+- `candidate` — ready for broader validation and operator trial
+- `stable` — accepted shape with an established validation path
+- `deprecated` — superseded; removal announced in advance
+
+The initial Access slice is `preview`.
+
+## Minimum release conditions for a bundle
+
+A bundle should not be treated as released in this repo unless:
+1. the bundle file exists under `bundles/`
+2. the rulepack exists under `conformance/rulepacks/`
+3. `tools/validate_fogstack.py` passes on the branch
+4. the offering has a current status document under `docs/`
+
+## Promotion path
+
+Preview -> Candidate -> Stable should be driven by:
+- successful validation on the active branch
+- no critical verifier failures
+- reviewed runtime anchors in existing substrate services
+- acceptance of the offering shape in draft PR review
+
+## Future additions
+
+The following remain for later phases:
+- signed bundle manifests
+- publication metadata
+- machine-readable support-state emission
+- evidence packaging for bundle releases
+- compatibility snapshots for each promoted offering

--- a/tools/fogstack_verify.py
+++ b/tools/fogstack_verify.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover
+    yaml = None
+
+TOOL_VERSION = "0.1"
+
+
+def load_doc(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix == ".json":
+        return json.loads(text)
+    if yaml is None:
+        raise SystemExit("ERR: PyYAML is required to verify YAML Fog Stack bundles")
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected mapping at top level: {path}")
+    return data
+
+
+def get_path(data: Any, path: str) -> Any:
+    cur = data
+    for part in path.split('.'):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return None
+    return cur
+
+
+def array_dict_field_values(bundle: dict[str, Any], path: str, field: str) -> list[Any]:
+    arr = get_path(bundle, path) or []
+    if not isinstance(arr, list):
+        return []
+    out: list[Any] = []
+    for item in arr:
+        if isinstance(item, dict) and field in item:
+            out.append(item[field])
+    return out
+
+
+def eval_when(bundle: dict[str, Any], when: dict[str, Any] | None) -> bool:
+    if not when:
+        return True
+    actual = get_path(bundle, when["path"])
+    if "equals" in when:
+        return actual == when["equals"]
+    if "in" in when:
+        return actual in when["in"]
+    return bool(actual)
+
+
+def rule_check(bundle: dict[str, Any], rule: dict[str, Any]) -> tuple[str, str]:
+    check = rule["check"]
+    op = check["op"]
+
+    if op == "path_true":
+        val = get_path(bundle, check["path"])
+        return ("pass", "ok") if val is True else ("fail", f"expected {check['path']} == true, got {val!r}")
+
+    if op == "path_equals":
+        val = get_path(bundle, check["path"])
+        return ("pass", "ok") if val == check["value"] else ("fail", f"expected {check['path']} == {check['value']!r}, got {val!r}")
+
+    if op == "path_not_in":
+        val = get_path(bundle, check["path"])
+        return ("pass", "ok") if val not in check["values"] else ("fail", f"value {val!r} is forbidden for {check['path']}")
+
+    if op == "path_contains_all":
+        arr = get_path(bundle, check["path"]) or []
+        if not isinstance(arr, list):
+            return ("fail", f"{check['path']} is not a list")
+        missing = [x for x in check["values"] if x not in arr]
+        return ("pass", "ok") if not missing else ("fail", "missing values: " + ", ".join(missing))
+
+    if op == "array_objects_field_contains_all":
+        vals = array_dict_field_values(bundle, check["path"], check["field"])
+        missing = [x for x in check["values"] if x not in vals]
+        return ("pass", "ok") if not missing else ("fail", "missing values: " + ", ".join(missing))
+
+    if op == "supported_profiles_all_false":
+        arr = get_path(bundle, check["path"]) or []
+        if not isinstance(arr, list):
+            return ("fail", f"{check['path']} is not a list")
+        offenders = []
+        for item in arr:
+            if isinstance(item, dict) and item.get("status") == "supported" and item.get(check["field"]) is not False:
+                offenders.append(item.get("id", "<unknown>"))
+        return ("pass", "ok") if not offenders else ("fail", f"supported profiles violate {check['field']}=false: {', '.join(offenders)}")
+
+    if op == "supported_profiles_any_match":
+        arr = get_path(bundle, check["path"]) or []
+        if not isinstance(arr, list):
+            return ("fail", f"{check['path']} is not a list")
+        criteria = check["criteria"]
+        for item in arr:
+            if isinstance(item, dict) and item.get("status") == "supported" and all(item.get(k) == v for k, v in criteria.items()):
+                return ("pass", "ok")
+        return ("fail", f"no supported profile matched {criteria!r}")
+
+    if op == "path_lte":
+        val = get_path(bundle, check["path"])
+        try:
+            ok = val <= check["value"]
+        except Exception:
+            ok = False
+        return ("pass", "ok") if ok else ("fail", f"expected {check['path']} <= {check['value']!r}, got {val!r}")
+
+    return ("fail", f"unknown op: {op}")
+
+
+def summarize(checks: list[dict[str, Any]]) -> tuple[str, int, dict[str, int]]:
+    counts = {"warning": 0, "error": 0, "critical": 0}
+    status = "pass"
+    for item in checks:
+        if item["status"] != "fail":
+            continue
+        sev = item["severity"]
+        if sev in ("warning", "warn"):
+            counts["warning"] += 1
+            if status == "pass":
+                status = "warn"
+        elif sev == "error":
+            counts["error"] += 1
+            status = "fail"
+        elif sev == "critical":
+            counts["critical"] += 1
+            status = "fail"
+        else:
+            counts["error"] += 1
+            status = "fail"
+    exit_code = 0 if counts["critical"] == 0 and counts["error"] == 0 else 2
+    return status, exit_code, counts
+
+
+def verify(bundle_path: Path, rulepack_path: Path) -> dict[str, Any]:
+    bundle = load_doc(bundle_path)
+    rulepack = load_doc(rulepack_path)
+    checks: list[dict[str, Any]] = []
+    for rule in rulepack.get("rules", []):
+        if not eval_when(bundle, rule.get("when")):
+            checks.append({"id": rule["id"], "severity": rule["severity"], "status": "skip", "message": "condition not met"})
+            continue
+        state, msg = rule_check(bundle, rule)
+        checks.append({"id": rule["id"], "severity": rule["severity"], "status": state, "message": msg})
+    status, exit_code, counts = summarize(checks)
+    return {
+        "tool": "fogstack verify",
+        "version": TOOL_VERSION,
+        "subject": {
+            "kind": bundle.get("kind", "FogStackBundle"),
+            "bundle_id": get_path(bundle, "metadata.bundle_id"),
+            "bundle_version": get_path(bundle, "metadata.version"),
+            "path": str(bundle_path),
+        },
+        "summary": {
+            "status": status,
+            "exit_code": exit_code,
+            "checks_run": len(checks),
+            "warnings": counts["warning"],
+            "errors": counts["error"],
+            "critical": counts["critical"],
+        },
+        "checks": checks,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Prototype Fog Stack bundle verifier")
+    parser.add_argument("bundle", type=Path)
+    parser.add_argument("--rulepack", type=Path)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    bundle = load_doc(args.bundle)
+    bundle_id = get_path(bundle, "metadata.bundle_id")
+    default_rulepack = Path(__file__).resolve().parents[1] / "conformance" / "rulepacks" / f"{bundle_id}-v0.1.yaml"
+    result = verify(args.bundle, args.rulepack or default_rulepack)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        s = result["summary"]
+        print(f"{result['subject']['bundle_id']} status={s['status']} checks={s['checks_run']} warnings={s['warnings']} errors={s['errors']} critical={s['critical']}")
+        for item in result["checks"]:
+            print(f"- {item['status'].upper():5s} {item['id']} [{item['severity']}] {item['message']}")
+    return result["summary"]["exit_code"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_fogstack.py
+++ b/tools/validate_fogstack.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+BUNDLE = ROOT / "bundles" / "fogstack.access-v0.1.yaml"
+RULEPACK = ROOT / "conformance" / "rulepacks" / "fogstack.access-v0.1.yaml"
+VERIFY = ROOT / "tools" / "fogstack_verify.py"
+
+
+def fail(msg: str) -> None:
+    print(f"ERR: {msg}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+for path in [BUNDLE, RULEPACK, VERIFY]:
+    if not path.exists():
+        fail(f"missing Fog Stack validation input: {path.relative_to(ROOT)}")
+
+cmd = [sys.executable, str(VERIFY), str(BUNDLE), "--rulepack", str(RULEPACK)]
+proc = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+if proc.returncode != 0:
+    if proc.stdout:
+        print(proc.stdout, end="", file=sys.stderr)
+    if proc.stderr:
+        print(proc.stderr, end="", file=sys.stderr)
+    fail("Fog Stack access bundle verification failed")
+
+print("OK: Fog Stack access bundle verification passed")


### PR DESCRIPTION
## Summary

This PR lands the smallest upstream-consistent Fog Stack slice in `prophet-platform`:

- `tools/fogstack_verify.py` — prototype bundle verifier
- `tools/validate_fogstack.py` — helper that runs verification over the initial Access bundle
- `bundles/fogstack.access-v0.1.yaml` — first in-repo bundle definition
- `conformance/rulepacks/fogstack.access-v0.1.yaml` — first in-repo offering rulepack
- `docs/FOGSTACK_INTEGRATION.md` — explains why the initial slice lands here and what remains sandbox-only
- `docs/FOGSTACK_OFFERINGS.md` — records current upstream vs sandbox offering status

## Why this shape

`prophet-platform` is already the runtime/deployment substrate, with explicit runtime classes and an existing validation/reproducibility posture. This PR therefore adds only the first productization/conformance hook rather than trying to import the entire Fog Stack catalog at once.

## Not in this PR

- root `Makefile` change for `validate-fogstack`
- Knowledge and Evaluation bundle/rulepack landings
- machine-readable lifecycle catalog
- operator packs and full release discipline surfaces

Those remain in sandbox incubation until this first verifier path is accepted.

## Follow-up

If this slice is accepted, the next PR should:
1. wire `validate-fogstack` into `make validate`
2. add Knowledge as the second offering
3. promote compatibility/lifecycle metadata in a substrate-consistent way
