### PR TITLE
Add Forensic Genesis edge runtime import notes

### DIFF
--- a/contracts/forensic-genesis/README.md
+++ b/contracts/forensic-genesis/README.md
@@ -1,0 +1,21 @@
+# Forensic Genesis Runtime Contract Stub
+
+This directory is the runtime-facing landing zone for the Forensic Genesis edge lane.
+
+## Purpose
+The normative schemas and compatibility rules live in `SocioProphet/prophet-platform-standards`. This directory exists so runtime services have an obvious home for:
+- generated bindings derived from the standards repo
+- topic consumer adapters
+- local validation fixtures used by runtime code
+- import notes tying runtime code to pinned standards revisions
+
+## First-pass event family
+- SNMP observations
+- Mount observations
+- Verification completion
+- Seal completion
+
+## Rules
+- Do not redefine canonical value schemas here.
+- Prefer generated bindings or copies derived from pinned standards imports.
+- Keep runtime consumers transport-aware but standards-neutral.

--- a/docs/FORENSIC_GENESIS_EDGE_IMPORT.md
+++ b/docs/FORENSIC_GENESIS_EDGE_IMPORT.md
@@ -1,0 +1,33 @@
+# Forensic Genesis Edge Import Note
+
+This repository is the runtime and deployment hub for SocioProphet. The normative standards surface for the Forensic Genesis edge lane belongs in `SocioProphet/prophet-platform-standards`.
+
+## What belongs here
+- runtime consumers of edge topics
+- deployment wiring for local broker / registry lanes
+- CI and smoke-test helpers for edge publication
+- import and synchronization notes tying runtime code to the standards repo
+
+## What does not belong here
+- canonical topic value schemas
+- normative ADRs for the edge schema family
+- registry compatibility policy as a source of truth
+
+## Initial edge topic family consumed by the platform
+- `edge.forensic.snmp.observed.v1`
+- `edge.forensic.mounts.observed.v1`
+- `edge.forensic.verify.completed.v1`
+- `edge.forensic.seal.completed.v1`
+
+## Runtime split
+The edge lane is intentionally layered:
+1. host-local collection and evidence persistence
+2. outbox publisher into Kafka fact topics
+3. compacted latest-state materializations where useful
+4. optional routing into deeper semantic/control-flow lanes
+
+## Immediate runtime tasks
+- add a local Redpanda/Schema Registry bring-up lane under `infra/local/`
+- add runtime consumers for the edge fact topics
+- add smoke tests proving publish/receipt/DLQ behavior on a real broker
+- bind runtime contracts back to the standards repo pins


### PR DESCRIPTION
## Summary
This draft PR stages the first runtime-facing landing zone for the Forensic Genesis edge lane.

## Added
- runtime import note clarifying the split with `prophet-platform-standards`
- runtime contract stub directory for generated bindings / consumer adapters

## Intent
Keep `prophet-platform` aligned with its role as the thin runtime/deployment monorepo while pointing canonical schemas and ADRs to the standards repo.

## Known limits
- This PR does not yet add the full broker/registry runtime lane.
- CI hooks and local broker bring-up should follow after the standards surface is reviewed.
