### PR TITLE
Add runnable semantic-bridge and zone-router entrypoints with smoke fixtures

### DIFF
--- a/apps/semantic-bridge/src/semantic_bridge/main.py
+++ b/apps/semantic-bridge/src/semantic_bridge/main.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .validators import validate_event_envelope, validate_membrane_decision
+
+
+def cmd_validate(args):
+    payload = json.loads(Path(args.path).read_text(encoding="utf-8"))
+    if args.kind == "event-envelope":
+        result = validate_event_envelope(payload)
+    else:
+        result = validate_membrane_decision(payload)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result.get("ok") else 2
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog="pp-semantic-bridge")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    validate = sub.add_parser("validate")
+    validate.add_argument("--kind", required=True, choices=["event-envelope", "membrane-decision"])
+    validate.add_argument("--path", required=True)
+    validate.set_defaults(fn=cmd_validate)
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.fn(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/zone-router/src/zone_router/main.py
+++ b/apps/zone-router/src/zone_router/main.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from .resolver import resolve_topic
+
+
+def cmd_plan(args):
+    topic = resolve_topic(args.zone_ref, args.event_type)
+    plan = {
+        "ok": True,
+        "zone_ref": args.zone_ref,
+        "event_type": args.event_type,
+        "topic": topic,
+        "carrier_ref": args.carrier_ref,
+        "event_ref": args.event_ref,
+        "receipt_ref": args.receipt_ref,
+        "catalog_ref": args.catalog_ref,
+    }
+    print(json.dumps(plan, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog="pp-zone-router")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    plan = sub.add_parser("plan")
+    plan.add_argument("--zone-ref", required=True)
+    plan.add_argument("--event-type", required=True)
+    plan.add_argument("--carrier-ref", required=True)
+    plan.add_argument("--event-ref", required=True)
+    plan.add_argument("--receipt-ref", required=True)
+    plan.add_argument("--catalog-ref", required=True)
+    plan.set_defaults(fn=cmd_plan)
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.fn(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/fixtures/event_envelope_sample.json
+++ b/tools/fixtures/event_envelope_sample.json
@@ -1,0 +1,9 @@
+{
+  "event_id": "evt-001",
+  "event_kind": "carrier.ingested",
+  "producer": "apps/lampstand",
+  "timestamp": "2026-04-12T00:00:00Z",
+  "payload": {
+    "carrier_ref": "carrier://sha256/example"
+  }
+}

--- a/tools/fixtures/membrane_decision_sample.json
+++ b/tools/fixtures/membrane_decision_sample.json
@@ -1,0 +1,6 @@
+{
+  "carrier_id": "carrier://sha256/example",
+  "decision": "admit",
+  "policy_ref": "policy://edge/default",
+  "timestamp": "2026-04-12T00:00:00Z"
+}


### PR DESCRIPTION
## Summary

This follow-on PR builds on the merged zone/membrane contract spine from #22 and lands a small additive runtime slice:

- add `apps/semantic-bridge/src/semantic_bridge/main.py`
- add `apps/zone-router/src/zone_router/main.py`
- add smoke fixtures for event envelope and membrane decision validation under `tools/fixtures/`

## Why this shape

PR #22 established the initial contract/docs/runtime-lane scaffolding:
- imported contract manifest scaffolding
- zone model and membrane docs
- `apps/lampstand` publication helpers
- `apps/semantic-bridge` validator helpers
- `apps/zone-router` topic resolver helper

This PR turns two of those lanes into callable entrypoints and adds minimal fixtures so the validation path is no longer purely structural.

## Scope limits

This PR intentionally does **not** yet:
- thread `zone_ref` / `topic_ref` through the existing Lampstand ingest/receipt/catalog path
- update `docs/INDEX.md` or `docs/INTEGRATION-MAP.md`
- update `tools/validate_repo.py`
- pin imported contract SHAs

Those in-place edits are prepared separately and should land in the next implementation PR.

## Notes

The branch currently starts from the merge-base for #22, so it is behind `main` by later commits. The changed files here are additive-only and should be easy to replay or rebase onto current `main` if desired.
