### PR TITLE
platform: fix eval fabric unified runtime consistency

### DIFF
--- a/apps/eval-fabric-api/app/intelligence_repositories.py
+++ b/apps/eval-fabric-api/app/intelligence_repositories.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from .db import ch_query, pg_fetch
+
+
+def get_frontier_provenance(limit: int = 50):
+    sql = """
+        select model_release_id,
+               groupUniqArray(source_trust_class) as source_trust_classes,
+               min(freshness_days) as min_freshness_days,
+               max(freshness_days) as max_freshness_days,
+               sum(reproduced_by_us) as reproduced_fact_count,
+               count() as metric_fact_count
+        from metric_facts
+        group by model_release_id
+        order by model_release_id asc
+        limit {limit:UInt64}
+    """
+    return ch_query(sql, {"limit": int(limit)})
+
+
+def get_reproduced_vs_claimed(limit: int = 50):
+    rows = pg_fetch(
+        """
+        select cs.competitor_snapshot_id,
+               cs.provider_id,
+               cs.model_release_id,
+               cs.reproduced_by_us,
+               cs.freshness_days,
+               cs.source_trust_class,
+               cs.strategic_relevance,
+               sd.name as source_name,
+               sd.methodology_snapshot_hash,
+               count(mc.metric_crosswalk_id) as crosswalk_count
+        from competitor_snapshots cs
+        join source_descriptors sd
+          on sd.source_descriptor_id = cs.source_descriptor_id
+        left join metric_crosswalks mc
+          on mc.source_descriptor_id = cs.source_descriptor_id
+        group by cs.competitor_snapshot_id, cs.provider_id, cs.model_release_id,
+                 cs.reproduced_by_us, cs.freshness_days, cs.source_trust_class,
+                 cs.strategic_relevance, sd.name, sd.methodology_snapshot_hash
+        order by cs.strategic_relevance desc, cs.freshness_days asc, cs.snapshot_ts desc
+        limit %s
+        """,
+        (int(limit),),
+    )
+    for row in rows:
+        row["coverage_state"] = "reproduced" if row["reproduced_by_us"] else "claimed_only"
+    return rows

--- a/apps/eval-fabric-api/app/unified_main.py
+++ b/apps/eval-fabric-api/app/unified_main.py
@@ -1,15 +1,30 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 
-from . import governance_repositories, intelligence_repositories, repositories
+from . import db, governance_repositories, intelligence_repositories, repositories
 
-app = FastAPI(title="Prophet Platform Eval Fabric", version="0.5.0")
+app = FastAPI(title="Prophet Platform Eval Fabric", version="0.5.1")
 
 
 @app.get("/healthz")
 def healthz() -> dict:
     return {"status": "ok", "service": "eval-fabric-api"}
+
+
+@app.get("/readyz")
+def readyz():
+    postgres = db.pg_health()
+    clickhouse = db.ch_health()
+    ok = bool(postgres.get("ok")) and bool(clickhouse.get("ok"))
+    payload = {
+        "status": "ok" if ok else "degraded",
+        "service": "eval-fabric-api",
+        "postgres": postgres,
+        "clickhouse": clickhouse,
+    }
+    return payload if ok else JSONResponse(status_code=503, content=payload)
 
 
 @app.get("/v1/frontier")

--- a/apps/eval-fabric-api/tests/test_http_unified_main.py
+++ b/apps/eval-fabric-api/tests/test_http_unified_main.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import app.unified_main as unified_main
+
+client = TestClient(unified_main.app)
+
+
+def test_healthz():
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["status"] == "ok"
+    assert payload["service"] == "eval-fabric-api"
+
+
+def test_readyz_success(monkeypatch):
+    monkeypatch.setattr(unified_main.db, "pg_health", lambda: {"ok": True})
+    monkeypatch.setattr(unified_main.db, "ch_health", lambda: {"ok": True})
+
+    resp = client.get("/readyz")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["status"] == "ok"
+    assert payload["postgres"]["ok"] is True
+    assert payload["clickhouse"]["ok"] is True
+
+
+def test_readyz_degraded(monkeypatch):
+    monkeypatch.setattr(unified_main.db, "pg_health", lambda: {"ok": False, "error": "postgres down"})
+    monkeypatch.setattr(unified_main.db, "ch_health", lambda: {"ok": True})
+
+    resp = client.get("/readyz")
+    assert resp.status_code == 503
+    payload = resp.json()
+    assert payload["status"] == "degraded"
+    assert payload["postgres"]["ok"] is False
+
+
+def test_frontier_provenance_uses_repository(monkeypatch):
+    expected = [{"model_release_id": "model.semantic-stack.2026-04-05", "metric_fact_count": 2}]
+    monkeypatch.setattr(unified_main.intelligence_repositories, "get_frontier_provenance", lambda limit=50: expected)
+
+    resp = client.get("/v1/frontier/provenance?limit=7")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["subjects"] == expected
+    assert payload["source"] == "clickhouse"
+
+
+def test_reproduced_vs_claimed_uses_repository(monkeypatch):
+    expected = [{"provider_id": "openai", "coverage_state": "claimed_only"}]
+    monkeypatch.setattr(unified_main.intelligence_repositories, "get_reproduced_vs_claimed", lambda limit=50: expected)
+
+    resp = client.get("/v1/competition/reproduced-vs-claimed?limit=9")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["items"] == expected
+    assert payload["source"] == "postgres"

--- a/apps/eval-fabric-api/tests/test_intelligence_repositories.py
+++ b/apps/eval-fabric-api/tests/test_intelligence_repositories.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import app.intelligence_repositories as intelligence_repositories
+
+
+def test_get_frontier_provenance_is_parameterized(monkeypatch):
+    seen = {}
+
+    def fake(sql, parameters=None):
+        seen["sql"] = sql
+        seen["parameters"] = parameters
+        return []
+
+    monkeypatch.setattr(intelligence_repositories, "ch_query", fake)
+    intelligence_repositories.get_frontier_provenance(limit=7)
+
+    assert "{limit:UInt64}" in seen["sql"]
+    assert seen["parameters"] == {"limit": 7}
+
+
+def test_get_reproduced_vs_claimed_uses_positional_params_and_derives_state(monkeypatch):
+    seen = {}
+
+    def fake(sql, params=()):
+        seen["sql"] = sql
+        seen["params"] = params
+        return [
+            {
+                "provider_id": "openai",
+                "reproduced_by_us": False,
+                "source_trust_class": "official_provider",
+                "freshness_days": 5,
+                "strategic_relevance": "high",
+                "crosswalk_count": 3,
+            },
+            {
+                "provider_id": "our_platform",
+                "reproduced_by_us": True,
+                "source_trust_class": "internal_reproduced",
+                "freshness_days": 0,
+                "strategic_relevance": "high",
+                "crosswalk_count": 5,
+            },
+        ]
+
+    monkeypatch.setattr(intelligence_repositories, "pg_fetch", fake)
+    rows = intelligence_repositories.get_reproduced_vs_claimed(limit=11)
+
+    assert "limit %s" in seen["sql"]
+    assert seen["params"] == (11,)
+    assert rows[0]["coverage_state"] == "claimed_only"
+    assert rows[1]["coverage_state"] == "reproduced"


### PR DESCRIPTION
## Summary

Fix two concrete pieces of eval-fabric runtime debt on current `main`:

1. add the missing `intelligence_repositories.py` module that `unified_main.py` already imports
2. add the `/readyz` endpoint that the eval-fabric README already documents

## Why

After the recent bootstrap + runtime + migration + score slices landed, `main` was left with a small but real consistency gap:
- the unified runtime referenced `intelligence_repositories` but that module was not present on `main`
- the README advertised `/readyz`, but the runtime did not yet expose it

This PR makes the runtime match the documented platform surface.

## Scope

Files included:
- `apps/eval-fabric-api/app/intelligence_repositories.py`
- `apps/eval-fabric-api/app/unified_main.py`

## Notes

This is intentionally a small cleanup PR. It does not add new conceptual scope; it removes technical debt by making the unified eval-fabric runtime internally consistent and aligned with its documented routes.
