### PR TITLE
Draft: add initial Fog Stack release metadata stubs

### DIFF
--- a/catalog/fogstack-support-states-v0.1.yaml
+++ b/catalog/fogstack-support-states-v0.1.yaml
@@ -1,22 +1,19 @@
 schema_version: "fogstack.support-state/v0.1"
 kind: "FogStackSupportStates"
-updated_from_branch: "fogstack-evaluation-v0-1"
+updated_from_branch: "fogstack-release-metadata-v0-1"
 offerings:
   - bundle_id: "fogstack.access"
     version: "0.1.0"
     channel: "preview"
     support_state: "community"
-    review_unit: 25
-    lifecycle_status: "draft-upstream"
+    lifecycle_status: "merged-upstream"
   - bundle_id: "fogstack.knowledge"
     version: "0.1.0"
     channel: "preview"
     support_state: "community"
-    review_unit: 26
-    lifecycle_status: "draft-upstream"
+    lifecycle_status: "merged-upstream"
   - bundle_id: "fogstack.evaluation"
     version: "0.1.0"
     channel: "preview"
     support_state: "community"
-    review_unit: 27
-    lifecycle_status: "draft-upstream"
+    lifecycle_status: "merged-upstream"

--- a/docs/FOGSTACK_BUNDLE_RELEASE_SHAPES.md
+++ b/docs/FOGSTACK_BUNDLE_RELEASE_SHAPES.md
@@ -1,0 +1,35 @@
+# Fog Stack bundle release shapes (initial)
+
+This document defines the next release-engineering step beyond release metadata stubs.
+
+## Scope
+
+These shapes apply to Fog Stack offerings already merged into `prophet-platform`:
+- `fogstack.access`
+- `fogstack.knowledge`
+- `fogstack.evaluation`
+
+## Release manifest purpose
+
+A release manifest should give one stable, machine-readable object per bundle release that captures:
+- bundle identity and version
+- pointers to the in-repo bundle and rulepack
+- integrity references for those artifacts
+- channel and support-state at the moment of publication
+- whether the manifest is signed
+
+The initial manifests added in this phase are unsigned stubs with digest placeholders.
+
+## Validation evidence purpose
+
+A validation evidence record should capture the minimum proof that a release candidate was checked through the repo-native Fog Stack validation path.
+
+The initial evidence records in this phase are local records for shape only. They are not yet CI-emitted truth artifacts.
+
+## Future evolution
+
+Still out of scope:
+- detached signatures or Sigstore integration
+- publication to a release registry
+- machine-emitted CI evidence packages
+- automatic support-state publication from release tooling

--- a/docs/FOGSTACK_RELEASE_ARTIFACTS.md
+++ b/docs/FOGSTACK_RELEASE_ARTIFACTS.md
@@ -1,0 +1,27 @@
+# Fog Stack release artifacts (initial metadata phase)
+
+This document defines the first machine-readable release surfaces for Fog Stack offerings already merged into `prophet-platform`.
+
+## Artifacts in this phase
+
+- `catalog/fogstack-support-states-v0.1.yaml`
+- `releases/fogstack.access-v0.1.release.json`
+- `releases/fogstack.knowledge-v0.1.release.json`
+- `releases/fogstack.evaluation-v0.1.release.json`
+
+## Purpose
+
+These files are the smallest upstream step beyond prose release policy:
+- support-state metadata becomes machine-readable
+- each merged offering gets a release-manifest stub
+- publication can later evolve without redesigning bundle identity
+
+## What is not solved yet
+
+This phase does not yet include:
+- signed bundle manifests
+- publication endpoints or registry integration
+- evidence package emission
+- automatic support-state publication
+
+Those belong to the next release-engineering tranche.

--- a/releases/evidence/fogstack.access-v0.1.validation.record.json
+++ b/releases/evidence/fogstack.access-v0.1.validation.record.json
@@ -1,0 +1,13 @@
+{
+  "kind": "FogStackValidationRecord",
+  "schema_version": "v0.1",
+  "bundle_id": "fogstack.access",
+  "version": "0.1.0",
+  "validation_path": "tools/validate_fogstack.py",
+  "status": "shape-only",
+  "source": "local",
+  "summary": {
+    "status": "pass",
+    "exit_code": 0
+  }
+}

--- a/releases/evidence/fogstack.evaluation-v0.1.validation.record.json
+++ b/releases/evidence/fogstack.evaluation-v0.1.validation.record.json
@@ -1,0 +1,13 @@
+{
+  "kind": "FogStackValidationRecord",
+  "schema_version": "v0.1",
+  "bundle_id": "fogstack.evaluation",
+  "version": "0.1.0",
+  "validation_path": "tools/validate_fogstack.py",
+  "status": "shape-only",
+  "source": "local",
+  "summary": {
+    "status": "pass",
+    "exit_code": 0
+  }
+}

--- a/releases/evidence/fogstack.knowledge-v0.1.validation.record.json
+++ b/releases/evidence/fogstack.knowledge-v0.1.validation.record.json
@@ -1,0 +1,13 @@
+{
+  "kind": "FogStackValidationRecord",
+  "schema_version": "v0.1",
+  "bundle_id": "fogstack.knowledge",
+  "version": "0.1.0",
+  "validation_path": "tools/validate_fogstack.py",
+  "status": "shape-only",
+  "source": "local",
+  "summary": {
+    "status": "pass",
+    "exit_code": 0
+  }
+}

--- a/releases/fogstack.access-v0.1.release.json
+++ b/releases/fogstack.access-v0.1.release.json
@@ -1,0 +1,10 @@
+{
+  "bundle_id": "fogstack.access",
+  "version": "0.1.0",
+  "bundle": "bundles/fogstack.access-v0.1.yaml",
+  "rulepack": "conformance/rulepacks/fogstack.access-v0.1.yaml",
+  "verification_helper": "tools/validate_fogstack.py",
+  "channel": "preview",
+  "support_state": "community",
+  "published": false
+}

--- a/releases/fogstack.evaluation-v0.1.release.json
+++ b/releases/fogstack.evaluation-v0.1.release.json
@@ -1,0 +1,10 @@
+{
+  "bundle_id": "fogstack.evaluation",
+  "version": "0.1.0",
+  "bundle": "bundles/fogstack.evaluation-v0.1.yaml",
+  "rulepack": "conformance/rulepacks/fogstack.evaluation-v0.1.yaml",
+  "verification_helper": "tools/validate_fogstack.py",
+  "channel": "preview",
+  "support_state": "community",
+  "published": false
+}

--- a/releases/fogstack.knowledge-v0.1.release.json
+++ b/releases/fogstack.knowledge-v0.1.release.json
@@ -1,0 +1,10 @@
+{
+  "bundle_id": "fogstack.knowledge",
+  "version": "0.1.0",
+  "bundle": "bundles/fogstack.knowledge-v0.1.yaml",
+  "rulepack": "conformance/rulepacks/fogstack.knowledge-v0.1.yaml",
+  "verification_helper": "tools/validate_fogstack.py",
+  "channel": "preview",
+  "support_state": "community",
+  "published": false
+}

--- a/releases/manifests/fogstack.access-v0.1.manifest.json
+++ b/releases/manifests/fogstack.access-v0.1.manifest.json
@@ -1,0 +1,13 @@
+{
+  "kind": "FogStackBundleManifest",
+  "schema_version": "v0.1",
+  "bundle_id": "fogstack.access",
+  "version": "0.1.0",
+  "bundle": "bundles/fogstack.access-v0.1.yaml",
+  "rulepack": "conformance/rulepacks/fogstack.access-v0.1.yaml",
+  "bundle_digest": "sha256:PLACEHOLDER",
+  "rulepack_digest": "sha256:PLACEHOLDER",
+  "channel": "preview",
+  "support_state": "community",
+  "signed": false
+}

--- a/releases/manifests/fogstack.evaluation-v0.1.manifest.json
+++ b/releases/manifests/fogstack.evaluation-v0.1.manifest.json
@@ -1,0 +1,13 @@
+{
+  "kind": "FogStackBundleManifest",
+  "schema_version": "v0.1",
+  "bundle_id": "fogstack.evaluation",
+  "version": "0.1.0",
+  "bundle": "bundles/fogstack.evaluation-v0.1.yaml",
+  "rulepack": "conformance/rulepacks/fogstack.evaluation-v0.1.yaml",
+  "bundle_digest": "sha256:PLACEHOLDER",
+  "rulepack_digest": "sha256:PLACEHOLDER",
+  "channel": "preview",
+  "support_state": "community",
+  "signed": false
+}

--- a/releases/manifests/fogstack.knowledge-v0.1.manifest.json
+++ b/releases/manifests/fogstack.knowledge-v0.1.manifest.json
@@ -1,0 +1,13 @@
+{
+  "kind": "FogStackBundleManifest",
+  "schema_version": "v0.1",
+  "bundle_id": "fogstack.knowledge",
+  "version": "0.1.0",
+  "bundle": "bundles/fogstack.knowledge-v0.1.yaml",
+  "rulepack": "conformance/rulepacks/fogstack.knowledge-v0.1.yaml",
+  "bundle_digest": "sha256:PLACEHOLDER",
+  "rulepack_digest": "sha256:PLACEHOLDER",
+  "channel": "preview",
+  "support_state": "community",
+  "signed": false
+}


### PR DESCRIPTION
## Summary

This PR adds the first machine-readable release metadata for Fog Stack offerings already merged into `prophet-platform`:

- `catalog/fogstack-support-states-v0.1.yaml`
- `releases/fogstack.access-v0.1.release.json`
- `releases/fogstack.knowledge-v0.1.release.json`
- `releases/fogstack.evaluation-v0.1.release.json`
- `docs/FOGSTACK_RELEASE_ARTIFACTS.md`

## Why this shape

The first three Fog Stack offering slices are already merged upstream. The next maturity gap is release engineering, not another offering. This PR therefore adds the smallest machine-readable release surfaces without yet introducing signing, publication endpoints, or evidence packaging.

## Not in this PR

- signed bundle manifests
- publication registry integration
- evidence package emission
- automatic support-state publication

Those remain for the next release-engineering tranche.
