### PR TITLE
Draft: wire Fog Stack validation into main Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke validate-fogstack
 
-validate: validate-repo drift-check standards-check topology-check test-go validate-phase4 test-python-apps
+validate: validate-repo drift-check standards-check topology-check test-go validate-phase4 test-python-apps validate-fogstack
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -55,3 +55,6 @@ validate-phase4:
 
 lampstand-vertical-slice-smoke:
 	bash apps/lampstand/scripts/vertical_slice_smoke.sh
+
+validate-fogstack:
+	python3 tools/validate_fogstack.py


### PR DESCRIPTION
## Summary

This PR adds the smallest missing integration step for Fog Stack on `main`:

- add `validate-fogstack` to `.PHONY`
- append `validate-fogstack` to the main `validate` target
- define `validate-fogstack` as `python3 tools/validate_fogstack.py`

## Why this PR exists

`main` already has:
- `tools/fogstack_verify.py`
- `tools/validate_fogstack.py`
- initial Access / Knowledge / Evaluation offering slices

What it does **not** yet have is the hook that makes Fog Stack validation part of the native repo validation chain. This PR closes that gap without mixing in broader release-engineering or catalog work.

## Not in this PR

- release metadata refresh (#41)
- release schemas / validation execution criteria (#42)
- signed manifests
- CI-emitted validation evidence

Those remain separate so the validation-path change stays easy to review.
