### PR TITLE
Draft: add Fog Stack CI validation artifact helper

### DIFF
--- a/docs/FOGSTACK_CI_VALIDATION_ARTIFACTS.md
+++ b/docs/FOGSTACK_CI_VALIDATION_ARTIFACTS.md
@@ -1,0 +1,41 @@
+# Fog Stack CI validation artifacts
+
+This document defines the first CI-oriented path for Fog Stack validation records.
+
+## Goal
+
+Turn verifier output into a schema-conforming `FogStackValidationRecord` that can later be referenced by release manifests and release evidence packages.
+
+## Minimal flow
+
+1. run `python3 tools/validate_fogstack.py` or `python3 tools/fogstack_verify.py ... --json`
+2. capture the verifier JSON output
+3. run `python3 tools/emit_fogstack_validation_record.py` to convert that JSON into a `FogStackValidationRecord`
+4. write the record into a deterministic artifact location under CI workspace or release packaging output
+
+## Example
+
+```bash
+python3 tools/fogstack_verify.py bundles/fogstack.access-v0.1.yaml --json > /tmp/fogstack.verify.json
+python3 tools/emit_fogstack_validation_record.py \
+  --verifier-json /tmp/fogstack.verify.json \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --source ci \
+  --evidence-ref artifact://ci/fogstack.access.verify.json \
+  --output /tmp/fogstack.access.validation.record.json
+```
+
+## What counts as executed evidence
+
+A record should only be treated as release evidence when:
+- `source` is `ci`
+- the underlying verifier JSON came from the native validation path
+- the bundle/rulepack on disk match the release candidate being published
+
+## Out of scope in this phase
+
+- automatic CI wiring
+- artifact upload/storage backend
+- cryptographic signing of validation records
+- release-manifest back-linking automation

--- a/tools/emit_fogstack_validation_record.py
+++ b/tools/emit_fogstack_validation_record.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Fog Stack validation record from verifier JSON")
+    parser.add_argument("--verifier-json", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--source", choices=["local", "ci"], default="ci")
+    parser.add_argument("--evidence-ref", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    verifier = load_json(args.verifier_json)
+    summary = verifier.get("summary") or {}
+    if not isinstance(summary, dict):
+        raise SystemExit("ERR: verifier summary is missing or malformed")
+
+    status = "executed" if args.source == "ci" else "shape-only"
+    if summary.get("status") == "fail":
+        status = "failed" if args.source == "ci" else "shape-only"
+
+    record = {
+        "kind": "FogStackValidationRecord",
+        "schema_version": "v0.1",
+        "bundle_id": args.bundle_id,
+        "version": args.version,
+        "validation_path": "tools/validate_fogstack.py",
+        "source": args.source,
+        "status": status,
+        "summary": {
+            "status": summary.get("status"),
+            "exit_code": summary.get("exit_code"),
+            "checks_run": summary.get("checks_run"),
+            "warnings": summary.get("warnings"),
+            "errors": summary.get("errors"),
+            "critical": summary.get("critical"),
+        },
+        "evidence_ref": args.evidence_ref,
+    }
+
+    text = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the first CI-oriented helper for Fog Stack validation evidence on top of current `main`:

- `tools/emit_fogstack_validation_record.py`
- `docs/FOGSTACK_CI_VALIDATION_ARTIFACTS.md`

## Why this shape

`main` already has:
- merged Access / Knowledge / Evaluation offering slices
- `tools/fogstack_verify.py`
- `tools/validate_fogstack.py`
- release metadata and release schemas under active review

What is still missing is a concrete helper that can turn verifier JSON into a schema-conforming validation record suitable for later reference by release manifests and evidence packages.

## Not in this PR

- automatic CI wiring
- artifact upload/storage backend
- cryptographic signing of validation records
- release-manifest back-linking automation

Those remain for the next release-engineering tranche.
