### PR TITLE
banking twin: formalize runtime scaffold tranche with validator

### DIFF
--- a/tools/validate_banking_runtime_scaffolds.py
+++ b/tools/validate_banking_runtime_scaffolds.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED = [
+    ROOT / "docs" / "banking-runtime-slices.md",
+    ROOT / "contracts" / "EventEnvelope.v0.1.json",
+    ROOT / "contracts" / "EvidenceReceipt.v0.1.json",
+    ROOT / "apps" / "banking-twin-ingest" / "README.md",
+    ROOT / "apps" / "banking-scenario-run" / "README.md",
+    ROOT / "apps" / "banking-capital-rollforward" / "README.md",
+    ROOT / "apps" / "banking-filing-assembler" / "README.md",
+]
+
+def fail(msg: str) -> int:
+    print(f"ERR: {msg}", file=sys.stderr)
+    return 2
+
+def main() -> int:
+    for path in REQUIRED:
+        if not path.exists():
+            return fail(f"missing required file: {path.relative_to(ROOT)}")
+    print("OK: banking runtime staging scaffolds present")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# banking twin: formalize runtime scaffold tranche with validator

## Summary

This draft PR formalizes the banking runtime scaffold tranche already present on `main` by adding the missing validator for the scaffold layout.

Included in this tranche:
- `tools/validate_banking_runtime_scaffolds.py`

## Why this PR exists

The banking runtime scaffold files are already present on `main`:
- `docs/banking-runtime-slices.md`
- `apps/banking-twin-ingest/README.md`
- `apps/banking-scenario-run/README.md`
- `apps/banking-capital-rollforward/README.md`
- `apps/banking-filing-assembler/README.md`

This PR makes that scaffold state reviewable and testable instead of leaving it as an unvalidated partial landing.

## Scope boundaries

This tranche is intentionally narrow.
It does not add banking runtime implementation code.
It does not modify EventEnvelope or EvidenceReceipt contracts.
It only adds the missing validator that checks the staging scaffold presence.

## Suggested review focus

- confirm the validator checks the right scaffold files
- confirm we want to keep the current scaffold files already on `main`
- confirm that runtime implementation should still wait on upstream semantic and standards canon
