### PR TITLE
Draft: refresh Fog Stack validation hook on current main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke validate-fogstack
 
-validate: validate-repo drift-check standards-check topology-check test-go validate-phase4 test-python-apps
+validate: validate-repo drift-check standards-check topology-check test-go validate-phase4 test-python-apps validate-fogstack
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -60,3 +60,6 @@ validate-phase4:
 
 lampstand-vertical-slice-smoke:
 	bash apps/lampstand/scripts/vertical_slice_smoke.sh
+
+validate-fogstack:
+	python3 tools/validate_fogstack.py


### PR DESCRIPTION
## Summary

This PR refreshes the missing Fog Stack validation hook against the current `main` branch.

It does only three things:
- add `validate-fogstack` to `.PHONY`
- append `validate-fogstack` to the main `validate` target
- define `validate-fogstack` as `python3 tools/validate_fogstack.py`

## Why this PR exists

Although an earlier hook PR merged, the current `main` Makefile no longer includes the Fog Stack validation target. `main` already has:
- `tools/fogstack_verify.py`
- `tools/validate_fogstack.py`
- merged Access / Knowledge / Evaluation offering slices

This PR refreshes the smallest missing integration step against the current repo state.

## Not in this PR

- release metadata / schemas / CI artifact work
- signed manifests
- CI-emitted validation evidence

Those remain separate so the hook refresh stays easy to review.
