### PR TITLE
Draft: add Fog Stack signed manifest helper

### DIFF
--- a/docs/FOGSTACK_SIGNED_MANIFESTS.md
+++ b/docs/FOGSTACK_SIGNED_MANIFESTS.md
@@ -1,0 +1,40 @@
+# Fog Stack signed manifests
+
+This document defines the first repo-native meaning of a **signed Fog Stack bundle manifest**.
+
+## Goal
+
+Move from unsigned manifest stubs to manifests that explicitly carry signature metadata in a way that matches the existing `FogStackBundleManifest` schema.
+
+## Minimal signed-manifest flow
+
+1. prepare an unsigned bundle manifest under `releases/manifests/`
+2. produce or obtain a signature artifact reference (for example a future Sigstore or Cosign output)
+3. run `python3 tools/attach_fogstack_manifest_signature.py` to attach the signature metadata to the manifest
+4. publish the updated manifest as the release manifest for that bundle version
+
+## Example
+
+```bash
+python3 tools/attach_fogstack_manifest_signature.py \
+  --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+  --signature-type cosign \
+  --signature-ref artifact://release/fogstack.access-v0.1.sig \
+  --output /tmp/fogstack.access-v0.1.signed.manifest.json
+```
+
+## What this phase does and does not mean
+
+This phase means:
+- the manifest shape can now carry signature metadata explicitly
+- release tooling has a minimal helper for attaching that metadata
+
+This phase does **not** yet mean:
+- signatures are verified automatically in CI
+- signatures are published to a registry
+- signature refs are globally resolvable
+- release publication is fully automated
+
+## Next step
+
+The next release-engineering step after this helper is to define how CI should verify the signature reference and emit a corresponding executed validation/evidence artifact.

--- a/tools/attach_fogstack_manifest_signature.py
+++ b/tools/attach_fogstack_manifest_signature.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Attach signature metadata to a Fog Stack bundle manifest")
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--signature-type", required=True, choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--signature-ref", required=True)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    manifest = load_json(args.manifest)
+    manifest["signed"] = True
+    manifest["signature"] = {
+        "type": args.signature_type,
+        "ref": args.signature_ref,
+    }
+
+    text = json.dumps(manifest, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the next small release-engineering step for Fog Stack on top of current `main`:

- `tools/attach_fogstack_manifest_signature.py`
- `docs/FOGSTACK_SIGNED_MANIFESTS.md`

## Why this shape

`main` already has:
- release-manifest stubs
- validation-record schemas and execution criteria
- the CI-oriented validation-record emitter

What is still missing is a minimal repo-native way to attach signature metadata to a bundle manifest in the shape already supported by the manifest schema.

## Not in this PR

- CI signature verification
- registry publication of signatures
- automatic release publication
- signature back-linking into validation evidence

Those remain for the next release-engineering tranche.
