### PR TITLE
Contract-back dashboard BFF overview and fix path-safe test loading

### DIFF
--- a/apps/dashboard-bff/main.py
+++ b/apps/dashboard-bff/main.py
@@ -1,4 +1,18 @@
 from fastapi import FastAPI
+from pathlib import Path
+import importlib.util
+
+
+def _load_overview_contract():
+    path = Path(__file__).with_name('contracts.py')
+    spec = importlib.util.spec_from_file_location('dashboard_bff_contracts', path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.OverviewResponse
+
+
+OverviewResponse = _load_overview_contract()
 
 app = FastAPI(title='dashboard-bff')
 
@@ -6,9 +20,11 @@ app = FastAPI(title='dashboard-bff')
 def health() -> dict:
     return {'service': 'dashboard-bff', 'status': 'ok'}
 
-@app.get('/v1/overview')
-def overview() -> dict:
-    return {
-        'service': 'dashboard-bff',
-        'views': ['overview', 'deepdive', 'cases'],
-    }
+@app.get('/v1/overview', response_model=OverviewResponse)
+def overview() -> object:
+    return OverviewResponse(
+        service='dashboard-bff',
+        views=['overview', 'deepdive', 'cases'],
+        trace_required=True,
+        evidence_required=True,
+    )

--- a/tests/platform_stubs/test_dashboard_bff_overview_contract.py
+++ b/tests/platform_stubs/test_dashboard_bff_overview_contract.py
@@ -1,13 +1,28 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
 from fastapi.testclient import TestClient
-from apps.dashboard_bff.main import app
-from apps.dashboard_bff.contracts import OverviewResponse
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module(relative_path: str, module_name: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_overview_contract():
-    client = TestClient(app)
+    dashboard_module = load_module('apps/dashboard-bff/main.py', 'dashboard_bff_main')
+    contracts_module = load_module('apps/dashboard-bff/contracts.py', 'dashboard_bff_contracts')
+    client = TestClient(dashboard_module.app)
     response = client.get('/v1/overview')
     data = response.json()
-    model = OverviewResponse(**data)
+    model = contracts_module.OverviewResponse(**data)
     assert model.service == 'dashboard-bff'
     assert isinstance(model.views, list)
     assert isinstance(model.trace_required, bool)


### PR DESCRIPTION
## What this changes

This follow-up PR deepens the first Wave 1 runtime slice without broadening scope.

### Included here
- make `apps/dashboard-bff/main.py` return the `OverviewResponse` contract explicitly
- fix `tests/platform_stubs/test_dashboard_bff_overview_contract.py` so it loads modules by file path instead of assuming an underscore-named package path that does not match the repo's dash-named app directory

## Why

The merged platform slice established the `dashboard-bff` contract file and the overview-contract test, but the runtime endpoint still returned a bare dict and the test imported a package path inconsistent with the repo layout. This PR brings the endpoint and the test into alignment with the actual monorepo shape.

## Follow-up still pending
- local `Makefile` parity for platform-contract checks
- deeper runtime composition inside `dashboard-bff`
