### PR TITLE
Add automated premerge audit workflow for hot-path changes

### DIFF
--- a/.github/workflows/premerge-audit.yml
+++ b/.github/workflows/premerge-audit.yml
@@ -1,0 +1,27 @@
+name: premerge-audit
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  premerge-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run premerge audit
+        env:
+          PREMERGE_BASE_REF: origin/${{ github.base_ref }}
+          PREMERGE_HEAD_REF: HEAD
+        run: python tools/premerge_audit.py

--- a/tools/premerge_audit.py
+++ b/tools/premerge_audit.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+HOT_PREFIXES = [
+    'Makefile',
+    '.github/workflows/',
+    'tools/',
+    'contracts/platform/',
+    'apps/',
+    'infra/k8s/overlays/',
+    'bundles/',
+    'conformance/',
+]
+
+
+def run(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, cwd=ROOT, text=True).strip()
+
+
+def main() -> int:
+    base_ref = os.environ.get('PREMERGE_BASE_REF', 'origin/main')
+    head_ref = os.environ.get('PREMERGE_HEAD_REF', 'HEAD')
+
+    diff_output = run(['git', 'diff', '--name-only', f'{base_ref}...{head_ref}'])
+    changed = [line for line in diff_output.splitlines() if line.strip()]
+
+    ahead_behind = run(['git', 'rev-list', '--left-right', '--count', f'{base_ref}...{head_ref}'])
+    behind, ahead = [int(x) for x in ahead_behind.split()]
+
+    hot_hits = [path for path in changed if any(path == prefix or path.startswith(prefix) for prefix in HOT_PREFIXES)]
+
+    print('premerge audit summary')
+    print(f'base_ref={base_ref}')
+    print(f'head_ref={head_ref}')
+    print(f'changed_files={len(changed)}')
+    print(f'ahead={ahead}')
+    print(f'behind={behind}')
+    print(f'hot_path_hits={len(hot_hits)}')
+
+    if hot_hits:
+        print('hot paths:')
+        for path in hot_hits:
+            print(f' - {path}')
+
+    if behind > 0:
+        print('branch is behind base and should be refreshed before merge')
+        return 1
+    if not changed:
+        print('no changed files detected')
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## What this changes

This PR adds a lightweight automated premerge audit lane for `prophet-platform`.

### Included here
- `tools/premerge_audit.py`
- `.github/workflows/premerge-audit.yml`

## Why

The repo has been moving quickly across several hot paths at once:
- Fog Stack validation and release-engineering surfaces
- evidence and operator-facing app lanes
- banking runtime scaffolds
- platform hosting and runtime slices

A small premerge audit gives us a repeatable guardrail before more conflict-prone slices land.

## What the audit checks

- changed files in the PR
- whether the branch is behind the base branch
- whether the PR touches high-risk hot paths such as `Makefile`, workflows, `tools/`, `contracts/platform/`, `apps/`, overlays, bundles, and conformance lanes

## Current scope limits

This audit is intentionally lightweight.
It does not replace code review, replay checks, or domain-specific validators.
It is a first automated merge-risk screen.
