### PR TITLE
Draft: add Fog Stack signature trust evidence record

### DIFF
--- a/docs/FOGSTACK_RELEASE_EVIDENCE_INDEX.md
+++ b/docs/FOGSTACK_RELEASE_EVIDENCE_INDEX.md
@@ -1,0 +1,43 @@
+# Fog Stack release evidence index
+
+This document defines the first repo-native **release evidence index** for Fog Stack.
+
+## Goal
+
+The release-engineering surfaces now produce separate machine-readable artifacts for one bundle version:
+- a release manifest
+- a validation record
+- a signature verification record
+- a signature trust record
+
+The purpose of the release evidence index is to provide one stable object that links those artifact refs together for a single bundle release.
+
+## Minimal flow
+
+1. prepare or update the release manifest
+2. emit the validation record
+3. emit the signature verification record
+4. emit the signature trust record
+5. run `tools/emit_fogstack_release_evidence_index.py` to produce the linking object
+
+## Example
+
+```bash
+python3 tools/emit_fogstack_release_evidence_index.py \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --manifest-ref releases/manifests/fogstack.access-v0.1.manifest.json \
+  --validation-record-ref releases/evidence/fogstack.access-v0.1.validation.record.json \
+  --signature-verification-record-ref releases/evidence/fogstack.access-v0.1.signature-verification.record.json \
+  --signature-trust-record-ref releases/evidence/fogstack.access-v0.1.signature-trust.record.json \
+  --output /tmp/fogstack.access-v0.1.evidence.index.json
+```
+
+## What this phase does not yet provide
+
+This phase does not yet provide:
+- automatic generation of the index in CI
+- back-link insertion into the manifest or evidence records
+- publication or registry integration for the index itself
+
+Those remain for the next release-engineering tranche.

--- a/docs/FOGSTACK_SIGNATURE_TRUST_EVIDENCE.md
+++ b/docs/FOGSTACK_SIGNATURE_TRUST_EVIDENCE.md
@@ -1,0 +1,53 @@
+# Fog Stack signature trust evidence
+
+This document defines the first repo-native shape for **signature trust evidence**.
+
+## Goal
+
+Move from:
+- manifests that can carry signature metadata
+- a helper that can attach signature metadata
+- a helper that can verify signed-manifest shape
+
+to:
+- a separate `FogStackSignatureTrustRecord` that can link:
+  - back to the manifest being verified
+  - sideways to the validation record for the same bundle version
+  - sideways to the signature-verification record for the same manifest
+
+## Minimal flow
+
+1. verify the signed-manifest shape with `tools/verify_fogstack_manifest_signature.py`
+2. capture the verification JSON output
+3. run `tools/emit_fogstack_signature_trust_record.py`
+4. write the resulting record into a deterministic release-evidence location
+
+## Example
+
+```bash
+python3 tools/verify_fogstack_manifest_signature.py \
+  --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+  --require-signed \
+  --json > /tmp/fogstack.access.signature.verify.json
+
+python3 tools/emit_fogstack_signature_trust_record.py \
+  --verification-evidence /tmp/fogstack.access.signature.verify.json \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --manifest-ref releases/manifests/fogstack.access-v0.1.manifest.json \
+  --signature-ref artifact://release/fogstack.access-v0.1.sig \
+  --verification-method cosign \
+  --validation-record-ref releases/evidence/fogstack.access-v0.1.validation.record.json \
+  --signature-verification-record-ref releases/evidence/fogstack.access-v0.1.signature-verification.record.json \
+  --output /tmp/fogstack.access.signature-trust.record.json
+```
+
+## What this phase does not yet provide
+
+This phase still does not provide:
+- cryptographic verification of the signature payload itself
+- registry resolution of signature refs
+- automatic back-linking into manifests or validation records
+- CI-emitted verified truth records
+
+Those remain the next tranche after this helper + record shape land.

--- a/docs/FOGSTACK_SIGNATURE_VERIFICATION_EVIDENCE.md
+++ b/docs/FOGSTACK_SIGNATURE_VERIFICATION_EVIDENCE.md
@@ -1,0 +1,50 @@
+# Fog Stack signature verification evidence
+
+This document defines the first repo-native shape for **signature verification evidence**.
+
+## Goal
+
+Move from:
+- manifests that can carry signature metadata
+- a helper that can attach signature metadata
+- a helper that can check signed-manifest shape
+
+to:
+- a separate `FogStackSignatureVerificationRecord` that can link:
+  - back to the manifest being verified
+  - sideways to the validation record for the same bundle version
+
+## Minimal flow
+
+1. verify the signed-manifest shape with `tools/verify_fogstack_manifest_signature.py`
+2. capture the verification JSON output
+3. run `tools/emit_fogstack_signature_verification_record.py`
+4. write the resulting record into a deterministic release-evidence location
+
+## Example
+
+```bash
+python3 tools/verify_fogstack_manifest_signature.py \
+  --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+  --require-signed \
+  --json > /tmp/fogstack.access.signature.verify.json
+
+python3 tools/emit_fogstack_signature_verification_record.py \
+  --verification-json /tmp/fogstack.access.signature.verify.json \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --manifest-ref releases/manifests/fogstack.access-v0.1.manifest.json \
+  --signature-ref artifact://release/fogstack.access-v0.1.sig \
+  --validation-record-ref releases/evidence/fogstack.access-v0.1.validation.record.json \
+  --output /tmp/fogstack.access.signature-verification.record.json
+```
+
+## What this phase does not yet provide
+
+This phase still does not provide:
+- cryptographic verification of the signature payload itself
+- registry resolution of signature refs
+- automatic back-linking into the manifest or validation record
+- CI-emitted verified truth records
+
+Those remain the next tranche after this helper + record shape land.

--- a/schemas/release/fogstack-release-evidence-index-v0.1.schema.json
+++ b/schemas/release/fogstack-release-evidence-index-v0.1.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-release-evidence-index-v0.1.schema.json",
+  "title": "FogStackReleaseEvidenceIndex",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "manifest_ref",
+    "validation_record_ref",
+    "signature_verification_record_ref",
+    "signature_trust_record_ref"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackReleaseEvidenceIndex" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+    "version": { "type": "string" },
+    "manifest_ref": { "type": "string" },
+    "validation_record_ref": { "type": "string" },
+    "signature_verification_record_ref": { "type": "string" },
+    "signature_trust_record_ref": { "type": "string" },
+    "notes": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/schemas/release/fogstack-signature-trust-record-v0.1.schema.json
+++ b/schemas/release/fogstack-signature-trust-record-v0.1.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-signature-trust-record-v0.1.schema.json",
+  "title": "FogStackSignatureTrustRecord",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "manifest_ref",
+    "signature_ref",
+    "verification_method",
+    "status",
+    "summary"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackSignatureTrustRecord" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+    "version": { "type": "string" },
+    "manifest_ref": { "type": "string" },
+    "signature_ref": { "type": "string" },
+    "verification_method": { "enum": ["cosign", "sigstore", "other"] },
+    "status": { "enum": ["verified", "failed", "shape-only"] },
+    "summary": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["pass", "warn", "fail"] },
+        "message": { "type": ["string", "null"] },
+        "evidence_count": { "type": ["integer", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "validation_record_ref": { "type": ["string", "null"] },
+    "signature_verification_record_ref": { "type": ["string", "null"] },
+    "key_ref": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/schemas/release/fogstack-signature-verification-record-v0.1.schema.json
+++ b/schemas/release/fogstack-signature-verification-record-v0.1.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-signature-verification-record-v0.1.schema.json",
+  "title": "FogStackSignatureVerificationRecord",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "manifest_ref",
+    "status",
+    "summary"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackSignatureVerificationRecord" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+    "version": { "type": "string" },
+    "manifest_ref": { "type": "string" },
+    "status": { "enum": ["shape-only", "verified", "failed"] },
+    "summary": {
+      "type": "object",
+      "required": ["status", "exit_code"],
+      "properties": {
+        "status": { "enum": ["pass", "warn", "fail"] },
+        "exit_code": { "type": "integer" },
+        "checks_run": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
+    "signature_ref": { "type": ["string", "null"] },
+    "validation_record_ref": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/tools/emit_fogstack_release_evidence_index.py
+++ b/tools/emit_fogstack_release_evidence_index.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Fog Stack release evidence index")
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--manifest-ref", required=True)
+    parser.add_argument("--validation-record-ref", required=True)
+    parser.add_argument("--signature-verification-record-ref", required=True)
+    parser.add_argument("--signature-trust-record-ref", required=True)
+    parser.add_argument("--notes", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    record = {
+        "kind": "FogStackReleaseEvidenceIndex",
+        "schema_version": "v0.1",
+        "bundle_id": args.bundle_id,
+        "version": args.version,
+        "manifest_ref": args.manifest_ref,
+        "validation_record_ref": args.validation_record_ref,
+        "signature_verification_record_ref": args.signature_verification_record_ref,
+        "signature_trust_record_ref": args.signature_trust_record_ref,
+        "notes": args.notes,
+    }
+
+    text = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/emit_fogstack_signature_trust_record.py
+++ b/tools/emit_fogstack_signature_trust_record.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Fog Stack signature trust record from external verification evidence")
+    parser.add_argument("--verification-evidence", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--manifest-ref", required=True)
+    parser.add_argument("--signature-ref", required=True)
+    parser.add_argument("--verification-method", required=True, choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--validation-record-ref", default=None)
+    parser.add_argument("--signature-verification-record-ref", default=None)
+    parser.add_argument("--key-ref", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    evidence = load_json(args.verification_evidence)
+    status = evidence.get("status")
+    if status == "pass":
+        trust_status = "verified"
+    elif status == "fail":
+        trust_status = "failed"
+    else:
+        trust_status = "shape-only"
+
+    record = {
+        "kind": "FogStackSignatureTrustRecord",
+        "schema_version": "v0.1",
+        "bundle_id": args.bundle_id,
+        "version": args.version,
+        "manifest_ref": args.manifest_ref,
+        "signature_ref": args.signature_ref,
+        "verification_method": args.verification_method,
+        "status": trust_status,
+        "summary": {
+            "status": status,
+            "message": evidence.get("message"),
+            "evidence_count": evidence.get("evidence_count"),
+        },
+        "validation_record_ref": args.validation_record_ref,
+        "signature_verification_record_ref": args.signature_verification_record_ref,
+        "key_ref": args.key_ref,
+    }
+
+    text = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/emit_fogstack_signature_verification_record.py
+++ b/tools/emit_fogstack_signature_verification_record.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Fog Stack signature verification record from manifest verification JSON")
+    parser.add_argument("--verification-json", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--manifest-ref", required=True)
+    parser.add_argument("--signature-ref", default=None)
+    parser.add_argument("--validation-record-ref", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    verification = load_json(args.verification_json)
+    summary = verification.get("summary") or {}
+    if not isinstance(summary, dict):
+        raise SystemExit("ERR: verification summary is missing or malformed")
+
+    status = "verified" if summary.get("status") == "pass" else "failed"
+    if summary.get("status") == "warn":
+        status = "shape-only"
+
+    record = {
+        "kind": "FogStackSignatureVerificationRecord",
+        "schema_version": "v0.1",
+        "bundle_id": args.bundle_id,
+        "version": args.version,
+        "manifest_ref": args.manifest_ref,
+        "status": status,
+        "summary": {
+            "status": summary.get("status"),
+            "exit_code": summary.get("exit_code"),
+            "checks_run": summary.get("checks_run"),
+        },
+        "signature_ref": args.signature_ref,
+        "validation_record_ref": args.validation_record_ref,
+    }
+
+    text = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the next trust-evidence step on top of the signed-manifest-helper branch:

- `schemas/release/fogstack-signature-trust-record-v0.1.schema.json`
- `tools/emit_fogstack_signature_trust_record.py`
- `docs/FOGSTACK_SIGNATURE_TRUST_EVIDENCE.md`

## Why this shape

The signed-manifest helper branch introduces:
- a helper to attach signature metadata to a manifest
- a helper to verify signed-manifest shape
- guidance on what a signed manifest means in this repo

This PR builds on that by defining a separate record for **signature trust evidence**, so release engineering can link:
- from manifest -> signature metadata
- from signature verification output -> signature trust record
- from that trust record -> validation record for the same bundle version

## Not in this PR

- cryptographic verification of the signature payload
- registry resolution of signature refs
- automatic back-linking into manifests or validation records
- CI-emitted verified truth records

Those remain the next release-engineering tranche.
