### PR TITLE
Draft: add Fog Stack release evidence index

### DIFF
--- a/docs/FOGSTACK_RELEASE_EVIDENCE_INDEX.md
+++ b/docs/FOGSTACK_RELEASE_EVIDENCE_INDEX.md
@@ -1,0 +1,43 @@
+# Fog Stack release evidence index
+
+This document defines the first repo-native **release evidence index** for Fog Stack.
+
+## Goal
+
+The release-engineering surfaces now produce separate machine-readable artifacts for one bundle version:
+- a release manifest
+- a validation record
+- a signature verification record
+- a signature trust record
+
+The purpose of the release evidence index is to provide one stable object that links those artifact refs together for a single bundle release.
+
+## Minimal flow
+
+1. prepare or update the release manifest
+2. emit the validation record
+3. emit the signature verification record
+4. emit the signature trust record
+5. run `tools/emit_fogstack_release_evidence_index.py` to produce the linking object
+
+## Example
+
+```bash
+python3 tools/emit_fogstack_release_evidence_index.py \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --manifest-ref releases/manifests/fogstack.access-v0.1.manifest.json \
+  --validation-record-ref releases/evidence/fogstack.access-v0.1.validation.record.json \
+  --signature-verification-record-ref releases/evidence/fogstack.access-v0.1.signature-verification.record.json \
+  --signature-trust-record-ref releases/evidence/fogstack.access-v0.1.signature-trust.record.json \
+  --output /tmp/fogstack.access-v0.1.evidence.index.json
+```
+
+## What this phase does not yet provide
+
+This phase does not yet provide:
+- automatic generation of the index in CI
+- back-link insertion into the manifest or evidence records
+- publication or registry integration for the index itself
+
+Those remain for the next release-engineering tranche.

--- a/schemas/release/fogstack-release-evidence-index-v0.1.schema.json
+++ b/schemas/release/fogstack-release-evidence-index-v0.1.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-release-evidence-index-v0.1.schema.json",
+  "title": "FogStackReleaseEvidenceIndex",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "manifest_ref",
+    "validation_record_ref",
+    "signature_verification_record_ref",
+    "signature_trust_record_ref"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackReleaseEvidenceIndex" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+    "version": { "type": "string" },
+    "manifest_ref": { "type": "string" },
+    "validation_record_ref": { "type": "string" },
+    "signature_verification_record_ref": { "type": "string" },
+    "signature_trust_record_ref": { "type": "string" },
+    "notes": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/tools/emit_fogstack_release_evidence_index.py
+++ b/tools/emit_fogstack_release_evidence_index.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Fog Stack release evidence index")
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--manifest-ref", required=True)
+    parser.add_argument("--validation-record-ref", required=True)
+    parser.add_argument("--signature-verification-record-ref", required=True)
+    parser.add_argument("--signature-trust-record-ref", required=True)
+    parser.add_argument("--notes", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    record = {
+        "kind": "FogStackReleaseEvidenceIndex",
+        "schema_version": "v0.1",
+        "bundle_id": args.bundle_id,
+        "version": args.version,
+        "manifest_ref": args.manifest_ref,
+        "validation_record_ref": args.validation_record_ref,
+        "signature_verification_record_ref": args.signature_verification_record_ref,
+        "signature_trust_record_ref": args.signature_trust_record_ref,
+        "notes": args.notes,
+    }
+
+    text = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This stacked PR adds the next release-evidence linkage step on top of the current trust-evidence branch:

- `schemas/release/fogstack-release-evidence-index-v0.1.schema.json`
- `tools/emit_fogstack_release_evidence_index.py`
- `docs/FOGSTACK_RELEASE_EVIDENCE_INDEX.md`

## Why this shape

The trust-evidence branch introduces:
- a signature trust-record schema
- a helper to emit signature trust records
- guidance for linking signature verification evidence

This PR builds on that by defining one repo-native index object that can link, for a single bundle version:
- the release manifest
- the validation record
- the signature verification record
- the signature trust record

## Not in this PR

- automatic generation of the index in CI
- back-link insertion into manifests or evidence records
- publication or registry integration for the index itself

Those remain for the next release-engineering tranche.
