### PR TITLE
platform: add logical-statistical suite fixtures for eval fabric

### DIFF
--- a/apps/eval-fabric-api/tests/fixtures/agent_spec_0001.json
+++ b/apps/eval-fabric-api/tests/fixtures/agent_spec_0001.json
@@ -1,0 +1,49 @@
+{
+  "agent_ref": "agent://socioprophet/example/retrieval-governed-operator",
+  "profiles": [
+    "evidence_profile_0001",
+    "control_gating_graduation_profile_0001",
+    "orchestration_ray_profile_0001"
+  ],
+  "control": {
+    "control_family": [
+      "policy_based",
+      "actor_critic",
+      "constrained_safe",
+      "goal_conditioned"
+    ],
+    "proposal_mode": "hybrid_llm_plus_symbolic",
+    "selection_mode": "gated_ranked_selection",
+    "reasoning_structure_discovery_mode": "task_level_structure_discovery",
+    "instance_execution_mode": "instance_level_structure_fill"
+  },
+  "gating": {
+    "gate_classes": ["hard_gate", "soft_gate", "graduation_gate"],
+    "action_profiles": {
+      "read_only": ["authorization_gate", "scope_gate", "policy_gate", "budget_gate"],
+      "tool_write": ["authorization_gate", "scope_gate", "policy_gate", "risk_gate", "evidence_gate", "approval_gate", "rollback_gate"]
+    }
+  },
+  "graduation": {
+    "current_stage": "L3_assist_mode",
+    "lane_scores": {
+      "capability": 3,
+      "safety_policy": 4,
+      "reliability_recovery": 3,
+      "observability_auditability": 4,
+      "provenance_reproducibility": 4,
+      "efficiency_budget": 3,
+      "human_oversight_acceptability": 4
+    }
+  },
+  "orchestration": {
+    "route_selection_surface": ["semantic_route", "logical_route", "retrieval_route", "execution_route"],
+    "ray_lifecycle": {
+      "data_surface": "ray_data",
+      "training_surface": "ray_train",
+      "tuning_surface": "ray_tune",
+      "serving_surface": "ray_serve",
+      "cluster_surface": "kuberay"
+    }
+  }
+}

--- a/apps/eval-fabric-api/tests/fixtures/logical_statistical_suite_0001.json
+++ b/apps/eval-fabric-api/tests/fixtures/logical_statistical_suite_0001.json
@@ -1,0 +1,43 @@
+{
+  "suite_id": "logical_statistical_suite_0001",
+  "upstream_refs": {
+    "standards_repo": "SocioProphet/socioprophet-agent-standards",
+    "profiles": [
+      "EVIDENCE_PROFILE_0001",
+      "CONTROL_GATING_GRADUATION_PROFILE_0001",
+      "ORCHESTRATION_RAY_PROFILE_0001",
+      "LOGICAL_STATISTICAL_PROFILE_0001",
+      "TEST_BUILDING_BLOCK_PROFILE_0001"
+    ],
+    "profile_manifest": "profiles/profile_manifest_0001.yaml",
+    "example_agent_spec": "examples/agent_spec_0001.json",
+    "example_ray_recipe": "examples/ray_recipe_lifecycle_0001.json",
+    "example_test_block": "examples/test_block_0001.json"
+  },
+  "route_expectations": [
+    "/v1/frontier",
+    "/v1/frontier/provenance",
+    "/v1/models/{model_release_id}/dossier",
+    "/v1/models/{model_release_id}/attribution",
+    "/v1/runs/{run_id}/provenance",
+    "/v1/governance/crosswalks",
+    "/v1/competition/reproduced-vs-claimed",
+    "/v1/competition/radar"
+  ],
+  "gate_activation_expectations": [
+    "authorization_gate",
+    "scope_gate",
+    "policy_gate",
+    "risk_gate",
+    "evidence_gate",
+    "approval_gate",
+    "rollback_gate"
+  ],
+  "ray_lifecycle_expectations": [
+    "ray_data_prepare",
+    "ray_train_fit",
+    "ray_tune_search",
+    "benchmark_evaluate",
+    "ray_serve_promote"
+  ]
+}

--- a/apps/eval-fabric-api/tests/fixtures/ray_recipe_lifecycle_0001.json
+++ b/apps/eval-fabric-api/tests/fixtures/ray_recipe_lifecycle_0001.json
@@ -1,0 +1,29 @@
+{
+  "recipe_ref": "recipe://benchmark/ray/eval-fabric-001",
+  "version": "0.0.1",
+  "controller": "ray_orchestrator",
+  "data_references": [
+    "object://datasets/train",
+    "object://datasets/test",
+    "object://datasets/benchmark"
+  ],
+  "worker_topology": {
+    "train_workers": 4,
+    "tune_workers": 2,
+    "benchmark_workers": 2,
+    "serve_replicas": 2
+  },
+  "lifecycle": [
+    "ray_data_prepare",
+    "ray_train_fit",
+    "ray_tune_search",
+    "benchmark_evaluate",
+    "ray_serve_promote"
+  ],
+  "outputs": [
+    "event_envelope",
+    "evidence_receipt",
+    "benchmark_report",
+    "promotion_decision"
+  ]
+}

--- a/apps/eval-fabric-api/tests/fixtures/test_block_0001.json
+++ b/apps/eval-fabric-api/tests/fixtures/test_block_0001.json
@@ -1,0 +1,35 @@
+{
+  "test_block_id": "test_block_0001",
+  "profile_refs": [
+    "logical_statistical_profile_0001",
+    "test_building_block_profile_0001",
+    "control_gating_graduation_profile_0001",
+    "orchestration_ray_profile_0001"
+  ],
+  "input_context": {
+    "task": "semantic route selection with weighted evidence and gate activation",
+    "evaluation_regime": "bounded_candidate_universe"
+  },
+  "expected_structure": {
+    "task_level": "discover route + weighted constraints + required gates",
+    "instance_level": "fill structure for current query and current policy context"
+  },
+  "expected_outputs": {
+    "selected_route": "logical_route",
+    "selected_action_profile": "tool_write"
+  },
+  "expected_gates": [
+    "authorization_gate",
+    "scope_gate",
+    "policy_gate",
+    "risk_gate",
+    "evidence_gate",
+    "approval_gate",
+    "rollback_gate"
+  ],
+  "expected_evidence_refs": [
+    "event_envelope",
+    "evidence_receipt",
+    "benchmark_report"
+  ]
+}

--- a/apps/eval-fabric-api/tests/test_logical_statistical_suite.py
+++ b/apps/eval-fabric-api/tests/test_logical_statistical_suite.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import main
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class _Emission:
+    def __init__(self) -> None:
+        self.payload_ref = "file:///tmp/payload.json"
+        self.event_ref = "file:///tmp/event.json"
+        self.receipt_ref = "file:///tmp/receipt.json"
+
+
+def _load(name: str):
+    return json.loads((FIXTURES / name).read_text())
+
+
+@pytest.fixture()
+def logical_suite():
+    return _load("logical_statistical_suite_0001.json")
+
+
+@pytest.fixture()
+def agent_spec():
+    return _load("agent_spec_0001.json")
+
+
+@pytest.fixture()
+def ray_recipe():
+    return _load("ray_recipe_lifecycle_0001.json")
+
+
+@pytest.fixture()
+def test_block():
+    return _load("test_block_0001.json")
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr(main, "maybe_emit_artifacts", lambda **kwargs: _Emission())
+    monkeypatch.setattr(main, "pg_health", lambda: {"ok": True})
+    monkeypatch.setattr(main, "ch_health", lambda: {"ok": True})
+
+    monkeypatch.setattr(
+        main.repositories,
+        "get_frontier",
+        lambda: [
+            {"subject_id": "model.semantic-stack.2026-04-05", "score": 0.782, "rank": 2},
+            {"subject_id": "gpt5_aug2025", "score": 0.801, "rank": 1},
+        ],
+    )
+    monkeypatch.setattr(
+        main.intelligence_repositories,
+        "get_frontier_provenance",
+        lambda limit=50: [
+            {
+                "model_release_id": "model.semantic-stack.2026-04-05",
+                "metric_fact_count": 2,
+                "reproduced_fact_count": 2,
+                "source_trust_classes": ["internal_reproduced"],
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        main.repositories,
+        "get_model_dossier",
+        lambda model_release_id: [
+            {"metric_definition_id": "md_denotation_accuracy", "value_scalar": 0.84}
+        ],
+    )
+    monkeypatch.setattr(
+        main.governance_repositories,
+        "get_model_attribution",
+        lambda model_release_id, window="rolling_30d": {
+            "subject_id": model_release_id,
+            "window": window,
+            "attributions": {"model_delta": 0.03},
+        },
+    )
+    monkeypatch.setattr(
+        main.governance_repositories,
+        "get_model_repro_entries",
+        lambda model_release_id: [
+            {"repro_ledger_entry_id": "repro_001", "run_id": "run_001"}
+        ],
+    )
+    monkeypatch.setattr(
+        main.governance_repositories,
+        "get_run_provenance",
+        lambda run_id: {
+            "run": {"run_id": run_id},
+            "repro_ledger_entries": [],
+            "methodology_snapshots": [],
+        },
+    )
+    monkeypatch.setattr(
+        main.governance_repositories,
+        "get_metric_crosswalks",
+        lambda limit=50: [{"metric_crosswalk_id": "crosswalk_001"}],
+    )
+    monkeypatch.setattr(
+        main.intelligence_repositories,
+        "get_reproduced_vs_claimed",
+        lambda limit=50: [{"competitor_snapshot_id": "cmp_openai", "coverage_state": "claimed_only"}],
+    )
+    monkeypatch.setattr(
+        main.repositories,
+        "get_competition_radar",
+        lambda: [{"provider_id": "openai"}, {"provider_id": "google"}],
+    )
+    return TestClient(main.app)
+
+
+def test_upstream_profile_alignment(logical_suite, agent_spec, ray_recipe, test_block) -> None:
+    expected_profiles = {
+        "EVIDENCE_PROFILE_0001",
+        "CONTROL_GATING_GRADUATION_PROFILE_0001",
+        "ORCHESTRATION_RAY_PROFILE_0001",
+        "LOGICAL_STATISTICAL_PROFILE_0001",
+        "TEST_BUILDING_BLOCK_PROFILE_0001",
+    }
+    assert expected_profiles.issubset(set(logical_suite["upstream_refs"]["profiles"]))
+    assert "evidence_profile_0001" in agent_spec["profiles"]
+    assert "control_gating_graduation_profile_0001" in agent_spec["profiles"]
+    assert "orchestration_ray_profile_0001" in agent_spec["profiles"]
+    assert test_block["expected_outputs"]["selected_route"] == "logical_route"
+    assert test_block["expected_outputs"]["selected_action_profile"] == "tool_write"
+    assert "ray_train_fit" in ray_recipe["lifecycle"]
+    assert "ray_serve_promote" in ray_recipe["lifecycle"]
+
+
+def test_route_inventory_matches_suite(logical_suite) -> None:
+    app_routes = {route.path for route in main.app.routes}
+    for route_path in logical_suite["route_expectations"]:
+        assert route_path in app_routes
+
+
+def test_frontier_and_provenance_routes_emit_evidence_headers(client: TestClient) -> None:
+    frontier = client.get("/v1/frontier")
+    assert frontier.status_code == 200
+    assert frontier.json()["provenance_mode"] == "trust-aware profile ranking"
+    assert frontier.headers["X-Payload-Ref"] == "file:///tmp/payload.json"
+    assert frontier.headers["X-Event-Envelope-Ref"] == "file:///tmp/event.json"
+    assert frontier.headers["X-Evidence-Receipt-Ref"] == "file:///tmp/receipt.json"
+
+    provenance = client.get("/v1/frontier/provenance")
+    assert provenance.status_code == 200
+    assert provenance.json()["subjects"][0]["model_release_id"] == "model.semantic-stack.2026-04-05"
+
+
+def test_dossier_and_attribution_align_with_test_block(client: TestClient, test_block) -> None:
+    dossier = client.get("/v1/models/model.semantic-stack.2026-04-05/dossier")
+    assert dossier.status_code == 200
+    body = dossier.json()
+    assert body["metrics"][0]["metric_definition_id"] == "md_denotation_accuracy"
+    assert body["attribution"]["attributions"]["model_delta"] == 0.03
+    assert body["repro_ledger_entries"][0]["repro_ledger_entry_id"] == "repro_001"
+
+    assert set(test_block["expected_gates"]) == {
+        "authorization_gate",
+        "scope_gate",
+        "policy_gate",
+        "risk_gate",
+        "evidence_gate",
+        "approval_gate",
+        "rollback_gate",
+    }
+
+
+def test_governance_and_competition_views(client: TestClient, logical_suite) -> None:
+    run_provenance = client.get("/v1/runs/run_001/provenance")
+    assert run_provenance.status_code == 200
+    assert run_provenance.json()["provenance"]["run"]["run_id"] == "run_001"
+
+    crosswalks = client.get("/v1/governance/crosswalks")
+    assert crosswalks.status_code == 200
+    assert crosswalks.json()["crosswalks"][0]["metric_crosswalk_id"] == "crosswalk_001"
+
+    reproduced = client.get("/v1/competition/reproduced-vs-claimed")
+    assert reproduced.status_code == 200
+    assert reproduced.json()["items"][0]["coverage_state"] == "claimed_only"
+
+    radar = client.get("/v1/competition/radar")
+    assert radar.status_code == 200
+    providers = {item["provider_id"] for item in radar.json()["competitors"]}
+    assert {"openai", "google"}.issubset(providers)
+
+    assert "ray_train_fit" in logical_suite["ray_lifecycle_expectations"]
+    assert "ray_serve_promote" in logical_suite["ray_lifecycle_expectations"]


### PR DESCRIPTION
## Summary

Import the merged upstream logical-statistical testing profiles into downstream eval-fabric suite fixtures and tests.

This PR adds:
- upstream-derived fixture files for the example agent spec, Ray recipe lifecycle, and logical-statistical test block
- one local suite definition that ties those fixtures back to the upstream profile manifest and profile refs
- one focused test module that validates the canonical eval-fabric routes against those logical-statistical suite expectations

## Why

The upstream standards repo now has:
- evidence profile
- control/gating/graduation/orchestration-Ray profiles
- examples and manifest
- logical-statistical and test-building-block profiles

The next downstream step is to consume those standards in the eval-fabric test layer rather than leaving them only as upstream documentation.

## Files included

- `apps/eval-fabric-api/tests/fixtures/agent_spec_0001.json`
- `apps/eval-fabric-api/tests/fixtures/ray_recipe_lifecycle_0001.json`
- `apps/eval-fabric-api/tests/fixtures/test_block_0001.json`
- `apps/eval-fabric-api/tests/fixtures/logical_statistical_suite_0001.json`
- `apps/eval-fabric-api/tests/test_logical_statistical_suite.py`

## Notes

This is intentionally a narrow standards-consumption PR. It does not invent new platform-local semantics; it imports the merged upstream profile language into downstream suite fixtures and route-level assertions.
