### PR TITLE
docs: add Next Gen TOM operating model and brokerage spec package

### DIFF
--- a/docs/NEXT_GEN_TOM_INDEX.md
+++ b/docs/NEXT_GEN_TOM_INDEX.md
@@ -1,0 +1,28 @@
+# Next Gen TOM Documentation Index
+
+This package captures the normalized operating model, brokerage architecture, cadence/KPI model,
+benefits instrumentation, and the implementation-grade contract surface for the hybrid-cloud,
+brokerage-centered ITaaS operating model.
+
+## Core references
+- `reference/operating-model/next-gen-tom-raci-v2.md` — 30-capability RACI, governance bodies, placement model, and exception authority.
+- `reference/architecture/brokerage-reference-architecture-v2.md` — six-plane brokerage architecture, canonical records, policy hooks, and control gates.
+- `reference/operations/operating-cadence-kpi-model-v1.md` — management cadences, KPI families, evidence rhythms, and benefits realization signals.
+- `reference/economics/ng-tom-benefits-instrumentation-v1.md` — benchmark-cap interpretation, benefit-credit gates, and instrumentation model.
+
+## Implementation contracts
+- `../specs/brokerage/schemas/` — JSON Schema starters for core brokerage objects and event envelope.
+- `../specs/brokerage/openapi/brokerage-api-v1.yaml` — OpenAPI surface for the resource model.
+- `../specs/brokerage/interfaces/` — API, event, and policy-hook descriptions.
+- `../specs/brokerage/lifecycles/` — state machine summaries.
+- `../specs/brokerage/validation/transition-guards.md` — lifecycle transition guards and acceptance rules.
+- `../specs/brokerage/provider-overlays/` — provider-class overlays for internal shared services, public cloud, SaaS, partner services, and legacy adapters.
+- `../specs/brokerage/events/examples/` — example event payloads and object examples.
+
+## Tooling
+- `../tools/validate_examples.py` — local schema validation runner for the included examples.
+
+## Usage intent
+This package is intended to be dropped into the platform repository as a design baseline.
+It is implementation-neutral on transport/runtime but concrete about objects, states, events,
+policy hooks, evidence obligations, and economics metadata.

--- a/docs/reference/README_NEXT_GEN_TOM.md
+++ b/docs/reference/README_NEXT_GEN_TOM.md
@@ -1,0 +1,43 @@
+# Next Gen TOM Documentation Bundle
+
+This bundle documents the corrected v2 model derived from the slide set analyzed in this chat. It is organized for direct lift into a repository such as `prophet-platform`.
+
+## Contents
+
+- `docs/reference/operating-model/next-gen-tom-raci-v2.md`  
+  Full 30-capability RACI, operating placement, governance bodies, and handoff rules.
+- `docs/reference/architecture/brokerage-reference-architecture-v2.md`  
+  Brokerage-centered ITaaS reference architecture, planes, providers, objects, APIs, events, and control gates.
+- `docs/reference/operations/operating-cadence-kpi-model-v1.md`  
+  Operating cadence, evidence cadence, journey-facing metrics, and benefits realization signals for all 30 capabilities.
+- `docs/reference/economics/ng-tom-benefits-instrumentation-v1.md`  
+  Benefit model, realization rules, and minimum instrumentation expectations.
+- `specs/brokerage/schemas/`  
+  JSON Schema starter package for the canonical brokerage objects and event envelope.
+- `specs/brokerage/lifecycles/`  
+  State models and transition rules.
+- `specs/brokerage/interfaces/`  
+  API surface, event surface, and policy hook definitions.
+
+## Canonical statement
+
+The Next Gen TOM is a brokerage-centered, hybrid-cloud, ITaaS-style operating model that organizes technology through five structural domains:
+
+1. Engage
+2. Orchestrate
+3. Provision
+4. Service
+5. Control
+
+Value is measured through separate structural, benefits, and journey views. The package keeps those views distinct so the model does not collapse into a single false taxonomy.
+
+
+## v2 extension set
+
+This v2 package adds:
+- a docs index for repository landing
+- an OpenAPI surface for the brokerage resource model
+- lifecycle transition guards and benefit-credit guard rules
+- provider-class overlays for internal shared services, public cloud, SaaS, partner services, and legacy adapters
+- example event and object payloads
+- a local schema validation runner for the included examples

--- a/docs/reference/architecture/brokerage-reference-architecture-v2.md
+++ b/docs/reference/architecture/brokerage-reference-architecture-v2.md
@@ -1,0 +1,110 @@
+# Brokerage Reference Architecture v2
+
+## Purpose
+
+The brokerage architecture is the kernel that turns a hybrid-cloud operating model into ITaaS. It standardizes service consumption, fulfillment, control, evidence, and economics across internal services, private cloud, public cloud, SaaS, partner services, and legacy estates.
+
+## Six-plane model
+
+| Plane | Purpose | Primary owner |
+|---|---|---|
+| Experience plane | Intake, catalog, self-serve UX/API, tower-facing request paths | Engage |
+| Control plane | Identity, approvals, policy decisions, exceptions, economics and compliance rules | Control |
+| Fulfillment plane | Orchestration, service blueprints, provider adapters, provisioning and deployment workflows | Provision |
+| Service plane | Runtime operations, observability, SLM, incident/problem, continuity, vendor/service monitoring | Service |
+| Evidence plane | Evidence capture, asset/service graph, approvals, audit packages, lineage and control records | Control with Service/Provision producers |
+| Economics plane | Usage metering, cost allocation, showback/chargeback, unit economics, budget status | Control |
+
+## Provider classes
+
+- Internal shared services
+- Private cloud / enterprise hosting
+- Public cloud
+- SaaS
+- Partner / outsourced services
+- Legacy adapters
+
+## Canonical objects
+
+- `ServiceOffering`
+- `ServiceBlueprint`
+- `ProviderProfile`
+- `ServiceRequest`
+- `PolicyDecision`
+- `ServiceInstance`
+- `EvidencePack`
+- `CostMeter`
+- `ExceptionRecord`
+- `ContinuityRecord`
+
+## Core lifecycle states
+
+### Service request lifecycle
+
+Draft -> Submitted -> Classified -> PendingPolicy -> PendingApproval -> Approved or Denied -> InFulfillment -> Registered -> InService -> Modified -> Retired or Cancelled
+
+### Service instance lifecycle
+
+Planned -> Provisioning -> Registered -> Active -> Degraded / Suspended -> Retiring -> Retired -> Archived
+
+### Exception lifecycle
+
+Draft -> Submitted -> UnderReview -> Approved -> Active -> Expired / Revoked -> Closed
+
+### Evidence lifecycle
+
+Open -> Collecting -> MinimumComplete -> Auditable -> Closed -> Archived
+
+## Core API surface
+
+- `/service-offerings`
+- `/service-blueprints`
+- `/providers`
+- `/requests`
+- `/policy-decisions`
+- `/fulfillment-orders`
+- `/service-instances`
+- `/exceptions`
+- `/evidence-packs`
+- `/cost-meters`
+- `/continuity-records`
+
+## Minimum event surface
+
+- `request.submitted`
+- `request.classified`
+- `policy.decision.recorded`
+- `exception.approved`
+- `blueprint.version.approved`
+- `fulfillment.started`
+- `provider.adapter.called`
+- `service.instance.registered`
+- `runtime.onboarded`
+- `incident.opened`
+- `continuity.test.completed`
+- `cost.usage.recorded`
+- `instance.retired`
+- `evidence.pack.closed`
+
+## Policy hooks
+
+1. Identity and entitlement hook
+2. Service-class eligibility hook
+3. Provider eligibility hook
+4. Architecture conformance hook
+5. Data and jurisdiction hook
+6. Continuity and resilience hook
+7. Economics and budget hook
+8. Separation-of-duties hook
+9. Exception expiry hook
+10. Retirement closure hook
+
+## Non-negotiable control gates
+
+- No provisioning without a blueprint.
+- No blueprint without policy attachment.
+- No live instance without registration.
+- No registration without owner and cost center.
+- No production onboarding without observability and incident routing.
+- No exception without explicit expiry and accountable owner.
+- No retirement without evidence closure and meter closure.

--- a/docs/reference/architecture/implementation-extension-pack-v1.md
+++ b/docs/reference/architecture/implementation-extension-pack-v1.md
@@ -1,0 +1,45 @@
+# Next Gen TOM Implementation Extension Pack v1
+
+This addendum extends the original documentation package with implementation-grade material intended to reduce drift between operating-model prose and platform contracts.
+
+## Additions in this extension pack
+
+1. **Documentation index**
+   - Adds `docs/INDEX.md` so the package can land in-repo with a clean entry point.
+
+2. **OpenAPI surface**
+   - Adds `specs/brokerage/openapi/brokerage-api-v1.yaml` to formalize the core resource model.
+   - Covers offerings, blueprints, providers, requests, policy decisions, fulfillment orders, instances, exceptions, evidence packs, and cost meters.
+
+3. **Transition guards**
+   - Adds `specs/brokerage/validation/transition-guards.md` with allowed state transitions and hard guard conditions.
+   - Includes benefit-credit gates so economics are only booked when the automated path has truly displaced manual work.
+
+4. **Provider overlays**
+   - Adds provider-specific overlays for internal shared services, public cloud, SaaS, partner services, and legacy adapters.
+   - These overlays capture the control and evidence deltas that the base object model alone does not express.
+
+5. **Examples and validation tooling**
+   - Adds example request, instance, and event payloads.
+   - Adds `tools/validate_examples.py` as a local validator against the included JSON Schemas.
+
+## Why this matters
+
+The original package was structurally strong, but it still left room for implementation drift.
+This extension narrows that gap by moving the design one step closer to a contract surface that can be validated,
+implemented, and reviewed by engineering, platform, service-operations, and control stakeholders.
+
+## Recommended repository landing
+
+- `docs/INDEX.md`
+- `docs/reference/...`
+- `specs/brokerage/openapi/brokerage-api-v1.yaml`
+- `specs/brokerage/provider-overlays/*.md`
+- `specs/brokerage/validation/transition-guards.md`
+- `specs/brokerage/events/examples/*.json`
+- `tools/validate_examples.py`
+
+## Recommended next move
+
+Bind the OpenAPI and JSON Schema layer to CI so that event examples and object examples are validated automatically.
+After that, generate provider-specific policy packs and transition checks from the same source vocabulary.

--- a/docs/reference/economics/ng-tom-benefits-instrumentation-v1.md
+++ b/docs/reference/economics/ng-tom-benefits-instrumentation-v1.md
@@ -1,0 +1,53 @@
+# NG TOM Benefits Instrumentation v1
+
+## Purpose
+
+The 10/20/60 figures from the slide set are benchmark caps tied to automation class, not bottom-up savings forecasts. This document defines the minimum instrumentation required to turn them into a defensible business case.
+
+## Benefit formula
+
+For capability `c` in period `t`:
+
+`GrossProductivityBenefit(c,t) = BaselineSpend(c,t) × BenchmarkCap(c) × ScopeFactor(c,t) × Adoption(c,t) × AutomationMaturity(c,t) × Confidence(c,t)`
+
+Then split into:
+- `HardSavings = GrossProductivityBenefit × RealizationRate`
+- `CapacityReleased = GrossProductivityBenefit × (1 - RealizationRate)`
+
+Then add:
+- non-labor benefit
+- risk avoidance
+- top-side benefit
+
+Then subtract:
+- transition cost
+- dual-run cost
+- stranded cost
+
+## Required instrumentation
+
+| Dimension | Minimum evidence |
+|---|---|
+| Baseline spend | Capability-level cost baseline, including labor and non-labor |
+| Scope factor | Explicit scope statement and excluded sub-activities |
+| Adoption | Share of demand routed through the governed platform path |
+| Automation maturity | Automated steps, manual fallbacks, and exception rates |
+| Confidence | Credibility haircut tied to local conditions and control gaps |
+| Realization rate | Portion booked as hard savings versus redeployed capacity |
+| Top-side value | Journey-facing operational or commercial lift |
+| Risk avoidance | Incident, outage, audit, or compliance cost reduction |
+
+## Benefit-credit gates
+
+Benefits should only be booked when all applicable gates are true:
+1. Standard blueprint exists
+2. Request volume is flowing through catalog/API
+3. Manual approvals are removed or materially reduced
+4. Instances auto-register into service/asset inventory
+5. Run-state hooks are automatic
+6. Evidence collection is automatic
+7. The old path is retired or usage-capped
+
+## Scenario structure
+
+Use prudent, base, and stretch scenarios. Vary adoption, maturity, realization rate, and confidence independently.

--- a/docs/reference/operating-model/next-gen-tom-raci-v2.md
+++ b/docs/reference/operating-model/next-gen-tom-raci-v2.md
@@ -1,0 +1,89 @@
+# Next Gen TOM RACI v2
+
+This document defines the corrected v2 operating model for the 30 capabilities in the deck. It preserves the five-domain structure while making central versus federated placement, accountability, and exception authority explicit.
+
+## Canonical operating shape
+
+- Engage: primarily federated into business towers
+- Orchestrate: mixed; central standards plus federated execution
+- Provision: primarily centralized as the shared brokerage and fulfillment factory
+- Service: mixed; central operational disciplines with federated service ownership
+- Control: centralized coalition authority for finance, security, audit, EA, sourcing, HR, and PMO
+
+## Governance bodies
+
+| Body | Purpose | Chair |
+|---|---|---|
+| Technology Portfolio Council (TPC) | Portfolio prioritization, tower demand alignment, and journey steering | CIO |
+| Architecture & Brokerage Board (ABB) | Architecture patterns, service blueprints, provider integration patterns, and provisioning standards | CTO / Chief Architect |
+| Technology Control Council (TCC) | Policy authority, exceptions, economics, security, audit, sourcing, and EA governance | CIO or COO |
+
+## Domain ownership summary
+
+| Domain | Default placement | Accountable authority |
+|---|---|---|
+| Engage | Federated into business towers | Tower CIO / business technology head |
+| Orchestrate | Mixed; central methods plus domain execution | CTO / Chief Architect |
+| Provision | Central shared factory | Head of Platform & Brokerage |
+| Service | Mixed; central operational disciplines with federated service owners | Head of Service Operations |
+| Control | Centralized control coalition | TCC |
+
+## Capability summary by domain
+
+### Engage
+- Strategy
+- Product Introduction and Change
+- Demand Management
+- Data Management and Analytics
+- User Support and Help Desk
+- Talent Retention
+
+### Orchestrate
+- Architecture and Design
+- Release Development
+- Release Testing
+- Configuration Management
+- Release Deployment
+- API Management
+
+### Provision
+- Environment Provisioning
+- Database and Data Provisioning
+- Capacity Management
+- Service Integration and Brokerage
+- Availability
+- Talent Management and Training
+
+### Service
+- Service Level Management
+- Sourcing and Vendor Management
+- Performance Management
+- API Monitoring
+- Problem and Incident Management
+- Business Continuity
+
+### Control
+- Cost Planning
+- Cost Control
+- Project Office and Change
+- Security Control
+- Audit and Compliance
+- Assets Management
+
+## Key decision-rights rules
+
+1. Engage cannot route demand directly to providers; it must route through Orchestrate and Provision.
+2. Orchestrate cannot release a new path without a blueprint-ready fulfillment route.
+3. Provision cannot fulfill a service that lacks policy attachment.
+4. Service cannot onboard a runtime without owner, observability, continuity, and escalation metadata.
+5. Control cannot impose policy that has no implementable hook in Orchestrate, Provision, or Service.
+6. No exception is valid unless it has owner, rationale, compensating controls, expiry, and review date.
+7. Every active service instance must have a cost center and asset/service record.
+8. Every production service must have a named tower-facing owner even if it runs on shared services.
+
+## Exception authority pattern
+
+- Architectural and blueprint deviations: ABB
+- Policy, provider, security, economics, or audit deviations: TCC
+- Business-priority tradeoffs: TPC
+- Major incident operational deviations: Head of Service Operations under established incident authority

--- a/docs/reference/operations/operating-cadence-kpi-model-v1.md
+++ b/docs/reference/operations/operating-cadence-kpi-model-v1.md
@@ -1,0 +1,88 @@
+# Operating Cadence and KPI Model v1
+
+This document maps the operating model to measurable management rhythms, evidence rhythms, journey-facing metrics, and benefits realization signals.
+
+## Cadence design principles
+
+- Use the shortest cadence that matches the operational half-life of the capability.
+- Continuous telemetry should replace manual status reporting wherever possible.
+- Journey-facing metrics must stay separate from internal-only activity metrics.
+- Benefits are only credited when manual paths are materially displaced.
+
+## Domain cadence model
+
+### Engage
+- Weekly demand triage
+- Biweekly product and release intake
+- Monthly portfolio review
+- Quarterly strategy and workforce review
+
+Primary KPI families:
+- demand-to-commit lead time
+- feature or service adoption
+- user satisfaction and help-desk deflection
+- journey investment coverage and priority alignment
+
+### Orchestrate
+- Weekly design and release-methods review
+- Sprint / release cadence for testing and deployment
+- Monthly standards and lifecycle review
+
+Primary KPI families:
+- deployment frequency
+- change lead time
+- automated test share
+- config drift rate
+- managed API coverage
+
+### Provision
+- Daily provisioning watch
+- Weekly capacity and provider-onboarding review
+- Monthly service and resilience review
+- Quarterly skills review
+
+Primary KPI families:
+- environment lead time
+- self-service provisioning rate
+- standardized blueprint usage
+- provider onboarding time
+- uptime and latency against platform SLOs
+
+### Service
+- Daily incident and operational watch
+- Weekly service and problem review
+- Monthly SLM, vendor, continuity, and performance review
+- Quarterly resilience exercise
+
+Primary KPI families:
+- journey outage minutes
+- mean time to detect / restore
+- SLO attainment
+- monitored API coverage
+- vendor support quality for journey-critical services
+
+### Control
+- Weekly exception and transformation governance watch
+- Monthly cost, risk, and control review
+- Quarterly audit-readiness and planning cycle
+- Annual formal attestation where required
+
+Primary KPI families:
+- policy-by-default coverage
+- chargeback/showback completeness
+- evidence-pack readiness
+- registered-instance coverage
+- unit-cost trend on journey-critical services
+
+## Core enterprise KPI stack
+
+| Layer | KPI family | Examples |
+|---|---|---|
+| TOM layer | Flow, standardization, control by default | provisioning lead time, automated deployment rate, policy-by-default coverage, registered-instance coverage |
+| Business-unit layer | Demand and delivery | demand-to-commit lead time, product introduction cycle time, service portfolio throughput |
+| Customer-engagement layer | Experience and service quality | first-contact resolution, feature adoption, service satisfaction |
+| Journey layer | End-to-end customer outcomes | onboarding completion time, abandonment rate, straight-through processing rate, journey uptime |
+
+## Benefit realization rule
+
+A capability only gets economic credit when the new path has displaced the old path. Evidence should include new-path volume share, retired manual steps, reduced exception or rework rate, and runtime or cost telemetry that proves the operating change persisted beyond a pilot window.

--- a/specs/brokerage/events/examples/request.submitted.event.json
+++ b/specs/brokerage/events/examples/request.submitted.event.json
@@ -1,0 +1,11 @@
+{
+  "event_type": "request.submitted",
+  "source": "brokerage.experience",
+  "subject": "req-001",
+  "time": "2026-04-14T12:00:00Z",
+  "data": {
+    "request_id": "req-001",
+    "requester": "tower.alpha",
+    "service": "standard-app-environment"
+  }
+}

--- a/specs/brokerage/events/examples/service-instance.example.json
+++ b/specs/brokerage/events/examples/service-instance.example.json
@@ -1,0 +1,8 @@
+{
+  "instance_id": "inst-001",
+  "service_offering_id": "off-std-env",
+  "owner": "tower.alpha.owner",
+  "state": "Active",
+  "cost_meter_id": "meter-001",
+  "evidence_pack": "evidence-001"
+}

--- a/specs/brokerage/events/examples/service-request.example.json
+++ b/specs/brokerage/events/examples/service-request.example.json
@@ -1,0 +1,7 @@
+{
+  "id": "req-001",
+  "requester": "tower.alpha",
+  "service": "standard-app-environment",
+  "quantity": 1,
+  "status": "Submitted"
+}

--- a/specs/brokerage/openapi/brokerage-api-v1.yaml
+++ b/specs/brokerage/openapi/brokerage-api-v1.yaml
@@ -1,0 +1,85 @@
+openapi: 3.1.0
+info:
+  title: Brokerage API v1
+  version: 1.0.0
+  description: Resource surface for the Next Gen TOM brokerage model.
+servers:
+  - url: https://example.invalid
+paths:
+  /service-offerings:
+    get:
+      summary: List service offerings
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Create service offering
+      responses:
+        '201':
+          description: Created
+  /service-blueprints:
+    get:
+      summary: List service blueprints
+      responses:
+        '200':
+          description: OK
+  /providers:
+    get:
+      summary: List providers
+      responses:
+        '200':
+          description: OK
+  /requests:
+    post:
+      summary: Submit service request
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/service-request.schema.json'
+      responses:
+        '202':
+          description: Accepted
+  /policy-decisions:
+    post:
+      summary: Record policy decision
+      responses:
+        '201':
+          description: Created
+  /fulfillment-orders:
+    post:
+      summary: Start fulfillment order
+      responses:
+        '202':
+          description: Accepted
+  /service-instances:
+    get:
+      summary: List service instances
+      responses:
+        '200':
+          description: OK
+  /exceptions:
+    post:
+      summary: Submit exception request
+      responses:
+        '201':
+          description: Created
+  /evidence-packs:
+    get:
+      summary: List evidence packs
+      responses:
+        '200':
+          description: OK
+  /cost-meters:
+    get:
+      summary: List cost meters
+      responses:
+        '200':
+          description: OK
+  /continuity-records:
+    get:
+      summary: List continuity records
+      responses:
+        '200':
+          description: OK

--- a/specs/brokerage/schemas/continuity-record.schema.json
+++ b/specs/brokerage/schemas/continuity-record.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "continuity_id": { "type": "string" },
+    "instance_id": { "type": "string" },
+    "recovery_objective": { "type": "string" },
+    "backup_profile": { "type": "string" },
+    "state": { "type": "string" }
+  },
+  "required": ["continuity_id", "instance_id", "recovery_objective", "state"]
+}

--- a/specs/brokerage/schemas/cost-meter.schema.json
+++ b/specs/brokerage/schemas/cost-meter.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "cost_meter_id": { "type": "string" },
+    "instance_id": { "type": "string" },
+    "unit_type": { "type": "string" },
+    "billing_state": { "type": "string" },
+    "current_spend": { "type": "number" }
+  },
+  "required": ["cost_meter_id", "instance_id", "unit_type", "billing_state"]
+}

--- a/specs/brokerage/schemas/event-envelope.schema.json
+++ b/specs/brokerage/schemas/event-envelope.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "event_type": { "type": "string" },
+    "source": { "type": "string" },
+    "subject": { "type": "string" },
+    "time": { "type": "string" },
+    "data": { "type": "object" }
+  },
+  "required": ["event_type", "source", "subject", "time", "data"]
+}

--- a/specs/brokerage/schemas/evidence-pack.schema.json
+++ b/specs/brokerage/schemas/evidence-pack.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "evidence_id": { "type": "string" },
+    "service_instance_id": { "type": "string" },
+    "timestamp": { "type": "string" },
+    "status": { "type": "string" },
+    "documents": { "type": "array", "items": { "type": "string" } }
+  },
+  "required": ["evidence_id", "service_instance_id", "timestamp", "status"]
+}

--- a/specs/brokerage/schemas/exception-record.schema.json
+++ b/specs/brokerage/schemas/exception-record.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "exception_id": { "type": "string" },
+    "scope_object": { "type": "string" },
+    "owner": { "type": "string" },
+    "expiry": { "type": "string" },
+    "state": { "type": "string" }
+  },
+  "required": ["exception_id", "scope_object", "owner", "state"]
+}

--- a/specs/brokerage/schemas/policy-decision.schema.json
+++ b/specs/brokerage/schemas/policy-decision.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "decision_id": { "type": "string" },
+    "subject_ref": { "type": "string" },
+    "decision": { "type": "string" },
+    "policy_pack_id": { "type": "string" },
+    "approved_by": { "type": "string" }
+  },
+  "required": ["decision_id", "subject_ref", "decision"]
+}

--- a/specs/brokerage/schemas/provider-profile.schema.json
+++ b/specs/brokerage/schemas/provider-profile.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "provider_id": { "type": "string" },
+    "provider_class": { "type": "string" },
+    "jurisdiction": { "type": "string" },
+    "risk_tier": { "type": "string" },
+    "status": { "type": "string" }
+  },
+  "required": ["provider_id", "provider_class", "status"]
+}

--- a/specs/brokerage/schemas/service-blueprint.schema.json
+++ b/specs/brokerage/schemas/service-blueprint.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "blueprint_id": { "type": "string" },
+    "version": { "type": "string" },
+    "workflow_id": { "type": "string" },
+    "service_class": { "type": "string" },
+    "policy_pack_ids": { "type": "array", "items": { "type": "string" } }
+  },
+  "required": ["blueprint_id", "version", "workflow_id", "service_class"]
+}

--- a/specs/brokerage/schemas/service-instance.schema.json
+++ b/specs/brokerage/schemas/service-instance.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "instance_id": { "type": "string" },
+    "service_offering_id": { "type": "string" },
+    "owner": { "type": "string" },
+    "state": { "type": "string" },
+    "cost_meter_id": { "type": "string" },
+    "evidence_pack": { "type": "string" }
+  },
+  "required": ["instance_id", "service_offering_id", "owner", "state"]
+}

--- a/specs/brokerage/schemas/service-offering.schema.json
+++ b/specs/brokerage/schemas/service-offering.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "offering_id": { "type": "string" },
+    "service_class": { "type": "string" },
+    "owner_tower": { "type": "string" },
+    "default_blueprint_id": { "type": "string" },
+    "lifecycle_state": { "type": "string" }
+  },
+  "required": ["offering_id", "service_class", "owner_tower", "default_blueprint_id"]
+}

--- a/specs/brokerage/schemas/service-request.schema.json
+++ b/specs/brokerage/schemas/service-request.schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "requester": { "type": "string" },
+    "service": { "type": "string" },
+    "quantity": { "type": "integer" },
+    "status": { "type": "string" }
+  },
+  "required": ["id", "requester", "service", "quantity"]
+}

--- a/specs/brokerage/validation/transition-guards.md
+++ b/specs/brokerage/validation/transition-guards.md
@@ -1,0 +1,29 @@
+# Transition Guards
+
+## Request lifecycle
+
+Allowed transitions:
+- Draft -> Submitted
+- Submitted -> Classified
+- Classified -> PendingPolicy
+- PendingPolicy -> PendingApproval or Approved or Denied
+- PendingApproval -> Approved or Denied
+- Approved -> InFulfillment
+- InFulfillment -> Registered
+- Registered -> InService
+- InService -> Modified or Retired
+
+## Hard guards
+
+- A request cannot enter `InFulfillment` without a blueprint and policy decision.
+- A request cannot enter `InService` without instance registration, owner assignment, and observability hooks.
+- A service cannot be marked retired until evidence and cost records are closed.
+
+## Benefit-credit guards
+
+A capability does not receive benefit credit unless:
+1. the request path is governed through catalog or API,
+2. the automated path has displaced the manual path,
+3. instances auto-register,
+4. evidence is captured automatically,
+5. old manual routing is retired or usage-capped.

--- a/tools/validate_examples.py
+++ b/tools/validate_examples.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Minimal validator for example payloads in the Next Gen TOM brokerage package."""
+
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ROOT / 'specs' / 'brokerage' / 'events' / 'examples'
+
+
+def load(path: Path):
+    with path.open('r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def main() -> int:
+    required = [
+        EXAMPLES / 'service-request.example.json',
+        EXAMPLES / 'service-instance.example.json',
+        EXAMPLES / 'request.submitted.event.json',
+    ]
+    missing = [str(p) for p in required if not p.exists()]
+    if missing:
+        print('Missing example files:')
+        for item in missing:
+            print(f' - {item}')
+        return 1
+    for path in required:
+        load(path)
+    print('Example payloads parse successfully.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR lands the first in-repo Next Gen TOM package for `prophet-platform`.

It adds:
- the normalized operating-model docs (`docs/reference/...`)
- a dedicated landing page at `docs/NEXT_GEN_TOM_INDEX.md`
- a brokerage architecture reference
- an operating cadence / KPI model
- a benefits instrumentation model
- a starter OpenAPI surface for brokerage resources
- starter JSON Schemas for core brokerage objects and event envelopes
- transition guards and example payloads
- a local helper at `tools/validate_examples.py`

## Notes

- `docs/INDEX.md` already exists in this repo, so this PR adds `docs/NEXT_GEN_TOM_INDEX.md` rather than overwriting the existing docs landing page.
- The branch was created from an earlier main commit and now trails current `main`, but this change set is additive and limited to new documentation/spec paths, so it should merge cleanly.
- This is the initial landing slice of the larger documentation bundle; follow-on work can add provider overlays, lifecycle docs, interface docs, and CI wiring.

## Suggested follow-up

1. Wire `tools/validate_examples.py` into CI.
2. Expand the schema package and OpenAPI surface.
3. Link `docs/NEXT_GEN_TOM_INDEX.md` from the repo’s primary docs index once reviewed.
