### PR TITLE
fogstack: wire CI validation records into platform evidence artifacts

### DIFF
--- a/.github/workflows/fogstack-validation.yml
+++ b/.github/workflows/fogstack-validation.yml
@@ -27,6 +27,9 @@ on:
       - "tools/fogstack_validation_to_evidence.py"
       - "docs/FOGSTACK_*.md"
 
+permissions:
+  contents: read
+
 jobs:
   validate-fogstack:
     runs-on: ubuntu-latest

--- a/.github/workflows/fogstack-validation.yml
+++ b/.github/workflows/fogstack-validation.yml
@@ -1,0 +1,129 @@
+name: FogStack Validation
+
+on:
+  pull_request:
+    paths:
+      - "bundles/**"
+      - "conformance/**"
+      - "catalog/fogstack-support-states-v0.1.yaml"
+      - "releases/**"
+      - "schemas/release/**"
+      - "tools/fogstack_verify.py"
+      - "tools/validate_fogstack.py"
+      - "tools/emit_fogstack_validation_record.py"
+      - "tools/fogstack_validation_to_evidence.py"
+      - "docs/FOGSTACK_*.md"
+  push:
+    branches: [main]
+    paths:
+      - "bundles/**"
+      - "conformance/**"
+      - "catalog/fogstack-support-states-v0.1.yaml"
+      - "releases/**"
+      - "schemas/release/**"
+      - "tools/fogstack_verify.py"
+      - "tools/validate_fogstack.py"
+      - "tools/emit_fogstack_validation_record.py"
+      - "tools/fogstack_validation_to_evidence.py"
+      - "docs/FOGSTACK_*.md"
+
+jobs:
+  validate-fogstack:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install validation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyyaml jsonschema pytest
+
+      - name: Run helper tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_validation_to_evidence.py
+
+      - name: Run native fogstack validation
+        run: |
+          mkdir -p artifacts
+          python3 tools/fogstack_verify.py bundles/fogstack.access-v0.1.yaml --json > artifacts/fogstack.access.verify.json
+          python3 tools/fogstack_verify.py bundles/fogstack.knowledge-v0.1.yaml --json > artifacts/fogstack.knowledge.verify.json
+          python3 tools/fogstack_verify.py bundles/fogstack.evaluation-v0.1.yaml --json > artifacts/fogstack.evaluation.verify.json
+
+      - name: Emit validation records
+        run: |
+          python3 tools/emit_fogstack_validation_record.py \
+            --verifier-json artifacts/fogstack.access.verify.json \
+            --bundle-id fogstack.access \
+            --version 0.1.0 \
+            --source ci \
+            --evidence-ref artifact://ci/fogstack.access.verify.json \
+            --output artifacts/fogstack.access.validation.record.json
+
+          python3 tools/emit_fogstack_validation_record.py \
+            --verifier-json artifacts/fogstack.knowledge.verify.json \
+            --bundle-id fogstack.knowledge \
+            --version 0.1.0 \
+            --source ci \
+            --evidence-ref artifact://ci/fogstack.knowledge.verify.json \
+            --output artifacts/fogstack.knowledge.validation.record.json
+
+          python3 tools/emit_fogstack_validation_record.py \
+            --verifier-json artifacts/fogstack.evaluation.verify.json \
+            --bundle-id fogstack.evaluation \
+            --version 0.1.0 \
+            --source ci \
+            --evidence-ref artifact://ci/fogstack.evaluation.verify.json \
+            --output artifacts/fogstack.evaluation.validation.record.json
+
+      - name: Enforce pass
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          failed = []
+          for path in sorted(Path("artifacts").glob("*.validation.record.json")):
+              data = json.loads(path.read_text(encoding="utf-8"))
+              summary = data.get("summary") or {}
+              if summary.get("status") != "pass":
+                  failed.append({
+                      "file": str(path),
+                      "status": summary.get("status"),
+                      "exit_code": summary.get("exit_code"),
+                  })
+          if failed:
+              print("FogStack validation failures detected:")
+              for item in failed:
+                  print(item)
+              raise SystemExit(1)
+          print("All FogStack validations passed.")
+          PY
+
+      - name: Convert validation records to evidence artifacts
+        run: |
+          mkdir -p ci_state
+          python3 tools/fogstack_validation_to_evidence.py \
+            --records-dir artifacts \
+            --state-root ci_state \
+            --service fogstack-validation
+
+      - name: Upload validation artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fogstack-validation-records
+          path: artifacts/
+          if-no-files-found: error
+
+      - name: Upload evidence artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fogstack-validation-evidence
+          path: ci_state/
+          if-no-files-found: error

--- a/docs/FOGSTACK_CI_VALIDATION_ARTIFACTS.md
+++ b/docs/FOGSTACK_CI_VALIDATION_ARTIFACTS.md
@@ -11,7 +11,8 @@ Turn verifier output into a schema-conforming `FogStackValidationRecord` that ca
 1. run `python3 tools/validate_fogstack.py` or `python3 tools/fogstack_verify.py ... --json`
 2. capture the verifier JSON output
 3. run `python3 tools/emit_fogstack_validation_record.py` to convert that JSON into a `FogStackValidationRecord`
-4. write the record into a deterministic artifact location under CI workspace or release packaging output
+4. run `python3 tools/fogstack_validation_to_evidence.py` to convert validation records into canonical platform evidence artifacts
+5. upload both the validation records and evidence artifacts from CI
 
 ## Example
 
@@ -24,6 +25,10 @@ python3 tools/emit_fogstack_validation_record.py \
   --source ci \
   --evidence-ref artifact://ci/fogstack.access.verify.json \
   --output /tmp/fogstack.access.validation.record.json
+python3 tools/fogstack_validation_to_evidence.py \
+  --records-dir /tmp \
+  --state-root /tmp/ci_state \
+  --service fogstack-validation
 ```
 
 ## What counts as executed evidence
@@ -32,10 +37,18 @@ A record should only be treated as release evidence when:
 - `source` is `ci`
 - the underlying verifier JSON came from the native validation path
 - the bundle/rulepack on disk match the release candidate being published
+- the emitted evidence artifacts are derived from that same CI-produced validation record
 
-## Out of scope in this phase
+## Now in scope
 
-- automatic CI wiring
-- artifact upload/storage backend
+This phase now includes:
+- automatic GitHub Actions wiring for Fog Stack validation
+- CI-emitted validation records
+- CI-emitted canonical evidence artifacts
+- artifact upload from CI for both validation records and evidence bundles
+
+## Still out of scope
+
 - cryptographic signing of validation records
 - release-manifest back-linking automation
+- registry publication of release evidence

--- a/tools/fogstack_validation_to_evidence.py
+++ b/tools/fogstack_validation_to_evidence.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def digest_json(payload: dict[str, Any]) -> str:
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(body).hexdigest()
+
+
+def bundle_subject_ref(bundle_id: str, version: str) -> str:
+    return f"bundle://{bundle_id}@{version}"
+
+
+def correlation_id(bundle_id: str, version: str) -> str:
+    safe = bundle_id.replace(".", "_").replace("/", "_")
+    return f"{safe}-{version}"
+
+
+@dataclass(frozen=True)
+class Layout:
+    state_root: Path
+    service: str
+
+    @property
+    def platform_root(self) -> Path:
+        return self.state_root / "prophet-platform"
+
+    @property
+    def payload_dir(self) -> Path:
+        return self.platform_root / "payloads" / self.service
+
+    @property
+    def event_dir(self) -> Path:
+        return self.platform_root / "events" / self.service
+
+    @property
+    def receipt_dir(self) -> Path:
+        return self.platform_root / "receipts" / self.service
+
+    @property
+    def catalog_file(self) -> Path:
+        return self.platform_root / "catalog" / self.service / "receipt_catalog.jsonl"
+
+    def ensure(self) -> None:
+        for p in [self.payload_dir, self.event_dir, self.receipt_dir, self.catalog_file.parent]:
+            p.mkdir(parents=True, exist_ok=True)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def emit_record(record: dict[str, Any], layout: Layout) -> dict[str, str]:
+    bundle_id = str(record["bundle_id"])
+    version = str(record["version"])
+    corr = correlation_id(bundle_id, version)
+    created_at = utc_now()
+    subject_ref = bundle_subject_ref(bundle_id, version)
+
+    payload = {
+        "kind": "FogStackValidationPayload",
+        "record": record,
+    }
+
+    payload_path = layout.payload_dir / f"{corr}.payload.json"
+    payload_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    payload_ref = f"file://{payload_path.resolve()}"
+
+    envelope = {
+        "version": "0.1",
+        "envelope_id": corr + "-event",
+        "created_at": created_at,
+        "event_type": "fogstack.validation.record.emitted",
+        "producer": "ci://github-actions",
+        "subject_ref": subject_ref,
+        "payload_ref": payload_ref,
+        "scope_ref": "scope://platform/fogstack-release-engineering",
+        "correlation_id": corr,
+        "classifiers": ["source:ci", "kind:fogstack-validation"],
+    }
+    env_hash = digest_json(envelope)
+
+    receipt = {
+        "version": "0.1",
+        "receipt_id": corr + "-receipt",
+        "created_at": created_at,
+        "service_ref": "ci://github-actions/fogstack-validation",
+        "action": "FogStackValidationRecordIngest",
+        "status": "succeeded",
+        "subject_ref": subject_ref,
+        "envelope_ref": f"event://{envelope['envelope_id']}",
+        "policy_refs": [],
+        "evidence_refs": [str(record.get("evidence_ref")) if record.get("evidence_ref") else payload_ref],
+        "output_refs": [payload_ref],
+        "metrics": {
+            "summary_status": (record.get("summary") or {}).get("status"),
+            "exit_code": (record.get("summary") or {}).get("exit_code"),
+        },
+        "hash": env_hash,
+        "hash_algo": "sha256",
+        "correlation_id": corr,
+    }
+
+    event_path = layout.event_dir / f"{corr}.event.json"
+    receipt_path = layout.receipt_dir / f"{corr}.receipt.json"
+    event_path.write_text(json.dumps({**envelope, "receipt_ref": f"receipt://{receipt['receipt_id']}"}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    catalog_entry = {
+        "version": "0.1",
+        "entry_id": corr + "-catalog",
+        "created_at": created_at,
+        "service_ref": layout.service,
+        "event_type": envelope["event_type"],
+        "status": receipt["status"],
+        "subject_ref": subject_ref,
+        "scope_ref": envelope["scope_ref"],
+        "envelope_ref": f"file://{event_path.resolve()}",
+        "receipt_ref": f"file://{receipt_path.resolve()}",
+        "payload_ref": payload_ref,
+        "correlation_id": corr,
+        "classifiers": envelope["classifiers"],
+    }
+    with layout.catalog_file.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(catalog_entry, sort_keys=True) + "\n")
+
+    return {
+        "correlation_id": corr,
+        "payload_ref": payload_ref,
+        "event_ref": f"file://{event_path.resolve()}",
+        "receipt_ref": f"file://{receipt_path.resolve()}",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Convert FogStack validation records into platform evidence artifacts")
+    parser.add_argument("--records-dir", type=Path, required=True, help="Directory containing *.validation.record.json files")
+    parser.add_argument("--state-root", type=Path, required=True)
+    parser.add_argument("--service", default="fogstack-validation")
+    args = parser.parse_args()
+
+    layout = Layout(state_root=args.state_root, service=args.service)
+    layout.ensure()
+
+    emitted = []
+    for path in sorted(args.records_dir.glob("*.validation.record.json")):
+        emitted.append(emit_record(load_json(path), layout))
+
+    print(json.dumps({"service": args.service, "count": len(emitted), "items": emitted}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_validation_to_evidence.py
+++ b/tools/tests/test_fogstack_validation_to_evidence.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_fogstack_validation_to_evidence(tmp_path: Path):
+    records = tmp_path / "artifacts"
+    records.mkdir()
+    (records / "fogstack.access.validation.record.json").write_text(json.dumps({
+        "kind": "FogStackValidationRecord",
+        "schema_version": "v0.1",
+        "bundle_id": "fogstack.access",
+        "version": "0.1.0",
+        "validation_path": "tools/validate_fogstack.py",
+        "source": "ci",
+        "status": "executed",
+        "summary": {"status": "pass", "exit_code": 0},
+        "evidence_ref": "artifact://ci/fogstack.access.verify.json",
+    }), encoding="utf-8")
+
+    script = Path(__file__).resolve().parents[1] / "fogstack_validation_to_evidence.py"
+    out = subprocess.run(
+        [sys.executable, str(script), "--records-dir", str(records), "--state-root", str(tmp_path / "state"), "--service", "fogstack-validation"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(out.stdout)
+    assert payload["count"] == 1
+    p = tmp_path / "state" / "prophet-platform"
+    assert (p / "payloads" / "fogstack-validation" / "fogstack_access-0.1.0.payload.json").exists()
+    assert (p / "events" / "fogstack-validation" / "fogstack_access-0.1.0.event.json").exists()
+    assert (p / "receipts" / "fogstack-validation" / "fogstack_access-0.1.0.receipt.json").exists()
+    assert (p / "catalog" / "fogstack-validation" / "receipt_catalog.jsonl").exists()


### PR DESCRIPTION
## What this does

Adds the first executed-evidence bridge for the merged Fog Stack release-engineering lane.

### Scope
- adds `.github/workflows/fogstack-validation.yml`
- adds `tools/fogstack_validation_to_evidence.py`
- adds `tools/tests/test_fogstack_validation_to_evidence.py`
- updates `docs/FOGSTACK_CI_VALIDATION_ARTIFACTS.md`

### CI behavior
- runs native Fog Stack validation for Access / Knowledge / Evaluation
- emits `FogStackValidationRecord` JSON via the already-merged helper
- converts those records into canonical type-first platform evidence artifacts under `prophet-platform/{payloads,events,receipts,catalog}/fogstack-validation`
- uploads both validation records and evidence artifacts as CI artifacts
- fails the workflow if any validation summary is not `pass`

## Why

PR #46 landed the release-engineering shapes and helper, but not executed CI truth. This PR turns those static surfaces into actual evidence artifacts without yet adding signing or registry complexity.

## Not in this PR

- signing of validation records
- registry publication
- evidence-console integration for Fog Stack validation views

Those are the next thin tranches after this CI bridge lands.
