### PR TITLE
platform: add eval fabric promotion and rollback suite fixtures

### DIFF
--- a/apps/eval-fabric-api/tests/fixtures/gate_activation_record_0001.json
+++ b/apps/eval-fabric-api/tests/fixtures/gate_activation_record_0001.json
@@ -1,0 +1,26 @@
+{
+  "gate_activation_record_id": "gate_activation_record_0001",
+  "action_ref": "action://eval-fabric/tool_write/logical_route",
+  "required_gates": [
+    "authorization_gate",
+    "scope_gate",
+    "policy_gate",
+    "risk_gate",
+    "evidence_gate",
+    "approval_gate",
+    "rollback_gate"
+  ],
+  "activated_gates": [
+    "authorization_gate",
+    "scope_gate",
+    "policy_gate",
+    "risk_gate",
+    "evidence_gate",
+    "approval_gate",
+    "rollback_gate"
+  ],
+  "failed_gates": [],
+  "policy_decision_ref": "policy://decision/eval-fabric-0001",
+  "approval_ref": "approval://operator/eval-fabric-0001",
+  "rollback_requirement": "required_before_side_effect"
+}

--- a/apps/eval-fabric-api/tests/fixtures/graduation_record_0001.json
+++ b/apps/eval-fabric-api/tests/fixtures/graduation_record_0001.json
@@ -1,0 +1,32 @@
+{
+  "graduation_record_id": "graduation_record_0001",
+  "agent_ref": "agent://socioprophet/example/retrieval-governed-operator",
+  "current_stage": "L3_assist_mode",
+  "target_stage": "L4_supervised_actuation",
+  "lane_scores": {
+    "capability": 3,
+    "safety_policy": 4,
+    "reliability_recovery": 3,
+    "observability_auditability": 4,
+    "provenance_reproducibility": 4,
+    "efficiency_budget": 3,
+    "human_oversight_acceptability": 4
+  },
+  "blocking_lanes": [],
+  "promotion_window": "rolling_30d",
+  "required_gates": [
+    "authorization_gate",
+    "scope_gate",
+    "policy_gate",
+    "risk_gate",
+    "evidence_gate",
+    "approval_gate",
+    "rollback_gate"
+  ],
+  "evidence_refs": [
+    "event_envelope",
+    "evidence_receipt",
+    "benchmark_report",
+    "promotion_decision"
+  ]
+}

--- a/apps/eval-fabric-api/tests/fixtures/promotion_decision_0001.json
+++ b/apps/eval-fabric-api/tests/fixtures/promotion_decision_0001.json
@@ -1,0 +1,23 @@
+{
+  "promotion_decision_id": "promotion_decision_0001",
+  "subject_ref": "model://model.semantic-stack.2026-04-05",
+  "source_ref": "recipe://benchmark/ray/eval-fabric-001",
+  "current_stage": "L3_assist_mode",
+  "target_stage": "L4_supervised_actuation",
+  "decision": "approved_with_gates",
+  "required_gates": [
+    "authorization_gate",
+    "scope_gate",
+    "policy_gate",
+    "risk_gate",
+    "evidence_gate",
+    "approval_gate",
+    "rollback_gate"
+  ],
+  "evidence_refs": [
+    "event_envelope",
+    "evidence_receipt",
+    "benchmark_report"
+  ],
+  "promotion_window": "rolling_30d"
+}

--- a/apps/eval-fabric-api/tests/fixtures/rollback_record_0001.json
+++ b/apps/eval-fabric-api/tests/fixtures/rollback_record_0001.json
@@ -1,0 +1,18 @@
+{
+  "rollback_record_id": "rollback_record_0001",
+  "subject_ref": "service://eval-fabric-api/ray-serve",
+  "trigger_ref": "promotion_decision_0001",
+  "rollback_reason": "post-promotion policy regression",
+  "required_gates": [
+    "authorization_gate",
+    "scope_gate",
+    "policy_gate",
+    "risk_gate",
+    "rollback_gate"
+  ],
+  "evidence_refs": [
+    "event_envelope",
+    "evidence_receipt"
+  ],
+  "status": "rollback_ready"
+}

--- a/apps/eval-fabric-api/tests/test_gate_activation_suite.py
+++ b/apps/eval-fabric-api/tests/test_gate_activation_suite.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str):
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_gate_activation_record_matches_test_block_expectations() -> None:
+    gate_record = _load("gate_activation_record_0001.json")
+    test_block = _load("test_block_0001.json")
+
+    assert set(gate_record["required_gates"]) == set(test_block["expected_gates"])
+    assert gate_record["failed_gates"] == []
+    assert gate_record["rollback_requirement"] == "required_before_side_effect"
+
+
+def test_gate_activation_aligns_with_promotion_and_rollback_artifacts() -> None:
+    gate_record = _load("gate_activation_record_0001.json")
+    promotion = _load("promotion_decision_0001.json")
+    rollback = _load("rollback_record_0001.json")
+
+    assert set(gate_record["required_gates"]).issuperset(set(promotion["required_gates"]))
+    assert set(rollback["required_gates"]).issubset(set(gate_record["required_gates"]))
+    assert gate_record["policy_decision_ref"].startswith("policy://decision/")
+    assert gate_record["approval_ref"].startswith("approval://")
+
+
+def test_gate_activation_is_logical_route_and_tool_write_aligned() -> None:
+    gate_record = _load("gate_activation_record_0001.json")
+    test_block = _load("test_block_0001.json")
+
+    assert gate_record["action_ref"].endswith("tool_write/logical_route")
+    assert test_block["expected_outputs"]["selected_route"] == "logical_route"
+    assert test_block["expected_outputs"]["selected_action_profile"] == "tool_write"

--- a/apps/eval-fabric-api/tests/test_graduation_readiness_suite.py
+++ b/apps/eval-fabric-api/tests/test_graduation_readiness_suite.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str):
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_graduation_record_matches_agent_and_test_block() -> None:
+    graduation = _load("graduation_record_0001.json")
+    agent_spec = _load("agent_spec_0001.json")
+    test_block = _load("test_block_0001.json")
+
+    assert graduation["agent_ref"] == agent_spec["agent_ref"]
+    assert graduation["current_stage"] == agent_spec["graduation"]["current_stage"]
+    assert set(graduation["required_gates"]) == set(test_block["expected_gates"])
+    assert graduation["target_stage"] == "L4_supervised_actuation"
+
+
+def test_graduation_has_no_blocking_lanes_for_this_fixture() -> None:
+    graduation = _load("graduation_record_0001.json")
+
+    assert graduation["blocking_lanes"] == []
+    assert graduation["promotion_window"] == "rolling_30d"
+    assert graduation["lane_scores"]["safety_policy"] >= graduation["lane_scores"]["capability"]
+    assert graduation["lane_scores"]["provenance_reproducibility"] >= 4
+
+
+def test_graduation_evidence_refs_link_to_promotion_shape() -> None:
+    graduation = _load("graduation_record_0001.json")
+    promotion = _load("promotion_decision_0001.json")
+
+    assert "promotion_decision" in graduation["evidence_refs"]
+    assert "benchmark_report" in graduation["evidence_refs"]
+    assert set(promotion["required_gates"]).issubset(set(graduation["required_gates"]))

--- a/apps/eval-fabric-api/tests/test_promotion_rollback_suite.py
+++ b/apps/eval-fabric-api/tests/test_promotion_rollback_suite.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str):
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_promotion_decision_matches_ray_lifecycle_and_gates() -> None:
+    promotion = _load("promotion_decision_0001.json")
+    ray_recipe = _load("ray_recipe_lifecycle_0001.json")
+    test_block = _load("test_block_0001.json")
+
+    assert promotion["source_ref"] == ray_recipe["recipe_ref"]
+    assert promotion["decision"] == "approved_with_gates"
+    assert promotion["target_stage"] == "L4_supervised_actuation"
+    assert set(promotion["required_gates"]) == set(test_block["expected_gates"])
+    assert "benchmark_report" in promotion["evidence_refs"]
+    assert "ray_serve_promote" in ray_recipe["lifecycle"]
+
+
+def test_rollback_record_has_required_gate_and_evidence_shape() -> None:
+    rollback = _load("rollback_record_0001.json")
+    promotion = _load("promotion_decision_0001.json")
+
+    assert rollback["trigger_ref"] == promotion["promotion_decision_id"]
+    assert rollback["status"] == "rollback_ready"
+    assert "rollback_gate" in rollback["required_gates"]
+    assert "evidence_receipt" in rollback["evidence_refs"]
+
+
+def test_promotion_and_rollback_share_governed_action_shape() -> None:
+    promotion = _load("promotion_decision_0001.json")
+    rollback = _load("rollback_record_0001.json")
+
+    common = {"authorization_gate", "scope_gate", "policy_gate", "risk_gate"}
+    assert common.issubset(set(promotion["required_gates"]))
+    assert common.issubset(set(rollback["required_gates"]))
+    assert promotion["subject_ref"].startswith("model://")
+    assert rollback["subject_ref"].startswith("service://")


### PR DESCRIPTION
## Summary

Add a focused promotion/rollback artifact fixture layer for the eval-fabric Ray lifecycle suite.

## Why

The eval-fabric lane now has:
- upstream logical-statistical testing profiles
- downstream logical-statistical suite fixtures
- a Ray lifecycle suite test module

The next narrow verification step is to make promotion and rollback artifacts explicit and testable so bounded promotion logic does not remain only implied by route-level behavior.

## Scope

Files included:
- `apps/eval-fabric-api/tests/fixtures/promotion_decision_0001.json`
- `apps/eval-fabric-api/tests/fixtures/rollback_record_0001.json`
- `apps/eval-fabric-api/tests/test_promotion_rollback_suite.py`

## What this covers

- promotion decision alignment with Ray lifecycle fixtures
- required gate expectations for promotion-path actions
- rollback artifact readiness and evidence shape
- shared governed-action requirements between promotion and rollback

## Notes

This PR is intentionally narrow. It does not add new runtime behavior; it extends the downstream suite layer so promotion and rollback become first-class tested artifacts in the eval-fabric lifecycle.
