### PR TITLE
Build: wire storage suite into repo validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke validate-fogstack
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check test-go validate-phase4 test-python-apps validate-fogstack
+validate: validate-repo drift-check standards-check topology-check test-go validate-phase4 test-python-apps validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -63,3 +63,6 @@ lampstand-vertical-slice-smoke:
 
 validate-fogstack:
 	python3 tools/validate_fogstack.py
+
+validate-storage-suite:
+	python3 tools/validate_storage_suite.py


### PR DESCRIPTION
Tiny follow-up on top of current `main`.

This PR wires the already-merged storage validation suite into the repo `Makefile` so the storage slice is exercised by the normal validation path.

Changes:
- add `validate-storage-suite` to `.PHONY`
- invoke `validate-storage-suite` from `validate`
- add `validate-storage-suite` target calling `python3 tools/validate_storage_suite.py`

This is intentionally minimal and depends on the storage slice work already merged via earlier PRs.