### PR TITLE
platform: add eval fabric graduation readiness suite fixtures

### DIFF
--- a/apps/eval-fabric-api/tests/fixtures/graduation_record_0001.json
+++ b/apps/eval-fabric-api/tests/fixtures/graduation_record_0001.json
@@ -1,0 +1,32 @@
+{
+  "graduation_record_id": "graduation_record_0001",
+  "agent_ref": "agent://socioprophet/example/retrieval-governed-operator",
+  "current_stage": "L3_assist_mode",
+  "target_stage": "L4_supervised_actuation",
+  "lane_scores": {
+    "capability": 3,
+    "safety_policy": 4,
+    "reliability_recovery": 3,
+    "observability_auditability": 4,
+    "provenance_reproducibility": 4,
+    "efficiency_budget": 3,
+    "human_oversight_acceptability": 4
+  },
+  "blocking_lanes": [],
+  "promotion_window": "rolling_30d",
+  "required_gates": [
+    "authorization_gate",
+    "scope_gate",
+    "policy_gate",
+    "risk_gate",
+    "evidence_gate",
+    "approval_gate",
+    "rollback_gate"
+  ],
+  "evidence_refs": [
+    "event_envelope",
+    "evidence_receipt",
+    "benchmark_report",
+    "promotion_decision"
+  ]
+}

--- a/apps/eval-fabric-api/tests/test_graduation_readiness_suite.py
+++ b/apps/eval-fabric-api/tests/test_graduation_readiness_suite.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str):
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_graduation_record_matches_agent_and_test_block() -> None:
+    graduation = _load("graduation_record_0001.json")
+    agent_spec = _load("agent_spec_0001.json")
+    test_block = _load("test_block_0001.json")
+
+    assert graduation["agent_ref"] == agent_spec["agent_ref"]
+    assert graduation["current_stage"] == agent_spec["graduation"]["current_stage"]
+    assert set(graduation["required_gates"]) == set(test_block["expected_gates"])
+    assert graduation["target_stage"] == "L4_supervised_actuation"
+
+
+def test_graduation_has_no_blocking_lanes_for_this_fixture() -> None:
+    graduation = _load("graduation_record_0001.json")
+
+    assert graduation["blocking_lanes"] == []
+    assert graduation["promotion_window"] == "rolling_30d"
+    assert graduation["lane_scores"]["safety_policy"] >= graduation["lane_scores"]["capability"]
+    assert graduation["lane_scores"]["provenance_reproducibility"] >= 4
+
+
+def test_graduation_evidence_refs_link_to_promotion_shape() -> None:
+    graduation = _load("graduation_record_0001.json")
+    promotion = _load("promotion_decision_0001.json")
+
+    assert "promotion_decision" in graduation["evidence_refs"]
+    assert "benchmark_report" in graduation["evidence_refs"]
+    assert set(promotion["required_gates"]).issubset(set(graduation["required_gates"]))


### PR DESCRIPTION
## Summary

Add a focused graduation-readiness artifact layer on top of the gate-activation and promotion/rollback suite work for the eval-fabric lane.

## Why

The eval-fabric suite stack now has:
- upstream logical-statistical testing profiles
- downstream logical-statistical suite fixtures
- a Ray lifecycle suite test module
- promotion and rollback artifact fixtures
- gate activation artifact fixtures

The next narrow verification step is to make graduation-readiness records explicit and test them against the already-landed agent spec, test block, and promotion artifacts.

## Scope

Files included:
- `apps/eval-fabric-api/tests/fixtures/graduation_record_0001.json`
- `apps/eval-fabric-api/tests/test_graduation_readiness_suite.py`

## What this covers

- graduation record alignment with the upstream-derived agent spec and test block
- lane-score and blocking-lane expectations
- evidence linkage between graduation and promotion artifacts

## Notes

This PR is intentionally narrow. It does not add runtime behavior; it extends the downstream suite-consumption pattern so graduation readiness becomes a first-class tested artifact in the eval-fabric lifecycle.
