### PR TITLE
apps: add openai-research-mcp runtime starter

### DIFF
--- a/apps/openai-research-mcp/README.md
+++ b/apps/openai-research-mcp/README.md
@@ -1,0 +1,31 @@
+# openai-research-mcp
+
+Runtime starter for a deep-research-compatible remote MCP service on Prophet Platform.
+
+This lane intentionally keeps **retrieval** separate from **artifact export**:
+
+- `search` and `fetch` are the MCP-facing read-only contract
+- artifact export is a separate handoff path that requires `artifacts:write`
+- public artifact payloads expose `artifact_id`, `object_key`, and optional `download_url`, not raw local paths
+
+## Layout
+
+- `research_mcp/` — auth, retrieval, audit, artifact, and service orchestration
+- `server.py` — local CLI demos and small HTTP validation surface
+- `config/` — example token and OpenAI-facing configuration
+- `data/` — example fixture corpus
+- `tests/` — smoke and service tests
+- `scripts/run_tests.sh` — compile + unittest
+- `scripts/verify_bundle.py` — checks core files are present
+
+## Local quickstart
+
+```bash
+export MCP_STATIC_TOKENS_FILE=config/static_tokens.example.json
+python server.py verify-bundle
+bash scripts/run_tests.sh
+python server.py doctor
+python server.py demo-search "canonical urls" --token reader-token
+python server.py demo-fetch doc-citations-001 --token reader-token
+python server.py demo-export --title "Sandbox report" --narrative "Narrative" --document-ids doc-citations-001 --token export-token
+```

--- a/apps/openai-research-mcp/config/openai_responses_config.example.json
+++ b/apps/openai-research-mcp/config/openai_responses_config.example.json
@@ -1,0 +1,10 @@
+{
+  "tools": [
+    {
+      "type": "mcp",
+      "server_label": "openai-research-mcp",
+      "server_url": "https://mcp.example.com",
+      "require_approval": "never"
+    }
+  ]
+}

--- a/apps/openai-research-mcp/config/static_tokens.example.json
+++ b/apps/openai-research-mcp/config/static_tokens.example.json
@@ -1,0 +1,19 @@
+{
+  "tokens": {
+    "reader-token": {
+      "subject": "reader-1",
+      "organization": "demo-org",
+      "scopes": [
+        "documents:read"
+      ]
+    },
+    "export-token": {
+      "subject": "writer-1",
+      "organization": "demo-org",
+      "scopes": [
+        "documents:read",
+        "artifacts:write"
+      ]
+    }
+  }
+}

--- a/apps/openai-research-mcp/config/widget_csp.json
+++ b/apps/openai-research-mcp/config/widget_csp.json
@@ -1,0 +1,9 @@
+{
+  "connectDomains": [
+    "https://mcp.example.com"
+  ],
+  "resourceDomains": [
+    "https://web-sandbox.oaiusercontent.com"
+  ],
+  "frameDomains": []
+}

--- a/apps/openai-research-mcp/data/example_documents.json
+++ b/apps/openai-research-mcp/data/example_documents.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "doc-citations-001",
+    "title": "Canonical URLs and citations",
+    "text": "Canonical URLs should remain stable across search, fetch, audit, and export.",
+    "url": "https://example.com/docs/canonical-urls",
+    "metadata": {
+      "topic": "citations"
+    },
+    "allowed_organizations": [
+      "demo-org"
+    ],
+    "tags": [
+      "canonical",
+      "citations"
+    ]
+  },
+  {
+    "id": "doc-sandbox-001",
+    "title": "Sandbox and workspace separation",
+    "text": "Browser sandbox, research service, and artifact workspace should be treated as separate planes.",
+    "url": "https://example.com/docs/sandbox-workspace",
+    "metadata": {
+      "topic": "sandbox"
+    },
+    "allowed_organizations": [
+      "demo-org"
+    ],
+    "tags": [
+      "sandbox",
+      "workspace"
+    ]
+  }
+]

--- a/apps/openai-research-mcp/docs/backend_adapter.md
+++ b/apps/openai-research-mcp/docs/backend_adapter.md
@@ -1,0 +1,9 @@
+# Backend adapter notes
+
+The production seam is the retrieval backend.
+
+Minimum contract:
+- `search(query, limit, auth_context) -> list[Document]`
+- `fetch(document_id, auth_context) -> Document`
+
+If an internal retrieval service already exists, keep the response shapes stable and preserve canonical URLs exactly across search, fetch, audit, and export.

--- a/apps/openai-research-mcp/pyproject.toml
+++ b/apps/openai-research-mcp/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openai-research-mcp"
+version = "0.1.0"
+description = "Prophet Platform deep-research-compatible MCP runtime starter"
+requires-python = ">=3.11"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["research_mcp*"]

--- a/apps/openai-research-mcp/research_mcp/__init__.py
+++ b/apps/openai-research-mcp/research_mcp/__init__.py
@@ -1,0 +1,2 @@
+APP_NAME = "openai-research-mcp"
+__version__ = "0.1.0"

--- a/apps/openai-research-mcp/research_mcp/artifacts.py
+++ b/apps/openai-research-mcp/research_mcp/artifacts.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from pathlib import Path
+
+from .errors import InvalidInputError
+
+
+class LocalDirectoryObjectStore:
+    def __init__(self, root: str | Path, *, public_base_url: str | None = None):
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.public_base_url = public_base_url.rstrip("/") if public_base_url else None
+
+    def _safe_name(self, name: str) -> str:
+        if ".." in name or name.startswith("/"):
+            raise InvalidInputError("unsafe object key")
+        return name
+
+    def put_text(self, relative_name: str, content: str) -> dict:
+        object_key = self._safe_name(relative_name)
+        path = self.root / object_key
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        out = {"object_key": object_key, "sha256": digest, "local_path": str(path)}
+        if self.public_base_url:
+            out["download_url"] = "{}/{}".format(self.public_base_url, object_key)
+        return out
+
+
+class MarkdownArtifactExporter:
+    def __init__(self, object_store: LocalDirectoryObjectStore):
+        self.object_store = object_store
+
+    def export_report(self, *, title: str, narrative: str, documents: list[dict]) -> dict:
+        artifact_id = "sandbox-report-artifact-{}".format(uuid.uuid4().hex[:16])
+        lines = ["# {}".format(title), "", narrative, "", "## Sources", ""]
+        for doc in documents:
+            lines.append("- {} — {}".format(doc["title"], doc["url"]))
+        body = "\n".join(lines).rstrip() + "\n"
+        stored = self.object_store.put_text("{}.md".format(artifact_id), body)
+        manifest = {
+            "artifact_id": artifact_id,
+            "object_key": stored["object_key"],
+            "sha256": stored["sha256"],
+            "sources": [{"id": d["id"], "url": d["url"]} for d in documents],
+            "local_path": stored["local_path"],
+        }
+        manifest_store = self.object_store.put_text(
+            "{}.md.manifest.json".format(artifact_id),
+            json.dumps(manifest, indent=2, sort_keys=True),
+        )
+        public = {
+            "artifact_id": artifact_id,
+            "object_key": stored["object_key"],
+            "sha256": stored["sha256"],
+            "manifest_object_key": manifest_store["object_key"],
+        }
+        if "download_url" in stored:
+            public["download_url"] = stored["download_url"]
+        return public

--- a/apps/openai-research-mcp/research_mcp/audit.py
+++ b/apps/openai-research-mcp/research_mcp/audit.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class JsonlAuditSink:
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def emit(self, payload: dict):
+        row = dict(payload)
+        row.setdefault("ts", datetime.now(timezone.utc).isoformat())
+        with self.path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, sort_keys=True) + "\n")

--- a/apps/openai-research-mcp/research_mcp/auth.py
+++ b/apps/openai-research-mcp/research_mcp/auth.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .errors import AuthError
+from .models import AuthContext
+
+
+def load_static_tokens(path: Path) -> dict[str, dict]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data.get("tokens", {})
+
+
+class StaticTokenAuthorizer:
+    def __init__(self, tokens: dict[str, dict], *, allow_anonymous_read: bool = True):
+        self.tokens = tokens
+        self.allow_anonymous_read = allow_anonymous_read
+
+    def authorize_read(self, token: str | None) -> AuthContext:
+        if token and token in self.tokens:
+            row = self.tokens[token]
+            return AuthContext(
+                subject=row.get("subject"),
+                organization=row.get("organization"),
+                scopes=tuple(row.get("scopes", [])),
+                anonymous_read=False,
+            )
+        if self.allow_anonymous_read:
+            return AuthContext(anonymous_read=True)
+        raise AuthError("missing_token")
+
+    def authorize_export(self, token: str | None) -> AuthContext:
+        if not token or token not in self.tokens:
+            raise AuthError("missing_token")
+        row = self.tokens[token]
+        ctx = AuthContext(
+            subject=row.get("subject"),
+            organization=row.get("organization"),
+            scopes=tuple(row.get("scopes", [])),
+            anonymous_read=False,
+        )
+        if "artifacts:write" not in ctx.scopes:
+            raise AuthError("missing_scope:artifacts:write")
+        return ctx

--- a/apps/openai-research-mcp/research_mcp/bundle.py
+++ b/apps/openai-research-mcp/research_mcp/bundle.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REQUIRED_RELATIVE_FILES = (
+    "README.md",
+    "server.py",
+    "pyproject.toml",
+    "research_mcp/__init__.py",
+    "research_mcp/models.py",
+    "research_mcp/errors.py",
+    "research_mcp/auth.py",
+    "research_mcp/store.py",
+    "research_mcp/service.py",
+    "research_mcp/artifacts.py",
+    "research_mcp/audit.py",
+    "config/static_tokens.example.json",
+    "config/openai_responses_config.example.json",
+    "data/example_documents.json",
+    "tests/test_smoke.py",
+)
+
+
+def bundle_integrity_report(root: str | Path) -> dict:
+    root = Path(root)
+    present = []
+    missing = []
+    for rel in REQUIRED_RELATIVE_FILES:
+        if (root / rel).exists():
+            present.append(rel)
+        else:
+            missing.append(rel)
+    return {
+        "root": str(root),
+        "required_files": list(REQUIRED_RELATIVE_FILES),
+        "present": present,
+        "missing": missing,
+        "ok": not missing,
+    }

--- a/apps/openai-research-mcp/research_mcp/errors.py
+++ b/apps/openai-research-mcp/research_mcp/errors.py
@@ -1,0 +1,29 @@
+class ResearchMcpError(Exception):
+    def __init__(self, code: str, message: str, http_status: int = 400):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.http_status = http_status
+
+    def to_dict(self):
+        return {"error": self.code, "message": self.message}
+
+
+class InvalidInputError(ResearchMcpError):
+    def __init__(self, message: str):
+        super().__init__("invalid_input", message, 400)
+
+
+class AuthError(ResearchMcpError):
+    def __init__(self, message: str = "unauthorized"):
+        super().__init__("unauthorized", message, 401)
+
+
+class ForbiddenError(ResearchMcpError):
+    def __init__(self, message: str = "forbidden"):
+        super().__init__("forbidden", message, 403)
+
+
+class DocumentNotFoundError(ResearchMcpError):
+    def __init__(self, message: str = "document not found"):
+        super().__init__("document_not_found", message, 404)

--- a/apps/openai-research-mcp/research_mcp/models.py
+++ b/apps/openai-research-mcp/research_mcp/models.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AuthContext:
+    subject: str | None = None
+    organization: str | None = None
+    scopes: tuple[str, ...] = ()
+    anonymous_read: bool = False
+
+    def has_scope(self, scope: str) -> bool:
+        return scope in self.scopes
+
+
+@dataclass(frozen=True)
+class Document:
+    id: str
+    title: str
+    text: str
+    url: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    allowed_organizations: tuple[str, ...] = ()
+    allowed_subjects: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+
+    def is_visible_to(self, auth_context: AuthContext) -> bool:
+        if self.allowed_organizations:
+            if not auth_context.organization or auth_context.organization not in self.allowed_organizations:
+                return False
+        if self.allowed_subjects:
+            if not auth_context.subject or auth_context.subject not in self.allowed_subjects:
+                return False
+        return True
+
+    def search_result(self) -> dict[str, str]:
+        return {"id": self.id, "title": self.title, "url": self.url}
+
+    def fetch_result(self) -> dict[str, Any]:
+        out = {"id": self.id, "title": self.title, "text": self.text, "url": self.url}
+        if self.metadata:
+            out["metadata"] = self.metadata
+        return out

--- a/apps/openai-research-mcp/research_mcp/service.py
+++ b/apps/openai-research-mcp/research_mcp/service.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from .audit import JsonlAuditSink
+from .auth import StaticTokenAuthorizer
+from .artifacts import MarkdownArtifactExporter
+from .store import InMemoryDocumentBackend
+
+
+class ResearchService:
+    def __init__(self, *, backend: InMemoryDocumentBackend, authorizer: StaticTokenAuthorizer, audit_sink: JsonlAuditSink, exporter: MarkdownArtifactExporter):
+        self.backend = backend
+        self.authorizer = authorizer
+        self.audit_sink = audit_sink
+        self.exporter = exporter
+
+    def search_contract(self, query: str, *, limit: int = 10, token: str | None = None) -> dict:
+        ctx = self.authorizer.authorize_read(token)
+        docs = self.backend.search(query, limit=limit, auth_context=ctx)
+        self.audit_sink.emit({
+            "event": "search",
+            "query": query,
+            "limit": limit,
+            "results": [d.id for d in docs],
+            "organization": ctx.organization,
+            "subject": ctx.subject,
+        })
+        return {"results": [doc.search_result() for doc in docs]}
+
+    def fetch_contract(self, document_id: str, *, token: str | None = None) -> dict:
+        ctx = self.authorizer.authorize_read(token)
+        doc = self.backend.fetch(document_id, auth_context=ctx)
+        self.audit_sink.emit({
+            "event": "fetch",
+            "document_id": document_id,
+            "organization": ctx.organization,
+            "subject": ctx.subject,
+            "url": doc.url,
+        })
+        return doc.fetch_result()
+
+    def export_report_handoff(self, title: str, narrative: str, document_ids: list[str], *, token: str | None = None) -> dict:
+        ctx = self.authorizer.authorize_export(token)
+        docs = [self.backend.fetch(doc_id, auth_context=ctx).fetch_result() for doc_id in document_ids]
+        payload = self.exporter.export_report(title=title, narrative=narrative, documents=docs)
+        self.audit_sink.emit({
+            "event": "export_report",
+            "artifact_id": payload["artifact_id"],
+            "document_ids": document_ids,
+            "organization": ctx.organization,
+            "subject": ctx.subject,
+        })
+        return payload

--- a/apps/openai-research-mcp/research_mcp/store.py
+++ b/apps/openai-research-mcp/research_mcp/store.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.parse import urlparse
+
+from .errors import DocumentNotFoundError, InvalidInputError
+from .models import AuthContext, Document
+
+
+def validate_canonical_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise InvalidInputError(f"invalid canonical url: {url}")
+    return parsed._replace(fragment="").geturl()
+
+
+def load_documents_from_json(path: Path) -> list[Document]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return [
+        Document(
+            id=str(item["id"]),
+            title=str(item["title"]),
+            text=str(item.get("text", "")),
+            url=validate_canonical_url(str(item["url"])),
+            metadata=dict(item.get("metadata", {})),
+            allowed_organizations=tuple(item.get("allowed_organizations", [])),
+            allowed_subjects=tuple(item.get("allowed_subjects", [])),
+            tags=tuple(item.get("tags", [])),
+        )
+        for item in data
+    ]
+
+
+class InMemoryDocumentBackend:
+    def __init__(self, documents: list[Document]):
+        self.documents = list(documents)
+        self.by_id = {doc.id: doc for doc in self.documents}
+
+    def visible_documents(self, ctx: AuthContext) -> list[Document]:
+        return [doc for doc in self.documents if doc.is_visible_to(ctx)]
+
+    def search(self, query: str, *, limit: int, auth_context: AuthContext) -> list[Document]:
+        q = query.strip().casefold()
+        if not q:
+            return []
+        scored = []
+        for doc in self.visible_documents(auth_context):
+            hay = "{}\n{}\n{}".format(doc.title, doc.text, " ".join(doc.tags)).casefold()
+            score = hay.count(q) or sum(1 for token in q.split() if token and token in hay)
+            if score:
+                scored.append((score, doc))
+        scored.sort(key=lambda item: (-item[0], item[1].title, item[1].id))
+        return [doc for _, doc in scored[:limit]]
+
+    def fetch(self, document_id: str, *, auth_context: AuthContext) -> Document:
+        if document_id not in self.by_id:
+            raise DocumentNotFoundError()
+        doc = self.by_id[document_id]
+        if not doc.is_visible_to(auth_context):
+            raise DocumentNotFoundError()
+        return doc

--- a/apps/openai-research-mcp/scripts/demo_http.sh
+++ b/apps/openai-research-mcp/scripts/demo_http.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+PORT="${PORT:-18080}"
+export MCP_STATIC_TOKENS_FILE="${MCP_STATIC_TOKENS_FILE:-config/static_tokens.example.json}"
+python server.py serve-http --host 127.0.0.1 --port "$PORT" &
+PID=$!
+trap 'kill "$PID" >/dev/null 2>&1 || true' EXIT
+for _ in $(seq 1 50); do
+  if curl -fsS "http://127.0.0.1:${PORT}/healthz" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.2
+done
+curl -sS -H "Authorization: Bearer reader-token" "http://127.0.0.1:${PORT}/search?q=canonical&limit=2"

--- a/apps/openai-research-mcp/scripts/run_tests.sh
+++ b/apps/openai-research-mcp/scripts/run_tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+python scripts/verify_bundle.py
+python -m compileall -q .
+python -m unittest discover -s tests -v

--- a/apps/openai-research-mcp/scripts/verify_bundle.py
+++ b/apps/openai-research-mcp/scripts/verify_bundle.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from research_mcp.bundle import bundle_integrity_report
+
+print(json.dumps(bundle_integrity_report(ROOT), indent=2, sort_keys=True))

--- a/apps/openai-research-mcp/server.py
+++ b/apps/openai-research-mcp/server.py
@@ -92,7 +92,7 @@ def make_handler(service: ResearchService):
                     return self._send(200, payload)
                 except ResearchMcpError as exc:
                     return self._send(exc.http_status, exc.to_dict())
-            self._send(404, {"error": "not_found"})
+            return self._send(404, {"error": "not_found"})
 
         def do_POST(self):
             parsed = urlparse(self.path)

--- a/apps/openai-research-mcp/server.py
+++ b/apps/openai-research-mcp/server.py
@@ -113,7 +113,7 @@ def make_handler(service: ResearchService):
     return Handler
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="cmd", required=True)
     sub.add_parser("verify-bundle")

--- a/apps/openai-research-mcp/server.py
+++ b/apps/openai-research-mcp/server.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from research_mcp import APP_NAME, __version__
+from research_mcp.artifacts import LocalDirectoryObjectStore, MarkdownArtifactExporter
+from research_mcp.audit import JsonlAuditSink
+from research_mcp.auth import StaticTokenAuthorizer, load_static_tokens
+from research_mcp.bundle import bundle_integrity_report
+from research_mcp.errors import ResearchMcpError
+from research_mcp.service import ResearchService
+from research_mcp.store import InMemoryDocumentBackend, load_documents_from_json
+
+ROOT = Path(__file__).resolve().parent
+
+
+def build_service() -> ResearchService:
+    docs_path = Path(os.environ.get("MCP_DOC_JSON_PATH", str(ROOT / "data" / "example_documents.json")))
+    docs = load_documents_from_json(docs_path)
+    tokens_path = Path(os.environ.get("MCP_STATIC_TOKENS_FILE", str(ROOT / "config" / "static_tokens.example.json")))
+    authorizer = StaticTokenAuthorizer(
+        load_static_tokens(tokens_path),
+        allow_anonymous_read=os.environ.get("MCP_ALLOW_ANONYMOUS_READ", "true").lower() in {"1", "true", "yes"},
+    )
+    audit_path = Path(os.environ.get("MCP_AUDIT_LOG_PATH", str(ROOT / "var" / "audit" / "events.jsonl")))
+    object_store = LocalDirectoryObjectStore(
+        ROOT / "var" / "artifacts" / "reports",
+        public_base_url=os.environ.get("MCP_PUBLIC_ARTIFACT_BASE_URL"),
+    )
+    return ResearchService(
+        backend=InMemoryDocumentBackend(docs),
+        authorizer=authorizer,
+        audit_sink=JsonlAuditSink(audit_path),
+        exporter=MarkdownArtifactExporter(object_store),
+    )
+
+
+def dump(payload):
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def doctor_payload():
+    return {
+        "app_name": APP_NAME,
+        "version": __version__,
+        "bundle_integrity": bundle_integrity_report(ROOT),
+        "expected_fixture_docs": str(ROOT / "data" / "example_documents.json"),
+        "expected_tokens": str(ROOT / "config" / "static_tokens.example.json"),
+    }
+
+
+def make_handler(service: ResearchService):
+    class Handler(BaseHTTPRequestHandler):
+        def _read_json(self):
+            length = int(self.headers.get("Content-Length", "0") or 0)
+            raw = self.rfile.read(length).decode("utf-8") if length else "{}"
+            return json.loads(raw)
+
+        def _send(self, code: int, payload):
+            body = dump(payload).encode("utf-8")
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            if parsed.path == "/healthz":
+                return self._send(200, {"ok": True})
+            if parsed.path == "/doctor":
+                return self._send(200, doctor_payload())
+            if parsed.path == "/search":
+                try:
+                    q = parse_qs(parsed.query).get("q", [""])[0]
+                    limit = int(parse_qs(parsed.query).get("limit", ["10"])[0])
+                    token = self.headers.get("Authorization", "").removeprefix("Bearer ").strip() or None
+                    payload = service.search_contract(q, limit=limit, token=token)
+                    return self._send(200, payload)
+                except ResearchMcpError as exc:
+                    return self._send(exc.http_status, exc.to_dict())
+            if parsed.path == "/fetch":
+                try:
+                    doc_id = parse_qs(parsed.query).get("id", [""])[0]
+                    token = self.headers.get("Authorization", "").removeprefix("Bearer ").strip() or None
+                    payload = service.fetch_contract(doc_id, token=token)
+                    return self._send(200, payload)
+                except ResearchMcpError as exc:
+                    return self._send(exc.http_status, exc.to_dict())
+            self._send(404, {"error": "not_found"})
+
+        def do_POST(self):
+            parsed = urlparse(self.path)
+            if parsed.path == "/export":
+                try:
+                    token = self.headers.get("Authorization", "").removeprefix("Bearer ").strip() or None
+                    body = self._read_json()
+                    payload = service.export_report_handoff(
+                        title=body["title"],
+                        narrative=body["narrative"],
+                        document_ids=body["document_ids"],
+                        token=token,
+                    )
+                    return self._send(200, payload)
+                except ResearchMcpError as exc:
+                    return self._send(exc.http_status, exc.to_dict())
+            self._send(404, {"error": "not_found"})
+    return Handler
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("verify-bundle")
+    sub.add_parser("doctor")
+
+    p = sub.add_parser("demo-search")
+    p.add_argument("query")
+    p.add_argument("--token")
+    p.add_argument("--limit", type=int, default=10)
+
+    p = sub.add_parser("demo-fetch")
+    p.add_argument("document_id")
+    p.add_argument("--token")
+
+    p = sub.add_parser("demo-export")
+    p.add_argument("--title", required=True)
+    p.add_argument("--narrative", required=True)
+    p.add_argument("--document-ids", nargs="+", required=True)
+    p.add_argument("--token")
+
+    p = sub.add_parser("serve-http")
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=18080)
+
+    args = parser.parse_args()
+    service = build_service()
+
+    if args.cmd == "verify-bundle":
+        print(dump(bundle_integrity_report(ROOT)))
+        return 0
+    if args.cmd == "doctor":
+        print(dump(doctor_payload()))
+        return 0
+    if args.cmd == "demo-search":
+        print(dump(service.search_contract(args.query, limit=args.limit, token=args.token)))
+        return 0
+    if args.cmd == "demo-fetch":
+        print(dump(service.fetch_contract(args.document_id, token=args.token)))
+        return 0
+    if args.cmd == "demo-export":
+        print(dump(service.export_report_handoff(args.title, args.narrative, args.document_ids, token=args.token)))
+        return 0
+    if args.cmd == "serve-http":
+        if not os.environ.get("MCP_PUBLIC_ARTIFACT_BASE_URL"):
+            os.environ["MCP_PUBLIC_ARTIFACT_BASE_URL"] = f"http://{args.host}:{args.port}/artifacts"
+        server = ThreadingHTTPServer((args.host, args.port), make_handler(build_service()))
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            pass
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/openai-research-mcp/server.py
+++ b/apps/openai-research-mcp/server.py
@@ -109,7 +109,7 @@ def make_handler(service: ResearchService):
                     return self._send(200, payload)
                 except ResearchMcpError as exc:
                     return self._send(exc.http_status, exc.to_dict())
-            self._send(404, {"error": "not_found"})
+            return self._send(404, {"error": "not_found"})
     return Handler
 
 

--- a/apps/openai-research-mcp/server.py
+++ b/apps/openai-research-mcp/server.py
@@ -163,6 +163,7 @@ def main() -> int:
         try:
             server.serve_forever()
         except KeyboardInterrupt:
+            # Allow Ctrl+C to stop the server without printing a traceback.
             pass
         return 0
 

--- a/apps/openai-research-mcp/tests/test_smoke.py
+++ b/apps/openai-research-mcp/tests/test_smoke.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from research_mcp.bundle import bundle_integrity_report
+from server import build_service
+
+
+class SmokeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        os.environ["MCP_AUDIT_LOG_PATH"] = str(Path(self.tmp.name) / "events.jsonl")
+        os.environ["MCP_STATIC_TOKENS_FILE"] = str(ROOT / "config" / "static_tokens.example.json")
+        os.environ["MCP_DOC_JSON_PATH"] = str(ROOT / "data" / "example_documents.json")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_bundle_ok(self):
+        report = bundle_integrity_report(ROOT)
+        self.assertTrue(report["ok"], report)
+
+    def test_search_and_fetch(self):
+        service = build_service()
+        search = service.search_contract("canonical", limit=5, token="reader-token")
+        self.assertEqual(search["results"][0]["id"], "doc-citations-001")
+        fetch = service.fetch_contract("doc-citations-001", token="reader-token")
+        self.assertEqual(fetch["id"], "doc-citations-001")
+
+    def test_export_requires_scope(self):
+        service = build_service()
+        with self.assertRaises(Exception):
+            service.export_report_handoff("t", "n", ["doc-citations-001"], token="reader-token")
+        payload = service.export_report_handoff("t", "n", ["doc-citations-001"], token="export-token")
+        self.assertIn("artifact_id", payload)
+
+    def test_cli_verify(self):
+        out = subprocess.check_output([sys.executable, "server.py", "verify-bundle"], cwd=ROOT)
+        data = json.loads(out)
+        self.assertTrue(data["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/OPENAI_RESEARCH_MCP_RUNTIME.md
+++ b/docs/OPENAI_RESEARCH_MCP_RUNTIME.md
@@ -1,0 +1,15 @@
+# OpenAI research MCP runtime lane
+
+`apps/openai-research-mcp/` is the Prophet Platform runtime starter for a deep-research-compatible remote MCP service.
+
+Why it belongs here:
+
+- it is a deployable runtime surface, not a standards-only repository concern
+- it mirrors the platform rule that deployable services belong under `apps/`
+- it keeps the read-only `search` / `fetch` research plane separate from export handoff
+
+Operational rule:
+
+1. retrieval stays read-only
+2. artifact export is separately authorized
+3. browser/widget payloads do not receive raw local filesystem paths


### PR DESCRIPTION
## Summary

Add a new runtime starter under `apps/openai-research-mcp/` for a deep-research-compatible remote MCP service.

This lands in `prophet-platform` because the repository is the runtime and deployment home for platform services, and `apps/` is the documented home for deployable runtimes.

## What is included

- `apps/openai-research-mcp/README.md`
- `apps/openai-research-mcp/server.py`
- `apps/openai-research-mcp/pyproject.toml`
- `apps/openai-research-mcp/research_mcp/` package with models, errors, auth, retrieval, audit, artifacts, service orchestration, and bundle verification
- `apps/openai-research-mcp/config/` example config for static tokens, widget CSP, and OpenAI MCP wiring
- `apps/openai-research-mcp/data/example_documents.json`
- `apps/openai-research-mcp/scripts/verify_bundle.py`
- `apps/openai-research-mcp/scripts/run_tests.sh`
- `apps/openai-research-mcp/scripts/demo_http.sh`
- `apps/openai-research-mcp/tests/test_smoke.py`
- `docs/OPENAI_RESEARCH_MCP_RUNTIME.md`

## Design constraints carried into this lane

- keep the deep-research-facing plane read-only around `search` / `fetch`
- keep artifact export as a separately authorized handoff path
- never expose raw local filesystem paths in public artifact payloads
- keep this as a runtime starter, not a standards source of truth

## Validation performed locally before upstreaming

- compileall passed for the app subtree
- `bash scripts/run_tests.sh` passed
- bundle integrity verification passed

## Notes

This PR is intentionally additive. It does not rewrite existing repo index files such as `apps/README.md` or `docs/INTEGRATION-MAP.md`; those can be updated in a follow-up once this runtime lane lands cleanly.