### PR TITLE
docs: reserve Node Commander runtime home

### DIFF
--- a/apps/node-commander/README.md
+++ b/apps/node-commander/README.md
@@ -1,0 +1,34 @@
+# node-commander
+
+Bootstrap runtime starter for the local-first SourceOS / SociOS control-node lane.
+
+## Purpose
+
+`node-commander` is the small operator-side runtime that gives the control node a concrete, deployable command surface before the larger image-generation and validation flow is fully wired.
+
+This starter is intentionally narrow. It proves the runtime home and service shape inside `prophet-platform` without pretending the full implementation is finished.
+
+## Current scope
+
+This starter owns:
+
+- `/healthz` — liveness only
+- `/readyz` — local runtime readiness only
+- `/v1/node-commander/status` — minimal local status envelope
+- `/v1/node-commander/heartbeat` — explicit bootstrap heartbeat surface
+
+## Non-goals in this starter
+
+This starter does not yet:
+
+- issue real node control commands
+- run build/promotion gates itself
+- own the canonical contract definitions
+- replace `agentplane` execution/evidence ownership
+
+## Upstream / downstream split
+
+- canonical contracts: `SourceOS-Linux/sourceos-spec`
+- workstation/bootstrap lane: `SociOS-Linux/source-os`
+- execution/evidence seam: `SocioProphet/agentplane`
+- runtime implementation: this repo

--- a/docs/NODE_COMMANDER_RUNTIME_HOME.md
+++ b/docs/NODE_COMMANDER_RUNTIME_HOME.md
@@ -1,0 +1,49 @@
+# Node Commander runtime home (v0)
+
+## Purpose
+
+This note records why `prophet-platform` is the eventual runtime and deployment home for the real `Node Commander` service.
+
+## Why this belongs here
+
+`prophet-platform` is explicitly the runtime and deployment hub for the SocioProphet platform, and its `apps/` directory is the home for deployable services.
+
+That makes this repository the correct downstream home for the production-facing `Node Commander` runtime once the implementation moves beyond the current bootstrap envelope.
+
+## Current status
+
+The current operator-side work has already proven a first local runtime envelope:
+
+- nix-darwin-managed control node on macOS
+- Podman / OCI build, push, and local run path
+- launch-agent-managed local runtime invocation
+- local-first posture for node control and pre-promotion validation
+
+But the current image is still a bootstrap placeholder, not the real service.
+
+## Decision
+
+When the real runtime is ready, it should land in this repository as an `apps/node-commander/` service rather than staying only in host-local bootstrap code.
+
+Expected runtime responsibilities include:
+
+- local or delegated node command execution
+- OCI-backed service packaging
+- explicit config/state/evidence directories
+- integration with downstream execution/evidence surfaces
+- support for build validation and image-promotion workflows
+
+## Repo split
+
+- `SourceOS-Linux/sourceos-spec`
+  - canonical ADRs and typed contracts
+- `SociOS-Linux/source-os`
+  - workstation/bootstrap application of the control-node profile
+- `SocioProphet/agentplane`
+  - execution/evidence/replay consumption seam
+- `SocioProphet/prophet-platform`
+  - real runtime/service implementation home for `Node Commander`
+
+## Immediate implication
+
+This note does **not** move the bootstrap placeholder into `prophet-platform` yet. It only freezes the eventual runtime landing zone so implementation work does not drift into the wrong repository.


### PR DESCRIPTION
Add a documentation note reserving prophet-platform as the eventual runtime/deployment home for the real Node Commander service. Documentation only.