### PR TITLE
apps: add node-commander runtime starter scaffold

### DIFF
--- a/apps/node-commander/README.md
+++ b/apps/node-commander/README.md
@@ -1,0 +1,34 @@
+# node-commander
+
+Bootstrap runtime starter for the local-first SourceOS / SociOS control-node lane.
+
+## Purpose
+
+`node-commander` is the small operator-side runtime that gives the control node a concrete, deployable command surface before the larger image-generation and validation flow is fully wired.
+
+This starter is intentionally narrow. It proves the runtime home and service shape inside `prophet-platform` without pretending the full implementation is finished.
+
+## Current scope
+
+This starter owns:
+
+- `/healthz` — liveness only
+- `/readyz` — local runtime readiness only
+- `/v1/node-commander/status` — minimal local status envelope
+- `/v1/node-commander/heartbeat` — explicit bootstrap heartbeat surface
+
+## Non-goals in this starter
+
+This starter does not yet:
+
+- issue real node control commands
+- run build/promotion gates itself
+- own the canonical contract definitions
+- replace `agentplane` execution/evidence ownership
+
+## Upstream / downstream split
+
+- canonical contracts: `SourceOS-Linux/sourceos-spec`
+- workstation/bootstrap lane: `SociOS-Linux/source-os`
+- execution/evidence seam: `SocioProphet/agentplane`
+- runtime implementation: this repo

--- a/apps/node-commander/app/main.py
+++ b/apps/node-commander/app/main.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from . import service
+
+app = FastAPI(title="Prophet Platform Node Commander", version="0.1.0")
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"status": "ok", "service": "node-commander"}
+
+
+@app.get("/readyz")
+def readyz() -> dict:
+    return {"status": "ready", "service": "node-commander"}
+
+
+@app.get("/v1/node-commander/status")
+def status() -> dict:
+    return service.get_status_view()
+
+
+@app.get("/v1/node-commander/heartbeat")
+def heartbeat() -> dict:
+    return service.get_heartbeat_view()

--- a/apps/node-commander/app/service.py
+++ b/apps/node-commander/app/service.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def get_status_view() -> dict:
+    return {
+        "service": "node-commander",
+        "mode": "bootstrap",
+        "placement_order": [
+            "local",
+            "trusted-private",
+            "attested-fog",
+            "burst-cloud"
+        ],
+        "runtime": {
+            "container_runtime": "podman",
+            "service_scope": "user"
+        },
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def get_heartbeat_view() -> dict:
+    return {
+        "service": "node-commander",
+        "heartbeat": "ok",
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/apps/node-commander/pyproject.toml
+++ b/apps/node-commander/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "node-commander"
+version = "0.1.0"
+description = "Bootstrap runtime starter for the local-first SourceOS / SociOS control-node lane"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.115,<1.0",
+  "uvicorn>=0.32,<1.0"
+]
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/apps/node-commander/tests/test_http_main.py
+++ b/apps/node-commander/tests/test_http_main.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import app.main as main
+
+client = TestClient(main.app)
+
+
+def test_healthz() -> None:
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json()["service"] == "node-commander"
+
+
+def test_readyz() -> None:
+    resp = client.get("/readyz")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ready"
+
+
+def test_status_route() -> None:
+    resp = client.get("/v1/node-commander/status")
+    assert resp.status_code == 200
+    assert resp.json()["service"] == "node-commander"
+    assert resp.json()["runtime"]["container_runtime"] == "podman"
+
+
+def test_heartbeat_route() -> None:
+    resp = client.get("/v1/node-commander/heartbeat")
+    assert resp.status_code == 200
+    assert resp.json()["heartbeat"] == "ok"


### PR DESCRIPTION
Add a minimal `apps/node-commander/` runtime starter so the service has a concrete implementation home in `prophet-platform`.

Included:
- app README
- minimal FastAPI entrypoint
- service module
- HTTP smoke tests
- starter `pyproject.toml`

This is additive and intentionally narrow.