### PR TITLE
docs: add node-commander runtime contract and container starter

### DIFF
--- a/apps/node-commander/Containerfile
+++ b/apps/node-commander/Containerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml /app/pyproject.toml
+RUN pip install --no-cache-dir fastapi uvicorn
+
+COPY app /app/app
+COPY config /app/config
+
+EXPOSE 8080
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/apps/node-commander/config/example.config.json
+++ b/apps/node-commander/config/example.config.json
@@ -1,0 +1,8 @@
+{
+  "mode": "bootstrap",
+  "control_node_profile_ref": "urn:srcos:control-node:macbook-air-operator-01",
+  "node_commander_runtime_ref": "urn:srcos:node-commander:runtime:macbook-air-operator-01",
+  "promotion_gate_ref": "urn:srcos:image-gate:sourceos-workstation-v0-dev",
+  "evidence_dir": "/var/lib/node-commander/evidence",
+  "image_ref": "us-central1-docker.pkg.dev/socioprophet-web/node-commander/node-commander:dev-boot"
+}

--- a/docs/NODE_COMMANDER_RUNTIME_CONTRACT.md
+++ b/docs/NODE_COMMANDER_RUNTIME_CONTRACT.md
@@ -1,0 +1,58 @@
+# Node Commander runtime contract (v0)
+
+## Purpose
+
+This note captures the first concrete runtime contract for the `apps/node-commander/` lane.
+
+It is intentionally narrow and matches the current bootstrap reality:
+
+- local-first operator/control-node runtime
+- Podman / OCI packaging
+- user-scoped service execution on the control node
+- explicit config, state, and log paths
+
+## Runtime identity
+
+- service name: `node-commander`
+- canonical app path: `apps/node-commander/`
+- canonical HTTP entrypoint: `app.main`
+- current mode: `bootstrap`
+
+## Expected packaging
+
+The runtime should support both:
+
+1. local Python service execution for development
+2. OCI image packaging for operator-node deployment and promotion tests
+
+The current preferred container runtime assumption is Podman/OCI.
+
+## Runtime directories
+
+The first contract shape assumes three host-visible paths:
+
+- config: `/etc/node-commander`
+- state: `/var/lib/node-commander`
+- logs: `/tmp/node-commander.log` and `/tmp/node-commander.err.log` during bootstrap, with a later move to a repo-governed or platform-governed destination
+
+## Configuration surface
+
+The runtime should accept, at minimum:
+
+- `mode` (`bootstrap`, later `service`)
+- `control_node_profile_ref`
+- `promotion_gate_ref`
+- `evidence_dir`
+- `image_ref`
+
+## Immediate non-goals
+
+This v0 contract does not yet require:
+
+- remote executor dispatch
+- full image-promotion policy enforcement
+- direct Git repo mutation
+- full CloudShell semantics
+- attested fog scheduling
+
+Those remain downstream follow-on slices.


### PR DESCRIPTION
Stacked on top of PR #85.

Add the next narrow runtime slice for `apps/node-commander/`:
- runtime contract note
- example config
- starter Containerfile

This remains additive and bootstrap-oriented.