### PR TITLE
platform: add Liberty Stack and M2 runtime consumer lane

### DIFF
--- a/apps/liberty-stack-readout/README.md
+++ b/apps/liberty-stack-readout/README.md
@@ -1,0 +1,20 @@
+# Liberty Stack readout app
+
+This app is the first thin operator-facing surface for the Liberty Stack runtime lane.
+
+## Purpose
+
+Expose a minimal HTTP readout for:
+- Liberty Stack receipts
+- verification records
+- workflow event refs
+- a summarized subject status view
+
+## First endpoints
+
+- `/healthz`
+- `/v1/liberty-stack/readout`
+
+## Current status
+
+This is intentionally minimal and file-backed. It is a thin surface over the receipt and readout helpers already landed in the repo.

--- a/contracts/liberty-stack/events/cutover.approved.v0.schema.json
+++ b/contracts/liberty-stack/events/cutover.approved.v0.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "cutover.approved.v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event_id", "emitted_at", "subject_ref", "approval_ref"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "emitted_at": {"type": "string"},
+    "subject_ref": {"type": "string"},
+    "approval_ref": {"type": "string"},
+    "decision_record_ref": {"type": ["string", "null"]}
+  }
+}

--- a/contracts/liberty-stack/events/manifest.validated.v0.schema.json
+++ b/contracts/liberty-stack/events/manifest.validated.v0.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "manifest.validated.v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event_id", "emitted_at", "manifest_id", "status"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "emitted_at": {"type": "string"},
+    "manifest_id": {"type": "string"},
+    "status": {"enum": ["pass", "warn", "fail"]},
+    "receipt_ref": {"type": ["string", "null"]}
+  }
+}

--- a/contracts/liberty-stack/events/replay.completed.v0.schema.json
+++ b/contracts/liberty-stack/events/replay.completed.v0.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "replay.completed.v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event_id", "emitted_at", "subject_ref", "status"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "emitted_at": {"type": "string"},
+    "subject_ref": {"type": "string"},
+    "status": {"enum": ["pass", "warn", "fail"]},
+    "verification_record_ref": {"type": ["string", "null"]}
+  }
+}

--- a/contracts/liberty-stack/events/replay.requested.v0.schema.json
+++ b/contracts/liberty-stack/events/replay.requested.v0.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "replay.requested.v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event_id", "emitted_at", "subject_ref", "replay_window_ref"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "emitted_at": {"type": "string"},
+    "subject_ref": {"type": "string"},
+    "replay_window_ref": {"type": "string"},
+    "reason": {"type": ["string", "null"]}
+  }
+}

--- a/contracts/liberty-stack/receipts/liberty-stack-receipt.v0.schema.json
+++ b/contracts/liberty-stack/receipts/liberty-stack-receipt.v0.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "liberty-stack-receipt.v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["status", "action", "subject_ref"],
+  "properties": {
+    "status": {"enum": ["succeeded", "failed", "blocked"]},
+    "action": {"type": "string"},
+    "subject_ref": {"type": "string"},
+    "evidence_bundle_ref": {"type": ["string", "null"]},
+    "verification_record_ref": {"type": ["string", "null"]},
+    "notes": {"type": ["string", "null"]}
+  }
+}

--- a/docs/LIBERTY_STACK_EVIDENCE_READOUT.md
+++ b/docs/LIBERTY_STACK_EVIDENCE_READOUT.md
@@ -1,0 +1,30 @@
+# Liberty Stack evidence readout
+
+## Purpose
+
+This note defines the first thin operator-visible readout surface for the Liberty Stack lane in `prophet-platform`.
+
+It is intentionally simple: the goal is to make receipts, verification records, and workflow events inspectable before a larger operator UI exists.
+
+## Minimum visible artifacts
+
+A first readout surface SHOULD show:
+- action receipts
+- verification record refs
+- evidence bundle refs
+- replay request and replay completion events
+- cutover approval events
+- current status for a selected subject
+
+## First readout questions
+
+For any selected subject, the surface SHOULD make it easy to answer:
+1. what action was attempted
+2. whether it succeeded, failed, or was blocked
+3. which evidence bundle supports the current state
+4. whether replay was requested and how it completed
+5. whether cutover approval exists
+
+## Deliberate limits
+
+This first readout note does not require a full UI implementation. A CLI, JSON view, or thin HTTP surface is acceptable in the first runtime slice as long as the evidence and workflow state are operator-visible.

--- a/docs/LIBERTY_STACK_PLATFORM_LANE.md
+++ b/docs/LIBERTY_STACK_PLATFORM_LANE.md
@@ -1,0 +1,45 @@
+# Liberty Stack platform lane
+
+## Purpose
+
+This document defines the first runtime-facing platform lane for Liberty Stack inside `prophet-platform`.
+
+The upstream normative profiles and schemas live in `SocioProphet/socioprophet-agent-standards` under the AgentOS, M2 adapter IPC, and Liberty Stack contract family.
+
+This repository is the downstream runtime and operator home for:
+- provider adapter execution
+- verification and replay execution
+- cutover workflow handling
+- operator-facing evidence surfaces
+
+## Scope of this lane
+
+This platform lane is responsible for consuming the upstream standards and turning them into:
+- repo-native validators
+- runtime helpers and emitters
+- event contracts for workflow execution
+- operator runbooks and evidence surfaces
+
+## Upstream dependencies
+
+This lane assumes upstream standards for:
+- `AGENTOS_SPEC_0001`
+- `M2_ADAPTER_IPC_PROFILE_0001`
+- `LIBERTY_STACK_PROFILE_0001`
+
+## First runtime concerns
+
+The first runtime slice should cover:
+1. manifest validation
+2. provider adapter invocation and receipts
+3. replay and verification execution
+4. cutover approval recording
+
+## Deliberate limits
+
+This first lane note does not yet define:
+- full UI implementation
+- Linux packaging or bootstrap behavior
+- provider-specific adapters
+
+Those remain downstream follow-on work after this lane shape is accepted.

--- a/docs/M2_WORKSTATION_ADAPTER_RUNTIME.md
+++ b/docs/M2_WORKSTATION_ADAPTER_RUNTIME.md
@@ -1,0 +1,31 @@
+# M2 workstation adapter runtime
+
+## Purpose
+
+This note records how `prophet-platform` should consume the upstream M2 adapter IPC contract family.
+
+The upstream semantic source of truth is `M2_ADAPTER_IPC_PROFILE_0001` in `SocioProphet/socioprophet-agent-standards`.
+
+## Runtime expectations
+
+A runtime consuming M2 should be able to:
+- read adapter capability declarations
+- validate adapter message shape
+- record adapter receipts and failures
+- expose adapter results to operator-visible evidence surfaces
+
+## Core operations expected in the first runtime slice
+
+- `info`
+- `lock_validate`
+- `lock_hash`
+- `env_realize`
+- `task_run`
+- `deps_inventory`
+
+## Downstream implementation rules
+
+1. `prophet-platform` should not redefine the upstream M2 message grammar.
+2. Runtime helpers should validate and emit payloads that conform to the upstream schemas.
+3. Operator-facing surfaces should preserve error codes and receipt references rather than collapsing them into unstructured log text.
+4. Any platform-local helper should remain additive and runtime-facing, not a second standards source of truth.

--- a/tools/demo_liberty_stack_runtime.py
+++ b/tools/demo_liberty_stack_runtime.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(*args: str) -> None:
+    subprocess.run([sys.executable, *args], cwd=ROOT, check=True)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        manifest = tmpdir / "manifest.json"
+        receipt = tmpdir / "receipt.json"
+        event = tmpdir / "manifest.validated.event.json"
+        readout = tmpdir / "readout.json"
+
+        manifest.write_text(
+            json.dumps(
+                {
+                    "manifest_id": "manifest://liberty-stack/demo/0001",
+                    "owner_ref": "actor://demo/operator",
+                    "datasets": [
+                        {
+                            "dataset_id": "dataset://demo/docs",
+                            "provider": "demo",
+                            "service": "files",
+                            "target_format": "portable_bundle",
+                            "verification_method": "count_hash_metadata_review",
+                        }
+                    ],
+                },
+                indent=2,
+            ) + "\n",
+            encoding="utf-8",
+        )
+
+        run("tools/validate_liberty_stack_manifest.py", "--manifest", str(manifest))
+        run(
+            "tools/emit_liberty_stack_receipt.py",
+            "--action",
+            "validate_manifest",
+            "--subject-ref",
+            "manifest://liberty-stack/demo/0001",
+            "--status",
+            "succeeded",
+            "--output",
+            str(receipt),
+        )
+        run(
+            "tools/emit_manifest_validated_event.py",
+            "--manifest-id",
+            "manifest://liberty-stack/demo/0001",
+            "--status",
+            "pass",
+            "--receipt-ref",
+            str(receipt),
+            "--output",
+            str(event),
+        )
+
+        rendered = subprocess.check_output(
+            [
+                sys.executable,
+                "tools/render_liberty_stack_readout.py",
+                "--receipt",
+                str(receipt),
+                "--event",
+                str(event),
+            ],
+            cwd=ROOT,
+            text=True,
+        )
+        readout.write_text(rendered, encoding="utf-8")
+        print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/emit_liberty_stack_receipt.py
+++ b/tools/emit_liberty_stack_receipt.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Liberty Stack workflow receipt")
+    parser.add_argument("--action", required=True)
+    parser.add_argument("--subject-ref", required=True)
+    parser.add_argument("--status", required=True, choices=["succeeded", "failed", "blocked"])
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    receipt = {
+        "status": args.status,
+        "action": args.action,
+        "subject_ref": args.subject_ref,
+    }
+
+    text = json.dumps(receipt, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/emit_manifest_validated_event.py
+++ b/tools/emit_manifest_validated_event.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Liberty Stack manifest.validated event")
+    parser.add_argument("--manifest-id", required=True)
+    parser.add_argument("--status", required=True, choices=["pass", "warn", "fail"])
+    parser.add_argument("--receipt-ref", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    event = {
+        "event_id": f"event://liberty-stack/{args.manifest_id}/manifest-validated",
+        "emitted_at": "2026-04-17T00:00:00Z",
+        "manifest_id": args.manifest_id,
+        "status": args.status,
+        "receipt_ref": args.receipt_ref,
+    }
+
+    text = json.dumps(event, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/render_liberty_stack_readout.py
+++ b/tools/render_liberty_stack_readout.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render a thin Liberty Stack evidence readout")
+    parser.add_argument("--receipt", type=Path, required=True)
+    parser.add_argument("--verification", type=Path, default=None)
+    parser.add_argument("--event", type=Path, action="append", default=[])
+    args = parser.parse_args()
+
+    receipt = load_json(args.receipt)
+    verification = load_json(args.verification) if args.verification else None
+    events = [load_json(path) for path in args.event]
+
+    readout = {
+        "subject_ref": receipt.get("subject_ref"),
+        "action": receipt.get("action"),
+        "status": receipt.get("status"),
+        "evidence_bundle_ref": receipt.get("evidence_bundle_ref"),
+        "verification": verification,
+        "events": events,
+    }
+    print(json.dumps(readout, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_liberty_stack_runtime_demo.py
+++ b/tools/test_liberty_stack_runtime_demo.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    output = subprocess.check_output(
+        [sys.executable, "tools/demo_liberty_stack_runtime.py"],
+        cwd=ROOT,
+        text=True,
+    )
+    payload = json.loads(output)
+    assert payload["action"] == "validate_manifest"
+    assert payload["status"] == "succeeded"
+    assert payload["subject_ref"] == "manifest://liberty-stack/demo/0001"
+    print(json.dumps({"ok": True, "subject_ref": payload["subject_ref"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_liberty_stack_manifest.py
+++ b/tools/validate_liberty_stack_manifest.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a Liberty Stack manifest shape")
+    parser.add_argument("--manifest", required=True, type=Path)
+    args = parser.parse_args()
+
+    payload = json.loads(args.manifest.read_text(encoding="utf-8"))
+    required_top = ["manifest_id", "owner_ref", "datasets"]
+    missing = [k for k in required_top if k not in payload]
+    if missing:
+        print(json.dumps({"ok": False, "missing": missing}))
+        return 2
+
+    if not isinstance(payload.get("datasets"), list) or not payload["datasets"]:
+        print(json.dumps({"ok": False, "error": "datasets must be a non-empty list"}))
+        return 2
+
+    first = payload["datasets"][0]
+    dataset_required = ["dataset_id", "provider", "service", "target_format", "verification_method"]
+    dataset_missing = [k for k in dataset_required if k not in first]
+    if dataset_missing:
+        print(json.dumps({"ok": False, "dataset_missing": dataset_missing}))
+        return 2
+
+    print(json.dumps({"ok": True, "manifest_id": payload["manifest_id"], "datasets": len(payload["datasets"])}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This draft PR adds the first downstream runtime-consumer tranche for the newly merged upstream AgentOS / Liberty Stack / M2 standards work.

It lands a thin but real platform slice that:
- reserves a Liberty Stack runtime lane in `prophet-platform`
- defines how `prophet-platform` should consume the upstream M2 adapter IPC family
- adds a first manifest validator helper
- adds the first Liberty Stack workflow event contracts for replay and cutover

## What this PR adds

### Docs
- `docs/LIBERTY_STACK_PLATFORM_LANE.md`
- `docs/M2_WORKSTATION_ADAPTER_RUNTIME.md`

### Tools
- `tools/validate_liberty_stack_manifest.py`

### Contracts
- `contracts/liberty-stack/events/replay.requested.v0.schema.json`
- `contracts/liberty-stack/events/replay.completed.v0.schema.json`
- `contracts/liberty-stack/events/cutover.approved.v0.schema.json`

## Why this shape

The upstream standards tranche is now merged in `socioprophet-agent-standards`.

This repo is the downstream runtime and operator home, so the first platform responsibility is not to redefine those standards. It is to:
1. consume them explicitly
2. validate their machine-readable payloads
3. expose workflow contracts that runtime helpers and operator surfaces can use

## Review focus

1. Is this the right minimal runtime-consumer slice for the newly merged standards tranche?
2. Are the first workflow event contracts scoped correctly for replay and cutover execution?
3. Should the next platform slice add emitters/receipts first, or a thin operator service first?

## Intentional limits

This draft does **not** yet add:
- provider-specific adapters
- operator UI implementation
- Linux substrate packaging
- full receipt/evidence emission helpers

Those should follow after this lane shape is accepted.
