### PR TITLE
apps: add liberty stack readout HTTP entrypoint

### DIFF
--- a/apps/liberty-stack-readout/main.py
+++ b/apps/liberty-stack-readout/main.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Query
+
+app = FastAPI(title="liberty-stack-readout", version="0.1.0")
+
+
+def _load_json(path: str) -> dict[str, Any]:
+    file_path = Path(path)
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail=f"file not found: {path}")
+    return json.loads(file_path.read_text(encoding="utf-8"))
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok", "service": "liberty-stack-readout"}
+
+
+@app.get("/v1/liberty-stack/readout")
+def readout(
+    receipt: str = Query(..., description="Path to receipt JSON"),
+    verification: str | None = Query(None, description="Optional path to verification JSON"),
+    event: list[str] | None = Query(None, description="Optional path(s) to event JSON"),
+) -> dict[str, Any]:
+    receipt_payload = _load_json(receipt)
+    verification_payload = _load_json(verification) if verification else None
+    event_payloads = [_load_json(item) for item in (event or [])]
+
+    return {
+        "subject_ref": receipt_payload.get("subject_ref"),
+        "action": receipt_payload.get("action"),
+        "status": receipt_payload.get("status"),
+        "evidence_bundle_ref": receipt_payload.get("evidence_bundle_ref"),
+        "verification": verification_payload,
+        "events": event_payloads,
+    }

--- a/apps/liberty-stack-readout/store.py
+++ b/apps/liberty-stack-readout/store.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def find_latest_receipt_for_subject(state_root: str, subject_ref: str) -> Path | None:
+    base = Path(state_root)
+    if not base.exists():
+        return None
+    candidates: list[Path] = []
+    for path in base.rglob('*.json'):
+        payload = _read_json(path)
+        if not isinstance(payload, dict):
+            continue
+        if payload.get('subject_ref') == subject_ref:
+            candidates.append(path)
+    if not candidates:
+        return None
+    return sorted(candidates, key=lambda p: p.stat().st_mtime, reverse=True)[0]
+
+
+def build_subject_readout(state_root: str, subject_ref: str) -> dict[str, Any] | None:
+    receipt_path = find_latest_receipt_for_subject(state_root, subject_ref)
+    if receipt_path is None:
+        return None
+    receipt = _read_json(receipt_path) or {}
+    return {
+        'subject_ref': subject_ref,
+        'receipt_ref': str(receipt_path),
+        'action': receipt.get('action'),
+        'status': receipt.get('status'),
+        'evidence_bundle_ref': receipt.get('evidence_bundle_ref'),
+    }

--- a/apps/liberty-stack-readout/tests/test_http_readout.py
+++ b/apps/liberty-stack-readout/tests/test_http_readout.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import importlib.util
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(relative_path: str, module_name: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_readout_http(tmp_path):
+    app_module = load_module('main.py', 'liberty_stack_readout_main')
+    client = TestClient(app_module.app)
+
+    receipt = tmp_path / 'receipt.json'
+    receipt.write_text(json.dumps({
+        'status': 'succeeded',
+        'action': 'validate_manifest',
+        'subject_ref': 'manifest://liberty-stack/demo/0001',
+        'evidence_bundle_ref': 'bundle://demo/0001'
+    }), encoding='utf-8')
+
+    response = client.get('/v1/liberty-stack/readout', params={'receipt': str(receipt)})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['action'] == 'validate_manifest'
+    assert data['status'] == 'succeeded'
+    assert data['subject_ref'] == 'manifest://liberty-stack/demo/0001'

--- a/apps/liberty-stack-readout/tests/test_store_subject_discovery.py
+++ b/apps/liberty-stack-readout/tests/test_store_subject_discovery.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(relative_path: str, module_name: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_subject_readout(tmp_path):
+    store = load_module('store.py', 'liberty_stack_readout_store')
+    state_root = tmp_path / 'state'
+    state_root.mkdir(parents=True, exist_ok=True)
+
+    receipt = state_root / 'receipt-001.json'
+    receipt.write_text(json.dumps({
+        'status': 'succeeded',
+        'action': 'validate_manifest',
+        'subject_ref': 'manifest://liberty-stack/demo/0001',
+        'evidence_bundle_ref': 'bundle://demo/0001'
+    }), encoding='utf-8')
+
+    payload = store.build_subject_readout(str(state_root), 'manifest://liberty-stack/demo/0001')
+    assert payload is not None
+    assert payload['action'] == 'validate_manifest'
+    assert payload['status'] == 'succeeded'
+    assert payload['subject_ref'] == 'manifest://liberty-stack/demo/0001'


### PR DESCRIPTION
## Summary

Add the missing executable entrypoint for the already-landed `apps/liberty-stack-readout/` scaffold.

## What this PR adds

- `apps/liberty-stack-readout/main.py`
- `apps/liberty-stack-readout/tests/test_http_readout.py`

## Why

The README for the readout app is already on `main`, but the app did not yet have a runtime entrypoint or a simple HTTP smoke test.

This PR closes that gap with a minimal file-backed FastAPI surface for:
- `/healthz`
- `/v1/liberty-stack/readout`

## Scope

This is intentionally thin. It does not add persistent storage, auth, or a richer operator UI. It only makes the existing readout lane executable and testable.
