### PR TITLE
feat(platform): add SourceOS OS build consumer release descriptor

### DIFF
--- a/releases/sourceos.osbuild-v1.release.json
+++ b/releases/sourceos.osbuild-v1.release.json
@@ -1,0 +1,51 @@
+{
+  "apiVersion": "prophet-platform.socioprophet.org/v1alpha1",
+  "kind": "PlatformReleaseDescriptor",
+  "metadata": {
+    "name": "sourceos-osbuild-v1",
+    "status": "draft"
+  },
+  "spec": {
+    "summary": "Consumer-side release descriptor for the SourceOS OS build / cybernetic boundary tranche.",
+    "dependsOn": {
+      "contracts": {
+        "repo": "SourceOS-Linux/sourceos-spec",
+        "mergeCommit": "025ebc02dcf6eeeb21340804fb5e60fe30cc7be8",
+        "objects": [
+          "OSImage",
+          "NodeBinding",
+          "CyberneticAssignment"
+        ]
+      },
+      "platformStandardsPr": {
+        "repo": "SocioProphet/prophet-platform-standards",
+        "number": 7
+      },
+      "policyFabricPr": {
+        "repo": "SocioProphet/policy-fabric",
+        "number": 20
+      },
+      "agentplanePr": {
+        "repo": "SocioProphet/agentplane",
+        "number": 40
+      }
+    },
+    "consume": {
+      "lockUpdatePending": true,
+      "lockTarget": "standards.lock.yaml",
+      "generatedArtifacts": [
+        "contracts/identity/",
+        "contracts/evidence/"
+      ],
+      "runtimeTargets": [
+        "apps/agentplane",
+        "apps/workspace-controller",
+        "apps/identity-prime"
+      ]
+    },
+    "notes": [
+      "This descriptor is intentionally draft-only until the sourceos-spec seam receives any final catalog/API polish.",
+      "The standards.lock pin update should be the last merge in the train."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This draft PR stages the first `prophet-platform` consumer artifact for the SourceOS OS build / cybernetic boundary rollout.

It adds:

- `releases/sourceos.osbuild-v1.release.json`

## Intent

The goal is to record the dependency chain and release ordering for the OS build / cybernetic boundary tranche inside the runtime/deployment hub without mutating `standards.lock.yaml` yet.

## Why this is draft-only

The upstream seam exists now (`SourceOS-Linux/sourceos-spec` PR #26 merged), but the lock pin should still be the **last** merge in the train after any follow-on contract-polish patch settles.

This PR therefore records the consumer dependency chain while deliberately leaving `standards.lock.yaml` untouched.

## Current dependency chain

- upstream contracts: `SourceOS-Linux/sourceos-spec` merge commit `025ebc02dcf6eeeb21340804fb5e60fe30cc7be8`
- platform interpretation: `SocioProphet/prophet-platform-standards` PR #7
- control-repo gates: `SocioProphet/policy-fabric` PR #20
- runtime validation: `SocioProphet/agentplane` PR #40

## What this PR does not do yet

- no `standards.lock.yaml` update yet
- no generated artifact import yet
- no app wiring yet

Those should follow only after the upstream seam and immediate downstream consumers are stable.
