### PR TITLE
apps: add Liberty Stack subject readout HTTP surface

### DIFF
--- a/apps/liberty-stack-readout/subject_readout.py
+++ b/apps/liberty-stack-readout/subject_readout.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException, Query
+
+from store import build_subject_readout
+
+app = FastAPI(title="liberty-stack-subject-readout", version="0.1.0")
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok", "service": "liberty-stack-subject-readout"}
+
+
+@app.get("/v1/liberty-stack/by-subject")
+def by_subject(
+    state_root: str = Query(..., description="Root directory to search for receipt JSON"),
+    subject_ref: str = Query(..., description="Subject to resolve from local state"),
+) -> dict:
+    payload = build_subject_readout(state_root, subject_ref)
+    if payload is None:
+        raise HTTPException(status_code=404, detail="subject not found")
+    return payload

--- a/apps/liberty-stack-readout/tests/test_subject_http_readout.py
+++ b/apps/liberty-stack-readout/tests/test_subject_http_readout.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import importlib.util
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(relative_path: str, module_name: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_subject_http_readout(tmp_path):
+    app_module = load_module('subject_readout.py', 'liberty_stack_subject_readout')
+    client = TestClient(app_module.app)
+
+    state_root = tmp_path / 'state'
+    state_root.mkdir(parents=True, exist_ok=True)
+    receipt = state_root / 'receipt-001.json'
+    receipt.write_text(json.dumps({
+        'status': 'succeeded',
+        'action': 'validate_manifest',
+        'subject_ref': 'manifest://liberty-stack/demo/0001',
+        'evidence_bundle_ref': 'bundle://demo/0001'
+    }), encoding='utf-8')
+
+    response = client.get('/v1/liberty-stack/by-subject', params={
+        'state_root': str(state_root),
+        'subject_ref': 'manifest://liberty-stack/demo/0001'
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data['action'] == 'validate_manifest'
+    assert data['status'] == 'succeeded'
+    assert data['subject_ref'] == 'manifest://liberty-stack/demo/0001'


### PR DESCRIPTION
## Summary

Add the subject-driven companion surface for the already-merged Liberty Stack readout app.

## What this PR adds

- `apps/liberty-stack-readout/subject_readout.py`
- `apps/liberty-stack-readout/tests/test_subject_http_readout.py`

## Why

The current readout app on `main` already supports explicit path-driven readout.
What it did not yet expose over HTTP was the subject-driven discovery path built on the store helper.

This PR closes that gap with a thin companion HTTP entrypoint:
- `/healthz`
- `/v1/liberty-stack/by-subject`

## Scope

This remains intentionally thin and additive. It does not replace the existing readout entrypoint; it adds the missing subject-oriented operator path on top of it.
