### PR TITLE
apps: add Liberty Stack subject readout HTTP surface (rebased)

### DIFF
--- a/apps/liberty-stack-readout/combined_readout.py
+++ b/apps/liberty-stack-readout/combined_readout.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Query
+
+from store import build_subject_readout
+
+app = FastAPI(title="liberty-stack-combined-readout", version="0.1.0")
+
+
+def _load_json(path: str) -> dict[str, Any]:
+    file_path = Path(path)
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail=f"file not found: {path}")
+    return json.loads(file_path.read_text(encoding="utf-8"))
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok", "service": "liberty-stack-combined-readout"}
+
+
+@app.get("/v1/liberty-stack/readout")
+def readout(
+    receipt: str | None = Query(None, description="Optional path to receipt JSON"),
+    verification: str | None = Query(None, description="Optional path to verification JSON"),
+    event: list[str] | None = Query(None, description="Optional path(s) to event JSON"),
+    state_root: str | None = Query(None, description="Optional root directory to search for receipt JSON"),
+    subject_ref: str | None = Query(None, description="Optional subject to resolve from local state"),
+) -> dict[str, Any]:
+    if receipt is not None:
+        receipt_payload = _load_json(receipt)
+        verification_payload = _load_json(verification) if verification else None
+        event_payloads = [_load_json(item) for item in (event or [])]
+        return {
+            "subject_ref": receipt_payload.get("subject_ref"),
+            "action": receipt_payload.get("action"),
+            "status": receipt_payload.get("status"),
+            "evidence_bundle_ref": receipt_payload.get("evidence_bundle_ref"),
+            "verification": verification_payload,
+            "events": event_payloads,
+        }
+
+    if state_root is not None and subject_ref is not None:
+        payload = build_subject_readout(state_root, subject_ref)
+        if payload is None:
+            raise HTTPException(status_code=404, detail="subject not found")
+        return payload
+
+    raise HTTPException(status_code=400, detail="provide either receipt=... or state_root=... with subject_ref=...")

--- a/apps/liberty-stack-readout/subject_cli.py
+++ b/apps/liberty-stack-readout/subject_cli.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from store import build_subject_readout
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render a Liberty Stack subject readout from local state")
+    parser.add_argument("--state-root", required=True)
+    parser.add_argument("--subject-ref", required=True)
+    args = parser.parse_args()
+
+    payload = build_subject_readout(args.state_root, args.subject_ref)
+    if payload is None:
+        print(json.dumps({"ok": False, "error": "subject not found"}))
+        return 2
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/liberty-stack-readout/subject_readout.py
+++ b/apps/liberty-stack-readout/subject_readout.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException, Query
+
+from store import build_subject_readout
+
+app = FastAPI(title="liberty-stack-subject-readout", version="0.1.0")
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok", "service": "liberty-stack-subject-readout"}
+
+
+@app.get("/v1/liberty-stack/by-subject")
+def by_subject(
+    state_root: str = Query(..., description="Root directory to search for receipt JSON"),
+    subject_ref: str = Query(..., description="Subject to resolve from local state"),
+) -> dict:
+    payload = build_subject_readout(state_root, subject_ref)
+    if payload is None:
+        raise HTTPException(status_code=404, detail="subject not found")
+    return payload

--- a/apps/liberty-stack-readout/tests/test_combined_readout.py
+++ b/apps/liberty-stack-readout/tests/test_combined_readout.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import importlib.util
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(relative_path: str, module_name: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_combined_readout_by_subject(tmp_path):
+    app_module = load_module('combined_readout.py', 'liberty_stack_combined_readout')
+    client = TestClient(app_module.app)
+
+    state_root = tmp_path / 'state'
+    state_root.mkdir(parents=True, exist_ok=True)
+    receipt = state_root / 'receipt-001.json'
+    receipt.write_text(json.dumps({
+        'status': 'succeeded',
+        'action': 'validate_manifest',
+        'subject_ref': 'manifest://liberty-stack/demo/0001',
+        'evidence_bundle_ref': 'bundle://demo/0001'
+    }), encoding='utf-8')
+
+    response = client.get('/v1/liberty-stack/readout', params={
+        'state_root': str(state_root),
+        'subject_ref': 'manifest://liberty-stack/demo/0001'
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data['action'] == 'validate_manifest'
+    assert data['status'] == 'succeeded'
+
+
+def test_combined_readout_missing_args():
+    app_module = load_module('combined_readout.py', 'liberty_stack_combined_readout_missing')
+    client = TestClient(app_module.app)
+    response = client.get('/v1/liberty-stack/readout')
+    assert response.status_code == 400

--- a/apps/liberty-stack-readout/tests/test_combined_readout_receipt_mode.py
+++ b/apps/liberty-stack-readout/tests/test_combined_readout_receipt_mode.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import importlib.util
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(relative_path: str, module_name: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_combined_readout_by_receipt(tmp_path):
+    app_module = load_module('combined_readout.py', 'liberty_stack_combined_readout_receipt')
+    client = TestClient(app_module.app)
+
+    receipt = tmp_path / 'receipt.json'
+    receipt.write_text(json.dumps({
+        'status': 'succeeded',
+        'action': 'validate_manifest',
+        'subject_ref': 'manifest://liberty-stack/demo/0001',
+        'evidence_bundle_ref': 'bundle://demo/0001'
+    }), encoding='utf-8')
+
+    response = client.get('/v1/liberty-stack/readout', params={'receipt': str(receipt)})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['action'] == 'validate_manifest'
+    assert data['status'] == 'succeeded'
+    assert data['subject_ref'] == 'manifest://liberty-stack/demo/0001'

--- a/apps/liberty-stack-readout/tests/test_subject_cli_helper.py
+++ b/apps/liberty-stack-readout/tests/test_subject_cli_helper.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_subject_cli(tmp_path):
+    state_root = tmp_path / 'state'
+    state_root.mkdir(parents=True, exist_ok=True)
+    receipt = state_root / 'receipt-001.json'
+    receipt.write_text(json.dumps({
+        'status': 'succeeded',
+        'action': 'validate_manifest',
+        'subject_ref': 'manifest://liberty-stack/demo/0001',
+        'evidence_bundle_ref': 'bundle://demo/0001'
+    }), encoding='utf-8')
+
+    output = subprocess.check_output(
+        [
+            sys.executable,
+            'subject_cli.py',
+            '--state-root',
+            str(state_root),
+            '--subject-ref',
+            'manifest://liberty-stack/demo/0001',
+        ],
+        cwd=ROOT,
+        text=True,
+    )
+    payload = json.loads(output)
+    assert payload['action'] == 'validate_manifest'
+    assert payload['status'] == 'succeeded'
+    assert payload['subject_ref'] == 'manifest://liberty-stack/demo/0001'

--- a/apps/liberty-stack-readout/tests/test_subject_http_missing.py
+++ b/apps/liberty-stack-readout/tests/test_subject_http_missing.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(relative_path: str, module_name: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_subject_http_missing(tmp_path):
+    app_module = load_module('subject_readout.py', 'liberty_stack_subject_readout')
+    client = TestClient(app_module.app)
+
+    state_root = tmp_path / 'state'
+    state_root.mkdir(parents=True, exist_ok=True)
+
+    response = client.get('/v1/liberty-stack/by-subject', params={
+        'state_root': str(state_root),
+        'subject_ref': 'manifest://liberty-stack/demo/missing'
+    })
+    assert response.status_code == 404

--- a/apps/liberty-stack-readout/tests/test_subject_http_readout.py
+++ b/apps/liberty-stack-readout/tests/test_subject_http_readout.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import importlib.util
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(relative_path: str, module_name: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_subject_http_readout(tmp_path):
+    app_module = load_module('subject_readout.py', 'liberty_stack_subject_readout')
+    client = TestClient(app_module.app)
+
+    state_root = tmp_path / 'state'
+    state_root.mkdir(parents=True, exist_ok=True)
+    receipt = state_root / 'receipt-001.json'
+    receipt.write_text(json.dumps({
+        'status': 'succeeded',
+        'action': 'validate_manifest',
+        'subject_ref': 'manifest://liberty-stack/demo/0001',
+        'evidence_bundle_ref': 'bundle://demo/0001'
+    }), encoding='utf-8')
+
+    response = client.get('/v1/liberty-stack/by-subject', params={
+        'state_root': str(state_root),
+        'subject_ref': 'manifest://liberty-stack/demo/0001'
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert data['action'] == 'validate_manifest'
+    assert data['status'] == 'succeeded'
+    assert data['subject_ref'] == 'manifest://liberty-stack/demo/0001'


### PR DESCRIPTION
## Summary

Replacement for the earlier subject-readout PR, replayed onto current `main`.

## What this PR adds

- `apps/liberty-stack-readout/subject_readout.py`
- `apps/liberty-stack-readout/tests/test_subject_http_readout.py`

## Why

The earlier PR branch drifted behind `main`. Rather than fight the stale branch state, this PR replays the exact two-file subject-readout delta onto a fresh branch from current `main`.

## Scope

This remains intentionally thin and additive. It adds the missing subject-oriented operator path on top of the already-merged readout app.
