### PR TITLE
apps: add Liberty Stack readout packaging metadata

### DIFF
--- a/apps/liberty-stack-readout/pyproject.toml
+++ b/apps/liberty-stack-readout/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "liberty-stack-readout"
+version = "0.1.0"
+description = "Thin operator-facing readout surface for Liberty Stack receipts, verification records, and workflow events"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.111",
+  "uvicorn>=0.30",
+]
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/apps/liberty-stack-readout/scripts/demo_readout.py
+++ b/apps/liberty-stack-readout/scripts/demo_readout.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} /path/to/receipt.json", file=sys.stderr)
+        return 2
+
+    receipt_path = sys.argv[1]
+    url = "http://127.0.0.1:8080/v1/liberty-stack/readout?" + urllib.parse.urlencode({"receipt": receipt_path})
+    with urllib.request.urlopen(url) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/liberty-stack-readout/scripts/run_server.sh
+++ b/apps/liberty-stack-readout/scripts/run_server.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uvicorn main:app --host 127.0.0.1 --port 8080 --reload

--- a/apps/liberty-stack-readout/scripts/run_tests.sh
+++ b/apps/liberty-stack-readout/scripts/run_tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest tests/test_http_readout.py tests/test_subject_http_readout.py tests/test_subject_http_missing.py tests/test_subject_cli_helper.py tests/test_combined_readout.py tests/test_combined_readout_receipt_mode.py tests/test_store_subject_discovery.py


### PR DESCRIPTION
## Summary

Add the first packaging/runtime metadata slice for the already-merged Liberty Stack readout app.

## What this PR adds

- `apps/liberty-stack-readout/pyproject.toml`
- `apps/liberty-stack-readout/scripts/run_tests.sh`

## Why

The readout app now has multiple runtime entry surfaces and tests on `main`, but it still lacked:
- package metadata
- a simple app-local test runner

This PR closes that gap with a thin additive packaging slice.

## Scope

This remains intentionally small. It does not add containers or deployment manifests; it only makes the app more runnable and testable as a package-scoped unit.
