### PR TITLE
Draft: add Fog Stack external signature verification inputs

### DIFF
--- a/docs/FOGSTACK_CRYPTOGRAPHIC_SIGNATURE_VERIFICATION.md
+++ b/docs/FOGSTACK_CRYPTOGRAPHIC_SIGNATURE_VERIFICATION.md
@@ -1,0 +1,50 @@
+# Fog Stack cryptographic signature verification
+
+This document defines the first repo-native shape for **cryptographic signature verification results**.
+
+## Goal
+
+Move from:
+- manifests that can carry signature metadata
+- helpers that attach signature metadata
+- helpers that verify signed-manifest shape
+- trust records that reference signature evidence
+
+to:
+- a separate `FogStackCryptographicSignatureVerificationRecord` that captures the result of an actual external verification step.
+
+## Minimal flow
+
+1. run an external cryptographic verification step for the signature artifact
+2. capture its JSON or normalized evidence output
+3. run `tools/emit_fogstack_cryptographic_signature_verification_record.py`
+4. write the resulting record into a deterministic release-evidence location
+
+## Example
+
+```bash
+python3 tools/emit_fogstack_cryptographic_signature_verification_record.py \
+  --verification-evidence /tmp/fogstack.access.cosign.verify.json \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --manifest-ref releases/manifests/fogstack.access-v0.1.manifest.json \
+  --signature-ref artifact://release/fogstack.access-v0.1.sig \
+  --verification-tool cosign \
+  --manifest-digest sha256:deadbeef \
+  --key-ref key://release/cosign.pub \
+  --validation-record-ref releases/evidence/fogstack.access-v0.1.validation.record.json \
+  --signature-verification-record-ref releases/evidence/fogstack.access-v0.1.signature-verification.record.json \
+  --signature-trust-record-ref releases/evidence/fogstack.access-v0.1.signature-trust.record.json \
+  --release-evidence-index-ref releases/evidence/fogstack.access-v0.1.evidence.index.json \
+  --output /tmp/fogstack.access-v0.1.crypto-verification.record.json
+```
+
+## What this phase does not yet provide
+
+This phase still does not provide:
+- integrated execution of `cosign verify` or equivalent inside this helper
+- registry resolution of signature refs
+- CI-enforced verified truth records
+- automatic mutation/back-linking of existing artifacts
+
+Those remain for the next release-engineering tranche.

--- a/docs/FOGSTACK_EXTERNAL_SIGNATURE_VERIFICATION_INPUTS.md
+++ b/docs/FOGSTACK_EXTERNAL_SIGNATURE_VERIFICATION_INPUTS.md
@@ -1,0 +1,26 @@
+# Fog Stack external signature verification inputs
+
+This document defines the normalization contract for ingesting external signature verification outputs.
+
+## Goal
+
+Provide a stable input format so different tools (cosign, sigstore, etc.) can feed into the Fog Stack trust pipeline.
+
+## Minimal flow
+
+1. run external verification (e.g. `cosign verify`)
+2. capture JSON output
+3. run `tools/normalize_fogstack_signature_verification_evidence.py`
+4. feed normalized output into cryptographic verification record emitter
+
+## Why this matters
+
+Without normalization, every tool produces different JSON, making the trust pipeline brittle.
+
+This step standardizes input before it becomes part of the Fog Stack trust graph.
+
+## Out of scope
+
+- actual verification execution
+- trust enforcement
+- CI automation

--- a/docs/FOGSTACK_RELEASE_ARTIFACT_LINKING.md
+++ b/docs/FOGSTACK_RELEASE_ARTIFACT_LINKING.md
@@ -1,0 +1,41 @@
+# Fog Stack release artifact linking
+
+This document defines the first repo-native helper for **back-linking** release and trust artifacts.
+
+## Goal
+
+Move from separate machine-readable artifacts to artifacts that can point back to each other consistently for one bundle version.
+
+The helper in this phase updates:
+- the release manifest
+- the validation record
+- the signature verification record
+- the signature trust record
+
+so each can carry the relevant backlink refs.
+
+## Minimal flow
+
+1. emit or prepare the individual artifacts
+2. emit the release evidence index
+3. run `tools/link_fogstack_release_artifacts.py`
+4. persist the updated artifacts back to their deterministic release paths
+
+## Example
+
+```bash
+python3 tools/link_fogstack_release_artifacts.py \
+  --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+  --validation-record releases/evidence/fogstack.access-v0.1.validation.record.json \
+  --signature-verification-record releases/evidence/fogstack.access-v0.1.signature-verification.record.json \
+  --signature-trust-record releases/evidence/fogstack.access-v0.1.signature-trust.record.json \
+  --evidence-index-ref releases/evidence/fogstack.access-v0.1.evidence.index.json
+```
+
+## Out of scope
+
+This phase does not yet provide:
+- automatic CI execution of the linker
+- mutation of artifacts after publication
+- cryptographic verification of linked refs
+- registry publication of the linked artifact set

--- a/docs/FOGSTACK_RELEASE_EVIDENCE_INDEX.md
+++ b/docs/FOGSTACK_RELEASE_EVIDENCE_INDEX.md
@@ -1,0 +1,43 @@
+# Fog Stack release evidence index
+
+This document defines the first repo-native **release evidence index** for Fog Stack.
+
+## Goal
+
+The release-engineering surfaces now produce separate machine-readable artifacts for one bundle version:
+- a release manifest
+- a validation record
+- a signature verification record
+- a signature trust record
+
+The purpose of the release evidence index is to provide one stable object that links those artifact refs together for a single bundle release.
+
+## Minimal flow
+
+1. prepare or update the release manifest
+2. emit the validation record
+3. emit the signature verification record
+4. emit the signature trust record
+5. run `tools/emit_fogstack_release_evidence_index.py` to produce the linking object
+
+## Example
+
+```bash
+python3 tools/emit_fogstack_release_evidence_index.py \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --manifest-ref releases/manifests/fogstack.access-v0.1.manifest.json \
+  --validation-record-ref releases/evidence/fogstack.access-v0.1.validation.record.json \
+  --signature-verification-record-ref releases/evidence/fogstack.access-v0.1.signature-verification.record.json \
+  --signature-trust-record-ref releases/evidence/fogstack.access-v0.1.signature-trust.record.json \
+  --output /tmp/fogstack.access-v0.1.evidence.index.json
+```
+
+## What this phase does not yet provide
+
+This phase does not yet provide:
+- automatic generation of the index in CI
+- back-link insertion into the manifest or evidence records
+- publication or registry integration for the index itself
+
+Those remain for the next release-engineering tranche.

--- a/docs/FOGSTACK_SIGNATURE_TRUST_EVIDENCE.md
+++ b/docs/FOGSTACK_SIGNATURE_TRUST_EVIDENCE.md
@@ -1,0 +1,53 @@
+# Fog Stack signature trust evidence
+
+This document defines the first repo-native shape for **signature trust evidence**.
+
+## Goal
+
+Move from:
+- manifests that can carry signature metadata
+- a helper that can attach signature metadata
+- a helper that can verify signed-manifest shape
+
+to:
+- a separate `FogStackSignatureTrustRecord` that can link:
+  - back to the manifest being verified
+  - sideways to the validation record for the same bundle version
+  - sideways to the signature-verification record for the same manifest
+
+## Minimal flow
+
+1. verify the signed-manifest shape with `tools/verify_fogstack_manifest_signature.py`
+2. capture the verification JSON output
+3. run `tools/emit_fogstack_signature_trust_record.py`
+4. write the resulting record into a deterministic release-evidence location
+
+## Example
+
+```bash
+python3 tools/verify_fogstack_manifest_signature.py \
+  --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+  --require-signed \
+  --json > /tmp/fogstack.access.signature.verify.json
+
+python3 tools/emit_fogstack_signature_trust_record.py \
+  --verification-evidence /tmp/fogstack.access.signature.verify.json \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --manifest-ref releases/manifests/fogstack.access-v0.1.manifest.json \
+  --signature-ref artifact://release/fogstack.access-v0.1.sig \
+  --verification-method cosign \
+  --validation-record-ref releases/evidence/fogstack.access-v0.1.validation.record.json \
+  --signature-verification-record-ref releases/evidence/fogstack.access-v0.1.signature-verification.record.json \
+  --output /tmp/fogstack.access.signature-trust.record.json
+```
+
+## What this phase does not yet provide
+
+This phase still does not provide:
+- cryptographic verification of the signature payload itself
+- registry resolution of signature refs
+- automatic back-linking into manifests or validation records
+- CI-emitted verified truth records
+
+Those remain the next tranche after this helper + record shape land.

--- a/docs/FOGSTACK_SIGNATURE_VERIFICATION_EVIDENCE.md
+++ b/docs/FOGSTACK_SIGNATURE_VERIFICATION_EVIDENCE.md
@@ -1,0 +1,50 @@
+# Fog Stack signature verification evidence
+
+This document defines the first repo-native shape for **signature verification evidence**.
+
+## Goal
+
+Move from:
+- manifests that can carry signature metadata
+- a helper that can attach signature metadata
+- a helper that can check signed-manifest shape
+
+to:
+- a separate `FogStackSignatureVerificationRecord` that can link:
+  - back to the manifest being verified
+  - sideways to the validation record for the same bundle version
+
+## Minimal flow
+
+1. verify the signed-manifest shape with `tools/verify_fogstack_manifest_signature.py`
+2. capture the verification JSON output
+3. run `tools/emit_fogstack_signature_verification_record.py`
+4. write the resulting record into a deterministic release-evidence location
+
+## Example
+
+```bash
+python3 tools/verify_fogstack_manifest_signature.py \
+  --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+  --require-signed \
+  --json > /tmp/fogstack.access.signature.verify.json
+
+python3 tools/emit_fogstack_signature_verification_record.py \
+  --verification-json /tmp/fogstack.access.signature.verify.json \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --manifest-ref releases/manifests/fogstack.access-v0.1.manifest.json \
+  --signature-ref artifact://release/fogstack.access-v0.1.sig \
+  --validation-record-ref releases/evidence/fogstack.access-v0.1.validation.record.json \
+  --output /tmp/fogstack.access.signature-verification.record.json
+```
+
+## What this phase does not yet provide
+
+This phase still does not provide:
+- cryptographic verification of the signature payload itself
+- registry resolution of signature refs
+- automatic back-linking into the manifest or validation record
+- CI-emitted verified truth records
+
+Those remain the next tranche after this helper + record shape land.

--- a/docs/FOGSTACK_SIGNED_MANIFEST_VERIFICATION.md
+++ b/docs/FOGSTACK_SIGNED_MANIFEST_VERIFICATION.md
@@ -1,0 +1,38 @@
+# Fog Stack signed manifest verification
+
+This document defines the smallest repo-native meaning of **signed-manifest verification** for Fog Stack.
+
+## Goal
+
+Move from:
+- unsigned manifest stubs
+- a helper that can attach signature metadata
+
+to:
+- a helper that can check whether a manifest claiming to be signed actually carries the required signature metadata shape.
+
+## Minimal verification scope in this phase
+
+The verification helper in this phase checks only manifest-local conditions:
+- `signed` is present and boolean
+- if `signed: true`, a `signature` object exists
+- `signature.type` is one of the supported enum values
+- `signature.ref` is present and non-empty
+
+This phase does **not** verify the cryptographic validity of the signature reference.
+
+## Example
+
+```bash
+python3 tools/verify_fogstack_manifest_signature.py \
+  --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+  --require-signed \
+  --json
+```
+
+## Future evolution
+
+The next tranche after this helper should define:
+- how CI resolves and verifies the signature reference
+- how signature verification results are emitted as release evidence
+- how release manifests and validation records link to the same evidence package

--- a/schemas/release/fogstack-bundle-manifest-v0.1.schema.json
+++ b/schemas/release/fogstack-bundle-manifest-v0.1.schema.json
@@ -36,7 +36,11 @@
         "ref": { "type": "string" }
       },
       "additionalProperties": false
-    }
+    },
+    "validation_record_ref": { "type": ["string", "null"] },
+    "signature_verification_record_ref": { "type": ["string", "null"] },
+    "signature_trust_record_ref": { "type": ["string", "null"] },
+    "release_evidence_index_ref": { "type": ["string", "null"] }
   },
   "additionalProperties": false
 }

--- a/schemas/release/fogstack-cryptographic-signature-verification-record-v0.1.schema.json
+++ b/schemas/release/fogstack-cryptographic-signature-verification-record-v0.1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-cryptographic-signature-verification-record-v0.1.schema.json",
+  "title": "FogStackCryptographicSignatureVerificationRecord",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "manifest_ref",
+    "signature_ref",
+    "verification_tool",
+    "status",
+    "summary"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackCryptographicSignatureVerificationRecord" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+    "version": { "type": "string" },
+    "manifest_ref": { "type": "string" },
+    "signature_ref": { "type": "string" },
+    "verification_tool": { "enum": ["cosign", "sigstore", "other"] },
+    "status": { "enum": ["verified", "failed", "shape-only"] },
+    "summary": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["pass", "warn", "fail"] },
+        "message": { "type": ["string", "null"] },
+        "verified_digest": { "type": ["string", "null"] },
+        "evidence_count": { "type": ["integer", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "manifest_digest": { "type": ["string", "null"] },
+    "key_ref": { "type": ["string", "null"] },
+    "validation_record_ref": { "type": ["string", "null"] },
+    "signature_verification_record_ref": { "type": ["string", "null"] },
+    "signature_trust_record_ref": { "type": ["string", "null"] },
+    "release_evidence_index_ref": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/schemas/release/fogstack-external-signature-verification-evidence-v0.1.schema.json
+++ b/schemas/release/fogstack-external-signature-verification-evidence-v0.1.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-external-signature-verification-evidence-v0.1.schema.json",
+  "title": "FogStackExternalSignatureVerificationEvidence",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "tool",
+    "status"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackExternalSignatureVerificationEvidence" },
+    "schema_version": { "const": "v0.1" },
+    "tool": { "enum": ["cosign", "sigstore", "other"] },
+    "status": { "enum": ["pass", "warn", "fail"] },
+    "message": { "type": ["string", "null"] },
+    "verified_digest": { "type": ["string", "null"] },
+    "evidence_count": { "type": ["integer", "null"] },
+    "key_ref": { "type": ["string", "null"] },
+    "raw_ref": { "type": ["string", "null"] }
+  },
+  "additionalProperties": true
+}

--- a/schemas/release/fogstack-release-evidence-index-v0.1.schema.json
+++ b/schemas/release/fogstack-release-evidence-index-v0.1.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-release-evidence-index-v0.1.schema.json",
+  "title": "FogStackReleaseEvidenceIndex",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "manifest_ref",
+    "validation_record_ref",
+    "signature_verification_record_ref",
+    "signature_trust_record_ref"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackReleaseEvidenceIndex" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+    "version": { "type": "string" },
+    "manifest_ref": { "type": "string" },
+    "validation_record_ref": { "type": "string" },
+    "signature_verification_record_ref": { "type": "string" },
+    "signature_trust_record_ref": { "type": "string" },
+    "notes": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/schemas/release/fogstack-signature-trust-record-v0.1.schema.json
+++ b/schemas/release/fogstack-signature-trust-record-v0.1.schema.json
@@ -35,6 +35,7 @@
     },
     "validation_record_ref": { "type": ["string", "null"] },
     "signature_verification_record_ref": { "type": ["string", "null"] },
+    "release_evidence_index_ref": { "type": ["string", "null"] },
     "key_ref": { "type": ["string", "null"] }
   },
   "additionalProperties": false

--- a/schemas/release/fogstack-signature-trust-record-v0.1.schema.json
+++ b/schemas/release/fogstack-signature-trust-record-v0.1.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-signature-trust-record-v0.1.schema.json",
+  "title": "FogStackSignatureTrustRecord",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "manifest_ref",
+    "signature_ref",
+    "verification_method",
+    "status",
+    "summary"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackSignatureTrustRecord" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+    "version": { "type": "string" },
+    "manifest_ref": { "type": "string" },
+    "signature_ref": { "type": "string" },
+    "verification_method": { "enum": ["cosign", "sigstore", "other"] },
+    "status": { "enum": ["verified", "failed", "shape-only"] },
+    "summary": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["pass", "warn", "fail"] },
+        "message": { "type": ["string", "null"] },
+        "evidence_count": { "type": ["integer", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "validation_record_ref": { "type": ["string", "null"] },
+    "signature_verification_record_ref": { "type": ["string", "null"] },
+    "key_ref": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/schemas/release/fogstack-signature-verification-record-v0.1.schema.json
+++ b/schemas/release/fogstack-signature-verification-record-v0.1.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-signature-verification-record-v0.1.schema.json",
+  "title": "FogStackSignatureVerificationRecord",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "manifest_ref",
+    "status",
+    "summary"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackSignatureVerificationRecord" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+    "version": { "type": "string" },
+    "manifest_ref": { "type": "string" },
+    "status": { "enum": ["shape-only", "verified", "failed"] },
+    "summary": {
+      "type": "object",
+      "required": ["status", "exit_code"],
+      "properties": {
+        "status": { "enum": ["pass", "warn", "fail"] },
+        "exit_code": { "type": "integer" },
+        "checks_run": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
+    "signature_ref": { "type": ["string", "null"] },
+    "validation_record_ref": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/schemas/release/fogstack-signature-verification-record-v0.1.schema.json
+++ b/schemas/release/fogstack-signature-verification-record-v0.1.schema.json
@@ -30,7 +30,9 @@
       "additionalProperties": true
     },
     "signature_ref": { "type": ["string", "null"] },
-    "validation_record_ref": { "type": ["string", "null"] }
+    "validation_record_ref": { "type": ["string", "null"] },
+    "signature_trust_record_ref": { "type": ["string", "null"] },
+    "release_evidence_index_ref": { "type": ["string", "null"] }
   },
   "additionalProperties": false
 }

--- a/schemas/release/fogstack-validation-record-v0.1.schema.json
+++ b/schemas/release/fogstack-validation-record-v0.1.schema.json
@@ -33,7 +33,11 @@
       },
       "additionalProperties": true
     },
-    "evidence_ref": { "type": ["string", "null"] }
+    "evidence_ref": { "type": ["string", "null"] },
+    "manifest_ref": { "type": ["string", "null"] },
+    "signature_verification_record_ref": { "type": ["string", "null"] },
+    "signature_trust_record_ref": { "type": ["string", "null"] },
+    "release_evidence_index_ref": { "type": ["string", "null"] }
   },
   "additionalProperties": false
 }

--- a/tools/emit_fogstack_cryptographic_signature_verification_record.py
+++ b/tools/emit_fogstack_cryptographic_signature_verification_record.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Fog Stack cryptographic signature verification record")
+    parser.add_argument("--verification-evidence", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--manifest-ref", required=True)
+    parser.add_argument("--signature-ref", required=True)
+    parser.add_argument("--verification-tool", required=True, choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--manifest-digest", default=None)
+    parser.add_argument("--key-ref", default=None)
+    parser.add_argument("--validation-record-ref", default=None)
+    parser.add_argument("--signature-verification-record-ref", default=None)
+    parser.add_argument("--signature-trust-record-ref", default=None)
+    parser.add_argument("--release-evidence-index-ref", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    evidence = load_json(args.verification_evidence)
+    status = evidence.get("status")
+    if status == "pass":
+        verify_status = "verified"
+    elif status == "fail":
+        verify_status = "failed"
+    else:
+        verify_status = "shape-only"
+
+    record = {
+        "kind": "FogStackCryptographicSignatureVerificationRecord",
+        "schema_version": "v0.1",
+        "bundle_id": args.bundle_id,
+        "version": args.version,
+        "manifest_ref": args.manifest_ref,
+        "signature_ref": args.signature_ref,
+        "verification_tool": args.verification_tool,
+        "status": verify_status,
+        "summary": {
+            "status": status,
+            "message": evidence.get("message"),
+            "verified_digest": evidence.get("verified_digest"),
+            "evidence_count": evidence.get("evidence_count"),
+        },
+        "manifest_digest": args.manifest_digest,
+        "key_ref": args.key_ref,
+        "validation_record_ref": args.validation_record_ref,
+        "signature_verification_record_ref": args.signature_verification_record_ref,
+        "signature_trust_record_ref": args.signature_trust_record_ref,
+        "release_evidence_index_ref": args.release_evidence_index_ref,
+    }
+
+    text = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/emit_fogstack_release_evidence_index.py
+++ b/tools/emit_fogstack_release_evidence_index.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Fog Stack release evidence index")
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--manifest-ref", required=True)
+    parser.add_argument("--validation-record-ref", required=True)
+    parser.add_argument("--signature-verification-record-ref", required=True)
+    parser.add_argument("--signature-trust-record-ref", required=True)
+    parser.add_argument("--notes", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    record = {
+        "kind": "FogStackReleaseEvidenceIndex",
+        "schema_version": "v0.1",
+        "bundle_id": args.bundle_id,
+        "version": args.version,
+        "manifest_ref": args.manifest_ref,
+        "validation_record_ref": args.validation_record_ref,
+        "signature_verification_record_ref": args.signature_verification_record_ref,
+        "signature_trust_record_ref": args.signature_trust_record_ref,
+        "notes": args.notes,
+    }
+
+    text = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/emit_fogstack_signature_trust_record.py
+++ b/tools/emit_fogstack_signature_trust_record.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Fog Stack signature trust record from external verification evidence")
+    parser.add_argument("--verification-evidence", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--manifest-ref", required=True)
+    parser.add_argument("--signature-ref", required=True)
+    parser.add_argument("--verification-method", required=True, choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--validation-record-ref", default=None)
+    parser.add_argument("--signature-verification-record-ref", default=None)
+    parser.add_argument("--key-ref", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    evidence = load_json(args.verification_evidence)
+    status = evidence.get("status")
+    if status == "pass":
+        trust_status = "verified"
+    elif status == "fail":
+        trust_status = "failed"
+    else:
+        trust_status = "shape-only"
+
+    record = {
+        "kind": "FogStackSignatureTrustRecord",
+        "schema_version": "v0.1",
+        "bundle_id": args.bundle_id,
+        "version": args.version,
+        "manifest_ref": args.manifest_ref,
+        "signature_ref": args.signature_ref,
+        "verification_method": args.verification_method,
+        "status": trust_status,
+        "summary": {
+            "status": status,
+            "message": evidence.get("message"),
+            "evidence_count": evidence.get("evidence_count"),
+        },
+        "validation_record_ref": args.validation_record_ref,
+        "signature_verification_record_ref": args.signature_verification_record_ref,
+        "key_ref": args.key_ref,
+    }
+
+    text = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/emit_fogstack_signature_verification_record.py
+++ b/tools/emit_fogstack_signature_verification_record.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Fog Stack signature verification record from manifest verification JSON")
+    parser.add_argument("--verification-json", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--manifest-ref", required=True)
+    parser.add_argument("--signature-ref", default=None)
+    parser.add_argument("--validation-record-ref", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    verification = load_json(args.verification_json)
+    summary = verification.get("summary") or {}
+    if not isinstance(summary, dict):
+        raise SystemExit("ERR: verification summary is missing or malformed")
+
+    status = "verified" if summary.get("status") == "pass" else "failed"
+    if summary.get("status") == "warn":
+        status = "shape-only"
+
+    record = {
+        "kind": "FogStackSignatureVerificationRecord",
+        "schema_version": "v0.1",
+        "bundle_id": args.bundle_id,
+        "version": args.version,
+        "manifest_ref": args.manifest_ref,
+        "status": status,
+        "summary": {
+            "status": summary.get("status"),
+            "exit_code": summary.get("exit_code"),
+            "checks_run": summary.get("checks_run"),
+        },
+        "signature_ref": args.signature_ref,
+        "validation_record_ref": args.validation_record_ref,
+    }
+
+    text = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/link_fogstack_release_artifacts.py
+++ b/tools/link_fogstack_release_artifacts.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Link Fog Stack release artifacts by inserting backlink refs")
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--validation-record", required=True, type=Path)
+    parser.add_argument("--signature-verification-record", required=True, type=Path)
+    parser.add_argument("--signature-trust-record", required=True, type=Path)
+    parser.add_argument("--evidence-index-ref", required=True)
+    args = parser.parse_args()
+
+    manifest = load_json(args.manifest)
+    validation = load_json(args.validation_record)
+    sig_verify = load_json(args.signature_verification_record)
+    sig_trust = load_json(args.signature_trust_record)
+
+    manifest["validation_record_ref"] = str(args.validation_record)
+    manifest["signature_verification_record_ref"] = str(args.signature_verification_record)
+    manifest["signature_trust_record_ref"] = str(args.signature_trust_record)
+    manifest["release_evidence_index_ref"] = args.evidence_index_ref
+
+    validation["manifest_ref"] = str(args.manifest)
+    validation["signature_verification_record_ref"] = str(args.signature_verification_record)
+    validation["signature_trust_record_ref"] = str(args.signature_trust_record)
+    validation["release_evidence_index_ref"] = args.evidence_index_ref
+
+    sig_verify["validation_record_ref"] = str(args.validation_record)
+    sig_verify["signature_trust_record_ref"] = str(args.signature_trust_record)
+    sig_verify["release_evidence_index_ref"] = args.evidence_index_ref
+
+    sig_trust["validation_record_ref"] = str(args.validation_record)
+    sig_trust["signature_verification_record_ref"] = str(args.signature_verification_record)
+    sig_trust["release_evidence_index_ref"] = args.evidence_index_ref
+
+    write_json(args.manifest, manifest)
+    write_json(args.validation_record, validation)
+    write_json(args.signature_verification_record, sig_verify)
+    write_json(args.signature_trust_record, sig_trust)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/normalize_fogstack_signature_verification_evidence.py
+++ b/tools/normalize_fogstack_signature_verification_evidence.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Normalize external signature verification output into FogStackExternalSignatureVerificationEvidence")
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--tool", required=True, choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    raw = json.loads(args.input.read_text(encoding="utf-8"))
+
+    # minimal normalization contract
+    evidence = {
+        "kind": "FogStackExternalSignatureVerificationEvidence",
+        "schema_version": "v0.1",
+        "tool": args.tool,
+        "status": raw.get("status") or "unknown",
+        "message": raw.get("message"),
+        "verified_digest": raw.get("verified_digest"),
+        "evidence_count": raw.get("evidence_count"),
+        "key_ref": raw.get("key_ref"),
+        "raw_ref": str(args.input),
+    }
+
+    text = json.dumps(evidence, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_fogstack_manifest_signature.py
+++ b/tools/verify_fogstack_manifest_signature.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify Fog Stack signed-manifest metadata")
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--require-signed", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    manifest = load_json(args.manifest)
+    signed = manifest.get("signed")
+    signature = manifest.get("signature")
+    checks: list[dict[str, Any]] = []
+
+    def record(rule_id: str, status: str, message: str) -> None:
+        checks.append({"id": rule_id, "status": status, "message": message})
+
+    if signed is True:
+        record("SIG-001", "pass", "manifest marked signed")
+    elif signed is False:
+        if args.require_signed:
+            record("SIG-001", "fail", "manifest is not marked signed")
+        else:
+            record("SIG-001", "warn", "manifest is unsigned")
+    else:
+        record("SIG-001", "fail", "manifest missing boolean 'signed' field")
+
+    if signed is True:
+        if not isinstance(signature, dict):
+            record("SIG-002", "fail", "signed manifest missing signature object")
+        else:
+            sig_type = signature.get("type")
+            sig_ref = signature.get("ref")
+            if sig_type in {"cosign", "sigstore", "other"}:
+                record("SIG-002", "pass", f"signature type present: {sig_type}")
+            else:
+                record("SIG-002", "fail", f"invalid signature type: {sig_type!r}")
+            if isinstance(sig_ref, str) and sig_ref.strip():
+                record("SIG-003", "pass", "signature reference present")
+            else:
+                record("SIG-003", "fail", "signature reference missing or empty")
+    else:
+        record("SIG-002", "skip", "signature object not required for unsigned manifest")
+        record("SIG-003", "skip", "signature reference not required for unsigned manifest")
+
+    statuses = [c["status"] for c in checks]
+    if "fail" in statuses:
+        overall = "fail"
+        exit_code = 2
+    elif "warn" in statuses:
+        overall = "warn"
+        exit_code = 0
+    else:
+        overall = "pass"
+        exit_code = 0
+
+    result = {
+        "tool": "fogstack verify-signature",
+        "subject": str(args.manifest),
+        "summary": {
+            "status": overall,
+            "exit_code": exit_code,
+            "checks_run": len(checks)
+        },
+        "checks": checks
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"{args.manifest} status={overall} checks={len(checks)}")
+        for item in checks:
+            print(f"- {item['status'].upper():5s} {item['id']} {item['message']}")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the normalization layer for external signature verification inputs:

- `schemas/release/fogstack-external-signature-verification-evidence-v0.1.schema.json`
- `tools/normalize_fogstack_signature_verification_evidence.py`
- `docs/FOGSTACK_EXTERNAL_SIGNATURE_VERIFICATION_INPUTS.md`

## Why this shape

PR #76 defines the output record for cryptographic verification.
This PR defines the *input contract* for feeding external verification tools into that system.

## Not in this PR

- execution of verification tools
- CI enforcement
- trust validation

Those remain next steps.
