### PR TITLE
platform: add eval fabric lifecycle artifact graph suite

### DIFF
--- a/apps/eval-fabric-api/tests/fixtures/lifecycle_artifact_graph_0001.json
+++ b/apps/eval-fabric-api/tests/fixtures/lifecycle_artifact_graph_0001.json
@@ -1,0 +1,19 @@
+{
+  "artifact_graph_id": "lifecycle_artifact_graph_0001",
+  "agent_ref": "agent://socioprophet/example/retrieval-governed-operator",
+  "edges": [
+    {"from": "recipe://benchmark/ray/eval-fabric-001", "to": "promotion_decision_0001", "type": "promotes"},
+    {"from": "promotion_decision_0001", "to": "gate_activation_record_0001", "type": "requires_gate_activation"},
+    {"from": "gate_activation_record_0001", "to": "graduation_record_0001", "type": "supports_graduation"},
+    {"from": "promotion_decision_0001", "to": "rollback_record_0001", "type": "rollback_ready"}
+  ],
+  "evidence_refs": [
+    "event_envelope",
+    "evidence_receipt",
+    "benchmark_report",
+    "promotion_decision",
+    "rollback_record",
+    "gate_activation_record",
+    "graduation_record"
+  ]
+}

--- a/apps/eval-fabric-api/tests/test_artifact_graph_suite.py
+++ b/apps/eval-fabric-api/tests/test_artifact_graph_suite.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str):
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_artifact_graph_connects_lifecycle_records() -> None:
+    graph = _load("lifecycle_artifact_graph_0001.json")
+    promotion = _load("promotion_decision_0001.json")
+    rollback = _load("rollback_record_0001.json")
+    gate = _load("gate_activation_record_0001.json")
+    graduation = _load("graduation_record_0001.json")
+    ray_recipe = _load("ray_recipe_lifecycle_0001.json")
+
+    edge_pairs = {(e["from"], e["to"], e["type"]) for e in graph["edges"]}
+    assert (ray_recipe["recipe_ref"], promotion["promotion_decision_id"], "promotes") in edge_pairs
+    assert (promotion["promotion_decision_id"], gate["gate_activation_record_id"], "requires_gate_activation") in edge_pairs
+    assert (gate["gate_activation_record_id"], graduation["graduation_record_id"], "supports_graduation") in edge_pairs
+    assert (promotion["promotion_decision_id"], rollback["rollback_record_id"], "rollback_ready") in edge_pairs
+
+
+def test_artifact_graph_has_expected_evidence_bundle() -> None:
+    graph = _load("lifecycle_artifact_graph_0001.json")
+    expected = {
+        "event_envelope",
+        "evidence_receipt",
+        "benchmark_report",
+        "promotion_decision",
+        "rollback_record",
+        "gate_activation_record",
+        "graduation_record",
+    }
+    assert set(graph["evidence_refs"]) == expected


### PR DESCRIPTION
## Summary

Add a focused lifecycle artifact-graph fixture and test module for the eval-fabric lane.

## Why

The current downstream suite ladder already covers:
- Ray lifecycle expectations
- promotion / rollback artifacts
- gate activation records
- graduation readiness records

The next narrow verification step is to encode the relationships between those artifacts explicitly as one lifecycle graph and test that the expected edges and evidence bundle exist.

## Files included

- `apps/eval-fabric-api/tests/fixtures/lifecycle_artifact_graph_0001.json`
- `apps/eval-fabric-api/tests/test_artifact_graph_suite.py`

## What this covers

- links between Ray recipe, promotion decision, gate activation, graduation record, and rollback record
- expected lifecycle edge semantics
- expected evidence bundle shape across the lifecycle artifact graph

## Notes

This PR is intentionally narrow. It does not add runtime behavior; it closes the current downstream verification ladder by making the artifact graph itself a first-class tested object.
