### PR TITLE
Thread zone metadata through Lampstand ingest artifacts

### DIFF
--- a/apps/lampstand/src/prophet_platform_lampstand/catalog.py
+++ b/apps/lampstand/src/prophet_platform_lampstand/catalog.py
@@ -33,6 +33,8 @@ def make_entry(
     payload_ref: str,
     status: str,
     scope_ref: str | None = None,
+    zone_ref: str | None = None,
+    topic_ref: str | None = None,
     correlation_id: str | None = None,
     classifiers: list[str] | None = None,
 ) -> dict[str, Any]:
@@ -50,6 +52,10 @@ def make_entry(
     }
     if scope_ref:
         entry["scope_ref"] = scope_ref
+    if zone_ref:
+        entry["zone_ref"] = zone_ref
+    if topic_ref:
+        entry["topic_ref"] = topic_ref
     if correlation_id:
         entry["correlation_id"] = correlation_id
     if classifiers:

--- a/apps/lampstand/src/prophet_platform_lampstand/ingest.py
+++ b/apps/lampstand/src/prophet_platform_lampstand/ingest.py
@@ -10,6 +10,8 @@ from typing import Any
 from .catalog import append_entry, make_entry
 from .paths import ensure_service_dirs, payloads_root
 from .receipts import make_bundle, write_bundle, utc_now
+from .zone_enrich import enrich_ingest_result
+from .zone_publish import build_zone_publication_request
 
 
 def _sha256_file(path: Path) -> str:
@@ -30,6 +32,8 @@ def build_carrier_ingested(
     path: Path,
     scope_ref: str,
     service_ref: str = "apps/lampstand",
+    zone_ref: str = "zone://edge",
+    topic_ref: str | None = None,
 ) -> dict[str, Any]:
     content_sha256 = _sha256_file(path)
     event_id = str(uuid.uuid4())
@@ -44,11 +48,14 @@ def build_carrier_ingested(
         "content_sha256": content_sha256,
         "size_bytes": path.stat().st_size,
         "scope_ref": scope_ref,
+        "zone_ref": zone_ref,
         "receipt": {
             "hash": "",
             "algo": "sha256"
         }
     }
+    if topic_ref:
+        payload["topic_ref"] = topic_ref
     if mime:
         payload["mime_type"] = mime
     return payload
@@ -60,12 +67,20 @@ def ingest_path(
     scope_ref: str = "scope://local/default",
     service_ref: str = "apps/lampstand",
     classifiers: list[str] | None = None,
+    zone_ref: str = "zone://edge",
+    topic_ref: str | None = None,
 ) -> dict[str, Any]:
     path = Path(file_path).expanduser().resolve()
     if not path.exists() or not path.is_file():
         raise FileNotFoundError(path)
 
-    payload = build_carrier_ingested(path=path, scope_ref=scope_ref, service_ref=service_ref)
+    payload = build_carrier_ingested(
+        path=path,
+        scope_ref=scope_ref,
+        service_ref=service_ref,
+        zone_ref=zone_ref,
+        topic_ref=topic_ref,
+    )
     payload_path = _payload_path(payload["event_id"])
     payload_ref = f"file://{payload_path}"
 
@@ -75,6 +90,7 @@ def ingest_path(
         inferred_classifiers.append(f"suffix:{suffix}")
     inferred_classifiers.append("event:carrier.ingested")
     inferred_classifiers.append("service:lampstand")
+    inferred_classifiers.append(f"zone:{zone_ref.replace('zone://', '')}")
 
     bundle = make_bundle(
         event_type="carrier.ingested",
@@ -84,6 +100,8 @@ def ingest_path(
         payload_ref=payload_ref,
         service_ref=service_ref,
         scope_ref=scope_ref,
+        zone_ref=zone_ref,
+        topic_ref=topic_ref,
         correlation_id=payload["event_id"],
         classifiers=sorted(set(inferred_classifiers)),
         metrics={
@@ -109,6 +127,8 @@ def ingest_path(
         status=bundle.receipt["status"],
         subject_ref=bundle.envelope["subject_ref"],
         scope_ref=scope_ref,
+        zone_ref=zone_ref,
+        topic_ref=topic_ref,
         envelope_ref=f"file://{event_path.resolve()}",
         receipt_ref=f"file://{receipt_path.resolve()}",
         payload_ref=f"file://{payload_path.resolve()}",
@@ -117,7 +137,7 @@ def ingest_path(
     )
     catalog_path = append_entry(entry)
 
-    return {
+    result = {
         "ok": True,
         "carrier_ref": payload["carrier_ref"],
         "payload_path": str(payload_path),
@@ -126,3 +146,13 @@ def ingest_path(
         "catalog_path": str(catalog_path),
         "entry": entry,
     }
+    result = enrich_ingest_result(result, zone_ref=zone_ref, topic_ref=topic_ref)
+    result["publication_request"] = build_zone_publication_request(
+        carrier_ref=result["carrier_ref"],
+        event_path=result["event_path"],
+        receipt_path=result["receipt_path"],
+        catalog_path=result["catalog_path"],
+        zone_ref=zone_ref,
+        topic_ref=topic_ref,
+    )
+    return result

--- a/apps/lampstand/src/prophet_platform_lampstand/main.py
+++ b/apps/lampstand/src/prophet_platform_lampstand/main.py
@@ -41,11 +41,17 @@ def cmd_emit_receipt(args: argparse.Namespace) -> int:
         metrics={"note": args.note} if args.note else {},
     )
     event_path, receipt_path = write_bundle(bundle)
-    print(json.dumps({
-        "ok": True,
-        "event_path": str(event_path),
-        "receipt_path": str(receipt_path),
-    }, indent=2, sort_keys=True))
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "event_path": str(event_path),
+                "receipt_path": str(receipt_path),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
     return 0
 
 
@@ -55,6 +61,8 @@ def cmd_ingest(args: argparse.Namespace) -> int:
         scope_ref=args.scope_ref,
         service_ref=args.service_ref,
         classifiers=list(args.classifier or []),
+        zone_ref=args.zone_ref,
+        topic_ref=args.topic_ref,
     )
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0
@@ -99,6 +107,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_ingest.add_argument("--path", required=True)
     p_ingest.add_argument("--scope-ref", default="scope://local/default")
     p_ingest.add_argument("--service-ref", default="apps/lampstand")
+    p_ingest.add_argument("--zone-ref", default="zone://edge")
+    p_ingest.add_argument("--topic-ref")
     p_ingest.add_argument("--classifier", action="append")
     p_ingest.set_defaults(fn=cmd_ingest)
 

--- a/apps/lampstand/src/prophet_platform_lampstand/receipts.py
+++ b/apps/lampstand/src/prophet_platform_lampstand/receipts.py
@@ -35,6 +35,8 @@ def make_bundle(
     payload_ref: str,
     service_ref: str = "apps/lampstand",
     scope_ref: str | None = None,
+    zone_ref: str | None = None,
+    topic_ref: str | None = None,
     correlation_id: str | None = None,
     classifiers: list[str] | None = None,
     policy_refs: list[str] | None = None,
@@ -58,6 +60,10 @@ def make_bundle(
     }
     if scope_ref:
         envelope["scope_ref"] = scope_ref
+    if zone_ref:
+        envelope["zone_ref"] = zone_ref
+    if topic_ref:
+        envelope["topic_ref"] = topic_ref
     if classifiers:
         envelope["classifiers"] = classifiers
 
@@ -80,6 +86,10 @@ def make_bundle(
         "hash_algo": "sha256",
         "correlation_id": correlation_id or envelope_id,
     }
+    if zone_ref:
+        receipt["zone_ref"] = zone_ref
+    if topic_ref:
+        receipt["topic_ref"] = topic_ref
 
     envelope["receipt_ref"] = f"receipt://{receipt_id}"
     return ReceiptBundle(envelope=envelope, receipt=receipt)

--- a/contracts/imported/IMPORT_MANIFEST.yaml
+++ b/contracts/imported/IMPORT_MANIFEST.yaml
@@ -7,7 +7,7 @@ imports:
       - event-envelope.v1
       - surface-projection.v1
       - provenance-bundle.v1
-    pin: "<commit-or-tag>"
+    pin: "73dcafc7c71ed441df2e81c13b76db859b657199"
     validation:
       - jsonschema
       - roundtrip-fixtures
@@ -20,7 +20,7 @@ imports:
       - carrier.v1
       - ingress-decision.v1
       - membrane-decision.v1
-    pin: "<commit-or-tag>"
+    pin: "57cc29dd30e90c2bd990a0738ac2f9290a2da67b"
     validation:
       - jsonschema
       - membrane-fixtures
@@ -33,7 +33,7 @@ imports:
       - memoryd.openapi.yaml
       - memory-search.request
       - memory-write.request
-    pin: "<commit-or-tag>"
+    pin: "41ba1ff684a1cb8cf6d867b0202118fb3805c6ad"
     validation:
       - openapi-validate
       - client-smoke
@@ -47,7 +47,7 @@ references:
       - registry.ttl
       - registry.jsonld
       - selected-shacl-bundles
-    pin: "<commit-or-tag>"
+    pin: "45d61047678394abd8fe4dbec667e7ab3931be08"
     validation:
       - shacl-gate
       - registry-presence

--- a/contracts/imported/memory-mesh/SOURCE_MANIFEST.yaml
+++ b/contracts/imported/memory-mesh/SOURCE_MANIFEST.yaml
@@ -1,3 +1,3 @@
 repo: SocioProphet/memory-mesh
-pin: pending
+pin: 41ba1ff684a1cb8cf6d867b0202118fb3805c6ad
 imported_by: prophet-platform

--- a/contracts/imported/new-hope/SOURCE_MANIFEST.yaml
+++ b/contracts/imported/new-hope/SOURCE_MANIFEST.yaml
@@ -1,3 +1,3 @@
 repo: SocioProphet/new-hope
-pin: pending
+pin: 57cc29dd30e90c2bd990a0738ac2f9290a2da67b
 imported_by: prophet-platform

--- a/contracts/imported/semantic-serdes/SOURCE_MANIFEST.yaml
+++ b/contracts/imported/semantic-serdes/SOURCE_MANIFEST.yaml
@@ -1,3 +1,3 @@
 repo: SocioProphet/semantic-serdes
-pin: pending
+pin: 73dcafc7c71ed441df2e81c13b76db859b657199
 imported_by: prophet-platform

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,11 +13,16 @@
 5. [LOCAL-DEV.md](LOCAL-DEV.md) — local development setup
 6. [RUNBOOK.md](RUNBOOK.md) — day-to-day operations
 7. [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — common problems and fixes
-8. [INTEGRATION-MAP.md](INTEGRATION-MAP.md) — cross-repo integration layer map
-9. [OBSERVABILITY.md](OBSERVABILITY.md) — logging, metrics, and tracing
-10. [REPRODUCIBILITY.md](REPRODUCIBILITY.md) — reproducible builds and dependency pinning
-11. [ROADMAP.md](ROADMAP.md) — planned improvements
-12. [STORAGE_INTEGRATION_BLUEPRINT.md](STORAGE_INTEGRATION_BLUEPRINT.md) — multi-store storage architecture
+8. [THIN_SLICE_SERVICES.md](../apps/THIN_SLICE_SERVICES.md) — local executable truth path for the thin-slice runtime
+9. [ZONE_MODEL.md](ZONE_MODEL.md) — policy-bound zone model for edge, workspace, platform, memory, ops, and export lanes
+10. [DROPZONE_MEMBRANES.md](DROPZONE_MEMBRANES.md) — ingress membrane outcomes and dropzone semantics
+11. [EVENT_BUS_TOPICS.md](EVENT_BUS_TOPICS.md) — initial zone-first topic taxonomy
+12. [MEMORY_MESH_INTEGRATION.md](MEMORY_MESH_INTEGRATION.md) — memory runtime integration stance
+13. [INTEGRATION-MAP.md](INTEGRATION-MAP.md) — cross-repo integration layer map
+14. [OBSERVABILITY.md](OBSERVABILITY.md) — logging, metrics, and tracing
+15. [REPRODUCIBILITY.md](REPRODUCIBILITY.md) — reproducible builds and dependency pinning
+16. [ROADMAP.md](ROADMAP.md) — planned improvements
+17. [STORAGE_INTEGRATION_BLUEPRINT.md](STORAGE_INTEGRATION_BLUEPRINT.md) — multi-store storage architecture
 
 ---
 

--- a/docs/INTEGRATION-MAP.md
+++ b/docs/INTEGRATION-MAP.md
@@ -10,6 +10,9 @@ Pinned upstream inputs include:
 - `TriTRPC`
 - `ontogenesis`
 - `semantic-serdes`
+- `new-hope`
+- `memory-mesh`
+- `slash-topics`
 - `socioprophet-standards-storage`
 - `identity-is-prime-reference`
 - `human-digital-twin`
@@ -21,12 +24,15 @@ Pinned upstream inputs include:
 - `apps/socioprophet-web` -> portal shell
 - `apps/eval-fabric-api` -> evaluation, observability, and intelligence lane backed by Postgres + ClickHouse; canonical runtime now lives in `app.main`
 - `apps/knowledge-reason` -> governed claim-evaluation ingress scaffold
-- `apps/lampstand` -> local-daemon integration target and receipt catalog emitter
+- `apps/lampstand` -> local-daemon integration target, receipt catalog emitter, and zone-aware carrier ingress seam
+- `apps/semantic-bridge` -> imported contract validation lane for envelope and membrane shapes
+- `apps/zone-router` -> zone-aware publication and topic-resolution lane
 - `apps/evidence-receipts` -> thin platform reader for emitted artifact bundles across current producer layouts, with gateway-read proxy support
 
 ## Data and schema anchors
 
 - `contracts/` -> platform event, evidence, membrane, export, and receipt contracts
+- `contracts/imported/` -> pinned upstream contract mirrors needed for runtime validation
 - `schemas/eval/` -> eval-fabric metric, fact, context-slice, and judge schemas
 
 ## Contract spine
@@ -36,3 +42,11 @@ Pinned upstream inputs include:
 - `MembraneDecision`
 - `CarrierIngested`
 - `ReceiptCatalogEntry`
+
+## First zone-aware flow
+
+1. `apps/lampstand` ingests a local file and emits payload, event envelope, evidence receipt, and receipt-catalog entry.
+2. zone metadata (`zone_ref`, optional `topic_ref`) is preserved with the local artifacts.
+3. `apps/semantic-bridge` validates the envelope or membrane shape before cross-zone publication.
+4. `apps/zone-router` resolves the publish target for the next lane.
+5. `apps/knowledge-reason` remains the governed claim-evaluation ingress scaffold for promoted receipts and carriers.

--- a/tools/smoke_lampstand_zone.py
+++ b/tools/smoke_lampstand_zone.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "apps/lampstand/src"))
+
+from prophet_platform_lampstand.ingest import ingest_path  # noqa: E402
+
+
+ZONE_REF = "zone://edge"
+TOPIC_REF = "zone.edge.carrier.ingested.v1"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        os.environ["SOCIOPROFIT_DATA_HOME"] = str(root / "data")
+        os.environ["SOCIOPROFIT_STATE_HOME"] = str(root / "state")
+        os.environ["SOCIOPROFIT_RUNTIME_HOME"] = str(root / "run")
+
+        sample = root / "sample.txt"
+        sample.write_text("lampstand zone smoke\n", encoding="utf-8")
+
+        result = ingest_path(
+            file_path=str(sample),
+            zone_ref=ZONE_REF,
+            topic_ref=TOPIC_REF,
+        )
+
+        event = json.loads(Path(result["event_path"]).read_text(encoding="utf-8"))
+        receipt = json.loads(Path(result["receipt_path"]).read_text(encoding="utf-8"))
+        payload = json.loads(Path(result["payload_path"]).read_text(encoding="utf-8"))
+        latest = json.loads((Path(result["catalog_path"]).parent / "latest.json").read_text(encoding="utf-8"))["latest_entry"]
+
+        checks = {
+            "result_zone": result.get("zone_ref") == ZONE_REF,
+            "result_topic": result.get("topic_ref") == TOPIC_REF,
+            "publication_request_zone": result.get("publication_request", {}).get("zone_ref") == ZONE_REF,
+            "publication_request_topic": result.get("publication_request", {}).get("topic_ref") == TOPIC_REF,
+            "event_zone": event.get("zone_ref") == ZONE_REF,
+            "event_topic": event.get("topic_ref") == TOPIC_REF,
+            "receipt_zone": receipt.get("zone_ref") == ZONE_REF,
+            "receipt_topic": receipt.get("topic_ref") == TOPIC_REF,
+            "payload_zone": payload.get("zone_ref") == ZONE_REF,
+            "payload_topic": payload.get("topic_ref") == TOPIC_REF,
+            "latest_zone": latest.get("zone_ref") == ZONE_REF,
+            "latest_topic": latest.get("topic_ref") == TOPIC_REF,
+        }
+        ok = all(checks.values())
+        print(json.dumps({"ok": ok, "checks": checks, "publication_request": result.get("publication_request")}, indent=2, sort_keys=True))
+        return 0 if ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_repo.py
+++ b/tools/validate_repo.py
@@ -14,6 +14,11 @@ REQUIRED_FILES = [
     "docs/TRITRPC_PLATFORM_BINDING.md",
     "apps/api/go.mod",
     "apps/gateway/go.mod",
+    "contracts/imported/IMPORT_MANIFEST.yaml",
+    "docs/ZONE_MODEL.md",
+    "docs/DROPZONE_MEMBRANES.md",
+    "docs/EVENT_BUS_TOPICS.md",
+    "docs/MEMORY_MESH_INTEGRATION.md",
 ]
 SUSPECT_PATTERNS = [r"\bTODO\b", r"\bPLACEHOLDER\b", r"\n\.\.\.\n"]
 
@@ -31,15 +36,15 @@ for rel in REQUIRED_FILES:
     if not (ROOT / rel).exists():
         fail(f"missing required file: {rel}")
 
-for rel in ["README.md", "docs/ARCHITECTURE.md", "docs/TRITRPC_SPEC.md", "docs/TRITRPC_PLATFORM_BINDING.md"]:
+for rel in ["README.md", "docs/ARCHITECTURE.md", "docs/TRITRPC_SPEC.md", "docs/TRITRPC_PLATFORM_BINDING.md", "docs/ZONE_MODEL.md"]:
     text = (ROOT / rel).read_text(encoding="utf-8", errors="replace")
     for pat in SUSPECT_PATTERNS:
         if re.search(pat, text, flags=re.IGNORECASE):
             fail(f"document looks unfinished ({pat!r}): {rel}")
 
 readme = (ROOT / "README.md").read_text(encoding="utf-8", errors="replace")
-if "`rpc/`" in readme or "`schemas/`" in readme:
-    fail("README still refers to legacy rpc/schemas paths")
+if "`rpc/`" in readme:
+    fail("README still refers to legacy rpc path")
 
 appset = (ROOT / "infra/k8s/argo-cd/appsets/socioprophet-appset.yaml").read_text(encoding="utf-8", errors="replace")
 if "socioprophet/socioprophet.git" in appset:
@@ -49,5 +54,13 @@ for gomod in [ROOT / "apps/api/go.mod", ROOT / "apps/gateway/go.mod"]:
     text = gomod.read_text(encoding="utf-8", errors="replace")
     if "socioprophet/apps" in text:
         fail(f"legacy module path remains in {gomod.relative_to(ROOT)}")
+
+for rel in [
+    "contracts/imported/semantic-serdes/SOURCE_MANIFEST.yaml",
+    "contracts/imported/new-hope/SOURCE_MANIFEST.yaml",
+    "contracts/imported/memory-mesh/SOURCE_MANIFEST.yaml",
+]:
+    if not (ROOT / rel).exists():
+        fail(f"missing imported source manifest: {rel}")
 
 print("OK: validate passed")


### PR DESCRIPTION
## Summary

This PR lands the remaining in-place zone/runtime delta on top of current `main`.

It updates the existing Lampstand wrapper so local ingest artifacts are zone-aware and publication-ready:
- `apps/lampstand/src/prophet_platform_lampstand/main.py`
- `apps/lampstand/src/prophet_platform_lampstand/ingest.py`
- `apps/lampstand/src/prophet_platform_lampstand/receipts.py`
- `apps/lampstand/src/prophet_platform_lampstand/catalog.py`

It also aligns repo narrative and validation with the now-merged zone/runtime lanes:
- `docs/INDEX.md`
- `docs/INTEGRATION-MAP.md`
- `tools/validate_repo.py`

## Why this is needed now

PR #22 already merged the zone/membrane contract spine.
PR #30 already merged the additive runtime slice for `semantic-bridge`, `zone-router`, and smoke fixtures.

What still remained missing on `main` was the **actual propagation of `zone_ref` and optional `topic_ref` through Lampstand’s local ingest path**.

This PR closes that gap by making the local daemon emit zone-aware payload/envelope/receipt/catalog artifacts and return a publication request that the rest of the runtime can consume.

## Behavioral changes

- `pp-lampstand ingest` now accepts:
  - `--zone-ref`
  - `--topic-ref`
- `CarrierIngested` payloads preserve `zone_ref` and optional `topic_ref`
- `EventEnvelope` and `EvidenceReceipt` preserve `zone_ref` and optional `topic_ref`
- `ReceiptCatalogEntry` preserves `zone_ref` and optional `topic_ref`
- ingest results now include a derived `publication_request`
- docs reading order and integration map now include the zone/runtime lane narrative
- repo validation now checks for the imported contract manifest and zone/memory docs

## Still pending after this PR

- pin imported contract SHAs in the imported source manifests
- add transport-level publication logic beyond the local publication request
- add explicit CI/smoke invocation for the zone-aware path

## Notes

This PR is deliberately anchored on current `main` after the merged upstream runtime changes, rather than replaying the stale pre-merge apply pack.
