### PR TITLE
Wire zone-aware Lampstand smoke into standard smoke path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke validate-fogstack validate-storage-suite
 
 validate: validate-repo drift-check standards-check topology-check test-go validate-phase4 test-python-apps validate-fogstack validate-storage-suite
 
@@ -30,7 +30,7 @@ test-python-apps:
 	cd apps/evidence-console && test -d .venv || python3 -m venv .venv
 	cd apps/evidence-console && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt && pytest -q tests
 
-smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console
+smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke
 
 smoke-health:
 	bash tools/smoke_tritrpc_health.sh
@@ -60,6 +60,9 @@ validate-phase4:
 
 lampstand-vertical-slice-smoke:
 	bash apps/lampstand/scripts/vertical_slice_smoke.sh
+
+lampstand-zone-smoke:
+	python3 tools/smoke_lampstand_zone.py
 
 validate-fogstack:
 	python3 tools/validate_fogstack.py

--- a/apps/lampstand/scripts/vertical_slice_smoke.sh
+++ b/apps/lampstand/scripts/vertical_slice_smoke.sh
@@ -16,6 +16,8 @@ EOF
 python3 -m prophet_platform_lampstand.main ingest \
   --path "$TMP/input/sample.txt" \
   --scope-ref "scope://local/default" \
+  --zone-ref "zone://edge" \
+  --topic-ref "zone.edge.carrier.ingested.v1" \
   --classifier "slice:phase4" \
   --classifier "service:lampstand"
 


### PR DESCRIPTION
## Summary

This PR wires the existing zone-aware Lampstand smoke path into the repository’s standard smoke surface.

It does two things:
- updates `Makefile` to add `lampstand-zone-smoke` and include it in `make smoke`
- updates `apps/lampstand/scripts/vertical_slice_smoke.sh` so the vertical slice ingest call now passes:
  - `--zone-ref zone://edge`
  - `--topic-ref zone.edge.carrier.ingested.v1`

## Why

PR #95 merged the remaining Lampstand zone/topic propagation and added the repo-native `tools/smoke_lampstand_zone.py` smoke invocation. What was still missing was wiring that path into the standard repo smoke flow rather than leaving it as a standalone helper.

This PR closes that gap.

## Scope

Intentionally narrow:
- no transport-level publisher yet
- no new contracts
- no validator changes
- no CI workflow changes yet

## Result

After this PR:
- `make smoke` includes the zone-aware Lampstand smoke
- the existing vertical slice shell smoke aligns with the new zone/topic-aware ingest path
