### PR TITLE
apps: add node-commander config loader and runtime entrypoint

### DIFF
--- a/apps/node-commander/app/config.py
+++ b/apps/node-commander/app/config.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CONFIG_PATH = Path("/app/config/example.config.json")
+
+
+def _resolve_config_path() -> Path:
+    configured = os.environ.get("NODE_COMMANDER_CONFIG")
+    if configured:
+        return Path(configured)
+    return DEFAULT_CONFIG_PATH
+
+
+def load_config() -> dict[str, Any]:
+    path = _resolve_config_path()
+    if not path.exists():
+        return {
+            "mode": "bootstrap",
+            "control_node_profile_ref": None,
+            "node_commander_runtime_ref": None,
+            "promotion_gate_ref": None,
+            "evidence_dir": None,
+            "image_ref": None,
+            "config_path": str(path),
+            "config_loaded": False,
+        }
+
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    data = dict(data)
+    data["config_path"] = str(path)
+    data["config_loaded"] = True
+    return data

--- a/apps/node-commander/app/runtime_main.py
+++ b/apps/node-commander/app/runtime_main.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .config import load_config
+
+app = FastAPI(title="Prophet Platform Node Commander Runtime", version="0.1.0")
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"status": "ok", "service": "node-commander"}
+
+
+@app.get("/readyz")
+def readyz() -> dict:
+    cfg = load_config()
+    return {
+        "status": "ready",
+        "service": "node-commander",
+        "config_loaded": cfg.get("config_loaded", False),
+    }
+
+
+@app.get("/v1/node-commander/status")
+def status() -> dict:
+    cfg = load_config()
+    return {
+        "service": "node-commander",
+        "mode": cfg.get("mode", "bootstrap"),
+        "control_node_profile_ref": cfg.get("control_node_profile_ref"),
+        "node_commander_runtime_ref": cfg.get("node_commander_runtime_ref"),
+        "promotion_gate_ref": cfg.get("promotion_gate_ref"),
+        "evidence_dir": cfg.get("evidence_dir"),
+        "image_ref": cfg.get("image_ref"),
+        "config_path": cfg.get("config_path"),
+        "config_loaded": cfg.get("config_loaded", False),
+    }
+
+
+@app.get("/v1/node-commander/heartbeat")
+def heartbeat() -> dict:
+    cfg = load_config()
+    return {
+        "service": "node-commander",
+        "heartbeat": "ok",
+        "mode": cfg.get("mode", "bootstrap"),
+        "config_loaded": cfg.get("config_loaded", False),
+    }

--- a/apps/node-commander/tests/test_runtime_config.py
+++ b/apps/node-commander/tests/test_runtime_config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.config import load_config
+
+
+def test_load_config_from_env(tmp_path: Path, monkeypatch) -> None:
+    cfg = {
+        "mode": "bootstrap",
+        "control_node_profile_ref": "urn:srcos:control-node:test"
+    }
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setenv("NODE_COMMANDER_CONFIG", str(cfg_path))
+
+    loaded = load_config()
+    assert loaded["config_loaded"] is True
+    assert loaded["control_node_profile_ref"] == "urn:srcos:control-node:test"


### PR DESCRIPTION
Stacked on top of PR #86.

Add the next narrow runtime step for `apps/node-commander/`:
- config loader
- runtime entrypoint that reflects loaded config
- runtime config smoke test

This keeps the implementation bootstrap-oriented while making the service consume real config instead of hard-coded status values.