### PR TITLE
apps: add node-commander CLI and local run helper

### DIFF
--- a/apps/node-commander/app/cli.py
+++ b/apps/node-commander/app/cli.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Sequence
+
+import uvicorn
+
+from .config import load_config
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="node-commander")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    serve = sub.add_parser("serve", help="run the node-commander runtime HTTP service")
+    serve.add_argument("--host", default="0.0.0.0")
+    serve.add_argument("--port", type=int, default=8080)
+
+    sub.add_parser("print-config", help="print the effective loaded config")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "print-config":
+        print(json.dumps(load_config(), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "serve":
+        uvicorn.run("app.runtime_main:app", host=args.host, port=args.port)
+        return 0
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/node-commander/scripts/run_local.sh
+++ b/apps/node-commander/scripts/run_local.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="${HOST:-0.0.0.0}"
+PORT="${PORT:-8080}"
+
+python -m app.cli serve --host "$HOST" --port "$PORT"

--- a/apps/node-commander/tests/test_cli.py
+++ b/apps/node-commander/tests/test_cli.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app import cli
+
+
+def test_print_config_reads_env(tmp_path: Path, monkeypatch, capsys) -> None:
+    cfg = {
+        "mode": "bootstrap",
+        "control_node_profile_ref": "urn:srcos:control-node:test"
+    }
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setenv("NODE_COMMANDER_CONFIG", str(cfg_path))
+
+    rc = cli.main(["print-config"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"control_node_profile_ref": "urn:srcos:control-node:test"' in out


### PR DESCRIPTION
Stacked on top of PR #98.

Add the next runtime step for `apps/node-commander/`:
- CLI entrypoint with `serve` and `print-config`
- local run helper
- CLI smoke test

This gives the starter runtime an explicit command path instead of only module-level HTTP entrypoints.