### PR TITLE
tests: add node-commander runtime HTTP checks and example-config launcher

### DIFF
--- a/apps/node-commander/scripts/run_with_example_config.sh
+++ b/apps/node-commander/scripts/run_with_example_config.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+export NODE_COMMANDER_CONFIG="$APP_DIR/config/example.config.json"
+python -m app.cli serve --host 0.0.0.0 --port 8080

--- a/apps/node-commander/tests/test_http_runtime_main.py
+++ b/apps/node-commander/tests/test_http_runtime_main.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import app.runtime_main as runtime_main
+
+client = TestClient(runtime_main.app)
+
+
+def test_runtime_readyz_exposes_config_state(monkeypatch, tmp_path: Path) -> None:
+    cfg = {
+        "mode": "bootstrap",
+        "control_node_profile_ref": "urn:srcos:control-node:test",
+        "node_commander_runtime_ref": "urn:srcos:node-commander:test",
+        "promotion_gate_ref": "urn:srcos:image-gate:test",
+        "evidence_dir": "/tmp/evidence",
+        "image_ref": "example/image:test",
+    }
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setenv("NODE_COMMANDER_CONFIG", str(cfg_path))
+
+    resp = client.get("/readyz")
+    assert resp.status_code == 200
+    assert resp.json()["config_loaded"] is True
+
+
+def test_runtime_status_reflects_loaded_config(monkeypatch, tmp_path: Path) -> None:
+    cfg = {
+        "mode": "bootstrap",
+        "control_node_profile_ref": "urn:srcos:control-node:test",
+        "node_commander_runtime_ref": "urn:srcos:node-commander:test",
+        "promotion_gate_ref": "urn:srcos:image-gate:test",
+        "evidence_dir": "/tmp/evidence",
+        "image_ref": "example/image:test",
+    }
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setenv("NODE_COMMANDER_CONFIG", str(cfg_path))
+
+    resp = client.get("/v1/node-commander/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["config_loaded"] is True
+    assert body["control_node_profile_ref"] == "urn:srcos:control-node:test"
+    assert body["image_ref"] == "example/image:test"


### PR DESCRIPTION
Stacked on top of PR #99.

Add:
- runtime-aware HTTP tests for `runtime_main`
- a launcher helper that runs the service with the example config

This keeps the branch additive but makes the runtime path more operator-usable and test-backed.