### PR TITLE
docs(platform): add office cloud runtime architecture and starter schemas

### DIFF
--- a/apps/node-commander/Containerfile
+++ b/apps/node-commander/Containerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml /app/pyproject.toml
+RUN pip install --no-cache-dir fastapi uvicorn
+
+COPY app /app/app
+COPY config /app/config
+
+EXPOSE 8080
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/apps/node-commander/README.md
+++ b/apps/node-commander/README.md
@@ -1,0 +1,34 @@
+# node-commander
+
+Bootstrap runtime starter for the local-first SourceOS / SociOS control-node lane.
+
+## Purpose
+
+`node-commander` is the small operator-side runtime that gives the control node a concrete, deployable command surface before the larger image-generation and validation flow is fully wired.
+
+This starter is intentionally narrow. It proves the runtime home and service shape inside `prophet-platform` without pretending the full implementation is finished.
+
+## Current scope
+
+This starter owns:
+
+- `/healthz` — liveness only
+- `/readyz` — local runtime readiness only
+- `/v1/node-commander/status` — minimal local status envelope
+- `/v1/node-commander/heartbeat` — explicit bootstrap heartbeat surface
+
+## Non-goals in this starter
+
+This starter does not yet:
+
+- issue real node control commands
+- run build/promotion gates itself
+- own the canonical contract definitions
+- replace `agentplane` execution/evidence ownership
+
+## Upstream / downstream split
+
+- canonical contracts: `SourceOS-Linux/sourceos-spec`
+- workstation/bootstrap lane: `SociOS-Linux/source-os`
+- execution/evidence seam: `SocioProphet/agentplane`
+- runtime implementation: this repo

--- a/apps/node-commander/app/cli.py
+++ b/apps/node-commander/app/cli.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Sequence
+
+import uvicorn
+
+from .config import load_config
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="node-commander")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    serve = sub.add_parser("serve", help="run the node-commander runtime HTTP service")
+    serve.add_argument("--host", default="0.0.0.0")
+    serve.add_argument("--port", type=int, default=8080)
+
+    sub.add_parser("print-config", help="print the effective loaded config")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "print-config":
+        print(json.dumps(load_config(), indent=2, sort_keys=True))
+        return 0
+
+    if args.command == "serve":
+        uvicorn.run("app.runtime_main:app", host=args.host, port=args.port)
+        return 0
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/node-commander/app/config.py
+++ b/apps/node-commander/app/config.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CONFIG_PATH = Path("/app/config/example.config.json")
+
+
+def _resolve_config_path() -> Path:
+    configured = os.environ.get("NODE_COMMANDER_CONFIG")
+    if configured:
+        return Path(configured)
+    return DEFAULT_CONFIG_PATH
+
+
+def load_config() -> dict[str, Any]:
+    path = _resolve_config_path()
+    if not path.exists():
+        return {
+            "mode": "bootstrap",
+            "control_node_profile_ref": None,
+            "node_commander_runtime_ref": None,
+            "promotion_gate_ref": None,
+            "evidence_dir": None,
+            "image_ref": None,
+            "config_path": str(path),
+            "config_loaded": False,
+        }
+
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    data = dict(data)
+    data["config_path"] = str(path)
+    data["config_loaded"] = True
+    return data

--- a/apps/node-commander/app/main.py
+++ b/apps/node-commander/app/main.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from . import service
+
+app = FastAPI(title="Prophet Platform Node Commander", version="0.1.0")
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"status": "ok", "service": "node-commander"}
+
+
+@app.get("/readyz")
+def readyz() -> dict:
+    return {"status": "ready", "service": "node-commander"}
+
+
+@app.get("/v1/node-commander/status")
+def status() -> dict:
+    return service.get_status_view()
+
+
+@app.get("/v1/node-commander/heartbeat")
+def heartbeat() -> dict:
+    return service.get_heartbeat_view()

--- a/apps/node-commander/app/runtime_main.py
+++ b/apps/node-commander/app/runtime_main.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .config import load_config
+
+app = FastAPI(title="Prophet Platform Node Commander Runtime", version="0.1.0")
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"status": "ok", "service": "node-commander"}
+
+
+@app.get("/readyz")
+def readyz() -> dict:
+    cfg = load_config()
+    return {
+        "status": "ready",
+        "service": "node-commander",
+        "config_loaded": cfg.get("config_loaded", False),
+    }
+
+
+@app.get("/v1/node-commander/status")
+def status() -> dict:
+    cfg = load_config()
+    return {
+        "service": "node-commander",
+        "mode": cfg.get("mode", "bootstrap"),
+        "control_node_profile_ref": cfg.get("control_node_profile_ref"),
+        "node_commander_runtime_ref": cfg.get("node_commander_runtime_ref"),
+        "promotion_gate_ref": cfg.get("promotion_gate_ref"),
+        "evidence_dir": cfg.get("evidence_dir"),
+        "image_ref": cfg.get("image_ref"),
+        "config_path": cfg.get("config_path"),
+        "config_loaded": cfg.get("config_loaded", False),
+    }
+
+
+@app.get("/v1/node-commander/heartbeat")
+def heartbeat() -> dict:
+    cfg = load_config()
+    return {
+        "service": "node-commander",
+        "heartbeat": "ok",
+        "mode": cfg.get("mode", "bootstrap"),
+        "config_loaded": cfg.get("config_loaded", False),
+    }

--- a/apps/node-commander/app/service.py
+++ b/apps/node-commander/app/service.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def get_status_view() -> dict:
+    return {
+        "service": "node-commander",
+        "mode": "bootstrap",
+        "placement_order": [
+            "local",
+            "trusted-private",
+            "attested-fog",
+            "burst-cloud"
+        ],
+        "runtime": {
+            "container_runtime": "podman",
+            "service_scope": "user"
+        },
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def get_heartbeat_view() -> dict:
+    return {
+        "service": "node-commander",
+        "heartbeat": "ok",
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/apps/node-commander/config/example.config.json
+++ b/apps/node-commander/config/example.config.json
@@ -1,0 +1,8 @@
+{
+  "mode": "bootstrap",
+  "control_node_profile_ref": "urn:srcos:control-node:macbook-air-operator-01",
+  "node_commander_runtime_ref": "urn:srcos:node-commander:runtime:macbook-air-operator-01",
+  "promotion_gate_ref": "urn:srcos:image-gate:sourceos-workstation-v0-dev",
+  "evidence_dir": "/var/lib/node-commander/evidence",
+  "image_ref": "us-central1-docker.pkg.dev/socioprophet-web/node-commander/node-commander:dev-boot"
+}

--- a/apps/node-commander/pyproject.toml
+++ b/apps/node-commander/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "node-commander"
+version = "0.1.0"
+description = "Bootstrap runtime starter for the local-first SourceOS / SociOS control-node lane"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.115,<1.0",
+  "uvicorn>=0.32,<1.0"
+]
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/apps/node-commander/scripts/run_local.sh
+++ b/apps/node-commander/scripts/run_local.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="${HOST:-0.0.0.0}"
+PORT="${PORT:-8080}"
+
+python -m app.cli serve --host "$HOST" --port "$PORT"

--- a/apps/node-commander/scripts/run_with_example_config.sh
+++ b/apps/node-commander/scripts/run_with_example_config.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+export NODE_COMMANDER_CONFIG="$APP_DIR/config/example.config.json"
+python -m app.cli serve --host 0.0.0.0 --port 8080

--- a/apps/node-commander/tests/test_cli.py
+++ b/apps/node-commander/tests/test_cli.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app import cli
+
+
+def test_print_config_reads_env(tmp_path: Path, monkeypatch, capsys) -> None:
+    cfg = {
+        "mode": "bootstrap",
+        "control_node_profile_ref": "urn:srcos:control-node:test"
+    }
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setenv("NODE_COMMANDER_CONFIG", str(cfg_path))
+
+    rc = cli.main(["print-config"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"control_node_profile_ref": "urn:srcos:control-node:test"' in out

--- a/apps/node-commander/tests/test_http_main.py
+++ b/apps/node-commander/tests/test_http_main.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+import app.main as main
+
+client = TestClient(main.app)
+
+
+def test_healthz() -> None:
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json()["service"] == "node-commander"
+
+
+def test_readyz() -> None:
+    resp = client.get("/readyz")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ready"
+
+
+def test_status_route() -> None:
+    resp = client.get("/v1/node-commander/status")
+    assert resp.status_code == 200
+    assert resp.json()["service"] == "node-commander"
+    assert resp.json()["runtime"]["container_runtime"] == "podman"
+
+
+def test_heartbeat_route() -> None:
+    resp = client.get("/v1/node-commander/heartbeat")
+    assert resp.status_code == 200
+    assert resp.json()["heartbeat"] == "ok"

--- a/apps/node-commander/tests/test_http_runtime_main.py
+++ b/apps/node-commander/tests/test_http_runtime_main.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import app.runtime_main as runtime_main
+
+client = TestClient(runtime_main.app)
+
+
+def test_runtime_readyz_exposes_config_state(monkeypatch, tmp_path: Path) -> None:
+    cfg = {
+        "mode": "bootstrap",
+        "control_node_profile_ref": "urn:srcos:control-node:test",
+        "node_commander_runtime_ref": "urn:srcos:node-commander:test",
+        "promotion_gate_ref": "urn:srcos:image-gate:test",
+        "evidence_dir": "/tmp/evidence",
+        "image_ref": "example/image:test",
+    }
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setenv("NODE_COMMANDER_CONFIG", str(cfg_path))
+
+    resp = client.get("/readyz")
+    assert resp.status_code == 200
+    assert resp.json()["config_loaded"] is True
+
+
+def test_runtime_status_reflects_loaded_config(monkeypatch, tmp_path: Path) -> None:
+    cfg = {
+        "mode": "bootstrap",
+        "control_node_profile_ref": "urn:srcos:control-node:test",
+        "node_commander_runtime_ref": "urn:srcos:node-commander:test",
+        "promotion_gate_ref": "urn:srcos:image-gate:test",
+        "evidence_dir": "/tmp/evidence",
+        "image_ref": "example/image:test",
+    }
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setenv("NODE_COMMANDER_CONFIG", str(cfg_path))
+
+    resp = client.get("/v1/node-commander/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["config_loaded"] is True
+    assert body["control_node_profile_ref"] == "urn:srcos:control-node:test"
+    assert body["image_ref"] == "example/image:test"

--- a/apps/node-commander/tests/test_runtime_config.py
+++ b/apps/node-commander/tests/test_runtime_config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.config import load_config
+
+
+def test_load_config_from_env(tmp_path: Path, monkeypatch) -> None:
+    cfg = {
+        "mode": "bootstrap",
+        "control_node_profile_ref": "urn:srcos:control-node:test"
+    }
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    monkeypatch.setenv("NODE_COMMANDER_CONFIG", str(cfg_path))
+
+    loaded = load_config()
+    assert loaded["config_loaded"] is True
+    assert loaded["control_node_profile_ref"] == "urn:srcos:control-node:test"

--- a/docs/NODE_COMMANDER_RUNTIME_CONTRACT.md
+++ b/docs/NODE_COMMANDER_RUNTIME_CONTRACT.md
@@ -1,0 +1,58 @@
+# Node Commander runtime contract (v0)
+
+## Purpose
+
+This note captures the first concrete runtime contract for the `apps/node-commander/` lane.
+
+It is intentionally narrow and matches the current bootstrap reality:
+
+- local-first operator/control-node runtime
+- Podman / OCI packaging
+- user-scoped service execution on the control node
+- explicit config, state, and log paths
+
+## Runtime identity
+
+- service name: `node-commander`
+- canonical app path: `apps/node-commander/`
+- canonical HTTP entrypoint: `app.main`
+- current mode: `bootstrap`
+
+## Expected packaging
+
+The runtime should support both:
+
+1. local Python service execution for development
+2. OCI image packaging for operator-node deployment and promotion tests
+
+The current preferred container runtime assumption is Podman/OCI.
+
+## Runtime directories
+
+The first contract shape assumes three host-visible paths:
+
+- config: `/etc/node-commander`
+- state: `/var/lib/node-commander`
+- logs: `/tmp/node-commander.log` and `/tmp/node-commander.err.log` during bootstrap, with a later move to a repo-governed or platform-governed destination
+
+## Configuration surface
+
+The runtime should accept, at minimum:
+
+- `mode` (`bootstrap`, later `service`)
+- `control_node_profile_ref`
+- `promotion_gate_ref`
+- `evidence_dir`
+- `image_ref`
+
+## Immediate non-goals
+
+This v0 contract does not yet require:
+
+- remote executor dispatch
+- full image-promotion policy enforcement
+- direct Git repo mutation
+- full CloudShell semantics
+- attested fog scheduling
+
+Those remain downstream follow-on slices.

--- a/docs/OFFICE_CLOUD_SUITE_RUNTIME.md
+++ b/docs/OFFICE_CLOUD_SUITE_RUNTIME.md
@@ -1,0 +1,60 @@
+# Office Cloud Suite Runtime
+
+## Purpose
+
+This document defines the platform runtime split for the SourceOS office and workspace suite.
+
+`prophet-platform` is the runtime and deployment home for the cloud office control plane. It should realize the office suite product semantics defined in `SocioProphet/prophet-workspace` and the host integration surfaces defined in `SociOS-Linux/source-os`.
+
+## Runtime responsibilities
+
+The platform should own:
+- WOPI host behavior and document session control
+- document metadata, versions, locks, and writeback records
+- office preview and conversion workers
+- office context extraction and indexing runtime
+- AI action routing and receipt emission
+- workflow runtime for office/document automations
+- deployment topology, namespaces, and service wiring
+
+## Service set
+
+Planned service surfaces:
+- `services/wopi-host/`
+- `services/office-render-convert/`
+- `services/office-context-extractor/`
+- `services/workspace-ai-orchestrator/`
+- `services/office-action-service/`
+- `services/workspace-agent-studio/`
+
+## Cross-repo integration
+
+### Upstream product/domain
+
+`SocioProphet/prophet-workspace` should define:
+- workspace office capability families
+- product parity expectations
+- user-facing and admin-facing semantics
+
+### Downstream host realization
+
+`SociOS-Linux/source-os` should define:
+- LibreOffice defaults
+- local extraction hooks
+- local smoke tests
+- font and MIME integration
+- desktop office shell behavior
+
+## First runtime contracts
+
+The first runtime contracts should include:
+- office document record
+- office AI action record
+- office AI receipt record
+- workspace flow record
+
+Those contracts should support local desktop and cloud editing paths without binding the product to a single editor implementation.
+
+## Editor posture
+
+The runtime should treat LibreOffice / Collabora as an editing and conversion engine, not as the total product. The workspace graph, AI orchestration, and document-control services belong at the platform layer.

--- a/schemas/office/office_ai_action.schema.json
+++ b/schemas/office/office_ai_action.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/office/office_ai_action.schema.json",
+  "title": "office_ai_action",
+  "type": "object",
+  "required": [
+    "action_id",
+    "action_type",
+    "approval_state"
+  ],
+  "properties": {
+    "action_id": {"type": "string"},
+    "action_type": {
+      "type": "string",
+      "enum": [
+        "INSERT_TEXT",
+        "REPLACE_TEXT",
+        "SUMMARIZE",
+        "CREATE_FORMULA",
+        "CREATE_CHART",
+        "CREATE_SLIDE",
+        "ADD_COMMENT",
+        "ADD_SUGGESTION",
+        "EXPORT",
+        "CREATE_TASK",
+        "DRAFT_EMAIL"
+      ]
+    },
+    "target_document_id": {"type": "string"},
+    "target_region": {"type": "string"},
+    "prompt_ref": {"type": "string"},
+    "grounding_refs": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "model_ref": {"type": "string"},
+    "proposed_change": {"type": "object"},
+    "approval_state": {
+      "type": "string",
+      "enum": ["PROPOSED", "APPROVED", "APPLIED", "REJECTED", "FAILED"]
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/office/office_document_record.schema.json
+++ b/schemas/office/office_document_record.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/office/office_document_record.schema.json",
+  "title": "office_document_record",
+  "type": "object",
+  "required": [
+    "document_id",
+    "tenant_id",
+    "storage_uri",
+    "source_provider",
+    "current_format",
+    "canonical_format",
+    "permissions_ref",
+    "version_head"
+  ],
+  "properties": {
+    "document_id": {"type": "string"},
+    "tenant_id": {"type": "string"},
+    "owner_id": {"type": "string"},
+    "storage_uri": {"type": "string"},
+    "source_provider": {
+      "type": "string",
+      "enum": ["SOURCEOS", "MICROSOFT", "GOOGLE", "IMPORTED", "UNKNOWN"]
+    },
+    "source_provider_id": {"type": "string"},
+    "source_mime_type": {"type": "string"},
+    "current_format": {"type": "string"},
+    "canonical_format": {
+      "type": "string",
+      "enum": ["ODF", "OOXML", "PDF", "MIXED"]
+    },
+    "permissions_ref": {"type": "string"},
+    "version_head": {"type": "string"},
+    "editor_binding": {
+      "type": "string",
+      "enum": ["LOCAL_LIBREOFFICE", "COLLABORA", "HEADLESS", "OTHER"]
+    },
+    "created_at": {"type": "string", "format": "date-time"},
+    "updated_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/schemas/workspace/workspace_flow_record.schema.json
+++ b/schemas/workspace/workspace_flow_record.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/workspace/workspace_flow_record.schema.json",
+  "title": "workspace_flow_record",
+  "type": "object",
+  "required": ["flow_id", "starter", "steps", "permissions", "enabled"],
+  "properties": {
+    "flow_id": {"type": "string"},
+    "starter": {"type": "object"},
+    "steps": {
+      "type": "array",
+      "items": {"type": "object"}
+    },
+    "variables": {
+      "type": "array",
+      "items": {"type": "object"}
+    },
+    "tools": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "approval_gates": {
+      "type": "array",
+      "items": {"type": "object"}
+    },
+    "schedule": {"type": "object"},
+    "permissions": {"type": "object"},
+    "audit_log_ref": {"type": "string"},
+    "enabled": {"type": "boolean"}
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

Seed the cloud/runtime home for the SourceOS office suite program inside the existing `prophet-platform` repo.

Add:
- `docs/OFFICE_CLOUD_SUITE_RUNTIME.md`
- `schemas/office/office_document_record.schema.json`
- `schemas/office/office_ai_action.schema.json`
- `schemas/workspace/workspace_flow_record.schema.json`

## Why

The workspace office suite needs a runtime and deployment home before we create any new repo surface.

This PR makes `prophet-platform` the runtime home for:
- WOPI host and document control
- office conversion / preview / extraction services
- AI action routing and workflow runtime
- starter office and workspace contracts consumed by platform services

## Cross-repo posture

- `prophet-workspace` = product semantics
- `prophet-platform` = runtime and deployment
- `source-os` = Linux and desktop integration

## Note

This is the first runtime slice only. It seeds architecture and contract scaffolding so follow-on services can land against an agreed shape.
