### PR TITLE
docs(platform): add office cloud runtime architecture and starter schemas (rebased)

### DIFF
--- a/docs/OFFICE_CLOUD_SUITE_RUNTIME.md
+++ b/docs/OFFICE_CLOUD_SUITE_RUNTIME.md
@@ -1,0 +1,60 @@
+# Office Cloud Suite Runtime
+
+## Purpose
+
+This document defines the platform runtime split for the SourceOS office and workspace suite.
+
+`prophet-platform` is the runtime and deployment home for the cloud office control plane. It should realize the office suite product semantics defined in `SocioProphet/prophet-workspace` and the host integration surfaces defined in `SociOS-Linux/source-os`.
+
+## Runtime responsibilities
+
+The platform should own:
+- WOPI host behavior and document session control
+- document metadata, versions, locks, and writeback records
+- office preview and conversion workers
+- office context extraction and indexing runtime
+- AI action routing and receipt emission
+- workflow runtime for office/document automations
+- deployment topology, namespaces, and service wiring
+
+## Service set
+
+Planned service surfaces:
+- `services/wopi-host/`
+- `services/office-render-convert/`
+- `services/office-context-extractor/`
+- `services/workspace-ai-orchestrator/`
+- `services/office-action-service/`
+- `services/workspace-agent-studio/`
+
+## Cross-repo integration
+
+### Upstream product/domain
+
+`SocioProphet/prophet-workspace` should define:
+- workspace office capability families
+- product parity expectations
+- user-facing and admin-facing semantics
+
+### Downstream host realization
+
+`SociOS-Linux/source-os` should define:
+- LibreOffice defaults
+- local extraction hooks
+- local smoke tests
+- font and MIME integration
+- desktop office shell behavior
+
+## First runtime contracts
+
+The first runtime contracts should include:
+- office document record
+- office AI action record
+- office AI receipt record
+- workspace flow record
+
+Those contracts should support local desktop and cloud editing paths without binding the product to a single editor implementation.
+
+## Editor posture
+
+The runtime should treat LibreOffice / Collabora as an editing and conversion engine, not as the total product. The workspace graph, AI orchestration, and document-control services belong at the platform layer.

--- a/schemas/office/office_ai_action.schema.json
+++ b/schemas/office/office_ai_action.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/office/office_ai_action.schema.json",
+  "title": "office_ai_action",
+  "type": "object",
+  "required": [
+    "action_id",
+    "action_type",
+    "approval_state"
+  ],
+  "properties": {
+    "action_id": {"type": "string"},
+    "action_type": {
+      "type": "string",
+      "enum": [
+        "INSERT_TEXT",
+        "REPLACE_TEXT",
+        "SUMMARIZE",
+        "CREATE_FORMULA",
+        "CREATE_CHART",
+        "CREATE_SLIDE",
+        "ADD_COMMENT",
+        "ADD_SUGGESTION",
+        "EXPORT",
+        "CREATE_TASK",
+        "DRAFT_EMAIL"
+      ]
+    },
+    "target_document_id": {"type": "string"},
+    "target_region": {"type": "string"},
+    "prompt_ref": {"type": "string"},
+    "grounding_refs": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "model_ref": {"type": "string"},
+    "proposed_change": {"type": "object"},
+    "approval_state": {
+      "type": "string",
+      "enum": ["PROPOSED", "APPROVED", "APPLIED", "REJECTED", "FAILED"]
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/office/office_document_record.schema.json
+++ b/schemas/office/office_document_record.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/office/office_document_record.schema.json",
+  "title": "office_document_record",
+  "type": "object",
+  "required": [
+    "document_id",
+    "tenant_id",
+    "storage_uri",
+    "source_provider",
+    "current_format",
+    "canonical_format",
+    "permissions_ref",
+    "version_head"
+  ],
+  "properties": {
+    "document_id": {"type": "string"},
+    "tenant_id": {"type": "string"},
+    "owner_id": {"type": "string"},
+    "storage_uri": {"type": "string"},
+    "source_provider": {
+      "type": "string",
+      "enum": ["SOURCEOS", "MICROSOFT", "GOOGLE", "IMPORTED", "UNKNOWN"]
+    },
+    "source_provider_id": {"type": "string"},
+    "source_mime_type": {"type": "string"},
+    "current_format": {"type": "string"},
+    "canonical_format": {
+      "type": "string",
+      "enum": ["ODF", "OOXML", "PDF", "MIXED"]
+    },
+    "permissions_ref": {"type": "string"},
+    "version_head": {"type": "string"},
+    "editor_binding": {
+      "type": "string",
+      "enum": ["LOCAL_LIBREOFFICE", "COLLABORA", "HEADLESS", "OTHER"]
+    },
+    "created_at": {"type": "string", "format": "date-time"},
+    "updated_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/schemas/workspace/workspace_flow_record.schema.json
+++ b/schemas/workspace/workspace_flow_record.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/workspace/workspace_flow_record.schema.json",
+  "title": "workspace_flow_record",
+  "type": "object",
+  "required": ["flow_id", "starter", "steps", "permissions", "enabled"],
+  "properties": {
+    "flow_id": {"type": "string"},
+    "starter": {"type": "object"},
+    "steps": {
+      "type": "array",
+      "items": {"type": "object"}
+    },
+    "variables": {
+      "type": "array",
+      "items": {"type": "object"}
+    },
+    "tools": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "approval_gates": {
+      "type": "array",
+      "items": {"type": "object"}
+    },
+    "schedule": {"type": "object"},
+    "permissions": {"type": "object"},
+    "audit_log_ref": {"type": "string"},
+    "enabled": {"type": "boolean"}
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

Replaces the polluted office runtime PR with a fresh current-`main` branch containing only the office runtime slice.

Add:
- `docs/OFFICE_CLOUD_SUITE_RUNTIME.md`
- `schemas/office/office_document_record.schema.json`
- `schemas/office/office_ai_action.schema.json`
- `schemas/workspace/workspace_flow_record.schema.json`

## Why

The prior runtime branch picked up unrelated `node-commander` history. This rebased PR replays only the office runtime files onto current `main`.

## Cross-repo posture

- `prophet-workspace` = product semantics and capability contract
- `prophet-platform` = cloud/runtime realization
- `source-os` = Linux and desktop realization
