### PR TITLE
apps: add Liberty Stack readout canonical app entrypoint

### DIFF
--- a/apps/liberty-stack-readout/app.py
+++ b/apps/liberty-stack-readout/app.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from combined_readout import app
+
+__all__ = ["app"]

--- a/apps/liberty-stack-readout/scripts/run_canonical_app.sh
+++ b/apps/liberty-stack-readout/scripts/run_canonical_app.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uvicorn app:app --host 127.0.0.1 --port 8080 --reload

--- a/apps/liberty-stack-readout/tests/test_app_entrypoint.py
+++ b/apps/liberty-stack-readout/tests/test_app_entrypoint.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(relative_path: str, module_name: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_app_entrypoint_exports_app():
+    app_module = load_module('app.py', 'liberty_stack_readout_app')
+    assert hasattr(app_module, 'app')


### PR DESCRIPTION
## Summary

Add the missing canonical package-scoped app entrypoint for the Liberty Stack readout app.

## What this PR adds

- `apps/liberty-stack-readout/app.py`
- `apps/liberty-stack-readout/tests/test_app_entrypoint.py`

## Why

The readout app on `main` already has:
- package metadata
- local runner scripts
- multiple runtime entry surfaces

What it was still missing was one canonical package-scoped `app` entrypoint that downstream tools and runners can target consistently.

## Scope

This is intentionally thin and additive. It does not change the existing runtime surfaces; it adds the canonical exported entrypoint on top of them.
