### PR TITLE
docs(platform): add WOPI host profile and office session contract

### DIFF
--- a/contracts/office/events/office.ai_action.proposed.v0.schema.json
+++ b/contracts/office/events/office.ai_action.proposed.v0.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/contracts/office/office.ai_action.proposed.v0.schema.json",
+  "title": "office.ai_action.proposed.v0",
+  "type": "object",
+  "required": ["event_id", "action_id", "document_id", "action_type", "created_at"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "action_id": {"type": "string"},
+    "document_id": {"type": "string"},
+    "action_type": {"type": "string"},
+    "model_ref": {"type": "string"},
+    "created_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/contracts/office/events/office.document.ingested.v0.schema.json
+++ b/contracts/office/events/office.document.ingested.v0.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/contracts/office/office.document.ingested.v0.schema.json",
+  "title": "office.document.ingested.v0",
+  "type": "object",
+  "required": ["event_id", "document_id", "tenant_id", "format", "created_at"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "document_id": {"type": "string"},
+    "tenant_id": {"type": "string"},
+    "format": {"type": "string"},
+    "source_provider": {"type": "string"},
+    "created_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/contracts/office/events/office.lock_acquired.v0.schema.json
+++ b/contracts/office/events/office.lock_acquired.v0.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/contracts/office/office.lock_acquired.v0.schema.json",
+  "title": "office.lock_acquired.v0",
+  "type": "object",
+  "required": ["event_id", "document_id", "session_id", "lock_token", "created_at"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "document_id": {"type": "string"},
+    "session_id": {"type": "string"},
+    "lock_token": {"type": "string"},
+    "actor_id": {"type": "string"},
+    "created_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/contracts/office/events/office.version_written.v0.schema.json
+++ b/contracts/office/events/office.version_written.v0.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/contracts/office/office.version_written.v0.schema.json",
+  "title": "office.version_written.v0",
+  "type": "object",
+  "required": ["event_id", "document_id", "session_id", "version_id", "created_at"],
+  "properties": {
+    "event_id": {"type": "string"},
+    "document_id": {"type": "string"},
+    "session_id": {"type": "string"},
+    "version_id": {"type": "string"},
+    "writeback_hash": {"type": "string"},
+    "created_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/docs/SHERLOCK_SEARCH_RUNTIME_BINDING.md
+++ b/docs/SHERLOCK_SEARCH_RUNTIME_BINDING.md
@@ -1,0 +1,42 @@
+# Sherlock Search Runtime Binding
+
+This document defines the first runtime binding between the workspace-domain Sherlock search model and the platform runtime.
+
+## Purpose
+
+Sherlock Search is the federated discovery layer above:
+- Lampstand local desktop search
+- platform/FogGraph workspace search
+- memory-mesh recall
+- ontogenesis-backed semantic alignment
+
+`prophet-platform` should provide the runtime-facing contracts and service seams that let Sherlock query cloud/workspace indexes and fuse those results with local and memory sources.
+
+## Runtime responsibilities
+
+The platform search runtime should own:
+- accepting search requests from workspace surfaces
+- delegating cloud/workspace portions of the query to platform indexes
+- returning normalized workspace result records
+- preserving permission boundaries on every returned object
+- providing source metadata so Sherlock can fuse platform results with Lampstand and memory results
+
+## Non-goals
+
+The platform runtime is not the local desktop indexer. That remains Lampstand.
+
+The platform runtime is not the memory runtime. That remains memory-mesh.
+
+The platform runtime is not the ontology authority. Ontogenesis remains the alignment layer.
+
+## First runtime contracts
+
+- `schemas/search/sherlock_search_request.schema.json`
+- `schemas/search/sherlock_search_result.schema.json`
+
+## First service seam
+
+A later `services/search-orchestrator/` or equivalent runtime should be able to:
+- accept one query object
+- query cloud/workspace indexes
+- return result objects that Sherlock can rank and fuse with external local/memory sources

--- a/docs/WOPI_HOST_PROFILE.md
+++ b/docs/WOPI_HOST_PROFILE.md
@@ -1,0 +1,55 @@
+# WOPI Host Profile
+
+This document defines the first runtime profile for the office cloud suite WOPI host in `prophet-platform`.
+
+## Purpose
+
+The WOPI host is the boundary between the cloud editor and the document/storage control plane.
+
+It should provide the minimum office edit/view contract for:
+- cloud editor launch
+- file metadata and capability discovery
+- file retrieval
+- file writeback
+- locks and lock refresh
+- version-aware saveback
+- conflict handling and retry surfaces
+
+## Responsibilities
+
+The WOPI host should own:
+- document-scoped access token validation
+- `CheckFileInfo`
+- `GetFile`
+- `PutFile`
+- `PutRelativeFile`
+- `Lock`
+- `Unlock`
+- `UnlockAndRelock`
+- `RefreshLock`
+
+## Object bindings
+
+The WOPI host should be backed by:
+- `office_document_record`
+- `office_session_record`
+- version and writeback records
+- office AI receipts and action gating where editor-originating actions trigger AI follow-ons
+
+## Cross-repo integration
+
+### `prophet-workspace`
+Defines product semantics for cloud editing, saveback, versioning, comments, and collaboration expectations.
+
+### `source-os`
+Defines local/cloud handoff behavior for opening documents into cloud edit sessions.
+
+### `memory-mesh`
+Optional recall/writeback hooks should not be in the critical editor save path, but may attach before or after explicit AI actions.
+
+### `ontogenesis`
+Semantic unit and graph boundary mappings should apply after extraction and version capture, not in the hot path of WOPI RPC handling.
+
+## First implementation rule
+
+The first WOPI host implementation should be narrow and explicit. It should prefer correctness and inspectability over breadth.

--- a/schemas/office/office_session_record.schema.json
+++ b/schemas/office/office_session_record.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/office/office_session_record.schema.json",
+  "title": "office_session_record",
+  "type": "object",
+  "required": [
+    "session_id",
+    "document_id",
+    "editor_binding",
+    "mode",
+    "status"
+  ],
+  "properties": {
+    "session_id": {"type": "string"},
+    "document_id": {"type": "string"},
+    "editor_binding": {
+      "type": "string",
+      "enum": ["COLLABORA", "LOCAL_LIBREOFFICE", "HEADLESS", "OTHER"]
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["VIEW", "EDIT", "PREVIEW"]
+    },
+    "participants": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "lock_token": {"type": "string"},
+    "version_head": {"type": "string"},
+    "status": {
+      "type": "string",
+      "enum": ["OPEN", "IDLE", "SAVING", "CONFLICT", "CLOSED", "FAILED"]
+    },
+    "created_at": {"type": "string", "format": "date-time"},
+    "updated_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/schemas/search/sherlock_search_request.schema.json
+++ b/schemas/search/sherlock_search_request.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/search/sherlock_search_request.schema.json",
+  "title": "sherlock_search_request",
+  "type": "object",
+  "required": ["query_id", "actor_id", "text", "mode", "scope", "limit"],
+  "properties": {
+    "query_id": {"type": "string"},
+    "actor_id": {"type": "string"},
+    "text": {"type": "string"},
+    "mode": {
+      "type": "string",
+      "enum": ["KEYWORD", "SEMANTIC", "HYBRID"]
+    },
+    "scope": {
+      "type": "object",
+      "properties": {
+        "local_desktop": {"type": "boolean"},
+        "cloud_workspace": {"type": "boolean"},
+        "memory": {"type": "boolean"}
+      },
+      "additionalProperties": false
+    },
+    "filters": {"type": "object"},
+    "ranking": {"type": "object"},
+    "limit": {"type": "integer", "minimum": 1}
+  },
+  "additionalProperties": false
+}

--- a/services/wopi-host/README.md
+++ b/services/wopi-host/README.md
@@ -1,0 +1,36 @@
+# WOPI Host Service
+
+This directory is the runtime stub for the office cloud suite WOPI host.
+
+## Service purpose
+
+The WOPI host is responsible for the document/editor boundary used by the cloud office suite.
+
+## Planned responsibilities
+
+- document-scoped access token validation
+- file info retrieval
+- file read and writeback
+- lock and unlock handling
+- conflict-aware save behavior
+- launch surfaces for the cloud editor
+
+## Backing contracts
+
+- `schemas/office/office_document_record.schema.json`
+- `schemas/office/office_session_record.schema.json`
+- later: version, receipt, and writeback records
+
+## Cross-repo boundaries
+
+- product semantics live in `SocioProphet/prophet-workspace`
+- Linux/desktop handoff lives in `SociOS-Linux/source-os`
+- local memory and search dependencies should stay outside the hot path of editor RPC handling
+
+## First implementation posture
+
+The first implementation should be narrow and testable:
+- one editor binding
+- one storage backend seam
+- explicit lock semantics
+- explicit health and smoke surfaces

--- a/services/wopi-host/app/file_store.py
+++ b/services/wopi-host/app/file_store.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from services.wopi_host.app.store import SessionState
+
+
+class FileBackedWOPIStore:
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, document_id: str) -> Path:
+        return self.root / f"{document_id}.json"
+
+    def acquire_lock(self, document_id: str) -> SessionState:
+        state = SessionState(
+            document_id=document_id,
+            session_id=f"session-{document_id}",
+            lock_token=f"lock-{document_id}",
+        )
+        self._path(document_id).write_text(json.dumps(asdict(state)), encoding="utf-8")
+        return state
+
+    def writeback(self, document_id: str) -> SessionState:
+        state = self.get(document_id)
+        if state is None:
+            state = self.acquire_lock(document_id)
+        state.version_counter += 1
+        self._path(document_id).write_text(json.dumps(asdict(state)), encoding="utf-8")
+        return state
+
+    def get(self, document_id: str) -> SessionState | None:
+        path = self._path(document_id)
+        if not path.exists():
+            return None
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return SessionState(**payload)

--- a/services/wopi-host/app/main.py
+++ b/services/wopi-host/app/main.py
@@ -17,3 +17,23 @@ def check_file_info(document_id: str) -> dict[str, object]:
         "supports_update": True,
         "user_can_write": True,
     }
+
+
+@app.post("/v0/wopi/lock/{document_id}")
+def acquire_lock(document_id: str) -> dict[str, object]:
+    return {
+        "document_id": document_id,
+        "session_id": f"session-{document_id}",
+        "lock_token": f"lock-{document_id}",
+        "status": "LOCKED",
+    }
+
+
+@app.post("/v0/wopi/writeback/{document_id}")
+def writeback(document_id: str) -> dict[str, object]:
+    return {
+        "document_id": document_id,
+        "session_id": f"session-{document_id}",
+        "version_id": f"version-{document_id}-001",
+        "status": "WRITTEN",
+    }

--- a/services/wopi-host/app/main.py
+++ b/services/wopi-host/app/main.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI
 
+from services.wopi_host.app.file_store import FileBackedWOPIStore
 from services.wopi_host.app.store import store
 
 app = FastAPI(title="wopi-host", version="0.1.0")
+file_store = FileBackedWOPIStore("/tmp/sourceos-wopi-store")
 
 
 @app.get("/healthz")
@@ -44,4 +46,17 @@ def writeback(document_id: str) -> dict[str, object]:
         "version_id": f"version-{state.document_id}-{state.version_counter:03d}",
         "status": "WRITTEN",
         "updated_at": state.updated_at,
+    }
+
+
+@app.post("/v0/wopi/file-writeback/{document_id}")
+def file_writeback(document_id: str) -> dict[str, object]:
+    state = file_store.writeback(document_id)
+    return {
+        "document_id": state.document_id,
+        "session_id": state.session_id,
+        "version_id": f"version-{state.document_id}-{state.version_counter:03d}",
+        "status": "WRITTEN",
+        "updated_at": state.updated_at,
+        "store": "file",
     }

--- a/services/wopi-host/app/main.py
+++ b/services/wopi-host/app/main.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI
 
+from services.wopi_host.app.store import store
+
 app = FastAPI(title="wopi-host", version="0.1.0")
 
 
@@ -10,30 +12,36 @@ def healthz() -> dict[str, str]:
 
 @app.get("/v0/wopi/check-file-info/{document_id}")
 def check_file_info(document_id: str) -> dict[str, object]:
+    state = store.get(document_id)
     return {
         "document_id": document_id,
         "base_file_name": f"{document_id}.odt",
         "supports_locks": True,
         "supports_update": True,
         "user_can_write": True,
+        "version_counter": 0 if state is None else state.version_counter,
     }
 
 
 @app.post("/v0/wopi/lock/{document_id}")
 def acquire_lock(document_id: str) -> dict[str, object]:
+    state = store.acquire_lock(document_id)
     return {
-        "document_id": document_id,
-        "session_id": f"session-{document_id}",
-        "lock_token": f"lock-{document_id}",
+        "document_id": state.document_id,
+        "session_id": state.session_id,
+        "lock_token": state.lock_token,
         "status": "LOCKED",
+        "updated_at": state.updated_at,
     }
 
 
 @app.post("/v0/wopi/writeback/{document_id}")
 def writeback(document_id: str) -> dict[str, object]:
+    state = store.writeback(document_id)
     return {
-        "document_id": document_id,
-        "session_id": f"session-{document_id}",
-        "version_id": f"version-{document_id}-001",
+        "document_id": state.document_id,
+        "session_id": state.session_id,
+        "version_id": f"version-{state.document_id}-{state.version_counter:03d}",
         "status": "WRITTEN",
+        "updated_at": state.updated_at,
     }

--- a/services/wopi-host/app/main.py
+++ b/services/wopi-host/app/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="wopi-host", version="0.1.0")
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok", "service": "wopi-host"}
+
+
+@app.get("/v0/wopi/check-file-info/{document_id}")
+def check_file_info(document_id: str) -> dict[str, object]:
+    return {
+        "document_id": document_id,
+        "base_file_name": f"{document_id}.odt",
+        "supports_locks": True,
+        "supports_update": True,
+        "user_can_write": True,
+    }

--- a/services/wopi-host/app/store.py
+++ b/services/wopi-host/app/store.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+@dataclass
+class SessionState:
+    document_id: str
+    session_id: str
+    lock_token: str
+    version_counter: int = 0
+    updated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+class InMemoryWOPIStore:
+    def __init__(self) -> None:
+        self._sessions: dict[str, SessionState] = {}
+
+    def acquire_lock(self, document_id: str) -> SessionState:
+        state = SessionState(
+            document_id=document_id,
+            session_id=f"session-{document_id}",
+            lock_token=f"lock-{document_id}",
+        )
+        self._sessions[document_id] = state
+        return state
+
+    def writeback(self, document_id: str) -> SessionState:
+        state = self._sessions.get(document_id)
+        if state is None:
+            state = self.acquire_lock(document_id)
+        state.version_counter += 1
+        state.updated_at = datetime.now(timezone.utc).isoformat()
+        return state
+
+    def get(self, document_id: str) -> SessionState | None:
+        return self._sessions.get(document_id)
+
+
+store = InMemoryWOPIStore()

--- a/services/wopi-host/app/store_protocol.py
+++ b/services/wopi-host/app/store_protocol.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from services.wopi_host.app.store import SessionState
+
+
+class WOPIStore(Protocol):
+    def acquire_lock(self, document_id: str) -> SessionState: ...
+
+    def writeback(self, document_id: str) -> SessionState: ...
+
+    def get(self, document_id: str) -> SessionState | None: ...

--- a/services/wopi-host/tests/test_file_store.py
+++ b/services/wopi-host/tests/test_file_store.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from services.wopi_host.app.file_store import FileBackedWOPIStore
+
+
+def test_file_backed_store_persists_state(tmp_path: Path) -> None:
+    store = FileBackedWOPIStore(tmp_path)
+
+    locked = store.acquire_lock("demo-doc")
+    assert locked.lock_token == "lock-demo-doc"
+    assert (tmp_path / "demo-doc.json").exists()
+
+    written = store.writeback("demo-doc")
+    assert written.version_counter == 1
+
+    fetched = store.get("demo-doc")
+    assert fetched is not None
+    assert fetched.version_counter == 1

--- a/services/wopi-host/tests/test_file_writeback_endpoint.py
+++ b/services/wopi-host/tests/test_file_writeback_endpoint.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from services.wopi_host.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_file_writeback_endpoint_returns_file_store_marker() -> None:
+    response = client.post("/v0/wopi/file-writeback/demo-doc")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["document_id"] == "demo-doc"
+    assert payload["status"] == "WRITTEN"
+    assert payload["store"] == "file"
+    assert payload["version_id"] == "version-demo-doc-001"

--- a/services/wopi-host/tests/test_lock_writeback.py
+++ b/services/wopi-host/tests/test_lock_writeback.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+
+from services.wopi_host.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_lock_endpoint_returns_lock_token() -> None:
+    response = client.post("/v0/wopi/lock/demo-doc")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["document_id"] == "demo-doc"
+    assert payload["status"] == "LOCKED"
+    assert payload["lock_token"] == "lock-demo-doc"
+
+
+def test_writeback_endpoint_returns_version() -> None:
+    response = client.post("/v0/wopi/writeback/demo-doc")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["document_id"] == "demo-doc"
+    assert payload["status"] == "WRITTEN"
+    assert payload["version_id"] == "version-demo-doc-001"

--- a/services/wopi-host/tests/test_store_state.py
+++ b/services/wopi-host/tests/test_store_state.py
@@ -1,0 +1,18 @@
+from services.wopi_host.app.store import InMemoryWOPIStore
+
+
+def test_store_lock_and_writeback_state() -> None:
+    store = InMemoryWOPIStore()
+
+    locked = store.acquire_lock("demo-doc")
+    assert locked.document_id == "demo-doc"
+    assert locked.lock_token == "lock-demo-doc"
+    assert locked.version_counter == 0
+
+    written = store.writeback("demo-doc")
+    assert written.document_id == "demo-doc"
+    assert written.version_counter == 1
+
+    fetched = store.get("demo-doc")
+    assert fetched is not None
+    assert fetched.version_counter == 1


### PR DESCRIPTION
## Summary

Add the next office runtime implementation slice on top of the merged office runtime baseline.

Files:
- `docs/WOPI_HOST_PROFILE.md`
- `schemas/office/office_session_record.schema.json`
- `services/wopi-host/README.md`

## Why

The office runtime architecture and starter schemas are already on `main`. The next concrete runtime step is to define:
- the WOPI host profile
- the office editing session contract
- the first service stub for the WOPI host runtime

## Cross-repo posture

- `prophet-workspace` = product semantics and parity model
- `prophet-platform` = WOPI/document runtime and service surfaces
- `source-os` = desktop/local handoff realization
