### PR TITLE
platform: add eval fabric lifecycle artifact builders

### DIFF
--- a/apps/eval-fabric-api/app/lifecycle_artifacts.py
+++ b/apps/eval-fabric-api/app/lifecycle_artifacts.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_promotion_decision(
+    *,
+    promotion_decision_id: str,
+    subject_ref: str,
+    source_ref: str,
+    current_stage: str,
+    target_stage: str,
+    required_gates: list[str],
+    evidence_refs: list[str],
+    promotion_window: str,
+    decision: str = "approved_with_gates",
+) -> dict[str, Any]:
+    return {
+        "promotion_decision_id": promotion_decision_id,
+        "subject_ref": subject_ref,
+        "source_ref": source_ref,
+        "current_stage": current_stage,
+        "target_stage": target_stage,
+        "decision": decision,
+        "required_gates": required_gates,
+        "evidence_refs": evidence_refs,
+        "promotion_window": promotion_window,
+    }
+
+
+def build_rollback_record(
+    *,
+    rollback_record_id: str,
+    subject_ref: str,
+    trigger_ref: str,
+    rollback_reason: str,
+    required_gates: list[str],
+    evidence_refs: list[str],
+    status: str = "rollback_ready",
+) -> dict[str, Any]:
+    return {
+        "rollback_record_id": rollback_record_id,
+        "subject_ref": subject_ref,
+        "trigger_ref": trigger_ref,
+        "rollback_reason": rollback_reason,
+        "required_gates": required_gates,
+        "evidence_refs": evidence_refs,
+        "status": status,
+    }
+
+
+def build_gate_activation_record(
+    *,
+    gate_activation_record_id: str,
+    action_ref: str,
+    required_gates: list[str],
+    activated_gates: list[str],
+    failed_gates: list[str],
+    policy_decision_ref: str,
+    approval_ref: str,
+    rollback_requirement: str,
+) -> dict[str, Any]:
+    return {
+        "gate_activation_record_id": gate_activation_record_id,
+        "action_ref": action_ref,
+        "required_gates": required_gates,
+        "activated_gates": activated_gates,
+        "failed_gates": failed_gates,
+        "policy_decision_ref": policy_decision_ref,
+        "approval_ref": approval_ref,
+        "rollback_requirement": rollback_requirement,
+    }
+
+
+def build_graduation_record(
+    *,
+    graduation_record_id: str,
+    agent_ref: str,
+    current_stage: str,
+    target_stage: str,
+    lane_scores: dict[str, int],
+    blocking_lanes: list[str],
+    promotion_window: str,
+    required_gates: list[str],
+    evidence_refs: list[str],
+) -> dict[str, Any]:
+    return {
+        "graduation_record_id": graduation_record_id,
+        "agent_ref": agent_ref,
+        "current_stage": current_stage,
+        "target_stage": target_stage,
+        "lane_scores": lane_scores,
+        "blocking_lanes": blocking_lanes,
+        "promotion_window": promotion_window,
+        "required_gates": required_gates,
+        "evidence_refs": evidence_refs,
+    }
+
+
+def build_lifecycle_artifact_graph(
+    *,
+    artifact_graph_id: str,
+    agent_ref: str,
+    edges: list[dict[str, str]],
+    evidence_refs: list[str],
+) -> dict[str, Any]:
+    return {
+        "artifact_graph_id": artifact_graph_id,
+        "agent_ref": agent_ref,
+        "edges": edges,
+        "evidence_refs": evidence_refs,
+    }

--- a/apps/eval-fabric-api/tests/test_lifecycle_artifact_builders.py
+++ b/apps/eval-fabric-api/tests/test_lifecycle_artifact_builders.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.lifecycle_artifacts import (
+    build_gate_activation_record,
+    build_graduation_record,
+    build_lifecycle_artifact_graph,
+    build_promotion_decision,
+    build_rollback_record,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str):
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_build_promotion_decision_matches_fixture() -> None:
+    expected = _load("promotion_decision_0001.json")
+    built = build_promotion_decision(**expected)
+    assert built == expected
+
+
+def test_build_rollback_record_matches_fixture() -> None:
+    expected = _load("rollback_record_0001.json")
+    built = build_rollback_record(**expected)
+    assert built == expected
+
+
+def test_build_gate_activation_record_matches_fixture() -> None:
+    expected = _load("gate_activation_record_0001.json")
+    built = build_gate_activation_record(**expected)
+    assert built == expected
+
+
+def test_build_graduation_record_matches_fixture() -> None:
+    expected = _load("graduation_record_0001.json")
+    built = build_graduation_record(**expected)
+    assert built == expected
+
+
+def test_build_lifecycle_artifact_graph_matches_fixture() -> None:
+    expected = _load("lifecycle_artifact_graph_0001.json")
+    built = build_lifecycle_artifact_graph(**expected)
+    assert built == expected


### PR DESCRIPTION
## Summary

Add a narrow runtime-adjacent helper layer for lifecycle artifacts in the eval-fabric app.

## Why

The current downstream stack now has fixture and test coverage for:
- promotion decisions
- rollback records
- gate activation records
- graduation records
- lifecycle artifact graphs

What it still lacks is a canonical builder module in the runtime codebase that can construct those artifact shapes directly, instead of leaving them only as fixture JSONs.

## Files included

- `apps/eval-fabric-api/app/lifecycle_artifacts.py`
- `apps/eval-fabric-api/tests/test_lifecycle_artifact_builders.py`

## What this adds

- builder helpers for promotion decisions
- builder helpers for rollback records
- builder helpers for gate activation records
- builder helpers for graduation records
- builder helpers for lifecycle artifact graphs
- tests that assert those builders reproduce the current canonical fixture shapes exactly

## Notes

This PR is intentionally narrow. It does not yet change live route behavior; it creates the canonical builder surface needed for a later runtime-emission phase while preserving exact compatibility with the already-merged fixture vocabulary.
