### PR TITLE
services(platform): add WOPI payload/document store seam

### DIFF
--- a/services/wopi-host/app/document_store.py
+++ b/services/wopi-host/app/document_store.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class DocumentPayloadStore:
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, document_id: str) -> Path:
+        return self.root / f"{document_id}.bin"
+
+    def get_bytes(self, document_id: str) -> bytes | None:
+        path = self._path(document_id)
+        if not path.exists():
+            return None
+        return path.read_bytes()
+
+    def put_bytes(self, document_id: str, payload: bytes) -> None:
+        self._path(document_id).write_bytes(payload)

--- a/services/wopi-host/app/document_store.py
+++ b/services/wopi-host/app/document_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from hashlib import sha256
 from pathlib import Path
 
 
@@ -19,3 +20,13 @@ class DocumentPayloadStore:
 
     def put_bytes(self, document_id: str, payload: bytes) -> None:
         self._path(document_id).write_bytes(payload)
+
+    def get_metadata(self, document_id: str) -> dict[str, object] | None:
+        payload = self.get_bytes(document_id)
+        if payload is None:
+            return None
+        return {
+            "document_id": document_id,
+            "size_bytes": len(payload),
+            "sha256": sha256(payload).hexdigest(),
+        }

--- a/services/wopi-host/app/main.py
+++ b/services/wopi-host/app/main.py
@@ -113,3 +113,16 @@ def payload_metadata(document_id: str):
     if metadata is None:
         return Response(status_code=404)
     return metadata
+
+
+@app.get("/v0/wopi/document-summary/{document_id}")
+def document_summary(document_id: str) -> dict[str, object]:
+    state = store.get(document_id)
+    metadata = document_store.get_metadata(document_id)
+    return {
+        "document_id": document_id,
+        "has_session": state is not None,
+        "version_counter": 0 if state is None else state.version_counter,
+        "versions": version_store.list_versions(document_id),
+        "payload_metadata": metadata,
+    }

--- a/services/wopi-host/app/main.py
+++ b/services/wopi-host/app/main.py
@@ -1,10 +1,17 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
+from pydantic import BaseModel
 
+from services.wopi_host.app.document_store import DocumentPayloadStore
 from services.wopi_host.app.file_store import FileBackedWOPIStore
 from services.wopi_host.app.store import store
 
 app = FastAPI(title="wopi-host", version="0.1.0")
 file_store = FileBackedWOPIStore("/tmp/sourceos-wopi-store")
+document_store = DocumentPayloadStore("/tmp/sourceos-wopi-docs")
+
+
+class PutFileRequest(BaseModel):
+    payload: str
 
 
 @app.get("/healthz")
@@ -15,6 +22,7 @@ def healthz() -> dict[str, str]:
 @app.get("/v0/wopi/check-file-info/{document_id}")
 def check_file_info(document_id: str) -> dict[str, object]:
     state = store.get(document_id)
+    payload = document_store.get_bytes(document_id)
     return {
         "document_id": document_id,
         "base_file_name": f"{document_id}.odt",
@@ -22,6 +30,7 @@ def check_file_info(document_id: str) -> dict[str, object]:
         "supports_update": True,
         "user_can_write": True,
         "version_counter": 0 if state is None else state.version_counter,
+        "has_payload": payload is not None,
     }
 
 
@@ -59,4 +68,24 @@ def file_writeback(document_id: str) -> dict[str, object]:
         "status": "WRITTEN",
         "updated_at": state.updated_at,
         "store": "file",
+    }
+
+
+@app.get("/v0/wopi/get-file/{document_id}")
+def get_file(document_id: str):
+    payload = document_store.get_bytes(document_id)
+    if payload is None:
+        return Response(status_code=404)
+    return Response(content=payload, media_type="application/octet-stream")
+
+
+@app.post("/v0/wopi/put-file/{document_id}")
+def put_file(document_id: str, body: PutFileRequest) -> dict[str, object]:
+    document_store.put_bytes(document_id, body.payload.encode("utf-8"))
+    state = store.writeback(document_id)
+    return {
+        "document_id": state.document_id,
+        "version_id": f"version-{state.document_id}-{state.version_counter:03d}",
+        "status": "WRITTEN",
+        "store": "payload",
     }

--- a/services/wopi-host/app/main.py
+++ b/services/wopi-host/app/main.py
@@ -105,3 +105,11 @@ def list_versions(document_id: str) -> dict[str, object]:
         "document_id": document_id,
         "versions": version_store.list_versions(document_id),
     }
+
+
+@app.get("/v0/wopi/payload-metadata/{document_id}")
+def payload_metadata(document_id: str):
+    metadata = document_store.get_metadata(document_id)
+    if metadata is None:
+        return Response(status_code=404)
+    return metadata

--- a/services/wopi-host/app/main.py
+++ b/services/wopi-host/app/main.py
@@ -4,10 +4,12 @@ from pydantic import BaseModel
 from services.wopi_host.app.document_store import DocumentPayloadStore
 from services.wopi_host.app.file_store import FileBackedWOPIStore
 from services.wopi_host.app.store import store
+from services.wopi_host.app.version_store import DocumentVersionStore
 
 app = FastAPI(title="wopi-host", version="0.1.0")
 file_store = FileBackedWOPIStore("/tmp/sourceos-wopi-store")
 document_store = DocumentPayloadStore("/tmp/sourceos-wopi-docs")
+version_store = DocumentVersionStore("/tmp/sourceos-wopi-versions")
 
 
 class PutFileRequest(BaseModel):
@@ -49,10 +51,12 @@ def acquire_lock(document_id: str) -> dict[str, object]:
 @app.post("/v0/wopi/writeback/{document_id}")
 def writeback(document_id: str) -> dict[str, object]:
     state = store.writeback(document_id)
+    version_id = f"version-{state.document_id}-{state.version_counter:03d}"
+    version_store.append(document_id, version_id)
     return {
         "document_id": state.document_id,
         "session_id": state.session_id,
-        "version_id": f"version-{state.document_id}-{state.version_counter:03d}",
+        "version_id": version_id,
         "status": "WRITTEN",
         "updated_at": state.updated_at,
     }
@@ -61,10 +65,12 @@ def writeback(document_id: str) -> dict[str, object]:
 @app.post("/v0/wopi/file-writeback/{document_id}")
 def file_writeback(document_id: str) -> dict[str, object]:
     state = file_store.writeback(document_id)
+    version_id = f"version-{state.document_id}-{state.version_counter:03d}"
+    version_store.append(document_id, version_id)
     return {
         "document_id": state.document_id,
         "session_id": state.session_id,
-        "version_id": f"version-{state.document_id}-{state.version_counter:03d}",
+        "version_id": version_id,
         "status": "WRITTEN",
         "updated_at": state.updated_at,
         "store": "file",
@@ -83,9 +89,19 @@ def get_file(document_id: str):
 def put_file(document_id: str, body: PutFileRequest) -> dict[str, object]:
     document_store.put_bytes(document_id, body.payload.encode("utf-8"))
     state = store.writeback(document_id)
+    version_id = f"version-{state.document_id}-{state.version_counter:03d}"
+    version_store.append(document_id, version_id)
     return {
         "document_id": state.document_id,
-        "version_id": f"version-{state.document_id}-{state.version_counter:03d}",
+        "version_id": version_id,
         "status": "WRITTEN",
         "store": "payload",
+    }
+
+
+@app.get("/v0/wopi/versions/{document_id}")
+def list_versions(document_id: str) -> dict[str, object]:
+    return {
+        "document_id": document_id,
+        "versions": version_store.list_versions(document_id),
     }

--- a/services/wopi-host/app/version_store.py
+++ b/services/wopi-host/app/version_store.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class DocumentVersionStore:
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, document_id: str) -> Path:
+        return self.root / f"{document_id}.versions.json"
+
+    def append(self, document_id: str, version_id: str) -> None:
+        path = self._path(document_id)
+        versions = self.list_versions(document_id)
+        versions.append(version_id)
+        path.write_text(json.dumps(versions), encoding="utf-8")
+
+    def list_versions(self, document_id: str) -> list[str]:
+        path = self._path(document_id)
+        if not path.exists():
+            return []
+        return json.loads(path.read_text(encoding="utf-8"))

--- a/services/wopi-host/tests/test_check_file_info_payload_flag.py
+++ b/services/wopi-host/tests/test_check_file_info_payload_flag.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+
+from services.wopi_host.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_check_file_info_reflects_payload_presence() -> None:
+    before = client.get('/v0/wopi/check-file-info/demo-doc')
+    assert before.status_code == 200
+    assert before.json()['has_payload'] is False
+
+    client.post('/v0/wopi/put-file/demo-doc', json={'payload': 'payload bytes'})
+
+    after = client.get('/v0/wopi/check-file-info/demo-doc')
+    assert after.status_code == 200
+    payload = after.json()
+    assert payload['has_payload'] is True
+    assert payload['version_counter'] == 1

--- a/services/wopi-host/tests/test_document_summary_endpoint.py
+++ b/services/wopi-host/tests/test_document_summary_endpoint.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+
+from services.wopi_host.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_document_summary_reflects_payload_and_versions() -> None:
+    client.post('/v0/wopi/put-file/demo-doc', json={'payload': 'v1'})
+    client.post('/v0/wopi/put-file/demo-doc', json={'payload': 'v2'})
+
+    response = client.get('/v0/wopi/document-summary/demo-doc')
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['document_id'] == 'demo-doc'
+    assert payload['has_session'] is True
+    assert payload['version_counter'] == 2
+    assert payload['versions'] == ['version-demo-doc-001', 'version-demo-doc-002']
+    assert payload['payload_metadata']['size_bytes'] == len(b'v2')

--- a/services/wopi-host/tests/test_document_summary_missing.py
+++ b/services/wopi-host/tests/test_document_summary_missing.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from services.wopi_host.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_document_summary_for_missing_doc_is_empty() -> None:
+    response = client.get('/v0/wopi/document-summary/missing-doc')
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['document_id'] == 'missing-doc'
+    assert payload['has_session'] is False
+    assert payload['version_counter'] == 0
+    assert payload['versions'] == []
+    assert payload['payload_metadata'] is None

--- a/services/wopi-host/tests/test_missing_payload_endpoints.py
+++ b/services/wopi-host/tests/test_missing_payload_endpoints.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+
+from services.wopi_host.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_missing_payload_endpoints_return_not_found() -> None:
+    get_response = client.get('/v0/wopi/get-file/missing-doc')
+    assert get_response.status_code == 404
+
+    metadata_response = client.get('/v0/wopi/payload-metadata/missing-doc')
+    assert metadata_response.status_code == 404

--- a/services/wopi-host/tests/test_payload_metadata_endpoint.py
+++ b/services/wopi-host/tests/test_payload_metadata_endpoint.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from services.wopi_host.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_payload_metadata_reports_size_and_hash() -> None:
+    client.post('/v0/wopi/put-file/demo-doc', json={'payload': 'hello office world'})
+
+    response = client.get('/v0/wopi/payload-metadata/demo-doc')
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['document_id'] == 'demo-doc'
+    assert payload['size_bytes'] == len(b'hello office world')
+    assert len(payload['sha256']) == 64

--- a/services/wopi-host/tests/test_payload_store_endpoints.py
+++ b/services/wopi-host/tests/test_payload_store_endpoints.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+
+from services.wopi_host.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_put_file_then_get_file_roundtrip() -> None:
+    put_response = client.post(
+        "/v0/wopi/put-file/demo-doc",
+        json={"payload": "hello office world"},
+    )
+    assert put_response.status_code == 200
+    put_payload = put_response.json()
+    assert put_payload["document_id"] == "demo-doc"
+    assert put_payload["status"] == "WRITTEN"
+    assert put_payload["store"] == "payload"
+
+    get_response = client.get("/v0/wopi/get-file/demo-doc")
+    assert get_response.status_code == 200
+    assert get_response.content == b"hello office world"

--- a/services/wopi-host/tests/test_version_history_endpoint.py
+++ b/services/wopi-host/tests/test_version_history_endpoint.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from services.wopi_host.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_version_history_tracks_put_file_versions() -> None:
+    client.post('/v0/wopi/put-file/demo-doc', json={'payload': 'v1'})
+    client.post('/v0/wopi/put-file/demo-doc', json={'payload': 'v2'})
+
+    response = client.get('/v0/wopi/versions/demo-doc')
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['document_id'] == 'demo-doc'
+    assert payload['versions'] == ['version-demo-doc-001', 'version-demo-doc-002']


### PR DESCRIPTION
## Summary

Add the next office runtime follow-on on top of the merged WOPI/session baseline.

Files:
- `services/wopi-host/app/document_store.py`
- `services/wopi-host/app/main.py` updates for payload endpoints
- `services/wopi-host/tests/test_payload_store_endpoints.py`

## Why

The prior office runtime PR established:
- WOPI host profile
- office session contract
- lock/writeback stubs
- in-memory and file-backed session state

This follow-on adds the missing payload/document seam so the WOPI stub can round-trip actual document bytes, not only session metadata.

## Scope

Intentionally narrow and additive:
- no full backend storage integration yet
- one file-backed payload adapter
- one get-file / put-file round-trip test
