### PR TITLE
docs(platform): add Sherlock search runtime contracts and service stub (ready)

### DIFF
--- a/docs/SEARCH_ORCHESTRATOR_PROFILE.md
+++ b/docs/SEARCH_ORCHESTRATOR_PROFILE.md
@@ -1,0 +1,38 @@
+# Sherlock Search Orchestrator Runtime Profile
+
+This document defines the first platform runtime profile for federated Sherlock search.
+
+## Purpose
+
+The search orchestrator is the runtime layer that accepts a Sherlock query and fans out to the relevant backends:
+- local desktop search signals from Lampstand
+- workspace/cloud search signals from platform indexes
+- memory recall signals from memory-mesh
+- semantic normalization signals from ontogenesis-aligned units and entities
+
+## Platform responsibility
+
+`prophet-platform` should own the runtime-facing orchestration seam for workspace/cloud search and result normalization.
+It should not replace Lampstand or memory-mesh; it should consume their outputs through stable contracts.
+
+## First runtime contracts
+
+- `schemas/search/sherlock_search_request.schema.json`
+- `schemas/search/sherlock_search_result.schema.json`
+
+## First service seam
+
+A later `services/search-orchestrator/` service should:
+- accept one Sherlock request
+- query platform/FogGraph indexes
+- return normalized search results
+- preserve permission boundaries and provenance signals
+- expose source markers so higher-level fusion can combine platform results with Lampstand and memory results
+
+## Non-goals
+
+- desktop crawling and indexing
+- memory storage and recall policy
+- ontology authoring
+
+Those remain in `lampstand`, `memory-mesh`, and `ontogenesis`.

--- a/schemas/search/sherlock_search_result.schema.json
+++ b/schemas/search/sherlock_search_result.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/search/sherlock_search_result.schema.json",
+  "title": "sherlock_search_result",
+  "type": "object",
+  "required": ["result_id", "source", "entity_type", "title", "score"],
+  "properties": {
+    "result_id": {"type": "string"},
+    "source": {"type": "string", "enum": ["LAMPSTAND", "PLATFORM", "MEMORY", "MIXED"]},
+    "entity_type": {"type": "string", "enum": ["DOCUMENT", "SHEET", "SLIDE", "COMMENT", "TASK", "CHAT", "MAIL", "MEETING", "PROJECT", "MEMORY_NOTE"]},
+    "title": {"type": "string"},
+    "snippet": {"type": "string"},
+    "path_or_uri": {"type": "string"},
+    "canonical_format": {"type": "string"},
+    "source_format": {"type": "string"},
+    "owner_ref": {"type": "string"},
+    "project_refs": {"type": "array", "items": {"type": "string"}},
+    "permission_ref": {"type": "string"},
+    "score": {
+      "type": "object",
+      "required": ["final"],
+      "properties": {
+        "lexical": {"type": "number"},
+        "semantic": {"type": "number"},
+        "memory": {"type": "number"},
+        "final": {"type": "number"}
+      },
+      "additionalProperties": false
+    },
+    "actions": {
+      "type": "object",
+      "properties": {
+        "open_local": {"type": "boolean"},
+        "open_cloud": {"type": "boolean"},
+        "summarize": {"type": "boolean"},
+        "create_task": {"type": "boolean"},
+        "draft_reply": {"type": "boolean"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/services/search-orchestrator/README.md
+++ b/services/search-orchestrator/README.md
@@ -1,0 +1,33 @@
+# Search Orchestrator Service
+
+This directory is the runtime stub for federated Sherlock search on the platform side.
+
+## Service purpose
+
+The search orchestrator is responsible for accepting Sherlock search requests and returning normalized result objects for workspace/cloud search.
+
+It should eventually:
+- accept a Sherlock query object
+- query platform workspace indexes
+- normalize and return result objects
+- preserve permission boundaries and provenance
+- expose source markers so higher-level fusion can combine platform results with Lampstand and memory results
+
+## Backing contracts
+
+- `schemas/search/sherlock_search_request.schema.json`
+- `schemas/search/sherlock_search_result.schema.json`
+
+## Cross-repo boundaries
+
+- workspace/product semantics live in `SocioProphet/prophet-workspace`
+- local desktop indexing remains in `SocioProphet/lampstand`
+- memory recall remains in `SocioProphet/memory-mesh`
+- ontology/alignment remains in `SocioProphet/ontogenesis`
+
+## First implementation posture
+
+The first implementation should be narrow and inspectable:
+- one request shape
+- one result shape
+- one platform-side execution seam


### PR DESCRIPTION
## Summary

Replacement non-draft PR for the Sherlock runtime slice.

Files:
- `docs/SEARCH_ORCHESTRATOR_PROFILE.md`
- `schemas/search/sherlock_search_request.schema.json`
- `schemas/search/sherlock_search_result.schema.json`
- `services/search-orchestrator/README.md`

## Why

The draft PR is blocked only by the connector's ready-for-review transition bug. This replacement carries the same content on a non-draft branch so review/merge can proceed.
