### PR TITLE
services(platform): add search orchestrator app stub (ready)

### DIFF
--- a/services/search-orchestrator/app/main.py
+++ b/services/search-orchestrator/app/main.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="search-orchestrator", version="0.1.0")
+
+
+class SearchRequest(BaseModel):
+    query_id: str
+    actor_id: str
+    text: str
+    mode: str
+    limit: int
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok", "service": "search-orchestrator"}
+
+
+@app.post("/v0/search/query")
+def search_query(body: SearchRequest) -> dict[str, object]:
+    return {
+        "query_id": body.query_id,
+        "actor_id": body.actor_id,
+        "mode": body.mode,
+        "results": [],
+    }


### PR DESCRIPTION
## Summary

Replacement non-draft PR for the first executable search-orchestrator slice.

Files:
- `services/search-orchestrator/app/main.py`

## Why

The draft PR is blocked only by the connector's ready-for-review transition bug. This replacement carries the same content on a non-draft branch so review/merge can proceed.
