### PR TITLE
tests(platform): add search orchestrator service smoke test

### DIFF
--- a/services/search-orchestrator/tests/test_service_smoke.py
+++ b/services/search-orchestrator/tests/test_service_smoke.py
@@ -1,0 +1,31 @@
+from fastapi.testclient import TestClient
+
+from services.search_orchestrator.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_health_endpoint() -> None:
+    response = client.get('/healthz')
+    assert response.status_code == 200
+    assert response.json()['service'] == 'search-orchestrator'
+
+
+def test_query_endpoint_returns_normalized_empty_results() -> None:
+    response = client.post(
+        '/v0/search/query',
+        json={
+            'query_id': 'q1',
+            'actor_id': 'user-1',
+            'text': 'budget',
+            'mode': 'HYBRID',
+            'limit': 5,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['query_id'] == 'q1'
+    assert payload['actor_id'] == 'user-1'
+    assert payload['mode'] == 'HYBRID'
+    assert payload['results'] == []


### PR DESCRIPTION
## Summary

Add direct smoke coverage for the merged search-orchestrator app stub.

Files:
- `services/search-orchestrator/tests/test_service_smoke.py`

## Why

The app stub is already on `main`. This follow-on adds the first direct runtime test so the service slice is not only executable but also checked for basic health and normalized empty-result behavior.
