### PR TITLE
services(platform): add typed platform-result path to search orchestrator (ready)

### DIFF
--- a/services/search-orchestrator/app/main.py
+++ b/services/search-orchestrator/app/main.py
@@ -1,15 +1,8 @@
 from fastapi import FastAPI
-from pydantic import BaseModel
+
+from services.search_orchestrator.app.models import SearchRequest, SearchResult, SearchResultScore
 
 app = FastAPI(title="search-orchestrator", version="0.1.0")
-
-
-class SearchRequest(BaseModel):
-    query_id: str
-    actor_id: str
-    text: str
-    mode: str
-    limit: int
 
 
 @app.get("/healthz")
@@ -19,9 +12,22 @@ def healthz() -> dict[str, str]:
 
 @app.post("/v0/search/query")
 def search_query(body: SearchRequest) -> dict[str, object]:
+    results: list[dict[str, object]] = []
+    scope = body.scope or None
+
+    if scope is not None and scope.cloud_workspace and body.text.strip():
+        result = SearchResult(
+            result_id=f"platform-{body.query_id}",
+            source="PLATFORM",
+            entity_type="DOCUMENT",
+            title=f"Workspace result placeholder for: {body.text}",
+            score=SearchResultScore(final=1.0),
+        )
+        results.append(result.model_dump())
+
     return {
         "query_id": body.query_id,
         "actor_id": body.actor_id,
         "mode": body.mode,
-        "results": [],
+        "results": results,
     }

--- a/services/search-orchestrator/app/models.py
+++ b/services/search-orchestrator/app/models.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel
+
+
+class SearchScope(BaseModel):
+    local_desktop: bool = False
+    cloud_workspace: bool = True
+    memory: bool = False
+
+
+class SearchRequest(BaseModel):
+    query_id: str
+    actor_id: str
+    text: str
+    mode: str
+    limit: int
+    scope: SearchScope | None = None
+
+
+class SearchResultScore(BaseModel):
+    final: float
+
+
+class SearchResult(BaseModel):
+    result_id: str
+    source: str
+    entity_type: str
+    title: str
+    score: SearchResultScore

--- a/services/search-orchestrator/tests/test_platform_scope_result.py
+++ b/services/search-orchestrator/tests/test_platform_scope_result.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+
+from services.search_orchestrator.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_cloud_workspace_scope_returns_platform_result() -> None:
+    response = client.post(
+        '/v0/search/query',
+        json={
+            'query_id': 'q1',
+            'actor_id': 'user-1',
+            'text': 'budget',
+            'mode': 'HYBRID',
+            'limit': 5,
+            'scope': {'cloud_workspace': True, 'local_desktop': False, 'memory': False},
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['results'][0]['source'] == 'PLATFORM'
+    assert payload['results'][0]['entity_type'] == 'DOCUMENT'


### PR DESCRIPTION
## Summary

Replacement non-draft PR for the typed platform-result search-orchestrator slice.

Files:
- `services/search-orchestrator/app/models.py`
- `services/search-orchestrator/app/main.py`
- `services/search-orchestrator/tests/test_platform_scope_result.py`

## Why

The draft PR is blocked only by the connector's ready-for-review transition bug. This replacement carries the same content on a non-draft branch so review/merge can proceed.
