### PR TITLE
services(platform): add search backend provider seam (ready)

### DIFF
--- a/services/search-orchestrator/app/backends.py
+++ b/services/search-orchestrator/app/backends.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PlatformSearchResult:
+    result_id: str
+    source: str
+    entity_type: str
+    title: str
+    final_score: float
+
+
+def query_platform_workspace(text: str, enabled: bool = True) -> list[PlatformSearchResult]:
+    if not enabled or not text.strip():
+        return []
+    return [
+        PlatformSearchResult(
+            result_id=f"platform-{text}",
+            source="PLATFORM",
+            entity_type="DOCUMENT",
+            title=f"Workspace result placeholder for: {text}",
+            final_score=1.0,
+        )
+    ]

--- a/services/search-orchestrator/app/main.py
+++ b/services/search-orchestrator/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 
+from services.search_orchestrator.app.backends import query_platform_workspace
 from services.search_orchestrator.app.models import SearchRequest, SearchResult, SearchResultScore
 
 app = FastAPI(title="search-orchestrator", version="0.1.0")
@@ -15,13 +16,16 @@ def search_query(body: SearchRequest) -> dict[str, object]:
     results: list[dict[str, object]] = []
     scope = body.scope or None
 
-    if scope is not None and scope.cloud_workspace and body.text.strip():
+    for item in query_platform_workspace(
+        text=body.text,
+        enabled=(scope is not None and scope.cloud_workspace),
+    ):
         result = SearchResult(
-            result_id=f"platform-{body.query_id}",
-            source="PLATFORM",
-            entity_type="DOCUMENT",
-            title=f"Workspace result placeholder for: {body.text}",
-            score=SearchResultScore(final=1.0),
+            result_id=item.result_id,
+            source=item.source,
+            entity_type=item.entity_type,
+            title=item.title,
+            score=SearchResultScore(final=item.final_score),
         )
         results.append(result.model_dump())
 

--- a/services/search-orchestrator/tests/test_backends.py
+++ b/services/search-orchestrator/tests/test_backends.py
@@ -1,0 +1,12 @@
+from services.search_orchestrator.app.backends import query_platform_workspace
+
+
+def test_query_platform_workspace_returns_placeholder_result() -> None:
+    results = query_platform_workspace('budget', enabled=True)
+    assert len(results) == 1
+    assert results[0].source == 'PLATFORM'
+    assert results[0].entity_type == 'DOCUMENT'
+
+
+def test_query_platform_workspace_disabled_returns_empty() -> None:
+    assert query_platform_workspace('budget', enabled=False) == []


### PR DESCRIPTION
## Summary

Replacement non-draft PR for the search backend/provider seam slice.

Files:
- `services/search-orchestrator/app/backends.py`
- `services/search-orchestrator/app/main.py`
- `services/search-orchestrator/tests/test_backends.py`

## Why

The draft PR is blocked only by the connector's ready-for-review transition bug. This replacement carries the same content on a non-draft branch so review/merge can proceed.
