### PR TITLE
platform: emit lifecycle bundle from eval fabric runtime

### DIFF
--- a/apps/eval-fabric-api/app/lifecycle_bundle.py
+++ b/apps/eval-fabric-api/app/lifecycle_bundle.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .lifecycle_artifacts import (
+    build_gate_activation_record,
+    build_graduation_record,
+    build_lifecycle_artifact_graph,
+    build_promotion_decision,
+    build_rollback_record,
+)
+
+DEFAULT_AGENT_REF = "agent://socioprophet/example/retrieval-governed-operator"
+DEFAULT_RECIPE_REF = "recipe://benchmark/ray/eval-fabric-001"
+DEFAULT_CURRENT_STAGE = "L3_assist_mode"
+DEFAULT_TARGET_STAGE = "L4_supervised_actuation"
+DEFAULT_PROMOTION_WINDOW = "rolling_30d"
+DEFAULT_REQUIRED_GATES = [
+    "authorization_gate",
+    "scope_gate",
+    "policy_gate",
+    "risk_gate",
+    "evidence_gate",
+    "approval_gate",
+    "rollback_gate",
+]
+DEFAULT_LANE_SCORES = {
+    "capability": 3,
+    "safety_policy": 4,
+    "reliability_recovery": 3,
+    "observability_auditability": 4,
+    "provenance_reproducibility": 4,
+    "efficiency_budget": 3,
+    "human_oversight_acceptability": 4,
+}
+
+
+def _id_slug(model_release_id: str) -> str:
+    return model_release_id.replace("/", "-").replace(":", "-").replace(" ", "-")
+
+
+def build_lifecycle_bundle(*, model_release_id: str, agent_ref: str = DEFAULT_AGENT_REF, recipe_ref: str = DEFAULT_RECIPE_REF) -> dict[str, Any]:
+    slug = _id_slug(model_release_id)
+    subject_ref = f"model://{model_release_id}"
+
+    promotion_decision = build_promotion_decision(
+        promotion_decision_id=f"promotion_decision::{slug}",
+        subject_ref=subject_ref,
+        source_ref=recipe_ref,
+        current_stage=DEFAULT_CURRENT_STAGE,
+        target_stage=DEFAULT_TARGET_STAGE,
+        required_gates=DEFAULT_REQUIRED_GATES,
+        evidence_refs=["event_envelope", "evidence_receipt", "benchmark_report"],
+        promotion_window=DEFAULT_PROMOTION_WINDOW,
+    )
+
+    rollback_record = build_rollback_record(
+        rollback_record_id=f"rollback_record::{slug}",
+        subject_ref="service://eval-fabric-api/ray-serve",
+        trigger_ref=promotion_decision["promotion_decision_id"],
+        rollback_reason="post-promotion policy regression",
+        required_gates=[
+            "authorization_gate",
+            "scope_gate",
+            "policy_gate",
+            "risk_gate",
+            "rollback_gate",
+        ],
+        evidence_refs=["event_envelope", "evidence_receipt"],
+    )
+
+    gate_activation_record = build_gate_activation_record(
+        gate_activation_record_id=f"gate_activation_record::{slug}",
+        action_ref="action://eval-fabric/tool_write/logical_route",
+        required_gates=DEFAULT_REQUIRED_GATES,
+        activated_gates=DEFAULT_REQUIRED_GATES,
+        failed_gates=[],
+        policy_decision_ref=f"policy://decision/{slug}",
+        approval_ref=f"approval://operator/{slug}",
+        rollback_requirement="required_before_side_effect",
+    )
+
+    graduation_record = build_graduation_record(
+        graduation_record_id=f"graduation_record::{slug}",
+        agent_ref=agent_ref,
+        current_stage=DEFAULT_CURRENT_STAGE,
+        target_stage=DEFAULT_TARGET_STAGE,
+        lane_scores=DEFAULT_LANE_SCORES,
+        blocking_lanes=[],
+        promotion_window=DEFAULT_PROMOTION_WINDOW,
+        required_gates=DEFAULT_REQUIRED_GATES,
+        evidence_refs=[
+            "event_envelope",
+            "evidence_receipt",
+            "benchmark_report",
+            "promotion_decision",
+        ],
+    )
+
+    artifact_graph = build_lifecycle_artifact_graph(
+        artifact_graph_id=f"lifecycle_artifact_graph::{slug}",
+        agent_ref=agent_ref,
+        edges=[
+            {"from": recipe_ref, "to": promotion_decision["promotion_decision_id"], "type": "promotes"},
+            {"from": promotion_decision["promotion_decision_id"], "to": gate_activation_record["gate_activation_record_id"], "type": "requires_gate_activation"},
+            {"from": gate_activation_record["gate_activation_record_id"], "to": graduation_record["graduation_record_id"], "type": "supports_graduation"},
+            {"from": promotion_decision["promotion_decision_id"], "to": rollback_record["rollback_record_id"], "type": "rollback_ready"},
+        ],
+        evidence_refs=[
+            "event_envelope",
+            "evidence_receipt",
+            "benchmark_report",
+            "promotion_decision",
+            "rollback_record",
+            "gate_activation_record",
+            "graduation_record",
+        ],
+    )
+
+    return {
+        "model_release_id": model_release_id,
+        "agent_ref": agent_ref,
+        "recipe_ref": recipe_ref,
+        "promotion_decision": promotion_decision,
+        "rollback_record": rollback_record,
+        "gate_activation_record": gate_activation_record,
+        "graduation_record": graduation_record,
+        "artifact_graph": artifact_graph,
+        "source": "runtime+builders",
+    }

--- a/apps/eval-fabric-api/app/main.py
+++ b/apps/eval-fabric-api/app/main.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from fastapi import FastAPI, Response, status
 
-from . import governance_repositories, intelligence_repositories, repositories
+from . import governance_repositories, intelligence_repositories, lifecycle_bundle, repositories
 from .db import ch_health, pg_health
 from .receipts import maybe_emit_artifacts
 
@@ -141,6 +141,21 @@ def model_attribution(model_release_id: str, response: Response, window: str = "
         payload=payload,
         classifiers=["route:attribution", "source:postgres"],
         metrics={"window": window}
+    )
+    return payload
+
+
+@app.get("/v1/models/{model_release_id}/lifecycle-bundle")
+def model_lifecycle_bundle(model_release_id: str, response: Response) -> dict:
+    payload = lifecycle_bundle.build_lifecycle_bundle(model_release_id=model_release_id)
+    _emit(
+        response,
+        event_type="eval.fabric.lifecycle.bundle.read",
+        action="LifecycleBundleQuery",
+        subject_ref=f"model://{model_release_id}",
+        payload=payload,
+        classifiers=["route:lifecycle-bundle", "source:runtime+builders"],
+        metrics={"artifact_count": 5},
     )
     return payload
 

--- a/apps/eval-fabric-api/tests/test_lifecycle_bundle_route.py
+++ b/apps/eval-fabric-api/tests/test_lifecycle_bundle_route.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import main
+
+
+class _Emission:
+    def __init__(self) -> None:
+        self.payload_ref = "file:///tmp/payload.json"
+        self.event_ref = "file:///tmp/event.json"
+        self.receipt_ref = "file:///tmp/receipt.json"
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr(main, "maybe_emit_artifacts", lambda **kwargs: _Emission())
+    return TestClient(main.app)
+
+
+def test_lifecycle_bundle_route_returns_expected_shape(client: TestClient) -> None:
+    response = client.get("/v1/models/model.semantic-stack.2026-04-05/lifecycle-bundle")
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["model_release_id"] == "model.semantic-stack.2026-04-05"
+    assert body["agent_ref"].startswith("agent://")
+    assert body["recipe_ref"] == "recipe://benchmark/ray/eval-fabric-001"
+    assert body["promotion_decision"]["subject_ref"] == "model://model.semantic-stack.2026-04-05"
+    assert body["promotion_decision"]["target_stage"] == "L4_supervised_actuation"
+    assert body["rollback_record"]["trigger_ref"] == body["promotion_decision"]["promotion_decision_id"]
+    assert body["gate_activation_record"]["action_ref"].endswith("tool_write/logical_route")
+    assert body["graduation_record"]["current_stage"] == "L3_assist_mode"
+    assert len(body["artifact_graph"]["edges"]) == 4
+    assert body["source"] == "runtime+builders"
+
+
+def test_lifecycle_bundle_route_emits_receipt_headers(client: TestClient) -> None:
+    response = client.get("/v1/models/model.semantic-stack.2026-04-05/lifecycle-bundle")
+    assert response.status_code == 200
+    assert response.headers["X-Payload-Ref"] == "file:///tmp/payload.json"
+    assert response.headers["X-Event-Envelope-Ref"] == "file:///tmp/event.json"
+    assert response.headers["X-Evidence-Receipt-Ref"] == "file:///tmp/receipt.json"


### PR DESCRIPTION
## Summary

Add a narrow live runtime-emission surface for eval-fabric lifecycle artifacts.

## Why

The current downstream stack already has:
- canonical lifecycle artifact fixture shapes
- builder helpers for promotion / rollback / gate activation / graduation / artifact graph records
- tests for the fixture and builder layers

What it still lacks is a live runtime route that emits those artifact shapes from the canonical eval-fabric app instead of leaving them only in fixtures and builder tests.

## Files included

- `apps/eval-fabric-api/app/lifecycle_bundle.py`
- `apps/eval-fabric-api/app/main.py`
- `apps/eval-fabric-api/tests/test_lifecycle_bundle_route.py`

## What this adds

- a canonical lifecycle bundle builder for a given model release ID
- a new runtime route: `/v1/models/{model_release_id}/lifecycle-bundle`
- receipt/header emission for that route using the existing eval-fabric emission path
- tests asserting payload shape and receipt headers

## Notes

This is intentionally narrow. It does not change existing routes; it adds one runtime-emission surface that uses the already-merged builder layer and preserves compatibility with the canonical fixture vocabulary.
