### PR TITLE
Draft: add Fog Stack external signature verification runner

### DIFF
--- a/docs/FOGSTACK_SIGNATURE_VERIFICATION_EXECUTION.md
+++ b/docs/FOGSTACK_SIGNATURE_VERIFICATION_EXECUTION.md
@@ -1,0 +1,43 @@
+# Fog Stack signature verification execution
+
+This document defines the first repo-native execution wrapper for external signature verification.
+
+## Goal
+
+Move from:
+- a normalization contract for external signature verification output
+- a repo-native pipeline runner that transforms normalized evidence into a cryptographic verification record
+
+to:
+- one wrapper that runs an external verifier command, captures its output, normalizes it, and feeds the Fog Stack verification pipeline.
+
+## Minimal flow
+
+1. provide a release manifest and bundle identity/version
+2. invoke `tools/run_external_fogstack_signature_verifier.py`
+3. pass the external verifier command after `--`
+4. the wrapper captures stdout JSON, normalizes it, and emits the cryptographic verification record
+
+## Example
+
+```bash
+python3 tools/run_external_fogstack_signature_verifier.py \
+  --tool cosign \
+  --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --raw-output /tmp/fogstack.access.raw.verify.json \
+  --normalized-output /tmp/fogstack.access.normalized.verify.json \
+  --record-output /tmp/fogstack.access.crypto-verification.record.json \
+  -- cosign verify-blob --signature artifact://release/fogstack.access-v0.1.sig bundle.tar.gz
+```
+
+## What this phase does not yet provide
+
+This wrapper still does not:
+- interpret every verifier's output format automatically beyond the normalized contract
+- enforce CI execution
+- mutate manifest/trust artifacts after verification
+- guarantee registry resolution of signature references
+
+Those remain later steps.

--- a/tools/run_external_fogstack_signature_verifier.py
+++ b/tools/run_external_fogstack_signature_verifier.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run an external signature verifier and feed the Fog Stack verification pipeline")
+    parser.add_argument("--tool", required=True, choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--raw-output", required=True, type=Path)
+    parser.add_argument("--normalized-output", required=True, type=Path)
+    parser.add_argument("--record-output", required=True, type=Path)
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="External verifier command, e.g. cosign verify ...")
+    args = parser.parse_args()
+
+    if not args.command:
+        raise SystemExit("ERR: external verifier command is required after '--'")
+
+    proc = subprocess.run(args.command, capture_output=True, text=True)
+
+    if proc.stdout.strip():
+        args.raw_output.write_text(proc.stdout, encoding="utf-8")
+    else:
+        # minimal fallback envelope when the command emits no stdout JSON
+        args.raw_output.write_text(json.dumps({
+            "status": "fail" if proc.returncode else "warn",
+            "message": proc.stderr.strip() or "external verifier produced no stdout",
+            "evidence_count": 0,
+        }, indent=2) + "\n", encoding="utf-8")
+
+    normalize_cmd = [
+        "python3",
+        "tools/normalize_fogstack_signature_verification_evidence.py",
+        "--input", str(args.raw_output),
+        "--tool", args.tool,
+        "--output", str(args.normalized_output),
+    ]
+    norm = subprocess.run(normalize_cmd)
+    if norm.returncode != 0:
+        raise SystemExit(norm.returncode)
+
+    pipeline_cmd = [
+        "python3",
+        "tools/run_fogstack_signature_verification_pipeline.py",
+        "--manifest", str(args.manifest),
+        "--raw-evidence", str(args.normalized_output),
+        "--tool", args.tool,
+        "--bundle-id", args.bundle_id,
+        "--version", args.version,
+        "--record-output", str(args.record_output),
+    ]
+    pipe = subprocess.run(pipeline_cmd)
+    if pipe.returncode != 0:
+        raise SystemExit(pipe.returncode)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the next trust tranche on top of current `main`:

- `tools/run_external_fogstack_signature_verifier.py`
- `docs/FOGSTACK_SIGNATURE_VERIFICATION_EXECUTION.md`

## Why this shape

The repo already has:
- a normalization contract for external signature verification evidence
- a repo-native verification pipeline runner that emits a cryptographic verification record

This PR adds the first execution wrapper that:
- runs an external verifier command
- captures its output
- normalizes that output
- feeds the existing Fog Stack verification pipeline

## Not in this PR

- fully generic parsing for every verifier output format
- CI enforcement
- automatic backlink mutation
- registry resolution of signature references

Those remain later steps.
