### PR TITLE
platform: extend eval fabric smoke to verify lifecycle bundle route

### DIFF
--- a/tools/smoke_eval_fabric.sh
+++ b/tools/smoke_eval_fabric.sh
@@ -24,6 +24,7 @@ curl -fsS "http://127.0.0.1:8080/readyz" >"$TMPDIR/ready.json"
 curl -fsS -D "$TMPDIR/frontier.headers" "http://127.0.0.1:8080/v1/frontier" >"$TMPDIR/frontier.json"
 curl -fsS "http://127.0.0.1:8080/v1/models/model.semantic-stack.2026-04-05/dossier" >"$TMPDIR/dossier.json"
 curl -fsS "http://127.0.0.1:8080/v1/competition/radar" >"$TMPDIR/radar.json"
+curl -fsS -D "$TMPDIR/lifecycle.headers" "http://127.0.0.1:8080/v1/models/model.semantic-stack.2026-04-05/lifecycle-bundle" >"$TMPDIR/lifecycle.json"
 
 python3 - "$TMPDIR" <<'PY' > "$TMPDIR/refs.txt"
 import json
@@ -36,18 +37,24 @@ ready = json.loads((tmp / "ready.json").read_text())
 frontier = json.loads((tmp / "frontier.json").read_text())
 dossier = json.loads((tmp / "dossier.json").read_text())
 radar = json.loads((tmp / "radar.json").read_text())
+lifecycle = json.loads((tmp / "lifecycle.json").read_text())
 
-headers = {}
-for line in (tmp / "frontier.headers").read_text().splitlines():
-    if ":" not in line:
-        continue
-    k, v = line.split(":", 1)
-    headers[k.strip().lower()] = v.strip()
+def parse_headers(path: Path):
+    headers = {}
+    for line in path.read_text().splitlines():
+        if ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        headers[k.strip().lower()] = v.strip()
+    return headers
 
-event_ref = headers.get("x-event-envelope-ref")
-receipt_ref = headers.get("x-evidence-receipt-ref")
-payload_ref = headers.get("x-payload-ref")
-assert event_ref and receipt_ref and payload_ref, headers
+frontier_headers = parse_headers(tmp / "frontier.headers")
+lifecycle_headers = parse_headers(tmp / "lifecycle.headers")
+
+for header_set in (frontier_headers, lifecycle_headers):
+    assert header_set.get("x-event-envelope-ref"), header_set
+    assert header_set.get("x-evidence-receipt-ref"), header_set
+    assert header_set.get("x-payload-ref"), header_set
 
 assert health["status"] == "ok", health
 assert health["service"] == "eval-fabric-api", health
@@ -68,33 +75,57 @@ assert "md_false_allow_rate" in metric_ids, dossier
 providers = {item["provider_id"] for item in radar["competitors"]}
 assert {"openai", "google"}.issubset(providers), radar
 
-print(payload_ref)
-print(event_ref)
-print(receipt_ref)
+assert lifecycle["model_release_id"] == "model.semantic-stack.2026-04-05", lifecycle
+assert lifecycle["agent_ref"].startswith("agent://"), lifecycle
+assert lifecycle["recipe_ref"] == "recipe://benchmark/ray/eval-fabric-001", lifecycle
+assert lifecycle["promotion_decision"]["target_stage"] == "L4_supervised_actuation", lifecycle
+assert lifecycle["rollback_record"]["trigger_ref"] == lifecycle["promotion_decision"]["promotion_decision_id"], lifecycle
+assert lifecycle["gate_activation_record"]["action_ref"].endswith("tool_write/logical_route"), lifecycle
+assert lifecycle["graduation_record"]["current_stage"] == "L3_assist_mode", lifecycle
+assert len(lifecycle["artifact_graph"]["edges"]) == 4, lifecycle
+
+print(frontier_headers["x-payload-ref"])
+print(frontier_headers["x-event-envelope-ref"])
+print(frontier_headers["x-evidence-receipt-ref"])
+print(lifecycle_headers["x-payload-ref"])
+print(lifecycle_headers["x-event-envelope-ref"])
+print(lifecycle_headers["x-evidence-receipt-ref"])
 PY
 
 mapfile -t REFS < "$TMPDIR/refs.txt"
-PAYLOAD_REF="${REFS[0]}"
-EVENT_REF="${REFS[1]}"
-RECEIPT_REF="${REFS[2]}"
+FRONTIER_PAYLOAD_REF="${REFS[0]}"
+FRONTIER_EVENT_REF="${REFS[1]}"
+FRONTIER_RECEIPT_REF="${REFS[2]}"
+LIFECYCLE_PAYLOAD_REF="${REFS[3]}"
+LIFECYCLE_EVENT_REF="${REFS[4]}"
+LIFECYCLE_RECEIPT_REF="${REFS[5]}"
 
-PAYLOAD_PATH="${PAYLOAD_REF#file://}"
-EVENT_PATH="${EVENT_REF#file://}"
-RECEIPT_PATH="${RECEIPT_REF#file://}"
+FRONTIER_PAYLOAD_PATH="${FRONTIER_PAYLOAD_REF#file://}"
+FRONTIER_EVENT_PATH="${FRONTIER_EVENT_REF#file://}"
+FRONTIER_RECEIPT_PATH="${FRONTIER_RECEIPT_REF#file://}"
+LIFECYCLE_PAYLOAD_PATH="${LIFECYCLE_PAYLOAD_REF#file://}"
+LIFECYCLE_EVENT_PATH="${LIFECYCLE_EVENT_REF#file://}"
+LIFECYCLE_RECEIPT_PATH="${LIFECYCLE_RECEIPT_REF#file://}"
 
-docker compose -f "$COMPOSE" exec -T eval-fabric-api sh -lc "test -f '$PAYLOAD_PATH' && test -f '$EVENT_PATH' && test -f '$RECEIPT_PATH'"
+docker compose -f "$COMPOSE" exec -T eval-fabric-api sh -lc "test -f '$FRONTIER_PAYLOAD_PATH' && test -f '$FRONTIER_EVENT_PATH' && test -f '$FRONTIER_RECEIPT_PATH' && test -f '$LIFECYCLE_PAYLOAD_PATH' && test -f '$LIFECYCLE_EVENT_PATH' && test -f '$LIFECYCLE_RECEIPT_PATH'"
 
-case "$PAYLOAD_PATH" in
-  */payloads/eval-fabric-api/*) ;;
-  *) echo "unexpected payload layout: $PAYLOAD_PATH" >&2; exit 1 ;;
-esac
-case "$EVENT_PATH" in
-  */events/eval-fabric-api/*) ;;
-  *) echo "unexpected event layout: $EVENT_PATH" >&2; exit 1 ;;
-esac
-case "$RECEIPT_PATH" in
-  */receipts/eval-fabric-api/*) ;;
-  *) echo "unexpected receipt layout: $RECEIPT_PATH" >&2; exit 1 ;;
-esac
+for path in "$FRONTIER_PAYLOAD_PATH" "$LIFECYCLE_PAYLOAD_PATH"; do
+  case "$path" in
+    */payloads/eval-fabric-api/*) ;;
+    *) echo "unexpected payload layout: $path" >&2; exit 1 ;;
+  esac
+done
+for path in "$FRONTIER_EVENT_PATH" "$LIFECYCLE_EVENT_PATH"; do
+  case "$path" in
+    */events/eval-fabric-api/*) ;;
+    *) echo "unexpected event layout: $path" >&2; exit 1 ;;
+  esac
+done
+for path in "$FRONTIER_RECEIPT_PATH" "$LIFECYCLE_RECEIPT_PATH"; do
+  case "$path" in
+    */receipts/eval-fabric-api/*) ;;
+    *) echo "unexpected receipt layout: $path" >&2; exit 1 ;;
+  esac
+done
 
-echo '{"ok":true,"receipts_emitted":true,"layout":"type-first"}'
+echo '{"ok":true,"receipts_emitted":true,"layout":"type-first","lifecycle_bundle_verified":true}'


### PR DESCRIPTION
## Summary

Extend the eval-fabric smoke path to cover the new live lifecycle-bundle runtime route.

## Why

The preceding runtime-emission PR adds a new route:
- `/v1/models/{model_release_id}/lifecycle-bundle`

The smoke script should verify that route as part of the canonical local execution loop so the new runtime surface is checked alongside health, readiness, frontier, dossier, and radar.

## File included

- `tools/smoke_eval_fabric.sh`

## What this adds

- lifecycle-bundle request + payload validation
- lifecycle-bundle receipt/header validation
- on-disk payload/event/receipt existence checks for both frontier and lifecycle-bundle routes
- final smoke output marking lifecycle-bundle verification complete

## Notes

This is intentionally narrow. It does not change runtime behavior; it extends the existing smoke harness so the new lifecycle-bundle route becomes part of the standard execution verification path.
