### PR TITLE
Draft: add Fog Stack release sealing

### DIFF
--- a/docs/FOGSTACK_RELEASE_SEALING.md
+++ b/docs/FOGSTACK_RELEASE_SEALING.md
@@ -1,0 +1,42 @@
+# Fog Stack release sealing
+
+This document defines the first repo-native **release sealing** step for Fog Stack.
+
+## Goal
+
+Move from linked release/trust artifacts to a deterministic, tamper-evident summary hash for a bundle version.
+
+## Minimal flow
+
+1. choose the artifact files that define the release/trust state for a bundle version
+2. run `tools/emit_fogstack_release_seal.py`
+3. persist the resulting `FogStackReleaseSeal` as part of the release evidence set
+
+## Example
+
+```bash
+python3 tools/emit_fogstack_release_seal.py \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --artifact manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+  --artifact validation releases/evidence/fogstack.access-v0.1.validation.record.json \
+  --artifact sigverify releases/evidence/fogstack.access-v0.1.signature-verification.record.json \
+  --artifact sigtrust releases/evidence/fogstack.access-v0.1.signature-trust.record.json \
+  --artifact evidenceindex releases/evidence/fogstack.access-v0.1.evidence.index.json \
+  --output /tmp/fogstack.access-v0.1.seal.json
+```
+
+## What this phase provides
+
+- deterministic SHA-256 hashes for each referenced artifact
+- a deterministic `release_root_hash` computed from the sorted artifact-hash set
+- a single machine-readable seal object for a bundle version
+
+## What this phase does not yet provide
+
+- Merkle proofs
+- signature over the seal itself
+- CI enforcement of the seal
+- automatic rebuild of the seal when any artifact changes
+
+Those remain the next release-engineering tranche.

--- a/schemas/release/fogstack-release-seal-v0.1.schema.json
+++ b/schemas/release/fogstack-release-seal-v0.1.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-release-seal-v0.1.schema.json",
+  "title": "FogStackReleaseSeal",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "algorithm",
+    "release_root_hash",
+    "artifact_hashes"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackReleaseSeal" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+    "version": { "type": "string" },
+    "algorithm": { "enum": ["sha256"] },
+    "release_root_hash": { "type": "string" },
+    "artifact_hashes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["label", "ref", "hash"],
+        "properties": {
+          "label": { "type": "string" },
+          "ref": { "type": "string" },
+          "hash": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "notes": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/tools/emit_fogstack_release_seal.py
+++ b/tools/emit_fogstack_release_seal.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            h.update(chunk)
+    return 'sha256:' + h.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Emit a Fog Stack release seal from artifact files')
+    parser.add_argument('--bundle-id', required=True)
+    parser.add_argument('--version', required=True)
+    parser.add_argument('--artifact', action='append', nargs=2, metavar=('LABEL', 'PATH'), required=True,
+                        help='Artifact label and file path; may be repeated')
+    parser.add_argument('--notes', default=None)
+    parser.add_argument('--output', type=Path, default=None)
+    args = parser.parse_args()
+
+    artifact_hashes: list[dict[str, str]] = []
+    for label, path_str in args.artifact:
+        p = Path(path_str)
+        artifact_hashes.append({
+            'label': label,
+            'ref': str(p),
+            'hash': sha256_file(p),
+        })
+
+    artifact_hashes.sort(key=lambda x: x['label'])
+    root_material = json.dumps(artifact_hashes, sort_keys=True).encode('utf-8')
+    release_root_hash = 'sha256:' + hashlib.sha256(root_material).hexdigest()
+
+    seal = {
+        'kind': 'FogStackReleaseSeal',
+        'schema_version': 'v0.1',
+        'bundle_id': args.bundle_id,
+        'version': args.version,
+        'algorithm': 'sha256',
+        'release_root_hash': release_root_hash,
+        'artifact_hashes': artifact_hashes,
+        'notes': args.notes,
+    }
+
+    text = json.dumps(seal, indent=2) + '\n'
+    if args.output:
+        args.output.write_text(text, encoding='utf-8')
+    else:
+        print(text, end='')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the next trust/release tranche on top of current `main`:

- `schemas/release/fogstack-release-seal-v0.1.schema.json`
- `tools/emit_fogstack_release_seal.py`
- `docs/FOGSTACK_RELEASE_SEALING.md`

## Why this shape

The repo already has linked release/trust artifacts for a bundle version:
- manifest
- validation record
- signature verification record
- signature trust record
- release evidence index

This PR adds a repo-native seal object that computes deterministic SHA-256 hashes over those artifacts and emits a single `release_root_hash` for the bundle version.

## Not in this PR

- Merkle proofs
- signature over the seal itself
- CI enforcement of the seal
- automatic seal rebuild on artifact mutation

Those remain for the next release-engineering tranche.
