### PR TITLE
Draft: add Fog Stack release seal signature support

### DIFF
--- a/docs/FOGSTACK_RELEASE_SEALING.md
+++ b/docs/FOGSTACK_RELEASE_SEALING.md
@@ -1,0 +1,42 @@
+# Fog Stack release sealing
+
+This document defines the first repo-native **release sealing** step for Fog Stack.
+
+## Goal
+
+Move from linked release/trust artifacts to a deterministic, tamper-evident summary hash for a bundle version.
+
+## Minimal flow
+
+1. choose the artifact files that define the release/trust state for a bundle version
+2. run `tools/emit_fogstack_release_seal.py`
+3. persist the resulting `FogStackReleaseSeal` as part of the release evidence set
+
+## Example
+
+```bash
+python3 tools/emit_fogstack_release_seal.py \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --artifact manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+  --artifact validation releases/evidence/fogstack.access-v0.1.validation.record.json \
+  --artifact sigverify releases/evidence/fogstack.access-v0.1.signature-verification.record.json \
+  --artifact sigtrust releases/evidence/fogstack.access-v0.1.signature-trust.record.json \
+  --artifact evidenceindex releases/evidence/fogstack.access-v0.1.evidence.index.json \
+  --output /tmp/fogstack.access-v0.1.seal.json
+```
+
+## What this phase provides
+
+- deterministic SHA-256 hashes for each referenced artifact
+- a deterministic `release_root_hash` computed from the sorted artifact-hash set
+- a single machine-readable seal object for a bundle version
+
+## What this phase does not yet provide
+
+- Merkle proofs
+- signature over the seal itself
+- CI enforcement of the seal
+- automatic rebuild of the seal when any artifact changes
+
+Those remain the next release-engineering tranche.

--- a/docs/FOGSTACK_RELEASE_SEAL_SIGNATURES.md
+++ b/docs/FOGSTACK_RELEASE_SEAL_SIGNATURES.md
@@ -1,0 +1,49 @@
+# Fog Stack release seal signatures
+
+This document defines the first repo-native meaning of a **signed release seal**.
+
+## Goal
+
+Move from:
+- an unsigned `FogStackReleaseSeal`
+- a helper that computes `release_root_hash`
+
+to:
+- a seal that can explicitly carry signature metadata
+- a helper that can verify the signed-seal shape before later cryptographic verification layers exist.
+
+## Minimal flow
+
+1. emit the release seal with `tools/emit_fogstack_release_seal.py`
+2. attach signature metadata with `tools/attach_fogstack_release_seal_signature.py`
+3. verify the signed-seal shape with `tools/verify_fogstack_release_seal_signature.py`
+
+## Example
+
+```bash
+python3 tools/attach_fogstack_release_seal_signature.py \
+  --seal releases/seals/fogstack.access-v0.1.seal.json \
+  --signature-type cosign \
+  --signature-ref artifact://release/fogstack.access-v0.1.seal.sig \
+  --output /tmp/fogstack.access-v0.1.signed.seal.json
+
+python3 tools/verify_fogstack_release_seal_signature.py \
+  --seal /tmp/fogstack.access-v0.1.signed.seal.json \
+  --require-signed \
+  --json
+```
+
+## What this phase provides
+
+- seal schema can carry `signed` + `signature`
+- helper to attach signature metadata to a seal
+- helper to verify signed-seal metadata shape
+
+## What this phase does not yet provide
+
+- cryptographic verification of the seal signature payload
+- automatic CI verification of the seal signature
+- publication of signed seals
+- linking the seal signature into the broader trust graph
+
+Those remain later steps.

--- a/schemas/release/fogstack-release-seal-v0.1.schema.json
+++ b/schemas/release/fogstack-release-seal-v0.1.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-release-seal-v0.1.schema.json",
+  "title": "FogStackReleaseSeal",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "algorithm",
+    "release_root_hash",
+    "artifact_hashes"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackReleaseSeal" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+    "version": { "type": "string" },
+    "algorithm": { "enum": ["sha256"] },
+    "release_root_hash": { "type": "string" },
+    "artifact_hashes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["label", "ref", "hash"],
+        "properties": {
+          "label": { "type": "string" },
+          "ref": { "type": "string" },
+          "hash": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "notes": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/schemas/release/fogstack-release-seal-v0.1.schema.json
+++ b/schemas/release/fogstack-release-seal-v0.1.schema.json
@@ -10,7 +10,8 @@
     "version",
     "algorithm",
     "release_root_hash",
-    "artifact_hashes"
+    "artifact_hashes",
+    "signed"
   ],
   "properties": {
     "kind": { "const": "FogStackReleaseSeal" },
@@ -31,6 +32,16 @@
         },
         "additionalProperties": false
       }
+    },
+    "signed": { "type": "boolean" },
+    "signature": {
+      "type": ["object", "null"],
+      "required": ["type", "ref"],
+      "properties": {
+        "type": { "enum": ["cosign", "sigstore", "other"] },
+        "ref": { "type": "string" }
+      },
+      "additionalProperties": false
     },
     "notes": { "type": ["string", "null"] }
   },

--- a/tools/attach_fogstack_release_seal_signature.py
+++ b/tools/attach_fogstack_release_seal_signature.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Attach signature metadata to a Fog Stack release seal")
+    parser.add_argument("--seal", required=True, type=Path)
+    parser.add_argument("--signature-type", required=True, choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--signature-ref", required=True)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    seal = load_json(args.seal)
+    seal["signed"] = True
+    seal["signature"] = {
+        "type": args.signature_type,
+        "ref": args.signature_ref,
+    }
+
+    text = json.dumps(seal, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/emit_fogstack_release_seal.py
+++ b/tools/emit_fogstack_release_seal.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            h.update(chunk)
+    return 'sha256:' + h.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Emit a Fog Stack release seal from artifact files')
+    parser.add_argument('--bundle-id', required=True)
+    parser.add_argument('--version', required=True)
+    parser.add_argument('--artifact', action='append', nargs=2, metavar=('LABEL', 'PATH'), required=True,
+                        help='Artifact label and file path; may be repeated')
+    parser.add_argument('--notes', default=None)
+    parser.add_argument('--output', type=Path, default=None)
+    args = parser.parse_args()
+
+    artifact_hashes: list[dict[str, str]] = []
+    for label, path_str in args.artifact:
+        p = Path(path_str)
+        artifact_hashes.append({
+            'label': label,
+            'ref': str(p),
+            'hash': sha256_file(p),
+        })
+
+    artifact_hashes.sort(key=lambda x: x['label'])
+    root_material = json.dumps(artifact_hashes, sort_keys=True).encode('utf-8')
+    release_root_hash = 'sha256:' + hashlib.sha256(root_material).hexdigest()
+
+    seal = {
+        'kind': 'FogStackReleaseSeal',
+        'schema_version': 'v0.1',
+        'bundle_id': args.bundle_id,
+        'version': args.version,
+        'algorithm': 'sha256',
+        'release_root_hash': release_root_hash,
+        'artifact_hashes': artifact_hashes,
+        'notes': args.notes,
+    }
+
+    text = json.dumps(seal, indent=2) + '\n'
+    if args.output:
+        args.output.write_text(text, encoding='utf-8')
+    else:
+        print(text, end='')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/verify_fogstack_release_seal_signature.py
+++ b/tools/verify_fogstack_release_seal_signature.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify Fog Stack release seal signature metadata")
+    parser.add_argument("--seal", required=True, type=Path)
+    parser.add_argument("--require-signed", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    seal = load_json(args.seal)
+    signed = seal.get("signed")
+    signature = seal.get("signature")
+    checks = []
+
+    def record(rule_id: str, status: str, message: str) -> None:
+        checks.append({"id": rule_id, "status": status, "message": message})
+
+    if signed is True:
+        record("SEALSIG-001", "pass", "seal marked signed")
+    elif signed is False:
+        if args.require_signed:
+            record("SEALSIG-001", "fail", "seal is not marked signed")
+        else:
+            record("SEALSIG-001", "warn", "seal is unsigned")
+    else:
+        record("SEALSIG-001", "fail", "seal missing boolean 'signed' field")
+
+    if signed is True:
+        if not isinstance(signature, dict):
+            record("SEALSIG-002", "fail", "signed seal missing signature object")
+        else:
+            sig_type = signature.get("type")
+            sig_ref = signature.get("ref")
+            if sig_type in {"cosign", "sigstore", "other"}:
+                record("SEALSIG-002", "pass", f"signature type present: {sig_type}")
+            else:
+                record("SEALSIG-002", "fail", f"invalid signature type: {sig_type!r}")
+            if isinstance(sig_ref, str) and sig_ref.strip():
+                record("SEALSIG-003", "pass", "signature reference present")
+            else:
+                record("SEALSIG-003", "fail", "signature reference missing or empty")
+    else:
+        record("SEALSIG-002", "skip", "signature object not required for unsigned seal")
+        record("SEALSIG-003", "skip", "signature reference not required for unsigned seal")
+
+    statuses = [c["status"] for c in checks]
+    if "fail" in statuses:
+        overall = "fail"
+        exit_code = 2
+    elif "warn" in statuses:
+        overall = "warn"
+        exit_code = 0
+    else:
+        overall = "pass"
+        exit_code = 0
+
+    result = {
+        "tool": "fogstack verify-seal-signature",
+        "subject": str(args.seal),
+        "summary": {
+            "status": overall,
+            "exit_code": exit_code,
+            "checks_run": len(checks)
+        },
+        "checks": checks
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"{args.seal} status={overall} checks={len(checks)}")
+        for item in checks:
+            print(f"- {item['status'].upper():5s} {item['id']} {item['message']}")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This stacked PR adds the next release-sealing step on top of the current release-seal branch:

- updated `schemas/release/fogstack-release-seal-v0.1.schema.json`
- `tools/attach_fogstack_release_seal_signature.py`
- `tools/verify_fogstack_release_seal_signature.py`
- `docs/FOGSTACK_RELEASE_SEAL_SIGNATURES.md`

## Why this shape

The current release-seal branch introduces:
- the `FogStackReleaseSeal` schema
- a helper that computes deterministic artifact hashes and a `release_root_hash`
- a guidance doc for release sealing

This PR builds on that by letting the seal itself carry signature metadata and by adding repo-native helpers to attach and verify the signed-seal shape.

## Not in this PR

- cryptographic verification of the seal signature payload
- CI enforcement of seal-signature verification
- publication of signed seals
- linkage of seal-signature verification into the wider trust graph

Those remain later steps.
