### PR TITLE
Storage: align receipts with evidence reader layout

### DIFF
--- a/apps/storage-promotion/receipts.py
+++ b/apps/storage-promotion/receipts.py
@@ -10,37 +10,59 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+SERVICE_DIR = "storage-promotion"
+SERVICE_REF = "apps/storage-promotion"
+
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
 
 def digest_json(payload: dict[str, Any]) -> str:
-    body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
     return hashlib.sha256(body).hexdigest()
 
 
-def state_root() -> Path:
-    return Path(os.environ.get("STORAGE_PROMOTION_STATE_HOME", ".storage-promotion-state")).resolve()
+def state_home() -> Path:
+    if v := os.environ.get("SOCIOPROFIT_STATE_HOME"):
+        return Path(v)
+    if v := os.environ.get("STORAGE_PROMOTION_STATE_HOME"):
+        return Path(v)
+    return Path.home() / ".local" / "state"
+
+
+def platform_state_root() -> Path:
+    return state_home() / "prophet-platform"
+
+
+def payloads_root() -> Path:
+    return platform_state_root() / "payloads" / SERVICE_DIR
 
 
 def events_root() -> Path:
-    return state_root() / "events"
+    return platform_state_root() / "events" / SERVICE_DIR
 
 
 def receipts_root() -> Path:
-    return state_root() / "receipts"
+    return platform_state_root() / "receipts" / SERVICE_DIR
 
 
 def ensure_dirs() -> None:
-    events_root().mkdir(parents=True, exist_ok=True)
-    receipts_root().mkdir(parents=True, exist_ok=True)
+    for path in [payloads_root(), events_root(), receipts_root()]:
+        path.mkdir(parents=True, exist_ok=True)
 
 
 @dataclass(frozen=True)
 class ReceiptBundle:
     envelope: dict[str, Any]
     receipt: dict[str, Any]
+
+
+def write_payload(payload: dict[str, Any], *, stem: str) -> tuple[Path, str]:
+    ensure_dirs()
+    path = payloads_root() / f"{stem}.payload.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path, f"file://{path.resolve()}"
 
 
 def make_bundle(
@@ -50,7 +72,7 @@ def make_bundle(
     status: str,
     subject_ref: str,
     payload_ref: str,
-    service_ref: str = "apps/storage-promotion",
+    service_ref: str = SERVICE_REF,
     scope_ref: str | None = None,
     correlation_id: str | None = None,
     classifiers: list[str] | None = None,
@@ -104,7 +126,7 @@ def make_bundle(
 
 def write_bundle(bundle: ReceiptBundle, *, stem: str | None = None) -> tuple[Path, Path]:
     ensure_dirs()
-    stem = stem or bundle.envelope["envelope_id"]
+    stem = stem or bundle.envelope["correlation_id"]
     event_path = events_root() / f"{stem}.event.json"
     receipt_path = receipts_root() / f"{stem}.receipt.json"
     event_path.write_text(json.dumps(bundle.envelope, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tools/validate_storage_evidence_layout.py
+++ b/tools/validate_storage_evidence_layout.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+STORAGE_RECEIPTS = ROOT / "apps" / "storage-promotion" / "receipts.py"
+EVIDENCE_APP = ROOT / "apps" / "evidence-receipts"
+
+
+def fail(msg: str) -> int:
+    print(f"ERR: {msg}", file=sys.stderr)
+    return 2
+
+
+def load_storage_receipts():
+    spec = importlib.util.spec_from_file_location("storage_receipts", STORAGE_RECEIPTS)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load storage receipt helper")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    sys.path.insert(0, str(EVIDENCE_APP))
+    from app.store import get_bundle, list_services
+
+    storage_receipts = load_storage_receipts()
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ["SOCIOPROFIT_STATE_HOME"] = str(Path(tmp) / "state")
+        payload = {"kind": "storage-layout-smoke", "ok": True}
+        payload_path, payload_ref = storage_receipts.write_payload(payload, stem="storage-layout-smoke")
+        bundle = storage_receipts.make_bundle(
+            event_type="storage.layout.smoke",
+            action="StorageLayoutSmoke",
+            status="succeeded",
+            subject_ref="storage://layout-smoke",
+            payload_ref=payload_ref,
+            correlation_id="storage-layout-smoke",
+            classifiers=["slice:storage-promotion", "layout:type-first"],
+        )
+        event_path, receipt_path = storage_receipts.write_bundle(bundle, stem="storage-layout-smoke")
+
+        if not payload_path.exists() or not event_path.exists() or not receipt_path.exists():
+            return fail("storage receipt artifacts were not written")
+        services = list_services()
+        if "storage-promotion" not in services:
+            return fail(f"storage-promotion missing from services: {services}")
+        readback = get_bundle(service="storage-promotion", correlation_id="storage-layout-smoke")
+        if readback is None:
+            return fail("evidence-receipts could not read storage bundle")
+        if readback.get("payload") != payload:
+            return fail("readback payload mismatch")
+        if readback.get("event", {}).get("event_type") != "storage.layout.smoke":
+            return fail("readback event mismatch")
+        if readback.get("receipt", {}).get("service_ref") != "apps/storage-promotion":
+            return fail("readback receipt service mismatch")
+
+    print("OK: storage evidence layout aligns with evidence-receipts")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_storage_suite.py
+++ b/tools/validate_storage_suite.py
@@ -11,6 +11,7 @@ CHECKS = [
     ROOT / "tools" / "validate_storage_vertical_slice.py",
     ROOT / "tools" / "validate_storage_receipts_vertical_slice.py",
     ROOT / "tools" / "validate_storage_live_typedb_mode.py",
+    ROOT / "tools" / "validate_storage_evidence_layout.py",
 ]
 
 


### PR DESCRIPTION
Aligns `apps/storage-promotion` receipt output with the canonical evidence reader layout now used by `apps/evidence-receipts`.

Why:
- `evidence-receipts` now reads the canonical type-first artifact layout: `prophet-platform/{payloads,events,receipts}/<service>`.
- `storage-promotion` was still writing service-local event/receipt files under its standalone state tree.

Changes:
- update `apps/storage-promotion/receipts.py` to use canonical type-first evidence layout
- add `tools/validate_storage_evidence_layout.py` proving `evidence-receipts` can read a storage-promotion bundle
- include that validator in `tools/validate_storage_suite.py`

Kept intentionally narrow to avoid conflicting with fast-moving eval, FogStack, evidence, and zone-router work.