### PR TITLE
docs(platform): add real-time ops fabric contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check test-go validate-phase4 test-python-apps validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check validate-ops-fabric test-go validate-phase4 test-python-apps validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -16,6 +16,9 @@ standards-check:
 
 topology-check:
 	python3 tools/check_transport_topology.py
+
+validate-ops-fabric:
+	python3 tools/validate_ops_fabric.py
 
 test-go:
 	go test ./libs/go/tritrpcbridge/...

--- a/docs/OPS_FABRIC_GLOBAL_DEVSECOPS_ALIGNMENT.md
+++ b/docs/OPS_FABRIC_GLOBAL_DEVSECOPS_ALIGNMENT.md
@@ -1,0 +1,22 @@
+# Ops Fabric and Global DevSecOps Intelligence Alignment
+
+Prophet Real-Time Ops Fabric must integrate with `SocioProphet/global-devsecops-intelligence` as the upstream operations-domain intelligence plane.
+
+`prophet-platform` owns runtime APIs, event and evidence contracts, deployment wiring, and the operational proposal surface.
+
+`global-devsecops-intelligence` owns the DevSecOps, AIOps, and AI4IT domain specialization: operations taxonomy, topic ladder, entity extraction schemas, mapping DSL, story grouping, explainability, feedback loops, measurement profile, IBM ITOPS seed alignment, and operational graph projections.
+
+Ops Fabric must consume this intelligence rather than recreate it locally.
+
+## Required v0.1 seams
+
+- `ActionProposal` should support `intelligence_refs` for DevSecOps and AI4IT evidence.
+- `TelemetryEvent` should support an operations profile reference when events are classified by the AI4IT profile.
+- Security and operational-exhaust signals from `global-devsecops-intelligence` should influence proposal scoring before any execution lease is emitted.
+- Future `ops-fabric-api` routes should preserve intelligence references in proposal, policy-check, and lease-candidate responses.
+
+## Dependency direction
+
+`platform standards -> knowledge / ontology standards -> global-devsecops-intelligence -> prophet-platform runtime implementations`
+
+This keeps `prophet-platform` as the runtime implementation layer and keeps domain intelligence in the repository that already owns AI4IT and ITOPS semantics.

--- a/docs/OPS_FABRIC_SHERLOCK_SEARCH_ALIGNMENT.md
+++ b/docs/OPS_FABRIC_SHERLOCK_SEARCH_ALIGNMENT.md
@@ -1,0 +1,23 @@
+# Ops Fabric and Sherlock Search Alignment
+
+Prophet Real-Time Ops Fabric must integrate with Sherlock Search as the discovery and chat-ops retrieval plane.
+
+Ops Fabric produces operational events, evidence references, intelligence references, action proposals, and handoff candidates.
+
+Sherlock Search provides the federated discovery layer that lets operators and agents retrieve those artifacts across Lampstand local search, platform workspace indexes, memory-mesh recall, and ontogenesis-backed semantic alignment.
+
+## Required v0.1 seams
+
+- Ops Fabric artifacts must be searchable as platform result records.
+- Action proposals must preserve titles, summaries, target IDs, evidence references, policy status, and intelligence references for retrieval.
+- Sherlock chat-ops flows must be able to ask: what changed, what is risky, what evidence supports this recommendation, what policy blocked it, and what handoff candidate exists.
+- Search results must preserve permission boundaries and source metadata.
+- Sherlock remains the discovery and chat-ops surface; Ops Fabric remains the operational control-plane producer.
+
+## Runtime binding
+
+The first binding is through the existing platform search runtime lane and the future `services/search-orchestrator/` provider seam.
+
+Ops Fabric should emit searchable records with source `OPS_FABRIC`, entity types such as `TELEMETRY_EVENT`, `ACTION_PROPOSAL`, `HANDOFF_CANDIDATE`, and `OPS_EVIDENCE`, and stable IDs that Sherlock can rank and fuse with local, memory, and semantic sources.
+
+This makes Sherlock Search the Watson Discovery plus chat-ops analogue for the open SocioProphet stack.

--- a/docs/PROPHET_REAL_TIME_OPS_FABRIC.md
+++ b/docs/PROPHET_REAL_TIME_OPS_FABRIC.md
@@ -14,7 +14,7 @@ v0.1 is report-only. Autonomous mutation is out of scope.
 4. Policy gate: policy-fabric evaluation before any recommendation can become executable.
 5. Agentplane bridge: approved proposals become action-lease candidates with evidence, rollback, and replay references.
 6. Evidence memory: memory-mesh persistence for operational recommendations and incident/action history.
-7. Search surface: lampstand indexing over services, incidents, proposals, receipts, and operational evidence.
+7. Search surface: lampstand indexing plus sherlock-search discovery over services, incidents, proposals, receipts, operational evidence, and chat-ops queries.
 8. DevSecOps intelligence: `global-devsecops-intelligence` supplies the AI4IT and ITOPS domain profile, taxonomy, mapping semantics, and operational graph projections.
 
 ## Repository ownership
@@ -33,6 +33,8 @@ v0.1 is report-only. Autonomous mutation is out of scope.
 
 `lampstand` owns local and platform search/index surfaces.
 
+`sherlock-search` owns the discovery and chat-ops retrieval plane over Ops Fabric events, proposals, evidence, and intelligence references.
+
 ## v0.1 contracts
 
 Tranche 1 introduces:
@@ -40,9 +42,9 @@ Tranche 1 introduces:
 - `EvidenceRef`
 - `TelemetryEvent`
 - `ActionProposal`
-- `ActionLease`
+- `HandoffCandidate`
 
-These contracts are intentionally small. They establish evidence references, source classification, proposal scoring inputs, policy status, and the lease handoff seam.
+These contracts are intentionally small. They establish evidence references, source classification, proposal scoring inputs, policy status, and the report-only handoff seam.
 
 ## Agent-native flow
 
@@ -52,9 +54,9 @@ These contracts are intentionally small. They establish evidence references, sou
 4. The observability graph links services, workloads, metrics, costs, security signals, and topology.
 5. The resource governor emits an `ActionProposal`.
 6. The proposal is policy checked.
-7. Allowed proposals may become `ActionLease` candidates.
+7. Allowed proposals may become report-only `HandoffCandidate` records.
 8. Evidence is written to memory surfaces.
-9. Search/index surfaces expose the proposal, evidence, and receipt chain.
+9. Search/index surfaces expose the proposal, evidence, and receipt chain for sherlock-search and chat-ops retrieval.
 10. Execution remains manual or supervised in v0.1.
 
 ## Initial proposal types
@@ -75,7 +77,7 @@ These contracts are intentionally small. They establish evidence references, sou
 
 ## Acceptance criteria
 
-- JSON schemas exist for core event, evidence, proposal, and lease contracts.
+- JSON schemas exist for core event, evidence, proposal, and report-only handoff contracts.
 - Example payloads exist for the first right-sizing scenario.
 - No autonomous mutation is introduced.
 - Every proposal includes evidence references, impact estimates, blast radius, reversibility, autonomy tier, and policy status.

--- a/docs/PROPHET_REAL_TIME_OPS_FABRIC.md
+++ b/docs/PROPHET_REAL_TIME_OPS_FABRIC.md
@@ -1,0 +1,82 @@
+# Prophet Real-Time Ops Fabric v0.1
+
+Prophet Real-Time Ops Fabric is the agent-native operations lane for Prophet Platform.
+
+It aligns the useful parts of enterprise streaming, observability, AIOps, AI4IT, and resource optimization while avoiding closed-suite architecture. The fabric lets governed agents observe runtime state, reason over typed evidence, propose operational changes, pass policy gates, and hand approved work to execution surfaces with replayable receipts.
+
+v0.1 is report-only. Autonomous mutation is out of scope.
+
+## Capability lanes
+
+1. Event spine: normalized operational facts from telemetry, CI/CD, runtime, cost, energy, policy, and security sources.
+2. Observability graph: typed relationships among services, workloads, nodes, deployments, traces, metrics, costs, incidents, and security signals.
+3. Resource governor: deterministic `ActionProposal` generation for right-sizing, autoscaling policy, SLO risk, cost risk, and security risk.
+4. Policy gate: policy-fabric evaluation before any recommendation can become executable.
+5. Agentplane bridge: approved proposals become action-lease candidates with evidence, rollback, and replay references.
+6. Evidence memory: memory-mesh persistence for operational recommendations and incident/action history.
+7. Search surface: lampstand indexing over services, incidents, proposals, receipts, and operational evidence.
+8. DevSecOps intelligence: `global-devsecops-intelligence` supplies the AI4IT and ITOPS domain profile, taxonomy, mapping semantics, and operational graph projections.
+
+## Repository ownership
+
+`prophet-platform` owns runtime APIs, contracts, local and cluster services, deployment wiring, and product surface.
+
+`global-devsecops-intelligence` owns the operations-domain intelligence plane: DevSecOps, AIOps, AI4IT taxonomy, IBM ITOPS seed mapping, entity extraction, story grouping, explainability, feedback loops, and operational graph projections.
+
+`ontogenesis` owns broader canonical ontology and promotion gates.
+
+`policy-fabric` owns action legality, blast-radius controls, autonomy tiers, and approval thresholds.
+
+`agentplane` owns governed execution, leases, run artifacts, replay artifacts, receipts, and placement decisions.
+
+`memory-mesh` owns evidence memory and recommendation history.
+
+`lampstand` owns local and platform search/index surfaces.
+
+## v0.1 contracts
+
+Tranche 1 introduces:
+
+- `EvidenceRef`
+- `TelemetryEvent`
+- `ActionProposal`
+- `ActionLease`
+
+These contracts are intentionally small. They establish evidence references, source classification, proposal scoring inputs, policy status, and the lease handoff seam.
+
+## Agent-native flow
+
+1. A collector receives or synthesizes operational facts.
+2. Facts become typed platform events.
+3. Events attach stable evidence references.
+4. The observability graph links services, workloads, metrics, costs, security signals, and topology.
+5. The resource governor emits an `ActionProposal`.
+6. The proposal is policy checked.
+7. Allowed proposals may become `ActionLease` candidates.
+8. Evidence is written to memory surfaces.
+9. Search/index surfaces expose the proposal, evidence, and receipt chain.
+10. Execution remains manual or supervised in v0.1.
+
+## Initial proposal types
+
+- `RIGHTSIZE_WORKLOAD`
+- `ADJUST_REPLICA_POLICY`
+- `ADJUST_AUTOSCALER_TARGET`
+- `ADD_BUDGET_GUARDRAIL`
+- `FLAG_SLO_RISK`
+- `FLAG_SECURITY_RISK`
+
+## Policy status values
+
+- `NOT_EVALUATED`
+- `ALLOWED_REPORT_ONLY`
+- `ALLOWED_WITH_APPROVAL`
+- `DENIED`
+
+## Acceptance criteria
+
+- JSON schemas exist for core event, evidence, proposal, and lease contracts.
+- Example payloads exist for the first right-sizing scenario.
+- No autonomous mutation is introduced.
+- Every proposal includes evidence references, impact estimates, blast radius, reversibility, autonomy tier, and policy status.
+- The contracts are ready for the next read-only service slice: `services/ops-fabric-api/`.

--- a/examples/ops/action-proposal-sample.v0.1.json
+++ b/examples/ops/action-proposal-sample.v0.1.json
@@ -1,0 +1,58 @@
+{
+  "proposal_id": "ops.proposal.0001",
+  "proposal_type": "RIGHTSIZE_WORKLOAD",
+  "created_at": "2026-04-24T17:46:00Z",
+  "target": {
+    "kind": "Workload",
+    "id": "sample-workload",
+    "namespace": "default",
+    "cluster": "p0-lab",
+    "zone": "local"
+  },
+  "summary": "Report-only right-sizing recommendation for a sample workload.",
+  "rationale": [
+    "Observed usage is materially lower than reserved capacity.",
+    "Global DevSecOps intelligence is attached as a domain profile reference.",
+    "Sherlock-search can retrieve this proposal through the platform search lane."
+  ],
+  "recommended_change": {
+    "mode": "REPORT_ONLY",
+    "patch_kind": "ResourceIntent",
+    "before": {"cpu_units": 1000, "memory_units": 2048},
+    "after": {"cpu_units": 500, "memory_units": 1024}
+  },
+  "impact_estimate": {
+    "cost_delta_monthly_usd": -42.0,
+    "energy_delta_kwh_monthly": -9.5,
+    "slo_risk_delta": 0.02,
+    "security_risk_delta": 0.0,
+    "confidence": 0.72
+  },
+  "risk": {
+    "blast_radius": "LOW",
+    "reversibility": "ROLLBACK_PATCH",
+    "requires_human_approval": true,
+    "notes": ["No mutation is permitted in v0.1."]
+  },
+  "policy_status": "NOT_EVALUATED",
+  "autonomy_tier": "REPORT_ONLY",
+  "evidence_refs": [
+    {
+      "evidence_id": "evidence.metric-window.0001",
+      "kind": "METRIC_WINDOW",
+      "source": "synthetic-v0",
+      "uri": "memory://ops-fixtures/metric-window/0001",
+      "observed_at": "2026-04-24T17:45:00Z",
+      "digest": "sha256:placeholder"
+    }
+  ],
+  "intelligence_refs": [
+    {
+      "intelligence_id": "gdi.profile.operational-exhaust-fusion.v0",
+      "source_repo": "SocioProphet/global-devsecops-intelligence",
+      "profile_ref": "profiles/operational-exhaust-fusion-profile.v0.yaml",
+      "kind": "OPERATIONAL_EXHAUST_FUSION",
+      "confidence": 0.7
+    }
+  ]
+}

--- a/schemas/ops/README.md
+++ b/schemas/ops/README.md
@@ -8,6 +8,6 @@ The contracts are deliberately small and report-only:
 - `intelligence-ref.schema.v0.1.json` references operations-domain intelligence from `global-devsecops-intelligence`.
 - `telemetry-event.schema.v0.1.json` captures normalized operational facts.
 - `action-proposal.schema.v0.1.json` represents a resource-governor recommendation.
-- `action-lease.schema.v0.1.json` represents an execution candidate for AgentPlane handoff.
+- `handoff-candidate.schema.v0.1.json` represents a report-only AgentPlane or GitOps handoff candidate.
 
 v0.1 does not permit autonomous mutation.

--- a/schemas/ops/README.md
+++ b/schemas/ops/README.md
@@ -1,0 +1,13 @@
+# Ops Fabric Schemas
+
+This directory contains v0.1 contracts for Prophet Real-Time Ops Fabric.
+
+The contracts are deliberately small and report-only:
+
+- `evidence-ref.schema.v0.1.json` references supporting operational evidence.
+- `intelligence-ref.schema.v0.1.json` references operations-domain intelligence from `global-devsecops-intelligence`.
+- `telemetry-event.schema.v0.1.json` captures normalized operational facts.
+- `action-proposal.schema.v0.1.json` represents a resource-governor recommendation.
+- `action-lease.schema.v0.1.json` represents an execution candidate for AgentPlane handoff.
+
+v0.1 does not permit autonomous mutation.

--- a/schemas/ops/action-proposal.schema.v0.1.json
+++ b/schemas/ops/action-proposal.schema.v0.1.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/ops/action-proposal.schema.v0.1.json",
+  "title": "ActionProposal",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "proposal_id",
+    "proposal_type",
+    "created_at",
+    "target",
+    "summary",
+    "rationale",
+    "recommended_change",
+    "impact_estimate",
+    "risk",
+    "policy_status",
+    "autonomy_tier",
+    "evidence_refs"
+  ],
+  "properties": {
+    "proposal_id": {"type": "string", "minLength": 1},
+    "proposal_type": {
+      "type": "string",
+      "enum": [
+        "RIGHTSIZE_WORKLOAD",
+        "ADJUST_REPLICA_POLICY",
+        "ADJUST_AUTOSCALER_TARGET",
+        "ADD_BUDGET_GUARDRAIL",
+        "FLAG_SLO_RISK",
+        "FLAG_SECURITY_RISK"
+      ]
+    },
+    "created_at": {"type": "string", "format": "date-time"},
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {"type": "string", "minLength": 1},
+        "id": {"type": "string", "minLength": 1},
+        "namespace": {"type": "string"},
+        "cluster": {"type": "string"},
+        "zone": {"type": "string"}
+      }
+    },
+    "summary": {"type": "string", "minLength": 1},
+    "rationale": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+    "recommended_change": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["mode"],
+      "properties": {
+        "mode": {"type": "string", "enum": ["REPORT_ONLY", "GITOPS_PATCH_CANDIDATE", "ACTION_LEASE_CANDIDATE"]},
+        "patch_kind": {"type": "string"},
+        "before": {"type": "object", "additionalProperties": true},
+        "after": {"type": "object", "additionalProperties": true}
+      }
+    },
+    "impact_estimate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cost_delta_monthly_usd", "slo_risk_delta", "confidence"],
+      "properties": {
+        "cost_delta_monthly_usd": {"type": "number"},
+        "energy_delta_kwh_monthly": {"type": "number"},
+        "slo_risk_delta": {"type": "number"},
+        "security_risk_delta": {"type": "number"},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+      }
+    },
+    "risk": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["blast_radius", "reversibility", "requires_human_approval"],
+      "properties": {
+        "blast_radius": {"type": "string", "enum": ["LOW", "MEDIUM", "HIGH"]},
+        "reversibility": {"type": "string", "enum": ["IMMEDIATE", "ROLLBACK_PATCH", "MANUAL_RECOVERY", "UNKNOWN"]},
+        "requires_human_approval": {"type": "boolean"},
+        "notes": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "policy_status": {"type": "string", "enum": ["NOT_EVALUATED", "ALLOWED_REPORT_ONLY", "ALLOWED_WITH_APPROVAL", "DENIED"]},
+    "autonomy_tier": {"type": "string", "enum": ["REPORT_ONLY", "SUPERVISED", "PREAPPROVED_LOW_RISK", "AUTONOMOUS_DISABLED"]},
+    "evidence_refs": {
+      "type": "array",
+      "items": {"$ref": "evidence-ref.schema.v0.1.json"},
+      "minItems": 1
+    },
+    "intelligence_refs": {
+      "type": "array",
+      "items": {"$ref": "intelligence-ref.schema.v0.1.json"},
+      "default": []
+    }
+  }
+}

--- a/schemas/ops/evidence-ref.schema.v0.1.json
+++ b/schemas/ops/evidence-ref.schema.v0.1.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/ops/evidence-ref.schema.v0.1.json",
+  "title": "EvidenceRef",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["evidence_id", "kind", "source", "uri", "observed_at"],
+  "properties": {
+    "evidence_id": {"type": "string", "minLength": 1},
+    "kind": {
+      "type": "string",
+      "enum": [
+        "METRIC_WINDOW",
+        "TRACE_SAMPLE",
+        "TOPOLOGY_SNAPSHOT",
+        "COST_SAMPLE",
+        "ENERGY_SAMPLE",
+        "SECURITY_SIGNAL",
+        "POLICY_DECISION",
+        "RECEIPT",
+        "RUN_ARTIFACT",
+        "INTELLIGENCE_PROFILE"
+      ]
+    },
+    "source": {"type": "string", "minLength": 1},
+    "uri": {"type": "string", "minLength": 1},
+    "observed_at": {"type": "string", "format": "date-time"},
+    "digest": {"type": "string"},
+    "notes": {"type": "string"}
+  }
+}

--- a/schemas/ops/handoff-candidate.schema.v0.1.json
+++ b/schemas/ops/handoff-candidate.schema.v0.1.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/ops/handoff-candidate.schema.v0.1.json",
+  "title": "HandoffCandidate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "handoff_id",
+    "proposal_id",
+    "created_at",
+    "target_plane",
+    "policy_decision_id",
+    "review_status",
+    "rollback_ref",
+    "evidence_refs"
+  ],
+  "properties": {
+    "handoff_id": {"type": "string", "minLength": 1},
+    "proposal_id": {"type": "string", "minLength": 1},
+    "created_at": {"type": "string", "format": "date-time"},
+    "target_plane": {"type": "string", "enum": ["AGENTPLANE", "GITOPS", "MANUAL_REVIEW"]},
+    "policy_decision_id": {"type": "string", "minLength": 1},
+    "review_status": {"type": "string", "enum": ["DRAFT", "READY_FOR_REVIEW", "APPROVED", "REJECTED"]},
+    "rollback_ref": {"type": "string", "minLength": 1},
+    "evidence_refs": {
+      "type": "array",
+      "items": {"$ref": "evidence-ref.schema.v0.1.json"},
+      "minItems": 1
+    },
+    "intelligence_refs": {
+      "type": "array",
+      "items": {"$ref": "intelligence-ref.schema.v0.1.json"},
+      "default": []
+    }
+  }
+}

--- a/schemas/ops/intelligence-ref.schema.v0.1.json
+++ b/schemas/ops/intelligence-ref.schema.v0.1.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/ops/intelligence-ref.schema.v0.1.json",
+  "title": "IntelligenceRef",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["intelligence_id", "source_repo", "profile_ref", "kind"],
+  "properties": {
+    "intelligence_id": {"type": "string", "minLength": 1},
+    "source_repo": {"type": "string", "const": "SocioProphet/global-devsecops-intelligence"},
+    "profile_ref": {"type": "string", "minLength": 1},
+    "kind": {
+      "type": "string",
+      "enum": [
+        "AI4IT_PROFILE",
+        "ITOPS_MAPPING",
+        "OPS_GRAPH_PROJECTION",
+        "ENTITY_EXTRACTION",
+        "STORY_GROUPING",
+        "OPERATIONAL_EXHAUST_FUSION",
+        "SECURITY_POSTURE_SIGNAL"
+      ]
+    },
+    "uri": {"type": "string"},
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+    "notes": {"type": "string"}
+  }
+}

--- a/schemas/ops/telemetry-event.schema.v0.1.json
+++ b/schemas/ops/telemetry-event.schema.v0.1.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/ops/telemetry-event.schema.v0.1.json",
+  "title": "TelemetryEvent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event_id", "event_type", "observed_at", "subject", "source", "measurements"],
+  "properties": {
+    "event_id": {"type": "string", "minLength": 1},
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "WORKLOAD_RESOURCE_SAMPLE",
+        "SERVICE_HEALTH_SAMPLE",
+        "TOPOLOGY_CHANGE",
+        "COST_SAMPLE",
+        "ENERGY_SAMPLE",
+        "SECURITY_SIGNAL",
+        "INCIDENT_SIGNAL",
+        "DEVSECOPS_INTELLIGENCE_SIGNAL"
+      ]
+    },
+    "observed_at": {"type": "string", "format": "date-time"},
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "id"],
+      "properties": {
+        "kind": {"type": "string", "minLength": 1},
+        "id": {"type": "string", "minLength": 1},
+        "namespace": {"type": "string"},
+        "cluster": {"type": "string"},
+        "zone": {"type": "string"}
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["system"],
+      "properties": {
+        "system": {"type": "string", "minLength": 1},
+        "adapter": {"type": "string"},
+        "version": {"type": "string"}
+      }
+    },
+    "ops_profile_ref": {"type": "string"},
+    "measurements": {
+      "type": "object",
+      "additionalProperties": {"type": ["number", "integer", "string", "boolean", "null"]}
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {"$ref": "evidence-ref.schema.v0.1.json"},
+      "default": []
+    },
+    "intelligence_refs": {
+      "type": "array",
+      "items": {"$ref": "intelligence-ref.schema.v0.1.json"},
+      "default": []
+    }
+  }
+}

--- a/tools/validate_ops_fabric.py
+++ b/tools/validate_ops_fabric.py
@@ -57,6 +57,13 @@ def read_json(path: str) -> dict:
     return data
 
 
+def require_terms(path: str, text: str) -> None:
+    normalized = text.lower()
+    for term in REQUIRED_DOC_TERMS.get(path, []):
+        if term.lower() not in normalized:
+            fail(f"{path} missing required term: {term}")
+
+
 def main() -> None:
     for path in REQUIRED_JSON:
         read_json(path)
@@ -68,9 +75,7 @@ def main() -> None:
         text = full.read_text(encoding="utf-8")
         if not text.strip():
             fail(f"empty required doc: {path}")
-        for term in REQUIRED_DOC_TERMS.get(path, []):
-            if term not in text:
-                fail(f"{path} missing required term: {term}")
+        require_terms(path, text)
 
     proposal = read_json("examples/ops/action-proposal-sample.v0.1.json")
     if proposal.get("policy_status") != "NOT_EVALUATED":

--- a/tools/validate_ops_fabric.py
+++ b/tools/validate_ops_fabric.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_JSON = [
+    "schemas/ops/evidence-ref.schema.v0.1.json",
+    "schemas/ops/intelligence-ref.schema.v0.1.json",
+    "schemas/ops/telemetry-event.schema.v0.1.json",
+    "schemas/ops/action-proposal.schema.v0.1.json",
+    "schemas/ops/handoff-candidate.schema.v0.1.json",
+    "examples/ops/action-proposal-sample.v0.1.json",
+]
+
+REQUIRED_DOCS = [
+    "docs/PROPHET_REAL_TIME_OPS_FABRIC.md",
+    "docs/OPS_FABRIC_GLOBAL_DEVSECOPS_ALIGNMENT.md",
+    "docs/OPS_FABRIC_SHERLOCK_SEARCH_ALIGNMENT.md",
+]
+
+REQUIRED_DOC_TERMS = {
+    "docs/PROPHET_REAL_TIME_OPS_FABRIC.md": [
+        "global-devsecops-intelligence",
+        "sherlock",
+        "report-only",
+    ],
+    "docs/OPS_FABRIC_GLOBAL_DEVSECOPS_ALIGNMENT.md": [
+        "global-devsecops-intelligence",
+        "AI4IT",
+        "operational graph",
+    ],
+    "docs/OPS_FABRIC_SHERLOCK_SEARCH_ALIGNMENT.md": [
+        "Sherlock Search",
+        "chat-ops",
+        "OPS_FABRIC",
+    ],
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ops fabric validation failed: {message}")
+
+
+def read_json(path: str) -> dict:
+    full = ROOT / path
+    if not full.exists():
+        fail(f"missing required JSON file: {path}")
+    try:
+        data = json.loads(full.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+    if not isinstance(data, dict):
+        fail(f"expected JSON object in {path}")
+    return data
+
+
+def main() -> None:
+    for path in REQUIRED_JSON:
+        read_json(path)
+
+    for path in REQUIRED_DOCS:
+        full = ROOT / path
+        if not full.exists():
+            fail(f"missing required doc: {path}")
+        text = full.read_text(encoding="utf-8")
+        if not text.strip():
+            fail(f"empty required doc: {path}")
+        for term in REQUIRED_DOC_TERMS.get(path, []):
+            if term not in text:
+                fail(f"{path} missing required term: {term}")
+
+    proposal = read_json("examples/ops/action-proposal-sample.v0.1.json")
+    if proposal.get("policy_status") != "NOT_EVALUATED":
+        fail("sample proposal must remain policy_status=NOT_EVALUATED")
+    if proposal.get("autonomy_tier") != "REPORT_ONLY":
+        fail("sample proposal must remain autonomy_tier=REPORT_ONLY")
+    if not proposal.get("intelligence_refs"):
+        fail("sample proposal must include global-devsecops intelligence_refs")
+
+    print("ops fabric validation passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Prophet Real-Time Ops Fabric v0.1 as the agent-native operations lane for platform observability, AI4IT/DevSecOps intelligence, resource-governor proposals, policy gates, evidence memory, Sherlock-search retrieval, and AgentPlane/GitOps handoff candidates.

This is the non-draft replacement for #127, which was closed only because the connector's mark-ready mutation failed against GitHub's GraphQL response shape.

## Scope

- Adds `docs/PROPHET_REAL_TIME_OPS_FABRIC.md`
- Adds `docs/OPS_FABRIC_GLOBAL_DEVSECOPS_ALIGNMENT.md`
- Adds `docs/OPS_FABRIC_SHERLOCK_SEARCH_ALIGNMENT.md`
- Adds `schemas/ops/` contracts for evidence refs, intelligence refs, telemetry events, action proposals, and report-only handoff candidates
- Adds an example report-only action proposal
- Adds `tools/validate_ops_fabric.py`
- Wires `validate-ops-fabric` into `make validate`

## Integration points

- `SocioProphet/global-devsecops-intelligence` is the upstream operations-domain profile for DevSecOps / AIOps / AI4IT semantics.
- `SocioProphet/sherlock-search` is the Watson Discovery plus chat-ops analogue and should retrieve Ops Fabric events, proposals, evidence, and intelligence references through the platform search lane.
- `agentplane` remains the governed execution plane; this PR only defines report-only handoff candidates and does not enable autonomous mutation.

## Safety posture

- v0.1 is report-only.
- No Kubernetes, host, cloud, or workload mutation is introduced.
- No autonomous action execution is introduced.

## Validation

Previous draft PR #127 was green on:

- validate
- ci
- premerge-audit
- platform-contracts-check
- platform-wave1-stubs

## Tracking

Tracks #126.
Replaces #127.