### PR TITLE
Draft: add Fog Stack pack catalog and readiness tracking

### DIFF
--- a/catalog/fogstack-packs-v0.1.yaml
+++ b/catalog/fogstack-packs-v0.1.yaml
@@ -1,0 +1,70 @@
+schema_version: "fogstack.packs/v0.1"
+kind: "FogStackPacks"
+repository_strategy: "single-repo-for-now"
+canonical_repo: "SocioProphet/prophet-platform"
+packs:
+  - id: "fogstack.access"
+    label: "Fog Stack Access"
+    category: "product_surface"
+    readiness_pct: 70
+    repo_split_now: false
+    substrate_anchors:
+      - "apps/gateway"
+      - "apps/api"
+      - "cloudshell-fog"
+    notes: "Most mature customer-facing surface; remaining work is mostly trust/release hardening."
+  - id: "fogstack.knowledge"
+    label: "Fog Stack Knowledge"
+    category: "product_surface"
+    readiness_pct: 55
+    repo_split_now: false
+    substrate_anchors:
+      - "apps/knowledge-reason"
+      - "apps/lampstand"
+    notes: "Clear substrate anchors, but more composition-heavy and operationally mixed."
+  - id: "fogstack.evaluation"
+    label: "Fog Stack Evaluation"
+    category: "product_surface"
+    readiness_pct: 55
+    repo_split_now: false
+    substrate_anchors:
+      - "apps/eval-fabric-api"
+      - "docs/PLATFORM_EVAL_FABRIC.md"
+    notes: "Real platform surface, but still more internal than packaged."
+  - id: "fogstack.security"
+    label: "Fog Stack Security / Trust"
+    category: "shared_capability"
+    readiness_pct: 35
+    repo_split_now: false
+    substrate_anchors:
+      - "schemas/release/*"
+      - "tools/*fogstack*"
+    notes: "Strong platform capability, but not yet an independently packaged product surface."
+  - id: "fogstack.data"
+    label: "Fog Stack Data"
+    category: "packaging_view"
+    readiness_pct: 30
+    repo_split_now: false
+    substrate_anchors:
+      - "knowledge + evaluation surfaces"
+    notes: "Better treated as a packaging view over Knowledge + Evaluation than as a separate repo."
+  - id: "fogstack.ai"
+    label: "Fog Stack AI"
+    category: "future_pack"
+    readiness_pct: 20
+    repo_split_now: false
+    substrate_anchors: []
+    notes: "Not enough independent runtime/product surface yet."
+  - id: "fogstack.automation"
+    label: "Fog Stack Automation"
+    category: "future_pack"
+    readiness_pct: 20
+    repo_split_now: false
+    substrate_anchors: []
+    notes: "Workflow/orchestration is not yet a distinct first-class product surface."
+repo_split_triggers:
+  - "independent release cadence"
+  - "distinct operator lifecycle and deployment surface"
+  - "dedicated CI/test obligations that reduce overall complexity"
+  - "support burden distinct from the shared trust/release substrate"
+  - "ability to share trust/release graph without duplicating platform-wide evidence logic"

--- a/docs/FOGSTACK_PACKS.md
+++ b/docs/FOGSTACK_PACKS.md
@@ -1,0 +1,76 @@
+# Fog Stack packs
+
+This document records the current Fog Stack pack taxonomy, product-surface intent, and readiness levels inside `prophet-platform`.
+
+## Decision
+
+Fog Stack should **not** split into separate repositories for AI, Data, Automation, Security, or other future pack categories yet.
+
+The shared trust/release graph is still the dominant implementation concern, and the current pack boundaries do not yet justify independent lifecycles. The right move is to keep engineering in `prophet-platform`, track pack readiness here, and split only when a pack has a clearly independent release cadence, operator lifecycle, support burden, and CI surface.
+
+## Current packs
+
+### Fog Stack Access
+- Type: real product surface
+- Readiness: 70%
+- Repo split now: no
+- Why: strongest customer-facing surface so far; remaining work is mainly trust/release hardening, not basic product identity.
+
+### Fog Stack Knowledge
+- Type: real product surface
+- Readiness: 55%
+- Repo split now: no
+- Why: clear substrate anchors but more composition-heavy and operationally mixed.
+
+### Fog Stack Evaluation
+- Type: real product surface
+- Readiness: 55%
+- Repo split now: no
+- Why: real platform surface, but still more internal than packaged.
+
+### Fog Stack Security / Trust
+- Type: strong shared capability
+- Readiness: 80% as platform capability / 35% as standalone pack
+- Repo split now: no
+- Why: the shared trust/release graph is still the dominant engineering concern.
+
+### Fog Stack Data
+- Type: emerging packaging view
+- Readiness: 30%
+- Repo split now: no
+- Why: better modeled as a packaging view over Knowledge + Evaluation than as an independent engineering island.
+
+### Fog Stack AI
+- Type: conceptual future pack
+- Readiness: 20%
+- Repo split now: no
+- Why: not enough independent runtime/product surface yet.
+
+### Fog Stack Automation
+- Type: conceptual future pack
+- Readiness: 20%
+- Repo split now: no
+- Why: workflow/orchestration is not yet a distinct first-class product surface.
+
+## Repo split triggers
+
+A future Fog Stack pack should not move into its own repository until most of the following are true:
+
+1. it has an independent release cadence
+2. it has a distinct operator lifecycle and deployment surface
+3. it has dedicated CI/test obligations that reduce, not increase, repo complexity
+4. it has support responsibilities distinct from the shared trust/release substrate
+5. the trust/release graph can be shared without duplicating platform-wide signing/evidence logic
+
+## Relationship to `prophet-platform`
+
+`prophet-platform` remains the canonical runtime and deployment substrate.
+
+Fog Stack currently lands here as:
+- productization
+- conformance
+- release metadata
+- trust graph
+- evidence and sealing machinery
+
+The future packs should therefore be treated as catalog and packaging surfaces until they are mature enough to justify independent repos.

--- a/docs/FOGSTACK_STATUS.md
+++ b/docs/FOGSTACK_STATUS.md
@@ -6,6 +6,21 @@ This document captures the current state of Fog Stack work inside `prophet-platf
 
 `prophet-platform` is the runtime and deployment substrate for platform services. Fog Stack lands here as the productization, conformance, release, and trust layer for deployable offerings built on that substrate.
 
+## Repository strategy decision
+
+Fog Stack should **not** split into separate repositories for AI, Data, Automation, Security, or other future pack categories yet.
+
+At the current stage, the trust/release machinery is still highly shared across all surfaces. Splitting now would mostly increase coordination overhead and fragment the release/trust graph before those categories have clearly independent lifecycles.
+
+The correct near-term move is:
+- keep the engineering and trust/release machinery in `prophet-platform`
+- track future pack categories here as product surfaces and readiness states
+- split into separate repos only when a pack has an independently justified lifecycle, release cadence, operator surface, and support burden
+
+See also:
+- `docs/FOGSTACK_PACKS.md`
+- `catalog/fogstack-packs-v0.1.yaml`
+
 ## Merged offering slices
 
 The following initial offering slices are already merged into `main`:
@@ -27,15 +42,25 @@ The following supporting slices are already merged into `main`:
 - signed-manifest verification helper via PR #58
 - signature trust evidence record via PR #62
 - release evidence index via PR #63
+- artifact backlinking via PR #68
+- cryptographic signature verification record via PR #76
+- external signature verification input normalization via PR #93
 
 ## Current open review units
 
 As of this capture, the primary open Fog Stack review units are:
 
-- **PR #68** — release artifact backlinking
-- **PR #76** — cryptographic signature verification record
+- **PR #119** — external signature verification runner
+- **PR #121** — release sealing
+- **PR #123** — release seal signature support
 
 These should be treated as the current active trust/release-engineering path.
+
+## Product-pack readiness matrix
+
+The detailed matrix and pack taxonomy now live in:
+- `docs/FOGSTACK_PACKS.md`
+- `catalog/fogstack-packs-v0.1.yaml`
 
 ## Current trust graph shape
 
@@ -47,18 +72,19 @@ The release/trust graph now consists of these machine-readable artifacts:
 - signature trust record
 - cryptographic signature verification record
 - release evidence index
+- release seal
 
-The backlinking tranche under review is what turns those from parallel records into an explicitly linked graph.
+The open trust/release PRs are what move this system from linked artifacts to a more cryptographically grounded, tamper-evident release graph.
 
 ## Immediate next tranche
 
 After the current open PRs are accepted, the next release-engineering tranche should focus on:
 
-1. **Cryptographic verification execution** rather than only cryptographic verification record shape.
-2. **Automatic backlinking** and deterministic evidence-index production.
-3. **CI-emitted verified truth records** instead of shape-only local records.
-4. **Signed manifest publication and trust proof** rather than local trust structure only.
+1. **Verification execution** rather than only verification record shape.
+2. **Seal signing and seal-signature trust** rather than unsigned seal computation only.
+3. **CI-emitted verified truth records** instead of shape-only or local records.
+4. **Automatic artifact/backlink mutation** so the graph becomes self-updating under the release pipeline.
 
 ## Position in the maturity ladder
 
-Fog Stack in `prophet-platform` is now past initial offering definition. The active frontier is no longer offering taxonomy; it is release/trust hardening.
+Fog Stack in `prophet-platform` is now past initial offering definition. The active frontier is no longer offering taxonomy; it is release/trust hardening and future pack-boundary justification.


### PR DESCRIPTION
## Summary

This PR adds the repo-native Fog Stack pack taxonomy and readiness tracking surfaces:

- `docs/FOGSTACK_PACKS.md`
- `catalog/fogstack-packs-v0.1.yaml`
- updated `docs/FOGSTACK_STATUS.md`

## Why this PR exists

Fog Stack now has:
- merged offering slices
- merged validation / release-engineering surfaces
- active trust/release review units

What the repo did not yet have was a canonical pack taxonomy, readiness matrix, and explicit repository-strategy decision in one place.

This PR captures:
- the current “no repo split yet” decision
- qualitative pack readiness by surface
- repo split triggers
- links from the canonical status doc to the detailed pack taxonomy and machine-readable catalog

## Scope

This PR is documentation + machine-readable catalog only. It does not add runtime or trust logic.
