### PR TITLE
services(ops): add read-only ops fabric API slice

### DIFF
--- a/.github/workflows/ops-fabric-api.yml
+++ b/.github/workflows/ops-fabric-api.yml
@@ -1,0 +1,31 @@
+name: ops-fabric-api
+
+on:
+  pull_request:
+    paths:
+      - 'services/ops-fabric-api/**'
+      - '.github/workflows/ops-fabric-api.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/ops-fabric-api/**'
+      - '.github/workflows/ops-fabric-api.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          cd services/ops-fabric-api
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-test.txt
+      - name: Test
+        run: |
+          cd services/ops-fabric-api
+          pytest

--- a/services/ops-fabric-api/README.md
+++ b/services/ops-fabric-api/README.md
@@ -1,0 +1,20 @@
+# Ops Fabric API
+
+Read-only runtime slice for Prophet Real-Time Ops Fabric.
+
+This service turns operational samples into report-only proposal records. It owns no deployment writer and no direct platform state writer in this slice.
+
+## Initial routes
+
+- `GET /healthz`
+- `GET /readyz`
+- `POST /v1/ops/proposals/rightsize`
+
+## Integration seams
+
+- `global-devsecops-intelligence` supplies operations-domain intelligence references.
+- `sherlock-search` retrieves proposal and evidence records through the platform search lane.
+- `policy-fabric` evaluates proposal legality in a later slice.
+- `agentplane` receives reviewed handoff candidates in a later slice.
+
+v0.1 remains report-only.

--- a/services/ops-fabric-api/app/__init__.py
+++ b/services/ops-fabric-api/app/__init__.py
@@ -1,0 +1,1 @@
+"""Ops Fabric API package."""

--- a/services/ops-fabric-api/app/main.py
+++ b/services/ops-fabric-api/app/main.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app.models import ActionProposal, WorkloadResourceSample
+from app.proposals import build_rightsize_proposal
+
+app = FastAPI(title="ops-fabric-api", version="0.1.0")
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok", "service": "ops-fabric-api"}
+
+
+@app.get("/readyz")
+def readyz() -> dict[str, str]:
+    return {"status": "ready", "service": "ops-fabric-api"}
+
+
+@app.post("/v1/ops/proposals/rightsize", response_model=ActionProposal)
+def rightsize(body: WorkloadResourceSample) -> ActionProposal:
+    return build_rightsize_proposal(body)

--- a/services/ops-fabric-api/app/models.py
+++ b/services/ops-fabric-api/app/models.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class EvidenceRef(BaseModel):
+    evidence_id: str
+    kind: str
+    source: str
+    uri: str
+    observed_at: str
+    digest: str | None = None
+    notes: str | None = None
+
+
+class IntelligenceRef(BaseModel):
+    intelligence_id: str
+    source_repo: str = "SocioProphet/global-devsecops-intelligence"
+    profile_ref: str
+    kind: str
+    uri: str | None = None
+    confidence: float | None = None
+    notes: str | None = None
+
+
+class WorkloadTarget(BaseModel):
+    kind: str = "Workload"
+    id: str
+    namespace: str | None = None
+    cluster: str | None = None
+    zone: str | None = None
+
+
+class WorkloadResourceSample(BaseModel):
+    target: WorkloadTarget
+    observed_at: str
+    cpu_request_millicores: int = Field(ge=1)
+    cpu_p95_millicores: int = Field(ge=0)
+    memory_request_mib: int = Field(ge=1)
+    memory_p95_mib: int = Field(ge=0)
+    monthly_cost_usd: float = 0.0
+    evidence_refs: list[EvidenceRef]
+    intelligence_refs: list[IntelligenceRef] = []
+
+
+class ProposalImpact(BaseModel):
+    cost_delta_monthly_usd: float
+    energy_delta_kwh_monthly: float | None = None
+    slo_risk_delta: float
+    security_risk_delta: float = 0.0
+    confidence: float
+
+
+class ProposalRisk(BaseModel):
+    blast_radius: str
+    reversibility: str
+    requires_human_approval: bool
+    notes: list[str] = []
+
+
+class ActionProposal(BaseModel):
+    proposal_id: str
+    proposal_type: str
+    created_at: str
+    target: WorkloadTarget
+    summary: str
+    rationale: list[str]
+    recommended_change: dict[str, object]
+    impact_estimate: ProposalImpact
+    risk: ProposalRisk
+    policy_status: str = "NOT_EVALUATED"
+    autonomy_tier: str = "REPORT_ONLY"
+    evidence_refs: list[EvidenceRef]
+    intelligence_refs: list[IntelligenceRef] = []

--- a/services/ops-fabric-api/app/proposals.py
+++ b/services/ops-fabric-api/app/proposals.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from hashlib import sha256
+
+from app.models import ActionProposal, ProposalImpact, ProposalRisk, WorkloadResourceSample
+
+
+def stable_proposal_id(sample: WorkloadResourceSample) -> str:
+    material = f"{sample.target.id}|{sample.observed_at}|{sample.cpu_request_millicores}|{sample.cpu_p95_millicores}|{sample.memory_request_mib}|{sample.memory_p95_mib}"
+    return "ops.proposal." + sha256(material.encode("utf-8")).hexdigest()[:16]
+
+
+def build_rightsize_proposal(sample: WorkloadResourceSample) -> ActionProposal:
+    cpu_after = min(max(sample.cpu_p95_millicores * 2, 100), sample.cpu_request_millicores)
+    memory_after = min(max(sample.memory_p95_mib * 2, 128), sample.memory_request_mib)
+    ratio = sample.cpu_p95_millicores / sample.cpu_request_millicores
+    confidence = 0.82 if ratio < 0.25 else 0.72 if ratio < 0.5 else 0.55
+    savings_ratio = max(0.0, 1.0 - (cpu_after / sample.cpu_request_millicores))
+    monthly_savings = round(sample.monthly_cost_usd * savings_ratio, 2)
+
+    return ActionProposal(
+        proposal_id=stable_proposal_id(sample),
+        proposal_type="RIGHTSIZE_WORKLOAD",
+        created_at=sample.observed_at,
+        target=sample.target,
+        summary=f"Report-only right-sizing proposal for {sample.target.id}.",
+        rationale=[
+            "Observed usage is below reserved capacity for the supplied sample window.",
+            "The recommendation remains report-only in this slice.",
+            "DevSecOps intelligence references are preserved for downstream review.",
+        ],
+        recommended_change={
+            "mode": "REPORT_ONLY",
+            "patch_kind": "ResourceIntent",
+            "before": {
+                "cpu_request_millicores": sample.cpu_request_millicores,
+                "memory_request_mib": sample.memory_request_mib,
+            },
+            "after": {
+                "cpu_request_millicores": cpu_after,
+                "memory_request_mib": memory_after,
+            },
+        },
+        impact_estimate=ProposalImpact(
+            cost_delta_monthly_usd=-monthly_savings,
+            energy_delta_kwh_monthly=None,
+            slo_risk_delta=0.02 if savings_ratio > 0 else 0.0,
+            security_risk_delta=0.0,
+            confidence=confidence,
+        ),
+        risk=ProposalRisk(
+            blast_radius="LOW",
+            reversibility="ROLLBACK_PATCH",
+            requires_human_approval=True,
+            notes=["Report-only slice."],
+        ),
+        policy_status="NOT_EVALUATED",
+        autonomy_tier="REPORT_ONLY",
+        evidence_refs=sample.evidence_refs,
+        intelligence_refs=sample.intelligence_refs,
+    )

--- a/services/ops-fabric-api/pytest.ini
+++ b/services/ops-fabric-api/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath = .
+testpaths = tests
+addopts = -q

--- a/services/ops-fabric-api/requirements-test.txt
+++ b/services/ops-fabric-api/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest
+httpx

--- a/services/ops-fabric-api/requirements.txt
+++ b/services/ops-fabric-api/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+pydantic

--- a/services/ops-fabric-api/tests/test_http_health.py
+++ b/services/ops-fabric-api/tests/test_http_health.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_healthz() -> None:
+    client = TestClient(app)
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json()["service"] == "ops-fabric-api"
+
+
+def test_readyz() -> None:
+    client = TestClient(app)
+    response = client.get("/readyz")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ready"

--- a/services/ops-fabric-api/tests/test_proposals.py
+++ b/services/ops-fabric-api/tests/test_proposals.py
@@ -1,0 +1,51 @@
+from app.models import EvidenceRef, IntelligenceRef, WorkloadResourceSample, WorkloadTarget
+from app.proposals import build_rightsize_proposal
+
+
+def sample() -> WorkloadResourceSample:
+    return WorkloadResourceSample(
+        target=WorkloadTarget(
+            kind="Workload",
+            id="sample-workload",
+            namespace="default",
+            cluster="p0-lab",
+            zone="local",
+        ),
+        observed_at="2026-04-24T17:45:00Z",
+        cpu_request_millicores=1000,
+        cpu_p95_millicores=220,
+        memory_request_mib=2048,
+        memory_p95_mib=620,
+        monthly_cost_usd=96.0,
+        evidence_refs=[
+            EvidenceRef(
+                evidence_id="evidence.metric-window.0001",
+                kind="METRIC_WINDOW",
+                source="synthetic-v0",
+                uri="memory://ops-fixtures/metric-window/0001",
+                observed_at="2026-04-24T17:45:00Z",
+            )
+        ],
+        intelligence_refs=[
+            IntelligenceRef(
+                intelligence_id="gdi.profile.operational-exhaust-fusion.v0",
+                profile_ref="profiles/operational-exhaust-fusion-profile.v0.yaml",
+                kind="OPERATIONAL_EXHAUST_FUSION",
+                confidence=0.7,
+            )
+        ],
+    )
+
+
+def test_build_rightsize_proposal_is_report_only() -> None:
+    proposal = build_rightsize_proposal(sample())
+    assert proposal.proposal_type == "RIGHTSIZE_WORKLOAD"
+    assert proposal.policy_status == "NOT_EVALUATED"
+    assert proposal.autonomy_tier == "REPORT_ONLY"
+    assert proposal.recommended_change["mode"] == "REPORT_ONLY"
+
+
+def test_build_rightsize_proposal_preserves_intelligence_refs() -> None:
+    proposal = build_rightsize_proposal(sample())
+    assert proposal.intelligence_refs
+    assert proposal.intelligence_refs[0].source_repo == "SocioProphet/global-devsecops-intelligence"


### PR DESCRIPTION
## Summary

Adds the first read-only runtime slice for Prophet Real-Time Ops Fabric after the Tranche 1 contracts landed in #129.

## Scope

- Adds `services/ops-fabric-api/`
- Adds FastAPI health and readiness routes
- Adds a report-only right-sizing proposal route
- Adds Pydantic models for evidence refs, intelligence refs, workload samples, and action proposals
- Preserves `SocioProphet/global-devsecops-intelligence` references in proposal output
- Adds service-local unit tests for deterministic report-only proposal generation
- Adds service-local HTTP health tests
- Adds service-local pytest configuration
- Adds a dedicated `ops-fabric-api` GitHub Actions workflow

## Safety posture

- Read-only slice
- No platform state writer
- No deployment writer
- No autonomous action path
- Proposal status remains `NOT_EVALUATED`
- Proposal autonomy tier remains `REPORT_ONLY`

## Prior foundation

- Builds on the merged Tranche 1 contract foundation from #129.

## Program lane

Tranche 2: read-only `services/ops-fabric-api/` slice.