### PR TITLE
services(platform): enrich normalized platform search results (ready)

### DIFF
--- a/services/search-orchestrator/app/backends.py
+++ b/services/search-orchestrator/app/backends.py
@@ -9,7 +9,13 @@ class PlatformSearchResult:
     source: str
     entity_type: str
     title: str
+    snippet: str
+    path_or_uri: str
     final_score: float
+    open_cloud: bool = True
+    summarize: bool = True
+    create_task: bool = True
+    draft_reply: bool = False
 
 
 def query_platform_workspace(text: str, enabled: bool = True) -> list[PlatformSearchResult]:
@@ -21,6 +27,8 @@ def query_platform_workspace(text: str, enabled: bool = True) -> list[PlatformSe
             source="PLATFORM",
             entity_type="DOCUMENT",
             title=f"Workspace result placeholder for: {text}",
+            snippet=f"Matched workspace content for query: {text}",
+            path_or_uri=f"workspace://documents/{text}",
             final_score=1.0,
         )
     ]

--- a/services/search-orchestrator/app/main.py
+++ b/services/search-orchestrator/app/main.py
@@ -25,6 +25,8 @@ def search_query(body: SearchRequest) -> dict[str, object]:
             source=item.source,
             entity_type=item.entity_type,
             title=item.title,
+            snippet=item.snippet,
+            path_or_uri=item.path_or_uri,
             score=SearchResultScore(final=item.final_score),
         )
         results.append(result.model_dump())

--- a/services/search-orchestrator/app/models.py
+++ b/services/search-orchestrator/app/models.py
@@ -20,9 +20,20 @@ class SearchResultScore(BaseModel):
     final: float
 
 
+class SearchResultActions(BaseModel):
+    open_local: bool = False
+    open_cloud: bool = False
+    summarize: bool = False
+    create_task: bool = False
+    draft_reply: bool = False
+
+
 class SearchResult(BaseModel):
     result_id: str
     source: str
     entity_type: str
     title: str
+    snippet: str | None = None
+    path_or_uri: str | None = None
     score: SearchResultScore
+    actions: SearchResultActions | None = None

--- a/services/search-orchestrator/tests/test_platform_scope_result.py
+++ b/services/search-orchestrator/tests/test_platform_scope_result.py
@@ -22,3 +22,5 @@ def test_cloud_workspace_scope_returns_platform_result() -> None:
     payload = response.json()
     assert payload['results'][0]['source'] == 'PLATFORM'
     assert payload['results'][0]['entity_type'] == 'DOCUMENT'
+    assert payload['results'][0]['snippet'] == 'Matched workspace content for query: budget'
+    assert payload['results'][0]['path_or_uri'] == 'workspace://documents/budget'


### PR DESCRIPTION
## Summary

Replacement non-draft PR for the richer normalized platform search result slice.

Files:
- `services/search-orchestrator/app/models.py`
- `services/search-orchestrator/app/backends.py`
- `services/search-orchestrator/app/main.py`
- `services/search-orchestrator/tests/test_platform_scope_result.py`

## Why

The draft PR is blocked only by the connector's ready-for-review transition bug. This replacement carries the same content on a non-draft branch so review/merge can proceed.
