### PR TITLE
services(ops): add ops fabric persistence and search records

### DIFF
--- a/services/ops-fabric-api/README.md
+++ b/services/ops-fabric-api/README.md
@@ -4,11 +4,20 @@ Read-only runtime slice for Prophet Real-Time Ops Fabric.
 
 This service turns operational samples into report-only proposal records. It owns no deployment writer and no direct platform state writer in this slice.
 
-## Initial routes
+## Routes
 
 - `GET /healthz`
 - `GET /readyz`
+- `POST /v1/ops/events`
+- `GET /v1/ops/events`
 - `POST /v1/ops/proposals/rightsize`
+- `GET /v1/ops/proposals`
+- `GET /v1/ops/proposals/{proposal_id}`
+- `GET /v1/ops/search-records`
+
+## Search records
+
+`/v1/ops/search-records` emits `OPS_FABRIC` records for Sherlock Search and Lampstand-style indexing. Records currently cover telemetry events and action proposals.
 
 ## Integration seams
 

--- a/services/ops-fabric-api/app/main.py
+++ b/services/ops-fabric-api/app/main.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
-from app.models import ActionProposal, WorkloadResourceSample
+from app.models import ActionProposal, SearchRecord, TelemetryEvent, WorkloadResourceSample
 from app.proposals import build_rightsize_proposal
+from app.store import store
 
 app = FastAPI(title="ops-fabric-api", version="0.1.0")
 
@@ -18,6 +19,35 @@ def readyz() -> dict[str, str]:
     return {"status": "ready", "service": "ops-fabric-api"}
 
 
+@app.post("/v1/ops/events", response_model=TelemetryEvent)
+def add_event(body: TelemetryEvent) -> TelemetryEvent:
+    return store.add_event(body)
+
+
+@app.get("/v1/ops/events", response_model=list[TelemetryEvent])
+def list_events() -> list[TelemetryEvent]:
+    return store.list_events()
+
+
 @app.post("/v1/ops/proposals/rightsize", response_model=ActionProposal)
 def rightsize(body: WorkloadResourceSample) -> ActionProposal:
-    return build_rightsize_proposal(body)
+    proposal = build_rightsize_proposal(body)
+    return store.add_proposal(proposal)
+
+
+@app.get("/v1/ops/proposals", response_model=list[ActionProposal])
+def list_proposals() -> list[ActionProposal]:
+    return store.list_proposals()
+
+
+@app.get("/v1/ops/proposals/{proposal_id}", response_model=ActionProposal)
+def get_proposal(proposal_id: str) -> ActionProposal:
+    proposal = store.get_proposal(proposal_id)
+    if proposal is None:
+        raise HTTPException(status_code=404, detail="proposal not found")
+    return proposal
+
+
+@app.get("/v1/ops/search-records", response_model=list[SearchRecord])
+def search_records() -> list[SearchRecord]:
+    return store.search_records()

--- a/services/ops-fabric-api/app/models.py
+++ b/services/ops-fabric-api/app/models.py
@@ -19,7 +19,7 @@ class IntelligenceRef(BaseModel):
     profile_ref: str
     kind: str
     uri: str | None = None
-    confidence: float | None = None
+    confidence: float | None = Field(default=None, ge=0, le=1)
     notes: str | None = None
 
 
@@ -37,9 +37,9 @@ class TelemetryEvent(BaseModel):
     observed_at: str
     subject: WorkloadTarget
     source: dict[str, str]
-    measurements: dict[str, int | float | str | bool | None] = {}
-    evidence_refs: list[EvidenceRef] = []
-    intelligence_refs: list[IntelligenceRef] = []
+    measurements: dict[str, int | float | str | bool | None] = Field(default_factory=dict)
+    evidence_refs: list[EvidenceRef] = Field(default_factory=list)
+    intelligence_refs: list[IntelligenceRef] = Field(default_factory=list)
 
 
 class WorkloadResourceSample(BaseModel):
@@ -51,7 +51,7 @@ class WorkloadResourceSample(BaseModel):
     memory_p95_mib: int = Field(ge=0)
     monthly_cost_usd: float = 0.0
     evidence_refs: list[EvidenceRef]
-    intelligence_refs: list[IntelligenceRef] = []
+    intelligence_refs: list[IntelligenceRef] = Field(default_factory=list)
 
 
 class ProposalImpact(BaseModel):
@@ -59,14 +59,14 @@ class ProposalImpact(BaseModel):
     energy_delta_kwh_monthly: float | None = None
     slo_risk_delta: float
     security_risk_delta: float = 0.0
-    confidence: float
+    confidence: float = Field(ge=0, le=1)
 
 
 class ProposalRisk(BaseModel):
     blast_radius: str
     reversibility: str
     requires_human_approval: bool
-    notes: list[str] = []
+    notes: list[str] = Field(default_factory=list)
 
 
 class ActionProposal(BaseModel):
@@ -82,7 +82,7 @@ class ActionProposal(BaseModel):
     policy_status: str = "NOT_EVALUATED"
     autonomy_tier: str = "REPORT_ONLY"
     evidence_refs: list[EvidenceRef]
-    intelligence_refs: list[IntelligenceRef] = []
+    intelligence_refs: list[IntelligenceRef] = Field(default_factory=list)
 
 
 class SearchRecord(BaseModel):
@@ -92,6 +92,6 @@ class SearchRecord(BaseModel):
     title: str
     text: str
     target_ref: str | None = None
-    evidence_ref_ids: list[str] = []
-    intelligence_ref_ids: list[str] = []
-    final_score: float = 1.0
+    evidence_ref_ids: list[str] = Field(default_factory=list)
+    intelligence_ref_ids: list[str] = Field(default_factory=list)
+    final_score: float = Field(default=1.0, ge=0, le=1)

--- a/services/ops-fabric-api/app/models.py
+++ b/services/ops-fabric-api/app/models.py
@@ -31,6 +31,17 @@ class WorkloadTarget(BaseModel):
     zone: str | None = None
 
 
+class TelemetryEvent(BaseModel):
+    event_id: str
+    event_type: str
+    observed_at: str
+    subject: WorkloadTarget
+    source: dict[str, str]
+    measurements: dict[str, int | float | str | bool | None] = {}
+    evidence_refs: list[EvidenceRef] = []
+    intelligence_refs: list[IntelligenceRef] = []
+
+
 class WorkloadResourceSample(BaseModel):
     target: WorkloadTarget
     observed_at: str
@@ -72,3 +83,15 @@ class ActionProposal(BaseModel):
     autonomy_tier: str = "REPORT_ONLY"
     evidence_refs: list[EvidenceRef]
     intelligence_refs: list[IntelligenceRef] = []
+
+
+class SearchRecord(BaseModel):
+    result_id: str
+    source: str = "OPS_FABRIC"
+    entity_type: str
+    title: str
+    text: str
+    target_ref: str | None = None
+    evidence_ref_ids: list[str] = []
+    intelligence_ref_ids: list[str] = []
+    final_score: float = 1.0

--- a/services/ops-fabric-api/app/store.py
+++ b/services/ops-fabric-api/app/store.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from app.models import ActionProposal, SearchRecord, TelemetryEvent
+
+
+class OpsFabricStore:
+    def __init__(self) -> None:
+        self.events: dict[str, TelemetryEvent] = {}
+        self.proposals: dict[str, ActionProposal] = {}
+
+    def add_event(self, event: TelemetryEvent) -> TelemetryEvent:
+        self.events[event.event_id] = event
+        return event
+
+    def list_events(self) -> list[TelemetryEvent]:
+        return list(self.events.values())
+
+    def add_proposal(self, proposal: ActionProposal) -> ActionProposal:
+        self.proposals[proposal.proposal_id] = proposal
+        return proposal
+
+    def get_proposal(self, proposal_id: str) -> ActionProposal | None:
+        return self.proposals.get(proposal_id)
+
+    def list_proposals(self) -> list[ActionProposal]:
+        return list(self.proposals.values())
+
+    def search_records(self) -> list[SearchRecord]:
+        records: list[SearchRecord] = []
+        for proposal in self.proposals.values():
+            records.append(
+                SearchRecord(
+                    result_id=proposal.proposal_id,
+                    entity_type="ACTION_PROPOSAL",
+                    title=proposal.summary,
+                    text=" ".join(proposal.rationale),
+                    target_ref=proposal.target.id,
+                    evidence_ref_ids=[ref.evidence_id for ref in proposal.evidence_refs],
+                    intelligence_ref_ids=[ref.intelligence_id for ref in proposal.intelligence_refs],
+                    final_score=proposal.impact_estimate.confidence,
+                )
+            )
+        for event in self.events.values():
+            records.append(
+                SearchRecord(
+                    result_id=event.event_id,
+                    entity_type="TELEMETRY_EVENT",
+                    title=f"{event.event_type} for {event.subject.id}",
+                    text=f"{event.event_type} {event.subject.id}",
+                    target_ref=event.subject.id,
+                    evidence_ref_ids=[ref.evidence_id for ref in event.evidence_refs],
+                    intelligence_ref_ids=[ref.intelligence_id for ref in event.intelligence_refs],
+                    final_score=1.0,
+                )
+            )
+        return records
+
+
+store = OpsFabricStore()

--- a/services/ops-fabric-api/tests/test_event_routes.py
+++ b/services/ops-fabric-api/tests/test_event_routes.py
@@ -1,0 +1,52 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.store import store
+
+client = TestClient(app)
+
+
+def setup_function() -> None:
+    store.events.clear()
+    store.proposals.clear()
+
+
+def event_payload() -> dict[str, object]:
+    return {
+        "event_id": "ops.event.0001",
+        "event_type": "WORKLOAD_RESOURCE_SAMPLE",
+        "observed_at": "2026-04-24T17:45:00Z",
+        "subject": {"kind": "Workload", "id": "sample-workload", "namespace": "default", "cluster": "p0-lab", "zone": "local"},
+        "source": {"system": "synthetic-v0", "adapter": "ops-fabric-test"},
+        "measurements": {"cpu_request_millicores": 1000, "cpu_p95_millicores": 220},
+        "evidence_refs": [
+            {
+                "evidence_id": "evidence.event.0001",
+                "kind": "METRIC_WINDOW",
+                "source": "synthetic-v0",
+                "uri": "memory://ops-fixtures/event/0001",
+                "observed_at": "2026-04-24T17:45:00Z"
+            }
+        ],
+        "intelligence_refs": []
+    }
+
+
+def test_event_route_stores_and_lists_event() -> None:
+    response = client.post("/v1/ops/events", json=event_payload())
+    assert response.status_code == 200
+    assert response.json()["event_id"] == "ops.event.0001"
+
+    list_response = client.get("/v1/ops/events")
+    assert list_response.status_code == 200
+    assert list_response.json()[0]["event_type"] == "WORKLOAD_RESOURCE_SAMPLE"
+
+
+def test_search_records_include_event_record() -> None:
+    client.post("/v1/ops/events", json=event_payload())
+    response = client.get("/v1/ops/search-records")
+    assert response.status_code == 200
+    body = response.json()
+    assert body[0]["source"] == "OPS_FABRIC"
+    assert body[0]["entity_type"] == "TELEMETRY_EVENT"
+    assert body[0]["evidence_ref_ids"] == ["evidence.event.0001"]

--- a/services/ops-fabric-api/tests/test_store_routes.py
+++ b/services/ops-fabric-api/tests/test_store_routes.py
@@ -1,0 +1,64 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.store import store
+
+client = TestClient(app)
+
+
+def setup_function() -> None:
+    store.events.clear()
+    store.proposals.clear()
+
+
+def sample_payload() -> dict[str, object]:
+    return {
+        "target": {"kind": "Workload", "id": "sample-workload", "namespace": "default", "cluster": "p0-lab", "zone": "local"},
+        "observed_at": "2026-04-24T17:45:00Z",
+        "cpu_request_millicores": 1000,
+        "cpu_p95_millicores": 220,
+        "memory_request_mib": 2048,
+        "memory_p95_mib": 620,
+        "monthly_cost_usd": 96.0,
+        "evidence_refs": [
+            {
+                "evidence_id": "evidence.metric-window.0001",
+                "kind": "METRIC_WINDOW",
+                "source": "synthetic-v0",
+                "uri": "memory://ops-fixtures/metric-window/0001",
+                "observed_at": "2026-04-24T17:45:00Z"
+            }
+        ],
+        "intelligence_refs": [
+            {
+                "intelligence_id": "gdi.profile.operational-exhaust-fusion.v0",
+                "profile_ref": "profiles/operational-exhaust-fusion-profile.v0.yaml",
+                "kind": "OPERATIONAL_EXHAUST_FUSION",
+                "confidence": 0.7
+            }
+        ]
+    }
+
+
+def test_rightsize_route_stores_and_retrieves_proposal() -> None:
+    response = client.post("/v1/ops/proposals/rightsize", json=sample_payload())
+    assert response.status_code == 200
+    proposal_id = response.json()["proposal_id"]
+
+    list_response = client.get("/v1/ops/proposals")
+    assert list_response.status_code == 200
+    assert list_response.json()[0]["proposal_id"] == proposal_id
+
+    get_response = client.get(f"/v1/ops/proposals/{proposal_id}")
+    assert get_response.status_code == 200
+    assert get_response.json()["autonomy_tier"] == "REPORT_ONLY"
+
+
+def test_search_records_include_ops_fabric_proposal_record() -> None:
+    client.post("/v1/ops/proposals/rightsize", json=sample_payload())
+    response = client.get("/v1/ops/search-records")
+    assert response.status_code == 200
+    body = response.json()
+    assert body[0]["source"] == "OPS_FABRIC"
+    assert body[0]["entity_type"] == "ACTION_PROPOSAL"
+    assert body[0]["intelligence_ref_ids"] == ["gdi.profile.operational-exhaust-fusion.v0"]


### PR DESCRIPTION
## Summary

Adds the Tranche 3 read-only persistence and retrieval seams for Prophet Real-Time Ops Fabric.

## Scope

- Adds `TelemetryEvent` and `SearchRecord` runtime models
- Hardens Pydantic defaults with `Field(default_factory=...)`
- Adds in-memory event/proposal store
- Stores report-only right-sizing proposals after generation
- Adds event ingestion/listing routes
- Adds proposal listing and lookup routes
- Adds `OPS_FABRIC` search-record export for Sherlock Search and Lampstand-style indexing
- Updates service docs for the new routes
- Adds route tests for event storage, proposal retrieval, and search records

## Routes added

- `POST /v1/ops/events`
- `GET /v1/ops/events`
- `GET /v1/ops/proposals`
- `GET /v1/ops/proposals/{proposal_id}`
- `GET /v1/ops/search-records`

## Safety posture

- Read-only API slice
- In-memory store only
- No deployment writer
- No platform state writer
- No autonomous action path
- Proposal status remains `NOT_EVALUATED`
- Proposal autonomy tier remains `REPORT_ONLY`

## Program lane

Tranche 3: event/proposal retrieval plus Sherlock/Lampstand search-record seam.