### PR TITLE
services(search): ingest Alexandrian learning search records

### DIFF
--- a/.github/workflows/search-orchestrator.yml
+++ b/.github/workflows/search-orchestrator.yml
@@ -1,0 +1,29 @@
+name: search-orchestrator
+
+on:
+  pull_request:
+    paths:
+      - 'services/search-orchestrator/**'
+      - '.github/workflows/search-orchestrator.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/search-orchestrator/**'
+      - '.github/workflows/search-orchestrator.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r services/search-orchestrator/requirements.txt -r services/search-orchestrator/requirements-test.txt
+      - name: Test
+        run: |
+          pytest -q services/search-orchestrator/tests

--- a/.github/workflows/search-orchestrator.yml
+++ b/.github/workflows/search-orchestrator.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/search-orchestrator
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -23,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r services/search-orchestrator/requirements.txt -r services/search-orchestrator/requirements-test.txt
+          pip install -r requirements.txt -r requirements-test.txt
       - name: Test
         run: |
-          pytest -q services/search-orchestrator/tests
+          PYTHONPATH=. pytest -q tests

--- a/services/search-orchestrator/app/backends.py
+++ b/services/search-orchestrator/app/backends.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from services.search_orchestrator.app.models import LearningSearchRecord
+from app.models import LearningSearchRecord
 
 
 @dataclass
@@ -24,8 +24,6 @@ ACADEMY_RECORDS: dict[str, LearningSearchRecord] = {}
 
 
 def ingest_academy_record(record: LearningSearchRecord) -> LearningSearchRecord:
-    if record.source != "ALEXANDRIAN_ACADEMY":
-        raise ValueError("academy records must use source ALEXANDRIAN_ACADEMY")
     ACADEMY_RECORDS[record.header.object_id] = record
     return record
 

--- a/services/search-orchestrator/app/backends.py
+++ b/services/search-orchestrator/app/backends.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from services.search_orchestrator.app.models import LearningSearchRecord
+
 
 @dataclass
 class PlatformSearchResult:
@@ -16,6 +18,39 @@ class PlatformSearchResult:
     summarize: bool = True
     create_task: bool = True
     draft_reply: bool = False
+
+
+ACADEMY_RECORDS: dict[str, LearningSearchRecord] = {}
+
+
+def ingest_academy_record(record: LearningSearchRecord) -> LearningSearchRecord:
+    if record.source != "ALEXANDRIAN_ACADEMY":
+        raise ValueError("academy records must use source ALEXANDRIAN_ACADEMY")
+    ACADEMY_RECORDS[record.header.object_id] = record
+    return record
+
+
+def query_academy_records(text: str, enabled: bool = True) -> list[PlatformSearchResult]:
+    if not enabled or not text.strip():
+        return []
+    needle = text.lower()
+    results: list[PlatformSearchResult] = []
+    for record in ACADEMY_RECORDS.values():
+        haystack = " ".join([record.title, record.text, record.target_ref]).lower()
+        if needle not in haystack:
+            continue
+        results.append(
+            PlatformSearchResult(
+                result_id=record.header.object_id,
+                source=record.source,
+                entity_type=record.entity_type,
+                title=record.title,
+                snippet=record.text,
+                path_or_uri=f"alexandrian://learning-search/{record.header.object_id}",
+                final_score=record.final_score,
+            )
+        )
+    return results
 
 
 def query_platform_workspace(text: str, enabled: bool = True) -> list[PlatformSearchResult]:

--- a/services/search-orchestrator/app/main.py
+++ b/services/search-orchestrator/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 
-from services.search_orchestrator.app.backends import query_platform_workspace
-from services.search_orchestrator.app.models import SearchRequest, SearchResult, SearchResultScore
+from services.search_orchestrator.app.backends import ingest_academy_record, query_academy_records, query_platform_workspace
+from services.search_orchestrator.app.models import LearningSearchRecord, SearchRequest, SearchResult, SearchResultScore
 
 app = FastAPI(title="search-orchestrator", version="0.1.0")
 
@@ -11,15 +11,30 @@ def healthz() -> dict[str, str]:
     return {"status": "ok", "service": "search-orchestrator"}
 
 
+@app.post("/v1/search/ingest/academy", response_model=LearningSearchRecord)
+def ingest_academy(body: LearningSearchRecord) -> LearningSearchRecord:
+    return ingest_academy_record(body)
+
+
 @app.post("/v0/search/query")
 def search_query(body: SearchRequest) -> dict[str, object]:
     results: list[dict[str, object]] = []
     scope = body.scope or None
+    enabled = scope is not None and scope.cloud_workspace
 
-    for item in query_platform_workspace(
-        text=body.text,
-        enabled=(scope is not None and scope.cloud_workspace),
-    ):
+    for item in query_platform_workspace(text=body.text, enabled=enabled):
+        result = SearchResult(
+            result_id=item.result_id,
+            source=item.source,
+            entity_type=item.entity_type,
+            title=item.title,
+            snippet=item.snippet,
+            path_or_uri=item.path_or_uri,
+            score=SearchResultScore(final=item.final_score),
+        )
+        results.append(result.model_dump())
+
+    for item in query_academy_records(text=body.text, enabled=enabled):
         result = SearchResult(
             result_id=item.result_id,
             source=item.source,
@@ -35,5 +50,5 @@ def search_query(body: SearchRequest) -> dict[str, object]:
         "query_id": body.query_id,
         "actor_id": body.actor_id,
         "mode": body.mode,
-        "results": results,
+        "results": results[: body.limit],
     }

--- a/services/search-orchestrator/app/main.py
+++ b/services/search-orchestrator/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 
-from services.search_orchestrator.app.backends import ingest_academy_record, query_academy_records, query_platform_workspace
-from services.search_orchestrator.app.models import LearningSearchRecord, SearchRequest, SearchResult, SearchResultScore
+from app.backends import ingest_academy_record, query_academy_records, query_platform_workspace
+from app.models import LearningSearchRecord, SearchRequest, SearchResult, SearchResultScore
 
 app = FastAPI(title="search-orchestrator", version="0.1.0")
 

--- a/services/search-orchestrator/app/models.py
+++ b/services/search-orchestrator/app/models.py
@@ -37,3 +37,29 @@ class SearchResult(BaseModel):
     path_or_uri: str | None = None
     score: SearchResultScore
     actions: SearchResultActions | None = None
+
+
+class AcademyRecordHeader(BaseModel):
+    object_id: str
+    object_type: str
+    object_version: str | None = None
+    created_at: str | None = None
+    created_by_contributor_id: str | None = None
+    created_by_role: str | None = None
+    status: str | None = None
+    policy_tags: list[str] = []
+
+
+class LearningSearchRecord(BaseModel):
+    header: AcademyRecordHeader
+    source: str
+    entity_type: str
+    title: str
+    text: str
+    target_ref: str
+    evidence_ref_ids: list[str] = []
+    memory_ref_ids: list[str] = []
+    search_ref_ids: list[str] = []
+    governance_ref_ids: list[str] = []
+    agentplane_run_ref_ids: list[str] = []
+    final_score: float = 1.0

--- a/services/search-orchestrator/app/models.py
+++ b/services/search-orchestrator/app/models.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel
+from typing import Literal
+
+from pydantic import BaseModel, Field
 
 
 class SearchScope(BaseModel):
@@ -47,19 +49,19 @@ class AcademyRecordHeader(BaseModel):
     created_by_contributor_id: str | None = None
     created_by_role: str | None = None
     status: str | None = None
-    policy_tags: list[str] = []
+    policy_tags: list[str] = Field(default_factory=list)
 
 
 class LearningSearchRecord(BaseModel):
     header: AcademyRecordHeader
-    source: str
-    entity_type: str
+    source: Literal["ALEXANDRIAN_ACADEMY"]
+    entity_type: Literal["LEARNING_ACTION_EXPLANATION", "LEARNING_LOOP_RECORD"]
     title: str
     text: str
     target_ref: str
-    evidence_ref_ids: list[str] = []
-    memory_ref_ids: list[str] = []
-    search_ref_ids: list[str] = []
-    governance_ref_ids: list[str] = []
-    agentplane_run_ref_ids: list[str] = []
-    final_score: float = 1.0
+    evidence_ref_ids: list[str] = Field(default_factory=list)
+    memory_ref_ids: list[str] = Field(default_factory=list)
+    search_ref_ids: list[str] = Field(default_factory=list)
+    governance_ref_ids: list[str] = Field(default_factory=list)
+    agentplane_run_ref_ids: list[str] = Field(default_factory=list)
+    final_score: float = Field(default=1.0, ge=0, le=1)

--- a/services/search-orchestrator/requirements-test.txt
+++ b/services/search-orchestrator/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest
+httpx

--- a/services/search-orchestrator/requirements.txt
+++ b/services/search-orchestrator/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+pydantic

--- a/services/search-orchestrator/tests/test_academy_ingest.py
+++ b/services/search-orchestrator/tests/test_academy_ingest.py
@@ -1,0 +1,64 @@
+from fastapi.testclient import TestClient
+
+from services.search_orchestrator.app.backends import ACADEMY_RECORDS
+from services.search_orchestrator.app.main import app
+
+client = TestClient(app)
+
+
+def setup_function() -> None:
+    ACADEMY_RECORDS.clear()
+
+
+def academy_record() -> dict[str, object]:
+    return {
+        "header": {
+            "object_id": "lsr_00000001",
+            "object_type": "LearningSearchRecord",
+            "object_version": "0.1.0",
+            "created_at": "2026-04-24T19:55:00Z",
+            "created_by_contributor_id": "system.alexandrian",
+            "created_by_role": "system",
+            "status": "draft",
+            "policy_tags": ["learning-loop", "search", "evidence-first"],
+        },
+        "source": "ALEXANDRIAN_ACADEMY",
+        "entity_type": "LEARNING_ACTION_EXPLANATION",
+        "title": "Why next learning action was recommended",
+        "text": "Review cited evidence span before attempting the next assessment item.",
+        "target_ref": "llr_00000001",
+        "evidence_ref_ids": ["ariadne.span.example.0001"],
+        "memory_ref_ids": ["memory-mesh://learning-context/example-0001"],
+        "search_ref_ids": ["sherlock://learning-search/example-0001"],
+        "governance_ref_ids": ["oracle://evaluation/example-0001", "moirai://changeset/example-0001", "policy-fabric://decision/example-0001"],
+        "agentplane_run_ref_ids": ["agentplane://run/example-0001"],
+        "final_score": 1.0,
+    }
+
+
+def test_academy_ingest_accepts_learning_search_record() -> None:
+    response = client.post("/v1/search/ingest/academy", json=academy_record())
+    assert response.status_code == 200
+    assert response.json()["source"] == "ALEXANDRIAN_ACADEMY"
+    assert response.json()["header"]["object_id"] == "lsr_00000001"
+
+
+def test_academy_record_is_queryable_when_cloud_scope_enabled() -> None:
+    client.post("/v1/search/ingest/academy", json=academy_record())
+    response = client.post(
+        "/v0/search/query",
+        json={
+            "query_id": "q-academy",
+            "actor_id": "user-1",
+            "text": "evidence",
+            "mode": "HYBRID",
+            "limit": 10,
+            "scope": {"cloud_workspace": True, "local_desktop": False, "memory": False},
+        },
+    )
+    assert response.status_code == 200
+    results = response.json()["results"]
+    academy_results = [item for item in results if item["source"] == "ALEXANDRIAN_ACADEMY"]
+    assert academy_results
+    assert academy_results[0]["entity_type"] == "LEARNING_ACTION_EXPLANATION"
+    assert academy_results[0]["path_or_uri"] == "alexandrian://learning-search/lsr_00000001"

--- a/services/search-orchestrator/tests/test_academy_ingest.py
+++ b/services/search-orchestrator/tests/test_academy_ingest.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 
-from services.search_orchestrator.app.backends import ACADEMY_RECORDS
-from services.search_orchestrator.app.main import app
+from app.backends import ACADEMY_RECORDS
+from app.main import app
 
 client = TestClient(app)
 

--- a/services/search-orchestrator/tests/test_backends.py
+++ b/services/search-orchestrator/tests/test_backends.py
@@ -1,4 +1,4 @@
-from services.search_orchestrator.app.backends import query_platform_workspace
+from app.backends import query_platform_workspace
 
 
 def test_query_platform_workspace_returns_placeholder_result() -> None:

--- a/services/search-orchestrator/tests/test_platform_scope_result.py
+++ b/services/search-orchestrator/tests/test_platform_scope_result.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from services.search_orchestrator.app.main import app
+from app.main import app
 
 
 client = TestClient(app)

--- a/services/search-orchestrator/tests/test_service_smoke.py
+++ b/services/search-orchestrator/tests/test_service_smoke.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
 
-from services.search_orchestrator.app.main import app
+from app.main import app
 
 
 client = TestClient(app)


### PR DESCRIPTION
## Summary

Adds the receiving-side platform search adapter for Alexandrian `LearningSearchRecord` artifacts.

## Scope

- Adds `LearningSearchRecord` and Academy record models
- Adds in-memory Academy search record backend
- Adds `POST /v1/search/ingest/academy`
- Includes Academy records in `/v0/search/query` when cloud workspace scope is enabled
- Adds service-local requirements and dedicated `search-orchestrator` workflow
- Adds tests for ingest and query behavior

## Integration

This is the platform receiving side for Alexandrian Academy's guarded publishing chain:

`LearningLoopRecord -> LearningActionExplanation -> LearningSearchRecord -> search-orchestrator/Lampstand/Sherlock retrieval`

## Safety posture

- In-memory receiving slice only
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback
- Source is constrained to `ALEXANDRIAN_ACADEMY`

## Program lane

Platform receiving side: search ingestion for Alexandrian learning explanation records.