### PR TITLE
services(search): add academy repository seam

### DIFF
--- a/services/search-orchestrator/app/backends.py
+++ b/services/search-orchestrator/app/backends.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from app.models import LearningSearchRecord
+from app.repositories import academy_repository
 
 
 @dataclass
@@ -20,12 +21,12 @@ class PlatformSearchResult:
     draft_reply: bool = False
 
 
-ACADEMY_RECORDS: dict[str, LearningSearchRecord] = {}
+def reset_academy_records() -> None:
+    academy_repository.clear()
 
 
 def ingest_academy_record(record: LearningSearchRecord) -> LearningSearchRecord:
-    ACADEMY_RECORDS[record.header.object_id] = record
-    return record
+    return academy_repository.ingest(record)
 
 
 def query_academy_records(text: str, enabled: bool = True) -> list[PlatformSearchResult]:
@@ -33,7 +34,7 @@ def query_academy_records(text: str, enabled: bool = True) -> list[PlatformSearc
         return []
     needle = text.lower()
     results: list[PlatformSearchResult] = []
-    for record in ACADEMY_RECORDS.values():
+    for record in academy_repository.list_records():
         haystack = " ".join([record.title, record.text, record.target_ref]).lower()
         if needle not in haystack:
             continue

--- a/services/search-orchestrator/app/repositories.py
+++ b/services/search-orchestrator/app/repositories.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from app.models import LearningSearchRecord
+
+
+class AcademySearchRepository:
+    def ingest(self, record: LearningSearchRecord) -> LearningSearchRecord:
+        raise NotImplementedError
+
+    def list_records(self) -> list[LearningSearchRecord]:
+        raise NotImplementedError
+
+    def clear(self) -> None:
+        raise NotImplementedError
+
+
+class InMemoryAcademySearchRepository(AcademySearchRepository):
+    def __init__(self) -> None:
+        self._records: dict[str, LearningSearchRecord] = {}
+
+    def ingest(self, record: LearningSearchRecord) -> LearningSearchRecord:
+        self._records[record.header.object_id] = record
+        return record
+
+    def list_records(self) -> list[LearningSearchRecord]:
+        return list(self._records.values())
+
+    def clear(self) -> None:
+        self._records.clear()
+
+
+academy_repository: AcademySearchRepository = InMemoryAcademySearchRepository()

--- a/services/search-orchestrator/tests/test_academy_ingest.py
+++ b/services/search-orchestrator/tests/test_academy_ingest.py
@@ -1,13 +1,13 @@
 from fastapi.testclient import TestClient
 
-from app.backends import ACADEMY_RECORDS
+from app.backends import reset_academy_records
 from app.main import app
 
 client = TestClient(app)
 
 
 def setup_function() -> None:
-    ACADEMY_RECORDS.clear()
+    reset_academy_records()
 
 
 def academy_record() -> dict[str, object]:

--- a/services/search-orchestrator/tests/test_repositories.py
+++ b/services/search-orchestrator/tests/test_repositories.py
@@ -1,0 +1,38 @@
+from app.models import AcademyRecordHeader, LearningSearchRecord
+from app.repositories import InMemoryAcademySearchRepository
+
+
+def record(record_id: str = "lsr_00000001") -> LearningSearchRecord:
+    return LearningSearchRecord(
+        header=AcademyRecordHeader(
+            object_id=record_id,
+            object_type="LearningSearchRecord",
+            policy_tags=["learning-loop", "search"],
+        ),
+        source="ALEXANDRIAN_ACADEMY",
+        entity_type="LEARNING_ACTION_EXPLANATION",
+        title="Why next learning action was recommended",
+        text="Review cited evidence before attempting the next item.",
+        target_ref="llr_00000001",
+        evidence_ref_ids=["ariadne.span.example.0001"],
+        memory_ref_ids=["memory-mesh://learning-context/example-0001"],
+        search_ref_ids=["sherlock://learning-search/example-0001"],
+        governance_ref_ids=["policy-fabric://decision/example-0001"],
+        agentplane_run_ref_ids=["agentplane://run/example-0001"],
+        final_score=1.0,
+    )
+
+
+def test_in_memory_academy_repository_ingests_and_lists_records() -> None:
+    repo = InMemoryAcademySearchRepository()
+    repo.ingest(record())
+    records = repo.list_records()
+    assert len(records) == 1
+    assert records[0].header.object_id == "lsr_00000001"
+
+
+def test_in_memory_academy_repository_clear_removes_records() -> None:
+    repo = InMemoryAcademySearchRepository()
+    repo.ingest(record())
+    repo.clear()
+    assert repo.list_records() == []


### PR DESCRIPTION
## Summary

Refactors Academy search-record storage in `search-orchestrator` behind a repository seam so later Lampstand or platform datastore persistence can be added without changing route behavior.

## Scope

- Adds `AcademySearchRepository` interface
- Adds `InMemoryAcademySearchRepository` implementation
- Rewires Academy ingest/query helpers through the repository
- Updates tests to use the reset seam instead of a module-global dict
- Adds direct repository unit tests

## Safety posture

- No route contract change
- No persistence side effect beyond existing in-memory behavior
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback

## Program lane

Platform search receiving side: repository abstraction for Academy search records.