### PR TITLE
services(search): add durable academy store and visibility filters

### DIFF
--- a/services/search-orchestrator/app/backends.py
+++ b/services/search-orchestrator/app/backends.py
@@ -29,12 +29,42 @@ def ingest_academy_record(record: LearningSearchRecord) -> LearningSearchRecord:
     return academy_repository.ingest(record)
 
 
-def query_academy_records(text: str, enabled: bool = True) -> list[PlatformSearchResult]:
-    if not enabled or not text.strip():
+def _allowed(values: list[str], candidate: str | None) -> bool:
+    if not values:
+        return True
+    return candidate is not None and candidate in values
+
+
+def academy_record_visible(
+    record: LearningSearchRecord,
+    actor_id: str,
+    workspace_id: str | None = None,
+    jurisdiction_id: str | None = None,
+) -> bool:
+    visibility = record.visibility
+    if visibility is None:
+        return True
+    return (
+        _allowed(visibility.allowed_actor_ids, actor_id)
+        and _allowed(visibility.allowed_workspace_ids, workspace_id)
+        and _allowed(visibility.allowed_jurisdiction_ids, jurisdiction_id)
+    )
+
+
+def query_academy_records(
+    text: str,
+    enabled: bool = True,
+    actor_id: str | None = None,
+    workspace_id: str | None = None,
+    jurisdiction_id: str | None = None,
+) -> list[PlatformSearchResult]:
+    if not enabled or not text.strip() or actor_id is None:
         return []
     needle = text.lower()
     results: list[PlatformSearchResult] = []
     for record in academy_repository.list_records():
+        if not academy_record_visible(record, actor_id, workspace_id, jurisdiction_id):
+            continue
         haystack = " ".join([record.title, record.text, record.target_ref]).lower()
         if needle not in haystack:
             continue

--- a/services/search-orchestrator/app/main.py
+++ b/services/search-orchestrator/app/main.py
@@ -34,7 +34,7 @@ def search_query(body: SearchRequest) -> dict[str, object]:
         )
         results.append(result.model_dump())
 
-    for item in query_academy_records(text=body.text, enabled=enabled):
+    for item in query_academy_records(body.text, enabled, body.actor_id, body.workspace_id, body.jurisdiction_id):
         result = SearchResult(
             result_id=item.result_id,
             source=item.source,

--- a/services/search-orchestrator/app/models.py
+++ b/services/search-orchestrator/app/models.py
@@ -15,6 +15,8 @@ class SearchRequest(BaseModel):
     text: str
     mode: str
     limit: int
+    workspace_id: str | None = None
+    jurisdiction_id: str | None = None
     scope: SearchScope | None = None
 
 
@@ -52,6 +54,12 @@ class AcademyRecordHeader(BaseModel):
     policy_tags: list[str] = Field(default_factory=list)
 
 
+class AcademyVisibility(BaseModel):
+    allowed_actor_ids: list[str] = Field(default_factory=list)
+    allowed_workspace_ids: list[str] = Field(default_factory=list)
+    allowed_jurisdiction_ids: list[str] = Field(default_factory=list)
+
+
 class LearningSearchRecord(BaseModel):
     header: AcademyRecordHeader
     source: Literal["ALEXANDRIAN_ACADEMY"]
@@ -64,4 +72,5 @@ class LearningSearchRecord(BaseModel):
     search_ref_ids: list[str] = Field(default_factory=list)
     governance_ref_ids: list[str] = Field(default_factory=list)
     agentplane_run_ref_ids: list[str] = Field(default_factory=list)
+    visibility: AcademyVisibility | None = None
     final_score: float = Field(default=1.0, ge=0, le=1)

--- a/services/search-orchestrator/app/repositories.py
+++ b/services/search-orchestrator/app/repositories.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+import os
+from pathlib import Path
+
 from app.models import LearningSearchRecord
 
 
@@ -29,4 +33,41 @@ class InMemoryAcademySearchRepository(AcademySearchRepository):
         self._records.clear()
 
 
-academy_repository: AcademySearchRepository = InMemoryAcademySearchRepository()
+class JsonFileAcademySearchRepository(AcademySearchRepository):
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            self.path.write_text("[]\n", encoding="utf-8")
+
+    def _load(self) -> list[LearningSearchRecord]:
+        raw = json.loads(self.path.read_text(encoding="utf-8"))
+        if not isinstance(raw, list):
+            return []
+        return [LearningSearchRecord.model_validate(item) for item in raw]
+
+    def _save(self, records: list[LearningSearchRecord]) -> None:
+        payload = [record.model_dump(mode="json") for record in records]
+        self.path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+    def ingest(self, record: LearningSearchRecord) -> LearningSearchRecord:
+        records = {item.header.object_id: item for item in self._load()}
+        records[record.header.object_id] = record
+        self._save(list(records.values()))
+        return record
+
+    def list_records(self) -> list[LearningSearchRecord]:
+        return self._load()
+
+    def clear(self) -> None:
+        self._save([])
+
+
+def build_academy_repository() -> AcademySearchRepository:
+    path = os.environ.get("SEARCH_ORCHESTRATOR_ACADEMY_STORE")
+    if path:
+        return JsonFileAcademySearchRepository(Path(path))
+    return InMemoryAcademySearchRepository()
+
+
+academy_repository: AcademySearchRepository = build_academy_repository()

--- a/services/search-orchestrator/tests/test_academy_repository_persistence.py
+++ b/services/search-orchestrator/tests/test_academy_repository_persistence.py
@@ -1,0 +1,41 @@
+from app.models import AcademyRecordHeader, LearningSearchRecord
+from app.repositories import JsonFileAcademySearchRepository
+
+
+def record(record_id: str = "lsr_00000001") -> LearningSearchRecord:
+    return LearningSearchRecord(
+        header=AcademyRecordHeader(object_id=record_id, object_type="LearningSearchRecord"),
+        source="ALEXANDRIAN_ACADEMY",
+        entity_type="LEARNING_ACTION_EXPLANATION",
+        title="Why next learning action was recommended",
+        text="Review cited evidence before attempting the next item.",
+        target_ref="llr_00000001",
+        evidence_ref_ids=["ariadne.span.example.0001"],
+        memory_ref_ids=["memory-mesh://learning-context/example-0001"],
+        search_ref_ids=["sherlock://learning-search/example-0001"],
+        governance_ref_ids=["policy-fabric://decision/example-0001"],
+        agentplane_run_ref_ids=["agentplane://run/example-0001"],
+        final_score=1.0,
+    )
+
+
+def test_json_file_repository_persists_records_across_instances(tmp_path) -> None:
+    path = tmp_path / "academy-search.json"
+    first = JsonFileAcademySearchRepository(path)
+    first.ingest(record())
+
+    second = JsonFileAcademySearchRepository(path)
+    records = second.list_records()
+
+    assert len(records) == 1
+    assert records[0].header.object_id == "lsr_00000001"
+    assert records[0].source == "ALEXANDRIAN_ACADEMY"
+
+
+def test_json_file_repository_clear_removes_file_records(tmp_path) -> None:
+    path = tmp_path / "academy-search.json"
+    repo = JsonFileAcademySearchRepository(path)
+    repo.ingest(record())
+    repo.clear()
+
+    assert repo.list_records() == []

--- a/services/search-orchestrator/tests/test_academy_visibility.py
+++ b/services/search-orchestrator/tests/test_academy_visibility.py
@@ -1,0 +1,65 @@
+from fastapi.testclient import TestClient
+
+from app.backends import reset_academy_records
+from app.main import app
+
+client = TestClient(app)
+
+
+def setup_function() -> None:
+    reset_academy_records()
+
+
+def academy_record() -> dict[str, object]:
+    return {
+        "header": {
+            "object_id": "lsr_visibility_0001",
+            "object_type": "LearningSearchRecord",
+            "policy_tags": ["learning-loop", "search"],
+        },
+        "source": "ALEXANDRIAN_ACADEMY",
+        "entity_type": "LEARNING_ACTION_EXPLANATION",
+        "title": "Why next learning action was recommended",
+        "text": "Visibility gated evidence explanation.",
+        "target_ref": "llr_visibility_0001",
+        "visibility": {
+            "allowed_actor_ids": ["allowed-user"],
+            "allowed_workspace_ids": ["academy-workspace"],
+            "allowed_jurisdiction_ids": ["pa-us"],
+        },
+        "final_score": 1.0,
+    }
+
+
+def query(actor_id: str, workspace_id: str | None, jurisdiction_id: str | None) -> list[dict[str, object]]:
+    payload = {
+        "query_id": "q-visibility",
+        "actor_id": actor_id,
+        "text": "evidence",
+        "mode": "HYBRID",
+        "limit": 10,
+        "scope": {"cloud_workspace": True, "local_desktop": False, "memory": False},
+    }
+    if workspace_id is not None:
+        payload["workspace_id"] = workspace_id
+    if jurisdiction_id is not None:
+        payload["jurisdiction_id"] = jurisdiction_id
+    response = client.post("/v0/search/query", json=payload)
+    assert response.status_code == 200
+    return [item for item in response.json()["results"] if item["source"] == "ALEXANDRIAN_ACADEMY"]
+
+
+def test_academy_visibility_allows_matching_actor_workspace_and_jurisdiction() -> None:
+    assert client.post("/v1/search/ingest/academy", json=academy_record()).status_code == 200
+    results = query("allowed-user", "academy-workspace", "pa-us")
+    assert len(results) == 1
+
+
+def test_academy_visibility_denies_wrong_actor() -> None:
+    assert client.post("/v1/search/ingest/academy", json=academy_record()).status_code == 200
+    assert query("other-user", "academy-workspace", "pa-us") == []
+
+
+def test_academy_visibility_denies_missing_workspace() -> None:
+    assert client.post("/v1/search/ingest/academy", json=academy_record()).status_code == 200
+    assert query("allowed-user", None, "pa-us") == []


### PR DESCRIPTION
## Summary

Adds durable-file backed Academy search storage and request-scoped visibility filtering to `search-orchestrator`.

## Scope

- Adds optional `workspace_id` and `jurisdiction_id` to `SearchRequest`
- Adds optional `visibility` constraints to `LearningSearchRecord`
- Adds `JsonFileAcademySearchRepository`
- Keeps default repository behavior in-memory unless `SEARCH_ORCHESTRATOR_ACADEMY_STORE` is set
- Filters Academy results by actor, workspace, and jurisdiction when visibility constraints exist
- Adds repository persistence tests
- Adds Academy visibility tests

## Safety posture

- Default runtime behavior remains in-memory
- File-backed storage is opt-in by environment variable
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback
- Restricted records are withheld unless actor/workspace/jurisdiction context matches

## Program lane

Platform search receiving side: durable Academy storage seam and visibility filtering.