### PR TITLE
services(search): add policy seam and lampstand academy repository

### DIFF
--- a/services/search-orchestrator/app/backends.py
+++ b/services/search-orchestrator/app/backends.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from app.models import LearningSearchRecord
+from app.policy import AcademyPolicyContext, academy_policy_evaluator
 from app.repositories import academy_repository
 
 
@@ -29,26 +30,21 @@ def ingest_academy_record(record: LearningSearchRecord) -> LearningSearchRecord:
     return academy_repository.ingest(record)
 
 
-def _allowed(values: list[str], candidate: str | None) -> bool:
-    if not values:
-        return True
-    return candidate is not None and candidate in values
-
-
 def academy_record_visible(
     record: LearningSearchRecord,
     actor_id: str,
     workspace_id: str | None = None,
     jurisdiction_id: str | None = None,
 ) -> bool:
-    visibility = record.visibility
-    if visibility is None:
-        return True
-    return (
-        _allowed(visibility.allowed_actor_ids, actor_id)
-        and _allowed(visibility.allowed_workspace_ids, workspace_id)
-        and _allowed(visibility.allowed_jurisdiction_ids, jurisdiction_id)
+    decision = academy_policy_evaluator.decide(
+        record,
+        AcademyPolicyContext(
+            actor_id=actor_id,
+            workspace_id=workspace_id,
+            jurisdiction_id=jurisdiction_id,
+        ),
     )
+    return decision.allowed
 
 
 def query_academy_records(

--- a/services/search-orchestrator/app/policy.py
+++ b/services/search-orchestrator/app/policy.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.models import LearningSearchRecord
+
+
+@dataclass(frozen=True)
+class AcademyPolicyContext:
+    actor_id: str
+    workspace_id: str | None = None
+    jurisdiction_id: str | None = None
+
+
+@dataclass(frozen=True)
+class AcademyPolicyDecision:
+    allowed: bool
+    reason: str
+    decision_ref: str = "policy-fabric://local-fallback/academy-search-visibility"
+
+
+class AcademyPolicyEvaluator:
+    def decide(self, record: LearningSearchRecord, context: AcademyPolicyContext) -> AcademyPolicyDecision:
+        raise NotImplementedError
+
+
+class LocalVisibilityPolicyEvaluator(AcademyPolicyEvaluator):
+    def decide(self, record: LearningSearchRecord, context: AcademyPolicyContext) -> AcademyPolicyDecision:
+        visibility = record.visibility
+        if visibility is None:
+            return AcademyPolicyDecision(allowed=True, reason="no visibility constraints")
+        if visibility.allowed_actor_ids and context.actor_id not in visibility.allowed_actor_ids:
+            return AcademyPolicyDecision(allowed=False, reason="actor not allowed")
+        if visibility.allowed_workspace_ids and context.workspace_id not in visibility.allowed_workspace_ids:
+            return AcademyPolicyDecision(allowed=False, reason="workspace not allowed")
+        if visibility.allowed_jurisdiction_ids and context.jurisdiction_id not in visibility.allowed_jurisdiction_ids:
+            return AcademyPolicyDecision(allowed=False, reason="jurisdiction not allowed")
+        return AcademyPolicyDecision(allowed=True, reason="local visibility policy allowed")
+
+
+academy_policy_evaluator: AcademyPolicyEvaluator = LocalVisibilityPolicyEvaluator()

--- a/services/search-orchestrator/app/repositories.py
+++ b/services/search-orchestrator/app/repositories.py
@@ -63,7 +63,39 @@ class JsonFileAcademySearchRepository(AcademySearchRepository):
         self._save([])
 
 
+class LampstandJsonlAcademySearchRepository(AcademySearchRepository):
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            self.path.write_text("", encoding="utf-8")
+
+    def ingest(self, record: LearningSearchRecord) -> LearningSearchRecord:
+        records = {item.header.object_id: item for item in self.list_records()}
+        records[record.header.object_id] = record
+        with self.path.open("w", encoding="utf-8") as handle:
+            for item in records.values():
+                handle.write(json.dumps(item.model_dump(mode="json"), sort_keys=False) + "\n")
+        return record
+
+    def list_records(self) -> list[LearningSearchRecord]:
+        records: list[LearningSearchRecord] = []
+        if not self.path.exists():
+            return records
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            records.append(LearningSearchRecord.model_validate(json.loads(line)))
+        return records
+
+    def clear(self) -> None:
+        self.path.write_text("", encoding="utf-8")
+
+
 def build_academy_repository() -> AcademySearchRepository:
+    lampstand_path = os.environ.get("SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_JSONL")
+    if lampstand_path:
+        return LampstandJsonlAcademySearchRepository(Path(lampstand_path))
     path = os.environ.get("SEARCH_ORCHESTRATOR_ACADEMY_STORE")
     if path:
         return JsonFileAcademySearchRepository(Path(path))

--- a/services/search-orchestrator/tests/test_academy_lampstand_repository.py
+++ b/services/search-orchestrator/tests/test_academy_lampstand_repository.py
@@ -1,0 +1,41 @@
+from app.models import AcademyRecordHeader, LearningSearchRecord
+from app.repositories import LampstandJsonlAcademySearchRepository
+
+
+def record(record_id: str = "lsr_0001", text: str = "Searchable explanation.") -> LearningSearchRecord:
+    return LearningSearchRecord(
+        header=AcademyRecordHeader(object_id=record_id, object_type="LearningSearchRecord"),
+        source="ALEXANDRIAN_ACADEMY",
+        entity_type="LEARNING_ACTION_EXPLANATION",
+        title="Why recommended",
+        text=text,
+        target_ref="llr_0001",
+        final_score=1.0,
+    )
+
+
+def test_lampstand_jsonl_repository_writes_jsonl(tmp_path) -> None:
+    path = tmp_path / "academy-search.jsonl"
+    repo = LampstandJsonlAcademySearchRepository(path)
+    repo.ingest(record())
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert "ALEXANDRIAN_ACADEMY" in lines[0]
+
+
+def test_lampstand_jsonl_repository_upserts_by_object_id(tmp_path) -> None:
+    path = tmp_path / "academy-search.jsonl"
+    repo = LampstandJsonlAcademySearchRepository(path)
+    repo.ingest(record("same-id", "first"))
+    repo.ingest(record("same-id", "second"))
+    records = repo.list_records()
+    assert len(records) == 1
+    assert records[0].text == "second"
+
+
+def test_lampstand_jsonl_repository_clear_removes_records(tmp_path) -> None:
+    path = tmp_path / "academy-search.jsonl"
+    repo = LampstandJsonlAcademySearchRepository(path)
+    repo.ingest(record())
+    repo.clear()
+    assert repo.list_records() == []

--- a/services/search-orchestrator/tests/test_policy.py
+++ b/services/search-orchestrator/tests/test_policy.py
@@ -1,0 +1,39 @@
+from app.models import AcademyRecordHeader, AcademyVisibility, LearningSearchRecord
+from app.policy import AcademyPolicyContext, LocalVisibilityPolicyEvaluator
+
+
+def record(visibility: AcademyVisibility | None = None) -> LearningSearchRecord:
+    return LearningSearchRecord(
+        header=AcademyRecordHeader(object_id="lsr_policy_0001", object_type="LearningSearchRecord"),
+        source="ALEXANDRIAN_ACADEMY",
+        entity_type="LEARNING_ACTION_EXPLANATION",
+        title="Why next learning action was recommended",
+        text="Policy gated explanation.",
+        target_ref="llr_policy_0001",
+        visibility=visibility,
+    )
+
+
+def test_local_policy_allows_unrestricted_record() -> None:
+    decision = LocalVisibilityPolicyEvaluator().decide(record(), AcademyPolicyContext(actor_id="user-1"))
+    assert decision.allowed
+    assert decision.decision_ref == "policy-fabric://local-fallback/academy-search-visibility"
+
+
+def test_local_policy_denies_wrong_actor() -> None:
+    visibility = AcademyVisibility(allowed_actor_ids=["allowed-user"])
+    decision = LocalVisibilityPolicyEvaluator().decide(record(visibility), AcademyPolicyContext(actor_id="other-user"))
+    assert not decision.allowed
+
+
+def test_local_policy_allows_matching_workspace_and_jurisdiction() -> None:
+    visibility = AcademyVisibility(
+        allowed_actor_ids=["allowed-user"],
+        allowed_workspace_ids=["academy-workspace"],
+        allowed_jurisdiction_ids=["pa-us"],
+    )
+    decision = LocalVisibilityPolicyEvaluator().decide(
+        record(visibility),
+        AcademyPolicyContext(actor_id="allowed-user", workspace_id="academy-workspace", jurisdiction_id="pa-us"),
+    )
+    assert decision.allowed


### PR DESCRIPTION
## Summary

Adds a policy-decision seam for Academy search visibility and an opt-in Lampstand-oriented JSONL repository adapter for Academy search records.

## Scope

- Adds `app/policy.py` with a local fallback Policy Fabric-compatible decision seam
- Rewires Academy visibility filtering through the policy evaluator
- Adds `LampstandJsonlAcademySearchRepository`
- Selects Lampstand JSONL storage when `SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_JSONL` is set
- Adds policy seam tests
- Adds Lampstand JSONL repository tests

## Integration

Policy behavior remains local fallback today, with a decision ref that can later be replaced by a real Policy Fabric evaluator. Lampstand JSONL is opt-in and keeps default runtime behavior unchanged.

## Safety posture

- No route contract change
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback
- Default repository remains the existing non-durable path unless configured

## Program lane

Platform search receiving side: Policy Fabric seam and Lampstand repository adapter.