### PR TITLE
Add Fog Stack release seal signature support

### DIFF
--- a/docs/FOGSTACK_RELEASE_SEAL_SIGNATURES.md
+++ b/docs/FOGSTACK_RELEASE_SEAL_SIGNATURES.md
@@ -1,0 +1,49 @@
+# Fog Stack release seal signatures
+
+This document defines the first repo-native meaning of a **signed release seal**.
+
+## Goal
+
+Move from:
+- an unsigned `FogStackReleaseSeal`
+- a helper that computes `release_root_hash`
+
+to:
+- a seal that can explicitly carry signature metadata
+- a helper that can verify the signed-seal shape before later cryptographic verification layers exist.
+
+## Minimal flow
+
+1. emit the release seal with `tools/emit_fogstack_release_seal.py`
+2. attach signature metadata with `tools/attach_fogstack_release_seal_signature.py`
+3. verify the signed-seal shape with `tools/verify_fogstack_release_seal_signature.py`
+
+## Example
+
+```bash
+python3 tools/attach_fogstack_release_seal_signature.py \
+  --seal releases/seals/fogstack.access-v0.1.seal.json \
+  --signature-type cosign \
+  --signature-ref artifact://release/fogstack.access-v0.1.seal.sig \
+  --output /tmp/fogstack.access-v0.1.signed.seal.json
+
+python3 tools/verify_fogstack_release_seal_signature.py \
+  --seal /tmp/fogstack.access-v0.1.signed.seal.json \
+  --require-signed \
+  --json
+```
+
+## What this phase provides
+
+- seal schema can carry `signed` + `signature`
+- helper to attach signature metadata to a seal
+- helper to verify signed-seal metadata shape
+
+## What this phase does not yet provide
+
+- cryptographic verification of the seal signature payload
+- automatic CI verification of the seal signature
+- publication of signed seals
+- linking the seal signature into the broader trust graph
+
+Those remain later steps.

--- a/schemas/release/fogstack-release-seal-v0.1.schema.json
+++ b/schemas/release/fogstack-release-seal-v0.1.schema.json
@@ -10,7 +10,8 @@
     "version",
     "algorithm",
     "release_root_hash",
-    "artifact_hashes"
+    "artifact_hashes",
+    "signed"
   ],
   "properties": {
     "kind": { "const": "FogStackReleaseSeal" },
@@ -31,6 +32,16 @@
         },
         "additionalProperties": false
       }
+    },
+    "signed": { "type": "boolean" },
+    "signature": {
+      "type": ["object", "null"],
+      "required": ["type", "ref"],
+      "properties": {
+        "type": { "enum": ["cosign", "sigstore", "other"] },
+        "ref": { "type": "string" }
+      },
+      "additionalProperties": false
     },
     "notes": { "type": ["string", "null"] }
   },

--- a/tools/attach_fogstack_release_seal_signature.py
+++ b/tools/attach_fogstack_release_seal_signature.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Attach signature metadata to a Fog Stack release seal")
+    parser.add_argument("--seal", required=True, type=Path)
+    parser.add_argument("--signature-type", required=True, choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--signature-ref", required=True)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    seal = load_json(args.seal)
+    seal["signed"] = True
+    seal["signature"] = {
+        "type": args.signature_type,
+        "ref": args.signature_ref,
+    }
+
+    text = json.dumps(seal, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_fogstack_release_seal_signature.py
+++ b/tools/verify_fogstack_release_seal_signature.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify Fog Stack release seal signature metadata")
+    parser.add_argument("--seal", required=True, type=Path)
+    parser.add_argument("--require-signed", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    seal = load_json(args.seal)
+    signed = seal.get("signed")
+    signature = seal.get("signature")
+    checks = []
+
+    def record(rule_id: str, status: str, message: str) -> None:
+        checks.append({"id": rule_id, "status": status, "message": message})
+
+    if signed is True:
+        record("SEALSIG-001", "pass", "seal marked signed")
+    elif signed is False:
+        if args.require_signed:
+            record("SEALSIG-001", "fail", "seal is not marked signed")
+        else:
+            record("SEALSIG-001", "warn", "seal is unsigned")
+    else:
+        record("SEALSIG-001", "fail", "seal missing boolean 'signed' field")
+
+    if signed is True:
+        if not isinstance(signature, dict):
+            record("SEALSIG-002", "fail", "signed seal missing signature object")
+        else:
+            sig_type = signature.get("type")
+            sig_ref = signature.get("ref")
+            if sig_type in {"cosign", "sigstore", "other"}:
+                record("SEALSIG-002", "pass", f"signature type present: {sig_type}")
+            else:
+                record("SEALSIG-002", "fail", f"invalid signature type: {sig_type!r}")
+            if isinstance(sig_ref, str) and sig_ref.strip():
+                record("SEALSIG-003", "pass", "signature reference present")
+            else:
+                record("SEALSIG-003", "fail", "signature reference missing or empty")
+    else:
+        record("SEALSIG-002", "skip", "signature object not required for unsigned seal")
+        record("SEALSIG-003", "skip", "signature reference not required for unsigned seal")
+
+    statuses = [c["status"] for c in checks]
+    if "fail" in statuses:
+        overall = "fail"
+        exit_code = 2
+    elif "warn" in statuses:
+        overall = "warn"
+        exit_code = 0
+    else:
+        overall = "pass"
+        exit_code = 0
+
+    result = {
+        "tool": "fogstack verify-seal-signature",
+        "subject": str(args.seal),
+        "summary": {
+            "status": overall,
+            "exit_code": exit_code,
+            "checks_run": len(checks)
+        },
+        "checks": checks
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"{args.seal} status={overall} checks={len(checks)}")
+        for item in checks:
+            print(f"- {item['status'].upper():5s} {item['id']} {item['message']}")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR refreshes the release seal signature support slice directly onto current `main`:

- updated `schemas/release/fogstack-release-seal-v0.1.schema.json`
- `tools/attach_fogstack_release_seal_signature.py`
- `tools/verify_fogstack_release_seal_signature.py`
- `docs/FOGSTACK_RELEASE_SEAL_SIGNATURES.md`

## Why this PR exists

An earlier draft PR carried this slice on a stacked base. This PR restates the same work directly against current `main` so review can focus on the seal-signature support itself.

This tranche lets the release seal carry signature metadata and adds repo-native helpers to attach and verify the signed-seal shape.

## Not in this PR

- cryptographic verification of the seal signature payload
- CI enforcement of seal-signature verification
- publication of signed seals
- linkage of seal-signature verification into the wider trust graph

Those remain later steps.
