### PR TITLE
apps(openai-research-mcp): add ops docs and smoke workflow

### DIFF
--- a/.github/workflows/openai-research-mcp-smoke.yml
+++ b/.github/workflows/openai-research-mcp-smoke.yml
@@ -1,0 +1,24 @@
+name: openai-research-mcp-smoke
+
+on:
+  pull_request:
+    paths:
+      - 'apps/openai-research-mcp/**'
+      - '.github/workflows/openai-research-mcp-smoke.yml'
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: apps/openai-research-mcp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run bundle smoke tests
+        run: bash scripts/run_tests.sh

--- a/apps/openai-research-mcp/docs/artifact_handoff.md
+++ b/apps/openai-research-mcp/docs/artifact_handoff.md
@@ -1,0 +1,16 @@
+# Artifact handoff
+
+The runtime separates retrieval from export.
+
+Public artifact payloads should expose:
+- `artifact_id`
+- `object_key`
+- `sha256`
+- optional `download_url`
+
+Public artifact payloads must not expose:
+- raw local filesystem paths
+- private storage roots
+- implicit workspace assumptions
+
+The internal manifest may retain local operational details, but those stay behind the service boundary.

--- a/apps/openai-research-mcp/docs/audit_log_schema.md
+++ b/apps/openai-research-mcp/docs/audit_log_schema.md
@@ -1,0 +1,14 @@
+# Audit log schema notes
+
+Each audit event should carry enough context to reconstruct what happened without rereading service logs.
+
+Recommended fields:
+- `ts`
+- `event`
+- `subject`
+- `organization`
+- `document_id` or `results`
+- canonical `url` where relevant
+- `artifact_id` for export handoff events
+
+Do not log bearer tokens or raw secret material.

--- a/apps/openai-research-mcp/docs/deployment.md
+++ b/apps/openai-research-mcp/docs/deployment.md
@@ -1,0 +1,10 @@
+# Deployment notes
+
+Recommended order:
+1. put the service behind a gateway that validates identity
+2. prefer trusted identity headers only behind that gateway
+3. use detached object storage for artifacts
+4. expose a remote MCP or HTTP facade over HTTPS
+5. publish only after freezing compatible tool schemas
+
+Local bring-up in this lane is intentionally simpler than production.

--- a/apps/openai-research-mcp/docs/gateway_auth.md
+++ b/apps/openai-research-mcp/docs/gateway_auth.md
@@ -1,0 +1,10 @@
+# Gateway auth notes
+
+Preferred production posture:
+
+- terminate external auth at the gateway
+- validate identity and organization membership at the gateway
+- inject trusted subject / organization / scopes headers only on the internal hop
+- do not trust caller-supplied identity headers from the public edge
+
+Static token configuration in this lane is for local bring-up only.

--- a/apps/openai-research-mcp/docs/release_management.md
+++ b/apps/openai-research-mcp/docs/release_management.md
@@ -1,0 +1,11 @@
+# Release management
+
+Treat these as separate release surfaces:
+
+- tool schema shape
+- runtime behavior
+- artifact payload shape
+- auth boundary assumptions
+- widget/browser integration assumptions
+
+Do not change all of them at once unless the PR clearly calls out compatibility risk.

--- a/apps/openai-research-mcp/docs/sandbox_workspace_strategy.md
+++ b/apps/openai-research-mcp/docs/sandbox_workspace_strategy.md
@@ -1,0 +1,10 @@
+# Sandbox / workspace strategy
+
+Treat these as separate planes:
+
+- browser or widget sandbox
+- MCP or HTTP research runtime
+- local or detached artifact workspace
+- upstream retrieval systems
+
+Handoffs between planes should use explicit IDs or URLs, not implicit shared filesystem assumptions.

--- a/apps/openai-research-mcp/docs/threat_model.md
+++ b/apps/openai-research-mcp/docs/threat_model.md
@@ -1,0 +1,16 @@
+# Threat model
+
+Primary boundaries:
+
+1. browser/widget sandbox
+2. research service runtime
+3. artifact storage
+4. upstream retrieval systems
+
+Core rules:
+
+- keep `search` / `fetch` read-only
+- require separate authorization for export
+- preserve canonical URLs across search, fetch, audit, and export
+- never expose raw local paths in public artifact payloads
+- treat gateway identity as authoritative when running behind a trusted proxy

--- a/apps/openai-research-mcp/schemas/audit_event.schema.json
+++ b/apps/openai-research-mcp/schemas/audit_event.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AuditEvent",
+  "type": "object",
+  "required": ["ts", "event"],
+  "properties": {
+    "ts": {"type": "string"},
+    "event": {"type": "string"},
+    "subject": {"type": ["string", "null"]},
+    "organization": {"type": ["string", "null"]},
+    "document_id": {"type": "string"},
+    "results": {"type": "array", "items": {"type": "string"}},
+    "url": {"type": "string"},
+    "artifact_id": {"type": "string"}
+  },
+  "additionalProperties": true
+}

--- a/apps/openai-research-mcp/schemas/fetch_response.schema.json
+++ b/apps/openai-research-mcp/schemas/fetch_response.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "FetchResponse",
+  "type": "object",
+  "required": ["id", "title", "text", "url"],
+  "properties": {
+    "id": {"type": "string"},
+    "title": {"type": "string"},
+    "text": {"type": "string"},
+    "url": {"type": "string", "format": "uri"},
+    "metadata": {"type": "object"}
+  },
+  "additionalProperties": false
+}

--- a/apps/openai-research-mcp/schemas/search_response.schema.json
+++ b/apps/openai-research-mcp/schemas/search_response.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SearchResponse",
+  "type": "object",
+  "required": ["results"],
+  "properties": {
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "url"],
+        "properties": {
+          "id": {"type": "string"},
+          "title": {"type": "string"},
+          "url": {"type": "string", "format": "uri"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

Follow-up remediation for the merged `apps/openai-research-mcp` runtime lane.

This PR adds the reviewer-facing operational docs and a repo-native smoke workflow that did not make the initial runtime-lane merge.

## Included

- `apps/openai-research-mcp/docs/deployment.md`
- `apps/openai-research-mcp/docs/gateway_auth.md`
- `apps/openai-research-mcp/docs/threat_model.md`
- `apps/openai-research-mcp/docs/release_management.md`
- `apps/openai-research-mcp/docs/sandbox_workspace_strategy.md`
- `.github/workflows/openai-research-mcp-smoke.yml`

## Why this exists

The runtime lane is already on `main`, but it still needed:

- deployment guidance
- gateway-auth posture notes
- threat-model notes
- release-surface notes
- an explicit sandbox/workspace split note
- CI smoke coverage for the new subtree

## Remaining gap

The shared repo index files still need to mention this lane:

- `apps/README.md`
- `docs/INTEGRATION-MAP.md`

The connector available in this session can add new files cleanly, but it does not expose the update path needed for existing-file edits through the high-level write tool. That shared-index update should be landed as the next small follow-up once we use a write path that supports existing-file updates.