### PR TITLE
services(search): align academy visibility policy decisions

### DIFF
--- a/services/search-orchestrator/app/policy.py
+++ b/services/search-orchestrator/app/policy.py
@@ -17,6 +17,8 @@ class AcademyPolicyDecision:
     allowed: bool
     reason: str
     decision_ref: str = "policy-fabric://local-fallback/academy-search-visibility"
+    request: dict[str, object] | None = None
+    decision: dict[str, object] | None = None
 
 
 class AcademyPolicyEvaluator:
@@ -24,18 +26,93 @@ class AcademyPolicyEvaluator:
         raise NotImplementedError
 
 
+def build_academy_visibility_request(record: LearningSearchRecord, context: AcademyPolicyContext) -> dict[str, object]:
+    visibility = record.visibility
+    return {
+        "request_id": f"academy_visibility_request::{record.header.object_id}",
+        "action": "academy.search.read",
+        "actor": {
+            "actor_id": context.actor_id,
+            "workspace_id": context.workspace_id,
+            "jurisdiction_id": context.jurisdiction_id,
+        },
+        "resource": {
+            "resource_id": record.header.object_id,
+            "source": record.source,
+            "entity_type": record.entity_type,
+            "target_ref": record.target_ref,
+            "policy_tags": record.header.policy_tags,
+            "visibility": visibility.model_dump(mode="json") if visibility else {},
+        },
+        "evidence_refs": record.evidence_ref_ids,
+        "governance_refs": record.governance_ref_ids,
+    }
+
+
+def build_academy_visibility_decision(
+    *,
+    request: dict[str, object],
+    allowed: bool,
+    reason: str,
+    context: AcademyPolicyContext,
+    record: LearningSearchRecord,
+) -> dict[str, object]:
+    return {
+        "policy_decision_id": f"academy_visibility_decision::{record.header.object_id}",
+        "request_id": str(request["request_id"]),
+        "subject_ref": f"academy://search-record/{record.header.object_id}",
+        "action_ref": "action://academy/search/read",
+        "decision": "allow" if allowed else "deny",
+        "required_gates": [
+            "actor_gate",
+            "workspace_gate",
+            "jurisdiction_gate",
+            "policy_tag_gate",
+            "evidence_gate",
+        ],
+        "reason": reason,
+        "visibility_scope": {
+            "actor_id": context.actor_id,
+            "workspace_id": context.workspace_id,
+            "jurisdiction_id": context.jurisdiction_id,
+        },
+        "validation_evidence": [str(request["request_id"])],
+        "notes": ["Local fallback decision shaped to Policy Fabric Academy visibility contract."],
+    }
+
+
 class LocalVisibilityPolicyEvaluator(AcademyPolicyEvaluator):
     def decide(self, record: LearningSearchRecord, context: AcademyPolicyContext) -> AcademyPolicyDecision:
+        request = build_academy_visibility_request(record, context)
         visibility = record.visibility
-        if visibility is None:
-            return AcademyPolicyDecision(allowed=True, reason="no visibility constraints")
-        if visibility.allowed_actor_ids and context.actor_id not in visibility.allowed_actor_ids:
-            return AcademyPolicyDecision(allowed=False, reason="actor not allowed")
-        if visibility.allowed_workspace_ids and context.workspace_id not in visibility.allowed_workspace_ids:
-            return AcademyPolicyDecision(allowed=False, reason="workspace not allowed")
-        if visibility.allowed_jurisdiction_ids and context.jurisdiction_id not in visibility.allowed_jurisdiction_ids:
-            return AcademyPolicyDecision(allowed=False, reason="jurisdiction not allowed")
-        return AcademyPolicyDecision(allowed=True, reason="local visibility policy allowed")
+        allowed = True
+        reason = "no visibility constraints"
+        if visibility is not None:
+            if visibility.allowed_actor_ids and context.actor_id not in visibility.allowed_actor_ids:
+                allowed = False
+                reason = "actor not allowed"
+            elif visibility.allowed_workspace_ids and context.workspace_id not in visibility.allowed_workspace_ids:
+                allowed = False
+                reason = "workspace not allowed"
+            elif visibility.allowed_jurisdiction_ids and context.jurisdiction_id not in visibility.allowed_jurisdiction_ids:
+                allowed = False
+                reason = "jurisdiction not allowed"
+            else:
+                reason = "local visibility policy allowed"
+        decision = build_academy_visibility_decision(
+            request=request,
+            allowed=allowed,
+            reason=reason,
+            context=context,
+            record=record,
+        )
+        return AcademyPolicyDecision(
+            allowed=allowed,
+            reason=reason,
+            decision_ref=f"policy-fabric://decision/{decision['policy_decision_id']}",
+            request=request,
+            decision=decision,
+        )
 
 
 academy_policy_evaluator: AcademyPolicyEvaluator = LocalVisibilityPolicyEvaluator()

--- a/services/search-orchestrator/tests/test_policy.py
+++ b/services/search-orchestrator/tests/test_policy.py
@@ -4,12 +4,18 @@ from app.policy import AcademyPolicyContext, LocalVisibilityPolicyEvaluator
 
 def record(visibility: AcademyVisibility | None = None) -> LearningSearchRecord:
     return LearningSearchRecord(
-        header=AcademyRecordHeader(object_id="lsr_policy_0001", object_type="LearningSearchRecord"),
+        header=AcademyRecordHeader(
+            object_id="lsr_policy_0001",
+            object_type="LearningSearchRecord",
+            policy_tags=["learning-loop", "search"],
+        ),
         source="ALEXANDRIAN_ACADEMY",
         entity_type="LEARNING_ACTION_EXPLANATION",
         title="Why next learning action was recommended",
         text="Policy gated explanation.",
         target_ref="llr_policy_0001",
+        evidence_ref_ids=["evidence://academy/span/0001"],
+        governance_ref_ids=["policy-fabric://decision/example-0001"],
         visibility=visibility,
     )
 
@@ -17,13 +23,28 @@ def record(visibility: AcademyVisibility | None = None) -> LearningSearchRecord:
 def test_local_policy_allows_unrestricted_record() -> None:
     decision = LocalVisibilityPolicyEvaluator().decide(record(), AcademyPolicyContext(actor_id="user-1"))
     assert decision.allowed
-    assert decision.decision_ref == "policy-fabric://local-fallback/academy-search-visibility"
+    assert decision.decision is not None
+    assert decision.decision["decision"] == "allow"
+    assert decision.decision["action_ref"] == "action://academy/search/read"
+    assert decision.decision_ref == "policy-fabric://decision/academy_visibility_decision::lsr_policy_0001"
 
 
 def test_local_policy_denies_wrong_actor() -> None:
     visibility = AcademyVisibility(allowed_actor_ids=["allowed-user"])
     decision = LocalVisibilityPolicyEvaluator().decide(record(visibility), AcademyPolicyContext(actor_id="other-user"))
     assert not decision.allowed
+    assert decision.decision is not None
+    assert decision.decision["decision"] == "deny"
+    assert decision.reason == "actor not allowed"
+
+
+def test_local_policy_emits_request_shape() -> None:
+    visibility = AcademyVisibility(allowed_actor_ids=["allowed-user"])
+    decision = LocalVisibilityPolicyEvaluator().decide(record(visibility), AcademyPolicyContext(actor_id="allowed-user"))
+    assert decision.request is not None
+    assert decision.request["action"] == "academy.search.read"
+    assert decision.request["resource"]["source"] == "ALEXANDRIAN_ACADEMY"
+    assert decision.request["resource"]["entity_type"] == "LEARNING_ACTION_EXPLANATION"
 
 
 def test_local_policy_allows_matching_workspace_and_jurisdiction() -> None:
@@ -37,3 +58,5 @@ def test_local_policy_allows_matching_workspace_and_jurisdiction() -> None:
         AcademyPolicyContext(actor_id="allowed-user", workspace_id="academy-workspace", jurisdiction_id="pa-us"),
     )
     assert decision.allowed
+    assert decision.decision is not None
+    assert decision.decision["visibility_scope"]["workspace_id"] == "academy-workspace"


### PR DESCRIPTION
## Summary

Aligns the `search-orchestrator` local Academy visibility evaluator with the governed Policy Fabric Academy search visibility request/decision contract added in `policy-fabric`.

## Scope

- Adds Policy Fabric-shaped Academy visibility request generation
- Adds Policy Fabric-shaped Academy visibility decision generation
- Keeps the current local fallback evaluator behavior
- Updates tests to assert request and decision contract shape

## Integration

This makes the local fallback evaluator emit the same request and decision fields expected from a future live Policy Fabric evaluator.

## Safety posture

- No route contract change
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback
- No change to allow/deny semantics beyond richer decision metadata

## Program lane

Platform adapter to Policy Fabric Academy search visibility contract.