### PR TITLE
platform: add Michael machine science schemas and docs

### DIFF
--- a/docs/MICHAEL_MACHINE_SCIENCE.md
+++ b/docs/MICHAEL_MACHINE_SCIENCE.md
@@ -1,0 +1,52 @@
+# Michael Machine Science
+
+## Purpose
+
+This note records the platform-facing machine-science role for Michael.
+
+Michael is a governed machine-science agent that integrates three epistemic engines under one promotion spine:
+- symbolic or neuro-symbolic deduction
+- probabilistic-relational belief update
+- symbolic-regression candidate-law discovery
+
+## Runtime role in prophet-platform
+
+`prophet-platform` is the governance and eval surface for Michael artifacts.
+
+This repo should own the machine-readable contracts and promotion/evaluation objects for:
+- belief states
+- equation candidates
+- counterexamples
+- promotion decisions
+- human digital twin state
+- evidence packets
+
+## Truth-status separation
+
+Michael should keep these statuses distinct:
+- asserted truth
+- believed truth
+- candidate law
+- promoted heuristic
+- rejected hypothesis
+
+The platform should not collapse these into one undifferentiated output class.
+
+## Promotion rule
+
+A discovered equation should first become a soft rule or governed heuristic before it is ever treated as an asserted ontology law.
+
+The intended progression is:
+- candidate law
+- promoted heuristic
+- soft rule
+- constraint
+- asserted truth
+
+## Repo bindings
+
+- semantics: `ontogenesis`
+- instance plane: `gaia-world-model`
+- governance and eval: `prophet-platform`
+- execution packs: `prophet-platform-fabric-mlops-ts-suite`
+- public profile and conformance: `socioprophet-agent-standards`

--- a/docs/MICHAEL_PROMOTION_LADDER.md
+++ b/docs/MICHAEL_PROMOTION_LADDER.md
@@ -1,0 +1,43 @@
+# Michael Promotion Ladder
+
+## Purpose
+
+This note records the bounded promotion ladder for Michael artifacts.
+
+## Ladder
+
+1. `candidate_law`
+2. `promoted_heuristic`
+3. `soft_rule`
+4. `constraint`
+5. `asserted_truth`
+
+## Interpretation
+
+A candidate discovered by symbolic regression or probabilistic-relational reasoning is not immediately an asserted ontology law.
+
+It should pass through governed promotion stages where evidence, methodology, constraints, and policy all remain visible.
+
+## Required gate families
+
+Promotion should remain compatible with these gate families:
+- authorization
+- scope
+- policy
+- risk
+- evidence
+- approval
+- rollback
+
+## Minimum evidence posture
+
+A promotion decision should be backed by:
+- methodology snapshot reference
+- evidence packet reference
+- gate results
+- signers or approvals when required
+- counterexamples or constraint witnesses when applicable
+
+## Human twin boundary
+
+Promotion involving a human digital twin must remain bounded by consent, purpose, and projection restrictions. A twin is a bounded projection, not the human subject itself.

--- a/schemas/michael/belief_state.schema.json
+++ b/schemas/michael/belief_state.schema.json
@@ -1,0 +1,55 @@
+{
+  "$id": "https://socioprophet.org/schema/michael/belief_state.schema.json",
+  "type": "object",
+  "required": [
+    "kind",
+    "agent",
+    "belief_state_id",
+    "world_ref",
+    "ontology_context_ref",
+    "truth_status",
+    "engine",
+    "inputs",
+    "outputs",
+    "methodology_snapshot_ref",
+    "evidence_packet_ref",
+    "promotion_status"
+  ],
+  "properties": {
+    "kind": { "const": "belief_state" },
+    "agent": { "const": "Michael" },
+    "belief_state_id": { "type": "string" },
+    "world_ref": { "type": "string" },
+    "ontology_context_ref": { "type": "string" },
+    "truth_status": { "enum": ["believed_truth"] },
+    "engine": {
+      "type": "object",
+      "required": ["family", "version"],
+      "properties": {
+        "family": { "enum": ["psl", "problog", "deepproblog", "deepseaproblog", "scallop"] },
+        "version": { "type": "string" }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "properties": {
+        "grounded_assertions": { "type": "array", "items": { "type": "string" } },
+        "observation_records": { "type": "array", "items": { "type": "string" } },
+        "rule_templates": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "properties": {
+        "posterior_atoms": { "type": "array" },
+        "weighted_rules": { "type": "array" },
+        "hypotheses": { "type": "array" }
+      }
+    },
+    "calibration": { "type": "object" },
+    "constraints": { "type": "object" },
+    "methodology_snapshot_ref": { "type": "string" },
+    "evidence_packet_ref": { "type": "string" },
+    "promotion_status": { "enum": ["candidate", "promoted", "rejected", "held"] }
+  }
+}

--- a/schemas/michael/counterexample.schema.json
+++ b/schemas/michael/counterexample.schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "https://socioprophet.org/schema/michael/counterexample.schema.json",
+  "type": "object",
+  "required": [
+    "kind",
+    "counterexample_id",
+    "candidate_ref",
+    "target_ref",
+    "observation_ref",
+    "reason"
+  ],
+  "properties": {
+    "kind": { "const": "counterexample" },
+    "counterexample_id": { "type": "string" },
+    "candidate_ref": { "type": "string" },
+    "target_ref": { "type": "string" },
+    "observation_ref": { "type": "string" },
+    "reason": { "type": "string" },
+    "evidence_packet_ref": { "type": "string" },
+    "created_at": { "type": "string" }
+  }
+}

--- a/schemas/michael/equation_candidate.schema.json
+++ b/schemas/michael/equation_candidate.schema.json
@@ -1,0 +1,51 @@
+{
+  "$id": "https://socioprophet.org/schema/michael/equation_candidate.schema.json",
+  "type": "object",
+  "required": [
+    "kind",
+    "agent",
+    "candidate_id",
+    "truth_status",
+    "target_ref",
+    "engine",
+    "expression",
+    "fit",
+    "constraints",
+    "methodology_snapshot_ref",
+    "evidence_packet_ref",
+    "promotion_status"
+  ],
+  "properties": {
+    "kind": { "const": "equation_candidate" },
+    "agent": { "const": "Michael" },
+    "candidate_id": { "type": "string" },
+    "truth_status": { "enum": ["candidate_law"] },
+    "target_ref": { "type": "string" },
+    "engine": {
+      "type": "object",
+      "required": ["family", "version"],
+      "properties": {
+        "family": { "enum": ["pysr", "bingo", "dso"] },
+        "version": { "type": "string" }
+      }
+    },
+    "expression": {
+      "type": "object",
+      "required": ["canonical"],
+      "properties": {
+        "canonical": { "type": "string" },
+        "latex": { "type": "string" }
+      }
+    },
+    "symbols": { "type": "array" },
+    "constants": { "type": "array" },
+    "fit": { "type": "object" },
+    "stability": { "type": "object" },
+    "constraints": { "type": "object" },
+    "counterexamples": { "type": "array" },
+    "derived_soft_rules": { "type": "array" },
+    "methodology_snapshot_ref": { "type": "string" },
+    "evidence_packet_ref": { "type": "string" },
+    "promotion_status": { "enum": ["candidate", "promoted", "rejected", "held"] }
+  }
+}

--- a/schemas/michael/evidence_packet.schema.json
+++ b/schemas/michael/evidence_packet.schema.json
@@ -1,0 +1,20 @@
+{
+  "$id": "https://socioprophet.org/schema/michael/evidence_packet.schema.json",
+  "type": "object",
+  "required": [
+    "kind",
+    "evidence_packet_id",
+    "subject_ref",
+    "methodology_snapshot_ref",
+    "evidence_refs"
+  ],
+  "properties": {
+    "kind": { "const": "evidence_packet" },
+    "evidence_packet_id": { "type": "string" },
+    "subject_ref": { "type": "string" },
+    "methodology_snapshot_ref": { "type": "string" },
+    "evidence_refs": { "type": "array" },
+    "metrics": { "type": "object" },
+    "notes": { "type": "array" }
+  }
+}

--- a/schemas/michael/human_digital_twin_state.schema.json
+++ b/schemas/michael/human_digital_twin_state.schema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "https://socioprophet.org/schema/michael/human_digital_twin_state.schema.json",
+  "type": "object",
+  "required": [
+    "kind",
+    "subject_ref",
+    "twin_ref",
+    "consent_envelope_ref",
+    "projection_bounds",
+    "memory_state_ref",
+    "cognition_state_ref",
+    "observation_refs",
+    "policy_status"
+  ],
+  "properties": {
+    "kind": { "const": "human_digital_twin_state" },
+    "subject_ref": { "type": "string" },
+    "twin_ref": { "type": "string" },
+    "consent_envelope_ref": { "type": "string" },
+    "projection_bounds": {
+      "type": "object",
+      "required": ["allowed_modalities", "allowed_purposes", "retention_policy"],
+      "properties": {
+        "allowed_modalities": { "type": "array" },
+        "allowed_purposes": { "type": "array" },
+        "retention_policy": { "type": "string" }
+      }
+    },
+    "memory_state_ref": { "type": "string" },
+    "cognition_state_ref": { "type": "string" },
+    "observation_refs": { "type": "array" },
+    "belief_state_refs": { "type": "array" },
+    "candidate_law_refs": { "type": "array" },
+    "policy_status": { "enum": ["active", "restricted", "revoked"] }
+  }
+}


### PR DESCRIPTION
## Summary

Add the first Michael machine-science schema and documentation tranche to `prophet-platform`.

## Files included

- `schemas/michael/belief_state.schema.json`
- `schemas/michael/equation_candidate.schema.json`
- `schemas/michael/counterexample.schema.json`
- `schemas/michael/promotion_decision.schema.json`
- `schemas/michael/human_digital_twin_state.schema.json`
- `schemas/michael/evidence_packet.schema.json`
- `docs/MICHAEL_MACHINE_SCIENCE.md`
- `docs/MICHAEL_PROMOTION_LADDER.md`

## Why

`prophet-platform` is the governance and evaluation plane for Michael artifacts. This tranche gives it the first concrete machine-readable boundaries between believed truth, candidate law, promotion decisions, evidence packets, and bounded human digital twin state.

## Notes

This is intentionally a starter tranche. It does not yet wire these contracts into live runtime behavior, but it gives the repo the canonical schema surface needed for later eval, promotion, and artifact emission work.
