### PR TITLE
services(search): add lampstand carrier academy repository

### DIFF
--- a/services/search-orchestrator/app/repositories.py
+++ b/services/search-orchestrator/app/repositories.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
+from typing import Any
 
 from app.models import LearningSearchRecord
 
@@ -92,7 +94,73 @@ class LampstandJsonlAcademySearchRepository(AcademySearchRepository):
         self.path.write_text("", encoding="utf-8")
 
 
+class LampstandCarrierAcademySearchRepository(AcademySearchRepository):
+    def __init__(
+        self,
+        payload_dir: Path,
+        *,
+        scope_ref: str = "scope://academy/search",
+        zone_ref: str = "zone://edge",
+        topic_ref: str = "topic://academy/search",
+    ) -> None:
+        self.payload_dir = payload_dir
+        self.scope_ref = scope_ref
+        self.zone_ref = zone_ref
+        self.topic_ref = topic_ref
+        self.payload_dir.mkdir(parents=True, exist_ok=True)
+
+    def _record_path(self, record: LearningSearchRecord) -> Path:
+        safe_id = record.header.object_id.replace("/", "_").replace(":", "_")
+        return self.payload_dir / f"{safe_id}.LearningSearchRecord.json"
+
+    def _ingest_path(self, path: Path) -> dict[str, Any]:
+        try:
+            from prophet_platform_lampstand.ingest import ingest_path
+        except ModuleNotFoundError:
+            repo_root = Path(__file__).resolve().parents[3]
+            lampstand_src = repo_root / "apps" / "lampstand" / "src"
+            sys.path.insert(0, str(lampstand_src))
+            from prophet_platform_lampstand.ingest import ingest_path
+        return ingest_path(
+            file_path=str(path),
+            scope_ref=self.scope_ref,
+            service_ref="services/search-orchestrator",
+            classifiers=[
+                "source:alexandrian-academy",
+                "entity:learning-search-record",
+                "service:search-orchestrator",
+            ],
+            zone_ref=self.zone_ref,
+            topic_ref=self.topic_ref,
+        )
+
+    def ingest(self, record: LearningSearchRecord) -> LearningSearchRecord:
+        path = self._record_path(record)
+        path.write_text(json.dumps(record.model_dump(mode="json"), indent=2, sort_keys=False) + "\n", encoding="utf-8")
+        result = self._ingest_path(path)
+        path.with_suffix(".lampstand-ingest-result.json").write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return record
+
+    def list_records(self) -> list[LearningSearchRecord]:
+        records: list[LearningSearchRecord] = []
+        for path in sorted(self.payload_dir.glob("*.LearningSearchRecord.json")):
+            records.append(LearningSearchRecord.model_validate(json.loads(path.read_text(encoding="utf-8"))))
+        return records
+
+    def clear(self) -> None:
+        for path in self.payload_dir.glob("*.LearningSearchRecord.json"):
+            path.unlink()
+        for path in self.payload_dir.glob("*.lampstand-ingest-result.json"):
+            path.unlink()
+
+
 def build_academy_repository() -> AcademySearchRepository:
+    carrier_dir = os.environ.get("SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_CARRIER_DIR")
+    if carrier_dir:
+        return LampstandCarrierAcademySearchRepository(Path(carrier_dir))
     lampstand_path = os.environ.get("SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_JSONL")
     if lampstand_path:
         return LampstandJsonlAcademySearchRepository(Path(lampstand_path))

--- a/services/search-orchestrator/tests/test_academy_lampstand_carrier_repository.py
+++ b/services/search-orchestrator/tests/test_academy_lampstand_carrier_repository.py
@@ -1,0 +1,52 @@
+from app.models import AcademyRecordHeader, LearningSearchRecord
+from app.repositories import LampstandCarrierAcademySearchRepository
+
+
+def record(record_id: str = "lsr_carrier_0001") -> LearningSearchRecord:
+    return LearningSearchRecord(
+        header=AcademyRecordHeader(object_id=record_id, object_type="LearningSearchRecord"),
+        source="ALEXANDRIAN_ACADEMY",
+        entity_type="LEARNING_ACTION_EXPLANATION",
+        title="Why recommended",
+        text="Carrier ingest explanation.",
+        target_ref="llr_carrier_0001",
+        final_score=1.0,
+    )
+
+
+def test_lampstand_carrier_repository_materializes_payload_and_result(tmp_path, monkeypatch) -> None:
+    calls = []
+
+    def fake_ingest(self, path):
+        calls.append(str(path))
+        return {
+            "ok": True,
+            "carrier_ref": "carrier://test",
+            "payload_path": str(path),
+            "receipt_path": str(tmp_path / "receipt.json"),
+            "catalog_path": str(tmp_path / "catalog.json"),
+        }
+
+    monkeypatch.setattr(LampstandCarrierAcademySearchRepository, "_ingest_path", fake_ingest)
+    repo = LampstandCarrierAcademySearchRepository(tmp_path)
+    repo.ingest(record())
+
+    payloads = list(tmp_path.glob("*.LearningSearchRecord.json"))
+    results = list(tmp_path.glob("*.lampstand-ingest-result.json"))
+    assert len(payloads) == 1
+    assert len(results) == 1
+    assert calls == [str(payloads[0])]
+    assert repo.list_records()[0].source == "ALEXANDRIAN_ACADEMY"
+
+
+def test_lampstand_carrier_repository_clear_removes_payload_and_result(tmp_path, monkeypatch) -> None:
+    def fake_ingest(self, path):
+        return {"ok": True, "payload_path": str(path)}
+
+    monkeypatch.setattr(LampstandCarrierAcademySearchRepository, "_ingest_path", fake_ingest)
+    repo = LampstandCarrierAcademySearchRepository(tmp_path)
+    repo.ingest(record())
+    repo.clear()
+
+    assert list(tmp_path.glob("*.LearningSearchRecord.json")) == []
+    assert list(tmp_path.glob("*.lampstand-ingest-result.json")) == []


### PR DESCRIPTION
## Summary

Adds a true Lampstand carrier-ingestion repository mode for Academy search records.

## Scope

- Adds `LampstandCarrierAcademySearchRepository`
- Materializes each `LearningSearchRecord` as a JSON carrier payload
- Calls Lampstand's existing `ingest_path` flow to create carrier ingestion, receipts, and catalog entries
- Stores the Lampstand ingest result alongside the materialized payload
- Enables the mode via `SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_CARRIER_DIR`
- Adds tests with a monkeypatched Lampstand ingest call to prove payload/result behavior without external state

## Safety posture

- Opt-in by environment variable
- No route contract change
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback
- Existing in-memory, JSON file, and JSONL modes remain available

## Program lane

Platform search receiving side: true Lampstand carrier/receipt ingestion for Academy search records.