### PR TITLE
Add Fog Stack release seal cryptographic verification record

### DIFF
--- a/docs/FOGSTACK_RELEASE_SEAL_CRYPTOGRAPHIC_VERIFICATION.md
+++ b/docs/FOGSTACK_RELEASE_SEAL_CRYPTOGRAPHIC_VERIFICATION.md
@@ -1,0 +1,51 @@
+# Fog Stack release seal cryptographic verification
+
+This document defines the first repo-native shape for **cryptographic verification of a release seal signature**.
+
+## Goal
+
+Move from:
+- a release seal that can carry signature metadata
+- helpers that attach and verify signed-seal shape
+
+to:
+- a separate `FogStackReleaseSealCryptographicVerificationRecord` that captures the result of an actual verification step over the seal signature.
+
+## Minimal flow
+
+1. produce or obtain external verification evidence for the seal signature
+2. run `tools/emit_fogstack_release_seal_cryptographic_verification_record.py`
+3. persist the resulting record into the release evidence set
+
+## Example
+
+```bash
+python3 tools/emit_fogstack_release_seal_cryptographic_verification_record.py \
+  --verification-evidence /tmp/fogstack.access.seal.verify.json \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --seal-ref releases/seals/fogstack.access-v0.1.seal.json \
+  --signature-ref artifact://release/fogstack.access-v0.1.seal.sig \
+  --verification-tool cosign \
+  --seal-root-hash sha256:deadbeef \
+  --output /tmp/fogstack.access-v0.1.seal.crypto-verification.record.json
+```
+
+## Digest consistency rule
+
+If both of the following are present:
+- `seal_root_hash`
+- external `verified_root_hash`
+
+then the emitter computes `seal_root_hash_matches`.
+
+A mismatch should be treated as a failed cryptographic verification result even if the external tool reported pass.
+
+## What this phase does not yet provide
+
+This phase still does not provide:
+- direct invocation of external verification tools
+- CI-enforced execution
+- automatic linkage of the seal verification record into the broader trust graph
+
+Those remain later steps.

--- a/schemas/release/fogstack-release-seal-cryptographic-verification-record-v0.1.schema.json
+++ b/schemas/release/fogstack-release-seal-cryptographic-verification-record-v0.1.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-release-seal-cryptographic-verification-record-v0.1.schema.json",
+  "title": "FogStackReleaseSealCryptographicVerificationRecord",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "seal_ref",
+    "signature_ref",
+    "verification_tool",
+    "status",
+    "summary"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackReleaseSealCryptographicVerificationRecord" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+    "version": { "type": "string" },
+    "seal_ref": { "type": "string" },
+    "signature_ref": { "type": "string" },
+    "verification_tool": { "enum": ["cosign", "sigstore", "other"] },
+    "status": { "enum": ["verified", "failed", "shape-only"] },
+    "summary": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["pass", "warn", "fail"] },
+        "message": { "type": ["string", "null"] },
+        "verified_root_hash": { "type": ["string", "null"] },
+        "seal_root_hash_matches": { "type": ["boolean", "null"] },
+        "evidence_count": { "type": ["integer", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "seal_root_hash": { "type": ["string", "null"] },
+    "key_ref": { "type": ["string", "null"] },
+    "release_evidence_index_ref": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/tools/emit_fogstack_release_seal_cryptographic_verification_record.py
+++ b/tools/emit_fogstack_release_seal_cryptographic_verification_record.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Fog Stack release seal cryptographic verification record")
+    parser.add_argument("--verification-evidence", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--seal-ref", required=True)
+    parser.add_argument("--signature-ref", required=True)
+    parser.add_argument("--verification-tool", required=True, choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--seal-root-hash", default=None)
+    parser.add_argument("--key-ref", default=None)
+    parser.add_argument("--release-evidence-index-ref", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    evidence = load_json(args.verification_evidence)
+    status = evidence.get("status")
+    if status == "pass":
+        verify_status = "verified"
+    elif status == "fail":
+        verify_status = "failed"
+    else:
+        verify_status = "shape-only"
+
+    verified_root_hash = evidence.get("verified_root_hash")
+    seal_root_hash_matches = None
+    if isinstance(args.seal_root_hash, str) and isinstance(verified_root_hash, str):
+        seal_root_hash_matches = args.seal_root_hash == verified_root_hash
+        if seal_root_hash_matches is False:
+            verify_status = "failed"
+
+    record = {
+        "kind": "FogStackReleaseSealCryptographicVerificationRecord",
+        "schema_version": "v0.1",
+        "bundle_id": args.bundle_id,
+        "version": args.version,
+        "seal_ref": args.seal_ref,
+        "signature_ref": args.signature_ref,
+        "verification_tool": args.verification_tool,
+        "status": verify_status,
+        "summary": {
+            "status": status,
+            "message": evidence.get("message"),
+            "verified_root_hash": verified_root_hash,
+            "seal_root_hash_matches": seal_root_hash_matches,
+            "evidence_count": evidence.get("evidence_count"),
+        },
+        "seal_root_hash": args.seal_root_hash,
+        "key_ref": evidence.get("key_ref") or args.key_ref,
+        "release_evidence_index_ref": args.release_evidence_index_ref,
+    }
+
+    text = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the next release-seal trust tranche directly on top of current `main`:

- `schemas/release/fogstack-release-seal-cryptographic-verification-record-v0.1.schema.json`
- `tools/emit_fogstack_release_seal_cryptographic_verification_record.py`
- `docs/FOGSTACK_RELEASE_SEAL_CRYPTOGRAPHIC_VERIFICATION.md`

## Why this PR exists

The repo already has:
- release sealing
- release seal signature support

What is still missing is a dedicated machine-readable record for the result of cryptographic verification over the seal signature, including root-hash consistency.

This PR adds that record shape and the emitter for it.

## Not in this PR

- direct invocation of external verification tools
- CI-enforced execution
- automatic linkage of the seal verification record into the broader trust graph

Those remain later steps.
