### PR TITLE
services(search): add live policy fabric evaluator adapter

### DIFF
--- a/services/search-orchestrator/app/policy.py
+++ b/services/search-orchestrator/app/policy.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import json
+import os
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 
 from app.models import LearningSearchRecord
@@ -63,13 +67,7 @@ def build_academy_visibility_decision(
         "subject_ref": f"academy://search-record/{record.header.object_id}",
         "action_ref": "action://academy/search/read",
         "decision": "allow" if allowed else "deny",
-        "required_gates": [
-            "actor_gate",
-            "workspace_gate",
-            "jurisdiction_gate",
-            "policy_tag_gate",
-            "evidence_gate",
-        ],
+        "required_gates": ["actor_gate", "workspace_gate", "jurisdiction_gate", "policy_tag_gate", "evidence_gate"],
         "reason": reason,
         "visibility_scope": {
             "actor_id": context.actor_id,
@@ -79,6 +77,20 @@ def build_academy_visibility_decision(
         "validation_evidence": [str(request["request_id"])],
         "notes": ["Local fallback decision shaped to Policy Fabric Academy visibility contract."],
     }
+
+
+def policy_decision_from_payload(payload: dict[str, object], request: dict[str, object]) -> AcademyPolicyDecision:
+    decision_value = payload.get("decision")
+    allowed = decision_value == "allow"
+    reason = str(payload.get("reason", "policy fabric decision"))
+    decision_id = str(payload.get("policy_decision_id", "unknown"))
+    return AcademyPolicyDecision(
+        allowed=allowed,
+        reason=reason,
+        decision_ref=f"policy-fabric://decision/{decision_id}",
+        request=request,
+        decision=payload,
+    )
 
 
 class LocalVisibilityPolicyEvaluator(AcademyPolicyEvaluator):
@@ -106,13 +118,40 @@ class LocalVisibilityPolicyEvaluator(AcademyPolicyEvaluator):
             context=context,
             record=record,
         )
-        return AcademyPolicyDecision(
-            allowed=allowed,
-            reason=reason,
-            decision_ref=f"policy-fabric://decision/{decision['policy_decision_id']}",
-            request=request,
-            decision=decision,
+        return policy_decision_from_payload(decision, request)
+
+
+class HttpPolicyFabricEvaluator(AcademyPolicyEvaluator):
+    def __init__(self, endpoint: str, fallback: AcademyPolicyEvaluator | None = None, timeout_seconds: float = 2.0) -> None:
+        self.endpoint = endpoint
+        self.fallback = fallback or LocalVisibilityPolicyEvaluator()
+        self.timeout_seconds = timeout_seconds
+
+    def decide(self, record: LearningSearchRecord, context: AcademyPolicyContext) -> AcademyPolicyDecision:
+        request_payload = build_academy_visibility_request(record, context)
+        body = json.dumps(request_payload).encode("utf-8")
+        request = urllib.request.Request(
+            self.endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
         )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            if not isinstance(payload, dict):
+                raise ValueError("Policy Fabric response must be a JSON object")
+            return policy_decision_from_payload(payload, request_payload)
+        except (OSError, urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError, json.JSONDecodeError):
+            return self.fallback.decide(record, context)
 
 
-academy_policy_evaluator: AcademyPolicyEvaluator = LocalVisibilityPolicyEvaluator()
+def build_academy_policy_evaluator() -> AcademyPolicyEvaluator:
+    endpoint = os.environ.get("SEARCH_ORCHESTRATOR_POLICY_FABRIC_ENDPOINT")
+    if endpoint:
+        timeout = float(os.environ.get("SEARCH_ORCHESTRATOR_POLICY_FABRIC_TIMEOUT_SECONDS", "2.0"))
+        return HttpPolicyFabricEvaluator(endpoint=endpoint, timeout_seconds=timeout)
+    return LocalVisibilityPolicyEvaluator()
+
+
+academy_policy_evaluator: AcademyPolicyEvaluator = build_academy_policy_evaluator()

--- a/services/search-orchestrator/tests/test_policy_http.py
+++ b/services/search-orchestrator/tests/test_policy_http.py
@@ -1,0 +1,109 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from app.models import AcademyRecordHeader, LearningSearchRecord
+from app.policy import AcademyPolicyContext, HttpPolicyFabricEvaluator, LocalVisibilityPolicyEvaluator
+
+
+def record() -> LearningSearchRecord:
+    return LearningSearchRecord(
+        header=AcademyRecordHeader(object_id="lsr_http_policy_0001", object_type="LearningSearchRecord"),
+        source="ALEXANDRIAN_ACADEMY",
+        entity_type="LEARNING_ACTION_EXPLANATION",
+        title="Why recommended",
+        text="Policy Fabric checked explanation.",
+        target_ref="llr_http_policy_0001",
+        final_score=1.0,
+    )
+
+
+class FakePolicyHandler(BaseHTTPRequestHandler):
+    response_payload = {
+        "policy_decision_id": "academy_visibility_decision_http_0001",
+        "request_id": "academy_visibility_request_http_0001",
+        "subject_ref": "academy://search-record/lsr_http_policy_0001",
+        "action_ref": "action://academy/search/read",
+        "decision": "allow",
+        "required_gates": ["actor_gate"],
+        "reason": "fake policy allow",
+        "validation_evidence": ["fake"],
+    }
+    received = None
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        FakePolicyHandler.received = json.loads(self.rfile.read(length).decode("utf-8"))
+        body = json.dumps(FakePolicyHandler.response_payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+
+def start_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), FakePolicyHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def test_http_policy_fabric_evaluator_uses_remote_allow_decision() -> None:
+    FakePolicyHandler.received = None
+    FakePolicyHandler.response_payload = {
+        "policy_decision_id": "academy_visibility_decision_http_allow",
+        "request_id": "academy_visibility_request_http_allow",
+        "subject_ref": "academy://search-record/lsr_http_policy_0001",
+        "action_ref": "action://academy/search/read",
+        "decision": "allow",
+        "required_gates": ["actor_gate"],
+        "reason": "fake policy allow",
+        "validation_evidence": ["fake"],
+    }
+    server, thread = start_server()
+    try:
+        evaluator = HttpPolicyFabricEvaluator(f"http://127.0.0.1:{server.server_port}/decide")
+        decision = evaluator.decide(record(), AcademyPolicyContext(actor_id="user-1"))
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+    assert decision.allowed
+    assert decision.decision_ref == "policy-fabric://decision/academy_visibility_decision_http_allow"
+    assert FakePolicyHandler.received["action"] == "academy.search.read"
+
+
+def test_http_policy_fabric_evaluator_uses_remote_deny_decision() -> None:
+    FakePolicyHandler.response_payload = {
+        "policy_decision_id": "academy_visibility_decision_http_deny",
+        "request_id": "academy_visibility_request_http_deny",
+        "subject_ref": "academy://search-record/lsr_http_policy_0001",
+        "action_ref": "action://academy/search/read",
+        "decision": "deny",
+        "required_gates": ["actor_gate"],
+        "reason": "fake policy deny",
+        "validation_evidence": ["fake"],
+    }
+    server, thread = start_server()
+    try:
+        evaluator = HttpPolicyFabricEvaluator(f"http://127.0.0.1:{server.server_port}/decide")
+        decision = evaluator.decide(record(), AcademyPolicyContext(actor_id="user-1"))
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+    assert not decision.allowed
+    assert decision.reason == "fake policy deny"
+
+
+def test_http_policy_fabric_evaluator_falls_back_on_connection_failure() -> None:
+    evaluator = HttpPolicyFabricEvaluator(
+        "http://127.0.0.1:1/decide",
+        fallback=LocalVisibilityPolicyEvaluator(),
+        timeout_seconds=0.01,
+    )
+    decision = evaluator.decide(record(), AcademyPolicyContext(actor_id="user-1"))
+    assert decision.allowed
+    assert decision.reason == "no visibility constraints"


### PR DESCRIPTION
## Summary

Adds an endpoint-explicit Policy Fabric HTTP evaluator adapter for Academy search visibility decisions.

## Scope

- Adds `HttpPolicyFabricEvaluator`
- Selects it only when `SEARCH_ORCHESTRATOR_POLICY_FABRIC_ENDPOINT` is configured
- Keeps `LocalVisibilityPolicyEvaluator` as the fallback
- Adds bounded timeout via `SEARCH_ORCHESTRATOR_POLICY_FABRIC_TIMEOUT_SECONDS`
- Adds fake-server tests for remote allow, remote deny, and connection-failure fallback

## Integration

The adapter posts the Policy Fabric-shaped Academy visibility request to the configured endpoint and consumes the Policy Fabric-shaped decision response. When no endpoint is configured, behavior remains local-only.

## Safety posture

- Endpoint-explicit
- Timeout-bounded
- Local fallback preserved
- No route contract change
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback

## Program lane

Live Policy Fabric evaluator adapter for Academy search visibility.