### PR TITLE
Add Fog Stack release seal verification runner

### DIFF
--- a/docs/FOGSTACK_RELEASE_SEAL_VERIFICATION_EXECUTION.md
+++ b/docs/FOGSTACK_RELEASE_SEAL_VERIFICATION_EXECUTION.md
@@ -1,0 +1,54 @@
+# Fog Stack release seal verification execution
+
+This document defines the first repo-native execution wrapper for external verification of a signed Fog Stack release seal.
+
+## Goal
+
+Move from:
+- a release seal
+- seal signature support
+- a cryptographic verification record shape
+
+to:
+- one wrapper that runs an external verifier command, captures its output, normalizes it, compares the verified root hash to the seal's `release_root_hash`, and emits the seal cryptographic verification record.
+
+## Minimal flow
+
+1. provide the release seal and bundle identity/version
+2. invoke `tools/run_external_fogstack_release_seal_verifier.py`
+3. pass the external verifier command after `--`
+4. the wrapper captures stdout JSON, normalizes it, and emits the seal cryptographic verification record
+
+## Example
+
+```bash
+python3 tools/run_external_fogstack_release_seal_verifier.py \
+  --tool cosign \
+  --seal releases/seals/fogstack.access-v0.1.seal.json \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --signature-ref artifact://release/fogstack.access-v0.1.seal.sig \
+  --evidence-output /tmp/fogstack.access.seal.verify.json \
+  --record-output /tmp/fogstack.access.seal.crypto-verification.record.json \
+  -- cosign verify-blob --signature artifact://release/fogstack.access-v0.1.seal.sig seal.json
+```
+
+## Root-hash consistency rule
+
+If both of the following are present:
+- `seal.release_root_hash`
+- external `verified_root_hash`
+
+then the runner passes both into the seal cryptographic verification record emitter, which computes `seal_root_hash_matches`.
+
+A mismatch should be treated as a failed verification result even if the external tool reported pass.
+
+## What this phase does not yet provide
+
+This wrapper still does not:
+- interpret every verifier's output format automatically beyond the minimal normalization logic
+- enforce CI execution
+- mutate the wider trust graph after verification
+- guarantee registry resolution of signature references
+
+Those remain later steps.

--- a/tools/run_external_fogstack_release_seal_verifier.py
+++ b/tools/run_external_fogstack_release_seal_verifier.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run an external verifier for a Fog Stack release seal and emit the cryptographic verification record")
+    parser.add_argument("--tool", required=True, choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--seal", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--signature-ref", required=True)
+    parser.add_argument("--evidence-output", required=True, type=Path)
+    parser.add_argument("--record-output", required=True, type=Path)
+    parser.add_argument("--key-ref", default=None)
+    parser.add_argument("--release-evidence-index-ref", default=None)
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="External verifier command, e.g. cosign verify ...")
+    args = parser.parse_args()
+
+    if not args.command:
+        raise SystemExit("ERR: external verifier command is required after '--'")
+
+    seal = load_json(args.seal)
+    seal_root_hash = seal.get("release_root_hash")
+
+    proc = subprocess.run(args.command, capture_output=True, text=True)
+
+    if proc.stdout.strip():
+        try:
+            raw = json.loads(proc.stdout)
+        except Exception:
+            raw = {
+                "status": "fail" if proc.returncode else "warn",
+                "message": "external verifier stdout was not JSON",
+                "verified_root_hash": None,
+                "evidence_count": 0,
+                "key_ref": args.key_ref,
+            }
+    else:
+        raw = {
+            "status": "fail" if proc.returncode else "warn",
+            "message": proc.stderr.strip() or "external verifier produced no stdout",
+            "verified_root_hash": None,
+            "evidence_count": 0,
+            "key_ref": args.key_ref,
+        }
+
+    evidence = {
+        "status": raw.get("status") or (raw.get("summary") or {}).get("status") or "unknown",
+        "message": raw.get("message") or (raw.get("summary") or {}).get("message"),
+        "verified_root_hash": raw.get("verified_root_hash") or (raw.get("summary") or {}).get("verified_root_hash"),
+        "evidence_count": raw.get("evidence_count") or (raw.get("summary") or {}).get("evidence_count"),
+        "key_ref": raw.get("key_ref") or args.key_ref,
+    }
+    args.evidence_output.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+
+    emit_cmd = [
+        "python3",
+        "tools/emit_fogstack_release_seal_cryptographic_verification_record.py",
+        "--verification-evidence", str(args.evidence_output),
+        "--bundle-id", args.bundle_id,
+        "--version", args.version,
+        "--seal-ref", str(args.seal),
+        "--signature-ref", args.signature_ref,
+        "--verification-tool", args.tool,
+        "--output", str(args.record_output),
+    ]
+    if isinstance(seal_root_hash, str):
+        emit_cmd.extend(["--seal-root-hash", seal_root_hash])
+    if args.key_ref:
+        emit_cmd.extend(["--key-ref", args.key_ref])
+    if args.release_evidence_index_ref:
+        emit_cmd.extend(["--release-evidence-index-ref", args.release_evidence_index_ref])
+
+    emit = subprocess.run(emit_cmd)
+    if emit.returncode != 0:
+        raise SystemExit(emit.returncode)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the next release-seal trust tranche directly on top of current `main`:

- `tools/run_external_fogstack_release_seal_verifier.py`
- `docs/FOGSTACK_RELEASE_SEAL_VERIFICATION_EXECUTION.md`

## Why this PR exists

The repo already has:
- release sealing
- release seal signature support
- a cryptographic verification record shape for the release seal signature

What is still missing is a repo-native execution wrapper that runs an external verifier command, captures its output, normalizes it, compares the verified root hash against the seal, and emits the seal cryptographic verification record.

## Not in this PR

- fully generic parsing for every verifier output format
- CI enforcement
- automatic trust-graph mutation after verification
- registry resolution of signature references

Those remain later steps.
