### PR TITLE
services(search): document academy modes and expose safe config

### DIFF
--- a/services/search-orchestrator/README.md
+++ b/services/search-orchestrator/README.md
@@ -17,6 +17,8 @@ It should eventually:
 
 - `schemas/search/sherlock_search_request.schema.json`
 - `schemas/search/sherlock_search_result.schema.json`
+- `SocioProphet/alexandrian-academy` `LearningSearchRecord`
+- `SocioProphet/policy-fabric` Academy search visibility request and decision contracts
 
 ## Cross-repo boundaries
 
@@ -24,6 +26,41 @@ It should eventually:
 - local desktop indexing remains in `SocioProphet/lampstand`
 - memory recall remains in `SocioProphet/memory-mesh`
 - ontology/alignment remains in `SocioProphet/ontogenesis`
+- Academy learning-loop explanation ownership remains in `SocioProphet/alexandrian-academy`
+- Academy visibility decisions are governed by `SocioProphet/policy-fabric`
+
+## Academy bridge modes
+
+Academy search-record storage is selected by environment variable. The default remains in-memory and has no persistence side effect.
+
+| Mode | Environment variable | Behavior |
+| --- | --- | --- |
+| in-memory | none | Process-local Academy records only. |
+| json-file | `SEARCH_ORCHESTRATOR_ACADEMY_STORE` | Stores all Academy records in one JSON array file. |
+| lampstand-jsonl | `SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_JSONL` | Stores Academy records as one JSONL file for Lampstand-style indexing. |
+| lampstand-carrier | `SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_CARRIER_DIR` | Materializes records as carrier payloads and uses Lampstand `ingest_path` to emit payload, event, receipt, catalog, and publication-request artifacts. |
+
+Academy visibility is policy-gated. By default, the service uses the local fallback evaluator. If `SEARCH_ORCHESTRATOR_POLICY_FABRIC_ENDPOINT` is set, the service posts Policy Fabric-shaped Academy visibility requests to that endpoint and falls back to local evaluation on timeout or failure.
+
+| Variable | Purpose |
+| --- | --- |
+| `SEARCH_ORCHESTRATOR_POLICY_FABRIC_ENDPOINT` | Optional explicit Policy Fabric decision endpoint. |
+| `SEARCH_ORCHESTRATOR_POLICY_FABRIC_TIMEOUT_SECONDS` | Optional timeout in seconds; default is `2.0`. |
+
+The live Policy Fabric adapter is endpoint-explicit. No endpoint is called unless configured.
+
+## Runtime introspection
+
+`GET /v1/search/debug/config` returns non-secret runtime mode information:
+
+- active Academy repository mode;
+- which storage modes are configured as booleans;
+- current Academy record count;
+- active Academy policy evaluator mode;
+- whether a Policy Fabric endpoint is configured, without returning the endpoint URL;
+- timeout value.
+
+The debug endpoint deliberately does not return paths, URLs, or secrets.
 
 ## First implementation posture
 
@@ -31,3 +68,5 @@ The first implementation should be narrow and inspectable:
 - one request shape
 - one result shape
 - one platform-side execution seam
+- explicit Academy bridge modes
+- safe runtime introspection without secret disclosure

--- a/services/search-orchestrator/app/main.py
+++ b/services/search-orchestrator/app/main.py
@@ -2,6 +2,8 @@ from fastapi import FastAPI
 
 from app.backends import ingest_academy_record, query_academy_records, query_platform_workspace
 from app.models import LearningSearchRecord, SearchRequest, SearchResult, SearchResultScore
+from app.policy import describe_academy_policy_evaluator
+from app.repositories import describe_academy_repository
 
 app = FastAPI(title="search-orchestrator", version="0.1.0")
 
@@ -9,6 +11,16 @@ app = FastAPI(title="search-orchestrator", version="0.1.0")
 @app.get("/healthz")
 def healthz() -> dict[str, str]:
     return {"status": "ok", "service": "search-orchestrator"}
+
+
+@app.get("/v1/search/debug/config")
+def debug_config() -> dict[str, object]:
+    return {
+        "service": "search-orchestrator",
+        "academy_repository": describe_academy_repository(),
+        "academy_policy": describe_academy_policy_evaluator(),
+        "redaction": "paths, URLs, and secrets are not returned",
+    }
 
 
 @app.post("/v1/search/ingest/academy", response_model=LearningSearchRecord)

--- a/services/search-orchestrator/app/policy.py
+++ b/services/search-orchestrator/app/policy.py
@@ -29,6 +29,9 @@ class AcademyPolicyEvaluator:
     def decide(self, record: LearningSearchRecord, context: AcademyPolicyContext) -> AcademyPolicyDecision:
         raise NotImplementedError
 
+    def mode(self) -> str:
+        return self.__class__.__name__
+
 
 def build_academy_visibility_request(record: LearningSearchRecord, context: AcademyPolicyContext) -> dict[str, object]:
     visibility = record.visibility
@@ -120,6 +123,9 @@ class LocalVisibilityPolicyEvaluator(AcademyPolicyEvaluator):
         )
         return policy_decision_from_payload(decision, request)
 
+    def mode(self) -> str:
+        return "local-fallback"
+
 
 class HttpPolicyFabricEvaluator(AcademyPolicyEvaluator):
     def __init__(self, endpoint: str, fallback: AcademyPolicyEvaluator | None = None, timeout_seconds: float = 2.0) -> None:
@@ -145,6 +151,9 @@ class HttpPolicyFabricEvaluator(AcademyPolicyEvaluator):
         except (OSError, urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError, json.JSONDecodeError):
             return self.fallback.decide(record, context)
 
+    def mode(self) -> str:
+        return "http-policy-fabric"
+
 
 def build_academy_policy_evaluator() -> AcademyPolicyEvaluator:
     endpoint = os.environ.get("SEARCH_ORCHESTRATOR_POLICY_FABRIC_ENDPOINT")
@@ -152,6 +161,16 @@ def build_academy_policy_evaluator() -> AcademyPolicyEvaluator:
         timeout = float(os.environ.get("SEARCH_ORCHESTRATOR_POLICY_FABRIC_TIMEOUT_SECONDS", "2.0"))
         return HttpPolicyFabricEvaluator(endpoint=endpoint, timeout_seconds=timeout)
     return LocalVisibilityPolicyEvaluator()
+
+
+def describe_academy_policy_evaluator() -> dict[str, object]:
+    return {
+        "mode": academy_policy_evaluator.mode(),
+        "configured": {
+            "policy_fabric_endpoint": bool(os.environ.get("SEARCH_ORCHESTRATOR_POLICY_FABRIC_ENDPOINT")),
+            "timeout_seconds": float(os.environ.get("SEARCH_ORCHESTRATOR_POLICY_FABRIC_TIMEOUT_SECONDS", "2.0")),
+        },
+    }
 
 
 academy_policy_evaluator: AcademyPolicyEvaluator = build_academy_policy_evaluator()

--- a/services/search-orchestrator/app/repositories.py
+++ b/services/search-orchestrator/app/repositories.py
@@ -19,6 +19,9 @@ class AcademySearchRepository:
     def clear(self) -> None:
         raise NotImplementedError
 
+    def mode(self) -> str:
+        return self.__class__.__name__
+
 
 class InMemoryAcademySearchRepository(AcademySearchRepository):
     def __init__(self) -> None:
@@ -33,6 +36,9 @@ class InMemoryAcademySearchRepository(AcademySearchRepository):
 
     def clear(self) -> None:
         self._records.clear()
+
+    def mode(self) -> str:
+        return "in-memory"
 
 
 class JsonFileAcademySearchRepository(AcademySearchRepository):
@@ -64,6 +70,9 @@ class JsonFileAcademySearchRepository(AcademySearchRepository):
     def clear(self) -> None:
         self._save([])
 
+    def mode(self) -> str:
+        return "json-file"
+
 
 class LampstandJsonlAcademySearchRepository(AcademySearchRepository):
     def __init__(self, path: Path) -> None:
@@ -92,6 +101,9 @@ class LampstandJsonlAcademySearchRepository(AcademySearchRepository):
 
     def clear(self) -> None:
         self.path.write_text("", encoding="utf-8")
+
+    def mode(self) -> str:
+        return "lampstand-jsonl"
 
 
 class LampstandCarrierAcademySearchRepository(AcademySearchRepository):
@@ -156,6 +168,9 @@ class LampstandCarrierAcademySearchRepository(AcademySearchRepository):
         for path in self.payload_dir.glob("*.lampstand-ingest-result.json"):
             path.unlink()
 
+    def mode(self) -> str:
+        return "lampstand-carrier"
+
 
 def build_academy_repository() -> AcademySearchRepository:
     carrier_dir = os.environ.get("SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_CARRIER_DIR")
@@ -168,6 +183,18 @@ def build_academy_repository() -> AcademySearchRepository:
     if path:
         return JsonFileAcademySearchRepository(Path(path))
     return InMemoryAcademySearchRepository()
+
+
+def describe_academy_repository() -> dict[str, object]:
+    return {
+        "mode": academy_repository.mode(),
+        "configured": {
+            "json_file": bool(os.environ.get("SEARCH_ORCHESTRATOR_ACADEMY_STORE")),
+            "lampstand_jsonl": bool(os.environ.get("SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_JSONL")),
+            "lampstand_carrier": bool(os.environ.get("SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_CARRIER_DIR")),
+        },
+        "record_count": len(academy_repository.list_records()),
+    }
 
 
 academy_repository: AcademySearchRepository = build_academy_repository()

--- a/services/search-orchestrator/tests/test_debug_config.py
+++ b/services/search-orchestrator/tests/test_debug_config.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_debug_config_reports_modes_without_paths_or_urls() -> None:
+    response = client.get("/v1/search/debug/config")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["service"] == "search-orchestrator"
+    assert payload["academy_repository"]["mode"] in {
+        "in-memory",
+        "json-file",
+        "lampstand-jsonl",
+        "lampstand-carrier",
+    }
+    assert payload["academy_policy"]["mode"] in {"local-fallback", "http-policy-fabric"}
+    text = str(payload)
+    assert "http://" not in text
+    assert "https://" not in text
+    assert "/tmp/" not in text
+    assert "SEARCH_ORCHESTRATOR_POLICY_FABRIC_ENDPOINT" not in text


### PR DESCRIPTION
## Summary

Adds operator documentation and a safe runtime config endpoint for the Search Orchestrator Academy bridge modes.

## Scope

- Documents Academy repository modes: in-memory, JSON file, Lampstand JSONL, Lampstand carrier
- Documents live Policy Fabric endpoint configuration and timeout
- Adds `GET /v1/search/debug/config`
- Reports active repository and policy modes without returning paths, URLs, or secrets
- Adds tests for the debug config endpoint redaction behavior

## Safety posture

- No route behavior change for ingest/query
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback
- Debug endpoint redacts paths, URLs, and secrets

## Program lane

Search Orchestrator operator readiness: Academy bridge mode documentation and safe runtime introspection.