### PR TITLE
Add Fog Stack release seal artifact linking

### DIFF
--- a/docs/FOGSTACK_RELEASE_SEAL_ARTIFACT_LINKING.md
+++ b/docs/FOGSTACK_RELEASE_SEAL_ARTIFACT_LINKING.md
@@ -1,0 +1,35 @@
+# Fog Stack release seal artifact linking
+
+This document defines the first repo-native backlinking step for release seal artifacts.
+
+## Goal
+
+Move from separate release seal artifacts to artifacts that explicitly point to each other:
+- the release seal
+- the release seal cryptographic verification record
+- the release evidence index
+
+## Minimal flow
+
+1. emit the release seal
+2. emit the release seal cryptographic verification record
+3. emit or prepare the release evidence index
+4. run `tools/link_fogstack_release_seal_artifacts.py`
+
+## Example
+
+Run the linker with the seal file, the seal crypto-verification record file, and the evidence index file.
+
+## What this phase provides
+
+- `release_evidence_index_ref` on the seal
+- `release_seal_cryptographic_verification_record_ref` on the seal
+- `release_seal_ref` and `release_seal_cryptographic_verification_record_ref` on the evidence index
+
+## What this phase does not yet provide
+
+- CI automation of backlink insertion
+- cryptographic verification of linked refs
+- publication of the linked artifact set
+
+Those remain later steps.

--- a/schemas/release/fogstack-release-evidence-index-v0.1.schema.json
+++ b/schemas/release/fogstack-release-evidence-index-v0.1.schema.json
@@ -22,6 +22,8 @@
     "validation_record_ref": { "type": "string" },
     "signature_verification_record_ref": { "type": "string" },
     "signature_trust_record_ref": { "type": "string" },
+    "release_seal_ref": { "type": ["string", "null"] },
+    "release_seal_cryptographic_verification_record_ref": { "type": ["string", "null"] },
     "notes": { "type": ["string", "null"] }
   },
   "additionalProperties": false

--- a/schemas/release/fogstack-release-seal-v0.1.schema.json
+++ b/schemas/release/fogstack-release-seal-v0.1.schema.json
@@ -43,6 +43,8 @@
       },
       "additionalProperties": false
     },
+    "release_evidence_index_ref": { "type": ["string", "null"] },
+    "release_seal_cryptographic_verification_record_ref": { "type": ["string", "null"] },
     "notes": { "type": ["string", "null"] }
   },
   "additionalProperties": false

--- a/tools/link_fogstack_release_seal_artifacts.py
+++ b/tools/link_fogstack_release_seal_artifacts.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Link Fog Stack release seal artifacts by inserting backlink refs")
+    parser.add_argument("--seal", required=True, type=Path)
+    parser.add_argument("--seal-crypto-record", required=True, type=Path)
+    parser.add_argument("--evidence-index", required=True, type=Path)
+    args = parser.parse_args()
+
+    seal = load_json(args.seal)
+    seal_crypto = load_json(args.seal_crypto_record)
+    evidence_index = load_json(args.evidence_index)
+
+    seal["release_evidence_index_ref"] = str(args.evidence_index)
+    seal["release_seal_cryptographic_verification_record_ref"] = str(args.seal_crypto_record)
+
+    seal_crypto["release_evidence_index_ref"] = str(args.evidence_index)
+
+    evidence_index["release_seal_ref"] = str(args.seal)
+    evidence_index["release_seal_cryptographic_verification_record_ref"] = str(args.seal_crypto_record)
+
+    write_json(args.seal, seal)
+    write_json(args.seal_crypto_record, seal_crypto)
+    write_json(args.evidence_index, evidence_index)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the next release-seal trust tranche directly on top of current `main`:

- updated `schemas/release/fogstack-release-evidence-index-v0.1.schema.json`
- updated `schemas/release/fogstack-release-seal-v0.1.schema.json`
- `tools/link_fogstack_release_seal_artifacts.py`
- `docs/FOGSTACK_RELEASE_SEAL_ARTIFACT_LINKING.md`

## Why this PR exists

The repo already has:
- release sealing
- release seal cryptographic verification records
- a release evidence index

What is still missing is explicit backlinking between the seal, the seal cryptographic verification record, and the evidence index.

This PR lets those artifacts reference each other directly, keeping the seal side of the trust graph aligned with the broader Fog Stack evidence graph.

## Not in this PR

- CI automation of backlink insertion
- cryptographic verification of linked refs
- publication of the linked artifact set

Those remain later steps.
