### PR TITLE
services(search): populate normalized result actions

### DIFF
--- a/services/search-orchestrator/app/main.py
+++ b/services/search-orchestrator/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 
 from app.backends import ingest_academy_record, query_academy_records, query_platform_workspace
-from app.models import LearningSearchRecord, SearchRequest, SearchResult, SearchResultScore
+from app.models import LearningSearchRecord, SearchRequest, SearchResult, SearchResultScore, SearchResultActions
 
 app = FastAPI(title="search-orchestrator", version="0.1.0")
 
@@ -31,6 +31,12 @@ def search_query(body: SearchRequest) -> dict[str, object]:
             snippet=item.snippet,
             path_or_uri=item.path_or_uri,
             score=SearchResultScore(final=item.final_score),
+            actions=SearchResultActions(
+                open_cloud=item.open_cloud,
+                summarize=item.summarize,
+                create_task=item.create_task,
+                draft_reply=item.draft_reply,
+            ),
         )
         results.append(result.model_dump())
 
@@ -43,6 +49,12 @@ def search_query(body: SearchRequest) -> dict[str, object]:
             snippet=item.snippet,
             path_or_uri=item.path_or_uri,
             score=SearchResultScore(final=item.final_score),
+            actions=SearchResultActions(
+                open_cloud=item.open_cloud,
+                summarize=item.summarize,
+                create_task=item.create_task,
+                draft_reply=item.draft_reply,
+            ),
         )
         results.append(result.model_dump())
 

--- a/services/search-orchestrator/tests/test_platform_scope_result.py
+++ b/services/search-orchestrator/tests/test_platform_scope_result.py
@@ -24,3 +24,7 @@ def test_cloud_workspace_scope_returns_platform_result() -> None:
     assert payload['results'][0]['entity_type'] == 'DOCUMENT'
     assert payload['results'][0]['snippet'] == 'Matched workspace content for query: budget'
     assert payload['results'][0]['path_or_uri'] == 'workspace://documents/budget'
+    assert payload['results'][0]['actions']['open_cloud'] is True
+    assert payload['results'][0]['actions']['summarize'] is True
+    assert payload['results'][0]['actions']['create_task'] is True
+    assert payload['results'][0]['actions']['draft_reply'] is False


### PR DESCRIPTION
## Summary

Add the next search-orchestrator follow-on on top of the merged academy/policy-aware search runtime.

Files:
- `services/search-orchestrator/app/main.py`
- `services/search-orchestrator/tests/test_platform_scope_result.py`

## Why

The current `main` search-orchestrator already has:
- typed request/result models
- academy ingestion and visibility filtering
- backend/provider seam
- richer snippet and URI fields

This follow-on populates the normalized `actions` field on returned results and adds direct coverage for those action flags.
