### PR TITLE
Add Fog Stack release proof pipeline runner

### DIFF
--- a/docs/FOGSTACK_RELEASE_PROOF_PIPELINE.md
+++ b/docs/FOGSTACK_RELEASE_PROOF_PIPELINE.md
@@ -1,0 +1,38 @@
+# Fog Stack release proof pipeline
+
+This document defines the first repo-native **release proof pipeline** for the seal side of Fog Stack.
+
+## Goal
+
+Move from separate helpers for:
+- external release seal verification execution
+- release seal cryptographic verification record emission
+- release seal artifact backlinking
+
+to:
+- one wrapper that runs the external seal verifier, emits the seal cryptographic verification record, and then links the resulting artifacts into the seal-side trust graph.
+
+## Minimal flow
+
+1. provide the release seal, bundle identity/version, signature reference, and evidence index
+2. invoke `tools/run_fogstack_release_proof_pipeline.py`
+3. pass the external verifier command after `--`
+4. the wrapper emits the seal cryptographic verification record and updates the seal-side backlinks
+
+## Example
+
+Use the wrapper with a seal file, a signature reference, output paths for evidence and the cryptographic verification record, an evidence index path, and the external verifier command after `--`.
+
+## What this phase provides
+
+- one orchestrated proof step for the seal side of the trust graph
+- automatic invocation of the seal verification wrapper
+- automatic backlink insertion after the cryptographic record is produced
+
+## What this phase does not yet provide
+
+- CI enforcement of the proof pipeline
+- mutation of the non-seal side of the wider trust graph
+- registry publication of the resulting proof set
+
+Those remain later steps.

--- a/tools/run_fogstack_release_proof_pipeline.py
+++ b/tools/run_fogstack_release_proof_pipeline.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the Fog Stack release proof pipeline for a sealed bundle")
+    parser.add_argument("--tool", required=True, choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--seal", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--signature-ref", required=True)
+    parser.add_argument("--evidence-output", required=True, type=Path)
+    parser.add_argument("--seal-crypto-record", required=True, type=Path)
+    parser.add_argument("--evidence-index", required=True, type=Path)
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="External seal verifier command, e.g. cosign verify ...")
+    args = parser.parse_args()
+
+    if not args.command:
+        raise SystemExit("ERR: external seal verifier command is required after '--'")
+
+    run_cmd = [
+        "python3",
+        "tools/run_external_fogstack_release_seal_verifier.py",
+        "--tool", args.tool,
+        "--seal", str(args.seal),
+        "--bundle-id", args.bundle_id,
+        "--version", args.version,
+        "--signature-ref", args.signature_ref,
+        "--evidence-output", str(args.evidence_output),
+        "--record-output", str(args.seal_crypto_record),
+        "--",
+    ] + args.command
+    proc = subprocess.run(run_cmd)
+    if proc.returncode != 0:
+        raise SystemExit(proc.returncode)
+
+    link_cmd = [
+        "python3",
+        "tools/link_fogstack_release_seal_artifacts.py",
+        "--seal", str(args.seal),
+        "--seal-crypto-record", str(args.seal_crypto_record),
+        "--evidence-index", str(args.evidence_index),
+    ]
+    link = subprocess.run(link_cmd)
+    if link.returncode != 0:
+        raise SystemExit(link.returncode)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the next release-seal trust tranche directly on top of current `main`:

- `tools/run_fogstack_release_proof_pipeline.py`
- `docs/FOGSTACK_RELEASE_PROOF_PIPELINE.md`

## Why this PR exists

The repo already has:
- release seal verification execution
- release seal cryptographic verification records
- release seal artifact linking

What is still missing is one repo-native wrapper that executes the seal verifier path and then mutates the seal-side trust graph in one step.

This PR adds that orchestrating helper.

## Not in this PR

- CI enforcement of the proof pipeline
- mutation of the non-seal side of the wider trust graph
- registry publication of the resulting proof set

Those remain later steps.
