### PR TITLE
Add Fog Stack release proof CI workflow

### DIFF
--- a/.github/workflows/fogstack-release-proof.yml
+++ b/.github/workflows/fogstack-release-proof.yml
@@ -1,0 +1,127 @@
+name: FogStack Release Proof
+
+on:
+  pull_request:
+    paths:
+      - "catalog/fogstack-packs-v0.1.yaml"
+      - "releases/**"
+      - "schemas/release/**"
+      - "tools/*fogstack*"
+      - "tools/tests/test_fogstack_release_proof_pipeline.py"
+      - "docs/FOGSTACK_*.md"
+      - ".github/workflows/fogstack-release-proof.yml"
+  push:
+    branches: [main]
+    paths:
+      - "catalog/fogstack-packs-v0.1.yaml"
+      - "releases/**"
+      - "schemas/release/**"
+      - "tools/*fogstack*"
+      - "tools/tests/test_fogstack_release_proof_pipeline.py"
+      - "docs/FOGSTACK_*.md"
+      - ".github/workflows/fogstack-release-proof.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  release-proof:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Run release proof tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_release_proof_pipeline.py
+
+      - name: Smoke release proof pipeline
+        run: |
+          mkdir -p artifacts/release-proof
+
+          python3 tools/emit_fogstack_release_seal.py \
+            --bundle-id fogstack.access \
+            --version 0.1.0 \
+            --artifact manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+            --artifact validation releases/evidence/fogstack.access-v0.1.validation.record.json \
+            --output artifacts/release-proof/fogstack.access.seal.json
+
+          python3 tools/attach_fogstack_release_seal_signature.py \
+            --seal artifacts/release-proof/fogstack.access.seal.json \
+            --signature-type cosign \
+            --signature-ref artifact://release/fogstack.access-v0.1.seal.sig \
+            --output artifacts/release-proof/fogstack.access.seal.json
+
+          python3 tools/emit_fogstack_release_evidence_index.py \
+            --bundle-id fogstack.access \
+            --version 0.1.0 \
+            --manifest-ref releases/manifests/fogstack.access-v0.1.manifest.json \
+            --validation-record-ref releases/evidence/fogstack.access-v0.1.validation.record.json \
+            --signature-verification-record-ref releases/evidence/fogstack.access-v0.1.signature-verification.record.json \
+            --signature-trust-record-ref releases/evidence/fogstack.access-v0.1.signature-trust.record.json \
+            --output artifacts/release-proof/fogstack.access.evidence.index.json
+
+          SEAL_HASH=$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+          data = json.loads(Path('artifacts/release-proof/fogstack.access.seal.json').read_text(encoding='utf-8'))
+          print(data['release_root_hash'])
+          PY
+          )
+
+          cat > artifacts/release-proof/mock_seal_verify.py <<'PY'
+          import json, os
+          print(json.dumps({
+              "status": "pass",
+              "verified_root_hash": os.environ["SEAL_HASH"],
+              "evidence_count": 1,
+          }))
+          PY
+
+          SEAL_HASH="$SEAL_HASH" python3 tools/run_fogstack_release_proof_pipeline.py \
+            --tool cosign \
+            --seal artifacts/release-proof/fogstack.access.seal.json \
+            --bundle-id fogstack.access \
+            --version 0.1.0 \
+            --signature-ref artifact://release/fogstack.access-v0.1.seal.sig \
+            --evidence-output artifacts/release-proof/fogstack.access.seal.verify.json \
+            --seal-crypto-record artifacts/release-proof/fogstack.access.seal.crypto-verification.record.json \
+            --evidence-index artifacts/release-proof/fogstack.access.evidence.index.json \
+            -- python3 artifacts/release-proof/mock_seal_verify.py
+
+      - name: Assert proof outputs linked
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          seal = json.loads(Path('artifacts/release-proof/fogstack.access.seal.json').read_text(encoding='utf-8'))
+          crypto = json.loads(Path('artifacts/release-proof/fogstack.access.seal.crypto-verification.record.json').read_text(encoding='utf-8'))
+          index = json.loads(Path('artifacts/release-proof/fogstack.access.evidence.index.json').read_text(encoding='utf-8'))
+
+          assert crypto['status'] == 'verified', crypto
+          assert crypto['summary']['seal_root_hash_matches'] is True, crypto
+          assert seal['release_evidence_index_ref'].endswith('fogstack.access.evidence.index.json'), seal
+          assert seal['release_seal_cryptographic_verification_record_ref'].endswith('fogstack.access.seal.crypto-verification.record.json'), seal
+          assert index['release_seal_ref'].endswith('fogstack.access.seal.json'), index
+          assert index['release_seal_cryptographic_verification_record_ref'].endswith('fogstack.access.seal.crypto-verification.record.json'), index
+          print('FogStack release proof pipeline smoke passed.')
+          PY
+
+      - name: Upload release proof artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fogstack-release-proof-artifacts
+          path: artifacts/release-proof/
+          if-no-files-found: error

--- a/tools/tests/test_fogstack_release_proof_pipeline.py
+++ b/tools/tests/test_fogstack_release_proof_pipeline.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_release_proof_pipeline_links_seal_artifacts(tmp_path: Path) -> None:
+    seal = tmp_path / "fogstack.access.seal.json"
+    seal_root_hash = "sha256:test-seal-root"
+    _write_json(
+        seal,
+        {
+            "kind": "FogStackReleaseSeal",
+            "schema_version": "v0.1",
+            "bundle_id": "fogstack.access",
+            "version": "0.1.0",
+            "algorithm": "sha256",
+            "release_root_hash": seal_root_hash,
+            "artifact_hashes": [],
+            "signed": True,
+            "signature": {"type": "cosign", "ref": "artifact://release/fogstack.access-v0.1.seal.sig"},
+        },
+    )
+
+    evidence_index = tmp_path / "fogstack.access.evidence.index.json"
+    _write_json(
+        evidence_index,
+        {
+            "kind": "FogStackReleaseEvidenceIndex",
+            "schema_version": "v0.1",
+            "bundle_id": "fogstack.access",
+            "version": "0.1.0",
+            "manifest_ref": "releases/manifests/fogstack.access-v0.1.manifest.json",
+            "validation_record_ref": "releases/evidence/fogstack.access-v0.1.validation.record.json",
+            "signature_verification_record_ref": "releases/evidence/fogstack.access-v0.1.signature-verification.record.json",
+            "signature_trust_record_ref": "releases/evidence/fogstack.access-v0.1.signature-trust.record.json",
+            "notes": None,
+        },
+    )
+
+    mock_verify = tmp_path / "mock_verify.py"
+    mock_verify.write_text(
+        "import json, os\n"
+        "print(json.dumps({\"status\": \"pass\", \"verified_root_hash\": os.environ['SEAL_HASH'], \"evidence_count\": 1}))\n",
+        encoding="utf-8",
+    )
+
+    evidence_output = tmp_path / "fogstack.access.seal.verify.json"
+    seal_crypto_record = tmp_path / "fogstack.access.seal.crypto-verification.record.json"
+
+    env = os.environ.copy()
+    env["SEAL_HASH"] = seal_root_hash
+
+    cmd = [
+        sys.executable,
+        "tools/run_fogstack_release_proof_pipeline.py",
+        "--tool",
+        "cosign",
+        "--seal",
+        str(seal),
+        "--bundle-id",
+        "fogstack.access",
+        "--version",
+        "0.1.0",
+        "--signature-ref",
+        "artifact://release/fogstack.access-v0.1.seal.sig",
+        "--evidence-output",
+        str(evidence_output),
+        "--seal-crypto-record",
+        str(seal_crypto_record),
+        "--evidence-index",
+        str(evidence_index),
+        "--",
+        sys.executable,
+        str(mock_verify),
+    ]
+    subprocess.run(cmd, check=True, env=env)
+
+    crypto = _read_json(seal_crypto_record)
+    assert crypto["status"] == "verified"
+    assert crypto["summary"]["seal_root_hash_matches"] is True
+
+    seal_after = _read_json(seal)
+    assert seal_after["release_evidence_index_ref"] == str(evidence_index)
+    assert seal_after["release_seal_cryptographic_verification_record_ref"] == str(seal_crypto_record)
+
+    index_after = _read_json(evidence_index)
+    assert index_after["release_seal_ref"] == str(seal)
+    assert index_after["release_seal_cryptographic_verification_record_ref"] == str(seal_crypto_record)


### PR DESCRIPTION
## Summary

This PR adds the next Fog Stack release-proof tranche directly on top of current `main`:

- `.github/workflows/fogstack-release-proof.yml`
- `tools/tests/test_fogstack_release_proof_pipeline.py`

## Why this PR exists

The repo already has:
- release sealing
- release seal signature support
- release seal cryptographic verification records
- a release proof pipeline runner

What is still missing is CI-backed execution that proves the release-proof path actually works end to end and produces linked proof artifacts.

This PR adds:
- an end-to-end pytest for the release proof pipeline helper
- a GitHub Actions workflow that emits a seal, signs it in-shape, runs the proof pipeline with a mock verifier, and asserts the linked outputs

## Not in this PR

- real cosign/sigstore network or registry integration
- CI mutation of the non-seal side of the wider trust graph
- publication of the resulting proof set beyond artifact upload

Those remain later steps.
