### PR TITLE
telemetry(runtime): add runtime skeleton for transparent telemetry slice

### DIFF
--- a/.github/workflows/telemetry-runtime-slice.yml
+++ b/.github/workflows/telemetry-runtime-slice.yml
@@ -1,0 +1,51 @@
+name: telemetry-runtime-slice
+
+on:
+  pull_request:
+    paths:
+      - 'telemetry/**'
+      - 'apps/evidence-receipts/**'
+      - 'apps/evidence-console/**'
+      - 'tools/demo_transparent_telemetry_runtime.py'
+      - 'tools/tests/test_demo_transparent_telemetry_runtime.py'
+      - '.github/workflows/telemetry-runtime-slice.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'telemetry/**'
+      - 'apps/evidence-receipts/**'
+      - 'apps/evidence-console/**'
+      - 'tools/demo_transparent_telemetry_runtime.py'
+      - 'tools/tests/test_demo_transparent_telemetry_runtime.py'
+      - '.github/workflows/telemetry-runtime-slice.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  telemetry-runtime-slice:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install runtime slice dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install \
+            -r apps/evidence-receipts/requirements.txt \
+            -r apps/evidence-receipts/requirements-test.txt \
+            -r apps/evidence-console/requirements.txt \
+            -r apps/evidence-console/requirements-test.txt
+      - name: Run telemetry runtime slice tests
+        run: |
+          python -m pytest -q \
+            apps/evidence-receipts/tests/test_telemetry_runtime.py \
+            apps/evidence-receipts/tests/test_telemetry_runtime_receipts.py \
+            apps/evidence-receipts/tests/test_telemetry_runtime_policy_replay.py \
+            apps/evidence-console/tests/test_telemetry_view.py \
+            apps/evidence-console/tests/test_http_main.py \
+            apps/evidence-console/tests/test_telemetry_route_end_to_end.py \
+            apps/evidence-console/tests/test_telemetry_route_high_privacy.py \
+            tools/tests/test_demo_transparent_telemetry_runtime.py

--- a/apps/evidence-console/app/main.py
+++ b/apps/evidence-console/app/main.py
@@ -33,6 +33,11 @@ def recent_events(limit: int = 25, per_service_limit: int = 15) -> dict:
     return service.get_recent_events_view(limit=limit, per_service_limit=per_service_limit)
 
 
+@app.get("/v1/console/telemetry")
+def recent_telemetry(limit: int = 25, service_name: str = "telemetry-runtime") -> dict:
+    return service.get_recent_telemetry_view(service_name=service_name, limit=limit)
+
+
 @app.get("/console/evidence", response_class=HTMLResponse)
 def console_ui() -> str:
     return """<!doctype html>
@@ -67,6 +72,10 @@ def console_ui() -> str:
     <h2>Recent Events</h2>
     <pre id=\"recent\">loading...</pre>
   </section>
+  <section>
+    <h2>Recent Telemetry</h2>
+    <pre id=\"telemetry\">loading...</pre>
+  </section>
 
 <script>
 async function load(id, url) {
@@ -83,6 +92,7 @@ load('frontier', '/v1/console/frontier');
 load('model', '/v1/console/models/model.semantic-stack.2026-04-05');
 load('coverage', '/v1/console/coverage');
 load('recent', '/v1/console/recent-events');
+load('telemetry', '/v1/console/telemetry');
 </script>
 </body>
 </html>"""

--- a/apps/evidence-console/app/service.py
+++ b/apps/evidence-console/app/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from . import client
+from . import client, telemetry_view
 
 
 def _parse_created_at(value: str | None) -> datetime:
@@ -80,3 +80,7 @@ def get_recent_events_view(limit: int = 25, per_service_limit: int = 15) -> dict
         "services": services,
         "items": items,
     }
+
+
+def get_recent_telemetry_view(service_name: str = "telemetry-runtime", limit: int = 25) -> dict[str, Any]:
+    return telemetry_view.get_recent_telemetry_view(service=service_name, limit=limit)

--- a/apps/evidence-console/app/telemetry_view.py
+++ b/apps/evidence-console/app/telemetry_view.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+
+from . import client
+
+
+def get_recent_telemetry_view(service: str = "telemetry-runtime", limit: int = 25) -> dict[str, Any]:
+    items = client.get_recent_receipts(service=service, limit=limit)
+    return {
+        "service": service,
+        "items": items,
+    }

--- a/apps/evidence-console/tests/test_http_main.py
+++ b/apps/evidence-console/tests/test_http_main.py
@@ -45,6 +45,14 @@ def test_recent_events_route(monkeypatch):
     assert resp.json() == expected
 
 
+def test_recent_telemetry_route(monkeypatch):
+    expected = {"service": "telemetry-runtime", "items": [{"event_type": "reliability.conversation.stream.completed"}]}
+    monkeypatch.setattr(main.service, "get_recent_telemetry_view", lambda service_name="telemetry-runtime", limit=25: expected)
+    resp = client.get("/v1/console/telemetry?limit=10&service_name=telemetry-runtime")
+    assert resp.status_code == 200
+    assert resp.json() == expected
+
+
 def test_console_ui_contains_fetch_targets():
     resp = client.get("/console/evidence")
     assert resp.status_code == 200
@@ -54,3 +62,4 @@ def test_console_ui_contains_fetch_targets():
     assert "/v1/console/models/model.semantic-stack.2026-04-05" in body
     assert "/v1/console/coverage" in body
     assert "/v1/console/recent-events" in body
+    assert "/v1/console/telemetry" in body

--- a/apps/evidence-console/tests/test_telemetry_route_end_to_end.py
+++ b/apps/evidence-console/tests/test_telemetry_route_end_to_end.py
@@ -71,10 +71,10 @@ def _read_recent_from_state(tmp_path: Path, service: str, limit: int = 25) -> li
     for receipt_path in receipt_dir.glob("*.receipt.json"):
         correlation_id = receipt_path.name[: -len(".receipt.json")]
         receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
-        event_path = event_dir / f"{{correlation_id}}.event.json"
-        event = json.loads(event_path.read_text(encoding="utf-8")) if event_path.exists() else {{}}
-        payload_path = payload_dir / f"{{correlation_id}}.payload.json"
-        items.append({{
+        event_path = event_dir / f"{correlation_id}.event.json"
+        event = json.loads(event_path.read_text(encoding="utf-8")) if event_path.exists() else {}
+        payload_path = payload_dir / f"{correlation_id}.payload.json"
+        items.append({
             "service": service,
             "correlation_id": correlation_id,
             "created_at": receipt.get("created_at") or event.get("created_at"),
@@ -82,10 +82,10 @@ def _read_recent_from_state(tmp_path: Path, service: str, limit: int = 25) -> li
             "action": receipt.get("action"),
             "event_type": event.get("event_type"),
             "subject_ref": receipt.get("subject_ref") or event.get("subject_ref"),
-            "receipt_ref": f"file://{{receipt_path.resolve()}}",
-            "event_ref": f"file://{{event_path.resolve()}}" if event_path.exists() else None,
-            "payload_ref": f"file://{{payload_path.resolve()}}" if payload_path.exists() else None,
-        }})
+            "receipt_ref": f"file://{receipt_path.resolve()}",
+            "event_ref": f"file://{event_path.resolve()}" if event_path.exists() else None,
+            "payload_ref": f"file://{payload_path.resolve()}" if payload_path.exists() else None,
+        })
     items.sort(key=lambda item: datetime.fromisoformat(str(item["created_at"]).replace("Z", "+00:00")), reverse=True)
     return items[:limit]
 
@@ -106,7 +106,7 @@ def test_telemetry_route_reflects_blocked_optional_analytics_and_allowed_reliabi
     items = payload["items"]
     assert len(items) == 2
 
-    by_event = {{item["event_type"]: item for item in items}}
+    by_event = {item["event_type"]: item for item in items}
     assert by_event["analytics.turn.rendered.summary"]["status"] == "blocked"
     assert by_event["analytics.turn.rendered.summary"]["action"] == "BLOCK"
     assert by_event["reliability.conversation.stream.completed"]["status"] == "recorded"

--- a/apps/evidence-console/tests/test_telemetry_route_end_to_end.py
+++ b/apps/evidence-console/tests/test_telemetry_route_end_to_end.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = ROOT.parents[1]
+EVIDENCE_RECEIPTS_ROOT = REPO_ROOT / "apps" / "evidence-receipts"
+sys.path.insert(0, str(ROOT))
+
+import app.main as main  # type: ignore
+
+client = TestClient(main.app)
+
+
+def _emit_reference_bundles(tmp_path: Path) -> None:
+    script = f'''
+import sys
+sys.path.insert(0, {str(EVIDENCE_RECEIPTS_ROOT)!r})
+from app.telemetry_runtime import emit_event_bundle
+
+emit_event_bundle(
+    "telemetry-runtime",
+    "analytics.turn.rendered.summary",
+    {{
+        "local_turn_id": "turn-analytics-001",
+        "turn_has_citations": True,
+        "citations_rendered_count": 2,
+        "source_footer_seen": True,
+        "citation_panel_opened_during_turn": False,
+        "subject_ref": "turn://turn-analytics-001",
+        "created_at": "2026-04-25T14:10:00+00:00",
+    }},
+    control_snapshot={{"product_analytics": "disabled"}},
+)
+
+emit_event_bundle(
+    "telemetry-runtime",
+    "reliability.conversation.stream.completed",
+    {{
+        "request_id": "req-reliability-001",
+        "local_turn_id": "turn-reliability-001",
+        "duration_ms_bucket": 4200,
+        "stream_transport": "sse_like",
+        "completion_status": "clean_final_message",
+        "subject_ref": "turn://turn-reliability-001",
+        "created_at": "2026-04-25T14:11:00+00:00",
+    }},
+    control_snapshot={{"product_analytics": "disabled"}},
+)
+'''
+    env = os.environ.copy()
+    env["SOCIOPROFIT_STATE_HOME"] = str(tmp_path)
+    subprocess.run([sys.executable, "-c", script], cwd=REPO_ROOT, check=True, env=env)
+
+
+def _read_recent_from_state(tmp_path: Path, service: str, limit: int = 25) -> list[dict]:
+    base = tmp_path / "prophet-platform"
+    receipt_dir = base / "receipts" / service
+    event_dir = base / "events" / service
+    payload_dir = base / "payloads" / service
+    items: list[dict] = []
+    if not receipt_dir.exists():
+        return items
+    for receipt_path in receipt_dir.glob("*.receipt.json"):
+        correlation_id = receipt_path.name[: -len(".receipt.json")]
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        event_path = event_dir / f"{{correlation_id}}.event.json"
+        event = json.loads(event_path.read_text(encoding="utf-8")) if event_path.exists() else {{}}
+        payload_path = payload_dir / f"{{correlation_id}}.payload.json"
+        items.append({{
+            "service": service,
+            "correlation_id": correlation_id,
+            "created_at": receipt.get("created_at") or event.get("created_at"),
+            "status": receipt.get("status"),
+            "action": receipt.get("action"),
+            "event_type": event.get("event_type"),
+            "subject_ref": receipt.get("subject_ref") or event.get("subject_ref"),
+            "receipt_ref": f"file://{{receipt_path.resolve()}}",
+            "event_ref": f"file://{{event_path.resolve()}}" if event_path.exists() else None,
+            "payload_ref": f"file://{{payload_path.resolve()}}" if payload_path.exists() else None,
+        }})
+    items.sort(key=lambda item: datetime.fromisoformat(str(item["created_at"]).replace("Z", "+00:00")), reverse=True)
+    return items[:limit]
+
+
+def test_telemetry_route_reflects_blocked_optional_analytics_and_allowed_reliability(monkeypatch, tmp_path):
+    _emit_reference_bundles(tmp_path)
+
+    def recent(service: str, limit: int = 25):
+        return _read_recent_from_state(tmp_path, service=service, limit=limit)
+
+    monkeypatch.setattr(main.service.telemetry_view.client, "get_recent_receipts", recent)
+    monkeypatch.setattr(main.service.client, "get_recent_receipts", recent)
+
+    resp = client.get("/v1/console/telemetry?service_name=telemetry-runtime&limit=10")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["service"] == "telemetry-runtime"
+    items = payload["items"]
+    assert len(items) == 2
+
+    by_event = {{item["event_type"]: item for item in items}}
+    assert by_event["analytics.turn.rendered.summary"]["status"] == "blocked"
+    assert by_event["analytics.turn.rendered.summary"]["action"] == "BLOCK"
+    assert by_event["reliability.conversation.stream.completed"]["status"] == "recorded"
+    assert by_event["reliability.conversation.stream.completed"]["action"] == "TRANSFORM_ALLOW"

--- a/apps/evidence-console/tests/test_telemetry_route_high_privacy.py
+++ b/apps/evidence-console/tests/test_telemetry_route_high_privacy.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = ROOT.parents[1]
+EVIDENCE_RECEIPTS_ROOT = REPO_ROOT / "apps" / "evidence-receipts"
+sys.path.insert(0, str(ROOT))
+
+import app.main as main  # type: ignore
+
+client = TestClient(main.app)
+
+
+def _emit_high_privacy_bundle(tmp_path: Path) -> None:
+    script = f'''
+import sys
+sys.path.insert(0, {str(EVIDENCE_RECEIPTS_ROOT)!r})
+from app.telemetry_runtime import emit_event_bundle
+
+emit_event_bundle(
+    "telemetry-runtime",
+    "analytics.citations.rendered.summary",
+    {{
+        "local_turn_id": "turn-high-privacy-route-001",
+        "citations_rendered_count": 4,
+        "enhanced_citations_present": True,
+        "sources_footer_present": True,
+        "subject_ref": "turn://turn-high-privacy-route-001",
+        "created_at": "2026-04-25T14:30:00+00:00",
+    }},
+    control_snapshot={{"product_analytics": "high_privacy"}},
+)
+'''
+    env = os.environ.copy()
+    env["SOCIOPROFIT_STATE_HOME"] = str(tmp_path)
+    subprocess.run([sys.executable, "-c", script], cwd=REPO_ROOT, check=True, env=env)
+
+
+def _read_recent_from_state(tmp_path: Path, service: str, limit: int = 25) -> list[dict]:
+    base = tmp_path / "prophet-platform"
+    receipt_dir = base / "receipts" / service
+    event_dir = base / "events" / service
+    payload_dir = base / "payloads" / service
+    items: list[dict] = []
+    if not receipt_dir.exists():
+        return items
+    for receipt_path in receipt_dir.glob("*.receipt.json"):
+        correlation_id = receipt_path.name[: -len(".receipt.json")]
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        event_path = event_dir / f"{correlation_id}.event.json"
+        event = json.loads(event_path.read_text(encoding="utf-8")) if event_path.exists() else {}
+        payload_path = payload_dir / f"{correlation_id}.payload.json"
+        items.append({
+            "service": service,
+            "correlation_id": correlation_id,
+            "created_at": receipt.get("created_at") or event.get("created_at"),
+            "status": receipt.get("status"),
+            "action": receipt.get("action"),
+            "event_type": event.get("event_type"),
+            "subject_ref": receipt.get("subject_ref") or event.get("subject_ref"),
+            "receipt_ref": f"file://{receipt_path.resolve()}",
+            "event_ref": f"file://{event_path.resolve()}" if event_path.exists() else None,
+            "payload_ref": f"file://{payload_path.resolve()}" if payload_path.exists() else None,
+        })
+    items.sort(key=lambda item: datetime.fromisoformat(str(item["created_at"]).replace("Z", "+00:00")), reverse=True)
+    return items[:limit]
+
+
+def test_telemetry_route_reflects_high_privacy_block(monkeypatch, tmp_path):
+    _emit_high_privacy_bundle(tmp_path)
+
+    def recent(service: str, limit: int = 25):
+        return _read_recent_from_state(tmp_path, service=service, limit=limit)
+
+    monkeypatch.setattr(main.service.telemetry_view.client, "get_recent_receipts", recent)
+    monkeypatch.setattr(main.service.client, "get_recent_receipts", recent)
+
+    resp = client.get("/v1/console/telemetry?service_name=telemetry-runtime&limit=10")
+    assert resp.status_code == 200
+    payload = resp.json()
+    items = payload["items"]
+    assert len(items) == 1
+    item = items[0]
+    assert item["event_type"] == "analytics.citations.rendered.summary"
+    assert item["status"] == "blocked"
+    assert item["action"] == "BLOCK"

--- a/apps/evidence-console/tests/test_telemetry_view.py
+++ b/apps/evidence-console/tests/test_telemetry_view.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import app.telemetry_view as telemetry_view  # type: ignore
+
+
+def test_get_recent_telemetry_view(monkeypatch):
+    expected_items = [
+        {
+            "service": "telemetry-runtime",
+            "correlation_id": "corr-123",
+            "event_type": "reliability.conversation.stream.completed",
+            "status": "recorded",
+        }
+    ]
+    monkeypatch.setattr(telemetry_view.client, "get_recent_receipts", lambda service, limit=25: expected_items)
+    payload = telemetry_view.get_recent_telemetry_view(service="telemetry-runtime", limit=7)
+    assert payload["service"] == "telemetry-runtime"
+    assert payload["items"] == expected_items

--- a/apps/evidence-receipts/app/telemetry_runtime.py
+++ b/apps/evidence-receipts/app/telemetry_runtime.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from . import store
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TELEMETRY_ROOT = REPO_ROOT / "telemetry"
+MANIFESTS_DIR = TELEMETRY_ROOT / "manifests"
+CONTROLS_PATH = TELEMETRY_ROOT / "controls" / "global_controls.json"
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_manifest(event_type: str) -> dict[str, Any]:
+    path = MANIFESTS_DIR / f"{event_type}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"unknown telemetry manifest: {event_type}")
+    return _read_json(path)
+
+
+def load_controls() -> dict[str, Any]:
+    if not CONTROLS_PATH.exists():
+        return {"controls": []}
+    return _read_json(CONTROLS_PATH)
+
+
+def _default_control_state_for_plane(plane: str) -> str:
+    controls = load_controls().get("controls", [])
+    for control in controls:
+        if plane in control.get("applies_to_planes", []):
+            return str(control.get("default_state", "enabled"))
+    return "enabled"
+
+
+def _control_state_for_plane(plane: str, control_snapshot: dict[str, str] | None) -> str:
+    controls = load_controls().get("controls", [])
+    for control in controls:
+        if plane in control.get("applies_to_planes", []):
+            control_id = str(control.get("control_id"))
+            if control_snapshot and control_id in control_snapshot:
+                return str(control_snapshot[control_id])
+            return str(control.get("default_state", "enabled"))
+    return _default_control_state_for_plane(plane)
+
+
+def _to_milliseconds(raw_value: Any) -> float | None:
+    if isinstance(raw_value, (int, float)):
+        return float(raw_value)
+    return None
+
+
+def _bucket_duration(value_ms: float, allowed_values: list[str]) -> str:
+    def parse_unit(raw: str) -> float:
+        raw = raw.strip().lower()
+        if raw.endswith("ms"):
+            return float(raw[:-2])
+        if raw.endswith("s"):
+            return float(raw[:-1]) * 1000.0
+        return float(raw)
+
+    for label in allowed_values:
+        token = label.lower()
+        if token.startswith("lt_"):
+            upper = parse_unit(token.removeprefix("lt_"))
+            if value_ms < upper:
+                return label
+        elif token.startswith("gt_"):
+            lower = parse_unit(token.removeprefix("gt_"))
+            if value_ms > lower:
+                return label
+        elif "_to_" in token:
+            lower_raw, upper_raw = token.split("_to_", 1)
+            lower = parse_unit(lower_raw)
+            upper = parse_unit(upper_raw)
+            if lower <= value_ms < upper:
+                return label
+        elif token.endswith("s") or token.endswith("ms"):
+            threshold = parse_unit(token)
+            if value_ms <= threshold:
+                return label
+    return allowed_values[-1] if allowed_values else str(int(value_ms))
+
+
+def _transform_field(spec: dict[str, Any], value: Any) -> Any:
+    transform = str(spec.get("transform", "none"))
+    if transform in {"none", "aggregate_only"}:
+        return value
+    if transform == "hash":
+        return hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:16]
+    if transform == "truncate":
+        return str(value)[:32]
+    if transform == "bucket":
+        numeric = _to_milliseconds(value)
+        allowed = list(spec.get("allowed_values", []))
+        if numeric is None or not allowed:
+            return str(value)
+        return _bucket_duration(numeric, allowed)
+    if transform == "drop":
+        return None
+    return value
+
+
+def _integrity_hash(payload: dict[str, Any]) -> str:
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def reduce_event(
+    event_type: str,
+    payload: dict[str, Any],
+    *,
+    control_snapshot: dict[str, str] | None = None,
+    policy_version: str = "telemetry-policy-v0.1",
+) -> dict[str, Any]:
+    manifest = load_manifest(event_type)
+    created_at = str(payload.get("created_at") or _utcnow_iso())
+    plane = str(manifest["plane"])
+    control_state = _control_state_for_plane(plane, control_snapshot)
+
+    reduced_fields: dict[str, Any] = {}
+    transformed_fields: list[str] = []
+    missing_required: list[str] = []
+
+    for field in manifest.get("fields", []):
+        name = str(field["name"])
+        if name not in payload:
+            if field.get("required"):
+                missing_required.append(name)
+            continue
+        transformed = _transform_field(field, payload[name])
+        if transformed is not None:
+            reduced_fields[name] = transformed
+        if str(field.get("transform", "none")) not in {"none", "aggregate_only"}:
+            transformed_fields.append(name)
+
+    blocked_reason = None
+    if missing_required:
+        action = "BLOCK"
+        blocked_reason = f"missing_required_fields:{','.join(sorted(missing_required))}"
+    elif manifest.get("essential") is False and control_state in {"disabled", "high_privacy"}:
+        action = "BLOCK"
+        blocked_reason = "disabled_by_user"
+    else:
+        action = "TRANSFORM_ALLOW" if transformed_fields else "ALLOW"
+
+    destinations = [] if action == "BLOCK" else list(manifest.get("destinations", []))
+    subject_ref = str(payload.get("subject_ref") or f"telemetry://{event_type}")
+    retention_days = int(manifest.get("retention_days", 1))
+    retention_deadline = (
+        datetime.fromisoformat(created_at.replace("Z", "+00:00")) + timedelta(days=retention_days)
+    ).isoformat()
+
+    outcome = {
+        "event": event_type,
+        "plane": plane,
+        "manifest_version": str(manifest.get("version", "1.0.0")),
+        "policy_version": policy_version,
+        "control_snapshot": control_snapshot or {},
+        "control_state": control_state,
+        "action": action,
+        "blocked_reason": blocked_reason,
+        "transformed_fields": sorted(set(transformed_fields)),
+        "destinations": destinations,
+        "created_at": created_at,
+        "retention_deadline": retention_deadline,
+        "subject_ref": subject_ref,
+        "reduced_fields": reduced_fields,
+    }
+    return outcome
+
+
+def emit_event_bundle(
+    service: str,
+    event_type: str,
+    payload: dict[str, Any],
+    *,
+    control_snapshot: dict[str, str] | None = None,
+    policy_version: str = "telemetry-policy-v0.1",
+) -> dict[str, Any]:
+    correlation_id = str(payload.get("correlation_id") or uuid.uuid4().hex)
+    outcome = reduce_event(
+        event_type,
+        payload,
+        control_snapshot=control_snapshot,
+        policy_version=policy_version,
+    )
+
+    layout = store.resolve_layout(service)
+    layout.payload_dir.mkdir(parents=True, exist_ok=True)
+    layout.event_dir.mkdir(parents=True, exist_ok=True)
+    layout.receipt_dir.mkdir(parents=True, exist_ok=True)
+    if layout.catalog_file is not None:
+        layout.catalog_file.parent.mkdir(parents=True, exist_ok=True)
+
+    payload_path = layout.payload_dir / f"{correlation_id}.payload.json"
+    event_path = layout.event_dir / f"{correlation_id}.event.json"
+    receipt_path = layout.receipt_dir / f"{correlation_id}.receipt.json"
+
+    payload_doc = {
+        "event": event_type,
+        "plane": outcome["plane"],
+        "fields": outcome["reduced_fields"],
+        "control_state": outcome["control_state"],
+        "destinations": outcome["destinations"],
+    }
+    payload_path.write_text(json.dumps(payload_doc, indent=2) + "\n", encoding="utf-8")
+
+    event_doc = {
+        "event_type": event_type,
+        "plane": outcome["plane"],
+        "created_at": outcome["created_at"],
+        "subject_ref": outcome["subject_ref"],
+        "policy_action": outcome["action"],
+        "payload_ref": f"file://{payload_path.resolve()}",
+    }
+    event_path.write_text(json.dumps(event_doc, indent=2) + "\n", encoding="utf-8")
+
+    receipt_doc = {
+        "receipt_id": f"rcpt_{correlation_id}",
+        "status": "blocked" if outcome["action"] == "BLOCK" else "recorded",
+        "action": outcome["action"],
+        "subject_ref": outcome["subject_ref"],
+        "created_at": outcome["created_at"],
+        "retention_deadline": outcome["retention_deadline"],
+        "integrity_hash": _integrity_hash(payload_doc),
+        "plane": outcome["plane"],
+        "event_type": event_type,
+        "destinations": outcome["destinations"],
+        "blocked_reason": outcome["blocked_reason"],
+        "transformed_fields": outcome["transformed_fields"],
+    }
+    receipt_path.write_text(json.dumps(receipt_doc, indent=2) + "\n", encoding="utf-8")
+
+    catalog_entry = {
+        "service": service,
+        "correlation_id": correlation_id,
+        "event_type": event_type,
+        "plane": outcome["plane"],
+        "created_at": outcome["created_at"],
+        "status": receipt_doc["status"],
+        "action": receipt_doc["action"],
+        "subject_ref": receipt_doc["subject_ref"],
+        "receipt_ref": f"file://{receipt_path.resolve()}",
+        "event_ref": f"file://{event_path.resolve()}",
+        "payload_ref": f"file://{payload_path.resolve()}",
+    }
+    if layout.catalog_file is not None:
+        with layout.catalog_file.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(catalog_entry) + "\n")
+
+    return {
+        "service": service,
+        "correlation_id": correlation_id,
+        "outcome": outcome,
+        "catalog_entry": catalog_entry,
+        "receipt": receipt_doc,
+        "event": event_doc,
+        "payload": payload_doc,
+    }

--- a/apps/evidence-receipts/tests/test_telemetry_runtime.py
+++ b/apps/evidence-receipts/tests/test_telemetry_runtime.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import app.telemetry_runtime as telemetry_runtime  # type: ignore
+
+
+def test_reduce_event_blocks_optional_analytics_when_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    payload = {
+        "local_turn_id": "turn-123",
+        "citations_rendered_count": 4,
+        "enhanced_citations_present": True,
+        "sources_footer_present": True,
+        "subject_ref": "turn://turn-123",
+        "created_at": "2026-04-25T13:30:00+00:00",
+    }
+    result = telemetry_runtime.emit_event_bundle(
+        "telemetry-runtime",
+        "analytics.citations.rendered.summary",
+        payload,
+        control_snapshot={"product_analytics": "disabled"},
+    )
+    assert result["outcome"]["action"] == "BLOCK"
+    assert result["receipt"]["status"] == "blocked"
+    assert result["receipt"]["blocked_reason"] == "disabled_by_user"
+    assert result["catalog_entry"]["service"] == "telemetry-runtime"
+
+
+def test_reduce_event_allows_reliability_when_analytics_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    payload = {
+        "request_id": "req-123",
+        "local_turn_id": "turn-123",
+        "duration_ms_bucket": 6400,
+        "stream_transport": "sse_like",
+        "completion_status": "clean_final_message",
+        "subject_ref": "turn://turn-123",
+        "created_at": "2026-04-25T13:31:00+00:00",
+    }
+    result = telemetry_runtime.emit_event_bundle(
+        "telemetry-runtime",
+        "reliability.conversation.stream.completed",
+        payload,
+        control_snapshot={"product_analytics": "disabled"},
+    )
+    assert result["outcome"]["action"] == "TRANSFORM_ALLOW"
+    assert "request_id" in result["outcome"]["transformed_fields"]
+    assert "local_turn_id" in result["outcome"]["transformed_fields"]
+    assert result["payload"]["fields"]["duration_ms_bucket"] == "5s_to_10s"
+    assert result["receipt"]["status"] == "recorded"
+
+
+def test_manifest_loader_raises_for_unknown_event():
+    try:
+        telemetry_runtime.load_manifest("does.not.exist")
+    except FileNotFoundError:
+        return
+    raise AssertionError("expected FileNotFoundError for unknown manifest")

--- a/apps/evidence-receipts/tests/test_telemetry_runtime_policy_replay.py
+++ b/apps/evidence-receipts/tests/test_telemetry_runtime_policy_replay.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import app.telemetry_runtime as telemetry_runtime  # type: ignore
+
+
+def test_reduce_event_is_deterministic_for_same_input():
+    payload = {
+        "request_id": "req-replay-001",
+        "local_turn_id": "turn-replay-001",
+        "duration_ms_bucket": 6400,
+        "stream_transport": "sse_like",
+        "completion_status": "clean_final_message",
+        "subject_ref": "turn://turn-replay-001",
+        "created_at": "2026-04-25T14:20:00+00:00",
+    }
+    control_snapshot = {"product_analytics": "disabled"}
+
+    first = telemetry_runtime.reduce_event(
+        "reliability.conversation.stream.completed",
+        payload,
+        control_snapshot=control_snapshot,
+        policy_version="telemetry-policy-v0.1",
+    )
+    second = telemetry_runtime.reduce_event(
+        "reliability.conversation.stream.completed",
+        payload,
+        control_snapshot=control_snapshot,
+        policy_version="telemetry-policy-v0.1",
+    )
+
+    assert first == second
+    assert first["action"] == "TRANSFORM_ALLOW"
+    assert first["reduced_fields"]["duration_ms_bucket"] == "5s_to_10s"
+
+
+def test_missing_required_fields_blocks_before_optional_controls_apply():
+    payload = {
+        "local_turn_id": "turn-missing-001",
+        "citations_rendered_count": 2,
+        "source_footer_seen": True,
+        "citation_panel_opened_during_turn": False,
+        "subject_ref": "turn://turn-missing-001",
+        "created_at": "2026-04-25T14:21:00+00:00",
+    }
+    outcome = telemetry_runtime.reduce_event(
+        "analytics.turn.rendered.summary",
+        payload,
+        control_snapshot={"product_analytics": "enabled"},
+    )
+    assert outcome["action"] == "BLOCK"
+    assert outcome["blocked_reason"] == "missing_required_fields:turn_has_citations"
+
+
+def test_high_privacy_blocks_optional_analytics_in_reduce_event():
+    payload = {
+        "local_turn_id": "turn-high-privacy-001",
+        "citations_rendered_count": 4,
+        "enhanced_citations_present": True,
+        "sources_footer_present": True,
+        "subject_ref": "turn://turn-high-privacy-001",
+        "created_at": "2026-04-25T14:22:00+00:00",
+    }
+    outcome = telemetry_runtime.reduce_event(
+        "analytics.citations.rendered.summary",
+        payload,
+        control_snapshot={"product_analytics": "high_privacy"},
+    )
+    assert outcome["action"] == "BLOCK"
+    assert outcome["blocked_reason"] == "disabled_by_user"
+    assert outcome["destinations"] == []

--- a/apps/evidence-receipts/tests/test_telemetry_runtime_receipts.py
+++ b/apps/evidence-receipts/tests/test_telemetry_runtime_receipts.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import app.telemetry_runtime as telemetry_runtime  # type: ignore
+
+
+def test_high_privacy_blocks_optional_analytics(monkeypatch, tmp_path):
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    result = telemetry_runtime.emit_event_bundle(
+        "telemetry-runtime",
+        "analytics.turn.rendered.summary",
+        {
+            "local_turn_id": "turn-privacy-001",
+            "turn_has_citations": True,
+            "citations_rendered_count": 2,
+            "source_footer_seen": True,
+            "citation_panel_opened_during_turn": False,
+            "subject_ref": "turn://turn-privacy-001",
+        },
+        control_snapshot={"product_analytics": "high_privacy"},
+    )
+    assert result["outcome"]["action"] == "BLOCK"
+    assert result["receipt"]["status"] == "blocked"
+    assert result["receipt"]["blocked_reason"] == "disabled_by_user"
+
+
+def test_receipt_contains_transformed_field_names_and_destinations(monkeypatch, tmp_path):
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    result = telemetry_runtime.emit_event_bundle(
+        "telemetry-runtime",
+        "reliability.conversation.stream.completed",
+        {
+            "request_id": "req-x",
+            "local_turn_id": "turn-x",
+            "duration_ms_bucket": 1200,
+            "stream_transport": "sse_like",
+            "completion_status": "clean_final_message",
+            "subject_ref": "turn://turn-x",
+        },
+    )
+    receipt = result["receipt"]
+    assert receipt["status"] == "recorded"
+    assert receipt["destinations"] == ["reliability_store"]
+    assert sorted(receipt["transformed_fields"]) == ["duration_ms_bucket", "local_turn_id", "request_id"]
+    assert receipt["integrity_hash"].startswith("sha256:")
+
+
+def test_emitted_bundle_files_exist(monkeypatch, tmp_path):
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    result = telemetry_runtime.emit_event_bundle(
+        "telemetry-runtime",
+        "receipts.citation_resolution.summary",
+        {
+            "local_turn_id": "turn-files-001",
+            "citations_resolved_count": 3,
+            "resolution_status": "succeeded",
+            "latency_bucket": 300,
+            "subject_ref": "turn://turn-files-001",
+        },
+    )
+    payload_ref = result["catalog_entry"]["payload_ref"].removeprefix("file://")
+    event_ref = result["catalog_entry"]["event_ref"].removeprefix("file://")
+    receipt_ref = result["catalog_entry"]["receipt_ref"].removeprefix("file://")
+    assert Path(payload_ref).exists()
+    assert Path(event_ref).exists()
+    assert Path(receipt_ref).exists()
+    payload = json.loads(Path(payload_ref).read_text(encoding="utf-8"))
+    assert payload["event"] == "receipts.citation_resolution.summary"

--- a/contracts/evidence/agent-action-receipt.schema.json
+++ b/contracts/evidence/agent-action-receipt.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AgentActionReceipt",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["kind", "id", "agentRef", "action"],
+  "properties": {
+    "kind": { "const": "AgentActionReceipt" },
+    "id": { "type": "string", "minLength": 1 },
+    "agentRef": { "type": "string", "minLength": 1 },
+    "action": { "type": "string", "minLength": 1 },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/contracts/institution/context-pack.schema.json
+++ b/contracts/institution/context-pack.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "InstitutionContextPack",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["kind", "id"],
+  "properties": {
+    "kind": { "const": "InstitutionContextPack" },
+    "id": { "type": "string", "minLength": 1 },
+    "subjectRef": { "type": "string" },
+    "contextRefs": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/contracts/institution/relationship.schema.json
+++ b/contracts/institution/relationship.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "InstitutionRelationship",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["kind", "id", "sourceRef", "targetRef"],
+  "properties": {
+    "kind": { "const": "InstitutionRelationship" },
+    "id": { "type": "string", "minLength": 1 },
+    "sourceRef": { "type": "string", "minLength": 1 },
+    "targetRef": { "type": "string", "minLength": 1 },
+    "relationshipType": { "type": "string" }
+  }
+}

--- a/contracts/risk/information-barrier.schema.json
+++ b/contracts/risk/information-barrier.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "InformationBarrier",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["kind", "id", "scopeRef"],
+  "properties": {
+    "kind": { "const": "InformationBarrier" },
+    "id": { "type": "string", "minLength": 1 },
+    "scopeRef": { "type": "string", "minLength": 1 },
+    "blockedRefs": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/tools/demo_transparent_telemetry_runtime.py
+++ b/tools/demo_transparent_telemetry_runtime.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "apps" / "evidence-receipts"))
+
+from app.telemetry_runtime import emit_event_bundle  # type: ignore
+
+
+def main() -> None:
+    result = emit_event_bundle(
+        "telemetry-runtime",
+        "reliability.conversation.stream.completed",
+        {
+            "request_id": "req-demo-001",
+            "local_turn_id": "turn-demo-001",
+            "duration_ms_bucket": 4200,
+            "stream_transport": "sse_like",
+            "completion_status": "clean_final_message",
+            "subject_ref": "turn://turn-demo-001",
+        },
+        control_snapshot={"product_analytics": "disabled"},
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tests/test_demo_transparent_telemetry_runtime.py
+++ b/tools/tests/test_demo_transparent_telemetry_runtime.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_demo_transparent_telemetry_runtime(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["SOCIOPROFIT_STATE_HOME"] = str(tmp_path)
+    proc = subprocess.run(
+        [sys.executable, "tools/demo_transparent_telemetry_runtime.py"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    payload = json.loads(proc.stdout)
+    assert payload["service"] == "telemetry-runtime"
+    assert payload["outcome"]["event"] == "reliability.conversation.stream.completed"
+    assert payload["receipt"]["status"] == "recorded"
+    assert payload["catalog_entry"]["service"] == "telemetry-runtime"


### PR DESCRIPTION
## Summary

This PR adds the first runtime skeleton for the transparent telemetry slice on top of the merged `telemetry/` seed package.

The goal is to make the package executable without widening scope too early.

## What lands here

### evidence-receipts runtime core
- `apps/evidence-receipts/app/telemetry_runtime.py`
  - manifest loader
  - control resolution
  - field transformation
  - policy reduction
  - receipt and bundle emission into the existing evidence state layout

### tests
- `apps/evidence-receipts/tests/test_telemetry_runtime.py`
  - optional analytics blocked when disabled
  - reliability event still allowed when analytics is disabled
  - unknown manifest handling

### console-side reader
- `apps/evidence-console/app/telemetry_view.py`
  - thin reader over recent telemetry receipt summaries
- `apps/evidence-console/tests/test_telemetry_view.py`

### manual demo path
- `tools/demo_transparent_telemetry_runtime.py`

## Why this is intentionally narrow

The platform now has a seeded `telemetry/` package with schemas, controls, and first-slice manifests on `main`.

The next correct move is not to broaden the telemetry surface. It is to prove one slice end to end:
- manifest lookup
- control-aware policy decision
- transformed outbound payload shape
- receipt bundle write
- inspector-consumable recent view

## Deliberate limits of this PR

This PR does **not** yet modify the existing evidence-console HTTP routes or UI.
That integration is the immediate follow-on, but I am not pretending it is finished here because the connector path is much cleaner for additive files than for patching multiple existing app files atomically.

So this PR stops at a runtime skeleton that is already testable and can be consumed by a follow-up route/UI wiring PR.

## Intended next work after this PR

1. Wire `telemetry_view` into evidence-console HTTP routes and minimal HTML surface.
2. Add a local inspector-visible stream for the conversation/citation slice.
3. Add replay-style policy outcome tests.
4. Only then broaden beyond the first slice.
