### PR TITLE
Add openssl-backed Fog Stack release proof verification

### DIFF
--- a/.github/workflows/fogstack-release-proof.yml
+++ b/.github/workflows/fogstack-release-proof.yml
@@ -8,6 +8,7 @@ on:
       - "schemas/release/**"
       - "tools/*fogstack*"
       - "tools/tests/test_fogstack_release_proof_pipeline.py"
+      - "tools/tests/test_run_openssl_fogstack_release_seal_verifier.py"
       - "docs/FOGSTACK_*.md"
       - ".github/workflows/fogstack-release-proof.yml"
   push:
@@ -18,6 +19,7 @@ on:
       - "schemas/release/**"
       - "tools/*fogstack*"
       - "tools/tests/test_fogstack_release_proof_pipeline.py"
+      - "tools/tests/test_run_openssl_fogstack_release_seal_verifier.py"
       - "docs/FOGSTACK_*.md"
       - ".github/workflows/fogstack-release-proof.yml"
 
@@ -44,7 +46,7 @@ jobs:
 
       - name: Run release proof tests
         run: |
-          python -m pytest -q tools/tests/test_fogstack_release_proof_pipeline.py
+          python -m pytest -q tools/tests/test_fogstack_release_proof_pipeline.py tools/tests/test_run_openssl_fogstack_release_seal_verifier.py
 
       - name: Smoke release proof pipeline
         run: |
@@ -57,10 +59,14 @@ jobs:
             --artifact validation releases/evidence/fogstack.access-v0.1.validation.record.json \
             --output artifacts/release-proof/fogstack.access.seal.json
 
+          openssl genpkey -algorithm RSA -out artifacts/release-proof/private.pem
+          openssl pkey -in artifacts/release-proof/private.pem -pubout -out artifacts/release-proof/public.pem
+          openssl dgst -sha256 -sign artifacts/release-proof/private.pem -out artifacts/release-proof/fogstack.access.seal.sig artifacts/release-proof/fogstack.access.seal.json
+
           python3 tools/attach_fogstack_release_seal_signature.py \
             --seal artifacts/release-proof/fogstack.access.seal.json \
-            --signature-type cosign \
-            --signature-ref artifact://release/fogstack.access-v0.1.seal.sig \
+            --signature-type other \
+            --signature-ref artifacts/release-proof/fogstack.access.seal.sig \
             --output artifacts/release-proof/fogstack.access.seal.json
 
           python3 tools/emit_fogstack_release_evidence_index.py \
@@ -72,33 +78,20 @@ jobs:
             --signature-trust-record-ref releases/evidence/fogstack.access-v0.1.signature-trust.record.json \
             --output artifacts/release-proof/fogstack.access.evidence.index.json
 
-          SEAL_HASH=$(python3 - <<'PY'
-          import json
-          from pathlib import Path
-          data = json.loads(Path('artifacts/release-proof/fogstack.access.seal.json').read_text(encoding='utf-8'))
-          print(data['release_root_hash'])
-          PY
-          )
-
-          cat > artifacts/release-proof/mock_seal_verify.py <<'PY'
-          import json, os
-          print(json.dumps({
-              "status": "pass",
-              "verified_root_hash": os.environ["SEAL_HASH"],
-              "evidence_count": 1,
-          }))
-          PY
-
-          SEAL_HASH="$SEAL_HASH" python3 tools/run_fogstack_release_proof_pipeline.py \
-            --tool cosign \
+          python3 tools/run_fogstack_release_proof_pipeline.py \
+            --tool other \
             --seal artifacts/release-proof/fogstack.access.seal.json \
             --bundle-id fogstack.access \
             --version 0.1.0 \
-            --signature-ref artifact://release/fogstack.access-v0.1.seal.sig \
+            --signature-ref artifacts/release-proof/fogstack.access.seal.sig \
             --evidence-output artifacts/release-proof/fogstack.access.seal.verify.json \
             --seal-crypto-record artifacts/release-proof/fogstack.access.seal.crypto-verification.record.json \
             --evidence-index artifacts/release-proof/fogstack.access.evidence.index.json \
-            -- python3 artifacts/release-proof/mock_seal_verify.py
+            -- python3 tools/run_openssl_fogstack_release_seal_verifier.py \
+              --seal artifacts/release-proof/fogstack.access.seal.json \
+              --signature artifacts/release-proof/fogstack.access.seal.sig \
+              --public-key artifacts/release-proof/public.pem \
+              --key-ref artifacts/release-proof/public.pem
 
       - name: Assert proof outputs linked
         run: |

--- a/tools/run_openssl_fogstack_release_seal_verifier.py
+++ b/tools/run_openssl_fogstack_release_seal_verifier.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify a Fog Stack release seal signature with openssl and emit normalized JSON")
+    parser.add_argument("--seal", required=True, type=Path)
+    parser.add_argument("--signature", required=True, type=Path)
+    parser.add_argument("--public-key", required=True, type=Path)
+    parser.add_argument("--key-ref", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    if shutil.which("openssl") is None:
+        raise SystemExit("ERR: openssl is required")
+
+    seal = load_json(args.seal)
+    proc = subprocess.run(
+        [
+            "openssl",
+            "dgst",
+            "-sha256",
+            "-verify",
+            str(args.public_key),
+            "-signature",
+            str(args.signature),
+            str(args.seal),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    ok = proc.returncode == 0
+    evidence = {
+        "status": "pass" if ok else "fail",
+        "message": (proc.stdout or proc.stderr).strip() or ("verified" if ok else "verification failed"),
+        "verified_root_hash": seal.get("release_root_hash") if ok else None,
+        "evidence_count": 1,
+        "key_ref": args.key_ref or str(args.public_key),
+    }
+
+    text = json.dumps(evidence, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_run_openssl_fogstack_release_seal_verifier.py
+++ b/tools/tests/test_run_openssl_fogstack_release_seal_verifier.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.skipif(shutil.which("openssl") is None, reason="openssl not installed")
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_openssl_release_seal_verifier(tmp_path: Path) -> None:
+    seal = tmp_path / "release.seal.json"
+    sig = tmp_path / "release.seal.sig"
+    priv = tmp_path / "private.pem"
+    pub = tmp_path / "public.pem"
+    out = tmp_path / "verify.json"
+
+    _write_json(
+        seal,
+        {
+            "kind": "FogStackReleaseSeal",
+            "schema_version": "v0.1",
+            "bundle_id": "fogstack.access",
+            "version": "0.1.0",
+            "algorithm": "sha256",
+            "release_root_hash": "sha256:test-seal-root",
+            "artifact_hashes": [],
+            "signed": True,
+            "signature": {"type": "other", "ref": str(sig)},
+        },
+    )
+
+    subprocess.run(["openssl", "genpkey", "-algorithm", "RSA", "-out", str(priv)], check=True)
+    subprocess.run(["openssl", "pkey", "-in", str(priv), "-pubout", "-out", str(pub)], check=True)
+    subprocess.run(["openssl", "dgst", "-sha256", "-sign", str(priv), "-out", str(sig), str(seal)], check=True)
+
+    cmd = [
+        sys.executable,
+        "tools/run_openssl_fogstack_release_seal_verifier.py",
+        "--seal",
+        str(seal),
+        "--signature",
+        str(sig),
+        "--public-key",
+        str(pub),
+        "--output",
+        str(out),
+    ]
+    subprocess.run(cmd, check=True)
+
+    data = _read_json(out)
+    assert data["status"] == "pass"
+    assert data["verified_root_hash"] == "sha256:test-seal-root"


### PR DESCRIPTION
## Summary

This PR upgrades the Fog Stack release-proof path from a mock verifier to a real local cryptographic verifier based on `openssl`:

- `tools/run_openssl_fogstack_release_seal_verifier.py`
- `tools/tests/test_run_openssl_fogstack_release_seal_verifier.py`
- updated `.github/workflows/fogstack-release-proof.yml`

## Why this PR exists

The repo already has:
- release sealing
- release seal signature support
- release seal cryptographic verification records
- a release proof pipeline runner
- CI-backed proof workflow using a mock verifier

What was still weak was that the proof CI path was synthetic. This PR makes the proof lane materially stronger by exercising a real detached-signature verification path in CI.

## What changes

- adds a repo-native helper that verifies a signed release seal using `openssl`
- adds a test that generates a keypair, signs a seal, and asserts successful verification
- updates the release-proof workflow to use the openssl-backed verifier instead of the mock verifier

## Not in this PR

- real cosign/sigstore network or registry integration
- mutation of the non-seal side of the wider trust graph
- publication of the resulting proof set beyond artifact upload

Those remain later steps.
