### PR TITLE
Add Fog Stack wider release graph linking

### DIFF
--- a/docs/FOGSTACK_WIDER_RELEASE_GRAPH.md
+++ b/docs/FOGSTACK_WIDER_RELEASE_GRAPH.md
@@ -1,0 +1,36 @@
+# Fog Stack wider release graph
+
+This document defines the next widening step for the Fog Stack trust graph.
+
+## Goal
+
+Move from a seal-side trust graph to a wider release graph where the primary non-seal artifacts also carry references to the release seal and the release-seal cryptographic verification record.
+
+## Minimal flow
+
+1. produce or update the manifest, validation record, signature verification record, and signature trust record
+2. produce the release seal and the release-seal cryptographic verification record
+3. run `tools/link_fogstack_wider_release_graph.py`
+
+## Example
+
+Run the linker with:
+- the manifest
+- the validation record
+- the signature verification record
+- the signature trust record
+- the release seal
+- the release-seal cryptographic verification record
+
+## What this phase provides
+
+- `release_seal_ref` on the main release/trust artifacts
+- `release_seal_cryptographic_verification_record_ref` on the main release/trust artifacts
+
+## What this phase does not yet provide
+
+- CI automation of wider-graph mutation
+- cryptographic verification of the linked refs themselves
+- publication of the wider linked graph
+
+Those remain later steps.

--- a/schemas/release/fogstack-bundle-manifest-v0.1.schema.json
+++ b/schemas/release/fogstack-bundle-manifest-v0.1.schema.json
@@ -40,7 +40,9 @@
     "validation_record_ref": { "type": ["string", "null"] },
     "signature_verification_record_ref": { "type": ["string", "null"] },
     "signature_trust_record_ref": { "type": ["string", "null"] },
-    "release_evidence_index_ref": { "type": ["string", "null"] }
+    "release_evidence_index_ref": { "type": ["string", "null"] },
+    "release_seal_ref": { "type": ["string", "null"] },
+    "release_seal_cryptographic_verification_record_ref": { "type": ["string", "null"] }
   },
   "additionalProperties": false
 }

--- a/schemas/release/fogstack-signature-trust-record-v0.1.schema.json
+++ b/schemas/release/fogstack-signature-trust-record-v0.1.schema.json
@@ -36,6 +36,8 @@
     "validation_record_ref": { "type": ["string", "null"] },
     "signature_verification_record_ref": { "type": ["string", "null"] },
     "release_evidence_index_ref": { "type": ["string", "null"] },
+    "release_seal_ref": { "type": ["string", "null"] },
+    "release_seal_cryptographic_verification_record_ref": { "type": ["string", "null"] },
     "key_ref": { "type": ["string", "null"] }
   },
   "additionalProperties": false

--- a/schemas/release/fogstack-signature-verification-record-v0.1.schema.json
+++ b/schemas/release/fogstack-signature-verification-record-v0.1.schema.json
@@ -32,7 +32,9 @@
     "signature_ref": { "type": ["string", "null"] },
     "validation_record_ref": { "type": ["string", "null"] },
     "signature_trust_record_ref": { "type": ["string", "null"] },
-    "release_evidence_index_ref": { "type": ["string", "null"] }
+    "release_evidence_index_ref": { "type": ["string", "null"] },
+    "release_seal_ref": { "type": ["string", "null"] },
+    "release_seal_cryptographic_verification_record_ref": { "type": ["string", "null"] }
   },
   "additionalProperties": false
 }

--- a/schemas/release/fogstack-validation-record-v0.1.schema.json
+++ b/schemas/release/fogstack-validation-record-v0.1.schema.json
@@ -37,7 +37,9 @@
     "manifest_ref": { "type": ["string", "null"] },
     "signature_verification_record_ref": { "type": ["string", "null"] },
     "signature_trust_record_ref": { "type": ["string", "null"] },
-    "release_evidence_index_ref": { "type": ["string", "null"] }
+    "release_evidence_index_ref": { "type": ["string", "null"] },
+    "release_seal_ref": { "type": ["string", "null"] },
+    "release_seal_cryptographic_verification_record_ref": { "type": ["string", "null"] }
   },
   "additionalProperties": false
 }

--- a/tools/link_fogstack_wider_release_graph.py
+++ b/tools/link_fogstack_wider_release_graph.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Link Fog Stack wider release graph artifacts")
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--validation-record", required=True, type=Path)
+    parser.add_argument("--signature-verification-record", required=True, type=Path)
+    parser.add_argument("--signature-trust-record", required=True, type=Path)
+    parser.add_argument("--release-seal", required=True, type=Path)
+    parser.add_argument("--release-seal-crypto-record", required=True, type=Path)
+    args = parser.parse_args()
+
+    manifest = load_json(args.manifest)
+    validation = load_json(args.validation_record)
+    sig_verify = load_json(args.signature_verification_record)
+    sig_trust = load_json(args.signature_trust_record)
+
+    for obj in (manifest, validation, sig_verify, sig_trust):
+        obj["release_seal_ref"] = str(args.release_seal)
+        obj["release_seal_cryptographic_verification_record_ref"] = str(args.release_seal_crypto_record)
+
+    write_json(args.manifest, manifest)
+    write_json(args.validation_record, validation)
+    write_json(args.signature_verification_record, sig_verify)
+    write_json(args.signature_trust_record, sig_trust)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the next widening step for the Fog Stack trust graph directly on top of current `main`:

- updated `schemas/release/fogstack-bundle-manifest-v0.1.schema.json`
- updated `schemas/release/fogstack-validation-record-v0.1.schema.json`
- updated `schemas/release/fogstack-signature-verification-record-v0.1.schema.json`
- updated `schemas/release/fogstack-signature-trust-record-v0.1.schema.json`
- `tools/link_fogstack_wider_release_graph.py`
- `docs/FOGSTACK_WIDER_RELEASE_GRAPH.md`

## Why this PR exists

The repo already has a seal-side trust graph. What is still missing is explicit linkage from the main non-seal release/trust artifacts back to:
- the release seal
- the release-seal cryptographic verification record

This PR adds those references and the helper that mutates them together.

## Not in this PR

- CI automation of wider-graph mutation
- cryptographic verification of linked refs themselves
- publication of the wider linked graph

Those remain later steps.
