### PR TITLE
docs(platform): add auth standards consumption plan

### DIFF
--- a/apps/identity-prime/README.md
+++ b/apps/identity-prime/README.md
@@ -1,0 +1,51 @@
+# identity-prime
+
+`identity-prime` is the intended platform runtime lane for identity normalization and first-party session shaping inside `prophet-platform`.
+
+This directory is currently a **placeholder runtime landing zone**.
+
+It exists so future implementation work has a clear, bounded home and does not drift into unrelated gateway or service surfaces.
+
+## Why this lane exists
+
+The upstream SocioProphet agent standards define the platform posture for:
+
+- authentication, session, and recovery
+- credential enrollment and authenticator lifecycle
+- enterprise federation and claim mapping
+- workload and service identity
+
+`prophet-platform` is the runtime and deployment hub where those upstream standards become platform behavior.
+
+`identity-prime` is the intended runtime seam for that work.
+
+## Intended responsibilities
+
+This lane is expected to cover:
+
+- first-party session orchestration
+- normalization of external identity proof into internal subject / tenant / assurance context
+- platform-facing identity contracts
+- identity/session lifecycle evidence emission
+
+## Current status
+
+This subtree does **not** yet claim a full implementation.
+
+At this stage it is a designated runtime landing zone and boundary marker.
+
+## Review rule
+
+Future PRs that touch this lane should state:
+
+- which upstream auth standard(s) they implement
+- which ingress or session seam they bind
+- what they intentionally defer
+
+## Related platform seams
+
+- `standards.lock.yaml`
+- `contracts/identity/`
+- gateway/browser ingress
+- enterprise identity ingress
+- service-to-service identity handoff

--- a/docs/COMPLIES_WITH_STANDARDS.md
+++ b/docs/COMPLIES_WITH_STANDARDS.md
@@ -1,0 +1,56 @@
+# Complies with Standards
+
+This repository consumes upstream SocioProphet standards as implementation inputs.
+
+It is the runtime and deployment home where upstream standards become running services, platform contracts, and deployment topology. It is **not** the canonical source of truth for the standards themselves.
+
+## Upstream standards currently relevant here
+
+### Authentication and identity
+
+From `SocioProphet/socioprophet-agent-standards`:
+
+- `docs/standards/authentication/001-agent-authentication-session-and-recovery-standard.md`
+- `docs/standards/authentication/002-credential-enrollment-and-authenticator-lifecycle-standard.md`
+- `docs/standards/authentication/003-enterprise-federation-and-claim-mapping-standard.md`
+- `docs/standards/authentication/004-workload-and-service-identity-standard.md`
+- `conformance/CONFORMANCE-CRITERIA-0001.md`
+
+### Other already-pinned standards and references
+
+See `standards.lock.yaml` for the active external standards and reference inputs already pinned by commit.
+
+## Consumption posture
+
+At the time of writing, `prophet-platform` declares the following posture for the auth standards tranche:
+
+- **001** — consumed as the umbrella platform auth/session/recovery posture
+- **002** — consumed as the target credential-enrollment and authenticator-lifecycle posture
+- **003** — consumed as the target enterprise federation and claim-normalization posture
+- **004** — consumed as the target machine/workload identity posture
+
+This declaration is intentionally conservative.
+
+It does **not** claim that every runtime seam in this repository is already fully conformant to the complete upstream standards tranche. It records that these are the standards this repo is aligning to and that future runtime work should be reviewed against them.
+
+## Current binding seams in this repository
+
+The primary seams that should bind to the auth standards tranche are:
+
+- `standards.lock.yaml`
+- browser ingress through the gateway
+- `contracts/identity/`
+- any future or current `apps/identity-prime` runtime lane
+- service-to-service identity for platform services
+
+## Current status
+
+Current status should be read as:
+
+- standards-consumption intent is explicit
+- runtime alignment is in progress
+- broad claims of full conformance are premature until the relevant runtime seams are implemented or updated
+
+## Review rule
+
+Future changes touching auth/session/identity surfaces in this repository should state which upstream standard(s) they implement, extend, or intentionally defer.

--- a/docs/PLATFORM_AUTH_STANDARDS_CONSUMPTION.md
+++ b/docs/PLATFORM_AUTH_STANDARDS_CONSUMPTION.md
@@ -1,0 +1,101 @@
+# Platform Authentication Standards Consumption Plan
+
+## Purpose
+
+This document records how `prophet-platform` should consume the merged SocioProphet agent authentication standards without overreaching into unrelated runtime work.
+
+It is intentionally an **alignment and gap-declaration document**, not a claim that the platform has already fully implemented the complete authentication stack.
+
+## Upstream standards consumed
+
+`prophet-platform` should consume the following upstream standards from `SocioProphet/socioprophet-agent-standards`:
+
+- `docs/standards/authentication/001-agent-authentication-session-and-recovery-standard.md`
+- `docs/standards/authentication/002-credential-enrollment-and-authenticator-lifecycle-standard.md`
+- `docs/standards/authentication/003-enterprise-federation-and-claim-mapping-standard.md`
+- `docs/standards/authentication/004-workload-and-service-identity-standard.md`
+- `conformance/CONFORMANCE-CRITERIA-0001.md`
+
+## Why this repo is the first consumer
+
+The repository README already states that standards and governance stay in dedicated upstream repositories and that `prophet-platform` is where those standards become running services, deployment topologies, and platform contracts.
+
+That makes `prophet-platform` the correct first implementation-side consumer for the auth standards tranche.
+
+## Current platform seams relevant to auth
+
+From the current repository posture, the most relevant seams are:
+
+- `standards.lock.yaml`
+  - already pins upstream standards and reference inputs
+  - already includes identity-facing generated artifact targets such as `contracts/identity/`
+  - already names `apps/identity-prime` as a runtime target under the standards-consumption model
+- `docs/ARCHITECTURE.md`
+  - documents browser ingress via a small HTTP gateway that relays internally over TriTRPC
+- browser shell / portal surfaces
+- gateway ingress surfaces
+- future `identity-prime` runtime lane
+- identity and evidence contract directories
+
+## Current gap statement
+
+At the time of writing:
+
+1. The platform has an upstream standards-consumption mechanism (`standards.lock.yaml`), but it does **not yet explicitly pin or declare consumption of the auth standards tranche** from `socioprophet-agent-standards`.
+2. The architecture document exposes browser ingress and internal transport posture, but it does **not yet describe a first-class browser auth/session architecture** in the same explicit way.
+3. The standards lock references identity-oriented generated artifacts and an `apps/identity-prime` runtime target, but the implementation posture for that lane is still under-specified from the repository’s public-facing docs.
+
+## Intended implementation posture
+
+The platform should align to the upstream auth standards with the following shape:
+
+### Browser lane
+
+- browser ingress remains through the gateway
+- browser auth/session posture should align to the upstream standard’s first-party session and gateway/BFF expectations
+- browser runtime code should not introduce ad hoc long-lived front-end token storage
+
+### Enterprise federation lane
+
+- tenant routing and external proof should align to the enterprise federation standard
+- any enterprise IdP claim handling should be normalized before authorization decisions
+- external proof should still terminate in platform-controlled first-party session/state
+
+### Identity runtime lane
+
+- `apps/identity-prime` should become the explicit runtime landing zone for identity and session orchestration in the platform
+- `contracts/identity/` should carry the generated/platform contracts needed by that runtime lane
+- implementation should remain additive and not silently reshape unrelated services
+
+### Workload/service identity lane
+
+- machine identities for platform services should align to the workload/service identity standard
+- service-to-service auth should not reuse human/browser auth posture
+- runtime targets consuming downstream APIs should use audience-scoped machine credentials
+
+## Safe next implementation steps
+
+The next safe implementation steps in this repo are:
+
+1. add an explicit standards-consumption declaration for the auth standards tranche in `standards.lock.yaml`
+2. add a "Complies with Standards" reference from the README or another canonical repo entry point
+3. add or refine the `identity-prime` runtime lane documentation before touching broader runtime auth behavior
+4. only after those steps, make narrow runtime changes tied to one explicit auth seam at a time
+
+## Things this document does **not** claim
+
+This document does **not** claim that:
+
+- the full passkey/browser/session architecture is already implemented in this repo
+- enterprise federation is already fully realized here
+- the machine identity lane is already complete
+- the gateway or browser surfaces are already fully conformant to the upstream auth standards
+
+It is a disciplined statement of **where the standards should bind** and **what the next safe move is**.
+
+## Recommended follow-on PR order
+
+1. standards-lock auth import / pin update
+2. README or canonical entrypoint compliance declaration
+3. identity-prime runtime lane documentation
+4. narrow implementation PRs for specific auth/session seams


### PR DESCRIPTION
## Summary

Add a narrow platform-facing auth standards consumption plan that binds the merged upstream auth standards tranche to the existing `prophet-platform` seams without touching runtime code.

## Why this PR exists

The upstream standards work has already moved:
- auth standards 001–004 are merged in `socioprophet-agent-standards`
- auth/conformance catalogs are merged

`prophet-platform` is the correct first implementation-side consumer because its README explicitly says standards remain upstream while this repo is where those standards become running services and platform contracts.

At the same time, the current platform docs do not yet expose a first-class auth/session architecture, and the existing `standards.lock.yaml` does not yet explicitly declare consumption of the auth standards tranche.

This PR therefore does **not** claim full runtime implementation. It records:
- which upstream standards should bind here
- which existing platform seams are relevant (`standards.lock.yaml`, gateway/browser ingress, `contracts/identity/`, `apps/identity-prime`)
- what the next safe implementation steps are
- what this repo should **not** claim yet

## Scope

- adds `docs/PLATFORM_AUTH_STANDARDS_CONSUMPTION.md`

## Intentional non-goals

- no runtime auth code changes
- no gateway/session implementation changes
- no `standards.lock.yaml` mutation yet
- no broad README rewrites

## Follow-on work

1. add explicit auth standards consumption in `standards.lock.yaml`
2. add a "Complies with Standards" declaration from a canonical entrypoint
3. refine the `identity-prime` runtime lane documentation
4. only then make narrow runtime auth/session changes
