### PR TITLE
Add Fog Stack wider release proof pipeline runner

### DIFF
--- a/docs/FOGSTACK_WIDER_RELEASE_PROOF_PIPELINE.md
+++ b/docs/FOGSTACK_WIDER_RELEASE_PROOF_PIPELINE.md
@@ -1,0 +1,37 @@
+# Fog Stack wider release proof pipeline
+
+This document defines the repo-native **wider release proof pipeline** for Fog Stack.
+
+## Goal
+
+Move from:
+- a seal-side proof pipeline
+- a separate wider release graph linker
+
+to:
+- one wrapper that first executes the seal-side proof pipeline and then links the wider release graph so the main non-seal artifacts carry seal-side proof references.
+
+## Minimal flow
+
+1. provide the manifest, validation record, signature verification record, signature trust record, release seal, bundle identity/version, signature reference, evidence output path, seal crypto record path, and evidence index path
+2. invoke `tools/run_fogstack_wider_release_proof_pipeline.py`
+3. pass the external verifier command after `--`
+4. the wrapper executes the seal proof pipeline and then mutates the wider release graph
+
+## Example
+
+Run the wrapper with the manifest, validation record, signature verification record, signature trust record, release seal, bundle identity, signature reference, output paths, and the external verifier command after `--`.
+
+## What this phase provides
+
+- one orchestrated proof step for the seal side plus the wider release graph
+- automatic invocation of the seal proof pipeline
+- automatic backlink insertion into the main non-seal release/trust artifacts
+
+## What this phase does not yet provide
+
+- CI enforcement of the wider proof pipeline
+- publication of the resulting proof set
+- mutation of every downstream consumer of the wider trust graph
+
+Those remain later steps.

--- a/tools/run_fogstack_wider_release_proof_pipeline.py
+++ b/tools/run_fogstack_wider_release_proof_pipeline.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the Fog Stack wider release proof pipeline")
+    parser.add_argument("--tool", required=True, choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--validation-record", required=True, type=Path)
+    parser.add_argument("--signature-verification-record", required=True, type=Path)
+    parser.add_argument("--signature-trust-record", required=True, type=Path)
+    parser.add_argument("--seal", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--signature-ref", required=True)
+    parser.add_argument("--evidence-output", required=True, type=Path)
+    parser.add_argument("--seal-crypto-record", required=True, type=Path)
+    parser.add_argument("--evidence-index", required=True, type=Path)
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="External seal verifier command, e.g. cosign verify ...")
+    args = parser.parse_args()
+
+    if not args.command:
+        raise SystemExit("ERR: external seal verifier command is required after '--'")
+
+    proof_cmd = [
+        "python3",
+        "tools/run_fogstack_release_proof_pipeline.py",
+        "--tool", args.tool,
+        "--seal", str(args.seal),
+        "--bundle-id", args.bundle_id,
+        "--version", args.version,
+        "--signature-ref", args.signature_ref,
+        "--evidence-output", str(args.evidence_output),
+        "--seal-crypto-record", str(args.seal_crypto_record),
+        "--evidence-index", str(args.evidence_index),
+        "--",
+    ] + args.command
+    proof = subprocess.run(proof_cmd)
+    if proof.returncode != 0:
+        raise SystemExit(proof.returncode)
+
+    wider_cmd = [
+        "python3",
+        "tools/link_fogstack_wider_release_graph.py",
+        "--manifest", str(args.manifest),
+        "--validation-record", str(args.validation_record),
+        "--signature-verification-record", str(args.signature_verification_record),
+        "--signature-trust-record", str(args.signature_trust_record),
+        "--release-seal", str(args.seal),
+        "--release-seal-crypto-record", str(args.seal_crypto_record),
+    ]
+    wider = subprocess.run(wider_cmd)
+    if wider.returncode != 0:
+        raise SystemExit(wider.returncode)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the next Fog Stack proof tranche directly on top of current `main`:

- `tools/run_fogstack_wider_release_proof_pipeline.py`
- `docs/FOGSTACK_WIDER_RELEASE_PROOF_PIPELINE.md`

## Why this PR exists

The repo already has:
- a seal-side release proof pipeline
- wider release graph linking

What is still missing is one repo-native wrapper that runs the seal-side proof pipeline and then mutates the wider release graph in one step.

This PR adds that orchestrating helper.

## Not in this PR

- CI enforcement of the wider proof pipeline
- publication of the resulting proof set
- mutation of every downstream consumer of the wider trust graph

Those remain later steps.
