### PR TITLE
deploy(search): add academy bridge profiles and smoke

### DIFF
--- a/infra/local/docker-compose.search-orchestrator.academy.yml
+++ b/infra/local/docker-compose.search-orchestrator.academy.yml
@@ -1,0 +1,21 @@
+services:
+  search-orchestrator:
+    image: python:3.12-slim
+    working_dir: /workspace/services/search-orchestrator
+    command: >
+      sh -lc "pip install --no-cache-dir -r requirements.txt && uvicorn app.main:app --host 0.0.0.0 --port 8080"
+    ports:
+      - "8088:8080"
+    environment:
+      SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_CARRIER_DIR: /workspace/.runtime/search-orchestrator/academy-carriers
+      SEARCH_ORCHESTRATOR_POLICY_FABRIC_TIMEOUT_SECONDS: "2.0"
+      SOCIOPROFIT_STATE_HOME: /workspace/.runtime/state
+      SOCIOPROFIT_DATA_HOME: /workspace/.runtime/data
+      SOCIOPROFIT_RUNTIME_HOME: /workspace/.runtime/run
+    volumes:
+      - ../../:/workspace
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=2)"]
+      interval: 5s
+      timeout: 3s
+      retries: 20

--- a/services/search-orchestrator/README.md
+++ b/services/search-orchestrator/README.md
@@ -49,6 +49,24 @@ Academy visibility is policy-gated. By default, the service uses the local fallb
 
 The live Policy Fabric adapter is endpoint-explicit. No endpoint is called unless configured.
 
+## Deployment profiles
+
+Runtime profile definitions live in `services/search-orchestrator/deploy/academy-bridge-profiles.yaml`.
+
+A local compose profile for Lampstand carrier mode lives at `infra/local/docker-compose.search-orchestrator.academy.yml`.
+
+Example local run:
+
+```bash
+docker compose -f infra/local/docker-compose.search-orchestrator.academy.yml up --build
+```
+
+Then inspect the active non-secret configuration:
+
+```bash
+curl http://127.0.0.1:8088/v1/search/debug/config
+```
+
 ## Runtime introspection
 
 `GET /v1/search/debug/config` returns non-secret runtime mode information:
@@ -70,3 +88,4 @@ The first implementation should be narrow and inspectable:
 - one platform-side execution seam
 - explicit Academy bridge modes
 - safe runtime introspection without secret disclosure
+- repeatable local deployment smoke for Lampstand carrier mode

--- a/services/search-orchestrator/deploy/academy-bridge-profiles.yaml
+++ b/services/search-orchestrator/deploy/academy-bridge-profiles.yaml
@@ -1,0 +1,58 @@
+profiles:
+  local_dev:
+    description: Process-local Academy records and local fallback policy evaluation.
+    environment: {}
+    expected_debug:
+      academy_repository_mode: in-memory
+      academy_policy_mode: local-fallback
+
+  json_file:
+    description: Durable single-file Academy search storage with local fallback policy evaluation.
+    environment:
+      SEARCH_ORCHESTRATOR_ACADEMY_STORE: /var/lib/prophet-platform/search-orchestrator/academy-search.json
+    expected_debug:
+      academy_repository_mode: json-file
+      academy_policy_mode: local-fallback
+
+  lampstand_jsonl:
+    description: Academy records exported to a JSONL file for Lampstand-style indexing.
+    environment:
+      SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_JSONL: /var/lib/prophet-platform/search-orchestrator/academy-search.jsonl
+    expected_debug:
+      academy_repository_mode: lampstand-jsonl
+      academy_policy_mode: local-fallback
+
+  lampstand_carrier:
+    description: Academy records materialized as Lampstand carrier payloads with receipt/catalog output.
+    environment:
+      SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_CARRIER_DIR: /var/lib/prophet-platform/search-orchestrator/academy-carriers
+      SOCIOPROFIT_STATE_HOME: /var/lib/prophet-platform/state
+      SOCIOPROFIT_DATA_HOME: /var/lib/prophet-platform/data
+      SOCIOPROFIT_RUNTIME_HOME: /run/prophet-platform
+    expected_debug:
+      academy_repository_mode: lampstand-carrier
+      academy_policy_mode: local-fallback
+
+  lampstand_carrier_policy_fabric:
+    description: Lampstand carrier mode plus endpoint-explicit Policy Fabric visibility decisions.
+    environment:
+      SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_CARRIER_DIR: /var/lib/prophet-platform/search-orchestrator/academy-carriers
+      SEARCH_ORCHESTRATOR_POLICY_FABRIC_ENDPOINT: http://policy-fabric:8080/v1/academy/search/visibility/decide
+      SEARCH_ORCHESTRATOR_POLICY_FABRIC_TIMEOUT_SECONDS: "2.0"
+      SOCIOPROFIT_STATE_HOME: /var/lib/prophet-platform/state
+      SOCIOPROFIT_DATA_HOME: /var/lib/prophet-platform/data
+      SOCIOPROFIT_RUNTIME_HOME: /run/prophet-platform
+    expected_debug:
+      academy_repository_mode: lampstand-carrier
+      academy_policy_mode: http-policy-fabric
+
+notes:
+  precedence:
+    - SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_CARRIER_DIR
+    - SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_JSONL
+    - SEARCH_ORCHESTRATOR_ACADEMY_STORE
+    - in-memory default
+  safety:
+    - No live Policy Fabric endpoint is called unless SEARCH_ORCHESTRATOR_POLICY_FABRIC_ENDPOINT is set.
+    - The debug endpoint reports booleans and modes, not configured paths or endpoint URLs.
+    - Lampstand carrier mode writes only to configured local filesystem roots.

--- a/services/search-orchestrator/requirements.txt
+++ b/services/search-orchestrator/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 pydantic
+uvicorn[standard]

--- a/services/search-orchestrator/tests/test_academy_lampstand_deployment_smoke.py
+++ b/services/search-orchestrator/tests/test_academy_lampstand_deployment_smoke.py
@@ -1,0 +1,73 @@
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def academy_record() -> dict[str, object]:
+    return {
+        "header": {
+            "object_id": "lsr_deploy_smoke_0001",
+            "object_type": "LearningSearchRecord",
+            "policy_tags": ["learning-loop", "search"],
+        },
+        "source": "ALEXANDRIAN_ACADEMY",
+        "entity_type": "LEARNING_ACTION_EXPLANATION",
+        "title": "Why recommended",
+        "text": "Deployment smoke evidence explanation.",
+        "target_ref": "llr_deploy_smoke_0001",
+        "evidence_ref_ids": ["evidence://academy/span/0001"],
+        "final_score": 1.0,
+    }
+
+
+def load_configured_app(monkeypatch, tmp_path):
+    monkeypatch.setenv("SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_CARRIER_DIR", str(tmp_path / "academy-carriers"))
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.setenv("SOCIOPROFIT_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.setenv("SOCIOPROFIT_RUNTIME_HOME", str(tmp_path / "runtime"))
+
+    import app.repositories as repositories
+    import app.policy as policy
+    import app.backends as backends
+    import app.main as main
+
+    importlib.reload(repositories)
+    importlib.reload(policy)
+    importlib.reload(backends)
+    importlib.reload(main)
+    return main.app
+
+
+def test_lampstand_carrier_deployment_smoke(monkeypatch, tmp_path) -> None:
+    app = load_configured_app(monkeypatch, tmp_path)
+    client = TestClient(app)
+
+    config_response = client.get("/v1/search/debug/config")
+    assert config_response.status_code == 200
+    config = config_response.json()
+    assert config["academy_repository"]["mode"] == "lampstand-carrier"
+    assert config["academy_policy"]["mode"] == "local-fallback"
+
+    ingest_response = client.post("/v1/search/ingest/academy", json=academy_record())
+    assert ingest_response.status_code == 200
+
+    query_response = client.post(
+        "/v0/search/query",
+        json={
+            "query_id": "q-deploy-smoke",
+            "actor_id": "user-1",
+            "text": "evidence",
+            "mode": "HYBRID",
+            "limit": 10,
+            "scope": {"cloud_workspace": True, "local_desktop": False, "memory": False},
+        },
+    )
+    assert query_response.status_code == 200
+    academy_results = [item for item in query_response.json()["results"] if item["source"] == "ALEXANDRIAN_ACADEMY"]
+    assert academy_results
+
+    state_root = tmp_path / "state" / "prophet-platform"
+    assert list((tmp_path / "academy-carriers").glob("*.LearningSearchRecord.json"))
+    assert list((state_root / "payloads" / "lampstand").glob("*.CarrierIngested.json"))
+    assert list((state_root / "receipts" / "lampstand").glob("*.json"))
+    assert list((state_root / "catalog" / "lampstand").glob("*.jsonl"))


### PR DESCRIPTION
## Summary

Adds deployment profiles and a repeatable deployment smoke for the Search Orchestrator Academy bridge.

## Scope

- Adds Academy bridge deployment profile manifest
- Adds local Docker Compose profile for Lampstand carrier mode
- Adds `uvicorn[standard]` as the Search Orchestrator runtime dependency
- Adds deployment smoke that configures Lampstand carrier mode, verifies `/v1/search/debug/config`, ingests an Academy `LearningSearchRecord`, queries it, and verifies carrier artifacts
- Adds README deployment notes for local run and runtime inspection

## Safety posture

- Local deployment and test-only operational additions
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback
- Lampstand carrier mode remains explicitly configured

## Program lane

Search Orchestrator deployment readiness for Academy bridge modes.