### PR TITLE
Add Fog Stack canonical manifest digests and CI enforcement

### DIFF
--- a/.github/workflows/fogstack-validation.yml
+++ b/.github/workflows/fogstack-validation.yml
@@ -12,6 +12,8 @@ on:
       - "tools/validate_fogstack.py"
       - "tools/emit_fogstack_validation_record.py"
       - "tools/fogstack_validation_to_evidence.py"
+      - "tools/refresh_fogstack_manifest_digests.py"
+      - "tools/tests/test_refresh_fogstack_manifest_digests.py"
       - "docs/FOGSTACK_*.md"
   push:
     branches: [main]
@@ -25,6 +27,8 @@ on:
       - "tools/validate_fogstack.py"
       - "tools/emit_fogstack_validation_record.py"
       - "tools/fogstack_validation_to_evidence.py"
+      - "tools/refresh_fogstack_manifest_digests.py"
+      - "tools/tests/test_refresh_fogstack_manifest_digests.py"
       - "docs/FOGSTACK_*.md"
 
 permissions:
@@ -50,7 +54,14 @@ jobs:
 
       - name: Run helper tests
         run: |
-          python -m pytest -q tools/tests/test_fogstack_validation_to_evidence.py
+          python -m pytest -q tools/tests/test_fogstack_validation_to_evidence.py tools/tests/test_refresh_fogstack_manifest_digests.py
+
+      - name: Enforce manifest digests
+        run: |
+          python3 tools/refresh_fogstack_manifest_digests.py --check \
+            releases/manifests/fogstack.access-v0.1.manifest.json \
+            releases/manifests/fogstack.knowledge-v0.1.manifest.json \
+            releases/manifests/fogstack.evaluation-v0.1.manifest.json
 
       - name: Run native fogstack validation
         run: |

--- a/releases/manifests/fogstack.access-v0.1.manifest.json
+++ b/releases/manifests/fogstack.access-v0.1.manifest.json
@@ -6,8 +6,8 @@
   "bundle": "bundles/fogstack.access-v0.1.yaml",
   "rulepack": "conformance/rulepacks/fogstack.access-v0.1.yaml",
   "verification_helper": "tools/validate_fogstack.py",
-  "bundle_digest": "sha256:PLACEHOLDER",
-  "rulepack_digest": "sha256:PLACEHOLDER",
+  "bundle_digest": "sha256:ce86ac46fc0befd616d8a46ec594cd9ba3bf2af2d720557c4a8f56e495626ed0",
+  "rulepack_digest": "sha256:14fcd59a585251ad0685fe00e743212605285ed193d4c9896dd62db5224eaf73",
   "channel": "preview",
   "support_state": "community",
   "signed": false

--- a/releases/manifests/fogstack.evaluation-v0.1.manifest.json
+++ b/releases/manifests/fogstack.evaluation-v0.1.manifest.json
@@ -6,8 +6,8 @@
   "bundle": "bundles/fogstack.evaluation-v0.1.yaml",
   "rulepack": "conformance/rulepacks/fogstack.evaluation-v0.1.yaml",
   "verification_helper": "tools/validate_fogstack.py",
-  "bundle_digest": "sha256:PLACEHOLDER",
-  "rulepack_digest": "sha256:PLACEHOLDER",
+  "bundle_digest": "sha256:e2c06f31ffb2d856b050740f88c29206954148622e8b87c68efe004beb1ed473",
+  "rulepack_digest": "sha256:e5832ff75cb378f6eb7a29ca39c85f3e522c93260f8d63fe806ed6d163625deb",
   "channel": "preview",
   "support_state": "community",
   "signed": false

--- a/releases/manifests/fogstack.knowledge-v0.1.manifest.json
+++ b/releases/manifests/fogstack.knowledge-v0.1.manifest.json
@@ -6,8 +6,8 @@
   "bundle": "bundles/fogstack.knowledge-v0.1.yaml",
   "rulepack": "conformance/rulepacks/fogstack.knowledge-v0.1.yaml",
   "verification_helper": "tools/validate_fogstack.py",
-  "bundle_digest": "sha256:PLACEHOLDER",
-  "rulepack_digest": "sha256:PLACEHOLDER",
+  "bundle_digest": "sha256:e32a4f060059e1e19bd3d745d58891a53722614196cd19f96045c6ca8c788bef",
+  "rulepack_digest": "sha256:4bc939d6a23cc6a15ed1d2bad0cfc9e6b56661199bd67eb0b050b6d171b0e2e4",
   "channel": "preview",
   "support_state": "community",
   "signed": false

--- a/tools/refresh_fogstack_manifest_digests.py
+++ b/tools/refresh_fogstack_manifest_digests.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            h.update(chunk)
+    return 'sha256:' + h.hexdigest()
+
+
+def refresh_manifest(path: Path, check: bool) -> bool:
+    data = json.loads(path.read_text(encoding='utf-8'))
+    bundle_path = Path(data['bundle'])
+    rulepack_path = Path(data['rulepack'])
+
+    expected_bundle = sha256_file(bundle_path)
+    expected_rulepack = sha256_file(rulepack_path)
+
+    changed = False
+    if data.get('bundle_digest') != expected_bundle:
+        data['bundle_digest'] = expected_bundle
+        changed = True
+    if data.get('rulepack_digest') != expected_rulepack:
+        data['rulepack_digest'] = expected_rulepack
+        changed = True
+
+    if check:
+        return not changed
+
+    if changed:
+        path.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Refresh Fog Stack manifest bundle/rulepack digests')
+    parser.add_argument('manifests', nargs='+', type=Path)
+    parser.add_argument('--check', action='store_true', help='Fail if any manifest digest is stale')
+    args = parser.parse_args()
+
+    ok = True
+    for manifest in args.manifests:
+        ok = refresh_manifest(manifest, check=args.check) and ok
+
+    return 0 if ok else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/tests/test_refresh_fogstack_manifest_digests.py
+++ b/tools/tests/test_refresh_fogstack_manifest_digests.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_refresh_fogstack_manifest_digests_updates_placeholder_values(tmp_path: Path) -> None:
+    bundle = tmp_path / 'bundle.yaml'
+    bundle.write_text('kind: test\n', encoding='utf-8')
+
+    rulepack = tmp_path / 'rulepack.yaml'
+    rulepack.write_text('kind: rulepack\n', encoding='utf-8')
+
+    manifest = tmp_path / 'manifest.json'
+    manifest.write_text(json.dumps({
+        'kind': 'FogStackBundleManifest',
+        'schema_version': 'v0.1',
+        'bundle_id': 'fogstack.test',
+        'version': '0.1.0',
+        'bundle': str(bundle),
+        'rulepack': str(rulepack),
+        'bundle_digest': 'sha256:PLACEHOLDER',
+        'rulepack_digest': 'sha256:PLACEHOLDER',
+        'channel': 'preview',
+        'support_state': 'community',
+        'signed': False,
+    }, indent=2) + '\n', encoding='utf-8')
+
+    subprocess.run([
+        sys.executable,
+        'tools/refresh_fogstack_manifest_digests.py',
+        str(manifest),
+    ], check=True)
+
+    data = json.loads(manifest.read_text(encoding='utf-8'))
+    assert data['bundle_digest'].startswith('sha256:')
+    assert data['rulepack_digest'].startswith('sha256:')
+    assert data['bundle_digest'] != 'sha256:PLACEHOLDER'
+    assert data['rulepack_digest'] != 'sha256:PLACEHOLDER'


### PR DESCRIPTION
## Summary

This PR hardens the canonical Fog Stack release manifests on top of current `main`:

- `tools/refresh_fogstack_manifest_digests.py`
- `tools/tests/test_refresh_fogstack_manifest_digests.py`
- refreshed digests in the three canonical release manifests
- updated `.github/workflows/fogstack-validation.yml` to test and enforce manifest digests

## Why this PR exists

The canonical Fog Stack release manifests still used placeholder bundle/rulepack digests, which is below the quality bar for a serious release surface.

This PR:
- computes and stores real SHA-256 digests for the Access / Knowledge / Evaluation manifests
- adds a helper to refresh/check those digests
- adds a unit test for the helper
- enforces digest correctness in the existing Fog Stack validation workflow

## Not in this PR

- automatic digest refresh for every future bundle version
- signed publication of refreshed manifests
- registry-backed digest resolution

Those remain later steps.
