### PR TITLE
docs: add Next Gen TOM platform binding

### DIFF
--- a/.github/workflows/brokerage-validation.yml
+++ b/.github/workflows/brokerage-validation.yml
@@ -1,0 +1,17 @@
+name: brokerage-validation
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  validate-brokerage-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Validate brokerage example payloads
+        run: python tools/validate_examples.py

--- a/docs/reference/next-gen-tom/INDEX.md
+++ b/docs/reference/next-gen-tom/INDEX.md
@@ -1,0 +1,19 @@
+# Next Gen TOM Platform Binding
+
+This package is the `prophet-platform` implementation binding for the Next Gen operating model.
+
+## Scope
+
+This repository does **not** define the normative operating model. The normative model lives in the standards layer. This repository carries the platform binding:
+- brokerage architecture for runtime and deployment context
+- API and schema starters for brokerage resources
+- validation helpers and example payloads
+- lifecycle guards for implementation and review
+
+## Contents
+- `brokerage-architecture.md`
+- `../../../specs/brokerage/openapi/brokerage-api-v1.yaml`
+- `../../../specs/brokerage/schemas/`
+- `../../../specs/brokerage/validation/transition-guards.md`
+- `../../../specs/brokerage/events/examples/`
+- `../../../tools/validate_examples.py`

--- a/docs/reference/next-gen-tom/brokerage-architecture.md
+++ b/docs/reference/next-gen-tom/brokerage-architecture.md
@@ -1,0 +1,40 @@
+# Next Gen TOM Brokerage Architecture Binding
+
+## Purpose
+
+This document binds the normative Next Gen operating model to `prophet-platform` runtime concerns.
+
+The platform role is to realize brokered service consumption through:
+- standard resource models
+- controlled fulfillment workflows
+- evidence and cost metadata
+- lifecycle guards and validation helpers
+
+## Six-plane model
+
+| Plane | Runtime concern |
+|---|---|
+| Experience | request intake, service catalog, API boundary |
+| Control | policy decisions, approvals, cost and compliance rules |
+| Fulfillment | service blueprints, workflows, provider adapters |
+| Service | observability, SLM, incident and continuity hooks |
+| Evidence | service-instance registration, control records, audit packages |
+| Economics | usage, allocation, showback and unit-cost telemetry |
+
+## Canonical objects carried in this repo
+
+- `ServiceRequest`
+- `ServiceInstance`
+- `EventEnvelope`
+
+These are starter objects only. They are sufficient to define the initial API, examples, and validation path.
+
+## Control gates
+
+- no fulfillment without a blueprint and policy decision
+- no active service without registration and owner assignment
+- no benefit credit without governed request flow and automated evidence capture
+
+## Repo role
+
+`prophet-platform` is the implementation binding for the operating model, not the sole canonical home of the standard.


### PR DESCRIPTION
## Summary

This PR adds the `prophet-platform` implementation binding for the Next Gen operating model.

It adds:
- `docs/reference/next-gen-tom/INDEX.md`
- `docs/reference/next-gen-tom/brokerage-architecture.md`

## Why this shape

The normative operating model belongs in the standards layer. This repository already carries the starter brokerage API, schemas, event examples, and validation helper on `main`; this PR adds the missing documentation layer that explains how those implementation assets bind to the operating model.

## Notes

- This PR is intentionally small and additive.
- It avoids duplicating the normative model in the runtime repo.
- It should be read alongside the companion standards PR in `prophet-platform-standards`.
