### PR TITLE
Add Fog Stack manifest publication path

### DIFF
--- a/.github/workflows/fogstack-manifest-publication.yml
+++ b/.github/workflows/fogstack-manifest-publication.yml
@@ -1,0 +1,64 @@
+name: FogStack Manifest Publication
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "bundles/**"
+      - "conformance/**"
+      - "releases/manifests/**"
+      - "tools/build_fogstack_manifest_publication_set.py"
+      - "tools/tests/test_build_fogstack_manifest_publication_set.py"
+      - "docs/FOGSTACK_*.md"
+      - ".github/workflows/fogstack-manifest-publication.yml"
+  push:
+    branches: [main]
+    paths:
+      - "bundles/**"
+      - "conformance/**"
+      - "releases/manifests/**"
+      - "tools/build_fogstack_manifest_publication_set.py"
+      - "tools/tests/test_build_fogstack_manifest_publication_set.py"
+      - "docs/FOGSTACK_*.md"
+      - ".github/workflows/fogstack-manifest-publication.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  manifest-publication:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Run publication helper tests
+        run: |
+          python -m pytest -q tools/tests/test_build_fogstack_manifest_publication_set.py
+
+      - name: Build publishable manifest set
+        run: |
+          mkdir -p artifacts/manifest-publication
+          python3 tools/build_fogstack_manifest_publication_set.py \
+            --output-dir artifacts/manifest-publication \
+            --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+            --manifest releases/manifests/fogstack.knowledge-v0.1.manifest.json \
+            --manifest releases/manifests/fogstack.evaluation-v0.1.manifest.json
+
+      - name: Upload manifest publication artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fogstack-manifest-publication
+          path: artifacts/manifest-publication/
+          if-no-files-found: error

--- a/tools/build_fogstack_manifest_publication_set.py
+++ b/tools/build_fogstack_manifest_publication_set.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a publishable Fog Stack manifest set")
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--manifest", action="append", required=True, type=Path)
+    parser.add_argument("--signature-type", choices=["cosign", "sigstore", "other"], default=None)
+    parser.add_argument("--signature-ref-prefix", default=None)
+    args = parser.parse_args()
+
+    manifests_dir = args.output_dir / "manifests"
+    manifests_dir.mkdir(parents=True, exist_ok=True)
+
+    publication_index: dict[str, Any] = {
+        "kind": "FogStackManifestPublicationSet",
+        "schema_version": "v0.1",
+        "manifests": [],
+    }
+
+    for manifest_path in args.manifest:
+        data = load_json(manifest_path)
+        if args.signature_type and args.signature_ref_prefix:
+            bundle_id = data.get("bundle_id")
+            version = data.get("version")
+            data["signed"] = True
+            data["signature"] = {
+                "type": args.signature_type,
+                "ref": f"{args.signature_ref_prefix.rstrip('/')}/{bundle_id}-{version}.sig",
+            }
+
+        out_path = manifests_dir / manifest_path.name
+        out_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        publication_index["manifests"].append(
+            {
+                "bundle_id": data.get("bundle_id"),
+                "version": data.get("version"),
+                "ref": str(out_path),
+                "signed": data.get("signed"),
+            }
+        )
+
+    index_path = args.output_dir / "manifest-publication-set.json"
+    index_path.write_text(json.dumps(publication_index, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_build_fogstack_manifest_publication_set.py
+++ b/tools/tests/test_build_fogstack_manifest_publication_set.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_build_manifest_publication_set_attaches_optional_signatures(tmp_path: Path) -> None:
+    manifest = tmp_path / 'fogstack.access-v0.1.manifest.json'
+    manifest.write_text(json.dumps({
+        'kind': 'FogStackBundleManifest',
+        'schema_version': 'v0.1',
+        'bundle_id': 'fogstack.access',
+        'version': '0.1.0',
+        'bundle': 'bundles/fogstack.access-v0.1.yaml',
+        'rulepack': 'conformance/rulepacks/fogstack.access-v0.1.yaml',
+        'bundle_digest': 'sha256:test',
+        'rulepack_digest': 'sha256:test',
+        'channel': 'preview',
+        'support_state': 'community',
+        'signed': False,
+    }, indent=2) + '\n', encoding='utf-8')
+
+    out_dir = tmp_path / 'publication'
+    subprocess.run([
+        sys.executable,
+        'tools/build_fogstack_manifest_publication_set.py',
+        '--output-dir', str(out_dir),
+        '--manifest', str(manifest),
+        '--signature-type', 'cosign',
+        '--signature-ref-prefix', 'artifact://release',
+    ], check=True)
+
+    published = json.loads((out_dir / 'manifests' / manifest.name).read_text(encoding='utf-8'))
+    assert published['signed'] is True
+    assert published['signature']['type'] == 'cosign'
+    assert published['signature']['ref'].endswith('fogstack.access-0.1.0.sig')
+
+    index = json.loads((out_dir / 'manifest-publication-set.json').read_text(encoding='utf-8'))
+    assert index['kind'] == 'FogStackManifestPublicationSet'
+    assert len(index['manifests']) == 1
+    assert index['manifests'][0]['bundle_id'] == 'fogstack.access'


### PR DESCRIPTION
## Summary

This PR adds the next release-surface hardening tranche directly on top of current `main`:

- `tools/build_fogstack_manifest_publication_set.py`
- `tools/tests/test_build_fogstack_manifest_publication_set.py`
- `.github/workflows/fogstack-manifest-publication.yml`

## Why this PR exists

The canonical Fog Stack manifests now carry real bundle/rulepack digests, but the repo still lacks a repo-native manifest publication path that emits a publishable manifest set artifact.

This PR adds:
- a helper that builds a publication set from canonical manifests
- an optional signature-metadata attachment mode for those publication artifacts
- a test for the helper
- a workflow that emits the publishable manifest set as a GitHub Actions artifact

## Not in this PR

- signed publication backed by real external signing infrastructure by default
- registry publication of the manifest set
- promotion / channel mutation logic

Those remain later steps.
