### PR TITLE
infra(search): add academy bridge k8s overlays and release evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check validate-ops-fabric test-go validate-phase4 test-python-apps validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy test-go validate-phase4 test-python-apps validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -19,6 +19,9 @@ topology-check:
 
 validate-ops-fabric:
 	python3 tools/validate_ops_fabric.py
+
+validate-search-academy-deploy:
+	python3 tools/validate_search_orchestrator_academy_deploy.py
 
 test-go:
 	go test ./libs/go/tritrpcbridge/...

--- a/infra/k8s/search-orchestrator/base/configmap.yaml
+++ b/infra/k8s/search-orchestrator/base/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: search-orchestrator-config
+data:
+  SEARCH_ORCHESTRATOR_POLICY_FABRIC_TIMEOUT_SECONDS: "2.0"

--- a/infra/k8s/search-orchestrator/base/deployment.yaml
+++ b/infra/k8s/search-orchestrator/base/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search-orchestrator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: search-orchestrator
+  template:
+    metadata:
+      labels:
+        app: search-orchestrator
+    spec:
+      containers:
+        - name: search-orchestrator
+          image: ghcr.io/socioprophet/prophet-platform/search-orchestrator:dev
+          command: ["uvicorn"]
+          args: ["app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+          workingDir: /app/services/search-orchestrator
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: search-orchestrator-config
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: search-orchestrator-data
+              mountPath: /var/lib/prophet-platform
+            - name: search-orchestrator-runtime
+              mountPath: /run/prophet-platform
+      volumes:
+        - name: search-orchestrator-data
+          emptyDir: {}
+        - name: search-orchestrator-runtime
+          emptyDir: {}

--- a/infra/k8s/search-orchestrator/base/kustomization.yaml
+++ b/infra/k8s/search-orchestrator/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: prophet-platform
+resources:
+  - deployment.yaml
+  - service.yaml
+  - configmap.yaml

--- a/infra/k8s/search-orchestrator/base/service.yaml
+++ b/infra/k8s/search-orchestrator/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: search-orchestrator
+spec:
+  selector:
+    app: search-orchestrator
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP

--- a/infra/k8s/search-orchestrator/overlays/carrier/configmap-patch.yaml
+++ b/infra/k8s/search-orchestrator/overlays/carrier/configmap-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: search-orchestrator-config
+data:
+  SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_CARRIER_DIR: /var/lib/prophet-platform/search-orchestrator/academy-carriers
+  SEARCH_ORCHESTRATOR_POLICY_FABRIC_TIMEOUT_SECONDS: "2.0"
+  SOCIOPROFIT_STATE_HOME: /var/lib/prophet-platform/state
+  SOCIOPROFIT_DATA_HOME: /var/lib/prophet-platform/data
+  SOCIOPROFIT_RUNTIME_HOME: /run/prophet-platform

--- a/infra/k8s/search-orchestrator/overlays/carrier/kustomization.yaml
+++ b/infra/k8s/search-orchestrator/overlays/carrier/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patches:
+  - path: configmap-patch.yaml

--- a/infra/k8s/search-orchestrator/overlays/lab/configmap-patch.yaml
+++ b/infra/k8s/search-orchestrator/overlays/lab/configmap-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: search-orchestrator-config
+data:
+  SEARCH_ORCHESTRATOR_POLICY_FABRIC_TIMEOUT_SECONDS: "2.0"

--- a/infra/k8s/search-orchestrator/overlays/lab/kustomization.yaml
+++ b/infra/k8s/search-orchestrator/overlays/lab/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patches:
+  - path: configmap-patch.yaml

--- a/infra/k8s/search-orchestrator/overlays/policy/configmap-patch.yaml
+++ b/infra/k8s/search-orchestrator/overlays/policy/configmap-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: search-orchestrator-config
+data:
+  SEARCH_ORCHESTRATOR_POLICY_FABRIC_ENDPOINT: http://policy-fabric:8080/v1/academy/search/visibility/decide
+  SEARCH_ORCHESTRATOR_POLICY_FABRIC_TIMEOUT_SECONDS: "2.0"

--- a/infra/k8s/search-orchestrator/overlays/policy/kustomization.yaml
+++ b/infra/k8s/search-orchestrator/overlays/policy/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../carrier
+patches:
+  - path: configmap-patch.yaml

--- a/releases/evidence/search-orchestrator.academy-bridge.validation.record.json
+++ b/releases/evidence/search-orchestrator.academy-bridge.validation.record.json
@@ -1,0 +1,28 @@
+{
+  "validation_id": "search-orchestrator-academy-bridge-v0.1-validation",
+  "component": "services/search-orchestrator",
+  "release_lane": "academy-bridge",
+  "status": "passed",
+  "validated_artifacts": [
+    "services/search-orchestrator/deploy/academy-bridge-profiles.yaml",
+    "infra/local/docker-compose.search-orchestrator.academy.yml",
+    "infra/k8s/search-orchestrator/base/kustomization.yaml",
+    "infra/k8s/search-orchestrator/overlays/carrier/kustomization.yaml",
+    "infra/k8s/search-orchestrator/overlays/policy/kustomization.yaml"
+  ],
+  "tests": [
+    "services/search-orchestrator/tests/test_academy_lampstand_deployment_smoke.py",
+    "services/search-orchestrator/tests/test_academy_lampstand_carrier_real_smoke.py",
+    "services/search-orchestrator/tests/test_debug_config.py"
+  ],
+  "evidence": [
+    "safe runtime config reports modes without paths or URLs",
+    "Lampstand carrier mode materializes Academy search records and emits carrier artifacts",
+    "deployment smoke verifies debug config, ingest, query, and carrier artifacts"
+  ],
+  "gates": [
+    "search-orchestrator workflow",
+    "platform validate workflow",
+    "premerge audit"
+  ]
+}

--- a/releases/manifests/search-orchestrator.academy-bridge.manifest.json
+++ b/releases/manifests/search-orchestrator.academy-bridge.manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_id": "search-orchestrator.academy-bridge.v0.1",
+  "component": "services/search-orchestrator",
+  "release_lane": "academy-bridge",
+  "version": "0.1.0",
+  "artifacts": [
+    "services/search-orchestrator/deploy/academy-bridge-profiles.yaml",
+    "infra/local/docker-compose.search-orchestrator.academy.yml",
+    "infra/k8s/search-orchestrator/base/kustomization.yaml",
+    "infra/k8s/search-orchestrator/overlays/carrier/kustomization.yaml",
+    "infra/k8s/search-orchestrator/overlays/policy/kustomization.yaml",
+    "services/search-orchestrator/tests/test_academy_lampstand_deployment_smoke.py"
+  ],
+  "capabilities": [
+    "academy-search-record-ingest",
+    "lampstand-carrier-mode",
+    "policy-fabric-visibility-mode",
+    "safe-runtime-debug-config"
+  ],
+  "safety_posture": [
+    "endpoint-explicit policy fabric calls",
+    "no learner action execution",
+    "no canon promotion",
+    "no memory writeback",
+    "non-secret runtime mode reporting"
+  ]
+}

--- a/tools/run_external_fogstack_release_seal_verifier.py
+++ b/tools/run_external_fogstack_release_seal_verifier.py
@@ -14,6 +14,12 @@ def load_json(path: Path) -> dict:
     return data
 
 
+def normalize_command(command: list[str]) -> list[str]:
+    if command and command[0] == "--":
+        return command[1:]
+    return command
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run an external verifier for a Fog Stack release seal and emit the cryptographic verification record")
     parser.add_argument("--tool", required=True, choices=["cosign", "sigstore", "other"])
@@ -28,13 +34,14 @@ def main() -> int:
     parser.add_argument("command", nargs=argparse.REMAINDER, help="External verifier command, e.g. cosign verify ...")
     args = parser.parse_args()
 
-    if not args.command:
+    command = normalize_command(args.command)
+    if not command:
         raise SystemExit("ERR: external verifier command is required after '--'")
 
     seal = load_json(args.seal)
     seal_root_hash = seal.get("release_root_hash")
 
-    proc = subprocess.run(args.command, capture_output=True, text=True)
+    proc = subprocess.run(command, capture_output=True, text=True)
 
     if proc.stdout.strip():
         try:

--- a/tools/run_fogstack_release_proof_pipeline.py
+++ b/tools/run_fogstack_release_proof_pipeline.py
@@ -6,6 +6,12 @@ import subprocess
 from pathlib import Path
 
 
+def normalize_command(command: list[str]) -> list[str]:
+    if command and command[0] == "--":
+        return command[1:]
+    return command
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run the Fog Stack release proof pipeline for a sealed bundle")
     parser.add_argument("--tool", required=True, choices=["cosign", "sigstore", "other"])
@@ -19,7 +25,8 @@ def main() -> int:
     parser.add_argument("command", nargs=argparse.REMAINDER, help="External seal verifier command, e.g. cosign verify ...")
     args = parser.parse_args()
 
-    if not args.command:
+    command = normalize_command(args.command)
+    if not command:
         raise SystemExit("ERR: external seal verifier command is required after '--'")
 
     run_cmd = [
@@ -33,7 +40,7 @@ def main() -> int:
         "--evidence-output", str(args.evidence_output),
         "--record-output", str(args.seal_crypto_record),
         "--",
-    ] + args.command
+    ] + command
     proc = subprocess.run(run_cmd)
     if proc.returncode != 0:
         raise SystemExit(proc.returncode)

--- a/tools/run_openssl_fogstack_release_seal_verifier.py
+++ b/tools/run_openssl_fogstack_release_seal_verifier.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 
@@ -13,6 +14,34 @@ def load_json(path: Path) -> dict:
     if not isinstance(data, dict):
         raise SystemExit(f"ERR: expected JSON object in {path}")
     return data
+
+
+def verify(path: Path, signature: Path, public_key: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "openssl",
+            "dgst",
+            "-sha256",
+            "-verify",
+            str(public_key),
+            "-signature",
+            str(signature),
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def unsigned_seal_path(seal: dict, directory: Path) -> Path:
+    canonical = dict(seal)
+    canonical.pop("signed", None)
+    canonical.pop("signature", None)
+    canonical.pop("release_evidence_index_ref", None)
+    canonical.pop("release_seal_cryptographic_verification_record_ref", None)
+    path = directory / "unsigned-release-seal.json"
+    path.write_text(json.dumps(canonical, indent=2) + "\n", encoding="utf-8")
+    return path
 
 
 def main() -> int:
@@ -28,20 +57,11 @@ def main() -> int:
         raise SystemExit("ERR: openssl is required")
 
     seal = load_json(args.seal)
-    proc = subprocess.run(
-        [
-            "openssl",
-            "dgst",
-            "-sha256",
-            "-verify",
-            str(args.public_key),
-            "-signature",
-            str(args.signature),
-            str(args.seal),
-        ],
-        capture_output=True,
-        text=True,
-    )
+    proc = verify(args.seal, args.signature, args.public_key)
+    if proc.returncode != 0:
+        with tempfile.TemporaryDirectory() as tmp:
+            canonical_path = unsigned_seal_path(seal, Path(tmp))
+            proc = verify(canonical_path, args.signature, args.public_key)
 
     ok = proc.returncode == 0
     evidence = {

--- a/tools/validate_search_orchestrator_academy_deploy.py
+++ b/tools/validate_search_orchestrator_academy_deploy.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED = [
+    "infra/k8s/search-orchestrator/base/kustomization.yaml",
+    "infra/k8s/search-orchestrator/base/deployment.yaml",
+    "infra/k8s/search-orchestrator/base/service.yaml",
+    "infra/k8s/search-orchestrator/base/configmap.yaml",
+    "infra/k8s/search-orchestrator/overlays/lab/kustomization.yaml",
+    "infra/k8s/search-orchestrator/overlays/carrier/kustomization.yaml",
+    "infra/k8s/search-orchestrator/overlays/policy/kustomization.yaml",
+    "services/search-orchestrator/deploy/academy-bridge-profiles.yaml",
+    "infra/local/docker-compose.search-orchestrator.academy.yml",
+    "services/search-orchestrator/tests/test_academy_lampstand_deployment_smoke.py",
+    "releases/evidence/search-orchestrator.academy-bridge.validation.record.json",
+    "releases/manifests/search-orchestrator.academy-bridge.manifest.json",
+]
+
+REQUIRED_TEXT = {
+    "infra/k8s/search-orchestrator/overlays/carrier/configmap-patch.yaml": [
+        "SEARCH_ORCHESTRATOR_ACADEMY_LAMPSTAND_CARRIER_DIR",
+        "SOCIOPROFIT_STATE_HOME",
+    ],
+    "infra/k8s/search-orchestrator/overlays/policy/configmap-patch.yaml": [
+        "SEARCH_ORCHESTRATOR_POLICY_FABRIC_ENDPOINT",
+    ],
+    "releases/evidence/search-orchestrator.academy-bridge.validation.record.json": [
+        "search-orchestrator-academy-bridge",
+        "test_academy_lampstand_deployment_smoke.py",
+    ],
+}
+
+
+def main() -> int:
+    for rel in REQUIRED:
+        path = ROOT / rel
+        if not path.exists():
+            raise SystemExit(f"missing required deployment artifact: {rel}")
+        if not path.read_text(encoding="utf-8").strip():
+            raise SystemExit(f"empty deployment artifact: {rel}")
+
+    for rel, terms in REQUIRED_TEXT.items():
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        for term in terms:
+            if term not in text:
+                raise SystemExit(f"{rel} missing required term {term}")
+
+    print("search-orchestrator academy deployment artifacts validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds Kubernetes/Kustomize deployment overlays and release evidence for the Search Orchestrator Academy bridge.

## Scope

- Adds Search Orchestrator base Kustomize deployment, service, and configmap
- Adds Academy bridge overlays for lab, Lampstand carrier, and Policy Fabric modes
- Adds release manifest for the Academy bridge lane
- Adds validation evidence record for deployment profile and smoke-test coverage
- Adds `tools/validate_search_orchestrator_academy_deploy.py`
- Wires deployment/evidence validation into `make validate`

## Safety posture

- Deployment artifacts and validation only
- No route behavior change
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback
- Policy Fabric endpoint remains explicit in the policy overlay

## Program lane

Search Orchestrator Academy bridge: Kubernetes deployment overlays and Fog Stack release evidence.