### PR TITLE
Add Fog Stack manifest promotion path

### DIFF
--- a/.github/workflows/fogstack-manifest-promotion.yml
+++ b/.github/workflows/fogstack-manifest-promotion.yml
@@ -1,0 +1,81 @@
+name: FogStack Manifest Promotion
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "bundles/**"
+      - "conformance/**"
+      - "catalog/fogstack-support-states-v0.1.yaml"
+      - "releases/manifests/**"
+      - "tools/build_fogstack_manifest_publication_set.py"
+      - "tools/promote_fogstack_manifest_publication_set.py"
+      - "tools/tests/test_build_fogstack_manifest_publication_set.py"
+      - "tools/tests/test_promote_fogstack_manifest_publication_set.py"
+      - "docs/FOGSTACK_*.md"
+      - ".github/workflows/fogstack-manifest-promotion.yml"
+  push:
+    branches: [main]
+    paths:
+      - "bundles/**"
+      - "conformance/**"
+      - "catalog/fogstack-support-states-v0.1.yaml"
+      - "releases/manifests/**"
+      - "tools/build_fogstack_manifest_publication_set.py"
+      - "tools/promote_fogstack_manifest_publication_set.py"
+      - "tools/tests/test_build_fogstack_manifest_publication_set.py"
+      - "tools/tests/test_promote_fogstack_manifest_publication_set.py"
+      - "docs/FOGSTACK_*.md"
+      - ".github/workflows/fogstack-manifest-promotion.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  manifest-promotion:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml
+
+      - name: Run publication and promotion tests
+        run: |
+          python -m pytest -q \
+            tools/tests/test_build_fogstack_manifest_publication_set.py \
+            tools/tests/test_promote_fogstack_manifest_publication_set.py
+
+      - name: Build canonical publication set
+        run: |
+          mkdir -p artifacts/manifest-promotion/base artifacts/manifest-promotion/promoted
+          python3 tools/build_fogstack_manifest_publication_set.py \
+            --output-dir artifacts/manifest-promotion/base \
+            --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+            --manifest releases/manifests/fogstack.knowledge-v0.1.manifest.json \
+            --manifest releases/manifests/fogstack.evaluation-v0.1.manifest.json
+
+      - name: Promote publication set to candidate/supported
+        run: |
+          python3 tools/promote_fogstack_manifest_publication_set.py \
+            --input-dir artifacts/manifest-promotion/base \
+            --output-dir artifacts/manifest-promotion/promoted \
+            --support-catalog catalog/fogstack-support-states-v0.1.yaml \
+            --target-channel candidate \
+            --target-support-state supported
+
+      - name: Upload promoted manifest set
+        uses: actions/upload-artifact@v4
+        with:
+          name: fogstack-manifest-promotion
+          path: artifacts/manifest-promotion/
+          if-no-files-found: error

--- a/docs/FOGSTACK_MANIFEST_PROMOTION.md
+++ b/docs/FOGSTACK_MANIFEST_PROMOTION.md
@@ -1,0 +1,40 @@
+# Fog Stack manifest promotion
+
+This document defines the repo-native **manifest promotion** path for Fog Stack.
+
+## Goal
+
+Move from:
+- a canonical manifest publication set
+
+to:
+- a promoted manifest set that carries target channel and support-state values appropriate for the next release lane.
+
+## Minimal flow
+
+1. build the canonical publication set with `tools/build_fogstack_manifest_publication_set.py`
+2. run `tools/promote_fogstack_manifest_publication_set.py`
+3. provide the support-state catalog and optional target channel/support-state overrides
+4. persist the resulting promoted manifest set as a publishable artifact
+
+## Example
+
+Run the promotion helper with:
+- an input publication-set directory
+- an output directory
+- `catalog/fogstack-support-states-v0.1.yaml`
+- optional `--target-channel` and `--target-support-state` overrides
+
+## What this phase provides
+
+- channel/support-state mutation for the publishable manifest set
+- promotion metadata in the output publication-set index
+- lifecycle-status carry-through from the support-state catalog
+
+## What this phase does not yet provide
+
+- signed publication backed by external signing infrastructure by default
+- registry publication of the promoted manifest set
+- policy-gated promotion approval logic
+
+Those remain later steps.

--- a/tools/promote_fogstack_manifest_publication_set.py
+++ b/tools/promote_fogstack_manifest_publication_set.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Promote a Fog Stack manifest publication set")
+    parser.add_argument("--input-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--support-catalog", required=True, type=Path)
+    parser.add_argument("--target-channel", default=None)
+    parser.add_argument("--target-support-state", default=None)
+    args = parser.parse_args()
+
+    index_path = args.input_dir / "manifest-publication-set.json"
+    index = load_json(index_path)
+    manifests = index.get("manifests") or []
+    if not isinstance(manifests, list):
+        raise SystemExit("ERR: publication set manifests list missing or malformed")
+
+    catalog = yaml.safe_load(args.support_catalog.read_text(encoding="utf-8")) or {}
+    offerings = catalog.get("offerings") or []
+    catalog_map = {
+        (item.get("bundle_id"), item.get("version")): item
+        for item in offerings
+        if isinstance(item, dict)
+    }
+
+    out_manifests_dir = args.output_dir / "manifests"
+    out_manifests_dir.mkdir(parents=True, exist_ok=True)
+
+    promoted_index: dict[str, Any] = {
+        "kind": "FogStackManifestPublicationSet",
+        "schema_version": "v0.1",
+        "promotion": {
+            "channel": args.target_channel,
+            "support_state": args.target_support_state,
+            "catalog": str(args.support_catalog),
+        },
+        "manifests": [],
+    }
+
+    for item in manifests:
+        ref = item.get("ref")
+        if not isinstance(ref, str):
+            raise SystemExit("ERR: manifest ref missing in publication set")
+        src = Path(ref)
+        data = load_json(src)
+        bundle_id = data.get("bundle_id")
+        version = data.get("version")
+        cat_item = catalog_map.get((bundle_id, version), {})
+
+        data["channel"] = args.target_channel or cat_item.get("channel") or data.get("channel")
+        data["support_state"] = args.target_support_state or cat_item.get("support_state") or data.get("support_state")
+
+        out_path = out_manifests_dir / src.name
+        out_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+        promoted_index["manifests"].append(
+            {
+                "bundle_id": bundle_id,
+                "version": version,
+                "ref": str(out_path),
+                "signed": data.get("signed"),
+                "channel": data.get("channel"),
+                "support_state": data.get("support_state"),
+                "lifecycle_status": cat_item.get("lifecycle_status"),
+            }
+        )
+
+    (args.output_dir / "manifest-publication-set.json").write_text(
+        json.dumps(promoted_index, indent=2) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_promote_fogstack_manifest_publication_set.py
+++ b/tools/tests/test_promote_fogstack_manifest_publication_set.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_promote_fogstack_manifest_publication_set_updates_channel_and_support_state(tmp_path: Path) -> None:
+    input_dir = tmp_path / 'input'
+    manifests_dir = input_dir / 'manifests'
+    manifests_dir.mkdir(parents=True)
+
+    manifest = manifests_dir / 'fogstack.access-v0.1.manifest.json'
+    manifest.write_text(json.dumps({
+        'kind': 'FogStackBundleManifest',
+        'schema_version': 'v0.1',
+        'bundle_id': 'fogstack.access',
+        'version': '0.1.0',
+        'bundle': 'bundles/fogstack.access-v0.1.yaml',
+        'rulepack': 'conformance/rulepacks/fogstack.access-v0.1.yaml',
+        'bundle_digest': 'sha256:test',
+        'rulepack_digest': 'sha256:test',
+        'channel': 'preview',
+        'support_state': 'community',
+        'signed': False,
+    }, indent=2) + '\n', encoding='utf-8')
+
+    (input_dir / 'manifest-publication-set.json').write_text(json.dumps({
+        'kind': 'FogStackManifestPublicationSet',
+        'schema_version': 'v0.1',
+        'manifests': [
+            {
+                'bundle_id': 'fogstack.access',
+                'version': '0.1.0',
+                'ref': str(manifest),
+                'signed': False,
+            }
+        ],
+    }, indent=2) + '\n', encoding='utf-8')
+
+    catalog = tmp_path / 'support.yaml'
+    catalog.write_text(
+        'schema_version: "fogstack.support-state/v0.1"\n'
+        'kind: "FogStackSupportStates"\n'
+        'offerings:\n'
+        '  - bundle_id: "fogstack.access"\n'
+        '    version: "0.1.0"\n'
+        '    channel: "preview"\n'
+        '    support_state: "community"\n'
+        '    lifecycle_status: "merged-upstream"\n',
+        encoding='utf-8',
+    )
+
+    output_dir = tmp_path / 'output'
+    subprocess.run([
+        sys.executable,
+        'tools/promote_fogstack_manifest_publication_set.py',
+        '--input-dir', str(input_dir),
+        '--output-dir', str(output_dir),
+        '--support-catalog', str(catalog),
+        '--target-channel', 'candidate',
+        '--target-support-state', 'supported',
+    ], check=True)
+
+    promoted_manifest = json.loads((output_dir / 'manifests' / manifest.name).read_text(encoding='utf-8'))
+    assert promoted_manifest['channel'] == 'candidate'
+    assert promoted_manifest['support_state'] == 'supported'
+
+    promoted_index = json.loads((output_dir / 'manifest-publication-set.json').read_text(encoding='utf-8'))
+    assert promoted_index['promotion']['channel'] == 'candidate'
+    assert promoted_index['promotion']['support_state'] == 'supported'
+    assert promoted_index['manifests'][0]['lifecycle_status'] == 'merged-upstream'


### PR DESCRIPTION
## Summary

This PR adds the next release-surface tranche directly on top of current `main`:

- `tools/promote_fogstack_manifest_publication_set.py`
- `tools/tests/test_promote_fogstack_manifest_publication_set.py`
- `.github/workflows/fogstack-manifest-promotion.yml`
- `docs/FOGSTACK_MANIFEST_PROMOTION.md`

## Why this PR exists

The repo now has a canonical manifest publication path, but it still lacks a repo-native way to promote a publication set into a target channel/support-state combination using the support-state catalog.

This PR adds:
- a promotion helper for the publication set
- a unit test for that helper
- a workflow that builds and promotes the canonical publication set as an artifact
- documentation for the promotion path

## Not in this PR

- signed publication backed by external signing infrastructure by default
- registry publication of the promoted manifest set
- policy-gated promotion approval logic

Those remain later steps.
