### PR TITLE
Fog release proof pipeline: canonical refs

### DIFF
--- a/docs/FOGSTACK_RELEASE_PROOF_PIPELINE.md
+++ b/docs/FOGSTACK_RELEASE_PROOF_PIPELINE.md
@@ -19,19 +19,36 @@ to:
 3. pass the external verifier command after `--`
 4. the wrapper emits the seal cryptographic verification record and updates the seal-side backlinks
 
+## Canonical upstream refs
+
+The proof pipeline can now also stamp the release evidence index with optional canonical upstream refs so the release-proof artifact set points back to the already-merged Fog ownership surfaces.
+
+Supported optional refs:
+- `--canonical-contract-surface-ref`
+- `--canonical-deployment-surface-ref`
+- `--canonical-runtime-surface-ref`
+- `--canonical-policy-surface-ref`
+
+Recommended targets are the live upstream homes:
+- `SocioProphet/api-spec` under `fog/`
+- `SocioProphet/manifests` under `fog/`
+- `SocioProphet/cloudshell-fog`
+- `SocioProphet/policy-fabric`
+
 ## Example
 
-Use the wrapper with a seal file, a signature reference, output paths for evidence and the cryptographic verification record, an evidence index path, and the external verifier command after `--`.
+Use the wrapper with a seal file, a signature reference, output paths for evidence and the cryptographic verification record, an evidence index path, the optional canonical upstream refs, and the external verifier command after `--`.
 
 ## What this phase provides
 
 - one orchestrated proof step for the seal side of the trust graph
 - automatic invocation of the seal verification wrapper
 - automatic backlink insertion after the cryptographic record is produced
+- optional insertion of canonical upstream refs into the release evidence index so the proof set names the shared Fog contract, deployment, runtime, and policy surfaces it depends on
 
 ## What this phase does not yet provide
 
-- CI enforcement of the proof pipeline
+- CI enforcement of canonical upstream refs
 - mutation of the non-seal side of the wider trust graph
 - registry publication of the resulting proof set
 

--- a/schemas/release/fogstack-release-evidence-index-v0.1.schema.json
+++ b/schemas/release/fogstack-release-evidence-index-v0.1.schema.json
@@ -24,6 +24,10 @@
     "signature_trust_record_ref": { "type": "string" },
     "release_seal_ref": { "type": ["string", "null"] },
     "release_seal_cryptographic_verification_record_ref": { "type": ["string", "null"] },
+    "canonical_contract_surface_ref": { "type": ["string", "null"] },
+    "canonical_deployment_surface_ref": { "type": ["string", "null"] },
+    "canonical_runtime_surface_ref": { "type": ["string", "null"] },
+    "canonical_policy_surface_ref": { "type": ["string", "null"] },
     "notes": { "type": ["string", "null"] }
   },
   "additionalProperties": false

--- a/tools/link_fogstack_release_seal_artifacts.py
+++ b/tools/link_fogstack_release_seal_artifacts.py
@@ -22,6 +22,10 @@ def main() -> int:
     parser.add_argument("--seal", required=True, type=Path)
     parser.add_argument("--seal-crypto-record", required=True, type=Path)
     parser.add_argument("--evidence-index", required=True, type=Path)
+    parser.add_argument("--canonical-contract-surface-ref")
+    parser.add_argument("--canonical-deployment-surface-ref")
+    parser.add_argument("--canonical-runtime-surface-ref")
+    parser.add_argument("--canonical-policy-surface-ref")
     args = parser.parse_args()
 
     seal = load_json(args.seal)
@@ -35,6 +39,15 @@ def main() -> int:
 
     evidence_index["release_seal_ref"] = str(args.seal)
     evidence_index["release_seal_cryptographic_verification_record_ref"] = str(args.seal_crypto_record)
+
+    if args.canonical_contract_surface_ref is not None:
+        evidence_index["canonical_contract_surface_ref"] = args.canonical_contract_surface_ref
+    if args.canonical_deployment_surface_ref is not None:
+        evidence_index["canonical_deployment_surface_ref"] = args.canonical_deployment_surface_ref
+    if args.canonical_runtime_surface_ref is not None:
+        evidence_index["canonical_runtime_surface_ref"] = args.canonical_runtime_surface_ref
+    if args.canonical_policy_surface_ref is not None:
+        evidence_index["canonical_policy_surface_ref"] = args.canonical_policy_surface_ref
 
     write_json(args.seal, seal)
     write_json(args.seal_crypto_record, seal_crypto)

--- a/tools/run_fogstack_release_proof_pipeline.py
+++ b/tools/run_fogstack_release_proof_pipeline.py
@@ -22,6 +22,10 @@ def main() -> int:
     parser.add_argument("--evidence-output", required=True, type=Path)
     parser.add_argument("--seal-crypto-record", required=True, type=Path)
     parser.add_argument("--evidence-index", required=True, type=Path)
+    parser.add_argument("--canonical-contract-surface-ref")
+    parser.add_argument("--canonical-deployment-surface-ref")
+    parser.add_argument("--canonical-runtime-surface-ref")
+    parser.add_argument("--canonical-policy-surface-ref")
     parser.add_argument("command", nargs=argparse.REMAINDER, help="External seal verifier command, e.g. cosign verify ...")
     args = parser.parse_args()
 
@@ -52,6 +56,15 @@ def main() -> int:
         "--seal-crypto-record", str(args.seal_crypto_record),
         "--evidence-index", str(args.evidence_index),
     ]
+    if args.canonical_contract_surface_ref is not None:
+        link_cmd += ["--canonical-contract-surface-ref", args.canonical_contract_surface_ref]
+    if args.canonical_deployment_surface_ref is not None:
+        link_cmd += ["--canonical-deployment-surface-ref", args.canonical_deployment_surface_ref]
+    if args.canonical_runtime_surface_ref is not None:
+        link_cmd += ["--canonical-runtime-surface-ref", args.canonical_runtime_surface_ref]
+    if args.canonical_policy_surface_ref is not None:
+        link_cmd += ["--canonical-policy-surface-ref", args.canonical_policy_surface_ref]
+
     link = subprocess.run(link_cmd)
     if link.returncode != 0:
         raise SystemExit(link.returncode)

--- a/tools/tests/test_fogstack_release_proof_pipeline.py
+++ b/tools/tests/test_fogstack_release_proof_pipeline.py
@@ -62,6 +62,11 @@ def test_release_proof_pipeline_links_seal_artifacts(tmp_path: Path) -> None:
     env = os.environ.copy()
     env["SEAL_HASH"] = seal_root_hash
 
+    contract_ref = "https://github.com/SocioProphet/api-spec/tree/master/fog"
+    deployment_ref = "https://github.com/SocioProphet/manifests/tree/master/fog"
+    runtime_ref = "https://github.com/SocioProphet/cloudshell-fog"
+    policy_ref = "https://github.com/SocioProphet/policy-fabric/tree/main/contracts"
+
     cmd = [
         sys.executable,
         "tools/run_fogstack_release_proof_pipeline.py",
@@ -81,6 +86,14 @@ def test_release_proof_pipeline_links_seal_artifacts(tmp_path: Path) -> None:
         str(seal_crypto_record),
         "--evidence-index",
         str(evidence_index),
+        "--canonical-contract-surface-ref",
+        contract_ref,
+        "--canonical-deployment-surface-ref",
+        deployment_ref,
+        "--canonical-runtime-surface-ref",
+        runtime_ref,
+        "--canonical-policy-surface-ref",
+        policy_ref,
         "--",
         sys.executable,
         str(mock_verify),
@@ -98,3 +111,7 @@ def test_release_proof_pipeline_links_seal_artifacts(tmp_path: Path) -> None:
     index_after = _read_json(evidence_index)
     assert index_after["release_seal_ref"] == str(seal)
     assert index_after["release_seal_cryptographic_verification_record_ref"] == str(seal_crypto_record)
+    assert index_after["canonical_contract_surface_ref"] == contract_ref
+    assert index_after["canonical_deployment_surface_ref"] == deployment_ref
+    assert index_after["canonical_runtime_surface_ref"] == runtime_ref
+    assert index_after["canonical_policy_surface_ref"] == policy_ref


### PR DESCRIPTION
Add canonical upstream ref support to the Fog release proof pipeline, linker, schema, test, and docs.