### PR TITLE
docs: add Next Gen TOM platform binding and validation workflow

### DIFF
--- a/.github/workflows/brokerage-validation.yml
+++ b/.github/workflows/brokerage-validation.yml
@@ -1,0 +1,17 @@
+name: brokerage-validation
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  validate-brokerage-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Validate brokerage example payloads
+        run: python tools/validate_examples.py

--- a/docs/reference/next-gen-tom/INDEX.md
+++ b/docs/reference/next-gen-tom/INDEX.md
@@ -1,0 +1,9 @@
+# Next Gen TOM Platform Binding
+
+This directory documents how `prophet-platform` binds to the normative Next Gen operating model.
+
+The standards layer defines the operating model. This runtime repository carries the implementation-facing binding:
+- brokerage architecture context
+- starter API and schema surface already present in `specs/brokerage/`
+- validation helpers and examples
+- lifecycle guard documentation

--- a/docs/reference/next-gen-tom/brokerage-architecture.md
+++ b/docs/reference/next-gen-tom/brokerage-architecture.md
@@ -1,0 +1,25 @@
+# Next Gen TOM Brokerage Architecture Binding
+
+This document explains the runtime-facing binding of the Next Gen operating model inside `prophet-platform`.
+
+## Platform role
+
+The platform realizes brokered service consumption through:
+- controlled request intake
+- standard resource models
+- fulfillment workflows and provider adapters
+- service-instance registration
+- evidence and cost metadata
+
+## Runtime planes
+
+- Experience: request intake and API boundary
+- Control: policy decisions, approvals, cost and compliance rules
+- Fulfillment: blueprints, workflows, provider adapters
+- Service: observability, SLM, incident and continuity hooks
+- Evidence: registration, control records, audit packages
+- Economics: usage, allocation, showback and unit-cost telemetry
+
+## Repo role
+
+`prophet-platform` is the implementation binding for the operating model, not the sole canonical home of the standard.


### PR DESCRIPTION
## Summary

This PR adds the clean `prophet-platform` implementation binding for the Next Gen operating model.

It adds:
- `docs/reference/next-gen-tom/INDEX.md`
- `docs/reference/next-gen-tom/brokerage-architecture.md`
- `.github/workflows/brokerage-validation.yml`

## Why this shape

The normative operating model now lives in the standards layer. This runtime repository already carries the starter brokerage API, schemas, examples, and validation helper on `main`; this PR adds the missing documentation binding and wires the existing example validator into CI.

## Notes

- This PR is intentionally small and additive.
- It avoids duplicating normative operating-model content in the runtime repo.
- It supersedes earlier stale runtime-repo landings.
