### PR TITLE
Add Prophet operations intelligence evidence slice

### DIFF
--- a/docs/PROPHET_OPERATIONS_INTELLIGENCE.md
+++ b/docs/PROPHET_OPERATIONS_INTELLIGENCE.md
@@ -1,0 +1,86 @@
+# Prophet Operations Intelligence
+
+This document describes the first Prophet-native operations intelligence evidence slice in `prophet-platform`.
+
+This is not an integration with proprietary observability or optimization products. It is the first open, repo-native evidence path for the same broad category of capability:
+
+- runtime operational signals
+- runtime topology evidence
+- service health assessment
+- policy-gated optimization recommendations
+
+## First slice
+
+The first slice adds four contract surfaces:
+
+- `ProphetOperationalSignal`
+- `ProphetRuntimeTopologyEvidence`
+- `ProphetServiceHealthAssessment`
+- `ProphetOptimizationRecommendation`
+
+It also adds `tools/normalize_prophet_operations_evidence.py`, a vendor-neutral normalizer that accepts a compact local JSON observation and emits a `ProphetOperationsEvidenceBundle` containing normalized signals, optional topology, health assessments, and recommendations.
+
+## Intent
+
+The goal is to make platform operations evidence executable before building dashboards or action automation.
+
+The minimal flow is:
+
+```text
+raw local observation
+  -> normalized operational signals
+  -> optional runtime topology evidence
+  -> service health assessment
+  -> optimization recommendation
+  -> policy gate pending
+```
+
+The recommendation output is deliberately policy-gated. The helper does not execute remediation, mutate infrastructure, or grant authority. It emits evidence and proposed action intent for a later policy/evaluation layer.
+
+## Input shape
+
+The normalizer accepts JSON with these optional top-level fields:
+
+- `source`
+- `observed_at`
+- `signals`
+- `topology`
+
+Example:
+
+```json
+{
+  "source": {"system": "local-demo", "emitter": "unit-test"},
+  "observed_at": "2026-04-25T18:00:00Z",
+  "signals": [
+    {
+      "subject": {"id": "svc-api", "type": "service", "name": "api"},
+      "signal": {"name": "error_rate", "type": "metric", "value": 0.12, "unit": "ratio", "severity": "warn"}
+    }
+  ],
+  "topology": {
+    "scope": {"environment": "test"},
+    "nodes": [{"id": "svc-api", "type": "service", "name": "api"}],
+    "edges": []
+  }
+}
+```
+
+Run:
+
+```bash
+python tools/normalize_prophet_operations_evidence.py raw.json --output artifacts/operations/bundle.json
+```
+
+## Deliberate limits
+
+This PR does not add:
+
+- live collectors
+- external vendor adapters
+- dashboard/UI routes
+- remote action execution
+- scheduler mutation
+- policy decision service calls
+
+Those are follow-on slices. The correct next step is to connect recommendations to a Policy Fabric decision contract, then expose the emitted bundle through the existing platform evidence surfaces.

--- a/schemas/operations/prophet-operational-signal-v0.1.schema.json
+++ b/schemas/operations/prophet-operational-signal-v0.1.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/operations/prophet-operational-signal-v0.1.schema.json",
+  "title": "ProphetOperationalSignal",
+  "type": "object",
+  "required": ["kind", "schema_version", "signal_id", "source", "observed_at", "subject", "signal"],
+  "properties": {
+    "kind": { "const": "ProphetOperationalSignal" },
+    "schema_version": { "const": "v0.1" },
+    "signal_id": { "type": "string", "minLength": 1 },
+    "source": {
+      "type": "object",
+      "required": ["system", "emitter"],
+      "properties": {
+        "system": { "type": "string", "minLength": 1 },
+        "emitter": { "type": "string", "minLength": 1 },
+        "ref": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "observed_at": { "type": "string", "minLength": 1 },
+    "subject": {
+      "type": "object",
+      "required": ["id", "type"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "type": { "type": "string", "minLength": 1 },
+        "name": { "type": ["string", "null"] },
+        "namespace": { "type": ["string", "null"] },
+        "owner_ref": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "signal": {
+      "type": "object",
+      "required": ["name", "type"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "type": { "enum": ["metric", "event", "log", "trace", "state", "health", "cost", "capacity", "security", "other"] },
+        "value": { "type": ["number", "string", "boolean", "object", "array", "null"] },
+        "unit": { "type": ["string", "null"] },
+        "severity": { "enum": ["debug", "info", "notice", "warn", "error", "critical", "unknown"] }
+      },
+      "additionalProperties": true
+    },
+    "evidence_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+    "raw_ref": { "type": ["string", "null"] },
+    "raw_sha256": { "type": ["string", "null"] },
+    "notes": { "type": ["string", "null"] }
+  },
+  "additionalProperties": true
+}

--- a/schemas/operations/prophet-optimization-recommendation-v0.1.schema.json
+++ b/schemas/operations/prophet-optimization-recommendation-v0.1.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/operations/prophet-optimization-recommendation-v0.1.schema.json",
+  "title": "ProphetOptimizationRecommendation",
+  "type": "object",
+  "required": ["kind", "schema_version", "recommendation_id", "created_at", "subject", "action"],
+  "properties": {
+    "kind": { "const": "ProphetOptimizationRecommendation" },
+    "schema_version": { "const": "v0.1" },
+    "recommendation_id": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string", "minLength": 1 },
+    "subject": {
+      "type": "object",
+      "required": ["id", "type"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "type": { "type": "string", "minLength": 1 },
+        "name": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "action": {
+      "type": "object",
+      "required": ["type", "intent"],
+      "properties": {
+        "type": { "enum": ["resize", "reschedule", "scale", "throttle", "isolate", "rollback", "investigate", "no_op", "other"] },
+        "intent": { "type": "string", "minLength": 1 },
+        "description": { "type": ["string", "null"] },
+        "parameters": { "type": "object", "additionalProperties": true }
+      },
+      "additionalProperties": true
+    },
+    "basis": {
+      "type": "object",
+      "properties": {
+        "health_assessment_ref": { "type": ["string", "null"] },
+        "topology_ref": { "type": ["string", "null"] },
+        "signal_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "reason": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "policy_gate": {
+      "type": "object",
+      "properties": {
+        "required": { "type": "boolean", "default": true },
+        "policy_ref": { "type": ["string", "null"] },
+        "decision_ref": { "type": ["string", "null"] },
+        "decision": { "enum": ["pending", "allow", "deny", "manual_review", "unknown"] }
+      },
+      "additionalProperties": true
+    },
+    "risk": {
+      "type": "object",
+      "properties": {
+        "level": { "enum": ["low", "medium", "high", "critical", "unknown"] },
+        "notes": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "evidence_refs": { "type": "array", "items": { "type": "string" }, "default": [] }
+  },
+  "additionalProperties": true
+}

--- a/schemas/operations/prophet-runtime-topology-evidence-v0.1.schema.json
+++ b/schemas/operations/prophet-runtime-topology-evidence-v0.1.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/operations/prophet-runtime-topology-evidence-v0.1.schema.json",
+  "title": "ProphetRuntimeTopologyEvidence",
+  "type": "object",
+  "required": ["kind", "schema_version", "topology_id", "observed_at", "nodes", "edges"],
+  "properties": {
+    "kind": { "const": "ProphetRuntimeTopologyEvidence" },
+    "schema_version": { "const": "v0.1" },
+    "topology_id": { "type": "string", "minLength": 1 },
+    "observed_at": { "type": "string", "minLength": 1 },
+    "scope": {
+      "type": "object",
+      "properties": {
+        "environment": { "type": ["string", "null"] },
+        "workspace_ref": { "type": ["string", "null"] },
+        "release_ref": { "type": ["string", "null"] },
+        "policy_ref": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "type"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "type": { "type": "string", "minLength": 1 },
+          "name": { "type": ["string", "null"] },
+          "status": { "type": ["string", "null"] },
+          "metadata": { "type": "object", "additionalProperties": true }
+        },
+        "additionalProperties": true
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["from", "to", "type"],
+        "properties": {
+          "from": { "type": "string", "minLength": 1 },
+          "to": { "type": "string", "minLength": 1 },
+          "type": { "type": "string", "minLength": 1 },
+          "observed_by": { "type": ["string", "null"] },
+          "metadata": { "type": "object", "additionalProperties": true }
+        },
+        "additionalProperties": true
+      }
+    },
+    "evidence_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+    "raw_ref": { "type": ["string", "null"] },
+    "raw_sha256": { "type": ["string", "null"] }
+  },
+  "additionalProperties": true
+}

--- a/schemas/operations/prophet-service-health-assessment-v0.1.schema.json
+++ b/schemas/operations/prophet-service-health-assessment-v0.1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/operations/prophet-service-health-assessment-v0.1.schema.json",
+  "title": "ProphetServiceHealthAssessment",
+  "type": "object",
+  "required": ["kind", "schema_version", "assessment_id", "assessed_at", "subject", "health"],
+  "properties": {
+    "kind": { "const": "ProphetServiceHealthAssessment" },
+    "schema_version": { "const": "v0.1" },
+    "assessment_id": { "type": "string", "minLength": 1 },
+    "assessed_at": { "type": "string", "minLength": 1 },
+    "subject": {
+      "type": "object",
+      "required": ["id", "type"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "type": { "type": "string", "minLength": 1 },
+        "name": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "health": {
+      "type": "object",
+      "required": ["state"],
+      "properties": {
+        "state": { "enum": ["healthy", "degraded", "unhealthy", "unknown"] },
+        "score": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "summary": { "type": ["string", "null"] },
+        "reasons": { "type": "array", "items": { "type": "string" }, "default": [] }
+      },
+      "additionalProperties": true
+    },
+    "input_signal_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+    "topology_ref": { "type": ["string", "null"] },
+    "policy_ref": { "type": ["string", "null"] },
+    "evidence_refs": { "type": "array", "items": { "type": "string" }, "default": [] }
+  },
+  "additionalProperties": true
+}

--- a/tools/normalize_prophet_operations_evidence.py
+++ b/tools/normalize_prophet_operations_evidence.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Normalize raw local operations observations into Prophet operations evidence.
+
+This helper is intentionally vendor-neutral. It accepts a compact raw JSON input and emits
+Prophet-native operational signals, optional topology evidence, health assessments, and
+optimization recommendations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _stable_id(prefix: str, payload: Any) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"{prefix}-{_sha256_bytes(encoded)[:16]}"
+
+
+def _as_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def normalize_signal(raw_signal: Dict[str, Any], *, source: Dict[str, Any], observed_at: str, raw_ref: str | None, raw_sha256: str | None) -> Dict[str, Any]:
+    subject = raw_signal.get("subject") or raw_signal.get("resource") or {}
+    signal = raw_signal.get("signal") or raw_signal.get("metric") or raw_signal.get("event") or {}
+    normalized = {
+        "kind": "ProphetOperationalSignal",
+        "schema_version": "v0.1",
+        "signal_id": raw_signal.get("signal_id") or _stable_id("opsig", raw_signal),
+        "source": {
+            "system": source.get("system", "unknown"),
+            "emitter": source.get("emitter", "normalize_prophet_operations_evidence"),
+            "ref": source.get("ref"),
+        },
+        "observed_at": raw_signal.get("observed_at") or observed_at,
+        "subject": {
+            "id": str(subject.get("id") or subject.get("name") or "unknown"),
+            "type": str(subject.get("type") or "unknown"),
+            "name": subject.get("name"),
+            "namespace": subject.get("namespace"),
+            "owner_ref": subject.get("owner_ref"),
+        },
+        "signal": {
+            "name": str(signal.get("name") or raw_signal.get("name") or "unknown"),
+            "type": signal.get("type") or raw_signal.get("type") or "metric",
+            "value": signal.get("value", raw_signal.get("value")),
+            "unit": signal.get("unit", raw_signal.get("unit")),
+            "severity": signal.get("severity", raw_signal.get("severity", "unknown")),
+        },
+        "evidence_refs": _as_list(raw_signal.get("evidence_refs")),
+        "raw_ref": raw_ref,
+        "raw_sha256": raw_sha256,
+        "notes": raw_signal.get("notes"),
+    }
+    return normalized
+
+
+def normalize_topology(raw_topology: Dict[str, Any], *, observed_at: str, raw_ref: str | None, raw_sha256: str | None) -> Dict[str, Any]:
+    normalized = {
+        "kind": "ProphetRuntimeTopologyEvidence",
+        "schema_version": "v0.1",
+        "topology_id": raw_topology.get("topology_id") or _stable_id("topology", raw_topology),
+        "observed_at": raw_topology.get("observed_at") or observed_at,
+        "scope": raw_topology.get("scope", {}),
+        "nodes": raw_topology.get("nodes", []),
+        "edges": raw_topology.get("edges", []),
+        "evidence_refs": _as_list(raw_topology.get("evidence_refs")),
+        "raw_ref": raw_ref,
+        "raw_sha256": raw_sha256,
+    }
+    return normalized
+
+
+def assess_health(signal_records: Iterable[Dict[str, Any]], *, topology_ref: str | None = None) -> List[Dict[str, Any]]:
+    assessments: Dict[str, Dict[str, Any]] = {}
+    for record in signal_records:
+        subject = record["subject"]
+        key = f"{subject['type']}:{subject['id']}"
+        severity = record.get("signal", {}).get("severity", "unknown")
+        state = "healthy"
+        reasons: List[str] = []
+        if severity in {"critical", "error"}:
+            state = "unhealthy"
+            reasons.append(f"{record['signal']['name']} severity={severity}")
+        elif severity == "warn":
+            state = "degraded"
+            reasons.append(f"{record['signal']['name']} severity=warn")
+        current = assessments.get(key)
+        if not current:
+            current = {
+                "kind": "ProphetServiceHealthAssessment",
+                "schema_version": "v0.1",
+                "assessment_id": _stable_id("health", {"subject": subject, "topology_ref": topology_ref}),
+                "assessed_at": _utc_now(),
+                "subject": subject,
+                "health": {"state": "healthy", "score": 1.0, "summary": "No degraded signals observed.", "reasons": []},
+                "input_signal_refs": [],
+                "topology_ref": topology_ref,
+                "policy_ref": None,
+                "evidence_refs": [],
+            }
+            assessments[key] = current
+        current["input_signal_refs"].append(record["signal_id"])
+        if state == "unhealthy" or (state == "degraded" and current["health"]["state"] == "healthy"):
+            current["health"]["state"] = state
+            current["health"]["score"] = 0.2 if state == "unhealthy" else 0.6
+            current["health"]["summary"] = f"{subject.get('name') or subject['id']} is {state}."
+        current["health"]["reasons"].extend(reasons)
+    return list(assessments.values())
+
+
+def recommend(assessments: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    recommendations: List[Dict[str, Any]] = []
+    for assessment in assessments:
+        state = assessment["health"]["state"]
+        if state == "healthy":
+            continue
+        action_type = "investigate" if state == "degraded" else "isolate"
+        subject = assessment["subject"]
+        rec = {
+            "kind": "ProphetOptimizationRecommendation",
+            "schema_version": "v0.1",
+            "recommendation_id": _stable_id("oprec", {"assessment": assessment["assessment_id"], "action": action_type}),
+            "created_at": _utc_now(),
+            "subject": subject,
+            "action": {
+                "type": action_type,
+                "intent": "restore_service_health",
+                "description": f"{action_type} {subject.get('name') or subject['id']} based on health assessment.",
+                "parameters": {},
+            },
+            "basis": {
+                "health_assessment_ref": assessment["assessment_id"],
+                "topology_ref": assessment.get("topology_ref"),
+                "signal_refs": assessment.get("input_signal_refs", []),
+                "reason": assessment["health"].get("summary"),
+            },
+            "policy_gate": {"required": True, "policy_ref": assessment.get("policy_ref"), "decision_ref": None, "decision": "pending"},
+            "risk": {"level": "medium" if state == "degraded" else "high", "notes": None},
+            "evidence_refs": assessment.get("evidence_refs", []),
+        }
+        recommendations.append(rec)
+    return recommendations
+
+
+def normalize_document(raw: Dict[str, Any], *, raw_ref: str | None, raw_sha256: str | None) -> Dict[str, Any]:
+    observed_at = raw.get("observed_at") or _utc_now()
+    source = raw.get("source") or {"system": "local", "emitter": "normalize_prophet_operations_evidence"}
+    signals = [normalize_signal(item, source=source, observed_at=observed_at, raw_ref=raw_ref, raw_sha256=raw_sha256) for item in raw.get("signals", [])]
+    topology = normalize_topology(raw["topology"], observed_at=observed_at, raw_ref=raw_ref, raw_sha256=raw_sha256) if raw.get("topology") else None
+    topology_ref = topology["topology_id"] if topology else None
+    assessments = assess_health(signals, topology_ref=topology_ref)
+    recommendations = recommend(assessments)
+    return {
+        "kind": "ProphetOperationsEvidenceBundle",
+        "schema_version": "v0.1",
+        "bundle_id": raw.get("bundle_id") or _stable_id("opsbundle", raw),
+        "created_at": _utc_now(),
+        "signals": signals,
+        "topology": topology,
+        "health_assessments": assessments,
+        "recommendations": recommendations,
+        "raw_ref": raw_ref,
+        "raw_sha256": raw_sha256,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Raw operations observation JSON")
+    parser.add_argument("--output", type=Path, required=True, help="Output normalized evidence bundle JSON")
+    parser.add_argument("--raw-ref", default=None, help="Optional raw evidence reference URI/path")
+    args = parser.parse_args()
+
+    payload = args.input.read_bytes()
+    raw = json.loads(payload.decode("utf-8"))
+    bundle = normalize_document(raw, raw_ref=args.raw_ref or str(args.input), raw_sha256=_sha256_bytes(payload))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_normalize_prophet_operations_evidence.py
+++ b/tools/tests/test_normalize_prophet_operations_evidence.py
@@ -1,0 +1,44 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_normalize_prophet_operations_evidence(tmp_path: Path):
+    raw = {
+        "source": {"system": "local-demo", "emitter": "unit-test"},
+        "observed_at": "2026-04-25T18:00:00Z",
+        "signals": [
+            {
+                "subject": {"id": "svc-api", "type": "service", "name": "api"},
+                "signal": {"name": "error_rate", "type": "metric", "value": 0.12, "unit": "ratio", "severity": "warn"},
+            },
+            {
+                "subject": {"id": "worker-1", "type": "workload", "name": "worker"},
+                "signal": {"name": "restart_loop", "type": "event", "value": True, "severity": "error"},
+            },
+        ],
+        "topology": {
+            "scope": {"environment": "test"},
+            "nodes": [
+                {"id": "svc-api", "type": "service", "name": "api"},
+                {"id": "worker-1", "type": "workload", "name": "worker"},
+            ],
+            "edges": [{"from": "svc-api", "to": "worker-1", "type": "depends_on"}],
+        },
+    }
+    input_path = tmp_path / "raw.json"
+    output_path = tmp_path / "bundle.json"
+    input_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    script = Path(__file__).resolve().parents[1] / "normalize_prophet_operations_evidence.py"
+    subprocess.run([sys.executable, str(script), str(input_path), "--output", str(output_path)], check=True)
+
+    bundle = json.loads(output_path.read_text(encoding="utf-8"))
+    assert bundle["kind"] == "ProphetOperationsEvidenceBundle"
+    assert len(bundle["signals"]) == 2
+    assert bundle["topology"]["kind"] == "ProphetRuntimeTopologyEvidence"
+    assert {item["health"]["state"] for item in bundle["health_assessments"]} == {"degraded", "unhealthy"}
+    assert len(bundle["recommendations"]) == 2
+    assert all(item["policy_gate"]["required"] for item in bundle["recommendations"])
+    assert {item["action"]["type"] for item in bundle["recommendations"]} == {"investigate", "isolate"}


### PR DESCRIPTION
## Summary

Adds the first Prophet-native operations intelligence evidence slice.

This PR adds:
- `schemas/operations/prophet-operational-signal-v0.1.schema.json`
- `schemas/operations/prophet-runtime-topology-evidence-v0.1.schema.json`
- `schemas/operations/prophet-service-health-assessment-v0.1.schema.json`
- `schemas/operations/prophet-optimization-recommendation-v0.1.schema.json`
- `tools/normalize_prophet_operations_evidence.py`
- `tools/tests/test_normalize_prophet_operations_evidence.py`
- `docs/PROPHET_OPERATIONS_INTELLIGENCE.md`

## Boundary

This is not an integration with proprietary observability or optimization products.

It is a vendor-neutral Prophet Platform evidence path for:
- operational signals
- runtime topology evidence
- service health assessment
- policy-gated optimization recommendations

## Runtime behavior

The normalizer consumes a compact local raw JSON observation and emits a `ProphetOperationsEvidenceBundle` containing:
- normalized operational signals
- optional topology evidence
- health assessments
- recommendations with `policy_gate.required=true`

## Intentional non-goals

- no live collectors
- no external vendor adapters
- no dashboard/UI routes
- no remote action execution
- no scheduler mutation
- no policy decision service calls

## Next tranche

Connect the emitted recommendations to a Policy Fabric decision contract and expose the operations evidence bundle through the existing platform evidence surfaces.
