### PR TITLE
Link operations recommendations to Policy Fabric decisions

### DIFF
--- a/docs/PROPHET_OPERATIONS_INTELLIGENCE.md
+++ b/docs/PROPHET_OPERATIONS_INTELLIGENCE.md
@@ -8,6 +8,7 @@ This is not an integration with proprietary observability or optimization produc
 - runtime topology evidence
 - service health assessment
 - policy-gated optimization recommendations
+- evidence links to governed Policy Fabric action decisions
 
 ## First slice
 
@@ -18,7 +19,7 @@ The first slice adds four contract surfaces:
 - `ProphetServiceHealthAssessment`
 - `ProphetOptimizationRecommendation`
 
-It also adds `tools/normalize_prophet_operations_evidence.py`, a vendor-neutral normalizer that accepts a compact local JSON observation and emits a `ProphetOperationsEvidenceBundle` containing normalized signals, optional topology, health assessments, and recommendations.
+It also adds `tools/normalize_prophet_operations_evidence.py`, a vendor-neutral normalizer that accepts a compact local JSON observation and emits a `ProphetOperationsEvidenceBundle` containing normalized signals, optional topology, health assessments, recommendations, and evidence links.
 
 ## Intent
 
@@ -32,10 +33,41 @@ raw local observation
   -> optional runtime topology evidence
   -> service health assessment
   -> optimization recommendation
-  -> policy gate pending
+  -> Policy Fabric action decision reference
+  -> evidence link
 ```
 
 The recommendation output is deliberately policy-gated. The helper does not execute remediation, mutate infrastructure, or grant authority. It emits evidence and proposed action intent for a later policy/evaluation layer.
+
+## Policy Fabric decision linkage
+
+Each non-healthy assessment can emit a `ProphetOptimizationRecommendation`. Each recommendation carries:
+
+- `policy_gate.required=true`
+- `policy_gate.policy_ref=policy://operations/default-action-gates/v1`
+- `policy_gate.decision_contract_ref=schema://policy-fabric/contracts/prophet_operations_action_decision_v1.schema.json`
+- `policy_gate.decision_ref=policy-fabric://prophet-operations-action-decision/v1/<recommendation_id>`
+- `policy_gate.decision=pending`
+
+The decision contract lives in `SocioProphet/policy-fabric` as `ProphetOperationsActionDecision`. The platform-side bundle does not make the decision. It records the required decision target and emits an evidence link that connects the operations bundle to the policy-decision artifact.
+
+The emitted evidence-link shape is:
+
+```json
+{
+  "kind": "ProphetOperationsEvidenceLink",
+  "schema_version": "v0.1",
+  "from_ref": "artifact://prophet-platform/operations/<bundle_id>",
+  "to_ref": "policy-fabric://prophet-operations-action-decision/v1/<recommendation_id>",
+  "relationship": "requires_policy_decision",
+  "contract_ref": "schema://policy-fabric/contracts/prophet_operations_action_decision_v1.schema.json",
+  "recommendation_ref": "<recommendation_id>"
+}
+```
+
+A checked-in example is available at:
+
+- `examples/operations/prophet_operations_evidence_bundle_with_policy_decision_links_0001.json`
 
 ## Input shape
 
@@ -74,13 +106,13 @@ python tools/normalize_prophet_operations_evidence.py raw.json --output artifact
 
 ## Deliberate limits
 
-This PR does not add:
+This lane does not add:
 
 - live collectors
 - external vendor adapters
 - dashboard/UI routes
 - remote action execution
 - scheduler mutation
-- policy decision service calls
+- live policy service calls
 
-Those are follow-on slices. The correct next step is to connect recommendations to a Policy Fabric decision contract, then expose the emitted bundle through the existing platform evidence surfaces.
+Those are follow-on slices. The correct next step is to expose the emitted operations bundle through existing platform evidence surfaces and add a policy-decision ingest/example path once Policy Fabric decisions are produced by a live evaluator.

--- a/examples/operations/prophet_operations_evidence_bundle_with_policy_decision_links_0001.json
+++ b/examples/operations/prophet_operations_evidence_bundle_with_policy_decision_links_0001.json
@@ -1,0 +1,157 @@
+{
+  "kind": "ProphetOperationsEvidenceBundle",
+  "schema_version": "v0.1",
+  "bundle_id": "opsbundle-demo-0001",
+  "created_at": "2026-04-25T21:30:00Z",
+  "signals": [
+    {
+      "kind": "ProphetOperationalSignal",
+      "schema_version": "v0.1",
+      "signal_id": "opsig-restart-loop-worker-1",
+      "source": {
+        "system": "local-demo",
+        "emitter": "example",
+        "ref": null
+      },
+      "observed_at": "2026-04-25T21:29:00Z",
+      "subject": {
+        "id": "worker-1",
+        "type": "workload",
+        "name": "worker",
+        "namespace": "demo",
+        "owner_ref": "service:svc-api"
+      },
+      "signal": {
+        "name": "restart_loop",
+        "type": "event",
+        "value": true,
+        "unit": null,
+        "severity": "error"
+      },
+      "evidence_refs": [],
+      "raw_ref": "examples/operations/raw_worker_restart_loop.json",
+      "raw_sha256": "example-sha256-placeholder",
+      "notes": null
+    }
+  ],
+  "topology": {
+    "kind": "ProphetRuntimeTopologyEvidence",
+    "schema_version": "v0.1",
+    "topology_id": "topology-demo-0001",
+    "observed_at": "2026-04-25T21:29:00Z",
+    "scope": {
+      "environment": "demo",
+      "workspace_ref": "workspace:demo",
+      "release_ref": "release:demo",
+      "policy_ref": "policy://operations/default-action-gates/v1"
+    },
+    "nodes": [
+      {
+        "id": "svc-api",
+        "type": "service",
+        "name": "api",
+        "status": "degraded",
+        "metadata": {}
+      },
+      {
+        "id": "worker-1",
+        "type": "workload",
+        "name": "worker",
+        "status": "unhealthy",
+        "metadata": {}
+      }
+    ],
+    "edges": [
+      {
+        "from": "svc-api",
+        "to": "worker-1",
+        "type": "depends_on",
+        "observed_by": "example",
+        "metadata": {}
+      }
+    ],
+    "evidence_refs": [],
+    "raw_ref": "examples/operations/raw_worker_restart_loop.json",
+    "raw_sha256": "example-sha256-placeholder"
+  },
+  "health_assessments": [
+    {
+      "kind": "ProphetServiceHealthAssessment",
+      "schema_version": "v0.1",
+      "assessment_id": "health-worker-1",
+      "assessed_at": "2026-04-25T21:30:00Z",
+      "subject": {
+        "id": "worker-1",
+        "type": "workload",
+        "name": "worker"
+      },
+      "health": {
+        "state": "unhealthy",
+        "score": 0.2,
+        "summary": "worker is unhealthy.",
+        "reasons": [
+          "restart_loop severity=error"
+        ]
+      },
+      "input_signal_refs": [
+        "opsig-restart-loop-worker-1"
+      ],
+      "topology_ref": "topology-demo-0001",
+      "policy_ref": "policy://operations/default-action-gates/v1",
+      "evidence_refs": []
+    }
+  ],
+  "recommendations": [
+    {
+      "kind": "ProphetOptimizationRecommendation",
+      "schema_version": "v0.1",
+      "recommendation_id": "oprec-worker-1-isolate",
+      "created_at": "2026-04-25T21:30:00Z",
+      "subject": {
+        "id": "worker-1",
+        "type": "workload",
+        "name": "worker"
+      },
+      "action": {
+        "type": "isolate",
+        "intent": "restore_service_health",
+        "description": "isolate worker based on health assessment.",
+        "parameters": {}
+      },
+      "basis": {
+        "health_assessment_ref": "health-worker-1",
+        "topology_ref": "topology-demo-0001",
+        "signal_refs": [
+          "opsig-restart-loop-worker-1"
+        ],
+        "reason": "worker is unhealthy."
+      },
+      "policy_gate": {
+        "required": true,
+        "policy_ref": "policy://operations/default-action-gates/v1",
+        "decision_contract_ref": "schema://policy-fabric/contracts/prophet_operations_action_decision_v1.schema.json",
+        "decision_ref": "policy-fabric://prophet-operations-action-decision/v1/oprec-worker-1-isolate",
+        "decision": "pending"
+      },
+      "risk": {
+        "level": "high",
+        "notes": null
+      },
+      "evidence_refs": []
+    }
+  ],
+  "evidence_links": [
+    {
+      "kind": "ProphetOperationsEvidenceLink",
+      "schema_version": "v0.1",
+      "link_id": "opslink-demo-0001",
+      "from_ref": "artifact://prophet-platform/operations/opsbundle-demo-0001",
+      "to_ref": "policy-fabric://prophet-operations-action-decision/v1/oprec-worker-1-isolate",
+      "relationship": "requires_policy_decision",
+      "contract_ref": "schema://policy-fabric/contracts/prophet_operations_action_decision_v1.schema.json",
+      "recommendation_ref": "oprec-worker-1-isolate"
+    }
+  ],
+  "raw_ref": "examples/operations/raw_worker_restart_loop.json",
+  "raw_sha256": "example-sha256-placeholder"
+}

--- a/tools/normalize_prophet_operations_evidence.py
+++ b/tools/normalize_prophet_operations_evidence.py
@@ -15,6 +15,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
+POLICY_FABRIC_OPERATIONS_DECISION_CONTRACT = "schema://policy-fabric/contracts/prophet_operations_action_decision_v1.schema.json"
+DEFAULT_OPERATIONS_POLICY_REF = "policy://operations/default-action-gates/v1"
+
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -126,6 +129,10 @@ def assess_health(signal_records: Iterable[Dict[str, Any]], *, topology_ref: str
     return list(assessments.values())
 
 
+def policy_decision_ref_for(recommendation_id: str) -> str:
+    return f"policy-fabric://prophet-operations-action-decision/v1/{recommendation_id}"
+
+
 def recommend(assessments: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
     recommendations: List[Dict[str, Any]] = []
     for assessment in assessments:
@@ -134,10 +141,11 @@ def recommend(assessments: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
             continue
         action_type = "investigate" if state == "degraded" else "isolate"
         subject = assessment["subject"]
+        recommendation_id = _stable_id("oprec", {"assessment": assessment["assessment_id"], "action": action_type})
         rec = {
             "kind": "ProphetOptimizationRecommendation",
             "schema_version": "v0.1",
-            "recommendation_id": _stable_id("oprec", {"assessment": assessment["assessment_id"], "action": action_type}),
+            "recommendation_id": recommendation_id,
             "created_at": _utc_now(),
             "subject": subject,
             "action": {
@@ -152,12 +160,36 @@ def recommend(assessments: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "signal_refs": assessment.get("input_signal_refs", []),
                 "reason": assessment["health"].get("summary"),
             },
-            "policy_gate": {"required": True, "policy_ref": assessment.get("policy_ref"), "decision_ref": None, "decision": "pending"},
+            "policy_gate": {
+                "required": True,
+                "policy_ref": assessment.get("policy_ref") or DEFAULT_OPERATIONS_POLICY_REF,
+                "decision_contract_ref": POLICY_FABRIC_OPERATIONS_DECISION_CONTRACT,
+                "decision_ref": policy_decision_ref_for(recommendation_id),
+                "decision": "pending",
+            },
             "risk": {"level": "medium" if state == "degraded" else "high", "notes": None},
             "evidence_refs": assessment.get("evidence_refs", []),
         }
         recommendations.append(rec)
     return recommendations
+
+
+def evidence_links_for(bundle_id: str, recommendations: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    links: List[Dict[str, Any]] = []
+    for recommendation in recommendations:
+        links.append(
+            {
+                "kind": "ProphetOperationsEvidenceLink",
+                "schema_version": "v0.1",
+                "link_id": _stable_id("opslink", {"bundle_id": bundle_id, "recommendation": recommendation["recommendation_id"]}),
+                "from_ref": f"artifact://prophet-platform/operations/{bundle_id}",
+                "to_ref": recommendation["policy_gate"]["decision_ref"],
+                "relationship": "requires_policy_decision",
+                "contract_ref": recommendation["policy_gate"]["decision_contract_ref"],
+                "recommendation_ref": recommendation["recommendation_id"],
+            }
+        )
+    return links
 
 
 def normalize_document(raw: Dict[str, Any], *, raw_ref: str | None, raw_sha256: str | None) -> Dict[str, Any]:
@@ -168,15 +200,17 @@ def normalize_document(raw: Dict[str, Any], *, raw_ref: str | None, raw_sha256: 
     topology_ref = topology["topology_id"] if topology else None
     assessments = assess_health(signals, topology_ref=topology_ref)
     recommendations = recommend(assessments)
+    bundle_id = raw.get("bundle_id") or _stable_id("opsbundle", raw)
     return {
         "kind": "ProphetOperationsEvidenceBundle",
         "schema_version": "v0.1",
-        "bundle_id": raw.get("bundle_id") or _stable_id("opsbundle", raw),
+        "bundle_id": bundle_id,
         "created_at": _utc_now(),
         "signals": signals,
         "topology": topology,
         "health_assessments": assessments,
         "recommendations": recommendations,
+        "evidence_links": evidence_links_for(bundle_id, recommendations),
         "raw_ref": raw_ref,
         "raw_sha256": raw_sha256,
     }

--- a/tools/tests/test_normalize_prophet_operations_evidence.py
+++ b/tools/tests/test_normalize_prophet_operations_evidence.py
@@ -4,6 +4,10 @@ import sys
 from pathlib import Path
 
 
+POLICY_FABRIC_DECISION_CONTRACT = "schema://policy-fabric/contracts/prophet_operations_action_decision_v1.schema.json"
+DEFAULT_OPERATIONS_POLICY_REF = "policy://operations/default-action-gates/v1"
+
+
 def test_normalize_prophet_operations_evidence(tmp_path: Path):
     raw = {
         "source": {"system": "local-demo", "emitter": "unit-test"},
@@ -42,3 +46,17 @@ def test_normalize_prophet_operations_evidence(tmp_path: Path):
     assert len(bundle["recommendations"]) == 2
     assert all(item["policy_gate"]["required"] for item in bundle["recommendations"])
     assert {item["action"]["type"] for item in bundle["recommendations"]} == {"investigate", "isolate"}
+
+    for recommendation in bundle["recommendations"]:
+        gate = recommendation["policy_gate"]
+        assert gate["policy_ref"] == DEFAULT_OPERATIONS_POLICY_REF
+        assert gate["decision_contract_ref"] == POLICY_FABRIC_DECISION_CONTRACT
+        assert gate["decision_ref"].startswith("policy-fabric://prophet-operations-action-decision/v1/oprec-")
+        assert gate["decision"] == "pending"
+
+    assert len(bundle["evidence_links"]) == len(bundle["recommendations"])
+    linked_recommendations = {link["recommendation_ref"] for link in bundle["evidence_links"]}
+    assert linked_recommendations == {item["recommendation_id"] for item in bundle["recommendations"]}
+    assert all(link["relationship"] == "requires_policy_decision" for link in bundle["evidence_links"])
+    assert all(link["contract_ref"] == POLICY_FABRIC_DECISION_CONTRACT for link in bundle["evidence_links"])
+    assert all(link["to_ref"].startswith("policy-fabric://prophet-operations-action-decision/v1/oprec-") for link in bundle["evidence_links"])


### PR DESCRIPTION
## Summary

Completes the next Prophet operations intelligence tranche by linking platform-side recommendations to the Policy Fabric action decision contract.

This PR updates:
- `tools/normalize_prophet_operations_evidence.py`
- `tools/tests/test_normalize_prophet_operations_evidence.py`
- `docs/PROPHET_OPERATIONS_INTELLIGENCE.md`

This PR adds:
- `examples/operations/prophet_operations_evidence_bundle_with_policy_decision_links_0001.json`

## What changes

Recommendations now carry:
- `policy_gate.required=true`
- `policy_gate.policy_ref=policy://operations/default-action-gates/v1`
- `policy_gate.decision_contract_ref=schema://policy-fabric/contracts/prophet_operations_action_decision_v1.schema.json`
- deterministic `policy_gate.decision_ref=policy-fabric://prophet-operations-action-decision/v1/<recommendation_id>`
- `policy_gate.decision=pending`

Bundles now include `evidence_links` connecting:

`artifact://prophet-platform/operations/<bundle_id>`

...to:

`policy-fabric://prophet-operations-action-decision/v1/<recommendation_id>`

with relationship `requires_policy_decision`.

## Boundary

No live policy service call is added.
No remediation execution is added.
No scheduler or infrastructure mutation is added.

The platform emits the required decision target and evidence link. Policy Fabric owns the governed decision artifact.

## Why

PR #178 created Prophet-native operations recommendations. Policy Fabric PR #25 created the decision contract. This PR closes the evidence-link gap between them.
