### PR TITLE
Enforce operations policy decisions before action execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ test-python-apps:
 	cd apps/semantic-bridge && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-test.txt && PYTHONPATH=src pytest -q tests
 
 test-tools:
-	python3 -m pytest -q tools/tests
+	test -d .venv-tools || python3 -m venv .venv-tools
+	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest && pytest -q tools/tests
 
 smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy test-go test-python-apps smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy test-go validate-phase4 test-python-apps validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -39,6 +39,9 @@ test-python-apps:
 	cd apps/zone-router && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-test.txt && PYTHONPATH=src pytest -q tests
 	cd apps/semantic-bridge && test -d .venv || python3 -m venv .venv
 	cd apps/semantic-bridge && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-test.txt && PYTHONPATH=src pytest -q tests
+
+test-tools:
+	python3 -m pytest -q tools/tests
 
 smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-python-apps:
 
 test-tools:
 	test -d .venv-tools || python3 -m venv .venv-tools
-	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest && pytest -q tools/tests
+	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml && pytest -q tools/tests
 
 smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke
 

--- a/docs/PROPHET_OPERATIONS_INTELLIGENCE.md
+++ b/docs/PROPHET_OPERATIONS_INTELLIGENCE.md
@@ -9,6 +9,7 @@ This is not an integration with proprietary observability or optimization produc
 - service health assessment
 - policy-gated optimization recommendations
 - evidence links to governed Policy Fabric action decisions
+- local validation that blocks execution unless a matching allow decision exists
 
 ## First slice
 
@@ -35,6 +36,8 @@ raw local observation
   -> optimization recommendation
   -> Policy Fabric action decision reference
   -> evidence link
+  -> local decision validation
+  -> executable only when decision.outcome=allow
 ```
 
 The recommendation output is deliberately policy-gated. The helper does not execute remediation, mutate infrastructure, or grant authority. It emits evidence and proposed action intent for a later policy/evaluation layer.
@@ -68,6 +71,50 @@ The emitted evidence-link shape is:
 A checked-in example is available at:
 
 - `examples/operations/prophet_operations_evidence_bundle_with_policy_decision_links_0001.json`
+
+## Action decision enforcement
+
+`tools/validate_prophet_operations_policy_decisions.py` validates operations bundles against supplied `ProphetOperationsActionDecision` artifacts.
+
+Execution rule:
+
+- missing decision: blocked
+- `decision.outcome=pending`: blocked
+- `decision.outcome=manual_review`: blocked
+- `decision.outcome=defer`: blocked
+- `decision.outcome=deny`: blocked
+- `decision.outcome=unknown`: blocked
+- `decision.outcome=allow`: executable only if recommendation, subject, and action linkage match
+
+The validator also checks that the decision uses:
+
+- `kind=ProphetOperationsActionDecision`
+- `schema_version=v1`
+- `recommendation_ref=<recommendation_id>`
+- matching `subject.id` and `subject.type`, when present
+- matching `proposed_action.type` and `proposed_action.intent`, when present
+
+Example blocked validation:
+
+```bash
+python tools/validate_prophet_operations_policy_decisions.py \
+  --bundle examples/operations/prophet_operations_evidence_bundle_with_policy_decision_links_0001.json \
+  --decision examples/operations/prophet_operations_action_decision_manual_review_0001.json
+```
+
+Example executable validation:
+
+```bash
+python tools/validate_prophet_operations_policy_decisions.py \
+  --bundle examples/operations/prophet_operations_evidence_bundle_with_policy_decision_links_0001.json \
+  --decision examples/operations/prophet_operations_action_decision_allow_0001.json \
+  --require-executable
+```
+
+Checked-in decision examples:
+
+- `examples/operations/prophet_operations_action_decision_manual_review_0001.json`
+- `examples/operations/prophet_operations_action_decision_allow_0001.json`
 
 ## Input shape
 
@@ -115,4 +162,4 @@ This lane does not add:
 - scheduler mutation
 - live policy service calls
 
-Those are follow-on slices. The correct next step is to expose the emitted operations bundle through existing platform evidence surfaces and add a policy-decision ingest/example path once Policy Fabric decisions are produced by a live evaluator.
+Those are follow-on slices. The current enforcement surface is local: it proves that an operation recommendation cannot be treated as executable unless a supplied Policy Fabric decision artifact explicitly allows it and links to the recommendation consistently.

--- a/examples/operations/prophet_operations_action_decision_allow_0001.json
+++ b/examples/operations/prophet_operations_action_decision_allow_0001.json
@@ -1,0 +1,50 @@
+{
+  "kind": "ProphetOperationsActionDecision",
+  "schema_version": "v1",
+  "decision_id": "ops-decision-allow-0001",
+  "decided_at": "2026-04-25T21:40:00Z",
+  "recommendation_ref": "oprec-worker-1-isolate",
+  "subject": {
+    "id": "worker-1",
+    "type": "workload",
+    "name": "worker"
+  },
+  "proposed_action": {
+    "type": "isolate",
+    "intent": "restore_service_health",
+    "description": "Isolate worker after restart-loop health assessment.",
+    "parameters": {
+      "isolation_mode": "quarantine-network"
+    }
+  },
+  "decision": {
+    "outcome": "allow",
+    "reason": "Policy allows single-workload isolation for unhealthy restart-loop after explicit gate approval.",
+    "risk_level": "high",
+    "expires_at": "2026-04-25T22:40:00Z"
+  },
+  "basis": {
+    "policy_refs": [
+      "policy://operations/default-action-gates/v1"
+    ],
+    "health_assessment_ref": "health-worker-1",
+    "topology_ref": "topology-demo-0001",
+    "signal_refs": [
+      "opsig-restart-loop-worker-1"
+    ],
+    "evidence_refs": [
+      "artifact://prophet-platform/operations/opsbundle-demo-0001"
+    ]
+  },
+  "controls": {
+    "requires_human_approval": true,
+    "requires_change_window": false,
+    "max_execution_scope": "single-workload",
+    "rollback_required": true
+  },
+  "audit": {
+    "actor": "policy-fabric/example",
+    "mode": "hybrid",
+    "notes": "Allow example for platform-side executable recommendation validation."
+  }
+}

--- a/examples/operations/prophet_operations_action_decision_manual_review_0001.json
+++ b/examples/operations/prophet_operations_action_decision_manual_review_0001.json
@@ -1,0 +1,50 @@
+{
+  "kind": "ProphetOperationsActionDecision",
+  "schema_version": "v1",
+  "decision_id": "ops-decision-manual-review-0001",
+  "decided_at": "2026-04-25T21:35:00Z",
+  "recommendation_ref": "oprec-worker-1-isolate",
+  "subject": {
+    "id": "worker-1",
+    "type": "workload",
+    "name": "worker"
+  },
+  "proposed_action": {
+    "type": "isolate",
+    "intent": "restore_service_health",
+    "description": "Isolate worker after restart-loop health assessment.",
+    "parameters": {
+      "isolation_mode": "quarantine-network"
+    }
+  },
+  "decision": {
+    "outcome": "manual_review",
+    "reason": "High-risk remediation requires human approval before execution.",
+    "risk_level": "high",
+    "expires_at": null
+  },
+  "basis": {
+    "policy_refs": [
+      "policy://operations/default-action-gates/v1"
+    ],
+    "health_assessment_ref": "health-worker-1",
+    "topology_ref": "topology-demo-0001",
+    "signal_refs": [
+      "opsig-restart-loop-worker-1"
+    ],
+    "evidence_refs": [
+      "artifact://prophet-platform/operations/opsbundle-demo-0001"
+    ]
+  },
+  "controls": {
+    "requires_human_approval": true,
+    "requires_change_window": false,
+    "max_execution_scope": "single-workload",
+    "rollback_required": true
+  },
+  "audit": {
+    "actor": "policy-fabric/example",
+    "mode": "hybrid",
+    "notes": "Manual-review example for platform-side action blocking."
+  }
+}

--- a/tools/tests/test_validate_prophet_operations_policy_decisions.py
+++ b/tools/tests/test_validate_prophet_operations_policy_decisions.py
@@ -1,0 +1,69 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def run_validator(*args: str) -> subprocess.CompletedProcess[str]:
+    script = repo_root() / "tools" / "validate_prophet_operations_policy_decisions.py"
+    return subprocess.run([sys.executable, str(script), *args], text=True, capture_output=True)
+
+
+def bundle_path() -> Path:
+    return repo_root() / "examples" / "operations" / "prophet_operations_evidence_bundle_with_policy_decision_links_0001.json"
+
+
+def manual_review_decision_path() -> Path:
+    return repo_root() / "examples" / "operations" / "prophet_operations_action_decision_manual_review_0001.json"
+
+
+def allow_decision_path() -> Path:
+    return repo_root() / "examples" / "operations" / "prophet_operations_action_decision_allow_0001.json"
+
+
+def test_manual_review_decision_blocks_execution_without_failing_non_executable_validation():
+    result = run_validator("--bundle", str(bundle_path()), "--decision", str(manual_review_decision_path()))
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert report["summary"]["blocked_count"] == 1
+    assert report["summary"]["executable_count"] == 0
+    assert report["blocked_recommendations"] == [
+        {"recommendation_id": "oprec-worker-1-isolate", "outcome": "manual_review"}
+    ]
+
+
+def test_manual_review_decision_fails_when_executable_action_is_required():
+    result = run_validator(
+        "--bundle",
+        str(bundle_path()),
+        "--decision",
+        str(manual_review_decision_path()),
+        "--require-executable",
+    )
+    assert result.returncode != 0
+    assert "decision outcome=manual_review" in result.stderr
+
+
+def test_missing_decision_fails_when_executable_action_is_required():
+    result = run_validator("--bundle", str(bundle_path()), "--require-executable")
+    assert result.returncode != 0
+    assert "requires policy decision but no matching decision artifact" in result.stderr
+
+
+def test_allow_decision_passes_when_executable_action_is_required():
+    result = run_validator(
+        "--bundle",
+        str(bundle_path()),
+        "--decision",
+        str(allow_decision_path()),
+        "--require-executable",
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert report["summary"]["blocked_count"] == 0
+    assert report["summary"]["executable_count"] == 1
+    assert report["executable_recommendations"] == ["oprec-worker-1-isolate"]

--- a/tools/validate_prophet_operations_policy_decisions.py
+++ b/tools/validate_prophet_operations_policy_decisions.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Validate Prophet operations recommendations against Policy Fabric action decisions.
+
+This validator enforces the first non-execution safety boundary for Prophet operations
+intelligence:
+
+- recommendations that require policy decisions must resolve to a matching decision artifact;
+- decision artifacts must use the Policy Fabric `ProphetOperationsActionDecision` shape;
+- pending, deny, manual_review, defer, and unknown decisions are blocked for execution;
+- allow decisions are only executable when recommendation/action/subject linkage is consistent.
+
+The validator intentionally performs structural checks locally. It does not call a live Policy
+Fabric service and it does not execute remediation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+ALLOWED_EXECUTION_OUTCOME = "allow"
+BLOCKING_OUTCOMES = {"pending", "deny", "manual_review", "defer", "unknown"}
+EXPECTED_DECISION_KIND = "ProphetOperationsActionDecision"
+EXPECTED_DECISION_VERSION = "v1"
+EXPECTED_RECOMMENDATION_KIND = "ProphetOptimizationRecommendation"
+EXPECTED_BUNDLE_KIND = "ProphetOperationsEvidenceBundle"
+
+
+class ValidationError(Exception):
+    pass
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def as_list(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def decision_index(decisions: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    index: Dict[str, Dict[str, Any]] = {}
+    for decision in decisions:
+        if decision.get("kind") != EXPECTED_DECISION_KIND:
+            raise ValidationError(f"decision has invalid kind: {decision.get('kind')}")
+        if decision.get("schema_version") != EXPECTED_DECISION_VERSION:
+            raise ValidationError(f"decision {decision.get('decision_id')} has invalid schema_version: {decision.get('schema_version')}")
+        ref = decision.get("recommendation_ref")
+        if not ref:
+            raise ValidationError(f"decision {decision.get('decision_id')} is missing recommendation_ref")
+        if ref in index:
+            raise ValidationError(f"duplicate decision for recommendation_ref={ref}")
+        index[ref] = decision
+    return index
+
+
+def validate_decision_link(recommendation: Dict[str, Any], decision: Dict[str, Any]) -> Tuple[bool, str]:
+    rec_id = recommendation.get("recommendation_id")
+    if recommendation.get("kind") != EXPECTED_RECOMMENDATION_KIND:
+        raise ValidationError(f"recommendation {rec_id} has invalid kind: {recommendation.get('kind')}")
+    if decision.get("recommendation_ref") != rec_id:
+        raise ValidationError(f"decision {decision.get('decision_id')} does not reference recommendation {rec_id}")
+
+    rec_subject = recommendation.get("subject", {})
+    dec_subject = decision.get("subject", {})
+    for field in ("id", "type"):
+        if dec_subject.get(field) is not None and dec_subject.get(field) != rec_subject.get(field):
+            raise ValidationError(
+                f"decision {decision.get('decision_id')} subject.{field}={dec_subject.get(field)!r} does not match recommendation {rec_id} subject.{field}={rec_subject.get(field)!r}"
+            )
+
+    rec_action = recommendation.get("action", {})
+    dec_action = decision.get("proposed_action", {})
+    for field in ("type", "intent"):
+        if dec_action.get(field) is not None and dec_action.get(field) != rec_action.get(field):
+            raise ValidationError(
+                f"decision {decision.get('decision_id')} proposed_action.{field}={dec_action.get(field)!r} does not match recommendation {rec_id} action.{field}={rec_action.get(field)!r}"
+            )
+
+    outcome = decision.get("decision", {}).get("outcome", "unknown")
+    if outcome in BLOCKING_OUTCOMES:
+        return False, outcome
+    if outcome != ALLOWED_EXECUTION_OUTCOME:
+        raise ValidationError(f"decision {decision.get('decision_id')} has unsupported outcome={outcome!r}")
+    return True, outcome
+
+
+def validate_bundle(bundle: Dict[str, Any], decisions: Iterable[Dict[str, Any]], *, require_executable: bool) -> Dict[str, Any]:
+    if bundle.get("kind") != EXPECTED_BUNDLE_KIND:
+        raise ValidationError(f"bundle has invalid kind: {bundle.get('kind')}")
+
+    decisions_by_rec = decision_index(decisions)
+    checks: List[Dict[str, Any]] = []
+    executable_recommendations: List[str] = []
+    blocked_recommendations: List[Dict[str, str]] = []
+
+    for recommendation in bundle.get("recommendations", []):
+        rec_id = recommendation.get("recommendation_id")
+        gate = recommendation.get("policy_gate", {})
+        if gate.get("required") is not True:
+            checks.append({"recommendation_id": rec_id, "status": "pass", "reason": "policy gate not required"})
+            continue
+
+        decision = decisions_by_rec.get(rec_id)
+        if not decision:
+            if require_executable:
+                raise ValidationError(f"recommendation {rec_id} requires policy decision but no matching decision artifact was supplied")
+            checks.append({"recommendation_id": rec_id, "status": "blocked", "reason": "missing_decision"})
+            blocked_recommendations.append({"recommendation_id": rec_id, "outcome": "missing_decision"})
+            continue
+
+        executable, outcome = validate_decision_link(recommendation, decision)
+        if executable:
+            executable_recommendations.append(rec_id)
+            checks.append({"recommendation_id": rec_id, "status": "pass", "reason": "decision_allows_execution"})
+        else:
+            if require_executable:
+                raise ValidationError(f"recommendation {rec_id} is not executable: decision outcome={outcome}")
+            blocked_recommendations.append({"recommendation_id": rec_id, "outcome": outcome})
+            checks.append({"recommendation_id": rec_id, "status": "blocked", "reason": f"decision_outcome_{outcome}"})
+
+    return {
+        "kind": "ProphetOperationsPolicyDecisionValidationReport",
+        "schema_version": "v0.1",
+        "bundle_id": bundle.get("bundle_id"),
+        "summary": {
+            "recommendation_count": len(bundle.get("recommendations", [])),
+            "decision_count": len(decisions_by_rec),
+            "executable_count": len(executable_recommendations),
+            "blocked_count": len(blocked_recommendations),
+            "require_executable": require_executable,
+        },
+        "checks": checks,
+        "executable_recommendations": executable_recommendations,
+        "blocked_recommendations": blocked_recommendations,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle", type=Path, required=True, help="ProphetOperationsEvidenceBundle JSON")
+    parser.add_argument("--decision", type=Path, action="append", default=[], help="Policy Fabric ProphetOperationsActionDecision JSON. May be supplied more than once.")
+    parser.add_argument("--output", type=Path, default=None, help="Optional output validation report JSON")
+    parser.add_argument("--require-executable", action="store_true", help="Fail unless every policy-gated recommendation has an allow decision")
+    args = parser.parse_args()
+
+    bundle = load_json(args.bundle)
+    decisions = [load_json(path) for path in args.decision]
+    report = validate_bundle(bundle, decisions, require_executable=args.require_executable)
+
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    else:
+        print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds local enforcement for Prophet operations recommendations against Policy Fabric action decision artifacts.

This PR adds:
- `tools/validate_prophet_operations_policy_decisions.py`
- `tools/tests/test_validate_prophet_operations_policy_decisions.py`
- `examples/operations/prophet_operations_action_decision_manual_review_0001.json`
- `examples/operations/prophet_operations_action_decision_allow_0001.json`

This PR updates:
- `Makefile` so `make validate` runs `tools/tests`
- `docs/PROPHET_OPERATIONS_INTELLIGENCE.md` with blocked-action semantics

## Enforcement rule

A policy-gated recommendation is not executable unless a matching `ProphetOperationsActionDecision` artifact exists and has `decision.outcome=allow`.

Blocked outcomes:
- missing decision
- pending
- manual_review
- defer
- deny
- unknown

The validator also checks recommendation/decision consistency:
- decision kind/version
- recommendation ref
- subject linkage
- action type / intent linkage

## Boundary

No live policy service call is added.
No scheduler or infrastructure mutation is added.
No remediation execution is added.

This is a local enforcement/validation surface that prevents operations recommendations from being treated as executable action without an explicit Policy Fabric allow decision.

## Validation

`make validate` now includes `test-tools`, which creates an isolated `.venv-tools`, installs `pytest`, and runs `pytest -q tools/tests`.
