### PR TITLE
Wire academy bridge into ApplicationSet under fogstack.knowledge

### DIFF
--- a/infra/k8s/argo-cd/appsets/socioprophet-appset.yaml
+++ b/infra/k8s/argo-cd/appsets/socioprophet-appset.yaml
@@ -13,6 +13,9 @@ spec:
             path: apps/gateway/kustomize/overlays/dev
           - name: socioprophet-web
             path: apps/socioprophet-web/kustomize/overlays/dev
+          - name: search-orchestrator-academy-bridge
+            path: infra/k8s/search-orchestrator/overlays/policy
+            bundle: fogstack.knowledge
   template:
     metadata:
       name: '{{name}}'

--- a/tools/validate_search_orchestrator_academy_deploy.py
+++ b/tools/validate_search_orchestrator_academy_deploy.py
@@ -17,6 +17,7 @@ REQUIRED = [
     "services/search-orchestrator/tests/test_academy_lampstand_deployment_smoke.py",
     "releases/evidence/search-orchestrator.academy-bridge.validation.record.json",
     "releases/manifests/search-orchestrator.academy-bridge.manifest.json",
+    "infra/k8s/argo-cd/appsets/socioprophet-appset.yaml",
 ]
 
 REQUIRED_TEXT = {
@@ -30,6 +31,12 @@ REQUIRED_TEXT = {
     "releases/evidence/search-orchestrator.academy-bridge.validation.record.json": [
         "search-orchestrator-academy-bridge",
         "test_academy_lampstand_deployment_smoke.py",
+    ],
+    "infra/k8s/argo-cd/appsets/socioprophet-appset.yaml": [
+        "kind: ApplicationSet",
+        "search-orchestrator-academy-bridge",
+        "infra/k8s/search-orchestrator/overlays/policy",
+        "bundle: fogstack.knowledge",
     ],
 }
 


### PR DESCRIPTION
## Summary

Adds the existing Search Orchestrator Academy Bridge deployment overlay to the ArgoCD ApplicationSet and validates that it is bound to the named `fogstack.knowledge` bundle.

This PR updates:
- `infra/k8s/argo-cd/appsets/socioprophet-appset.yaml`
- `tools/validate_search_orchestrator_academy_deploy.py`

## What changes

The ApplicationSet now includes:

```yaml
- name: search-orchestrator-academy-bridge
  path: infra/k8s/search-orchestrator/overlays/policy
  bundle: fogstack.knowledge
```

The deployment validator now requires:
- the ApplicationSet artifact exists
- `kind: ApplicationSet`
- `search-orchestrator-academy-bridge`
- `infra/k8s/search-orchestrator/overlays/policy`
- `bundle: fogstack.knowledge`

## Why

The repo already had validated Academy Bridge deployment artifacts, but the top-level ArgoCD ApplicationSet only deployed API, gateway, and web. This closes the deployment-topology gap without inventing a parallel deployment path.

## Software review

Correctness: this reuses the existing validated Search Orchestrator policy overlay instead of adding a duplicate Academy deployment.

Risk: low. The change is declarative AppSet wiring plus validation. It does not change service code or runtime behavior outside ArgoCD reconciliation.

Known limitation: this does not prove live ArgoCD reconciliation in a cluster; it proves repo-native deployment topology and CI validation.
