### PR TITLE
Lock operations decisions to Policy Fabric schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-python-apps:
 
 test-tools:
 	test -d .venv-tools || python3 -m venv .venv-tools
-	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml && pytest -q tools/tests
+	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests
 
 smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke
 

--- a/docs/PROPHET_OPERATIONS_INTELLIGENCE.md
+++ b/docs/PROPHET_OPERATIONS_INTELLIGENCE.md
@@ -10,6 +10,7 @@ This is not an integration with proprietary observability or optimization produc
 - policy-gated optimization recommendations
 - evidence links to governed Policy Fabric action decisions
 - local validation that blocks execution unless a matching allow decision exists
+- vendored Policy Fabric schema validation for operations action decisions
 
 ## First slice
 
@@ -36,6 +37,7 @@ raw local observation
   -> optimization recommendation
   -> Policy Fabric action decision reference
   -> evidence link
+  -> vendored Policy Fabric schema validation
   -> local decision validation
   -> executable only when decision.outcome=allow
 ```
@@ -86,13 +88,16 @@ Execution rule:
 - `decision.outcome=unknown`: blocked
 - `decision.outcome=allow`: executable only if recommendation, subject, and action linkage match
 
-The validator also checks that the decision uses:
+The validator checks decisions in two layers:
 
-- `kind=ProphetOperationsActionDecision`
-- `schema_version=v1`
-- `recommendation_ref=<recommendation_id>`
-- matching `subject.id` and `subject.type`, when present
-- matching `proposed_action.type` and `proposed_action.intent`, when present
+1. JSON Schema validation against the vendored Policy Fabric contract:
+   - `schemas/external/policy-fabric/prophet_operations_action_decision_v1.schema.json`
+2. Semantic linkage validation:
+   - `kind=ProphetOperationsActionDecision`
+   - `schema_version=v1`
+   - `recommendation_ref=<recommendation_id>`
+   - matching `subject.id` and `subject.type`, when present
+   - matching `proposed_action.type` and `proposed_action.intent`, when present
 
 Example blocked validation:
 
@@ -115,6 +120,18 @@ Checked-in decision examples:
 
 - `examples/operations/prophet_operations_action_decision_manual_review_0001.json`
 - `examples/operations/prophet_operations_action_decision_allow_0001.json`
+
+## Policy Fabric schema lock
+
+The platform vendors the Policy Fabric operations action decision schema from:
+
+- `SocioProphet/policy-fabric:contracts/prophet_operations_action_decision_v1.schema.json`
+
+The vendored platform copy lives at:
+
+- `schemas/external/policy-fabric/prophet_operations_action_decision_v1.schema.json`
+
+This gives `prophet-platform` a local, CI-runnable contract lock. It reduces silent drift between platform enforcement and the Policy Fabric decision shape. It does not replace live Policy Fabric service integration.
 
 ## Input shape
 
@@ -162,4 +179,4 @@ This lane does not add:
 - scheduler mutation
 - live policy service calls
 
-Those are follow-on slices. The current enforcement surface is local: it proves that an operation recommendation cannot be treated as executable unless a supplied Policy Fabric decision artifact explicitly allows it and links to the recommendation consistently.
+Those are follow-on slices. The current enforcement surface is local: it proves that an operation recommendation cannot be treated as executable unless a supplied Policy Fabric decision artifact validates against the vendored Policy Fabric schema, explicitly allows it, and links to the recommendation consistently.

--- a/schemas/external/policy-fabric/prophet_operations_action_decision_v1.schema.json
+++ b/schemas/external/policy-fabric/prophet_operations_action_decision_v1.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/prophet_operations_action_decision_v1.schema.json",
+  "title": "ProphetOperationsActionDecision",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "decision_id",
+    "decided_at",
+    "recommendation_ref",
+    "decision",
+    "basis"
+  ],
+  "properties": {
+    "kind": { "const": "ProphetOperationsActionDecision" },
+    "schema_version": { "const": "v1" },
+    "decision_id": { "type": "string", "minLength": 1 },
+    "decided_at": { "type": "string", "minLength": 1 },
+    "recommendation_ref": { "type": "string", "minLength": 1 },
+    "subject": {
+      "type": "object",
+      "properties": {
+        "id": { "type": ["string", "null"] },
+        "type": { "type": ["string", "null"] },
+        "name": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "proposed_action": {
+      "type": "object",
+      "properties": {
+        "type": { "type": ["string", "null"] },
+        "intent": { "type": ["string", "null"] },
+        "description": { "type": ["string", "null"] },
+        "parameters": { "type": "object", "additionalProperties": true }
+      },
+      "additionalProperties": true
+    },
+    "decision": {
+      "type": "object",
+      "required": ["outcome"],
+      "properties": {
+        "outcome": { "enum": ["allow", "deny", "manual_review", "defer", "unknown"] },
+        "reason": { "type": ["string", "null"] },
+        "risk_level": { "enum": ["low", "medium", "high", "critical", "unknown"] },
+        "expires_at": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "basis": {
+      "type": "object",
+      "required": ["policy_refs"],
+      "properties": {
+        "policy_refs": { "type": "array", "items": { "type": "string" } },
+        "health_assessment_ref": { "type": ["string", "null"] },
+        "topology_ref": { "type": ["string", "null"] },
+        "signal_refs": { "type": "array", "items": { "type": "string" }, "default": [] },
+        "evidence_refs": { "type": "array", "items": { "type": "string" }, "default": [] }
+      },
+      "additionalProperties": true
+    },
+    "controls": {
+      "type": "object",
+      "properties": {
+        "requires_human_approval": { "type": "boolean", "default": false },
+        "requires_change_window": { "type": "boolean", "default": false },
+        "max_execution_scope": { "type": ["string", "null"] },
+        "rollback_required": { "type": "boolean", "default": false }
+      },
+      "additionalProperties": true
+    },
+    "audit": {
+      "type": "object",
+      "properties": {
+        "actor": { "type": ["string", "null"] },
+        "mode": { "enum": ["automated", "human", "hybrid", "unknown"] },
+        "notes": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/tools/tests/test_validate_prophet_operations_policy_decisions.py
+++ b/tools/tests/test_validate_prophet_operations_policy_decisions.py
@@ -67,3 +67,16 @@ def test_allow_decision_passes_when_executable_action_is_required():
     assert report["summary"]["blocked_count"] == 0
     assert report["summary"]["executable_count"] == 1
     assert report["executable_recommendations"] == ["oprec-worker-1-isolate"]
+
+
+def test_invalid_decision_shape_fails_policy_fabric_schema_validation(tmp_path: Path):
+    invalid = json.loads(allow_decision_path().read_text(encoding="utf-8"))
+    del invalid["basis"]
+    invalid_path = tmp_path / "invalid_decision.json"
+    invalid_path.write_text(json.dumps(invalid), encoding="utf-8")
+
+    result = run_validator("--bundle", str(bundle_path()), "--decision", str(invalid_path))
+
+    assert result.returncode != 0
+    assert "failed Policy Fabric schema validation" in result.stderr
+    assert "basis" in result.stderr

--- a/tools/validate_prophet_operations_policy_decisions.py
+++ b/tools/validate_prophet_operations_policy_decisions.py
@@ -5,12 +5,13 @@ This validator enforces the first non-execution safety boundary for Prophet oper
 intelligence:
 
 - recommendations that require policy decisions must resolve to a matching decision artifact;
-- decision artifacts must use the Policy Fabric `ProphetOperationsActionDecision` shape;
+- decision artifacts must validate against the vendored Policy Fabric
+  `ProphetOperationsActionDecision` JSON Schema;
 - pending, deny, manual_review, defer, and unknown decisions are blocked for execution;
 - allow decisions are only executable when recommendation/action/subject linkage is consistent.
 
-The validator intentionally performs structural checks locally. It does not call a live Policy
-Fabric service and it does not execute remediation.
+The validator intentionally performs local checks. It does not call a live Policy Fabric service and
+it does not execute remediation.
 """
 
 from __future__ import annotations
@@ -19,6 +20,11 @@ import argparse
 import json
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Tuple
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY_FABRIC_DECISION_SCHEMA = ROOT / "schemas" / "external" / "policy-fabric" / "prophet_operations_action_decision_v1.schema.json"
 
 ALLOWED_EXECUTION_OUTCOME = "allow"
 BLOCKING_OUTCOMES = {"pending", "deny", "manual_review", "defer", "unknown"}
@@ -36,6 +42,12 @@ def load_json(path: Path) -> Dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def load_policy_fabric_schema() -> Dict[str, Any]:
+    if not POLICY_FABRIC_DECISION_SCHEMA.exists():
+        raise ValidationError(f"missing vendored Policy Fabric schema: {POLICY_FABRIC_DECISION_SCHEMA}")
+    return load_json(POLICY_FABRIC_DECISION_SCHEMA)
+
+
 def as_list(value: Any) -> List[Any]:
     if value is None:
         return []
@@ -44,9 +56,19 @@ def as_list(value: Any) -> List[Any]:
     return [value]
 
 
-def decision_index(decisions: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+def validate_decision_schema(decision: Dict[str, Any], schema: Dict[str, Any]) -> None:
+    try:
+        jsonschema.validate(decision, schema)
+    except jsonschema.ValidationError as exc:
+        decision_id = decision.get("decision_id", "<unknown>")
+        path = ".".join(str(part) for part in exc.absolute_path) or "<root>"
+        raise ValidationError(f"decision {decision_id} failed Policy Fabric schema validation at {path}: {exc.message}") from exc
+
+
+def decision_index(decisions: Iterable[Dict[str, Any]], schema: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     index: Dict[str, Dict[str, Any]] = {}
     for decision in decisions:
+        validate_decision_schema(decision, schema)
         if decision.get("kind") != EXPECTED_DECISION_KIND:
             raise ValidationError(f"decision has invalid kind: {decision.get('kind')}")
         if decision.get("schema_version") != EXPECTED_DECISION_VERSION:
@@ -95,7 +117,8 @@ def validate_bundle(bundle: Dict[str, Any], decisions: Iterable[Dict[str, Any]],
     if bundle.get("kind") != EXPECTED_BUNDLE_KIND:
         raise ValidationError(f"bundle has invalid kind: {bundle.get('kind')}")
 
-    decisions_by_rec = decision_index(decisions)
+    schema = load_policy_fabric_schema()
+    decisions_by_rec = decision_index(decisions, schema)
     checks: List[Dict[str, Any]] = []
     executable_recommendations: List[str] = []
     blocked_recommendations: List[Dict[str, str]] = []


### PR DESCRIPTION
## Summary

Adds a local Policy Fabric schema lock for Prophet operations action decisions and validates supplied decision artifacts against that schema before semantic execution-gate checks.

This PR adds:
- `schemas/external/policy-fabric/prophet_operations_action_decision_v1.schema.json`

This PR updates:
- `tools/validate_prophet_operations_policy_decisions.py`
- `tools/tests/test_validate_prophet_operations_policy_decisions.py`
- `Makefile`
- `docs/PROPHET_OPERATIONS_INTELLIGENCE.md`

## What changes

The operations policy-decision validator now:
- loads the vendored Policy Fabric decision schema
- validates every supplied `ProphetOperationsActionDecision` with `jsonschema.validate`
- rejects invalid decision artifacts before recommendation/action linkage checks
- keeps existing blocked-action behavior for missing, manual_review, deny, defer, pending, and unknown outcomes

The tool-test environment now installs `jsonschema`.

## Software review

Correctness: closes a cross-repo contract drift gap by pinning the Policy Fabric decision shape locally in `prophet-platform` and enforcing it in CI tests.

Risk: low. This is validation hardening only. It does not call a live Policy Fabric service and does not execute remediation.

Weakness: the vendored schema can drift from upstream `policy-fabric` unless refreshed by process or a connector-backed check. Next hardening should register this lock in Sociosphere and add an upstream schema digest/refresh check.
