### PR TITLE
Refresh Fog release proof canonical surface refs

### DIFF
--- a/docs/FOGSTACK_RELEASE_PROOF_PIPELINE.md
+++ b/docs/FOGSTACK_RELEASE_PROOF_PIPELINE.md
@@ -15,24 +15,55 @@ to:
 ## Minimal flow
 
 1. provide the release seal, bundle identity/version, signature reference, and evidence index
-2. invoke `tools/run_fogstack_release_proof_pipeline.py`
-3. pass the external verifier command after `--`
-4. the wrapper emits the seal cryptographic verification record and updates the seal-side backlinks
+2. optionally provide canonical contract/deployment/runtime/policy surface refs
+3. invoke `tools/run_fogstack_release_proof_pipeline.py`
+4. pass the external verifier command after `--`
+5. the wrapper emits the seal cryptographic verification record and updates the seal-side backlinks
 
 ## Example
 
-Use the wrapper with a seal file, a signature reference, output paths for evidence and the cryptographic verification record, an evidence index path, and the external verifier command after `--`.
+Use the wrapper with a seal file, a signature reference, output paths for evidence and the cryptographic verification record, an evidence index path, optional canonical surface refs, and the external verifier command after `--`.
+
+```bash
+python tools/run_fogstack_release_proof_pipeline.py \
+  --tool cosign \
+  --seal releases/seals/fogstack.access-v0.1.seal.json \
+  --bundle-id fogstack.access \
+  --version 0.1.0 \
+  --signature-ref artifact://release/fogstack.access-v0.1.seal.sig \
+  --evidence-output releases/evidence/fogstack.access-v0.1.seal.verify.json \
+  --seal-crypto-record releases/evidence/fogstack.access-v0.1.seal.crypto-verification.record.json \
+  --evidence-index releases/evidence/fogstack.access-v0.1.evidence.index.json \
+  --canonical-contract-surface-ref schema://fogstack/access/contracts/v0.1 \
+  --canonical-deployment-surface-ref k8s://fogstack/access/deployment/v0.1 \
+  --canonical-runtime-surface-ref runtime://fogstack/access/runtime/v0.1 \
+  --canonical-policy-surface-ref policy://fogstack/access/policy/v0.1 \
+  -- cosign verify ...
+```
+
+## Canonical surface refs
+
+The release evidence index can carry canonical refs for the surfaces that define the release boundary:
+
+- `canonical_contract_surface_ref`
+- `canonical_deployment_surface_ref`
+- `canonical_runtime_surface_ref`
+- `canonical_policy_surface_ref`
+
+These refs are optional. When provided to the release proof pipeline, they are passed to `tools/link_fogstack_release_seal_artifacts.py` and persisted into the `FogStackReleaseEvidenceIndex` alongside the release seal and cryptographic verification record refs.
 
 ## What this phase provides
 
 - one orchestrated proof step for the seal side of the trust graph
 - automatic invocation of the seal verification wrapper
 - automatic backlink insertion after the cryptographic record is produced
+- optional canonical surface refs in the release evidence index
 
 ## What this phase does not yet provide
 
 - CI enforcement of the proof pipeline
 - mutation of the non-seal side of the wider trust graph
 - registry publication of the resulting proof set
+- validation that canonical surface refs resolve to live external systems
 
 Those remain later steps.

--- a/schemas/release/fogstack-release-evidence-index-v0.1.schema.json
+++ b/schemas/release/fogstack-release-evidence-index-v0.1.schema.json
@@ -24,6 +24,10 @@
     "signature_trust_record_ref": { "type": "string" },
     "release_seal_ref": { "type": ["string", "null"] },
     "release_seal_cryptographic_verification_record_ref": { "type": ["string", "null"] },
+    "canonical_contract_surface_ref": { "type": ["string", "null"] },
+    "canonical_deployment_surface_ref": { "type": ["string", "null"] },
+    "canonical_runtime_surface_ref": { "type": ["string", "null"] },
+    "canonical_policy_surface_ref": { "type": ["string", "null"] },
     "notes": { "type": ["string", "null"] }
   },
   "additionalProperties": false

--- a/tools/link_fogstack_release_seal_artifacts.py
+++ b/tools/link_fogstack_release_seal_artifacts.py
@@ -22,6 +22,10 @@ def main() -> int:
     parser.add_argument("--seal", required=True, type=Path)
     parser.add_argument("--seal-crypto-record", required=True, type=Path)
     parser.add_argument("--evidence-index", required=True, type=Path)
+    parser.add_argument("--canonical-contract-surface-ref")
+    parser.add_argument("--canonical-deployment-surface-ref")
+    parser.add_argument("--canonical-runtime-surface-ref")
+    parser.add_argument("--canonical-policy-surface-ref")
     args = parser.parse_args()
 
     seal = load_json(args.seal)
@@ -35,6 +39,14 @@ def main() -> int:
 
     evidence_index["release_seal_ref"] = str(args.seal)
     evidence_index["release_seal_cryptographic_verification_record_ref"] = str(args.seal_crypto_record)
+    if args.canonical_contract_surface_ref is not None:
+        evidence_index["canonical_contract_surface_ref"] = args.canonical_contract_surface_ref
+    if args.canonical_deployment_surface_ref is not None:
+        evidence_index["canonical_deployment_surface_ref"] = args.canonical_deployment_surface_ref
+    if args.canonical_runtime_surface_ref is not None:
+        evidence_index["canonical_runtime_surface_ref"] = args.canonical_runtime_surface_ref
+    if args.canonical_policy_surface_ref is not None:
+        evidence_index["canonical_policy_surface_ref"] = args.canonical_policy_surface_ref
 
     write_json(args.seal, seal)
     write_json(args.seal_crypto_record, seal_crypto)

--- a/tools/run_fogstack_release_proof_pipeline.py
+++ b/tools/run_fogstack_release_proof_pipeline.py
@@ -22,6 +22,10 @@ def main() -> int:
     parser.add_argument("--evidence-output", required=True, type=Path)
     parser.add_argument("--seal-crypto-record", required=True, type=Path)
     parser.add_argument("--evidence-index", required=True, type=Path)
+    parser.add_argument("--canonical-contract-surface-ref")
+    parser.add_argument("--canonical-deployment-surface-ref")
+    parser.add_argument("--canonical-runtime-surface-ref")
+    parser.add_argument("--canonical-policy-surface-ref")
     parser.add_argument("command", nargs=argparse.REMAINDER, help="External seal verifier command, e.g. cosign verify ...")
     args = parser.parse_args()
 
@@ -52,6 +56,14 @@ def main() -> int:
         "--seal-crypto-record", str(args.seal_crypto_record),
         "--evidence-index", str(args.evidence_index),
     ]
+    if args.canonical_contract_surface_ref is not None:
+        link_cmd += ["--canonical-contract-surface-ref", args.canonical_contract_surface_ref]
+    if args.canonical_deployment_surface_ref is not None:
+        link_cmd += ["--canonical-deployment-surface-ref", args.canonical_deployment_surface_ref]
+    if args.canonical_runtime_surface_ref is not None:
+        link_cmd += ["--canonical-runtime-surface-ref", args.canonical_runtime_surface_ref]
+    if args.canonical_policy_surface_ref is not None:
+        link_cmd += ["--canonical-policy-surface-ref", args.canonical_policy_surface_ref]
     link = subprocess.run(link_cmd)
     if link.returncode != 0:
         raise SystemExit(link.returncode)

--- a/tools/tests/test_fogstack_release_proof_pipeline.py
+++ b/tools/tests/test_fogstack_release_proof_pipeline.py
@@ -81,6 +81,14 @@ def test_release_proof_pipeline_links_seal_artifacts(tmp_path: Path) -> None:
         str(seal_crypto_record),
         "--evidence-index",
         str(evidence_index),
+        "--canonical-contract-surface-ref",
+        "schema://fogstack/access/contracts/v0.1",
+        "--canonical-deployment-surface-ref",
+        "k8s://fogstack/access/deployment/v0.1",
+        "--canonical-runtime-surface-ref",
+        "runtime://fogstack/access/runtime/v0.1",
+        "--canonical-policy-surface-ref",
+        "policy://fogstack/access/policy/v0.1",
         "--",
         sys.executable,
         str(mock_verify),
@@ -98,3 +106,7 @@ def test_release_proof_pipeline_links_seal_artifacts(tmp_path: Path) -> None:
     index_after = _read_json(evidence_index)
     assert index_after["release_seal_ref"] == str(seal)
     assert index_after["release_seal_cryptographic_verification_record_ref"] == str(seal_crypto_record)
+    assert index_after["canonical_contract_surface_ref"] == "schema://fogstack/access/contracts/v0.1"
+    assert index_after["canonical_deployment_surface_ref"] == "k8s://fogstack/access/deployment/v0.1"
+    assert index_after["canonical_runtime_surface_ref"] == "runtime://fogstack/access/runtime/v0.1"
+    assert index_after["canonical_policy_surface_ref"] == "policy://fogstack/access/policy/v0.1"


### PR DESCRIPTION
## Summary

Refreshes the stale PR #176 work onto current `main`.

This PR adds canonical surface refs to the Fog Stack release proof pipeline and evidence index.

Changed files:
- `tools/link_fogstack_release_seal_artifacts.py`
- `tools/run_fogstack_release_proof_pipeline.py`
- `schemas/release/fogstack-release-evidence-index-v0.1.schema.json`
- `tools/tests/test_fogstack_release_proof_pipeline.py`
- `docs/FOGSTACK_RELEASE_PROOF_PIPELINE.md`

## What changes

The release proof pipeline and linker now accept optional:
- `--canonical-contract-surface-ref`
- `--canonical-deployment-surface-ref`
- `--canonical-runtime-surface-ref`
- `--canonical-policy-surface-ref`

When provided, the refs are persisted into the `FogStackReleaseEvidenceIndex`.

The schema now allows:
- `canonical_contract_surface_ref`
- `canonical_deployment_surface_ref`
- `canonical_runtime_surface_ref`
- `canonical_policy_surface_ref`

The test now proves those refs survive the full release proof pipeline.

## Software review

Correctness: this is the same useful canonical-ref work from #176, refreshed onto current `main` after the platform hardening and workflow changes.

Risk: low. Optional fields only; no behavior change unless refs are supplied.

Weakness: this records canonical surface refs but does not resolve or validate the external target systems. That remains a later hardening step.

## Supersedes

Supersedes stale PR #176.
