### PR TITLE
Refresh search orchestrator normalized result actions

### DIFF
--- a/services/search-orchestrator/app/main.py
+++ b/services/search-orchestrator/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 
 from app.backends import ingest_academy_record, query_academy_records, query_platform_workspace
-from app.models import LearningSearchRecord, SearchRequest, SearchResult, SearchResultScore
+from app.models import LearningSearchRecord, SearchRequest, SearchResult, SearchResultActions, SearchResultScore
 from app.policy import describe_academy_policy_evaluator
 from app.repositories import describe_academy_repository
 
@@ -28,6 +28,15 @@ def ingest_academy(body: LearningSearchRecord) -> LearningSearchRecord:
     return ingest_academy_record(body)
 
 
+def _actions_for(item) -> SearchResultActions:
+    return SearchResultActions(
+        open_cloud=item.open_cloud,
+        summarize=item.summarize,
+        create_task=item.create_task,
+        draft_reply=item.draft_reply,
+    )
+
+
 @app.post("/v0/search/query")
 def search_query(body: SearchRequest) -> dict[str, object]:
     results: list[dict[str, object]] = []
@@ -43,6 +52,7 @@ def search_query(body: SearchRequest) -> dict[str, object]:
             snippet=item.snippet,
             path_or_uri=item.path_or_uri,
             score=SearchResultScore(final=item.final_score),
+            actions=_actions_for(item),
         )
         results.append(result.model_dump())
 
@@ -55,6 +65,7 @@ def search_query(body: SearchRequest) -> dict[str, object]:
             snippet=item.snippet,
             path_or_uri=item.path_or_uri,
             score=SearchResultScore(final=item.final_score),
+            actions=_actions_for(item),
         )
         results.append(result.model_dump())
 

--- a/services/search-orchestrator/tests/test_platform_scope_result.py
+++ b/services/search-orchestrator/tests/test_platform_scope_result.py
@@ -24,3 +24,7 @@ def test_cloud_workspace_scope_returns_platform_result() -> None:
     assert payload['results'][0]['entity_type'] == 'DOCUMENT'
     assert payload['results'][0]['snippet'] == 'Matched workspace content for query: budget'
     assert payload['results'][0]['path_or_uri'] == 'workspace://documents/budget'
+    assert payload['results'][0]['actions']['open_cloud'] is True
+    assert payload['results'][0]['actions']['summarize'] is True
+    assert payload['results'][0]['actions']['create_task'] is True
+    assert payload['results'][0]['actions']['draft_reply'] is False


### PR DESCRIPTION
## Summary

Refreshes stale PR #157 onto current `main`.

This PR populates normalized search result `actions` from existing search backend action flags.

Changed files:
- `services/search-orchestrator/app/main.py`
- `services/search-orchestrator/tests/test_platform_scope_result.py`

## What changes

Search results now include:
- `actions.open_cloud`
- `actions.summarize`
- `actions.create_task`
- `actions.draft_reply`

The test now asserts the expected action flags on the platform workspace result.

## Software review

Correctness: `SearchResultActions` already exists in the model; this wires existing backend booleans into the normalized API response instead of leaving `actions` unset.

Risk: low. Response enrichment only; no search retrieval behavior change.

Weakness: this covers the platform workspace result path. Broader Academy result action semantics remain tied to current backend flags.

## Supersedes

Supersedes stale PR #157.
