### PR TITLE
Audit stale zone publication stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -25,6 +25,9 @@ validate-search-academy-deploy:
 
 validate-lampstand-lifecycle:
 	python3 tools/validate_lampstand_lifecycle.py
+
+validate-zone-stack-audit:
+	python3 tools/validate_zone_publication_stack_audit.py
 
 test-go:
 	go test ./libs/go/tritrpcbridge/...

--- a/docs/ZONE_PUBLICATION_STACK_AUDIT.md
+++ b/docs/ZONE_PUBLICATION_STACK_AUDIT.md
@@ -1,0 +1,79 @@
+# Zone publication stack audit
+
+## Purpose
+
+This audit records the stale zone-publication PR stack and defines the next clean review surface.
+
+Stale stack:
+
+- #142 — zone publication validation and local transport runtime
+- #156 — zone-router transport adapters and lifecycle outcomes
+- #173 — retry-aware zone publication lifecycle
+
+## Decision
+
+Do not merge the stale stack as-is.
+
+The stack was built across old branch bases and spans semantic validation, transport adapters, publication outcomes, retry state, contracts, smoke paths, and Makefile wiring. It should be replaced by a current-main review unit with explicit boundaries and fresh CI proof.
+
+## Replacement scope
+
+A replacement review unit should account for:
+
+1. semantic-bridge validation for zone publication artifacts
+2. zone-router semantic gate integration
+3. local publication outcome emission
+4. adapterized transport modes
+5. delivery artifact contract
+6. retry and attempt state
+7. publication outcome linkage
+8. smoke coverage for semantic validation and transport publish
+9. Makefile wiring for tests and smokes
+10. Sociosphere build-intelligence registration after merge
+
+## Files implicated by stale stack
+
+PR #142:
+
+- `Makefile`
+- `apps/semantic-bridge/requirements-test.txt`
+- `apps/semantic-bridge/src/semantic_bridge/main.py`
+- `apps/semantic-bridge/src/semantic_bridge/validators.py`
+- `apps/semantic-bridge/tests/test_validators.py`
+- `apps/zone-router/src/zone_router/main.py`
+- `apps/zone-router/src/zone_router/semantic_gate.py`
+- `apps/zone-router/src/zone_router/transport.py`
+- `apps/zone-router/tests/test_publish.py`
+- `apps/zone-router/tests/test_semantic_integration.py`
+- `apps/zone-router/tests/test_transport.py`
+- `contracts/ZonePublicationOutcome.v0.1.json`
+- `tools/smoke_semantic_bridge_zone_validation.py`
+- `tools/smoke_zone_router_transport_publish.py`
+
+PR #156:
+
+- `apps/zone-router/src/zone_router/main.py`
+- `apps/zone-router/src/zone_router/transport.py`
+- `apps/zone-router/src/zone_router/transport_adapters.py`
+- `apps/zone-router/tests/test_publish_runtime.py`
+- `apps/zone-router/tests/test_transport_adapters.py`
+- `contracts/ZonePublicationDelivery.v0.1.json`
+- `contracts/ZonePublicationOutcome.v0.1.json`
+- `tools/smoke_zone_router_transport_publish.py`
+
+PR #173:
+
+- `apps/zone-router/src/zone_router/retry_state.py`
+- `apps/zone-router/src/zone_router/transport.py`
+- `apps/zone-router/tests/test_retry_lifecycle.py`
+- `contracts/ZonePublicationFailureEvidence.v0.1.json`
+- `contracts/ZonePublicationOutcome.v0.1.json`
+- `tools/smoke_zone_router_transport_publish.py`
+
+## Software review
+
+Correctness: the stale stack is directionally useful but not merge-safe.
+
+Risk: direct merge would mix old-base runtime changes, contracts, tests, and Makefile edits into current main without a clean review surface.
+
+Next action: land this audit, close #142/#156/#173 as superseded, then open a current-main implementation PR for the minimal safe replacement slice.

--- a/tools/validate_zone_publication_stack_audit.py
+++ b/tools/validate_zone_publication_stack_audit.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT = ROOT / "docs" / "ZONE_PUBLICATION_STACK_AUDIT.md"
+REQUIRED_TERMS = [
+    "#142",
+    "#156",
+    "#173",
+    "semantic-bridge validation",
+    "zone-router semantic gate integration",
+    "adapterized transport modes",
+    "retry and attempt state",
+    "Sociosphere build-intelligence registration after merge",
+]
+
+
+def main() -> int:
+    if not AUDIT.exists():
+        raise SystemExit(f"missing audit file: {AUDIT.relative_to(ROOT)}")
+    text = AUDIT.read_text(encoding="utf-8")
+    missing = [term for term in REQUIRED_TERMS if term not in text]
+    if missing:
+        raise SystemExit("zone publication stack audit missing required terms: " + ", ".join(missing))
+    print("zone publication stack audit validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a current-main audit for the stale zone-publication PR stack and wires the audit into validation.

This PR adds:
- `docs/ZONE_PUBLICATION_STACK_AUDIT.md`
- `tools/validate_zone_publication_stack_audit.py`

This PR updates:
- `Makefile`

## Why

The open zone-publication stack is stale and split across old bases:
- #142 — zone publication validation and local transport runtime
- #156 — zone-router transport adapters and lifecycle outcomes
- #173 — retry-aware zone publication lifecycle

The stack is directionally useful, but not merge-safe as-is. It crosses semantic-bridge, zone-router, contracts, tests, smoke tooling, and Makefile wiring.

## What this does

This PR creates a validated decision record that:
- identifies the stale stack
- records implicated files
- defines the replacement scope
- makes the audit CI-owned through `make validate`

## Software review

Correctness: prevents the stale stack from occupying review space without a current-main decision artifact.

Risk: low. Audit/validator/Makefile only; no runtime behavior change.

Next action after merge: close #142/#156/#173 as superseded and open a current-main implementation PR for the minimal safe replacement slice.
