### PR TITLE
Add minimal zone publication local outcome lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -29,6 +29,9 @@ validate-lampstand-lifecycle:
 validate-zone-stack-audit:
 	python3 tools/validate_zone_publication_stack_audit.py
 
+zone-router-publication-local-publish-smoke:
+	python3 tools/smoke_zone_publication_local_publish.py
+
 test-go:
 	go test ./libs/go/tritrpcbridge/...
 	go test ./apps/api/...
@@ -50,7 +53,7 @@ test-tools:
 	test -d .venv-tools || python3 -m venv .venv-tools
 	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests
 
-smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke
+smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke semantic-bridge-zone-validation-smoke
 
 smoke-health:
 	bash tools/smoke_tritrpc_health.sh

--- a/apps/zone-router/src/zone_router/publish.py
+++ b/apps/zone-router/src/zone_router/publish.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .outbox import publication_outbox_root
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _outcomes_root(service: str = "zone-router") -> Path:
+    root = publication_outbox_root(service) / "outcomes"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _outcome_log_path(service: str = "zone-router") -> Path:
+    root = publication_outbox_root(service)
+    root.mkdir(parents=True, exist_ok=True)
+    return root / "publication_outcome_log.jsonl"
+
+
+def load_publication_record(path: str | Path) -> dict[str, Any]:
+    record_path = Path(path).expanduser().resolve()
+    data = json.loads(record_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected publication record object in {record_path}")
+    return data
+
+
+def publish_publication_record(
+    *,
+    record_path: str | Path,
+    transport_ref: str = "transport://local/jsonl",
+    service: str = "zone-router",
+) -> dict[str, Any]:
+    path = Path(record_path).expanduser().resolve()
+    record = load_publication_record(path)
+    outcome_id = str(uuid.uuid4())
+    outcome = {
+        "version": "0.1",
+        "outcome_id": outcome_id,
+        "publication_id": record["publication_id"],
+        "status": "published",
+        "zone_ref": record["zone_ref"],
+        "topic": record["topic"],
+        "transport_ref": transport_ref,
+        "publication_record_ref": str(path),
+        "carrier_ref": record.get("carrier_ref"),
+        "event_ref": record.get("event_ref"),
+        "receipt_ref": record.get("receipt_ref"),
+        "catalog_ref": record.get("catalog_ref"),
+        "published_at": _utc_now(),
+        "error": None,
+    }
+    outcome_path = _outcomes_root(service) / f"{outcome_id}.publication-outcome.json"
+    outcome_path.write_text(json.dumps(outcome, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    log_path = _outcome_log_path(service)
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(outcome, sort_keys=True) + "\n")
+
+    return {
+        "ok": True,
+        "outcome_path": str(outcome_path),
+        "log_path": str(log_path),
+        "outcome": outcome,
+    }

--- a/contracts/ZonePublicationOutcome.v0.1.json
+++ b/contracts/ZonePublicationOutcome.v0.1.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/contracts/ZonePublicationOutcome.v0.1.json",
+  "title": "ZonePublicationOutcome",
+  "type": "object",
+  "required": [
+    "version",
+    "outcome_id",
+    "publication_id",
+    "status",
+    "zone_ref",
+    "topic",
+    "publication_record_ref",
+    "published_at"
+  ],
+  "properties": {
+    "version": { "const": "0.1" },
+    "outcome_id": { "type": "string", "minLength": 1 },
+    "publication_id": { "type": "string", "minLength": 1 },
+    "status": { "enum": ["published", "failed"] },
+    "zone_ref": { "type": "string", "minLength": 1 },
+    "topic": { "type": "string", "minLength": 1 },
+    "transport_ref": { "type": "string", "minLength": 1 },
+    "publication_record_ref": { "type": "string", "minLength": 1 },
+    "carrier_ref": { "type": ["string", "null"] },
+    "event_ref": { "type": ["string", "null"] },
+    "receipt_ref": { "type": ["string", "null"] },
+    "catalog_ref": { "type": ["string", "null"] },
+    "published_at": { "type": "string", "minLength": 1 },
+    "error": { "type": ["string", "null"] }
+  },
+  "additionalProperties": true
+}

--- a/tools/smoke_zone_publication_local_publish.py
+++ b/tools/smoke_zone_publication_local_publish.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "apps/lampstand/src"))
+sys.path.insert(0, str(ROOT / "apps/zone-router/src"))
+
+from prophet_platform_lampstand.ingest import ingest_path  # noqa: E402
+from zone_router.outbox import write_publication_record  # noqa: E402
+from zone_router.planner import plan_publication_request  # noqa: E402
+from zone_router.publish import publish_publication_record  # noqa: E402
+
+ZONE_REF = "zone://edge"
+EXPECTED_TOPIC = "zone.edge.carrier.ingested.v1"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        os.environ["SOCIOPROFIT_DATA_HOME"] = str(root / "data")
+        os.environ["SOCIOPROFIT_STATE_HOME"] = str(root / "state")
+        os.environ["SOCIOPROFIT_RUNTIME_HOME"] = str(root / "run")
+
+        sample = root / "sample.txt"
+        sample.write_text("zone publication local publish smoke\n", encoding="utf-8")
+
+        ingest_result = ingest_path(file_path=str(sample), zone_ref=ZONE_REF)
+        plan = plan_publication_request(ingest_result["publication_request"])
+        record_result = write_publication_record(plan)
+        publish_result = publish_publication_record(record_path=record_result["record_path"])
+        outcome = publish_result["outcome"]
+
+        checks = {
+            "ingest_ok": ingest_result.get("ok") is True,
+            "plan_ok": plan.get("ok") is True,
+            "record_ok": record_result.get("ok") is True,
+            "publish_ok": publish_result.get("ok") is True,
+            "record_path_exists": Path(record_result["record_path"]).exists(),
+            "outcome_path_exists": Path(publish_result["outcome_path"]).exists(),
+            "outcome_status_published": outcome.get("status") == "published",
+            "outcome_publication_id_matches": outcome.get("publication_id") == record_result["record"].get("publication_id"),
+            "outcome_topic_expected": outcome.get("topic") == EXPECTED_TOPIC,
+            "outcome_record_ref_matches": outcome.get("publication_record_ref") == str(Path(record_result["record_path"]).resolve()),
+            "outcome_catalog_ref_matches": outcome.get("catalog_ref") == record_result["record"].get("catalog_ref"),
+            "outcome_receipt_ref_matches": outcome.get("receipt_ref") == record_result["record"].get("receipt_ref"),
+            "outcome_event_ref_matches": outcome.get("event_ref") == record_result["record"].get("event_ref"),
+        }
+        ok = all(checks.values())
+        print(json.dumps({"ok": ok, "checks": checks, "record": record_result["record"], "outcome": outcome}, indent=2, sort_keys=True))
+        return 0 if ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the minimal current-main replacement implementation for the zone publication lifecycle stack.

This PR adds:
- `contracts/ZonePublicationOutcome.v0.1.json`
- `apps/zone-router/src/zone_router/publish.py`
- `tools/smoke_zone_publication_local_publish.py`

This PR updates:
- `Makefile`

## What it proves

The new smoke validates the local path:

`Lampstand ingest -> zone plan -> outbox publication record -> local published outcome`

The outcome preserves traceability to:
- publication record
- carrier
- event
- receipt
- catalog
- topic
- zone

## Software review

Correctness: this is the minimal safe replacement slice after #186 closed the stale zone-publication stack. It advances from planned publication records to a local published outcome with a contract, writer, log, and smoke coverage.

Risk: low-to-medium. It adds runtime code under `apps/zone-router`, but the behavior is local-only and CI-smoked. It does not add remote broker mutation.

Weakness: this does not implement transport adapters, retry state, failure evidence, or remote publication. Those remain follow-on slices.

## Prior cleanup

Supersedes the stale stacked lane closed through #186: #142, #156, and #173.
