### PR TITLE
Add zone publication failure evidence path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -32,6 +32,9 @@ validate-zone-stack-audit:
 zone-router-publication-local-publish-smoke:
 	python3 tools/smoke_zone_publication_local_publish.py
 
+zone-router-publication-failure-evidence-smoke:
+	python3 tools/smoke_zone_publication_failure_evidence.py
+
 test-go:
 	go test ./libs/go/tritrpcbridge/...
 	go test ./apps/api/...
@@ -53,7 +56,7 @@ test-tools:
 	test -d .venv-tools || python3 -m venv .venv-tools
 	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests
 
-smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke semantic-bridge-zone-validation-smoke
+smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke semantic-bridge-zone-validation-smoke
 
 smoke-health:
 	bash tools/smoke_tritrpc_health.sh

--- a/apps/zone-router/src/zone_router/publish.py
+++ b/apps/zone-router/src/zone_router/publish.py
@@ -34,6 +34,17 @@ def load_publication_record(path: str | Path) -> dict[str, Any]:
     return data
 
 
+def _write_outcome(outcome: dict[str, Any], *, service: str) -> dict[str, Any]:
+    outcome_path = _outcomes_root(service) / f"{outcome['outcome_id']}.publication-outcome.json"
+    outcome_path.write_text(json.dumps(outcome, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    log_path = _outcome_log_path(service)
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(outcome, sort_keys=True) + "\n")
+
+    return {"outcome_path": str(outcome_path), "log_path": str(log_path)}
+
+
 def publish_publication_record(
     *,
     record_path: str | Path,
@@ -48,8 +59,42 @@ def publish_publication_record(
         transport_ref=transport_ref,
         service=service,
     )
-    delivery = delivery_result["delivery"]
     outcome_id = str(uuid.uuid4())
+
+    if not delivery_result.get("ok"):
+        failure = delivery_result["failure"]
+        outcome = {
+            "version": "0.1",
+            "outcome_id": outcome_id,
+            "publication_id": record["publication_id"],
+            "status": "failed",
+            "zone_ref": record["zone_ref"],
+            "topic": record["topic"],
+            "transport_ref": transport_ref,
+            "transport_kind": failure["transport_kind"],
+            "failure_ref": delivery_result["failure_path"],
+            "failure_id": failure["failure_id"],
+            "publication_record_ref": str(path),
+            "carrier_ref": record.get("carrier_ref"),
+            "event_ref": record.get("event_ref"),
+            "receipt_ref": record.get("receipt_ref"),
+            "catalog_ref": record.get("catalog_ref"),
+            "published_at": None,
+            "failed_at": failure["failed_at"],
+            "error": delivery_result["error"],
+        }
+        refs = _write_outcome(outcome, service=service)
+        return {
+            "ok": False,
+            "outcome_path": refs["outcome_path"],
+            "log_path": refs["log_path"],
+            "outcome": outcome,
+            "failure": failure,
+            "failure_path": delivery_result["failure_path"],
+            "error": delivery_result["error"],
+        }
+
+    delivery = delivery_result["delivery"]
     outcome = {
         "version": "0.1",
         "outcome_id": outcome_id,
@@ -70,17 +115,12 @@ def publish_publication_record(
         "published_at": _utc_now(),
         "error": None,
     }
-    outcome_path = _outcomes_root(service) / f"{outcome_id}.publication-outcome.json"
-    outcome_path.write_text(json.dumps(outcome, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-    log_path = _outcome_log_path(service)
-    with log_path.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(outcome, sort_keys=True) + "\n")
+    refs = _write_outcome(outcome, service=service)
 
     return {
         "ok": True,
-        "outcome_path": str(outcome_path),
-        "log_path": str(log_path),
+        "outcome_path": refs["outcome_path"],
+        "log_path": refs["log_path"],
         "outcome": outcome,
         "delivery": delivery,
         "delivery_path": delivery_result["delivery_path"],

--- a/apps/zone-router/src/zone_router/transport_adapters.py
+++ b/apps/zone-router/src/zone_router/transport_adapters.py
@@ -10,7 +10,8 @@ from .outbox import publication_outbox_root
 
 LOCAL_JSONL = "transport://local/jsonl"
 KAFKA_JSONL = "transport://kafka/jsonl"
-SUPPORTED_TRANSPORTS = {LOCAL_JSONL, KAFKA_JSONL}
+FAIL_TEST = "transport://fail/test"
+SUPPORTED_TRANSPORTS = {LOCAL_JSONL, KAFKA_JSONL, FAIL_TEST}
 
 
 def _utc_now() -> str:
@@ -22,11 +23,19 @@ def _transport_kind(transport_ref: str) -> str:
         return "local-jsonl"
     if transport_ref == KAFKA_JSONL:
         return "kafka-jsonl-local-standin"
+    if transport_ref == FAIL_TEST:
+        return "fail-test"
     raise ValueError(f"unsupported transport_ref={transport_ref!r}")
 
 
 def _deliveries_root(service: str = "zone-router") -> Path:
     root = publication_outbox_root(service) / "deliveries"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _failures_root(service: str = "zone-router") -> Path:
+    root = publication_outbox_root(service) / "failures"
     root.mkdir(parents=True, exist_ok=True)
     return root
 
@@ -41,6 +50,35 @@ def _safe_topic(topic: str) -> str:
     return topic.replace("/", "_").replace(":", "_")
 
 
+def _failure_evidence(
+    *,
+    record: dict[str, Any],
+    publication_record_ref: str,
+    transport_ref: str,
+    error: str,
+    service: str,
+) -> dict[str, Any]:
+    failure_id = str(uuid.uuid4())
+    failure = {
+        "version": "0.1",
+        "failure_id": failure_id,
+        "publication_id": record["publication_id"],
+        "transport_ref": transport_ref,
+        "transport_kind": _transport_kind(transport_ref),
+        "topic": record["topic"],
+        "publication_record_ref": publication_record_ref,
+        "carrier_ref": record.get("carrier_ref"),
+        "event_ref": record.get("event_ref"),
+        "receipt_ref": record.get("receipt_ref"),
+        "catalog_ref": record.get("catalog_ref"),
+        "failed_at": _utc_now(),
+        "error": error,
+    }
+    failure_path = _failures_root(service) / f"{failure_id}.failure-evidence.json"
+    failure_path.write_text(json.dumps(failure, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return {"ok": False, "failure_path": str(failure_path), "failure": failure, "error": error}
+
+
 def deliver_publication_record(
     *,
     record: dict[str, Any],
@@ -49,7 +87,21 @@ def deliver_publication_record(
     service: str = "zone-router",
 ) -> dict[str, Any]:
     if transport_ref not in SUPPORTED_TRANSPORTS:
-        raise ValueError(f"unsupported transport_ref={transport_ref!r}")
+        return _failure_evidence(
+            record=record,
+            publication_record_ref=publication_record_ref,
+            transport_ref=transport_ref,
+            error=f"unsupported transport_ref={transport_ref!r}",
+            service=service,
+        )
+    if transport_ref == FAIL_TEST:
+        return _failure_evidence(
+            record=record,
+            publication_record_ref=publication_record_ref,
+            transport_ref=transport_ref,
+            error="forced failure for transport://fail/test",
+            service=service,
+        )
 
     delivery_id = str(uuid.uuid4())
     delivery = {

--- a/contracts/ZonePublicationFailureEvidence.v0.1.json
+++ b/contracts/ZonePublicationFailureEvidence.v0.1.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/contracts/ZonePublicationFailureEvidence.v0.1.json",
+  "title": "ZonePublicationFailureEvidence",
+  "type": "object",
+  "required": [
+    "version",
+    "failure_id",
+    "publication_id",
+    "transport_ref",
+    "transport_kind",
+    "topic",
+    "publication_record_ref",
+    "failed_at",
+    "error"
+  ],
+  "properties": {
+    "version": { "const": "0.1" },
+    "failure_id": { "type": "string", "minLength": 1 },
+    "publication_id": { "type": "string", "minLength": 1 },
+    "transport_ref": { "type": "string", "minLength": 1 },
+    "transport_kind": { "type": "string", "minLength": 1 },
+    "topic": { "type": "string", "minLength": 1 },
+    "publication_record_ref": { "type": "string", "minLength": 1 },
+    "carrier_ref": { "type": ["string", "null"] },
+    "event_ref": { "type": ["string", "null"] },
+    "receipt_ref": { "type": ["string", "null"] },
+    "catalog_ref": { "type": ["string", "null"] },
+    "failed_at": { "type": "string", "minLength": 1 },
+    "error": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": true
+}

--- a/contracts/ZonePublicationOutcome.v0.1.json
+++ b/contracts/ZonePublicationOutcome.v0.1.json
@@ -12,11 +12,8 @@
     "topic",
     "transport_ref",
     "transport_kind",
-    "delivery_ref",
-    "delivery_id",
-    "topic_log_ref",
     "publication_record_ref",
-    "published_at"
+    "error"
   ],
   "properties": {
     "version": { "const": "0.1" },
@@ -27,16 +24,29 @@
     "topic": { "type": "string", "minLength": 1 },
     "transport_ref": { "type": "string", "minLength": 1 },
     "transport_kind": { "type": "string", "minLength": 1 },
-    "delivery_ref": { "type": "string", "minLength": 1 },
-    "delivery_id": { "type": "string", "minLength": 1 },
-    "topic_log_ref": { "type": "string", "minLength": 1 },
+    "delivery_ref": { "type": ["string", "null"] },
+    "delivery_id": { "type": ["string", "null"] },
+    "topic_log_ref": { "type": ["string", "null"] },
+    "failure_ref": { "type": ["string", "null"] },
+    "failure_id": { "type": ["string", "null"] },
     "publication_record_ref": { "type": "string", "minLength": 1 },
     "carrier_ref": { "type": ["string", "null"] },
     "event_ref": { "type": ["string", "null"] },
     "receipt_ref": { "type": ["string", "null"] },
     "catalog_ref": { "type": ["string", "null"] },
-    "published_at": { "type": "string", "minLength": 1 },
+    "published_at": { "type": ["string", "null"] },
+    "failed_at": { "type": ["string", "null"] },
     "error": { "type": ["string", "null"] }
   },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "published" } } },
+      "then": { "required": ["delivery_ref", "delivery_id", "topic_log_ref", "published_at"] }
+    },
+    {
+      "if": { "properties": { "status": { "const": "failed" } } },
+      "then": { "required": ["failure_ref", "failure_id", "failed_at"] }
+    }
+  ],
   "additionalProperties": true
 }

--- a/tools/smoke_zone_publication_failure_evidence.py
+++ b/tools/smoke_zone_publication_failure_evidence.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "apps/lampstand/src"))
+sys.path.insert(0, str(ROOT / "apps/zone-router/src"))
+
+from prophet_platform_lampstand.ingest import ingest_path  # noqa: E402
+from zone_router.outbox import write_publication_record  # noqa: E402
+from zone_router.planner import plan_publication_request  # noqa: E402
+from zone_router.publish import publish_publication_record  # noqa: E402
+
+ZONE_REF = "zone://edge"
+FAIL_TRANSPORT = "transport://fail/test"
+EXPECTED_TOPIC = "zone.edge.carrier.ingested.v1"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        os.environ["SOCIOPROFIT_DATA_HOME"] = str(root / "data")
+        os.environ["SOCIOPROFIT_STATE_HOME"] = str(root / "state")
+        os.environ["SOCIOPROFIT_RUNTIME_HOME"] = str(root / "run")
+
+        sample = root / "sample.txt"
+        sample.write_text("zone publication failure evidence smoke\n", encoding="utf-8")
+
+        ingest_result = ingest_path(file_path=str(sample), zone_ref=ZONE_REF)
+        plan = plan_publication_request(ingest_result["publication_request"])
+        record_result = write_publication_record(plan)
+        publish_result = publish_publication_record(record_path=record_result["record_path"], transport_ref=FAIL_TRANSPORT)
+        outcome = publish_result["outcome"]
+        failure = publish_result["failure"]
+
+        checks = {
+            "ingest_ok": ingest_result.get("ok") is True,
+            "plan_ok": plan.get("ok") is True,
+            "record_ok": record_result.get("ok") is True,
+            "publish_failed": publish_result.get("ok") is False,
+            "failure_path_exists": Path(publish_result["failure_path"]).exists(),
+            "outcome_path_exists": Path(publish_result["outcome_path"]).exists(),
+            "failure_transport_kind": failure.get("transport_kind") == "fail-test",
+            "failure_publication_id_matches": failure.get("publication_id") == record_result["record"].get("publication_id"),
+            "failure_topic_expected": failure.get("topic") == EXPECTED_TOPIC,
+            "outcome_status_failed": outcome.get("status") == "failed",
+            "outcome_failure_ref_matches": outcome.get("failure_ref") == publish_result.get("failure_path"),
+            "outcome_failure_id_matches": outcome.get("failure_id") == failure.get("failure_id"),
+            "outcome_publication_id_matches": outcome.get("publication_id") == record_result["record"].get("publication_id"),
+            "outcome_error_present": bool(outcome.get("error")),
+            "outcome_record_ref_matches": outcome.get("publication_record_ref") == str(Path(record_result["record_path"]).resolve()),
+            "outcome_catalog_ref_matches": outcome.get("catalog_ref") == record_result["record"].get("catalog_ref"),
+            "outcome_receipt_ref_matches": outcome.get("receipt_ref") == record_result["record"].get("receipt_ref"),
+            "outcome_event_ref_matches": outcome.get("event_ref") == record_result["record"].get("event_ref"),
+        }
+        ok = all(checks.values())
+        print(json.dumps({"ok": ok, "checks": checks, "record": record_result["record"], "failure": failure, "outcome": outcome}, indent=2, sort_keys=True))
+        return 0 if ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the next zone publication lifecycle slice after PR #188: failed publication outcomes with failure evidence.

This PR adds:
- `contracts/ZonePublicationFailureEvidence.v0.1.json`
- `tools/smoke_zone_publication_failure_evidence.py`

This PR updates:
- `apps/zone-router/src/zone_router/transport_adapters.py`
- `apps/zone-router/src/zone_router/publish.py`
- `contracts/ZonePublicationOutcome.v0.1.json`
- `Makefile`

## What changes

Adds explicit `transport://fail/test` behavior. A forced-failure publication now emits:
- failure evidence artifact
- failed publication outcome
- outcome refs back to failure evidence
- traceability to publication record, carrier, event, receipt, catalog, zone, and topic

The failure smoke proves:
- forced publish returns `ok=false`
- failure evidence file exists
- failed outcome file exists
- outcome links to `failure_ref` and `failure_id`
- outcome and failure evidence both preserve record linkage

## Software review

Correctness: this adds a first-class failed-outcome path instead of treating delivery errors as unstructured exceptions.

Risk: moderate but bounded. Runtime code changes are local-file-backed and covered by smoke through `make validate`.

Weakness: this does not yet implement retry/attempt state or remote broker publication.
