### PR TITLE
Add zone publication retry attempt state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -35,6 +35,9 @@ zone-router-publication-local-publish-smoke:
 zone-router-publication-failure-evidence-smoke:
 	python3 tools/smoke_zone_publication_failure_evidence.py
 
+zone-router-publication-retry-state-smoke:
+	python3 tools/smoke_zone_publication_retry_state.py
+
 test-go:
 	go test ./libs/go/tritrpcbridge/...
 	go test ./apps/api/...
@@ -56,7 +59,7 @@ test-tools:
 	test -d .venv-tools || python3 -m venv .venv-tools
 	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests
 
-smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke semantic-bridge-zone-validation-smoke
+smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke semantic-bridge-zone-validation-smoke
 
 smoke-health:
 	bash tools/smoke_tritrpc_health.sh

--- a/apps/zone-router/src/zone_router/publish.py
+++ b/apps/zone-router/src/zone_router/publish.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from .outbox import publication_outbox_root
+from .retry_state import next_attempt_state, retry_eligible
 from .transport_adapters import deliver_publication_record
 
 
@@ -36,6 +37,7 @@ def load_publication_record(path: str | Path) -> dict[str, Any]:
 
 def _write_outcome(outcome: dict[str, Any], *, service: str) -> dict[str, Any]:
     outcome_path = _outcomes_root(service) / f"{outcome['outcome_id']}.publication-outcome.json"
+    outcome["outcome_ref"] = str(outcome_path)
     outcome_path.write_text(json.dumps(outcome, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     log_path = _outcome_log_path(service)
@@ -43,6 +45,17 @@ def _write_outcome(outcome: dict[str, Any], *, service: str) -> dict[str, Any]:
         fh.write(json.dumps(outcome, sort_keys=True) + "\n")
 
     return {"outcome_path": str(outcome_path), "log_path": str(log_path)}
+
+
+def _attempt_fields(publication_id: str, *, service: str) -> dict[str, Any]:
+    state = next_attempt_state(publication_id, service=service)
+    return {
+        "attempt": state["attempt"],
+        "previous_outcome_id": state["previous_outcome_id"],
+        "previous_outcome_status": state["previous_outcome_status"],
+        "previous_outcome_ref": state["previous_outcome_ref"],
+        "retry_after_failure": state["retry_after_failure"],
+    }
 
 
 def publish_publication_record(
@@ -53,6 +66,7 @@ def publish_publication_record(
 ) -> dict[str, Any]:
     path = Path(record_path).expanduser().resolve()
     record = load_publication_record(path)
+    attempt_fields = _attempt_fields(record["publication_id"], service=service)
     delivery_result = deliver_publication_record(
         record=record,
         publication_record_ref=str(path),
@@ -82,7 +96,9 @@ def publish_publication_record(
             "published_at": None,
             "failed_at": failure["failed_at"],
             "error": delivery_result["error"],
+            **attempt_fields,
         }
+        outcome["retry_eligible"] = retry_eligible(outcome)
         refs = _write_outcome(outcome, service=service)
         return {
             "ok": False,
@@ -114,7 +130,9 @@ def publish_publication_record(
         "catalog_ref": record.get("catalog_ref"),
         "published_at": _utc_now(),
         "error": None,
+        **attempt_fields,
     }
+    outcome["retry_eligible"] = retry_eligible(outcome)
     refs = _write_outcome(outcome, service=service)
 
     return {

--- a/apps/zone-router/src/zone_router/retry_state.py
+++ b/apps/zone-router/src/zone_router/retry_state.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .outbox import publication_outbox_root
+
+
+def outcome_log_path(service: str = "zone-router") -> Path:
+    return publication_outbox_root(service) / "publication_outcome_log.jsonl"
+
+
+def read_outcomes(publication_id: str, *, service: str = "zone-router") -> list[dict[str, Any]]:
+    path = outcome_log_path(service)
+    if not path.exists():
+        return []
+    outcomes: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        data = json.loads(line)
+        if isinstance(data, dict) and data.get("publication_id") == publication_id:
+            outcomes.append(data)
+    return outcomes
+
+
+def next_attempt_state(publication_id: str, *, service: str = "zone-router") -> dict[str, Any]:
+    outcomes = read_outcomes(publication_id, service=service)
+    previous = outcomes[-1] if outcomes else None
+    return {
+        "attempt": len(outcomes) + 1,
+        "previous_outcome_id": previous.get("outcome_id") if previous else None,
+        "previous_outcome_status": previous.get("status") if previous else None,
+        "previous_outcome_ref": previous.get("outcome_ref") if previous else None,
+        "retry_after_failure": bool(previous and previous.get("status") == "failed"),
+    }
+
+
+def retry_eligible(outcome: dict[str, Any]) -> bool:
+    return outcome.get("status") == "failed"

--- a/contracts/ZonePublicationOutcome.v0.1.json
+++ b/contracts/ZonePublicationOutcome.v0.1.json
@@ -13,11 +13,14 @@
     "transport_ref",
     "transport_kind",
     "publication_record_ref",
+    "attempt",
+    "retry_eligible",
     "error"
   ],
   "properties": {
     "version": { "const": "0.1" },
     "outcome_id": { "type": "string", "minLength": 1 },
+    "outcome_ref": { "type": ["string", "null"] },
     "publication_id": { "type": "string", "minLength": 1 },
     "status": { "enum": ["published", "failed"] },
     "zone_ref": { "type": "string", "minLength": 1 },
@@ -34,6 +37,12 @@
     "event_ref": { "type": ["string", "null"] },
     "receipt_ref": { "type": ["string", "null"] },
     "catalog_ref": { "type": ["string", "null"] },
+    "attempt": { "type": "integer", "minimum": 1 },
+    "previous_outcome_id": { "type": ["string", "null"] },
+    "previous_outcome_status": { "type": ["string", "null"] },
+    "previous_outcome_ref": { "type": ["string", "null"] },
+    "retry_after_failure": { "type": "boolean" },
+    "retry_eligible": { "type": "boolean" },
     "published_at": { "type": ["string", "null"] },
     "failed_at": { "type": ["string", "null"] },
     "error": { "type": ["string", "null"] }

--- a/tools/smoke_zone_publication_retry_state.py
+++ b/tools/smoke_zone_publication_retry_state.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "apps/lampstand/src"))
+sys.path.insert(0, str(ROOT / "apps/zone-router/src"))
+
+from prophet_platform_lampstand.ingest import ingest_path  # noqa: E402
+from zone_router.outbox import write_publication_record  # noqa: E402
+from zone_router.planner import plan_publication_request  # noqa: E402
+from zone_router.publish import publish_publication_record  # noqa: E402
+
+ZONE_REF = "zone://edge"
+FAIL_TRANSPORT = "transport://fail/test"
+SUCCESS_TRANSPORT = "transport://local/jsonl"
+EXPECTED_TOPIC = "zone.edge.carrier.ingested.v1"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        os.environ["SOCIOPROFIT_DATA_HOME"] = str(root / "data")
+        os.environ["SOCIOPROFIT_STATE_HOME"] = str(root / "state")
+        os.environ["SOCIOPROFIT_RUNTIME_HOME"] = str(root / "run")
+
+        sample = root / "sample.txt"
+        sample.write_text("zone publication retry state smoke\n", encoding="utf-8")
+
+        ingest_result = ingest_path(file_path=str(sample), zone_ref=ZONE_REF)
+        plan = plan_publication_request(ingest_result["publication_request"])
+        record_result = write_publication_record(plan)
+        record_path = record_result["record_path"]
+
+        failed_publish = publish_publication_record(record_path=record_path, transport_ref=FAIL_TRANSPORT)
+        success_publish = publish_publication_record(record_path=record_path, transport_ref=SUCCESS_TRANSPORT)
+
+        failed = failed_publish["outcome"]
+        succeeded = success_publish["outcome"]
+
+        checks = {
+            "ingest_ok": ingest_result.get("ok") is True,
+            "plan_ok": plan.get("ok") is True,
+            "record_ok": record_result.get("ok") is True,
+            "first_publish_failed": failed_publish.get("ok") is False,
+            "second_publish_succeeded": success_publish.get("ok") is True,
+            "first_attempt_is_one": failed.get("attempt") == 1,
+            "first_status_failed": failed.get("status") == "failed",
+            "first_retry_eligible": failed.get("retry_eligible") is True,
+            "first_previous_is_none": failed.get("previous_outcome_id") is None,
+            "second_attempt_is_two": succeeded.get("attempt") == 2,
+            "second_status_published": succeeded.get("status") == "published",
+            "second_retry_not_eligible": succeeded.get("retry_eligible") is False,
+            "second_retry_after_failure": succeeded.get("retry_after_failure") is True,
+            "second_previous_id_matches": succeeded.get("previous_outcome_id") == failed.get("outcome_id"),
+            "second_previous_status_failed": succeeded.get("previous_outcome_status") == "failed",
+            "second_previous_ref_matches": succeeded.get("previous_outcome_ref") == failed.get("outcome_ref"),
+            "same_publication_id": succeeded.get("publication_id") == failed.get("publication_id") == record_result["record"].get("publication_id"),
+            "topic_expected": succeeded.get("topic") == EXPECTED_TOPIC,
+            "success_delivery_exists": Path(success_publish["delivery_path"]).exists(),
+            "failure_evidence_exists": Path(failed_publish["failure_path"]).exists(),
+        }
+        ok = all(checks.values())
+        print(json.dumps({"ok": ok, "checks": checks, "failed": failed, "succeeded": succeeded}, indent=2, sort_keys=True))
+        return 0 if ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds retry and attempt state for zone publication outcomes after the failure-evidence path merged.

This PR adds:
- `apps/zone-router/src/zone_router/retry_state.py`
- `tools/smoke_zone_publication_retry_state.py`

This PR updates:
- `apps/zone-router/src/zone_router/publish.py`
- `contracts/ZonePublicationOutcome.v0.1.json`
- `Makefile`

## What changes

Every publication outcome now carries:
- `attempt`
- `previous_outcome_id`
- `previous_outcome_status`
- `previous_outcome_ref`
- `retry_after_failure`
- `retry_eligible`

The retry smoke proves:
- first publish through `transport://fail/test` fails with attempt `1`
- failed outcome is retry eligible
- second publish through `transport://local/jsonl` succeeds with attempt `2`
- second outcome links back to the failed outcome id/status/ref

## Software review

Correctness: builds retry state from the existing outcome log, so there is no hidden scheduler or external state store.

Risk: moderate but bounded. Runtime outcome shape changes are schema-governed and covered by smoke through `make validate`.

Weakness: this does not add a scheduler, policy gate, or remote broker transport. It records retry state; it does not autonomously retry.
