### PR TITLE
Add safe remote broker transport seam

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -38,6 +38,9 @@ zone-router-publication-failure-evidence-smoke:
 zone-router-publication-retry-state-smoke:
 	python3 tools/smoke_zone_publication_retry_state.py
 
+zone-router-publication-remote-broker-seam-smoke:
+	python3 tools/smoke_zone_publication_remote_broker_seam.py
+
 test-go:
 	go test ./libs/go/tritrpcbridge/...
 	go test ./apps/api/...
@@ -59,7 +62,7 @@ test-tools:
 	test -d .venv-tools || python3 -m venv .venv-tools
 	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests
 
-smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke semantic-bridge-zone-validation-smoke
+smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke semantic-bridge-zone-validation-smoke
 
 smoke-health:
 	bash tools/smoke_tritrpc_health.sh

--- a/apps/zone-router/src/zone_router/transport_adapters.py
+++ b/apps/zone-router/src/zone_router/transport_adapters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -10,8 +11,10 @@ from .outbox import publication_outbox_root
 
 LOCAL_JSONL = "transport://local/jsonl"
 KAFKA_JSONL = "transport://kafka/jsonl"
+KAFKA_REMOTE = "transport://kafka/remote"
 FAIL_TEST = "transport://fail/test"
-SUPPORTED_TRANSPORTS = {LOCAL_JSONL, KAFKA_JSONL, FAIL_TEST}
+SUPPORTED_TRANSPORTS = {LOCAL_JSONL, KAFKA_JSONL, KAFKA_REMOTE, FAIL_TEST}
+REQUIRED_KAFKA_ENV = ("ZONE_ROUTER_KAFKA_BOOTSTRAP_SERVERS", "ZONE_ROUTER_KAFKA_TOPIC_PREFIX")
 
 
 def _utc_now() -> str:
@@ -23,9 +26,11 @@ def _transport_kind(transport_ref: str) -> str:
         return "local-jsonl"
     if transport_ref == KAFKA_JSONL:
         return "kafka-jsonl-local-standin"
+    if transport_ref == KAFKA_REMOTE:
+        return "kafka-remote"
     if transport_ref == FAIL_TEST:
         return "fail-test"
-    raise ValueError(f"unsupported transport_ref={transport_ref!r}")
+    return "unsupported"
 
 
 def _deliveries_root(service: str = "zone-router") -> Path:
@@ -79,6 +84,49 @@ def _failure_evidence(
     return {"ok": False, "failure_path": str(failure_path), "failure": failure, "error": error}
 
 
+def _missing_remote_kafka_config() -> list[str]:
+    return [name for name in REQUIRED_KAFKA_ENV if not os.environ.get(name)]
+
+
+def _delivery_payload(
+    *,
+    record: dict[str, Any],
+    publication_record_ref: str,
+    transport_ref: str,
+) -> dict[str, Any]:
+    return {
+        "version": "0.1",
+        "delivery_id": str(uuid.uuid4()),
+        "publication_id": record["publication_id"],
+        "transport_ref": transport_ref,
+        "transport_kind": _transport_kind(transport_ref),
+        "topic": record["topic"],
+        "publication_record_ref": publication_record_ref,
+        "carrier_ref": record.get("carrier_ref"),
+        "event_ref": record.get("event_ref"),
+        "receipt_ref": record.get("receipt_ref"),
+        "catalog_ref": record.get("catalog_ref"),
+        "delivered_at": _utc_now(),
+    }
+
+
+def _write_local_delivery(*, record: dict[str, Any], publication_record_ref: str, transport_ref: str, service: str) -> dict[str, Any]:
+    delivery = _delivery_payload(record=record, publication_record_ref=publication_record_ref, transport_ref=transport_ref)
+    delivery_path = _deliveries_root(service) / f"{delivery['delivery_id']}.delivery.json"
+    delivery_path.write_text(json.dumps(delivery, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    topic_log_path = _topic_logs_root(service) / f"{_safe_topic(record['topic'])}.jsonl"
+    with topic_log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(delivery, sort_keys=True) + "\n")
+
+    return {
+        "ok": True,
+        "delivery_path": str(delivery_path),
+        "topic_log_path": str(topic_log_path),
+        "delivery": delivery,
+    }
+
+
 def deliver_publication_record(
     *,
     record: dict[str, Any],
@@ -102,33 +150,22 @@ def deliver_publication_record(
             error="forced failure for transport://fail/test",
             service=service,
         )
+    if transport_ref == KAFKA_REMOTE:
+        missing = _missing_remote_kafka_config()
+        if missing:
+            return _failure_evidence(
+                record=record,
+                publication_record_ref=publication_record_ref,
+                transport_ref=transport_ref,
+                error="remote Kafka transport requires configuration: " + ", ".join(missing),
+                service=service,
+            )
+        return _failure_evidence(
+            record=record,
+            publication_record_ref=publication_record_ref,
+            transport_ref=transport_ref,
+            error="remote Kafka broker client is not implemented in this safe seam",
+            service=service,
+        )
 
-    delivery_id = str(uuid.uuid4())
-    delivery = {
-        "version": "0.1",
-        "delivery_id": delivery_id,
-        "publication_id": record["publication_id"],
-        "transport_ref": transport_ref,
-        "transport_kind": _transport_kind(transport_ref),
-        "topic": record["topic"],
-        "publication_record_ref": publication_record_ref,
-        "carrier_ref": record.get("carrier_ref"),
-        "event_ref": record.get("event_ref"),
-        "receipt_ref": record.get("receipt_ref"),
-        "catalog_ref": record.get("catalog_ref"),
-        "delivered_at": _utc_now(),
-    }
-
-    delivery_path = _deliveries_root(service) / f"{delivery_id}.delivery.json"
-    delivery_path.write_text(json.dumps(delivery, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-    topic_log_path = _topic_logs_root(service) / f"{_safe_topic(record['topic'])}.jsonl"
-    with topic_log_path.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps(delivery, sort_keys=True) + "\n")
-
-    return {
-        "ok": True,
-        "delivery_path": str(delivery_path),
-        "topic_log_path": str(topic_log_path),
-        "delivery": delivery,
-    }
+    return _write_local_delivery(record=record, publication_record_ref=publication_record_ref, transport_ref=transport_ref, service=service)

--- a/tools/smoke_zone_publication_remote_broker_seam.py
+++ b/tools/smoke_zone_publication_remote_broker_seam.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "apps/lampstand/src"))
+sys.path.insert(0, str(ROOT / "apps/zone-router/src"))
+
+from prophet_platform_lampstand.ingest import ingest_path  # noqa: E402
+from zone_router.outbox import write_publication_record  # noqa: E402
+from zone_router.planner import plan_publication_request  # noqa: E402
+from zone_router.publish import publish_publication_record  # noqa: E402
+
+ZONE_REF = "zone://edge"
+REMOTE_TRANSPORT = "transport://kafka/remote"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        os.environ["SOCIOPROFIT_DATA_HOME"] = str(root / "data")
+        os.environ["SOCIOPROFIT_STATE_HOME"] = str(root / "state")
+        os.environ["SOCIOPROFIT_RUNTIME_HOME"] = str(root / "run")
+        os.environ.pop("ZONE_ROUTER_KAFKA_BOOTSTRAP_SERVERS", None)
+        os.environ.pop("ZONE_ROUTER_KAFKA_TOPIC_PREFIX", None)
+
+        sample = root / "sample.txt"
+        sample.write_text("zone publication remote broker seam smoke\n", encoding="utf-8")
+
+        ingest_result = ingest_path(file_path=str(sample), zone_ref=ZONE_REF)
+        plan = plan_publication_request(ingest_result["publication_request"])
+        record_result = write_publication_record(plan)
+        publish_result = publish_publication_record(record_path=record_result["record_path"], transport_ref=REMOTE_TRANSPORT)
+        outcome = publish_result["outcome"]
+        failure = publish_result["failure"]
+
+        checks = {
+            "ingest_ok": ingest_result.get("ok") is True,
+            "plan_ok": plan.get("ok") is True,
+            "record_ok": record_result.get("ok") is True,
+            "publish_failed": publish_result.get("ok") is False,
+            "failure_path_exists": Path(publish_result["failure_path"]).exists(),
+            "outcome_path_exists": Path(publish_result["outcome_path"]).exists(),
+            "failure_transport_kind": failure.get("transport_kind") == "kafka-remote",
+            "failure_mentions_config": "requires configuration" in failure.get("error", ""),
+            "failure_mentions_bootstrap": "ZONE_ROUTER_KAFKA_BOOTSTRAP_SERVERS" in failure.get("error", ""),
+            "failure_mentions_topic_prefix": "ZONE_ROUTER_KAFKA_TOPIC_PREFIX" in failure.get("error", ""),
+            "outcome_status_failed": outcome.get("status") == "failed",
+            "outcome_transport_kind": outcome.get("transport_kind") == "kafka-remote",
+            "outcome_failure_ref_matches": outcome.get("failure_ref") == publish_result.get("failure_path"),
+            "outcome_error_mentions_config": "requires configuration" in outcome.get("error", ""),
+        }
+        ok = all(checks.values())
+        print(json.dumps({"ok": ok, "checks": checks, "failure": failure, "outcome": outcome}, indent=2, sort_keys=True))
+        return 0 if ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a safe remote broker transport seam for zone publication without enabling silent remote mutation.

This PR updates:
- `apps/zone-router/src/zone_router/transport_adapters.py`
- `tools/smoke_zone_publication_remote_broker_seam.py`
- `Makefile`

## What changes

Adds `transport://kafka/remote` as an explicit broker-required transport mode.

Behavior is safe-by-default:
- without `ZONE_ROUTER_KAFKA_BOOTSTRAP_SERVERS` and `ZONE_ROUTER_KAFKA_TOPIC_PREFIX`, publish fails with structured failure evidence
- even with config present, the current seam fails closed because the real broker client is not implemented in this slice
- no remote broker mutation is performed

The smoke proves that remote broker mode does not silently fall back to local publication and instead emits a failed outcome with failure evidence when configuration is absent.

## Software review

Correctness: this creates the remote broker seam while preserving no-hidden-automation. It distinguishes local stand-in behavior from real broker-required behavior.

Risk: low-to-moderate. Runtime adapter behavior changes, but the new remote path fails closed and is covered by smoke through `make validate`.

Weakness: this does not implement a real Kafka client. That should be a later explicitly configured and policy-gated tranche.
