### PR TITLE
Add Policy Fabric operations endpoint client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -28,6 +28,9 @@ validate-lampstand-lifecycle:
 
 validate-zone-stack-audit:
 	python3 tools/validate_zone_publication_stack_audit.py
+
+policy-fabric-endpoint-client-smoke:
+	python3 tools/smoke_policy_fabric_operations_endpoint_client.py
 
 zone-router-publication-local-publish-smoke:
 	python3 tools/smoke_zone_publication_local_publish.py
@@ -62,7 +65,7 @@ test-tools:
 	test -d .venv-tools || python3 -m venv .venv-tools
 	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests
 
-smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke semantic-bridge-zone-validation-smoke
+smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke policy-fabric-endpoint-client-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke semantic-bridge-zone-validation-smoke
 
 smoke-health:
 	bash tools/smoke_tritrpc_health.sh

--- a/tools/request_policy_fabric_operations_decision.py
+++ b/tools/request_policy_fabric_operations_decision.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "external" / "policy-fabric" / "prophet_operations_action_decision_v1.schema.json"
+DEFAULT_PATH = "/v1/operations/action-decision"
+
+
+class PolicyFabricClientError(Exception):
+    pass
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise PolicyFabricClientError(f"expected JSON object in {path}")
+    return data
+
+
+def endpoint_url(base_url: str) -> str:
+    base = base_url.rstrip("/")
+    return base + DEFAULT_PATH
+
+
+def request_decision(*, base_url: str, recommendation: dict[str, Any], mode: str, timeout_seconds: float = 5.0) -> dict[str, Any]:
+    payload = json.dumps({"recommendation": recommendation, "mode": mode}, sort_keys=True).encode("utf-8")
+    req = urllib.request.Request(
+        endpoint_url(base_url),
+        data=payload,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_seconds) as resp:  # noqa: S310 - explicit operator-supplied endpoint
+            body = resp.read().decode("utf-8")
+            if resp.status < 200 or resp.status >= 300:
+                raise PolicyFabricClientError(f"Policy Fabric endpoint returned HTTP {resp.status}: {body}")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise PolicyFabricClientError(f"Policy Fabric endpoint returned HTTP {exc.code}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise PolicyFabricClientError(f"Policy Fabric endpoint unavailable: {exc.reason}") from exc
+
+    data = json.loads(body)
+    if not isinstance(data, dict):
+        raise PolicyFabricClientError("Policy Fabric endpoint returned non-object JSON")
+    schema = load_json(SCHEMA)
+    jsonschema.validate(data, schema)
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Request a Prophet operations action decision from a live Policy Fabric endpoint")
+    parser.add_argument("--endpoint", required=True, help="Policy Fabric base URL, e.g. http://127.0.0.1:8080")
+    parser.add_argument("--recommendation", type=Path, required=True, help="Operations recommendation JSON object")
+    parser.add_argument("--mode", default="report_only", choices=["report_only", "enforcing"])
+    parser.add_argument("--timeout-seconds", type=float, default=5.0)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    decision = request_decision(
+        base_url=args.endpoint,
+        recommendation=load_json(args.recommendation),
+        mode=args.mode,
+        timeout_seconds=args.timeout_seconds,
+    )
+    encoded = json.dumps(decision, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(encoded, encoding="utf-8")
+    else:
+        print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/smoke_policy_fabric_operations_endpoint_client.py
+++ b/tools/smoke_policy_fabric_operations_endpoint_client.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+RECOMMENDATION = {
+    "recommendation_id": "oprec-live-endpoint-smoke",
+    "risk_level": "low",
+    "requested_outcome": "allow",
+    "subject": {"id": "service-1", "type": "service", "name": "service-1"},
+    "action": {"type": "restart", "intent": "restore health", "description": "restart service"},
+    "policy_refs": ["policy://operations/default-action-gates/v1"],
+}
+
+
+class Handler(BaseHTTPRequestHandler):
+    requests: list[dict[str, Any]] = []
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        return
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/v1/operations/action-decision":
+            self.send_response(404)
+            self.end_headers()
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length).decode("utf-8"))
+        Handler.requests.append(body)
+        rec = body["recommendation"]
+        decision = {
+            "kind": "ProphetOperationsActionDecision",
+            "schema_version": "v1",
+            "decision_id": "opdec-live-endpoint-smoke",
+            "decided_at": "2026-04-26T00:00:00+00:00",
+            "recommendation_ref": rec["recommendation_id"],
+            "subject": rec["subject"],
+            "proposed_action": rec["action"],
+            "decision": {"outcome": "manual_review", "reason": "mock_endpoint_report_only", "risk_level": rec["risk_level"], "expires_at": None},
+            "basis": {"policy_refs": rec["policy_refs"], "signal_refs": [], "evidence_refs": []},
+            "controls": {"requires_human_approval": True, "requires_change_window": False, "rollback_required": False},
+            "audit": {"actor": "mock-policy-fabric", "mode": "automated", "notes": "smoke"},
+        }
+        payload = json.dumps(decision, sort_keys=True).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        recommendation_path = tmp / "recommendation.json"
+        output_path = tmp / "decision.json"
+        recommendation_path.write_text(json.dumps(RECOMMENDATION, indent=2) + "\n", encoding="utf-8")
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            base_url = f"http://127.0.0.1:{server.server_port}"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tools" / "request_policy_fabric_operations_decision.py"),
+                    "--endpoint",
+                    base_url,
+                    "--recommendation",
+                    str(recommendation_path),
+                    "--mode",
+                    "report_only",
+                    "--output",
+                    str(output_path),
+                ],
+                cwd=ROOT,
+                check=True,
+            )
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+
+        decision = json.loads(output_path.read_text(encoding="utf-8"))
+        request = Handler.requests[0] if Handler.requests else {}
+        checks = {
+            "request_seen": len(Handler.requests) == 1,
+            "request_mode_report_only": request.get("mode") == "report_only",
+            "request_recommendation_preserved": request.get("recommendation", {}).get("recommendation_id") == RECOMMENDATION["recommendation_id"],
+            "decision_kind": decision.get("kind") == "ProphetOperationsActionDecision",
+            "recommendation_ref": decision.get("recommendation_ref") == RECOMMENDATION["recommendation_id"],
+            "manual_review": decision.get("decision", {}).get("outcome") == "manual_review",
+            "requires_human": decision.get("controls", {}).get("requires_human_approval") is True,
+        }
+        ok = all(checks.values())
+        print(json.dumps({"ok": ok, "checks": checks, "decision": decision}, indent=2, sort_keys=True))
+        return 0 if ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a live Policy Fabric operations decision endpoint client to `prophet-platform`.

This PR adds:
- `tools/request_policy_fabric_operations_decision.py`
- `tools/smoke_policy_fabric_operations_endpoint_client.py`

This PR updates:
- `Makefile`

## What changes

The client POSTs to:
- `/v1/operations/action-decision`

It sends:
- `recommendation`
- `mode`

It validates the returned decision against the vendored Policy Fabric schema:
- `schemas/external/policy-fabric/prophet_operations_action_decision_v1.schema.json`

The smoke uses a local mock HTTP endpoint to prove:
- request shape is correct
- `report_only` mode is sent
- recommendation payload is preserved
- returned decision validates against the schema
- manual-review safety semantics are preserved

## Software review

Correctness: this wires the platform side to the live Policy Fabric endpoint contract without depending on an external deployment during CI.

Risk: low. Client only; no action execution or hidden remote mutation.

Weakness: this does not yet invoke the client inside the action execution gate. That should remain a separate policy-gated tranche.
