### PR TITLE
platform: add Michael attribution delta schema and route test

### DIFF
--- a/apps/eval-fabric-api/tests/test_michael_attribution_deltas.py
+++ b/apps/eval-fabric-api/tests/test_michael_attribution_deltas.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import main
+
+
+class _Emission:
+    def __init__(self) -> None:
+        self.payload_ref = "file:///tmp/payload.json"
+        self.event_ref = "file:///tmp/event.json"
+        self.receipt_ref = "file:///tmp/receipt.json"
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr(main, "maybe_emit_artifacts", lambda **kwargs: _Emission())
+    monkeypatch.setattr(
+        main.governance_repositories,
+        "get_model_attribution",
+        lambda model_release_id, window="rolling_30d": {
+            "subject_id": model_release_id,
+            "window": window,
+            "attributions": {
+                "belief_delta": 0.11,
+                "rule_delta": 0.07,
+                "law_delta": 0.03,
+                "constraint_delta": 0.02,
+                "model_delta": 0.19,
+            },
+            "notes": "machine science attribution example",
+        },
+    )
+    return TestClient(main.app)
+
+
+def test_model_attribution_route_carries_michael_delta_fields(client: TestClient) -> None:
+    response = client.get("/v1/models/model.semantic-stack.2026-04-05/attribution")
+    assert response.status_code == 200
+    body = response.json()
+    attrs = body["attribution"]["attributions"]
+
+    assert attrs["belief_delta"] == 0.11
+    assert attrs["rule_delta"] == 0.07
+    assert attrs["law_delta"] == 0.03
+    assert attrs["constraint_delta"] == 0.02
+    assert attrs["model_delta"] == 0.19
+    assert body["window"] == "rolling_30d"
+    assert response.headers["X-Payload-Ref"] == "file:///tmp/payload.json"
+    assert response.headers["X-Event-Envelope-Ref"] == "file:///tmp/event.json"
+    assert response.headers["X-Evidence-Receipt-Ref"] == "file:///tmp/receipt.json"

--- a/docs/MICHAEL_ATTRIBUTION_DELTAS.md
+++ b/docs/MICHAEL_ATTRIBUTION_DELTAS.md
@@ -1,0 +1,29 @@
+# Michael Attribution Deltas
+
+## Purpose
+
+This note records the Michael-specific causal-attribution delta vocabulary for the eval-fabric governance plane.
+
+## Delta fields
+
+The intended Michael-facing attribution surface SHOULD distinguish at least:
+- `belief_delta`
+- `rule_delta`
+- `law_delta`
+- `constraint_delta`
+
+These sit alongside broader fields such as `model_delta` when present.
+
+## Why this matters
+
+Michael does not collapse all epistemic change into one undifferentiated score.
+
+The eval-fabric plane should therefore be able to express:
+- change in probabilistic belief state
+- change in soft-rule influence
+- change in candidate or promoted law influence
+- change in asserted constraint influence
+
+## Runtime implication
+
+The existing `/v1/models/{model_release_id}/attribution` route can already carry an `attributions` object. This note and the accompanying schema define the expected Michael-facing shape for that object when the machine-science lane is active.

--- a/schemas/michael/causal_attribution_delta.schema.json
+++ b/schemas/michael/causal_attribution_delta.schema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://socioprophet.org/schema/michael/causal_attribution_delta.schema.json",
+  "type": "object",
+  "required": [
+    "subject_id",
+    "window",
+    "attributions"
+  ],
+  "properties": {
+    "subject_id": { "type": "string" },
+    "window": { "type": "string" },
+    "attributions": {
+      "type": "object",
+      "properties": {
+        "belief_delta": { "type": "number" },
+        "rule_delta": { "type": "number" },
+        "law_delta": { "type": "number" },
+        "constraint_delta": { "type": "number" },
+        "model_delta": { "type": "number" }
+      },
+      "additionalProperties": true
+    },
+    "notes": { "type": ["string", "null"] }
+  }
+}


### PR DESCRIPTION
## Summary

Add the first Michael-specific causal-attribution delta tranche to `prophet-platform`.

## Files

- `schemas/michael/causal_attribution_delta.schema.json`
- `docs/MICHAEL_ATTRIBUTION_DELTAS.md`
- `apps/eval-fabric-api/tests/test_michael_attribution_deltas.py`

## Why

The Michael machine-science lane needs the eval-fabric governance plane to distinguish changes in:
- belief state
- rule influence
- candidate/promoted law influence
- asserted constraint influence

This PR adds the first explicit schema, note, and route-level test for that delta vocabulary while reusing the existing attribution surface.
