### PR TITLE
Add guarded Policy Fabric operations validation workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -31,6 +31,9 @@ validate-zone-stack-audit:
 
 policy-fabric-endpoint-client-smoke:
 	python3 tools/smoke_policy_fabric_operations_endpoint_client.py
+
+policy-fabric-guarded-workflow-smoke:
+	python3 tools/smoke_policy_fabric_guarded_operations_validation.py
 
 zone-router-publication-local-publish-smoke:
 	python3 tools/smoke_zone_publication_local_publish.py
@@ -65,7 +68,7 @@ test-tools:
 	test -d .venv-tools || python3 -m venv .venv-tools
 	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests
 
-smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke policy-fabric-endpoint-client-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke semantic-bridge-zone-validation-smoke
+smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke semantic-bridge-zone-validation-smoke
 
 smoke-health:
 	bash tools/smoke_tritrpc_health.sh

--- a/tools/run_policy_fabric_guarded_operations_validation.py
+++ b/tools/run_policy_fabric_guarded_operations_validation.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUEST_CLIENT = ROOT / "tools" / "request_policy_fabric_operations_decision.py"
+VALIDATOR = ROOT / "tools" / "validate_prophet_operations_policy_decisions.py"
+
+
+class GuardedWorkflowError(Exception):
+    pass
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise GuardedWorkflowError(f"expected JSON object in {path}")
+    return data
+
+
+def first_policy_gated_recommendation(bundle: dict[str, Any]) -> dict[str, Any]:
+    for recommendation in bundle.get("recommendations", []):
+        if recommendation.get("policy_gate", {}).get("required") is True:
+            return recommendation
+    raise GuardedWorkflowError("bundle contains no policy-gated recommendation")
+
+
+def run_checked(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True)
+    if result.returncode != 0:
+        raise GuardedWorkflowError(
+            "command failed with exit code "
+            + str(result.returncode)
+            + "\nCOMMAND: "
+            + " ".join(cmd)
+            + "\nSTDOUT:\n"
+            + result.stdout
+            + "\nSTDERR:\n"
+            + result.stderr
+        )
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fetch a Policy Fabric operation decision and validate an operations bundle without executing remediation")
+    parser.add_argument("--endpoint", required=True, help="Policy Fabric base URL")
+    parser.add_argument("--bundle", type=Path, required=True, help="ProphetOperationsEvidenceBundle JSON")
+    parser.add_argument("--mode", default="report_only", choices=["report_only", "enforcing"])
+    parser.add_argument("--workdir", type=Path, required=True, help="Directory for generated decision/report artifacts")
+    parser.add_argument("--require-executable", action="store_true", help="Fail unless fetched decision allows execution")
+    args = parser.parse_args()
+
+    bundle = load_json(args.bundle)
+    recommendation = first_policy_gated_recommendation(bundle)
+    args.workdir.mkdir(parents=True, exist_ok=True)
+    recommendation_path = args.workdir / "policy_fabric_recommendation.json"
+    decision_path = args.workdir / "policy_fabric_decision.json"
+    report_path = args.workdir / "policy_fabric_validation_report.json"
+    recommendation_path.write_text(json.dumps(recommendation, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    run_checked(
+        [
+            sys.executable,
+            str(REQUEST_CLIENT),
+            "--endpoint",
+            args.endpoint,
+            "--recommendation",
+            str(recommendation_path),
+            "--mode",
+            args.mode,
+            "--output",
+            str(decision_path),
+        ]
+    )
+    validator_cmd = [
+        sys.executable,
+        str(VALIDATOR),
+        "--bundle",
+        str(args.bundle),
+        "--decision",
+        str(decision_path),
+        "--output",
+        str(report_path),
+    ]
+    if args.require_executable:
+        validator_cmd.append("--require-executable")
+    run_checked(validator_cmd)
+
+    report = load_json(report_path)
+    result = {
+        "ok": True,
+        "executed_remediation": False,
+        "mode": args.mode,
+        "recommendation_path": str(recommendation_path),
+        "decision_path": str(decision_path),
+        "report_path": str(report_path),
+        "summary": report.get("summary", {}),
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/smoke_policy_fabric_guarded_operations_validation.py
+++ b/tools/smoke_policy_fabric_guarded_operations_validation.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+BUNDLE = ROOT / "examples" / "operations" / "prophet_operations_evidence_bundle_with_policy_decision_links_0001.json"
+
+
+class Handler(BaseHTTPRequestHandler):
+    requests: list[dict[str, Any]] = []
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        return
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/v1/operations/action-decision":
+            self.send_response(404)
+            self.end_headers()
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        body = json.loads(self.rfile.read(length).decode("utf-8"))
+        Handler.requests.append(body)
+        rec = body["recommendation"]
+        decision = {
+            "kind": "ProphetOperationsActionDecision",
+            "schema_version": "v1",
+            "decision_id": "opdec-guarded-workflow-smoke",
+            "decided_at": "2026-04-26T00:00:00+00:00",
+            "recommendation_ref": rec["recommendation_id"],
+            "subject": rec["subject"],
+            "proposed_action": rec["action"],
+            "decision": {"outcome": "manual_review", "reason": "mock_endpoint_report_only", "risk_level": "high", "expires_at": None},
+            "basis": {"policy_refs": ["policy://operations/default-action-gates/v1"], "signal_refs": [], "evidence_refs": []},
+            "controls": {"requires_human_approval": True, "requires_change_window": False, "rollback_required": False},
+            "audit": {"actor": "mock-policy-fabric", "mode": "automated", "notes": "guarded smoke"},
+        }
+        payload = json.dumps(decision, sort_keys=True).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        workdir = Path(td)
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            base_url = f"http://127.0.0.1:{server.server_port}"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "tools" / "run_policy_fabric_guarded_operations_validation.py"),
+                    "--endpoint",
+                    base_url,
+                    "--bundle",
+                    str(BUNDLE),
+                    "--mode",
+                    "report_only",
+                    "--workdir",
+                    str(workdir),
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+
+        output = json.loads(result.stdout)
+        decision_path = Path(output["decision_path"])
+        report_path = Path(output["report_path"])
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        checks = {
+            "request_seen": len(Handler.requests) == 1,
+            "request_mode_report_only": Handler.requests[0].get("mode") == "report_only",
+            "ok": output.get("ok") is True,
+            "no_remediation_execution": output.get("executed_remediation") is False,
+            "decision_path_exists": decision_path.exists(),
+            "report_path_exists": report_path.exists(),
+            "blocked_count_one": report.get("summary", {}).get("blocked_count") == 1,
+            "executable_count_zero": report.get("summary", {}).get("executable_count") == 0,
+            "manual_review_blocked": report.get("blocked_recommendations") == [{"recommendation_id": "oprec-worker-1-isolate", "outcome": "manual_review"}],
+        }
+        ok = all(checks.values())
+        print(json.dumps({"ok": ok, "checks": checks, "output": output}, indent=2, sort_keys=True))
+        return 0 if ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a guarded workflow that invokes the Policy Fabric operations endpoint client, writes a decision artifact, and validates the operations evidence bundle through the existing local policy-decision gate.

This PR adds:
- `tools/run_policy_fabric_guarded_operations_validation.py`
- `tools/smoke_policy_fabric_guarded_operations_validation.py`

This PR updates:
- `Makefile`

## What changes

The workflow performs:
1. load operations evidence bundle
2. extract the first policy-gated recommendation
3. call the Policy Fabric endpoint client
4. write returned decision as an artifact
5. run the existing `validate_prophet_operations_policy_decisions.py` gate
6. emit a validation report

The smoke uses a local mock Policy Fabric endpoint and proves:
- request mode is `report_only`
- decision/report artifacts are written
- manual-review blocks execution
- no remediation is executed

## Software review

Correctness: this advances the endpoint client from standalone request tool to a guarded validation workflow while preserving the existing execution-blocking validator.

Risk: low-to-moderate. It adds workflow code but no remediation execution and no hidden remote mutation.

Weakness: runtime endpoint configuration remains future work; this still uses explicit operator-supplied endpoint arguments.
