### PR TITLE
Refresh Fog Stack manifest promotion policy enforcement

### DIFF
--- a/.github/workflows/fogstack-manifest-promotion.yml
+++ b/.github/workflows/fogstack-manifest-promotion.yml
@@ -7,11 +7,14 @@ on:
       - "bundles/**"
       - "conformance/**"
       - "catalog/fogstack-support-states-v0.1.yaml"
+      - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
       - "releases/manifests/**"
       - "tools/build_fogstack_manifest_publication_set.py"
       - "tools/promote_fogstack_manifest_publication_set.py"
+      - "tools/check_fogstack_manifest_promotion_policy.py"
       - "tools/tests/test_build_fogstack_manifest_publication_set.py"
       - "tools/tests/test_promote_fogstack_manifest_publication_set.py"
+      - "tools/tests/test_check_fogstack_manifest_promotion_policy.py"
       - "docs/FOGSTACK_*.md"
       - ".github/workflows/fogstack-manifest-promotion.yml"
   push:
@@ -20,11 +23,14 @@ on:
       - "bundles/**"
       - "conformance/**"
       - "catalog/fogstack-support-states-v0.1.yaml"
+      - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
       - "releases/manifests/**"
       - "tools/build_fogstack_manifest_publication_set.py"
       - "tools/promote_fogstack_manifest_publication_set.py"
+      - "tools/check_fogstack_manifest_promotion_policy.py"
       - "tools/tests/test_build_fogstack_manifest_publication_set.py"
       - "tools/tests/test_promote_fogstack_manifest_publication_set.py"
+      - "tools/tests/test_check_fogstack_manifest_promotion_policy.py"
       - "docs/FOGSTACK_*.md"
       - ".github/workflows/fogstack-manifest-promotion.yml"
 
@@ -53,7 +59,8 @@ jobs:
         run: |
           python -m pytest -q \
             tools/tests/test_build_fogstack_manifest_publication_set.py \
-            tools/tests/test_promote_fogstack_manifest_publication_set.py
+            tools/tests/test_promote_fogstack_manifest_publication_set.py \
+            tools/tests/test_check_fogstack_manifest_promotion_policy.py
 
       - name: Build canonical publication set
         run: |
@@ -72,6 +79,12 @@ jobs:
             --support-catalog catalog/fogstack-support-states-v0.1.yaml \
             --target-channel candidate \
             --target-support-state supported
+
+      - name: Enforce promotion policy
+        run: |
+          python3 tools/check_fogstack_manifest_promotion_policy.py \
+            --publication-set artifacts/manifest-promotion/promoted/manifest-publication-set.json \
+            --policy-catalog catalog/fogstack-manifest-promotion-policy-v0.1.yaml
 
       - name: Upload promoted manifest set
         uses: actions/upload-artifact@v4

--- a/catalog/fogstack-manifest-promotion-policy-v0.1.yaml
+++ b/catalog/fogstack-manifest-promotion-policy-v0.1.yaml
@@ -1,0 +1,28 @@
+schema_version: "fogstack.manifest-promotion-policy/v0.1"
+kind: "FogStackManifestPromotionPolicy"
+defaults:
+  require_explicit_target_channel: true
+  require_explicit_target_support_state: true
+allowed_transitions:
+  preview:
+    community:
+      candidate:
+        - supported
+        - community
+  candidate:
+    supported:
+      stable:
+        - supported
+    community:
+      stable:
+        - supported
+  stable:
+    supported:
+      extended:
+        - extended
+      deprecated:
+        - deprecated
+  extended:
+    extended:
+      deprecated:
+        - deprecated

--- a/docs/FOGSTACK_MANIFEST_PROMOTION_POLICY.md
+++ b/docs/FOGSTACK_MANIFEST_PROMOTION_POLICY.md
@@ -1,0 +1,43 @@
+# Fog Stack manifest promotion policy
+
+This document defines the repo-native policy surface for Fog Stack manifest promotion.
+
+## Goal
+
+Move from unrestricted manifest promotion to governed promotion transitions that are checked against an explicit policy catalog.
+
+## Policy model
+
+The policy catalog lives at:
+- `catalog/fogstack-manifest-promotion-policy-v0.1.yaml`
+
+It currently defines:
+- whether explicit target channel/support-state values are required
+- which channel/support-state transitions are allowed
+
+## Minimal flow
+
+1. build the canonical publication set
+2. promote the publication set with `tools/promote_fogstack_manifest_publication_set.py`
+3. check the promoted output with `tools/check_fogstack_manifest_promotion_policy.py`
+4. only treat the promoted set as valid if the checker passes
+
+## Example
+
+Run the checker against:
+- the promoted `manifest-publication-set.json`
+- `catalog/fogstack-manifest-promotion-policy-v0.1.yaml`
+
+## What this phase provides
+
+- explicit transition policy for channel/support-state movement
+- CI enforcement of that policy in the manifest-promotion workflow
+- prior-state carry-through in the promoted publication set so transitions are auditable
+
+## What this phase does not yet provide
+
+- approval workflows with human sign-off
+- external signing as a requirement for promotion
+- registry publication gates
+
+Those remain later steps.

--- a/tools/check_fogstack_manifest_promotion_policy.py
+++ b/tools/check_fogstack_manifest_promotion_policy.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check a Fog Stack manifest promotion set against policy")
+    parser.add_argument("--publication-set", required=True, type=Path)
+    parser.add_argument("--policy-catalog", required=True, type=Path)
+    args = parser.parse_args()
+
+    publication = load_json(args.publication_set)
+    policy = yaml.safe_load(args.policy_catalog.read_text(encoding="utf-8")) or {}
+    defaults = policy.get("defaults") or {}
+    transitions = policy.get("allowed_transitions") or {}
+
+    promotion = publication.get("promotion") or {}
+    manifests = publication.get("manifests") or []
+    if not isinstance(manifests, list):
+        raise SystemExit("ERR: manifests list missing or malformed")
+
+    require_channel = bool(defaults.get("require_explicit_target_channel"))
+    require_support = bool(defaults.get("require_explicit_target_support_state"))
+
+    if require_channel and not promotion.get("channel"):
+        raise SystemExit("ERR: promotion.channel is required by policy")
+    if require_support and not promotion.get("support_state"):
+        raise SystemExit("ERR: promotion.support_state is required by policy")
+
+    violations: list[str] = []
+    for item in manifests:
+        if not isinstance(item, dict):
+            violations.append("manifest entry is not an object")
+            continue
+        bundle_id = item.get("bundle_id")
+        prev_channel = item.get("previous_channel")
+        prev_support = item.get("previous_support_state")
+        target_channel = item.get("channel")
+        target_support = item.get("support_state")
+
+        allowed_supports = (((transitions.get(prev_channel) or {}).get(prev_support) or {}).get(target_channel))
+        if not isinstance(allowed_supports, list) or target_support not in allowed_supports:
+            violations.append(
+                f"{bundle_id}: disallowed transition {prev_channel}/{prev_support} -> {target_channel}/{target_support}"
+            )
+
+    if violations:
+        for item in violations:
+            print(item)
+        raise SystemExit(1)
+
+    print("FogStack manifest promotion policy passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/promote_fogstack_manifest_publication_set.py
+++ b/tools/promote_fogstack_manifest_publication_set.py
@@ -63,8 +63,14 @@ def main() -> int:
         version = data.get("version")
         cat_item = catalog_map.get((bundle_id, version), {})
 
-        data["channel"] = args.target_channel or cat_item.get("channel") or data.get("channel")
-        data["support_state"] = args.target_support_state or cat_item.get("support_state") or data.get("support_state")
+        previous_channel = data.get("channel")
+        previous_support_state = data.get("support_state")
+
+        target_channel = args.target_channel or cat_item.get("channel") or previous_channel
+        target_support_state = args.target_support_state or cat_item.get("support_state") or previous_support_state
+
+        data["channel"] = target_channel
+        data["support_state"] = target_support_state
 
         out_path = out_manifests_dir / src.name
         out_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
@@ -75,8 +81,10 @@ def main() -> int:
                 "version": version,
                 "ref": str(out_path),
                 "signed": data.get("signed"),
-                "channel": data.get("channel"),
-                "support_state": data.get("support_state"),
+                "previous_channel": previous_channel,
+                "previous_support_state": previous_support_state,
+                "channel": target_channel,
+                "support_state": target_support_state,
                 "lifecycle_status": cat_item.get("lifecycle_status"),
             }
         )

--- a/tools/tests/test_check_fogstack_manifest_promotion_policy.py
+++ b/tools/tests/test_check_fogstack_manifest_promotion_policy.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')
+
+
+def _write_policy(path: Path) -> None:
+    path.write_text(
+        'schema_version: "fogstack.manifest-promotion-policy/v0.1"\n'
+        'kind: "FogStackManifestPromotionPolicy"\n'
+        'defaults:\n'
+        '  require_explicit_target_channel: true\n'
+        '  require_explicit_target_support_state: true\n'
+        'allowed_transitions:\n'
+        '  preview:\n'
+        '    community:\n'
+        '      candidate:\n'
+        '        - supported\n'
+        '        - community\n',
+        encoding='utf-8',
+    )
+
+
+def test_check_fogstack_manifest_promotion_policy_allows_valid_transition(tmp_path: Path) -> None:
+    publication = tmp_path / 'manifest-publication-set.json'
+    _write_json(publication, {
+        'kind': 'FogStackManifestPublicationSet',
+        'schema_version': 'v0.1',
+        'promotion': {'channel': 'candidate', 'support_state': 'supported'},
+        'manifests': [
+            {
+                'bundle_id': 'fogstack.access',
+                'version': '0.1.0',
+                'ref': 'manifests/fogstack.access-v0.1.manifest.json',
+                'signed': False,
+                'previous_channel': 'preview',
+                'previous_support_state': 'community',
+                'channel': 'candidate',
+                'support_state': 'supported',
+            }
+        ],
+    })
+    policy = tmp_path / 'policy.yaml'
+    _write_policy(policy)
+
+    subprocess.run([
+        sys.executable,
+        'tools/check_fogstack_manifest_promotion_policy.py',
+        '--publication-set', str(publication),
+        '--policy-catalog', str(policy),
+    ], check=True)
+
+
+def test_check_fogstack_manifest_promotion_policy_rejects_invalid_transition(tmp_path: Path) -> None:
+    publication = tmp_path / 'manifest-publication-set.json'
+    _write_json(publication, {
+        'kind': 'FogStackManifestPublicationSet',
+        'schema_version': 'v0.1',
+        'promotion': {'channel': 'stable', 'support_state': 'supported'},
+        'manifests': [
+            {
+                'bundle_id': 'fogstack.access',
+                'version': '0.1.0',
+                'ref': 'manifests/fogstack.access-v0.1.manifest.json',
+                'signed': False,
+                'previous_channel': 'preview',
+                'previous_support_state': 'community',
+                'channel': 'stable',
+                'support_state': 'supported',
+            }
+        ],
+    })
+    policy = tmp_path / 'policy.yaml'
+    _write_policy(policy)
+
+    proc = subprocess.run([
+        sys.executable,
+        'tools/check_fogstack_manifest_promotion_policy.py',
+        '--publication-set', str(publication),
+        '--policy-catalog', str(policy),
+    ])
+    assert proc.returncode != 0

--- a/tools/tests/test_promote_fogstack_manifest_publication_set.py
+++ b/tools/tests/test_promote_fogstack_manifest_publication_set.py
@@ -71,3 +71,5 @@ def test_promote_fogstack_manifest_publication_set_updates_channel_and_support_s
     assert promoted_index['promotion']['channel'] == 'candidate'
     assert promoted_index['promotion']['support_state'] == 'supported'
     assert promoted_index['manifests'][0]['lifecycle_status'] == 'merged-upstream'
+    assert promoted_index['manifests'][0]['previous_channel'] == 'preview'
+    assert promoted_index['manifests'][0]['previous_support_state'] == 'community'


### PR DESCRIPTION
## Summary

This PR refreshes the manifest promotion policy tranche directly on top of current `main`:

- `catalog/fogstack-manifest-promotion-policy-v0.1.yaml`
- `tools/check_fogstack_manifest_promotion_policy.py`
- `tools/tests/test_check_fogstack_manifest_promotion_policy.py`
- updated `tools/promote_fogstack_manifest_publication_set.py`
- updated `tools/tests/test_promote_fogstack_manifest_publication_set.py`
- updated `.github/workflows/fogstack-manifest-promotion.yml`
- `docs/FOGSTACK_MANIFEST_PROMOTION_POLICY.md`

## Why this PR exists

The previous policy PR (#194) was cut on a stale base. This PR refreshes the same governed-promotion tranche onto current `main` so it can merge cleanly.

This tranche makes manifest promotion:
- policy-aware
- transition-validated
- CI-enforced

## Not in this PR

- human approval workflows
- external signing as a hard requirement for promotion
- registry publication gates

Those remain later steps.
