### PR TITLE
Add Fog Stack manifest promotion approval enforcement

### DIFF
--- a/.github/workflows/fogstack-manifest-promotion.yml
+++ b/.github/workflows/fogstack-manifest-promotion.yml
@@ -9,12 +9,16 @@ on:
       - "catalog/fogstack-support-states-v0.1.yaml"
       - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
       - "releases/manifests/**"
+      - "schemas/release/fogstack-manifest-promotion-approval-record-v0.1.schema.json"
       - "tools/build_fogstack_manifest_publication_set.py"
       - "tools/promote_fogstack_manifest_publication_set.py"
       - "tools/check_fogstack_manifest_promotion_policy.py"
+      - "tools/emit_fogstack_manifest_promotion_approval_record.py"
+      - "tools/check_fogstack_manifest_promotion_approval_record.py"
       - "tools/tests/test_build_fogstack_manifest_publication_set.py"
       - "tools/tests/test_promote_fogstack_manifest_publication_set.py"
       - "tools/tests/test_check_fogstack_manifest_promotion_policy.py"
+      - "tools/tests/test_fogstack_manifest_promotion_approval_record.py"
       - "docs/FOGSTACK_*.md"
       - ".github/workflows/fogstack-manifest-promotion.yml"
   push:
@@ -25,12 +29,16 @@ on:
       - "catalog/fogstack-support-states-v0.1.yaml"
       - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
       - "releases/manifests/**"
+      - "schemas/release/fogstack-manifest-promotion-approval-record-v0.1.schema.json"
       - "tools/build_fogstack_manifest_publication_set.py"
       - "tools/promote_fogstack_manifest_publication_set.py"
       - "tools/check_fogstack_manifest_promotion_policy.py"
+      - "tools/emit_fogstack_manifest_promotion_approval_record.py"
+      - "tools/check_fogstack_manifest_promotion_approval_record.py"
       - "tools/tests/test_build_fogstack_manifest_publication_set.py"
       - "tools/tests/test_promote_fogstack_manifest_publication_set.py"
       - "tools/tests/test_check_fogstack_manifest_promotion_policy.py"
+      - "tools/tests/test_fogstack_manifest_promotion_approval_record.py"
       - "docs/FOGSTACK_*.md"
       - ".github/workflows/fogstack-manifest-promotion.yml"
 
@@ -55,16 +63,17 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest pyyaml
 
-      - name: Run publication and promotion tests
+      - name: Run publication, promotion, policy, and approval tests
         run: |
           python -m pytest -q \
             tools/tests/test_build_fogstack_manifest_publication_set.py \
             tools/tests/test_promote_fogstack_manifest_publication_set.py \
-            tools/tests/test_check_fogstack_manifest_promotion_policy.py
+            tools/tests/test_check_fogstack_manifest_promotion_policy.py \
+            tools/tests/test_fogstack_manifest_promotion_approval_record.py
 
       - name: Build canonical publication set
         run: |
-          mkdir -p artifacts/manifest-promotion/base artifacts/manifest-promotion/promoted
+          mkdir -p artifacts/manifest-promotion/base artifacts/manifest-promotion/promoted artifacts/manifest-promotion/approval
           python3 tools/build_fogstack_manifest_publication_set.py \
             --output-dir artifacts/manifest-promotion/base \
             --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
@@ -85,6 +94,24 @@ jobs:
           python3 tools/check_fogstack_manifest_promotion_policy.py \
             --publication-set artifacts/manifest-promotion/promoted/manifest-publication-set.json \
             --policy-catalog catalog/fogstack-manifest-promotion-policy-v0.1.yaml
+
+      - name: Emit signed promotion approval record
+        run: |
+          python3 tools/emit_fogstack_manifest_promotion_approval_record.py \
+            --promotion-set artifacts/manifest-promotion/promoted/manifest-publication-set.json \
+            --required-approvals 2 \
+            --approval release-manager:release-manager:approved candidate promotion \
+            --approval security-reviewer:security-reviewer:approved release evidence \
+            --signature-type other \
+            --signature-ref artifact://ci/fogstack.manifest-promotion.approval.sig \
+            --output artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.record.json
+
+      - name: Enforce signed promotion approval
+        run: |
+          python3 tools/check_fogstack_manifest_promotion_approval_record.py \
+            --approval-record artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.record.json \
+            --promotion-set artifacts/manifest-promotion/promoted/manifest-publication-set.json \
+            --require-signed
 
       - name: Upload promoted manifest set
         uses: actions/upload-artifact@v4

--- a/.github/workflows/fogstack-manifest-promotion.yml
+++ b/.github/workflows/fogstack-manifest-promotion.yml
@@ -100,8 +100,8 @@ jobs:
           python3 tools/emit_fogstack_manifest_promotion_approval_record.py \
             --promotion-set artifacts/manifest-promotion/promoted/manifest-publication-set.json \
             --required-approvals 2 \
-            --approval release-manager:release-manager:approved candidate promotion \
-            --approval security-reviewer:security-reviewer:approved release evidence \
+            --approval 'release-manager:release-manager:approved candidate promotion' \
+            --approval 'security-reviewer:security-reviewer:approved release evidence' \
             --signature-type other \
             --signature-ref artifact://ci/fogstack.manifest-promotion.approval.sig \
             --output artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.record.json

--- a/docs/FOGSTACK_MANIFEST_PROMOTION_APPROVAL.md
+++ b/docs/FOGSTACK_MANIFEST_PROMOTION_APPROVAL.md
@@ -1,0 +1,43 @@
+# Fog Stack manifest promotion approval
+
+This document defines the repo-native approval surface for Fog Stack manifest promotion.
+
+## Goal
+
+Move from policy-valid promotion to promotion that is also approval-bound, signature-aware, and digest-bound to the promoted manifest publication set.
+
+## Approval record
+
+The approval record schema lives at:
+- `schemas/release/fogstack-manifest-promotion-approval-record-v0.1.schema.json`
+
+The approval record captures:
+- promoted publication-set reference
+- promoted publication-set digest
+- target channel and support state
+- required approval count
+- approver identities and roles
+- signature metadata
+
+## Minimal flow
+
+1. build the canonical publication set
+2. promote it through the manifest promotion helper
+3. check the promotion policy
+4. emit a promotion approval record
+5. check that the approval record is approved, sufficiently approved, signed, and digest-bound to the promoted set
+
+## What this phase provides
+
+- explicit approval record shape
+- approval emitter
+- approval checker
+- CI enforcement that the promoted set has a signed approval record
+
+## What this phase does not yet provide
+
+- external identity-provider backed approver resolution
+- cryptographic verification of the approval signature payload
+- registry publication gates
+
+Those remain later steps.

--- a/schemas/release/fogstack-manifest-promotion-approval-record-v0.1.schema.json
+++ b/schemas/release/fogstack-manifest-promotion-approval-record-v0.1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-manifest-promotion-approval-record-v0.1.schema.json",
+  "title": "FogStackManifestPromotionApprovalRecord",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "promotion_set_ref",
+    "promotion_set_digest",
+    "status",
+    "required_approvals",
+    "approvals",
+    "signed"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackManifestPromotionApprovalRecord" },
+    "schema_version": { "const": "v0.1" },
+    "promotion_set_ref": { "type": "string" },
+    "promotion_set_digest": { "type": "string" },
+    "target_channel": { "type": ["string", "null"] },
+    "target_support_state": { "type": ["string", "null"] },
+    "status": { "enum": ["approved", "rejected", "shape-only"] },
+    "required_approvals": { "type": "integer", "minimum": 1 },
+    "approvals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["approver", "role"],
+        "properties": {
+          "approver": { "type": "string" },
+          "role": { "type": "string" },
+          "statement": { "type": ["string", "null"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "signed": { "type": "boolean" },
+    "signature": {
+      "type": ["object", "null"],
+      "required": ["type", "ref"],
+      "properties": {
+        "type": { "enum": ["cosign", "sigstore", "other"] },
+        "ref": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "notes": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/tools/check_fogstack_manifest_promotion_approval_record.py
+++ b/tools/check_fogstack_manifest_promotion_approval_record.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return "sha256:" + h.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check a Fog Stack manifest promotion approval record")
+    parser.add_argument("--approval-record", required=True, type=Path)
+    parser.add_argument("--promotion-set", required=True, type=Path)
+    parser.add_argument("--require-signed", action="store_true")
+    args = parser.parse_args()
+
+    record = load_json(args.approval_record)
+    errors: list[str] = []
+
+    if record.get("kind") != "FogStackManifestPromotionApprovalRecord":
+        errors.append("approval record kind mismatch")
+    if record.get("status") != "approved":
+        errors.append(f"approval record status is not approved: {record.get('status')!r}")
+
+    expected_digest = sha256_file(args.promotion_set)
+    if record.get("promotion_set_digest") != expected_digest:
+        errors.append("promotion set digest mismatch")
+
+    required = record.get("required_approvals")
+    approvals = record.get("approvals") or []
+    if not isinstance(required, int) or required < 1:
+        errors.append("required_approvals must be a positive integer")
+    if not isinstance(approvals, list) or len(approvals) < (required if isinstance(required, int) else 1):
+        errors.append("insufficient approvals")
+
+    approvers: set[str] = set()
+    for approval in approvals if isinstance(approvals, list) else []:
+        if not isinstance(approval, dict):
+            errors.append("approval entry is not an object")
+            continue
+        approver = approval.get("approver")
+        role = approval.get("role")
+        if not isinstance(approver, str) or not approver.strip():
+            errors.append("approval entry missing approver")
+        if not isinstance(role, str) or not role.strip():
+            errors.append("approval entry missing role")
+        if isinstance(approver, str):
+            if approver in approvers:
+                errors.append(f"duplicate approver: {approver}")
+            approvers.add(approver)
+
+    signed = record.get("signed")
+    signature = record.get("signature")
+    if args.require_signed:
+        if signed is not True:
+            errors.append("approval record is not marked signed")
+        if not isinstance(signature, dict):
+            errors.append("signed approval missing signature object")
+        else:
+            if signature.get("type") not in {"cosign", "sigstore", "other"}:
+                errors.append("invalid signature type")
+            if not isinstance(signature.get("ref"), str) or not signature.get("ref"):
+                errors.append("signature ref missing")
+
+    if errors:
+        for item in errors:
+            print(item)
+        raise SystemExit(1)
+
+    print("FogStack manifest promotion approval record passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/emit_fogstack_manifest_promotion_approval_record.py
+++ b/tools/emit_fogstack_manifest_promotion_approval_record.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return "sha256:" + h.hexdigest()
+
+
+def parse_approval(value: str) -> dict[str, str | None]:
+    parts = value.split(":", 2)
+    if len(parts) < 2:
+        raise SystemExit("ERR: approvals must be approver:role[:statement]")
+    approver, role = parts[0], parts[1]
+    statement = parts[2] if len(parts) == 3 else None
+    return {"approver": approver, "role": role, "statement": statement}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a Fog Stack manifest promotion approval record")
+    parser.add_argument("--promotion-set", required=True, type=Path)
+    parser.add_argument("--required-approvals", required=True, type=int)
+    parser.add_argument("--approval", action="append", required=True, help="approver:role[:statement]")
+    parser.add_argument("--status", default="approved", choices=["approved", "rejected", "shape-only"])
+    parser.add_argument("--signature-type", choices=["cosign", "sigstore", "other"], default=None)
+    parser.add_argument("--signature-ref", default=None)
+    parser.add_argument("--notes", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    promotion = load_json(args.promotion_set)
+    promotion_meta = promotion.get("promotion") or {}
+
+    signature = None
+    signed = False
+    if args.signature_type or args.signature_ref:
+        if not args.signature_type or not args.signature_ref:
+            raise SystemExit("ERR: both --signature-type and --signature-ref are required for signed approvals")
+        signature = {"type": args.signature_type, "ref": args.signature_ref}
+        signed = True
+
+    record = {
+        "kind": "FogStackManifestPromotionApprovalRecord",
+        "schema_version": "v0.1",
+        "promotion_set_ref": str(args.promotion_set),
+        "promotion_set_digest": sha256_file(args.promotion_set),
+        "target_channel": promotion_meta.get("channel"),
+        "target_support_state": promotion_meta.get("support_state"),
+        "status": args.status,
+        "required_approvals": args.required_approvals,
+        "approvals": [parse_approval(item) for item in args.approval],
+        "signed": signed,
+        "signature": signature,
+        "notes": args.notes,
+    }
+
+    text = json.dumps(record, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_manifest_promotion_approval_record.py
+++ b/tools/tests/test_fogstack_manifest_promotion_approval_record.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + '\n', encoding='utf-8')
+
+
+def test_emit_and_check_signed_promotion_approval_record(tmp_path: Path) -> None:
+    promotion_set = tmp_path / 'manifest-publication-set.json'
+    _write_json(promotion_set, {
+        'kind': 'FogStackManifestPublicationSet',
+        'schema_version': 'v0.1',
+        'promotion': {'channel': 'candidate', 'support_state': 'supported'},
+        'manifests': [],
+    })
+
+    approval = tmp_path / 'approval.record.json'
+    subprocess.run([
+        sys.executable,
+        'tools/emit_fogstack_manifest_promotion_approval_record.py',
+        '--promotion-set', str(promotion_set),
+        '--required-approvals', '2',
+        '--approval', 'alice:release-manager:approved candidate promotion',
+        '--approval', 'bob:security-reviewer:approved release evidence',
+        '--signature-type', 'other',
+        '--signature-ref', 'artifact://release/fogstack.promotion.approval.sig',
+        '--output', str(approval),
+    ], check=True)
+
+    record = json.loads(approval.read_text(encoding='utf-8'))
+    assert record['kind'] == 'FogStackManifestPromotionApprovalRecord'
+    assert record['status'] == 'approved'
+    assert record['signed'] is True
+    assert len(record['approvals']) == 2
+    assert record['target_channel'] == 'candidate'
+    assert record['target_support_state'] == 'supported'
+
+    subprocess.run([
+        sys.executable,
+        'tools/check_fogstack_manifest_promotion_approval_record.py',
+        '--approval-record', str(approval),
+        '--promotion-set', str(promotion_set),
+        '--require-signed',
+    ], check=True)
+
+
+def test_check_promotion_approval_record_rejects_unsigned_when_required(tmp_path: Path) -> None:
+    promotion_set = tmp_path / 'manifest-publication-set.json'
+    _write_json(promotion_set, {
+        'kind': 'FogStackManifestPublicationSet',
+        'schema_version': 'v0.1',
+        'promotion': {'channel': 'candidate', 'support_state': 'supported'},
+        'manifests': [],
+    })
+
+    approval = tmp_path / 'approval.record.json'
+    subprocess.run([
+        sys.executable,
+        'tools/emit_fogstack_manifest_promotion_approval_record.py',
+        '--promotion-set', str(promotion_set),
+        '--required-approvals', '1',
+        '--approval', 'alice:release-manager:approved',
+        '--output', str(approval),
+    ], check=True)
+
+    proc = subprocess.run([
+        sys.executable,
+        'tools/check_fogstack_manifest_promotion_approval_record.py',
+        '--approval-record', str(approval),
+        '--promotion-set', str(promotion_set),
+        '--require-signed',
+    ])
+    assert proc.returncode != 0
+
+
+def test_check_promotion_approval_record_rejects_digest_mismatch(tmp_path: Path) -> None:
+    promotion_set = tmp_path / 'manifest-publication-set.json'
+    _write_json(promotion_set, {
+        'kind': 'FogStackManifestPublicationSet',
+        'schema_version': 'v0.1',
+        'promotion': {'channel': 'candidate', 'support_state': 'supported'},
+        'manifests': [],
+    })
+
+    approval = tmp_path / 'approval.record.json'
+    subprocess.run([
+        sys.executable,
+        'tools/emit_fogstack_manifest_promotion_approval_record.py',
+        '--promotion-set', str(promotion_set),
+        '--required-approvals', '1',
+        '--approval', 'alice:release-manager:approved',
+        '--signature-type', 'other',
+        '--signature-ref', 'artifact://release/fogstack.promotion.approval.sig',
+        '--output', str(approval),
+    ], check=True)
+
+    _write_json(promotion_set, {
+        'kind': 'FogStackManifestPublicationSet',
+        'schema_version': 'v0.1',
+        'promotion': {'channel': 'stable', 'support_state': 'supported'},
+        'manifests': [],
+    })
+
+    proc = subprocess.run([
+        sys.executable,
+        'tools/check_fogstack_manifest_promotion_approval_record.py',
+        '--approval-record', str(approval),
+        '--promotion-set', str(promotion_set),
+        '--require-signed',
+    ])
+    assert proc.returncode != 0


### PR DESCRIPTION
## Summary

This PR adds the next release-governance tranche directly on top of current `main`:

- `schemas/release/fogstack-manifest-promotion-approval-record-v0.1.schema.json`
- `tools/emit_fogstack_manifest_promotion_approval_record.py`
- `tools/check_fogstack_manifest_promotion_approval_record.py`
- `tools/tests/test_fogstack_manifest_promotion_approval_record.py`
- updated `.github/workflows/fogstack-manifest-promotion.yml`
- `docs/FOGSTACK_MANIFEST_PROMOTION_APPROVAL.md`

## Why this PR exists

The repo now has policy-enforced promotion, but promotion still needs an explicit approval artifact that is digest-bound to the promoted manifest set and signature-aware.

This PR adds:
- approval record schema
- approval record emitter
- approval record checker
- CI enforcement that the promoted set has a signed approval record
- documentation for the approval surface

## Not in this PR

- external identity-provider backed approver resolution
- cryptographic verification of the approval signature payload
- registry publication gates

Those remain later steps.
