### PR TITLE
SourceOS: add control-plane contracts v0

### DIFF
--- a/.github/workflows/sourceos-contracts.yml
+++ b/.github/workflows/sourceos-contracts.yml
@@ -1,0 +1,30 @@
+name: SourceOS contracts
+
+on:
+  pull_request:
+    paths:
+      - "contracts/sourceos/**"
+      - "docs/SOURCEOS_*.md"
+      - "tools/validate_sourceos_contracts.py"
+      - ".github/workflows/sourceos-contracts.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "contracts/sourceos/**"
+      - "docs/SOURCEOS_*.md"
+      - "tools/validate_sourceos_contracts.py"
+      - ".github/workflows/sourceos-contracts.yml"
+
+jobs:
+  validate-sourceos-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validation dependency
+        run: python -m pip install jsonschema
+      - name: Validate SourceOS contracts
+        run: python tools/validate_sourceos_contracts.py

--- a/contracts/sourceos/boot-release-set.v0.schema.json
+++ b/contracts/sourceos/boot-release-set.v0.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/sourceos/boot-release-set.v0.schema.json",
+  "title": "SourceOS BootReleaseSet v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "id",
+    "created_at",
+    "channel",
+    "boot_modes",
+    "platform_entrypoints",
+    "artifacts",
+    "authorization",
+    "proof_requirements",
+    "signatures"
+  ],
+  "properties": {
+    "schema_version": { "const": "sourceos.boot-release-set/v0" },
+    "kind": { "const": "SourceOSBootReleaseSet" },
+    "id": { "type": "string", "pattern": "^sbrs-[a-z0-9][a-z0-9._-]{5,127}$" },
+    "description": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "channel": { "type": "string", "enum": ["dev", "candidate", "stable", "extended", "deprecated"] },
+    "parent_release_set_ref": { "type": "string" },
+    "boot_modes": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "enum": ["live", "installer", "rescue", "rollback", "recovery"] }
+    },
+    "platform_entrypoints": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["platform", "entry_kind", "entry_ref"],
+        "properties": {
+          "platform": { "type": "string", "enum": ["apple_silicon", "uefi", "bios", "vm", "generic"] },
+          "entry_kind": { "type": "string", "enum": ["asahi_installer_entry", "apple_boot_picker_os", "ipxe", "uefi_httpboot", "iso", "disk_image", "vm_image"] },
+          "entry_ref": { "type": "string", "minLength": 1 },
+          "notes": { "type": "string" }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "artifact_kind", "uri", "digest"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "artifact_kind": { "type": "string", "enum": ["kernel", "initrd", "rootfs", "installer_tree", "boot_script", "manifest", "recovery_userland", "other"] },
+          "uri": { "type": "string", "minLength": 1 },
+          "digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+          "size_bytes": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "authorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "token_binding", "ttl_seconds"],
+      "properties": {
+        "mode": { "type": "string", "enum": ["none", "single_use_code", "device_claim", "mtls", "signed_offline_blob"] },
+        "token_binding": { "type": "string", "enum": ["none", "device_claim", "device_identity", "user_session", "org_policy"] },
+        "ttl_seconds": { "type": "integer", "minimum": 0 },
+        "requires_online_redemption": { "type": "boolean" }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "disk_write": { "type": "string", "enum": ["denied", "scoped", "full"] },
+        "network": { "type": "string", "enum": ["none", "restricted", "full"] },
+        "kexec": { "type": "string", "enum": ["denied", "allowed"] },
+        "rollback": { "type": "string", "enum": ["denied", "allowed"] },
+        "enrollment": { "type": "string", "enum": ["denied", "allowed"] }
+      }
+    },
+    "proof_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["emit_fingerprint", "emit_manifest_hashes", "emit_boot_log_ref"],
+      "properties": {
+        "emit_fingerprint": { "type": "boolean" },
+        "emit_manifest_hashes": { "type": "boolean" },
+        "emit_boot_log_ref": { "type": "boolean" },
+        "required_report_endpoint": { "type": "string" }
+      }
+    },
+    "offline_fallback": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allowed": { "type": "boolean" },
+        "last_known_good_ref": { "type": "string" },
+        "max_age_seconds": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "signatures": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key_id", "algorithm", "signature_ref"],
+        "properties": {
+          "key_id": { "type": "string", "minLength": 1 },
+          "algorithm": { "type": "string", "enum": ["ed25519", "sigstore", "gpg", "x509"] },
+          "signature_ref": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/contracts/sourceos/config-source.v0.schema.json
+++ b/contracts/sourceos/config-source.v0.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/sourceos/config-source.v0.schema.json",
+  "title": "SourceOS ConfigSource v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "id",
+    "source_type",
+    "location",
+    "nix",
+    "refs",
+    "update_policy",
+    "token_policy"
+  ],
+  "properties": {
+    "schema_version": { "const": "sourceos.config-source/v0" },
+    "kind": { "const": "SourceOSConfigSource" },
+    "id": { "type": "string", "pattern": "^scfg-[a-z0-9][a-z0-9._-]{5,127}$" },
+    "source_type": { "type": "string", "enum": ["git", "local_path", "archive", "catalog"] },
+    "location": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["canonical_ref"],
+      "properties": {
+        "canonical_ref": { "type": "string", "minLength": 1 },
+        "local_path": { "type": "string" },
+        "remote_url": { "type": "string" },
+        "mirror_url": { "type": "string" }
+      }
+    },
+    "nix": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["entry_kind", "entry_ref"],
+      "properties": {
+        "entry_kind": { "type": "string", "enum": ["flake", "pinned_nixpkgs", "none"] },
+        "entry_ref": { "type": "string", "minLength": 1 },
+        "lock_ref": { "type": "string" },
+        "outputs": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+      }
+    },
+    "refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["allowed_refs", "stable_ref"],
+      "properties": {
+        "allowed_refs": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "stable_ref": { "type": "string" },
+        "branch_channel_map": {
+          "type": "object",
+          "additionalProperties": { "type": "string", "enum": ["dev", "candidate", "stable", "extended", "deprecated"] }
+        }
+      }
+    },
+    "update_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "requires_signature_verification", "build_trigger"],
+      "properties": {
+        "mode": { "type": "string", "enum": ["manual", "pull", "pr", "push"] },
+        "requires_signature_verification": { "type": "boolean" },
+        "required_status_checks": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "build_trigger": { "type": "string", "enum": ["manual", "on_ref_change", "on_tag", "scheduled"] }
+      }
+    },
+    "token_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["token_ref", "token_kind", "storage_rule"],
+      "properties": {
+        "token_ref": { "type": "string", "minLength": 1 },
+        "token_kind": { "type": "string", "enum": ["none", "read", "issue", "write_ref", "ephemeral_session"] },
+        "storage_rule": { "type": "string", "enum": ["secret_door", "device_keychain", "org_secret_store", "not_applicable"] },
+        "redaction_required": { "type": "boolean" },
+        "allowed_ref_writes": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+      }
+    },
+    "cache_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "local_cache": { "type": "boolean" },
+        "remote_cache": { "type": "boolean" },
+        "trusted_cache_keys": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+      }
+    }
+  }
+}

--- a/contracts/sourceos/examples/boot-release-set.m2-demo.v0.json
+++ b/contracts/sourceos/examples/boot-release-set.m2-demo.v0.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "sourceos.boot-release-set/v0",
+  "kind": "SourceOSBootReleaseSet",
+  "id": "sbrs-m2-demo-recovery-0001",
+  "description": "M2 demo SourceOS recovery/install/live boot release set.",
+  "created_at": "2026-04-26T15:00:00Z",
+  "channel": "dev",
+  "parent_release_set_ref": "srset-m2-demo-0001",
+  "boot_modes": ["live", "installer", "recovery", "rollback"],
+  "platform_entrypoints": [
+    {
+      "platform": "apple_silicon",
+      "entry_kind": "asahi_installer_entry",
+      "entry_ref": "installer-tree:sourceos/m2/recovery/0001",
+      "notes": "Expected to be packaged as a boot-picker-visible installer/recovery entry via the Apple Silicon/Asahi-compatible path."
+    },
+    {
+      "platform": "uefi",
+      "entry_kind": "ipxe",
+      "entry_ref": "ipxe:sourceos/recovery/0001",
+      "notes": "Generic parity path for later PC/Purism support."
+    }
+  ],
+  "artifacts": [
+    {
+      "name": "sourceos-recovery-kernel",
+      "artifact_kind": "kernel",
+      "uri": "artifact:sourceos/m2/recovery/kernel/0001",
+      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "size_bytes": 0
+    },
+    {
+      "name": "sourceos-recovery-initrd",
+      "artifact_kind": "initrd",
+      "uri": "artifact:sourceos/m2/recovery/initrd/0001",
+      "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "size_bytes": 0
+    },
+    {
+      "name": "sourceos-recovery-manifest",
+      "artifact_kind": "manifest",
+      "uri": "artifact:sourceos/m2/recovery/manifest/0001",
+      "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "size_bytes": 0
+    }
+  ],
+  "authorization": {
+    "mode": "single_use_code",
+    "token_binding": "device_claim",
+    "ttl_seconds": 900,
+    "requires_online_redemption": true
+  },
+  "capabilities": {
+    "disk_write": "scoped",
+    "network": "restricted",
+    "kexec": "allowed",
+    "rollback": "allowed",
+    "enrollment": "allowed"
+  },
+  "proof_requirements": {
+    "emit_fingerprint": true,
+    "emit_manifest_hashes": true,
+    "emit_boot_log_ref": true,
+    "required_report_endpoint": "tritrpc:sourceos.boot.proof.report"
+  },
+  "offline_fallback": {
+    "allowed": true,
+    "last_known_good_ref": "sbrs-m2-demo-recovery-0000",
+    "max_age_seconds": 604800
+  },
+  "signatures": [
+    {
+      "key_id": "sourceos-demo-signing-key-v0",
+      "algorithm": "ed25519",
+      "signature_ref": "sig:sourceos-m2-demo-recovery-0001"
+    }
+  ]
+}

--- a/contracts/sourceos/examples/release-set.m2-demo.v0.json
+++ b/contracts/sourceos/examples/release-set.m2-demo.v0.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "sourceos.release-set/v0",
+  "kind": "SourceOSReleaseSet",
+  "id": "srset-m2-demo-0001",
+  "description": "M2 demo release set for SourceOS system/user/agent lifecycle proof.",
+  "created_at": "2026-04-26T15:00:00Z",
+  "channel": "dev",
+  "support_state": "experimental",
+  "system": {
+    "base_kind": "ostree",
+    "base_ref": "ostree:sourceos/m2/silverblue-gnome/dev/0001",
+    "architecture": "aarch64",
+    "platform_targets": ["apple_silicon_m2"],
+    "host_integration_surface": "hisc-sourceos-m2-v0",
+    "rollback_refs": ["ostree:sourceos/m2/silverblue-gnome/dev/0000"]
+  },
+  "user": {
+    "experience_profile": "xp-macos-like-gnome-v0",
+    "ux_archetype": "macos_like",
+    "desktop": "gnome",
+    "closure_refs": ["nix:closure:user/macos-like-gnome/0001"],
+    "degraded_parity_notes": []
+  },
+  "agent": {
+    "default_isolation": "container",
+    "environment_refs": ["nix:closure:agent/base-tools/0001"],
+    "capability_policy_ref": "policy:sourceos-agent-standard-v0",
+    "risk_policy_ref": "policy:sourceos-risk-isolation-v0"
+  },
+  "policy": {
+    "policy_bundle_ref": "policy:sourceos-m2-demo-v0",
+    "crypto_profile": "standard",
+    "required_signatures": 1
+  },
+  "assignment": {
+    "scope_kind": "device",
+    "scope_id": "device:m2-demo"
+  },
+  "provenance": {
+    "config_sources": ["scfg-m2-demo-local"],
+    "bom_ref": "bom:sourceos-m2-demo-0001",
+    "build_ref": "build:sourceos-m2-demo-0001",
+    "sbom_refs": ["sbom:sourceos-m2-demo-0001"],
+    "evidence_refs": ["evidence:sourceos-m2-demo-build-0001"]
+  },
+  "signatures": [
+    {
+      "key_id": "sourceos-demo-signing-key-v0",
+      "algorithm": "ed25519",
+      "signature_ref": "sig:sourceos-m2-demo-0001"
+    }
+  ]
+}

--- a/contracts/sourceos/fingerprint.v0.schema.json
+++ b/contracts/sourceos/fingerprint.v0.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/sourceos/fingerprint.v0.schema.json",
+  "title": "SourceOS Fingerprint v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "id",
+    "observed_at",
+    "subject",
+    "system",
+    "runtime",
+    "policy",
+    "provenance"
+  ],
+  "properties": {
+    "schema_version": { "const": "sourceos.fingerprint/v0" },
+    "kind": { "const": "SourceOSFingerprint" },
+    "id": { "type": "string", "pattern": "^sfp-[a-z0-9][a-z0-9._-]{5,127}$" },
+    "observed_at": { "type": "string", "format": "date-time" },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subject_kind", "subject_id"],
+      "properties": {
+        "subject_kind": { "type": "string", "enum": ["device", "user_workspace", "agent_workspace", "boot_environment"] },
+        "subject_id": { "type": "string", "minLength": 1 },
+        "device_claim": { "type": "string" }
+      }
+    },
+    "system": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["architecture", "kernel", "boot_mode"],
+      "properties": {
+        "architecture": { "type": "string" },
+        "kernel": { "type": "string" },
+        "boot_mode": { "type": "string", "enum": ["normal", "live", "installer", "rescue", "rollback", "recovery", "unknown"] },
+        "system_base_ref": { "type": "string" },
+        "rollback_available": { "type": "boolean" }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["isolation", "libc", "shell", "tool_dialect"],
+      "properties": {
+        "isolation": { "type": "string", "enum": ["host", "container", "vm", "layered", "microvm_mesh", "boot_env", "unknown"] },
+        "libc": { "type": "string", "enum": ["glibc", "musl", "bionic", "unknown", "not_applicable"] },
+        "shell": { "type": "string" },
+        "tool_dialect": { "type": "string", "enum": ["gnu", "busybox", "bsd", "mixed", "unknown"] },
+        "pid1": { "type": "string" },
+        "container_runtime": { "type": "string" },
+        "hypervisor": { "type": "string" }
+      }
+    },
+    "lsm": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "selinux_visible": { "type": "boolean" },
+        "selinux_mode": { "type": "string", "enum": ["enforcing", "permissive", "disabled", "not_visible", "unknown"] },
+        "apparmor_visible": { "type": "boolean" },
+        "landlock_visible": { "type": "boolean" },
+        "host_enforced_possible": { "type": "boolean" }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_bundle_ref", "release_set_ref"],
+      "properties": {
+        "policy_bundle_ref": { "type": "string" },
+        "release_set_ref": { "type": "string" },
+        "boot_release_set_ref": { "type": "string" },
+        "capability_manifest_ref": { "type": "string" },
+        "network_scope": { "type": "string", "enum": ["none", "restricted", "full", "unknown"] },
+        "filesystem_scope": { "type": "string", "enum": ["none", "portal_only", "scoped", "full", "unknown"] }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_refs"],
+      "properties": {
+        "config_source_refs": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "closure_refs": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "artifact_digests": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "evidence_refs": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+      }
+    },
+    "compliance": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "status": { "type": "string", "enum": ["unknown", "compliant", "noncompliant", "degraded"] },
+        "reasons": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/contracts/sourceos/release-set.v0.schema.json
+++ b/contracts/sourceos/release-set.v0.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/sourceos/release-set.v0.schema.json",
+  "title": "SourceOS ReleaseSet v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "kind",
+    "id",
+    "created_at",
+    "channel",
+    "support_state",
+    "system",
+    "user",
+    "agent",
+    "policy",
+    "provenance",
+    "signatures"
+  ],
+  "properties": {
+    "schema_version": { "const": "sourceos.release-set/v0" },
+    "kind": { "const": "SourceOSReleaseSet" },
+    "id": { "type": "string", "pattern": "^srset-[a-z0-9][a-z0-9._-]{5,127}$" },
+    "description": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "channel": { "type": "string", "enum": ["dev", "candidate", "stable", "extended", "deprecated"] },
+    "support_state": { "type": "string", "enum": ["experimental", "community", "supported", "extended", "deprecated"] },
+    "system": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["base_kind", "base_ref", "architecture", "rollback_refs"],
+      "properties": {
+        "base_kind": { "type": "string", "enum": ["ostree", "rpm-ostree", "bootc", "nixos-generation", "external"] },
+        "base_ref": { "type": "string", "minLength": 1 },
+        "architecture": { "type": "string", "enum": ["aarch64", "x86_64", "multi"] },
+        "platform_targets": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "host_integration_surface": { "type": "string" },
+        "rollback_refs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "user": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["experience_profile", "closure_refs"],
+      "properties": {
+        "experience_profile": { "type": "string", "minLength": 1 },
+        "ux_archetype": { "type": "string", "enum": ["macos_like", "windows_like", "linux_native", "minimal", "custom"] },
+        "desktop": { "type": "string", "enum": ["gnome", "kde", "sway", "hyprland", "none", "custom"] },
+        "closure_refs": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "degraded_parity_notes": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["default_isolation", "environment_refs", "capability_policy_ref"],
+      "properties": {
+        "default_isolation": { "type": "string", "enum": ["container", "vm", "layered", "microvm_mesh", "none"] },
+        "environment_refs": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "capability_policy_ref": { "type": "string", "minLength": 1 },
+        "risk_policy_ref": { "type": "string" }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["policy_bundle_ref", "crypto_profile"],
+      "properties": {
+        "policy_bundle_ref": { "type": "string", "minLength": 1 },
+        "crypto_profile": { "type": "string", "enum": ["standard", "fips140_3_mode"] },
+        "required_signatures": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "assignment": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scope_kind": { "type": "string", "enum": ["device", "user", "group", "project", "organization", "fleet"] },
+        "scope_id": { "type": "string" }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["config_sources", "bom_ref", "build_ref"],
+      "properties": {
+        "config_sources": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "bom_ref": { "type": "string", "minLength": 1 },
+        "build_ref": { "type": "string", "minLength": 1 },
+        "sbom_refs": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "evidence_refs": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+      }
+    },
+    "signatures": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key_id", "algorithm", "signature_ref"],
+        "properties": {
+          "key_id": { "type": "string", "minLength": 1 },
+          "algorithm": { "type": "string", "enum": ["ed25519", "sigstore", "gpg", "x509"] },
+          "signature_ref": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/docs/SOURCEOS_BOOT_PROVISIONING_PROTOCOL.md
+++ b/docs/SOURCEOS_BOOT_PROVISIONING_PROTOCOL.md
@@ -1,0 +1,189 @@
+# SourceOS boot provisioning protocol v0
+
+This protocol defines how SourceOS serves secure live, installer, rescue, rollback, and recovery environments from the control plane.
+
+It is intentionally compatible with two implementation families:
+
+- Apple Silicon boot-picker / Asahi-style installer entry flows.
+- Generic PC/Purism/UEFI flows using iPXE, HTTPBoot, ISO, disk-image, or nlboot-style bootstrap media.
+
+## Design position
+
+Classic PXE semantics are not assumed globally. SourceOS defines PXE-like semantics:
+
+1. a minimal boot substrate starts first,
+2. it proves or claims device identity,
+3. it fetches signed boot instructions,
+4. it verifies boot artifacts,
+5. it boots, installs, repairs, or rolls back,
+6. it reports proof artifacts.
+
+On Apple Silicon, this maps to boot-picker-visible normal and recovery/installer entries. On PC-class systems, this can map to iPXE/UEFI HTTPBoot or a small persistent nlboot-like medium.
+
+## Actors
+
+### Boot environment
+
+A minimal environment that can:
+
+- collect device claim data,
+- acquire restricted network access,
+- redeem an authorization token when required,
+- fetch a BootReleaseSet,
+- verify signatures and artifact digests,
+- boot/kexec/install/repair/rollback according to policy,
+- emit a Fingerprint and boot log reference.
+
+### Control plane
+
+The web/API management surface that:
+
+- registers devices,
+- creates or assigns ReleaseSets and BootReleaseSets,
+- issues single-use enrollment or boot codes,
+- binds codes to device claims,
+- serves signed manifests and artifacts,
+- records proofs and compliance status.
+
+### Sociosphere
+
+The workspace controller and governance plane that should observe SourceOS lifecycle artifacts and evidence. Sociosphere is not the boot server in v0, but it must be able to register and validate SourceOS composition/evidence objects.
+
+## Boot-time authorization flow
+
+1. Boot environment starts.
+2. Boot environment generates or reads a device claim.
+3. User enters a one-time code, or the environment presents mTLS/device credentials.
+4. Control plane verifies:
+   - code validity,
+   - TTL,
+   - one-time-use status,
+   - device claim binding,
+   - assigned ReleaseSet/BootReleaseSet,
+   - policy compatibility.
+5. Control plane returns a signed BootReleaseSet manifest or a pointer to one.
+6. Boot environment downloads artifacts.
+7. Boot environment verifies all artifact digests and manifest signatures.
+8. Boot environment executes the authorized mode: live, installer, rescue, rollback, or recovery.
+9. Boot environment emits proof artifacts.
+10. Control plane evaluates compliance.
+
+## Authorization modes
+
+### none
+
+Allowed only for public demo artifacts that do not write disks, do not enroll devices, and do not expose secrets.
+
+### single_use_code
+
+Preferred Release-1 enrollment mode. The code must be:
+
+- time-bound,
+- one-time-use,
+- bound to a device claim at redemption,
+- bound to an authorized BootReleaseSet or ReleaseSet.
+
+### device_claim
+
+Used after a device is enrolled. The boot environment presents a device identity key or claim and receives only assignments authorized for that device.
+
+### mtls
+
+Optional stronger channel for later fleet operation.
+
+### signed_offline_blob
+
+Used when online redemption is unavailable. The blob must still encode expiration, assignment, and signature metadata.
+
+## Capability modes
+
+A BootReleaseSet must declare what the boot environment is allowed to do.
+
+### live
+
+- Disk write: denied by default.
+- Network: restricted by default.
+- kexec: optional.
+- Enrollment: optional.
+
+### installer
+
+- Disk write: scoped.
+- Network: restricted.
+- kexec/install: allowed.
+- Enrollment: allowed when policy permits.
+
+### recovery
+
+- Disk write: scoped.
+- Rollback: allowed.
+- Repair user/agent closures: allowed.
+- Re-enrollment/key rotation: allowed when policy permits.
+
+### rollback
+
+- Disk write: scoped to rollback target.
+- Network: optional.
+- Required output: post-rollback Fingerprint.
+
+## Apple Silicon mapping
+
+Apple Silicon does not provide generic firmware PXE semantics. SourceOS should expose normal and recovery/installer entries as boot-picker-visible operating system or installer entries via the Apple Silicon/Asahi-compatible path.
+
+The SourceOS recovery entry should behave like a recovery environment within Linux-managed constraints:
+
+- fetch assigned BootReleaseSets,
+- repair/re-pin Nix closures,
+- rebase or roll back the system base,
+- rotate device keys or re-enroll,
+- emit proof artifacts.
+
+The contract target is capability parity with recovery-style workflows, not literal execution inside Apple 1TR recoveryOS.
+
+## nlboot mapping
+
+The nlboot shape is retained as a useful implementation primitive:
+
+- minimal boot environment,
+- announce endpoint,
+- server-directed boot instructions,
+- optional claim code/client certificate,
+- kexec into target system,
+- offline fallback.
+
+SourceOS changes the payload semantics:
+
+- boot instructions become a signed BootReleaseSet manifest,
+- hashes are SHA-256 minimum,
+- disk-write/kexec/rollback are policy-gated,
+- proof reporting is mandatory for managed flows,
+- last-known-good fallback is represented as a signed offline fallback reference.
+
+## Required proof artifacts
+
+Every managed boot operation must emit:
+
+- boot environment Fingerprint,
+- manifest digest list,
+- applied ReleaseSet or BootReleaseSet id,
+- boot/provisioning log reference,
+- compliance result or failure evidence.
+
+## Non-goals for v0
+
+- No global cloud mesh implementation.
+- No federated learning lifecycle.
+- No guarantee of hardware remote attestation.
+- No claim that SourceOS can run arbitrary code inside Apple-signed recoveryOS.
+
+## Acceptance criteria
+
+A v0 boot proof passes when a test device can:
+
+1. boot into a minimal SourceOS recovery/provisioning environment,
+2. redeem or present authorization,
+3. fetch a signed BootReleaseSet,
+4. verify artifact digests,
+5. perform live/install/recovery/rollback behavior according to policy,
+6. emit a valid Fingerprint,
+7. appear as compliant or noncompliant in the control plane.

--- a/docs/SOURCEOS_CONTROL_PLANE_CONTRACTS.md
+++ b/docs/SOURCEOS_CONTROL_PLANE_CONTRACTS.md
@@ -1,0 +1,132 @@
+# SourceOS control plane contracts v0
+
+This document defines the first platform-native SourceOS control plane contract set for `prophet-platform`.
+
+SourceOS is not treated here as a standalone distro. It is treated as an opt-in agentic operating and fleet lifecycle system that composes:
+
+- an immutable OSTree/Silverblue/CoreOS-style system plane,
+- a Nix-managed lifecycle and policy plane,
+- separated user and agent spaces,
+- risk-proportional isolation for agent work,
+- signed release, boot, and proof artifacts,
+- local-first operation that can later replicate into local mesh, cloud twin, and cloud mesh topologies.
+
+## Contract goals
+
+The contracts in `contracts/sourceos/` make the SourceOS control plane machine-addressable instead of narrative-only. They are intentionally minimal but strict enough to support a demo and later fleet expansion.
+
+Current contracts:
+
+- `release-set.v0.schema.json` — normal lifecycle release object for system, user, agent, policy, provenance, and assignment metadata.
+- `boot-release-set.v0.schema.json` — bootable release object for live, installer, rescue, rollback, and recovery environments.
+- `fingerprint.v0.schema.json` — observed runtime/device/workspace report emitted by systems and agent spaces.
+- `config-source.v0.schema.json` — Git/Nix source channel object for local-first declarative lifecycle management.
+
+## Planes
+
+### System plane
+
+The system plane is an immutable, rollbackable host substrate. It accepts only policy-approved system base references and boot integration metadata. It must not become the place where desktop preferences, toolchains, browsers, or agent experiments accumulate.
+
+Required outputs:
+
+- booted system base identifier,
+- verification status,
+- rollback candidates,
+- host integration surface version,
+- fingerprint emission.
+
+### Lifecycle plane
+
+The lifecycle plane resolves declarative inputs into signed release outputs. For SourceOS v0, Nix and Git are first-class lifecycle primitives, not ad-hoc package managers.
+
+Required outputs:
+
+- resolved bill of materials,
+- Nix closure references for user and agent spaces,
+- policy bundle references,
+- release signatures,
+- provenance records.
+
+### User plane
+
+The user plane contains selectable experience profiles: macOS-like GNOME, Windows-like KDE, Linux-native, tiling, accessibility, development, and other user-facing choices. These choices compile into profile references and closures; they do not mutate the system plane directly.
+
+Required outputs:
+
+- selected experience profile,
+- closure references,
+- host integration requirements,
+- compatibility/degraded-parity notes when relevant.
+
+### Agent plane
+
+The agent plane contains tools, runtimes, models, evaluation harnesses, workspace bundles, and isolation choices. Policy may upgrade the selected isolation level when task, data, or tool risk requires it.
+
+Required outputs:
+
+- agent environment closure references,
+- isolation profile,
+- capability manifest,
+- evidence/proof references,
+- fingerprint emission.
+
+## Object model
+
+### ReleaseSet
+
+A ReleaseSet is the normal deployment object. It references the system base, user experience closures, agent environment closures, policy bundle, provenance, and assignment scope. It is signed and immutable once promoted.
+
+### BootReleaseSet
+
+A BootReleaseSet is a bootable ReleaseSet derivative. It is used for secure live boot, install, rescue, recovery, rollback, and Apple Silicon boot-picker/recovery-like flows. It can be produced from the same Git/Nix source graph as normal releases.
+
+### Fingerprint
+
+A Fingerprint is observed fact, not desired state. It reports what the device/workspace actually booted or ran: system base, runtime dialect, libc, shell, LSM visibility, isolation mode, active policy, release identifiers, and proof references.
+
+### ConfigSource
+
+A ConfigSource binds a local or remote Git source into the lifecycle plane. It specifies refs, update mode, token reference, flake entrypoint, branch-to-channel mapping, cache policy, and signature requirements.
+
+## Identity and registration
+
+Devices self-register as a primitive. A device generates a keypair locally and presents a device claim. The control plane binds that claim to a user, group, project, or organization only after explicit opt-in enrollment.
+
+Release-1 does not require full cloud mesh. The model is designed so local-host state can later replicate through:
+
+`local host -> local mesh -> cloud twin -> cloud mesh`
+
+without changing the contract objects.
+
+## Security invariants
+
+- Reasoning is not execution.
+- Execution is capability-mediated.
+- System space is immutable and rollbackable.
+- User and agent spaces are separated by design.
+- Agent isolation is risk-proportional.
+- Tokens are references to secret-door entries, never embedded in Git, Nix stores, logs, or manifests.
+- BootReleaseSets and ReleaseSets require integrity metadata and signatures before promotion.
+- Fingerprints report observed state and must not be treated as policy declarations.
+
+## Demo objective
+
+The v0 demo objective is lifecycle proof on one Mac M2 device with the SourceOS control plane served through the project site:
+
+1. Device self-registers.
+2. A ConfigSource is bound.
+3. A ReleaseSet is built from a Git/Nix source.
+4. A BootReleaseSet is generated or selected for recovery/install/live path.
+5. The device applies the release.
+6. The device emits a Fingerprint.
+7. The control plane marks the device compliant or noncompliant.
+8. Rollback remains available.
+
+## Relationship to nlboot
+
+`SociOS-Linux/nlboot` remains an external evolving boot dependency. SourceOS keeps the nlboot shape where useful: a minimal boot environment announces itself, receives boot instructions, verifies artifacts, and kexecs or installs. The SourceOS upgrade is that the response becomes a signed BootReleaseSet object graph with policy and proof obligations.
+
+## Relationship to Sociosphere
+
+Sociosphere must be aware of SourceOS release, boot, and lifecycle artifacts. This contract set is written so Sociosphere can validate composition, governance, evidence, and workspace registration without owning the boot implementation itself.

--- a/docs/SOURCEOS_LIFECYCLE_STATE_MACHINE.md
+++ b/docs/SOURCEOS_LIFECYCLE_STATE_MACHINE.md
@@ -1,0 +1,224 @@
+# SourceOS lifecycle state machine v0
+
+This document defines the minimum lifecycle state machine needed to prove SourceOS control-plane behavior on a single Mac M2 demo device while preserving the same object model for later fleet, mesh, and cloud-twin expansion.
+
+## Scope
+
+This state machine governs SourceOS control-plane artifacts only. It does not implement federated learning, cloud mesh replication, or global fleet orchestration in v0. It defines the proof-bearing lifecycle that those systems can later reuse.
+
+## Primary objects
+
+- `ConfigSource`: declarative lifecycle input, usually a Git repository with a Nix flake or lockfile.
+- `ReleaseSet`: signed normal lifecycle release for system, user, agent, policy, and provenance state.
+- `BootReleaseSet`: signed bootable release for live, installer, rescue, rollback, or recovery flow.
+- `Fingerprint`: observed state emitted by a device, workspace, or boot environment.
+
+## States
+
+### 1. ConfigSourceRegistered
+
+A local or remote source is registered with policy boundaries.
+
+Required proof:
+
+- ConfigSource object exists.
+- Token reference is a secret-door reference, not a literal token.
+- Allowed refs and update mode are declared.
+
+### 2. RefDetected
+
+A source ref is selected or observed.
+
+Allowed triggers:
+
+- manual selection,
+- pull update,
+- PR branch update,
+- tag creation,
+- scheduled poll.
+
+Required proof:
+
+- ref name,
+- commit/tag identifier where applicable,
+- verification result for required signatures/status checks.
+
+### 3. BuildResolved
+
+The lifecycle plane resolves source inputs into build inputs.
+
+Required proof:
+
+- Nix entrypoint resolved,
+- lockfile or pin reference captured,
+- bill of materials reference created,
+- policy compatibility check completed.
+
+### 4. ReleaseBuilt
+
+System, user, and agent outputs are built or selected.
+
+Required proof:
+
+- system base reference,
+- user closure references,
+- agent environment references,
+- policy bundle reference,
+- build log/evidence reference.
+
+### 5. ReleaseSigned
+
+A ReleaseSet is signed and becomes immutable for promotion purposes.
+
+Required proof:
+
+- ReleaseSet object,
+- signature references,
+- signing key identifiers,
+- required signature threshold result.
+
+### 6. BootReleaseBuilt
+
+A BootReleaseSet is built or selected when a live, installer, rescue, recovery, or rollback flow is required.
+
+Required proof:
+
+- BootReleaseSet object,
+- boot mode list,
+- platform entrypoints,
+- signed artifact manifest,
+- proof reporting requirement.
+
+### 7. Assigned
+
+A ReleaseSet or BootReleaseSet is assigned to a device, user, group, project, organization, or fleet.
+
+Required proof:
+
+- assignment scope kind and identifier,
+- policy bundle reference,
+- channel and support state,
+- rollback candidate where applicable.
+
+### 8. Redeemed
+
+For boot/install/recovery, a one-time boot or enrollment authorization is redeemed.
+
+Required proof:
+
+- device claim,
+- authorization mode,
+- token TTL,
+- redemption result,
+- bound ReleaseSet or BootReleaseSet identifier.
+
+### 9. Deployed
+
+The device or workspace applies the release.
+
+Required proof:
+
+- deployment log reference,
+- applied release identifier,
+- applied system/user/agent refs,
+- rollback candidate retained.
+
+### 10. Fingerprinted
+
+The subject emits observed state.
+
+Required proof:
+
+- Fingerprint object,
+- observed system and runtime facts,
+- active policy reference,
+- evidence references.
+
+### 11. ComplianceEvaluated
+
+The control plane evaluates the fingerprint against assigned release and policy.
+
+Possible outcomes:
+
+- `compliant`,
+- `noncompliant`,
+- `degraded`,
+- `unknown`.
+
+Required proof:
+
+- evaluated fingerprint id,
+- expected release id,
+- policy id,
+- decision reason list.
+
+### 12. RollbackAvailable
+
+Rollback remains possible after successful deployment.
+
+Required proof:
+
+- previous system base reference,
+- previous user/agent closure references where available,
+- rollback BootReleaseSet if used.
+
+### 13. RolledBack
+
+A rollback has been executed.
+
+Required proof:
+
+- rollback trigger,
+- target rollback reference,
+- post-rollback fingerprint,
+- compliance result.
+
+## Transition table
+
+| From | To | Gate |
+| --- | --- | --- |
+| ConfigSourceRegistered | RefDetected | ref allowed by ConfigSource |
+| RefDetected | BuildResolved | signature/status policy satisfied or explicitly waived |
+| BuildResolved | ReleaseBuilt | policy compatibility passes |
+| ReleaseBuilt | ReleaseSigned | required signature threshold met |
+| ReleaseSigned | BootReleaseBuilt | boot/install/recovery requested |
+| ReleaseSigned | Assigned | release channel/support transition allowed |
+| BootReleaseBuilt | Assigned | boot artifact manifest signed |
+| Assigned | Redeemed | single-use/device claim authorization valid, if required |
+| Assigned | Deployed | device fetch/apply succeeds |
+| Redeemed | Deployed | boot environment verifies artifacts and applies/install/boots |
+| Deployed | Fingerprinted | subject emits observed-state record |
+| Fingerprinted | ComplianceEvaluated | fingerprint schema valid and policy evaluable |
+| ComplianceEvaluated | RollbackAvailable | previous release refs retained |
+| ComplianceEvaluated | RolledBack | noncompliant/degraded state triggers rollback policy |
+| RollbackAvailable | RolledBack | operator or policy requests rollback |
+
+## Failure handling
+
+Failures must emit evidence. Silent skipping is not permitted.
+
+Required failure facts:
+
+- state where failure occurred,
+- object id if available,
+- policy gate that failed,
+- log/evidence reference,
+- recommended next state.
+
+## Demo acceptance criteria
+
+The first M2 demo is considered lifecycle-complete when the control plane can show:
+
+1. ConfigSource registered.
+2. ReleaseSet built and signed.
+3. BootReleaseSet built or selected for recovery/install/live path.
+4. Release assigned to the M2 device.
+5. Device self-registers or redeems enrollment.
+6. Device applies or stages the release.
+7. Device emits Fingerprint.
+8. Control plane evaluates compliance.
+9. Rollback candidate remains available.
+
+## Sociosphere registration expectation
+
+Every SourceOS ReleaseSet, BootReleaseSet, and Fingerprint should be registerable in Sociosphere as governance-aware platform evidence. Sociosphere does not need to own implementation, but it must see lifecycle object creation, policy gates, and compliance/proof outcomes.

--- a/tools/validate_sourceos_contracts.py
+++ b/tools/validate_sourceos_contracts.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    import jsonschema
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("ERR: jsonschema is required to validate SourceOS contracts") from exc
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "contracts" / "sourceos"
+EXAMPLE_DIR = SCHEMA_DIR / "examples"
+
+SCHEMA_EXAMPLES = {
+    "release-set.v0.schema.json": ["release-set.m2-demo.v0.json"],
+    "boot-release-set.v0.schema.json": ["boot-release-set.m2-demo.v0.json"],
+    "fingerprint.v0.schema.json": [],
+    "config-source.v0.schema.json": [],
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def validate_file(schema_path: Path, document_path: Path) -> None:
+    schema = load_json(schema_path)
+    document = load_json(document_path)
+    jsonschema.Draft202012Validator.check_schema(schema)
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(document), key=lambda err: list(err.path))
+    if errors:
+        print(f"ERR: {document_path} failed {schema_path.name}")
+        for err in errors:
+            loc = ".".join(str(part) for part in err.path) or "<root>"
+            print(f"  - {loc}: {err.message}")
+        raise SystemExit(1)
+    print(f"OK: {document_path.relative_to(ROOT)} validates against {schema_path.relative_to(ROOT)}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate SourceOS contract examples against JSON schemas")
+    parser.add_argument("--schema-dir", type=Path, default=SCHEMA_DIR)
+    parser.add_argument("--example-dir", type=Path, default=EXAMPLE_DIR)
+    args = parser.parse_args()
+
+    for schema_name, examples in SCHEMA_EXAMPLES.items():
+        schema_path = args.schema_dir / schema_name
+        if not schema_path.exists():
+            raise SystemExit(f"ERR: missing schema {schema_path}")
+        jsonschema.Draft202012Validator.check_schema(load_json(schema_path))
+        for example_name in examples:
+            example_path = args.example_dir / example_name
+            if not example_path.exists():
+                raise SystemExit(f"ERR: missing example {example_path}")
+            validate_file(schema_path, example_path)
+
+    print("SourceOS contract validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the first repo-native SourceOS control-plane contract set for the M2 demo and later fleet/mesh expansion.

This PR introduces:

- `ReleaseSet` schema for normal lifecycle releases across system, user, agent, policy, provenance, and signatures.
- `BootReleaseSet` schema for live/install/rescue/recovery/rollback boot artifacts.
- `Fingerprint` schema for observed device/workspace/boot-environment state.
- `ConfigSource` schema for Git/Nix lifecycle inputs with token-door semantics.
- M2 demo example objects for ReleaseSet and BootReleaseSet.
- SourceOS lifecycle state-machine documentation.
- SourceOS secure boot provisioning protocol documentation.
- Contract validation tool and GitHub Actions workflow.

## Design intent

SourceOS is modeled as an opt-in agentic OS/fleet lifecycle system, not a standalone distro. The contracts preserve the intended split:

- immutable OSTree/Silverblue/CoreOS-style system plane,
- Nix-managed lifecycle plane,
- separate user and agent spaces,
- risk-proportional agent isolation,
- signed release and boot artifacts,
- local-first operation that can later replicate through local mesh, cloud twin, and cloud mesh.

## nlboot / boot path

The boot protocol keeps the useful nlboot shape: minimal boot environment, announce, server-directed boot instructions, verification, and kexec/install/recovery. SourceOS upgrades that into signed `BootReleaseSet` object graphs with policy and proof obligations.

## Sociosphere registration expectation

This PR explicitly documents that SourceOS ReleaseSet, BootReleaseSet, and Fingerprint objects must be visible to Sociosphere as governance/build-intelligence evidence. A companion Sociosphere registration item should track workspace-controller validation and lifecycle-awareness.

## Validation

New workflow: `.github/workflows/sourceos-contracts.yml`

Expected command:

```bash
python tools/validate_sourceos_contracts.py
```

The workflow installs `jsonschema` and validates the demo examples against the v0 schemas.

## Notes

The branch was created from the current platform line at the time of work. It may need update from `main` before merge if main moved while this work was being written.