### PR TITLE
Add Fog Stack promotion approval cryptographic verification

### DIFF
--- a/.github/workflows/fogstack-manifest-promotion.yml
+++ b/.github/workflows/fogstack-manifest-promotion.yml
@@ -8,17 +8,22 @@ on:
       - "conformance/**"
       - "catalog/fogstack-support-states-v0.1.yaml"
       - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
+      - "catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml"
       - "releases/manifests/**"
       - "schemas/release/fogstack-manifest-promotion-approval-record-v0.1.schema.json"
       - "tools/build_fogstack_manifest_publication_set.py"
       - "tools/promote_fogstack_manifest_publication_set.py"
       - "tools/check_fogstack_manifest_promotion_policy.py"
+      - "tools/check_fogstack_manifest_promotion_approver_policy.py"
       - "tools/emit_fogstack_manifest_promotion_approval_record.py"
       - "tools/check_fogstack_manifest_promotion_approval_record.py"
+      - "tools/run_openssl_fogstack_manifest_promotion_approval_verifier.py"
       - "tools/tests/test_build_fogstack_manifest_publication_set.py"
       - "tools/tests/test_promote_fogstack_manifest_publication_set.py"
       - "tools/tests/test_check_fogstack_manifest_promotion_policy.py"
+      - "tools/tests/test_check_fogstack_manifest_promotion_approver_policy.py"
       - "tools/tests/test_fogstack_manifest_promotion_approval_record.py"
+      - "tools/tests/test_run_openssl_fogstack_manifest_promotion_approval_verifier.py"
       - "docs/FOGSTACK_*.md"
       - ".github/workflows/fogstack-manifest-promotion.yml"
   push:
@@ -28,17 +33,22 @@ on:
       - "conformance/**"
       - "catalog/fogstack-support-states-v0.1.yaml"
       - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
+      - "catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml"
       - "releases/manifests/**"
       - "schemas/release/fogstack-manifest-promotion-approval-record-v0.1.schema.json"
       - "tools/build_fogstack_manifest_publication_set.py"
       - "tools/promote_fogstack_manifest_publication_set.py"
       - "tools/check_fogstack_manifest_promotion_policy.py"
+      - "tools/check_fogstack_manifest_promotion_approver_policy.py"
       - "tools/emit_fogstack_manifest_promotion_approval_record.py"
       - "tools/check_fogstack_manifest_promotion_approval_record.py"
+      - "tools/run_openssl_fogstack_manifest_promotion_approval_verifier.py"
       - "tools/tests/test_build_fogstack_manifest_publication_set.py"
       - "tools/tests/test_promote_fogstack_manifest_publication_set.py"
       - "tools/tests/test_check_fogstack_manifest_promotion_policy.py"
+      - "tools/tests/test_check_fogstack_manifest_promotion_approver_policy.py"
       - "tools/tests/test_fogstack_manifest_promotion_approval_record.py"
+      - "tools/tests/test_run_openssl_fogstack_manifest_promotion_approval_verifier.py"
       - "docs/FOGSTACK_*.md"
       - ".github/workflows/fogstack-manifest-promotion.yml"
 
@@ -69,7 +79,9 @@ jobs:
             tools/tests/test_build_fogstack_manifest_publication_set.py \
             tools/tests/test_promote_fogstack_manifest_publication_set.py \
             tools/tests/test_check_fogstack_manifest_promotion_policy.py \
-            tools/tests/test_fogstack_manifest_promotion_approval_record.py
+            tools/tests/test_check_fogstack_manifest_promotion_approver_policy.py \
+            tools/tests/test_fogstack_manifest_promotion_approval_record.py \
+            tools/tests/test_run_openssl_fogstack_manifest_promotion_approval_verifier.py
 
       - name: Build canonical publication set
         run: |
@@ -103,15 +115,35 @@ jobs:
             --approval 'release-manager:release-manager:approved candidate promotion' \
             --approval 'security-reviewer:security-reviewer:approved release evidence' \
             --signature-type other \
-            --signature-ref artifact://ci/fogstack.manifest-promotion.approval.sig \
+            --signature-ref artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.sig \
             --output artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.record.json
 
-      - name: Enforce signed promotion approval
+      - name: Enforce approval metadata and approver policy
         run: |
           python3 tools/check_fogstack_manifest_promotion_approval_record.py \
             --approval-record artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.record.json \
             --promotion-set artifacts/manifest-promotion/promoted/manifest-publication-set.json \
             --require-signed
+
+          python3 tools/check_fogstack_manifest_promotion_approver_policy.py \
+            --approval-record artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.record.json \
+            --approver-policy catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml
+
+      - name: Sign and verify promotion approval record
+        run: |
+          openssl genpkey -algorithm RSA -out artifacts/manifest-promotion/approval/private.pem
+          openssl pkey -in artifacts/manifest-promotion/approval/private.pem -pubout -out artifacts/manifest-promotion/approval/public.pem
+          openssl dgst -sha256 \
+            -sign artifacts/manifest-promotion/approval/private.pem \
+            -out artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.sig \
+            artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.record.json
+
+          python3 tools/run_openssl_fogstack_manifest_promotion_approval_verifier.py \
+            --approval-record artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.record.json \
+            --signature artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.sig \
+            --public-key artifacts/manifest-promotion/approval/public.pem \
+            --key-ref artifacts/manifest-promotion/approval/public.pem \
+            --output artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.signature-verification.json
 
       - name: Upload promoted manifest set
         uses: actions/upload-artifact@v4

--- a/catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml
+++ b/catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml
@@ -1,0 +1,12 @@
+schema_version: "fogstack.manifest-promotion-approver-policy/v0.1"
+kind: "FogStackManifestPromotionApproverPolicy"
+required_roles:
+  - "release-manager"
+  - "security-reviewer"
+approvers:
+  - id: "release-manager"
+    roles:
+      - "release-manager"
+  - id: "security-reviewer"
+    roles:
+      - "security-reviewer"

--- a/docs/FOGSTACK_MANIFEST_PROMOTION_APPROVAL_CRYPTOGRAPHY.md
+++ b/docs/FOGSTACK_MANIFEST_PROMOTION_APPROVAL_CRYPTOGRAPHY.md
@@ -1,0 +1,46 @@
+# Fog Stack manifest promotion approval cryptography
+
+This document defines the repo-native cryptographic verification layer for Fog Stack manifest promotion approval.
+
+## Goal
+
+Move from approval records that carry signature metadata to approval records whose signature payload is verified in CI, with approver role policy checked independently.
+
+## Approval signature verification
+
+The OpenSSL-backed verifier lives at:
+- `tools/run_openssl_fogstack_manifest_promotion_approval_verifier.py`
+
+It verifies an approval-record signature with a public key and emits JSON verification output with:
+- approval record reference
+- approval record digest
+- signature reference
+- verifier
+- key reference
+- pass/fail status
+
+## Approver policy
+
+The approver policy catalog lives at:
+- `catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml`
+
+It defines:
+- required approval roles
+- allowed approver identities
+- roles allowed for each approver
+
+## CI enforcement
+
+The manifest-promotion workflow now enforces:
+1. publication-set promotion policy
+2. approval metadata
+3. approver role policy
+4. cryptographic verification of the approval-record signature
+
+## What this phase does not yet provide
+
+- external identity-provider backed approver resolution
+- long-lived release signing keys
+- registry publication gates
+
+Those remain later steps.

--- a/tools/check_fogstack_manifest_promotion_approver_policy.py
+++ b/tools/check_fogstack_manifest_promotion_approver_policy.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check Fog Stack promotion approval roles")
+    parser.add_argument("--approval-record", required=True, type=Path)
+    parser.add_argument("--approver-policy", required=True, type=Path)
+    args = parser.parse_args()
+
+    record = load_json(args.approval_record)
+    policy = yaml.safe_load(args.approver_policy.read_text(encoding="utf-8")) or {}
+
+    approver_roles = {}
+    for item in policy.get("approvers") or []:
+        if isinstance(item, dict) and isinstance(item.get("id"), str):
+            approver_roles[item["id"]] = set(item.get("roles") or [])
+
+    required_roles = set(policy.get("required_roles") or [])
+    seen_roles = set()
+    errors = []
+
+    for approval in record.get("approvals") or []:
+        approver = approval.get("approver") if isinstance(approval, dict) else None
+        role = approval.get("role") if isinstance(approval, dict) else None
+        if approver not in approver_roles:
+            errors.append(f"unknown approver: {approver}")
+            continue
+        if role not in approver_roles[approver]:
+            errors.append(f"role mismatch for approver: {approver}")
+            continue
+        seen_roles.add(role)
+
+    missing = sorted(required_roles - seen_roles)
+    if missing:
+        errors.append("missing required roles: " + ", ".join(missing))
+
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+
+    print("FogStack promotion approver policy passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_openssl_fogstack_manifest_promotion_approval_verifier.py
+++ b/tools/run_openssl_fogstack_manifest_promotion_approval_verifier.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify a Fog Stack promotion approval signature with OpenSSL")
+    parser.add_argument("--approval-record", required=True, type=Path)
+    parser.add_argument("--signature", required=True, type=Path)
+    parser.add_argument("--public-key", required=True, type=Path)
+    parser.add_argument("--key-ref", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    proc = subprocess.run(
+        [
+            "openssl",
+            "dgst",
+            "-sha256",
+            "-verify",
+            str(args.public_key),
+            "-signature",
+            str(args.signature),
+            str(args.approval_record),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    passed = proc.returncode == 0
+    result = {
+        "kind": "FogStackManifestPromotionApprovalSignatureVerification",
+        "schema_version": "v0.1",
+        "approval_record_ref": str(args.approval_record),
+        "approval_record_digest": sha256_file(args.approval_record),
+        "signature_ref": str(args.signature),
+        "verification_tool": "openssl",
+        "key_ref": args.key_ref or str(args.public_key),
+        "status": "pass" if passed else "fail",
+        "message": proc.stdout.strip() or proc.stderr.strip() or None,
+    }
+    text = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_check_fogstack_manifest_promotion_approver_policy.py
+++ b/tools/tests/test_check_fogstack_manifest_promotion_approver_policy.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def write_policy(path: Path) -> None:
+    path.write_text(
+        'schema_version: "fogstack.manifest-promotion-approver-policy/v0.1"\n'
+        'kind: "FogStackManifestPromotionApproverPolicy"\n'
+        'required_roles:\n'
+        '  - "release-manager"\n'
+        '  - "security-reviewer"\n'
+        'approvers:\n'
+        '  - id: "release-manager"\n'
+        '    roles:\n'
+        '      - "release-manager"\n'
+        '  - id: "security-reviewer"\n'
+        '    roles:\n'
+        '      - "security-reviewer"\n',
+        encoding="utf-8",
+    )
+
+
+def test_approver_policy_allows_required_roles(tmp_path: Path) -> None:
+    approval = tmp_path / "approval.record.json"
+    write_json(approval, {
+        "approvals": [
+            {"approver": "release-manager", "role": "release-manager"},
+            {"approver": "security-reviewer", "role": "security-reviewer"},
+        ]
+    })
+    policy = tmp_path / "approver-policy.yaml"
+    write_policy(policy)
+    subprocess.run([
+        sys.executable,
+        "tools/check_fogstack_manifest_promotion_approver_policy.py",
+        "--approval-record", str(approval),
+        "--approver-policy", str(policy),
+    ], check=True)
+
+
+def test_approver_policy_rejects_unknown_approver(tmp_path: Path) -> None:
+    approval = tmp_path / "approval.record.json"
+    write_json(approval, {
+        "approvals": [
+            {"approver": "unknown", "role": "release-manager"},
+        ]
+    })
+    policy = tmp_path / "approver-policy.yaml"
+    write_policy(policy)
+    proc = subprocess.run([
+        sys.executable,
+        "tools/check_fogstack_manifest_promotion_approver_policy.py",
+        "--approval-record", str(approval),
+        "--approver-policy", str(policy),
+    ])
+    assert proc.returncode != 0

--- a/tools/tests/test_run_openssl_fogstack_manifest_promotion_approval_verifier.py
+++ b/tools/tests/test_run_openssl_fogstack_manifest_promotion_approval_verifier.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_openssl_promotion_approval_verifier_accepts_valid_signature(tmp_path: Path) -> None:
+    if not shutil.which("openssl"):
+        pytest.skip("openssl is not available")
+
+    approval = tmp_path / "approval.record.json"
+    approval.write_text(json.dumps({"kind": "FogStackManifestPromotionApprovalRecord"}, indent=2) + "\n", encoding="utf-8")
+    private_key = tmp_path / "private.pem"
+    public_key = tmp_path / "public.pem"
+    signature = tmp_path / "approval.sig"
+    output = tmp_path / "verification.json"
+
+    subprocess.run(["openssl", "genpkey", "-algorithm", "RSA", "-out", str(private_key)], check=True)
+    subprocess.run(["openssl", "pkey", "-in", str(private_key), "-pubout", "-out", str(public_key)], check=True)
+    subprocess.run(["openssl", "dgst", "-sha256", "-sign", str(private_key), "-out", str(signature), str(approval)], check=True)
+
+    subprocess.run([
+        sys.executable,
+        "tools/run_openssl_fogstack_manifest_promotion_approval_verifier.py",
+        "--approval-record", str(approval),
+        "--signature", str(signature),
+        "--public-key", str(public_key),
+        "--key-ref", str(public_key),
+        "--output", str(output),
+    ], check=True)
+
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert data["status"] == "pass"
+    assert data["verification_tool"] == "openssl"
+    assert data["approval_record_digest"].startswith("sha256:")


### PR DESCRIPTION
## Summary

This PR adds the next release-governance tranche directly on top of current `main`:

- `catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml`
- `tools/check_fogstack_manifest_promotion_approver_policy.py`
- `tools/run_openssl_fogstack_manifest_promotion_approval_verifier.py`
- `tools/tests/test_check_fogstack_manifest_promotion_approver_policy.py`
- `tools/tests/test_run_openssl_fogstack_manifest_promotion_approval_verifier.py`
- updated `.github/workflows/fogstack-manifest-promotion.yml`
- `docs/FOGSTACK_MANIFEST_PROMOTION_APPROVAL_CRYPTOGRAPHY.md`

## Why this PR exists

The repo now has approval-bound manifest promotion, but approval still needed two hardening layers:

- approver role policy, so approvals are not arbitrary strings
- cryptographic verification of the approval record signature payload, so signature metadata is not just decorative

This PR adds both and wires them into the manifest-promotion workflow.

## Not in this PR

- external identity-provider backed approver resolution
- long-lived release signing keys
- registry publication gates

Those remain later steps.
