### PR TITLE
specs: add ProviderBinding broker contract

### DIFF
--- a/.github/workflows/provider-binding-validation.yml
+++ b/.github/workflows/provider-binding-validation.yml
@@ -1,0 +1,28 @@
+name: provider-binding-validation
+
+on:
+  pull_request:
+    paths:
+      - "specs/brokerage/schemas/provider-binding.schema.json"
+      - "specs/brokerage/events/examples/provider-binding.example.json"
+      - "tools/validate_provider_binding_examples.py"
+      - ".github/workflows/provider-binding-validation.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "specs/brokerage/schemas/provider-binding.schema.json"
+      - "specs/brokerage/events/examples/provider-binding.example.json"
+      - "tools/validate_provider_binding_examples.py"
+      - ".github/workflows/provider-binding-validation.yml"
+
+jobs:
+  validate-provider-binding:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate ProviderBinding example
+        run: python tools/validate_provider_binding_examples.py

--- a/docs/reference/next-gen-tom/provider-binding.md
+++ b/docs/reference/next-gen-tom/provider-binding.md
@@ -1,0 +1,28 @@
+# ProviderBinding Platform Contract
+
+## Purpose
+
+`ProviderBinding` is the bridge between a service class and a concrete provider implementation.
+
+A service offering says what can be consumed. A blueprint says how it may be fulfilled. A provider profile says which provider is eligible. A provider binding says which provider implementation is approved for a given service class under a declared policy, evidence, cost, and portability posture.
+
+## Required semantics
+
+A ProviderBinding must declare:
+
+- service class
+- provider class
+- provider identifier
+- blueprint reference
+- policy pack references
+- portability tier
+- native feature exposure
+- evidence profile
+- cost meter profile
+- continuity profile
+- exit plan reference
+- approval state
+
+## Broker rule
+
+No production service instance should be fulfilled without an approved provider binding unless an explicit exception record exists.

--- a/specs/brokerage/events/examples/provider-binding.example.json
+++ b/specs/brokerage/events/examples/provider-binding.example.json
@@ -1,0 +1,23 @@
+{
+  "binding_id": "binding-standard-app-env-public-cloud-001",
+  "service_class": "environment",
+  "provider_class": "public-cloud",
+  "provider_id": "provider.public-cloud.primary",
+  "blueprint_id": "blueprint.standard-app-environment.v1",
+  "policy_pack_ids": [
+    "policy.identity.baseline.v1",
+    "policy.cost-allocation.required.v1",
+    "policy.observability.required.v1"
+  ],
+  "portability_tier": "P2-blueprint-portable",
+  "native_features_exposed": [
+    "managed-network-policy",
+    "provider-native-secrets-integration"
+  ],
+  "evidence_profile_id": "evidence.standard-environment.v1",
+  "cost_meter_profile_id": "cost.environment-day.v1",
+  "continuity_profile_id": "continuity.standard-devtest.v1",
+  "exit_plan_ref": "exit.redeploy-from-blueprint.v1",
+  "approval_state": "Approved",
+  "owner": "platform-brokerage"
+}

--- a/specs/brokerage/schemas/provider-binding.schema.json
+++ b/specs/brokerage/schemas/provider-binding.schema.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "binding_id": { "type": "string" },
+    "service_class": { "type": "string" },
+    "provider_class": {
+      "type": "string",
+      "enum": ["internal-shared-service", "private-cloud", "public-cloud", "saas", "partner-managed-service", "legacy-adapter"]
+    },
+    "provider_id": { "type": "string" },
+    "blueprint_id": { "type": "string" },
+    "policy_pack_ids": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+    "portability_tier": {
+      "type": "string",
+      "enum": ["P0-governed-native", "P1-contract-compatible", "P2-blueprint-portable", "P3-operationally-portable", "P4-exit-tested"]
+    },
+    "native_features_exposed": { "type": "array", "items": { "type": "string" } },
+    "evidence_profile_id": { "type": "string" },
+    "cost_meter_profile_id": { "type": "string" },
+    "continuity_profile_id": { "type": "string" },
+    "exit_plan_ref": { "type": "string" },
+    "approval_state": { "type": "string", "enum": ["Draft", "UnderReview", "Approved", "Suspended", "Retired"] },
+    "owner": { "type": "string" }
+  },
+  "required": ["binding_id", "service_class", "provider_class", "provider_id", "blueprint_id", "policy_pack_ids", "portability_tier", "evidence_profile_id", "cost_meter_profile_id", "continuity_profile_id", "exit_plan_ref", "approval_state", "owner"]
+}

--- a/tools/validate_provider_binding_examples.py
+++ b/tools/validate_provider_binding_examples.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Validate ProviderBinding examples without third-party dependencies."""
+
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE = ROOT / "specs" / "brokerage" / "events" / "examples" / "provider-binding.example.json"
+
+REQUIRED = [
+    "binding_id",
+    "service_class",
+    "provider_class",
+    "provider_id",
+    "blueprint_id",
+    "policy_pack_ids",
+    "portability_tier",
+    "evidence_profile_id",
+    "cost_meter_profile_id",
+    "continuity_profile_id",
+    "exit_plan_ref",
+    "approval_state",
+    "owner",
+]
+
+PROVIDER_CLASSES = {
+    "internal-shared-service",
+    "private-cloud",
+    "public-cloud",
+    "saas",
+    "partner-managed-service",
+    "legacy-adapter",
+}
+
+PORTABILITY_TIERS = {
+    "P0-governed-native",
+    "P1-contract-compatible",
+    "P2-blueprint-portable",
+    "P3-operationally-portable",
+    "P4-exit-tested",
+}
+
+APPROVAL_STATES = {"Draft", "UnderReview", "Approved", "Suspended", "Retired"}
+
+
+def main() -> int:
+    if not EXAMPLE.exists():
+        print(f"Missing example: {EXAMPLE}")
+        return 1
+
+    with EXAMPLE.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    missing = [key for key in REQUIRED if key not in payload]
+    if missing:
+        print("ProviderBinding example missing required keys:")
+        for key in missing:
+            print(f" - {key}")
+        return 1
+
+    if payload["provider_class"] not in PROVIDER_CLASSES:
+        print("Invalid provider_class")
+        return 1
+    if payload["portability_tier"] not in PORTABILITY_TIERS:
+        print("Invalid portability_tier")
+        return 1
+    if payload["approval_state"] not in APPROVAL_STATES:
+        print("Invalid approval_state")
+        return 1
+    if not isinstance(payload["policy_pack_ids"], list) or not payload["policy_pack_ids"]:
+        print("policy_pack_ids must be a non-empty list")
+        return 1
+
+    print("ProviderBinding example passes required checks.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the clean ProviderBinding implementation contract for the cross-cloud services broker model.

It adds:
- `docs/reference/next-gen-tom/provider-binding.md`
- `specs/brokerage/schemas/provider-binding.schema.json`
- `specs/brokerage/events/examples/provider-binding.example.json`
- `tools/validate_provider_binding_examples.py`
- `.github/workflows/provider-binding-validation.yml`

## Why

ProviderBinding is the missing bridge between a service class and a concrete provider implementation. It records provider class, provider identity, blueprint, policy packs, portability tier, evidence profile, cost meter profile, continuity profile, exit plan, approval state, and owner.

## Notes

- This PR keeps normative doctrine out of the runtime repo.
- Standards-side doctrine, service/provider matrix, broker events, and reasoning outputs are carried in the companion standards PR.
- This branch was cut from current `main` and supersedes the earlier stale ProviderBinding PR.
