### PR TITLE
specs: add ProviderBinding schema validation

### DIFF
--- a/.github/workflows/provider-binding-validation.yml
+++ b/.github/workflows/provider-binding-validation.yml
@@ -16,6 +16,9 @@ on:
       - "tools/validate_provider_binding_examples.py"
       - ".github/workflows/provider-binding-validation.yml"
 
+permissions:
+  contents: read
+
 jobs:
   validate-provider-binding:
     runs-on: ubuntu-latest

--- a/.github/workflows/provider-binding-validation.yml
+++ b/.github/workflows/provider-binding-validation.yml
@@ -1,0 +1,30 @@
+name: provider-binding-validation
+
+on:
+  pull_request:
+    paths:
+      - "specs/brokerage/schemas/provider-binding.schema.json"
+      - "specs/brokerage/events/examples/provider-binding.example.json"
+      - "tools/validate_provider_binding_examples.py"
+      - ".github/workflows/provider-binding-validation.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "specs/brokerage/schemas/provider-binding.schema.json"
+      - "specs/brokerage/events/examples/provider-binding.example.json"
+      - "tools/validate_provider_binding_examples.py"
+      - ".github/workflows/provider-binding-validation.yml"
+
+jobs:
+  validate-provider-binding:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install validation dependency
+        run: python -m pip install jsonschema
+      - name: Validate ProviderBinding example against schema
+        run: python tools/validate_provider_binding_examples.py

--- a/docs/reference/next-gen-tom/provider-binding.md
+++ b/docs/reference/next-gen-tom/provider-binding.md
@@ -1,0 +1,28 @@
+# ProviderBinding Platform Contract
+
+## Purpose
+
+`ProviderBinding` is the bridge between a service class and a concrete provider implementation.
+
+A service offering says what can be consumed. A blueprint says how it may be fulfilled. A provider profile says which provider is eligible. A provider binding says which provider implementation is approved for a given service class under a declared policy, evidence, cost, and portability posture.
+
+## Required semantics
+
+A ProviderBinding must declare:
+
+- service class
+- provider class
+- provider identifier
+- blueprint reference
+- policy pack references
+- portability tier
+- native feature exposure
+- evidence profile
+- cost meter profile
+- continuity profile
+- exit plan reference
+- approval state
+
+## Broker rule
+
+No production service instance should be fulfilled without an approved provider binding unless an explicit exception record exists.

--- a/specs/brokerage/events/examples/provider-binding.example.json
+++ b/specs/brokerage/events/examples/provider-binding.example.json
@@ -1,0 +1,23 @@
+{
+  "binding_id": "binding-standard-app-env-public-cloud-001",
+  "service_class": "environment",
+  "provider_class": "public-cloud",
+  "provider_id": "provider.public-cloud.primary",
+  "blueprint_id": "blueprint.standard-app-environment.v1",
+  "policy_pack_ids": [
+    "policy.identity.baseline.v1",
+    "policy.cost-allocation.required.v1",
+    "policy.observability.required.v1"
+  ],
+  "portability_tier": "P2-blueprint-portable",
+  "native_features_exposed": [
+    "managed-network-policy",
+    "provider-native-secrets-integration"
+  ],
+  "evidence_profile_id": "evidence.standard-environment.v1",
+  "cost_meter_profile_id": "cost.environment-day.v1",
+  "continuity_profile_id": "continuity.standard-devtest.v1",
+  "exit_plan_ref": "exit.redeploy-from-blueprint.v1",
+  "approval_state": "Approved",
+  "owner": "platform-brokerage"
+}

--- a/specs/brokerage/schemas/provider-binding.schema.json
+++ b/specs/brokerage/schemas/provider-binding.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ProviderBinding",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "binding_id": { "type": "string", "minLength": 1 },
+    "service_class": { "type": "string", "minLength": 1 },
+    "provider_class": {
+      "type": "string",
+      "enum": ["internal-shared-service", "private-cloud", "public-cloud", "saas", "partner-managed-service", "legacy-adapter"]
+    },
+    "provider_id": { "type": "string", "minLength": 1 },
+    "blueprint_id": { "type": "string", "minLength": 1 },
+    "policy_pack_ids": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+    "portability_tier": {
+      "type": "string",
+      "enum": ["P0-governed-native", "P1-contract-compatible", "P2-blueprint-portable", "P3-operationally-portable", "P4-exit-tested"]
+    },
+    "native_features_exposed": { "type": "array", "items": { "type": "string" } },
+    "evidence_profile_id": { "type": "string", "minLength": 1 },
+    "cost_meter_profile_id": { "type": "string", "minLength": 1 },
+    "continuity_profile_id": { "type": "string", "minLength": 1 },
+    "exit_plan_ref": { "type": "string", "minLength": 1 },
+    "approval_state": { "type": "string", "enum": ["Draft", "UnderReview", "Approved", "Suspended", "Retired"] },
+    "owner": { "type": "string", "minLength": 1 }
+  },
+  "required": ["binding_id", "service_class", "provider_class", "provider_id", "blueprint_id", "policy_pack_ids", "portability_tier", "evidence_profile_id", "cost_meter_profile_id", "continuity_profile_id", "exit_plan_ref", "approval_state", "owner"]
+}

--- a/tools/validate_provider_binding_examples.py
+++ b/tools/validate_provider_binding_examples.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Validate ProviderBinding examples against their JSON Schema."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "specs" / "brokerage" / "schemas" / "provider-binding.schema.json"
+EXAMPLE_PATH = ROOT / "specs" / "brokerage" / "events" / "examples" / "provider-binding.example.json"
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> int:
+    missing = [str(path) for path in (SCHEMA_PATH, EXAMPLE_PATH) if not path.exists()]
+    if missing:
+        print("Missing ProviderBinding validation inputs:")
+        for item in missing:
+            print(f" - {item}")
+        return 1
+
+    schema = load_json(SCHEMA_PATH)
+    example = load_json(EXAMPLE_PATH)
+
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(example), key=lambda error: list(error.path))
+
+    if errors:
+        print("ProviderBinding example failed schema validation:")
+        for error in errors:
+            location = ".".join(str(part) for part in error.path) or "<root>"
+            print(f" - {location}: {error.message}")
+        return 1
+
+    print("ProviderBinding example validates against provider-binding.schema.json.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Re-lands the ProviderBinding implementation contract from current `main` and upgrades validation from required-key checks to JSON Schema validation.

Adds:
- `docs/reference/next-gen-tom/provider-binding.md`
- `specs/brokerage/schemas/provider-binding.schema.json`
- `specs/brokerage/events/examples/provider-binding.example.json`
- `tools/validate_provider_binding_examples.py`
- `.github/workflows/provider-binding-validation.yml`

## Why

ProviderBinding is the runtime-facing bridge between a service class and a concrete provider implementation. This PR records provider class, provider identity, blueprint, policy packs, portability tier, evidence profile, cost meter profile, continuity profile, exit plan, approval state, and owner.

## Validation

The new workflow installs `jsonschema` and validates the ProviderBinding example against `provider-binding.schema.json`.

## Notes

- This PR keeps normative doctrine in the standards layer.
- It supersedes #208, which was opened before `main` moved again.
