### PR TITLE
build(search): add image publish and digest pinning flow

### DIFF
--- a/.github/workflows/search-orchestrator-image.yml
+++ b/.github/workflows/search-orchestrator-image.yml
@@ -1,0 +1,76 @@
+name: search-orchestrator-image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/search-orchestrator/**'
+      - '.github/workflows/search-orchestrator-image.yml'
+  pull_request:
+    paths:
+      - 'services/search-orchestrator/**'
+      - '.github/workflows/search-orchestrator-image.yml'
+      - 'tools/validate_search_orchestrator_image_release.py'
+      - 'releases/images/search-orchestrator.image-lock.example.json'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image for pull request
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/search-orchestrator/Dockerfile
+          push: false
+          tags: ghcr.io/socioprophet/prophet-platform/search-orchestrator:pr-${{ github.event.pull_request.number }}
+
+      - name: Build and push image
+        if: github.event_name == 'push'
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/search-orchestrator/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/socioprophet/prophet-platform/search-orchestrator:main
+            ghcr.io/socioprophet/prophet-platform/search-orchestrator:${{ github.sha }}
+
+      - name: Emit digest evidence
+        if: github.event_name == 'push'
+        run: |
+          mkdir -p image-evidence
+          cat > image-evidence/search-orchestrator-image.json <<EOF
+          {
+            "image": "ghcr.io/socioprophet/prophet-platform/search-orchestrator",
+            "source_sha": "${{ github.sha }}",
+            "digest": "${{ steps.build.outputs.digest }}",
+            "pinned_ref": "ghcr.io/socioprophet/prophet-platform/search-orchestrator@${{ steps.build.outputs.digest }}"
+          }
+          EOF
+
+      - name: Upload digest evidence
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: search-orchestrator-image-evidence
+          path: image-evidence/search-orchestrator-image.json

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -22,6 +22,9 @@ validate-ops-fabric:
 
 validate-search-academy-deploy:
 	python3 tools/validate_search_orchestrator_academy_deploy.py
+
+validate-search-image-release:
+	python3 tools/validate_search_orchestrator_image_release.py
 
 validate-lampstand-lifecycle:
 	python3 tools/validate_lampstand_lifecycle.py

--- a/releases/evidence/search-orchestrator.academy-bridge.validation.record.json
+++ b/releases/evidence/search-orchestrator.academy-bridge.validation.record.json
@@ -4,6 +4,11 @@
   "release_lane": "academy-bridge",
   "status": "passed",
   "validated_artifacts": [
+    "services/search-orchestrator/Dockerfile",
+    ".github/workflows/search-orchestrator-image.yml",
+    "releases/images/search-orchestrator.image-lock.example.json",
+    "tools/render_search_orchestrator_image_patch.py",
+    "tools/validate_search_orchestrator_image_release.py",
     "services/search-orchestrator/deploy/academy-bridge-profiles.yaml",
     "infra/local/docker-compose.search-orchestrator.academy.yml",
     "infra/k8s/search-orchestrator/base/kustomization.yaml",
@@ -25,7 +30,8 @@
     "services/search-orchestrator/tests/test_academy_lampstand_deployment_smoke.py",
     "services/search-orchestrator/tests/test_academy_lampstand_carrier_real_smoke.py",
     "services/search-orchestrator/tests/test_debug_config.py",
-    "services/search-orchestrator/tests/test_debug_metrics.py"
+    "services/search-orchestrator/tests/test_debug_metrics.py",
+    "tools/tests/test_search_orchestrator_image_patch.py"
   ],
   "evidence": [
     "safe runtime config reports modes without paths or URLs",
@@ -37,10 +43,13 @@
     "release readout summarizes Academy to Search Orchestrator to Lampstand to Policy Fabric to FogStack evidence path",
     "Kubernetes base includes ServiceAccount/RBAC, PVC-backed storage, network policy, non-root security context, read-only root filesystem, and dropped Linux capabilities",
     "Policy Fabric endpoint is sourced from Secret/ExternalSecret examples rather than ConfigMap",
-    "debug metrics endpoint reports counters without actor ids, queries, URLs, paths, or secrets"
+    "debug metrics endpoint reports counters without actor ids, queries, URLs, paths, or secrets",
+    "Search Orchestrator image workflow builds/publishes GHCR image and emits digest evidence",
+    "image lock renderer converts digest evidence into a digest-pinned deployment patch"
   ],
   "gates": [
     "search-orchestrator workflow",
+    "search-orchestrator-image workflow",
     "platform validate workflow",
     "premerge audit",
     "FogStack release evidence validation"

--- a/releases/images/search-orchestrator.image-lock.example.json
+++ b/releases/images/search-orchestrator.image-lock.example.json
@@ -1,0 +1,10 @@
+{
+  "image_lock_id": "search-orchestrator-image-lock-example",
+  "component": "services/search-orchestrator",
+  "image": "ghcr.io/socioprophet/prophet-platform/search-orchestrator",
+  "source_sha": "REPLACE_WITH_GIT_SHA",
+  "digest": "sha256:REPLACE_WITH_IMAGE_DIGEST",
+  "pinned_ref": "ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:REPLACE_WITH_IMAGE_DIGEST",
+  "workflow": ".github/workflows/search-orchestrator-image.yml",
+  "status": "example"
+}

--- a/releases/manifests/search-orchestrator.academy-bridge.manifest.json
+++ b/releases/manifests/search-orchestrator.academy-bridge.manifest.json
@@ -6,6 +6,11 @@
   "bundle_ref": "bundles/fogstack.knowledge-v0.1.yaml",
   "argocd_appset_ref": "infra/argocd/appsets/search-orchestrator-academy-appset.yaml",
   "artifacts": [
+    "services/search-orchestrator/Dockerfile",
+    ".github/workflows/search-orchestrator-image.yml",
+    "releases/images/search-orchestrator.image-lock.example.json",
+    "tools/render_search_orchestrator_image_patch.py",
+    "tools/validate_search_orchestrator_image_release.py",
     "services/search-orchestrator/deploy/academy-bridge-profiles.yaml",
     "infra/local/docker-compose.search-orchestrator.academy.yml",
     "infra/k8s/search-orchestrator/base/kustomization.yaml",
@@ -34,7 +39,9 @@
     "operator-rollout-checklist",
     "release-readout",
     "kubernetes-production-hardening",
-    "non-secret-runtime-metrics"
+    "non-secret-runtime-metrics",
+    "image-build-publish",
+    "digest-pinned-image-rendering"
   ],
   "safety_posture": [
     "endpoint-explicit policy fabric calls",
@@ -44,6 +51,7 @@
     "dropped linux capabilities",
     "persistent carrier storage",
     "namespace-scoped network policy",
+    "digest-pinned production image workflow",
     "no learner action execution",
     "no canon promotion",
     "no memory writeback",

--- a/services/search-orchestrator/Dockerfile
+++ b/services/search-orchestrator/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app/services/search-orchestrator
+
+COPY services/search-orchestrator/requirements.txt ./requirements.txt
+RUN python -m pip install --upgrade pip \
+    && pip install -r requirements.txt
+
+COPY services/search-orchestrator/app ./app
+
+USER 10001:10001
+EXPOSE 8080
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/tools/render_search_orchestrator_image_patch.py
+++ b/tools/render_search_orchestrator_image_patch.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+DIGEST_RE = re.compile(r"^sha256:[a-fA-F0-9]{64}$")
+IMAGE = "ghcr.io/socioprophet/prophet-platform/search-orchestrator"
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return data
+
+
+def validate_lock(lock: dict) -> str:
+    digest = str(lock.get("digest", ""))
+    pinned_ref = str(lock.get("pinned_ref", ""))
+    if not DIGEST_RE.match(digest):
+        raise SystemExit("image lock digest must be sha256:<64 hex chars>")
+    expected = f"{IMAGE}@{digest}"
+    if pinned_ref != expected:
+        raise SystemExit(f"image lock pinned_ref must equal {expected}")
+    return pinned_ref
+
+
+def render_patch(pinned_ref: str) -> str:
+    return f"""apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search-orchestrator
+spec:
+  template:
+    spec:
+      containers:
+        - name: search-orchestrator
+          image: {pinned_ref}
+          imagePullPolicy: IfNotPresent
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render a digest-pinned Search Orchestrator deployment patch from an image lock")
+    parser.add_argument("--image-lock", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    pinned_ref = validate_lock(load_json(args.image_lock))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(render_patch(pinned_ref), encoding="utf-8")
+    print(f"wrote digest-pinned deployment patch to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_search_orchestrator_image_patch.py
+++ b/tools/tests/test_search_orchestrator_image_patch.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+
+from tools.render_search_orchestrator_image_patch import IMAGE, main
+
+
+def test_image_patch_renderer_writes_pinned_image(tmp_path, monkeypatch) -> None:
+    digest = "sha256:" + ("a" * 64)
+    lock_path = tmp_path / "lock.json"
+    output_path = tmp_path / "patch.yaml"
+    lock_path.write_text(
+        json.dumps(
+            {
+                "image": IMAGE,
+                "digest": digest,
+                "pinned_ref": IMAGE + "@" + digest,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("sys.argv", ["tool", "--image-lock", str(lock_path), "--output", str(output_path)])
+    assert main() == 0
+    rendered = output_path.read_text(encoding="utf-8")
+    assert "image: " + IMAGE + "@" + digest in rendered
+    assert "name: search-orchestrator" in rendered

--- a/tools/tests/test_search_orchestrator_image_patch.py
+++ b/tools/tests/test_search_orchestrator_image_patch.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
+import importlib.util
 import json
+from pathlib import Path
 
-from tools.render_search_orchestrator_image_patch import IMAGE, main
+MODULE_PATH = Path(__file__).resolve().parents[1] / "render_search_orchestrator_image_patch.py"
+SPEC = importlib.util.spec_from_file_location("render_search_orchestrator_image_patch", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+IMAGE = MODULE.IMAGE
+main = MODULE.main
 
 
 def test_image_patch_renderer_writes_pinned_image(tmp_path, monkeypatch) -> None:

--- a/tools/validate_search_orchestrator_academy_deploy.py
+++ b/tools/validate_search_orchestrator_academy_deploy.py
@@ -5,6 +5,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 REQUIRED = [
+    "services/search-orchestrator/Dockerfile",
+    ".github/workflows/search-orchestrator-image.yml",
+    "releases/images/search-orchestrator.image-lock.example.json",
+    "tools/render_search_orchestrator_image_patch.py",
+    "tools/validate_search_orchestrator_image_release.py",
     "infra/k8s/search-orchestrator/base/kustomization.yaml",
     "infra/k8s/search-orchestrator/base/deployment.yaml",
     "infra/k8s/search-orchestrator/base/service.yaml",
@@ -33,6 +38,32 @@ REQUIRED = [
 ]
 
 REQUIRED_TEXT = {
+    "services/search-orchestrator/Dockerfile": [
+        "FROM python:3.12-slim",
+        "USER 10001:10001",
+        "uvicorn",
+    ],
+    ".github/workflows/search-orchestrator-image.yml": [
+        "docker/build-push-action",
+        "ghcr.io/socioprophet/prophet-platform/search-orchestrator",
+        "steps.build.outputs.digest",
+        "search-orchestrator-image-evidence",
+    ],
+    "releases/images/search-orchestrator.image-lock.example.json": [
+        "search-orchestrator-image-lock-example",
+        "pinned_ref",
+        "sha256:REPLACE_WITH_IMAGE_DIGEST",
+    ],
+    "tools/render_search_orchestrator_image_patch.py": [
+        "Render a digest-pinned Search Orchestrator deployment patch",
+        "pinned_ref",
+        "Deployment",
+    ],
+    "tools/validate_search_orchestrator_image_release.py": [
+        "search-orchestrator image release artifacts validated",
+        "pinned_ref",
+        "digest form",
+    ],
     "infra/k8s/search-orchestrator/base/kustomization.yaml": [
         "serviceaccount-rbac.yaml",
         "pvc.yaml",
@@ -113,12 +144,16 @@ REQUIRED_TEXT = {
     "releases/evidence/search-orchestrator.academy-bridge.validation.record.json": [
         "test_debug_metrics.py",
         "networkpolicy.yaml",
+        "search-orchestrator-image.yml",
+        "search-orchestrator.image-lock.example.json",
         "SEARCH_ORCHESTRATOR_ACADEMY_BRIDGE_PRODUCTION_HARDENING.md",
         "SEARCH_ORCHESTRATOR_ACADEMY_BRIDGE_OBSERVABILITY.md",
     ],
     "releases/manifests/search-orchestrator.academy-bridge.manifest.json": [
         "networkpolicy.yaml",
         "test_debug_metrics.py",
+        "search-orchestrator-image.yml",
+        "search-orchestrator.image-lock.example.json",
         "SEARCH_ORCHESTRATOR_ACADEMY_BRIDGE_PRODUCTION_HARDENING.md",
         "SEARCH_ORCHESTRATOR_ACADEMY_BRIDGE_OBSERVABILITY.md",
     ],

--- a/tools/validate_search_orchestrator_image_release.py
+++ b/tools/validate_search_orchestrator_image_release.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED = [
+    "services/search-orchestrator/Dockerfile",
+    ".github/workflows/search-orchestrator-image.yml",
+    "releases/images/search-orchestrator.image-lock.example.json",
+]
+
+REQUIRED_TEXT = {
+    "services/search-orchestrator/Dockerfile": [
+        "FROM python:3.12-slim",
+        "USER 10001:10001",
+        "uvicorn",
+    ],
+    ".github/workflows/search-orchestrator-image.yml": [
+        "docker/build-push-action",
+        "ghcr.io/socioprophet/prophet-platform/search-orchestrator",
+        "steps.build.outputs.digest",
+        "search-orchestrator-image-evidence",
+    ],
+    "releases/images/search-orchestrator.image-lock.example.json": [
+        "search-orchestrator-image-lock-example",
+        "pinned_ref",
+        "sha256:REPLACE_WITH_IMAGE_DIGEST",
+    ],
+}
+
+
+def main() -> int:
+    for rel in REQUIRED:
+        path = ROOT / rel
+        if not path.exists():
+            raise SystemExit(f"missing required image artifact: {rel}")
+        if not path.read_text(encoding="utf-8").strip():
+            raise SystemExit(f"empty image artifact: {rel}")
+
+    for rel, terms in REQUIRED_TEXT.items():
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        for term in terms:
+            if term not in text:
+                raise SystemExit(f"{rel} missing required term {term}")
+
+    lock = json.loads((ROOT / "releases/images/search-orchestrator.image-lock.example.json").read_text(encoding="utf-8"))
+    if not str(lock.get("pinned_ref", "")).startswith("ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:"):
+        raise SystemExit("image lock pinned_ref must use digest form")
+
+    print("search-orchestrator image release artifacts validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds Search Orchestrator image build/publish and digest-pinning workflow support.

## Scope

- Adds `services/search-orchestrator/Dockerfile`
- Adds GHCR image build/publish workflow
- Emits image digest evidence on main pushes
- Adds image lock example with digest-pinned reference shape
- Adds renderer for digest-pinned deployment patches from image locks
- Adds renderer unit test
- Adds image release validator and wires it into `make validate`
- Links image workflow, image lock, and renderer into Academy bridge release manifest and validation evidence
- Extends Academy deployment validator to require image release artifacts

## Safety posture

- PR builds do not push images
- Main push publishes to GHCR with immutable SHA tag and digest evidence
- Production deployment remains digest-pinned through image lock/rendered patch workflow
- No runtime route behavior change
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback

## Program lane

Search Orchestrator Academy bridge image provenance and digest pinning.