### PR TITLE
Add Fog Stack release publication gate

### DIFF
--- a/.github/workflows/fogstack-manifest-promotion.yml
+++ b/.github/workflows/fogstack-manifest-promotion.yml
@@ -9,8 +9,10 @@ on:
       - "catalog/fogstack-support-states-v0.1.yaml"
       - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
       - "catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml"
+      - "catalog/fogstack-release-publication-gate-policy-v0.1.yaml"
       - "releases/manifests/**"
       - "schemas/release/fogstack-manifest-promotion-approval-record-v0.1.schema.json"
+      - "schemas/release/fogstack-release-publication-gate-record-v0.1.schema.json"
       - "tools/build_fogstack_manifest_publication_set.py"
       - "tools/promote_fogstack_manifest_publication_set.py"
       - "tools/check_fogstack_manifest_promotion_policy.py"
@@ -18,12 +20,14 @@ on:
       - "tools/emit_fogstack_manifest_promotion_approval_record.py"
       - "tools/check_fogstack_manifest_promotion_approval_record.py"
       - "tools/run_openssl_fogstack_manifest_promotion_approval_verifier.py"
+      - "tools/emit_fogstack_release_publication_gate_record.py"
       - "tools/tests/test_build_fogstack_manifest_publication_set.py"
       - "tools/tests/test_promote_fogstack_manifest_publication_set.py"
       - "tools/tests/test_check_fogstack_manifest_promotion_policy.py"
       - "tools/tests/test_check_fogstack_manifest_promotion_approver_policy.py"
       - "tools/tests/test_fogstack_manifest_promotion_approval_record.py"
       - "tools/tests/test_run_openssl_fogstack_manifest_promotion_approval_verifier.py"
+      - "tools/tests/test_emit_fogstack_release_publication_gate_record.py"
       - "docs/FOGSTACK_*.md"
       - ".github/workflows/fogstack-manifest-promotion.yml"
   push:
@@ -34,8 +38,10 @@ on:
       - "catalog/fogstack-support-states-v0.1.yaml"
       - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
       - "catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml"
+      - "catalog/fogstack-release-publication-gate-policy-v0.1.yaml"
       - "releases/manifests/**"
       - "schemas/release/fogstack-manifest-promotion-approval-record-v0.1.schema.json"
+      - "schemas/release/fogstack-release-publication-gate-record-v0.1.schema.json"
       - "tools/build_fogstack_manifest_publication_set.py"
       - "tools/promote_fogstack_manifest_publication_set.py"
       - "tools/check_fogstack_manifest_promotion_policy.py"
@@ -43,12 +49,14 @@ on:
       - "tools/emit_fogstack_manifest_promotion_approval_record.py"
       - "tools/check_fogstack_manifest_promotion_approval_record.py"
       - "tools/run_openssl_fogstack_manifest_promotion_approval_verifier.py"
+      - "tools/emit_fogstack_release_publication_gate_record.py"
       - "tools/tests/test_build_fogstack_manifest_publication_set.py"
       - "tools/tests/test_promote_fogstack_manifest_publication_set.py"
       - "tools/tests/test_check_fogstack_manifest_promotion_policy.py"
       - "tools/tests/test_check_fogstack_manifest_promotion_approver_policy.py"
       - "tools/tests/test_fogstack_manifest_promotion_approval_record.py"
       - "tools/tests/test_run_openssl_fogstack_manifest_promotion_approval_verifier.py"
+      - "tools/tests/test_emit_fogstack_release_publication_gate_record.py"
       - "docs/FOGSTACK_*.md"
       - ".github/workflows/fogstack-manifest-promotion.yml"
 
@@ -73,7 +81,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest pyyaml
 
-      - name: Run publication, promotion, policy, and approval tests
+      - name: Run publication, promotion, policy, approval, and gate tests
         run: |
           python -m pytest -q \
             tools/tests/test_build_fogstack_manifest_publication_set.py \
@@ -81,11 +89,12 @@ jobs:
             tools/tests/test_check_fogstack_manifest_promotion_policy.py \
             tools/tests/test_check_fogstack_manifest_promotion_approver_policy.py \
             tools/tests/test_fogstack_manifest_promotion_approval_record.py \
-            tools/tests/test_run_openssl_fogstack_manifest_promotion_approval_verifier.py
+            tools/tests/test_run_openssl_fogstack_manifest_promotion_approval_verifier.py \
+            tools/tests/test_emit_fogstack_release_publication_gate_record.py
 
       - name: Build canonical publication set
         run: |
-          mkdir -p artifacts/manifest-promotion/base artifacts/manifest-promotion/promoted artifacts/manifest-promotion/approval
+          mkdir -p artifacts/manifest-promotion/base artifacts/manifest-promotion/promoted artifacts/manifest-promotion/approval artifacts/manifest-promotion/gate
           python3 tools/build_fogstack_manifest_publication_set.py \
             --output-dir artifacts/manifest-promotion/base \
             --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
@@ -144,6 +153,26 @@ jobs:
             --public-key artifacts/manifest-promotion/approval/public.pem \
             --key-ref artifacts/manifest-promotion/approval/public.pem \
             --output artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.signature-verification.json
+
+      - name: Enforce release publication gate
+        run: |
+          cat > artifacts/manifest-promotion/gate/release-identity.json <<'JSON'
+          {
+            "kind": "FogStackReleaseIdentity",
+            "schema_version": "v0.1",
+            "id": "github-actions",
+            "issuer": "github-actions",
+            "subject": "SocioProphet/prophet-platform/.github/workflows/fogstack-manifest-promotion.yml"
+          }
+          JSON
+
+          python3 tools/emit_fogstack_release_publication_gate_record.py \
+            --publication-set artifacts/manifest-promotion/promoted/manifest-publication-set.json \
+            --approval-record artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.record.json \
+            --approval-signature-verification artifacts/manifest-promotion/approval/fogstack.manifest-promotion.approval.signature-verification.json \
+            --release-identity artifacts/manifest-promotion/gate/release-identity.json \
+            --policy-catalog catalog/fogstack-release-publication-gate-policy-v0.1.yaml \
+            --output artifacts/manifest-promotion/gate/fogstack.release-publication-gate.record.json
 
       - name: Upload promoted manifest set
         uses: actions/upload-artifact@v4

--- a/catalog/fogstack-release-publication-gate-policy-v0.1.yaml
+++ b/catalog/fogstack-release-publication-gate-policy-v0.1.yaml
@@ -1,0 +1,10 @@
+schema_version: "fogstack.release-publication-gate-policy/v0.1"
+kind: "FogStackReleasePublicationGatePolicy"
+requirements:
+  approval_status: "approved"
+  approval_signature_status: "pass"
+  require_release_identity: true
+allowed_release_identities:
+  - id: "github-actions"
+    issuer: "github-actions"
+    subject: "SocioProphet/prophet-platform/.github/workflows/fogstack-manifest-promotion.yml"

--- a/docs/FOGSTACK_RELEASE_PUBLICATION_GATE.md
+++ b/docs/FOGSTACK_RELEASE_PUBLICATION_GATE.md
@@ -1,0 +1,53 @@
+# Fog Stack release publication gate
+
+This document defines the repo-native publication gate for Fog Stack promoted manifest sets.
+
+## Goal
+
+Move from approved and signature-verified promotion to a final publication gate that verifies the promotion can be published by a permitted release identity.
+
+## Gate policy
+
+The gate policy lives at:
+- `catalog/fogstack-release-publication-gate-policy-v0.1.yaml`
+
+It currently requires:
+- approved promotion approval status
+- passing approval-signature verification
+- an allowed release identity
+
+## Gate record
+
+The gate record schema lives at:
+- `schemas/release/fogstack-release-publication-gate-record-v0.1.schema.json`
+
+The gate record captures:
+- publication set reference
+- approval record reference
+- approval-signature verification reference
+- release identity reference
+- pass/fail checks
+
+## Minimal flow
+
+1. build and promote the manifest publication set
+2. enforce promotion policy
+3. emit and verify the signed promotion approval record
+4. emit a release identity record
+5. evaluate the release publication gate with `tools/emit_fogstack_release_publication_gate_record.py`
+6. only publish the promoted manifest set if the gate passes
+
+## What this phase provides
+
+- explicit publication gate policy
+- release identity binding
+- gate record emission
+- CI enforcement in the manifest-promotion workflow
+
+## What this phase does not yet provide
+
+- registry publication of the gated artifact set
+- external identity-provider backed release identity
+- long-lived KMS/HSM-backed signing keys
+
+Those remain later steps.

--- a/schemas/release/fogstack-release-publication-gate-record-v0.1.schema.json
+++ b/schemas/release/fogstack-release-publication-gate-record-v0.1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-release-publication-gate-record-v0.1.schema.json",
+  "title": "FogStackReleasePublicationGateRecord",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "publication_set_ref",
+    "approval_record_ref",
+    "approval_signature_verification_ref",
+    "release_identity_ref",
+    "status",
+    "checks"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackReleasePublicationGateRecord" },
+    "schema_version": { "const": "v0.1" },
+    "publication_set_ref": { "type": "string" },
+    "approval_record_ref": { "type": "string" },
+    "approval_signature_verification_ref": { "type": "string" },
+    "release_identity_ref": { "type": "string" },
+    "status": { "enum": ["pass", "fail"] },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "status", "message"],
+        "properties": {
+          "id": { "type": "string" },
+          "status": { "enum": ["pass", "fail"] },
+          "message": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/emit_fogstack_release_publication_gate_record.py
+++ b/tools/emit_fogstack_release_publication_gate_record.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def record(checks: list[dict[str, str]], rule_id: str, status: str, message: str) -> None:
+    checks.append({"id": rule_id, "status": status, "message": message})
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Evaluate the Fog Stack release publication gate")
+    parser.add_argument("--publication-set", required=True, type=Path)
+    parser.add_argument("--approval-record", required=True, type=Path)
+    parser.add_argument("--approval-signature-verification", required=True, type=Path)
+    parser.add_argument("--release-identity", required=True, type=Path)
+    parser.add_argument("--policy-catalog", required=True, type=Path)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    publication = load_json(args.publication_set)
+    approval = load_json(args.approval_record)
+    sig_verify = load_json(args.approval_signature_verification)
+    identity = load_json(args.release_identity)
+    policy = yaml.safe_load(args.policy_catalog.read_text(encoding="utf-8")) or {}
+    requirements = policy.get("requirements") or {}
+
+    checks: list[dict[str, str]] = []
+
+    expected_status = requirements.get("approval_status", "approved")
+    if approval.get("status") == expected_status:
+        record(checks, "PUBGATE-001", "pass", "approval status matches policy")
+    else:
+        record(checks, "PUBGATE-001", "fail", "approval status does not match policy")
+
+    expected_sig_status = requirements.get("approval_signature_status", "pass")
+    if sig_verify.get("status") == expected_sig_status:
+        record(checks, "PUBGATE-002", "pass", "approval signature verification passed")
+    else:
+        record(checks, "PUBGATE-002", "fail", "approval signature verification did not pass")
+
+    if requirements.get("require_release_identity", True):
+        allowed = policy.get("allowed_release_identities") or []
+        identity_tuple = (identity.get("id"), identity.get("issuer"), identity.get("subject"))
+        allowed_tuples = {
+            (item.get("id"), item.get("issuer"), item.get("subject"))
+            for item in allowed
+            if isinstance(item, dict)
+        }
+        if identity_tuple in allowed_tuples:
+            record(checks, "PUBGATE-003", "pass", "release identity is allowed")
+        else:
+            record(checks, "PUBGATE-003", "fail", "release identity is not allowed")
+
+    if publication.get("kind") == "FogStackManifestPublicationSet":
+        record(checks, "PUBGATE-004", "pass", "publication set kind is valid")
+    else:
+        record(checks, "PUBGATE-004", "fail", "publication set kind is invalid")
+
+    status = "fail" if any(item["status"] == "fail" for item in checks) else "pass"
+    gate = {
+        "kind": "FogStackReleasePublicationGateRecord",
+        "schema_version": "v0.1",
+        "publication_set_ref": str(args.publication_set),
+        "approval_record_ref": str(args.approval_record),
+        "approval_signature_verification_ref": str(args.approval_signature_verification),
+        "release_identity_ref": str(args.release_identity),
+        "status": status,
+        "checks": checks,
+    }
+
+    text = json.dumps(gate, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0 if status == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_emit_fogstack_release_publication_gate_record.py
+++ b/tools/tests/test_emit_fogstack_release_publication_gate_record.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_policy(path: Path) -> None:
+    path.write_text(
+        'schema_version: "fogstack.release-publication-gate-policy/v0.1"\n'
+        'kind: "FogStackReleasePublicationGatePolicy"\n'
+        'requirements:\n'
+        '  approval_status: "approved"\n'
+        '  approval_signature_status: "pass"\n'
+        '  require_release_identity: true\n'
+        'allowed_release_identities:\n'
+        '  - id: "github-actions"\n'
+        '    issuer: "github-actions"\n'
+        '    subject: "SocioProphet/prophet-platform/.github/workflows/fogstack-manifest-promotion.yml"\n',
+        encoding="utf-8",
+    )
+
+
+def test_release_publication_gate_allows_valid_inputs(tmp_path: Path) -> None:
+    publication = tmp_path / "manifest-publication-set.json"
+    approval = tmp_path / "approval.record.json"
+    sig_verify = tmp_path / "approval.signature-verification.json"
+    identity = tmp_path / "release-identity.json"
+    policy = tmp_path / "publication-gate-policy.yaml"
+    output = tmp_path / "publication-gate.record.json"
+
+    _write_json(publication, {
+        "kind": "FogStackManifestPublicationSet",
+        "schema_version": "v0.1",
+        "manifests": [],
+    })
+    _write_json(approval, {
+        "kind": "FogStackManifestPromotionApprovalRecord",
+        "status": "approved",
+    })
+    _write_json(sig_verify, {
+        "kind": "FogStackManifestPromotionApprovalSignatureVerification",
+        "status": "pass",
+    })
+    _write_json(identity, {
+        "kind": "FogStackReleaseIdentity",
+        "schema_version": "v0.1",
+        "id": "github-actions",
+        "issuer": "github-actions",
+        "subject": "SocioProphet/prophet-platform/.github/workflows/fogstack-manifest-promotion.yml",
+    })
+    _write_policy(policy)
+
+    subprocess.run([
+        sys.executable,
+        "tools/emit_fogstack_release_publication_gate_record.py",
+        "--publication-set", str(publication),
+        "--approval-record", str(approval),
+        "--approval-signature-verification", str(sig_verify),
+        "--release-identity", str(identity),
+        "--policy-catalog", str(policy),
+        "--output", str(output),
+    ], check=True)
+
+    gate = json.loads(output.read_text(encoding="utf-8"))
+    assert gate["kind"] == "FogStackReleasePublicationGateRecord"
+    assert gate["status"] == "pass"
+    assert all(check["status"] == "pass" for check in gate["checks"])
+
+
+def test_release_publication_gate_rejects_bad_identity(tmp_path: Path) -> None:
+    publication = tmp_path / "manifest-publication-set.json"
+    approval = tmp_path / "approval.record.json"
+    sig_verify = tmp_path / "approval.signature-verification.json"
+    identity = tmp_path / "release-identity.json"
+    policy = tmp_path / "publication-gate-policy.yaml"
+
+    _write_json(publication, {"kind": "FogStackManifestPublicationSet"})
+    _write_json(approval, {"status": "approved"})
+    _write_json(sig_verify, {"status": "pass"})
+    _write_json(identity, {
+        "id": "unknown",
+        "issuer": "github-actions",
+        "subject": "SocioProphet/prophet-platform/.github/workflows/fogstack-manifest-promotion.yml",
+    })
+    _write_policy(policy)
+
+    proc = subprocess.run([
+        sys.executable,
+        "tools/emit_fogstack_release_publication_gate_record.py",
+        "--publication-set", str(publication),
+        "--approval-record", str(approval),
+        "--approval-signature-verification", str(sig_verify),
+        "--release-identity", str(identity),
+        "--policy-catalog", str(policy),
+    ])
+    assert proc.returncode != 0


### PR DESCRIPTION
## Summary

This PR adds the final release-publication gate tranche directly on top of current `main`:

- `catalog/fogstack-release-publication-gate-policy-v0.1.yaml`
- `schemas/release/fogstack-release-publication-gate-record-v0.1.schema.json`
- `tools/emit_fogstack_release_publication_gate_record.py`
- `tools/tests/test_emit_fogstack_release_publication_gate_record.py`
- updated `.github/workflows/fogstack-manifest-promotion.yml`
- `docs/FOGSTACK_RELEASE_PUBLICATION_GATE.md`

## Why this PR exists

The repo now has:
- policy-enforced promotion
- approval-bound promotion
- cryptographically verified approval signatures

What is still missing is the final publication gate that binds the promoted set, approval record, approval-signature verification, and release identity into one pass/fail gate record.

This PR adds that gate and enforces it in the manifest-promotion workflow.

## Not in this PR

- registry publication of the gated artifact set
- external identity-provider backed release identity
- long-lived KMS/HSM-backed signing keys

Those remain later steps.
