### PR TITLE
Add Fog Stack registry publication index

### DIFF
--- a/.github/workflows/fogstack-registry-publication.yml
+++ b/.github/workflows/fogstack-registry-publication.yml
@@ -1,0 +1,138 @@
+name: FogStack Registry Publication
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "catalog/fogstack-release-publication-gate-policy-v0.1.yaml"
+      - "releases/manifests/**"
+      - "schemas/release/fogstack-registry-publication-index-v0.1.schema.json"
+      - "tools/build_fogstack_registry_publication_index.py"
+      - "tools/check_fogstack_registry_publication_index.py"
+      - "tools/tests/test_fogstack_registry_publication_index.py"
+      - "docs/FOGSTACK_*.md"
+      - ".github/workflows/fogstack-registry-publication.yml"
+  push:
+    branches: [main]
+    paths:
+      - "catalog/fogstack-release-publication-gate-policy-v0.1.yaml"
+      - "releases/manifests/**"
+      - "schemas/release/fogstack-registry-publication-index-v0.1.schema.json"
+      - "tools/build_fogstack_registry_publication_index.py"
+      - "tools/check_fogstack_registry_publication_index.py"
+      - "tools/tests/test_fogstack_registry_publication_index.py"
+      - "docs/FOGSTACK_*.md"
+      - ".github/workflows/fogstack-registry-publication.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  registry-publication:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml
+
+      - name: Run registry publication tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_registry_publication_index.py
+
+      - name: Build registry-ready publication inputs
+        run: |
+          mkdir -p artifacts/registry-publication/promoted/manifests artifacts/registry-publication/gate
+
+          cp releases/manifests/fogstack.access-v0.1.manifest.json artifacts/registry-publication/promoted/manifests/fogstack.access-v0.1.manifest.json
+          cp releases/manifests/fogstack.knowledge-v0.1.manifest.json artifacts/registry-publication/promoted/manifests/fogstack.knowledge-v0.1.manifest.json
+          cp releases/manifests/fogstack.evaluation-v0.1.manifest.json artifacts/registry-publication/promoted/manifests/fogstack.evaluation-v0.1.manifest.json
+
+          cat > artifacts/registry-publication/promoted/manifest-publication-set.json <<'JSON'
+          {
+            "kind": "FogStackManifestPublicationSet",
+            "schema_version": "v0.1",
+            "promotion": {
+              "channel": "candidate",
+              "support_state": "supported"
+            },
+            "manifests": [
+              {
+                "bundle_id": "fogstack.access",
+                "version": "0.1.0",
+                "ref": "artifacts/registry-publication/promoted/manifests/fogstack.access-v0.1.manifest.json",
+                "signed": false,
+                "channel": "candidate",
+                "support_state": "supported"
+              },
+              {
+                "bundle_id": "fogstack.knowledge",
+                "version": "0.1.0",
+                "ref": "artifacts/registry-publication/promoted/manifests/fogstack.knowledge-v0.1.manifest.json",
+                "signed": false,
+                "channel": "candidate",
+                "support_state": "supported"
+              },
+              {
+                "bundle_id": "fogstack.evaluation",
+                "version": "0.1.0",
+                "ref": "artifacts/registry-publication/promoted/manifests/fogstack.evaluation-v0.1.manifest.json",
+                "signed": false,
+                "channel": "candidate",
+                "support_state": "supported"
+              }
+            ]
+          }
+          JSON
+
+          cat > artifacts/registry-publication/gate/publication-gate.record.json <<'JSON'
+          {
+            "kind": "FogStackReleasePublicationGateRecord",
+            "schema_version": "v0.1",
+            "publication_set_ref": "artifacts/registry-publication/promoted/manifest-publication-set.json",
+            "approval_record_ref": "artifacts/registry-publication/gate/approval.record.json",
+            "approval_signature_verification_ref": "artifacts/registry-publication/gate/approval.signature-verification.json",
+            "release_identity_ref": "artifacts/registry-publication/gate/release-identity.json",
+            "status": "pass",
+            "checks": [
+              {"id": "PUBGATE-001", "status": "pass", "message": "approval status matches policy"},
+              {"id": "PUBGATE-002", "status": "pass", "message": "approval signature verification passed"},
+              {"id": "PUBGATE-003", "status": "pass", "message": "release identity is allowed"},
+              {"id": "PUBGATE-004", "status": "pass", "message": "publication set kind is valid"}
+            ]
+          }
+          JSON
+
+      - name: Build registry publication index
+        run: |
+          python3 tools/build_fogstack_registry_publication_index.py \
+            --registry-uri artifact://ci/fogstack-registry \
+            --publication-set artifacts/registry-publication/promoted/manifest-publication-set.json \
+            --publication-gate-record artifacts/registry-publication/gate/publication-gate.record.json \
+            --artifact manifest-publication-set artifacts/registry-publication/promoted/manifest-publication-set.json \
+            --artifact publication-gate-record artifacts/registry-publication/gate/publication-gate.record.json \
+            --artifact manifest-access artifacts/registry-publication/promoted/manifests/fogstack.access-v0.1.manifest.json \
+            --artifact manifest-knowledge artifacts/registry-publication/promoted/manifests/fogstack.knowledge-v0.1.manifest.json \
+            --artifact manifest-evaluation artifacts/registry-publication/promoted/manifests/fogstack.evaluation-v0.1.manifest.json \
+            --output artifacts/registry-publication/fogstack-registry-publication.index.json
+
+      - name: Check registry publication index
+        run: |
+          python3 tools/check_fogstack_registry_publication_index.py \
+            --index artifacts/registry-publication/fogstack-registry-publication.index.json
+
+      - name: Upload registry publication artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fogstack-registry-publication
+          path: artifacts/registry-publication/
+          if-no-files-found: error

--- a/docs/FOGSTACK_REGISTRY_PUBLICATION.md
+++ b/docs/FOGSTACK_REGISTRY_PUBLICATION.md
@@ -1,0 +1,48 @@
+# Fog Stack registry publication
+
+This document defines the first repo-native registry-ready publication surface for Fog Stack.
+
+## Goal
+
+Move from gated promotion artifacts in CI to a registry publication index that can be consumed by a future registry or distribution plane.
+
+## Registry publication index
+
+The registry publication index schema lives at:
+- `schemas/release/fogstack-registry-publication-index-v0.1.schema.json`
+
+The index records:
+- registry URI
+- promoted manifest publication set reference and digest
+- release publication gate record reference and digest
+- artifact references and digests
+
+## Minimal flow
+
+1. build or collect a promoted manifest publication set
+2. require a passing release publication gate record
+3. run `tools/build_fogstack_registry_publication_index.py`
+4. check the resulting index with `tools/check_fogstack_registry_publication_index.py`
+5. upload or publish the index and referenced artifacts
+
+## Current CI boundary
+
+The current workflow emits a registry-ready artifact set as a GitHub Actions artifact. It does not yet publish to an external registry.
+
+The workflow uses a synthetic passing publication gate record for the registry-index smoke path. The stricter promotion workflow is responsible for producing real policy, approval, signature, and gate artifacts. A future tranche should compose those workflow outputs directly rather than reconstructing a gate fixture.
+
+## What this phase provides
+
+- typed registry publication index
+- builder and checker helpers
+- CI artifact publication for the registry-ready set
+- digest checks for all indexed artifacts
+
+## What this phase does not yet provide
+
+- external registry publication
+- promotion workflow artifact handoff into the registry workflow
+- registry authentication or publication credentials
+- revocation or rollback index publication
+
+Those remain later steps.

--- a/schemas/release/fogstack-registry-publication-index-v0.1.schema.json
+++ b/schemas/release/fogstack-registry-publication-index-v0.1.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-registry-publication-index-v0.1.schema.json",
+  "title": "FogStackRegistryPublicationIndex",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "registry_uri",
+    "publication_set_ref",
+    "publication_set_digest",
+    "publication_gate_record_ref",
+    "publication_gate_record_digest",
+    "artifacts"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackRegistryPublicationIndex" },
+    "schema_version": { "const": "v0.1" },
+    "registry_uri": { "type": "string" },
+    "publication_set_ref": { "type": "string" },
+    "publication_set_digest": { "type": "string" },
+    "publication_gate_record_ref": { "type": "string" },
+    "publication_gate_record_digest": { "type": "string" },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "ref", "digest"],
+        "properties": {
+          "kind": { "type": "string" },
+          "ref": { "type": "string" },
+          "digest": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "notes": { "type": ["string", "null"] }
+  },
+  "additionalProperties": false
+}

--- a/tools/build_fogstack_registry_publication_index.py
+++ b/tools/build_fogstack_registry_publication_index.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a Fog Stack registry publication index")
+    parser.add_argument("--registry-uri", required=True)
+    parser.add_argument("--publication-set", required=True, type=Path)
+    parser.add_argument("--publication-gate-record", required=True, type=Path)
+    parser.add_argument("--artifact", action="append", nargs=2, metavar=("KIND", "PATH"), required=True)
+    parser.add_argument("--notes", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    publication_set = load_json(args.publication_set)
+    if publication_set.get("kind") != "FogStackManifestPublicationSet":
+        raise SystemExit("ERR: publication set kind mismatch")
+
+    gate = load_json(args.publication_gate_record)
+    if gate.get("kind") != "FogStackReleasePublicationGateRecord":
+        raise SystemExit("ERR: publication gate record kind mismatch")
+    if gate.get("status") != "pass":
+        raise SystemExit("ERR: publication gate did not pass")
+
+    artifacts = []
+    for kind, path_str in args.artifact:
+        path = Path(path_str)
+        artifacts.append({"kind": kind, "ref": str(path), "digest": sha256_file(path)})
+
+    index = {
+        "kind": "FogStackRegistryPublicationIndex",
+        "schema_version": "v0.1",
+        "registry_uri": args.registry_uri,
+        "publication_set_ref": str(args.publication_set),
+        "publication_set_digest": sha256_file(args.publication_set),
+        "publication_gate_record_ref": str(args.publication_gate_record),
+        "publication_gate_record_digest": sha256_file(args.publication_gate_record),
+        "artifacts": artifacts,
+        "notes": args.notes,
+    }
+
+    text = json.dumps(index, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_fogstack_registry_publication_index.py
+++ b/tools/check_fogstack_registry_publication_index.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check a Fog Stack registry publication index")
+    parser.add_argument("--index", required=True, type=Path)
+    args = parser.parse_args()
+
+    index = load_json(args.index)
+    errors = []
+
+    if index.get("kind") != "FogStackRegistryPublicationIndex":
+        errors.append("index kind mismatch")
+    if not index.get("registry_uri"):
+        errors.append("registry_uri is required")
+
+    pub_ref = index.get("publication_set_ref")
+    pub_digest = index.get("publication_set_digest")
+    if isinstance(pub_ref, str) and Path(pub_ref).exists():
+        if sha256_file(Path(pub_ref)) != pub_digest:
+            errors.append("publication set digest mismatch")
+    else:
+        errors.append("publication_set_ref missing or not found")
+
+    gate_ref = index.get("publication_gate_record_ref")
+    gate_digest = index.get("publication_gate_record_digest")
+    if isinstance(gate_ref, str) and Path(gate_ref).exists():
+        gate = load_json(Path(gate_ref))
+        if gate.get("status") != "pass":
+            errors.append("publication gate status is not pass")
+        if sha256_file(Path(gate_ref)) != gate_digest:
+            errors.append("publication gate record digest mismatch")
+    else:
+        errors.append("publication_gate_record_ref missing or not found")
+
+    artifacts = index.get("artifacts") or []
+    if not isinstance(artifacts, list) or not artifacts:
+        errors.append("artifacts list is missing or empty")
+    else:
+        for artifact in artifacts:
+            ref = artifact.get("ref") if isinstance(artifact, dict) else None
+            digest = artifact.get("digest") if isinstance(artifact, dict) else None
+            if not isinstance(ref, str) or not Path(ref).exists():
+                errors.append(f"artifact ref missing or not found: {ref}")
+                continue
+            if sha256_file(Path(ref)) != digest:
+                errors.append(f"artifact digest mismatch: {ref}")
+
+    if errors:
+        for item in errors:
+            print(item)
+        return 1
+
+    print("FogStack registry publication index passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_registry_publication_index.py
+++ b/tools/tests/test_fogstack_registry_publication_index.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_and_check_registry_publication_index(tmp_path: Path) -> None:
+    publication_set = tmp_path / "manifest-publication-set.json"
+    gate_record = tmp_path / "publication-gate.record.json"
+    manifest = tmp_path / "fogstack.access-v0.1.manifest.json"
+    index = tmp_path / "registry-publication.index.json"
+
+    _write_json(publication_set, {
+        "kind": "FogStackManifestPublicationSet",
+        "schema_version": "v0.1",
+        "manifests": [
+            {"bundle_id": "fogstack.access", "version": "0.1.0", "ref": str(manifest), "signed": False}
+        ],
+    })
+    _write_json(gate_record, {
+        "kind": "FogStackReleasePublicationGateRecord",
+        "schema_version": "v0.1",
+        "status": "pass",
+        "checks": [],
+    })
+    _write_json(manifest, {
+        "kind": "FogStackBundleManifest",
+        "schema_version": "v0.1",
+        "bundle_id": "fogstack.access",
+        "version": "0.1.0",
+    })
+
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_registry_publication_index.py",
+        "--registry-uri", "artifact://ci/fogstack-registry",
+        "--publication-set", str(publication_set),
+        "--publication-gate-record", str(gate_record),
+        "--artifact", "manifest", str(manifest),
+        "--output", str(index),
+    ], check=True)
+
+    data = json.loads(index.read_text(encoding="utf-8"))
+    assert data["kind"] == "FogStackRegistryPublicationIndex"
+    assert data["registry_uri"] == "artifact://ci/fogstack-registry"
+    assert data["publication_set_digest"].startswith("sha256:")
+    assert data["publication_gate_record_digest"].startswith("sha256:")
+    assert data["artifacts"][0]["digest"].startswith("sha256:")
+
+    subprocess.run([
+        sys.executable,
+        "tools/check_fogstack_registry_publication_index.py",
+        "--index", str(index),
+    ], check=True)
+
+
+def test_check_registry_publication_index_rejects_failed_gate(tmp_path: Path) -> None:
+    publication_set = tmp_path / "manifest-publication-set.json"
+    gate_record = tmp_path / "publication-gate.record.json"
+    artifact = tmp_path / "artifact.json"
+    index = tmp_path / "registry-publication.index.json"
+
+    _write_json(publication_set, {"kind": "FogStackManifestPublicationSet", "schema_version": "v0.1", "manifests": []})
+    _write_json(gate_record, {"kind": "FogStackReleasePublicationGateRecord", "status": "fail", "checks": []})
+    _write_json(artifact, {"kind": "Artifact"})
+
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_registry_publication_index.py",
+        "--registry-uri", "artifact://ci/fogstack-registry",
+        "--publication-set", str(publication_set),
+        "--publication-gate-record", str(gate_record),
+        "--artifact", "artifact", str(artifact),
+        "--output", str(index),
+    ], check=False)
+
+    # Builder must reject a failed publication gate and avoid producing a usable index.
+    assert not index.exists()


### PR DESCRIPTION
## Summary

Adds the first registry-ready Fog Stack release index surface:

- registry publication index schema
- index builder and checker helpers
- tests
- CI workflow that emits a registry-ready artifact bundle
- documentation

This is an artifact-index tranche. It does not connect to an external distribution service.
