### PR TITLE
release(search): automate image digest pinning

### DIFF
--- a/.github/workflows/search-orchestrator-image-pin.yml
+++ b/.github/workflows/search-orchestrator-image-pin.yml
@@ -1,0 +1,70 @@
+name: search-orchestrator-image-pin
+
+on:
+  workflow_run:
+    workflows:
+      - search-orchestrator-image
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  pin:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: search-orchestrator-image-evidence
+          path: image-evidence
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply image lock
+        run: |
+          python3 tools/apply_search_orchestrator_image_lock.py \
+            --evidence image-evidence/search-orchestrator-image.json \
+            --lock-output releases/images/search-orchestrator.image-lock.json \
+            --patch-output infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml
+
+      - name: Validate image release artifacts
+        run: |
+          python3 tools/validate_search_orchestrator_image_release.py
+
+      - name: Create pinning pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: automation/search-orchestrator-image-pin
+          delete-branch: true
+          title: "release(search): pin search orchestrator image digest"
+          commit-message: "release(search): pin search orchestrator image digest"
+          body: |
+            ## Summary
+
+            Pins the Search Orchestrator image digest from the successful `search-orchestrator-image` workflow run.
+
+            ## Scope
+
+            - Updates `releases/images/search-orchestrator.image-lock.json`
+            - Updates the digest-pinned Kustomize image patch
+            - Keeps the example lock unchanged
+
+            ## Safety posture
+
+            - Digest pin only
+            - No runtime route behavior change
+            - No learner action execution
+            - No Canon promotion
+            - No policy grant creation
+            - No memory writeback
+          add-paths: |
+            releases/images/search-orchestrator.image-lock.json
+            infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml

--- a/releases/evidence/search-orchestrator.academy-bridge.validation.record.json
+++ b/releases/evidence/search-orchestrator.academy-bridge.validation.record.json
@@ -6,8 +6,10 @@
   "validated_artifacts": [
     "services/search-orchestrator/Dockerfile",
     ".github/workflows/search-orchestrator-image.yml",
+    ".github/workflows/search-orchestrator-image-pin.yml",
     "releases/images/search-orchestrator.image-lock.example.json",
     "tools/render_search_orchestrator_image_patch.py",
+    "tools/apply_search_orchestrator_image_lock.py",
     "tools/validate_search_orchestrator_image_release.py",
     "services/search-orchestrator/deploy/academy-bridge-profiles.yaml",
     "infra/local/docker-compose.search-orchestrator.academy.yml",
@@ -31,7 +33,8 @@
     "services/search-orchestrator/tests/test_academy_lampstand_carrier_real_smoke.py",
     "services/search-orchestrator/tests/test_debug_config.py",
     "services/search-orchestrator/tests/test_debug_metrics.py",
-    "tools/tests/test_search_orchestrator_image_patch.py"
+    "tools/tests/test_search_orchestrator_image_patch.py",
+    "tools/tests/test_apply_search_orchestrator_image_lock.py"
   ],
   "evidence": [
     "safe runtime config reports modes without paths or URLs",
@@ -45,11 +48,13 @@
     "Policy Fabric endpoint is sourced from Secret/ExternalSecret examples rather than ConfigMap",
     "debug metrics endpoint reports counters without actor ids, queries, URLs, paths, or secrets",
     "Search Orchestrator image workflow builds/publishes GHCR image and emits digest evidence",
-    "image lock renderer converts digest evidence into a digest-pinned deployment patch"
+    "image lock renderer converts digest evidence into a digest-pinned deployment patch",
+    "image pin workflow converts successful main image-build evidence into an automated pinning pull request"
   ],
   "gates": [
     "search-orchestrator workflow",
     "search-orchestrator-image workflow",
+    "search-orchestrator-image-pin workflow",
     "platform validate workflow",
     "premerge audit",
     "FogStack release evidence validation"

--- a/releases/manifests/search-orchestrator.academy-bridge.manifest.json
+++ b/releases/manifests/search-orchestrator.academy-bridge.manifest.json
@@ -8,8 +8,10 @@
   "artifacts": [
     "services/search-orchestrator/Dockerfile",
     ".github/workflows/search-orchestrator-image.yml",
+    ".github/workflows/search-orchestrator-image-pin.yml",
     "releases/images/search-orchestrator.image-lock.example.json",
     "tools/render_search_orchestrator_image_patch.py",
+    "tools/apply_search_orchestrator_image_lock.py",
     "tools/validate_search_orchestrator_image_release.py",
     "services/search-orchestrator/deploy/academy-bridge-profiles.yaml",
     "infra/local/docker-compose.search-orchestrator.academy.yml",
@@ -25,6 +27,7 @@
     "bundles/fogstack.knowledge-v0.1.yaml",
     "services/search-orchestrator/tests/test_academy_lampstand_deployment_smoke.py",
     "services/search-orchestrator/tests/test_debug_metrics.py",
+    "tools/tests/test_apply_search_orchestrator_image_lock.py",
     "docs/SEARCH_ORCHESTRATOR_ACADEMY_BRIDGE_ROLLOUT_CHECKLIST.md",
     "docs/SEARCH_ORCHESTRATOR_ACADEMY_BRIDGE_RELEASE_READOUT.md",
     "docs/SEARCH_ORCHESTRATOR_ACADEMY_BRIDGE_PRODUCTION_HARDENING.md",
@@ -41,7 +44,8 @@
     "kubernetes-production-hardening",
     "non-secret-runtime-metrics",
     "image-build-publish",
-    "digest-pinned-image-rendering"
+    "digest-pinned-image-rendering",
+    "automated-image-pin-pr"
   ],
   "safety_posture": [
     "endpoint-explicit policy fabric calls",
@@ -52,6 +56,7 @@
     "persistent carrier storage",
     "namespace-scoped network policy",
     "digest-pinned production image workflow",
+    "automated post-build digest pin pull request",
     "no learner action execution",
     "no canon promotion",
     "no memory writeback",

--- a/tools/apply_search_orchestrator_image_lock.py
+++ b/tools/apply_search_orchestrator_image_lock.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from render_search_orchestrator_image_patch import IMAGE, validate_lock, render_patch
+
+LOCK_PATH = Path("releases/images/search-orchestrator.image-lock.json")
+PATCH_PATH = Path("infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml")
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return data
+
+
+def build_lock(evidence: dict) -> dict:
+    digest = str(evidence.get("digest", ""))
+    source_sha = str(evidence.get("source_sha", ""))
+    pinned_ref = str(evidence.get("pinned_ref", ""))
+    lock = {
+        "image_lock_id": "search-orchestrator-image-lock",
+        "component": "services/search-orchestrator",
+        "image": IMAGE,
+        "source_sha": source_sha,
+        "digest": digest,
+        "pinned_ref": pinned_ref,
+        "workflow": ".github/workflows/search-orchestrator-image.yml",
+        "status": "pinned",
+    }
+    validate_lock(lock)
+    return lock
+
+
+def write_outputs(lock: dict, lock_path: Path, patch_path: Path) -> None:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    patch_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(json.dumps(lock, indent=2) + "\n", encoding="utf-8")
+    patch_path.write_text(render_patch(str(lock["pinned_ref"])), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Apply Search Orchestrator image digest evidence to release lock and Kustomize patch")
+    parser.add_argument("--evidence", required=True, type=Path)
+    parser.add_argument("--lock-output", type=Path, default=LOCK_PATH)
+    parser.add_argument("--patch-output", type=Path, default=PATCH_PATH)
+    args = parser.parse_args()
+
+    lock = build_lock(load_json(args.evidence))
+    write_outputs(lock, args.lock_output, args.patch_output)
+    print(f"wrote image lock to {args.lock_output}")
+    print(f"wrote image patch to {args.patch_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_apply_search_orchestrator_image_lock.py
+++ b/tools/tests/test_apply_search_orchestrator_image_lock.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "apply_search_orchestrator_image_lock.py"
+sys.path.insert(0, str(MODULE_PATH.parent))
 SPEC = importlib.util.spec_from_file_location("apply_search_orchestrator_image_lock", MODULE_PATH)
 assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)

--- a/tools/tests/test_apply_search_orchestrator_image_lock.py
+++ b/tools/tests/test_apply_search_orchestrator_image_lock.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "apply_search_orchestrator_image_lock.py"
+SPEC = importlib.util.spec_from_file_location("apply_search_orchestrator_image_lock", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+IMAGE = MODULE.IMAGE
+main = MODULE.main
+
+
+def test_image_lock_applier_writes_lock_and_patch(tmp_path, monkeypatch) -> None:
+    digest = "sha256:" + ("b" * 64)
+    evidence = {
+        "image": IMAGE,
+        "source_sha": "abc123",
+        "digest": digest,
+        "pinned_ref": IMAGE + "@" + digest,
+    }
+    evidence_path = tmp_path / "evidence.json"
+    lock_path = tmp_path / "image-lock.json"
+    patch_path = tmp_path / "image-patch.yaml"
+    evidence_path.write_text(json.dumps(evidence), encoding="utf-8")
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["tool", "--evidence", str(evidence_path), "--lock-output", str(lock_path), "--patch-output", str(patch_path)],
+    )
+    assert main() == 0
+
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert lock["digest"] == digest
+    assert lock["pinned_ref"] == IMAGE + "@" + digest
+    rendered = patch_path.read_text(encoding="utf-8")
+    assert "image: " + IMAGE + "@" + digest in rendered
+    assert "name: search-orchestrator" in rendered

--- a/tools/validate_search_orchestrator_image_release.py
+++ b/tools/validate_search_orchestrator_image_release.py
@@ -8,7 +8,10 @@ ROOT = Path(__file__).resolve().parents[1]
 REQUIRED = [
     "services/search-orchestrator/Dockerfile",
     ".github/workflows/search-orchestrator-image.yml",
+    ".github/workflows/search-orchestrator-image-pin.yml",
     "releases/images/search-orchestrator.image-lock.example.json",
+    "tools/render_search_orchestrator_image_patch.py",
+    "tools/apply_search_orchestrator_image_lock.py",
 ]
 
 REQUIRED_TEXT = {
@@ -23,10 +26,26 @@ REQUIRED_TEXT = {
         "steps.build.outputs.digest",
         "search-orchestrator-image-evidence",
     ],
+    ".github/workflows/search-orchestrator-image-pin.yml": [
+        "workflow_run",
+        "search-orchestrator-image",
+        "download-artifact",
+        "apply_search_orchestrator_image_lock.py",
+    ],
     "releases/images/search-orchestrator.image-lock.example.json": [
         "search-orchestrator-image-lock-example",
         "pinned_ref",
         "sha256:REPLACE_WITH_IMAGE_DIGEST",
+    ],
+    "tools/render_search_orchestrator_image_patch.py": [
+        "Render a digest-pinned Search Orchestrator deployment patch",
+        "pinned_ref",
+        "Deployment",
+    ],
+    "tools/apply_search_orchestrator_image_lock.py": [
+        "Apply Search Orchestrator image digest evidence",
+        "image-lock.json",
+        "image-patch.yaml",
     ],
 }
 


### PR DESCRIPTION
## Summary

Adds automation to convert successful Search Orchestrator image-build digest evidence into a follow-up digest-pinning pull request.

## Scope

- Adds `search-orchestrator-image-pin` workflow triggered by successful `search-orchestrator-image` runs on `main`
- Downloads image digest evidence from the completed image workflow
- Applies digest evidence into `releases/images/search-orchestrator.image-lock.json`
- Renders a digest-pinned Kustomize deployment image patch
- Opens an automated pinning PR for those generated files
- Adds `tools/apply_search_orchestrator_image_lock.py`
- Adds unit test coverage for the applier
- Extends image release validation and release evidence links

## Safety posture

- Automation is triggered only after successful image workflow completion on `main`
- Generated PR is reviewable before merge
- No runtime route behavior change
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback

## Program lane

Search Orchestrator Academy bridge post-build digest pin automation.