### PR TITLE
Add Fog Stack filesystem registry adapter

### DIFF
--- a/.github/workflows/fogstack-filesystem-registry.yml
+++ b/.github/workflows/fogstack-filesystem-registry.yml
@@ -1,0 +1,112 @@
+name: FogStack Filesystem Registry
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "schemas/release/fogstack-registry-publication-index-v0.1.schema.json"
+      - "tools/build_fogstack_registry_publication_index.py"
+      - "tools/check_fogstack_registry_publication_index.py"
+      - "tools/publish_fogstack_filesystem_registry.py"
+      - "tools/check_fogstack_filesystem_registry.py"
+      - "tools/tests/test_fogstack_registry_publication_index.py"
+      - "tools/tests/test_fogstack_filesystem_registry.py"
+      - "docs/FOGSTACK_*.md"
+      - ".github/workflows/fogstack-filesystem-registry.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/release/fogstack-registry-publication-index-v0.1.schema.json"
+      - "tools/build_fogstack_registry_publication_index.py"
+      - "tools/check_fogstack_registry_publication_index.py"
+      - "tools/publish_fogstack_filesystem_registry.py"
+      - "tools/check_fogstack_filesystem_registry.py"
+      - "tools/tests/test_fogstack_registry_publication_index.py"
+      - "tools/tests/test_fogstack_filesystem_registry.py"
+      - "docs/FOGSTACK_*.md"
+      - ".github/workflows/fogstack-filesystem-registry.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  filesystem-registry:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Run filesystem registry tests
+        run: |
+          python -m pytest -q \
+            tools/tests/test_fogstack_registry_publication_index.py \
+            tools/tests/test_fogstack_filesystem_registry.py
+
+      - name: Build filesystem registry smoke artifacts
+        run: |
+          mkdir -p artifacts/filesystem-registry/input artifacts/filesystem-registry/output
+
+          cp releases/manifests/fogstack.access-v0.1.manifest.json artifacts/filesystem-registry/input/fogstack.access-v0.1.manifest.json
+
+          cat > artifacts/filesystem-registry/input/manifest-publication-set.json <<'JSON'
+          {
+            "kind": "FogStackManifestPublicationSet",
+            "schema_version": "v0.1",
+            "manifests": [
+              {
+                "bundle_id": "fogstack.access",
+                "version": "0.1.0",
+                "ref": "artifacts/filesystem-registry/input/fogstack.access-v0.1.manifest.json",
+                "signed": false
+              }
+            ]
+          }
+          JSON
+
+          cat > artifacts/filesystem-registry/input/publication-gate.record.json <<'JSON'
+          {
+            "kind": "FogStackReleasePublicationGateRecord",
+            "schema_version": "v0.1",
+            "status": "pass",
+            "checks": []
+          }
+          JSON
+
+          python3 tools/build_fogstack_registry_publication_index.py \
+            --registry-uri file://artifacts/filesystem-registry/output \
+            --publication-set artifacts/filesystem-registry/input/manifest-publication-set.json \
+            --publication-gate-record artifacts/filesystem-registry/input/publication-gate.record.json \
+            --artifact manifest-access artifacts/filesystem-registry/input/fogstack.access-v0.1.manifest.json \
+            --output artifacts/filesystem-registry/input/registry-publication.index.json
+
+          python3 tools/check_fogstack_registry_publication_index.py \
+            --index artifacts/filesystem-registry/input/registry-publication.index.json
+
+          python3 tools/publish_fogstack_filesystem_registry.py \
+            --index artifacts/filesystem-registry/input/registry-publication.index.json \
+            --registry-root artifacts/filesystem-registry/output \
+            --bundle-id fogstack.access \
+            --version 0.1.0
+
+          python3 tools/check_fogstack_filesystem_registry.py \
+            --registry-root artifacts/filesystem-registry/output \
+            --bundle-id fogstack.access \
+            --version 0.1.0
+
+      - name: Upload filesystem registry artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fogstack-filesystem-registry
+          path: artifacts/filesystem-registry/
+          if-no-files-found: error

--- a/docs/FOGSTACK_FILESYSTEM_REGISTRY.md
+++ b/docs/FOGSTACK_FILESYSTEM_REGISTRY.md
@@ -1,0 +1,45 @@
+# Fog Stack filesystem registry
+
+This document defines the first external-consumable registry adapter for Fog Stack releases.
+
+## Goal
+
+Move from registry-ready CI artifacts to a concrete filesystem registry layout that can be copied, mirrored, served, or adapted into a later network registry.
+
+## Filesystem registry layout
+
+The publisher writes releases under:
+
+- `<registry-root>/<bundle-id>/<version>/registry-publication.index.json`
+- `<registry-root>/<bundle-id>/<version>/release-pointer.json`
+- `<registry-root>/<bundle-id>/<version>/artifacts/*`
+
+The release pointer includes:
+
+- bundle id
+- version
+- registry publication index reference
+- registry publication index digest
+
+## Minimal flow
+
+1. build a gated registry publication index with `tools/build_fogstack_registry_publication_index.py`
+2. check the index with `tools/check_fogstack_registry_publication_index.py`
+3. publish it to a filesystem registry with `tools/publish_fogstack_filesystem_registry.py`
+4. verify the filesystem registry release with `tools/check_fogstack_filesystem_registry.py`
+
+## What this phase provides
+
+- concrete external-consumable registry layout
+- digest-checked artifact copy into the registry
+- release pointer for lookup
+- CI smoke workflow for publish/check behavior
+
+## What this phase does not yet provide
+
+- authenticated network registry publication
+- signed registry root metadata
+- rollback or revocation index publication
+- registry replication or mirror policy
+
+Those remain later steps.

--- a/tools/check_fogstack_filesystem_registry.py
+++ b/tools/check_fogstack_filesystem_registry.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check a Fog Stack filesystem registry release")
+    parser.add_argument("--registry-root", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+
+    release_root = args.registry_root / args.bundle_id / args.version
+    pointer_path = release_root / "release-pointer.json"
+    index_path = release_root / "registry-publication.index.json"
+
+    errors: list[str] = []
+    if not pointer_path.exists():
+        errors.append("release-pointer.json missing")
+    if not index_path.exists():
+        errors.append("registry-publication.index.json missing")
+
+    if errors:
+        for item in errors:
+            print(item)
+        return 1
+
+    pointer = load_json(pointer_path)
+    index = load_json(index_path)
+
+    if pointer.get("index_digest") != sha256_file(index_path):
+        errors.append("index digest mismatch")
+    if pointer.get("bundle_id") != args.bundle_id or pointer.get("version") != args.version:
+        errors.append("release pointer identity mismatch")
+
+    artifacts_root = release_root / "artifacts"
+    for artifact in index.get("artifacts") or []:
+        ref = artifact.get("ref") if isinstance(artifact, dict) else None
+        digest = artifact.get("digest") if isinstance(artifact, dict) else None
+        if not isinstance(ref, str):
+            errors.append("artifact ref missing")
+            continue
+        artifact_path = artifacts_root / Path(ref).name
+        if not artifact_path.exists():
+            errors.append(f"artifact missing: {artifact_path}")
+            continue
+        if sha256_file(artifact_path) != digest:
+            errors.append(f"artifact digest mismatch: {artifact_path}")
+
+    if errors:
+        for item in errors:
+            print(item)
+        return 1
+
+    print("FogStack filesystem registry release passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/publish_fogstack_filesystem_registry.py
+++ b/tools/publish_fogstack_filesystem_registry.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def safe_name(ref: str) -> str:
+    name = Path(ref).name
+    if not name or name in {".", ".."}:
+        raise SystemExit(f"ERR: unsafe artifact ref: {ref}")
+    return name
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Publish a Fog Stack registry publication index to a filesystem registry")
+    parser.add_argument("--index", required=True, type=Path)
+    parser.add_argument("--registry-root", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+
+    index = load_json(args.index)
+    if index.get("kind") != "FogStackRegistryPublicationIndex":
+        raise SystemExit("ERR: registry publication index kind mismatch")
+
+    release_root = args.registry_root / args.bundle_id / args.version
+    artifacts_root = release_root / "artifacts"
+    artifacts_root.mkdir(parents=True, exist_ok=True)
+
+    for artifact in index.get("artifacts") or []:
+        if not isinstance(artifact, dict):
+            raise SystemExit("ERR: artifact entry is not an object")
+        ref = artifact.get("ref")
+        digest = artifact.get("digest")
+        if not isinstance(ref, str):
+            raise SystemExit("ERR: artifact ref missing")
+        source = Path(ref)
+        if not source.exists():
+            raise SystemExit(f"ERR: artifact source missing: {source}")
+        actual_digest = sha256_file(source)
+        if actual_digest != digest:
+            raise SystemExit(f"ERR: artifact digest mismatch: {source}")
+        shutil.copy2(source, artifacts_root / safe_name(ref))
+
+    index_target = release_root / "registry-publication.index.json"
+    shutil.copy2(args.index, index_target)
+
+    pointer = {
+        "kind": "FogStackFilesystemRegistryReleasePointer",
+        "schema_version": "v0.1",
+        "bundle_id": args.bundle_id,
+        "version": args.version,
+        "index_ref": str(index_target),
+        "index_digest": sha256_file(index_target),
+    }
+    (release_root / "release-pointer.json").write_text(json.dumps(pointer, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(pointer, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_filesystem_registry.py
+++ b/tools/tests/test_fogstack_filesystem_registry.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def test_publish_and_check_filesystem_registry(tmp_path: Path) -> None:
+    publication_set = tmp_path / "manifest-publication-set.json"
+    gate_record = tmp_path / "publication-gate.record.json"
+    manifest = tmp_path / "fogstack.access-v0.1.manifest.json"
+    index = tmp_path / "registry-publication.index.json"
+    registry_root = tmp_path / "registry"
+
+    write_json(publication_set, {
+        "kind": "FogStackManifestPublicationSet",
+        "schema_version": "v0.1",
+        "manifests": [],
+    })
+    write_json(gate_record, {
+        "kind": "FogStackReleasePublicationGateRecord",
+        "schema_version": "v0.1",
+        "status": "pass",
+        "checks": [],
+    })
+    write_json(manifest, {
+        "kind": "FogStackBundleManifest",
+        "schema_version": "v0.1",
+        "bundle_id": "fogstack.access",
+        "version": "0.1.0",
+    })
+
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_registry_publication_index.py",
+        "--registry-uri", "file://registry/fogstack",
+        "--publication-set", str(publication_set),
+        "--publication-gate-record", str(gate_record),
+        "--artifact", "manifest", str(manifest),
+        "--output", str(index),
+    ], check=True)
+
+    subprocess.run([
+        sys.executable,
+        "tools/publish_fogstack_filesystem_registry.py",
+        "--index", str(index),
+        "--registry-root", str(registry_root),
+        "--bundle-id", "fogstack.access",
+        "--version", "0.1.0",
+    ], check=True)
+
+    release_root = registry_root / "fogstack.access" / "0.1.0"
+    assert (release_root / "release-pointer.json").exists()
+    assert (release_root / "registry-publication.index.json").exists()
+    assert (release_root / "artifacts" / manifest.name).exists()
+
+    subprocess.run([
+        sys.executable,
+        "tools/check_fogstack_filesystem_registry.py",
+        "--registry-root", str(registry_root),
+        "--bundle-id", "fogstack.access",
+        "--version", "0.1.0",
+    ], check=True)
+
+
+def test_filesystem_registry_check_rejects_missing_release(tmp_path: Path) -> None:
+    proc = subprocess.run([
+        sys.executable,
+        "tools/check_fogstack_filesystem_registry.py",
+        "--registry-root", str(tmp_path / "registry"),
+        "--bundle-id", "fogstack.access",
+        "--version", "0.1.0",
+    ])
+    assert proc.returncode != 0


### PR DESCRIPTION
## Summary

This PR adds the first external-consumable Fog Stack registry adapter:

- filesystem registry publisher
- filesystem registry checker
- tests
- CI smoke workflow
- documentation

It publishes an already gated registry publication index and referenced artifacts into a local filesystem registry layout.

## Not in this PR

- network registry publication
- signed registry root metadata
- rollback or revocation index publication
