### PR TITLE
SourceOS: add M2 lifecycle proof generator

### DIFF
--- a/.github/workflows/sourceos-contracts.yml
+++ b/.github/workflows/sourceos-contracts.yml
@@ -6,6 +6,8 @@ on:
       - "contracts/sourceos/**"
       - "docs/SOURCEOS_*.md"
       - "tools/validate_sourceos_contracts.py"
+      - "tools/build_sourceos_m2_lifecycle_proof.py"
+      - "tools/smoke_sourceos_m2_lifecycle_proof.py"
       - ".github/workflows/sourceos-contracts.yml"
   push:
     branches:
@@ -14,6 +16,8 @@ on:
       - "contracts/sourceos/**"
       - "docs/SOURCEOS_*.md"
       - "tools/validate_sourceos_contracts.py"
+      - "tools/build_sourceos_m2_lifecycle_proof.py"
+      - "tools/smoke_sourceos_m2_lifecycle_proof.py"
       - ".github/workflows/sourceos-contracts.yml"
 
 jobs:
@@ -28,3 +32,5 @@ jobs:
         run: python -m pip install jsonschema
       - name: Validate SourceOS contracts
         run: python tools/validate_sourceos_contracts.py
+      - name: Smoke SourceOS M2 lifecycle proof
+        run: python tools/smoke_sourceos_m2_lifecycle_proof.py

--- a/contracts/sourceos/compliance-result.v0.schema.json
+++ b/contracts/sourceos/compliance-result.v0.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/sourceos/compliance-result.v0.schema.json",
+  "title": "SourceOS ComplianceResult v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "kind", "id", "evaluated_at", "subject", "expected", "observed", "status", "checks"],
+  "properties": {
+    "schema_version": { "const": "sourceos.compliance-result/v0" },
+    "kind": { "const": "SourceOSComplianceResult" },
+    "id": { "type": "string", "pattern": "^scr-[a-z0-9][a-z0-9._-]{5,127}$" },
+    "evaluated_at": { "type": "string", "format": "date-time" },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subject_kind", "subject_id"],
+      "properties": {
+        "subject_kind": { "type": "string", "enum": ["device", "user_workspace", "agent_workspace", "boot_environment"] },
+        "subject_id": { "type": "string", "minLength": 1 }
+      }
+    },
+    "expected": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["release_set_ref", "policy_bundle_ref"],
+      "properties": {
+        "release_set_ref": { "type": "string", "minLength": 1 },
+        "boot_release_set_ref": { "type": "string" },
+        "policy_bundle_ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "observed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fingerprint_ref", "release_set_ref", "policy_bundle_ref"],
+      "properties": {
+        "fingerprint_ref": { "type": "string", "minLength": 1 },
+        "release_set_ref": { "type": "string", "minLength": 1 },
+        "boot_release_set_ref": { "type": "string" },
+        "policy_bundle_ref": { "type": "string", "minLength": 1 }
+      }
+    },
+    "status": { "type": "string", "enum": ["compliant", "noncompliant", "degraded", "unknown"] },
+    "checks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "status"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "enum": ["pass", "fail", "warn", "unknown"] },
+          "expected": { "type": "string" },
+          "observed": { "type": "string" },
+          "reason": { "type": "string" }
+        }
+      }
+    },
+    "evidence_refs": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+  }
+}

--- a/contracts/sourceos/examples/compliance-result.m2-demo.v0.json
+++ b/contracts/sourceos/examples/compliance-result.m2-demo.v0.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "sourceos.compliance-result/v0",
+  "kind": "SourceOSComplianceResult",
+  "id": "scr-m2-demo-0001",
+  "evaluated_at": "2026-04-26T15:30:00Z",
+  "subject": {
+    "subject_kind": "device",
+    "subject_id": "device:m2-demo"
+  },
+  "expected": {
+    "release_set_ref": "srset-m2-demo-0001",
+    "boot_release_set_ref": "sbrs-m2-demo-recovery-0001",
+    "policy_bundle_ref": "policy:sourceos-m2-demo-v0"
+  },
+  "observed": {
+    "fingerprint_ref": "sfp-m2-demo-0001",
+    "release_set_ref": "srset-m2-demo-0001",
+    "boot_release_set_ref": "sbrs-m2-demo-recovery-0001",
+    "policy_bundle_ref": "policy:sourceos-m2-demo-v0"
+  },
+  "status": "compliant",
+  "checks": [
+    {
+      "name": "release-set-match",
+      "status": "pass",
+      "expected": "srset-m2-demo-0001",
+      "observed": "srset-m2-demo-0001"
+    },
+    {
+      "name": "policy-bundle-match",
+      "status": "pass",
+      "expected": "policy:sourceos-m2-demo-v0",
+      "observed": "policy:sourceos-m2-demo-v0"
+    },
+    {
+      "name": "rollback-available",
+      "status": "pass",
+      "expected": "true",
+      "observed": "true"
+    }
+  ],
+  "evidence_refs": ["evidence:sourceos-m2-demo-compliance-0001"]
+}

--- a/contracts/sourceos/examples/config-source.m2-demo.v0.json
+++ b/contracts/sourceos/examples/config-source.m2-demo.v0.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "sourceos.config-source/v0",
+  "kind": "SourceOSConfigSource",
+  "id": "scfg-m2-demo-local",
+  "source_type": "git",
+  "location": {
+    "canonical_ref": "git:local/sourceos-m2-demo#main",
+    "local_path": "~/dev/sourceos-m2-demo",
+    "remote_url": "https://github.com/SocioProphet/sourceos-workspace.git"
+  },
+  "nix": {
+    "entry_kind": "flake",
+    "entry_ref": "flake.nix",
+    "lock_ref": "flake.lock",
+    "outputs": [
+      "packages.aarch64-linux.sourceosM2System",
+      "packages.aarch64-linux.macosLikeUserProfile",
+      "packages.aarch64-linux.agentBaseTools"
+    ]
+  },
+  "refs": {
+    "allowed_refs": ["main", "feature/*", "release/*", "refs/tags/*"],
+    "stable_ref": "main",
+    "branch_channel_map": {
+      "main": "stable",
+      "feature/*": "dev",
+      "release/*": "candidate"
+    }
+  },
+  "update_policy": {
+    "mode": "pull",
+    "requires_signature_verification": false,
+    "required_status_checks": [],
+    "build_trigger": "manual"
+  },
+  "token_policy": {
+    "token_ref": "secret:none",
+    "token_kind": "none",
+    "storage_rule": "not_applicable",
+    "redaction_required": true,
+    "allowed_ref_writes": []
+  },
+  "cache_policy": {
+    "local_cache": true,
+    "remote_cache": false,
+    "trusted_cache_keys": []
+  }
+}

--- a/contracts/sourceos/examples/fingerprint.m2-demo.v0.json
+++ b/contracts/sourceos/examples/fingerprint.m2-demo.v0.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": "sourceos.fingerprint/v0",
+  "kind": "SourceOSFingerprint",
+  "id": "sfp-m2-demo-0001",
+  "observed_at": "2026-04-26T15:30:00Z",
+  "subject": {
+    "subject_kind": "device",
+    "subject_id": "device:m2-demo",
+    "device_claim": "device-claim:m2-demo-public-key-fingerprint"
+  },
+  "system": {
+    "architecture": "aarch64",
+    "kernel": "sourceos-demo-kernel",
+    "boot_mode": "normal",
+    "system_base_ref": "ostree:sourceos/m2/silverblue-gnome/dev/0001",
+    "rollback_available": true
+  },
+  "runtime": {
+    "isolation": "host",
+    "libc": "glibc",
+    "shell": "bash",
+    "tool_dialect": "gnu",
+    "pid1": "systemd"
+  },
+  "lsm": {
+    "selinux_visible": false,
+    "selinux_mode": "not_visible",
+    "apparmor_visible": false,
+    "landlock_visible": false,
+    "host_enforced_possible": true
+  },
+  "policy": {
+    "policy_bundle_ref": "policy:sourceos-m2-demo-v0",
+    "release_set_ref": "srset-m2-demo-0001",
+    "boot_release_set_ref": "sbrs-m2-demo-recovery-0001",
+    "capability_manifest_ref": "capabilities:sourceos-m2-demo-0001",
+    "network_scope": "restricted",
+    "filesystem_scope": "scoped"
+  },
+  "provenance": {
+    "config_source_refs": ["scfg-m2-demo-local"],
+    "closure_refs": [
+      "nix:closure:user/macos-like-gnome/0001",
+      "nix:closure:agent/base-tools/0001"
+    ],
+    "artifact_digests": [
+      "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    ],
+    "evidence_refs": ["evidence:sourceos-m2-demo-fingerprint-0001"]
+  },
+  "compliance": {
+    "status": "compliant",
+    "reasons": ["Observed release, policy, architecture, and rollback state match assigned demo release."]
+  }
+}

--- a/contracts/sourceos/examples/proof-index.m2-demo.v0.json
+++ b/contracts/sourceos/examples/proof-index.m2-demo.v0.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": "sourceos.proof-index/v0",
+  "kind": "SourceOSProofIndex",
+  "id": "spi-m2-demo-0001",
+  "created_at": "2026-04-26T15:30:00Z",
+  "proof_kind": "m2_lifecycle_demo",
+  "summary": "Deterministic local SourceOS M2 lifecycle proof bundle covering ConfigSource, ReleaseSet, BootReleaseSet, Fingerprint, and ComplianceResult.",
+  "artifacts": [
+    {
+      "name": "config-source",
+      "kind": "SourceOSConfigSource",
+      "path": "config-source.json",
+      "schema_ref": "contracts/sourceos/config-source.v0.schema.json"
+    },
+    {
+      "name": "release-set",
+      "kind": "SourceOSReleaseSet",
+      "path": "release-set.json",
+      "schema_ref": "contracts/sourceos/release-set.v0.schema.json"
+    },
+    {
+      "name": "boot-release-set",
+      "kind": "SourceOSBootReleaseSet",
+      "path": "boot-release-set.json",
+      "schema_ref": "contracts/sourceos/boot-release-set.v0.schema.json"
+    },
+    {
+      "name": "fingerprint",
+      "kind": "SourceOSFingerprint",
+      "path": "fingerprint.json",
+      "schema_ref": "contracts/sourceos/fingerprint.v0.schema.json"
+    },
+    {
+      "name": "compliance-result",
+      "kind": "SourceOSComplianceResult",
+      "path": "compliance-result.json",
+      "schema_ref": "contracts/sourceos/compliance-result.v0.schema.json"
+    }
+  ],
+  "sociosphere_registration_ref": "SocioProphet/sociosphere#190",
+  "notes": [
+    "This is a deterministic local proof fixture, not a live boot execution record.",
+    "nlboot implementation output can be mapped into the BootReleaseSet shape later."
+  ]
+}

--- a/contracts/sourceos/proof-index.v0.schema.json
+++ b/contracts/sourceos/proof-index.v0.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/sourceos/proof-index.v0.schema.json",
+  "title": "SourceOS ProofIndex v0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "kind", "id", "created_at", "proof_kind", "artifacts"],
+  "properties": {
+    "schema_version": { "const": "sourceos.proof-index/v0" },
+    "kind": { "const": "SourceOSProofIndex" },
+    "id": { "type": "string", "pattern": "^spi-[a-z0-9][a-z0-9._-]{5,127}$" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "proof_kind": { "type": "string", "enum": ["m2_lifecycle_demo", "boot_provisioning", "release_assignment", "compliance"] },
+    "summary": { "type": "string" },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "kind", "path", "schema_ref"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "kind": { "type": "string", "minLength": 1 },
+          "path": { "type": "string", "minLength": 1 },
+          "schema_ref": { "type": "string", "minLength": 1 },
+          "digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" }
+        }
+      }
+    },
+    "sociosphere_registration_ref": { "type": "string" },
+    "notes": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/docs/SOURCEOS_M2_LIFECYCLE_PROOF.md
+++ b/docs/SOURCEOS_M2_LIFECYCLE_PROOF.md
@@ -1,0 +1,59 @@
+# SourceOS M2 lifecycle proof v0
+
+This document defines the local deterministic proof path for the SourceOS M2 demo after the v0 contract surface lands.
+
+The proof path is deliberately repo-local and deterministic. It does not perform live boot, disk writes, GitHub token use, or nlboot execution. It proves that the control-plane object loop can be generated, validated, indexed, and compliance-evaluated without hidden state.
+
+## Generated artifacts
+
+`tools/build_sourceos_m2_lifecycle_proof.py` writes:
+
+- `config-source.json`
+- `release-set.json`
+- `boot-release-set.json`
+- `fingerprint.json`
+- `compliance-result.json`
+- `proof-index.json`
+
+By default the bundle is written under:
+
+```bash
+artifacts/sourceos/m2-lifecycle-proof
+```
+
+## Command
+
+```bash
+python tools/build_sourceos_m2_lifecycle_proof.py
+```
+
+Smoke test:
+
+```bash
+python tools/smoke_sourceos_m2_lifecycle_proof.py
+```
+
+## What this proves
+
+The v0 proof demonstrates the SourceOS control-plane lifecycle spine:
+
+1. ConfigSource is declared as a Git/Nix lifecycle input.
+2. ReleaseSet is assigned to the M2 demo device.
+3. BootReleaseSet is available for recovery/install/live behavior.
+4. Fingerprint reports observed state.
+5. ComplianceResult compares observed state to assigned state.
+6. ProofIndex ties the generated objects together with digests.
+
+## What this does not prove yet
+
+- It does not prove an Apple Silicon boot-picker entry.
+- It does not execute nlboot.
+- It does not write disk partitions.
+- It does not use live GitHub tokens.
+- It does not provide the website UI.
+
+Those remain separate implementation tranches.
+
+## Sociosphere integration
+
+Sociosphere issue `SocioProphet/sociosphere#190` tracks workspace-governance awareness for SourceOS contract and lifecycle artifacts.

--- a/tools/build_sourceos_m2_lifecycle_proof.py
+++ b/tools/build_sourceos_m2_lifecycle_proof.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    import jsonschema
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("ERR: jsonschema is required to validate SourceOS lifecycle proof artifacts") from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "contracts" / "sourceos"
+DEFAULT_OUT = ROOT / "artifacts" / "sourceos" / "m2-lifecycle-proof"
+STAMP = "2026-04-26T15:30:00Z"
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_ref(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def validate(schema_name: str, document: dict[str, Any]) -> None:
+    schema = load_json(SCHEMA_DIR / schema_name)
+    jsonschema.Draft202012Validator.check_schema(schema)
+    errors = sorted(jsonschema.Draft202012Validator(schema).iter_errors(document), key=lambda err: list(err.path))
+    if errors:
+        for err in errors:
+            loc = ".".join(str(part) for part in err.path) or "<root>"
+            print(f"{schema_name}: {loc}: {err.message}")
+        raise SystemExit(1)
+
+
+def build_objects() -> dict[str, dict[str, Any]]:
+    config_source = {
+        "schema_version": "sourceos.config-source/v0",
+        "kind": "SourceOSConfigSource",
+        "id": "scfg-m2-demo-local",
+        "source_type": "git",
+        "location": {
+            "canonical_ref": "git:local/sourceos-m2-demo#main",
+            "local_path": "~/dev/sourceos-m2-demo",
+            "remote_url": "https://github.com/SocioProphet/sourceos-workspace.git",
+        },
+        "nix": {
+            "entry_kind": "flake",
+            "entry_ref": "flake.nix",
+            "lock_ref": "flake.lock",
+            "outputs": [
+                "packages.aarch64-linux.sourceosM2System",
+                "packages.aarch64-linux.macosLikeUserProfile",
+                "packages.aarch64-linux.agentBaseTools",
+            ],
+        },
+        "refs": {
+            "allowed_refs": ["main", "feature/*", "release/*", "refs/tags/*"],
+            "stable_ref": "main",
+            "branch_channel_map": {"main": "stable", "feature/*": "dev", "release/*": "candidate"},
+        },
+        "update_policy": {
+            "mode": "pull",
+            "requires_signature_verification": False,
+            "required_status_checks": [],
+            "build_trigger": "manual",
+        },
+        "token_policy": {
+            "token_ref": "secret:none",
+            "token_kind": "none",
+            "storage_rule": "not_applicable",
+            "redaction_required": True,
+            "allowed_ref_writes": [],
+        },
+        "cache_policy": {"local_cache": True, "remote_cache": False, "trusted_cache_keys": []},
+    }
+
+    release_set = {
+        "schema_version": "sourceos.release-set/v0",
+        "kind": "SourceOSReleaseSet",
+        "id": "srset-m2-demo-0001",
+        "description": "M2 demo release set for SourceOS system/user/agent lifecycle proof.",
+        "created_at": STAMP,
+        "channel": "dev",
+        "support_state": "experimental",
+        "system": {
+            "base_kind": "ostree",
+            "base_ref": "ostree:sourceos/m2/silverblue-gnome/dev/0001",
+            "architecture": "aarch64",
+            "platform_targets": ["apple_silicon_m2"],
+            "host_integration_surface": "hisc-sourceos-m2-v0",
+            "rollback_refs": ["ostree:sourceos/m2/silverblue-gnome/dev/0000"],
+        },
+        "user": {
+            "experience_profile": "xp-macos-like-gnome-v0",
+            "ux_archetype": "macos_like",
+            "desktop": "gnome",
+            "closure_refs": ["nix:closure:user/macos-like-gnome/0001"],
+            "degraded_parity_notes": [],
+        },
+        "agent": {
+            "default_isolation": "container",
+            "environment_refs": ["nix:closure:agent/base-tools/0001"],
+            "capability_policy_ref": "policy:sourceos-agent-standard-v0",
+            "risk_policy_ref": "policy:sourceos-risk-isolation-v0",
+        },
+        "policy": {"policy_bundle_ref": "policy:sourceos-m2-demo-v0", "crypto_profile": "standard", "required_signatures": 1},
+        "assignment": {"scope_kind": "device", "scope_id": "device:m2-demo"},
+        "provenance": {
+            "config_sources": ["scfg-m2-demo-local"],
+            "bom_ref": "bom:sourceos-m2-demo-0001",
+            "build_ref": "build:sourceos-m2-demo-0001",
+            "sbom_refs": ["sbom:sourceos-m2-demo-0001"],
+            "evidence_refs": ["evidence:sourceos-m2-demo-build-0001"],
+        },
+        "signatures": [{"key_id": "sourceos-demo-signing-key-v0", "algorithm": "ed25519", "signature_ref": "sig:sourceos-m2-demo-0001"}],
+    }
+
+    boot_release_set = {
+        "schema_version": "sourceos.boot-release-set/v0",
+        "kind": "SourceOSBootReleaseSet",
+        "id": "sbrs-m2-demo-recovery-0001",
+        "description": "M2 demo SourceOS recovery/install/live boot release set.",
+        "created_at": STAMP,
+        "channel": "dev",
+        "parent_release_set_ref": "srset-m2-demo-0001",
+        "boot_modes": ["live", "installer", "recovery", "rollback"],
+        "platform_entrypoints": [
+            {"platform": "apple_silicon", "entry_kind": "asahi_installer_entry", "entry_ref": "installer-tree:sourceos/m2/recovery/0001", "notes": "Boot-picker-visible installer/recovery entry via Apple Silicon/Asahi-compatible path."},
+            {"platform": "uefi", "entry_kind": "ipxe", "entry_ref": "ipxe:sourceos/recovery/0001", "notes": "Generic parity path for later PC/Purism support."},
+        ],
+        "artifacts": [
+            {"name": "sourceos-recovery-kernel", "artifact_kind": "kernel", "uri": "artifact:sourceos/m2/recovery/kernel/0001", "digest": "sha256:" + "0" * 64, "size_bytes": 0},
+            {"name": "sourceos-recovery-initrd", "artifact_kind": "initrd", "uri": "artifact:sourceos/m2/recovery/initrd/0001", "digest": "sha256:" + "1" * 64, "size_bytes": 0},
+            {"name": "sourceos-recovery-manifest", "artifact_kind": "manifest", "uri": "artifact:sourceos/m2/recovery/manifest/0001", "digest": "sha256:" + "2" * 64, "size_bytes": 0},
+        ],
+        "authorization": {"mode": "single_use_code", "token_binding": "device_claim", "ttl_seconds": 900, "requires_online_redemption": True},
+        "capabilities": {"disk_write": "scoped", "network": "restricted", "kexec": "allowed", "rollback": "allowed", "enrollment": "allowed"},
+        "proof_requirements": {"emit_fingerprint": True, "emit_manifest_hashes": True, "emit_boot_log_ref": True, "required_report_endpoint": "tritrpc:sourceos.boot.proof.report"},
+        "offline_fallback": {"allowed": True, "last_known_good_ref": "sbrs-m2-demo-recovery-0000", "max_age_seconds": 604800},
+        "signatures": [{"key_id": "sourceos-demo-signing-key-v0", "algorithm": "ed25519", "signature_ref": "sig:sourceos-m2-demo-recovery-0001"}],
+    }
+
+    fingerprint = {
+        "schema_version": "sourceos.fingerprint/v0",
+        "kind": "SourceOSFingerprint",
+        "id": "sfp-m2-demo-0001",
+        "observed_at": STAMP,
+        "subject": {"subject_kind": "device", "subject_id": "device:m2-demo", "device_claim": "device-claim:m2-demo-public-key-fingerprint"},
+        "system": {"architecture": "aarch64", "kernel": "sourceos-demo-kernel", "boot_mode": "normal", "system_base_ref": release_set["system"]["base_ref"], "rollback_available": True},
+        "runtime": {"isolation": "host", "libc": "glibc", "shell": "bash", "tool_dialect": "gnu", "pid1": "systemd"},
+        "lsm": {"selinux_visible": False, "selinux_mode": "not_visible", "apparmor_visible": False, "landlock_visible": False, "host_enforced_possible": True},
+        "policy": {"policy_bundle_ref": release_set["policy"]["policy_bundle_ref"], "release_set_ref": release_set["id"], "boot_release_set_ref": boot_release_set["id"], "capability_manifest_ref": "capabilities:sourceos-m2-demo-0001", "network_scope": "restricted", "filesystem_scope": "scoped"},
+        "provenance": {"config_source_refs": [config_source["id"]], "closure_refs": release_set["user"]["closure_refs"] + release_set["agent"]["environment_refs"], "artifact_digests": [boot_release_set["artifacts"][0]["digest"], boot_release_set["artifacts"][1]["digest"]], "evidence_refs": ["evidence:sourceos-m2-demo-fingerprint-0001"]},
+        "compliance": {"status": "compliant", "reasons": ["Observed release, policy, architecture, and rollback state match assigned demo release."]},
+    }
+
+    compliance_result = {
+        "schema_version": "sourceos.compliance-result/v0",
+        "kind": "SourceOSComplianceResult",
+        "id": "scr-m2-demo-0001",
+        "evaluated_at": STAMP,
+        "subject": {"subject_kind": "device", "subject_id": "device:m2-demo"},
+        "expected": {"release_set_ref": release_set["id"], "boot_release_set_ref": boot_release_set["id"], "policy_bundle_ref": release_set["policy"]["policy_bundle_ref"]},
+        "observed": {"fingerprint_ref": fingerprint["id"], "release_set_ref": fingerprint["policy"]["release_set_ref"], "boot_release_set_ref": fingerprint["policy"]["boot_release_set_ref"], "policy_bundle_ref": fingerprint["policy"]["policy_bundle_ref"]},
+        "status": "compliant",
+        "checks": [
+            {"name": "release-set-match", "status": "pass", "expected": release_set["id"], "observed": fingerprint["policy"]["release_set_ref"]},
+            {"name": "policy-bundle-match", "status": "pass", "expected": release_set["policy"]["policy_bundle_ref"], "observed": fingerprint["policy"]["policy_bundle_ref"]},
+            {"name": "rollback-available", "status": "pass", "expected": "true", "observed": str(fingerprint["system"]["rollback_available"]).lower()},
+        ],
+        "evidence_refs": ["evidence:sourceos-m2-demo-compliance-0001"],
+    }
+
+    return {
+        "config-source.json": config_source,
+        "release-set.json": release_set,
+        "boot-release-set.json": boot_release_set,
+        "fingerprint.json": fingerprint,
+        "compliance-result.json": compliance_result,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build deterministic local SourceOS M2 lifecycle proof bundle")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--no-validate", action="store_true")
+    args = parser.parse_args()
+
+    objects = build_objects()
+    schema_by_file = {
+        "config-source.json": "config-source.v0.schema.json",
+        "release-set.json": "release-set.v0.schema.json",
+        "boot-release-set.json": "boot-release-set.v0.schema.json",
+        "fingerprint.json": "fingerprint.v0.schema.json",
+        "compliance-result.json": "compliance-result.v0.schema.json",
+    }
+
+    if not args.no_validate:
+        for name, document in objects.items():
+            validate(schema_by_file[name], document)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    for name, document in objects.items():
+        write_json(args.output_dir / name, document)
+
+    kind_by_file = {
+        "config-source.json": "SourceOSConfigSource",
+        "release-set.json": "SourceOSReleaseSet",
+        "boot-release-set.json": "SourceOSBootReleaseSet",
+        "fingerprint.json": "SourceOSFingerprint",
+        "compliance-result.json": "SourceOSComplianceResult",
+    }
+    artifacts = []
+    for name in objects:
+        path = args.output_dir / name
+        artifacts.append({"name": name.removesuffix(".json"), "kind": kind_by_file[name], "path": name, "schema_ref": f"contracts/sourceos/{schema_by_file[name]}", "digest": sha256_ref(path)})
+
+    proof_index = {
+        "schema_version": "sourceos.proof-index/v0",
+        "kind": "SourceOSProofIndex",
+        "id": "spi-m2-demo-0001",
+        "created_at": STAMP,
+        "proof_kind": "m2_lifecycle_demo",
+        "summary": "Deterministic local SourceOS M2 lifecycle proof bundle covering ConfigSource, ReleaseSet, BootReleaseSet, Fingerprint, and ComplianceResult.",
+        "artifacts": artifacts,
+        "sociosphere_registration_ref": "SocioProphet/sociosphere#190",
+        "notes": ["This is a deterministic local proof fixture, not a live boot execution record.", "nlboot implementation output can be mapped into the BootReleaseSet shape later."],
+    }
+    if not args.no_validate:
+        validate("proof-index.v0.schema.json", proof_index)
+    write_json(args.output_dir / "proof-index.json", proof_index)
+
+    print(f"SourceOS M2 lifecycle proof bundle written to {args.output_dir}")
+    print("SourceOS M2 lifecycle proof passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/smoke_sourceos_m2_lifecycle_proof.py
+++ b/tools/smoke_sourceos_m2_lifecycle_proof.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def main() -> int:
+    with TemporaryDirectory() as tmp:
+        out = Path(tmp) / "proof"
+        subprocess.run([
+            sys.executable,
+            str(ROOT / "tools" / "build_sourceos_m2_lifecycle_proof.py"),
+            "--output-dir",
+            str(out),
+        ], check=True)
+
+        expected = [
+            "config-source.json",
+            "release-set.json",
+            "boot-release-set.json",
+            "fingerprint.json",
+            "compliance-result.json",
+            "proof-index.json",
+        ]
+        for name in expected:
+            if not (out / name).exists():
+                raise SystemExit(f"ERR: missing generated proof artifact {name}")
+
+        compliance = load(out / "compliance-result.json")
+        if compliance.get("status") != "compliant":
+            raise SystemExit("ERR: expected generated compliance result to be compliant")
+
+        proof_index = load(out / "proof-index.json")
+        artifact_names = {item.get("path") for item in proof_index.get("artifacts", [])}
+        for name in expected[:-1]:
+            if name not in artifact_names:
+                raise SystemExit(f"ERR: proof-index does not reference {name}")
+
+    print("SourceOS M2 lifecycle proof smoke passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_sourceos_contracts.py
+++ b/tools/validate_sourceos_contracts.py
@@ -19,8 +19,10 @@ EXAMPLE_DIR = SCHEMA_DIR / "examples"
 SCHEMA_EXAMPLES = {
     "release-set.v0.schema.json": ["release-set.m2-demo.v0.json"],
     "boot-release-set.v0.schema.json": ["boot-release-set.m2-demo.v0.json"],
-    "fingerprint.v0.schema.json": [],
-    "config-source.v0.schema.json": [],
+    "fingerprint.v0.schema.json": ["fingerprint.m2-demo.v0.json"],
+    "config-source.v0.schema.json": ["config-source.m2-demo.v0.json"],
+    "compliance-result.v0.schema.json": ["compliance-result.m2-demo.v0.json"],
+    "proof-index.v0.schema.json": ["proof-index.m2-demo.v0.json"],
 }
 
 


### PR DESCRIPTION
## Summary

Implements the executable SourceOS M2 lifecycle proof path against the v0 SourceOS contracts already merged in `prophet-platform`.

This PR adds:

- `SourceOSComplianceResult` schema + M2 demo fixture
- `SourceOSProofIndex` schema + M2 demo fixture
- ConfigSource and Fingerprint M2 demo fixtures
- deterministic local proof generator: `tools/build_sourceos_m2_lifecycle_proof.py`
- proof smoke: `tools/smoke_sourceos_m2_lifecycle_proof.py`
- extended SourceOS contract validator coverage
- SourceOS workflow update to run both static validation and generated proof smoke
- proof documentation: `docs/SOURCEOS_M2_LIFECYCLE_PROOF.md`

## What this proves

This proves the repo-local control-plane object loop:

1. ConfigSource is declared as Git/Nix lifecycle input.
2. ReleaseSet is assigned to the M2 demo device.
3. BootReleaseSet is available for recovery/install/live path.
4. Fingerprint reports observed state.
5. ComplianceResult compares observed state to assigned state.
6. ProofIndex binds all generated objects together with digests.

## What this does not prove

This does not yet prove Apple Silicon boot-picker integration, nlboot execution, disk writes, live GitHub tokens, or the website UI. Those remain follow-on implementation tranches.

## Validation

The SourceOS workflow now runs:

```bash
python tools/validate_sourceos_contracts.py
python tools/smoke_sourceos_m2_lifecycle_proof.py
```

Sociosphere tracking remains: `SocioProphet/sociosphere#190`.