### PR TITLE
fogstack: enforce signature verification pipeline exit codes

### DIFF
--- a/docs/FOGSTACK_SIGNATURE_VERIFICATION_PIPELINE.md
+++ b/docs/FOGSTACK_SIGNATURE_VERIFICATION_PIPELINE.md
@@ -19,28 +19,37 @@ to:
 3. run `tools/run_fogstack_signature_verification_pipeline.py`
 4. persist the normalized evidence and cryptographic verification record into deterministic release-evidence paths
 
-## Example
+## Canonical CLI
 
 ```bash
 python3 tools/run_fogstack_signature_verification_pipeline.py \
   --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
-  --raw-evidence /tmp/fogstack.access.cosign.verify.json \
-  --tool cosign \
-  --bundle-id fogstack.access \
-  --version 0.1.0 \
-  --normalized-output /tmp/fogstack.access.normalized.verify.json \
-  --record-output /tmp/fogstack.access.crypto-verification.record.json
+  --external-evidence /tmp/fogstack.access.cosign.verify.json \
+  --out /tmp/fogstack.access.crypto-verification.record.json
 ```
+
+The helper preserves older aliases for existing workflows:
+- `--raw-evidence` for `--external-evidence`
+- `--record-output` for `--out`
+
+Use `--normalized-output` when the normalized external evidence object should be persisted separately.
 
 ## Digest consistency rule
 
-If both of the following are present:
+The pipeline requires:
 - `manifest.bundle_digest`
 - normalized `verified_digest`
 
-then the pipeline computes `manifest_digest_matches` and includes it in the record summary.
+The cryptographic verification record is `verified` only when the external evidence status is `pass` and the verified digest exactly matches the manifest bundle digest.
 
-A digest mismatch should be treated as a failed cryptographic verification result even if the external tool reported pass.
+A digest mismatch is a hard failed verification result. The helper still emits the failed record when an output path is provided so reviewers can inspect the evidence, but the process exits nonzero.
+
+## Exit codes
+
+- `0`: pass / verified
+- `1`: warning / non-fatal shape-only record
+- `2`: failure, including digest mismatch or external verification failure
+- `3`: invalid input or tool usage error, including malformed JSON, missing inputs, missing manifest digest, or missing verified digest
 
 ## Out of scope in this phase
 

--- a/tools/run_fogstack_signature_verification_pipeline.py
+++ b/tools/run_fogstack_signature_verification_pipeline.py
@@ -6,21 +6,51 @@ import json
 from pathlib import Path
 from typing import Any
 
+EXIT_PASS = 0
+EXIT_WARN = 1
+EXIT_FAIL = 2
+EXIT_INVALID = 3
+
 
 def load_json(path: Path) -> dict[str, Any]:
-    data = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"missing JSON input: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"malformed JSON input: {path}: {exc}") from exc
     if not isinstance(data, dict):
-        raise SystemExit(f"ERR: expected JSON object in {path}")
+        raise ValueError(f"expected JSON object in {path}")
     return data
+
+
+def nested_summary_value(data: dict[str, Any], key: str) -> Any:
+    summary = data.get("summary")
+    if isinstance(summary, dict) and key in summary:
+        return summary.get(key)
+    return None
+
+
+def normalize_status(raw_status: Any) -> str:
+    if raw_status in {"pass", "warn", "fail"}:
+        return str(raw_status)
+    if raw_status in {"verified", "success", "ok", True}:
+        return "pass"
+    if raw_status in {"warning", "shape-only"}:
+        return "warn"
+    if raw_status in {"failed", "error", False}:
+        return "fail"
+    return "warn"
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run the Fog Stack signature verification pipeline from external evidence to cryptographic verification record")
     parser.add_argument("--manifest", required=True, type=Path)
-    parser.add_argument("--raw-evidence", required=True, type=Path)
-    parser.add_argument("--tool", required=True, choices=["cosign", "sigstore", "other"])
-    parser.add_argument("--bundle-id", required=True)
-    parser.add_argument("--version", required=True)
+    parser.add_argument("--external-evidence", dest="external_evidence", type=Path, default=None)
+    parser.add_argument("--raw-evidence", dest="external_evidence", type=Path, default=None, help="deprecated alias for --external-evidence")
+    parser.add_argument("--tool", default="cosign", choices=["cosign", "sigstore", "other"])
+    parser.add_argument("--bundle-id", default=None)
+    parser.add_argument("--version", default=None)
     parser.add_argument("--signature-ref", default=None)
     parser.add_argument("--key-ref", default=None)
     parser.add_argument("--validation-record-ref", default=None)
@@ -29,48 +59,66 @@ def main() -> int:
     parser.add_argument("--release-evidence-index-ref", default=None)
     parser.add_argument("--normalized-output", type=Path, default=None)
     parser.add_argument("--record-output", type=Path, default=None)
+    parser.add_argument("--out", dest="record_output", type=Path, default=None, help="alias for --record-output")
     args = parser.parse_args()
 
-    manifest = load_json(args.manifest)
-    raw = load_json(args.raw_evidence)
+    if args.external_evidence is None:
+        print("ERR: --external-evidence is required", flush=True)
+        return EXIT_INVALID
+
+    try:
+        manifest = load_json(args.manifest)
+        raw = load_json(args.external_evidence)
+    except ValueError as exc:
+        print(f"ERR: {exc}", flush=True)
+        return EXIT_INVALID
+
+    manifest_digest = manifest.get("bundle_digest")
+    verified_digest = raw.get("verified_digest") or nested_summary_value(raw, "verified_digest")
+    raw_status = raw.get("status") or nested_summary_value(raw, "status") or "warn"
+    norm_status = normalize_status(raw_status)
+
+    if not isinstance(manifest_digest, str) or not manifest_digest:
+        print("ERR: manifest.bundle_digest is required", flush=True)
+        return EXIT_INVALID
+    if not isinstance(verified_digest, str) or not verified_digest:
+        print("ERR: external evidence verified_digest is required", flush=True)
+        return EXIT_INVALID
+
+    digest_match = manifest_digest == verified_digest
+    if norm_status == "pass" and digest_match:
+        record_status = "verified"
+        exit_code = EXIT_PASS
+    elif norm_status == "warn" and digest_match:
+        record_status = "shape-only"
+        exit_code = EXIT_WARN
+    else:
+        record_status = "failed"
+        exit_code = EXIT_FAIL
 
     normalized = {
         "kind": "FogStackExternalSignatureVerificationEvidence",
         "schema_version": "v0.1",
         "tool": args.tool,
-        "status": raw.get("status") or (raw.get("summary") or {}).get("status") or "unknown",
-        "message": raw.get("message") or (raw.get("summary") or {}).get("message"),
-        "verified_digest": raw.get("verified_digest") or (raw.get("summary") or {}).get("verified_digest"),
-        "evidence_count": raw.get("evidence_count") or (raw.get("summary") or {}).get("evidence_count"),
+        "status": norm_status,
+        "message": raw.get("message") or nested_summary_value(raw, "message"),
+        "verified_digest": verified_digest,
+        "evidence_count": raw.get("evidence_count") or nested_summary_value(raw, "evidence_count"),
         "key_ref": raw.get("key_ref") or args.key_ref,
-        "raw_ref": str(args.raw_evidence),
+        "raw_ref": str(args.external_evidence),
     }
-
-    manifest_digest = manifest.get("bundle_digest")
-    verified_digest = normalized.get("verified_digest")
-    digest_match = None
-    if isinstance(manifest_digest, str) and isinstance(verified_digest, str):
-        digest_match = manifest_digest == verified_digest
-
-    norm_status = normalized["status"]
-    if norm_status == "pass" and digest_match is True:
-        record_status = "verified"
-    elif norm_status == "fail" or digest_match is False:
-        record_status = "failed"
-    else:
-        record_status = "shape-only"
 
     record = {
         "kind": "FogStackCryptographicSignatureVerificationRecord",
         "schema_version": "v0.1",
-        "bundle_id": args.bundle_id,
-        "version": args.version,
+        "bundle_id": args.bundle_id or manifest.get("bundle_id"),
+        "version": args.version or manifest.get("version"),
         "manifest_ref": str(args.manifest),
-        "signature_ref": args.signature_ref or ((manifest.get("signature") or {}).get("ref")),
+        "signature_ref": args.signature_ref or ((manifest.get("signature") or {}).get("ref")) or "",
         "verification_tool": args.tool,
         "status": record_status,
         "summary": {
-            "status": norm_status,
+            "status": norm_status if exit_code != EXIT_FAIL else "fail",
             "message": normalized.get("message"),
             "verified_digest": verified_digest,
             "evidence_count": normalized.get("evidence_count"),
@@ -84,13 +132,24 @@ def main() -> int:
         "release_evidence_index_ref": args.release_evidence_index_ref,
     }
 
+    if not record["bundle_id"] or not record["version"]:
+        print("ERR: bundle_id and version must be supplied by args or manifest", flush=True)
+        return EXIT_INVALID
+
     if args.normalized_output:
+        args.normalized_output.parent.mkdir(parents=True, exist_ok=True)
         args.normalized_output.write_text(json.dumps(normalized, indent=2) + "\n", encoding="utf-8")
     if args.record_output:
+        args.record_output.parent.mkdir(parents=True, exist_ok=True)
         args.record_output.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
     if not args.normalized_output and not args.record_output:
         print(json.dumps({"normalized": normalized, "record": record}, indent=2))
-    return 0
+
+    if exit_code == EXIT_FAIL:
+        print("ERR: Fog Stack signature verification failed", flush=True)
+    elif exit_code == EXIT_WARN:
+        print("WARN: Fog Stack signature verification produced shape-only record", flush=True)
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_run_fogstack_signature_verification_pipeline_exitcodes.py
+++ b/tools/tests/test_run_fogstack_signature_verification_pipeline_exitcodes.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path("tools/run_fogstack_signature_verification_pipeline.py")
+
+
+def write_json(path: Path, data: dict[str, object]) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def base_manifest() -> dict[str, object]:
+    return {
+        "kind": "FogStackBundleManifest",
+        "schema_version": "v0.1",
+        "bundle_id": "fogstack.access",
+        "version": "0.1.0",
+        "bundle_digest": "sha256:abc123",
+        "signature": {"ref": "oci://example/fogstack.access.sig"},
+    }
+
+
+def run_pipeline(tmp_path: Path, evidence: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    manifest = tmp_path / "manifest.json"
+    raw = tmp_path / "cosign.json"
+    record = tmp_path / "record.json"
+    write_json(manifest, base_manifest())
+    write_json(raw, evidence)
+
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--manifest",
+            str(manifest),
+            "--external-evidence",
+            str(raw),
+            "--out",
+            str(record),
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_signature_pipeline_success_emits_verified_record(tmp_path: Path) -> None:
+    proc = run_pipeline(tmp_path, {"status": "pass", "verified_digest": "sha256:abc123"})
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    record = json.loads((tmp_path / "record.json").read_text(encoding="utf-8"))
+    assert record["status"] == "verified"
+    assert record["summary"]["manifest_digest_matches"] is True
+
+
+def test_signature_pipeline_digest_mismatch_fails_hard(tmp_path: Path) -> None:
+    proc = run_pipeline(tmp_path, {"status": "pass", "verified_digest": "sha256:wrong"})
+    assert proc.returncode == 2
+
+    record = json.loads((tmp_path / "record.json").read_text(encoding="utf-8"))
+    assert record["status"] == "failed"
+    assert record["summary"]["status"] == "fail"
+    assert record["summary"]["manifest_digest_matches"] is False
+
+
+def test_signature_pipeline_malformed_input_returns_invalid(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.json"
+    raw = tmp_path / "broken.json"
+    write_json(manifest, base_manifest())
+    raw.write_text("{not-json", encoding="utf-8")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--manifest",
+            str(manifest),
+            "--external-evidence",
+            str(raw),
+            "--out",
+            str(tmp_path / "record.json"),
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 3
+    assert not (tmp_path / "record.json").exists()
+
+
+def test_signature_pipeline_warning_returns_one(tmp_path: Path) -> None:
+    proc = run_pipeline(tmp_path, {"status": "warn", "verified_digest": "sha256:abc123"})
+    assert proc.returncode == 1
+
+    record = json.loads((tmp_path / "record.json").read_text(encoding="utf-8"))
+    assert record["status"] == "shape-only"
+    assert record["summary"]["manifest_digest_matches"] is True
+
+
+def test_signature_pipeline_raw_evidence_alias_still_works(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.json"
+    raw = tmp_path / "cosign.json"
+    record = tmp_path / "record.json"
+    write_json(manifest, base_manifest())
+    write_json(raw, {"status": "pass", "verified_digest": "sha256:abc123"})
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--manifest",
+            str(manifest),
+            "--raw-evidence",
+            str(raw),
+            "--record-output",
+            str(record),
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert json.loads(record.read_text(encoding="utf-8"))["status"] == "verified"


### PR DESCRIPTION
## Summary

Hardens `tools/run_fogstack_signature_verification_pipeline.py` so the CLI result matches the cryptographic verification outcome.

## What changed

- Adds canonical `--external-evidence` and `--out` arguments.
- Preserves existing aliases:
  - `--raw-evidence` for `--external-evidence`
  - `--record-output` for `--out`
- Makes invalid input return `3`.
- Makes warning / shape-only output return `1`.
- Makes digest mismatch or verification failure return `2`.
- Keeps verified success at `0`.
- Emits failed records on digest mismatch when an output path is supplied, so evidence remains inspectable.
- Documents the CLI and exit-code contract.
- Adds pytest coverage for success, digest mismatch, malformed JSON, warning, and legacy alias compatibility.

## Why this PR exists

The runner already emitted a `failed` record on digest mismatch, but the process still returned `0`. That is unsafe for CI and release gates because downstream jobs could treat failed cryptographic verification as success.

## Scope

Focused hardening only. This PR does not invoke cosign/sigstore directly, mutate trust records, or change registry publication behavior.
