### PR TITLE
sourceos: publish M2 lifecycle proof to filesystem registry

### DIFF
--- a/.github/workflows/sourceos-contracts.yml
+++ b/.github/workflows/sourceos-contracts.yml
@@ -8,6 +8,8 @@ on:
       - "tools/validate_sourceos_contracts.py"
       - "tools/build_sourceos_m2_lifecycle_proof.py"
       - "tools/smoke_sourceos_m2_lifecycle_proof.py"
+      - "tools/publish_sourceos_m2_filesystem_registry.py"
+      - "tools/smoke_sourceos_m2_filesystem_registry.py"
       - ".github/workflows/sourceos-contracts.yml"
   push:
     branches:
@@ -18,6 +20,8 @@ on:
       - "tools/validate_sourceos_contracts.py"
       - "tools/build_sourceos_m2_lifecycle_proof.py"
       - "tools/smoke_sourceos_m2_lifecycle_proof.py"
+      - "tools/publish_sourceos_m2_filesystem_registry.py"
+      - "tools/smoke_sourceos_m2_filesystem_registry.py"
       - ".github/workflows/sourceos-contracts.yml"
 
 jobs:
@@ -34,3 +38,5 @@ jobs:
         run: python tools/validate_sourceos_contracts.py
       - name: Smoke SourceOS M2 lifecycle proof
         run: python tools/smoke_sourceos_m2_lifecycle_proof.py
+      - name: Smoke SourceOS M2 filesystem registry
+        run: python tools/smoke_sourceos_m2_filesystem_registry.py

--- a/docs/SOURCEOS_M2_FILESYSTEM_REGISTRY.md
+++ b/docs/SOURCEOS_M2_FILESYSTEM_REGISTRY.md
@@ -1,0 +1,71 @@
+# SourceOS M2 filesystem registry
+
+This document defines the current local filesystem-registry proof path for the SourceOS M2 lifecycle bundle.
+
+## Goal
+
+Move from a generated deterministic M2 lifecycle proof bundle to a concrete local registry layout that can later be served, mirrored, or consumed by a boot/recovery planner.
+
+## Inputs
+
+The registry publisher consumes the proof bundle emitted by:
+
+```bash
+python tools/build_sourceos_m2_lifecycle_proof.py --output-dir <proof-dir>
+```
+
+That bundle contains:
+
+- `config-source.json`
+- `release-set.json`
+- `boot-release-set.json`
+- `nlboot-crosswalk.json`
+- `fingerprint.json`
+- `compliance-result.json`
+- `proof-index.json`
+
+## Registry layout
+
+The publisher writes:
+
+- `<registry-root>/sourceos/<release-id>/<version>/release-pointer.json`
+- `<registry-root>/sourceos/<release-id>/<version>/proof-index.json`
+- `<registry-root>/sourceos/<release-id>/<version>/artifacts/*`
+
+The release pointer records:
+
+- release id
+- version
+- proof index digest
+- copied proof artifacts and digests
+
+## Safety boundary
+
+This remains a local proof artifact publication path.
+
+It does not add:
+
+- network registry publication
+- artifact fetching by boot clients
+- host mutation
+- disk writes
+- `kexec`
+- remote state mutation
+
+## Validation
+
+The SourceOS contracts workflow now runs:
+
+```bash
+python tools/smoke_sourceos_m2_filesystem_registry.py
+```
+
+That smoke builds the M2 lifecycle proof bundle, publishes it into a temporary filesystem registry, and verifies that the release pointer references the required proof artifacts.
+
+## Follow-on
+
+Next useful tranche:
+
+1. make nlboot consume a registry-published manifest fixture without side effects,
+2. emit a synthetic boot `Fingerprint`, and
+3. validate that synthetic boot `Fingerprint` against the assigned `ReleaseSet` and `BootReleaseSet`.

--- a/tools/publish_sourceos_m2_filesystem_registry.py
+++ b/tools/publish_sourceos_m2_filesystem_registry.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def safe_copy_name(path: Path) -> str:
+    name = path.name
+    if not name or name in {".", ".."}:
+        raise SystemExit(f"ERR: unsafe artifact name for {path}")
+    return name
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Publish a SourceOS M2 proof bundle into a filesystem registry layout")
+    parser.add_argument("--proof-dir", required=True, type=Path)
+    parser.add_argument("--registry-root", required=True, type=Path)
+    parser.add_argument("--release-id", default="srset-m2-demo-0001")
+    parser.add_argument("--version", default="0.0.1-demo")
+    args = parser.parse_args()
+
+    proof_index_path = args.proof_dir / "proof-index.json"
+    proof_index = load_json(proof_index_path)
+    if proof_index.get("kind") != "SourceOSProofIndex":
+        raise SystemExit("ERR: proof-index kind mismatch")
+
+    release_root = args.registry_root / "sourceos" / args.release_id / args.version
+    artifacts_root = release_root / "artifacts"
+    artifacts_root.mkdir(parents=True, exist_ok=True)
+
+    copied_artifacts: list[dict[str, Any]] = []
+    for item in proof_index.get("artifacts") or []:
+        if not isinstance(item, dict):
+            raise SystemExit("ERR: proof-index artifact entry is not an object")
+        rel_path = item.get("path")
+        expected_digest = item.get("digest")
+        if not isinstance(rel_path, str):
+            raise SystemExit("ERR: proof-index artifact path missing")
+        source = args.proof_dir / rel_path
+        if not source.exists():
+            raise SystemExit(f"ERR: proof artifact missing: {source}")
+        actual_digest = sha256_file(source)
+        if actual_digest != expected_digest:
+            raise SystemExit(f"ERR: proof artifact digest mismatch: {source}")
+        target = artifacts_root / safe_copy_name(source)
+        shutil.copy2(source, target)
+        copied_artifacts.append({
+            "name": item.get("name"),
+            "kind": item.get("kind"),
+            "path": f"artifacts/{target.name}",
+            "digest": actual_digest,
+        })
+
+    proof_index_target = release_root / "proof-index.json"
+    shutil.copy2(proof_index_path, proof_index_target)
+
+    pointer = {
+        "kind": "SourceOSFilesystemRegistryReleasePointer",
+        "schema_version": "sourceos.filesystem-registry-pointer/v0",
+        "release_id": args.release_id,
+        "version": args.version,
+        "proof_index_ref": "proof-index.json",
+        "proof_index_digest": sha256_file(proof_index_target),
+        "artifacts": copied_artifacts,
+    }
+    write_json(release_root / "release-pointer.json", pointer)
+    print(json.dumps(pointer, indent=2, sort_keys=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/smoke_sourceos_m2_filesystem_registry.py
+++ b/tools/smoke_sourceos_m2_filesystem_registry.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def main() -> int:
+    with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        proof_dir = tmp_path / "proof"
+        registry_root = tmp_path / "registry"
+
+        subprocess.run([
+            sys.executable,
+            str(ROOT / "tools" / "build_sourceos_m2_lifecycle_proof.py"),
+            "--output-dir",
+            str(proof_dir),
+        ], check=True)
+
+        subprocess.run([
+            sys.executable,
+            str(ROOT / "tools" / "publish_sourceos_m2_filesystem_registry.py"),
+            "--proof-dir",
+            str(proof_dir),
+            "--registry-root",
+            str(registry_root),
+            "--release-id",
+            "srset-m2-demo-0001",
+            "--version",
+            "0.0.1-demo",
+        ], check=True)
+
+        release_root = registry_root / "sourceos" / "srset-m2-demo-0001" / "0.0.1-demo"
+        pointer_path = release_root / "release-pointer.json"
+        proof_index_path = release_root / "proof-index.json"
+        if not pointer_path.exists():
+            raise SystemExit("ERR: missing release-pointer.json")
+        if not proof_index_path.exists():
+            raise SystemExit("ERR: missing proof-index.json")
+
+        pointer = load(pointer_path)
+        if pointer.get("kind") != "SourceOSFilesystemRegistryReleasePointer":
+            raise SystemExit("ERR: release pointer kind mismatch")
+        artifact_paths = {item.get("path") for item in pointer.get("artifacts", [])}
+        required = {
+            "artifacts/config-source.json",
+            "artifacts/release-set.json",
+            "artifacts/boot-release-set.json",
+            "artifacts/nlboot-crosswalk.json",
+            "artifacts/fingerprint.json",
+            "artifacts/compliance-result.json",
+        }
+        missing = sorted(required - artifact_paths)
+        if missing:
+            raise SystemExit("ERR: registry pointer missing artifacts: " + ", ".join(missing))
+
+    print("SourceOS M2 filesystem registry smoke passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a local filesystem-registry publication smoke for the SourceOS M2 lifecycle proof bundle.

## Changes

- Adds `tools/publish_sourceos_m2_filesystem_registry.py`
- Adds `tools/smoke_sourceos_m2_filesystem_registry.py`
- Wires the smoke into `.github/workflows/sourceos-contracts.yml`
- Adds `docs/SOURCEOS_M2_FILESYSTEM_REGISTRY.md`

## Why

The M2 proof path now generates a coherent lifecycle bundle and nlboot crosswalk. This PR gives that generated proof bundle a concrete local registry layout that can later be served, mirrored, or consumed by nlboot without introducing live execution.

## Safety boundary

This remains a local proof artifact publication path.

No network registry publication, artifact fetching by boot clients, host mutation, disk writes, kexec execution, or remote state mutation is added.

## Validation

The SourceOS contracts workflow now runs:

```bash
python tools/validate_sourceos_contracts.py
python tools/smoke_sourceos_m2_lifecycle_proof.py
python tools/smoke_sourceos_m2_filesystem_registry.py
```
