### PR TITLE
SourceOS: adapt nlboot manifest into BootReleaseSet

### DIFF
--- a/.github/workflows/sourceos-contracts.yml
+++ b/.github/workflows/sourceos-contracts.yml
@@ -10,6 +10,8 @@ on:
       - "tools/smoke_sourceos_m2_lifecycle_proof.py"
       - "tools/publish_sourceos_m2_filesystem_registry.py"
       - "tools/smoke_sourceos_m2_filesystem_registry.py"
+      - "tools/convert_nlboot_manifest_to_sourceos_bootreleaseset.py"
+      - "tools/smoke_nlboot_to_sourceos_bootreleaseset.py"
       - ".github/workflows/sourceos-contracts.yml"
   push:
     branches:
@@ -22,6 +24,8 @@ on:
       - "tools/smoke_sourceos_m2_lifecycle_proof.py"
       - "tools/publish_sourceos_m2_filesystem_registry.py"
       - "tools/smoke_sourceos_m2_filesystem_registry.py"
+      - "tools/convert_nlboot_manifest_to_sourceos_bootreleaseset.py"
+      - "tools/smoke_nlboot_to_sourceos_bootreleaseset.py"
       - ".github/workflows/sourceos-contracts.yml"
 
 jobs:
@@ -40,3 +44,5 @@ jobs:
         run: python tools/smoke_sourceos_m2_lifecycle_proof.py
       - name: Smoke SourceOS M2 filesystem registry
         run: python tools/smoke_sourceos_m2_filesystem_registry.py
+      - name: Smoke nlboot BootReleaseSet adapter
+        run: python tools/smoke_nlboot_to_sourceos_bootreleaseset.py

--- a/contracts/sourceos/examples/nlboot-manifest.m2-demo.recovery.json
+++ b/contracts/sourceos/examples/nlboot-manifest.m2-demo.recovery.json
@@ -1,0 +1,16 @@
+{
+  "manifest_id": "urn:srcos:boot-manifest:m2-demo-recovery",
+  "boot_release_set_id": "urn:srcos:boot-release-set:m2-demo-recovery-2026-04-26",
+  "base_release_set_ref": "urn:srcos:release-set:m2-demo-2026-04-26",
+  "boot_mode": "recovery",
+  "artifacts": {
+    "kernel_ref": "urn:srcos:artifact:m2-demo-kernel",
+    "initrd_ref": "urn:srcos:artifact:m2-demo-initrd",
+    "rootfs_ref": "urn:srcos:artifact:m2-demo-rootfs"
+  },
+  "signature_ref": "urn:srcos:signature:m2-demo-recovery",
+  "signer_ref": "urn:srcos:key:sourceos-demo-signing-key-v0",
+  "signature_algorithm": "rsa-pss-sha256",
+  "crypto_profile": "fips-140-3-compatible",
+  "signature_hex": "7335ffa2b904c00ddd62cf7ff6cfaeec6147454476b7acf6aedc537a541768be3b323e3d0493d4372a976945d9161e1faecf6cb77fdd09e897e14c7327895ae0c7c65179ff4fe900af547cf517903847e05b680c69711d40b0c5a3413e5e9708b1db3f866c94921bd3d21d37f6f3d299ea34432f0b0312717ea5cff76edc93a6d632f5263a89e8e6b62d2e2f78306c3c30577ee6c3d659d55da504736097b909c96362899685c1d3124d37e40afe3665889d51fc57a55bc36312d992777a469c4775849f0c4be1741f7b155b1f875d2cb32e19a80d12c86a85fb64b392e06ecbbf315882a92d2a695ac8b20b875c0bcf547834b461"
+}

--- a/contracts/sourceos/examples/nlboot-token.m2-demo.recovery.json
+++ b/contracts/sourceos/examples/nlboot-token.m2-demo.recovery.json
@@ -1,0 +1,14 @@
+{
+  "token_id": "urn:srcos:enrollment-token:m2-demo-recovery",
+  "purpose": "recovery",
+  "audience": {
+    "subject_kind": "device",
+    "subject_id": "urn:srcos:device:m2-local-demo"
+  },
+  "release_set_ref": "urn:srcos:release-set:m2-demo-2026-04-26",
+  "boot_release_set_ref": "urn:srcos:boot-release-set:m2-demo-recovery-2026-04-26",
+  "one_time_use": true,
+  "issued_at": "2026-04-26T14:31:00Z",
+  "expires_at": "2026-04-26T14:46:00Z",
+  "status": "issued"
+}

--- a/tools/convert_nlboot_manifest_to_sourceos_bootreleaseset.py
+++ b/tools/convert_nlboot_manifest_to_sourceos_bootreleaseset.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+try:
+    import jsonschema
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit("ERR: jsonschema is required to validate SourceOS BootReleaseSet output") from exc
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts" / "sourceos" / "boot-release-set.v0.schema.json"
+
+BOOT_MODE_MAP = {
+    "recovery": "recovery",
+    "installer": "installer",
+    "ephemeral": "live",
+    "bootstrap": "live",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def digest_for_ref(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def require_string(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise SystemExit(f"ERR: {key} must be a non-empty string")
+    return value
+
+
+def convert(manifest: dict[str, Any], token: dict[str, Any]) -> dict[str, Any]:
+    boot_mode = require_string(manifest, "boot_mode")
+    if boot_mode not in BOOT_MODE_MAP:
+        raise SystemExit(f"ERR: unsupported nlboot boot_mode={boot_mode!r}")
+
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict):
+        raise SystemExit("ERR: manifest.artifacts must be an object")
+    for required in ("kernel_ref", "initrd_ref", "rootfs_ref"):
+        if not isinstance(artifacts.get(required), str) or not artifacts[required]:
+            raise SystemExit(f"ERR: manifest.artifacts.{required} is required")
+
+    token_boot_ref = require_string(token, "boot_release_set_ref")
+    manifest_boot_ref = require_string(manifest, "boot_release_set_id")
+    if token_boot_ref != manifest_boot_ref:
+        raise SystemExit("ERR: token boot_release_set_ref does not match manifest boot_release_set_id")
+    token_release_ref = require_string(token, "release_set_ref")
+    manifest_release_ref = require_string(manifest, "base_release_set_ref")
+    if token_release_ref != manifest_release_ref:
+        raise SystemExit("ERR: token release_set_ref does not match manifest base_release_set_ref")
+
+    signature_algorithm = require_string(manifest, "signature_algorithm")
+    crypto_profile = require_string(manifest, "crypto_profile")
+    if signature_algorithm != "rsa-pss-sha256":
+        raise SystemExit("ERR: only rsa-pss-sha256 nlboot manifests are accepted")
+    if crypto_profile != "fips-140-3-compatible":
+        raise SystemExit("ERR: only fips-140-3-compatible nlboot manifests are accepted")
+
+    source_artifacts = [
+        ("kernel", artifacts["kernel_ref"]),
+        ("initrd", artifacts["initrd_ref"]),
+        ("rootfs", artifacts["rootfs_ref"]),
+        ("manifest", require_string(manifest, "manifest_id")),
+    ]
+
+    sourceos_mode = BOOT_MODE_MAP[boot_mode]
+    boot_modes = [sourceos_mode]
+    if sourceos_mode == "recovery":
+        boot_modes.append("rollback")
+
+    return {
+        "schema_version": "sourceos.boot-release-set/v0",
+        "kind": "SourceOSBootReleaseSet",
+        "id": "sbrs-nlboot-m2-demo-recovery-0001",
+        "description": "SourceOS BootReleaseSet generated from nlboot signed M2 recovery manifest metadata.",
+        "created_at": "2026-04-26T19:30:00Z",
+        "channel": "dev",
+        "parent_release_set_ref": manifest_release_ref,
+        "boot_modes": boot_modes,
+        "platform_entrypoints": [
+            {
+                "platform": "apple_silicon",
+                "entry_kind": "asahi_installer_entry",
+                "entry_ref": manifest_boot_ref,
+                "notes": "Generated from nlboot signed manifest; actual Apple Silicon packaging remains a PAL-Mac tranche.",
+            },
+            {
+                "platform": "generic",
+                "entry_kind": "disk_image",
+                "entry_ref": manifest_boot_ref,
+                "notes": "Generic side-effect-free adapter path for nlboot bootstrap media.",
+            },
+        ],
+        "artifacts": [
+            {
+                "name": f"nlboot-{kind}",
+                "artifact_kind": kind,
+                "uri": ref,
+                "digest": digest_for_ref(ref),
+                "size_bytes": 0,
+            }
+            for kind, ref in source_artifacts
+        ],
+        "authorization": {
+            "mode": "single_use_code" if token.get("one_time_use") is True else "device_claim",
+            "token_binding": "device_claim",
+            "ttl_seconds": 900,
+            "requires_online_redemption": True,
+        },
+        "capabilities": {
+            "disk_write": "scoped" if sourceos_mode in {"installer", "recovery", "rollback"} else "denied",
+            "network": "restricted",
+            "kexec": "denied",
+            "rollback": "allowed" if "rollback" in boot_modes else "denied",
+            "enrollment": "allowed",
+        },
+        "proof_requirements": {
+            "emit_fingerprint": True,
+            "emit_manifest_hashes": True,
+            "emit_boot_log_ref": True,
+            "required_report_endpoint": "tritrpc:sourceos.boot.proof.report",
+        },
+        "offline_fallback": {
+            "allowed": True,
+            "last_known_good_ref": "sbrs-m2-demo-recovery-0000",
+            "max_age_seconds": 604800,
+        },
+        "signatures": [
+            {
+                "key_id": require_string(manifest, "signer_ref"),
+                "algorithm": "x509",
+                "signature_ref": require_string(manifest, "signature_ref"),
+            }
+        ],
+    }
+
+
+def validate_output(document: dict[str, Any]) -> None:
+    schema = load_json(SCHEMA)
+    jsonschema.Draft202012Validator.check_schema(schema)
+    errors = sorted(jsonschema.Draft202012Validator(schema).iter_errors(document), key=lambda err: list(err.path))
+    if errors:
+        for err in errors:
+            loc = ".".join(str(part) for part in err.path) or "<root>"
+            print(f"{loc}: {err.message}")
+        raise SystemExit(1)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Convert nlboot signed manifest metadata into SourceOS BootReleaseSet")
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--token", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--no-validate", action="store_true")
+    args = parser.parse_args()
+
+    document = convert(load_json(args.manifest), load_json(args.token))
+    if not args.no_validate:
+        validate_output(document)
+    write_json(args.output, document)
+    print(f"SourceOS BootReleaseSet written to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/smoke_nlboot_to_sourceos_bootreleaseset.py
+++ b/tools/smoke_nlboot_to_sourceos_bootreleaseset.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected object in {path}")
+    return data
+
+
+def main() -> int:
+    with TemporaryDirectory() as tmp:
+        output = Path(tmp) / "boot-release-set.from-nlboot.json"
+        subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "tools" / "convert_nlboot_manifest_to_sourceos_bootreleaseset.py"),
+                "--manifest",
+                str(ROOT / "contracts" / "sourceos" / "examples" / "nlboot-manifest.m2-demo.recovery.json"),
+                "--token",
+                str(ROOT / "contracts" / "sourceos" / "examples" / "nlboot-token.m2-demo.recovery.json"),
+                "--output",
+                str(output),
+            ],
+            check=True,
+        )
+        document = load_json(output)
+        if document.get("kind") != "SourceOSBootReleaseSet":
+            raise SystemExit("ERR: generated document is not a SourceOSBootReleaseSet")
+        if "recovery" not in document.get("boot_modes", []):
+            raise SystemExit("ERR: generated BootReleaseSet is missing recovery mode")
+        if document.get("capabilities", {}).get("kexec") != "denied":
+            raise SystemExit("ERR: adapter must not enable kexec")
+        if document.get("capabilities", {}).get("network") != "restricted":
+            raise SystemExit("ERR: adapter must keep network restricted")
+        if document.get("authorization", {}).get("mode") != "single_use_code":
+            raise SystemExit("ERR: expected single_use_code authorization")
+        signature = (document.get("signatures") or [{}])[0]
+        if signature.get("signature_ref") != "urn:srcos:signature:m2-demo-recovery":
+            raise SystemExit("ERR: signature_ref was not preserved")
+
+    print("nlboot to SourceOS BootReleaseSet adapter smoke passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Superseded

This PR is superseded by `#223`, which re-landed the same side-effect-free nlboot manifest → SourceOS BootReleaseSet adapter from current `main` and was merged as commit `3bcf02364f9fe0e7c985ddc9190a6be28d534a86`.

Closing to avoid duplicate adapter work and reduce review noise.

## Original summary

Adds a side-effect-free adapter that maps nlboot signed M2 recovery manifest metadata into a SourceOS `BootReleaseSet` object.

This PR adds:

- nlboot M2 recovery manifest fixture
- nlboot M2 recovery enrollment token fixture
- `tools/convert_nlboot_manifest_to_sourceos_bootreleaseset.py`
- `tools/smoke_nlboot_to_sourceos_bootreleaseset.py`
- SourceOS workflow coverage for the adapter smoke, alongside lifecycle proof and filesystem registry smokes

## Safety posture

The adapter preserves the safe boundary:

- validates manifest/token binding
- requires `rsa-pss-sha256`
- requires `fips-140-3-compatible`
- emits schema-valid `SourceOSBootReleaseSet`
- sets `kexec` capability to `denied`
- keeps network `restricted`
- preserves signature reference as evidence
