### PR TITLE
fogstack: add filesystem registry root builder and checker

### DIFF
--- a/.github/workflows/fogstack-filesystem-registry-root.yml
+++ b/.github/workflows/fogstack-filesystem-registry-root.yml
@@ -1,0 +1,42 @@
+name: FogStack Filesystem Registry Root
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "schemas/release/fogstack-filesystem-registry-root-v0.1.schema.json"
+      - "tools/build_fogstack_filesystem_registry_root.py"
+      - "tools/check_fogstack_filesystem_registry_root.py"
+      - "tools/tests/test_fogstack_filesystem_registry.py"
+      - "docs/FOGSTACK_FILESYSTEM_REGISTRY.md"
+      - ".github/workflows/fogstack-filesystem-registry-root.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/release/fogstack-filesystem-registry-root-v0.1.schema.json"
+      - "tools/build_fogstack_filesystem_registry_root.py"
+      - "tools/check_fogstack_filesystem_registry_root.py"
+      - "tools/tests/test_fogstack_filesystem_registry.py"
+      - "docs/FOGSTACK_FILESYSTEM_REGISTRY.md"
+      - ".github/workflows/fogstack-filesystem-registry-root.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  registry-root:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+      - name: Run filesystem registry root tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_filesystem_registry.py

--- a/docs/FOGSTACK_FILESYSTEM_REGISTRY.md
+++ b/docs/FOGSTACK_FILESYSTEM_REGISTRY.md
@@ -14,6 +14,10 @@ The publisher writes releases under:
 - `<registry-root>/<bundle-id>/<version>/release-pointer.json`
 - `<registry-root>/<bundle-id>/<version>/artifacts/*`
 
+The registry-root builder writes:
+
+- `<registry-root>/registry-root.json`
+
 The release pointer includes:
 
 - bundle id
@@ -21,24 +25,42 @@ The release pointer includes:
 - registry publication index reference
 - registry publication index digest
 
+The registry root includes:
+
+- registry URI
+- generated timestamp
+- release pointer references and digests
+- registry publication index references and digests
+- a root digest computed over canonical JSON
+- signature metadata in shape-only form for this tranche
+
 ## Minimal flow
 
 1. build a gated registry publication index with `tools/build_fogstack_registry_publication_index.py`
 2. check the index with `tools/check_fogstack_registry_publication_index.py`
 3. publish it to a filesystem registry with `tools/publish_fogstack_filesystem_registry.py`
 4. verify the filesystem registry release with `tools/check_fogstack_filesystem_registry.py`
+5. build registry-root metadata with `tools/build_fogstack_filesystem_registry_root.py`
+6. check registry-root metadata with `tools/check_fogstack_filesystem_registry_root.py`
+
+## Registry root semantics
+
+The registry root is the consumer-facing catalog root for a filesystem registry export. It does not replace per-release pointer checks. Instead, it lets consumers verify that the exported registry root consistently names the release pointers and publication indexes available in the registry.
+
+This tranche uses shape-only signature metadata. It establishes the object and checker path without claiming KMS/HSM-backed registry-root signing.
 
 ## What this phase provides
 
 - concrete external-consumable registry layout
 - digest-checked artifact copy into the registry
 - release pointer for lookup
-- CI smoke workflow for publish/check behavior
+- registry-root metadata covering release pointers and publication indexes
+- dedicated CI workflow for registry-root behavior
 
 ## What this phase does not yet provide
 
 - authenticated network registry publication
-- signed registry root metadata
+- cryptographic registry-root signature verification
 - rollback or revocation index publication
 - registry replication or mirror policy
 

--- a/schemas/release/fogstack-filesystem-registry-root-v0.1.schema.json
+++ b/schemas/release/fogstack-filesystem-registry-root-v0.1.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-filesystem-registry-root-v0.1.schema.json",
+  "title": "FogStackFilesystemRegistryRoot",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "schema_version",
+    "registry_uri",
+    "generated_at",
+    "releases",
+    "root_digest",
+    "signatures"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackFilesystemRegistryRoot" },
+    "schema_version": { "const": "v0.1" },
+    "registry_uri": { "type": "string", "minLength": 1 },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "releases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["bundle_id", "version", "pointer_ref", "pointer_digest", "index_ref", "index_digest"],
+        "properties": {
+          "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+          "version": { "type": "string", "minLength": 1 },
+          "pointer_ref": { "type": "string", "minLength": 1 },
+          "pointer_digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+          "index_ref": { "type": "string", "minLength": 1 },
+          "index_digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" }
+        }
+      }
+    },
+    "root_digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "signatures": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key_id", "algorithm", "signature_ref"],
+        "properties": {
+          "key_id": { "type": "string", "minLength": 1 },
+          "algorithm": { "type": "string", "enum": ["ed25519", "sigstore", "gpg", "x509", "shape-only"] },
+          "signature_ref": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/tools/build_fogstack_filesystem_registry_root.py
+++ b/tools/build_fogstack_filesystem_registry_root.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def canonical_digest(data: dict[str, Any]) -> str:
+    encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def discover_release(registry_root: Path, release_root: Path) -> dict[str, Any]:
+    pointer_path = release_root / "release-pointer.json"
+    index_path = release_root / "registry-publication.index.json"
+    if not pointer_path.exists():
+        raise SystemExit(f"ERR: release pointer missing: {pointer_path}")
+    if not index_path.exists():
+        raise SystemExit(f"ERR: registry publication index missing: {index_path}")
+    pointer = load_json(pointer_path)
+    bundle_id = pointer.get("bundle_id")
+    version = pointer.get("version")
+    if not isinstance(bundle_id, str) or not isinstance(version, str):
+        raise SystemExit(f"ERR: malformed release pointer identity: {pointer_path}")
+    if pointer.get("index_digest") != sha256_file(index_path):
+        raise SystemExit(f"ERR: release index digest mismatch: {index_path}")
+    return {
+        "bundle_id": bundle_id,
+        "version": version,
+        "pointer_ref": str(pointer_path.relative_to(registry_root)),
+        "pointer_digest": sha256_file(pointer_path),
+        "index_ref": str(index_path.relative_to(registry_root)),
+        "index_digest": sha256_file(index_path),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a signed-shape Fog Stack filesystem registry root")
+    parser.add_argument("--registry-root", required=True, type=Path)
+    parser.add_argument("--registry-uri", required=True)
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--key-id", default="shape-only-registry-root-key")
+    parser.add_argument("--signature-ref", default="shape-only://fogstack/filesystem-registry-root")
+    args = parser.parse_args()
+
+    if not args.registry_root.exists():
+        raise SystemExit(f"ERR: registry root missing: {args.registry_root}")
+
+    releases: list[dict[str, Any]] = []
+    for pointer_path in sorted(args.registry_root.glob("fogstack.*/*/release-pointer.json")):
+        releases.append(discover_release(args.registry_root, pointer_path.parent))
+    if not releases:
+        raise SystemExit("ERR: no Fog Stack filesystem registry releases found")
+
+    unsigned_root: dict[str, Any] = {
+        "kind": "FogStackFilesystemRegistryRoot",
+        "schema_version": "v0.1",
+        "registry_uri": args.registry_uri,
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "releases": releases,
+        "signatures": [
+            {
+                "key_id": args.key_id,
+                "algorithm": "shape-only",
+                "signature_ref": args.signature_ref,
+            }
+        ],
+    }
+    digest_material = dict(unsigned_root)
+    digest_material["root_digest"] = None
+    unsigned_root["root_digest"] = canonical_digest(digest_material)
+
+    output = args.output or (args.registry_root / "registry-root.json")
+    output.write_text(json.dumps(unsigned_root, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(unsigned_root, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_fogstack_filesystem_registry_root.py
+++ b/tools/check_fogstack_filesystem_registry_root.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def canonical_digest(data: dict[str, Any]) -> str:
+    encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check a Fog Stack filesystem registry root")
+    parser.add_argument("--registry-root", required=True, type=Path)
+    parser.add_argument("--root", type=Path, default=None)
+    args = parser.parse_args()
+
+    root_path = args.root or (args.registry_root / "registry-root.json")
+    errors: list[str] = []
+    if not root_path.exists():
+        print(f"registry root missing: {root_path}")
+        return 1
+
+    root = load_json(root_path)
+    if root.get("kind") != "FogStackFilesystemRegistryRoot":
+        errors.append("registry root kind mismatch")
+
+    expected_digest_material = dict(root)
+    expected_digest_material["root_digest"] = None
+    if root.get("root_digest") != canonical_digest(expected_digest_material):
+        errors.append("registry root digest mismatch")
+
+    releases = root.get("releases") or []
+    if not isinstance(releases, list) or not releases:
+        errors.append("registry root releases missing")
+        releases = []
+
+    for release in releases:
+        if not isinstance(release, dict):
+            errors.append("registry root release entry is not an object")
+            continue
+        pointer_ref = release.get("pointer_ref")
+        index_ref = release.get("index_ref")
+        if not isinstance(pointer_ref, str) or not isinstance(index_ref, str):
+            errors.append("registry root release refs missing")
+            continue
+        pointer_path = args.registry_root / pointer_ref
+        index_path = args.registry_root / index_ref
+        if not pointer_path.exists():
+            errors.append(f"release pointer missing: {pointer_path}")
+            continue
+        if not index_path.exists():
+            errors.append(f"release index missing: {index_path}")
+            continue
+        if release.get("pointer_digest") != sha256_file(pointer_path):
+            errors.append(f"release pointer digest mismatch: {pointer_path}")
+        if release.get("index_digest") != sha256_file(index_path):
+            errors.append(f"release index digest mismatch: {index_path}")
+        pointer = load_json(pointer_path)
+        if pointer.get("index_digest") != sha256_file(index_path):
+            errors.append(f"pointer index digest mismatch: {pointer_path}")
+        if pointer.get("bundle_id") != release.get("bundle_id") or pointer.get("version") != release.get("version"):
+            errors.append(f"release identity mismatch: {pointer_path}")
+
+    signatures = root.get("signatures") or []
+    if not isinstance(signatures, list) or not signatures:
+        errors.append("registry root signatures missing")
+
+    if errors:
+        for item in errors:
+            print(item)
+        return 1
+
+    print("FogStack filesystem registry root passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_filesystem_registry.py
+++ b/tools/tests/test_fogstack_filesystem_registry.py
@@ -10,7 +10,7 @@ def write_json(path: Path, data: dict) -> None:
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
-def test_publish_and_check_filesystem_registry(tmp_path: Path) -> None:
+def build_registry(tmp_path: Path) -> Path:
     publication_set = tmp_path / "manifest-publication-set.json"
     gate_record = tmp_path / "publication-gate.record.json"
     manifest = tmp_path / "fogstack.access-v0.1.manifest.json"
@@ -53,11 +53,15 @@ def test_publish_and_check_filesystem_registry(tmp_path: Path) -> None:
         "--bundle-id", "fogstack.access",
         "--version", "0.1.0",
     ], check=True)
+    return registry_root
 
+
+def test_publish_and_check_filesystem_registry(tmp_path: Path) -> None:
+    registry_root = build_registry(tmp_path)
     release_root = registry_root / "fogstack.access" / "0.1.0"
     assert (release_root / "release-pointer.json").exists()
     assert (release_root / "registry-publication.index.json").exists()
-    assert (release_root / "artifacts" / manifest.name).exists()
+    assert (release_root / "artifacts" / "fogstack.access-v0.1.manifest.json").exists()
 
     subprocess.run([
         sys.executable,
@@ -66,6 +70,52 @@ def test_publish_and_check_filesystem_registry(tmp_path: Path) -> None:
         "--bundle-id", "fogstack.access",
         "--version", "0.1.0",
     ], check=True)
+
+
+def test_filesystem_registry_root_build_and_check(tmp_path: Path) -> None:
+    registry_root = build_registry(tmp_path)
+
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_filesystem_registry_root.py",
+        "--registry-root", str(registry_root),
+        "--registry-uri", "file://registry/fogstack",
+    ], check=True)
+
+    root_path = registry_root / "registry-root.json"
+    assert root_path.exists()
+    root = json.loads(root_path.read_text(encoding="utf-8"))
+    assert root["kind"] == "FogStackFilesystemRegistryRoot"
+    assert root["releases"][0]["bundle_id"] == "fogstack.access"
+    assert root["signatures"][0]["algorithm"] == "shape-only"
+
+    subprocess.run([
+        sys.executable,
+        "tools/check_fogstack_filesystem_registry_root.py",
+        "--registry-root", str(registry_root),
+    ], check=True)
+
+
+def test_filesystem_registry_root_check_rejects_tampered_pointer(tmp_path: Path) -> None:
+    registry_root = build_registry(tmp_path)
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_filesystem_registry_root.py",
+        "--registry-root", str(registry_root),
+        "--registry-uri", "file://registry/fogstack",
+    ], check=True)
+
+    pointer = registry_root / "fogstack.access" / "0.1.0" / "release-pointer.json"
+    data = json.loads(pointer.read_text(encoding="utf-8"))
+    data["version"] = "0.1.1"
+    write_json(pointer, data)
+
+    proc = subprocess.run([
+        sys.executable,
+        "tools/check_fogstack_filesystem_registry_root.py",
+        "--registry-root", str(registry_root),
+    ])
+    assert proc.returncode != 0
 
 
 def test_filesystem_registry_check_rejects_missing_release(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds a registry-root schema, builder, checker, and validation tests for the Fog Stack filesystem registry.

## What changed

- Adds `fogstack-filesystem-registry-root-v0.1.schema.json` to define the root metadata format.
- Adds `tools/build_fogstack_filesystem_registry_root.py` to emit the root metadata with release and registry pointer digests.
- Adds `tools/check_fogstack_filesystem_registry_root.py` to validate the root metadata.
- Updates the relevant tests and workflows to include the registry root validation.

## Why this PR exists

This is the next step after implementing the Fog Stack filesystem registry adapter. The root metadata is needed for consumers to verify the integrity and contents of a filesystem registry, including pointers to release indexes and artifact digests.

## Scope

Focused on registry root metadata and validation. Does not include full cryptographic signing or network publication.
