### PR TITLE
ci(search): update image workflow triggers

### DIFF
--- a/.github/workflows/search-orchestrator-image.yml
+++ b/.github/workflows/search-orchestrator-image.yml
@@ -1,16 +1,21 @@
 name: search-orchestrator-image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
     paths:
       - 'services/search-orchestrator/**'
       - '.github/workflows/search-orchestrator-image.yml'
+      - '.github/workflows/search-orchestrator-image-pin.yml'
+      - 'tools/apply_search_orchestrator_image_lock.py'
   pull_request:
     paths:
       - 'services/search-orchestrator/**'
       - '.github/workflows/search-orchestrator-image.yml'
+      - '.github/workflows/search-orchestrator-image-pin.yml'
+      - 'tools/apply_search_orchestrator_image_lock.py'
       - 'tools/validate_search_orchestrator_image_release.py'
       - 'releases/images/search-orchestrator.image-lock.example.json'
 
@@ -27,7 +32,7 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -44,7 +49,7 @@ jobs:
           tags: ghcr.io/socioprophet/prophet-platform/search-orchestrator:pr-${{ github.event.pull_request.number }}
 
       - name: Build and push image
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         id: build
         uses: docker/build-push-action@v6
         with:
@@ -56,7 +61,7 @@ jobs:
             ghcr.io/socioprophet/prophet-platform/search-orchestrator:${{ github.sha }}
 
       - name: Emit digest evidence
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: |
           mkdir -p image-evidence
           cat > image-evidence/search-orchestrator-image.json <<EOF
@@ -69,7 +74,7 @@ jobs:
           EOF
 
       - name: Upload digest evidence
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: search-orchestrator-image-evidence


### PR DESCRIPTION
## Summary

Updates the Search Orchestrator image workflow so it can be run on demand and so related image-pin workflow changes are included in validation.

## Scope

- Adds manual workflow dispatch support
- Includes image pin workflow and image lock applier paths in image workflow filters
- Keeps PR behavior as build-only and non-publishing

## Safety posture

Workflow-only change. No runtime route behavior change.