### PR TITLE
sourceos: use captured nlboot plan fixture for boot fingerprint smoke

### DIFF
--- a/contracts/sourceos/examples/nlboot-plan.m2-demo.recovery.json
+++ b/contracts/sourceos/examples/nlboot-plan.m2-demo.recovery.json
@@ -1,0 +1,18 @@
+{
+  "ok": true,
+  "plan": {
+    "action": "boot-recovery",
+    "manifest_id": "urn:srcos:boot-manifest:m2-demo-recovery",
+    "boot_release_set_id": "sbrs-nlboot-m2-demo-recovery-0001",
+    "release_set_ref": "srset-m2-demo-0001",
+    "artifacts": {
+      "kernel_ref": "urn:srcos:artifact:m2-demo-kernel",
+      "initrd_ref": "urn:srcos:artifact:m2-demo-initrd",
+      "rootfs_ref": "urn:srcos:artifact:m2-demo-rootfs"
+    },
+    "authorized_by": "urn:srcos:enrollment-token:m2-demo-recovery",
+    "signature_algorithm": "rsa-pss-sha256",
+    "crypto_profile": "fips-140-3-compatible",
+    "execute": false
+  }
+}

--- a/tools/smoke_sourceos_synthetic_boot_fingerprint.py
+++ b/tools/smoke_sourceos_synthetic_boot_fingerprint.py
@@ -22,8 +22,8 @@ def main() -> int:
         tmp_path = Path(tmp)
         proof_dir = tmp_path / "proof"
         generated_boot_release = tmp_path / "boot-release-set.from-nlboot.json"
-        boot_plan = tmp_path / "nlboot-plan.json"
         fingerprint = tmp_path / "synthetic-boot-fingerprint.json"
+        boot_plan = ROOT / "contracts" / "sourceos" / "examples" / "nlboot-plan.m2-demo.recovery.json"
 
         subprocess.run([
             sys.executable,
@@ -43,25 +43,8 @@ def main() -> int:
             str(generated_boot_release),
         ], check=True)
 
-        # Synthetic equivalent of nlboot-plan output; this stays side-effect-free.
-        boot_plan.write_text(json.dumps({
-            "ok": True,
-            "plan": {
-                "action": "boot-recovery",
-                "manifest_id": "urn:srcos:boot-manifest:m2-demo-recovery",
-                "boot_release_set_id": "sbrs-nlboot-m2-demo-recovery-0001",
-                "release_set_ref": "srset-m2-demo-0001",
-                "artifacts": {
-                    "kernel_ref": "urn:srcos:artifact:m2-demo-kernel",
-                    "initrd_ref": "urn:srcos:artifact:m2-demo-initrd",
-                    "rootfs_ref": "urn:srcos:artifact:m2-demo-rootfs"
-                },
-                "authorized_by": "urn:srcos:enrollment-token:m2-demo-recovery",
-                "signature_algorithm": "rsa-pss-sha256",
-                "crypto_profile": "fips-140-3-compatible",
-                "execute": False
-            }
-        }, indent=2) + "\n", encoding="utf-8")
+        if load(boot_plan).get("plan", {}).get("execute") is not False:
+            raise SystemExit("ERR: captured nlboot-plan fixture must remain execute=false")
 
         subprocess.run([
             sys.executable,


### PR DESCRIPTION
## Summary

Replaces the inline synthetic nlboot-plan-shaped object in the SourceOS synthetic boot Fingerprint smoke with a checked-in captured plan fixture.

## Adds

- `contracts/sourceos/examples/nlboot-plan.m2-demo.recovery.json`
- smoke update so `tools/smoke_sourceos_synthetic_boot_fingerprint.py` consumes the fixture
- explicit assertion that the captured plan remains `execute=false`

## Why

The previous tranche proved synthetic boot Fingerprint emission. This tightens the proof path by making the nlboot-plan-shaped input a reusable fixture rather than an inline object hidden inside the smoke script.

## Safety boundary

Still proof-only.

No live boot execution, nlboot execution, artifact fetching, host mutation, disk writes, kexec execution, or remote state mutation is added.

## Validation

Existing SourceOS workflow continues to run:

```bash
python tools/smoke_sourceos_synthetic_boot_fingerprint.py
```
