### PR TITLE
sourceos: add boot fingerprint compliance helper

### DIFF
--- a/tools/check_sourceos_boot_fingerprint_compliance.py
+++ b/tools/check_sourceos_boot_fingerprint_compliance.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def check(name: str, expected: Any, observed: Any) -> dict[str, str]:
+    passed = expected == observed
+    return {
+        "name": name,
+        "status": "pass" if passed else "fail",
+        "expected": str(expected),
+        "observed": str(observed),
+    }
+
+
+def evaluate(release_set: dict[str, Any], boot_release_set: dict[str, Any], fingerprint: dict[str, Any]) -> dict[str, Any]:
+    release_id = release_set.get("id")
+    boot_release_id = boot_release_set.get("id")
+    policy_ref = release_set.get("policy", {}).get("policy_bundle_ref")
+
+    checks = [
+        check("release-set-ref", release_id, fingerprint.get("policy", {}).get("release_set_ref")),
+        check("boot-release-set-ref", boot_release_id, fingerprint.get("policy", {}).get("boot_release_set_ref")),
+        check("policy-bundle-ref", policy_ref, fingerprint.get("policy", {}).get("policy_bundle_ref")),
+        check("subject-kind", "boot_environment", fingerprint.get("subject", {}).get("subject_kind")),
+        check("runtime-isolation", "boot_env", fingerprint.get("runtime", {}).get("isolation")),
+        check("boot-mode", "recovery", fingerprint.get("system", {}).get("boot_mode")),
+    ]
+
+    boot_modes = set(boot_release_set.get("boot_modes") or [])
+    checks.append(check("rollback-available", "rollback" in boot_modes, fingerprint.get("system", {}).get("rollback_available")))
+
+    expected_network = boot_release_set.get("capabilities", {}).get("network", "restricted")
+    checks.append(check("network-scope", expected_network, fingerprint.get("policy", {}).get("network_scope")))
+
+    expected_fs = "scoped" if boot_release_set.get("capabilities", {}).get("disk_write") == "scoped" else "none"
+    checks.append(check("filesystem-scope", expected_fs, fingerprint.get("policy", {}).get("filesystem_scope")))
+
+    status = "fail" if any(item["status"] == "fail" for item in checks) else "pass"
+    return {
+        "schema_version": "sourceos.boot-fingerprint-compliance/v0",
+        "kind": "SourceOSBootFingerprintComplianceResult",
+        "status": status,
+        "release_set_ref": str(release_id),
+        "boot_release_set_ref": str(boot_release_id),
+        "fingerprint_ref": str(fingerprint.get("id")),
+        "checks": checks,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check SourceOS boot Fingerprint against assigned ReleaseSet and BootReleaseSet")
+    parser.add_argument("--release-set", required=True, type=Path)
+    parser.add_argument("--boot-release-set", required=True, type=Path)
+    parser.add_argument("--fingerprint", required=True, type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    result = evaluate(load_json(args.release_set), load_json(args.boot_release_set), load_json(args.fingerprint))
+    text = json.dumps(result, indent=2, sort_keys=False) + "\n"
+    if args.output:
+        write_json(args.output, result)
+    else:
+        print(text, end="")
+    return 0 if result["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/smoke_sourceos_synthetic_boot_fingerprint.py
+++ b/tools/smoke_sourceos_synthetic_boot_fingerprint.py
@@ -23,6 +23,7 @@ def main() -> int:
         proof_dir = tmp_path / "proof"
         generated_boot_release = tmp_path / "boot-release-set.from-nlboot.json"
         fingerprint = tmp_path / "synthetic-boot-fingerprint.json"
+        compliance = tmp_path / "boot-fingerprint-compliance.json"
         boot_plan = ROOT / "contracts" / "sourceos" / "examples" / "nlboot-plan.m2-demo.recovery.json"
 
         subprocess.run([
@@ -59,21 +60,31 @@ def main() -> int:
             str(fingerprint),
         ], check=True)
 
+        subprocess.run([
+            sys.executable,
+            str(ROOT / "tools" / "check_sourceos_boot_fingerprint_compliance.py"),
+            "--release-set",
+            str(proof_dir / "release-set.json"),
+            "--boot-release-set",
+            str(generated_boot_release),
+            "--fingerprint",
+            str(fingerprint),
+            "--output",
+            str(compliance),
+        ], check=True)
+
         document = load(fingerprint)
         if document.get("kind") != "SourceOSFingerprint":
             raise SystemExit("ERR: synthetic boot output is not a SourceOSFingerprint")
-        if document.get("subject", {}).get("subject_kind") != "boot_environment":
-            raise SystemExit("ERR: synthetic boot fingerprint subject is not boot_environment")
-        if document.get("runtime", {}).get("isolation") != "boot_env":
-            raise SystemExit("ERR: synthetic boot fingerprint runtime isolation is not boot_env")
-        if document.get("system", {}).get("boot_mode") != "recovery":
-            raise SystemExit("ERR: synthetic boot fingerprint boot_mode is not recovery")
-        if document.get("policy", {}).get("release_set_ref") != "srset-m2-demo-0001":
-            raise SystemExit("ERR: synthetic boot fingerprint release_set_ref mismatch")
-        if document.get("policy", {}).get("boot_release_set_ref") != "sbrs-nlboot-m2-demo-recovery-0001":
-            raise SystemExit("ERR: synthetic boot fingerprint boot_release_set_ref mismatch")
-        if document.get("compliance", {}).get("status") != "compliant":
-            raise SystemExit("ERR: synthetic boot fingerprint did not report compliant")
+        result = load(compliance)
+        if result.get("kind") != "SourceOSBootFingerprintComplianceResult":
+            raise SystemExit("ERR: compliance output kind mismatch")
+        if result.get("status") != "pass":
+            raise SystemExit("ERR: boot fingerprint compliance did not pass")
+        checks = {item.get("name"): item.get("status") for item in result.get("checks", [])}
+        for required in ["release-set-ref", "boot-release-set-ref", "policy-bundle-ref", "runtime-isolation", "boot-mode"]:
+            if checks.get(required) != "pass":
+                raise SystemExit(f"ERR: compliance check did not pass: {required}")
 
     print("SourceOS synthetic boot fingerprint smoke passed.")
     return 0


### PR DESCRIPTION
## Summary

Adds a reusable SourceOS boot Fingerprint compliance helper and wires it into the synthetic boot Fingerprint smoke.

## Adds

- `tools/check_sourceos_boot_fingerprint_compliance.py`
- smoke update so `tools/smoke_sourceos_synthetic_boot_fingerprint.py` validates generated boot fingerprints through the helper

## Why

The proof path now emits a synthetic boot-environment `Fingerprint`. This PR adds the reusable checker that validates that fingerprint against the assigned `ReleaseSet` and `BootReleaseSet` rather than relying only on inline assertions.

## Safety boundary

Validation only.

No live boot execution, nlboot execution, artifact fetching, host mutation, disk writes, kexec execution, or remote state mutation is added.

## Validation

Existing SourceOS workflow continues to run:

```bash
python tools/smoke_sourceos_synthetic_boot_fingerprint.py
```

The smoke now also emits `boot-fingerprint-compliance.json` and requires compliance status `pass`.
