### PR TITLE
Add Prophet Lattice product surface contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check lattice-surfaces-check validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check lattice-surfaces-check validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -16,6 +16,9 @@ standards-check:
 
 topology-check:
 	python3 tools/check_transport_topology.py
+
+lattice-surfaces-check:
+	python3 tools/validate_lattice_surfaces.py
 
 validate-ops-fabric:
 	python3 tools/validate_ops_fabric.py

--- a/contracts/lattice/boot-release-set.v1.example.json
+++ b/contracts/lattice/boot-release-set.v1.example.json
@@ -1,0 +1,26 @@
+{
+  "apiVersion": "sourceos.dev/v1",
+  "kind": "BootReleaseSet",
+  "metadata": {
+    "name": "sourceos-recovery-demo",
+    "version": "0.1.0",
+    "createdAt": "2026-04-26T00:00:00Z",
+    "labels": {"surface": "fog-boot", "stage": "demo"}
+  },
+  "spec": {
+    "releaseSetRef": "prophet-lattice/releases/sourceos-demo/0.1.0",
+    "platforms": ["apple-silicon"],
+    "channels": ["recovery"],
+    "artifacts": [
+      {"name": "kernel", "role": "kernel", "uri": "https://example.invalid/kernel", "sha256": "0000000000000000000000000000000000000000000000000000000000000000"},
+      {"name": "initrd", "role": "initrd", "uri": "https://example.invalid/initrd", "sha256": "1111111111111111111111111111111111111111111111111111111111111111"}
+    ],
+    "policy": {"network": "enrollment-only", "diskWrite": "recovery-only", "tokenRequired": true, "allowedActions": ["announce", "enroll", "fetch", "verify", "repair", "attest"]},
+    "evidence": {"correlationId": "platform-boot-demo", "requiredReports": ["device-claim", "manifest-hash", "verification-result", "selected-channel", "boot-mode", "measurement", "attestation"]},
+    "provenance": {"builderId": "sourceos-boot", "sourceRefs": ["SourceOS-Linux/sourceos-boot"], "attestations": ["slsa", "in-toto"]},
+    "trust": {"model": "tuf", "rootRef": "trust-root-demo", "metadataRef": "tuf-metadata-demo", "threshold": 1},
+    "signature": {"type": "sigstore", "bundleRef": "demo-bundle", "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222"},
+    "antiRollback": {"minimumVersion": "0.1.0", "allowOfflineFallback": true, "allowedRollbackRefs": []},
+    "telemetry": {"traceRequired": true, "metricSet": ["boot-duration", "verify-duration", "download-bytes", "action-result"]}
+  }
+}

--- a/contracts/lattice/runtime-asset.v1.example.json
+++ b/contracts/lattice/runtime-asset.v1.example.json
@@ -1,0 +1,31 @@
+{
+  "apiVersion": "lattice.socioprophet.dev/v1",
+  "kind": "RuntimeAsset",
+  "metadata": {
+    "name": "prophet-python-ml",
+    "version": "0.1.0",
+    "createdAt": "2026-04-26T00:00:00Z",
+    "labels": {"surface": "lattice-studio", "stage": "demo"}
+  },
+  "spec": {
+    "runtimeClass": "notebook",
+    "languages": ["python"],
+    "channels": [
+      {"name": "nixpkgs", "type": "nixpkgs", "trusted": true},
+      {"name": "prophet-core", "type": "prophet", "trusted": true}
+    ],
+    "build": {"system": "nix", "entrypoint": "runtimes/prophet-python-ml/flake.nix", "lockfile": "runtimes/prophet-python-ml/flake.lock", "sourceRef": "SocioProphet/lattice-forge", "builderId": "lattice-forge-nix-builder"},
+    "artifacts": [
+      {"name": "runtime-closure", "role": "nix-closure", "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"},
+      {"name": "runtime-sbom", "role": "sbom", "digest": "sha256:4444444444444444444444444444444444444444444444444444444444444444"}
+    ],
+    "provenance": {"attestations": ["slsa", "in-toto"], "sourceRefs": ["SocioProphet/lattice-forge"], "builderId": "lattice-forge-nix-builder"},
+    "sbom": {"formats": ["spdx", "cyclonedx"], "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555"},
+    "signature": {"type": "sigstore", "bundleRef": "demo-bundle", "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666"},
+    "scan": {"vulnerability": "not-run", "license": "not-run", "policy": "not-run"},
+    "policy": {"network": "restricted", "secrets": "scoped", "accelerators": ["cpu"], "defaultIsolation": "container"},
+    "compatibility": {"surfaces": ["jupyter", "ray", "beam", "agentplane", "sourceos-user", "prophet-platform"]},
+    "telemetry": {"traceRequired": true, "metricSet": ["build-duration", "scan-duration", "artifact-size", "promotion-result"]},
+    "promotion": {"channel": "dev", "rollbackRef": "runtime/prophet-python-ml/0.0.1"}
+  }
+}

--- a/docs/LATTICE_PRODUCT_SURFACES.md
+++ b/docs/LATTICE_PRODUCT_SURFACES.md
@@ -1,0 +1,59 @@
+# Prophet Lattice Product Surfaces
+
+Prophet Platform is the runtime and deployment hub for Prophet Lattice. This document records how the first Fog Stack product surfaces enter the platform contract layer.
+
+## Surfaces covered in this tranche
+
+### Fog Boot / SourceOS Boot
+
+Producer repo: `SourceOS-Linux/sourceos-boot`
+
+Platform handoff object: `BootReleaseSet v1`
+
+Platform responsibility:
+
+- ingest BootReleaseSet metadata;
+- assign BootReleaseSets to device, project, group, or organization scopes;
+- require evidence correlation IDs;
+- bind boot/recovery actions to PolicyBundle and ReleaseSet state;
+- collect boot evidence into the platform evidence lane.
+
+### Lattice Forge
+
+Producer repo: `SocioProphet/lattice-forge`
+
+Platform handoff object: `RuntimeAsset v1`
+
+Platform responsibility:
+
+- ingest RuntimeAsset metadata;
+- expose approved runtimes to projects, deployment spaces, notebooks, agents, and shell sessions;
+- require provenance, SBOM, signature, scan, compatibility, telemetry, and promotion fields;
+- link runtime use to NotebookSession, AgentAsset, ModelAsset, PipelineAsset, and EvidenceBundle objects.
+
+## Validation contract
+
+`make validate` now includes `lattice-surfaces-check`, implemented by:
+
+```text
+tools/validate_lattice_surfaces.py
+```
+
+The check validates platform-facing example payloads under:
+
+```text
+contracts/lattice/
+```
+
+## Dependency direction
+
+The platform consumes product-surface contracts. It does not own the implementation details of boot/recovery or runtime construction.
+
+- `sourceos-boot` owns boot/recovery implementation.
+- `lattice-forge` owns runtime construction and evidence sidecars.
+- `prophet-platform` owns platform ingestion, assignment, policy binding, and evidence correlation.
+- `sourceos-spec` should become the canonical home for stable shared schemas once these contracts harden.
+
+## Doctrine
+
+Lattice is the control plane. SourceOS is the substrate. Fog is where execution happens.

--- a/tools/validate_lattice_surfaces.py
+++ b/tools/validate_lattice_surfaces.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Validate Prophet Lattice product-surface contract examples.
+
+This platform gate verifies that the platform can ingest the current handoff
+objects from `sourceos-boot` and `lattice-forge` without depending on those repos
+at runtime.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+SHA256_RE = re.compile(r"^sha256:[a-fA-F0-9]{64}$")
+HEX64_RE = re.compile(r"^[a-fA-F0-9]{64}$")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def load(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    require(isinstance(data, dict), f"{path} must contain a JSON object")
+    return data
+
+
+def require_keys(obj: dict, keys: list[str], where: str) -> None:
+    missing = [key for key in keys if key not in obj]
+    require(not missing, f"{where} missing keys: {', '.join(missing)}")
+
+
+def validate_boot_release_set(path: Path) -> None:
+    doc = load(path)
+    require(doc.get("apiVersion") == "sourceos.dev/v1", "BootReleaseSet apiVersion must be sourceos.dev/v1")
+    require(doc.get("kind") == "BootReleaseSet", "BootReleaseSet kind mismatch")
+    require_keys(doc, ["metadata", "spec"], "BootReleaseSet")
+    spec = doc["spec"]
+    require_keys(spec, ["platforms", "channels", "artifacts", "policy", "evidence", "provenance", "trust", "signature", "antiRollback", "telemetry"], "BootReleaseSet.spec")
+    require(spec["artifacts"], "BootReleaseSet must have artifacts")
+    for artifact in spec["artifacts"]:
+        require_keys(artifact, ["name", "role", "uri", "sha256"], "BootReleaseSet artifact")
+        require(HEX64_RE.match(artifact["sha256"]) is not None, "BootReleaseSet artifact sha256 must be 64 hex characters")
+    require(SHA256_RE.match(spec["signature"]["digest"]) is not None, "BootReleaseSet signature.digest must be sha256:<64 hex>")
+
+
+def validate_runtime_asset(path: Path) -> None:
+    doc = load(path)
+    require(doc.get("apiVersion") == "lattice.socioprophet.dev/v1", "RuntimeAsset apiVersion must be lattice.socioprophet.dev/v1")
+    require(doc.get("kind") == "RuntimeAsset", "RuntimeAsset kind mismatch")
+    require_keys(doc, ["metadata", "spec"], "RuntimeAsset")
+    spec = doc["spec"]
+    require_keys(spec, ["runtimeClass", "languages", "build", "artifacts", "provenance", "sbom", "signature", "scan", "policy", "compatibility", "telemetry", "promotion"], "RuntimeAsset.spec")
+    require(spec["artifacts"], "RuntimeAsset must have artifacts")
+    for artifact in spec["artifacts"]:
+        require_keys(artifact, ["name", "role", "digest"], "RuntimeAsset artifact")
+        require(SHA256_RE.match(artifact["digest"]) is not None, "RuntimeAsset artifact digest must be sha256:<64 hex>")
+    require(SHA256_RE.match(spec["sbom"]["digest"]) is not None, "RuntimeAsset sbom.digest must be sha256:<64 hex>")
+    require(SHA256_RE.match(spec["signature"]["digest"]) is not None, "RuntimeAsset signature.digest must be sha256:<64 hex>")
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    checks = [
+        (validate_boot_release_set, root / "contracts" / "lattice" / "boot-release-set.v1.example.json"),
+        (validate_runtime_asset, root / "contracts" / "lattice" / "runtime-asset.v1.example.json"),
+    ]
+    failed = False
+    for validator, path in checks:
+        try:
+            validator(path)
+            print(f"PASS {path}")
+        except Exception as exc:  # noqa: BLE001
+            failed = True
+            print(f"FAIL {path}: {exc}", file=sys.stderr)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds platform-facing contract examples and validation for the first Prophet Lattice/Fog Stack product surfaces.

## What changed

- Adds BootReleaseSet v1 example under `contracts/lattice/`.
- Adds RuntimeAsset v1 example under `contracts/lattice/`.
- Adds `tools/validate_lattice_surfaces.py`.
- Wires `lattice-surfaces-check` into `make validate` on top of current `main`.
- Adds `docs/LATTICE_PRODUCT_SURFACES.md` describing producer/consumer boundaries.

## Why

`sourceos-boot` and `lattice-forge` are now real product-surface repos. Prophet Platform must consume their handoff objects as first-class platform contracts instead of leaving them isolated.

## Integration impact

- `sourceos-boot` remains owner of BootReleaseSet implementation and boot/recovery logic.
- `lattice-forge` remains owner of RuntimeAsset implementation and runtime evidence sidecars.
- `prophet-platform` now owns platform ingestion, assignment, policy binding, and evidence correlation for those surfaces.
- `sourceos-spec` should absorb stable schemas once the contracts harden.

## Validation

`make validate` now includes Lattice product-surface validation.

## Note

Supersedes closed stale PR #228, which diverged substantially from current main.
