### PR TITLE
Add Lattice surface ingestor service stub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check lattice-surfaces-check validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check lattice-surfaces-check validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -19,6 +19,11 @@ topology-check:
 
 lattice-surfaces-check:
 	python3 tools/validate_lattice_surfaces.py
+
+lattice-surface-ingestor-smoke:
+	cd apps/lattice-surface-ingestor && test -d .venv || python3 -m venv .venv
+	cd apps/lattice-surface-ingestor && . .venv/bin/activate && python -m pip install --upgrade pip pytest && PYTHONPATH=src pytest -q tests
+	PYTHONPATH=apps/lattice-surface-ingestor/src python3 -m lattice_surface_ingestor.cli ingest contracts/lattice/boot-release-set.v1.example.json contracts/lattice/runtime-asset.v1.example.json >/tmp/lattice-surface-records.json
 
 validate-ops-fabric:
 	python3 tools/validate_ops_fabric.py

--- a/apps/lattice-surface-ingestor/pyproject.toml
+++ b/apps/lattice-surface-ingestor/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "prophet-lattice-surface-ingestor"
+version = "0.1.0"
+description = "Side-effect-free ingestor for Prophet Lattice product-surface handoff objects."
+requires-python = ">=3.11"
+
+[project.scripts]
+lattice-surface-ingest = "lattice_surface_ingestor.cli:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/__init__.py
+++ b/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/__init__.py
@@ -1,0 +1,4 @@
+"""Prophet Lattice surface ingestor."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/cli.py
+++ b/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/cli.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Command-line interface for Lattice surface ingestion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .ingest import ingest_surface
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return data
+
+
+def ingest(args: argparse.Namespace) -> int:
+    records = [ingest_surface(load_json(path)).to_dict() for path in args.inputs]
+    payload: dict[str, Any] = {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecordSet",
+        "records": records,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Ingest Lattice product-surface handoff objects")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    ingest_parser = subparsers.add_parser("ingest", help="Normalize handoff objects into PlatformAssetRecordSet")
+    ingest_parser.add_argument("inputs", type=Path, nargs="+")
+    ingest_parser.set_defaults(func=ingest)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"lattice-surface-ingest: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/ingest.py
+++ b/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/ingest.py
@@ -1,0 +1,111 @@
+"""Normalize Lattice product-surface handoff objects into platform assets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PlatformAssetRecord:
+    """Normalized record emitted by the side-effect-free ingestor."""
+
+    asset_id: str
+    asset_kind: str
+    name: str
+    version: str
+    source_api_version: str
+    source_kind: str
+    producer_repo: str
+    policy_ref: str | None
+    evidence_correlation_id: str | None
+    promotion_channel: str | None
+    compatibility_surfaces: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "prophet.socioprophet.dev/v1",
+            "kind": "PlatformAssetRecord",
+            "assetId": self.asset_id,
+            "assetKind": self.asset_kind,
+            "name": self.name,
+            "version": self.version,
+            "sourceApiVersion": self.source_api_version,
+            "sourceKind": self.source_kind,
+            "producerRepo": self.producer_repo,
+            "policyRef": self.policy_ref,
+            "evidenceCorrelationId": self.evidence_correlation_id,
+            "promotionChannel": self.promotion_channel,
+            "compatibilitySurfaces": self.compatibility_surfaces,
+        }
+
+
+def ingest_surface(doc: dict[str, Any]) -> PlatformAssetRecord:
+    """Dispatch a supported handoff object into a normalized platform asset."""
+
+    kind = doc.get("kind")
+    if kind == "BootReleaseSet":
+        return ingest_boot_release_set(doc)
+    if kind == "RuntimeAsset":
+        return ingest_runtime_asset(doc)
+    raise ValueError(f"unsupported lattice surface kind: {kind!r}")
+
+
+def ingest_boot_release_set(doc: dict[str, Any]) -> PlatformAssetRecord:
+    metadata = _required_dict(doc, "metadata")
+    spec = _required_dict(doc, "spec")
+    evidence = _required_dict(spec, "evidence")
+    name = _required_str(metadata, "name")
+    version = _required_str(metadata, "version")
+    return PlatformAssetRecord(
+        asset_id=f"boot-release-set:{name}:{version}",
+        asset_kind="boot-release-set",
+        name=name,
+        version=version,
+        source_api_version=_required_str(doc, "apiVersion"),
+        source_kind="BootReleaseSet",
+        producer_repo="SourceOS-Linux/sourceos-boot",
+        policy_ref=spec.get("releaseSetRef"),
+        evidence_correlation_id=evidence.get("correlationId"),
+        promotion_channel=None,
+        compatibility_surfaces=["sourceos-boot", "prophet-platform"],
+    )
+
+
+def ingest_runtime_asset(doc: dict[str, Any]) -> PlatformAssetRecord:
+    metadata = _required_dict(doc, "metadata")
+    spec = _required_dict(doc, "spec")
+    promotion = _required_dict(spec, "promotion")
+    compatibility = _required_dict(spec, "compatibility")
+    name = _required_str(metadata, "name")
+    version = _required_str(metadata, "version")
+    surfaces = compatibility.get("surfaces", [])
+    if not isinstance(surfaces, list):
+        raise ValueError("RuntimeAsset compatibility.surfaces must be a list")
+    return PlatformAssetRecord(
+        asset_id=f"runtime-asset:{name}:{version}",
+        asset_kind="runtime-asset",
+        name=name,
+        version=version,
+        source_api_version=_required_str(doc, "apiVersion"),
+        source_kind="RuntimeAsset",
+        producer_repo="SocioProphet/lattice-forge",
+        policy_ref=None,
+        evidence_correlation_id=None,
+        promotion_channel=promotion.get("channel"),
+        compatibility_surfaces=[str(surface) for surface in surfaces],
+    )
+
+
+def _required_dict(data: dict[str, Any], key: str) -> dict[str, Any]:
+    value = data.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"{key} must be an object")
+    return value
+
+
+def _required_str(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a non-empty string")
+    return value

--- a/apps/lattice-surface-ingestor/tests/test_ingest.py
+++ b/apps/lattice-surface-ingestor/tests/test_ingest.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+from lattice_surface_ingestor.cli import main
+from lattice_surface_ingestor.ingest import ingest_surface
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def load_contract(name: str) -> dict:
+    return json.loads((ROOT / "contracts" / "lattice" / name).read_text(encoding="utf-8"))
+
+
+def test_ingest_boot_release_set_contract() -> None:
+    record = ingest_surface(load_contract("boot-release-set.v1.example.json"))
+    assert record.asset_kind == "boot-release-set"
+    assert record.producer_repo == "SourceOS-Linux/sourceos-boot"
+    assert record.evidence_correlation_id == "platform-boot-demo"
+    assert "prophet-platform" in record.compatibility_surfaces
+
+
+def test_ingest_runtime_asset_contract() -> None:
+    record = ingest_surface(load_contract("runtime-asset.v1.example.json"))
+    assert record.asset_kind == "runtime-asset"
+    assert record.producer_repo == "SocioProphet/lattice-forge"
+    assert record.promotion_channel == "dev"
+    assert "agentplane" in record.compatibility_surfaces
+
+
+def test_ingestor_cli_emits_record_set(capsys) -> None:
+    rc = main([
+        "ingest",
+        str(ROOT / "contracts" / "lattice" / "boot-release-set.v1.example.json"),
+        str(ROOT / "contracts" / "lattice" / "runtime-asset.v1.example.json"),
+    ])
+    assert rc == 0
+    emitted = json.loads(capsys.readouterr().out)
+    assert emitted["kind"] == "PlatformAssetRecordSet"
+    assert len(emitted["records"]) == 2


### PR DESCRIPTION
## Summary

Adds the first side-effect-free platform ingestion service for Prophet Lattice product-surface handoff objects.

## What changed

- Adds `apps/lattice-surface-ingestor` Python app.
- Normalizes `BootReleaseSet` and `RuntimeAsset` into `PlatformAssetRecord` objects.
- Adds CLI: `lattice-surface-ingest ingest ...`.
- Adds tests using the platform's own `contracts/lattice` examples.
- Wires `lattice-surface-ingestor-smoke` into `make validate`.

## Why

The platform now consumes `sourceos-boot` and `lattice-forge` as real product surfaces. This PR creates the first service boundary that turns those handoff objects into normalized platform asset records for later catalog/evidence indexing.

## Safety

The ingestor is read-only and side-effect-free. It reads JSON handoff objects and emits normalized JSON records.

## Context

The roadmap has long defined SocioProphet around content aggregation, community data catalog / AI analytics hub, collaboration, model zoo, reproducible publishing, and knowledge graph features. The Lattice surface ingestor is a low-level platform primitive that supports that evidence/catalog trajectory by normalizing boot and runtime assets into platform records.
