### PR TITLE
Emit Lattice surface records as deterministic build artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ lattice-surfaces-check:
 lattice-surface-ingestor-smoke:
 	cd apps/lattice-surface-ingestor && test -d .venv || python3 -m venv .venv
 	cd apps/lattice-surface-ingestor && . .venv/bin/activate && python -m pip install --upgrade pip pytest && PYTHONPATH=src pytest -q tests
-	PYTHONPATH=apps/lattice-surface-ingestor/src python3 -m lattice_surface_ingestor.cli ingest contracts/lattice/boot-release-set.v1.example.json contracts/lattice/runtime-asset.v1.example.json >/tmp/lattice-surface-records.json
+	mkdir -p build/lattice-surface-ingestor
+	PYTHONPATH=apps/lattice-surface-ingestor/src python3 -m lattice_surface_ingestor.cli ingest contracts/lattice/boot-release-set.v1.example.json contracts/lattice/runtime-asset.v1.example.json --output build/lattice-surface-ingestor/lattice-surface-records.json
+	test -s build/lattice-surface-ingestor/lattice-surface-records.json
 
 validate-ops-fabric:
 	python3 tools/validate_ops_fabric.py

--- a/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/cli.py
+++ b/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/cli.py
@@ -19,14 +19,27 @@ def load_json(path: Path) -> dict[str, Any]:
     return data
 
 
-def ingest(args: argparse.Namespace) -> int:
-    records = [ingest_surface(load_json(path)).to_dict() for path in args.inputs]
-    payload: dict[str, Any] = {
+def build_record_set(inputs: list[Path]) -> dict[str, Any]:
+    records = [ingest_surface(load_json(path)).to_dict() for path in inputs]
+    return {
         "apiVersion": "prophet.socioprophet.dev/v1",
         "kind": "PlatformAssetRecordSet",
         "records": records,
     }
-    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def emit_payload(payload: dict[str, Any], output: Path | None) -> None:
+    rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if output is None:
+        print(rendered, end="")
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(rendered, encoding="utf-8")
+
+
+def ingest(args: argparse.Namespace) -> int:
+    payload = build_record_set(args.inputs)
+    emit_payload(payload, args.output)
     return 0
 
 
@@ -35,6 +48,7 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
     ingest_parser = subparsers.add_parser("ingest", help="Normalize handoff objects into PlatformAssetRecordSet")
     ingest_parser.add_argument("inputs", type=Path, nargs="+")
+    ingest_parser.add_argument("--output", type=Path, help="Optional path for deterministic JSON output")
     ingest_parser.set_defaults(func=ingest)
     return parser
 

--- a/apps/lattice-surface-ingestor/tests/test_ingest.py
+++ b/apps/lattice-surface-ingestor/tests/test_ingest.py
@@ -37,3 +37,19 @@ def test_ingestor_cli_emits_record_set(capsys) -> None:
     emitted = json.loads(capsys.readouterr().out)
     assert emitted["kind"] == "PlatformAssetRecordSet"
     assert len(emitted["records"]) == 2
+
+
+def test_ingestor_cli_writes_deterministic_record_set(tmp_path) -> None:
+    output = tmp_path / "records" / "lattice-surface-records.json"
+    rc = main([
+        "ingest",
+        str(ROOT / "contracts" / "lattice" / "boot-release-set.v1.example.json"),
+        str(ROOT / "contracts" / "lattice" / "runtime-asset.v1.example.json"),
+        "--output",
+        str(output),
+    ])
+    assert rc == 0
+    emitted = json.loads(output.read_text(encoding="utf-8"))
+    assert emitted["apiVersion"] == "prophet.socioprophet.dev/v1"
+    assert emitted["kind"] == "PlatformAssetRecordSet"
+    assert [record["assetKind"] for record in emitted["records"]] == ["boot-release-set", "runtime-asset"]


### PR DESCRIPTION
## Summary

Extends the Lattice surface ingestor so platform asset records can be emitted as deterministic JSON artifacts, not only printed to stdout.

## What changed

- Adds `--output` support to `lattice-surface-ingest ingest`.
- Adds deterministic output helper coverage.
- Updates the Makefile smoke gate to write `build/lattice-surface-ingestor/lattice-surface-records.json`.
- Verifies the emitted file exists and is non-empty.

## Why

The next catalog/evidence layer needs a durable artifact to consume. This makes the ingestor produce a concrete platform asset record artifact from BootReleaseSet and RuntimeAsset handoff objects.

## Safety

Still side-effect-free with respect to platform state. The only write is to an explicit output path requested by the caller / smoke gate.
