### PR TITLE
Persist Lattice surface records into deterministic record store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,10 @@ lattice-surface-ingestor-smoke:
 	cd apps/lattice-surface-ingestor && . .venv/bin/activate && python -m pip install --upgrade pip pytest && PYTHONPATH=src pytest -q tests
 	mkdir -p build/lattice-surface-ingestor
 	PYTHONPATH=apps/lattice-surface-ingestor/src python3 -m lattice_surface_ingestor.cli ingest contracts/lattice/boot-release-set.v1.example.json contracts/lattice/runtime-asset.v1.example.json --output build/lattice-surface-ingestor/lattice-surface-records.json
+	PYTHONPATH=apps/lattice-surface-ingestor/src python3 -m lattice_surface_ingestor.cli enrich build/lattice-surface-ingestor/lattice-surface-records.json --output build/lattice-surface-ingestor/lattice-surface-enrichments.json
 	PYTHONPATH=apps/lattice-surface-ingestor/src python3 -m lattice_surface_ingestor.cli store build/lattice-surface-ingestor/lattice-surface-records.json build/lattice-surface-ingestor/store
 	test -s build/lattice-surface-ingestor/lattice-surface-records.json
+	test -s build/lattice-surface-ingestor/lattice-surface-enrichments.json
 	test -s build/lattice-surface-ingestor/store/manifest.json
 
 validate-ops-fabric:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ lattice-surface-ingestor-smoke:
 	cd apps/lattice-surface-ingestor && . .venv/bin/activate && python -m pip install --upgrade pip pytest && PYTHONPATH=src pytest -q tests
 	mkdir -p build/lattice-surface-ingestor
 	PYTHONPATH=apps/lattice-surface-ingestor/src python3 -m lattice_surface_ingestor.cli ingest contracts/lattice/boot-release-set.v1.example.json contracts/lattice/runtime-asset.v1.example.json --output build/lattice-surface-ingestor/lattice-surface-records.json
+	PYTHONPATH=apps/lattice-surface-ingestor/src python3 -m lattice_surface_ingestor.cli store build/lattice-surface-ingestor/lattice-surface-records.json build/lattice-surface-ingestor/store
 	test -s build/lattice-surface-ingestor/lattice-surface-records.json
+	test -s build/lattice-surface-ingestor/store/manifest.json
 
 validate-ops-fabric:
 	python3 tools/validate_ops_fabric.py

--- a/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/cli.py
+++ b/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/cli.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from .enrich import enrich_record_set
 from .ingest import ingest_surface
 from .store import write_record_set
 
@@ -44,6 +45,13 @@ def ingest(args: argparse.Namespace) -> int:
     return 0
 
 
+def enrich(args: argparse.Namespace) -> int:
+    record_set = load_json(args.record_set)
+    payload = enrich_record_set(record_set)
+    emit_payload(payload, args.output)
+    return 0
+
+
 def store(args: argparse.Namespace) -> int:
     record_set = load_json(args.record_set)
     written = write_record_set(record_set, args.output_dir)
@@ -59,6 +67,11 @@ def build_parser() -> argparse.ArgumentParser:
     ingest_parser.add_argument("inputs", type=Path, nargs="+")
     ingest_parser.add_argument("--output", type=Path, help="Optional path for deterministic JSON output")
     ingest_parser.set_defaults(func=ingest)
+
+    enrich_parser = subparsers.add_parser("enrich", help="Generate deterministic search/topic/governance/modeling enrichments")
+    enrich_parser.add_argument("record_set", type=Path)
+    enrich_parser.add_argument("--output", type=Path, help="Optional path for enrichment JSON output")
+    enrich_parser.set_defaults(func=enrich)
 
     store_parser = subparsers.add_parser("store", help="Write PlatformAssetRecordSet into deterministic per-asset files")
     store_parser.add_argument("record_set", type=Path)

--- a/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/cli.py
+++ b/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from .ingest import ingest_surface
+from .store import write_record_set
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -43,13 +44,26 @@ def ingest(args: argparse.Namespace) -> int:
     return 0
 
 
+def store(args: argparse.Namespace) -> int:
+    record_set = load_json(args.record_set)
+    written = write_record_set(record_set, args.output_dir)
+    print(json.dumps({"written": [str(path) for path in written]}, indent=2, sort_keys=True))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Ingest Lattice product-surface handoff objects")
     subparsers = parser.add_subparsers(dest="command", required=True)
+
     ingest_parser = subparsers.add_parser("ingest", help="Normalize handoff objects into PlatformAssetRecordSet")
     ingest_parser.add_argument("inputs", type=Path, nargs="+")
     ingest_parser.add_argument("--output", type=Path, help="Optional path for deterministic JSON output")
     ingest_parser.set_defaults(func=ingest)
+
+    store_parser = subparsers.add_parser("store", help="Write PlatformAssetRecordSet into deterministic per-asset files")
+    store_parser.add_argument("record_set", type=Path)
+    store_parser.add_argument("output_dir", type=Path)
+    store_parser.set_defaults(func=store)
     return parser
 
 

--- a/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/enrich.py
+++ b/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/enrich.py
@@ -1,0 +1,146 @@
+"""Deterministic enrichment for Lattice platform asset records.
+
+The enrichment layer is intentionally rule-based for this tranche. It gives
+Sherlock Search, Slash Topics, New Hope, ContractForge, Policy Fabric, and later
+metadata/language-modeling workflows a shared sidecar without forking the
+canonical PlatformAssetRecord identity.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def enrich_record(record: dict[str, Any]) -> dict[str, Any]:
+    asset_id = _required_str(record, "assetId")
+    asset_kind = _required_str(record, "assetKind")
+    producer_repo = _required_str(record, "producerRepo")
+    promotion_channel = record.get("promotionChannel")
+    compatibility_surfaces = record.get("compatibilitySurfaces", [])
+    if not isinstance(compatibility_surfaces, list):
+        compatibility_surfaces = []
+
+    topics = topic_candidates(asset_kind=asset_kind, producer_repo=producer_repo, promotion_channel=promotion_channel)
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecordEnrichment",
+        "assetId": asset_id,
+        "search": {
+            "docType": "lattice.platformAssetRecord",
+            "title": f"{record.get('name')} {record.get('version')}",
+            "facets": {
+                "assetKind": asset_kind,
+                "producerRepo": producer_repo,
+                "promotionChannel": promotion_channel,
+                "compatibilitySurfaces": [str(surface) for surface in compatibility_surfaces],
+            },
+        },
+        "slashTopics": topics,
+        "newHope": {
+            "carrierKind": "PlatformAssetRecordCarrier",
+            "entityId": asset_id,
+            "citationSource": producer_repo,
+            "lensCandidates": [str(surface) for surface in compatibility_surfaces],
+            "membraneStatus": "candidate",
+        },
+        "contractForge": {
+            "subjectClass": contract_subject_class(asset_kind),
+            "lifecycleStatus": lifecycle_status(promotion_channel),
+            "evidenceRef": record.get("evidenceCorrelationId"),
+        },
+        "policyFabric": {
+            "subjectClass": policy_subject_class(asset_kind),
+            "gateStatus": policy_gate_status(promotion_channel),
+            "policyRef": record.get("policyRef"),
+        },
+        "languageModeling": {
+            "use": "metadata-classification-and-governance-explanation",
+            "plainLanguageSummary": summary_for(record),
+            "controlledVocabularyTerms": sorted(set(term.strip("/").replace("/", ".") for term in topics)),
+            "classificationLabels": classifier_labels(asset_kind=asset_kind, producer_repo=producer_repo, promotion_channel=promotion_channel),
+            "negativeConstraints": ["do-not-overwrite-canonical-platform-asset-record"],
+        },
+    }
+
+
+def enrich_record_set(record_set: dict[str, Any]) -> dict[str, Any]:
+    if record_set.get("kind") != "PlatformAssetRecordSet":
+        raise ValueError("record_set.kind must be PlatformAssetRecordSet")
+    records = record_set.get("records")
+    if not isinstance(records, list):
+        raise ValueError("record_set.records must be a list")
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecordEnrichmentSet",
+        "enrichments": [enrich_record(record) for record in records if isinstance(record, dict)],
+    }
+
+
+def topic_candidates(*, asset_kind: str, producer_repo: str, promotion_channel: object) -> list[str]:
+    topics = {"/lattice", "/governance", "/evidence", "/provenance"}
+    if asset_kind == "boot-release-set":
+        topics.update({"/lattice/boot", "/sourceos", "/sourceos/boot", "/sourceos/recovery", "/release"})
+    if asset_kind == "runtime-asset":
+        topics.update({"/lattice/runtime", "/lattice/forge", "/notebook", "/agentplane", "/supply-chain"})
+    if producer_repo == "SourceOS-Linux/sourceos-boot":
+        topics.update({"/sourceos", "/boot", "/recovery"})
+    if producer_repo == "SocioProphet/lattice-forge":
+        topics.update({"/forge", "/runtime", "/supply-chain"})
+    if isinstance(promotion_channel, str) and promotion_channel:
+        topics.add(f"/lifecycle/{promotion_channel}")
+    topics.update({"/contracts", "/policy", "/modeling"})
+    return sorted(topics)
+
+
+def contract_subject_class(asset_kind: str) -> str:
+    return {
+        "boot-release-set": "BootReleaseContractReferencedAsset",
+        "runtime-asset": "RuntimeContractReferencedAsset",
+    }.get(asset_kind, "GenericContractReferencedAsset")
+
+
+def policy_subject_class(asset_kind: str) -> str:
+    return {
+        "boot-release-set": "BootReleasePolicySubject",
+        "runtime-asset": "RuntimePolicySubject",
+    }.get(asset_kind, "GenericPolicySubject")
+
+
+def lifecycle_status(promotion_channel: object) -> str:
+    if promotion_channel in {"stable", "emergency"}:
+        return "approved"
+    if promotion_channel == "deprecated":
+        return "deprecated"
+    return "candidate"
+
+
+def policy_gate_status(promotion_channel: object) -> str:
+    if promotion_channel == "stable":
+        return "eligible-for-standard-use"
+    if promotion_channel == "emergency":
+        return "eligible-for-emergency-use"
+    if promotion_channel == "deprecated":
+        return "blocked-deprecated"
+    return "candidate-review-required"
+
+
+def classifier_labels(*, asset_kind: str, producer_repo: str, promotion_channel: object) -> list[str]:
+    labels = [asset_kind, producer_repo.replace("/", ":")]
+    if isinstance(promotion_channel, str) and promotion_channel:
+        labels.append(f"channel:{promotion_channel}")
+    return labels
+
+
+def summary_for(record: dict[str, Any]) -> str:
+    name = record.get("name")
+    version = record.get("version")
+    asset_kind = record.get("assetKind")
+    producer_repo = record.get("producerRepo")
+    return f"{asset_kind} {name} version {version} produced by {producer_repo}."
+
+
+def _required_str(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a non-empty string")
+    return value

--- a/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/store.py
+++ b/apps/lattice-surface-ingestor/src/lattice_surface_ingestor/store.py
@@ -1,0 +1,55 @@
+"""Deterministic local record store for Lattice platform asset records.
+
+This module is deliberately file-based and side-effect-scoped. It writes only to
+a caller-provided directory so the first catalog/evidence persistence path can be
+validated without introducing a database dependency or long-running service.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+ASSET_ID_SAFE_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
+
+
+def sanitize_asset_id(asset_id: str) -> str:
+    sanitized = ASSET_ID_SAFE_RE.sub("_", asset_id).strip("_")
+    if not sanitized:
+        raise ValueError("assetId produced an empty filename")
+    return sanitized
+
+
+def write_record_set(record_set: dict[str, Any], output_dir: Path) -> list[Path]:
+    """Write a PlatformAssetRecordSet into deterministic per-record JSON files."""
+
+    if record_set.get("kind") != "PlatformAssetRecordSet":
+        raise ValueError("record_set.kind must be PlatformAssetRecordSet")
+    records = record_set.get("records")
+    if not isinstance(records, list):
+        raise ValueError("record_set.records must be a list")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError("each record must be an object")
+        asset_id = record.get("assetId")
+        if not isinstance(asset_id, str) or not asset_id:
+            raise ValueError("each record must include a non-empty assetId")
+        path = output_dir / f"{sanitize_asset_id(asset_id)}.json"
+        path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        written.append(path)
+
+    manifest = {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecordStoreManifest",
+        "recordCount": len(written),
+        "records": [path.name for path in written],
+    }
+    manifest_path = output_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    written.append(manifest_path)
+    return written

--- a/apps/lattice-surface-ingestor/tests/test_ingest.py
+++ b/apps/lattice-surface-ingestor/tests/test_ingest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from lattice_surface_ingestor.cli import main
 from lattice_surface_ingestor.ingest import ingest_surface
+from lattice_surface_ingestor.store import write_record_set
 
 ROOT = Path(__file__).resolve().parents[3]
 
@@ -53,3 +54,36 @@ def test_ingestor_cli_writes_deterministic_record_set(tmp_path) -> None:
     assert emitted["apiVersion"] == "prophet.socioprophet.dev/v1"
     assert emitted["kind"] == "PlatformAssetRecordSet"
     assert [record["assetKind"] for record in emitted["records"]] == ["boot-release-set", "runtime-asset"]
+
+
+def test_record_store_writes_per_asset_files(tmp_path) -> None:
+    record_set = {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecordSet",
+        "records": [
+            ingest_surface(load_contract("boot-release-set.v1.example.json")).to_dict(),
+            ingest_surface(load_contract("runtime-asset.v1.example.json")).to_dict(),
+        ],
+    }
+    written = write_record_set(record_set, tmp_path / "store")
+    names = sorted(path.name for path in written)
+    assert "boot-release-set:sourceos-recovery-demo:0.1.0.json" in names
+    assert "runtime-asset:prophet-python-ml:0.1.0.json" in names
+    assert "manifest.json" in names
+
+
+def test_store_cli_writes_per_asset_files(tmp_path) -> None:
+    record_set_path = tmp_path / "record-set.json"
+    output_dir = tmp_path / "store"
+    main([
+        "ingest",
+        str(ROOT / "contracts" / "lattice" / "boot-release-set.v1.example.json"),
+        str(ROOT / "contracts" / "lattice" / "runtime-asset.v1.example.json"),
+        "--output",
+        str(record_set_path),
+    ])
+    rc = main(["store", str(record_set_path), str(output_dir)])
+    assert rc == 0
+    assert (output_dir / "manifest.json").exists()
+    assert (output_dir / "boot-release-set:sourceos-recovery-demo:0.1.0.json").exists()
+    assert (output_dir / "runtime-asset:prophet-python-ml:0.1.0.json").exists()

--- a/apps/lattice-surface-ingestor/tests/test_ingest.py
+++ b/apps/lattice-surface-ingestor/tests/test_ingest.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from lattice_surface_ingestor.cli import main
+from lattice_surface_ingestor.enrich import enrich_record_set
 from lattice_surface_ingestor.ingest import ingest_surface
 from lattice_surface_ingestor.store import write_record_set
 
@@ -10,6 +11,17 @@ ROOT = Path(__file__).resolve().parents[3]
 
 def load_contract(name: str) -> dict:
     return json.loads((ROOT / "contracts" / "lattice" / name).read_text(encoding="utf-8"))
+
+
+def make_record_set() -> dict:
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecordSet",
+        "records": [
+            ingest_surface(load_contract("boot-release-set.v1.example.json")).to_dict(),
+            ingest_surface(load_contract("runtime-asset.v1.example.json")).to_dict(),
+        ],
+    }
 
 
 def test_ingest_boot_release_set_contract() -> None:
@@ -57,15 +69,7 @@ def test_ingestor_cli_writes_deterministic_record_set(tmp_path) -> None:
 
 
 def test_record_store_writes_per_asset_files(tmp_path) -> None:
-    record_set = {
-        "apiVersion": "prophet.socioprophet.dev/v1",
-        "kind": "PlatformAssetRecordSet",
-        "records": [
-            ingest_surface(load_contract("boot-release-set.v1.example.json")).to_dict(),
-            ingest_surface(load_contract("runtime-asset.v1.example.json")).to_dict(),
-        ],
-    }
-    written = write_record_set(record_set, tmp_path / "store")
+    written = write_record_set(make_record_set(), tmp_path / "store")
     names = sorted(path.name for path in written)
     assert "boot-release-set:sourceos-recovery-demo:0.1.0.json" in names
     assert "runtime-asset:prophet-python-ml:0.1.0.json" in names
@@ -87,3 +91,39 @@ def test_store_cli_writes_per_asset_files(tmp_path) -> None:
     assert (output_dir / "manifest.json").exists()
     assert (output_dir / "boot-release-set:sourceos-recovery-demo:0.1.0.json").exists()
     assert (output_dir / "runtime-asset:prophet-python-ml:0.1.0.json").exists()
+
+
+def test_enrichment_includes_search_topics_governance_contract_policy_and_modeling() -> None:
+    enrichment_set = enrich_record_set(make_record_set())
+    assert enrichment_set["kind"] == "PlatformAssetRecordEnrichmentSet"
+    enrichments = enrichment_set["enrichments"]
+    runtime = next(item for item in enrichments if item["assetId"].startswith("runtime-asset:"))
+    boot = next(item for item in enrichments if item["assetId"].startswith("boot-release-set:"))
+
+    assert runtime["search"]["docType"] == "lattice.platformAssetRecord"
+    assert "/lattice/runtime" in runtime["slashTopics"]
+    assert runtime["newHope"]["carrierKind"] == "PlatformAssetRecordCarrier"
+    assert runtime["contractForge"]["subjectClass"] == "RuntimeContractReferencedAsset"
+    assert runtime["policyFabric"]["subjectClass"] == "RuntimePolicySubject"
+    assert runtime["languageModeling"]["use"] == "metadata-classification-and-governance-explanation"
+
+    assert "/lattice/boot" in boot["slashTopics"]
+    assert boot["contractForge"]["subjectClass"] == "BootReleaseContractReferencedAsset"
+    assert boot["policyFabric"]["subjectClass"] == "BootReleasePolicySubject"
+
+
+def test_enrichment_cli_writes_sidecar(tmp_path) -> None:
+    record_set_path = tmp_path / "record-set.json"
+    enrichment_path = tmp_path / "enrichment.json"
+    main([
+        "ingest",
+        str(ROOT / "contracts" / "lattice" / "boot-release-set.v1.example.json"),
+        str(ROOT / "contracts" / "lattice" / "runtime-asset.v1.example.json"),
+        "--output",
+        str(record_set_path),
+    ])
+    rc = main(["enrich", str(record_set_path), "--output", str(enrichment_path)])
+    assert rc == 0
+    emitted = json.loads(enrichment_path.read_text(encoding="utf-8"))
+    assert emitted["kind"] == "PlatformAssetRecordEnrichmentSet"
+    assert len(emitted["enrichments"]) == 2

--- a/docs/LATTICE_CONTRACT_POLICY_MODELING_INTEGRATION.md
+++ b/docs/LATTICE_CONTRACT_POLICY_MODELING_INTEGRATION.md
@@ -1,0 +1,175 @@
+# Lattice Contract, Policy, and Modeling Integration
+
+Lattice surface records are not only search documents. They are contract subjects, policy subjects, and modeling examples.
+
+This companion document extends `docs/LATTICE_SEARCH_GOVERNANCE_INTEGRATION.md` with first-class integration points for:
+
+- `contractforge`
+- `policy-fabric`
+- `prophet-core-contracts`
+- `prophet-core-policy`
+- `graphbrain-contract`
+- internal metadata classifiers
+- internal language-modeling datasets
+
+## Canonical object
+
+The canonical object remains:
+
+```text
+PlatformAssetRecord
+```
+
+The record identity must not fork per subsystem. Search, policy, contract analysis, and modeling layers may add enrichments, but they must not create a competing asset identity.
+
+## ContractForge integration
+
+ContractForge is the canonical home for contract lifecycle, economic artifact semantics, settlement artifacts, adjustment semantics, and finalization boundaries.
+
+A `PlatformAssetRecord` should map into ContractForge as a contract-referenced asset whenever it affects release rights, runtime eligibility, fleet assignment, obligations, settlement, or governance explanations.
+
+Minimum mapping:
+
+```text
+PlatformAssetRecord -> ContractReferencedAsset
+assetId -> subject identifier
+producerRepo -> source citation
+policyRef -> governing policy reference
+promotionChannel -> lifecycle state
+evidenceCorrelationId -> evidence reference
+compatibilitySurfaces -> permitted-use surfaces
+```
+
+Required questions:
+
+- Which asset is governed by which contract or policy reference?
+- Which project, group, org, device, fleet, or workspace may use it?
+- Is the asset candidate, approved, deprecated, revoked, or finalized?
+- Which time/effective-state rule applies to a promotion or rollback?
+- Which evidence record explains the current state?
+
+## Policy Fabric integration
+
+Policy Fabric is the governed control repository for authoring, validating, packaging, reviewing, replaying, and governing policy-as-code.
+
+A `PlatformAssetRecord` should map into Policy Fabric as a policy subject and evidence carrier.
+
+Minimum mapping:
+
+```text
+PlatformAssetRecord -> PolicySubject
+assetKind -> policy subject class
+policyRef -> PolicyBundle or compiled plan reference
+producerRepo -> source repository claim
+promotionChannel -> release gate input
+evidenceCorrelationId -> validation or replay evidence link
+compatibilitySurfaces -> capability constraints
+```
+
+Required questions:
+
+- Is this asset allowed to be indexed?
+- Is this runtime allowed for this workspace, project, org, or agent?
+- Is this boot release allowed for this device or fleet?
+- Which validation report justified the state?
+- Which replay report can reproduce the decision?
+
+## Contract and language modeling
+
+We need to do data science on our own platform artifacts.
+
+Every `PlatformAssetRecord` should be convertible into examples for contract analysis, policy analysis, search ranking, metadata classification, and language-model evaluation.
+
+Minimum modeling artifacts:
+
+```text
+ContractModelExample
+PolicyModelExample
+SearchIndexDocument
+SlashTopicCandidateSet
+NewHopeCarrier
+GraphbrainArtifactCandidate
+```
+
+Minimum modeling fields:
+
+```text
+source_record_id
+source_kind
+plain_language_summary
+controlled_vocabulary_terms
+slash_topic_candidates
+policy_claims
+contract_claims
+evidence_links
+classification_labels
+negative_constraints
+```
+
+The purpose is to let the platform classify, summarize, test, and explain its own operating artifacts.
+
+## Graphbrain / model-contract integration
+
+Graphbrain-contract treats model and network artifacts as governed objects with architecture probes, patch plans, retrain jobs, and evaluation reports.
+
+Runtime records should connect to this layer when they provide execution context for model training, evaluation, or deployment.
+
+Minimum mapping:
+
+```text
+RuntimeAsset -> governed runtime context
+PlatformAssetRecord -> model governance subject
+compatibilitySurfaces -> execution or evaluation surfaces
+policyRef -> training/evaluation constraint
+evidenceCorrelationId -> evaluation or release evidence link
+```
+
+Required questions:
+
+- Which runtime produced or evaluated a model artifact?
+- Which policy constrained the training or evaluation job?
+- Which runtime change requires re-evaluation?
+- Which evidence links the model result to the runtime state?
+
+## Metadata classifier outputs
+
+The metadata classifier layer must emit enrichment objects, not overwrite canonical records.
+
+Required classifier outputs:
+
+```text
+asset_class
+lifecycle_stage
+risk_class
+surface_scope
+producer_domain
+supply_chain_posture
+evidence_completeness
+search_visibility
+slash_topic_candidates
+new_hope_membrane_status
+contract_subject_class
+contract_lifecycle_status
+policy_subject_class
+policy_gate_status
+language_modeling_use
+```
+
+## Implementation sequence
+
+1. Emit deterministic `PlatformAssetRecordSet` and per-record files.
+2. Add deterministic slash-topic candidate sidecars.
+3. Add contract/policy/modeling enrichment sidecars.
+4. Add Sherlock Search ingestion fixtures.
+5. Add Slash Topics topic-pack fixtures.
+6. Add New Hope carrier and membrane mapping fixtures.
+7. Add ContractForge referenced-asset fixture.
+8. Add Policy Fabric policy-subject fixture.
+9. Add Graphbrain runtime-context fixture.
+10. Persist enriched records through catalog/evidence services.
+
+## Doctrine
+
+Sherlock Search, Slash Topics, New Hope, ContractForge, Policy Fabric, Graphbrain, and Prophet Platform must share one metadata spine.
+
+The platform should understand its own contracts, policies, records, runtimes, and release states well enough to search them, govern them, classify them, train on them, and explain them.

--- a/docs/LATTICE_SEARCH_GOVERNANCE_INTEGRATION.md
+++ b/docs/LATTICE_SEARCH_GOVERNANCE_INTEGRATION.md
@@ -1,0 +1,182 @@
+# Lattice Search, Topic, and Governance Integration
+
+Lattice surface records must not stop at platform-local evidence files. They are discovery, classification, governance, and data-science inputs.
+
+This document fixes the integration seam that must exist between:
+
+- `prophet-platform`
+- `sherlock-search`
+- `slash-topics`
+- `new-hope`
+- later catalog/evidence services
+
+## Why this exists
+
+The failure mode to avoid is the classic suite-integration failure: search, studio, discovery, governance, and model tooling each develop their own metadata model. That makes language models, cataloging, discovery, and governance feel bolted together rather than native.
+
+For Prophet Lattice, every product-surface record must be:
+
+1. searchable by Sherlock Search;
+2. scoped and classified by Slash Topics;
+3. available to New Hope-style semantic/runtime governance;
+4. preserved as evidence for catalog, model, runtime, and boot provenance.
+
+## Current producer
+
+`apps/lattice-surface-ingestor` emits:
+
+```text
+PlatformAssetRecordSet
+```
+
+and can persist deterministic per-asset files:
+
+```text
+build/lattice-surface-ingestor/store/*.json
+```
+
+## Sherlock Search integration contract
+
+Sherlock Search is the canonical Sherlock-related search/discovery repo.
+
+The handoff from Prophet Platform to Sherlock should use each `PlatformAssetRecord` as an indexable document.
+
+Minimum index fields:
+
+```text
+assetId
+assetKind
+name
+version
+sourceKind
+sourceApiVersion
+producerRepo
+policyRef
+evidenceCorrelationId
+promotionChannel
+compatibilitySurfaces
+```
+
+Recommended Sherlock document envelope:
+
+```json
+{
+  "docType": "lattice.platformAssetRecord",
+  "assetId": "runtime-asset:prophet-python-ml:0.1.0",
+  "title": "prophet-python-ml 0.1.0",
+  "body": "RuntimeAsset v1 from SocioProphet/lattice-forge",
+  "metadata": {
+    "assetKind": "runtime-asset",
+    "producerRepo": "SocioProphet/lattice-forge",
+    "promotionChannel": "dev",
+    "compatibilitySurfaces": ["jupyter", "ray", "beam", "agentplane", "sourceos-user", "prophet-platform"]
+  }
+}
+```
+
+Sherlock must be able to search and facet over boot/runtime records alongside content, research, project, model, and dataset records.
+
+## Slash Topics integration contract
+
+Slash Topics are governed, signed, replayable scopes for search and knowledge surfaces.
+
+Every `PlatformAssetRecord` should receive deterministic topic candidates from metadata alone before any ML classifier runs.
+
+Minimum generated slash topics:
+
+```text
+/lattice
+/lattice/runtime
+/lattice/boot
+/sourceos
+/fogstack
+/governance
+/evidence
+/provenance
+```
+
+Mapping rules:
+
+```text
+assetKind=boot-release-set -> /lattice/boot /sourceos /recovery /release
+assetKind=runtime-asset -> /lattice/runtime /forge /notebook /agentplane
+producerRepo=SourceOS-Linux/sourceos-boot -> /sourceos /boot /recovery
+producerRepo=SocioProphet/lattice-forge -> /forge /runtime /supply-chain
+promotionChannel=dev -> /lifecycle/dev
+```
+
+Slash Topics should later provide signed topic-pack outputs for these records so Sherlock and New Hope consume the same scope vocabulary.
+
+## New Hope integration contract
+
+New Hope is the higher-order semantic runtime for agentic commons, with first-class concepts such as carrier, receptor, membrane, runtime, Message, Thread, Claim, Citation, Entity, Lens, and ModerationEvent.
+
+For Lattice surface records, New Hope should consume the records as semantic carriers for governance and classification.
+
+Minimum New Hope mapping:
+
+```text
+PlatformAssetRecord -> Carrier
+assetId -> Entity.id
+producerRepo -> Citation.source
+policyRef -> Claim.policyRef
+evidenceCorrelationId -> Evidence/Citation link
+compatibilitySurfaces -> Lens candidates
+promotionChannel -> Lifecycle/Governance attribute
+```
+
+The membrane model should answer:
+
+- Is this asset allowed to be discoverable?
+- Is this runtime allowed for this project/user/org?
+- Is this boot release approved for this device/fleet?
+- Which metadata classifiers have touched the record?
+- Which evidence objects justify its governance state?
+
+## Metadata classifier requirements
+
+The metadata classifier layer must treat platform asset records as first-class objects.
+
+Required classifier outputs:
+
+```text
+asset_class
+lifecycle_stage
+risk_class
+surface_scope
+producer_domain
+supply_chain_posture
+evidence_completeness
+search_visibility
+slash_topic_candidates
+new_hope_membrane_status
+```
+
+These classifier outputs should be appended to the record as a downstream enrichment object, not overwrite the canonical producer record.
+
+## Non-duplication rule
+
+Do not create separate Sherlock-only, Slash-only, or New-Hope-only schemas for boot/runtime assets.
+
+The canonical object is:
+
+```text
+PlatformAssetRecord
+```
+
+Search, topic, and governance layers may add enrichments, but the platform record remains the source of truth for asset identity.
+
+## Near-term implementation sequence
+
+1. `prophet-platform`: emit deterministic `PlatformAssetRecordSet` and per-record files.
+2. `prophet-platform`: add deterministic topic candidate generation sidecar.
+3. `sherlock-search`: add ingestion fixture for `PlatformAssetRecord` documents.
+4. `slash-topics`: add topic-pack fixture for Lattice/FogStack asset records.
+5. `new-hope`: add Carrier/Lens/Membrane mapping fixture for `PlatformAssetRecord`.
+6. `prophet-platform`: persist enriched records through catalog/evidence service.
+
+## Doctrine
+
+Search, studio, catalog, governance, and model/runtime management must share the same metadata spine.
+
+Sherlock Search is not a sidecar. Slash Topics are not decoration. New Hope is not post-hoc moderation. They are the discovery, scoping, and semantic governance layers for the same Lattice asset graph.


### PR DESCRIPTION
## Summary

Adds a deterministic local record store for normalized Lattice surface asset records.

## What changed

- Adds `lattice_surface_ingestor.store`.
- Adds CLI command: `lattice-surface-ingest store <record-set> <output-dir>`.
- Adds tests for per-asset record persistence and store manifest generation.
- Extends the validation smoke to generate:
  - `build/lattice-surface-ingestor/lattice-surface-records.json`
  - `build/lattice-surface-ingestor/store/manifest.json`
  - one JSON file per asset record.

## Why

This moves the platform one step beyond ingestion-by-stdout. The next catalog/evidence layer needs durable, deterministic records that can be indexed by Sherlock Search, classified by Slash Topics / metadata classifiers, and governed through New Hope-style data science and curation workflows.

## Safety

The store is file-based and scoped to a caller-provided output directory. It introduces no database, network, or long-running service dependency.
