### PR TITLE
fogstack: add registry rollback and revocation index

### DIFF
--- a/.github/workflows/fogstack-registry-lifecycle.yml
+++ b/.github/workflows/fogstack-registry-lifecycle.yml
@@ -1,0 +1,42 @@
+name: FogStack Registry Lifecycle
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "schemas/release/fogstack-registry-rollback-revocation-index-v0.1.schema.json"
+      - "tools/build_fogstack_registry_rollback_revocation_index.py"
+      - "tools/check_fogstack_registry_rollback_revocation_index.py"
+      - "tools/tests/test_fogstack_filesystem_registry.py"
+      - "docs/FOGSTACK_FILESYSTEM_REGISTRY.md"
+      - ".github/workflows/fogstack-registry-lifecycle.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/release/fogstack-registry-rollback-revocation-index-v0.1.schema.json"
+      - "tools/build_fogstack_registry_rollback_revocation_index.py"
+      - "tools/check_fogstack_registry_rollback_revocation_index.py"
+      - "tools/tests/test_fogstack_filesystem_registry.py"
+      - "docs/FOGSTACK_FILESYSTEM_REGISTRY.md"
+      - ".github/workflows/fogstack-registry-lifecycle.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  registry-lifecycle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+      - name: Run filesystem registry lifecycle tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_filesystem_registry.py

--- a/docs/FOGSTACK_FILESYSTEM_REGISTRY.md
+++ b/docs/FOGSTACK_FILESYSTEM_REGISTRY.md
@@ -18,6 +18,10 @@ The registry-root builder writes:
 
 - `<registry-root>/registry-root.json`
 
+The registry lifecycle builder writes:
+
+- `<registry-root>/rollback-revocation.index.json`
+
 The release pointer includes:
 
 - bundle id
@@ -34,6 +38,13 @@ The registry root includes:
 - a root digest computed over canonical JSON
 - signature metadata in shape-only form for this tranche
 
+The rollback/revocation index includes:
+
+- rollback target release pointers and digests
+- revocation or suspension entries for release pointers
+- lifecycle index digest over canonical JSON
+- signature metadata in shape-only form for this tranche
+
 ## Minimal flow
 
 1. build a gated registry publication index with `tools/build_fogstack_registry_publication_index.py`
@@ -42,6 +53,8 @@ The registry root includes:
 4. verify the filesystem registry release with `tools/check_fogstack_filesystem_registry.py`
 5. build registry-root metadata with `tools/build_fogstack_filesystem_registry_root.py`
 6. check registry-root metadata with `tools/check_fogstack_filesystem_registry_root.py`
+7. build rollback/revocation lifecycle metadata with `tools/build_fogstack_registry_rollback_revocation_index.py`
+8. check rollback/revocation lifecycle metadata with `tools/check_fogstack_registry_rollback_revocation_index.py`
 
 ## Registry root semantics
 
@@ -49,19 +62,30 @@ The registry root is the consumer-facing catalog root for a filesystem registry 
 
 This tranche uses shape-only signature metadata. It establishes the object and checker path without claiming KMS/HSM-backed registry-root signing.
 
+## Rollback and revocation semantics
+
+The rollback/revocation index records release lifecycle state outside the immutable release pointer itself.
+
+Rollback targets are releases that operators may return to. A rollback target may be `eligible`, `preferred`, or `deprecated`.
+
+Revocations are releases that consumers should not select. A revocation may be `revoked` or `suspended` and must carry a reason.
+
+A release must not be both a rollback target and a revocation entry in the same lifecycle index. The checker enforces that conflict rule and validates pointer digests against the filesystem registry.
+
 ## What this phase provides
 
 - concrete external-consumable registry layout
 - digest-checked artifact copy into the registry
 - release pointer for lookup
 - registry-root metadata covering release pointers and publication indexes
-- dedicated CI workflow for registry-root behavior
+- rollback/revocation lifecycle metadata for registry consumers
+- dedicated CI workflows for registry-root and registry-lifecycle behavior
 
 ## What this phase does not yet provide
 
 - authenticated network registry publication
-- cryptographic registry-root signature verification
-- rollback or revocation index publication
+- cryptographic registry-root or lifecycle-index signature verification
 - registry replication or mirror policy
+- policy-engine selection of rollback targets
 
 Those remain later steps.

--- a/schemas/release/fogstack-registry-rollback-revocation-index-v0.1.schema.json
+++ b/schemas/release/fogstack-registry-rollback-revocation-index-v0.1.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-registry-rollback-revocation-index-v0.1.schema.json",
+  "title": "FogStackRegistryRollbackRevocationIndex",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "schema_version",
+    "registry_uri",
+    "generated_at",
+    "rollback_targets",
+    "revocations",
+    "index_digest",
+    "signatures"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackRegistryRollbackRevocationIndex" },
+    "schema_version": { "const": "v0.1" },
+    "registry_uri": { "type": "string", "minLength": 1 },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "rollback_targets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["bundle_id", "version", "pointer_ref", "pointer_digest", "status"],
+        "properties": {
+          "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+          "version": { "type": "string", "minLength": 1 },
+          "pointer_ref": { "type": "string", "minLength": 1 },
+          "pointer_digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+          "status": { "type": "string", "enum": ["eligible", "preferred", "deprecated"] },
+          "reason": { "type": "string" }
+        }
+      }
+    },
+    "revocations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["bundle_id", "version", "pointer_ref", "pointer_digest", "revocation_status", "reason"],
+        "properties": {
+          "bundle_id": { "type": "string", "pattern": "^fogstack\\.[a-z0-9_.-]+$" },
+          "version": { "type": "string", "minLength": 1 },
+          "pointer_ref": { "type": "string", "minLength": 1 },
+          "pointer_digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+          "revocation_status": { "type": "string", "enum": ["revoked", "suspended"] },
+          "reason": { "type": "string", "minLength": 1 },
+          "effective_at": { "type": "string", "format": "date-time" }
+        }
+      }
+    },
+    "index_digest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "signatures": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key_id", "algorithm", "signature_ref"],
+        "properties": {
+          "key_id": { "type": "string", "minLength": 1 },
+          "algorithm": { "type": "string", "enum": ["ed25519", "sigstore", "gpg", "x509", "shape-only"] },
+          "signature_ref": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/tools/build_fogstack_registry_rollback_revocation_index.py
+++ b/tools/build_fogstack_registry_rollback_revocation_index.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def canonical_digest(data: dict[str, Any]) -> str:
+    encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def release_entry(registry_root: Path, release_ref: str, status: str, reason: str) -> dict[str, Any]:
+    release_root = registry_root / release_ref
+    pointer_path = release_root / "release-pointer.json"
+    if not pointer_path.exists():
+        raise SystemExit(f"ERR: release pointer missing: {pointer_path}")
+    pointer = load_json(pointer_path)
+    bundle_id = pointer.get("bundle_id")
+    version = pointer.get("version")
+    if not isinstance(bundle_id, str) or not isinstance(version, str):
+        raise SystemExit(f"ERR: malformed release pointer identity: {pointer_path}")
+    return {
+        "bundle_id": bundle_id,
+        "version": version,
+        "pointer_ref": str(pointer_path.relative_to(registry_root)),
+        "pointer_digest": sha256_file(pointer_path),
+        "status": status,
+        "reason": reason,
+    }
+
+
+def revoked_entry(registry_root: Path, release_ref: str, status: str, reason: str) -> dict[str, Any]:
+    entry = release_entry(registry_root, release_ref, status="deprecated", reason=reason)
+    entry.pop("status")
+    entry["revocation_status"] = status
+    entry["effective_at"] = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return entry
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build Fog Stack registry rollback/revocation index")
+    parser.add_argument("--registry-root", required=True, type=Path)
+    parser.add_argument("--registry-uri", required=True)
+    parser.add_argument("--rollback-target", action="append", default=[], help="release path relative to registry root, for example fogstack.access/0.1.0")
+    parser.add_argument("--preferred-rollback-target", action="append", default=[], help="preferred rollback release path relative to registry root")
+    parser.add_argument("--revoke", action="append", default=[], help="revoked release path relative to registry root")
+    parser.add_argument("--suspend", action="append", default=[], help="suspended release path relative to registry root")
+    parser.add_argument("--reason", default="operator-specified registry lifecycle state")
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--key-id", default="shape-only-registry-lifecycle-key")
+    parser.add_argument("--signature-ref", default="shape-only://fogstack/registry-rollback-revocation-index")
+    args = parser.parse_args()
+
+    if not args.registry_root.exists():
+        raise SystemExit(f"ERR: registry root missing: {args.registry_root}")
+
+    rollback_targets: list[dict[str, Any]] = []
+    for ref in args.rollback_target:
+        rollback_targets.append(release_entry(args.registry_root, ref, "eligible", args.reason))
+    for ref in args.preferred_rollback_target:
+        rollback_targets.append(release_entry(args.registry_root, ref, "preferred", args.reason))
+
+    revocations: list[dict[str, Any]] = []
+    for ref in args.revoke:
+        revocations.append(revoked_entry(args.registry_root, ref, "revoked", args.reason))
+    for ref in args.suspend:
+        revocations.append(revoked_entry(args.registry_root, ref, "suspended", args.reason))
+
+    index: dict[str, Any] = {
+        "kind": "FogStackRegistryRollbackRevocationIndex",
+        "schema_version": "v0.1",
+        "registry_uri": args.registry_uri,
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "rollback_targets": rollback_targets,
+        "revocations": revocations,
+        "signatures": [
+            {
+                "key_id": args.key_id,
+                "algorithm": "shape-only",
+                "signature_ref": args.signature_ref,
+            }
+        ],
+    }
+    digest_material = dict(index)
+    digest_material["index_digest"] = None
+    index["index_digest"] = canonical_digest(digest_material)
+
+    output = args.output or (args.registry_root / "rollback-revocation.index.json")
+    output.write_text(json.dumps(index, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(index, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_fogstack_registry_rollback_revocation_index.py
+++ b/tools/check_fogstack_registry_rollback_revocation_index.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def canonical_digest(data: dict[str, Any]) -> str:
+    encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def check_entry(registry_root: Path, entry: dict[str, Any], errors: list[str]) -> None:
+    pointer_ref = entry.get("pointer_ref")
+    pointer_digest = entry.get("pointer_digest")
+    bundle_id = entry.get("bundle_id")
+    version = entry.get("version")
+    if not isinstance(pointer_ref, str):
+        errors.append("pointer_ref missing")
+        return
+    pointer_path = registry_root / pointer_ref
+    if not pointer_path.exists():
+        errors.append(f"pointer missing: {pointer_path}")
+        return
+    if pointer_digest != sha256_file(pointer_path):
+        errors.append(f"pointer digest mismatch: {pointer_path}")
+    pointer = load_json(pointer_path)
+    if pointer.get("bundle_id") != bundle_id or pointer.get("version") != version:
+        errors.append(f"pointer identity mismatch: {pointer_path}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check Fog Stack registry rollback/revocation index")
+    parser.add_argument("--registry-root", required=True, type=Path)
+    parser.add_argument("--index", type=Path, default=None)
+    args = parser.parse_args()
+
+    index_path = args.index or (args.registry_root / "rollback-revocation.index.json")
+    if not index_path.exists():
+        print(f"rollback/revocation index missing: {index_path}")
+        return 1
+
+    errors: list[str] = []
+    index = load_json(index_path)
+    if index.get("kind") != "FogStackRegistryRollbackRevocationIndex":
+        errors.append("index kind mismatch")
+
+    digest_material = dict(index)
+    digest_material["index_digest"] = None
+    if index.get("index_digest") != canonical_digest(digest_material):
+        errors.append("index digest mismatch")
+
+    rollback_targets = index.get("rollback_targets") or []
+    revocations = index.get("revocations") or []
+    if not isinstance(rollback_targets, list):
+        errors.append("rollback_targets is not a list")
+        rollback_targets = []
+    if not isinstance(revocations, list):
+        errors.append("revocations is not a list")
+        revocations = []
+
+    revoked_identities = set()
+    for entry in revocations:
+        if not isinstance(entry, dict):
+            errors.append("revocation entry is not an object")
+            continue
+        check_entry(args.registry_root, entry, errors)
+        revoked_identities.add((entry.get("bundle_id"), entry.get("version")))
+
+    for entry in rollback_targets:
+        if not isinstance(entry, dict):
+            errors.append("rollback entry is not an object")
+            continue
+        check_entry(args.registry_root, entry, errors)
+        if (entry.get("bundle_id"), entry.get("version")) in revoked_identities:
+            errors.append(f"release cannot be both rollback target and revoked: {entry.get('bundle_id')} {entry.get('version')}")
+
+    signatures = index.get("signatures") or []
+    if not isinstance(signatures, list) or not signatures:
+        errors.append("index signatures missing")
+
+    if errors:
+        for item in errors:
+            print(item)
+        return 1
+
+    print("FogStack registry rollback/revocation index passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_filesystem_registry.py
+++ b/tools/tests/test_fogstack_filesystem_registry.py
@@ -96,6 +96,51 @@ def test_filesystem_registry_root_build_and_check(tmp_path: Path) -> None:
     ], check=True)
 
 
+def test_registry_rollback_revocation_index_build_and_check(tmp_path: Path) -> None:
+    registry_root = build_registry(tmp_path)
+
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_registry_rollback_revocation_index.py",
+        "--registry-root", str(registry_root),
+        "--registry-uri", "file://registry/fogstack",
+        "--preferred-rollback-target", "fogstack.access/0.1.0",
+    ], check=True)
+
+    index_path = registry_root / "rollback-revocation.index.json"
+    assert index_path.exists()
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    assert index["kind"] == "FogStackRegistryRollbackRevocationIndex"
+    assert index["rollback_targets"][0]["status"] == "preferred"
+    assert index["revocations"] == []
+
+    subprocess.run([
+        sys.executable,
+        "tools/check_fogstack_registry_rollback_revocation_index.py",
+        "--registry-root", str(registry_root),
+    ], check=True)
+
+
+def test_registry_rollback_revocation_index_rejects_revoked_rollback_target(tmp_path: Path) -> None:
+    registry_root = build_registry(tmp_path)
+
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_registry_rollback_revocation_index.py",
+        "--registry-root", str(registry_root),
+        "--registry-uri", "file://registry/fogstack",
+        "--rollback-target", "fogstack.access/0.1.0",
+        "--revoke", "fogstack.access/0.1.0",
+    ], check=True)
+
+    proc = subprocess.run([
+        sys.executable,
+        "tools/check_fogstack_registry_rollback_revocation_index.py",
+        "--registry-root", str(registry_root),
+    ])
+    assert proc.returncode != 0
+
+
 def test_filesystem_registry_root_check_rejects_tampered_pointer(tmp_path: Path) -> None:
     registry_root = build_registry(tmp_path)
     subprocess.run([


### PR DESCRIPTION
## Summary

Adds rollback/revocation lifecycle metadata for the Fog Stack filesystem registry.

## What changed

- Adds `fogstack-registry-rollback-revocation-index-v0.1.schema.json`.
- Adds `tools/build_fogstack_registry_rollback_revocation_index.py`.
- Adds `tools/check_fogstack_registry_rollback_revocation_index.py`.
- Extends filesystem registry tests to cover lifecycle index build/check and conflict rejection.
- Adds dedicated `FogStack Registry Lifecycle` workflow.
- Updates filesystem registry docs with rollback/revocation semantics.

## Why this PR exists

The filesystem registry now has release pointers and registry root metadata. Consumers also need a machine-readable lifecycle surface that can identify rollback-eligible releases and releases that are revoked or suspended without mutating immutable release pointers.

## Safety boundary

This tranche establishes shape-only lifecycle metadata and local validation. It does not add network registry publication, live consumer selection logic, cryptographic lifecycle-index signature verification, or policy-engine rollback decisions.
