### PR TITLE
Add Lattice Studio governed notebook session slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,14 @@ lattice-studio-smoke:
 	cd apps/lattice-studio && test -d .venv || python3 -m venv .venv
 	cd apps/lattice-studio && . .venv/bin/activate && python -m pip install --upgrade pip pytest && PYTHONPATH=src pytest -q tests
 	mkdir -p build/lattice-studio
-	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli create-session --project-id demo-project --user-id demo-user --runtime-asset apps/lattice-studio/examples/runtime-asset.prophet-python-ml.json --catalog-input catalog://datasets/demo-csv --policy-ref policy://lattice-studio/demo --output-dir build/lattice-studio/session
+	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-demo-catalog --output-dir build/lattice-studio/catalog
+	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli create-session --project-id demo-project --user-id demo-user --runtime-asset apps/lattice-studio/examples/runtime-asset.prophet-python-ml.json --catalog-input catalog://datasets/demo-csv@0.1.0 --catalog-input catalog://models/demo-classifier@0.1.0 --catalog-input catalog://applications/demo-notebook-app@0.1.0 --catalog-input catalog://services/demo-inference-service@0.1.0 --policy-ref policy://lattice-studio/demo --output-dir build/lattice-studio/session
 	test -s build/lattice-studio/session/notebook-session.json
 	test -s build/lattice-studio/session/notebook-session-evidence.json
+	test -s build/lattice-studio/catalog/datasets_demo-csv/catalog-asset.json
+	test -s build/lattice-studio/catalog/models_demo-classifier/catalog-asset.json
+	test -s build/lattice-studio/catalog/applications_demo-notebook-app/catalog-asset.json
+	test -s build/lattice-studio/catalog/services_demo-inference-service/catalog-asset.json
 
 validate-ops-fabric:
 	python3 tools/validate_ops_fabric.py

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -30,6 +30,14 @@ lattice-surface-ingestor-smoke:
 	test -s build/lattice-surface-ingestor/lattice-surface-records.json
 	test -s build/lattice-surface-ingestor/lattice-surface-enrichments.json
 	test -s build/lattice-surface-ingestor/store/manifest.json
+
+lattice-studio-smoke:
+	cd apps/lattice-studio && test -d .venv || python3 -m venv .venv
+	cd apps/lattice-studio && . .venv/bin/activate && python -m pip install --upgrade pip pytest && PYTHONPATH=src pytest -q tests
+	mkdir -p build/lattice-studio
+	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli create-session --project-id demo-project --user-id demo-user --runtime-asset apps/lattice-studio/examples/runtime-asset.prophet-python-ml.json --catalog-input catalog://datasets/demo-csv --policy-ref policy://lattice-studio/demo --output-dir build/lattice-studio/session
+	test -s build/lattice-studio/session/notebook-session.json
+	test -s build/lattice-studio/session/notebook-session-evidence.json
 
 validate-ops-fabric:
 	python3 tools/validate_ops_fabric.py

--- a/apps/lattice-studio/docs/CATALOG_REQUIREMENTS_MIT_DATAHUB.md
+++ b/apps/lattice-studio/docs/CATALOG_REQUIREMENTS_MIT_DATAHUB.md
@@ -1,0 +1,112 @@
+# Lattice Studio Catalog Requirements from MIT DataHub
+
+This note captures requirements from the MIT CSAIL DataHub lineage for the Lattice Studio / catalog vertical slice.
+
+## Source project
+
+MIT CSAIL DataHub was described by the MIT Database Group as an experimental hosted platform, GitHub-like, for organizing, managing, sharing, collaborating on, and making sense of data.
+
+The useful product frame:
+
+```text
+manage data -> use others' data -> make sense of data
+```
+
+Functional areas to learn from:
+
+```text
+ingestion
+curation
+sharing
+collaboration
+discovery
+linking
+query
+analytics
+visualization
+machine learning
+versioned datasets
+```
+
+## Requirement for Prophet Lattice
+
+Lattice Studio must not be only a notebook launcher.
+
+It must become a governed collaborative data-science workbench where notebook sessions are linked to catalog assets, runtime assets, evidence, policies, and search/topic/governance enrichments.
+
+## Minimum Lattice Studio / Catalog vertical slice
+
+The first demo-grade slice must include:
+
+1. Project workspace.
+2. Runtime selection from `RuntimeAsset`.
+3. NotebookSession record.
+4. Catalog input binding.
+5. Evidence output.
+6. Search/discovery indexing through `PlatformAssetRecord`.
+7. Topic classification through Slash Topics.
+8. Semantic governance through New Hope.
+9. Policy/contract context through Policy Fabric and ContractForge.
+10. A path to query/analytics/visualization rather than just static metadata.
+
+## Catalog object implications
+
+A catalog asset should have:
+
+```text
+asset id
+owner
+version
+schema or shape
+source reference
+license/usage policy
+curation state
+quality state
+lineage/evidence
+linked notebook sessions
+linked runtime assets
+search document
+topic candidates
+policy/contract subject mapping
+```
+
+## NotebookSession implications
+
+A notebook session should record:
+
+```text
+project id
+user id
+runtime asset id
+kernel name
+catalog inputs
+policy reference
+created time
+session digest
+evidence reports
+```
+
+This is why `NotebookSession` is the first Lattice Studio object in this tranche.
+
+## Design rule
+
+Do not repeat the IBM failure pattern where Studio, Discovery, catalog, language/modeling, and governance each own separate metadata identities.
+
+Lattice Studio must use the same metadata spine as the rest of Prophet Lattice:
+
+```text
+RuntimeAsset / BootReleaseSet
+  -> PlatformAssetRecord
+  -> enrichments
+  -> search/topics/governance/policy/contract/modeling
+  -> catalog/workbench experience
+```
+
+## Next implementation targets
+
+1. Add `CatalogAsset` and `CatalogAssetVersion` fixtures in `prophet-platform`.
+2. Bind `NotebookSession.catalogInputs[]` to real `CatalogAsset` identifiers.
+3. Emit a `NotebookSessionEvidence` record for each session.
+4. Convert notebook/session/catalog records into `PlatformAssetRecord` objects.
+5. Feed those records into Sherlock Search and Slash Topics.
+6. Add a small analytics/visualization stub so the demo shows data use, not only metadata.

--- a/apps/lattice-studio/docs/CATALOG_REQUIREMENTS_ZENODO_CK.md
+++ b/apps/lattice-studio/docs/CATALOG_REQUIREMENTS_ZENODO_CK.md
@@ -1,0 +1,108 @@
+# Lattice Studio Catalog Requirements from Zenodo and CK/CMX
+
+This note captures requirements from Zenodo and Collective Knowledge / Collective Mind / CMX for the Lattice Studio and catalog vertical slice.
+
+## Zenodo requirements
+
+Zenodo's core repository unit is a record composed of metadata, files, and a persistent identifier. Published files and persistent identifiers are immutable. Updates create new versions. Zenodo also has a concept DOI for all versions and a version DOI for each specific version.
+
+Lattice implications:
+
+1. `CatalogAsset` must distinguish a durable asset concept from immutable asset versions.
+2. `CatalogAssetVersion` must be immutable after publication.
+3. File/object digests must be recorded before promotion.
+4. Metadata may be amended, but file payload identity must not be silently rewritten.
+5. Every published catalog asset should be capable of carrying an external persistent identifier field.
+6. Access policy must support public metadata with restricted file access.
+7. Version-specific citation and concept-level citation must both be representable.
+
+Minimum fields:
+
+```text
+catalogAssetId
+conceptPersistentId
+versionPersistentId
+version
+metadata
+files
+fileDigests
+accessPolicy
+creators
+publicationDate
+relatedWorks
+license
+communitiesOrCollections
+```
+
+## CK / Collective Knowledge / CMX requirements
+
+CK and its successor lineage around Collective Mind / CMX focus on FAIR, reusable, portable artifacts and automations across code, data, models, scripts, experiments, software, hardware, and workflows.
+
+Lattice implications:
+
+1. Catalog assets must be file-based and portable where possible.
+2. Artifacts need extensible JSON/YAML metadata.
+3. Reusable automations must be first-class catalog objects, not hidden scripts.
+4. Workflows should be chainable across models, datasets, software, and hardware.
+5. Notebook sessions should record workflow/action metadata for rerun and reuse.
+6. Runtime, hardware, dataset, model, and script inputs should all be represented as linked assets.
+7. Reproducibility evidence should be generated as part of the normal workbench path.
+
+Minimum fields:
+
+```text
+automationId
+action
+inputs
+outputs
+runtimeAssetId
+hardwareProfile
+softwareProfile
+datasetRefs
+modelRefs
+scriptRefs
+workflowRefs
+reproduceCommand
+```
+
+## Combined Lattice requirement
+
+Lattice Studio must combine three ideas:
+
+```text
+MIT DataHub: collaborative data workbench and catalog
+Zenodo: durable archival records, persistent IDs, immutable versions
+CK/CMX: portable reusable artifacts and automations with FAIR metadata
+```
+
+Therefore a notebook session is not enough. The demo vertical slice must evolve toward:
+
+```text
+CatalogAsset -> CatalogAssetVersion -> RuntimeAsset -> NotebookSession -> Evidence -> Search/Topics/Governance
+```
+
+## Immediate implementation sequence
+
+1. Add `NotebookSession` and `NotebookSessionEvidence`.
+2. Add `CatalogAsset` and `CatalogAssetVersion` fixtures.
+3. Bind notebook `catalogInputs[]` to catalog asset versions.
+4. Add a reproducibility command / workflow action field to notebook evidence.
+5. Add citation/persistent identifier fields to catalog versions.
+6. Convert catalog and notebook objects into `PlatformAssetRecord` and enrichment sidecars.
+7. Make Sherlock Search index catalog/notebook/session records.
+
+## Design rule
+
+A dataset, runtime, notebook, automation, model, or evidence artifact is not first-class unless it is:
+
+```text
+findable
+versioned
+citable or referenceable
+policy-governed
+reproducible
+linked to runtime and evidence
+searchable
+classified by topics
+governable by semantic membranes
+```

--- a/apps/lattice-studio/examples/runtime-asset.prophet-python-ml.json
+++ b/apps/lattice-studio/examples/runtime-asset.prophet-python-ml.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "lattice.socioprophet.dev/v1",
+  "kind": "RuntimeAsset",
+  "metadata": {
+    "name": "prophet-python-ml",
+    "version": "0.1.0",
+    "createdAt": "2026-04-26T00:00:00Z"
+  },
+  "spec": {
+    "runtimeClass": "notebook",
+    "languages": ["python"],
+    "build": {"system": "nix", "entrypoint": "runtimes/prophet-python-ml/flake.nix", "builderId": "lattice-forge-nix-builder"},
+    "artifacts": [{"name": "runtime-closure", "role": "nix-closure", "digest": "sha256:3333333333333333333333333333333333333333333333333333333333333333"}],
+    "provenance": {"attestations": ["slsa", "in-toto"], "sourceRefs": ["SocioProphet/lattice-forge"], "builderId": "lattice-forge-nix-builder"},
+    "sbom": {"formats": ["spdx"], "digest": "sha256:5555555555555555555555555555555555555555555555555555555555555555"},
+    "signature": {"type": "sigstore", "digest": "sha256:6666666666666666666666666666666666666666666666666666666666666666"},
+    "scan": {"vulnerability": "not-run", "license": "not-run", "policy": "not-run"},
+    "policy": {"network": "restricted", "secrets": "scoped", "accelerators": ["cpu"], "defaultIsolation": "container"},
+    "compatibility": {"surfaces": ["jupyter", "ray", "beam", "agentplane", "sourceos-user", "prophet-platform"]},
+    "telemetry": {"traceRequired": true, "metricSet": ["build-duration", "scan-duration", "artifact-size", "promotion-result"]},
+    "promotion": {"channel": "dev", "rollbackRef": "runtime/prophet-python-ml/0.0.1"}
+  }
+}

--- a/apps/lattice-studio/pyproject.toml
+++ b/apps/lattice-studio/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "prophet-lattice-studio"
+version = "0.1.0"
+description = "Governed notebook/session workbench surface for Prophet Lattice."
+requires-python = ">=3.11"
+
+[project.scripts]
+lattice-studio = "lattice_studio.cli:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/apps/lattice-studio/src/lattice_studio/__init__.py
+++ b/apps/lattice-studio/src/lattice_studio/__init__.py
@@ -1,0 +1,4 @@
+"""Prophet Lattice Studio package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/apps/lattice-studio/src/lattice_studio/catalog.py
+++ b/apps/lattice-studio/src/lattice_studio/catalog.py
@@ -1,0 +1,153 @@
+"""Catalog asset records for Lattice Studio.
+
+The catalog model borrows the right primitives from Zenodo and CK/CMX:
+
+- concept-level identity separate from immutable versions;
+- version-specific persistent references;
+- digest-bearing file records;
+- portable automation/workflow metadata;
+- first-class reproducibility command.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CatalogFile:
+    path: str
+    digest: str
+    media_type: str
+    size_bytes: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "digest": self.digest,
+            "mediaType": self.media_type,
+            "sizeBytes": self.size_bytes,
+        }
+
+
+@dataclass(frozen=True)
+class CatalogAutomation:
+    automation_id: str
+    action: str
+    reproduce_command: str
+    workflow_refs: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "automationId": self.automation_id,
+            "action": self.action,
+            "reproduceCommand": self.reproduce_command,
+            "workflowRefs": self.workflow_refs,
+        }
+
+
+@dataclass(frozen=True)
+class CatalogAssetVersion:
+    catalog_asset_id: str
+    version: str
+    version_persistent_id: str | None
+    files: list[CatalogFile]
+    license: str
+    access_policy: str
+    automation: CatalogAutomation | None
+    published_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "studio.socioprophet.dev/v1",
+            "kind": "CatalogAssetVersion",
+            "catalogAssetId": self.catalog_asset_id,
+            "version": self.version,
+            "versionPersistentId": self.version_persistent_id,
+            "files": [file.to_dict() for file in self.files],
+            "license": self.license,
+            "accessPolicy": self.access_policy,
+            "automation": self.automation.to_dict() if self.automation else None,
+            "publishedAt": self.published_at,
+            "immutableAfterPublication": True,
+        }
+
+
+@dataclass(frozen=True)
+class CatalogAsset:
+    catalog_asset_id: str
+    title: str
+    owner: str
+    concept_persistent_id: str | None
+    creators: list[str]
+    collections: list[str]
+    latest_version: CatalogAssetVersion
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "studio.socioprophet.dev/v1",
+            "kind": "CatalogAsset",
+            "catalogAssetId": self.catalog_asset_id,
+            "title": self.title,
+            "owner": self.owner,
+            "conceptPersistentId": self.concept_persistent_id,
+            "creators": self.creators,
+            "collections": self.collections,
+            "latestVersion": self.latest_version.to_dict(),
+        }
+
+
+def demo_catalog_asset() -> CatalogAsset:
+    file = CatalogFile(
+        path="demo-csv/data.csv",
+        digest="sha256:" + hashlib.sha256(b"demo-csv-data").hexdigest(),
+        media_type="text/csv",
+        size_bytes=len(b"demo-csv-data"),
+    )
+    automation = CatalogAutomation(
+        automation_id="automation://lattice-studio/load-demo-csv",
+        action="load-csv",
+        reproduce_command="lattice-studio create-session --catalog-input catalog://datasets/demo-csv@0.1.0",
+        workflow_refs=["workflow://lattice-studio/demo-notebook"],
+    )
+    version = CatalogAssetVersion(
+        catalog_asset_id="catalog://datasets/demo-csv",
+        version="0.1.0",
+        version_persistent_id="doi:10.0000/lattice.demo-csv.v1",
+        files=[file],
+        license="CC-BY-4.0",
+        access_policy="public-metadata-restricted-files",
+        automation=automation,
+    )
+    return CatalogAsset(
+        catalog_asset_id="catalog://datasets/demo-csv",
+        title="Demo CSV Dataset",
+        owner="SocioProphet",
+        concept_persistent_id="doi:10.0000/lattice.demo-csv",
+        creators=["SocioProphet"],
+        collections=["lattice-studio-demo"],
+        latest_version=version,
+    )
+
+
+def catalog_evidence(asset: CatalogAsset) -> dict[str, Any]:
+    doc = asset.to_dict()
+    digest = hashlib.sha256(json.dumps(doc, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "CatalogAssetEvidence",
+        "catalogAssetId": asset.catalog_asset_id,
+        "latestVersion": asset.latest_version.version,
+        "assetDigest": f"sha256:{digest}",
+        "evidenceReports": [
+            "concept-persistent-id",
+            "version-persistent-id",
+            "file-digests",
+            "access-policy",
+            "automation-reproduce-command",
+        ],
+    }

--- a/apps/lattice-studio/src/lattice_studio/catalog.py
+++ b/apps/lattice-studio/src/lattice_studio/catalog.py
@@ -1,12 +1,15 @@
 """Catalog asset records for Lattice Studio.
 
-The catalog model borrows the right primitives from Zenodo and CK/CMX:
+The catalog model borrows the right primitives from MIT DataHub, Zenodo, and
+CK/CMX:
 
+- collaborative data/workbench objects;
 - concept-level identity separate from immutable versions;
 - version-specific persistent references;
 - digest-bearing file records;
 - portable automation/workflow metadata;
-- first-class reproducibility command.
+- first-class reproducibility commands;
+- explicit asset classes for data, ML, applications, and services.
 """
 
 from __future__ import annotations
@@ -15,7 +18,9 @@ import hashlib
 import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
+
+CatalogAssetType = Literal["data", "ml-model", "application", "service", "workflow", "notebook"]
 
 
 @dataclass(frozen=True)
@@ -59,6 +64,11 @@ class CatalogAssetVersion:
     license: str
     access_policy: str
     automation: CatalogAutomation | None
+    runtime_asset_refs: list[str] = field(default_factory=list)
+    dataset_refs: list[str] = field(default_factory=list)
+    model_refs: list[str] = field(default_factory=list)
+    service_refs: list[str] = field(default_factory=list)
+    application_refs: list[str] = field(default_factory=list)
     published_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
     def to_dict(self) -> dict[str, Any]:
@@ -72,6 +82,11 @@ class CatalogAssetVersion:
             "license": self.license,
             "accessPolicy": self.access_policy,
             "automation": self.automation.to_dict() if self.automation else None,
+            "runtimeAssetRefs": self.runtime_asset_refs,
+            "datasetRefs": self.dataset_refs,
+            "modelRefs": self.model_refs,
+            "serviceRefs": self.service_refs,
+            "applicationRefs": self.application_refs,
             "publishedAt": self.published_at,
             "immutableAfterPublication": True,
         }
@@ -80,6 +95,7 @@ class CatalogAssetVersion:
 @dataclass(frozen=True)
 class CatalogAsset:
     catalog_asset_id: str
+    asset_type: CatalogAssetType
     title: str
     owner: str
     concept_persistent_id: str | None
@@ -92,6 +108,7 @@ class CatalogAsset:
             "apiVersion": "studio.socioprophet.dev/v1",
             "kind": "CatalogAsset",
             "catalogAssetId": self.catalog_asset_id,
+            "assetType": self.asset_type,
             "title": self.title,
             "owner": self.owner,
             "conceptPersistentId": self.concept_persistent_id,
@@ -101,37 +118,129 @@ class CatalogAsset:
         }
 
 
+def _digest_for(label: str) -> str:
+    return "sha256:" + hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _file(path: str, media_type: str) -> CatalogFile:
+    return CatalogFile(path=path, digest=_digest_for(path), media_type=media_type, size_bytes=len(path.encode("utf-8")))
+
+
+def _automation(automation_id: str, action: str, command: str) -> CatalogAutomation:
+    return CatalogAutomation(
+        automation_id=automation_id,
+        action=action,
+        reproduce_command=command,
+        workflow_refs=["workflow://lattice-studio/demo-vertical-slice"],
+    )
+
+
 def demo_catalog_asset() -> CatalogAsset:
-    file = CatalogFile(
-        path="demo-csv/data.csv",
-        digest="sha256:" + hashlib.sha256(b"demo-csv-data").hexdigest(),
-        media_type="text/csv",
-        size_bytes=len(b"demo-csv-data"),
-    )
-    automation = CatalogAutomation(
-        automation_id="automation://lattice-studio/load-demo-csv",
-        action="load-csv",
-        reproduce_command="lattice-studio create-session --catalog-input catalog://datasets/demo-csv@0.1.0",
-        workflow_refs=["workflow://lattice-studio/demo-notebook"],
-    )
-    version = CatalogAssetVersion(
+    return demo_catalog_assets()[0]
+
+
+def demo_catalog_assets() -> list[CatalogAsset]:
+    data_version = CatalogAssetVersion(
         catalog_asset_id="catalog://datasets/demo-csv",
         version="0.1.0",
         version_persistent_id="doi:10.0000/lattice.demo-csv.v1",
-        files=[file],
+        files=[_file("demo-csv/data.csv", "text/csv")],
         license="CC-BY-4.0",
         access_policy="public-metadata-restricted-files",
-        automation=automation,
+        automation=_automation(
+            "automation://lattice-studio/load-demo-csv",
+            "load-csv",
+            "lattice-studio create-session --catalog-input catalog://datasets/demo-csv@0.1.0",
+        ),
+        runtime_asset_refs=["runtime-asset:prophet-python-ml:0.1.0"],
     )
-    return CatalogAsset(
-        catalog_asset_id="catalog://datasets/demo-csv",
-        title="Demo CSV Dataset",
-        owner="SocioProphet",
-        concept_persistent_id="doi:10.0000/lattice.demo-csv",
-        creators=["SocioProphet"],
-        collections=["lattice-studio-demo"],
-        latest_version=version,
+    model_version = CatalogAssetVersion(
+        catalog_asset_id="catalog://models/demo-classifier",
+        version="0.1.0",
+        version_persistent_id="doi:10.0000/lattice.demo-classifier.v1",
+        files=[_file("demo-classifier/model.onnx", "application/octet-stream")],
+        license="Apache-2.0",
+        access_policy="governed-project-use",
+        automation=_automation(
+            "automation://lattice-studio/evaluate-demo-classifier",
+            "evaluate-model",
+            "lattice-studio create-session --catalog-input catalog://models/demo-classifier@0.1.0",
+        ),
+        runtime_asset_refs=["runtime-asset:prophet-python-ml:0.1.0"],
+        dataset_refs=["catalog://datasets/demo-csv@0.1.0"],
     )
+    app_version = CatalogAssetVersion(
+        catalog_asset_id="catalog://applications/demo-notebook-app",
+        version="0.1.0",
+        version_persistent_id="doi:10.0000/lattice.demo-notebook-app.v1",
+        files=[_file("demo-notebook-app/app.py", "text/x-python")],
+        license="MIT",
+        access_policy="project-members",
+        automation=_automation(
+            "automation://lattice-studio/run-demo-app",
+            "run-application",
+            "lattice-studio create-session --catalog-input catalog://applications/demo-notebook-app@0.1.0",
+        ),
+        dataset_refs=["catalog://datasets/demo-csv@0.1.0"],
+        model_refs=["catalog://models/demo-classifier@0.1.0"],
+    )
+    service_version = CatalogAssetVersion(
+        catalog_asset_id="catalog://services/demo-inference-service",
+        version="0.1.0",
+        version_persistent_id="doi:10.0000/lattice.demo-inference-service.v1",
+        files=[_file("demo-inference-service/openapi.json", "application/json")],
+        license="MIT",
+        access_policy="service-account-scoped",
+        automation=_automation(
+            "automation://lattice-studio/smoke-demo-service",
+            "smoke-service",
+            "lattice-studio create-session --catalog-input catalog://services/demo-inference-service@0.1.0",
+        ),
+        model_refs=["catalog://models/demo-classifier@0.1.0"],
+        application_refs=["catalog://applications/demo-notebook-app@0.1.0"],
+    )
+    return [
+        CatalogAsset(
+            catalog_asset_id="catalog://datasets/demo-csv",
+            asset_type="data",
+            title="Demo CSV Dataset",
+            owner="SocioProphet",
+            concept_persistent_id="doi:10.0000/lattice.demo-csv",
+            creators=["SocioProphet"],
+            collections=["lattice-studio-demo"],
+            latest_version=data_version,
+        ),
+        CatalogAsset(
+            catalog_asset_id="catalog://models/demo-classifier",
+            asset_type="ml-model",
+            title="Demo Classifier Model",
+            owner="SocioProphet",
+            concept_persistent_id="doi:10.0000/lattice.demo-classifier",
+            creators=["SocioProphet"],
+            collections=["lattice-studio-demo", "ml"],
+            latest_version=model_version,
+        ),
+        CatalogAsset(
+            catalog_asset_id="catalog://applications/demo-notebook-app",
+            asset_type="application",
+            title="Demo Notebook Application",
+            owner="SocioProphet",
+            concept_persistent_id="doi:10.0000/lattice.demo-notebook-app",
+            creators=["SocioProphet"],
+            collections=["lattice-studio-demo", "applications"],
+            latest_version=app_version,
+        ),
+        CatalogAsset(
+            catalog_asset_id="catalog://services/demo-inference-service",
+            asset_type="service",
+            title="Demo Inference Service",
+            owner="SocioProphet",
+            concept_persistent_id="doi:10.0000/lattice.demo-inference-service",
+            creators=["SocioProphet"],
+            collections=["lattice-studio-demo", "services"],
+            latest_version=service_version,
+        ),
+    ]
 
 
 def catalog_evidence(asset: CatalogAsset) -> dict[str, Any]:
@@ -141,6 +250,7 @@ def catalog_evidence(asset: CatalogAsset) -> dict[str, Any]:
         "apiVersion": "studio.socioprophet.dev/v1",
         "kind": "CatalogAssetEvidence",
         "catalogAssetId": asset.catalog_asset_id,
+        "assetType": asset.asset_type,
         "latestVersion": asset.latest_version.version,
         "assetDigest": f"sha256:{digest}",
         "evidenceReports": [
@@ -149,5 +259,6 @@ def catalog_evidence(asset: CatalogAsset) -> dict[str, Any]:
             "file-digests",
             "access-policy",
             "automation-reproduce-command",
+            "linked-runtime-data-model-application-service-assets",
         ],
     }

--- a/apps/lattice-studio/src/lattice_studio/cli.py
+++ b/apps/lattice-studio/src/lattice_studio/cli.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""CLI for Lattice Studio governed notebook sessions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .session import create_session, load_json, write_session_bundle
+
+
+def create_notebook_session(args: argparse.Namespace) -> int:
+    runtime_asset = load_json(args.runtime_asset)
+    catalog_inputs = args.catalog_input or []
+    session = create_session(
+        project_id=args.project_id,
+        user_id=args.user_id,
+        runtime_asset=runtime_asset,
+        catalog_inputs=catalog_inputs,
+        policy_ref=args.policy_ref,
+    )
+    written = write_session_bundle(session, args.output_dir)
+    print(json.dumps({"written": [str(path) for path in written]}, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Lattice Studio governed notebook sessions")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create_parser = subparsers.add_parser("create-session", help="Create a governed NotebookSession bundle")
+    create_parser.add_argument("--project-id", required=True)
+    create_parser.add_argument("--user-id", required=True)
+    create_parser.add_argument("--runtime-asset", type=Path, required=True)
+    create_parser.add_argument("--catalog-input", action="append", default=[])
+    create_parser.add_argument("--policy-ref")
+    create_parser.add_argument("--output-dir", type=Path, required=True)
+    create_parser.set_defaults(func=create_notebook_session)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"lattice-studio: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/lattice-studio/src/lattice_studio/cli.py
+++ b/apps/lattice-studio/src/lattice_studio/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""CLI for Lattice Studio governed notebook sessions."""
+"""CLI for Lattice Studio governed notebook sessions and catalog assets."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import json
 import sys
 from pathlib import Path
 
+from .catalog import catalog_evidence, demo_catalog_assets
 from .session import create_session, load_json, write_session_bundle
 
 
@@ -26,8 +27,24 @@ def create_notebook_session(args: argparse.Namespace) -> int:
     return 0
 
 
+def emit_demo_catalog(args: argparse.Namespace) -> int:
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for asset in demo_catalog_assets():
+        asset_dir_name = asset.catalog_asset_id.replace("catalog://", "").replace("/", "_")
+        asset_dir = args.output_dir / asset_dir_name
+        asset_dir.mkdir(parents=True, exist_ok=True)
+        asset_path = asset_dir / "catalog-asset.json"
+        evidence_path = asset_dir / "catalog-asset-evidence.json"
+        asset_path.write_text(json.dumps(asset.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        evidence_path.write_text(json.dumps(catalog_evidence(asset), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        written.extend([asset_path, evidence_path])
+    print(json.dumps({"written": [str(path) for path in written]}, indent=2, sort_keys=True))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Lattice Studio governed notebook sessions")
+    parser = argparse.ArgumentParser(description="Lattice Studio governed notebook sessions and catalog assets")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     create_parser = subparsers.add_parser("create-session", help="Create a governed NotebookSession bundle")
@@ -38,6 +55,10 @@ def build_parser() -> argparse.ArgumentParser:
     create_parser.add_argument("--policy-ref")
     create_parser.add_argument("--output-dir", type=Path, required=True)
     create_parser.set_defaults(func=create_notebook_session)
+
+    catalog_parser = subparsers.add_parser("emit-demo-catalog", help="Emit demo CatalogAsset bundles for data, ML, app, and service assets")
+    catalog_parser.add_argument("--output-dir", type=Path, required=True)
+    catalog_parser.set_defaults(func=emit_demo_catalog)
     return parser
 
 

--- a/apps/lattice-studio/src/lattice_studio/session.py
+++ b/apps/lattice-studio/src/lattice_studio/session.py
@@ -1,0 +1,128 @@
+"""Governed notebook session records for Lattice Studio.
+
+This is the first Watson Studio/JupyterHub-style vertical slice: a session is
+bound to a project, a RuntimeAsset, optional catalog inputs, and an evidence
+record. No notebook server is launched in this tranche; the model is designed so
+JupyterHub/KubeSpawner/etc. can consume the same record later.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class NotebookSession:
+    session_id: str
+    project_id: str
+    user_id: str
+    runtime_asset_id: str
+    kernel_name: str
+    catalog_inputs: list[str]
+    policy_ref: str | None
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "studio.socioprophet.dev/v1",
+            "kind": "NotebookSession",
+            "sessionId": self.session_id,
+            "projectId": self.project_id,
+            "userId": self.user_id,
+            "runtimeAssetId": self.runtime_asset_id,
+            "kernelName": self.kernel_name,
+            "catalogInputs": self.catalog_inputs,
+            "policyRef": self.policy_ref,
+            "createdAt": self.created_at,
+        }
+
+
+def create_session(
+    *,
+    project_id: str,
+    user_id: str,
+    runtime_asset: dict[str, Any],
+    catalog_inputs: list[str] | None = None,
+    policy_ref: str | None = None,
+) -> NotebookSession:
+    metadata = _required_dict(runtime_asset, "metadata")
+    name = _required_str(metadata, "name")
+    version = _required_str(metadata, "version")
+    runtime_asset_id = f"runtime-asset:{name}:{version}"
+    kernel_name = f"{name}-{version}"
+    seed = json.dumps(
+        {
+            "projectId": project_id,
+            "userId": user_id,
+            "runtimeAssetId": runtime_asset_id,
+            "catalogInputs": sorted(catalog_inputs or []),
+            "policyRef": policy_ref,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    session_id = "notebook-session:" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+    return NotebookSession(
+        session_id=session_id,
+        project_id=project_id,
+        user_id=user_id,
+        runtime_asset_id=runtime_asset_id,
+        kernel_name=kernel_name,
+        catalog_inputs=sorted(catalog_inputs or []),
+        policy_ref=policy_ref,
+    )
+
+
+def evidence_for_session(session: NotebookSession) -> dict[str, Any]:
+    session_doc = session.to_dict()
+    digest = hashlib.sha256(json.dumps(session_doc, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "NotebookSessionEvidence",
+        "sessionId": session.session_id,
+        "runtimeAssetId": session.runtime_asset_id,
+        "projectId": session.project_id,
+        "userId": session.user_id,
+        "sessionDigest": f"sha256:{digest}",
+        "evidenceReports": [
+            "runtime-binding",
+            "kernel-selection",
+            "catalog-input-binding",
+            "policy-binding",
+        ],
+    }
+
+
+def write_session_bundle(session: NotebookSession, output_dir: Path) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    session_path = output_dir / "notebook-session.json"
+    evidence_path = output_dir / "notebook-session-evidence.json"
+    session_path.write_text(json.dumps(session.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    evidence_path.write_text(json.dumps(evidence_for_session(session), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return [session_path, evidence_path]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return data
+
+
+def _required_dict(data: dict[str, Any], key: str) -> dict[str, Any]:
+    value = data.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"{key} must be an object")
+    return value
+
+
+def _required_str(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a non-empty string")
+    return value

--- a/apps/lattice-studio/tests/test_notebook_session.py
+++ b/apps/lattice-studio/tests/test_notebook_session.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+from lattice_studio.cli import main
+from lattice_studio.session import create_session, evidence_for_session, load_json
+
+ROOT = Path(__file__).resolve().parents[3]
+RUNTIME_ASSET = ROOT / "apps" / "lattice-studio" / "examples" / "runtime-asset.prophet-python-ml.json"
+
+
+def test_create_session_binds_runtime_and_catalog_inputs() -> None:
+    runtime_asset = load_json(RUNTIME_ASSET)
+    session = create_session(
+        project_id="demo-project",
+        user_id="demo-user",
+        runtime_asset=runtime_asset,
+        catalog_inputs=["catalog://datasets/demo-csv"],
+        policy_ref="policy://lattice-studio/demo",
+    )
+
+    assert session.runtime_asset_id == "runtime-asset:prophet-python-ml:0.1.0"
+    assert session.kernel_name == "prophet-python-ml-0.1.0"
+    assert session.catalog_inputs == ["catalog://datasets/demo-csv"]
+    assert session.policy_ref == "policy://lattice-studio/demo"
+
+
+def test_session_evidence_links_runtime_project_user_and_digest() -> None:
+    runtime_asset = load_json(RUNTIME_ASSET)
+    session = create_session(project_id="demo-project", user_id="demo-user", runtime_asset=runtime_asset)
+    evidence = evidence_for_session(session)
+
+    assert evidence["kind"] == "NotebookSessionEvidence"
+    assert evidence["sessionId"] == session.session_id
+    assert evidence["runtimeAssetId"] == session.runtime_asset_id
+    assert evidence["sessionDigest"].startswith("sha256:")
+    assert "runtime-binding" in evidence["evidenceReports"]
+
+
+def test_lattice_studio_cli_writes_session_bundle(tmp_path) -> None:
+    output_dir = tmp_path / "session"
+    rc = main([
+        "create-session",
+        "--project-id",
+        "demo-project",
+        "--user-id",
+        "demo-user",
+        "--runtime-asset",
+        str(RUNTIME_ASSET),
+        "--catalog-input",
+        "catalog://datasets/demo-csv",
+        "--policy-ref",
+        "policy://lattice-studio/demo",
+        "--output-dir",
+        str(output_dir),
+    ])
+    assert rc == 0
+    session_doc = json.loads((output_dir / "notebook-session.json").read_text(encoding="utf-8"))
+    evidence_doc = json.loads((output_dir / "notebook-session-evidence.json").read_text(encoding="utf-8"))
+    assert session_doc["kind"] == "NotebookSession"
+    assert evidence_doc["kind"] == "NotebookSessionEvidence"

--- a/apps/lattice-studio/tests/test_notebook_session.py
+++ b/apps/lattice-studio/tests/test_notebook_session.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from lattice_studio.catalog import catalog_evidence, demo_catalog_assets
 from lattice_studio.cli import main
 from lattice_studio.session import create_session, evidence_for_session, load_json
 
@@ -58,3 +59,49 @@ def test_lattice_studio_cli_writes_session_bundle(tmp_path) -> None:
     evidence_doc = json.loads((output_dir / "notebook-session-evidence.json").read_text(encoding="utf-8"))
     assert session_doc["kind"] == "NotebookSession"
     assert evidence_doc["kind"] == "NotebookSessionEvidence"
+
+
+def test_demo_catalog_assets_cover_data_ml_application_and_service() -> None:
+    assets = demo_catalog_assets()
+    by_type = {asset.asset_type: asset for asset in assets}
+
+    assert set(by_type) == {"data", "ml-model", "application", "service"}
+    assert by_type["data"].latest_version.runtime_asset_refs == ["runtime-asset:prophet-python-ml:0.1.0"]
+    assert by_type["ml-model"].latest_version.dataset_refs == ["catalog://datasets/demo-csv@0.1.0"]
+    assert by_type["application"].latest_version.model_refs == ["catalog://models/demo-classifier@0.1.0"]
+    assert by_type["service"].latest_version.application_refs == ["catalog://applications/demo-notebook-app@0.1.0"]
+
+
+def test_catalog_evidence_is_digest_backed_and_zenodo_ck_informed() -> None:
+    for asset in demo_catalog_assets():
+        doc = asset.to_dict()
+        evidence = catalog_evidence(asset)
+        assert doc["kind"] == "CatalogAsset"
+        assert doc["assetType"] in {"data", "ml-model", "application", "service"}
+        assert doc["conceptPersistentId"].startswith("doi:")
+        assert doc["latestVersion"]["versionPersistentId"].startswith("doi:")
+        assert doc["latestVersion"]["immutableAfterPublication"] is True
+        assert doc["latestVersion"]["automation"]["reproduceCommand"]
+        assert evidence["assetDigest"].startswith("sha256:")
+        assert "linked-runtime-data-model-application-service-assets" in evidence["evidenceReports"]
+
+
+def test_lattice_studio_cli_writes_demo_catalog_bundles(tmp_path) -> None:
+    output_dir = tmp_path / "catalog"
+    rc = main(["emit-demo-catalog", "--output-dir", str(output_dir)])
+    assert rc == 0
+
+    expected_dirs = {
+        "datasets_demo-csv",
+        "models_demo-classifier",
+        "applications_demo-notebook-app",
+        "services_demo-inference-service",
+    }
+    assert expected_dirs == {path.name for path in output_dir.iterdir() if path.is_dir()}
+    for asset_dir in output_dir.iterdir():
+        if not asset_dir.is_dir():
+            continue
+        asset_doc = json.loads((asset_dir / "catalog-asset.json").read_text(encoding="utf-8"))
+        evidence_doc = json.loads((asset_dir / "catalog-asset-evidence.json").read_text(encoding="utf-8"))
+        assert asset_doc["kind"] == "CatalogAsset"
+        assert evidence_doc["kind"] == "CatalogAssetEvidence"


### PR DESCRIPTION
## Summary

Adds the first Lattice Studio / Watson Studio-style governed notebook session vertical slice.

## What changed

- Adds `apps/lattice-studio` Python app.
- Adds `NotebookSession` and `NotebookSessionEvidence` records.
- Adds CLI: `lattice-studio create-session`.
- Adds RuntimeAsset fixture for `prophet-python-ml`.
- Adds tests for runtime binding, catalog inputs, policy binding, evidence digest, and CLI output.
- Adds `apps/lattice-studio/docs/CATALOG_REQUIREMENTS_MIT_DATAHUB.md` to capture catalog/workbench requirements from the MIT CSAIL DataHub lineage.
- Wires `lattice-studio-smoke` into `make validate`.

## Why

This pivots from metadata-spine plumbing to the demo-critical workbench surface: a governed JupyterHub/Watson Studio-style path where notebook sessions bind to RuntimeAsset, catalog inputs, policy refs, and evidence.

## Integration

- Consumes `RuntimeAsset v1` from Lattice Forge.
- Produces `NotebookSession` and `NotebookSessionEvidence` as the next platform records for catalog/search/governance integration.
- Establishes the next CatalogAsset requirement so Studio is catalog-first, not notebook-only.

## Validation

`make validate` now creates a demo notebook session bundle under `build/lattice-studio/session` and asserts both session and evidence artifacts exist.
