### PR TITLE
Emit Lattice Studio outputs as PlatformAssetRecords

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,14 @@ lattice-studio-smoke:
 	mkdir -p build/lattice-studio
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-demo-catalog --output-dir build/lattice-studio/catalog
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli create-session --project-id demo-project --user-id demo-user --runtime-asset apps/lattice-studio/examples/runtime-asset.prophet-python-ml.json --catalog-input catalog://datasets/demo-csv@0.1.0 --catalog-input catalog://models/demo-classifier@0.1.0 --catalog-input catalog://applications/demo-notebook-app@0.1.0 --catalog-input catalog://services/demo-inference-service@0.1.0 --policy-ref policy://lattice-studio/demo --output-dir build/lattice-studio/session
+	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-platform-records --catalog-asset build/lattice-studio/catalog/datasets_demo-csv/catalog-asset.json --catalog-asset build/lattice-studio/catalog/models_demo-classifier/catalog-asset.json --catalog-asset build/lattice-studio/catalog/applications_demo-notebook-app/catalog-asset.json --catalog-asset build/lattice-studio/catalog/services_demo-inference-service/catalog-asset.json --notebook-session build/lattice-studio/session/notebook-session.json --output build/lattice-studio/studio-platform-records.json
 	test -s build/lattice-studio/session/notebook-session.json
 	test -s build/lattice-studio/session/notebook-session-evidence.json
 	test -s build/lattice-studio/catalog/datasets_demo-csv/catalog-asset.json
 	test -s build/lattice-studio/catalog/models_demo-classifier/catalog-asset.json
 	test -s build/lattice-studio/catalog/applications_demo-notebook-app/catalog-asset.json
 	test -s build/lattice-studio/catalog/services_demo-inference-service/catalog-asset.json
+	test -s build/lattice-studio/studio-platform-records.json
 
 validate-ops-fabric:
 	python3 tools/validate_ops_fabric.py

--- a/apps/lattice-studio/src/lattice_studio/cli.py
+++ b/apps/lattice-studio/src/lattice_studio/cli.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from .catalog import catalog_evidence, demo_catalog_assets
+from .platform_records import catalog_asset_to_platform_record, notebook_session_to_platform_record, platform_record_set
 from .session import create_session, load_json, write_session_bundle
 
 
@@ -43,6 +44,19 @@ def emit_demo_catalog(args: argparse.Namespace) -> int:
     return 0
 
 
+def emit_platform_records(args: argparse.Namespace) -> int:
+    records = []
+    for path in args.catalog_asset:
+        records.append(catalog_asset_to_platform_record(load_json(path)))
+    for path in args.notebook_session:
+        records.append(notebook_session_to_platform_record(load_json(path)))
+    payload = platform_record_set(records)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"written": [str(args.output)], "recordCount": len(records)}, indent=2, sort_keys=True))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Lattice Studio governed notebook sessions and catalog assets")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -59,6 +73,12 @@ def build_parser() -> argparse.ArgumentParser:
     catalog_parser = subparsers.add_parser("emit-demo-catalog", help="Emit demo CatalogAsset bundles for data, ML, app, and service assets")
     catalog_parser.add_argument("--output-dir", type=Path, required=True)
     catalog_parser.set_defaults(func=emit_demo_catalog)
+
+    records_parser = subparsers.add_parser("emit-platform-records", help="Convert Studio catalog/session artifacts into PlatformAssetRecordSet")
+    records_parser.add_argument("--catalog-asset", type=Path, action="append", default=[])
+    records_parser.add_argument("--notebook-session", type=Path, action="append", default=[])
+    records_parser.add_argument("--output", type=Path, required=True)
+    records_parser.set_defaults(func=emit_platform_records)
     return parser
 
 

--- a/apps/lattice-studio/src/lattice_studio/platform_records.py
+++ b/apps/lattice-studio/src/lattice_studio/platform_records.py
@@ -1,0 +1,77 @@
+"""Convert Lattice Studio outputs into PlatformAssetRecord objects.
+
+This module bridges the Studio/catalog slice into the existing Lattice metadata
+spine. Catalog assets and notebook sessions become the same canonical
+PlatformAssetRecord identity shape used by runtime and boot product surfaces.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def catalog_asset_to_platform_record(asset_doc: dict[str, Any]) -> dict[str, Any]:
+    if asset_doc.get("kind") != "CatalogAsset":
+        raise ValueError("catalog asset document kind must be CatalogAsset")
+    catalog_asset_id = _required_str(asset_doc, "catalogAssetId")
+    asset_type = _required_str(asset_doc, "assetType")
+    latest_version = _required_dict(asset_doc, "latestVersion")
+    version = _required_str(latest_version, "version")
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecord",
+        "assetId": f"catalog-asset:{catalog_asset_id}@{version}",
+        "assetKind": f"catalog-{asset_type}",
+        "name": catalog_asset_id,
+        "version": version,
+        "sourceApiVersion": _required_str(asset_doc, "apiVersion"),
+        "sourceKind": "CatalogAsset",
+        "producerRepo": "SocioProphet/prophet-platform",
+        "policyRef": latest_version.get("accessPolicy"),
+        "evidenceCorrelationId": None,
+        "promotionChannel": "catalog-demo",
+        "compatibilitySurfaces": ["lattice-studio", "prophet-platform", "sherlock-search", "slash-topics"],
+    }
+
+
+def notebook_session_to_platform_record(session_doc: dict[str, Any]) -> dict[str, Any]:
+    if session_doc.get("kind") != "NotebookSession":
+        raise ValueError("session document kind must be NotebookSession")
+    session_id = _required_str(session_doc, "sessionId")
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecord",
+        "assetId": session_id,
+        "assetKind": "notebook-session",
+        "name": session_id,
+        "version": "0.1.0",
+        "sourceApiVersion": _required_str(session_doc, "apiVersion"),
+        "sourceKind": "NotebookSession",
+        "producerRepo": "SocioProphet/prophet-platform",
+        "policyRef": session_doc.get("policyRef"),
+        "evidenceCorrelationId": session_id,
+        "promotionChannel": "session-demo",
+        "compatibilitySurfaces": ["lattice-studio", "jupyter", "prophet-platform", "sherlock-search", "slash-topics"],
+    }
+
+
+def platform_record_set(records: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecordSet",
+        "records": records,
+    }
+
+
+def _required_dict(data: dict[str, Any], key: str) -> dict[str, Any]:
+    value = data.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"{key} must be an object")
+    return value
+
+
+def _required_str(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a non-empty string")
+    return value

--- a/apps/lattice-studio/tests/test_notebook_session.py
+++ b/apps/lattice-studio/tests/test_notebook_session.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from lattice_studio.catalog import catalog_evidence, demo_catalog_assets
 from lattice_studio.cli import main
+from lattice_studio.platform_records import catalog_asset_to_platform_record, notebook_session_to_platform_record, platform_record_set
 from lattice_studio.session import create_session, evidence_for_session, load_json
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -105,3 +106,50 @@ def test_lattice_studio_cli_writes_demo_catalog_bundles(tmp_path) -> None:
         evidence_doc = json.loads((asset_dir / "catalog-asset-evidence.json").read_text(encoding="utf-8"))
         assert asset_doc["kind"] == "CatalogAsset"
         assert evidence_doc["kind"] == "CatalogAssetEvidence"
+
+
+def test_studio_outputs_convert_to_platform_asset_records() -> None:
+    catalog_records = [catalog_asset_to_platform_record(asset.to_dict()) for asset in demo_catalog_assets()]
+    runtime_asset = load_json(RUNTIME_ASSET)
+    session = create_session(
+        project_id="demo-project",
+        user_id="demo-user",
+        runtime_asset=runtime_asset,
+        catalog_inputs=["catalog://datasets/demo-csv@0.1.0"],
+    )
+    session_record = notebook_session_to_platform_record(session.to_dict())
+    record_set = platform_record_set([*catalog_records, session_record])
+
+    assert record_set["kind"] == "PlatformAssetRecordSet"
+    assert len(record_set["records"]) == 5
+    kinds = {record["assetKind"] for record in record_set["records"]}
+    assert {"catalog-data", "catalog-ml-model", "catalog-application", "catalog-service", "notebook-session"} == kinds
+
+
+def test_lattice_studio_cli_emits_platform_records(tmp_path) -> None:
+    catalog_dir = tmp_path / "catalog"
+    session_dir = tmp_path / "session"
+    records_path = tmp_path / "studio-platform-records.json"
+    assert main(["emit-demo-catalog", "--output-dir", str(catalog_dir)]) == 0
+    assert main([
+        "create-session",
+        "--project-id",
+        "demo-project",
+        "--user-id",
+        "demo-user",
+        "--runtime-asset",
+        str(RUNTIME_ASSET),
+        "--catalog-input",
+        "catalog://datasets/demo-csv@0.1.0",
+        "--output-dir",
+        str(session_dir),
+    ]) == 0
+    catalog_asset_paths = sorted(str(path) for path in catalog_dir.glob("*/catalog-asset.json"))
+    args = ["emit-platform-records"]
+    for path in catalog_asset_paths:
+        args.extend(["--catalog-asset", path])
+    args.extend(["--notebook-session", str(session_dir / "notebook-session.json"), "--output", str(records_path)])
+    assert main(args) == 0
+    emitted = json.loads(records_path.read_text(encoding="utf-8"))
+    assert emitted["kind"] == "PlatformAssetRecordSet"
+    assert len(emitted["records"]) == 5


### PR DESCRIPTION
## Summary

Converts Lattice Studio catalog assets and notebook sessions into canonical `PlatformAssetRecord` objects.

## What changed

- Adds `lattice_studio.platform_records`.
- Adds CLI command `lattice-studio emit-platform-records`.
- Adds tests for catalog data/model/application/service records plus notebook-session records.
- Updates `lattice-studio-smoke` to emit `build/lattice-studio/studio-platform-records.json`.

## Why

Studio outputs now flow into the same platform metadata spine as the rest of Prophet Lattice.

## Validation

`make validate` now generates Studio catalog/session artifacts and converts them into a `PlatformAssetRecordSet` build artifact.
