### PR TITLE
Add notebook adapter launch dry-runs

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/notebook_launch.py
+++ b/apps/lattice-studio/src/lattice_studio/notebook_launch.py
@@ -1,0 +1,153 @@
+"""Dry-run launch plans for Lattice Studio notebook surface adapters.
+
+The NotebookSurfacePlane defines adapter intent. This module turns spawn requests
+into deterministic adapter-specific launch plans without starting external
+services. Actual launch execution can later bind these plans to SourceOS,
+Kubernetes, JupyterHub, Zeppelin, browser runtimes, Julia, or Quarto builders.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from .notebook_plane import NotebookSurfaceSpawnRequest, demo_spawn_requests
+
+LaunchBackend = Literal["jupyter-server", "zeppelin-server", "browser-runtime", "julia-process", "quarto-renderer"]
+
+BACKENDS: dict[str, LaunchBackend] = {
+    "jupyterlab": "jupyter-server",
+    "zeppelin": "zeppelin-server",
+    "observable": "browser-runtime",
+    "plutojl": "julia-process",
+    "quarto": "quarto-renderer",
+}
+
+COMMANDS: dict[str, list[str]] = {
+    "jupyterlab": ["jupyter", "lab", "--ServerApp.token=<redacted>", "--ip=0.0.0.0"],
+    "zeppelin": ["zeppelin-daemon.sh", "start", "--interpreter=spark,sql,python"],
+    "observable": ["observable", "preview", "--workspace", "workspace://demo"],
+    "plutojl": ["julia", "-e", "using Pluto; Pluto.run(host=\"0.0.0.0\")"],
+    "quarto": ["quarto", "render", "notebooks/demo.qmd", "--to", "html"],
+}
+
+
+@dataclass(frozen=True)
+class NotebookSurfaceLaunchPlan:
+    launch_plan_id: str
+    spawn_request_id: str
+    adapter: str
+    backend: LaunchBackend
+    command: list[str]
+    environment: dict[str, str]
+    mounted_catalog_inputs: list[str]
+    local_workspace_ref: str | None
+    policy_ref: str | None
+    dry_run: bool = True
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "studio.socioprophet.dev/v1",
+            "kind": "NotebookSurfaceLaunchPlan",
+            "launchPlanId": self.launch_plan_id,
+            "spawnRequestId": self.spawn_request_id,
+            "adapter": self.adapter,
+            "backend": self.backend,
+            "command": self.command,
+            "environment": self.environment,
+            "mountedCatalogInputs": self.mounted_catalog_inputs,
+            "localWorkspaceRef": self.local_workspace_ref,
+            "policyRef": self.policy_ref,
+            "dryRun": self.dry_run,
+            "createdAt": self.created_at,
+        }
+
+
+def launch_plan_for_request(request: NotebookSurfaceSpawnRequest) -> NotebookSurfaceLaunchPlan:
+    backend = BACKENDS[request.adapter]
+    seed = json.dumps(
+        {
+            "spawnRequestId": request.spawn_request_id,
+            "adapter": request.adapter,
+            "backend": backend,
+            "catalogInputs": request.catalog_inputs,
+            "localWorkspaceRef": request.local_workspace_ref,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    environment = {
+        "LATTICE_NOTEBOOK_ADAPTER": request.adapter,
+        "LATTICE_NOTEBOOK_ROLE": request.role,
+        "LATTICE_RUNTIME_ASSET_ID": request.runtime_asset_id or "",
+        "LATTICE_POLICY_REF": request.policy_ref or "",
+        "LATTICE_DRY_RUN": "true",
+    }
+    return NotebookSurfaceLaunchPlan(
+        launch_plan_id="notebook-launch:" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16],
+        spawn_request_id=request.spawn_request_id,
+        adapter=request.adapter,
+        backend=backend,
+        command=COMMANDS[request.adapter],
+        environment=environment,
+        mounted_catalog_inputs=request.catalog_inputs,
+        local_workspace_ref=request.local_workspace_ref,
+        policy_ref=request.policy_ref,
+    )
+
+
+def demo_launch_plans() -> list[NotebookSurfaceLaunchPlan]:
+    return [launch_plan_for_request(request) for request in demo_spawn_requests()]
+
+
+def launch_plan_evidence(plans: list[NotebookSurfaceLaunchPlan]) -> dict[str, Any]:
+    docs = [plan.to_dict() for plan in plans]
+    digest = hashlib.sha256(json.dumps(docs, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "NotebookSurfaceLaunchEvidence",
+        "launchPlanDigest": f"sha256:{digest}",
+        "launchPlanCount": len(plans),
+        "adapters": sorted({plan.adapter for plan in plans}),
+        "backends": sorted({plan.backend for plan in plans}),
+        "evidenceReports": [
+            "adapter-specific-launch-plan",
+            "dry-run-only",
+            "runtime-environment-binding",
+            "catalog-input-mount-binding",
+            "local-workspace-binding",
+            "policy-binding",
+        ],
+    }
+
+
+def launch_plan_set_to_platform_record(plans: list[NotebookSurfaceLaunchPlan]) -> dict[str, Any]:
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecord",
+        "assetId": "notebook-launch-plan-set:lattice-studio-demo",
+        "assetKind": "notebook-launch-plan-set",
+        "name": "lattice-studio-notebook-launch-plans",
+        "version": "0.1.0",
+        "sourceApiVersion": "studio.socioprophet.dev/v1",
+        "sourceKind": "NotebookSurfaceLaunchPlanSet",
+        "producerRepo": "SocioProphet/prophet-platform",
+        "policyRef": "policy://lattice-studio/demo",
+        "evidenceCorrelationId": "notebook-launch-plan-set:lattice-studio-demo",
+        "promotionChannel": "dry-run",
+        "compatibilitySurfaces": [
+            "lattice-studio",
+            "jupyterlab",
+            "zeppelin",
+            "observable",
+            "plutojl",
+            "quarto",
+            "sourceos-local",
+            "datahub",
+            "sherlock-search",
+        ],
+    }

--- a/apps/lattice-studio/src/lattice_studio/notebook_launch_cli.py
+++ b/apps/lattice-studio/src/lattice_studio/notebook_launch_cli.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""CLI for notebook surface adapter launch dry-runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .notebook_launch import demo_launch_plans, launch_plan_evidence, launch_plan_set_to_platform_record
+
+
+def emit_demo_launch_plans(args: argparse.Namespace) -> int:
+    plans = demo_launch_plans()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    plans_path = args.output_dir / "notebook-launch-plans.json"
+    evidence_path = args.output_dir / "notebook-launch-evidence.json"
+    record_path = args.output_dir / "notebook-launch-platform-record.json"
+
+    plans_path.write_text(
+        json.dumps(
+            {
+                "apiVersion": "studio.socioprophet.dev/v1",
+                "kind": "NotebookSurfaceLaunchPlanSet",
+                "plans": [plan.to_dict() for plan in plans],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    evidence_path.write_text(json.dumps(launch_plan_evidence(plans), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    record_path.write_text(
+        json.dumps(launch_plan_set_to_platform_record(plans), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps({"written": [str(plans_path), str(evidence_path), str(record_path)]}, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Lattice Studio notebook adapter launch dry-runs")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    demo_parser = subparsers.add_parser("emit-demo", help="Emit demo launch plans for all notebook adapters")
+    demo_parser.add_argument("--output-dir", type=Path, required=True)
+    demo_parser.set_defaults(func=emit_demo_launch_plans)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"lattice-notebook-launch: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/lattice-studio/tests/test_notebook_launch.py
+++ b/apps/lattice-studio/tests/test_notebook_launch.py
@@ -1,0 +1,64 @@
+import json
+
+from lattice_studio.notebook_launch import demo_launch_plans, launch_plan_evidence, launch_plan_set_to_platform_record
+from lattice_studio.notebook_launch_cli import main
+
+
+def test_launch_plans_cover_all_notebook_adapters_and_backends() -> None:
+    plans = demo_launch_plans()
+    by_adapter = {plan.adapter: plan for plan in plans}
+
+    assert set(by_adapter) == {"jupyterlab", "zeppelin", "observable", "plutojl", "quarto"}
+    assert by_adapter["jupyterlab"].backend == "jupyter-server"
+    assert by_adapter["zeppelin"].backend == "zeppelin-server"
+    assert by_adapter["observable"].backend == "browser-runtime"
+    assert by_adapter["plutojl"].backend == "julia-process"
+    assert by_adapter["quarto"].backend == "quarto-renderer"
+
+    assert by_adapter["jupyterlab"].command[:2] == ["jupyter", "lab"]
+    assert by_adapter["zeppelin"].command[0] == "zeppelin-daemon.sh"
+    assert by_adapter["observable"].command[:2] == ["observable", "preview"]
+    assert by_adapter["plutojl"].command[0] == "julia"
+    assert by_adapter["quarto"].command[:2] == ["quarto", "render"]
+
+
+def test_launch_plans_bind_runtime_catalog_workspace_and_policy() -> None:
+    for plan in demo_launch_plans():
+        doc = plan.to_dict()
+        assert doc["kind"] == "NotebookSurfaceLaunchPlan"
+        assert doc["dryRun"] is True
+        assert doc["environment"]["LATTICE_RUNTIME_ASSET_ID"] == "runtime-asset:prophet-python-ml:0.1.0"
+        assert doc["environment"]["LATTICE_POLICY_REF"] == "policy://lattice-studio/demo"
+        assert "catalog://datasets/demo-csv@0.1.0" in doc["mountedCatalogInputs"]
+        assert doc["localWorkspaceRef"] == "workspace://demo"
+
+
+def test_launch_plan_evidence_and_platform_record() -> None:
+    plans = demo_launch_plans()
+    evidence = launch_plan_evidence(plans)
+    record = launch_plan_set_to_platform_record(plans)
+
+    assert evidence["kind"] == "NotebookSurfaceLaunchEvidence"
+    assert evidence["launchPlanCount"] == 5
+    assert "zeppelin-server" in evidence["backends"]
+    assert "quarto-renderer" in evidence["backends"]
+    assert "adapter-specific-launch-plan" in evidence["evidenceReports"]
+    assert record["kind"] == "PlatformAssetRecord"
+    assert record["assetKind"] == "notebook-launch-plan-set"
+    assert "zeppelin" in record["compatibilitySurfaces"]
+    assert "quarto" in record["compatibilitySurfaces"]
+
+
+def test_notebook_launch_cli_emits_demo_artifacts(tmp_path) -> None:
+    output_dir = tmp_path / "launch"
+    rc = main(["emit-demo", "--output-dir", str(output_dir)])
+    assert rc == 0
+
+    plans = json.loads((output_dir / "notebook-launch-plans.json").read_text(encoding="utf-8"))
+    evidence = json.loads((output_dir / "notebook-launch-evidence.json").read_text(encoding="utf-8"))
+    record = json.loads((output_dir / "notebook-launch-platform-record.json").read_text(encoding="utf-8"))
+
+    assert plans["kind"] == "NotebookSurfaceLaunchPlanSet"
+    assert len(plans["plans"]) == 5
+    assert evidence["kind"] == "NotebookSurfaceLaunchEvidence"
+    assert record["kind"] == "PlatformAssetRecord"


### PR DESCRIPTION
Adds deterministic launch dry-runs for the Lattice Studio notebook surface adapters. JupyterLab maps to a Jupyter server plan, Zeppelin maps to a Zeppelin server plan, Observable maps to a browser runtime plan, Pluto.jl maps to a Julia process plan, and Quarto maps to a render/publish plan. Includes model code, CLI emission, tests, evidence, and platform record output.