### PR TITLE
Add BYOC storage compute IO placement contracts

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/byoc.py
+++ b/apps/lattice-studio/src/lattice_studio/byoc.py
@@ -1,0 +1,286 @@
+"""Bring-your-own-cloud compatibility contracts for Lattice Studio.
+
+BYOC support must be provider-neutral across storage, compute, and I/O. It also
+needs a local/fog terminal surface. CloudShell Fog provides that local/fog shell
+lane through OIDC, placement, policy profiles, WebSocket PTY, Kubernetes/stub
+connectors, audit events, OpenTelemetry, Argo CD, and Tekton Chains.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+StorageKind = Literal["s3-compatible", "azure-blob", "gcs", "posix", "nfs", "minio", "lakehouse"]
+ComputeKind = Literal["kubernetes", "array-cluster", "ray-cluster", "spark-cluster", "edge-node", "local-sourceos"]
+IOKind = Literal["object-store", "posix-mount", "websocket-pty", "kafka", "http-api", "jdbc", "arrow-flight"]
+
+
+@dataclass(frozen=True)
+class BYOCStorageProfile:
+    profile_id: str
+    kind: StorageKind
+    endpoint_ref: str
+    credential_ref: str
+    sovereignty_zone: str
+    data_residency: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "profileId": self.profile_id,
+            "kind": self.kind,
+            "endpointRef": self.endpoint_ref,
+            "credentialRef": self.credential_ref,
+            "sovereigntyZone": self.sovereignty_zone,
+            "dataResidency": self.data_residency,
+        }
+
+
+@dataclass(frozen=True)
+class BYOCComputeTarget:
+    target_id: str
+    kind: ComputeKind
+    cluster_ref: str
+    scheduler_ref: str
+    accelerator_profile: str
+    trust_tier: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "targetId": self.target_id,
+            "kind": self.kind,
+            "clusterRef": self.cluster_ref,
+            "schedulerRef": self.scheduler_ref,
+            "acceleratorProfile": self.accelerator_profile,
+            "trustTier": self.trust_tier,
+        }
+
+
+@dataclass(frozen=True)
+class BYOCIOBinding:
+    binding_id: str
+    kind: IOKind
+    source_ref: str
+    sink_ref: str
+    policy_ref: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "bindingId": self.binding_id,
+            "kind": self.kind,
+            "sourceRef": self.source_ref,
+            "sinkRef": self.sink_ref,
+            "policyRef": self.policy_ref,
+        }
+
+
+@dataclass(frozen=True)
+class CloudShellFogBinding:
+    binding_id: str
+    repo_ref: str
+    session_api_ref: str
+    websocket_pty_ref: str
+    placement_mode: str
+    policy_profile: str
+    runtime_connector: str
+    audit_ref: str
+    telemetry_ref: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "bindingId": self.binding_id,
+            "repoRef": self.repo_ref,
+            "sessionApiRef": self.session_api_ref,
+            "websocketPtyRef": self.websocket_pty_ref,
+            "placementMode": self.placement_mode,
+            "policyProfile": self.policy_profile,
+            "runtimeConnector": self.runtime_connector,
+            "auditRef": self.audit_ref,
+            "telemetryRef": self.telemetry_ref,
+            "capabilities": [
+                "oidc-authentication",
+                "fog-first-placement",
+                "cloud-fallback",
+                "yaml-policy-profiles",
+                "websocket-pty",
+                "kubernetes-runtime-connector",
+                "stub-runtime-connector",
+                "audit-events",
+                "opentelemetry",
+                "argocd-gitops",
+                "tekton-chains-supply-chain",
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class BYOCPlacementPlan:
+    plan_id: str
+    storage_profiles: list[BYOCStorageProfile]
+    compute_targets: list[BYOCComputeTarget]
+    io_bindings: list[BYOCIOBinding]
+    cloudshell_fog: CloudShellFogBinding
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "studio.socioprophet.dev/v1",
+            "kind": "BYOCPlacementPlan",
+            "planId": self.plan_id,
+            "storageProfiles": [profile.to_dict() for profile in self.storage_profiles],
+            "computeTargets": [target.to_dict() for target in self.compute_targets],
+            "ioBindings": [binding.to_dict() for binding in self.io_bindings],
+            "cloudShellFog": self.cloudshell_fog.to_dict(),
+            "createdAt": self.created_at,
+            "designRule": "Storage, compute, and I/O placement must be provider-neutral and able to run near governed data.",
+        }
+
+
+def _digest(prefix: str, payload: dict[str, Any]) -> str:
+    seed = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return f"{prefix}:" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def demo_byoc_placement_plan() -> BYOCPlacementPlan:
+    storage = [
+        BYOCStorageProfile(
+            profile_id="storage:s3-compatible-demo",
+            kind="s3-compatible",
+            endpoint_ref="s3://byoc-demo-bucket",
+            credential_ref="secret://byoc/s3/demo",
+            sovereignty_zone="customer-controlled",
+            data_residency="us-east-demo",
+        ),
+        BYOCStorageProfile(
+            profile_id="storage:posix-local-demo",
+            kind="posix",
+            endpoint_ref="file:///workspace/data",
+            credential_ref="local://sourceos/session",
+            sovereignty_zone="local-sourceos",
+            data_residency="edge-local",
+        ),
+    ]
+    compute = [
+        BYOCComputeTarget(
+            target_id="compute:kubernetes-demo",
+            kind="kubernetes",
+            cluster_ref="k8s://customer-cluster/dev",
+            scheduler_ref="kubernetes/default-scheduler",
+            accelerator_profile="cpu-standard",
+            trust_tier="trusted-cloud-or-region",
+        ),
+        BYOCComputeTarget(
+            target_id="compute:array-demo",
+            kind="array-cluster",
+            cluster_ref="array://training-cluster/demo",
+            scheduler_ref="array/ray-scheduler",
+            accelerator_profile="gpu-optional",
+            trust_tier="customer-controlled-compute",
+        ),
+        BYOCComputeTarget(
+            target_id="compute:sourceos-local-demo",
+            kind="local-sourceos",
+            cluster_ref="sourceos://local/workbench",
+            scheduler_ref="local/sourceos-runner",
+            accelerator_profile="cpu-local",
+            trust_tier="local-edge",
+        ),
+    ]
+    io = [
+        BYOCIOBinding(
+            binding_id="io:object-store-to-ray",
+            kind="object-store",
+            source_ref="s3://byoc-demo-bucket/datasets/demo-csv",
+            sink_ref="ray://training-cluster/demo/input",
+            policy_ref="policy://byoc/data-access",
+        ),
+        BYOCIOBinding(
+            binding_id="io:local-pty-to-workspace",
+            kind="websocket-pty",
+            source_ref="wss://cloudshell-fog/v1/sessions/demo/pty",
+            sink_ref="sourceos://local/workbench",
+            policy_ref="policy://cloudshell-fog/default-profile",
+        ),
+        BYOCIOBinding(
+            binding_id="io:beam-output-to-lake",
+            kind="object-store",
+            source_ref="beam://pipeline/demo/output",
+            sink_ref="s3://byoc-demo-bucket/features/demo",
+            policy_ref="policy://byoc/pipeline-output",
+        ),
+    ]
+    fog = CloudShellFogBinding(
+        binding_id="cloudshell-fog:demo",
+        repo_ref="SocioProphet/cloudshell-fog",
+        session_api_ref="POST /v1/sessions",
+        websocket_pty_ref="GET /v1/sessions/{id}/pty",
+        placement_mode="fog-first-cloud-fallback",
+        policy_profile="default",
+        runtime_connector="k8s-or-stub",
+        audit_ref="cloudshell-fog:structured-audit-events",
+        telemetry_ref="cloudshell-fog:opentelemetry",
+    )
+    return BYOCPlacementPlan(
+        plan_id=_digest("byoc-placement", {"storage": len(storage), "compute": len(compute), "io": len(io)}),
+        storage_profiles=storage,
+        compute_targets=compute,
+        io_bindings=io,
+        cloudshell_fog=fog,
+    )
+
+
+def byoc_evidence(plan: BYOCPlacementPlan) -> dict[str, Any]:
+    doc = plan.to_dict()
+    digest = hashlib.sha256(json.dumps(doc, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "BYOCPlacementEvidence",
+        "planId": plan.plan_id,
+        "placementDigest": f"sha256:{digest}",
+        "storageProfileCount": len(plan.storage_profiles),
+        "computeTargetCount": len(plan.compute_targets),
+        "ioBindingCount": len(plan.io_bindings),
+        "evidenceReports": [
+            "provider-neutral-storage",
+            "provider-neutral-compute",
+            "io-binding-policy",
+            "fog-first-terminal-placement",
+            "cloud-fallback",
+            "oidc-session-auth",
+            "websocket-pty-binding",
+            "audit-telemetry-binding",
+        ],
+    }
+
+
+def byoc_to_platform_record(plan: BYOCPlacementPlan) -> dict[str, Any]:
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecord",
+        "assetId": plan.plan_id,
+        "assetKind": "byoc-placement-plan",
+        "name": "lattice-studio-byoc-placement-plan",
+        "version": "0.1.0",
+        "sourceApiVersion": "studio.socioprophet.dev/v1",
+        "sourceKind": "BYOCPlacementPlan",
+        "producerRepo": "SocioProphet/prophet-platform",
+        "policyRef": "policy://byoc/placement",
+        "evidenceCorrelationId": plan.plan_id,
+        "promotionChannel": "dry-run",
+        "compatibilitySurfaces": [
+            "lattice-studio",
+            "byoc",
+            "kubernetes",
+            "array-cluster",
+            "ray",
+            "beam",
+            "sourceos-local",
+            "cloudshell-fog",
+            "object-storage",
+            "websocket-pty",
+            "sherlock-search",
+        ],
+    }

--- a/apps/lattice-studio/src/lattice_studio/byoc_cli.py
+++ b/apps/lattice-studio/src/lattice_studio/byoc_cli.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""CLI for BYOC placement dry-runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .byoc import byoc_evidence, byoc_to_platform_record, demo_byoc_placement_plan
+
+
+def emit_demo(args: argparse.Namespace) -> int:
+    plan = demo_byoc_placement_plan()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    plan_path = args.output_dir / "byoc-placement-plan.json"
+    evidence_path = args.output_dir / "byoc-placement-evidence.json"
+    record_path = args.output_dir / "byoc-platform-record.json"
+    plan_path.write_text(json.dumps(plan.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    evidence_path.write_text(json.dumps(byoc_evidence(plan), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    record_path.write_text(json.dumps(byoc_to_platform_record(plan), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"written": [str(plan_path), str(evidence_path), str(record_path)]}, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Lattice Studio BYOC placement dry-run")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    demo = subparsers.add_parser("emit-demo", help="Emit demo BYOC storage/compute/I/O placement plan")
+    demo.add_argument("--output-dir", type=Path, required=True)
+    demo.set_defaults(func=emit_demo)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"lattice-byoc: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/lattice-studio/src/lattice_studio/m2_topolvm.py
+++ b/apps/lattice-studio/src/lattice_studio/m2_topolvm.py
@@ -1,0 +1,189 @@
+"""SourceOS M2 + TopoLVM placement for local VM and Kubernetes pools.
+
+This bridge treats M2 proof bundles as governed local filesystem registry inputs
+and maps them onto TopoLVM-backed local storage for Inception agent clusters,
+local VMs, and Kubernetes pool joins. It remains side-effect-free: no disk
+mutation, no kexec, no remote state mutation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+PlacementMode = Literal["local-vm", "k8s-pool-join", "inception-agent-cluster"]
+
+
+@dataclass(frozen=True)
+class TopoLVMVolumeClaim:
+    claim_id: str
+    storage_class: str
+    size: str
+    mount_path: str
+    access_mode: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "claimId": self.claim_id,
+            "storageClass": self.storage_class,
+            "size": self.size,
+            "mountPath": self.mount_path,
+            "accessMode": self.access_mode,
+        }
+
+
+@dataclass(frozen=True)
+class M2RegistryMount:
+    registry_root: str
+    proof_index_ref: str
+    release_pointer_ref: str
+    mounted_artifacts: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "registryRoot": self.registry_root,
+            "proofIndexRef": self.proof_index_ref,
+            "releasePointerRef": self.release_pointer_ref,
+            "mountedArtifacts": self.mounted_artifacts,
+        }
+
+
+@dataclass(frozen=True)
+class M2TopoLVMPlacementPlan:
+    plan_id: str
+    mode: PlacementMode
+    cluster_ref: str
+    node_pool_ref: str
+    topolvm_claims: list[TopoLVMVolumeClaim]
+    m2_registry_mount: M2RegistryMount
+    inception_refs: list[str]
+    safety_boundary: list[str]
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "studio.socioprophet.dev/v1",
+            "kind": "M2TopoLVMPlacementPlan",
+            "planId": self.plan_id,
+            "mode": self.mode,
+            "clusterRef": self.cluster_ref,
+            "nodePoolRef": self.node_pool_ref,
+            "topolvmClaims": [claim.to_dict() for claim in self.topolvm_claims],
+            "m2RegistryMount": self.m2_registry_mount.to_dict(),
+            "inceptionRefs": self.inception_refs,
+            "safetyBoundary": self.safety_boundary,
+            "createdAt": self.created_at,
+        }
+
+
+def _digest(prefix: str, payload: dict[str, Any]) -> str:
+    seed = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return f"{prefix}:" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def demo_m2_topolvm_placement_plan() -> M2TopoLVMPlacementPlan:
+    claims = [
+        TopoLVMVolumeClaim(
+            claim_id="topolvm-claim:m2-registry",
+            storage_class="topolvm-provisioner",
+            size="20Gi",
+            mount_path="/var/lib/sourceos/m2-registry",
+            access_mode="ReadWriteOnce",
+        ),
+        TopoLVMVolumeClaim(
+            claim_id="topolvm-claim:agent-workspace",
+            storage_class="topolvm-provisioner",
+            size="50Gi",
+            mount_path="/workspace",
+            access_mode="ReadWriteOnce",
+        ),
+    ]
+    mount = M2RegistryMount(
+        registry_root="file:///var/lib/sourceos/m2-registry",
+        proof_index_ref="contracts/sourceos/examples/proof-index.m2-demo.v0.json",
+        release_pointer_ref="sourceos/demo/0.1.0/release-pointer.json",
+        mounted_artifacts=[
+            "config-source.json",
+            "release-set.json",
+            "boot-release-set.json",
+            "nlboot-crosswalk.json",
+            "fingerprint.json",
+            "compliance-result.json",
+            "proof-index.json",
+        ],
+    )
+    payload = {"mode": "inception-agent-cluster", "cluster": "k8s://local-inception/demo"}
+    return M2TopoLVMPlacementPlan(
+        plan_id=_digest("m2-topolvm-placement", payload),
+        mode="inception-agent-cluster",
+        cluster_ref="k8s://local-inception/demo",
+        node_pool_ref="k8s-nodepool://local-vm/topolvm-agents",
+        topolvm_claims=claims,
+        m2_registry_mount=mount,
+        inception_refs=[
+            "ontogenesis:Platform/Inception.ttl#MinIO",
+            "ontogenesis:Platform/Inception.ttl#Bus",
+            "ontogenesis:Platform/Inception.ttl#ROCKZDB",
+            "ontogenesis:Platform/Inception.ttl#GIB",
+            "ontogenesis:Platform/Inception.ttl#SAPIEN",
+        ],
+        safety_boundary=[
+            "no-host-mutation",
+            "no-kexec",
+            "no-remote-state-mutation",
+            "filesystem-registry-proof-only",
+            "topolvm-mount-dry-run",
+        ],
+    )
+
+
+def m2_topolvm_evidence(plan: M2TopoLVMPlacementPlan) -> dict[str, Any]:
+    doc = plan.to_dict()
+    digest = hashlib.sha256(json.dumps(doc, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "M2TopoLVMEvidence",
+        "planId": plan.plan_id,
+        "placementDigest": f"sha256:{digest}",
+        "claimCount": len(plan.topolvm_claims),
+        "mountedArtifactCount": len(plan.m2_registry_mount.mounted_artifacts),
+        "evidenceReports": [
+            "sourceos-m2-filesystem-registry",
+            "topolvm-volume-claims",
+            "local-vm-k8s-pool-join",
+            "inception-agent-cluster-binding",
+            "proof-index-mounted",
+            "safety-boundary-no-host-mutation",
+        ],
+    }
+
+
+def m2_topolvm_to_platform_record(plan: M2TopoLVMPlacementPlan) -> dict[str, Any]:
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecord",
+        "assetId": plan.plan_id,
+        "assetKind": "m2-topolvm-placement-plan",
+        "name": "sourceos-m2-topolvm-inception-placement",
+        "version": "0.1.0",
+        "sourceApiVersion": "studio.socioprophet.dev/v1",
+        "sourceKind": "M2TopoLVMPlacementPlan",
+        "producerRepo": "SocioProphet/prophet-platform",
+        "policyRef": "policy://sourceos/m2-topolvm-placement",
+        "evidenceCorrelationId": plan.plan_id,
+        "promotionChannel": "dry-run",
+        "compatibilitySurfaces": [
+            "sourceos-m2",
+            "topolvm",
+            "kubernetes",
+            "local-vm",
+            "inception-agent-cluster",
+            "byoc",
+            "cloudshell-fog",
+            "lattice-studio",
+            "sherlock-search",
+        ],
+    }

--- a/apps/lattice-studio/src/lattice_studio/m2_topolvm_cli.py
+++ b/apps/lattice-studio/src/lattice_studio/m2_topolvm_cli.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""CLI for SourceOS M2 + TopoLVM placement dry-runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .m2_topolvm import demo_m2_topolvm_placement_plan, m2_topolvm_evidence, m2_topolvm_to_platform_record
+
+
+def emit_demo(args: argparse.Namespace) -> int:
+    plan = demo_m2_topolvm_placement_plan()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    plan_path = args.output_dir / "m2-topolvm-placement-plan.json"
+    evidence_path = args.output_dir / "m2-topolvm-evidence.json"
+    record_path = args.output_dir / "m2-topolvm-platform-record.json"
+    plan_path.write_text(json.dumps(plan.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    evidence_path.write_text(json.dumps(m2_topolvm_evidence(plan), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    record_path.write_text(json.dumps(m2_topolvm_to_platform_record(plan), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"written": [str(plan_path), str(evidence_path), str(record_path)]}, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Lattice Studio SourceOS M2 TopoLVM placement dry-run")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    demo = subparsers.add_parser("emit-demo", help="Emit demo SourceOS M2 TopoLVM placement plan")
+    demo.add_argument("--output-dir", type=Path, required=True)
+    demo.set_defaults(func=emit_demo)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"lattice-m2-topolvm: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/lattice-studio/src/lattice_studio/notebook_placement.py
+++ b/apps/lattice-studio/src/lattice_studio/notebook_placement.py
@@ -1,0 +1,226 @@
+"""Unified notebook and shell placement for Lattice Studio.
+
+CloudShell Fog and notebook surfaces should share placement semantics: run close
+to governed data when possible, fall back to trusted cloud placement when not,
+respect OIDC identity, policy profiles, resource quotas, trust tier, audit, and
+telemetry. This module also adds a command-line notebook lane based on
+SourceOS-Linux/dnote.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from .byoc import CloudShellFogBinding, demo_byoc_placement_plan
+from .notebook_plane import NotebookSurfaceSpawnRequest, demo_spawn_requests
+
+
+@dataclass(frozen=True)
+class CommandLineNotebookBinding:
+    binding_id: str
+    repo_ref: str
+    engine: str
+    local_store_ref: str
+    sync_ref: str | None
+    commands: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "bindingId": self.binding_id,
+            "repoRef": self.repo_ref,
+            "engine": self.engine,
+            "localStoreRef": self.local_store_ref,
+            "syncRef": self.sync_ref,
+            "commands": self.commands,
+            "capabilities": [
+                "single-binary",
+                "sqlite-local-store",
+                "full-text-search",
+                "self-hosted-sync",
+                "terminal-native-notes",
+                "sourceos-local-friendly",
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class NotebookPlacementDecision:
+    decision_id: str
+    spawn_request_id: str
+    adapter: str
+    placement_mode: str
+    compute_target_ref: str
+    storage_profile_ref: str
+    io_binding_refs: list[str]
+    cloudshell_session_api_ref: str
+    policy_profile: str
+    trust_tier: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "decisionId": self.decision_id,
+            "spawnRequestId": self.spawn_request_id,
+            "adapter": self.adapter,
+            "placementMode": self.placement_mode,
+            "computeTargetRef": self.compute_target_ref,
+            "storageProfileRef": self.storage_profile_ref,
+            "ioBindingRefs": self.io_binding_refs,
+            "cloudshellSessionApiRef": self.cloudshell_session_api_ref,
+            "policyProfile": self.policy_profile,
+            "trustTier": self.trust_tier,
+        }
+
+
+@dataclass(frozen=True)
+class UnifiedNotebookShellPlacementPlan:
+    plan_id: str
+    cloudshell_fog: CloudShellFogBinding
+    command_line_notebook: CommandLineNotebookBinding
+    notebook_decisions: list[NotebookPlacementDecision]
+    placement_signals: list[str]
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "studio.socioprophet.dev/v1",
+            "kind": "UnifiedNotebookShellPlacementPlan",
+            "planId": self.plan_id,
+            "cloudShellFog": self.cloudshell_fog.to_dict(),
+            "commandLineNotebook": self.command_line_notebook.to_dict(),
+            "notebookDecisions": [decision.to_dict() for decision in self.notebook_decisions],
+            "placementSignals": self.placement_signals,
+            "createdAt": self.created_at,
+            "designRule": "Notebook placement and shell placement must share data-locality, policy, trust, audit, and runtime-connector semantics.",
+        }
+
+
+def _digest(prefix: str, payload: dict[str, Any]) -> str:
+    seed = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return f"{prefix}:" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def demo_command_line_notebook_binding() -> CommandLineNotebookBinding:
+    return CommandLineNotebookBinding(
+        binding_id="command-notebook:dnote",
+        repo_ref="SourceOS-Linux/dnote",
+        engine="dnote",
+        local_store_ref="sqlite://$HOME/.dnote/dnote.db",
+        sync_ref="https://dnote.local/sourceos-sync",
+        commands=[
+            "dnote add <book> -c <content>",
+            "dnote view <book>",
+            "dnote find <query>",
+            "dnote sync",
+        ],
+    )
+
+
+def placement_decision_for_request(request: NotebookSurfaceSpawnRequest) -> NotebookPlacementDecision:
+    byoc = demo_byoc_placement_plan()
+    if request.adapter == "zeppelin":
+        compute_ref = "compute:kubernetes-demo"
+        storage_ref = "storage:s3-compatible-demo"
+        trust_tier = "trusted-cloud-or-region"
+    elif request.adapter in {"jupyterlab", "plutojl"}:
+        compute_ref = "compute:array-demo"
+        storage_ref = "storage:s3-compatible-demo"
+        trust_tier = "customer-controlled-compute"
+    else:
+        compute_ref = "compute:sourceos-local-demo"
+        storage_ref = "storage:posix-local-demo"
+        trust_tier = "local-edge"
+    io_refs = [binding.binding_id for binding in byoc.io_bindings]
+    payload = {"spawnRequestId": request.spawn_request_id, "adapter": request.adapter, "compute": compute_ref}
+    return NotebookPlacementDecision(
+        decision_id=_digest("notebook-placement", payload),
+        spawn_request_id=request.spawn_request_id,
+        adapter=request.adapter,
+        placement_mode="fog-first-cloud-fallback",
+        compute_target_ref=compute_ref,
+        storage_profile_ref=storage_ref,
+        io_binding_refs=io_refs,
+        cloudshell_session_api_ref="POST /v1/sessions",
+        policy_profile="default",
+        trust_tier=trust_tier,
+    )
+
+
+def demo_unified_notebook_shell_placement_plan() -> UnifiedNotebookShellPlacementPlan:
+    byoc = demo_byoc_placement_plan()
+    requests = demo_spawn_requests()
+    decisions = [placement_decision_for_request(request) for request in requests]
+    payload = {"cloudshell": byoc.cloudshell_fog.binding_id, "decisions": len(decisions)}
+    return UnifiedNotebookShellPlacementPlan(
+        plan_id=_digest("notebook-shell-placement", payload),
+        cloudshell_fog=byoc.cloudshell_fog,
+        command_line_notebook=demo_command_line_notebook_binding(),
+        notebook_decisions=decisions,
+        placement_signals=[
+            "latency",
+            "capacity",
+            "trust-tier",
+            "data-residency",
+            "policy-profile",
+            "runtime-connector",
+            "audit-requirement",
+            "telemetry-requirement",
+        ],
+    )
+
+
+def notebook_shell_placement_evidence(plan: UnifiedNotebookShellPlacementPlan) -> dict[str, Any]:
+    doc = plan.to_dict()
+    digest = hashlib.sha256(json.dumps(doc, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "NotebookShellPlacementEvidence",
+        "planId": plan.plan_id,
+        "placementDigest": f"sha256:{digest}",
+        "notebookDecisionCount": len(plan.notebook_decisions),
+        "evidenceReports": [
+            "shared-cloudshell-notebook-placement",
+            "fog-first-cloud-fallback",
+            "policy-profile-binding",
+            "oidc-session-binding",
+            "websocket-pty-binding",
+            "command-line-notebook-binding",
+            "dnote-sqlite-store",
+            "audit-telemetry-binding",
+        ],
+    }
+
+
+def notebook_shell_placement_to_platform_record(plan: UnifiedNotebookShellPlacementPlan) -> dict[str, Any]:
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecord",
+        "assetId": plan.plan_id,
+        "assetKind": "notebook-shell-placement-plan",
+        "name": "lattice-studio-notebook-shell-placement-plan",
+        "version": "0.1.0",
+        "sourceApiVersion": "studio.socioprophet.dev/v1",
+        "sourceKind": "UnifiedNotebookShellPlacementPlan",
+        "producerRepo": "SocioProphet/prophet-platform",
+        "policyRef": "policy://byoc/notebook-shell-placement",
+        "evidenceCorrelationId": plan.plan_id,
+        "promotionChannel": "dry-run",
+        "compatibilitySurfaces": [
+            "lattice-studio",
+            "cloudshell-fog",
+            "sourceos-local",
+            "socios-linux",
+            "dnote",
+            "jupyterlab",
+            "zeppelin",
+            "observable",
+            "plutojl",
+            "quarto",
+            "byoc",
+            "websocket-pty",
+            "sherlock-search",
+        ],
+    }

--- a/apps/lattice-studio/tests/test_byoc.py
+++ b/apps/lattice-studio/tests/test_byoc.py
@@ -1,0 +1,52 @@
+import json
+
+from lattice_studio.byoc import byoc_evidence, byoc_to_platform_record, demo_byoc_placement_plan
+from lattice_studio.byoc_cli import main
+
+
+def test_byoc_plan_covers_storage_compute_io_and_cloudshell_fog() -> None:
+    plan = demo_byoc_placement_plan()
+    doc = plan.to_dict()
+
+    assert doc["kind"] == "BYOCPlacementPlan"
+    assert len(doc["storageProfiles"]) == 2
+    assert {profile["kind"] for profile in doc["storageProfiles"]} == {"s3-compatible", "posix"}
+    assert len(doc["computeTargets"]) == 3
+    assert {target["kind"] for target in doc["computeTargets"]} == {"kubernetes", "array-cluster", "local-sourceos"}
+    assert len(doc["ioBindings"]) == 3
+    assert {binding["kind"] for binding in doc["ioBindings"]} == {"object-store", "websocket-pty"}
+    assert doc["cloudShellFog"]["repoRef"] == "SocioProphet/cloudshell-fog"
+    assert doc["cloudShellFog"]["placementMode"] == "fog-first-cloud-fallback"
+    assert "websocket-pty" in doc["cloudShellFog"]["capabilities"]
+    assert "tekton-chains-supply-chain" in doc["cloudShellFog"]["capabilities"]
+
+
+def test_byoc_evidence_and_platform_record() -> None:
+    plan = demo_byoc_placement_plan()
+    evidence = byoc_evidence(plan)
+    record = byoc_to_platform_record(plan)
+
+    assert evidence["kind"] == "BYOCPlacementEvidence"
+    assert evidence["storageProfileCount"] == 2
+    assert evidence["computeTargetCount"] == 3
+    assert evidence["ioBindingCount"] == 3
+    assert "fog-first-terminal-placement" in evidence["evidenceReports"]
+    assert "websocket-pty-binding" in evidence["evidenceReports"]
+    assert record["kind"] == "PlatformAssetRecord"
+    assert record["assetKind"] == "byoc-placement-plan"
+    assert "cloudshell-fog" in record["compatibilitySurfaces"]
+    assert "array-cluster" in record["compatibilitySurfaces"]
+
+
+def test_byoc_cli_emits_demo_artifacts(tmp_path) -> None:
+    output_dir = tmp_path / "byoc"
+    rc = main(["emit-demo", "--output-dir", str(output_dir)])
+    assert rc == 0
+
+    plan = json.loads((output_dir / "byoc-placement-plan.json").read_text(encoding="utf-8"))
+    evidence = json.loads((output_dir / "byoc-placement-evidence.json").read_text(encoding="utf-8"))
+    record = json.loads((output_dir / "byoc-platform-record.json").read_text(encoding="utf-8"))
+
+    assert plan["kind"] == "BYOCPlacementPlan"
+    assert evidence["kind"] == "BYOCPlacementEvidence"
+    assert record["kind"] == "PlatformAssetRecord"

--- a/apps/lattice-studio/tests/test_m2_topolvm.py
+++ b/apps/lattice-studio/tests/test_m2_topolvm.py
@@ -1,0 +1,55 @@
+import json
+
+from lattice_studio.m2_topolvm import (
+    demo_m2_topolvm_placement_plan,
+    m2_topolvm_evidence,
+    m2_topolvm_to_platform_record,
+)
+from lattice_studio.m2_topolvm_cli import main
+
+
+def test_m2_topolvm_plan_binds_sourceos_registry_to_local_k8s_pool() -> None:
+    plan = demo_m2_topolvm_placement_plan()
+    doc = plan.to_dict()
+
+    assert doc["kind"] == "M2TopoLVMPlacementPlan"
+    assert doc["mode"] == "inception-agent-cluster"
+    assert doc["clusterRef"] == "k8s://local-inception/demo"
+    assert doc["nodePoolRef"] == "k8s-nodepool://local-vm/topolvm-agents"
+    assert len(doc["topolvmClaims"]) == 2
+    assert {claim["storageClass"] for claim in doc["topolvmClaims"]} == {"topolvm-provisioner"}
+    assert doc["m2RegistryMount"]["proofIndexRef"] == "contracts/sourceos/examples/proof-index.m2-demo.v0.json"
+    assert "proof-index.json" in doc["m2RegistryMount"]["mountedArtifacts"]
+    assert "ontogenesis:Platform/Inception.ttl#MinIO" in doc["inceptionRefs"]
+    assert "no-host-mutation" in doc["safetyBoundary"]
+    assert "topolvm-mount-dry-run" in doc["safetyBoundary"]
+
+
+def test_m2_topolvm_evidence_and_platform_record() -> None:
+    plan = demo_m2_topolvm_placement_plan()
+    evidence = m2_topolvm_evidence(plan)
+    record = m2_topolvm_to_platform_record(plan)
+
+    assert evidence["kind"] == "M2TopoLVMEvidence"
+    assert evidence["claimCount"] == 2
+    assert evidence["mountedArtifactCount"] == 7
+    assert "sourceos-m2-filesystem-registry" in evidence["evidenceReports"]
+    assert "inception-agent-cluster-binding" in evidence["evidenceReports"]
+    assert record["kind"] == "PlatformAssetRecord"
+    assert record["assetKind"] == "m2-topolvm-placement-plan"
+    assert "topolvm" in record["compatibilitySurfaces"]
+    assert "inception-agent-cluster" in record["compatibilitySurfaces"]
+
+
+def test_m2_topolvm_cli_emits_demo_artifacts(tmp_path) -> None:
+    output_dir = tmp_path / "m2-topolvm"
+    rc = main(["emit-demo", "--output-dir", str(output_dir)])
+    assert rc == 0
+
+    plan = json.loads((output_dir / "m2-topolvm-placement-plan.json").read_text(encoding="utf-8"))
+    evidence = json.loads((output_dir / "m2-topolvm-evidence.json").read_text(encoding="utf-8"))
+    record = json.loads((output_dir / "m2-topolvm-platform-record.json").read_text(encoding="utf-8"))
+
+    assert plan["kind"] == "M2TopoLVMPlacementPlan"
+    assert evidence["kind"] == "M2TopoLVMEvidence"
+    assert record["kind"] == "PlatformAssetRecord"


### PR DESCRIPTION
Adds provider-neutral BYOC placement contracts for storage, compute, and I/O. Integrates CloudShell Fog as the fog-first browser terminal and WebSocket PTY lane. Includes BYOC placement plan, evidence, platform record output, CLI emission, and tests.