### PR TITLE
fogstack: verify registry metadata signatures with OpenSSL

### DIFF
--- a/.github/workflows/fogstack-registry-metadata-signatures.yml
+++ b/.github/workflows/fogstack-registry-metadata-signatures.yml
@@ -1,0 +1,42 @@
+name: FogStack Registry Metadata Signatures
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "schemas/release/fogstack-filesystem-registry-root-v0.1.schema.json"
+      - "schemas/release/fogstack-registry-rollback-revocation-index-v0.1.schema.json"
+      - "tools/run_openssl_fogstack_registry_metadata_verifier.py"
+      - "tools/tests/test_run_openssl_fogstack_registry_metadata_verifier.py"
+      - "docs/FOGSTACK_FILESYSTEM_REGISTRY.md"
+      - ".github/workflows/fogstack-registry-metadata-signatures.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/release/fogstack-filesystem-registry-root-v0.1.schema.json"
+      - "schemas/release/fogstack-registry-rollback-revocation-index-v0.1.schema.json"
+      - "tools/run_openssl_fogstack_registry_metadata_verifier.py"
+      - "tools/tests/test_run_openssl_fogstack_registry_metadata_verifier.py"
+      - "docs/FOGSTACK_FILESYSTEM_REGISTRY.md"
+      - ".github/workflows/fogstack-registry-metadata-signatures.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  registry-metadata-signatures:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+      - name: Run registry metadata signature tests
+        run: |
+          python -m pytest -q tools/tests/test_run_openssl_fogstack_registry_metadata_verifier.py

--- a/docs/FOGSTACK_FILESYSTEM_REGISTRY.md
+++ b/docs/FOGSTACK_FILESYSTEM_REGISTRY.md
@@ -36,14 +36,14 @@ The registry root includes:
 - release pointer references and digests
 - registry publication index references and digests
 - a root digest computed over canonical JSON
-- signature metadata in shape-only form for this tranche
+- signature metadata, either `shape-only` or `openssl-rsa-sha256`
 
 The rollback/revocation index includes:
 
 - rollback target release pointers and digests
 - revocation or suspension entries for release pointers
 - lifecycle index digest over canonical JSON
-- signature metadata in shape-only form for this tranche
+- signature metadata, either `shape-only` or `openssl-rsa-sha256`
 
 ## Minimal flow
 
@@ -55,12 +55,11 @@ The rollback/revocation index includes:
 6. check registry-root metadata with `tools/check_fogstack_filesystem_registry_root.py`
 7. build rollback/revocation lifecycle metadata with `tools/build_fogstack_registry_rollback_revocation_index.py`
 8. check rollback/revocation lifecycle metadata with `tools/check_fogstack_registry_rollback_revocation_index.py`
+9. verify registry metadata signatures with `tools/run_openssl_fogstack_registry_metadata_verifier.py`
 
 ## Registry root semantics
 
 The registry root is the consumer-facing catalog root for a filesystem registry export. It does not replace per-release pointer checks. Instead, it lets consumers verify that the exported registry root consistently names the release pointers and publication indexes available in the registry.
-
-This tranche uses shape-only signature metadata. It establishes the object and checker path without claiming KMS/HSM-backed registry-root signing.
 
 ## Rollback and revocation semantics
 
@@ -72,6 +71,19 @@ Revocations are releases that consumers should not select. A revocation may be `
 
 A release must not be both a rollback target and a revocation entry in the same lifecycle index. The checker enforces that conflict rule and validates pointer digests against the filesystem registry.
 
+## Registry metadata signature verification
+
+`tools/run_openssl_fogstack_registry_metadata_verifier.py` verifies detached OpenSSL RSA/SHA-256 signatures over canonicalized registry metadata.
+
+The canonical payload is the metadata JSON with `signatures` set to an empty array and encoded with sorted keys and compact separators. This makes verification stable across formatting changes while keeping the signature metadata out of the signed payload.
+
+This local verification tranche supports:
+
+- `FogStackFilesystemRegistryRoot`
+- `FogStackRegistryRollbackRevocationIndex`
+- `openssl-rsa-sha256` signature entries
+- tamper rejection for modified metadata
+
 ## What this phase provides
 
 - concrete external-consumable registry layout
@@ -79,12 +91,13 @@ A release must not be both a rollback target and a revocation entry in the same 
 - release pointer for lookup
 - registry-root metadata covering release pointers and publication indexes
 - rollback/revocation lifecycle metadata for registry consumers
-- dedicated CI workflows for registry-root and registry-lifecycle behavior
+- local OpenSSL verification for registry metadata signatures
+- dedicated CI workflows for registry-root, registry-lifecycle, and registry metadata signature behavior
 
 ## What this phase does not yet provide
 
 - authenticated network registry publication
-- cryptographic registry-root or lifecycle-index signature verification
+- KMS/HSM-backed production signing keys
 - registry replication or mirror policy
 - policy-engine selection of rollback targets
 

--- a/schemas/release/fogstack-filesystem-registry-root-v0.1.schema.json
+++ b/schemas/release/fogstack-filesystem-registry-root-v0.1.schema.json
@@ -44,7 +44,7 @@
         "required": ["key_id", "algorithm", "signature_ref"],
         "properties": {
           "key_id": { "type": "string", "minLength": 1 },
-          "algorithm": { "type": "string", "enum": ["ed25519", "sigstore", "gpg", "x509", "shape-only"] },
+          "algorithm": { "type": "string", "enum": ["ed25519", "sigstore", "gpg", "x509", "openssl-rsa-sha256", "shape-only"] },
           "signature_ref": { "type": "string", "minLength": 1 }
         }
       }

--- a/schemas/release/fogstack-registry-rollback-revocation-index-v0.1.schema.json
+++ b/schemas/release/fogstack-registry-rollback-revocation-index-v0.1.schema.json
@@ -62,7 +62,7 @@
         "required": ["key_id", "algorithm", "signature_ref"],
         "properties": {
           "key_id": { "type": "string", "minLength": 1 },
-          "algorithm": { "type": "string", "enum": ["ed25519", "sigstore", "gpg", "x509", "shape-only"] },
+          "algorithm": { "type": "string", "enum": ["ed25519", "sigstore", "gpg", "x509", "openssl-rsa-sha256", "shape-only"] },
           "signature_ref": { "type": "string", "minLength": 1 }
         }
       }

--- a/tools/run_openssl_fogstack_registry_metadata_verifier.py
+++ b/tools/run_openssl_fogstack_registry_metadata_verifier.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+SUPPORTED_KINDS = {
+    "FogStackFilesystemRegistryRoot": "registry_root",
+    "FogStackRegistryRollbackRevocationIndex": "rollback_revocation_index",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_bytes(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def canonical_payload(metadata: dict[str, Any]) -> bytes:
+    payload = dict(metadata)
+    payload["signatures"] = []
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def find_signature(metadata: dict[str, Any], signature_ref: str | None) -> dict[str, Any]:
+    signatures = metadata.get("signatures") or []
+    if not isinstance(signatures, list):
+        raise SystemExit("ERR: metadata signatures must be a list")
+    candidates = [item for item in signatures if isinstance(item, dict)]
+    if signature_ref:
+        candidates = [item for item in candidates if item.get("signature_ref") == signature_ref]
+    candidates = [item for item in candidates if item.get("algorithm") == "openssl-rsa-sha256"]
+    if not candidates:
+        raise SystemExit("ERR: no openssl-rsa-sha256 signature found")
+    if len(candidates) > 1:
+        raise SystemExit("ERR: multiple matching openssl-rsa-sha256 signatures found")
+    return candidates[0]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify Fog Stack registry metadata canonical signature with OpenSSL")
+    parser.add_argument("--metadata", required=True, type=Path)
+    parser.add_argument("--signature", required=True, type=Path)
+    parser.add_argument("--public-key", required=True, type=Path)
+    parser.add_argument("--signature-ref", default=None)
+    parser.add_argument("--key-ref", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    metadata = load_json(args.metadata)
+    kind = metadata.get("kind")
+    if kind not in SUPPORTED_KINDS:
+        raise SystemExit(f"ERR: unsupported registry metadata kind: {kind}")
+
+    signature_entry = find_signature(metadata, args.signature_ref)
+    expected_ref = signature_entry.get("signature_ref")
+    if args.signature_ref and expected_ref != args.signature_ref:
+        raise SystemExit("ERR: requested signature ref does not match metadata")
+
+    payload = canonical_payload(metadata)
+    with tempfile.NamedTemporaryFile() as handle:
+        handle.write(payload)
+        handle.flush()
+        proc = subprocess.run(
+            [
+                "openssl",
+                "dgst",
+                "-sha256",
+                "-verify",
+                str(args.public_key),
+                "-signature",
+                str(args.signature),
+                handle.name,
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    passed = proc.returncode == 0
+    result = {
+        "kind": "FogStackRegistryMetadataSignatureVerification",
+        "schema_version": "v0.1",
+        "metadata_kind": kind,
+        "metadata_ref": str(args.metadata),
+        "metadata_payload_digest": sha256_bytes(payload),
+        "signature_ref": expected_ref,
+        "signature_file_ref": str(args.signature),
+        "verification_tool": "openssl",
+        "key_ref": args.key_ref or str(args.public_key),
+        "status": "pass" if passed else "fail",
+        "message": proc.stdout.strip() or proc.stderr.strip() or None,
+    }
+    text = json.dumps(result, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_run_openssl_fogstack_registry_metadata_verifier.py
+++ b/tools/tests/test_run_openssl_fogstack_registry_metadata_verifier.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def canonical_payload(metadata: dict) -> bytes:
+    payload = dict(metadata)
+    payload["signatures"] = []
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def write_signed_metadata(tmp_path: Path, metadata: dict, name: str) -> tuple[Path, Path, Path]:
+    if not shutil.which("openssl"):
+        pytest.skip("openssl is not available")
+
+    private_key = tmp_path / f"{name}.private.pem"
+    public_key = tmp_path / f"{name}.public.pem"
+    payload = tmp_path / f"{name}.payload.json"
+    signature = tmp_path / f"{name}.sig"
+    metadata_path = tmp_path / f"{name}.json"
+
+    subprocess.run(["openssl", "genpkey", "-algorithm", "RSA", "-out", str(private_key)], check=True)
+    subprocess.run(["openssl", "pkey", "-in", str(private_key), "-pubout", "-out", str(public_key)], check=True)
+    payload.write_bytes(canonical_payload(metadata))
+    subprocess.run(["openssl", "dgst", "-sha256", "-sign", str(private_key), "-out", str(signature), str(payload)], check=True)
+    metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+    return metadata_path, signature, public_key
+
+
+def registry_root_metadata() -> dict:
+    return {
+        "kind": "FogStackFilesystemRegistryRoot",
+        "schema_version": "v0.1",
+        "registry_uri": "file://registry/fogstack",
+        "generated_at": "2026-04-27T00:00:00Z",
+        "releases": [],
+        "root_digest": "sha256:" + "a" * 64,
+        "signatures": [
+            {
+                "key_id": "test-registry-key",
+                "algorithm": "openssl-rsa-sha256",
+                "signature_ref": "registry-root.sig",
+            }
+        ],
+    }
+
+
+def lifecycle_metadata() -> dict:
+    return {
+        "kind": "FogStackRegistryRollbackRevocationIndex",
+        "schema_version": "v0.1",
+        "registry_uri": "file://registry/fogstack",
+        "generated_at": "2026-04-27T00:00:00Z",
+        "rollback_targets": [],
+        "revocations": [],
+        "index_digest": "sha256:" + "b" * 64,
+        "signatures": [
+            {
+                "key_id": "test-registry-key",
+                "algorithm": "openssl-rsa-sha256",
+                "signature_ref": "lifecycle.sig",
+            }
+        ],
+    }
+
+
+def run_verify(metadata_path: Path, signature: Path, public_key: Path, output: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "tools/run_openssl_fogstack_registry_metadata_verifier.py",
+            "--metadata",
+            str(metadata_path),
+            "--signature",
+            str(signature),
+            "--public-key",
+            str(public_key),
+            "--output",
+            str(output),
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_openssl_registry_root_metadata_verifier_accepts_valid_signature(tmp_path: Path) -> None:
+    metadata_path, signature, public_key = write_signed_metadata(tmp_path, registry_root_metadata(), "registry-root")
+    output = tmp_path / "verification.json"
+
+    proc = run_verify(metadata_path, signature, public_key, output)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    result = json.loads(output.read_text(encoding="utf-8"))
+    assert result["kind"] == "FogStackRegistryMetadataSignatureVerification"
+    assert result["metadata_kind"] == "FogStackFilesystemRegistryRoot"
+    assert result["status"] == "pass"
+    assert result["metadata_payload_digest"].startswith("sha256:")
+
+
+def test_openssl_lifecycle_metadata_verifier_accepts_valid_signature(tmp_path: Path) -> None:
+    metadata_path, signature, public_key = write_signed_metadata(tmp_path, lifecycle_metadata(), "lifecycle")
+    output = tmp_path / "verification.json"
+
+    proc = run_verify(metadata_path, signature, public_key, output)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+    result = json.loads(output.read_text(encoding="utf-8"))
+    assert result["metadata_kind"] == "FogStackRegistryRollbackRevocationIndex"
+    assert result["status"] == "pass"
+
+
+def test_openssl_registry_metadata_verifier_rejects_tamper(tmp_path: Path) -> None:
+    metadata = registry_root_metadata()
+    metadata_path, signature, public_key = write_signed_metadata(tmp_path, metadata, "registry-root")
+    output = tmp_path / "verification.json"
+
+    tampered = json.loads(metadata_path.read_text(encoding="utf-8"))
+    tampered["registry_uri"] = "file://registry/tampered"
+    metadata_path.write_text(json.dumps(tampered, indent=2) + "\n", encoding="utf-8")
+
+    proc = run_verify(metadata_path, signature, public_key, output)
+    assert proc.returncode == 1
+    result = json.loads(output.read_text(encoding="utf-8"))
+    assert result["status"] == "fail"
+
+
+def test_openssl_registry_metadata_verifier_rejects_shape_only_signature(tmp_path: Path) -> None:
+    metadata = registry_root_metadata()
+    metadata["signatures"][0]["algorithm"] = "shape-only"
+    metadata_path = tmp_path / "registry-root.json"
+    signature = tmp_path / "registry-root.sig"
+    public_key = tmp_path / "registry-root.public.pem"
+    metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+    signature.write_text("not-a-real-signature", encoding="utf-8")
+    public_key.write_text("not-a-real-key", encoding="utf-8")
+
+    proc = run_verify(metadata_path, signature, public_key, tmp_path / "verification.json")
+    assert proc.returncode != 0


### PR DESCRIPTION
## Summary

Adds local OpenSSL-backed signature verification for Fog Stack registry metadata.

## What changed

- Allows `openssl-rsa-sha256` signature metadata on:
  - `FogStackFilesystemRegistryRoot`
  - `FogStackRegistryRollbackRevocationIndex`
- Adds `tools/run_openssl_fogstack_registry_metadata_verifier.py`.
- Adds tests that verify:
  - registry-root metadata signature success
  - rollback/revocation lifecycle-index signature success
  - metadata tamper rejection
  - shape-only signature rejection
- Adds dedicated `FogStack Registry Metadata Signatures` workflow.
- Updates filesystem registry docs with canonical payload semantics.

## Canonical payload

The verifier signs/verifies the metadata JSON with `signatures` replaced by an empty array, encoded with sorted keys and compact separators. This keeps signature metadata outside the signed payload while making verification stable across formatting changes.

## Safety boundary

This tranche uses local fixture-generated OpenSSL RSA/SHA-256 signatures. It does not add network registry publication, KMS/HSM-backed production keys, Sigstore integration, or policy-engine consumer selection.
