### PR TITLE
Add execution approval request artifacts

### DIFF
--- a/apps/lattice-studio/examples/runtime-asset.prophet-python-ml.json
+++ b/apps/lattice-studio/examples/runtime-asset.prophet-python-ml.json
@@ -22,6 +22,7 @@
         "jupyterlab",
         "zeppelin",
         "observable",
+        "plutojl",
         "quarto",
         "lattice-studio",
         "ray",

--- a/apps/lattice-studio/src/lattice_studio/execution_approval.py
+++ b/apps/lattice-studio/src/lattice_studio/execution_approval.py
@@ -1,0 +1,165 @@
+"""Governed approval request artifacts for Lattice Studio."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from .safe_execution_plan import demo_safe_execution_plan
+
+ApprovalRequestStatus = Literal["requested", "approved", "rejected", "expired"]
+ApprovalScope = Literal["dry-run-render", "ephemeral-namespace", "readonly-mount", "terminal-session-render", "manifest-render"]
+
+
+@dataclass(frozen=True)
+class RequiredApproval:
+    approver_ref: str
+    scope: ApprovalScope
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "approverRef": self.approver_ref,
+            "scope": self.scope,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class ExecutionApprovalRequest:
+    request_id: str
+    safe_execution_plan_ref: str
+    placement_report_ref: str
+    status: ApprovalRequestStatus
+    requested_by: str
+    required_approvals: list[RequiredApproval]
+    policy_refs: list[str]
+    evidence_refs: list[str]
+    blocked_effects: list[str]
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "apiVersion": "studio.socioprophet.dev/v1",
+            "kind": "ExecutionApprovalRequest",
+            "requestId": self.request_id,
+            "safeExecutionPlanRef": self.safe_execution_plan_ref,
+            "placementReportRef": self.placement_report_ref,
+            "status": self.status,
+            "requestedBy": self.requested_by,
+            "requiredApprovals": [approval.to_dict() for approval in self.required_approvals],
+            "policyRefs": self.policy_refs,
+            "evidenceRefs": self.evidence_refs,
+            "blockedEffects": self.blocked_effects,
+            "createdAt": self.created_at,
+            "boundary": [
+                "request-artifact-only",
+                "no-apply",
+                "no-host-change",
+                "no-terminal-attach",
+                "readonly-registry-only",
+            ],
+        }
+
+
+def _digest(prefix: str, payload: dict[str, Any]) -> str:
+    seed = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return f"{prefix}:" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def demo_execution_approval_request() -> ExecutionApprovalRequest:
+    plan = demo_safe_execution_plan()
+    approvals = [
+        RequiredApproval(
+            approver_ref="policy://approvers/platform-ops",
+            scope="ephemeral-namespace",
+            reason="Approve dry-run namespace preparation.",
+        ),
+        RequiredApproval(
+            approver_ref="policy://approvers/sourceos-storage",
+            scope="readonly-mount",
+            reason="Approve readonly SourceOS registry mount planning.",
+        ),
+        RequiredApproval(
+            approver_ref="policy://approvers/security-audit",
+            scope="terminal-session-render",
+            reason="Approve CloudShell Fog session request rendering.",
+        ),
+    ]
+    payload = {"safePlan": plan.plan_id, "placement": plan.placement_report_ref, "approvals": len(approvals)}
+    return ExecutionApprovalRequest(
+        request_id=_digest("execution-approval", payload),
+        safe_execution_plan_ref=plan.plan_id,
+        placement_report_ref=plan.placement_report_ref,
+        status="requested",
+        requested_by="actor://lattice-studio/demo",
+        required_approvals=approvals,
+        policy_refs=[
+            "policy://placement/safe-execution",
+            "policy://byoc/notebook-shell-placement",
+            "policy://sourceos/m2-topolvm-placement",
+        ],
+        evidence_refs=[
+            f"evidence://{plan.plan_id}",
+            "evidence://placement-dry-run:lattice-studio-demo",
+        ],
+        blocked_effects=[
+            "host-change",
+            "persistent-apply",
+            "remote-state-change",
+            "writeable-registry-mount",
+            "terminal-attach",
+        ],
+    )
+
+
+def execution_approval_evidence(request: ExecutionApprovalRequest) -> dict[str, Any]:
+    doc = request.to_dict()
+    digest = hashlib.sha256(json.dumps(doc, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "ExecutionApprovalEvidence",
+        "requestId": request.request_id,
+        "requestDigest": f"sha256:{digest}",
+        "status": request.status,
+        "approvalCount": len(request.required_approvals),
+        "evidenceReports": [
+            "safe-execution-plan-binding",
+            "placement-report-binding",
+            "required-approvals",
+            "policy-binding",
+            "boundary",
+            "blocked-effects",
+        ],
+    }
+
+
+def execution_approval_to_platform_record(request: ExecutionApprovalRequest) -> dict[str, Any]:
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecord",
+        "assetId": request.request_id,
+        "assetKind": "execution-approval-request",
+        "name": "lattice-studio-execution-approval-request",
+        "version": "0.1.0",
+        "sourceApiVersion": "studio.socioprophet.dev/v1",
+        "sourceKind": "ExecutionApprovalRequest",
+        "producerRepo": "SocioProphet/prophet-platform",
+        "policyRef": "policy://placement/safe-execution",
+        "evidenceCorrelationId": request.request_id,
+        "promotionChannel": request.status,
+        "compatibilitySurfaces": [
+            "lattice-studio",
+            "safe-placement-execution",
+            "placement-decision",
+            "approval-workflow",
+            "byoc",
+            "cloudshell-fog",
+            "sourceos-m2",
+            "topolvm",
+            "sherlock-search",
+        ],
+    }

--- a/apps/lattice-studio/src/lattice_studio/execution_approval_cli.py
+++ b/apps/lattice-studio/src/lattice_studio/execution_approval_cli.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""CLI for Lattice Studio execution approval request artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .execution_approval import (
+    demo_execution_approval_request,
+    execution_approval_evidence,
+    execution_approval_to_platform_record,
+)
+
+
+def emit_demo(args: argparse.Namespace) -> int:
+    request = demo_execution_approval_request()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    request_path = args.output_dir / "execution-approval-request.json"
+    evidence_path = args.output_dir / "execution-approval-evidence.json"
+    record_path = args.output_dir / "execution-approval-platform-record.json"
+    request_path.write_text(json.dumps(request.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    evidence_path.write_text(json.dumps(execution_approval_evidence(request), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    record_path.write_text(json.dumps(execution_approval_to_platform_record(request), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"written": [str(request_path), str(evidence_path), str(record_path)]}, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Lattice Studio execution approval request artifacts")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    demo = subparsers.add_parser("emit-demo", help="Emit demo execution approval request")
+    demo.add_argument("--output-dir", type=Path, required=True)
+    demo.set_defaults(func=emit_demo)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"lattice-execution-approval: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/lattice-studio/tests/test_execution_approval.py
+++ b/apps/lattice-studio/tests/test_execution_approval.py
@@ -1,0 +1,54 @@
+import json
+
+from lattice_studio.execution_approval import (
+    demo_execution_approval_request,
+    execution_approval_evidence,
+    execution_approval_to_platform_record,
+)
+from lattice_studio.execution_approval_cli import main
+
+
+def test_execution_approval_request_is_request_only_and_policy_bound() -> None:
+    request = demo_execution_approval_request()
+    doc = request.to_dict()
+
+    assert doc["kind"] == "ExecutionApprovalRequest"
+    assert doc["status"] == "requested"
+    assert doc["safeExecutionPlanRef"].startswith("safe-placement-execution:")
+    assert doc["placementReportRef"] == "placement-dry-run:lattice-studio-demo"
+    assert "request-artifact-only" in doc["boundary"]
+    assert "no-apply" in doc["boundary"]
+    assert "no-host-change" in doc["boundary"]
+    assert "terminal-attach" in doc["blockedEffects"]
+    assert "policy://placement/safe-execution" in doc["policyRefs"]
+    assert len(doc["requiredApprovals"]) == 3
+
+
+def test_execution_approval_evidence_and_platform_record() -> None:
+    request = demo_execution_approval_request()
+    evidence = execution_approval_evidence(request)
+    record = execution_approval_to_platform_record(request)
+
+    assert evidence["kind"] == "ExecutionApprovalEvidence"
+    assert evidence["status"] == "requested"
+    assert evidence["approvalCount"] == 3
+    assert "required-approvals" in evidence["evidenceReports"]
+    assert "blocked-effects" in evidence["evidenceReports"]
+    assert record["kind"] == "PlatformAssetRecord"
+    assert record["assetKind"] == "execution-approval-request"
+    assert "approval-workflow" in record["compatibilitySurfaces"]
+    assert "safe-placement-execution" in record["compatibilitySurfaces"]
+
+
+def test_execution_approval_cli_emits_demo_artifacts(tmp_path) -> None:
+    output_dir = tmp_path / "approval"
+    rc = main(["emit-demo", "--output-dir", str(output_dir)])
+    assert rc == 0
+
+    request = json.loads((output_dir / "execution-approval-request.json").read_text(encoding="utf-8"))
+    evidence = json.loads((output_dir / "execution-approval-evidence.json").read_text(encoding="utf-8"))
+    record = json.loads((output_dir / "execution-approval-platform-record.json").read_text(encoding="utf-8"))
+
+    assert request["kind"] == "ExecutionApprovalRequest"
+    assert evidence["kind"] == "ExecutionApprovalEvidence"
+    assert record["kind"] == "PlatformAssetRecord"


### PR DESCRIPTION
Adds ExecutionApprovalRequest as the governed approval artifact after SafePlacementExecutionPlan. Includes model code, CLI emission, evidence, platform record output, and tests. This branch is rebased from current main and replaces stale PR 249.