### PR TITLE
Harden OSM Map API browser integration

### DIFF
--- a/apps/osm-map-api/README.md
+++ b/apps/osm-map-api/README.md
@@ -17,6 +17,7 @@ This is not a production tile server. It is a strict API boundary that can run a
 5. Fail readiness if required fixture roots are absent.
 6. Preserve provenance/source refs in every response.
 7. Keep Lattice runtime assets gated until executable runtime admission is approved.
+8. Permit browser access only from explicitly configured origins.
 
 ## Runtime configuration
 
@@ -30,6 +31,51 @@ Optional:
 
 - `OSM_MAP_API_HOST` — default `127.0.0.1`.
 - `OSM_MAP_API_PORT` — default `8088`.
+- `OSM_MAP_API_CORS_ALLOWED_ORIGINS` — comma-separated browser origins allowed to call the API. Empty by default, which disables CORS preflight handling.
+- `OSM_MAP_API_CORS_ALLOW_CREDENTIALS` — `true` only when the configured browser origin must send credentials. Default `false`.
+
+## Browser / Vue shell integration
+
+The Vue product shell calls the API through `VITE_GAIA_MAP_API_BASE`.
+
+Local development shape:
+
+```bash
+cd apps/osm-map-api
+export GAIA_FIXTURE_ROOT="$HOME/dev/gaia-world-model"
+export SHERLOCK_FIXTURE_ROOT="$HOME/dev/sherlock-search"
+export SOCIOSPHERE_FIXTURE_ROOT="$HOME/dev/sociosphere"
+export OSM_MAP_API_HOST=127.0.0.1
+export OSM_MAP_API_PORT=8088
+export OSM_MAP_API_CORS_ALLOWED_ORIGINS="http://localhost:5174"
+python3 -m osm_map_api
+```
+
+Then the Vue shell should set:
+
+```bash
+VITE_GAIA_MAP_API_BASE=http://127.0.0.1:8088
+```
+
+The current Vue shell also supports deterministic demo fallback mode. Fallback mode is for product demonstration when this API is not reachable; it is not a production data plane and it does not replace API readiness.
+
+Suggested environment mapping:
+
+| Environment | `VITE_GAIA_MAP_API_BASE` | `OSM_MAP_API_CORS_ALLOWED_ORIGINS` |
+| --- | --- | --- |
+| local API direct | `http://127.0.0.1:8088` | `http://localhost:5174` |
+| local Vite proxy | `/api` | not required if same-origin proxy is used |
+| preview/staging | staging API URL | staging app origin |
+| production | production API URL or same-origin gateway path | production app origin |
+
+Do not use `*` with credentialed browser access. Prefer explicit origins and same-origin gateway/proxy deployment when possible.
+
+## Health and readiness
+
+- `GET /healthz` reports process liveness only.
+- `GET /readyz` verifies required fixture roots and fails with `503` when the API cannot serve the GAIA/OSM fixture-backed contract.
+
+The Vue shell may render demo fallback when the API is not ready, but operators should still treat `/readyz != ready` as a backend issue.
 
 ## Endpoints
 

--- a/apps/osm-map-api/osm_map_api/main.py
+++ b/apps/osm-map-api/osm_map_api/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Request, status
+from fastapi.middleware.cors import CORSMiddleware
 
 from .receipts import response_receipt, with_artifact_receipt
 from .repository import ArtifactError, OSMArtifactRepository
@@ -13,6 +14,21 @@ from .settings import Settings
 
 def repository(request: Request) -> OSMArtifactRepository:
     return request.app.state.repository
+
+
+def _configure_cors(app: FastAPI, settings: Settings) -> None:
+    """Enable browser access only when allowed origins are configured."""
+
+    if not settings.cors_allowed_origins:
+        return
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=list(settings.cors_allowed_origins),
+        allow_credentials=settings.cors_allow_credentials,
+        allow_methods=["GET", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "Accept"],
+        expose_headers=["Content-Type"],
+    )
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -30,6 +46,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             "state, provenance state, and governance state."
         ),
     )
+    _configure_cors(app, resolved_settings)
     app.state.repository = repo
 
     @app.get("/healthz", tags=["health"])

--- a/apps/osm-map-api/osm_map_api/settings.py
+++ b/apps/osm-map-api/osm_map_api/settings.py
@@ -3,8 +3,14 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+
+
+def _split_csv(value: str) -> tuple[str, ...]:
+    """Parse comma-separated environment values into a stable tuple."""
+
+    return tuple(part.strip() for part in value.split(",") if part.strip())
 
 
 @dataclass(frozen=True)
@@ -16,6 +22,8 @@ class Settings:
     sociosphere_fixture_root: Path
     host: str = "127.0.0.1"
     port: int = 8088
+    cors_allowed_origins: tuple[str, ...] = field(default_factory=tuple)
+    cors_allow_credentials: bool = False
 
     @classmethod
     def from_env(cls) -> "Settings":
@@ -27,6 +35,13 @@ class Settings:
             ).expanduser(),
             host=os.environ.get("OSM_MAP_API_HOST", "127.0.0.1"),
             port=int(os.environ.get("OSM_MAP_API_PORT", "8088")),
+            cors_allowed_origins=_split_csv(
+                os.environ.get("OSM_MAP_API_CORS_ALLOWED_ORIGINS", "")
+            ),
+            cors_allow_credentials=os.environ.get(
+                "OSM_MAP_API_CORS_ALLOW_CREDENTIALS", "false"
+            ).lower()
+            in {"1", "true", "yes"},
         )
 
     def missing_roots(self) -> list[str]:

--- a/apps/osm-map-api/tests/test_osm_map_api.py
+++ b/apps/osm-map-api/tests/test_osm_map_api.py
@@ -117,15 +117,18 @@ def make_fixture_roots(tmp_path: Path) -> tuple[Path, Path, Path]:
     return gaia, sherlock, sociosphere
 
 
-def make_client(tmp_path: Path) -> TestClient:
-    gaia, sherlock, sociosphere = make_fixture_roots(tmp_path)
-    app = create_app(
-        Settings(
-            gaia_fixture_root=gaia,
-            sherlock_fixture_root=sherlock,
-            sociosphere_fixture_root=sociosphere,
-        )
+def settings_for_roots(gaia: Path, sherlock: Path, sociosphere: Path, **kwargs) -> Settings:
+    return Settings(
+        gaia_fixture_root=gaia,
+        sherlock_fixture_root=sherlock,
+        sociosphere_fixture_root=sociosphere,
+        **kwargs,
     )
+
+
+def make_client(tmp_path: Path, **settings_kwargs) -> TestClient:
+    gaia, sherlock, sociosphere = make_fixture_roots(tmp_path)
+    app = create_app(settings_for_roots(gaia, sherlock, sociosphere, **settings_kwargs))
     return TestClient(app)
 
 
@@ -171,6 +174,51 @@ def test_health_and_readiness(tmp_path: Path) -> None:
     client = make_client(tmp_path)
     assert client.get("/healthz").json() == {"status": "ok"}
     assert client.get("/readyz").json() == {"status": "ready"}
+
+
+def test_cors_is_disabled_by_default(tmp_path: Path) -> None:
+    client = make_client(tmp_path)
+    response = client.options(
+        "/map-layers",
+        headers={
+            "Origin": "http://localhost:5174",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code == 405
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_cors_allows_configured_vue_shell_origin(tmp_path: Path) -> None:
+    client = make_client(
+        tmp_path,
+        cors_allowed_origins=("http://localhost:5174", "https://app.socioprophet.local"),
+    )
+    preflight = client.options(
+        "/map-layers",
+        headers={
+            "Origin": "http://localhost:5174",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert preflight.status_code == 200
+    assert preflight.headers["access-control-allow-origin"] == "http://localhost:5174"
+    response = client.get("/map-layers", headers={"Origin": "http://localhost:5174"})
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://localhost:5174"
+
+
+def test_cors_rejects_unlisted_browser_origin(tmp_path: Path) -> None:
+    client = make_client(tmp_path, cors_allowed_origins=("http://localhost:5174",))
+    preflight = client.options(
+        "/map-layers",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert preflight.status_code == 400
+    assert "access-control-allow-origin" not in preflight.headers
 
 
 def test_map_layer_catalog_preserves_attribution_and_receipts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Hardens the fixture-backed OSM Map API for browser consumption from the Vue `/map` shell.

## Scope

- Adds explicit CORS runtime settings:
  - `OSM_MAP_API_CORS_ALLOWED_ORIGINS`
  - `OSM_MAP_API_CORS_ALLOW_CREDENTIALS`
- Enables FastAPI CORS middleware only when explicit allowed origins are configured.
- Adds tests for default no-CORS behavior, allowed Vue shell origin, and rejected unlisted origins.
- Documents local/preview/staging/production `VITE_GAIA_MAP_API_BASE` expectations.
- Documents `/healthz` vs `/readyz` behavior and demo fallback semantics.

## Non-goals

- Does not add a production tile server.
- Does not add live OSM ingestion.
- Does not alter advisory route/safety posture.
- Does not weaken attribution/provenance receipt behavior.

## Validation

Expected workflow:

- `OSM Map API`: pytest and OpenAPI contract check.

Manual validation target for Codex/local agents:

```bash
cd apps/osm-map-api
python3 -m pip install -e '.[test]'
pytest -q
python3 scripts/check_openapi_contract.py
```

Closes #258.