### PR TITLE
Seed Professional Intelligence OS alignment spine

### DIFF
--- a/contracts/evidence/adoption-event.schema.json
+++ b/contracts/evidence/adoption-event.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/professional-intelligence/adoption-event.schema.json",
+  "title": "AdoptionEvent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "eventId",
+    "eventType",
+    "occurredAt",
+    "actor",
+    "workspace",
+    "capability",
+    "outcome"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "eventId": { "type": "string", "minLength": 8 },
+    "correlationId": { "type": "string" },
+    "occurredAt": { "type": "string", "format": "date-time" },
+    "eventType": {
+      "type": "string",
+      "enum": [
+        "workflow_started",
+        "workflow_completed",
+        "agent_output_accepted",
+        "agent_output_edited",
+        "agent_output_rejected",
+        "human_escalation",
+        "policy_block",
+        "approval_completed",
+        "source_trusted",
+        "source_disputed",
+        "workspace_reuse",
+        "playbook_completion",
+        "demo_acceptance",
+        "kpi_movement"
+      ]
+    },
+    "actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "id"],
+      "properties": {
+        "type": { "type": "string", "enum": ["human", "agent", "system"] },
+        "id": { "type": "string" },
+        "role": { "type": "string" }
+      }
+    },
+    "workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type"],
+      "properties": {
+        "id": { "type": "string" },
+        "type": { "type": "string", "enum": ["client", "matter", "deal", "asset", "fund", "project", "initiative", "demo"] },
+        "tenantId": { "type": "string" }
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string" },
+        "playbookId": { "type": "string" },
+        "agentId": { "type": "string" },
+        "repo": { "type": "string" }
+      }
+    },
+    "outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "type": "string", "enum": ["started", "accepted", "edited", "rejected", "blocked", "escalated", "completed", "measured"] },
+        "timeSavedSecondsEstimate": { "type": "integer", "minimum": 0 },
+        "cycleTimeDeltaSeconds": { "type": "integer" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "businessMetric": { "type": "string" },
+        "businessMetricDelta": { "type": "number" }
+      }
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "ref"],
+        "properties": {
+          "kind": { "type": "string" },
+          "ref": { "type": "string" },
+          "hash": { "type": "string" }
+        }
+      }
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    }
+  }
+}

--- a/contracts/evidence/adoption-event.v0.1.example.json
+++ b/contracts/evidence/adoption-event.v0.1.example.json
@@ -1,0 +1,42 @@
+{
+  "schemaVersion": "v0.1",
+  "eventId": "adopt-0001",
+  "correlationId": "pi-demo-0001",
+  "eventType": "playbook_completion",
+  "occurredAt": "2026-04-29T15:20:00Z",
+  "actor": {
+    "type": "agent",
+    "id": "opportunity-review-agent",
+    "role": "review-packet-generator"
+  },
+  "workspace": {
+    "id": "workroom-demo-0001",
+    "type": "demo",
+    "tenantId": "tenant-demo"
+  },
+  "capability": {
+    "id": "workspace-os",
+    "playbookId": "client-opportunity-review",
+    "agentId": "opportunity-review-agent",
+    "repo": "SocioProphet/prophet-workspace"
+  },
+  "outcome": {
+    "status": "completed",
+    "timeSavedSecondsEstimate": 600,
+    "cycleTimeDeltaSeconds": -300,
+    "confidence": 0.82,
+    "businessMetric": "demoGateCompletionPercent",
+    "businessMetricDelta": 16.7
+  },
+  "evidenceRefs": [
+    {
+      "kind": "agent-run",
+      "ref": "agentplane://runs/pi-demo-0001",
+      "hash": "sha256:demo"
+    }
+  ],
+  "labels": {
+    "program": "professional-intelligence-os",
+    "gate": "gate-3"
+  }
+}

--- a/contracts/institution/institution-entity.schema.json
+++ b/contracts/institution/institution-entity.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/professional-intelligence/institution-entity.schema.json",
+  "title": "InstitutionEntity",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "entityId", "entityType", "displayName"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "entityId": { "type": "string" },
+    "entityType": {
+      "type": "string",
+      "enum": ["person", "organization", "client", "matter", "deal", "fund", "asset", "contract", "workspace", "policy", "obligation", "decision", "agent"]
+    },
+    "displayName": { "type": "string" },
+    "canonicalRef": { "type": "string" },
+    "sourceRefs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["system", "ref"],
+        "properties": {
+          "system": { "type": "string" },
+          "ref": { "type": "string" },
+          "retrievedAt": { "type": "string", "format": "date-time" }
+        }
+      }
+    },
+    "attributes": { "type": "object", "additionalProperties": true },
+    "classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sensitivity": { "type": "string", "enum": ["public", "internal", "confidential", "restricted", "sealed"] },
+        "jurisdiction": { "type": "string" },
+        "retentionClass": { "type": "string" }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "createdAt": { "type": "string", "format": "date-time" },
+        "updatedAt": { "type": "string", "format": "date-time" },
+        "createdBy": { "type": "string" },
+        "hash": { "type": "string" }
+      }
+    }
+  }
+}

--- a/contracts/institution/institution-entity.v0.1.example.json
+++ b/contracts/institution/institution-entity.v0.1.example.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "v0.1",
+  "entityId": "org-demo-0001",
+  "entityType": "organization",
+  "displayName": "Example Organization",
+  "canonicalRef": "entity://organization/org-demo-0001",
+  "sourceRefs": [
+    {
+      "system": "sherlock-search",
+      "ref": "search-packet://pi-demo-0001",
+      "retrievedAt": "2026-04-29T15:20:00Z"
+    }
+  ],
+  "attributes": {
+    "sector": "professional-services",
+    "region": "demo"
+  },
+  "classification": {
+    "sensitivity": "internal",
+    "jurisdiction": "US",
+    "retentionClass": "demo"
+  },
+  "provenance": {
+    "createdAt": "2026-04-29T15:20:00Z",
+    "updatedAt": "2026-04-29T15:20:00Z",
+    "createdBy": "DelEx",
+    "hash": "sha256:demo"
+  }
+}

--- a/contracts/policy/obligation.schema.json
+++ b/contracts/policy/obligation.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/professional-intelligence/obligation.schema.json",
+  "title": "Obligation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "obligationId",
+    "obligationType",
+    "source",
+    "subject",
+    "action",
+    "effect"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "obligationId": { "type": "string" },
+    "obligationType": {
+      "type": "string",
+      "enum": [
+        "confidentiality",
+        "ai_use_restriction",
+        "billing_guideline",
+        "approval_requirement",
+        "data_handling",
+        "workspace_access",
+        "information_barrier",
+        "retention",
+        "disclosure",
+        "economic_adjustment",
+        "other"
+      ]
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "ref"],
+      "properties": {
+        "kind": { "type": "string", "enum": ["contract", "guideline", "policy", "matter", "deal", "manual", "other"] },
+        "ref": { "type": "string" },
+        "section": { "type": "string" },
+        "hash": { "type": "string" }
+      }
+    },
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["entityId"],
+      "properties": {
+        "entityId": { "type": "string" },
+        "role": { "type": "string" },
+        "workspaceId": { "type": "string" }
+      }
+    },
+    "beneficiary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "entityId": { "type": "string" },
+        "role": { "type": "string" }
+      }
+    },
+    "action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verb"],
+      "properties": {
+        "verb": { "type": "string" },
+        "resourceClass": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    "effect": { "type": "string", "enum": ["allow", "deny", "require_approval", "escalate", "record", "notify"] },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tenantId": { "type": "string" },
+        "workspaceId": { "type": "string" },
+        "jurisdiction": { "type": "string" },
+        "resourceTags": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "effectiveTime": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "startsAt": { "type": "string", "format": "date-time" },
+        "endsAt": { "type": "string", "format": "date-time" },
+        "amends": { "type": "string" }
+      }
+    },
+    "policyMapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policyFamily": { "type": "string" },
+        "policyId": { "type": "string" },
+        "policyVersion": { "type": "string" }
+      }
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "ref"],
+        "properties": {
+          "kind": { "type": "string" },
+          "ref": { "type": "string" },
+          "hash": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/contracts/policy/obligation.v0.1.example.json
+++ b/contracts/policy/obligation.v0.1.example.json
@@ -1,0 +1,50 @@
+{
+  "schemaVersion": "v0.1",
+  "obligationId": "obl-demo-0001",
+  "obligationType": "ai_use_restriction",
+  "source": {
+    "kind": "guideline",
+    "ref": "guideline://demo/client-ai-use",
+    "section": "AI Use",
+    "hash": "sha256:demo"
+  },
+  "subject": {
+    "entityId": "org-demo-0001",
+    "role": "client",
+    "workspaceId": "workroom-demo-0001"
+  },
+  "beneficiary": {
+    "entityId": "org-demo-0001",
+    "role": "client"
+  },
+  "action": {
+    "verb": "summarize",
+    "resourceClass": "confidential-document",
+    "description": "Generated summaries require a policy decision and evidence reference."
+  },
+  "effect": "require_approval",
+  "scope": {
+    "tenantId": "tenant-demo",
+    "workspaceId": "workroom-demo-0001",
+    "jurisdiction": "US",
+    "resourceTags": [
+      "confidential",
+      "demo"
+    ]
+  },
+  "effectiveTime": {
+    "startsAt": "2026-04-29T15:20:00Z"
+  },
+  "policyMapping": {
+    "policyFamily": "ai-use-restriction",
+    "policyId": "policy-demo-ai-use",
+    "policyVersion": "v0.1"
+  },
+  "evidenceRefs": [
+    {
+      "kind": "source-guideline",
+      "ref": "guideline://demo/client-ai-use",
+      "hash": "sha256:demo"
+    }
+  ]
+}

--- a/contracts/risk/conflict-check.schema.json
+++ b/contracts/risk/conflict-check.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/professional-intelligence/conflict-check.schema.json",
+  "title": "ConflictCheck",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "checkId", "workspaceId", "requestedAction", "subjects", "result"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "checkId": { "type": "string" },
+    "workspaceId": { "type": "string" },
+    "requestedAction": { "type": "string" },
+    "subjects": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["entityId", "role"],
+        "properties": {
+          "entityId": { "type": "string" },
+          "role": { "type": "string" },
+          "displayName": { "type": "string" }
+        }
+      }
+    },
+    "signals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["signalType", "severity", "description"],
+        "properties": {
+          "signalType": { "type": "string", "enum": ["prior_work", "opposing_party", "related_party", "restricted_list", "relationship", "employee_interest", "confidentiality", "data_use", "ai_use", "other"] },
+          "severity": { "type": "string", "enum": ["info", "low", "medium", "high", "blocking"] },
+          "description": { "type": "string" },
+          "sourceRef": { "type": "string" },
+          "evidenceHash": { "type": "string" }
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["decision"],
+      "properties": {
+        "decision": { "type": "string", "enum": ["clear", "needs_review", "blocked", "insufficient_context"] },
+        "reviewQueue": { "type": "string" },
+        "reviewerRole": { "type": "string" },
+        "explanation": { "type": "string" }
+      }
+    },
+    "policyDecisionRefs": { "type": "array", "items": { "type": "string" } },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/contracts/risk/conflict-check.v0.1.example.json
+++ b/contracts/risk/conflict-check.v0.1.example.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": "v0.1",
+  "checkId": "conflict-demo-0001",
+  "workspaceId": "workroom-demo-0001",
+  "requestedAction": "create-workroom",
+  "subjects": [
+    {
+      "entityId": "org-demo-0001",
+      "role": "client",
+      "displayName": "Example Organization"
+    }
+  ],
+  "signals": [
+    {
+      "signalType": "ai_use",
+      "severity": "medium",
+      "description": "Generated summary action requires approval before release.",
+      "sourceRef": "obligation://obl-demo-0001",
+      "evidenceHash": "sha256:demo"
+    }
+  ],
+  "result": {
+    "decision": "needs_review",
+    "reviewQueue": "policy-review",
+    "reviewerRole": "policy-reviewer",
+    "explanation": "A policy-sensitive action requires review before workroom output release."
+  },
+  "policyDecisionRefs": [
+    "policy-decision://policy-demo-ai-use/decision-0001"
+  ],
+  "evidenceRefs": [
+    "evidence://conflict-demo-0001"
+  ]
+}

--- a/docs/strategy/professional-intelligence-os.md
+++ b/docs/strategy/professional-intelligence-os.md
@@ -1,0 +1,103 @@
+# Professional Intelligence OS
+
+## Purpose
+
+Professional Intelligence OS is the SocioProphet product spine for governed institutional work. It turns the existing platform, workspace, policy, agent, model, memory, contract, search, ontology, and DelEx repositories into one executable system for high-trust organizations.
+
+This is not a clone of any vertical SaaS product. It is the trust-native operating layer for institutions that need governed AI, relationship intelligence, compliance, workflow execution, evidence, and measurable adoption.
+
+## Category thesis
+
+Professional firms and regulated institutions do not need generic chat layered over documents. They need institution-aware AI that can operate across relationships, matters, deals, contracts, obligations, policies, permissions, revenue workflows, and evidence trails.
+
+The durable platform asset is the institution context engine: a governed compilation of institutional knowledge, role semantics, relationship graph, playbooks, obligations, policy constraints, access boundaries, decision history, and runtime evidence.
+
+## Core capabilities
+
+1. Institution Context Engine
+   - Compiles institution-specific context from graph, workspace, memory, policy, contracts, catalog, and search surfaces.
+   - Produces scoped context packs for agents, users, workspaces, and playbooks.
+   - Must respect RBAC, ABAC, ReBAC, policy constraints, and workspace boundaries.
+
+2. Institution Graph
+   - Canonical graph of people, organizations, clients, matters, deals, assets, funds, relationships, contracts, obligations, workspaces, decisions, evidence, and agent runs.
+   - Provides the substrate for conflicts, relationship intelligence, diligence, client/matter/deal context, and real-assets workflows.
+
+3. Agent Fabric
+   - Governed agent execution using Agentplane, Agent Registry, Model Router, Guardrail Fabric, Memory Mesh, and Model Governance Ledger.
+   - Agents are workflow actors with purpose, tool grants, data scopes, policies, evals, approvals, audit logs, and replay evidence.
+
+4. Conflict Engine
+   - Detects and routes potential conflicts across entities, matters, deals, employee interests, restricted lists, ownership structures, relationship constraints, and AI/data-use policies.
+   - Produces reviewable conflict reports and evidence receipts.
+
+5. Obligation Ledger
+   - Converts contracts, client terms, outside guidelines, data-use restrictions, billing rules, confidentiality terms, and AI-use constraints into machine-readable obligations.
+   - ContractForge owns contract/economic semantics; Policy Fabric owns executable policy overlays.
+
+6. Ethical Walls and Information Barriers
+   - Policy-aware access and retrieval boundaries for workspaces, documents, memory chunks, graph edges, agent tools, and model context.
+   - Enforces information barriers before retrieval, tool execution, memory recall, or agent output release.
+
+7. Workspace OS
+   - Prophet Workspace is the professional workroom layer for clients, matters, deals, projects, funds, assets, and initiatives.
+   - Workrooms contain documents, meetings, tasks, decisions, agents, obligations, policies, evidence, notes, search, and workflow state.
+
+8. Adoption Telemetry
+   - Measures whether workflows are used, trusted, edited, rejected, escalated, accepted, and producing business impact.
+   - DelEx consumes this telemetry for KPIs, delivery boards, demo acceptance, repo readiness, and bounty/acceleration scoring.
+
+9. Evidence Plane
+   - Every material AI or workflow action should emit evidence: source references, policy checks, model/tool versions, permissions evaluated, approval path, output hash, timestamps, and replay metadata.
+
+10. Vertical Packs
+   - Legal, private capital, investment banking, consulting, accounting, real assets, public-sector, research, and nonprofit packs share the same platform substrate with domain-specific schemas, playbooks, policies, evals, and dashboards.
+
+## Repo ownership map
+
+- `SocioProphet/delivery-excellence*`: operating model, KPIs, boards, playbooks, readiness, bounties, and delivery evidence acceptance.
+- `SocioProphet/prophet-platform`: runtime/deployment hub, service contracts, API surfaces, datastore wiring, evidence/adoption contracts, and GitOps integration.
+- `SocioProphet/prophet-workspace`: user-facing workrooms and workspace application semantics.
+- `SocioProphet/agentplane`: evidence-forward execution control plane.
+- `SocioProphet/agent-registry`: agent identities, sessions, tool grants, revocation, and authority.
+- `SocioProphet/model-router`: governed model routing and fallback policy.
+- `SocioProphet/guardrail-fabric`: reusable guardrails for models, agents, RAG, tools, and deployments.
+- `SocioProphet/model-governance-ledger`: model, dataset, eval, promotion, factsheet, compliance, and rollback evidence.
+- `SocioProphet/memory-mesh`: governed recall/writeback, retrieval adapters, and memory service runtime.
+- `SocioProphet/policy-fabric`: policy authoring, validation, packaging, replay, and executable policy overlays.
+- `SocioProphet/contractforge`: contract lifecycle, obligations, economics, settlement artifacts, and temporal correction semantics.
+- `SocioProphet/gaia-world-model` and `SocioProphet/orion-field-intelligence`: real-assets, geospatial, field intelligence, and Earth-context packs.
+- `SocioProphet/ontogenesis`, `semantic-serdes`, `regis-entity-graph`, `lattice-forge`: ontology, graph, serialization, and query surfaces.
+
+## Initial demo workflows
+
+1. Legal new matter intake
+   - Intake request, entity resolution, conflict screen, obligation review, wall recommendation, approval, workspace creation, and evidence receipt.
+
+2. Private capital deal screening
+   - Ingest target, enrich entity, map relationships, compare to thesis, detect restrictions/conflicts, generate sourced screening memo, route to partner.
+
+3. Real-assets diligence
+   - Asset intake, ownership graph, lease/contract obligations, geospatial/field context, environmental or operational risks, diligence memo, approval workflow.
+
+4. Revenue integrity review
+   - Work capture, billing guideline enforcement, prebill exceptions, realization risk, adjustment explanation, and partner review.
+
+## Acceptance criteria
+
+The first integrated slice is acceptable when it can:
+
+- load a playbook from DelEx/InnerSource;
+- resolve institution context from graph, memory, policy, contract, search, and workspace sources;
+- execute a governed agent step through Agentplane or a local stand-in;
+- enforce a policy or obligation before producing output;
+- emit adoption and evidence events;
+- create or update a Prophet Workspace workroom;
+- expose enough runtime surface in `prophet-platform` for smoke testing.
+
+## Non-goals
+
+- Do not hard-code a single vertical workflow into the platform core.
+- Do not bypass policy, wall, or evidence controls for demo speed.
+- Do not treat chat as the product. Chat is one interaction mode over governed institutional workflows.
+- Do not encode confidential third-party interview content. Use only public market understanding and independent architecture.

--- a/professional-intelligence.manifest.yaml
+++ b/professional-intelligence.manifest.yaml
@@ -1,0 +1,163 @@
+apiVersion: socioprophet.io/v1alpha1
+kind: ProfessionalIntelligenceManifest
+metadata:
+  name: professional-intelligence-os
+  owner: SocioProphet
+  status: seed
+  created: "2026-04-29"
+  description: >-
+    Cross-repo alignment manifest for the Professional Intelligence OS product spine.
+    This binds DelEx delivery governance, Prophet Platform runtime, Prophet Workspace
+    workrooms, and governed AI/policy/model services into one executable architecture.
+
+principles:
+  - DelEx governs delivery, readiness, KPIs, boards, playbooks, and acceptance evidence.
+  - Prophet Platform hosts runtime services, service contracts, deployment wiring, and smoke tests.
+  - Prophet Workspace owns user-facing workrooms and professional collaboration surfaces.
+  - Agent/model/policy/memory/contract repos own specialized governed service semantics.
+  - Every material AI or workflow action emits evidence and adoption telemetry.
+
+capabilities:
+  institutionContextEngine:
+    status: proposed
+    ownerRepos:
+      - SocioProphet/prophet-platform
+      - SocioProphet/memory-mesh
+      - SocioProphet/ontogenesis
+      - SocioProphet/regis-entity-graph
+      - SocioProphet/sherlock-search
+    runtimeRepo: SocioProphet/prophet-platform
+    contractPaths:
+      - contracts/institution/context-pack.schema.json
+      - contracts/institution/institution-entity.schema.json
+    notes: Compiles scoped institutional context for users, workspaces, agents, and playbooks.
+
+  institutionGraph:
+    status: proposed
+    ownerRepos:
+      - SocioProphet/regis-entity-graph
+      - SocioProphet/ontogenesis
+      - SocioProphet/semantic-serdes
+      - SocioProphet/lattice-forge
+    runtimeRepo: SocioProphet/prophet-platform
+    contractPaths:
+      - contracts/institution/institution-entity.schema.json
+      - contracts/institution/relationship.schema.json
+    notes: Canonical graph of people, orgs, clients, matters, deals, assets, relationships, obligations, decisions, and evidence.
+
+  agentFabric:
+    status: active-fragmented
+    ownerRepos:
+      - SocioProphet/agentplane
+      - SocioProphet/agent-registry
+      - SocioProphet/model-router
+      - SocioProphet/guardrail-fabric
+      - SocioProphet/model-governance-ledger
+      - SocioProphet/memory-mesh
+    runtimeRepo: SocioProphet/prophet-platform
+    contractPaths:
+      - contracts/evidence/agent-action-receipt.schema.json
+    notes: Governed agent execution with identity, authority, routing, guardrails, memory, evals, and replay evidence.
+
+  conflictEngine:
+    status: proposed
+    ownerRepos:
+      - SocioProphet/regis-entity-graph
+      - SocioProphet/policy-fabric
+      - SocioProphet/guardrail-fabric
+      - SocioProphet/prophet-platform
+    runtimeRepo: SocioProphet/prophet-platform
+    contractPaths:
+      - contracts/risk/conflict-check.schema.json
+    notes: Entity, relationship, matter, deal, employee, restricted-list, ownership, and AI/data-use conflict review.
+
+  obligationLedger:
+    status: proposed
+    ownerRepos:
+      - SocioProphet/contractforge
+      - SocioProphet/policy-fabric
+      - SocioProphet/model-governance-ledger
+    runtimeRepo: SocioProphet/prophet-platform
+    contractPaths:
+      - contracts/policy/obligation.schema.json
+    notes: Machine-readable contractual, client-term, billing, confidentiality, data-use, and AI-use obligations.
+
+  ethicalWalls:
+    status: proposed
+    ownerRepos:
+      - SocioProphet/policy-fabric
+      - SocioProphet/guardrail-fabric
+      - SocioProphet/prophet-workspace
+      - SocioProphet/prophet-platform
+    runtimeRepo: SocioProphet/prophet-platform
+    contractPaths:
+      - contracts/risk/information-barrier.schema.json
+    notes: Permission-aware boundaries across documents, memory, graph edges, workspaces, tools, prompts, and model context.
+
+  workspaceOS:
+    status: active-seed
+    ownerRepos:
+      - SocioProphet/prophet-workspace
+      - SocioProphet/sherlock-search
+      - SocioProphet/speechlab
+      - SocioProphet/orion-field-intelligence
+    runtimeRepo: SocioProphet/prophet-platform
+    contractPaths:
+      - contracts/workspace/workroom.schema.json
+    notes: Professional workrooms for clients, matters, deals, funds, assets, projects, and initiatives.
+
+  adoptionTelemetry:
+    status: proposed
+    ownerRepos:
+      - SocioProphet/delivery-excellence
+      - SocioProphet/delivery-excellence-automation
+      - SocioProphet/prophet-platform
+      - SocioProphet/prophet-workspace
+    runtimeRepo: SocioProphet/prophet-platform
+    contractPaths:
+      - contracts/evidence/adoption-event.schema.json
+    notes: Usage, trust, acceptance, edits, escalations, cycle time, demo acceptance, and KPI movement.
+
+  revenueIntegrity:
+    status: proposed
+    ownerRepos:
+      - SocioProphet/contractforge
+      - SocioProphet/policy-fabric
+      - SocioProphet/prophet-workspace
+      - SocioProphet/delivery-excellence
+    runtimeRepo: SocioProphet/prophet-platform
+    contractPaths:
+      - contracts/revenue/work-capture-event.schema.json
+      - contracts/revenue/prebill-exception.schema.json
+    notes: Work capture, billing guideline enforcement, prebill review, realization risk, and leakage reduction.
+
+verticalPacks:
+  legal:
+    status: seed
+    playbooks:
+      - legal/new-matter-intake
+      - legal/conflicts-clearance
+  privateCapital:
+    status: seed
+    playbooks:
+      - private-capital/deal-screening
+      - private-capital/ic-memo
+  realAssets:
+    status: seed
+    playbooks:
+      - real-assets/asset-diligence
+  revenue:
+    status: seed
+    playbooks:
+      - revenue/prebill-review
+
+demoAcceptance:
+  required:
+    - playbook_loaded
+    - institution_context_resolved
+    - policy_or_obligation_checked
+    - agent_step_executed
+    - evidence_receipt_emitted
+    - adoption_event_emitted
+    - workspace_workroom_created_or_updated
+    - smoke_test_passed

--- a/tools/validate_professional_intelligence.py
+++ b/tools/validate_professional_intelligence.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Validate Professional Intelligence OS platform contracts and manifest.
+
+This validator is deliberately dependency-light. It validates the JSON fixtures against
+the schema subset used by the seed Professional Intelligence contracts and checks that
+contract paths referenced by `professional-intelligence.manifest.yaml` exist.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "professional-intelligence.manifest.yaml"
+SCHEMA_EXAMPLES = [
+    (
+        ROOT / "contracts/evidence/adoption-event.schema.json",
+        ROOT / "contracts/evidence/adoption-event.v0.1.example.json",
+    ),
+    (
+        ROOT / "contracts/institution/institution-entity.schema.json",
+        ROOT / "contracts/institution/institution-entity.v0.1.example.json",
+    ),
+    (
+        ROOT / "contracts/policy/obligation.schema.json",
+        ROOT / "contracts/policy/obligation.v0.1.example.json",
+    ),
+    (
+        ROOT / "contracts/risk/conflict-check.schema.json",
+        ROOT / "contracts/risk/conflict-check.v0.1.example.json",
+    ),
+]
+
+
+class ValidationError(Exception):
+    pass
+
+
+def load_json(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+
+
+def json_type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    return type(value).__name__
+
+
+def type_matches(value: Any, expected: str) -> bool:
+    actual = json_type_name(value)
+    if expected == "number":
+        return actual in {"integer", "number"}
+    return actual == expected
+
+
+def validate_schema(schema: dict[str, Any], value: Any, path: str = "$") -> None:
+    if "const" in schema and value != schema["const"]:
+        raise ValidationError(f"{path}: expected const {schema['const']!r}, got {value!r}")
+
+    if "enum" in schema and value not in schema["enum"]:
+        raise ValidationError(f"{path}: {value!r} not in enum {schema['enum']!r}")
+
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        expected_types = expected_type if isinstance(expected_type, list) else [expected_type]
+        if not any(type_matches(value, item) for item in expected_types):
+            raise ValidationError(
+                f"{path}: expected type {expected_types!r}, got {json_type_name(value)!r}"
+            )
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        for key in required:
+            if key not in value:
+                raise ValidationError(f"{path}: missing required property {key!r}")
+
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            extra = sorted(set(value) - set(properties))
+            if extra:
+                raise ValidationError(f"{path}: unexpected properties {extra!r}")
+
+        additional = schema.get("additionalProperties")
+        for key, item in value.items():
+            child_schema = properties.get(key)
+            if child_schema is None and isinstance(additional, dict):
+                child_schema = additional
+            if child_schema is not None:
+                validate_schema(child_schema, item, f"{path}.{key}")
+
+    if isinstance(value, list):
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            for index, item in enumerate(value):
+                validate_schema(item_schema, item, f"{path}[{index}]")
+
+
+def validate_manifest_contract_paths() -> None:
+    if not MANIFEST.exists():
+        raise ValidationError("missing professional-intelligence.manifest.yaml")
+
+    text = MANIFEST.read_text(encoding="utf-8")
+    contract_paths = re.findall(r"^\s*-\s+(contracts/[^\s#]+)\s*$", text, flags=re.MULTILINE)
+    if not contract_paths:
+        raise ValidationError("manifest does not declare any contractPaths entries")
+
+    missing = [path for path in contract_paths if not (ROOT / path).exists()]
+    if missing:
+        joined = ", ".join(missing)
+        raise ValidationError(f"manifest references missing contract paths: {joined}")
+
+    print(f"ok: manifest references {len(contract_paths)} existing contract paths")
+
+
+def validate_examples() -> None:
+    for schema_path, example_path in SCHEMA_EXAMPLES:
+        schema = load_json(schema_path)
+        example = load_json(example_path)
+        validate_schema(schema, example)
+        print(
+            "ok: "
+            f"{example_path.relative_to(ROOT)} validates against {schema_path.relative_to(ROOT)}"
+        )
+
+
+def main() -> int:
+    try:
+        validate_manifest_contract_paths()
+        validate_examples()
+    except ValidationError as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+
+    print("OK: Professional Intelligence validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_repo.py
+++ b/tools/validate_repo.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import re
+import subprocess
 import sys
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -26,6 +27,14 @@ SUSPECT_PATTERNS = [r"\bTODO\b", r"\bPLACEHOLDER\b", r"\n\.\.\.\n"]
 def fail(msg: str) -> None:
     print(f"ERR: {msg}", file=sys.stderr)
     raise SystemExit(2)
+
+
+def run_professional_intelligence_validation() -> None:
+    validator = ROOT / "tools/validate_professional_intelligence.py"
+    if validator.exists():
+        result = subprocess.run([sys.executable, str(validator)], cwd=ROOT, check=False)
+        if result.returncode != 0:
+            fail("Professional Intelligence validation failed")
 
 
 for rel in REQUIRED_DIRS:
@@ -62,5 +71,7 @@ for rel in [
 ]:
     if not (ROOT / rel).exists():
         fail(f"missing imported source manifest: {rel}")
+
+run_professional_intelligence_validation()
 
 print("OK: validate passed")


### PR DESCRIPTION
## Summary

Seeds the Professional Intelligence OS alignment spine in `prophet-platform` and adds validation fixtures.

Adds:
- `docs/strategy/professional-intelligence-os.md`
- `professional-intelligence.manifest.yaml`
- `contracts/evidence/adoption-event.schema.json`
- `contracts/evidence/adoption-event.v0.1.example.json`
- `contracts/institution/institution-entity.schema.json`
- `contracts/institution/institution-entity.v0.1.example.json`
- `contracts/policy/obligation.schema.json`
- `contracts/policy/obligation.v0.1.example.json`
- `contracts/risk/conflict-check.schema.json`
- `contracts/risk/conflict-check.v0.1.example.json`
- `tools/validate_professional_intelligence.py`

Updates:
- `tools/validate_repo.py` now invokes Professional Intelligence validation when the validator is present.

## Why

This turns the institutional intelligence strategy into concrete platform artifacts. The platform now has a product-level manifest, seed contracts, examples, and validation for institution entities, adoption telemetry, obligations, and conflict checks.

## Repo alignment

- DelEx governs delivery, KPIs, boards, playbooks, and acceptance evidence.
- Prophet Platform owns runtime/deployment contracts and service composition.
- Prophet Workspace owns professional workrooms.
- Policy Fabric owns executable policy overlays.
- ContractForge owns obligation semantics.
- Agent/model/memory repos own governed AI execution.

## Completion impact

- Overall Professional Intelligence OS alignment: ~23% -> ~28%
- Platform contracts: ~30% -> ~45%
- Architecture spine: ~35% -> ~40%
- Cybernetic controls: ~16% -> ~20%
- Demo readiness: ~10% -> ~14%

## Validation

Validation is wired through existing repo validation:

```bash
python3 tools/validate_repo.py
```

Professional Intelligence-specific validation can also run directly:

```bash
python3 tools/validate_professional_intelligence.py
```