### PR TITLE
contracts: add Professional Intelligence manifest schemas

### DIFF
--- a/contracts/evidence/agent-action-receipt.schema.json
+++ b/contracts/evidence/agent-action-receipt.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/professional-intelligence/agent-action-receipt.schema.json",
+  "title": "AgentActionReceipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "receiptId", "agentId", "action", "status", "createdAt"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "receiptId": { "type": "string", "minLength": 1 },
+    "agentId": { "type": "string", "minLength": 1 },
+    "actorId": { "type": "string" },
+    "workspaceId": { "type": "string" },
+    "action": { "type": "string", "minLength": 1 },
+    "status": { "type": "string", "enum": ["planned", "started", "completed", "failed", "blocked", "requires_review"] },
+    "authorityRef": { "type": "string" },
+    "policyDecisionRefs": { "type": "array", "items": { "type": "string" } },
+    "inputRefs": { "type": "array", "items": { "type": "string" } },
+    "outputRefs": { "type": "array", "items": { "type": "string" } },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "completedAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/institution/context-pack.schema.json
+++ b/contracts/institution/context-pack.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/professional-intelligence/context-pack.schema.json",
+  "title": "InstitutionContextPack",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "contextPackId", "scope", "entities"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "contextPackId": { "type": "string", "minLength": 1 },
+    "scope": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["scopeId", "scopeType"],
+      "properties": {
+        "scopeId": { "type": "string", "minLength": 1 },
+        "scopeType": { "type": "string", "enum": ["user", "workspace", "client", "matter", "deal", "project", "institution"] }
+      }
+    },
+    "entities": { "type": "array", "items": { "type": "string" } },
+    "relationshipRefs": { "type": "array", "items": { "type": "string" } },
+    "policyRefs": { "type": "array", "items": { "type": "string" } },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "generatedAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/contracts/institution/relationship.schema.json
+++ b/contracts/institution/relationship.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/professional-intelligence/relationship.schema.json",
+  "title": "InstitutionRelationship",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "relationshipId", "sourceEntityId", "targetEntityId", "relationshipType"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "relationshipId": { "type": "string", "minLength": 1 },
+    "sourceEntityId": { "type": "string", "minLength": 1 },
+    "targetEntityId": { "type": "string", "minLength": 1 },
+    "relationshipType": { "type": "string", "minLength": 1 },
+    "direction": { "type": "string", "enum": ["directed", "undirected"] },
+    "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+    "effectiveFrom": { "type": "string", "format": "date-time" },
+    "effectiveTo": { "type": "string", "format": "date-time" },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "attributes": { "type": "object", "additionalProperties": true }
+  }
+}

--- a/contracts/revenue/prebill-exception.schema.json
+++ b/contracts/revenue/prebill-exception.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/professional-intelligence/prebill-exception.schema.json",
+  "title": "PrebillException",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "exceptionId", "workroomId", "exceptionType", "status", "openedAt"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "exceptionId": { "type": "string", "minLength": 1 },
+    "workroomId": { "type": "string", "minLength": 1 },
+    "exceptionType": { "type": "string", "enum": ["guideline", "rate", "narrative", "missing_evidence", "write_down", "write_off", "realization_risk", "other"] },
+    "status": { "type": "string", "enum": ["open", "reviewing", "approved", "rejected", "resolved", "closed"] },
+    "openedAt": { "type": "string", "format": "date-time" },
+    "closedAt": { "type": "string", "format": "date-time" },
+    "ownerId": { "type": "string" },
+    "description": { "type": "string" },
+    "workCaptureEventRefs": { "type": "array", "items": { "type": "string" } },
+    "policyRefs": { "type": "array", "items": { "type": "string" } },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "resolution": { "type": "string" }
+  }
+}

--- a/contracts/revenue/work-capture-event.schema.json
+++ b/contracts/revenue/work-capture-event.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/professional-intelligence/work-capture-event.schema.json",
+  "title": "WorkCaptureEvent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "eventId", "workroomId", "actorId", "capturedAt", "workType"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "eventId": { "type": "string", "minLength": 1 },
+    "workroomId": { "type": "string", "minLength": 1 },
+    "actorId": { "type": "string", "minLength": 1 },
+    "capturedAt": { "type": "string", "format": "date-time" },
+    "workType": { "type": "string", "minLength": 1 },
+    "description": { "type": "string" },
+    "durationMinutes": { "type": "integer", "minimum": 0 },
+    "matterRef": { "type": "string" },
+    "clientRef": { "type": "string" },
+    "policyRefs": { "type": "array", "items": { "type": "string" } },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "billingDisposition": { "type": "string", "enum": ["billable", "non_billable", "write_off", "review_required"] }
+  }
+}

--- a/contracts/risk/information-barrier.schema.json
+++ b/contracts/risk/information-barrier.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/professional-intelligence/information-barrier.schema.json",
+  "title": "InformationBarrier",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "barrierId", "name", "scope", "rules", "status"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "barrierId": { "type": "string", "minLength": 1 },
+    "name": { "type": "string", "minLength": 1 },
+    "scope": { "type": "object", "additionalProperties": true },
+    "rules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["ruleId", "effect"],
+        "properties": {
+          "ruleId": { "type": "string", "minLength": 1 },
+          "effect": { "type": "string", "enum": ["allow", "deny", "review"] },
+          "subjectRefs": { "type": "array", "items": { "type": "string" } },
+          "resourceRefs": { "type": "array", "items": { "type": "string" } },
+          "rationale": { "type": "string" }
+        }
+      }
+    },
+    "status": { "type": "string", "enum": ["draft", "active", "suspended", "retired"] },
+    "owner": { "type": "string" },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/contracts/workspace/workroom.schema.json
+++ b/contracts/workspace/workroom.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/professional-intelligence/workroom.schema.json",
+  "title": "Workroom",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "workroomId", "workroomType", "title", "status"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "workroomId": { "type": "string", "minLength": 1 },
+    "workroomType": { "type": "string", "enum": ["client", "matter", "deal", "fund", "asset", "project", "initiative", "internal"] },
+    "title": { "type": "string", "minLength": 1 },
+    "status": { "type": "string", "enum": ["draft", "active", "archived", "closed"] },
+    "ownerId": { "type": "string" },
+    "participantRefs": { "type": "array", "items": { "type": "string" } },
+    "contextPackRefs": { "type": "array", "items": { "type": "string" } },
+    "policyRefs": { "type": "array", "items": { "type": "string" } },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "createdAt": { "type": "string", "format": "date-time" },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  }
+}


### PR DESCRIPTION
Adds the missing schema files referenced by professional-intelligence.manifest.yaml so repo-wide validation can pass.