### PR TITLE
Emit platform records for model-fabric services

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/model_fabric_records.py
+++ b/apps/lattice-studio/src/lattice_studio/model_fabric_records.py
@@ -1,0 +1,115 @@
+"""Emit PlatformAssetRecord objects for model-fabric services.
+
+This module projects entries from the functional service registry into the
+canonical platform-record spine used by Lattice Studio and Prophet Platform.
+It is intentionally registry-only: it does not invoke model routers, guardrail
+evaluators, ledgers, agent registries, or live provider services.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .platform_records import platform_record_set
+
+MODEL_FABRIC_SURFACES = {"routing", "guardrail", "model-governance", "agent-registry"}
+
+
+def functional_service_to_model_fabric_record(service: dict[str, Any]) -> dict[str, Any]:
+    """Convert one functional service registry entry into a PlatformAssetRecord."""
+    service_id = _required_str(service, "serviceId")
+    surface = _required_str(service, "surface")
+    status = _required_str(service, "status")
+    source_repos = _required_list(service, "sourceRepos")
+    evidence_requirements = _required_list(service, "evidenceRequirements")
+    promotion = _required_dict(service, "promotion")
+    carry = _required_dict(service, "sourceosCarryPolicy")
+
+    if surface not in MODEL_FABRIC_SURFACES:
+        raise ValueError(f"service surface {surface!r} is not a model-fabric surface")
+    if carry.get("role") != "carry-only":
+        raise ValueError("sourceosCarryPolicy.role must be carry-only")
+    if carry.get("mayReplaceServiceArtifact") is not False:
+        raise ValueError("SourceOS must not replace model-fabric service artifacts")
+    if carry.get("mayPromoteModel") is not False:
+        raise ValueError("SourceOS must not promote model-fabric models")
+
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecord",
+        "assetId": service_id,
+        "assetKind": f"model-fabric-{surface}",
+        "name": _name_from_service_id(service_id),
+        "version": _version_from_service_id(service_id),
+        "sourceApiVersion": "modality.socioprophet.dev/v1",
+        "sourceKind": "FunctionalServiceRegistryService",
+        "producerRepo": "SocioProphet/prophet-platform",
+        "policyRef": carry.get("role"),
+        "evidenceCorrelationId": service_id,
+        "promotionChannel": promotion.get("state") or status,
+        "compatibilitySurfaces": [
+            "lattice-studio",
+            "prophet-platform",
+            "functional-model-surfaces",
+            "model-fabric",
+            surface,
+            *source_repos,
+        ],
+        "modelFabric": {
+            "serviceStatus": status,
+            "sourceRepos": source_repos,
+            "evidenceRequirements": evidence_requirements,
+            "rollbackRef": _required_str(promotion, "rollbackRef"),
+            "sourceosCarryPolicy": carry,
+        },
+    }
+
+
+def functional_service_registry_to_model_fabric_record_set(registry: dict[str, Any]) -> dict[str, Any]:
+    """Convert model-fabric services from a registry into a PlatformAssetRecordSet."""
+    if registry.get("apiVersion") != "modality.socioprophet.dev/v1":
+        raise ValueError("registry apiVersion must be modality.socioprophet.dev/v1")
+    if registry.get("kind") != "FunctionalServiceRegistry":
+        raise ValueError("registry kind must be FunctionalServiceRegistry")
+    services = registry.get("spec", {}).get("services", [])
+    if not isinstance(services, list):
+        raise ValueError("registry spec.services must be a list")
+    records = [
+        functional_service_to_model_fabric_record(service)
+        for service in services
+        if isinstance(service, dict) and service.get("surface") in MODEL_FABRIC_SURFACES
+    ]
+    return platform_record_set(records)
+
+
+def _required_str(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _required_dict(data: dict[str, Any], key: str) -> dict[str, Any]:
+    value = data.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"{key} must be an object")
+    return value
+
+
+def _required_list(data: dict[str, Any], key: str) -> list[Any]:
+    value = data.get(key)
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{key} must be a non-empty list")
+    return value
+
+
+def _version_from_service_id(service_id: str) -> str:
+    if "@" not in service_id:
+        return "0.1.0"
+    return service_id.rsplit("@", 1)[1]
+
+
+def _name_from_service_id(service_id: str) -> str:
+    without_scheme = service_id.removeprefix("service://")
+    without_version = without_scheme.rsplit("@", 1)[0]
+    return without_version.replace("/", "-")

--- a/apps/lattice-studio/tests/test_model_fabric_records.py
+++ b/apps/lattice-studio/tests/test_model_fabric_records.py
@@ -1,0 +1,70 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from lattice_studio.model_fabric_records import (
+    MODEL_FABRIC_SURFACES,
+    functional_service_registry_to_model_fabric_record_set,
+    functional_service_to_model_fabric_record,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+REGISTRY = ROOT / "contracts" / "modality" / "functional-service-registry.v1.example.json"
+
+
+def _registry() -> dict:
+    return json.loads(REGISTRY.read_text(encoding="utf-8"))
+
+
+def test_functional_service_registry_emits_model_fabric_record_set() -> None:
+    record_set = functional_service_registry_to_model_fabric_record_set(_registry())
+
+    assert record_set["apiVersion"] == "prophet.socioprophet.dev/v1"
+    assert record_set["kind"] == "PlatformAssetRecordSet"
+    records = record_set["records"]
+    assert {record["assetKind"] for record in records} == {
+        "model-fabric-routing",
+        "model-fabric-guardrail",
+        "model-fabric-model-governance",
+        "model-fabric-agent-registry",
+    }
+    assert {record["modelFabric"]["sourceosCarryPolicy"]["role"] for record in records} == {"carry-only"}
+    assert {record["modelFabric"]["sourceosCarryPolicy"]["mayPromoteModel"] for record in records} == {False}
+    assert {record["modelFabric"]["sourceosCarryPolicy"]["mayReplaceServiceArtifact"] for record in records} == {False}
+
+
+def test_model_fabric_records_include_expected_source_repos_and_surfaces() -> None:
+    record_set = functional_service_registry_to_model_fabric_record_set(_registry())
+    by_kind = {record["assetKind"]: record for record in record_set["records"]}
+
+    assert "SocioProphet/model-router" in by_kind["model-fabric-routing"]["compatibilitySurfaces"]
+    assert "SocioProphet/guardrail-fabric" in by_kind["model-fabric-guardrail"]["compatibilitySurfaces"]
+    assert "SocioProphet/model-governance-ledger" in by_kind["model-fabric-model-governance"]["compatibilitySurfaces"]
+    assert "SocioProphet/agent-registry" in by_kind["model-fabric-agent-registry"]["compatibilitySurfaces"]
+    for surface in MODEL_FABRIC_SURFACES:
+        assert any(surface in record["compatibilitySurfaces"] for record in record_set["records"])
+
+
+def test_model_fabric_record_rejects_sourceos_mutable_model_authority() -> None:
+    service = next(
+        service
+        for service in _registry()["spec"]["services"]
+        if service["surface"] == "routing"
+    )
+    bad = json.loads(json.dumps(service))
+    bad["sourceosCarryPolicy"]["mayPromoteModel"] = True
+
+    with pytest.raises(ValueError, match="must not promote"):
+        functional_service_to_model_fabric_record(bad)
+
+
+def test_model_fabric_record_rejects_non_fabric_surface() -> None:
+    service = next(
+        service
+        for service in _registry()["spec"]["services"]
+        if service["surface"] == "language"
+    )
+
+    with pytest.raises(ValueError, match="not a model-fabric surface"):
+        functional_service_to_model_fabric_record(service)

--- a/docs/MODEL_FABRIC_PLATFORM_RECORDS.md
+++ b/docs/MODEL_FABRIC_PLATFORM_RECORDS.md
@@ -1,0 +1,26 @@
+# Model Fabric Platform Records
+
+Prophet Platform projects model-fabric service registry entries into the canonical `PlatformAssetRecord` spine.
+
+## Scope
+
+The first model-fabric record emitter reads the functional service registry and emits records for:
+
+- `model-router`
+- `guardrail-fabric`
+- `model-governance-ledger`
+- `agent-registry`
+
+It does not invoke model providers, route requests, evaluate guardrails, mutate ledgers, or grant agent authority. It only projects registry metadata into platform records.
+
+## SourceOS carry boundary
+
+Every emitted model-fabric record requires SourceOS carry policy to remain `carry-only`:
+
+- SourceOS may carry clients, launchers, refs, cache policy, and evidence collectors.
+- SourceOS must not promote models.
+- SourceOS must not replace service artifacts.
+
+## Integration
+
+The records are emitted by `apps/lattice-studio/src/lattice_studio/model_fabric_records.py` and tested against `contracts/modality/functional-service-registry.v1.example.json`.


### PR DESCRIPTION
## Summary

Adds a registry-only model-fabric platform-record emitter for Prophet Platform.

This PR adds:

- `lattice_studio.model_fabric_records`
- tests against `contracts/modality/functional-service-registry.v1.example.json`
- docs for model-fabric platform-record projection

## Scope

The emitter converts model-fabric service registry entries into `PlatformAssetRecord` records for:

- model-router
- guardrail-fabric
- model-governance-ledger
- agent-registry

## Boundaries

This is metadata projection only. It does not invoke model providers, route requests, evaluate guardrails, mutate ledgers, or grant agent authority. SourceOS remains carry-only.

## Validation

Runs through the normal Prophet Platform PR checks.
