### PR TITLE
Add model-fabric adapter contract fixtures

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/model_fabric_adapters.py
+++ b/apps/lattice-studio/src/lattice_studio/model_fabric_adapters.py
@@ -1,0 +1,90 @@
+"""Model-fabric runtime adapter contract fixtures.
+
+These adapters describe how Prophet Platform will bind model-fabric backing
+services. They are contract fixtures only. They do not invoke provider APIs,
+execute models, mutate ledgers, or grant agent authority.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+REQUIRED_SURFACES = {"routing", "guardrail", "model-governance", "agent-registry"}
+REQUIRED_BOUNDARIES = {"no-secret-material", "sourceos-carry-only"}
+
+
+def validate_model_fabric_adapter_set(adapter_set: dict[str, Any]) -> dict[str, Any]:
+    if adapter_set.get("apiVersion") != "modelfabric.socioprophet.dev/v1":
+        raise ValueError("adapter set apiVersion must be modelfabric.socioprophet.dev/v1")
+    if adapter_set.get("kind") != "ModelFabricRuntimeAdapterSet":
+        raise ValueError("adapter set kind must be ModelFabricRuntimeAdapterSet")
+    adapters = adapter_set.get("spec", {}).get("adapters", [])
+    if not isinstance(adapters, list) or not adapters:
+        raise ValueError("adapter set spec.adapters must be a non-empty list")
+
+    seen_ids: set[str] = set()
+    surfaces: set[str] = set()
+    for idx, adapter in enumerate(adapters):
+        _validate_adapter(adapter, idx)
+        adapter_id = adapter["adapterId"]
+        if adapter_id in seen_ids:
+            raise ValueError(f"duplicate adapterId: {adapter_id}")
+        seen_ids.add(adapter_id)
+        surfaces.add(adapter["surface"])
+    missing = sorted(REQUIRED_SURFACES - surfaces)
+    if missing:
+        raise ValueError(f"missing model-fabric adapter surfaces: {missing}")
+    return adapter_set
+
+
+def summarize_model_fabric_adapter_set(adapter_set: dict[str, Any]) -> dict[str, Any]:
+    validate_model_fabric_adapter_set(adapter_set)
+    adapters = adapter_set["spec"]["adapters"]
+    return {
+        "apiVersion": "modelfabric.socioprophet.dev/v1",
+        "kind": "ModelFabricRuntimeAdapterSummary",
+        "adapterCount": len(adapters),
+        "surfaces": sorted({adapter["surface"] for adapter in adapters}),
+        "serviceRefs": sorted(adapter["serviceRef"] for adapter in adapters),
+        "mode": sorted({adapter["mode"] for adapter in adapters}),
+        "boundary": sorted(set().union(*(set(adapter["boundary"]) for adapter in adapters))),
+    }
+
+
+def _validate_adapter(adapter: dict[str, Any], idx: int) -> None:
+    prefix = f"adapters[{idx}]"
+    required = {
+        "adapterId",
+        "serviceRef",
+        "surface",
+        "mode",
+        "commandRef",
+        "inputRefs",
+        "outputRefs",
+        "evidenceRefs",
+        "policyRefs",
+        "boundary",
+    }
+    missing = sorted(required - set(adapter))
+    if missing:
+        raise ValueError(f"{prefix} missing fields: {missing}")
+    if not str(adapter["adapterId"]).startswith("adapter://"):
+        raise ValueError(f"{prefix}.adapterId must be an adapter:// ref")
+    if not str(adapter["serviceRef"]).startswith("service://"):
+        raise ValueError(f"{prefix}.serviceRef must be a service:// ref")
+    if adapter["surface"] not in REQUIRED_SURFACES:
+        raise ValueError(f"{prefix}.surface is not a known model-fabric surface")
+    if adapter["mode"] != "contract-fixture":
+        raise ValueError(f"{prefix}.mode must be contract-fixture")
+    for list_field in ["inputRefs", "outputRefs", "evidenceRefs", "policyRefs", "boundary"]:
+        value = adapter[list_field]
+        if not isinstance(value, list) or not value:
+            raise ValueError(f"{prefix}.{list_field} must be a non-empty list")
+    boundaries = set(adapter["boundary"])
+    missing_boundary = sorted(REQUIRED_BOUNDARIES - boundaries)
+    if missing_boundary:
+        raise ValueError(f"{prefix}.boundary missing required boundaries: {missing_boundary}")
+    if adapter["surface"] == "model-governance" and "no-ledger-mutation" not in boundaries:
+        raise ValueError(f"{prefix}.boundary must include no-ledger-mutation")
+    if adapter["surface"] == "agent-registry" and "no-authority-grant" not in boundaries:
+        raise ValueError(f"{prefix}.boundary must include no-authority-grant")

--- a/apps/lattice-studio/tests/test_model_fabric_adapters.py
+++ b/apps/lattice-studio/tests/test_model_fabric_adapters.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from lattice_studio.model_fabric_adapters import (
+    REQUIRED_SURFACES,
+    summarize_model_fabric_adapter_set,
+    validate_model_fabric_adapter_set,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+ADAPTER_SET = ROOT / "contracts" / "model-fabric" / "runtime-adapter-set.example.json"
+
+
+def _adapter_set() -> dict:
+    return json.loads(ADAPTER_SET.read_text(encoding="utf-8"))
+
+
+def test_model_fabric_adapter_set_validates() -> None:
+    adapter_set = validate_model_fabric_adapter_set(_adapter_set())
+
+    assert adapter_set["kind"] == "ModelFabricRuntimeAdapterSet"
+    assert {adapter["surface"] for adapter in adapter_set["spec"]["adapters"]} == REQUIRED_SURFACES
+
+
+def test_model_fabric_adapter_summary_covers_required_boundaries() -> None:
+    summary = summarize_model_fabric_adapter_set(_adapter_set())
+
+    assert summary["kind"] == "ModelFabricRuntimeAdapterSummary"
+    assert summary["adapterCount"] == 4
+    assert set(summary["surfaces"]) == REQUIRED_SURFACES
+    assert set(summary["mode"]) == {"contract-fixture"}
+    assert "no-secret-material" in summary["boundary"]
+    assert "sourceos-carry-only" in summary["boundary"]
+    assert "no-authority-grant" in summary["boundary"]
+    assert "no-ledger-mutation" in summary["boundary"]
+
+
+def test_model_fabric_adapter_set_rejects_missing_surface() -> None:
+    adapter_set = _adapter_set()
+    adapter_set["spec"]["adapters"] = [
+        adapter for adapter in adapter_set["spec"]["adapters"] if adapter["surface"] != "agent-registry"
+    ]
+
+    with pytest.raises(ValueError, match="missing model-fabric adapter surfaces"):
+        validate_model_fabric_adapter_set(adapter_set)
+
+
+def test_model_fabric_adapter_set_rejects_authority_grant_boundary_violation() -> None:
+    adapter_set = _adapter_set()
+    agent = next(adapter for adapter in adapter_set["spec"]["adapters"] if adapter["surface"] == "agent-registry")
+    agent["boundary"] = [item for item in agent["boundary"] if item != "no-authority-grant"]
+
+    with pytest.raises(ValueError, match="no-authority-grant"):
+        validate_model_fabric_adapter_set(adapter_set)

--- a/contracts/model-fabric/runtime-adapter-set.example.json
+++ b/contracts/model-fabric/runtime-adapter-set.example.json
@@ -1,0 +1,60 @@
+{
+  "apiVersion": "modelfabric.socioprophet.dev/v1",
+  "kind": "ModelFabricRuntimeAdapterSet",
+  "metadata": {
+    "name": "prophet-platform-model-fabric-adapters",
+    "version": "0.1.0"
+  },
+  "spec": {
+    "adapters": [
+      {
+        "adapterId": "adapter://socioprophet/model-router/default@0.1.0",
+        "serviceRef": "service://socioprophet/model-router/default@0.1.0",
+        "surface": "routing",
+        "mode": "contract-fixture",
+        "commandRef": "tool://model-router/route",
+        "inputRefs": ["contract://model-router/route-request"],
+        "outputRefs": ["contract://model-router/route-decision"],
+        "evidenceRefs": ["evidence://model-router/demo/request-001"],
+        "policyRefs": ["policy://model-router/local-first-v1"],
+        "boundary": ["no-provider-call", "no-model-execution", "no-secret-material", "sourceos-carry-only"]
+      },
+      {
+        "adapterId": "adapter://socioprophet/guardrail-fabric/default@0.1.0",
+        "serviceRef": "service://socioprophet/guardrail-fabric/default@0.1.0",
+        "surface": "guardrail",
+        "mode": "contract-fixture",
+        "commandRef": "tool://guardrail-fabric/test",
+        "inputRefs": ["contract://guardrail-fabric/guardrail-input"],
+        "outputRefs": ["contract://guardrail-fabric/guardrail-decision"],
+        "evidenceRefs": ["evidence://guardrail-fabric/demo/input-001"],
+        "policyRefs": ["guardrail://fabric/default-safe-text-v1"],
+        "boundary": ["no-provider-call", "no-model-execution", "no-secret-material", "sourceos-carry-only"]
+      },
+      {
+        "adapterId": "adapter://socioprophet/model-governance-ledger/default@0.1.0",
+        "serviceRef": "service://socioprophet/model-governance-ledger/default@0.1.0",
+        "surface": "model-governance",
+        "mode": "contract-fixture",
+        "commandRef": "tool://model-governance-ledger/records",
+        "inputRefs": ["contract://model-governance-ledger/promotion-record"],
+        "outputRefs": ["contract://model-governance-ledger/platform-ledger-record"],
+        "evidenceRefs": ["evidence://model-governance-ledger/demo/promotion-001"],
+        "policyRefs": ["policy://model-governance/promotion-v1"],
+        "boundary": ["no-ledger-mutation", "no-model-artifact-write", "no-secret-material", "sourceos-carry-only"]
+      },
+      {
+        "adapterId": "adapter://socioprophet/agent-registry/default@0.1.0",
+        "serviceRef": "service://socioprophet/agent-registry/default@0.1.0",
+        "surface": "agent-registry",
+        "mode": "contract-fixture",
+        "commandRef": "tool://agent-registry/list",
+        "inputRefs": ["contract://agent-registry/session-authority"],
+        "outputRefs": ["contract://agent-registry/agent-registry-record"],
+        "evidenceRefs": ["evidence://agent-registry/demo/session-authority-001"],
+        "policyRefs": ["policy://agent-registry/evidence-required-v1"],
+        "boundary": ["no-authority-grant", "no-identity-provider-call", "no-secret-material", "sourceos-carry-only"]
+      }
+    ]
+  }
+}

--- a/docs/MODEL_FABRIC_ADAPTERS.md
+++ b/docs/MODEL_FABRIC_ADAPTERS.md
@@ -1,0 +1,45 @@
+# Model Fabric Adapter Contracts
+
+Prophet Platform uses model-fabric adapter contracts to describe how platform services bind to the first model-fabric backing tools.
+
+## Scope
+
+The first adapter set covers:
+
+- `model-router`
+- `guardrail-fabric`
+- `model-governance-ledger`
+- `agent-registry`
+
+These are contract fixtures only. They define service refs, command refs, input/output refs, evidence refs, policy refs, and explicit boundaries.
+
+## Boundary
+
+The first adapter contract set is deterministic and local-only.
+
+It does not:
+
+- call external providers;
+- execute model inference;
+- mutate model-governance ledgers;
+- grant agent authority;
+- store secret material;
+- write model artifacts.
+
+SourceOS remains carry-only. It can carry clients, refs, launchers, cache policy, and evidence collectors. It must not promote models or replace service artifacts.
+
+## Validation
+
+The contract fixture lives at:
+
+```text
+contracts/model-fabric/runtime-adapter-set.example.json
+```
+
+The validator lives at:
+
+```text
+apps/lattice-studio/src/lattice_studio/model_fabric_adapters.py
+```
+
+The test suite validates required surfaces, boundaries, service refs, and failure cases.


### PR DESCRIPTION
## Summary

Implements the model-fabric adapter contract fixture slice from #277.

Adds:

- `contracts/model-fabric/runtime-adapter-set.example.json`
- `lattice_studio.model_fabric_adapters`
- pytest coverage for required surfaces and boundary failures
- adapter contract documentation

## Scope

This is contract fixture work only. It covers the platform binding contract for:

- model-router
- guardrail-fabric
- model-governance-ledger
- agent-registry

## Boundary

No external service calls, no secret material, no model artifacts, no ledger mutation, and no authority grants. SourceOS remains carry-only.

Closes #277
