### PR TITLE
Pin search orchestrator image digest on current main

### DIFF
--- a/infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml
+++ b/infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search-orchestrator
+spec:
+  template:
+    spec:
+      containers:
+        - name: search-orchestrator
+          image: ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:bbfea6e4a7ea432d77766a37464dfa666242dfe2621fc0e586ca2bde80c52066
+          imagePullPolicy: IfNotPresent

--- a/releases/images/search-orchestrator.image-lock.json
+++ b/releases/images/search-orchestrator.image-lock.json
@@ -1,0 +1,10 @@
+{
+  "image_lock_id": "search-orchestrator-image-lock",
+  "component": "services/search-orchestrator",
+  "image": "ghcr.io/socioprophet/prophet-platform/search-orchestrator",
+  "source_sha": "3f5a12aa5b86c60cb55fab3f36f6a5b528a772db",
+  "digest": "sha256:bbfea6e4a7ea432d77766a37464dfa666242dfe2621fc0e586ca2bde80c52066",
+  "pinned_ref": "ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:bbfea6e4a7ea432d77766a37464dfa666242dfe2621fc0e586ca2bde80c52066",
+  "workflow": ".github/workflows/search-orchestrator-image.yml",
+  "status": "pinned"
+}


### PR DESCRIPTION
Closes #286.

## Summary

Replays the stale automation digest-pin from PR #234 onto current `main`.

## Scope

- Adds `releases/images/search-orchestrator.image-lock.json`.
- Adds `infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml`.

## Safety posture

- Digest pin only.
- No runtime route behavior change.
- No learner action execution.
- No Canon promotion.
- No policy grant creation.
- No memory writeback.

## Validation

Pending GitHub workflows on this PR.