### PR TITLE
Emit explicit query envelope role refs

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/query_planner.py
+++ b/apps/lattice-studio/src/lattice_studio/query_planner.py
@@ -7,8 +7,10 @@ route, policy, catalog, memory, lab, and safety evidence.
 Architecture rule: Slash Topics and New Hope are not merely peer backends.
 Every nontrivial query is routed through a governance envelope first:
 
-1. Slash Topics provides explicit topic scope, topic pack, and memory posture.
-2. New Hope provides membrane admission and carrier/runtime policy semantics.
+1. Slash Topics provides the public query/governance surface, explicit topic scope,
+   topic pack, public adapter, future runtime alias, and memory posture.
+2. New Hope provides the internal membrane/runtime substrate and compatibility refs
+   for carrier/receptor/protocol/membrane/replay/provenance/federation semantics.
 3. Memory Mesh records scoped recall/writeback/evidence policy without storing raw
    sensitive payloads by default.
 4. Lab profiles define model/customization inputs for embeddings, NLP, image,
@@ -36,6 +38,10 @@ class QueryGovernanceEnvelope:
     topic_scope_ref: str
     topic_pack_ref: str
     membrane_ref: str
+    public_surface_ref: str
+    runtime_substrate_ref: str
+    runtime_alias_ref: str
+    compatibility_ref: str
     memory_profile_ref: str
     memory_event_ref: str
     lab_profile_refs: list[str]
@@ -47,6 +53,10 @@ class QueryGovernanceEnvelope:
             "topicScopeRef": self.topic_scope_ref,
             "topicPackRef": self.topic_pack_ref,
             "membraneRef": self.membrane_ref,
+            "publicSurfaceRef": self.public_surface_ref,
+            "runtimeSubstrateRef": self.runtime_substrate_ref,
+            "runtimeAliasRef": self.runtime_alias_ref,
+            "compatibilityRef": self.compatibility_ref,
             "memoryProfileRef": self.memory_profile_ref,
             "memoryEventRef": self.memory_event_ref,
             "labProfileRefs": self.lab_profile_refs,
@@ -126,7 +136,11 @@ class QueryRoutingDryRunPlan:
             "boundary": [
                 "dry-run-only",
                 "slash-topic-scope-required",
+                "slash-topics-public-surface-required",
                 "newhope-membrane-required",
+                "new-hope-runtime-substrate-required",
+                "new-hope-compatibility-ref-preserved",
+                "slash-topics-runtime-alias-preserved",
                 "memory-mesh-context-bound",
                 "lab-profile-bound",
                 "no-remote-query-execution",
@@ -153,11 +167,16 @@ def _digest(prefix: str, payload: dict[str, Any]) -> str:
 
 def demo_query_governance_envelope(topic: str = "/lattice/federated-query") -> QueryGovernanceEnvelope:
     payload = {"topic": topic, "membrane": "query-admission", "memory": "scoped-recall"}
+    compatibility_ref = "newhope://membranes/query-admission@0.1.0"
     return QueryGovernanceEnvelope(
         envelope_id=_digest("query-governance", payload),
         topic_scope_ref=f"slash-topic://{topic.strip('/')}",
         topic_pack_ref="slash-topics://packs/lattice-federated-query@0.1.0",
-        membrane_ref="newhope://membranes/query-admission@0.1.0",
+        membrane_ref=compatibility_ref,
+        public_surface_ref="slash-topics://surfaces/lattice-query-governance@0.1.0",
+        runtime_substrate_ref="newhope://runtime/membrane-substrate@0.1.0",
+        runtime_alias_ref="slash-topics://runtime/membranes/query-admission@0.1.0",
+        compatibility_ref=compatibility_ref,
         memory_profile_ref="memory-mesh://profiles/slash-topic-scoped-recall@0.1.0",
         memory_event_ref="memory-mesh://events/query-route-dry-run",
         lab_profile_refs=[
@@ -197,8 +216,18 @@ def _blocked_decision(request: QueryRouteRequest, reason: str) -> QueryRouteDeci
 def route_query(request: QueryRouteRequest) -> QueryRouteDecision:
     if not request.governance.topic_scope_ref.startswith("slash-topic://"):
         return _blocked_decision(request, "Missing Slash Topic scope.")
+    if not request.governance.topic_pack_ref.startswith("slash-topics://packs/"):
+        return _blocked_decision(request, "Missing Slash Topics topic pack reference.")
+    if not request.governance.public_surface_ref.startswith("slash-topics://surfaces/"):
+        return _blocked_decision(request, "Missing Slash Topics public query/governance surface reference.")
     if not request.governance.membrane_ref.startswith("newhope://membranes/"):
         return _blocked_decision(request, "Missing New Hope membrane admission reference.")
+    if not request.governance.runtime_substrate_ref.startswith("newhope://runtime/"):
+        return _blocked_decision(request, "Missing New Hope runtime substrate reference.")
+    if not request.governance.runtime_alias_ref.startswith("slash-topics://runtime/membranes/"):
+        return _blocked_decision(request, "Missing future Slash Topics runtime alias reference.")
+    if request.governance.compatibility_ref != request.governance.membrane_ref:
+        return _blocked_decision(request, "New Hope compatibility reference must match membrane admission reference.")
     if not request.governance.memory_profile_ref.startswith("memory-mesh://profiles/"):
         return _blocked_decision(request, "Missing Memory Mesh scoped memory profile.")
     if not request.governance.lab_profile_refs:
@@ -211,7 +240,7 @@ def route_query(request: QueryRouteRequest) -> QueryRouteDecision:
     backend = candidates[0]
     scope_allowed = request.catalog_scope in backend.catalog_scope or request.catalog_scope == "*"
     status: RouteDecisionStatus = "routable" if scope_allowed else "blocked"
-    reason = "Catalog scope is allowed after Slash Topics, New Hope, Memory Mesh, and lab-profile envelope checks." if scope_allowed else "Requested catalog scope is outside selected backend policy scope."
+    reason = "Catalog scope is allowed after Slash Topics public surface, New Hope runtime substrate, Memory Mesh, and lab-profile envelope checks." if scope_allowed else "Requested catalog scope is outside selected backend policy scope."
     payload = {"requestId": request.request_id, "backendId": backend.backend_id, "status": status}
     return QueryRouteDecision(
         decision_id=_digest("query-route", payload),
@@ -288,7 +317,11 @@ def query_routing_evidence(plan: QueryRoutingDryRunPlan) -> dict[str, Any]:
         "evidenceReports": [
             "dry-run-only",
             "slash-topic-scope-required",
+            "slash-topics-public-surface",
             "newhope-membrane-required",
+            "new-hope-runtime-substrate",
+            "new-hope-compatibility-preserved",
+            "slash-topics-runtime-alias",
             "memory-mesh-context-bound",
             "lab-profile-bound",
             "query-language-routing",
@@ -317,7 +350,7 @@ def query_routing_to_platform_record(plan: QueryRoutingDryRunPlan) -> dict[str, 
         "assetId": plan.plan_id,
         "assetKind": "query-routing-dry-run-plan",
         "name": "lattice-studio-query-routing-dry-run-plan",
-        "version": "0.2.0",
+        "version": "0.3.0",
         "sourceApiVersion": "studio.socioprophet.dev/v1",
         "sourceKind": "QueryRoutingDryRunPlan",
         "producerRepo": "SocioProphet/prophet-platform",
@@ -328,7 +361,11 @@ def query_routing_to_platform_record(plan: QueryRoutingDryRunPlan) -> dict[str, 
             "lattice-studio",
             "federated-query",
             "query-routing-dry-run",
+            "slash-topics-public-surface",
             "slash-topics",
+            "slash-topics-runtime-alias",
+            "new-hope-runtime-substrate",
+            "new-hope-compatibility",
             "new-hope",
             "memory-mesh",
             "nlp-lab",

--- a/apps/lattice-studio/tests/test_query_planner.py
+++ b/apps/lattice-studio/tests/test_query_planner.py
@@ -52,7 +52,11 @@ def test_query_routing_requires_governance_envelope_before_backend_selection() -
         envelope = request["governanceEnvelope"]
         assert envelope["topicScopeRef"].startswith("slash-topic://")
         assert envelope["topicPackRef"].startswith("slash-topics://packs/")
+        assert envelope["publicSurfaceRef"].startswith("slash-topics://surfaces/")
         assert envelope["membraneRef"].startswith("newhope://membranes/")
+        assert envelope["runtimeSubstrateRef"].startswith("newhope://runtime/")
+        assert envelope["runtimeAliasRef"].startswith("slash-topics://runtime/membranes/")
+        assert envelope["compatibilityRef"] == envelope["membraneRef"]
         assert envelope["memoryProfileRef"].startswith("memory-mesh://profiles/")
         assert envelope["memoryEventRef"] == "memory-mesh://events/query-route-dry-run"
         assert "lab://nlp-lab/default" in envelope["labProfileRefs"]
@@ -77,6 +81,38 @@ def test_query_routing_requires_governance_envelope_before_backend_selection() -
         assert decision["governanceSequence"][4] == "physical-backend-route"
 
 
+def test_query_routing_blocks_when_governance_envelope_is_missing_runtime_substrate() -> None:
+    envelope = demo_query_governance_envelope()
+    broken = type(envelope)(
+        envelope_id=envelope.envelope_id,
+        topic_scope_ref=envelope.topic_scope_ref,
+        topic_pack_ref=envelope.topic_pack_ref,
+        membrane_ref=envelope.membrane_ref,
+        public_surface_ref=envelope.public_surface_ref,
+        runtime_substrate_ref="",
+        runtime_alias_ref=envelope.runtime_alias_ref,
+        compatibility_ref=envelope.compatibility_ref,
+        memory_profile_ref=envelope.memory_profile_ref,
+        memory_event_ref=envelope.memory_event_ref,
+        lab_profile_refs=envelope.lab_profile_refs,
+        required_sequence=envelope.required_sequence,
+    )
+    request = QueryRouteRequest(
+        request_id="query-request:missing-runtime-substrate",
+        language="sql",
+        query="SELECT 1",
+        catalog_scope="catalog://datasets",
+        actor_ref="actor://lattice-studio/demo",
+        policy_ref="policy://query/federated",
+        governance=broken,
+    )
+
+    decision = route_query(request)
+    assert decision.status == "blocked"
+    assert decision.backend_id is None
+    assert "runtime substrate" in decision.reason
+
+
 def test_query_routing_blocks_when_governance_envelope_is_missing_memory_profile() -> None:
     envelope = demo_query_governance_envelope()
     broken = type(envelope)(
@@ -84,6 +120,10 @@ def test_query_routing_blocks_when_governance_envelope_is_missing_memory_profile
         topic_scope_ref=envelope.topic_scope_ref,
         topic_pack_ref=envelope.topic_pack_ref,
         membrane_ref=envelope.membrane_ref,
+        public_surface_ref=envelope.public_surface_ref,
+        runtime_substrate_ref=envelope.runtime_substrate_ref,
+        runtime_alias_ref=envelope.runtime_alias_ref,
+        compatibility_ref=envelope.compatibility_ref,
         memory_profile_ref="",
         memory_event_ref=envelope.memory_event_ref,
         lab_profile_refs=envelope.lab_profile_refs,
@@ -111,7 +151,11 @@ def test_query_routing_dry_run_preserves_no_execution_boundary() -> None:
 
     assert "dry-run-only" in boundary
     assert "slash-topic-scope-required" in boundary
+    assert "slash-topics-public-surface-required" in boundary
     assert "newhope-membrane-required" in boundary
+    assert "new-hope-runtime-substrate-required" in boundary
+    assert "new-hope-compatibility-ref-preserved" in boundary
+    assert "slash-topics-runtime-alias-preserved" in boundary
     assert "memory-mesh-context-bound" in boundary
     assert "lab-profile-bound" in boundary
     assert "no-remote-query-execution" in boundary
@@ -137,7 +181,11 @@ def test_query_routing_evidence_and_platform_record() -> None:
     assert evidence["routableCount"] == 12
     assert "dry-run-only" in evidence["evidenceReports"]
     assert "slash-topic-scope-required" in evidence["evidenceReports"]
+    assert "slash-topics-public-surface" in evidence["evidenceReports"]
     assert "newhope-membrane-required" in evidence["evidenceReports"]
+    assert "new-hope-runtime-substrate" in evidence["evidenceReports"]
+    assert "new-hope-compatibility-preserved" in evidence["evidenceReports"]
+    assert "slash-topics-runtime-alias" in evidence["evidenceReports"]
     assert "memory-mesh-context-bound" in evidence["evidenceReports"]
     assert "lab-profile-bound" in evidence["evidenceReports"]
     assert "ontology-query-route" in evidence["evidenceReports"]
@@ -147,8 +195,12 @@ def test_query_routing_evidence_and_platform_record() -> None:
     assert "lampstand-route" in evidence["evidenceReports"]
     assert record["kind"] == "PlatformAssetRecord"
     assert record["assetKind"] == "query-routing-dry-run-plan"
-    assert record["version"] == "0.2.0"
+    assert record["version"] == "0.3.0"
     assert "federated-query" in record["compatibilitySurfaces"]
+    assert "slash-topics-public-surface" in record["compatibilitySurfaces"]
+    assert "slash-topics-runtime-alias" in record["compatibilitySurfaces"]
+    assert "new-hope-runtime-substrate" in record["compatibilitySurfaces"]
+    assert "new-hope-compatibility" in record["compatibilitySurfaces"]
     assert "memory-mesh" in record["compatibilitySurfaces"]
     assert "embedding-lab" in record["compatibilitySurfaces"]
 


### PR DESCRIPTION
Closes #288.

## Summary

Makes Lattice query-routing dry-run artifacts explicitly encode the Slash Topics / New Hope topology decision.

## Changes

- Adds explicit query envelope refs:
  - `publicSurfaceRef` for Slash Topics.
  - `runtimeSubstrateRef` for New Hope.
  - `runtimeAliasRef` for future Slash Topics runtime aliases.
  - `compatibilityRef` preserving New Hope membrane compatibility.
- Emits evidence reports for `slash-topics-public-surface`, `new-hope-runtime-substrate`, `new-hope-compatibility-preserved`, and `slash-topics-runtime-alias`.
- Updates PlatformAssetRecord compatibility surfaces with non-ambiguous names.
- Adds tests for missing runtime substrate and role-specific envelope fields.

## Non-goals

- No runtime query execution.
- No repo rename.
- No physical migration of New Hope objects.

## Validation

Pending GitHub workflows.