### PR TITLE
Add Lattice Model Zoo fixture

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/model_zoo.py
+++ b/apps/lattice-studio/src/lattice_studio/model_zoo.py
@@ -1,0 +1,138 @@
+"""Lattice Model Zoo product-surface fixture.
+
+The model zoo is a governed discovery and promotion surface. It consumes the
+Lattice Studio/Data/GovernAI product spine and emits a deterministic model
+entry with lineage, runtime, evaluation, factsheet, endpoint, and use-policy
+refs. It does not implement a serving backend.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .platform_records import platform_record_set
+from .product_spine import demo_product_spine
+
+
+def demo_model_zoo_entry() -> dict[str, Any]:
+    spine = demo_product_spine()
+    data_product = spine["dataProduct"]
+    runtime = spine["runtimeAsset"]
+    evaluation = spine["evaluationBundle"]
+    factsheet = spine["factsheet"]
+
+    model_ref = factsheet["subjectRef"]
+    endpoint_ref = "urn:srcos:model-endpoint:community_truth_demo_candidate_dry_run"
+    use_policy_ref = "urn:srcos:policy:model-use-community-truth-demo"
+
+    model_card = {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "ModelCard",
+        "id": "urn:srcos:model-card:community_truth_demo_candidate",
+        "modelRef": model_ref,
+        "name": "Community Truth Demo Model",
+        "purpose": "Classify factuality and annotation quality for the Lattice demo path.",
+        "ownerRef": "urn:srcos:community:lattice-demo",
+        "trainingDataRefs": ["urn:srcos:dataset:community_truth_demo_training", data_product["id"]],
+        "evaluationDataRefs": ["urn:srcos:dataset:community_truth_demo_evaluation"],
+        "runtimeRef": runtime["metadata"]["name"] + ":" + runtime["metadata"]["version"],
+        "factsheetRef": factsheet["id"],
+        "evaluationRefs": [evaluation["id"]],
+        "limitations": ["Synthetic demo fixture only", "Not approved for production use"],
+    }
+    runtime_profile = {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "ModelRuntimeProfile",
+        "id": "urn:srcos:model-runtime-profile:community_truth_demo_candidate",
+        "modelRef": model_ref,
+        "runtimeAssetRef": "runtime-asset:prophet-python-ml:0.1.0",
+        "servingBackends": ["ray-serve", "kserve", "seldon-core"],
+        "defaultServingBackend": "ray-serve",
+        "executionMode": "dry-run",
+        "policyRef": "urn:srcos:policy:model-runtime-community-truth-demo",
+    }
+    endpoint = {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "ModelEndpoint",
+        "id": endpoint_ref,
+        "modelRef": model_ref,
+        "servingBackend": "ray-serve",
+        "route": "/models/community-truth-demo-candidate",
+        "state": "candidate-dry-run",
+        "policyRef": "urn:srcos:policy:model-endpoint-community-truth-demo",
+    }
+    use_policy = {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "ModelUsePolicy",
+        "id": use_policy_ref,
+        "modelRef": model_ref,
+        "allowedUses": ["evaluation", "demo", "research-review"],
+        "forbiddenUses": ["production-decisioning", "unsupervised-export"],
+        "requiresApprovalFor": ["promotion", "publication", "external-serving"],
+        "policyRef": "urn:srcos:policy:model-eval-demo",
+    }
+    entry = {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "ModelZooEntry",
+        "id": "urn:srcos:model-zoo-entry:community_truth_demo_candidate",
+        "modelRef": model_ref,
+        "name": "Community Truth Demo Candidate",
+        "description": "Governed model zoo entry for the Lattice Studio/Data/GovernAI vertical demo.",
+        "state": "candidate",
+        "dataProductRefs": [data_product["id"]],
+        "trainingDatasetRefs": ["urn:srcos:dataset:community_truth_demo_training"],
+        "evaluationDatasetRefs": ["urn:srcos:dataset:community_truth_demo_evaluation"],
+        "runtimeProfileRef": runtime_profile["id"],
+        "endpointRef": endpoint_ref,
+        "modelCardRef": model_card["id"],
+        "factsheetRef": factsheet["id"],
+        "evaluationBundleRefs": [evaluation["id"]],
+        "usePolicyRef": use_policy_ref,
+        "lineageRefs": [data_product["id"], spine["annotationSet"]["id"], spine["queryRun"]["queryRunId"]],
+        "evidenceRefs": ["urn:srcos:evidence:community_truth_demo_model_eval", "urn:srcos:evidence:community_truth_demo_factsheet"],
+        "promotionGate": {"state": "needs-review", "workflowRef": "urn:srcos:workflow:model-review-demo"},
+    }
+    records = platform_record_set([
+        {
+            "apiVersion": "prophet.socioprophet.dev/v1",
+            "kind": "PlatformAssetRecord",
+            "assetId": entry["id"],
+            "assetKind": "model-zoo-entry",
+            "name": entry["name"],
+            "version": "0.1.0",
+            "sourceApiVersion": "studio.socioprophet.dev/v1",
+            "sourceKind": "ModelZooEntry",
+            "producerRepo": "SocioProphet/prophet-platform",
+            "policyRef": use_policy["policyRef"],
+            "evidenceCorrelationId": "urn:srcos:evidence:community_truth_demo_model_eval",
+            "promotionChannel": "lattice-data-governai-demo",
+            "compatibilitySurfaces": ["lattice-studio", "model-zoo", "sherlock-search", "slash-topics", "policy-fabric", "agentplane"],
+        },
+        {
+            "apiVersion": "prophet.socioprophet.dev/v1",
+            "kind": "PlatformAssetRecord",
+            "assetId": endpoint_ref,
+            "assetKind": "model-endpoint",
+            "name": "Community Truth Demo Candidate Endpoint",
+            "version": "0.1.0",
+            "sourceApiVersion": "studio.socioprophet.dev/v1",
+            "sourceKind": "ModelEndpoint",
+            "producerRepo": "SocioProphet/prophet-platform",
+            "policyRef": endpoint["policyRef"],
+            "evidenceCorrelationId": "urn:srcos:evidence:community_truth_demo_model_endpoint",
+            "promotionChannel": "lattice-data-governai-demo",
+            "compatibilitySurfaces": ["model-zoo", "ray-serve", "kserve", "seldon-core", "policy-fabric"],
+        },
+    ])
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "LatticeModelZooFixture",
+        "entry": entry,
+        "modelCard": model_card,
+        "runtimeProfile": runtime_profile,
+        "endpoint": endpoint,
+        "usePolicy": use_policy,
+        "evaluationBundle": evaluation,
+        "factsheet": factsheet,
+        "platformRecords": records,
+    }

--- a/apps/lattice-studio/tests/test_model_zoo.py
+++ b/apps/lattice-studio/tests/test_model_zoo.py
@@ -1,0 +1,56 @@
+from lattice_studio.model_zoo import demo_model_zoo_entry
+
+
+def test_model_zoo_fixture_emits_required_product_objects() -> None:
+    fixture = demo_model_zoo_entry()
+
+    assert fixture["kind"] == "LatticeModelZooFixture"
+    assert fixture["entry"]["kind"] == "ModelZooEntry"
+    assert fixture["modelCard"]["kind"] == "ModelCard"
+    assert fixture["runtimeProfile"]["kind"] == "ModelRuntimeProfile"
+    assert fixture["endpoint"]["kind"] == "ModelEndpoint"
+    assert fixture["usePolicy"]["kind"] == "ModelUsePolicy"
+    assert fixture["evaluationBundle"]["kind"] == "EvaluationBundle"
+    assert fixture["factsheet"]["kind"] == "Factsheet"
+
+
+def test_model_zoo_fixture_preserves_lineage_runtime_policy_and_eval_refs() -> None:
+    fixture = demo_model_zoo_entry()
+    entry = fixture["entry"]
+    model_card = fixture["modelCard"]
+    runtime_profile = fixture["runtimeProfile"]
+    endpoint = fixture["endpoint"]
+    use_policy = fixture["usePolicy"]
+    evaluation = fixture["evaluationBundle"]
+    factsheet = fixture["factsheet"]
+
+    assert entry["modelRef"] == factsheet["subjectRef"]
+    assert entry["modelCardRef"] == model_card["id"]
+    assert entry["runtimeProfileRef"] == runtime_profile["id"]
+    assert entry["endpointRef"] == endpoint["id"]
+    assert entry["usePolicyRef"] == use_policy["id"]
+    assert entry["factsheetRef"] == factsheet["id"]
+    assert entry["evaluationBundleRefs"] == [evaluation["id"]]
+    assert "urn:srcos:data-product:community_truth_demo" in entry["dataProductRefs"]
+    assert runtime_profile["runtimeAssetRef"] == "runtime-asset:prophet-python-ml:0.1.0"
+    assert endpoint["servingBackend"] == "ray-serve"
+    assert endpoint["state"] == "candidate-dry-run"
+    assert "production-decisioning" in use_policy["forbiddenUses"]
+    assert "promotion" in use_policy["requiresApprovalFor"]
+
+
+def test_model_zoo_fixture_emits_platform_records_for_search_and_governance() -> None:
+    records = demo_model_zoo_entry()["platformRecords"]
+
+    assert records["kind"] == "PlatformAssetRecordSet"
+    kinds = {record["assetKind"] for record in records["records"]}
+    assert kinds == {"model-zoo-entry", "model-endpoint"}
+    for record in records["records"]:
+        assert record["producerRepo"] == "SocioProphet/prophet-platform"
+        assert record["promotionChannel"] == "lattice-data-governai-demo"
+        assert record["policyRef"]
+        assert record["evidenceCorrelationId"]
+    model_record = next(record for record in records["records"] if record["assetKind"] == "model-zoo-entry")
+    assert "sherlock-search" in model_record["compatibilitySurfaces"]
+    assert "policy-fabric" in model_record["compatibilitySurfaces"]
+    assert "agentplane" in model_record["compatibilitySurfaces"]


### PR DESCRIPTION
## Summary

Adds a governed Model Zoo product-surface fixture for Lattice Studio/Data/GovernAI.

## Adds

- `apps/lattice-studio/src/lattice_studio/model_zoo.py`
- `apps/lattice-studio/tests/test_model_zoo.py`

## Coverage

Creates deterministic fixture objects for ModelZooEntry, ModelCard, ModelRuntimeProfile, ModelEndpoint, ModelUsePolicy, EvaluationBundle, Factsheet, and PlatformAssetRecord output.

## Scope discipline

This is a product-surface fixture only. It does not implement serving infrastructure and does not redefine canonical schemas.

## Validation

Expected:

```bash
cd apps/lattice-studio
python -m pytest
```

## Tracking

Closes #293.
Advances #291.