### PR TITLE
Add Lattice active metadata fixture

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/active_metadata.py
+++ b/apps/lattice-studio/src/lattice_studio/active_metadata.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from .annotation_training import demo_annotation_training_loop
 from .model_zoo import demo_model_zoo_entry
 from .platform_records import platform_record_set
 from .product_spine import demo_product_spine
@@ -19,12 +20,14 @@ from .publication_review import demo_publication_review_package
 
 def demo_active_metadata_spine() -> dict[str, Any]:
     product_spine = demo_product_spine()
+    annotation_training = demo_annotation_training_loop()
     model_zoo = demo_model_zoo_entry()
     prompt_rag = demo_prompt_rag_eval_lab()
     publication_review = demo_publication_review_package()
 
     source_sets = [
         ("product-spine", product_spine["platformRecords"]["records"]),
+        ("annotation-training", annotation_training["platformRecords"]["records"]),
         ("model-zoo", model_zoo["platformRecords"]["records"]),
         ("prompt-rag-eval", prompt_rag["platformRecords"]["records"]),
         ("publication-review", publication_review["platformRecords"]["records"]),

--- a/apps/lattice-studio/src/lattice_studio/active_metadata.py
+++ b/apps/lattice-studio/src/lattice_studio/active_metadata.py
@@ -1,0 +1,97 @@
+"""Lattice active metadata ingestion fixture.
+
+Active metadata is emitted by product/execution events, not only hand-authored
+catalog records. This fixture normalizes records from the current Lattice
+Studio/Data/GovernAI product surfaces into ingestion events and derived
+PlatformAssetRecord enrichment sidecars.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .model_zoo import demo_model_zoo_entry
+from .platform_records import platform_record_set
+from .product_spine import demo_product_spine
+from .prompt_rag_eval import demo_prompt_rag_eval_lab
+from .publication_review import demo_publication_review_package
+
+
+def demo_active_metadata_spine() -> dict[str, Any]:
+    product_spine = demo_product_spine()
+    model_zoo = demo_model_zoo_entry()
+    prompt_rag = demo_prompt_rag_eval_lab()
+    publication_review = demo_publication_review_package()
+
+    source_sets = [
+        ("product-spine", product_spine["platformRecords"]["records"]),
+        ("model-zoo", model_zoo["platformRecords"]["records"]),
+        ("prompt-rag-eval", prompt_rag["platformRecords"]["records"]),
+        ("publication-review", publication_review["platformRecords"]["records"]),
+    ]
+    events: list[dict[str, Any]] = []
+    enrichments: list[dict[str, Any]] = []
+    for source_surface, records in source_sets:
+        for record in records:
+            event = _event_from_record(source_surface, record)
+            events.append(event)
+            enrichments.append(_enrichment_from_event(event))
+
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "LatticeActiveMetadataFixture",
+        "sourceSurfaces": [name for name, _ in source_sets],
+        "events": events,
+        "enrichmentRecords": platform_record_set(enrichments),
+        "routing": {
+            "searchConsumer": "SocioProphet/sherlock-search#30",
+            "topicConsumer": "SocioProphet/slash-topics#23",
+            "semanticMembraneConsumer": "SocioProphet/new-hope#7",
+            "policyConsumer": "SocioProphet/policy-fabric#39",
+            "topologyConsumer": "SocioProphet/sociosphere#238",
+        },
+        "safety": {"fixtureOnly": True, "network": "none", "secrets": "none", "hostMutation": False},
+    }
+
+
+def _event_from_record(source_surface: str, record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "ActiveMetadataEvent",
+        "eventId": f"active-metadata:{source_surface}:{record['assetKind']}:{_safe(record['assetId'])}",
+        "sourceSurface": source_surface,
+        "sourceRepo": record["producerRepo"],
+        "assetId": record["assetId"],
+        "assetKind": record["assetKind"],
+        "sourceKind": record["sourceKind"],
+        "policyRef": record.get("policyRef"),
+        "evidenceCorrelationId": record.get("evidenceCorrelationId"),
+        "promotionChannel": record.get("promotionChannel"),
+        "compatibilitySurfaces": list(record.get("compatibilitySurfaces", [])),
+        "emittedBy": "lattice-studio-active-metadata-fixture",
+        "emittedAt": "2026-05-01T21:30:00Z",
+    }
+
+
+def _enrichment_from_event(event: dict[str, Any]) -> dict[str, Any]:
+    surfaces = set(event["compatibilitySurfaces"])
+    surfaces.update({"active-metadata", "sherlock-search", "slash-topics", "policy-fabric"})
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecord",
+        "assetId": event["assetId"],
+        "assetKind": f"active-metadata-{event['assetKind']}",
+        "name": f"Active metadata for {event['assetKind']}",
+        "version": "0.1.0",
+        "sourceApiVersion": event["apiVersion"],
+        "sourceKind": "ActiveMetadataEvent",
+        "producerRepo": "SocioProphet/prophet-platform",
+        "policyRef": event["policyRef"],
+        "evidenceCorrelationId": event["evidenceCorrelationId"],
+        "promotionChannel": event["promotionChannel"],
+        "compatibilitySurfaces": sorted(surfaces),
+    }
+
+
+def _safe(value: str) -> str:
+    return value.replace(":", "-").replace("/", "-")

--- a/apps/lattice-studio/tests/test_active_metadata.py
+++ b/apps/lattice-studio/tests/test_active_metadata.py
@@ -7,6 +7,7 @@ def test_active_metadata_spine_emits_events_from_all_product_surfaces() -> None:
     assert fixture["kind"] == "LatticeActiveMetadataFixture"
     assert set(fixture["sourceSurfaces"]) == {
         "product-spine",
+        "annotation-training",
         "model-zoo",
         "prompt-rag-eval",
         "publication-review",
@@ -34,6 +35,9 @@ def test_active_metadata_spine_covers_core_asset_kinds() -> None:
     assert "prompt-asset" in kinds
     assert "research-package" in kinds
     assert "reproduction-attempt" in kinds
+    assert "training-dataset" in kinds
+    assert "evaluation-dataset" in kinds
+    assert "annotation-reliability-score" in kinds
 
 
 def test_active_metadata_enrichment_records_route_to_downstream_consumers() -> None:

--- a/apps/lattice-studio/tests/test_active_metadata.py
+++ b/apps/lattice-studio/tests/test_active_metadata.py
@@ -1,0 +1,71 @@
+from lattice_studio.active_metadata import demo_active_metadata_spine
+
+
+def test_active_metadata_spine_emits_events_from_all_product_surfaces() -> None:
+    fixture = demo_active_metadata_spine()
+
+    assert fixture["kind"] == "LatticeActiveMetadataFixture"
+    assert set(fixture["sourceSurfaces"]) == {
+        "product-spine",
+        "model-zoo",
+        "prompt-rag-eval",
+        "publication-review",
+    }
+    events = fixture["events"]
+    assert events
+    assert {event["sourceSurface"] for event in events} == set(fixture["sourceSurfaces"])
+    for event in events:
+        assert event["kind"] == "ActiveMetadataEvent"
+        assert event["assetId"]
+        assert event["assetKind"]
+        assert event["sourceKind"]
+        assert event["sourceRepo"] == "SocioProphet/prophet-platform"
+        assert event["evidenceCorrelationId"]
+        assert event["promotionChannel"] == "lattice-data-governai-demo"
+
+
+def test_active_metadata_spine_covers_core_asset_kinds() -> None:
+    kinds = {event["assetKind"] for event in demo_active_metadata_spine()["events"]}
+
+    assert "data-product" in kinds
+    assert "publication-artifact" in kinds
+    assert "model-zoo-entry" in kinds
+    assert "rag-pipeline" in kinds
+    assert "prompt-asset" in kinds
+    assert "research-package" in kinds
+    assert "reproduction-attempt" in kinds
+
+
+def test_active_metadata_enrichment_records_route_to_downstream_consumers() -> None:
+    fixture = demo_active_metadata_spine()
+    records = fixture["enrichmentRecords"]
+
+    assert records["kind"] == "PlatformAssetRecordSet"
+    assert len(records["records"]) == len(fixture["events"])
+    for record in records["records"]:
+        assert record["sourceKind"] == "ActiveMetadataEvent"
+        assert record["producerRepo"] == "SocioProphet/prophet-platform"
+        assert record["assetKind"].startswith("active-metadata-")
+        assert "active-metadata" in record["compatibilitySurfaces"]
+        assert "sherlock-search" in record["compatibilitySurfaces"]
+        assert "slash-topics" in record["compatibilitySurfaces"]
+        assert "policy-fabric" in record["compatibilitySurfaces"]
+
+
+def test_active_metadata_routing_points_to_estate_consumers() -> None:
+    routing = demo_active_metadata_spine()["routing"]
+
+    assert routing["searchConsumer"] == "SocioProphet/sherlock-search#30"
+    assert routing["topicConsumer"] == "SocioProphet/slash-topics#23"
+    assert routing["semanticMembraneConsumer"] == "SocioProphet/new-hope#7"
+    assert routing["policyConsumer"] == "SocioProphet/policy-fabric#39"
+    assert routing["topologyConsumer"] == "SocioProphet/sociosphere#238"
+
+
+def test_active_metadata_safety_is_fixture_only() -> None:
+    safety = demo_active_metadata_spine()["safety"]
+
+    assert safety["fixtureOnly"] is True
+    assert safety["network"] == "none"
+    assert safety["secrets"] == "none"
+    assert safety["hostMutation"] is False


### PR DESCRIPTION
## Summary

Adds an active metadata ingestion fixture for Lattice Studio/Data/GovernAI.

## Adds

- `apps/lattice-studio/src/lattice_studio/active_metadata.py`
- `apps/lattice-studio/tests/test_active_metadata.py`

## Coverage

Emits ActiveMetadataEvent and enrichment PlatformAssetRecord outputs from product spine, annotation-to-training, Model Zoo, Prompt/RAG/Evaluation Lab, and publication/review surfaces.

## Routing

Routes enrichment to Sherlock Search, Slash Topics, New Hope, Policy Fabric, and SocioSphere consumers without redefining asset identity.

## Scope discipline

Fixture-only. No network, no secrets, no host mutation.

## Validation

Expected:

```bash
cd apps/lattice-studio
python -m pytest
```

## Tracking

Closes #297.
Advances #291.