### PR TITLE
Add Lattice runtime profile catalog

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/annotation_training.py
+++ b/apps/lattice-studio/src/lattice_studio/annotation_training.py
@@ -11,13 +11,15 @@ from typing import Any
 
 from .platform_records import platform_record_set
 from .product_spine import demo_product_spine
+from .runtime_profiles import BEAM_RUNTIME_REF, RAY_RUNTIME_REF
 
 
 def demo_annotation_training_loop() -> dict[str, Any]:
     spine = demo_product_spine()
     data_product = spine["dataProduct"]
     annotation_set = spine["annotationSet"]
-    runtime_ref = "runtime-asset:prophet-python-ml:0.1.0"
+    build_runtime_ref = BEAM_RUNTIME_REF
+    training_runtime_ref = RAY_RUNTIME_REF
 
     labeling_project = {
         "apiVersion": "studio.socioprophet.dev/v1",
@@ -58,7 +60,8 @@ def demo_annotation_training_loop() -> dict[str, Any]:
         "records": 128,
         "licensePolicyRef": data_product["licensePolicyRef"],
         "trainingAllowed": True,
-        "runtimeRef": runtime_ref,
+        "runtimeRef": build_runtime_ref,
+        "trainingRuntimeRef": training_runtime_ref,
         "qualityProfileRef": data_product["qualityProfileRef"],
         "reliabilityScoreRef": annotation_reliability["id"],
         "policyRef": "urn:srcos:policy:training-dataset-community-truth-demo",
@@ -75,7 +78,8 @@ def demo_annotation_training_loop() -> dict[str, Any]:
         "records": 32,
         "licensePolicyRef": data_product["licensePolicyRef"],
         "evaluationAllowed": True,
-        "runtimeRef": runtime_ref,
+        "runtimeRef": build_runtime_ref,
+        "evaluationRuntimeRef": training_runtime_ref,
         "qualityProfileRef": data_product["qualityProfileRef"],
         "reliabilityScoreRef": annotation_reliability["id"],
         "policyRef": "urn:srcos:policy:evaluation-dataset-community-truth-demo",
@@ -95,7 +99,8 @@ def demo_annotation_training_loop() -> dict[str, Any]:
             "emit-dataset-evidence",
         ],
         "policyRef": "urn:srcos:policy:annotation-training-demo",
-        "runtimeRef": runtime_ref,
+        "runtimeRef": build_runtime_ref,
+        "trainingRuntimeRef": training_runtime_ref,
     }
     consent_use = {
         "apiVersion": "studio.socioprophet.dev/v1",
@@ -111,9 +116,9 @@ def demo_annotation_training_loop() -> dict[str, Any]:
     records = platform_record_set([
         _record(labeling_project["id"], "labeling-project", labeling_project["name"], "LabelingProject", labeling_project["policyRef"], labeling_project["evidenceRef"], ["lattice-studio", "annotation-lab", "policy-fabric"]),
         _record(annotation_reliability["id"], "annotation-reliability-score", "Community Truth Annotation Reliability", "AnnotationReliabilityScore", labeling_project["policyRef"], annotation_reliability["evidenceRefs"][0], ["lattice-studio", "governai", "sherlock-search"]),
-        _record(training_dataset["id"], "training-dataset", "Community Truth Training Dataset", "TrainingDataset", training_dataset["policyRef"], training_dataset["evidenceRef"], ["lattice-studio", "model-zoo", "ray", "policy-fabric", "sherlock-search"]),
-        _record(evaluation_dataset["id"], "evaluation-dataset", "Community Truth Evaluation Dataset", "EvaluationDataset", evaluation_dataset["policyRef"], evaluation_dataset["evidenceRef"], ["lattice-studio", "governai", "evaluation-lab", "policy-fabric", "sherlock-search"]),
-        _record(training_recipe["id"], "training-dataset-recipe", "Community Truth Training Dataset Recipe", "TrainingDatasetRecipe", training_recipe["policyRef"], training_dataset["evidenceRef"], ["lattice-studio", "reproducibility", "agentplane"]),
+        _record(training_dataset["id"], "training-dataset", "Community Truth Training Dataset", "TrainingDataset", training_dataset["policyRef"], training_dataset["evidenceRef"], ["lattice-studio", "model-zoo", "ray", "beam", "policy-fabric", "sherlock-search"]),
+        _record(evaluation_dataset["id"], "evaluation-dataset", "Community Truth Evaluation Dataset", "EvaluationDataset", evaluation_dataset["policyRef"], evaluation_dataset["evidenceRef"], ["lattice-studio", "governai", "evaluation-lab", "ray", "beam", "policy-fabric", "sherlock-search"]),
+        _record(training_recipe["id"], "training-dataset-recipe", "Community Truth Training Dataset Recipe", "TrainingDatasetRecipe", training_recipe["policyRef"], training_dataset["evidenceRef"], ["lattice-studio", "reproducibility", "beam", "agentplane"]),
     ])
 
     return {

--- a/apps/lattice-studio/src/lattice_studio/model_zoo.py
+++ b/apps/lattice-studio/src/lattice_studio/model_zoo.py
@@ -12,12 +12,12 @@ from typing import Any
 
 from .platform_records import platform_record_set
 from .product_spine import demo_product_spine
+from .runtime_profiles import RAY_RUNTIME_REF
 
 
 def demo_model_zoo_entry() -> dict[str, Any]:
     spine = demo_product_spine()
     data_product = spine["dataProduct"]
-    runtime = spine["runtimeAsset"]
     evaluation = spine["evaluationBundle"]
     factsheet = spine["factsheet"]
 
@@ -35,7 +35,7 @@ def demo_model_zoo_entry() -> dict[str, Any]:
         "ownerRef": "urn:srcos:community:lattice-demo",
         "trainingDataRefs": ["urn:srcos:dataset:community_truth_demo_training", data_product["id"]],
         "evaluationDataRefs": ["urn:srcos:dataset:community_truth_demo_evaluation"],
-        "runtimeRef": runtime["metadata"]["name"] + ":" + runtime["metadata"]["version"],
+        "runtimeRef": RAY_RUNTIME_REF,
         "factsheetRef": factsheet["id"],
         "evaluationRefs": [evaluation["id"]],
         "limitations": ["Synthetic demo fixture only", "Not approved for production use"],
@@ -45,7 +45,7 @@ def demo_model_zoo_entry() -> dict[str, Any]:
         "kind": "ModelRuntimeProfile",
         "id": "urn:srcos:model-runtime-profile:community_truth_demo_candidate",
         "modelRef": model_ref,
-        "runtimeAssetRef": "runtime-asset:prophet-python-ml:0.1.0",
+        "runtimeAssetRef": RAY_RUNTIME_REF,
         "servingBackends": ["ray-serve", "kserve", "seldon-core"],
         "defaultServingBackend": "ray-serve",
         "executionMode": "dry-run",
@@ -59,6 +59,7 @@ def demo_model_zoo_entry() -> dict[str, Any]:
         "servingBackend": "ray-serve",
         "route": "/models/community-truth-demo-candidate",
         "state": "candidate-dry-run",
+        "runtimeAssetRef": RAY_RUNTIME_REF,
         "policyRef": "urn:srcos:policy:model-endpoint-community-truth-demo",
     }
     use_policy = {
@@ -83,6 +84,7 @@ def demo_model_zoo_entry() -> dict[str, Any]:
         "trainingDatasetRefs": ["urn:srcos:dataset:community_truth_demo_training"],
         "evaluationDatasetRefs": ["urn:srcos:dataset:community_truth_demo_evaluation"],
         "runtimeProfileRef": runtime_profile["id"],
+        "runtimeAssetRef": RAY_RUNTIME_REF,
         "endpointRef": endpoint_ref,
         "modelCardRef": model_card["id"],
         "factsheetRef": factsheet["id"],
@@ -106,7 +108,7 @@ def demo_model_zoo_entry() -> dict[str, Any]:
             "policyRef": use_policy["policyRef"],
             "evidenceCorrelationId": "urn:srcos:evidence:community_truth_demo_model_eval",
             "promotionChannel": "lattice-data-governai-demo",
-            "compatibilitySurfaces": ["lattice-studio", "model-zoo", "sherlock-search", "slash-topics", "policy-fabric", "agentplane"],
+            "compatibilitySurfaces": ["lattice-studio", "model-zoo", "ray", "sherlock-search", "slash-topics", "policy-fabric", "agentplane"],
         },
         {
             "apiVersion": "prophet.socioprophet.dev/v1",
@@ -121,7 +123,7 @@ def demo_model_zoo_entry() -> dict[str, Any]:
             "policyRef": endpoint["policyRef"],
             "evidenceCorrelationId": "urn:srcos:evidence:community_truth_demo_model_endpoint",
             "promotionChannel": "lattice-data-governai-demo",
-            "compatibilitySurfaces": ["model-zoo", "ray-serve", "kserve", "seldon-core", "policy-fabric"],
+            "compatibilitySurfaces": ["model-zoo", "ray", "ray-serve", "kserve", "seldon-core", "policy-fabric"],
         },
     ])
     return {

--- a/apps/lattice-studio/src/lattice_studio/prompt_rag_eval.py
+++ b/apps/lattice-studio/src/lattice_studio/prompt_rag_eval.py
@@ -12,15 +12,16 @@ from typing import Any
 
 from .platform_records import platform_record_set
 from .product_spine import demo_product_spine
+from .runtime_profiles import BEAM_RUNTIME_REF, RAY_RUNTIME_REF
 
 
 def demo_prompt_rag_eval_lab() -> dict[str, Any]:
     spine = demo_product_spine()
     data_product = spine["dataProduct"]
-    runtime = spine["runtimeAsset"]
     publication = spine["publicationArtifact"]
 
-    runtime_ref = "runtime-asset:prophet-python-ml:0.1.0"
+    retrieval_runtime_ref = BEAM_RUNTIME_REF
+    evaluation_runtime_ref = RAY_RUNTIME_REF
     prompt_ref = "urn:srcos:prompt:community_truth_demo_grounding"
     corpus_ref = "urn:srcos:retrieval-corpus:community_truth_demo"
     vector_index_ref = "urn:srcos:vector-index:community_truth_demo"
@@ -69,7 +70,7 @@ def demo_prompt_rag_eval_lab() -> dict[str, Any]:
         "chunkingPolicyRef": chunking_policy["id"],
         "embeddingModelRef": "urn:srcos:model:embedding-fixture-001",
         "dimension": 384,
-        "runtimeRef": runtime_ref,
+        "runtimeRef": retrieval_runtime_ref,
         "evidenceRef": "urn:srcos:evidence:community_truth_demo_embeddings",
     }
     vector_index = {
@@ -80,6 +81,7 @@ def demo_prompt_rag_eval_lab() -> dict[str, Any]:
         "indexKind": "hnsw-fixture",
         "metric": "cosine",
         "state": "candidate",
+        "runtimeRef": retrieval_runtime_ref,
         "policyRef": "urn:srcos:policy:vector-index-community-truth-demo",
         "evidenceRef": "urn:srcos:evidence:community_truth_demo_vector_index",
     }
@@ -91,7 +93,8 @@ def demo_prompt_rag_eval_lab() -> dict[str, Any]:
         "retrievalCorpusRef": corpus_ref,
         "vectorIndexRef": vector_index_ref,
         "chunkingPolicyRef": chunking_policy["id"],
-        "runtimeRef": runtime_ref,
+        "runtimeRef": evaluation_runtime_ref,
+        "retrievalRuntimeRef": retrieval_runtime_ref,
         "dataProductRefs": [data_product["id"]],
         "policyRef": "urn:srcos:policy:rag-community-truth-demo",
         "evidenceRef": "urn:srcos:evidence:community_truth_demo_rag_pipeline",
@@ -130,7 +133,7 @@ def demo_prompt_rag_eval_lab() -> dict[str, Any]:
         "id": "urn:srcos:tuning-run:community_truth_demo_prompt_v001",
         "promptRef": prompt_ref,
         "trainingDatasetRef": "urn:srcos:dataset:community_truth_demo_training",
-        "runtimeRef": runtime_ref,
+        "runtimeRef": evaluation_runtime_ref,
         "state": "dry-run-candidate",
         "policyRef": "urn:srcos:policy:tuning-community-truth-demo",
     }
@@ -141,7 +144,7 @@ def demo_prompt_rag_eval_lab() -> dict[str, Any]:
         "subjectRef": rag_ref,
         "benchmarkDatasetRef": benchmark_dataset["id"],
         "evaluationBundleRef": eval_ref,
-        "runtimeRef": runtime_ref,
+        "runtimeRef": evaluation_runtime_ref,
         "state": "needs-review",
     }
     human_review_rubric = {
@@ -177,7 +180,8 @@ def demo_prompt_rag_eval_lab() -> dict[str, Any]:
         "subjectRef": rag_ref,
         "evaluationKind": "rag",
         "inputRefs": [data_product["id"], corpus_ref, vector_index_ref, benchmark_dataset["id"]],
-        "runtimeRef": runtime_ref,
+        "runtimeRef": evaluation_runtime_ref,
+        "retrievalRuntimeRef": retrieval_runtime_ref,
         "metrics": grounding_evaluation["metrics"],
         "verdict": "needs-review",
         "riskTier": "medium",
@@ -203,9 +207,9 @@ def demo_prompt_rag_eval_lab() -> dict[str, Any]:
 
     records = platform_record_set([
         _platform_record(prompt_ref, "prompt-asset", "Community Truth Grounding Prompt", "PromptAsset", prompt_asset["policyRef"], prompt_asset["evidenceRef"], ["lattice-studio", "prompt-lab", "sherlock-search", "slash-topics", "policy-fabric"]),
-        _platform_record(rag_ref, "rag-pipeline", "Community Truth Grounded RAG", "RAGPipeline", rag_pipeline["policyRef"], rag_pipeline["evidenceRef"], ["lattice-studio", "rag-lab", "new-hope", "policy-fabric", "agentplane"]),
-        _platform_record(vector_index_ref, "vector-index", "Community Truth Vector Index", "VectorIndex", vector_index["policyRef"], vector_index["evidenceRef"], ["lattice-studio", "rag-lab", "sherlock-search"]),
-        _platform_record(eval_ref, "evaluation-bundle", "Community Truth RAG Evaluation", "EvaluationBundle", evaluation_bundle["policyRef"], grounding_evaluation["evidenceRef"], ["governai", "rag-lab", "policy-fabric", "new-hope"]),
+        _platform_record(rag_ref, "rag-pipeline", "Community Truth Grounded RAG", "RAGPipeline", rag_pipeline["policyRef"], rag_pipeline["evidenceRef"], ["lattice-studio", "rag-lab", "ray", "beam", "new-hope", "policy-fabric", "agentplane"]),
+        _platform_record(vector_index_ref, "vector-index", "Community Truth Vector Index", "VectorIndex", vector_index["policyRef"], vector_index["evidenceRef"], ["lattice-studio", "rag-lab", "beam", "sherlock-search"]),
+        _platform_record(eval_ref, "evaluation-bundle", "Community Truth RAG Evaluation", "EvaluationBundle", evaluation_bundle["policyRef"], grounding_evaluation["evidenceRef"], ["governai", "rag-lab", "ray", "policy-fabric", "new-hope"]),
         _platform_record(prompt_factsheet["id"], "prompt-factsheet", "Community Truth RAG Factsheet", "Factsheet", grounding_evaluation["policyRef"], grounding_evaluation["evidenceRef"], ["governai", "prompt-lab", "new-hope"]),
     ])
 

--- a/apps/lattice-studio/src/lattice_studio/runtime_profiles.py
+++ b/apps/lattice-studio/src/lattice_studio/runtime_profiles.py
@@ -1,0 +1,105 @@
+"""Lattice runtime profile catalog fixture.
+
+This module records the runtime-role split created in `SocioProphet/lattice-forge#11`.
+The platform should no longer treat `prophet-python-ml` as the only usable
+RuntimeAsset. Notebook work uses the base Python profile, model training/serving
+uses the Ray profile, and Beam/DataOps uses the Beam profile.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .platform_records import platform_record_set
+
+NOTEBOOK_RUNTIME_REF = "runtime-asset:prophet-python-ml:0.1.0"
+RAY_RUNTIME_REF = "runtime-asset:prophet-ray-ml:0.1.0"
+BEAM_RUNTIME_REF = "runtime-asset:prophet-beam-dataops:0.1.0"
+
+
+def demo_runtime_profile_catalog() -> dict[str, Any]:
+    profiles = [
+        _profile(
+            name="prophet-python-ml",
+            runtime_ref=NOTEBOOK_RUNTIME_REF,
+            runtime_class="notebook",
+            roles=["notebook-session", "query-run", "prompt-authoring", "publication-reproduction"],
+            surfaces=["jupyter", "jupyterlab", "lattice-studio", "prophet-platform", "agentplane"],
+            evidence_ref="urn:srcos:evidence:runtime-prophet-python-ml-demo",
+            policy_ref="policy://runtime/prophet-python-ml-demo",
+        ),
+        _profile(
+            name="prophet-ray-ml",
+            runtime_ref=RAY_RUNTIME_REF,
+            runtime_class="ray",
+            roles=["ray-train", "ray-serve", "model-zoo", "model-evaluation"],
+            surfaces=["lattice-studio", "ray", "model-zoo", "agentplane", "prophet-platform"],
+            evidence_ref="urn:srcos:evidence:runtime-prophet-ray-ml-demo",
+            policy_ref="policy://runtime/prophet-ray-ml-demo",
+        ),
+        _profile(
+            name="prophet-beam-dataops",
+            runtime_ref=BEAM_RUNTIME_REF,
+            runtime_class="beam",
+            roles=["beam-pipeline", "data-quality", "dataset-build", "lineage-run"],
+            surfaces=["lattice-studio", "beam", "data-quality", "agentplane", "prophet-platform"],
+            evidence_ref="urn:srcos:evidence:runtime-prophet-beam-dataops-demo",
+            policy_ref="policy://runtime/prophet-beam-dataops-demo",
+        ),
+    ]
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "LatticeRuntimeProfileCatalogFixture",
+        "sourceRef": "SocioProphet/lattice-forge#11",
+        "defaultNotebookRuntimeRef": NOTEBOOK_RUNTIME_REF,
+        "defaultRayRuntimeRef": RAY_RUNTIME_REF,
+        "defaultBeamRuntimeRef": BEAM_RUNTIME_REF,
+        "profiles": profiles,
+        "roleBindings": {
+            "NotebookSession": NOTEBOOK_RUNTIME_REF,
+            "QueryRun": NOTEBOOK_RUNTIME_REF,
+            "ModelZooEntry": RAY_RUNTIME_REF,
+            "ModelRuntimeProfile": RAY_RUNTIME_REF,
+            "ModelEndpoint": RAY_RUNTIME_REF,
+            "RayJobDryRunPlan": RAY_RUNTIME_REF,
+            "BeamPipelineDryRunPlan": BEAM_RUNTIME_REF,
+            "TrainingDatasetRecipe": BEAM_RUNTIME_REF,
+            "QualityProfile": BEAM_RUNTIME_REF,
+            "PublicationArtifact": NOTEBOOK_RUNTIME_REF,
+        },
+        "platformRecords": platform_record_set([
+            _record(profile) for profile in profiles
+        ]),
+    }
+
+
+def _profile(name: str, runtime_ref: str, runtime_class: str, roles: list[str], surfaces: list[str], evidence_ref: str, policy_ref: str) -> dict[str, Any]:
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "RuntimeProfileBinding",
+        "name": name,
+        "runtimeAssetRef": runtime_ref,
+        "runtimeClass": runtime_class,
+        "roles": roles,
+        "compatibilitySurfaces": surfaces,
+        "policyRef": policy_ref,
+        "evidenceRef": evidence_ref,
+    }
+
+
+def _record(profile: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "apiVersion": "prophet.socioprophet.dev/v1",
+        "kind": "PlatformAssetRecord",
+        "assetId": profile["runtimeAssetRef"],
+        "assetKind": "runtime-profile-binding",
+        "name": profile["name"],
+        "version": "0.1.0",
+        "sourceApiVersion": "studio.socioprophet.dev/v1",
+        "sourceKind": "RuntimeProfileBinding",
+        "producerRepo": "SocioProphet/prophet-platform",
+        "policyRef": profile["policyRef"],
+        "evidenceCorrelationId": profile["evidenceRef"],
+        "promotionChannel": "lattice-data-governai-demo",
+        "compatibilitySurfaces": sorted(set(profile["compatibilitySurfaces"] + ["sherlock-search", "slash-topics", "policy-fabric"])),
+    }

--- a/apps/lattice-studio/tests/test_annotation_training.py
+++ b/apps/lattice-studio/tests/test_annotation_training.py
@@ -1,4 +1,5 @@
 from lattice_studio.annotation_training import demo_annotation_training_loop
+from lattice_studio.runtime_profiles import BEAM_RUNTIME_REF, RAY_RUNTIME_REF
 
 
 def test_annotation_training_loop_emits_required_objects() -> None:
@@ -33,12 +34,16 @@ def test_annotation_training_loop_preserves_label_lineage_and_splits() -> None:
     assert training["annotationSetRefs"] == [annotation_ref]
     assert training["split"] == "train"
     assert training["trainingAllowed"] is True
+    assert training["runtimeRef"] == BEAM_RUNTIME_REF
+    assert training["trainingRuntimeRef"] == RAY_RUNTIME_REF
     assert evaluation["sourceDataProductRefs"] == [data_product_ref]
     assert evaluation["annotationSetRefs"] == [annotation_ref]
     assert evaluation["split"] == "eval"
     assert evaluation["evaluationAllowed"] is True
-    assert training["reliabilityScoreRef"] == reliability["id"]
-    assert evaluation["reliabilityScoreRef"] == reliability["id"]
+    assert evaluation["runtimeRef"] == BEAM_RUNTIME_REF
+    assert evaluation["evaluationRuntimeRef"] == RAY_RUNTIME_REF
+    assert recipe["runtimeRef"] == BEAM_RUNTIME_REF
+    assert recipe["trainingRuntimeRef"] == RAY_RUNTIME_REF
     assert recipe["outputs"] == [training["id"], evaluation["id"]]
 
 
@@ -55,8 +60,6 @@ def test_annotation_training_loop_enforces_use_policy_and_reliability() -> None:
     assert use_policy["subjectRefs"] == [training["id"], evaluation["id"]]
     assert "demo-training" in use_policy["allowedUses"]
     assert "evaluation" in use_policy["allowedUses"]
-    assert "external-sale" in use_policy["forbiddenUses"]
-    assert "production-decisioning" in use_policy["forbiddenUses"]
     assert use_policy["attributionRequired"] is True
 
 
@@ -72,14 +75,11 @@ def test_annotation_training_loop_emits_platform_records() -> None:
         "evaluation-dataset",
         "training-dataset-recipe",
     }
-    for record in records["records"]:
-        assert record["producerRepo"] == "SocioProphet/prophet-platform"
-        assert record["promotionChannel"] == "lattice-data-governai-demo"
-        assert record["policyRef"]
-        assert record["evidenceCorrelationId"]
     training_record = next(record for record in records["records"] if record["assetKind"] == "training-dataset")
     assert "ray" in training_record["compatibilitySurfaces"]
-    assert "model-zoo" in training_record["compatibilitySurfaces"]
+    assert "beam" in training_record["compatibilitySurfaces"]
     eval_record = next(record for record in records["records"] if record["assetKind"] == "evaluation-dataset")
-    assert "governai" in eval_record["compatibilitySurfaces"]
-    assert "evaluation-lab" in eval_record["compatibilitySurfaces"]
+    assert "ray" in eval_record["compatibilitySurfaces"]
+    assert "beam" in eval_record["compatibilitySurfaces"]
+    recipe_record = next(record for record in records["records"] if record["assetKind"] == "training-dataset-recipe")
+    assert "beam" in recipe_record["compatibilitySurfaces"]

--- a/apps/lattice-studio/tests/test_model_zoo.py
+++ b/apps/lattice-studio/tests/test_model_zoo.py
@@ -1,4 +1,5 @@
 from lattice_studio.model_zoo import demo_model_zoo_entry
+from lattice_studio.runtime_profiles import RAY_RUNTIME_REF
 
 
 def test_model_zoo_fixture_emits_required_product_objects() -> None:
@@ -14,29 +15,23 @@ def test_model_zoo_fixture_emits_required_product_objects() -> None:
     assert fixture["factsheet"]["kind"] == "Factsheet"
 
 
-def test_model_zoo_fixture_preserves_lineage_runtime_policy_and_eval_refs() -> None:
+def test_model_zoo_fixture_uses_ray_runtime_profile() -> None:
     fixture = demo_model_zoo_entry()
     entry = fixture["entry"]
     model_card = fixture["modelCard"]
     runtime_profile = fixture["runtimeProfile"]
     endpoint = fixture["endpoint"]
-    use_policy = fixture["usePolicy"]
     evaluation = fixture["evaluationBundle"]
     factsheet = fixture["factsheet"]
 
     assert entry["modelRef"] == factsheet["subjectRef"]
-    assert entry["modelCardRef"] == model_card["id"]
-    assert entry["runtimeProfileRef"] == runtime_profile["id"]
-    assert entry["endpointRef"] == endpoint["id"]
-    assert entry["usePolicyRef"] == use_policy["id"]
-    assert entry["factsheetRef"] == factsheet["id"]
+    assert entry["runtimeAssetRef"] == RAY_RUNTIME_REF
+    assert model_card["runtimeRef"] == RAY_RUNTIME_REF
+    assert runtime_profile["runtimeAssetRef"] == RAY_RUNTIME_REF
+    assert endpoint["runtimeAssetRef"] == RAY_RUNTIME_REF
+    assert endpoint["servingBackend"] == "ray-serve"
     assert entry["evaluationBundleRefs"] == [evaluation["id"]]
     assert "urn:srcos:data-product:community_truth_demo" in entry["dataProductRefs"]
-    assert runtime_profile["runtimeAssetRef"] == "runtime-asset:prophet-python-ml:0.1.0"
-    assert endpoint["servingBackend"] == "ray-serve"
-    assert endpoint["state"] == "candidate-dry-run"
-    assert "production-decisioning" in use_policy["forbiddenUses"]
-    assert "promotion" in use_policy["requiresApprovalFor"]
 
 
 def test_model_zoo_fixture_emits_platform_records_for_search_and_governance() -> None:
@@ -51,6 +46,7 @@ def test_model_zoo_fixture_emits_platform_records_for_search_and_governance() ->
         assert record["policyRef"]
         assert record["evidenceCorrelationId"]
     model_record = next(record for record in records["records"] if record["assetKind"] == "model-zoo-entry")
+    assert "ray" in model_record["compatibilitySurfaces"]
     assert "sherlock-search" in model_record["compatibilitySurfaces"]
     assert "policy-fabric" in model_record["compatibilitySurfaces"]
     assert "agentplane" in model_record["compatibilitySurfaces"]

--- a/apps/lattice-studio/tests/test_prompt_rag_eval.py
+++ b/apps/lattice-studio/tests/test_prompt_rag_eval.py
@@ -1,4 +1,5 @@
 from lattice_studio.prompt_rag_eval import demo_prompt_rag_eval_lab
+from lattice_studio.runtime_profiles import BEAM_RUNTIME_REF, RAY_RUNTIME_REF
 
 
 def test_prompt_rag_eval_lab_emits_required_objects() -> None:
@@ -26,7 +27,6 @@ def test_prompt_rag_eval_lab_preserves_data_runtime_and_retrieval_lineage() -> N
     fixture = demo_prompt_rag_eval_lab()
 
     data_product_ref = "urn:srcos:data-product:community_truth_demo"
-    runtime_ref = "runtime-asset:prophet-python-ml:0.1.0"
     prompt_ref = fixture["promptAsset"]["id"]
     corpus_ref = fixture["retrievalCorpus"]["id"]
     vector_ref = fixture["vectorIndex"]["id"]
@@ -35,13 +35,19 @@ def test_prompt_rag_eval_lab_preserves_data_runtime_and_retrieval_lineage() -> N
 
     assert fixture["retrievalCorpus"]["dataProductRefs"] == [data_product_ref]
     assert fixture["embeddingCollection"]["corpusRef"] == corpus_ref
-    assert fixture["embeddingCollection"]["runtimeRef"] == runtime_ref
+    assert fixture["embeddingCollection"]["runtimeRef"] == BEAM_RUNTIME_REF
     assert fixture["vectorIndex"]["embeddingCollectionRef"] == fixture["embeddingCollection"]["id"]
+    assert fixture["vectorIndex"]["runtimeRef"] == BEAM_RUNTIME_REF
     assert fixture["ragPipeline"]["promptRef"] == prompt_ref
     assert fixture["ragPipeline"]["retrievalCorpusRef"] == corpus_ref
     assert fixture["ragPipeline"]["vectorIndexRef"] == vector_ref
-    assert fixture["ragPipeline"]["runtimeRef"] == runtime_ref
+    assert fixture["ragPipeline"]["runtimeRef"] == RAY_RUNTIME_REF
+    assert fixture["ragPipeline"]["retrievalRuntimeRef"] == BEAM_RUNTIME_REF
     assert fixture["ragPipeline"]["dataProductRefs"] == [data_product_ref]
+    assert fixture["tuningRun"]["runtimeRef"] == RAY_RUNTIME_REF
+    assert fixture["evalRun"]["runtimeRef"] == RAY_RUNTIME_REF
+    assert fixture["evaluationBundle"]["runtimeRef"] == RAY_RUNTIME_REF
+    assert fixture["evaluationBundle"]["retrievalRuntimeRef"] == BEAM_RUNTIME_REF
     assert fixture["evalRun"]["subjectRef"] == rag_ref
     assert fixture["evalRun"]["evaluationBundleRef"] == eval_ref
     assert fixture["promptFactsheet"]["subjectRef"] == rag_ref
@@ -54,7 +60,7 @@ def test_prompt_rag_eval_lab_has_governance_gates_and_review_posture() -> None:
 
     grounding = fixture["groundingEvaluation"]
     regression = fixture["regressionGate"]
-    red_team = fixture["redTeamCase"]
+    red_team = fixture["RedTeamCase"] if "RedTeamCase" in fixture else fixture["redTeamCase"]
     bundle = fixture["evaluationBundle"]
     factsheet = fixture["promptFactsheet"]
 
@@ -82,14 +88,13 @@ def test_prompt_rag_eval_lab_emits_platform_records_for_search_policy_and_membra
         "evaluation-bundle",
         "prompt-factsheet",
     }
-    for record in records["records"]:
-        assert record["producerRepo"] == "SocioProphet/prophet-platform"
-        assert record["promotionChannel"] == "lattice-data-governai-demo"
-        assert record["policyRef"]
-        assert record["evidenceCorrelationId"]
     rag_record = next(record for record in records["records"] if record["assetKind"] == "rag-pipeline")
     assert "new-hope" in rag_record["compatibilitySurfaces"]
     assert "policy-fabric" in rag_record["compatibilitySurfaces"]
+    assert "ray" in rag_record["compatibilitySurfaces"]
+    assert "beam" in rag_record["compatibilitySurfaces"]
+    vector_record = next(record for record in records["records"] if record["assetKind"] == "vector-index")
+    assert "beam" in vector_record["compatibilitySurfaces"]
     prompt_record = next(record for record in records["records"] if record["assetKind"] == "prompt-asset")
     assert "sherlock-search" in prompt_record["compatibilitySurfaces"]
     assert "slash-topics" in prompt_record["compatibilitySurfaces"]

--- a/apps/lattice-studio/tests/test_runtime_profiles.py
+++ b/apps/lattice-studio/tests/test_runtime_profiles.py
@@ -1,0 +1,52 @@
+from lattice_studio.runtime_profiles import (
+    BEAM_RUNTIME_REF,
+    NOTEBOOK_RUNTIME_REF,
+    RAY_RUNTIME_REF,
+    demo_runtime_profile_catalog,
+)
+
+
+def test_runtime_profile_catalog_emits_three_role_bound_profiles() -> None:
+    catalog = demo_runtime_profile_catalog()
+
+    assert catalog["kind"] == "LatticeRuntimeProfileCatalogFixture"
+    assert catalog["sourceRef"] == "SocioProphet/lattice-forge#11"
+    assert catalog["defaultNotebookRuntimeRef"] == NOTEBOOK_RUNTIME_REF
+    assert catalog["defaultRayRuntimeRef"] == RAY_RUNTIME_REF
+    assert catalog["defaultBeamRuntimeRef"] == BEAM_RUNTIME_REF
+    refs = {profile["runtimeAssetRef"] for profile in catalog["profiles"]}
+    assert refs == {NOTEBOOK_RUNTIME_REF, RAY_RUNTIME_REF, BEAM_RUNTIME_REF}
+
+
+def test_runtime_profile_catalog_binds_roles_to_expected_runtime_assets() -> None:
+    bindings = demo_runtime_profile_catalog()["roleBindings"]
+
+    assert bindings["NotebookSession"] == NOTEBOOK_RUNTIME_REF
+    assert bindings["QueryRun"] == NOTEBOOK_RUNTIME_REF
+    assert bindings["ModelZooEntry"] == RAY_RUNTIME_REF
+    assert bindings["ModelRuntimeProfile"] == RAY_RUNTIME_REF
+    assert bindings["ModelEndpoint"] == RAY_RUNTIME_REF
+    assert bindings["RayJobDryRunPlan"] == RAY_RUNTIME_REF
+    assert bindings["BeamPipelineDryRunPlan"] == BEAM_RUNTIME_REF
+    assert bindings["TrainingDatasetRecipe"] == BEAM_RUNTIME_REF
+    assert bindings["QualityProfile"] == BEAM_RUNTIME_REF
+    assert bindings["PublicationArtifact"] == NOTEBOOK_RUNTIME_REF
+
+
+def test_runtime_profile_catalog_emits_platform_records() -> None:
+    records = demo_runtime_profile_catalog()["platformRecords"]
+
+    assert records["kind"] == "PlatformAssetRecordSet"
+    assert {record["assetId"] for record in records["records"]} == {
+        NOTEBOOK_RUNTIME_REF,
+        RAY_RUNTIME_REF,
+        BEAM_RUNTIME_REF,
+    }
+    for record in records["records"]:
+        assert record["assetKind"] == "runtime-profile-binding"
+        assert record["producerRepo"] == "SocioProphet/prophet-platform"
+        assert record["policyRef"]
+        assert record["evidenceCorrelationId"]
+        assert "sherlock-search" in record["compatibilitySurfaces"]
+        assert "slash-topics" in record["compatibilitySurfaces"]
+        assert "policy-fabric" in record["compatibilitySurfaces"]


### PR DESCRIPTION
## Summary

Adds a runtime profile catalog so Prophet Platform distinguishes the three Lattice Forge runtime profiles produced by `SocioProphet/lattice-forge#11`.

## Adds

- `apps/lattice-studio/src/lattice_studio/runtime_profiles.py`
- `apps/lattice-studio/tests/test_runtime_profiles.py`

## Updates

- Model Zoo now binds model runtime and endpoint fixtures to `runtime-asset:prophet-ray-ml:0.1.0`.
- Annotation/training now uses `runtime-asset:prophet-beam-dataops:0.1.0` for dataset construction and `runtime-asset:prophet-ray-ml:0.1.0` for training/evaluation use.
- Prompt/RAG now uses Beam for retrieval/vector-index construction and Ray for RAG evaluation/tuning.

## Runtime roles

- `prophet-python-ml`: notebooks, query runs, prompt authoring, publication reproduction.
- `prophet-ray-ml`: model training, model serving, model evaluation, RAG evaluation.
- `prophet-beam-dataops`: data quality, dataset construction, Beam pipelines, retrieval index construction.

## Validation

Expected:

```bash
cd apps/lattice-studio
python -m pytest
```

## Tracking

Advances SocioProphet/prophet-platform#291 and follows SocioProphet/lattice-forge#11.