### PR TITLE
Add Lattice runtime release readiness fixture

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/runtime_release_readiness.py
+++ b/apps/lattice-studio/src/lattice_studio/runtime_release_readiness.py
@@ -1,0 +1,69 @@
+"""Runtime release readiness fixture for Lattice Studio.
+
+This fixture records the post-evidence runtime release posture created by
+Lattice Forge and Policy Fabric. It is additive to the original demo readiness
+report so older demo evidence remains stable while the release lane can move
+forward independently.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .runtime_profiles import BEAM_RUNTIME_REF, NOTEBOOK_RUNTIME_REF, RAY_RUNTIME_REF
+
+RUNTIME_RELEASE_MANIFEST_REF = "runtime-promotion-manifest:lattice-runtime-promotion-manifest:0.2.0"
+REQUIRED_RELEASE_REFS = {
+    "runtimeEvidence": "SocioProphet/lattice-forge#13",
+    "runtimePolicy": "SocioProphet/policy-fabric#43",
+    "runtimeTopologyPrevious": "SocioProphet/sociosphere#243",
+}
+
+
+def demo_runtime_release_readiness() -> dict[str, Any]:
+    profiles = [
+        _profile("prophet-python-ml", NOTEBOOK_RUNTIME_REF, "notebook"),
+        _profile("prophet-ray-ml", RAY_RUNTIME_REF, "ray"),
+        _profile("prophet-beam-dataops", BEAM_RUNTIME_REF, "beam"),
+    ]
+    return {
+        "apiVersion": "studio.socioprophet.dev/v1",
+        "kind": "LatticeRuntimeReleaseReadinessReport",
+        "metadata": {
+            "name": "lattice-runtime-release-readiness",
+            "version": "0.1.0",
+        },
+        "estateRefs": REQUIRED_RELEASE_REFS,
+        "manifestRef": RUNTIME_RELEASE_MANIFEST_REF,
+        "profiles": profiles,
+        "requiredEvidence": [
+            "RuntimeAsset",
+            "SBOM",
+            "scan-report",
+            "attestation",
+            "signature",
+            "external-scanner-evidence",
+            "external-signing-authority-evidence",
+            "human-approval",
+        ],
+        "decisionPosture": {
+            "devRelease": "allow",
+            "stableRelease": "allow-with-required-evidence",
+            "generatedOnlyStableRelease": "deny",
+            "policyFabricRequired": True,
+        },
+        "safety": {"network": "none", "secrets": "none", "hostMutation": False},
+    }
+
+
+def _profile(name: str, runtime_ref: str, runtime_class: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "runtimeRef": runtime_ref,
+        "runtimeClass": runtime_class,
+        "manifestRef": RUNTIME_RELEASE_MANIFEST_REF,
+        "externalScannerEvidenceRef": f"urn:srcos:evidence:{name}:external-scanner",
+        "externalSigningEvidenceRef": f"urn:srcos:evidence:{name}:external-signing-authority",
+        "humanApprovalEvidenceRef": f"urn:srcos:evidence:{name}:human-approval",
+        "releaseDecision": "allow-with-required-evidence",
+    }

--- a/apps/lattice-studio/tests/test_runtime_release_readiness.py
+++ b/apps/lattice-studio/tests/test_runtime_release_readiness.py
@@ -1,0 +1,58 @@
+from lattice_studio.runtime_profiles import BEAM_RUNTIME_REF, NOTEBOOK_RUNTIME_REF, RAY_RUNTIME_REF
+from lattice_studio.runtime_release_readiness import (
+    RUNTIME_RELEASE_MANIFEST_REF,
+    demo_runtime_release_readiness,
+)
+
+
+def test_runtime_release_readiness_shape_and_refs() -> None:
+    report = demo_runtime_release_readiness()
+
+    assert report["kind"] == "LatticeRuntimeReleaseReadinessReport"
+    assert report["metadata"]["name"] == "lattice-runtime-release-readiness"
+    assert report["manifestRef"] == RUNTIME_RELEASE_MANIFEST_REF
+    assert report["estateRefs"]["runtimeEvidence"] == "SocioProphet/lattice-forge#13"
+    assert report["estateRefs"]["runtimePolicy"] == "SocioProphet/policy-fabric#43"
+
+
+def test_runtime_release_readiness_covers_all_runtime_profiles() -> None:
+    report = demo_runtime_release_readiness()
+    profiles = {profile["runtimeRef"]: profile for profile in report["profiles"]}
+
+    assert set(profiles) == {NOTEBOOK_RUNTIME_REF, RAY_RUNTIME_REF, BEAM_RUNTIME_REF}
+    assert profiles[NOTEBOOK_RUNTIME_REF]["runtimeClass"] == "notebook"
+    assert profiles[RAY_RUNTIME_REF]["runtimeClass"] == "ray"
+    assert profiles[BEAM_RUNTIME_REF]["runtimeClass"] == "beam"
+    for profile in profiles.values():
+        assert profile["manifestRef"] == RUNTIME_RELEASE_MANIFEST_REF
+        assert profile["externalScannerEvidenceRef"].startswith("urn:srcos:evidence:")
+        assert profile["externalSigningEvidenceRef"].startswith("urn:srcos:evidence:")
+        assert profile["humanApprovalEvidenceRef"].startswith("urn:srcos:evidence:")
+        assert profile["releaseDecision"] == "allow-with-required-evidence"
+
+
+def test_runtime_release_readiness_requires_generated_and_external_evidence() -> None:
+    required = set(demo_runtime_release_readiness()["requiredEvidence"])
+
+    assert {
+        "RuntimeAsset",
+        "SBOM",
+        "scan-report",
+        "attestation",
+        "signature",
+        "external-scanner-evidence",
+        "external-signing-authority-evidence",
+        "human-approval",
+    } <= required
+
+
+def test_runtime_release_readiness_decision_posture_and_safety() -> None:
+    report = demo_runtime_release_readiness()
+    posture = report["decisionPosture"]
+    safety = report["safety"]
+
+    assert posture["devRelease"] == "allow"
+    assert posture["stableRelease"] == "allow-with-required-evidence"
+    assert posture["generatedOnlyStableRelease"] == "deny"
+    assert posture["policyFabricRequired"] is True
+    assert safety == {"network": "none", "secrets": "none", "hostMutation": False}


### PR DESCRIPTION
## Summary

Adds an additive runtime release readiness fixture for the Lattice Studio/Data/GovernAI path.

## Adds

- `apps/lattice-studio/src/lattice_studio/runtime_release_readiness.py`
- `apps/lattice-studio/tests/test_runtime_release_readiness.py`

## Coverage

The fixture records manifest `0.2.0`, required generated and external evidence classes, all three runtime profiles, and evidence-gated release decisions.

## Scope discipline

This is additive to the existing demo-readiness report. It preserves the older demo path while giving runtime release posture a dedicated surface.

## Validation

Expected:

```bash
cd apps/lattice-studio
python -m pytest
```

## Tracking

Follows SocioProphet/lattice-forge#13 and SocioProphet/policy-fabric#43.