### PR TITLE
Add GAIA fixture-backed layer catalog endpoint

### DIFF
--- a/apps/osm-map-api/openapi/required-paths.v0.json
+++ b/apps/osm-map-api/openapi/required-paths.v0.json
@@ -6,6 +6,9 @@
     {"path": "/readyz", "method": "get"},
     {"path": "/map-layers", "method": "get"},
     {"path": "/map-layers/{layer_id}", "method": "get"},
+    {"path": "/gaia/layers", "method": "get"},
+    {"path": "/gaia/layers/{layer_id}", "method": "get"},
+    {"path": "/gaia/tile-manifests/{layer_id}", "method": "get"},
     {"path": "/features/by-osm/{osm_type}/{osm_id}", "method": "get"},
     {"path": "/features/by-h3/{h3_cell}", "method": "get"},
     {"path": "/route-graphs/osm", "method": "get"},
@@ -16,6 +19,8 @@
   "required_safety_terms": [
     "advisory",
     "OpenStreetMap",
-    "attribution"
+    "attribution",
+    "fixture-backed",
+    "production_tile_serving"
   ]
 }

--- a/apps/osm-map-api/osm_map_api/gaia_layer_catalog.py
+++ b/apps/osm-map-api/osm_map_api/gaia_layer_catalog.py
@@ -1,0 +1,86 @@
+"""Fixture-backed GAIA layer catalog helpers.
+
+This module exposes bounded OSM ingest layer metadata without implementing
+production tile serving or live OSM ingestion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .repository import ArtifactError, OSMArtifactRepository
+
+BOUNDED_OSM_MANIFEST_PATH = "examples/osm-bounded-ingest/osm-layer-manifest-candidate.v1.json"
+
+
+def _manifest_path(repo: OSMArtifactRepository) -> Path:
+    return repo.settings.gaia_fixture_root / BOUNDED_OSM_MANIFEST_PATH
+
+
+def _assert_layer_manifest(layer: dict[str, Any]) -> None:
+    if not layer.get("layer_id"):
+        raise ArtifactError("GAIA layer manifest missing layer_id")
+    attribution = layer.get("attribution")
+    if not isinstance(attribution, dict):
+        raise ArtifactError("GAIA layer manifest missing attribution")
+    if not attribution.get("attribution_text"):
+        raise ArtifactError("GAIA layer manifest missing attribution_text")
+    if not attribution.get("license_refs"):
+        raise ArtifactError("GAIA layer manifest missing license_refs")
+    provenance = layer.get("provenance")
+    if not isinstance(provenance, dict):
+        raise ArtifactError("GAIA layer manifest missing provenance")
+    if not provenance.get("fixture_digest"):
+        raise ArtifactError("GAIA layer manifest missing fixture_digest")
+    if not provenance.get("source_refs"):
+        raise ArtifactError("GAIA layer manifest missing source_refs")
+    spatial = layer.get("spatial")
+    if not isinstance(spatial, dict) or not spatial.get("bbox") or not spatial.get("h3_cells"):
+        raise ArtifactError("GAIA layer manifest missing bbox or h3_cells")
+    tiles = layer.get("tiles")
+    if not isinstance(tiles, dict):
+        raise ArtifactError("GAIA layer manifest missing tiles")
+    url_template = str(tiles.get("url_template", ""))
+    if not url_template.startswith("placeholder://"):
+        raise ArtifactError("GAIA layer manifest must use placeholder tile URL in fixture mode")
+    description = str(layer.get("description", "")).lower()
+    if "not production" not in description and "non-production" not in description:
+        raise ArtifactError("GAIA layer manifest must declare non-production tile boundary")
+
+
+def load_bounded_osm_layer(repo: OSMArtifactRepository) -> dict[str, Any]:
+    layer = repo._load_json(_manifest_path(repo))
+    _assert_layer_manifest(layer)
+    return layer
+
+
+def gaia_layers(repo: OSMArtifactRepository) -> list[dict[str, Any]]:
+    return [load_bounded_osm_layer(repo)]
+
+
+def gaia_layer(repo: OSMArtifactRepository, layer_id: str) -> dict[str, Any] | None:
+    layer = load_bounded_osm_layer(repo)
+    if layer.get("layer_id") == layer_id:
+        return layer
+    return None
+
+
+def gaia_tile_manifest(repo: OSMArtifactRepository, layer_id: str) -> dict[str, Any] | None:
+    layer = gaia_layer(repo, layer_id)
+    if layer is None:
+        return None
+    return {
+        "manifest_version": layer.get("manifest_version"),
+        "layer_id": layer.get("layer_id"),
+        "layer_type": layer.get("layer_type"),
+        "title": layer.get("title"),
+        "description": layer.get("description"),
+        "tile_serving_status": "fixture-placeholder-not-production",
+        "production_tile_serving": False,
+        "tiles": layer.get("tiles"),
+        "spatial": layer.get("spatial"),
+        "attribution": layer.get("attribution"),
+        "provenance": layer.get("provenance"),
+        "classification": layer.get("classification"),
+    }

--- a/apps/osm-map-api/osm_map_api/main.py
+++ b/apps/osm-map-api/osm_map_api/main.py
@@ -7,6 +7,11 @@ from typing import Any
 from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 
+from .gaia_layer_catalog import (
+    gaia_layer as catalog_gaia_layer,
+    gaia_layers as catalog_gaia_layers,
+    gaia_tile_manifest as catalog_gaia_tile_manifest,
+)
 from .receipts import response_receipt, with_artifact_receipt
 from .repository import ArtifactError, OSMArtifactRepository
 from .settings import Settings
@@ -43,7 +48,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         description=(
             "Read-only fixture-backed API for OpenStreetMap-derived GAIA map layers, "
             "feature bindings, advisory route graphs, attribution receipts, runtime-boundary "
-            "state, provenance state, and governance state."
+            "state, provenance state, governance state, and fixture-backed GAIA layer catalog "
+            "metadata."
         ),
     )
     _configure_cors(app, resolved_settings)
@@ -83,6 +89,42 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         if layer is None:
             raise HTTPException(status_code=404, detail=f"map layer not found: {layer_id}")
         return with_artifact_receipt("map-layer", layer)
+
+    @app.get("/gaia/layers", tags=["gaia"])
+    def gaia_layers(request: Request) -> dict[str, Any]:
+        try:
+            layers = catalog_gaia_layers(repository(request))
+        except ArtifactError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        return {
+            "layers": [with_artifact_receipt("gaia-layer", layer) for layer in layers],
+            "catalog_mode": "fixture-backed",
+            "production_tile_serving": False,
+            "response_receipt": response_receipt("gaia-layer-list", layers),
+        }
+
+    @app.get("/gaia/layers/{layer_id}", tags=["gaia"])
+    def gaia_layer(layer_id: str, request: Request) -> dict[str, Any]:
+        try:
+            layer = catalog_gaia_layer(repository(request), layer_id)
+        except ArtifactError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        if layer is None:
+            raise HTTPException(status_code=404, detail=f"GAIA layer not found: {layer_id}")
+        return with_artifact_receipt("gaia-layer", layer)
+
+    @app.get("/gaia/tile-manifests/{layer_id}", tags=["gaia"])
+    def gaia_tile_manifest(layer_id: str, request: Request) -> dict[str, Any]:
+        try:
+            manifest = catalog_gaia_tile_manifest(repository(request), layer_id)
+        except ArtifactError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        if manifest is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"GAIA tile manifest not found: {layer_id}",
+            )
+        return with_artifact_receipt("gaia-tile-manifest", manifest)
 
     @app.get("/features/by-osm/{osm_type}/{osm_id}", tags=["features"])
     def feature_by_osm(osm_type: str, osm_id: str, request: Request) -> dict[str, Any]:

--- a/apps/osm-map-api/osm_map_api/main.py
+++ b/apps/osm-map-api/osm_map_api/main.py
@@ -49,7 +49,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             "Read-only fixture-backed API for OpenStreetMap-derived GAIA map layers, "
             "feature bindings, advisory route graphs, attribution receipts, runtime-boundary "
             "state, provenance state, governance state, and fixture-backed GAIA layer catalog "
-            "metadata."
+            "metadata. GAIA tile-manifest responses expose production_tile_serving=false to "
+            "make the non-production tile boundary machine visible."
         ),
     )
     _configure_cors(app, resolved_settings)

--- a/apps/osm-map-api/tests/test_gaia_layer_catalog.py
+++ b/apps/osm-map-api/tests/test_gaia_layer_catalog.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from osm_map_api.main import create_app
+from osm_map_api.settings import Settings
+
+from test_osm_map_api import assert_receipt, make_fixture_roots, write_json
+
+BOUNDED_LAYER_ID = "osm-layer-manifest-candidate-lower-manhattan-bounded-extract-2026-04-26"
+FIXTURE_DIGEST = "sha256:e5baba1a98e0e59887bf19fe840b0544904f23d05e5fb9989a9f53f86d1b360b"
+
+
+def make_gaia_catalog_client(tmp_path: Path) -> TestClient:
+    gaia, sherlock, sociosphere = make_fixture_roots(tmp_path)
+    layer_manifest = {
+        "manifest_version": "v1",
+        "layer_id": BOUNDED_LAYER_ID,
+        "layer_type": "vector",
+        "title": "GAIA OSM Bounded Ingest Layer – Lower Manhattan Bounded Extract",
+        "description": "Bounded OSM ingest layer manifest candidate. Fixture-backed API catalog surface. Not production tile-serving. Advisory only.",
+        "sources": [
+            {
+                "source_id": "osm-source-envelope-lower-manhattan-bounded-extract-2026-04-26",
+                "source_type": "OpenStreetMap extract",
+                "source_refs": [
+                    "osm-extract://bounded/lower-manhattan/2026-04-26",
+                    "osm-source-receipt.v1.json",
+                    "osm-feature-bindings.v1.json",
+                ],
+            }
+        ],
+        "tiles": {
+            "url_template": "placeholder://tiles/gaia/osm-bounded/{z}/{x}/{y}.mvt",
+            "min_zoom": 0,
+            "max_zoom": 14,
+            "format": "mvt",
+        },
+        "spatial": {
+            "bbox": [-74.012, 40.705, -73.998, 40.718],
+            "h3_cells": ["89283082807ffff", "8928308280fffff", "8928308281fffff"],
+            "crs": "EPSG:4326",
+        },
+        "attribution": {
+            "attribution_text": "© OpenStreetMap contributors",
+            "license_refs": ["ODbL-1.0"],
+            "source_urls": ["https://www.openstreetmap.org"],
+        },
+        "provenance": {
+            "source_refs": [
+                "osm-source-receipt.v1.json",
+                "osm-feature-bindings.v1.json",
+                "osm-extract://bounded/lower-manhattan/2026-04-26",
+            ],
+            "fixture_digest": FIXTURE_DIGEST,
+            "runtime_refs": ["gaia-bounded-osm-ingest-runner@v1"],
+            "created_at": "2026-04-27T06:10:00Z",
+            "content_hash": "sha256:ae4f4d078e81de81fd413ad2f243f250af99bc268580143801fa18875214c5d9",
+        },
+        "classification": {
+            "data_class": "public",
+            "handling_tags": ["demo", "osm", "bounded-extract", "geospatial", "advisory"],
+        },
+    }
+    write_json(
+        gaia / "examples/osm-bounded-ingest/osm-layer-manifest-candidate.v1.json",
+        layer_manifest,
+    )
+    app = create_app(
+        Settings(
+            gaia_fixture_root=gaia,
+            sherlock_fixture_root=sherlock,
+            sociosphere_fixture_root=sociosphere,
+        )
+    )
+    return TestClient(app)
+
+
+def test_gaia_layer_catalog_lists_bounded_osm_layer(tmp_path: Path) -> None:
+    client = make_gaia_catalog_client(tmp_path)
+    payload = client.get("/gaia/layers").json()
+
+    assert payload["catalog_mode"] == "fixture-backed"
+    assert payload["production_tile_serving"] is False
+    assert len(payload["layers"]) == 1
+    layer = payload["layers"][0]
+    assert layer["layer_id"] == BOUNDED_LAYER_ID
+    assert layer["tiles"]["url_template"].startswith("placeholder://")
+    assert layer["provenance"]["fixture_digest"] == FIXTURE_DIGEST
+    assert layer["classification"]["data_class"] == "public"
+    assert "ODbL-1.0" in layer["attribution"]["license_refs"]
+    assert_receipt(payload["response_receipt"], response_kind="gaia-layer-list")
+    assert_receipt(layer["response_receipt"], response_kind="gaia-layer")
+
+
+def test_gaia_layer_detail_preserves_attribution_and_provenance(tmp_path: Path) -> None:
+    client = make_gaia_catalog_client(tmp_path)
+    response = client.get(f"/gaia/layers/{BOUNDED_LAYER_ID}")
+
+    assert response.status_code == 200
+    layer = response.json()
+    assert layer["spatial"]["bbox"] == [-74.012, 40.705, -73.998, 40.718]
+    assert "8928308280fffff" in layer["spatial"]["h3_cells"]
+    assert "osm-source-receipt.v1.json" in layer["provenance"]["source_refs"]
+    assert "© OpenStreetMap contributors" in layer["attribution"]["attribution_text"]
+    assert layer["classification"]["handling_tags"][-1] == "advisory"
+    assert_receipt(layer["response_receipt"], response_kind="gaia-layer")
+
+
+def test_gaia_tile_manifest_is_explicitly_non_production(tmp_path: Path) -> None:
+    client = make_gaia_catalog_client(tmp_path)
+    response = client.get(f"/gaia/tile-manifests/{BOUNDED_LAYER_ID}")
+
+    assert response.status_code == 200
+    manifest = response.json()
+    assert manifest["layer_id"] == BOUNDED_LAYER_ID
+    assert manifest["production_tile_serving"] is False
+    assert manifest["tile_serving_status"] == "fixture-placeholder-not-production"
+    assert manifest["tiles"]["format"] == "mvt"
+    assert manifest["tiles"]["url_template"].startswith("placeholder://")
+    assert manifest["provenance"]["fixture_digest"] == FIXTURE_DIGEST
+    assert_receipt(manifest["response_receipt"], response_kind="gaia-tile-manifest")
+
+
+def test_gaia_layer_catalog_unknown_layer_returns_404(tmp_path: Path) -> None:
+    client = make_gaia_catalog_client(tmp_path)
+
+    missing_layer = client.get("/gaia/layers/unknown-layer")
+    missing_tile_manifest = client.get("/gaia/tile-manifests/unknown-layer")
+
+    assert missing_layer.status_code == 404
+    assert missing_tile_manifest.status_code == 404
+
+
+def test_gaia_layer_catalog_does_not_break_health_or_readiness(tmp_path: Path) -> None:
+    client = make_gaia_catalog_client(tmp_path)
+
+    assert client.get("/healthz").json() == {"status": "ok"}
+    assert client.get("/readyz").json() == {"status": "ready"}


### PR DESCRIPTION
## Summary

Materializes issue #309 because the initial Copilot WIP PR #310 remained empty.

Adds a fixture-backed GAIA layer catalog surface to the existing OSM Map API:

- `GET /gaia/layers`
- `GET /gaia/layers/{layer_id}`
- `GET /gaia/tile-manifests/{layer_id}`

The new helper consumes the bounded OSM layer manifest shape emitted by `SocioProphet/gaia-world-model#17` from `examples/osm-bounded-ingest/osm-layer-manifest-candidate.v1.json` under the configured `GAIA_FIXTURE_ROOT`.

## Guardrails

- Fixture-backed catalog only.
- No production tile generation.
- No live OSM/PBF/Overpass ingestion.
- No proxying real tile traffic.
- No cross-repo edits.
- Tile manifest endpoint explicitly returns `production_tile_serving: false` and `fixture-placeholder-not-production`.

## Validation expected

The OSM Map API workflow should run:

```bash
cd apps/osm-map-api
pytest -q
python3 scripts/check_openapi_contract.py
python3 -m compileall osm_map_api
```

## Known gaps

- `openapi/generated.openapi.json` is generated by `scripts/check_openapi_contract.py`; this PR updates the required-path contract rather than hand-editing generated output.
- This is not production tile serving and does not claim GAIA World Model v1 completion.

Closes #309.