### PR TITLE
docs(platform): add office collaboration runtime slice

### DIFF
--- a/docs/OFFICE_COLLABORATION_RUNTIME.md
+++ b/docs/OFFICE_COLLABORATION_RUNTIME.md
@@ -1,0 +1,40 @@
+# Office Collaboration Runtime
+
+This document defines the runtime slice for office collaboration records in `prophet-platform`.
+
+## Purpose
+
+The office/workspace product already needs collaboration objects such as:
+- comment/review threads
+- suggestions
+- review state
+
+This runtime slice gives those product objects a concrete platform home.
+
+## Runtime responsibilities
+
+`prophet-platform` should own:
+- collaboration record storage and retrieval
+- version linkage for collaboration objects
+- runtime service seams for comments and suggestions
+- audit/evidence linkage for agent-created collaboration objects
+- permission-aware retrieval and mutation
+
+## First runtime records
+
+- `office_collaboration_thread_record`
+- `office_suggestion_record`
+
+## First service seam
+
+A later `services/office-collaboration/` runtime should be able to:
+- create and fetch collaboration threads
+- create and resolve suggestions
+- bind collaboration records to office artifacts and versions
+- preserve receipts and policy-safe side effects
+
+## Cross-repo boundaries
+
+- `prophet-workspace` owns the product collaboration model
+- `prophet-platform` owns runtime records and service seams
+- `source-os` owns local/cloud handoff affordances, not canonical collaboration storage

--- a/schemas/office/office_collaboration_thread_record.schema.json
+++ b/schemas/office/office_collaboration_thread_record.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/office/office_collaboration_thread_record.schema.json",
+  "title": "office_collaboration_thread_record",
+  "type": "object",
+  "required": ["thread_id", "document_id", "thread_type", "status"],
+  "properties": {
+    "thread_id": {"type": "string"},
+    "document_id": {"type": "string"},
+    "semantic_unit_ref": {"type": "string"},
+    "thread_type": {
+      "type": "string",
+      "enum": ["COMMENT", "REVIEW", "DISCUSSION"]
+    },
+    "status": {
+      "type": "string",
+      "enum": ["OPEN", "RESOLVED", "CLOSED"]
+    },
+    "participant_refs": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "version_id": {"type": "string"},
+    "receipt_ref": {"type": "string"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "updated_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/schemas/office/office_suggestion_record.schema.json
+++ b/schemas/office/office_suggestion_record.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/office/office_suggestion_record.schema.json",
+  "title": "office_suggestion_record",
+  "type": "object",
+  "required": ["suggestion_id", "document_id", "status"],
+  "properties": {
+    "suggestion_id": {"type": "string"},
+    "document_id": {"type": "string"},
+    "semantic_unit_ref": {"type": "string"},
+    "before_ref": {"type": "string"},
+    "after_ref": {"type": "string"},
+    "proposer_ref": {"type": "string"},
+    "status": {
+      "type": "string",
+      "enum": ["PROPOSED", "ACCEPTED", "REJECTED"]
+    },
+    "version_id": {"type": "string"},
+    "receipt_ref": {"type": "string"},
+    "created_at": {"type": "string", "format": "date-time"},
+    "updated_at": {"type": "string", "format": "date-time"}
+  },
+  "additionalProperties": false
+}

--- a/services/office-collaboration/README.md
+++ b/services/office-collaboration/README.md
@@ -1,0 +1,22 @@
+# Office Collaboration Service
+
+This directory is the runtime stub for office collaboration in `prophet-platform`.
+
+## Purpose
+
+The office collaboration service should eventually provide the runtime seam for:
+- comment/review threads
+- suggestions
+- review state transitions
+- version-aware collaboration history
+
+## Backing records
+
+- `schemas/office/office_collaboration_thread_record.schema.json`
+- `schemas/office/office_suggestion_record.schema.json`
+
+## Cross-repo posture
+
+- product semantics live in `SocioProphet/prophet-workspace`
+- runtime storage/execution lives in `SocioProphet/prophet-platform`
+- local/cloud affordances live in `SociOS-Linux/source-os`


### PR DESCRIPTION
## Summary

Add the bounded office collaboration runtime slice on top of current `main`.

Files:
- `docs/OFFICE_COLLABORATION_RUNTIME.md`
- `schemas/office/office_collaboration_thread_record.schema.json`
- `schemas/office/office_suggestion_record.schema.json`
- `services/office-collaboration/README.md`

## Why

The workspace collaboration product model is now on `main`. This follow-on gives that product slice a concrete runtime home in `prophet-platform`.
