### PR TITLE
services(platform): add office collaboration service stub

### DIFF
--- a/services/office-collaboration/app/main.py
+++ b/services/office-collaboration/app/main.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timezone
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+app = FastAPI(title="office-collaboration", version="0.1.0")
+THREADS: dict[str, dict[str, object]] = {}
+SUGGESTIONS: dict[str, dict[str, object]] = {}
+
+
+class ThreadIn(BaseModel):
+    thread_id: str
+    document_id: str
+    thread_type: str
+    semantic_unit_ref: str | None = None
+
+
+class SuggestionIn(BaseModel):
+    suggestion_id: str
+    document_id: str
+    semantic_unit_ref: str | None = None
+    before_ref: str | None = None
+    after_ref: str | None = None
+
+
+class SuggestionStatusIn(BaseModel):
+    status: str
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok", "service": "office-collaboration"}
+
+
+@app.post("/v0/office-collaboration/threads")
+def create_thread(body: ThreadIn) -> dict[str, object]:
+    now = datetime.now(timezone.utc).isoformat()
+    record = {
+        "thread_id": body.thread_id,
+        "document_id": body.document_id,
+        "thread_type": body.thread_type,
+        "semantic_unit_ref": body.semantic_unit_ref,
+        "status": "OPEN",
+        "created_at": now,
+        "updated_at": now,
+    }
+    THREADS[body.thread_id] = record
+    return record
+
+
+@app.get("/v0/office-collaboration/threads/{thread_id}")
+def get_thread(thread_id: str) -> dict[str, object]:
+    record = THREADS.get(thread_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+    return record
+
+
+@app.post("/v0/office-collaboration/suggestions")
+def create_suggestion(body: SuggestionIn) -> dict[str, object]:
+    now = datetime.now(timezone.utc).isoformat()
+    record = {
+        "suggestion_id": body.suggestion_id,
+        "document_id": body.document_id,
+        "semantic_unit_ref": body.semantic_unit_ref,
+        "before_ref": body.before_ref,
+        "after_ref": body.after_ref,
+        "status": "PROPOSED",
+        "created_at": now,
+        "updated_at": now,
+    }
+    SUGGESTIONS[body.suggestion_id] = record
+    return record
+
+
+@app.post("/v0/office-collaboration/suggestions/{suggestion_id}/status")
+def update_suggestion_status(suggestion_id: str, body: SuggestionStatusIn) -> dict[str, object]:
+    record = SUGGESTIONS.get(suggestion_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="suggestion not found")
+    record["status"] = body.status
+    record["updated_at"] = datetime.now(timezone.utc).isoformat()
+    return record

--- a/services/office-collaboration/tests/test_service_smoke.py
+++ b/services/office-collaboration/tests/test_service_smoke.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_create_and_fetch_thread() -> None:
+    create = client.post(
+        '/v0/office-collaboration/threads',
+        json={
+            'thread_id': 't1',
+            'document_id': 'doc1',
+            'thread_type': 'COMMENT',
+        },
+    )
+    assert create.status_code == 200
+
+    fetched = client.get('/v0/office-collaboration/threads/t1')
+    assert fetched.status_code == 200
+    assert fetched.json()['thread_id'] == 't1'
+    assert fetched.json()['status'] == 'OPEN'
+
+
+def test_create_and_update_suggestion() -> None:
+    create = client.post(
+        '/v0/office-collaboration/suggestions',
+        json={
+            'suggestion_id': 's1',
+            'document_id': 'doc1',
+            'before_ref': 'before',
+            'after_ref': 'after',
+        },
+    )
+    assert create.status_code == 200
+    assert create.json()['status'] == 'PROPOSED'
+
+    update = client.post(
+        '/v0/office-collaboration/suggestions/s1/status',
+        json={'status': 'ACCEPTED'},
+    )
+    assert update.status_code == 200
+    assert update.json()['status'] == 'ACCEPTED'


### PR DESCRIPTION
## Summary

Add the first executable office-collaboration runtime slice on top of current `main`.

Files:
- `services/office-collaboration/app/main.py`
- `services/office-collaboration/tests/test_service_smoke.py`

## Why

The product-side and runtime-side collaboration models are already on `main`. This follow-on adds the first executable service seam so comments, threads, and suggestions are no longer only modeled artifacts.
