### PR TITLE
services(platform): add collaboration messages and version-aware suggestion status

### DIFF
--- a/services/office-collaboration/app/main.py
+++ b/services/office-collaboration/app/main.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 app = FastAPI(title="office-collaboration", version="0.1.0")
 THREADS: dict[str, dict[str, object]] = {}
+THREAD_MESSAGES: dict[str, list[dict[str, object]]] = {}
 SUGGESTIONS: dict[str, dict[str, object]] = {}
 
 
@@ -13,6 +14,12 @@ class ThreadIn(BaseModel):
     document_id: str
     thread_type: str
     semantic_unit_ref: str | None = None
+
+
+class ThreadMessageIn(BaseModel):
+    message_id: str
+    actor_ref: str
+    body: str
 
 
 class SuggestionIn(BaseModel):
@@ -25,6 +32,7 @@ class SuggestionIn(BaseModel):
 
 class SuggestionStatusIn(BaseModel):
     status: str
+    version_id: str | None = None
 
 
 @app.get("/healthz")
@@ -45,6 +53,7 @@ def create_thread(body: ThreadIn) -> dict[str, object]:
         "updated_at": now,
     }
     THREADS[body.thread_id] = record
+    THREAD_MESSAGES[body.thread_id] = []
     return record
 
 
@@ -54,6 +63,31 @@ def get_thread(thread_id: str) -> dict[str, object]:
     if record is None:
         raise HTTPException(status_code=404, detail="thread not found")
     return record
+
+
+@app.post("/v0/office-collaboration/threads/{thread_id}/messages")
+def add_thread_message(thread_id: str, body: ThreadMessageIn) -> dict[str, object]:
+    thread = THREADS.get(thread_id)
+    if thread is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+    now = datetime.now(timezone.utc).isoformat()
+    message = {
+        "message_id": body.message_id,
+        "thread_id": thread_id,
+        "actor_ref": body.actor_ref,
+        "body": body.body,
+        "created_at": now,
+    }
+    THREAD_MESSAGES.setdefault(thread_id, []).append(message)
+    thread["updated_at"] = now
+    return message
+
+
+@app.get("/v0/office-collaboration/threads/{thread_id}/messages")
+def list_thread_messages(thread_id: str) -> dict[str, object]:
+    if thread_id not in THREADS:
+        raise HTTPException(status_code=404, detail="thread not found")
+    return {"thread_id": thread_id, "messages": THREAD_MESSAGES.get(thread_id, [])}
 
 
 @app.post("/v0/office-collaboration/suggestions")
@@ -66,6 +100,7 @@ def create_suggestion(body: SuggestionIn) -> dict[str, object]:
         "before_ref": body.before_ref,
         "after_ref": body.after_ref,
         "status": "PROPOSED",
+        "version_id": None,
         "created_at": now,
         "updated_at": now,
     }
@@ -79,5 +114,6 @@ def update_suggestion_status(suggestion_id: str, body: SuggestionStatusIn) -> di
     if record is None:
         raise HTTPException(status_code=404, detail="suggestion not found")
     record["status"] = body.status
+    record["version_id"] = body.version_id
     record["updated_at"] = datetime.now(timezone.utc).isoformat()
     return record

--- a/services/office-collaboration/tests/test_collaboration_behaviors.py
+++ b/services/office-collaboration/tests/test_collaboration_behaviors.py
@@ -1,0 +1,36 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_thread_messages_roundtrip() -> None:
+    client.post(
+        '/v0/office-collaboration/threads',
+        json={'thread_id': 't1', 'document_id': 'doc1', 'thread_type': 'COMMENT'},
+    )
+    msg = client.post(
+        '/v0/office-collaboration/threads/t1/messages',
+        json={'message_id': 'm1', 'actor_ref': 'user-1', 'body': 'Needs a wording change.'},
+    )
+    assert msg.status_code == 200
+
+    fetched = client.get('/v0/office-collaboration/threads/t1/messages')
+    assert fetched.status_code == 200
+    assert fetched.json()['messages'][0]['body'] == 'Needs a wording change.'
+
+
+def test_suggestion_status_records_version() -> None:
+    client.post(
+        '/v0/office-collaboration/suggestions',
+        json={'suggestion_id': 's1', 'document_id': 'doc1', 'before_ref': 'before', 'after_ref': 'after'},
+    )
+    update = client.post(
+        '/v0/office-collaboration/suggestions/s1/status',
+        json={'status': 'ACCEPTED', 'version_id': 'version-doc1-002'},
+    )
+    assert update.status_code == 200
+    assert update.json()['status'] == 'ACCEPTED'
+    assert update.json()['version_id'] == 'version-doc1-002'


### PR DESCRIPTION
## Summary

Add the next executable office-collaboration behavior slice on top of current `main`.

Files:
- `services/office-collaboration/app/main.py`
- `services/office-collaboration/tests/test_collaboration_behaviors.py`

## Why

The collaboration service stub is already on `main`. This follow-on adds:
- thread messages
- message retrieval
- version-aware suggestion status updates
- direct smoke coverage for those behaviors
