### PR TITLE
services(platform): extend collaboration behavior with resolution and suggestion listing

### DIFF
--- a/services/office-collaboration/app/main.py
+++ b/services/office-collaboration/app/main.py
@@ -22,6 +22,12 @@ class ThreadMessageIn(BaseModel):
     body: str
 
 
+class ThreadStatusIn(BaseModel):
+    status: str
+    version_id: str | None = None
+    receipt_ref: str | None = None
+
+
 class SuggestionIn(BaseModel):
     suggestion_id: str
     document_id: str
@@ -33,6 +39,7 @@ class SuggestionIn(BaseModel):
 class SuggestionStatusIn(BaseModel):
     status: str
     version_id: str | None = None
+    receipt_ref: str | None = None
 
 
 @app.get("/healthz")
@@ -49,6 +56,8 @@ def create_thread(body: ThreadIn) -> dict[str, object]:
         "thread_type": body.thread_type,
         "semantic_unit_ref": body.semantic_unit_ref,
         "status": "OPEN",
+        "version_id": None,
+        "receipt_ref": None,
         "created_at": now,
         "updated_at": now,
     }
@@ -90,6 +99,18 @@ def list_thread_messages(thread_id: str) -> dict[str, object]:
     return {"thread_id": thread_id, "messages": THREAD_MESSAGES.get(thread_id, [])}
 
 
+@app.post("/v0/office-collaboration/threads/{thread_id}/status")
+def update_thread_status(thread_id: str, body: ThreadStatusIn) -> dict[str, object]:
+    record = THREADS.get(thread_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+    record["status"] = body.status
+    record["version_id"] = body.version_id
+    record["receipt_ref"] = body.receipt_ref
+    record["updated_at"] = datetime.now(timezone.utc).isoformat()
+    return record
+
+
 @app.post("/v0/office-collaboration/suggestions")
 def create_suggestion(body: SuggestionIn) -> dict[str, object]:
     now = datetime.now(timezone.utc).isoformat()
@@ -101,11 +122,28 @@ def create_suggestion(body: SuggestionIn) -> dict[str, object]:
         "after_ref": body.after_ref,
         "status": "PROPOSED",
         "version_id": None,
+        "receipt_ref": None,
         "created_at": now,
         "updated_at": now,
     }
     SUGGESTIONS[body.suggestion_id] = record
     return record
+
+
+@app.get("/v0/office-collaboration/suggestions/{suggestion_id}")
+def get_suggestion(suggestion_id: str) -> dict[str, object]:
+    record = SUGGESTIONS.get(suggestion_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="suggestion not found")
+    return record
+
+
+@app.get("/v0/office-collaboration/documents/{document_id}/suggestions")
+def list_document_suggestions(document_id: str) -> dict[str, object]:
+    return {
+        "document_id": document_id,
+        "suggestions": [item for item in SUGGESTIONS.values() if item["document_id"] == document_id],
+    }
 
 
 @app.post("/v0/office-collaboration/suggestions/{suggestion_id}/status")
@@ -115,5 +153,6 @@ def update_suggestion_status(suggestion_id: str, body: SuggestionStatusIn) -> di
         raise HTTPException(status_code=404, detail="suggestion not found")
     record["status"] = body.status
     record["version_id"] = body.version_id
+    record["receipt_ref"] = body.receipt_ref
     record["updated_at"] = datetime.now(timezone.utc).isoformat()
     return record

--- a/services/office-collaboration/tests/test_service_smoke.py
+++ b/services/office-collaboration/tests/test_service_smoke.py
@@ -6,7 +6,7 @@ from app.main import app
 client = TestClient(app)
 
 
-def test_create_and_fetch_thread() -> None:
+def test_create_thread_add_message_and_resolve() -> None:
     create = client.post(
         '/v0/office-collaboration/threads',
         json={
@@ -17,10 +17,28 @@ def test_create_and_fetch_thread() -> None:
     )
     assert create.status_code == 200
 
-    fetched = client.get('/v0/office-collaboration/threads/t1')
+    msg = client.post(
+        '/v0/office-collaboration/threads/t1/messages',
+        json={
+            'message_id': 'm1',
+            'actor_ref': 'user-1',
+            'body': 'Needs a wording change.',
+        },
+    )
+    assert msg.status_code == 200
+
+    fetched = client.get('/v0/office-collaboration/threads/t1/messages')
     assert fetched.status_code == 200
-    assert fetched.json()['thread_id'] == 't1'
-    assert fetched.json()['status'] == 'OPEN'
+    assert fetched.json()['messages'][0]['body'] == 'Needs a wording change.'
+
+    resolved = client.post(
+        '/v0/office-collaboration/threads/t1/status',
+        json={'status': 'RESOLVED', 'version_id': 'version-doc1-002', 'receipt_ref': 'receipt-1'},
+    )
+    assert resolved.status_code == 200
+    assert resolved.json()['status'] == 'RESOLVED'
+    assert resolved.json()['version_id'] == 'version-doc1-002'
+    assert resolved.json()['receipt_ref'] == 'receipt-1'
 
 
 def test_create_and_update_suggestion() -> None:
@@ -36,9 +54,19 @@ def test_create_and_update_suggestion() -> None:
     assert create.status_code == 200
     assert create.json()['status'] == 'PROPOSED'
 
+    fetched = client.get('/v0/office-collaboration/suggestions/s1')
+    assert fetched.status_code == 200
+    assert fetched.json()['suggestion_id'] == 's1'
+
+    listed = client.get('/v0/office-collaboration/documents/doc1/suggestions')
+    assert listed.status_code == 200
+    assert listed.json()['suggestions'][0]['suggestion_id'] == 's1'
+
     update = client.post(
         '/v0/office-collaboration/suggestions/s1/status',
-        json={'status': 'ACCEPTED'},
+        json={'status': 'ACCEPTED', 'version_id': 'version-doc1-002', 'receipt_ref': 'receipt-2'},
     )
     assert update.status_code == 200
     assert update.json()['status'] == 'ACCEPTED'
+    assert update.json()['version_id'] == 'version-doc1-002'
+    assert update.json()['receipt_ref'] == 'receipt-2'


### PR DESCRIPTION
## Summary

Add the next executable office-collaboration behavior slice on top of current `main`.

Files:
- `services/office-collaboration/app/main.py`
- `services/office-collaboration/tests/test_service_smoke.py`

## Why

The current collaboration service already supports thread creation, messages, and suggestion status updates. This follow-on adds:
- thread resolution with version and receipt linkage
- suggestion retrieval
- document-level suggestion listing
- stronger behavior smoke coverage
