### PR TITLE
services(platform): add suggestion event history

### DIFF
--- a/services/office-collaboration/app/main.py
+++ b/services/office-collaboration/app/main.py
@@ -8,6 +8,7 @@ THREADS: dict[str, dict[str, object]] = {}
 THREAD_MESSAGES: dict[str, list[dict[str, object]]] = {}
 THREAD_EVENTS: dict[str, list[dict[str, object]]] = {}
 SUGGESTIONS: dict[str, dict[str, object]] = {}
+SUGGESTION_EVENTS: dict[str, list[dict[str, object]]] = {}
 
 
 class ThreadIn(BaseModel):
@@ -43,159 +44,134 @@ class SuggestionStatusIn(BaseModel):
     receipt_ref: str | None = None
 
 
-@app.get("/healthz")
+@app.get('/healthz')
 def healthz() -> dict[str, str]:
-    return {"status": "ok", "service": "office-collaboration"}
+    return {'status': 'ok', 'service': 'office-collaboration'}
 
 
-@app.post("/v0/office-collaboration/threads")
+@app.post('/v0/office-collaboration/threads')
 def create_thread(body: ThreadIn) -> dict[str, object]:
     now = datetime.now(timezone.utc).isoformat()
     record = {
-        "thread_id": body.thread_id,
-        "document_id": body.document_id,
-        "thread_type": body.thread_type,
-        "semantic_unit_ref": body.semantic_unit_ref,
-        "status": "OPEN",
-        "version_id": None,
-        "receipt_ref": None,
-        "created_at": now,
-        "updated_at": now,
+        'thread_id': body.thread_id,
+        'document_id': body.document_id,
+        'thread_type': body.thread_type,
+        'semantic_unit_ref': body.semantic_unit_ref,
+        'status': 'OPEN',
+        'version_id': None,
+        'receipt_ref': None,
+        'created_at': now,
+        'updated_at': now,
     }
     THREADS[body.thread_id] = record
     THREAD_MESSAGES[body.thread_id] = []
-    THREAD_EVENTS[body.thread_id] = [
-        {
-            "event_type": "THREAD_CREATED",
-            "thread_id": body.thread_id,
-            "created_at": now,
-        }
-    ]
+    THREAD_EVENTS[body.thread_id] = [{'event_type': 'THREAD_CREATED', 'thread_id': body.thread_id, 'created_at': now}]
     return record
 
 
-@app.get("/v0/office-collaboration/threads/{thread_id}")
+@app.get('/v0/office-collaboration/threads/{thread_id}')
 def get_thread(thread_id: str) -> dict[str, object]:
     record = THREADS.get(thread_id)
     if record is None:
-        raise HTTPException(status_code=404, detail="thread not found")
+        raise HTTPException(status_code=404, detail='thread not found')
     return record
 
 
-@app.get("/v0/office-collaboration/documents/{document_id}/threads")
+@app.get('/v0/office-collaboration/documents/{document_id}/threads')
 def list_document_threads(document_id: str) -> dict[str, object]:
-    return {
-        "document_id": document_id,
-        "threads": [item for item in THREADS.values() if item["document_id"] == document_id],
-    }
+    return {'document_id': document_id, 'threads': [item for item in THREADS.values() if item['document_id'] == document_id]}
 
 
-@app.post("/v0/office-collaboration/threads/{thread_id}/messages")
+@app.post('/v0/office-collaboration/threads/{thread_id}/messages')
 def add_thread_message(thread_id: str, body: ThreadMessageIn) -> dict[str, object]:
     thread = THREADS.get(thread_id)
     if thread is None:
-        raise HTTPException(status_code=404, detail="thread not found")
+        raise HTTPException(status_code=404, detail='thread not found')
     now = datetime.now(timezone.utc).isoformat()
-    message = {
-        "message_id": body.message_id,
-        "thread_id": thread_id,
-        "actor_ref": body.actor_ref,
-        "body": body.body,
-        "created_at": now,
-    }
+    message = {'message_id': body.message_id, 'thread_id': thread_id, 'actor_ref': body.actor_ref, 'body': body.body, 'created_at': now}
     THREAD_MESSAGES.setdefault(thread_id, []).append(message)
-    THREAD_EVENTS.setdefault(thread_id, []).append(
-        {
-            "event_type": "MESSAGE_ADDED",
-            "thread_id": thread_id,
-            "message_id": body.message_id,
-            "actor_ref": body.actor_ref,
-            "created_at": now,
-        }
-    )
-    thread["updated_at"] = now
+    THREAD_EVENTS.setdefault(thread_id, []).append({'event_type': 'MESSAGE_ADDED', 'thread_id': thread_id, 'message_id': body.message_id, 'actor_ref': body.actor_ref, 'created_at': now})
+    thread['updated_at'] = now
     return message
 
 
-@app.get("/v0/office-collaboration/threads/{thread_id}/messages")
+@app.get('/v0/office-collaboration/threads/{thread_id}/messages')
 def list_thread_messages(thread_id: str) -> dict[str, object]:
     if thread_id not in THREADS:
-        raise HTTPException(status_code=404, detail="thread not found")
-    return {"thread_id": thread_id, "messages": THREAD_MESSAGES.get(thread_id, [])}
+        raise HTTPException(status_code=404, detail='thread not found')
+    return {'thread_id': thread_id, 'messages': THREAD_MESSAGES.get(thread_id, [])}
 
 
-@app.get("/v0/office-collaboration/threads/{thread_id}/events")
+@app.get('/v0/office-collaboration/threads/{thread_id}/events')
 def list_thread_events(thread_id: str) -> dict[str, object]:
     if thread_id not in THREADS:
-        raise HTTPException(status_code=404, detail="thread not found")
-    return {"thread_id": thread_id, "events": THREAD_EVENTS.get(thread_id, [])}
+        raise HTTPException(status_code=404, detail='thread not found')
+    return {'thread_id': thread_id, 'events': THREAD_EVENTS.get(thread_id, [])}
 
 
-@app.post("/v0/office-collaboration/threads/{thread_id}/status")
+@app.post('/v0/office-collaboration/threads/{thread_id}/status')
 def update_thread_status(thread_id: str, body: ThreadStatusIn) -> dict[str, object]:
     record = THREADS.get(thread_id)
     if record is None:
-        raise HTTPException(status_code=404, detail="thread not found")
+        raise HTTPException(status_code=404, detail='thread not found')
     now = datetime.now(timezone.utc).isoformat()
-    record["status"] = body.status
-    record["version_id"] = body.version_id
-    record["receipt_ref"] = body.receipt_ref
-    record["updated_at"] = now
-    THREAD_EVENTS.setdefault(thread_id, []).append(
-        {
-            "event_type": "THREAD_STATUS_UPDATED",
-            "thread_id": thread_id,
-            "status": body.status,
-            "version_id": body.version_id,
-            "receipt_ref": body.receipt_ref,
-            "created_at": now,
-        }
-    )
+    record['status'] = body.status
+    record['version_id'] = body.version_id
+    record['receipt_ref'] = body.receipt_ref
+    record['updated_at'] = now
+    THREAD_EVENTS.setdefault(thread_id, []).append({'event_type': 'THREAD_STATUS_UPDATED', 'thread_id': thread_id, 'status': body.status, 'version_id': body.version_id, 'receipt_ref': body.receipt_ref, 'created_at': now})
     return record
 
 
-@app.post("/v0/office-collaboration/suggestions")
+@app.post('/v0/office-collaboration/suggestions')
 def create_suggestion(body: SuggestionIn) -> dict[str, object]:
     now = datetime.now(timezone.utc).isoformat()
     record = {
-        "suggestion_id": body.suggestion_id,
-        "document_id": body.document_id,
-        "semantic_unit_ref": body.semantic_unit_ref,
-        "before_ref": body.before_ref,
-        "after_ref": body.after_ref,
-        "status": "PROPOSED",
-        "version_id": None,
-        "receipt_ref": None,
-        "created_at": now,
-        "updated_at": now,
+        'suggestion_id': body.suggestion_id,
+        'document_id': body.document_id,
+        'semantic_unit_ref': body.semantic_unit_ref,
+        'before_ref': body.before_ref,
+        'after_ref': body.after_ref,
+        'status': 'PROPOSED',
+        'version_id': None,
+        'receipt_ref': None,
+        'created_at': now,
+        'updated_at': now,
     }
     SUGGESTIONS[body.suggestion_id] = record
+    SUGGESTION_EVENTS[body.suggestion_id] = [{'event_type': 'SUGGESTION_CREATED', 'suggestion_id': body.suggestion_id, 'created_at': now}]
     return record
 
 
-@app.get("/v0/office-collaboration/suggestions/{suggestion_id}")
+@app.get('/v0/office-collaboration/suggestions/{suggestion_id}')
 def get_suggestion(suggestion_id: str) -> dict[str, object]:
     record = SUGGESTIONS.get(suggestion_id)
     if record is None:
-        raise HTTPException(status_code=404, detail="suggestion not found")
+        raise HTTPException(status_code=404, detail='suggestion not found')
     return record
 
 
-@app.get("/v0/office-collaboration/documents/{document_id}/suggestions")
+@app.get('/v0/office-collaboration/suggestions/{suggestion_id}/events')
+def list_suggestion_events(suggestion_id: str) -> dict[str, object]:
+    if suggestion_id not in SUGGESTIONS:
+        raise HTTPException(status_code=404, detail='suggestion not found')
+    return {'suggestion_id': suggestion_id, 'events': SUGGESTION_EVENTS.get(suggestion_id, [])}
+
+
+@app.get('/v0/office-collaboration/documents/{document_id}/suggestions')
 def list_document_suggestions(document_id: str) -> dict[str, object]:
-    return {
-        "document_id": document_id,
-        "suggestions": [item for item in SUGGESTIONS.values() if item["document_id"] == document_id],
-    }
+    return {'document_id': document_id, 'suggestions': [item for item in SUGGESTIONS.values() if item['document_id'] == document_id]}
 
 
-@app.post("/v0/office-collaboration/suggestions/{suggestion_id}/status")
+@app.post('/v0/office-collaboration/suggestions/{suggestion_id}/status')
 def update_suggestion_status(suggestion_id: str, body: SuggestionStatusIn) -> dict[str, object]:
     record = SUGGESTIONS.get(suggestion_id)
     if record is None:
-        raise HTTPException(status_code=404, detail="suggestion not found")
-    record["status"] = body.status
-    record["version_id"] = body.version_id
-    record["receipt_ref"] = body.receipt_ref
-    record["updated_at"] = datetime.now(timezone.utc).isoformat()
+        raise HTTPException(status_code=404, detail='suggestion not found')
+    now = datetime.now(timezone.utc).isoformat()
+    record['status'] = body.status
+    record['version_id'] = body.version_id
+    record['receipt_ref'] = body.receipt_ref
+    record['updated_at'] = now
+    SUGGESTION_EVENTS.setdefault(suggestion_id, []).append({'event_type': 'SUGGESTION_STATUS_UPDATED', 'suggestion_id': suggestion_id, 'status': body.status, 'version_id': body.version_id, 'receipt_ref': body.receipt_ref, 'created_at': now})
     return record

--- a/services/office-collaboration/tests/test_suggestion_event_history.py
+++ b/services/office-collaboration/tests/test_suggestion_event_history.py
@@ -1,0 +1,32 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_suggestion_event_history_tracks_create_and_status_change() -> None:
+    created = client.post(
+        '/v0/office-collaboration/suggestions',
+        json={
+            'suggestion_id': 's1',
+            'document_id': 'doc1',
+            'before_ref': 'before',
+            'after_ref': 'after',
+        },
+    )
+    assert created.status_code == 200
+
+    updated = client.post(
+        '/v0/office-collaboration/suggestions/s1/status',
+        json={'status': 'ACCEPTED', 'version_id': 'version-doc1-002', 'receipt_ref': 'receipt-2'},
+    )
+    assert updated.status_code == 200
+
+    events = client.get('/v0/office-collaboration/suggestions/s1/events')
+    assert events.status_code == 200
+    assert events.json()['events'][0]['event_type'] == 'SUGGESTION_CREATED'
+    assert events.json()['events'][-1]['event_type'] == 'SUGGESTION_STATUS_UPDATED'
+    assert events.json()['events'][-1]['version_id'] == 'version-doc1-002'
+    assert events.json()['events'][-1]['receipt_ref'] == 'receipt-2'


### PR DESCRIPTION
## Summary

Add suggestion event history on top of the current office-collaboration runtime.

Files:
- `services/office-collaboration/app/main.py`
- `services/office-collaboration/tests/test_suggestion_event_history.py`

## Why

Current `main` already has thread events and version-aware status updates. This follow-on adds the same kind of auditable event history for suggestions so review behavior is less state-only and more traceable.
