### PR TITLE
Add Fog Stack registry root and rollback index

### DIFF
--- a/.github/workflows/fogstack-registry-root.yml
+++ b/.github/workflows/fogstack-registry-root.yml
@@ -1,0 +1,52 @@
+name: FogStack Registry Root
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "schemas/release/fogstack-registry-root-metadata-v0.1.schema.json"
+      - "schemas/release/fogstack-registry-revocation-index-v0.1.schema.json"
+      - "tools/build_fogstack_registry_root_metadata.py"
+      - "tools/check_fogstack_registry_root_metadata.py"
+      - "tools/build_fogstack_registry_revocation_index.py"
+      - "tools/check_fogstack_registry_revocation_index.py"
+      - "tools/tests/test_fogstack_registry_root_metadata.py"
+      - "docs/FOGSTACK_*.md"
+      - ".github/workflows/fogstack-registry-root.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/release/fogstack-registry-root-metadata-v0.1.schema.json"
+      - "schemas/release/fogstack-registry-revocation-index-v0.1.schema.json"
+      - "tools/build_fogstack_registry_root_metadata.py"
+      - "tools/check_fogstack_registry_root_metadata.py"
+      - "tools/build_fogstack_registry_revocation_index.py"
+      - "tools/check_fogstack_registry_revocation_index.py"
+      - "tools/tests/test_fogstack_registry_root_metadata.py"
+      - "docs/FOGSTACK_*.md"
+      - ".github/workflows/fogstack-registry-root.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  registry-root:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Run registry root tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_registry_root_metadata.py

--- a/docs/FOGSTACK_REGISTRY_ROOT.md
+++ b/docs/FOGSTACK_REGISTRY_ROOT.md
@@ -1,0 +1,60 @@
+# Fog Stack registry root and rollback index
+
+This document defines the repo-native registry root metadata and rollback/revocation index for Fog Stack releases.
+
+## Goal
+
+Move from a filesystem registry layout to a root metadata surface that records the current registry state and a rollback/revocation index that can mark releases as revoked or rolled back.
+
+## Registry root metadata
+
+The registry root metadata schema lives at:
+
+- `schemas/release/fogstack-registry-root-metadata-v0.1.schema.json`
+
+The registry root records:
+
+- registry URI
+- release entries
+- release pointer references and digests
+- registry publication index references and digests
+- rollback/revocation index reference and digest
+- signature metadata for future signed-root enforcement
+
+## Rollback / revocation index
+
+The rollback/revocation index schema lives at:
+
+- `schemas/release/fogstack-registry-revocation-index-v0.1.schema.json`
+
+The index records release entries with:
+
+- bundle id
+- version
+- status: `revoked` or `rollback`
+- reason
+- optional superseding release reference
+
+## Minimal flow
+
+1. publish one or more releases into the filesystem registry
+2. build a rollback/revocation index with `tools/build_fogstack_registry_revocation_index.py`
+3. check it with `tools/check_fogstack_registry_revocation_index.py`
+4. build registry root metadata with `tools/build_fogstack_registry_root_metadata.py`
+5. check it with `tools/check_fogstack_registry_root_metadata.py`
+
+## What this phase provides
+
+- registry root metadata schema
+- rollback/revocation index schema
+- builders and checkers for both surfaces
+- CI coverage for root and rollback/revocation behavior
+
+## What this phase does not yet provide
+
+- cryptographic signing and verification of registry root metadata
+- externally hosted registry root publication
+- automated client-side rollback enforcement
+- KMS/HSM-backed registry root signing keys
+
+Those remain later hardening steps.

--- a/schemas/release/fogstack-registry-revocation-index-v0.1.schema.json
+++ b/schemas/release/fogstack-registry-revocation-index-v0.1.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-registry-revocation-index-v0.1.schema.json",
+  "title": "FogStackRegistryRevocationIndex",
+  "type": "object",
+  "required": ["kind", "schema_version", "entries"],
+  "properties": {
+    "kind": { "const": "FogStackRegistryRevocationIndex" },
+    "schema_version": { "const": "v0.1" },
+    "entries": { "type": "array" }
+  },
+  "additionalProperties": true
+}

--- a/schemas/release/fogstack-registry-root-metadata-v0.1.schema.json
+++ b/schemas/release/fogstack-registry-root-metadata-v0.1.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/release/fogstack-registry-root-metadata-v0.1.schema.json",
+  "title": "FogStackRegistryRootMetadata",
+  "type": "object",
+  "required": ["kind", "schema_version", "registry_uri", "releases", "signed"],
+  "properties": {
+    "kind": { "const": "FogStackRegistryRootMetadata" },
+    "schema_version": { "const": "v0.1" },
+    "registry_uri": { "type": "string" },
+    "releases": { "type": "array" },
+    "revocation_index_ref": { "type": ["string", "null"] },
+    "revocation_index_digest": { "type": ["string", "null"] },
+    "signed": { "type": "boolean" },
+    "signature": { "type": ["object", "null"] }
+  },
+  "additionalProperties": true
+}

--- a/tools/build_fogstack_registry_revocation_index.py
+++ b/tools/build_fogstack_registry_revocation_index.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_entry(value: str) -> dict[str, str | None]:
+    parts = value.split(":", 4)
+    if len(parts) < 3:
+        raise SystemExit("ERR: entries must be bundle_id:version:status[:reason[:superseded_by]]")
+    bundle_id, version, status = parts[0], parts[1], parts[2]
+    if status not in {"revoked", "rollback"}:
+        raise SystemExit("ERR: status must be revoked or rollback")
+    reason = parts[3] if len(parts) >= 4 and parts[3] else None
+    superseded_by = parts[4] if len(parts) == 5 and parts[4] else None
+    return {
+        "bundle_id": bundle_id,
+        "version": version,
+        "status": status,
+        "reason": reason,
+        "superseded_by": superseded_by,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a Fog Stack registry revocation index")
+    parser.add_argument("--entry", action="append", default=[], help="bundle_id:version:status[:reason[:superseded_by]]")
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    index = {
+        "kind": "FogStackRegistryRevocationIndex",
+        "schema_version": "v0.1",
+        "entries": [parse_entry(item) for item in args.entry],
+    }
+    text = json.dumps(index, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/build_fogstack_registry_root_metadata.py
+++ b/tools/build_fogstack_registry_root_metadata.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build Fog Stack registry root metadata")
+    parser.add_argument("--registry-uri", required=True)
+    parser.add_argument("--release", action="append", nargs=3, metavar=("BUNDLE_ID", "VERSION", "RELEASE_ROOT"), required=True)
+    parser.add_argument("--revocation-index", type=Path, default=None)
+    parser.add_argument("--signature-type", choices=["cosign", "sigstore", "other"], default=None)
+    parser.add_argument("--signature-ref", default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args()
+
+    releases = []
+    for bundle_id, version, release_root_str in args.release:
+        release_root = Path(release_root_str)
+        pointer = release_root / "release-pointer.json"
+        index = release_root / "registry-publication.index.json"
+        if not pointer.exists():
+            raise SystemExit(f"ERR: missing release pointer: {pointer}")
+        if not index.exists():
+            raise SystemExit(f"ERR: missing registry index: {index}")
+        releases.append({
+            "bundle_id": bundle_id,
+            "version": version,
+            "release_pointer_ref": str(pointer),
+            "release_pointer_digest": sha256_file(pointer),
+            "registry_publication_index_ref": str(index),
+            "registry_publication_index_digest": sha256_file(index),
+        })
+
+    rev_ref = str(args.revocation_index) if args.revocation_index else None
+    rev_digest = sha256_file(args.revocation_index) if args.revocation_index else None
+    signed = bool(args.signature_type and args.signature_ref)
+    root = {
+        "kind": "FogStackRegistryRootMetadata",
+        "schema_version": "v0.1",
+        "registry_uri": args.registry_uri,
+        "releases": releases,
+        "revocation_index_ref": rev_ref,
+        "revocation_index_digest": rev_digest,
+        "signed": signed,
+        "signature": {"type": args.signature_type, "ref": args.signature_ref} if signed else None,
+    }
+
+    text = json.dumps(root, indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_fogstack_registry_revocation_index.py
+++ b/tools/check_fogstack_registry_revocation_index.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check a Fog Stack registry revocation index")
+    parser.add_argument("--index", required=True, type=Path)
+    args = parser.parse_args()
+
+    index = load_json(args.index)
+    errors: list[str] = []
+    if index.get("kind") != "FogStackRegistryRevocationIndex":
+        errors.append("index kind mismatch")
+
+    seen: set[tuple[str, str]] = set()
+    entries = index.get("entries")
+    if not isinstance(entries, list):
+        errors.append("entries must be a list")
+    else:
+        for entry in entries:
+            if not isinstance(entry, dict):
+                errors.append("entry is not an object")
+                continue
+            bundle_id = entry.get("bundle_id")
+            version = entry.get("version")
+            status = entry.get("status")
+            if not isinstance(bundle_id, str) or not bundle_id:
+                errors.append("entry missing bundle_id")
+            if not isinstance(version, str) or not version:
+                errors.append("entry missing version")
+            if status not in {"revoked", "rollback"}:
+                errors.append(f"invalid status: {status}")
+            key = (str(bundle_id), str(version))
+            if key in seen:
+                errors.append(f"duplicate entry: {bundle_id}@{version}")
+            seen.add(key)
+
+    if errors:
+        print("\n".join(errors))
+        return 1
+    print("FogStack registry revocation index passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_fogstack_registry_root_metadata.py
+++ b/tools/check_fogstack_registry_root_metadata.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+
+def load_json(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return value
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check Fog Stack registry root metadata")
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--require-signed", action="store_true")
+    args = parser.parse_args()
+
+    root = load_json(args.root)
+    errors: list[str] = []
+
+    if root.get("kind") != "FogStackRegistryRootMetadata":
+        errors.append("root kind mismatch")
+    if not root.get("registry_uri"):
+        errors.append("registry_uri missing")
+
+    for release in root.get("releases") or []:
+        for ref_key, digest_key in [
+            ("release_pointer_ref", "release_pointer_digest"),
+            ("registry_publication_index_ref", "registry_publication_index_digest"),
+        ]:
+            ref = release.get(ref_key) if isinstance(release, dict) else None
+            expected = release.get(digest_key) if isinstance(release, dict) else None
+            if not isinstance(ref, str) or not Path(ref).exists():
+                errors.append(f"missing ref: {ref}")
+                continue
+            if sha256_file(Path(ref)) != expected:
+                errors.append(f"digest mismatch: {ref}")
+
+    ref = root.get("revocation_index_ref")
+    expected = root.get("revocation_index_digest")
+    if isinstance(ref, str):
+        if not Path(ref).exists():
+            errors.append(f"missing index: {ref}")
+        elif sha256_file(Path(ref)) != expected:
+            errors.append("index digest mismatch")
+
+    if args.require_signed:
+        sig = root.get("signature")
+        if root.get("signed") is not True:
+            errors.append("root not signed")
+        if not isinstance(sig, dict) or not sig.get("ref"):
+            errors.append("signature metadata missing")
+
+    if errors:
+        print("\n".join(errors))
+        return 1
+    print("FogStack registry root metadata passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_registry_root_metadata.py
+++ b/tools/tests/test_fogstack_registry_root_metadata.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_and_check_registry_root_metadata(tmp_path: Path) -> None:
+    release_root = tmp_path / "registry" / "fogstack.access" / "0.1.0"
+    pointer = release_root / "release-pointer.json"
+    index = release_root / "registry-publication.index.json"
+    revocations = tmp_path / "revocations.json"
+    root = tmp_path / "registry-root.json"
+
+    write_json(pointer, {
+        "kind": "FogStackFilesystemRegistryReleasePointer",
+        "schema_version": "v0.1",
+        "bundle_id": "fogstack.access",
+        "version": "0.1.0",
+        "index_ref": str(index),
+        "index_digest": "sha256:test",
+    })
+    write_json(index, {
+        "kind": "FogStackRegistryPublicationIndex",
+        "schema_version": "v0.1",
+        "registry_uri": "file://registry",
+        "artifacts": [],
+    })
+
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_registry_revocation_index.py",
+        "--entry", "fogstack.old:0.0.1:revoked:superseded:",
+        "--output", str(revocations),
+    ], check=True)
+
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_registry_root_metadata.py",
+        "--registry-uri", "file://registry",
+        "--release", "fogstack.access", "0.1.0", str(release_root),
+        "--revocation-index", str(revocations),
+        "--signature-type", "other",
+        "--signature-ref", "artifact://registry/root.sig",
+        "--output", str(root),
+    ], check=True)
+
+    data = json.loads(root.read_text(encoding="utf-8"))
+    assert data["kind"] == "FogStackRegistryRootMetadata"
+    assert data["signed"] is True
+    assert data["releases"][0]["release_pointer_digest"].startswith("sha256:")
+    assert data["revocation_index_digest"].startswith("sha256:")
+
+    subprocess.run([
+        sys.executable,
+        "tools/check_fogstack_registry_root_metadata.py",
+        "--root", str(root),
+        "--require-signed",
+    ], check=True)
+
+
+def test_registry_root_checker_rejects_bad_pointer_digest(tmp_path: Path) -> None:
+    release_root = tmp_path / "registry" / "fogstack.access" / "0.1.0"
+    pointer = release_root / "release-pointer.json"
+    index = release_root / "registry-publication.index.json"
+    root = tmp_path / "registry-root.json"
+
+    write_json(pointer, {"kind": "pointer"})
+    write_json(index, {"kind": "index"})
+    write_json(root, {
+        "kind": "FogStackRegistryRootMetadata",
+        "schema_version": "v0.1",
+        "registry_uri": "file://registry",
+        "signed": True,
+        "signature": {"type": "other", "ref": "artifact://registry/root.sig"},
+        "releases": [
+            {
+                "bundle_id": "fogstack.access",
+                "version": "0.1.0",
+                "release_pointer_ref": str(pointer),
+                "release_pointer_digest": "sha256:wrong",
+                "registry_publication_index_ref": str(index),
+                "registry_publication_index_digest": "sha256:wrong",
+            }
+        ],
+    })
+
+    proc = subprocess.run([
+        sys.executable,
+        "tools/check_fogstack_registry_root_metadata.py",
+        "--root", str(root),
+        "--require-signed",
+    ])
+    assert proc.returncode != 0
+
+
+def test_revocation_index_checker_rejects_duplicates(tmp_path: Path) -> None:
+    revocations = tmp_path / "revocations.json"
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_registry_revocation_index.py",
+        "--entry", "fogstack.access:0.1.0:revoked:first:",
+        "--entry", "fogstack.access:0.1.0:rollback:duplicate:fogstack.access@0.0.9",
+        "--output", str(revocations),
+    ], check=True)
+
+    proc = subprocess.run([
+        sys.executable,
+        "tools/check_fogstack_registry_revocation_index.py",
+        "--index", str(revocations),
+    ])
+    assert proc.returncode != 0


### PR DESCRIPTION
## Summary

Implements the scoped FogStack registry root / rollback tranche from #320.

Adds:
- registry root metadata schema
- rollback/revocation index schema
- root builder/checker
- rollback/revocation builder/checker
- tests covering pass/fail paths
- CI workflow
- docs

## Review gate

Codex review is tracked in #322. Do not merge until #322 is approved or maintainer override is recorded.

## Non-goals

- no network registry publication
- no KMS/HSM signing
- no external identity-provider integration
- no Office/Lattice/GAIA/telemetry mutation

Closes #320.
