### PR TITLE
docs(fogstack): refresh pack readiness for Office, Lattice, and Registry surfaces

### DIFF
--- a/catalog/fogstack-packs-v0.1.yaml
+++ b/catalog/fogstack-packs-v0.1.yaml
@@ -31,6 +31,21 @@ packs:
       - "apps/eval-fabric-api"
       - "docs/PLATFORM_EVAL_FABRIC.md"
     notes: "Real platform surface, but still more internal than packaged."
+  - id: "fogstack.office"
+    label: "Fog Stack Office / Collaboration"
+    category: "product_surface"
+    readiness_pct: 55
+    repo_split_now: false
+    substrate_anchors:
+      - "services/office-collaboration"
+      - "schemas/office"
+      - "docs/OFFICE_COLLABORATION_RUNTIME.md"
+    notes: >
+      Executable collaboration runtime added via PRs #314–#319: thread creation, messages,
+      version-aware suggestion status, thread resolution, event history, and suggestion event
+      history are all in place with behavior tests. Schemas exist for collaboration thread and
+      suggestion records. Not yet hardened for production auth, durable persistence, or external
+      identity. Surface is at executable-demo posture, not production deployment.
   - id: "fogstack.security"
     label: "Fog Stack Security / Trust"
     category: "shared_capability"
@@ -40,21 +55,51 @@ packs:
       - "schemas/release/*"
       - "tools/*fogstack*"
     notes: "Strong platform capability, but not yet an independently packaged product surface."
-  - id: "fogstack.data"
-    label: "Fog Stack Data"
-    category: "packaging_view"
-    readiness_pct: 30
+  - id: "fogstack.registry"
+    label: "Fog Stack Registry / Release Distribution"
+    category: "product_surface"
+    readiness_pct: 60
     repo_split_now: false
     substrate_anchors:
-      - "knowledge + evaluation surfaces"
-    notes: "Better treated as a packaging view over Knowledge + Evaluation than as a separate repo."
-  - id: "fogstack.ai"
-    label: "Fog Stack AI"
-    category: "future_pack"
-    readiness_pct: 20
+      - "registry"
+      - "tools/promote_fogstack_manifest_publication_set.py"
+      - "tools/check_fogstack_manifest_promotion_policy.py"
+      - "tools/build_fogstack_registry_root_metadata.py"
+      - "tools/check_fogstack_registry_revocation_index.py"
+    notes: >
+      Gated, CI-backed artifact publication pipeline with filesystem registry adapter,
+      registry-root metadata, rollback/revocation lifecycle index, and local registry metadata
+      signature-verification support across PRs #211–#215, #224, #237, #248, and #324.
+      Known gaps: network registry publication, production KMS/HSM-backed signing, external
+      identity binding, client-side rollback/revocation enforcement, and operator-facing
+      release-distribution UX. No external registry or production deployment exists.
+  - id: "fogstack.data"
+    label: "Fog Stack Data / GovernAI"
+    category: "product_surface"
+    readiness_pct: 50
     repo_split_now: false
-    substrate_anchors: []
-    notes: "Not enough independent runtime/product surface yet."
+    substrate_anchors:
+      - "apps/lattice-studio"
+      - "knowledge + evaluation surfaces"
+    notes: >
+      Upgraded from 30% (packaging view) to 50% (fixture-ready product surface) following the
+      Lattice Studio/Data/GovernAI vertical slice in PRs #299–#308. Full deterministic fixture
+      path now covers product-spine, annotation-to-training, active metadata, trust/reputation,
+      and GovernAI routing consumers. Still fixture/demo-only; no live data backend, external
+      data contracts, or production data pipeline exists on main.
+  - id: "fogstack.ai"
+    label: "Fog Stack AI / Lattice Studio"
+    category: "product_surface"
+    readiness_pct: 45
+    repo_split_now: false
+    substrate_anchors:
+      - "apps/lattice-studio"
+    notes: >
+      Upgraded from 20% (conceptual future pack) to 45% (fixture-ready product surface) following
+      the Lattice Studio vertical slice in PRs #299–#308: model zoo, prompt/RAG/evaluation lab,
+      publication review, runtime profile catalog (three Lattice Forge runtimes), demo readiness
+      report, and runtime release readiness fixture. All surfaces are fixture/demo-only; no live
+      inference, model training, serving infrastructure, or production ML pipeline exists on main.
   - id: "fogstack.automation"
     label: "Fog Stack Automation"
     category: "future_pack"

--- a/docs/FOGSTACK_PACKS.md
+++ b/docs/FOGSTACK_PACKS.md
@@ -28,23 +28,35 @@ The shared trust/release graph is still the dominant implementation concern, and
 - Repo split now: no
 - Why: real platform surface, but still more internal than packaged.
 
+### Fog Stack Office / Collaboration
+- Type: real product surface (executable-demo posture)
+- Readiness: 55%
+- Repo split now: no
+- Why: an executable collaboration runtime landed via PRs #314–#319 with thread creation, messages, version-aware suggestion status, thread and suggestion resolution, and full event-history behaviors, all covered by behavior tests. JSON schemas exist for thread and suggestion records. Not yet hardened for production auth, durable persistence, or external identity; surface is at executable-demo posture, not production deployment.
+
 ### Fog Stack Security / Trust
 - Type: strong shared capability
 - Readiness: 80% as platform capability / 35% as standalone pack
 - Repo split now: no
 - Why: the shared trust/release graph is still the dominant engineering concern.
 
-### Fog Stack Data
-- Type: emerging packaging view
-- Readiness: 30%
+### Fog Stack Registry / Release Distribution
+- Type: real product surface (demo/CI posture)
+- Readiness: 60%
 - Repo split now: no
-- Why: better treated as a packaging view over Knowledge + Evaluation than as an independent engineering island.
+- Why: the registry/release-distribution lane now includes gated publication, filesystem registry export, registry publication indexes, registry-root metadata, rollback/revocation lifecycle indexes, and local registry metadata signature-verification support across PRs #211–#215, #224, #237, #248, and #324. It is no longer just a future release-plumbing concept. Remaining gaps are network registry publication, production KMS/HSM-backed signing, external identity binding, client-side rollback/revocation enforcement, and operator-facing release-distribution UX. No external registry or production deployment exists on main.
 
-### Fog Stack AI
-- Type: conceptual future pack
-- Readiness: 20%
+### Fog Stack Data / GovernAI
+- Type: fixture-ready product surface
+- Readiness: 50%
 - Repo split now: no
-- Why: not enough independent runtime/product surface yet.
+- Why: upgraded from 30% (packaging view over Knowledge + Evaluation) to 50% following the Lattice Studio/Data/GovernAI vertical slice merged in PRs #299–#308. The full deterministic fixture path now covers product-spine, annotation-to-training, active metadata, trust/reputation signals, and GovernAI routing consumers. Still fixture/demo-only; no live data backend, external data contracts, or production data pipeline exists on main.
+
+### Fog Stack AI / Lattice Studio
+- Type: fixture-ready product surface
+- Readiness: 45%
+- Repo split now: no
+- Why: upgraded from 20% (conceptual future pack) to 45% following the Lattice Studio vertical slice in PRs #299–#308. The surface now includes model zoo, prompt/RAG/evaluation lab, publication review/reproduction, runtime profile catalog (three Lattice Forge runtimes), a demo readiness report, and a runtime release readiness fixture. All surfaces are fixture/demo-only; no live inference, model training, serving infrastructure, or production ML pipeline exists on main.
 
 ### Fog Stack Automation
 - Type: conceptual future pack

--- a/docs/FOGSTACK_STATUS.md
+++ b/docs/FOGSTACK_STATUS.md
@@ -28,6 +28,9 @@ The following initial offering slices are already merged into `main`:
 - **Fog Stack Access** — initial upstream offering slice via PR #25
 - **Fog Stack Knowledge** — governed ingress + local daemon offering slice via PR #26
 - **Fog Stack Evaluation** — evaluation fabric offering slice via PR #27
+- **Fog Stack Office / Collaboration** — office collaboration runtime schema and service slice via PRs #314–#319
+- **Fog Stack Data / GovernAI** — Lattice Studio/Data/GovernAI product-surface fixtures (product-spine, annotation-to-training, active metadata, trust/reputation, runtime profile catalog, demo readiness report, runtime release readiness) via PRs #299–#308
+- **Fog Stack AI / Lattice Studio** — Lattice Studio AI product-surface fixtures (model zoo, prompt/RAG/eval lab, publication review, runtime profile catalog, demo readiness report, runtime release readiness) via PRs #299–#308
 
 ## Merged validation and release-engineering slices
 
@@ -66,10 +69,15 @@ The following supporting slices are already merged into `main`:
 - release publication gate via PR #211
 - registry publication index via PR #212
 - filesystem registry adapter via PR #215
+- filesystem registry root builder/checker via PR #224
+- registry rollback/revocation lifecycle index via PR #237
+- local OpenSSL-backed registry metadata signature verification via PR #248
+- registry-root metadata and rollback/revocation tranche via PR #324
+- tightened registry root and revocation schemas via PR #330
 
 ## Current active frontier
 
-Fog Stack is past initial offering definition and past local trust-graph construction. The active frontier is now release publication and registry hardening.
+Fog Stack is past initial offering definition, local trust-graph construction, first-generation filesystem registry publication, registry-root metadata, rollback/revocation lifecycle indexing, local registry metadata signature verification, and strict registry schema hardening. The active frontier is now Office / Collaboration service hardening, Lattice Studio/Data/GovernAI live-backend readiness, network registry publication, production signing/identity integration, and operator-facing release-distribution UX.
 
 The current release path is:
 
@@ -82,10 +90,25 @@ The current release path is:
 7. emit a release publication gate record
 8. build a registry publication index
 9. publish the gated index and referenced artifacts to a filesystem registry layout
+10. emit registry-root metadata and rollback/revocation lifecycle indexes
+11. locally verify registry metadata signatures where fixture OpenSSL signing is present
+12. validate registry root and revocation metadata against tightened schemas
 
 ## Product-pack readiness matrix
 
-The detailed matrix and pack taxonomy live in:
+| Pack | Readiness | Category | Notes |
+|---|---|---|---|
+| Fog Stack Access | 70% | product_surface | Most mature customer-facing surface |
+| Fog Stack Knowledge | 55% | product_surface | Composition-heavy, operationally mixed |
+| Fog Stack Evaluation | 55% | product_surface | More internal than packaged |
+| Fog Stack Office / Collaboration | 55% | product_surface | Executable-demo posture; PRs #314–#319 |
+| Fog Stack Security / Trust | 35% (standalone) | shared_capability | 80% as platform capability |
+| Fog Stack Registry / Release Distribution | 60% | product_surface | Filesystem registry, root metadata, lifecycle index, local signature verification, and strict schemas; PRs #211–#215, #224, #237, #248, #324, #330 |
+| Fog Stack Data / GovernAI | 50% | product_surface | Fixture-ready; upgraded from 30%; PRs #299–#308 |
+| Fog Stack AI / Lattice Studio | 45% | product_surface | Fixture-ready; upgraded from 20%; PRs #299–#308 |
+| Fog Stack Automation | 20% | future_pack | No distinct surface yet |
+
+The detailed taxonomy and per-pack notes live in:
 - `docs/FOGSTACK_PACKS.md`
 - `catalog/fogstack-packs-v0.1.yaml`
 
@@ -112,18 +135,23 @@ The release/trust/publication graph now consists of these machine-readable artif
 - release publication gate record
 - registry publication index
 - filesystem registry publication/check artifacts
+- filesystem registry root metadata
+- registry-root metadata
+- rollback/revocation lifecycle index
+- registry metadata signature-verification evidence
+- tightened registry root and revocation schemas
 
 ## Known gaps and next tranches
 
 The next release-engineering tranche should focus on:
 
 1. **Network registry publication** beyond filesystem registry export.
-2. **Signed registry root metadata** so registry consumers can verify the registry root, not just individual artifact records.
-3. **Rollback and revocation indexes** for promoted or published artifact sets.
+2. **Production signing and identity binding**: KMS/HSM-backed registry and release signing, external identity-provider binding, and policy-managed key lifecycle.
+3. **Client-side rollback/revocation enforcement** so consumers act on lifecycle indexes rather than merely validating their shape.
 4. **Signature verification pipeline exit-code hygiene** so digest mismatch and malformed input fail hard at the CLI layer.
-5. **Status and registry docs kept current** whenever publication gates or registry adapters land.
-6. **External identity-provider / KMS / HSM integration** for release identity and signing keys when the workflow moves beyond local demo-grade keys.
+5. **Operator-facing release-distribution UX** including one-command local demo, release-readiness dashboards, and pack-specific smoke deployments.
+6. **Status and registry docs kept current** whenever publication gates, registry adapters, lifecycle indexes, signing tranches, or schema hardening land.
 
 ## Position in the maturity ladder
 
-Fog Stack in `prophet-platform` is now in release-publication hardening. It has moved from offering taxonomy and local trust records into gated, CI-backed, registry-ready artifact publication surfaces. The immediate risk is stale status documentation or weak CLI semantics causing operators to misread publication readiness.
+Fog Stack in `prophet-platform` is now in registry-backed release-distribution hardening. It has moved from offering taxonomy and local trust records into gated, CI-backed, filesystem-registry artifact publication with root metadata, lifecycle index, local signature-verification support, and tightened registry schemas. The immediate risk is stale status documentation or weak CLI semantics causing operators to misread publication readiness.


### PR DESCRIPTION
## Summary

Clean non-draft replacement for closed draft PR #326. Refreshes FogStack pack readiness after recent upstream Office collaboration, Lattice Studio/Data/GovernAI, and registry-root/lifecycle/signature-hardening work.

## Changes

- Updates `catalog/fogstack-packs-v0.1.yaml`:
  - adds `fogstack.office` at 55% executable-demo posture
  - adds `fogstack.registry` at 60% after filesystem registry, root metadata, rollback/revocation lifecycle index, local registry metadata signature verification, and schema hardening
  - upgrades `fogstack.data` to Data / GovernAI at 50% fixture-ready product-surface posture
  - upgrades `fogstack.ai` to AI / Lattice Studio at 45% fixture-ready product-surface posture
  - preserves `repository_strategy: single-repo-for-now`
- Updates `docs/FOGSTACK_PACKS.md` with matching pack prose.
- Updates `docs/FOGSTACK_STATUS.md` with:
  - Office, Data/GovernAI, and AI/Lattice offering slices
  - registry-root / rollback-revocation / local signature-verification / strict-schema maturity
  - corrected readiness matrix
  - remaining gaps for network registry, production signing/identity, client enforcement, CLI exit-code hygiene, and operator UX

## Safety boundary

- Docs/catalog only.
- No runtime code changes.
- No new repos.
- No pack ID renames.
- No claim of external registry, production deployment, KMS/HSM signing, live data backend, live inference/training, or client-side rollback enforcement.

Closes #321.
Review gate: #328.
Supersedes closed draft PR #326.