### PR TITLE
fogstack: add one-command local release demo

### DIFF
--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -1,0 +1,82 @@
+name: FogStack Local Demo
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "bundles/**"
+      - "conformance/**"
+      - "catalog/fogstack-support-states-v0.1.yaml"
+      - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
+      - "catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml"
+      - "catalog/fogstack-release-publication-gate-policy-v0.1.yaml"
+      - "releases/manifests/**"
+      - "tools/run_fogstack_local_demo.py"
+      - "tools/fogstack_verify.py"
+      - "tools/emit_fogstack_validation_record.py"
+      - "tools/build_fogstack_manifest_publication_set.py"
+      - "tools/promote_fogstack_manifest_publication_set.py"
+      - "tools/check_fogstack_manifest_promotion_policy.py"
+      - "tools/emit_fogstack_manifest_promotion_approval_record.py"
+      - "tools/check_fogstack_manifest_promotion_approval_record.py"
+      - "tools/check_fogstack_manifest_promotion_approver_policy.py"
+      - "tools/run_openssl_fogstack_manifest_promotion_approval_verifier.py"
+      - "tools/emit_fogstack_release_publication_gate_record.py"
+      - "tools/build_fogstack_registry_publication_index.py"
+      - "tools/publish_fogstack_filesystem_registry.py"
+      - "tools/check_fogstack_filesystem_registry.py"
+      - "tools/build_fogstack_registry_revocation_index.py"
+      - "tools/check_fogstack_registry_revocation_index.py"
+      - "tools/build_fogstack_registry_root_metadata.py"
+      - "tools/check_fogstack_registry_root_metadata.py"
+      - "tools/tests/test_run_fogstack_local_demo.py"
+      - ".github/workflows/fogstack-local-demo.yml"
+  push:
+    branches: [main]
+    paths:
+      - "bundles/**"
+      - "conformance/**"
+      - "catalog/fogstack-support-states-v0.1.yaml"
+      - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
+      - "catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml"
+      - "catalog/fogstack-release-publication-gate-policy-v0.1.yaml"
+      - "releases/manifests/**"
+      - "tools/run_fogstack_local_demo.py"
+      - "tools/tests/test_run_fogstack_local_demo.py"
+      - ".github/workflows/fogstack-local-demo.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  fogstack-local-demo:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml
+
+      - name: Run local demo end-to-end test
+        run: |
+          python -m pytest -q tools/tests/test_run_fogstack_local_demo.py
+
+      - name: Run operator demo command
+        run: |
+          python3 tools/run_fogstack_local_demo.py --pack access --output-dir build/fogstack-local-demo
+
+      - name: Upload local demo artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fogstack-local-demo
+          path: build/fogstack-local-demo/
+          if-no-files-found: error

--- a/tools/run_fogstack_local_demo.py
+++ b/tools/run_fogstack_local_demo.py
@@ -77,6 +77,19 @@ def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
     lifecycle_dir = output_dir / "lifecycle"
     root_dir = output_dir / "root"
 
+    for path in [
+        validation_dir,
+        publication_dir,
+        promoted_dir,
+        approval_dir,
+        gate_dir,
+        registry_publication_dir,
+        registry_root_dir,
+        lifecycle_dir,
+        root_dir,
+    ]:
+        path.mkdir(parents=True, exist_ok=True)
+
     verify_json = validation_dir / f"{bundle_id}.verify.json"
     validation_record = validation_dir / f"{bundle_id}.validation.record.json"
 
@@ -157,7 +170,6 @@ def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
         "--approver-policy", str(approver_policy),
     ])
 
-    approval_dir.mkdir(parents=True, exist_ok=True)
     run(["openssl", "genpkey", "-algorithm", "RSA", "-out", str(approval_private)])
     run(["openssl", "pkey", "-in", str(approval_private), "-pubout", "-out", str(approval_public)])
     run([

--- a/tools/run_fogstack_local_demo.py
+++ b/tools/run_fogstack_local_demo.py
@@ -221,6 +221,13 @@ def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
         "--bundle-id", bundle_id,
         "--version", version,
     ], stdout=registry_publication_dir / "release-pointer.json")
+    run([
+        sys.executable,
+        "tools/check_fogstack_filesystem_registry.py",
+        "--registry-root", str(registry_root_dir),
+        "--bundle-id", bundle_id,
+        "--version", version,
+    ])
 
     revocation_index = lifecycle_dir / "registry-revocation-index.json"
     run([
@@ -284,6 +291,7 @@ def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
             "publication_gate_passed",
             "registry_index_built",
             "filesystem_registry_published",
+            "filesystem_registry_checked",
             "revocation_index_checked",
             "registry_root_checked",
         ],

--- a/tools/run_fogstack_local_demo.py
+++ b/tools/run_fogstack_local_demo.py
@@ -93,7 +93,7 @@ def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
         "--verifier-json", str(verify_json),
         "--bundle-id", bundle_id,
         "--version", version,
-        "--source", "local-demo",
+        "--source", "local",
         "--evidence-ref", rel(verify_json),
         "--output", str(validation_record),
     ])

--- a/tools/run_fogstack_local_demo.py
+++ b/tools/run_fogstack_local_demo.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PACKS: dict[str, dict[str, str]] = {
+    "access": {
+        "bundle_id": "fogstack.access",
+        "version": "0.1.0",
+        "bundle": "bundles/fogstack.access-v0.1.yaml",
+        "manifest": "releases/manifests/fogstack.access-v0.1.manifest.json",
+    }
+}
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def run(cmd: list[str], *, stdout: Path | None = None) -> None:
+    if stdout:
+        stdout.parent.mkdir(parents=True, exist_ok=True)
+        with stdout.open("w", encoding="utf-8") as handle:
+            subprocess.run(cmd, cwd=ROOT, check=True, stdout=handle)
+    else:
+        subprocess.run(cmd, cwd=ROOT, check=True)
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
+    if pack not in PACKS:
+        raise SystemExit(f"ERR: unsupported FogStack local demo pack: {pack}")
+
+    cfg = PACKS[pack]
+    bundle_id = cfg["bundle_id"]
+    version = cfg["version"]
+    bundle = ROOT / cfg["bundle"]
+    manifest = ROOT / cfg["manifest"]
+    support_catalog = ROOT / "catalog" / "fogstack-support-states-v0.1.yaml"
+    promotion_policy = ROOT / "catalog" / "fogstack-manifest-promotion-policy-v0.1.yaml"
+    approver_policy = ROOT / "catalog" / "fogstack-manifest-promotion-approver-policy-v0.1.yaml"
+    publication_gate_policy = ROOT / "catalog" / "fogstack-release-publication-gate-policy-v0.1.yaml"
+
+    required = [bundle, manifest, support_catalog, promotion_policy, approver_policy, publication_gate_policy]
+    missing = [path for path in required if not path.exists()]
+    if missing:
+        raise SystemExit("ERR: missing local demo inputs: " + ", ".join(rel(path) for path in missing))
+
+    output_dir = output_dir if output_dir.is_absolute() else ROOT / output_dir
+    if clean and output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    validation_dir = output_dir / "validation"
+    publication_dir = output_dir / "publication"
+    promoted_dir = output_dir / "promoted"
+    approval_dir = output_dir / "approval"
+    gate_dir = output_dir / "gate"
+    registry_publication_dir = output_dir / "registry-publication"
+    registry_root_dir = output_dir / "registry"
+    lifecycle_dir = output_dir / "lifecycle"
+    root_dir = output_dir / "root"
+
+    verify_json = validation_dir / f"{bundle_id}.verify.json"
+    validation_record = validation_dir / f"{bundle_id}.validation.record.json"
+
+    run([
+        sys.executable,
+        "tools/fogstack_verify.py",
+        str(bundle),
+        "--json",
+    ], stdout=verify_json)
+
+    run([
+        sys.executable,
+        "tools/emit_fogstack_validation_record.py",
+        "--verifier-json", str(verify_json),
+        "--bundle-id", bundle_id,
+        "--version", version,
+        "--source", "local-demo",
+        "--evidence-ref", rel(verify_json),
+        "--output", str(validation_record),
+    ])
+
+    run([
+        sys.executable,
+        "tools/build_fogstack_manifest_publication_set.py",
+        "--output-dir", str(publication_dir),
+        "--manifest", str(manifest),
+        "--signature-type", "other",
+        "--signature-ref-prefix", "artifact://local-demo/signatures",
+    ])
+
+    run([
+        sys.executable,
+        "tools/promote_fogstack_manifest_publication_set.py",
+        "--input-dir", str(publication_dir),
+        "--output-dir", str(promoted_dir),
+        "--support-catalog", str(support_catalog),
+        "--target-channel", "candidate",
+        "--target-support-state", "supported",
+    ])
+
+    promoted_set = promoted_dir / "manifest-publication-set.json"
+    run([
+        sys.executable,
+        "tools/check_fogstack_manifest_promotion_policy.py",
+        "--publication-set", str(promoted_set),
+        "--policy-catalog", str(promotion_policy),
+    ])
+
+    approval_record = approval_dir / "fogstack.manifest-promotion.approval.record.json"
+    approval_sig = approval_dir / "fogstack.manifest-promotion.approval.sig"
+    approval_private = approval_dir / "private.pem"
+    approval_public = approval_dir / "public.pem"
+    approval_verification = approval_dir / "fogstack.manifest-promotion.approval.signature-verification.json"
+
+    run([
+        sys.executable,
+        "tools/emit_fogstack_manifest_promotion_approval_record.py",
+        "--promotion-set", str(promoted_set),
+        "--required-approvals", "2",
+        "--approval", "release-manager:release-manager:approved local demo candidate promotion",
+        "--approval", "security-reviewer:security-reviewer:approved local demo release evidence",
+        "--signature-type", "other",
+        "--signature-ref", str(approval_sig),
+        "--output", str(approval_record),
+    ])
+
+    run([
+        sys.executable,
+        "tools/check_fogstack_manifest_promotion_approval_record.py",
+        "--approval-record", str(approval_record),
+        "--promotion-set", str(promoted_set),
+        "--require-signed",
+    ])
+    run([
+        sys.executable,
+        "tools/check_fogstack_manifest_promotion_approver_policy.py",
+        "--approval-record", str(approval_record),
+        "--approver-policy", str(approver_policy),
+    ])
+
+    approval_dir.mkdir(parents=True, exist_ok=True)
+    run(["openssl", "genpkey", "-algorithm", "RSA", "-out", str(approval_private)])
+    run(["openssl", "pkey", "-in", str(approval_private), "-pubout", "-out", str(approval_public)])
+    run([
+        "openssl", "dgst", "-sha256",
+        "-sign", str(approval_private),
+        "-out", str(approval_sig),
+        str(approval_record),
+    ])
+    run([
+        sys.executable,
+        "tools/run_openssl_fogstack_manifest_promotion_approval_verifier.py",
+        "--approval-record", str(approval_record),
+        "--signature", str(approval_sig),
+        "--public-key", str(approval_public),
+        "--key-ref", str(approval_public),
+        "--output", str(approval_verification),
+    ])
+
+    release_identity = gate_dir / "release-identity.json"
+    write_json(release_identity, {
+        "kind": "FogStackReleaseIdentity",
+        "schema_version": "v0.1",
+        "id": "github-actions",
+        "issuer": "github-actions",
+        "subject": "SocioProphet/prophet-platform/.github/workflows/fogstack-manifest-promotion.yml",
+    })
+
+    publication_gate = gate_dir / "fogstack.release-publication-gate.record.json"
+    run([
+        sys.executable,
+        "tools/emit_fogstack_release_publication_gate_record.py",
+        "--publication-set", str(promoted_set),
+        "--approval-record", str(approval_record),
+        "--approval-signature-verification", str(approval_verification),
+        "--release-identity", str(release_identity),
+        "--policy-catalog", str(publication_gate_policy),
+        "--output", str(publication_gate),
+    ])
+
+    registry_index = registry_publication_dir / "registry-publication.index.json"
+    run([
+        sys.executable,
+        "tools/build_fogstack_registry_publication_index.py",
+        "--registry-uri", f"file://{rel(registry_root_dir)}",
+        "--publication-set", str(promoted_set),
+        "--publication-gate-record", str(publication_gate),
+        "--artifact", "manifest-publication-set", str(promoted_set),
+        "--artifact", "approval-record", str(approval_record),
+        "--artifact", "approval-signature-verification", str(approval_verification),
+        "--artifact", "release-publication-gate", str(publication_gate),
+        "--artifact", "validation-record", str(validation_record),
+        "--notes", "local demo filesystem registry publication",
+        "--output", str(registry_index),
+    ])
+
+    run([
+        sys.executable,
+        "tools/publish_fogstack_filesystem_registry.py",
+        "--index", str(registry_index),
+        "--registry-root", str(registry_root_dir),
+        "--bundle-id", bundle_id,
+        "--version", version,
+    ], stdout=registry_publication_dir / "release-pointer.json")
+
+    revocation_index = lifecycle_dir / "registry-revocation-index.json"
+    run([
+        sys.executable,
+        "tools/build_fogstack_registry_revocation_index.py",
+        "--output", str(revocation_index),
+    ])
+    run([
+        sys.executable,
+        "tools/check_fogstack_registry_revocation_index.py",
+        "--index", str(revocation_index),
+    ])
+
+    registry_root_metadata = root_dir / "registry-root-metadata.json"
+    release_root = registry_root_dir / bundle_id / version
+    run([
+        sys.executable,
+        "tools/build_fogstack_registry_root_metadata.py",
+        "--registry-uri", f"file://{rel(registry_root_dir)}",
+        "--release", bundle_id, version, str(release_root),
+        "--revocation-index", str(revocation_index),
+        "--signature-type", "other",
+        "--signature-ref", "artifact://local-demo/registry-root.sig",
+        "--output", str(registry_root_metadata),
+    ])
+    run([
+        sys.executable,
+        "tools/check_fogstack_registry_root_metadata.py",
+        "--root", str(registry_root_metadata),
+        "--require-signed",
+    ])
+
+    summary = {
+        "kind": "FogStackLocalDemoRun",
+        "schema_version": "v0.1",
+        "bundle_id": bundle_id,
+        "version": version,
+        "registry_uri": f"file://{rel(registry_root_dir)}",
+        "channel": "candidate",
+        "support_state": "supported",
+        "artifacts": {
+            "verify_json": rel(verify_json),
+            "validation_record": rel(validation_record),
+            "publication_set": rel(publication_dir / "manifest-publication-set.json"),
+            "promoted_publication_set": rel(promoted_set),
+            "approval_record": rel(approval_record),
+            "approval_signature_verification": rel(approval_verification),
+            "publication_gate": rel(publication_gate),
+            "registry_publication_index": rel(registry_index),
+            "filesystem_release_pointer": rel(release_root / "release-pointer.json"),
+            "revocation_index": rel(revocation_index),
+            "registry_root_metadata": rel(registry_root_metadata),
+        },
+        "checks": [
+            "bundle_verified",
+            "validation_record_emitted",
+            "publication_set_built",
+            "promotion_policy_passed",
+            "approval_record_checked",
+            "approval_signature_verified",
+            "publication_gate_passed",
+            "registry_index_built",
+            "filesystem_registry_published",
+            "revocation_index_checked",
+            "registry_root_checked",
+        ],
+    }
+    summary_path = output_dir / "fogstack-local-demo.summary.json"
+    write_json(summary_path, summary)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a local FogStack release/registry demo end to end")
+    parser.add_argument("--pack", choices=sorted(PACKS), default="access")
+    parser.add_argument("--output-dir", type=Path, default=Path("build/fogstack-local-demo"))
+    parser.add_argument("--no-clean", action="store_true", help="Do not remove the output directory before running")
+    args = parser.parse_args()
+
+    summary = build_demo(args.pack, args.output_dir, clean=not args.no_clean)
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_run_fogstack_local_demo.py
+++ b/tools/tests/test_run_fogstack_local_demo.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_run_fogstack_local_demo_access(tmp_path: Path) -> None:
+    output_dir = tmp_path / "fogstack-local-demo"
+
+    subprocess.run([
+        sys.executable,
+        "tools/run_fogstack_local_demo.py",
+        "--pack",
+        "access",
+        "--output-dir",
+        str(output_dir),
+    ], check=True)
+
+    summary_path = output_dir / "fogstack-local-demo.summary.json"
+    assert summary_path.exists()
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["kind"] == "FogStackLocalDemoRun"
+    assert summary["bundle_id"] == "fogstack.access"
+    assert summary["version"] == "0.1.0"
+    assert summary["channel"] == "candidate"
+    assert summary["support_state"] == "supported"
+
+    expected_checks = {
+        "bundle_verified",
+        "validation_record_emitted",
+        "publication_set_built",
+        "promotion_policy_passed",
+        "approval_record_checked",
+        "approval_signature_verified",
+        "publication_gate_passed",
+        "registry_index_built",
+        "filesystem_registry_published",
+        "filesystem_registry_checked",
+        "revocation_index_checked",
+        "registry_root_checked",
+    }
+    assert expected_checks.issubset(set(summary["checks"]))
+
+    artifacts = summary["artifacts"]
+    required_artifacts = [
+        "verify_json",
+        "validation_record",
+        "publication_set",
+        "promoted_publication_set",
+        "approval_record",
+        "approval_signature_verification",
+        "publication_gate",
+        "registry_publication_index",
+        "filesystem_release_pointer",
+        "revocation_index",
+        "registry_root_metadata",
+    ]
+    for key in required_artifacts:
+        assert key in artifacts
+        assert Path(artifacts[key]).exists(), f"missing {key}: {artifacts[key]}"
+
+    gate = json.loads(Path(artifacts["publication_gate"]).read_text(encoding="utf-8"))
+    assert gate["kind"] == "FogStackReleasePublicationGateRecord"
+    assert gate["status"] == "pass"
+
+    root = json.loads(Path(artifacts["registry_root_metadata"]).read_text(encoding="utf-8"))
+    assert root["kind"] == "FogStackRegistryRootMetadata"
+    assert root["signed"] is True
+    assert root["releases"][0]["bundle_id"] == "fogstack.access"
+    assert root["releases"][0]["release_pointer_digest"].startswith("sha256:")
+
+    pointer = json.loads(Path(artifacts["filesystem_release_pointer"]).read_text(encoding="utf-8"))
+    assert pointer["kind"] == "FogStackFilesystemRegistryReleasePointer"
+    assert pointer["bundle_id"] == "fogstack.access"
+    assert pointer["version"] == "0.1.0"
+    assert pointer["index_digest"].startswith("sha256:")


### PR DESCRIPTION
## Summary

Adds an executable FogStack local demo path instead of another status/documentation tranche.

This PR adds a repo-native runner that exercises the FogStack Access release path end to end:

1. bundle verification
2. validation record emission
3. manifest publication set build
4. candidate/supported promotion
5. promotion policy check
6. two-approver approval record
7. local OpenSSL approval signature verification
8. release publication gate
9. registry publication index build
10. filesystem registry publish
11. filesystem registry integrity check
12. revocation index build/check
13. registry-root metadata build/check
14. summary artifact emission

## Files

- `tools/run_fogstack_local_demo.py`
- `tools/tests/test_run_fogstack_local_demo.py`
- `.github/workflows/fogstack-local-demo.yml`

## Operator command

```bash
python3 tools/run_fogstack_local_demo.py --pack access --output-dir build/fogstack-local-demo
```

## CI coverage

Adds `FogStack Local Demo` workflow. The workflow runs:

```bash
python -m pytest -q tools/tests/test_run_fogstack_local_demo.py
python3 tools/run_fogstack_local_demo.py --pack access --output-dir build/fogstack-local-demo
```

and uploads `build/fogstack-local-demo/` as an artifact.

## Non-goals

- No network registry publication.
- No production KMS/HSM signing.
- No client-side rollback runtime.
- No Office/Lattice/status-readiness mutation.
- No new repo.

## Notes

This is a local filesystem demo slice only, but it turns the release/registry machinery into an operator-executable path.