### PR TITLE
fogstack: add local demo operator entrypoint

### DIFF
--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -11,6 +11,7 @@ on:
       - "catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml"
       - "catalog/fogstack-release-publication-gate-policy-v0.1.yaml"
       - "releases/manifests/**"
+      - "Makefile"
       - "tools/run_fogstack_local_demo.py"
       - "tools/fogstack_verify.py"
       - "tools/emit_fogstack_validation_record.py"
@@ -41,6 +42,7 @@ on:
       - "catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml"
       - "catalog/fogstack-release-publication-gate-policy-v0.1.yaml"
       - "releases/manifests/**"
+      - "Makefile"
       - "tools/run_fogstack_local_demo.py"
       - "tools/tests/test_run_fogstack_local_demo.py"
       - ".github/workflows/fogstack-local-demo.yml"
@@ -72,7 +74,7 @@ jobs:
 
       - name: Run operator demo command
         run: |
-          python3 tools/run_fogstack_local_demo.py --pack all --output-dir build/fogstack-local-demo
+          make fogstack-local-demo
 
       - name: Upload local demo artifacts
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -176,3 +176,7 @@ validate-fogstack:
 
 validate-storage-suite:
 	python3 tools/validate_storage_suite.py
+
+.PHONY: fogstack-local-demo
+fogstack-local-demo:
+	python3 tools/run_fogstack_local_demo.py --pack all --output-dir build/fogstack-local-demo --summary

--- a/tools/run_fogstack_local_demo.py
+++ b/tools/run_fogstack_local_demo.py
@@ -367,15 +367,41 @@ def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
     return summary
 
 
+def render_summary_text(summary: dict[str, Any]) -> str:
+    release_lines = [
+        f"- {release['bundle_id']}@{release['version']} ({release['pack']})"
+        for release in summary.get("releases", [])
+    ]
+    artifact_paths = summary.get("artifacts", {})
+    lines = [
+        "FogStack local demo passed.",
+        f"Pack selection: {summary.get('pack')}",
+        f"Release count: {len(summary.get('releases', []))}",
+        "Releases:",
+        *release_lines,
+        f"Channel/support: {summary.get('channel')}/{summary.get('support_state')}",
+        f"Registry URI: {summary.get('registry_uri')}",
+        f"Publication gate: {artifact_paths.get('publication_gate')}",
+        f"Registry root metadata: {artifact_paths.get('registry_root_metadata')}",
+        f"Summary JSON: {rel(Path(artifact_paths.get('registry_root_metadata', '.')).parent.parent / 'fogstack-local-demo.summary.json')}",
+        f"Checks passed: {len(summary.get('checks', []))}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run a local FogStack release/registry demo end to end")
     parser.add_argument("--pack", choices=sorted(PACK_ALIASES), default="access")
     parser.add_argument("--output-dir", type=Path, default=Path("build/fogstack-local-demo"))
     parser.add_argument("--no-clean", action="store_true", help="Do not remove the output directory before running")
+    parser.add_argument("--summary", action="store_true", help="Print a compact human-readable summary instead of JSON")
     args = parser.parse_args()
 
     summary = build_demo(args.pack, args.output_dir, clean=not args.no_clean)
-    print(json.dumps(summary, indent=2))
+    if args.summary:
+        print(render_summary_text(summary), end="")
+    else:
+        print(json.dumps(summary, indent=2))
     return 0
 
 

--- a/tools/tests/test_run_fogstack_local_demo.py
+++ b/tools/tests/test_run_fogstack_local_demo.py
@@ -120,3 +120,37 @@ def test_run_fogstack_local_demo_all_packs(tmp_path: Path) -> None:
         pointer = json.loads(Path(release["filesystem_release_pointer"]).read_text(encoding="utf-8"))
         assert pointer["bundle_id"] == release["bundle_id"]
         assert pointer["version"] == "0.1.0"
+
+
+def test_run_fogstack_local_demo_summary_output(tmp_path: Path) -> None:
+    output_dir = tmp_path / "summary-demo"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "tools/run_fogstack_local_demo.py",
+            "--pack",
+            "access",
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "FogStack local demo passed." in proc.stdout
+    assert "Pack selection: access" in proc.stdout
+    assert "Release count: 1" in proc.stdout
+    assert "fogstack.access@0.1.0" in proc.stdout
+    assert "Channel/support: candidate/supported" in proc.stdout
+    assert "Publication gate:" in proc.stdout
+    assert "Registry root metadata:" in proc.stdout
+    assert "Summary JSON:" in proc.stdout
+    assert "Checks passed: 12" in proc.stdout
+
+    summary_path = output_dir / "fogstack-local-demo.summary.json"
+    assert summary_path.exists()
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["pack"] == "access"
+    assert summary["bundle_id"] == "fogstack.access"


### PR DESCRIPTION
## Summary

Adds a stable operator entrypoint for the FogStack local demo and a compact human-readable summary mode.

## What changed

- Adds `--summary` to `tools/run_fogstack_local_demo.py`.
- Adds `make fogstack-local-demo` as the stable operator command.
- Updates the FogStack Local Demo workflow to prove `make fogstack-local-demo` directly.
- Adds test coverage for human-readable summary output.

## Operator command

```bash
make fogstack-local-demo
```

The target runs:

```bash
python3 tools/run_fogstack_local_demo.py --pack all --output-dir build/fogstack-local-demo --summary
```

## Validation intent

```bash
python -m pytest -q tools/tests/test_run_fogstack_local_demo.py
make fogstack-local-demo
```

## Non-goals

- No network registry publication.
- No production signing or KMS/HSM work.
- No client rollback runtime.
- No status/readiness doc churn.

Depends on #332 and #333.