### PR TITLE
fogstack: emit markdown summary for local demo

### DIFF
--- a/tools/run_fogstack_local_demo.py
+++ b/tools/run_fogstack_local_demo.py
@@ -45,6 +45,11 @@ def write_json(path: Path, data: dict[str, Any]) -> None:
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
 def run(cmd: list[str], *, stdout: Path | None = None) -> None:
     if stdout:
         stdout.parent.mkdir(parents=True, exist_ok=True)
@@ -320,7 +325,11 @@ def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
         "--require-signed",
     ])
 
+    summary_path = output_dir / "fogstack-local-demo.summary.json"
+    summary_markdown = output_dir / "fogstack-local-demo.summary.md"
     artifacts: dict[str, Any] = {
+        "summary_json": rel(summary_path),
+        "summary_markdown": rel(summary_markdown),
         "publication_set": rel(dirs["publication"] / "manifest-publication-set.json"),
         "promoted_publication_set": rel(promoted_set),
         "approval_record": rel(approval_record),
@@ -362,8 +371,8 @@ def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
             "registry_root_checked",
         ],
     }
-    summary_path = output_dir / "fogstack-local-demo.summary.json"
     write_json(summary_path, summary)
+    write_text(summary_markdown, render_summary_markdown(summary))
     return summary
 
 
@@ -383,10 +392,51 @@ def render_summary_text(summary: dict[str, Any]) -> str:
         f"Registry URI: {summary.get('registry_uri')}",
         f"Publication gate: {artifact_paths.get('publication_gate')}",
         f"Registry root metadata: {artifact_paths.get('registry_root_metadata')}",
-        f"Summary JSON: {rel(Path(artifact_paths.get('registry_root_metadata', '.')).parent.parent / 'fogstack-local-demo.summary.json')}",
+        f"Summary JSON: {artifact_paths.get('summary_json')}",
+        f"Summary Markdown: {artifact_paths.get('summary_markdown')}",
         f"Checks passed: {len(summary.get('checks', []))}",
     ]
     return "\n".join(lines) + "\n"
+
+
+def render_summary_markdown(summary: dict[str, Any]) -> str:
+    artifacts = summary.get("artifacts", {})
+    release_rows = [
+        f"| `{release['bundle_id']}` | `{release['version']}` | `{release['pack']}` | `{release['validation_record']}` | `{release['filesystem_release_pointer']}` |"
+        for release in summary.get("releases", [])
+    ]
+    check_rows = [f"- `{check}`" for check in summary.get("checks", [])]
+    lines = [
+        "# FogStack Local Demo Summary",
+        "",
+        "## Result",
+        "",
+        "Status: **passed**",
+        f"Pack selection: `{summary.get('pack')}`",
+        f"Release count: **{len(summary.get('releases', []))}**",
+        f"Channel/support: `{summary.get('channel')}/{summary.get('support_state')}`",
+        f"Registry URI: `{summary.get('registry_uri')}`",
+        "",
+        "## Releases",
+        "",
+        "| Bundle | Version | Pack | Validation record | Filesystem release pointer |",
+        "|---|---:|---|---|---|",
+        *release_rows,
+        "",
+        "## Key artifacts",
+        "",
+        f"- Publication gate: `{artifacts.get('publication_gate')}`",
+        f"- Registry root metadata: `{artifacts.get('registry_root_metadata')}`",
+        f"- Registry publication index: `{artifacts.get('registry_publication_index')}`",
+        f"- Revocation index: `{artifacts.get('revocation_index')}`",
+        f"- Summary JSON: `{artifacts.get('summary_json')}`",
+        "",
+        "## Checks",
+        "",
+        *check_rows,
+        "",
+    ]
+    return "\n".join(lines)
 
 
 def main() -> int:

--- a/tools/tests/test_run_fogstack_local_demo.py
+++ b/tools/tests/test_run_fogstack_local_demo.py
@@ -60,6 +60,8 @@ def assert_common(summary: dict, pack: str) -> dict:
 
     artifacts = summary["artifacts"]
     for key in [
+        "summary_json",
+        "summary_markdown",
         "publication_set",
         "promoted_publication_set",
         "approval_record",
@@ -121,6 +123,15 @@ def test_run_fogstack_local_demo_all_packs(tmp_path: Path) -> None:
         assert pointer["bundle_id"] == release["bundle_id"]
         assert pointer["version"] == "0.1.0"
 
+    markdown = Path(summary["artifacts"]["summary_markdown"]).read_text(encoding="utf-8")
+    assert "# FogStack Local Demo Summary" in markdown
+    assert "Release count: **3**" in markdown
+    assert "Registry URI:" in markdown
+    assert "Publication gate:" in markdown
+    assert "Registry root metadata:" in markdown
+    for bundle_id in CANONICAL_BUNDLES:
+        assert bundle_id in markdown
+
 
 def test_run_fogstack_local_demo_summary_output(tmp_path: Path) -> None:
     output_dir = tmp_path / "summary-demo"
@@ -147,10 +158,13 @@ def test_run_fogstack_local_demo_summary_output(tmp_path: Path) -> None:
     assert "Publication gate:" in proc.stdout
     assert "Registry root metadata:" in proc.stdout
     assert "Summary JSON:" in proc.stdout
+    assert "Summary Markdown:" in proc.stdout
     assert "Checks passed: 12" in proc.stdout
 
     summary_path = output_dir / "fogstack-local-demo.summary.json"
+    markdown_path = output_dir / "fogstack-local-demo.summary.md"
     assert summary_path.exists()
+    assert markdown_path.exists()
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert summary["pack"] == "access"
     assert summary["bundle_id"] == "fogstack.access"


### PR DESCRIPTION
## Summary

Adds a stakeholder-readable Markdown summary artifact to the FogStack local demo output.

## What changed

- `tools/run_fogstack_local_demo.py` now writes:
  - `fogstack-local-demo.summary.json`
  - `fogstack-local-demo.summary.md`
- The JSON artifact map now includes `summary_json` and `summary_markdown`.
- `--summary` output now prints both summary artifact paths.
- Tests now assert the Markdown summary includes:
  - release count
  - canonical release IDs
  - registry URI
  - publication gate path
  - registry root metadata path

## Operator impact

The existing command remains unchanged:

```bash
make fogstack-local-demo
```

It now produces both JSON and Markdown summary artifacts under `build/fogstack-local-demo/`.

## Validation intent

```bash
python -m pytest -q tools/tests/test_run_fogstack_local_demo.py
make fogstack-local-demo
```

## Non-goals

- No network registry publication.
- No production signing or KMS/HSM work.
- No client rollback runtime.
- No status/readiness doc churn.
- No browser UI yet.