### PR TITLE
fogstack: emit HTML summary for local demo

### DIFF
--- a/tools/run_fogstack_local_demo.py
+++ b/tools/run_fogstack_local_demo.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import shutil
 import subprocess
@@ -327,9 +328,11 @@ def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
 
     summary_path = output_dir / "fogstack-local-demo.summary.json"
     summary_markdown = output_dir / "fogstack-local-demo.summary.md"
+    summary_html = output_dir / "index.html"
     artifacts: dict[str, Any] = {
         "summary_json": rel(summary_path),
         "summary_markdown": rel(summary_markdown),
+        "summary_html": rel(summary_html),
         "publication_set": rel(dirs["publication"] / "manifest-publication-set.json"),
         "promoted_publication_set": rel(promoted_set),
         "approval_record": rel(approval_record),
@@ -373,6 +376,7 @@ def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
     }
     write_json(summary_path, summary)
     write_text(summary_markdown, render_summary_markdown(summary))
+    write_text(summary_html, render_summary_html(summary))
     return summary
 
 
@@ -394,6 +398,7 @@ def render_summary_text(summary: dict[str, Any]) -> str:
         f"Registry root metadata: {artifact_paths.get('registry_root_metadata')}",
         f"Summary JSON: {artifact_paths.get('summary_json')}",
         f"Summary Markdown: {artifact_paths.get('summary_markdown')}",
+        f"Summary HTML: {artifact_paths.get('summary_html')}",
         f"Checks passed: {len(summary.get('checks', []))}",
     ]
     return "\n".join(lines) + "\n"
@@ -430,6 +435,7 @@ def render_summary_markdown(summary: dict[str, Any]) -> str:
         f"- Registry publication index: `{artifacts.get('registry_publication_index')}`",
         f"- Revocation index: `{artifacts.get('revocation_index')}`",
         f"- Summary JSON: `{artifacts.get('summary_json')}`",
+        f"- Summary HTML: `{artifacts.get('summary_html')}`",
         "",
         "## Checks",
         "",
@@ -437,6 +443,82 @@ def render_summary_markdown(summary: dict[str, Any]) -> str:
         "",
     ]
     return "\n".join(lines)
+
+
+def render_summary_html(summary: dict[str, Any]) -> str:
+    def esc(value: Any) -> str:
+        return html.escape(str(value), quote=True)
+
+    artifacts = summary.get("artifacts", {})
+    release_rows = "\n".join(
+        "<tr>"
+        f"<td>{esc(release['bundle_id'])}</td>"
+        f"<td>{esc(release['version'])}</td>"
+        f"<td>{esc(release['pack'])}</td>"
+        f"<td><code>{esc(release['validation_record'])}</code></td>"
+        f"<td><code>{esc(release['filesystem_release_pointer'])}</code></td>"
+        "</tr>"
+        for release in summary.get("releases", [])
+    )
+    check_items = "\n".join(f"<li><code>{esc(check)}</code></li>" for check in summary.get("checks", []))
+    artifact_items = "\n".join(
+        f"<li><strong>{esc(label)}:</strong> <code>{esc(path)}</code></li>"
+        for label, path in [
+            ("Publication gate", artifacts.get("publication_gate")),
+            ("Registry root metadata", artifacts.get("registry_root_metadata")),
+            ("Registry publication index", artifacts.get("registry_publication_index")),
+            ("Revocation index", artifacts.get("revocation_index")),
+            ("Summary JSON", artifacts.get("summary_json")),
+            ("Summary Markdown", artifacts.get("summary_markdown")),
+        ]
+    )
+    return f"""<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <title>FogStack Local Demo Summary</title>
+  <style>
+    :root {{ color-scheme: light dark; }}
+    body {{ font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem; line-height: 1.5; }}
+    main {{ max-width: 1120px; }}
+    .status {{ display: inline-block; padding: 0.25rem 0.6rem; border: 1px solid currentColor; border-radius: 999px; font-weight: 700; }}
+    table {{ border-collapse: collapse; width: 100%; margin: 1rem 0; }}
+    th, td {{ border: 1px solid currentColor; padding: 0.45rem 0.6rem; text-align: left; vertical-align: top; }}
+    code {{ word-break: break-word; }}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>FogStack Local Demo Summary</h1>
+    <p class=\"status\">Status: passed</p>
+    <dl>
+      <dt>Pack selection</dt><dd><code>{esc(summary.get('pack'))}</code></dd>
+      <dt>Release count</dt><dd>{esc(len(summary.get('releases', [])))}</dd>
+      <dt>Channel/support</dt><dd><code>{esc(summary.get('channel'))}/{esc(summary.get('support_state'))}</code></dd>
+      <dt>Registry URI</dt><dd><code>{esc(summary.get('registry_uri'))}</code></dd>
+    </dl>
+
+    <h2>Releases</h2>
+    <table>
+      <thead><tr><th>Bundle</th><th>Version</th><th>Pack</th><th>Validation record</th><th>Filesystem release pointer</th></tr></thead>
+      <tbody>
+        {release_rows}
+      </tbody>
+    </table>
+
+    <h2>Key artifacts</h2>
+    <ul>
+      {artifact_items}
+    </ul>
+
+    <h2>Checks</h2>
+    <ul>
+      {check_items}
+    </ul>
+  </main>
+</body>
+</html>
+"""
 
 
 def main() -> int:

--- a/tools/tests/test_run_fogstack_local_demo.py
+++ b/tools/tests/test_run_fogstack_local_demo.py
@@ -62,6 +62,7 @@ def assert_common(summary: dict, pack: str) -> dict:
     for key in [
         "summary_json",
         "summary_markdown",
+        "summary_html",
         "publication_set",
         "promoted_publication_set",
         "approval_record",
@@ -132,6 +133,17 @@ def test_run_fogstack_local_demo_all_packs(tmp_path: Path) -> None:
     for bundle_id in CANONICAL_BUNDLES:
         assert bundle_id in markdown
 
+    index_html = Path(summary["artifacts"]["summary_html"]).read_text(encoding="utf-8")
+    assert "<title>FogStack Local Demo Summary</title>" in index_html
+    assert "<h2>Releases</h2>" in index_html
+    assert "Release count" in index_html
+    assert "Registry URI" in index_html
+    assert "Publication gate" in index_html
+    assert "Registry root metadata" in index_html
+    assert "Registry publication index" in index_html
+    for bundle_id in CANONICAL_BUNDLES:
+        assert bundle_id in index_html
+
 
 def test_run_fogstack_local_demo_summary_output(tmp_path: Path) -> None:
     output_dir = tmp_path / "summary-demo"
@@ -159,12 +171,15 @@ def test_run_fogstack_local_demo_summary_output(tmp_path: Path) -> None:
     assert "Registry root metadata:" in proc.stdout
     assert "Summary JSON:" in proc.stdout
     assert "Summary Markdown:" in proc.stdout
+    assert "Summary HTML:" in proc.stdout
     assert "Checks passed: 12" in proc.stdout
 
     summary_path = output_dir / "fogstack-local-demo.summary.json"
     markdown_path = output_dir / "fogstack-local-demo.summary.md"
+    html_path = output_dir / "index.html"
     assert summary_path.exists()
     assert markdown_path.exists()
+    assert html_path.exists()
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert summary["pack"] == "access"
     assert summary["bundle_id"] == "fogstack.access"


### PR DESCRIPTION
## Summary

Adds a browser-readable `index.html` summary artifact to the FogStack local demo output.

## What changed

- `tools/run_fogstack_local_demo.py` now writes `build/fogstack-local-demo/index.html` alongside the existing JSON and Markdown summaries.
- The artifact map now includes `summary_html`.
- `--summary` output now prints the HTML summary path.
- Tests now assert `index.html` includes:
  - releases table
  - release count
  - canonical release IDs
  - registry URI
  - publication gate path
  - registry root metadata path
  - registry publication index path

## Operator impact

The command remains unchanged:

```bash
make fogstack-local-demo
```

The demo output now includes:

```bash
build/fogstack-local-demo/index.html
build/fogstack-local-demo/fogstack-local-demo.summary.md
build/fogstack-local-demo/fogstack-local-demo.summary.json
```

## Validation intent

```bash
python -m pytest -q tools/tests/test_run_fogstack_local_demo.py
make fogstack-local-demo
```

## Non-goals

- No network registry publication.
- No production signing or KMS/HSM work.
- No client rollback runtime.
- No served web app yet.
- No status/readiness doc churn.