### PR TITLE
fogstack: emit digest index for local demo artifacts

### DIFF
--- a/tools/run_fogstack_local_demo.py
+++ b/tools/run_fogstack_local_demo.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import html
 import json
 import shutil
@@ -51,6 +52,14 @@ def write_text(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
 def run(cmd: list[str], *, stdout: Path | None = None) -> None:
     if stdout:
         stdout.parent.mkdir(parents=True, exist_ok=True)
@@ -65,6 +74,11 @@ def rel(path: Path) -> str:
         return str(path.relative_to(ROOT))
     except ValueError:
         return str(path)
+
+
+def path_from_ref(ref: str) -> Path:
+    path = Path(ref)
+    return path if path.is_absolute() else ROOT / path
 
 
 def pack_configs(pack: str) -> list[dict[str, str]]:
@@ -84,6 +98,58 @@ def output_dirs(output_dir: Path) -> dict[str, Path]:
         "registry_root": output_dir / "registry",
         "lifecycle": output_dir / "lifecycle",
         "root": output_dir / "root",
+    }
+
+
+def collect_artifact_refs(summary: dict[str, Any]) -> list[tuple[str, str]]:
+    refs: list[tuple[str, str]] = []
+    for artifact_id, artifact_ref in (summary.get("artifacts") or {}).items():
+        if artifact_id == "artifact_index":
+            continue
+        if isinstance(artifact_ref, str):
+            refs.append((artifact_id, artifact_ref))
+
+    for release in summary.get("releases") or []:
+        if not isinstance(release, dict):
+            continue
+        bundle_id = release.get("bundle_id", "unknown")
+        for key in ["verify_json", "validation_record", "filesystem_release_pointer"]:
+            artifact_ref = release.get(key)
+            if isinstance(artifact_ref, str):
+                refs.append((f"release:{bundle_id}:{key}", artifact_ref))
+
+    seen: set[str] = set()
+    deduped: list[tuple[str, str]] = []
+    for artifact_id, artifact_ref in refs:
+        dedupe_key = f"{artifact_id}\0{artifact_ref}"
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        deduped.append((artifact_id, artifact_ref))
+    return deduped
+
+
+def build_artifact_index(summary: dict[str, Any]) -> dict[str, Any]:
+    entries: list[dict[str, Any]] = []
+    for artifact_id, artifact_ref in collect_artifact_refs(summary):
+        path = path_from_ref(artifact_ref)
+        if not path.exists():
+            raise SystemExit(f"ERR: local demo artifact missing before indexing: {artifact_ref}")
+        entries.append({
+            "id": artifact_id,
+            "ref": artifact_ref,
+            "digest": sha256_file(path),
+            "size_bytes": path.stat().st_size,
+        })
+
+    return {
+        "kind": "FogStackLocalDemoArtifactIndex",
+        "schema_version": "v0.1",
+        "demo_kind": summary.get("kind"),
+        "pack": summary.get("pack"),
+        "registry_uri": summary.get("registry_uri"),
+        "release_count": len(summary.get("releases", [])),
+        "artifacts": entries,
     }
 
 
@@ -329,10 +395,12 @@ def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
     summary_path = output_dir / "fogstack-local-demo.summary.json"
     summary_markdown = output_dir / "fogstack-local-demo.summary.md"
     summary_html = output_dir / "index.html"
+    artifact_index = output_dir / "demo-artifacts.index.json"
     artifacts: dict[str, Any] = {
         "summary_json": rel(summary_path),
         "summary_markdown": rel(summary_markdown),
         "summary_html": rel(summary_html),
+        "artifact_index": rel(artifact_index),
         "publication_set": rel(dirs["publication"] / "manifest-publication-set.json"),
         "promoted_publication_set": rel(promoted_set),
         "approval_record": rel(approval_record),
@@ -377,6 +445,7 @@ def build_demo(pack: str, output_dir: Path, clean: bool) -> dict[str, Any]:
     write_json(summary_path, summary)
     write_text(summary_markdown, render_summary_markdown(summary))
     write_text(summary_html, render_summary_html(summary))
+    write_json(artifact_index, build_artifact_index(summary))
     return summary
 
 
@@ -399,6 +468,7 @@ def render_summary_text(summary: dict[str, Any]) -> str:
         f"Summary JSON: {artifact_paths.get('summary_json')}",
         f"Summary Markdown: {artifact_paths.get('summary_markdown')}",
         f"Summary HTML: {artifact_paths.get('summary_html')}",
+        f"Artifact index: {artifact_paths.get('artifact_index')}",
         f"Checks passed: {len(summary.get('checks', []))}",
     ]
     return "\n".join(lines) + "\n"
@@ -436,6 +506,7 @@ def render_summary_markdown(summary: dict[str, Any]) -> str:
         f"- Revocation index: `{artifacts.get('revocation_index')}`",
         f"- Summary JSON: `{artifacts.get('summary_json')}`",
         f"- Summary HTML: `{artifacts.get('summary_html')}`",
+        f"- Artifact index: `{artifacts.get('artifact_index')}`",
         "",
         "## Checks",
         "",
@@ -470,6 +541,7 @@ def render_summary_html(summary: dict[str, Any]) -> str:
             ("Revocation index", artifacts.get("revocation_index")),
             ("Summary JSON", artifacts.get("summary_json")),
             ("Summary Markdown", artifacts.get("summary_markdown")),
+            ("Artifact index", artifacts.get("artifact_index")),
         ]
     )
     return f"""<!doctype html>

--- a/tools/tests/test_run_fogstack_local_demo.py
+++ b/tools/tests/test_run_fogstack_local_demo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -27,6 +28,7 @@ CANONICAL_BUNDLES = {
     "fogstack.knowledge",
     "fogstack.evaluation",
 }
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 def run_demo(pack: str, output_dir: Path) -> dict:
@@ -63,6 +65,7 @@ def assert_common(summary: dict, pack: str) -> dict:
         "summary_json",
         "summary_markdown",
         "summary_html",
+        "artifact_index",
         "publication_set",
         "promoted_publication_set",
         "approval_record",
@@ -85,6 +88,23 @@ def assert_common(summary: dict, pack: str) -> dict:
     return root
 
 
+def artifact_index_by_id(summary: dict) -> dict[str, dict]:
+    index_path = Path(summary["artifacts"]["artifact_index"])
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    assert index["kind"] == "FogStackLocalDemoArtifactIndex"
+    assert index["schema_version"] == "v0.1"
+    assert index["demo_kind"] == "FogStackLocalDemoRun"
+    assert index["pack"] == summary["pack"]
+    assert index["registry_uri"] == summary["registry_uri"]
+    assert index["release_count"] == len(summary["releases"])
+    by_id = {entry["id"]: entry for entry in index["artifacts"]}
+    for entry in index["artifacts"]:
+        assert DIGEST_RE.match(entry["digest"]), entry
+        assert entry["size_bytes"] > 0, entry
+        assert Path(entry["ref"]).exists(), entry
+    return by_id
+
+
 def test_run_fogstack_local_demo_access(tmp_path: Path) -> None:
     summary = run_demo("access", tmp_path / "access-demo")
     root = assert_common(summary, "access")
@@ -104,6 +124,20 @@ def test_run_fogstack_local_demo_access(tmp_path: Path) -> None:
     assert pointer["bundle_id"] == "fogstack.access"
     assert pointer["version"] == "0.1.0"
     assert pointer["index_digest"].startswith("sha256:")
+
+    index = artifact_index_by_id(summary)
+    for artifact_id in [
+        "summary_json",
+        "summary_markdown",
+        "summary_html",
+        "publication_gate",
+        "registry_root_metadata",
+        "registry_publication_index",
+        "release:fogstack.access:verify_json",
+        "release:fogstack.access:validation_record",
+        "release:fogstack.access:filesystem_release_pointer",
+    ]:
+        assert artifact_id in index
 
 
 def test_run_fogstack_local_demo_all_packs(tmp_path: Path) -> None:
@@ -130,6 +164,7 @@ def test_run_fogstack_local_demo_all_packs(tmp_path: Path) -> None:
     assert "Registry URI:" in markdown
     assert "Publication gate:" in markdown
     assert "Registry root metadata:" in markdown
+    assert "Artifact index:" in markdown
     for bundle_id in CANONICAL_BUNDLES:
         assert bundle_id in markdown
 
@@ -141,8 +176,24 @@ def test_run_fogstack_local_demo_all_packs(tmp_path: Path) -> None:
     assert "Publication gate" in index_html
     assert "Registry root metadata" in index_html
     assert "Registry publication index" in index_html
+    assert "Artifact index" in index_html
     for bundle_id in CANONICAL_BUNDLES:
         assert bundle_id in index_html
+
+    index = artifact_index_by_id(summary)
+    for artifact_id in [
+        "summary_json",
+        "summary_markdown",
+        "summary_html",
+        "publication_gate",
+        "registry_root_metadata",
+        "registry_publication_index",
+    ]:
+        assert artifact_id in index
+    for bundle_id in CANONICAL_BUNDLES:
+        assert f"release:{bundle_id}:verify_json" in index
+        assert f"release:{bundle_id}:validation_record" in index
+        assert f"release:{bundle_id}:filesystem_release_pointer" in index
 
 
 def test_run_fogstack_local_demo_summary_output(tmp_path: Path) -> None:
@@ -172,14 +223,17 @@ def test_run_fogstack_local_demo_summary_output(tmp_path: Path) -> None:
     assert "Summary JSON:" in proc.stdout
     assert "Summary Markdown:" in proc.stdout
     assert "Summary HTML:" in proc.stdout
+    assert "Artifact index:" in proc.stdout
     assert "Checks passed: 12" in proc.stdout
 
     summary_path = output_dir / "fogstack-local-demo.summary.json"
     markdown_path = output_dir / "fogstack-local-demo.summary.md"
     html_path = output_dir / "index.html"
+    artifact_index_path = output_dir / "demo-artifacts.index.json"
     assert summary_path.exists()
     assert markdown_path.exists()
     assert html_path.exists()
+    assert artifact_index_path.exists()
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert summary["pack"] == "access"
     assert summary["bundle_id"] == "fogstack.access"


### PR DESCRIPTION
## Summary

Adds a digest index for generated FogStack local demo artifacts.

## What changed

- `tools/run_fogstack_local_demo.py` now writes `build/fogstack-local-demo/demo-artifacts.index.json`.
- The index records each indexed artifact with:
  - artifact id
  - ref
  - SHA-256 digest
  - size in bytes
- The local demo artifact map now includes `artifact_index`.
- Text, Markdown, and HTML summaries now reference the artifact index.
- Tests assert the index includes key generated outputs and per-release proof artifacts.

## Indexed critical artifacts

The tests require index entries for:

- `summary_json`
- `summary_markdown`
- `summary_html`
- `publication_gate`
- `registry_root_metadata`
- `registry_publication_index`
- per-release `verify_json`
- per-release `validation_record`
- per-release `filesystem_release_pointer`

## Operator impact

The command remains unchanged:

```bash
make fogstack-local-demo
```

The demo output now includes:

```bash
build/fogstack-local-demo/demo-artifacts.index.json
build/fogstack-local-demo/index.html
build/fogstack-local-demo/fogstack-local-demo.summary.md
build/fogstack-local-demo/fogstack-local-demo.summary.json
```

## Validation intent

```bash
python -m pytest -q tools/tests/test_run_fogstack_local_demo.py
make fogstack-local-demo
```

## Non-goals

- No network registry publication.
- No production signing or KMS/HSM work.
- No client rollback runtime.
- No served web app.
- No status/readiness doc churn.