### PR TITLE
fogstack: verify local demo artifact index

### DIFF
--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -13,6 +13,7 @@ on:
       - "releases/manifests/**"
       - "Makefile"
       - "tools/run_fogstack_local_demo.py"
+      - "tools/check_fogstack_local_demo_artifact_index.py"
       - "tools/fogstack_verify.py"
       - "tools/emit_fogstack_validation_record.py"
       - "tools/build_fogstack_manifest_publication_set.py"
@@ -31,6 +32,7 @@ on:
       - "tools/build_fogstack_registry_root_metadata.py"
       - "tools/check_fogstack_registry_root_metadata.py"
       - "tools/tests/test_run_fogstack_local_demo.py"
+      - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - ".github/workflows/fogstack-local-demo.yml"
   push:
     branches: [main]
@@ -44,7 +46,9 @@ on:
       - "releases/manifests/**"
       - "Makefile"
       - "tools/run_fogstack_local_demo.py"
+      - "tools/check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_run_fogstack_local_demo.py"
+      - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - ".github/workflows/fogstack-local-demo.yml"
 
 permissions:
@@ -70,11 +74,15 @@ jobs:
 
       - name: Run local demo end-to-end test
         run: |
-          python -m pytest -q tools/tests/test_run_fogstack_local_demo.py
+          python -m pytest -q tools/tests/test_run_fogstack_local_demo.py tools/tests/test_check_fogstack_local_demo_artifact_index.py
 
       - name: Run operator demo command
         run: |
           make fogstack-local-demo
+
+      - name: Check generated artifact index
+        run: |
+          python3 tools/check_fogstack_local_demo_artifact_index.py --index build/fogstack-local-demo/demo-artifacts.index.json
 
       - name: Upload local demo artifacts
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -180,3 +180,4 @@ validate-storage-suite:
 .PHONY: fogstack-local-demo
 fogstack-local-demo:
 	python3 tools/run_fogstack_local_demo.py --pack all --output-dir build/fogstack-local-demo --summary
+	python3 tools/check_fogstack_local_demo_artifact_index.py --index build/fogstack-local-demo/demo-artifacts.index.json

--- a/tools/check_fogstack_local_demo_artifact_index.py
+++ b/tools/check_fogstack_local_demo_artifact_index.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def path_from_ref(ref: str) -> Path:
+    path = Path(ref)
+    return path if path.is_absolute() else ROOT / path
+
+
+def validate_index(index_path: Path) -> list[str]:
+    index = load_json(index_path)
+    errors: list[str] = []
+
+    if index.get("kind") != "FogStackLocalDemoArtifactIndex":
+        errors.append("index kind mismatch")
+    if index.get("schema_version") != "v0.1":
+        errors.append("index schema_version mismatch")
+
+    artifacts = index.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        errors.append("artifacts list missing or empty")
+        return errors
+
+    seen_ids: set[str] = set()
+    seen_refs: set[str] = set()
+    for position, entry in enumerate(artifacts):
+        if not isinstance(entry, dict):
+            errors.append(f"artifact[{position}] is not an object")
+            continue
+
+        artifact_id = entry.get("id")
+        artifact_ref = entry.get("ref")
+        digest = entry.get("digest")
+        size_bytes = entry.get("size_bytes")
+
+        if not isinstance(artifact_id, str) or not artifact_id:
+            errors.append(f"artifact[{position}] id missing or malformed")
+        elif artifact_id in seen_ids:
+            errors.append(f"duplicate artifact id: {artifact_id}")
+        else:
+            seen_ids.add(artifact_id)
+
+        if not isinstance(artifact_ref, str) or not artifact_ref:
+            errors.append(f"artifact[{position}] ref missing or malformed")
+            continue
+        if artifact_ref in seen_refs:
+            errors.append(f"duplicate artifact ref: {artifact_ref}")
+        else:
+            seen_refs.add(artifact_ref)
+
+        if not isinstance(digest, str) or not digest.startswith("sha256:") or len(digest) != 71:
+            errors.append(f"artifact[{position}] digest missing or malformed")
+
+        if not isinstance(size_bytes, int) or size_bytes <= 0:
+            errors.append(f"artifact[{position}] size_bytes missing or non-positive")
+
+        artifact_path = path_from_ref(artifact_ref)
+        if not artifact_path.exists():
+            errors.append(f"artifact missing: {artifact_ref}")
+            continue
+        if not artifact_path.is_file():
+            errors.append(f"artifact is not a file: {artifact_ref}")
+            continue
+
+        actual_digest = sha256_file(artifact_path)
+        if isinstance(digest, str) and actual_digest != digest:
+            errors.append(f"artifact digest mismatch: {artifact_ref}")
+
+        actual_size = artifact_path.stat().st_size
+        if isinstance(size_bytes, int) and actual_size != size_bytes:
+            errors.append(f"artifact size mismatch: {artifact_ref}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check a FogStack local demo artifact digest index")
+    parser.add_argument("--index", required=True, type=Path)
+    args = parser.parse_args()
+
+    errors = validate_index(args.index)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("FogStack local demo artifact index passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_fogstack_local_demo.py
+++ b/tools/run_fogstack_local_demo.py
@@ -103,8 +103,9 @@ def output_dirs(output_dir: Path) -> dict[str, Path]:
 
 def collect_artifact_refs(summary: dict[str, Any]) -> list[tuple[str, str]]:
     refs: list[tuple[str, str]] = []
+    single_pack_aliases = {"verify_json", "validation_record", "filesystem_release_pointer"}
     for artifact_id, artifact_ref in (summary.get("artifacts") or {}).items():
-        if artifact_id == "artifact_index":
+        if artifact_id == "artifact_index" or artifact_id in single_pack_aliases:
             continue
         if isinstance(artifact_ref, str):
             refs.append((artifact_id, artifact_ref))
@@ -118,13 +119,12 @@ def collect_artifact_refs(summary: dict[str, Any]) -> list[tuple[str, str]]:
             if isinstance(artifact_ref, str):
                 refs.append((f"release:{bundle_id}:{key}", artifact_ref))
 
-    seen: set[str] = set()
+    seen_refs: set[str] = set()
     deduped: list[tuple[str, str]] = []
     for artifact_id, artifact_ref in refs:
-        dedupe_key = f"{artifact_id}\0{artifact_ref}"
-        if dedupe_key in seen:
+        if artifact_ref in seen_refs:
             continue
-        seen.add(dedupe_key)
+        seen_refs.add(artifact_ref)
         deduped.append((artifact_id, artifact_ref))
     return deduped
 

--- a/tools/tests/test_check_fogstack_local_demo_artifact_index.py
+++ b/tools/tests/test_check_fogstack_local_demo_artifact_index.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_demo(output_dir: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/run_fogstack_local_demo.py",
+            "--pack",
+            "access",
+            "--output-dir",
+            str(output_dir),
+        ],
+        check=True,
+    )
+
+
+def test_check_fogstack_local_demo_artifact_index_passes(tmp_path: Path) -> None:
+    output_dir = tmp_path / "demo"
+    run_demo(output_dir)
+
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/check_fogstack_local_demo_artifact_index.py",
+            "--index",
+            str(output_dir / "demo-artifacts.index.json"),
+        ],
+        check=True,
+    )
+
+
+def test_check_fogstack_local_demo_artifact_index_rejects_tampering(tmp_path: Path) -> None:
+    output_dir = tmp_path / "demo"
+    run_demo(output_dir)
+
+    html_summary = output_dir / "index.html"
+    html_summary.write_text(
+        html_summary.read_text(encoding="utf-8") + "\n<!-- tampered -->\n",
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "tools/check_fogstack_local_demo_artifact_index.py",
+            "--index",
+            str(output_dir / "demo-artifacts.index.json"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode != 0
+    assert "artifact digest mismatch" in proc.stderr
+    assert "index.html" in proc.stderr


### PR DESCRIPTION
## Summary

Adds a checker for the FogStack local demo artifact digest index and wires it into the focused local-demo workflow and operator target.

## What changed

- Adds `tools/check_fogstack_local_demo_artifact_index.py`.
- Adds tests proving:
  - a fresh demo artifact index passes verification
  - tampering with an indexed artifact causes verification failure
- Updates `.github/workflows/fogstack-local-demo.yml` to run the checker after `make fogstack-local-demo`.
- Updates `make fogstack-local-demo` to verify `build/fogstack-local-demo/demo-artifacts.index.json` after generating the demo.

## Checker behavior

The checker verifies:

- index kind and schema version
- non-empty artifact list
- duplicate artifact ids / refs are rejected
- each indexed artifact exists
- each indexed artifact is a file
- SHA-256 digest matches file contents
- size metadata matches file size

## Operator impact

The operator command remains:

```bash
make fogstack-local-demo
```

It now fails if the generated digest index is stale or any indexed artifact is modified after indexing.

## Validation intent

```bash
python -m pytest -q tools/tests/test_run_fogstack_local_demo.py tools/tests/test_check_fogstack_local_demo_artifact_index.py
make fogstack-local-demo
```

## Non-goals

- No network registry publication.
- No production signing or KMS/HSM work.
- No client rollback runtime.
- No served web app.
- No status/readiness doc churn.