### PR TITLE
fogstack: serve local demo summary over HTTP

### DIFF
--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -13,6 +13,7 @@ on:
       - "releases/manifests/**"
       - "Makefile"
       - "tools/run_fogstack_local_demo.py"
+      - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
       - "tools/fogstack_verify.py"
       - "tools/emit_fogstack_validation_record.py"
@@ -33,6 +34,7 @@ on:
       - "tools/check_fogstack_registry_root_metadata.py"
       - "tools/tests/test_run_fogstack_local_demo.py"
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
+      - "tools/tests/test_serve_fogstack_local_demo.py"
       - ".github/workflows/fogstack-local-demo.yml"
   push:
     branches: [main]
@@ -46,9 +48,11 @@ on:
       - "releases/manifests/**"
       - "Makefile"
       - "tools/run_fogstack_local_demo.py"
+      - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_run_fogstack_local_demo.py"
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
+      - "tools/tests/test_serve_fogstack_local_demo.py"
       - ".github/workflows/fogstack-local-demo.yml"
 
 permissions:
@@ -74,7 +78,7 @@ jobs:
 
       - name: Run local demo end-to-end test
         run: |
-          python -m pytest -q tools/tests/test_run_fogstack_local_demo.py tools/tests/test_check_fogstack_local_demo_artifact_index.py
+          python -m pytest -q tools/tests/test_run_fogstack_local_demo.py tools/tests/test_check_fogstack_local_demo_artifact_index.py tools/tests/test_serve_fogstack_local_demo.py
 
       - name: Run operator demo command
         run: |

--- a/Makefile
+++ b/Makefile
@@ -181,3 +181,7 @@ validate-storage-suite:
 fogstack-local-demo:
 	python3 tools/run_fogstack_local_demo.py --pack all --output-dir build/fogstack-local-demo --summary
 	python3 tools/check_fogstack_local_demo_artifact_index.py --index build/fogstack-local-demo/demo-artifacts.index.json
+
+.PHONY: fogstack-local-demo-serve
+fogstack-local-demo-serve: fogstack-local-demo
+	python3 tools/serve_fogstack_local_demo.py --directory build/fogstack-local-demo --host 127.0.0.1 --port 8765

--- a/tools/serve_fogstack_local_demo.py
+++ b/tools/serve_fogstack_local_demo.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import functools
+import http.server
+import socketserver
+import sys
+from pathlib import Path
+
+
+class ReusableTCPServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Serve generated FogStack local demo artifacts")
+    parser.add_argument("--directory", type=Path, default=Path("build/fogstack-local-demo"))
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    args = parser.parse_args()
+
+    directory = args.directory.resolve()
+    index = directory / "index.html"
+    if not directory.exists() or not directory.is_dir():
+        print(f"ERR: demo directory does not exist: {directory}", file=sys.stderr)
+        return 1
+    if not index.exists() or not index.is_file():
+        print(f"ERR: demo index.html does not exist: {index}", file=sys.stderr)
+        return 1
+
+    handler = functools.partial(http.server.SimpleHTTPRequestHandler, directory=str(directory))
+    with ReusableTCPServer((args.host, args.port), handler) as httpd:
+        host, port = httpd.server_address
+        print(f"Serving FogStack local demo at http://{host}:{port}/index.html", flush=True)
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_serve_fogstack_local_demo.py
+++ b/tools/tests/test_serve_fogstack_local_demo.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+
+def test_serve_fogstack_local_demo_index(tmp_path: Path) -> None:
+    output_dir = tmp_path / "demo"
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/run_fogstack_local_demo.py",
+            "--pack",
+            "access",
+            "--output-dir",
+            str(output_dir),
+        ],
+        check=True,
+    )
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "tools/serve_fogstack_local_demo.py",
+            "--directory",
+            str(output_dir),
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "0",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert proc.stdout is not None
+        line = proc.stdout.readline().strip()
+        assert line.startswith("Serving FogStack local demo at http://127.0.0.1:")
+        url = line.removeprefix("Serving FogStack local demo at ")
+
+        body = ""
+        last_error: Exception | None = None
+        for _ in range(20):
+            try:
+                with urllib.request.urlopen(url, timeout=2) as response:
+                    body = response.read().decode("utf-8")
+                break
+            except Exception as exc:  # pragma: no cover - retry guard for slow CI sockets
+                last_error = exc
+                time.sleep(0.1)
+        else:
+            raise AssertionError(f"server did not respond: {last_error}")
+
+        assert "<title>FogStack Local Demo Summary</title>" in body
+        assert "FogStack Local Demo Summary" in body
+        assert "fogstack.access" in body
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)


### PR DESCRIPTION
## Summary

Adds a lightweight local HTTP serving path for generated FogStack local demo artifacts.

## What changed

- Adds `tools/serve_fogstack_local_demo.py`, a stdlib-only static server wrapper over the generated demo output.
- Adds `make fogstack-local-demo-serve`.
- Adds a smoke test that:
  - generates local demo artifacts
  - starts the local server on an ephemeral port
  - fetches `/index.html`
  - verifies the FogStack summary title and release ID are served
- Updates the focused FogStack Local Demo workflow to include the server smoke test.

## Operator impact

Generate and serve the local demo with:

```bash
make fogstack-local-demo-serve
```

Default URL:

```text
http://127.0.0.1:8765/index.html
```

## Validation intent

```bash
python -m pytest -q tools/tests/test_run_fogstack_local_demo.py tools/tests/test_check_fogstack_local_demo_artifact_index.py tools/tests/test_serve_fogstack_local_demo.py
make fogstack-local-demo
python3 tools/serve_fogstack_local_demo.py --directory build/fogstack-local-demo --host 127.0.0.1 --port 8765
```

## Non-goals

- No network registry publication.
- No production signing or KMS/HSM work.
- No client rollback runtime.
- No long-running service manager.
- No status/readiness doc churn.