### PR TITLE
fogstack: add deploy plan schema and builder

### DIFF
--- a/.github/workflows/fogstack-deploy-plan.yml
+++ b/.github/workflows/fogstack-deploy-plan.yml
@@ -1,0 +1,57 @@
+name: FogStack Deploy Plan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "bundles/fogstack.*.yaml"
+      - "releases/manifests/fogstack.*.manifest.json"
+      - "schemas/deploy/**"
+      - "tools/build_fogstack_deploy_plan.py"
+      - "tools/tests/test_fogstack_deploy_plan.py"
+      - ".github/workflows/fogstack-deploy-plan.yml"
+  push:
+    branches: [main]
+    paths:
+      - "bundles/fogstack.*.yaml"
+      - "releases/manifests/fogstack.*.manifest.json"
+      - "schemas/deploy/**"
+      - "tools/build_fogstack_deploy_plan.py"
+      - "tools/tests/test_fogstack_deploy_plan.py"
+      - ".github/workflows/fogstack-deploy-plan.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-plan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml jsonschema
+
+      - name: Run deploy plan tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_deploy_plan.py
+
+      - name: Build access deploy plan artifact
+        run: |
+          python3 tools/build_fogstack_deploy_plan.py \
+            --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+            --profile local-dev \
+            --target local \
+            --namespace fogstack-access \
+            --health-endpoint /healthz \
+            --output build/fogstack-deploy-plan/fogstack.access.deploy-plan.json
+          test -s build/fogstack-deploy-plan/fogstack.access.deploy-plan.json

--- a/schemas/deploy/fogstack-deploy-plan-v0.1.schema.json
+++ b/schemas/deploy/fogstack-deploy-plan-v0.1.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/deploy/fogstack-deploy-plan-v0.1.schema.json",
+  "title": "FogStackDeployPlan",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "profile",
+    "target",
+    "namespace",
+    "manifest_ref",
+    "manifest_digest",
+    "bundle_ref",
+    "bundle_digest",
+    "runtime",
+    "deployment",
+    "artifacts",
+    "policy"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackDeployPlan" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "minLength": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "profile": { "type": "string", "minLength": 1 },
+    "target": { "type": "string", "enum": ["local", "kubernetes", "openshift"] },
+    "namespace": { "type": "string", "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" },
+    "manifest_ref": { "type": "string", "minLength": 1 },
+    "manifest_digest": { "$ref": "#/$defs/sha256_digest" },
+    "bundle_ref": { "type": "string", "minLength": 1 },
+    "bundle_digest": { "$ref": "#/$defs/sha256_digest" },
+    "runtime": {
+      "type": "object",
+      "required": ["substrate", "service_classes", "components"],
+      "properties": {
+        "substrate": { "type": "string", "minLength": 1 },
+        "service_classes": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "components": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/component" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "deployment": {
+      "type": "object",
+      "required": [
+        "minimum_nodes_for_first_value",
+        "max_required_services",
+        "install_time_target_minutes",
+        "kubernetes_required",
+        "root_required",
+        "health_endpoint"
+      ],
+      "properties": {
+        "minimum_nodes_for_first_value": { "type": "integer", "minimum": 1 },
+        "max_required_services": { "type": "integer", "minimum": 1 },
+        "install_time_target_minutes": { "type": "integer", "minimum": 1 },
+        "kubernetes_required": { "type": "boolean" },
+        "root_required": { "type": "boolean" },
+        "health_endpoint": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "artifacts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/artifact" },
+      "minItems": 1
+    },
+    "policy": {
+      "type": "object",
+      "required": ["required_contracts", "security_claims"],
+      "properties": {
+        "required_contracts": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "security_claims": {
+          "type": "object",
+          "required": [
+            "operator_identity",
+            "node_identity",
+            "workload_identity",
+            "peer_identity",
+            "signed_artifacts",
+            "sbom_required",
+            "provenance_required"
+          ],
+          "properties": {
+            "operator_identity": { "type": "boolean" },
+            "node_identity": { "type": "boolean" },
+            "workload_identity": { "type": "boolean" },
+            "peer_identity": { "type": "boolean" },
+            "signed_artifacts": { "type": "boolean" },
+            "sbom_required": { "type": "boolean" },
+            "provenance_required": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "sha256_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "component": {
+      "type": "object",
+      "required": ["id", "role"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "role": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "artifact": {
+      "type": "object",
+      "required": ["id", "ref", "digest"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "ref": { "type": "string", "minLength": 1 },
+        "digest": { "$ref": "#/$defs/sha256_digest" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/build_fogstack_deploy_plan.py
+++ b/tools/build_fogstack_deploy_plan.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected YAML object in {path}")
+    return data
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def selected_profile(bundle: dict[str, Any], profile_id: str) -> dict[str, Any]:
+    profiles = bundle.get("profiles", {}).get("supported", [])
+    if not isinstance(profiles, list):
+        raise SystemExit("ERR: bundle profiles.supported must be a list")
+    for profile in profiles:
+        if isinstance(profile, dict) and profile.get("id") == profile_id:
+            return profile
+    raise SystemExit(f"ERR: profile not found in bundle: {profile_id}")
+
+
+def build_plan(manifest_path: Path, profile_id: str, target: str, namespace: str, health_endpoint: str) -> dict[str, Any]:
+    manifest_path = manifest_path if manifest_path.is_absolute() else ROOT / manifest_path
+    manifest = load_json(manifest_path)
+
+    bundle_ref = manifest.get("bundle")
+    if not isinstance(bundle_ref, str) or not bundle_ref:
+        raise SystemExit("ERR: manifest missing bundle ref")
+    bundle_path = ROOT / bundle_ref
+    bundle = load_yaml(bundle_path)
+
+    profile = selected_profile(bundle, profile_id)
+    metadata = bundle.get("metadata", {})
+    runtime = bundle.get("runtime", {})
+    deployment = bundle.get("deployment", {})
+    contracts = bundle.get("contracts", {})
+    security = bundle.get("security", {})
+
+    bundle_id = manifest.get("bundle_id")
+    version = manifest.get("version")
+    if bundle_id != metadata.get("bundle_id"):
+        raise SystemExit("ERR: manifest bundle_id does not match bundle metadata")
+    if version != metadata.get("version"):
+        raise SystemExit("ERR: manifest version does not match bundle metadata")
+
+    manifest_digest = sha256_file(manifest_path)
+    bundle_digest = manifest.get("bundle_digest")
+    if not isinstance(bundle_digest, str) or not bundle_digest.startswith("sha256:"):
+        raise SystemExit("ERR: manifest bundle_digest missing or malformed")
+
+    return {
+        "kind": "FogStackDeployPlan",
+        "schema_version": "v0.1",
+        "bundle_id": bundle_id,
+        "version": version,
+        "profile": profile_id,
+        "target": target,
+        "namespace": namespace,
+        "manifest_ref": rel(manifest_path),
+        "manifest_digest": manifest_digest,
+        "bundle_ref": bundle_ref,
+        "bundle_digest": bundle_digest,
+        "runtime": {
+            "substrate": runtime.get("substrate"),
+            "service_classes": runtime.get("service_classes", []),
+            "components": runtime.get("components", []),
+        },
+        "deployment": {
+            "minimum_nodes_for_first_value": deployment.get("minimum_nodes_for_first_value"),
+            "max_required_services": deployment.get("max_required_services"),
+            "install_time_target_minutes": deployment.get("install_time_target_minutes"),
+            "kubernetes_required": bool(profile.get("kubernetes_required")),
+            "root_required": bool(profile.get("root_required")),
+            "health_endpoint": health_endpoint,
+        },
+        "artifacts": [
+            {
+                "id": "bundle",
+                "ref": bundle_ref,
+                "digest": bundle_digest,
+            },
+            {
+                "id": "manifest",
+                "ref": rel(manifest_path),
+                "digest": manifest_digest,
+            },
+        ],
+        "policy": {
+            "required_contracts": contracts.get("required", []),
+            "security_claims": {
+                "operator_identity": bool(security.get("identities", {}).get("operator_identity")),
+                "node_identity": bool(security.get("identities", {}).get("node_identity")),
+                "workload_identity": bool(security.get("identities", {}).get("workload_identity")),
+                "peer_identity": bool(security.get("identities", {}).get("peer_identity")),
+                "signed_artifacts": bool(security.get("supply_chain", {}).get("signed_artifacts")),
+                "sbom_required": bool(security.get("supply_chain", {}).get("sbom_required")),
+                "provenance_required": bool(security.get("supply_chain", {}).get("provenance_required")),
+            },
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a FogStack deploy plan from a bundle manifest")
+    parser.add_argument("--manifest", default="releases/manifests/fogstack.access-v0.1.manifest.json", type=Path)
+    parser.add_argument("--profile", default="local-dev")
+    parser.add_argument("--target", choices=["local", "kubernetes", "openshift"], default="local")
+    parser.add_argument("--namespace", default="fogstack-access")
+    parser.add_argument("--health-endpoint", default="/healthz")
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    plan = build_plan(args.manifest, args.profile, args.target, args.namespace, args.health_endpoint)
+    output = args.output if args.output.is_absolute() else ROOT / args.output
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(plan, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_deploy_plan.py
+++ b/tools/tests/test_fogstack_deploy_plan.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+SCHEMA = Path("schemas/deploy/fogstack-deploy-plan-v0.1.schema.json")
+MANIFEST = Path("releases/manifests/fogstack.access-v0.1.manifest.json")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def test_build_fogstack_access_deploy_plan(tmp_path: Path) -> None:
+    output = tmp_path / "fogstack.access.deploy-plan.json"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/build_fogstack_deploy_plan.py",
+            "--manifest",
+            str(MANIFEST),
+            "--profile",
+            "local-dev",
+            "--target",
+            "local",
+            "--namespace",
+            "fogstack-access",
+            "--health-endpoint",
+            "/healthz",
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    plan = load_json(output)
+    schema = load_json(SCHEMA)
+    Draft202012Validator(schema).validate(plan)
+
+    assert plan["kind"] == "FogStackDeployPlan"
+    assert plan["schema_version"] == "v0.1"
+    assert plan["bundle_id"] == "fogstack.access"
+    assert plan["version"] == "0.1.0"
+    assert plan["profile"] == "local-dev"
+    assert plan["target"] == "local"
+    assert plan["namespace"] == "fogstack-access"
+    assert plan["manifest_ref"] == str(MANIFEST)
+    assert plan["bundle_ref"] == "bundles/fogstack.access-v0.1.yaml"
+    assert DIGEST_RE.match(plan["manifest_digest"])
+    assert DIGEST_RE.match(plan["bundle_digest"])
+
+    assert plan["runtime"]["substrate"] == "prophet-platform"
+    assert plan["runtime"]["service_classes"] == ["edge-service", "cluster-service"]
+    component_ids = {component["id"] for component in plan["runtime"]["components"]}
+    assert component_ids == {"cloudshell-fog", "apps/gateway", "apps/api"}
+
+    assert plan["deployment"]["minimum_nodes_for_first_value"] == 1
+    assert plan["deployment"]["max_required_services"] == 3
+    assert plan["deployment"]["install_time_target_minutes"] == 30
+    assert plan["deployment"]["kubernetes_required"] is False
+    assert plan["deployment"]["root_required"] is False
+    assert plan["deployment"]["health_endpoint"] == "/healthz"
+
+    artifacts = {artifact["id"]: artifact for artifact in plan["artifacts"]}
+    assert set(artifacts) == {"bundle", "manifest"}
+    assert artifacts["bundle"]["ref"] == plan["bundle_ref"]
+    assert artifacts["bundle"]["digest"] == plan["bundle_digest"]
+    assert artifacts["manifest"]["ref"] == plan["manifest_ref"]
+    assert artifacts["manifest"]["digest"] == plan["manifest_digest"]
+
+    assert plan["policy"]["required_contracts"] == [
+        "EventEnvelope",
+        "EvidenceReceipt",
+        "MembraneDecision",
+    ]
+    assert plan["policy"]["security_claims"] == {
+        "operator_identity": True,
+        "node_identity": True,
+        "workload_identity": True,
+        "peer_identity": True,
+        "signed_artifacts": True,
+        "sbom_required": True,
+        "provenance_required": True,
+    }
+
+
+def test_build_fogstack_access_cluster_profile(tmp_path: Path) -> None:
+    output = tmp_path / "fogstack.access.cluster.deploy-plan.json"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/build_fogstack_deploy_plan.py",
+            "--manifest",
+            str(MANIFEST),
+            "--profile",
+            "cluster-standard",
+            "--target",
+            "kubernetes",
+            "--namespace",
+            "fogstack-access",
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    plan = load_json(output)
+    Draft202012Validator(load_json(SCHEMA)).validate(plan)
+    assert plan["profile"] == "cluster-standard"
+    assert plan["target"] == "kubernetes"
+    assert plan["deployment"]["kubernetes_required"] is True
+    assert plan["deployment"]["root_required"] is False


### PR DESCRIPTION
## Summary

Turn 1 of the IBM-parity deploy/runtime lane.

Adds `FogStackDeployPlan v0.1` schema, a deploy-plan builder for `fogstack.access`, tests, and a focused deploy-plan workflow.

## What changed

- Adds `schemas/deploy/fogstack-deploy-plan-v0.1.schema.json`.
- Adds `tools/build_fogstack_deploy_plan.py`.
- Adds `tools/tests/test_fogstack_deploy_plan.py`.
- Adds `.github/workflows/fogstack-deploy-plan.yml`.

## Deploy plan contents

The generated plan captures:

- bundle id/version/profile/target/namespace
- manifest ref and digest
- bundle ref and digest
- runtime substrate, service classes, and components
- deployment requirements and health endpoint
- artifact refs/digests
- required contracts
- security claims for identity and supply-chain expectations

## Validation intent

```bash
python -m pytest -q tools/tests/test_fogstack_deploy_plan.py
python3 tools/build_fogstack_deploy_plan.py \
  --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
  --profile local-dev \
  --target local \
  --namespace fogstack-access \
  --health-endpoint /healthz \
  --output build/fogstack-deploy-plan/fogstack.access.deploy-plan.json
```

## Non-goals

- No Kubernetes manifests yet.
- No cluster runtime yet.
- No GitOps bundle yet.
- No local-demo artifact-index integration yet.
- No status/readiness doc churn.

Parity plan counter: Turn 1 / 32 toward credible MVP IBM-style parity.