### PR TITLE
fogstack: add deploy plan checker

### DIFF
--- a/.github/workflows/fogstack-deploy-plan.yml
+++ b/.github/workflows/fogstack-deploy-plan.yml
@@ -8,7 +8,9 @@ on:
       - "releases/manifests/fogstack.*.manifest.json"
       - "schemas/deploy/**"
       - "tools/build_fogstack_deploy_plan.py"
+      - "tools/check_fogstack_deploy_plan.py"
       - "tools/tests/test_fogstack_deploy_plan.py"
+      - "tools/tests/test_check_fogstack_deploy_plan.py"
       - ".github/workflows/fogstack-deploy-plan.yml"
   push:
     branches: [main]
@@ -17,7 +19,9 @@ on:
       - "releases/manifests/fogstack.*.manifest.json"
       - "schemas/deploy/**"
       - "tools/build_fogstack_deploy_plan.py"
+      - "tools/check_fogstack_deploy_plan.py"
       - "tools/tests/test_fogstack_deploy_plan.py"
+      - "tools/tests/test_check_fogstack_deploy_plan.py"
       - ".github/workflows/fogstack-deploy-plan.yml"
 
 permissions:
@@ -43,7 +47,7 @@ jobs:
 
       - name: Run deploy plan tests
         run: |
-          python -m pytest -q tools/tests/test_fogstack_deploy_plan.py
+          python -m pytest -q tools/tests/test_fogstack_deploy_plan.py tools/tests/test_check_fogstack_deploy_plan.py
 
       - name: Build access deploy plan artifact
         run: |
@@ -55,3 +59,7 @@ jobs:
             --health-endpoint /healthz \
             --output build/fogstack-deploy-plan/fogstack.access.deploy-plan.json
           test -s build/fogstack-deploy-plan/fogstack.access.deploy-plan.json
+
+      - name: Check access deploy plan artifact
+        run: |
+          python3 tools/check_fogstack_deploy_plan.py --plan build/fogstack-deploy-plan/fogstack.access.deploy-plan.json

--- a/tools/check_fogstack_deploy_plan.py
+++ b/tools/check_fogstack_deploy_plan.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SCHEMA = ROOT / "schemas" / "deploy" / "fogstack-deploy-plan-v0.1.schema.json"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def path_from_ref(ref: str) -> Path:
+    path = Path(ref)
+    return path if path.is_absolute() else ROOT / path
+
+
+def validate_schema(plan: dict[str, Any], schema_path: Path) -> list[str]:
+    schema = load_json(schema_path)
+    validator = Draft202012Validator(schema)
+    return [
+        f"schema error at {'/'.join(str(part) for part in error.absolute_path) or '$'}: {error.message}"
+        for error in sorted(validator.iter_errors(plan), key=lambda item: list(item.absolute_path))
+    ]
+
+
+def validate_plan(plan_path: Path, schema_path: Path = DEFAULT_SCHEMA) -> list[str]:
+    errors: list[str] = []
+    plan = load_json(plan_path)
+
+    errors.extend(validate_schema(plan, schema_path))
+    if errors:
+        return errors
+
+    manifest_ref = plan["manifest_ref"]
+    bundle_ref = plan["bundle_ref"]
+    manifest_path = path_from_ref(manifest_ref)
+    bundle_path = path_from_ref(bundle_ref)
+
+    if not manifest_path.exists():
+        errors.append(f"manifest_ref missing: {manifest_ref}")
+    elif not manifest_path.is_file():
+        errors.append(f"manifest_ref is not a file: {manifest_ref}")
+    else:
+        actual_manifest_digest = sha256_file(manifest_path)
+        if actual_manifest_digest != plan["manifest_digest"]:
+            errors.append(f"manifest_digest mismatch: {manifest_ref}")
+
+    if not bundle_path.exists():
+        errors.append(f"bundle_ref missing: {bundle_ref}")
+    elif not bundle_path.is_file():
+        errors.append(f"bundle_ref is not a file: {bundle_ref}")
+    else:
+        actual_bundle_digest = sha256_file(bundle_path)
+        if actual_bundle_digest != plan["bundle_digest"]:
+            errors.append(f"bundle_digest mismatch: {bundle_ref}")
+
+    if manifest_path.exists() and manifest_path.is_file():
+        manifest = load_json(manifest_path)
+        if manifest.get("bundle_id") != plan["bundle_id"]:
+            errors.append("manifest bundle_id does not match deploy plan")
+        if manifest.get("version") != plan["version"]:
+            errors.append("manifest version does not match deploy plan")
+        if manifest.get("bundle") != bundle_ref:
+            errors.append("manifest bundle ref does not match deploy plan")
+        if manifest.get("bundle_digest") != plan["bundle_digest"]:
+            errors.append("manifest bundle_digest does not match deploy plan")
+
+    artifact_ids: set[str] = set()
+    artifact_refs: set[str] = set()
+    for index, artifact in enumerate(plan.get("artifacts", [])):
+        artifact_id = artifact["id"]
+        artifact_ref = artifact["ref"]
+        artifact_digest = artifact["digest"]
+
+        if artifact_id in artifact_ids:
+            errors.append(f"duplicate artifact id: {artifact_id}")
+        artifact_ids.add(artifact_id)
+
+        if artifact_ref in artifact_refs:
+            errors.append(f"duplicate artifact ref: {artifact_ref}")
+        artifact_refs.add(artifact_ref)
+
+        artifact_path = path_from_ref(artifact_ref)
+        if not artifact_path.exists():
+            errors.append(f"artifact[{index}] missing: {artifact_ref}")
+            continue
+        if not artifact_path.is_file():
+            errors.append(f"artifact[{index}] is not a file: {artifact_ref}")
+            continue
+        actual_digest = sha256_file(artifact_path)
+        if actual_digest != artifact_digest:
+            errors.append(f"artifact[{index}] digest mismatch: {artifact_ref}")
+
+    required_artifacts = {
+        "bundle": (bundle_ref, plan["bundle_digest"]),
+        "manifest": (manifest_ref, plan["manifest_digest"]),
+    }
+    artifacts_by_id = {artifact["id"]: artifact for artifact in plan.get("artifacts", [])}
+    for artifact_id, (expected_ref, expected_digest) in required_artifacts.items():
+        artifact = artifacts_by_id.get(artifact_id)
+        if artifact is None:
+            errors.append(f"required artifact missing from deploy plan: {artifact_id}")
+            continue
+        if artifact["ref"] != expected_ref:
+            errors.append(f"required artifact ref mismatch: {artifact_id}")
+        if artifact["digest"] != expected_digest:
+            errors.append(f"required artifact digest mismatch: {artifact_id}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check a FogStack deploy plan")
+    parser.add_argument("--plan", required=True, type=Path)
+    parser.add_argument("--schema", default=DEFAULT_SCHEMA, type=Path)
+    args = parser.parse_args()
+
+    errors = validate_plan(args.plan, args.schema)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("FogStack deploy plan passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_check_fogstack_deploy_plan.py
+++ b/tools/tests/test_check_fogstack_deploy_plan.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+MANIFEST = Path("releases/manifests/fogstack.access-v0.1.manifest.json")
+
+
+def build_plan(output: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/build_fogstack_deploy_plan.py",
+            "--manifest",
+            str(MANIFEST),
+            "--profile",
+            "local-dev",
+            "--target",
+            "local",
+            "--namespace",
+            "fogstack-access",
+            "--health-endpoint",
+            "/healthz",
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+
+def check_plan(plan: Path, *, check: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "tools/check_fogstack_deploy_plan.py",
+            "--plan",
+            str(plan),
+        ],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def test_check_fogstack_deploy_plan_passes(tmp_path: Path) -> None:
+    plan = tmp_path / "fogstack.access.deploy-plan.json"
+    build_plan(plan)
+
+    proc = check_plan(plan, check=True)
+    assert "FogStack deploy plan passed." in proc.stdout
+
+
+def test_check_fogstack_deploy_plan_rejects_missing_required_field(tmp_path: Path) -> None:
+    plan = tmp_path / "fogstack.access.deploy-plan.json"
+    build_plan(plan)
+
+    data = json.loads(plan.read_text(encoding="utf-8"))
+    del data["namespace"]
+    write_json(plan, data)
+
+    proc = check_plan(plan)
+    assert proc.returncode != 0
+    assert "schema error" in proc.stderr
+    assert "namespace" in proc.stderr
+
+
+def test_check_fogstack_deploy_plan_rejects_bad_manifest_digest(tmp_path: Path) -> None:
+    plan = tmp_path / "fogstack.access.deploy-plan.json"
+    build_plan(plan)
+
+    data = json.loads(plan.read_text(encoding="utf-8"))
+    data["manifest_digest"] = "sha256:" + ("0" * 64)
+    data["artifacts"] = [
+        artifact if artifact["id"] != "manifest" else {**artifact, "digest": data["manifest_digest"]}
+        for artifact in data["artifacts"]
+    ]
+    write_json(plan, data)
+
+    proc = check_plan(plan)
+    assert proc.returncode != 0
+    assert "manifest_digest mismatch" in proc.stderr
+
+
+def test_check_fogstack_deploy_plan_rejects_tampered_artifact(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle.yaml"
+    manifest = tmp_path / "manifest.json"
+    plan = tmp_path / "deploy-plan.json"
+
+    original_bundle = Path("bundles/fogstack.access-v0.1.yaml")
+    original_manifest = Path("releases/manifests/fogstack.access-v0.1.manifest.json")
+    bundle.write_text(original_bundle.read_text(encoding="utf-8"), encoding="utf-8")
+    manifest_data = json.loads(original_manifest.read_text(encoding="utf-8"))
+    manifest_data["bundle"] = str(bundle)
+    manifest.write_text(json.dumps(manifest_data, indent=2) + "\n", encoding="utf-8")
+
+    build_plan_input = subprocess.run(
+        [
+            sys.executable,
+            "tools/build_fogstack_deploy_plan.py",
+            "--manifest",
+            str(manifest),
+            "--profile",
+            "local-dev",
+            "--target",
+            "local",
+            "--namespace",
+            "fogstack-access",
+            "--output",
+            str(plan),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert build_plan_input.returncode == 0
+
+    bundle.write_text(bundle.read_text(encoding="utf-8") + "\n# tampered\n", encoding="utf-8")
+
+    proc = check_plan(plan)
+    assert proc.returncode != 0
+    assert "bundle_digest mismatch" in proc.stderr or "artifact[0] digest mismatch" in proc.stderr


### PR DESCRIPTION
## Summary

Turn 2 of the IBM-parity deploy/runtime lane.

Adds a strict checker for `FogStackDeployPlan v0.1`, malformed-plan rejection tests, and focused deploy-plan workflow enforcement.

## What changed

- Adds `tools/check_fogstack_deploy_plan.py`.
- Adds `tools/tests/test_check_fogstack_deploy_plan.py`.
- Updates `.github/workflows/fogstack-deploy-plan.yml` to run checker tests and validate the generated deploy-plan artifact.

## Checker behavior

The checker validates:

- deploy-plan JSON Schema compliance
- manifest ref exists and digest matches
- bundle ref exists and digest matches
- manifest bundle/version/bundle ref consistency
- artifact refs exist and are files
- artifact digests match file contents
- duplicate artifact ids/refs are rejected
- required bundle and manifest artifact entries are present and consistent

## Validation intent

```bash
python -m pytest -q tools/tests/test_fogstack_deploy_plan.py tools/tests/test_check_fogstack_deploy_plan.py
python3 tools/build_fogstack_deploy_plan.py \
  --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
  --profile local-dev \
  --target local \
  --namespace fogstack-access \
  --health-endpoint /healthz \
  --output build/fogstack-deploy-plan/fogstack.access.deploy-plan.json
python3 tools/check_fogstack_deploy_plan.py --plan build/fogstack-deploy-plan/fogstack.access.deploy-plan.json
```

## Non-goals

- No Kubernetes manifests yet.
- No cluster runtime yet.
- No GitOps bundle yet.
- No local-demo artifact-index integration yet.
- No status/readiness doc churn.

Parity plan counter: Turn 2 / 32 toward credible MVP IBM-style parity.