### PR TITLE
fogstack: add runtime plan metadata

### DIFF
--- a/.github/workflows/fogstack-agent-core-plan.yml
+++ b/.github/workflows/fogstack-agent-core-plan.yml
@@ -1,0 +1,62 @@
+name: FogStack Agent Core Plan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "schemas/agent/**"
+      - "tools/build_fogstack_agent_core_plan.py"
+      - "tools/check_fogstack_agent_core_plan.py"
+      - "tools/tests/test_fogstack_agent_core_plan.py"
+      - ".github/workflows/fogstack-agent-core-plan.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/agent/**"
+      - "tools/build_fogstack_agent_core_plan.py"
+      - "tools/check_fogstack_agent_core_plan.py"
+      - "tools/tests/test_fogstack_agent_core_plan.py"
+      - ".github/workflows/fogstack-agent-core-plan.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  agent-core-plan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest jsonschema
+
+      - name: Run agent core plan tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_agent_core_plan.py
+
+      - name: Build access agent core plan artifact
+        run: |
+          python3 tools/build_fogstack_agent_core_plan.py \
+            --bundle-id fogstack.access \
+            --version 0.1.0 \
+            --agent-id agent:fogstack.access.operator \
+            --human-anchor-role operator \
+            --runtime-mode local \
+            --isolation process \
+            --identity-mode local-dev \
+            --max-runtime-seconds 900 \
+            --output build/fogstack-agent-core-plan/fogstack.access.agent-core-plan.json
+          test -s build/fogstack-agent-core-plan/fogstack.access.agent-core-plan.json
+
+      - name: Check access agent core plan artifact
+        run: |
+          python3 tools/check_fogstack_agent_core_plan.py --plan build/fogstack-agent-core-plan/fogstack.access.agent-core-plan.json

--- a/schemas/agent/fogstack-agent-core-plan-v0.1.schema.json
+++ b/schemas/agent/fogstack-agent-core-plan-v0.1.schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/agent/fogstack-agent-core-plan-v0.1.schema.json",
+  "title": "FogStackAgentCorePlan",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "agent_plane"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackAgentCorePlan" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "minLength": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "agent_plane": {
+      "type": "object",
+      "required": [
+        "runtime",
+        "identity",
+        "gateway",
+        "memory",
+        "observability",
+        "policy",
+        "approval_gates"
+      ],
+      "properties": {
+        "runtime": { "$ref": "#/$defs/runtime" },
+        "identity": { "$ref": "#/$defs/identity" },
+        "gateway": { "$ref": "#/$defs/gateway" },
+        "memory": { "$ref": "#/$defs/memory" },
+        "observability": { "$ref": "#/$defs/observability" },
+        "policy": { "$ref": "#/$defs/policy" },
+        "approval_gates": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/approval_gate" },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "runtime": {
+      "type": "object",
+      "required": ["mode", "isolation", "max_runtime_seconds"],
+      "properties": {
+        "mode": { "enum": ["local", "sandbox", "cluster"] },
+        "isolation": { "enum": ["process", "container", "kata", "gvisor"] },
+        "max_runtime_seconds": { "type": "integer", "minimum": 1, "maximum": 86400 }
+      },
+      "additionalProperties": false
+    },
+    "identity": {
+      "type": "object",
+      "required": ["agent_id", "identity_mode", "human_anchor_required", "human_anchor_role"],
+      "properties": {
+        "agent_id": { "type": "string", "pattern": "^agent:[a-z0-9][a-z0-9._:-]*$" },
+        "identity_mode": { "enum": ["local-dev", "workload", "spiffe", "oidc"] },
+        "human_anchor_required": { "const": true },
+        "human_anchor_role": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "gateway": {
+      "type": "object",
+      "required": ["tool_protocols", "allowed_tools"],
+      "properties": {
+        "tool_protocols": {
+          "type": "array",
+          "items": { "enum": ["mcp", "a2a", "cli", "http"] },
+          "minItems": 1
+        },
+        "allowed_tools": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/tool" },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "tool": {
+      "type": "object",
+      "required": ["name", "purpose", "side_effects"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "purpose": { "type": "string", "minLength": 1 },
+        "side_effects": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "memory": {
+      "type": "object",
+      "required": ["short_term", "long_term", "retention_policy"],
+      "properties": {
+        "short_term": { "enum": ["run_context", "disabled"] },
+        "long_term": { "enum": ["disabled-by-default", "explicit-opt-in"] },
+        "retention_policy": { "enum": ["local-demo", "ephemeral", "policy-bound"] }
+      },
+      "additionalProperties": false
+    },
+    "observability": {
+      "type": "object",
+      "required": ["run_record_required", "trace_required", "artifact_index_required", "approval_record_required"],
+      "properties": {
+        "run_record_required": { "const": true },
+        "trace_required": { "type": "boolean" },
+        "artifact_index_required": { "const": true },
+        "approval_record_required": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "policy": {
+      "type": "object",
+      "required": [
+        "human_approval_required_for_deploy",
+        "network_access_default",
+        "filesystem_scope",
+        "secrets_access",
+        "dangerous_actions_require_quorum"
+      ],
+      "properties": {
+        "human_approval_required_for_deploy": { "const": true },
+        "network_access_default": { "const": "deny" },
+        "filesystem_scope": { "const": "repo-local" },
+        "secrets_access": { "const": "deny" },
+        "dangerous_actions_require_quorum": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "approval_gate": {
+      "type": "object",
+      "required": ["id", "action", "required_approvals", "human_required"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "action": { "type": "string", "minLength": 1 },
+        "required_approvals": { "type": "integer", "minimum": 1 },
+        "human_required": { "const": true }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/build_fogstack_agent_core_plan.py
+++ b/tools/build_fogstack_agent_core_plan.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+DEFAULT_TOOLS = [
+    {
+        "name": "fogstack.verify",
+        "purpose": "Verify FogStack bundle conformance before release or deployment planning.",
+        "side_effects": false,
+    },
+    {
+        "name": "fogstack.build_deploy_plan",
+        "purpose": "Build a deploy plan from a verified FogStack bundle manifest.",
+        "side_effects": true,
+    },
+    {
+        "name": "fogstack.check_deploy_plan",
+        "purpose": "Check deploy-plan schema, references, and artifact digests.",
+        "side_effects": false,
+    },
+]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def build_agent_core_plan(
+    bundle_id: str,
+    version: str,
+    agent_id: str,
+    human_anchor_role: str,
+    runtime_mode: str,
+    isolation: str,
+    identity_mode: str,
+    max_runtime_seconds: int,
+) -> dict[str, Any]:
+    return {
+        "kind": "FogStackAgentCorePlan",
+        "schema_version": "v0.1",
+        "bundle_id": bundle_id,
+        "version": version,
+        "agent_plane": {
+            "runtime": {
+                "mode": runtime_mode,
+                "isolation": isolation,
+                "max_runtime_seconds": max_runtime_seconds,
+            },
+            "identity": {
+                "agent_id": agent_id,
+                "identity_mode": identity_mode,
+                "human_anchor_required": True,
+                "human_anchor_role": human_anchor_role,
+            },
+            "gateway": {
+                "tool_protocols": ["mcp", "cli"],
+                "allowed_tools": DEFAULT_TOOLS,
+            },
+            "memory": {
+                "short_term": "run_context",
+                "long_term": "disabled-by-default",
+                "retention_policy": "local-demo",
+            },
+            "observability": {
+                "run_record_required": True,
+                "trace_required": True,
+                "artifact_index_required": True,
+                "approval_record_required": True,
+            },
+            "policy": {
+                "human_approval_required_for_deploy": True,
+                "network_access_default": "deny",
+                "filesystem_scope": "repo-local",
+                "secrets_access": "deny",
+                "dangerous_actions_require_quorum": True,
+            },
+            "approval_gates": [
+                {
+                    "id": "deploy-plan-approval",
+                    "action": "approve FogStack deploy plan before runtime deployment",
+                    "required_approvals": 1,
+                    "human_required": True,
+                },
+                {
+                    "id": "dangerous-action-quorum",
+                    "action": "approve network, secrets, production, or destructive runtime action",
+                    "required_approvals": 3,
+                    "human_required": True,
+                },
+            ],
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a FogStack agent core plan")
+    parser.add_argument("--bundle-id", default="fogstack.access")
+    parser.add_argument("--version", default="0.1.0")
+    parser.add_argument("--agent-id", default="agent:fogstack.access.operator")
+    parser.add_argument("--human-anchor-role", default="operator")
+    parser.add_argument("--runtime-mode", choices=["local", "sandbox", "cluster"], default="local")
+    parser.add_argument("--isolation", choices=["process", "container", "kata", "gvisor"], default="process")
+    parser.add_argument("--identity-mode", choices=["local-dev", "workload", "spiffe", "oidc"], default="local-dev")
+    parser.add_argument("--max-runtime-seconds", type=int, default=900)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    plan = build_agent_core_plan(
+        bundle_id=args.bundle_id,
+        version=args.version,
+        agent_id=args.agent_id,
+        human_anchor_role=args.human_anchor_role,
+        runtime_mode=args.runtime_mode,
+        isolation=args.isolation,
+        identity_mode=args.identity_mode,
+        max_runtime_seconds=args.max_runtime_seconds,
+    )
+
+    output = args.output if args.output.is_absolute() else ROOT / args.output
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(plan, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_fogstack_agent_core_plan.py
+++ b/tools/check_fogstack_agent_core_plan.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SCHEMA = ROOT / "schemas" / "agent" / "fogstack-agent-core-plan-v0.1.schema.json"
+REQUIRED_TOOLS = {
+    "fogstack.verify",
+    "fogstack.build_deploy_plan",
+    "fogstack.check_deploy_plan",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def validate_schema(plan: dict[str, Any], schema_path: Path) -> list[str]:
+    schema = load_json(schema_path)
+    validator = Draft202012Validator(schema)
+    return [
+        f"schema error at {'/'.join(str(part) for part in error.absolute_path) or '$'}: {error.message}"
+        for error in sorted(validator.iter_errors(plan), key=lambda item: list(item.absolute_path))
+    ]
+
+
+def validate_plan(plan_path: Path, schema_path: Path = DEFAULT_SCHEMA) -> list[str]:
+    errors: list[str] = []
+    plan = load_json(plan_path)
+    errors.extend(validate_schema(plan, schema_path))
+    if errors:
+        return errors
+
+    agent_plane = plan["agent_plane"]
+    identity = agent_plane["identity"]
+    policy = agent_plane["policy"]
+    gateway = agent_plane["gateway"]
+    observability = agent_plane["observability"]
+    memory = agent_plane["memory"]
+    approval_gates = agent_plane["approval_gates"]
+
+    if identity["human_anchor_required"] is not True:
+        errors.append("human anchor must be required")
+    if not identity["human_anchor_role"]:
+        errors.append("human anchor role must be non-empty")
+
+    if policy["network_access_default"] != "deny":
+        errors.append("network access must default to deny")
+    if policy["secrets_access"] != "deny":
+        errors.append("secrets access must be deny by default")
+    if policy["filesystem_scope"] != "repo-local":
+        errors.append("filesystem scope must be repo-local")
+    if policy["human_approval_required_for_deploy"] is not True:
+        errors.append("deploy actions must require human approval")
+    if policy["dangerous_actions_require_quorum"] is not True:
+        errors.append("dangerous actions must require quorum")
+
+    if observability["run_record_required"] is not True:
+        errors.append("agent run record must be required")
+    if observability["artifact_index_required"] is not True:
+        errors.append("artifact index must be required")
+    if observability["approval_record_required"] is not True:
+        errors.append("approval record must be required")
+
+    if memory["long_term"] != "disabled-by-default":
+        errors.append("long-term memory must be disabled by default")
+
+    tools = gateway["allowed_tools"]
+    tool_names = [tool["name"] for tool in tools]
+    duplicate_tools = sorted({name for name in tool_names if tool_names.count(name) > 1})
+    for name in duplicate_tools:
+        errors.append(f"duplicate allowed tool: {name}")
+
+    missing_tools = sorted(REQUIRED_TOOLS - set(tool_names))
+    for name in missing_tools:
+        errors.append(f"required allowed tool missing: {name}")
+
+    tool_by_name = {tool["name"]: tool for tool in tools}
+    if tool_by_name.get("fogstack.verify", {}).get("side_effects") is not False:
+        errors.append("fogstack.verify must be side-effect free")
+    if tool_by_name.get("fogstack.check_deploy_plan", {}).get("side_effects") is not False:
+        errors.append("fogstack.check_deploy_plan must be side-effect free")
+
+    gates_by_id = {gate["id"]: gate for gate in approval_gates}
+    deploy_gate = gates_by_id.get("deploy-plan-approval")
+    if deploy_gate is None:
+        errors.append("deploy-plan-approval gate is required")
+    elif deploy_gate["human_required"] is not True or deploy_gate["required_approvals"] < 1:
+        errors.append("deploy-plan-approval gate must require at least one human approval")
+
+    dangerous_gate = gates_by_id.get("dangerous-action-quorum")
+    if dangerous_gate is None:
+        errors.append("dangerous-action-quorum gate is required")
+    elif dangerous_gate["human_required"] is not True or dangerous_gate["required_approvals"] < 3:
+        errors.append("dangerous-action-quorum gate must require at least three human approvals")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check a FogStack agent core plan")
+    parser.add_argument("--plan", required=True, type=Path)
+    parser.add_argument("--schema", default=DEFAULT_SCHEMA, type=Path)
+    args = parser.parse_args()
+
+    errors = validate_plan(args.plan, args.schema)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("FogStack agent core plan passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_agent_core_plan.py
+++ b/tools/tests/test_fogstack_agent_core_plan.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+SCHEMA = Path("schemas/agent/fogstack-agent-core-plan-v0.1.schema.json")
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def build_plan(output: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/build_fogstack_agent_core_plan.py",
+            "--bundle-id",
+            "fogstack.access",
+            "--version",
+            "0.1.0",
+            "--agent-id",
+            "agent:fogstack.access.operator",
+            "--human-anchor-role",
+            "operator",
+            "--runtime-mode",
+            "local",
+            "--isolation",
+            "process",
+            "--identity-mode",
+            "local-dev",
+            "--max-runtime-seconds",
+            "900",
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+
+def check_plan(plan: Path, *, check: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "tools/check_fogstack_agent_core_plan.py",
+            "--plan",
+            str(plan),
+        ],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def test_build_fogstack_agent_core_plan(tmp_path: Path) -> None:
+    output = tmp_path / "fogstack.access.agent-core-plan.json"
+    build_plan(output)
+
+    plan = load_json(output)
+    Draft202012Validator(load_json(SCHEMA)).validate(plan)
+
+    assert plan["kind"] == "FogStackAgentCorePlan"
+    assert plan["schema_version"] == "v0.1"
+    assert plan["bundle_id"] == "fogstack.access"
+    assert plan["version"] == "0.1.0"
+
+    agent_plane = plan["agent_plane"]
+    assert agent_plane["runtime"] == {
+        "mode": "local",
+        "isolation": "process",
+        "max_runtime_seconds": 900,
+    }
+    assert agent_plane["identity"] == {
+        "agent_id": "agent:fogstack.access.operator",
+        "identity_mode": "local-dev",
+        "human_anchor_required": True,
+        "human_anchor_role": "operator",
+    }
+    assert agent_plane["memory"] == {
+        "short_term": "run_context",
+        "long_term": "disabled-by-default",
+        "retention_policy": "local-demo",
+    }
+    assert agent_plane["observability"] == {
+        "run_record_required": True,
+        "trace_required": True,
+        "artifact_index_required": True,
+        "approval_record_required": True,
+    }
+    assert agent_plane["policy"] == {
+        "human_approval_required_for_deploy": True,
+        "network_access_default": "deny",
+        "filesystem_scope": "repo-local",
+        "secrets_access": "deny",
+        "dangerous_actions_require_quorum": True,
+    }
+
+    tool_names = {tool["name"] for tool in agent_plane["gateway"]["allowed_tools"]}
+    assert tool_names == {
+        "fogstack.verify",
+        "fogstack.build_deploy_plan",
+        "fogstack.check_deploy_plan",
+    }
+
+    gates = {gate["id"]: gate for gate in agent_plane["approval_gates"]}
+    assert gates["deploy-plan-approval"]["required_approvals"] == 1
+    assert gates["deploy-plan-approval"]["human_required"] is True
+    assert gates["dangerous-action-quorum"]["required_approvals"] == 3
+    assert gates["dangerous-action-quorum"]["human_required"] is True
+
+
+def test_check_fogstack_agent_core_plan_passes(tmp_path: Path) -> None:
+    output = tmp_path / "fogstack.access.agent-core-plan.json"
+    build_plan(output)
+
+    proc = check_plan(output, check=True)
+    assert "FogStack agent core plan passed." in proc.stdout
+
+
+def test_check_fogstack_agent_core_plan_rejects_network_allow(tmp_path: Path) -> None:
+    output = tmp_path / "fogstack.access.agent-core-plan.json"
+    build_plan(output)
+
+    plan = load_json(output)
+    plan["agent_plane"]["policy"]["network_access_default"] = "allow"
+    write_json(output, plan)
+
+    proc = check_plan(output)
+    assert proc.returncode != 0
+    assert "network_access_default" in proc.stderr or "network access" in proc.stderr
+
+
+def test_check_fogstack_agent_core_plan_rejects_missing_human_anchor(tmp_path: Path) -> None:
+    output = tmp_path / "fogstack.access.agent-core-plan.json"
+    build_plan(output)
+
+    plan = load_json(output)
+    plan["agent_plane"]["identity"]["human_anchor_required"] = False
+    write_json(output, plan)
+
+    proc = check_plan(output)
+    assert proc.returncode != 0
+    assert "human_anchor_required" in proc.stderr or "human anchor" in proc.stderr
+
+
+def test_check_fogstack_agent_core_plan_rejects_missing_required_tool(tmp_path: Path) -> None:
+    output = tmp_path / "fogstack.access.agent-core-plan.json"
+    build_plan(output)
+
+    plan = load_json(output)
+    plan["agent_plane"]["gateway"]["allowed_tools"] = [
+        tool
+        for tool in plan["agent_plane"]["gateway"]["allowed_tools"]
+        if tool["name"] != "fogstack.check_deploy_plan"
+    ]
+    write_json(output, plan)
+
+    proc = check_plan(output)
+    assert proc.returncode != 0
+    assert "required allowed tool missing: fogstack.check_deploy_plan" in proc.stderr
+
+
+def test_check_fogstack_agent_core_plan_rejects_weak_dangerous_quorum(tmp_path: Path) -> None:
+    output = tmp_path / "fogstack.access.agent-core-plan.json"
+    build_plan(output)
+
+    plan = load_json(output)
+    for gate in plan["agent_plane"]["approval_gates"]:
+        if gate["id"] == "dangerous-action-quorum":
+            gate["required_approvals"] = 1
+    write_json(output, plan)
+
+    proc = check_plan(output)
+    assert proc.returncode != 0
+    assert "dangerous-action-quorum gate must require at least three human approvals" in proc.stderr


### PR DESCRIPTION
Adds a schema, builder, checker, tests, and workflow for the new FogStack runtime planning metadata.

Turn 3 / 32.