### PR TITLE
fogstack: link deploy plan to runtime contract

### DIFF
--- a/.github/workflows/fogstack-deploy-plan.yml
+++ b/.github/workflows/fogstack-deploy-plan.yml
@@ -7,8 +7,11 @@ on:
       - "bundles/fogstack.*.yaml"
       - "releases/manifests/fogstack.*.manifest.json"
       - "schemas/deploy/**"
+      - "schemas/agent/fogstack-agent-corps-plan-v0.1.schema.json"
       - "tools/build_fogstack_deploy_plan.py"
       - "tools/check_fogstack_deploy_plan.py"
+      - "tools/build_fogstack_runtime_contract.py"
+      - "tools/check_fogstack_runtime_contract.py"
       - "tools/tests/test_fogstack_deploy_plan.py"
       - "tools/tests/test_check_fogstack_deploy_plan.py"
       - ".github/workflows/fogstack-deploy-plan.yml"
@@ -18,8 +21,11 @@ on:
       - "bundles/fogstack.*.yaml"
       - "releases/manifests/fogstack.*.manifest.json"
       - "schemas/deploy/**"
+      - "schemas/agent/fogstack-agent-corps-plan-v0.1.schema.json"
       - "tools/build_fogstack_deploy_plan.py"
       - "tools/check_fogstack_deploy_plan.py"
+      - "tools/build_fogstack_runtime_contract.py"
+      - "tools/check_fogstack_runtime_contract.py"
       - "tools/tests/test_fogstack_deploy_plan.py"
       - "tools/tests/test_check_fogstack_deploy_plan.py"
       - ".github/workflows/fogstack-deploy-plan.yml"
@@ -49,6 +55,21 @@ jobs:
         run: |
           python -m pytest -q tools/tests/test_fogstack_deploy_plan.py tools/tests/test_check_fogstack_deploy_plan.py
 
+      - name: Build access runtime contract artifact
+        run: |
+          python3 tools/build_fogstack_runtime_contract.py \
+            --bundle-id fogstack.access \
+            --version 0.1.0 \
+            --actor-id agent:fogstack.access.operator \
+            --human-anchor-role operator \
+            --runtime-mode local \
+            --isolation process \
+            --identity-mode local-dev \
+            --max-runtime-seconds 900 \
+            --output build/fogstack-deploy-plan/fogstack.access.runtime-contract.json
+          test -s build/fogstack-deploy-plan/fogstack.access.runtime-contract.json
+          python3 tools/check_fogstack_runtime_contract.py --contract build/fogstack-deploy-plan/fogstack.access.runtime-contract.json
+
       - name: Build access deploy plan artifact
         run: |
           python3 tools/build_fogstack_deploy_plan.py \
@@ -57,6 +78,7 @@ jobs:
             --target local \
             --namespace fogstack-access \
             --health-endpoint /healthz \
+            --runtime-contract build/fogstack-deploy-plan/fogstack.access.runtime-contract.json \
             --output build/fogstack-deploy-plan/fogstack.access.deploy-plan.json
           test -s build/fogstack-deploy-plan/fogstack.access.deploy-plan.json
 

--- a/schemas/deploy/fogstack-deploy-plan-v0.1.schema.json
+++ b/schemas/deploy/fogstack-deploy-plan-v0.1.schema.json
@@ -15,6 +15,8 @@
     "manifest_digest",
     "bundle_ref",
     "bundle_digest",
+    "agent_corps_plan_ref",
+    "agent_corps_plan_digest",
     "runtime",
     "deployment",
     "artifacts",
@@ -32,6 +34,8 @@
     "manifest_digest": { "$ref": "#/$defs/sha256_digest" },
     "bundle_ref": { "type": "string", "minLength": 1 },
     "bundle_digest": { "$ref": "#/$defs/sha256_digest" },
+    "agent_corps_plan_ref": { "type": "string", "minLength": 1 },
+    "agent_corps_plan_digest": { "$ref": "#/$defs/sha256_digest" },
     "runtime": {
       "type": "object",
       "required": ["substrate", "service_classes", "components"],

--- a/tools/build_fogstack_deploy_plan.py
+++ b/tools/build_fogstack_deploy_plan.py
@@ -53,9 +53,18 @@ def selected_profile(bundle: dict[str, Any], profile_id: str) -> dict[str, Any]:
     raise SystemExit(f"ERR: profile not found in bundle: {profile_id}")
 
 
-def build_plan(manifest_path: Path, profile_id: str, target: str, namespace: str, health_endpoint: str) -> dict[str, Any]:
+def build_plan(
+    manifest_path: Path,
+    profile_id: str,
+    target: str,
+    namespace: str,
+    health_endpoint: str,
+    runtime_contract_path: Path,
+) -> dict[str, Any]:
     manifest_path = manifest_path if manifest_path.is_absolute() else ROOT / manifest_path
+    runtime_contract_path = runtime_contract_path if runtime_contract_path.is_absolute() else ROOT / runtime_contract_path
     manifest = load_json(manifest_path)
+    runtime_contract = load_json(runtime_contract_path)
 
     bundle_ref = manifest.get("bundle")
     if not isinstance(bundle_ref, str) or not bundle_ref:
@@ -76,12 +85,20 @@ def build_plan(manifest_path: Path, profile_id: str, target: str, namespace: str
         raise SystemExit("ERR: manifest bundle_id does not match bundle metadata")
     if version != metadata.get("version"):
         raise SystemExit("ERR: manifest version does not match bundle metadata")
+    if runtime_contract.get("kind") != "FogStackAgentCorpsPlan":
+        raise SystemExit("ERR: runtime contract must be a FogStackAgentCorpsPlan")
+    if runtime_contract.get("bundle_id") != bundle_id:
+        raise SystemExit("ERR: runtime contract bundle_id does not match manifest")
+    if runtime_contract.get("version") != version:
+        raise SystemExit("ERR: runtime contract version does not match manifest")
 
     manifest_digest = sha256_file(manifest_path)
+    runtime_contract_digest = sha256_file(runtime_contract_path)
     bundle_digest = manifest.get("bundle_digest")
     if not isinstance(bundle_digest, str) or not bundle_digest.startswith("sha256:"):
         raise SystemExit("ERR: manifest bundle_digest missing or malformed")
 
+    runtime_contract_ref = rel(runtime_contract_path)
     return {
         "kind": "FogStackDeployPlan",
         "schema_version": "v0.1",
@@ -94,6 +111,8 @@ def build_plan(manifest_path: Path, profile_id: str, target: str, namespace: str
         "manifest_digest": manifest_digest,
         "bundle_ref": bundle_ref,
         "bundle_digest": bundle_digest,
+        "agent_corps_plan_ref": runtime_contract_ref,
+        "agent_corps_plan_digest": runtime_contract_digest,
         "runtime": {
             "substrate": runtime.get("substrate"),
             "service_classes": runtime.get("service_classes", []),
@@ -118,6 +137,11 @@ def build_plan(manifest_path: Path, profile_id: str, target: str, namespace: str
                 "ref": rel(manifest_path),
                 "digest": manifest_digest,
             },
+            {
+                "id": "agent-corps-plan",
+                "ref": runtime_contract_ref,
+                "digest": runtime_contract_digest,
+            },
         ],
         "policy": {
             "required_contracts": contracts.get("required", []),
@@ -141,10 +165,18 @@ def main() -> int:
     parser.add_argument("--target", choices=["local", "kubernetes", "openshift"], default="local")
     parser.add_argument("--namespace", default="fogstack-access")
     parser.add_argument("--health-endpoint", default="/healthz")
+    parser.add_argument("--runtime-contract", required=True, type=Path)
     parser.add_argument("--output", required=True, type=Path)
     args = parser.parse_args()
 
-    plan = build_plan(args.manifest, args.profile, args.target, args.namespace, args.health_endpoint)
+    plan = build_plan(
+        args.manifest,
+        args.profile,
+        args.target,
+        args.namespace,
+        args.health_endpoint,
+        args.runtime_contract,
+    )
     output = args.output if args.output.is_absolute() else ROOT / args.output
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(plan, indent=2) + "\n", encoding="utf-8")

--- a/tools/check_fogstack_deploy_plan.py
+++ b/tools/check_fogstack_deploy_plan.py
@@ -54,8 +54,10 @@ def validate_plan(plan_path: Path, schema_path: Path = DEFAULT_SCHEMA) -> list[s
 
     manifest_ref = plan["manifest_ref"]
     bundle_ref = plan["bundle_ref"]
+    agent_corps_ref = plan["agent_corps_plan_ref"]
     manifest_path = path_from_ref(manifest_ref)
     bundle_path = path_from_ref(bundle_ref)
+    agent_corps_path = path_from_ref(agent_corps_ref)
 
     if not manifest_path.exists():
         errors.append(f"manifest_ref missing: {manifest_ref}")
@@ -74,6 +76,22 @@ def validate_plan(plan_path: Path, schema_path: Path = DEFAULT_SCHEMA) -> list[s
         actual_bundle_digest = sha256_file(bundle_path)
         if actual_bundle_digest != plan["bundle_digest"]:
             errors.append(f"bundle_digest mismatch: {bundle_ref}")
+
+    if not agent_corps_path.exists():
+        errors.append(f"agent_corps_plan_ref missing: {agent_corps_ref}")
+    elif not agent_corps_path.is_file():
+        errors.append(f"agent_corps_plan_ref is not a file: {agent_corps_ref}")
+    else:
+        actual_agent_corps_digest = sha256_file(agent_corps_path)
+        if actual_agent_corps_digest != plan["agent_corps_plan_digest"]:
+            errors.append(f"agent_corps_plan_digest mismatch: {agent_corps_ref}")
+        agent_corps_plan = load_json(agent_corps_path)
+        if agent_corps_plan.get("kind") != "FogStackAgentCorpsPlan":
+            errors.append("agent_corps_plan_ref must point to a FogStackAgentCorpsPlan")
+        if agent_corps_plan.get("bundle_id") != plan["bundle_id"]:
+            errors.append("Agent Corps plan bundle_id does not match deploy plan")
+        if agent_corps_plan.get("version") != plan["version"]:
+            errors.append("Agent Corps plan version does not match deploy plan")
 
     if manifest_path.exists() and manifest_path.is_file():
         manifest = load_json(manifest_path)
@@ -115,6 +133,7 @@ def validate_plan(plan_path: Path, schema_path: Path = DEFAULT_SCHEMA) -> list[s
     required_artifacts = {
         "bundle": (bundle_ref, plan["bundle_digest"]),
         "manifest": (manifest_ref, plan["manifest_digest"]),
+        "agent-corps-plan": (agent_corps_ref, plan["agent_corps_plan_digest"]),
     }
     artifacts_by_id = {artifact["id"]: artifact for artifact in plan.get("artifacts", [])}
     for artifact_id, (expected_ref, expected_digest) in required_artifacts.items():

--- a/tools/tests/test_check_fogstack_deploy_plan.py
+++ b/tools/tests/test_check_fogstack_deploy_plan.py
@@ -9,7 +9,35 @@ from pathlib import Path
 MANIFEST = Path("releases/manifests/fogstack.access-v0.1.manifest.json")
 
 
-def build_plan(output: Path) -> None:
+def build_runtime_contract(output: Path, *, bundle_id: str = "fogstack.access", version: str = "0.1.0") -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/build_fogstack_runtime_contract.py",
+            "--bundle-id",
+            bundle_id,
+            "--version",
+            version,
+            "--actor-id",
+            "agent:fogstack.access.operator",
+            "--human-anchor-role",
+            "operator",
+            "--runtime-mode",
+            "local",
+            "--isolation",
+            "process",
+            "--identity-mode",
+            "local-dev",
+            "--max-runtime-seconds",
+            "900",
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+
+def build_plan(output: Path, runtime_contract: Path) -> None:
     subprocess.run(
         [
             sys.executable,
@@ -24,6 +52,8 @@ def build_plan(output: Path) -> None:
             "fogstack-access",
             "--health-endpoint",
             "/healthz",
+            "--runtime-contract",
+            str(runtime_contract),
             "--output",
             str(output),
         ],
@@ -50,16 +80,20 @@ def write_json(path: Path, data: dict) -> None:
 
 
 def test_check_fogstack_deploy_plan_passes(tmp_path: Path) -> None:
+    contract = tmp_path / "fogstack.access.runtime-contract.json"
     plan = tmp_path / "fogstack.access.deploy-plan.json"
-    build_plan(plan)
+    build_runtime_contract(contract)
+    build_plan(plan, contract)
 
     proc = check_plan(plan, check=True)
     assert "FogStack deploy plan passed." in proc.stdout
 
 
 def test_check_fogstack_deploy_plan_rejects_missing_required_field(tmp_path: Path) -> None:
+    contract = tmp_path / "fogstack.access.runtime-contract.json"
     plan = tmp_path / "fogstack.access.deploy-plan.json"
-    build_plan(plan)
+    build_runtime_contract(contract)
+    build_plan(plan, contract)
 
     data = json.loads(plan.read_text(encoding="utf-8"))
     del data["namespace"]
@@ -72,8 +106,10 @@ def test_check_fogstack_deploy_plan_rejects_missing_required_field(tmp_path: Pat
 
 
 def test_check_fogstack_deploy_plan_rejects_bad_manifest_digest(tmp_path: Path) -> None:
+    contract = tmp_path / "fogstack.access.runtime-contract.json"
     plan = tmp_path / "fogstack.access.deploy-plan.json"
-    build_plan(plan)
+    build_runtime_contract(contract)
+    build_plan(plan, contract)
 
     data = json.loads(plan.read_text(encoding="utf-8"))
     data["manifest_digest"] = "sha256:" + ("0" * 64)
@@ -88,9 +124,47 @@ def test_check_fogstack_deploy_plan_rejects_bad_manifest_digest(tmp_path: Path) 
     assert "manifest_digest mismatch" in proc.stderr
 
 
+def test_check_fogstack_deploy_plan_rejects_tampered_runtime_contract(tmp_path: Path) -> None:
+    contract = tmp_path / "fogstack.access.runtime-contract.json"
+    plan = tmp_path / "fogstack.access.deploy-plan.json"
+    build_runtime_contract(contract)
+    build_plan(plan, contract)
+
+    contract_data = json.loads(contract.read_text(encoding="utf-8"))
+    contract_data["agent_corps"]["runtime"]["max_runtime_seconds"] = 901
+    write_json(contract, contract_data)
+
+    proc = check_plan(plan)
+    assert proc.returncode != 0
+    assert "agent_corps_plan_digest mismatch" in proc.stderr or "artifact[2] digest mismatch" in proc.stderr
+
+
+def test_check_fogstack_deploy_plan_rejects_mismatched_runtime_contract_version(tmp_path: Path) -> None:
+    contract = tmp_path / "fogstack.access.runtime-contract.json"
+    plan = tmp_path / "fogstack.access.deploy-plan.json"
+    build_runtime_contract(contract)
+    build_plan(plan, contract)
+
+    data = json.loads(plan.read_text(encoding="utf-8"))
+    contract_data = json.loads(contract.read_text(encoding="utf-8"))
+    contract_data["version"] = "9.9.9"
+    write_json(contract, contract_data)
+    data["agent_corps_plan_digest"] = "sha256:" + ("0" * 64)
+    data["artifacts"] = [
+        artifact if artifact["id"] != "agent-corps-plan" else {**artifact, "digest": data["agent_corps_plan_digest"]}
+        for artifact in data["artifacts"]
+    ]
+    write_json(plan, data)
+
+    proc = check_plan(plan)
+    assert proc.returncode != 0
+    assert "Agent Corps plan version does not match deploy plan" in proc.stderr
+
+
 def test_check_fogstack_deploy_plan_rejects_tampered_artifact(tmp_path: Path) -> None:
     bundle = tmp_path / "bundle.yaml"
     manifest = tmp_path / "manifest.json"
+    contract = tmp_path / "runtime-contract.json"
     plan = tmp_path / "deploy-plan.json"
 
     original_bundle = Path("bundles/fogstack.access-v0.1.yaml")
@@ -99,6 +173,7 @@ def test_check_fogstack_deploy_plan_rejects_tampered_artifact(tmp_path: Path) ->
     manifest_data = json.loads(original_manifest.read_text(encoding="utf-8"))
     manifest_data["bundle"] = str(bundle)
     manifest.write_text(json.dumps(manifest_data, indent=2) + "\n", encoding="utf-8")
+    build_runtime_contract(contract)
 
     build_plan_input = subprocess.run(
         [
@@ -112,6 +187,8 @@ def test_check_fogstack_deploy_plan_rejects_tampered_artifact(tmp_path: Path) ->
             "local",
             "--namespace",
             "fogstack-access",
+            "--runtime-contract",
+            str(contract),
             "--output",
             str(plan),
         ],

--- a/tools/tests/test_fogstack_deploy_plan.py
+++ b/tools/tests/test_fogstack_deploy_plan.py
@@ -20,9 +20,35 @@ def load_json(path: Path) -> dict:
     return data
 
 
-def test_build_fogstack_access_deploy_plan(tmp_path: Path) -> None:
-    output = tmp_path / "fogstack.access.deploy-plan.json"
+def build_runtime_contract(output: Path, *, bundle_id: str = "fogstack.access", version: str = "0.1.0") -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            "tools/build_fogstack_runtime_contract.py",
+            "--bundle-id",
+            bundle_id,
+            "--version",
+            version,
+            "--actor-id",
+            "agent:fogstack.access.operator",
+            "--human-anchor-role",
+            "operator",
+            "--runtime-mode",
+            "local",
+            "--isolation",
+            "process",
+            "--identity-mode",
+            "local-dev",
+            "--max-runtime-seconds",
+            "900",
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
 
+
+def build_deploy_plan(output: Path, runtime_contract: Path, *, profile: str = "local-dev", target: str = "local") -> None:
     subprocess.run(
         [
             sys.executable,
@@ -30,18 +56,27 @@ def test_build_fogstack_access_deploy_plan(tmp_path: Path) -> None:
             "--manifest",
             str(MANIFEST),
             "--profile",
-            "local-dev",
+            profile,
             "--target",
-            "local",
+            target,
             "--namespace",
             "fogstack-access",
             "--health-endpoint",
             "/healthz",
+            "--runtime-contract",
+            str(runtime_contract),
             "--output",
             str(output),
         ],
         check=True,
     )
+
+
+def test_build_fogstack_access_deploy_plan(tmp_path: Path) -> None:
+    runtime_contract = tmp_path / "fogstack.access.runtime-contract.json"
+    output = tmp_path / "fogstack.access.deploy-plan.json"
+    build_runtime_contract(runtime_contract)
+    build_deploy_plan(output, runtime_contract)
 
     plan = load_json(output)
     schema = load_json(SCHEMA)
@@ -56,8 +91,10 @@ def test_build_fogstack_access_deploy_plan(tmp_path: Path) -> None:
     assert plan["namespace"] == "fogstack-access"
     assert plan["manifest_ref"] == str(MANIFEST)
     assert plan["bundle_ref"] == "bundles/fogstack.access-v0.1.yaml"
+    assert plan["agent_corps_plan_ref"] == str(runtime_contract)
     assert DIGEST_RE.match(plan["manifest_digest"])
     assert DIGEST_RE.match(plan["bundle_digest"])
+    assert DIGEST_RE.match(plan["agent_corps_plan_digest"])
 
     assert plan["runtime"]["substrate"] == "prophet-platform"
     assert plan["runtime"]["service_classes"] == ["edge-service", "cluster-service"]
@@ -72,11 +109,13 @@ def test_build_fogstack_access_deploy_plan(tmp_path: Path) -> None:
     assert plan["deployment"]["health_endpoint"] == "/healthz"
 
     artifacts = {artifact["id"]: artifact for artifact in plan["artifacts"]}
-    assert set(artifacts) == {"bundle", "manifest"}
+    assert set(artifacts) == {"bundle", "manifest", "agent-corps-plan"}
     assert artifacts["bundle"]["ref"] == plan["bundle_ref"]
     assert artifacts["bundle"]["digest"] == plan["bundle_digest"]
     assert artifacts["manifest"]["ref"] == plan["manifest_ref"]
     assert artifacts["manifest"]["digest"] == plan["manifest_digest"]
+    assert artifacts["agent-corps-plan"]["ref"] == plan["agent_corps_plan_ref"]
+    assert artifacts["agent-corps-plan"]["digest"] == plan["agent_corps_plan_digest"]
 
     assert plan["policy"]["required_contracts"] == [
         "EventEnvelope",
@@ -95,29 +134,45 @@ def test_build_fogstack_access_deploy_plan(tmp_path: Path) -> None:
 
 
 def test_build_fogstack_access_cluster_profile(tmp_path: Path) -> None:
+    runtime_contract = tmp_path / "fogstack.access.runtime-contract.json"
     output = tmp_path / "fogstack.access.cluster.deploy-plan.json"
+    build_runtime_contract(runtime_contract)
+    build_deploy_plan(output, runtime_contract, profile="cluster-standard", target="kubernetes")
 
-    subprocess.run(
+    plan = load_json(output)
+    Draft202012Validator(load_json(SCHEMA)).validate(plan)
+    assert plan["profile"] == "cluster-standard"
+    assert plan["target"] == "kubernetes"
+    assert plan["agent_corps_plan_ref"] == str(runtime_contract)
+    assert plan["deployment"]["kubernetes_required"] is True
+    assert plan["deployment"]["root_required"] is False
+
+
+def test_build_fogstack_deploy_plan_rejects_mismatched_runtime_contract(tmp_path: Path) -> None:
+    runtime_contract = tmp_path / "fogstack.knowledge.runtime-contract.json"
+    output = tmp_path / "fogstack.access.deploy-plan.json"
+    build_runtime_contract(runtime_contract, bundle_id="fogstack.knowledge")
+
+    proc = subprocess.run(
         [
             sys.executable,
             "tools/build_fogstack_deploy_plan.py",
             "--manifest",
             str(MANIFEST),
             "--profile",
-            "cluster-standard",
+            "local-dev",
             "--target",
-            "kubernetes",
+            "local",
             "--namespace",
             "fogstack-access",
+            "--runtime-contract",
+            str(runtime_contract),
             "--output",
             str(output),
         ],
-        check=True,
+        capture_output=True,
+        text=True,
     )
 
-    plan = load_json(output)
-    Draft202012Validator(load_json(SCHEMA)).validate(plan)
-    assert plan["profile"] == "cluster-standard"
-    assert plan["target"] == "kubernetes"
-    assert plan["deployment"]["kubernetes_required"] is True
-    assert plan["deployment"]["root_required"] is False
+    assert proc.returncode != 0
+    assert "runtime contract bundle_id does not match manifest" in proc.stderr


### PR DESCRIPTION
Turn 4 of the deploy/runtime parity lane.

This links FogStackDeployPlan v0.1 to the FogStackAgentCorpsPlan runtime contract by ref and SHA-256 digest.

Changes:
- requires agent_corps_plan_ref and agent_corps_plan_digest in the deploy-plan schema
- requires --runtime-contract in the deploy-plan builder
- adds the runtime contract as a deploy-plan artifact
- validates referenced contract existence, digest, kind, bundle id, and version
- updates deploy-plan tests and workflow to build/check the runtime contract before the deploy plan

Parity plan counter: Turn 4 / 32 toward credible MVP IBM-style parity.