### PR TITLE
fogstack: render Kubernetes manifests from deploy plan

### DIFF
--- a/.github/workflows/fogstack-kubernetes-manifests.yml
+++ b/.github/workflows/fogstack-kubernetes-manifests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pyyaml
+          python -m pip install pytest pyyaml jsonschema
 
       - name: Run Kubernetes manifest tests
         run: |

--- a/.github/workflows/fogstack-kubernetes-manifests.yml
+++ b/.github/workflows/fogstack-kubernetes-manifests.yml
@@ -1,0 +1,90 @@
+name: FogStack Kubernetes Manifests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "schemas/agent/**"
+      - "schemas/deploy/**"
+      - "bundles/fogstack.*.yaml"
+      - "releases/manifests/fogstack.*.manifest.json"
+      - "tools/build_fogstack_runtime_contract.py"
+      - "tools/build_fogstack_deploy_plan.py"
+      - "tools/check_fogstack_deploy_plan.py"
+      - "tools/render_fogstack_kubernetes_manifests.py"
+      - "tools/tests/test_render_fogstack_kubernetes_manifests.py"
+      - ".github/workflows/fogstack-kubernetes-manifests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/agent/**"
+      - "schemas/deploy/**"
+      - "bundles/fogstack.*.yaml"
+      - "releases/manifests/fogstack.*.manifest.json"
+      - "tools/build_fogstack_runtime_contract.py"
+      - "tools/build_fogstack_deploy_plan.py"
+      - "tools/check_fogstack_deploy_plan.py"
+      - "tools/render_fogstack_kubernetes_manifests.py"
+      - "tools/tests/test_render_fogstack_kubernetes_manifests.py"
+      - ".github/workflows/fogstack-kubernetes-manifests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  kubernetes-manifests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml
+
+      - name: Run Kubernetes manifest tests
+        run: |
+          python -m pytest -q tools/tests/test_render_fogstack_kubernetes_manifests.py
+
+      - name: Build runtime contract
+        run: |
+          python3 tools/build_fogstack_runtime_contract.py \
+            --bundle-id fogstack.access \
+            --version 0.1.0 \
+            --actor-id agent:fogstack.access.operator \
+            --human-anchor-role operator \
+            --runtime-mode local \
+            --isolation process \
+            --identity-mode local-dev \
+            --max-runtime-seconds 900 \
+            --output build/fogstack-kubernetes/fogstack.access.runtime-contract.json
+
+      - name: Build deploy plan
+        run: |
+          python3 tools/build_fogstack_deploy_plan.py \
+            --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+            --profile local-dev \
+            --target kubernetes \
+            --namespace fogstack-access \
+            --health-endpoint /healthz \
+            --runtime-contract build/fogstack-kubernetes/fogstack.access.runtime-contract.json \
+            --output build/fogstack-kubernetes/fogstack.access.deploy-plan.json
+          python3 tools/check_fogstack_deploy_plan.py --plan build/fogstack-kubernetes/fogstack.access.deploy-plan.json
+
+      - name: Render Kubernetes manifests
+        run: |
+          python3 tools/render_fogstack_kubernetes_manifests.py \
+            --deploy-plan build/fogstack-kubernetes/fogstack.access.deploy-plan.json \
+            --output-dir build/fogstack-kubernetes/manifests \
+            --image ghcr.io/socioprophet/fogstack-access:0.1.0 \
+            --port 8080
+          test -s build/fogstack-kubernetes/manifests/configmap.yaml
+          test -s build/fogstack-kubernetes/manifests/deployment.yaml
+          test -s build/fogstack-kubernetes/manifests/service.yaml

--- a/tools/render_fogstack_kubernetes_manifests.py
+++ b/tools/render_fogstack_kubernetes_manifests.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LABEL_PREFIX = "fogstack.socioprophet.io"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def DNS_label(value: str) -> str:
+    return value.replace(".", "-").replace("_", "-").lower()
+
+
+def common_labels(plan: dict[str, Any]) -> dict[str, str]:
+    return {
+        f"{LABEL_PREFIX}/bundle-id": plan["bundle_id"],
+        f"{LABEL_PREFIX}/version": plan["version"],
+        f"{LABEL_PREFIX}/profile": plan["profile"],
+        f"{LABEL_PREFIX}/target": plan["target"],
+        f"{LABEL_PREFIX}/agent-corps": "enabled",
+    }
+
+
+def common_annotations(plan: dict[str, Any]) -> dict[str, str]:
+    return {
+        f"{LABEL_PREFIX}/manifest-ref": plan["manifest_ref"],
+        f"{LABEL_PREFIX}/manifest-digest": plan["manifest_digest"],
+        f"{LABEL_PREFIX}/bundle-ref": plan["bundle_ref"],
+        f"{LABEL_PREFIX}/bundle-digest": plan["bundle_digest"],
+        f"{LABEL_PREFIX}/agent-corps-plan-ref": plan["agent_corps_plan_ref"],
+        f"{LABEL_PREFIX}/agent-corps-plan-digest": plan["agent_corps_plan_digest"],
+    }
+
+
+def render_config_map(plan: dict[str, Any], name: str, labels: dict[str, str], annotations: dict[str, str]) -> dict[str, Any]:
+    components = ",".join(component["id"] for component in plan["runtime"]["components"])
+    return {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": f"{name}-config",
+            "namespace": plan["namespace"],
+            "labels": labels,
+            "annotations": annotations,
+        },
+        "data": {
+            "bundle_id": plan["bundle_id"],
+            "version": plan["version"],
+            "profile": plan["profile"],
+            "target": plan["target"],
+            "runtime_substrate": plan["runtime"]["substrate"],
+            "runtime_components": components,
+            "health_endpoint": plan["deployment"]["health_endpoint"],
+            "agent_corps_plan_ref": plan["agent_corps_plan_ref"],
+            "agent_corps_plan_digest": plan["agent_corps_plan_digest"],
+        },
+    }
+
+
+def render_deployment(plan: dict[str, Any], name: str, labels: dict[str, str], annotations: dict[str, str], image: str, port: int) -> dict[str, Any]:
+    selector = {
+        "app.kubernetes.io/name": name,
+        "app.kubernetes.io/part-of": "fogstack",
+        f"{LABEL_PREFIX}/bundle-id": plan["bundle_id"],
+    }
+    pod_labels = labels | selector
+    return {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": name,
+            "namespace": plan["namespace"],
+            "labels": labels | {"app.kubernetes.io/name": name, "app.kubernetes.io/part-of": "fogstack"},
+            "annotations": annotations,
+        },
+        "spec": {
+            "replicas": 1,
+            "selector": {"matchLabels": selector},
+            "template": {
+                "metadata": {
+                    "labels": pod_labels,
+                    "annotations": annotations,
+                },
+                "spec": {
+                    "containers": [
+                        {
+                            "name": name,
+                            "image": image,
+                            "imagePullPolicy": "IfNotPresent",
+                            "ports": [{"name": "http", "containerPort": port}],
+                            "envFrom": [{"configMapRef": {"name": f"{name}-config"}}],
+                            "readinessProbe": {
+                                "httpGet": {"path": plan["deployment"]["health_endpoint"], "port": "http"},
+                                "initialDelaySeconds": 3,
+                                "periodSeconds": 10,
+                            },
+                            "livenessProbe": {
+                                "httpGet": {"path": plan["deployment"]["health_endpoint"], "port": "http"},
+                                "initialDelaySeconds": 10,
+                                "periodSeconds": 20,
+                            },
+                        }
+                    ]
+                },
+            },
+        },
+    }
+
+
+def render_service(plan: dict[str, Any], name: str, labels: dict[str, str], annotations: dict[str, str], port: int) -> dict[str, Any]:
+    return {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+            "name": name,
+            "namespace": plan["namespace"],
+            "labels": labels | {"app.kubernetes.io/name": name, "app.kubernetes.io/part-of": "fogstack"},
+            "annotations": annotations,
+        },
+        "spec": {
+            "type": "ClusterIP",
+            "selector": {
+                "app.kubernetes.io/name": name,
+                "app.kubernetes.io/part-of": "fogstack",
+                f"{LABEL_PREFIX}/bundle-id": plan["bundle_id"],
+            },
+            "ports": [{"name": "http", "port": port, "targetPort": "http"}],
+        },
+    }
+
+
+def render_manifests(plan: dict[str, Any], image: str, port: int) -> dict[str, dict[str, Any]]:
+    if plan.get("kind") != "FogStackDeployPlan":
+        raise SystemExit("ERR: expected FogStackDeployPlan")
+    if not plan.get("agent_corps_plan_ref") or not plan.get("agent_corps_plan_digest"):
+        raise SystemExit("ERR: deploy plan must include Agent Corps plan ref and digest")
+
+    name = DNS_label(plan["bundle_id"])
+    labels = common_labels(plan)
+    annotations = common_annotations(plan)
+    return {
+        "configmap.yaml": render_config_map(plan, name, labels, annotations),
+        "deployment.yaml": render_deployment(plan, name, labels, annotations, image, port),
+        "service.yaml": render_service(plan, name, labels, annotations, port),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render Kubernetes manifests from a FogStack deploy plan")
+    parser.add_argument("--deploy-plan", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--image", default="ghcr.io/socioprophet/fogstack-access:0.1.0")
+    parser.add_argument("--port", type=int, default=8080)
+    args = parser.parse_args()
+
+    deploy_plan_path = args.deploy_plan if args.deploy_plan.is_absolute() else ROOT / args.deploy_plan
+    output_dir = args.output_dir if args.output_dir.is_absolute() else ROOT / args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifests = render_manifests(load_json(deploy_plan_path), args.image, args.port)
+    for filename, manifest in manifests.items():
+        (output_dir / filename).write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    print(json.dumps({"kind": "FogStackKubernetesManifestSet", "output_dir": str(output_dir), "files": sorted(manifests)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_render_fogstack_kubernetes_manifests.py
+++ b/tools/tests/test_render_fogstack_kubernetes_manifests.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+MANIFEST = Path("releases/manifests/fogstack.access-v0.1.manifest.json")
+LABEL_PREFIX = "fogstack.socioprophet.io"
+
+
+def build_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    contract = tmp_path / "runtime-contract.json"
+    plan = tmp_path / "deploy-plan.json"
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_runtime_contract.py",
+        "--bundle-id", "fogstack.access",
+        "--version", "0.1.0",
+        "--actor-id", "agent:fogstack.access.operator",
+        "--human-anchor-role", "operator",
+        "--runtime-mode", "local",
+        "--isolation", "process",
+        "--identity-mode", "local-dev",
+        "--max-runtime-seconds", "900",
+        "--output", str(contract),
+    ], check=True)
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_deploy_plan.py",
+        "--manifest", str(MANIFEST),
+        "--profile", "local-dev",
+        "--target", "kubernetes",
+        "--namespace", "fogstack-access",
+        "--health-endpoint", "/healthz",
+        "--runtime-contract", str(contract),
+        "--output", str(plan),
+    ], check=True)
+    return contract, plan
+
+
+def load_yaml(path: Path) -> dict:
+    value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_render_fogstack_kubernetes_manifests(tmp_path: Path) -> None:
+    contract, plan = build_inputs(tmp_path)
+    output_dir = tmp_path / "kubernetes"
+    subprocess.run([
+        sys.executable,
+        "tools/render_fogstack_kubernetes_manifests.py",
+        "--deploy-plan", str(plan),
+        "--output-dir", str(output_dir),
+        "--image", "ghcr.io/socioprophet/fogstack-access:0.1.0",
+        "--port", "8080",
+    ], check=True)
+
+    config_map = load_yaml(output_dir / "configmap.yaml")
+    deployment = load_yaml(output_dir / "deployment.yaml")
+    service = load_yaml(output_dir / "service.yaml")
+    plan_data = json.loads(plan.read_text(encoding="utf-8"))
+
+    assert config_map["kind"] == "ConfigMap"
+    assert config_map["metadata"]["name"] == "fogstack-access-config"
+    assert config_map["metadata"]["namespace"] == "fogstack-access"
+    assert config_map["data"]["agent_corps_plan_ref"] == str(contract)
+    assert config_map["data"]["agent_corps_plan_digest"] == plan_data["agent_corps_plan_digest"]
+
+    assert deployment["kind"] == "Deployment"
+    assert deployment["metadata"]["name"] == "fogstack-access"
+    assert deployment["metadata"]["labels"][f"{LABEL_PREFIX}/bundle-id"] == "fogstack.access"
+    assert deployment["metadata"]["labels"][f"{LABEL_PREFIX}/agent-corps"] == "enabled"
+    assert deployment["metadata"]["annotations"][f"{LABEL_PREFIX}/agent-corps-plan-ref"] == str(contract)
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    assert container["image"] == "ghcr.io/socioprophet/fogstack-access:0.1.0"
+    assert container["readinessProbe"]["httpGet"] == {"path": "/healthz", "port": "http"}
+    assert container["livenessProbe"]["httpGet"] == {"path": "/healthz", "port": "http"}
+
+    assert service["kind"] == "Service"
+    assert service["metadata"]["name"] == "fogstack-access"
+    assert service["metadata"]["labels"][f"{LABEL_PREFIX}/agent-corps"] == "enabled"
+    assert service["spec"]["selector"][f"{LABEL_PREFIX}/bundle-id"] == "fogstack.access"
+    assert service["spec"]["ports"] == [{"name": "http", "port": 8080, "targetPort": "http"}]
+
+
+def test_render_fogstack_kubernetes_manifests_requires_agent_corps_link(tmp_path: Path) -> None:
+    _contract, plan = build_inputs(tmp_path)
+    output_dir = tmp_path / "kubernetes"
+    data = json.loads(plan.read_text(encoding="utf-8"))
+    del data["agent_corps_plan_ref"]
+    plan.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    proc = subprocess.run([
+        sys.executable,
+        "tools/render_fogstack_kubernetes_manifests.py",
+        "--deploy-plan", str(plan),
+        "--output-dir", str(output_dir),
+    ], capture_output=True, text=True)
+
+    assert proc.returncode != 0
+    assert "Agent Corps" in proc.stderr


### PR DESCRIPTION
Turn 5 of the deploy/runtime parity lane.

Adds Kubernetes manifest rendering for `fogstack.access` from a verified deploy plan.

Changes:
- adds `tools/render_fogstack_kubernetes_manifests.py`
- renders ConfigMap, Deployment, and Service YAML
- carries Agent Corps labels and annotations from the linked deploy plan
- adds tests for generated YAML and missing Agent Corps link rejection
- adds focused Kubernetes manifest workflow

Parity plan counter: Turn 5 / 32 toward credible MVP IBM-style parity.