### PR TITLE
fogstack: add local demo deploy-plan target

### DIFF
--- a/.github/workflows/fogstack-kubernetes-manifests.yml
+++ b/.github/workflows/fogstack-kubernetes-manifests.yml
@@ -8,13 +8,16 @@ on:
       - "schemas/deploy/**"
       - "bundles/fogstack.*.yaml"
       - "releases/manifests/fogstack.*.manifest.json"
+      - "Makefile"
       - "tools/build_fogstack_runtime_contract.py"
       - "tools/build_fogstack_deploy_plan.py"
       - "tools/check_fogstack_deploy_plan.py"
       - "tools/render_fogstack_kubernetes_manifests.py"
       - "tools/check_fogstack_kubernetes_manifests.py"
+      - "tools/run_fogstack_local_demo_deploy_plan.py"
       - "tools/tests/test_render_fogstack_kubernetes_manifests.py"
       - "tools/tests/test_check_fogstack_kubernetes_manifests.py"
+      - "tools/tests/test_run_fogstack_local_demo_deploy_plan.py"
       - ".github/workflows/fogstack-kubernetes-manifests.yml"
   push:
     branches: [main]
@@ -23,13 +26,16 @@ on:
       - "schemas/deploy/**"
       - "bundles/fogstack.*.yaml"
       - "releases/manifests/fogstack.*.manifest.json"
+      - "Makefile"
       - "tools/build_fogstack_runtime_contract.py"
       - "tools/build_fogstack_deploy_plan.py"
       - "tools/check_fogstack_deploy_plan.py"
       - "tools/render_fogstack_kubernetes_manifests.py"
       - "tools/check_fogstack_kubernetes_manifests.py"
+      - "tools/run_fogstack_local_demo_deploy_plan.py"
       - "tools/tests/test_render_fogstack_kubernetes_manifests.py"
       - "tools/tests/test_check_fogstack_kubernetes_manifests.py"
+      - "tools/tests/test_run_fogstack_local_demo_deploy_plan.py"
       - ".github/workflows/fogstack-kubernetes-manifests.yml"
 
 permissions:
@@ -57,7 +63,8 @@ jobs:
         run: |
           python -m pytest -q \
             tools/tests/test_render_fogstack_kubernetes_manifests.py \
-            tools/tests/test_check_fogstack_kubernetes_manifests.py
+            tools/tests/test_check_fogstack_kubernetes_manifests.py \
+            tools/tests/test_run_fogstack_local_demo_deploy_plan.py
 
       - name: Build runtime contract
         run: |
@@ -100,3 +107,12 @@ jobs:
           python3 tools/check_fogstack_kubernetes_manifests.py \
             --deploy-plan build/fogstack-kubernetes/fogstack.access.deploy-plan.json \
             --manifest-dir build/fogstack-kubernetes/manifests
+
+      - name: Run local demo deploy-plan target
+        run: |
+          make fogstack-local-demo-deploy-plan
+          test -s build/fogstack-local-demo/deploy/fogstack.access.deploy-demo.summary.json
+          test -s build/fogstack-local-demo/deploy/fogstack.access.kubernetes-manifest-check.record.json
+          test -s build/fogstack-local-demo/deploy/kubernetes/configmap.yaml
+          test -s build/fogstack-local-demo/deploy/kubernetes/deployment.yaml
+          test -s build/fogstack-local-demo/deploy/kubernetes/service.yaml

--- a/Makefile
+++ b/Makefile
@@ -185,3 +185,7 @@ fogstack-local-demo:
 .PHONY: fogstack-local-demo-serve
 fogstack-local-demo-serve: fogstack-local-demo
 	python3 tools/serve_fogstack_local_demo.py --directory build/fogstack-local-demo --host 127.0.0.1 --port 8765
+
+.PHONY: fogstack-local-demo-deploy-plan
+fogstack-local-demo-deploy-plan:
+	python3 tools/run_fogstack_local_demo_deploy_plan.py --output-dir build/fogstack-local-demo/deploy --summary

--- a/tools/run_fogstack_local_demo_deploy_plan.py
+++ b/tools/run_fogstack_local_demo_deploy_plan.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=ROOT, check=True, capture_output=True, text=True)
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]:
+    output_dir = output_dir if output_dir.is_absolute() else ROOT / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    runtime_contract = output_dir / "fogstack.access.runtime-contract.json"
+    deploy_plan = output_dir / "fogstack.access.deploy-plan.json"
+    manifest_dir = output_dir / "kubernetes"
+    check_record = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
+    summary_path = output_dir / "fogstack.access.deploy-demo.summary.json"
+
+    run([
+        sys.executable,
+        "tools/build_fogstack_runtime_contract.py",
+        "--bundle-id", "fogstack.access",
+        "--version", "0.1.0",
+        "--actor-id", "agent:fogstack.access.operator",
+        "--human-anchor-role", "operator",
+        "--runtime-mode", "local",
+        "--isolation", "process",
+        "--identity-mode", "local-dev",
+        "--max-runtime-seconds", "900",
+        "--output", str(runtime_contract),
+    ])
+    run([
+        sys.executable,
+        "tools/check_fogstack_runtime_contract.py",
+        "--contract", str(runtime_contract),
+    ])
+    run([
+        sys.executable,
+        "tools/build_fogstack_deploy_plan.py",
+        "--manifest", "releases/manifests/fogstack.access-v0.1.manifest.json",
+        "--profile", "local-dev",
+        "--target", "kubernetes",
+        "--namespace", "fogstack-access",
+        "--health-endpoint", "/healthz",
+        "--runtime-contract", str(runtime_contract),
+        "--output", str(deploy_plan),
+    ])
+    run([
+        sys.executable,
+        "tools/check_fogstack_deploy_plan.py",
+        "--plan", str(deploy_plan),
+    ])
+    run([
+        sys.executable,
+        "tools/render_fogstack_kubernetes_manifests.py",
+        "--deploy-plan", str(deploy_plan),
+        "--output-dir", str(manifest_dir),
+        "--image", image,
+        "--port", str(port),
+    ])
+    check = run([
+        sys.executable,
+        "tools/check_fogstack_kubernetes_manifests.py",
+        "--deploy-plan", str(deploy_plan),
+        "--manifest-dir", str(manifest_dir),
+    ])
+
+    manifests = [
+        manifest_dir / "configmap.yaml",
+        manifest_dir / "deployment.yaml",
+        manifest_dir / "service.yaml",
+    ]
+    record = {
+        "kind": "FogStackKubernetesManifestCheckRecord",
+        "schema_version": "v0.1",
+        "status": "passed",
+        "bundle_id": "fogstack.access",
+        "version": "0.1.0",
+        "deploy_plan_ref": rel(deploy_plan),
+        "agent_corps_plan_ref": rel(runtime_contract),
+        "manifest_dir": rel(manifest_dir),
+        "manifests": [rel(path) for path in manifests],
+        "checker_stdout": check.stdout.strip(),
+    }
+    write_json(check_record, record)
+
+    summary = {
+        "kind": "FogStackLocalDemoDeployPlanRun",
+        "schema_version": "v0.1",
+        "bundle_id": "fogstack.access",
+        "version": "0.1.0",
+        "target": "kubernetes",
+        "artifacts": {
+            "agent_corps_plan": rel(runtime_contract),
+            "deploy_plan": rel(deploy_plan),
+            "kubernetes_configmap": rel(manifest_dir / "configmap.yaml"),
+            "kubernetes_deployment": rel(manifest_dir / "deployment.yaml"),
+            "kubernetes_service": rel(manifest_dir / "service.yaml"),
+            "kubernetes_manifest_check_record": rel(check_record),
+            "summary": rel(summary_path),
+        },
+        "checks": [
+            "agent_corps_plan_built",
+            "agent_corps_plan_checked",
+            "deploy_plan_built",
+            "deploy_plan_checked",
+            "kubernetes_manifests_rendered",
+            "kubernetes_manifests_checked",
+        ],
+    }
+    write_json(summary_path, summary)
+    return summary
+
+
+def render_summary(summary: dict[str, Any]) -> str:
+    artifacts = summary["artifacts"]
+    lines = [
+        "FogStack local demo deploy plan passed.",
+        f"Bundle: {summary['bundle_id']}@{summary['version']}",
+        f"Target: {summary['target']}",
+        f"Agent Corps plan: {artifacts['agent_corps_plan']}",
+        f"Deploy plan: {artifacts['deploy_plan']}",
+        f"Kubernetes ConfigMap: {artifacts['kubernetes_configmap']}",
+        f"Kubernetes Deployment: {artifacts['kubernetes_deployment']}",
+        f"Kubernetes Service: {artifacts['kubernetes_service']}",
+        f"Manifest check record: {artifacts['kubernetes_manifest_check_record']}",
+        f"Checks passed: {len(summary['checks'])}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate FogStack local demo deploy-plan artifacts")
+    parser.add_argument("--output-dir", type=Path, default=Path("build/fogstack-local-demo/deploy"))
+    parser.add_argument("--image", default="ghcr.io/socioprophet/fogstack-access:0.1.0")
+    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args()
+
+    summary = build_deploy_demo(args.output_dir, args.image, args.port)
+    if args.summary:
+        print(render_summary(summary), end="")
+    else:
+        print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
+++ b/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
+    output_dir = tmp_path / "deploy"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "tools/run_fogstack_local_demo_deploy_plan.py",
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "FogStack local demo deploy plan passed." in proc.stdout
+    assert "Bundle: fogstack.access@0.1.0" in proc.stdout
+    assert "Target: kubernetes" in proc.stdout
+    assert "Checks passed: 6" in proc.stdout
+
+    summary_path = output_dir / "fogstack.access.deploy-demo.summary.json"
+    check_record_path = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
+    runtime_contract_path = output_dir / "fogstack.access.runtime-contract.json"
+    deploy_plan_path = output_dir / "fogstack.access.deploy-plan.json"
+    manifest_dir = output_dir / "kubernetes"
+
+    for path in [
+        summary_path,
+        check_record_path,
+        runtime_contract_path,
+        deploy_plan_path,
+        manifest_dir / "configmap.yaml",
+        manifest_dir / "deployment.yaml",
+        manifest_dir / "service.yaml",
+    ]:
+        assert path.exists(), f"missing {path}"
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["kind"] == "FogStackLocalDemoDeployPlanRun"
+    assert summary["bundle_id"] == "fogstack.access"
+    assert summary["version"] == "0.1.0"
+    assert summary["target"] == "kubernetes"
+    assert set(summary["checks"]) == {
+        "agent_corps_plan_built",
+        "agent_corps_plan_checked",
+        "deploy_plan_built",
+        "deploy_plan_checked",
+        "kubernetes_manifests_rendered",
+        "kubernetes_manifests_checked",
+    }
+
+    artifacts = summary["artifacts"]
+    assert artifacts["agent_corps_plan"].endswith("fogstack.access.runtime-contract.json")
+    assert artifacts["deploy_plan"].endswith("fogstack.access.deploy-plan.json")
+    assert artifacts["kubernetes_configmap"].endswith("configmap.yaml")
+    assert artifacts["kubernetes_deployment"].endswith("deployment.yaml")
+    assert artifacts["kubernetes_service"].endswith("service.yaml")
+    assert artifacts["kubernetes_manifest_check_record"].endswith("fogstack.access.kubernetes-manifest-check.record.json")
+
+    check_record = json.loads(check_record_path.read_text(encoding="utf-8"))
+    assert check_record["kind"] == "FogStackKubernetesManifestCheckRecord"
+    assert check_record["status"] == "passed"
+    assert check_record["bundle_id"] == "fogstack.access"
+    assert "FogStack Kubernetes manifests passed." in check_record["checker_stdout"]
+
+    deployment = yaml.safe_load((manifest_dir / "deployment.yaml").read_text(encoding="utf-8"))
+    assert deployment["kind"] == "Deployment"
+    assert deployment["metadata"]["labels"]["fogstack.socioprophet.io/agent-corps"] == "enabled"


### PR DESCRIPTION
Turn 7 of the deploy/runtime parity lane.

Adds a local-demo deploy-plan target that generates the runtime contract, deploy plan, Kubernetes manifests, and manifest-check record under build/fogstack-local-demo/deploy.

Files:
- tools/run_fogstack_local_demo_deploy_plan.py
- tools/tests/test_run_fogstack_local_demo_deploy_plan.py
- Makefile
- .github/workflows/fogstack-kubernetes-manifests.yml

Parity plan counter: Turn 7 / 32 toward credible MVP IBM-style parity.