### PR TITLE
fogstack: index local demo deploy artifacts

### DIFF
--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -13,8 +13,16 @@ on:
       - "releases/manifests/**"
       - "Makefile"
       - "tools/run_fogstack_local_demo.py"
+      - "tools/run_fogstack_local_demo_deploy_plan.py"
+      - "tools/update_fogstack_local_demo_deploy_artifacts.py"
       - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
+      - "tools/build_fogstack_runtime_contract.py"
+      - "tools/check_fogstack_runtime_contract.py"
+      - "tools/build_fogstack_deploy_plan.py"
+      - "tools/check_fogstack_deploy_plan.py"
+      - "tools/render_fogstack_kubernetes_manifests.py"
+      - "tools/check_fogstack_kubernetes_manifests.py"
       - "tools/fogstack_verify.py"
       - "tools/emit_fogstack_validation_record.py"
       - "tools/build_fogstack_manifest_publication_set.py"
@@ -35,6 +43,7 @@ on:
       - "tools/tests/test_run_fogstack_local_demo.py"
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
+      - "tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py"
       - ".github/workflows/fogstack-local-demo.yml"
   push:
     branches: [main]
@@ -48,11 +57,20 @@ on:
       - "releases/manifests/**"
       - "Makefile"
       - "tools/run_fogstack_local_demo.py"
+      - "tools/run_fogstack_local_demo_deploy_plan.py"
+      - "tools/update_fogstack_local_demo_deploy_artifacts.py"
       - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
+      - "tools/build_fogstack_runtime_contract.py"
+      - "tools/check_fogstack_runtime_contract.py"
+      - "tools/build_fogstack_deploy_plan.py"
+      - "tools/check_fogstack_deploy_plan.py"
+      - "tools/render_fogstack_kubernetes_manifests.py"
+      - "tools/check_fogstack_kubernetes_manifests.py"
       - "tools/tests/test_run_fogstack_local_demo.py"
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
+      - "tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py"
       - ".github/workflows/fogstack-local-demo.yml"
 
 permissions:
@@ -74,15 +92,26 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pyyaml
+          python -m pip install pytest pyyaml jsonschema
 
       - name: Run local demo end-to-end test
         run: |
-          python -m pytest -q tools/tests/test_run_fogstack_local_demo.py tools/tests/test_check_fogstack_local_demo_artifact_index.py tools/tests/test_serve_fogstack_local_demo.py
+          python -m pytest -q \
+            tools/tests/test_run_fogstack_local_demo.py \
+            tools/tests/test_check_fogstack_local_demo_artifact_index.py \
+            tools/tests/test_serve_fogstack_local_demo.py \
+            tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
 
       - name: Run operator demo command
         run: |
           make fogstack-local-demo
+
+      - name: Integrate deploy-plan artifacts
+        run: |
+          make fogstack-local-demo-deploy-plan
+          python3 tools/update_fogstack_local_demo_deploy_artifacts.py \
+            --summary-json build/fogstack-local-demo/fogstack-local-demo.summary.json \
+            --deploy-summary-json build/fogstack-local-demo/deploy/fogstack.access.deploy-demo.summary.json
 
       - name: Check generated artifact index
         run: |

--- a/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REQUIRED = {"deploy_agent_corps_plan", "deploy_plan", "deploy_kubernetes_configmap", "deploy_kubernetes_deployment", "deploy_kubernetes_service", "deploy_kubernetes_manifest_check_record", "deploy_summary"}
+
+
+def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
+    output_dir = tmp_path / "demo"
+    deploy_dir = output_dir / "deploy"
+    subprocess.run([sys.executable, "tools/run_fogstack_local_demo.py", "--pack", "all", "--output-dir", str(output_dir)], check=True)
+    subprocess.run([sys.executable, "tools/run_fogstack_local_demo_deploy_plan.py", "--output-dir", str(deploy_dir)], check=True)
+    subprocess.run([sys.executable, "tools/update_fogstack_local_demo_deploy_artifacts.py", "--summary-json", str(output_dir / "fogstack-local-demo.summary.json"), "--deploy-summary-json", str(deploy_dir / "fogstack.access.deploy-demo.summary.json")], check=True)
+
+    summary = json.loads((output_dir / "fogstack-local-demo.summary.json").read_text(encoding="utf-8"))
+    assert REQUIRED.issubset(set(summary["artifacts"]))
+    assert "deploy_plan_built" in summary["checks"]
+    assert "kubernetes_manifests_checked" in summary["checks"]
+
+    artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
+    indexed = {entry["id"]: entry for entry in artifact_index["artifacts"]}
+    assert REQUIRED.issubset(set(indexed))
+    for key in REQUIRED:
+        assert indexed[key]["digest"].startswith("sha256:")
+        assert Path(indexed[key]["ref"]).exists()
+
+    assert "Deploy plan artifacts" in (output_dir / "fogstack-local-demo.summary.md").read_text(encoding="utf-8")
+    assert "Deploy plan artifacts" in (output_dir / "index.html").read_text(encoding="utf-8")

--- a/tools/update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/update_fogstack_local_demo_deploy_artifacts.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOY_ARTIFACT_KEYS = {
+    "agent_corps_plan": "deploy_agent_corps_plan",
+    "deploy_plan": "deploy_plan",
+    "kubernetes_configmap": "deploy_kubernetes_configmap",
+    "kubernetes_deployment": "deploy_kubernetes_deployment",
+    "kubernetes_service": "deploy_kubernetes_service",
+    "kubernetes_manifest_check_record": "deploy_kubernetes_manifest_check_record",
+    "summary": "deploy_summary",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def path_from_ref(ref: str) -> Path:
+    path = Path(ref)
+    return path if path.is_absolute() else ROOT / path
+
+
+def build_artifact_index(summary: dict[str, Any]) -> dict[str, Any]:
+    entries: list[dict[str, Any]] = []
+    seen_refs: set[str] = set()
+    for artifact_id, artifact_ref in sorted((summary.get("artifacts") or {}).items()):
+        if artifact_id == "artifact_index" or not isinstance(artifact_ref, str):
+            continue
+        if artifact_ref in seen_refs:
+            continue
+        seen_refs.add(artifact_ref)
+        path = path_from_ref(artifact_ref)
+        if not path.exists() or not path.is_file():
+            raise SystemExit(f"ERR: indexed artifact is missing or not a file: {artifact_ref}")
+        entries.append({
+            "id": artifact_id,
+            "ref": artifact_ref,
+            "digest": sha256_file(path),
+            "size_bytes": path.stat().st_size,
+        })
+
+    for release in summary.get("releases") or []:
+        if not isinstance(release, dict):
+            continue
+        bundle_id = release.get("bundle_id", "unknown")
+        for key in ["verify_json", "validation_record", "filesystem_release_pointer"]:
+            artifact_ref = release.get(key)
+            if not isinstance(artifact_ref, str) or artifact_ref in seen_refs:
+                continue
+            seen_refs.add(artifact_ref)
+            path = path_from_ref(artifact_ref)
+            if not path.exists() or not path.is_file():
+                raise SystemExit(f"ERR: release artifact is missing or not a file: {artifact_ref}")
+            entries.append({
+                "id": f"release:{bundle_id}:{key}",
+                "ref": artifact_ref,
+                "digest": sha256_file(path),
+                "size_bytes": path.stat().st_size,
+            })
+
+    return {
+        "kind": "FogStackLocalDemoArtifactIndex",
+        "schema_version": "v0.1",
+        "demo_kind": summary.get("kind"),
+        "pack": summary.get("pack"),
+        "registry_uri": summary.get("registry_uri"),
+        "release_count": len(summary.get("releases", [])),
+        "artifacts": entries,
+    }
+
+
+def append_markdown(markdown_path: Path, deploy_summary: dict[str, Any]) -> None:
+    artifacts = deploy_summary["artifacts"]
+    section = [
+        "",
+        "## Deploy plan artifacts",
+        "",
+        f"- Agent Corps plan: `{artifacts['agent_corps_plan']}`",
+        f"- Deploy plan: `{artifacts['deploy_plan']}`",
+        f"- Kubernetes ConfigMap: `{artifacts['kubernetes_configmap']}`",
+        f"- Kubernetes Deployment: `{artifacts['kubernetes_deployment']}`",
+        f"- Kubernetes Service: `{artifacts['kubernetes_service']}`",
+        f"- Manifest check record: `{artifacts['kubernetes_manifest_check_record']}`",
+        "",
+    ]
+    markdown_path.write_text(markdown_path.read_text(encoding="utf-8") + "\n".join(section), encoding="utf-8")
+
+
+def append_html(html_path: Path, deploy_summary: dict[str, Any]) -> None:
+    def esc(value: Any) -> str:
+        return html.escape(str(value), quote=True)
+
+    artifacts = deploy_summary["artifacts"]
+    section = """
+    <h2>Deploy plan artifacts</h2>
+    <ul>
+      <li><strong>Agent Corps plan:</strong> <code>{agent}</code></li>
+      <li><strong>Deploy plan:</strong> <code>{plan}</code></li>
+      <li><strong>Kubernetes ConfigMap:</strong> <code>{configmap}</code></li>
+      <li><strong>Kubernetes Deployment:</strong> <code>{deployment}</code></li>
+      <li><strong>Kubernetes Service:</strong> <code>{service}</code></li>
+      <li><strong>Manifest check record:</strong> <code>{check}</code></li>
+    </ul>
+""".format(
+        agent=esc(artifacts["agent_corps_plan"]),
+        plan=esc(artifacts["deploy_plan"]),
+        configmap=esc(artifacts["kubernetes_configmap"]),
+        deployment=esc(artifacts["kubernetes_deployment"]),
+        service=esc(artifacts["kubernetes_service"]),
+        check=esc(artifacts["kubernetes_manifest_check_record"]),
+    )
+    html_text = html_path.read_text(encoding="utf-8")
+    html_path.write_text(html_text.replace("\n  </main>", section + "\n  </main>"), encoding="utf-8")
+
+
+def update_summary(summary_path: Path, deploy_summary_path: Path) -> dict[str, Any]:
+    summary = load_json(summary_path)
+    deploy_summary = load_json(deploy_summary_path)
+
+    artifacts = summary.setdefault("artifacts", {})
+    for source_key, target_key in DEPLOY_ARTIFACT_KEYS.items():
+        artifacts[target_key] = deploy_summary["artifacts"][source_key]
+
+    checks = summary.setdefault("checks", [])
+    for check in ["deploy_plan_built", "kubernetes_manifests_rendered", "kubernetes_manifests_checked"]:
+        if check not in checks:
+            checks.append(check)
+
+    write_json(summary_path, summary)
+    markdown_path = path_from_ref(artifacts["summary_markdown"])
+    html_path = path_from_ref(artifacts["summary_html"])
+    append_markdown(markdown_path, deploy_summary)
+    append_html(html_path, deploy_summary)
+
+    artifact_index_path = path_from_ref(artifacts["artifact_index"])
+    write_json(artifact_index_path, build_artifact_index(summary))
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Merge local demo deploy-plan artifacts into the local demo summaries and digest index")
+    parser.add_argument("--summary-json", type=Path, default=Path("build/fogstack-local-demo/fogstack-local-demo.summary.json"))
+    parser.add_argument("--deploy-summary-json", type=Path, default=Path("build/fogstack-local-demo/deploy/fogstack.access.deploy-demo.summary.json"))
+    args = parser.parse_args()
+
+    summary_path = args.summary_json if args.summary_json.is_absolute() else ROOT / args.summary_json
+    deploy_summary_path = args.deploy_summary_json if args.deploy_summary_json.is_absolute() else ROOT / args.deploy_summary_json
+    summary = update_summary(summary_path, deploy_summary_path)
+    print(json.dumps({"kind": "FogStackLocalDemoDeployArtifactUpdate", "status": "passed", "artifact_index": summary["artifacts"]["artifact_index"]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Turn 8 of the deploy/runtime parity lane.

Adds local-demo deploy artifact integration so deploy-plan and Kubernetes manifest artifacts are linked from the local demo summary and included in demo-artifacts.index.json with SHA-256 digest coverage.

Files:
- tools/update_fogstack_local_demo_deploy_artifacts.py
- tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
- .github/workflows/fogstack-local-demo.yml

Parity plan counter: Turn 8 / 32 toward credible MVP IBM-style parity.