### PR TITLE
fogstack: add full local demo proof target

### DIFF
--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -15,6 +15,7 @@ on:
       - "tools/run_fogstack_local_demo.py"
       - "tools/run_fogstack_local_demo_deploy_plan.py"
       - "tools/update_fogstack_local_demo_deploy_artifacts.py"
+      - "tools/run_fogstack_local_demo_full.py"
       - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
       - "tools/build_fogstack_runtime_contract.py"
@@ -44,6 +45,7 @@ on:
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
       - "tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py"
+      - "tools/tests/test_run_fogstack_local_demo_full.py"
       - ".github/workflows/fogstack-local-demo.yml"
   push:
     branches: [main]
@@ -59,6 +61,7 @@ on:
       - "tools/run_fogstack_local_demo.py"
       - "tools/run_fogstack_local_demo_deploy_plan.py"
       - "tools/update_fogstack_local_demo_deploy_artifacts.py"
+      - "tools/run_fogstack_local_demo_full.py"
       - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
       - "tools/build_fogstack_runtime_contract.py"
@@ -71,6 +74,7 @@ on:
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
       - "tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py"
+      - "tools/tests/test_run_fogstack_local_demo_full.py"
       - ".github/workflows/fogstack-local-demo.yml"
 
 permissions:
@@ -100,18 +104,16 @@ jobs:
             tools/tests/test_run_fogstack_local_demo.py \
             tools/tests/test_check_fogstack_local_demo_artifact_index.py \
             tools/tests/test_serve_fogstack_local_demo.py \
-            tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
+            tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py \
+            tools/tests/test_run_fogstack_local_demo_full.py
 
-      - name: Run operator demo command
+      - name: Run full operator demo command
         run: |
-          make fogstack-local-demo
-
-      - name: Integrate deploy-plan artifacts
-        run: |
-          make fogstack-local-demo-deploy-plan
-          python3 tools/update_fogstack_local_demo_deploy_artifacts.py \
-            --summary-json build/fogstack-local-demo/fogstack-local-demo.summary.json \
-            --deploy-summary-json build/fogstack-local-demo/deploy/fogstack.access.deploy-demo.summary.json
+          make fogstack-local-demo-full
+          test -s build/fogstack-local-demo/fogstack-local-demo.full.summary.json
+          test -s build/fogstack-local-demo/demo-artifacts.index.json
+          test -s build/fogstack-local-demo/deploy/fogstack.access.deploy-plan.json
+          test -s build/fogstack-local-demo/deploy/kubernetes/deployment.yaml
 
       - name: Check generated artifact index
         run: |

--- a/Makefile
+++ b/Makefile
@@ -189,3 +189,7 @@ fogstack-local-demo-serve: fogstack-local-demo
 .PHONY: fogstack-local-demo-deploy-plan
 fogstack-local-demo-deploy-plan:
 	python3 tools/run_fogstack_local_demo_deploy_plan.py --output-dir build/fogstack-local-demo/deploy --summary
+
+.PHONY: fogstack-local-demo-full
+fogstack-local-demo-full:
+	python3 tools/run_fogstack_local_demo_full.py --output-dir build/fogstack-local-demo --summary

--- a/tools/run_fogstack_local_demo_full.py
+++ b/tools/run_fogstack_local_demo_full.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, cwd=ROOT, check=True)
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
+    output_dir = output_dir if output_dir.is_absolute() else ROOT / output_dir
+    if clean and output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    deploy_dir = output_dir / "deploy"
+    summary_path = output_dir / "fogstack-local-demo.summary.json"
+    deploy_summary_path = deploy_dir / "fogstack.access.deploy-demo.summary.json"
+    artifact_index_path = output_dir / "demo-artifacts.index.json"
+    full_summary_path = output_dir / "fogstack-local-demo.full.summary.json"
+
+    run([
+        sys.executable,
+        "tools/run_fogstack_local_demo.py",
+        "--pack",
+        "all",
+        "--output-dir",
+        str(output_dir),
+        "--summary",
+    ])
+    run([
+        sys.executable,
+        "tools/run_fogstack_local_demo_deploy_plan.py",
+        "--output-dir",
+        str(deploy_dir),
+        "--summary",
+    ])
+    run([
+        sys.executable,
+        "tools/update_fogstack_local_demo_deploy_artifacts.py",
+        "--summary-json",
+        str(summary_path),
+        "--deploy-summary-json",
+        str(deploy_summary_path),
+    ])
+    run([
+        sys.executable,
+        "tools/check_fogstack_local_demo_artifact_index.py",
+        "--index",
+        str(artifact_index_path),
+    ])
+
+    summary = {
+        "kind": "FogStackLocalDemoFullRun",
+        "schema_version": "v0.1",
+        "status": "passed",
+        "output_dir": rel(output_dir),
+        "artifacts": {
+            "local_demo_summary": rel(summary_path),
+            "local_demo_markdown": rel(output_dir / "fogstack-local-demo.summary.md"),
+            "local_demo_html": rel(output_dir / "index.html"),
+            "artifact_index": rel(artifact_index_path),
+            "deploy_summary": rel(deploy_summary_path),
+            "deploy_plan": rel(deploy_dir / "fogstack.access.deploy-plan.json"),
+            "agent_corps_plan": rel(deploy_dir / "fogstack.access.runtime-contract.json"),
+            "kubernetes_configmap": rel(deploy_dir / "kubernetes" / "configmap.yaml"),
+            "kubernetes_deployment": rel(deploy_dir / "kubernetes" / "deployment.yaml"),
+            "kubernetes_service": rel(deploy_dir / "kubernetes" / "service.yaml"),
+            "kubernetes_manifest_check_record": rel(deploy_dir / "fogstack.access.kubernetes-manifest-check.record.json"),
+        },
+        "checks": [
+            "local_demo_generated",
+            "deploy_plan_generated",
+            "deploy_artifacts_integrated",
+            "artifact_index_checked",
+        ],
+    }
+    write_json(full_summary_path, summary)
+    return summary
+
+
+def render_summary(summary: dict[str, Any]) -> str:
+    artifacts = summary["artifacts"]
+    lines = [
+        "FogStack full local demo passed.",
+        f"Output directory: {summary['output_dir']}",
+        f"HTML summary: {artifacts['local_demo_html']}",
+        f"Artifact index: {artifacts['artifact_index']}",
+        f"Deploy plan: {artifacts['deploy_plan']}",
+        f"Kubernetes deployment: {artifacts['kubernetes_deployment']}",
+        f"Checks passed: {len(summary['checks'])}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run the full FogStack local demo proof path")
+    parser.add_argument("--output-dir", type=Path, default=Path("build/fogstack-local-demo"))
+    parser.add_argument("--no-clean", action="store_true")
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args()
+
+    summary = run_full_demo(args.output_dir, clean=not args.no_clean)
+    if args.summary:
+        print(render_summary(summary), end="")
+    else:
+        print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_run_fogstack_local_demo_full.py
+++ b/tools/tests/test_run_fogstack_local_demo_full.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REQUIRED_FULL_ARTIFACTS = {
+    "local_demo_summary",
+    "local_demo_markdown",
+    "local_demo_html",
+    "artifact_index",
+    "deploy_summary",
+    "deploy_plan",
+    "agent_corps_plan",
+    "kubernetes_configmap",
+    "kubernetes_deployment",
+    "kubernetes_service",
+    "kubernetes_manifest_check_record",
+}
+
+
+def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
+    output_dir = tmp_path / "fogstack-local-demo"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "tools/run_fogstack_local_demo_full.py",
+            "--output-dir",
+            str(output_dir),
+            "--summary",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "FogStack full local demo passed." in proc.stdout
+    assert "Artifact index:" in proc.stdout
+    assert "Deploy plan:" in proc.stdout
+    assert "Kubernetes deployment:" in proc.stdout
+
+    full_summary_path = output_dir / "fogstack-local-demo.full.summary.json"
+    assert full_summary_path.exists()
+    full_summary = json.loads(full_summary_path.read_text(encoding="utf-8"))
+    assert full_summary["kind"] == "FogStackLocalDemoFullRun"
+    assert full_summary["status"] == "passed"
+    assert REQUIRED_FULL_ARTIFACTS == set(full_summary["artifacts"])
+    for ref in full_summary["artifacts"].values():
+        assert Path(ref).exists(), ref
+
+    artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
+    indexed_ids = {entry["id"] for entry in artifact_index["artifacts"]}
+    assert "deploy_plan" in indexed_ids
+    assert "deploy_kubernetes_deployment" in indexed_ids
+    assert "deploy_kubernetes_manifest_check_record" in indexed_ids
+
+    html = (output_dir / "index.html").read_text(encoding="utf-8")
+    assert "Deploy plan artifacts" in html
+    assert "fogstack.access.deploy-plan.json" in html


### PR DESCRIPTION
Turn 9 of the deploy/runtime parity lane.

Adds the canonical full local proof command that runs release demo, deploy-plan demo, deploy-artifact integration, and digest-index verification in one operator path.

Files:
- tools/run_fogstack_local_demo_full.py
- tools/tests/test_run_fogstack_local_demo_full.py
- Makefile
- .github/workflows/fogstack-local-demo.yml

Parity plan counter: Turn 9 / 32 toward credible MVP IBM-style parity.