### PR TITLE
fogstack: add optional kubectl dry-run validation

### DIFF
--- a/.github/workflows/fogstack-kubernetes-manifests.yml
+++ b/.github/workflows/fogstack-kubernetes-manifests.yml
@@ -108,6 +108,13 @@ jobs:
             --deploy-plan build/fogstack-kubernetes/fogstack.access.deploy-plan.json \
             --manifest-dir build/fogstack-kubernetes/manifests
 
+      - name: Check Kubernetes manifests with optional kubectl dry-run
+        run: |
+          python3 tools/check_fogstack_kubernetes_manifests.py \
+            --deploy-plan build/fogstack-kubernetes/fogstack.access.deploy-plan.json \
+            --manifest-dir build/fogstack-kubernetes/manifests \
+            --kubectl-dry-run
+
       - name: Run local demo deploy-plan target
         run: |
           make fogstack-local-demo-deploy-plan

--- a/tools/check_fogstack_kubernetes_manifests.py
+++ b/tools/check_fogstack_kubernetes_manifests.py
@@ -14,6 +14,13 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 LABEL_PREFIX = "fogstack.socioprophet.io"
+DISCOVERY_FAILURE_MARKERS = (
+    "couldn't get current server API group list",
+    "the server could not find the requested resource",
+    "connection refused",
+    "unable to recognize",
+    "no configuration has been provided",
+)
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -176,6 +183,11 @@ def resolve_kubectl(kubectl: str) -> str | None:
     return shutil.which(kubectl)
 
 
+def is_discovery_failure(details: str) -> bool:
+    lowered = details.lower()
+    return any(marker in lowered for marker in DISCOVERY_FAILURE_MARKERS)
+
+
 def run_kubectl_dry_run(manifest_dir: Path, kubectl: str, require_kubectl: bool) -> tuple[list[str], str]:
     resolved = resolve_kubectl(kubectl)
     if resolved is None:
@@ -190,6 +202,8 @@ def run_kubectl_dry_run(manifest_dir: Path, kubectl: str, require_kubectl: bool)
     )
     if proc.returncode != 0:
         details = (proc.stderr or proc.stdout).strip()
+        if not require_kubectl and is_discovery_failure(details):
+            return [], "kubectl dry-run unavailable; offline validation used"
         return [f"kubectl dry-run failed: {details}"], "kubectl dry-run failed"
     return [], "kubectl dry-run passed"
 

--- a/tools/check_fogstack_kubernetes_manifests.py
+++ b/tools/check_fogstack_kubernetes_manifests.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -167,21 +169,57 @@ def validate_manifests(deploy_plan_path: Path, manifest_dir: Path) -> list[str]:
     return errors
 
 
+def resolve_kubectl(kubectl: str) -> str | None:
+    if "/" in kubectl:
+        path = Path(kubectl)
+        return str(path) if path.exists() else None
+    return shutil.which(kubectl)
+
+
+def run_kubectl_dry_run(manifest_dir: Path, kubectl: str, require_kubectl: bool) -> tuple[list[str], str]:
+    resolved = resolve_kubectl(kubectl)
+    if resolved is None:
+        if require_kubectl:
+            return [f"kubectl not found: {kubectl}"], "kubectl required but unavailable"
+        return [], "kubectl unavailable; offline validation used"
+
+    proc = subprocess.run(
+        [resolved, "apply", "--dry-run=client", "--validate=false", "-f", str(manifest_dir)],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        details = (proc.stderr or proc.stdout).strip()
+        return [f"kubectl dry-run failed: {details}"], "kubectl dry-run failed"
+    return [], "kubectl dry-run passed"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Check rendered FogStack Kubernetes manifests")
     parser.add_argument("--deploy-plan", required=True, type=Path)
     parser.add_argument("--manifest-dir", required=True, type=Path)
+    parser.add_argument("--kubectl-dry-run", action="store_true", help="Also attempt kubectl apply --dry-run=client when kubectl is available")
+    parser.add_argument("--kubectl", default="kubectl", help="kubectl executable name or path")
+    parser.add_argument("--require-kubectl", action="store_true", help="Fail if --kubectl-dry-run is requested and kubectl is unavailable")
     args = parser.parse_args()
 
     deploy_plan_path = args.deploy_plan if args.deploy_plan.is_absolute() else ROOT / args.deploy_plan
     manifest_dir = args.manifest_dir if args.manifest_dir.is_absolute() else ROOT / args.manifest_dir
     errors = validate_manifests(deploy_plan_path, manifest_dir)
+    status_lines = ["offline validation passed"] if not errors else []
+    if not errors and args.kubectl_dry_run:
+        kubectl_errors, kubectl_status = run_kubectl_dry_run(manifest_dir, args.kubectl, args.require_kubectl)
+        errors.extend(kubectl_errors)
+        status_lines.append(kubectl_status)
+
     if errors:
         for error in errors:
             print(error, file=sys.stderr)
         return 1
 
     print("FogStack Kubernetes manifests passed.")
+    for line in status_lines:
+        print(line)
     return 0
 
 

--- a/tools/tests/test_check_fogstack_kubernetes_manifests.py
+++ b/tools/tests/test_check_fogstack_kubernetes_manifests.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -22,8 +23,8 @@ def build_inputs(tmp_path: Path) -> tuple[Path, Path]:
     return plan, manifest_dir
 
 
-def run_checker(plan: Path, manifest_dir: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run([sys.executable, "tools/check_fogstack_kubernetes_manifests.py", "--deploy-plan", str(plan), "--manifest-dir", str(manifest_dir)], capture_output=True, text=True)
+def run_checker(plan: Path, manifest_dir: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, "tools/check_fogstack_kubernetes_manifests.py", "--deploy-plan", str(plan), "--manifest-dir", str(manifest_dir), *extra], capture_output=True, text=True)
 
 
 def load_yaml(path: Path) -> dict:
@@ -41,6 +42,31 @@ def test_check_fogstack_kubernetes_manifests_passes(tmp_path: Path) -> None:
     proc = run_checker(plan, manifest_dir)
     assert proc.returncode == 0
     assert "FogStack Kubernetes manifests passed." in proc.stdout
+    assert "offline validation passed" in proc.stdout
+
+
+def test_check_fogstack_kubernetes_manifests_kubectl_fallback(tmp_path: Path) -> None:
+    plan, manifest_dir = build_inputs(tmp_path)
+    proc = run_checker(plan, manifest_dir, "--kubectl-dry-run", "--kubectl", "definitely-missing-kubectl")
+    assert proc.returncode == 0
+    assert "kubectl unavailable; offline validation used" in proc.stdout
+
+
+def test_check_fogstack_kubernetes_manifests_requires_kubectl_when_requested(tmp_path: Path) -> None:
+    plan, manifest_dir = build_inputs(tmp_path)
+    proc = run_checker(plan, manifest_dir, "--kubectl-dry-run", "--require-kubectl", "--kubectl", "definitely-missing-kubectl")
+    assert proc.returncode != 0
+    assert "kubectl not found" in proc.stderr
+
+
+def test_check_fogstack_kubernetes_manifests_kubectl_success_path(tmp_path: Path) -> None:
+    plan, manifest_dir = build_inputs(tmp_path)
+    fake_kubectl = tmp_path / "kubectl"
+    fake_kubectl.write_text("#!/usr/bin/env sh\necho kubectl dry-run ok\nexit 0\n", encoding="utf-8")
+    fake_kubectl.chmod(fake_kubectl.stat().st_mode | 0o111)
+    proc = run_checker(plan, manifest_dir, "--kubectl-dry-run", "--kubectl", str(fake_kubectl))
+    assert proc.returncode == 0
+    assert "kubectl dry-run passed" in proc.stdout
 
 
 def test_check_fogstack_kubernetes_manifests_rejects_missing_agent_corps_label(tmp_path: Path) -> None:


### PR DESCRIPTION
Turn 11 of the deploy/runtime parity lane.

Adds optional kubectl client dry-run validation to the rendered Kubernetes manifest checker while preserving offline validation as the default fallback.

Files:
- tools/check_fogstack_kubernetes_manifests.py
- tools/tests/test_check_fogstack_kubernetes_manifests.py
- .github/workflows/fogstack-kubernetes-manifests.yml

Parity plan counter: Turn 11 / 32 toward credible MVP IBM-style parity.