### PR TITLE
fogstack: index cluster readiness evidence

### DIFF
--- a/tools/run_fogstack_local_demo_deploy_plan.py
+++ b/tools/run_fogstack_local_demo_deploy_plan.py
@@ -36,6 +36,7 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
     deploy_plan = output_dir / "fogstack.access.deploy-plan.json"
     manifest_dir = output_dir / "kubernetes"
     check_record = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
+    readiness_record = output_dir / "fogstack.access.cluster-readiness.record.json"
     summary_path = output_dir / "fogstack.access.deploy-demo.summary.json"
 
     run([
@@ -85,6 +86,8 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
         "tools/check_fogstack_kubernetes_manifests.py",
         "--deploy-plan", str(deploy_plan),
         "--manifest-dir", str(manifest_dir),
+        "--kubectl-dry-run",
+        "--record-output", str(readiness_record),
     ])
 
     manifests = [
@@ -92,6 +95,7 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
         manifest_dir / "deployment.yaml",
         manifest_dir / "service.yaml",
     ]
+    readiness = json.loads(readiness_record.read_text(encoding="utf-8"))
     record = {
         "kind": "FogStackKubernetesManifestCheckRecord",
         "schema_version": "v0.1",
@@ -102,6 +106,9 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
         "agent_corps_plan_ref": rel(runtime_contract),
         "manifest_dir": rel(manifest_dir),
         "manifests": [rel(path) for path in manifests],
+        "cluster_readiness_record_ref": rel(readiness_record),
+        "cluster_readiness_status": readiness.get("status"),
+        "cluster_validation_path": readiness.get("validation_path"),
         "checker_stdout": check.stdout.strip(),
     }
     write_json(check_record, record)
@@ -119,6 +126,7 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
             "kubernetes_deployment": rel(manifest_dir / "deployment.yaml"),
             "kubernetes_service": rel(manifest_dir / "service.yaml"),
             "kubernetes_manifest_check_record": rel(check_record),
+            "cluster_readiness_record": rel(readiness_record),
             "summary": rel(summary_path),
         },
         "checks": [
@@ -128,6 +136,7 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
             "deploy_plan_checked",
             "kubernetes_manifests_rendered",
             "kubernetes_manifests_checked",
+            "cluster_readiness_record_emitted",
         ],
     }
     write_json(summary_path, summary)
@@ -146,6 +155,7 @@ def render_summary(summary: dict[str, Any]) -> str:
         f"Kubernetes Deployment: {artifacts['kubernetes_deployment']}",
         f"Kubernetes Service: {artifacts['kubernetes_service']}",
         f"Manifest check record: {artifacts['kubernetes_manifest_check_record']}",
+        f"Cluster readiness record: {artifacts['cluster_readiness_record']}",
         f"Checks passed: {len(summary['checks'])}",
     ]
     return "\n".join(lines) + "\n"

--- a/tools/run_fogstack_local_demo_full.py
+++ b/tools/run_fogstack_local_demo_full.py
@@ -89,11 +89,13 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
             "kubernetes_deployment": rel(deploy_dir / "kubernetes" / "deployment.yaml"),
             "kubernetes_service": rel(deploy_dir / "kubernetes" / "service.yaml"),
             "kubernetes_manifest_check_record": rel(deploy_dir / "fogstack.access.kubernetes-manifest-check.record.json"),
+            "cluster_readiness_record": rel(deploy_dir / "fogstack.access.cluster-readiness.record.json"),
         },
         "checks": [
             "local_demo_generated",
             "deploy_plan_generated",
             "deploy_artifacts_integrated",
+            "cluster_readiness_record_indexed",
             "artifact_index_checked",
         ],
     }
@@ -110,6 +112,7 @@ def render_summary(summary: dict[str, Any]) -> str:
         f"Artifact index: {artifacts['artifact_index']}",
         f"Deploy plan: {artifacts['deploy_plan']}",
         f"Kubernetes deployment: {artifacts['kubernetes_deployment']}",
+        f"Cluster readiness record: {artifacts['cluster_readiness_record']}",
         f"Checks passed: {len(summary['checks'])}",
     ]
     return "\n".join(lines) + "\n"

--- a/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
+++ b/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
@@ -26,10 +26,12 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert "FogStack local demo deploy plan passed." in proc.stdout
     assert "Bundle: fogstack.access@0.1.0" in proc.stdout
     assert "Target: kubernetes" in proc.stdout
-    assert "Checks passed: 6" in proc.stdout
+    assert "Cluster readiness record:" in proc.stdout
+    assert "Checks passed: 7" in proc.stdout
 
     summary_path = output_dir / "fogstack.access.deploy-demo.summary.json"
     check_record_path = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
+    readiness_record_path = output_dir / "fogstack.access.cluster-readiness.record.json"
     runtime_contract_path = output_dir / "fogstack.access.runtime-contract.json"
     deploy_plan_path = output_dir / "fogstack.access.deploy-plan.json"
     manifest_dir = output_dir / "kubernetes"
@@ -37,6 +39,7 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     for path in [
         summary_path,
         check_record_path,
+        readiness_record_path,
         runtime_contract_path,
         deploy_plan_path,
         manifest_dir / "configmap.yaml",
@@ -57,6 +60,7 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
         "deploy_plan_checked",
         "kubernetes_manifests_rendered",
         "kubernetes_manifests_checked",
+        "cluster_readiness_record_emitted",
     }
 
     artifacts = summary["artifacts"]
@@ -66,12 +70,19 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert artifacts["kubernetes_deployment"].endswith("deployment.yaml")
     assert artifacts["kubernetes_service"].endswith("service.yaml")
     assert artifacts["kubernetes_manifest_check_record"].endswith("fogstack.access.kubernetes-manifest-check.record.json")
+    assert artifacts["cluster_readiness_record"].endswith("fogstack.access.cluster-readiness.record.json")
 
     check_record = json.loads(check_record_path.read_text(encoding="utf-8"))
     assert check_record["kind"] == "FogStackKubernetesManifestCheckRecord"
     assert check_record["status"] == "passed"
     assert check_record["bundle_id"] == "fogstack.access"
+    assert check_record["cluster_readiness_record_ref"].endswith("fogstack.access.cluster-readiness.record.json")
     assert "FogStack Kubernetes manifests passed." in check_record["checker_stdout"]
+
+    readiness_record = json.loads(readiness_record_path.read_text(encoding="utf-8"))
+    assert readiness_record["kind"] == "FogStackClusterReadinessRecord"
+    assert readiness_record["status"] == "passed"
+    assert readiness_record["offline_validation"]["status"] == "passed"
 
     deployment = yaml.safe_load((manifest_dir / "deployment.yaml").read_text(encoding="utf-8"))
     assert deployment["kind"] == "Deployment"

--- a/tools/tests/test_run_fogstack_local_demo_full.py
+++ b/tools/tests/test_run_fogstack_local_demo_full.py
@@ -18,6 +18,7 @@ REQUIRED_FULL_ARTIFACTS = {
     "kubernetes_deployment",
     "kubernetes_service",
     "kubernetes_manifest_check_record",
+    "cluster_readiness_record",
 }
 
 
@@ -40,6 +41,7 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert "Artifact index:" in proc.stdout
     assert "Deploy plan:" in proc.stdout
     assert "Kubernetes deployment:" in proc.stdout
+    assert "Cluster readiness record:" in proc.stdout
 
     full_summary_path = output_dir / "fogstack-local-demo.full.summary.json"
     assert full_summary_path.exists()
@@ -47,18 +49,25 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert full_summary["kind"] == "FogStackLocalDemoFullRun"
     assert full_summary["status"] == "passed"
     assert REQUIRED_FULL_ARTIFACTS == set(full_summary["artifacts"])
+    assert "cluster_readiness_record_indexed" in full_summary["checks"]
     for ref in full_summary["artifacts"].values():
         assert Path(ref).exists(), ref
+
+    readiness_record = json.loads(Path(full_summary["artifacts"]["cluster_readiness_record"]).read_text(encoding="utf-8"))
+    assert readiness_record["kind"] == "FogStackClusterReadinessRecord"
+    assert readiness_record["status"] == "passed"
 
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed_ids = {entry["id"] for entry in artifact_index["artifacts"]}
     assert "deploy_plan" in indexed_ids
     assert "deploy_kubernetes_deployment" in indexed_ids
     assert "deploy_kubernetes_manifest_check_record" in indexed_ids
+    assert "deploy_cluster_readiness_record" in indexed_ids
 
     html = (output_dir / "index.html").read_text(encoding="utf-8")
     assert "Deploy readiness" in html
     assert "SHA-256 digest" in html
     assert "indexed" in html
     assert "deploy_plan" in html
+    assert "deploy_cluster_readiness_record" in html
     assert "fogstack.access.deploy-plan.json" in html

--- a/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 
-REQUIRED = {"deploy_agent_corps_plan", "deploy_plan", "deploy_kubernetes_configmap", "deploy_kubernetes_deployment", "deploy_kubernetes_service", "deploy_kubernetes_manifest_check_record", "deploy_summary"}
+REQUIRED = {"deploy_agent_corps_plan", "deploy_plan", "deploy_kubernetes_configmap", "deploy_kubernetes_deployment", "deploy_kubernetes_service", "deploy_kubernetes_manifest_check_record", "deploy_cluster_readiness_record", "deploy_summary"}
 
 
 def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
@@ -20,6 +20,7 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     assert REQUIRED.issubset(set(summary["artifacts"]))
     assert "deploy_plan_built" in summary["checks"]
     assert "kubernetes_manifests_checked" in summary["checks"]
+    assert "cluster_readiness_record_emitted" in summary["checks"]
 
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed = {entry["id"]: entry for entry in artifact_index["artifacts"]}
@@ -27,6 +28,10 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     for key in REQUIRED:
         assert indexed[key]["digest"].startswith("sha256:")
         assert Path(indexed[key]["ref"]).exists()
+
+    readiness_record = json.loads(Path(summary["artifacts"]["deploy_cluster_readiness_record"]).read_text(encoding="utf-8"))
+    assert readiness_record["kind"] == "FogStackClusterReadinessRecord"
+    assert readiness_record["status"] == "passed"
 
     markdown = (output_dir / "fogstack-local-demo.summary.md").read_text(encoding="utf-8")
     html = (output_dir / "index.html").read_text(encoding="utf-8")
@@ -37,4 +42,5 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
         assert "indexed" in content
         assert "deploy_plan" in content
         assert "deploy_kubernetes_deployment" in content
+        assert "deploy_cluster_readiness_record" in content
         assert "sha256:" in content

--- a/tools/update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/update_fogstack_local_demo_deploy_artifacts.py
@@ -17,6 +17,7 @@ DEPLOY_ARTIFACT_KEYS = {
     "kubernetes_deployment": "deploy_kubernetes_deployment",
     "kubernetes_service": "deploy_kubernetes_service",
     "kubernetes_manifest_check_record": "deploy_kubernetes_manifest_check_record",
+    "cluster_readiness_record": "deploy_cluster_readiness_record",
     "summary": "deploy_summary",
 }
 DEPLOY_ARTIFACT_LABELS = {
@@ -26,6 +27,7 @@ DEPLOY_ARTIFACT_LABELS = {
     "deploy_kubernetes_deployment": "Kubernetes Deployment",
     "deploy_kubernetes_service": "Kubernetes Service",
     "deploy_kubernetes_manifest_check_record": "Manifest check record",
+    "deploy_cluster_readiness_record": "Cluster readiness record",
     "deploy_summary": "Deploy summary",
 }
 
@@ -177,7 +179,7 @@ def update_summary(summary_path: Path, deploy_summary_path: Path) -> dict[str, A
         artifacts[target_key] = deploy_summary["artifacts"][source_key]
 
     checks = summary.setdefault("checks", [])
-    for check in ["deploy_plan_built", "kubernetes_manifests_rendered", "kubernetes_manifests_checked"]:
+    for check in ["deploy_plan_built", "kubernetes_manifests_rendered", "kubernetes_manifests_checked", "cluster_readiness_record_emitted"]:
         if check not in checks:
             checks.append(check)
 


### PR DESCRIPTION
Turn 13 of the deploy/runtime parity lane.

Includes the cluster-readiness record in the deploy demo summary, full local demo summary, local demo artifact index, and deploy readiness table.

Files:
- tools/run_fogstack_local_demo_deploy_plan.py
- tools/run_fogstack_local_demo_full.py
- tools/update_fogstack_local_demo_deploy_artifacts.py
- deploy/local-demo tests

Parity plan counter: Turn 13 / 32 toward credible MVP IBM-style parity.