### PR TITLE
fogstack: add GitOps bundle schema and generator

### DIFF
--- a/.github/workflows/fogstack-gitops-bundle.yml
+++ b/.github/workflows/fogstack-gitops-bundle.yml
@@ -1,0 +1,88 @@
+name: FogStack GitOps Bundle
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "schemas/gitops/**"
+      - "schemas/agent/**"
+      - "schemas/deploy/**"
+      - "bundles/fogstack.*.yaml"
+      - "releases/manifests/fogstack.*.manifest.json"
+      - "tools/build_fogstack_runtime_contract.py"
+      - "tools/build_fogstack_deploy_plan.py"
+      - "tools/render_fogstack_kubernetes_manifests.py"
+      - "tools/build_fogstack_gitops_bundle.py"
+      - "tools/tests/test_fogstack_gitops_bundle.py"
+      - ".github/workflows/fogstack-gitops-bundle.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/gitops/**"
+      - "schemas/agent/**"
+      - "schemas/deploy/**"
+      - "bundles/fogstack.*.yaml"
+      - "releases/manifests/fogstack.*.manifest.json"
+      - "tools/build_fogstack_runtime_contract.py"
+      - "tools/build_fogstack_deploy_plan.py"
+      - "tools/render_fogstack_kubernetes_manifests.py"
+      - "tools/build_fogstack_gitops_bundle.py"
+      - "tools/tests/test_fogstack_gitops_bundle.py"
+      - ".github/workflows/fogstack-gitops-bundle.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  gitops-bundle:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml jsonschema
+
+      - name: Run GitOps bundle tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_gitops_bundle.py
+
+      - name: Build sample GitOps bundle
+        run: |
+          mkdir -p build/fogstack-gitops-inputs
+          python3 tools/build_fogstack_runtime_contract.py \
+            --bundle-id fogstack.access \
+            --version 0.1.0 \
+            --actor-id agent:fogstack.access.operator \
+            --human-anchor-role operator \
+            --output build/fogstack-gitops-inputs/runtime-contract.json
+          python3 tools/build_fogstack_deploy_plan.py \
+            --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+            --profile local-dev \
+            --target kubernetes \
+            --namespace fogstack-access \
+            --health-endpoint /healthz \
+            --runtime-contract build/fogstack-gitops-inputs/runtime-contract.json \
+            --output build/fogstack-gitops-inputs/deploy-plan.json
+          python3 tools/render_fogstack_kubernetes_manifests.py \
+            --deploy-plan build/fogstack-gitops-inputs/deploy-plan.json \
+            --output-dir build/fogstack-gitops-inputs/manifests
+          python3 tools/build_fogstack_gitops_bundle.py \
+            --deploy-plan build/fogstack-gitops-inputs/deploy-plan.json \
+            --manifest-dir build/fogstack-gitops-inputs/manifests \
+            --output-dir build/fogstack-gitops \
+            --repo-url https://github.com/SocioProphet/prophet-platform.git \
+            --target-revision main \
+            --gitops-path gitops/fogstack.access
+          test -s build/fogstack-gitops/gitops-bundle.json
+          test -s build/fogstack-gitops/application.yaml
+          test -s build/fogstack-gitops/kustomization.yaml
+          test -s build/fogstack-gitops/manifests/deployment.yaml

--- a/schemas/gitops/fogstack-gitops-bundle-v0.1.schema.json
+++ b/schemas/gitops/fogstack-gitops-bundle-v0.1.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/gitops/fogstack-gitops-bundle-v0.1.schema.json",
+  "title": "FogStackGitOpsBundle",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "namespace",
+    "deploy_plan_ref",
+    "deploy_plan_digest",
+    "agent_corps_plan_ref",
+    "agent_corps_plan_digest",
+    "source",
+    "application",
+    "kustomization",
+    "manifests",
+    "artifacts"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackGitOpsBundle" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "minLength": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "namespace": { "type": "string", "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" },
+    "deploy_plan_ref": { "type": "string", "minLength": 1 },
+    "deploy_plan_digest": { "$ref": "#/$defs/sha256_digest" },
+    "agent_corps_plan_ref": { "type": "string", "minLength": 1 },
+    "agent_corps_plan_digest": { "$ref": "#/$defs/sha256_digest" },
+    "source": {
+      "type": "object",
+      "required": ["repo_url", "target_revision", "path"],
+      "properties": {
+        "repo_url": { "type": "string", "minLength": 1 },
+        "target_revision": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "application": {
+      "type": "object",
+      "required": ["name", "ref", "digest"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "ref": { "type": "string", "minLength": 1 },
+        "digest": { "$ref": "#/$defs/sha256_digest" }
+      },
+      "additionalProperties": false
+    },
+    "kustomization": {
+      "type": "object",
+      "required": ["ref", "digest"],
+      "properties": {
+        "ref": { "type": "string", "minLength": 1 },
+        "digest": { "$ref": "#/$defs/sha256_digest" }
+      },
+      "additionalProperties": false
+    },
+    "manifests": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/artifact" },
+      "minItems": 1
+    },
+    "artifacts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/artifact" },
+      "minItems": 1
+    }
+  },
+  "$defs": {
+    "sha256_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "artifact": {
+      "type": "object",
+      "required": ["id", "ref", "digest"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "ref": { "type": "string", "minLength": 1 },
+        "digest": { "$ref": "#/$defs/sha256_digest" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/build_fogstack_gitops_bundle.py
+++ b/tools/build_fogstack_gitops_bundle.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LABEL_PREFIX = "fogstack.socioprophet.io"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def write_yaml(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def dns_label(value: str) -> str:
+    return value.replace(".", "-").replace("_", "-").lower()
+
+
+def copy_manifest(src: Path, dst: Path) -> dict[str, str]:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+    return {"id": dst.stem, "ref": rel(dst), "digest": sha256_file(dst)}
+
+
+def render_application(plan: dict[str, Any], name: str, repo_url: str, target_revision: str, path: str) -> dict[str, Any]:
+    labels = {
+        f"{LABEL_PREFIX}/bundle-id": plan["bundle_id"],
+        f"{LABEL_PREFIX}/version": plan["version"],
+        f"{LABEL_PREFIX}/agent-corps": "enabled",
+    }
+    annotations = {
+        f"{LABEL_PREFIX}/deploy-plan-ref": plan["deploy_plan_ref"] if "deploy_plan_ref" in plan else "",
+        f"{LABEL_PREFIX}/deploy-plan-digest": plan["deploy_plan_digest"] if "deploy_plan_digest" in plan else "",
+        f"{LABEL_PREFIX}/agent-corps-plan-ref": plan["agent_corps_plan_ref"],
+        f"{LABEL_PREFIX}/agent-corps-plan-digest": plan["agent_corps_plan_digest"],
+    }
+    return {
+        "apiVersion": "argoproj.io/v1alpha1",
+        "kind": "Application",
+        "metadata": {
+            "name": name,
+            "namespace": "argocd",
+            "labels": labels,
+            "annotations": annotations,
+        },
+        "spec": {
+            "project": "default",
+            "source": {
+                "repoURL": repo_url,
+                "targetRevision": target_revision,
+                "path": path,
+            },
+            "destination": {
+                "server": "https://kubernetes.default.svc",
+                "namespace": plan["namespace"],
+            },
+            "syncPolicy": {
+                "automated": None,
+                "syncOptions": ["CreateNamespace=true"],
+            },
+        },
+    }
+
+
+def render_kustomization(resources: list[str], namespace: str, labels: dict[str, str]) -> dict[str, Any]:
+    return {
+        "apiVersion": "kustomize.config.k8s.io/v1beta1",
+        "kind": "Kustomization",
+        "namespace": namespace,
+        "resources": resources,
+        "commonLabels": labels,
+    }
+
+
+def build_bundle(
+    deploy_plan_path: Path,
+    manifest_dir: Path,
+    output_dir: Path,
+    repo_url: str,
+    target_revision: str,
+    gitops_path: str,
+) -> dict[str, Any]:
+    deploy_plan_path = deploy_plan_path if deploy_plan_path.is_absolute() else ROOT / deploy_plan_path
+    manifest_dir = manifest_dir if manifest_dir.is_absolute() else ROOT / manifest_dir
+    output_dir = output_dir if output_dir.is_absolute() else ROOT / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    plan = load_json(deploy_plan_path)
+    if plan.get("kind") != "FogStackDeployPlan":
+        raise SystemExit("ERR: expected FogStackDeployPlan")
+
+    name = dns_label(plan["bundle_id"])
+    manifests_dir = output_dir / "manifests"
+    copied = [
+        copy_manifest(manifest_dir / "configmap.yaml", manifests_dir / "configmap.yaml"),
+        copy_manifest(manifest_dir / "deployment.yaml", manifests_dir / "deployment.yaml"),
+        copy_manifest(manifest_dir / "service.yaml", manifests_dir / "service.yaml"),
+    ]
+
+    common_labels = {
+        f"{LABEL_PREFIX}/bundle-id": plan["bundle_id"],
+        f"{LABEL_PREFIX}/version": plan["version"],
+        f"{LABEL_PREFIX}/agent-corps": "enabled",
+    }
+    kustomization_path = output_dir / "kustomization.yaml"
+    application_path = output_dir / "application.yaml"
+    bundle_path = output_dir / "gitops-bundle.json"
+
+    render_kustomization_payload = render_kustomization(
+        ["manifests/configmap.yaml", "manifests/deployment.yaml", "manifests/service.yaml"],
+        plan["namespace"],
+        common_labels,
+    )
+    write_yaml(kustomization_path, render_kustomization_payload)
+    write_yaml(application_path, render_application(plan | {"deploy_plan_ref": rel(deploy_plan_path), "deploy_plan_digest": sha256_file(deploy_plan_path)}, name, repo_url, target_revision, gitops_path))
+
+    artifacts = [
+        {"id": "deploy-plan", "ref": rel(deploy_plan_path), "digest": sha256_file(deploy_plan_path)},
+        {"id": "agent-corps-plan", "ref": plan["agent_corps_plan_ref"], "digest": plan["agent_corps_plan_digest"]},
+        {"id": "application", "ref": rel(application_path), "digest": sha256_file(application_path)},
+        {"id": "kustomization", "ref": rel(kustomization_path), "digest": sha256_file(kustomization_path)},
+        *copied,
+    ]
+    bundle = {
+        "kind": "FogStackGitOpsBundle",
+        "schema_version": "v0.1",
+        "bundle_id": plan["bundle_id"],
+        "version": plan["version"],
+        "namespace": plan["namespace"],
+        "deploy_plan_ref": rel(deploy_plan_path),
+        "deploy_plan_digest": sha256_file(deploy_plan_path),
+        "agent_corps_plan_ref": plan["agent_corps_plan_ref"],
+        "agent_corps_plan_digest": plan["agent_corps_plan_digest"],
+        "source": {
+            "repo_url": repo_url,
+            "target_revision": target_revision,
+            "path": gitops_path,
+        },
+        "application": {
+            "name": name,
+            "ref": rel(application_path),
+            "digest": sha256_file(application_path),
+        },
+        "kustomization": {
+            "ref": rel(kustomization_path),
+            "digest": sha256_file(kustomization_path),
+        },
+        "manifests": copied,
+        "artifacts": artifacts,
+    }
+    write_json(bundle_path, bundle)
+    return bundle
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a FogStack GitOps bundle from a deploy plan and rendered manifests")
+    parser.add_argument("--deploy-plan", required=True, type=Path)
+    parser.add_argument("--manifest-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--repo-url", default="https://github.com/SocioProphet/prophet-platform.git")
+    parser.add_argument("--target-revision", default="main")
+    parser.add_argument("--gitops-path", default="build/fogstack-gitops")
+    args = parser.parse_args()
+
+    bundle = build_bundle(args.deploy_plan, args.manifest_dir, args.output_dir, args.repo_url, args.target_revision, args.gitops_path)
+    print(json.dumps(bundle, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_gitops_bundle.py
+++ b/tools/tests/test_fogstack_gitops_bundle.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+
+SCHEMA = Path("schemas/gitops/fogstack-gitops-bundle-v0.1.schema.json")
+MANIFEST = Path("releases/manifests/fogstack.access-v0.1.manifest.json")
+
+
+def load_json(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def load_yaml(path: Path) -> dict:
+    value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def test_build_fogstack_gitops_bundle(tmp_path: Path) -> None:
+    contract = tmp_path / "runtime-contract.json"
+    deploy_plan = tmp_path / "deploy-plan.json"
+    manifest_dir = tmp_path / "manifests"
+    output_dir = tmp_path / "gitops"
+
+    subprocess.run([sys.executable, "tools/build_fogstack_runtime_contract.py", "--bundle-id", "fogstack.access", "--version", "0.1.0", "--actor-id", "agent:fogstack.access.operator", "--human-anchor-role", "operator", "--output", str(contract)], check=True)
+    subprocess.run([sys.executable, "tools/build_fogstack_deploy_plan.py", "--manifest", str(MANIFEST), "--profile", "local-dev", "--target", "kubernetes", "--namespace", "fogstack-access", "--health-endpoint", "/healthz", "--runtime-contract", str(contract), "--output", str(deploy_plan)], check=True)
+    subprocess.run([sys.executable, "tools/render_fogstack_kubernetes_manifests.py", "--deploy-plan", str(deploy_plan), "--output-dir", str(manifest_dir)], check=True)
+    subprocess.run([sys.executable, "tools/build_fogstack_gitops_bundle.py", "--deploy-plan", str(deploy_plan), "--manifest-dir", str(manifest_dir), "--output-dir", str(output_dir), "--repo-url", "https://example.invalid/repo.git", "--target-revision", "main", "--gitops-path", "gitops/fogstack.access"], check=True)
+
+    bundle = load_json(output_dir / "gitops-bundle.json")
+    Draft202012Validator(load_json(SCHEMA)).validate(bundle)
+    assert bundle["kind"] == "FogStackGitOpsBundle"
+    assert bundle["bundle_id"] == "fogstack.access"
+    assert bundle["version"] == "0.1.0"
+    assert bundle["namespace"] == "fogstack-access"
+    assert bundle["deploy_plan_digest"].startswith("sha256:")
+    assert bundle["agent_corps_plan_digest"].startswith("sha256:")
+
+    application = load_yaml(output_dir / "application.yaml")
+    assert application["kind"] == "Application"
+    assert application["metadata"]["name"] == "fogstack-access"
+    assert application["spec"]["source"]["path"] == "gitops/fogstack.access"
+    assert application["spec"]["destination"]["namespace"] == "fogstack-access"
+
+    kustomization = load_yaml(output_dir / "kustomization.yaml")
+    assert kustomization["kind"] == "Kustomization"
+    assert kustomization["resources"] == ["manifests/configmap.yaml", "manifests/deployment.yaml", "manifests/service.yaml"]
+
+    artifact_ids = {artifact["id"] for artifact in bundle["artifacts"]}
+    assert {"deploy-plan", "agent-corps-plan", "application", "kustomization", "configmap", "deployment", "service"}.issubset(artifact_ids)
+    for artifact in bundle["artifacts"]:
+        assert artifact["digest"].startswith("sha256:")
+        assert Path(artifact["ref"]).exists(), artifact


### PR DESCRIPTION
Turn 14 of the deploy/runtime parity lane.

Starts the GitOps lane with FogStackGitOpsBundle v0.1 schema, a generator, focused tests, and workflow proof.

Files:
- schemas/gitops/fogstack-gitops-bundle-v0.1.schema.json
- tools/build_fogstack_gitops_bundle.py
- tools/tests/test_fogstack_gitops_bundle.py
- .github/workflows/fogstack-gitops-bundle.yml

Parity plan counter: Turn 14 / 32 toward credible MVP IBM-style parity.