### PR TITLE
fogstack: index GitOps artifacts in local demo

### DIFF
--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -10,6 +10,7 @@ on:
       - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
       - "catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml"
       - "catalog/fogstack-release-publication-gate-policy-v0.1.yaml"
+      - "schemas/gitops/**"
       - "releases/manifests/**"
       - "Makefile"
       - "tools/run_fogstack_local_demo.py"
@@ -24,6 +25,8 @@ on:
       - "tools/check_fogstack_deploy_plan.py"
       - "tools/render_fogstack_kubernetes_manifests.py"
       - "tools/check_fogstack_kubernetes_manifests.py"
+      - "tools/build_fogstack_gitops_bundle.py"
+      - "tools/check_fogstack_gitops_bundle.py"
       - "tools/fogstack_verify.py"
       - "tools/emit_fogstack_validation_record.py"
       - "tools/build_fogstack_manifest_publication_set.py"
@@ -56,6 +59,7 @@ on:
       - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
       - "catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml"
       - "catalog/fogstack-release-publication-gate-policy-v0.1.yaml"
+      - "schemas/gitops/**"
       - "releases/manifests/**"
       - "Makefile"
       - "tools/run_fogstack_local_demo.py"
@@ -70,6 +74,8 @@ on:
       - "tools/check_fogstack_deploy_plan.py"
       - "tools/render_fogstack_kubernetes_manifests.py"
       - "tools/check_fogstack_kubernetes_manifests.py"
+      - "tools/build_fogstack_gitops_bundle.py"
+      - "tools/check_fogstack_gitops_bundle.py"
       - "tools/tests/test_run_fogstack_local_demo.py"
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
@@ -114,6 +120,9 @@ jobs:
           test -s build/fogstack-local-demo/demo-artifacts.index.json
           test -s build/fogstack-local-demo/deploy/fogstack.access.deploy-plan.json
           test -s build/fogstack-local-demo/deploy/kubernetes/deployment.yaml
+          test -s build/fogstack-local-demo/deploy/gitops/gitops-bundle.json
+          test -s build/fogstack-local-demo/deploy/gitops/application.yaml
+          test -s build/fogstack-local-demo/deploy/gitops/kustomization.yaml
 
       - name: Check generated artifact index
         run: |

--- a/tools/run_fogstack_local_demo_deploy_plan.py
+++ b/tools/run_fogstack_local_demo_deploy_plan.py
@@ -35,6 +35,7 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
     runtime_contract = output_dir / "fogstack.access.runtime-contract.json"
     deploy_plan = output_dir / "fogstack.access.deploy-plan.json"
     manifest_dir = output_dir / "kubernetes"
+    gitops_dir = output_dir / "gitops"
     check_record = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
     readiness_record = output_dir / "fogstack.access.cluster-readiness.record.json"
     summary_path = output_dir / "fogstack.access.deploy-demo.summary.json"
@@ -89,6 +90,21 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
         "--kubectl-dry-run",
         "--record-output", str(readiness_record),
     ])
+    run([
+        sys.executable,
+        "tools/build_fogstack_gitops_bundle.py",
+        "--deploy-plan", str(deploy_plan),
+        "--manifest-dir", str(manifest_dir),
+        "--output-dir", str(gitops_dir),
+        "--repo-url", "https://github.com/SocioProphet/prophet-platform.git",
+        "--target-revision", "main",
+        "--gitops-path", "gitops/fogstack.access",
+    ])
+    run([
+        sys.executable,
+        "tools/check_fogstack_gitops_bundle.py",
+        "--bundle", str(gitops_dir / "gitops-bundle.json"),
+    ])
 
     manifests = [
         manifest_dir / "configmap.yaml",
@@ -127,6 +143,12 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
             "kubernetes_service": rel(manifest_dir / "service.yaml"),
             "kubernetes_manifest_check_record": rel(check_record),
             "cluster_readiness_record": rel(readiness_record),
+            "gitops_bundle": rel(gitops_dir / "gitops-bundle.json"),
+            "gitops_application": rel(gitops_dir / "application.yaml"),
+            "gitops_kustomization": rel(gitops_dir / "kustomization.yaml"),
+            "gitops_configmap": rel(gitops_dir / "manifests" / "configmap.yaml"),
+            "gitops_deployment": rel(gitops_dir / "manifests" / "deployment.yaml"),
+            "gitops_service": rel(gitops_dir / "manifests" / "service.yaml"),
             "summary": rel(summary_path),
         },
         "checks": [
@@ -137,6 +159,8 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
             "kubernetes_manifests_rendered",
             "kubernetes_manifests_checked",
             "cluster_readiness_record_emitted",
+            "gitops_bundle_built",
+            "gitops_bundle_checked",
         ],
     }
     write_json(summary_path, summary)
@@ -156,6 +180,8 @@ def render_summary(summary: dict[str, Any]) -> str:
         f"Kubernetes Service: {artifacts['kubernetes_service']}",
         f"Manifest check record: {artifacts['kubernetes_manifest_check_record']}",
         f"Cluster readiness record: {artifacts['cluster_readiness_record']}",
+        f"GitOps bundle: {artifacts['gitops_bundle']}",
+        f"GitOps application: {artifacts['gitops_application']}",
         f"Checks passed: {len(summary['checks'])}",
     ]
     return "\n".join(lines) + "\n"

--- a/tools/run_fogstack_local_demo_full.py
+++ b/tools/run_fogstack_local_demo_full.py
@@ -90,12 +90,19 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
             "kubernetes_service": rel(deploy_dir / "kubernetes" / "service.yaml"),
             "kubernetes_manifest_check_record": rel(deploy_dir / "fogstack.access.kubernetes-manifest-check.record.json"),
             "cluster_readiness_record": rel(deploy_dir / "fogstack.access.cluster-readiness.record.json"),
+            "gitops_bundle": rel(deploy_dir / "gitops" / "gitops-bundle.json"),
+            "gitops_application": rel(deploy_dir / "gitops" / "application.yaml"),
+            "gitops_kustomization": rel(deploy_dir / "gitops" / "kustomization.yaml"),
+            "gitops_configmap": rel(deploy_dir / "gitops" / "manifests" / "configmap.yaml"),
+            "gitops_deployment": rel(deploy_dir / "gitops" / "manifests" / "deployment.yaml"),
+            "gitops_service": rel(deploy_dir / "gitops" / "manifests" / "service.yaml"),
         },
         "checks": [
             "local_demo_generated",
             "deploy_plan_generated",
             "deploy_artifacts_integrated",
             "cluster_readiness_record_indexed",
+            "gitops_bundle_indexed",
             "artifact_index_checked",
         ],
     }
@@ -113,6 +120,8 @@ def render_summary(summary: dict[str, Any]) -> str:
         f"Deploy plan: {artifacts['deploy_plan']}",
         f"Kubernetes deployment: {artifacts['kubernetes_deployment']}",
         f"Cluster readiness record: {artifacts['cluster_readiness_record']}",
+        f"GitOps bundle: {artifacts['gitops_bundle']}",
+        f"GitOps application: {artifacts['gitops_application']}",
         f"Checks passed: {len(summary['checks'])}",
     ]
     return "\n".join(lines) + "\n"

--- a/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
+++ b/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
@@ -27,7 +27,9 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert "Bundle: fogstack.access@0.1.0" in proc.stdout
     assert "Target: kubernetes" in proc.stdout
     assert "Cluster readiness record:" in proc.stdout
-    assert "Checks passed: 7" in proc.stdout
+    assert "GitOps bundle:" in proc.stdout
+    assert "GitOps application:" in proc.stdout
+    assert "Checks passed: 9" in proc.stdout
 
     summary_path = output_dir / "fogstack.access.deploy-demo.summary.json"
     check_record_path = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
@@ -35,6 +37,7 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     runtime_contract_path = output_dir / "fogstack.access.runtime-contract.json"
     deploy_plan_path = output_dir / "fogstack.access.deploy-plan.json"
     manifest_dir = output_dir / "kubernetes"
+    gitops_dir = output_dir / "gitops"
 
     for path in [
         summary_path,
@@ -45,6 +48,12 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
         manifest_dir / "configmap.yaml",
         manifest_dir / "deployment.yaml",
         manifest_dir / "service.yaml",
+        gitops_dir / "gitops-bundle.json",
+        gitops_dir / "application.yaml",
+        gitops_dir / "kustomization.yaml",
+        gitops_dir / "manifests" / "configmap.yaml",
+        gitops_dir / "manifests" / "deployment.yaml",
+        gitops_dir / "manifests" / "service.yaml",
     ]:
         assert path.exists(), f"missing {path}"
 
@@ -61,6 +70,8 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
         "kubernetes_manifests_rendered",
         "kubernetes_manifests_checked",
         "cluster_readiness_record_emitted",
+        "gitops_bundle_built",
+        "gitops_bundle_checked",
     }
 
     artifacts = summary["artifacts"]
@@ -71,6 +82,10 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert artifacts["kubernetes_service"].endswith("service.yaml")
     assert artifacts["kubernetes_manifest_check_record"].endswith("fogstack.access.kubernetes-manifest-check.record.json")
     assert artifacts["cluster_readiness_record"].endswith("fogstack.access.cluster-readiness.record.json")
+    assert artifacts["gitops_bundle"].endswith("gitops-bundle.json")
+    assert artifacts["gitops_application"].endswith("application.yaml")
+    assert artifacts["gitops_kustomization"].endswith("kustomization.yaml")
+    assert artifacts["gitops_deployment"].endswith("deployment.yaml")
 
     check_record = json.loads(check_record_path.read_text(encoding="utf-8"))
     assert check_record["kind"] == "FogStackKubernetesManifestCheckRecord"
@@ -83,6 +98,11 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert readiness_record["kind"] == "FogStackClusterReadinessRecord"
     assert readiness_record["status"] == "passed"
     assert readiness_record["offline_validation"]["status"] == "passed"
+
+    gitops_bundle = json.loads((gitops_dir / "gitops-bundle.json").read_text(encoding="utf-8"))
+    assert gitops_bundle["kind"] == "FogStackGitOpsBundle"
+    assert gitops_bundle["bundle_id"] == "fogstack.access"
+    assert gitops_bundle["deploy_plan_digest"].startswith("sha256:")
 
     deployment = yaml.safe_load((manifest_dir / "deployment.yaml").read_text(encoding="utf-8"))
     assert deployment["kind"] == "Deployment"

--- a/tools/tests/test_run_fogstack_local_demo_full.py
+++ b/tools/tests/test_run_fogstack_local_demo_full.py
@@ -19,6 +19,12 @@ REQUIRED_FULL_ARTIFACTS = {
     "kubernetes_service",
     "kubernetes_manifest_check_record",
     "cluster_readiness_record",
+    "gitops_bundle",
+    "gitops_application",
+    "gitops_kustomization",
+    "gitops_configmap",
+    "gitops_deployment",
+    "gitops_service",
 }
 
 
@@ -42,6 +48,8 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert "Deploy plan:" in proc.stdout
     assert "Kubernetes deployment:" in proc.stdout
     assert "Cluster readiness record:" in proc.stdout
+    assert "GitOps bundle:" in proc.stdout
+    assert "GitOps application:" in proc.stdout
 
     full_summary_path = output_dir / "fogstack-local-demo.full.summary.json"
     assert full_summary_path.exists()
@@ -50,6 +58,7 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert full_summary["status"] == "passed"
     assert REQUIRED_FULL_ARTIFACTS == set(full_summary["artifacts"])
     assert "cluster_readiness_record_indexed" in full_summary["checks"]
+    assert "gitops_bundle_indexed" in full_summary["checks"]
     for ref in full_summary["artifacts"].values():
         assert Path(ref).exists(), ref
 
@@ -57,12 +66,19 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert readiness_record["kind"] == "FogStackClusterReadinessRecord"
     assert readiness_record["status"] == "passed"
 
+    gitops_bundle = json.loads(Path(full_summary["artifacts"]["gitops_bundle"]).read_text(encoding="utf-8"))
+    assert gitops_bundle["kind"] == "FogStackGitOpsBundle"
+    assert gitops_bundle["bundle_id"] == "fogstack.access"
+
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed_ids = {entry["id"] for entry in artifact_index["artifacts"]}
     assert "deploy_plan" in indexed_ids
     assert "deploy_kubernetes_deployment" in indexed_ids
     assert "deploy_kubernetes_manifest_check_record" in indexed_ids
     assert "deploy_cluster_readiness_record" in indexed_ids
+    assert "deploy_gitops_bundle" in indexed_ids
+    assert "deploy_gitops_application" in indexed_ids
+    assert "deploy_gitops_deployment" in indexed_ids
 
     html = (output_dir / "index.html").read_text(encoding="utf-8")
     assert "Deploy readiness" in html
@@ -70,4 +86,5 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert "indexed" in html
     assert "deploy_plan" in html
     assert "deploy_cluster_readiness_record" in html
+    assert "deploy_gitops_bundle" in html
     assert "fogstack.access.deploy-plan.json" in html

--- a/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
@@ -6,7 +6,22 @@ import sys
 from pathlib import Path
 
 
-REQUIRED = {"deploy_agent_corps_plan", "deploy_plan", "deploy_kubernetes_configmap", "deploy_kubernetes_deployment", "deploy_kubernetes_service", "deploy_kubernetes_manifest_check_record", "deploy_cluster_readiness_record", "deploy_summary"}
+REQUIRED = {
+    "deploy_agent_corps_plan",
+    "deploy_plan",
+    "deploy_kubernetes_configmap",
+    "deploy_kubernetes_deployment",
+    "deploy_kubernetes_service",
+    "deploy_kubernetes_manifest_check_record",
+    "deploy_cluster_readiness_record",
+    "deploy_gitops_bundle",
+    "deploy_gitops_application",
+    "deploy_gitops_kustomization",
+    "deploy_gitops_configmap",
+    "deploy_gitops_deployment",
+    "deploy_gitops_service",
+    "deploy_summary",
+}
 
 
 def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
@@ -21,6 +36,8 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     assert "deploy_plan_built" in summary["checks"]
     assert "kubernetes_manifests_checked" in summary["checks"]
     assert "cluster_readiness_record_emitted" in summary["checks"]
+    assert "gitops_bundle_built" in summary["checks"]
+    assert "gitops_bundle_checked" in summary["checks"]
 
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed = {entry["id"]: entry for entry in artifact_index["artifacts"]}
@@ -33,6 +50,10 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     assert readiness_record["kind"] == "FogStackClusterReadinessRecord"
     assert readiness_record["status"] == "passed"
 
+    gitops_bundle = json.loads(Path(summary["artifacts"]["deploy_gitops_bundle"]).read_text(encoding="utf-8"))
+    assert gitops_bundle["kind"] == "FogStackGitOpsBundle"
+    assert gitops_bundle["bundle_id"] == "fogstack.access"
+
     markdown = (output_dir / "fogstack-local-demo.summary.md").read_text(encoding="utf-8")
     html = (output_dir / "index.html").read_text(encoding="utf-8")
     for content in [markdown, html]:
@@ -43,4 +64,6 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
         assert "deploy_plan" in content
         assert "deploy_kubernetes_deployment" in content
         assert "deploy_cluster_readiness_record" in content
+        assert "deploy_gitops_bundle" in content
+        assert "deploy_gitops_application" in content
         assert "sha256:" in content

--- a/tools/update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/update_fogstack_local_demo_deploy_artifacts.py
@@ -18,6 +18,12 @@ DEPLOY_ARTIFACT_KEYS = {
     "kubernetes_service": "deploy_kubernetes_service",
     "kubernetes_manifest_check_record": "deploy_kubernetes_manifest_check_record",
     "cluster_readiness_record": "deploy_cluster_readiness_record",
+    "gitops_bundle": "deploy_gitops_bundle",
+    "gitops_application": "deploy_gitops_application",
+    "gitops_kustomization": "deploy_gitops_kustomization",
+    "gitops_configmap": "deploy_gitops_configmap",
+    "gitops_deployment": "deploy_gitops_deployment",
+    "gitops_service": "deploy_gitops_service",
     "summary": "deploy_summary",
 }
 DEPLOY_ARTIFACT_LABELS = {
@@ -28,6 +34,12 @@ DEPLOY_ARTIFACT_LABELS = {
     "deploy_kubernetes_service": "Kubernetes Service",
     "deploy_kubernetes_manifest_check_record": "Manifest check record",
     "deploy_cluster_readiness_record": "Cluster readiness record",
+    "deploy_gitops_bundle": "GitOps bundle",
+    "deploy_gitops_application": "GitOps Application",
+    "deploy_gitops_kustomization": "GitOps Kustomization",
+    "deploy_gitops_configmap": "GitOps ConfigMap",
+    "deploy_gitops_deployment": "GitOps Deployment",
+    "deploy_gitops_service": "GitOps Service",
     "deploy_summary": "Deploy summary",
 }
 
@@ -179,7 +191,7 @@ def update_summary(summary_path: Path, deploy_summary_path: Path) -> dict[str, A
         artifacts[target_key] = deploy_summary["artifacts"][source_key]
 
     checks = summary.setdefault("checks", [])
-    for check in ["deploy_plan_built", "kubernetes_manifests_rendered", "kubernetes_manifests_checked", "cluster_readiness_record_emitted"]:
+    for check in ["deploy_plan_built", "kubernetes_manifests_rendered", "kubernetes_manifests_checked", "cluster_readiness_record_emitted", "gitops_bundle_built", "gitops_bundle_checked"]:
         if check not in checks:
             checks.append(check)
 


### PR DESCRIPTION
Turn 16 of the deploy/runtime parity lane.

Includes GitOps bundle artifacts in the local deploy demo, full local demo summary, local demo artifact index, and deploy readiness table.

Files:
- tools/run_fogstack_local_demo_deploy_plan.py
- tools/run_fogstack_local_demo_full.py
- tools/update_fogstack_local_demo_deploy_artifacts.py
- local demo tests
- .github/workflows/fogstack-local-demo.yml

Parity plan counter: Turn 16 / 32 toward credible MVP IBM-style parity.