### PR TITLE
fogstack: emit GitOps readiness record

### DIFF
--- a/.github/workflows/fogstack-gitops-bundle.yml
+++ b/.github/workflows/fogstack-gitops-bundle.yml
@@ -14,8 +14,10 @@ on:
       - "tools/render_fogstack_kubernetes_manifests.py"
       - "tools/build_fogstack_gitops_bundle.py"
       - "tools/check_fogstack_gitops_bundle.py"
+      - "tools/emit_fogstack_gitops_readiness_record.py"
       - "tools/tests/test_fogstack_gitops_bundle.py"
       - "tools/tests/test_check_fogstack_gitops_bundle.py"
+      - "tools/tests/test_fogstack_gitops_readiness_record.py"
       - ".github/workflows/fogstack-gitops-bundle.yml"
   push:
     branches: [main]
@@ -30,8 +32,10 @@ on:
       - "tools/render_fogstack_kubernetes_manifests.py"
       - "tools/build_fogstack_gitops_bundle.py"
       - "tools/check_fogstack_gitops_bundle.py"
+      - "tools/emit_fogstack_gitops_readiness_record.py"
       - "tools/tests/test_fogstack_gitops_bundle.py"
       - "tools/tests/test_check_fogstack_gitops_bundle.py"
+      - "tools/tests/test_fogstack_gitops_readiness_record.py"
       - ".github/workflows/fogstack-gitops-bundle.yml"
 
 permissions:
@@ -59,7 +63,8 @@ jobs:
         run: |
           python -m pytest -q \
             tools/tests/test_fogstack_gitops_bundle.py \
-            tools/tests/test_check_fogstack_gitops_bundle.py
+            tools/tests/test_check_fogstack_gitops_bundle.py \
+            tools/tests/test_fogstack_gitops_readiness_record.py
 
       - name: Build sample GitOps bundle
         run: |
@@ -89,7 +94,14 @@ jobs:
             --target-revision main \
             --gitops-path gitops/fogstack.access
           python3 tools/check_fogstack_gitops_bundle.py --bundle build/fogstack-gitops/gitops-bundle.json
+          python3 tools/emit_fogstack_gitops_readiness_record.py \
+            --bundle build/fogstack-gitops/gitops-bundle.json \
+            --output build/fogstack-gitops/gitops-readiness.record.json \
+            --generator-status passed \
+            --checker-status passed \
+            --checker-message "FogStack GitOps bundle passed."
           test -s build/fogstack-gitops/gitops-bundle.json
+          test -s build/fogstack-gitops/gitops-readiness.record.json
           test -s build/fogstack-gitops/application.yaml
           test -s build/fogstack-gitops/kustomization.yaml
           test -s build/fogstack-gitops/manifests/deployment.yaml

--- a/tools/emit_fogstack_gitops_readiness_record.py
+++ b/tools/emit_fogstack_gitops_readiness_record.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def normalize_status(value: str) -> str:
+    allowed = {"passed", "failed", "skipped"}
+    if value not in allowed:
+        raise SystemExit(f"ERR: invalid status {value}; expected one of {sorted(allowed)}")
+    return value
+
+
+def emit_record(bundle_path: Path, output_path: Path, generator_status: str, checker_status: str, checker_message: str) -> dict[str, Any]:
+    bundle_path = bundle_path if bundle_path.is_absolute() else ROOT / bundle_path
+    output_path = output_path if output_path.is_absolute() else ROOT / output_path
+    bundle = load_json(bundle_path)
+    if bundle.get("kind") != "FogStackGitOpsBundle":
+        raise SystemExit("ERR: expected FogStackGitOpsBundle")
+
+    generator_status = normalize_status(generator_status)
+    checker_status = normalize_status(checker_status)
+    status = "passed" if generator_status == "passed" and checker_status == "passed" else "failed"
+    record = {
+        "kind": "FogStackGitOpsReadinessRecord",
+        "schema_version": "v0.1",
+        "status": status,
+        "bundle_id": bundle["bundle_id"],
+        "version": bundle["version"],
+        "namespace": bundle["namespace"],
+        "gitops_bundle_ref": rel(bundle_path),
+        "gitops_bundle_digest": sha256_file(bundle_path),
+        "deploy_plan_ref": bundle["deploy_plan_ref"],
+        "deploy_plan_digest": bundle["deploy_plan_digest"],
+        "agent_corps_plan_ref": bundle["agent_corps_plan_ref"],
+        "agent_corps_plan_digest": bundle["agent_corps_plan_digest"],
+        "source": bundle["source"],
+        "application_ref": bundle["application"]["ref"],
+        "application_digest": bundle["application"]["digest"],
+        "kustomization_ref": bundle["kustomization"]["ref"],
+        "kustomization_digest": bundle["kustomization"]["digest"],
+        "manifest_count": len(bundle["manifests"]),
+        "artifact_count": len(bundle["artifacts"]),
+        "generator": {
+            "status": generator_status,
+        },
+        "checker": {
+            "status": checker_status,
+            "message": checker_message,
+        },
+        "validation_result": {
+            "status": checker_status,
+            "bundle_validated": checker_status == "passed",
+        },
+    }
+    write_json(output_path, record)
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a FogStack GitOps readiness record")
+    parser.add_argument("--bundle", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--generator-status", choices=["passed", "failed", "skipped"], default="passed")
+    parser.add_argument("--checker-status", choices=["passed", "failed", "skipped"], default="passed")
+    parser.add_argument("--checker-message", default="FogStack GitOps bundle passed.")
+    args = parser.parse_args()
+
+    record = emit_record(args.bundle, args.output, args.generator_status, args.checker_status, args.checker_message)
+    print(json.dumps(record, indent=2))
+    return 0 if record["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_gitops_readiness_record.py
+++ b/tools/tests/test_fogstack_gitops_readiness_record.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+MANIFEST = Path("releases/manifests/fogstack.access-v0.1.manifest.json")
+
+
+def build_bundle(tmp_path: Path) -> Path:
+    contract = tmp_path / "runtime-contract.json"
+    deploy_plan = tmp_path / "deploy-plan.json"
+    manifest_dir = tmp_path / "manifests"
+    output_dir = tmp_path / "gitops"
+    subprocess.run([sys.executable, "tools/build_fogstack_runtime_contract.py", "--bundle-id", "fogstack.access", "--version", "0.1.0", "--actor-id", "agent:fogstack.access.operator", "--human-anchor-role", "operator", "--output", str(contract)], check=True)
+    subprocess.run([sys.executable, "tools/build_fogstack_deploy_plan.py", "--manifest", str(MANIFEST), "--profile", "local-dev", "--target", "kubernetes", "--namespace", "fogstack-access", "--health-endpoint", "/healthz", "--runtime-contract", str(contract), "--output", str(deploy_plan)], check=True)
+    subprocess.run([sys.executable, "tools/render_fogstack_kubernetes_manifests.py", "--deploy-plan", str(deploy_plan), "--output-dir", str(manifest_dir)], check=True)
+    subprocess.run([sys.executable, "tools/build_fogstack_gitops_bundle.py", "--deploy-plan", str(deploy_plan), "--manifest-dir", str(manifest_dir), "--output-dir", str(output_dir)], check=True)
+    subprocess.run([sys.executable, "tools/check_fogstack_gitops_bundle.py", "--bundle", str(output_dir / "gitops-bundle.json")], check=True)
+    return output_dir / "gitops-bundle.json"
+
+
+def test_emit_fogstack_gitops_readiness_record_passed(tmp_path: Path) -> None:
+    bundle = build_bundle(tmp_path)
+    output = tmp_path / "gitops-readiness.record.json"
+    subprocess.run([sys.executable, "tools/emit_fogstack_gitops_readiness_record.py", "--bundle", str(bundle), "--output", str(output)], check=True)
+    record = json.loads(output.read_text(encoding="utf-8"))
+    assert record["kind"] == "FogStackGitOpsReadinessRecord"
+    assert record["status"] == "passed"
+    assert record["bundle_id"] == "fogstack.access"
+    assert record["version"] == "0.1.0"
+    assert record["source"]["target_revision"] == "main"
+    assert record["gitops_bundle_digest"].startswith("sha256:")
+    assert record["generator"]["status"] == "passed"
+    assert record["checker"]["status"] == "passed"
+    assert record["validation_result"]["bundle_validated"] is True
+
+
+def test_emit_fogstack_gitops_readiness_record_failed_checker(tmp_path: Path) -> None:
+    bundle = build_bundle(tmp_path)
+    output = tmp_path / "gitops-readiness.record.json"
+    proc = subprocess.run([sys.executable, "tools/emit_fogstack_gitops_readiness_record.py", "--bundle", str(bundle), "--output", str(output), "--checker-status", "failed", "--checker-message", "forced failure"], capture_output=True, text=True)
+    assert proc.returncode != 0
+    record = json.loads(output.read_text(encoding="utf-8"))
+    assert record["status"] == "failed"
+    assert record["checker"]["status"] == "failed"
+    assert record["checker"]["message"] == "forced failure"
+    assert record["validation_result"]["bundle_validated"] is False


### PR DESCRIPTION
Turn 17 of the deploy/runtime parity lane.

Adds a FogStackGitOpsReadinessRecord emitter and focused tests. The record captures generator/checker status, bundle source path, target revision, bundle digest, deploy-plan digest, Agent Corps digest, and validation result.

Files:
- tools/emit_fogstack_gitops_readiness_record.py
- tools/tests/test_fogstack_gitops_readiness_record.py
- .github/workflows/fogstack-gitops-bundle.yml

Parity plan counter: Turn 17 / 32 toward credible MVP IBM-style parity.