### PR TITLE
fogstack: index GitOps readiness evidence

### DIFF
--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -16,6 +16,7 @@ on:
       - "tools/run_fogstack_local_demo.py"
       - "tools/run_fogstack_local_demo_deploy_plan.py"
       - "tools/update_fogstack_local_demo_deploy_artifacts.py"
+      - "tools/update_fogstack_local_demo_gitops_readiness.py"
       - "tools/run_fogstack_local_demo_full.py"
       - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
@@ -27,6 +28,7 @@ on:
       - "tools/check_fogstack_kubernetes_manifests.py"
       - "tools/build_fogstack_gitops_bundle.py"
       - "tools/check_fogstack_gitops_bundle.py"
+      - "tools/emit_fogstack_gitops_readiness_record.py"
       - "tools/fogstack_verify.py"
       - "tools/emit_fogstack_validation_record.py"
       - "tools/build_fogstack_manifest_publication_set.py"
@@ -65,6 +67,7 @@ on:
       - "tools/run_fogstack_local_demo.py"
       - "tools/run_fogstack_local_demo_deploy_plan.py"
       - "tools/update_fogstack_local_demo_deploy_artifacts.py"
+      - "tools/update_fogstack_local_demo_gitops_readiness.py"
       - "tools/run_fogstack_local_demo_full.py"
       - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
@@ -76,6 +79,7 @@ on:
       - "tools/check_fogstack_kubernetes_manifests.py"
       - "tools/build_fogstack_gitops_bundle.py"
       - "tools/check_fogstack_gitops_bundle.py"
+      - "tools/emit_fogstack_gitops_readiness_record.py"
       - "tools/tests/test_run_fogstack_local_demo.py"
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
@@ -123,6 +127,7 @@ jobs:
           test -s build/fogstack-local-demo/deploy/gitops/gitops-bundle.json
           test -s build/fogstack-local-demo/deploy/gitops/application.yaml
           test -s build/fogstack-local-demo/deploy/gitops/kustomization.yaml
+          test -s build/fogstack-local-demo/deploy/fogstack.access.gitops-readiness.record.json
 
       - name: Check generated artifact index
         run: |

--- a/tools/run_fogstack_local_demo_deploy_plan.py
+++ b/tools/run_fogstack_local_demo_deploy_plan.py
@@ -36,6 +36,7 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
     deploy_plan = output_dir / "fogstack.access.deploy-plan.json"
     manifest_dir = output_dir / "kubernetes"
     gitops_dir = output_dir / "gitops"
+    gitops_readiness_record = output_dir / "fogstack.access.gitops-readiness.record.json"
     check_record = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
     readiness_record = output_dir / "fogstack.access.cluster-readiness.record.json"
     summary_path = output_dir / "fogstack.access.deploy-demo.summary.json"
@@ -100,10 +101,19 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
         "--target-revision", "main",
         "--gitops-path", "gitops/fogstack.access",
     ])
-    run([
+    gitops_check = run([
         sys.executable,
         "tools/check_fogstack_gitops_bundle.py",
         "--bundle", str(gitops_dir / "gitops-bundle.json"),
+    ])
+    run([
+        sys.executable,
+        "tools/emit_fogstack_gitops_readiness_record.py",
+        "--bundle", str(gitops_dir / "gitops-bundle.json"),
+        "--output", str(gitops_readiness_record),
+        "--generator-status", "passed",
+        "--checker-status", "passed",
+        "--checker-message", gitops_check.stdout.strip(),
     ])
 
     manifests = [
@@ -149,6 +159,7 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
             "gitops_configmap": rel(gitops_dir / "manifests" / "configmap.yaml"),
             "gitops_deployment": rel(gitops_dir / "manifests" / "deployment.yaml"),
             "gitops_service": rel(gitops_dir / "manifests" / "service.yaml"),
+            "gitops_readiness_record": rel(gitops_readiness_record),
             "summary": rel(summary_path),
         },
         "checks": [
@@ -161,6 +172,7 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
             "cluster_readiness_record_emitted",
             "gitops_bundle_built",
             "gitops_bundle_checked",
+            "gitops_readiness_record_emitted",
         ],
     }
     write_json(summary_path, summary)
@@ -182,6 +194,7 @@ def render_summary(summary: dict[str, Any]) -> str:
         f"Cluster readiness record: {artifacts['cluster_readiness_record']}",
         f"GitOps bundle: {artifacts['gitops_bundle']}",
         f"GitOps application: {artifacts['gitops_application']}",
+        f"GitOps readiness record: {artifacts['gitops_readiness_record']}",
         f"Checks passed: {len(summary['checks'])}",
     ]
     return "\n".join(lines) + "\n"

--- a/tools/run_fogstack_local_demo_full.py
+++ b/tools/run_fogstack_local_demo_full.py
@@ -38,6 +38,7 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
     deploy_dir = output_dir / "deploy"
     summary_path = output_dir / "fogstack-local-demo.summary.json"
     deploy_summary_path = deploy_dir / "fogstack.access.deploy-demo.summary.json"
+    gitops_readiness_path = deploy_dir / "fogstack.access.gitops-readiness.record.json"
     artifact_index_path = output_dir / "demo-artifacts.index.json"
     full_summary_path = output_dir / "fogstack-local-demo.full.summary.json"
 
@@ -64,6 +65,14 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
         str(summary_path),
         "--deploy-summary-json",
         str(deploy_summary_path),
+    ])
+    run([
+        sys.executable,
+        "tools/update_fogstack_local_demo_gitops_readiness.py",
+        "--summary-json",
+        str(summary_path),
+        "--gitops-readiness-record",
+        str(gitops_readiness_path),
     ])
     run([
         sys.executable,
@@ -96,6 +105,7 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
             "gitops_configmap": rel(deploy_dir / "gitops" / "manifests" / "configmap.yaml"),
             "gitops_deployment": rel(deploy_dir / "gitops" / "manifests" / "deployment.yaml"),
             "gitops_service": rel(deploy_dir / "gitops" / "manifests" / "service.yaml"),
+            "gitops_readiness_record": rel(gitops_readiness_path),
         },
         "checks": [
             "local_demo_generated",
@@ -103,6 +113,7 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
             "deploy_artifacts_integrated",
             "cluster_readiness_record_indexed",
             "gitops_bundle_indexed",
+            "gitops_readiness_record_indexed",
             "artifact_index_checked",
         ],
     }
@@ -122,6 +133,7 @@ def render_summary(summary: dict[str, Any]) -> str:
         f"Cluster readiness record: {artifacts['cluster_readiness_record']}",
         f"GitOps bundle: {artifacts['gitops_bundle']}",
         f"GitOps application: {artifacts['gitops_application']}",
+        f"GitOps readiness record: {artifacts['gitops_readiness_record']}",
         f"Checks passed: {len(summary['checks'])}",
     ]
     return "\n".join(lines) + "\n"

--- a/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
+++ b/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
@@ -29,11 +29,13 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert "Cluster readiness record:" in proc.stdout
     assert "GitOps bundle:" in proc.stdout
     assert "GitOps application:" in proc.stdout
-    assert "Checks passed: 9" in proc.stdout
+    assert "GitOps readiness record:" in proc.stdout
+    assert "Checks passed: 10" in proc.stdout
 
     summary_path = output_dir / "fogstack.access.deploy-demo.summary.json"
     check_record_path = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
     readiness_record_path = output_dir / "fogstack.access.cluster-readiness.record.json"
+    gitops_readiness_path = output_dir / "fogstack.access.gitops-readiness.record.json"
     runtime_contract_path = output_dir / "fogstack.access.runtime-contract.json"
     deploy_plan_path = output_dir / "fogstack.access.deploy-plan.json"
     manifest_dir = output_dir / "kubernetes"
@@ -43,6 +45,7 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
         summary_path,
         check_record_path,
         readiness_record_path,
+        gitops_readiness_path,
         runtime_contract_path,
         deploy_plan_path,
         manifest_dir / "configmap.yaml",
@@ -72,6 +75,7 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
         "cluster_readiness_record_emitted",
         "gitops_bundle_built",
         "gitops_bundle_checked",
+        "gitops_readiness_record_emitted",
     }
 
     artifacts = summary["artifacts"]
@@ -86,6 +90,7 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert artifacts["gitops_application"].endswith("application.yaml")
     assert artifacts["gitops_kustomization"].endswith("kustomization.yaml")
     assert artifacts["gitops_deployment"].endswith("deployment.yaml")
+    assert artifacts["gitops_readiness_record"].endswith("fogstack.access.gitops-readiness.record.json")
 
     check_record = json.loads(check_record_path.read_text(encoding="utf-8"))
     assert check_record["kind"] == "FogStackKubernetesManifestCheckRecord"
@@ -103,6 +108,11 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert gitops_bundle["kind"] == "FogStackGitOpsBundle"
     assert gitops_bundle["bundle_id"] == "fogstack.access"
     assert gitops_bundle["deploy_plan_digest"].startswith("sha256:")
+
+    gitops_readiness = json.loads(gitops_readiness_path.read_text(encoding="utf-8"))
+    assert gitops_readiness["kind"] == "FogStackGitOpsReadinessRecord"
+    assert gitops_readiness["status"] == "passed"
+    assert gitops_readiness["validation_result"]["bundle_validated"] is True
 
     deployment = yaml.safe_load((manifest_dir / "deployment.yaml").read_text(encoding="utf-8"))
     assert deployment["kind"] == "Deployment"

--- a/tools/tests/test_run_fogstack_local_demo_full.py
+++ b/tools/tests/test_run_fogstack_local_demo_full.py
@@ -25,6 +25,7 @@ REQUIRED_FULL_ARTIFACTS = {
     "gitops_configmap",
     "gitops_deployment",
     "gitops_service",
+    "gitops_readiness_record",
 }
 
 
@@ -50,6 +51,7 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert "Cluster readiness record:" in proc.stdout
     assert "GitOps bundle:" in proc.stdout
     assert "GitOps application:" in proc.stdout
+    assert "GitOps readiness record:" in proc.stdout
 
     full_summary_path = output_dir / "fogstack-local-demo.full.summary.json"
     assert full_summary_path.exists()
@@ -59,6 +61,7 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert REQUIRED_FULL_ARTIFACTS == set(full_summary["artifacts"])
     assert "cluster_readiness_record_indexed" in full_summary["checks"]
     assert "gitops_bundle_indexed" in full_summary["checks"]
+    assert "gitops_readiness_record_indexed" in full_summary["checks"]
     for ref in full_summary["artifacts"].values():
         assert Path(ref).exists(), ref
 
@@ -70,6 +73,10 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert gitops_bundle["kind"] == "FogStackGitOpsBundle"
     assert gitops_bundle["bundle_id"] == "fogstack.access"
 
+    gitops_readiness = json.loads(Path(full_summary["artifacts"]["gitops_readiness_record"]).read_text(encoding="utf-8"))
+    assert gitops_readiness["kind"] == "FogStackGitOpsReadinessRecord"
+    assert gitops_readiness["status"] == "passed"
+
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed_ids = {entry["id"] for entry in artifact_index["artifacts"]}
     assert "deploy_plan" in indexed_ids
@@ -79,12 +86,15 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert "deploy_gitops_bundle" in indexed_ids
     assert "deploy_gitops_application" in indexed_ids
     assert "deploy_gitops_deployment" in indexed_ids
+    assert "deploy_gitops_readiness_record" in indexed_ids
 
     html = (output_dir / "index.html").read_text(encoding="utf-8")
     assert "Deploy readiness" in html
+    assert "GitOps readiness" in html
     assert "SHA-256 digest" in html
     assert "indexed" in html
     assert "deploy_plan" in html
     assert "deploy_cluster_readiness_record" in html
     assert "deploy_gitops_bundle" in html
+    assert "deploy_gitops_readiness_record" in html
     assert "fogstack.access.deploy-plan.json" in html

--- a/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
@@ -20,6 +20,7 @@ REQUIRED = {
     "deploy_gitops_configmap",
     "deploy_gitops_deployment",
     "deploy_gitops_service",
+    "deploy_gitops_readiness_record",
     "deploy_summary",
 }
 
@@ -30,6 +31,7 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     subprocess.run([sys.executable, "tools/run_fogstack_local_demo.py", "--pack", "all", "--output-dir", str(output_dir)], check=True)
     subprocess.run([sys.executable, "tools/run_fogstack_local_demo_deploy_plan.py", "--output-dir", str(deploy_dir)], check=True)
     subprocess.run([sys.executable, "tools/update_fogstack_local_demo_deploy_artifacts.py", "--summary-json", str(output_dir / "fogstack-local-demo.summary.json"), "--deploy-summary-json", str(deploy_dir / "fogstack.access.deploy-demo.summary.json")], check=True)
+    subprocess.run([sys.executable, "tools/update_fogstack_local_demo_gitops_readiness.py", "--summary-json", str(output_dir / "fogstack-local-demo.summary.json"), "--gitops-readiness-record", str(deploy_dir / "fogstack.access.gitops-readiness.record.json")], check=True)
 
     summary = json.loads((output_dir / "fogstack-local-demo.summary.json").read_text(encoding="utf-8"))
     assert REQUIRED.issubset(set(summary["artifacts"]))
@@ -38,6 +40,7 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     assert "cluster_readiness_record_emitted" in summary["checks"]
     assert "gitops_bundle_built" in summary["checks"]
     assert "gitops_bundle_checked" in summary["checks"]
+    assert "gitops_readiness_record_indexed" in summary["checks"]
 
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed = {entry["id"]: entry for entry in artifact_index["artifacts"]}
@@ -54,10 +57,15 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     assert gitops_bundle["kind"] == "FogStackGitOpsBundle"
     assert gitops_bundle["bundle_id"] == "fogstack.access"
 
+    gitops_readiness = json.loads(Path(summary["artifacts"]["deploy_gitops_readiness_record"]).read_text(encoding="utf-8"))
+    assert gitops_readiness["kind"] == "FogStackGitOpsReadinessRecord"
+    assert gitops_readiness["status"] == "passed"
+
     markdown = (output_dir / "fogstack-local-demo.summary.md").read_text(encoding="utf-8")
     html = (output_dir / "index.html").read_text(encoding="utf-8")
     for content in [markdown, html]:
         assert "Deploy readiness" in content
+        assert "GitOps readiness" in content
         assert "Artifact ID" in content
         assert "SHA-256 digest" in content
         assert "indexed" in content
@@ -66,4 +74,5 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
         assert "deploy_cluster_readiness_record" in content
         assert "deploy_gitops_bundle" in content
         assert "deploy_gitops_application" in content
+        assert "deploy_gitops_readiness_record" in content
         assert "sha256:" in content

--- a/tools/update_fogstack_local_demo_gitops_readiness.py
+++ b/tools/update_fogstack_local_demo_gitops_readiness.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_ID = "deploy_gitops_readiness_record"
+LABEL = "GitOps readiness record"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def path_from_ref(ref: str) -> Path:
+    path = Path(ref)
+    return path if path.is_absolute() else ROOT / path
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def add_index_entry(index_path: Path, artifact_ref: str) -> None:
+    index = load_json(index_path)
+    artifact_path = path_from_ref(artifact_ref)
+    if not artifact_path.exists() or not artifact_path.is_file():
+        raise SystemExit(f"ERR: GitOps readiness artifact missing: {artifact_ref}")
+    entries = [entry for entry in index.get("artifacts", []) if entry.get("id") != ARTIFACT_ID]
+    entries.append({
+        "id": ARTIFACT_ID,
+        "ref": artifact_ref,
+        "digest": sha256_file(artifact_path),
+        "size_bytes": artifact_path.stat().st_size,
+    })
+    index["artifacts"] = entries
+    write_json(index_path, index)
+
+
+def append_markdown(markdown_path: Path, artifact_ref: str, digest: str) -> None:
+    section = "\n".join([
+        "",
+        "## GitOps readiness",
+        "",
+        "| Artifact ID | Artifact | Ref | SHA-256 digest | Status |",
+        "|---|---|---|---|---|",
+        f"| `{ARTIFACT_ID}` | {LABEL} | `{artifact_ref}` | `{digest}` | `indexed` |",
+        "",
+    ])
+    markdown_path.write_text(markdown_path.read_text(encoding="utf-8") + section, encoding="utf-8")
+
+
+def append_html(html_path: Path, artifact_ref: str, digest: str) -> None:
+    section = f"""
+    <h2>GitOps readiness</h2>
+    <table>
+      <thead><tr><th>Artifact ID</th><th>Artifact</th><th>Ref</th><th>SHA-256 digest</th><th>Status</th></tr></thead>
+      <tbody>
+        <tr><td><code>{html.escape(ARTIFACT_ID)}</code></td><td>{html.escape(LABEL)}</td><td><code>{html.escape(artifact_ref)}</code></td><td><code>{html.escape(digest)}</code></td><td>indexed</td></tr>
+      </tbody>
+    </table>
+"""
+    html_text = html_path.read_text(encoding="utf-8")
+    html_path.write_text(html_text.replace("\n  </main>", section + "\n  </main>"), encoding="utf-8")
+
+
+def update(summary_path: Path, gitops_record: Path) -> dict[str, Any]:
+    summary = load_json(summary_path)
+    artifact_ref = rel(gitops_record if gitops_record.is_absolute() else ROOT / gitops_record)
+    artifact_path = path_from_ref(artifact_ref)
+    digest = sha256_file(artifact_path)
+
+    artifacts = summary.setdefault("artifacts", {})
+    artifacts[ARTIFACT_ID] = artifact_ref
+    checks = summary.setdefault("checks", [])
+    if "gitops_readiness_record_indexed" not in checks:
+        checks.append("gitops_readiness_record_indexed")
+    write_json(summary_path, summary)
+
+    add_index_entry(path_from_ref(artifacts["artifact_index"]), artifact_ref)
+    append_markdown(path_from_ref(artifacts["summary_markdown"]), artifact_ref, digest)
+    append_html(path_from_ref(artifacts["summary_html"]), artifact_ref, digest)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Add GitOps readiness evidence to a FogStack local demo")
+    parser.add_argument("--summary-json", type=Path, default=Path("build/fogstack-local-demo/fogstack-local-demo.summary.json"))
+    parser.add_argument("--gitops-readiness-record", type=Path, default=Path("build/fogstack-local-demo/deploy/fogstack.access.gitops-readiness.record.json"))
+    args = parser.parse_args()
+    summary_path = args.summary_json if args.summary_json.is_absolute() else ROOT / args.summary_json
+    record_path = args.gitops_readiness_record if args.gitops_readiness_record.is_absolute() else ROOT / args.gitops_readiness_record
+    update(summary_path, record_path)
+    print(json.dumps({"kind": "FogStackLocalDemoGitOpsReadinessUpdate", "status": "passed", "artifact_id": ARTIFACT_ID}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/update_fogstack_local_demo_gitops_readiness.py
+++ b/tools/update_fogstack_local_demo_gitops_readiness.py
@@ -45,19 +45,31 @@ def rel(path: Path) -> str:
         return str(path)
 
 
-def add_index_entry(index_path: Path, artifact_ref: str) -> None:
+def refresh_index(index_path: Path, artifact_ref: str) -> None:
     index = load_json(index_path)
     artifact_path = path_from_ref(artifact_ref)
     if not artifact_path.exists() or not artifact_path.is_file():
         raise SystemExit(f"ERR: GitOps readiness artifact missing: {artifact_ref}")
-    entries = [entry for entry in index.get("artifacts", []) if entry.get("id") != ARTIFACT_ID]
-    entries.append({
-        "id": ARTIFACT_ID,
-        "ref": artifact_ref,
-        "digest": sha256_file(artifact_path),
-        "size_bytes": artifact_path.stat().st_size,
-    })
-    index["artifacts"] = entries
+
+    by_id = {entry["id"]: entry for entry in index.get("artifacts", []) if isinstance(entry, dict) and entry.get("id")}
+    by_id[ARTIFACT_ID] = {"id": ARTIFACT_ID, "ref": artifact_ref}
+
+    refreshed = []
+    for artifact_id in sorted(by_id):
+        entry = by_id[artifact_id]
+        ref = entry.get("ref")
+        if not isinstance(ref, str) or not ref:
+            continue
+        path = path_from_ref(ref)
+        if not path.exists() or not path.is_file():
+            raise SystemExit(f"ERR: indexed artifact missing while refreshing: {ref}")
+        refreshed.append({
+            "id": artifact_id,
+            "ref": ref,
+            "digest": sha256_file(path),
+            "size_bytes": path.stat().st_size,
+        })
+    index["artifacts"] = refreshed
     write_json(index_path, index)
 
 
@@ -101,9 +113,9 @@ def update(summary_path: Path, gitops_record: Path) -> dict[str, Any]:
         checks.append("gitops_readiness_record_indexed")
     write_json(summary_path, summary)
 
-    add_index_entry(path_from_ref(artifacts["artifact_index"]), artifact_ref)
     append_markdown(path_from_ref(artifacts["summary_markdown"]), artifact_ref, digest)
     append_html(path_from_ref(artifacts["summary_html"]), artifact_ref, digest)
+    refresh_index(path_from_ref(artifacts["artifact_index"]), artifact_ref)
     return summary
 
 


### PR DESCRIPTION
Turn 18 of the deploy/runtime parity lane.

Includes the GitOps readiness record in the full local demo artifact index and deploy readiness evidence path.

Files:
- tools/run_fogstack_local_demo_deploy_plan.py
- tools/run_fogstack_local_demo_full.py
- tools/update_fogstack_local_demo_gitops_readiness.py
- local demo tests
- .github/workflows/fogstack-local-demo.yml

Parity plan counter: Turn 18 / 32 toward credible MVP IBM-style parity.