### PR TITLE
fogstack: add local cluster runtime adapter contract

### DIFF
--- a/.github/workflows/fogstack-local-cluster-runtime.yml
+++ b/.github/workflows/fogstack-local-cluster-runtime.yml
@@ -1,0 +1,106 @@
+name: FogStack Local Cluster Runtime
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "schemas/runtime/**"
+      - "schemas/gitops/**"
+      - "schemas/agent/**"
+      - "schemas/deploy/**"
+      - "bundles/fogstack.*.yaml"
+      - "releases/manifests/fogstack.*.manifest.json"
+      - "tools/build_fogstack_runtime_contract.py"
+      - "tools/build_fogstack_deploy_plan.py"
+      - "tools/render_fogstack_kubernetes_manifests.py"
+      - "tools/check_fogstack_kubernetes_manifests.py"
+      - "tools/build_fogstack_gitops_bundle.py"
+      - "tools/check_fogstack_gitops_bundle.py"
+      - "tools/emit_fogstack_gitops_readiness_record.py"
+      - "tools/build_fogstack_local_cluster_runtime_adapter.py"
+      - "tools/tests/test_fogstack_local_cluster_runtime_adapter.py"
+      - ".github/workflows/fogstack-local-cluster-runtime.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/runtime/**"
+      - "schemas/gitops/**"
+      - "schemas/agent/**"
+      - "schemas/deploy/**"
+      - "bundles/fogstack.*.yaml"
+      - "releases/manifests/fogstack.*.manifest.json"
+      - "tools/build_fogstack_runtime_contract.py"
+      - "tools/build_fogstack_deploy_plan.py"
+      - "tools/render_fogstack_kubernetes_manifests.py"
+      - "tools/check_fogstack_kubernetes_manifests.py"
+      - "tools/build_fogstack_gitops_bundle.py"
+      - "tools/check_fogstack_gitops_bundle.py"
+      - "tools/emit_fogstack_gitops_readiness_record.py"
+      - "tools/build_fogstack_local_cluster_runtime_adapter.py"
+      - "tools/tests/test_fogstack_local_cluster_runtime_adapter.py"
+      - ".github/workflows/fogstack-local-cluster-runtime.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  local-cluster-runtime:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml jsonschema
+
+      - name: Run local cluster runtime tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_local_cluster_runtime_adapter.py
+
+      - name: Build sample local cluster runtime adapter
+        run: |
+          mkdir -p build/fogstack-runtime-inputs
+          python3 tools/build_fogstack_runtime_contract.py \
+            --bundle-id fogstack.access \
+            --version 0.1.0 \
+            --actor-id agent:fogstack.access.operator \
+            --human-anchor-role operator \
+            --output build/fogstack-runtime-inputs/runtime-contract.json
+          python3 tools/build_fogstack_deploy_plan.py \
+            --manifest releases/manifests/fogstack.access-v0.1.manifest.json \
+            --profile local-dev \
+            --target kubernetes \
+            --namespace fogstack-access \
+            --health-endpoint /healthz \
+            --runtime-contract build/fogstack-runtime-inputs/runtime-contract.json \
+            --output build/fogstack-runtime-inputs/deploy-plan.json
+          python3 tools/render_fogstack_kubernetes_manifests.py \
+            --deploy-plan build/fogstack-runtime-inputs/deploy-plan.json \
+            --output-dir build/fogstack-runtime-inputs/manifests
+          python3 tools/check_fogstack_kubernetes_manifests.py \
+            --deploy-plan build/fogstack-runtime-inputs/deploy-plan.json \
+            --manifest-dir build/fogstack-runtime-inputs/manifests \
+            --record-output build/fogstack-runtime-inputs/cluster-readiness.json
+          python3 tools/build_fogstack_gitops_bundle.py \
+            --deploy-plan build/fogstack-runtime-inputs/deploy-plan.json \
+            --manifest-dir build/fogstack-runtime-inputs/manifests \
+            --output-dir build/fogstack-runtime-inputs/gitops
+          python3 tools/check_fogstack_gitops_bundle.py --bundle build/fogstack-runtime-inputs/gitops/gitops-bundle.json
+          python3 tools/emit_fogstack_gitops_readiness_record.py \
+            --bundle build/fogstack-runtime-inputs/gitops/gitops-bundle.json \
+            --output build/fogstack-runtime-inputs/gitops-readiness.json
+          python3 tools/build_fogstack_local_cluster_runtime_adapter.py \
+            --deploy-plan build/fogstack-runtime-inputs/deploy-plan.json \
+            --cluster-readiness-record build/fogstack-runtime-inputs/cluster-readiness.json \
+            --gitops-bundle build/fogstack-runtime-inputs/gitops/gitops-bundle.json \
+            --gitops-readiness-record build/fogstack-runtime-inputs/gitops-readiness.json \
+            --output build/fogstack-runtime-inputs/local-cluster-runtime-adapter.json
+          test -s build/fogstack-runtime-inputs/local-cluster-runtime-adapter.json

--- a/schemas/runtime/fogstack-local-cluster-runtime-adapter-v0.1.schema.json
+++ b/schemas/runtime/fogstack-local-cluster-runtime-adapter-v0.1.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/runtime/fogstack-local-cluster-runtime-adapter-v0.1.schema.json",
+  "title": "FogStackLocalClusterRuntimeAdapter",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "bundle_id",
+    "version",
+    "namespace",
+    "adapter",
+    "inputs",
+    "runtime_policy",
+    "artifacts"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackLocalClusterRuntimeAdapter" },
+    "schema_version": { "const": "v0.1" },
+    "bundle_id": { "type": "string", "minLength": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "namespace": { "type": "string", "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" },
+    "adapter": {
+      "type": "object",
+      "required": ["mode", "cluster_provider", "cluster_name", "kubectl_context", "supported_tools"],
+      "properties": {
+        "mode": { "enum": ["dry-run", "local-cluster"] },
+        "cluster_provider": { "enum": ["kind", "generic-kubernetes"] },
+        "cluster_name": { "type": "string", "minLength": 1 },
+        "kubectl_context": { "type": "string", "minLength": 1 },
+        "supported_tools": {
+          "type": "array",
+          "items": { "enum": ["kubectl", "kind"] },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "inputs": {
+      "type": "object",
+      "required": [
+        "deploy_plan_ref",
+        "deploy_plan_digest",
+        "cluster_readiness_record_ref",
+        "cluster_readiness_record_digest",
+        "gitops_bundle_ref",
+        "gitops_bundle_digest",
+        "gitops_readiness_record_ref",
+        "gitops_readiness_record_digest"
+      ],
+      "properties": {
+        "deploy_plan_ref": { "type": "string", "minLength": 1 },
+        "deploy_plan_digest": { "$ref": "#/$defs/sha256_digest" },
+        "cluster_readiness_record_ref": { "type": "string", "minLength": 1 },
+        "cluster_readiness_record_digest": { "$ref": "#/$defs/sha256_digest" },
+        "gitops_bundle_ref": { "type": "string", "minLength": 1 },
+        "gitops_bundle_digest": { "$ref": "#/$defs/sha256_digest" },
+        "gitops_readiness_record_ref": { "type": "string", "minLength": 1 },
+        "gitops_readiness_record_digest": { "$ref": "#/$defs/sha256_digest" }
+      },
+      "additionalProperties": false
+    },
+    "runtime_policy": {
+      "type": "object",
+      "required": ["live_apply_allowed", "requires_human_approval", "network_default", "secrets_default"],
+      "properties": {
+        "live_apply_allowed": { "const": false },
+        "requires_human_approval": { "const": true },
+        "network_default": { "const": "deny" },
+        "secrets_default": { "const": "deny" }
+      },
+      "additionalProperties": false
+    },
+    "artifacts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/artifact" },
+      "minItems": 1
+    }
+  },
+  "$defs": {
+    "sha256_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "artifact": {
+      "type": "object",
+      "required": ["id", "ref", "digest"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "ref": { "type": "string", "minLength": 1 },
+        "digest": { "$ref": "#/$defs/sha256_digest" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/build_fogstack_local_cluster_runtime_adapter.py
+++ b/tools/build_fogstack_local_cluster_runtime_adapter.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def artifact(artifact_id: str, path: Path) -> dict[str, str]:
+    path = resolve(path)
+    return {"id": artifact_id, "ref": rel(path), "digest": sha256_file(path)}
+
+
+def build_adapter(
+    deploy_plan_path: Path,
+    cluster_readiness_path: Path,
+    gitops_bundle_path: Path,
+    gitops_readiness_path: Path,
+    output_path: Path,
+    mode: str,
+    cluster_provider: str,
+    cluster_name: str,
+    kubectl_context: str,
+) -> dict[str, Any]:
+    deploy_plan_path = resolve(deploy_plan_path)
+    cluster_readiness_path = resolve(cluster_readiness_path)
+    gitops_bundle_path = resolve(gitops_bundle_path)
+    gitops_readiness_path = resolve(gitops_readiness_path)
+    output_path = resolve(output_path)
+
+    deploy_plan = load_json(deploy_plan_path)
+    cluster_readiness = load_json(cluster_readiness_path)
+    gitops_bundle = load_json(gitops_bundle_path)
+    gitops_readiness = load_json(gitops_readiness_path)
+
+    if deploy_plan.get("kind") != "FogStackDeployPlan":
+        raise SystemExit("ERR: expected FogStackDeployPlan")
+    if cluster_readiness.get("kind") != "FogStackClusterReadinessRecord":
+        raise SystemExit("ERR: expected FogStackClusterReadinessRecord")
+    if gitops_bundle.get("kind") != "FogStackGitOpsBundle":
+        raise SystemExit("ERR: expected FogStackGitOpsBundle")
+    if gitops_readiness.get("kind") != "FogStackGitOpsReadinessRecord":
+        raise SystemExit("ERR: expected FogStackGitOpsReadinessRecord")
+
+    bundle_id = deploy_plan["bundle_id"]
+    version = deploy_plan["version"]
+    namespace = deploy_plan["namespace"]
+    for name, data in [("GitOps bundle", gitops_bundle), ("GitOps readiness", gitops_readiness)]:
+        if data.get("bundle_id") != bundle_id:
+            raise SystemExit(f"ERR: {name} bundle_id does not match deploy plan")
+        if data.get("version") != version:
+            raise SystemExit(f"ERR: {name} version does not match deploy plan")
+    if cluster_readiness.get("status") != "passed":
+        raise SystemExit("ERR: cluster readiness record must have passed status")
+    if gitops_readiness.get("status") != "passed":
+        raise SystemExit("ERR: GitOps readiness record must have passed status")
+
+    supported_tools = ["kubectl"] if cluster_provider == "generic-kubernetes" else ["kubectl", "kind"]
+    adapter = {
+        "kind": "FogStackLocalClusterRuntimeAdapter",
+        "schema_version": "v0.1",
+        "bundle_id": bundle_id,
+        "version": version,
+        "namespace": namespace,
+        "adapter": {
+            "mode": mode,
+            "cluster_provider": cluster_provider,
+            "cluster_name": cluster_name,
+            "kubectl_context": kubectl_context,
+            "supported_tools": supported_tools,
+        },
+        "inputs": {
+            "deploy_plan_ref": rel(deploy_plan_path),
+            "deploy_plan_digest": sha256_file(deploy_plan_path),
+            "cluster_readiness_record_ref": rel(cluster_readiness_path),
+            "cluster_readiness_record_digest": sha256_file(cluster_readiness_path),
+            "gitops_bundle_ref": rel(gitops_bundle_path),
+            "gitops_bundle_digest": sha256_file(gitops_bundle_path),
+            "gitops_readiness_record_ref": rel(gitops_readiness_path),
+            "gitops_readiness_record_digest": sha256_file(gitops_readiness_path),
+        },
+        "runtime_policy": {
+            "live_apply_allowed": False,
+            "requires_human_approval": True,
+            "network_default": "deny",
+            "secrets_default": "deny",
+        },
+        "artifacts": [
+            artifact("deploy-plan", deploy_plan_path),
+            artifact("cluster-readiness-record", cluster_readiness_path),
+            artifact("gitops-bundle", gitops_bundle_path),
+            artifact("gitops-readiness-record", gitops_readiness_path),
+        ],
+    }
+    write_json(output_path, adapter)
+    return adapter
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a FogStack local cluster runtime adapter contract")
+    parser.add_argument("--deploy-plan", required=True, type=Path)
+    parser.add_argument("--cluster-readiness-record", required=True, type=Path)
+    parser.add_argument("--gitops-bundle", required=True, type=Path)
+    parser.add_argument("--gitops-readiness-record", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--mode", choices=["dry-run", "local-cluster"], default="dry-run")
+    parser.add_argument("--cluster-provider", choices=["kind", "generic-kubernetes"], default="kind")
+    parser.add_argument("--cluster-name", default="fogstack-local")
+    parser.add_argument("--kubectl-context", default="kind-fogstack-local")
+    args = parser.parse_args()
+
+    adapter = build_adapter(
+        deploy_plan_path=args.deploy_plan,
+        cluster_readiness_path=args.cluster_readiness_record,
+        gitops_bundle_path=args.gitops_bundle,
+        gitops_readiness_path=args.gitops_readiness_record,
+        output_path=args.output,
+        mode=args.mode,
+        cluster_provider=args.cluster_provider,
+        cluster_name=args.cluster_name,
+        kubectl_context=args.kubectl_context,
+    )
+    print(json.dumps(adapter, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_local_cluster_runtime_adapter.py
+++ b/tools/tests/test_fogstack_local_cluster_runtime_adapter.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+MANIFEST = Path("releases/manifests/fogstack.access-v0.1.manifest.json")
+SCHEMA = Path("schemas/runtime/fogstack-local-cluster-runtime-adapter-v0.1.schema.json")
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def build_inputs(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    contract = tmp_path / "runtime-contract.json"
+    deploy_plan = tmp_path / "deploy-plan.json"
+    manifests = tmp_path / "manifests"
+    cluster_record = tmp_path / "cluster-readiness.json"
+    gitops_dir = tmp_path / "gitops"
+    gitops_record = tmp_path / "gitops-readiness.json"
+    subprocess.run([sys.executable, "tools/build_fogstack_runtime_contract.py", "--bundle-id", "fogstack.access", "--version", "0.1.0", "--actor-id", "agent:fogstack.access.operator", "--human-anchor-role", "operator", "--output", str(contract)], check=True)
+    subprocess.run([sys.executable, "tools/build_fogstack_deploy_plan.py", "--manifest", str(MANIFEST), "--profile", "local-dev", "--target", "kubernetes", "--namespace", "fogstack-access", "--health-endpoint", "/healthz", "--runtime-contract", str(contract), "--output", str(deploy_plan)], check=True)
+    subprocess.run([sys.executable, "tools/render_fogstack_kubernetes_manifests.py", "--deploy-plan", str(deploy_plan), "--output-dir", str(manifests)], check=True)
+    subprocess.run([sys.executable, "tools/check_fogstack_kubernetes_manifests.py", "--deploy-plan", str(deploy_plan), "--manifest-dir", str(manifests), "--record-output", str(cluster_record)], check=True)
+    subprocess.run([sys.executable, "tools/build_fogstack_gitops_bundle.py", "--deploy-plan", str(deploy_plan), "--manifest-dir", str(manifests), "--output-dir", str(gitops_dir)], check=True)
+    subprocess.run([sys.executable, "tools/check_fogstack_gitops_bundle.py", "--bundle", str(gitops_dir / "gitops-bundle.json")], check=True)
+    subprocess.run([sys.executable, "tools/emit_fogstack_gitops_readiness_record.py", "--bundle", str(gitops_dir / "gitops-bundle.json"), "--output", str(gitops_record)], check=True)
+    return deploy_plan, cluster_record, gitops_dir / "gitops-bundle.json", gitops_record
+
+
+def test_build_fogstack_local_cluster_runtime_adapter(tmp_path: Path) -> None:
+    deploy_plan, cluster_record, gitops_bundle, gitops_record = build_inputs(tmp_path)
+    output = tmp_path / "local-cluster-runtime-adapter.json"
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_local_cluster_runtime_adapter.py",
+        "--deploy-plan", str(deploy_plan),
+        "--cluster-readiness-record", str(cluster_record),
+        "--gitops-bundle", str(gitops_bundle),
+        "--gitops-readiness-record", str(gitops_record),
+        "--output", str(output),
+    ], check=True)
+    adapter = load_json(output)
+    Draft202012Validator(load_json(SCHEMA)).validate(adapter)
+    assert adapter["kind"] == "FogStackLocalClusterRuntimeAdapter"
+    assert adapter["bundle_id"] == "fogstack.access"
+    assert adapter["version"] == "0.1.0"
+    assert adapter["namespace"] == "fogstack-access"
+    assert adapter["adapter"]["mode"] == "dry-run"
+    assert adapter["adapter"]["cluster_provider"] == "kind"
+    assert adapter["adapter"]["supported_tools"] == ["kubectl", "kind"]
+    assert adapter["runtime_policy"] == {
+        "live_apply_allowed": False,
+        "requires_human_approval": True,
+        "network_default": "deny",
+        "secrets_default": "deny",
+    }
+    for key in ["deploy_plan_digest", "cluster_readiness_record_digest", "gitops_bundle_digest", "gitops_readiness_record_digest"]:
+        assert adapter["inputs"][key].startswith("sha256:")
+    artifact_ids = {artifact["id"] for artifact in adapter["artifacts"]}
+    assert artifact_ids == {"deploy-plan", "cluster-readiness-record", "gitops-bundle", "gitops-readiness-record"}


### PR DESCRIPTION
Turn 19 of the deploy/runtime parity lane.

Starts the local cluster runtime lane with a Kind/kubectl-compatible runtime adapter skeleton. This is contract-only and dry-run oriented; it does not create or mutate a live cluster.

Files:
- schemas/runtime/fogstack-local-cluster-runtime-adapter-v0.1.schema.json
- tools/build_fogstack_local_cluster_runtime_adapter.py
- tools/tests/test_fogstack_local_cluster_runtime_adapter.py
- .github/workflows/fogstack-local-cluster-runtime.yml

Parity plan counter: Turn 19 / 32 toward credible MVP IBM-style parity.