### PR TITLE
fogstack: emit runtime dry-run record

### DIFF
--- a/.github/workflows/fogstack-local-cluster-runtime.yml
+++ b/.github/workflows/fogstack-local-cluster-runtime.yml
@@ -18,7 +18,9 @@ on:
       - "tools/check_fogstack_gitops_bundle.py"
       - "tools/emit_fogstack_gitops_readiness_record.py"
       - "tools/build_fogstack_local_cluster_runtime_adapter.py"
+      - "tools/emit_fogstack_runtime_dry_run_record.py"
       - "tools/tests/test_fogstack_local_cluster_runtime_adapter.py"
+      - "tools/tests/test_fogstack_runtime_dry_run_record.py"
       - ".github/workflows/fogstack-local-cluster-runtime.yml"
   push:
     branches: [main]
@@ -37,7 +39,9 @@ on:
       - "tools/check_fogstack_gitops_bundle.py"
       - "tools/emit_fogstack_gitops_readiness_record.py"
       - "tools/build_fogstack_local_cluster_runtime_adapter.py"
+      - "tools/emit_fogstack_runtime_dry_run_record.py"
       - "tools/tests/test_fogstack_local_cluster_runtime_adapter.py"
+      - "tools/tests/test_fogstack_runtime_dry_run_record.py"
       - ".github/workflows/fogstack-local-cluster-runtime.yml"
 
 permissions:
@@ -63,7 +67,9 @@ jobs:
 
       - name: Run local cluster runtime tests
         run: |
-          python -m pytest -q tools/tests/test_fogstack_local_cluster_runtime_adapter.py
+          python -m pytest -q \
+            tools/tests/test_fogstack_local_cluster_runtime_adapter.py \
+            tools/tests/test_fogstack_runtime_dry_run_record.py
 
       - name: Build sample local cluster runtime adapter
         run: |
@@ -103,4 +109,9 @@ jobs:
             --gitops-bundle build/fogstack-runtime-inputs/gitops/gitops-bundle.json \
             --gitops-readiness-record build/fogstack-runtime-inputs/gitops-readiness.json \
             --output build/fogstack-runtime-inputs/local-cluster-runtime-adapter.json
+          python3 tools/emit_fogstack_runtime_dry_run_record.py \
+            --runtime-adapter build/fogstack-runtime-inputs/local-cluster-runtime-adapter.json \
+            --manifest-dir build/fogstack-runtime-inputs/manifests \
+            --output build/fogstack-runtime-inputs/runtime-dry-run.record.json
           test -s build/fogstack-runtime-inputs/local-cluster-runtime-adapter.json
+          test -s build/fogstack-runtime-inputs/runtime-dry-run.record.json

--- a/schemas/runtime/fogstack-runtime-dry-run-record-v0.1.schema.json
+++ b/schemas/runtime/fogstack-runtime-dry-run-record-v0.1.schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/runtime/fogstack-runtime-dry-run-record-v0.1.schema.json",
+  "title": "FogStackRuntimeDryRunRecord",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "status",
+    "bundle_id",
+    "version",
+    "namespace",
+    "runtime_adapter_ref",
+    "runtime_adapter_digest",
+    "deploy_plan_ref",
+    "deploy_plan_digest",
+    "cluster_readiness_record_ref",
+    "cluster_readiness_record_digest",
+    "gitops_bundle_ref",
+    "gitops_bundle_digest",
+    "gitops_readiness_record_ref",
+    "gitops_readiness_record_digest",
+    "kubernetes_manifests",
+    "runtime_policy",
+    "dry_run_result",
+    "artifacts"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackRuntimeDryRunRecord" },
+    "schema_version": { "const": "v0.1" },
+    "status": { "enum": ["passed", "failed"] },
+    "bundle_id": { "type": "string", "minLength": 1 },
+    "version": { "type": "string", "minLength": 1 },
+    "namespace": { "type": "string", "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$" },
+    "runtime_adapter_ref": { "type": "string", "minLength": 1 },
+    "runtime_adapter_digest": { "$ref": "#/$defs/sha256_digest" },
+    "deploy_plan_ref": { "type": "string", "minLength": 1 },
+    "deploy_plan_digest": { "$ref": "#/$defs/sha256_digest" },
+    "cluster_readiness_record_ref": { "type": "string", "minLength": 1 },
+    "cluster_readiness_record_digest": { "$ref": "#/$defs/sha256_digest" },
+    "gitops_bundle_ref": { "type": "string", "minLength": 1 },
+    "gitops_bundle_digest": { "$ref": "#/$defs/sha256_digest" },
+    "gitops_readiness_record_ref": { "type": "string", "minLength": 1 },
+    "gitops_readiness_record_digest": { "$ref": "#/$defs/sha256_digest" },
+    "kubernetes_manifests": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/artifact" },
+      "minItems": 3
+    },
+    "runtime_policy": {
+      "type": "object",
+      "required": ["live_apply_allowed", "requires_human_approval", "network_default", "secrets_default"],
+      "properties": {
+        "live_apply_allowed": { "const": false },
+        "requires_human_approval": { "const": true },
+        "network_default": { "const": "deny" },
+        "secrets_default": { "const": "deny" }
+      },
+      "additionalProperties": false
+    },
+    "dry_run_result": {
+      "type": "object",
+      "required": ["mode", "mutated_cluster", "validated_inputs", "validation_path"],
+      "properties": {
+        "mode": { "const": "dry-run" },
+        "mutated_cluster": { "const": false },
+        "validated_inputs": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        },
+        "validation_path": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "artifacts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/artifact" },
+      "minItems": 1
+    }
+  },
+  "$defs": {
+    "sha256_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "artifact": {
+      "type": "object",
+      "required": ["id", "ref", "digest"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "ref": { "type": "string", "minLength": 1 },
+        "digest": { "$ref": "#/$defs/sha256_digest" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/emit_fogstack_runtime_dry_run_record.py
+++ b/tools/emit_fogstack_runtime_dry_run_record.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def artifact(artifact_id: str, path: Path) -> dict[str, str]:
+    path = resolve(path)
+    return {"id": artifact_id, "ref": rel(path), "digest": sha256_file(path)}
+
+
+def require_digest(path: Path, expected: str, label: str) -> None:
+    actual = sha256_file(path)
+    if actual != expected:
+        raise SystemExit(f"ERR: {label} digest mismatch")
+
+
+def emit_record(adapter_path: Path, manifest_dir: Path, output_path: Path) -> dict[str, Any]:
+    adapter_path = resolve(adapter_path)
+    manifest_dir = resolve(manifest_dir)
+    output_path = resolve(output_path)
+    adapter = load_json(adapter_path)
+    if adapter.get("kind") != "FogStackLocalClusterRuntimeAdapter":
+        raise SystemExit("ERR: expected FogStackLocalClusterRuntimeAdapter")
+    if adapter["adapter"]["mode"] != "dry-run":
+        raise SystemExit("ERR: runtime adapter must be in dry-run mode")
+    if adapter["runtime_policy"]["live_apply_allowed"] is not False:
+        raise SystemExit("ERR: live apply must be disabled for dry-run record")
+
+    inputs = adapter["inputs"]
+    deploy_plan_path = resolve(Path(inputs["deploy_plan_ref"]))
+    cluster_record_path = resolve(Path(inputs["cluster_readiness_record_ref"]))
+    gitops_bundle_path = resolve(Path(inputs["gitops_bundle_ref"]))
+    gitops_readiness_path = resolve(Path(inputs["gitops_readiness_record_ref"]))
+    require_digest(deploy_plan_path, inputs["deploy_plan_digest"], "deploy plan")
+    require_digest(cluster_record_path, inputs["cluster_readiness_record_digest"], "cluster readiness record")
+    require_digest(gitops_bundle_path, inputs["gitops_bundle_digest"], "GitOps bundle")
+    require_digest(gitops_readiness_path, inputs["gitops_readiness_record_digest"], "GitOps readiness record")
+
+    deploy_plan = load_json(deploy_plan_path)
+    cluster_record = load_json(cluster_record_path)
+    gitops_bundle = load_json(gitops_bundle_path)
+    gitops_readiness = load_json(gitops_readiness_path)
+    if deploy_plan.get("bundle_id") != adapter["bundle_id"] or deploy_plan.get("version") != adapter["version"]:
+        raise SystemExit("ERR: deploy plan does not match adapter bundle/version")
+    if cluster_record.get("status") != "passed":
+        raise SystemExit("ERR: cluster readiness record must have passed status")
+    if gitops_bundle.get("bundle_id") != adapter["bundle_id"] or gitops_bundle.get("version") != adapter["version"]:
+        raise SystemExit("ERR: GitOps bundle does not match adapter bundle/version")
+    if gitops_readiness.get("status") != "passed":
+        raise SystemExit("ERR: GitOps readiness record must have passed status")
+
+    manifest_paths = [
+        manifest_dir / "configmap.yaml",
+        manifest_dir / "deployment.yaml",
+        manifest_dir / "service.yaml",
+    ]
+    for path in manifest_paths:
+        if not path.exists() or not path.is_file():
+            raise SystemExit(f"ERR: Kubernetes manifest missing: {path}")
+
+    record = {
+        "kind": "FogStackRuntimeDryRunRecord",
+        "schema_version": "v0.1",
+        "status": "passed",
+        "bundle_id": adapter["bundle_id"],
+        "version": adapter["version"],
+        "namespace": adapter["namespace"],
+        "runtime_adapter_ref": rel(adapter_path),
+        "runtime_adapter_digest": sha256_file(adapter_path),
+        "deploy_plan_ref": rel(deploy_plan_path),
+        "deploy_plan_digest": sha256_file(deploy_plan_path),
+        "cluster_readiness_record_ref": rel(cluster_record_path),
+        "cluster_readiness_record_digest": sha256_file(cluster_record_path),
+        "gitops_bundle_ref": rel(gitops_bundle_path),
+        "gitops_bundle_digest": sha256_file(gitops_bundle_path),
+        "gitops_readiness_record_ref": rel(gitops_readiness_path),
+        "gitops_readiness_record_digest": sha256_file(gitops_readiness_path),
+        "kubernetes_manifests": [
+            artifact("kubernetes-configmap", manifest_paths[0]),
+            artifact("kubernetes-deployment", manifest_paths[1]),
+            artifact("kubernetes-service", manifest_paths[2]),
+        ],
+        "runtime_policy": adapter["runtime_policy"],
+        "dry_run_result": {
+            "mode": "dry-run",
+            "mutated_cluster": False,
+            "validated_inputs": [
+                "runtime_adapter",
+                "deploy_plan",
+                "cluster_readiness_record",
+                "gitops_bundle",
+                "gitops_readiness_record",
+                "kubernetes_manifests",
+            ],
+            "validation_path": "contract-and-digest-only",
+        },
+        "artifacts": [
+            artifact("runtime-adapter", adapter_path),
+            artifact("deploy-plan", deploy_plan_path),
+            artifact("cluster-readiness-record", cluster_record_path),
+            artifact("gitops-bundle", gitops_bundle_path),
+            artifact("gitops-readiness-record", gitops_readiness_path),
+            artifact("kubernetes-configmap", manifest_paths[0]),
+            artifact("kubernetes-deployment", manifest_paths[1]),
+            artifact("kubernetes-service", manifest_paths[2]),
+        ],
+    }
+    write_json(output_path, record)
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a FogStack runtime dry-run record")
+    parser.add_argument("--runtime-adapter", required=True, type=Path)
+    parser.add_argument("--manifest-dir", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    record = emit_record(args.runtime_adapter, args.manifest_dir, args.output)
+    print(json.dumps(record, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_runtime_dry_run_record.py
+++ b/tools/tests/test_fogstack_runtime_dry_run_record.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+MANIFEST = Path("releases/manifests/fogstack.access-v0.1.manifest.json")
+SCHEMA = Path("schemas/runtime/fogstack-runtime-dry-run-record-v0.1.schema.json")
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def build_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    contract = tmp_path / "runtime-contract.json"
+    deploy_plan = tmp_path / "deploy-plan.json"
+    manifests = tmp_path / "manifests"
+    cluster_record = tmp_path / "cluster-readiness.json"
+    gitops_dir = tmp_path / "gitops"
+    gitops_record = tmp_path / "gitops-readiness.json"
+    adapter = tmp_path / "runtime-adapter.json"
+    subprocess.run([sys.executable, "tools/build_fogstack_runtime_contract.py", "--bundle-id", "fogstack.access", "--version", "0.1.0", "--actor-id", "agent:fogstack.access.operator", "--human-anchor-role", "operator", "--output", str(contract)], check=True)
+    subprocess.run([sys.executable, "tools/build_fogstack_deploy_plan.py", "--manifest", str(MANIFEST), "--profile", "local-dev", "--target", "kubernetes", "--namespace", "fogstack-access", "--health-endpoint", "/healthz", "--runtime-contract", str(contract), "--output", str(deploy_plan)], check=True)
+    subprocess.run([sys.executable, "tools/render_fogstack_kubernetes_manifests.py", "--deploy-plan", str(deploy_plan), "--output-dir", str(manifests)], check=True)
+    subprocess.run([sys.executable, "tools/check_fogstack_kubernetes_manifests.py", "--deploy-plan", str(deploy_plan), "--manifest-dir", str(manifests), "--record-output", str(cluster_record)], check=True)
+    subprocess.run([sys.executable, "tools/build_fogstack_gitops_bundle.py", "--deploy-plan", str(deploy_plan), "--manifest-dir", str(manifests), "--output-dir", str(gitops_dir)], check=True)
+    subprocess.run([sys.executable, "tools/check_fogstack_gitops_bundle.py", "--bundle", str(gitops_dir / "gitops-bundle.json")], check=True)
+    subprocess.run([sys.executable, "tools/emit_fogstack_gitops_readiness_record.py", "--bundle", str(gitops_dir / "gitops-bundle.json"), "--output", str(gitops_record)], check=True)
+    subprocess.run([sys.executable, "tools/build_fogstack_local_cluster_runtime_adapter.py", "--deploy-plan", str(deploy_plan), "--cluster-readiness-record", str(cluster_record), "--gitops-bundle", str(gitops_dir / "gitops-bundle.json"), "--gitops-readiness-record", str(gitops_record), "--output", str(adapter)], check=True)
+    return adapter, manifests
+
+
+def test_emit_fogstack_runtime_dry_run_record(tmp_path: Path) -> None:
+    adapter, manifests = build_inputs(tmp_path)
+    output = tmp_path / "runtime-dry-run.json"
+    subprocess.run([sys.executable, "tools/emit_fogstack_runtime_dry_run_record.py", "--runtime-adapter", str(adapter), "--manifest-dir", str(manifests), "--output", str(output)], check=True)
+    record = load_json(output)
+    Draft202012Validator(load_json(SCHEMA)).validate(record)
+    assert record["kind"] == "FogStackRuntimeDryRunRecord"
+    assert record["status"] == "passed"
+    assert record["bundle_id"] == "fogstack.access"
+    assert record["namespace"] == "fogstack-access"
+    assert record["dry_run_result"]["mutated_cluster"] is False
+    assert record["dry_run_result"]["validation_path"] == "contract-and-digest-only"
+    assert record["runtime_policy"]["live_apply_allowed"] is False
+    assert len(record["kubernetes_manifests"]) == 3
+    assert {artifact["id"] for artifact in record["artifacts"]} == {"runtime-adapter", "deploy-plan", "cluster-readiness-record", "gitops-bundle", "gitops-readiness-record", "kubernetes-configmap", "kubernetes-deployment", "kubernetes-service"}
+
+
+def test_emit_fogstack_runtime_dry_run_record_rejects_tampered_input(tmp_path: Path) -> None:
+    adapter, manifests = build_inputs(tmp_path)
+    data = load_json(adapter)
+    data["inputs"]["deploy_plan_digest"] = "sha256:" + ("0" * 64)
+    adapter.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    output = tmp_path / "runtime-dry-run.json"
+    proc = subprocess.run([sys.executable, "tools/emit_fogstack_runtime_dry_run_record.py", "--runtime-adapter", str(adapter), "--manifest-dir", str(manifests), "--output", str(output)], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert "deploy plan digest mismatch" in proc.stderr


### PR DESCRIPTION
Turn 20 of the deploy/runtime parity lane.

Adds FogStackRuntimeDryRunRecord schema and emitter. The record proves non-mutating runtime dry-run validation over the runtime adapter, deploy plan, Kubernetes manifests, GitOps bundle, cluster-readiness record, and GitOps readiness record.

Files:
- schemas/runtime/fogstack-runtime-dry-run-record-v0.1.schema.json
- tools/emit_fogstack_runtime_dry_run_record.py
- tools/tests/test_fogstack_runtime_dry_run_record.py
- .github/workflows/fogstack-local-cluster-runtime.yml

Parity plan counter: Turn 20 / 32 toward credible MVP IBM-style parity.