### PR TITLE
fogstack: index runtime evidence in local demo

### DIFF
--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -10,6 +10,7 @@ on:
       - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
       - "catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml"
       - "catalog/fogstack-release-publication-gate-policy-v0.1.yaml"
+      - "schemas/runtime/**"
       - "schemas/gitops/**"
       - "releases/manifests/**"
       - "Makefile"
@@ -17,6 +18,7 @@ on:
       - "tools/run_fogstack_local_demo_deploy_plan.py"
       - "tools/update_fogstack_local_demo_deploy_artifacts.py"
       - "tools/update_fogstack_local_demo_gitops_readiness.py"
+      - "tools/update_fogstack_local_demo_runtime_evidence.py"
       - "tools/run_fogstack_local_demo_full.py"
       - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
@@ -29,6 +31,8 @@ on:
       - "tools/build_fogstack_gitops_bundle.py"
       - "tools/check_fogstack_gitops_bundle.py"
       - "tools/emit_fogstack_gitops_readiness_record.py"
+      - "tools/build_fogstack_local_cluster_runtime_adapter.py"
+      - "tools/emit_fogstack_runtime_dry_run_record.py"
       - "tools/fogstack_verify.py"
       - "tools/emit_fogstack_validation_record.py"
       - "tools/build_fogstack_manifest_publication_set.py"
@@ -61,6 +65,7 @@ on:
       - "catalog/fogstack-manifest-promotion-policy-v0.1.yaml"
       - "catalog/fogstack-manifest-promotion-approver-policy-v0.1.yaml"
       - "catalog/fogstack-release-publication-gate-policy-v0.1.yaml"
+      - "schemas/runtime/**"
       - "schemas/gitops/**"
       - "releases/manifests/**"
       - "Makefile"
@@ -68,6 +73,7 @@ on:
       - "tools/run_fogstack_local_demo_deploy_plan.py"
       - "tools/update_fogstack_local_demo_deploy_artifacts.py"
       - "tools/update_fogstack_local_demo_gitops_readiness.py"
+      - "tools/update_fogstack_local_demo_runtime_evidence.py"
       - "tools/run_fogstack_local_demo_full.py"
       - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
@@ -80,6 +86,8 @@ on:
       - "tools/build_fogstack_gitops_bundle.py"
       - "tools/check_fogstack_gitops_bundle.py"
       - "tools/emit_fogstack_gitops_readiness_record.py"
+      - "tools/build_fogstack_local_cluster_runtime_adapter.py"
+      - "tools/emit_fogstack_runtime_dry_run_record.py"
       - "tools/tests/test_run_fogstack_local_demo.py"
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
@@ -128,6 +136,8 @@ jobs:
           test -s build/fogstack-local-demo/deploy/gitops/application.yaml
           test -s build/fogstack-local-demo/deploy/gitops/kustomization.yaml
           test -s build/fogstack-local-demo/deploy/fogstack.access.gitops-readiness.record.json
+          test -s build/fogstack-local-demo/deploy/fogstack.access.local-cluster-runtime-adapter.json
+          test -s build/fogstack-local-demo/deploy/fogstack.access.runtime-dry-run.record.json
 
       - name: Check generated artifact index
         run: |

--- a/tools/run_fogstack_local_demo_deploy_plan.py
+++ b/tools/run_fogstack_local_demo_deploy_plan.py
@@ -37,6 +37,8 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
     manifest_dir = output_dir / "kubernetes"
     gitops_dir = output_dir / "gitops"
     gitops_readiness_record = output_dir / "fogstack.access.gitops-readiness.record.json"
+    runtime_adapter = output_dir / "fogstack.access.local-cluster-runtime-adapter.json"
+    runtime_dry_run_record = output_dir / "fogstack.access.runtime-dry-run.record.json"
     check_record = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
     readiness_record = output_dir / "fogstack.access.cluster-readiness.record.json"
     summary_path = output_dir / "fogstack.access.deploy-demo.summary.json"
@@ -115,6 +117,22 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
         "--checker-status", "passed",
         "--checker-message", gitops_check.stdout.strip(),
     ])
+    run([
+        sys.executable,
+        "tools/build_fogstack_local_cluster_runtime_adapter.py",
+        "--deploy-plan", str(deploy_plan),
+        "--cluster-readiness-record", str(readiness_record),
+        "--gitops-bundle", str(gitops_dir / "gitops-bundle.json"),
+        "--gitops-readiness-record", str(gitops_readiness_record),
+        "--output", str(runtime_adapter),
+    ])
+    run([
+        sys.executable,
+        "tools/emit_fogstack_runtime_dry_run_record.py",
+        "--runtime-adapter", str(runtime_adapter),
+        "--manifest-dir", str(manifest_dir),
+        "--output", str(runtime_dry_run_record),
+    ])
 
     manifests = [
         manifest_dir / "configmap.yaml",
@@ -160,6 +178,8 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
             "gitops_deployment": rel(gitops_dir / "manifests" / "deployment.yaml"),
             "gitops_service": rel(gitops_dir / "manifests" / "service.yaml"),
             "gitops_readiness_record": rel(gitops_readiness_record),
+            "runtime_adapter": rel(runtime_adapter),
+            "runtime_dry_run_record": rel(runtime_dry_run_record),
             "summary": rel(summary_path),
         },
         "checks": [
@@ -173,6 +193,8 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
             "gitops_bundle_built",
             "gitops_bundle_checked",
             "gitops_readiness_record_emitted",
+            "runtime_adapter_built",
+            "runtime_dry_run_record_emitted",
         ],
     }
     write_json(summary_path, summary)
@@ -195,6 +217,8 @@ def render_summary(summary: dict[str, Any]) -> str:
         f"GitOps bundle: {artifacts['gitops_bundle']}",
         f"GitOps application: {artifacts['gitops_application']}",
         f"GitOps readiness record: {artifacts['gitops_readiness_record']}",
+        f"Runtime adapter: {artifacts['runtime_adapter']}",
+        f"Runtime dry-run record: {artifacts['runtime_dry_run_record']}",
         f"Checks passed: {len(summary['checks'])}",
     ]
     return "\n".join(lines) + "\n"

--- a/tools/run_fogstack_local_demo_full.py
+++ b/tools/run_fogstack_local_demo_full.py
@@ -39,6 +39,8 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
     summary_path = output_dir / "fogstack-local-demo.summary.json"
     deploy_summary_path = deploy_dir / "fogstack.access.deploy-demo.summary.json"
     gitops_readiness_path = deploy_dir / "fogstack.access.gitops-readiness.record.json"
+    runtime_adapter_path = deploy_dir / "fogstack.access.local-cluster-runtime-adapter.json"
+    runtime_dry_run_path = deploy_dir / "fogstack.access.runtime-dry-run.record.json"
     artifact_index_path = output_dir / "demo-artifacts.index.json"
     full_summary_path = output_dir / "fogstack-local-demo.full.summary.json"
 
@@ -76,6 +78,16 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
     ])
     run([
         sys.executable,
+        "tools/update_fogstack_local_demo_runtime_evidence.py",
+        "--summary-json",
+        str(summary_path),
+        "--runtime-adapter",
+        str(runtime_adapter_path),
+        "--runtime-dry-run-record",
+        str(runtime_dry_run_path),
+    ])
+    run([
+        sys.executable,
         "tools/check_fogstack_local_demo_artifact_index.py",
         "--index",
         str(artifact_index_path),
@@ -106,6 +118,8 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
             "gitops_deployment": rel(deploy_dir / "gitops" / "manifests" / "deployment.yaml"),
             "gitops_service": rel(deploy_dir / "gitops" / "manifests" / "service.yaml"),
             "gitops_readiness_record": rel(gitops_readiness_path),
+            "runtime_adapter": rel(runtime_adapter_path),
+            "runtime_dry_run_record": rel(runtime_dry_run_path),
         },
         "checks": [
             "local_demo_generated",
@@ -114,6 +128,8 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
             "cluster_readiness_record_indexed",
             "gitops_bundle_indexed",
             "gitops_readiness_record_indexed",
+            "runtime_adapter_indexed",
+            "runtime_dry_run_record_indexed",
             "artifact_index_checked",
         ],
     }
@@ -134,6 +150,8 @@ def render_summary(summary: dict[str, Any]) -> str:
         f"GitOps bundle: {artifacts['gitops_bundle']}",
         f"GitOps application: {artifacts['gitops_application']}",
         f"GitOps readiness record: {artifacts['gitops_readiness_record']}",
+        f"Runtime adapter: {artifacts['runtime_adapter']}",
+        f"Runtime dry-run record: {artifacts['runtime_dry_run_record']}",
         f"Checks passed: {len(summary['checks'])}",
     ]
     return "\n".join(lines) + "\n"

--- a/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
+++ b/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
@@ -30,12 +30,16 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert "GitOps bundle:" in proc.stdout
     assert "GitOps application:" in proc.stdout
     assert "GitOps readiness record:" in proc.stdout
-    assert "Checks passed: 10" in proc.stdout
+    assert "Runtime adapter:" in proc.stdout
+    assert "Runtime dry-run record:" in proc.stdout
+    assert "Checks passed: 12" in proc.stdout
 
     summary_path = output_dir / "fogstack.access.deploy-demo.summary.json"
     check_record_path = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
     readiness_record_path = output_dir / "fogstack.access.cluster-readiness.record.json"
     gitops_readiness_path = output_dir / "fogstack.access.gitops-readiness.record.json"
+    runtime_adapter_path = output_dir / "fogstack.access.local-cluster-runtime-adapter.json"
+    runtime_dry_run_path = output_dir / "fogstack.access.runtime-dry-run.record.json"
     runtime_contract_path = output_dir / "fogstack.access.runtime-contract.json"
     deploy_plan_path = output_dir / "fogstack.access.deploy-plan.json"
     manifest_dir = output_dir / "kubernetes"
@@ -46,6 +50,8 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
         check_record_path,
         readiness_record_path,
         gitops_readiness_path,
+        runtime_adapter_path,
+        runtime_dry_run_path,
         runtime_contract_path,
         deploy_plan_path,
         manifest_dir / "configmap.yaml",
@@ -76,6 +82,8 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
         "gitops_bundle_built",
         "gitops_bundle_checked",
         "gitops_readiness_record_emitted",
+        "runtime_adapter_built",
+        "runtime_dry_run_record_emitted",
     }
 
     artifacts = summary["artifacts"]
@@ -91,6 +99,8 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert artifacts["gitops_kustomization"].endswith("kustomization.yaml")
     assert artifacts["gitops_deployment"].endswith("deployment.yaml")
     assert artifacts["gitops_readiness_record"].endswith("fogstack.access.gitops-readiness.record.json")
+    assert artifacts["runtime_adapter"].endswith("fogstack.access.local-cluster-runtime-adapter.json")
+    assert artifacts["runtime_dry_run_record"].endswith("fogstack.access.runtime-dry-run.record.json")
 
     check_record = json.loads(check_record_path.read_text(encoding="utf-8"))
     assert check_record["kind"] == "FogStackKubernetesManifestCheckRecord"
@@ -113,6 +123,15 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert gitops_readiness["kind"] == "FogStackGitOpsReadinessRecord"
     assert gitops_readiness["status"] == "passed"
     assert gitops_readiness["validation_result"]["bundle_validated"] is True
+
+    runtime_adapter = json.loads(runtime_adapter_path.read_text(encoding="utf-8"))
+    assert runtime_adapter["kind"] == "FogStackLocalClusterRuntimeAdapter"
+    assert runtime_adapter["runtime_policy"]["live_apply_allowed"] is False
+
+    runtime_dry_run = json.loads(runtime_dry_run_path.read_text(encoding="utf-8"))
+    assert runtime_dry_run["kind"] == "FogStackRuntimeDryRunRecord"
+    assert runtime_dry_run["status"] == "passed"
+    assert runtime_dry_run["dry_run_result"]["mutated_cluster"] is False
 
     deployment = yaml.safe_load((manifest_dir / "deployment.yaml").read_text(encoding="utf-8"))
     assert deployment["kind"] == "Deployment"

--- a/tools/tests/test_run_fogstack_local_demo_full.py
+++ b/tools/tests/test_run_fogstack_local_demo_full.py
@@ -26,6 +26,8 @@ REQUIRED_FULL_ARTIFACTS = {
     "gitops_deployment",
     "gitops_service",
     "gitops_readiness_record",
+    "runtime_adapter",
+    "runtime_dry_run_record",
 }
 
 
@@ -52,6 +54,8 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert "GitOps bundle:" in proc.stdout
     assert "GitOps application:" in proc.stdout
     assert "GitOps readiness record:" in proc.stdout
+    assert "Runtime adapter:" in proc.stdout
+    assert "Runtime dry-run record:" in proc.stdout
 
     full_summary_path = output_dir / "fogstack-local-demo.full.summary.json"
     assert full_summary_path.exists()
@@ -62,6 +66,8 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert "cluster_readiness_record_indexed" in full_summary["checks"]
     assert "gitops_bundle_indexed" in full_summary["checks"]
     assert "gitops_readiness_record_indexed" in full_summary["checks"]
+    assert "runtime_adapter_indexed" in full_summary["checks"]
+    assert "runtime_dry_run_record_indexed" in full_summary["checks"]
     for ref in full_summary["artifacts"].values():
         assert Path(ref).exists(), ref
 
@@ -77,6 +83,14 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert gitops_readiness["kind"] == "FogStackGitOpsReadinessRecord"
     assert gitops_readiness["status"] == "passed"
 
+    runtime_adapter = json.loads(Path(full_summary["artifacts"]["runtime_adapter"]).read_text(encoding="utf-8"))
+    assert runtime_adapter["kind"] == "FogStackLocalClusterRuntimeAdapter"
+    assert runtime_adapter["runtime_policy"]["live_apply_allowed"] is False
+
+    runtime_dry_run = json.loads(Path(full_summary["artifacts"]["runtime_dry_run_record"]).read_text(encoding="utf-8"))
+    assert runtime_dry_run["kind"] == "FogStackRuntimeDryRunRecord"
+    assert runtime_dry_run["dry_run_result"]["mutated_cluster"] is False
+
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed_ids = {entry["id"] for entry in artifact_index["artifacts"]}
     assert "deploy_plan" in indexed_ids
@@ -87,14 +101,19 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert "deploy_gitops_application" in indexed_ids
     assert "deploy_gitops_deployment" in indexed_ids
     assert "deploy_gitops_readiness_record" in indexed_ids
+    assert "deploy_runtime_adapter" in indexed_ids
+    assert "deploy_runtime_dry_run_record" in indexed_ids
 
     html = (output_dir / "index.html").read_text(encoding="utf-8")
     assert "Deploy readiness" in html
     assert "GitOps readiness" in html
+    assert "Runtime evidence" in html
     assert "SHA-256 digest" in html
     assert "indexed" in html
     assert "deploy_plan" in html
     assert "deploy_cluster_readiness_record" in html
     assert "deploy_gitops_bundle" in html
     assert "deploy_gitops_readiness_record" in html
+    assert "deploy_runtime_adapter" in html
+    assert "deploy_runtime_dry_run_record" in html
     assert "fogstack.access.deploy-plan.json" in html

--- a/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
@@ -21,6 +21,8 @@ REQUIRED = {
     "deploy_gitops_deployment",
     "deploy_gitops_service",
     "deploy_gitops_readiness_record",
+    "deploy_runtime_adapter",
+    "deploy_runtime_dry_run_record",
     "deploy_summary",
 }
 
@@ -32,6 +34,7 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     subprocess.run([sys.executable, "tools/run_fogstack_local_demo_deploy_plan.py", "--output-dir", str(deploy_dir)], check=True)
     subprocess.run([sys.executable, "tools/update_fogstack_local_demo_deploy_artifacts.py", "--summary-json", str(output_dir / "fogstack-local-demo.summary.json"), "--deploy-summary-json", str(deploy_dir / "fogstack.access.deploy-demo.summary.json")], check=True)
     subprocess.run([sys.executable, "tools/update_fogstack_local_demo_gitops_readiness.py", "--summary-json", str(output_dir / "fogstack-local-demo.summary.json"), "--gitops-readiness-record", str(deploy_dir / "fogstack.access.gitops-readiness.record.json")], check=True)
+    subprocess.run([sys.executable, "tools/update_fogstack_local_demo_runtime_evidence.py", "--summary-json", str(output_dir / "fogstack-local-demo.summary.json"), "--runtime-adapter", str(deploy_dir / "fogstack.access.local-cluster-runtime-adapter.json"), "--runtime-dry-run-record", str(deploy_dir / "fogstack.access.runtime-dry-run.record.json")], check=True)
 
     summary = json.loads((output_dir / "fogstack-local-demo.summary.json").read_text(encoding="utf-8"))
     assert REQUIRED.issubset(set(summary["artifacts"]))
@@ -41,6 +44,8 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     assert "gitops_bundle_built" in summary["checks"]
     assert "gitops_bundle_checked" in summary["checks"]
     assert "gitops_readiness_record_indexed" in summary["checks"]
+    assert "runtime_adapter_indexed" in summary["checks"]
+    assert "runtime_dry_run_record_indexed" in summary["checks"]
 
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed = {entry["id"]: entry for entry in artifact_index["artifacts"]}
@@ -61,11 +66,20 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     assert gitops_readiness["kind"] == "FogStackGitOpsReadinessRecord"
     assert gitops_readiness["status"] == "passed"
 
+    runtime_adapter = json.loads(Path(summary["artifacts"]["deploy_runtime_adapter"]).read_text(encoding="utf-8"))
+    assert runtime_adapter["kind"] == "FogStackLocalClusterRuntimeAdapter"
+    assert runtime_adapter["runtime_policy"]["live_apply_allowed"] is False
+
+    runtime_dry_run = json.loads(Path(summary["artifacts"]["deploy_runtime_dry_run_record"]).read_text(encoding="utf-8"))
+    assert runtime_dry_run["kind"] == "FogStackRuntimeDryRunRecord"
+    assert runtime_dry_run["dry_run_result"]["mutated_cluster"] is False
+
     markdown = (output_dir / "fogstack-local-demo.summary.md").read_text(encoding="utf-8")
     html = (output_dir / "index.html").read_text(encoding="utf-8")
     for content in [markdown, html]:
         assert "Deploy readiness" in content
         assert "GitOps readiness" in content
+        assert "Runtime evidence" in content
         assert "Artifact ID" in content
         assert "SHA-256 digest" in content
         assert "indexed" in content
@@ -75,4 +89,6 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
         assert "deploy_gitops_bundle" in content
         assert "deploy_gitops_application" in content
         assert "deploy_gitops_readiness_record" in content
+        assert "deploy_runtime_adapter" in content
+        assert "deploy_runtime_dry_run_record" in content
         assert "sha256:" in content

--- a/tools/update_fogstack_local_demo_runtime_evidence.py
+++ b/tools/update_fogstack_local_demo_runtime_evidence.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACTS = {
+    "deploy_runtime_adapter": "Runtime adapter",
+    "deploy_runtime_dry_run_record": "Runtime dry-run record",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def path_from_ref(ref: str) -> Path:
+    path = Path(ref)
+    return path if path.is_absolute() else ROOT / path
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def refresh_index(index_path: Path, refs_by_id: dict[str, str]) -> None:
+    index = load_json(index_path)
+    by_id = {entry["id"]: entry for entry in index.get("artifacts", []) if isinstance(entry, dict) and entry.get("id")}
+    for artifact_id, artifact_ref in refs_by_id.items():
+        by_id[artifact_id] = {"id": artifact_id, "ref": artifact_ref}
+
+    refreshed = []
+    for artifact_id in sorted(by_id):
+        entry = by_id[artifact_id]
+        ref = entry.get("ref")
+        if not isinstance(ref, str) or not ref:
+            continue
+        path = path_from_ref(ref)
+        if not path.exists() or not path.is_file():
+            raise SystemExit(f"ERR: indexed artifact missing while refreshing: {ref}")
+        refreshed.append({
+            "id": artifact_id,
+            "ref": ref,
+            "digest": sha256_file(path),
+            "size_bytes": path.stat().st_size,
+        })
+    index["artifacts"] = refreshed
+    write_json(index_path, index)
+
+
+def append_markdown(markdown_path: Path, refs_by_id: dict[str, str]) -> None:
+    rows = []
+    for artifact_id, label in ARTIFACTS.items():
+        ref = refs_by_id[artifact_id]
+        digest = sha256_file(path_from_ref(ref))
+        rows.append(f"| `{artifact_id}` | {label} | `{ref}` | `{digest}` | `indexed` |")
+    section = "\n".join([
+        "",
+        "## Runtime evidence",
+        "",
+        "| Artifact ID | Artifact | Ref | SHA-256 digest | Status |",
+        "|---|---|---|---|---|",
+        *rows,
+        "",
+    ])
+    markdown_path.write_text(markdown_path.read_text(encoding="utf-8") + section, encoding="utf-8")
+
+
+def append_html(html_path: Path, refs_by_id: dict[str, str]) -> None:
+    rows = []
+    for artifact_id, label in ARTIFACTS.items():
+        ref = refs_by_id[artifact_id]
+        digest = sha256_file(path_from_ref(ref))
+        rows.append(
+            f"<tr><td><code>{html.escape(artifact_id)}</code></td>"
+            f"<td>{html.escape(label)}</td>"
+            f"<td><code>{html.escape(ref)}</code></td>"
+            f"<td><code>{html.escape(digest)}</code></td>"
+            "<td>indexed</td></tr>"
+        )
+    section = f"""
+    <h2>Runtime evidence</h2>
+    <table>
+      <thead><tr><th>Artifact ID</th><th>Artifact</th><th>Ref</th><th>SHA-256 digest</th><th>Status</th></tr></thead>
+      <tbody>
+        {' '.join(rows)}
+      </tbody>
+    </table>
+"""
+    html_text = html_path.read_text(encoding="utf-8")
+    html_path.write_text(html_text.replace("\n  </main>", section + "\n  </main>"), encoding="utf-8")
+
+
+def update(summary_path: Path, runtime_adapter: Path, runtime_dry_run: Path) -> dict[str, Any]:
+    summary = load_json(summary_path)
+    refs_by_id = {
+        "deploy_runtime_adapter": rel(runtime_adapter if runtime_adapter.is_absolute() else ROOT / runtime_adapter),
+        "deploy_runtime_dry_run_record": rel(runtime_dry_run if runtime_dry_run.is_absolute() else ROOT / runtime_dry_run),
+    }
+    for ref in refs_by_id.values():
+        path = path_from_ref(ref)
+        if not path.exists() or not path.is_file():
+            raise SystemExit(f"ERR: runtime evidence artifact missing: {ref}")
+
+    artifacts = summary.setdefault("artifacts", {})
+    artifacts.update(refs_by_id)
+    checks = summary.setdefault("checks", [])
+    for check in ["runtime_adapter_indexed", "runtime_dry_run_record_indexed"]:
+        if check not in checks:
+            checks.append(check)
+    write_json(summary_path, summary)
+
+    append_markdown(path_from_ref(artifacts["summary_markdown"]), refs_by_id)
+    append_html(path_from_ref(artifacts["summary_html"]), refs_by_id)
+    refresh_index(path_from_ref(artifacts["artifact_index"]), refs_by_id)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Add runtime evidence to a FogStack local demo")
+    parser.add_argument("--summary-json", type=Path, default=Path("build/fogstack-local-demo/fogstack-local-demo.summary.json"))
+    parser.add_argument("--runtime-adapter", type=Path, default=Path("build/fogstack-local-demo/deploy/fogstack.access.local-cluster-runtime-adapter.json"))
+    parser.add_argument("--runtime-dry-run-record", type=Path, default=Path("build/fogstack-local-demo/deploy/fogstack.access.runtime-dry-run.record.json"))
+    args = parser.parse_args()
+    summary_path = args.summary_json if args.summary_json.is_absolute() else ROOT / args.summary_json
+    adapter_path = args.runtime_adapter if args.runtime_adapter.is_absolute() else ROOT / args.runtime_adapter
+    dry_run_path = args.runtime_dry_run_record if args.runtime_dry_run_record.is_absolute() else ROOT / args.runtime_dry_run_record
+    update(summary_path, adapter_path, dry_run_path)
+    print(json.dumps({"kind": "FogStackLocalDemoRuntimeEvidenceUpdate", "status": "passed", "artifact_ids": sorted(ARTIFACTS)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Turn 21 of the deploy/runtime parity lane.

Indexes runtime adapter and runtime dry-run evidence in the full local demo artifact index and operator summaries. This remains non-mutating and keeps live cluster apply disabled.

Files:
- tools/run_fogstack_local_demo_deploy_plan.py
- tools/run_fogstack_local_demo_full.py
- tools/update_fogstack_local_demo_runtime_evidence.py
- local demo tests
- .github/workflows/fogstack-local-demo.yml

Parity plan counter: Turn 21 / 32 toward credible MVP IBM-style parity.