### PR TITLE
fogstack: add Agent Machine node profile contract

### DIFF
--- a/.github/workflows/fogstack-agent-machine-node-profile.yml
+++ b/.github/workflows/fogstack-agent-machine-node-profile.yml
@@ -1,0 +1,58 @@
+name: FogStack Agent Machine Node Profile
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "schemas/runtime/fogstack-agent-machine-node-profile-v0.1.schema.json"
+      - "tools/build_fogstack_agent_machine_node_profile.py"
+      - "tools/tests/test_fogstack_agent_machine_node_profile.py"
+      - ".github/workflows/fogstack-agent-machine-node-profile.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/runtime/fogstack-agent-machine-node-profile-v0.1.schema.json"
+      - "tools/build_fogstack_agent_machine_node_profile.py"
+      - "tools/tests/test_fogstack_agent_machine_node_profile.py"
+      - ".github/workflows/fogstack-agent-machine-node-profile.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  agent-machine-node-profile:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest jsonschema
+
+      - name: Run Agent Machine node profile tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_agent_machine_node_profile.py
+
+      - name: Build sample node profiles
+        run: |
+          python3 tools/build_fogstack_agent_machine_node_profile.py \
+            --output build/fogstack-node-profile/sourceos-agent-machine-node-profile.json
+          python3 tools/build_fogstack_agent_machine_node_profile.py \
+            --output build/fogstack-node-profile/agentos-agent-machine-node-profile.json \
+            --os-family AgentOS \
+            --distribution AgentOS-Linux \
+            --immutability ostree \
+            --configuration-model rpm-ostree \
+            --image-builder rpm-ostree \
+            --update-strategy ostree-rebase \
+            --no-topolvm
+          test -s build/fogstack-node-profile/sourceos-agent-machine-node-profile.json
+          test -s build/fogstack-node-profile/agentos-agent-machine-node-profile.json

--- a/schemas/runtime/fogstack-agent-machine-node-profile-v0.1.schema.json
+++ b/schemas/runtime/fogstack-agent-machine-node-profile-v0.1.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/runtime/fogstack-agent-machine-node-profile-v0.1.schema.json",
+  "title": "FogStackAgentMachineNodeProfile",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "profile_id",
+    "node_role",
+    "os",
+    "image",
+    "declarative_updates",
+    "storage",
+    "agent_machine",
+    "governance",
+    "runtime_policy"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackAgentMachineNodeProfile" },
+    "schema_version": { "const": "v0.1" },
+    "profile_id": { "type": "string", "minLength": 1 },
+    "node_role": { "enum": ["edge-agent-node", "cluster-agent-node", "control-plane-agent-node"] },
+    "os": {
+      "type": "object",
+      "required": ["family", "distribution", "immutability", "configuration_model"],
+      "properties": {
+        "family": { "enum": ["SourceOS", "AgentOS", "SociOS-Linux"] },
+        "distribution": { "type": "string", "minLength": 1 },
+        "immutability": { "enum": ["ostree", "nixos", "image-based", "unknown"] },
+        "configuration_model": { "enum": ["nix-flake", "ignition-butane", "rpm-ostree", "container-image", "hybrid"] }
+      },
+      "additionalProperties": false
+    },
+    "image": {
+      "type": "object",
+      "required": ["builder", "image_ref", "digest_required", "sbom_required", "provenance_required"],
+      "properties": {
+        "builder": { "enum": ["nix", "rpm-ostree", "bootc", "containerfile", "unknown"] },
+        "image_ref": { "type": "string", "minLength": 1 },
+        "digest_required": { "const": true },
+        "sbom_required": { "const": true },
+        "provenance_required": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "declarative_updates": {
+      "type": "object",
+      "required": ["strategy", "rollback_required", "preflight_required", "agentplane_gate_required"],
+      "properties": {
+        "strategy": { "enum": ["nix-flake-switch", "ostree-rebase", "image-promotion", "hybrid"] },
+        "rollback_required": { "const": true },
+        "preflight_required": { "const": true },
+        "agentplane_gate_required": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "storage": {
+      "type": "object",
+      "required": ["ephemeral_storage", "persistent_storage", "topolvm_required", "volume_policy"],
+      "properties": {
+        "ephemeral_storage": { "enum": ["local", "topolvm", "none"] },
+        "persistent_storage": { "enum": ["topolvm", "external-csi", "none"] },
+        "topolvm_required": { "type": "boolean" },
+        "volume_policy": { "enum": ["deny-by-default", "explicit-claim-only"] }
+      },
+      "additionalProperties": false
+    },
+    "agent_machine": {
+      "type": "object",
+      "required": ["enabled", "identity_ref", "workload_runtime", "node_contract_required"],
+      "properties": {
+        "enabled": { "const": true },
+        "identity_ref": { "type": "string", "minLength": 1 },
+        "workload_runtime": { "enum": ["rootless-podman", "kubernetes", "systemd-user", "hybrid"] },
+        "node_contract_required": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "governance": {
+      "type": "object",
+      "required": ["agentplane_ref", "policyplane_ref", "human_approval_required", "live_mutation_default"],
+      "properties": {
+        "agentplane_ref": { "type": "string", "minLength": 1 },
+        "policyplane_ref": { "type": "string", "minLength": 1 },
+        "human_approval_required": { "const": true },
+        "live_mutation_default": { "const": "deny" }
+      },
+      "additionalProperties": false
+    },
+    "runtime_policy": {
+      "type": "object",
+      "required": ["network_default", "secrets_default", "host_mutation_default", "cluster_join_default"],
+      "properties": {
+        "network_default": { "const": "deny" },
+        "secrets_default": { "const": "deny" },
+        "host_mutation_default": { "const": "deny" },
+        "cluster_join_default": { "const": "approval-required" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/build_fogstack_agent_machine_node_profile.py
+++ b/tools/build_fogstack_agent_machine_node_profile.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def build_profile(
+    profile_id: str,
+    node_role: str,
+    os_family: str,
+    distribution: str,
+    immutability: str,
+    configuration_model: str,
+    image_builder: str,
+    image_ref: str,
+    update_strategy: str,
+    topolvm_required: bool,
+    agent_identity_ref: str,
+    workload_runtime: str,
+    agentplane_ref: str,
+    policyplane_ref: str,
+) -> dict[str, Any]:
+    persistent_storage = "topolvm" if topolvm_required else "external-csi"
+    ephemeral_storage = "topolvm" if topolvm_required else "local"
+    return {
+        "kind": "FogStackAgentMachineNodeProfile",
+        "schema_version": "v0.1",
+        "profile_id": profile_id,
+        "node_role": node_role,
+        "os": {
+            "family": os_family,
+            "distribution": distribution,
+            "immutability": immutability,
+            "configuration_model": configuration_model,
+        },
+        "image": {
+            "builder": image_builder,
+            "image_ref": image_ref,
+            "digest_required": True,
+            "sbom_required": True,
+            "provenance_required": True,
+        },
+        "declarative_updates": {
+            "strategy": update_strategy,
+            "rollback_required": True,
+            "preflight_required": True,
+            "agentplane_gate_required": True,
+        },
+        "storage": {
+            "ephemeral_storage": ephemeral_storage,
+            "persistent_storage": persistent_storage,
+            "topolvm_required": topolvm_required,
+            "volume_policy": "explicit-claim-only",
+        },
+        "agent_machine": {
+            "enabled": True,
+            "identity_ref": agent_identity_ref,
+            "workload_runtime": workload_runtime,
+            "node_contract_required": True,
+        },
+        "governance": {
+            "agentplane_ref": agentplane_ref,
+            "policyplane_ref": policyplane_ref,
+            "human_approval_required": True,
+            "live_mutation_default": "deny",
+        },
+        "runtime_policy": {
+            "network_default": "deny",
+            "secrets_default": "deny",
+            "host_mutation_default": "deny",
+            "cluster_join_default": "approval-required",
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a FogStack Agent Machine node profile")
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--profile-id", default="sourceos.agent-machine.edge.v0.1")
+    parser.add_argument("--node-role", choices=["edge-agent-node", "cluster-agent-node", "control-plane-agent-node"], default="edge-agent-node")
+    parser.add_argument("--os-family", choices=["SourceOS", "AgentOS", "SociOS-Linux"], default="SourceOS")
+    parser.add_argument("--distribution", default="SourceOS-Linux")
+    parser.add_argument("--immutability", choices=["ostree", "nixos", "image-based", "unknown"], default="nixos")
+    parser.add_argument("--configuration-model", choices=["nix-flake", "ignition-butane", "rpm-ostree", "container-image", "hybrid"], default="nix-flake")
+    parser.add_argument("--image-builder", choices=["nix", "rpm-ostree", "bootc", "containerfile", "unknown"], default="nix")
+    parser.add_argument("--image-ref", default="sourceos://images/agent-machine-edge@v0.1")
+    parser.add_argument("--update-strategy", choices=["nix-flake-switch", "ostree-rebase", "image-promotion", "hybrid"], default="nix-flake-switch")
+    parser.add_argument("--topolvm-required", action="store_true", default=True)
+    parser.add_argument("--no-topolvm", dest="topolvm_required", action="store_false")
+    parser.add_argument("--agent-identity-ref", default="agent-machine://sourceos/edge/default")
+    parser.add_argument("--workload-runtime", choices=["rootless-podman", "kubernetes", "systemd-user", "hybrid"], default="hybrid")
+    parser.add_argument("--agentplane-ref", default="github://SocioProphet/agentplane")
+    parser.add_argument("--policyplane-ref", default="github://SocioProphet/policy-fabric")
+    args = parser.parse_args()
+
+    profile = build_profile(
+        profile_id=args.profile_id,
+        node_role=args.node_role,
+        os_family=args.os_family,
+        distribution=args.distribution,
+        immutability=args.immutability,
+        configuration_model=args.configuration_model,
+        image_builder=args.image_builder,
+        image_ref=args.image_ref,
+        update_strategy=args.update_strategy,
+        topolvm_required=args.topolvm_required,
+        agent_identity_ref=args.agent_identity_ref,
+        workload_runtime=args.workload_runtime,
+        agentplane_ref=args.agentplane_ref,
+        policyplane_ref=args.policyplane_ref,
+    )
+    output = args.output if args.output.is_absolute() else ROOT / args.output
+    write_json(output, profile)
+    print(json.dumps(profile, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_agent_machine_node_profile.py
+++ b/tools/tests/test_fogstack_agent_machine_node_profile.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+SCHEMA = Path("schemas/runtime/fogstack-agent-machine-node-profile-v0.1.schema.json")
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def test_build_fogstack_agent_machine_node_profile(tmp_path: Path) -> None:
+    output = tmp_path / "agent-machine-node-profile.json"
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_agent_machine_node_profile.py",
+        "--output", str(output),
+    ], check=True)
+
+    profile = load_json(output)
+    Draft202012Validator(load_json(SCHEMA)).validate(profile)
+    assert profile["kind"] == "FogStackAgentMachineNodeProfile"
+    assert profile["profile_id"] == "sourceos.agent-machine.edge.v0.1"
+    assert profile["node_role"] == "edge-agent-node"
+    assert profile["os"] == {
+        "family": "SourceOS",
+        "distribution": "SourceOS-Linux",
+        "immutability": "nixos",
+        "configuration_model": "nix-flake",
+    }
+    assert profile["image"]["builder"] == "nix"
+    assert profile["image"]["digest_required"] is True
+    assert profile["image"]["sbom_required"] is True
+    assert profile["image"]["provenance_required"] is True
+    assert profile["declarative_updates"] == {
+        "strategy": "nix-flake-switch",
+        "rollback_required": True,
+        "preflight_required": True,
+        "agentplane_gate_required": True,
+    }
+    assert profile["storage"]["topolvm_required"] is True
+    assert profile["storage"]["persistent_storage"] == "topolvm"
+    assert profile["agent_machine"]["enabled"] is True
+    assert profile["agent_machine"]["node_contract_required"] is True
+    assert profile["governance"]["agentplane_ref"] == "github://SocioProphet/agentplane"
+    assert profile["governance"]["policyplane_ref"] == "github://SocioProphet/policy-fabric"
+    assert profile["governance"]["human_approval_required"] is True
+    assert profile["governance"]["live_mutation_default"] == "deny"
+    assert profile["runtime_policy"] == {
+        "network_default": "deny",
+        "secrets_default": "deny",
+        "host_mutation_default": "deny",
+        "cluster_join_default": "approval-required",
+    }
+
+
+def test_build_agentos_node_profile_without_topolvm(tmp_path: Path) -> None:
+    output = tmp_path / "agentos-node-profile.json"
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_agent_machine_node_profile.py",
+        "--output", str(output),
+        "--os-family", "AgentOS",
+        "--distribution", "AgentOS-Linux",
+        "--immutability", "ostree",
+        "--configuration-model", "rpm-ostree",
+        "--image-builder", "rpm-ostree",
+        "--update-strategy", "ostree-rebase",
+        "--no-topolvm",
+    ], check=True)
+
+    profile = load_json(output)
+    Draft202012Validator(load_json(SCHEMA)).validate(profile)
+    assert profile["os"]["family"] == "AgentOS"
+    assert profile["os"]["immutability"] == "ostree"
+    assert profile["declarative_updates"]["strategy"] == "ostree-rebase"
+    assert profile["storage"]["topolvm_required"] is False
+    assert profile["storage"]["persistent_storage"] == "external-csi"


### PR DESCRIPTION
Alignment tranche for SourceOS/AgentOS agentic node operations.

Adds a FogStackAgentMachineNodeProfile v0.1 contract plus generator, tests, and focused workflow. This explicitly models SourceOS/AgentOS/SociOS-Linux node substrate assumptions, immutable/declarative image strategy, Nix/ostree-style update paths, TopoLVM storage policy, Agent Machine identity, and AgentPlane/PolicyPlane governance references.

Files:
- schemas/runtime/fogstack-agent-machine-node-profile-v0.1.schema.json
- tools/build_fogstack_agent_machine_node_profile.py
- tools/tests/test_fogstack_agent_machine_node_profile.py
- .github/workflows/fogstack-agent-machine-node-profile.yml

Purpose: prevent FogStack runtime evidence from drifting away from SourceOS, AgentOS, TopoLVM, and AgentPlane-controlled node operations.