### PR TITLE
fogstack: make TurtleTerm and BearBrowser first-class node surfaces

### DIFF
--- a/schemas/runtime/fogstack-agent-machine-node-profile-v0.1.schema.json
+++ b/schemas/runtime/fogstack-agent-machine-node-profile-v0.1.schema.json
@@ -13,6 +13,7 @@
     "declarative_updates",
     "storage",
     "agent_machine",
+    "use_surfaces",
     "governance",
     "runtime_policy"
   ],
@@ -77,6 +78,16 @@
       },
       "additionalProperties": false
     },
+    "use_surfaces": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/use_surface" },
+      "minItems": 2,
+      "contains": {
+        "type": "object",
+        "required": ["id"],
+        "properties": { "id": { "const": "turtleterm" } }
+      }
+    },
     "governance": {
       "type": "object",
       "required": ["agentplane_ref", "policyplane_ref", "human_approval_required", "live_mutation_default"],
@@ -96,6 +107,27 @@
         "secrets_default": { "const": "deny" },
         "host_mutation_default": { "const": "deny" },
         "cluster_join_default": { "const": "approval-required" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "use_surface": {
+      "type": "object",
+      "required": ["id", "name", "surface_type", "repo_ref", "first_class", "agentplane_visible", "policyplane_guarded", "capabilities"],
+      "properties": {
+        "id": { "enum": ["turtleterm", "bearbrowser"] },
+        "name": { "type": "string", "minLength": 1 },
+        "surface_type": { "enum": ["terminal", "browser"] },
+        "repo_ref": { "type": "string", "minLength": 1 },
+        "first_class": { "const": true },
+        "agentplane_visible": { "const": true },
+        "policyplane_guarded": { "const": true },
+        "capabilities": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        }
       },
       "additionalProperties": false
     }

--- a/schemas/runtime/fogstack-agent-machine-node-profile-v0.1.schema.json
+++ b/schemas/runtime/fogstack-agent-machine-node-profile-v0.1.schema.json
@@ -82,11 +82,22 @@
       "type": "array",
       "items": { "$ref": "#/$defs/use_surface" },
       "minItems": 2,
-      "contains": {
-        "type": "object",
-        "required": ["id"],
-        "properties": { "id": { "const": "turtleterm" } }
-      }
+      "allOf": [
+        {
+          "contains": {
+            "type": "object",
+            "required": ["id"],
+            "properties": { "id": { "const": "turtleterm" } }
+          }
+        },
+        {
+          "contains": {
+            "type": "object",
+            "required": ["id"],
+            "properties": { "id": { "const": "bearbrowser" } }
+          }
+        }
+      ]
     },
     "governance": {
       "type": "object",

--- a/tools/build_fogstack_agent_machine_node_profile.py
+++ b/tools/build_fogstack_agent_machine_node_profile.py
@@ -15,6 +15,41 @@ def write_json(path: Path, data: dict[str, Any]) -> None:
     path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
+def default_use_surfaces() -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "turtleterm",
+            "name": "TurtleTerm",
+            "surface_type": "terminal",
+            "repo_ref": "github://SourceOS-Linux/TurtleTerm",
+            "first_class": True,
+            "agentplane_visible": True,
+            "policyplane_guarded": True,
+            "capabilities": [
+                "operator-shell",
+                "agent-command-session",
+                "runtime-evidence-review",
+                "node-debug-console",
+            ],
+        },
+        {
+            "id": "bearbrowser",
+            "name": "BearBrowser",
+            "surface_type": "browser",
+            "repo_ref": "github://SourceOS-Linux/BearBrowser",
+            "first_class": True,
+            "agentplane_visible": True,
+            "policyplane_guarded": True,
+            "capabilities": [
+                "operator-web-console",
+                "local-demo-review",
+                "gitops-readiness-review",
+                "policy-gated-browsing",
+            ],
+        },
+    ]
+
+
 def build_profile(
     profile_id: str,
     node_role: str,
@@ -69,6 +104,7 @@ def build_profile(
             "workload_runtime": workload_runtime,
             "node_contract_required": True,
         },
+        "use_surfaces": default_use_surfaces(),
         "governance": {
             "agentplane_ref": agentplane_ref,
             "policyplane_ref": policyplane_ref,

--- a/tools/tests/test_fogstack_agent_machine_node_profile.py
+++ b/tools/tests/test_fogstack_agent_machine_node_profile.py
@@ -17,6 +17,30 @@ def load_json(path: Path) -> dict:
     return data
 
 
+def assert_use_surfaces(profile: dict) -> None:
+    surfaces = {surface["id"]: surface for surface in profile["use_surfaces"]}
+    assert {"turtleterm", "bearbrowser"}.issubset(surfaces)
+    turtleterm = surfaces["turtleterm"]
+    assert turtleterm["name"] == "TurtleTerm"
+    assert turtleterm["surface_type"] == "terminal"
+    assert turtleterm["repo_ref"] == "github://SourceOS-Linux/TurtleTerm"
+    assert turtleterm["first_class"] is True
+    assert turtleterm["agentplane_visible"] is True
+    assert turtleterm["policyplane_guarded"] is True
+    assert "agent-command-session" in turtleterm["capabilities"]
+    assert "node-debug-console" in turtleterm["capabilities"]
+
+    bearbrowser = surfaces["bearbrowser"]
+    assert bearbrowser["name"] == "BearBrowser"
+    assert bearbrowser["surface_type"] == "browser"
+    assert bearbrowser["repo_ref"] == "github://SourceOS-Linux/BearBrowser"
+    assert bearbrowser["first_class"] is True
+    assert bearbrowser["agentplane_visible"] is True
+    assert bearbrowser["policyplane_guarded"] is True
+    assert "operator-web-console" in bearbrowser["capabilities"]
+    assert "policy-gated-browsing" in bearbrowser["capabilities"]
+
+
 def test_build_fogstack_agent_machine_node_profile(tmp_path: Path) -> None:
     output = tmp_path / "agent-machine-node-profile.json"
     subprocess.run([
@@ -50,6 +74,7 @@ def test_build_fogstack_agent_machine_node_profile(tmp_path: Path) -> None:
     assert profile["storage"]["persistent_storage"] == "topolvm"
     assert profile["agent_machine"]["enabled"] is True
     assert profile["agent_machine"]["node_contract_required"] is True
+    assert_use_surfaces(profile)
     assert profile["governance"]["agentplane_ref"] == "github://SocioProphet/agentplane"
     assert profile["governance"]["policyplane_ref"] == "github://SocioProphet/policy-fabric"
     assert profile["governance"]["human_approval_required"] is True
@@ -84,3 +109,4 @@ def test_build_agentos_node_profile_without_topolvm(tmp_path: Path) -> None:
     assert profile["declarative_updates"]["strategy"] == "ostree-rebase"
     assert profile["storage"]["topolvm_required"] is False
     assert profile["storage"]["persistent_storage"] == "external-csi"
+    assert_use_surfaces(profile)


### PR DESCRIPTION
Follow-on alignment tranche for SourceOS/AgentOS Agent Machine node operations.

This makes TurtleTerm and BearBrowser first-class use surfaces in the FogStackAgentMachineNodeProfile contract.

Changes:
- requires `use_surfaces` in the node profile schema
- requires both `turtleterm` and `bearbrowser` entries at the schema level
- emits TurtleTerm as a first-class terminal surface with `github://SourceOS-Linux/TurtleTerm`
- emits BearBrowser as a first-class browser surface with `github://SourceOS-Linux/BearBrowser`
- marks both surfaces as AgentPlane-visible and PolicyPlane-guarded
- extends node profile tests to prove both surfaces and key capabilities

Purpose: ensure SourceOS/AgentOS agent-machine nodes have TurtleTerm and BearBrowser as governed operator surfaces rather than optional UI afterthoughts.