### PR TITLE
docs(platform): define open office suite runtime boundary

### DIFF
--- a/docs/OFFICE_CLOUD_SUITE_RUNTIME.md
+++ b/docs/OFFICE_CLOUD_SUITE_RUNTIME.md
@@ -4,23 +4,46 @@
 
 This document defines the platform runtime split for the SourceOS office and workspace suite.
 
-`prophet-platform` is the runtime and deployment home for the cloud office control plane. It should realize the office suite product semantics defined in `SocioProphet/prophet-workspace` and the host integration surfaces defined in `SociOS-Linux/source-os`.
+`prophet-platform` is the runtime and deployment home for the open cloud-office control plane. It realizes the office-suite product semantics defined in `SocioProphet/prophet-workspace` and binds them to the current SourceOS host/user surfaces under `SourceOS-Linux/*`.
+
+This is not a Microsoft 365 or Google Workspace dependency layer. SourceOS must provide parity with those suites while keeping the canonical product, runtime authority, storage contracts, policy decisions, and evidence records open, inspectable, and self-hostable.
 
 ## Runtime responsibilities
 
-The platform should own:
+The platform owns:
+
 - WOPI host behavior and document session control
-- document metadata, versions, locks, and writeback records
+- document metadata, versions, locks, writeback records, and conflict state
 - office preview and conversion workers
-- office context extraction and indexing runtime
+- asynchronous office context extraction and indexing runtime
 - AI action routing and receipt emission
 - workflow runtime for office/document automations
-- deployment topology, namespaces, and service wiring
+- deployment topology, namespaces, service wiring, and health/smoke surfaces
+- permission-aware collaboration runtime for comments, review threads, suggestions, and review-state transitions
+
+The WOPI hot path must remain narrow and inspectable. Extraction, indexing, semantic graph updates, memory attachment, and AI follow-ons happen after version capture or through explicit policy-approved actions; they do not sit inside the critical editor save path.
+
+## Six-lane split
+
+The office suite is a six-lane system, not a standalone office clone.
+
+| Lane | Repository surface | Ownership boundary |
+|---|---|---|
+| Product/domain | `SocioProphet/prophet-workspace` | Workroom semantics, office capability families, user/admin product expectations, OfficeArtifact contracts, review expectations, and workroom binding. |
+| Platform runtime | `SocioProphet/prophet-platform` | WOPI, records, locks, writeback, conversion, context extraction, AI receipts, workflow runtime, service wiring, and deployment topology. |
+| Local execution | `SourceOS-Linux/sourceos-devtools` and Agent Machine contracts | Guarded local generation, inspection, conversion, evidence emission, scoped output roots, and dry-run-by-default CLI behavior. |
+| Shell/document surface | `SourceOS-Linux/sourceos-shell` | Linux-first document/PDF/native shell behavior, local/cloud handoff affordances, secure document lanes, and desktop integration. |
+| Operator terminal surface | `SourceOS-Linux/TurtleTerm` | Policy-aware terminal commands, trusted execution receipts, `/office` operator flows, evidence inspection, and agent delegation. |
+| Browser/collaboration surface | `SourceOS-Linux/BearBrowser` | WOPI launch, web-editor sessions, governed browser automation, download quarantine, workspace mounts, and human/agent browser profiles. |
+
+The historical shorthand `source-os` should not obscure the current implementation split. Current SourceOS host realization is distributed across the SourceOS-Linux repositories above.
 
 ## Service set
 
 Planned service surfaces:
+
 - `services/wopi-host/`
+- `services/office-collaboration/`
 - `services/office-render-convert/`
 - `services/office-context-extractor/`
 - `services/workspace-ai-orchestrator/`
@@ -31,30 +54,104 @@ Planned service surfaces:
 
 ### Upstream product/domain
 
-`SocioProphet/prophet-workspace` should define:
+`SocioProphet/prophet-workspace` defines:
+
 - workspace office capability families
 - product parity expectations
+- workroom-bound OfficeArtifact contracts
 - user-facing and admin-facing semantics
+- review posture and side-effect expectations
 
-### Downstream host realization
+### Platform runtime
 
-`SociOS-Linux/source-os` should define:
-- LibreOffice defaults
-- local extraction hooks
-- local smoke tests
-- font and MIME integration
+`SocioProphet/prophet-platform` defines and runs:
+
+- editor/document/session runtime contracts
+- version/writeback/lock/conflict records
+- office collaboration records
+- context extraction and indexing workers
+- AI action and receipt records
+- workflow and automation runtime
+- deployment and service topology
+
+### Host and local realization
+
+`SourceOS-Linux/sourceos-devtools`, `SourceOS-Linux/sourceos-shell`, `SourceOS-Linux/TurtleTerm`, and `SourceOS-Linux/BearBrowser` define:
+
+- LibreOffice defaults and local smoke tests
+- local extraction hooks and MIME/font integration
+- guarded Agent Machine mount behavior
+- SourceOS office CLI behavior
+- terminal/operator office flows
+- browser/WOPI launch and automation flows
 - desktop office shell behavior
+
+### Migration and closed-provider exit
+
+`SocioProphet/exodus` owns migration, evidence, and sovereignty planning for movement out of closed vendor control surfaces. Any Google, Microsoft, or Apple source integration belongs to migration/import/export evidence and provider-control scoring unless an explicit policy says otherwise.
+
+## Closed-provider boundary
+
+The core office suite must not depend on Google Workspace, Microsoft 365, Microsoft Graph, or Google APIs for normal operation.
+
+Closed providers may appear only as:
+
+- provenance labels for imported artifacts
+- migration/source adapters governed by Exodus
+- compatibility test fixtures
+- export/import bridges that are disabled by default
+- evidence inputs for Exit Readiness Index / Provider Control Surface analysis
+
+Closed providers must not be:
+
+- canonical storage authorities
+- required runtime services
+- default execution backends
+- policy authorities
+- collaboration state authorities
+- WOPI hot-path dependencies
+
+Schema language should therefore distinguish:
+
+- `source_provider` / provenance: where an artifact came from
+- `execution_backend`: the open runtime engine used by SourceOS
+- `compatibility_adapter`: a policy-gated bridge for import/export/migration
+- `core_authority`: SourceOS/Prophet-owned runtime authority
 
 ## First runtime contracts
 
 The first runtime contracts should include:
-- office document record
-- office AI action record
-- office AI receipt record
-- workspace flow record
 
-Those contracts should support local desktop and cloud editing paths without binding the product to a single editor implementation.
+- `office_document_record`
+- `office_session_record`
+- `office_collaboration_thread_record`
+- `office_suggestion_record`
+- `office_version_record`
+- `office_writeback_record`
+- `office_policy_decision_record`
+- `office_adapter_profile`
+- `office_ai_action_record`
+- `office_ai_receipt_record`
+- `workspace_flow_record`
+
+Those contracts should support local desktop and cloud editing paths without binding the product to a single editor implementation or closed provider.
 
 ## Editor posture
 
-The runtime should treat LibreOffice / Collabora as an editing and conversion engine, not as the total product. The workspace graph, AI orchestration, and document-control services belong at the platform layer.
+The runtime treats LibreOffice and Collabora as editing/conversion engines, not as the total product. The workspace graph, policy fabric, AI orchestration, receipts, collaboration records, and document-control services belong at the platform layer.
+
+Preferred initial posture:
+
+- LibreOffice: local-first headless generation, render, inspect, and conversion
+- Collabora: open browser-collaboration and WOPI-compatible editing path
+- SourceOS-native surfaces: future first-party document/app doors
+- ONLYOFFICE: optional open deployment compatibility candidate only after policy/license review
+- Google/Microsoft: migration/import/export compatibility only, disabled by default and governed through Exodus-style evidence
+
+## Non-goals
+
+- Do not create a monolithic office suite repository.
+- Do not vendor an entire editor stack into `prophet-platform`.
+- Do not make Google Workspace or Microsoft 365 normal runtime dependencies.
+- Do not place memory, semantic extraction, or ontology mutation in the critical WOPI save path.
+- Do not treat chat, browser session state, or terminal history as the durable system of record.

--- a/docs/OFFICE_COLLABORATION_RUNTIME.md
+++ b/docs/OFFICE_COLLABORATION_RUNTIME.md
@@ -5,36 +5,57 @@ This document defines the runtime slice for office collaboration records in `pro
 ## Purpose
 
 The office/workspace product already needs collaboration objects such as:
+
 - comment/review threads
 - suggestions
 - review state
+- version-aware review history
+- policy-safe agent-created collaboration objects
 
-This runtime slice gives those product objects a concrete platform home.
+This runtime slice gives those product objects a concrete platform home without making chat history, browser session state, or editor-local metadata the durable collaboration authority.
 
 ## Runtime responsibilities
 
-`prophet-platform` should own:
+`prophet-platform` owns:
+
 - collaboration record storage and retrieval
 - version linkage for collaboration objects
 - runtime service seams for comments and suggestions
 - audit/evidence linkage for agent-created collaboration objects
 - permission-aware retrieval and mutation
+- collaboration state transitions for review and resolution flows
 
 ## First runtime records
 
 - `office_collaboration_thread_record`
 - `office_suggestion_record`
 
+Follow-up records should include:
+
+- collaboration message/reply records
+- version-aware review state records
+- policy decision records for external publish/share/send side effects
+- receipt records for agent-authored comments or suggestions
+
 ## First service seam
 
-A later `services/office-collaboration/` runtime should be able to:
+`services/office-collaboration/` should be able to:
+
 - create and fetch collaboration threads
 - create and resolve suggestions
 - bind collaboration records to office artifacts and versions
 - preserve receipts and policy-safe side effects
+- expose health and smoke surfaces for deterministic runtime validation
 
 ## Cross-repo boundaries
 
-- `prophet-workspace` owns the product collaboration model
-- `prophet-platform` owns runtime records and service seams
-- `source-os` owns local/cloud handoff affordances, not canonical collaboration storage
+- `SocioProphet/prophet-workspace` owns the product collaboration model and workroom semantics.
+- `SocioProphet/prophet-platform` owns runtime records, service seams, version linkage, receipts, and permission-aware mutation.
+- `SourceOS-Linux/sourceos-shell`, `SourceOS-Linux/sourceos-devtools`, `SourceOS-Linux/TurtleTerm`, and `SourceOS-Linux/BearBrowser` own local/cloud handoff affordances, CLI/operator/browser surfaces, and guarded local execution. They do not own canonical collaboration storage.
+- `SocioProphet/exodus` owns closed-provider migration and sovereignty evidence when imported Google/Microsoft/Apple artifacts or metadata are involved.
+
+## Closed-provider boundary
+
+Google Workspace, Microsoft 365, and Microsoft Graph are not collaboration-state authorities for the SourceOS office suite. They may be represented only as provenance/import/export compatibility sources under explicit policy and migration evidence.
+
+The canonical collaboration state for SourceOS office artifacts remains in open Prophet/SourceOS records, version links, receipts, and policy decisions.

--- a/docs/WOPI_HOST_PROFILE.md
+++ b/docs/WOPI_HOST_PROFILE.md
@@ -1,12 +1,13 @@
 # WOPI Host Profile
 
-This document defines the first runtime profile for the office cloud suite WOPI host in `prophet-platform`.
+This document defines the first runtime profile for the open office cloud-suite WOPI host in `prophet-platform`.
 
 ## Purpose
 
-The WOPI host is the boundary between the cloud editor and the document/storage control plane.
+The WOPI host is the boundary between an editor surface and the document/storage control plane.
 
 It should provide the minimum office edit/view contract for:
+
 - cloud editor launch
 - file metadata and capability discovery
 - file retrieval
@@ -15,9 +16,12 @@ It should provide the minimum office edit/view contract for:
 - version-aware saveback
 - conflict handling and retry surfaces
 
+The WOPI host is not the total office product. It is a narrow, testable runtime seam inside the broader SourceOS office suite.
+
 ## Responsibilities
 
-The WOPI host should own:
+The WOPI host owns:
+
 - document-scoped access token validation
 - `CheckFileInfo`
 - `GetFile`
@@ -27,29 +31,55 @@ The WOPI host should own:
 - `Unlock`
 - `UnlockAndRelock`
 - `RefreshLock`
+- conflict-safe writeback handoff to version/writeback records
 
 ## Object bindings
 
 The WOPI host should be backed by:
+
 - `office_document_record`
 - `office_session_record`
 - version and writeback records
+- policy decision records for side effects
 - office AI receipts and action gating where editor-originating actions trigger AI follow-ons
 
 ## Cross-repo integration
 
-### `prophet-workspace`
-Defines product semantics for cloud editing, saveback, versioning, comments, and collaboration expectations.
+### `SocioProphet/prophet-workspace`
 
-### `source-os`
-Defines local/cloud handoff behavior for opening documents into cloud edit sessions.
+Defines product semantics for office artifacts, cloud editing, saveback, versioning, comments, review state, and collaboration expectations.
+
+### `SocioProphet/prophet-platform`
+
+Defines and runs the WOPI host, document/session/version/writeback records, collaboration runtime, service health surfaces, and deployment topology.
+
+### SourceOS host surfaces
+
+`SourceOS-Linux/sourceos-shell`, `SourceOS-Linux/sourceos-devtools`, `SourceOS-Linux/TurtleTerm`, and `SourceOS-Linux/BearBrowser` define local/cloud handoff behavior for opening documents into editor sessions, inspecting office evidence, launching WOPI/browser sessions, and guarding local output/download roots.
 
 ### `memory-mesh`
-Optional recall/writeback hooks should not be in the critical editor save path, but may attach before or after explicit AI actions.
+
+Optional recall/writeback hooks should not be in the critical editor save path. They may attach before or after explicit AI actions and after version capture.
 
 ### `ontogenesis`
+
 Semantic unit and graph boundary mappings should apply after extraction and version capture, not in the hot path of WOPI RPC handling.
+
+### `SocioProphet/exodus`
+
+Closed-provider import/export/migration state belongs to Exodus-style migration evidence. Google Workspace, Microsoft 365, Microsoft Graph, and Apple provider surfaces must not become WOPI hot-path dependencies or durable office authorities.
 
 ## First implementation rule
 
 The first WOPI host implementation should be narrow and explicit. It should prefer correctness and inspectability over breadth.
+
+Initial acceptance posture:
+
+- one open editor binding
+- one storage backend seam
+- explicit lock semantics
+- explicit version/writeback records
+- explicit conflict-state behavior
+- health and smoke surfaces suitable for CI
+- no Google/Microsoft runtime dependency
+- no semantic extraction or memory mutation inside the critical save path


### PR DESCRIPTION
## Summary

Defines the SourceOS office suite runtime as a six-lane system instead of a standalone office clone:

- `SocioProphet/prophet-workspace` owns product/domain semantics.
- `SocioProphet/prophet-platform` owns runtime records, services, WOPI, writeback, extraction, receipts, workflow, and deployment topology.
- `SourceOS-Linux/sourceos-devtools` and Agent Machine contracts own guarded local execution.
- `SourceOS-Linux/sourceos-shell` owns Linux-first document/PDF/native shell behavior.
- `SourceOS-Linux/TurtleTerm` owns operator terminal and evidence flows.
- `SourceOS-Linux/BearBrowser` owns WOPI/browser collaboration and governed automation surfaces.

Also hardens the closed-provider boundary: Google Workspace, Microsoft 365, Microsoft Graph, and Google APIs may appear only as provenance/import/export/migration compatibility surfaces governed through Exodus-style evidence, not as canonical runtime authorities or WOPI hot-path dependencies.

## Changes

- Updates `docs/OFFICE_CLOUD_SUITE_RUNTIME.md` with the six-lane split, closed-provider boundary, expanded runtime responsibilities, and first contract backlog.
- Updates `docs/OFFICE_COLLABORATION_RUNTIME.md` to align collaboration authority with open Prophet/SourceOS records and SourceOS host surfaces.
- Updates `docs/WOPI_HOST_PROFILE.md` to clarify the WOPI host as a narrow open runtime seam and prohibit Google/Microsoft hot-path dependency.

## Validation

- Compared branch against `main`; branch is 3 commits ahead and 0 behind.
- Changed files are documentation-only:
  - `docs/OFFICE_CLOUD_SUITE_RUNTIME.md`
  - `docs/OFFICE_COLLABORATION_RUNTIME.md`
  - `docs/WOPI_HOST_PROFILE.md`

## Follow-up

The next implementation slice should add runtime contracts for:

- `office_version_record`
- `office_writeback_record`
- `office_policy_decision_record`
- `office_adapter_profile`

with closed providers represented only as disabled-by-default compatibility/migration adapters.