### PR TITLE
fogstack: link runtime dry-run evidence to AgentPlane runs

### DIFF
--- a/schemas/runtime/fogstack-runtime-dry-run-record-v0.1.schema.json
+++ b/schemas/runtime/fogstack-runtime-dry-run-record-v0.1.schema.json
@@ -14,6 +14,7 @@
     "runtime_adapter_digest",
     "node_profile_ref",
     "node_profile_digest",
+    "agentplane_run",
     "deploy_plan_ref",
     "deploy_plan_digest",
     "cluster_readiness_record_ref",
@@ -38,6 +39,19 @@
     "runtime_adapter_digest": { "$ref": "#/$defs/sha256_digest" },
     "node_profile_ref": { "type": "string", "minLength": 1 },
     "node_profile_digest": { "$ref": "#/$defs/sha256_digest" },
+    "agentplane_run": {
+      "type": "object",
+      "required": ["run_id", "run_ref", "agentplane_ref", "requested_by", "execution_mode", "approval_state"],
+      "properties": {
+        "run_id": { "type": "string", "minLength": 1 },
+        "run_ref": { "type": "string", "minLength": 1 },
+        "agentplane_ref": { "type": "string", "minLength": 1 },
+        "requested_by": { "type": "string", "minLength": 1 },
+        "execution_mode": { "const": "dry-run" },
+        "approval_state": { "const": "live-apply-requires-human-approval" }
+      },
+      "additionalProperties": false
+    },
     "deploy_plan_ref": { "type": "string", "minLength": 1 },
     "deploy_plan_digest": { "$ref": "#/$defs/sha256_digest" },
     "cluster_readiness_record_ref": { "type": "string", "minLength": 1 },

--- a/tools/emit_fogstack_runtime_dry_run_record.py
+++ b/tools/emit_fogstack_runtime_dry_run_record.py
@@ -26,7 +26,7 @@ def write_json(path: Path, data: dict[str, Any]) -> None:
 def sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(8192), b""):
+        for chunk in iter(lambda: handle.read(8192), b=""):
             digest.update(chunk)
     return "sha256:" + digest.hexdigest()
 
@@ -67,7 +67,26 @@ def require_node_surfaces(node_profile: dict[str, Any]) -> None:
             raise SystemExit(f"ERR: node surface is not PolicyPlane-guarded: {surface_id}")
 
 
-def emit_record(adapter_path: Path, manifest_dir: Path, output_path: Path) -> dict[str, Any]:
+def agentplane_run_payload(run_id: str, run_ref: str, agentplane_ref: str, requested_by: str) -> dict[str, str]:
+    return {
+        "run_id": run_id,
+        "run_ref": run_ref,
+        "agentplane_ref": agentplane_ref,
+        "requested_by": requested_by,
+        "execution_mode": "dry-run",
+        "approval_state": "live-apply-requires-human-approval",
+    }
+
+
+def emit_record(
+    adapter_path: Path,
+    manifest_dir: Path,
+    output_path: Path,
+    agentplane_run_id: str,
+    agentplane_run_ref: str,
+    agentplane_ref: str,
+    requested_by: str,
+) -> dict[str, Any]:
     adapter_path = resolve(adapter_path)
     manifest_dir = resolve(manifest_dir)
     output_path = resolve(output_path)
@@ -107,6 +126,8 @@ def emit_record(adapter_path: Path, manifest_dir: Path, output_path: Path) -> di
         raise SystemExit("ERR: GitOps bundle does not match adapter bundle/version")
     if gitops_readiness.get("status") != "passed":
         raise SystemExit("ERR: GitOps readiness record must have passed status")
+    if agentplane_ref != node_profile["governance"].get("agentplane_ref"):
+        raise SystemExit("ERR: AgentPlane run ref does not match node profile governance")
 
     manifest_paths = [
         manifest_dir / "configmap.yaml",
@@ -128,6 +149,7 @@ def emit_record(adapter_path: Path, manifest_dir: Path, output_path: Path) -> di
         "runtime_adapter_digest": sha256_file(adapter_path),
         "node_profile_ref": rel(node_profile_path),
         "node_profile_digest": sha256_file(node_profile_path),
+        "agentplane_run": agentplane_run_payload(agentplane_run_id, agentplane_run_ref, agentplane_ref, requested_by),
         "deploy_plan_ref": rel(deploy_plan_path),
         "deploy_plan_digest": sha256_file(deploy_plan_path),
         "cluster_readiness_record_ref": rel(cluster_record_path),
@@ -146,6 +168,7 @@ def emit_record(adapter_path: Path, manifest_dir: Path, output_path: Path) -> di
             "mode": "dry-run",
             "mutated_cluster": False,
             "validated_inputs": [
+                "agentplane_run",
                 "runtime_adapter",
                 "node_profile",
                 "deploy_plan",
@@ -177,8 +200,20 @@ def main() -> int:
     parser.add_argument("--runtime-adapter", required=True, type=Path)
     parser.add_argument("--manifest-dir", required=True, type=Path)
     parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--agentplane-run-id", default="agentplane-run:fogstack.access:local-dry-run")
+    parser.add_argument("--agentplane-run-ref", default="agentplane://runs/fogstack.access/local-dry-run")
+    parser.add_argument("--agentplane-ref", default="github://SocioProphet/agentplane")
+    parser.add_argument("--requested-by", default="human:operator")
     args = parser.parse_args()
-    record = emit_record(args.runtime_adapter, args.manifest_dir, args.output)
+    record = emit_record(
+        args.runtime_adapter,
+        args.manifest_dir,
+        args.output,
+        args.agentplane_run_id,
+        args.agentplane_run_ref,
+        args.agentplane_ref,
+        args.requested_by,
+    )
     print(json.dumps(record, indent=2))
     return 0
 

--- a/tools/emit_fogstack_runtime_dry_run_record.py
+++ b/tools/emit_fogstack_runtime_dry_run_record.py
@@ -26,7 +26,7 @@ def write_json(path: Path, data: dict[str, Any]) -> None:
 def sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(8192), b=""):
+        for chunk in iter(lambda: handle.read(8192), b""):
             digest.update(chunk)
     return "sha256:" + digest.hexdigest()
 

--- a/tools/tests/test_fogstack_runtime_dry_run_record.py
+++ b/tools/tests/test_fogstack_runtime_dry_run_record.py
@@ -42,7 +42,16 @@ def build_inputs(tmp_path: Path) -> tuple[Path, Path]:
 def test_emit_fogstack_runtime_dry_run_record(tmp_path: Path) -> None:
     adapter, manifests = build_inputs(tmp_path)
     output = tmp_path / "runtime-dry-run.json"
-    subprocess.run([sys.executable, "tools/emit_fogstack_runtime_dry_run_record.py", "--runtime-adapter", str(adapter), "--manifest-dir", str(manifests), "--output", str(output)], check=True)
+    subprocess.run([
+        sys.executable,
+        "tools/emit_fogstack_runtime_dry_run_record.py",
+        "--runtime-adapter", str(adapter),
+        "--manifest-dir", str(manifests),
+        "--output", str(output),
+        "--agentplane-run-id", "agentplane-run:test",
+        "--agentplane-run-ref", "agentplane://runs/test",
+        "--requested-by", "human:test-operator",
+    ], check=True)
     record = load_json(output)
     Draft202012Validator(load_json(SCHEMA)).validate(record)
     assert record["kind"] == "FogStackRuntimeDryRunRecord"
@@ -50,7 +59,16 @@ def test_emit_fogstack_runtime_dry_run_record(tmp_path: Path) -> None:
     assert record["bundle_id"] == "fogstack.access"
     assert record["namespace"] == "fogstack-access"
     assert record["node_profile_digest"].startswith("sha256:")
+    assert record["agentplane_run"] == {
+        "run_id": "agentplane-run:test",
+        "run_ref": "agentplane://runs/test",
+        "agentplane_ref": "github://SocioProphet/agentplane",
+        "requested_by": "human:test-operator",
+        "execution_mode": "dry-run",
+        "approval_state": "live-apply-requires-human-approval",
+    }
     assert record["dry_run_result"]["mutated_cluster"] is False
+    assert "agentplane_run" in record["dry_run_result"]["validated_inputs"]
     assert "node_profile" in record["dry_run_result"]["validated_inputs"]
     assert record["dry_run_result"]["validation_path"] == "contract-and-digest-only"
     assert record["runtime_policy"]["live_apply_allowed"] is False
@@ -67,3 +85,18 @@ def test_emit_fogstack_runtime_dry_run_record_rejects_tampered_input(tmp_path: P
     proc = subprocess.run([sys.executable, "tools/emit_fogstack_runtime_dry_run_record.py", "--runtime-adapter", str(adapter), "--manifest-dir", str(manifests), "--output", str(output)], capture_output=True, text=True)
     assert proc.returncode != 0
     assert "node profile digest mismatch" in proc.stderr
+
+
+def test_emit_fogstack_runtime_dry_run_record_rejects_wrong_agentplane_ref(tmp_path: Path) -> None:
+    adapter, manifests = build_inputs(tmp_path)
+    output = tmp_path / "runtime-dry-run.json"
+    proc = subprocess.run([
+        sys.executable,
+        "tools/emit_fogstack_runtime_dry_run_record.py",
+        "--runtime-adapter", str(adapter),
+        "--manifest-dir", str(manifests),
+        "--output", str(output),
+        "--agentplane-ref", "github://SocioProphet/wrong-agentplane",
+    ], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert "AgentPlane run ref does not match node profile governance" in proc.stderr

--- a/tools/tests/test_run_fogstack_local_demo_full.py
+++ b/tools/tests/test_run_fogstack_local_demo_full.py
@@ -89,8 +89,14 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
 
     runtime_dry_run = json.loads(Path(full_summary["artifacts"]["runtime_dry_run_record"]).read_text(encoding="utf-8"))
     assert runtime_dry_run["kind"] == "FogStackRuntimeDryRunRecord"
+    assert runtime_dry_run["agentplane_run"]["run_id"] == "agentplane-run:fogstack.access:local-dry-run"
+    assert runtime_dry_run["agentplane_run"]["run_ref"] == "agentplane://runs/fogstack.access/local-dry-run"
+    assert runtime_dry_run["agentplane_run"]["agentplane_ref"] == "github://SocioProphet/agentplane"
+    assert runtime_dry_run["agentplane_run"]["requested_by"] == "human:operator"
+    assert runtime_dry_run["agentplane_run"]["approval_state"] == "live-apply-requires-human-approval"
     assert runtime_dry_run["dry_run_result"]["mutated_cluster"] is False
     assert runtime_dry_run["dry_run_result"]["validation_path"] == "contract-and-digest-only"
+    assert "agentplane_run" in runtime_dry_run["dry_run_result"]["validated_inputs"]
 
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed_ids = {entry["id"] for entry in artifact_index["artifacts"]}
@@ -110,6 +116,11 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert "GitOps readiness" in html
     assert "Runtime evidence" in html
     assert "Runtime readiness" in html
+    assert "AgentPlane run ID" in html
+    assert "agentplane-run:fogstack.access:local-dry-run" in html
+    assert "agentplane://runs/fogstack.access/local-dry-run" in html
+    assert "github://SocioProphet/agentplane" in html
+    assert "live-apply-requires-human-approval" in html
     assert "TurtleTerm" in html
     assert "BearBrowser" in html
     assert "github://SourceOS-Linux/TurtleTerm" in html

--- a/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
@@ -49,6 +49,7 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     assert "runtime_adapter_indexed" in summary["checks"]
     assert "runtime_dry_run_record_indexed" in summary["checks"]
     assert "runtime_readiness_summary_appended" in summary["checks"]
+    assert "agentplane_run_linked" in summary["checks"]
 
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed = {entry["id"]: entry for entry in artifact_index["artifacts"]}
@@ -82,8 +83,14 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
 
     runtime_dry_run = json.loads(Path(summary["artifacts"]["deploy_runtime_dry_run_record"]).read_text(encoding="utf-8"))
     assert runtime_dry_run["kind"] == "FogStackRuntimeDryRunRecord"
+    assert runtime_dry_run["agentplane_run"]["run_id"] == "agentplane-run:fogstack.access:local-dry-run"
+    assert runtime_dry_run["agentplane_run"]["run_ref"] == "agentplane://runs/fogstack.access/local-dry-run"
+    assert runtime_dry_run["agentplane_run"]["agentplane_ref"] == "github://SocioProphet/agentplane"
+    assert runtime_dry_run["agentplane_run"]["requested_by"] == "human:operator"
+    assert runtime_dry_run["agentplane_run"]["approval_state"] == "live-apply-requires-human-approval"
     assert runtime_dry_run["dry_run_result"]["mutated_cluster"] is False
     assert runtime_dry_run["dry_run_result"]["validation_path"] == "contract-and-digest-only"
+    assert "agentplane_run" in runtime_dry_run["dry_run_result"]["validated_inputs"]
     assert "node_profile" in runtime_dry_run["dry_run_result"]["validated_inputs"]
 
     markdown = (output_dir / "fogstack-local-demo.summary.md").read_text(encoding="utf-8")
@@ -93,6 +100,11 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
         assert "GitOps readiness" in content
         assert "Runtime evidence" in content
         assert "Runtime readiness" in content
+        assert "AgentPlane run ID" in content
+        assert "agentplane-run:fogstack.access:local-dry-run" in content
+        assert "agentplane://runs/fogstack.access/local-dry-run" in content
+        assert "github://SocioProphet/agentplane" in content
+        assert "live-apply-requires-human-approval" in content
         assert "TurtleTerm" in content
         assert "BearBrowser" in content
         assert "github://SourceOS-Linux/TurtleTerm" in content

--- a/tools/update_fogstack_local_demo_runtime_evidence.py
+++ b/tools/update_fogstack_local_demo_runtime_evidence.py
@@ -84,10 +84,14 @@ def runtime_readiness(runtime_adapter_ref: str, runtime_dry_run_ref: str) -> dic
     missing_surfaces = [surface_id for surface_id in SURFACES if surface_id not in surfaces]
     if missing_surfaces:
         raise SystemExit(f"ERR: node profile missing required use surfaces: {', '.join(missing_surfaces)}")
+    agentplane_run = dry_run.get("agentplane_run")
+    if not isinstance(agentplane_run, dict):
+        raise SystemExit("ERR: runtime dry-run evidence missing AgentPlane run linkage")
 
     return {
         "node_profile_ref": node_profile_ref,
         "node_profile_digest": dry_run.get("node_profile_digest") or adapter.get("inputs", {}).get("node_profile_digest"),
+        "agentplane_run": agentplane_run,
         "surfaces": surfaces,
         "dry_run_mode": dry_run.get("dry_run_result", {}).get("mode"),
         "validation_path": dry_run.get("dry_run_result", {}).get("validation_path"),
@@ -111,6 +115,7 @@ def append_markdown(markdown_path: Path, refs_by_id: dict[str, str], readiness: 
             f"| {surface['name']} | `{surface['repo_ref']}` | `{surface['surface_type']}` | "
             f"`first_class={str(surface['first_class']).lower()}; agentplane_visible={str(surface['agentplane_visible']).lower()}; policyplane_guarded={str(surface['policyplane_guarded']).lower()}` |"
         )
+    agentplane = readiness["agentplane_run"]
 
     section = "\n".join([
         "",
@@ -124,6 +129,12 @@ def append_markdown(markdown_path: Path, refs_by_id: dict[str, str], readiness: 
         "",
         "| Signal | Value |",
         "|---|---|",
+        f"| AgentPlane run ID | `{agentplane['run_id']}` |",
+        f"| AgentPlane run ref | `{agentplane['run_ref']}` |",
+        f"| AgentPlane ref | `{agentplane['agentplane_ref']}` |",
+        f"| Requested by | `{agentplane['requested_by']}` |",
+        f"| AgentPlane execution mode | `{agentplane['execution_mode']}` |",
+        f"| AgentPlane approval state | `{agentplane['approval_state']}` |",
         f"| Node profile | `{readiness['node_profile_ref']}` |",
         f"| Node profile digest | `{readiness['node_profile_digest']}` |",
         f"| Dry-run mode | `{readiness['dry_run_mode']}` |",
@@ -167,6 +178,7 @@ def append_html(html_path: Path, refs_by_id: dict[str, str], readiness: dict[str
             f"<td><code>{html.escape(surface['surface_type'])}</code></td>"
             f"<td><code>{html.escape(governance)}</code></td></tr>"
         )
+    agentplane = readiness["agentplane_run"]
 
     section = f"""
     <h2>Runtime evidence</h2>
@@ -180,6 +192,12 @@ def append_html(html_path: Path, refs_by_id: dict[str, str], readiness: dict[str
     <table>
       <thead><tr><th>Signal</th><th>Value</th></tr></thead>
       <tbody>
+        <tr><td>AgentPlane run ID</td><td><code>{html.escape(str(agentplane['run_id']))}</code></td></tr>
+        <tr><td>AgentPlane run ref</td><td><code>{html.escape(str(agentplane['run_ref']))}</code></td></tr>
+        <tr><td>AgentPlane ref</td><td><code>{html.escape(str(agentplane['agentplane_ref']))}</code></td></tr>
+        <tr><td>Requested by</td><td><code>{html.escape(str(agentplane['requested_by']))}</code></td></tr>
+        <tr><td>AgentPlane execution mode</td><td><code>{html.escape(str(agentplane['execution_mode']))}</code></td></tr>
+        <tr><td>AgentPlane approval state</td><td><code>{html.escape(str(agentplane['approval_state']))}</code></td></tr>
         <tr><td>Node profile</td><td><code>{html.escape(str(readiness['node_profile_ref']))}</code></td></tr>
         <tr><td>Node profile digest</td><td><code>{html.escape(str(readiness['node_profile_digest']))}</code></td></tr>
         <tr><td>Dry-run mode</td><td><code>{html.escape(str(readiness['dry_run_mode']))}</code></td></tr>
@@ -215,7 +233,7 @@ def update(summary_path: Path, runtime_adapter: Path, runtime_dry_run: Path) -> 
     artifacts = summary.setdefault("artifacts", {})
     artifacts.update(refs_by_id)
     checks = summary.setdefault("checks", [])
-    for check in ["runtime_adapter_indexed", "runtime_dry_run_record_indexed", "runtime_readiness_summary_appended"]:
+    for check in ["runtime_adapter_indexed", "runtime_dry_run_record_indexed", "runtime_readiness_summary_appended", "agentplane_run_linked"]:
         if check not in checks:
             checks.append(check)
     write_json(summary_path, summary)


### PR DESCRIPTION
Turn 26 / 32 toward credible MVP IBM-style parity.

Adds AgentPlane run linkage to runtime dry-run evidence and operator-facing local demo summaries.

Changes:
- requires `agentplane_run` in `FogStackRuntimeDryRunRecord`
- emits AgentPlane run ID, run ref, AgentPlane repo ref, requested-by, execution mode, and approval state
- validates AgentPlane ref against the Agent Machine node profile governance ref
- marks `agentplane_run` as a validated dry-run input
- surfaces AgentPlane run linkage in local demo Runtime readiness Markdown/HTML
- updates runtime dry-run and local-demo tests

Purpose: ensure runtime evidence is tied to AgentPlane-managed execution context before any live runtime mutation work begins.