### PR TITLE
fogstack: link runtime dry-run evidence to PolicyPlane decisions

### DIFF
--- a/schemas/runtime/fogstack-runtime-dry-run-record-v0.1.schema.json
+++ b/schemas/runtime/fogstack-runtime-dry-run-record-v0.1.schema.json
@@ -15,6 +15,7 @@
     "node_profile_ref",
     "node_profile_digest",
     "agentplane_run",
+    "policyplane_decision",
     "deploy_plan_ref",
     "deploy_plan_digest",
     "cluster_readiness_record_ref",
@@ -49,6 +50,22 @@
         "requested_by": { "type": "string", "minLength": 1 },
         "execution_mode": { "const": "dry-run" },
         "approval_state": { "const": "live-apply-requires-human-approval" }
+      },
+      "additionalProperties": false
+    },
+    "policyplane_decision": {
+      "type": "object",
+      "required": ["decision_id", "decision_ref", "policyplane_ref", "subject_ref", "decision", "effect", "reason", "live_apply_allowed", "human_approval_required"],
+      "properties": {
+        "decision_id": { "type": "string", "minLength": 1 },
+        "decision_ref": { "type": "string", "minLength": 1 },
+        "policyplane_ref": { "type": "string", "minLength": 1 },
+        "subject_ref": { "type": "string", "minLength": 1 },
+        "decision": { "const": "dry-run-allowed" },
+        "effect": { "const": "allow-dry-run-deny-live-apply" },
+        "reason": { "type": "string", "minLength": 1 },
+        "live_apply_allowed": { "const": false },
+        "human_approval_required": { "const": true }
       },
       "additionalProperties": false
     },

--- a/tools/emit_fogstack_runtime_dry_run_record.py
+++ b/tools/emit_fogstack_runtime_dry_run_record.py
@@ -78,6 +78,26 @@ def agentplane_run_payload(run_id: str, run_ref: str, agentplane_ref: str, reque
     }
 
 
+def policyplane_decision_payload(
+    decision_id: str,
+    decision_ref: str,
+    policyplane_ref: str,
+    subject_ref: str,
+    reason: str,
+) -> dict[str, Any]:
+    return {
+        "decision_id": decision_id,
+        "decision_ref": decision_ref,
+        "policyplane_ref": policyplane_ref,
+        "subject_ref": subject_ref,
+        "decision": "dry-run-allowed",
+        "effect": "allow-dry-run-deny-live-apply",
+        "reason": reason,
+        "live_apply_allowed": False,
+        "human_approval_required": True,
+    }
+
+
 def emit_record(
     adapter_path: Path,
     manifest_dir: Path,
@@ -86,6 +106,11 @@ def emit_record(
     agentplane_run_ref: str,
     agentplane_ref: str,
     requested_by: str,
+    policyplane_decision_id: str,
+    policyplane_decision_ref: str,
+    policyplane_ref: str,
+    policy_subject_ref: str,
+    policy_reason: str,
 ) -> dict[str, Any]:
     adapter_path = resolve(adapter_path)
     manifest_dir = resolve(manifest_dir)
@@ -128,6 +153,8 @@ def emit_record(
         raise SystemExit("ERR: GitOps readiness record must have passed status")
     if agentplane_ref != node_profile["governance"].get("agentplane_ref"):
         raise SystemExit("ERR: AgentPlane run ref does not match node profile governance")
+    if policyplane_ref != node_profile["governance"].get("policyplane_ref"):
+        raise SystemExit("ERR: PolicyPlane decision ref does not match node profile governance")
 
     manifest_paths = [
         manifest_dir / "configmap.yaml",
@@ -150,6 +177,13 @@ def emit_record(
         "node_profile_ref": rel(node_profile_path),
         "node_profile_digest": sha256_file(node_profile_path),
         "agentplane_run": agentplane_run_payload(agentplane_run_id, agentplane_run_ref, agentplane_ref, requested_by),
+        "policyplane_decision": policyplane_decision_payload(
+            policyplane_decision_id,
+            policyplane_decision_ref,
+            policyplane_ref,
+            policy_subject_ref,
+            policy_reason,
+        ),
         "deploy_plan_ref": rel(deploy_plan_path),
         "deploy_plan_digest": sha256_file(deploy_plan_path),
         "cluster_readiness_record_ref": rel(cluster_record_path),
@@ -169,6 +203,7 @@ def emit_record(
             "mutated_cluster": False,
             "validated_inputs": [
                 "agentplane_run",
+                "policyplane_decision",
                 "runtime_adapter",
                 "node_profile",
                 "deploy_plan",
@@ -204,6 +239,11 @@ def main() -> int:
     parser.add_argument("--agentplane-run-ref", default="agentplane://runs/fogstack.access/local-dry-run")
     parser.add_argument("--agentplane-ref", default="github://SocioProphet/agentplane")
     parser.add_argument("--requested-by", default="human:operator")
+    parser.add_argument("--policyplane-decision-id", default="policyplane-decision:fogstack.access:local-dry-run")
+    parser.add_argument("--policyplane-decision-ref", default="policyplane://decisions/fogstack.access/local-dry-run")
+    parser.add_argument("--policyplane-ref", default="github://SocioProphet/policy-fabric")
+    parser.add_argument("--policy-subject-ref", default="agentplane://runs/fogstack.access/local-dry-run")
+    parser.add_argument("--policy-reason", default="Dry-run evidence is allowed; live apply remains denied until human approval.")
     args = parser.parse_args()
     record = emit_record(
         args.runtime_adapter,
@@ -213,6 +253,11 @@ def main() -> int:
         args.agentplane_run_ref,
         args.agentplane_ref,
         args.requested_by,
+        args.policyplane_decision_id,
+        args.policyplane_decision_ref,
+        args.policyplane_ref,
+        args.policy_subject_ref,
+        args.policy_reason,
     )
     print(json.dumps(record, indent=2))
     return 0

--- a/tools/tests/test_fogstack_runtime_dry_run_record.py
+++ b/tools/tests/test_fogstack_runtime_dry_run_record.py
@@ -51,6 +51,10 @@ def test_emit_fogstack_runtime_dry_run_record(tmp_path: Path) -> None:
         "--agentplane-run-id", "agentplane-run:test",
         "--agentplane-run-ref", "agentplane://runs/test",
         "--requested-by", "human:test-operator",
+        "--policyplane-decision-id", "policyplane-decision:test",
+        "--policyplane-decision-ref", "policyplane://decisions/test",
+        "--policy-subject-ref", "agentplane://runs/test",
+        "--policy-reason", "test dry-run allowed",
     ], check=True)
     record = load_json(output)
     Draft202012Validator(load_json(SCHEMA)).validate(record)
@@ -67,8 +71,20 @@ def test_emit_fogstack_runtime_dry_run_record(tmp_path: Path) -> None:
         "execution_mode": "dry-run",
         "approval_state": "live-apply-requires-human-approval",
     }
+    assert record["policyplane_decision"] == {
+        "decision_id": "policyplane-decision:test",
+        "decision_ref": "policyplane://decisions/test",
+        "policyplane_ref": "github://SocioProphet/policy-fabric",
+        "subject_ref": "agentplane://runs/test",
+        "decision": "dry-run-allowed",
+        "effect": "allow-dry-run-deny-live-apply",
+        "reason": "test dry-run allowed",
+        "live_apply_allowed": False,
+        "human_approval_required": True,
+    }
     assert record["dry_run_result"]["mutated_cluster"] is False
     assert "agentplane_run" in record["dry_run_result"]["validated_inputs"]
+    assert "policyplane_decision" in record["dry_run_result"]["validated_inputs"]
     assert "node_profile" in record["dry_run_result"]["validated_inputs"]
     assert record["dry_run_result"]["validation_path"] == "contract-and-digest-only"
     assert record["runtime_policy"]["live_apply_allowed"] is False
@@ -100,3 +116,18 @@ def test_emit_fogstack_runtime_dry_run_record_rejects_wrong_agentplane_ref(tmp_p
     ], capture_output=True, text=True)
     assert proc.returncode != 0
     assert "AgentPlane run ref does not match node profile governance" in proc.stderr
+
+
+def test_emit_fogstack_runtime_dry_run_record_rejects_wrong_policyplane_ref(tmp_path: Path) -> None:
+    adapter, manifests = build_inputs(tmp_path)
+    output = tmp_path / "runtime-dry-run.json"
+    proc = subprocess.run([
+        sys.executable,
+        "tools/emit_fogstack_runtime_dry_run_record.py",
+        "--runtime-adapter", str(adapter),
+        "--manifest-dir", str(manifests),
+        "--output", str(output),
+        "--policyplane-ref", "github://SocioProphet/wrong-policy-fabric",
+    ], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert "PolicyPlane decision ref does not match node profile governance" in proc.stderr

--- a/tools/tests/test_run_fogstack_local_demo_full.py
+++ b/tools/tests/test_run_fogstack_local_demo_full.py
@@ -94,9 +94,17 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert runtime_dry_run["agentplane_run"]["agentplane_ref"] == "github://SocioProphet/agentplane"
     assert runtime_dry_run["agentplane_run"]["requested_by"] == "human:operator"
     assert runtime_dry_run["agentplane_run"]["approval_state"] == "live-apply-requires-human-approval"
+    assert runtime_dry_run["policyplane_decision"]["decision_id"] == "policyplane-decision:fogstack.access:local-dry-run"
+    assert runtime_dry_run["policyplane_decision"]["decision_ref"] == "policyplane://decisions/fogstack.access/local-dry-run"
+    assert runtime_dry_run["policyplane_decision"]["policyplane_ref"] == "github://SocioProphet/policy-fabric"
+    assert runtime_dry_run["policyplane_decision"]["decision"] == "dry-run-allowed"
+    assert runtime_dry_run["policyplane_decision"]["effect"] == "allow-dry-run-deny-live-apply"
+    assert runtime_dry_run["policyplane_decision"]["live_apply_allowed"] is False
+    assert runtime_dry_run["policyplane_decision"]["human_approval_required"] is True
     assert runtime_dry_run["dry_run_result"]["mutated_cluster"] is False
     assert runtime_dry_run["dry_run_result"]["validation_path"] == "contract-and-digest-only"
     assert "agentplane_run" in runtime_dry_run["dry_run_result"]["validated_inputs"]
+    assert "policyplane_decision" in runtime_dry_run["dry_run_result"]["validated_inputs"]
 
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed_ids = {entry["id"] for entry in artifact_index["artifacts"]}
@@ -120,6 +128,12 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert "agentplane-run:fogstack.access:local-dry-run" in html
     assert "agentplane://runs/fogstack.access/local-dry-run" in html
     assert "github://SocioProphet/agentplane" in html
+    assert "PolicyPlane decision ID" in html
+    assert "policyplane-decision:fogstack.access:local-dry-run" in html
+    assert "policyplane://decisions/fogstack.access/local-dry-run" in html
+    assert "github://SocioProphet/policy-fabric" in html
+    assert "dry-run-allowed" in html
+    assert "allow-dry-run-deny-live-apply" in html
     assert "live-apply-requires-human-approval" in html
     assert "TurtleTerm" in html
     assert "BearBrowser" in html

--- a/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
@@ -50,6 +50,7 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     assert "runtime_dry_run_record_indexed" in summary["checks"]
     assert "runtime_readiness_summary_appended" in summary["checks"]
     assert "agentplane_run_linked" in summary["checks"]
+    assert "policyplane_decision_linked" in summary["checks"]
 
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed = {entry["id"]: entry for entry in artifact_index["artifacts"]}
@@ -88,9 +89,17 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     assert runtime_dry_run["agentplane_run"]["agentplane_ref"] == "github://SocioProphet/agentplane"
     assert runtime_dry_run["agentplane_run"]["requested_by"] == "human:operator"
     assert runtime_dry_run["agentplane_run"]["approval_state"] == "live-apply-requires-human-approval"
+    assert runtime_dry_run["policyplane_decision"]["decision_id"] == "policyplane-decision:fogstack.access:local-dry-run"
+    assert runtime_dry_run["policyplane_decision"]["decision_ref"] == "policyplane://decisions/fogstack.access/local-dry-run"
+    assert runtime_dry_run["policyplane_decision"]["policyplane_ref"] == "github://SocioProphet/policy-fabric"
+    assert runtime_dry_run["policyplane_decision"]["decision"] == "dry-run-allowed"
+    assert runtime_dry_run["policyplane_decision"]["effect"] == "allow-dry-run-deny-live-apply"
+    assert runtime_dry_run["policyplane_decision"]["live_apply_allowed"] is False
+    assert runtime_dry_run["policyplane_decision"]["human_approval_required"] is True
     assert runtime_dry_run["dry_run_result"]["mutated_cluster"] is False
     assert runtime_dry_run["dry_run_result"]["validation_path"] == "contract-and-digest-only"
     assert "agentplane_run" in runtime_dry_run["dry_run_result"]["validated_inputs"]
+    assert "policyplane_decision" in runtime_dry_run["dry_run_result"]["validated_inputs"]
     assert "node_profile" in runtime_dry_run["dry_run_result"]["validated_inputs"]
 
     markdown = (output_dir / "fogstack-local-demo.summary.md").read_text(encoding="utf-8")
@@ -104,6 +113,12 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
         assert "agentplane-run:fogstack.access:local-dry-run" in content
         assert "agentplane://runs/fogstack.access/local-dry-run" in content
         assert "github://SocioProphet/agentplane" in content
+        assert "PolicyPlane decision ID" in content
+        assert "policyplane-decision:fogstack.access:local-dry-run" in content
+        assert "policyplane://decisions/fogstack.access/local-dry-run" in content
+        assert "github://SocioProphet/policy-fabric" in content
+        assert "dry-run-allowed" in content
+        assert "allow-dry-run-deny-live-apply" in content
         assert "live-apply-requires-human-approval" in content
         assert "TurtleTerm" in content
         assert "BearBrowser" in content

--- a/tools/update_fogstack_local_demo_runtime_evidence.py
+++ b/tools/update_fogstack_local_demo_runtime_evidence.py
@@ -87,11 +87,15 @@ def runtime_readiness(runtime_adapter_ref: str, runtime_dry_run_ref: str) -> dic
     agentplane_run = dry_run.get("agentplane_run")
     if not isinstance(agentplane_run, dict):
         raise SystemExit("ERR: runtime dry-run evidence missing AgentPlane run linkage")
+    policyplane_decision = dry_run.get("policyplane_decision")
+    if not isinstance(policyplane_decision, dict):
+        raise SystemExit("ERR: runtime dry-run evidence missing PolicyPlane decision linkage")
 
     return {
         "node_profile_ref": node_profile_ref,
         "node_profile_digest": dry_run.get("node_profile_digest") or adapter.get("inputs", {}).get("node_profile_digest"),
         "agentplane_run": agentplane_run,
+        "policyplane_decision": policyplane_decision,
         "surfaces": surfaces,
         "dry_run_mode": dry_run.get("dry_run_result", {}).get("mode"),
         "validation_path": dry_run.get("dry_run_result", {}).get("validation_path"),
@@ -116,6 +120,7 @@ def append_markdown(markdown_path: Path, refs_by_id: dict[str, str], readiness: 
             f"`first_class={str(surface['first_class']).lower()}; agentplane_visible={str(surface['agentplane_visible']).lower()}; policyplane_guarded={str(surface['policyplane_guarded']).lower()}` |"
         )
     agentplane = readiness["agentplane_run"]
+    policyplane = readiness["policyplane_decision"]
 
     section = "\n".join([
         "",
@@ -135,6 +140,15 @@ def append_markdown(markdown_path: Path, refs_by_id: dict[str, str], readiness: 
         f"| Requested by | `{agentplane['requested_by']}` |",
         f"| AgentPlane execution mode | `{agentplane['execution_mode']}` |",
         f"| AgentPlane approval state | `{agentplane['approval_state']}` |",
+        f"| PolicyPlane decision ID | `{policyplane['decision_id']}` |",
+        f"| PolicyPlane decision ref | `{policyplane['decision_ref']}` |",
+        f"| PolicyPlane ref | `{policyplane['policyplane_ref']}` |",
+        f"| PolicyPlane subject | `{policyplane['subject_ref']}` |",
+        f"| PolicyPlane decision | `{policyplane['decision']}` |",
+        f"| PolicyPlane effect | `{policyplane['effect']}` |",
+        f"| PolicyPlane reason | `{policyplane['reason']}` |",
+        f"| PolicyPlane live apply allowed | `{str(policyplane['live_apply_allowed']).lower()}` |",
+        f"| PolicyPlane human approval required | `{str(policyplane['human_approval_required']).lower()}` |",
         f"| Node profile | `{readiness['node_profile_ref']}` |",
         f"| Node profile digest | `{readiness['node_profile_digest']}` |",
         f"| Dry-run mode | `{readiness['dry_run_mode']}` |",
@@ -179,6 +193,7 @@ def append_html(html_path: Path, refs_by_id: dict[str, str], readiness: dict[str
             f"<td><code>{html.escape(governance)}</code></td></tr>"
         )
     agentplane = readiness["agentplane_run"]
+    policyplane = readiness["policyplane_decision"]
 
     section = f"""
     <h2>Runtime evidence</h2>
@@ -198,6 +213,15 @@ def append_html(html_path: Path, refs_by_id: dict[str, str], readiness: dict[str
         <tr><td>Requested by</td><td><code>{html.escape(str(agentplane['requested_by']))}</code></td></tr>
         <tr><td>AgentPlane execution mode</td><td><code>{html.escape(str(agentplane['execution_mode']))}</code></td></tr>
         <tr><td>AgentPlane approval state</td><td><code>{html.escape(str(agentplane['approval_state']))}</code></td></tr>
+        <tr><td>PolicyPlane decision ID</td><td><code>{html.escape(str(policyplane['decision_id']))}</code></td></tr>
+        <tr><td>PolicyPlane decision ref</td><td><code>{html.escape(str(policyplane['decision_ref']))}</code></td></tr>
+        <tr><td>PolicyPlane ref</td><td><code>{html.escape(str(policyplane['policyplane_ref']))}</code></td></tr>
+        <tr><td>PolicyPlane subject</td><td><code>{html.escape(str(policyplane['subject_ref']))}</code></td></tr>
+        <tr><td>PolicyPlane decision</td><td><code>{html.escape(str(policyplane['decision']))}</code></td></tr>
+        <tr><td>PolicyPlane effect</td><td><code>{html.escape(str(policyplane['effect']))}</code></td></tr>
+        <tr><td>PolicyPlane reason</td><td><code>{html.escape(str(policyplane['reason']))}</code></td></tr>
+        <tr><td>PolicyPlane live apply allowed</td><td><code>{html.escape(str(policyplane['live_apply_allowed']).lower())}</code></td></tr>
+        <tr><td>PolicyPlane human approval required</td><td><code>{html.escape(str(policyplane['human_approval_required']).lower())}</code></td></tr>
         <tr><td>Node profile</td><td><code>{html.escape(str(readiness['node_profile_ref']))}</code></td></tr>
         <tr><td>Node profile digest</td><td><code>{html.escape(str(readiness['node_profile_digest']))}</code></td></tr>
         <tr><td>Dry-run mode</td><td><code>{html.escape(str(readiness['dry_run_mode']))}</code></td></tr>
@@ -233,7 +257,7 @@ def update(summary_path: Path, runtime_adapter: Path, runtime_dry_run: Path) -> 
     artifacts = summary.setdefault("artifacts", {})
     artifacts.update(refs_by_id)
     checks = summary.setdefault("checks", [])
-    for check in ["runtime_adapter_indexed", "runtime_dry_run_record_indexed", "runtime_readiness_summary_appended", "agentplane_run_linked"]:
+    for check in ["runtime_adapter_indexed", "runtime_dry_run_record_indexed", "runtime_readiness_summary_appended", "agentplane_run_linked", "policyplane_decision_linked"]:
         if check not in checks:
             checks.append(check)
     write_json(summary_path, summary)


### PR DESCRIPTION
Turn 27 / 32 toward credible MVP IBM-style parity.

Adds PolicyPlane decision linkage before runtime actions.

Changes:
- requires `policyplane_decision` in `FogStackRuntimeDryRunRecord`
- emits PolicyPlane decision ID, decision ref, policy fabric ref, subject ref, decision, effect, reason, live-apply state, and human-approval requirement
- validates PolicyPlane ref against the Agent Machine node profile governance ref
- marks `policyplane_decision` as a validated dry-run input
- surfaces PolicyPlane decision linkage in local demo Runtime readiness Markdown/HTML
- updates runtime dry-run and local-demo tests

Purpose: ensure runtime evidence is policy-gated before any live cluster mutation work begins.