### PR TITLE
fogstack: emit immutable update readiness record

### DIFF
--- a/.github/workflows/fogstack-local-cluster-runtime.yml
+++ b/.github/workflows/fogstack-local-cluster-runtime.yml
@@ -11,6 +11,7 @@ on:
       - "bundles/fogstack.*.yaml"
       - "releases/manifests/fogstack.*.manifest.json"
       - "tools/build_fogstack_agent_machine_node_profile.py"
+      - "tools/emit_fogstack_immutable_update_readiness_record.py"
       - "tools/build_fogstack_runtime_contract.py"
       - "tools/build_fogstack_deploy_plan.py"
       - "tools/render_fogstack_kubernetes_manifests.py"
@@ -22,6 +23,7 @@ on:
       - "tools/emit_fogstack_runtime_dry_run_record.py"
       - "tools/tests/test_fogstack_local_cluster_runtime_adapter.py"
       - "tools/tests/test_fogstack_runtime_dry_run_record.py"
+      - "tools/tests/test_fogstack_immutable_update_readiness_record.py"
       - ".github/workflows/fogstack-local-cluster-runtime.yml"
   push:
     branches: [main]
@@ -33,6 +35,7 @@ on:
       - "bundles/fogstack.*.yaml"
       - "releases/manifests/fogstack.*.manifest.json"
       - "tools/build_fogstack_agent_machine_node_profile.py"
+      - "tools/emit_fogstack_immutable_update_readiness_record.py"
       - "tools/build_fogstack_runtime_contract.py"
       - "tools/build_fogstack_deploy_plan.py"
       - "tools/render_fogstack_kubernetes_manifests.py"
@@ -44,6 +47,7 @@ on:
       - "tools/emit_fogstack_runtime_dry_run_record.py"
       - "tools/tests/test_fogstack_local_cluster_runtime_adapter.py"
       - "tools/tests/test_fogstack_runtime_dry_run_record.py"
+      - "tools/tests/test_fogstack_immutable_update_readiness_record.py"
       - ".github/workflows/fogstack-local-cluster-runtime.yml"
 
 permissions:
@@ -71,13 +75,17 @@ jobs:
         run: |
           python -m pytest -q \
             tools/tests/test_fogstack_local_cluster_runtime_adapter.py \
-            tools/tests/test_fogstack_runtime_dry_run_record.py
+            tools/tests/test_fogstack_runtime_dry_run_record.py \
+            tools/tests/test_fogstack_immutable_update_readiness_record.py
 
       - name: Build sample local cluster runtime adapter
         run: |
           mkdir -p build/fogstack-runtime-inputs
           python3 tools/build_fogstack_agent_machine_node_profile.py \
             --output build/fogstack-runtime-inputs/node-profile.json
+          python3 tools/emit_fogstack_immutable_update_readiness_record.py \
+            --node-profile build/fogstack-runtime-inputs/node-profile.json \
+            --output build/fogstack-runtime-inputs/immutable-update-readiness.record.json
           python3 tools/build_fogstack_runtime_contract.py \
             --bundle-id fogstack.access \
             --version 0.1.0 \
@@ -119,5 +127,6 @@ jobs:
             --manifest-dir build/fogstack-runtime-inputs/manifests \
             --output build/fogstack-runtime-inputs/runtime-dry-run.record.json
           test -s build/fogstack-runtime-inputs/node-profile.json
+          test -s build/fogstack-runtime-inputs/immutable-update-readiness.record.json
           test -s build/fogstack-runtime-inputs/local-cluster-runtime-adapter.json
           test -s build/fogstack-runtime-inputs/runtime-dry-run.record.json

--- a/schemas/runtime/fogstack-immutable-update-readiness-record-v0.1.schema.json
+++ b/schemas/runtime/fogstack-immutable-update-readiness-record-v0.1.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/runtime/fogstack-immutable-update-readiness-record-v0.1.schema.json",
+  "title": "FogStackImmutableUpdateReadinessRecord",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "status",
+    "node_profile_ref",
+    "node_profile_digest",
+    "os",
+    "image",
+    "declarative_updates",
+    "governance",
+    "policy",
+    "readiness"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackImmutableUpdateReadinessRecord" },
+    "schema_version": { "const": "v0.1" },
+    "status": { "enum": ["passed", "failed"] },
+    "node_profile_ref": { "type": "string", "minLength": 1 },
+    "node_profile_digest": { "$ref": "#/$defs/sha256_digest" },
+    "os": {
+      "type": "object",
+      "required": ["family", "distribution", "immutability", "configuration_model"],
+      "properties": {
+        "family": { "enum": ["SourceOS", "AgentOS", "SociOS-Linux"] },
+        "distribution": { "type": "string", "minLength": 1 },
+        "immutability": { "enum": ["ostree", "nixos", "image-based", "unknown"] },
+        "configuration_model": { "enum": ["nix-flake", "ignition-butane", "rpm-ostree", "container-image", "hybrid"] }
+      },
+      "additionalProperties": false
+    },
+    "image": {
+      "type": "object",
+      "required": ["builder", "image_ref", "digest_required", "sbom_required", "provenance_required"],
+      "properties": {
+        "builder": { "enum": ["nix", "rpm-ostree", "bootc", "containerfile", "unknown"] },
+        "image_ref": { "type": "string", "minLength": 1 },
+        "digest_required": { "const": true },
+        "sbom_required": { "const": true },
+        "provenance_required": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "declarative_updates": {
+      "type": "object",
+      "required": ["strategy", "rollback_required", "preflight_required", "agentplane_gate_required"],
+      "properties": {
+        "strategy": { "enum": ["nix-flake-switch", "ostree-rebase", "image-promotion", "hybrid"] },
+        "rollback_required": { "const": true },
+        "preflight_required": { "const": true },
+        "agentplane_gate_required": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "governance": {
+      "type": "object",
+      "required": ["agentplane_ref", "policyplane_ref", "human_approval_required", "live_mutation_default"],
+      "properties": {
+        "agentplane_ref": { "type": "string", "minLength": 1 },
+        "policyplane_ref": { "type": "string", "minLength": 1 },
+        "human_approval_required": { "const": true },
+        "live_mutation_default": { "const": "deny" }
+      },
+      "additionalProperties": false
+    },
+    "policy": {
+      "type": "object",
+      "required": ["host_mutation_default", "cluster_join_default", "live_update_allowed", "requires_agentplane_gate", "requires_policyplane_decision"],
+      "properties": {
+        "host_mutation_default": { "const": "deny" },
+        "cluster_join_default": { "const": "approval-required" },
+        "live_update_allowed": { "const": false },
+        "requires_agentplane_gate": { "const": true },
+        "requires_policyplane_decision": { "const": true }
+      },
+      "additionalProperties": false
+    },
+    "readiness": {
+      "type": "object",
+      "required": ["digest_ready", "sbom_ready", "provenance_ready", "rollback_ready", "preflight_ready", "agentplane_gate_ready", "policyplane_gate_ready"],
+      "properties": {
+        "digest_ready": { "type": "boolean" },
+        "sbom_ready": { "type": "boolean" },
+        "provenance_ready": { "type": "boolean" },
+        "rollback_ready": { "type": "boolean" },
+        "preflight_ready": { "type": "boolean" },
+        "agentplane_gate_ready": { "type": "boolean" },
+        "policyplane_gate_ready": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "sha256_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/emit_fogstack_immutable_update_readiness_record.py
+++ b/tools/emit_fogstack_immutable_update_readiness_record.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def emit_record(node_profile_path: Path, output_path: Path) -> dict[str, Any]:
+    node_profile_path = resolve(node_profile_path)
+    output_path = resolve(output_path)
+    node_profile = load_json(node_profile_path)
+    if node_profile.get("kind") != "FogStackAgentMachineNodeProfile":
+        raise SystemExit("ERR: expected FogStackAgentMachineNodeProfile")
+
+    image = node_profile["image"]
+    updates = node_profile["declarative_updates"]
+    governance = node_profile["governance"]
+    runtime_policy = node_profile["runtime_policy"]
+    readiness = {
+        "digest_ready": image.get("digest_required") is True,
+        "sbom_ready": image.get("sbom_required") is True,
+        "provenance_ready": image.get("provenance_required") is True,
+        "rollback_ready": updates.get("rollback_required") is True,
+        "preflight_ready": updates.get("preflight_required") is True,
+        "agentplane_gate_ready": updates.get("agentplane_gate_required") is True and bool(governance.get("agentplane_ref")),
+        "policyplane_gate_ready": bool(governance.get("policyplane_ref")),
+    }
+    status = "passed" if all(readiness.values()) and governance.get("live_mutation_default") == "deny" and runtime_policy.get("host_mutation_default") == "deny" else "failed"
+
+    record = {
+        "kind": "FogStackImmutableUpdateReadinessRecord",
+        "schema_version": "v0.1",
+        "status": status,
+        "node_profile_ref": rel(node_profile_path),
+        "node_profile_digest": sha256_file(node_profile_path),
+        "os": node_profile["os"],
+        "image": image,
+        "declarative_updates": updates,
+        "governance": governance,
+        "policy": {
+            "host_mutation_default": runtime_policy["host_mutation_default"],
+            "cluster_join_default": runtime_policy["cluster_join_default"],
+            "live_update_allowed": False,
+            "requires_agentplane_gate": True,
+            "requires_policyplane_decision": True,
+        },
+        "readiness": readiness,
+    }
+    write_json(output_path, record)
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a FogStack immutable/declarative update readiness record")
+    parser.add_argument("--node-profile", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    record = emit_record(args.node_profile, args.output)
+    print(json.dumps(record, indent=2))
+    return 0 if record["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_immutable_update_readiness_record.py
+++ b/tools/tests/test_fogstack_immutable_update_readiness_record.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+SCHEMA = Path("schemas/runtime/fogstack-immutable-update-readiness-record-v0.1.schema.json")
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def emit_record(node_profile: Path, output: Path) -> dict:
+    subprocess.run([
+        sys.executable,
+        "tools/emit_fogstack_immutable_update_readiness_record.py",
+        "--node-profile", str(node_profile),
+        "--output", str(output),
+    ], check=True)
+    return load_json(output)
+
+
+def test_emit_immutable_update_readiness_record_sourceos_nix(tmp_path: Path) -> None:
+    node_profile = tmp_path / "sourceos-node-profile.json"
+    output = tmp_path / "immutable-update-readiness.json"
+    subprocess.run([sys.executable, "tools/build_fogstack_agent_machine_node_profile.py", "--output", str(node_profile)], check=True)
+
+    record = emit_record(node_profile, output)
+    Draft202012Validator(load_json(SCHEMA)).validate(record)
+    assert record["kind"] == "FogStackImmutableUpdateReadinessRecord"
+    assert record["status"] == "passed"
+    assert record["os"]["family"] == "SourceOS"
+    assert record["os"]["immutability"] == "nixos"
+    assert record["os"]["configuration_model"] == "nix-flake"
+    assert record["image"]["builder"] == "nix"
+    assert record["image"]["digest_required"] is True
+    assert record["image"]["sbom_required"] is True
+    assert record["image"]["provenance_required"] is True
+    assert record["declarative_updates"]["strategy"] == "nix-flake-switch"
+    assert record["declarative_updates"]["rollback_required"] is True
+    assert record["declarative_updates"]["preflight_required"] is True
+    assert record["declarative_updates"]["agentplane_gate_required"] is True
+    assert record["governance"]["agentplane_ref"] == "github://SocioProphet/agentplane"
+    assert record["governance"]["policyplane_ref"] == "github://SocioProphet/policy-fabric"
+    assert record["policy"] == {
+        "host_mutation_default": "deny",
+        "cluster_join_default": "approval-required",
+        "live_update_allowed": False,
+        "requires_agentplane_gate": True,
+        "requires_policyplane_decision": True,
+    }
+    assert all(record["readiness"].values())
+
+
+def test_emit_immutable_update_readiness_record_agentos_ostree(tmp_path: Path) -> None:
+    node_profile = tmp_path / "agentos-node-profile.json"
+    output = tmp_path / "immutable-update-readiness.json"
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_agent_machine_node_profile.py",
+        "--output", str(node_profile),
+        "--os-family", "AgentOS",
+        "--distribution", "AgentOS-Linux",
+        "--immutability", "ostree",
+        "--configuration-model", "rpm-ostree",
+        "--image-builder", "rpm-ostree",
+        "--update-strategy", "ostree-rebase",
+        "--no-topolvm",
+    ], check=True)
+
+    record = emit_record(node_profile, output)
+    Draft202012Validator(load_json(SCHEMA)).validate(record)
+    assert record["status"] == "passed"
+    assert record["os"]["family"] == "AgentOS"
+    assert record["os"]["immutability"] == "ostree"
+    assert record["os"]["configuration_model"] == "rpm-ostree"
+    assert record["image"]["builder"] == "rpm-ostree"
+    assert record["declarative_updates"]["strategy"] == "ostree-rebase"
+    assert all(record["readiness"].values())


### PR DESCRIPTION
Turn 28 / 32 toward credible MVP IBM-style parity.

Adds a SourceOS/AgentOS immutable/declarative update readiness record.

Changes:
- adds `FogStackImmutableUpdateReadinessRecord` schema
- adds emitter derived from `FogStackAgentMachineNodeProfile`
- proves SourceOS/Nix/nix-flake readiness
- proves AgentOS/ostree/rpm-ostree readiness
- checks digest, SBOM, provenance, rollback, preflight, AgentPlane gate, PolicyPlane gate, host mutation denial, and approval-required cluster join
- emits a sample readiness record in the local-cluster-runtime workflow

Purpose: align immutable image and declarative update readiness with SourceOS/AgentOS node operations before live update or cluster mutation work begins.