### PR TITLE
fogstack: emit Agent Machine node inventory record

### DIFF
--- a/.github/workflows/fogstack-local-cluster-runtime.yml
+++ b/.github/workflows/fogstack-local-cluster-runtime.yml
@@ -11,6 +11,7 @@ on:
       - "bundles/fogstack.*.yaml"
       - "releases/manifests/fogstack.*.manifest.json"
       - "tools/build_fogstack_agent_machine_node_profile.py"
+      - "tools/emit_fogstack_agent_machine_node_inventory_record.py"
       - "tools/emit_fogstack_immutable_update_readiness_record.py"
       - "tools/build_fogstack_runtime_contract.py"
       - "tools/build_fogstack_deploy_plan.py"
@@ -24,6 +25,7 @@ on:
       - "tools/tests/test_fogstack_local_cluster_runtime_adapter.py"
       - "tools/tests/test_fogstack_runtime_dry_run_record.py"
       - "tools/tests/test_fogstack_immutable_update_readiness_record.py"
+      - "tools/tests/test_fogstack_agent_machine_node_inventory_record.py"
       - ".github/workflows/fogstack-local-cluster-runtime.yml"
   push:
     branches: [main]
@@ -35,6 +37,7 @@ on:
       - "bundles/fogstack.*.yaml"
       - "releases/manifests/fogstack.*.manifest.json"
       - "tools/build_fogstack_agent_machine_node_profile.py"
+      - "tools/emit_fogstack_agent_machine_node_inventory_record.py"
       - "tools/emit_fogstack_immutable_update_readiness_record.py"
       - "tools/build_fogstack_runtime_contract.py"
       - "tools/build_fogstack_deploy_plan.py"
@@ -48,6 +51,7 @@ on:
       - "tools/tests/test_fogstack_local_cluster_runtime_adapter.py"
       - "tools/tests/test_fogstack_runtime_dry_run_record.py"
       - "tools/tests/test_fogstack_immutable_update_readiness_record.py"
+      - "tools/tests/test_fogstack_agent_machine_node_inventory_record.py"
       - ".github/workflows/fogstack-local-cluster-runtime.yml"
 
 permissions:
@@ -76,13 +80,17 @@ jobs:
           python -m pytest -q \
             tools/tests/test_fogstack_local_cluster_runtime_adapter.py \
             tools/tests/test_fogstack_runtime_dry_run_record.py \
-            tools/tests/test_fogstack_immutable_update_readiness_record.py
+            tools/tests/test_fogstack_immutable_update_readiness_record.py \
+            tools/tests/test_fogstack_agent_machine_node_inventory_record.py
 
       - name: Build sample local cluster runtime adapter
         run: |
           mkdir -p build/fogstack-runtime-inputs
           python3 tools/build_fogstack_agent_machine_node_profile.py \
             --output build/fogstack-runtime-inputs/node-profile.json
+          python3 tools/emit_fogstack_agent_machine_node_inventory_record.py \
+            --node-profile build/fogstack-runtime-inputs/node-profile.json \
+            --output build/fogstack-runtime-inputs/agent-machine-node-inventory.record.json
           python3 tools/emit_fogstack_immutable_update_readiness_record.py \
             --node-profile build/fogstack-runtime-inputs/node-profile.json \
             --output build/fogstack-runtime-inputs/immutable-update-readiness.record.json
@@ -127,6 +135,7 @@ jobs:
             --manifest-dir build/fogstack-runtime-inputs/manifests \
             --output build/fogstack-runtime-inputs/runtime-dry-run.record.json
           test -s build/fogstack-runtime-inputs/node-profile.json
+          test -s build/fogstack-runtime-inputs/agent-machine-node-inventory.record.json
           test -s build/fogstack-runtime-inputs/immutable-update-readiness.record.json
           test -s build/fogstack-runtime-inputs/local-cluster-runtime-adapter.json
           test -s build/fogstack-runtime-inputs/runtime-dry-run.record.json

--- a/schemas/runtime/fogstack-agent-machine-node-inventory-record-v0.1.schema.json
+++ b/schemas/runtime/fogstack-agent-machine-node-inventory-record-v0.1.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/runtime/fogstack-agent-machine-node-inventory-record-v0.1.schema.json",
+  "title": "FogStackAgentMachineNodeInventoryRecord",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "status",
+    "node_profile_ref",
+    "node_profile_digest",
+    "inventory",
+    "storage",
+    "agent_machine",
+    "cluster",
+    "governance",
+    "readiness"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackAgentMachineNodeInventoryRecord" },
+    "schema_version": { "const": "v0.1" },
+    "status": { "enum": ["passed", "failed"] },
+    "node_profile_ref": { "type": "string", "minLength": 1 },
+    "node_profile_digest": { "$ref": "#/$defs/sha256_digest" },
+    "inventory": {
+      "type": "object",
+      "required": ["node_id", "node_role", "os_family", "distribution", "immutability", "configuration_model"],
+      "properties": {
+        "node_id": { "type": "string", "minLength": 1 },
+        "node_role": { "enum": ["edge-agent-node", "cluster-agent-node", "control-plane-agent-node"] },
+        "os_family": { "enum": ["SourceOS", "AgentOS", "SociOS-Linux"] },
+        "distribution": { "type": "string", "minLength": 1 },
+        "immutability": { "enum": ["ostree", "nixos", "image-based", "unknown"] },
+        "configuration_model": { "enum": ["nix-flake", "ignition-butane", "rpm-ostree", "container-image", "hybrid"] }
+      },
+      "additionalProperties": false
+    },
+    "storage": {
+      "type": "object",
+      "required": ["topolvm_required", "ephemeral_storage", "persistent_storage", "volume_policy", "storage_ready"],
+      "properties": {
+        "topolvm_required": { "type": "boolean" },
+        "ephemeral_storage": { "enum": ["local", "topolvm", "none"] },
+        "persistent_storage": { "enum": ["topolvm", "external-csi", "none"] },
+        "volume_policy": { "enum": ["deny-by-default", "explicit-claim-only"] },
+        "storage_ready": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "agent_machine": {
+      "type": "object",
+      "required": ["enabled", "identity_ref", "workload_runtime", "node_contract_required", "use_surfaces"],
+      "properties": {
+        "enabled": { "const": true },
+        "identity_ref": { "type": "string", "minLength": 1 },
+        "workload_runtime": { "enum": ["rootless-podman", "kubernetes", "systemd-user", "hybrid"] },
+        "node_contract_required": { "const": true },
+        "use_surfaces": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "repo_ref", "first_class", "agentplane_visible", "policyplane_guarded"],
+            "properties": {
+              "id": { "enum": ["turtleterm", "bearbrowser"] },
+              "repo_ref": { "type": "string", "minLength": 1 },
+              "first_class": { "const": true },
+              "agentplane_visible": { "const": true },
+              "policyplane_guarded": { "const": true }
+            },
+            "additionalProperties": false
+          },
+          "minItems": 2
+        }
+      },
+      "additionalProperties": false
+    },
+    "cluster": {
+      "type": "object",
+      "required": ["cluster_provider", "cluster_role", "join_policy", "mutation_default"],
+      "properties": {
+        "cluster_provider": { "enum": ["kind", "generic-kubernetes", "future-agentos-cluster"] },
+        "cluster_role": { "enum": ["worker", "control-plane", "single-node"] },
+        "join_policy": { "const": "approval-required" },
+        "mutation_default": { "const": "deny" }
+      },
+      "additionalProperties": false
+    },
+    "governance": {
+      "type": "object",
+      "required": ["agentplane_ref", "policyplane_ref", "human_approval_required", "live_mutation_default"],
+      "properties": {
+        "agentplane_ref": { "type": "string", "minLength": 1 },
+        "policyplane_ref": { "type": "string", "minLength": 1 },
+        "human_approval_required": { "const": true },
+        "live_mutation_default": { "const": "deny" }
+      },
+      "additionalProperties": false
+    },
+    "readiness": {
+      "type": "object",
+      "required": ["node_profile_ready", "agent_machine_ready", "storage_ready", "surfaces_ready", "governance_ready", "cluster_join_ready"],
+      "properties": {
+        "node_profile_ready": { "type": "boolean" },
+        "agent_machine_ready": { "type": "boolean" },
+        "storage_ready": { "type": "boolean" },
+        "surfaces_ready": { "type": "boolean" },
+        "governance_ready": { "type": "boolean" },
+        "cluster_join_ready": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "sha256_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/emit_fogstack_agent_machine_node_inventory_record.py
+++ b/tools/emit_fogstack_agent_machine_node_inventory_record.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_SURFACES = {"turtleterm", "bearbrowser"}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def compact_surface(surface: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": surface["id"],
+        "repo_ref": surface["repo_ref"],
+        "first_class": surface["first_class"],
+        "agentplane_visible": surface["agentplane_visible"],
+        "policyplane_guarded": surface["policyplane_guarded"],
+    }
+
+
+def emit_record(
+    node_profile_path: Path,
+    output_path: Path,
+    node_id: str,
+    cluster_provider: str,
+    cluster_role: str,
+) -> dict[str, Any]:
+    node_profile_path = resolve(node_profile_path)
+    output_path = resolve(output_path)
+    node_profile = load_json(node_profile_path)
+    if node_profile.get("kind") != "FogStackAgentMachineNodeProfile":
+        raise SystemExit("ERR: expected FogStackAgentMachineNodeProfile")
+
+    surfaces = {surface.get("id"): surface for surface in node_profile.get("use_surfaces", []) if isinstance(surface, dict)}
+    missing = REQUIRED_SURFACES - set(surfaces)
+    if missing:
+        raise SystemExit(f"ERR: missing required use surfaces: {', '.join(sorted(missing))}")
+
+    storage = node_profile["storage"]
+    agent_machine = node_profile["agent_machine"]
+    governance = node_profile["governance"]
+    runtime_policy = node_profile["runtime_policy"]
+    readiness = {
+        "node_profile_ready": True,
+        "agent_machine_ready": agent_machine.get("enabled") is True and agent_machine.get("node_contract_required") is True,
+        "storage_ready": storage.get("topolvm_required") is False or storage.get("persistent_storage") == "topolvm",
+        "surfaces_ready": all(
+            surfaces[surface_id].get("first_class") is True
+            and surfaces[surface_id].get("agentplane_visible") is True
+            and surfaces[surface_id].get("policyplane_guarded") is True
+            for surface_id in REQUIRED_SURFACES
+        ),
+        "governance_ready": bool(governance.get("agentplane_ref")) and bool(governance.get("policyplane_ref")) and governance.get("human_approval_required") is True,
+        "cluster_join_ready": runtime_policy.get("cluster_join_default") == "approval-required",
+    }
+    status = "passed" if all(readiness.values()) and runtime_policy.get("host_mutation_default") == "deny" else "failed"
+
+    record = {
+        "kind": "FogStackAgentMachineNodeInventoryRecord",
+        "schema_version": "v0.1",
+        "status": status,
+        "node_profile_ref": rel(node_profile_path),
+        "node_profile_digest": sha256_file(node_profile_path),
+        "inventory": {
+            "node_id": node_id,
+            "node_role": node_profile["node_role"],
+            "os_family": node_profile["os"]["family"],
+            "distribution": node_profile["os"]["distribution"],
+            "immutability": node_profile["os"]["immutability"],
+            "configuration_model": node_profile["os"]["configuration_model"],
+        },
+        "storage": {
+            "topolvm_required": storage["topolvm_required"],
+            "ephemeral_storage": storage["ephemeral_storage"],
+            "persistent_storage": storage["persistent_storage"],
+            "volume_policy": storage["volume_policy"],
+            "storage_ready": readiness["storage_ready"],
+        },
+        "agent_machine": {
+            "enabled": agent_machine["enabled"],
+            "identity_ref": agent_machine["identity_ref"],
+            "workload_runtime": agent_machine["workload_runtime"],
+            "node_contract_required": agent_machine["node_contract_required"],
+            "use_surfaces": [compact_surface(surfaces[surface_id]) for surface_id in sorted(REQUIRED_SURFACES)],
+        },
+        "cluster": {
+            "cluster_provider": cluster_provider,
+            "cluster_role": cluster_role,
+            "join_policy": "approval-required",
+            "mutation_default": "deny",
+        },
+        "governance": governance,
+        "readiness": readiness,
+    }
+    write_json(output_path, record)
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a FogStack Agent Machine node inventory record")
+    parser.add_argument("--node-profile", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--node-id", default="agent-machine://sourceos/edge/default")
+    parser.add_argument("--cluster-provider", choices=["kind", "generic-kubernetes", "future-agentos-cluster"], default="kind")
+    parser.add_argument("--cluster-role", choices=["worker", "control-plane", "single-node"], default="worker")
+    args = parser.parse_args()
+    record = emit_record(args.node_profile, args.output, args.node_id, args.cluster_provider, args.cluster_role)
+    print(json.dumps(record, indent=2))
+    return 0 if record["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_agent_machine_node_inventory_record.py
+++ b/tools/tests/test_fogstack_agent_machine_node_inventory_record.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+SCHEMA = Path("schemas/runtime/fogstack-agent-machine-node-inventory-record-v0.1.schema.json")
+
+
+def load_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def emit_inventory(node_profile: Path, output: Path, *extra: str) -> dict:
+    subprocess.run([
+        sys.executable,
+        "tools/emit_fogstack_agent_machine_node_inventory_record.py",
+        "--node-profile", str(node_profile),
+        "--output", str(output),
+        *extra,
+    ], check=True)
+    return load_json(output)
+
+
+def assert_required_surfaces(record: dict) -> None:
+    surfaces = {surface["id"]: surface for surface in record["agent_machine"]["use_surfaces"]}
+    assert surfaces["turtleterm"]["repo_ref"] == "github://SourceOS-Linux/TurtleTerm"
+    assert surfaces["turtleterm"]["first_class"] is True
+    assert surfaces["turtleterm"]["agentplane_visible"] is True
+    assert surfaces["turtleterm"]["policyplane_guarded"] is True
+    assert surfaces["bearbrowser"]["repo_ref"] == "github://SourceOS-Linux/BearBrowser"
+    assert surfaces["bearbrowser"]["first_class"] is True
+    assert surfaces["bearbrowser"]["agentplane_visible"] is True
+    assert surfaces["bearbrowser"]["policyplane_guarded"] is True
+
+
+def test_emit_agent_machine_node_inventory_sourceos_topolvm(tmp_path: Path) -> None:
+    node_profile = tmp_path / "sourceos-node-profile.json"
+    output = tmp_path / "node-inventory.json"
+    subprocess.run([sys.executable, "tools/build_fogstack_agent_machine_node_profile.py", "--output", str(node_profile)], check=True)
+
+    record = emit_inventory(node_profile, output)
+    Draft202012Validator(load_json(SCHEMA)).validate(record)
+    assert record["kind"] == "FogStackAgentMachineNodeInventoryRecord"
+    assert record["status"] == "passed"
+    assert record["inventory"]["node_role"] == "edge-agent-node"
+    assert record["inventory"]["os_family"] == "SourceOS"
+    assert record["inventory"]["immutability"] == "nixos"
+    assert record["inventory"]["configuration_model"] == "nix-flake"
+    assert record["storage"]["topolvm_required"] is True
+    assert record["storage"]["persistent_storage"] == "topolvm"
+    assert record["storage"]["storage_ready"] is True
+    assert record["agent_machine"]["enabled"] is True
+    assert record["agent_machine"]["node_contract_required"] is True
+    assert_required_surfaces(record)
+    assert record["cluster"] == {
+        "cluster_provider": "kind",
+        "cluster_role": "worker",
+        "join_policy": "approval-required",
+        "mutation_default": "deny",
+    }
+    assert record["governance"]["agentplane_ref"] == "github://SocioProphet/agentplane"
+    assert record["governance"]["policyplane_ref"] == "github://SocioProphet/policy-fabric"
+    assert all(record["readiness"].values())
+
+
+def test_emit_agent_machine_node_inventory_agentos_external_csi(tmp_path: Path) -> None:
+    node_profile = tmp_path / "agentos-node-profile.json"
+    output = tmp_path / "node-inventory.json"
+    subprocess.run([
+        sys.executable,
+        "tools/build_fogstack_agent_machine_node_profile.py",
+        "--output", str(node_profile),
+        "--os-family", "AgentOS",
+        "--distribution", "AgentOS-Linux",
+        "--immutability", "ostree",
+        "--configuration-model", "rpm-ostree",
+        "--image-builder", "rpm-ostree",
+        "--update-strategy", "ostree-rebase",
+        "--no-topolvm",
+    ], check=True)
+
+    record = emit_inventory(node_profile, output, "--cluster-provider", "generic-kubernetes", "--cluster-role", "single-node")
+    Draft202012Validator(load_json(SCHEMA)).validate(record)
+    assert record["status"] == "passed"
+    assert record["inventory"]["os_family"] == "AgentOS"
+    assert record["inventory"]["immutability"] == "ostree"
+    assert record["storage"]["topolvm_required"] is False
+    assert record["storage"]["persistent_storage"] == "external-csi"
+    assert record["storage"]["storage_ready"] is True
+    assert record["cluster"]["cluster_provider"] == "generic-kubernetes"
+    assert record["cluster"]["cluster_role"] == "single-node"
+    assert_required_surfaces(record)
+    assert all(record["readiness"].values())


### PR DESCRIPTION
Turn 29 / 32 toward credible MVP IBM-style parity.

Adds an Agent Machine + TopoLVM node inventory record.

Changes:
- adds `FogStackAgentMachineNodeInventoryRecord` schema
- adds inventory emitter derived from `FogStackAgentMachineNodeProfile`
- captures node role, SourceOS/AgentOS identity, immutable configuration model, Agent Machine identity, workload runtime, TurtleTerm/BearBrowser surfaces, TopoLVM/external-CSI storage posture, cluster role, join policy, mutation default, AgentPlane governance, and PolicyPlane governance
- proves SourceOS/TopoLVM worker inventory
- proves AgentOS/external-CSI single-node inventory
- emits a sample inventory record in the local-cluster-runtime workflow

Purpose: make Agent Machine + TopoLVM node membership visible and testable before live cluster join or mutation work begins.