### PR TITLE
fogstack: index node and update readiness evidence in local demo

### DIFF
--- a/tools/run_fogstack_local_demo_deploy_plan.py
+++ b/tools/run_fogstack_local_demo_deploy_plan.py
@@ -33,6 +33,8 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
     output_dir.mkdir(parents=True, exist_ok=True)
 
     node_profile = output_dir / "fogstack.access.agent-machine-node-profile.json"
+    node_inventory_record = output_dir / "fogstack.access.agent-machine-node-inventory.record.json"
+    immutable_update_readiness_record = output_dir / "fogstack.access.immutable-update-readiness.record.json"
     runtime_contract = output_dir / "fogstack.access.runtime-contract.json"
     deploy_plan = output_dir / "fogstack.access.deploy-plan.json"
     manifest_dir = output_dir / "kubernetes"
@@ -48,6 +50,18 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
         sys.executable,
         "tools/build_fogstack_agent_machine_node_profile.py",
         "--output", str(node_profile),
+    ])
+    run([
+        sys.executable,
+        "tools/emit_fogstack_agent_machine_node_inventory_record.py",
+        "--node-profile", str(node_profile),
+        "--output", str(node_inventory_record),
+    ])
+    run([
+        sys.executable,
+        "tools/emit_fogstack_immutable_update_readiness_record.py",
+        "--node-profile", str(node_profile),
+        "--output", str(immutable_update_readiness_record),
     ])
     run([
         sys.executable,
@@ -172,6 +186,8 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
         "target": "kubernetes",
         "artifacts": {
             "node_profile": rel(node_profile),
+            "node_inventory_record": rel(node_inventory_record),
+            "immutable_update_readiness_record": rel(immutable_update_readiness_record),
             "agent_corps_plan": rel(runtime_contract),
             "deploy_plan": rel(deploy_plan),
             "kubernetes_configmap": rel(manifest_dir / "configmap.yaml"),
@@ -192,6 +208,8 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
         },
         "checks": [
             "node_profile_built",
+            "node_inventory_record_emitted",
+            "immutable_update_readiness_record_emitted",
             "agent_corps_plan_built",
             "agent_corps_plan_checked",
             "deploy_plan_built",
@@ -217,6 +235,8 @@ def render_summary(summary: dict[str, Any]) -> str:
         f"Bundle: {summary['bundle_id']}@{summary['version']}",
         f"Target: {summary['target']}",
         f"Agent Machine node profile: {artifacts['node_profile']}",
+        f"Agent Machine node inventory: {artifacts['node_inventory_record']}",
+        f"Immutable update readiness: {artifacts['immutable_update_readiness_record']}",
         f"Agent Corps plan: {artifacts['agent_corps_plan']}",
         f"Deploy plan: {artifacts['deploy_plan']}",
         f"Kubernetes ConfigMap: {artifacts['kubernetes_configmap']}",

--- a/tools/run_fogstack_local_demo_full.py
+++ b/tools/run_fogstack_local_demo_full.py
@@ -38,6 +38,8 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
     deploy_dir = output_dir / "deploy"
     summary_path = output_dir / "fogstack-local-demo.summary.json"
     deploy_summary_path = deploy_dir / "fogstack.access.deploy-demo.summary.json"
+    node_inventory_path = deploy_dir / "fogstack.access.agent-machine-node-inventory.record.json"
+    immutable_update_path = deploy_dir / "fogstack.access.immutable-update-readiness.record.json"
     gitops_readiness_path = deploy_dir / "fogstack.access.gitops-readiness.record.json"
     runtime_adapter_path = deploy_dir / "fogstack.access.local-cluster-runtime-adapter.json"
     runtime_dry_run_path = deploy_dir / "fogstack.access.runtime-dry-run.record.json"
@@ -104,6 +106,8 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
             "local_demo_html": rel(output_dir / "index.html"),
             "artifact_index": rel(artifact_index_path),
             "deploy_summary": rel(deploy_summary_path),
+            "node_inventory_record": rel(node_inventory_path),
+            "immutable_update_readiness_record": rel(immutable_update_path),
             "deploy_plan": rel(deploy_dir / "fogstack.access.deploy-plan.json"),
             "agent_corps_plan": rel(deploy_dir / "fogstack.access.runtime-contract.json"),
             "kubernetes_configmap": rel(deploy_dir / "kubernetes" / "configmap.yaml"),
@@ -125,6 +129,8 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
             "local_demo_generated",
             "deploy_plan_generated",
             "deploy_artifacts_integrated",
+            "node_inventory_record_indexed",
+            "immutable_update_readiness_record_indexed",
             "cluster_readiness_record_indexed",
             "gitops_bundle_indexed",
             "gitops_readiness_record_indexed",
@@ -144,6 +150,8 @@ def render_summary(summary: dict[str, Any]) -> str:
         f"Output directory: {summary['output_dir']}",
         f"HTML summary: {artifacts['local_demo_html']}",
         f"Artifact index: {artifacts['artifact_index']}",
+        f"Agent Machine node inventory: {artifacts['node_inventory_record']}",
+        f"Immutable update readiness: {artifacts['immutable_update_readiness_record']}",
         f"Deploy plan: {artifacts['deploy_plan']}",
         f"Kubernetes deployment: {artifacts['kubernetes_deployment']}",
         f"Cluster readiness record: {artifacts['cluster_readiness_record']}",

--- a/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
+++ b/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
@@ -27,16 +27,20 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert "Bundle: fogstack.access@0.1.0" in proc.stdout
     assert "Target: kubernetes" in proc.stdout
     assert "Agent Machine node profile:" in proc.stdout
+    assert "Agent Machine node inventory:" in proc.stdout
+    assert "Immutable update readiness:" in proc.stdout
     assert "Cluster readiness record:" in proc.stdout
     assert "GitOps bundle:" in proc.stdout
     assert "GitOps application:" in proc.stdout
     assert "GitOps readiness record:" in proc.stdout
     assert "Runtime adapter:" in proc.stdout
     assert "Runtime dry-run record:" in proc.stdout
-    assert "Checks passed: 13" in proc.stdout
+    assert "Checks passed: 15" in proc.stdout
 
     summary_path = output_dir / "fogstack.access.deploy-demo.summary.json"
     node_profile_path = output_dir / "fogstack.access.agent-machine-node-profile.json"
+    node_inventory_path = output_dir / "fogstack.access.agent-machine-node-inventory.record.json"
+    immutable_update_path = output_dir / "fogstack.access.immutable-update-readiness.record.json"
     check_record_path = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
     readiness_record_path = output_dir / "fogstack.access.cluster-readiness.record.json"
     gitops_readiness_path = output_dir / "fogstack.access.gitops-readiness.record.json"
@@ -50,6 +54,8 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     for path in [
         summary_path,
         node_profile_path,
+        node_inventory_path,
+        immutable_update_path,
         check_record_path,
         readiness_record_path,
         gitops_readiness_path,
@@ -76,6 +82,8 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     assert summary["target"] == "kubernetes"
     assert set(summary["checks"]) == {
         "node_profile_built",
+        "node_inventory_record_emitted",
+        "immutable_update_readiness_record_emitted",
         "agent_corps_plan_built",
         "agent_corps_plan_checked",
         "deploy_plan_built",
@@ -92,6 +100,8 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
 
     artifacts = summary["artifacts"]
     assert artifacts["node_profile"].endswith("fogstack.access.agent-machine-node-profile.json")
+    assert artifacts["node_inventory_record"].endswith("fogstack.access.agent-machine-node-inventory.record.json")
+    assert artifacts["immutable_update_readiness_record"].endswith("fogstack.access.immutable-update-readiness.record.json")
     assert artifacts["agent_corps_plan"].endswith("fogstack.access.runtime-contract.json")
     assert artifacts["deploy_plan"].endswith("fogstack.access.deploy-plan.json")
     assert artifacts["kubernetes_configmap"].endswith("configmap.yaml")
@@ -111,6 +121,21 @@ def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     surfaces = {surface["id"]: surface for surface in node_profile["use_surfaces"]}
     assert surfaces["turtleterm"]["repo_ref"] == "github://SourceOS-Linux/TurtleTerm"
     assert surfaces["bearbrowser"]["repo_ref"] == "github://SourceOS-Linux/BearBrowser"
+
+    node_inventory = json.loads(node_inventory_path.read_text(encoding="utf-8"))
+    assert node_inventory["kind"] == "FogStackAgentMachineNodeInventoryRecord"
+    assert node_inventory["status"] == "passed"
+    assert node_inventory["storage"]["topolvm_required"] is True
+    assert node_inventory["storage"]["persistent_storage"] == "topolvm"
+    assert node_inventory["cluster"]["join_policy"] == "approval-required"
+
+    immutable_update = json.loads(immutable_update_path.read_text(encoding="utf-8"))
+    assert immutable_update["kind"] == "FogStackImmutableUpdateReadinessRecord"
+    assert immutable_update["status"] == "passed"
+    assert immutable_update["image"]["digest_required"] is True
+    assert immutable_update["image"]["sbom_required"] is True
+    assert immutable_update["image"]["provenance_required"] is True
+    assert immutable_update["policy"]["live_update_allowed"] is False
 
     check_record = json.loads(check_record_path.read_text(encoding="utf-8"))
     assert check_record["kind"] == "FogStackKubernetesManifestCheckRecord"

--- a/tools/tests/test_run_fogstack_local_demo_full.py
+++ b/tools/tests/test_run_fogstack_local_demo_full.py
@@ -12,6 +12,8 @@ REQUIRED_FULL_ARTIFACTS = {
     "local_demo_html",
     "artifact_index",
     "deploy_summary",
+    "node_inventory_record",
+    "immutable_update_readiness_record",
     "deploy_plan",
     "agent_corps_plan",
     "kubernetes_configmap",
@@ -48,6 +50,8 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
 
     assert "FogStack full local demo passed." in proc.stdout
     assert "Artifact index:" in proc.stdout
+    assert "Agent Machine node inventory:" in proc.stdout
+    assert "Immutable update readiness:" in proc.stdout
     assert "Deploy plan:" in proc.stdout
     assert "Kubernetes deployment:" in proc.stdout
     assert "Cluster readiness record:" in proc.stdout
@@ -63,6 +67,8 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert full_summary["kind"] == "FogStackLocalDemoFullRun"
     assert full_summary["status"] == "passed"
     assert REQUIRED_FULL_ARTIFACTS == set(full_summary["artifacts"])
+    assert "node_inventory_record_indexed" in full_summary["checks"]
+    assert "immutable_update_readiness_record_indexed" in full_summary["checks"]
     assert "cluster_readiness_record_indexed" in full_summary["checks"]
     assert "gitops_bundle_indexed" in full_summary["checks"]
     assert "gitops_readiness_record_indexed" in full_summary["checks"]
@@ -70,6 +76,21 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert "runtime_dry_run_record_indexed" in full_summary["checks"]
     for ref in full_summary["artifacts"].values():
         assert Path(ref).exists(), ref
+
+    node_inventory = json.loads(Path(full_summary["artifacts"]["node_inventory_record"]).read_text(encoding="utf-8"))
+    assert node_inventory["kind"] == "FogStackAgentMachineNodeInventoryRecord"
+    assert node_inventory["status"] == "passed"
+    assert node_inventory["storage"]["topolvm_required"] is True
+    assert node_inventory["storage"]["persistent_storage"] == "topolvm"
+    assert node_inventory["cluster"]["join_policy"] == "approval-required"
+
+    immutable_update = json.loads(Path(full_summary["artifacts"]["immutable_update_readiness_record"]).read_text(encoding="utf-8"))
+    assert immutable_update["kind"] == "FogStackImmutableUpdateReadinessRecord"
+    assert immutable_update["status"] == "passed"
+    assert immutable_update["image"]["digest_required"] is True
+    assert immutable_update["image"]["sbom_required"] is True
+    assert immutable_update["image"]["provenance_required"] is True
+    assert immutable_update["policy"]["live_update_allowed"] is False
 
     readiness_record = json.loads(Path(full_summary["artifacts"]["cluster_readiness_record"]).read_text(encoding="utf-8"))
     assert readiness_record["kind"] == "FogStackClusterReadinessRecord"
@@ -108,6 +129,8 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
 
     artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
     indexed_ids = {entry["id"] for entry in artifact_index["artifacts"]}
+    assert "deploy_node_inventory_record" in indexed_ids
+    assert "deploy_immutable_update_readiness_record" in indexed_ids
     assert "deploy_plan" in indexed_ids
     assert "deploy_kubernetes_deployment" in indexed_ids
     assert "deploy_kubernetes_manifest_check_record" in indexed_ids
@@ -124,6 +147,10 @@ def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     assert "GitOps readiness" in html
     assert "Runtime evidence" in html
     assert "Runtime readiness" in html
+    assert "deploy_node_inventory_record" in html
+    assert "deploy_immutable_update_readiness_record" in html
+    assert "Agent Machine node inventory" in html
+    assert "Immutable update readiness" in html
     assert "AgentPlane run ID" in html
     assert "agentplane-run:fogstack.access:local-dry-run" in html
     assert "agentplane://runs/fogstack.access/local-dry-run" in html

--- a/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 REQUIRED = {
     "deploy_node_profile",
+    "deploy_node_inventory_record",
+    "deploy_immutable_update_readiness_record",
     "deploy_agent_corps_plan",
     "deploy_plan",
     "deploy_kubernetes_configmap",
@@ -40,6 +42,8 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     summary = json.loads((output_dir / "fogstack-local-demo.summary.json").read_text(encoding="utf-8"))
     assert REQUIRED.issubset(set(summary["artifacts"]))
     assert "node_profile_built" in summary["checks"]
+    assert "node_inventory_record_emitted" in summary["checks"]
+    assert "immutable_update_readiness_record_emitted" in summary["checks"]
     assert "deploy_plan_built" in summary["checks"]
     assert "kubernetes_manifests_checked" in summary["checks"]
     assert "cluster_readiness_record_emitted" in summary["checks"]
@@ -64,6 +68,20 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     surfaces = {surface["id"]: surface for surface in node_profile["use_surfaces"]}
     assert surfaces["turtleterm"]["repo_ref"] == "github://SourceOS-Linux/TurtleTerm"
     assert surfaces["bearbrowser"]["repo_ref"] == "github://SourceOS-Linux/BearBrowser"
+
+    node_inventory = json.loads(Path(summary["artifacts"]["deploy_node_inventory_record"]).read_text(encoding="utf-8"))
+    assert node_inventory["kind"] == "FogStackAgentMachineNodeInventoryRecord"
+    assert node_inventory["status"] == "passed"
+    assert node_inventory["storage"]["topolvm_required"] is True
+    assert node_inventory["cluster"]["join_policy"] == "approval-required"
+
+    immutable_update = json.loads(Path(summary["artifacts"]["deploy_immutable_update_readiness_record"]).read_text(encoding="utf-8"))
+    assert immutable_update["kind"] == "FogStackImmutableUpdateReadinessRecord"
+    assert immutable_update["status"] == "passed"
+    assert immutable_update["image"]["digest_required"] is True
+    assert immutable_update["image"]["sbom_required"] is True
+    assert immutable_update["image"]["provenance_required"] is True
+    assert immutable_update["policy"]["live_update_allowed"] is False
 
     readiness_record = json.loads(Path(summary["artifacts"]["deploy_cluster_readiness_record"]).read_text(encoding="utf-8"))
     assert readiness_record["kind"] == "FogStackClusterReadinessRecord"
@@ -109,6 +127,10 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
         assert "GitOps readiness" in content
         assert "Runtime evidence" in content
         assert "Runtime readiness" in content
+        assert "deploy_node_inventory_record" in content
+        assert "deploy_immutable_update_readiness_record" in content
+        assert "Agent Machine node inventory" in content
+        assert "Immutable update readiness" in content
         assert "AgentPlane run ID" in content
         assert "agentplane-run:fogstack.access:local-dry-run" in content
         assert "agentplane://runs/fogstack.access/local-dry-run" in content

--- a/tools/update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/update_fogstack_local_demo_deploy_artifacts.py
@@ -12,6 +12,8 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 DEPLOY_ARTIFACT_KEYS = {
     "node_profile": "deploy_node_profile",
+    "node_inventory_record": "deploy_node_inventory_record",
+    "immutable_update_readiness_record": "deploy_immutable_update_readiness_record",
     "agent_corps_plan": "deploy_agent_corps_plan",
     "deploy_plan": "deploy_plan",
     "kubernetes_configmap": "deploy_kubernetes_configmap",
@@ -29,6 +31,8 @@ DEPLOY_ARTIFACT_KEYS = {
 }
 DEPLOY_ARTIFACT_LABELS = {
     "deploy_node_profile": "Agent Machine node profile",
+    "deploy_node_inventory_record": "Agent Machine node inventory",
+    "deploy_immutable_update_readiness_record": "Immutable update readiness",
     "deploy_agent_corps_plan": "Agent Corps plan",
     "deploy_plan": "Deploy plan",
     "deploy_kubernetes_configmap": "Kubernetes ConfigMap",
@@ -193,7 +197,7 @@ def update_summary(summary_path: Path, deploy_summary_path: Path) -> dict[str, A
         artifacts[target_key] = deploy_summary["artifacts"][source_key]
 
     checks = summary.setdefault("checks", [])
-    for check in ["node_profile_built", "deploy_plan_built", "kubernetes_manifests_rendered", "kubernetes_manifests_checked", "cluster_readiness_record_emitted", "gitops_bundle_built", "gitops_bundle_checked"]:
+    for check in ["node_profile_built", "node_inventory_record_emitted", "immutable_update_readiness_record_emitted", "deploy_plan_built", "kubernetes_manifests_rendered", "kubernetes_manifests_checked", "cluster_readiness_record_emitted", "gitops_bundle_built", "gitops_bundle_checked"]:
         if check not in checks:
             checks.append(check)
 


### PR DESCRIPTION
Turn 30 / 32 toward credible MVP IBM-style parity.

Surfaces Agent Machine node inventory and immutable update readiness in the full local demo evidence index and operator summaries.

Changes:
- local deploy demo now emits `fogstack.access.agent-machine-node-inventory.record.json`
- local deploy demo now emits `fogstack.access.immutable-update-readiness.record.json`
- deploy artifact updater indexes both records as `deploy_node_inventory_record` and `deploy_immutable_update_readiness_record`
- full local demo summary exposes both records as top-level artifacts
- deploy/full local-demo tests prove both artifacts exist, are indexed, and are visible in HTML/Markdown

Purpose: make Agent Machine + TopoLVM node inventory and SourceOS/AgentOS immutable update readiness visible in the same operator-facing proof path as runtime and GitOps evidence.