### PR TITLE
fogstack: add parity readiness validation

### DIFF
--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -20,6 +20,8 @@ on:
       - "tools/update_fogstack_local_demo_gitops_readiness.py"
       - "tools/update_fogstack_local_demo_runtime_evidence.py"
       - "tools/run_fogstack_local_demo_full.py"
+      - "tools/check_fogstack_parity_readiness.py"
+      - "tools/run_fogstack_parity_readiness.py"
       - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
       - "tools/build_fogstack_runtime_contract.py"
@@ -33,6 +35,9 @@ on:
       - "tools/emit_fogstack_gitops_readiness_record.py"
       - "tools/build_fogstack_local_cluster_runtime_adapter.py"
       - "tools/emit_fogstack_runtime_dry_run_record.py"
+      - "tools/build_fogstack_agent_machine_node_profile.py"
+      - "tools/emit_fogstack_agent_machine_node_inventory_record.py"
+      - "tools/emit_fogstack_immutable_update_readiness_record.py"
       - "tools/fogstack_verify.py"
       - "tools/emit_fogstack_validation_record.py"
       - "tools/build_fogstack_manifest_publication_set.py"
@@ -55,6 +60,8 @@ on:
       - "tools/tests/test_serve_fogstack_local_demo.py"
       - "tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py"
       - "tools/tests/test_run_fogstack_local_demo_full.py"
+      - "tools/tests/test_fogstack_parity_readiness.py"
+      - "tools/tests/test_run_fogstack_parity_readiness.py"
       - ".github/workflows/fogstack-local-demo.yml"
   push:
     branches: [main]
@@ -75,6 +82,8 @@ on:
       - "tools/update_fogstack_local_demo_gitops_readiness.py"
       - "tools/update_fogstack_local_demo_runtime_evidence.py"
       - "tools/run_fogstack_local_demo_full.py"
+      - "tools/check_fogstack_parity_readiness.py"
+      - "tools/run_fogstack_parity_readiness.py"
       - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
       - "tools/build_fogstack_runtime_contract.py"
@@ -88,11 +97,16 @@ on:
       - "tools/emit_fogstack_gitops_readiness_record.py"
       - "tools/build_fogstack_local_cluster_runtime_adapter.py"
       - "tools/emit_fogstack_runtime_dry_run_record.py"
+      - "tools/build_fogstack_agent_machine_node_profile.py"
+      - "tools/emit_fogstack_agent_machine_node_inventory_record.py"
+      - "tools/emit_fogstack_immutable_update_readiness_record.py"
       - "tools/tests/test_run_fogstack_local_demo.py"
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
       - "tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py"
       - "tools/tests/test_run_fogstack_local_demo_full.py"
+      - "tools/tests/test_fogstack_parity_readiness.py"
+      - "tools/tests/test_run_fogstack_parity_readiness.py"
       - ".github/workflows/fogstack-local-demo.yml"
 
 permissions:
@@ -123,13 +137,21 @@ jobs:
             tools/tests/test_check_fogstack_local_demo_artifact_index.py \
             tools/tests/test_serve_fogstack_local_demo.py \
             tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py \
-            tools/tests/test_run_fogstack_local_demo_full.py
+            tools/tests/test_run_fogstack_local_demo_full.py \
+            tools/tests/test_fogstack_parity_readiness.py \
+            tools/tests/test_run_fogstack_parity_readiness.py
 
       - name: Run full operator demo command
         run: |
           make fogstack-local-demo-full
+          python3 tools/check_fogstack_parity_readiness.py \
+            --summary build/fogstack-local-demo/fogstack-local-demo.full.summary.json \
+            --index build/fogstack-local-demo/demo-artifacts.index.json \
+            --output build/fogstack-local-demo/fogstack-parity-readiness.record.json \
+            --summary-text
           test -s build/fogstack-local-demo/fogstack-local-demo.full.summary.json
           test -s build/fogstack-local-demo/demo-artifacts.index.json
+          test -s build/fogstack-local-demo/fogstack-parity-readiness.record.json
           test -s build/fogstack-local-demo/deploy/fogstack.access.deploy-plan.json
           test -s build/fogstack-local-demo/deploy/kubernetes/deployment.yaml
           test -s build/fogstack-local-demo/deploy/gitops/gitops-bundle.json
@@ -138,6 +160,13 @@ jobs:
           test -s build/fogstack-local-demo/deploy/fogstack.access.gitops-readiness.record.json
           test -s build/fogstack-local-demo/deploy/fogstack.access.local-cluster-runtime-adapter.json
           test -s build/fogstack-local-demo/deploy/fogstack.access.runtime-dry-run.record.json
+          test -s build/fogstack-local-demo/deploy/fogstack.access.agent-machine-node-inventory.record.json
+          test -s build/fogstack-local-demo/deploy/fogstack.access.immutable-update-readiness.record.json
+
+      - name: Run one-command parity readiness
+        run: |
+          python3 tools/run_fogstack_parity_readiness.py --summary
+          test -s build/fogstack-local-demo/fogstack-parity-readiness.record.json
 
       - name: Check generated artifact index
         run: |

--- a/tools/check_fogstack_parity_readiness.py
+++ b/tools/check_fogstack_parity_readiness.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_SUMMARY_ARTIFACTS = {
+    "local_demo_summary",
+    "local_demo_markdown",
+    "local_demo_html",
+    "artifact_index",
+    "deploy_summary",
+    "node_inventory_record",
+    "immutable_update_readiness_record",
+    "deploy_plan",
+    "agent_corps_plan",
+    "cluster_readiness_record",
+    "gitops_bundle",
+    "gitops_application",
+    "gitops_kustomization",
+    "gitops_readiness_record",
+    "runtime_adapter",
+    "runtime_dry_run_record",
+}
+REQUIRED_INDEX_IDS = {
+    "deploy_node_profile",
+    "deploy_node_inventory_record",
+    "deploy_immutable_update_readiness_record",
+    "deploy_agent_corps_plan",
+    "deploy_plan",
+    "deploy_kubernetes_configmap",
+    "deploy_kubernetes_deployment",
+    "deploy_kubernetes_service",
+    "deploy_kubernetes_manifest_check_record",
+    "deploy_cluster_readiness_record",
+    "deploy_gitops_bundle",
+    "deploy_gitops_application",
+    "deploy_gitops_kustomization",
+    "deploy_gitops_configmap",
+    "deploy_gitops_deployment",
+    "deploy_gitops_service",
+    "deploy_gitops_readiness_record",
+    "deploy_runtime_adapter",
+    "deploy_runtime_dry_run_record",
+    "deploy_summary",
+}
+
+
+def path_from_ref(ref: str) -> Path:
+    path = Path(ref)
+    return path if path.is_absolute() else ROOT / path
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def require(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def check_artifact_files(artifacts: dict[str, Any], errors: list[str]) -> dict[str, Path]:
+    paths: dict[str, Path] = {}
+    for artifact_id in sorted(REQUIRED_SUMMARY_ARTIFACTS):
+        ref = artifacts.get(artifact_id)
+        if not isinstance(ref, str):
+            errors.append(f"missing summary artifact: {artifact_id}")
+            continue
+        path = path_from_ref(ref)
+        paths[artifact_id] = path
+        require(path.exists() and path.is_file(), f"summary artifact missing on disk: {artifact_id} {ref}", errors)
+    return paths
+
+
+def check_index(index: dict[str, Any], errors: list[str]) -> None:
+    require(index.get("kind") == "FogStackLocalDemoArtifactIndex", "artifact index kind mismatch", errors)
+    entries = {entry.get("id"): entry for entry in index.get("artifacts", []) if isinstance(entry, dict)}
+    for artifact_id in sorted(REQUIRED_INDEX_IDS):
+        entry = entries.get(artifact_id)
+        if not entry:
+            errors.append(f"artifact index missing id: {artifact_id}")
+            continue
+        ref = entry.get("ref")
+        digest = entry.get("digest")
+        if not isinstance(ref, str):
+            errors.append(f"artifact index missing ref: {artifact_id}")
+            continue
+        path = path_from_ref(ref)
+        require(path.exists() and path.is_file(), f"artifact index file missing: {artifact_id} {ref}", errors)
+        if path.exists() and path.is_file():
+            require(digest == sha256_file(path), f"artifact index digest mismatch: {artifact_id}", errors)
+
+
+def check_records(paths: dict[str, Path], errors: list[str]) -> list[dict[str, str]]:
+    checked: list[dict[str, str]] = []
+
+    node_inventory = load_json(paths["node_inventory_record"])
+    require(node_inventory.get("kind") == "FogStackAgentMachineNodeInventoryRecord", "node inventory kind mismatch", errors)
+    require(node_inventory.get("status") == "passed", "node inventory did not pass", errors)
+    require(node_inventory.get("storage", {}).get("topolvm_required") is True, "node inventory does not require TopoLVM for default SourceOS node", errors)
+    require(node_inventory.get("storage", {}).get("persistent_storage") == "topolvm", "node inventory persistent storage is not TopoLVM", errors)
+    surfaces = {surface.get("id"): surface for surface in node_inventory.get("agent_machine", {}).get("use_surfaces", []) if isinstance(surface, dict)}
+    for surface_id, expected_ref in {
+        "turtleterm": "github://SourceOS-Linux/TurtleTerm",
+        "bearbrowser": "github://SourceOS-Linux/BearBrowser",
+    }.items():
+        surface = surfaces.get(surface_id)
+        require(isinstance(surface, dict), f"missing required use surface: {surface_id}", errors)
+        if surface:
+            require(surface.get("repo_ref") == expected_ref, f"wrong repo ref for surface: {surface_id}", errors)
+            require(surface.get("agentplane_visible") is True, f"surface not AgentPlane-visible: {surface_id}", errors)
+            require(surface.get("policyplane_guarded") is True, f"surface not PolicyPlane-guarded: {surface_id}", errors)
+    checked.append({"id": "node_inventory", "status": "passed"})
+
+    immutable_update = load_json(paths["immutable_update_readiness_record"])
+    require(immutable_update.get("kind") == "FogStackImmutableUpdateReadinessRecord", "immutable update kind mismatch", errors)
+    require(immutable_update.get("status") == "passed", "immutable update readiness did not pass", errors)
+    require(all(immutable_update.get("readiness", {}).values()), "immutable update readiness flags are not all true", errors)
+    require(immutable_update.get("policy", {}).get("live_update_allowed") is False, "immutable update allows live update", errors)
+    checked.append({"id": "immutable_update_readiness", "status": "passed"})
+
+    cluster = load_json(paths["cluster_readiness_record"])
+    require(cluster.get("kind") == "FogStackClusterReadinessRecord", "cluster readiness kind mismatch", errors)
+    require(cluster.get("status") == "passed", "cluster readiness did not pass", errors)
+    checked.append({"id": "cluster_readiness", "status": "passed"})
+
+    gitops = load_json(paths["gitops_readiness_record"])
+    require(gitops.get("kind") == "FogStackGitOpsReadinessRecord", "GitOps readiness kind mismatch", errors)
+    require(gitops.get("status") == "passed", "GitOps readiness did not pass", errors)
+    require(gitops.get("validation_result", {}).get("bundle_validated") is True, "GitOps bundle was not validated", errors)
+    checked.append({"id": "gitops_readiness", "status": "passed"})
+
+    runtime_adapter = load_json(paths["runtime_adapter"])
+    require(runtime_adapter.get("kind") == "FogStackLocalClusterRuntimeAdapter", "runtime adapter kind mismatch", errors)
+    require(runtime_adapter.get("runtime_policy", {}).get("live_apply_allowed") is False, "runtime adapter allows live apply", errors)
+    checked.append({"id": "runtime_adapter", "status": "passed"})
+
+    runtime = load_json(paths["runtime_dry_run_record"])
+    require(runtime.get("kind") == "FogStackRuntimeDryRunRecord", "runtime dry-run kind mismatch", errors)
+    require(runtime.get("status") == "passed", "runtime dry-run did not pass", errors)
+    require(runtime.get("dry_run_result", {}).get("mutated_cluster") is False, "runtime dry-run mutated cluster", errors)
+    require(runtime.get("dry_run_result", {}).get("validation_path") == "contract-and-digest-only", "runtime dry-run validation path mismatch", errors)
+    require(runtime.get("runtime_policy", {}).get("live_apply_allowed") is False, "runtime dry-run allows live apply", errors)
+    agentplane = runtime.get("agentplane_run", {})
+    require(agentplane.get("agentplane_ref") == "github://SocioProphet/agentplane", "AgentPlane ref mismatch", errors)
+    require(agentplane.get("approval_state") == "live-apply-requires-human-approval", "AgentPlane approval state mismatch", errors)
+    policy = runtime.get("policyplane_decision", {})
+    require(policy.get("policyplane_ref") == "github://SocioProphet/policy-fabric", "PolicyPlane ref mismatch", errors)
+    require(policy.get("effect") == "allow-dry-run-deny-live-apply", "PolicyPlane effect mismatch", errors)
+    require(policy.get("live_apply_allowed") is False, "PolicyPlane allows live apply", errors)
+    require(policy.get("human_approval_required") is True, "PolicyPlane does not require human approval", errors)
+    checked.append({"id": "runtime_dry_run", "status": "passed"})
+
+    for artifact_id in ["deploy_plan", "agent_corps_plan", "gitops_bundle", "gitops_application", "gitops_kustomization"]:
+        require(paths[artifact_id].exists(), f"required artifact missing: {artifact_id}", errors)
+        checked.append({"id": artifact_id, "status": "present"})
+
+    return checked
+
+
+def build_record(summary_path: Path, index_path: Path, output_path: Path) -> dict[str, Any]:
+    summary = load_json(summary_path)
+    index = load_json(index_path)
+    errors: list[str] = []
+    require(summary.get("kind") == "FogStackLocalDemoFullRun", "full summary kind mismatch", errors)
+    require(summary.get("status") == "passed", "full summary status is not passed", errors)
+    artifacts = summary.get("artifacts")
+    if not isinstance(artifacts, dict):
+        raise SystemExit("ERR: full summary artifacts must be an object")
+    paths = check_artifact_files(artifacts, errors)
+    check_index(index, errors)
+    checked = check_records(paths, errors) if not errors else []
+    record = {
+        "kind": "FogStackParityReadinessRecord",
+        "schema_version": "v0.1",
+        "status": "failed" if errors else "passed",
+        "parity_target": "credible-mvp-ibm-style-parity",
+        "turn_counter": "31/32",
+        "summary_ref": str(summary_path.relative_to(ROOT)) if summary_path.is_relative_to(ROOT) else str(summary_path),
+        "summary_digest": sha256_file(summary_path),
+        "artifact_index_ref": str(index_path.relative_to(ROOT)) if index_path.is_relative_to(ROOT) else str(index_path),
+        "artifact_index_digest": sha256_file(index_path),
+        "checked_lanes": checked,
+        "required_summary_artifacts": sorted(REQUIRED_SUMMARY_ARTIFACTS),
+        "required_index_ids": sorted(REQUIRED_INDEX_IDS),
+        "errors": errors,
+    }
+    write_json(output_path, record)
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check FogStack credible-MVP parity readiness from full local demo evidence")
+    parser.add_argument("--summary", type=Path, default=Path("build/fogstack-local-demo/fogstack-local-demo.full.summary.json"))
+    parser.add_argument("--index", type=Path, default=Path("build/fogstack-local-demo/demo-artifacts.index.json"))
+    parser.add_argument("--output", type=Path, default=Path("build/fogstack-local-demo/fogstack-parity-readiness.record.json"))
+    parser.add_argument("--summary-text", action="store_true")
+    args = parser.parse_args()
+
+    summary_path = path_from_ref(str(args.summary))
+    index_path = path_from_ref(str(args.index))
+    output_path = path_from_ref(str(args.output))
+    record = build_record(summary_path, index_path, output_path)
+    if args.summary_text:
+        print(f"FogStack parity readiness: {record['status']}")
+        print(f"Parity target: {record['parity_target']}")
+        print(f"Checked lanes: {len(record['checked_lanes'])}")
+        print(f"Output: {args.output}")
+    else:
+        print(json.dumps(record, indent=2))
+    if record["status"] != "passed":
+        for error in record["errors"]:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_fogstack_parity_readiness.py
+++ b/tools/run_fogstack_parity_readiness.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, cwd=ROOT, check=True)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def run_parity(output_dir: Path, clean: bool) -> dict[str, Any]:
+    output_dir = output_dir if output_dir.is_absolute() else ROOT / output_dir
+    full_summary = output_dir / "fogstack-local-demo.full.summary.json"
+    artifact_index = output_dir / "demo-artifacts.index.json"
+    parity_record = output_dir / "fogstack-parity-readiness.record.json"
+
+    full_demo_cmd = [sys.executable, "tools/run_fogstack_local_demo_full.py", "--output-dir", str(output_dir), "--summary"]
+    if not clean:
+        full_demo_cmd.append("--no-clean")
+    run(full_demo_cmd)
+    run([
+        sys.executable,
+        "tools/check_fogstack_parity_readiness.py",
+        "--summary", str(full_summary),
+        "--index", str(artifact_index),
+        "--output", str(parity_record),
+    ])
+    return load_json(parity_record)
+
+
+def render_summary(record: dict[str, Any]) -> str:
+    lines = [
+        f"FogStack parity readiness: {record['status']}",
+        f"Parity target: {record['parity_target']}",
+        f"Turn counter: {record['turn_counter']}",
+        f"Checked lanes: {len(record['checked_lanes'])}",
+        f"Required artifacts: {len(record['required_summary_artifacts'])}",
+        f"Required index IDs: {len(record['required_index_ids'])}",
+        f"Errors: {len(record['errors'])}",
+        f"Record: {record['artifact_index_ref'].rsplit('/', 1)[0]}/fogstack-parity-readiness.record.json",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run FogStack local demo and check credible-MVP parity readiness")
+    parser.add_argument("--output-dir", type=Path, default=Path("build/fogstack-local-demo"))
+    parser.add_argument("--no-clean", action="store_true")
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args()
+
+    record = run_parity(args.output_dir, clean=not args.no_clean)
+    if args.summary:
+        print(render_summary(record), end="")
+    else:
+        print(json.dumps(record, indent=2))
+    return 0 if record["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_parity_readiness.py
+++ b/tools/tests/test_fogstack_parity_readiness.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_check_fogstack_parity_readiness(tmp_path: Path) -> None:
+    output_dir = tmp_path / "fogstack-local-demo"
+    subprocess.run([sys.executable, "tools/run_fogstack_local_demo_full.py", "--output-dir", str(output_dir), "--summary"], check=True)
+    record_path = output_dir / "fogstack-parity-readiness.record.json"
+    proc = subprocess.run([sys.executable, "tools/check_fogstack_parity_readiness.py", "--summary", str(output_dir / "fogstack-local-demo.full.summary.json"), "--index", str(output_dir / "demo-artifacts.index.json"), "--output", str(record_path), "--summary-text"], check=True, capture_output=True, text=True)
+    assert "FogStack parity readiness: passed" in proc.stdout
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["kind"] == "FogStackParityReadinessRecord"
+    assert record["status"] == "passed"
+    assert record["errors"] == []
+    checked = {lane["id"] for lane in record["checked_lanes"]}
+    for lane in ["node_inventory", "immutable_update_readiness", "cluster_readiness", "gitops_readiness", "runtime_adapter", "runtime_dry_run", "deploy_plan", "agent_corps_plan", "gitops_bundle", "gitops_application", "gitops_kustomization"]:
+        assert lane in checked
+    for artifact_id in ["deploy_runtime_dry_run_record", "deploy_node_inventory_record", "deploy_immutable_update_readiness_record"]:
+        assert artifact_id in record["required_index_ids"]

--- a/tools/tests/test_run_fogstack_parity_readiness.py
+++ b/tools/tests/test_run_fogstack_parity_readiness.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_run_fogstack_parity_readiness(tmp_path: Path) -> None:
+    output_dir = tmp_path / "fogstack-local-demo"
+    proc = subprocess.run([
+        sys.executable,
+        "tools/run_fogstack_parity_readiness.py",
+        "--output-dir", str(output_dir),
+        "--summary",
+    ], check=True, capture_output=True, text=True)
+    assert "FogStack parity readiness: passed" in proc.stdout
+    assert "Parity target: credible-mvp-ibm-style-parity" in proc.stdout
+    assert "Turn counter: 31/32" in proc.stdout
+    record_path = output_dir / "fogstack-parity-readiness.record.json"
+    assert record_path.exists()
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["kind"] == "FogStackParityReadinessRecord"
+    assert record["status"] == "passed"
+    assert record["errors"] == []


### PR DESCRIPTION
Turn 31 / 32 toward credible MVP IBM-style parity.

Adds a one-command parity readiness validator over the full local demo evidence graph.

Changes:
- adds `tools/check_fogstack_parity_readiness.py`
- adds `tools/run_fogstack_parity_readiness.py`
- adds focused tests for the checker and one-command runner
- updates the local demo workflow to run parity readiness validation and upload the readiness record

The readiness checker validates MVP-critical evidence across:
- Agent Machine node inventory
- immutable/declarative update readiness
- cluster readiness
- GitOps readiness
- runtime adapter
- runtime dry-run evidence
- AgentPlane run linkage
- PolicyPlane decision linkage
- Agent Corps plan
- deploy plan
- GitOps bundle/application/kustomization
- full local demo artifact index digests

Purpose: provide one consolidated command and one readiness record for credible MVP IBM-style parity.