### PR TITLE
fogstack: declare credible MVP parity status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,3 +193,7 @@ fogstack-local-demo-deploy-plan:
 .PHONY: fogstack-local-demo-full
 fogstack-local-demo-full:
 	python3 tools/run_fogstack_local_demo_full.py --output-dir build/fogstack-local-demo --summary
+
+.PHONY: fogstack-parity-readiness
+fogstack-parity-readiness:
+	python3 tools/run_fogstack_parity_readiness.py --summary

--- a/catalog/fogstack-packs-v0.1.yaml
+++ b/catalog/fogstack-packs-v0.1.yaml
@@ -5,7 +5,8 @@ canonical_repo: "SocioProphet/prophet-platform"
 parity_posture:
   target: "credible-mvp-ibm-style-parity"
   status: "reached"
-  proof_command: "python3 tools/run_fogstack_parity_readiness.py --summary"
+  proof_command: "make fogstack-parity-readiness"
+  implementation_command: "python3 tools/run_fogstack_parity_readiness.py --summary"
   proof_record: "build/fogstack-local-demo/fogstack-parity-readiness.record.json"
   scope: "local, CI-backed, non-mutating, evidence-based MVP parity"
   not_in_scope:
@@ -27,6 +28,7 @@ packs:
       - "cloudshell-fog"
       - "releases/manifests/fogstack.access-v0.1.manifest.json"
       - "tools/run_fogstack_parity_readiness.py"
+      - "Makefile:fogstack-parity-readiness"
     notes: "Most mature customer-facing surface; now has local deploy, GitOps, runtime dry-run, node inventory, AgentPlane, PolicyPlane, and parity-readiness evidence. Production gaps remain live apply, observability, and external identity/signing."
   - id: "fogstack.knowledge"
     label: "Fog Stack Knowledge"

--- a/catalog/fogstack-packs-v0.1.yaml
+++ b/catalog/fogstack-packs-v0.1.yaml
@@ -2,69 +2,136 @@ schema_version: "fogstack.packs/v0.1"
 kind: "FogStackPacks"
 repository_strategy: "single-repo-for-now"
 canonical_repo: "SocioProphet/prophet-platform"
+parity_posture:
+  target: "credible-mvp-ibm-style-parity"
+  status: "reached"
+  proof_command: "python3 tools/run_fogstack_parity_readiness.py --summary"
+  proof_record: "build/fogstack-local-demo/fogstack-parity-readiness.record.json"
+  scope: "local, CI-backed, non-mutating, evidence-based MVP parity"
+  not_in_scope:
+    - "production parity"
+    - "live cluster mutation"
+    - "network registry publication"
+    - "external KMS/HSM signing"
+    - "live AgentPlane execution backend"
+    - "production observability"
 packs:
   - id: "fogstack.access"
     label: "Fog Stack Access"
     category: "product_surface"
-    readiness_pct: 70
+    readiness_pct: 88
     repo_split_now: false
     substrate_anchors:
       - "apps/gateway"
       - "apps/api"
       - "cloudshell-fog"
-    notes: "Most mature customer-facing surface; remaining work is mostly trust/release hardening."
+      - "releases/manifests/fogstack.access-v0.1.manifest.json"
+      - "tools/run_fogstack_parity_readiness.py"
+    notes: "Most mature customer-facing surface; now has local deploy, GitOps, runtime dry-run, node inventory, AgentPlane, PolicyPlane, and parity-readiness evidence. Production gaps remain live apply, observability, and external identity/signing."
   - id: "fogstack.knowledge"
     label: "Fog Stack Knowledge"
     category: "product_surface"
-    readiness_pct: 55
+    readiness_pct: 72
     repo_split_now: false
     substrate_anchors:
       - "apps/knowledge-reason"
       - "apps/lampstand"
-    notes: "Clear substrate anchors, but more composition-heavy and operationally mixed."
+      - "office collaboration/search surfaces"
+    notes: "Clear substrate anchors and stronger platform context after local evidence work; still composition-heavy and not yet packaged as an independent deployable pack."
   - id: "fogstack.evaluation"
     label: "Fog Stack Evaluation"
     category: "product_surface"
-    readiness_pct: 55
+    readiness_pct: 76
     repo_split_now: false
     substrate_anchors:
       - "apps/eval-fabric-api"
       - "docs/PLATFORM_EVAL_FABRIC.md"
-    notes: "Real platform surface, but still more internal than packaged."
+      - "evidence/receipt surfaces"
+    notes: "Real platform surface with strong evidence orientation; still more internal than standalone customer package."
   - id: "fogstack.security"
     label: "Fog Stack Security / Trust"
     category: "shared_capability"
-    readiness_pct: 35
+    readiness_pct: 90
     repo_split_now: false
     substrate_anchors:
       - "schemas/release/*"
+      - "schemas/runtime/*"
       - "tools/*fogstack*"
-    notes: "Strong platform capability, but not yet an independently packaged product surface."
+      - "tools/check_fogstack_parity_readiness.py"
+    notes: "Strong shared capability across release, registry, deployment, runtime, AgentPlane/PolicyPlane linkage, and local parity readiness. Not yet standalone due to external KMS/HSM and production identity gaps."
   - id: "fogstack.data"
-    label: "Fog Stack Data"
+    label: "Fog Stack Data / GovernAI"
     category: "packaging_view"
-    readiness_pct: 30
+    readiness_pct: 68
     repo_split_now: false
     substrate_anchors:
       - "knowledge + evaluation surfaces"
-    notes: "Better treated as a packaging view over Knowledge + Evaluation than as a separate repo."
+      - "lattice data/governance fixtures"
+    notes: "Better treated as a packaging view over Knowledge, Evaluation, and Lattice/GovernAI surfaces than as an independent engineering island."
   - id: "fogstack.ai"
-    label: "Fog Stack AI"
-    category: "future_pack"
-    readiness_pct: 20
+    label: "Fog Stack AI / Lattice Runtime"
+    category: "emerging_product_surface"
+    readiness_pct: 62
     repo_split_now: false
-    substrate_anchors: []
-    notes: "Not enough independent runtime/product surface yet."
+    substrate_anchors:
+      - "lattice model/prompt/evaluation surfaces"
+      - "runtime evidence path"
+    notes: "Materially stronger than the original future-pack estimate due to Lattice/runtime/evidence work, but not yet an independent AI product pack."
   - id: "fogstack.automation"
-    label: "Fog Stack Automation"
+    label: "Fog Stack Automation / Workflow"
     category: "future_pack"
-    readiness_pct: 20
+    readiness_pct: 45
     repo_split_now: false
-    substrate_anchors: []
-    notes: "Workflow/orchestration is not yet a distinct first-class product surface."
+    substrate_anchors:
+      - "AgentPlane linkage"
+      - "PolicyPlane linkage"
+      - "workflow/orchestration surfaces"
+    notes: "Workflow and orchestration are now visible in runtime evidence, but live execution backend and production workflow control are still post-MVP."
+  - id: "fogstack.registry"
+    label: "Fog Stack Registry / Release Distribution"
+    category: "shared_capability"
+    readiness_pct: 78
+    repo_split_now: false
+    substrate_anchors:
+      - "registry publication index"
+      - "filesystem registry adapter"
+      - "registry root metadata"
+      - "revocation/rollback indexes"
+    notes: "Strong local/filesystem registry and release-distribution evidence; post-MVP gaps remain network registry publication and external signing identity."
+  - id: "fogstack.runtime"
+    label: "Fog Stack Runtime / Agent Machine Node Ops"
+    category: "shared_runtime_capability"
+    readiness_pct: 72
+    repo_split_now: false
+    substrate_anchors:
+      - "FogStackAgentMachineNodeProfile"
+      - "FogStackAgentMachineNodeInventoryRecord"
+      - "FogStackImmutableUpdateReadinessRecord"
+      - "FogStackRuntimeDryRunRecord"
+      - "TurtleTerm / BearBrowser use surfaces"
+    notes: "Now has local runtime adapter, dry-run evidence, node inventory, TopoLVM posture, immutable update readiness, AgentPlane run linkage, and PolicyPlane decision linkage. Live cluster apply and live AgentPlane execution remain post-MVP."
+  - id: "fogstack.office"
+    label: "Fog Stack Office / Collaboration"
+    category: "emerging_product_surface"
+    readiness_pct: 58
+    repo_split_now: false
+    substrate_anchors:
+      - "office collaboration runtime"
+      - "thread/suggestion/history surfaces"
+      - "search/runtime evidence adjacency"
+    notes: "Office/collaboration is now a real product surface in the repository, but it is not yet packaged as an independently deployable Fog Stack pack."
 repo_split_triggers:
   - "independent release cadence"
   - "distinct operator lifecycle and deployment surface"
   - "dedicated CI/test obligations that reduce overall complexity"
-  - "support burden distinct from the shared trust/release substrate"
-  - "ability to share trust/release graph without duplicating platform-wide evidence logic"
+  - "support burden distinct from the shared trust/release/runtime substrate"
+  - "ability to share trust/release/runtime graph without duplicating platform-wide evidence logic"
+post_mvp_gaps:
+  - "live cluster apply with rollback proof"
+  - "network registry publication"
+  - "external KMS/HSM-backed signing and approval identity"
+  - "live AgentPlane execution backend"
+  - "stronger GitOps controller reconciliation receipts"
+  - "production observability and alerting"
+  - "TopoLVM live cluster integration"
+  - "Nix/ostree update execution receipts"

--- a/docs/FOGSTACK_PACKS.md
+++ b/docs/FOGSTACK_PACKS.md
@@ -2,55 +2,93 @@
 
 This document records the current Fog Stack pack taxonomy, product-surface intent, and readiness levels inside `prophet-platform`.
 
+## Current parity posture
+
+Fog Stack has reached **credible MVP IBM-style parity** for a local, CI-backed, non-mutating, evidence-based operator proof.
+
+The canonical proof command is:
+
+```bash
+python3 tools/run_fogstack_parity_readiness.py --summary
+```
+
+The command emits:
+
+```text
+build/fogstack-local-demo/fogstack-parity-readiness.record.json
+```
+
+This parity posture means the local evidence graph proves release, registry, deploy, GitOps, runtime dry-run, Agent Machine node inventory, immutable/declarative update readiness, TurtleTerm/BearBrowser use surfaces, AgentPlane run linkage, and PolicyPlane decision linkage.
+
+It does **not** mean production parity. Live cluster apply, network registry publication, external KMS/HSM-backed signing, production observability, live AgentPlane execution, real GitOps controller reconciliation, and SourceOS/AgentOS live update execution remain post-MVP gaps.
+
 ## Decision
 
-Fog Stack should **not** split into separate repositories for AI, Data, Automation, Security, or other future pack categories yet.
+Fog Stack should **not** split into separate repositories for AI, Data, Automation, Security, Registry, Runtime, Agent Machine, or Office categories yet.
 
-The shared trust/release graph is still the dominant implementation concern, and the current pack boundaries do not yet justify independent lifecycles. The right move is to keep engineering in `prophet-platform`, track pack readiness here, and split only when a pack has a clearly independent release cadence, operator lifecycle, support burden, and CI surface.
+The shared trust/release/publication/runtime evidence graph is still the dominant implementation concern, and the current pack boundaries do not yet justify independent lifecycles. The right move is to keep engineering in `prophet-platform`, track pack readiness here, and split only when a pack has a clearly independent release cadence, operator lifecycle, support burden, and CI surface.
 
 ## Current packs
 
 ### Fog Stack Access
 - Type: real product surface
-- Readiness: 70%
+- Readiness: 88%
 - Repo split now: no
-- Why: strongest customer-facing surface so far; remaining work is mainly trust/release hardening, not basic product identity.
+- Why: strongest customer-facing surface. It now has local deploy evidence, GitOps bundle/readiness, runtime dry-run, Agent Machine node inventory, immutable update readiness, AgentPlane linkage, PolicyPlane linkage, and one-command parity validation. Remaining work is live cluster apply, production observability, stronger GitOps controller receipts, and external identity/signing.
 
 ### Fog Stack Knowledge
 - Type: real product surface
-- Readiness: 55%
+- Readiness: 72%
 - Repo split now: no
-- Why: clear substrate anchors but more composition-heavy and operationally mixed.
+- Why: clear substrate anchors through knowledge-reason, Lampstand, search, and collaboration adjacency. It is stronger than the earlier estimate, but still composition-heavy and not yet independently packaged.
 
 ### Fog Stack Evaluation
 - Type: real product surface
-- Readiness: 55%
+- Readiness: 76%
 - Repo split now: no
-- Why: real platform surface, but still more internal than packaged.
+- Why: strong evidence orientation and real eval-fabric substrate. Still more internal platform capability than standalone customer package.
 
 ### Fog Stack Security / Trust
 - Type: strong shared capability
-- Readiness: 80% as platform capability / 35% as standalone pack
+- Readiness: 90% as platform capability / not yet standalone pack
 - Repo split now: no
-- Why: the shared trust/release graph is still the dominant engineering concern.
+- Why: the shared trust/release/runtime graph now spans signing evidence, release gates, registry evidence, runtime dry-run safety, AgentPlane, PolicyPlane, and parity readiness. It should remain shared until external KMS/HSM and production identity are integrated.
 
-### Fog Stack Data
+### Fog Stack Data / GovernAI
 - Type: emerging packaging view
-- Readiness: 30%
+- Readiness: 68%
 - Repo split now: no
-- Why: better treated as a packaging view over Knowledge + Evaluation than as an independent engineering island.
+- Why: best treated as a packaging view over Knowledge, Evaluation, Lattice, and GovernAI surfaces. It has meaningful substrate but not enough independent operational lifecycle to split.
 
-### Fog Stack AI
-- Type: conceptual future pack
-- Readiness: 20%
+### Fog Stack AI / Lattice Runtime
+- Type: emerging product surface
+- Readiness: 62%
 - Repo split now: no
-- Why: not enough independent runtime/product surface yet.
+- Why: Lattice/model/prompt/evaluation runtime work makes this stronger than a conceptual future pack, but it is not yet an independently packaged AI product surface.
 
-### Fog Stack Automation
-- Type: conceptual future pack
-- Readiness: 20%
+### Fog Stack Automation / Workflow
+- Type: future pack with emerging substrate
+- Readiness: 45%
 - Repo split now: no
-- Why: workflow/orchestration is not yet a distinct first-class product surface.
+- Why: AgentPlane and PolicyPlane linkage now appears in runtime evidence, but live execution backend, workflow runtime, and production orchestration remain post-MVP.
+
+### Fog Stack Registry / Release Distribution
+- Type: shared capability
+- Readiness: 78%
+- Repo split now: no
+- Why: filesystem registry, publication indexes, root metadata, and revocation/rollback evidence make this a strong local shared capability. Network registry publication and external signing identity remain post-MVP.
+
+### Fog Stack Runtime / Agent Machine Node Ops
+- Type: shared runtime capability
+- Readiness: 72%
+- Repo split now: no
+- Why: runtime evidence now includes Agent Machine node profile, node inventory, TopoLVM storage posture, immutable update readiness, TurtleTerm/BearBrowser surfaces, AgentPlane run linkage, PolicyPlane decision linkage, and runtime dry-run. Live cluster apply and live AgentPlane execution remain post-MVP.
+
+### Fog Stack Office / Collaboration
+- Type: emerging product surface
+- Readiness: 58%
+- Repo split now: no
+- Why: office collaboration runtime, thread history, suggestions, and search adjacency are now real repository surfaces. It is not yet a Fog Stack deployable pack with its own operator lifecycle.
 
 ## Repo split triggers
 
@@ -59,8 +97,8 @@ A future Fog Stack pack should not move into its own repository until most of th
 1. it has an independent release cadence
 2. it has a distinct operator lifecycle and deployment surface
 3. it has dedicated CI/test obligations that reduce, not increase, repo complexity
-4. it has support responsibilities distinct from the shared trust/release substrate
-5. the trust/release graph can be shared without duplicating platform-wide signing/evidence logic
+4. it has support responsibilities distinct from the shared trust/release/runtime substrate
+5. the trust/release/runtime graph can be shared without duplicating platform-wide signing, evidence, runtime, and policy logic
 
 ## Relationship to `prophet-platform`
 
@@ -71,6 +109,26 @@ Fog Stack currently lands here as:
 - conformance
 - release metadata
 - trust graph
-- evidence and sealing machinery
+- registry publication
+- deployment evidence
+- GitOps evidence
+- runtime dry-run evidence
+- Agent Machine node evidence
+- AgentPlane/PolicyPlane linkage
+- parity readiness validation
 
-The future packs should therefore be treated as catalog and packaging surfaces until they are mature enough to justify independent repos.
+The future packs should therefore be treated as catalog, packaging, and operator-surface views until they are mature enough to justify independent repos.
+
+## Post-MVP gaps
+
+The next work should not pretend the local MVP proof is production parity. Remaining gaps include:
+
+1. live cluster apply with rollback proof
+2. network registry publication
+3. external KMS/HSM-backed signing and approval identity
+4. live AgentPlane execution backend
+5. stronger GitOps controller reconciliation receipts
+6. production observability and alerting
+7. TopoLVM live cluster integration
+8. Nix/ostree update execution receipts for SourceOS/AgentOS
+9. operator UX consolidation and reusable evidence rendering modules

--- a/docs/FOGSTACK_PACKS.md
+++ b/docs/FOGSTACK_PACKS.md
@@ -9,6 +9,12 @@ Fog Stack has reached **credible MVP IBM-style parity** for a local, CI-backed, 
 The canonical proof command is:
 
 ```bash
+make fogstack-parity-readiness
+```
+
+The target wraps:
+
+```bash
 python3 tools/run_fogstack_parity_readiness.py --summary
 ```
 
@@ -116,6 +122,7 @@ Fog Stack currently lands here as:
 - Agent Machine node evidence
 - AgentPlane/PolicyPlane linkage
 - parity readiness validation
+- canonical Makefile target for the MVP parity check
 
 The future packs should therefore be treated as catalog, packaging, and operator-surface views until they are mature enough to justify independent repos.
 

--- a/docs/FOGSTACK_STATUS.md
+++ b/docs/FOGSTACK_STATUS.md
@@ -17,6 +17,12 @@ This does **not** mean production parity. The MVP parity claim is bounded to loc
 The canonical one-command MVP parity check is:
 
 ```bash
+make fogstack-parity-readiness
+```
+
+The target wraps:
+
+```bash
 python3 tools/run_fogstack_parity_readiness.py --summary
 ```
 
@@ -100,6 +106,7 @@ The following supporting slices are already merged into `main`:
 - Agent Machine node inventory records
 - full local demo evidence indexing and operator summaries
 - parity readiness checker and one-command parity runner
+- `make fogstack-parity-readiness` canonical operator target
 
 ## Current active frontier
 
@@ -131,6 +138,7 @@ The current local MVP parity path is:
 22. bind runtime dry-run evidence to PolicyPlane decision context
 23. index all MVP-critical artifacts in the full local demo
 24. emit one consolidated FogStack parity readiness record
+25. expose the parity proof through a canonical Makefile target
 
 ## Product-pack readiness matrix
 
@@ -178,6 +186,7 @@ The release/trust/publication/runtime graph now consists of these machine-readab
 - PolicyPlane decision linkage
 - local demo artifact index
 - parity readiness record
+- Makefile parity-readiness target
 
 ## Known post-MVP gaps
 

--- a/docs/FOGSTACK_STATUS.md
+++ b/docs/FOGSTACK_STATUS.md
@@ -4,16 +4,38 @@ This document captures the current state of Fog Stack work inside `prophet-platf
 
 ## Repository role
 
-`prophet-platform` is the runtime and deployment substrate for platform services. Fog Stack lands here as the productization, conformance, release, publication, and trust layer for deployable offerings built on that substrate.
+`prophet-platform` is the runtime and deployment substrate for platform services. Fog Stack lands here as the productization, conformance, release, publication, deployment, runtime-evidence, and trust layer for deployable offerings built on that substrate.
+
+## Current parity posture
+
+Fog Stack has reached **credible MVP IBM-style parity** inside `prophet-platform`.
+
+This means the repository now has a single local evidence path that proves a deployable Fog Stack Access candidate across release, registry, deploy, GitOps, runtime dry-run, Agent Machine node substrate, immutable/declarative update readiness, AgentPlane linkage, PolicyPlane decision linkage, and operator-facing evidence.
+
+This does **not** mean production parity. The MVP parity claim is bounded to local, contract-backed, non-mutating, CI-proven evidence. Live cluster mutation, external KMS/HSM signing, production observability, network registry publication, and live AgentPlane execution remain post-MVP work.
+
+The canonical one-command MVP parity check is:
+
+```bash
+python3 tools/run_fogstack_parity_readiness.py --summary
+```
+
+It emits:
+
+```text
+build/fogstack-local-demo/fogstack-parity-readiness.record.json
+```
+
+The readiness checker validates the full local demo evidence graph, artifact-index digest integrity, and MVP-critical runtime safety invariants.
 
 ## Repository strategy decision
 
-Fog Stack should **not** split into separate repositories for AI, Data, Automation, Security, or other future pack categories yet.
+Fog Stack should **not** split into separate repositories for AI, Data, Automation, Security, Registry, Agent Machine, or node-operation categories yet.
 
-At the current stage, the trust/release/publication machinery is still highly shared across all surfaces. Splitting now would mostly increase coordination overhead and fragment the release/trust graph before those categories have clearly independent lifecycles.
+At the current stage, the trust/release/publication/runtime-evidence machinery is still highly shared across all surfaces. Splitting now would mostly increase coordination overhead and fragment the release/trust/runtime graph before those categories have clearly independent lifecycles.
 
 The correct near-term move is:
-- keep the engineering and trust/release/publication machinery in `prophet-platform`
+- keep the engineering and trust/release/publication/runtime evidence machinery in `prophet-platform`
 - track future pack categories here as product surfaces and readiness states
 - split into separate repos only when a pack has an independently justified lifecycle, release cadence, operator surface, and support burden
 
@@ -29,7 +51,7 @@ The following initial offering slices are already merged into `main`:
 - **Fog Stack Knowledge** — governed ingress + local daemon offering slice via PR #26
 - **Fog Stack Evaluation** — evaluation fabric offering slice via PR #27
 
-## Merged validation and release-engineering slices
+## Merged validation, release, and runtime slices
 
 The following supporting slices are already merged into `main`:
 
@@ -66,12 +88,24 @@ The following supporting slices are already merged into `main`:
 - release publication gate via PR #211
 - registry publication index via PR #212
 - filesystem registry adapter via PR #215
+- registry root metadata and revocation/rollback index support
+- local demo deploy-plan generation
+- Kubernetes manifest rendering and cluster-readiness dry-run records
+- GitOps bundle generation, checking, and readiness records
+- local cluster runtime adapter and runtime dry-run records
+- Agent Machine node profile, TurtleTerm, and BearBrowser use-surface contracts
+- AgentPlane run linkage in runtime evidence
+- PolicyPlane decision linkage in runtime evidence
+- immutable/declarative update readiness records
+- Agent Machine node inventory records
+- full local demo evidence indexing and operator summaries
+- parity readiness checker and one-command parity runner
 
 ## Current active frontier
 
-Fog Stack is past initial offering definition and past local trust-graph construction. The active frontier is now release publication and registry hardening.
+Fog Stack is now past initial release-publication hardening and has entered **MVP runtime evidence closure**.
 
-The current release path is:
+The current local MVP parity path is:
 
 1. validate bundles and rulepacks
 2. emit validation records
@@ -82,6 +116,21 @@ The current release path is:
 7. emit a release publication gate record
 8. build a registry publication index
 9. publish the gated index and referenced artifacts to a filesystem registry layout
+10. build local deploy-plan evidence for `fogstack.access`
+11. render Kubernetes manifests
+12. emit cluster-readiness dry-run records
+13. build and check GitOps bundle artifacts
+14. emit GitOps readiness records
+15. build Agent Machine node profile evidence
+16. prove TurtleTerm and BearBrowser as first-class governed use surfaces
+17. emit immutable/declarative update readiness records
+18. emit Agent Machine node inventory records including TopoLVM storage posture
+19. build a local cluster runtime adapter
+20. emit non-mutating runtime dry-run evidence
+21. bind runtime dry-run evidence to AgentPlane run context
+22. bind runtime dry-run evidence to PolicyPlane decision context
+23. index all MVP-critical artifacts in the full local demo
+24. emit one consolidated FogStack parity readiness record
 
 ## Product-pack readiness matrix
 
@@ -89,9 +138,9 @@ The detailed matrix and pack taxonomy live in:
 - `docs/FOGSTACK_PACKS.md`
 - `catalog/fogstack-packs-v0.1.yaml`
 
-## Current trust/publication graph shape
+## Current trust/publication/runtime graph shape
 
-The release/trust/publication graph now consists of these machine-readable artifacts:
+The release/trust/publication/runtime graph now consists of these machine-readable artifacts:
 
 - release manifest
 - validation record
@@ -112,18 +161,41 @@ The release/trust/publication graph now consists of these machine-readable artif
 - release publication gate record
 - registry publication index
 - filesystem registry publication/check artifacts
+- Agent Machine node profile
+- Agent Machine node inventory record
+- immutable/declarative update readiness record
+- deploy plan
+- Kubernetes manifests
+- Kubernetes manifest check record
+- cluster-readiness record
+- GitOps bundle
+- GitOps Application
+- GitOps Kustomization
+- GitOps readiness record
+- local cluster runtime adapter
+- runtime dry-run record
+- AgentPlane run linkage
+- PolicyPlane decision linkage
+- local demo artifact index
+- parity readiness record
 
-## Known gaps and next tranches
+## Known post-MVP gaps
 
-The next release-engineering tranche should focus on:
+The next tranches should focus on:
 
-1. **Network registry publication** beyond filesystem registry export.
-2. **Signed registry root metadata** so registry consumers can verify the registry root, not just individual artifact records.
-3. **Rollback and revocation indexes** for promoted or published artifact sets.
-4. **Signature verification pipeline exit-code hygiene** so digest mismatch and malformed input fail hard at the CLI layer.
-5. **Status and registry docs kept current** whenever publication gates or registry adapters land.
-6. **External identity-provider / KMS / HSM integration** for release identity and signing keys when the workflow moves beyond local demo-grade keys.
+1. **Live cluster apply path** guarded by AgentPlane and PolicyPlane, including explicit human approval and rollback proof.
+2. **Network registry publication** beyond filesystem registry export.
+3. **External KMS/HSM integration** for release identity, signing keys, and runtime approval identities.
+4. **Live AgentPlane execution backend** rather than local script-driven evidence only.
+5. **Stronger GitOps controller integration** with a real controller reconciliation receipt, not only generated Application/Kustomization artifacts.
+6. **Production observability** for runtime, deployment, GitOps reconciliation, node inventory drift, and policy decisions.
+7. **TopoLVM live cluster integration** beyond node-profile and inventory evidence.
+8. **Immutable update execution path** for SourceOS/AgentOS, including real Nix/ostree update preflight, staging, rollback, and audit receipts.
+9. **Operator UX consolidation** so local-demo evidence renderers are decomposed into reusable modules instead of several ad hoc updaters.
+10. **Status and registry docs kept current** whenever publication gates, runtime surfaces, or registry adapters land.
 
 ## Position in the maturity ladder
 
-Fog Stack in `prophet-platform` is now in release-publication hardening. It has moved from offering taxonomy and local trust records into gated, CI-backed, registry-ready artifact publication surfaces. The immediate risk is stale status documentation or weak CLI semantics causing operators to misread publication readiness.
+Fog Stack in `prophet-platform` is now at **credible MVP IBM-style parity** for local, evidence-backed, non-mutating operator proof.
+
+It has moved from offering taxonomy and local trust records into gated, CI-backed, registry-ready, runtime-evidenced, AgentPlane/PolicyPlane-linked artifact surfaces. The immediate risk is now not lack of proof, but overclaiming production readiness before live cluster execution, production observability, external identity/signing, and network registry publication are complete.


### PR DESCRIPTION
Turn 32 / 32 toward credible MVP IBM-style parity.

This closes the local MVP parity status/readout lane without widening into live cluster mutation.

Changes:
- add canonical `make fogstack-parity-readiness` target wrapping `python3 tools/run_fogstack_parity_readiness.py --summary`
- update `docs/FOGSTACK_STATUS.md` to declare bounded credible MVP IBM-style parity
- update `docs/FOGSTACK_PACKS.md` with revised pack readiness and explicit post-MVP gaps
- update `catalog/fogstack-packs-v0.1.yaml` with machine-readable parity posture, canonical proof command, implementation command, and post-MVP gap list

Scope boundary:
- local, CI-backed, non-mutating, evidence-based MVP parity only
- no live cluster apply
- no production parity claim
- no external KMS/HSM signing claim
- no live AgentPlane execution backend claim

Canonical operator command after this PR:

```bash
make fogstack-parity-readiness
```

Expected output:

```text
build/fogstack-local-demo/fogstack-parity-readiness.record.json
```

Post-MVP gaps intentionally preserved:
- live cluster apply with rollback proof
- network registry publication
- external KMS/HSM-backed signing and approval identity
- live AgentPlane execution backend
- stronger GitOps controller reconciliation receipts
- production observability and alerting
- TopoLVM live cluster integration
- Nix/ostree update execution receipts

Validation target:
- `FogStack Local Demo` should run because `Makefile` changed and includes the new parity target path.
- Broad repo validation should remain unaffected because code behavior only adds a wrapper target and status/catalog documentation.