### PR TITLE
fogstack: add read-only live cluster preflight evidence

### DIFF
--- a/.github/workflows/fogstack-local-cluster-runtime.yml
+++ b/.github/workflows/fogstack-local-cluster-runtime.yml
@@ -13,6 +13,7 @@ on:
       - "tools/build_fogstack_agent_machine_node_profile.py"
       - "tools/emit_fogstack_agent_machine_node_inventory_record.py"
       - "tools/emit_fogstack_immutable_update_readiness_record.py"
+      - "tools/emit_fogstack_live_cluster_preflight_record.py"
       - "tools/build_fogstack_runtime_contract.py"
       - "tools/build_fogstack_deploy_plan.py"
       - "tools/render_fogstack_kubernetes_manifests.py"
@@ -26,6 +27,7 @@ on:
       - "tools/tests/test_fogstack_runtime_dry_run_record.py"
       - "tools/tests/test_fogstack_immutable_update_readiness_record.py"
       - "tools/tests/test_fogstack_agent_machine_node_inventory_record.py"
+      - "tools/tests/test_fogstack_live_cluster_preflight_record.py"
       - ".github/workflows/fogstack-local-cluster-runtime.yml"
   push:
     branches: [main]
@@ -39,6 +41,7 @@ on:
       - "tools/build_fogstack_agent_machine_node_profile.py"
       - "tools/emit_fogstack_agent_machine_node_inventory_record.py"
       - "tools/emit_fogstack_immutable_update_readiness_record.py"
+      - "tools/emit_fogstack_live_cluster_preflight_record.py"
       - "tools/build_fogstack_runtime_contract.py"
       - "tools/build_fogstack_deploy_plan.py"
       - "tools/render_fogstack_kubernetes_manifests.py"
@@ -52,6 +55,7 @@ on:
       - "tools/tests/test_fogstack_runtime_dry_run_record.py"
       - "tools/tests/test_fogstack_immutable_update_readiness_record.py"
       - "tools/tests/test_fogstack_agent_machine_node_inventory_record.py"
+      - "tools/tests/test_fogstack_live_cluster_preflight_record.py"
       - ".github/workflows/fogstack-local-cluster-runtime.yml"
 
 permissions:
@@ -81,7 +85,8 @@ jobs:
             tools/tests/test_fogstack_local_cluster_runtime_adapter.py \
             tools/tests/test_fogstack_runtime_dry_run_record.py \
             tools/tests/test_fogstack_immutable_update_readiness_record.py \
-            tools/tests/test_fogstack_agent_machine_node_inventory_record.py
+            tools/tests/test_fogstack_agent_machine_node_inventory_record.py \
+            tools/tests/test_fogstack_live_cluster_preflight_record.py
 
       - name: Build sample local cluster runtime adapter
         run: |
@@ -123,6 +128,12 @@ jobs:
           python3 tools/emit_fogstack_gitops_readiness_record.py \
             --bundle build/fogstack-runtime-inputs/gitops/gitops-bundle.json \
             --output build/fogstack-runtime-inputs/gitops-readiness.json
+          python3 tools/emit_fogstack_live_cluster_preflight_record.py \
+            --deploy-plan build/fogstack-runtime-inputs/deploy-plan.json \
+            --node-profile build/fogstack-runtime-inputs/node-profile.json \
+            --gitops-bundle build/fogstack-runtime-inputs/gitops/gitops-bundle.json \
+            --kubectl missing-kubectl-for-ci-safe-fallback \
+            --output build/fogstack-runtime-inputs/live-cluster-preflight.record.json
           python3 tools/build_fogstack_local_cluster_runtime_adapter.py \
             --node-profile build/fogstack-runtime-inputs/node-profile.json \
             --deploy-plan build/fogstack-runtime-inputs/deploy-plan.json \
@@ -137,5 +148,6 @@ jobs:
           test -s build/fogstack-runtime-inputs/node-profile.json
           test -s build/fogstack-runtime-inputs/agent-machine-node-inventory.record.json
           test -s build/fogstack-runtime-inputs/immutable-update-readiness.record.json
+          test -s build/fogstack-runtime-inputs/live-cluster-preflight.record.json
           test -s build/fogstack-runtime-inputs/local-cluster-runtime-adapter.json
           test -s build/fogstack-runtime-inputs/runtime-dry-run.record.json

--- a/schemas/runtime/fogstack-live-cluster-preflight-record-v0.1.schema.json
+++ b/schemas/runtime/fogstack-live-cluster-preflight-record-v0.1.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/runtime/fogstack-live-cluster-preflight-record-v0.1.schema.json",
+  "title": "FogStackLiveClusterPreflightRecord",
+  "type": "object",
+  "required": [
+    "kind",
+    "schema_version",
+    "status",
+    "namespace",
+    "mode",
+    "kubectl",
+    "source_artifacts",
+    "safety",
+    "checks",
+    "read_operations",
+    "errors"
+  ],
+  "properties": {
+    "kind": { "const": "FogStackLiveClusterPreflightRecord" },
+    "schema_version": { "const": "v0.1" },
+    "status": { "enum": ["passed", "failed", "blocked"] },
+    "reason": { "type": ["string", "null"] },
+    "namespace": { "type": "string", "minLength": 1 },
+    "mode": { "const": "read-only-live-preflight" },
+    "kubectl": {
+      "type": "object",
+      "required": ["executable", "available", "resolved_path"],
+      "additionalProperties": true
+    },
+    "source_artifacts": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/artifact" }
+    },
+    "safety": {
+      "type": "object",
+      "required": ["mutation_mode", "mutated_cluster", "live_apply_allowed", "human_approval_required_for_apply"],
+      "properties": {
+        "mutation_mode": { "const": "read-only" },
+        "mutated_cluster": { "const": false },
+        "live_apply_allowed": { "const": false },
+        "human_approval_required_for_apply": { "const": true }
+      },
+      "additionalProperties": true
+    },
+    "cluster": { "type": "object" },
+    "checks": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/check" }
+    },
+    "read_operations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/read_operation" }
+    },
+    "errors": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "required": ["id", "ref", "digest"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "ref": { "type": "string", "minLength": 1 },
+        "digest": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "check": {
+      "type": "object",
+      "required": ["id", "status"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "status": { "enum": ["passed", "failed", "blocked"] }
+      },
+      "additionalProperties": false
+    },
+    "read_operation": {
+      "type": "object",
+      "required": ["args", "status", "returncode"],
+      "properties": {
+        "args": { "type": "array", "items": { "type": "string" } },
+        "status": { "enum": ["passed", "failed", "denied"] },
+        "returncode": { "type": ["integer", "null"] }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/emit_fogstack_live_cluster_preflight_record.py
+++ b/tools/emit_fogstack_live_cluster_preflight_record.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+READ_TIMEOUT_SECONDS = 15
+
+
+MUTATING_VERBS = {"apply", "create", "delete", "patch", "replace", "rollout", "scale", "set", "annotate", "label", "cordon", "drain", "uncordon"}
+READ_ONLY_COMMANDS = {
+    ("config", "current-context"),
+    ("version", "--client"),
+    ("cluster-info",),
+    ("get", "namespace"),
+    ("get", "storageclass"),
+    ("api-resources",),
+    ("auth", "can-i"),
+}
+
+
+def resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    import hashlib
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def resolve_kubectl(kubectl: str) -> str | None:
+    if "/" in kubectl:
+        path = Path(kubectl)
+        return str(path) if path.exists() else None
+    return shutil.which(kubectl)
+
+
+def command_is_allowed(args: list[str]) -> bool:
+    if not args:
+        return False
+    if args[0] in MUTATING_VERBS and args[:2] != ["auth", "can-i"]:
+        return False
+    return any(tuple(args[: len(prefix)]) == prefix for prefix in READ_ONLY_COMMANDS)
+
+
+def run_kubectl(kubectl_path: str, args: list[str]) -> dict[str, Any]:
+    if not command_is_allowed(args):
+        return {
+            "args": ["kubectl", *args],
+            "status": "denied",
+            "returncode": None,
+            "stdout": "",
+            "stderr": "command denied by read-only preflight allowlist",
+        }
+    proc = subprocess.run(
+        [kubectl_path, *args],
+        capture_output=True,
+        text=True,
+        timeout=READ_TIMEOUT_SECONDS,
+    )
+    return {
+        "args": ["kubectl", *args],
+        "status": "passed" if proc.returncode == 0 else "failed",
+        "returncode": proc.returncode,
+        "stdout": proc.stdout.strip(),
+        "stderr": proc.stderr.strip(),
+    }
+
+
+def parse_json_output(command: dict[str, Any]) -> dict[str, Any]:
+    if command.get("status") != "passed" or not command.get("stdout"):
+        return {}
+    try:
+        data = json.loads(command["stdout"])
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def parse_yes(command: dict[str, Any]) -> bool:
+    return command.get("status") == "passed" and str(command.get("stdout", "")).strip().lower() == "yes"
+
+
+def storage_summary(command: dict[str, Any]) -> dict[str, Any]:
+    data = parse_json_output(command)
+    items = data.get("items", []) if isinstance(data.get("items"), list) else []
+    classes = []
+    topolvm = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        metadata = item.get("metadata", {}) if isinstance(item.get("metadata"), dict) else {}
+        name = str(metadata.get("name", ""))
+        provisioner = str(item.get("provisioner", ""))
+        entry = {"name": name, "provisioner": provisioner}
+        classes.append(entry)
+        if "topolvm" in name.lower() or "topolvm" in provisioner.lower():
+            topolvm.append(entry)
+    return {
+        "storageclass_count": len(classes),
+        "storageclasses": classes,
+        "topolvm_observed": bool(topolvm),
+        "topolvm_storageclasses": topolvm,
+    }
+
+
+def api_resource_summary(command: dict[str, Any]) -> dict[str, Any]:
+    resources = [line.strip() for line in str(command.get("stdout", "")).splitlines() if line.strip()]
+    lowered = {resource.lower() for resource in resources}
+    argo = any("applications.argoproj.io" == resource or resource.endswith(".argoproj.io") for resource in lowered)
+    flux = any(resource.endswith(".toolkit.fluxcd.io") for resource in lowered)
+    return {
+        "resource_count": len(resources),
+        "resources": resources,
+        "gitops_controller_api_observed": argo or flux,
+        "argo_cd_api_observed": argo,
+        "flux_api_observed": flux,
+    }
+
+
+def source_artifact(path: Path | None, artifact_id: str) -> dict[str, str] | None:
+    if path is None:
+        return None
+    resolved = resolve(path)
+    if not resolved.exists() or not resolved.is_file():
+        return {"id": artifact_id, "ref": rel(resolved), "digest": "missing"}
+    return {"id": artifact_id, "ref": rel(resolved), "digest": sha256_file(resolved)}
+
+
+def infer_namespace(namespace: str | None, deploy_plan_path: Path | None) -> str:
+    if namespace:
+        return namespace
+    if deploy_plan_path:
+        plan_path = resolve(deploy_plan_path)
+        if plan_path.exists():
+            plan = load_json(plan_path)
+            value = plan.get("namespace")
+            if isinstance(value, str) and value:
+                return value
+    return "fogstack-access"
+
+
+def build_blocked_record(
+    *,
+    namespace: str,
+    kubectl: str,
+    resolved_kubectl: str | None,
+    reason: str,
+    require_live_cluster: bool,
+    source_artifacts: list[dict[str, str]],
+) -> dict[str, Any]:
+    return {
+        "kind": "FogStackLiveClusterPreflightRecord",
+        "schema_version": "v0.1",
+        "status": "blocked",
+        "reason": reason,
+        "namespace": namespace,
+        "mode": "read-only-live-preflight",
+        "kubectl": {
+            "executable": kubectl,
+            "available": resolved_kubectl is not None,
+            "resolved_path": resolved_kubectl,
+        },
+        "source_artifacts": source_artifacts,
+        "safety": safety_block(),
+        "checks": [],
+        "read_operations": [],
+        "errors": [reason] if require_live_cluster else [],
+    }
+
+
+def safety_block() -> dict[str, Any]:
+    return {
+        "mutation_mode": "read-only",
+        "mutated_cluster": False,
+        "applied_resources": False,
+        "created_resources": False,
+        "deleted_resources": False,
+        "live_apply_allowed": False,
+        "human_approval_required_for_apply": True,
+        "allowed_command_families": ["config current-context", "version --client", "cluster-info", "get", "api-resources", "auth can-i"],
+        "denied_command_families": sorted(MUTATING_VERBS),
+    }
+
+
+def emit_record(
+    *,
+    output_path: Path,
+    namespace: str,
+    kubectl: str,
+    require_live_cluster: bool,
+    deploy_plan: Path | None,
+    node_profile: Path | None,
+    gitops_bundle: Path | None,
+) -> dict[str, Any]:
+    source_artifacts = [
+        artifact
+        for artifact in [
+            source_artifact(deploy_plan, "deploy-plan"),
+            source_artifact(node_profile, "node-profile"),
+            source_artifact(gitops_bundle, "gitops-bundle"),
+        ]
+        if artifact is not None
+    ]
+    resolved_kubectl = resolve_kubectl(kubectl)
+    if resolved_kubectl is None:
+        record = build_blocked_record(
+            namespace=namespace,
+            kubectl=kubectl,
+            resolved_kubectl=None,
+            reason="kubectl unavailable; live cluster preflight not attempted",
+            require_live_cluster=require_live_cluster,
+            source_artifacts=source_artifacts,
+        )
+        write_json(output_path, record)
+        return record
+
+    operations: list[dict[str, Any]] = []
+
+    def run(args: list[str]) -> dict[str, Any]:
+        command = run_kubectl(resolved_kubectl, args)
+        operations.append({key: command[key] for key in ["args", "status", "returncode"]})
+        return command
+
+    current_context = run(["config", "current-context"])
+    client_version = run(["version", "--client", "-o", "json"])
+    cluster_info = run(["cluster-info"])
+    if cluster_info.get("status") != "passed":
+        reason = "cluster-info failed; live cluster unavailable or kubeconfig not usable"
+        record = build_blocked_record(
+            namespace=namespace,
+            kubectl=kubectl,
+            resolved_kubectl=resolved_kubectl,
+            reason=reason,
+            require_live_cluster=require_live_cluster,
+            source_artifacts=source_artifacts,
+        )
+        record["read_operations"] = operations
+        record["kubectl"]["current_context"] = current_context.get("stdout")
+        record["kubectl"]["cluster_info_error"] = cluster_info.get("stderr") or cluster_info.get("stdout")
+        write_json(output_path, record)
+        return record
+
+    namespace_get = run(["get", "namespace", namespace, "-o", "json"])
+    storageclasses = run(["get", "storageclass", "-o", "json"])
+    api_resources = run(["api-resources", "-o", "name"])
+    can_get_pods = run(["auth", "can-i", "get", "pods", "--namespace", namespace])
+    can_list_pods = run(["auth", "can-i", "list", "pods", "--namespace", namespace])
+    can_create_deployments = run(["auth", "can-i", "create", "deployments", "--namespace", namespace])
+    can_update_deployments = run(["auth", "can-i", "update", "deployments", "--namespace", namespace])
+    can_patch_deployments = run(["auth", "can-i", "patch", "deployments", "--namespace", namespace])
+
+    ns = parse_json_output(namespace_get)
+    storage = storage_summary(storageclasses)
+    resources = api_resource_summary(api_resources)
+    authorization = {
+        "can_get_pods": parse_yes(can_get_pods),
+        "can_list_pods": parse_yes(can_list_pods),
+        "can_create_deployments": parse_yes(can_create_deployments),
+        "can_update_deployments": parse_yes(can_update_deployments),
+        "can_patch_deployments": parse_yes(can_patch_deployments),
+        "mutation_permissions_observed_by_sar_only": any(
+            parse_yes(command) for command in [can_create_deployments, can_update_deployments, can_patch_deployments]
+        ),
+    }
+    checks = [
+        {"id": "kubectl_available", "status": "passed"},
+        {"id": "current_context", "status": "passed" if current_context.get("status") == "passed" else "failed"},
+        {"id": "cluster_reachable", "status": "passed"},
+        {"id": "namespace_exists", "status": "passed" if namespace_get.get("status") == "passed" and ns.get("metadata", {}).get("name") == namespace else "failed"},
+        {"id": "storageclasses_readable", "status": "passed" if storageclasses.get("status") == "passed" else "failed"},
+        {"id": "readonly_pod_access", "status": "passed" if authorization["can_get_pods"] and authorization["can_list_pods"] else "failed"},
+        {"id": "api_resources_readable", "status": "passed" if api_resources.get("status") == "passed" else "failed"},
+    ]
+    status = "passed" if all(check["status"] == "passed" for check in checks) else "failed"
+    errors = [check["id"] for check in checks if check["status"] != "passed"]
+    record = {
+        "kind": "FogStackLiveClusterPreflightRecord",
+        "schema_version": "v0.1",
+        "status": status,
+        "reason": None if status == "passed" else "one or more read-only live preflight checks failed",
+        "namespace": namespace,
+        "mode": "read-only-live-preflight",
+        "kubectl": {
+            "executable": kubectl,
+            "available": True,
+            "resolved_path": resolved_kubectl,
+            "current_context": current_context.get("stdout"),
+            "client_version": parse_json_output(client_version),
+        },
+        "source_artifacts": source_artifacts,
+        "safety": safety_block(),
+        "cluster": {
+            "namespace": ns.get("metadata", {}),
+            "storage": storage,
+            "api_resources": resources,
+            "authorization": authorization,
+        },
+        "checks": checks,
+        "read_operations": operations,
+        "errors": errors,
+    }
+    write_json(output_path, record)
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a non-mutating FogStack live cluster preflight record")
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--namespace")
+    parser.add_argument("--deploy-plan", type=Path)
+    parser.add_argument("--node-profile", type=Path)
+    parser.add_argument("--gitops-bundle", type=Path)
+    parser.add_argument("--kubectl", default="kubectl")
+    parser.add_argument("--require-live-cluster", action="store_true")
+    args = parser.parse_args()
+
+    namespace = infer_namespace(args.namespace, args.deploy_plan)
+    output = resolve(args.output)
+    record = emit_record(
+        output_path=output,
+        namespace=namespace,
+        kubectl=args.kubectl,
+        require_live_cluster=args.require_live_cluster,
+        deploy_plan=args.deploy_plan,
+        node_profile=args.node_profile,
+        gitops_bundle=args.gitops_bundle,
+    )
+    print(json.dumps(record, indent=2))
+    if record["status"] == "failed" or (record["status"] == "blocked" and args.require_live_cluster):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_live_cluster_preflight_record.py
+++ b/tools/tests/test_fogstack_live_cluster_preflight_record.py
@@ -5,14 +5,22 @@ import subprocess
 import sys
 from pathlib import Path
 
+import jsonschema
+
 
 SCRIPT = Path("tools/emit_fogstack_live_cluster_preflight_record.py")
+SCHEMA = Path("schemas/runtime/fogstack-live-cluster-preflight-record-v0.1.schema.json")
 
 
 def read_json(path: Path) -> dict:
     data = json.loads(path.read_text(encoding="utf-8"))
     assert isinstance(data, dict)
     return data
+
+
+def validate_record(record: dict) -> None:
+    schema = read_json(SCHEMA)
+    jsonschema.validate(record, schema)
 
 
 def run_preflight(output: Path, *extra: str) -> subprocess.CompletedProcess[str]:
@@ -67,6 +75,7 @@ def test_preflight_blocks_safely_when_kubectl_missing(tmp_path: Path) -> None:
     proc = run_preflight(output, "--kubectl", "missing-kubectl-for-live-preflight")
     assert proc.returncode == 0
     record = read_json(output)
+    validate_record(record)
     assert record["kind"] == "FogStackLiveClusterPreflightRecord"
     assert record["status"] == "blocked"
     assert record["safety"]["mutation_mode"] == "read-only"
@@ -80,6 +89,7 @@ def test_preflight_requires_live_cluster_when_requested(tmp_path: Path) -> None:
     proc = run_preflight(output, "--kubectl", "missing-kubectl-for-live-preflight", "--require-live-cluster")
     assert proc.returncode == 1
     record = read_json(output)
+    validate_record(record)
     assert record["status"] == "blocked"
     assert record["errors"] == ["kubectl unavailable; live cluster preflight not attempted"]
 
@@ -91,6 +101,7 @@ def test_preflight_passes_with_fake_readonly_cluster(tmp_path: Path) -> None:
     proc = run_preflight(output, "--kubectl", str(kubectl), "--namespace", "fogstack-access")
     assert proc.returncode == 0, proc.stderr
     record = read_json(output)
+    validate_record(record)
     assert record["status"] == "passed"
     assert record["namespace"] == "fogstack-access"
     assert record["safety"]["mutation_mode"] == "read-only"

--- a/tools/tests/test_fogstack_live_cluster_preflight_record.py
+++ b/tools/tests/test_fogstack_live_cluster_preflight_record.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path("tools/emit_fogstack_live_cluster_preflight_record.py")
+
+
+def read_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def run_preflight(output: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(SCRIPT), "--output", str(output), *extra], capture_output=True, text=True)
+
+
+def fake_kubectl(path: Path, log_path: Path) -> Path:
+    script = f'''#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+log_path = Path({str(log_path)!r})
+args = sys.argv[1:]
+log_path.parent.mkdir(parents=True, exist_ok=True)
+with log_path.open("a", encoding="utf-8") as handle:
+    handle.write(" ".join(args) + "\\n")
+
+if args[:2] == ["config", "current-context"]:
+    print("kind-fogstack")
+    raise SystemExit(0)
+if args[:2] == ["version", "--client"]:
+    print(json.dumps({{"clientVersion": {{"gitVersion": "v1.30.0"}}}}))
+    raise SystemExit(0)
+if args[:1] == ["cluster-info"]:
+    print("Kubernetes control plane is running at https://127.0.0.1")
+    raise SystemExit(0)
+if args[:2] == ["get", "namespace"]:
+    print(json.dumps({{"metadata": {{"name": args[2], "labels": {{"fogstack.socioprophet.io/preflight": "true"}}}}}}))
+    raise SystemExit(0)
+if args[:2] == ["get", "storageclass"]:
+    print(json.dumps({{"items": [{{"metadata": {{"name": "topolvm-provisioner"}}, "provisioner": "topolvm.io"}}]}}))
+    raise SystemExit(0)
+if args[:1] == ["api-resources"]:
+    print("pods\\ndeployments.apps\\napplications.argoproj.io\\nkustomizations.kustomize.toolkit.fluxcd.io")
+    raise SystemExit(0)
+if args[:2] == ["auth", "can-i"]:
+    print("yes")
+    raise SystemExit(0)
+print("unexpected args: " + " ".join(args), file=sys.stderr)
+raise SystemExit(2)
+'''
+    path.write_text(script, encoding="utf-8")
+    path.chmod(path.stat().st_mode | 0o111)
+    return path
+
+
+def test_preflight_blocks_safely_when_kubectl_missing(tmp_path: Path) -> None:
+    output = tmp_path / "preflight.json"
+    proc = run_preflight(output, "--kubectl", "missing-kubectl-for-live-preflight")
+    assert proc.returncode == 0
+    record = read_json(output)
+    assert record["kind"] == "FogStackLiveClusterPreflightRecord"
+    assert record["status"] == "blocked"
+    assert record["safety"]["mutation_mode"] == "read-only"
+    assert record["safety"]["mutated_cluster"] is False
+    assert record["safety"]["live_apply_allowed"] is False
+    assert record["errors"] == []
+
+
+def test_preflight_requires_live_cluster_when_requested(tmp_path: Path) -> None:
+    output = tmp_path / "preflight.json"
+    proc = run_preflight(output, "--kubectl", "missing-kubectl-for-live-preflight", "--require-live-cluster")
+    assert proc.returncode == 1
+    record = read_json(output)
+    assert record["status"] == "blocked"
+    assert record["errors"] == ["kubectl unavailable; live cluster preflight not attempted"]
+
+
+def test_preflight_passes_with_fake_readonly_cluster(tmp_path: Path) -> None:
+    output = tmp_path / "preflight.json"
+    log_path = tmp_path / "kubectl.log"
+    kubectl = fake_kubectl(tmp_path / "kubectl", log_path)
+    proc = run_preflight(output, "--kubectl", str(kubectl), "--namespace", "fogstack-access")
+    assert proc.returncode == 0, proc.stderr
+    record = read_json(output)
+    assert record["status"] == "passed"
+    assert record["namespace"] == "fogstack-access"
+    assert record["safety"]["mutation_mode"] == "read-only"
+    assert record["safety"]["mutated_cluster"] is False
+    assert record["safety"]["applied_resources"] is False
+    assert record["cluster"]["storage"]["topolvm_observed"] is True
+    assert record["cluster"]["api_resources"]["gitops_controller_api_observed"] is True
+    assert record["cluster"]["authorization"]["can_get_pods"] is True
+    assert record["cluster"]["authorization"]["mutation_permissions_observed_by_sar_only"] is True
+    assert {check["status"] for check in record["checks"]} == {"passed"}
+
+    calls = log_path.read_text(encoding="utf-8").splitlines()
+    forbidden = ("apply", "create", "delete", "patch", "replace", "rollout", "scale", "set", "annotate", "label")
+    for call in calls:
+        parts = call.split()
+        assert parts[0] not in forbidden
+    assert "auth can-i create deployments --namespace fogstack-access" in calls
+    assert "auth can-i patch deployments --namespace fogstack-access" in calls
+
+
+def test_preflight_command_allowlist_denies_mutating_family() -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("preflight", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.command_is_allowed(["get", "namespace", "fogstack-access"])
+    assert module.command_is_allowed(["auth", "can-i", "create", "deployments"])
+    assert not module.command_is_allowed(["apply", "-f", "manifests"])
+    assert not module.command_is_allowed(["delete", "namespace", "fogstack-access"])


### PR DESCRIPTION
Deployment parity tranche A / live-cluster preflight v0.1.

This adds a non-mutating live cluster preflight record for FogStack runtime/deployment readiness. It intentionally does not add live apply, resource mutation, or controller reconciliation. The goal is to make live environment discovery explicit before any future apply path exists.

Changes:
- add `tools/emit_fogstack_live_cluster_preflight_record.py`
- add `schemas/runtime/fogstack-live-cluster-preflight-record-v0.1.schema.json`
- add `tools/tests/test_fogstack_live_cluster_preflight_record.py`
- wire the new tests and CI-safe preflight artifact into `.github/workflows/fogstack-local-cluster-runtime.yml`

Safety boundary:
- mode is `read-only-live-preflight`
- `live_apply_allowed=false`
- `mutated_cluster=false`
- no apply/create/delete/patch/replace/rollout/scale operations are executed
- mutation permission checks are SubjectAccessReview-style `kubectl auth can-i` only
- CI path uses a missing kubectl fallback to produce a safe `blocked` record instead of pretending there is a live cluster

Evidence captured when a live kube context exists:
- current context
- client version
- cluster reachability
- namespace existence
- StorageClass inventory and TopoLVM observation
- GitOps controller API observation from API resources
- read authorization for pods
- SAR-only mutation permission observations
- source artifact digests for deploy plan, node profile, and GitOps bundle

Validation:
- tests prove safe blocked behavior when kubectl is unavailable
- tests prove `--require-live-cluster` fails when no live cluster is available
- tests prove a fake read-only cluster emits a schema-valid passed record
- tests prove the command allowlist rejects direct mutation command families

Next tranche after this PR:
- connect this preflight record into parity readiness and operator summaries
- then add human-approved live apply planning, still without execution by default