### PR TITLE
infra(search): wire digest image patch into policy overlay

### DIFF
--- a/infra/k8s/search-orchestrator/overlays/policy/kustomization.yaml
+++ b/infra/k8s/search-orchestrator/overlays/policy/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 patches:
   - path: configmap-patch.yaml
   - path: deployment-patch.yaml
+  - path: image-patch.yaml


### PR DESCRIPTION
## Summary

Wires the generated digest-pinned Search Orchestrator image patch into the policy Kustomize overlay.

## Scope

- Adds `image-patch.yaml` to `infra/k8s/search-orchestrator/overlays/policy/kustomization.yaml`
- Ensures the existing real image lock and rendered image patch are actually applied by the policy overlay

## Safety posture

- Deployment wiring only
- No runtime route behavior change
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback

## Program lane

Search Orchestrator Academy bridge image digest pin closure.