### PR TITLE
schemas(platform): add office runtime records

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lattice-studio-smoke:
 	cd apps/lattice-studio && . .venv/bin/activate && python -m pip install --upgrade pip pytest && PYTHONPATH=src pytest -q tests
 	mkdir -p build/lattice-studio
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-demo-catalog --output-dir build/lattice-studio/catalog
-	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli create-session --project-id demo-project --user-id demo-user --runtime-asset apps/lattice-studio/examples/runtime-asset.prophet-python-ml.json --catalog-input catalog://datasets/demo-csv@0.1.0 --catalog-input catalog://models/demo-classifier@0.1.0 --catalog-input catalog://applications/demo-notebook-app@0.1.0 --catalog-input catalog://services/demo-inference-service@0.1.0 --policy-ref policy://lattice-studio/demo --output-dir build/lattice-studio/session
+	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli create-session --project-id demo-project --user-id demo-user --runtime-asset apps/lattice-studio/examples/runtime-asset.prophet-python-ml.json --catalog-input catalog://datasets/demo-csv@0.1.0 --catalog-input catalog://models/demo-classifier@0.1.0 --catalog-input catalog://applications/demo-notebook-app@0.1.0 --catalog-input catalog://services/demo-inference-service@0.1.0 --policy-ref policy://lattice-studio/paas-demo --output-dir build/lattice-studio/session
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-notebook-plane --output-dir build/lattice-studio/notebook-plane
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-workspace-demo --output-dir build/lattice-studio/workspace
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-atlas-context --output-dir build/lattice-studio/atlas
@@ -176,6 +176,10 @@ validate-fogstack:
 
 validate-storage-suite:
 	python3 tools/validate_storage_suite.py
+
+.PHONY: validate-office-runtime-contracts
+validate-office-runtime-contracts:
+	python3 tools/validate_office_runtime_contracts.py
 
 .PHONY: fogstack-local-demo
 fogstack-local-demo:

--- a/docs/OFFICE_CLOUD_SUITE_RUNTIME.md
+++ b/docs/OFFICE_CLOUD_SUITE_RUNTIME.md
@@ -136,6 +136,25 @@ The first runtime contracts should include:
 
 Those contracts should support local desktop and cloud editing paths without binding the product to a single editor implementation or closed provider.
 
+## Current contract paths
+
+Implemented office runtime contract paths:
+
+| Contract | Schema | Example | Purpose |
+|---|---|---|---|
+| Version | `schemas/office/office_version_record.schema.json` | `schemas/office/examples/office_version_record.example.json` | Captures document version lineage, content refs, content hashes, source provenance, and open execution backend. |
+| Writeback | `schemas/office/office_writeback_record.schema.json` | `schemas/office/examples/office_writeback_record.example.json` | Captures WOPI/local saveback operations, lock tokens, base/result versions, conflict state, and receipts. |
+| Policy decision | `schemas/office/office_policy_decision_record.schema.json` | `schemas/office/examples/office_policy_decision_record.example.json` | Captures approval/denial/review posture for edits, sends, publishes, imports, exports, and AI side effects. |
+| Adapter profile | `schemas/office/office_adapter_profile.schema.json` | `schemas/office/examples/office_adapter_profile.example.json` | Captures open runtime adapters and quarantined closed-provider migration/compatibility adapters. |
+
+Validation entrypoint:
+
+```bash
+python3 tools/validate_office_runtime_contracts.py
+```
+
+The adapter profile schema enforces that Google Workspace, Microsoft 365, Microsoft Graph, Apple iCloud, and Apple Notes profiles cannot be enabled by default, cannot be runtime dependencies, and cannot be core authority.
+
 ## Editor posture
 
 The runtime treats LibreOffice and Collabora as editing/conversion engines, not as the total product. The workspace graph, policy fabric, AI orchestration, receipts, collaboration records, and document-control services belong at the platform layer.

--- a/docs/WOPI_HOST_PROFILE.md
+++ b/docs/WOPI_HOST_PROFILE.md
@@ -39,9 +39,22 @@ The WOPI host should be backed by:
 
 - `office_document_record`
 - `office_session_record`
-- version and writeback records
-- policy decision records for side effects
+- `office_version_record`
+- `office_writeback_record`
+- `office_policy_decision_record`
+- `office_adapter_profile`
 - office AI receipts and action gating where editor-originating actions trigger AI follow-ons
+
+Concrete runtime schema paths:
+
+- `schemas/office/office_document_record.schema.json`
+- `schemas/office/office_session_record.schema.json`
+- `schemas/office/office_version_record.schema.json`
+- `schemas/office/office_writeback_record.schema.json`
+- `schemas/office/office_policy_decision_record.schema.json`
+- `schemas/office/office_adapter_profile.schema.json`
+
+The version and writeback records are the first durable handoff between WOPI RPC handling and asynchronous extraction, indexing, memory attachment, semantic graph mapping, and AI follow-on actions.
 
 ## Cross-repo integration
 

--- a/schemas/office/examples/office_adapter_profile.example.json
+++ b/schemas/office/examples/office_adapter_profile.example.json
@@ -1,0 +1,21 @@
+{
+  "adapter_id": "office-adapter-profile-google-workspace-import",
+  "adapter_type": "MIGRATION_EVIDENCE",
+  "provider": "GOOGLE_WORKSPACE",
+  "authority_scope": "MIGRATION_ONLY",
+  "enabled_by_default": false,
+  "runtime_dependency": false,
+  "policy_ref": "policy://office/closed-provider-quarantine",
+  "surface_refs": [
+    "exodus://providers/google-workspace"
+  ],
+  "capability_refs": [
+    "capability://office/import-metadata-only"
+  ],
+  "exodus_profile_ref": "exodus://provider-control-surface/google-workspace",
+  "notes": "Closed provider profile is migration evidence only, not a runtime authority.",
+  "labels": {
+    "sourceos.closed_provider": "quarantined",
+    "sourceos.default": "disabled"
+  }
+}

--- a/schemas/office/examples/office_policy_decision_record.example.json
+++ b/schemas/office/examples/office_policy_decision_record.example.json
@@ -1,0 +1,33 @@
+{
+  "decision_id": "office-policy-decision-demo-0001",
+  "tenant_id": "tenant-demo",
+  "document_id": "office-document-demo-0001",
+  "workroom_id": "workroom-demo-0001",
+  "actor_ref": "agentplane://agents/office-demo-writer",
+  "action_type": "SEND_MAIL",
+  "decision": "REQUIRE_REVIEW",
+  "status": "ACTIVE",
+  "risk_class": "EXTERNAL_SIDE_EFFECT",
+  "policy_refs": [
+    "policy://office/default-human-review-before-send"
+  ],
+  "adapter_profile_ref": "office-adapter-profile-sourceos-mail-draft",
+  "closed_provider_refs": [],
+  "obligation_refs": [
+    "obligation://office/human-review"
+  ],
+  "receipt_refs": [
+    "receipt://office/policy-demo-0001"
+  ],
+  "side_effects": {
+    "external_publish": false,
+    "email_send": true,
+    "calendar_mutation": false,
+    "closed_provider_write": false
+  },
+  "requested_at": "2026-05-03T22:10:00Z",
+  "expires_at": "2026-05-04T22:10:00Z",
+  "labels": {
+    "sourceos.review": "required"
+  }
+}

--- a/schemas/office/examples/office_version_record.example.json
+++ b/schemas/office/examples/office_version_record.example.json
@@ -1,0 +1,24 @@
+{
+  "version_id": "office-version-demo-0001",
+  "document_id": "office-document-demo-0001",
+  "tenant_id": "tenant-demo",
+  "version_number": 1,
+  "content_ref": "sourceos-office://workroom-demo-0001/versions/office-version-demo-0001.odt",
+  "content_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "format": "odt",
+  "canonical_format": "ODF",
+  "source_provider": "SOURCEOS",
+  "execution_backend": "LIBREOFFICE",
+  "capture_source": "AI_GENERATION",
+  "created_by_ref": "agentplane://agents/office-demo-writer",
+  "policy_decision_ref": "policy-decision://office/demo-allow-generate",
+  "receipt_refs": [
+    "receipt://office/version-demo-0001"
+  ],
+  "semantic_unit_refs": [],
+  "created_at": "2026-05-03T22:00:00Z",
+  "labels": {
+    "sourceos.surface": "office-runtime",
+    "sourceos.authority": "open"
+  }
+}

--- a/schemas/office/examples/office_writeback_record.example.json
+++ b/schemas/office/examples/office_writeback_record.example.json
@@ -1,0 +1,23 @@
+{
+  "writeback_id": "office-writeback-demo-0001",
+  "document_id": "office-document-demo-0001",
+  "session_id": "office-session-demo-0001",
+  "operation": "WOPI_PUT_FILE",
+  "status": "COMMITTED",
+  "base_version_id": "office-version-demo-0001",
+  "result_version_id": "office-version-demo-0002",
+  "lock_token": "lock-demo-0001",
+  "actor_ref": "user://demo-reviewer",
+  "source": "EDITOR_SESSION",
+  "execution_backend": "COLLABORA",
+  "content_ref": "sourceos-office://workroom-demo-0001/writeback/office-writeback-demo-0001.odt",
+  "content_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "policy_decision_ref": "policy-decision://office/demo-saveback",
+  "receipt_ref": "receipt://office/writeback-demo-0001",
+  "requested_at": "2026-05-03T22:05:00Z",
+  "committed_at": "2026-05-03T22:05:03Z",
+  "labels": {
+    "sourceos.wopi": "put-file",
+    "sourceos.hot_path": "narrow"
+  }
+}

--- a/schemas/office/office_adapter_profile.schema.json
+++ b/schemas/office/office_adapter_profile.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/office/office_adapter_profile.schema.json",
+  "title": "office_adapter_profile",
+  "type": "object",
+  "required": [
+    "adapter_id",
+    "adapter_type",
+    "provider",
+    "authority_scope",
+    "enabled_by_default",
+    "runtime_dependency",
+    "policy_ref"
+  ],
+  "properties": {
+    "adapter_id": {"type": "string"},
+    "adapter_type": {"type": "string", "enum": ["OPEN_RUNTIME", "COMPATIBILITY_IMPORT", "COMPATIBILITY_EXPORT", "MIGRATION_EVIDENCE", "TEST_FIXTURE"]},
+    "provider": {"type": "string", "enum": ["SOURCEOS", "LIBREOFFICE", "COLLABORA", "ONLYOFFICE", "GOOGLE_WORKSPACE", "MICROSOFT_365", "MICROSOFT_GRAPH", "APPLE_ICLOUD", "APPLE_NOTES", "OTHER"]},
+    "authority_scope": {"type": "string", "enum": ["CORE_AUTHORITY", "EXECUTION_BACKEND", "PROVENANCE_ONLY", "MIGRATION_ONLY", "TEST_ONLY"]},
+    "enabled_by_default": {"type": "boolean"},
+    "runtime_dependency": {"type": "boolean"},
+    "policy_ref": {"type": "string"},
+    "surface_refs": {"type": "array", "items": {"type": "string"}},
+    "capability_refs": {"type": "array", "items": {"type": "string"}},
+    "exodus_profile_ref": {"type": "string"},
+    "notes": {"type": "string"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "provider": {
+            "enum": ["GOOGLE_WORKSPACE", "MICROSOFT_365", "MICROSOFT_GRAPH", "APPLE_ICLOUD", "APPLE_NOTES"]
+          }
+        },
+        "required": ["provider"]
+      },
+      "then": {
+        "properties": {
+          "enabled_by_default": {"const": false},
+          "runtime_dependency": {"const": false},
+          "authority_scope": {"enum": ["PROVENANCE_ONLY", "MIGRATION_ONLY", "TEST_ONLY"]},
+          "adapter_type": {"enum": ["COMPATIBILITY_IMPORT", "COMPATIBILITY_EXPORT", "MIGRATION_EVIDENCE", "TEST_FIXTURE"]}
+        }
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/schemas/office/office_policy_decision_record.schema.json
+++ b/schemas/office/office_policy_decision_record.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/office/office_policy_decision_record.schema.json",
+  "title": "office_policy_decision_record",
+  "type": "object",
+  "required": [
+    "decision_id",
+    "tenant_id",
+    "actor_ref",
+    "action_type",
+    "decision",
+    "status",
+    "policy_refs",
+    "requested_at"
+  ],
+  "properties": {
+    "decision_id": {"type": "string"},
+    "tenant_id": {"type": "string"},
+    "document_id": {"type": "string"},
+    "workroom_id": {"type": "string"},
+    "actor_ref": {"type": "string"},
+    "action_type": {"type": "string", "enum": ["EDIT", "SAVE", "EXPORT", "IMPORT", "SHARE", "PUBLISH", "SEND_MAIL", "CREATE_CALENDAR_ITEM", "AI_SUGGESTION", "AI_REWRITE", "MIGRATION_IMPORT"]},
+    "decision": {"type": "string", "enum": ["ALLOW", "DENY", "REQUIRE_REVIEW", "REQUIRE_QUORUM", "DRY_RUN_ONLY"]},
+    "status": {"type": "string", "enum": ["REQUESTED", "ACTIVE", "SUPERSEDED", "EXPIRED", "REVOKED"]},
+    "risk_class": {"type": "string", "enum": ["LOW", "MEDIUM", "HIGH", "REGULATED", "EXTERNAL_SIDE_EFFECT"]},
+    "policy_refs": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "adapter_profile_ref": {"type": "string"},
+    "closed_provider_refs": {"type": "array", "items": {"type": "string"}},
+    "obligation_refs": {"type": "array", "items": {"type": "string"}},
+    "receipt_refs": {"type": "array", "items": {"type": "string"}},
+    "side_effects": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "external_publish": {"type": "boolean"},
+        "email_send": {"type": "boolean"},
+        "calendar_mutation": {"type": "boolean"},
+        "closed_provider_write": {"type": "boolean"}
+      }
+    },
+    "requested_at": {"type": "string", "format": "date-time"},
+    "expires_at": {"type": "string", "format": "date-time"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  },
+  "additionalProperties": false
+}

--- a/schemas/office/office_version_record.schema.json
+++ b/schemas/office/office_version_record.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/office/office_version_record.schema.json",
+  "title": "office_version_record",
+  "type": "object",
+  "required": [
+    "version_id",
+    "document_id",
+    "tenant_id",
+    "version_number",
+    "content_ref",
+    "content_hash",
+    "format",
+    "canonical_format",
+    "source_provider",
+    "execution_backend",
+    "capture_source",
+    "created_at"
+  ],
+  "properties": {
+    "version_id": {"type": "string"},
+    "document_id": {"type": "string"},
+    "tenant_id": {"type": "string"},
+    "version_number": {"type": "integer", "minimum": 1},
+    "parent_version_id": {"type": "string"},
+    "previous_version_id": {"type": "string"},
+    "content_ref": {"type": "string"},
+    "content_hash": {"type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$"},
+    "format": {"type": "string", "enum": ["odt", "ods", "odp", "docx", "xlsx", "pptx", "pdf", "md", "txt", "csv", "json", "html", "eml", "ics"]},
+    "canonical_format": {"type": "string", "enum": ["ODF", "OOXML", "PDF", "MARKDOWN", "PLAIN_TEXT", "MIXED"]},
+    "source_provider": {
+      "type": "string",
+      "enum": ["SOURCEOS", "IMPORTED_MICROSOFT", "IMPORTED_GOOGLE", "IMPORTED_APPLE", "IMPORTED_OPEN_DOCUMENT", "IMPORTED_OOXML", "IMPORTED_PDF", "IMPORTED_OTHER", "UNKNOWN"],
+      "description": "Provenance only. Closed providers are not runtime authorities."
+    },
+    "execution_backend": {
+      "type": "string",
+      "enum": ["SOURCEOS_NATIVE", "LIBREOFFICE", "COLLABORA", "HEADLESS", "MANUAL", "OTHER_OPEN"],
+      "description": "Open runtime engine used to create or capture the version."
+    },
+    "capture_source": {"type": "string", "enum": ["INITIAL_IMPORT", "LOCAL_SAVE", "WOPI_WRITEBACK", "CONVERSION", "AI_GENERATION", "MANUAL_UPLOAD", "MIGRATION_IMPORT", "SYSTEM_WORKFLOW"]},
+    "created_by_ref": {"type": "string"},
+    "writeback_ref": {"type": "string"},
+    "policy_decision_ref": {"type": "string"},
+    "receipt_refs": {"type": "array", "items": {"type": "string"}},
+    "semantic_unit_refs": {"type": "array", "items": {"type": "string"}},
+    "created_at": {"type": "string", "format": "date-time"},
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  },
+  "additionalProperties": false
+}

--- a/schemas/office/office_writeback_record.schema.json
+++ b/schemas/office/office_writeback_record.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/office/office_writeback_record.schema.json",
+  "title": "office_writeback_record",
+  "type": "object",
+  "required": [
+    "writeback_id",
+    "document_id",
+    "session_id",
+    "operation",
+    "status",
+    "base_version_id",
+    "source",
+    "execution_backend",
+    "requested_at"
+  ],
+  "properties": {
+    "writeback_id": {"type": "string"},
+    "document_id": {"type": "string"},
+    "session_id": {"type": "string"},
+    "operation": {"type": "string", "enum": ["WOPI_PUT_FILE", "WOPI_PUT_RELATIVE_FILE", "LOCAL_SAVE", "CONVERSION_SAVE", "IMPORT_SAVE", "AUTOSAVE"]},
+    "status": {"type": "string", "enum": ["REQUESTED", "ACCEPTED", "REJECTED", "CONFLICT", "COMMITTED", "FAILED", "ROLLED_BACK"]},
+    "base_version_id": {"type": "string"},
+    "result_version_id": {"type": "string"},
+    "lock_token": {"type": "string"},
+    "actor_ref": {"type": "string"},
+    "source": {"type": "string", "enum": ["EDITOR_SESSION", "LOCAL_CLI", "AGENT_ACTION", "MIGRATION_IMPORT", "SYSTEM_WORKFLOW"]},
+    "execution_backend": {"type": "string", "enum": ["SOURCEOS_NATIVE", "LIBREOFFICE", "COLLABORA", "HEADLESS", "MANUAL", "OTHER_OPEN"]},
+    "content_ref": {"type": "string"},
+    "content_hash": {"type": "string", "pattern": "^sha256:[a-fA-F0-9]{64}$"},
+    "policy_decision_ref": {"type": "string"},
+    "receipt_ref": {"type": "string"},
+    "conflict_ref": {"type": "string"},
+    "requested_at": {"type": "string", "format": "date-time"},
+    "committed_at": {"type": "string", "format": "date-time"},
+    "error": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "code": {"type": "string"},
+        "message": {"type": "string"},
+        "retryable": {"type": "boolean"}
+      }
+    },
+    "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+  },
+  "additionalProperties": false
+}

--- a/tools/tests/test_validate_office_runtime_contracts.py
+++ b/tools/tests/test_validate_office_runtime_contracts.py
@@ -1,0 +1,41 @@
+"""Tests for SourceOS office runtime contract validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from tools import validate_office_runtime_contracts
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_json(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_office_runtime_contract_examples_validate():
+    assert validate_office_runtime_contracts.main() == 0
+
+
+def test_closed_provider_adapter_cannot_be_core_authority():
+    schema = _load_json(ROOT / "schemas" / "office" / "office_adapter_profile.schema.json")
+    example = _load_json(ROOT / "schemas" / "office" / "examples" / "office_adapter_profile.example.json")
+    example["authority_scope"] = "CORE_AUTHORITY"
+    example["enabled_by_default"] = True
+    example["runtime_dependency"] = True
+    example["adapter_type"] = "OPEN_RUNTIME"
+
+    errors = list(Draft202012Validator(schema).iter_errors(example))
+
+    assert errors
+    assert any(
+        "CORE_AUTHORITY" in error.message
+        or "False was expected" in error.message
+        or "OPEN_RUNTIME" in error.message
+        for error in errors
+    )

--- a/tools/tests/test_validate_office_runtime_contracts.py
+++ b/tools/tests/test_validate_office_runtime_contracts.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 from jsonschema import Draft202012Validator
 
-from tools import validate_office_runtime_contracts
-
 
 ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import validate_office_runtime_contracts  # noqa: E402
 
 
 def _load_json(path: Path):

--- a/tools/validate_office_runtime_contracts.py
+++ b/tools/validate_office_runtime_contracts.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Validate SourceOS office runtime contract examples."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PAIRS = [
+    (
+        ROOT / "schemas" / "office" / "office_version_record.schema.json",
+        ROOT / "schemas" / "office" / "examples" / "office_version_record.example.json",
+    ),
+    (
+        ROOT / "schemas" / "office" / "office_writeback_record.schema.json",
+        ROOT / "schemas" / "office" / "examples" / "office_writeback_record.example.json",
+    ),
+    (
+        ROOT / "schemas" / "office" / "office_policy_decision_record.schema.json",
+        ROOT / "schemas" / "office" / "examples" / "office_policy_decision_record.example.json",
+    ),
+    (
+        ROOT / "schemas" / "office" / "office_adapter_profile.schema.json",
+        ROOT / "schemas" / "office" / "examples" / "office_adapter_profile.example.json",
+    ),
+]
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate_pair(schema_path: Path, example_path: Path) -> list[str]:
+    schema = load_json(schema_path)
+    example = load_json(example_path)
+
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(example), key=lambda error: list(error.path))
+
+    rendered: list[str] = []
+    for error in errors:
+        location = ".".join(str(part) for part in error.path) or "<root>"
+        rendered.append(f"{example_path.relative_to(ROOT)} {location}: {error.message}")
+    return rendered
+
+
+def main() -> int:
+    missing = [
+        str(path.relative_to(ROOT))
+        for pair in CONTRACT_PAIRS
+        for path in pair
+        if not path.exists()
+    ]
+    if missing:
+        print("Missing office runtime contract validation inputs:")
+        for item in missing:
+            print(f" - {item}")
+        return 1
+
+    failures: list[str] = []
+    for schema_path, example_path in CONTRACT_PAIRS:
+        failures.extend(validate_pair(schema_path, example_path))
+
+    if failures:
+        print("Office runtime contract examples failed validation:")
+        for item in failures:
+            print(f" - {item}")
+        return 1
+
+    print("Office runtime contract examples validate.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #365.

Adds the next SourceOS office runtime contract slice for open WOPI/saveback execution:

- `office_version_record`
- `office_writeback_record`
- `office_policy_decision_record`
- `office_adapter_profile`

The adapter profile schema enforces the closed-provider quarantine boundary: Google Workspace, Microsoft 365, Microsoft Graph, Apple iCloud, and Apple Notes cannot be enabled by default, cannot be runtime dependencies, and cannot be core authority.

## Changes

### Schemas

- `schemas/office/office_version_record.schema.json`
- `schemas/office/office_writeback_record.schema.json`
- `schemas/office/office_policy_decision_record.schema.json`
- `schemas/office/office_adapter_profile.schema.json`

### Examples

- `schemas/office/examples/office_version_record.example.json`
- `schemas/office/examples/office_writeback_record.example.json`
- `schemas/office/examples/office_policy_decision_record.example.json`
- `schemas/office/examples/office_adapter_profile.example.json`

### Validation

- Adds `tools/validate_office_runtime_contracts.py`.
- Adds `tools/tests/test_validate_office_runtime_contracts.py`.
- Adds `make validate-office-runtime-contracts`.

### Docs

- Updates `docs/OFFICE_CLOUD_SUITE_RUNTIME.md` with concrete contract paths and validation command.
- Updates `docs/WOPI_HOST_PROFILE.md` with concrete WOPI object bindings.

## Validation performed

- Local equivalent validation of all schemas and examples using `jsonschema.Draft202012Validator` passed.
- Local equivalent pytest coverage passed for:
  - example validation
  - negative closed-provider authority test
- Branch diff is limited to office runtime schemas/examples/docs/tools plus one Makefile validation target.

## Notes

The branch is behind current `main`, but changes are additive and documentation/schema/test oriented. GitHub mergeability should determine whether replay is required. No closed-provider credentials, OAuth flows, or API clients are introduced.