### PR TITLE
lock(auth): pin agent auth standards consumption

### DIFF
--- a/standards.lock.yaml
+++ b/standards.lock.yaml
@@ -120,6 +120,31 @@ spec:
           storageAuthorityRemainsExternal: true
           runtimeConformanceRequiredForMarketData: true
 
+      agent-auth-standards:
+        repo: SocioProphet/socioprophet-agent-standards
+        class: agent-auth-and-identity-profile
+        channel: controlled
+        pin:
+          commit: baed2ca7f9fa07fe1ed9354f9d896fd982c22616
+          tag: null
+        consume:
+          docs:
+            - docs/standards/authentication/001-agent-authentication-session-and-recovery-standard.md
+            - docs/standards/authentication/002-credential-enrollment-and-authenticator-lifecycle-standard.md
+            - docs/standards/authentication/003-enterprise-federation-and-claim-mapping-standard.md
+            - docs/standards/authentication/004-workload-and-service-identity-standard.md
+            - conformance/CONFORMANCE-CRITERIA-0001.md
+          runtime_targets:
+            - apps/gateway
+            - apps/identity-prime
+          generated_artifacts:
+            - contracts/identity/
+            - docs/generated/identity/
+        rules:
+          shadowSpecForbidden: true
+          localProfileOverridesForbidden: true
+          identityRuntimeConformanceRequired: true
+
     reference_inputs:
       identity-prime-reference:
         repo: SocioProphet/identity-is-prime-reference


### PR DESCRIPTION
## Summary

Add the merged SocioProphet agent authentication standards tranche to `standards.lock.yaml` as a controlled normative standards import.

## What changes

Adds one new entry under `spec.imports.normative_standards`:

- `agent-auth-standards`
  - repo: `SocioProphet/socioprophet-agent-standards`
  - class: `agent-auth-and-identity-profile`
  - channel: `controlled`
  - pin: `baed2ca7f9fa07fe1ed9354f9d896fd982c22616`
  - docs consumed:
    - `docs/standards/authentication/001-agent-authentication-session-and-recovery-standard.md`
    - `docs/standards/authentication/002-credential-enrollment-and-authenticator-lifecycle-standard.md`
    - `docs/standards/authentication/003-enterprise-federation-and-claim-mapping-standard.md`
    - `docs/standards/authentication/004-workload-and-service-identity-standard.md`
    - `conformance/CONFORMANCE-CRITERIA-0001.md`
  - runtime targets:
    - `apps/gateway`
    - `apps/identity-prime`
  - generated artifacts:
    - `contracts/identity/`
    - `docs/generated/identity/`

## Why

The auth standards tranche is already merged upstream in `socioprophet-agent-standards`. `prophet-platform` already has the standards-lock mechanism and already names identity-facing runtime/generated seams. This PR turns the auth standards from documented intent into a pinned platform input.

## Scope

- one-file lock update only
- no runtime code changes
- no generated artifacts changed yet
- no gateway/session behavior changes

## Validation

- Compared branch against `main`: one commit ahead, zero behind
- Diff scope: exactly `standards.lock.yaml`
- Local YAML parse check passed for the updated file shape

## Follow-on

- refresh or replace the docs/compliance PR if needed
- add generated identity contract placeholders only after the lock update is accepted
- refine `apps/identity-prime` in a separate narrow runtime-lane PR
