### PR TITLE
contracts(identity): add initial identity context schemas

### DIFF
--- a/contracts/identity/IdentityProofIngressRecord.v0.1.json
+++ b/contracts/identity/IdentityProofIngressRecord.v0.1.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/identity/IdentityProofIngressRecord.v0.1.json",
+  "title": "IdentityProofIngressRecord",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "proof_record_id",
+    "proof_source",
+    "tenant_id",
+    "received_at",
+    "result"
+  ],
+  "properties": {
+    "version": {
+      "const": "0.1"
+    },
+    "proof_record_id": {
+      "type": "string"
+    },
+    "proof_source": {
+      "type": "string",
+      "enum": [
+        "first_party_passkey",
+        "enterprise_oidc",
+        "enterprise_saml",
+        "workload_identity",
+        "recovery_flow"
+      ]
+    },
+    "subject_id": {
+      "type": "string"
+    },
+    "tenant_id": {
+      "type": "string"
+    },
+    "issuer_ref": {
+      "type": "string"
+    },
+    "upstream_subject": {
+      "type": "string"
+    },
+    "received_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "result": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "rejected",
+        "inconclusive"
+      ]
+    },
+    "assurance_context": {
+      "type": "object"
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "correlation_id": {
+      "type": "string"
+    }
+  }
+}

--- a/contracts/identity/IdentitySessionContext.v0.1.json
+++ b/contracts/identity/IdentitySessionContext.v0.1.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/identity/IdentitySessionContext.v0.1.json",
+  "title": "IdentitySessionContext",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "session_id",
+    "subject_id",
+    "tenant_id",
+    "issued_at",
+    "expires_at",
+    "assurance_context",
+    "stepup_state",
+    "risk_state"
+  ],
+  "properties": {
+    "version": {
+      "const": "0.1"
+    },
+    "session_id": {
+      "type": "string"
+    },
+    "subject_id": {
+      "type": "string"
+    },
+    "tenant_id": {
+      "type": "string"
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "last_seen_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "assurance_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "level",
+        "authenticator_refs"
+      ],
+      "properties": {
+        "level": {
+          "type": "string"
+        },
+        "authenticator_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "proof_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "stepup_state": {
+      "type": "string",
+      "enum": [
+        "not_required",
+        "required",
+        "completed",
+        "expired"
+      ]
+    },
+    "risk_state": {
+      "type": "string",
+      "enum": [
+        "normal",
+        "elevated",
+        "restricted",
+        "revoked"
+      ]
+    },
+    "policy_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/contracts/identity/IdentitySubjectContext.v0.1.json
+++ b/contracts/identity/IdentitySubjectContext.v0.1.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/identity/IdentitySubjectContext.v0.1.json",
+  "title": "IdentitySubjectContext",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "subject_id",
+    "subject_class",
+    "tenant_id",
+    "assurance_context",
+    "created_at"
+  ],
+  "properties": {
+    "version": {
+      "const": "0.1"
+    },
+    "subject_id": {
+      "type": "string"
+    },
+    "subject_class": {
+      "type": "string",
+      "enum": [
+        "human_first_party",
+        "human_federated",
+        "privileged_operator",
+        "service_workload",
+        "recovery_breakglass"
+      ]
+    },
+    "tenant_id": {
+      "type": "string"
+    },
+    "assurance_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "level",
+        "proof_refs"
+      ],
+      "properties": {
+        "level": {
+          "type": "string"
+        },
+        "proof_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "step_up_required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "credential_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "federation_binding_ref": {
+      "type": "string"
+    },
+    "policy_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/contracts/identity/README.md
+++ b/contracts/identity/README.md
@@ -1,0 +1,30 @@
+# Identity Contracts
+
+This directory contains platform-facing identity contract placeholders aligned to the locked `agent-auth-standards` import in `standards.lock.yaml`.
+
+These contracts are intentionally small v0.1 schema surfaces. They establish the first shared vocabulary for identity normalization and session shaping without claiming a complete runtime implementation.
+
+## Current contracts
+
+- `IdentitySubjectContext.v0.1.json`
+  - internal subject, tenant, and assurance context after identity proof normalization
+- `IdentitySessionContext.v0.1.json`
+  - first-party session context shape for platform consumers
+- `IdentityProofIngressRecord.v0.1.json`
+  - record of accepted, rejected, or inconclusive identity proof ingress
+
+## Upstream standards
+
+These contracts should be reviewed against:
+
+- `SocioProphet/socioprophet-agent-standards` authentication standard 001
+- credential lifecycle standard 002
+- enterprise federation and claim mapping standard 003
+- workload and service identity standard 004
+- conformance criteria 0001
+
+## Non-goals
+
+This directory does not implement authentication, session storage, passkey UX, enterprise federation, or machine identity issuance.
+
+Runtime behavior should land separately under the `apps/identity-prime` lane or a specific platform ingress seam.


### PR DESCRIPTION
## Summary

Add the first platform-facing identity contract placeholders now that the auth standards tranche is pinned in `standards.lock.yaml`.

## What lands

- `contracts/identity/README.md`
- `contracts/identity/IdentitySubjectContext.v0.1.json`
- `contracts/identity/IdentitySessionContext.v0.1.json`
- `contracts/identity/IdentityProofIngressRecord.v0.1.json`

## Why

PR #379 pinned `SocioProphet/socioprophet-agent-standards` as `agent-auth-standards` and declared `contracts/identity/` plus `docs/generated/identity/` as generated artifact targets. This PR adds the first small contract surfaces under that declared identity seam.

## Scope

- contract placeholders only
- no runtime implementation
- no gateway/session behavior change
- no passkey, federation, recovery, or machine-identity runtime implementation

## Contract roles

- `IdentitySubjectContext` — normalized internal subject / tenant / assurance context
- `IdentitySessionContext` — first-party session context shape for platform consumers
- `IdentityProofIngressRecord` — accepted/rejected/inconclusive identity proof ingress record

## Validation

- JSON schemas were parsed locally before commit
- Branch compared against `main`: 4 added files, 0 behind

## Follow-on

- add generated identity examples / fixtures
- add `apps/identity-prime` runtime contract-consumption note
- only then bind a single ingress/session seam to these contracts
