### PR TITLE
docs(identity): add identity contract examples and consumption note

### DIFF
--- a/apps/identity-prime/docs/contract-consumption.md
+++ b/apps/identity-prime/docs/contract-consumption.md
@@ -1,0 +1,38 @@
+# identity-prime Contract Consumption
+
+## Purpose
+
+This note records how the `identity-prime` runtime lane should consume the first identity contracts now present under `contracts/identity/`.
+
+This is a documentation-only step. It does not implement authentication, session storage, federation, recovery, or machine identity behavior.
+
+## Contracts consumed
+
+- `contracts/identity/IdentityProofIngressRecord.v0.1.json`
+  - ingress record for accepted, rejected, or inconclusive identity proof
+- `contracts/identity/IdentitySubjectContext.v0.1.json`
+  - normalized internal subject, tenant, and assurance context
+- `contracts/identity/IdentitySessionContext.v0.1.json`
+  - first-party platform session context shape
+
+## Intended flow
+
+The first runtime seam should be:
+
+1. receive a proof ingress result from an approved upstream lane
+2. emit or persist an `IdentityProofIngressRecord`
+3. normalize that proof into an `IdentitySubjectContext`
+4. later, after session behavior is explicitly implemented, issue an `IdentitySessionContext`
+
+## Review rules
+
+Future implementation PRs should state:
+
+- which identity contract they consume or emit
+- which upstream auth standard they satisfy
+- which behavior is intentionally deferred
+- whether the PR changes subject, tenant, assurance, or session semantics
+
+## Non-goals
+
+This note does not claim that `identity-prime` currently implements the above flow. It only defines the expected contract consumption order for future narrow runtime PRs.

--- a/docs/generated/identity/examples/identity_proof_ingress_record.example.v0.1.json
+++ b/docs/generated/identity/examples/identity_proof_ingress_record.example.v0.1.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.1",
+  "proof_record_id": "proof_enterprise_oidc_0001",
+  "proof_source": "enterprise_oidc",
+  "subject_id": "subj_01HUMAN123",
+  "tenant_id": "tenant_acme",
+  "issuer_ref": "issuer_acme_oidc",
+  "upstream_subject": "00u-example-subject",
+  "received_at": "2026-05-04T19:50:00Z",
+  "result": "accepted",
+  "assurance_context": {
+    "level": "aal2_phishing_resistant_target",
+    "acr": "urn:socioprophet:auth:aal2-target",
+    "amr": [
+      "oidc",
+      "passkey"
+    ]
+  },
+  "evidence_refs": [
+    "evidence_proof_accepted_0001"
+  ],
+  "correlation_id": "corr_identity_ingress_0001"
+}

--- a/docs/generated/identity/examples/identity_session_context.example.v0.1.json
+++ b/docs/generated/identity/examples/identity_session_context.example.v0.1.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.1",
+  "session_id": "sess_01PLATFORM123",
+  "subject_id": "subj_01HUMAN123",
+  "tenant_id": "tenant_acme",
+  "issued_at": "2026-05-04T19:50:05Z",
+  "expires_at": "2026-05-04T23:50:05Z",
+  "last_seen_at": "2026-05-04T20:05:00Z",
+  "assurance_context": {
+    "level": "aal2_phishing_resistant_target",
+    "authenticator_refs": [
+      "cred_passkey_primary_0001"
+    ],
+    "proof_refs": [
+      "proof_enterprise_oidc_0001"
+    ]
+  },
+  "stepup_state": "not_required",
+  "risk_state": "normal",
+  "policy_refs": [
+    "policy_session_default_0001"
+  ],
+  "evidence_refs": [
+    "evidence_session_issued_0001"
+  ]
+}

--- a/docs/generated/identity/examples/identity_subject_context.example.v0.1.json
+++ b/docs/generated/identity/examples/identity_subject_context.example.v0.1.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.1",
+  "subject_id": "subj_01HUMAN123",
+  "subject_class": "human_federated",
+  "tenant_id": "tenant_acme",
+  "assurance_context": {
+    "level": "aal2_phishing_resistant_target",
+    "proof_refs": [
+      "proof_enterprise_oidc_0001"
+    ],
+    "step_up_required": false
+  },
+  "credential_refs": [
+    "cred_passkey_primary_0001"
+  ],
+  "federation_binding_ref": "fed_binding_acme_oidc_0001",
+  "policy_refs": [
+    "policy_identity_default_0001"
+  ],
+  "created_at": "2026-05-04T19:50:00Z"
+}


### PR DESCRIPTION
## Summary

Add generated identity example fixtures and a narrow `identity-prime` contract-consumption note after the initial identity contracts landed.

## What lands

- `docs/generated/identity/examples/identity_subject_context.example.v0.1.json`
- `docs/generated/identity/examples/identity_session_context.example.v0.1.json`
- `docs/generated/identity/examples/identity_proof_ingress_record.example.v0.1.json`
- `apps/identity-prime/docs/contract-consumption.md`

## Why

PR #379 pinned the upstream auth standards tranche in `standards.lock.yaml`.
PR #380 added the initial identity contract schemas under `contracts/identity/`.

This PR adds examples for those contracts and documents the intended consumption order for `identity-prime` without changing runtime behavior.

## Scope

- documentation and example fixtures only
- no runtime code changes
- no gateway/session behavior changes
- no auth implementation claim

## Validation

- JSON examples were parsed locally before upload
- Branch compared against `main`: 4 added files, 0 behind

## Follow-on

- add a small fixture/schema validation hook if needed
- bind one concrete `identity-prime` ingress/session seam only after these examples are accepted
