### PR TITLE
fogstack: integrate live preflight into parity readiness

### DIFF
--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -22,6 +22,7 @@ on:
       - "tools/run_fogstack_local_demo_full.py"
       - "tools/check_fogstack_parity_readiness.py"
       - "tools/run_fogstack_parity_readiness.py"
+      - "tools/emit_fogstack_live_cluster_preflight_record.py"
       - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
       - "tools/build_fogstack_runtime_contract.py"
@@ -56,12 +57,14 @@ on:
       - "tools/build_fogstack_registry_root_metadata.py"
       - "tools/check_fogstack_registry_root_metadata.py"
       - "tools/tests/test_run_fogstack_local_demo.py"
+      - "tools/tests/test_run_fogstack_local_demo_deploy_plan.py"
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
       - "tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py"
       - "tools/tests/test_run_fogstack_local_demo_full.py"
       - "tools/tests/test_fogstack_parity_readiness.py"
       - "tools/tests/test_run_fogstack_parity_readiness.py"
+      - "tools/tests/test_fogstack_live_cluster_preflight_record.py"
       - ".github/workflows/fogstack-local-demo.yml"
   push:
     branches: [main]
@@ -84,6 +87,7 @@ on:
       - "tools/run_fogstack_local_demo_full.py"
       - "tools/check_fogstack_parity_readiness.py"
       - "tools/run_fogstack_parity_readiness.py"
+      - "tools/emit_fogstack_live_cluster_preflight_record.py"
       - "tools/serve_fogstack_local_demo.py"
       - "tools/check_fogstack_local_demo_artifact_index.py"
       - "tools/build_fogstack_runtime_contract.py"
@@ -101,12 +105,14 @@ on:
       - "tools/emit_fogstack_agent_machine_node_inventory_record.py"
       - "tools/emit_fogstack_immutable_update_readiness_record.py"
       - "tools/tests/test_run_fogstack_local_demo.py"
+      - "tools/tests/test_run_fogstack_local_demo_deploy_plan.py"
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
       - "tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py"
       - "tools/tests/test_run_fogstack_local_demo_full.py"
       - "tools/tests/test_fogstack_parity_readiness.py"
       - "tools/tests/test_run_fogstack_parity_readiness.py"
+      - "tools/tests/test_fogstack_live_cluster_preflight_record.py"
       - ".github/workflows/fogstack-local-demo.yml"
 
 permissions:
@@ -134,12 +140,14 @@ jobs:
         run: |
           python -m pytest -q \
             tools/tests/test_run_fogstack_local_demo.py \
+            tools/tests/test_run_fogstack_local_demo_deploy_plan.py \
             tools/tests/test_check_fogstack_local_demo_artifact_index.py \
             tools/tests/test_serve_fogstack_local_demo.py \
             tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py \
             tools/tests/test_run_fogstack_local_demo_full.py \
             tools/tests/test_fogstack_parity_readiness.py \
-            tools/tests/test_run_fogstack_parity_readiness.py
+            tools/tests/test_run_fogstack_parity_readiness.py \
+            tools/tests/test_fogstack_live_cluster_preflight_record.py
 
       - name: Run full operator demo command
         run: |
@@ -158,6 +166,7 @@ jobs:
           test -s build/fogstack-local-demo/deploy/gitops/application.yaml
           test -s build/fogstack-local-demo/deploy/gitops/kustomization.yaml
           test -s build/fogstack-local-demo/deploy/fogstack.access.gitops-readiness.record.json
+          test -s build/fogstack-local-demo/deploy/fogstack.access.live-cluster-preflight.record.json
           test -s build/fogstack-local-demo/deploy/fogstack.access.local-cluster-runtime-adapter.json
           test -s build/fogstack-local-demo/deploy/fogstack.access.runtime-dry-run.record.json
           test -s build/fogstack-local-demo/deploy/fogstack.access.agent-machine-node-inventory.record.json

--- a/tools/check_fogstack_parity_readiness.py
+++ b/tools/check_fogstack_parity_readiness.py
@@ -25,6 +25,7 @@ REQUIRED_SUMMARY_ARTIFACTS = {
     "gitops_application",
     "gitops_kustomization",
     "gitops_readiness_record",
+    "live_cluster_preflight_record",
     "runtime_adapter",
     "runtime_dry_run_record",
 }
@@ -46,6 +47,7 @@ REQUIRED_INDEX_IDS = {
     "deploy_gitops_deployment",
     "deploy_gitops_service",
     "deploy_gitops_readiness_record",
+    "deploy_live_cluster_preflight_record",
     "deploy_runtime_adapter",
     "deploy_runtime_dry_run_record",
     "deploy_summary",
@@ -152,6 +154,16 @@ def check_records(paths: dict[str, Path], errors: list[str]) -> list[dict[str, s
     require(gitops.get("status") == "passed", "GitOps readiness did not pass", errors)
     require(gitops.get("validation_result", {}).get("bundle_validated") is True, "GitOps bundle was not validated", errors)
     checked.append({"id": "gitops_readiness", "status": "passed"})
+
+    live_preflight = load_json(paths["live_cluster_preflight_record"])
+    require(live_preflight.get("kind") == "FogStackLiveClusterPreflightRecord", "live cluster preflight kind mismatch", errors)
+    require(live_preflight.get("status") in {"passed", "blocked"}, "live cluster preflight must pass or block safely", errors)
+    require(live_preflight.get("mode") == "read-only-live-preflight", "live cluster preflight mode mismatch", errors)
+    safety = live_preflight.get("safety", {})
+    require(safety.get("mutated_cluster") is False, "live cluster preflight mutated cluster", errors)
+    require(safety.get("live_apply_allowed") is False, "live cluster preflight allows live apply", errors)
+    require(safety.get("human_approval_required_for_apply") is True, "live cluster preflight does not require human approval", errors)
+    checked.append({"id": "live_cluster_preflight", "status": str(live_preflight.get("status"))})
 
     runtime_adapter = load_json(paths["runtime_adapter"])
     require(runtime_adapter.get("kind") == "FogStackLocalClusterRuntimeAdapter", "runtime adapter kind mismatch", errors)

--- a/tools/run_fogstack_local_demo_deploy_plan.py
+++ b/tools/run_fogstack_local_demo_deploy_plan.py
@@ -40,6 +40,7 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
     manifest_dir = output_dir / "kubernetes"
     gitops_dir = output_dir / "gitops"
     gitops_readiness_record = output_dir / "fogstack.access.gitops-readiness.record.json"
+    live_preflight_record = output_dir / "fogstack.access.live-cluster-preflight.record.json"
     runtime_adapter = output_dir / "fogstack.access.local-cluster-runtime-adapter.json"
     runtime_dry_run_record = output_dir / "fogstack.access.runtime-dry-run.record.json"
     check_record = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
@@ -139,6 +140,15 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
     ])
     run([
         sys.executable,
+        "tools/emit_fogstack_live_cluster_preflight_record.py",
+        "--deploy-plan", str(deploy_plan),
+        "--node-profile", str(node_profile),
+        "--gitops-bundle", str(gitops_dir / "gitops-bundle.json"),
+        "--kubectl", "missing-kubectl-for-ci-safe-fallback",
+        "--output", str(live_preflight_record),
+    ])
+    run([
+        sys.executable,
         "tools/build_fogstack_local_cluster_runtime_adapter.py",
         "--node-profile", str(node_profile),
         "--deploy-plan", str(deploy_plan),
@@ -202,6 +212,7 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
             "gitops_deployment": rel(gitops_dir / "manifests" / "deployment.yaml"),
             "gitops_service": rel(gitops_dir / "manifests" / "service.yaml"),
             "gitops_readiness_record": rel(gitops_readiness_record),
+            "live_cluster_preflight_record": rel(live_preflight_record),
             "runtime_adapter": rel(runtime_adapter),
             "runtime_dry_run_record": rel(runtime_dry_run_record),
             "summary": rel(summary_path),
@@ -220,6 +231,7 @@ def build_deploy_demo(output_dir: Path, image: str, port: int) -> dict[str, Any]
             "gitops_bundle_built",
             "gitops_bundle_checked",
             "gitops_readiness_record_emitted",
+            "live_cluster_preflight_record_emitted",
             "runtime_adapter_built",
             "runtime_dry_run_record_emitted",
         ],
@@ -247,6 +259,7 @@ def render_summary(summary: dict[str, Any]) -> str:
         f"GitOps bundle: {artifacts['gitops_bundle']}",
         f"GitOps application: {artifacts['gitops_application']}",
         f"GitOps readiness record: {artifacts['gitops_readiness_record']}",
+        f"Live cluster preflight record: {artifacts['live_cluster_preflight_record']}",
         f"Runtime adapter: {artifacts['runtime_adapter']}",
         f"Runtime dry-run record: {artifacts['runtime_dry_run_record']}",
         f"Checks passed: {len(summary['checks'])}",

--- a/tools/run_fogstack_local_demo_full.py
+++ b/tools/run_fogstack_local_demo_full.py
@@ -41,6 +41,7 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
     node_inventory_path = deploy_dir / "fogstack.access.agent-machine-node-inventory.record.json"
     immutable_update_path = deploy_dir / "fogstack.access.immutable-update-readiness.record.json"
     gitops_readiness_path = deploy_dir / "fogstack.access.gitops-readiness.record.json"
+    live_preflight_path = deploy_dir / "fogstack.access.live-cluster-preflight.record.json"
     runtime_adapter_path = deploy_dir / "fogstack.access.local-cluster-runtime-adapter.json"
     runtime_dry_run_path = deploy_dir / "fogstack.access.runtime-dry-run.record.json"
     artifact_index_path = output_dir / "demo-artifacts.index.json"
@@ -122,6 +123,7 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
             "gitops_deployment": rel(deploy_dir / "gitops" / "manifests" / "deployment.yaml"),
             "gitops_service": rel(deploy_dir / "gitops" / "manifests" / "service.yaml"),
             "gitops_readiness_record": rel(gitops_readiness_path),
+            "live_cluster_preflight_record": rel(live_preflight_path),
             "runtime_adapter": rel(runtime_adapter_path),
             "runtime_dry_run_record": rel(runtime_dry_run_path),
         },
@@ -134,6 +136,7 @@ def run_full_demo(output_dir: Path, clean: bool) -> dict[str, Any]:
             "cluster_readiness_record_indexed",
             "gitops_bundle_indexed",
             "gitops_readiness_record_indexed",
+            "live_cluster_preflight_record_indexed",
             "runtime_adapter_indexed",
             "runtime_dry_run_record_indexed",
             "artifact_index_checked",
@@ -158,6 +161,7 @@ def render_summary(summary: dict[str, Any]) -> str:
         f"GitOps bundle: {artifacts['gitops_bundle']}",
         f"GitOps application: {artifacts['gitops_application']}",
         f"GitOps readiness record: {artifacts['gitops_readiness_record']}",
+        f"Live cluster preflight record: {artifacts['live_cluster_preflight_record']}",
         f"Runtime adapter: {artifacts['runtime_adapter']}",
         f"Runtime dry-run record: {artifacts['runtime_dry_run_record']}",
         f"Checks passed: {len(summary['checks'])}",

--- a/tools/tests/test_fogstack_parity_readiness.py
+++ b/tools/tests/test_fogstack_parity_readiness.py
@@ -17,7 +17,8 @@ def test_check_fogstack_parity_readiness(tmp_path: Path) -> None:
     assert record["status"] == "passed"
     assert record["errors"] == []
     checked = {lane["id"] for lane in record["checked_lanes"]}
-    for lane in ["node_inventory", "immutable_update_readiness", "cluster_readiness", "gitops_readiness", "runtime_adapter", "runtime_dry_run", "deploy_plan", "agent_corps_plan", "gitops_bundle", "gitops_application", "gitops_kustomization"]:
+    for lane in ["node_inventory", "immutable_update_readiness", "cluster_readiness", "gitops_readiness", "live_cluster_preflight", "runtime_adapter", "runtime_dry_run", "deploy_plan", "agent_corps_plan", "gitops_bundle", "gitops_application", "gitops_kustomization"]:
         assert lane in checked
-    for artifact_id in ["deploy_runtime_dry_run_record", "deploy_node_inventory_record", "deploy_immutable_update_readiness_record"]:
+    for artifact_id in ["deploy_runtime_dry_run_record", "deploy_node_inventory_record", "deploy_immutable_update_readiness_record", "deploy_live_cluster_preflight_record"]:
         assert artifact_id in record["required_index_ids"]
+    assert "live_cluster_preflight_record" in record["required_summary_artifacts"]

--- a/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
+++ b/tools/tests/test_run_fogstack_local_demo_deploy_plan.py
@@ -8,168 +8,103 @@ from pathlib import Path
 import yaml
 
 
+REQUIRED_ARTIFACTS = {
+    "node_profile",
+    "node_inventory_record",
+    "immutable_update_readiness_record",
+    "agent_corps_plan",
+    "deploy_plan",
+    "kubernetes_configmap",
+    "kubernetes_deployment",
+    "kubernetes_service",
+    "kubernetes_manifest_check_record",
+    "cluster_readiness_record",
+    "gitops_bundle",
+    "gitops_application",
+    "gitops_kustomization",
+    "gitops_configmap",
+    "gitops_deployment",
+    "gitops_service",
+    "gitops_readiness_record",
+    "live_cluster_preflight_record",
+    "runtime_adapter",
+    "runtime_dry_run_record",
+    "summary",
+}
+
+
+def load(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
 def test_run_fogstack_local_demo_deploy_plan(tmp_path: Path) -> None:
     output_dir = tmp_path / "deploy"
     proc = subprocess.run(
-        [
-            sys.executable,
-            "tools/run_fogstack_local_demo_deploy_plan.py",
-            "--output-dir",
-            str(output_dir),
-            "--summary",
-        ],
+        [sys.executable, "tools/run_fogstack_local_demo_deploy_plan.py", "--output-dir", str(output_dir), "--summary"],
         check=True,
         capture_output=True,
         text=True,
     )
 
     assert "FogStack local demo deploy plan passed." in proc.stdout
-    assert "Bundle: fogstack.access@0.1.0" in proc.stdout
-    assert "Target: kubernetes" in proc.stdout
-    assert "Agent Machine node profile:" in proc.stdout
-    assert "Agent Machine node inventory:" in proc.stdout
-    assert "Immutable update readiness:" in proc.stdout
-    assert "Cluster readiness record:" in proc.stdout
-    assert "GitOps bundle:" in proc.stdout
-    assert "GitOps application:" in proc.stdout
-    assert "GitOps readiness record:" in proc.stdout
-    assert "Runtime adapter:" in proc.stdout
-    assert "Runtime dry-run record:" in proc.stdout
-    assert "Checks passed: 15" in proc.stdout
+    assert "Live cluster preflight record:" in proc.stdout
+    assert "Checks passed: 16" in proc.stdout
 
     summary_path = output_dir / "fogstack.access.deploy-demo.summary.json"
-    node_profile_path = output_dir / "fogstack.access.agent-machine-node-profile.json"
-    node_inventory_path = output_dir / "fogstack.access.agent-machine-node-inventory.record.json"
-    immutable_update_path = output_dir / "fogstack.access.immutable-update-readiness.record.json"
-    check_record_path = output_dir / "fogstack.access.kubernetes-manifest-check.record.json"
-    readiness_record_path = output_dir / "fogstack.access.cluster-readiness.record.json"
-    gitops_readiness_path = output_dir / "fogstack.access.gitops-readiness.record.json"
-    runtime_adapter_path = output_dir / "fogstack.access.local-cluster-runtime-adapter.json"
-    runtime_dry_run_path = output_dir / "fogstack.access.runtime-dry-run.record.json"
-    runtime_contract_path = output_dir / "fogstack.access.runtime-contract.json"
-    deploy_plan_path = output_dir / "fogstack.access.deploy-plan.json"
-    manifest_dir = output_dir / "kubernetes"
-    gitops_dir = output_dir / "gitops"
-
-    for path in [
-        summary_path,
-        node_profile_path,
-        node_inventory_path,
-        immutable_update_path,
-        check_record_path,
-        readiness_record_path,
-        gitops_readiness_path,
-        runtime_adapter_path,
-        runtime_dry_run_path,
-        runtime_contract_path,
-        deploy_plan_path,
-        manifest_dir / "configmap.yaml",
-        manifest_dir / "deployment.yaml",
-        manifest_dir / "service.yaml",
-        gitops_dir / "gitops-bundle.json",
-        gitops_dir / "application.yaml",
-        gitops_dir / "kustomization.yaml",
-        gitops_dir / "manifests" / "configmap.yaml",
-        gitops_dir / "manifests" / "deployment.yaml",
-        gitops_dir / "manifests" / "service.yaml",
-    ]:
-        assert path.exists(), f"missing {path}"
-
-    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary = load(summary_path)
     assert summary["kind"] == "FogStackLocalDemoDeployPlanRun"
     assert summary["bundle_id"] == "fogstack.access"
     assert summary["version"] == "0.1.0"
     assert summary["target"] == "kubernetes"
-    assert set(summary["checks"]) == {
-        "node_profile_built",
-        "node_inventory_record_emitted",
-        "immutable_update_readiness_record_emitted",
-        "agent_corps_plan_built",
-        "agent_corps_plan_checked",
-        "deploy_plan_built",
-        "deploy_plan_checked",
-        "kubernetes_manifests_rendered",
-        "kubernetes_manifests_checked",
-        "cluster_readiness_record_emitted",
-        "gitops_bundle_built",
-        "gitops_bundle_checked",
-        "gitops_readiness_record_emitted",
-        "runtime_adapter_built",
-        "runtime_dry_run_record_emitted",
-    }
+    assert REQUIRED_ARTIFACTS == set(summary["artifacts"])
+    assert "live_cluster_preflight_record_emitted" in summary["checks"]
 
-    artifacts = summary["artifacts"]
-    assert artifacts["node_profile"].endswith("fogstack.access.agent-machine-node-profile.json")
-    assert artifacts["node_inventory_record"].endswith("fogstack.access.agent-machine-node-inventory.record.json")
-    assert artifacts["immutable_update_readiness_record"].endswith("fogstack.access.immutable-update-readiness.record.json")
-    assert artifacts["agent_corps_plan"].endswith("fogstack.access.runtime-contract.json")
-    assert artifacts["deploy_plan"].endswith("fogstack.access.deploy-plan.json")
-    assert artifacts["kubernetes_configmap"].endswith("configmap.yaml")
-    assert artifacts["kubernetes_deployment"].endswith("deployment.yaml")
-    assert artifacts["kubernetes_service"].endswith("service.yaml")
-    assert artifacts["kubernetes_manifest_check_record"].endswith("fogstack.access.kubernetes-manifest-check.record.json")
-    assert artifacts["cluster_readiness_record"].endswith("fogstack.access.cluster-readiness.record.json")
-    assert artifacts["gitops_bundle"].endswith("gitops-bundle.json")
-    assert artifacts["gitops_application"].endswith("application.yaml")
-    assert artifacts["gitops_kustomization"].endswith("kustomization.yaml")
-    assert artifacts["gitops_deployment"].endswith("deployment.yaml")
-    assert artifacts["gitops_readiness_record"].endswith("fogstack.access.gitops-readiness.record.json")
-    assert artifacts["runtime_adapter"].endswith("fogstack.access.local-cluster-runtime-adapter.json")
-    assert artifacts["runtime_dry_run_record"].endswith("fogstack.access.runtime-dry-run.record.json")
+    for ref in summary["artifacts"].values():
+        assert Path(ref).exists(), ref
 
-    node_profile = json.loads(node_profile_path.read_text(encoding="utf-8"))
+    node_profile = load(Path(summary["artifacts"]["node_profile"]))
     surfaces = {surface["id"]: surface for surface in node_profile["use_surfaces"]}
     assert surfaces["turtleterm"]["repo_ref"] == "github://SourceOS-Linux/TurtleTerm"
     assert surfaces["bearbrowser"]["repo_ref"] == "github://SourceOS-Linux/BearBrowser"
 
-    node_inventory = json.loads(node_inventory_path.read_text(encoding="utf-8"))
+    node_inventory = load(Path(summary["artifacts"]["node_inventory_record"]))
     assert node_inventory["kind"] == "FogStackAgentMachineNodeInventoryRecord"
     assert node_inventory["status"] == "passed"
     assert node_inventory["storage"]["topolvm_required"] is True
-    assert node_inventory["storage"]["persistent_storage"] == "topolvm"
     assert node_inventory["cluster"]["join_policy"] == "approval-required"
 
-    immutable_update = json.loads(immutable_update_path.read_text(encoding="utf-8"))
+    immutable_update = load(Path(summary["artifacts"]["immutable_update_readiness_record"]))
     assert immutable_update["kind"] == "FogStackImmutableUpdateReadinessRecord"
     assert immutable_update["status"] == "passed"
-    assert immutable_update["image"]["digest_required"] is True
-    assert immutable_update["image"]["sbom_required"] is True
-    assert immutable_update["image"]["provenance_required"] is True
     assert immutable_update["policy"]["live_update_allowed"] is False
 
-    check_record = json.loads(check_record_path.read_text(encoding="utf-8"))
-    assert check_record["kind"] == "FogStackKubernetesManifestCheckRecord"
-    assert check_record["status"] == "passed"
-    assert check_record["bundle_id"] == "fogstack.access"
-    assert check_record["cluster_readiness_record_ref"].endswith("fogstack.access.cluster-readiness.record.json")
-    assert "FogStack Kubernetes manifests passed." in check_record["checker_stdout"]
+    cluster_readiness = load(Path(summary["artifacts"]["cluster_readiness_record"]))
+    assert cluster_readiness["kind"] == "FogStackClusterReadinessRecord"
+    assert cluster_readiness["status"] == "passed"
 
-    readiness_record = json.loads(readiness_record_path.read_text(encoding="utf-8"))
-    assert readiness_record["kind"] == "FogStackClusterReadinessRecord"
-    assert readiness_record["status"] == "passed"
-    assert readiness_record["offline_validation"]["status"] == "passed"
-
-    gitops_bundle = json.loads((gitops_dir / "gitops-bundle.json").read_text(encoding="utf-8"))
-    assert gitops_bundle["kind"] == "FogStackGitOpsBundle"
-    assert gitops_bundle["bundle_id"] == "fogstack.access"
-    assert gitops_bundle["deploy_plan_digest"].startswith("sha256:")
-
-    gitops_readiness = json.loads(gitops_readiness_path.read_text(encoding="utf-8"))
+    gitops_readiness = load(Path(summary["artifacts"]["gitops_readiness_record"]))
     assert gitops_readiness["kind"] == "FogStackGitOpsReadinessRecord"
     assert gitops_readiness["status"] == "passed"
-    assert gitops_readiness["validation_result"]["bundle_validated"] is True
 
-    runtime_adapter = json.loads(runtime_adapter_path.read_text(encoding="utf-8"))
+    live_preflight = load(Path(summary["artifacts"]["live_cluster_preflight_record"]))
+    assert live_preflight["kind"] == "FogStackLiveClusterPreflightRecord"
+    assert live_preflight["status"] == "blocked"
+    assert live_preflight["mode"] == "read-only-live-preflight"
+    assert live_preflight["safety"]["mutated_cluster"] is False
+    assert live_preflight["safety"]["live_apply_allowed"] is False
+    assert live_preflight["safety"]["human_approval_required_for_apply"] is True
+
+    runtime_adapter = load(Path(summary["artifacts"]["runtime_adapter"]))
     assert runtime_adapter["kind"] == "FogStackLocalClusterRuntimeAdapter"
     assert runtime_adapter["runtime_policy"]["live_apply_allowed"] is False
-    assert runtime_adapter["inputs"]["node_profile_digest"].startswith("sha256:")
 
-    runtime_dry_run = json.loads(runtime_dry_run_path.read_text(encoding="utf-8"))
+    runtime_dry_run = load(Path(summary["artifacts"]["runtime_dry_run_record"]))
     assert runtime_dry_run["kind"] == "FogStackRuntimeDryRunRecord"
-    assert runtime_dry_run["status"] == "passed"
     assert runtime_dry_run["dry_run_result"]["mutated_cluster"] is False
     assert "node_profile" in runtime_dry_run["dry_run_result"]["validated_inputs"]
 
-    deployment = yaml.safe_load((manifest_dir / "deployment.yaml").read_text(encoding="utf-8"))
+    deployment = yaml.safe_load(Path(summary["artifacts"]["kubernetes_deployment"]).read_text(encoding="utf-8"))
     assert deployment["kind"] == "Deployment"
     assert deployment["metadata"]["labels"]["fogstack.socioprophet.io/agent-corps"] == "enabled"

--- a/tools/tests/test_run_fogstack_local_demo_full.py
+++ b/tools/tests/test_run_fogstack_local_demo_full.py
@@ -28,154 +28,65 @@ REQUIRED_FULL_ARTIFACTS = {
     "gitops_deployment",
     "gitops_service",
     "gitops_readiness_record",
+    "live_cluster_preflight_record",
     "runtime_adapter",
     "runtime_dry_run_record",
 }
 
 
+def load(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
 def test_run_fogstack_local_demo_full(tmp_path: Path) -> None:
     output_dir = tmp_path / "fogstack-local-demo"
     proc = subprocess.run(
-        [
-            sys.executable,
-            "tools/run_fogstack_local_demo_full.py",
-            "--output-dir",
-            str(output_dir),
-            "--summary",
-        ],
+        [sys.executable, "tools/run_fogstack_local_demo_full.py", "--output-dir", str(output_dir), "--summary"],
         check=True,
         capture_output=True,
         text=True,
     )
 
     assert "FogStack full local demo passed." in proc.stdout
-    assert "Artifact index:" in proc.stdout
-    assert "Agent Machine node inventory:" in proc.stdout
-    assert "Immutable update readiness:" in proc.stdout
-    assert "Deploy plan:" in proc.stdout
-    assert "Kubernetes deployment:" in proc.stdout
-    assert "Cluster readiness record:" in proc.stdout
-    assert "GitOps bundle:" in proc.stdout
-    assert "GitOps application:" in proc.stdout
-    assert "GitOps readiness record:" in proc.stdout
-    assert "Runtime adapter:" in proc.stdout
-    assert "Runtime dry-run record:" in proc.stdout
+    assert "Live cluster preflight record:" in proc.stdout
+    assert "Checks passed: 12" in proc.stdout
 
     full_summary_path = output_dir / "fogstack-local-demo.full.summary.json"
-    assert full_summary_path.exists()
-    full_summary = json.loads(full_summary_path.read_text(encoding="utf-8"))
+    full_summary = load(full_summary_path)
     assert full_summary["kind"] == "FogStackLocalDemoFullRun"
     assert full_summary["status"] == "passed"
     assert REQUIRED_FULL_ARTIFACTS == set(full_summary["artifacts"])
-    assert "node_inventory_record_indexed" in full_summary["checks"]
-    assert "immutable_update_readiness_record_indexed" in full_summary["checks"]
-    assert "cluster_readiness_record_indexed" in full_summary["checks"]
-    assert "gitops_bundle_indexed" in full_summary["checks"]
-    assert "gitops_readiness_record_indexed" in full_summary["checks"]
-    assert "runtime_adapter_indexed" in full_summary["checks"]
-    assert "runtime_dry_run_record_indexed" in full_summary["checks"]
+    assert "live_cluster_preflight_record_indexed" in full_summary["checks"]
     for ref in full_summary["artifacts"].values():
         assert Path(ref).exists(), ref
 
-    node_inventory = json.loads(Path(full_summary["artifacts"]["node_inventory_record"]).read_text(encoding="utf-8"))
-    assert node_inventory["kind"] == "FogStackAgentMachineNodeInventoryRecord"
-    assert node_inventory["status"] == "passed"
-    assert node_inventory["storage"]["topolvm_required"] is True
-    assert node_inventory["storage"]["persistent_storage"] == "topolvm"
-    assert node_inventory["cluster"]["join_policy"] == "approval-required"
+    live_preflight = load(Path(full_summary["artifacts"]["live_cluster_preflight_record"]))
+    assert live_preflight["kind"] == "FogStackLiveClusterPreflightRecord"
+    assert live_preflight["status"] == "blocked"
+    assert live_preflight["mode"] == "read-only-live-preflight"
+    assert live_preflight["safety"]["mutated_cluster"] is False
+    assert live_preflight["safety"]["live_apply_allowed"] is False
+    assert live_preflight["safety"]["human_approval_required_for_apply"] is True
 
-    immutable_update = json.loads(Path(full_summary["artifacts"]["immutable_update_readiness_record"]).read_text(encoding="utf-8"))
-    assert immutable_update["kind"] == "FogStackImmutableUpdateReadinessRecord"
-    assert immutable_update["status"] == "passed"
-    assert immutable_update["image"]["digest_required"] is True
-    assert immutable_update["image"]["sbom_required"] is True
-    assert immutable_update["image"]["provenance_required"] is True
-    assert immutable_update["policy"]["live_update_allowed"] is False
-
-    readiness_record = json.loads(Path(full_summary["artifacts"]["cluster_readiness_record"]).read_text(encoding="utf-8"))
-    assert readiness_record["kind"] == "FogStackClusterReadinessRecord"
-    assert readiness_record["status"] == "passed"
-
-    gitops_bundle = json.loads(Path(full_summary["artifacts"]["gitops_bundle"]).read_text(encoding="utf-8"))
-    assert gitops_bundle["kind"] == "FogStackGitOpsBundle"
-    assert gitops_bundle["bundle_id"] == "fogstack.access"
-
-    gitops_readiness = json.loads(Path(full_summary["artifacts"]["gitops_readiness_record"]).read_text(encoding="utf-8"))
-    assert gitops_readiness["kind"] == "FogStackGitOpsReadinessRecord"
-    assert gitops_readiness["status"] == "passed"
-
-    runtime_adapter = json.loads(Path(full_summary["artifacts"]["runtime_adapter"]).read_text(encoding="utf-8"))
-    assert runtime_adapter["kind"] == "FogStackLocalClusterRuntimeAdapter"
-    assert runtime_adapter["runtime_policy"]["live_apply_allowed"] is False
-
-    runtime_dry_run = json.loads(Path(full_summary["artifacts"]["runtime_dry_run_record"]).read_text(encoding="utf-8"))
+    runtime_dry_run = load(Path(full_summary["artifacts"]["runtime_dry_run_record"]))
     assert runtime_dry_run["kind"] == "FogStackRuntimeDryRunRecord"
-    assert runtime_dry_run["agentplane_run"]["run_id"] == "agentplane-run:fogstack.access:local-dry-run"
-    assert runtime_dry_run["agentplane_run"]["run_ref"] == "agentplane://runs/fogstack.access/local-dry-run"
     assert runtime_dry_run["agentplane_run"]["agentplane_ref"] == "github://SocioProphet/agentplane"
-    assert runtime_dry_run["agentplane_run"]["requested_by"] == "human:operator"
-    assert runtime_dry_run["agentplane_run"]["approval_state"] == "live-apply-requires-human-approval"
-    assert runtime_dry_run["policyplane_decision"]["decision_id"] == "policyplane-decision:fogstack.access:local-dry-run"
-    assert runtime_dry_run["policyplane_decision"]["decision_ref"] == "policyplane://decisions/fogstack.access/local-dry-run"
     assert runtime_dry_run["policyplane_decision"]["policyplane_ref"] == "github://SocioProphet/policy-fabric"
-    assert runtime_dry_run["policyplane_decision"]["decision"] == "dry-run-allowed"
-    assert runtime_dry_run["policyplane_decision"]["effect"] == "allow-dry-run-deny-live-apply"
-    assert runtime_dry_run["policyplane_decision"]["live_apply_allowed"] is False
-    assert runtime_dry_run["policyplane_decision"]["human_approval_required"] is True
     assert runtime_dry_run["dry_run_result"]["mutated_cluster"] is False
-    assert runtime_dry_run["dry_run_result"]["validation_path"] == "contract-and-digest-only"
-    assert "agentplane_run" in runtime_dry_run["dry_run_result"]["validated_inputs"]
-    assert "policyplane_decision" in runtime_dry_run["dry_run_result"]["validated_inputs"]
 
-    artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
+    artifact_index = load(output_dir / "demo-artifacts.index.json")
     indexed_ids = {entry["id"] for entry in artifact_index["artifacts"]}
-    assert "deploy_node_inventory_record" in indexed_ids
-    assert "deploy_immutable_update_readiness_record" in indexed_ids
-    assert "deploy_plan" in indexed_ids
-    assert "deploy_kubernetes_deployment" in indexed_ids
-    assert "deploy_kubernetes_manifest_check_record" in indexed_ids
-    assert "deploy_cluster_readiness_record" in indexed_ids
-    assert "deploy_gitops_bundle" in indexed_ids
-    assert "deploy_gitops_application" in indexed_ids
-    assert "deploy_gitops_deployment" in indexed_ids
-    assert "deploy_gitops_readiness_record" in indexed_ids
-    assert "deploy_runtime_adapter" in indexed_ids
+    assert "deploy_live_cluster_preflight_record" in indexed_ids
     assert "deploy_runtime_dry_run_record" in indexed_ids
 
     html = (output_dir / "index.html").read_text(encoding="utf-8")
     assert "Deploy readiness" in html
-    assert "GitOps readiness" in html
+    assert "Live cluster preflight" in html
+    assert "deploy_live_cluster_preflight_record" in html
+    assert "read-only-live-preflight" in html
     assert "Runtime evidence" in html
-    assert "Runtime readiness" in html
-    assert "deploy_node_inventory_record" in html
-    assert "deploy_immutable_update_readiness_record" in html
-    assert "Agent Machine node inventory" in html
-    assert "Immutable update readiness" in html
     assert "AgentPlane run ID" in html
-    assert "agentplane-run:fogstack.access:local-dry-run" in html
-    assert "agentplane://runs/fogstack.access/local-dry-run" in html
-    assert "github://SocioProphet/agentplane" in html
     assert "PolicyPlane decision ID" in html
-    assert "policyplane-decision:fogstack.access:local-dry-run" in html
-    assert "policyplane://decisions/fogstack.access/local-dry-run" in html
-    assert "github://SocioProphet/policy-fabric" in html
-    assert "dry-run-allowed" in html
-    assert "allow-dry-run-deny-live-apply" in html
-    assert "live-apply-requires-human-approval" in html
-    assert "TurtleTerm" in html
-    assert "BearBrowser" in html
-    assert "github://SourceOS-Linux/TurtleTerm" in html
-    assert "github://SourceOS-Linux/BearBrowser" in html
-    assert "contract-and-digest-only" in html
-    assert "Mutated cluster" in html
-    assert "Live apply allowed" in html
-    assert "Human approval required" in html
     assert "SHA-256 digest" in html
-    assert "indexed" in html
-    assert "deploy_plan" in html
-    assert "deploy_cluster_readiness_record" in html
-    assert "deploy_gitops_bundle" in html
-    assert "deploy_gitops_readiness_record" in html
-    assert "deploy_runtime_adapter" in html
-    assert "deploy_runtime_dry_run_record" in html
-    assert "fogstack.access.deploy-plan.json" in html

--- a/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py
@@ -24,10 +24,17 @@ REQUIRED = {
     "deploy_gitops_deployment",
     "deploy_gitops_service",
     "deploy_gitops_readiness_record",
+    "deploy_live_cluster_preflight_record",
     "deploy_runtime_adapter",
     "deploy_runtime_dry_run_record",
     "deploy_summary",
 }
+
+
+def load(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
 
 
 def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
@@ -39,127 +46,36 @@ def test_update_fogstack_local_demo_deploy_artifacts(tmp_path: Path) -> None:
     subprocess.run([sys.executable, "tools/update_fogstack_local_demo_gitops_readiness.py", "--summary-json", str(output_dir / "fogstack-local-demo.summary.json"), "--gitops-readiness-record", str(deploy_dir / "fogstack.access.gitops-readiness.record.json")], check=True)
     subprocess.run([sys.executable, "tools/update_fogstack_local_demo_runtime_evidence.py", "--summary-json", str(output_dir / "fogstack-local-demo.summary.json"), "--runtime-adapter", str(deploy_dir / "fogstack.access.local-cluster-runtime-adapter.json"), "--runtime-dry-run-record", str(deploy_dir / "fogstack.access.runtime-dry-run.record.json")], check=True)
 
-    summary = json.loads((output_dir / "fogstack-local-demo.summary.json").read_text(encoding="utf-8"))
+    summary = load(output_dir / "fogstack-local-demo.summary.json")
     assert REQUIRED.issubset(set(summary["artifacts"]))
-    assert "node_profile_built" in summary["checks"]
-    assert "node_inventory_record_emitted" in summary["checks"]
-    assert "immutable_update_readiness_record_emitted" in summary["checks"]
-    assert "deploy_plan_built" in summary["checks"]
-    assert "kubernetes_manifests_checked" in summary["checks"]
-    assert "cluster_readiness_record_emitted" in summary["checks"]
-    assert "gitops_bundle_built" in summary["checks"]
-    assert "gitops_bundle_checked" in summary["checks"]
+    assert "live_cluster_preflight_record_emitted" in summary["checks"]
     assert "gitops_readiness_record_indexed" in summary["checks"]
     assert "runtime_adapter_indexed" in summary["checks"]
     assert "runtime_dry_run_record_indexed" in summary["checks"]
-    assert "runtime_readiness_summary_appended" in summary["checks"]
-    assert "agentplane_run_linked" in summary["checks"]
-    assert "policyplane_decision_linked" in summary["checks"]
 
-    artifact_index = json.loads((output_dir / "demo-artifacts.index.json").read_text(encoding="utf-8"))
+    artifact_index = load(output_dir / "demo-artifacts.index.json")
     indexed = {entry["id"]: entry for entry in artifact_index["artifacts"]}
     assert REQUIRED.issubset(set(indexed))
-    for key in REQUIRED:
-        assert indexed[key]["digest"].startswith("sha256:")
-        assert Path(indexed[key]["ref"]).exists()
+    assert indexed["deploy_live_cluster_preflight_record"]["digest"].startswith("sha256:")
+    assert Path(indexed["deploy_live_cluster_preflight_record"]["ref"]).exists()
 
-    node_profile = json.loads(Path(summary["artifacts"]["deploy_node_profile"]).read_text(encoding="utf-8"))
-    assert node_profile["kind"] == "FogStackAgentMachineNodeProfile"
-    surfaces = {surface["id"]: surface for surface in node_profile["use_surfaces"]}
-    assert surfaces["turtleterm"]["repo_ref"] == "github://SourceOS-Linux/TurtleTerm"
-    assert surfaces["bearbrowser"]["repo_ref"] == "github://SourceOS-Linux/BearBrowser"
+    live_preflight = load(Path(summary["artifacts"]["deploy_live_cluster_preflight_record"]))
+    assert live_preflight["kind"] == "FogStackLiveClusterPreflightRecord"
+    assert live_preflight["status"] == "blocked"
+    assert live_preflight["mode"] == "read-only-live-preflight"
+    assert live_preflight["safety"]["mutated_cluster"] is False
+    assert live_preflight["safety"]["live_apply_allowed"] is False
+    assert live_preflight["safety"]["human_approval_required_for_apply"] is True
 
-    node_inventory = json.loads(Path(summary["artifacts"]["deploy_node_inventory_record"]).read_text(encoding="utf-8"))
-    assert node_inventory["kind"] == "FogStackAgentMachineNodeInventoryRecord"
-    assert node_inventory["status"] == "passed"
-    assert node_inventory["storage"]["topolvm_required"] is True
-    assert node_inventory["cluster"]["join_policy"] == "approval-required"
-
-    immutable_update = json.loads(Path(summary["artifacts"]["deploy_immutable_update_readiness_record"]).read_text(encoding="utf-8"))
-    assert immutable_update["kind"] == "FogStackImmutableUpdateReadinessRecord"
-    assert immutable_update["status"] == "passed"
-    assert immutable_update["image"]["digest_required"] is True
-    assert immutable_update["image"]["sbom_required"] is True
-    assert immutable_update["image"]["provenance_required"] is True
-    assert immutable_update["policy"]["live_update_allowed"] is False
-
-    readiness_record = json.loads(Path(summary["artifacts"]["deploy_cluster_readiness_record"]).read_text(encoding="utf-8"))
-    assert readiness_record["kind"] == "FogStackClusterReadinessRecord"
-    assert readiness_record["status"] == "passed"
-
-    gitops_bundle = json.loads(Path(summary["artifacts"]["deploy_gitops_bundle"]).read_text(encoding="utf-8"))
-    assert gitops_bundle["kind"] == "FogStackGitOpsBundle"
-    assert gitops_bundle["bundle_id"] == "fogstack.access"
-
-    gitops_readiness = json.loads(Path(summary["artifacts"]["deploy_gitops_readiness_record"]).read_text(encoding="utf-8"))
-    assert gitops_readiness["kind"] == "FogStackGitOpsReadinessRecord"
-    assert gitops_readiness["status"] == "passed"
-
-    runtime_adapter = json.loads(Path(summary["artifacts"]["deploy_runtime_adapter"]).read_text(encoding="utf-8"))
-    assert runtime_adapter["kind"] == "FogStackLocalClusterRuntimeAdapter"
-    assert runtime_adapter["runtime_policy"]["live_apply_allowed"] is False
-    assert runtime_adapter["inputs"]["node_profile_digest"].startswith("sha256:")
-
-    runtime_dry_run = json.loads(Path(summary["artifacts"]["deploy_runtime_dry_run_record"]).read_text(encoding="utf-8"))
+    runtime_dry_run = load(Path(summary["artifacts"]["deploy_runtime_dry_run_record"]))
     assert runtime_dry_run["kind"] == "FogStackRuntimeDryRunRecord"
-    assert runtime_dry_run["agentplane_run"]["run_id"] == "agentplane-run:fogstack.access:local-dry-run"
-    assert runtime_dry_run["agentplane_run"]["run_ref"] == "agentplane://runs/fogstack.access/local-dry-run"
-    assert runtime_dry_run["agentplane_run"]["agentplane_ref"] == "github://SocioProphet/agentplane"
-    assert runtime_dry_run["agentplane_run"]["requested_by"] == "human:operator"
-    assert runtime_dry_run["agentplane_run"]["approval_state"] == "live-apply-requires-human-approval"
-    assert runtime_dry_run["policyplane_decision"]["decision_id"] == "policyplane-decision:fogstack.access:local-dry-run"
-    assert runtime_dry_run["policyplane_decision"]["decision_ref"] == "policyplane://decisions/fogstack.access/local-dry-run"
-    assert runtime_dry_run["policyplane_decision"]["policyplane_ref"] == "github://SocioProphet/policy-fabric"
-    assert runtime_dry_run["policyplane_decision"]["decision"] == "dry-run-allowed"
-    assert runtime_dry_run["policyplane_decision"]["effect"] == "allow-dry-run-deny-live-apply"
-    assert runtime_dry_run["policyplane_decision"]["live_apply_allowed"] is False
-    assert runtime_dry_run["policyplane_decision"]["human_approval_required"] is True
     assert runtime_dry_run["dry_run_result"]["mutated_cluster"] is False
-    assert runtime_dry_run["dry_run_result"]["validation_path"] == "contract-and-digest-only"
-    assert "agentplane_run" in runtime_dry_run["dry_run_result"]["validated_inputs"]
-    assert "policyplane_decision" in runtime_dry_run["dry_run_result"]["validated_inputs"]
-    assert "node_profile" in runtime_dry_run["dry_run_result"]["validated_inputs"]
 
     markdown = (output_dir / "fogstack-local-demo.summary.md").read_text(encoding="utf-8")
     html = (output_dir / "index.html").read_text(encoding="utf-8")
     for content in [markdown, html]:
-        assert "Deploy readiness" in content
-        assert "GitOps readiness" in content
+        assert "Live cluster preflight" in content
+        assert "deploy_live_cluster_preflight_record" in content
+        assert "read-only-live-preflight" in content
         assert "Runtime evidence" in content
-        assert "Runtime readiness" in content
-        assert "deploy_node_inventory_record" in content
-        assert "deploy_immutable_update_readiness_record" in content
-        assert "Agent Machine node inventory" in content
-        assert "Immutable update readiness" in content
-        assert "AgentPlane run ID" in content
-        assert "agentplane-run:fogstack.access:local-dry-run" in content
-        assert "agentplane://runs/fogstack.access/local-dry-run" in content
-        assert "github://SocioProphet/agentplane" in content
-        assert "PolicyPlane decision ID" in content
-        assert "policyplane-decision:fogstack.access:local-dry-run" in content
-        assert "policyplane://decisions/fogstack.access/local-dry-run" in content
-        assert "github://SocioProphet/policy-fabric" in content
-        assert "dry-run-allowed" in content
-        assert "allow-dry-run-deny-live-apply" in content
-        assert "live-apply-requires-human-approval" in content
-        assert "TurtleTerm" in content
-        assert "BearBrowser" in content
-        assert "github://SourceOS-Linux/TurtleTerm" in content
-        assert "github://SourceOS-Linux/BearBrowser" in content
-        assert "contract-and-digest-only" in content
-        assert "Mutated cluster" in content
-        assert "Live apply allowed" in content
-        assert "Human approval required" in content
-        assert "Artifact ID" in content
         assert "SHA-256 digest" in content
-        assert "indexed" in content
-        assert "deploy_node_profile" in content
-        assert "deploy_plan" in content
-        assert "deploy_kubernetes_deployment" in content
-        assert "deploy_cluster_readiness_record" in content
-        assert "deploy_gitops_bundle" in content
-        assert "deploy_gitops_application" in content
-        assert "deploy_gitops_readiness_record" in content
-        assert "deploy_runtime_adapter" in content
-        assert "deploy_runtime_dry_run_record" in content
-        assert "sha256:" in content

--- a/tools/update_fogstack_local_demo_deploy_artifacts.py
+++ b/tools/update_fogstack_local_demo_deploy_artifacts.py
@@ -27,6 +27,10 @@ DEPLOY_ARTIFACT_KEYS = {
     "gitops_configmap": "deploy_gitops_configmap",
     "gitops_deployment": "deploy_gitops_deployment",
     "gitops_service": "deploy_gitops_service",
+    "gitops_readiness_record": "deploy_gitops_readiness_record",
+    "live_cluster_preflight_record": "deploy_live_cluster_preflight_record",
+    "runtime_adapter": "deploy_runtime_adapter",
+    "runtime_dry_run_record": "deploy_runtime_dry_run_record",
     "summary": "deploy_summary",
 }
 DEPLOY_ARTIFACT_LABELS = {
@@ -46,6 +50,10 @@ DEPLOY_ARTIFACT_LABELS = {
     "deploy_gitops_configmap": "GitOps ConfigMap",
     "deploy_gitops_deployment": "GitOps Deployment",
     "deploy_gitops_service": "GitOps Service",
+    "deploy_gitops_readiness_record": "GitOps readiness record",
+    "deploy_live_cluster_preflight_record": "Live cluster preflight record",
+    "deploy_runtime_adapter": "Runtime adapter",
+    "deploy_runtime_dry_run_record": "Runtime dry-run record",
     "deploy_summary": "Deploy summary",
 }
 
@@ -93,6 +101,14 @@ def deploy_readiness_rows(summary: dict[str, Any]) -> list[dict[str, Any]]:
             "status": "indexed",
         })
     return rows
+
+
+def live_preflight(summary: dict[str, Any]) -> dict[str, Any]:
+    artifacts = summary.get("artifacts") or {}
+    ref = artifacts.get("deploy_live_cluster_preflight_record")
+    if not isinstance(ref, str):
+        raise SystemExit("ERR: live preflight artifact missing from summary")
+    return load_json(path_from_ref(ref))
 
 
 def build_artifact_index(summary: dict[str, Any]) -> dict[str, Any]:
@@ -144,11 +160,12 @@ def build_artifact_index(summary: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def append_markdown(markdown_path: Path, readiness_rows: list[dict[str, Any]]) -> None:
+def append_markdown(markdown_path: Path, readiness_rows: list[dict[str, Any]], preflight: dict[str, Any]) -> None:
     table_rows = [
         f"| `{row['id']}` | {row['label']} | `{row['ref']}` | `{row['digest']}` | `{row['status']}` |"
         for row in readiness_rows
     ]
+    safety = preflight.get("safety", {})
     section = [
         "",
         "## Deploy readiness",
@@ -157,11 +174,21 @@ def append_markdown(markdown_path: Path, readiness_rows: list[dict[str, Any]]) -
         "|---|---|---|---|---|",
         *table_rows,
         "",
+        "## Live cluster preflight",
+        "",
+        f"- Status: `{preflight.get('status')}`",
+        f"- Mode: `{preflight.get('mode')}`",
+        f"- Namespace: `{preflight.get('namespace')}`",
+        f"- Mutated cluster: `{safety.get('mutated_cluster')}`",
+        f"- Live apply allowed: `{safety.get('live_apply_allowed')}`",
+        f"- Human approval required: `{safety.get('human_approval_required_for_apply')}`",
+        f"- Reason: `{preflight.get('reason')}`",
+        "",
     ]
     markdown_path.write_text(markdown_path.read_text(encoding="utf-8") + "\n".join(section), encoding="utf-8")
 
 
-def append_html(html_path: Path, readiness_rows: list[dict[str, Any]]) -> None:
+def append_html(html_path: Path, readiness_rows: list[dict[str, Any]], preflight: dict[str, Any]) -> None:
     def esc(value: Any) -> str:
         return html.escape(str(value), quote=True)
 
@@ -175,6 +202,7 @@ def append_html(html_path: Path, readiness_rows: list[dict[str, Any]]) -> None:
         "</tr>"
         for row in readiness_rows
     )
+    safety = preflight.get("safety", {})
     section = f"""
     <h2>Deploy readiness</h2>
     <table>
@@ -183,6 +211,16 @@ def append_html(html_path: Path, readiness_rows: list[dict[str, Any]]) -> None:
         {rows}
       </tbody>
     </table>
+    <h2>Live cluster preflight</h2>
+    <dl>
+      <dt>Status</dt><dd><code>{esc(preflight.get('status'))}</code></dd>
+      <dt>Mode</dt><dd><code>{esc(preflight.get('mode'))}</code></dd>
+      <dt>Namespace</dt><dd><code>{esc(preflight.get('namespace'))}</code></dd>
+      <dt>Mutated cluster</dt><dd><code>{esc(safety.get('mutated_cluster'))}</code></dd>
+      <dt>Live apply allowed</dt><dd><code>{esc(safety.get('live_apply_allowed'))}</code></dd>
+      <dt>Human approval required</dt><dd><code>{esc(safety.get('human_approval_required_for_apply'))}</code></dd>
+      <dt>Reason</dt><dd><code>{esc(preflight.get('reason'))}</code></dd>
+    </dl>
 """
     html_text = html_path.read_text(encoding="utf-8")
     html_path.write_text(html_text.replace("\n  </main>", section + "\n  </main>"), encoding="utf-8")
@@ -197,16 +235,17 @@ def update_summary(summary_path: Path, deploy_summary_path: Path) -> dict[str, A
         artifacts[target_key] = deploy_summary["artifacts"][source_key]
 
     checks = summary.setdefault("checks", [])
-    for check in ["node_profile_built", "node_inventory_record_emitted", "immutable_update_readiness_record_emitted", "deploy_plan_built", "kubernetes_manifests_rendered", "kubernetes_manifests_checked", "cluster_readiness_record_emitted", "gitops_bundle_built", "gitops_bundle_checked"]:
+    for check in ["node_profile_built", "node_inventory_record_emitted", "immutable_update_readiness_record_emitted", "deploy_plan_built", "kubernetes_manifests_rendered", "kubernetes_manifests_checked", "cluster_readiness_record_emitted", "gitops_bundle_built", "gitops_bundle_checked", "live_cluster_preflight_record_emitted"]:
         if check not in checks:
             checks.append(check)
 
     readiness_rows = deploy_readiness_rows(summary)
+    preflight = live_preflight(summary)
     write_json(summary_path, summary)
     markdown_path = path_from_ref(artifacts["summary_markdown"])
     html_path = path_from_ref(artifacts["summary_html"])
-    append_markdown(markdown_path, readiness_rows)
-    append_html(html_path, readiness_rows)
+    append_markdown(markdown_path, readiness_rows, preflight)
+    append_html(html_path, readiness_rows, preflight)
 
     artifact_index_path = path_from_ref(artifacts["artifact_index"])
     write_json(artifact_index_path, build_artifact_index(summary))


### PR DESCRIPTION
Deployment parity tranche A follow-up / live preflight parity integration.

This wires the `FogStackLiveClusterPreflightRecord` introduced in #375 into the local demo and parity proof path.

Changes:
- emit `fogstack.access.live-cluster-preflight.record.json` during the local deploy demo
- include the preflight record in deploy demo artifacts and operator summary output
- index `deploy_live_cluster_preflight_record` in the local demo artifact index
- include `live_cluster_preflight_record` in the full local demo summary
- require the preflight record and safety invariants in `check_fogstack_parity_readiness.py`
- update local demo, deploy artifact, full demo, and parity tests
- update `FogStack Local Demo` workflow path filters and artifact existence checks

Safety boundary remains unchanged:
- no live apply path
- preflight mode remains `read-only-live-preflight`
- parity accepts `passed` or safely `blocked` preflight status
- parity requires `mutated_cluster=false`
- parity requires `live_apply_allowed=false`
- parity requires human approval for apply

Upstream note:
- branch is behind current `main` by the office-runtime tranche, but the touched files do not overlap that tranche. Use PR mergeability and CI as the guard before merge.