### PR TITLE
tools(identity): validate identity contract examples

### DIFF
--- a/tools/tests/test_validate_identity_contract_examples.py
+++ b/tools/tests/test_validate_identity_contract_examples.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+from tools.validate_identity_contract_examples import validate_all
+
+
+def test_identity_contract_examples_validate() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    validate_all(repo_root)

--- a/tools/tests/test_validate_identity_contract_examples.py
+++ b/tools/tests/test_validate_identity_contract_examples.py
@@ -1,8 +1,21 @@
-from pathlib import Path
+from __future__ import annotations
 
-from tools.validate_identity_contract_examples import validate_all
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def load_validator_module(repo_root: Path) -> ModuleType:
+    module_path = repo_root / "tools" / "validate_identity_contract_examples.py"
+    spec = importlib.util.spec_from_file_location("validate_identity_contract_examples", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_identity_contract_examples_validate() -> None:
     repo_root = Path(__file__).resolve().parents[2]
-    validate_all(repo_root)
+    module = load_validator_module(repo_root)
+    module.validate_all(repo_root)

--- a/tools/validate_identity_contract_examples.py
+++ b/tools/validate_identity_contract_examples.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+from jsonschema import Draft202012Validator
+
+
+EXAMPLE_PAIRS = (
+    (
+        Path("contracts/identity/IdentitySubjectContext.v0.1.json"),
+        Path("docs/generated/identity/examples/identity_subject_context.example.v0.1.json"),
+    ),
+    (
+        Path("contracts/identity/IdentitySessionContext.v0.1.json"),
+        Path("docs/generated/identity/examples/identity_session_context.example.v0.1.json"),
+    ),
+    (
+        Path("contracts/identity/IdentityProofIngressRecord.v0.1.json"),
+        Path("docs/generated/identity/examples/identity_proof_ingress_record.example.v0.1.json"),
+    ),
+)
+
+
+def load_json(path: Path) -> object:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate_pair(root: Path, schema_rel: Path, example_rel: Path) -> None:
+    schema_path = root / schema_rel
+    example_path = root / example_rel
+
+    if not schema_path.is_file():
+        raise FileNotFoundError(f"missing schema: {schema_rel}")
+    if not example_path.is_file():
+        raise FileNotFoundError(f"missing example: {example_rel}")
+
+    schema = load_json(schema_path)
+    example = load_json(example_path)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(example)
+
+
+def validate_all(root: Path, pairs: Iterable[tuple[Path, Path]] = EXAMPLE_PAIRS) -> None:
+    for schema_rel, example_rel in pairs:
+        validate_pair(root, schema_rel, example_rel)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate generated identity examples against identity JSON schemas."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of tools/.",
+    )
+    args = parser.parse_args()
+
+    validate_all(args.root.resolve())
+    print("identity contract examples validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Add a small validation helper and pytest wrapper for the identity contract examples merged in the previous tranche.

## What lands

- `tools/validate_identity_contract_examples.py`
- `tools/tests/test_validate_identity_contract_examples.py`

## Why

PR #380 added initial identity schemas under `contracts/identity/`.
PR #381 added generated examples under `docs/generated/identity/examples/`.

This PR makes those examples enforceable by validating each example against its corresponding schema.

## Scope

- validation tooling only
- no runtime implementation
- no gateway/session behavior change
- no Makefile update required

## Validation path

The existing `test-tools` target already installs `pytest`, `pyyaml`, and `jsonschema`, then runs:

```bash
pytest -q tools/tests
```

The new test is therefore picked up by the existing tool-test path without broad CI changes.

## Follow-on

After this lands, the next narrow implementation step should be the first `identity-prime` proof-ingress emitter seam.
