### PR TITLE
contracts(ops): add operational exhaust and trader-agent emitter contracts

### DIFF
--- a/contracts/OperationalExhaustObserved.v0.1.json
+++ b/contracts/OperationalExhaustObserved.v0.1.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/OperationalExhaustObserved.v0.1.json",
+  "title": "OperationalExhaustObserved",
+  "type": "object",
+  "required": [
+    "version",
+    "event_id",
+    "observed_at",
+    "source_repo",
+    "source_surface",
+    "source_runtime",
+    "environment_ref",
+    "trace_ref",
+    "projection_family"
+  ],
+  "properties": {
+    "version": { "const": "0.1" },
+    "event_id": { "type": "string" },
+    "observed_at": { "type": "string" },
+    "source_repo": { "type": "string" },
+    "source_surface": { "type": "string" },
+    "source_runtime": { "type": "string" },
+    "environment_ref": { "type": "string" },
+    "trace_ref": { "type": "string" },
+    "story_ref": { "type": "string" },
+    "agent_ref": { "type": "string" },
+    "policy_ref": { "type": "string" },
+    "evidence_ref": { "type": "string" },
+    "artifact_ref": { "type": "string" },
+    "projection_family": {
+      "type": "string",
+      "enum": [
+        "ci_delivery",
+        "runtime_service_agent",
+        "policy_evidence",
+        "market_data_operations",
+        "trader_agent_execution",
+        "trader_agent_learning"
+      ]
+    },
+    "severity": { "type": "string" },
+    "operational_band": { "type": "string" },
+    "attributes": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "receipt": {
+      "type": "object",
+      "required": ["hash", "algo"],
+      "properties": {
+        "hash": { "type": "string" },
+        "algo": { "type": "string", "enum": ["sha256", "blake3"] }
+      }
+    }
+  }
+}

--- a/contracts/TraderAgentExecutionObserved.v0.1.json
+++ b/contracts/TraderAgentExecutionObserved.v0.1.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/TraderAgentExecutionObserved.v0.1.json",
+  "title": "TraderAgentExecutionObserved",
+  "type": "object",
+  "required": [
+    "version",
+    "event_id",
+    "observed_at",
+    "strategy_run_ref",
+    "model_ref",
+    "feature_snapshot_ref",
+    "market_window_ref",
+    "risk_policy_ref",
+    "order_intent_ref",
+    "execution_ref",
+    "venue_ref",
+    "trace_ref",
+    "projection_family"
+  ],
+  "properties": {
+    "version": { "const": "0.1" },
+    "event_id": { "type": "string" },
+    "observed_at": { "type": "string" },
+    "strategy_run_ref": { "type": "string" },
+    "model_ref": { "type": "string" },
+    "feature_snapshot_ref": { "type": "string" },
+    "market_window_ref": { "type": "string" },
+    "risk_policy_ref": { "type": "string" },
+    "order_intent_ref": { "type": "string" },
+    "execution_ref": { "type": "string" },
+    "venue_ref": { "type": "string" },
+    "portfolio_scope_ref": { "type": "string" },
+    "post_trade_evaluation_ref": { "type": "string" },
+    "replay_ref": { "type": "string" },
+    "trace_ref": { "type": "string" },
+    "projection_family": { "const": "trader_agent_execution" },
+    "outcome": {
+      "type": "string",
+      "enum": ["created", "acknowledged", "filled", "rejected", "cancelled", "risk_blocked", "kill_switched"]
+    },
+    "slippage_bps": { "type": "number" },
+    "risk_controls": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "attributes": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "receipt": {
+      "type": "object",
+      "required": ["hash", "algo"],
+      "properties": {
+        "hash": { "type": "string" },
+        "algo": { "type": "string", "enum": ["sha256", "blake3"] }
+      }
+    }
+  }
+}

--- a/docs/OPERATIONAL_EXHAUST_EMITTER_GUIDE.md
+++ b/docs/OPERATIONAL_EXHAUST_EMITTER_GUIDE.md
@@ -1,0 +1,75 @@
+# Operational Exhaust Emitter Guide
+
+## Purpose
+
+This document defines the first runtime-side emission guidance aligned to the
+`global-devsecops-intelligence` operational exhaust fusion profile.
+
+It is the source-side counterpart to the ops-domain fusion boundary and machine-readable
+profile in `SocioProphet/global-devsecops-intelligence`.
+
+## Scope
+
+This guide applies to platform services, market-data runtimes, and trader-agent runtimes
+that need to emit normalized operational exhaust without relocating canonical domain
+semantics out of their owning repositories.
+
+## Required event families
+
+Runtime surfaces SHOULD emit at least the following normalized event families:
+- `OperationalExhaustObserved.v0.1`
+- `TraderAgentExecutionObserved.v0.1` when the runtime performs or supervises trading actions
+
+## Emission rules
+
+1. Emit a normalized operational event whenever a runtime crosses an operational boundary:
+   - health degraded/restored
+   - queue pressure / backpressure changes
+   - policy/evidence receipt emitted
+   - market-data gap detected
+   - replay started/completed
+   - trader-agent strategy run started/stopped
+   - order intent created / execution acknowledged / filled / rejected / cancelled
+   - risk control or kill-switch activation
+
+2. Preserve canonical domain payloads in their owning stores. Emit references, hashes,
+   and receipts here rather than copying raw sensitive payloads.
+
+3. Populate common required fields consistently:
+   - `event_id`
+   - `observed_at`
+   - `source_repo`
+   - `source_surface`
+   - `source_runtime`
+   - `environment_ref`
+   - `trace_ref`
+   - `projection_family`
+
+4. Trader-agent runtimes SHOULD also populate:
+   - `strategy_run_ref`
+   - `model_ref`
+   - `feature_snapshot_ref`
+   - `market_window_ref`
+   - `risk_policy_ref`
+   - `order_intent_ref`
+   - `execution_ref`
+   - `venue_ref`
+
+## Export destination
+
+These normalized operational events are intended to be projected into
+`SocioProphet/global-devsecops-intelligence`, which owns the ops-domain fusion layer,
+measurement plane, and derived operational graph projections.
+
+## Deliberate non-goals
+
+- This guide does not redefine canonical market semantics.
+- This guide does not replace canonical wire/storage invariants.
+- This guide does not require that every runtime store all exhaust locally.
+  Emission may be direct, buffered, or receipt-based depending on runtime shape.
+
+## Immediate follow-on
+
+- add concrete emitter helpers in the runtime services that now own market-data and trader execution lanes
+- add extraction/mapping rules in `global-devsecops-intelligence`
+- add replay / post-trade evaluation emission guidance for trader-agent learning loops

--- a/examples/operational-exhaust/operational_exhaust_observed.example.json
+++ b/examples/operational-exhaust/operational_exhaust_observed.example.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.1",
+  "event_id": "opx_0001",
+  "observed_at": "2026-05-05T02:40:00Z",
+  "source_repo": "SocioProphet/prophet-platform",
+  "source_surface": "market-data-runtime",
+  "source_runtime": "marketdata-replay-worker",
+  "environment_ref": "env:local-dev",
+  "trace_ref": "trace:marketdata-gap-0001",
+  "story_ref": "story:marketdata-gap-review-0001",
+  "agent_ref": "agent:marketdata-supervisor",
+  "policy_ref": "policy:marketdata-runtime-profile-v0",
+  "evidence_ref": "evidence:gap-alert-0001",
+  "artifact_ref": "artifact:replay-window-0001",
+  "projection_family": "market_data_operations",
+  "severity": "warning",
+  "operational_band": "degraded",
+  "attributes": {
+    "event_type": "gap.detected",
+    "instrument_ref": "instrument:example-equity",
+    "venue_ref": "venue:example",
+    "gap_start": "2026-05-05T02:39:10Z",
+    "gap_end": "2026-05-05T02:39:15Z"
+  },
+  "receipt": {
+    "hash": "sha256:example-operational-exhaust-observed",
+    "algo": "sha256"
+  }
+}

--- a/examples/operational-exhaust/trader_agent_execution_observed.example.json
+++ b/examples/operational-exhaust/trader_agent_execution_observed.example.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.1",
+  "event_id": "tae_0001",
+  "observed_at": "2026-05-05T02:41:00Z",
+  "strategy_run_ref": "strategy-run:mean-reversion-demo-0001",
+  "model_ref": "model:research-agent-v0",
+  "feature_snapshot_ref": "features:demo-window-0001",
+  "market_window_ref": "market-window:example-20260505-0240",
+  "risk_policy_ref": "risk-policy:paper-trading-v0",
+  "order_intent_ref": "order-intent:demo-0001",
+  "execution_ref": "execution:demo-ack-0001",
+  "venue_ref": "venue:paper",
+  "portfolio_scope_ref": "portfolio:paper-demo",
+  "post_trade_evaluation_ref": "post-trade:pending",
+  "replay_ref": "replay:demo-window-0001",
+  "trace_ref": "trace:trader-agent-demo-0001",
+  "projection_family": "trader_agent_execution",
+  "outcome": "acknowledged",
+  "slippage_bps": 0.0,
+  "risk_controls": [
+    "max_notional",
+    "paper_only",
+    "kill_switch_enabled"
+  ],
+  "attributes": {
+    "event_type": "order.acknowledged",
+    "side": "buy",
+    "quantity_ref": "redacted:paper-size",
+    "symbol_ref": "instrument:example-equity"
+  },
+  "receipt": {
+    "hash": "sha256:example-trader-agent-execution-observed",
+    "algo": "sha256"
+  }
+}

--- a/tools/emit_operational_exhaust_examples.py
+++ b/tools/emit_operational_exhaust_examples.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Emit example operational-exhaust events for local smoke checks.
+
+This helper intentionally emits deterministic example JSON rather than connecting to
+runtime services. Real emitters should populate the same fields from service context,
+trace context, policy/evidence receipts, and trader-agent execution state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ROOT / "examples" / "operational-exhaust"
+
+
+def load(name: str) -> dict:
+    return json.loads((EXAMPLES / name).read_text())
+
+
+def main() -> int:
+    events = [
+        load("operational_exhaust_observed.example.json"),
+        load("trader_agent_execution_observed.example.json"),
+    ]
+    print(json.dumps(events, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_operational_exhaust_examples.py
+++ b/tools/tests/test_operational_exhaust_examples.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_operational_exhaust_examples_validate():
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "validate_operational_exhaust_examples.py")],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tools/validate_operational_exhaust_examples.py
+++ b/tools/validate_operational_exhaust_examples.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Validate the repository's operational-exhaust example payloads.
+
+This is a lightweight dependency-free shape check. It does not replace full JSON Schema
+validation; it keeps examples honest in minimal CI/dev environments.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES = ROOT / "examples" / "operational-exhaust"
+
+COMMON_REQUIRED = {
+    "version",
+    "event_id",
+    "observed_at",
+    "source_repo",
+    "source_surface",
+    "source_runtime",
+    "environment_ref",
+    "trace_ref",
+    "projection_family",
+}
+
+TRADER_REQUIRED = {
+    "version",
+    "event_id",
+    "observed_at",
+    "strategy_run_ref",
+    "model_ref",
+    "feature_snapshot_ref",
+    "market_window_ref",
+    "risk_policy_ref",
+    "order_intent_ref",
+    "execution_ref",
+    "venue_ref",
+    "trace_ref",
+    "projection_family",
+}
+
+
+def read_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except Exception as exc:  # pragma: no cover - command-line diagnostics
+        raise SystemExit(f"failed to parse {path}: {exc}") from exc
+
+
+def require_fields(name: str, payload: dict, required: set[str]) -> list[str]:
+    return sorted(field for field in required if field not in payload)
+
+
+def main() -> int:
+    checks = [
+        (
+            "operational_exhaust_observed.example.json",
+            COMMON_REQUIRED,
+            "market_data_operations",
+        ),
+        (
+            "trader_agent_execution_observed.example.json",
+            TRADER_REQUIRED,
+            "trader_agent_execution",
+        ),
+    ]
+    failed = False
+    for filename, required, projection_family in checks:
+        path = EXAMPLES / filename
+        payload = read_json(path)
+        missing = require_fields(filename, payload, required)
+        if missing:
+            print(f"[FAIL] {filename}: missing fields: {', '.join(missing)}", file=sys.stderr)
+            failed = True
+        if payload.get("projection_family") != projection_family:
+            print(
+                f"[FAIL] {filename}: projection_family={payload.get('projection_family')!r}, expected {projection_family!r}",
+                file=sys.stderr,
+            )
+            failed = True
+    if failed:
+        return 1
+    print("[OK] operational-exhaust examples passed lightweight shape checks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `contracts/OperationalExhaustObserved.v0.1.json`
- add `contracts/TraderAgentExecutionObserved.v0.1.json`
- add `docs/OPERATIONAL_EXHAUST_EMITTER_GUIDE.md`

## Why
This is the runtime-side counterpart to `global-devsecops-intelligence` PR #3. It gives platform services, market-data runtimes, and trader-agent runtimes a normalized source-side event shape for projecting operational exhaust into the global DevSecOps intelligence surface.

## Boundary
This PR does **not** move canonical market semantics, canonical storage semantics, or canonical ontology ownership into `prophet-platform`. It only defines runtime-emitted operational projection events and source-side emitter guidance.

## Related
- `SocioProphet/global-devsecops-intelligence` PR #3: operational exhaust and trader-agent fusion boundary
