### PR TITLE
services(platform): align WOPI host smoke with office runtime records

### DIFF
--- a/.github/workflows/wopi-host-validation.yml
+++ b/.github/workflows/wopi-host-validation.yml
@@ -32,4 +32,4 @@ jobs:
         run: python -m pip install --upgrade pip fastapi==0.115.0 httpx==0.27.2 pytest jsonschema
 
       - name: Run WOPI host smoke tests
-        run: pytest -q services/wopi-host/tests
+        run: PYTHONPATH=. pytest -q services/wopi-host/tests

--- a/.github/workflows/wopi-host-validation.yml
+++ b/.github/workflows/wopi-host-validation.yml
@@ -1,0 +1,35 @@
+name: wopi-host-validation
+
+on:
+  pull_request:
+    paths:
+      - 'services/wopi-host/**'
+      - 'schemas/office/**'
+      - '.github/workflows/wopi-host-validation.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'services/wopi-host/**'
+      - 'schemas/office/**'
+      - '.github/workflows/wopi-host-validation.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  wopi-host-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip fastapi==0.115.0 httpx==0.27.2 pytest jsonschema
+
+      - name: Run WOPI host smoke tests
+        run: pytest -q services/wopi-host/tests

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service package namespace for platform service smoke tests."""

--- a/services/wopi-host/README.md
+++ b/services/wopi-host/README.md
@@ -1,36 +1,66 @@
 # WOPI Host Service
 
-This directory is the runtime stub for the office cloud suite WOPI host.
+This directory contains the first narrow runtime smoke for the SourceOS office cloud-suite WOPI host.
 
 ## Service purpose
 
-The WOPI host is responsible for the document/editor boundary used by the cloud office suite.
+The WOPI host is responsible for the document/editor boundary used by the open office suite.
 
-## Planned responsibilities
+It is not the total office product. It is the runtime seam that lets editor sessions interact with platform-owned document, session, version, lock, and writeback records.
 
-- document-scoped access token validation
-- file info retrieval
-- file read and writeback
-- lock and unlock handling
-- conflict-aware save behavior
-- launch surfaces for the cloud editor
+## Implemented smoke responsibilities
+
+- document-scoped file info retrieval
+- payload read/write roundtrip
+- lock acquisition
+- lock refresh
+- unlock/release
+- writeback version emission
+- file-backed writeback smoke
+- payload metadata
+- document summary
+- runtime record projection for:
+  - `office_document_record`
+  - `office_session_record`
+  - `office_version_record`
+  - `office_writeback_record`
 
 ## Backing contracts
 
 - `schemas/office/office_document_record.schema.json`
 - `schemas/office/office_session_record.schema.json`
-- later: version, receipt, and writeback records
+- `schemas/office/office_version_record.schema.json`
+- `schemas/office/office_writeback_record.schema.json`
+- `schemas/office/office_policy_decision_record.schema.json`
+- `schemas/office/office_adapter_profile.schema.json`
+
+## Contract validation
+
+The WOPI host smoke tests validate emitted runtime records against the platform schemas.
+
+```bash
+python -m pip install fastapi==0.115.0 httpx==0.27.2 pytest jsonschema
+pytest -q services/wopi-host/tests
+```
+
+The dedicated GitHub workflow is `.github/workflows/wopi-host-validation.yml`.
 
 ## Cross-repo boundaries
 
 - product semantics live in `SocioProphet/prophet-workspace`
-- Linux/desktop handoff lives in `SociOS-Linux/source-os`
-- local memory and search dependencies should stay outside the hot path of editor RPC handling
+- runtime records and service seams live in `SocioProphet/prophet-platform`
+- Linux/desktop handoff lives in SourceOS host surfaces such as `SourceOS-Linux/sourceos-shell`, `SourceOS-Linux/sourceos-devtools`, `SourceOS-Linux/TurtleTerm`, and `SourceOS-Linux/BearBrowser`
+- local memory/search/ontology dependencies stay outside the hot path of editor RPC handling
+- closed-provider migration/import/export evidence belongs in Exodus-style migration flows, not in WOPI runtime authority
 
 ## First implementation posture
 
-The first implementation should be narrow and testable:
-- one editor binding
-- one storage backend seam
+The implementation remains intentionally narrow and testable:
+
+- one open editor binding: Collabora-style browser editor path
+- one storage backend seam for payload/file-backed smoke
 - explicit lock semantics
+- explicit version and writeback records
 - explicit health and smoke surfaces
+- no Google/Microsoft runtime dependency
+- no memory or semantic graph mutation inside the critical save path

--- a/services/wopi-host/app/main.py
+++ b/services/wopi-host/app/main.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from hashlib import sha256
+
 from fastapi import FastAPI, Response
 from pydantic import BaseModel
 
 from services.wopi_host.app.document_store import DocumentPayloadStore
 from services.wopi_host.app.file_store import FileBackedWOPIStore
-from services.wopi_host.app.store import store
+from services.wopi_host.app.store import SessionState, store
 from services.wopi_host.app.version_store import DocumentVersionStore
 
 app = FastAPI(title="wopi-host", version="0.1.0")
@@ -11,9 +16,161 @@ file_store = FileBackedWOPIStore("/tmp/sourceos-wopi-store")
 document_store = DocumentPayloadStore("/tmp/sourceos-wopi-docs")
 version_store = DocumentVersionStore("/tmp/sourceos-wopi-versions")
 
+VERSION_RECORDS: dict[str, dict[str, object]] = {}
+WRITEBACK_RECORDS: dict[str, dict[str, object]] = {}
+
 
 class PutFileRequest(BaseModel):
     payload: str
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _payload(document_id: str) -> bytes:
+    return document_store.get_bytes(document_id) or b""
+
+
+def _content_hash(document_id: str) -> str:
+    return "sha256:" + sha256(_payload(document_id)).hexdigest()
+
+
+def _content_ref(document_id: str, version_id: str) -> str:
+    return f"sourceos-office://wopi-host/{document_id}/versions/{version_id}.odt"
+
+
+def _storage_uri(document_id: str) -> str:
+    return f"sourceos-office://wopi-host/{document_id}.odt"
+
+
+def _document_record(document_id: str) -> dict[str, object]:
+    versions = version_store.list_versions(document_id)
+    state = store.get(document_id)
+    now = _now()
+    return {
+        "document_id": document_id,
+        "tenant_id": "tenant-demo",
+        "owner_id": "user://wopi-demo-owner",
+        "storage_uri": _storage_uri(document_id),
+        "source_provider": "SOURCEOS",
+        "current_format": "odt",
+        "canonical_format": "ODF",
+        "permissions_ref": "permissions://office/wopi-host-demo",
+        "version_head": versions[-1] if versions else f"version-{document_id}-000",
+        "editor_binding": "COLLABORA",
+        "created_at": state.updated_at if state else now,
+        "updated_at": state.updated_at if state else now,
+    }
+
+
+def _session_record(state: SessionState, status: str = "OPEN") -> dict[str, object]:
+    return {
+        "session_id": state.session_id,
+        "document_id": state.document_id,
+        "editor_binding": "COLLABORA",
+        "mode": "EDIT",
+        "participants": [],
+        "lock_token": state.lock_token,
+        "version_head": f"version-{state.document_id}-{state.version_counter:03d}",
+        "status": status,
+        "created_at": state.updated_at,
+        "updated_at": state.updated_at,
+    }
+
+
+def _version_record(
+    *,
+    document_id: str,
+    version_id: str,
+    version_number: int,
+    capture_source: str,
+    previous_version_id: str | None = None,
+    writeback_ref: str | None = None,
+) -> dict[str, object]:
+    now = _now()
+    record: dict[str, object] = {
+        "version_id": version_id,
+        "document_id": document_id,
+        "tenant_id": "tenant-demo",
+        "version_number": version_number,
+        "content_ref": _content_ref(document_id, version_id),
+        "content_hash": _content_hash(document_id),
+        "format": "odt",
+        "canonical_format": "ODF",
+        "source_provider": "SOURCEOS",
+        "execution_backend": "COLLABORA",
+        "capture_source": capture_source,
+        "created_by_ref": "service://wopi-host",
+        "receipt_refs": [],
+        "semantic_unit_refs": [],
+        "created_at": now,
+        "labels": {"sourceos.wopi": capture_source.lower().replace("_", "-")},
+    }
+    if previous_version_id:
+        record["previous_version_id"] = previous_version_id
+    if writeback_ref:
+        record["writeback_ref"] = writeback_ref
+    VERSION_RECORDS[version_id] = record
+    return record
+
+
+def _writeback_record(
+    *,
+    document_id: str,
+    state: SessionState,
+    version_id: str,
+    writeback_id: str,
+    base_version_id: str,
+    operation: str,
+) -> dict[str, object]:
+    now = _now()
+    record: dict[str, object] = {
+        "writeback_id": writeback_id,
+        "document_id": document_id,
+        "session_id": state.session_id,
+        "operation": operation,
+        "status": "COMMITTED",
+        "base_version_id": base_version_id,
+        "result_version_id": version_id,
+        "lock_token": state.lock_token,
+        "actor_ref": "service://wopi-host",
+        "source": "EDITOR_SESSION",
+        "execution_backend": "COLLABORA",
+        "content_ref": _content_ref(document_id, version_id),
+        "content_hash": _content_hash(document_id),
+        "receipt_ref": f"receipt://office/wopi-host/{writeback_id}",
+        "requested_at": now,
+        "committed_at": now,
+        "labels": {"sourceos.hot_path": "narrow"},
+    }
+    WRITEBACK_RECORDS[writeback_id] = record
+    return record
+
+
+def _record_writeback(document_id: str, state: SessionState, operation: str) -> tuple[dict[str, object], dict[str, object]]:
+    versions_before = version_store.list_versions(document_id)
+    base_version_id = versions_before[-1] if versions_before else f"version-{document_id}-000"
+    version_id = f"version-{state.document_id}-{state.version_counter:03d}"
+    writeback_id = f"writeback-{state.document_id}-{state.version_counter:03d}"
+    version_store.append(document_id, version_id)
+    writeback = _writeback_record(
+        document_id=document_id,
+        state=state,
+        version_id=version_id,
+        writeback_id=writeback_id,
+        base_version_id=base_version_id,
+        operation=operation,
+    )
+    version = _version_record(
+        document_id=document_id,
+        version_id=version_id,
+        version_number=state.version_counter,
+        capture_source="WOPI_WRITEBACK",
+        previous_version_id=None if base_version_id.endswith("-000") else base_version_id,
+        writeback_ref=f"writeback://office/{writeback_id}",
+    )
+    return version, writeback
 
 
 @app.get("/healthz")
@@ -33,6 +190,7 @@ def check_file_info(document_id: str) -> dict[str, object]:
         "user_can_write": True,
         "version_counter": 0 if state is None else state.version_counter,
         "has_payload": payload is not None,
+        "document_record": _document_record(document_id),
     }
 
 
@@ -45,35 +203,72 @@ def acquire_lock(document_id: str) -> dict[str, object]:
         "lock_token": state.lock_token,
         "status": "LOCKED",
         "updated_at": state.updated_at,
+        "session_record": _session_record(state),
+    }
+
+
+@app.post("/v0/wopi/refresh-lock/{document_id}")
+def refresh_lock(document_id: str) -> dict[str, object]:
+    state = store.refresh_lock(document_id)
+    if state is None:
+        return Response(status_code=404)
+    return {
+        "document_id": state.document_id,
+        "session_id": state.session_id,
+        "lock_token": state.lock_token,
+        "status": "LOCK_REFRESHED",
+        "updated_at": state.updated_at,
+        "session_record": _session_record(state),
+    }
+
+
+@app.post("/v0/wopi/unlock/{document_id}")
+def unlock(document_id: str) -> dict[str, object]:
+    state = store.release_lock(document_id)
+    if state is None:
+        return Response(status_code=404)
+    return {
+        "document_id": state.document_id,
+        "session_id": state.session_id,
+        "lock_token": state.lock_token,
+        "status": "UNLOCKED",
+        "updated_at": state.updated_at,
+        "session_record": _session_record(state, status="CLOSED"),
     }
 
 
 @app.post("/v0/wopi/writeback/{document_id}")
 def writeback(document_id: str) -> dict[str, object]:
     state = store.writeback(document_id)
-    version_id = f"version-{state.document_id}-{state.version_counter:03d}"
-    version_store.append(document_id, version_id)
+    version, writeback_record = _record_writeback(document_id, state, "WOPI_PUT_FILE")
     return {
         "document_id": state.document_id,
         "session_id": state.session_id,
-        "version_id": version_id,
+        "version_id": version["version_id"],
         "status": "WRITTEN",
         "updated_at": state.updated_at,
+        "version_record": version,
+        "writeback_record": writeback_record,
+        "document_record": _document_record(document_id),
+        "session_record": _session_record(state, status="SAVING"),
     }
 
 
 @app.post("/v0/wopi/file-writeback/{document_id}")
 def file_writeback(document_id: str) -> dict[str, object]:
     state = file_store.writeback(document_id)
-    version_id = f"version-{state.document_id}-{state.version_counter:03d}"
-    version_store.append(document_id, version_id)
+    version, writeback_record = _record_writeback(document_id, state, "WOPI_PUT_FILE")
     return {
         "document_id": state.document_id,
         "session_id": state.session_id,
-        "version_id": version_id,
+        "version_id": version["version_id"],
         "status": "WRITTEN",
         "updated_at": state.updated_at,
         "store": "file",
+        "version_record": version,
+        "writeback_record": writeback_record,
+        "document_record": _document_record(document_id),
+        "session_record": _session_record(state, status="SAVING"),
     }
 
 
@@ -89,13 +284,16 @@ def get_file(document_id: str):
 def put_file(document_id: str, body: PutFileRequest) -> dict[str, object]:
     document_store.put_bytes(document_id, body.payload.encode("utf-8"))
     state = store.writeback(document_id)
-    version_id = f"version-{state.document_id}-{state.version_counter:03d}"
-    version_store.append(document_id, version_id)
+    version, writeback_record = _record_writeback(document_id, state, "WOPI_PUT_FILE")
     return {
         "document_id": state.document_id,
-        "version_id": version_id,
+        "version_id": version["version_id"],
         "status": "WRITTEN",
         "store": "payload",
+        "version_record": version,
+        "writeback_record": writeback_record,
+        "document_record": _document_record(document_id),
+        "session_record": _session_record(state, status="SAVING"),
     }
 
 
@@ -105,6 +303,19 @@ def list_versions(document_id: str) -> dict[str, object]:
         "document_id": document_id,
         "versions": version_store.list_versions(document_id),
     }
+
+
+@app.get("/v0/wopi/version-records/{document_id}")
+def list_version_records(document_id: str) -> dict[str, object]:
+    records = [item for item in VERSION_RECORDS.values() if item["document_id"] == document_id]
+    records.sort(key=lambda item: int(item["version_number"]))
+    return {"document_id": document_id, "version_records": records}
+
+
+@app.get("/v0/wopi/writeback-records/{document_id}")
+def list_writeback_records(document_id: str) -> dict[str, object]:
+    records = [item for item in WRITEBACK_RECORDS.values() if item["document_id"] == document_id]
+    return {"document_id": document_id, "writeback_records": records}
 
 
 @app.get("/v0/wopi/payload-metadata/{document_id}")
@@ -125,4 +336,8 @@ def document_summary(document_id: str) -> dict[str, object]:
         "version_counter": 0 if state is None else state.version_counter,
         "versions": version_store.list_versions(document_id),
         "payload_metadata": metadata,
+        "document_record": _document_record(document_id),
+        "session_record": _session_record(state) if state else None,
+        "version_records": [item for item in VERSION_RECORDS.values() if item["document_id"] == document_id],
+        "writeback_records": [item for item in WRITEBACK_RECORDS.values() if item["document_id"] == document_id],
     }

--- a/services/wopi-host/app/store.py
+++ b/services/wopi-host/app/store.py
@@ -26,6 +26,16 @@ class InMemoryWOPIStore:
         self._sessions[document_id] = state
         return state
 
+    def refresh_lock(self, document_id: str) -> SessionState | None:
+        state = self._sessions.get(document_id)
+        if state is None:
+            return None
+        state.updated_at = datetime.now(timezone.utc).isoformat()
+        return state
+
+    def release_lock(self, document_id: str) -> SessionState | None:
+        return self._sessions.pop(document_id, None)
+
     def writeback(self, document_id: str) -> SessionState:
         state = self._sessions.get(document_id)
         if state is None:

--- a/services/wopi-host/tests/test_check_file_info_payload_flag.py
+++ b/services/wopi-host/tests/test_check_file_info_payload_flag.py
@@ -7,14 +7,18 @@ client = TestClient(app)
 
 
 def test_check_file_info_reflects_payload_presence() -> None:
-    before = client.get('/v0/wopi/check-file-info/demo-doc')
+    document_id = 'check-info-doc'
+
+    before = client.get(f'/v0/wopi/check-file-info/{document_id}')
     assert before.status_code == 200
     assert before.json()['has_payload'] is False
 
-    client.post('/v0/wopi/put-file/demo-doc', json={'payload': 'payload bytes'})
+    client.post(f'/v0/wopi/put-file/{document_id}', json={'payload': 'payload bytes'})
 
-    after = client.get('/v0/wopi/check-file-info/demo-doc')
+    after = client.get(f'/v0/wopi/check-file-info/{document_id}')
     assert after.status_code == 200
     payload = after.json()
     assert payload['has_payload'] is True
     assert payload['version_counter'] == 1
+    assert payload['document_record']['document_id'] == document_id
+    assert payload['document_record']['source_provider'] == 'SOURCEOS'

--- a/services/wopi-host/tests/test_contract_records_validate_against_schemas.py
+++ b/services/wopi-host/tests/test_contract_records_validate_against_schemas.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+import json
+
+from fastapi.testclient import TestClient
+from jsonschema import Draft202012Validator
+
+from services.wopi_host.app.main import app
+
+
+ROOT = Path(__file__).resolve().parents[3]
+client = TestClient(app)
+
+
+def _load_schema(path: str) -> dict[str, object]:
+    with (ROOT / path).open("r", encoding="utf-8") as handle:
+        schema = json.load(handle)
+    Draft202012Validator.check_schema(schema)
+    return schema
+
+
+def _assert_valid(schema_path: str, payload: dict[str, object]) -> None:
+    schema = _load_schema(schema_path)
+    errors = sorted(Draft202012Validator(schema).iter_errors(payload), key=lambda error: list(error.path))
+    assert errors == []
+
+
+def test_wopi_put_file_records_validate_against_office_runtime_schemas() -> None:
+    document_id = "schema-contract-doc"
+
+    response = client.post(
+        f"/v0/wopi/put-file/{document_id}",
+        json={"payload": "contract aligned payload"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    _assert_valid("schemas/office/office_document_record.schema.json", payload["document_record"])
+    _assert_valid("schemas/office/office_session_record.schema.json", payload["session_record"])
+    _assert_valid("schemas/office/office_version_record.schema.json", payload["version_record"])
+    _assert_valid("schemas/office/office_writeback_record.schema.json", payload["writeback_record"])
+
+    assert payload["document_record"]["source_provider"] == "SOURCEOS"
+    assert payload["version_record"]["execution_backend"] == "COLLABORA"
+    assert payload["writeback_record"]["status"] == "COMMITTED"
+    assert payload["writeback_record"]["result_version_id"] == payload["version_record"]["version_id"]
+
+
+def test_wopi_lock_session_record_validates_against_session_schema() -> None:
+    document_id = "schema-lock-doc"
+
+    response = client.post(f"/v0/wopi/lock/{document_id}")
+    assert response.status_code == 200
+    payload = response.json()
+
+    _assert_valid("schemas/office/office_session_record.schema.json", payload["session_record"])
+    assert payload["session_record"]["status"] == "OPEN"
+
+    unlock = client.post(f"/v0/wopi/unlock/{document_id}")
+    assert unlock.status_code == 200
+    unlock_payload = unlock.json()
+    _assert_valid("schemas/office/office_session_record.schema.json", unlock_payload["session_record"])
+    assert unlock_payload["session_record"]["status"] == "CLOSED"

--- a/services/wopi-host/tests/test_document_summary_endpoint.py
+++ b/services/wopi-host/tests/test_document_summary_endpoint.py
@@ -7,14 +7,20 @@ client = TestClient(app)
 
 
 def test_document_summary_reflects_payload_and_versions() -> None:
-    client.post('/v0/wopi/put-file/demo-doc', json={'payload': 'v1'})
-    client.post('/v0/wopi/put-file/demo-doc', json={'payload': 'v2'})
+    document_id = 'summary-doc'
 
-    response = client.get('/v0/wopi/document-summary/demo-doc')
+    client.post(f'/v0/wopi/put-file/{document_id}', json={'payload': 'v1'})
+    client.post(f'/v0/wopi/put-file/{document_id}', json={'payload': 'v2'})
+
+    response = client.get(f'/v0/wopi/document-summary/{document_id}')
     assert response.status_code == 200
     payload = response.json()
-    assert payload['document_id'] == 'demo-doc'
+    assert payload['document_id'] == document_id
     assert payload['has_session'] is True
     assert payload['version_counter'] == 2
-    assert payload['versions'] == ['version-demo-doc-001', 'version-demo-doc-002']
+    assert payload['versions'] == [f'version-{document_id}-001', f'version-{document_id}-002']
     assert payload['payload_metadata']['size_bytes'] == len(b'v2')
+    assert payload['document_record']['version_head'] == f'version-{document_id}-002'
+    assert payload['session_record']['status'] == 'OPEN'
+    assert len(payload['version_records']) == 2
+    assert len(payload['writeback_records']) == 2

--- a/services/wopi-host/tests/test_file_writeback_endpoint.py
+++ b/services/wopi-host/tests/test_file_writeback_endpoint.py
@@ -7,10 +7,14 @@ client = TestClient(app)
 
 
 def test_file_writeback_endpoint_returns_file_store_marker() -> None:
-    response = client.post("/v0/wopi/file-writeback/demo-doc")
+    document_id = 'file-writeback-doc'
+
+    response = client.post(f'/v0/wopi/file-writeback/{document_id}')
     assert response.status_code == 200
     payload = response.json()
-    assert payload["document_id"] == "demo-doc"
-    assert payload["status"] == "WRITTEN"
-    assert payload["store"] == "file"
-    assert payload["version_id"] == "version-demo-doc-001"
+    assert payload['document_id'] == document_id
+    assert payload['status'] == 'WRITTEN'
+    assert payload['store'] == 'file'
+    assert payload['version_id'] == f'version-{document_id}-001'
+    assert payload['version_record']['execution_backend'] == 'COLLABORA'
+    assert payload['writeback_record']['operation'] == 'WOPI_PUT_FILE'

--- a/services/wopi-host/tests/test_lock_writeback.py
+++ b/services/wopi-host/tests/test_lock_writeback.py
@@ -7,18 +7,50 @@ client = TestClient(app)
 
 
 def test_lock_endpoint_returns_lock_token() -> None:
-    response = client.post("/v0/wopi/lock/demo-doc")
+    document_id = 'lock-doc'
+
+    response = client.post(f'/v0/wopi/lock/{document_id}')
     assert response.status_code == 200
     payload = response.json()
-    assert payload["document_id"] == "demo-doc"
-    assert payload["status"] == "LOCKED"
-    assert payload["lock_token"] == "lock-demo-doc"
+    assert payload['document_id'] == document_id
+    assert payload['status'] == 'LOCKED'
+    assert payload['lock_token'] == f'lock-{document_id}'
+    assert payload['session_record']['document_id'] == document_id
+    assert payload['session_record']['status'] == 'OPEN'
 
 
-def test_writeback_endpoint_returns_version() -> None:
-    response = client.post("/v0/wopi/writeback/demo-doc")
+def test_refresh_and_unlock_endpoints_update_session_contract() -> None:
+    document_id = 'lock-refresh-doc'
+
+    lock_response = client.post(f'/v0/wopi/lock/{document_id}')
+    assert lock_response.status_code == 200
+
+    refresh_response = client.post(f'/v0/wopi/refresh-lock/{document_id}')
+    assert refresh_response.status_code == 200
+    refresh_payload = refresh_response.json()
+    assert refresh_payload['status'] == 'LOCK_REFRESHED'
+    assert refresh_payload['session_record']['status'] == 'OPEN'
+
+    unlock_response = client.post(f'/v0/wopi/unlock/{document_id}')
+    assert unlock_response.status_code == 200
+    unlock_payload = unlock_response.json()
+    assert unlock_payload['status'] == 'UNLOCKED'
+    assert unlock_payload['session_record']['status'] == 'CLOSED'
+
+    missing_refresh = client.post(f'/v0/wopi/refresh-lock/{document_id}')
+    assert missing_refresh.status_code == 404
+
+
+def test_writeback_endpoint_returns_version_and_contract_records() -> None:
+    document_id = 'writeback-doc'
+
+    response = client.post(f'/v0/wopi/writeback/{document_id}')
     assert response.status_code == 200
     payload = response.json()
-    assert payload["document_id"] == "demo-doc"
-    assert payload["status"] == "WRITTEN"
-    assert payload["version_id"] == "version-demo-doc-001"
+    assert payload['document_id'] == document_id
+    assert payload['status'] == 'WRITTEN'
+    assert payload['version_id'] == f'version-{document_id}-001'
+    assert payload['version_record']['version_id'] == payload['version_id']
+    assert payload['version_record']['capture_source'] == 'WOPI_WRITEBACK'
+    assert payload['writeback_record']['result_version_id'] == payload['version_id']
+    assert payload['writeback_record']['status'] == 'COMMITTED'

--- a/services/wopi-host/tests/test_payload_metadata_endpoint.py
+++ b/services/wopi-host/tests/test_payload_metadata_endpoint.py
@@ -7,11 +7,13 @@ client = TestClient(app)
 
 
 def test_payload_metadata_reports_size_and_hash() -> None:
-    client.post('/v0/wopi/put-file/demo-doc', json={'payload': 'hello office world'})
+    document_id = 'metadata-doc'
 
-    response = client.get('/v0/wopi/payload-metadata/demo-doc')
+    client.post(f'/v0/wopi/put-file/{document_id}', json={'payload': 'hello office world'})
+
+    response = client.get(f'/v0/wopi/payload-metadata/{document_id}')
     assert response.status_code == 200
     payload = response.json()
-    assert payload['document_id'] == 'demo-doc'
+    assert payload['document_id'] == document_id
     assert payload['size_bytes'] == len(b'hello office world')
     assert len(payload['sha256']) == 64

--- a/services/wopi-host/tests/test_payload_store_endpoints.py
+++ b/services/wopi-host/tests/test_payload_store_endpoints.py
@@ -7,16 +7,20 @@ client = TestClient(app)
 
 
 def test_put_file_then_get_file_roundtrip() -> None:
+    document_id = 'payload-roundtrip-doc'
+
     put_response = client.post(
-        "/v0/wopi/put-file/demo-doc",
-        json={"payload": "hello office world"},
+        f'/v0/wopi/put-file/{document_id}',
+        json={'payload': 'hello office world'},
     )
     assert put_response.status_code == 200
     put_payload = put_response.json()
-    assert put_payload["document_id"] == "demo-doc"
-    assert put_payload["status"] == "WRITTEN"
-    assert put_payload["store"] == "payload"
+    assert put_payload['document_id'] == document_id
+    assert put_payload['status'] == 'WRITTEN'
+    assert put_payload['store'] == 'payload'
+    assert put_payload['version_record']['document_id'] == document_id
+    assert put_payload['writeback_record']['operation'] == 'WOPI_PUT_FILE'
 
-    get_response = client.get("/v0/wopi/get-file/demo-doc")
+    get_response = client.get(f'/v0/wopi/get-file/{document_id}')
     assert get_response.status_code == 200
-    assert get_response.content == b"hello office world"
+    assert get_response.content == b'hello office world'

--- a/services/wopi-host/tests/test_version_history_endpoint.py
+++ b/services/wopi-host/tests/test_version_history_endpoint.py
@@ -7,11 +7,19 @@ client = TestClient(app)
 
 
 def test_version_history_tracks_put_file_versions() -> None:
-    client.post('/v0/wopi/put-file/demo-doc', json={'payload': 'v1'})
-    client.post('/v0/wopi/put-file/demo-doc', json={'payload': 'v2'})
+    document_id = 'version-history-doc'
 
-    response = client.get('/v0/wopi/versions/demo-doc')
+    client.post(f'/v0/wopi/put-file/{document_id}', json={'payload': 'v1'})
+    client.post(f'/v0/wopi/put-file/{document_id}', json={'payload': 'v2'})
+
+    response = client.get(f'/v0/wopi/versions/{document_id}')
     assert response.status_code == 200
     payload = response.json()
-    assert payload['document_id'] == 'demo-doc'
-    assert payload['versions'] == ['version-demo-doc-001', 'version-demo-doc-002']
+    assert payload['document_id'] == document_id
+    assert payload['versions'] == [f'version-{document_id}-001', f'version-{document_id}-002']
+
+    records = client.get(f'/v0/wopi/version-records/{document_id}')
+    assert records.status_code == 200
+    version_records = records.json()['version_records']
+    assert [item['version_id'] for item in version_records] == payload['versions']
+    assert version_records[-1]['capture_source'] == 'WOPI_WRITEBACK'

--- a/services/wopi_host/__init__.py
+++ b/services/wopi_host/__init__.py
@@ -1,0 +1,10 @@
+"""Import bridge for the hyphenated `services/wopi-host` source tree."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_HYPHENATED_DIR = _PACKAGE_DIR.parent / "wopi-host"
+
+__path__ = [str(_HYPHENATED_DIR)]


### PR DESCRIPTION
## Summary

Implements the next narrow WOPI host smoke slice after #378.

This does not implement a full WOPI server. It aligns the existing `services/wopi-host` smoke surface with the office runtime contracts now present in `schemas/office/`.

## Changes

### WOPI host runtime smoke

- Preserves existing WOPI host endpoints and response compatibility.
- Adds runtime record projection for:
  - `office_document_record`
  - `office_session_record`
  - `office_version_record`
  - `office_writeback_record`
- Adds in-memory lock refresh and unlock/release methods.
- Adds WOPI endpoints:
  - `POST /v0/wopi/refresh-lock/{document_id}`
  - `POST /v0/wopi/unlock/{document_id}`
  - `GET /v0/wopi/version-records/{document_id}`
  - `GET /v0/wopi/writeback-records/{document_id}`
- Keeps memory/search/semantic graph mutation outside the hot path.
- Introduces no Google/Microsoft/Apple runtime dependency.

### Tests

- Extends WOPI tests to assert nested runtime records.
- Adds schema validation tests for emitted runtime records using `Draft202012Validator`.
- Isolates existing tests with unique document IDs to avoid cross-test state leakage.

### CI

- Adds `.github/workflows/wopi-host-validation.yml` to run WOPI host tests when WOPI service or office schemas change.

### Docs

- Updates `services/wopi-host/README.md` to describe the implemented smoke surface, contract bindings, and validation command.

## Validation target

```bash
python -m pip install fastapi==0.115.0 httpx==0.27.2 pytest jsonschema
pytest -q services/wopi-host/tests
```

## Notes

The branch is behind current `main`, but the changed-file scope is limited to WOPI host service/tests/docs plus a new WOPI validation workflow. I checked current `main` for the core WOPI app/store files before opening; upstream had not changed those files relative to this branch base.