### PR TITLE
docs(kmaas): add canonical KMaaS product package

### DIFF
--- a/docs/kmaas/KMAAS_DATA_SALES_PLAY.md
+++ b/docs/kmaas/KMAAS_DATA_SALES_PLAY.md
@@ -1,0 +1,68 @@
+# KMaaS Data Sales Play
+
+## Executive thesis
+
+Enterprise AI usually improves retrieval before it improves trust. That fails in production. The hard problem is not generating an answer; it is proving why an action was allowed, which policy governed it, what evidence supported it, where execution occurred, and how to replay the result under audit.
+
+SocioProphet KMaaS addresses that gap with a governed knowledge and execution layer that binds domain backbones, systems of record, policy, telemetry, provenance, and agentic workflows into one operational surface.
+
+## Why trust-first
+
+Logs are not provenance. Dashboards are not replay. Incident response becomes archaeology, audits become manual evidence hunts, and automation scales faster than governance capacity.
+
+Trust-first discipline changes the artifact of record: every material run is expected to emit reviewable evidence of what happened, under which policy, with which inputs, where it ran, and how it can be reproduced or challenged.
+
+## Why we win
+
+### Cheaper trust
+
+KMaaS lowers audit burden, incident cost, and safe-deployment latency by producing proof artifacts during normal operation instead of assembling evidence after the fact.
+
+### Better placement
+
+KMaaS routes work under explicit constraints such as data locality, jurisdiction, latency, egress, risk, and review requirements so tasks run where they should.
+
+### Verifiability is the product
+
+KMaaS replaces narrative assurance with replayable artifacts that stand up in audit, security, and operational review. The product makes governance predictable, repeatable, and inspectable.
+
+## Executive buying matrix
+
+| Buyer | Artifact | Value | Acceptance |
+|---|---|---|---|
+| Platform team | Proof pack and placement receipt | Safer deployment and lower governance cost | Receipts and evidence produced |
+| Audit team | Policy artifact and audit pack | Lower audit burden and clearer controls | Policy pinned and evidence preserved |
+| Security team | Replay artifact and run trace | Faster investigation and exportable evidence | Replay works and evidence is exportable |
+| Operations | Phase evidence and governed knowledge surface | Faster time-to-context and better operator throughput | Workflow speed and adoption improve |
+
+## What buyers keep
+
+- Proof Pack: run artifact, policy artifact, promotion history, replay artifact, and audit package.
+- Placement Receipt: execution site, applied constraints, rationale, and comparable alternatives.
+- Phase Gate Evidence: acceptance traces, evaluation outputs, and production-readiness artifacts.
+
+## Commercial package
+
+- Minimum engagement: `$1.11M` baseline.
+- Start gate: joint staffing plan interviewed, approved, and certified.
+- Baseline scope: one anchor domain backbone, data-plane integration, control-plane binding, text-native onboarding, telemetry, evaluation harness, and measurable definition of done.
+- Expansion lanes: audio, video, advanced personalization, OCR augmentation, and deeper workflow automation.
+
+## Expected outcomes
+
+- 30-50% increase in first-contact resolution for suitable service, support, and operations workflows.
+- 70% faster time-to-proficiency for new analysts in knowledge-dense environments.
+- 2x to 5x measured improvement in time-on-task for selected workflows once phase targets are met.
+- Lower audit friction and lower MTTR through attributable, policy-bounded, replayable execution.
+- Progression from coarse retrieval toward precise retrieval, with latency targets moving from approximately 60 seconds to 8 seconds to 1 second and action count moving from 10 to 5 to 1.
+
+## Sales qualification test
+
+A prospect is a good KMaaS candidate if at least three of these are true:
+
+- knowledge is spread across multiple systems of record and content repositories;
+- regulated or policy-bound decisions require evidence and audit support;
+- teams cannot prove why an automated action was allowed;
+- onboarding, support, investigation, or review workflows are slowed by evidence hunting;
+- the buyer needs local / edge / cloud placement decisions to be governed rather than opportunistic;
+- the buyer needs agentic workflows but cannot accept black-box automation.

--- a/docs/kmaas/KMAAS_DELIVERY_DOCTRINE.md
+++ b/docs/kmaas/KMAAS_DELIVERY_DOCTRINE.md
@@ -1,0 +1,135 @@
+# KMaaS Delivery Doctrine
+
+## Delivery invariant
+
+KMaaS starts with the data plane and domain backbone. Content onboarding comes after canonical identity, policy, and lineage exist. Experience workflows come last.
+
+The sequence is deliberate:
+
+1. Domain backbone.
+2. Data plane.
+3. Control plane.
+4. Systems of record.
+5. Text-native content.
+6. Audio.
+7. Video.
+8. Experience workflows.
+
+## Implementation sequence
+
+| Sequence | Layer | Primary action | Output / gate |
+|---|---|---|---|
+| Seq 0 | Domain | Select anchor domain | Canonical nouns and policy surface |
+| Seq 1 | Data plane | Define entities, IDs, lineage | Stable object model and provenance |
+| Seq 2 | Control plane | Bind RBAC / ABAC to canonical model | Computable decisions and evidence events |
+| Seq 3 | Systems | Onboard HRIS / ERP / CRM / IAM first | Schema contract, cadence, reconciliation |
+| Seq 4 | Content | Admit text-native content first | Stable citations and clean evaluation |
+| Seq 5 | Experience | Enable agents after prior layers stabilize | Governed copilots and routing |
+
+## Channel ladder
+
+### Phase 0 — admission gates
+
+KMaaS does not index everything. It admits bounded corpora and known formats. Initial supported text formats are plain text, markdown, HTML, JSON, XML, CSV, DOCX, and PDFs with a text layer. Scanned PDFs and image-only documents are out of scope for the initial phase.
+
+### Phase 1 — text
+
+Primary retrieval units are document and paragraph. Optional high-value sentence indexing may be enabled selectively.
+
+Required identifiers:
+
+- `doc_id`
+- `doc_rev`
+- `span_id`
+- `char_range`
+- `segmenter_ver`
+
+### Phase 2 — audio
+
+Primary retrieval units are audio file and timecoded segment.
+
+Required identifiers:
+
+- `audio_id`
+- `segment_id`
+- `start_ms`
+- `end_ms`
+- `transcript_rev`
+- optional `speaker_id`
+- optional confidence values
+
+### Phase 3 — video
+
+Primary retrieval units are video, clip, and selectively frame.
+
+Required identifiers:
+
+- `video_id`
+- `clip_id`
+- `start_ms`
+- `end_ms`
+- `frame_id`
+- `frame_index`
+- `fps_assumed`
+- `decode_method_ver`
+
+OCR is a post-localization augmentation on retrieved clips or frames, not the ingestion backbone.
+
+## Metric contract summary
+
+| Metric ID | Measure | Unit | Phase target |
+|---|---|---|---|
+| `TAB.TEXT.GRAN` | text retrieval precision | top-1 accuracy | 80% at doc / paragraph / sentence |
+| `TAB.VIDEO.GRAN` | video retrieval precision | success@5 | 65% at video / clip / selective frame |
+| `TAB.TEXT.SCALE` | text-source scale | count | 20k / 120k / 800k |
+| `TAD.LATENCY.JIT` | end-to-end latency | seconds | 60 / 8 / 1 |
+| `TAD.RELEVANCE.JFM` | relevance under rubric | % relevant | 70 / 83 / 98 |
+
+## Measurement protocols
+
+- Text retrieval uses top-1 exact-match accuracy against a labeled gold set at the target retrieval unit.
+- Video retrieval uses success@5 or recall@5 with overlap rules against labeled temporal windows.
+- Relevance is human-scored with a defined rubric and blinded evaluation where possible.
+- Latency is measured end-to-end from request receipt to delivered answer.
+- Action count measures discrete user or agent interactions required to produce a correct answer.
+- No metric is production-grade without evidence artifacts, logs, and reproducible evaluation runs.
+
+## Phase gates
+
+| Phase | Required state | Channel scope | Acceptance signal |
+|---|---|---|---|
+| Phase 1 | domain backbone + first system of record + text indexed | text | labeled queries + logs + timing traces |
+| Phase 2 | context binding + audio alignment + reranking validated | text + audio | relevance and friction improve vs baseline |
+| Phase 3 | sentence precision + video clip retrieval + caching | text + audio + video | provenance intact + near-real-time response |
+
+## Ownership and governance
+
+| Group | Role | Focus | Signal |
+|---|---|---|---|
+| Leadership / PMO | delivery lead | staffing, milestones, decisions | approved plan + risk log |
+| Platform / SRE | platform ops | reliability, telemetry, release health | SLOs + incident path |
+| Migration / Data Eng | migration factory | schema, lineage, reconciliation | parity + cutover readiness |
+| Controls / Compliance | control review | policy, access, evidence | decisions + audit pack |
+| AI / Automation | retrieval + workflow | eval, latency, automation behavior | validated runs + metric trend |
+| Customer Success | adoption lead | onboarding, enablement, proficiency | uptake + training status |
+
+## Governance forums
+
+| Forum | Scope | Trigger | Output |
+|---|---|---|---|
+| Steering | commercial + strategic alignment | milestone or escalation | scope, budget, priority decisions |
+| Ops Board | roadmap + release control | regular operating cadence | quality gates + release decisions |
+| Controls WG | policy + risk + evidence review | change, incident, audit | access decisions + review package |
+
+## Definition of done
+
+A KMaaS phase is not done because code shipped. It is done when evidence exists, the evidence validates, and the buyer can retain artifacts that prove what happened.
+
+At minimum, every completed phase must produce:
+
+- phase-gate record;
+- proof pack;
+- metric run result;
+- audit-readable summary;
+- failure / exception register;
+- replay or reproduction path for critical outputs.

--- a/docs/kmaas/KMAAS_REPO_RESPONSIBILITY_MAP.md
+++ b/docs/kmaas/KMAAS_REPO_RESPONSIBILITY_MAP.md
@@ -1,0 +1,72 @@
+# KMaaS Repository Responsibility Map
+
+## Purpose
+
+This map prevents KMaaS from becoming another cross-repo idea with no owner. Each surface has a primary repo, secondary contributors, and an explicit handoff contract.
+
+## Responsibility table
+
+| Surface | Primary owner | Secondary contributors | Output |
+|---|---|---|---|
+| Product/runtime surface | `prophet-platform` | `agentplane`, `sociosphere` | KMaaS routes, dashboards, proof-pack viewer, phase status |
+| Domain ontology | `ontogenesis` | standards repos, product teams | domain backbone, KPI object, evidence span, policy envelope terms |
+| Normative schemas | standards repos | `prophet-platform`, `agentplane` | metric contract, phase gate, proof pack, KPI pack schemas |
+| Execution receipts | `agentplane` | `TriTRPC`, `sociosphere` | run artifacts, placement receipts, replay manifests |
+| Workspace orchestration | `sociosphere` | `agentplane`, `prophet-platform` | engagement workflow, workspace lock, onboarding state |
+| Governed context packs | `slash-topics` | `sociosphere`, `agentplane` | topic pack identity, provenance, locality, cache/fetch events |
+| Deterministic transport | `TriTRPC` | `agentplane` | policy/evidence references, receipt refs, replay refs, transport metadata |
+| Human approval / consent | `human-digital-twin` | `policy-fabric`, `agentplane` | policy/approval events, attestation refs, human-governed replay expectations |
+| Linux packaging | `SourceOS-Linux`, `SociOS-Linux` | `prophet-platform` | local-first service profile, system integration, offline proof-pack path |
+
+## Near-term integration order
+
+1. Land product doctrine in `prophet-platform/docs/kmaas/`.
+2. Land normative schemas in the standards repository.
+3. Add ontology terms and SHACL/JSON-LD examples in `ontogenesis`.
+4. Wire KMaaS receipt/proof-pack names into `agentplane`.
+5. Add engagement workflow templates to `sociosphere`.
+6. Bind context-pack events in `slash-topics`.
+7. Expose dashboard surfaces in `prophet-platform`.
+8. Carry packaged runtime into SourceOS/SociOS after product contracts stabilize.
+
+## Handoff contracts
+
+### Standards to platform
+
+Standards repos publish schemas and examples. `prophet-platform` consumes pinned versions and exposes runtime views. The platform must not silently drift from standards-layer contracts.
+
+### Sociosphere to AgentPlane
+
+Sociosphere owns workspace truth: manifest ID, lock digest, dependency references, and onboarding state. AgentPlane owns execution truth: placement decision, run artifact, evidence seal, and replay manifest.
+
+### Slash Topics to AgentPlane
+
+Slash Topics owns context pack identity, locality, digest, cache/fetch events, and retrieval provenance. AgentPlane consumes those events into proof packs and run receipts.
+
+### Human Digital Twin to AgentPlane
+
+Human Digital Twin owns consent, approval, policy decision, and human-governed attestation events. AgentPlane consumes policy/approval references and must preserve them in replayable proof artifacts.
+
+### TriTRPC to runtime services
+
+TriTRPC owns deterministic transport envelopes and policy/evidence reference carriage. It does not own KPI semantics, domain ontology, or policy decisions.
+
+## Out of scope for this package
+
+- replacing existing MAIPJ/GAKW receipt work;
+- moving all standards into `prophet-platform`;
+- implementing runtime code before schemas are frozen;
+- treating SourceOS/SociOS packaging as the first landing zone.
+
+## First implementation epic
+
+The first implementation epic should produce a Phase 1 text-only KMaaS baseline:
+
+- one anchor domain;
+- one system-of-record manifest;
+- one bounded text corpus;
+- one metric contract record;
+- one phase-gate record;
+- one proof pack;
+- one audit-readable report;
+- one replay or reproduction path.

--- a/docs/kmaas/README.md
+++ b/docs/kmaas/README.md
@@ -1,0 +1,31 @@
+# KMaaS canonical package
+
+KMaaS is the SocioProphet product lane for trust-first governed knowledge and execution over client-owned data.
+
+This folder is the platform-facing source of truth for the KMaaS commercial and delivery doctrine. It translates the Drive sales-play artifact into repo-backed product material that can be referenced by runtime services, standards packages, dashboards, and engagement delivery work.
+
+## Reading order
+
+1. `KMAAS_DATA_SALES_PLAY.md` — buyer-facing offer, commercial posture, and trust-first value proposition.
+2. `KMAAS_DELIVERY_DOCTRINE.md` — implementation sequence, metric contract, phase gates, and channel ladder.
+3. `KMAAS_REPO_RESPONSIBILITY_MAP.md` — upstream ownership across Prophet Platform, AgentPlane, Sociosphere, Slash Topics, TriTRPC, Human Digital Twin, Ontogenesis, and standards repos.
+
+## Product invariant
+
+KMaaS is not generic search, generic RAG, or undifferentiated content management. KMaaS starts with a domain backbone and data-plane identity model, binds policy and evidence, then progressively onboards text, audio, and video under measurable phase gates.
+
+## Runtime invariant
+
+A KMaaS workflow is not production-grade unless it emits reviewable evidence: what happened, under which policy, with which inputs, where execution occurred, and how the result can be replayed or challenged.
+
+## Standards dependencies
+
+The platform implementation depends on standards-layer artifacts for:
+
+- metric contracts;
+- phase-gate records;
+- KPI pack definitions;
+- proof-pack envelopes;
+- relevance and retrieval evaluation rubrics.
+
+Those normative schemas belong in the SocioProphet standards repositories. This folder defines the product/runtime integration profile that consumes them.


### PR DESCRIPTION
## Summary

Adds the canonical KMaaS product/doctrine package under `docs/kmaas/`.

This lands the repo-backed source for the KMaaS Data Sales Play and delivery doctrine so the work is no longer stranded only in Drive.

## Files

- `docs/kmaas/README.md`
- `docs/kmaas/KMAAS_DATA_SALES_PLAY.md`
- `docs/kmaas/KMAAS_DELIVERY_DOCTRINE.md`
- `docs/kmaas/KMAAS_REPO_RESPONSIBILITY_MAP.md`

## Doctrine captured

- trust-first governed knowledge and execution
- proof packs / placement receipts / phase-gate evidence
- data-plane-first onboarding order
- text -> audio -> video channel ladder
- KMaaS metric contract and phase gates
- repo responsibility map across `prophet-platform`, `agentplane`, `sociosphere`, `slash-topics`, `TriTRPC`, `human-digital-twin`, `ontogenesis`, and standards repos

## Scope

Docs only. No runtime rewires, schema validation changes, dashboard routes, or CI behavior changes in this PR.

## Follow-ons

1. Add normative KMaaS schemas in the standards repo.
2. Add ontogenesis terms for KPI packs, metric contracts, proof packs, evidence spans, and domain backbones.
3. Wire the proof-pack / placement-receipt names into AgentPlane and Prophet Platform evidence-console surfaces.
