### PR TITLE
docs(openai-research-mcp): index runtime lane

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -12,6 +12,7 @@
 * `lampstand` — local-daemon integration target with platform receipt/catalog emission
 * `evidence-receipts` — platform reader surface for emitted payload/event/receipt artifacts
 * `evidence-console` — thin operator-facing surface over recent evidence and eval-fabric artifact views
+* `openai-research-mcp` — research MCP runtime starter
 
 ## Planned imports / promotions
 

--- a/apps/openai-research-mcp/schemas/artifact_handoff.schema.json
+++ b/apps/openai-research-mcp/schemas/artifact_handoff.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ArtifactHandoff",
+  "type": "object",
+  "required": ["artifact_id", "object_key", "sha256", "manifest_object_key"],
+  "properties": {
+    "artifact_id": {"type": "string"},
+    "object_key": {"type": "string"},
+    "sha256": {"type": "string"},
+    "manifest_object_key": {"type": "string"},
+    "download_url": {"type": "string", "format": "uri"}
+  },
+  "additionalProperties": false
+}

--- a/docs/INTEGRATION-MAP.md
+++ b/docs/INTEGRATION-MAP.md
@@ -28,6 +28,7 @@ Pinned upstream inputs include:
 - `apps/semantic-bridge` -> imported contract validation lane for envelope and membrane shapes
 - `apps/zone-router` -> zone-aware publication and topic-resolution lane
 - `apps/evidence-receipts` -> thin platform reader for emitted artifact bundles across current producer layouts, with gateway-read proxy support
+- `apps/openai-research-mcp` -> research MCP runtime starter
 
 ## Data and schema anchors
 


### PR DESCRIPTION
## Summary

Index the merged `apps/openai-research-mcp` runtime lane in the repo-native navigation surfaces and add a machine-checkable artifact handoff schema.

## Changes

- Add `openai-research-mcp` to `apps/README.md`
- Add `apps/openai-research-mcp` to `docs/INTEGRATION-MAP.md`
- Add `apps/openai-research-mcp/schemas/artifact_handoff.schema.json`

## Upstream-state note

This branch was created from current `main` at `6ee17aceafc5f4c22e133294746a808457ec6964`. Upstream moved again while the PR was being prepared, but the new upstream changes are in WOPI, cell-service, and FogStack shell/runtime files, not the files changed here.

## Scope

This PR is intentionally tiny and additive. It does not modify the runtime implementation, WOPI, cell-service, FogStack workflows, or platform validation code.