### PR TITLE
docs(search): add multicloud rollout prep and OpenShift compatibility

### DIFF
--- a/.github/workflows/search-orchestrator-multicloud-rollout.yml
+++ b/.github/workflows/search-orchestrator-multicloud-rollout.yml
@@ -1,0 +1,31 @@
+name: search-orchestrator-multicloud-rollout
+
+on:
+  pull_request:
+    paths:
+      - 'docs/SEARCH_ORCHESTRATOR_MULTICLOUD_ROLLOUT_PREP.md'
+      - 'releases/evidence/search-orchestrator-multicloud-rollout-matrix.v0.1.json'
+      - 'releases/evidence/search-orchestrator-multicloud-rollout-evidence.template.json'
+      - 'releases/evidence/search-orchestrator.multicloud-rollout-prep.validation.record.json'
+      - 'releases/manifests/search-orchestrator.multicloud-rollout-prep.manifest.json'
+      - 'tools/validate_search_orchestrator_multicloud_rollout.py'
+      - '.github/workflows/search-orchestrator-multicloud-rollout.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/SEARCH_ORCHESTRATOR_MULTICLOUD_ROLLOUT_PREP.md'
+      - 'releases/evidence/search-orchestrator-multicloud-rollout-matrix.v0.1.json'
+      - 'releases/evidence/search-orchestrator-multicloud-rollout-evidence.template.json'
+      - 'releases/evidence/search-orchestrator.multicloud-rollout-prep.validation.record.json'
+      - 'releases/manifests/search-orchestrator.multicloud-rollout-prep.manifest.json'
+      - 'tools/validate_search_orchestrator_multicloud_rollout.py'
+      - '.github/workflows/search-orchestrator-multicloud-rollout.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate Search Orchestrator multicloud rollout prep
+        run: python3 tools/validate_search_orchestrator_multicloud_rollout.py

--- a/docs/SEARCH_ORCHESTRATOR_MULTICLOUD_ROLLOUT_PREP.md
+++ b/docs/SEARCH_ORCHESTRATOR_MULTICLOUD_ROLLOUT_PREP.md
@@ -1,0 +1,120 @@
+# Search Orchestrator Multi-Cloud Rollout Preparation
+
+## Purpose
+
+This document prepares Search Orchestrator for later rollout across hyperscale, sovereign, regional, OpenShift-compatible, OKD-compatible, and bring-your-own-cloud Kubernetes environments.
+
+This is not live rollout evidence. It is the provider-neutral preparation surface. Real production completion still requires actual cluster captures.
+
+## Scope boundary
+
+This is a Search Orchestrator rollout-prep lane, not an Alexandrian Academy validator. Academy is one current consumer path. The provider taxonomy, OpenShift compatibility, storage expectations, and cloud evidence requirements are general deployment concerns for Search Orchestrator.
+
+## Deployment invariant
+
+Every provider rollout must preserve the same Search Orchestrator invariant:
+
+```text
+Search Orchestrator deployed from digest-pinned image
+→ policy overlay applies provider-safe secret and storage bindings
+→ health/config/metrics endpoints prove runtime state without leaking secrets
+→ workload evidence is captured for the selected consumer path
+→ release evidence records provider, cluster, image, policy, storage, and rollback posture
+```
+
+## Major provider taxonomy
+
+### Global hyperscalers
+
+The primary global providers we must model are:
+
+- AWS;
+- Microsoft Azure;
+- Google Cloud;
+- Oracle Cloud Infrastructure;
+- IBM Cloud;
+- Alibaba Cloud;
+- Huawei Cloud;
+- Tencent Cloud.
+
+### AI, edge, and developer clouds
+
+The rollout matrix also tracks providers that may matter for AI, edge, developer, bare-metal, and regional deployment:
+
+- Cloudflare;
+- Akamai/Linode;
+- DigitalOcean;
+- Vultr;
+- Equinix Metal;
+- CoreWeave;
+- Crusoe Cloud.
+
+### Regional and sovereign providers
+
+The rollout matrix keeps regional and sovereign candidates because data residency and procurement rules can force provider selection outside the global hyperscaler set.
+
+Examples include OVHcloud, Scaleway, Hetzner, IONOS, STACKIT, Open Telekom Cloud, Sakura Cloud, Naver Cloud, Kakao Cloud, KT Cloud, Core42/G42, STC Cloud, Ooredoo, Liquid Cloud, MTN Cloud, Vodacom Business, Claro/Embratel, Telefonica, Locaweb, UOL Host, Baidu AI Cloud, UCloud, and others.
+
+## OpenShift and OKD compatibility
+
+Search Orchestrator must remain compatible with:
+
+- generic Kubernetes;
+- Red Hat OpenShift;
+- OKD.
+
+The base deployment should avoid assumptions that break OpenShift restricted security context behavior.
+
+Required compatibility controls:
+
+- run as non-root;
+- no privileged container;
+- no hostPath dependency;
+- `allowPrivilegeEscalation: false`;
+- drop all Linux capabilities;
+- use `RuntimeDefault` seccomp;
+- avoid ConfigMap-backed secret material;
+- keep Policy Fabric endpoint Secret-backed;
+- use PVC-backed carrier storage;
+- keep OpenShift Route as an optional provider overlay rather than a base dependency.
+
+## Evidence required per provider
+
+Each provider rollout must capture:
+
+1. rendered manifests;
+2. ArgoCD or GitOps sync evidence;
+3. `/healthz` output;
+4. `/v1/search/debug/config` output;
+5. `/v1/search/debug/metrics` output;
+6. selected workload ingest/query proof;
+7. carrier or storage artifact proof where enabled;
+8. image digest pin verification;
+9. Secret or ExternalSecret binding verification;
+10. PVC/storage-class binding verification;
+11. NetworkPolicy verification or a documented CNI exception;
+12. rollback verification.
+
+## Provider-neutral preflight checklist
+
+Before any provider rollout:
+
+1. Verify digest lock exists.
+2. Verify rendered image reference is digest-pinned.
+3. Verify provider Secret/ExternalSecret path is selected.
+4. Verify storage class and PVC binding plan.
+5. Verify OpenShift/OKD compatibility constraints.
+6. Verify runtime debug endpoints redact paths, URLs, actors, queries, and secrets.
+7. Verify rollback and artifact retention policy.
+
+## Completion standard
+
+This preparation lane is complete when the repository contains:
+
+- this document;
+- a machine-readable provider matrix;
+- a Search Orchestrator multi-cloud rollout evidence template;
+- a validator dedicated to this lane;
+- a CI workflow for this validator.
+
+Production rollout is complete only after real provider evidence records are captured and committed.

--- a/docs/SEARCH_ORCHESTRATOR_MULTICLOUD_ROLLOUT_PREP.md
+++ b/docs/SEARCH_ORCHESTRATOR_MULTICLOUD_ROLLOUT_PREP.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document prepares Search Orchestrator for later rollout across hyperscale, sovereign, regional, OpenShift-compatible, OKD-compatible, and bring-your-own-cloud Kubernetes environments.
+This document prepares Search Orchestrator for later rollout across hyperscale, sovereign, regional, OpenShift-compatible, OKD-compatible, and BYOC/self-hosted Kubernetes environments.
 
 This is not live rollout evidence. It is the provider-neutral preparation surface. Real production completion still requires actual cluster captures.
 
@@ -106,6 +106,10 @@ Before any provider rollout:
 5. Verify OpenShift/OKD compatibility constraints.
 6. Verify runtime debug endpoints redact paths, URLs, actors, queries, and secrets.
 7. Verify rollback and artifact retention policy.
+
+## BYOC/self-hosted target
+
+BYOC/self-hosted deployment is a first-class target. It covers customer-owned Kubernetes, local/fog clusters, private OpenShift or OKD, and governed storage substrates such as Ceph, Longhorn, TopoLVM, NFS, or cloud-adjacent CSI backends.
 
 ## Completion standard
 

--- a/releases/evidence/search-orchestrator-multicloud-rollout-evidence.template.json
+++ b/releases/evidence/search-orchestrator-multicloud-rollout-evidence.template.json
@@ -1,0 +1,36 @@
+{
+  "evidence_id": "search-orchestrator-multicloud-rollout-evidence-template",
+  "component": "services/search-orchestrator",
+  "release_lane": "multicloud-rollout-prep",
+  "status": "template-pending-real-provider-capture",
+  "provider": "REPLACE_WITH_PROVIDER_ID",
+  "region": "REPLACE_WITH_PROVIDER_REGION",
+  "cluster_ref": "REPLACE_WITH_CLUSTER_REF",
+  "kubernetes_substrate": "REPLACE_WITH_KUBERNETES_SUBSTRATE",
+  "openshift_compatibility_target": "REPLACE_WITH_GENERIC_KUBERNETES_OR_OPENSHIFT_OR_OKD",
+  "git_sha": "REPLACE_WITH_DEPLOYED_GIT_SHA",
+  "image_lock_ref": "releases/images/search-orchestrator.image-lock.json",
+  "kustomize_overlay": "infra/k8s/search-orchestrator/overlays/policy",
+  "required_captures": {
+    "rendered_manifests": "REPLACE_WITH_RENDERED_MANIFESTS_ARTIFACT_REF",
+    "gitops_sync": "REPLACE_WITH_GITOPS_SYNC_ARTIFACT_REF",
+    "healthz": "REPLACE_WITH_HEALTHZ_CAPTURE_REF",
+    "debug_config": "REPLACE_WITH_DEBUG_CONFIG_CAPTURE_REF",
+    "debug_metrics": "REPLACE_WITH_DEBUG_METRICS_CAPTURE_REF",
+    "workload_ingest_query": "REPLACE_WITH_WORKLOAD_INGEST_QUERY_CAPTURE_REF",
+    "storage_or_carrier_artifacts": "REPLACE_WITH_STORAGE_OR_CARRIER_ARTIFACT_REF",
+    "rollback_verification": "REPLACE_WITH_ROLLBACK_VERIFICATION_REF",
+    "image_digest_pin_verification": "REPLACE_WITH_IMAGE_DIGEST_CAPTURE_REF",
+    "secret_or_externalsecret_binding": "REPLACE_WITH_SECRET_BINDING_CAPTURE_REF",
+    "pvc_storage_class_binding": "REPLACE_WITH_PVC_CAPTURE_REF",
+    "network_policy_or_cni_exception": "REPLACE_WITH_NETWORK_POLICY_CAPTURE_OR_EXCEPTION_REF",
+    "openshift_or_okd_compatibility_check": "REPLACE_WITH_OPENSHIFT_COMPAT_CAPTURE_REF"
+  },
+  "safety_assertions": [
+    "runtime debug surfaces must not expose paths, endpoint URLs, actor IDs, query strings, API keys, or secret values",
+    "debug metrics must expose counters only",
+    "provider secret binding must not use ConfigMap for secret material",
+    "image reference must use ghcr digest form or a provider-approved mirror with digest pinning",
+    "rollback verification must preserve evidence artifacts unless corruption is confirmed"
+  ]
+}

--- a/releases/evidence/search-orchestrator-multicloud-rollout-matrix.v0.1.json
+++ b/releases/evidence/search-orchestrator-multicloud-rollout-matrix.v0.1.json
@@ -1,0 +1,71 @@
+{
+  "matrix_id": "search-orchestrator-multicloud-rollout-matrix-v0.1",
+  "component": "services/search-orchestrator",
+  "release_lane": "multicloud-rollout-prep",
+  "status": "prepared-pending-real-provider-captures",
+  "global_hyperscalers": [
+    "aws",
+    "azure",
+    "google-cloud",
+    "oracle-cloud",
+    "ibm-cloud",
+    "alibaba-cloud",
+    "huawei-cloud",
+    "tencent-cloud"
+  ],
+  "ai_edge_and_developer_clouds": [
+    "cloudflare",
+    "akamai-linode",
+    "digitalocean",
+    "vultr",
+    "equinix-metal",
+    "coreweave",
+    "crusoe-cloud"
+  ],
+  "regional_and_sovereign_candidates": {
+    "north_america": ["aws", "azure", "google-cloud", "oracle-cloud", "ibm-cloud", "cloudflare", "akamai-linode", "digitalocean", "vultr", "equinix-metal", "coreweave", "crusoe-cloud"],
+    "south_america": ["aws", "azure", "google-cloud", "oracle-cloud", "ibm-cloud", "huawei-cloud", "claro-embratel", "telefonica", "locaweb", "uol-host"],
+    "europe": ["aws", "azure", "google-cloud", "oracle-cloud", "ibm-cloud", "ovhcloud", "scaleway", "stackit", "hetzner", "ionos", "open-telekom-cloud", "clever-cloud", "proximus", "post-telecom"],
+    "middle_east": ["aws", "azure", "google-cloud", "oracle-cloud", "alibaba-cloud", "huawei-cloud", "core42-g42", "eand-enterprise", "stc-cloud", "ooredoo"],
+    "africa": ["aws", "azure", "google-cloud", "oracle-cloud", "huawei-cloud", "liquid-cloud", "mtn-cloud", "vodacom-business", "africa-data-centres"],
+    "asia_pacific": ["aws", "azure", "google-cloud", "oracle-cloud", "ibm-cloud", "alibaba-cloud", "huawei-cloud", "tencent-cloud", "volcano-engine", "naver-cloud", "kakao-cloud", "kt-cloud", "sakura-cloud", "fujitsu-cloud", "nec-cloud", "ntt-global-data-centers"],
+    "china_mainland": ["alibaba-cloud", "huawei-cloud", "tencent-cloud", "volcano-engine", "baidu-ai-cloud", "ucloud"]
+  },
+  "kubernetes_substrates": {
+    "generic": ["conformant-kubernetes", "capi-cluster", "k3s", "rke2", "talos", "kind-lab"],
+    "managed": ["eks", "aks", "gke", "oke", "iks", "roks", "alibaba-ack", "tencent-tke", "huawei-cce", "openshift-dedicated", "aro", "rosa"],
+    "openshift_compatible": ["openshift", "okd", "red-hat-openshift-service-on-aws", "azure-red-hat-openshift", "red-hat-openshift-on-ibm-cloud"]
+  },
+  "openshift_compatibility": {
+    "required": true,
+    "targets": ["openshift", "okd", "generic-kubernetes"],
+    "scc_profile": "restricted-v2-compatible",
+    "required_controls": [
+      "runAsNonRoot",
+      "allowPrivilegeEscalation=false",
+      "drop all linux capabilities",
+      "RuntimeDefault seccomp",
+      "readOnlyRootFilesystem",
+      "no hostPath dependency",
+      "no privileged containers",
+      "Secret-backed Policy Fabric endpoint",
+      "PVC-backed carrier storage"
+    ],
+    "route_compatibility": "OpenShift Route may be added as a provider overlay; base remains Service/Kustomize portable"
+  },
+  "provider_evidence_required": [
+    "rendered_manifests",
+    "gitops_sync",
+    "healthz",
+    "debug_config",
+    "debug_metrics",
+    "workload_ingest_query",
+    "storage_or_carrier_artifacts",
+    "rollback_verification",
+    "image_digest_pin_verification",
+    "secret_or_externalsecret_binding",
+    "pvc_storage_class_binding",
+    "network_policy_or_cni_exception",
+    "openshift_or_okd_compatibility_check"
+  ]
+}

--- a/releases/evidence/search-orchestrator.multicloud-rollout-prep.validation.record.json
+++ b/releases/evidence/search-orchestrator.multicloud-rollout-prep.validation.record.json
@@ -1,0 +1,25 @@
+{
+  "validation_id": "search-orchestrator-multicloud-rollout-prep-v0.1-validation",
+  "component": "services/search-orchestrator",
+  "release_lane": "multicloud-rollout-prep",
+  "status": "passed",
+  "validated_artifacts": [
+    "docs/SEARCH_ORCHESTRATOR_MULTICLOUD_ROLLOUT_PREP.md",
+    "releases/evidence/search-orchestrator-multicloud-rollout-matrix.v0.1.json",
+    "releases/evidence/search-orchestrator-multicloud-rollout-evidence.template.json",
+    "releases/manifests/search-orchestrator.multicloud-rollout-prep.manifest.json",
+    "tools/validate_search_orchestrator_multicloud_rollout.py",
+    ".github/workflows/search-orchestrator-multicloud-rollout.yml"
+  ],
+  "coverage": [
+    "global provider matrix",
+    "regional provider matrix",
+    "OpenShift and OKD compatibility surface",
+    "provider evidence template",
+    "dedicated validator and workflow"
+  ],
+  "gates": [
+    "search-orchestrator-multicloud-rollout workflow",
+    "dedicated multicloud rollout validator"
+  ]
+}

--- a/releases/manifests/search-orchestrator.multicloud-rollout-prep.manifest.json
+++ b/releases/manifests/search-orchestrator.multicloud-rollout-prep.manifest.json
@@ -1,0 +1,32 @@
+{
+  "manifest_id": "search-orchestrator.multicloud-rollout-prep.v0.1",
+  "component": "services/search-orchestrator",
+  "release_lane": "multicloud-rollout-prep",
+  "version": "0.1.0",
+  "status": "prepared-pending-real-provider-captures",
+  "artifacts": [
+    "docs/SEARCH_ORCHESTRATOR_MULTICLOUD_ROLLOUT_PREP.md",
+    "releases/evidence/search-orchestrator-multicloud-rollout-matrix.v0.1.json",
+    "releases/evidence/search-orchestrator-multicloud-rollout-evidence.template.json",
+    "releases/evidence/search-orchestrator.multicloud-rollout-prep.validation.record.json",
+    "tools/validate_search_orchestrator_multicloud_rollout.py",
+    ".github/workflows/search-orchestrator-multicloud-rollout.yml"
+  ],
+  "coverage": [
+    "global-hyperscalers",
+    "regional-sovereign-providers",
+    "ai-edge-developer-clouds",
+    "generic-kubernetes",
+    "openshift",
+    "okd",
+    "byoc-self-hosted"
+  ],
+  "safety_posture": [
+    "no live rollout claim",
+    "provider evidence template only",
+    "OpenShift restricted-v2 compatibility surface",
+    "secret-backed endpoint expectation",
+    "PVC-backed storage expectation",
+    "digest-pinned image expectation"
+  ]
+}

--- a/tools/validate_search_orchestrator_multicloud_rollout.py
+++ b/tools/validate_search_orchestrator_multicloud_rollout.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+MATRIX = ROOT / "releases/evidence/search-orchestrator-multicloud-rollout-matrix.v0.1.json"
+GUIDE = ROOT / "docs/SEARCH_ORCHESTRATOR_MULTICLOUD_ROLLOUT_PREP.md"
+TEMPLATE = ROOT / "releases/evidence/search-orchestrator-multicloud-rollout-evidence.template.json"
+
+REQUIRED_GLOBAL = {
+    "aws",
+    "azure",
+    "google-cloud",
+    "oracle-cloud",
+    "ibm-cloud",
+    "alibaba-cloud",
+    "huawei-cloud",
+    "tencent-cloud",
+}
+
+REQUIRED_REGIONS = {
+    "north_america",
+    "south_america",
+    "europe",
+    "middle_east",
+    "africa",
+    "asia_pacific",
+    "china_mainland",
+}
+
+REQUIRED_EVIDENCE = {
+    "rendered_manifests",
+    "gitops_sync",
+    "healthz",
+    "debug_config",
+    "debug_metrics",
+    "workload_ingest_query",
+    "storage_or_carrier_artifacts",
+    "rollback_verification",
+    "image_digest_pin_verification",
+    "secret_or_externalsecret_binding",
+    "pvc_storage_class_binding",
+    "network_policy_or_cni_exception",
+    "openshift_or_okd_compatibility_check",
+}
+
+REQUIRED_OPENSHIFT = {
+    "openshift",
+    "okd",
+    "generic-kubernetes",
+}
+
+REQUIRED_GUIDE_TERMS = [
+    "Google Cloud",
+    "Azure",
+    "AWS",
+    "IBM Cloud",
+    "Oracle Cloud",
+    "Alibaba Cloud",
+    "Huawei Cloud",
+    "Tencent Cloud",
+    "OpenShift",
+    "OKD",
+    "BYOC/self-hosted",
+    "NetworkPolicy",
+    "ExternalSecret",
+]
+
+
+def main() -> int:
+    matrix = json.loads(MATRIX.read_text(encoding="utf-8"))
+    guide = GUIDE.read_text(encoding="utf-8")
+    template = TEMPLATE.read_text(encoding="utf-8")
+
+    missing_global = REQUIRED_GLOBAL.difference(matrix.get("global_hyperscalers", []))
+    if missing_global:
+        raise SystemExit(f"missing global providers: {sorted(missing_global)}")
+
+    region_map = matrix.get("regional_and_sovereign_candidates", {})
+    missing_regions = REQUIRED_REGIONS.difference(region_map)
+    if missing_regions:
+        raise SystemExit(f"missing regional provider coverage: {sorted(missing_regions)}")
+
+    for region, providers in region_map.items():
+        if not providers:
+            raise SystemExit(f"region {region} has no providers")
+
+    missing_evidence = REQUIRED_EVIDENCE.difference(matrix.get("provider_evidence_required", []))
+    if missing_evidence:
+        raise SystemExit(f"missing evidence requirements: {sorted(missing_evidence)}")
+
+    openshift_targets = set(matrix.get("openshift_compatibility", {}).get("targets", []))
+    missing_targets = REQUIRED_OPENSHIFT.difference(openshift_targets)
+    if missing_targets:
+        raise SystemExit(f"missing OpenShift compatibility targets: {sorted(missing_targets)}")
+
+    controls = "\n".join(matrix.get("openshift_compatibility", {}).get("required_controls", []))
+    for term in [
+        "runAsNonRoot",
+        "allowPrivilegeEscalation=false",
+        "RuntimeDefault seccomp",
+        "no privileged containers",
+        "PVC-backed carrier storage",
+    ]:
+        if term not in controls:
+            raise SystemExit(f"missing OpenShift control: {term}")
+
+    for term in REQUIRED_GUIDE_TERMS:
+        if term not in guide:
+            raise SystemExit(f"guide missing term: {term}")
+
+    for term in [
+        "template-pending-real-provider-capture",
+        "rendered_manifests",
+        "rollback_verification",
+        "openshift_or_okd_compatibility_check",
+    ]:
+        if term not in template:
+            raise SystemExit(f"template missing term: {term}")
+
+    print("search-orchestrator multicloud rollout preparation validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a provider-neutral Search Orchestrator multi-cloud rollout preparation lane, separated from Academy bridge deployment validation.

## Scope

- Adds Search Orchestrator multi-cloud rollout preparation guide
- Adds machine-readable provider matrix covering hyperscalers, regional/sovereign providers, AI/edge/developer clouds, generic Kubernetes, OpenShift, and OKD
- Adds provider-neutral rollout evidence template
- Adds dedicated multicloud rollout validator
- Adds dedicated CI workflow for the multicloud rollout prep lane
- Adds release manifest and validation evidence for the new lane

## Safety posture

- Preparation and validation only
- No live rollout claim
- No runtime route behavior change
- No learner action execution
- No Canon promotion
- No policy grant creation
- No memory writeback
- Academy deployment validator remains Academy-specific

## Program lane

Search Orchestrator provider-neutral multi-cloud and OpenShift-compatible rollout preparation.