### PR TITLE
Align telemetry with runtime control plane evidence

### DIFF
--- a/docs/PLATFORM_TELEMETRY_REQUIREMENTS.md
+++ b/docs/PLATFORM_TELEMETRY_REQUIREMENTS.md
@@ -12,6 +12,8 @@ This document defines runtime telemetry requirements for `prophet-platform`.
 - no write-on-read persistent cache mutation
 - scoped recovery instead of broad destructive cache purges
 - batched sender support with compression, retry, and unload delivery where supported
+- transport coverage across `fetch`, `XMLHttpRequest`, and beacon-style unload delivery
+- typed runtime-policy telemetry for retry, stream, cache, polling, connector-routing, and redaction behavior
 
 ## Required fields
 Signals should include:
@@ -32,8 +34,16 @@ Where relevant also include:
 - `recovery_policy`
 - `artifact_digest`
 - `policy_decision_id`
+- `agentplane_run_id`
+- `runtime_dry_run_record_ref`
+- `live_cluster_preflight_record_ref`
+- `identity_context_ref`
+
+## Runtime control-plane alignment
+Runtime telemetry must align with `docs/TELEMETRY_RUNTIME_CONTROL_PLANE_ALIGNMENT.md` for current FogStack dry-run, live-preflight, identity, PolicyPlane, AgentPlane, and parity-readiness evidence surfaces.
 
 ## Cross-repo alignment
 - `socioprophet-standards-storage/docs/standards/040-observability-otel.md`
-- `socioprophet-standards-storage/docs/standards/041-telemetry-control-plane-and-recovery.md`
+- `socioprophet-standards-storage/docs/standards/041-runtime-control-plane-telemetry.md`
 - `global-devsecops-intelligence/docs/architecture/telemetry-surface-profile.md`
+- `global-devsecops-intelligence/docs/architecture/runtime-control-plane-telemetry-alignment.md`

--- a/docs/TELEMETRY_EVENT_PLANE.md
+++ b/docs/TELEMETRY_EVENT_PLANE.md
@@ -1,3 +1,32 @@
 # Telemetry Event Plane
 
 Defines platform runtime telemetry topic families and required event fields.
+
+## Runtime control-plane alignment
+
+This event plane is extended by `docs/TELEMETRY_RUNTIME_CONTROL_PLANE_ALIGNMENT.md`, which binds telemetry to current runtime evidence records including FogStack dry-run records, live-cluster preflight records, identity context, AgentPlane runs, PolicyPlane decisions, parity-readiness records, and evidence indexes.
+
+## Topic families
+
+The platform SHOULD publish or normalize telemetry across these topic families:
+
+- `platform.telemetry.runtime.v1`
+- `platform.telemetry.control.v1`
+- `platform.telemetry.recovery.v1`
+- `platform.telemetry.evidence.v1`
+- `platform.telemetry.policy.v1`
+
+## Required correlation
+
+Runtime-control-plane events SHOULD preserve:
+
+- `trace_id`
+- `request_id`
+- `build_id`
+- `artifact_digest`
+- `policyplane_decision_id`
+- `agentplane_run_id`
+- `runtime_dry_run_record_ref`
+- `live_cluster_preflight_record_ref`
+- `identity_context_ref`
+- `parity_readiness_record_ref`

--- a/docs/TELEMETRY_RUNTIME_CONTROL_PLANE_ALIGNMENT.md
+++ b/docs/TELEMETRY_RUNTIME_CONTROL_PLANE_ALIGNMENT.md
@@ -1,0 +1,60 @@
+# Telemetry Runtime Control Plane Alignment
+
+## Purpose
+This document aligns the existing platform telemetry baseline with the current `prophet-platform` runtime evidence graph.
+
+The April telemetry baseline remains valid, but the platform has since added identity contracts, FogStack runtime dry-run records, live cluster preflight records, AgentPlane linkage, PolicyPlane linkage, and parity-readiness evidence. Telemetry must now bind to those records explicitly.
+
+## Current runtime anchors
+Telemetry consumers SHOULD treat the following platform artifacts as first-class runtime evidence anchors:
+
+- `schemas/runtime/fogstack-runtime-dry-run-record-v0.1.schema.json`
+- `schemas/runtime/fogstack-live-cluster-preflight-record-v0.1.schema.json`
+- `tools/emit_fogstack_runtime_dry_run_record.py`
+- `tools/emit_fogstack_live_cluster_preflight_record.py`
+- `tools/check_fogstack_parity_readiness.py`
+- `tools/validate_identity_contract_examples.py`
+- `docs/PLATFORM_TELEMETRY_REQUIREMENTS.md`
+- `docs/TELEMETRY_EVENT_PLANE.md`
+
+## Required telemetry bindings
+Runtime telemetry SHOULD emit or preserve correlation for:
+
+- `agentplane_run_id`
+- `policyplane_decision_id`
+- `artifact_digest`
+- `runtime_dry_run_record_ref`
+- `live_cluster_preflight_record_ref`
+- `identity_context_ref`
+- `parity_readiness_record_ref`
+- `evidence_index_ref`
+
+## Control-plane signal families
+The platform SHOULD distinguish:
+
+- `runtime.bootstrap.*`
+- `runtime.identity.*`
+- `runtime.dry_run.*`
+- `runtime.live_preflight.*`
+- `runtime.policy_decision.*`
+- `runtime.agentplane_run.*`
+- `runtime.recovery.*`
+- `runtime.parity_readiness.*`
+
+## Policy alignment
+Telemetry MUST preserve whether a runtime path is read-only, dry-run, safely blocked, approval-required, or live-apply capable.
+
+For FogStack live-cluster surfaces, telemetry MUST preserve:
+
+- `live_apply_allowed`
+- `mutated_cluster`
+- `human_approval_required`
+- `preflight_status`
+
+## Relationship to standards
+This document consumes the upstream standard:
+
+- `socioprophet-standards-storage/docs/standards/041-runtime-control-plane-telemetry.md`
+
+## Follow-on implementation
+The next implementation tranche SHOULD add JSON schemas or examples for canonical runtime telemetry envelopes that reference the existing FogStack runtime and identity records.


### PR DESCRIPTION
Replaces draft PR #390, which was closed because the connector draft-to-ready mutation is broken. Adds runtime-control-plane telemetry alignment against current FogStack dry-run, live-preflight, identity, AgentPlane, PolicyPlane, and parity-readiness evidence surfaces, and cross-links platform telemetry docs to the new alignment surface.