### PR TITLE
apps(openai-research-mcp): add HTTP search fetch backend

### DIFF
--- a/apps/openai-research-mcp/research_mcp/errors.py
+++ b/apps/openai-research-mcp/research_mcp/errors.py
@@ -27,3 +27,13 @@ class ForbiddenError(ResearchMcpError):
 class DocumentNotFoundError(ResearchMcpError):
     def __init__(self, message: str = "document not found"):
         super().__init__("document_not_found", message, 404)
+
+
+class BackendUnavailableError(ResearchMcpError):
+    def __init__(self, message: str = "backend unavailable"):
+        super().__init__("backend_unavailable", message, 502)
+
+
+class BackendProtocolError(ResearchMcpError):
+    def __init__(self, message: str = "backend protocol error"):
+        super().__init__("backend_protocol_error", message, 502)

--- a/apps/openai-research-mcp/research_mcp/store.py
+++ b/apps/openai-research-mcp/research_mcp/store.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from urllib.parse import urlparse
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlparse
+from urllib.request import Request, urlopen
 
-from .errors import DocumentNotFoundError, InvalidInputError
+from .errors import BackendProtocolError, BackendUnavailableError, DocumentNotFoundError, InvalidInputError
 from .models import AuthContext, Document
 
 
@@ -15,10 +18,9 @@ def validate_canonical_url(url: str) -> str:
     return parsed._replace(fragment="").geturl()
 
 
-def load_documents_from_json(path: Path) -> list[Document]:
-    data = json.loads(path.read_text(encoding="utf-8"))
-    return [
-        Document(
+def _document_from_mapping(item: dict[str, Any]) -> Document:
+    try:
+        return Document(
             id=str(item["id"]),
             title=str(item["title"]),
             text=str(item.get("text", "")),
@@ -28,8 +30,13 @@ def load_documents_from_json(path: Path) -> list[Document]:
             allowed_subjects=tuple(item.get("allowed_subjects", [])),
             tags=tuple(item.get("tags", [])),
         )
-        for item in data
-    ]
+    except KeyError as exc:
+        raise BackendProtocolError(f"missing document field: {exc.args[0]}") from exc
+
+
+def load_documents_from_json(path: Path) -> list[Document]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return [_document_from_mapping(item) for item in data]
 
 
 class InMemoryDocumentBackend:
@@ -60,3 +67,63 @@ class InMemoryDocumentBackend:
         if not doc.is_visible_to(auth_context):
             raise DocumentNotFoundError()
         return doc
+
+
+class HttpSearchFetchBackend:
+    """Small stdlib-only adapter for an upstream search/fetch service.
+
+    Expected upstream contract:
+    - GET /search?q=<query>&limit=<n> -> {"results": [{"id", "title", "url", ...}]}
+    - GET /fetch?id=<document_id> -> {"id", "title", "text", "url", ...}
+    """
+
+    def __init__(self, base_url: str, *, timeout_seconds: float = 5.0):
+        self.base_url = base_url.rstrip("/")
+        parsed = urlparse(self.base_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise InvalidInputError("backend base_url must be an absolute HTTP(S) URL")
+        self.timeout_seconds = timeout_seconds
+
+    def _headers(self, auth_context: AuthContext) -> dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if auth_context.subject:
+            headers["X-Subject"] = auth_context.subject
+        if auth_context.organization:
+            headers["X-Organization"] = auth_context.organization
+        if auth_context.scopes:
+            headers["X-Scopes"] = " ".join(auth_context.scopes)
+        return headers
+
+    def _get_json(self, path: str, params: dict[str, str], auth_context: AuthContext) -> dict[str, Any]:
+        url = f"{self.base_url}{path}?{urlencode(params)}"
+        request = Request(url, headers=self._headers(auth_context), method="GET")
+        try:
+            with urlopen(request, timeout=self.timeout_seconds) as response:
+                raw = response.read().decode("utf-8")
+        except HTTPError as exc:
+            if exc.code == 404:
+                raise DocumentNotFoundError() from exc
+            raise BackendUnavailableError(f"backend returned HTTP {exc.code}") from exc
+        except URLError as exc:
+            raise BackendUnavailableError(str(exc.reason)) from exc
+        except TimeoutError as exc:
+            raise BackendUnavailableError("backend request timed out") from exc
+
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise BackendProtocolError("backend returned invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise BackendProtocolError("backend JSON response must be an object")
+        return payload
+
+    def search(self, query: str, *, limit: int, auth_context: AuthContext) -> list[Document]:
+        payload = self._get_json("/search", {"q": query, "limit": str(limit)}, auth_context)
+        results = payload.get("results")
+        if not isinstance(results, list):
+            raise BackendProtocolError("search response must contain results array")
+        return [_document_from_mapping(item) for item in results[:limit]]
+
+    def fetch(self, document_id: str, *, auth_context: AuthContext) -> Document:
+        payload = self._get_json("/fetch", {"id": document_id}, auth_context)
+        return _document_from_mapping(payload)

--- a/apps/openai-research-mcp/tests/test_http_backend.py
+++ b/apps/openai-research-mcp/tests/test_http_backend.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from research_mcp.errors import BackendProtocolError, DocumentNotFoundError
+from research_mcp.models import AuthContext
+from research_mcp.store import HttpSearchFetchBackend
+
+
+class _BackendHandler(BaseHTTPRequestHandler):
+    seen_headers: dict[str, str] = {}
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A002 - stdlib signature
+        return None
+
+    def _send_json(self, status: int, payload):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        _BackendHandler.seen_headers = {key: value for key, value in self.headers.items()}
+        parsed = urlparse(self.path)
+        query = parse_qs(parsed.query)
+        if parsed.path == "/search":
+            q = query.get("q", [""])[0]
+            if q == "malformed":
+                return self._send_json(200, {"results": {"not": "a list"}})
+            return self._send_json(
+                200,
+                {
+                    "results": [
+                        {
+                            "id": "remote-doc",
+                            "title": "Remote Canonical Doc",
+                            "text": "remote body",
+                            "url": "https://example.com/remote#fragment",
+                            "metadata": {"source": "remote"},
+                        }
+                    ]
+                },
+            )
+        if parsed.path == "/fetch":
+            document_id = query.get("id", [""])[0]
+            if document_id == "missing":
+                return self._send_json(404, {"error": "not_found"})
+            if document_id == "bad-url":
+                return self._send_json(200, {"id": "bad-url", "title": "Bad", "text": "bad", "url": "/relative"})
+            return self._send_json(
+                200,
+                {
+                    "id": document_id,
+                    "title": "Fetched Remote Doc",
+                    "text": "remote fetch body",
+                    "url": "https://example.com/fetched#ignored",
+                },
+            )
+        return self._send_json(404, {"error": "not_found"})
+
+
+class HttpBackendTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), _BackendHandler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        host, port = cls.server.server_address
+        cls.base_url = f"http://{host}:{port}"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.thread.join(timeout=5)
+
+    def test_search_forwards_identity_headers_and_normalizes_urls(self):
+        backend = HttpSearchFetchBackend(self.base_url)
+        auth = AuthContext(subject="subject-a", organization="org-a", scopes=("documents:read",))
+
+        docs = backend.search("canonical", limit=5, auth_context=auth)
+
+        self.assertEqual([doc.id for doc in docs], ["remote-doc"])
+        self.assertEqual(docs[0].url, "https://example.com/remote")
+        self.assertEqual(_BackendHandler.seen_headers.get("X-Subject"), "subject-a")
+        self.assertEqual(_BackendHandler.seen_headers.get("X-Organization"), "org-a")
+        self.assertEqual(_BackendHandler.seen_headers.get("X-Scopes"), "documents:read")
+
+    def test_fetch_maps_404_to_document_not_found(self):
+        backend = HttpSearchFetchBackend(self.base_url)
+        with self.assertRaises(DocumentNotFoundError):
+            backend.fetch("missing", auth_context=AuthContext(anonymous_read=True))
+
+    def test_search_rejects_malformed_results_payload(self):
+        backend = HttpSearchFetchBackend(self.base_url)
+        with self.assertRaises(BackendProtocolError):
+            backend.search("malformed", limit=5, auth_context=AuthContext(anonymous_read=True))
+
+    def test_fetch_rejects_invalid_canonical_url(self):
+        backend = HttpSearchFetchBackend(self.base_url)
+        with self.assertRaises(Exception):
+            backend.fetch("bad-url", auth_context=AuthContext(anonymous_read=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add the first real backend adapter seam for `openai-research-mcp`: a stdlib-only HTTP search/fetch backend.

## Changes

- add `BackendUnavailableError` and `BackendProtocolError`
- add `_document_from_mapping(...)` to centralize upstream document normalization
- add `HttpSearchFetchBackend`
- forward subject, organization, and scope context to upstream services via headers
- normalize canonical URLs and strip fragments from upstream results
- map upstream HTTP 404 to `DocumentNotFoundError`
- map malformed upstream payloads and invalid JSON to explicit backend protocol errors
- add focused in-process HTTP backend tests without external dependencies

## Upstream-state note

This branch was created from current `main` at `65ab4ac7a3d5c4d1caca70b2ab99492b10dc68b5`, after the backend-store test foundation merged.

## Scope

This does not change the default runtime path. The in-memory backend remains the default. This PR only adds an adapter and tests so a real retrieval service can be wired next.