### PR TITLE
fogstack: add plan-only live apply record

### DIFF
--- a/.github/workflows/fogstack-live-apply-plan.yml
+++ b/.github/workflows/fogstack-live-apply-plan.yml
@@ -1,0 +1,41 @@
+name: FogStack Live Apply Plan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "schemas/runtime/fogstack-live-apply-plan-record-v0.1.schema.json"
+      - "tools/emit_fogstack_live_apply_plan_record.py"
+      - "tools/tests/test_fogstack_live_apply_plan_record.py"
+      - ".github/workflows/fogstack-live-apply-plan.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/runtime/fogstack-live-apply-plan-record-v0.1.schema.json"
+      - "tools/emit_fogstack_live_apply_plan_record.py"
+      - "tools/tests/test_fogstack_live_apply_plan_record.py"
+      - ".github/workflows/fogstack-live-apply-plan.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  live-plan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest jsonschema
+
+      - name: Run focused tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_live_apply_plan_record.py

--- a/schemas/runtime/fogstack-live-apply-plan-record-v0.1.schema.json
+++ b/schemas/runtime/fogstack-live-apply-plan-record-v0.1.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/runtime/fogstack-live-apply-plan-record-v0.1.schema.json",
+  "title": "FogStackLiveApplyPlanRecord",
+  "type": "object",
+  "required": ["kind", "schema_version", "status", "mode", "safety"],
+  "properties": {
+    "kind": { "const": "FogStackLiveApplyPlanRecord" },
+    "schema_version": { "const": "v0.1" },
+    "status": { "enum": ["passed", "blocked"] },
+    "mode": { "const": "plan-only" },
+    "safety": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/tools/emit_fogstack_live_apply_plan_record.py
+++ b/tools/emit_fogstack_live_apply_plan_record.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def artifact(path: Path, artifact_id: str) -> dict[str, str]:
+    path = resolve(path)
+    if not path.exists() or not path.is_file():
+        raise SystemExit(f"ERR: required artifact missing: {path}")
+    return {"id": artifact_id, "ref": rel(path), "digest": sha256_file(path)}
+
+
+def preflight_safe(preflight: dict[str, Any]) -> bool:
+    safety = preflight.get("safety") if isinstance(preflight.get("safety"), dict) else {}
+    return (
+        preflight.get("kind") == "FogStackLiveClusterPreflightRecord"
+        and preflight.get("mode") == "read-only-live-preflight"
+        and preflight.get("status") in {"passed", "blocked"}
+        and safety.get("mutated_cluster") is False
+        and safety.get("live_apply_allowed") is False
+    )
+
+
+def preflight_ready(preflight: dict[str, Any]) -> bool:
+    return preflight_safe(preflight) and preflight.get("status") == "passed"
+
+
+def emit_record(
+    *,
+    deploy_plan_path: Path,
+    live_preflight_path: Path,
+    output_path: Path,
+    agentplane_ref: str,
+    policyplane_ref: str,
+    requested_by: str,
+) -> dict[str, Any]:
+    deploy_plan_path = resolve(deploy_plan_path)
+    live_preflight_path = resolve(live_preflight_path)
+    output_path = resolve(output_path)
+    deploy_plan = load_json(deploy_plan_path)
+    preflight = load_json(live_preflight_path)
+    if deploy_plan.get("kind") != "FogStackDeployPlan":
+        raise SystemExit("ERR: expected FogStackDeployPlan")
+    if not preflight_safe(preflight):
+        raise SystemExit("ERR: live preflight record is unsafe for planning")
+
+    ready = preflight_ready(preflight)
+    record = {
+        "kind": "FogStackLiveApplyPlanRecord",
+        "schema_version": "v0.1",
+        "status": "passed" if ready else "blocked",
+        "mode": "plan-only",
+        "bundle_id": deploy_plan.get("bundle_id"),
+        "version": deploy_plan.get("version"),
+        "namespace": deploy_plan.get("namespace") or preflight.get("namespace"),
+        "target": deploy_plan.get("target"),
+        "deploy_plan_ref": rel(deploy_plan_path),
+        "deploy_plan_digest": sha256_file(deploy_plan_path),
+        "live_preflight_ref": rel(live_preflight_path),
+        "live_preflight_digest": sha256_file(live_preflight_path),
+        "live_preflight_status": preflight.get("status"),
+        "agentplane": {
+            "agentplane_ref": agentplane_ref,
+            "requested_by": requested_by,
+            "mode": "plan-only",
+            "future_execution_run_required": True,
+        },
+        "policyplane": {
+            "policyplane_ref": policyplane_ref,
+            "decision": "allow-plan-deny-run",
+            "future_execute_decision_required": True,
+            "human_approval_required": True,
+        },
+        "safety": {
+            "plan_only": True,
+            "run_performed": False,
+            "mutated_cluster": False,
+            "live_apply_allowed": False,
+            "future_approval_record_required": True,
+            "rollback_plan_required": True,
+        },
+        "planned_resources": ["ConfigMap", "Deployment", "Service"],
+        "blockers": [] if ready else ["live preflight is blocked"],
+        "source_artifacts": [
+            artifact(deploy_plan_path, "deploy-plan"),
+            artifact(live_preflight_path, "live-cluster-preflight-record"),
+        ],
+    }
+    write_json(output_path, record)
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a plan-only FogStack live apply plan record")
+    parser.add_argument("--deploy-plan", required=True, type=Path)
+    parser.add_argument("--live-preflight", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--require-ready", action="store_true")
+    parser.add_argument("--agentplane-ref", default="github://SocioProphet/agentplane")
+    parser.add_argument("--policyplane-ref", default="github://SocioProphet/policy-fabric")
+    parser.add_argument("--requested-by", default="human:operator")
+    args = parser.parse_args()
+
+    record = emit_record(
+        deploy_plan_path=args.deploy_plan,
+        live_preflight_path=args.live_preflight,
+        output_path=args.output,
+        agentplane_ref=args.agentplane_ref,
+        policyplane_ref=args.policyplane_ref,
+        requested_by=args.requested_by,
+    )
+    print(json.dumps(record, indent=2))
+    if args.require_ready and record["status"] != "passed":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_live_apply_plan_record.py
+++ b/tools/tests/test_fogstack_live_apply_plan_record.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import jsonschema
+
+
+SCHEMA = Path("schemas/runtime/fogstack-live-apply-plan-record-v0.1.schema.json")
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def read_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def validate_record(record: dict) -> None:
+    jsonschema.validate(record, read_json(SCHEMA))
+
+
+def deploy_plan(path: Path) -> None:
+    write_json(path, {
+        "kind": "FogStackDeployPlan",
+        "schema_version": "v0.1",
+        "bundle_id": "fogstack.access",
+        "version": "0.1.0",
+        "namespace": "fogstack-access",
+        "target": "kubernetes",
+    })
+
+
+def preflight(path: Path, status: str) -> None:
+    write_json(path, {
+        "kind": "FogStackLiveClusterPreflightRecord",
+        "schema_version": "v0.1",
+        "status": status,
+        "reason": None if status == "passed" else "test blocked fixture",
+        "namespace": "fogstack-access",
+        "mode": "read-only-live-preflight",
+        "kubectl": {"executable": "kubectl", "available": status == "passed", "resolved_path": "/tmp/kubectl" if status == "passed" else None},
+        "source_artifacts": [],
+        "safety": {
+            "mutation_mode": "read-only",
+            "mutated_cluster": False,
+            "live_apply_allowed": False,
+            "human_approval_required_for_apply": True,
+        },
+        "checks": [],
+        "read_operations": [],
+        "errors": [],
+    })
+
+
+def run_plan(tmp_path: Path, status: str, *extra: str) -> subprocess.CompletedProcess[str]:
+    plan_path = tmp_path / "deploy-plan.json"
+    preflight_path = tmp_path / "preflight.json"
+    output = tmp_path / "plan-record.json"
+    deploy_plan(plan_path)
+    preflight(preflight_path, status)
+    return subprocess.run([
+        sys.executable,
+        "tools/emit_fogstack_live_apply_plan_record.py",
+        "--deploy-plan", str(plan_path),
+        "--live-preflight", str(preflight_path),
+        "--output", str(output),
+        *extra,
+    ], capture_output=True, text=True)
+
+
+def test_plan_blocks_when_preflight_is_blocked(tmp_path: Path) -> None:
+    proc = run_plan(tmp_path, "blocked")
+    assert proc.returncode == 0, proc.stderr
+    record = read_json(tmp_path / "plan-record.json")
+    validate_record(record)
+    assert record["kind"] == "FogStackLiveApplyPlanRecord"
+    assert record["status"] == "blocked"
+    assert record["mode"] == "plan-only"
+    assert record["live_preflight_status"] == "blocked"
+    assert record["safety"]["plan_only"] is True
+    assert record["safety"]["run_performed"] is False
+    assert record["safety"]["mutated_cluster"] is False
+    assert record["safety"]["live_apply_allowed"] is False
+    assert record["blockers"] == ["live preflight is blocked"]
+
+
+def test_plan_passes_when_preflight_passes(tmp_path: Path) -> None:
+    proc = run_plan(tmp_path, "passed")
+    assert proc.returncode == 0, proc.stderr
+    record = read_json(tmp_path / "plan-record.json")
+    validate_record(record)
+    assert record["status"] == "passed"
+    assert record["live_preflight_status"] == "passed"
+    assert record["blockers"] == []
+    assert record["agentplane"]["agentplane_ref"] == "github://SocioProphet/agentplane"
+    assert record["policyplane"]["policyplane_ref"] == "github://SocioProphet/policy-fabric"
+    assert record["policyplane"]["decision"] == "allow-plan-deny-run"
+    assert record["planned_resources"] == ["ConfigMap", "Deployment", "Service"]
+
+
+def test_require_ready_fails_when_preflight_is_blocked(tmp_path: Path) -> None:
+    proc = run_plan(tmp_path, "blocked", "--require-ready")
+    assert proc.returncode == 1
+    record = read_json(tmp_path / "plan-record.json")
+    validate_record(record)
+    assert record["status"] == "blocked"


### PR DESCRIPTION
Replacement for stale PR #397.

Deployment parity tranche B / plan-only live apply record v0.1.

This adds a plan-only `FogStackLiveApplyPlanRecord` surface. It does not execute live apply, does not run kubectl, does not trigger GitOps sync, and does not mutate cluster state.

Changes:
- add `tools/emit_fogstack_live_apply_plan_record.py`
- add minimal `schemas/runtime/fogstack-live-apply-plan-record-v0.1.schema.json`
- add behavior-heavy tests in `tools/tests/test_fogstack_live_apply_plan_record.py`
- add focused workflow `.github/workflows/fogstack-live-apply-plan.yml`

Safety boundary:
- record mode is `plan-only`
- `run_performed=false`
- `mutated_cluster=false`
- `live_apply_allowed=false`
- future approval record required
- future AgentPlane execution run required
- future PolicyPlane execute decision required
- rollback plan required before future execution

Planning behavior:
- emits `blocked` when the live preflight record is safely blocked
- emits `passed` only when the live preflight record is passed
- `--require-ready` fails when preflight is blocked

Note: `main` is moving quickly. This branch was refreshed from latest observed main and then main advanced again before PR creation. If premerge-audit reports stale branch, refresh this same four-file patch on top of latest main.