### PR TITLE
docs(identity): align anonymous reputation contracts with identity-prime v2

### DIFF
--- a/apps/identity-prime/docs/anonymous-reputation-consumption.md
+++ b/apps/identity-prime/docs/anonymous-reputation-consumption.md
@@ -1,0 +1,45 @@
+# identity-prime Anonymous Reputation Consumption
+
+## Purpose
+
+This note binds the already-merged anonymous reputation contracts to the `identity-prime` contract-consumption lane without claiming a runtime implementation.
+
+The intent is to keep scoped anonymous reputation subordinate to the identity proof and subject-normalization path.
+
+## Inputs
+
+The anonymous reputation lane should consume:
+
+- `contracts/identity/IdentityProofIngressRecord.v0.1.json`
+- `contracts/identity/IdentitySubjectContext.v0.1.json`
+- `contracts/identity/IdentitySessionContext.v0.1.json` when session semantics are implemented
+
+## Runtime-adjacent contracts
+
+The following top-level contracts are currently consumed as constitutional-floor runtime contracts:
+
+- `contracts/LinkabilityScope.v0.1.json`
+- `contracts/AnonymousReputationReceipt.v0.1.json`
+- `contracts/RevocationToken.v0.1.json`
+- `contracts/TraceOpenRequest.v0.1.json`
+
+## Intended flow
+
+1. Receive an accepted or inconclusive identity proof ingress result.
+2. Normalize subject context and assurance level.
+3. Resolve whether a constitutional or guild scope permits pseudonymous participation.
+4. Select or create a `LinkabilityScope` for that bounded scope.
+5. Emit an `AnonymousReputationReceipt` for qualifying scoped activity.
+6. Only emit `RevocationToken` or `TraceOpenRequest` under a declared authority path and trigger policy.
+
+## Runtime constraints
+
+- Anonymous reputation must not create identity.
+- Anonymous reputation must not weaken assurance requirements.
+- Linkability must be scoped.
+- Trace-open must be authority-bound and policy-referenced.
+- Revocation must be recorded as a policy-governed event, not an informal operator action.
+
+## Non-goals
+
+This note does not implement anonymous credentials, zero-knowledge proofs, revocation registries, trace-open execution, or session behavior. It documents the intended consumption boundary for future narrow runtime PRs.

--- a/contracts/identity/anonymous-reputation-boundary.md
+++ b/contracts/identity/anonymous-reputation-boundary.md
@@ -1,0 +1,34 @@
+# Anonymous Reputation Boundary
+
+## Purpose
+
+This note records how the platform-facing anonymous reputation contracts relate to the identity contract lane.
+
+The current anonymous reputation contracts live at the top level of `contracts/` because they were introduced as runtime/materialization contracts for Alexandrian constitutional-floor work:
+
+- `contracts/AnonymousReputationReceipt.v0.1.json`
+- `contracts/LinkabilityScope.v0.1.json`
+- `contracts/RevocationToken.v0.1.json`
+- `contracts/TraceOpenRequest.v0.1.json`
+
+They are identity-adjacent, but they are not replacements for identity proof, subject normalization, or session state.
+
+## Boundary rule
+
+Anonymous reputation contracts must consume or reference normalized identity/seam outputs; they must not become a parallel identity system.
+
+The expected ordering is:
+
+1. `IdentityProofIngressRecord` records proof ingress result.
+2. `IdentitySubjectContext` normalizes subject, tenant, assurance, and policy context.
+3. `LinkabilityScope` defines a bounded scope where repeated pseudonymous actions may be publicly or auditor-linkable.
+4. `AnonymousReputationReceipt` records a scoped reputation event under a pseudonymous subject commitment.
+5. `RevocationToken` and `TraceOpenRequest` provide bounded accountability paths when policy permits.
+
+## Non-goals
+
+This note does not implement cryptography, authentication, revocation, trace-open, or session behavior. It prevents contract drift while those runtime seams are designed.
+
+## Follow-on
+
+A later PR may move these schemas under `contracts/identity/anonymous-reputation/` after runtime consumption and validation paths are stable.

--- a/docs/generated/identity/anonymous-reputation/examples/anonymous_reputation_receipt.example.v0.1.json
+++ b/docs/generated/identity/anonymous-reputation/examples/anonymous_reputation_receipt.example.v0.1.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.1",
+  "receipt_id": "ANON-REP-RECEIPT-EXAMPLE-0001",
+  "created_at": "2026-05-05T00:05:00Z",
+  "scope_ref": "GUILD-ALEXANDRIAN-REASONING",
+  "pseudonymous_subject_commitment": "commitment-example-000000000001",
+  "event_type": "moderation",
+  "event_ref": "MOD-EVENT-EXAMPLE-0001",
+  "linkability_scope_ref": "LINK-SCOPE-ALEXANDRIAN-REVIEW-0001",
+  "reputation_delta": 0.25,
+  "evidence_refs": [
+    "AegisVault://evidence/example-0001",
+    "MembraneDecision://example/0001"
+  ],
+  "revocation_token_ref": "REVOCATION-TOKEN-EXAMPLE-0001",
+  "trace_open_supported": true,
+  "receipt": {
+    "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "algo": "sha256"
+  }
+}

--- a/docs/generated/identity/anonymous-reputation/examples/linkability_scope.example.v0.1.json
+++ b/docs/generated/identity/anonymous-reputation/examples/linkability_scope.example.v0.1.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.1",
+  "scope_id": "LINK-SCOPE-ALEXANDRIAN-REVIEW-0001",
+  "created_at": "2026-05-05T00:00:00Z",
+  "scope_type": "guild",
+  "scope_ref": "GUILD-ALEXANDRIAN-REASONING",
+  "linkability_policy": "public_within_scope",
+  "revocation_supported": true,
+  "verifier_local_revocation_supported": true,
+  "trace_open_authority": {
+    "authority_ref": "AUTHORITY-CONSTITUTIONAL-PANEL-0001",
+    "trigger_policy_ref": "POLICY-ALEXANDRIAN-TRACE-OPEN-0001"
+  }
+}

--- a/docs/generated/identity/anonymous-reputation/examples/revocation_token.example.v0.1.json
+++ b/docs/generated/identity/anonymous-reputation/examples/revocation_token.example.v0.1.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "token_id": "REVOCATION-TOKEN-EXAMPLE-0001",
+  "scope_ref": "GUILD-ALEXANDRIAN-REASONING",
+  "subject_commitment": "commitment-example-000000000001",
+  "issued_at": "2026-05-05T00:10:00Z",
+  "issuer_ref": "AUTHORITY-CONSTITUTIONAL-PANEL-0001",
+  "reason_code": "constitutional_review_scope_violation",
+  "evidence_refs": [
+    "ConstitutionalReviewEvent://example/0001"
+  ],
+  "status": "active"
+}

--- a/docs/generated/identity/anonymous-reputation/examples/trace_open_request.example.v0.1.json
+++ b/docs/generated/identity/anonymous-reputation/examples/trace_open_request.example.v0.1.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.1",
+  "request_id": "TRACE-OPEN-REQUEST-EXAMPLE-0001",
+  "created_at": "2026-05-05T00:15:00Z",
+  "scope_ref": "GUILD-ALEXANDRIAN-REASONING",
+  "subject_commitment": "commitment-example-000000000001",
+  "authority_ref": "AUTHORITY-CONSTITUTIONAL-PANEL-0001",
+  "trigger_type": "constitutional_review",
+  "policy_refs": [
+    "POLICY-ALEXANDRIAN-TRACE-OPEN-0001"
+  ],
+  "evidence_refs": [
+    "ConstitutionalReviewEvent://example/0001"
+  ],
+  "status": "requested"
+}

--- a/tools/tests/test_validate_anonymous_reputation_contract_examples.py
+++ b/tools/tests/test_validate_anonymous_reputation_contract_examples.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def load_validator_module(repo_root: Path) -> ModuleType:
+    module_path = repo_root / "tools" / "validate_anonymous_reputation_contract_examples.py"
+    spec = importlib.util.spec_from_file_location("validate_anonymous_reputation_contract_examples", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_anonymous_reputation_contract_examples_validate() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    module = load_validator_module(repo_root)
+    module.validate_all(repo_root)

--- a/tools/validate_anonymous_reputation_contract_examples.py
+++ b/tools/validate_anonymous_reputation_contract_examples.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+from jsonschema import Draft202012Validator
+
+
+EXAMPLE_PAIRS = (
+    (
+        Path("contracts/LinkabilityScope.v0.1.json"),
+        Path("docs/generated/identity/anonymous-reputation/examples/linkability_scope.example.v0.1.json"),
+    ),
+    (
+        Path("contracts/AnonymousReputationReceipt.v0.1.json"),
+        Path("docs/generated/identity/anonymous-reputation/examples/anonymous_reputation_receipt.example.v0.1.json"),
+    ),
+    (
+        Path("contracts/RevocationToken.v0.1.json"),
+        Path("docs/generated/identity/anonymous-reputation/examples/revocation_token.example.v0.1.json"),
+    ),
+    (
+        Path("contracts/TraceOpenRequest.v0.1.json"),
+        Path("docs/generated/identity/anonymous-reputation/examples/trace_open_request.example.v0.1.json"),
+    ),
+)
+
+
+def load_json(path: Path) -> object:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate_pair(root: Path, schema_rel: Path, example_rel: Path) -> None:
+    schema_path = root / schema_rel
+    example_path = root / example_rel
+
+    if not schema_path.is_file():
+        raise FileNotFoundError(f"missing schema: {schema_rel}")
+    if not example_path.is_file():
+        raise FileNotFoundError(f"missing example: {example_rel}")
+
+    schema = load_json(schema_path)
+    example = load_json(example_path)
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(example)
+
+
+def validate_all(root: Path, pairs: Iterable[tuple[Path, Path]] = EXAMPLE_PAIRS) -> None:
+    for schema_rel, example_rel in pairs:
+        validate_pair(root, schema_rel, example_rel)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate anonymous reputation examples against runtime JSON schemas."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of tools/.",
+    )
+    args = parser.parse_args()
+
+    validate_all(args.root.resolve())
+    print("anonymous reputation contract examples validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closed after verified capture on current main.

Content was not discarded. The additive draft/stale #415 content is now present on current main; comparison of `replay/identity-anonymous-reputation-v4` against `main` is identical, and representative paths were verified on `main`:

- `contracts/identity/anonymous-reputation-boundary.md`
- `apps/identity-prime/docs/anonymous-reputation-consumption.md`
- `docs/generated/identity/anonymous-reputation/examples/anonymous_reputation_receipt.example.v0.1.json`
- `docs/generated/identity/anonymous-reputation/examples/linkability_scope.example.v0.1.json`
- `docs/generated/identity/anonymous-reputation/examples/revocation_token.example.v0.1.json`
- `docs/generated/identity/anonymous-reputation/examples/trace_open_request.example.v0.1.json`
- `tools/validate_anonymous_reputation_contract_examples.py`
- `tools/tests/test_validate_anonymous_reputation_contract_examples.py`

No replacement PR is required because the replay branch is identical to current main. Closing this stale draft only after verified capture.