### PR TITLE
fogstack: index plan-only live apply evidence

### DIFF
--- a/.github/workflows/fogstack-apply-plan-index.yml
+++ b/.github/workflows/fogstack-apply-plan-index.yml
@@ -1,0 +1,39 @@
+name: FogStack Apply Plan Index
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "tools/update_fogstack_local_demo_apply_plan.py"
+      - "tools/tests/test_update_fogstack_local_demo_apply_plan.py"
+      - ".github/workflows/fogstack-apply-plan-index.yml"
+  push:
+    branches: [main]
+    paths:
+      - "tools/update_fogstack_local_demo_apply_plan.py"
+      - "tools/tests/test_update_fogstack_local_demo_apply_plan.py"
+      - ".github/workflows/fogstack-apply-plan-index.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  apply-plan-index:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml jsonschema
+
+      - name: Run updater test
+        run: |
+          python -m pytest -q tools/tests/test_update_fogstack_local_demo_apply_plan.py

--- a/tools/tests/test_update_fogstack_local_demo_apply_plan.py
+++ b/tools/tests/test_update_fogstack_local_demo_apply_plan.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def load(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def test_update_fogstack_local_demo_apply_plan(tmp_path: Path) -> None:
+    output_dir = tmp_path / "demo"
+    deploy_dir = output_dir / "deploy"
+    subprocess.run([sys.executable, "tools/run_fogstack_local_demo.py", "--pack", "all", "--output-dir", str(output_dir)], check=True)
+    subprocess.run([sys.executable, "tools/run_fogstack_local_demo_deploy_plan.py", "--output-dir", str(deploy_dir)], check=True)
+    subprocess.run([sys.executable, "tools/update_fogstack_local_demo_deploy_artifacts.py", "--summary-json", str(output_dir / "fogstack-local-demo.summary.json"), "--deploy-summary-json", str(deploy_dir / "fogstack.access.deploy-demo.summary.json")], check=True)
+    proc = subprocess.run([sys.executable, "tools/update_fogstack_local_demo_apply_plan.py", "--summary-json", str(output_dir / "fogstack-local-demo.summary.json")], check=True, capture_output=True, text=True)
+    assert "FogStackLocalDemoApplyPlanUpdate" in proc.stdout
+
+    summary = load(output_dir / "fogstack-local-demo.summary.json")
+    assert "deploy_live_apply_plan_record" in summary["artifacts"]
+    assert "live_apply_plan_record_emitted" in summary["checks"]
+    assert "live_apply_plan_record_indexed" in summary["checks"]
+    assert "live_apply_plan_summary_appended" in summary["checks"]
+
+    plan_record = load(Path(summary["artifacts"]["deploy_live_apply_plan_record"]))
+    assert plan_record["kind"] == "FogStackLiveApplyPlanRecord"
+    assert plan_record["mode"] == "plan-only"
+    assert plan_record["status"] == "blocked"
+    assert plan_record["safety"]["run_performed"] is False
+    assert plan_record["safety"]["mutated_cluster"] is False
+    assert plan_record["safety"]["live_apply_allowed"] is False
+    assert plan_record["safety"]["future_approval_record_required"] is True
+
+    artifact_index = load(output_dir / "demo-artifacts.index.json")
+    indexed = {entry["id"]: entry for entry in artifact_index["artifacts"]}
+    assert "deploy_live_apply_plan_record" in indexed
+    assert indexed["deploy_live_apply_plan_record"]["digest"].startswith("sha256:")
+    assert Path(indexed["deploy_live_apply_plan_record"]["ref"]).exists()
+
+    markdown = (output_dir / "fogstack-local-demo.summary.md").read_text(encoding="utf-8")
+    html = (output_dir / "index.html").read_text(encoding="utf-8")
+    for content in [markdown, html]:
+        assert "Live apply planning" in content
+        assert "deploy_live_apply_plan_record" in content
+        assert "plan-only" in content
+        assert "Run performed" in content
+        assert "Mutated cluster" in content
+        assert "Live apply allowed" in content
+        assert "Future approval required" in content

--- a/tools/update_fogstack_local_demo_apply_plan.py
+++ b/tools/update_fogstack_local_demo_apply_plan.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_ID = "deploy_live_apply_plan_record"
+ARTIFACT_LABEL = "Live apply plan record"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def path_from_ref(ref: str) -> Path:
+    path = Path(ref)
+    return path if path.is_absolute() else ROOT / path
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def refresh_index(index_path: Path, artifact_ref: str) -> None:
+    index = load_json(index_path)
+    by_id = {entry["id"]: entry for entry in index.get("artifacts", []) if isinstance(entry, dict) and entry.get("id")}
+    path = path_from_ref(artifact_ref)
+    if not path.exists() or not path.is_file():
+        raise SystemExit(f"ERR: apply plan artifact missing: {artifact_ref}")
+    by_id[ARTIFACT_ID] = {
+        "id": ARTIFACT_ID,
+        "ref": artifact_ref,
+        "digest": sha256_file(path),
+        "size_bytes": path.stat().st_size,
+    }
+    index["artifacts"] = [by_id[key] for key in sorted(by_id)]
+    write_json(index_path, index)
+
+
+def emit_plan(deploy_plan_ref: str, live_preflight_ref: str, output_path: Path) -> dict[str, Any]:
+    import subprocess
+    import sys
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run([
+        sys.executable,
+        str(ROOT / "tools" / "emit_fogstack_live_apply_plan_record.py"),
+        "--deploy-plan",
+        deploy_plan_ref,
+        "--live-preflight",
+        live_preflight_ref,
+        "--output",
+        str(output_path),
+    ], cwd=ROOT, check=True, capture_output=True, text=True)
+    return load_json(output_path)
+
+
+def append_markdown(markdown_path: Path, artifact_ref: str, record: dict[str, Any]) -> None:
+    path = path_from_ref(artifact_ref)
+    section = "\n".join([
+        "",
+        "## Live apply planning",
+        "",
+        "| Artifact ID | Artifact | Ref | SHA-256 digest | Status |",
+        "|---|---|---|---|---|",
+        f"| `{ARTIFACT_ID}` | {ARTIFACT_LABEL} | `{artifact_ref}` | `{sha256_file(path)}` | `indexed` |",
+        "",
+        "| Signal | Value |",
+        "|---|---|",
+        f"| Mode | `{record.get('mode')}` |",
+        f"| Status | `{record.get('status')}` |",
+        f"| Live preflight status | `{record.get('live_preflight_status')}` |",
+        f"| Run performed | `{str(record.get('safety', {}).get('run_performed')).lower()}` |",
+        f"| Mutated cluster | `{str(record.get('safety', {}).get('mutated_cluster')).lower()}` |",
+        f"| Live apply allowed | `{str(record.get('safety', {}).get('live_apply_allowed')).lower()}` |",
+        f"| Future approval required | `{str(record.get('safety', {}).get('future_approval_record_required')).lower()}` |",
+        "",
+    ])
+    markdown_path.write_text(markdown_path.read_text(encoding="utf-8") + section, encoding="utf-8")
+
+
+def append_html(html_path: Path, artifact_ref: str, record: dict[str, Any]) -> None:
+    def esc(value: Any) -> str:
+        return html.escape(str(value), quote=True)
+
+    path = path_from_ref(artifact_ref)
+    safety = record.get("safety", {}) if isinstance(record.get("safety"), dict) else {}
+    section = f"""
+    <h2>Live apply planning</h2>
+    <table>
+      <thead><tr><th>Artifact ID</th><th>Artifact</th><th>Ref</th><th>SHA-256 digest</th><th>Status</th></tr></thead>
+      <tbody>
+        <tr><td><code>{esc(ARTIFACT_ID)}</code></td><td>{esc(ARTIFACT_LABEL)}</td><td><code>{esc(artifact_ref)}</code></td><td><code>{esc(sha256_file(path))}</code></td><td>indexed</td></tr>
+      </tbody>
+    </table>
+    <table>
+      <thead><tr><th>Signal</th><th>Value</th></tr></thead>
+      <tbody>
+        <tr><td>Mode</td><td><code>{esc(record.get('mode'))}</code></td></tr>
+        <tr><td>Status</td><td><code>{esc(record.get('status'))}</code></td></tr>
+        <tr><td>Live preflight status</td><td><code>{esc(record.get('live_preflight_status'))}</code></td></tr>
+        <tr><td>Run performed</td><td><code>{esc(str(safety.get('run_performed')).lower())}</code></td></tr>
+        <tr><td>Mutated cluster</td><td><code>{esc(str(safety.get('mutated_cluster')).lower())}</code></td></tr>
+        <tr><td>Live apply allowed</td><td><code>{esc(str(safety.get('live_apply_allowed')).lower())}</code></td></tr>
+        <tr><td>Future approval required</td><td><code>{esc(str(safety.get('future_approval_record_required')).lower())}</code></td></tr>
+      </tbody>
+    </table>
+"""
+    html_text = html_path.read_text(encoding="utf-8")
+    html_path.write_text(html_text.replace("\n  </main>", section + "\n  </main>"), encoding="utf-8")
+
+
+def update(summary_path: Path, output_path: Path | None) -> dict[str, Any]:
+    summary = load_json(summary_path)
+    artifacts = summary.setdefault("artifacts", {})
+    deploy_plan_ref = artifacts.get("deploy_plan")
+    preflight_ref = artifacts.get("deploy_live_cluster_preflight_record")
+    if not isinstance(deploy_plan_ref, str) or not isinstance(preflight_ref, str):
+        raise SystemExit("ERR: summary missing deploy plan or live preflight artifact")
+    if output_path is None:
+        output_path = path_from_ref(deploy_plan_ref).parent / "fogstack.access.live-apply-plan.record.json"
+    output_path = output_path if output_path.is_absolute() else ROOT / output_path
+    record = emit_plan(deploy_plan_ref, preflight_ref, output_path)
+    artifact_ref = rel(output_path)
+    artifacts[ARTIFACT_ID] = artifact_ref
+    checks = summary.setdefault("checks", [])
+    for check in ["live_apply_plan_record_emitted", "live_apply_plan_record_indexed", "live_apply_plan_summary_appended"]:
+        if check not in checks:
+            checks.append(check)
+    write_json(summary_path, summary)
+    refresh_index(path_from_ref(artifacts["artifact_index"]), artifact_ref)
+    append_markdown(path_from_ref(artifacts["summary_markdown"]), artifact_ref, record)
+    append_html(path_from_ref(artifacts["summary_html"]), artifact_ref, record)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Add plan-only live apply evidence to a FogStack local demo")
+    parser.add_argument("--summary-json", type=Path, default=Path("build/fogstack-local-demo/fogstack-local-demo.summary.json"))
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    summary_path = args.summary_json if args.summary_json.is_absolute() else ROOT / args.summary_json
+    summary = update(summary_path, args.output)
+    print(json.dumps({"kind": "FogStackLocalDemoApplyPlanUpdate", "status": "passed", "artifact": summary["artifacts"][ARTIFACT_ID]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Deployment parity tranche B follow-up.

This adds a standalone updater that appends the plan-only `FogStackLiveApplyPlanRecord` to the local demo evidence graph without modifying the existing deploy runner or full-demo runner.

Changes:
- add `tools/update_fogstack_local_demo_apply_plan.py`
- add `tools/tests/test_update_fogstack_local_demo_apply_plan.py`
- add focused workflow `.github/workflows/fogstack-apply-plan-index.yml`

Behavior:
- reads the existing local demo summary
- uses the existing deploy plan and live preflight record
- emits `fogstack.access.live-apply-plan.record.json`
- indexes `deploy_live_apply_plan_record`
- appends operator-facing Markdown and HTML summary sections

Safety boundary:
- this is still plan-only evidence
- no live apply execution
- no kubectl execution
- no GitOps sync execution
- requires the existing plan-only record safety fields to remain false for run/mutation/apply

Note: main moved after branch creation with unrelated work. This PR adds three files only; use premerge-audit as the freshness guard.