### PR TITLE
lock: consume agent action trace profile

### DIFF
--- a/contracts/agent-action-trace/README.md
+++ b/contracts/agent-action-trace/README.md
@@ -1,0 +1,22 @@
+# Agent Action / Trace Contracts
+
+This directory is the generated-artifact target for the `agent-action-trace-profile` standards import in `standards.lock.yaml`.
+
+## Upstream authority
+
+- Normative runtime-facing profile: `SocioProphet/socioprophet-agent-standards`
+- Semantic ontology authority: `SocioProphet/ontogenesis`
+- Bootstrap examples and validator authority: `SocioProphet/socioprophet-standards-storage`
+
+## Current status
+
+Placeholder only.
+
+No runtime implementation, generated schema materialization, or service behavior is introduced in this tranche.
+
+## Expected future artifacts
+
+- agent action/trace profile contract projections
+- generated action/trace example fixtures
+- runtime conformance reports for AgentPlane/workspace/lampstand consumers
+- policy/evidence/receipt linkage summaries

--- a/docs/generated/agent-action-trace/README.md
+++ b/docs/generated/agent-action-trace/README.md
@@ -1,0 +1,25 @@
+# Generated Agent Action / Trace Artifacts
+
+This directory is reserved for generated documentation and consumption notes derived from the pinned `agent-action-trace-profile` standards import.
+
+## Source standards lock entry
+
+See `standards.lock.yaml` entry:
+
+```yaml
+agent-action-trace-profile:
+  repo: SocioProphet/socioprophet-agent-standards
+  class: agent-action-trace-conformance-profile
+```
+
+## Runtime consumers
+
+Initial downstream surfaces listed by the lock entry:
+
+- `apps/agentplane`
+- `apps/workspace-controller`
+- `apps/lampstand`
+
+## Boundary
+
+This is generated-artifact scaffolding only. It does not claim implementation conformance until concrete generated contracts and runtime receipts are added.

--- a/standards.lock.yaml
+++ b/standards.lock.yaml
@@ -145,6 +145,30 @@ spec:
           localProfileOverridesForbidden: true
           identityRuntimeConformanceRequired: true
 
+      agent-action-trace-profile:
+        repo: SocioProphet/socioprophet-agent-standards
+        class: agent-action-trace-conformance-profile
+        channel: controlled
+        pin:
+          commit: 97e3f49ec4b27349f532db27ebaad618d4f9520c
+          tag: null
+        consume:
+          docs:
+            - docs/standards/agent-plane/001-agent-action-trace-conformance-profile.md
+            - conformance/AGENT-ACTION-TRACE-CONFORMANCE-0001.md
+          runtime_targets:
+            - apps/agentplane
+            - apps/workspace-controller
+            - apps/lampstand
+          generated_artifacts:
+            - contracts/agent-action-trace/
+            - docs/generated/agent-action-trace/
+        rules:
+          ontologyAuthorityExternal: true
+          bootstrapValidatorAuthorityExternal: true
+          traceIsEvidenceNotAuthority: true
+          runtimeConformanceRequired: true
+
     reference_inputs:
       identity-prime-reference:
         repo: SocioProphet/identity-is-prime-reference
@@ -252,6 +276,7 @@ spec:
     exportContractsDir: contracts/export
     modelContractsDir: contracts/model
     ontologyContractsDir: contracts/ontology
+    agentActionTraceContractsDir: contracts/agent-action-trace
   review:
     requiredOwners:
       - platform


### PR DESCRIPTION
## Summary

Ready replacement for draft PR #416.

Adds the merged Agent Action / Trace Conformance Profile from `SocioProphet/socioprophet-agent-standards` as a controlled normative standards import.

## What changes

- Adds `agent-action-trace-profile` under `spec.imports.normative_standards` in `standards.lock.yaml`
- Pins the merged profile commit: `97e3f49ec4b27349f532db27ebaad618d4f9520c`
- Adds generated-artifact target placeholders:
  - `contracts/agent-action-trace/README.md`
  - `docs/generated/agent-action-trace/README.md`
- Adds `agentActionTraceContractsDir` under generated contract directories

## Why

`SocioProphet/socioprophet-agent-standards#22` is merged and provides the runtime-facing Agent Action / Trace Conformance Profile. `prophet-platform` should consume it explicitly rather than allowing downstream services to invent their own action/trace conformance semantics.

## Boundary

- Semantic ontology authority remains `SocioProphet/ontogenesis`.
- Bootstrap validator/example authority remains `SocioProphet/socioprophet-standards-storage`.
- This PR only pins platform consumption and reserves generated artifact directories.
- No runtime behavior changes are introduced.

## Validation / upstream note

This replacement PR uses the same replayed head as draft PR #416 and is based on current `main` at the time of replay. Current PR surface is intentionally limited to three files:

- `standards.lock.yaml`
- `contracts/agent-action-trace/README.md`
- `docs/generated/agent-action-trace/README.md`

## Supersedes

Supersedes draft PR #416, which could not be transitioned out of draft through the available connector due to a connector GraphQL response-field issue.

## Follow-up

- generate concrete `contracts/agent-action-trace/` artifacts from the pinned profile
- add runtime consumption notes for `apps/agentplane`, `apps/workspace-controller`, and `apps/lampstand`
- add a small validator for generated contract placeholders once materialized