### PR TITLE
Add Professional Intelligence Gate 4 orchestration artifact

### DIFF
--- a/contracts/orchestration/pi-gate4-demo.schema.json
+++ b/contracts/orchestration/pi-gate4-demo.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/professional-intelligence/pi-gate4-demo.schema.json",
+  "title": "ProfessionalIntelligenceGate4Demo",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "demoId",
+    "gate",
+    "status",
+    "workroomRef",
+    "playbookRef",
+    "contextQueryRef",
+    "contextPackRefs",
+    "searchPacketRefs",
+    "policyDecisionRefs",
+    "obligationRefs",
+    "routeDecisionRefs",
+    "runtimeControlRefs",
+    "agentAuthorityRefs",
+    "agentplaneRunRefs",
+    "ledgerRefs",
+    "evidenceRefs",
+    "adoptionEventRefs",
+    "steps",
+    "acceptance"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "demoId": { "type": "string" },
+    "gate": { "const": "gate-4" },
+    "status": { "type": "string", "enum": ["planned", "ready", "executed", "accepted", "held"] },
+    "workroomRef": { "type": "string" },
+    "playbookRef": { "type": "string" },
+    "contextQueryRef": { "type": "string" },
+    "contextPackRefs": { "type": "array", "items": { "type": "string" } },
+    "searchPacketRefs": { "type": "array", "items": { "type": "string" } },
+    "policyDecisionRefs": { "type": "array", "items": { "type": "string" } },
+    "obligationRefs": { "type": "array", "items": { "type": "string" } },
+    "routeDecisionRefs": { "type": "array", "items": { "type": "string" } },
+    "runtimeControlRefs": { "type": "array", "items": { "type": "string" } },
+    "agentAuthorityRefs": { "type": "array", "items": { "type": "string" } },
+    "agentplaneRunRefs": { "type": "array", "items": { "type": "string" } },
+    "ledgerRefs": { "type": "array", "items": { "type": "string" } },
+    "workroomUpdateRefs": { "type": "array", "items": { "type": "string" } },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "adoptionEventRefs": { "type": "array", "items": { "type": "string" } },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["stepId", "inputRefs", "outputRefs", "evidenceRequired", "status"],
+        "properties": {
+          "stepId": { "type": "string" },
+          "inputRefs": { "type": "array", "items": { "type": "string" } },
+          "outputRefs": { "type": "array", "items": { "type": "string" } },
+          "evidenceRequired": { "type": "boolean" },
+          "status": { "type": "string" }
+        }
+      }
+    },
+    "acceptance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requiredEvidenceRefs", "requiredAdoptionEventRefs", "criteria"],
+      "properties": {
+        "requiredEvidenceRefs": { "type": "array", "items": { "type": "string" } },
+        "requiredAdoptionEventRefs": { "type": "array", "items": { "type": "string" } },
+        "criteria": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/contracts/orchestration/pi-gate4-demo.v0.1.example.json
+++ b/contracts/orchestration/pi-gate4-demo.v0.1.example.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "v0.1",
+  "demoId": "pi-gate4-demo-0001",
+  "gate": "gate-4",
+  "status": "ready",
+  "workroomRef": "workroom://workroom-demo-0001",
+  "playbookRef": "playbook://client-opportunity-review",
+  "contextQueryRef": "query://pi-demo-0001/context",
+  "contextPackRefs": [
+    "context-pack://pi-demo-0001"
+  ],
+  "searchPacketRefs": [
+    "search-packet://pi-demo-0001"
+  ],
+  "policyDecisionRefs": [
+    "policy-decision://ppd-allow-0001",
+    "policy-decision://ppd-review-0001"
+  ],
+  "obligationRefs": [
+    "obligation://obl-ai-use-demo-0001",
+    "obligation://obl-approval-demo-0001"
+  ],
+  "routeDecisionRefs": [
+    "route-decision://pi-demo-0001/review-packet",
+    "route-decision://pi-demo-0001/policy-sensitive-summary"
+  ],
+  "runtimeControlRefs": [
+    "guardrail-pack://professional-intelligence/gate-3-demo"
+  ],
+  "agentAuthorityRefs": [
+    "session://professional-intelligence/demo-001",
+    "revocation://professional-intelligence/current"
+  ],
+  "agentplaneRunRefs": [
+    "agentplane://runs/pi-demo-0001"
+  ],
+  "ledgerRefs": [
+    "ledger://professional-intelligence/route-evidence/review-packet",
+    "ledger://professional-intelligence/model-evidence/review-packet",
+    "ledger://professional-intelligence/promotion/review-packet-candidate",
+    "rollback://professional-intelligence/review-packet/current"
+  ],
+  "workroomUpdateRefs": [
+    "workroom://workroom-demo-0001"
+  ],
+  "evidenceRefs": [
+    "evidence://query/pi-demo-0001/context",
+    "evidence://model-router/pi-demo-0001/review-packet",
+    "evidence://guardrail-fabric/professional-intelligence/gate-3-demo",
+    "evidence://agentplane/pi-demo-0001/workflow-step",
+    "evidence://adoption/adopt-0001"
+  ],
+  "adoptionEventRefs": [
+    "adoption://adopt-0001"
+  ],
+  "steps": [
+    {
+      "stepId": "load-playbook",
+      "inputRefs": [
+        "playbook://client-opportunity-review"
+      ],
+      "outputRefs": [
+        "workroom://workroom-demo-0001"
+      ],
+      "evidenceRequired": true,
+      "status": "ready"
+    },
+    {
+      "stepId": "resolve-context",
+      "inputRefs": [
+        "query://pi-demo-0001/context",
+        "search-packet://pi-demo-0001",
+        "context-pack://pi-demo-0001"
+      ],
+      "outputRefs": [
+        "context-pack://pi-demo-0001"
+      ],
+      "evidenceRequired": true,
+      "status": "ready"
+    },
+    {
+      "stepId": "check-policy-and-obligations",
+      "inputRefs": [
+        "policy-decision://ppd-review-0001",
+        "obligation://obl-ai-use-demo-0001",
+        "obligation://obl-approval-demo-0001"
+      ],
+      "outputRefs": [
+        "evidence://policy/ppd-review-0001"
+      ],
+      "evidenceRequired": true,
+      "status": "ready"
+    },
+    {
+      "stepId": "select-route-and-controls",
+      "inputRefs": [
+        "route-decision://pi-demo-0001/review-packet",
+        "guardrail-pack://professional-intelligence/gate-3-demo",
+        "session://professional-intelligence/demo-001"
+      ],
+      "outputRefs": [
+        "evidence://model-router/pi-demo-0001/review-packet",
+        "evidence://guardrail-fabric/professional-intelligence/gate-3-demo"
+      ],
+      "evidenceRequired": true,
+      "status": "ready"
+    },
+    {
+      "stepId": "run-agentplane-bundle",
+      "inputRefs": [
+        "agentplane://bundle/professional-intelligence-client-opportunity-review"
+      ],
+      "outputRefs": [
+        "agentplane://runs/pi-demo-0001",
+        "evidence://agentplane/pi-demo-0001/workflow-step"
+      ],
+      "evidenceRequired": true,
+      "status": "ready"
+    },
+    {
+      "stepId": "seal-ledger-and-adoption",
+      "inputRefs": [
+        "ledger://professional-intelligence/model-evidence/review-packet",
+        "ledger://professional-intelligence/route-evidence/review-packet"
+      ],
+      "outputRefs": [
+        "adoption://adopt-0001",
+        "evidence://adoption/adopt-0001"
+      ],
+      "evidenceRequired": true,
+      "status": "ready"
+    }
+  ],
+  "acceptance": {
+    "requiredEvidenceRefs": [
+      "evidence://query/pi-demo-0001/context",
+      "evidence://model-router/pi-demo-0001/review-packet",
+      "evidence://guardrail-fabric/professional-intelligence/gate-3-demo",
+      "evidence://agentplane/pi-demo-0001/workflow-step",
+      "evidence://adoption/adopt-0001"
+    ],
+    "requiredAdoptionEventRefs": [
+      "adoption://adopt-0001"
+    ],
+    "criteria": [
+      "playbook is loaded",
+      "context is resolved",
+      "policy and obligation checks are referenced",
+      "route decision and runtime controls are referenced",
+      "Agentplane run is referenced",
+      "workroom and evidence outputs are referenced",
+      "adoption event is referenced"
+    ]
+  }
+}

--- a/tools/validate_professional_intelligence.py
+++ b/tools/validate_professional_intelligence.py
@@ -33,6 +33,10 @@ SCHEMA_EXAMPLES = [
         ROOT / "contracts/risk/conflict-check.schema.json",
         ROOT / "contracts/risk/conflict-check.v0.1.example.json",
     ),
+    (
+        ROOT / "contracts/orchestration/pi-gate4-demo.schema.json",
+        ROOT / "contracts/orchestration/pi-gate4-demo.v0.1.example.json",
+    ),
 ]
 
 
@@ -134,11 +138,66 @@ def validate_manifest_contract_paths() -> None:
     print(f"ok: manifest references {len(contract_paths)} existing contract paths")
 
 
+def validate_gate4_demo(example: dict[str, Any]) -> None:
+    required_top_level = [
+        "workroomRef",
+        "playbookRef",
+        "contextQueryRef",
+        "contextPackRefs",
+        "searchPacketRefs",
+        "policyDecisionRefs",
+        "obligationRefs",
+        "routeDecisionRefs",
+        "runtimeControlRefs",
+        "agentAuthorityRefs",
+        "agentplaneRunRefs",
+        "ledgerRefs",
+        "evidenceRefs",
+        "adoptionEventRefs",
+    ]
+    for key in required_top_level:
+        value = example.get(key)
+        if isinstance(value, list) and not value:
+            raise ValidationError(f"gate4 demo: {key} must not be empty")
+        if isinstance(value, str) and not value:
+            raise ValidationError(f"gate4 demo: {key} must not be empty")
+
+    steps = example.get("steps", [])
+    expected_steps = {
+        "load-playbook",
+        "resolve-context",
+        "check-policy-and-obligations",
+        "select-route-and-controls",
+        "run-agentplane-bundle",
+        "seal-ledger-and-adoption",
+    }
+    observed_steps = {step.get("stepId") for step in steps}
+    missing_steps = sorted(expected_steps - observed_steps)
+    if missing_steps:
+        raise ValidationError(f"gate4 demo: missing steps {missing_steps}")
+
+    for step in steps:
+        if step.get("evidenceRequired") is not True:
+            raise ValidationError(f"gate4 demo: step {step.get('stepId')} must require evidence")
+        if not step.get("inputRefs") or not step.get("outputRefs"):
+            raise ValidationError(f"gate4 demo: step {step.get('stepId')} must include inputRefs and outputRefs")
+
+    acceptance = example.get("acceptance", {})
+    if not acceptance.get("requiredEvidenceRefs"):
+        raise ValidationError("gate4 demo: acceptance.requiredEvidenceRefs must not be empty")
+    if not acceptance.get("requiredAdoptionEventRefs"):
+        raise ValidationError("gate4 demo: acceptance.requiredAdoptionEventRefs must not be empty")
+    if len(acceptance.get("criteria", [])) < 5:
+        raise ValidationError("gate4 demo: acceptance.criteria must include the core demo checkpoints")
+
+
 def validate_examples() -> None:
     for schema_path, example_path in SCHEMA_EXAMPLES:
         schema = load_json(schema_path)
         example = load_json(example_path)
         validate_schema(schema, example)
+        if example_path.name == "pi-gate4-demo.v0.1.example.json":
+            validate_gate4_demo(example)
         print(
             "ok: "
             f"{example_path.relative_to(ROOT)} validates against {schema_path.relative_to(ROOT)}"


### PR DESCRIPTION
## Summary

Adds the first Professional Intelligence OS Gate 4 orchestration artifact to `prophet-platform`.

Adds:
- `contracts/orchestration/pi-gate4-demo.schema.json`
- `contracts/orchestration/pi-gate4-demo.v0.1.example.json`

Updates:
- `tools/validate_professional_intelligence.py` to validate the Gate 4 orchestration artifact and enforce the required end-to-end step set.

## Why

Gate 4 needs one platform-level control object that traces the integrated demo path end to end:

`playbook -> context query -> policy/obligation check -> route decision -> runtime controls -> Agentplane run -> workroom/evidence/adoption output`

This PR binds the merged repo artifacts into a single validated orchestration object.

## Completion impact

- Overall alignment: ~64% -> ~68%
- Runtime implementation: ~35% -> ~42%
- Demo readiness: ~65% -> ~70%
- Cybernetic controls: ~45% -> ~50%

## Validation

```bash
python3 tools/validate_professional_intelligence.py
python3 tools/validate_repo.py
```