### PR TITLE
feat(reasoning): add deterministic reasoning failure runner slice

### DIFF
--- a/docs/reasoning-failure-runner-v0.1.md
+++ b/docs/reasoning-failure-runner-v0.1.md
@@ -1,0 +1,41 @@
+# Reasoning Failure Runner v0.1
+
+Parent: SocioProphet/sociosphere#271 and SocioProphet/prophet-platform#405.
+
+This slice adds the first runtime-facing reasoning-failure runner contract. The initial implementation is deliberately narrow: exact-string verification over synthetic fixtures only.
+
+## Purpose
+
+The runner converts a standards-shaped reasoning-failure case and perturbation suite into a provider-neutral `ReasoningFailureReceipt`. The receipt can later be consumed by Guardrail Fabric, Policy Fabric, AgentPlane, Model Governance Ledger, Agent Registry, Model Router, Sherlock, and DeliveryExcellence.
+
+## Initial deterministic lane
+
+The first lane targets exactness failures. It compares a protected string with an observed string and emits a failed receipt when they are not byte-identical.
+
+This covers high-risk operational surfaces such as:
+
+- config keys;
+- release refs;
+- schema refs;
+- package names;
+- filenames;
+- checksums;
+- exact IDs;
+- boot/runtime identifiers.
+
+## Non-goals
+
+This slice does not call external models, run LLM-as-judge, execute tools, mutate state, write ledger records, change guardrail behavior, or route agents. It creates deterministic synthetic evidence that downstream repos can consume.
+
+## CLI target
+
+```bash
+python3 tools/emit_reasoning_failure_receipt.py \
+  --case examples/reasoning-failure/exact-string-case.json \
+  --suite examples/reasoning-failure/exactness-perturbation-suite.json \
+  --out build/reasoning-failure/exact-string-receipt.json
+```
+
+## Safety posture
+
+The fixture uses `synthetic-only` privacy posture. Raw customer data, secrets, browser profiles, token stores, private app databases, regulated data, and unredacted telemetry are out of scope for this runner slice.

--- a/examples/reasoning-failure/exact-string-case.json
+++ b/examples/reasoning-failure/exact-string-case.json
@@ -1,0 +1,34 @@
+{
+  "kind": "ReasoningFailureCase",
+  "version": "0.1",
+  "caseId": "reasoning-failure.exact-string.synthetic.v0",
+  "failureModeRefs": [
+    "https://socioprophet.github.io/ontogenesis/platform/reasoning-failure#ExactStringFailure"
+  ],
+  "taskClass": "exactness",
+  "domain": "configuration",
+  "severity": "high",
+  "invariant": {
+    "invariantId": "exactness.byte-identical.identifier",
+    "description": "The protected identifier must remain byte-identical across transformation.",
+    "mustSurvivePerturbation": true
+  },
+  "expectedOutcome": "Preserve sourceos-syncd.release-set.v0.1 exactly.",
+  "observedOutput": "Identifier was normalized during prose rewrite.",
+  "protectedString": "sourceos-syncd.release-set.v0.1",
+  "observedString": "sourceos_syncd.release_set.v0.1",
+  "verifier": {
+    "verifierId": "deterministic.string.byte-compare.v0",
+    "verifierFamily": "deterministic",
+    "llmJudgeOnly": false
+  },
+  "evidenceReceiptRefs": [
+    "receipt:synthetic-exactness-byte-compare.v0"
+  ],
+  "mitigationRefs": [
+    "https://socioprophet.github.io/ontogenesis/platform/reasoning-failure#DeterministicToolDelegation"
+  ],
+  "residualRisk": "Exactness-sensitive outputs remain unsafe until deterministic verification passes.",
+  "riskAction": "require-tool-verification",
+  "privacyBoundary": "synthetic-only"
+}

--- a/examples/reasoning-failure/exactness-perturbation-suite.json
+++ b/examples/reasoning-failure/exactness-perturbation-suite.json
@@ -1,0 +1,29 @@
+{
+  "kind": "ReasoningPerturbationSuite",
+  "version": "0.1",
+  "suiteId": "perturbation-suite.exactness.synthetic.v0",
+  "targetCaseId": "reasoning-failure.exact-string.synthetic.v0",
+  "verifierFamily": "deterministic",
+  "perturbations": [
+    {
+      "perturbationId": "exactness.identifier-rename.v0",
+      "family": "identifier-rename",
+      "description": "Rename surrounding variables while preserving the protected identifier exactly.",
+      "invariantPreserving": true,
+      "expectedInvariantBehavior": "Protected identifier remains byte-identical."
+    },
+    {
+      "perturbationId": "exactness.distractor-injection.v0",
+      "family": "distractor-injection",
+      "description": "Add nearby similar-looking identifiers as distractors.",
+      "invariantPreserving": true,
+      "expectedInvariantBehavior": "Protected identifier remains byte-identical and is not replaced by a distractor."
+    }
+  ],
+  "evaluatorBiasControls": {
+    "llmJudgeAllowed": false,
+    "orderRandomization": true,
+    "verbosityBiasCheck": true,
+    "contaminationNoteRequired": true
+  }
+}

--- a/schemas/runtime/reasoning-failure-receipt-v0.1.schema.json
+++ b/schemas/runtime/reasoning-failure-receipt-v0.1.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/runtime/reasoning-failure-receipt-v0.1.schema.json",
+  "title": "ReasoningFailureReceipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kind",
+    "version",
+    "receiptId",
+    "caseId",
+    "suiteId",
+    "runner",
+    "privacyBoundary",
+    "failureModeRefs",
+    "verifierFamily",
+    "invariantResults",
+    "decision",
+    "riskAction",
+    "evidenceRefs",
+    "mitigationRefs",
+    "residualRisk"
+  ],
+  "properties": {
+    "kind": { "const": "ReasoningFailureReceipt" },
+    "version": { "const": "0.1" },
+    "receiptId": { "type": "string", "minLength": 1 },
+    "caseId": { "type": "string", "minLength": 1 },
+    "suiteId": { "type": "string", "minLength": 1 },
+    "runner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runnerId", "runnerVersion", "deterministic"],
+      "properties": {
+        "runnerId": { "type": "string", "minLength": 1 },
+        "runnerVersion": { "type": "string", "minLength": 1 },
+        "deterministic": { "type": "boolean" }
+      }
+    },
+    "privacyBoundary": {
+      "type": "string",
+      "enum": ["synthetic-only", "redacted-evidence-refs", "customer-boundary-local", "regulated-boundary-local"]
+    },
+    "failureModeRefs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "verifierFamily": {
+      "type": "string",
+      "enum": ["deterministic", "symbolic", "schema", "policy", "tool-backed", "human-review", "llm-judge-advisory"]
+    },
+    "invariantResults": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["invariantId", "passed", "expected", "observed"],
+        "properties": {
+          "invariantId": { "type": "string", "minLength": 1 },
+          "passed": { "type": "boolean" },
+          "expected": { "type": "string" },
+          "observed": { "type": "string" },
+          "detail": { "type": "string" }
+        }
+      }
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["passed", "failed", "requires-review", "blocked"]
+    },
+    "riskAction": {
+      "type": "string",
+      "enum": [
+        "record-only",
+        "warn",
+        "require-tool-verification",
+        "require-independent-verifier",
+        "require-human-review",
+        "quarantine",
+        "block",
+        "rollback",
+        "revoke-authority"
+      ]
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "mitigationRefs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "residualRisk": { "type": "string", "minLength": 1 },
+    "nextConsumers": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    }
+  }
+}

--- a/tools/emit_reasoning_failure_receipt.py
+++ b/tools/emit_reasoning_failure_receipt.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+RUNNER_ID = "prophet.reasoning-failure.exactness-runner"
+RUNNER_VERSION = "0.1"
+
+NEXT_CONSUMERS = [
+    "SocioProphet/agentplane",
+    "SocioProphet/guardrail-fabric",
+    "SocioProphet/policy-fabric",
+    "SocioProphet/model-governance-ledger",
+    "SocioProphet/agent-registry",
+    "SocioProphet/model-router",
+    "SocioProphet/sherlock-search",
+    "SocioProphet/delivery-excellence",
+]
+
+
+class ReasoningFailureRunnerError(ValueError):
+    """Raised when a reasoning-failure fixture cannot be evaluated."""
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def emit_receipt(case: dict[str, Any], suite: dict[str, Any]) -> dict[str, Any]:
+    _require_case(case)
+    _require_suite(suite)
+    if suite["targetCaseId"] != case["caseId"]:
+        raise ReasoningFailureRunnerError("suite.targetCaseId must match case.caseId")
+    if case["verifier"].get("llmJudgeOnly") is True:
+        raise ReasoningFailureRunnerError("deterministic runner refuses LLM-judge-only cases")
+    if case["privacyBoundary"] != "synthetic-only":
+        raise ReasoningFailureRunnerError("v0.1 runner only admits synthetic-only fixtures")
+
+    protected = case["protectedString"]
+    observed = case["observedString"]
+    passed = protected == observed
+    decision = "passed" if passed else "failed"
+    risk_action = "record-only" if passed else case["riskAction"]
+    detail = "byte-identical" if passed else "byte mismatch"
+
+    invariant_result = {
+        "invariantId": case["invariant"]["invariantId"],
+        "passed": passed,
+        "expected": protected,
+        "observed": observed,
+        "detail": detail,
+    }
+
+    receipt_basis = {
+        "caseId": case["caseId"],
+        "suiteId": suite["suiteId"],
+        "protectedString": protected,
+        "observedString": observed,
+        "passed": passed,
+    }
+    digest = hashlib.sha256(json.dumps(receipt_basis, sort_keys=True).encode("utf-8")).hexdigest()
+
+    return {
+        "kind": "ReasoningFailureReceipt",
+        "version": "0.1",
+        "receiptId": f"receipt:reasoning-failure:{digest[:24]}",
+        "caseId": case["caseId"],
+        "suiteId": suite["suiteId"],
+        "runner": {
+            "runnerId": RUNNER_ID,
+            "runnerVersion": RUNNER_VERSION,
+            "deterministic": True,
+        },
+        "privacyBoundary": case["privacyBoundary"],
+        "failureModeRefs": case["failureModeRefs"],
+        "verifierFamily": case["verifier"]["verifierFamily"],
+        "invariantResults": [invariant_result],
+        "decision": decision,
+        "riskAction": risk_action,
+        "evidenceRefs": list(dict.fromkeys(case["evidenceReceiptRefs"] + [f"evidence:byte-compare:{digest}"])),
+        "mitigationRefs": case["mitigationRefs"],
+        "residualRisk": case["residualRisk"],
+        "nextConsumers": NEXT_CONSUMERS,
+    }
+
+
+def emit_receipt_from_paths(case_path: Path, suite_path: Path) -> dict[str, Any]:
+    return emit_receipt(load_json(case_path), load_json(suite_path))
+
+
+def _require_case(case: dict[str, Any]) -> None:
+    required = [
+        "kind",
+        "version",
+        "caseId",
+        "failureModeRefs",
+        "invariant",
+        "protectedString",
+        "observedString",
+        "verifier",
+        "evidenceReceiptRefs",
+        "mitigationRefs",
+        "residualRisk",
+        "riskAction",
+        "privacyBoundary",
+    ]
+    missing = [key for key in required if key not in case]
+    if missing:
+        raise ReasoningFailureRunnerError(f"case missing required keys: {missing}")
+    if case["kind"] != "ReasoningFailureCase":
+        raise ReasoningFailureRunnerError("case.kind must be ReasoningFailureCase")
+    if not isinstance(case["protectedString"], str) or not isinstance(case["observedString"], str):
+        raise ReasoningFailureRunnerError("protectedString and observedString must be strings")
+    if case["verifier"].get("verifierFamily") != "deterministic":
+        raise ReasoningFailureRunnerError("v0.1 exactness runner requires deterministic verifier family")
+
+
+def _require_suite(suite: dict[str, Any]) -> None:
+    required = ["kind", "version", "suiteId", "targetCaseId", "verifierFamily", "perturbations"]
+    missing = [key for key in required if key not in suite]
+    if missing:
+        raise ReasoningFailureRunnerError(f"suite missing required keys: {missing}")
+    if suite["kind"] != "ReasoningPerturbationSuite":
+        raise ReasoningFailureRunnerError("suite.kind must be ReasoningPerturbationSuite")
+    if suite["verifierFamily"] != "deterministic":
+        raise ReasoningFailureRunnerError("v0.1 exactness runner requires deterministic suite verifier")
+    if not suite["perturbations"]:
+        raise ReasoningFailureRunnerError("suite must include at least one perturbation")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a deterministic reasoning-failure receipt.")
+    parser.add_argument("--case", required=True, type=Path, help="Path to ReasoningFailureCase JSON")
+    parser.add_argument("--suite", required=True, type=Path, help="Path to ReasoningPerturbationSuite JSON")
+    parser.add_argument("--out", required=True, type=Path, help="Output receipt path")
+    args = parser.parse_args()
+
+    receipt = emit_receipt_from_paths(args.case, args.suite)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_emit_reasoning_failure_receipt.py
+++ b/tools/tests/test_emit_reasoning_failure_receipt.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "emit_reasoning_failure_receipt.py"
+
+spec = importlib.util.spec_from_file_location("emit_reasoning_failure_receipt", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+assert spec is not None and spec.loader is not None
+spec.loader.exec_module(module)
+
+CASE_PATH = ROOT / "examples" / "reasoning-failure" / "exact-string-case.json"
+SUITE_PATH = ROOT / "examples" / "reasoning-failure" / "exactness-perturbation-suite.json"
+SCHEMA_PATH = ROOT / "schemas" / "runtime" / "reasoning-failure-receipt-v0.1.schema.json"
+
+
+def load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_emit_exactness_failure_receipt() -> None:
+    receipt = module.emit_receipt(load(CASE_PATH), load(SUITE_PATH))
+
+    assert receipt["kind"] == "ReasoningFailureReceipt"
+    assert receipt["version"] == "0.1"
+    assert receipt["caseId"] == "reasoning-failure.exact-string.synthetic.v0"
+    assert receipt["suiteId"] == "perturbation-suite.exactness.synthetic.v0"
+    assert receipt["runner"]["deterministic"] is True
+    assert receipt["privacyBoundary"] == "synthetic-only"
+    assert receipt["verifierFamily"] == "deterministic"
+    assert receipt["decision"] == "failed"
+    assert receipt["riskAction"] == "require-tool-verification"
+    assert receipt["invariantResults"][0]["passed"] is False
+    assert receipt["invariantResults"][0]["expected"] == "sourceos-syncd.release-set.v0.1"
+    assert receipt["invariantResults"][0]["observed"] == "sourceos_syncd.release_set.v0.1"
+    assert "SocioProphet/guardrail-fabric" in receipt["nextConsumers"]
+
+
+def test_emit_exactness_pass_receipt_when_strings_match() -> None:
+    case = load(CASE_PATH)
+    suite = load(SUITE_PATH)
+    case["observedString"] = case["protectedString"]
+
+    receipt = module.emit_receipt(case, suite)
+
+    assert receipt["decision"] == "passed"
+    assert receipt["riskAction"] == "record-only"
+    assert receipt["invariantResults"][0]["passed"] is True
+
+
+def test_emit_refuses_suite_case_mismatch() -> None:
+    case = load(CASE_PATH)
+    suite = load(SUITE_PATH)
+    suite["targetCaseId"] = "reasoning-failure.other.synthetic.v0"
+
+    with pytest.raises(module.ReasoningFailureRunnerError, match="suite.targetCaseId"):
+        module.emit_receipt(case, suite)
+
+
+def test_emit_refuses_llm_judge_only_case() -> None:
+    case = load(CASE_PATH)
+    suite = load(SUITE_PATH)
+    case["verifier"]["llmJudgeOnly"] = True
+
+    with pytest.raises(module.ReasoningFailureRunnerError, match="LLM-judge-only"):
+        module.emit_receipt(case, suite)
+
+
+def test_receipt_schema_required_fields_are_present() -> None:
+    schema = load(SCHEMA_PATH)
+    receipt = module.emit_receipt(load(CASE_PATH), load(SUITE_PATH))
+
+    for required in schema["required"]:
+        assert required in receipt
+
+    assert schema["title"] == "ReasoningFailureReceipt"


### PR DESCRIPTION
Superseded by #535, which replayed this six-file add-only reasoning-failure runner slice onto current main and merged as `c6d6fc7296cabf34319394a94e62bd7eeabe7258`.

Content capture verified before closure:

- `docs/reasoning-failure-runner-v0.1.md`
- `examples/reasoning-failure/exact-string-case.json`
- `examples/reasoning-failure/exactness-perturbation-suite.json`
- `schemas/runtime/reasoning-failure-receipt-v0.1.schema.json`
- `tools/emit_reasoning_failure_receipt.py`
- `tools/tests/test_emit_reasoning_failure_receipt.py`

The replacement preserved the deterministic exact-string runner boundary:

- synthetic-only fixtures
- no external model calls
- no LLM-as-judge
- no ledger writes
- no policy or agent authority changes

No content is being discarded; this stale predecessor is closed only after the replacement PR landed.