### PR TITLE
contracts: add agent action trace generated artifacts

### DIFF
--- a/.github/workflows/agent-action-trace-contracts.yml
+++ b/.github/workflows/agent-action-trace-contracts.yml
@@ -1,0 +1,28 @@
+name: agent-action-trace-contracts
+
+on:
+  pull_request:
+    paths:
+      - "contracts/agent-action-trace/**"
+      - "docs/generated/agent-action-trace/**"
+      - "tools/validate_agent_action_trace_contracts.py"
+      - ".github/workflows/agent-action-trace-contracts.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "contracts/agent-action-trace/**"
+      - "docs/generated/agent-action-trace/**"
+      - "tools/validate_agent_action_trace_contracts.py"
+      - ".github/workflows/agent-action-trace-contracts.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Validate generated agent action trace contracts
+        run: python3 tools/validate_agent_action_trace_contracts.py

--- a/contracts/agent-action-trace/README.md
+++ b/contracts/agent-action-trace/README.md
@@ -1,6 +1,6 @@
 # Agent Action / Trace Contracts
 
-This directory is the generated-artifact target for the `agent-action-trace-profile` standards import in `standards.lock.yaml`.
+This directory contains generated platform-facing contract artifacts derived from the pinned `agent-action-trace-profile` standards import in `standards.lock.yaml`.
 
 ## Upstream authority
 
@@ -8,15 +8,23 @@ This directory is the generated-artifact target for the `agent-action-trace-prof
 - Semantic ontology authority: `SocioProphet/ontogenesis`
 - Bootstrap examples and validator authority: `SocioProphet/socioprophet-standards-storage`
 
-## Current status
+## Current artifacts
 
-Placeholder only.
+- `agent-action-record.v0.1.schema.json`
+- `agent-trace-record.v0.1.schema.json`
+- `agent-action-trace-conformance-report.v0.1.schema.json`
+- `examples/agent-action-record.example.v0.1.json`
+- `examples/agent-trace-record.example.v0.1.json`
+- `examples/agent-action-trace-conformance-report.example.v0.1.json`
 
-No runtime implementation, generated schema materialization, or service behavior is introduced in this tranche.
+## Validation
 
-## Expected future artifacts
+Run:
 
-- agent action/trace profile contract projections
-- generated action/trace example fixtures
-- runtime conformance reports for AgentPlane/workspace/lampstand consumers
-- policy/evidence/receipt linkage summaries
+```bash
+python3 tools/validate_agent_action_trace_contracts.py
+```
+
+## Boundary
+
+These contracts do not implement runtime behavior. They define the platform-generated contract surface that downstream runtime components can consume in later implementation PRs.

--- a/contracts/agent-action-trace/agent-action-record.v0.1.schema.json
+++ b/contracts/agent-action-trace/agent-action-record.v0.1.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/prophet-platform/agent-action-trace/0.1.0/agent-action-record.schema.json",
+  "title": "AgentActionRecord",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {"const": "prophet-platform.socioprophet.org/v0.1"},
+    "kind": {"const": "AgentActionRecord"},
+    "metadata": {
+      "type": "object",
+      "required": ["recordId", "profileRef", "standardsRef"],
+      "properties": {
+        "recordId": {"type": "string"},
+        "profileRef": {"type": "string"},
+        "standardsRef": {"type": "string"},
+        "ontologyRef": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "type": "object",
+      "required": ["agentSubjectRef", "actionId", "actionType", "fromStateRef", "toStateRef", "timestamp", "policyRef", "receiptRef"],
+      "properties": {
+        "agentSubjectRef": {"type": "string"},
+        "actionId": {"type": "string"},
+        "actionType": {"type": "string"},
+        "fromStateRef": {"type": "string"},
+        "toStateRef": {"type": "string"},
+        "timestamp": {"type": "string", "format": "date-time"},
+        "policyRef": {"type": "string"},
+        "receiptRef": {"type": "string"},
+        "evidenceRefs": {"type": "array", "items": {"type": "string"}},
+        "traceRefs": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/agent-action-trace/agent-action-trace-conformance-report.v0.1.schema.json
+++ b/contracts/agent-action-trace/agent-action-trace-conformance-report.v0.1.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/prophet-platform/agent-action-trace/0.1.0/agent-action-trace-conformance-report.schema.json",
+  "title": "AgentActionTraceConformanceReport",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {"const": "prophet-platform.socioprophet.org/v0.1"},
+    "kind": {"const": "AgentActionTraceConformanceReport"},
+    "metadata": {
+      "type": "object",
+      "required": ["reportId", "profileRef", "standardsPin"],
+      "properties": {
+        "reportId": {"type": "string"},
+        "profileRef": {"type": "string"},
+        "standardsPin": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "type": "object",
+      "required": ["implementationRef", "ontologyRef", "bootstrapValidatorRef", "overallStatus", "checks"],
+      "properties": {
+        "implementationRef": {"type": "string"},
+        "ontologyRef": {"type": "string"},
+        "bootstrapValidatorRef": {"type": "string"},
+        "overallStatus": {"type": "string", "enum": ["pass", "warn", "fail"]},
+        "checks": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["id", "status", "evidenceRef"],
+            "properties": {
+              "id": {"type": "string"},
+              "status": {"type": "string", "enum": ["pass", "warn", "fail"]},
+              "evidenceRef": {"type": "string"},
+              "summary": {"type": "string"}
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/agent-action-trace/agent-trace-record.v0.1.schema.json
+++ b/contracts/agent-action-trace/agent-trace-record.v0.1.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/prophet-platform/agent-action-trace/0.1.0/agent-trace-record.schema.json",
+  "title": "AgentTraceRecord",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {"const": "prophet-platform.socioprophet.org/v0.1"},
+    "kind": {"const": "AgentTraceRecord"},
+    "metadata": {
+      "type": "object",
+      "required": ["recordId", "profileRef", "standardsRef"],
+      "properties": {
+        "recordId": {"type": "string"},
+        "profileRef": {"type": "string"},
+        "standardsRef": {"type": "string"},
+        "ontologyRef": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "type": "object",
+      "required": ["traceId", "pattern", "traceKind", "medium", "timestamp", "traceIsAuthority"],
+      "properties": {
+        "traceId": {"type": "string"},
+        "pattern": {"type": "string", "enum": ["ContractNet", "PubSub", "ContractNetPubSubBridge"]},
+        "traceKind": {"type": "string"},
+        "medium": {"type": "string"},
+        "timestamp": {"type": "string", "format": "date-time"},
+        "refActionId": {"type": "string"},
+        "taskId": {"type": "string"},
+        "topicId": {"type": "string"},
+        "messageId": {"type": "string"},
+        "policyRef": {"type": "string"},
+        "receiptRef": {"type": "string"},
+        "evidenceRefs": {"type": "array", "items": {"type": "string"}},
+        "traceIsAuthority": {"const": false}
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/agent-action-trace/examples/agent-action-record.example.v0.1.json
+++ b/contracts/agent-action-trace/examples/agent-action-record.example.v0.1.json
@@ -1,0 +1,22 @@
+{
+  "apiVersion": "prophet-platform.socioprophet.org/v0.1",
+  "kind": "AgentActionRecord",
+  "metadata": {
+    "recordId": "action-record-0001",
+    "profileRef": "github://SocioProphet/socioprophet-agent-standards/docs/standards/agent-plane/001-agent-action-trace-conformance-profile.md",
+    "standardsRef": "github://SocioProphet/socioprophet-agent-standards@97e3f49ec4b27349f532db27ebaad618d4f9520c",
+    "ontologyRef": "github://SocioProphet/ontogenesis/Middle/action-ontology.ttl"
+  },
+  "spec": {
+    "agentSubjectRef": "agent://platform/agentplane/bootstrap-agent",
+    "actionId": "action.exec.0001",
+    "actionType": "executeTask",
+    "fromStateRef": "state.awarded",
+    "toStateRef": "state.done",
+    "timestamp": "2026-05-05T18:30:00Z",
+    "policyRef": "policy://platform/action-trace/decision-0001",
+    "receiptRef": "receipt://platform/action-trace/action-record-0001",
+    "evidenceRefs": ["evidence://platform/action-trace/record-0001"],
+    "traceRefs": ["trace.done.0001"]
+  }
+}

--- a/contracts/agent-action-trace/examples/agent-action-trace-conformance-report.example.v0.1.json
+++ b/contracts/agent-action-trace/examples/agent-action-trace-conformance-report.example.v0.1.json
@@ -1,0 +1,29 @@
+{
+  "apiVersion": "prophet-platform.socioprophet.org/v0.1",
+  "kind": "AgentActionTraceConformanceReport",
+  "metadata": {
+    "reportId": "agent-action-trace-conformance-0001",
+    "profileRef": "github://SocioProphet/socioprophet-agent-standards/docs/standards/agent-plane/001-agent-action-trace-conformance-profile.md",
+    "standardsPin": "97e3f49ec4b27349f532db27ebaad618d4f9520c"
+  },
+  "spec": {
+    "implementationRef": "github://SocioProphet/prophet-platform/apps/agentplane",
+    "ontologyRef": "github://SocioProphet/ontogenesis/Middle/action-ontology.ttl",
+    "bootstrapValidatorRef": "github://SocioProphet/socioprophet-standards-storage/tools/action_ontology_validate_all.sh",
+    "overallStatus": "pass",
+    "checks": [
+      {
+        "id": "trace-is-evidence-not-authority",
+        "status": "pass",
+        "evidenceRef": "evidence://platform/action-trace/trace-record-0001",
+        "summary": "Trace records preserve coordination evidence without granting authority."
+      },
+      {
+        "id": "policy-and-receipt-refs-present",
+        "status": "pass",
+        "evidenceRef": "receipt://platform/action-trace/action-record-0001",
+        "summary": "Action and trace records include policy and receipt references."
+      }
+    ]
+  }
+}

--- a/contracts/agent-action-trace/examples/agent-trace-record.example.v0.1.json
+++ b/contracts/agent-action-trace/examples/agent-trace-record.example.v0.1.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "prophet-platform.socioprophet.org/v0.1",
+  "kind": "AgentTraceRecord",
+  "metadata": {
+    "recordId": "trace-record-0001",
+    "profileRef": "github://SocioProphet/socioprophet-agent-standards/docs/standards/agent-plane/001-agent-action-trace-conformance-profile.md",
+    "standardsRef": "github://SocioProphet/socioprophet-agent-standards@97e3f49ec4b27349f532db27ebaad618d4f9520c",
+    "ontologyRef": "github://SocioProphet/ontogenesis/Middle/action-ontology.ttl"
+  },
+  "spec": {
+    "traceId": "trace.done.0001",
+    "pattern": "ContractNet",
+    "traceKind": "done",
+    "medium": "bus:tasks",
+    "timestamp": "2026-05-05T18:30:01Z",
+    "refActionId": "action.exec.0001",
+    "taskId": "task-0001",
+    "policyRef": "policy://platform/action-trace/decision-0001",
+    "receiptRef": "receipt://platform/action-trace/trace-record-0001",
+    "evidenceRefs": ["evidence://platform/action-trace/record-0001"],
+    "traceIsAuthority": false
+  }
+}

--- a/docs/generated/agent-action-trace/contract-consumption.md
+++ b/docs/generated/agent-action-trace/contract-consumption.md
@@ -1,0 +1,38 @@
+# Agent Action / Trace Contract Consumption
+
+## Purpose
+
+This note documents the first platform-generated contract surface derived from the pinned Agent Action / Trace Conformance Profile.
+
+## Source standards
+
+- Runtime-facing profile: `SocioProphet/socioprophet-agent-standards#22`
+- Pinned commit: `97e3f49ec4b27349f532db27ebaad618d4f9520c`
+- Semantic ontology source: `SocioProphet/ontogenesis`
+- Bootstrap validator source: `SocioProphet/socioprophet-standards-storage`
+
+## Platform contract family
+
+- `AgentActionRecord`
+- `AgentTraceRecord`
+- `AgentActionTraceConformanceReport`
+
+## Initial consumers
+
+The standards lock declares these initial platform runtime targets:
+
+- `apps/agentplane`
+- `apps/workspace-controller`
+- `apps/lampstand`
+
+## Runtime boundary
+
+This tranche introduces generated contract artifacts only. Runtime code must not claim conformance until it emits matching records and produces a validation or receipt trail.
+
+## Validation
+
+Run:
+
+```bash
+python3 tools/validate_agent_action_trace_contracts.py
+```

--- a/tools/validate_agent_action_trace_contracts.py
+++ b/tools/validate_agent_action_trace_contracts.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_DIR = ROOT / "contracts" / "agent-action-trace"
+EXAMPLES_DIR = CONTRACT_DIR / "examples"
+EXPECTED_API_VERSION = "prophet-platform.socioprophet.org/v0.1"
+EXPECTED_KINDS = {
+    "agent-action-record.v0.1.schema.json": "AgentActionRecord",
+    "agent-trace-record.v0.1.schema.json": "AgentTraceRecord",
+    "agent-action-trace-conformance-report.v0.1.schema.json": "AgentActionTraceConformanceReport",
+}
+EXAMPLE_BY_KIND = {
+    "AgentActionRecord": "agent-action-record.example.v0.1.json",
+    "AgentTraceRecord": "agent-trace-record.example.v0.1.json",
+    "AgentActionTraceConformanceReport": "agent-action-trace-conformance-report.example.v0.1.json",
+}
+
+
+def fail(msg: str) -> None:
+    print(f"ERR: {msg}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def load_json(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        fail(f"{path.relative_to(ROOT)}: invalid JSON: {exc}")
+    if not isinstance(data, dict):
+        fail(f"{path.relative_to(ROOT)}: expected top-level object")
+    return data
+
+
+def require_keys(obj: dict, keys: list[str], where: str) -> None:
+    missing = [key for key in keys if key not in obj]
+    if missing:
+        fail(f"{where}: missing required keys: {', '.join(missing)}")
+
+
+def validate_schema(path: Path, expected_kind: str) -> None:
+    data = load_json(path)
+    if data.get("$schema") != "https://json-schema.org/draft/2020-12/schema":
+        fail(f"{path.relative_to(ROOT)}: expected JSON Schema draft 2020-12")
+    if data.get("title") != expected_kind:
+        fail(f"{path.relative_to(ROOT)}: expected title {expected_kind}")
+    props = data.get("properties")
+    if not isinstance(props, dict):
+        fail(f"{path.relative_to(ROOT)}: properties must be object")
+    if props.get("apiVersion", {}).get("const") != EXPECTED_API_VERSION:
+        fail(f"{path.relative_to(ROOT)}: apiVersion const mismatch")
+    if props.get("kind", {}).get("const") != expected_kind:
+        fail(f"{path.relative_to(ROOT)}: kind const mismatch")
+
+
+def validate_example(path: Path, expected_kind: str) -> None:
+    data = load_json(path)
+    require_keys(data, ["apiVersion", "kind", "metadata", "spec"], str(path.relative_to(ROOT)))
+    if data["apiVersion"] != EXPECTED_API_VERSION:
+        fail(f"{path.relative_to(ROOT)}: apiVersion mismatch")
+    if data["kind"] != expected_kind:
+        fail(f"{path.relative_to(ROOT)}: kind mismatch")
+    metadata = data["metadata"]
+    if not isinstance(metadata, dict):
+        fail(f"{path.relative_to(ROOT)}: metadata must be object")
+    for ref_key in ("profileRef", "standardsRef"):
+        if ref_key in metadata and "socioprophet-agent-standards" not in metadata[ref_key]:
+            fail(f"{path.relative_to(ROOT)}: metadata.{ref_key} must reference socioprophet-agent-standards")
+    if "ontologyRef" in metadata and "SocioProphet/ontogenesis" not in metadata["ontologyRef"]:
+        fail(f"{path.relative_to(ROOT)}: metadata.ontologyRef must reference SocioProphet/ontogenesis")
+
+    spec = data["spec"]
+    if not isinstance(spec, dict):
+        fail(f"{path.relative_to(ROOT)}: spec must be object")
+    if expected_kind == "AgentTraceRecord":
+        if spec.get("traceIsAuthority") is not False:
+            fail(f"{path.relative_to(ROOT)}: traceIsAuthority must be false")
+        require_keys(spec, ["traceId", "pattern", "traceKind", "medium", "timestamp"], f"{path.relative_to(ROOT)}:spec")
+    elif expected_kind == "AgentActionRecord":
+        require_keys(spec, ["agentSubjectRef", "actionId", "actionType", "policyRef", "receiptRef"], f"{path.relative_to(ROOT)}:spec")
+    elif expected_kind == "AgentActionTraceConformanceReport":
+        require_keys(spec, ["implementationRef", "ontologyRef", "bootstrapValidatorRef", "overallStatus", "checks"], f"{path.relative_to(ROOT)}:spec")
+        if "SocioProphet/ontogenesis" not in spec["ontologyRef"]:
+            fail(f"{path.relative_to(ROOT)}: spec.ontologyRef must reference SocioProphet/ontogenesis")
+        if "socioprophet-standards-storage" not in spec["bootstrapValidatorRef"]:
+            fail(f"{path.relative_to(ROOT)}: spec.bootstrapValidatorRef must reference socioprophet-standards-storage")
+
+
+def main() -> int:
+    for schema_name, kind in EXPECTED_KINDS.items():
+        schema_path = CONTRACT_DIR / schema_name
+        if not schema_path.exists():
+            fail(f"missing schema: {schema_path.relative_to(ROOT)}")
+        validate_schema(schema_path, kind)
+        example_path = EXAMPLES_DIR / EXAMPLE_BY_KIND[kind]
+        if not example_path.exists():
+            fail(f"missing example: {example_path.relative_to(ROOT)}")
+        validate_example(example_path, kind)
+    print("OK: validated agent action/trace generated contracts and examples")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Ready replacement for draft PR #423.

Adds concrete generated contract artifacts for the pinned Agent Action / Trace Conformance Profile.

## What lands

- `contracts/agent-action-trace/agent-action-record.v0.1.schema.json`
- `contracts/agent-action-trace/agent-trace-record.v0.1.schema.json`
- `contracts/agent-action-trace/agent-action-trace-conformance-report.v0.1.schema.json`
- matching example fixtures under `contracts/agent-action-trace/examples/`
- `docs/generated/agent-action-trace/contract-consumption.md`
- `tools/validate_agent_action_trace_contracts.py`
- `.github/workflows/agent-action-trace-contracts.yml`
- updated `contracts/agent-action-trace/README.md`

## Why

PR #421 pinned the Agent Action / Trace profile as a controlled normative standard and reserved generated-artifact directories. This PR materializes the first generated contract family and validation path without changing runtime behavior.

## Boundary

- Contract/example/validator only
- no runtime implementation
- no service conformance claim
- no AgentPlane behavior change
- semantic ontology authority remains `SocioProphet/ontogenesis`
- bootstrap validator authority remains `SocioProphet/socioprophet-standards-storage`

## Validation

All visible workflows on the same head SHA `1f8879cc847ee6d047f10679608856d417c407cc` completed successfully, including:

- `agent-action-trace-contracts`
- `validate`
- `ci`
- `platform-contracts-check`
- `premerge-audit`
- `brokerage-validation`
- `cloudshell-fog structural conformance v2`
- `cloudshell-fog structural conformance v3`
- `platform-wave1-stubs`
- `workspace-operation-runtime`

Focused workflow proof:

```text
Validate generated agent action trace contracts: success
```

## Supersedes

Supersedes draft PR #423, which is content/CI-valid but remains draft due to the connector draft-state limitation previously observed.

## Follow-up

- add runtime consumption notes for `apps/agentplane`, `apps/workspace-controller`, and `apps/lampstand`
- add negative fixtures for generated contracts
- wire generated conformance reports into runtime evidence once implementation surfaces emit records