### PR TITLE
docs: define provable AI operations exchange

### DIFF
--- a/contracts/ProvableAIOpsExchange.v0.1.json
+++ b/contracts/ProvableAIOpsExchange.v0.1.json
@@ -1,0 +1,838 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/ProvableAIOpsExchange.v0.1.json",
+  "title": "ProvableAIOpsExchange",
+  "type": "object",
+  "required": [
+    "version",
+    "exchange_id",
+    "created_at",
+    "brief",
+    "claims",
+    "artifacts",
+    "custody_events"
+  ],
+  "properties": {
+    "version": {
+      "const": "0.1"
+    },
+    "exchange_id": {
+      "type": "string",
+      "description": "Stable exchange, brief, or bundle identifier."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "brief": {
+      "$ref": "#/$defs/IntelligenceBrief"
+    },
+    "claims": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Claim"
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Evidence"
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Artifact"
+      }
+    },
+    "custody_events": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/CustodyEvent"
+      }
+    },
+    "specialists": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/SpecialistCredential"
+      }
+    },
+    "agent_actions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/AgentAction"
+      }
+    },
+    "evaluation_runs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/EvaluationRun"
+      }
+    },
+    "benchmark_packs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/BenchmarkPack"
+      }
+    },
+    "policy_decisions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/PolicyDecision"
+      }
+    },
+    "review_attestations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ReviewAttestation"
+      }
+    }
+  },
+  "$defs": {
+    "HashRef": {
+      "type": "object",
+      "required": [
+        "hash",
+        "hash_algo"
+      ],
+      "properties": {
+        "hash": {
+          "type": "string"
+        },
+        "hash_algo": {
+          "type": "string",
+          "enum": [
+            "sha256",
+            "blake3"
+          ]
+        },
+        "uri": {
+          "type": "string"
+        },
+        "media_type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Signature": {
+      "type": "object",
+      "required": [
+        "signer_ref",
+        "signature",
+        "signature_algo",
+        "signed_at"
+      ],
+      "properties": {
+        "signer_ref": {
+          "type": "string"
+        },
+        "signature": {
+          "type": "string"
+        },
+        "signature_algo": {
+          "type": "string"
+        },
+        "signed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "key_ref": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Claim": {
+      "type": "object",
+      "required": [
+        "claim_id",
+        "statement",
+        "status",
+        "confidence",
+        "evidence_refs",
+        "owner_ref",
+        "created_at"
+      ],
+      "properties": {
+        "claim_id": {
+          "type": "string"
+        },
+        "statement": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "supported",
+            "contested",
+            "superseded",
+            "retracted"
+          ]
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "scope": {
+          "type": "string"
+        },
+        "evidence_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "counterevidence_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "artifact_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policy_decision_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "owner_ref": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Evidence": {
+      "type": "object",
+      "required": [
+        "evidence_id",
+        "kind",
+        "subject_ref",
+        "hash_ref",
+        "source_ref",
+        "collected_at"
+      ],
+      "properties": {
+        "evidence_id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "dataset",
+            "document",
+            "log",
+            "metric",
+            "notebook",
+            "source_code",
+            "eval_output",
+            "receipt",
+            "external_source",
+            "human_observation"
+          ]
+        },
+        "subject_ref": {
+          "type": "string"
+        },
+        "hash_ref": {
+          "$ref": "#/$defs/HashRef"
+        },
+        "source_ref": {
+          "type": "string"
+        },
+        "license_ref": {
+          "type": "string"
+        },
+        "quality": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "collected_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "custody_event_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Artifact": {
+      "type": "object",
+      "required": [
+        "artifact_id",
+        "artifact_type",
+        "version",
+        "hash_ref",
+        "owner_ref",
+        "created_at"
+      ],
+      "properties": {
+        "artifact_id": {
+          "type": "string"
+        },
+        "artifact_type": {
+          "type": "string",
+          "enum": [
+            "intelligence_brief",
+            "benchmark_pack",
+            "model_card",
+            "dataset_card",
+            "policy_bundle",
+            "agent_manifest",
+            "ontology",
+            "eval_suite",
+            "dashboard",
+            "playbook",
+            "report_render"
+          ]
+        },
+        "version": {
+          "type": "string"
+        },
+        "hash_ref": {
+          "$ref": "#/$defs/HashRef"
+        },
+        "owner_ref": {
+          "type": "string"
+        },
+        "schema_ref": {
+          "type": "string"
+        },
+        "license_ref": {
+          "type": "string"
+        },
+        "input_artifact_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "output_artifact_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "certified",
+            "deprecated",
+            "revoked"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "CustodyEvent": {
+      "type": "object",
+      "required": [
+        "custody_event_id",
+        "event_type",
+        "actor_ref",
+        "subject_ref",
+        "occurred_at",
+        "hash_ref"
+      ],
+      "properties": {
+        "custody_event_id": {
+          "type": "string"
+        },
+        "event_type": {
+          "type": "string",
+          "enum": [
+            "created",
+            "ingested",
+            "transformed",
+            "evaluated",
+            "reviewed",
+            "approved",
+            "rejected",
+            "published",
+            "deployed",
+            "rolled_back",
+            "revoked",
+            "retired"
+          ]
+        },
+        "actor_ref": {
+          "type": "string"
+        },
+        "actor_type": {
+          "type": "string",
+          "enum": [
+            "human",
+            "agent",
+            "service",
+            "organization"
+          ]
+        },
+        "subject_ref": {
+          "type": "string"
+        },
+        "subject_type": {
+          "type": "string",
+          "enum": [
+            "claim",
+            "evidence",
+            "artifact",
+            "agent_action",
+            "evaluation_run",
+            "policy_decision",
+            "specialist_credential"
+          ]
+        },
+        "occurred_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "hash_ref": {
+          "$ref": "#/$defs/HashRef"
+        },
+        "previous_event_ref": {
+          "type": "string"
+        },
+        "policy_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "signature": {
+          "$ref": "#/$defs/Signature"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SpecialistCredential": {
+      "type": "object",
+      "required": [
+        "credential_id",
+        "subject_ref",
+        "issuer_ref",
+        "scope",
+        "status",
+        "issued_at"
+      ],
+      "properties": {
+        "credential_id": {
+          "type": "string"
+        },
+        "subject_ref": {
+          "type": "string"
+        },
+        "issuer_ref": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "assurance_level": {
+          "type": "string",
+          "enum": [
+            "self_asserted",
+            "peer_reviewed",
+            "certified",
+            "audited"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "active",
+            "suspended",
+            "revoked",
+            "expired"
+          ]
+        },
+        "issued_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "evidence_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "signature": {
+          "$ref": "#/$defs/Signature"
+        }
+      },
+      "additionalProperties": false
+    },
+    "AgentAction": {
+      "type": "object",
+      "required": [
+        "agent_action_id",
+        "agent_ref",
+        "tool_ref",
+        "input_refs",
+        "output_refs",
+        "policy_decision_ref",
+        "started_at",
+        "status"
+      ],
+      "properties": {
+        "agent_action_id": {
+          "type": "string"
+        },
+        "agent_ref": {
+          "type": "string"
+        },
+        "model_ref": {
+          "type": "string"
+        },
+        "tool_ref": {
+          "type": "string"
+        },
+        "runtime_ref": {
+          "type": "string"
+        },
+        "input_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "output_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "policy_decision_ref": {
+          "type": "string"
+        },
+        "custody_event_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "finished_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "accepted",
+            "succeeded",
+            "failed",
+            "denied",
+            "partial"
+          ]
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "EvaluationRun": {
+      "type": "object",
+      "required": [
+        "evaluation_run_id",
+        "benchmark_pack_ref",
+        "target_ref",
+        "runner_ref",
+        "started_at",
+        "status",
+        "metrics"
+      ],
+      "properties": {
+        "evaluation_run_id": {
+          "type": "string"
+        },
+        "benchmark_pack_ref": {
+          "type": "string"
+        },
+        "target_ref": {
+          "type": "string"
+        },
+        "runner_ref": {
+          "type": "string"
+        },
+        "input_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "output_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "finished_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "accepted",
+            "succeeded",
+            "failed",
+            "denied",
+            "partial"
+          ]
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "reproducibility": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "BenchmarkPack": {
+      "type": "object",
+      "required": [
+        "benchmark_pack_id",
+        "name",
+        "version",
+        "artifact_ref",
+        "task_scope",
+        "owner_ref"
+      ],
+      "properties": {
+        "benchmark_pack_id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "artifact_ref": {
+          "type": "string"
+        },
+        "task_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "owner_ref": {
+          "type": "string"
+        },
+        "policy_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "minimum_evidence_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "PolicyDecision": {
+      "type": "object",
+      "required": [
+        "policy_decision_id",
+        "policy_ref",
+        "subject_ref",
+        "decision",
+        "decided_at"
+      ],
+      "properties": {
+        "policy_decision_id": {
+          "type": "string"
+        },
+        "policy_ref": {
+          "type": "string"
+        },
+        "subject_ref": {
+          "type": "string"
+        },
+        "decision": {
+          "type": "string",
+          "enum": [
+            "allow",
+            "deny",
+            "review",
+            "quarantine"
+          ]
+        },
+        "reason": {
+          "type": "string"
+        },
+        "decided_by_ref": {
+          "type": "string"
+        },
+        "decided_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "input_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "output_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ReviewAttestation": {
+      "type": "object",
+      "required": [
+        "review_attestation_id",
+        "reviewer_ref",
+        "subject_ref",
+        "decision",
+        "reviewed_at"
+      ],
+      "properties": {
+        "review_attestation_id": {
+          "type": "string"
+        },
+        "reviewer_ref": {
+          "type": "string"
+        },
+        "subject_ref": {
+          "type": "string"
+        },
+        "review_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "decision": {
+          "type": "string",
+          "enum": [
+            "approve",
+            "request_changes",
+            "reject",
+            "abstain"
+          ]
+        },
+        "notes_ref": {
+          "type": "string"
+        },
+        "conflict_disclosure_ref": {
+          "type": "string"
+        },
+        "reviewed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "signature": {
+          "$ref": "#/$defs/Signature"
+        }
+      },
+      "additionalProperties": false
+    },
+    "IntelligenceBrief": {
+      "type": "object",
+      "required": [
+        "brief_id",
+        "title",
+        "artifact_ref",
+        "claim_refs",
+        "status"
+      ],
+      "properties": {
+        "brief_id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "artifact_ref": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "claim_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "audience": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "certified",
+            "contested",
+            "deprecated",
+            "revoked"
+          ]
+        },
+        "render_refs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -13,3 +13,13 @@ The initial family is intentionally small:
 - `LensOutput`
 - `ExportApproved`
 - `ExportDenied`
+- `ProvableAIOpsExchange`
+
+## Provable AI Operations Exchange
+
+`ProvableAIOpsExchange.v0.1.json` is the higher-order artifact graph for certified intelligence and agentic operations custody. It complements `EvidenceReceipt` rather than replacing it:
+
+- `EvidenceReceipt` is the compact runtime receipt emitted by services.
+- `ProvableAIOpsExchange` assembles claims, evidence, artifacts, custody events, specialist credentials, agent actions, evaluation runs, benchmark packs, policy decisions, review attestations, and rendered intelligence briefs.
+
+Use it when a workflow needs to replace analyst-style authority with reproducible, challengeable, policy-gated operating proof.

--- a/docs/PROVABLE_AI_OPS_EXCHANGE.md
+++ b/docs/PROVABLE_AI_OPS_EXCHANGE.md
@@ -1,0 +1,207 @@
+# Provable AI Operations Exchange
+
+Status: draft v0.1
+Owner lane: Prophet Platform runtime and evidence fabric
+Primary intent: replace analyst-authority intelligence with certified, reproducible, chain-of-custody operating intelligence for agentic enterprise operations.
+
+## Thesis
+
+The legacy analyst model sells conclusions, reputation, and periodic research distribution. The SocioProphet replacement model sells verifiable operating intelligence: claims backed by signed artifacts, reproducible evaluation runs, specialist attestations, policy decisions, custody events, and operational outcomes.
+
+This is not a market-research feature. It is a control-plane pattern for enterprise AI operations.
+
+## What changes
+
+A normal analyst brief says: trust the analyst.
+
+A Provable Intelligence Brief says: here is the claim, here is the evidence, here are the artifacts, here is the benchmark pack, here are the model and agent runs, here are the policies that admitted or denied the work, here are the human and agent reviewers, here is the custody chain, here are the uncertainty bounds, and here is how to reproduce or challenge the result.
+
+## Non-goals
+
+- Do not create a detached analyst-content shop.
+- Do not publish unsupported conclusions as first-class platform artifacts.
+- Do not let a human specialist, model, or agent certify work outside its scoped credential.
+- Do not treat PDF, slide, or dashboard renders as the system of record.
+- Do not accept evidence whose origin, hash, license, and custody trail are unknown.
+
+## Canonical loop
+
+1. Intake a question, market signal, operational issue, benchmark target, or governance concern.
+2. Register the work as a scoped exchange or brief.
+3. Collect evidence with source, hash, license, quality, and custody metadata.
+4. Produce or update artifacts: benchmark packs, eval suites, model cards, policy bundles, agent manifests, dashboards, reports, ontologies, or playbooks.
+5. Run policy admission before analysis, agent execution, publication, or deployment.
+6. Execute agent and specialist work under AgentPlane custody.
+7. Record model, tool, prompt, dataset, notebook, policy, and runtime versions.
+8. Generate claims only from evidence-linked outputs.
+9. Attach specialist and peer-review attestations.
+10. Publish a Provable Intelligence Brief as a rendered view over the evidence graph.
+11. Keep the brief live: expire, contest, supersede, retract, or recertify it as evidence changes.
+
+## Trust model
+
+The exchange uses four trust layers.
+
+### Artifact trust
+
+Every data product, eval suite, report render, policy bundle, model card, ontology, dashboard, or agent manifest has a stable artifact ID, version, content hash, schema reference, owner, license, status, and custody history.
+
+### Specialist trust
+
+A specialist may be a human, organization, service, or certified agent. Each credential has an issuer, subject, scope, assurance level, evidence references, status, expiration, and signature. Credentials are scoped and revocable.
+
+### Action trust
+
+Every agent or service action produces custody events. The required minimum is actor, tool/runtime/model reference, input references, output references, policy decision, start/finish timestamps, status, metrics, and signatures when available.
+
+### Claim trust
+
+A claim cannot be certified unless it has supporting evidence, artifact references, review attestations, policy decisions, confidence, and an expiry or recertification path. Counterevidence is first-class.
+
+## Contract family
+
+The v0.1 platform contract is materialized in:
+
+- `contracts/ProvableAIOpsExchange.v0.1.json`
+
+It defines:
+
+- `Claim`
+- `Evidence`
+- `Artifact`
+- `CustodyEvent`
+- `SpecialistCredential`
+- `AgentAction`
+- `EvaluationRun`
+- `BenchmarkPack`
+- `PolicyDecision`
+- `ReviewAttestation`
+- `IntelligenceBrief`
+
+This complements the existing `EvidenceReceipt` and event-envelope spine. `EvidenceReceipt` remains the small runtime receipt. `ProvableAIOpsExchange` is the higher-order graph envelope for assembled intelligence, certification, and operating proof.
+
+## Product surfaces
+
+### Sherlock Search
+
+Sherlock discovers claims, evidence, artifacts, specialists, benchmark packs, policy decisions, briefs, counterclaims, and operational playbooks. Search result ranking should be able to prefer certified artifacts over unsupported prose.
+
+### Sociosphere
+
+Sociosphere is the registry and graph surface for public and internal artifact discovery. It owns relationship traversal across organizations, specialists, claims, evidence, custody events, agent capabilities, and trust state.
+
+### AgentPlane
+
+AgentPlane records action custody for agent and tool execution. It must emit `AgentAction`, `PolicyDecision`, `CustodyEvent`, and receipt references for every admitted action.
+
+### Guardrail Fabric and Policy Fabric
+
+The policy layer gates ingestion, analysis, agent execution, specialist review, certification, publication, deployment, rollback, revocation, and export.
+
+### Model Governance Ledger
+
+The ledger records model and model-router decisions, eval runs, model-card artifacts, risk approvals, benchmark outcomes, recertification events, and revocation records.
+
+### DeliveryExcellence
+
+DeliveryExcellence turns the evidence graph into operating metrics: cost, latency, cycle time, benchmark deltas, automation ROI, agent reliability, governance coverage, control failures, review burden, and delivery throughput.
+
+### Ontogenesis
+
+Ontogenesis is the schema generator and semantic compiler. It should promote this v0.1 JSON contract into JSON-LD, SHACL, Avro, TriTRPC IDL, and CRD shapes.
+
+### HolographMe
+
+HolographMe owns specialist identity, credential projection, scoped digital-twin boundaries, review history, conflicts, reputation, and revocation surfaces.
+
+### Superconscious
+
+Superconscious watches for stale briefs, weak claims, missing counterevidence, decaying benchmark coverage, recurrent agent failures, and recertification needs.
+
+## Certification levels
+
+### Level 0: Draft
+
+The brief or artifact is visible but uncertified. It may contain unresolved evidence gaps.
+
+### Level 1: Evidence-linked
+
+Claims reference evidence and artifacts, but review and reproducibility are incomplete.
+
+### Level 2: Reproducible
+
+The benchmark, eval, notebook, or pipeline can be reproduced from registered artifacts and environment metadata.
+
+### Level 3: Specialist-reviewed
+
+Scoped human or agent specialists have signed review attestations.
+
+### Level 4: Policy-certified
+
+The work passed required governance, safety, licensing, privacy, export, and publication controls.
+
+### Level 5: Operationally proven
+
+The recommendation or automation has measured operating results and continuous telemetry.
+
+## Minimum admissibility rules
+
+A certified brief must have:
+
+- At least one registered `IntelligenceBrief` artifact.
+- At least one `Claim` with evidence references.
+- At least one `Evidence` object per certified claim.
+- At least one `CustodyEvent` for every certified artifact.
+- A policy decision for publication or deployment.
+- Review attestations for every scoped specialist claim.
+- Confidence and expiry metadata for non-trivial claims.
+- Explicit counterevidence handling.
+- Reproduction instructions for benchmark- or eval-backed claims.
+- Revocation and supersession path.
+
+## Demo vertical slice
+
+The first demo should replace a conventional enterprise AI analyst note.
+
+Example: `Enterprise AI Automation Readiness and Agentic Ops Benchmark`.
+
+The demo brief should contain:
+
+1. Executive summary render.
+2. Machine-readable claim graph.
+3. Benchmark pack for automation maturity.
+4. Evidence receipts for source material and benchmark outputs.
+5. Model-router and agent execution logs.
+6. Policy decisions for data admission and publication.
+7. Specialist review attestations.
+8. DeliveryExcellence dashboard metrics.
+9. Sherlock discovery surface.
+10. Sociosphere registry record.
+11. Revocation and recertification hooks.
+
+## Acceptance criteria for the v0.1 platform lane
+
+- The contract validates as JSON Schema draft 2020-12.
+- Platform docs explain how the exchange relates to EvidenceReceipt, eval fabric, knowledge-reason, Lampstand, semantic-bridge, and zone-router.
+- At least one synthetic exchange bundle can be created without touching live customer data.
+- The synthetic bundle contains one brief, three claims, five evidence records, two artifacts, one benchmark pack, one eval run, one policy decision, one agent action, one specialist credential, one review attestation, and custody events tying them together.
+- The bundle can be rendered as a human-readable Provable Intelligence Brief.
+- The same bundle can be queried by ID, artifact type, claim status, specialist scope, policy decision, benchmark pack, and custody subject.
+- Failed or missing custody data blocks certification above Level 1.
+
+## Implementation sequence
+
+1. Materialize the v0.1 contract.
+2. Add a synthetic fixture bundle.
+3. Add a validation script for contract and fixture integrity.
+4. Register the lane in the integration map.
+5. Add read endpoints to the existing evidence or knowledge-reason surfaces.
+6. Add write/admission events through AgentPlane once the contract is stable.
+7. Promote schema generation into Ontogenesis.
+8. Register artifacts and specialists in Sociosphere.
+9. Attach model and eval records in Model Governance Ledger.
+10. Publish the first Provable Intelligence Brief through Sherlock and SocioProphet docs.
+
+## Operating doctrine
+
+This lane exists to make enterprise intelligence challengeable, executable, inspectable, and governable. Analyst authority is replaced by artifact authority. Artifact authority is not blind trust; it is the combination of provenance, custody, reproducibility, policy, specialist review, and measured operational effect.


### PR DESCRIPTION
## Summary

Introduces the first platform lane for replacing legacy analyst-authority intelligence with certified, reproducible, chain-of-custody operating intelligence for agentic enterprise operations.

Changes:
- adds `docs/PROVABLE_AI_OPS_EXCHANGE.md`
- adds `contracts/ProvableAIOpsExchange.v0.1.json`
- indexes the new contract family in `contracts/README.md`

## Resolution

Closed as superseded/captured by clean replacement PR #555.

#555 preserved the intended additive contract content while avoiding stale high-churn index edits:

- `docs/PROVABLE_AI_OPS_EXCHANGE.md`
- `contracts/ProvableAIOpsExchange.v0.1.json`

## Deliberate deviation

The original stale branch modified `contracts/README.md`. The replacement intentionally omitted that high-churn index edit. Index surfacing can be added in a small follow-up PR if still useful.

## Follow-up lanes

- Add synthetic fixture bundle and validation script.
- Wire exchange graph into knowledge-reason, eval-fabric, evidence-receipts, Sherlock, Sociosphere, AgentPlane, Model Governance Ledger, DeliveryExcellence, and Ontogenesis.