### PR TITLE
contracts: add agent action trace negative fixtures and runtime-consumption notes

### DIFF
--- a/contracts/agent-action-trace/README.md
+++ b/contracts/agent-action-trace/README.md
@@ -13,9 +13,8 @@ This directory contains generated platform-facing contract artifacts derived fro
 - `agent-action-record.v0.1.schema.json`
 - `agent-trace-record.v0.1.schema.json`
 - `agent-action-trace-conformance-report.v0.1.schema.json`
-- `examples/agent-action-record.example.v0.1.json`
-- `examples/agent-trace-record.example.v0.1.json`
-- `examples/agent-action-trace-conformance-report.example.v0.1.json`
+- valid examples under `examples/`
+- invalid examples under `examples/invalid/`
 
 ## Validation
 
@@ -24,6 +23,16 @@ Run:
 ```bash
 python3 tools/validate_agent_action_trace_contracts.py
 ```
+
+The validator checks positive examples and asserts the negative fixtures fail as expected.
+
+## Negative fixtures
+
+The negative fixture set currently proves rejection of:
+
+- an `AgentActionRecord` missing `receiptRef`
+- an `AgentTraceRecord` that incorrectly sets `traceIsAuthority: true`
+- an `AgentActionTraceConformanceReport` that points bootstrap-validator authority at the wrong repository
 
 ## Boundary
 

--- a/contracts/agent-action-trace/examples/invalid/agent-action-record.missing-receipt.example.v0.1.json
+++ b/contracts/agent-action-trace/examples/invalid/agent-action-record.missing-receipt.example.v0.1.json
@@ -1,0 +1,19 @@
+{
+  "apiVersion": "prophet-platform.socioprophet.org/v0.1",
+  "kind": "AgentActionRecord",
+  "metadata": {
+    "recordId": "action-record-invalid-missing-receipt",
+    "profileRef": "github://SocioProphet/socioprophet-agent-standards/docs/standards/agent-plane/001-agent-action-trace-conformance-profile.md",
+    "standardsRef": "github://SocioProphet/socioprophet-agent-standards@97e3f49ec4b27349f532db27ebaad618d4f9520c",
+    "ontologyRef": "github://SocioProphet/ontogenesis/Middle/action-ontology.ttl"
+  },
+  "spec": {
+    "agentSubjectRef": "agent://platform/agentplane/bootstrap-agent",
+    "actionId": "action.exec.invalid.0001",
+    "actionType": "executeTask",
+    "fromStateRef": "state.awarded",
+    "toStateRef": "state.done",
+    "timestamp": "2026-05-05T18:40:00Z",
+    "policyRef": "policy://platform/action-trace/decision-invalid"
+  }
+}

--- a/contracts/agent-action-trace/examples/invalid/agent-action-trace-conformance-report.bad-bootstrap-ref.example.v0.1.json
+++ b/contracts/agent-action-trace/examples/invalid/agent-action-trace-conformance-report.bad-bootstrap-ref.example.v0.1.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "prophet-platform.socioprophet.org/v0.1",
+  "kind": "AgentActionTraceConformanceReport",
+  "metadata": {
+    "reportId": "agent-action-trace-conformance-invalid-bootstrap",
+    "profileRef": "github://SocioProphet/socioprophet-agent-standards/docs/standards/agent-plane/001-agent-action-trace-conformance-profile.md",
+    "standardsPin": "97e3f49ec4b27349f532db27ebaad618d4f9520c"
+  },
+  "spec": {
+    "implementationRef": "github://SocioProphet/prophet-platform/apps/agentplane",
+    "ontologyRef": "github://SocioProphet/ontogenesis/Middle/action-ontology.ttl",
+    "bootstrapValidatorRef": "github://SocioProphet/prophet-platform/tools/action_ontology_validate_all.sh",
+    "overallStatus": "pass",
+    "checks": [
+      {
+        "id": "bad-bootstrap-ref",
+        "status": "pass",
+        "evidenceRef": "evidence://platform/action-trace/invalid-bootstrap",
+        "summary": "This fixture must fail because bootstrap validator authority points at the wrong repo."
+      }
+    ]
+  }
+}

--- a/contracts/agent-action-trace/examples/invalid/agent-trace-record.authority-true.example.v0.1.json
+++ b/contracts/agent-action-trace/examples/invalid/agent-trace-record.authority-true.example.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "prophet-platform.socioprophet.org/v0.1",
+  "kind": "AgentTraceRecord",
+  "metadata": {
+    "recordId": "trace-record-invalid-authority",
+    "profileRef": "github://SocioProphet/socioprophet-agent-standards/docs/standards/agent-plane/001-agent-action-trace-conformance-profile.md",
+    "standardsRef": "github://SocioProphet/socioprophet-agent-standards@97e3f49ec4b27349f532db27ebaad618d4f9520c",
+    "ontologyRef": "github://SocioProphet/ontogenesis/Middle/action-ontology.ttl"
+  },
+  "spec": {
+    "traceId": "trace.invalid.authority.0001",
+    "pattern": "ContractNet",
+    "traceKind": "done",
+    "medium": "bus:tasks",
+    "timestamp": "2026-05-05T18:40:01Z",
+    "refActionId": "action.exec.invalid.0001",
+    "taskId": "task-invalid",
+    "traceIsAuthority": true
+  }
+}

--- a/docs/generated/agent-action-trace/contract-consumption.md
+++ b/docs/generated/agent-action-trace/contract-consumption.md
@@ -25,6 +25,12 @@ The standards lock declares these initial platform runtime targets:
 - `apps/workspace-controller`
 - `apps/lampstand`
 
+Runtime-specific consumption notes:
+
+- `docs/generated/agent-action-trace/runtime-consumption-agentplane.md`
+- `docs/generated/agent-action-trace/runtime-consumption-workspace-controller.md`
+- `docs/generated/agent-action-trace/runtime-consumption-lampstand.md`
+
 ## Runtime boundary
 
 This tranche introduces generated contract artifacts only. Runtime code must not claim conformance until it emits matching records and produces a validation or receipt trail.

--- a/docs/generated/agent-action-trace/runtime-consumption-agentplane.md
+++ b/docs/generated/agent-action-trace/runtime-consumption-agentplane.md
@@ -1,0 +1,31 @@
+# AgentPlane Agent Action / Trace Consumption Note
+
+## Purpose
+
+This note defines the first consumption boundary for AgentPlane against the generated Agent Action / Trace contracts.
+
+## Expected future role
+
+AgentPlane should eventually emit or preserve:
+
+- `AgentActionRecord`
+- `AgentTraceRecord`
+- `AgentActionTraceConformanceReport`
+
+## Current boundary
+
+This note is documentation-only. It does not claim AgentPlane runtime conformance.
+
+## Required future evidence
+
+A future AgentPlane implementation PR should include:
+
+- at least one emitted `AgentActionRecord` fixture
+- at least one emitted `AgentTraceRecord` fixture
+- a conformance report fixture
+- linkage to policy decision and receipt references
+- validator execution evidence using `tools/validate_agent_action_trace_contracts.py`
+
+## Non-authority rule
+
+AgentPlane must treat traces as coordination/evidence artifacts, not as authorization.

--- a/docs/generated/agent-action-trace/runtime-consumption-lampstand.md
+++ b/docs/generated/agent-action-trace/runtime-consumption-lampstand.md
@@ -1,0 +1,26 @@
+# Lampstand Agent Action / Trace Consumption Note
+
+## Purpose
+
+This note defines the first consumption boundary for Lampstand against the generated Agent Action / Trace contracts.
+
+## Expected future role
+
+Lampstand should eventually index action/trace records and conformance reports so users and agents can search governed coordination evidence.
+
+## Current boundary
+
+This note is documentation-only. It does not claim Lampstand runtime conformance.
+
+## Required future evidence
+
+A future implementation PR should show:
+
+- indexed action record references
+- indexed trace record references
+- search/result surfaces that identify policy and receipt refs
+- no promotion of trace records into authorization authority
+
+## Indexing rule
+
+Lampstand may index traces as evidence and retrieval context. It must not become the authority for deciding whether an action was allowed.

--- a/docs/generated/agent-action-trace/runtime-consumption-workspace-controller.md
+++ b/docs/generated/agent-action-trace/runtime-consumption-workspace-controller.md
@@ -1,0 +1,26 @@
+# Workspace Controller Agent Action / Trace Consumption Note
+
+## Purpose
+
+This note defines the first consumption boundary for the workspace-controller surface against the generated Agent Action / Trace contracts.
+
+## Expected future role
+
+The workspace controller should eventually preserve or reference action/trace records when workspace orchestration requests trigger governed agent-plane work.
+
+## Current boundary
+
+This note is documentation-only. It does not claim workspace-controller runtime conformance.
+
+## Required future evidence
+
+A future implementation PR should show:
+
+- action records associated with workspace operation requests
+- trace records for coordination outcomes
+- references to policy decisions and receipts
+- no direct treatment of traces as execution authority
+
+## Authority split
+
+Workspace state and orchestration context remain separate from semantic ontology authority and from policy authorization.

--- a/tools/validate_agent_action_trace_contracts.py
+++ b/tools/validate_agent_action_trace_contracts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT_DIR = ROOT / "contracts" / "agent-action-trace"
 EXAMPLES_DIR = CONTRACT_DIR / "examples"
+INVALID_DIR = EXAMPLES_DIR / "invalid"
 EXPECTED_API_VERSION = "prophet-platform.socioprophet.org/v0.1"
 EXPECTED_KINDS = {
     "agent-action-record.v0.1.schema.json": "AgentActionRecord",
@@ -18,6 +19,11 @@ EXAMPLE_BY_KIND = {
     "AgentActionRecord": "agent-action-record.example.v0.1.json",
     "AgentTraceRecord": "agent-trace-record.example.v0.1.json",
     "AgentActionTraceConformanceReport": "agent-action-trace-conformance-report.example.v0.1.json",
+}
+INVALID_EXAMPLES = {
+    "agent-action-record.missing-receipt.example.v0.1.json": "AgentActionRecord",
+    "agent-trace-record.authority-true.example.v0.1.json": "AgentTraceRecord",
+    "agent-action-trace-conformance-report.bad-bootstrap-ref.example.v0.1.json": "AgentActionTraceConformanceReport",
 }
 
 
@@ -90,6 +96,17 @@ def validate_example(path: Path, expected_kind: str) -> None:
             fail(f"{path.relative_to(ROOT)}: spec.bootstrapValidatorRef must reference socioprophet-standards-storage")
 
 
+def expect_invalid_example(path: Path, expected_kind: str) -> None:
+    try:
+        validate_example(path, expected_kind)
+    except SystemExit as exc:
+        if exc.code == 2:
+            print(f"OK: {path.relative_to(ROOT)} failed as expected")
+            return
+        raise
+    fail(f"{path.relative_to(ROOT)}: invalid example unexpectedly passed")
+
+
 def main() -> int:
     for schema_name, kind in EXPECTED_KINDS.items():
         schema_path = CONTRACT_DIR / schema_name
@@ -100,7 +117,14 @@ def main() -> int:
         if not example_path.exists():
             fail(f"missing example: {example_path.relative_to(ROOT)}")
         validate_example(example_path, kind)
-    print("OK: validated agent action/trace generated contracts and examples")
+
+    for example_name, kind in INVALID_EXAMPLES.items():
+        invalid_path = INVALID_DIR / example_name
+        if not invalid_path.exists():
+            fail(f"missing invalid example: {invalid_path.relative_to(ROOT)}")
+        expect_invalid_example(invalid_path, kind)
+
+    print("OK: validated agent action/trace generated contracts, examples, and negative fixtures")
     return 0
 
 

--- a/tools/validate_cell_gateway_api.py
+++ b/tools/validate_cell_gateway_api.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OPENAPI_PATH = ROOT / "contracts/cell/cell-service.openapi.yaml"
+ROUTES_PATH = ROOT / "contracts/cell/cell-service.routes.yaml"
+RUNTIME_DOC_PATH = ROOT / "docs/PERSONAL_INTELLIGENCE_CELL_RUNTIME.md"
+EVENT_TOPICS_PATH = ROOT / "docs/EVENT_BUS_TOPICS.md"
+PUBLICATION_PATH = ROOT / "apps/cell-service/src/cell_service/publication.py"
+SERVICE_PATH = ROOT / "apps/cell-service/src/cell_service/service.py"
+SMOKE_PATH = ROOT / "tools/smoke_cell_service_loop.py"
+
+REQUIRED_OPERATIONS = [
+    "cell.health",
+    "cell.create",
+    "cell.list",
+    "cell.get",
+    "cell.config.put",
+    "cell.config.get",
+    "cell.source.create",
+    "cell.watch.create",
+    "cell.watchPattern.create",
+    "cell.watchPattern.validate",
+    "cell.signal.ingest",
+    "cell.signal.ingestText",
+    "cell.signal.ingestLampstand",
+    "cell.feedItem.emit",
+    "cell.feed.private.export",
+    "cell.feed.rss.export",
+    "cell.publication.bundle",
+    "cell.feedback.record",
+    "cell.archive.export",
+    "cell.analytics.snapshot",
+]
+
+REQUIRED_POLICY_GATES = [
+    "cell.create",
+    "cell.configure",
+    "source.create",
+    "watch.create",
+    "watch_pattern.create",
+    "signal.ingest",
+    "feed_item.emit",
+    "feedback_event.record",
+    "cell_archive.export",
+]
+
+REQUIRED_PATHS = [
+    "/health",
+    "/cells",
+    "/cells/{cellId}",
+    "/cells/{cellId}/config",
+    "/sources",
+    "/watches",
+    "/watch-patterns",
+    "/watch-patterns/validate",
+    "/signals",
+    "/signals/text",
+    "/signals/lampstand",
+    "/feed-items",
+    "/cells/{cellId}/feeds/private",
+    "/cells/{cellId}/feeds/rss",
+    "/feed-items/{feedItemId}/publication-bundle",
+    "/feedback-events",
+    "/archives",
+    "/cells/{cellId}/analytics",
+]
+
+REQUIRED_TOPICS = [
+    "zone.cell.signal.ingested.v1",
+    "zone.cell.signal.scored.v1",
+    "zone.cell.feed.item_emitted.v1",
+    "zone.cell.feed.private_exported.v1",
+    "zone.cell.feed.rss_exported.v1",
+    "zone.cell.slash_topic.surface_built.v1",
+    "zone.cell.new_hope.membrane_event_built.v1",
+    "zone.cell.sherlock.search_packet_built.v1",
+    "zone.cell.feedback.recorded.v1",
+    "zone.cell.archive.exported.v1",
+]
+
+REQUIRED_PUBLICATION_SURFACES = [
+    "slashTopicSurface",
+    "newHopeMembraneEvent",
+    "sherlockSearchPacket",
+]
+
+
+def fail(message: str) -> None:
+    print(f"ERR: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def require_file(path: Path) -> str:
+    if not path.exists():
+        fail(f"missing required file: {path.relative_to(ROOT)}")
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def require_markers(text: str, markers: list[str], where: str) -> None:
+    for marker in markers:
+        if marker not in text:
+            fail(f"{where} missing marker: {marker}")
+
+
+def validate_openapi(text: str) -> None:
+    require_markers(
+        text,
+        [
+            "openapi: 3.1.0",
+            "title: SocioProphet Personal Intelligence Cell API",
+            "url: /api/cell/v1",
+            "bearerAuth",
+            "TextSignalIngestRequest",
+            "LampstandSignalIngestRequest",
+            "PrivateFeedDocument",
+            "PublicationBundle",
+            "AnalyticsSnapshot",
+        ],
+        "OpenAPI contract",
+    )
+    for path in REQUIRED_PATHS:
+        if path not in text:
+            fail(f"OpenAPI contract missing path: {path}")
+    for operation in REQUIRED_OPERATIONS:
+        if f"operationId: {operation}" not in text:
+            fail(f"OpenAPI contract missing operationId: {operation}")
+    for gate in REQUIRED_POLICY_GATES:
+        if f"x-policy-gate: {gate}" not in text:
+            fail(f"OpenAPI contract missing x-policy-gate: {gate}")
+
+
+def validate_routes(text: str) -> None:
+    require_markers(
+        text,
+        [
+            "base_path: /api/cell/v1",
+            "openapi: contracts/cell/cell-service.openapi.yaml",
+            "bearer_required: true",
+            "evidence_refs_required_for_signal_ingest: true",
+            "policy_decision_generated_by_service: true",
+            "ungoverned_publication_allowed: false",
+        ],
+        "route manifest",
+    )
+    for operation in REQUIRED_OPERATIONS:
+        if f"operation_id: {operation}" not in text:
+            fail(f"route manifest missing operation_id: {operation}")
+    for gate in REQUIRED_POLICY_GATES:
+        if f"policy_gate: {gate}" not in text:
+            fail(f"route manifest missing policy_gate: {gate}")
+    for topic in REQUIRED_TOPICS:
+        if topic not in text:
+            fail(f"route manifest missing topic: {topic}")
+
+
+def validate_route_operation_parity(openapi_text: str, routes_text: str) -> None:
+    openapi_ops = set(re.findall(r"operationId:\s*([^\s]+)", openapi_text))
+    route_ops = set(re.findall(r"operation_id:\s*([^\s]+)", routes_text))
+    missing_in_routes = sorted(openapi_ops - route_ops)
+    missing_in_openapi = sorted(route_ops - openapi_ops)
+    if missing_in_routes:
+        fail(f"operations missing in route manifest: {', '.join(missing_in_routes)}")
+    if missing_in_openapi:
+        fail(f"operations missing in OpenAPI contract: {', '.join(missing_in_openapi)}")
+
+
+def validate_publication_traceability(publication_text: str, service_text: str, smoke_text: str, topics_text: str, runtime_doc: str) -> None:
+    require_markers(
+        publication_text,
+        [
+            "slash_topic_surface",
+            "new_hope_membrane_event",
+            "sherlock_search_packet",
+            "cell_publication_bundle",
+        ],
+        "publication module",
+    )
+    service_delegates_bundle = "publication_bundle_for_feed_item" in service_text and "cell_publication_bundle" in service_text
+    for surface in REQUIRED_PUBLICATION_SURFACES:
+        if surface not in service_text and not service_delegates_bundle:
+            fail(f"service missing publication surface: {surface}")
+        if surface not in smoke_text:
+            fail(f"smoke missing publication surface: {surface}")
+    for topic in REQUIRED_TOPICS:
+        if topic not in topics_text:
+            fail(f"event topics doc missing topic: {topic}")
+    require_markers(
+        runtime_doc,
+        [
+            "PrivateFeed.Export",
+            "RssFeed.Export",
+            "PublicationBundle.Build",
+            "SlashTopicSurface.Build",
+            "NewHopeMembraneEvent.Build",
+            "SherlockSearchPacket.Build",
+        ],
+        "runtime doc API section",
+    )
+
+
+def main() -> None:
+    openapi_text = require_file(OPENAPI_PATH)
+    routes_text = require_file(ROUTES_PATH)
+    runtime_doc = require_file(RUNTIME_DOC_PATH)
+    topics_text = require_file(EVENT_TOPICS_PATH)
+    publication_text = require_file(PUBLICATION_PATH)
+    service_text = require_file(SERVICE_PATH)
+    smoke_text = require_file(SMOKE_PATH)
+
+    validate_openapi(openapi_text)
+    validate_routes(routes_text)
+    validate_route_operation_parity(openapi_text, routes_text)
+    validate_publication_traceability(publication_text, service_text, smoke_text, topics_text, runtime_doc)
+    print("OK: cell gateway API validation passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the next tranche of platform-generated Agent Action / Trace contract artifacts, including:

- negative fixtures for validation:
  - missing receipt in AgentActionRecord
  - invalid traceIsAuthority in AgentTraceRecord
  - bad bootstrap validator reference in AgentActionTraceConformanceReport
- runtime-consumption notes for AgentPlane, Workspace Controller, and Lampstand
- updated validator to check negative fixtures

## Resolution

Closed as superseded by clean partial replacement PR #556.

#556 captured the safe additive portion of this stale branch:

- `contracts/agent-action-trace/examples/invalid/agent-action-record.missing-receipt.example.v0.1.json`
- `contracts/agent-action-trace/examples/invalid/agent-action-trace-conformance-report.bad-bootstrap-ref.example.v0.1.json`
- `contracts/agent-action-trace/examples/invalid/agent-trace-record.authority-true.example.v0.1.json`
- `docs/generated/agent-action-trace/runtime-consumption-agentplane.md`
- `docs/generated/agent-action-trace/runtime-consumption-lampstand.md`
- `docs/generated/agent-action-trace/runtime-consumption-workspace-controller.md`

## Deliberate deviations

Skipped from the stale branch:

- `contracts/agent-action-trace/README.md`
- `docs/generated/agent-action-trace/contract-consumption.md`
- `tools/validate_agent_action_trace_contracts.py`
- `tools/validate_cell_gateway_api.py`

Reason: those are existing validator/index/adjacent-system edits and should be handled from a patch-safe/local checkout path. `tools/validate_cell_gateway_api.py` appears unrelated to this agent-action trace tranche and should be triaged separately.

## Follow-up

- Add validator support for negative fixtures in `tools/validate_agent_action_trace_contracts.py` from a patch-safe checkout.
- Add README / contract-consumption index surfacing after validator support lands.
- Triage `tools/validate_cell_gateway_api.py` separately in the Cell Gateway tranche.