### PR TITLE
apps(openai-research-mcp): add runtime backend selection

### DIFF
--- a/apps/openai-research-mcp/server.py
+++ b/apps/openai-research-mcp/server.py
@@ -12,16 +12,33 @@ from research_mcp.artifacts import LocalDirectoryObjectStore, MarkdownArtifactEx
 from research_mcp.audit import JsonlAuditSink
 from research_mcp.auth import StaticTokenAuthorizer, load_static_tokens
 from research_mcp.bundle import bundle_integrity_report
-from research_mcp.errors import ResearchMcpError
+from research_mcp.errors import InvalidInputError, ResearchMcpError
 from research_mcp.service import ResearchService
-from research_mcp.store import InMemoryDocumentBackend, load_documents_from_json
+from research_mcp.store import HttpSearchFetchBackend, InMemoryDocumentBackend, load_documents_from_json
 
 ROOT = Path(__file__).resolve().parent
 
 
+def configured_backend_mode() -> str:
+    return os.environ.get("MCP_BACKEND_MODE", "memory").strip().lower() or "memory"
+
+
+def build_backend():
+    mode = configured_backend_mode()
+    if mode == "memory":
+        docs_path = Path(os.environ.get("MCP_DOC_JSON_PATH", str(ROOT / "data" / "example_documents.json")))
+        docs = load_documents_from_json(docs_path)
+        return InMemoryDocumentBackend(docs)
+    if mode == "http":
+        backend_url = os.environ.get("MCP_HTTP_BACKEND_URL", "").strip()
+        if not backend_url:
+            raise InvalidInputError("MCP_HTTP_BACKEND_URL is required when MCP_BACKEND_MODE=http")
+        timeout = float(os.environ.get("MCP_HTTP_BACKEND_TIMEOUT_SECONDS", "5"))
+        return HttpSearchFetchBackend(backend_url, timeout_seconds=timeout)
+    raise InvalidInputError("MCP_BACKEND_MODE must be one of: memory, http")
+
+
 def build_service() -> ResearchService:
-    docs_path = Path(os.environ.get("MCP_DOC_JSON_PATH", str(ROOT / "data" / "example_documents.json")))
-    docs = load_documents_from_json(docs_path)
     tokens_path = Path(os.environ.get("MCP_STATIC_TOKENS_FILE", str(ROOT / "config" / "static_tokens.example.json")))
     authorizer = StaticTokenAuthorizer(
         load_static_tokens(tokens_path),
@@ -33,7 +50,7 @@ def build_service() -> ResearchService:
         public_base_url=os.environ.get("MCP_PUBLIC_ARTIFACT_BASE_URL"),
     )
     return ResearchService(
-        backend=InMemoryDocumentBackend(docs),
+        backend=build_backend(),
         authorizer=authorizer,
         audit_sink=JsonlAuditSink(audit_path),
         exporter=MarkdownArtifactExporter(object_store),
@@ -48,6 +65,8 @@ def doctor_payload():
     return {
         "app_name": APP_NAME,
         "version": __version__,
+        "backend_mode": configured_backend_mode(),
+        "http_backend_configured": bool(os.environ.get("MCP_HTTP_BACKEND_URL", "").strip()),
         "bundle_integrity": bundle_integrity_report(ROOT),
         "expected_fixture_docs": str(ROOT / "data" / "example_documents.json"),
         "expected_tokens": str(ROOT / "config" / "static_tokens.example.json"),
@@ -139,7 +158,6 @@ def main() -> int:
     p.add_argument("--port", type=int, default=18080)
 
     args = parser.parse_args()
-    service = build_service()
 
     if args.cmd == "verify-bundle":
         print(dump(bundle_integrity_report(ROOT)))
@@ -147,15 +165,7 @@ def main() -> int:
     if args.cmd == "doctor":
         print(dump(doctor_payload()))
         return 0
-    if args.cmd == "demo-search":
-        print(dump(service.search_contract(args.query, limit=args.limit, token=args.token)))
-        return 0
-    if args.cmd == "demo-fetch":
-        print(dump(service.fetch_contract(args.document_id, token=args.token)))
-        return 0
-    if args.cmd == "demo-export":
-        print(dump(service.export_report_handoff(args.title, args.narrative, args.document_ids, token=args.token)))
-        return 0
+
     if args.cmd == "serve-http":
         if not os.environ.get("MCP_PUBLIC_ARTIFACT_BASE_URL"):
             os.environ["MCP_PUBLIC_ARTIFACT_BASE_URL"] = f"http://{args.host}:{args.port}/artifacts"
@@ -166,6 +176,19 @@ def main() -> int:
             # Allow Ctrl+C to stop the server without printing a traceback.
             pass
         return 0
+
+    service = build_service()
+    if args.cmd == "demo-search":
+        print(dump(service.search_contract(args.query, limit=args.limit, token=args.token)))
+        return 0
+    if args.cmd == "demo-fetch":
+        print(dump(service.fetch_contract(args.document_id, token=args.token)))
+        return 0
+    if args.cmd == "demo-export":
+        print(dump(service.export_report_handoff(args.title, args.narrative, args.document_ids, token=args.token)))
+        return 0
+
+    return 1
 
 
 if __name__ == "__main__":

--- a/apps/openai-research-mcp/tests/test_backend_selection.py
+++ b/apps/openai-research-mcp/tests/test_backend_selection.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from research_mcp.errors import InvalidInputError
+from research_mcp.store import HttpSearchFetchBackend, InMemoryDocumentBackend
+from server import build_backend, doctor_payload
+
+
+class BackendSelectionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self._old_env = dict(os.environ)
+        os.environ["MCP_AUDIT_LOG_PATH"] = str(Path(self.tmp.name) / "events.jsonl")
+        os.environ["MCP_STATIC_TOKENS_FILE"] = str(ROOT / "config" / "static_tokens.example.json")
+        os.environ["MCP_DOC_JSON_PATH"] = str(ROOT / "data" / "example_documents.json")
+        os.environ.pop("MCP_BACKEND_MODE", None)
+        os.environ.pop("MCP_HTTP_BACKEND_URL", None)
+        os.environ.pop("MCP_HTTP_BACKEND_TIMEOUT_SECONDS", None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._old_env)
+        self.tmp.cleanup()
+
+    def test_default_backend_mode_is_memory(self):
+        backend = build_backend()
+        self.assertIsInstance(backend, InMemoryDocumentBackend)
+
+    def test_http_backend_mode_requires_backend_url(self):
+        os.environ["MCP_BACKEND_MODE"] = "http"
+        with self.assertRaises(InvalidInputError):
+            build_backend()
+
+    def test_http_backend_mode_builds_http_backend(self):
+        os.environ["MCP_BACKEND_MODE"] = "http"
+        os.environ["MCP_HTTP_BACKEND_URL"] = "https://retrieval.example.test"
+        os.environ["MCP_HTTP_BACKEND_TIMEOUT_SECONDS"] = "2.5"
+
+        backend = build_backend()
+
+        self.assertIsInstance(backend, HttpSearchFetchBackend)
+        self.assertEqual(backend.base_url, "https://retrieval.example.test")
+        self.assertEqual(backend.timeout_seconds, 2.5)
+
+    def test_unknown_backend_mode_is_rejected(self):
+        os.environ["MCP_BACKEND_MODE"] = "sqlite"
+        with self.assertRaises(InvalidInputError):
+            build_backend()
+
+    def test_doctor_reports_backend_mode_without_building_backend(self):
+        os.environ["MCP_BACKEND_MODE"] = "http"
+        os.environ.pop("MCP_HTTP_BACKEND_URL", None)
+
+        payload = doctor_payload()
+
+        self.assertEqual(payload["backend_mode"], "http")
+        self.assertFalse(payload["http_backend_configured"])
+        self.assertTrue(payload["bundle_integrity"]["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Wire runtime backend selection for `openai-research-mcp` without changing the default in-memory path.

## Changes

- add `MCP_BACKEND_MODE=memory|http`
- add `MCP_HTTP_BACKEND_URL` for HTTP backend mode
- add optional `MCP_HTTP_BACKEND_TIMEOUT_SECONDS`
- keep memory backend as the default
- make `doctor` and `verify-bundle` avoid constructing the backend
- report backend mode and HTTP backend configuration in `doctor_payload()`
- add focused backend-selection tests

## Upstream-state note

This branch was created from `17c33cfda928f20825a00d3e93e895dafbad622e`. Current `main` moved afterward in `apps/cell-service/src/cell_service/social_environment.py` and `docs/workspace-operation-runtime.md`, which do not overlap this PR.

## Scope

Only `apps/openai-research-mcp/server.py` and `apps/openai-research-mcp/tests/test_backend_selection.py` are changed. No backend service is enabled by default.