### PR TITLE
tools(cell): align publication traceability validator

### DIFF
--- a/tools/validate_cell_gateway_api.py
+++ b/tools/validate_cell_gateway_api.py
@@ -180,9 +180,11 @@ def validate_publication_traceability(publication_text: str, service_text: str, 
         ],
         "publication module",
     )
+    if "cell_publication_bundle" not in service_text:
+        fail("service missing publication bundle call: cell_publication_bundle")
     for surface in REQUIRED_PUBLICATION_SURFACES:
-        if surface not in service_text:
-            fail(f"service missing publication surface: {surface}")
+        if surface not in publication_text:
+            fail(f"publication module missing publication surface: {surface}")
         if surface not in smoke_text:
             fail(f"smoke missing publication surface: {surface}")
     for topic in REQUIRED_TOPICS:


### PR DESCRIPTION
## Summary

Fix the Cell gateway validation failure blocking unrelated PRs.

The validator was requiring camelCase publication surface names directly in `cell_service/service.py`, but the service correctly delegates to `cell_publication_bundle(...)`, and the publication module already emits the required camelCase surfaces.

## Changes

- require `cell_publication_bundle` in service code as the service-level traceability marker
- require `slashTopicSurface`, `newHopeMembraneEvent`, and `sherlockSearchPacket` in the publication module and smoke script
- keep the existing event-topic and runtime-doc checks unchanged

## Validation failure addressed

`ERR: service missing publication surface: slashTopicSurface`

## Scope

One validator file only: `tools/validate_cell_gateway_api.py`.