### PR TITLE
Add transparent fault attribution contracts

### DIFF
--- a/adr/ADR-035-transparent-fault-attribution-and-embedded-engine-policy.md
+++ b/adr/ADR-035-transparent-fault-attribution-and-embedded-engine-policy.md
@@ -1,0 +1,64 @@
+# ADR-035: Transparent fault attribution and embedded engine policy
+
+## Status
+Proposed
+
+## Context
+ADR-033 introduced canonical receipts and event envelopes so platform events can be replayed,
+audited, correlated, and indexed consistently. The next failure class is narrower and more
+operator-facing: first-party applications can cross hidden runtime boundaries during ordinary UI
+or document loading. A non-browser utility may instantiate an embedded browser engine, terminal
+bridge, automation bridge, AI worker, media decoder, network service, or diagnostic reporter
+without making that boundary visible to the human operator.
+
+The motivating case is a first-party Script Editor diagnostic report where the process terminates
+through a simulated guard fault in the WebKit namespace while loading AppKit/UIFoundation window
+state. That artifact is not evidence of external tampering by itself; it is evidence that dense
+machine diagnostics can still fail to explain causal continuity to the operator.
+
+## Decision
+Extend the ADR-033 event/evidence model with five transparent fault-attribution contracts:
+
+- `contracts/FaultEnvelope.v0.1.json`
+- `contracts/EngineManifest.v0.1.json`
+- `contracts/BoundaryTransition.v0.1.json`
+- `contracts/RolloutReceipt.v0.1.json`
+- `contracts/DiagnosticRedactionPolicy.v0.1.json`
+
+Rules:
+
+1. Every crash, guard fault, sandbox denial, policy abort, renderer failure, worker failure,
+   plugin failure, watchdog termination, and memory-pressure kill MUST produce a `FaultEnvelope`
+   or be represented as a domain event referenced by one.
+2. Every browser renderer, document renderer, terminal/PTTY bridge, automation bridge, AI worker,
+   media decoder, credential bridge, file picker bridge, diagnostic reporter, or network profiler
+   MUST have an `EngineManifest`.
+3. Every material transition across those boundaries MUST emit a `BoundaryTransition` linked to
+   a user action, system trigger, policy decision, or agent intent receipt.
+4. Every feature rollout or staged behavior that can affect diagnostics, engines, privacy,
+   policy, network behavior, credential access, or fault handling MUST resolve through a
+   human-readable `RolloutReceipt`.
+5. Diagnostic export MUST be tiered by `DiagnosticRedactionPolicy`, separating local-private
+   forensic bundles from default shareable reports and public issue artifacts.
+
+## Non-goals
+This ADR does not implement the BearBrowser component inspector, TurtleTerm system-action
+transcript, SourceOS Shell degraded-mode UI, or Sociosphere cross-repo rollup. It defines the
+portable contracts those product surfaces will consume.
+
+## Consequences
+- The platform can distinguish an actual compromise signal from a first-party opaque subsystem
+  fault.
+- Operator reports can answer “why is this engine running?” instead of only showing stack traces.
+- Built-in components receive at least the same transparency requirements as extensions.
+- Rollout state becomes locally resolvable rather than a mystery identifier.
+- Shareable diagnostics stop leaking stable identifiers by default.
+- Product repos can implement UI/UX incrementally while sharing one evidence vocabulary.
+
+## Follow-up implementation homes
+- BearBrowser: component inspector and embedded renderer manifests.
+- TurtleTerm: terminal/system-action transcript and PTY/automation boundary transitions.
+- SourceOS Shell: document/PDF/browser/terminal surface degraded mode and diagnostic UX.
+- Sociosphere: schema registration, repo-governance linkage, and cross-repo placement checks.
+- Ontogenesis: ontology terms and SHACL shapes for fault, engine, boundary, rollout, and redaction
+  classes.

--- a/contracts/BoundaryTransition.v0.1.json
+++ b/contracts/BoundaryTransition.v0.1.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/contracts/BoundaryTransition.v0.1.json",
+  "title": "BoundaryTransition v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "transitionId",
+    "timestamp",
+    "sourceComponent",
+    "targetComponent",
+    "boundaryType",
+    "initiator",
+    "userVisible"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "kind": { "const": "BoundaryTransition" },
+    "transitionId": { "type": "string", "minLength": 1 },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "sourceComponent": { "type": "string", "minLength": 1 },
+    "targetComponent": { "type": "string", "minLength": 1 },
+    "boundaryType": {
+      "type": "string",
+      "enum": [
+        "embedded_engine_initialization",
+        "network_open",
+        "file_open",
+        "credential_request",
+        "ai_invocation",
+        "shell_execution",
+        "automation_bridge_use",
+        "diagnostic_export",
+        "policy_gate",
+        "renderer_spawn",
+        "worker_spawn"
+      ]
+    },
+    "initiator": {
+      "type": "string",
+      "enum": [
+        "local_user_action",
+        "system_startup",
+        "feature_rollout",
+        "agent_action",
+        "remote_event",
+        "scheduled_task",
+        "unknown"
+      ]
+    },
+    "userVisible": { "type": "boolean" },
+    "userActionRef": { "type": "string" },
+    "policyDecisionRef": { "type": "string" },
+    "engineManifestRef": { "type": "string" },
+    "networkDelta": { "type": "string", "enum": ["none", "opened", "denied", "closed", "unknown"] },
+    "fileAccessDelta": { "type": "string", "enum": ["none", "opened", "denied", "closed", "unknown"] },
+    "credentialAccessDelta": { "type": "string", "enum": ["none", "requested", "denied", "granted", "unknown"] },
+    "aiAccessDelta": { "type": "string", "enum": ["none", "requested", "denied", "granted", "unknown"] },
+    "operatorExplanation": { "type": "string" },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/contracts/DiagnosticRedactionPolicy.v0.1.json
+++ b/contracts/DiagnosticRedactionPolicy.v0.1.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/contracts/DiagnosticRedactionPolicy.v0.1.json",
+  "title": "DiagnosticRedactionPolicy v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "tiers"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "kind": { "const": "DiagnosticRedactionPolicy" },
+    "tiers": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["localPrivate", "shareableDefault", "publicIssue"],
+      "properties": {
+        "localPrivate": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "stableDeviceIds": {"type": "string", "enum": ["preserve"]},
+            "bootSessionIds": {"type": "string", "enum": ["preserve"]},
+            "instructionBytes": {"type": "string", "enum": ["preserve"]},
+            "fullPaths": {"type": "string", "enum": ["preserve"]},
+            "tokensOrSecrets": {"type": "string", "enum": ["redact"]}
+          }
+        },
+        "shareableDefault": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "stableDeviceIds": {"type": "string", "enum": ["hash_with_local_salt"]},
+            "bootSessionIds": {"type": "string", "enum": ["hash_with_local_salt"]},
+            "instructionBytes": {"type": "string", "enum": ["omit"]},
+            "fullPaths": {"type": "string", "enum": ["redact"]},
+            "tokensOrSecrets": {"type": "string", "enum": ["redact"]}
+          }
+        },
+        "publicIssue": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "stableDeviceIds": {"type": "string", "enum": ["omit"]},
+            "bootSessionIds": {"type": "string", "enum": ["omit"]},
+            "instructionBytes": {"type": "string", "enum": ["omit"]},
+            "fullPaths": {"type": "string", "enum": ["classify_only"]},
+            "tokensOrSecrets": {"type": "string", "enum": ["redact"]}
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/EngineManifest.v0.1.json
+++ b/contracts/EngineManifest.v0.1.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/contracts/EngineManifest.v0.1.json",
+  "title": "EngineManifest v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "engineId",
+    "engineType",
+    "ownerComponent",
+    "observability"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "kind": { "const": "EngineManifest" },
+    "engineId": { "type": "string", "minLength": 1 },
+    "engineType": {
+      "type": "string",
+      "enum": [
+        "web_renderer",
+        "document_renderer",
+        "terminal_bridge",
+        "automation_bridge",
+        "ai_worker",
+        "media_decoder",
+        "credential_bridge",
+        "file_picker_bridge",
+        "diagnostic_reporter",
+        "network_profiler",
+        "storage_service"
+      ]
+    },
+    "ownerComponent": { "type": "string", "minLength": 1 },
+    "invocationSurfaces": { "type": "array", "items": { "type": "string" } },
+    "allowedContexts": { "type": "array", "items": { "type": "string" } },
+    "disallowedContexts": { "type": "array", "items": { "type": "string" } },
+    "defaultNetworkPolicy": {
+      "type": "string",
+      "enum": ["allow", "deny", "deny_until_origin_known", "policy_gated"]
+    },
+    "defaultFilePolicy": {
+      "type": "string",
+      "enum": ["allow", "deny", "user_gesture_required", "policy_gated"]
+    },
+    "credentialPolicy": {
+      "type": "string",
+      "enum": ["deny", "user_gesture_required", "policy_gated"]
+    },
+    "aiPolicy": {
+      "type": "string",
+      "enum": ["deny", "explicit_user_invocation", "policy_gated"]
+    },
+    "sandboxProfile": { "type": "string" },
+    "observability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["emitEngineInit", "emitBoundaryTransition", "emitFaultEnvelope"],
+      "properties": {
+        "emitEngineInit": { "type": "boolean" },
+        "emitBoundaryTransition": { "type": "boolean" },
+        "emitNetworkOpen": { "type": "boolean" },
+        "emitFileOpen": { "type": "boolean" },
+        "emitFaultEnvelope": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/contracts/FaultEnvelope.v0.1.json
+++ b/contracts/FaultEnvelope.v0.1.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/contracts/FaultEnvelope.v0.1.json",
+  "title": "FaultEnvelope v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "eventId",
+    "timestamp",
+    "eventType",
+    "severity",
+    "process",
+    "fault",
+    "privacy"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "kind": { "const": "FaultEnvelope" },
+    "eventId": { "type": "string", "minLength": 1 },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "eventType": {
+      "type": "string",
+      "enum": [
+        "process_crash",
+        "renderer_crash",
+        "worker_crash",
+        "plugin_crash",
+        "policy_abort",
+        "sandbox_denial",
+        "guard_fault",
+        "intentional_abort",
+        "watchdog_termination",
+        "memory_pressure_kill",
+        "dependency_initialization_failure",
+        "unhandled_exception"
+      ]
+    },
+    "severity": {
+      "type": "string",
+      "enum": [
+        "info",
+        "warning",
+        "degraded",
+        "component_terminated",
+        "process_terminated",
+        "security_relevant"
+      ]
+    },
+    "process": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
+      "properties": {
+        "pid": { "type": "integer", "minimum": 0 },
+        "name": { "type": "string", "minLength": 1 },
+        "binary": { "type": "string" },
+        "parent": { "type": "string" },
+        "codeIdentity": { "type": "string" }
+      }
+    },
+    "componentChain": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "fault": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["namespace", "subtype"],
+      "properties": {
+        "namespace": { "type": "string", "minLength": 1 },
+        "subtype": { "type": "string", "minLength": 1 },
+        "signalOrException": { "type": "string" },
+        "intentional": { "type": "boolean" },
+        "simulated": { "type": "boolean" },
+        "policyRelated": { "type": "string", "enum": ["yes", "no", "unknown"] }
+      }
+    },
+    "userAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "lastVisibleAction": { "type": "string" },
+        "surface": { "type": "string" },
+        "inputOrigin": { "type": "string" }
+      }
+    },
+    "engine": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "engineManifestRef": { "type": "string" },
+        "engineType": { "type": "string" },
+        "engineName": { "type": "string" },
+        "networkAllowed": { "type": "boolean" },
+        "fileAccessAllowed": { "type": "boolean" },
+        "credentialAccessAllowed": { "type": "boolean" },
+        "aiAccessAllowed": { "type": "boolean" }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sandboxProfile": { "type": "string" },
+        "allowDecisionRefs": { "type": "array", "items": { "type": "string" } },
+        "denyDecisionRefs": { "type": "array", "items": { "type": "string" } },
+        "policyReceiptRefs": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "rolloutReceiptRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tier", "stableIdentifiersRedacted"],
+      "properties": {
+        "tier": { "type": "string", "enum": ["local_private", "shareable_default", "public_issue"] },
+        "stableIdentifiersRedacted": { "type": "boolean" },
+        "instructionBytesRedacted": { "type": "boolean" },
+        "pathsRedacted": { "type": "boolean" }
+      }
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "operatorSummary": { "type": "string" }
+  }
+}

--- a/contracts/RolloutReceipt.v0.1.json
+++ b/contracts/RolloutReceipt.v0.1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/contracts/RolloutReceipt.v0.1.json",
+  "title": "RolloutReceipt v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "rolloutId",
+    "featureName",
+    "owner",
+    "activationReason",
+    "activationRule"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "kind": { "const": "RolloutReceipt" },
+    "rolloutId": { "type": "string" },
+    "featureName": { "type": "string" },
+    "featureVersion": { "type": "string" },
+    "owner": { "type": "string" },
+    "activationReason": { "type": "string" },
+    "activationRule": { "type": "string" },
+    "userOverride": { "type": "string" },
+    "killSwitch": { "type": "string" },
+    "policyClass": { "type": "string" },
+    "privacyClass": { "type": "string" },
+    "affectedBoundaries": { "type": "array", "items": { "type": "string" } },
+    "buildProvenance": {
+      "type": "object",
+      "properties": {
+        "repo": { "type": "string" },
+        "commit": { "type": "string" },
+        "ciReceipt": { "type": "string" }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "properties": {
+        "supported": { "type": "boolean" },
+        "rollbackCommand": { "type": "string" }
+      }
+    }
+  }
+}

--- a/tests/fixtures/fault-envelope-script-editor-synthetic.json
+++ b/tests/fixtures/fault-envelope-script-editor-synthetic.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": "v0.1",
+  "kind": "FaultEnvelope",
+  "eventId": "synthetic-script-editor-guard",
+  "timestamp": "2026-05-06T12:00:00Z",
+  "eventType": "guard_fault",
+  "severity": "process_terminated",
+  "process": {
+    "pid": 1438,
+    "name": "Script Editor",
+    "binary": "/System/Applications/Utilities/Script Editor.app/Contents/MacOS/Script Editor",
+    "parent": "launchd",
+    "codeIdentity": "com.apple.ScriptEditor2"
+  },
+  "componentChain": [
+    "document_controller",
+    "window_controller",
+    "ui_loader",
+    "embedded_web_view",
+    "renderer_engine"
+  ],
+  "fault": {
+    "namespace": "WEBKIT",
+    "subtype": "GUARD_TYPE_USER",
+    "signalOrException": "EXC_GUARD",
+    "intentional": true,
+    "simulated": true,
+    "policyRelated": "unknown"
+  },
+  "userAction": {
+    "lastVisibleAction": "open_document",
+    "surface": "editor",
+    "inputOrigin": "local_user"
+  },
+  "engine": {
+    "engineManifestRef": "EngineManifest.v0.1.json",
+    "engineType": "web_renderer",
+    "engineName": "WebKitLegacy",
+    "networkAllowed": false,
+    "fileAccessAllowed": false,
+    "credentialAccessAllowed": false,
+    "aiAccessAllowed": false
+  },
+  "policy": {
+    "sandboxProfile": "default",
+    "allowDecisionRefs": [],
+    "denyDecisionRefs": [],
+    "policyReceiptRefs": []
+  },
+  "rolloutReceiptRefs": [],
+  "privacy": {
+    "tier": "shareable_default",
+    "stableIdentifiersRedacted": true,
+    "instructionBytesRedacted": true,
+    "pathsRedacted": true
+  },
+  "evidenceRefs": [],
+  "operatorSummary": "Synthetic Script Editor guard-fault for ADR-035 testing purposes."
+}


### PR DESCRIPTION
## Summary

Replacement for closed unmerged PR #439 after branch refresh. Adds ADR-035 and the first portable contracts for transparent fault attribution and embedded-engine accountability.

This follows the existing platform contract authority rather than creating a new repo or burying the work in product repos. ADR-033 already establishes canonical receipts and event envelopes in `prophet-platform`; this PR extends that model for crash/guard/sandbox/engine/rollout/diagnostic-redaction surfaces.

## Added

- `adr/ADR-035-transparent-fault-attribution-and-embedded-engine-policy.md`
- `contracts/FaultEnvelope.v0.1.json`
- `contracts/EngineManifest.v0.1.json`
- `contracts/BoundaryTransition.v0.1.json`
- `contracts/RolloutReceipt.v0.1.json`
- `contracts/DiagnosticRedactionPolicy.v0.1.json`
- `tests/fixtures/fault-envelope-script-editor-synthetic.json`

## Design intent

The motivating case is a first-party Script Editor/WebKitLegacy guard-fault report. The finding is intentionally bounded: the artifact is not evidence of external tampering by itself. It is evidence that dense platform diagnostics can still fail to explain hidden subsystem causality to the operator.

The contracts support typed fault semantics, explicit engine manifests, boundary-transition records, human-readable rollout receipts, and redaction tiers for local-private/shareable/public diagnostic artifacts.

## Validation note

Previous CI on #439 showed the premerge failure was branch freshness, while repo validation failed on an existing `slashTopicSurface` publication-surface invariant. This replacement PR is opened after cleanly reapplying the files on the refreshed branch.

## Follow-up product homes

- BearBrowser: component inspector and renderer/automation manifests.
- TurtleTerm: system-action transcript and PTY/automation boundary transitions.
- SourceOS Shell: document/PDF/browser/terminal degraded-mode diagnostics.
- Sociosphere: schema distribution/registration and repo-governance rollup.
- Ontogenesis: ontology terms and SHACL shapes for fault, engine, boundary, rollout, and redaction classes.
