### PR TITLE
feat(semantic): import Ontogenesis Semantic Enterprise v0.1

### DIFF
--- a/contracts/semantic-enterprise/v0.1/semantic_enterprise_manifest.import.json
+++ b/contracts/semantic-enterprise/v0.1/semantic_enterprise_manifest.import.json
@@ -1,0 +1,75 @@
+{
+  "contract": "prophet-platform.semantic-enterprise.import",
+  "version": "0.1.0",
+  "source": {
+    "repository": "SocioProphet/ontogenesis",
+    "release": "semantic-enterprise-v0.1.0",
+    "manifest_path": "manifests/semantic_enterprise_v0_1_manifest.json",
+    "rollup_registry_path": "catalog/semantic_enterprise_v0_1_registry.ttl",
+    "release_note_path": "docs/semantic-enterprise/v0.1-release-note.md",
+    "import_bridge_path": "docs/semantic-enterprise/downstream-import-bridge-v0.1.md"
+  },
+  "closure_model": {
+    "inside_source": "Ontogenesis remains the authored semantic source of truth.",
+    "outside_runtime": "Prophet Platform exposes runtime-readable semantic catalog surfaces without rewriting source semantics.",
+    "boundary_membrane": "The import contract preserves provenance, registry references, validation gates, named-graph metadata, trust profile, and access class.",
+    "feedback_surface": "Downstream validation and runtime observations must be represented as platform evidence, not as silent ontology mutation."
+  },
+  "provenance_requirements": [
+    "source_path",
+    "canonical_iri",
+    "registry_reference",
+    "validation_gate",
+    "named_graph_uri",
+    "trust_profile",
+    "access_class"
+  ],
+  "scenarios": {
+    "finance": {
+      "scenario_path": "examples/scenarios/finance_aml_kyc_demo.ttl",
+      "query_path": "examples/queries/finance_aml_kyc.rq",
+      "named_graph_uri_fragment": "graphs/scenarios/finance-aml-kyc"
+    },
+    "threat-intel": {
+      "scenario_path": "examples/scenarios/threat_intel_lifecycle_demo.ttl",
+      "query_path": "examples/queries/threat_intel_lifecycle.rq",
+      "named_graph_uri_fragment": "graphs/scenarios/threat-intel-lifecycle"
+    },
+    "investigation": {
+      "scenario_path": "examples/scenarios/investigation_custody_timeline_demo.ttl",
+      "query_path": "examples/queries/investigation_custody_timeline.rq",
+      "named_graph_uri_fragment": "graphs/scenarios/investigation-custody"
+    },
+    "supply-chain": {
+      "scenario_path": "examples/scenarios/supply_chain_resilience_demo.ttl",
+      "query_path": "examples/queries/supply_chain_resilience.rq",
+      "named_graph_uri_fragment": "graphs/scenarios/supply-chain-resilience"
+    },
+    "defense-c2": {
+      "scenario_path": "examples/scenarios/defense_c2_cop_demo.ttl",
+      "query_path": "examples/queries/defense_c2_cop.rq",
+      "named_graph_uri_fragment": "graphs/scenarios/defense-c2-cop"
+    }
+  },
+  "named_graph_fixture_path": "examples/named-graphs/semantic_sector_named_graphs.ttl",
+  "downstream_consumers": [
+    "Prophet Platform",
+    "Sherlock Search",
+    "AgentPlane",
+    "PolicyFabric",
+    "SourceOS",
+    "DeliveryExcellence"
+  ],
+  "platform_outputs": {
+    "catalog_surface": "semantic-enterprise.catalog.v0.1",
+    "scenario_surface": "semantic-enterprise.scenario.v0.1",
+    "query_surface": "semantic-enterprise.query.v0.1",
+    "named_graph_surface": "semantic-enterprise.named-graph.v0.1"
+  },
+  "non_goals": [
+    "production_graph_storage",
+    "live_ingestion",
+    "operational_response_playbooks",
+    "access_control_implementation"
+  ]
+}

--- a/docs/SEMANTIC_ENTERPRISE_IMPORT.md
+++ b/docs/SEMANTIC_ENTERPRISE_IMPORT.md
@@ -1,0 +1,39 @@
+# Semantic Enterprise Import Boundary v0.1
+
+Prophet Platform consumes `semantic-enterprise-v0.1.0` from `SocioProphet/ontogenesis` as a platform-readable semantic catalog surface.
+
+Ontogenesis remains the authored semantic source of truth. Prophet Platform exposes platform-facing catalog, scenario, query, and named-graph surfaces while preserving provenance back to the source release.
+
+## Source release
+
+- Repository: `SocioProphet/ontogenesis`
+- Release/tag: `semantic-enterprise-v0.1.0`
+- Manifest: `manifests/semantic_enterprise_v0_1_manifest.json`
+- Rollup registry: `catalog/semantic_enterprise_v0_1_registry.ttl`
+
+## Platform import contract
+
+- `contracts/semantic-enterprise/v0.1/semantic_enterprise_manifest.import.json`
+
+The import contract records source paths, five sector scenarios, query paths, named graph URI fragments, downstream consumers, platform output surfaces, and the closure boundary between authored source and platform runtime.
+
+## Closure boundary
+
+The import contract distinguishes:
+
+- `inside_source`: authored source remains in Ontogenesis.
+- `outside_runtime`: Prophet Platform publishes platform-readable surfaces.
+- `boundary_membrane`: provenance and governance metadata survive translation.
+- `feedback_surface`: downstream observations are recorded as platform evidence.
+
+## Validation
+
+- `python3 tools/validate_semantic_enterprise_import.py`
+- `pytest -q tools/tests/test_semantic_enterprise_import.py`
+
+The pytest smoke tests are covered by the existing `test-tools` lane.
+
+## Parent work
+
+- `SocioProphet/prophet-platform#436`
+- `SocioProphet/delivery-excellence#21`

--- a/tools/tests/test_semantic_enterprise_import.py
+++ b/tools/tests/test_semantic_enterprise_import.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "contracts/semantic-enterprise/v0.1/semantic_enterprise_manifest.import.json"
+
+
+def load_contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def test_semantic_enterprise_contract_loads() -> None:
+    data = load_contract()
+    assert data["contract"] == "prophet-platform.semantic-enterprise.import"
+    assert data["version"] == "0.1.0"
+    assert data["source"]["repository"] == "SocioProphet/ontogenesis"
+    assert data["source"]["release"] == "semantic-enterprise-v0.1.0"
+
+
+def test_semantic_enterprise_has_all_sector_scenarios() -> None:
+    data = load_contract()
+    scenarios = data["scenarios"]
+    assert set(scenarios) == {
+        "finance",
+        "threat-intel",
+        "investigation",
+        "supply-chain",
+        "defense-c2",
+    }
+    for spec in scenarios.values():
+        assert spec["scenario_path"].startswith("examples/scenarios/")
+        assert spec["query_path"].startswith("examples/queries/")
+        assert spec["named_graph_uri_fragment"].startswith("graphs/scenarios/")
+
+
+def test_semantic_enterprise_preserves_boundary_and_provenance() -> None:
+    data = load_contract()
+    closure = data["closure_model"]
+    assert set(closure) == {
+        "inside_source",
+        "outside_runtime",
+        "boundary_membrane",
+        "feedback_surface",
+    }
+
+    provenance = set(data["provenance_requirements"])
+    assert {
+        "source_path",
+        "canonical_iri",
+        "registry_reference",
+        "validation_gate",
+        "named_graph_uri",
+        "trust_profile",
+        "access_class",
+    }.issubset(provenance)
+
+
+def test_semantic_enterprise_platform_surfaces_are_named() -> None:
+    data = load_contract()
+    outputs = data["platform_outputs"]
+    assert outputs["catalog_surface"] == "semantic-enterprise.catalog.v0.1"
+    assert outputs["scenario_surface"] == "semantic-enterprise.scenario.v0.1"
+    assert outputs["query_surface"] == "semantic-enterprise.query.v0.1"
+    assert outputs["named_graph_surface"] == "semantic-enterprise.named-graph.v0.1"

--- a/tools/validate_semantic_enterprise_import.py
+++ b/tools/validate_semantic_enterprise_import.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Validate Prophet Platform's Semantic Enterprise v0.1 import contract.
+
+The contract is platform-local. Ontogenesis remains the authored semantic source;
+this validator proves the platform import membrane preserves the expected source,
+scenario, query, named-graph, provenance, and closure surfaces.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = "contracts/semantic-enterprise/v0.1/semantic_enterprise_manifest.import.json"
+
+REQUIRED_SCENARIOS = {
+    "finance": "graphs/scenarios/finance-aml-kyc",
+    "threat-intel": "graphs/scenarios/threat-intel-lifecycle",
+    "investigation": "graphs/scenarios/investigation-custody",
+    "supply-chain": "graphs/scenarios/supply-chain-resilience",
+    "defense-c2": "graphs/scenarios/defense-c2-cop",
+}
+
+REQUIRED_PROVENANCE = {
+    "source_path",
+    "canonical_iri",
+    "registry_reference",
+    "validation_gate",
+    "named_graph_uri",
+    "trust_profile",
+    "access_class",
+}
+
+REQUIRED_CLOSURE_KEYS = {
+    "inside_source",
+    "outside_runtime",
+    "boundary_membrane",
+    "feedback_surface",
+}
+
+REQUIRED_OUTPUTS = {
+    "catalog_surface",
+    "scenario_surface",
+    "query_surface",
+    "named_graph_surface",
+}
+
+
+def main() -> int:
+    errors: list[str] = []
+    path = ROOT / CONTRACT_PATH
+    if not path.is_file():
+        print(f"missing contract: {CONTRACT_PATH}")
+        return 1
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"invalid JSON in {CONTRACT_PATH}: {exc}")
+        return 1
+
+    if data.get("contract") != "prophet-platform.semantic-enterprise.import":
+        errors.append("unexpected contract identifier")
+    if data.get("version") != "0.1.0":
+        errors.append("unexpected contract version")
+
+    source = data.get("source")
+    if not isinstance(source, dict):
+        errors.append("source must be an object")
+    else:
+        expected_source = {
+            "repository": "SocioProphet/ontogenesis",
+            "release": "semantic-enterprise-v0.1.0",
+            "manifest_path": "manifests/semantic_enterprise_v0_1_manifest.json",
+            "rollup_registry_path": "catalog/semantic_enterprise_v0_1_registry.ttl",
+            "release_note_path": "docs/semantic-enterprise/v0.1-release-note.md",
+            "import_bridge_path": "docs/semantic-enterprise/downstream-import-bridge-v0.1.md",
+        }
+        for key, expected in expected_source.items():
+            if source.get(key) != expected:
+                errors.append(f"source.{key} expected {expected!r}, got {source.get(key)!r}")
+
+    closure = data.get("closure_model")
+    if not isinstance(closure, dict):
+        errors.append("closure_model must be an object")
+    else:
+        missing = REQUIRED_CLOSURE_KEYS.difference(closure)
+        if missing:
+            errors.append(f"closure_model missing keys: {sorted(missing)}")
+        for key in REQUIRED_CLOSURE_KEYS.intersection(closure):
+            if not isinstance(closure.get(key), str) or not closure[key].strip():
+                errors.append(f"closure_model.{key} must be a non-empty string")
+
+    provenance = set(data.get("provenance_requirements") or [])
+    missing_provenance = REQUIRED_PROVENANCE.difference(provenance)
+    if missing_provenance:
+        errors.append(f"missing provenance requirements: {sorted(missing_provenance)}")
+
+    scenarios = data.get("scenarios")
+    if not isinstance(scenarios, dict):
+        errors.append("scenarios must be an object")
+    else:
+        for name, graph_fragment in REQUIRED_SCENARIOS.items():
+            spec = scenarios.get(name)
+            if not isinstance(spec, dict):
+                errors.append(f"missing scenario object: {name}")
+                continue
+            if not spec.get("scenario_path", "").startswith("examples/scenarios/"):
+                errors.append(f"{name} scenario_path must point into examples/scenarios")
+            if not spec.get("query_path", "").startswith("examples/queries/"):
+                errors.append(f"{name} query_path must point into examples/queries")
+            if spec.get("named_graph_uri_fragment") != graph_fragment:
+                errors.append(f"{name} named graph fragment mismatch")
+
+    if data.get("named_graph_fixture_path") != "examples/named-graphs/semantic_sector_named_graphs.ttl":
+        errors.append("named_graph_fixture_path mismatch")
+
+    outputs = data.get("platform_outputs")
+    if not isinstance(outputs, dict):
+        errors.append("platform_outputs must be an object")
+    else:
+        missing_outputs = REQUIRED_OUTPUTS.difference(outputs)
+        if missing_outputs:
+            errors.append(f"platform_outputs missing keys: {sorted(missing_outputs)}")
+
+    consumers = set(data.get("downstream_consumers") or [])
+    if "Prophet Platform" not in consumers:
+        errors.append("downstream_consumers must include Prophet Platform")
+
+    non_goals = set(data.get("non_goals") or [])
+    if "live_ingestion" not in non_goals:
+        errors.append("non_goals must include live_ingestion")
+
+    if errors:
+        print("Semantic Enterprise import contract validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("Semantic Enterprise import contract validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds the first Prophet Platform adoption surface for `semantic-enterprise-v0.1.0` from `SocioProphet/ontogenesis`.

## Added

- `contracts/semantic-enterprise/v0.1/semantic_enterprise_manifest.import.json`
  - platform-local import contract for the Ontogenesis release
  - preserves source release, source paths, scenario/query/named-graph mappings, provenance requirements, platform output surface names, and closure boundary
- `tools/validate_semantic_enterprise_import.py`
  - stdlib validator for the import contract
- `tools/tests/test_semantic_enterprise_import.py`
  - pytest smoke tests under the existing `test-tools` lane
- `docs/SEMANTIC_ENTERPRISE_IMPORT.md`
  - import boundary note for the platform membrane

## Design posture

Ontogenesis remains the authored semantic source. Prophet Platform exposes runtime-readable semantic catalog surfaces without rewriting source semantics.

The import contract explicitly models synergetic closure:
- inside source
- outside runtime
- boundary membrane
- feedback surface

## Parent issues

- Closes SocioProphet/prophet-platform#436
- Parent tracker: SocioProphet/delivery-excellence#21

## Validation target

Expected checks:
- repository validation
- tools pytest lane / `test-tools`