### PR TITLE
evidence-console: surface FogStack validation evidence (ready)

### DIFF
--- a/apps/evidence-console/README.md
+++ b/apps/evidence-console/README.md
@@ -17,7 +17,9 @@ The platform already has:
 - `/v1/console/frontier`
 - `/v1/console/models/{model_release_id}`
 - `/v1/console/coverage`
+- `/v1/console/fogstack/validation`
 - `/v1/console/recent-events`
+- `/v1/console/telemetry`
 - `/console/evidence` — minimal HTML stub
 
 ## Inputs

--- a/apps/evidence-console/app/main.py
+++ b/apps/evidence-console/app/main.py
@@ -28,6 +28,11 @@ def coverage(limit: int = 20) -> dict:
     return service.get_coverage_view(limit=limit)
 
 
+@app.get("/v1/console/fogstack/validation")
+def fogstack_validation(limit: int = 20) -> dict:
+    return service.get_fogstack_validation_view(limit=limit)
+
+
 @app.get("/v1/console/recent-events")
 def recent_events(limit: int = 25, per_service_limit: int = 15) -> dict:
     return service.get_recent_events_view(limit=limit, per_service_limit=per_service_limit)
@@ -69,6 +74,10 @@ def console_ui() -> str:
     <pre id=\"coverage\">loading...</pre>
   </section>
   <section>
+    <h2>FogStack Validation</h2>
+    <pre id=\"fogstack\">loading...</pre>
+  </section>
+  <section>
     <h2>Recent Events</h2>
     <pre id=\"recent\">loading...</pre>
   </section>
@@ -91,6 +100,7 @@ async function load(id, url) {
 load('frontier', '/v1/console/frontier');
 load('model', '/v1/console/models/model.semantic-stack.2026-04-05');
 load('coverage', '/v1/console/coverage');
+load('fogstack', '/v1/console/fogstack/validation');
 load('recent', '/v1/console/recent-events');
 load('telemetry', '/v1/console/telemetry');
 </script>

--- a/apps/evidence-console/app/service.py
+++ b/apps/evidence-console/app/service.py
@@ -70,6 +70,27 @@ def get_coverage_view(limit: int = 20) -> dict[str, Any]:
     }
 
 
+def get_fogstack_validation_view(limit: int = 20) -> dict[str, Any]:
+    items = client.get_recent_receipts("fogstack-validation", limit=max(limit, 20))
+    latest_by_bundle: list[dict[str, Any]] = []
+    seen_subjects: set[str] = set()
+    for item in _sorted(items):
+        subject_ref = item.get("subject_ref")
+        if not subject_ref or subject_ref in seen_subjects:
+            continue
+        seen_subjects.add(subject_ref)
+        bundle = _bundle_from_summary(item)
+        if bundle is not None:
+            latest_by_bundle.append(bundle)
+        if len(latest_by_bundle) >= limit:
+            break
+    recent = _sorted([item for item in items if item.get("event_type") == "fogstack.validation.record.emitted"])[:limit]
+    return {
+        "latest_by_bundle": latest_by_bundle,
+        "recent": recent,
+    }
+
+
 def get_recent_events_view(limit: int = 25, per_service_limit: int = 15) -> dict[str, Any]:
     services = client.get_services()
     items: list[dict[str, Any]] = []

--- a/apps/evidence-console/tests/test_http_main.py
+++ b/apps/evidence-console/tests/test_http_main.py
@@ -37,6 +37,14 @@ def test_coverage_route(monkeypatch):
     assert resp.json() == expected
 
 
+def test_fogstack_validation_route(monkeypatch):
+    expected = {"latest_by_bundle": [], "recent": []}
+    monkeypatch.setattr(main.service, "get_fogstack_validation_view", lambda limit=20: expected)
+    resp = client.get("/v1/console/fogstack/validation?limit=5")
+    assert resp.status_code == 200
+    assert resp.json() == expected
+
+
 def test_recent_events_route(monkeypatch):
     expected = {"services": ["eval-fabric-api", "lampstand"], "items": []}
     monkeypatch.setattr(main.service, "get_recent_events_view", lambda limit=25, per_service_limit=15: expected)
@@ -45,10 +53,10 @@ def test_recent_events_route(monkeypatch):
     assert resp.json() == expected
 
 
-def test_recent_telemetry_route(monkeypatch):
-    expected = {"service": "telemetry-runtime", "items": [{"event_type": "reliability.conversation.stream.completed"}]}
+def test_telemetry_route(monkeypatch):
+    expected = {"service": "telemetry-runtime", "items": []}
     monkeypatch.setattr(main.service, "get_recent_telemetry_view", lambda service_name="telemetry-runtime", limit=25: expected)
-    resp = client.get("/v1/console/telemetry?limit=10&service_name=telemetry-runtime")
+    resp = client.get("/v1/console/telemetry?service_name=telemetry-runtime&limit=5")
     assert resp.status_code == 200
     assert resp.json() == expected
 
@@ -61,5 +69,6 @@ def test_console_ui_contains_fetch_targets():
     assert "/v1/console/frontier" in body
     assert "/v1/console/models/model.semantic-stack.2026-04-05" in body
     assert "/v1/console/coverage" in body
+    assert "/v1/console/fogstack/validation" in body
     assert "/v1/console/recent-events" in body
     assert "/v1/console/telemetry" in body

--- a/apps/evidence-console/tests/test_service.py
+++ b/apps/evidence-console/tests/test_service.py
@@ -34,6 +34,19 @@ def test_model_view_filters_by_subject(monkeypatch):
     assert len(view["recent"]) == 2
 
 
+def test_fogstack_validation_view_groups_latest_by_bundle(monkeypatch):
+    items = [
+        {"service": "fogstack-validation", "correlation_id": "a-new", "event_type": "fogstack.validation.record.emitted", "subject_ref": "bundle://fogstack.access@0.1.0", "created_at": "2026-04-14T00:02:00+00:00"},
+        {"service": "fogstack-validation", "correlation_id": "a-old", "event_type": "fogstack.validation.record.emitted", "subject_ref": "bundle://fogstack.access@0.1.0", "created_at": "2026-04-14T00:01:00+00:00"},
+        {"service": "fogstack-validation", "correlation_id": "k1", "event_type": "fogstack.validation.record.emitted", "subject_ref": "bundle://fogstack.knowledge@0.1.0", "created_at": "2026-04-14T00:00:00+00:00"},
+    ]
+    monkeypatch.setattr(service.client, "get_recent_receipts", lambda service, limit=20: items)
+    monkeypatch.setattr(service.client, "get_bundle", lambda service, correlation_id: {"correlation_id": correlation_id})
+    view = service.get_fogstack_validation_view(limit=10)
+    assert [item["correlation_id"] for item in view["latest_by_bundle"]] == ["a-new", "k1"]
+    assert [item["correlation_id"] for item in view["recent"]] == ["a-new", "a-old", "k1"]
+
+
 def test_recent_events_merges_and_sorts(monkeypatch):
     monkeypatch.setattr(service.client, "get_services", lambda: ["eval-fabric-api", "lampstand"])
     monkeypatch.setattr(service.client, "get_recent_receipts", lambda service, limit=15: [

--- a/apps/gateway/cmd/tritrpc-gateway/main.go
+++ b/apps/gateway/cmd/tritrpc-gateway/main.go
@@ -57,7 +57,9 @@ func newMux(target string, key [32]byte, evidenceBase string, consoleBase string
     if consoleBase != "" {
         mux.HandleFunc("/v1/console/frontier", proxyGET(client, consoleBase, "/v1/console/frontier"))
         mux.HandleFunc("/v1/console/coverage", proxyGET(client, consoleBase, "/v1/console/coverage"))
+        mux.HandleFunc("/v1/console/fogstack/validation", proxyGET(client, consoleBase, "/v1/console/fogstack/validation"))
         mux.HandleFunc("/v1/console/recent-events", proxyGET(client, consoleBase, "/v1/console/recent-events"))
+        mux.HandleFunc("/v1/console/telemetry", proxyGET(client, consoleBase, "/v1/console/telemetry"))
         mux.HandleFunc("/v1/console/models/", proxyDynamicGET(client, consoleBase, "/v1/console/models/", "/v1/console/models/"))
         mux.HandleFunc("/console/evidence", proxyGET(client, consoleBase, "/console/evidence"))
     }

--- a/apps/gateway/cmd/tritrpc-gateway/main_test.go
+++ b/apps/gateway/cmd/tritrpc-gateway/main_test.go
@@ -74,6 +74,28 @@ func TestConsoleFrontierProxy(t *testing.T) {
     }
 }
 
+func TestConsoleFogstackValidationProxy(t *testing.T) {
+    upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if r.URL.Path != "/v1/console/fogstack/validation" {
+            t.Fatalf("unexpected path: %s", r.URL.Path)
+        }
+        if got := r.URL.Query().Get("limit"); got != "5" {
+            t.Fatalf("missing query param, got %q", got)
+        }
+        _ = json.NewEncoder(w).Encode(map[string]any{"latest_by_bundle": []any{}, "recent": []any{}})
+    }))
+    defer upstream.Close()
+
+    mux := newMux("tcp://127.0.0.1:9", [32]byte{}, "", upstream.URL, upstream.Client())
+    rr := httptest.NewRecorder()
+    req := httptest.NewRequest(http.MethodGet, "/v1/console/fogstack/validation?limit=5", nil)
+    mux.ServeHTTP(rr, req)
+
+    if rr.Code != http.StatusOK {
+        t.Fatalf("unexpected status: %d", rr.Code)
+    }
+}
+
 func TestConsoleModelProxyPathAndQuery(t *testing.T) {
     upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
         if r.URL.Path != "/v1/console/models/model.semantic-stack.2026-04-05" {


### PR DESCRIPTION
## What this does

Adds an operator-facing FogStack validation view to the already-merged evidence-console/evidence-receipts lane.

### Scope
- adds `/v1/console/fogstack/validation` to `apps/evidence-console`
- includes FogStack validation in the minimal `/console/evidence` HTML stub
- adds gateway proxy support for `/v1/console/fogstack/validation`
- adds console route/service tests
- adds gateway proxy test coverage
- preserves the telemetry view already present on `main`

## Why

PR #71 wires FogStack CI validation records into canonical platform evidence artifacts. This PR makes those validation records visible through the operator-facing evidence console rather than leaving them only as raw evidence-reader data.

## Relationship to PR #392

This PR is the non-draft successor to PR #392, created because the connector path for converting a validated draft PR to ready-for-review is currently broken. The code delta is the same narrow seven-file operator-surface slice.

## Limits

- no new persistence
- no cache/indexer
- no signing/registry behavior
- no dashboard framework

## Note

The repo is moving quickly. This is a narrow seven-file slice and may need a final fast-forward refresh before merge if `main` moves again.