### PR TITLE
docs: align WordOps Matrix surface with AgentTerm and homeserver deployment

### DIFF
--- a/docs/WORDOPS_MATRIX_HOMESERVER_DEPLOYMENT_PROFILE.md
+++ b/docs/WORDOPS_MATRIX_HOMESERVER_DEPLOYMENT_PROFILE.md
@@ -1,0 +1,146 @@
+# WordOps Matrix Homeserver Deployment Profile v0.1
+
+## Purpose
+
+This profile defines the first deployable Matrix homeserver shape for WordOps.
+
+WordOps needs a controlled Matrix homeserver estate because client-facing self-service support, private escalation rooms, Matrix-native agent rendezvous, and regulated public-to-private case pivots cannot rely on arbitrary public homeservers.
+
+## Deployment principle
+
+Start with our own Matrix homeserver containers, not public-server dependency.
+
+Public federation compatibility is required, but public-server dependency is not.
+
+## Estate split
+
+### Public edge estate
+
+Purpose:
+- public intake
+- support entry
+- community rooms
+- low-sensitivity self-service
+
+Default posture:
+- federated where appropriate
+- public directory publication disabled until moderation is live
+- no regulated case content
+- no high-risk agent capability exposure
+
+### Private core estate
+
+Purpose:
+- case rooms
+- escalation rooms
+- incident rooms
+- internal operator rooms
+- private agent workspaces
+
+Default posture:
+- private visibility
+- no third-party identity server by default
+- no public room directory publication
+- federation disabled for sensitive rooms unless policy allows it
+- E2EE posture checks before sensitive agent context is released
+
+## Container approach
+
+Phase 0 should use containerized Synapse estates with explicit image pinning.
+
+Required container responsibilities:
+- homeserver process
+- Postgres database
+- reverse proxy / TLS termination
+- worker separation when scaling requires it
+- media store volume
+- config volume
+- signing key persistence
+- backup path
+
+## Pull/build logic
+
+The deployment tooling should support two paths:
+
+### Pull path
+
+Use a pinned upstream Synapse image for initial deployment.
+
+Required controls:
+- image tag pinned
+- digest recorded when promoted
+- config generated into versioned deployment directory
+- signing key generated once and persisted outside disposable containers
+- Postgres volume explicitly named and backed up
+
+### Build path
+
+Build a local image only when we need a patched homeserver, custom hardening, or reproducible internal base images.
+
+Required controls:
+- Dockerfile or Containerfile checked into the repo before use
+- SBOM generated during build
+- image digest recorded
+- provenance emitted into the platform evidence lane
+- no mutable `latest` image in deployment profiles
+
+## Minimal local stack
+
+The first local stack should include:
+- `synapse-public`
+- `postgres-public`
+- `synapse-private`
+- `postgres-private`
+- `reverse-proxy`
+
+Optional later:
+- Element Web
+- Hookshot
+- maubot
+- Mjolnir
+- Matrix RTC stack
+- media repository split
+- workers and Redis
+
+## Config artifacts to produce next
+
+The next implementation slice should add:
+
+```text
+infra/wordops/matrix/local/docker-compose.yml
+infra/wordops/matrix/public/homeserver.yaml.template
+infra/wordops/matrix/private/homeserver.yaml.template
+infra/wordops/matrix/nginx/matrix.conf
+infra/wordops/matrix/scripts/render-config.sh
+infra/wordops/matrix/scripts/generate-signing-key.sh
+infra/wordops/matrix/scripts/smoke-check.sh
+```
+
+## Smoke checks
+
+Minimum checks:
+- public homeserver `/_matrix/client/versions` responds
+- private homeserver `/_matrix/client/versions` responds
+- public discovery JSON is served
+- private discovery JSON is served
+- registration disabled by default
+- room creation through service account works
+- public room publication is blocked until moderation baseline is enabled
+
+## Security gates
+
+Before public exposure:
+- TLS configured
+- registration policy explicit
+- admin account creation procedure documented
+- moderation bot configured
+- backup/restore path tested
+- homeserver signing key backed up
+- media retention policy documented
+- E2EE posture check documented for private rooms
+
+## Relationship to AgentTerm
+
+AgentTerm may connect to this Matrix estate as a terminal-native adapter.
+WordOps owns the Matrix-native client-facing self-service surface.
+Both consume the same homeserver substrate and shared platform authorities.

--- a/docs/WORDOPS_REFERENCE_ARCHITECTURE.md
+++ b/docs/WORDOPS_REFERENCE_ARCHITECTURE.md
@@ -1,136 +1,130 @@
-# WordOps Reference Architecture v0.2
+# WordOps Reference Architecture v0.3
 
 ## Purpose
 
-WordOps is a sovereign operations and case-control fabric with chat as one control surface, not the durable authority, not the policy engine, and not the regulated system of record.
+WordOps is the Matrix-native, client-facing ChatOps self-service agent for SocioProphet support, case intake, and first-line defense.
 
-The architecture is designed to support:
-- public and community Matrix ingress
-- private operator and case collaboration
-- agentic execution with ephemeral capabilities
-- support and scheduling flows
-- DevOps and platform control
-- analytics and Python-based investigation
-- regulated case orchestration via domain packs
+It is designed for people who enter through chat, public rooms, support rooms, office-hours flows, booking links, guided troubleshooting, and escalation paths. It is not the same surface as AgentTerm, which is the terminal-native operator console for engineers and platform operators.
 
-## Core principle
+## Architecture principle
 
-We keep five planes separate:
+WordOps is a surface over the shared platform control fabric. It must not become the durable case authority, the policy authority, or the agent identity authority.
+
+The shared fabric remains:
+- Prophet Platform runtime/deployment topology
+- Matrix as canonical network ChatOps substrate
+- Agent Registry for non-human identity, sessions, grants, and revocation
+- Policy Fabric for side-effect admission and policy evidence
+- AgentPlane for execution, placement, replay, and evidence
+- Sherlock Search for search packets and retrieval evidence
+- Sociosphere for workspace materialization and topology
+- MCP for tool/resource access
+- A2A for agent collaboration and tasking
+
+## Planes
+
+WordOps keeps these planes separate:
 - collaboration plane
 - capability plane
-- workflow plane
-- policy and trust plane
+- workflow/case plane
+- policy/trust plane
 - systems-of-record plane
+- analytics/search plane
 
-That separation prevents chat history, bot state, or ad hoc tool sessions from becoming shadow authorities.
+Chat is not the database. Matrix room power is not authorization. MCP session state is not authority. Agent presence is not permission.
+
+## Primary users
+
+WordOps serves:
+- clients
+- customers
+- support requesters
+- non-operator internal users
+- community members
+- first-line triage participants
+
+AgentTerm serves:
+- operators
+- engineers
+- incident commanders
+- platform maintainers
+- agent wranglers
 
 ## Matrix estates
 
 ### Public Matrix edge
-Use the public estate for:
+The public estate handles:
+- public support intake
 - community rooms
-- intake rooms
-- public support entry
-- low-sensitivity office-hours or booking coordination
-- public-facing bot entry points
+- public help flows
+- low-sensitivity self-service
+- public-facing agent rendezvous only when intentionally exposed
 
-Never use it as the regulated case record.
+Public rooms must never hold regulated case authority or sensitive case content.
 
 ### Private Matrix core
-Use the private estate for:
-- private ops rooms
+The private estate handles:
+- private support escalation rooms
+- per-case rooms
 - incident rooms
-- case rooms
-- agent workspaces tied to real tasks
-- regulated collaboration
+- internal ops rooms
+- regulated collaboration rooms
+- agent workspaces tied to real tasks and leases
 
-Defaults:
-- room version 12
-- private visibility
-- per-case or per-incident room factory
-- no third-party identity server by default
-- encrypted where appropriate
-- non-federated where required by policy
-- created by long-lived service account, not ad hoc by operators
+Sensitive work pivots from the public edge to the private core.
 
-## Agentic interoperability
+## WordOps first-line defense flow
 
-### MCP
-MCP is the agent-to-tool and agent-to-resource surface.
-We use it for tools, prompts, resources, session-scoped access, and host wrappers such as ChatGPT apps.
-MCP is not the durable workflow ledger.
+1. User enters through Matrix, web, email, voice, or another supported ingress.
+2. WordOps performs guided intake and self-service triage.
+3. Low-risk issues may be resolved by self-service guidance.
+4. If the issue needs human or regulated handling, WordOps creates or updates a case/task and pivots into a private room.
+5. Policy Fabric decides which side effects are allowed.
+6. Agent Registry, AgentPlane, Sherlock Search, and Sociosphere provide governed capabilities through leases.
+7. Outcomes are recorded into the appropriate system of record and evidence spine.
 
-### A2A
-A2A is the agent-to-agent collaboration layer.
-We use it for agent discovery, public Agent Cards, authenticated extended cards, delegated work, async tasking, and push notifications.
-A2A is not the domain system of record.
+## Ephemeral capabilities
 
-## Ephemeral capability model
-
-No principal gets standing meaningful privilege merely because it exists.
-Every meaningful capability is:
+No agent, bot, or adapter receives standing meaningful authority. Capabilities are:
 - task-bound
 - case-bound where relevant
 - audience-bound
 - time-bound
 - policy-approved
 
-Lease flow:
-1. requester initiates action
-2. policy evaluates actor, case/task context, environment, risk, and requested scope
-3. broker mints a short-lived downscoped lease
-4. target MCP server or A2A agent accepts only that lease
-5. lease expires or is revoked
-6. session is explicitly torn down where possible
+The broker issues short-lived capability leases after policy evaluation and, when required, human approval.
 
-## Canonical Task abstraction
+## Canonical Task model
 
-A single internal Task model is required to map:
-- workflow engine tasks/jobs
-- A2A Tasks
-- FHIR Tasks
-- ops/support work items
+WordOps actions must correlate to a shared Task abstraction that can map to:
+- A2A Task
+- Flowable task/job
+- FHIR Task where applicable
+- OpenProject work item
+- support/case task record
 
 Core fields:
-- `task_id`
-- `case_id`
-- `intent`
-- `status`
-- `risk_class`
-- `owner`
-- `requester`
-- `due_at`
-- `approvals`
-- `correlation_ids`
-- `artifacts`
-- `provenance`
+- task id
+- case id
+- intent
+- status
+- risk class
+- requester
+- owner
+- correlation ids
+- related artifacts
+- provenance
 
-## Workflow and case kernel
+## Search and evidence
 
-Durable orchestration lives outside chat and outside MCP.
-Use:
-- CMMN for evolving case work
-- BPMN for repeatable subprocesses
-- DMN for transparent routing and decision logic
+Sherlock Search owns search-packet and retrieval evidence behavior. WordOps consumes Sherlock packets for guided support, client-facing search assistance, case context hydration, and escalation evidence.
 
-The current practical target is Flowable.
+WordOps should not invent a parallel search-packet format.
 
-## Systems of record
+## Analytics and investigation
 
-Authoritative systems remain authoritative:
-- commercial support -> Zammad
-- internal ops/project work -> OpenProject
-- healthcare -> FHIR-facing domain adapter / clinical system
-- justice/public safety -> authoritative domain adapter
-- analytics -> observability plus notebooks and BI
+WordOps may request analytics and charting over logs/metrics, but sensitive access must use capability leases. Python/notebook/job runners do not get standing access merely because they are internal.
 
-The kernel orchestrates around them. It does not flatten them into one giant table.
+## Surface adapter invariant
 
-## Non-negotiable rules
-
-1. Public rooms are not regulated case records.
-2. Sensitive work pivots into private rooms and private workflow state immediately.
-3. Matrix membership and room power are not treated as authorization to mutate external systems.
-4. MCP sessions are not authentication and do not replace leases.
-5. A2A public Agent Cards expose discovery only; extended cards expose privileged capabilities only in authenticated sessions.
-6. Durable workflow state stays outside Matrix and outside MCP.
+WordOps and AgentTerm may offer different UX and command ergonomics. They must converge on the same underlying contracts for identity, policy, leases, tasks, search packets, events, and evidence.

--- a/docs/WORDOPS_SURFACE_ADAPTER_MODEL.md
+++ b/docs/WORDOPS_SURFACE_ADAPTER_MODEL.md
@@ -1,0 +1,117 @@
+# WordOps Surface Adapter Model v0.3
+
+## Decision
+
+WordOps and AgentTerm are peer surface adapters over the same platform control fabric. Neither supersedes the other.
+
+## Distinct design goals
+
+### WordOps
+
+WordOps is the Matrix-native, GUI/network-native, client-facing ChatOps self-service agent surface.
+
+Its primary users are:
+- clients
+- customers
+- support requesters
+- community members
+- non-operator internal users
+- first-line triage participants
+
+Its job is to provide the first line of defense for support, case intake, guided troubleshooting, scheduling, feedback capture, and controlled escalation.
+
+WordOps should optimize for:
+- Matrix rooms and spaces
+- guided self-service flows
+- support/case triage
+- public-to-private case pivot
+- calendar/office-hours flows
+- survey/NPS feedback capture
+- safe client-facing automation
+- escalation into operator and case workflows
+
+### AgentTerm
+
+AgentTerm is the terminal-native operator console for users who want to coordinate agents from a terminal.
+
+Its primary users are:
+- operators
+- engineers
+- incident commanders
+- platform maintainers
+- power users
+- agent wranglers
+
+Its job is to provide a local/terminal-first ChatOps console over the same underlying agents, rooms, workrooms, search packets, policy decisions, and execution evidence.
+
+AgentTerm should optimize for:
+- terminal-native command flow
+- local operator event log
+- slash-command ergonomics
+- process-backed participants
+- engineering workflows
+- evidence/event tailing
+- workroom and agent coordination
+
+## Shared substrate
+
+Both surfaces consume the same substrate:
+- Prophet Platform runtime and deployment topology
+- Matrix as canonical network ChatOps substrate
+- Agent Registry identity and session authority
+- Policy Fabric decision and evidence authority
+- AgentPlane execution, run, replay, and evidence authority
+- Sherlock Search search-packet and retrieval evidence authority
+- Sociosphere workspace materialization and topology authority
+- MCP tool/resource contracts
+- A2A agent discovery and task contracts
+- capability leases
+- canonical task/case/event correlation
+- audit and provenance spine
+
+## Authority split
+
+| Concern | Authority |
+| --- | --- |
+| Client-facing self-service ChatOps | WordOps |
+| Terminal-native operator console | AgentTerm |
+| Search packets and retrieval evidence | Sherlock Search |
+| Non-human identity, sessions, grants, revocation | Agent Registry |
+| Policy decision and side-effect admission | Policy Fabric |
+| Agent execution, placement, replay, evidence | AgentPlane |
+| Workspace materialization and repo/workspace state | Sociosphere |
+| Runtime/deployment hub and platform contracts | Prophet Platform |
+
+## Matrix-native WordOps role
+
+WordOps owns the Matrix-native client interaction model:
+- public intake rooms
+- support self-service rooms
+- guided troubleshooting flows
+- public-to-private escalation rooms
+- case handoff surfaces
+- client-facing agent replies
+- scheduling and office-hours coordination
+- feedback, poll, and survey handoff
+- safe outbound communication requests
+
+WordOps does not own durable case authority, non-human identity authority, or policy authority.
+
+## Terminal-native AgentTerm role
+
+AgentTerm owns the terminal operator interaction model:
+- operator shell
+- terminal command loop
+- local event log
+- operator-visible room/channel/thread view
+- CLI-driven adapter dispatch
+- terminal-first agent coordination
+
+AgentTerm does not own client-facing self-service UX or the Matrix-native support triage surface.
+
+## Design invariant
+
+A capability that exists in WordOps must be representable as a governed connector/capability in the shared substrate.
+A capability that exists in AgentTerm must be representable the same way.
+
+Surface-specific UX is allowed. Surface-specific authority is not.


### PR DESCRIPTION
## Summary

This PR updates the WordOps architecture to reflect the current upstream split between Matrix-native client-facing self-service and terminal-native operator workflows.

It makes three scoped changes:

1. Refines `docs/WORDOPS_REFERENCE_ARCHITECTURE.md` so WordOps is explicitly the Matrix-native, client-facing ChatOps self-service agent and first-line defense surface.
2. Adds `docs/WORDOPS_SURFACE_ADAPTER_MODEL.md`, defining WordOps and AgentTerm as peer surface adapters over the shared platform control fabric.
3. Adds `docs/WORDOPS_MATRIX_HOMESERVER_DEPLOYMENT_PROFILE.md`, establishing the initial container/pull/build profile for our own public/private Matrix homeserver estates.

## Design correction

AgentTerm is not more canonical than WordOps, and WordOps is not more canonical than AgentTerm.

- WordOps owns the Matrix-native, client-facing, GUI/network self-service surface.
- AgentTerm owns the terminal-native operator console.
- Both consume the same substrate: Prophet Platform, Matrix, Agent Registry, Policy Fabric, AgentPlane, Sherlock Search, Sociosphere, MCP, A2A, capability leases, tasks, events, and evidence.

## Why this belongs here

`prophet-platform` is the runtime and deployment hub for the SocioProphet platform. This PR updates platform-level guidance and the initial Matrix homeserver deployment profile; it does not move normative standards authority out of the standards repos.

## Validation

- Compared branch against `main`: 3 commits ahead, 0 behind.
- Scope limited to docs only.
- No runtime code changes.

## Next follow-up after merge

- Add `infra/wordops/matrix/local/docker-compose.yml`.
- Add public/private Synapse config templates.
- Add reverse proxy config and smoke checks.
- Add room-factory and support triage implementation slices.
