### PR TITLE
fogstack: require apply-plan evidence in parity readiness

### DIFF
--- a/.github/workflows/fogstack-apply-plan-parity.yml
+++ b/.github/workflows/fogstack-apply-plan-parity.yml
@@ -1,0 +1,47 @@
+name: FogStack Apply Plan Parity
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "tools/run_fogstack_parity_readiness.py"
+      - "tools/check_fogstack_parity_readiness.py"
+      - "tools/update_fogstack_local_demo_apply_plan.py"
+      - "tools/tests/test_fogstack_parity_readiness.py"
+      - "tools/tests/test_run_fogstack_parity_readiness.py"
+      - ".github/workflows/fogstack-apply-plan-parity.yml"
+  push:
+    branches: [main]
+    paths:
+      - "tools/run_fogstack_parity_readiness.py"
+      - "tools/check_fogstack_parity_readiness.py"
+      - "tools/update_fogstack_local_demo_apply_plan.py"
+      - "tools/tests/test_fogstack_parity_readiness.py"
+      - "tools/tests/test_run_fogstack_parity_readiness.py"
+      - ".github/workflows/fogstack-apply-plan-parity.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  apply-plan-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pyyaml jsonschema
+
+      - name: Run parity tests
+        run: |
+          python -m pytest -q \
+            tools/tests/test_fogstack_parity_readiness.py \
+            tools/tests/test_run_fogstack_parity_readiness.py

--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -17,6 +17,7 @@ on:
       - "tools/run_fogstack_local_demo.py"
       - "tools/run_fogstack_local_demo_deploy_plan.py"
       - "tools/update_fogstack_local_demo_deploy_artifacts.py"
+      - "tools/update_fogstack_local_demo_apply_plan.py"
       - "tools/update_fogstack_local_demo_gitops_readiness.py"
       - "tools/update_fogstack_local_demo_runtime_evidence.py"
       - "tools/run_fogstack_local_demo_full.py"
@@ -61,6 +62,7 @@ on:
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
       - "tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py"
+      - "tools/tests/test_update_fogstack_local_demo_apply_plan.py"
       - "tools/tests/test_run_fogstack_local_demo_full.py"
       - "tools/tests/test_fogstack_parity_readiness.py"
       - "tools/tests/test_run_fogstack_parity_readiness.py"
@@ -82,6 +84,7 @@ on:
       - "tools/run_fogstack_local_demo.py"
       - "tools/run_fogstack_local_demo_deploy_plan.py"
       - "tools/update_fogstack_local_demo_deploy_artifacts.py"
+      - "tools/update_fogstack_local_demo_apply_plan.py"
       - "tools/update_fogstack_local_demo_gitops_readiness.py"
       - "tools/update_fogstack_local_demo_runtime_evidence.py"
       - "tools/run_fogstack_local_demo_full.py"
@@ -109,6 +112,7 @@ on:
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
       - "tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py"
+      - "tools/tests/test_update_fogstack_local_demo_apply_plan.py"
       - "tools/tests/test_run_fogstack_local_demo_full.py"
       - "tools/tests/test_fogstack_parity_readiness.py"
       - "tools/tests/test_run_fogstack_parity_readiness.py"
@@ -144,6 +148,7 @@ jobs:
             tools/tests/test_check_fogstack_local_demo_artifact_index.py \
             tools/tests/test_serve_fogstack_local_demo.py \
             tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py \
+            tools/tests/test_update_fogstack_local_demo_apply_plan.py \
             tools/tests/test_run_fogstack_local_demo_full.py \
             tools/tests/test_fogstack_parity_readiness.py \
             tools/tests/test_run_fogstack_parity_readiness.py \
@@ -152,11 +157,7 @@ jobs:
       - name: Run full operator demo command
         run: |
           make fogstack-local-demo-full
-          python3 tools/check_fogstack_parity_readiness.py \
-            --summary build/fogstack-local-demo/fogstack-local-demo.full.summary.json \
-            --index build/fogstack-local-demo/demo-artifacts.index.json \
-            --output build/fogstack-local-demo/fogstack-parity-readiness.record.json \
-            --summary-text
+          python3 tools/run_fogstack_parity_readiness.py --no-clean --summary
           test -s build/fogstack-local-demo/fogstack-local-demo.full.summary.json
           test -s build/fogstack-local-demo/demo-artifacts.index.json
           test -s build/fogstack-local-demo/fogstack-parity-readiness.record.json
@@ -167,6 +168,7 @@ jobs:
           test -s build/fogstack-local-demo/deploy/gitops/kustomization.yaml
           test -s build/fogstack-local-demo/deploy/fogstack.access.gitops-readiness.record.json
           test -s build/fogstack-local-demo/deploy/fogstack.access.live-cluster-preflight.record.json
+          test -s build/fogstack-local-demo/deploy/fogstack.access.live-apply-plan.record.json
           test -s build/fogstack-local-demo/deploy/fogstack.access.local-cluster-runtime-adapter.json
           test -s build/fogstack-local-demo/deploy/fogstack.access.runtime-dry-run.record.json
           test -s build/fogstack-local-demo/deploy/fogstack.access.agent-machine-node-inventory.record.json
@@ -176,6 +178,7 @@ jobs:
         run: |
           python3 tools/run_fogstack_parity_readiness.py --summary
           test -s build/fogstack-local-demo/fogstack-parity-readiness.record.json
+          test -s build/fogstack-local-demo/deploy/fogstack.access.live-apply-plan.record.json
 
       - name: Check generated artifact index
         run: |

--- a/tools/check_fogstack_parity_readiness.py
+++ b/tools/check_fogstack_parity_readiness.py
@@ -26,6 +26,7 @@ REQUIRED_SUMMARY_ARTIFACTS = {
     "gitops_kustomization",
     "gitops_readiness_record",
     "live_cluster_preflight_record",
+    "live_apply_plan_record",
     "runtime_adapter",
     "runtime_dry_run_record",
 }
@@ -48,6 +49,7 @@ REQUIRED_INDEX_IDS = {
     "deploy_gitops_service",
     "deploy_gitops_readiness_record",
     "deploy_live_cluster_preflight_record",
+    "deploy_live_apply_plan_record",
     "deploy_runtime_adapter",
     "deploy_runtime_dry_run_record",
     "deploy_summary",
@@ -164,6 +166,22 @@ def check_records(paths: dict[str, Path], errors: list[str]) -> list[dict[str, s
     require(safety.get("live_apply_allowed") is False, "live cluster preflight allows live apply", errors)
     require(safety.get("human_approval_required_for_apply") is True, "live cluster preflight does not require human approval", errors)
     checked.append({"id": "live_cluster_preflight", "status": str(live_preflight.get("status"))})
+
+    apply_plan = load_json(paths["live_apply_plan_record"])
+    require(apply_plan.get("kind") == "FogStackLiveApplyPlanRecord", "live apply plan kind mismatch", errors)
+    require(apply_plan.get("status") in {"passed", "blocked"}, "live apply plan must pass or block safely", errors)
+    require(apply_plan.get("mode") == "plan-only", "live apply plan mode mismatch", errors)
+    apply_safety = apply_plan.get("safety", {})
+    require(apply_safety.get("plan_only") is True, "live apply plan is not plan-only", errors)
+    require(apply_safety.get("run_performed") is False, "live apply plan performed a run", errors)
+    require(apply_safety.get("mutated_cluster") is False, "live apply plan mutated cluster", errors)
+    require(apply_safety.get("live_apply_allowed") is False, "live apply plan allows live apply", errors)
+    require(apply_safety.get("future_approval_record_required") is True, "live apply plan does not require future approval", errors)
+    require(apply_safety.get("rollback_plan_required") is True, "live apply plan does not require rollback plan", errors)
+    require(apply_plan.get("agentplane", {}).get("agentplane_ref") == "github://SocioProphet/agentplane", "live apply plan AgentPlane ref mismatch", errors)
+    require(apply_plan.get("policyplane", {}).get("policyplane_ref") == "github://SocioProphet/policy-fabric", "live apply plan PolicyPlane ref mismatch", errors)
+    require(apply_plan.get("policyplane", {}).get("decision") == "allow-plan-deny-run", "live apply plan PolicyPlane decision mismatch", errors)
+    checked.append({"id": "live_apply_plan", "status": str(apply_plan.get("status"))})
 
     runtime_adapter = load_json(paths["runtime_adapter"])
     require(runtime_adapter.get("kind") == "FogStackLocalClusterRuntimeAdapter", "runtime adapter kind mismatch", errors)

--- a/tools/run_fogstack_parity_readiness.py
+++ b/tools/run_fogstack_parity_readiness.py
@@ -26,6 +26,7 @@ def load_json(path: Path) -> dict[str, Any]:
 def run_parity(output_dir: Path, clean: bool) -> dict[str, Any]:
     output_dir = output_dir if output_dir.is_absolute() else ROOT / output_dir
     full_summary = output_dir / "fogstack-local-demo.full.summary.json"
+    local_summary = output_dir / "fogstack-local-demo.summary.json"
     artifact_index = output_dir / "demo-artifacts.index.json"
     parity_record = output_dir / "fogstack-parity-readiness.record.json"
 
@@ -33,6 +34,21 @@ def run_parity(output_dir: Path, clean: bool) -> dict[str, Any]:
     if not clean:
         full_demo_cmd.append("--no-clean")
     run(full_demo_cmd)
+    run([
+        sys.executable,
+        "tools/update_fogstack_local_demo_apply_plan.py",
+        "--summary-json", str(local_summary),
+    ])
+    full_record = load_json(full_summary)
+    local_record = load_json(local_summary)
+    apply_ref = local_record.get("artifacts", {}).get("deploy_live_apply_plan_record")
+    if isinstance(apply_ref, str):
+        full_record.setdefault("artifacts", {})["live_apply_plan_record"] = apply_ref
+        checks = full_record.setdefault("checks", [])
+        for check in ["live_apply_plan_record_indexed", "live_apply_plan_summary_appended"]:
+            if check not in checks:
+                checks.append(check)
+        full_summary.write_text(json.dumps(full_record, indent=2) + "\n", encoding="utf-8")
     run([
         sys.executable,
         "tools/check_fogstack_parity_readiness.py",

--- a/tools/tests/test_fogstack_parity_readiness.py
+++ b/tools/tests/test_fogstack_parity_readiness.py
@@ -6,19 +6,57 @@ import sys
 from pathlib import Path
 
 
+def load(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def write(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def add_apply_plan_to_full_summary(output_dir: Path) -> None:
+    subprocess.run([sys.executable, "tools/update_fogstack_local_demo_apply_plan.py", "--summary-json", str(output_dir / "fogstack-local-demo.summary.json")], check=True)
+    local_summary = load(output_dir / "fogstack-local-demo.summary.json")
+    full_summary_path = output_dir / "fogstack-local-demo.full.summary.json"
+    full_summary = load(full_summary_path)
+    apply_ref = local_summary["artifacts"]["deploy_live_apply_plan_record"]
+    full_summary.setdefault("artifacts", {})["live_apply_plan_record"] = apply_ref
+    checks = full_summary.setdefault("checks", [])
+    for check in ["live_apply_plan_record_indexed", "live_apply_plan_summary_appended"]:
+        if check not in checks:
+            checks.append(check)
+    write(full_summary_path, full_summary)
+
+
 def test_check_fogstack_parity_readiness(tmp_path: Path) -> None:
     output_dir = tmp_path / "fogstack-local-demo"
     subprocess.run([sys.executable, "tools/run_fogstack_local_demo_full.py", "--output-dir", str(output_dir), "--summary"], check=True)
+    add_apply_plan_to_full_summary(output_dir)
     record_path = output_dir / "fogstack-parity-readiness.record.json"
     proc = subprocess.run([sys.executable, "tools/check_fogstack_parity_readiness.py", "--summary", str(output_dir / "fogstack-local-demo.full.summary.json"), "--index", str(output_dir / "demo-artifacts.index.json"), "--output", str(record_path), "--summary-text"], check=True, capture_output=True, text=True)
     assert "FogStack parity readiness: passed" in proc.stdout
-    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record = load(record_path)
     assert record["kind"] == "FogStackParityReadinessRecord"
     assert record["status"] == "passed"
     assert record["errors"] == []
     checked = {lane["id"] for lane in record["checked_lanes"]}
-    for lane in ["node_inventory", "immutable_update_readiness", "cluster_readiness", "gitops_readiness", "live_cluster_preflight", "runtime_adapter", "runtime_dry_run", "deploy_plan", "agent_corps_plan", "gitops_bundle", "gitops_application", "gitops_kustomization"]:
+    for lane in ["node_inventory", "immutable_update_readiness", "cluster_readiness", "gitops_readiness", "live_cluster_preflight", "live_apply_plan", "runtime_adapter", "runtime_dry_run", "deploy_plan", "agent_corps_plan", "gitops_bundle", "gitops_application", "gitops_kustomization"]:
         assert lane in checked
-    for artifact_id in ["deploy_runtime_dry_run_record", "deploy_node_inventory_record", "deploy_immutable_update_readiness_record", "deploy_live_cluster_preflight_record"]:
+    for artifact_id in ["deploy_runtime_dry_run_record", "deploy_node_inventory_record", "deploy_immutable_update_readiness_record", "deploy_live_cluster_preflight_record", "deploy_live_apply_plan_record"]:
         assert artifact_id in record["required_index_ids"]
     assert "live_cluster_preflight_record" in record["required_summary_artifacts"]
+    assert "live_apply_plan_record" in record["required_summary_artifacts"]
+
+
+def test_check_fogstack_parity_readiness_fails_without_apply_plan(tmp_path: Path) -> None:
+    output_dir = tmp_path / "fogstack-local-demo"
+    subprocess.run([sys.executable, "tools/run_fogstack_local_demo_full.py", "--output-dir", str(output_dir), "--summary"], check=True)
+    record_path = output_dir / "fogstack-parity-readiness.record.json"
+    proc = subprocess.run([sys.executable, "tools/check_fogstack_parity_readiness.py", "--summary", str(output_dir / "fogstack-local-demo.full.summary.json"), "--index", str(output_dir / "demo-artifacts.index.json"), "--output", str(record_path), "--summary-text"], capture_output=True, text=True)
+    assert proc.returncode == 1
+    record = load(record_path)
+    assert record["status"] == "failed"
+    assert "missing summary artifact: live_apply_plan_record" in record["errors"]
+    assert "artifact index missing id: deploy_live_apply_plan_record" in record["errors"]

--- a/tools/tests/test_run_fogstack_parity_readiness.py
+++ b/tools/tests/test_run_fogstack_parity_readiness.py
@@ -6,6 +6,12 @@ import sys
 from pathlib import Path
 
 
+def load(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
 def test_run_fogstack_parity_readiness(tmp_path: Path) -> None:
     output_dir = tmp_path / "fogstack-local-demo"
     proc = subprocess.run([
@@ -19,7 +25,22 @@ def test_run_fogstack_parity_readiness(tmp_path: Path) -> None:
     assert "Turn counter: 31/32" in proc.stdout
     record_path = output_dir / "fogstack-parity-readiness.record.json"
     assert record_path.exists()
-    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record = load(record_path)
     assert record["kind"] == "FogStackParityReadinessRecord"
     assert record["status"] == "passed"
     assert record["errors"] == []
+    assert "live_apply_plan" in {lane["id"] for lane in record["checked_lanes"]}
+    assert "live_apply_plan_record" in record["required_summary_artifacts"]
+    assert "deploy_live_apply_plan_record" in record["required_index_ids"]
+
+    full_summary = load(output_dir / "fogstack-local-demo.full.summary.json")
+    assert "live_apply_plan_record" in full_summary["artifacts"]
+    apply_plan = load(Path(full_summary["artifacts"]["live_apply_plan_record"]))
+    assert apply_plan["kind"] == "FogStackLiveApplyPlanRecord"
+    assert apply_plan["mode"] == "plan-only"
+    assert apply_plan["safety"]["run_performed"] is False
+    assert apply_plan["safety"]["mutated_cluster"] is False
+    assert apply_plan["safety"]["live_apply_allowed"] is False
+
+    index = load(output_dir / "demo-artifacts.index.json")
+    assert "deploy_live_apply_plan_record" in {entry["id"] for entry in index["artifacts"]}

--- a/tools/update_fogstack_local_demo_apply_plan.py
+++ b/tools/update_fogstack_local_demo_apply_plan.py
@@ -45,18 +45,19 @@ def sha256_file(path: Path) -> str:
     return "sha256:" + digest.hexdigest()
 
 
-def refresh_index(index_path: Path, artifact_ref: str) -> None:
+def refresh_index_entries(index_path: Path, refs_by_id: dict[str, str]) -> None:
     index = load_json(index_path)
     by_id = {entry["id"]: entry for entry in index.get("artifacts", []) if isinstance(entry, dict) and entry.get("id")}
-    path = path_from_ref(artifact_ref)
-    if not path.exists() or not path.is_file():
-        raise SystemExit(f"ERR: apply plan artifact missing: {artifact_ref}")
-    by_id[ARTIFACT_ID] = {
-        "id": ARTIFACT_ID,
-        "ref": artifact_ref,
-        "digest": sha256_file(path),
-        "size_bytes": path.stat().st_size,
-    }
+    for artifact_id, artifact_ref in refs_by_id.items():
+        path = path_from_ref(artifact_ref)
+        if not path.exists() or not path.is_file():
+            raise SystemExit(f"ERR: indexed artifact missing: {artifact_id} {artifact_ref}")
+        by_id[artifact_id] = {
+            "id": artifact_id,
+            "ref": artifact_ref,
+            "digest": sha256_file(path),
+            "size_bytes": path.stat().st_size,
+        }
     index["artifacts"] = [by_id[key] for key in sorted(by_id)]
     write_json(index_path, index)
 
@@ -152,9 +153,14 @@ def update(summary_path: Path, output_path: Path | None) -> dict[str, Any]:
         if check not in checks:
             checks.append(check)
     write_json(summary_path, summary)
-    refresh_index(path_from_ref(artifacts["artifact_index"]), artifact_ref)
     append_markdown(path_from_ref(artifacts["summary_markdown"]), artifact_ref, record)
     append_html(path_from_ref(artifacts["summary_html"]), artifact_ref, record)
+    refresh_index_entries(path_from_ref(artifacts["artifact_index"]), {
+        ARTIFACT_ID: artifact_ref,
+        "summary_json": rel(summary_path),
+        "summary_markdown": artifacts["summary_markdown"],
+        "summary_html": artifacts["summary_html"],
+    })
     return summary
 
 


### PR DESCRIPTION
Deployment parity tranche B canonicalization.

This wires the plan-only `FogStackLiveApplyPlanRecord` into the one-command parity path and makes parity readiness require it.

Changes:
- `run_fogstack_parity_readiness.py` now runs `update_fogstack_local_demo_apply_plan.py` after the full local demo and grafts the apply-plan artifact into the full summary.
- `check_fogstack_parity_readiness.py` now requires `live_apply_plan_record` and `deploy_live_apply_plan_record`.
- parity checks enforce non-execution invariants for the apply-plan record.
- direct checker test proves parity fails without the apply-plan artifact.
- one-command runner test proves the canonical path emits and indexes the apply-plan artifact.
- focused workflow added for apply-plan parity coverage.

Safety boundary:
- no live apply execution
- no kubectl execution
- no GitOps sync execution
- requires `run_performed=false`, `mutated_cluster=false`, `live_apply_allowed=false`, future approval required, and rollback plan required.

Note: main moved while this branch was prepared. If premerge-audit rejects freshness, refresh this same patch onto latest main.