### PR TITLE
apps(openai-research-mcp): add gateway auth foundation

### DIFF
--- a/apps/openai-research-mcp/research_mcp/auth.py
+++ b/apps/openai-research-mcp/research_mcp/auth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Mapping
 
 from .errors import AuthError
 from .models import AuthContext
@@ -12,12 +13,30 @@ def load_static_tokens(path: Path) -> dict[str, dict]:
     return data.get("tokens", {})
 
 
+def _header(headers: Mapping[str, str] | None, name: str) -> str | None:
+    if not headers:
+        return None
+    normalized = {key.lower(): value for key, value in headers.items()}
+    value = normalized.get(name.lower())
+    if value is None:
+        return None
+    value = str(value).strip()
+    return value or None
+
+
+def _parse_scopes(raw: str | None) -> tuple[str, ...]:
+    if not raw:
+        return ()
+    normalized = raw.replace(",", " ")
+    return tuple(scope for scope in normalized.split() if scope)
+
+
 class StaticTokenAuthorizer:
     def __init__(self, tokens: dict[str, dict], *, allow_anonymous_read: bool = True):
         self.tokens = tokens
         self.allow_anonymous_read = allow_anonymous_read
 
-    def authorize_read(self, token: str | None) -> AuthContext:
+    def authorize_read(self, token: str | None, headers: Mapping[str, str] | None = None) -> AuthContext:
         if token and token in self.tokens:
             row = self.tokens[token]
             return AuthContext(
@@ -30,7 +49,7 @@ class StaticTokenAuthorizer:
             return AuthContext(anonymous_read=True)
         raise AuthError("missing_token")
 
-    def authorize_export(self, token: str | None) -> AuthContext:
+    def authorize_export(self, token: str | None, headers: Mapping[str, str] | None = None) -> AuthContext:
         if not token or token not in self.tokens:
             raise AuthError("missing_token")
         row = self.tokens[token]
@@ -42,4 +61,51 @@ class StaticTokenAuthorizer:
         )
         if "artifacts:write" not in ctx.scopes:
             raise AuthError("missing_scope:artifacts:write")
+        return ctx
+
+
+class TrustedHeaderAuthorizer:
+    """Authorizer for deployments behind an identity-validating gateway."""
+
+    def __init__(
+        self,
+        *,
+        subject_header: str = "X-Subject",
+        organization_header: str = "X-Organization",
+        scopes_header: str = "X-Scopes",
+        allow_anonymous_read: bool = False,
+        read_scope: str = "documents:read",
+        export_scope: str = "artifacts:write",
+    ):
+        self.subject_header = subject_header
+        self.organization_header = organization_header
+        self.scopes_header = scopes_header
+        self.allow_anonymous_read = allow_anonymous_read
+        self.read_scope = read_scope
+        self.export_scope = export_scope
+
+    def _context(self, headers: Mapping[str, str] | None) -> AuthContext:
+        subject = _header(headers, self.subject_header)
+        organization = _header(headers, self.organization_header)
+        scopes = _parse_scopes(_header(headers, self.scopes_header))
+        if not subject:
+            if self.allow_anonymous_read:
+                return AuthContext(anonymous_read=True)
+            raise AuthError("missing_trusted_subject")
+        return AuthContext(subject=subject, organization=organization, scopes=scopes, anonymous_read=False)
+
+    def authorize_read(self, token: str | None, headers: Mapping[str, str] | None = None) -> AuthContext:
+        ctx = self._context(headers)
+        if ctx.anonymous_read:
+            return ctx
+        if self.read_scope and self.read_scope not in ctx.scopes:
+            raise AuthError(f"missing_scope:{self.read_scope}")
+        return ctx
+
+    def authorize_export(self, token: str | None, headers: Mapping[str, str] | None = None) -> AuthContext:
+        ctx = self._context(headers)
+        if ctx.anonymous_read:
+            raise AuthError("missing_trusted_subject")
+        if self.export_scope and self.export_scope not in ctx.scopes:
+            raise AuthError(f"missing_scope:{self.export_scope}")
         return ctx

--- a/apps/openai-research-mcp/research_mcp/service.py
+++ b/apps/openai-research-mcp/research_mcp/service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Mapping
+
 from .audit import JsonlAuditSink
 from .auth import StaticTokenAuthorizer
 from .artifacts import MarkdownArtifactExporter
@@ -13,8 +15,15 @@ class ResearchService:
         self.audit_sink = audit_sink
         self.exporter = exporter
 
-    def search_contract(self, query: str, *, limit: int = 10, token: str | None = None) -> dict:
-        ctx = self.authorizer.authorize_read(token)
+    def search_contract(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        token: str | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> dict:
+        ctx = self.authorizer.authorize_read(token, headers=headers)
         docs = self.backend.search(query, limit=limit, auth_context=ctx)
         self.audit_sink.emit({
             "event": "search",
@@ -26,8 +35,14 @@ class ResearchService:
         })
         return {"results": [doc.search_result() for doc in docs]}
 
-    def fetch_contract(self, document_id: str, *, token: str | None = None) -> dict:
-        ctx = self.authorizer.authorize_read(token)
+    def fetch_contract(
+        self,
+        document_id: str,
+        *,
+        token: str | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> dict:
+        ctx = self.authorizer.authorize_read(token, headers=headers)
         doc = self.backend.fetch(document_id, auth_context=ctx)
         self.audit_sink.emit({
             "event": "fetch",
@@ -38,8 +53,16 @@ class ResearchService:
         })
         return doc.fetch_result()
 
-    def export_report_handoff(self, title: str, narrative: str, document_ids: list[str], *, token: str | None = None) -> dict:
-        ctx = self.authorizer.authorize_export(token)
+    def export_report_handoff(
+        self,
+        title: str,
+        narrative: str,
+        document_ids: list[str],
+        *,
+        token: str | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> dict:
+        ctx = self.authorizer.authorize_export(token, headers=headers)
         docs = [self.backend.fetch(doc_id, auth_context=ctx).fetch_result() for doc_id in document_ids]
         payload = self.exporter.export_report(title=title, narrative=narrative, documents=docs)
         self.audit_sink.emit({

--- a/apps/openai-research-mcp/tests/test_context_auth.py
+++ b/apps/openai-research-mcp/tests/test_context_auth.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import unittest
+
+from research_mcp.auth import TrustedHeaderAuthorizer
+
+
+class ContextAuthTests(unittest.TestCase):
+    def test_context_authorizer_accepts_named_context(self):
+        authorizer = TrustedHeaderAuthorizer()
+        ctx = authorizer.authorize_read(
+            None,
+            headers={"X-Subject": "reader", "X-Organization": "demo-org", "X-Scopes": "documents:read"},
+        )
+        self.assertEqual(ctx.subject, "reader")
+        self.assertEqual(ctx.organization, "demo-org")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Replacement for #453, recreated from current `main` after Regis ACR changes moved upstream.

Add the first gateway-auth foundation for `openai-research-mcp` while preserving the existing static-token default.

## Changes

- add `TrustedHeaderAuthorizer`
- keep `StaticTokenAuthorizer` behavior compatible with existing calls
- allow service methods to receive optional request headers for auth context
- add a focused context-auth test

## Scope

This PR does not enable gateway mode in `server.py` yet. Runtime env-mode wiring will follow separately after this foundation lands.