### PR TITLE
demo: attach SourceOS state integrity to FogStack full local demo

### DIFF
--- a/.github/workflows/fogstack-local-demo.yml
+++ b/.github/workflows/fogstack-local-demo.yml
@@ -19,6 +19,8 @@ on:
       - "tools/update_fogstack_local_demo_deploy_artifacts.py"
       - "tools/update_fogstack_local_demo_gitops_readiness.py"
       - "tools/update_fogstack_local_demo_runtime_evidence.py"
+      - "tools/emit_sourceos_state_integrity_demo_report.py"
+      - "tools/update_fogstack_local_demo_sourceos_state_integrity.py"
       - "tools/run_fogstack_local_demo_full.py"
       - "tools/check_fogstack_parity_readiness.py"
       - "tools/run_fogstack_parity_readiness.py"
@@ -61,6 +63,7 @@ on:
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
       - "tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py"
+      - "tools/tests/test_update_fogstack_local_demo_sourceos_state_integrity.py"
       - "tools/tests/test_run_fogstack_local_demo_full.py"
       - "tools/tests/test_fogstack_parity_readiness.py"
       - "tools/tests/test_run_fogstack_parity_readiness.py"
@@ -84,6 +87,8 @@ on:
       - "tools/update_fogstack_local_demo_deploy_artifacts.py"
       - "tools/update_fogstack_local_demo_gitops_readiness.py"
       - "tools/update_fogstack_local_demo_runtime_evidence.py"
+      - "tools/emit_sourceos_state_integrity_demo_report.py"
+      - "tools/update_fogstack_local_demo_sourceos_state_integrity.py"
       - "tools/run_fogstack_local_demo_full.py"
       - "tools/check_fogstack_parity_readiness.py"
       - "tools/run_fogstack_parity_readiness.py"
@@ -109,6 +114,7 @@ on:
       - "tools/tests/test_check_fogstack_local_demo_artifact_index.py"
       - "tools/tests/test_serve_fogstack_local_demo.py"
       - "tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py"
+      - "tools/tests/test_update_fogstack_local_demo_sourceos_state_integrity.py"
       - "tools/tests/test_run_fogstack_local_demo_full.py"
       - "tools/tests/test_fogstack_parity_readiness.py"
       - "tools/tests/test_run_fogstack_parity_readiness.py"
@@ -144,6 +150,7 @@ jobs:
             tools/tests/test_check_fogstack_local_demo_artifact_index.py \
             tools/tests/test_serve_fogstack_local_demo.py \
             tools/tests/test_update_fogstack_local_demo_deploy_artifacts.py \
+            tools/tests/test_update_fogstack_local_demo_sourceos_state_integrity.py \
             tools/tests/test_run_fogstack_local_demo_full.py \
             tools/tests/test_fogstack_parity_readiness.py \
             tools/tests/test_run_fogstack_parity_readiness.py \
@@ -152,6 +159,12 @@ jobs:
       - name: Run full operator demo command
         run: |
           make fogstack-local-demo-full
+          python3 tools/update_fogstack_local_demo_sourceos_state_integrity.py \
+            --summary-json build/fogstack-local-demo/fogstack-local-demo.full.summary.json \
+            --artifact-index build/fogstack-local-demo/demo-artifacts.index.json \
+            --output build/fogstack-local-demo/sourceos.state-integrity-report.json \
+            --summary
+          python3 tools/check_fogstack_local_demo_artifact_index.py --index build/fogstack-local-demo/demo-artifacts.index.json
           python3 tools/check_fogstack_parity_readiness.py \
             --summary build/fogstack-local-demo/fogstack-local-demo.full.summary.json \
             --index build/fogstack-local-demo/demo-artifacts.index.json \
@@ -159,6 +172,7 @@ jobs:
             --summary-text
           test -s build/fogstack-local-demo/fogstack-local-demo.full.summary.json
           test -s build/fogstack-local-demo/demo-artifacts.index.json
+          test -s build/fogstack-local-demo/sourceos.state-integrity-report.json
           test -s build/fogstack-local-demo/fogstack-parity-readiness.record.json
           test -s build/fogstack-local-demo/deploy/fogstack.access.deploy-plan.json
           test -s build/fogstack-local-demo/deploy/kubernetes/deployment.yaml

--- a/tools/emit_sourceos_state_integrity_demo_report.py
+++ b/tools/emit_sourceos_state_integrity_demo_report.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def build_report() -> dict[str, Any]:
+    generated_at = "2026-05-05T00:00:00Z"
+    return {
+        "schema": "sourceos.state-integrity-report/v1alpha1",
+        "generated_at": generated_at,
+        "identity": {
+            "component": "sourceos-syncd",
+            "repo": "github://SourceOS-Linux/sourceos-syncd",
+            "pid": 0,
+            "process_name": "sourceos-syncd-demo",
+            "node_id_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "boot_id": None,
+            "version": "0.1.0-demo",
+            "commit": None,
+            "build_provenance": "github://SourceOS-Linux/sourceos-syncd",
+            "platform": "unknown",
+            "service_manager": "manual"
+        },
+        "collection": {
+            "status": "complete",
+            "duration_ms": 0,
+            "errors": [],
+            "redacted_fields": [],
+            "permission_denied_fields": [],
+            "timed_out_fields": [],
+            "unavailable_fields": []
+        },
+        "runtime": {
+            "process_started_at": generated_at,
+            "runtime_ready_at": generated_at,
+            "store_opened_at": generated_at,
+            "replay_started_at": generated_at,
+            "replay_completed_at": generated_at,
+            "first_heartbeat_at": generated_at,
+            "last_heartbeat_at": generated_at,
+            "last_clean_shutdown_at": None,
+            "last_dirty_open_at": None
+        },
+        "stores": [
+            {
+                "name": "sourceos-local-state-demo",
+                "role": "active",
+                "backend": "fixture",
+                "schema_version": "v1alpha1",
+                "created_by_version": "0.1.0-demo",
+                "runtime_version": "0.1.0-demo",
+                "previous_runtime_version": None,
+                "migration_state": "none",
+                "active_generation": 1,
+                "last_known_good_generation": 1,
+                "shadow_present": False,
+                "manifest_present": True,
+                "checksum_state": "verified",
+                "flags_raw": 0,
+                "flags_hex": "0x0",
+                "flags_decoded": [],
+                "unknown_flags": []
+            }
+        ],
+        "lanes": [
+            {
+                "name": "policy",
+                "status": "active",
+                "sla": {"max_staleness_seconds": 60},
+                "objects": {"total": 3, "verified": 3, "stale": 0, "unsafe": 0},
+                "journal": {"status": "verified", "entries": 3, "last_sequence": 3},
+                "maintenance": {"repair_required": False, "last_compaction_at": generated_at}
+            },
+            {
+                "name": "audit",
+                "status": "active",
+                "sla": {"max_staleness_seconds": 300},
+                "objects": {"total": 4, "verified": 4, "stale": 0, "unsafe": 0},
+                "journal": {"status": "verified", "entries": 4, "last_sequence": 4},
+                "maintenance": {"repair_required": False, "last_compaction_at": generated_at}
+            }
+        ],
+        "pipeline": {
+            "mode": "bounded-local-demo",
+            "source": "FogStack full local demo",
+            "upstream_contract": "github://SourceOS-Linux/sourceos-syncd/schemas/sourceos.state-integrity-report.v1alpha1.schema.json",
+            "mutating_repairs_enabled": False
+        },
+        "resources": {
+            "disk": {
+                "filesystem": "demo",
+                "free_bytes": 1024,
+                "total_bytes": 4096,
+                "free_ratio": 0.25,
+                "pressure": "none"
+            },
+            "memory": {"pressure": "none", "working_set_bytes": 0}
+        },
+        "policy": {
+            "policy_engine": "github://SocioProphet/policy-fabric",
+            "policy_decisions": {"allow": 3, "deny": 0, "manual_review": 0, "blocked_expected": 1}
+        },
+        "invariants": [
+            {
+                "id": "state-store-checksum-verified",
+                "status": "pass",
+                "severity": "info",
+                "evidence": {"store": "sourceos-local-state-demo", "checksum_state": "verified"},
+                "remediation": "No repair required for bounded local demo fixture."
+            },
+            {
+                "id": "repair-actions-disabled",
+                "status": "pass",
+                "severity": "info",
+                "evidence": {"mutating_repairs_enabled": False},
+                "remediation": "Keep repair apply disabled unless a signed approval plan exists."
+            }
+        ],
+        "diagnosis": {
+            "status": "healthy",
+            "summary": "SourceOS state-integrity fixture is healthy and non-mutating for the FogStack local demo.",
+            "operator_narrative": "State integrity is present as digest-indexed evidence. Repair apply remains disabled by policy."
+        },
+        "controls": [
+            {"id": "repair-apply-disabled", "status": "enforced", "policy_ref": "github://SocioProphet/policy-fabric"},
+            {"id": "artifact-index-required", "status": "enforced", "policy_ref": "github://SocioProphet/prophet-platform/tools/check_fogstack_local_demo_artifact_index.py"}
+        ],
+        "attestation": {
+            "status": "demo-evidence",
+            "artifact_indexed": True,
+            "source_repo": "github://SourceOS-Linux/sourceos-syncd",
+            "consumer_repo": "github://SocioProphet/prophet-platform"
+        }
+    }
+
+
+def update_artifact_index(index_path: Path, artifact_id: str, artifact_path: Path) -> None:
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    if not isinstance(index, dict) or not isinstance(index.get("artifacts"), list):
+        raise SystemExit(f"ERR: malformed artifact index: {index_path}")
+
+    artifact_ref = rel(artifact_path)
+    entry = {
+        "id": artifact_id,
+        "ref": artifact_ref,
+        "digest": sha256_file(artifact_path),
+        "size_bytes": artifact_path.stat().st_size
+    }
+
+    for existing in index["artifacts"]:
+        if not isinstance(existing, dict):
+            continue
+        if existing.get("id") == artifact_id or existing.get("ref") == artifact_ref:
+            existing.update(entry)
+            write_json(index_path, index)
+            return
+
+    index["artifacts"].append(entry)
+    write_json(index_path, index)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a SourceOS state-integrity report for the FogStack local demo")
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--artifact-index", type=Path)
+    parser.add_argument("--artifact-id", default="sourceos_state_integrity_report")
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args()
+
+    output = args.output if args.output.is_absolute() else ROOT / args.output
+    write_json(output, build_report())
+
+    if args.artifact_index:
+        index_path = args.artifact_index if args.artifact_index.is_absolute() else ROOT / args.artifact_index
+        update_artifact_index(index_path, args.artifact_id, output)
+
+    if args.summary:
+        print(f"SourceOS state integrity report: {rel(output)}")
+        if args.artifact_index:
+            print(f"Artifact index updated: {rel(index_path)}")
+    else:
+        print(json.dumps({"status": "passed", "report": rel(output)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_update_fogstack_local_demo_sourceos_state_integrity.py
+++ b/tools/tests/test_update_fogstack_local_demo_sourceos_state_integrity.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def load(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def test_update_fogstack_local_demo_sourceos_state_integrity(tmp_path: Path) -> None:
+    summary_path = tmp_path / "fogstack-local-demo.full.summary.json"
+    artifact_index_path = tmp_path / "demo-artifacts.index.json"
+    report_path = tmp_path / "sourceos.state-integrity-report.json"
+
+    summary_path.write_text(
+        json.dumps(
+            {
+                "kind": "FogStackLocalDemoFullRun",
+                "schema_version": "v0.1",
+                "status": "passed",
+                "artifacts": {},
+                "checks": [],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    artifact_index_path.write_text(
+        json.dumps(
+            {
+                "kind": "FogStackLocalDemoArtifactIndex",
+                "schema_version": "v0.1",
+                "artifacts": [],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "tools/update_fogstack_local_demo_sourceos_state_integrity.py",
+            "--summary-json",
+            str(summary_path),
+            "--artifact-index",
+            str(artifact_index_path),
+            "--output",
+            str(report_path),
+            "--summary",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "SourceOS state integrity report:" in proc.stdout
+    assert "FogStack full summary updated:" in proc.stdout
+    assert "Artifact index updated:" in proc.stdout
+
+    report = load(report_path)
+    assert report["schema"] == "sourceos.state-integrity-report/v1alpha1"
+    assert report["identity"]["component"] == "sourceos-syncd"
+    assert report["identity"]["repo"] == "github://SourceOS-Linux/sourceos-syncd"
+    assert report["collection"]["status"] == "complete"
+    assert report["pipeline"]["mode"] == "bounded-local-demo"
+    assert report["pipeline"]["mutating_repairs_enabled"] is False
+    assert report["diagnosis"]["status"] == "healthy"
+    assert report["attestation"]["artifact_indexed"] is True
+
+    summary = load(summary_path)
+    assert summary["artifacts"]["sourceos_state_integrity_report"] == str(report_path)
+    assert "sourceos_state_integrity_report_indexed" in summary["checks"]
+
+    index = load(artifact_index_path)
+    entries = index["artifacts"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["id"] == "sourceos_state_integrity_report"
+    assert entry["ref"] == str(report_path)
+    assert entry["digest"].startswith("sha256:")
+    assert len(entry["digest"]) == 71
+    assert entry["size_bytes"] == report_path.stat().st_size

--- a/tools/update_fogstack_local_demo_sourceos_state_integrity.py
+++ b/tools/update_fogstack_local_demo_sourceos_state_integrity.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from emit_sourceos_state_integrity_demo_report import build_report, rel, update_artifact_index, write_json
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def append_once(values: list[Any], value: Any) -> None:
+    if value not in values:
+        values.append(value)
+
+
+def update_summary(summary_path: Path, report_path: Path) -> dict[str, Any]:
+    summary = load_json(summary_path)
+    artifacts = summary.setdefault("artifacts", {})
+    if not isinstance(artifacts, dict):
+        raise SystemExit(f"ERR: summary artifacts must be an object: {summary_path}")
+    artifacts["sourceos_state_integrity_report"] = rel(report_path)
+
+    checks = summary.setdefault("checks", [])
+    if not isinstance(checks, list):
+        raise SystemExit(f"ERR: summary checks must be a list: {summary_path}")
+    append_once(checks, "sourceos_state_integrity_report_indexed")
+
+    write_json(summary_path, summary)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Attach SourceOS state-integrity evidence to a FogStack local demo run")
+    parser.add_argument("--summary-json", required=True, type=Path)
+    parser.add_argument("--artifact-index", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--summary", action="store_true")
+    args = parser.parse_args()
+
+    summary_path = args.summary_json if args.summary_json.is_absolute() else ROOT / args.summary_json
+    artifact_index_path = args.artifact_index if args.artifact_index.is_absolute() else ROOT / args.artifact_index
+    output_path = args.output if args.output.is_absolute() else ROOT / args.output
+
+    write_json(output_path, build_report())
+    update_artifact_index(artifact_index_path, "sourceos_state_integrity_report", output_path)
+    update_summary(summary_path, output_path)
+
+    if args.summary:
+        print(f"SourceOS state integrity report: {rel(output_path)}")
+        print(f"FogStack full summary updated: {rel(summary_path)}")
+        print(f"Artifact index updated: {rel(artifact_index_path)}")
+    else:
+        print(json.dumps({"status": "passed", "report": rel(output_path)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds SourceOS-Linux/sourceos-syncd state-integrity report as digest-indexed evidence for the full FogStack local demo. Integrates with the Makefile `fogstack-local-demo-full` target and updates the full summary JSON and artifact index. Includes focused post-processor test.