### PR TITLE
fogstack: add non-authorizing approval intent record

### DIFF
--- a/.github/workflows/fogstack-approval-intent.yml
+++ b/.github/workflows/fogstack-approval-intent.yml
@@ -1,0 +1,41 @@
+name: FogStack Approval Intent
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "schemas/runtime/fogstack-approval-intent-record-v0.1.schema.json"
+      - "tools/emit_fogstack_approval_intent_record.py"
+      - "tools/tests/test_fogstack_approval_intent_record.py"
+      - ".github/workflows/fogstack-approval-intent.yml"
+  push:
+    branches: [main]
+    paths:
+      - "schemas/runtime/fogstack-approval-intent-record-v0.1.schema.json"
+      - "tools/emit_fogstack_approval_intent_record.py"
+      - "tools/tests/test_fogstack_approval_intent_record.py"
+      - ".github/workflows/fogstack-approval-intent.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  approval-intent:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest jsonschema
+
+      - name: Run focused tests
+        run: |
+          python -m pytest -q tools/tests/test_fogstack_approval_intent_record.py

--- a/schemas/runtime/fogstack-approval-intent-record-v0.1.schema.json
+++ b/schemas/runtime/fogstack-approval-intent-record-v0.1.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.com/schemas/runtime/fogstack-approval-intent-record-v0.1.schema.json",
+  "title": "FogStackApprovalIntentRecord",
+  "type": "object",
+  "required": ["kind", "schema_version", "status", "mode", "safety"],
+  "properties": {
+    "kind": { "const": "FogStackApprovalIntentRecord" },
+    "schema_version": { "const": "v0.1" },
+    "status": { "const": "recorded" },
+    "mode": { "const": "intent-only" },
+    "safety": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/tools/emit_fogstack_approval_intent_record.py
+++ b/tools/emit_fogstack_approval_intent_record.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def resolve(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"ERR: expected JSON object in {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def source_artifact(path: Path, artifact_id: str) -> dict[str, str]:
+    path = resolve(path)
+    if not path.exists() or not path.is_file():
+        raise SystemExit(f"ERR: required source artifact missing: {path}")
+    return {"id": artifact_id, "ref": rel(path), "digest": sha256_file(path)}
+
+
+def plan_is_safe(plan: dict[str, Any]) -> bool:
+    safety = plan.get("safety") if isinstance(plan.get("safety"), dict) else {}
+    return (
+        plan.get("kind") == "FogStackLiveApplyPlanRecord"
+        and plan.get("mode") == "plan-only"
+        and plan.get("status") in {"passed", "blocked"}
+        and safety.get("run_performed") is False
+        and safety.get("mutated_cluster") is False
+        and safety.get("live_apply_allowed") is False
+    )
+
+
+def emit_record(
+    *,
+    apply_plan_path: Path,
+    output_path: Path,
+    requester: str,
+    reason: str,
+    approval_window: str,
+) -> dict[str, Any]:
+    apply_plan_path = resolve(apply_plan_path)
+    output_path = resolve(output_path)
+    plan = load_json(apply_plan_path)
+    if not plan_is_safe(plan):
+        raise SystemExit("ERR: apply plan is unsafe for approval intent")
+
+    record = {
+        "kind": "FogStackApprovalIntentRecord",
+        "schema_version": "v0.1",
+        "status": "recorded",
+        "mode": "intent-only",
+        "bundle_id": plan.get("bundle_id"),
+        "version": plan.get("version"),
+        "namespace": plan.get("namespace"),
+        "target": plan.get("target"),
+        "requester": requester,
+        "reason": reason,
+        "approval_window": approval_window,
+        "apply_plan_ref": rel(apply_plan_path),
+        "apply_plan_digest": sha256_file(apply_plan_path),
+        "source_artifacts": [source_artifact(apply_plan_path, "live-apply-plan-record")],
+        "safety": {
+            "intent_only": True,
+            "authorizes_execution": False,
+            "run_performed": False,
+            "mutated_cluster": False,
+            "live_apply_allowed": False,
+            "requires_policyplane_execute_decision": True,
+            "requires_agentplane_execution_run": True,
+            "requires_rollback_plan": True,
+            "requires_external_identity_binding": True,
+        },
+    }
+    write_json(output_path, record)
+    return record
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit a non-authorizing FogStack approval intent record")
+    parser.add_argument("--apply-plan", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--requester", default="human:operator")
+    parser.add_argument("--reason", default="Operator requests a future execution review; this record does not authorize execution.")
+    parser.add_argument("--approval-window", default="future-explicit-window-required")
+    args = parser.parse_args()
+
+    record = emit_record(
+        apply_plan_path=args.apply_plan,
+        output_path=args.output,
+        requester=args.requester,
+        reason=args.reason,
+        approval_window=args.approval_window,
+    )
+    print(json.dumps(record, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_fogstack_approval_intent_record.py
+++ b/tools/tests/test_fogstack_approval_intent_record.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import jsonschema
+
+
+SCHEMA = Path("schemas/runtime/fogstack-approval-intent-record-v0.1.schema.json")
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def read_json(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def validate_record(record: dict) -> None:
+    jsonschema.validate(record, read_json(SCHEMA))
+
+
+def apply_plan(path: Path, *, safe: bool) -> None:
+    write_json(path, {
+        "kind": "FogStackLiveApplyPlanRecord",
+        "schema_version": "v0.1",
+        "status": "blocked",
+        "mode": "plan-only",
+        "bundle_id": "fogstack.access",
+        "version": "0.1.0",
+        "namespace": "fogstack-access",
+        "target": "kubernetes",
+        "safety": {
+            "plan_only": True,
+            "run_performed": False,
+            "mutated_cluster": False,
+            "live_apply_allowed": not safe,
+            "future_approval_record_required": True,
+            "rollback_plan_required": True,
+        },
+    })
+
+
+def run_intent(tmp_path: Path, *, safe: bool) -> subprocess.CompletedProcess[str]:
+    plan_path = tmp_path / "apply-plan.json"
+    output = tmp_path / "approval-intent.json"
+    apply_plan(plan_path, safe=safe)
+    return subprocess.run([
+        sys.executable,
+        "tools/emit_fogstack_approval_intent_record.py",
+        "--apply-plan", str(plan_path),
+        "--output", str(output),
+        "--requester", "human:test-operator",
+        "--reason", "Test intent record only.",
+        "--approval-window", "test-window-required",
+    ], capture_output=True, text=True)
+
+
+def test_approval_intent_record_from_safe_plan(tmp_path: Path) -> None:
+    proc = run_intent(tmp_path, safe=True)
+    assert proc.returncode == 0, proc.stderr
+    record = read_json(tmp_path / "approval-intent.json")
+    validate_record(record)
+    assert record["kind"] == "FogStackApprovalIntentRecord"
+    assert record["status"] == "recorded"
+    assert record["mode"] == "intent-only"
+    assert record["requester"] == "human:test-operator"
+    assert record["bundle_id"] == "fogstack.access"
+    assert record["safety"]["intent_only"] is True
+    assert record["safety"]["authorizes_execution"] is False
+    assert record["safety"]["run_performed"] is False
+    assert record["safety"]["mutated_cluster"] is False
+    assert record["safety"]["live_apply_allowed"] is False
+    assert record["safety"]["requires_policyplane_execute_decision"] is True
+    assert record["safety"]["requires_agentplane_execution_run"] is True
+    assert record["safety"]["requires_rollback_plan"] is True
+    assert record["safety"]["requires_external_identity_binding"] is True
+    assert record["source_artifacts"][0]["id"] == "live-apply-plan-record"
+    assert record["source_artifacts"][0]["digest"].startswith("sha256:")
+
+
+def test_approval_intent_rejects_unsafe_plan(tmp_path: Path) -> None:
+    proc = run_intent(tmp_path, safe=False)
+    assert proc.returncode == 1
+    assert "unsafe for approval intent" in proc.stderr
+    assert not (tmp_path / "approval-intent.json").exists()


### PR DESCRIPTION
Deployment parity tranche C / approval intent v0.1.

This adds a non-authorizing `FogStackApprovalIntentRecord` surface before any execution path exists.

Changes:
- add `tools/emit_fogstack_approval_intent_record.py`
- add minimal `schemas/runtime/fogstack-approval-intent-record-v0.1.schema.json`
- add behavior-heavy tests in `tools/tests/test_fogstack_approval_intent_record.py`
- add focused workflow `.github/workflows/fogstack-approval-intent.yml`

Safety boundary:
- intent-only evidence
- does not authorize execution
- no live apply execution
- no kubectl execution
- no GitOps sync execution
- run_performed=false
- mutated_cluster=false
- live_apply_allowed=false
- requires future PolicyPlane execute decision
- requires future AgentPlane execution run
- requires rollback plan
- requires external identity binding

Behavior:
- emits approval intent from a safe plan-only `FogStackLiveApplyPlanRecord`
- rejects unsafe apply-plan records

Note: main advanced by one unrelated commit after branch creation. This PR adds new files only; use premerge-audit as freshness guard.