### PR TITLE
specs: add broker evidence profile validation

### DIFF
--- a/.github/workflows/provider-binding-evidence.yml
+++ b/.github/workflows/provider-binding-evidence.yml
@@ -1,0 +1,29 @@
+name: provider-binding-evidence
+
+on:
+  pull_request:
+    paths:
+      - "specs/brokerage/**"
+      - "docs/reference/next-gen-tom/**"
+      - "tools/validate_provider_binding_evidence_profile.py"
+      - ".github/workflows/provider-binding-evidence.yml"
+  push:
+    branches: [main]
+    paths:
+      - "specs/brokerage/**"
+      - "docs/reference/next-gen-tom/**"
+      - "tools/validate_provider_binding_evidence_profile.py"
+      - ".github/workflows/provider-binding-evidence.yml"
+
+jobs:
+  validate-provider-binding-evidence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install jsonschema
+        run: python -m pip install jsonschema
+      - name: Validate evidence profile
+        run: python tools/validate_provider_binding_evidence_profile.py

--- a/docs/reference/next-gen-tom/provider-binding-evidence-refs.md
+++ b/docs/reference/next-gen-tom/provider-binding-evidence-refs.md
@@ -1,0 +1,77 @@
+# ProviderBinding Evidence Profile and Evidence Surfaces
+
+## Purpose
+
+This document maps `ProviderBinding.evidence_profile_id` and related profile references to existing platform evidence surfaces.
+
+ProviderBinding declares which evidence profile applies. It does **not** itself store all evidence artifacts. Evidence is produced and stored by runtime lanes such as FogStack, PolicyPlane decision records, and AgentPlane execution bundles. The broker uses those upstream records to satisfy the evidence profile and justify approval.
+
+## ProviderBinding fields that matter
+
+The ProviderBinding contract includes profile references that drive broker approval and portability posture:
+
+- `evidence_profile_id`: selects the evidence profile that defines required evidence kinds for the binding.
+- `cost_meter_profile_id`: selects the cost metering profile.
+- `continuity_profile_id`: selects the continuity profile.
+- `exit_plan_ref`: points to the exit plan artifact.
+
+See `specs/brokerage/schemas/provider-binding.schema.json` for the authoritative field list.
+
+## Evidence profiles
+
+Evidence profiles are machine-readable requirements for a binding.
+
+- Schema: `specs/brokerage/schemas/provider-binding-evidence-profile.schema.json`
+- Example: `specs/brokerage/events/examples/provider-binding-evidence-profile.example.json`
+
+An evidence profile specifies the required evidence kinds for a given `(service_class, provider_class)` pairing and the minimum portability tier it can justify.
+
+## Evidence surfaces by lane
+
+The broker should satisfy evidence profiles using existing upstream artifacts.
+
+| Lane | Existing artifact | Path | How it satisfies evidence profiles |
+|---|---|---|---|
+| FogStack live preflight | `FogStackLiveClusterPreflightRecord` | `schemas/runtime/fogstack-live-cluster-preflight-record-v0.1.schema.json` | proves read-only safety posture on real clusters: no mutation, no live apply, human approval required |
+| FogStack runtime dry run | `FogStackRuntimeDryRunRecord` | `schemas/runtime/fogstack-runtime-dry-run-record-v0.1.schema.json` | proves AgentPlane linkage, PolicyPlane linkage, dry-run execution posture, and runtime policy context |
+| PolicyPlane broker decision | `BrokerPolicyDecision` | `policy-fabric/contracts/schemas/broker-policy-decision.schema.json` | proves allow/deny/exception/review posture and carries `required_evidence_refs` |
+| AgentPlane broker execution | `BrokerExecutionBundle` | `agentplane/schemas/broker-execution-bundle.schema.v0.1.json` | proves validation/smoke/replay bundle shape and carries `evidenceRefs` |
+| Identity subject | `IdentitySubjectContext` | `contracts/identity/IdentitySubjectContext.v0.1.json` | proves subject class, tenant context, assurance posture, and policy linkage |
+| Identity session | `IdentitySessionContext` | `contracts/identity/IdentitySessionContext.v0.1.json` | proves session-bound context and step-up/risk state when required |
+| Identity proof ingress | `IdentityProofIngressRecord` | `contracts/identity/IdentityProofIngressRecord.v0.1.json` | proves accepted, rejected, or inconclusive proof ingress and evidence linkage |
+| Office runtime | `office_*` records | `schemas/office/*.schema.json` | proves document, writeback, side-effect policy, or adapter posture when the service class is office/document mediated |
+
+## Where evidence references live
+
+Evidence references should live in the evidence-producing artifacts:
+
+- `BrokerPolicyDecision.required_evidence_refs` in PolicyPlane.
+- `BrokerExecutionBundle.evidenceRefs` in AgentPlane.
+- FogStack artifact refs and digests in runtime readiness and dry-run records.
+
+When the broker needs a normalized view, it should wrap those references into an EvidencePack or ProviderBindingApprovalRecord rather than duplicating FogStack, AgentPlane, or PolicyPlane content.
+
+## Recommended evidence ref pattern
+
+When a normalized EvidencePack is introduced, use stable refs with explicit kind prefixes. Examples:
+
+```text
+fogstack-live-preflight://fogstack.access.live-cluster-preflight.record.json
+fogstack-runtime-dry-run://fogstack.access.runtime-dry-run.record.json
+policy-decision://broker/decision-standard-app-env-001
+agentplane-bundle://bundle-provider-binding-smoke-001
+identity-subject://subject/demo-operator
+identity-session://session/demo-session
+identity-proof://proof/demo-proof
+```
+
+## Approval rule
+
+A ProviderBinding can move to `Approved` only when:
+
+1. its `evidence_profile_id` requirements are satisfied by upstream evidence artifacts, or
+2. an explicit exception record exists with owner, rationale, compensating controls, expiry, and review date.
+
+## Runtime posture
+
+The broker must reference current runtime evidence instead of creating parallel broker evidence records. New broker evidence objects should be introduced only when the evidence alignment map identifies a real gap.

--- a/specs/brokerage/events/examples/provider-binding-evidence-profile.example.json
+++ b/specs/brokerage/events/examples/provider-binding-evidence-profile.example.json
@@ -1,0 +1,19 @@
+{
+  "profile_id": "evidence-profile.environment.public-cloud.v1",
+  "service_class": "environment",
+  "provider_class": "public-cloud",
+  "required_evidence_kinds": [
+    "policy_decision",
+    "agentplane_execution",
+    "runtime_dry_run",
+    "live_preflight",
+    "identity_subject"
+  ],
+  "conditional_evidence_kinds": [
+    "cost_meter",
+    "exit_plan"
+  ],
+  "minimum_portability_tier": "P2-blueprint-portable",
+  "approval_rule": "Approval requires policy decision, broker execution evidence, dry-run evidence, live preflight safety evidence, and identity subject context unless an explicit exception exists.",
+  "owner": "platform-brokerage"
+}

--- a/specs/brokerage/schemas/provider-binding-evidence-profile.schema.json
+++ b/specs/brokerage/schemas/provider-binding-evidence-profile.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ProviderBindingEvidenceProfile",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "profile_id": { "type": "string", "minLength": 1 },
+    "service_class": { "type": "string", "minLength": 1 },
+    "provider_class": { "type": "string", "minLength": 1 },
+    "required_evidence_kinds": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "policy_decision",
+          "agentplane_execution",
+          "runtime_dry_run",
+          "live_preflight",
+          "identity_subject",
+          "identity_session",
+          "identity_proof",
+          "office_version",
+          "office_writeback",
+          "office_policy_decision",
+          "office_adapter_profile",
+          "cost_meter",
+          "exit_plan"
+        ]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "conditional_evidence_kinds": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    },
+    "minimum_portability_tier": {
+      "type": "string",
+      "enum": ["P0-governed-native", "P1-contract-compatible", "P2-blueprint-portable", "P3-operationally-portable", "P4-exit-tested"]
+    },
+    "approval_rule": { "type": "string", "minLength": 1 },
+    "owner": { "type": "string", "minLength": 1 }
+  },
+  "required": ["profile_id", "service_class", "provider_class", "required_evidence_kinds", "minimum_portability_tier", "approval_rule", "owner"]
+}

--- a/tools/validate_provider_binding_evidence_profile.py
+++ b/tools/validate_provider_binding_evidence_profile.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Validate ProviderBinding evidence profile examples against schema."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "specs" / "brokerage" / "schemas" / "provider-binding-evidence-profile.schema.json"
+EXAMPLE_PATH = ROOT / "specs" / "brokerage" / "events" / "examples" / "provider-binding-evidence-profile.example.json"
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> int:
+    missing = [str(path) for path in (SCHEMA_PATH, EXAMPLE_PATH) if not path.exists()]
+    if missing:
+        print("Missing ProviderBinding evidence profile validation inputs:")
+        for item in missing:
+            print(f" - {item}")
+        return 1
+
+    schema = load_json(SCHEMA_PATH)
+    example = load_json(EXAMPLE_PATH)
+
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(example), key=lambda error: list(error.path))
+
+    if errors:
+        print("ProviderBinding evidence profile example failed schema validation:")
+        for error in errors:
+            location = ".".join(str(part) for part in error.path) or "<root>"
+            print(f" - {location}: {error.message}")
+        return 1
+
+    print("ProviderBinding evidence profile example validates against schema.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Superseded by merged replacement #537.

Content was not discarded. The following stale/non-mergeable #460 content was replayed onto current main and merged in #537 at 578b25c56f4e110ae656c1c08185b5a1dc18bcea:

- `.github/workflows/provider-binding-evidence.yml`
- `docs/reference/next-gen-tom/provider-binding-evidence-refs.md`
- `specs/brokerage/events/examples/provider-binding-evidence-profile.example.json`
- `specs/brokerage/schemas/provider-binding-evidence-profile.schema.json`
- `tools/validate_provider_binding_evidence_profile.py`

The replacement also includes the workflow-permissions hardening fix:

```yaml
permissions:
  contents: read
```

Closing this stale PR only after verified capture and merge.