### PR TITLE
Pin Forensic Genesis edge standards in standards lock

### DIFF
--- a/standards.lock.yaml
+++ b/standards.lock.yaml
@@ -169,6 +169,24 @@ spec:
           traceIsEvidenceNotAuthority: true
           runtimeConformanceRequired: true
 
+      forensic-genesis-edge:
+        repo: SocioProphet/prophet-platform-standards
+        class: runtime-profile
+        channel: controlled
+        pin:
+          commit: b80737bafca6e399adf7eb8bf81aea3db61c8fa6
+          tag: null
+        consume:
+          docs:
+            - docs/FORENSIC_GENESIS_EDGE.md
+          generated_artifacts:
+            - contracts/forensic-genesis/
+            - docs/LOCAL-FORENSIC-GENESIS-EDGE.md
+            - infra/local/docker-compose.forensic-genesis-edge.yml
+        rules:
+          runtimeConformanceRequiredForForensicGenesisEdge: true
+          standardsRepoRemainsNormative: true
+
     reference_inputs:
       identity-prime-reference:
         repo: SocioProphet/identity-is-prime-reference


### PR DESCRIPTION
## Summary
This PR adds the Forensic Genesis edge standards source to `standards.lock.yaml`.

## Changes
- Adds `forensic-genesis-edge` under `spec.imports.normative_standards`.
- Pins the source to `SocioProphet/prophet-platform-standards` commit `b80737bafca6e399adf7eb8bf81aea3db61c8fa6`.
- Records the runtime-generated artifacts consumed by `prophet-platform`:
  - `contracts/forensic-genesis/`
  - `docs/LOCAL-FORENSIC-GENESIS-EDGE.md`
  - `infra/local/docker-compose.forensic-genesis-edge.yml`

## Context
The standards surface and additive runtime lane are already live. This PR only makes the default standards lock explicitly aware of the edge lane.

## Scope
One-file PR: `standards.lock.yaml` only.

## Notes
This supersedes earlier stale lock-only PR attempts and is rebuilt from the exact current `main` lock body.