### PR TITLE
Add Trust-First proof artifact contract v0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ It is intentionally a **thin platform monorepo**:
 - `infra/` contains deployment wiring (Kustomize, Argo CD appsets, namespaces, etc.)
 - `tools/` contains validation and smoke-test helpers (`standards.lock.yaml` gates platform drift checks)
 - `libs/` contains small shared runtime bindings that adapt pinned upstream standards into platform code
+- `schemas/` contains runtime-facing schema contracts, including Trust-First Event-IR and proof-artifact schemas
+- `examples/` contains canonical proof-artifact fixture examples
 
 ## Why this repo exists
 
@@ -27,8 +29,24 @@ make smoke-health
 2. `docs/TRITRPC_SPEC.md`
 3. `docs/TRITRPC_PLATFORM_BINDING.md`
 4. `docs/PLATFORM_EVAL_FABRIC.md`
-5. `contracts/`
-6. `infra/k8s/`
+5. `docs/trust-first-proof-artifacts.md`
+6. `docs/checker-contract.md`
+7. `contracts/`
+8. `infra/k8s/`
+
+## Trust-First proof artifact lane
+
+The platform now carries a runtime contract for replayable evidence artifacts:
+
+- `schemas/event-ir.schema.json` — typed Event-IR vocabulary for observed platform, runtime, and security events.
+- `schemas/proof-artifact.schema.json` — proof artifact contract for `PROVED`, `VIOLATION`, and `INCONCLUSIVE` claim results.
+- `docs/trust-first-proof-artifacts.md` — semantics for proof artifacts over observed event windows and explicit assumptions.
+- `docs/checker-contract.md` — deterministic checker behavior and policy handoff rules.
+- `examples/kms-key-usage-proved.json` — canonical successful fixture artifact.
+- `examples/kms-key-usage-violation.json` — canonical counterexample fixture artifact.
+- `examples/kms-key-usage-inconclusive.json` — canonical missing-evidence fixture artifact.
+
+This lane is the platform runtime counterpart to the typed boundary standard in `SocioProphet/prophet-platform-standards` and the Boundary Atlas in `SocioProphet/sociosphere`.
 
 ## Evaluation fabric lane
 

--- a/docs/checker-contract.md
+++ b/docs/checker-contract.md
@@ -1,0 +1,151 @@
+# Proof Artifact Checker Contract v0.1
+
+Status: runtime verifier draft.
+
+The checker is the small trusted verifier for Trust-First proof artifacts. The certifier may be expensive and complex. The checker must be deterministic, auditable, and conservative.
+
+## Inputs
+
+- Proof artifact conforming to `schemas/proof-artifact.schema.json`
+- Event-IR window conforming to `schemas/event-ir.schema.json`
+- Policy bundle identified by artifact `policy_bundle.hash`
+- Canonicalization rules for event window and config
+- Approved checker configuration
+
+## Required checker behavior
+
+### 1. Schema validation
+
+The checker validates:
+
+- artifact schema version is allowlisted;
+- artifact required fields are present;
+- Event-IR events validate against the approved Event-IR schema;
+- unknown schema versions are rejected.
+
+### 2. Policy bundle validation
+
+The checker validates:
+
+- `policy_bundle.hash` matches the supplied policy bundle;
+- `policy_bundle.sig` is valid when signature enforcement is enabled;
+- `compiler_id` is allowlisted for the claim kind.
+
+### 3. Input hash validation
+
+The checker recomputes:
+
+```text
+inputs_hash = sha256(canonical_events || canonical_config)
+```
+
+If the recomputed hash differs from the artifact `inputs_hash`, the artifact is rejected.
+
+### 4. Coverage gate
+
+The checker evaluates claim-kind coverage requirements. For `kms_key_usage`, `PROVED` requires at minimum:
+
+- `Policy.Pin`
+- `Identity.Attest`
+- `Token.Consume`
+- `KMS.Decrypt`
+- `Data.Write`
+- `Net.Send`
+
+If a required family is missing, `PROVED` is invalid and the result must be rejected or downgraded to `INCONCLUSIVE` by the caller.
+
+### 5. Verdict-specific checks
+
+#### PROVED
+
+The checker must validate at least one of:
+
+- an explicit invariant proof object; or
+- deterministic replay output that reproduces `PROVED` under pinned domains and budgets.
+
+The checker must reject `PROVED` when:
+
+- required coverage is absent;
+- event integrity is weaker than the allowed profile;
+- scope integrity is weaker than the allowed profile;
+- budgets were exhausted;
+- precision metadata indicates cutoff or unsound approximation;
+- input hash mismatch occurs.
+
+#### VIOLATION
+
+The checker validates that the witness/counterexample slice:
+
+- references event IDs present in the Event-IR window;
+- is consistent with event ordering and scope assumptions;
+- reaches or demonstrates the forbidden state or transition claimed.
+
+#### INCONCLUSIVE
+
+The checker validates that uncertainty is explicit:
+
+- missing evidence;
+- weak integrity;
+- weak scope binding;
+- budget exhaustion;
+- precision loss;
+- unknown clock/order model.
+
+`INCONCLUSIVE` is a valid artifact result. It is not proof of safety.
+
+## Canonicalization guidance
+
+Canonicalization must be deterministic:
+
+- JSON keys sorted;
+- stable event ordering by event ID or declared log order;
+- no implicit defaults not recorded in the artifact;
+- exact config included in hash calculation;
+- schema and compiler versions pinned.
+
+## Minimal pseudocode
+
+```python
+def check(artifact, events, policy_bundle, config):
+    assert schema_ok(artifact)
+    assert all(event_schema_ok(e) for e in events)
+    assert artifact.schema_version in allowlisted_schema_versions
+    assert verify_policy_bundle(policy_bundle, artifact.policy_bundle)
+    assert artifact.compiler_id in allowlisted_compilers[artifact.claim.kind]
+    assert recompute_inputs_hash(events, config) == artifact.inputs_hash
+    assert coverage_ok_or_not_proved(artifact, events)
+
+    if artifact.result == "PROVED":
+        assert assumptions_allow_proved(artifact.assumptions)
+        assert not budgets_exhausted(artifact)
+        assert proved_payload_ok(artifact, events, policy_bundle)
+    elif artifact.result == "VIOLATION":
+        assert witness_consistent(artifact.witness_or_counterexample, events)
+        assert witness_violates_claim(artifact.claim, artifact.witness_or_counterexample)
+    elif artifact.result == "INCONCLUSIVE":
+        assert uncertainty_declared(artifact)
+    else:
+        raise ValueError("unknown result")
+
+    return True
+```
+
+## Policy handoff
+
+The checker returns a validation result. Policy Fabric decides whether the checked artifact permits a boundary crossing or claim-mode promotion.
+
+Recommended policy defaults:
+
+- `PROVED` + approved assumptions may permit promotion to the artifact's supported claim mode.
+- `VIOLATION` blocks promotion and routes counterexample metadata.
+- `INCONCLUSIVE` blocks promotion and creates an evidence-gap backlog item.
+
+## Non-goals
+
+The checker does not:
+
+- decide all security properties exactly;
+- prove claims outside the observed window and assumptions;
+- replace runtime hardening;
+- treat logs or dashboards as proof by themselves;
+- silently repair missing evidence.

--- a/docs/trust-first-proof-artifacts.md
+++ b/docs/trust-first-proof-artifacts.md
@@ -1,0 +1,136 @@
+# Trust-First Proof Artifacts v0.1
+
+Status: runtime contract draft.
+
+Trust-First proof artifacts are replayable evidence packs for claims over observed Event-IR windows under explicit assumptions. They are not dashboards, alerts, or narrative security claims.
+
+## Core semantics
+
+A proof artifact evaluates a claim over an observed event window. It separates the world from what was observed.
+
+Let `L` be the normalized Event-IR stream and `A` be the declared assumptions: coverage, event integrity, scope integrity, clock model, policy bundle, and checker/compiler versions.
+
+A `PROVED` result means:
+
+```text
+For all traces consistent with L and A, the claim invariant holds.
+```
+
+A `VIOLATION` result means the artifact contains a witness or counterexample slice demonstrating a forbidden state or transition.
+
+An `INCONCLUSIVE` result means the system does not know: evidence is missing, assumptions are too weak, precision is insufficient, or budgets prevented certification.
+
+## Artifact contract
+
+Schema: `schemas/proof-artifact.schema.json`
+
+Required fields:
+
+- `schema_version`
+- `artifact_id`
+- `claim.kind` and `claim.params`
+- `assumptions.coverage`
+- `assumptions.event_integrity`
+- `assumptions.scope_integrity`
+- `assumptions.clock_model`
+- `assumptions.missing_evidence`
+- `policy_bundle.hash` and `policy_bundle.sig`
+- `compiler_id`
+- `domains`
+- `budgets`
+- `inputs_hash`
+- `result`
+- `precision`
+
+Optional but expected fields:
+
+- `producer_boundary`
+- `widen_schedule`
+- `invariant`
+- `witness_or_counterexample`
+- `telemetry`
+- `signature`
+
+## Event-IR contract
+
+Schema: `schemas/event-ir.schema.json`
+
+Each event is typed and scoped. If an event cannot be typed, scoped, or authenticated, it cannot justify a `PROVED` artifact.
+
+Core fields:
+
+- `id`
+- `kind`
+- `ts`
+- `actor`
+- `scope`
+- `target`
+- `attrs`
+- `auth`
+
+## Claim kinds
+
+Initial claim kinds:
+
+- `boundary_non_escape`
+- `ifc_no_flow`
+- `capability_confinement`
+- `usage_budget`
+- `kms_key_usage`
+
+## Coverage contracts
+
+The checker must enforce minimum coverage by claim kind. For `kms_key_usage`, required event families include:
+
+- `Policy.Pin`
+- `KMS.Decrypt`
+- `Token.Consume`
+- `Data.Write`
+- `Net.Send`
+- `Identity.Attest`
+
+Missing required evidence blocks `PROVED` and should produce or preserve `INCONCLUSIVE`.
+
+## Trust roots
+
+Trust roots are part of the artifact, not an external story.
+
+- Event authenticity: events are attributable to a signed or attested source.
+- Scope authenticity: scopes are attested or supplied by a trusted boundary oracle.
+- Policy authenticity: policy bundle is hash-pinned and signed.
+- Clock model: event order and skew are explicitly declared.
+- Checker identity: checker version and behavior are pinned.
+
+## Domains and budgets
+
+The artifact records abstract domains and budgets so precision and cost are visible.
+
+Supported domain labels in v0.1:
+
+- `intervals`
+- `signs`
+- `octagon`
+- `polyhedra`
+- `nnc_polyhedra`
+- `congruence`
+- `sharing`
+- `labels`
+- `capabilities`
+
+Budgets:
+
+- `max_iters`
+- `max_time_ms`
+- `max_branches`
+
+Budget exhaustion must not be disguised as proof.
+
+## Relationship to boundaries
+
+Proof artifacts are boundary surfaces. Their sufficiency is scoped:
+
+- A proof artifact may be `audit_sufficient` for a declared claim.
+- It is not automatically `microstate_sufficient`.
+- It does not prove safety outside its observation window and assumptions.
+
+Sociosphere records artifact availability in the Boundary Atlas. Policy Fabric decides whether a proof artifact is admissible for claim-mode promotion.

--- a/examples/kms-key-usage-inconclusive.json
+++ b/examples/kms-key-usage-inconclusive.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": "0.1",
+  "artifact_id": "kms-key-usage-inconclusive-demo",
+  "producer_boundary": "SocioProphet/prophet-platform",
+  "claim": {
+    "kind": "kms_key_usage",
+    "params": {
+      "key_id": "K-demo-001",
+      "allowed_actors": ["svc:payments"],
+      "allowed_scopes": ["PROC(payments)"],
+      "epoch_window": {
+        "start_ns": 0,
+        "end_ns": 3600000000000
+      },
+      "decrypt_budget_B": 2,
+      "allowed_sinks": [
+        {"sink": "payments_db", "label": "HIGH"}
+      ],
+      "forbidden_sinks": [
+        {"sink": "internet", "label": "LOW_NET"},
+        {"sink": "low_db", "label": "LOW"}
+      ],
+      "requires_token_kind": "KMS_DECRYPT_BUDGET"
+    }
+  },
+  "assumptions": {
+    "coverage": [
+      "Policy.Pin",
+      "Identity.Attest",
+      "KMS.Decrypt",
+      "Data.Write",
+      "Net.Send"
+    ],
+    "event_integrity": "signed_append_only",
+    "scope_integrity": "attested_scope",
+    "clock_model": "mono_ns_no_reorder",
+    "missing_evidence": ["Token.Consume"]
+  },
+  "policy_bundle": {
+    "hash": "sha256:9f3d2a1c0b1a4f5e6d7c8b9a0f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6",
+    "sig": "sig:demo-policy-bundle"
+  },
+  "compiler_id": "tfcc-0.4.0",
+  "domains": ["intervals", "octagon", "congruence", "sharing"],
+  "budgets": {
+    "max_iters": 60,
+    "max_time_ms": 800,
+    "max_branches": 16
+  },
+  "widen_schedule": {
+    "base": 2.718281828459045,
+    "checkpoints": [1, 3, 8, 21, 55, 149, 404]
+  },
+  "inputs_hash": "sha256:c606e5b56f6a69171775c85e1e14dc73ec982368791bb30f83c56a9901493c9a",
+  "result": "INCONCLUSIVE",
+  "witness_or_counterexample": {
+    "kind": "assumption_gap",
+    "missing_event_families": ["Token.Consume"],
+    "explanation": "Cannot certify budget safety because token-consumption evidence is absent from the observed Event-IR window."
+  },
+  "precision": {
+    "mode": "Approx",
+    "delta": 0.12
+  },
+  "telemetry": {
+    "mode": "fixture",
+    "widen_count": 0,
+    "budget_exhausted": false
+  },
+  "signature": "sig:none",
+  "notes": "Illustrative fixture artifact showing honest uncertainty from a missing evidence family."
+}

--- a/examples/kms-key-usage-proved.json
+++ b/examples/kms-key-usage-proved.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "0.1",
+  "artifact_id": "kms-key-usage-proved-demo",
+  "producer_boundary": "SocioProphet/prophet-platform",
+  "claim": {
+    "kind": "kms_key_usage",
+    "params": {
+      "key_id": "K-demo-001",
+      "allowed_actors": ["svc:payments"],
+      "allowed_scopes": ["PROC(payments)"],
+      "epoch_window": {
+        "start_ns": 0,
+        "end_ns": 3600000000000
+      },
+      "decrypt_budget_B": 2,
+      "allowed_sinks": [
+        {"sink": "payments_db", "label": "HIGH"}
+      ],
+      "forbidden_sinks": [
+        {"sink": "internet", "label": "LOW_NET"},
+        {"sink": "low_db", "label": "LOW"}
+      ],
+      "requires_token_kind": "KMS_DECRYPT_BUDGET"
+    }
+  },
+  "assumptions": {
+    "coverage": [
+      "Policy.Pin",
+      "Identity.Attest",
+      "Token.Consume",
+      "KMS.Decrypt",
+      "Data.Write",
+      "Net.Send"
+    ],
+    "event_integrity": "signed_append_only",
+    "scope_integrity": "attested_scope",
+    "clock_model": "mono_ns_no_reorder",
+    "missing_evidence": []
+  },
+  "policy_bundle": {
+    "hash": "sha256:9f3d2a1c0b1a4f5e6d7c8b9a0f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6",
+    "sig": "sig:demo-policy-bundle"
+  },
+  "compiler_id": "tfcc-0.4.0",
+  "domains": ["intervals", "octagon", "congruence", "sharing"],
+  "budgets": {
+    "max_iters": 60,
+    "max_time_ms": 800,
+    "max_branches": 16
+  },
+  "widen_schedule": {
+    "base": 2.718281828459045,
+    "checkpoints": [1, 3, 8, 21, 55, 149, 404]
+  },
+  "inputs_hash": "sha256:5edbe120df337e97e2f57dd9d3414a7d2b6d77af6ab7fe4b00ae42c2ac17e04a",
+  "result": "PROVED",
+  "invariant": {
+    "kind": "conjunctive",
+    "constraints": [
+      "Every successful KMS.Decrypt for K-demo-001 is performed by svc:payments in PROC(payments).",
+      "Every successful KMS.Decrypt has a matching Token.Consume of KMS_DECRYPT_BUDGET in the epoch window.",
+      "The successful decrypt count in the epoch is <= 2.",
+      "No plaintext handle produced by KMS.Decrypt(K-demo-001) is observed at forbidden sinks."
+    ],
+    "notes": "Fixture invariant for runtime contract demonstration only. A production checker must validate or replay the invariant."
+  },
+  "witness_or_counterexample": {},
+  "precision": {
+    "mode": "Approx",
+    "delta": 0.04
+  },
+  "telemetry": {
+    "mode": "fixture",
+    "widen_count": 0,
+    "budget_exhausted": false
+  },
+  "signature": "sig:none",
+  "notes": "Illustrative fixture artifact for the Trust-First proof-artifact contract."
+}

--- a/examples/kms-key-usage-violation.json
+++ b/examples/kms-key-usage-violation.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "0.1",
+  "artifact_id": "kms-key-usage-violation-demo",
+  "producer_boundary": "SocioProphet/prophet-platform",
+  "claim": {
+    "kind": "kms_key_usage",
+    "params": {
+      "key_id": "K-demo-001",
+      "allowed_actors": ["svc:payments"],
+      "allowed_scopes": ["PROC(payments)"],
+      "epoch_window": {
+        "start_ns": 0,
+        "end_ns": 3600000000000
+      },
+      "decrypt_budget_B": 2,
+      "allowed_sinks": [
+        {"sink": "payments_db", "label": "HIGH"}
+      ],
+      "forbidden_sinks": [
+        {"sink": "internet", "label": "LOW_NET"},
+        {"sink": "low_db", "label": "LOW"}
+      ],
+      "requires_token_kind": "KMS_DECRYPT_BUDGET"
+    }
+  },
+  "assumptions": {
+    "coverage": [
+      "Policy.Pin",
+      "Identity.Attest",
+      "Token.Consume",
+      "KMS.Decrypt",
+      "Data.Write",
+      "Net.Send"
+    ],
+    "event_integrity": "signed_append_only",
+    "scope_integrity": "attested_scope",
+    "clock_model": "mono_ns_no_reorder",
+    "missing_evidence": []
+  },
+  "policy_bundle": {
+    "hash": "sha256:9f3d2a1c0b1a4f5e6d7c8b9a0f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6",
+    "sig": "sig:demo-policy-bundle"
+  },
+  "compiler_id": "tfcc-0.4.0",
+  "domains": ["intervals", "octagon", "congruence", "sharing"],
+  "budgets": {
+    "max_iters": 60,
+    "max_time_ms": 800,
+    "max_branches": 16
+  },
+  "widen_schedule": {
+    "base": 2.718281828459045,
+    "checkpoints": [1, 3, 8, 21, 55, 149, 404]
+  },
+  "inputs_hash": "sha256:7eca9d0edceedc356fca641bd68f22e0ae966bc2babafaea4bb8e57524a998d0",
+  "result": "VIOLATION",
+  "witness_or_counterexample": {
+    "kind": "forbidden_sink_flow",
+    "violated_clause": "Flow confinement: plaintext derived from K-demo-001 must not reach internet.",
+    "slice_event_ids": ["e7", "e9"],
+    "taint_path": [
+      {
+        "handle": "pt2",
+        "introduced_at": "e7",
+        "event": "KMS.Decrypt"
+      },
+      {
+        "handle": "pt2",
+        "observed_at": "e9",
+        "event": "Net.Send",
+        "dst": "internet"
+      }
+    ],
+    "replay_window": {
+      "start_event": "e6",
+      "end_event": "e9"
+    }
+  },
+  "precision": {
+    "mode": "Exact",
+    "delta": 0.0
+  },
+  "telemetry": {
+    "mode": "fixture",
+    "widen_count": 0,
+    "budget_exhausted": false
+  },
+  "signature": "sig:none",
+  "notes": "Illustrative fixture artifact showing a forbidden plaintext flow witness."
+}

--- a/schemas/event-ir.schema.json
+++ b/schemas/event-ir.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/prophet-platform/event-ir.schema.json",
+  "title": "Trust-First Event-IR",
+  "description": "Typed event intermediate representation for proof-artifact claims over observed platform/security/runtime event windows.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "kind", "ts", "actor", "scope", "attrs", "auth"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^0\\.[0-9]+$"
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "Policy.Pin",
+        "Policy.Publish",
+        "Policy.Update",
+        "Policy.AllowBreakGlass",
+        "Identity.Attest",
+        "Workload.Identity",
+        "TLS.AttestPeer",
+        "Token.Issue",
+        "Token.Consume",
+        "KMS.Decrypt",
+        "KMS.GetKey",
+        "HSM.ImportKey",
+        "HSM.GenerateKey",
+        "HSM.Wrap",
+        "HSM.Unwrap",
+        "HSM.Sign",
+        "HSM.Decrypt",
+        "RPC.Send",
+        "RPC.Receive",
+        "Data.Read",
+        "Data.Write",
+        "Net.Send",
+        "Net.Recv",
+        "File.Read",
+        "File.Write",
+        "Mem.Copy",
+        "Scope.Enter",
+        "Scope.Exit",
+        "Namespace.Switch",
+        "Privilege.Change",
+        "Mount.Bind",
+        "Audit.Mark"
+      ]
+    },
+    "ts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["clock", "ns"],
+      "properties": {
+        "clock": {
+          "type": "string",
+          "enum": ["MONO", "WALL", "LOGICAL"]
+        },
+        "ns": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "skew_ns": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "actor": {
+      "type": "string",
+      "minLength": 1
+    },
+    "scope": {
+      "type": "string",
+      "minLength": 1,
+      "examples": ["PROC(payments)", "SERVICE(spiffe://svc/payments)", "CONTAINER(cid)", "HSM(hsm-7)", "TENANT(t1)"]
+    },
+    "target": {
+      "type": ["string", "null"]
+    },
+    "attrs": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "auth": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sig": { "type": ["string", "null"] },
+        "attestation": { "type": ["string", "null"] },
+        "source": { "type": ["string", "null"] },
+        "hash": { "type": ["string", "null"] }
+      }
+    },
+    "labels": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    }
+  }
+}

--- a/schemas/proof-artifact.schema.json
+++ b/schemas/proof-artifact.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.ai/prophet-platform/proof-artifact.schema.json",
+  "title": "Trust-First Proof Artifact",
+  "description": "Replayable evidence artifact for claims over Event-IR windows under explicit assumptions.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_id",
+    "claim",
+    "assumptions",
+    "policy_bundle",
+    "compiler_id",
+    "domains",
+    "budgets",
+    "inputs_hash",
+    "result",
+    "precision"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "pattern": "^0\\.[0-9]+$" },
+    "artifact_id": { "type": "string", "minLength": 4 },
+    "producer_boundary": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "params"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "boundary_non_escape",
+            "ifc_no_flow",
+            "capability_confinement",
+            "usage_budget",
+            "kms_key_usage"
+          ]
+        },
+        "params": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "assumptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["coverage", "event_integrity", "scope_integrity", "clock_model", "missing_evidence"],
+      "properties": {
+        "coverage": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
+        "event_integrity": { "type": "string", "enum": ["signed_append_only", "merkle_chain", "best_effort", "unknown"] },
+        "scope_integrity": { "type": "string", "enum": ["attested_scope", "trusted_oracle", "self_reported", "unknown"] },
+        "clock_model": { "type": "string" },
+        "missing_evidence": { "type": "array", "items": { "type": "string" }, "uniqueItems": true }
+      }
+    },
+    "policy_bundle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hash", "sig"],
+      "properties": {
+        "hash": { "type": "string" },
+        "sig": { "type": "string" },
+        "uri": { "type": "string" }
+      }
+    },
+    "compiler_id": { "type": "string" },
+    "domains": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["intervals", "signs", "octagon", "polyhedra", "nnc_polyhedra", "congruence", "sharing", "labels", "capabilities"]
+      },
+      "uniqueItems": true
+    },
+    "budgets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_iters", "max_time_ms", "max_branches"],
+      "properties": {
+        "max_iters": { "type": "integer", "minimum": 1 },
+        "max_time_ms": { "type": "integer", "minimum": 1 },
+        "max_branches": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "widen_schedule": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "base": { "type": "number", "exclusiveMinimum": 1 },
+        "checkpoints": { "type": "array", "items": { "type": "integer", "minimum": 1 } }
+      }
+    },
+    "inputs_hash": { "type": "string", "pattern": "^sha256:[A-Fa-f0-9]+$" },
+    "result": { "type": "string", "enum": ["PROVED", "VIOLATION", "INCONCLUSIVE"] },
+    "invariant": { "type": "object", "additionalProperties": true },
+    "witness_or_counterexample": { "type": "object", "additionalProperties": true },
+    "precision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode"],
+      "properties": {
+        "mode": { "type": "string", "enum": ["Exact", "Approx"] },
+        "delta": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "telemetry": { "type": "object", "additionalProperties": true },
+    "signature": { "type": "string" },
+    "notes": { "type": "string" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "result": { "const": "PROVED" } } },
+      "then": { "anyOf": [ { "required": ["invariant"] }, { "required": ["telemetry"] } ] }
+    },
+    {
+      "if": { "properties": { "result": { "const": "VIOLATION" } } },
+      "then": { "required": ["witness_or_counterexample"] }
+    },
+    {
+      "if": { "properties": { "result": { "const": "INCONCLUSIVE" } } },
+      "then": { "required": ["witness_or_counterexample"] }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds the platform runtime contract for Trust-First proof artifacts and typed Event-IR.

This PR makes `prophet-platform` the runtime verifier boundary for the first operational boundary spine:
- Event-IR schema for observed platform/security/runtime events;
- proof artifact schema for `PROVED`, `VIOLATION`, and `INCONCLUSIVE` results;
- checker contract defining deterministic validation behavior;
- canonical KMS key-usage fixture artifacts for proved, violation, and inconclusive states;
- README surface for the proof-artifact lane.

## Resolution

Closed as superseded/captured by clean replacement PR #554.

#554 preserved the intended additive contract content while avoiding stale README edits:

- `schemas/event-ir.schema.json`
- `schemas/proof-artifact.schema.json`
- `docs/trust-first-proof-artifacts.md`
- `docs/checker-contract.md`
- `examples/kms-key-usage-proved.json`
- `examples/kms-key-usage-violation.json`
- `examples/kms-key-usage-inconclusive.json`

## Deliberate deviation

The original stale branch modified `README.md`. The replacement intentionally omitted that high-churn edit. README surfacing can be added in a small follow-up PR if still useful.

## Follow-up

- Add runtime validator for proof artifact examples.
- Wire Policy Fabric admissibility gates to checker output.
- Register proof-artifact contract in Sociosphere Boundary Atlas.