### PR TITLE
Add ProCybernetica cybernetic governance evidence adapter boundary

### DIFF
--- a/contracts/procybernetica/cybernetic-governance-evidence-adapter.synthetic.json
+++ b/contracts/procybernetica/cybernetic-governance-evidence-adapter.synthetic.json
@@ -1,0 +1,69 @@
+{
+  "fixture_kind": "procybernetica_cybernetic_governance_evidence_adapter",
+  "fixture_version": "v0.1",
+  "publication_state": "public-synthetic",
+  "upstream_anchor": {
+    "procybernetica_issue": "SocioProphet/ProCybernetica#28",
+    "schema_bundle_issue": "SocioProphet/ProCybernetica#26",
+    "validator_issue": "SocioProphet/ProCybernetica#27"
+  },
+  "platform_record": {
+    "record_id": "platform-procybernetica-adapter-synthetic-001",
+    "record_kind": "runtime_eval_evidence_bridge",
+    "platform_owner": "SocioProphet/prophet-platform",
+    "runtime_claim": "none",
+    "private_telemetry_included": false
+  },
+  "procybernetica_references": [
+    {
+      "object_kind": "evidence_receipt",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/evidence_receipt.v1.json",
+      "object_ref": "receipt:platform:synthetic:001",
+      "platform_use": "runtime/eval evidence reference"
+    },
+    {
+      "object_kind": "monitor_alert",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/monitor_alert.v1.json",
+      "object_ref": "monitor-alert:platform:synthetic:001",
+      "platform_use": "monitor event reference"
+    },
+    {
+      "object_kind": "release_delta_report",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/release_delta_report.v1.json",
+      "object_ref": "release-delta:platform:synthetic:001",
+      "platform_use": "release/readiness delta evidence"
+    },
+    {
+      "object_kind": "cybernetic_safety_case",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/cybernetic_safety_case.v1.json",
+      "object_ref": "safety-case:platform:synthetic:001",
+      "platform_use": "assurance evidence package reference"
+    },
+    {
+      "object_kind": "authority_chain",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/authority_chain.v1.json",
+      "object_ref": "authority:platform:synthetic:001",
+      "platform_use": "governed runtime action authority reference"
+    },
+    {
+      "object_kind": "tool_permission_scope",
+      "schema_ref": "https://schemas.socioprophet.ai/cybernetic-governance/tool_permission_scope.v1.json",
+      "object_ref": "scope:platform:synthetic:001",
+      "platform_use": "runtime tool permission boundary reference"
+    }
+  ],
+  "adapter_rules": {
+    "do_not_fork_schema_names": true,
+    "platform_runtime_ownership_preserved": true,
+    "procybernetica_semantics_preserved": true,
+    "private_telemetry_requires_redaction_boundary": true,
+    "production_readiness_not_claimed_by_fixture": true
+  },
+  "non_claims": [
+    "This fixture does not represent live platform telemetry.",
+    "This fixture does not claim production readiness.",
+    "This fixture does not emit runtime evidence.",
+    "This fixture does not implement policy enforcement.",
+    "This fixture does not redefine ProCybernetica schemas."
+  ]
+}

--- a/docs/integrations/PROCYBERNETICA_CYBERNETIC_GOVERNANCE_EVIDENCE_ADAPTER.md
+++ b/docs/integrations/PROCYBERNETICA_CYBERNETIC_GOVERNANCE_EVIDENCE_ADAPTER.md
@@ -1,0 +1,82 @@
+# ProCybernetica Cybernetic Governance Evidence Adapter
+
+Status: v0.1 platform adapter specification  
+Upstream issue: `SocioProphet/ProCybernetica#28`  
+Platform issue: `SocioProphet/prophet-platform#473`  
+Runtime claim: none
+
+## Purpose
+
+This document defines how Prophet Platform should consume ProCybernetica cybernetic-governance objects as runtime/eval-fabric evidence references without forking their constitutional semantics.
+
+ProCybernetica owns the public constitutional schema and validator surface. Prophet Platform owns runtime/eval-fabric services, deployment records, readiness records, and platform evidence production.
+
+## Upstream ProCybernetica anchors
+
+- `SocioProphet/ProCybernetica#26` — Tier 1 `schemas/cybernetic-governance/*` schema bundle.
+- `SocioProphet/ProCybernetica#27` — defensive fixtures, validator, tests, and Makefile lane.
+- `SocioProphet/ProCybernetica#28` — integration-boundary record.
+
+## Adapter rule
+
+Platform records may reference ProCybernetica objects by schema ID, object ID, content digest, validation receipt, or public-safe fixture reference. Platform records must not silently redefine these objects.
+
+Allowed:
+
+- platform-side adapter metadata;
+- links to ProCybernetica schema IDs;
+- links to platform runtime/eval records;
+- public-safe synthetic fixtures;
+- bridge fields that preserve source schema names.
+
+Disallowed:
+
+- changing ProCybernetica object semantics in platform contracts;
+- treating ProCybernetica schemas as platform runtime ownership;
+- publishing private telemetry as public ProCybernetica evidence;
+- collapsing safety-case records into production-readiness claims.
+
+## Object mapping
+
+| ProCybernetica object | Platform consumption |
+| --- | --- |
+| `evidence_receipt.v1.json` | Runtime/eval evidence reference or exported evidence receipt link. |
+| `monitor_alert.v1.json` | Platform monitor event reference. |
+| `meta_monitor_report.v1.json` | Monitor health, calibration, or drift reference. |
+| `release_delta_report.v1.json` | Release/readiness delta evidence. |
+| `cybernetic_safety_case.v1.json` | Platform readiness or assurance evidence package reference. |
+| `authority_chain.v1.json` | Governed runtime action authority reference. |
+| `tool_permission_scope.v1.json` | Runtime tool/capability permission boundary reference. |
+| `agent_action_trace.v1.json` | Agentic action trace evidence reference. |
+| `privacy_evidence_classification.v1.json` | Public/private evidence disclosure posture. |
+| `incident_record.v1.json` | Platform incident/control-failure bridge reference. |
+
+## Public-synthetic fixture
+
+The initial fixture is:
+
+```text
+contracts/procybernetica/cybernetic-governance-evidence-adapter.synthetic.json
+```
+
+It demonstrates a platform readiness record that references ProCybernetica evidence receipt, monitor alert, release delta, safety case, authority chain, and tool permission objects without importing private telemetry or claiming production readiness.
+
+## Validation boundary
+
+The upstream validation lane remains in ProCybernetica:
+
+```bash
+make cybernetic-governance-fixtures
+make cybernetic-governance-ci
+```
+
+Prophet Platform should later add platform-side adapter validation that checks:
+
+- every referenced ProCybernetica object has a schema ID;
+- every bridge field preserves source object type;
+- runtime/eval records keep platform-specific fields outside ProCybernetica object bodies;
+- public examples contain no secrets, private telemetry, or customer data.
+
+## Non-claims
+
+This document does not implement runtime evidence emission, deployment gating, production telemetry, safety-case adjudication, or policy enforcement. It defines the platform adapter boundary and the first public-synthetic fixture surface.


### PR DESCRIPTION
## Summary

Implements the first concrete downstream tranche for `SocioProphet/prophet-platform#473`, created from `SocioProphet/ProCybernetica#28`.

Adds:

- `docs/integrations/PROCYBERNETICA_CYBERNETIC_GOVERNANCE_EVIDENCE_ADAPTER.md`
- `contracts/procybernetica/cybernetic-governance-evidence-adapter.synthetic.json`

## Purpose

Defines how Prophet Platform consumes ProCybernetica cybernetic-governance objects as runtime/eval-fabric evidence references without forking their constitutional semantics.

## Upstream anchors

- `SocioProphet/ProCybernetica#26` — Tier 1 `schemas/cybernetic-governance/*` schema bundle
- `SocioProphet/ProCybernetica#27` — defensive fixtures and validator
- `SocioProphet/ProCybernetica#28` — integration-boundary record

## Implementation posture

This PR is not only an issue placeholder. It lands the first platform-side adapter boundary artifact and a public-synthetic fixture.

The fixture demonstrates platform references to ProCybernetica:

- `evidence_receipt.v1.json`
- `monitor_alert.v1.json`
- `release_delta_report.v1.json`
- `cybernetic_safety_case.v1.json`
- `authority_chain.v1.json`
- `tool_permission_scope.v1.json`

## Non-claims

- Does not implement runtime evidence emission.
- Does not add production telemetry.
- Does not add deployment gating.
- Does not redefine ProCybernetica schemas.
- Does not claim production readiness.
- Does not include private telemetry, secrets, customer data, or live evidence.