### PR TITLE
Add Workspace Context platform binding v0.1

### DIFF
--- a/.github/workflows/workspace-context.yml
+++ b/.github/workflows/workspace-context.yml
@@ -1,0 +1,33 @@
+name: Workspace Context
+
+on:
+  pull_request:
+    paths:
+      - 'contracts/workspace-context/**'
+      - 'tools/validate_workspace_context_record.py'
+      - '.github/workflows/workspace-context.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'contracts/workspace-context/**'
+      - 'tools/validate_workspace_context_record.py'
+      - '.github/workflows/workspace-context.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-workspace-context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Validate Workspace Context record
+        run: python3 tools/validate_workspace_context_record.py

--- a/contracts/workspace-context/workspace-context-record.v0.1.example.json
+++ b/contracts/workspace-context/workspace-context-record.v0.1.example.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.1",
+  "record_id": "workspace-context-record-demo-0001",
+  "created_at": "2026-05-22T16:00:00Z",
+  "record_kind": "workspace_context_recorded",
+  "status": "recorded",
+  "workroom_ref": "workroom-demo-0001",
+  "context_graph_ref": "ctxgraph-demo-0001",
+  "workspace_object_ref": "ctxgraph-demo-0001",
+  "platform_refs": {
+    "event_envelope_ref": "event://workspace-context/demo-0001",
+    "evidence_receipt_ref": "evidence://workspace-context/demo-0001",
+    "decision_ref": null,
+    "platform_event_ref": null
+  },
+  "policy_refs": [
+    "policy-decision://policy-demo-ai-use/decision-0001"
+  ],
+  "evidence_refs": [
+    "evidence://workspace-context/demo-0001"
+  ],
+  "labels": {
+    "surface": "workspace-context",
+    "fixture": "public-synthetic"
+  }
+}

--- a/contracts/workspace-context/workspace-context-record.v0.1.json
+++ b/contracts/workspace-context/workspace-context-record.v0.1.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/workspace-context/workspace-context-record.v0.1.json",
+  "title": "WorkspaceContextRecord",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "record_id", "created_at", "record_kind", "status", "workroom_ref", "workspace_object_ref", "platform_refs", "policy_refs", "evidence_refs"],
+  "properties": {
+    "version": { "const": "0.1" },
+    "record_id": { "type": "string" },
+    "created_at": { "type": "string" },
+    "record_kind": { "type": "string" },
+    "status": { "type": "string" },
+    "workroom_ref": { "type": "string" },
+    "context_graph_ref": { "type": "string" },
+    "workspace_object_ref": { "type": "string" },
+    "platform_refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["event_envelope_ref", "evidence_receipt_ref"],
+      "properties": {
+        "event_envelope_ref": { "type": "string" },
+        "evidence_receipt_ref": { "type": "string" },
+        "decision_ref": { "type": ["string", "null"] },
+        "platform_event_ref": { "type": ["string", "null"] }
+      }
+    },
+    "policy_refs": { "type": "array", "items": { "type": "string" } },
+    "evidence_refs": { "type": "array", "items": { "type": "string" } },
+    "labels": { "type": "object", "additionalProperties": { "type": "string" } }
+  }
+}

--- a/docs/WORKSPACE_CONTEXT_RUNTIME.md
+++ b/docs/WORKSPACE_CONTEXT_RUNTIME.md
@@ -1,0 +1,49 @@
+# Workspace Context Runtime Binding
+
+Status: v0.1 platform binding note
+Runtime claim: none
+
+## Purpose
+
+This document records how Prophet Platform should consume the Workspace Context Fabric contracts introduced in `SocioProphet/prophet-workspace`.
+
+The workspace repository owns product and domain semantics. Prophet Platform owns runtime services, platform contracts, storage, transport, evidence, and deployment.
+
+## Platform binding rule
+
+Every material workspace-context action should map to existing platform evidence primitives:
+
+| Workspace action | Platform primitive |
+| --- | --- |
+| Context graph recorded | `EventEnvelope` plus `EvidenceReceipt` |
+| Provider capture recorded | `CarrierIngested` plus `EvidenceReceipt` |
+| Provider projection evaluated | `MembraneDecision` |
+| Provider projection allowed | `ExportApproved` plus `EvidenceReceipt` |
+| Provider projection denied | `ExportDenied` plus `EvidenceReceipt` |
+| Share grant created | `EventEnvelope` plus `EvidenceReceipt` |
+| Share grant revoked | `EventEnvelope` plus `EvidenceReceipt` |
+| Recall candidate created | `EventEnvelope` plus `EvidenceReceipt` |
+| External continuation recorded | `EventEnvelope` plus `EvidenceReceipt` |
+
+## Boundary posture
+
+Prophet Platform must not redefine workspace-domain objects. Platform contracts should reference the workspace objects by stable refs and preserve the existing platform evidence family.
+
+## First implementation target
+
+The first platform implementation should be contract-only:
+
+- add small event contracts under `contracts/workspace-context/`;
+- add a synthetic example fixture;
+- add validation that checks schema/example parseability and required refs;
+- avoid runtime service claims until the contract surface is merged and reviewed.
+
+## Follow-up service targets
+
+Later service work can add:
+
+- a workspace-context API surface;
+- a projection compiler service;
+- a policy/membrane evaluation route;
+- event and receipt emission into the platform evidence store;
+- local and cluster deployment wiring.

--- a/tools/validate_workspace_context_record.py
+++ b/tools/validate_workspace_context_record.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Validate Workspace Context platform record fixture."""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts/workspace-context/workspace-context-record.v0.1.json"
+EXAMPLE = ROOT / "contracts/workspace-context/workspace-context-record.v0.1.example.json"
+
+
+def main():
+    try:
+        schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        example = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+        for key in schema["required"]:
+            assert key in example, f"missing {key}"
+        assert example["version"] == "0.1"
+        assert example["platform_refs"]["event_envelope_ref"]
+        assert example["platform_refs"]["evidence_receipt_ref"]
+        assert example["workroom_ref"]
+        assert example["workspace_object_ref"]
+    except Exception as exc:
+        print(f"ERR: {exc}", file=sys.stderr)
+        return 2
+    print("OK: Workspace Context record validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the first Prophet Platform binding surface for Workspace Context Fabric.

This is intentionally contract-only. It records how platform should consume workspace context records through existing event/evidence primitives without claiming runtime service implementation yet.

## Changes

- Add `docs/WORKSPACE_CONTEXT_RUNTIME.md`
- Add `contracts/workspace-context/workspace-context-record.v0.1.json`
- Add `contracts/workspace-context/workspace-context-record.v0.1.example.json`
- Add `tools/validate_workspace_context_record.py`
- Add `.github/workflows/workspace-context.yml`

## Boundary posture

- `prophet-workspace` owns workspace/domain contracts.
- `prophet-platform` owns runtime binding, event/evidence storage, services, and deployment.
- Existing platform evidence primitives remain the base: `EventEnvelope`, `EvidenceReceipt`, `MembraneDecision`, `ExportApproved`, and `ExportDenied`.

## Validation

Expected local validation:

```bash
python3 tools/validate_workspace_context_record.py
```

The new workflow validates the synthetic workspace-context record fixture on PRs touching this surface.
