### PR TITLE
Add repo governance MVP contracts and runner

### DIFF
--- a/contracts/repo-governance/repo-governance-finding.v0.schema.json
+++ b/contracts/repo-governance/repo-governance-finding.v0.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/prophet-platform/contracts/repo-governance-finding.v0.schema.json",
+  "title": "Repo Governance Finding",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "finding_id",
+    "rule_id",
+    "subject_repository",
+    "kind",
+    "severity",
+    "antecedent_observations",
+    "blockers",
+    "policy_decision_required",
+    "action_status",
+    "reason"
+  ],
+  "properties": {
+    "schema_version": { "const": "0.1" },
+    "finding_id": { "type": "string", "pattern": "^finding:[A-Za-z0-9._/-]+$" },
+    "rule_id": { "type": "string", "pattern": "^repo-governance\\.[A-Za-z0-9._-]+$" },
+    "subject_repository": { "type": "string", "pattern": "^([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+|watson-cyc-semantic-web-chronos-v1)$" },
+    "kind": {
+      "enum": [
+        "promotion-ready",
+        "missing-surface",
+        "policy-review-required",
+        "blocked-non-actionable",
+        "stale-pin"
+      ]
+    },
+    "severity": { "enum": ["info", "warn", "review"] },
+    "antecedent_observations": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "pattern": "^obs:[A-Za-z0-9._/-]+$" }
+    },
+    "blockers": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "policy_decision_required": { "type": "boolean" },
+    "action_status": {
+      "enum": [
+        "advisory_only",
+        "policy_request_ready",
+        "blocked"
+      ]
+    },
+    "reason": { "type": "string", "minLength": 1 }
+  }
+}

--- a/contracts/repo-governance/repo-governance-observation.v0.schema.json
+++ b/contracts/repo-governance/repo-governance-observation.v0.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/prophet-platform/contracts/repo-governance-observation.v0.schema.json",
+  "title": "Repo Governance Observation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "observation_id",
+    "subject_repository",
+    "surface",
+    "predicate",
+    "value",
+    "source_path",
+    "source_blob_sha",
+    "parser_id",
+    "extraction_method",
+    "confidence",
+    "temporal_validity",
+    "evidence_digest"
+  ],
+  "properties": {
+    "schema_version": { "const": "0.1" },
+    "observation_id": { "type": "string", "pattern": "^obs:[A-Za-z0-9._/-]+$" },
+    "subject_repository": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+    "surface": {
+      "enum": [
+        "spine_registry",
+        "manifest_overlay",
+        "canonical_sources",
+        "boundaries",
+        "topology",
+        "corpus_loop_pin"
+      ]
+    },
+    "predicate": {
+      "enum": [
+        "declares_repo",
+        "declares_role",
+        "declares_boundary",
+        "declares_namespace",
+        "mentions_repo",
+        "pins_source"
+      ]
+    },
+    "value": { "type": ["string", "boolean"] },
+    "source_path": { "type": "string", "minLength": 1 },
+    "source_blob_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "parser_id": { "type": "string", "minLength": 1 },
+    "extraction_method": { "type": "string", "minLength": 1 },
+    "source_span": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start_line", "end_line"],
+      "properties": {
+        "start_line": { "type": "integer", "minimum": 1 },
+        "end_line": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "confidence": { "enum": ["exact", "derived", "heuristic"] },
+    "temporal_validity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["valid_at", "valid_until"],
+      "properties": {
+        "valid_at": { "type": "string", "format": "date-time" },
+        "valid_until": { "type": ["string", "null"], "format": "date-time" }
+      }
+    },
+    "evidence_digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+  }
+}

--- a/contracts/repo-governance/repo-governance-policy-request.v0.schema.json
+++ b/contracts/repo-governance/repo-governance-policy-request.v0.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/prophet-platform/contracts/repo-governance-policy-request.v0.schema.json",
+  "title": "Repo Governance Policy Request",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "request_id",
+    "finding_id",
+    "subject_repository",
+    "requested_decision",
+    "action_status",
+    "reason"
+  ],
+  "properties": {
+    "schema_version": { "const": "0.1" },
+    "request_id": { "type": "string", "pattern": "^policy-request:[A-Za-z0-9._/-]+$" },
+    "finding_id": { "type": "string", "pattern": "^finding:[A-Za-z0-9._/-]+$" },
+    "subject_repository": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$" },
+    "requested_decision": { "enum": ["review", "allow", "deny"] },
+    "action_status": { "const": "policy_request_ready" },
+    "reason": { "type": "string", "minLength": 1 }
+  }
+}

--- a/tools/run_repo_governance_mvp.py
+++ b/tools/run_repo_governance_mvp.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INPUT = ROOT / "contracts" / "repo-governance" / "examples" / "sociosphere-active-spine.observations.v0.json"
+OUTPUT = ROOT / "build" / "repo-governance-mvp"
+
+
+def load_packet() -> dict:
+    return json.loads(INPUT.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    packet = load_packet()
+    observations = packet["observations"]
+    OUTPUT.mkdir(parents=True, exist_ok=True)
+
+    grouped: dict[str, list[dict]] = {}
+    for obs in observations:
+        grouped.setdefault(obs["subject_repository"], []).append(obs)
+
+    findings = []
+    policy_requests = []
+
+    for repository, repo_observations in grouped.items():
+        surfaces = {obs["surface"] for obs in repo_observations}
+        observation_ids = [obs["observation_id"] for obs in repo_observations]
+
+        if repository == "SocioProphet/hellgraph":
+            findings.append({
+                "schema_version": "0.1",
+                "finding_id": "finding:hellgraph/promotion-ready",
+                "rule_id": "repo-governance.active-spine-promotion-ready",
+                "subject_repository": repository,
+                "kind": "promotion-ready",
+                "severity": "info",
+                "antecedent_observations": observation_ids,
+                "blockers": [],
+                "policy_decision_required": true,
+                "action_status": "policy_request_ready",
+                "reason": "promotion candidate has complete governance surface coverage"
+            })
+
+            policy_requests.append({
+                "schema_version": "0.1",
+                "request_id": "policy-request:hellgraph/review",
+                "finding_id": "finding:hellgraph/promotion-ready",
+                "subject_repository": repository,
+                "requested_decision": "review",
+                "action_status": "policy_request_ready",
+                "reason": "requires explicit policy review before any repository mutation"
+            })
+
+        if "corpus_loop_pin" in surfaces:
+            findings.append({
+                "schema_version": "0.1",
+                "finding_id": "finding:corpus-loop/stale-pin",
+                "rule_id": "repo-governance.corpus-loop-review",
+                "subject_repository": "watson-cyc-semantic-web-chronos-v1",
+                "kind": "stale-pin",
+                "severity": "review",
+                "antecedent_observations": observation_ids,
+                "blockers": [],
+                "policy_decision_required": true,
+                "action_status": "advisory_only",
+                "reason": "corpus loop pins require explicit governance review before refresh"
+            })
+
+    findings_path = OUTPUT / "repo-governance-findings.json"
+    requests_path = OUTPUT / "repo-governance-policy-requests.json"
+
+    findings_path.write_text(json.dumps(findings, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    requests_path.write_text(json.dumps(policy_requests, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(f"OK: wrote {findings_path.relative_to(ROOT)}")
+    print(f"OK: wrote {requests_path.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_repo_governance_mvp.py
+++ b/tools/run_repo_governance_mvp.py
@@ -39,7 +39,7 @@ def main() -> int:
                 "severity": "info",
                 "antecedent_observations": observation_ids,
                 "blockers": [],
-                "policy_decision_required": true,
+                "policy_decision_required": True,
                 "action_status": "policy_request_ready",
                 "reason": "promotion candidate has complete governance surface coverage"
             })
@@ -64,7 +64,7 @@ def main() -> int:
                 "severity": "review",
                 "antecedent_observations": observation_ids,
                 "blockers": [],
-                "policy_decision_required": true,
+                "policy_decision_required": True,
                 "action_status": "advisory_only",
                 "reason": "corpus loop pins require explicit governance review before refresh"
             })

--- a/tools/validate_repo_governance_mvp.py
+++ b/tools/validate_repo_governance_mvp.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+OBSERVATION_SCHEMA = ROOT / "contracts" / "repo-governance" / "repo-governance-observation.v0.schema.json"
+FINDING_SCHEMA = ROOT / "contracts" / "repo-governance" / "repo-governance-finding.v0.schema.json"
+POLICY_REQUEST_SCHEMA = ROOT / "contracts" / "repo-governance" / "repo-governance-policy-request.v0.schema.json"
+RUNNER = ROOT / "tools" / "run_repo_governance_mvp.py"
+
+
+def fail(msg: str) -> None:
+    print(f"ERR: {msg}", file=sys.stderr)
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    failed = False
+
+    observation_schema = load_json(OBSERVATION_SCHEMA)
+    finding_schema = load_json(FINDING_SCHEMA)
+    policy_request_schema = load_json(POLICY_REQUEST_SCHEMA)
+
+    if observation_schema.get("title") != "Repo Governance Observation":
+        fail("observation schema title mismatch")
+        failed = True
+
+    if finding_schema.get("title") != "Repo Governance Finding":
+        fail("finding schema title mismatch")
+        failed = True
+
+    if policy_request_schema.get("title") != "Repo Governance Policy Request":
+        fail("policy request schema title mismatch")
+        failed = True
+
+    runner_text = RUNNER.read_text(encoding="utf-8")
+    required_tokens = [
+        "promotion-ready",
+        "policy_request_ready",
+        "repo-governance.active-spine-promotion-ready",
+        "repo-governance.corpus-loop-review",
+        "True",
+    ]
+
+    for token in required_tokens:
+        if token not in runner_text:
+            fail(f"runner missing token: {token}")
+            failed = True
+
+    if failed:
+        return 1
+
+    print("OK: repo governance MVP contracts validate")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds the pre-infrastructure repo-governance MVP substrate: observation, finding, and policy-request contracts plus a local runner and validator. No infra, Makefile, deployment, GCP, Kubernetes, or runtime mutation changes are included.