### PR TITLE
Add local repo governance demo walkthrough and readout

### DIFF
--- a/contracts/repo-governance/examples/sociosphere-active-spine.observations.v0.json
+++ b/contracts/repo-governance/examples/sociosphere-active-spine.observations.v0.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "0.1",
+  "kind": "repo_governance_observation_set",
+  "observations": [
+    {
+      "schema_version": "0.1",
+      "observation_id": "obs:hellgraph/spine-role",
+      "subject_repository": "SocioProphet/hellgraph",
+      "surface": "spine_registry",
+      "predicate": "declares_role",
+      "value": "promotion_candidate",
+      "source_path": "registry/spine-v0.txt",
+      "source_blob_sha": "d5be4fc1a73b3b49764d6ebb02dce5886d261a4d",
+      "parser_id": "sociosphere.repo-governance-observation.bootstrap.v0",
+      "extraction_method": "spine.section.Candidates",
+      "source_span": { "start_line": 1, "end_line": 80 },
+      "confidence": "exact",
+      "temporal_validity": {
+        "valid_at": "2026-05-24T00:00:00Z",
+        "valid_until": null
+      },
+      "evidence_digest": "d96847bca85d29032afd620f771b54224b2a7619df1d0f6845749320c4369e60"
+    },
+    {
+      "schema_version": "0.1",
+      "observation_id": "obs:hellgraph/manifest-overlay",
+      "subject_repository": "SocioProphet/hellgraph",
+      "surface": "manifest_overlay",
+      "predicate": "declares_repo",
+      "value": true,
+      "source_path": "manifest/active-spine.repos.toml",
+      "source_blob_sha": "d0535218400c7911438130fc68a95d15addb23a7",
+      "parser_id": "sociosphere.repo-governance-observation.bootstrap.v0",
+      "extraction_method": "toml.active_spine.repos[]",
+      "source_span": { "start_line": 1, "end_line": 80 },
+      "confidence": "exact",
+      "temporal_validity": {
+        "valid_at": "2026-05-24T00:00:00Z",
+        "valid_until": null
+      },
+      "evidence_digest": "d96847bca85d29032afd620f771b54224b2a7619df1d0f6845749320c4369e60"
+    },
+    {
+      "schema_version": "0.1",
+      "observation_id": "obs:corpus-loop/pin",
+      "subject_repository": "SocioProphet/sociosphere",
+      "surface": "corpus_loop_pin",
+      "predicate": "pins_source",
+      "value": "watson-cyc-semantic-web-chronos-v1",
+      "source_path": "registry/corpus-loop-v1/valid.watson-cyc-chronos.pinned.json",
+      "source_blob_sha": "33c37dec6f03d160efa83f47654f27ec5376b53a",
+      "parser_id": "sociosphere.repo-governance-observation.bootstrap.v0",
+      "extraction_method": "json.corpus_loop_id",
+      "source_span": { "start_line": 1, "end_line": 120 },
+      "confidence": "exact",
+      "temporal_validity": {
+        "valid_at": "2026-05-24T00:00:00Z",
+        "valid_until": null
+      },
+      "evidence_digest": "d96847bca85d29032afd620f771b54224b2a7619df1d0f6845749320c4369e60"
+    }
+  ]
+}

--- a/docs/REPO_GOVERNANCE_DEMO.md
+++ b/docs/REPO_GOVERNANCE_DEMO.md
@@ -1,0 +1,67 @@
+# Repo Governance Demo Walkthrough
+
+## Purpose
+
+This walkthrough demonstrates the local pre-infrastructure governance MVP.
+
+The demo intentionally avoids:
+- cloud infrastructure;
+- Kubernetes;
+- Argo CD;
+- deployment automation;
+- repository mutation.
+
+## Inputs
+
+Checked-in Sociosphere observation packet:
+
+`contracts/repo-governance/examples/sociosphere-active-spine.observations.v0.json`
+
+## Execution
+
+Run the validator:
+
+```bash
+python3 tools/validate_repo_governance_mvp.py
+```
+
+Run the governance pipeline:
+
+```bash
+python3 tools/run_repo_governance_mvp.py
+```
+
+Render the governance readout:
+
+```bash
+python3 tools/render_repo_governance_readout.py
+```
+
+## Generated artifacts
+
+```text
+build/repo-governance-mvp/repo-governance-findings.json
+build/repo-governance-mvp/repo-governance-policy-requests.json
+build/repo-governance-mvp/repo-governance-readout.md
+```
+
+## Demonstrated behavior
+
+The demo proves:
+
+1. Sociosphere can emit typed governance observations.
+2. Prophet Platform can ingest observations.
+3. Findings can be deterministically generated.
+4. Policy-review requests can be deterministically generated.
+5. Findings remain advisory only.
+
+## Current safety boundary
+
+This MVP does not:
+- mutate repositories;
+- execute actions;
+- authorize deployment;
+- provision infrastructure;
+- reconcile clusters.
+
+All future runtime mutation must pass through an explicit policy-decision layer.

--- a/tools/render_repo_governance_readout.py
+++ b/tools/render_repo_governance_readout.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD = ROOT / "build" / "repo-governance-mvp"
+FINDINGS = BUILD / "repo-governance-findings.json"
+REQUESTS = BUILD / "repo-governance-policy-requests.json"
+OUTPUT = BUILD / "repo-governance-readout.md"
+
+
+def load_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def render() -> str:
+    findings = load_json(FINDINGS)
+    requests = load_json(REQUESTS)
+
+    lines: list[str] = []
+    lines.append("# Repo Governance MVP Readout")
+    lines.append("")
+    lines.append("## Findings")
+    lines.append("")
+
+    for finding in findings:
+        lines.append(f"### {finding['finding_id']}")
+        lines.append(f"- Repository: `{finding['subject_repository']}`")
+        lines.append(f"- Kind: `{finding['kind']}`")
+        lines.append(f"- Severity: `{finding['severity']}`")
+        lines.append(f"- Rule: `{finding['rule_id']}`")
+        lines.append(f"- Action status: `{finding['action_status']}`")
+        lines.append(f"- Policy required: `{finding['policy_decision_required']}`")
+        lines.append(f"- Reason: {finding['reason']}")
+        lines.append("")
+
+    lines.append("## Policy Requests")
+    lines.append("")
+
+    for request in requests:
+        lines.append(f"### {request['request_id']}")
+        lines.append(f"- Repository: `{request['subject_repository']}`")
+        lines.append(f"- Requested decision: `{request['requested_decision']}`")
+        lines.append(f"- Action status: `{request['action_status']}`")
+        lines.append(f"- Reason: {request['reason']}")
+        lines.append("")
+
+    lines.append("## Safety Boundary")
+    lines.append("")
+    lines.append("All findings are advisory only. No repository mutation or runtime action is authorized by this MVP.")
+    lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    BUILD.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(render(), encoding="utf-8")
+    print(f"OK: wrote {OUTPUT.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds the checked-in Sociosphere governance observation example, a deterministic governance readout renderer, and a local replay walkthrough. This tranche remains fully pre-infrastructure with no deployment, cloud, Kubernetes, Argo, or runtime mutation changes.