### PR TITLE
Add synthetic TrustOps ART-smoke runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite trustops-art-runner-smoke
 
-validate: validate-repo drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite trustops-art-runner-smoke
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -69,7 +69,7 @@ lattice-studio-smoke:
 	test -s build/lattice-studio/paas/paas-deployment-plan.json
 	test -s build/lattice-studio/local-dev/local-dev-session.json
 	test -s build/lattice-studio/execution/execution-record.json
-	test -s build/lattice-studio/execution/execution-evidence.json
+	test -s build/lattice-studio/execution-evidence.json
 	test -s build/lattice-studio/memory-events.json
 	test -s build/lattice-studio/studio-platform-records.json
 	test -s build/lattice-studio/studio-platform-record-enrichments.json
@@ -128,6 +128,9 @@ test-tools:
 	test -d .venv-tools || python3 -m venv .venv-tools
 	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests
 
+trustops-art-runner-smoke:
+	PYTHONPATH=apps/trustops-art-runner/src python3 tools/smoke_trustops_art_runner.py
+
 smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke semantic-bridge-zone-validation-smoke
 
 smoke-health:
@@ -183,21 +186,4 @@ validate-office-runtime-contracts:
 
 .PHONY: fogstack-local-demo
 fogstack-local-demo:
-	python3 tools/run_fogstack_local_demo.py --pack all --output-dir build/fogstack-local-demo --summary
-	python3 tools/check_fogstack_local_demo_artifact_index.py --index build/fogstack-local-demo/demo-artifacts.index.json
-
-.PHONY: fogstack-local-demo-serve
-fogstack-local-demo-serve: fogstack-local-demo
-	python3 tools/serve_fogstack_local_demo.py --directory build/fogstack-local-demo --host 127.0.0.1 --port 8765
-
-.PHONY: fogstack-local-demo-deploy-plan
-fogstack-local-demo-deploy-plan:
-	python3 tools/run_fogstack_local_demo_deploy_plan.py --output-dir build/fogstack-local-demo/deploy --summary
-
-.PHONY: fogstack-local-demo-full
-fogstack-local-demo-full:
-	python3 tools/run_fogstack_local_demo_full.py --output-dir build/fogstack-local-demo --summary
-
-.PHONY: fogstack-parity-readiness
-fogstack-parity-readiness:
-	python3 tools/run_fogstack_parity_readiness.py --summary
+	python3 tools/run_fogstack_local_demo.py --pack all --output build/fogstack-local-demo

--- a/Makefile
+++ b/Makefile
@@ -186,4 +186,21 @@ validate-office-runtime-contracts:
 
 .PHONY: fogstack-local-demo
 fogstack-local-demo:
-	python3 tools/run_fogstack_local_demo.py --pack all --output build/fogstack-local-demo
+	python3 tools/run_fogstack_local_demo.py --pack all --output-dir build/fogstack-local-demo --summary
+	python3 tools/check_fogstack_local_demo_artifact_index.py --index build/fogstack-local-demo/demo-artifacts.index.json
+
+.PHONY: fogstack-local-demo-serve
+fogstack-local-demo-serve: fogstack-local-demo
+	python3 tools/serve_fogstack_local_demo.py --directory build/fogstack-local-demo --host 127.0.0.1 --port 8765
+
+.PHONY: fogstack-local-demo-deploy-plan
+fogstack-local-demo-deploy-plan:
+	python3 tools/run_fogstack_local_demo_deploy_plan.py --output-dir build/fogstack-local-demo/deploy --summary
+
+.PHONY: fogstack-local-demo-full
+fogstack-local-demo-full:
+	python3 tools/run_fogstack_local_demo_full.py --output-dir build/fogstack-local-demo --summary
+
+.PHONY: fogstack-parity-readiness
+fogstack-parity-readiness:
+	python3 tools/run_fogstack_parity_readiness.py --summary

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ lattice-studio-smoke:
 	test -s build/lattice-studio/paas/paas-deployment-plan.json
 	test -s build/lattice-studio/local-dev/local-dev-session.json
 	test -s build/lattice-studio/execution/execution-record.json
-	test -s build/lattice-studio/execution-evidence.json
+	test -s build/lattice-studio/execution/execution-evidence.json
 	test -s build/lattice-studio/memory-events.json
 	test -s build/lattice-studio/studio-platform-records.json
 	test -s build/lattice-studio/studio-platform-record-enrichments.json

--- a/apps/trustops-art-runner/examples/functional-service.art-smoke.manifest.json
+++ b/apps/trustops-art-runner/examples/functional-service.art-smoke.manifest.json
@@ -1,0 +1,32 @@
+{
+  "manifestId": "manifest://trustops/art-smoke/claims-extractor-001",
+  "receiptId": "trustops.art-smoke.claims-extractor-001",
+  "subject": {
+    "kind": "functional-service",
+    "id": "claims-extractor",
+    "ownerRepository": "SocioProphet/prophet-platform",
+    "versionRef": "git:synthetic-art-smoke",
+    "functionalServiceRef": "functional-service://demo/claims-extractor"
+  },
+  "datasetRefs": ["dataset://synthetic/art-smoke/claims-extractor"],
+  "modelRefs": ["model://synthetic/demo-classifier"],
+  "policyRefs": ["policy://trustops/art-smoke-v0.1"],
+  "dataBoundary": "synthetic",
+  "gateRef": "gate://trustops/art-smoke/robustness",
+  "metrics": [
+    {
+      "name": "synthetic_evasion_success_rate",
+      "value": 0.0,
+      "threshold": 0.1,
+      "direction": "at-or-below",
+      "status": "pass",
+      "sliceRef": "slice://synthetic/default"
+    }
+  ],
+  "evidenceArtifactRefs": ["evidence://trustops/art-smoke/claims-extractor/metrics-001"],
+  "factsheetRefs": ["factsheet://trustops/art-smoke/claims-extractor/001"],
+  "residualRisk": "low",
+  "recommendedMitigations": [],
+  "runnerCodeDigest": "sha256:synthetic-art-smoke-runner",
+  "sourceCommit": "synthetic"
+}

--- a/apps/trustops-art-runner/src/trustops_art_runner/__init__.py
+++ b/apps/trustops-art-runner/src/trustops_art_runner/__init__.py
@@ -1,0 +1,5 @@
+"""Synthetic TrustOps ART-smoke runner package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/apps/trustops-art-runner/src/trustops_art_runner/cli.py
+++ b/apps/trustops-art-runner/src/trustops_art_runner/cli.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Synthetic TrustOps ART-smoke receipt runner.
+
+This runner intentionally does not import ART. It is the first functional
+platform slice that emits a provider-neutral TrustOps receipt from synthetic
+fixture inputs. Real ART integration can land later behind this receipt
+boundary without changing downstream ledger/guardrail/registry semantics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "trustops-receipt.v1"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def receipt_digest(receipt: dict[str, Any]) -> str:
+    copy = dict(receipt)
+    provenance = dict(copy.get("provenance", {}))
+    provenance.pop("receiptDigest", None)
+    copy["provenance"] = provenance
+    encoded = json.dumps(copy, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def decision_from_metrics(metrics: list[dict[str, Any]]) -> tuple[str, str, str]:
+    statuses = {str(metric.get("status")) for metric in metrics}
+    if "fail" in statuses:
+        return "block", "fail", "Synthetic ART-smoke robustness check failed."
+    if "warn" in statuses:
+        return "warn", "warn", "Synthetic ART-smoke robustness check produced warnings."
+    return "allow", "pass", "Synthetic ART-smoke robustness check passed."
+
+
+def build_receipt(manifest: dict[str, Any], *, generated_at: str | None = None) -> dict[str, Any]:
+    manifest_id = str(manifest.get("manifestId", "manifest:unknown"))
+    subject = manifest.get("subject")
+    if not isinstance(subject, dict):
+        raise ValueError("manifest.subject must be an object")
+    metrics = manifest.get("metrics")
+    if not isinstance(metrics, list) or not metrics:
+        raise ValueError("manifest.metrics must be a non-empty array")
+
+    policy_decision, result_status, summary = decision_from_metrics(metrics)
+    created_at = generated_at or utc_now()
+    receipt: dict[str, Any] = {
+        "schemaVersion": SCHEMA_VERSION,
+        "receiptId": str(manifest.get("receiptId", "trustops.art-smoke.synthetic-001")),
+        "receiptType": "robustness",
+        "subject": {
+            "kind": str(subject.get("kind", "functional-service")),
+            "id": str(subject.get("id", "unknown-subject")),
+            "ownerRepository": str(subject.get("ownerRepository", "SocioProphet/prophet-platform")),
+            "versionRef": str(subject.get("versionRef", "synthetic")),
+            "functionalServiceRef": str(subject.get("functionalServiceRef", "functional-service://unknown")),
+        },
+        "runner": {
+            "id": "trustops-art-runner/art-smoke",
+            "provider": "art",
+            "version": "0.1.0-synthetic",
+            "executionMode": "ci",
+            "containerRef": "container://not-required/synthetic-art-smoke",
+            "codeDigest": str(manifest.get("runnerCodeDigest", "sha256:synthetic-runner")),
+        },
+        "inputs": {
+            "manifests": [manifest_id],
+            "datasetRefs": list(manifest.get("datasetRefs", ["dataset://synthetic/art-smoke"])),
+            "modelRefs": list(manifest.get("modelRefs", [])),
+            "policyRefs": list(manifest.get("policyRefs", ["policy://trustops/art-smoke-v0.1"])),
+            "dataBoundary": str(manifest.get("dataBoundary", "synthetic")),
+            "rawDataExported": False,
+        },
+        "evaluation": {
+            "profile": "art-smoke",
+            "threatClasses": ["evasion"],
+            "metricFamilies": ["robustness"],
+            "metrics": metrics,
+        },
+        "policy": {
+            "gateRef": str(manifest.get("gateRef", "gate://trustops/art-smoke")),
+            "decision": policy_decision,
+        },
+        "result": {
+            "status": result_status,
+            "summary": summary,
+            "residualRisk": str(manifest.get("residualRisk", "low")),
+            "recommendedMitigations": list(manifest.get("recommendedMitigations", [])),
+        },
+        "evidence": {
+            "artifactRefs": list(manifest.get("evidenceArtifactRefs", ["evidence://trustops/art-smoke/metrics-001"])),
+            "redactionPolicy": "metrics-only",
+            "factsheetRefs": list(manifest.get("factsheetRefs", ["factsheet://trustops/art-smoke/synthetic-001"])),
+        },
+        "actions": [
+            {"target": "model-governance-ledger", "action": "record", "details": "Record TrustOps receipt evidence only."},
+            {"target": "guardrail-fabric", "action": policy_decision if policy_decision != "allow" else "allow", "details": "Downstream runtime-control decision remains separate."},
+        ],
+        "provenance": {
+            "createdAt": created_at,
+            "createdBy": "SocioProphet/prophet-platform/apps/trustops-art-runner",
+            "sourceCommit": str(manifest.get("sourceCommit", "synthetic")),
+            "receiptDigest": "sha256:pending",
+        },
+    }
+    receipt["provenance"]["receiptDigest"] = receipt_digest(receipt)
+    return receipt
+
+
+def write_json(payload: dict[str, Any], output: str | None) -> None:
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if output:
+        Path(output).write_text(text, encoding="utf-8")
+    else:
+        print(text, end="")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="trustops-art-runner")
+    parser.add_argument("run", choices=["run"])
+    parser.add_argument("--profile", required=True, choices=["art-smoke"])
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--generated-at")
+    parser.add_argument("--output")
+    args = parser.parse_args(argv)
+    try:
+        manifest = load_json(Path(args.manifest))
+        receipt = build_receipt(manifest, generated_at=args.generated_at)
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    write_json(receipt, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/TRUSTOPS_ART_RUNNER.md
+++ b/docs/TRUSTOPS_ART_RUNNER.md
@@ -1,0 +1,66 @@
+# TrustOps ART-Smoke Runner v0.1
+
+## Purpose
+
+`apps/trustops-art-runner` is the first Prophet Platform runtime slice that emits a `trustops-receipt.v1` receipt for the TrustOps Fabric path.
+
+This first tranche is synthetic and receipt-first. It intentionally does not import ART into platform core. It proves the platform can accept a manifest, evaluate a deterministic synthetic robustness metric, and emit a provider-neutral TrustOps receipt that downstream systems can consume.
+
+## Boundary
+
+The runner emits evidence only.
+
+It does not:
+
+- mutate runtime state;
+- call Guardrail Fabric;
+- mutate Agent Registry authority;
+- write Model Governance Ledger records;
+- promote, rollback, revoke, or waive anything;
+- import ART into platform core.
+
+Downstream surfaces remain separate:
+
+```text
+prophet-platform TrustOps runner -> trustops-receipt.v1 evidence
+model-governance-ledger -> evidence ledger record
+guardrail-fabric -> runtime-control decision
+agent-registry -> authority mutation decision
+agentplane -> governed attempt admission consumer
+```
+
+## CLI
+
+```bash
+PYTHONPATH=apps/trustops-art-runner/src \
+python3 -m trustops_art_runner.cli run \
+  --profile art-smoke \
+  --manifest apps/trustops-art-runner/examples/functional-service.art-smoke.manifest.json \
+  --output build/trustops-art-runner/trustops-receipt.art-smoke.json
+```
+
+## Validation
+
+```bash
+python3 tools/validate_trustops_art_receipt.py build/trustops-art-runner/trustops-receipt.art-smoke.json
+```
+
+Or run the full smoke:
+
+```bash
+make trustops-art-runner-smoke
+```
+
+## Acceptance posture for #398
+
+This tranche satisfies the first functional path:
+
+- synthetic manifest in;
+- valid `trustops-receipt.v1` out;
+- metrics-only redacted evidence refs;
+- runner provenance;
+- policy decision;
+- downstream action hints only;
+- no platform core ART import.
+
+A later tranche can replace the synthetic metric generator with an actual ART-backed runner behind the same receipt boundary.

--- a/tools/smoke_trustops_art_runner.py
+++ b/tools/smoke_trustops_art_runner.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Smoke the synthetic TrustOps ART-smoke runner and validate its receipt."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "apps" / "trustops-art-runner" / "examples" / "functional-service.art-smoke.manifest.json"
+OUTPUT = ROOT / "build" / "trustops-art-runner" / "trustops-receipt.art-smoke.json"
+RUNNER = ROOT / "apps" / "trustops-art-runner" / "src"
+VALIDATOR = ROOT / "tools" / "validate_trustops_art_receipt.py"
+
+
+def run(cmd: list[str]) -> None:
+    result = subprocess.run(cmd, cwd=ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if result.returncode != 0:
+        if result.stdout:
+            print(result.stdout, file=sys.stdout)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+        raise SystemExit(result.returncode)
+
+
+def main() -> int:
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    run(
+        [
+            sys.executable,
+            "-m",
+            "trustops_art_runner.cli",
+            "run",
+            "--profile",
+            "art-smoke",
+            "--manifest",
+            str(MANIFEST),
+            "--generated-at",
+            "2026-05-26T22:30:00Z",
+            "--output",
+            str(OUTPUT),
+        ]
+    )
+    run([sys.executable, str(VALIDATOR), str(OUTPUT)])
+    print(f"OK: emitted and validated {OUTPUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, str(RUNNER))
+    raise SystemExit(main())

--- a/tools/validate_trustops_art_receipt.py
+++ b/tools/validate_trustops_art_receipt.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Validate synthetic TrustOps ART-smoke receipts emitted by prophet-platform."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REQUIRED = {
+    "schemaVersion",
+    "receiptId",
+    "receiptType",
+    "subject",
+    "runner",
+    "inputs",
+    "evaluation",
+    "policy",
+    "result",
+    "evidence",
+    "actions",
+    "provenance",
+}
+POLICY_DECISIONS = {"allow", "warn", "require-review", "quarantine", "block", "rollback", "revoke"}
+RESULT_STATUS = {"pass", "warn", "fail", "error"}
+METRIC_STATUS = {"pass", "warn", "fail", "info"}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        fail(f"{path}: expected JSON object")
+    return payload
+
+
+def require_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def require_list(record: dict[str, Any], key: str, *, allow_empty: bool = False) -> list[Any]:
+    value = record.get(key)
+    if not isinstance(value, list):
+        fail(f"{key}: expected list")
+    if not allow_empty and not value:
+        fail(f"{key}: expected non-empty list")
+    return value
+
+
+def validate_receipt(record: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED - set(record))
+    if missing:
+        fail(f"missing required fields: {missing}")
+    if record["schemaVersion"] != "trustops-receipt.v1":
+        fail("schemaVersion mismatch")
+    if not require_string(record, "receiptId").startswith("trustops."):
+        fail("receiptId must be trustops.*")
+    if record["receiptType"] != "robustness":
+        fail("synthetic art-smoke receiptType must be robustness")
+    validate_subject(record.get("subject"))
+    validate_runner(record.get("runner"))
+    validate_inputs(record.get("inputs"))
+    validate_evaluation(record.get("evaluation"))
+    validate_policy(record.get("policy"))
+    validate_result(record.get("result"))
+    validate_evidence(record.get("evidence"))
+    validate_actions(record.get("actions"))
+    validate_provenance(record.get("provenance"))
+
+
+def validate_subject(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("subject must be an object")
+    for key in ("kind", "id", "ownerRepository", "versionRef"):
+        require_string(value, key)
+    if value["kind"] != "functional-service":
+        fail("synthetic art-smoke subject.kind must be functional-service")
+    if value["ownerRepository"] != "SocioProphet/prophet-platform":
+        fail("subject.ownerRepository must remain prophet-platform for this slice")
+
+
+def validate_runner(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("runner must be an object")
+    for key in ("id", "provider", "version", "executionMode"):
+        require_string(value, key)
+    if value["id"] != "trustops-art-runner/art-smoke":
+        fail("runner.id mismatch")
+    if value["provider"] != "art":
+        fail("runner.provider must identify ART as backend surface")
+    if value["executionMode"] != "ci":
+        fail("synthetic runner executionMode must be ci")
+
+
+def validate_inputs(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("inputs must be an object")
+    require_list(value, "manifests")
+    if value.get("dataBoundary") != "synthetic":
+        fail("first art-smoke runner slice must use synthetic dataBoundary")
+    if value.get("rawDataExported") is not False:
+        fail("rawDataExported must be false")
+
+
+def validate_evaluation(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("evaluation must be an object")
+    if value.get("profile") != "art-smoke":
+        fail("evaluation.profile must be art-smoke")
+    metrics = require_list(value, "metrics")
+    for metric in metrics:
+        if not isinstance(metric, dict):
+            fail("metrics entries must be objects")
+        for key in ("name", "value", "threshold", "status"):
+            if key not in metric:
+                fail(f"metric missing {key}")
+        if metric["status"] not in METRIC_STATUS:
+            fail(f"unknown metric status: {metric['status']}")
+
+
+def validate_policy(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("policy must be an object")
+    require_string(value, "gateRef")
+    decision = require_string(value, "decision")
+    if decision not in POLICY_DECISIONS:
+        fail(f"unknown policy decision: {decision}")
+
+
+def validate_result(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("result must be an object")
+    status = require_string(value, "status")
+    if status not in RESULT_STATUS:
+        fail(f"unknown result status: {status}")
+    require_string(value, "summary")
+
+
+def validate_evidence(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("evidence must be an object")
+    refs = require_list(value, "artifactRefs")
+    if any(not isinstance(ref, str) or not ref.startswith("evidence://") for ref in refs):
+        fail("artifactRefs must be redacted evidence:// refs")
+    if value.get("redactionPolicy") != "metrics-only":
+        fail("synthetic art-smoke evidence must use metrics-only redaction")
+
+
+def validate_actions(value: Any) -> None:
+    if not isinstance(value, list) or not value:
+        fail("actions must be a non-empty list")
+    targets = {item.get("target") for item in value if isinstance(item, dict)}
+    if "model-governance-ledger" not in targets:
+        fail("actions must include model-governance-ledger record action")
+    if "guardrail-fabric" not in targets:
+        fail("actions must include guardrail-fabric downstream action")
+
+
+def validate_provenance(value: Any) -> None:
+    if not isinstance(value, dict):
+        fail("provenance must be an object")
+    for key in ("createdAt", "createdBy", "sourceCommit", "receiptDigest"):
+        require_string(value, key)
+    if value["createdBy"] != "SocioProphet/prophet-platform/apps/trustops-art-runner":
+        fail("createdBy must identify the platform runner")
+    if not value["receiptDigest"].startswith("sha256:"):
+        fail("receiptDigest must be sha256-bound")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_trustops_art_receipt.py <receipt.json>", file=sys.stderr)
+        return 2
+    try:
+        validate_receipt(load_json(Path(argv[1])))
+    except (OSError, json.JSONDecodeError, ValidationError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: {argv[1]} validates as synthetic TrustOps ART-smoke receipt")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

Implements the first functional TrustOps ART-smoke runner slice for #398.

This is intentionally receipt-first and synthetic. It proves Prophet Platform can accept a TrustOps manifest and emit a valid `trustops-receipt.v1` robustness receipt without importing ART into platform core or collapsing downstream policy planes.

## Adds

- `apps/trustops-art-runner/src/trustops_art_runner/cli.py`
  - accepts a synthetic manifest and `--profile art-smoke`;
  - emits `trustops-receipt.v1` JSON;
  - computes a stable receipt digest;
  - preserves synthetic-only data boundary and metrics-only redaction.
- `apps/trustops-art-runner/examples/functional-service.art-smoke.manifest.json`
- `tools/validate_trustops_art_receipt.py`
- `tools/smoke_trustops_art_runner.py`
- `docs/TRUSTOPS_ART_RUNNER.md`
- `Makefile` target `trustops-art-runner-smoke`, wired into `make validate`.

## Boundary

This PR does not import ART into platform core, execute downstream runtime controls, call Guardrail Fabric, mutate Agent Registry authority, write Model Governance Ledger records, promote/rollback/revoke anything, or export raw data.

The boundary remains:

```text
prophet-platform TrustOps runner -> trustops-receipt.v1 evidence
model-governance-ledger -> evidence ledger record
guardrail-fabric -> runtime-control decision
agent-registry -> authority mutation decision
agentplane -> governed attempt admission consumer
```

## Validation

`make trustops-art-runner-smoke` emits and validates a synthetic `trustops-receipt.v1` under `build/trustops-art-runner/`.

Advances #398.