### PR TITLE
Add reasoning-failure receipt runner

### DIFF
--- a/.github/workflows/reasoning-failure-runner.yml
+++ b/.github/workflows/reasoning-failure-runner.yml
@@ -1,0 +1,33 @@
+name: reasoning-failure-runner
+
+on:
+  pull_request:
+    paths:
+      - "apps/reasoning-failure-runner/**"
+      - "tools/validate_reasoning_failure_receipt.py"
+      - "tools/smoke_reasoning_failure_runner.py"
+      - "docs/REASONING_FAILURE_RUNNER.md"
+      - ".github/workflows/reasoning-failure-runner.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/reasoning-failure-runner/**"
+      - "tools/validate_reasoning_failure_receipt.py"
+      - "tools/smoke_reasoning_failure_runner.py"
+      - "docs/REASONING_FAILURE_RUNNER.md"
+      - ".github/workflows/reasoning-failure-runner.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run reasoning-failure receipt smoke
+        run: python3 tools/smoke_reasoning_failure_runner.py

--- a/apps/reasoning-failure-runner/examples/exact-string-case.json
+++ b/apps/reasoning-failure-runner/examples/exact-string-case.json
@@ -1,0 +1,12 @@
+{
+  "caseId": "reasoning-failure-case:exact-string-001",
+  "caseType": "exact-string",
+  "description": "Synthetic exact-string case requiring filename preservation.",
+  "prompt": "Return the exact filename alpha-beta_report_v2.csv and nothing else.",
+  "expected": {
+    "exactString": "alpha-beta_report_v2.csv"
+  },
+  "candidateOutput": "alpha_beta_report_v2.csv",
+  "evidenceRefs": ["evidence://reasoning-failure/exact-string-001/prompt"],
+  "dataBoundary": "synthetic"
+}

--- a/apps/reasoning-failure-runner/examples/exactness-perturbations.json
+++ b/apps/reasoning-failure-runner/examples/exactness-perturbations.json
@@ -1,0 +1,16 @@
+{
+  "suiteId": "perturbation-suite:exactness-001",
+  "suiteType": "exactness",
+  "perturbations": [
+    {
+      "perturbationId": "perturbation:separator-swap",
+      "description": "Hyphen changed to underscore.",
+      "invariant": "exactString"
+    },
+    {
+      "perturbationId": "perturbation:extension-drop",
+      "description": "File extension removed.",
+      "invariant": "exactString"
+    }
+  ]
+}

--- a/apps/reasoning-failure-runner/src/reasoning_failure_runner/__init__.py
+++ b/apps/reasoning-failure-runner/src/reasoning_failure_runner/__init__.py
@@ -1,0 +1,5 @@
+"""Synthetic reasoning-failure runner package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/apps/reasoning-failure-runner/src/reasoning_failure_runner/cli.py
+++ b/apps/reasoning-failure-runner/src/reasoning_failure_runner/cli.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Synthetic reasoning-failure runner.
+
+This runner performs deterministic checks over synthetic cases and emits a
+provider-neutral reasoning-failure receipt. It intentionally avoids LLM-as-judge
+and keeps downstream ledger/guardrail/AgentPlane consumption separate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "prophet-platform.reasoning-failure-receipt.v0.1"
+RECORD_TYPE = "ReasoningFailureReceipt"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return payload
+
+
+def stable_hash(record: dict[str, Any]) -> str:
+    copy = dict(record)
+    copy.pop("receipt_hash", None)
+    encoded = json.dumps(copy, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def verify_exact_string(case: dict[str, Any]) -> dict[str, Any]:
+    expected = case.get("expected", {}).get("exactString")
+    candidate = case.get("candidateOutput")
+    passed = isinstance(expected, str) and candidate == expected
+    return {
+        "verifier_ref": "verifier://reasoning-failure/exact-string-v0.1",
+        "verifier_kind": "deterministic-exact-string",
+        "status": "pass" if passed else "fail",
+        "expected_ref": "case.expected.exactString",
+        "observed_ref": "case.candidateOutput",
+        "message": "candidate output exactly matched expected string" if passed else "candidate output did not exactly match expected string",
+    }
+
+
+def run_case(case: dict[str, Any], suite: dict[str, Any], *, generated_at: str | None) -> dict[str, Any]:
+    case_id = str(case.get("caseId", "reasoning-failure-case:unknown"))
+    suite_id = str(suite.get("suiteId", "perturbation-suite:unknown"))
+    case_type = str(case.get("caseType", "unknown"))
+    if case.get("dataBoundary") != "synthetic":
+        raise ValueError("first reasoning-failure slice requires synthetic dataBoundary")
+    if case_type != "exact-string":
+        raise ValueError(f"unsupported caseType for first slice: {case_type}")
+
+    verifier = verify_exact_string(case)
+    verifier_status = verifier["status"]
+    failed = verifier_status != "pass"
+    perturbations = suite.get("perturbations", [])
+    if not isinstance(perturbations, list) or not perturbations:
+        raise ValueError("suite.perturbations must be a non-empty array")
+
+    receipt: dict[str, Any] = {
+        "schemaVersion": SCHEMA_VERSION,
+        "recordType": RECORD_TYPE,
+        "receipt_id": f"reasoning-failure-receipt:{case_id.split(':')[-1]}",
+        "case_id": case_id,
+        "case_type": case_type,
+        "suite_id": suite_id,
+        "perturbation_ids": [str(item.get("perturbationId", "missing")) for item in perturbations],
+        "data_boundary": "synthetic",
+        "provider_dependency": "none",
+        "llm_judge_used": False,
+        "deterministic_verifier_refs": [verifier["verifier_ref"]],
+        "verifier_results": [verifier],
+        "invariant_outcomes": [
+            {
+                "invariant": "exactString",
+                "status": verifier_status,
+                "case_ref": case_id,
+                "suite_ref": suite_id,
+            }
+        ],
+        "policy_decision": "block" if failed else "allow",
+        "residual_risk": "medium" if failed else "low",
+        "mitigation_suggestions": [
+            "route exact-string tasks through deterministic post-check before completion"
+        ] if failed else [],
+        "next_action": "require-review" if failed else "record-only",
+        "evidence_refs": list(case.get("evidenceRefs", [])),
+        "downstream_refs": {
+            "model_governance_ledger": "follow-up:model-governance-ledger/trustops-receipt-ledger-record",
+            "guardrail_fabric": "follow-up:guardrail-fabric/trustops-guardrail-action-decision",
+            "agentplane": "follow-up:agentplane/admission-consumption",
+            "sherlock": "follow-up:sherlock/index-reasoning-failure-evidence",
+        },
+        "issued_at": generated_at or utc_now(),
+        "labels": {"issue": "SocioProphet/prophet-platform#405", "source": "reasoning-failure-runner"},
+    }
+    receipt["receipt_hash"] = stable_hash(receipt)
+    return receipt
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="reasoning-failure-runner")
+    parser.add_argument("run", choices=["run"])
+    parser.add_argument("--case", required=True)
+    parser.add_argument("--suite", required=True)
+    parser.add_argument("--generated-at")
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args(argv)
+    try:
+        case = load_json(Path(args.case))
+        suite = load_json(Path(args.suite))
+        receipt = run_case(case, suite, generated_at=args.generated_at)
+        Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.out).write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/REASONING_FAILURE_RUNNER.md
+++ b/docs/REASONING_FAILURE_RUNNER.md
@@ -1,0 +1,93 @@
+# Reasoning Failure Runner v0.1
+
+## Purpose
+
+`apps/reasoning-failure-runner` is the first narrow runtime slice for issue #405. It records a synthetic reasoning-failure case, runs deterministic perturbation checks, and emits a provider-neutral `ReasoningFailureReceipt v0.1`.
+
+This follows the same lifecycle-boundary discipline used across AgentPlane, Guardrail Fabric, Agent Registry, and Model Governance Ledger:
+
+```text
+case + perturbation suite = evidence input
+reasoning-failure runner = deterministic verifier lane
+ReasoningFailureReceipt = evidence receipt
+downstream consumers = separate follow-on planes
+```
+
+## Boundary
+
+This runner does not use an LLM judge.
+
+It does not call Guardrail Fabric, mutate Agent Registry authority, write Model Governance Ledger records, admit AgentPlane execution, or index Sherlock records directly.
+
+It emits a receipt with downstream refs only.
+
+## Initial fixture family
+
+The first fixture is an exact-string case:
+
+```text
+apps/reasoning-failure-runner/examples/exact-string-case.json
+apps/reasoning-failure-runner/examples/exactness-perturbations.json
+```
+
+The deterministic verifier checks whether `candidateOutput` exactly matches `expected.exactString`. This catches filename/checksum/string-exactness failures without using LLM-only judgment.
+
+## CLI
+
+```bash
+PYTHONPATH=apps/reasoning-failure-runner/src \
+python3 -m reasoning_failure_runner.cli run \
+  --case apps/reasoning-failure-runner/examples/exact-string-case.json \
+  --suite apps/reasoning-failure-runner/examples/exactness-perturbations.json \
+  --out build/reasoning-failure-runner/reasoning-failure-receipt.json
+```
+
+## Validation
+
+```bash
+python3 tools/validate_reasoning_failure_receipt.py build/reasoning-failure-runner/reasoning-failure-receipt.json
+```
+
+Or run the focused smoke:
+
+```bash
+python3 tools/smoke_reasoning_failure_runner.py
+```
+
+## Receipt fields
+
+The receipt includes:
+
+```text
+case_id
+case_type
+suite_id
+perturbation_ids
+data_boundary
+provider_dependency
+llm_judge_used
+deterministic_verifier_refs
+verifier_results
+invariant_outcomes
+policy_decision
+residual_risk
+mitigation_suggestions
+next_action
+evidence_refs
+downstream_refs
+receipt_hash
+```
+
+## Acceptance posture for #405
+
+This tranche satisfies the first functional path:
+
+- synthetic exact-string case in;
+- perturbation suite in;
+- deterministic verifier hook executed;
+- provider-neutral receipt out;
+- no LLM-only judgment;
+- no raw regulated/customer/personal data;
+- downstream consumer refs only.
+
+Later tranches can add relation reversal, identifier swap, unsupported causal claim, temporal inconsistency, multimodal contradiction via fixture refs, and multi-agent premature termination families behind the same receipt contract.

--- a/tools/smoke_reasoning_failure_runner.py
+++ b/tools/smoke_reasoning_failure_runner.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Smoke the synthetic reasoning-failure runner and validate its receipt."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER_SRC = ROOT / "apps" / "reasoning-failure-runner" / "src"
+CASE = ROOT / "apps" / "reasoning-failure-runner" / "examples" / "exact-string-case.json"
+SUITE = ROOT / "apps" / "reasoning-failure-runner" / "examples" / "exactness-perturbations.json"
+OUTPUT = ROOT / "build" / "reasoning-failure-runner" / "reasoning-failure-receipt.json"
+VALIDATOR = ROOT / "tools" / "validate_reasoning_failure_receipt.py"
+
+
+def run(cmd: list[str]) -> None:
+    result = subprocess.run(cmd, cwd=ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if result.returncode != 0:
+        if result.stdout:
+            print(result.stdout, file=sys.stdout)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+        raise SystemExit(result.returncode)
+
+
+def main() -> int:
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    run(
+        [
+            sys.executable,
+            "-m",
+            "reasoning_failure_runner.cli",
+            "run",
+            "--case",
+            str(CASE),
+            "--suite",
+            str(SUITE),
+            "--generated-at",
+            "2026-05-26T23:25:00Z",
+            "--out",
+            str(OUTPUT),
+        ]
+    )
+    run([sys.executable, str(VALIDATOR), str(OUTPUT)])
+    print(f"OK: emitted and validated {OUTPUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, str(RUNNER_SRC))
+    raise SystemExit(main())

--- a/tools/smoke_reasoning_failure_runner.py
+++ b/tools/smoke_reasoning_failure_runner.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -16,7 +17,9 @@ VALIDATOR = ROOT / "tools" / "validate_reasoning_failure_receipt.py"
 
 
 def run(cmd: list[str]) -> None:
-    result = subprocess.run(cmd, cwd=ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(RUNNER_SRC)
+    result = subprocess.run(cmd, cwd=ROOT, env=env, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
     if result.returncode != 0:
         if result.stdout:
             print(result.stdout, file=sys.stdout)
@@ -49,5 +52,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.path.insert(0, str(RUNNER_SRC))
     raise SystemExit(main())

--- a/tools/validate_reasoning_failure_receipt.py
+++ b/tools/validate_reasoning_failure_receipt.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Validate ReasoningFailureReceipt v0.1."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REQUIRED = {
+    "schemaVersion",
+    "recordType",
+    "receipt_id",
+    "case_id",
+    "case_type",
+    "suite_id",
+    "perturbation_ids",
+    "data_boundary",
+    "provider_dependency",
+    "llm_judge_used",
+    "deterministic_verifier_refs",
+    "verifier_results",
+    "invariant_outcomes",
+    "policy_decision",
+    "residual_risk",
+    "mitigation_suggestions",
+    "next_action",
+    "evidence_refs",
+    "downstream_refs",
+    "issued_at",
+    "receipt_hash",
+}
+POLICY_DECISIONS = {"allow", "warn", "require-review", "quarantine", "block", "rollback", "revoke"}
+NEXT_ACTIONS = {"record-only", "require-review", "quarantine", "block", "open-issue"}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        fail(f"{path}: expected JSON object")
+    return payload
+
+
+def require_string(record: dict[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"{key}: expected non-empty string")
+    return value
+
+
+def require_list(record: dict[str, Any], key: str, *, allow_empty: bool = False) -> list[Any]:
+    value = record.get(key)
+    if not isinstance(value, list):
+        fail(f"{key}: expected list")
+    if not allow_empty and not value:
+        fail(f"{key}: expected non-empty list")
+    return value
+
+
+def validate_receipt(record: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED - set(record))
+    if missing:
+        fail(f"missing required fields: {missing}")
+    if record["schemaVersion"] != "prophet-platform.reasoning-failure-receipt.v0.1":
+        fail("schemaVersion mismatch")
+    if record["recordType"] != "ReasoningFailureReceipt":
+        fail("recordType mismatch")
+    for key in ("receipt_id", "case_id", "case_type", "suite_id", "data_boundary", "provider_dependency", "policy_decision", "residual_risk", "next_action", "issued_at", "receipt_hash"):
+        require_string(record, key)
+    if record["data_boundary"] != "synthetic":
+        fail("first reasoning-failure receipt slice must be synthetic")
+    if record["provider_dependency"] != "none":
+        fail("first reasoning-failure receipt slice must be provider-neutral")
+    if record.get("llm_judge_used") is not False:
+        fail("llm_judge_used must be false")
+    if not record["receipt_hash"].startswith("sha256:"):
+        fail("receipt_hash must be sha256-bound")
+    if record["policy_decision"] not in POLICY_DECISIONS:
+        fail("unknown policy_decision")
+    if record["next_action"] not in NEXT_ACTIONS:
+        fail("unknown next_action")
+    require_list(record, "perturbation_ids")
+    verifier_refs = require_list(record, "deterministic_verifier_refs")
+    if any(not isinstance(ref, str) or not ref.startswith("verifier://") for ref in verifier_refs):
+        fail("deterministic_verifier_refs must be verifier:// refs")
+    validate_verifier_results(require_list(record, "verifier_results"))
+    validate_invariant_outcomes(require_list(record, "invariant_outcomes"))
+    evidence_refs = require_list(record, "evidence_refs")
+    if any(not isinstance(ref, str) or not ref.startswith("evidence://") for ref in evidence_refs):
+        fail("evidence_refs must be redacted evidence:// refs")
+    require_list(record, "mitigation_suggestions", allow_empty=True)
+    downstream = record.get("downstream_refs")
+    if not isinstance(downstream, dict):
+        fail("downstream_refs must be an object")
+    for key in ("model_governance_ledger", "guardrail_fabric", "agentplane", "sherlock"):
+        require_string(downstream, key)
+
+    any_fail = any(result.get("status") != "pass" for result in record["verifier_results"])
+    if any_fail and record["policy_decision"] == "allow":
+        fail("failing deterministic verifier cannot allow")
+    if any_fail and record["next_action"] == "record-only":
+        fail("failing deterministic verifier cannot be record-only")
+
+
+def validate_verifier_results(results: list[Any]) -> None:
+    for result in results:
+        if not isinstance(result, dict):
+            fail("verifier_results entries must be objects")
+        for key in ("verifier_ref", "verifier_kind", "status", "message"):
+            require_string(result, key)
+        if result["status"] not in {"pass", "fail", "warn"}:
+            fail("unknown verifier result status")
+        if not result["verifier_ref"].startswith("verifier://"):
+            fail("verifier_ref must be verifier:// ref")
+        if result["verifier_kind"] == "llm-judge":
+            fail("LLM-only judge verifier is not allowed in first slice")
+
+
+def validate_invariant_outcomes(outcomes: list[Any]) -> None:
+    for outcome in outcomes:
+        if not isinstance(outcome, dict):
+            fail("invariant_outcomes entries must be objects")
+        for key in ("invariant", "status", "case_ref", "suite_ref"):
+            require_string(outcome, key)
+        if outcome["status"] not in {"pass", "fail", "warn"}:
+            fail("unknown invariant outcome status")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_reasoning_failure_receipt.py <receipt.json>", file=sys.stderr)
+        return 2
+    try:
+        validate_receipt(load_json(Path(argv[1])))
+    except (OSError, json.JSONDecodeError, ValidationError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: {argv[1]} validates as ReasoningFailureReceipt v0.1")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

Implements the first narrow reasoning-failure vertical slice for #405.

This tranche is synthetic, deterministic, and receipt-first. It adds a runner that accepts a reasoning-failure case plus perturbation suite, executes deterministic verifier hooks, and emits a provider-neutral `ReasoningFailureReceipt v0.1`.

## Adds

- `apps/reasoning-failure-runner/src/reasoning_failure_runner/cli.py`
  - supports exact-string case execution;
  - runs deterministic exact-string verifier;
  - emits `ReasoningFailureReceipt v0.1`;
  - computes stable receipt hash;
  - records downstream refs without invoking downstream systems.
- `apps/reasoning-failure-runner/examples/exact-string-case.json`
- `apps/reasoning-failure-runner/examples/exactness-perturbations.json`
- `tools/validate_reasoning_failure_receipt.py`
- `tools/smoke_reasoning_failure_runner.py`
- `docs/REASONING_FAILURE_RUNNER.md`
- focused workflow `.github/workflows/reasoning-failure-runner.yml`

## Boundary

This PR does not use LLM-as-judge, call Guardrail Fabric, mutate Agent Registry authority, write Model Governance Ledger records, admit AgentPlane execution, index Sherlock records, or consume raw regulated/customer/personal data.

The boundary remains:

```text
case + perturbation suite = evidence input
reasoning-failure runner = deterministic verifier lane
ReasoningFailureReceipt = evidence receipt
downstream consumers = separate follow-on planes
```

## Validation

`python3 tools/smoke_reasoning_failure_runner.py` emits and validates a synthetic exact-string failure receipt under `build/reasoning-failure-runner/`.

Advances #405.