### PR TITLE
Add optional PROMETHEUS PySR execution path

### DIFF
--- a/.github/workflows/prometheus-optional-pysr.yml
+++ b/.github/workflows/prometheus-optional-pysr.yml
@@ -1,0 +1,75 @@
+name: prometheus-optional-pysr
+
+on:
+  pull_request:
+    paths:
+      - "tools/prometheus_pysr_mvp.py"
+      - "tools/validate_prometheus_pysr_mvp_artifact.py"
+      - "tests/fixtures/prometheus/**"
+      - "docs/PROMETHEUS_OPTIONAL_PYSR.md"
+      - ".github/workflows/prometheus-optional-pysr.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "tools/prometheus_pysr_mvp.py"
+      - "tools/validate_prometheus_pysr_mvp_artifact.py"
+      - "tests/fixtures/prometheus/**"
+      - "docs/PROMETHEUS_OPTIONAL_PYSR.md"
+      - ".github/workflows/prometheus-optional-pysr.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-prometheus-optional-pysr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install units dependency
+        run: python3 -m pip install sympy
+      - name: Validate fallback engine still emits candidate
+        run: |
+          mkdir -p build/prometheus/optional-pysr
+          python3 tools/prometheus_pysr_mvp.py \
+            --engine mvp_linear_fallback \
+            --data tests/fixtures/prometheus/pysr-mvp-linear.csv \
+            --target y \
+            --dataset-uri urn:dataset:prometheus:pysr-mvp-linear \
+            --target-unit meter \
+            --feature-unit x=meter \
+            --generated-at 2026-05-27T18:45:00Z \
+            --output build/prometheus/optional-pysr/fallback-candidate.json
+          python3 tools/validate_prometheus_pysr_mvp_artifact.py \
+            build/prometheus/optional-pysr/fallback-candidate.json \
+            --expect-units consistent
+      - name: Validate optional PySR fails closed when unavailable
+        run: |
+          ! python3 tools/prometheus_pysr_mvp.py \
+            --engine optional_pysr \
+            --data tests/fixtures/prometheus/pysr-mvp-linear.csv \
+            --target y \
+            --dataset-uri urn:dataset:prometheus:pysr-mvp-linear \
+            --target-unit meter \
+            --feature-unit x=meter \
+            --generated-at 2026-05-27T18:45:00Z \
+            --output build/prometheus/optional-pysr/should-not-exist.json
+      - name: Validate explicit fallback from optional PySR
+        run: |
+          python3 tools/prometheus_pysr_mvp.py \
+            --engine optional_pysr \
+            --allow-fallback \
+            --data tests/fixtures/prometheus/pysr-mvp-linear.csv \
+            --target y \
+            --dataset-uri urn:dataset:prometheus:pysr-mvp-linear \
+            --target-unit meter \
+            --feature-unit x=meter \
+            --generated-at 2026-05-27T18:45:00Z \
+            --output build/prometheus/optional-pysr/explicit-fallback-candidate.json
+          python3 tools/validate_prometheus_pysr_mvp_artifact.py \
+            build/prometheus/optional-pysr/explicit-fallback-candidate.json \
+            --expect-units consistent

--- a/docs/PROMETHEUS_OPTIONAL_PYSR.md
+++ b/docs/PROMETHEUS_OPTIONAL_PYSR.md
@@ -1,0 +1,57 @@
+# PROMETHEUS Optional PySR Execution
+
+Status: v0.1 implementation plan.
+
+This tranche prepares the next step after the MVP linear fallback: optional real PySR execution behind the same `EquationCandidate` artifact contract.
+
+## Position
+
+Real PySR execution must be optional at platform level until Julia, PySR, and SymbolicRegression.jl runtime posture are pinned.
+
+The platform contract remains stable:
+
+- emit `EquationCandidate`;
+- include dataset URI and SHA-256 content hash;
+- include method family, implementation mode, fit metric, complexity, units status, promotion state, and non-authority declaration;
+- never admit laws, ontology assertions, policy, or controllers from runtime output alone.
+
+## Execution modes
+
+The current MVP supports:
+
+- `mvp_linear_fallback`
+
+The next implementation should add:
+
+- `optional_pysr`
+
+`optional_pysr` is eligible only when the runtime environment has PySR and its Julia backend available. If unavailable, the tool must fail closed or explicitly fall back to `mvp_linear_fallback` when the caller requested fallback behavior.
+
+## Required PySR output mapping
+
+A PySR run should map to the existing candidate contract:
+
+- best expression or Pareto-front expression to `equationLatex`;
+- normalized mean squared error to `fitMetric`;
+- expression complexity to `complexity`;
+- configured operators to future AgentPlane `operatorLibrary` handoff;
+- package versions to future AgentPlane replay artifact;
+- candidate remains `promotionState: candidate` unless units are inconsistent, in which case it is `rejected`.
+
+## Non-goals
+
+This plan does not make PySR a required dependency for CI.
+
+This plan does not install Julia in platform workflows.
+
+This plan does not create AgentPlane replay artifacts directly.
+
+This plan does not promote candidates to SRAssertionProposal.
+
+## Acceptance criteria for next code tranche
+
+- CLI accepts `--engine mvp_linear_fallback|optional_pysr`.
+- `optional_pysr` attempts to import PySR lazily.
+- Missing PySR fails closed unless fallback is explicitly allowed.
+- Output artifact shape remains backward compatible with the MVP artifact validator.
+- CI continues to validate the fallback path without requiring PySR/Juila.

--- a/tools/prometheus_pysr_mvp.py
+++ b/tools/prometheus_pysr_mvp.py
@@ -53,6 +53,42 @@ def fit_linear_one_feature(rows: list[dict[str, float]], x_name: str, y_name: st
     return slope, intercept, nmse
 
 
+def fit_optional_pysr(rows: list[dict[str, float]], feature: str, target: str, args: argparse.Namespace) -> tuple[str, float, int, str]:
+    try:
+        import numpy as np
+        from pysr import PySRRegressor
+    except Exception as exc:
+        if args.allow_fallback:
+            slope, intercept, nmse = fit_linear_one_feature(rows, feature, target)
+            return f"{target} = {slope:.12g} {feature} + {intercept:.12g}", nmse, 3, "mvp_linear_fallback"
+        raise RuntimeError("optional_pysr requested but PySR is unavailable; use --allow-fallback to permit MVP fallback") from exc
+
+    x_values = np.array([[row[feature]] for row in rows], dtype=float)
+    y_values = np.array([row[target] for row in rows], dtype=float)
+    model = PySRRegressor(
+        niterations=args.pysr_iterations,
+        binary_operators=args.binary_operator,
+        unary_operators=args.unary_operator,
+        deterministic=True,
+        verbosity=0,
+    )
+    model.fit(x_values, y_values)
+    predictions = model.predict(x_values)
+    y_mean = float(np.mean(y_values))
+    mse = float(np.mean((y_values - predictions) ** 2))
+    denom = float(np.mean((y_values - y_mean) ** 2))
+    nmse = mse / denom if denom else 0.0
+    try:
+        latex_body = str(model.latex())
+    except Exception:
+        latex_body = str(model.sympy())
+    try:
+        complexity = int(model.get_best().get("complexity", 1))
+    except Exception:
+        complexity = 1
+    return f"{target} = {latex_body}", nmse, max(1, complexity), "optional_pysr"
+
+
 def units_status(target_unit: str | None, feature_units: dict[str, str], feature: str) -> str:
     if not target_unit or feature not in feature_units:
         return "unknown"
@@ -79,21 +115,26 @@ def build_artifact(args: argparse.Namespace) -> dict[str, Any]:
     if len(features) != 1:
         raise ValueError("MVP supports exactly one feature plus target")
     feature = features[0]
-    slope, intercept, nmse = fit_linear_one_feature(rows, feature, args.target)
+    if args.engine == "optional_pysr":
+        latex, nmse, complexity, implementation_mode = fit_optional_pysr(rows, feature, args.target, args)
+    else:
+        slope, intercept, nmse = fit_linear_one_feature(rows, feature, args.target)
+        latex = f"{args.target} = {slope:.12g} {feature} + {intercept:.12g}"
+        complexity = 3
+        implementation_mode = "mvp_linear_fallback"
     feature_units = {}
     if args.feature_unit:
         for pair in args.feature_unit:
             name, unit = pair.split("=", 1)
             feature_units[name] = unit
     u_status = units_status(args.target_unit, feature_units, feature)
-    latex = f"{args.target} = {slope:.12g} {feature} + {intercept:.12g}"
     candidate_id = f"urn:prometheus:equation-candidate:{sha256_file(data_path)[:16]}"
     return {
         "artifactType": "EquationCandidate",
         "applicationMode": "equation_discovery",
         "candidateId": candidate_id,
         "methodFamily": "pysr",
-        "implementationMode": "mvp_linear_fallback",
+        "implementationMode": implementation_mode,
         "datasetRef": {
             "uri": args.dataset_uri,
             "contentHash": sha256_file(data_path),
@@ -103,7 +144,7 @@ def build_artifact(args: argparse.Namespace) -> dict[str, Any]:
         "features": features,
         "equationLatex": latex,
         "fitMetric": {"name": "nmse", "value": nmse},
-        "complexity": 3,
+        "complexity": complexity,
         "unitsStatus": u_status,
         "promotionState": "candidate" if u_status != "inconsistent" else "rejected",
         "nonAuthorityDeclaration": "This is an EquationCandidate only. It is not a law, ontology assertion, policy, or controller.",
@@ -120,12 +161,17 @@ def main() -> int:
     parser.add_argument("--feature-unit", action="append", default=[])
     parser.add_argument("--generated-at")
     parser.add_argument("--output", required=True)
+    parser.add_argument("--engine", choices=["mvp_linear_fallback", "optional_pysr"], default="mvp_linear_fallback")
+    parser.add_argument("--allow-fallback", action="store_true")
+    parser.add_argument("--pysr-iterations", type=int, default=20)
+    parser.add_argument("--binary-operator", action="append", default=["+", "*", "-", "/"])
+    parser.add_argument("--unary-operator", action="append", default=[])
     args = parser.parse_args()
     artifact = build_artifact(args)
     out = Path(args.output)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(json.dumps({"ok": True, "output": str(out), "unitsStatus": artifact["unitsStatus"]}, sort_keys=True))
+    print(json.dumps({"ok": True, "output": str(out), "unitsStatus": artifact["unitsStatus"], "implementationMode": artifact["implementationMode"]}, sort_keys=True))
     return 0
 
 


### PR DESCRIPTION
## Summary

Adds an optional real-PySR execution path behind the existing PROMETHEUS `EquationCandidate` artifact contract.

This keeps the fallback path as the CI-default and avoids making Julia/PySR a mandatory platform dependency. `optional_pysr` imports PySR lazily and fails closed when PySR is unavailable unless `--allow-fallback` is explicitly provided.

## Changes

- Update `tools/prometheus_pysr_mvp.py`
  - add `--engine mvp_linear_fallback|optional_pysr`
  - add lazy PySR import path
  - add `--allow-fallback`
  - preserve the existing candidate artifact shape
- Add `docs/PROMETHEUS_OPTIONAL_PYSR.md`
- Add `.github/workflows/prometheus-optional-pysr.yml`
  - validates fallback still emits candidate artifacts
  - validates missing PySR fails closed
  - validates explicit fallback from optional PySR

## Boundary

This PR does not require PySR or Julia in CI. It does not create AgentPlane replay artifacts, promote SRAssertionProposal, mutate ontology, admit laws, authorize policy, or create controllers.

## Acceptance criteria

- Existing fallback behavior remains valid.
- `optional_pysr` fails closed when PySR is unavailable.
- `optional_pysr --allow-fallback` emits a valid candidate using the fallback engine.
- Candidate artifact remains backward-compatible with the existing validator.