### PR TITLE
Emit PROMETHEUS SR run artifacts from platform candidates

### DIFF
--- a/.github/workflows/prometheus-sr-run-artifact-emission.yml
+++ b/.github/workflows/prometheus-sr-run-artifact-emission.yml
@@ -1,0 +1,59 @@
+name: prometheus-sr-run-artifact-emission
+
+on:
+  pull_request:
+    paths:
+      - "tools/prometheus_pysr_mvp.py"
+      - "tools/prometheus_emit_sr_run_artifact.py"
+      - "tools/validate_prometheus_sr_run_artifact.py"
+      - "tests/fixtures/prometheus/**"
+      - "docs/PROMETHEUS_SR_RUN_ARTIFACT_EMISSION.md"
+      - ".github/workflows/prometheus-sr-run-artifact-emission.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "tools/prometheus_pysr_mvp.py"
+      - "tools/prometheus_emit_sr_run_artifact.py"
+      - "tools/validate_prometheus_sr_run_artifact.py"
+      - "tests/fixtures/prometheus/**"
+      - "docs/PROMETHEUS_SR_RUN_ARTIFACT_EMISSION.md"
+      - ".github/workflows/prometheus-sr-run-artifact-emission.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-prometheus-sr-run-artifact-emission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install units dependency
+        run: python3 -m pip install sympy
+      - name: Emit candidate and run artifact
+        run: |
+          mkdir -p build/prometheus/sr-run-artifact
+          python3 tools/prometheus_pysr_mvp.py \
+            --engine mvp_linear_fallback \
+            --data tests/fixtures/prometheus/pysr-mvp-linear.csv \
+            --target y \
+            --dataset-uri urn:dataset:prometheus:pysr-mvp-linear \
+            --target-unit meter \
+            --feature-unit x=meter \
+            --generated-at 2026-05-27T19:00:00Z \
+            --output build/prometheus/sr-run-artifact/equation-candidate.json
+          python3 tools/prometheus_emit_sr_run_artifact.py \
+            --candidate build/prometheus/sr-run-artifact/equation-candidate.json \
+            --run-id urn:prometheus:sr-run:pysr-mvp-linear:001 \
+            --chronos-carrier-id urn:chronos:carrier:prometheus:pysr-mvp-linear \
+            --random-seed 42 \
+            --issued-at 2026-05-27T19:00:01Z \
+            --output build/prometheus/sr-run-artifact/sr-run-artifact.json
+      - name: Validate run artifact
+        run: |
+          python3 tools/validate_prometheus_sr_run_artifact.py \
+            build/prometheus/sr-run-artifact/sr-run-artifact.json

--- a/docs/PROMETHEUS_SR_RUN_ARTIFACT_EMISSION.md
+++ b/docs/PROMETHEUS_SR_RUN_ARTIFACT_EMISSION.md
@@ -1,0 +1,37 @@
+# PROMETHEUS SR Run Artifact Emission
+
+Status: v0.1 platform evidence handoff.
+
+This tranche connects Prophet Platform candidate emission to the AgentPlane evidence spine by emitting an AgentPlane-compatible `SRRunArtifact` from a platform `EquationCandidate`.
+
+## Boundary
+
+This is evidence plumbing only.
+
+The emitted run artifact is not an ontology mutation, SRAssertionProposal, policy admission, controller signal, or deployment authorization. It records how the candidate was produced so AgentPlane and CHRONOS can evaluate replay and governance state.
+
+## Flow
+
+1. `tools/prometheus_pysr_mvp.py` emits `EquationCandidate`.
+2. `tools/prometheus_emit_sr_run_artifact.py` wraps the candidate into `SRRunArtifact`.
+3. `tools/validate_prometheus_sr_run_artifact.py` verifies required fields and recomputes `replayHash`.
+
+## Replay hash
+
+The replay hash uses the same canonical field order established in AgentPlane:
+
+- datasetRef.uri
+- datasetRef.contentHash
+- methodFamily
+- operatorLibrary.binaryOperators sorted ascending
+- operatorLibrary.unaryOperators sorted ascending
+- operatorLibrary.customOperators sorted ascending
+- randomSeed
+- runtimeEnvironment.packages sorted by name, then version
+- candidateRefs[*].equationLatex sorted ascending
+
+Canonical serialization is UTF-8 JSON with lexicographically sorted keys and no insignificant whitespace.
+
+## Non-authority
+
+`controlAuthority` is always false. The platform may emit evidence, but does not turn symbolic-regression output into runtime authority.

--- a/tools/prometheus_emit_sr_run_artifact.py
+++ b/tools/prometheus_emit_sr_run_artifact.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+HASH_FIELDS = [
+    "datasetRef.uri",
+    "datasetRef.contentHash",
+    "methodFamily",
+    "operatorLibrary.binaryOperators",
+    "operatorLibrary.unaryOperators",
+    "operatorLibrary.customOperators",
+    "randomSeed",
+    "runtimeEnvironment.packages",
+    "candidateRefs[*].equationLatex",
+]
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def package_versions() -> list[dict[str, str]]:
+    packages = [{"name": "python", "version": sys.version.split()[0]}]
+    try:
+        import sympy
+        packages.append({"name": "sympy", "version": str(sympy.__version__)})
+    except Exception:
+        packages.append({"name": "sympy", "version": "unavailable"})
+    return packages
+
+
+def canonical_hash_payload(run: dict[str, Any]) -> bytes:
+    payload = {
+        "datasetRef": {
+            "uri": run["datasetRef"]["uri"],
+            "contentHash": run["datasetRef"]["contentHash"],
+        },
+        "methodFamily": run["methodFamily"],
+        "operatorLibrary": {
+            "binaryOperators": sorted(run["operatorLibrary"].get("binaryOperators", [])),
+            "unaryOperators": sorted(run["operatorLibrary"].get("unaryOperators", [])),
+            "customOperators": sorted(run["operatorLibrary"].get("customOperators", [])),
+        },
+        "randomSeed": run["randomSeed"],
+        "runtimeEnvironment": {
+            "packages": sorted(run["runtimeEnvironment"].get("packages", []), key=lambda p: (p.get("name", ""), p.get("version", "")))
+        },
+        "candidateRefs": sorted([c["equationLatex"] for c in run.get("candidateRefs", [])]),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def build_run_artifact(candidate: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    dataset_ref = candidate["datasetRef"]
+    candidate_ref = {
+        "candidateId": candidate["candidateId"],
+        "equationLatex": candidate["equationLatex"],
+        "nmse": candidate["fitMetric"]["value"],
+        "complexity": candidate["complexity"],
+        "unitsStatus": candidate["unitsStatus"],
+        "promotionState": candidate["promotionState"],
+    }
+    run = {
+        "runId": args.run_id,
+        "datasetRef": {
+            "uri": dataset_ref["uri"],
+            "contentHash": dataset_ref["contentHash"],
+            "hashAlgorithm": dataset_ref.get("hashAlgorithm", "sha256"),
+        },
+        "methodFamily": candidate.get("methodFamily", "pysr"),
+        "operatorLibrary": {
+            "binaryOperators": args.binary_operator,
+            "unaryOperators": args.unary_operator,
+            "customOperators": args.custom_operator,
+        },
+        "randomSeed": args.random_seed,
+        "runtimeEnvironment": {
+            "packages": package_versions(),
+            "implementationMode": candidate.get("implementationMode", "unknown"),
+        },
+        "replayHash": {
+            "value": "0" * 64,
+            "algorithm": "sha256",
+            "coveredFields": HASH_FIELDS,
+        },
+        "controlAuthority": False,
+        "candidateRefs": [candidate_ref],
+        "chronosCarrierId": args.chronos_carrier_id,
+        "issuedAt": args.issued_at or now_utc(),
+    }
+    run["replayHash"]["value"] = hashlib.sha256(canonical_hash_payload(run)).hexdigest()
+    return run
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit AgentPlane-compatible PROMETHEUS SRRunArtifact")
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--chronos-carrier-id", required=True)
+    parser.add_argument("--random-seed", type=int)
+    parser.add_argument("--binary-operator", action="append", default=["+", "*", "-", "/"])
+    parser.add_argument("--unary-operator", action="append", default=[])
+    parser.add_argument("--custom-operator", action="append", default=[])
+    parser.add_argument("--issued-at")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    candidate = load_json(Path(args.candidate))
+    artifact = build_run_artifact(candidate, args)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(artifact, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"ok": True, "output": str(out), "replayHash": artifact["replayHash"]["value"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_prometheus_sr_run_artifact.py
+++ b/tools/validate_prometheus_sr_run_artifact.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+HASH_FIELDS = [
+    "datasetRef.uri",
+    "datasetRef.contentHash",
+    "methodFamily",
+    "operatorLibrary.binaryOperators",
+    "operatorLibrary.unaryOperators",
+    "operatorLibrary.customOperators",
+    "randomSeed",
+    "runtimeEnvironment.packages",
+    "candidateRefs[*].equationLatex",
+]
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        fail("root must be object")
+    return data
+
+
+def hex64(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(c in "0123456789abcdef" for c in value)
+
+
+def canonical_payload(run: dict[str, Any]) -> bytes:
+    payload = {
+        "datasetRef": {
+            "uri": run["datasetRef"]["uri"],
+            "contentHash": run["datasetRef"]["contentHash"],
+        },
+        "methodFamily": run["methodFamily"],
+        "operatorLibrary": {
+            "binaryOperators": sorted(run["operatorLibrary"].get("binaryOperators", [])),
+            "unaryOperators": sorted(run["operatorLibrary"].get("unaryOperators", [])),
+            "customOperators": sorted(run["operatorLibrary"].get("customOperators", [])),
+        },
+        "randomSeed": run["randomSeed"],
+        "runtimeEnvironment": {
+            "packages": sorted(run["runtimeEnvironment"].get("packages", []), key=lambda p: (p.get("name", ""), p.get("version", "")))
+        },
+        "candidateRefs": sorted([c["equationLatex"] for c in run.get("candidateRefs", [])]),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def validate(run: dict[str, Any]) -> None:
+    for key in ["runId", "datasetRef", "methodFamily", "operatorLibrary", "randomSeed", "runtimeEnvironment", "replayHash", "controlAuthority", "candidateRefs", "chronosCarrierId", "issuedAt"]:
+        if key not in run:
+            fail(f"missing {key}")
+    if run["methodFamily"] != "pysr":
+        fail("methodFamily must be pysr for this platform emitter")
+    ds = run["datasetRef"]
+    if not isinstance(ds, dict) or not ds.get("uri") or not hex64(ds.get("contentHash")) or ds.get("hashAlgorithm") != "sha256":
+        fail("invalid datasetRef")
+    if not isinstance(run["operatorLibrary"].get("binaryOperators"), list):
+        fail("operatorLibrary.binaryOperators must be array")
+    if not isinstance(run["operatorLibrary"].get("unaryOperators"), list):
+        fail("operatorLibrary.unaryOperators must be array")
+    if not isinstance(run["operatorLibrary"].get("customOperators"), list):
+        fail("operatorLibrary.customOperators must be array")
+    if run["controlAuthority"] is not False:
+        fail("controlAuthority must be false")
+    candidates = run["candidateRefs"]
+    if not isinstance(candidates, list) or not candidates:
+        fail("candidateRefs must be non-empty array")
+    for candidate in candidates:
+        if candidate.get("unitsStatus") == "inconsistent" and candidate.get("promotionState") not in {"candidate", "rejected"}:
+            fail("inconsistent units cannot be proposed/admitted")
+    replay = run["replayHash"]
+    if replay.get("algorithm") != "sha256" or replay.get("coveredFields") != HASH_FIELDS or not hex64(replay.get("value")):
+        fail("invalid replayHash")
+    computed = hashlib.sha256(canonical_payload(run)).hexdigest()
+    if computed != replay["value"]:
+        fail(f"replayHash mismatch: computed {computed}, expected {replay['value']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("artifact")
+    args = parser.parse_args()
+    run = load(Path(args.artifact))
+    validate(run)
+    print(json.dumps({"valid": True, "replayHash": run["replayHash"]["value"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Connects Prophet Platform PROMETHEUS `EquationCandidate` output to the AgentPlane SR evidence spine by emitting an AgentPlane-compatible `SRRunArtifact`.

This is evidence plumbing only. It does not promote SRAssertionProposal, mutate ontology, authorize policy, or create controller authority.

## Changes

- Add `tools/prometheus_emit_sr_run_artifact.py`
- Add `tools/validate_prometheus_sr_run_artifact.py`
- Add `docs/PROMETHEUS_SR_RUN_ARTIFACT_EMISSION.md`
- Add focused workflow `.github/workflows/prometheus-sr-run-artifact-emission.yml`

## Boundary

`controlAuthority` is always false. The platform can emit replay evidence, but the run artifact remains governed evidence for AgentPlane / CHRONOS review.

## Acceptance criteria

- Generate `EquationCandidate` through existing fallback engine.
- Wrap candidate into `SRRunArtifact`.
- Compute content-addressed SHA-256 replay hash using AgentPlane canonical field order.
- Validate replay hash by recomputation.
- Keep output non-authoritative and candidate-only.