### PR TITLE
Emit PROMETHEUS SINDy run artifacts

### DIFF
--- a/.github/workflows/prometheus-sindy-run-artifact-emission.yml
+++ b/.github/workflows/prometheus-sindy-run-artifact-emission.yml
@@ -1,0 +1,52 @@
+name: prometheus-sindy-run-artifact-emission
+
+on:
+  pull_request:
+    paths:
+      - "tools/prometheus_sindy_fast_path.py"
+      - "tools/prometheus_emit_sr_run_artifact.py"
+      - "tools/validate_prometheus_sr_run_artifact.py"
+      - "tests/fixtures/prometheus/sindy-fast-path-linear.csv"
+      - ".github/workflows/prometheus-sindy-run-artifact-emission.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "tools/prometheus_sindy_fast_path.py"
+      - "tools/prometheus_emit_sr_run_artifact.py"
+      - "tools/validate_prometheus_sr_run_artifact.py"
+      - "tests/fixtures/prometheus/sindy-fast-path-linear.csv"
+      - ".github/workflows/prometheus-sindy-run-artifact-emission.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-prometheus-sindy-run-artifact-emission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Emit SINDy candidate and run artifact
+        run: |
+          mkdir -p build/prometheus/sindy-run-artifact
+          python3 tools/prometheus_sindy_fast_path.py \
+            --data tests/fixtures/prometheus/sindy-fast-path-linear.csv \
+            --time-column t \
+            --value-column q \
+            --dataset-uri urn:dataset:prometheus:sindy-fast-path-linear \
+            --generated-at 2026-05-27T20:00:00Z \
+            --output build/prometheus/sindy-run-artifact/platform-dynamics-candidate.json
+          python3 tools/prometheus_emit_sr_run_artifact.py \
+            --candidate build/prometheus/sindy-run-artifact/platform-dynamics-candidate.json \
+            --run-id urn:prometheus:sr-run:sindy-fast-path-linear:001 \
+            --chronos-carrier-id urn:chronos:carrier:prometheus:sindy-fast-path-linear \
+            --issued-at 2026-05-27T20:00:01Z \
+            --output build/prometheus/sindy-run-artifact/sr-run-artifact.json
+      - name: Validate SINDy run artifact
+        run: |
+          python3 tools/validate_prometheus_sr_run_artifact.py \
+            build/prometheus/sindy-run-artifact/sr-run-artifact.json

--- a/tools/validate_prometheus_sr_run_artifact.py
+++ b/tools/validate_prometheus_sr_run_artifact.py
@@ -18,6 +18,7 @@ HASH_FIELDS = [
     "runtimeEnvironment.packages",
     "candidateRefs[*].equationLatex",
 ]
+METHOD_FAMILIES = {"pysr", "sindy"}
 
 
 def fail(message: str) -> None:
@@ -60,8 +61,8 @@ def validate(run: dict[str, Any]) -> None:
     for key in ["runId", "datasetRef", "methodFamily", "operatorLibrary", "randomSeed", "runtimeEnvironment", "replayHash", "controlAuthority", "candidateRefs", "chronosCarrierId", "issuedAt"]:
         if key not in run:
             fail(f"missing {key}")
-    if run["methodFamily"] != "pysr":
-        fail("methodFamily must be pysr for this platform emitter")
+    if run["methodFamily"] not in METHOD_FAMILIES:
+        fail("methodFamily must be pysr or sindy for this platform emitter")
     ds = run["datasetRef"]
     if not isinstance(ds, dict) or not ds.get("uri") or not hex64(ds.get("contentHash")) or ds.get("hashAlgorithm") != "sha256":
         fail("invalid datasetRef")
@@ -73,6 +74,8 @@ def validate(run: dict[str, Any]) -> None:
         fail("operatorLibrary.customOperators must be array")
     if run["controlAuthority"] is not False:
         fail("controlAuthority must be false")
+    if run["methodFamily"] == "sindy" and run["controlAuthority"] is not False:
+        fail("sindy controlAuthority must be false")
     candidates = run["candidateRefs"]
     if not isinstance(candidates, list) or not candidates:
         fail("candidateRefs must be non-empty array")


### PR DESCRIPTION
## Summary

Extends the Prophet Platform SRRunArtifact validation path so SINDy platform-dynamics candidates can be wrapped into AgentPlane-compatible run artifacts.

This follows the SINDy fast-path candidate emitter and preserves the same evidence-only posture.

## Changes

- Update `tools/validate_prometheus_sr_run_artifact.py` to allow `methodFamily: sindy` in addition to `pysr`.
- Add focused workflow `.github/workflows/prometheus-sindy-run-artifact-emission.yml`.
- Workflow emits a `PlatformDynamicsCandidate`, wraps it in `SRRunArtifact`, and validates replay hash recomputation.

## Boundary

SINDy output remains evidence only. `controlAuthority` is required to be false. This PR does not create runtime authority or production actions.

## Acceptance criteria

- SINDy platform-dynamics candidate can produce an SRRunArtifact.
- Replay hash validates by recomputation.
- `methodFamily: sindy` is accepted by the platform run-artifact validator.
- `controlAuthority: false` remains enforced.