### PR TITLE
Add consolidated PROMETHEUS local demo runner

### DIFF
--- a/.github/workflows/prometheus-local-demo.yml
+++ b/.github/workflows/prometheus-local-demo.yml
@@ -1,0 +1,51 @@
+name: prometheus-local-demo
+
+on:
+  pull_request:
+    paths:
+      - "tools/run_prometheus_local_demo.py"
+      - "tools/validate_prometheus_local_demo.py"
+      - "tools/prometheus_pysr_mvp.py"
+      - "tools/prometheus_sindy_fast_path.py"
+      - "tools/prometheus_emit_sr_run_artifact.py"
+      - "tools/validate_prometheus_sr_run_artifact.py"
+      - "tests/fixtures/prometheus/**"
+      - "docs/PROMETHEUS_LOCAL_DEMO.md"
+      - ".github/workflows/prometheus-local-demo.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "tools/run_prometheus_local_demo.py"
+      - "tools/validate_prometheus_local_demo.py"
+      - "tools/prometheus_pysr_mvp.py"
+      - "tools/prometheus_sindy_fast_path.py"
+      - "tools/prometheus_emit_sr_run_artifact.py"
+      - "tools/validate_prometheus_sr_run_artifact.py"
+      - "tests/fixtures/prometheus/**"
+      - "docs/PROMETHEUS_LOCAL_DEMO.md"
+      - ".github/workflows/prometheus-local-demo.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-prometheus-local-demo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install units dependency
+        run: python3 -m pip install sympy
+      - name: Run local PROMETHEUS demo
+        run: |
+          python3 tools/run_prometheus_local_demo.py \
+            --output-dir build/prometheus/local-demo \
+            --issued-at 2026-05-27T21:00:00Z
+      - name: Validate local PROMETHEUS demo manifest
+        run: |
+          python3 tools/validate_prometheus_local_demo.py \
+            build/prometheus/local-demo/manifest.json

--- a/docs/PROMETHEUS_LOCAL_DEMO.md
+++ b/docs/PROMETHEUS_LOCAL_DEMO.md
@@ -1,0 +1,38 @@
+# PROMETHEUS Local Demo Runner
+
+Status: v0.1 consolidated platform demo.
+
+This runner makes the PROMETHEUS MVP legible and repeatable. It emits both current platform paths:
+
+- PySR-style equation discovery through the deterministic fallback engine.
+- SINDy-style platform dynamics discovery through the fast-path time-series emitter.
+
+Each path produces a candidate artifact and an AgentPlane-compatible `SRRunArtifact`. The runner also writes a manifest with artifact paths and SHA-256 hashes.
+
+## Boundary
+
+The local demo emits evidence only. It does not create laws, ontology assertions, policies, controllers, or deployment authorizations.
+
+`controlAuthority` is false for both runs.
+
+## Usage
+
+Run:
+
+`python3 tools/run_prometheus_local_demo.py --output-dir build/prometheus/local-demo --issued-at 2026-05-27T21:00:00Z`
+
+Then validate:
+
+`python3 tools/validate_prometheus_local_demo.py build/prometheus/local-demo/manifest.json`
+
+## Outputs
+
+The runner writes:
+
+- `pysr/equation-candidate.json`
+- `pysr/sr-run-artifact.json`
+- `sindy/platform-dynamics-candidate.json`
+- `sindy/sr-run-artifact.json`
+- `manifest.json`
+
+The manifest records artifact hashes so downstream review can verify local-demo integrity.

--- a/tools/run_prometheus_local_demo.py
+++ b/tools/run_prometheus_local_demo.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def run_command(args: list[str]) -> None:
+    subprocess.run(args, check=True)
+
+
+def artifact_record(kind: str, path: Path) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "path": str(path),
+        "sha256": sha256_file(path),
+    }
+
+
+def build_manifest(output_dir: Path, issued_at: str, artifacts: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "manifestVersion": "0.1.0",
+        "kind": "PrometheusLocalDemoManifest",
+        "issuedAt": issued_at,
+        "nonAuthorityDeclaration": "PROMETHEUS local demo artifacts are evidence only. They are not laws, ontology assertions, policies, controllers, or deployment authorizations.",
+        "outputDir": str(output_dir),
+        "artifacts": artifacts,
+        "runs": [
+            {
+                "applicationMode": "equation_discovery",
+                "methodFamily": "pysr",
+                "candidateArtifact": str(output_dir / "pysr" / "equation-candidate.json"),
+                "runArtifact": str(output_dir / "pysr" / "sr-run-artifact.json"),
+                "controlAuthority": False,
+            },
+            {
+                "applicationMode": "platform_dynamics",
+                "methodFamily": "sindy",
+                "candidateArtifact": str(output_dir / "sindy" / "platform-dynamics-candidate.json"),
+                "runArtifact": str(output_dir / "sindy" / "sr-run-artifact.json"),
+                "controlAuthority": False,
+            },
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run consolidated PROMETHEUS local demo")
+    parser.add_argument("--output-dir", default="build/prometheus/local-demo")
+    parser.add_argument("--issued-at", default="2026-05-27T21:00:00Z")
+    args = parser.parse_args()
+
+    root = Path.cwd()
+    output_dir = Path(args.output_dir)
+    pysr_dir = output_dir / "pysr"
+    sindy_dir = output_dir / "sindy"
+    pysr_dir.mkdir(parents=True, exist_ok=True)
+    sindy_dir.mkdir(parents=True, exist_ok=True)
+
+    pysr_candidate = pysr_dir / "equation-candidate.json"
+    pysr_run = pysr_dir / "sr-run-artifact.json"
+    sindy_candidate = sindy_dir / "platform-dynamics-candidate.json"
+    sindy_run = sindy_dir / "sr-run-artifact.json"
+
+    run_command([
+        sys.executable,
+        "tools/prometheus_pysr_mvp.py",
+        "--engine",
+        "mvp_linear_fallback",
+        "--data",
+        "tests/fixtures/prometheus/pysr-mvp-linear.csv",
+        "--target",
+        "y",
+        "--dataset-uri",
+        "urn:dataset:prometheus:pysr-mvp-linear",
+        "--target-unit",
+        "meter",
+        "--feature-unit",
+        "x=meter",
+        "--generated-at",
+        args.issued_at,
+        "--output",
+        str(pysr_candidate),
+    ])
+
+    run_command([
+        sys.executable,
+        "tools/prometheus_emit_sr_run_artifact.py",
+        "--candidate",
+        str(pysr_candidate),
+        "--run-id",
+        "urn:prometheus:sr-run:pysr-local-demo:001",
+        "--chronos-carrier-id",
+        "urn:chronos:carrier:prometheus:local-demo:pysr",
+        "--random-seed",
+        "42",
+        "--issued-at",
+        args.issued_at,
+        "--output",
+        str(pysr_run),
+    ])
+
+    run_command([
+        sys.executable,
+        "tools/prometheus_sindy_fast_path.py",
+        "--data",
+        "tests/fixtures/prometheus/sindy-fast-path-linear.csv",
+        "--time-column",
+        "t",
+        "--value-column",
+        "q",
+        "--dataset-uri",
+        "urn:dataset:prometheus:sindy-fast-path-linear",
+        "--generated-at",
+        args.issued_at,
+        "--output",
+        str(sindy_candidate),
+    ])
+
+    run_command([
+        sys.executable,
+        "tools/prometheus_emit_sr_run_artifact.py",
+        "--candidate",
+        str(sindy_candidate),
+        "--run-id",
+        "urn:prometheus:sr-run:sindy-local-demo:001",
+        "--chronos-carrier-id",
+        "urn:chronos:carrier:prometheus:local-demo:sindy",
+        "--issued-at",
+        args.issued_at,
+        "--output",
+        str(sindy_run),
+    ])
+
+    artifacts = [
+        artifact_record("EquationCandidate", pysr_candidate),
+        artifact_record("SRRunArtifact", pysr_run),
+        artifact_record("PlatformDynamicsCandidate", sindy_candidate),
+        artifact_record("SRRunArtifact", sindy_run),
+    ]
+    manifest = build_manifest(output_dir, args.issued_at, artifacts)
+    manifest_path = output_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(json.dumps({"ok": True, "manifest": str(manifest_path), "artifactCount": len(artifacts)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_prometheus_local_demo.py
+++ b/tools/validate_prometheus_local_demo.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        fail(f"expected object: {path}")
+    return data
+
+
+def validate_candidate(path: Path, expected_kind: str, expected_method: str) -> None:
+    data = load(path)
+    if data.get("artifactType") != expected_kind:
+        fail(f"{path}: expected artifactType {expected_kind}")
+    if data.get("methodFamily") != expected_method:
+        fail(f"{path}: expected methodFamily {expected_method}")
+    if data.get("promotionState") not in {"candidate", "rejected"}:
+        fail(f"{path}: invalid promotionState")
+    if expected_method == "sindy" and data.get("controlAuthority") is not False:
+        fail(f"{path}: SINDy controlAuthority must be false")
+    if "not" not in data.get("nonAuthorityDeclaration", ""):
+        fail(f"{path}: missing non-authority declaration")
+
+
+def validate_run_artifact(path: Path, expected_method: str) -> None:
+    data = load(path)
+    if data.get("methodFamily") != expected_method:
+        fail(f"{path}: expected methodFamily {expected_method}")
+    if data.get("controlAuthority") is not False:
+        fail(f"{path}: controlAuthority must be false")
+    replay = data.get("replayHash", {})
+    if replay.get("algorithm") != "sha256" or len(replay.get("value", "")) != 64:
+        fail(f"{path}: invalid replayHash")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("manifest")
+    args = parser.parse_args()
+
+    manifest_path = Path(args.manifest)
+    manifest = load(manifest_path)
+    if manifest.get("kind") != "PrometheusLocalDemoManifest":
+        fail("manifest kind mismatch")
+    if "not laws" not in manifest.get("nonAuthorityDeclaration", ""):
+        fail("manifest missing non-authority declaration")
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list) or len(artifacts) != 4:
+        fail("manifest must contain exactly four artifacts")
+    for artifact in artifacts:
+        path = Path(artifact.get("path", ""))
+        if not path.exists():
+            fail(f"missing artifact: {path}")
+        if sha256_file(path) != artifact.get("sha256"):
+            fail(f"hash mismatch: {path}")
+    runs = manifest.get("runs")
+    if not isinstance(runs, list) or len(runs) != 2:
+        fail("manifest must contain exactly two runs")
+    run_by_method = {run.get("methodFamily"): run for run in runs}
+    if set(run_by_method) != {"pysr", "sindy"}:
+        fail("manifest must include pysr and sindy runs")
+    for method, run in run_by_method.items():
+        if run.get("controlAuthority") is not False:
+            fail(f"{method}: controlAuthority must be false")
+    validate_candidate(Path(run_by_method["pysr"]["candidateArtifact"]), "EquationCandidate", "pysr")
+    validate_run_artifact(Path(run_by_method["pysr"]["runArtifact"]), "pysr")
+    validate_candidate(Path(run_by_method["sindy"]["candidateArtifact"]), "PlatformDynamicsCandidate", "sindy")
+    validate_run_artifact(Path(run_by_method["sindy"]["runArtifact"]), "sindy")
+
+    print(json.dumps({"valid": True, "manifest": str(manifest_path), "artifactCount": len(artifacts)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a consolidated local PROMETHEUS demo runner that executes the current platform MVP paths and emits a manifest.

The runner executes:

- PySR-style equation discovery through the deterministic fallback engine.
- SINDy-style platform dynamics discovery through the fast-path time-series emitter.
- SRRunArtifact emission for both paths.
- Manifest generation with artifact paths and SHA-256 hashes.

## Changes

- Add `tools/run_prometheus_local_demo.py`
- Add `tools/validate_prometheus_local_demo.py`
- Add `docs/PROMETHEUS_LOCAL_DEMO.md`
- Add focused workflow `.github/workflows/prometheus-local-demo.yml`

## Boundary

This is a local evidence demo only. `controlAuthority` remains false for both runs.

## Acceptance criteria

- One command emits both current PROMETHEUS platform paths.
- Produces candidate artifacts, SRRunArtifacts, and manifest.
- Manifest records artifact paths and SHA-256 hashes.
- Validator confirms manifest integrity, method families, and evidence-only posture.
- Focused workflow validates the local demo.