### PR TITLE
Emit PROMETHEUS JSON-LD semantic handoff artifacts

### DIFF
--- a/.github/workflows/prometheus-jsonld.yml
+++ b/.github/workflows/prometheus-jsonld.yml
@@ -1,0 +1,52 @@
+name: prometheus-jsonld
+
+on:
+  pull_request:
+    paths:
+      - "tools/emit_prometheus_jsonld_review.py"
+      - "tools/validate_prometheus_jsonld_review.py"
+      - "tools/run_prometheus_local_demo.py"
+      - "docs/PROMETHEUS_JSONLD_REVIEW.md"
+      - ".github/workflows/prometheus-jsonld.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "tools/emit_prometheus_jsonld_review.py"
+      - "tools/validate_prometheus_jsonld_review.py"
+      - "tools/run_prometheus_local_demo.py"
+      - "docs/PROMETHEUS_JSONLD_REVIEW.md"
+      - ".github/workflows/prometheus-jsonld.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-prometheus-jsonld:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install units dependency
+        run: python3 -m pip install sympy
+      - name: Generate PROMETHEUS local demo artifacts
+        run: |
+          python3 tools/run_prometheus_local_demo.py \
+            --output-dir build/prometheus/jsonld \
+            --issued-at 2026-05-27T22:30:00Z
+      - name: Emit JSON-LD artifact
+        run: |
+          python3 tools/emit_prometheus_jsonld_review.py \
+            --candidate build/prometheus/jsonld/pysr/equation-candidate.json \
+            --run-artifact build/prometheus/jsonld/pysr/sr-run-artifact.json \
+            --review-id urn:prometheus:jsonld:pysr-local-demo:001 \
+            --review-surface automated_shacl_gate \
+            --issued-at 2026-05-27T22:31:00Z \
+            --output build/prometheus/jsonld/pysr/sr.jsonld
+      - name: Validate JSON-LD artifact
+        run: |
+          python3 tools/validate_prometheus_jsonld_review.py \
+            build/prometheus/jsonld/pysr/sr.jsonld

--- a/docs/PROMETHEUS_JSONLD_REVIEW.md
+++ b/docs/PROMETHEUS_JSONLD_REVIEW.md
@@ -1,0 +1,50 @@
+# PROMETHEUS JSON-LD Review Artifact
+
+Status: v0.1 semantic review handoff.
+
+This tranche emits an Ontogenesis-compatible JSON-LD review artifact from a PROMETHEUS candidate and an SRRunArtifact.
+
+## Boundary
+
+The JSON-LD artifact is a semantic review proposal only.
+
+It does not mutate Ontogenesis.
+
+It does not require WebProtege.
+
+It does not create a law.
+
+It does not create policy or runtime authority.
+
+## Inputs
+
+- Platform candidate artifact.
+- AgentPlane-compatible SRRunArtifact.
+
+## Output
+
+The output JSON-LD uses `@type: sr:SRAssertionProposal` and includes:
+
+- `sr:vocabVersion`
+- `sr:vocabularyPromotionState`
+- dataset evidence
+- fit metric
+- complexity metric
+- dimensional analysis
+- evidence replay reference
+- discovery method reference
+- promotion status
+- review state
+- semantic review surface
+- non-authority declaration
+- equation text
+
+## Review surfaces
+
+The default review surface is `automated_shacl_gate`, but the CLI accepts another configured review surface. WebProtege remains optional.
+
+## Validation
+
+Run:
+
+`python3 tools/validate_prometheus_jsonld_review.py build/prometheus/jsonld-review/sr-review.jsonld`

--- a/tools/emit_prometheus_jsonld_review.py
+++ b/tools/emit_prometheus_jsonld_review.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SR = "https://socioprophet.github.io/ontogenesis/symbolic-regression#"
+
+UNITS_RESOURCE = {
+    "consistent": "sr:UnitsConsistent",
+    "inconsistent": "sr:UnitsInconsistent",
+    "unknown": "sr:UnitsUnknown",
+    "unchecked": "sr:UnitsUnchecked",
+}
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def find_candidate_ref(run_artifact: dict[str, Any], candidate_id: str) -> dict[str, Any]:
+    for ref in run_artifact.get("candidateRefs", []):
+        if ref.get("candidateId") == candidate_id:
+            return ref
+    raise ValueError("run artifact does not reference candidateId")
+
+
+def build_jsonld(candidate: dict[str, Any], run_artifact: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    candidate_ref = find_candidate_ref(run_artifact, candidate["candidateId"])
+    units_status = candidate_ref["unitsStatus"]
+    promotion_state = "sr:ProposalCandidate" if units_status == "inconsistent" else "sr:ProposalProposed"
+    state = "sr:AdmissionBlocked" if units_status == "inconsistent" else "sr:AdmissionPendingReview"
+    dataset_ref = run_artifact["datasetRef"]
+    return {
+        "@context": {
+            "sr": SR,
+            "prov": "http://www.w3.org/ns/prov#",
+            "xsd": "http://www.w3.org/2001/XMLSchema#"
+        },
+        "@id": args.review_id,
+        "@type": "sr:SRAssertionProposal",
+        "sr:vocabVersion": "0.1.0",
+        "sr:vocabularyPromotionState": {"@id": "sr:VocabularyDraftState"},
+        "sr:hasDatasetEvidence": {
+            "@id": f"{args.review_id}/dataset",
+            "@type": "sr:DatasetEvidenceRef",
+            "sr:datasetUri": dataset_ref["uri"],
+            "sr:metricName": "sha256",
+            "sr:metricValue": dataset_ref["contentHash"]
+        },
+        "sr:hasFitMetric": {
+            "@id": f"{args.review_id}/fit-metric",
+            "@type": "sr:FitMetric",
+            "sr:metricName": "nmse",
+            "sr:metricValue": candidate_ref["nmse"]
+        },
+        "sr:hasComplexityMetric": {
+            "@id": f"{args.review_id}/complexity",
+            "@type": "sr:ComplexityMetric",
+            "sr:metricName": "complexity",
+            "sr:metricValue": candidate_ref["complexity"]
+        },
+        "sr:hasDimensionalAnalysis": {
+            "@id": f"{args.review_id}/dimensional-analysis",
+            "@type": "sr:DimensionalAnalysisResult",
+            "sr:hasUnitsStatus": {"@id": UNITS_RESOURCE[units_status]}
+        },
+        "sr:hasEvidenceReplay": {
+            "@id": run_artifact["runId"],
+            "@type": "sr:EvidenceReplayRef",
+            "sr:metricName": "replayHash",
+            "sr:metricValue": run_artifact["replayHash"]["value"]
+        },
+        "sr:hasDiscoveryMethod": {
+            "@id": f"{args.review_id}/method",
+            "@type": "sr:DiscoveryMethodRef",
+            "sr:methodFamily": run_artifact["methodFamily"]
+        },
+        "sr:hasPromotionStatus": {"@id": promotion_state},
+        "sr:hasAdmissionState": {"@id": state},
+        "sr:hasSemanticReviewSurface": {
+            "@id": f"{args.review_id}/review-surface",
+            "@type": "sr:SemanticReviewSurface",
+            "sr:reviewSurfaceType": args.review_surface
+        },
+        "sr:nonAuthorityDeclaration": "This JSON-LD artifact is a semantic review proposal only. It does not mutate ontology, create a law, or grant runtime authority.",
+        "sr:hasEquation": candidate_ref["equationLatex"],
+        "prov:generatedAtTime": args.issued_at or now_utc()
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit PROMETHEUS JSON-LD semantic review artifact")
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--run-artifact", required=True)
+    parser.add_argument("--review-id", required=True)
+    parser.add_argument("--review-surface", default="automated_shacl_gate")
+    parser.add_argument("--issued-at")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    candidate = load_json(Path(args.candidate))
+    run_artifact = load_json(Path(args.run_artifact))
+    document = build_jsonld(candidate, run_artifact, args)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"ok": True, "output": str(out), "reviewId": args.review_id}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_prometheus_jsonld_review.py
+++ b/tools/validate_prometheus_jsonld_review.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+REQUIRED_TOP_LEVEL = {
+    "@context",
+    "@id",
+    "@type",
+    "sr:vocabVersion",
+    "sr:vocabularyPromotionState",
+    "sr:hasDatasetEvidence",
+    "sr:hasFitMetric",
+    "sr:hasComplexityMetric",
+    "sr:hasDimensionalAnalysis",
+    "sr:hasEvidenceReplay",
+    "sr:hasDiscoveryMethod",
+    "sr:hasPromotionStatus",
+    "sr:hasAdmissionState",
+    "sr:hasSemanticReviewSurface",
+    "sr:nonAuthorityDeclaration",
+    "sr:hasEquation",
+    "prov:generatedAtTime",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        fail(f"expected JSON object: {path}")
+    return data
+
+
+def id_value(value: Any) -> str:
+    if isinstance(value, dict):
+        return str(value.get("@id", ""))
+    return str(value)
+
+
+def validate(document: dict[str, Any]) -> None:
+    missing = REQUIRED_TOP_LEVEL - set(document)
+    if missing:
+        fail(f"missing fields: {sorted(missing)}")
+    if document["@type"] != "sr:SRAssertionProposal":
+        fail("@type must be sr:SRAssertionProposal")
+    if document["sr:vocabVersion"] != "0.1.0":
+        fail("vocabVersion must be 0.1.0")
+    if id_value(document["sr:vocabularyPromotionState"]) != "sr:VocabularyDraftState":
+        fail("vocabularyPromotionState must be draft")
+    dim = document["sr:hasDimensionalAnalysis"]
+    if not isinstance(dim, dict):
+        fail("dimensional analysis must be object")
+    units = id_value(dim.get("sr:hasUnitsStatus"))
+    if units not in {"sr:UnitsConsistent", "sr:UnitsInconsistent", "sr:UnitsUnknown", "sr:UnitsUnchecked"}:
+        fail("invalid units status")
+    promotion = id_value(document["sr:hasPromotionStatus"])
+    state = id_value(document["sr:hasAdmissionState"])
+    if units == "sr:UnitsInconsistent":
+        if promotion not in {"sr:ProposalCandidate", "sr:ProposalRejected", "sr:ProposalFailureCorpus"}:
+            fail("inconsistent units cannot be proposed/admitted")
+        if state not in {"sr:AdmissionRejected", "sr:AdmissionBlocked"}:
+            fail("inconsistent units cannot be pending/admitted")
+    replay = document["sr:hasEvidenceReplay"]
+    if not isinstance(replay, dict) or not replay.get("@id"):
+        fail("evidence replay ref is required")
+    review_surface = document["sr:hasSemanticReviewSurface"]
+    if not isinstance(review_surface, dict):
+        fail("review surface must be object")
+    surface_type = review_surface.get("sr:reviewSurfaceType")
+    if surface_type not in {"automated_shacl_gate", "git_pr", "prophet_platform_ui", "cli", "sparql_editor", "webprotege"}:
+        fail("invalid review surface")
+    declaration = document["sr:nonAuthorityDeclaration"]
+    if not isinstance(declaration, str) or "does not" not in declaration:
+        fail("missing non-authority declaration")
+    if not isinstance(document["sr:hasEquation"], str) or not document["sr:hasEquation"]:
+        fail("equation string is required")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("document")
+    args = parser.parse_args()
+    document = load_json(Path(args.document))
+    validate(document)
+    print(json.dumps({"valid": True, "document": args.document}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a PROMETHEUS JSON-LD handoff artifact emitter from platform candidate evidence.

This translates a platform candidate plus SRRunArtifact into an Ontogenesis-compatible `sr:SRAssertionProposal` JSON-LD document for semantic review.

## Changes

- Add `tools/emit_prometheus_jsonld_review.py`.
- Add `tools/validate_prometheus_jsonld_review.py`.
- Add `docs/PROMETHEUS_JSONLD_REVIEW.md`.
- Add focused workflow `.github/workflows/prometheus-jsonld.yml`.

## Boundary

This emits an artifact only. It does not mutate Ontogenesis, require WebProtege, create a law, grant final admission, or create runtime authority.

## Acceptance criteria

- Uses existing local demo output as source evidence.
- Emits JSON-LD with `@type: sr:SRAssertionProposal`.
- Includes vocabulary version, draft vocabulary state, dataset evidence, fit metric, complexity metric, dimensional analysis, evidence replay reference, discovery method, review surface, equation text, and non-authority declaration.
- Validates inconsistent-unit promotion boundary.
- Keeps WebProtege optional.