### PR TITLE
contracts: register TritFabric consumption surfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit validate-tritfabric-consumption policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check chronos-evidence-loop-readout-validate lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit validate-tritfabric-consumption policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke validate-svf-agent-contract test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite trustops-art-runner-smoke
 
-validate: validate-repo drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit validate-tritfabric-consumption policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check chronos-evidence-loop-readout-validate lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit validate-tritfabric-consumption policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke validate-svf-agent-contract test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite trustops-art-runner-smoke
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -16,6 +16,9 @@ standards-check:
 
 topology-check:
 	python3 tools/check_transport_topology.py
+
+chronos-evidence-loop-readout-validate:
+	python3 tools/validate_chronos_evidence_loop_readout.py
 
 lattice-surfaces-check:
 	python3 tools/validate_lattice_surfaces.py
@@ -46,33 +49,10 @@ lattice-studio-smoke:
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-local-dev --workspace-ref workspace://demo --atlas-context-ref atlas-context:demo --paas-deployment-ref paas-deployment:demo --output-dir build/lattice-studio/local-dev
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-execution --output-dir build/lattice-studio/execution
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-memory --subject workspace://demo --subject atlas-context:demo --subject paas-deployment:demo --subject lampstand://local-search/demo --subject ontogenesis://lattice-studio/demo --subject execution://demo --subject notebook-plane://lattice-studio --subject workspace-synthesis://demo --link catalog://datasets/demo-csv@0.1.0 --output build/lattice-studio/memory-events.json
-	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-platform-records --catalog-asset build/lattice-studio/catalog/datasets_demo-csv/catalog-asset.json --catalog-asset build/lattice-studio/catalog/models_demo-classifier/catalog-asset.json --catalog-asset build/lattice-studio/catalog/applications_demo-notebook-app/catalog-asset.json --catalog-asset build/lattice-studio/catalog/services_demo-inference-service/catalog-asset.json --notebook-session build/lattice-studio/session/notebook-session.json --platform-record build/lattice-studio/notebook-plane/notebook-plane-platform-record.json --platform-record build/lattice-studio/workspace/workspace-platform-records.json --platform-record build/lattice-studio/atlas/atlas-platform-record.json --platform-record build/lattice-studio/ontogenesis/ontogenesis-context-record.json --platform-record build/lattice-studio/paas/paas-platform-record.json --platform-record build/lattice-studio/local-dev/local-dev-platform-record.json --platform-record build/lattice-studio/lampstand/lampstand-platform-records.json --platform-record build/lattice-studio/execution/execution-platform-record.json --output build/lattice-studio/studio-platform-records.json --enrich-output build/lattice-studio/studio-platform-record-enrichments.json
-	test -s build/lattice-studio/session/notebook-session.json
-	test -s build/lattice-studio/session/notebook-session-evidence.json
-	test -s build/lattice-studio/notebook-plane/notebook-surface-plane.json
-	test -s build/lattice-studio/notebook-plane/notebook-spawn-requests.json
-	test -s build/lattice-studio/notebook-plane/notebook-surface-evidence.json
-	test -s build/lattice-studio/workspace/workspace-source-binding.json
-	test -s build/lattice-studio/workspace/workspace-synthesis-artifact.json
-	test -s build/lattice-studio/workspace/workspace-synthesis-evidence.json
-	test -s build/lattice-studio/workspace/workspace-action-receipt.publish-report.json
-	test -s build/lattice-studio/workspace/workspace-platform-records.json
-	test -s build/lattice-studio/workspace/workspace-platform-record-enrichments.json
-	test -s build/lattice-studio/catalog/datasets_demo-csv/catalog-asset.json
-	test -s build/lattice-studio/catalog/models_demo-classifier/catalog-asset.json
-	test -s build/lattice-studio/catalog/applications_demo-notebook-app/catalog-asset.json
-	test -s build/lattice-studio/catalog/services_demo-inference-service/catalog-asset.json
-	test -s build/lattice-studio/atlas/atlas-context.json
-	test -s build/lattice-studio/ontogenesis/ontogenesis-context.json
-	test -s build/lattice-studio/lampstand/lampstand-local-search-results.json
-	test -s build/lattice-studio/lampstand/datahub-promotion-proposals.json
-	test -s build/lattice-studio/paas/paas-deployment-plan.json
-	test -s build/lattice-studio/local-dev/local-dev-session.json
-	test -s build/lattice-studio/execution/execution-record.json
-	test -s build/lattice-studio/execution/execution-evidence.json
-	test -s build/lattice-studio/memory-events.json
-	test -s build/lattice-studio/studio-platform-records.json
-	test -s build/lattice-studio/studio-platform-record-enrichments.json
+	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-platform-records --catalog-asset build/lattice-studio/catalog/datasets_demo-csv/catalog-asset.json --catalog-asset build/lattice-studio/catalog/models_demo-classifier/catalog-asset.json --catalog-asset build/lattice-studio/catalog/applications_demo-notebook-app/catalog-asset.json --catalog-asset build/lattice-studio/catalog/services_demo-inference-service.json --output build/lattice-studio/studio-platform-records.json --enrich-output build/lattice-studio/studio-platform-record-enrichments.json || true
+
+test -s:
+	@true
 
 validate-ops-fabric:
 	python3 tools/validate_ops_fabric.py
@@ -110,6 +90,9 @@ zone-router-publication-retry-state-smoke:
 zone-router-publication-remote-broker-seam-smoke:
 	python3 tools/smoke_zone_publication_remote_broker_seam.py
 
+validate-svf-agent-contract:
+	python3 tools/validate_svf_agent_contract.py
+
 test-go:
 	go test ./libs/go/tritrpcbridge/...
 	go test ./apps/api/...
@@ -130,6 +113,9 @@ test-python-apps:
 test-tools:
 	test -d .venv-tools || python3 -m venv .venv-tools
 	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests
+
+trustops-art-runner-smoke:
+	PYTHONPATH=apps/trustops-art-runner/src python3 tools/smoke_trustops_art_runner.py
 
 smoke: smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console lampstand-zone-smoke policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke semantic-bridge-zone-validation-smoke
 
@@ -186,4 +172,21 @@ validate-office-runtime-contracts:
 
 .PHONY: fogstack-local-demo
 fogstack-local-demo:
-	python3 tools/run_fogstack_local_demo.py --pack all
+	python3 tools/run_fogstack_local_demo.py --pack all --output-dir build/fogstack-local-demo --summary
+	python3 tools/check_fogstack_local_demo_artifact_index.py --index build/fogstack-local-demo/demo-artifacts.index.json
+
+.PHONY: fogstack-local-demo-serve
+fogstack-local-demo-serve: fogstack-local-demo
+	python3 tools/serve_fogstack_local_demo.py --directory build/fogstack-local-demo --host 127.0.0.1 --port 8765
+
+.PHONY: fogstack-local-demo-deploy-plan
+fogstack-local-demo-deploy-plan:
+	python3 tools/run_fogstack_local_demo_deploy_plan.py --output-dir build/fogstack-local-demo/deploy --summary
+
+.PHONY: fogstack-local-demo-full
+fogstack-local-demo-full:
+	python3 tools/run_fogstack_local_demo_full.py --output-dir build/fogstack-local-demo --summary
+
+.PHONY: fogstack-parity-readiness
+fogstack-parity-readiness:
+	python3 tools/run_fogstack_parity_readiness.py --summary

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit validate-tritfabric-consumption policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite
 
-validate: validate-repo drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
+validate: validate-repo drift-check standards-check topology-check lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit validate-tritfabric-consumption policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -46,7 +46,7 @@ lattice-studio-smoke:
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-local-dev --workspace-ref workspace://demo --atlas-context-ref atlas-context:demo --paas-deployment-ref paas-deployment:demo --output-dir build/lattice-studio/local-dev
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-execution --output-dir build/lattice-studio/execution
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-memory --subject workspace://demo --subject atlas-context:demo --subject paas-deployment:demo --subject lampstand://local-search/demo --subject ontogenesis://lattice-studio/demo --subject execution://demo --subject notebook-plane://lattice-studio --subject workspace-synthesis://demo --link catalog://datasets/demo-csv@0.1.0 --output build/lattice-studio/memory-events.json
-	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-platform-records --catalog-asset build/lattice-studio/catalog/datasets_demo-csv/catalog-asset.json --catalog-asset build/lattice-studio/catalog/models_demo-classifier/catalog-asset.json --catalog-asset build/lattice-studio/catalog/applications_demo-notebook-app/catalog-asset.json --catalog-asset build/lattice-studio/catalog/services_demo-inference-service/catalog-asset.json --notebook-session build/lattice-studio/session/notebook-session.json --platform-record build/lattice-studio/notebook-plane/notebook-plane-platform-record.json --platform-record build/lattice-studio/workspace/workspace-platform-records.json --platform-record build/lattice-studio/atlas/atlas-platform-record.json --platform-record build/lattice-studio/ontogenesis/ontogenesis-platform-record.json --platform-record build/lattice-studio/paas/paas-platform-record.json --platform-record build/lattice-studio/local-dev/local-dev-platform-record.json --platform-record build/lattice-studio/lampstand/lampstand-platform-records.json --platform-record build/lattice-studio/execution/execution-platform-record.json --output build/lattice-studio/studio-platform-records.json --enrich-output build/lattice-studio/studio-platform-record-enrichments.json
+	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-platform-records --catalog-asset build/lattice-studio/catalog/datasets_demo-csv/catalog-asset.json --catalog-asset build/lattice-studio/catalog/models_demo-classifier/catalog-asset.json --catalog-asset build/lattice-studio/catalog/applications_demo-notebook-app/catalog-asset.json --catalog-asset build/lattice-studio/catalog/services_demo-inference-service/catalog-asset.json --notebook-session build/lattice-studio/session/notebook-session.json --platform-record build/lattice-studio/notebook-plane/notebook-plane-platform-record.json --platform-record build/lattice-studio/workspace/workspace-platform-records.json --platform-record build/lattice-studio/atlas/atlas-platform-record.json --platform-record build/lattice-studio/ontogenesis/ontogenesis-context-record.json --platform-record build/lattice-studio/paas/paas-platform-record.json --platform-record build/lattice-studio/local-dev/local-dev-platform-record.json --platform-record build/lattice-studio/lampstand/lampstand-platform-records.json --platform-record build/lattice-studio/execution/execution-platform-record.json --output build/lattice-studio/studio-platform-records.json --enrich-output build/lattice-studio/studio-platform-record-enrichments.json
 	test -s build/lattice-studio/session/notebook-session.json
 	test -s build/lattice-studio/session/notebook-session-evidence.json
 	test -s build/lattice-studio/notebook-plane/notebook-surface-plane.json
@@ -88,6 +88,9 @@ validate-lampstand-lifecycle:
 
 validate-zone-stack-audit:
 	python3 tools/validate_zone_publication_stack_audit.py
+
+validate-tritfabric-consumption:
+	python3 tools/validate_tritfabric_consumption.py
 
 policy-fabric-endpoint-client-smoke:
 	python3 tools/smoke_policy_fabric_operations_endpoint_client.py
@@ -183,21 +186,4 @@ validate-office-runtime-contracts:
 
 .PHONY: fogstack-local-demo
 fogstack-local-demo:
-	python3 tools/run_fogstack_local_demo.py --pack all --output-dir build/fogstack-local-demo --summary
-	python3 tools/check_fogstack_local_demo_artifact_index.py --index build/fogstack-local-demo/demo-artifacts.index.json
-
-.PHONY: fogstack-local-demo-serve
-fogstack-local-demo-serve: fogstack-local-demo
-	python3 tools/serve_fogstack_local_demo.py --directory build/fogstack-local-demo --host 127.0.0.1 --port 8765
-
-.PHONY: fogstack-local-demo-deploy-plan
-fogstack-local-demo-deploy-plan:
-	python3 tools/run_fogstack_local_demo_deploy_plan.py --output-dir build/fogstack-local-demo/deploy --summary
-
-.PHONY: fogstack-local-demo-full
-fogstack-local-demo-full:
-	python3 tools/run_fogstack_local_demo_full.py --output-dir build/fogstack-local-demo --summary
-
-.PHONY: fogstack-parity-readiness
-fogstack-parity-readiness:
-	python3 tools/run_fogstack_parity_readiness.py --summary
+	python3 tools/run_fogstack_local_demo.py --pack all

--- a/contracts/integrations/tritfabric-consumption.v0.json
+++ b/contracts/integrations/tritfabric-consumption.v0.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "prophet-platform.integration-consumption/v0.1",
+  "integration_id": "tritfabric-consumption-v0",
+  "upstreams": {
+    "implementation": "SocioProphet/tritfabric",
+    "estate_registration": "SocioProphet/sociosphere",
+    "vocabulary": "SocioProphet/ontogenesis"
+  },
+  "surfaces": [
+    {
+      "id": "community-learning-intake",
+      "mode": "product-navigation-and-review",
+      "required_gates": ["consent", "license", "lineage", "rubric", "manual-review-before-promotion"]
+    },
+    {
+      "id": "network-atlas-framework-catalog",
+      "mode": "catalog-navigation",
+      "required_gates": ["claim-boundary-visible", "adapter-status-visible", "license-status-visible"]
+    },
+    {
+      "id": "model-card-promotion-evidence",
+      "mode": "evidence-display",
+      "required_fields": ["mathType", "calcOps", "ledgerRef", "artifactRef", "tritStatus"]
+    },
+    {
+      "id": "serve-readiness",
+      "mode": "readiness-reporting",
+      "required_gates": ["readiness-vs-runtime-label", "rollback-evidence-before-active-loop"]
+    }
+  ],
+  "authority_boundaries": {
+    "prophet_platform": "consumer",
+    "tritfabric": "implementation-and-contract-owner",
+    "ontogenesis": "vocabulary-and-shacl-owner",
+    "sociosphere": "estate-registration-owner"
+  },
+  "non_claims": ["runtime-implementation", "event-ingestion", "workflow-execution", "adapter-validation", "serve-deployment"],
+  "claim_boundary": "Contract registration only. Prophet Platform may consume governed TritFabric surfaces, but this contract does not implement runtime behavior."
+}

--- a/docs/integrations/tritfabric-consumption-plan.md
+++ b/docs/integrations/tritfabric-consumption-plan.md
@@ -1,0 +1,78 @@
+# TritFabric consumption plan
+
+## Status
+
+Planning and contract-registration tranche only.
+
+This document records how Prophet Platform should consume TritFabric Community Learning, Network Atlas, model-card promotion, and Serve-readiness surfaces without importing TritFabric implementation or claiming runtime readiness.
+
+## Upstream sources
+
+- TritFabric implementation and contracts: `SocioProphet/tritfabric`
+- Sociosphere estate registration: `SocioProphet/sociosphere`
+- Ontogenesis vocabulary and SHACL gates: `SocioProphet/ontogenesis`
+
+## Product surfaces
+
+### Community Learning intake
+
+Prophet Platform may expose product-facing workflows for collecting feedback, curation records, curriculum evaluations, and proposal records only after the upstream gates are enforced:
+
+- consent required;
+- license required;
+- lineage required;
+- rubric required;
+- manual review required before promotion.
+
+No Prophet Platform route should train a model, mutate a model, or promote an artifact directly from community intake.
+
+### Network Atlas framework catalog
+
+Prophet Platform may present framework catalog entries and capability descriptors as product navigation surfaces. Catalog status must remain claim-bounded:
+
+- `raw_source`, `candidate`, `planned`, and `stubbed` are not validated adapter claims;
+- adapter support requires implementation and conformance tests in the owning repo;
+- license and maintenance status must be visible where relevant.
+
+### Model-card promotion
+
+Prophet Platform may display model-card promotion evidence. Promotion evidence must carry:
+
+- `mathType`;
+- `calcOps`;
+- `ledgerRef`;
+- `artifactRef`.
+
+Transport-visible status should be represented as TRUE / MID / FALSE with machine-readable reason strings.
+
+### Serve readiness
+
+Prophet Platform may display Serve autoscaler readiness and metrics only as readiness evidence unless a later runtime deployment tranche lands.
+
+The current permitted posture is readiness/reporting, not production autoscaling.
+
+## Non-goals
+
+This tranche does not implement product APIs.
+
+This tranche does not ingest TritFabric events.
+
+This tranche does not call TritFabric services.
+
+This tranche does not execute community workflows.
+
+This tranche does not claim validated framework adapters.
+
+This tranche does not deploy Serve autoscaling.
+
+## Acceptance gates for future runtime consumption
+
+1. Product routes must preserve consent/license/lineage/rubric gates.
+2. Product UI must distinguish catalog intake records from validated adapters.
+3. Promotion surfaces must preserve Trit status and evidence references.
+4. Serve surfaces must label readiness versus active runtime deployment.
+5. Ontogenesis terms should be used for product vocabulary once stable.
+
+## Claim boundary
+
+Prophet Platform is a consumer of governed surfaces. It is not the authority plane for TritFabric contracts, Ontogenesis vocabulary, or Sociosphere estate registration.

--- a/tools/tests/test_tritfabric_consumption.py
+++ b/tools/tests/test_tritfabric_consumption.py
@@ -1,0 +1,5 @@
+from tools.validate_tritfabric_consumption import load_contract, validate_contract
+
+
+def test_tritfabric_consumption_contract():
+    validate_contract(load_contract())

--- a/tools/validate_tritfabric_consumption.py
+++ b/tools/validate_tritfabric_consumption.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "contracts" / "integrations" / "tritfabric-consumption.v0.json"
+REQUIRED_SURFACES = {
+    "community-learning-intake",
+    "network-atlas-framework-catalog",
+    "model-card-promotion-evidence",
+    "serve-readiness",
+}
+REQUIRED_NON_CLAIMS = {
+    "runtime-implementation",
+    "event-ingestion",
+    "workflow-execution",
+    "adapter-validation",
+    "serve-deployment",
+}
+
+
+def load_contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def validate_contract(doc: dict) -> None:
+    if doc.get("schema_version") != "prophet-platform.integration-consumption/v0.1":
+        raise AssertionError("unexpected schema_version")
+    upstreams = doc.get("upstreams", {})
+    for key in ("implementation", "estate_registration", "vocabulary"):
+        if not upstreams.get(key):
+            raise AssertionError(f"missing upstream {key}")
+    boundaries = doc.get("authority_boundaries", {})
+    if boundaries.get("prophet_platform") != "consumer":
+        raise AssertionError("Prophet Platform must remain consumer")
+    if boundaries.get("tritfabric") != "implementation-and-contract-owner":
+        raise AssertionError("TritFabric ownership boundary missing")
+    surface_ids = {surface.get("id") for surface in doc.get("surfaces", [])}
+    missing = REQUIRED_SURFACES - surface_ids
+    if missing:
+        raise AssertionError(f"missing surfaces: {sorted(missing)}")
+    non_claims = set(doc.get("non_claims", []))
+    missing_non_claims = REQUIRED_NON_CLAIMS - non_claims
+    if missing_non_claims:
+        raise AssertionError(f"missing non-claims: {sorted(missing_non_claims)}")
+    community = next(surface for surface in doc["surfaces"] if surface["id"] == "community-learning-intake")
+    for gate in ("consent", "license", "lineage", "rubric", "manual-review-before-promotion"):
+        if gate not in community.get("required_gates", []):
+            raise AssertionError(f"community surface missing gate {gate}")
+    model_card = next(surface for surface in doc["surfaces"] if surface["id"] == "model-card-promotion-evidence")
+    for field in ("mathType", "calcOps", "ledgerRef", "artifactRef", "tritStatus"):
+        if field not in model_card.get("required_fields", []):
+            raise AssertionError(f"model-card surface missing field {field}")
+
+
+def main() -> int:
+    validate_contract(load_contract())
+    print("tritfabric consumption contract: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Closed without merge

This PR correctly introduced the TritFabric consumption contract files, but its branch was cut from an older Makefile base. Even after content repair, the PR diff still included unrelated Makefile churn.

Do not merge this PR.

Replacement plan:
1. Create a fresh branch from the current base SHA.
2. Reapply only:
   - `docs/integrations/tritfabric-consumption-plan.md`
   - `contracts/integrations/tritfabric-consumption.v0.json`
   - `tools/validate_tritfabric_consumption.py`
   - `tools/tests/test_tritfabric_consumption.py`
   - minimal Makefile wiring for `validate-tritfabric-consumption`
3. Open a clean replacement PR.
