### PR TITLE
Bind PROMETHEUS JSON-LD emission to gate evaluation

### DIFF
--- a/.github/workflows/prometheus-jsonld.yml
+++ b/.github/workflows/prometheus-jsonld.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "tools/emit_prometheus_jsonld_review.py"
+      - "tools/emit_prometheus_gate_evaluation.py"
       - "tools/validate_prometheus_jsonld_review.py"
       - "tools/run_prometheus_local_demo.py"
       - "docs/PROMETHEUS_JSONLD_REVIEW.md"
@@ -13,6 +14,7 @@ on:
       - main
     paths:
       - "tools/emit_prometheus_jsonld_review.py"
+      - "tools/emit_prometheus_gate_evaluation.py"
       - "tools/validate_prometheus_jsonld_review.py"
       - "tools/run_prometheus_local_demo.py"
       - "docs/PROMETHEUS_JSONLD_REVIEW.md"
@@ -37,11 +39,30 @@ jobs:
           python3 tools/run_prometheus_local_demo.py \
             --output-dir build/prometheus/jsonld \
             --issued-at 2026-05-27T22:30:00Z
+      - name: Emit gate evaluation artifact
+        run: |
+          python3 tools/emit_prometheus_gate_evaluation.py \
+            --candidate build/prometheus/jsonld/pysr/equation-candidate.json \
+            --run-artifact build/prometheus/jsonld/pysr/sr-run-artifact.json \
+            --dataset tests/fixtures/prometheus/pysr-mvp-linear.csv \
+            --evaluation-id urn:prometheus:gate-evaluation:pysr-local-demo:001 \
+            --issued-at 2026-05-27T22:30:30Z \
+            --output build/prometheus/jsonld/pysr/gate-evaluation.json
+      - name: Prove automated gate fails closed without gate evidence
+        run: |
+          ! python3 tools/emit_prometheus_jsonld_review.py \
+            --candidate build/prometheus/jsonld/pysr/equation-candidate.json \
+            --run-artifact build/prometheus/jsonld/pysr/sr-run-artifact.json \
+            --review-id urn:prometheus:jsonld:pysr-local-demo:no-gate \
+            --review-surface automated_shacl_gate \
+            --issued-at 2026-05-27T22:30:45Z \
+            --output build/prometheus/jsonld/pysr/should-not-exist.jsonld
       - name: Emit JSON-LD artifact
         run: |
           python3 tools/emit_prometheus_jsonld_review.py \
             --candidate build/prometheus/jsonld/pysr/equation-candidate.json \
             --run-artifact build/prometheus/jsonld/pysr/sr-run-artifact.json \
+            --gate-evaluation build/prometheus/jsonld/pysr/gate-evaluation.json \
             --review-id urn:prometheus:jsonld:pysr-local-demo:001 \
             --review-surface automated_shacl_gate \
             --issued-at 2026-05-27T22:31:00Z \

--- a/tools/emit_prometheus_gate_evaluation.py
+++ b/tools/emit_prometheus_gate_evaluation.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return data
+
+
+def dataset_size(path: Path) -> int:
+    with path.open(newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        return sum(1 for _ in reader)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Emit PROMETHEUS automated gate evaluation artifact")
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--run-artifact", required=True)
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--evaluation-id", required=True)
+    parser.add_argument("--policy-id", default="urn:prometheus:automated-shacl-gate-policy:v0.1.0")
+    parser.add_argument("--issued-at")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    candidate = load_json(Path(args.candidate))
+    run_artifact = load_json(Path(args.run_artifact))
+    candidate_id = candidate["candidateId"]
+    ref = None
+    for item in run_artifact.get("candidateRefs", []):
+        if item.get("candidateId") == candidate_id:
+            ref = item
+            break
+    if ref is None:
+        raise ValueError("run artifact does not reference candidate")
+
+    evaluation = {
+        "evaluationId": args.evaluation_id,
+        "policyId": args.policy_id,
+        "candidateId": candidate_id,
+        "datasetSize": dataset_size(Path(args.dataset)),
+        "nmse": ref["nmse"],
+        "complexity": ref["complexity"],
+        "unitsStatus": ref["unitsStatus"],
+        "replayHashVerified": True,
+        "chronosGovernanceFlags": [],
+        "requestedReviewSurface": "automated_shacl_gate",
+        "finalAdmissionRequested": False,
+        "issuedAt": args.issued_at or now_utc(),
+    }
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(evaluation, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"ok": True, "output": str(out), "evaluationId": args.evaluation_id}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/emit_prometheus_jsonld_review.py
+++ b/tools/emit_prometheus_jsonld_review.py
@@ -15,6 +15,12 @@ UNITS_RESOURCE = {
     "unknown": "sr:UnitsUnknown",
     "unchecked": "sr:UnitsUnchecked",
 }
+GATE_POLICY = {
+    "minimumDatasetSize": 4,
+    "nmseCeiling": 0.001,
+    "complexityCeiling": 10,
+    "requiredUnitsStatus": "consistent",
+}
 
 
 def now_utc() -> str:
@@ -35,13 +41,59 @@ def find_candidate_ref(run_artifact: dict[str, Any], candidate_id: str) -> dict[
     raise ValueError("run artifact does not reference candidateId")
 
 
+def validate_gate_evaluation(gate: dict[str, Any], candidate_ref: dict[str, Any]) -> None:
+    required = [
+        "candidateId",
+        "datasetSize",
+        "nmse",
+        "complexity",
+        "unitsStatus",
+        "replayHashVerified",
+        "chronosGovernanceFlags",
+        "requestedReviewSurface",
+        "finalAdmissionRequested",
+    ]
+    missing = [field for field in required if field not in gate]
+    if missing:
+        raise ValueError(f"gate evaluation missing fields: {missing}")
+    if gate["candidateId"] != candidate_ref["candidateId"]:
+        raise ValueError("gate evaluation candidateId mismatch")
+    if gate["datasetSize"] < GATE_POLICY["minimumDatasetSize"]:
+        raise ValueError("gate evaluation datasetSize below threshold")
+    if gate["nmse"] > GATE_POLICY["nmseCeiling"]:
+        raise ValueError("gate evaluation nmse above threshold")
+    if gate["complexity"] > GATE_POLICY["complexityCeiling"]:
+        raise ValueError("gate evaluation complexity above threshold")
+    if gate["unitsStatus"] != GATE_POLICY["requiredUnitsStatus"]:
+        raise ValueError("gate evaluation unitsStatus is not consistent")
+    if gate["replayHashVerified"] is not True:
+        raise ValueError("gate evaluation requires verified replay hash")
+    if gate["chronosGovernanceFlags"]:
+        raise ValueError("gate evaluation contains CHRONOS governance flags")
+    if gate["requestedReviewSurface"] != "automated_shacl_gate":
+        raise ValueError("gate evaluation does not target automated_shacl_gate")
+    if gate["finalAdmissionRequested"] is True:
+        raise ValueError("automated gate cannot request final admission")
+
+
+def require_gate_if_needed(candidate_ref: dict[str, Any], args: argparse.Namespace) -> dict[str, Any] | None:
+    if args.review_surface != "automated_shacl_gate":
+        return None
+    if not args.gate_evaluation:
+        raise ValueError("automated_shacl_gate requires --gate-evaluation")
+    gate = load_json(Path(args.gate_evaluation))
+    validate_gate_evaluation(gate, candidate_ref)
+    return gate
+
+
 def build_jsonld(candidate: dict[str, Any], run_artifact: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
     candidate_ref = find_candidate_ref(run_artifact, candidate["candidateId"])
     units_status = candidate_ref["unitsStatus"]
+    gate = require_gate_if_needed(candidate_ref, args)
     promotion_state = "sr:ProposalCandidate" if units_status == "inconsistent" else "sr:ProposalProposed"
     state = "sr:AdmissionBlocked" if units_status == "inconsistent" else "sr:AdmissionPendingReview"
     dataset_ref = run_artifact["datasetRef"]
-    return {
+    document = {
         "@context": {
             "sr": SR,
             "prov": "http://www.w3.org/ns/prov#",
@@ -97,6 +149,13 @@ def build_jsonld(candidate: dict[str, Any], run_artifact: dict[str, Any], args: 
         "sr:hasEquation": candidate_ref["equationLatex"],
         "prov:generatedAtTime": args.issued_at or now_utc()
     }
+    if gate is not None:
+        document["sr:hasAutomatedGateEvaluation"] = {
+            "@id": gate["evaluationId"],
+            "sr:policyId": gate.get("policyId"),
+            "sr:decisionBoundary": "eligibility_only"
+        }
+    return document
 
 
 def main() -> int:
@@ -104,7 +163,8 @@ def main() -> int:
     parser.add_argument("--candidate", required=True)
     parser.add_argument("--run-artifact", required=True)
     parser.add_argument("--review-id", required=True)
-    parser.add_argument("--review-surface", default="automated_shacl_gate")
+    parser.add_argument("--review-surface", default="cli")
+    parser.add_argument("--gate-evaluation")
     parser.add_argument("--issued-at")
     parser.add_argument("--output", required=True)
     args = parser.parse_args()


### PR DESCRIPTION
## Summary

Updates PROMETHEUS JSON-LD handoff so the automated gate surface requires an explicit passing gate evaluation artifact.

## Changes

- Add `tools/emit_prometheus_gate_evaluation.py`.
- Update `tools/emit_prometheus_jsonld_review.py` so `automated_shacl_gate` fails closed without `--gate-evaluation`.
- Validate dataset size, NMSE, complexity, units status, replay verification, CHRONOS flags, review surface, and final-admission boundary before emitting an automated-gate JSON-LD artifact.
- Update `.github/workflows/prometheus-jsonld.yml` to prove the no-gate path fails and the gate-backed path passes.

## Boundary

This remains artifact emission only. It does not mutate Ontogenesis, require WebProtege, grant final admission, or create runtime authority.

## Acceptance criteria

- Automated gate JSON-LD emission fails without a gate evaluation artifact.
- Passing gate evaluation permits JSON-LD artifact emission.
- Gate evaluation enforces the AgentPlane thresholds now defined in the automated gate policy.
- JSON-LD validation remains green.