### PR TITLE
Extend PROMETHEUS local demo through JSON-LD handoff

### DIFF
--- a/docs/PROMETHEUS_LOCAL_DEMO.md
+++ b/docs/PROMETHEUS_LOCAL_DEMO.md
@@ -1,19 +1,23 @@
 # PROMETHEUS Local Demo Runner
 
-Status: v0.1 consolidated platform demo.
+Status: v0.2 consolidated platform demo.
 
-This runner makes the PROMETHEUS MVP legible and repeatable. It emits both current platform paths:
+This runner makes the PROMETHEUS MVP legible and repeatable. It emits the current platform evidence chain:
 
 - PySR-style equation discovery through the deterministic fallback engine.
+- AgentPlane-compatible SRRunArtifact emission for the PySR-style candidate.
+- Automated gate evaluation for the PySR-style candidate.
+- JSON-LD semantic handoff artifact for the PySR-style candidate.
 - SINDy-style platform dynamics discovery through the fast-path time-series emitter.
-
-Each path produces a candidate artifact and an AgentPlane-compatible `SRRunArtifact`. The runner also writes a manifest with artifact paths and SHA-256 hashes.
+- AgentPlane-compatible SRRunArtifact emission for the SINDy-style candidate.
 
 ## Boundary
 
 The local demo emits evidence only. It does not create laws, ontology assertions, policies, controllers, or deployment authorizations.
 
 `controlAuthority` is false for both runs.
+
+The JSON-LD artifact is a handoff artifact only. It does not mutate Ontogenesis and does not require WebProtege.
 
 ## Usage
 
@@ -31,6 +35,8 @@ The runner writes:
 
 - `pysr/equation-candidate.json`
 - `pysr/sr-run-artifact.json`
+- `pysr/gate-evaluation.json`
+- `pysr/sr.jsonld`
 - `sindy/platform-dynamics-candidate.json`
 - `sindy/sr-run-artifact.json`
 - `manifest.json`

--- a/tools/run_prometheus_local_demo.py
+++ b/tools/run_prometheus_local_demo.py
@@ -28,16 +28,12 @@ def run_command(args: list[str]) -> None:
 
 
 def artifact_record(kind: str, path: Path) -> dict[str, Any]:
-    return {
-        "kind": kind,
-        "path": str(path),
-        "sha256": sha256_file(path),
-    }
+    return {"kind": kind, "path": str(path), "sha256": sha256_file(path)}
 
 
 def build_manifest(output_dir: Path, issued_at: str, artifacts: list[dict[str, Any]]) -> dict[str, Any]:
     return {
-        "manifestVersion": "0.1.0",
+        "manifestVersion": "0.2.0",
         "kind": "PrometheusLocalDemoManifest",
         "issuedAt": issued_at,
         "nonAuthorityDeclaration": "PROMETHEUS local demo artifacts are evidence only. They are not laws, ontology assertions, policies, controllers, or deployment authorizations.",
@@ -49,6 +45,8 @@ def build_manifest(output_dir: Path, issued_at: str, artifacts: list[dict[str, A
                 "methodFamily": "pysr",
                 "candidateArtifact": str(output_dir / "pysr" / "equation-candidate.json"),
                 "runArtifact": str(output_dir / "pysr" / "sr-run-artifact.json"),
+                "gateEvaluationArtifact": str(output_dir / "pysr" / "gate-evaluation.json"),
+                "jsonldArtifact": str(output_dir / "pysr" / "sr.jsonld"),
                 "controlAuthority": False,
             },
             {
@@ -68,7 +66,6 @@ def main() -> int:
     parser.add_argument("--issued-at", default="2026-05-27T21:00:00Z")
     args = parser.parse_args()
 
-    root = Path.cwd()
     output_dir = Path(args.output_dir)
     pysr_dir = output_dir / "pysr"
     sindy_dir = output_dir / "sindy"
@@ -77,82 +74,78 @@ def main() -> int:
 
     pysr_candidate = pysr_dir / "equation-candidate.json"
     pysr_run = pysr_dir / "sr-run-artifact.json"
+    pysr_gate = pysr_dir / "gate-evaluation.json"
+    pysr_jsonld = pysr_dir / "sr.jsonld"
     sindy_candidate = sindy_dir / "platform-dynamics-candidate.json"
     sindy_run = sindy_dir / "sr-run-artifact.json"
 
     run_command([
-        sys.executable,
-        "tools/prometheus_pysr_mvp.py",
-        "--engine",
-        "mvp_linear_fallback",
-        "--data",
-        "tests/fixtures/prometheus/pysr-mvp-linear.csv",
-        "--target",
-        "y",
-        "--dataset-uri",
-        "urn:dataset:prometheus:pysr-mvp-linear",
-        "--target-unit",
-        "meter",
-        "--feature-unit",
-        "x=meter",
-        "--generated-at",
-        args.issued_at,
-        "--output",
-        str(pysr_candidate),
+        sys.executable, "tools/prometheus_pysr_mvp.py",
+        "--engine", "mvp_linear_fallback",
+        "--data", "tests/fixtures/prometheus/pysr-mvp-linear.csv",
+        "--target", "y",
+        "--dataset-uri", "urn:dataset:prometheus:pysr-mvp-linear",
+        "--target-unit", "meter",
+        "--feature-unit", "x=meter",
+        "--generated-at", args.issued_at,
+        "--output", str(pysr_candidate),
     ])
 
     run_command([
-        sys.executable,
-        "tools/prometheus_emit_sr_run_artifact.py",
-        "--candidate",
-        str(pysr_candidate),
-        "--run-id",
-        "urn:prometheus:sr-run:pysr-local-demo:001",
-        "--chronos-carrier-id",
-        "urn:chronos:carrier:prometheus:local-demo:pysr",
-        "--random-seed",
-        "42",
-        "--issued-at",
-        args.issued_at,
-        "--output",
-        str(pysr_run),
+        sys.executable, "tools/prometheus_emit_sr_run_artifact.py",
+        "--candidate", str(pysr_candidate),
+        "--run-id", "urn:prometheus:sr-run:pysr-local-demo:001",
+        "--chronos-carrier-id", "urn:chronos:carrier:prometheus:local-demo:pysr",
+        "--random-seed", "42",
+        "--issued-at", args.issued_at,
+        "--output", str(pysr_run),
     ])
 
     run_command([
-        sys.executable,
-        "tools/prometheus_sindy_fast_path.py",
-        "--data",
-        "tests/fixtures/prometheus/sindy-fast-path-linear.csv",
-        "--time-column",
-        "t",
-        "--value-column",
-        "q",
-        "--dataset-uri",
-        "urn:dataset:prometheus:sindy-fast-path-linear",
-        "--generated-at",
-        args.issued_at,
-        "--output",
-        str(sindy_candidate),
+        sys.executable, "tools/emit_prometheus_gate_evaluation.py",
+        "--candidate", str(pysr_candidate),
+        "--run-artifact", str(pysr_run),
+        "--dataset", "tests/fixtures/prometheus/pysr-mvp-linear.csv",
+        "--evaluation-id", "urn:prometheus:gate-evaluation:pysr-local-demo:001",
+        "--issued-at", args.issued_at,
+        "--output", str(pysr_gate),
     ])
 
     run_command([
-        sys.executable,
-        "tools/prometheus_emit_sr_run_artifact.py",
-        "--candidate",
-        str(sindy_candidate),
-        "--run-id",
-        "urn:prometheus:sr-run:sindy-local-demo:001",
-        "--chronos-carrier-id",
-        "urn:chronos:carrier:prometheus:local-demo:sindy",
-        "--issued-at",
-        args.issued_at,
-        "--output",
-        str(sindy_run),
+        sys.executable, "tools/emit_prometheus_jsonld_review.py",
+        "--candidate", str(pysr_candidate),
+        "--run-artifact", str(pysr_run),
+        "--gate-evaluation", str(pysr_gate),
+        "--review-id", "urn:prometheus:jsonld:pysr-local-demo:001",
+        "--review-surface", "automated_shacl_gate",
+        "--issued-at", args.issued_at,
+        "--output", str(pysr_jsonld),
+    ])
+
+    run_command([
+        sys.executable, "tools/prometheus_sindy_fast_path.py",
+        "--data", "tests/fixtures/prometheus/sindy-fast-path-linear.csv",
+        "--time-column", "t",
+        "--value-column", "q",
+        "--dataset-uri", "urn:dataset:prometheus:sindy-fast-path-linear",
+        "--generated-at", args.issued_at,
+        "--output", str(sindy_candidate),
+    ])
+
+    run_command([
+        sys.executable, "tools/prometheus_emit_sr_run_artifact.py",
+        "--candidate", str(sindy_candidate),
+        "--run-id", "urn:prometheus:sr-run:sindy-local-demo:001",
+        "--chronos-carrier-id", "urn:chronos:carrier:prometheus:local-demo:sindy",
+        "--issued-at", args.issued_at,
+        "--output", str(sindy_run),
     ])
 
     artifacts = [
         artifact_record("EquationCandidate", pysr_candidate),
         artifact_record("SRRunArtifact", pysr_run),
+        artifact_record("AutomatedGateEvaluation", pysr_gate),
+        artifact_record("SRAssertionProposalJSONLD", pysr_jsonld),
         artifact_record("PlatformDynamicsCandidate", sindy_candidate),
         artifact_record("SRRunArtifact", sindy_run),
     ]

--- a/tools/validate_prometheus_local_demo.py
+++ b/tools/validate_prometheus_local_demo.py
@@ -52,6 +52,34 @@ def validate_run_artifact(path: Path, expected_method: str) -> None:
         fail(f"{path}: invalid replayHash")
 
 
+def validate_gate_evaluation(path: Path, candidate_path: Path) -> None:
+    gate = load(path)
+    candidate = load(candidate_path)
+    if gate.get("candidateId") != candidate.get("candidateId"):
+        fail(f"{path}: gate candidateId mismatch")
+    if gate.get("requestedReviewSurface") != "automated_shacl_gate":
+        fail(f"{path}: gate must target automated_shacl_gate")
+    if gate.get("finalAdmissionRequested") is not False:
+        fail(f"{path}: gate must not request final admission")
+    if gate.get("replayHashVerified") is not True:
+        fail(f"{path}: replay hash must be verified")
+    if gate.get("chronosGovernanceFlags") != []:
+        fail(f"{path}: CHRONOS flags must be empty")
+
+
+def validate_jsonld(path: Path, gate_path: Path) -> None:
+    data = load(path)
+    gate = load(gate_path)
+    if data.get("@type") != "sr:SRAssertionProposal":
+        fail(f"{path}: expected sr:SRAssertionProposal")
+    if data.get("sr:hasAutomatedGateEvaluation", {}).get("@id") != gate.get("evaluationId"):
+        fail(f"{path}: automated gate evaluation reference mismatch")
+    if data.get("sr:hasSemanticReviewSurface", {}).get("sr:reviewSurfaceType") != "automated_shacl_gate":
+        fail(f"{path}: review surface must be automated_shacl_gate")
+    if "does not" not in data.get("sr:nonAuthorityDeclaration", ""):
+        fail(f"{path}: missing non-authority declaration")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("manifest")
@@ -61,11 +89,13 @@ def main() -> int:
     manifest = load(manifest_path)
     if manifest.get("kind") != "PrometheusLocalDemoManifest":
         fail("manifest kind mismatch")
+    if manifest.get("manifestVersion") != "0.2.0":
+        fail("manifestVersion must be 0.2.0")
     if "not laws" not in manifest.get("nonAuthorityDeclaration", ""):
         fail("manifest missing non-authority declaration")
     artifacts = manifest.get("artifacts")
-    if not isinstance(artifacts, list) or len(artifacts) != 4:
-        fail("manifest must contain exactly four artifacts")
+    if not isinstance(artifacts, list) or len(artifacts) != 6:
+        fail("manifest must contain exactly six artifacts")
     for artifact in artifacts:
         path = Path(artifact.get("path", ""))
         if not path.exists():
@@ -81,10 +111,14 @@ def main() -> int:
     for method, run in run_by_method.items():
         if run.get("controlAuthority") is not False:
             fail(f"{method}: controlAuthority must be false")
-    validate_candidate(Path(run_by_method["pysr"]["candidateArtifact"]), "EquationCandidate", "pysr")
-    validate_run_artifact(Path(run_by_method["pysr"]["runArtifact"]), "pysr")
-    validate_candidate(Path(run_by_method["sindy"]["candidateArtifact"]), "PlatformDynamicsCandidate", "sindy")
-    validate_run_artifact(Path(run_by_method["sindy"]["runArtifact"]), "sindy")
+    pysr = run_by_method["pysr"]
+    sindy = run_by_method["sindy"]
+    validate_candidate(Path(pysr["candidateArtifact"]), "EquationCandidate", "pysr")
+    validate_run_artifact(Path(pysr["runArtifact"]), "pysr")
+    validate_gate_evaluation(Path(pysr["gateEvaluationArtifact"]), Path(pysr["candidateArtifact"]))
+    validate_jsonld(Path(pysr["jsonldArtifact"]), Path(pysr["gateEvaluationArtifact"]))
+    validate_candidate(Path(sindy["candidateArtifact"]), "PlatformDynamicsCandidate", "sindy")
+    validate_run_artifact(Path(sindy["runArtifact"]), "sindy")
 
     print(json.dumps({"valid": True, "manifest": str(manifest_path), "artifactCount": len(artifacts)}, sort_keys=True))
     return 0


### PR DESCRIPTION
## Summary

Extends the consolidated PROMETHEUS local demo through the full current artifact chain.

The local demo now emits:

- PySR-style candidate.
- PySR SRRunArtifact.
- Gate evaluation artifact.
- JSON-LD semantic handoff artifact.
- SINDy-style platform dynamics candidate.
- SINDy SRRunArtifact.
- Manifest with hashes for all emitted artifacts.

## Changes

- Update `tools/run_prometheus_local_demo.py` to emit gate evaluation and JSON-LD artifacts.
- Update `tools/validate_prometheus_local_demo.py` to validate the full six-artifact manifest.
- Update `docs/PROMETHEUS_LOCAL_DEMO.md` to describe v0.2 outputs.

## Boundary

This remains a local evidence demo. It does not mutate Ontogenesis, require WebProtege, grant final admission, or create runtime authority.

## Acceptance criteria

- Local demo produces the full current PROMETHEUS chain.
- Manifest version advances to 0.2.0.
- Manifest contains six artifacts.
- Gate evaluation is linked to the PySR candidate.
- JSON-LD artifact references the gate evaluation.
- SINDy artifacts keep `controlAuthority: false`.