### PR TITLE
Upload PROMETHEUS local demo artifact bundle

### DIFF
--- a/.github/workflows/prometheus-local-demo.yml
+++ b/.github/workflows/prometheus-local-demo.yml
@@ -9,6 +9,8 @@ on:
       - "tools/prometheus_sindy_fast_path.py"
       - "tools/prometheus_emit_sr_run_artifact.py"
       - "tools/validate_prometheus_sr_run_artifact.py"
+      - "tools/emit_prometheus_gate_evaluation.py"
+      - "tools/emit_prometheus_jsonld_review.py"
       - "tests/fixtures/prometheus/**"
       - "docs/PROMETHEUS_LOCAL_DEMO.md"
       - ".github/workflows/prometheus-local-demo.yml"
@@ -22,6 +24,8 @@ on:
       - "tools/prometheus_sindy_fast_path.py"
       - "tools/prometheus_emit_sr_run_artifact.py"
       - "tools/validate_prometheus_sr_run_artifact.py"
+      - "tools/emit_prometheus_gate_evaluation.py"
+      - "tools/emit_prometheus_jsonld_review.py"
       - "tests/fixtures/prometheus/**"
       - "docs/PROMETHEUS_LOCAL_DEMO.md"
       - ".github/workflows/prometheus-local-demo.yml"
@@ -49,3 +53,10 @@ jobs:
         run: |
           python3 tools/validate_prometheus_local_demo.py \
             build/prometheus/local-demo/manifest.json
+      - name: Upload local PROMETHEUS artifact bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: prometheus-local-demo-bundle
+          path: build/prometheus/local-demo/
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## Summary

Updates the PROMETHEUS local-demo workflow so the validated evidence bundle is retained as a GitHub Actions artifact.

## Changes

- Add gate and JSON-LD tools to local-demo workflow path filters.
- Upload `build/prometheus/local-demo/` as `prometheus-local-demo-bundle`.
- Retain the uploaded bundle for 14 days.

## Boundary

This does not change runtime behavior or artifact semantics. It only makes the validated local-demo output retrievable from CI.

## Acceptance criteria

- Local demo still validates.
- Workflow uploads the validated bundle.
- Missing bundle fails the workflow.