### PR TITLE
Observe validate_change v2 environment contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Enable corepack
-        run: corepack enable
+      - name: Install pinned pnpm
+        run: npm install -g pnpm@9.15.4
       - name: Build
         run: |
           cd apps/socioprophet-web

--- a/artifacts/environment/requests/validate-change-v2-observation.json
+++ b/artifacts/environment/requests/validate-change-v2-observation.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "1.0",
+  "request_id": "environment:validation-request:validate-change-v2:2026-05-29",
+  "repo": "SocioProphet/prophet-platform",
+  "purpose": "Create an observable Prophet Platform pull-request validation surface for validate_change v2 environment fixtures.",
+  "changed_surfaces": [
+    "contracts/environment/validate-change-v2-request.example.json",
+    "contracts/environment/validate-change-v2-response.environment-requested.json",
+    "contracts/environment/validate-change-v2-response.environment-observed.json",
+    "contracts/environment/validate-change-v2-response.environment-failed.json",
+    "tools/validate_environment_validate_change_v2.py",
+    "Makefile",
+    "README.md"
+  ],
+  "expected_checks": [
+    "validate-environment-validate-change-v2"
+  ],
+  "non_claims": [
+    "This request does not execute live sandbox infrastructure.",
+    "This request does not certify Signadot-style runtime parity.",
+    "This request validates Prophet Platform validate_change v2 environment contract shape only."
+  ]
+}


### PR DESCRIPTION
## Purpose

Create an observable Prophet Platform pull-request validation surface for the `validate_change` v2 environment-validation contract.

## Scope

This PR adds an observation request artifact for the v2 fixtures and validator:

- `contracts/environment/validate-change-v2-request.example.json`
- `contracts/environment/validate-change-v2-response.environment-requested.json`
- `contracts/environment/validate-change-v2-response.environment-observed.json`
- `contracts/environment/validate-change-v2-response.environment-failed.json`
- `tools/validate_environment_validate_change_v2.py`
- `Makefile`
- `README.md`

## Expected observation

- `make validate-environment-validate-change-v2`

## Non-claims

This PR does not execute live sandbox infrastructure.
It does not certify Signadot-style runtime parity.
It validates Prophet Platform `validate_change` v2 environment contract shape only.