### PR TITLE
Add adversarial scenario reference binding

### DIFF
--- a/.github/workflows/adversarial-scenario-ref.yml
+++ b/.github/workflows/adversarial-scenario-ref.yml
@@ -1,0 +1,37 @@
+name: adversarial-scenario-ref
+
+on:
+  pull_request:
+    paths:
+      - "contracts/security/adversarial-scenario-ref.schema.json"
+      - "contracts/security/adversarial-scenario-ref.example.json"
+      - "tools/validate_adversarial_scenario_ref.py"
+      - "docs/ADVERSARIAL_SCENARIO_PLATFORM_BINDING.md"
+      - ".github/workflows/adversarial-scenario-ref.yml"
+      - "Makefile"
+      - "README.md"
+  push:
+    branches:
+      - main
+    paths:
+      - "contracts/security/adversarial-scenario-ref.schema.json"
+      - "contracts/security/adversarial-scenario-ref.example.json"
+      - "tools/validate_adversarial_scenario_ref.py"
+      - "docs/ADVERSARIAL_SCENARIO_PLATFORM_BINDING.md"
+      - ".github/workflows/adversarial-scenario-ref.yml"
+      - "Makefile"
+      - "README.md"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-adversarial-scenario-ref:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Validate adversarial scenario reference contract
+        run: make validate-adversarial-scenario-ref

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test-python-apps:
 	cd apps/evidence-receipts && test -d .venv || python3 -m venv .venv
 	cd apps/evidence-receipts && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt && pytest -q tests
 	cd apps/evidence-console && test -d .venv || python3 -m venv .venv
-	cd apps/evidence-console && . .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt && pytest -q tests
+	cd apps/evidence-console && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt && pytest -q tests
 	cd apps/zone-router && test -d .venv || python3 -m venv .venv
 	cd apps/zone-router && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-test.txt && PYTHONPATH=src pytest -q tests
 	cd apps/semantic-bridge && test -d .venv || python3 -m venv .venv

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check chronos-evidence-loop-readout-validate lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke validate-svf-agent-contract validate-environment-validate-change-v2 test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite trustops-art-runner-smoke
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check chronos-evidence-loop-readout-validate lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke validate-svf-agent-contract validate-environment-validate-change-v2 validate-adversarial-scenario-ref test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite trustops-art-runner-smoke
 
-validate: validate-repo drift-check standards-check topology-check chronos-evidence-loop-readout-validate lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke validate-svf-agent-contract validate-environment-validate-change-v2 test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite trustops-art-runner-smoke
+validate: validate-repo drift-check standards-check topology-check chronos-evidence-loop-readout-validate lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke validate-svf-agent-contract validate-environment-validate-change-v2 validate-adversarial-scenario-ref test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite trustops-art-runner-smoke
 
 validate-repo:
 	python3 tools/validate_repo.py
@@ -93,6 +93,9 @@ validate-svf-agent-contract:
 validate-environment-validate-change-v2:
 	python3 tools/validate_environment_validate_change_v2.py
 
+validate-adversarial-scenario-ref:
+	python3 tools/validate_adversarial_scenario_ref.py
+
 test-go:
 	go test ./libs/go/tritrpcbridge/...
 	go test ./apps/api/...
@@ -104,7 +107,7 @@ test-python-apps:
 	cd apps/evidence-receipts && test -d .venv || python3 -m venv .venv
 	cd apps/evidence-receipts && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt && pytest -q tests
 	cd apps/evidence-console && test -d .venv || python3 -m venv .venv
-	cd apps/evidence-console && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt && pytest -q tests
+	cd apps/evidence-console && . .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt && pytest -q tests
 	cd apps/zone-router && test -d .venv || python3 -m venv .venv
 	cd apps/zone-router && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-test.txt && PYTHONPATH=src pytest -q tests
 	cd apps/semantic-bridge && test -d .venv || python3 -m venv .venv

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Standards and governance stay in dedicated upstream repositories. `prophet-platf
 make validate
 make validate-svf-agent-contract
 make validate-environment-validate-change-v2
+make validate-adversarial-scenario-ref
 make smoke-health
 ```
 
@@ -30,8 +31,9 @@ make smoke-health
 3. `docs/TRITRPC_PLATFORM_BINDING.md`
 4. `docs/PLATFORM_EVAL_FABRIC.md`
 5. `docs/SVF_VALIDATE_CHANGE_AGENT_CONTRACT.md`
-6. `contracts/`
-7. `infra/k8s/`
+6. `docs/ADVERSARIAL_SCENARIO_PLATFORM_BINDING.md`
+7. `contracts/`
+8. `infra/k8s/`
 
 ## Sovereign Validation Fabric agent contract
 
@@ -70,6 +72,25 @@ make validate-environment-validate-change-v2
 ```
 
 Boundary: this is still a synthetic/no-network contract layer. It does not create live infrastructure, route traffic, isolate queues, isolate stateful resources, or certify Signadot-style runtime parity. AgentPlane owns execution/evidence. Sociosphere owns workspace/environment state. Prophet Platform owns this product/API invocation contract.
+
+## Adversarial scenario references
+
+Prophet Platform carries a narrow reference-only binding for governed SCOPE-D adversarial scenarios. This contract allows the platform to reference upstream scenario artifacts without creating a scenario builder, operator UI, runtime executor, report exporter, live collector, or memory writeback path.
+
+Relevant files:
+
+- `docs/ADVERSARIAL_SCENARIO_PLATFORM_BINDING.md`
+- `contracts/security/adversarial-scenario-ref.schema.json`
+- `contracts/security/adversarial-scenario-ref.example.json`
+- `tools/validate_adversarial_scenario_ref.py`
+
+Validate locally:
+
+```bash
+make validate-adversarial-scenario-ref
+```
+
+Boundary: scenario references are evidence-bearing pointers only. They do not grant runtime execution, procedure execution authority, engagement authorization, downstream activation, live target access, credential access, payload delivery, state mutation, destructive behavior, external delivery, report export, claim promotion, or memory writeback.
 
 ## Evaluation fabric lane
 

--- a/contracts/security/adversarial-scenario-ref.example.json
+++ b/contracts/security/adversarial-scenario-ref.example.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "0.1.0",
+  "scenarioRef": "adversarial-scenario:workspace-transduction-001",
+  "source": {
+    "scenarioRepo": "SocioProphet/SCOPE-D",
+    "scenarioPrRef": "SocioProphet/SCOPE-D#60",
+    "schemaRef": "config/schemas/wargames-adversarial-scenario.schema.json",
+    "ontologyRef": "SocioProphet/ontogenesis#112"
+  },
+  "bindingMode": "reference_only",
+  "platformUse": {
+    "apiSurface": "contract_reference",
+    "uiSurface": "none",
+    "runtimeExecution": false,
+    "reportExport": false,
+    "memoryWriteback": false,
+    "claimPromotion": false
+  },
+  "safetyBoundary": {
+    "nonProductionOnly": true,
+    "syntheticOrRedacted": true,
+    "liveTargetAccess": false,
+    "credentialAccess": false,
+    "payloadDelivery": false,
+    "stateMutation": false,
+    "destructiveBehavior": false,
+    "externalDelivery": false
+  },
+  "authority": {
+    "runtimeAuthority": false,
+    "procedureExecutionAuthority": false,
+    "engagementAuthorizationAuthority": false,
+    "activationAllowed": false
+  },
+  "evidenceRefs": [
+    "evidence:scout-header-summary-001",
+    "negative-evidence:missing-validator-record-001",
+    "proof:scout:profile-001"
+  ],
+  "runtimeDecisionReceiptRefs": ["wargames-runtime-receipt:allow-validate-001"],
+  "policyRefs": [
+    "policy:wargames-runtime-dry-run-v0.1",
+    "policy:scenario-boundary-reference-only"
+  ],
+  "semanticNonClaims": [
+    "does_not_execute_attack_procedure",
+    "does_not_authorize_engagement",
+    "does_not_claim_causal_attribution",
+    "does_not_promote_memory_writeback",
+    "does_not_establish_production_observation"
+  ],
+  "redactionState": "redacted"
+}

--- a/contracts/security/adversarial-scenario-ref.schema.json
+++ b/contracts/security/adversarial-scenario-ref.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/platform/adversarial-scenario-ref.schema.json",
+  "title": "Platform Adversarial Scenario Reference",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "scenarioRef",
+    "source",
+    "bindingMode",
+    "platformUse",
+    "safetyBoundary",
+    "authority",
+    "evidenceRefs",
+    "runtimeDecisionReceiptRefs",
+    "policyRefs",
+    "semanticNonClaims",
+    "redactionState"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "0.1.0" },
+    "scenarioRef": { "type": "string", "pattern": "^adversarial-scenario:[a-z0-9][a-z0-9._:-]*$" },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scenarioRepo", "scenarioPrRef", "schemaRef", "ontologyRef"],
+      "properties": {
+        "scenarioRepo": { "const": "SocioProphet/SCOPE-D" },
+        "scenarioPrRef": { "type": "string" },
+        "schemaRef": { "type": "string" },
+        "ontologyRef": { "type": "string" }
+      }
+    },
+    "bindingMode": { "enum": ["reference_only", "ingest_candidate"] },
+    "platformUse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["apiSurface", "uiSurface", "runtimeExecution", "reportExport", "memoryWriteback", "claimPromotion"],
+      "properties": {
+        "apiSurface": { "enum": ["none", "contract_reference", "future_api_candidate"] },
+        "uiSurface": { "enum": ["none", "future_operator_view_candidate"] },
+        "runtimeExecution": { "const": false },
+        "reportExport": { "const": false },
+        "memoryWriteback": { "const": false },
+        "claimPromotion": { "const": false }
+      }
+    },
+    "safetyBoundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["nonProductionOnly", "syntheticOrRedacted", "liveTargetAccess", "credentialAccess", "payloadDelivery", "stateMutation", "destructiveBehavior", "externalDelivery"],
+      "properties": {
+        "nonProductionOnly": { "const": true },
+        "syntheticOrRedacted": { "const": true },
+        "liveTargetAccess": { "const": false },
+        "credentialAccess": { "const": false },
+        "payloadDelivery": { "const": false },
+        "stateMutation": { "const": false },
+        "destructiveBehavior": { "const": false },
+        "externalDelivery": { "const": false }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runtimeAuthority", "procedureExecutionAuthority", "engagementAuthorizationAuthority", "activationAllowed"],
+      "properties": {
+        "runtimeAuthority": { "const": false },
+        "procedureExecutionAuthority": { "const": false },
+        "engagementAuthorizationAuthority": { "const": false },
+        "activationAllowed": { "const": false }
+      }
+    },
+    "evidenceRefs": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "runtimeDecisionReceiptRefs": { "type": "array", "minItems": 1, "items": { "type": "string", "pattern": "^wargames-runtime-receipt:[a-z0-9][a-z0-9._:-]*$" } },
+    "policyRefs": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "semanticNonClaims": { "type": "array", "minItems": 5, "items": { "type": "string" } },
+    "redactionState": { "enum": ["redacted", "synthetic", "withheld"] }
+  }
+}

--- a/docs/ADVERSARIAL_SCENARIO_PLATFORM_BINDING.md
+++ b/docs/ADVERSARIAL_SCENARIO_PLATFORM_BINDING.md
@@ -1,0 +1,71 @@
+# Adversarial Scenario Platform Binding
+
+Status: draft v0.1
+
+## Purpose
+
+This document defines the Prophet Platform binding for SCOPE-D adversarial scenario references.
+
+The platform binding is intentionally narrow. Prophet Platform may reference upstream governed scenario artifacts, but this tranche does not implement a scenario builder, operator UI, report exporter, runtime executor, live collector, or memory writeback path.
+
+## Ownership
+
+- SCOPE-D owns the executable adversarial scenario JSON contract and Wargames validation.
+- Ontogenesis owns the RDF/SHACL semantic projection.
+- Memory Mesh owns durable learning/writeback governance.
+- Prophet Workspace owns workspace channel/interface substrate contracts.
+- Prophet Platform owns this product/runtime reference binding.
+
+## Contract
+
+The platform-facing contract lives at:
+
+- `contracts/security/adversarial-scenario-ref.schema.json`
+- `contracts/security/adversarial-scenario-ref.example.json`
+- `tools/validate_adversarial_scenario_ref.py`
+
+Validate with:
+
+```bash
+make validate-adversarial-scenario-ref
+```
+
+## Boundary
+
+The binding is reference-only by default.
+
+It must not grant:
+
+- runtime execution;
+- procedure execution authority;
+- engagement authorization;
+- downstream activation;
+- live target access;
+- credential access;
+- payload delivery;
+- state mutation;
+- destructive behavior;
+- external delivery;
+- report export;
+- claim promotion;
+- memory writeback.
+
+## Required fields
+
+A scenario reference must carry:
+
+- `scenarioRef`;
+- SCOPE-D source repo and PR/schema references;
+- Ontogenesis semantic reference;
+- evidence refs;
+- runtime decision receipt refs;
+- policy refs;
+- explicit semantic non-claims;
+- redaction state;
+- fail-closed safety and authority fields.
+
+## Non-claims
+
+A platform scenario reference is not a finding, not a report, not a policy update, not a memory update, not an execution request, not a client delivery artifact, and not an authorization envelope.
+
+Platform services may later consume scenario references only after separate API/service design and validation gates are added.

--- a/tools/validate_adversarial_scenario_ref.py
+++ b/tools/validate_adversarial_scenario_ref.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts" / "security" / "adversarial-scenario-ref.schema.json"
+EXAMPLE = ROOT / "contracts" / "security" / "adversarial-scenario-ref.example.json"
+
+
+def load(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def check(name: str, ok: bool, detail=None):
+    return {"check": name, "passed": bool(ok), "detail": detail or []}
+
+
+def main() -> int:
+    schema = load(SCHEMA)
+    example = load(EXAMPLE)
+    out = []
+
+    out.append(check("schema-version", example.get("schemaVersion") == "0.1.0"))
+    out.append(check("scenario-ref", str(example.get("scenarioRef", "")).startswith("adversarial-scenario:")))
+    out.append(check("source-repo", example.get("source", {}).get("scenarioRepo") == "SocioProphet/SCOPE-D"))
+    out.append(check("binding-reference-only", example.get("bindingMode") == "reference_only"))
+
+    platform_use = example.get("platformUse", {})
+    out.append(check("platform-no-runtime-execution", platform_use.get("runtimeExecution") is False))
+    out.append(check("platform-no-report-export", platform_use.get("reportExport") is False))
+    out.append(check("platform-no-memory-writeback", platform_use.get("memoryWriteback") is False))
+    out.append(check("platform-no-claim-promotion", platform_use.get("claimPromotion") is False))
+
+    safety = example.get("safetyBoundary", {})
+    out.append(check("safety-non-production", safety.get("nonProductionOnly") is True))
+    for key in ["liveTargetAccess", "credentialAccess", "payloadDelivery", "stateMutation", "destructiveBehavior", "externalDelivery"]:
+        out.append(check(f"safety-{key}-false", safety.get(key) is False))
+
+    authority = example.get("authority", {})
+    for key in ["runtimeAuthority", "procedureExecutionAuthority", "engagementAuthorizationAuthority", "activationAllowed"]:
+        out.append(check(f"authority-{key}-false", authority.get(key) is False))
+
+    out.append(check("evidence-refs", isinstance(example.get("evidenceRefs"), list) and len(example["evidenceRefs"]) > 0))
+    out.append(check("runtime-decision-receipts", isinstance(example.get("runtimeDecisionReceiptRefs"), list) and len(example["runtimeDecisionReceiptRefs"]) > 0))
+    out.append(check("policy-refs", isinstance(example.get("policyRefs"), list) and len(example["policyRefs"]) > 0))
+    non_claims = set(example.get("semanticNonClaims", []))
+    out.append(check("non-claims-no-execution", "does_not_execute_attack_procedure" in non_claims))
+    out.append(check("non-claims-no-engagement", "does_not_authorize_engagement" in non_claims))
+    out.append(check("non-claims-no-memory-writeback", "does_not_promote_memory_writeback" in non_claims))
+
+    schema_required = set(schema.get("required", []))
+    example_keys = set(example.keys())
+    out.append(check("schema-required-covered", schema_required <= example_keys, [sorted(schema_required - example_keys)]))
+
+    passed = all(item["passed"] for item in out)
+    result = {"validator": "adversarial_scenario_ref.v0.1", "passed": passed, "results": out}
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if not passed:
+        print("FAIL: adversarial scenario reference contract", file=sys.stderr)
+        return 1
+    print("PASS: adversarial scenario reference contract")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a narrow Prophet Platform reference-only binding for governed SCOPE-D adversarial scenarios.

This gives Platform a way to reference upstream scenario artifacts without implementing a scenario builder, operator UI, runtime executor, report exporter, live collector, memory writeback path, or claim-promotion path.

## Adds

- `contracts/security/adversarial-scenario-ref.schema.json`
- `contracts/security/adversarial-scenario-ref.example.json`
- `tools/validate_adversarial_scenario_ref.py`
- `.github/workflows/adversarial-scenario-ref.yml`
- `docs/ADVERSARIAL_SCENARIO_PLATFORM_BINDING.md`

## Updates

- `Makefile`
  - adds `validate-adversarial-scenario-ref`
  - includes it in `make validate`
- `README.md`
  - adds adversarial scenario reference reading/validation guidance

## Boundary

Reference-only by default. No runtime execution, no procedure execution authority, no engagement authorization, no downstream activation, no live target access, no credential access, no payload delivery, no state mutation, no destructive behavior, no external delivery, no report export, no claim promotion, and no memory writeback.

## Relationship to upstreams

- SCOPE-D owns the executable adversarial scenario contract and validator.
- Ontogenesis owns the RDF/SHACL semantic projection.
- Memory Mesh owns durable learning/writeback governance.
- Prophet Workspace owns workspace channel/interface substrate contracts.
- Prophet Platform owns this product/runtime reference binding only.

## Acceptance criteria

- Scenario refs are accepted only as governed pointers.
- Platform safety and authority fields remain fail-closed.
- Runtime receipt, evidence, policy, and non-claim refs are required.
- `make validate-adversarial-scenario-ref` validates the example.