### PR TITLE
Add validate_change v2 API stub

### DIFF
--- a/.github/workflows/validate-change-v2-api-stub.yml
+++ b/.github/workflows/validate-change-v2-api-stub.yml
@@ -1,0 +1,27 @@
+name: validate-change-v2-api-stub
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Build API and gateway
+        run: |
+          go test ./libs/go/tritrpcbridge/...
+          go test ./apps/api/...
+          go test ./apps/gateway/...
+      - name: Validate environment contract fixtures
+        run: python3 tools/validate_environment_validate_change_v2.py
+      - name: Validate API stub wiring
+        run: python3 tools/smoke_validate_change_v2_api_stub.py

--- a/apps/api/cmd/socioprophet-api/main.go
+++ b/apps/api/cmd/socioprophet-api/main.go
@@ -10,6 +10,7 @@ import (
     "strings"
 
     "github.com/SocioProphet/prophet-platform/libs/go/tritrpcbridge/binding"
+    "github.com/SocioProphet/prophet-platform/libs/go/tritrpcbridge/tritrpcv1"
 )
 
 const defaultUnixSocket = "/tmp/socioprophet.sock"
@@ -63,13 +64,88 @@ func handle(c net.Conn, key [32]byte) {
     }
 }
 
-func handleHealth(c net.Conn, env interface{ }, key [32]byte) {
-    trienv, ok := env.(interface{ })
-    _ = trienv
+func handleHealth(c net.Conn, env *tritrpcv1.Envelope, key [32]byte) {
     var req binding.HealthPingRequest
-    payloadEnv, ok := any(env).(interface{ })
-    _ = payloadEnv
-    if err := binding.DecodeJSONPayload(any(env).(*struct{}), &req); err != nil {
-        _ = ok
+    if err := binding.DecodeJSONPayload(env, &req); err != nil {
+        log.Printf("decode health payload: %v", err)
+        return
+    }
+
+    resp := binding.HealthPingResponse{Ok: true, Pong: "PONG", Service: "socioprophet-api"}
+    if err := writeJSONResponse(c, binding.HealthService, binding.HealthPingRes, resp, key); err != nil {
+        log.Printf("write health response: %v", err)
+    }
+    _ = req // reserved for future trace/evidence hooks
+}
+
+func handleValidateChange(c net.Conn, env *tritrpcv1.Envelope, key [32]byte) {
+    var req map[string]any
+    if err := binding.DecodeJSONPayload(env, &req); err != nil {
+        log.Printf("decode validate_change payload: %v", err)
+        return
+    }
+
+    response := map[string]any{
+        "schema_version": "1.0",
+        "request_id": stringValue(req, "request_id", "environment:validate-change-v2-request:unknown"),
+        "response_id": "environment:validate-change-v2-response:requested:api-stub",
+        "status": "environment_requested",
+        "repo": stringValue(req, "repo", "unknown/unknown"),
+        "sociosphere_refs": req["sociosphere_refs"],
+        "selected_plans": req["selected_plans"],
+        "environment": req["environment_request"],
+        "agentplane_execution": map[string]any{
+            "executor_plane": "AgentPlane",
+            "sandbox_run_ref": "agentplane:sandbox-run:pending:api-stub",
+            "execution_status": "requested",
+            "evidence_refs": []string{},
+        },
+        "warnings": []string{
+            "validation_observation_missing",
+            "environment_execution_not_observed",
+        },
+        "next_required_action": "agentplane_synthetic_sandbox_run",
+        "non_claims": []string{
+            "API stub does not execute live sandbox infrastructure.",
+            "API stub does not certify Signadot-style runtime parity.",
+            "API stub returns a deterministic environment_requested response only.",
+        },
+    }
+
+    if err := writeJSONResponse(c, binding.ValidateChangeService, binding.ValidateChangeRes, response, key); err != nil {
+        log.Printf("write validate_change response: %v", err)
     }
 }
+
+func writeJSONResponse(c net.Conn, service string, method string, payload any, key [32]byte) error {
+    respNonce, respFrame, err := binding.MarshalJSONFrame(service, method, payload, key)
+    if err != nil {
+        return err
+    }
+    return binding.WriteRecord(c, respNonce, respFrame)
+}
+
+func stringValue(m map[string]any, key string, fallback string) string {
+    if value, ok := m[key].(string); ok && strings.TrimSpace(value) != "" {
+        return value
+    }
+    return fallback
+}
+
+func legacySockAddr() string {
+    if sock := strings.TrimSpace(os.Getenv("TRITRPC_SOCK")); sock != "" {
+        return "unix://" + sock
+    }
+    return ""
+}
+
+func firstNonEmpty(vs ...string) string {
+    for _, v := range vs {
+        if strings.TrimSpace(v) != "" {
+            return v
+        }
+    }
+    return ""
+}
+
+var _ = json.Valid

--- a/apps/api/cmd/socioprophet-api/main.go
+++ b/apps/api/cmd/socioprophet-api/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+    "encoding/json"
     "errors"
     "io"
     "log"
@@ -51,41 +52,24 @@ func handle(c net.Conn, key [32]byte) {
         log.Printf("verify envelope: %v", err)
         return
     }
-    if env.Service != binding.HealthService || env.Method != binding.HealthPingReq {
+
+    switch {
+    case env.Service == binding.HealthService && env.Method == binding.HealthPingReq:
+        handleHealth(c, env, key)
+    case env.Service == binding.ValidateChangeService && env.Method == binding.ValidateChangeReq:
+        handleValidateChange(c, env, key)
+    default:
         log.Printf("unexpected route: %s %s", env.Service, env.Method)
-        return
     }
+}
+
+func handleHealth(c net.Conn, env interface{ }, key [32]byte) {
+    trienv, ok := env.(interface{ })
+    _ = trienv
     var req binding.HealthPingRequest
-    if err := binding.DecodeJSONPayload(env, &req); err != nil {
-        log.Printf("decode request payload: %v", err)
-        return
+    payloadEnv, ok := any(env).(interface{ })
+    _ = payloadEnv
+    if err := binding.DecodeJSONPayload(any(env).(*struct{}), &req); err != nil {
+        _ = ok
     }
-
-    resp := binding.HealthPingResponse{Ok: true, Pong: "PONG", Service: "socioprophet-api"}
-    respNonce, respFrame, err := binding.MarshalJSONFrame(binding.HealthService, binding.HealthPingRes, resp, key)
-    if err != nil {
-        log.Printf("marshal response: %v", err)
-        return
-    }
-    if err := binding.WriteRecord(c, respNonce, respFrame); err != nil {
-        log.Printf("write response: %v", err)
-        return
-    }
-    _ = req // reserved for future trace/evidence hooks
-}
-
-func legacySockAddr() string {
-    if sock := strings.TrimSpace(os.Getenv("TRITRPC_SOCK")); sock != "" {
-        return "unix://" + sock
-    }
-    return ""
-}
-
-func firstNonEmpty(vs ...string) string {
-    for _, v := range vs {
-        if strings.TrimSpace(v) != "" {
-            return v
-        }
-    }
-    return ""
 }

--- a/apps/gateway/cmd/tritrpc-gateway/main.go
+++ b/apps/gateway/cmd/tritrpc-gateway/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+    "bytes"
     "encoding/json"
     "fmt"
     "io"
@@ -45,6 +46,18 @@ func newMux(target string, key [32]byte, evidenceBase string, consoleBase string
             return
         }
         _ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "pong": pong.Pong, "service": pong.Service})
+    })
+
+    mux.HandleFunc("/v1/validate-change", func(w http.ResponseWriter, r *http.Request) {
+        resp, err := validateChange(target, key, r)
+        if err != nil {
+            log.Printf("validate_change error: %v", err)
+            w.WriteHeader(http.StatusBadGateway)
+            _ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": err.Error()})
+            return
+        }
+        w.Header().Set("Content-Type", "application/json")
+        _, _ = w.Write(resp)
     })
 
     if evidenceBase != "" {
@@ -149,6 +162,50 @@ func ping(target string, key [32]byte) (*binding.HealthPingResponse, error) {
         return nil, err
     }
     return &resp, nil
+}
+
+func validateChange(target string, key [32]byte, r *http.Request) ([]byte, error) {
+    if r.Method != http.MethodPost {
+        return nil, fmt.Errorf("method not allowed: %s", r.Method)
+    }
+    body, err := io.ReadAll(io.LimitReader(r.Body, binding.MaxFrameBytes))
+    if err != nil {
+        return nil, err
+    }
+    if !json.Valid(body) {
+        return nil, fmt.Errorf("invalid JSON request body")
+    }
+
+    c, resolved, err := binding.Dial(target, defaultUnixSocket)
+    if err != nil {
+        return nil, err
+    }
+    defer c.Close()
+
+    var payload map[string]any
+    if err := json.NewDecoder(bytes.NewReader(body)).Decode(&payload); err != nil {
+        return nil, err
+    }
+    nonce, frame, err := binding.MarshalJSONFrame(binding.ValidateChangeService, binding.ValidateChangeReq, payload, key)
+    if err != nil {
+        return nil, err
+    }
+    if err := binding.WriteRecord(c, nonce, frame); err != nil {
+        return nil, err
+    }
+
+    respNonce, respFrame, err := binding.ReadRecord(c)
+    if err != nil {
+        return nil, err
+    }
+    env, err := binding.VerifyEnvelope(respFrame, respNonce, key)
+    if err != nil {
+        return nil, err
+    }
+    if env.Service != binding.ValidateChangeService || env.Method != binding.ValidateChangeRes {
+        return nil, fmt.Errorf("unexpected validate_change route from %s: %s %s", resolved, env.Service, env.Method)
+    }
+    return env.Payload, nil
 }
 
 func legacySockAddr() string {

--- a/libs/go/tritrpcbridge/binding/binding.go
+++ b/libs/go/tritrpcbridge/binding/binding.go
@@ -17,12 +17,15 @@ import (
 )
 
 const (
-    HealthService    = "platform.health.v1"
-    HealthPingReq    = "Health.Ping.REQ"
-    HealthPingRes    = "Health.Ping.RES"
-    NonceSize        = chacha20poly1305.NonceSizeX
-    recordHeaderSize = 4 + NonceSize
-    MaxFrameBytes    = 1 << 20
+    HealthService       = "platform.health.v1"
+    HealthPingReq       = "Health.Ping.REQ"
+    HealthPingRes       = "Health.Ping.RES"
+    ValidateChangeService = "platform.validate_change.v2"
+    ValidateChangeReq     = "ValidateChange.Environment.REQ"
+    ValidateChangeRes     = "ValidateChange.Environment.RES"
+    NonceSize           = chacha20poly1305.NonceSizeX
+    recordHeaderSize    = 4 + NonceSize
+    MaxFrameBytes       = 1 << 20
 )
 
 var (

--- a/tools/smoke_validate_change_v2_api_stub.py
+++ b/tools/smoke_validate_change_v2_api_stub.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BINDING = ROOT / "libs" / "go" / "tritrpcbridge" / "binding" / "binding.go"
+API = ROOT / "apps" / "api" / "cmd" / "socioprophet-api" / "main.go"
+GATEWAY = ROOT / "apps" / "gateway" / "cmd" / "tritrpc-gateway" / "main.go"
+REQUEST = ROOT / "contracts" / "environment" / "validate-change-v2-request.example.json"
+
+REQUIRED_BINDING = [
+    'ValidateChangeService = "platform.validate_change.v2"',
+    'ValidateChangeReq     = "ValidateChange.Environment.REQ"',
+    'ValidateChangeRes     = "ValidateChange.Environment.RES"',
+]
+REQUIRED_API = [
+    "handleValidateChange",
+    "binding.ValidateChangeService",
+    "binding.ValidateChangeReq",
+    '"status": "environment_requested"',
+    '"agentplane_synthetic_sandbox_run"',
+    '"API stub does not execute live sandbox infrastructure."',
+]
+REQUIRED_GATEWAY = [
+    'mux.HandleFunc("/v1/validate-change"',
+    "func validateChange(",
+    "binding.ValidateChangeService",
+    "binding.ValidateChangeReq",
+    "binding.ValidateChangeRes",
+]
+
+
+def require(text: str, needle: str, surface: str, problems: list[str]) -> None:
+    if needle not in text:
+        problems.append(f"missing {needle!r} in {surface}")
+
+
+def main() -> int:
+    problems: list[str] = []
+    binding = BINDING.read_text(encoding="utf-8")
+    api = API.read_text(encoding="utf-8")
+    gateway = GATEWAY.read_text(encoding="utf-8")
+    request = json.loads(REQUEST.read_text(encoding="utf-8"))
+
+    for needle in REQUIRED_BINDING:
+        require(binding, needle, str(BINDING.relative_to(ROOT)), problems)
+    for needle in REQUIRED_API:
+        require(api, needle, str(API.relative_to(ROOT)), problems)
+    for needle in REQUIRED_GATEWAY:
+        require(gateway, needle, str(GATEWAY.relative_to(ROOT)), problems)
+
+    if request.get("execution", {}).get("executor_plane") != "AgentPlane":
+        problems.append("request fixture executor_plane must be AgentPlane")
+    if request.get("environment_request", {}).get("requested_isolation_class") != "synthetic_no_network":
+        problems.append("request fixture must remain synthetic_no_network")
+
+    result = {
+        "validator": "prophet-platform.validate-change-v2.api-stub-smoke.v1",
+        "passed": not problems,
+        "problems": problems,
+        "non_claims": [
+            "Smoke check does not execute live sandbox infrastructure.",
+            "Smoke check does not certify Signadot-style runtime parity.",
+            "Smoke check validates route/contract wiring only."
+        ]
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    print(("PASS" if not problems else "FAIL") + ": validate_change v2 API stub smoke")
+    return 0 if not problems else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Purpose

Start Tranche 2 of the Signadot-parity bridge by adding a Prophet Platform API/gateway stub for `validate_change` v2 environment validation.

## Scope

This PR adds:

- TriTRPC route constants for `platform.validate_change.v2`
- API handling for `ValidateChange.Environment.REQ`
- deterministic `environment_requested` response behavior
- HTTP gateway route `POST /v1/validate-change`
- route/contract smoke check
- scoped workflow for validate-change-v2 API stub validation

## Boundary

This is still a synthetic/no-network stub. It does not execute live sandbox infrastructure, does not issue real AgentPlane evidence, does not route traffic into an isolated environment, and does not certify Signadot-style runtime parity.

## Expected validation

- `go test ./libs/go/tritrpcbridge/...`
- `go test ./apps/api/...`
- `go test ./apps/gateway/...`
- `python3 tools/validate_environment_validate_change_v2.py`
- `python3 tools/smoke_validate_change_v2_api_stub.py`