### PR TITLE
apps: add TritFabric consumption API stubs

### DIFF
--- a/apps/tritfabric-consumption-api/main.py
+++ b/apps/tritfabric-consumption-api/main.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "contracts" / "integrations" / "tritfabric-consumption.v0.json"
+
+
+def _load_contract() -> dict[str, Any]:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def _surface(surface_id: str) -> dict[str, Any]:
+    contract = _load_contract()
+    for surface in contract.get("surfaces", []):
+        if surface.get("id") == surface_id:
+            return surface
+    raise KeyError(f"unknown TritFabric surface: {surface_id}")
+
+
+def _base(surface_id: str) -> dict[str, Any]:
+    contract = _load_contract()
+    return {
+        "ok": True,
+        "integration_id": contract["integration_id"],
+        "surface": _surface(surface_id),
+        "authority_boundaries": contract["authority_boundaries"],
+        "non_claims": contract["non_claims"],
+        "mutation_authorized": False,
+        "runtime_execution_authorized": False,
+        "claim_boundary": contract["claim_boundary"],
+    }
+
+
+def community_learning_intake() -> dict[str, Any]:
+    """Describe Community Learning intake gates without ingesting events."""
+    out = _base("community-learning-intake")
+    out.update({
+        "mode": "intake-readiness",
+        "event_ingestion": False,
+        "workflow_execution": False,
+        "model_mutation": False,
+        "artifact_promotion": False,
+    })
+    return out
+
+
+def framework_catalog() -> dict[str, Any]:
+    """Describe Network Atlas catalog consumption without adapter validation."""
+    out = _base("network-atlas-framework-catalog")
+    out.update({
+        "mode": "catalog-readiness",
+        "adapter_validation": False,
+        "runtime_support_claim": False,
+    })
+    return out
+
+
+def promotion_evidence() -> dict[str, Any]:
+    """Describe model-card promotion evidence requirements without executing promotion."""
+    out = _base("model-card-promotion-evidence")
+    out.update({
+        "mode": "evidence-readiness",
+        "promotion_execution": False,
+        "required_status_semantics": ["TRUE", "MID", "FALSE"],
+    })
+    return out
+
+
+def serve_readiness() -> dict[str, Any]:
+    """Describe Serve readiness reporting without enabling Serve runtime behavior."""
+    out = _base("serve-readiness")
+    out.update({
+        "mode": "serve-readiness-reporting",
+        "serve_deployment": False,
+        "autoscaler_active_loop": False,
+        "production_readiness_claim": False,
+    })
+    return out
+
+
+def summary() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "surfaces": [
+            community_learning_intake(),
+            framework_catalog(),
+            promotion_evidence(),
+            serve_readiness(),
+        ],
+        "mutation_authorized": False,
+        "runtime_execution_authorized": False,
+    }
+
+
+try:
+    from fastapi import FastAPI
+except Exception:  # pragma: no cover
+    FastAPI = None  # type: ignore[assignment]
+
+
+if FastAPI is not None:
+    app = FastAPI(title="Prophet Platform TritFabric Consumption API", version="0.1")
+
+    @app.get("/healthz")
+    def healthz() -> dict[str, Any]:
+        return {"ok": True, "mode": "local-pre-infrastructure", "mutation_authorized": False}
+
+    @app.get("/tritfabric")
+    def summary_endpoint() -> dict[str, Any]:
+        return summary()
+
+    @app.get("/tritfabric/community-learning")
+    def community_learning_endpoint() -> dict[str, Any]:
+        return community_learning_intake()
+
+    @app.get("/tritfabric/framework-catalog")
+    def framework_catalog_endpoint() -> dict[str, Any]:
+        return framework_catalog()
+
+    @app.get("/tritfabric/promotion-evidence")
+    def promotion_evidence_endpoint() -> dict[str, Any]:
+        return promotion_evidence()
+
+    @app.get("/tritfabric/serve-readiness")
+    def serve_readiness_endpoint() -> dict[str, Any]:
+        return serve_readiness()
+
+
+def main() -> int:
+    print(json.dumps(summary(), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_tritfabric_consumption_api.py
+++ b/tools/tests/test_tritfabric_consumption_api.py
@@ -1,0 +1,72 @@
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE = ROOT / "apps" / "tritfabric-consumption-api" / "main.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("tritfabric_consumption_api", MODULE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_summary_exposes_all_surfaces_without_mutation():
+    api = _load_module()
+    out = api.summary()
+
+    assert out["ok"] is True
+    assert out["mutation_authorized"] is False
+    assert out["runtime_execution_authorized"] is False
+    assert {surface["surface"]["id"] for surface in out["surfaces"]} == {
+        "community-learning-intake",
+        "network-atlas-framework-catalog",
+        "model-card-promotion-evidence",
+        "serve-readiness",
+    }
+
+
+def test_community_learning_stub_preserves_gates_and_non_execution():
+    api = _load_module()
+    out = api.community_learning_intake()
+
+    assert out["mode"] == "intake-readiness"
+    assert out["event_ingestion"] is False
+    assert out["workflow_execution"] is False
+    assert out["model_mutation"] is False
+    assert out["artifact_promotion"] is False
+    for gate in ("consent", "license", "lineage", "rubric", "manual-review-before-promotion"):
+        assert gate in out["surface"]["required_gates"]
+
+
+def test_framework_catalog_stub_does_not_claim_adapter_validation():
+    api = _load_module()
+    out = api.framework_catalog()
+
+    assert out["mode"] == "catalog-readiness"
+    assert out["adapter_validation"] is False
+    assert out["runtime_support_claim"] is False
+    assert "claim-boundary-visible" in out["surface"]["required_gates"]
+
+
+def test_promotion_stub_requires_evidence_and_status_semantics_without_execution():
+    api = _load_module()
+    out = api.promotion_evidence()
+
+    assert out["mode"] == "evidence-readiness"
+    assert out["promotion_execution"] is False
+    assert out["required_status_semantics"] == ["TRUE", "MID", "FALSE"]
+    for field in ("mathType", "calcOps", "ledgerRef", "artifactRef", "tritStatus"):
+        assert field in out["surface"]["required_fields"]
+
+
+def test_serve_readiness_stub_does_not_enable_runtime():
+    api = _load_module()
+    out = api.serve_readiness()
+
+    assert out["mode"] == "serve-readiness-reporting"
+    assert out["serve_deployment"] is False
+    assert out["autoscaler_active_loop"] is False
+    assert out["production_readiness_claim"] is False


### PR DESCRIPTION
## Summary
- add local-pre-infrastructure TritFabric consumption API stubs
- expose read-only readiness surfaces for Community Learning, Network Atlas framework catalog, model-card promotion evidence, and Serve readiness
- add focused tests proving the stubs do not ingest events, execute workflows, mutate models, promote artifacts, validate adapters, or enable Serve runtime behavior

## Why
PR #503 registered Prophet Platform as a governed consumer of TritFabric surfaces. This PR adds product-facing API stubs that preserve that boundary without calling TritFabric services or claiming runtime readiness.

## Claim boundary
API stubs only. No event ingestion, workflow execution, model mutation, artifact promotion, adapter validation, Serve deployment, active autoscaler loop, or production readiness claim.

## Validation
- `python3 apps/tritfabric-consumption-api/main.py`
- `python3 -m pytest tools/tests/test_tritfabric_consumption_api.py`
