### PR TITLE
ci: add TritFabric API stub workflow

### DIFF
--- a/.github/workflows/tritfabric-consumption-api-stubs.yml
+++ b/.github/workflows/tritfabric-consumption-api-stubs.yml
@@ -1,0 +1,41 @@
+name: tritfabric-consumption-api-stubs
+
+on:
+  pull_request:
+    paths:
+      - "apps/tritfabric-consumption-api/**"
+      - "tools/run_tritfabric_consumption_api_stubs.py"
+      - "tools/tests/test_tritfabric_consumption_api.py"
+      - "contracts/integrations/tritfabric-consumption.v0.json"
+      - ".github/workflows/tritfabric-consumption-api-stubs.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/tritfabric-consumption-api/**"
+      - "tools/run_tritfabric_consumption_api_stubs.py"
+      - "tools/tests/test_tritfabric_consumption_api.py"
+      - "contracts/integrations/tritfabric-consumption.v0.json"
+      - ".github/workflows/tritfabric-consumption-api-stubs.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  tritfabric-consumption-api-stubs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependency
+        run: python -m pip install pytest
+
+      - name: Run TritFabric API stub runner
+        run: python3 tools/run_tritfabric_consumption_api_stubs.py
+
+      - name: Run focused TritFabric API stub tests
+        run: python3 -m pytest tools/tests/test_tritfabric_consumption_api.py


### PR DESCRIPTION
## Summary
- add a focused `tritfabric-consumption-api-stubs` workflow
- run `tools/run_tritfabric_consumption_api_stubs.py`
- run the focused TritFabric API stub pytest file
- scope the workflow to TritFabric API stub, runner, test, contract, and workflow path changes

## Why
The TritFabric consumption API stubs now have a standalone runner. This PR adds a focused CI lane for that surface without touching the broad `ci` or `validate` workflows.

## Claim boundary
CI wiring only. No runtime behavior, event ingestion, workflow execution, model mutation, artifact promotion, adapter validation, Serve deployment, active autoscaler loop, or production readiness claim.

## Validation
- focused GitHub Actions workflow: `tritfabric-consumption-api-stubs`
