### PR TITLE
test: harden DevSecOps Workroom negative fixtures

### DIFF
--- a/tests/fixtures/workroom/devsecops-workroom.causal-claim-without-evidence.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.causal-claim-without-evidence.invalid.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:causal-no-evidence",
+  "lane": "pre_merge_validation",
+  "runtime_parity_level": "synthetic_observed",
+  "source_refs": {
+    "change_set_ref": "changeset://github/SocioProphet/example/pull/1",
+    "environment_request_ref": "environment:validate-change-v2-request:invalid",
+    "validation_run_ref": "agentplane:runtime-sandbox-run:invalid",
+    "topology_ref": "topology://gaia/workroom/invalid/pre-merge"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:pre-merge-validation-failure:invalid",
+    "event_type": "pre_merge_validation_failure",
+    "source_lane": "pre_merge_validation",
+    "status": "open",
+    "summary": "Invalid fixture used to prove validator failure mode.",
+    "environment_ref": "environment://synthetic/invalid",
+    "topology_ref": "topology://gaia/workroom/invalid/pre-merge",
+    "evidence_refs": [
+      "evidence://fixture/invalid/evidence"
+    ],
+    "claim_refs": [
+      "rca-claim:invalid:causal-no-evidence"
+    ],
+    "decision_state": "blocked",
+    "non_claims": [
+      "Invalid fixture is expected to fail."
+    ]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://fixture/invalid/evidence",
+      "evidence_type": "validation_result",
+      "producer": "Prophet Platform negative fixture",
+      "summary": "Negative fixture evidence packet.",
+      "observed_at": "2026-05-31T17:30:00Z",
+      "provenance": {
+        "source_system": "Prophet Platform",
+        "source_ref": "validation-plan://invalid",
+        "collection_method": "negative_fixture"
+      },
+      "non_claims": [
+        "Fixture evidence is synthetic."
+      ]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:invalid:causal-no-evidence",
+      "claim_status": "supported_causal_claim",
+      "statement": "Negative fixture baseline observation.",
+      "evidence_refs": [],
+      "counterevidence_refs": [],
+      "confidence": "low",
+      "non_claims": [
+        "Negative fixture claim is not real RCA."
+      ]
+    }
+  ],
+  "action_grants": [
+    {
+      "grant_id": "action-grant:invalid:read",
+      "action_class": "read_only",
+      "status": "allowed",
+      "scope": "Read negative fixture evidence.",
+      "approval_required": false,
+      "non_claims": [
+        "Read-only fixture grant only."
+      ]
+    }
+  ],
+  "remediation_plans": [
+    {
+      "plan_id": "remediation-plan:invalid:read-only",
+      "plan_status": "candidate",
+      "risk_class": "low",
+      "summary": "Negative fixture candidate remediation.",
+      "evidence_refs": [
+        "evidence://fixture/invalid/evidence"
+      ],
+      "required_action_grant_refs": [],
+      "non_claims": [
+        "Candidate only."
+      ]
+    }
+  ],
+  "regression_fixtures": [
+    {
+      "fixture_id": "regression-fixture:invalid:candidate",
+      "fixture_status": "candidate",
+      "derived_from": "bde:pre-merge-validation-failure:invalid",
+      "summary": "Negative fixture candidate.",
+      "target_validation_plan_ref": "validation-plan://invalid",
+      "non_claims": [
+        "Candidate only."
+      ]
+    }
+  ],
+  "issued_at": "2026-05-31T17:31:00Z",
+  "non_claims": [
+    "This is an expected-failing negative fixture."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-workroom.plan-without-grant.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.plan-without-grant.invalid.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:plan-no-grant",
+  "lane": "pre_merge_validation",
+  "runtime_parity_level": "synthetic_observed",
+  "source_refs": {
+    "change_set_ref": "changeset://github/SocioProphet/example/pull/1",
+    "environment_request_ref": "environment:validate-change-v2-request:invalid",
+    "validation_run_ref": "agentplane:runtime-sandbox-run:invalid"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:pre-merge-validation-failure:invalid",
+    "event_type": "pre_merge_validation_failure",
+    "source_lane": "pre_merge_validation",
+    "status": "open",
+    "summary": "Invalid fixture used to prove missing grant rejection.",
+    "evidence_refs": ["evidence://fixture/invalid/evidence"],
+    "claim_refs": ["rca-claim:invalid:claim"],
+    "decision_state": "blocked",
+    "non_claims": ["Invalid fixture is expected to fail."]
+  },
+  "evidence_packets": [{"evidence_ref": "evidence://fixture/invalid/evidence", "evidence_type": "validation_result", "producer": "Prophet Platform negative fixture", "summary": "Negative fixture evidence packet.", "observed_at": "2026-05-31T17:30:00Z", "provenance": {"source_system": "Prophet Platform", "source_ref": "validation-plan://invalid"}, "non_claims": ["Fixture evidence is synthetic."]}],
+  "rca_claims": [{"claim_id": "rca-claim:invalid:claim", "claim_status": "observation", "statement": "Negative fixture baseline observation.", "evidence_refs": ["evidence://fixture/invalid/evidence"], "counterevidence_refs": [], "confidence": "low", "non_claims": ["Negative fixture claim is not real RCA."]}],
+  "action_grants": [],
+  "remediation_plans": [{"plan_id": "remediation-plan:invalid:plan-no-grant", "plan_status": "candidate", "risk_class": "high", "summary": "Invalid candidate plan omits its required grant reference.", "evidence_refs": ["evidence://fixture/invalid/evidence"], "required_action_grant_refs": [], "non_claims": ["Candidate only."]}],
+  "regression_fixtures": [{"fixture_id": "regression-fixture:invalid:candidate", "fixture_status": "candidate", "derived_from": "bde:pre-merge-validation-failure:invalid", "summary": "Negative fixture candidate.", "target_validation_plan_ref": "validation-plan://invalid", "non_claims": ["Candidate only."]}],
+  "issued_at": "2026-05-31T17:31:00Z",
+  "non_claims": ["This is an expected-failing negative fixture."]
+}

--- a/tests/fixtures/workroom/devsecops-workroom.post-merge-missing-investigation-ref.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.post-merge-missing-investigation-ref.invalid.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:missing-investigation-ref",
+  "lane": "post_merge_incident",
+  "runtime_parity_level": "contract_only",
+  "source_refs": {
+    "incident_ref": "incident://fixture/INC-NEGATIVE"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:invalid",
+    "event_type": "production_incident",
+    "source_lane": "post_merge_incident",
+    "status": "investigating",
+    "summary": "Invalid fixture omits the investigation run reference required by the incident lane.",
+    "evidence_refs": ["evidence://fixture/invalid/evidence"],
+    "claim_refs": ["rca-claim:invalid:claim"],
+    "decision_state": "needs_review",
+    "non_claims": ["Invalid fixture is expected to fail."]
+  },
+  "evidence_packets": [{"evidence_ref": "evidence://fixture/invalid/evidence", "evidence_type": "metric_observation", "producer": "Prophet Platform negative fixture", "summary": "Negative fixture evidence packet.", "observed_at": "2026-05-31T17:30:00Z", "provenance": {"source_system": "Prophet Platform", "source_ref": "incident://fixture/INC-NEGATIVE"}, "non_claims": ["Fixture evidence is synthetic."]}],
+  "rca_claims": [{"claim_id": "rca-claim:invalid:claim", "claim_status": "observation", "statement": "Negative fixture baseline observation.", "evidence_refs": ["evidence://fixture/invalid/evidence"], "counterevidence_refs": [], "confidence": "low", "non_claims": ["Negative fixture claim is not real RCA."]}],
+  "action_grants": [],
+  "remediation_plans": [],
+  "regression_fixtures": [{"fixture_id": "regression-fixture:invalid:candidate", "fixture_status": "candidate", "derived_from": "bde:production-incident:invalid", "summary": "Negative fixture candidate.", "target_validation_plan_ref": "validation-plan://invalid", "non_claims": ["Candidate only."]}],
+  "issued_at": "2026-05-31T17:31:00Z",
+  "non_claims": ["This is an expected-failing negative fixture."]
+}

--- a/tests/fixtures/workroom/devsecops-workroom.pre-merge-production-incident.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.pre-merge-production-incident.invalid.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:pre-merge-incident-type",
+  "lane": "pre_merge_validation",
+  "runtime_parity_level": "synthetic_observed",
+  "source_refs": {
+    "change_set_ref": "changeset://github/SocioProphet/example/pull/1",
+    "environment_request_ref": "environment:validate-change-v2-request:invalid",
+    "validation_run_ref": "agentplane:runtime-sandbox-run:invalid"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:pre-merge-validation-failure:invalid",
+    "event_type": "production_incident",
+    "source_lane": "pre_merge_validation",
+    "status": "open",
+    "summary": "Invalid fixture uses an incident-class event in the pre-merge validation lane.",
+    "evidence_refs": ["evidence://fixture/invalid/evidence"],
+    "claim_refs": ["rca-claim:invalid:claim"],
+    "decision_state": "blocked",
+    "non_claims": ["Invalid fixture is expected to fail."]
+  },
+  "evidence_packets": [{"evidence_ref": "evidence://fixture/invalid/evidence", "evidence_type": "validation_result", "producer": "Prophet Platform negative fixture", "summary": "Negative fixture evidence packet.", "observed_at": "2026-05-31T17:30:00Z", "provenance": {"source_system": "Prophet Platform", "source_ref": "validation-plan://invalid"}, "non_claims": ["Fixture evidence is synthetic."]}],
+  "rca_claims": [{"claim_id": "rca-claim:invalid:claim", "claim_status": "observation", "statement": "Negative fixture baseline observation.", "evidence_refs": ["evidence://fixture/invalid/evidence"], "counterevidence_refs": [], "confidence": "low", "non_claims": ["Negative fixture claim is not real RCA."]}],
+  "action_grants": [],
+  "remediation_plans": [],
+  "regression_fixtures": [{"fixture_id": "regression-fixture:invalid:candidate", "fixture_status": "candidate", "derived_from": "bde:pre-merge-validation-failure:invalid", "summary": "Negative fixture candidate.", "target_validation_plan_ref": "validation-plan://invalid", "non_claims": ["Candidate only."]}],
+  "issued_at": "2026-05-31T17:31:00Z",
+  "non_claims": ["This is an expected-failing negative fixture."]
+}

--- a/tests/fixtures/workroom/devsecops-workroom.runtime-observed-without-parity-gate.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.runtime-observed-without-parity-gate.invalid.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:runtime-observed",
+  "lane": "pre_merge_validation",
+  "runtime_parity_level": "runtime_observed",
+  "source_refs": {
+    "change_set_ref": "changeset://github/SocioProphet/example/pull/1",
+    "environment_request_ref": "environment:validate-change-v2-request:invalid",
+    "validation_run_ref": "agentplane:runtime-sandbox-run:invalid"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:pre-merge-validation-failure:invalid",
+    "event_type": "pre_merge_validation_failure",
+    "source_lane": "pre_merge_validation",
+    "status": "open",
+    "summary": "Invalid fixture claims observed runtime parity before external parity gates supply evidence.",
+    "evidence_refs": ["evidence://fixture/invalid/evidence"],
+    "claim_refs": ["rca-claim:invalid:claim"],
+    "decision_state": "blocked",
+    "non_claims": ["Invalid fixture is expected to fail."]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://fixture/invalid/evidence",
+      "evidence_type": "validation_result",
+      "producer": "Prophet Platform negative fixture",
+      "summary": "Negative fixture evidence packet.",
+      "observed_at": "2026-05-31T17:30:00Z",
+      "provenance": {"source_system": "Prophet Platform", "source_ref": "validation-plan://invalid", "collection_method": "negative_fixture"},
+      "non_claims": ["Fixture evidence is synthetic."]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:invalid:claim",
+      "claim_status": "observation",
+      "statement": "Negative fixture baseline observation.",
+      "evidence_refs": ["evidence://fixture/invalid/evidence"],
+      "counterevidence_refs": [],
+      "confidence": "low",
+      "non_claims": ["Negative fixture claim is not real RCA."]
+    }
+  ],
+  "action_grants": [],
+  "remediation_plans": [],
+  "regression_fixtures": [
+    {"fixture_id": "regression-fixture:invalid:candidate", "fixture_status": "candidate", "derived_from": "bde:pre-merge-validation-failure:invalid", "summary": "Negative fixture candidate.", "target_validation_plan_ref": "validation-plan://invalid", "non_claims": ["Candidate only."]}
+  ],
+  "issued_at": "2026-05-31T17:31:00Z",
+  "non_claims": ["This is an expected-failing negative fixture."]
+}

--- a/tools/validate_devsecops_workroom.py
+++ b/tools/validate_devsecops_workroom.py
@@ -9,10 +9,30 @@ from jsonschema import Draft202012Validator
 
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-workroom-v0.1.schema.json"
-FIXTURES = [
+VALID_FIXTURES = [
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.pre-merge-validation-failure.valid.json",
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.post-merge-incident.valid.json",
 ]
+INVALID_FIXTURES = {
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.causal-claim-without-evidence.invalid.json": [
+        "causal claims require evidence refs",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.high-risk-remediation-without-grant.invalid.json": [
+        "high/critical remediation requires action grant refs",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.mutation-action-without-approval.invalid.json": [
+        "mutation-class actions cannot be allowed without approval requirement",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.runtime-observed-without-parity-gate.invalid.json": [
+        "v0.1 fixture must not claim runtime_observed",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.pre-merge-production-incident.invalid.json": [
+        "pre_merge_validation lane must not use production_incident event_type",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.post-merge-missing-investigation-ref.invalid.json": [
+        "post_merge_incident lane requires source_refs.investigation_run_ref",
+    ],
+}
 
 CLAIM_STATUSES = {
     "observation",
@@ -68,6 +88,7 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
 
     lane = data.get("lane")
     parity = data.get("runtime_parity_level")
+    source_refs = data.get("source_refs", {})
     bde = data.get("behavioral_divergence_event", {})
     evidence_packets = data.get("evidence_packets", [])
     claims = data.get("rca_claims", [])
@@ -79,6 +100,19 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
         problems.append("lane must be pre_merge_validation or post_merge_incident")
     if parity not in {"contract_only", "synthetic_observed", "runtime_observed"}:
         problems.append("runtime_parity_level is invalid")
+
+    if not isinstance(source_refs, dict):
+        problems.append("source_refs must be an object when present")
+        source_refs = {}
+
+    if lane == "pre_merge_validation":
+        for key in ("change_set_ref", "environment_request_ref", "validation_run_ref"):
+            if not source_refs.get(key):
+                problems.append(f"pre_merge_validation lane requires source_refs.{key}")
+    if lane == "post_merge_incident":
+        for key in ("incident_ref", "investigation_run_ref"):
+            if not source_refs.get(key):
+                problems.append(f"post_merge_incident lane requires source_refs.{key}")
 
     if not isinstance(bde, dict):
         problems.append("behavioral_divergence_event must be an object")
@@ -165,21 +199,51 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
     return problems
 
 
+def validate_fixture(schema: dict[str, Any], path: Path) -> dict[str, list[str]]:
+    data = load(path)
+    schema_errors = schema_problems(schema, data)
+    semantic_errors = semantic_problems(data)
+    return {
+        "schema": schema_errors,
+        "semantic": semantic_errors,
+    }
+
+
+def assert_invalid_expectations(path: Path, problems: list[str], expected_substrings: list[str]) -> list[str]:
+    expectation_failures: list[str] = []
+    if not problems:
+        expectation_failures.append(f"{path}: expected invalid fixture to fail, but it passed")
+    for expected in expected_substrings:
+        if not any(expected in problem for problem in problems):
+            expectation_failures.append(f"{path}: expected invalid fixture problem containing {expected!r}")
+    return expectation_failures
+
+
 def main() -> int:
     failed = False
     schema = load(SCHEMA)
-    results: dict[str, dict[str, list[str]]] = {}
+    results: dict[str, dict[str, Any]] = {}
 
-    for path in FIXTURES:
-        data = load(path)
-        schema_errors = schema_problems(schema, data)
-        semantic_errors = semantic_problems(data)
-        problems = schema_errors + semantic_errors
+    for path in VALID_FIXTURES:
+        result = validate_fixture(schema, path)
+        problems = result["schema"] + result["semantic"]
         results[str(path.relative_to(ROOT))] = {
-            "schema": schema_errors,
-            "semantic": semantic_errors,
+            "expected": "valid",
+            **result,
         }
         failed = failed or bool(problems)
+
+    for path, expected_substrings in INVALID_FIXTURES.items():
+        result = validate_fixture(schema, path)
+        problems = result["schema"] + result["semantic"]
+        expectation_failures = assert_invalid_expectations(path.relative_to(ROOT), problems, expected_substrings)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid",
+            "expected_problem_substrings": expected_substrings,
+            "expectation_failures": expectation_failures,
+            **result,
+        }
+        failed = failed or bool(expectation_failures)
 
     report = {
         "validator": "prophet-platform.devsecops-workroom.validator.v1",
@@ -187,10 +251,11 @@ def main() -> int:
         "results": results,
         "non_claims": [
             "Validator checks workroom JSON Schema and semantic fixture constraints.",
+            "Validator asserts invalid fixtures fail for the expected governance reasons.",
             "Validator does not execute live sandbox infrastructure.",
             "Validator does not certify Signadot-style runtime parity.",
-            "Validator does not authorize production remediation."
-        ]
+            "Validator does not authorize production remediation.",
+        ],
     }
     print(json.dumps(report, indent=2, sort_keys=True))
     print(("PASS" if not failed else "FAIL") + ": devsecops workroom fixtures")

--- a/tools/validate_devsecops_workroom.py
+++ b/tools/validate_devsecops_workroom.py
@@ -17,11 +17,8 @@ INVALID_FIXTURES = {
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.causal-claim-without-evidence.invalid.json": [
         "causal claims require evidence refs",
     ],
-    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.high-risk-remediation-without-grant.invalid.json": [
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.plan-without-grant.invalid.json": [
         "high/critical remediation requires action grant refs",
-    ],
-    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.mutation-action-without-approval.invalid.json": [
-        "mutation-class actions cannot be allowed without approval requirement",
     ],
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.runtime-observed-without-parity-gate.invalid.json": [
         "v0.1 fixture must not claim runtime_observed",
@@ -186,7 +183,6 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
             problems.append("post_merge_incident lane must use incident-class event type")
 
     if parity == "runtime_observed":
-        # v0.1 fixtures must stay below runtime_observed until live parity gates have evidence.
         problems.append("v0.1 fixture must not claim runtime_observed")
 
     if not regression_fixtures:
@@ -201,11 +197,9 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
 
 def validate_fixture(schema: dict[str, Any], path: Path) -> dict[str, list[str]]:
     data = load(path)
-    schema_errors = schema_problems(schema, data)
-    semantic_errors = semantic_problems(data)
     return {
-        "schema": schema_errors,
-        "semantic": semantic_errors,
+        "schema": schema_problems(schema, data),
+        "semantic": semantic_problems(data),
     }
 
 
@@ -227,10 +221,7 @@ def main() -> int:
     for path in VALID_FIXTURES:
         result = validate_fixture(schema, path)
         problems = result["schema"] + result["semantic"]
-        results[str(path.relative_to(ROOT))] = {
-            "expected": "valid",
-            **result,
-        }
+        results[str(path.relative_to(ROOT))] = {"expected": "valid", **result}
         failed = failed or bool(problems)
 
     for path, expected_substrings in INVALID_FIXTURES.items():


### PR DESCRIPTION
## Summary

Hardens the DevSecOps Intelligence Workroom v0.1 validator with expected-invalid governance fixtures and minimal lane receipt-reference checks.

Adds expected-failing fixture coverage for:

- RCA support level without required evidence references;
- elevated-risk plan posture without the required grant reference;
- premature `runtime_observed` parity posture;
- validation-lane record with an incident-class event type;
- incident-lane record missing the investigation run reference.

Updates `tools/validate_devsecops_workroom.py` so it now:

- separates valid fixtures from expected-invalid fixtures;
- asserts valid fixtures pass JSON Schema plus semantic validation;
- asserts invalid fixtures fail for the expected governance reason;
- requires pre-merge Workroom records to carry `change_set_ref`, `environment_request_ref`, and `validation_run_ref`;
- requires post-merge incident Workroom records to carry `incident_ref` and `investigation_run_ref`.

## Boundary

Fixture and validator hardening only.

- No live sandbox execution.
- No Signadot runtime parity claim.
- No production remediation authorization.
- No duplication of Sociosphere environment state.
- No duplication of AgentPlane runtime evidence.
- Workroom records point at upstream authority refs.

## Validation

Expected CI path:

```bash
python tools/validate_devsecops_workroom.py
```

This validator is already wired in the `ci / orchestration-fixtures` job.

Local full-checkout validation was not run in this session because the sandbox could not resolve `github.com` for `git clone`. The patch was applied through the GitHub connector and diff-checked against `main`.

## Follow-up

A separate sanitized approval-posture negative test should be added later if connector filtering permits it.

Refs #520
Refs #519