### PR TITLE
ci: add validate target diagnostics workflow

### DIFF
--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -1,0 +1,75 @@
+name: validate-target-diagnostics
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  validate-target-diagnostics:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - validate-repo
+          - drift-check
+          - standards-check
+          - topology-check
+          - chronos-evidence-loop-readout-validate
+          - lattice-surfaces-check
+          - validate-ops-fabric
+          - validate-search-academy-deploy
+          - validate-search-image-release
+          - validate-lampstand-lifecycle
+          - validate-zone-stack-audit
+          - policy-fabric-endpoint-client-smoke
+          - policy-fabric-guarded-workflow-smoke
+          - zone-router-publication-local-publish-smoke
+          - zone-router-publication-failure-evidence-smoke
+          - zone-router-publication-retry-state-smoke
+          - zone-router-publication-remote-broker-seam-smoke
+          - validate-workroom-update-contract
+          - validate-professional-intelligence-manifest
+          - validate-svf-agent-contract
+          - validate-environment-validate-change-v2
+          - validate-channel-runtime-gates
+          - test-go
+          - validate-phase4
+          - validate-fogstack
+          - validate-storage-suite
+          - trustops-art-runner-smoke
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        if: matrix.target == 'test-go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Python validator dependencies
+        run: python -m pip install --upgrade pip pyyaml jsonschema
+      - name: Run target
+        run: make ${{ matrix.target }}
+
+  expensive-target-diagnostics:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - lattice-surface-ingestor-smoke
+          - lattice-studio-smoke
+          - test-python-apps
+          - test-tools
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run target
+        run: make ${{ matrix.target }}

--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -55,7 +55,34 @@ jobs:
       - name: Run target
         run: make ${{ matrix.target }}
 
-  expensive-target-diagnostics:
+  app-test-diagnostics:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: eval-fabric-api
+            command: cd apps/eval-fabric-api && test -d .venv || python3 -m venv .venv; cd apps/eval-fabric-api && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt && pytest -q tests ../knowledge-reason/tests
+          - name: evidence-receipts
+            command: cd apps/evidence-receipts && test -d .venv || python3 -m venv .venv; cd apps/evidence-receipts && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt && pytest -q tests
+          - name: evidence-console
+            command: cd apps/evidence-console && test -d .venv || python3 -m venv .venv; cd apps/evidence-console && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-test.txt && pytest -q tests
+          - name: zone-router
+            command: cd apps/zone-router && test -d .venv || python3 -m venv .venv; cd apps/zone-router && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-test.txt && PYTHONPATH=src pytest -q tests
+          - name: semantic-bridge
+            command: cd apps/semantic-bridge && test -d .venv || python3 -m venv .venv; cd apps/semantic-bridge && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-test.txt && PYTHONPATH=src pytest -q tests
+          - name: tools-tests
+            command: test -d .venv-tools || python3 -m venv .venv-tools; . .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run app/tool diagnostic
+        run: ${{ matrix.command }}
+
+  smoke-target-diagnostics:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -63,8 +90,6 @@ jobs:
         target:
           - lattice-surface-ingestor-smoke
           - lattice-studio-smoke
-          - test-python-apps
-          - test-tools
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -62,25 +62,49 @@ jobs:
       matrix:
         include:
           - name: eval-fabric-api
-            command: cd apps/eval-fabric-api && test -d .venv || python3 -m venv .venv; cd apps/eval-fabric-api && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt && pytest -q tests ../knowledge-reason/tests
+            working-directory: apps/eval-fabric-api
+            install: pip install -r requirements.txt -r requirements-test.txt
+            test: pytest -q tests ../knowledge-reason/tests
           - name: evidence-receipts
-            command: cd apps/evidence-receipts && test -d .venv || python3 -m venv .venv; cd apps/evidence-receipts && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-test.txt && pytest -q tests
+            working-directory: apps/evidence-receipts
+            install: pip install -r requirements.txt -r requirements-test.txt
+            test: pytest -q tests
           - name: evidence-console
-            command: cd apps/evidence-console && test -d .venv || python3 -m venv .venv; cd apps/evidence-console && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-test.txt && pytest -q tests
+            working-directory: apps/evidence-console
+            install: pip install -r requirements-test.txt
+            test: pytest -q tests
           - name: zone-router
-            command: cd apps/zone-router && test -d .venv || python3 -m venv .venv; cd apps/zone-router && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-test.txt && PYTHONPATH=src pytest -q tests
+            working-directory: apps/zone-router
+            install: pip install -r requirements-test.txt
+            test: PYTHONPATH=src pytest -q tests
           - name: semantic-bridge
-            command: cd apps/semantic-bridge && test -d .venv || python3 -m venv .venv; cd apps/semantic-bridge && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-test.txt && PYTHONPATH=src pytest -q tests
+            working-directory: apps/semantic-bridge
+            install: pip install -r requirements-test.txt
+            test: PYTHONPATH=src pytest -q tests
           - name: tools-tests
-            command: test -d .venv-tools || python3 -m venv .venv-tools; . .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests
+            working-directory: .
+            install: pip install pytest pyyaml jsonschema
+            test: pytest -q tools/tests
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Create virtualenv
+        working-directory: ${{ matrix.working-directory }}
+        run: python3 -m venv .venv
+      - name: Install app/tool test dependencies
+        working-directory: ${{ matrix.working-directory }}
+        run: |
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          ${{ matrix.install }}
       - name: Run app/tool diagnostic
-        run: ${{ matrix.command }}
+        working-directory: ${{ matrix.working-directory }}
+        run: |
+          . .venv/bin/activate
+          ${{ matrix.test }}
 
   smoke-target-diagnostics:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -101,10 +101,30 @@ jobs:
           python -m pip install --upgrade pip
           ${{ matrix.install }}
       - name: Run app/tool diagnostic
+        id: diagnostic
         working-directory: ${{ matrix.working-directory }}
+        shell: bash
         run: |
+          mkdir -p "$GITHUB_WORKSPACE/diagnostic-logs"
+          log="$GITHUB_WORKSPACE/diagnostic-logs/${{ matrix.name }}.log"
           . .venv/bin/activate
-          ${{ matrix.test }}
+          set +e
+          {
+            echo "target=${{ matrix.name }}"
+            echo "working_directory=${{ matrix.working-directory }}"
+            echo "test_command=${{ matrix.test }}"
+            ${{ matrix.test }}
+            status=$?
+            echo "exit_status=$status"
+            exit $status
+          } 2>&1 | tee "$log"
+          exit ${PIPESTATUS[0]}
+      - name: Upload diagnostic log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: diagnostic-${{ matrix.name }}
+          path: diagnostic-logs/${{ matrix.name }}.log
 
   smoke-target-diagnostics:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a temporary-style diagnostic workflow that splits the aggregate `make validate` surface into individual target-level jobs.

This is intended to isolate the current broad `validate` failure without guessing or patching unrelated code.

## What it does

- Adds `.github/workflows/validate-target-diagnostics.yml`.
- Runs common validate targets in a matrix with `fail-fast: false`.
- Runs heavier targets in a separate matrix so failures are visible by target.
- Installs basic Python validator dependencies for validator-style targets.
- Uses Go setup only for `test-go`.

## Boundary

No product behavior changes.
No contract changes.
No runtime changes.
No Workroom semantics changes.

## Follow-up

After this diagnostic workflow identifies the failing target, we should patch the target-specific failure and decide whether to keep, rename, or remove this diagnostic workflow.
