### PR TITLE
test: add Workroom approval posture negative fixture

### DIFF
--- a/tests/fixtures/workroom/devsecops-workroom.approval-posture.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.approval-posture.invalid.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:approval-posture",
+  "lane": "pre_merge_validation",
+  "runtime_parity_level": "synthetic_observed",
+  "source_refs": {
+    "change_set_ref": "changeset://github/SocioProphet/example/pull/1",
+    "environment_request_ref": "environment:validate-change-v2-request:invalid",
+    "validation_run_ref": "agentplane:runtime-sandbox-run:invalid"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:pre-merge-validation-failure:invalid-approval-posture",
+    "event_type": "pre_merge_validation_failure",
+    "source_lane": "pre_merge_validation",
+    "status": "open",
+    "summary": "Invalid fixture used to prove approval posture rejection.",
+    "evidence_refs": ["evidence://fixture/invalid/evidence"],
+    "claim_refs": ["rca-claim:invalid:claim"],
+    "decision_state": "blocked",
+    "non_claims": ["Invalid fixture is expected to fail."]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://fixture/invalid/evidence",
+      "evidence_type": "validation_result",
+      "producer": "Prophet Platform negative fixture",
+      "summary": "Negative fixture evidence packet.",
+      "observed_at": "2026-05-31T17:30:00Z",
+      "provenance": {
+        "source_system": "Prophet Platform",
+        "source_ref": "validation-plan://invalid"
+      },
+      "non_claims": ["Fixture evidence is synthetic."]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:invalid:claim",
+      "claim_status": "observation",
+      "statement": "Negative fixture baseline observation.",
+      "evidence_refs": ["evidence://fixture/invalid/evidence"],
+      "counterevidence_refs": [],
+      "confidence": "low",
+      "non_claims": ["Negative fixture claim is not real RCA."]
+    }
+  ],
+  "action_grants": [
+    {
+      "grant_id": "action-grant:invalid:approval-posture",
+      "action_class": "diagnostic_mutation",
+      "status": "allowed",
+      "scope": "Invalid approval posture fixture.",
+      "approval_required": false,
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "remediation_plans": [],
+  "regression_fixtures": [
+    {
+      "fixture_id": "regression-fixture:invalid:candidate",
+      "fixture_status": "candidate",
+      "derived_from": "bde:pre-merge-validation-failure:invalid-approval-posture",
+      "summary": "Negative fixture candidate.",
+      "target_validation_plan_ref": "validation-plan://invalid",
+      "non_claims": ["Candidate only."]
+    }
+  ],
+  "issued_at": "2026-05-31T17:31:00Z",
+  "non_claims": ["This is an expected-failing negative fixture."]
+}

--- a/tools/validate_devsecops_workroom.py
+++ b/tools/validate_devsecops_workroom.py
@@ -29,6 +29,9 @@ INVALID_FIXTURES = {
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.post-merge-missing-investigation-ref.invalid.json": [
         "post_merge_incident lane requires source_refs.investigation_run_ref",
     ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.approval-posture.invalid.json": [
+        "mutation-class actions cannot be allowed without approval requirement",
+    ],
 }
 
 CLAIM_STATUSES = {


### PR DESCRIPTION
## Summary

Adds sanitized expected-invalid coverage for Workroom action-grant approval posture.

This PR:

- adds `devsecops-workroom.approval-posture.invalid.json`;
- registers it in `INVALID_FIXTURES`;
- asserts the validator rejects an allowed mutation-class grant when `approval_required` is false.

## Boundary

Fixture and validator coverage only.

- No runtime execution.
- No production action authorization.
- No Signadot runtime parity claim.
- No Sociosphere or AgentPlane authority duplication.

## Validation

Expected CI path:

```bash
python tools/validate_devsecops_workroom.py
```

Refs #520
Refs #519