### PR TITLE
Validate Workroom SVF receipt evidence states

### DIFF
--- a/contracts/workroom/devsecops-workroom-v0.1.schema.json
+++ b/contracts/workroom/devsecops-workroom-v0.1.schema.json
@@ -19,29 +19,94 @@
     "non_claims"
   ],
   "properties": {
-    "schema_version": { "type": "string", "const": "0.1.0" },
-    "workroom_id": { "type": "string", "pattern": "^workroom:devsecops:" },
-    "lane": { "type": "string", "enum": ["pre_merge_validation", "post_merge_incident"] },
-    "runtime_parity_level": { "type": "string", "enum": ["contract_only", "synthetic_observed", "runtime_observed"] },
+    "schema_version": {
+      "type": "string",
+      "const": "0.1.0"
+    },
+    "workroom_id": {
+      "type": "string",
+      "pattern": "^workroom:devsecops:"
+    },
+    "lane": {
+      "type": "string",
+      "enum": [
+        "pre_merge_validation",
+        "post_merge_incident"
+      ]
+    },
+    "runtime_parity_level": {
+      "type": "string",
+      "enum": [
+        "contract_only",
+        "synthetic_observed",
+        "runtime_observed"
+      ]
+    },
+    "validation_evidence_state": {
+      "type": "string",
+      "enum": [
+        "not_configured",
+        "selected_only",
+        "missing_evidence",
+        "synthetic_observed",
+        "runtime_observed",
+        "verified_receipt",
+        "failed_receipt",
+        "stale_receipt"
+      ]
+    },
     "source_refs": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "change_set_ref": { "type": "string" },
-        "environment_request_ref": { "type": "string" },
-        "validation_run_ref": { "type": "string" },
-        "incident_ref": { "type": "string" },
-        "investigation_run_ref": { "type": "string" },
-        "topology_ref": { "type": "string" },
-        "blast_radius_ref": { "type": "string" }
+        "change_set_ref": {
+          "type": "string"
+        },
+        "environment_request_ref": {
+          "type": "string"
+        },
+        "validation_run_ref": {
+          "type": "string"
+        },
+        "validation_receipt_ref": {
+          "type": "string"
+        },
+        "validation_receipt_digest": {
+          "type": "string"
+        },
+        "incident_ref": {
+          "type": "string"
+        },
+        "investigation_run_ref": {
+          "type": "string"
+        },
+        "topology_ref": {
+          "type": "string"
+        },
+        "blast_radius_ref": {
+          "type": "string"
+        }
       }
     },
     "behavioral_divergence_event": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["event_id", "event_type", "source_lane", "status", "summary", "evidence_refs", "claim_refs", "decision_state", "non_claims"],
+      "required": [
+        "event_id",
+        "event_type",
+        "source_lane",
+        "status",
+        "summary",
+        "evidence_refs",
+        "claim_refs",
+        "decision_state",
+        "non_claims"
+      ],
       "properties": {
-        "event_id": { "type": "string", "pattern": "^bde:" },
+        "event_id": {
+          "type": "string",
+          "pattern": "^bde:"
+        },
         "event_type": {
           "type": "string",
           "enum": [
@@ -55,15 +120,64 @@
             "customer_impact_event"
           ]
         },
-        "source_lane": { "type": "string", "enum": ["pre_merge_validation", "post_merge_incident"] },
-        "status": { "type": "string", "enum": ["open", "investigating", "mitigated", "resolved", "converted_to_regression_fixture"] },
-        "summary": { "type": "string", "minLength": 1 },
-        "environment_ref": { "type": "string" },
-        "topology_ref": { "type": "string" },
-        "evidence_refs": { "type": "array", "items": { "type": "string", "pattern": "^evidence://" } },
-        "claim_refs": { "type": "array", "items": { "type": "string", "pattern": "^rca-claim:" } },
-        "decision_state": { "type": "string", "enum": ["blocked", "needs_review", "allowed_read_only", "resolved", "candidate_only"] },
-        "non_claims": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+        "source_lane": {
+          "type": "string",
+          "enum": [
+            "pre_merge_validation",
+            "post_merge_incident"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "open",
+            "investigating",
+            "mitigated",
+            "resolved",
+            "converted_to_regression_fixture"
+          ]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "environment_ref": {
+          "type": "string"
+        },
+        "topology_ref": {
+          "type": "string"
+        },
+        "evidence_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^evidence://"
+          }
+        },
+        "claim_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^rca-claim:"
+          }
+        },
+        "decision_state": {
+          "type": "string",
+          "enum": [
+            "blocked",
+            "needs_review",
+            "allowed_read_only",
+            "resolved",
+            "candidate_only"
+          ]
+        },
+        "non_claims": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
       }
     },
     "evidence_packets": {
@@ -72,24 +186,70 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["evidence_ref", "evidence_type", "producer", "summary", "observed_at", "provenance", "non_claims"],
+        "required": [
+          "evidence_ref",
+          "evidence_type",
+          "producer",
+          "summary",
+          "observed_at",
+          "provenance",
+          "non_claims"
+        ],
         "properties": {
-          "evidence_ref": { "type": "string", "pattern": "^evidence://" },
-          "evidence_type": { "type": "string", "enum": ["validation_result", "runtime_receipt", "log_observation", "metric_observation", "topology_snapshot", "runbook_excerpt", "deployment_metadata", "manual_observation"] },
-          "producer": { "type": "string" },
-          "summary": { "type": "string", "minLength": 1 },
-          "observed_at": { "type": "string", "format": "date-time" },
+          "evidence_ref": {
+            "type": "string",
+            "pattern": "^evidence://"
+          },
+          "evidence_type": {
+            "type": "string",
+            "enum": [
+              "validation_result",
+              "runtime_receipt",
+              "log_observation",
+              "metric_observation",
+              "topology_snapshot",
+              "runbook_excerpt",
+              "deployment_metadata",
+              "manual_observation"
+            ]
+          },
+          "producer": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time"
+          },
           "provenance": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["source_system", "source_ref"],
+            "required": [
+              "source_system",
+              "source_ref"
+            ],
             "properties": {
-              "source_system": { "type": "string" },
-              "source_ref": { "type": "string" },
-              "collection_method": { "type": "string" }
+              "source_system": {
+                "type": "string"
+              },
+              "source_ref": {
+                "type": "string"
+              },
+              "collection_method": {
+                "type": "string"
+              }
             }
           },
-          "non_claims": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+          "non_claims": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -99,15 +259,65 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["claim_id", "claim_status", "statement", "evidence_refs", "counterevidence_refs", "confidence", "non_claims"],
+        "required": [
+          "claim_id",
+          "claim_status",
+          "statement",
+          "evidence_refs",
+          "counterevidence_refs",
+          "confidence",
+          "non_claims"
+        ],
         "properties": {
-          "claim_id": { "type": "string", "pattern": "^rca-claim:" },
-          "claim_status": { "type": "string", "enum": ["observation", "hypothesis", "supported_causal_claim", "confirmed_causal_claim", "falsified_claim", "unknown"] },
-          "statement": { "type": "string", "minLength": 1 },
-          "evidence_refs": { "type": "array", "items": { "type": "string", "pattern": "^evidence://" } },
-          "counterevidence_refs": { "type": "array", "items": { "type": "string", "pattern": "^evidence://" } },
-          "confidence": { "type": "string", "enum": ["none", "low", "medium", "high"] },
-          "non_claims": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+          "claim_id": {
+            "type": "string",
+            "pattern": "^rca-claim:"
+          },
+          "claim_status": {
+            "type": "string",
+            "enum": [
+              "observation",
+              "hypothesis",
+              "supported_causal_claim",
+              "confirmed_causal_claim",
+              "falsified_claim",
+              "unknown"
+            ]
+          },
+          "statement": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^evidence://"
+            }
+          },
+          "counterevidence_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^evidence://"
+            }
+          },
+          "confidence": {
+            "type": "string",
+            "enum": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          "non_claims": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -116,14 +326,57 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["grant_id", "action_class", "status", "scope", "approval_required", "non_claims"],
+        "required": [
+          "grant_id",
+          "action_class",
+          "status",
+          "scope",
+          "approval_required",
+          "non_claims"
+        ],
         "properties": {
-          "grant_id": { "type": "string", "pattern": "^action-grant:" },
-          "action_class": { "type": "string", "enum": ["read_only", "diagnostic_mutation", "reversible_mitigation", "irreversible_mutation", "credential_sensitive", "data_sensitive", "customer_visible", "destructive", "privileged_identity", "network_exposure", "production_change"] },
-          "status": { "type": "string", "enum": ["allowed", "blocked", "requires_human_approval", "not_requested"] },
-          "scope": { "type": "string" },
-          "approval_required": { "type": "boolean" },
-          "non_claims": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+          "grant_id": {
+            "type": "string",
+            "pattern": "^action-grant:"
+          },
+          "action_class": {
+            "type": "string",
+            "enum": [
+              "read_only",
+              "diagnostic_mutation",
+              "reversible_mitigation",
+              "irreversible_mutation",
+              "credential_sensitive",
+              "data_sensitive",
+              "customer_visible",
+              "destructive",
+              "privileged_identity",
+              "network_exposure",
+              "production_change"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "allowed",
+              "blocked",
+              "requires_human_approval",
+              "not_requested"
+            ]
+          },
+          "scope": {
+            "type": "string"
+          },
+          "approval_required": {
+            "type": "boolean"
+          },
+          "non_claims": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -132,15 +385,65 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["plan_id", "plan_status", "risk_class", "summary", "evidence_refs", "required_action_grant_refs", "non_claims"],
+        "required": [
+          "plan_id",
+          "plan_status",
+          "risk_class",
+          "summary",
+          "evidence_refs",
+          "required_action_grant_refs",
+          "non_claims"
+        ],
         "properties": {
-          "plan_id": { "type": "string", "pattern": "^remediation-plan:" },
-          "plan_status": { "type": "string", "enum": ["candidate", "blocked", "approved", "executed", "rejected"] },
-          "risk_class": { "type": "string", "enum": ["read_only", "low", "medium", "high", "critical"] },
-          "summary": { "type": "string", "minLength": 1 },
-          "evidence_refs": { "type": "array", "items": { "type": "string", "pattern": "^evidence://" } },
-          "required_action_grant_refs": { "type": "array", "items": { "type": "string", "pattern": "^action-grant:" } },
-          "non_claims": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+          "plan_id": {
+            "type": "string",
+            "pattern": "^remediation-plan:"
+          },
+          "plan_status": {
+            "type": "string",
+            "enum": [
+              "candidate",
+              "blocked",
+              "approved",
+              "executed",
+              "rejected"
+            ]
+          },
+          "risk_class": {
+            "type": "string",
+            "enum": [
+              "read_only",
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^evidence://"
+            }
+          },
+          "required_action_grant_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^action-grant:"
+            }
+          },
+          "non_claims": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -149,18 +452,57 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["fixture_id", "fixture_status", "derived_from", "summary", "target_validation_plan_ref", "non_claims"],
+        "required": [
+          "fixture_id",
+          "fixture_status",
+          "derived_from",
+          "summary",
+          "target_validation_plan_ref",
+          "non_claims"
+        ],
         "properties": {
-          "fixture_id": { "type": "string", "pattern": "^regression-fixture:" },
-          "fixture_status": { "type": "string", "enum": ["candidate", "accepted", "rejected"] },
-          "derived_from": { "type": "string" },
-          "summary": { "type": "string", "minLength": 1 },
-          "target_validation_plan_ref": { "type": "string" },
-          "non_claims": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+          "fixture_id": {
+            "type": "string",
+            "pattern": "^regression-fixture:"
+          },
+          "fixture_status": {
+            "type": "string",
+            "enum": [
+              "candidate",
+              "accepted",
+              "rejected"
+            ]
+          },
+          "derived_from": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "target_validation_plan_ref": {
+            "type": "string"
+          },
+          "non_claims": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          }
         }
       }
     },
-    "issued_at": { "type": "string", "format": "date-time" },
-    "non_claims": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    }
   }
 }

--- a/docs/SVF_VALIDATE_CHANGE_AGENT_CONTRACT.md
+++ b/docs/SVF_VALIDATE_CHANGE_AGENT_CONTRACT.md
@@ -64,6 +64,27 @@ It may not:
 6. claim live or production readiness from advisory contract validation;
 7. treat raw CI status as a substitute for Sociosphere workspace state.
 
+## Validation evidence states
+
+`validate_change` and DevSecOps Workroom records must keep validation evidence state separate from broad runtime parity labels.
+
+Allowed evidence states are:
+
+- `not_configured`
+- `selected_only`
+- `missing_evidence`
+- `synthetic_observed`
+- `runtime_observed`
+- `verified_receipt`
+- `failed_receipt`
+- `stale_receipt`
+
+`runtime_observed` is not a claim that may be inferred from plan selection, command recommendation, or raw CI status. In v0.1 fixture semantics, `runtime_observed` requires `validation_evidence_state: verified_receipt` plus a `source_refs.validation_receipt_ref` whose value is represented by a `runtime_receipt` evidence packet provenance reference.
+
+`synthetic_observed` may be used for synthetic fixture evidence, but it must not be escalated to `runtime_observed` without verified receipt evidence.
+
+Receipt references are pointers to upstream evidence. Prophet Platform consumes them for agent-facing readiness summaries; it does not issue, sign, or certify SVF receipts.
+
 ## Initial request shape
 
 ```json
@@ -108,6 +129,8 @@ It may not:
 A PR readiness summary may state that Plans were selected, commands were recommended, or receipts are missing. It may not say that a change is validated unless matching receipts or observed validation evidence are attached through Sociosphere workspace state.
 
 For the first tranche, missing observed validation must be surfaced as `validation_observation_missing`, not silently converted into success.
+
+A readiness summary may report `runtime_observed` only when the Workroom or validate_change response carries a verified receipt reference and a matching runtime-receipt evidence packet. It must report `selected_only`, `missing_evidence`, `failed_receipt`, or `stale_receipt` when receipt evidence is absent, failed, or stale.
 
 ## Initial implementation order
 

--- a/tests/fixtures/workroom/devsecops-workroom.pre-merge-validation-failure.valid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.pre-merge-validation-failure.valid.json
@@ -3,10 +3,12 @@
   "workroom_id": "workroom:devsecops:pre-merge:scope-d-example",
   "lane": "pre_merge_validation",
   "runtime_parity_level": "synthetic_observed",
+  "validation_evidence_state": "synthetic_observed",
   "source_refs": {
     "change_set_ref": "changeset://github/SocioProphet/scope-d-example/pull/42",
     "environment_request_ref": "environment:validate-change-v2-request:scope-d-example",
     "validation_run_ref": "agentplane:runtime-sandbox-run:scope-d-example",
+    "validation_receipt_ref": "svf:receipt:scope-d-example.synthetic.001",
     "topology_ref": "topology://gaia/workroom/scope-d-example/pre-merge"
   },
   "behavioral_divergence_event": {

--- a/tests/fixtures/workroom/devsecops-workroom.pre-merge-verified-receipt.valid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.pre-merge-verified-receipt.valid.json
@@ -1,0 +1,119 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:pre-merge:sociosphere-svf-verified",
+  "lane": "pre_merge_validation",
+  "runtime_parity_level": "runtime_observed",
+  "validation_evidence_state": "verified_receipt",
+  "source_refs": {
+    "change_set_ref": "changeset://github/SocioProphet/sociosphere/pull/434",
+    "environment_request_ref": "environment:validate-change-v2-request:sociosphere-svf",
+    "validation_run_ref": "svf:run:sociosphere.registry-dogfood.verified",
+    "validation_receipt_ref": "svf:receipt:sociosphere.registry-dogfood.verified",
+    "validation_receipt_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "topology_ref": "topology://sociosphere/svf/local-dogfood"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:pre-merge-validation-success:sociosphere-svf",
+    "event_type": "pre_merge_validation_failure",
+    "source_lane": "pre_merge_validation",
+    "status": "resolved",
+    "summary": "Fixture models a verified SVF local receipt for Sociosphere registry dogfood validation.",
+    "environment_ref": "environment://local/sociosphere/svf",
+    "topology_ref": "topology://sociosphere/svf/local-dogfood",
+    "evidence_refs": [
+      "evidence://sociosphere/svf/registry-dogfood/verified-receipt"
+    ],
+    "claim_refs": [
+      "rca-claim:sociosphere-svf:receipt-observed"
+    ],
+    "decision_state": "resolved",
+    "non_claims": [
+      "Resolved state is fixture-scoped.",
+      "Fixture does not certify production readiness."
+    ]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://sociosphere/svf/registry-dogfood/verified-receipt",
+      "evidence_type": "runtime_receipt",
+      "producer": "Sociosphere SVF local runner",
+      "summary": "Verified local SVF receipt for registered Action execution and receipt digest verification.",
+      "observed_at": "2026-05-31T18:46:09Z",
+      "provenance": {
+        "source_system": "Sociosphere",
+        "source_ref": "svf:receipt:sociosphere.registry-dogfood.verified",
+        "collection_method": "fixture_mirrors_svf_local_receipt"
+      },
+      "non_claims": [
+        "Receipt is local-only.",
+        "Receipt does not certify container, browser, QEMU, cluster, or Signadot vendor parity."
+      ]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:sociosphere-svf:receipt-observed",
+      "claim_status": "observation",
+      "statement": "A Sociosphere SVF local receipt can be represented as runtime-observed validation evidence when the receipt reference is present and evidence provenance points to it.",
+      "evidence_refs": [
+        "evidence://sociosphere/svf/registry-dogfood/verified-receipt"
+      ],
+      "counterevidence_refs": [],
+      "confidence": "high",
+      "non_claims": [
+        "Observation is about fixture representation.",
+        "Observation does not authorize remediation."
+      ]
+    }
+  ],
+  "action_grants": [
+    {
+      "grant_id": "action-grant:sociosphere-svf:read-receipt",
+      "action_class": "read_only",
+      "status": "allowed",
+      "scope": "Read SVF receipt references and validation evidence for PR readiness.",
+      "approval_required": false,
+      "non_claims": [
+        "Grant permits read-only receipt inspection only.",
+        "Grant does not authorize execution."
+      ]
+    }
+  ],
+  "remediation_plans": [
+    {
+      "plan_id": "remediation-plan:sociosphere-svf:none-required",
+      "plan_status": "approved",
+      "risk_class": "read_only",
+      "summary": "No code remediation is required for the verified receipt fixture.",
+      "evidence_refs": [
+        "evidence://sociosphere/svf/registry-dogfood/verified-receipt"
+      ],
+      "required_action_grant_refs": [
+        "action-grant:sociosphere-svf:read-receipt"
+      ],
+      "non_claims": [
+        "Approval is fixture-scoped.",
+        "No production mutation is authorized."
+      ]
+    }
+  ],
+  "regression_fixtures": [
+    {
+      "fixture_id": "regression-fixture:sociosphere-svf:receipt-gate",
+      "fixture_status": "candidate",
+      "derived_from": "bde:pre-merge-validation-success:sociosphere-svf",
+      "summary": "Preserve a Workroom fixture that permits runtime_observed only with verified SVF receipt evidence.",
+      "target_validation_plan_ref": "svf:plan:sociosphere.registry-dogfood",
+      "non_claims": [
+        "Fixture is not a live execution record.",
+        "Fixture does not replace Sociosphere receipt verification."
+      ]
+    }
+  ],
+  "issued_at": "2026-05-31T18:47:00Z",
+  "non_claims": [
+    "This fixture models receipt consumption only.",
+    "This fixture does not execute SVF Actions.",
+    "This fixture does not create or sign receipts."
+  ]
+}

--- a/tools/validate_devsecops_workroom.py
+++ b/tools/validate_devsecops_workroom.py
@@ -11,6 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-workroom-v0.1.schema.json"
 VALID_FIXTURES = [
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.pre-merge-validation-failure.valid.json",
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.pre-merge-verified-receipt.valid.json",
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.post-merge-incident.valid.json",
 ]
 INVALID_FIXTURES = {
@@ -21,7 +22,7 @@ INVALID_FIXTURES = {
         "high/critical remediation requires action grant refs",
     ],
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.runtime-observed-without-parity-gate.invalid.json": [
-        "v0.1 fixture must not claim runtime_observed",
+        "runtime_observed requires source_refs.validation_receipt_ref",
     ],
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.pre-merge-production-incident.invalid.json": [
         "pre_merge_validation lane must not use production_incident event_type",
@@ -53,6 +54,18 @@ MUTATION_ACTION_CLASSES = {
     "network_exposure",
     "production_change",
 }
+VALIDATION_EVIDENCE_STATES = {
+    "not_configured",
+    "selected_only",
+    "missing_evidence",
+    "synthetic_observed",
+    "runtime_observed",
+    "verified_receipt",
+    "failed_receipt",
+    "stale_receipt",
+}
+RECEIPT_STATES = {"verified_receipt", "failed_receipt", "stale_receipt"}
+NON_RUNTIME_STATES = {"not_configured", "selected_only", "missing_evidence"}
 
 
 def load(path: Path) -> dict[str, Any]:
@@ -75,6 +88,17 @@ def ref_set(items: list[dict[str, Any]], key: str) -> set[str]:
     return {str(item.get(key)) for item in items if isinstance(item, dict)}
 
 
+def evidence_sources_by_type(evidence_packets: list[dict[str, Any]], evidence_type: str) -> set[str]:
+    refs: set[str] = set()
+    for packet in evidence_packets:
+        if not isinstance(packet, dict) or packet.get("evidence_type") != evidence_type:
+            continue
+        provenance = packet.get("provenance", {})
+        if isinstance(provenance, dict) and provenance.get("source_ref"):
+            refs.add(str(provenance["source_ref"]))
+    return refs
+
+
 def semantic_problems(data: dict[str, Any]) -> list[str]:
     problems: list[str] = []
 
@@ -85,6 +109,7 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
 
     lane = data.get("lane")
     parity = data.get("runtime_parity_level")
+    validation_state = data.get("validation_evidence_state")
     source_refs = data.get("source_refs", {})
     bde = data.get("behavioral_divergence_event", {})
     evidence_packets = data.get("evidence_packets", [])
@@ -97,6 +122,8 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
         problems.append("lane must be pre_merge_validation or post_merge_incident")
     if parity not in {"contract_only", "synthetic_observed", "runtime_observed"}:
         problems.append("runtime_parity_level is invalid")
+    if validation_state is not None and validation_state not in VALIDATION_EVIDENCE_STATES:
+        problems.append("validation_evidence_state is invalid")
 
     if not isinstance(source_refs, dict):
         problems.append("source_refs must be an object when present")
@@ -106,10 +133,36 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
         for key in ("change_set_ref", "environment_request_ref", "validation_run_ref"):
             if not source_refs.get(key):
                 problems.append(f"pre_merge_validation lane requires source_refs.{key}")
+        if not validation_state:
+            problems.append("pre_merge_validation lane requires validation_evidence_state")
     if lane == "post_merge_incident":
         for key in ("incident_ref", "investigation_run_ref"):
             if not source_refs.get(key):
                 problems.append(f"post_merge_incident lane requires source_refs.{key}")
+
+    if not isinstance(evidence_packets, list):
+        evidence_packets = []
+        problems.append("evidence_packets must be a list")
+
+    receipt_ref = source_refs.get("validation_receipt_ref")
+    receipt_sources = evidence_sources_by_type(evidence_packets, "runtime_receipt")
+
+    if validation_state in RECEIPT_STATES:
+        if not receipt_ref:
+            problems.append(f"{validation_state} requires source_refs.validation_receipt_ref")
+        elif receipt_ref not in receipt_sources:
+            problems.append(f"{validation_state} requires runtime_receipt evidence with provenance.source_ref {receipt_ref}")
+    if validation_state == "verified_receipt" and parity != "runtime_observed":
+        problems.append("verified_receipt requires runtime_parity_level runtime_observed")
+    if validation_state == "synthetic_observed" and parity != "synthetic_observed":
+        problems.append("synthetic_observed validation evidence requires runtime_parity_level synthetic_observed")
+    if validation_state in NON_RUNTIME_STATES and parity != "contract_only":
+        problems.append(f"{validation_state} requires runtime_parity_level contract_only")
+    if parity == "runtime_observed":
+        if validation_state != "verified_receipt":
+            problems.append("runtime_observed requires validation_evidence_state verified_receipt")
+        if not receipt_ref:
+            problems.append("runtime_observed requires source_refs.validation_receipt_ref")
 
     if not isinstance(bde, dict):
         problems.append("behavioral_divergence_event must be an object")
@@ -182,9 +235,6 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
         if bde.get("event_type") not in {"production_incident", "post_deploy_degradation", "customer_impact_event"}:
             problems.append("post_merge_incident lane must use incident-class event type")
 
-    if parity == "runtime_observed":
-        problems.append("v0.1 fixture must not claim runtime_observed")
-
     if not regression_fixtures:
         problems.append("at least one regression fixture candidate is required")
 
@@ -243,6 +293,7 @@ def main() -> int:
         "non_claims": [
             "Validator checks workroom JSON Schema and semantic fixture constraints.",
             "Validator asserts invalid fixtures fail for the expected governance reasons.",
+            "Validator checks validation receipt reference semantics for fixture records.",
             "Validator does not execute live sandbox infrastructure.",
             "Validator does not certify Signadot-style runtime parity.",
             "Validator does not authorize production remediation.",


### PR DESCRIPTION
## Summary

Adds receipt-aware validation evidence semantics to the DevSecOps Workroom / `validate_change` fixture layer.

## Changes

- Adds `validation_evidence_state` to the Workroom schema.
- Adds `source_refs.validation_receipt_ref` and `source_refs.validation_receipt_digest` to the Workroom schema.
- Updates `tools/validate_devsecops_workroom.py` so pre-merge validation records distinguish:
  - `not_configured`
  - `selected_only`
  - `missing_evidence`
  - `synthetic_observed`
  - `runtime_observed`
  - `verified_receipt`
  - `failed_receipt`
  - `stale_receipt`
- Requires `runtime_observed` to be backed by `validation_evidence_state: verified_receipt` and a matching `runtime_receipt` evidence packet provenance reference.
- Marks the existing pre-merge fixture as `synthetic_observed` rather than runtime-observed.
- Adds a valid Sociosphere SVF receipt-consumption fixture that models `runtime_observed` only with a verified receipt reference.
- Updates the `validate_change` contract documentation to state that Prophet Platform consumes receipt refs but does not issue or certify receipts.

## Boundary

- No live SVF execution in Prophet Platform.
- No Sociosphere registry duplication.
- No AgentPlane execution-authority duplication.
- No production remediation authority.
- No Signadot integration or vendor parity claim.

## Validation expected

```bash
python tools/validate_devsecops_workroom.py
```

This validator is already wired in the `ci / orchestration-fixtures` job.

Refs #523
Refs #520
Refs #519