### PR TITLE
PROMETHEUS: validate JSON-LD proposal against AgentPlane gate policy

### DIFF
--- a/.github/workflows/prometheus-jsonld.yml
+++ b/.github/workflows/prometheus-jsonld.yml
@@ -7,6 +7,7 @@ on:
       - "tools/emit_prometheus_gate_evaluation.py"
       - "tools/validate_prometheus_jsonld_review.py"
       - "tools/run_prometheus_local_demo.py"
+      - "tests/fixtures/prometheus/agentplane-sr-gate-policy.valid.json"
       - "docs/PROMETHEUS_JSONLD_REVIEW.md"
       - ".github/workflows/prometheus-jsonld.yml"
   push:
@@ -17,6 +18,7 @@ on:
       - "tools/emit_prometheus_gate_evaluation.py"
       - "tools/validate_prometheus_jsonld_review.py"
       - "tools/run_prometheus_local_demo.py"
+      - "tests/fixtures/prometheus/agentplane-sr-gate-policy.valid.json"
       - "docs/PROMETHEUS_JSONLD_REVIEW.md"
       - ".github/workflows/prometheus-jsonld.yml"
   workflow_dispatch:
@@ -39,12 +41,13 @@ jobs:
           python3 tools/run_prometheus_local_demo.py \
             --output-dir build/prometheus/jsonld \
             --issued-at 2026-05-27T22:30:00Z
-      - name: Emit gate evaluation artifact
+      - name: Emit gate evaluation artifact with AgentPlane policy fixture
         run: |
           python3 tools/emit_prometheus_gate_evaluation.py \
             --candidate build/prometheus/jsonld/pysr/equation-candidate.json \
             --run-artifact build/prometheus/jsonld/pysr/sr-run-artifact.json \
             --dataset tests/fixtures/prometheus/pysr-mvp-linear.csv \
+            --gate-policy tests/fixtures/prometheus/agentplane-sr-gate-policy.valid.json \
             --evaluation-id urn:prometheus:gate-evaluation:pysr-local-demo:001 \
             --issued-at 2026-05-27T22:30:30Z \
             --output build/prometheus/jsonld/pysr/gate-evaluation.json

--- a/tests/fixtures/prometheus/agentplane-sr-gate-policy.valid.json
+++ b/tests/fixtures/prometheus/agentplane-sr-gate-policy.valid.json
@@ -1,0 +1,19 @@
+{
+  "policyId": "urn:agentplane:sr-gate-policy:prometheus-equation-discovery-v0.1.0",
+  "schemaVersion": "0.1.0",
+  "applicationMode": "equation_discovery",
+  "methodFamilies": ["pysr", "sindy"],
+  "minimumDatasetRows": 4,
+  "maximumCandidateComplexity": 10,
+  "maximumNmse": 0.001,
+  "requiredUnitsStatus": "consistent",
+  "requireReplayVerified": true,
+  "allowControlAuthority": false,
+  "forbiddenGovernanceFlags": [
+    "dimensional_inconsistency",
+    "replay_unverified",
+    "control_authority_requested"
+  ],
+  "promotionEligibility": "review_required",
+  "nonAuthorityDeclaration": "Gate eligibility is not assertion admission, deployment authorization, controller authority, ontology mutation, or memory writeback."
+}

--- a/tools/emit_prometheus_gate_evaluation.py
+++ b/tools/emit_prometheus_gate_evaluation.py
@@ -9,6 +9,9 @@ from pathlib import Path
 from typing import Any
 
 
+DEFAULT_POLICY_ID = "urn:prometheus:automated-shacl-gate-policy:v0.1.0"
+
+
 def now_utc() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
@@ -26,19 +29,78 @@ def dataset_size(path: Path) -> int:
         return sum(1 for _ in reader)
 
 
+def load_policy(path: str | None) -> dict[str, Any] | None:
+    if not path:
+        return None
+    policy = load_json(Path(path))
+    required = {
+        "policyId",
+        "schemaVersion",
+        "applicationMode",
+        "methodFamilies",
+        "minimumDatasetRows",
+        "maximumCandidateComplexity",
+        "maximumNmse",
+        "requiredUnitsStatus",
+        "requireReplayVerified",
+        "allowControlAuthority",
+        "forbiddenGovernanceFlags",
+        "promotionEligibility",
+    }
+    missing = sorted(required - set(policy))
+    if missing:
+        raise ValueError(f"gate policy missing fields: {missing}")
+    if policy["schemaVersion"] != "0.1.0":
+        raise ValueError("gate policy schemaVersion must be 0.1.0")
+    if policy["applicationMode"] != "equation_discovery":
+        raise ValueError("gate policy applicationMode must be equation_discovery")
+    if policy["requireReplayVerified"] is not True:
+        raise ValueError("gate policy must require replay verification")
+    if policy["allowControlAuthority"] is not False:
+        raise ValueError("gate policy must not allow control authority")
+    if policy["requiredUnitsStatus"] != "consistent":
+        raise ValueError("gate policy must require consistent units")
+    if policy["promotionEligibility"] not in {"ineligible", "review_required", "eligible"}:
+        raise ValueError("gate policy promotionEligibility invalid")
+    return policy
+
+
+def validate_against_policy(evaluation: dict[str, Any], policy: dict[str, Any] | None, method_family: str) -> None:
+    if policy is None:
+        return
+    if method_family not in policy["methodFamilies"]:
+        raise ValueError("methodFamily not allowed by gate policy")
+    if evaluation["datasetSize"] < policy["minimumDatasetRows"]:
+        raise ValueError("datasetSize below gate policy minimum")
+    if evaluation["complexity"] > policy["maximumCandidateComplexity"]:
+        raise ValueError("complexity above gate policy maximum")
+    if evaluation["nmse"] > policy["maximumNmse"]:
+        raise ValueError("nmse above gate policy maximum")
+    if evaluation["unitsStatus"] != policy["requiredUnitsStatus"]:
+        raise ValueError("unitsStatus does not match gate policy")
+    if evaluation["replayHashVerified"] is not True:
+        raise ValueError("gate policy requires replay verification")
+    if evaluation["chronosGovernanceFlags"]:
+        raise ValueError("gate evaluation has governance flags")
+    if evaluation["finalAdmissionRequested"] is True:
+        raise ValueError("gate evaluation cannot request final admission")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Emit PROMETHEUS automated gate evaluation artifact")
     parser.add_argument("--candidate", required=True)
     parser.add_argument("--run-artifact", required=True)
     parser.add_argument("--dataset", required=True)
     parser.add_argument("--evaluation-id", required=True)
-    parser.add_argument("--policy-id", default="urn:prometheus:automated-shacl-gate-policy:v0.1.0")
+    parser.add_argument("--policy-id", default=DEFAULT_POLICY_ID)
+    parser.add_argument("--gate-policy")
     parser.add_argument("--issued-at")
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
 
     candidate = load_json(Path(args.candidate))
     run_artifact = load_json(Path(args.run_artifact))
+    policy = load_policy(args.gate_policy)
     candidate_id = candidate["candidateId"]
     ref = None
     for item in run_artifact.get("candidateRefs", []):
@@ -50,7 +112,7 @@ def main() -> int:
 
     evaluation = {
         "evaluationId": args.evaluation_id,
-        "policyId": args.policy_id,
+        "policyId": policy["policyId"] if policy else args.policy_id,
         "candidateId": candidate_id,
         "datasetSize": dataset_size(Path(args.dataset)),
         "nmse": ref["nmse"],
@@ -60,8 +122,10 @@ def main() -> int:
         "chronosGovernanceFlags": [],
         "requestedReviewSurface": "automated_shacl_gate",
         "finalAdmissionRequested": False,
+        "promotionEligibility": policy["promotionEligibility"] if policy else "review_required",
         "issuedAt": args.issued_at or now_utc(),
     }
+    validate_against_policy(evaluation, policy, run_artifact["methodFamily"])
     out = Path(args.output)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(evaluation, indent=2, sort_keys=True) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

Wires the existing PROMETHEUS automated-gate JSON-LD path to an explicit AgentPlane-style SR gate-policy fixture.

This PR adds:

- `tests/fixtures/prometheus/agentplane-sr-gate-policy.valid.json`
- `--gate-policy` support in `tools/emit_prometheus_gate_evaluation.py`
- policy-aware threshold checks for dataset rows, candidate complexity, NMSE, units status, replay verification, governance flags, method family, and final-admission denial
- workflow coverage in `.github/workflows/prometheus-jsonld.yml`

## Boundary

This remains proposal generation only.

It does not:

- mutate Ontogenesis;
- admit SR assertions;
- deploy discovered models;
- grant controller authority;
- write Memory Mesh;
- treat automated gate eligibility as truth.

## Validation path

The existing `prometheus-jsonld` workflow now proves:

1. local demo artifacts can be generated;
2. AgentPlane-style gate policy can be loaded;
3. gate evaluation is validated against that policy;
4. automated SHACL gate still fails closed without gate evidence;
5. JSON-LD `SRAssertionProposal` is emitted with `sr:hasAutomatedGateEvaluation`;
6. JSON-LD proposal validation still passes.

## Notes

The policy fixture mirrors the AgentPlane `SRGatePolicy` shape introduced in AgentPlane PR #260 while keeping Prophet Platform as the runtime consumer, not schema authority.