### PR TITLE
contracts: add Workroom validation receipt reference contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
         run: python tools/smoke_validate_change_v2_api_stub.py
       - name: Validate DevSecOps workroom fixtures
         run: python tools/validate_devsecops_workroom.py
+      - name: Validate DevSecOps validation receipt refs
+        run: python tools/validate_devsecops_validation_run_receipt_ref.py
       - name: Run world-class event loop proof
         run: |
           python specs/orchestration/world_class_event_loop_demo.py --out /tmp/world-class-event-loop --compact

--- a/contracts/workroom/devsecops-validation-run-receipt-ref-v0.1.schema.json
+++ b/contracts/workroom/devsecops-validation-run-receipt-ref-v0.1.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/prophet-platform/devsecops-validation-run-receipt-ref/v0.1.0",
+  "title": "DevSecOpsValidationRunReceiptRef",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "adapter_id",
+    "lane",
+    "authority_boundary",
+    "receipt_ref",
+    "run_ref",
+    "plan_ref",
+    "policy_ref",
+    "verification",
+    "certified_claims",
+    "non_certified_claims",
+    "workroom_projection",
+    "non_claims"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "0.1.0" },
+    "adapter_id": { "type": "string", "pattern": "^workroom:validation-receipt-adapter:" },
+    "lane": { "type": "string", "const": "pre_merge_validation" },
+    "authority_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["execution_authority", "receipt_authority", "workroom_authority"],
+      "properties": {
+        "execution_authority": { "type": "string", "enum": ["sociosphere_svf", "agentplane"] },
+        "receipt_authority": { "type": "string", "enum": ["sociosphere_svf", "agentplane"] },
+        "workroom_authority": { "type": "string", "const": "prophet_platform" }
+      }
+    },
+    "receipt_ref": { "type": "string", "pattern": "^svf:receipt:" },
+    "receipt_artifact_ref": { "type": "string" },
+    "run_ref": { "type": "string", "pattern": "^svf:run:" },
+    "run_artifact_ref": { "type": "string" },
+    "plan_ref": { "type": "string", "pattern": "^svf:plan:" },
+    "policy_ref": { "type": "string", "pattern": "^svf:policy:" },
+    "profile_ref": { "type": "string" },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "verifier", "verified_at"],
+      "properties": {
+        "status": { "type": "string", "enum": ["verified", "failed", "not_checked"] },
+        "verifier": { "type": "string", "minLength": 1 },
+        "verified_at": { "type": "string", "minLength": 1 },
+        "diagnostics_ref": { "type": "string" }
+      }
+    },
+    "certified_claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "non_certified_claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "workroom_projection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_refs", "runtime_parity_level", "evidence_packet_ref"],
+      "properties": {
+        "source_refs": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["validation_run_ref"],
+          "properties": {
+            "change_set_ref": { "type": "string" },
+            "environment_request_ref": { "type": "string" },
+            "validation_run_ref": { "type": "string" }
+          }
+        },
+        "runtime_parity_level": { "type": "string", "enum": ["contract_only", "synthetic_observed", "runtime_observed"] },
+        "evidence_packet_ref": { "type": "string", "pattern": "^evidence://" },
+        "decision_state": { "type": "string", "enum": ["blocked", "needs_review", "allowed_read_only", "resolved", "candidate_only"] }
+      }
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/tests/fixtures/workroom/devsecops-validation-run-receipt-ref.svf.valid.json
+++ b/tests/fixtures/workroom/devsecops-validation-run-receipt-ref.svf.valid.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "0.1.0",
+  "adapter_id": "workroom:validation-receipt-adapter:svf-local-smoke",
+  "lane": "pre_merge_validation",
+  "authority_boundary": {
+    "execution_authority": "sociosphere_svf",
+    "receipt_authority": "sociosphere_svf",
+    "workroom_authority": "prophet_platform"
+  },
+  "receipt_ref": "svf:receipt:example-local-smoke",
+  "receipt_artifact_ref": "artifacts/svf/runs/local-smoke/validation-receipt.json",
+  "run_ref": "svf:run:example-local-smoke",
+  "run_artifact_ref": "artifacts/svf/runs/local-smoke/validation-run.json",
+  "plan_ref": "svf:plan:prophet-platform-workroom-fixtures",
+  "policy_ref": "svf:policy:non-production-validation",
+  "profile_ref": "svf:profile:prophet-platform",
+  "verification": {
+    "status": "verified",
+    "verifier": "sociosphere.svf_runner.local",
+    "verified_at": "2026-05-31T19:30:00Z"
+  },
+  "certified_claims": [
+    "schema_conformant",
+    "fixtures_validated",
+    "receipt_integrity_verified"
+  ],
+  "non_certified_claims": [
+    "production_readiness",
+    "live_infrastructure_safety",
+    "container_runtime_parity",
+    "browser_runtime_parity",
+    "qemu_runtime_parity",
+    "signadot_vendor_parity",
+    "network_isolation_enforced"
+  ],
+  "workroom_projection": {
+    "source_refs": {
+      "change_set_ref": "changeset://github/SocioProphet/prophet-platform/pull/example",
+      "environment_request_ref": "environment:validate-change-v2-request:example",
+      "validation_run_ref": "svf:run:example-local-smoke"
+    },
+    "runtime_parity_level": "synthetic_observed",
+    "evidence_packet_ref": "evidence://svf/receipt/example-local-smoke",
+    "decision_state": "needs_review"
+  },
+  "non_claims": [
+    "This fixture adapts an external SVF receipt into the Workroom pre-merge lane.",
+    "Prophet Platform does not execute the validation run represented by this reference.",
+    "This fixture does not claim Signadot vendor parity or production readiness."
+  ]
+}

--- a/tools/validate_devsecops_validation_run_receipt_ref.py
+++ b/tools/validate_devsecops_validation_run_receipt_ref.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-validation-run-receipt-ref-v0.1.schema.json"
+VALID_FIXTURES = [
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-validation-run-receipt-ref.svf.valid.json",
+]
+SUPPORTED_CERTIFIED_CLAIMS = {
+    "schema_conformant",
+    "fixtures_validated",
+    "tests_passed",
+    "semantic_roundtrip_preserved",
+    "policy_boundary_preserved",
+    "non_production_only",
+    "runtime_smoke_passed",
+    "artifact_integrity_verified",
+    "receipt_integrity_verified",
+}
+REQUIRED_NON_CERTIFIED_CLAIMS = {
+    "production_readiness",
+    "live_infrastructure_safety",
+    "signadot_vendor_parity",
+}
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected object: {path}")
+    return data
+
+
+def schema_problems(schema: dict[str, Any], data: dict[str, Any]) -> list[str]:
+    validator = Draft202012Validator(schema)
+    problems: list[str] = []
+    for error in sorted(validator.iter_errors(data), key=lambda item: list(item.absolute_path)):
+        path = "/".join(str(part) for part in error.absolute_path) or "<root>"
+        problems.append(f"schema:{path}: {error.message}")
+    return problems
+
+
+def semantic_problems(data: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    boundary = data.get("authority_boundary", {})
+    verification = data.get("verification", {})
+    projection = data.get("workroom_projection", {})
+    source_refs = projection.get("source_refs", {}) if isinstance(projection, dict) else {}
+
+    if boundary.get("workroom_authority") != "prophet_platform":
+        problems.append("workroom authority must remain prophet_platform")
+    if boundary.get("execution_authority") == "prophet_platform":
+        problems.append("Prophet Platform must not be the execution authority")
+    if boundary.get("receipt_authority") == "prophet_platform":
+        problems.append("Prophet Platform must not be the receipt authority")
+
+    if data.get("receipt_ref") == data.get("run_ref"):
+        problems.append("receipt_ref and run_ref must remain distinct")
+    if source_refs.get("validation_run_ref") != data.get("run_ref"):
+        problems.append("workroom_projection.source_refs.validation_run_ref must equal run_ref")
+
+    status = verification.get("status")
+    if status != "verified":
+        problems.append("validation run receipt references must be verified before Workroom ingestion")
+
+    certified = set(data.get("certified_claims", []))
+    unsupported = sorted(certified - SUPPORTED_CERTIFIED_CLAIMS)
+    if unsupported:
+        problems.append(f"certified_claims contains unsupported scopes: {unsupported}")
+
+    non_certified = set(data.get("non_certified_claims", []))
+    missing_non_claims = sorted(REQUIRED_NON_CERTIFIED_CLAIMS - non_certified)
+    if missing_non_claims:
+        problems.append(f"non_certified_claims missing required non-claims: {missing_non_claims}")
+
+    parity = projection.get("runtime_parity_level") if isinstance(projection, dict) else None
+    if parity == "runtime_observed" and "signadot_vendor_parity" in non_certified:
+        problems.append("runtime_observed cannot be projected while Signadot vendor parity is non-certified")
+
+    return problems
+
+
+def main() -> int:
+    schema = load(SCHEMA)
+    failed = False
+    results: dict[str, dict[str, Any]] = {}
+
+    for path in VALID_FIXTURES:
+        data = load(path)
+        schema_errors = schema_problems(schema, data)
+        semantic_errors = semantic_problems(data)
+        problems = schema_errors + semantic_errors
+        failed = failed or bool(problems)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "valid",
+            "schema": schema_errors,
+            "semantic": semantic_errors,
+        }
+
+    report = {
+        "validator": "prophet-platform.devsecops-validation-run-receipt-ref.validator.v1",
+        "passed": not failed,
+        "results": results,
+        "non_claims": [
+            "Validator checks Workroom references to external validation run receipts.",
+            "Validator does not execute validation runs.",
+            "Validator does not issue Sociosphere or AgentPlane receipts.",
+            "Validator does not certify production readiness or Signadot vendor parity.",
+        ],
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(("PASS" if not failed else "FAIL") + ": devsecops validation run receipt refs")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Superseded/landed on current `main` through subsequent upstream movement.

Verified on `main` before closing:

- `contracts/workroom/devsecops-validation-run-receipt-ref-v0.1.schema.json` exists.
- `tests/fixtures/workroom/devsecops-validation-run-receipt-ref.svf.valid.json` exists.
- `tools/validate_devsecops_validation_run_receipt_ref.py` exists.
- `.github/workflows/ci.yml` includes `Validate DevSecOps validation receipt refs`.

Closing to remove stale non-mergeable PR clutter.