### PR TITLE
Gate validate_change PR readiness on SVF receipt state

### DIFF
--- a/contracts/environment/validate-change-v2-agentplane-run-link.example.json
+++ b/contracts/environment/validate-change-v2-agentplane-run-link.example.json
@@ -8,15 +8,15 @@
   },
   "agentplane_run_refs": {
     "requested": "agentplane:sandbox-run:requested:scope-d-example",
-    "observed": "agentplane:sandbox-run:observed:scope-d-example"
+    "observed": "agentplane:sandbox-run:observed:sociosphere-svf"
   },
   "status_mapping": {
     "environment_requested": "sandbox_requested",
     "environment_observed": "sandbox_observed"
   },
   "evidence_mapping": {
-    "observed_evidence_ref": "evidence://agentplane/sandbox-run/scope-d-example/synthetic-observed",
-    "observed_receipt_ref": "receipt://agentplane/sandbox-run/scope-d-example/synthetic-observed"
+    "observed_evidence_ref": "evidence://sociosphere/svf/registry-dogfood/verified-receipt",
+    "observed_receipt_ref": "svf:receipt:sociosphere.registry-dogfood.verified"
   },
   "execution_boundary": {
     "executor_plane": "AgentPlane",

--- a/contracts/environment/validate-change-v2-response.environment-failed.json
+++ b/contracts/environment/validate-change-v2-response.environment-failed.json
@@ -7,7 +7,7 @@
   "sociosphere_refs": {
     "workspace_registry": "svf:registry:sociosphere.workspace",
     "environment_profile_id": "environment-sandbox:profile:sociosphere.control-plane-readout",
-    "workspace_validation_status": "environment_failed"
+    "workspace_validation_status": "failed_receipt"
   },
   "selected_plans": [
     "svf:plan:scope-d.defensive-assurance-basic"
@@ -25,30 +25,47 @@
     "sandbox_run_ref": "agentplane:sandbox-run:failed:scope-d-example",
     "execution_status": "failed",
     "evidence_refs": [
-      "evidence://agentplane/sandbox-run/scope-d-example/synthetic-failed"
+      "evidence://sociosphere/svf/scope-d/failed-receipt"
     ]
   },
   "evidence_summary": {
     "evidence_status": "failed",
+    "validation_evidence_state": "failed_receipt",
     "receipt_refs": [
-      "receipt://agentplane/sandbox-run/scope-d-example/synthetic-failed"
+      "svf:receipt:scope-d.failed.001"
     ],
     "failure_codes": [
-      "synthetic_validation_failed"
+      "svf_receipt_failed"
     ],
     "non_certified_claims": [
-      "Failure fixture does not prove live infrastructure behavior.",
-      "Failure fixture does not certify production readiness.",
-      "Failure fixture proves failed-state contract shape only."
+      "Failed receipt blocks validation success.",
+      "Failed receipt does not certify production readiness.",
+      "Failed receipt requires repair and rerun before PR readiness."
+    ]
+  },
+  "pr_readiness": {
+    "readiness_state": "blocked",
+    "merge_allowed": false,
+    "required_evidence_state": "verified_receipt",
+    "observed_evidence_state": "failed_receipt",
+    "blocking_reason_codes": [
+      "svf_receipt_failed",
+      "verified_receipt_required"
+    ],
+    "summary": "Failed receipt evidence blocks PR readiness.",
+    "non_claims": [
+      "Readiness block is based on failed receipt state.",
+      "Readiness block does not authorize remediation."
     ]
   },
   "warnings": [
-    "environment_validation_failed"
+    "environment_validation_failed",
+    "validation_receipt_failed"
   ],
   "next_required_action": "remediate_and_rerun_environment_validation",
   "non_claims": [
-    "Failed synthetic evidence does not certify sandbox execution parity.",
-    "Failed synthetic evidence does not prove traffic routing or stateful isolation.",
-    "Failed synthetic evidence blocks validation-success claims."
+    "Failed receipt evidence does not certify sandbox execution parity.",
+    "Failed receipt evidence does not prove traffic routing or stateful isolation.",
+    "Failed receipt evidence blocks validation-success claims."
   ]
 }

--- a/contracts/environment/validate-change-v2-response.environment-observed.json
+++ b/contracts/environment/validate-change-v2-response.environment-observed.json
@@ -3,17 +3,17 @@
   "request_id": "environment:validate-change-v2-request:scope-d-example",
   "response_id": "environment:validate-change-v2-response:observed:scope-d-example",
   "status": "environment_observed",
-  "repo": "SocioProphet/SCOPE-D",
+  "repo": "SocioProphet/sociosphere",
   "sociosphere_refs": {
     "workspace_registry": "svf:registry:sociosphere.workspace",
     "environment_profile_id": "environment-sandbox:profile:sociosphere.control-plane-readout",
-    "workspace_validation_status": "environment_observed"
+    "workspace_validation_status": "verified_receipt"
   },
   "selected_plans": [
-    "svf:plan:scope-d.defensive-assurance-basic"
+    "svf:plan:sociosphere.registry-dogfood"
   ],
   "environment": {
-    "baseline_ref": "workspace://scope-d/main",
+    "baseline_ref": "workspace://sociosphere/main",
     "changed_service_refs": [],
     "requested_isolation_class": "synthetic_no_network",
     "requested_routing_class": "not_configured",
@@ -22,28 +22,44 @@
   },
   "agentplane_execution": {
     "executor_plane": "AgentPlane",
-    "sandbox_run_ref": "agentplane:sandbox-run:observed:scope-d-example",
+    "sandbox_run_ref": "agentplane:sandbox-run:observed:sociosphere-svf",
     "execution_status": "observed",
     "evidence_refs": [
-      "evidence://agentplane/sandbox-run/scope-d-example/synthetic-observed"
+      "evidence://sociosphere/svf/registry-dogfood/verified-receipt"
     ]
   },
   "evidence_summary": {
     "evidence_status": "observed",
+    "validation_evidence_state": "verified_receipt",
     "receipt_refs": [
-      "receipt://agentplane/sandbox-run/scope-d-example/synthetic-observed"
+      "svf:receipt:sociosphere.registry-dogfood.verified"
+    ],
+    "receipt_digests": [
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     ],
     "non_certified_claims": [
-      "No live infrastructure was created.",
       "No production readiness is certified.",
-      "Synthetic evidence proves contract shape only."
+      "Local receipt does not certify container, browser, QEMU, cluster, or vendor parity.",
+      "Prophet Platform consumes receipt evidence but does not issue receipts."
+    ]
+  },
+  "pr_readiness": {
+    "readiness_state": "ready",
+    "merge_allowed": true,
+    "required_evidence_state": "verified_receipt",
+    "observed_evidence_state": "verified_receipt",
+    "blocking_reason_codes": [],
+    "summary": "Receipt-backed local SVF validation evidence is present for the selected plan.",
+    "non_claims": [
+      "Readiness is scoped to the selected fixture plan.",
+      "Readiness does not certify production deployment safety."
     ]
   },
   "warnings": [],
-  "next_required_action": "none_for_synthetic_fixture",
+  "next_required_action": "none_for_verified_receipt_fixture",
   "non_claims": [
-    "Observed synthetic evidence does not certify sandbox execution parity.",
-    "Observed synthetic evidence does not prove traffic routing or stateful isolation.",
-    "Observed synthetic evidence does not authorize autonomous merge."
+    "Observed receipt evidence does not certify production readiness.",
+    "Observed receipt evidence does not prove traffic routing or stateful isolation.",
+    "Observed receipt evidence does not grant mutation authority."
   ]
 }

--- a/contracts/environment/validate-change-v2-response.environment-requested.json
+++ b/contracts/environment/validate-change-v2-response.environment-requested.json
@@ -26,6 +26,34 @@
     "execution_status": "requested",
     "evidence_refs": []
   },
+  "evidence_summary": {
+    "evidence_status": "missing",
+    "validation_evidence_state": "missing_evidence",
+    "receipt_refs": [],
+    "failure_codes": [
+      "validation_observation_missing"
+    ],
+    "non_certified_claims": [
+      "Plans were selected but no execution evidence was observed.",
+      "No validation success is certified.",
+      "No merge readiness is certified."
+    ]
+  },
+  "pr_readiness": {
+    "readiness_state": "blocked",
+    "merge_allowed": false,
+    "required_evidence_state": "verified_receipt",
+    "observed_evidence_state": "missing_evidence",
+    "blocking_reason_codes": [
+      "validation_observation_missing",
+      "verified_receipt_required"
+    ],
+    "summary": "Selected validation plans are not sufficient for PR readiness without observed receipt-backed evidence.",
+    "non_claims": [
+      "Readiness block is based on fixture evidence state only.",
+      "Readiness block does not execute validation."
+    ]
+  },
   "warnings": [
     "validation_observation_missing",
     "environment_execution_not_observed"

--- a/contracts/environment/validate-change-v2-response.selected-only.json
+++ b/contracts/environment/validate-change-v2-response.selected-only.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "1.0",
+  "request_id": "environment:validate-change-v2-request:scope-d-example",
+  "response_id": "environment:validate-change-v2-response:selected-only:scope-d-example",
+  "status": "environment_requested",
+  "repo": "SocioProphet/SCOPE-D",
+  "sociosphere_refs": {
+    "workspace_registry": "svf:registry:sociosphere.workspace",
+    "environment_profile_id": "environment-sandbox:profile:sociosphere.control-plane-readout",
+    "workspace_validation_status": "selected_only"
+  },
+  "selected_plans": [
+    "svf:plan:scope-d.defensive-assurance-basic"
+  ],
+  "environment": {
+    "baseline_ref": "workspace://scope-d/main",
+    "changed_service_refs": [],
+    "requested_isolation_class": "synthetic_no_network",
+    "requested_routing_class": "not_configured",
+    "requested_async_isolation_class": "not_configured",
+    "requested_stateful_resource_isolation_class": "not_configured"
+  },
+  "agentplane_execution": {
+    "executor_plane": "AgentPlane",
+    "sandbox_run_ref": "agentplane:sandbox-run:pending:scope-d-example:selected-only",
+    "execution_status": "requested",
+    "evidence_refs": []
+  },
+  "evidence_summary": {
+    "evidence_status": "selected_only",
+    "validation_evidence_state": "selected_only",
+    "receipt_refs": [],
+    "failure_codes": [
+      "validation_selected_not_executed"
+    ],
+    "non_certified_claims": [
+      "Plan selection is not execution evidence.",
+      "Plan selection does not certify validation success.",
+      "Plan selection does not authorize merge readiness."
+    ]
+  },
+  "pr_readiness": {
+    "readiness_state": "blocked",
+    "merge_allowed": false,
+    "required_evidence_state": "verified_receipt",
+    "observed_evidence_state": "selected_only",
+    "blocking_reason_codes": [
+      "validation_selected_not_executed",
+      "verified_receipt_required"
+    ],
+    "summary": "Plan selection alone is insufficient for PR readiness.",
+    "non_claims": [
+      "Readiness block is based on selection-only state.",
+      "Readiness block does not execute validation."
+    ]
+  },
+  "warnings": [
+    "validation_observation_missing",
+    "environment_execution_not_observed"
+  ],
+  "next_required_action": "execute_selected_svf_plan",
+  "non_claims": [
+    "Selected-only response does not execute validation actions.",
+    "Selected-only response does not certify validation success.",
+    "Selected-only response does not authorize autonomous merge."
+  ]
+}

--- a/contracts/environment/validate-change-v2-response.stale-receipt.json
+++ b/contracts/environment/validate-change-v2-response.stale-receipt.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "1.0",
+  "request_id": "environment:validate-change-v2-request:scope-d-example",
+  "response_id": "environment:validate-change-v2-response:stale-receipt:scope-d-example",
+  "status": "environment_failed",
+  "repo": "SocioProphet/SCOPE-D",
+  "sociosphere_refs": {
+    "workspace_registry": "svf:registry:sociosphere.workspace",
+    "environment_profile_id": "environment-sandbox:profile:sociosphere.control-plane-readout",
+    "workspace_validation_status": "stale_receipt"
+  },
+  "selected_plans": [
+    "svf:plan:scope-d.defensive-assurance-basic"
+  ],
+  "environment": {
+    "baseline_ref": "workspace://scope-d/main",
+    "changed_service_refs": [],
+    "requested_isolation_class": "synthetic_no_network",
+    "requested_routing_class": "not_configured",
+    "requested_async_isolation_class": "not_configured",
+    "requested_stateful_resource_isolation_class": "not_configured"
+  },
+  "agentplane_execution": {
+    "executor_plane": "AgentPlane",
+    "sandbox_run_ref": "agentplane:sandbox-run:stale:scope-d-example",
+    "execution_status": "failed",
+    "evidence_refs": [
+      "evidence://sociosphere/svf/scope-d/stale-receipt"
+    ]
+  },
+  "evidence_summary": {
+    "evidence_status": "stale",
+    "validation_evidence_state": "stale_receipt",
+    "receipt_refs": [
+      "svf:receipt:scope-d.stale.001"
+    ],
+    "failure_codes": [
+      "svf_receipt_stale"
+    ],
+    "non_certified_claims": [
+      "Stale receipt does not certify the current change set.",
+      "Stale receipt does not certify production readiness.",
+      "Stale receipt requires rerun before PR readiness."
+    ]
+  },
+  "pr_readiness": {
+    "readiness_state": "blocked",
+    "merge_allowed": false,
+    "required_evidence_state": "verified_receipt",
+    "observed_evidence_state": "stale_receipt",
+    "blocking_reason_codes": [
+      "svf_receipt_stale",
+      "verified_receipt_required"
+    ],
+    "summary": "Stale receipt evidence blocks PR readiness for the current change set.",
+    "non_claims": [
+      "Readiness block is based on stale receipt state.",
+      "Readiness block does not execute validation."
+    ]
+  },
+  "warnings": [
+    "validation_receipt_stale"
+  ],
+  "next_required_action": "rerun_selected_svf_plan",
+  "non_claims": [
+    "Stale receipt evidence does not certify the current change.",
+    "Stale receipt evidence does not prove traffic routing or stateful isolation.",
+    "Stale receipt evidence blocks validation-success claims."
+  ]
+}

--- a/tools/validate_environment_validate_change_v2.py
+++ b/tools/validate_environment_validate_change_v2.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -10,14 +9,28 @@ ROOT = Path(__file__).resolve().parents[1]
 FIXTURES = [
     ROOT / "contracts" / "environment" / "validate-change-v2-request.example.json",
     ROOT / "contracts" / "environment" / "validate-change-v2-response.environment-requested.json",
+    ROOT / "contracts" / "environment" / "validate-change-v2-response.selected-only.json",
     ROOT / "contracts" / "environment" / "validate-change-v2-response.environment-observed.json",
     ROOT / "contracts" / "environment" / "validate-change-v2-response.environment-failed.json",
+    ROOT / "contracts" / "environment" / "validate-change-v2-response.stale-receipt.json",
 ]
 STATUSES = {
     "environment_requested",
     "environment_observed",
     "environment_failed",
 }
+VALIDATION_EVIDENCE_STATES = {
+    "not_configured",
+    "selected_only",
+    "missing_evidence",
+    "synthetic_observed",
+    "runtime_observed",
+    "verified_receipt",
+    "failed_receipt",
+    "stale_receipt",
+}
+MERGE_READY_STATES = {"verified_receipt"}
+BLOCKING_STATES = {"not_configured", "selected_only", "missing_evidence", "failed_receipt", "stale_receipt"}
 
 
 def load(path: Path) -> dict[str, Any]:
@@ -52,11 +65,39 @@ def validate_request(data: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
+def validate_pr_readiness(data: dict[str, Any], evidence_state: str | None) -> list[dict[str, Any]]:
+    readiness = data.get("pr_readiness", {})
+    blocking_codes = readiness.get("blocking_reason_codes", []) if isinstance(readiness, dict) else []
+    merge_allowed = readiness.get("merge_allowed") if isinstance(readiness, dict) else None
+    readiness_state = readiness.get("readiness_state") if isinstance(readiness, dict) else None
+    results = [
+        check("readiness:object", isinstance(readiness, dict) and bool(readiness), [str(readiness)]),
+        check("readiness:required-state", readiness.get("required_evidence_state") == "verified_receipt" if isinstance(readiness, dict) else False),
+        check("readiness:non-claims", isinstance(readiness.get("non_claims"), list) and len(readiness.get("non_claims", [])) >= 1 if isinstance(readiness, dict) else False),
+    ]
+    if evidence_state in MERGE_READY_STATES:
+        results.extend([
+            check("readiness:verified:merge-allowed", merge_allowed is True, [str(merge_allowed)]),
+            check("readiness:verified:state", readiness_state == "ready", [str(readiness_state)]),
+            check("readiness:verified:no-blocking-codes", blocking_codes == [], [str(blocking_codes)]),
+        ])
+    if evidence_state in BLOCKING_STATES:
+        results.extend([
+            check(f"readiness:{evidence_state}:merge-blocked", merge_allowed is False, [str(merge_allowed)]),
+            check(f"readiness:{evidence_state}:not-ready", readiness_state in {"blocked", "needs_review"}, [str(readiness_state)]),
+            check(f"readiness:{evidence_state}:blocking-codes", isinstance(blocking_codes, list) and len(blocking_codes) >= 1, [str(blocking_codes)]),
+        ])
+    return results
+
+
 def validate_response(data: dict[str, Any]) -> list[dict[str, Any]]:
     status = data.get("status")
     execution = data.get("agentplane_execution", {})
     evidence_refs = execution.get("evidence_refs", [])
     evidence_summary = data.get("evidence_summary", {})
+    receipt_refs = evidence_summary.get("receipt_refs", []) if isinstance(evidence_summary, dict) else []
+    failure_codes = evidence_summary.get("failure_codes", []) if isinstance(evidence_summary, dict) else []
+    evidence_state = evidence_summary.get("validation_evidence_state") if isinstance(evidence_summary, dict) else None
     results = [
         check(f"response:{status}:schema-version", data.get("schema_version") == "1.0"),
         check(f"response:{status}:status", status in STATUSES, [str(status)]),
@@ -65,29 +106,35 @@ def validate_response(data: dict[str, Any]) -> list[dict[str, Any]]:
         check(f"response:{status}:executor-plane", execution.get("executor_plane") == "AgentPlane", [str(execution.get("executor_plane"))]),
         check(f"response:{status}:sandbox-run-ref", str(execution.get("sandbox_run_ref", "")).startswith("agentplane:sandbox-run:")),
         check(f"response:{status}:evidence-refs-list", isinstance(evidence_refs, list)),
+        check(f"response:{status}:evidence-summary", isinstance(evidence_summary, dict) and bool(evidence_summary), [str(evidence_summary)]),
+        check(f"response:{status}:validation-evidence-state", evidence_state in VALIDATION_EVIDENCE_STATES, [str(evidence_state)]),
         check(f"response:{status}:non-claims", isinstance(data.get("non_claims"), list) and len(data.get("non_claims", [])) >= 1),
     ]
+    results.extend(validate_pr_readiness(data, evidence_state))
+
     if status == "environment_requested":
         results.extend([
             check("response:requested:execution-status", execution.get("execution_status") == "requested"),
             check("response:requested:evidence-empty", evidence_refs == [], [str(evidence_refs)]),
+            check("response:requested:non-ready-state", evidence_state in {"selected_only", "missing_evidence"}, [str(evidence_state)]),
             check("response:requested:missing-warning", "environment_execution_not_observed" in data.get("warnings", []), [str(data.get("warnings", []))]),
         ])
     if status == "environment_observed":
-        receipt_refs = evidence_summary.get("receipt_refs", []) if isinstance(evidence_summary, dict) else []
         results.extend([
             check("response:observed:execution-status", execution.get("execution_status") == "observed"),
             check("response:observed:evidence-present", len(evidence_refs) >= 1, [str(evidence_refs)]),
+            check("response:observed:verified-receipt-state", evidence_state == "verified_receipt", [str(evidence_state)]),
             check("response:observed:receipt-present", isinstance(receipt_refs, list) and len(receipt_refs) >= 1, [str(receipt_refs)]),
+            check("response:observed:svf-receipt", all(str(ref).startswith("svf:receipt:") for ref in receipt_refs), [str(receipt_refs)]),
             check("response:observed:no-warnings", data.get("warnings") == [], [str(data.get("warnings"))]),
         ])
     if status == "environment_failed":
-        failure_codes = evidence_summary.get("failure_codes", []) if isinstance(evidence_summary, dict) else []
         results.extend([
             check("response:failed:execution-status", execution.get("execution_status") == "failed"),
+            check("response:failed:evidence-state", evidence_state in {"failed_receipt", "stale_receipt"}, [str(evidence_state)]),
             check("response:failed:evidence-present", len(evidence_refs) >= 1, [str(evidence_refs)]),
-            check("response:failed:failure-code", "synthetic_validation_failed" in failure_codes, [str(failure_codes)]),
-            check("response:failed:warning", "environment_validation_failed" in data.get("warnings", []), [str(data.get("warnings", []))]),
+            check("response:failed:failure-code", any(code in failure_codes for code in {"svf_receipt_failed", "svf_receipt_stale", "synthetic_validation_failed"}), [str(failure_codes)]),
+            check("response:failed:warning", any(warning in data.get("warnings", []) for warning in {"environment_validation_failed", "validation_receipt_failed", "validation_receipt_stale"}), [str(data.get("warnings", []))]),
         ])
     return results
 


### PR DESCRIPTION
## Summary

Adds explicit validate_change PR-readiness gating based on SVF receipt evidence state.

## Changes

- Extends the validate_change environment fixture validator to validate pr_readiness objects.
- Allows merge_ready only for verified_receipt.
- Blocks selected_only, missing_evidence, failed_receipt, and stale_receipt.
- Adds response fixtures covering those states.

Refs #523
Refs #520
Refs #519