### PR TITLE
Expose validate_change readiness fields in API stub

### DIFF
--- a/apps/api/cmd/socioprophet-api/main.go
+++ b/apps/api/cmd/socioprophet-api/main.go
@@ -100,6 +100,34 @@ func handleValidateChange(c net.Conn, env *tritrpcv1.Envelope, key [32]byte) {
             "execution_status": "requested",
             "evidence_refs": []string{},
         },
+        "evidence_summary": map[string]any{
+            "evidence_status": "missing",
+            "validation_evidence_state": "missing_evidence",
+            "receipt_refs": []string{},
+            "failure_codes": []string{
+                "validation_observation_missing",
+            },
+            "non_certified_claims": []string{
+                "Plans were selected but no execution evidence was observed.",
+                "No validation success is certified.",
+                "No merge readiness is certified.",
+            },
+        },
+        "pr_readiness": map[string]any{
+            "readiness_state": "blocked",
+            "merge_allowed": false,
+            "required_evidence_state": "verified_receipt",
+            "observed_evidence_state": "missing_evidence",
+            "blocking_reason_codes": []string{
+                "validation_observation_missing",
+                "verified_receipt_required",
+            },
+            "summary": "Selected validation plans are not sufficient for PR readiness without observed receipt-backed evidence.",
+            "non_claims": []string{
+                "Readiness block is based on missing evidence state.",
+                "Readiness block does not execute validation.",
+            },
+        },
         "warnings": []string{
             "validation_observation_missing",
             "environment_execution_not_observed",
@@ -109,6 +137,7 @@ func handleValidateChange(c net.Conn, env *tritrpcv1.Envelope, key [32]byte) {
             "API stub does not execute live sandbox infrastructure.",
             "API stub does not certify Signadot-style runtime parity.",
             "API stub returns a deterministic environment_requested response only.",
+            "API stub cannot report merge readiness without verified receipt evidence.",
         },
     }
 

--- a/tools/smoke_validate_change_v2_api_stub.py
+++ b/tools/smoke_validate_change_v2_api_stub.py
@@ -21,6 +21,12 @@ REQUIRED_API = [
     "binding.ValidateChangeReq",
     '"status": "environment_requested"',
     '"agentplane_synthetic_sandbox_run"',
+    '"evidence_summary"',
+    '"validation_evidence_state": "missing_evidence"',
+    '"pr_readiness"',
+    '"merge_allowed": false',
+    '"required_evidence_state": "verified_receipt"',
+    '"verified_receipt_required"',
     '"API stub does not execute live sandbox infrastructure."',
 ]
 REQUIRED_GATEWAY = [
@@ -63,7 +69,7 @@ def main() -> int:
         "non_claims": [
             "Smoke check does not execute live sandbox infrastructure.",
             "Smoke check does not certify Signadot-style runtime parity.",
-            "Smoke check validates route/contract wiring only."
+            "Smoke check validates route/contract wiring and readiness-field presence only."
         ]
     }
     print(json.dumps(result, indent=2, sort_keys=True))


### PR DESCRIPTION
## Summary

Adds the receipt-state and PR-readiness fields to the actual validate_change API stub response.

## Changes

- Adds evidence_summary.validation_evidence_state = missing_evidence.
- Adds blocking pr_readiness payload requiring verified_receipt.
- Extends the API-stub smoke validator so CI fails if readiness fields disappear.

Refs #523
Refs #520
Refs #519