### PR TITLE
test: replay SCOPE-D proposal safety fixtures

### DIFF
--- a/.github/workflows/scope-d-hardening-fixtures.yml
+++ b/.github/workflows/scope-d-hardening-fixtures.yml
@@ -1,0 +1,18 @@
+name: proposal-safety-fixtures
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate-proposal-safety-fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate proposal safety fixtures
+        run: python3 tools/validate_scope_d_hardening_fixtures.py

--- a/fixtures/ops-fabric/policyfabric-scope-d-auto-approval-denied.fixture.json
+++ b/fixtures/ops-fabric/policyfabric-scope-d-auto-approval-denied.fixture.json
@@ -1,0 +1,21 @@
+{
+  "fixture_id": "policyfabric-scope-d-auto-approval-denied.v0",
+  "expected_result": "INVALID_POLICY_DECISION",
+  "expected_reason": "POLICY_CANNOT_AUTO_APPROVE_SCOPE_D_DERIVED",
+  "input": {
+    "scope_d_provenance": {
+      "derived_from_scope_d": true,
+      "scope_d_run_id": "scope_d_run_001",
+      "operator_warning_required": true
+    }
+  },
+  "invalid_policy_output": {
+    "policy_status": "ALLOWED_AUTO",
+    "execution_eligible": true
+  },
+  "allowed_policy_outputs": [
+    "DENIED",
+    "ALLOWED_REPORT_ONLY",
+    "REQUIRES_HUMAN_REVIEW_SCOPE_D_ACK"
+  ]
+}

--- a/fixtures/ops-fabric/scope-d-derived-proposal-skips-human-review-routes-to-void.fixture.json
+++ b/fixtures/ops-fabric/scope-d-derived-proposal-skips-human-review-routes-to-void.fixture.json
@@ -1,0 +1,80 @@
+{
+  "fixture_id": "scope-d-derived-proposal-skips-human-review-routes-to-void.v0",
+  "expected_result": [
+    "INVALID_FOR_EXECUTION",
+    "ROUTED_TO_VOID_NETWORK"
+  ],
+  "expected_reason": "SCOPE_D_DERIVED_PROPOSAL_MISSING_EXPLICIT_HUMAN_REVIEW_SEMAPHORE",
+  "trace": {
+    "trace_id": "trace_scope_d_auto_approval_denied_001",
+    "events": [
+      {
+        "event_id": "evt_scope_d_validated_001",
+        "trace_id": "trace_scope_d_auto_approval_denied_001",
+        "span_id": "span_001",
+        "parent_span_id": null,
+        "event_type": "scope_d.validated",
+        "ts": "2026-01-08T00:00:00Z",
+        "producer": "SCOPE-D",
+        "payload": {
+          "scope_d_run_id": "scope_d_run_001",
+          "exercise_id": "exercise_001",
+          "safety_mode": "READ_ONLY"
+        }
+      },
+      {
+        "event_id": "evt_gdsi_projected_001",
+        "trace_id": "trace_scope_d_auto_approval_denied_001",
+        "span_id": "span_002",
+        "parent_span_id": "span_001",
+        "event_type": "gdsi.projected",
+        "ts": "2026-01-08T00:01:00Z",
+        "producer": "global-devsecops-intelligence",
+        "payload": {
+          "projection_id": "projection_001",
+          "scope_d_provenance": {
+            "derived_from_scope_d": true,
+            "scope_d_run_id": "scope_d_run_001",
+            "operator_warning_required": true
+          }
+        }
+      },
+      {
+        "event_id": "evt_policy_evaluated_001",
+        "trace_id": "trace_scope_d_auto_approval_denied_001",
+        "span_id": "span_003",
+        "parent_span_id": "span_002",
+        "event_type": "policy.evaluated",
+        "ts": "2026-01-08T00:02:00Z",
+        "producer": "policy-fabric",
+        "payload": {
+          "policy_status": "ALLOWED_AUTO",
+          "execution_eligible": true
+        }
+      },
+      {
+        "event_id": "evt_placement_selected_001",
+        "trace_id": "trace_scope_d_auto_approval_denied_001",
+        "span_id": "span_004",
+        "parent_span_id": "span_003",
+        "event_type": "placement.selected",
+        "ts": "2026-01-08T00:03:00Z",
+        "producer": "agentplane",
+        "payload": {
+          "executor_id": "executor_001"
+        }
+      }
+    ]
+  },
+  "missing_required_signal": "human.reviewed.explicit_scope_d_ack",
+  "required_void_record": {
+    "void_reason": "SCOPE_D_REQUIRES_HUMAN_REVIEW",
+    "containment_mode": "REVIEW_QUEUE",
+    "forbidden_actions": [
+      "execute",
+      "promote_to_canon",
+      "write_to_memory_as_truth",
+      "emit_execution_lease"
+    ]
+  }
+}

--- a/tools/validate_scope_d_hardening_fixtures.py
+++ b/tools/validate_scope_d_hardening_fixtures.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Validate Sprint-1 SCOPE-D hardening fixtures.
+
+This is deliberately narrow. It enforces only the hardening doctrine needed
+before broader ref/schema expansion:
+
+1. PolicyFabric must not auto-approve SCOPE-D-derived work.
+2. If an unsafe policy/placement trace appears anyway, receipt-style
+   defense-in-depth must fail closed and require Void Network containment.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_DIR = ROOT / "fixtures" / "ops-fabric"
+
+POLICY_FIXTURE = FIXTURE_DIR / "policyfabric-scope-d-auto-approval-denied.fixture.json"
+VOID_FIXTURE = FIXTURE_DIR / "scope-d-derived-proposal-skips-human-review-routes-to-void.fixture.json"
+
+ALLOWED_SCOPE_D_POLICY_OUTPUTS = {
+    "DENIED",
+    "ALLOWED_REPORT_ONLY",
+    "REQUIRES_HUMAN_REVIEW_SCOPE_D_ACK",
+}
+UNSAFE_EVENT_TYPES = {
+    "placement.selected",
+    "run.started",
+    "run.completed",
+    "execution.lease.issued",
+}
+REQUIRED_HUMAN_REVIEW_SIGNAL = "human.reviewed.explicit_scope_d_ack"
+REQUIRED_VOID_FORBIDDEN_ACTIONS = {
+    "execute",
+    "promote_to_canon",
+    "write_to_memory_as_truth",
+    "emit_execution_lease",
+}
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise AssertionError(f"missing fixture: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def iter_payloads(obj: Any):
+    if isinstance(obj, dict):
+        if "payload" in obj and isinstance(obj["payload"], dict):
+            yield obj["payload"]
+        yield obj
+        for value in obj.values():
+            yield from iter_payloads(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from iter_payloads(item)
+
+
+def contains_scope_d_provenance(obj: Any) -> bool:
+    for payload in iter_payloads(obj):
+        prov = payload.get("scope_d_provenance") if isinstance(payload, dict) else None
+        if isinstance(prov, dict) and prov.get("derived_from_scope_d") is True:
+            return True
+    return False
+
+
+def validate_policy_fixture() -> None:
+    fx = load_json(POLICY_FIXTURE)
+
+    if fx.get("expected_result") != "INVALID_POLICY_DECISION":
+        raise AssertionError("policy fixture must expect INVALID_POLICY_DECISION")
+    if fx.get("expected_reason") != "POLICY_CANNOT_AUTO_APPROVE_SCOPE_D_DERIVED":
+        raise AssertionError("policy fixture has wrong expected_reason")
+
+    input_prov = fx.get("input", {}).get("scope_d_provenance", {})
+    if input_prov.get("derived_from_scope_d") is not True:
+        raise AssertionError("policy fixture must start from SCOPE-D-derived input")
+
+    invalid = fx.get("invalid_policy_output", {})
+    if invalid.get("policy_status") != "ALLOWED_AUTO":
+        raise AssertionError("policy fixture must cover ALLOWED_AUTO denial")
+    if invalid.get("execution_eligible") is not True:
+        raise AssertionError("policy fixture must cover execution_eligible denial")
+
+    allowed = set(fx.get("allowed_policy_outputs", []))
+    if allowed != ALLOWED_SCOPE_D_POLICY_OUTPUTS:
+        raise AssertionError(
+            "allowed policy outputs must be exactly "
+            f"{sorted(ALLOWED_SCOPE_D_POLICY_OUTPUTS)}, got {sorted(allowed)}"
+        )
+
+
+def validate_void_fixture() -> None:
+    fx = load_json(VOID_FIXTURE)
+
+    expected = set(fx.get("expected_result", []))
+    if expected != {"INVALID_FOR_EXECUTION", "ROUTED_TO_VOID_NETWORK"}:
+        raise AssertionError("void fixture must expect invalid execution and void routing")
+    if fx.get("expected_reason") != "SCOPE_D_DERIVED_PROPOSAL_MISSING_EXPLICIT_HUMAN_REVIEW_SEMAPHORE":
+        raise AssertionError("void fixture has wrong expected_reason")
+
+    trace = fx.get("trace", {})
+    trace_id = trace.get("trace_id")
+    events = trace.get("events", [])
+    if not trace_id or not events:
+        raise AssertionError("void fixture must include a trace_id and events")
+
+    for event in events:
+        if event.get("trace_id") != trace_id:
+            raise AssertionError("all events must join on the fixture trace_id")
+
+    event_types = [event.get("event_type") for event in events]
+    if REQUIRED_HUMAN_REVIEW_SIGNAL in event_types:
+        raise AssertionError("negative fixture must omit explicit human review semaphore")
+    if not contains_scope_d_provenance(trace):
+        raise AssertionError("void fixture must contain SCOPE-D provenance")
+
+    unsafe_policy = False
+    unsafe_transition = False
+    for event in events:
+        payload = event.get("payload", {})
+        if event.get("event_type") == "policy.evaluated":
+            if payload.get("policy_status") == "ALLOWED_AUTO" or payload.get("execution_eligible") is True:
+                unsafe_policy = True
+        if event.get("event_type") in UNSAFE_EVENT_TYPES:
+            unsafe_transition = True
+
+    if not unsafe_policy:
+        raise AssertionError("void fixture must include unsafe policy output")
+    if not unsafe_transition:
+        raise AssertionError("void fixture must include unsafe downstream transition")
+
+    void_record = fx.get("required_void_record", {})
+    if void_record.get("void_reason") != "SCOPE_D_REQUIRES_HUMAN_REVIEW":
+        raise AssertionError("void fixture must require SCOPE_D_REQUIRES_HUMAN_REVIEW")
+    if void_record.get("containment_mode") != "REVIEW_QUEUE":
+        raise AssertionError("void fixture must route to REVIEW_QUEUE")
+
+    forbidden = set(void_record.get("forbidden_actions", []))
+    missing = REQUIRED_VOID_FORBIDDEN_ACTIONS - forbidden
+    if missing:
+        raise AssertionError(f"void record missing forbidden actions: {sorted(missing)}")
+
+
+def main() -> None:
+    validate_policy_fixture()
+    validate_void_fixture()
+    print("[OK] SCOPE-D hardening fixtures validated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fresh current-main replay of stale/non-mergeable #469.

Captured content:

- SCOPE-D-derived policy auto-approval denial fixture
- SCOPE-D-derived proposal missing explicit human review fixture
- narrow validator for the two hardening fixtures
- dedicated fixture validation workflow

## Repair included

This replay includes the workflow hardening that blocked the stale PR:

```yaml
permissions:
  contents: read
```

## Boundary

This remains a fixture/validator slice only. It does not introduce runtime authority, live execution, policy promotion, schema promotion, or broader ref expansion.

## Validation target

```bash
python3 tools/validate_scope_d_hardening_fixtures.py
```

## Supersedes

Supersedes stale/non-mergeable #469 after this replacement lands.