### PR TITLE
Validate Sociosphere SVF receipt ingestion fixture

### DIFF
--- a/tests/fixtures/workroom/devsecops-validation-run-receipt-ref.svf.valid.json
+++ b/tests/fixtures/workroom/devsecops-validation-run-receipt-ref.svf.valid.json
@@ -1,27 +1,29 @@
 {
   "schema_version": "0.1.0",
-  "adapter_id": "workroom:validation-receipt-adapter:svf-local-smoke",
+  "adapter_id": "workroom:validation-receipt-adapter:sociosphere-svf-registry-dogfood",
   "lane": "pre_merge_validation",
   "authority_boundary": {
     "execution_authority": "sociosphere_svf",
     "receipt_authority": "sociosphere_svf",
     "workroom_authority": "prophet_platform"
   },
-  "receipt_ref": "svf:receipt:example-local-smoke",
-  "receipt_artifact_ref": "artifacts/svf/runs/local-smoke/validation-receipt.json",
-  "run_ref": "svf:run:example-local-smoke",
+  "receipt_ref": "svf:receipt:sociosphere.registry-dogfood.verified",
+  "receipt_artifact_ref": "tests/fixtures/workroom/sociosphere-svf-validation-receipt.valid.json",
+  "run_ref": "svf:run:sociosphere.registry-dogfood.verified",
   "run_artifact_ref": "artifacts/svf/runs/local-smoke/validation-run.json",
-  "plan_ref": "svf:plan:prophet-platform-workroom-fixtures",
-  "policy_ref": "svf:policy:non-production-validation",
-  "profile_ref": "svf:profile:prophet-platform",
+  "plan_ref": "svf:plan:sociosphere.registry-dogfood",
+  "policy_ref": "svf:policy:sociosphere.local-readonly",
+  "profile_ref": "svf:profile:sociosphere.dogfood",
   "verification": {
     "status": "verified",
     "verifier": "sociosphere.svf_runner.local",
-    "verified_at": "2026-05-31T19:30:00Z"
+    "verified_at": "2026-05-31T18:46:09Z"
   },
   "certified_claims": [
     "schema_conformant",
-    "fixtures_validated",
+    "non_production_only",
+    "policy_boundary_preserved",
+    "artifact_integrity_verified",
     "receipt_integrity_verified"
   ],
   "non_certified_claims": [
@@ -35,17 +37,18 @@
   ],
   "workroom_projection": {
     "source_refs": {
-      "change_set_ref": "changeset://github/SocioProphet/prophet-platform/pull/example",
-      "environment_request_ref": "environment:validate-change-v2-request:example",
-      "validation_run_ref": "svf:run:example-local-smoke"
+      "change_set_ref": "changeset://github/SocioProphet/sociosphere/pull/434",
+      "environment_request_ref": "environment:validate-change-v2-request:sociosphere-svf",
+      "validation_run_ref": "svf:run:sociosphere.registry-dogfood.verified"
     },
     "runtime_parity_level": "synthetic_observed",
-    "evidence_packet_ref": "evidence://svf/receipt/example-local-smoke",
+    "evidence_packet_ref": "evidence://sociosphere/svf/registry-dogfood/verified-receipt",
     "decision_state": "needs_review"
   },
   "non_claims": [
-    "This fixture adapts an external SVF receipt into the Workroom pre-merge lane.",
+    "This fixture adapts an external Sociosphere SVF receipt into the Workroom pre-merge lane.",
     "Prophet Platform does not execute the validation run represented by this reference.",
+    "Prophet Platform does not issue or certify the Sociosphere receipt represented by this reference.",
     "This fixture does not claim Signadot vendor parity or production readiness."
   ]
 }

--- a/tests/fixtures/workroom/sociosphere-svf-validation-receipt.valid.json
+++ b/tests/fixtures/workroom/sociosphere-svf-validation-receipt.valid.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "1.0",
+  "receipt_id": "svf:receipt:sociosphere.registry-dogfood.verified",
+  "run_ref": "svf:run:sociosphere.registry-dogfood.verified",
+  "run_artifact": "artifacts/svf/runs/local-smoke/validation-run.json",
+  "run_digest": {
+    "algorithm": "sha256",
+    "digest": "1111111111111111111111111111111111111111111111111111111111111111"
+  },
+  "repo": "SocioProphet/sociosphere",
+  "profile_ref": "svf:profile:sociosphere.dogfood",
+  "plan_ref": "svf:plan:sociosphere.registry-dogfood",
+  "plan_digest": {
+    "algorithm": "sha256",
+    "digest": "2222222222222222222222222222222222222222222222222222222222222222"
+  },
+  "policy_ref": "svf:policy:sociosphere.local-readonly",
+  "policy_digest": {
+    "algorithm": "sha256",
+    "digest": "3333333333333333333333333333333333333333333333333333333333333333"
+  },
+  "input_digests": [
+    {
+      "name": "registry",
+      "path": "registry/sovereign-validation-fabric.yaml",
+      "algorithm": "sha256",
+      "digest": "4444444444444444444444444444444444444444444444444444444444444444"
+    }
+  ],
+  "output_digests": [
+    {
+      "name": "svf:action:sociosphere.validate-registry",
+      "path": "artifacts/svf/runs/local-smoke/01-svf_action_sociosphere.validate-registry.result.json",
+      "algorithm": "sha256",
+      "digest": "5555555555555555555555555555555555555555555555555555555555555555"
+    }
+  ],
+  "certified_claims": [
+    "artifact_integrity_verified",
+    "non_production_only",
+    "policy_boundary_preserved",
+    "receipt_integrity_verified",
+    "schema_conformant"
+  ],
+  "non_certified_claims": [
+    "production_readiness",
+    "live_infrastructure_safety",
+    "container_runtime_parity",
+    "browser_runtime_parity",
+    "qemu_runtime_parity",
+    "signadot_vendor_parity",
+    "network_isolation_enforced"
+  ],
+  "verification": {
+    "status": "verified",
+    "verifier": "sociosphere.svf_runner.local",
+    "verified_at": "2026-05-31T18:46:09Z",
+    "diagnostics": []
+  },
+  "issued_at": "2026-05-31T18:46:09Z",
+  "non_claims": [
+    "Fixture mirrors the Sociosphere SVF local receipt shape produced by tools/svf_runner.py.",
+    "Fixture values are stable deterministic stand-ins for exported artifact digests.",
+    "Fixture does not certify production readiness, live infrastructure safety, or Signadot vendor parity."
+  ]
+}

--- a/tools/validate_devsecops_validation_run_receipt_ref.py
+++ b/tools/validate_devsecops_validation_run_receipt_ref.py
@@ -12,6 +12,9 @@ SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-validation-run-receipt-ref
 VALID_FIXTURES = [
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-validation-run-receipt-ref.svf.valid.json",
 ]
+EXTERNAL_RECEIPT_FIXTURES = [
+    ROOT / "tests" / "fixtures" / "workroom" / "sociosphere-svf-validation-receipt.valid.json",
+]
 SUPPORTED_CERTIFIED_CLAIMS = {
     "schema_conformant",
     "fixtures_validated",
@@ -27,6 +30,25 @@ REQUIRED_NON_CERTIFIED_CLAIMS = {
     "production_readiness",
     "live_infrastructure_safety",
     "signadot_vendor_parity",
+}
+SOCIOSPHERE_REQUIRED_RECEIPT_FIELDS = {
+    "schema_version",
+    "receipt_id",
+    "run_ref",
+    "run_digest",
+    "repo",
+    "profile_ref",
+    "plan_ref",
+    "plan_digest",
+    "policy_ref",
+    "policy_digest",
+    "input_digests",
+    "output_digests",
+    "certified_claims",
+    "non_certified_claims",
+    "verification",
+    "issued_at",
+    "non_claims",
 }
 
 
@@ -44,6 +66,29 @@ def schema_problems(schema: dict[str, Any], data: dict[str, Any]) -> list[str]:
         path = "/".join(str(part) for part in error.absolute_path) or "<root>"
         problems.append(f"schema:{path}: {error.message}")
     return problems
+
+
+def digest_record_valid(record: Any) -> bool:
+    return (
+        isinstance(record, dict)
+        and record.get("algorithm") == "sha256"
+        and isinstance(record.get("digest"), str)
+        and len(record["digest"]) == 64
+    )
+
+
+def named_digest_list_valid(items: Any) -> bool:
+    return (
+        isinstance(items, list)
+        and bool(items)
+        and all(
+            isinstance(item, dict)
+            and isinstance(item.get("name"), str)
+            and isinstance(item.get("path"), str)
+            and digest_record_valid(item)
+            for item in items
+        )
+    )
 
 
 def semantic_problems(data: dict[str, Any]) -> list[str]:
@@ -86,13 +131,92 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
     return problems
 
 
+def sociosphere_receipt_problems(data: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    missing = sorted(SOCIOSPHERE_REQUIRED_RECEIPT_FIELDS - set(data))
+    problems.extend(f"sociosphere receipt missing required field: {field}" for field in missing)
+
+    if data.get("schema_version") != "1.0":
+        problems.append("sociosphere receipt schema_version must be 1.0")
+    if not str(data.get("receipt_id", "")).startswith("svf:receipt:"):
+        problems.append("sociosphere receipt_id must start with svf:receipt:")
+    if not str(data.get("run_ref", "")).startswith("svf:run:"):
+        problems.append("sociosphere run_ref must start with svf:run:")
+    if data.get("receipt_id") == data.get("run_ref"):
+        problems.append("sociosphere receipt_id and run_ref must be distinct")
+    if data.get("repo") != "SocioProphet/sociosphere":
+        problems.append("sociosphere receipt fixture must identify SocioProphet/sociosphere")
+    if data.get("profile_ref") != "svf:profile:sociosphere.dogfood":
+        problems.append("sociosphere receipt fixture must use dogfood profile")
+    if data.get("plan_ref") != "svf:plan:sociosphere.registry-dogfood":
+        problems.append("sociosphere receipt fixture must use registry dogfood plan")
+    if data.get("policy_ref") != "svf:policy:sociosphere.local-readonly":
+        problems.append("sociosphere receipt fixture must use local-readonly policy")
+
+    for field in ("run_digest", "plan_digest", "policy_digest"):
+        if not digest_record_valid(data.get(field)):
+            problems.append(f"sociosphere {field} must be a sha256 digest record")
+    if not named_digest_list_valid(data.get("input_digests")):
+        problems.append("sociosphere input_digests must be a non-empty named digest list")
+    if not named_digest_list_valid(data.get("output_digests")):
+        problems.append("sociosphere output_digests must be a non-empty named digest list")
+
+    verification = data.get("verification", {})
+    if not isinstance(verification, dict) or verification.get("status") != "verified":
+        problems.append("sociosphere receipt fixture must be verified")
+    if verification.get("verifier") != "sociosphere.svf_runner.local":
+        problems.append("sociosphere receipt verifier must be sociosphere.svf_runner.local")
+
+    certified = set(data.get("certified_claims", []))
+    unsupported = sorted(certified - SUPPORTED_CERTIFIED_CLAIMS)
+    if unsupported:
+        problems.append(f"sociosphere receipt has unsupported certified claims: {unsupported}")
+    required_certified = {"schema_conformant", "non_production_only", "receipt_integrity_verified"}
+    missing_certified = sorted(required_certified - certified)
+    if missing_certified:
+        problems.append(f"sociosphere receipt missing certified claims: {missing_certified}")
+
+    non_certified = set(data.get("non_certified_claims", []))
+    missing_non_claims = sorted(REQUIRED_NON_CERTIFIED_CLAIMS - non_certified)
+    if missing_non_claims:
+        problems.append(f"sociosphere receipt missing required non-claims: {missing_non_claims}")
+
+    return problems
+
+
+def cross_fixture_problems(adapter: dict[str, Any], receipt: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    projection = adapter.get("workroom_projection", {})
+    source_refs = projection.get("source_refs", {}) if isinstance(projection, dict) else {}
+
+    if adapter.get("authority_boundary", {}).get("receipt_authority") != "sociosphere_svf":
+        problems.append("adapter receipt_authority must be sociosphere_svf for Sociosphere receipt ingestion")
+    if adapter.get("authority_boundary", {}).get("execution_authority") != "sociosphere_svf":
+        problems.append("adapter execution_authority must be sociosphere_svf for Sociosphere receipt ingestion")
+    if adapter.get("receipt_ref") != receipt.get("receipt_id"):
+        problems.append("adapter receipt_ref must equal Sociosphere receipt_id")
+    if adapter.get("run_ref") != receipt.get("run_ref"):
+        problems.append("adapter run_ref must equal Sociosphere run_ref")
+    if adapter.get("plan_ref") != receipt.get("plan_ref"):
+        problems.append("adapter plan_ref must equal Sociosphere plan_ref")
+    if adapter.get("policy_ref") != receipt.get("policy_ref"):
+        problems.append("adapter policy_ref must equal Sociosphere policy_ref")
+    if source_refs.get("validation_run_ref") != receipt.get("run_ref"):
+        problems.append("adapter source_refs.validation_run_ref must equal Sociosphere run_ref")
+    if projection.get("runtime_parity_level") != "synthetic_observed":
+        problems.append("Sociosphere external receipt fixture must project only synthetic_observed in Workroom v0.1")
+    return problems
+
+
 def main() -> int:
     schema = load(SCHEMA)
     failed = False
     results: dict[str, dict[str, Any]] = {}
 
-    for path in VALID_FIXTURES:
-        data = load(path)
+    adapter_fixtures = [load(path) for path in VALID_FIXTURES]
+    receipt_fixtures = [load(path) for path in EXTERNAL_RECEIPT_FIXTURES]
+
+    for path, data in zip(VALID_FIXTURES, adapter_fixtures):
         schema_errors = schema_problems(schema, data)
         semantic_errors = semantic_problems(data)
         problems = schema_errors + semantic_errors
@@ -103,12 +227,30 @@ def main() -> int:
             "semantic": semantic_errors,
         }
 
+    for path, data in zip(EXTERNAL_RECEIPT_FIXTURES, receipt_fixtures):
+        semantic_errors = sociosphere_receipt_problems(data)
+        failed = failed or bool(semantic_errors)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "valid_external_sociosphere_receipt",
+            "semantic": semantic_errors,
+        }
+
+    if adapter_fixtures and receipt_fixtures:
+        cross_errors = cross_fixture_problems(adapter_fixtures[0], receipt_fixtures[0])
+        failed = failed or bool(cross_errors)
+        results["cross_fixture:sociosphere_receipt_adapter"] = {
+            "expected": "adapter_matches_external_receipt",
+            "semantic": cross_errors,
+        }
+
     report = {
         "validator": "prophet-platform.devsecops-validation-run-receipt-ref.validator.v1",
         "passed": not failed,
         "results": results,
         "non_claims": [
             "Validator checks Workroom references to external validation run receipts.",
+            "Validator checks Sociosphere-shaped receipt fixture semantics.",
+            "Validator does not recompute Sociosphere artifact digests.",
             "Validator does not execute validation runs.",
             "Validator does not issue Sociosphere or AgentPlane receipts.",
             "Validator does not certify production readiness or Signadot vendor parity.",


### PR DESCRIPTION
## Summary

Adds a stable Sociosphere-shaped SVF receipt fixture and validates that Prophet Platform consumes it as external evidence.

## Changes

- Adds `sociosphere-svf-validation-receipt.valid.json`.
- Aligns the Workroom receipt adapter fixture with that external receipt.
- Extends the receipt-ref validator to check Sociosphere receipt shape, authority boundary, certified claims, non-claims, and adapter/receipt ref alignment.

Refs #523
Refs #520
Refs #519