### PR TITLE
PROMETHEUS: add SHACL validation for SR proposals

### DIFF
--- a/.github/workflows/prometheus-jsonld.yml
+++ b/.github/workflows/prometheus-jsonld.yml
@@ -3,9 +3,11 @@ name: prometheus-jsonld
 on:
   pull_request:
     paths:
+      - "contracts/ontology/sr-assertion.shacl.ttl"
       - "tools/emit_prometheus_jsonld_review.py"
       - "tools/emit_prometheus_gate_evaluation.py"
       - "tools/validate_prometheus_jsonld_review.py"
+      - "tools/validate_prometheus_jsonld_shacl.py"
       - "tools/run_prometheus_local_demo.py"
       - "tests/fixtures/prometheus/agentplane-sr-gate-policy.valid.json"
       - "docs/PROMETHEUS_JSONLD_REVIEW.md"
@@ -14,9 +16,11 @@ on:
     branches:
       - main
     paths:
+      - "contracts/ontology/sr-assertion.shacl.ttl"
       - "tools/emit_prometheus_jsonld_review.py"
       - "tools/emit_prometheus_gate_evaluation.py"
       - "tools/validate_prometheus_jsonld_review.py"
+      - "tools/validate_prometheus_jsonld_shacl.py"
       - "tools/run_prometheus_local_demo.py"
       - "tests/fixtures/prometheus/agentplane-sr-gate-policy.valid.json"
       - "docs/PROMETHEUS_JSONLD_REVIEW.md"
@@ -34,8 +38,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install units dependency
-        run: python3 -m pip install sympy
+      - name: Install validation dependencies
+        run: python3 -m pip install sympy pyshacl rdflib
       - name: Generate PROMETHEUS local demo artifacts
         run: |
           python3 tools/run_prometheus_local_demo.py \
@@ -51,7 +55,7 @@ jobs:
             --evaluation-id urn:prometheus:gate-evaluation:pysr-local-demo:001 \
             --issued-at 2026-05-27T22:30:30Z \
             --output build/prometheus/jsonld/pysr/gate-evaluation.json
-      - name: Prove automated gate fails closed without gate evidence
+      - name: Require gate evidence for automated review
         run: |
           ! python3 tools/emit_prometheus_jsonld_review.py \
             --candidate build/prometheus/jsonld/pysr/equation-candidate.json \
@@ -70,7 +74,11 @@ jobs:
             --review-surface automated_shacl_gate \
             --issued-at 2026-05-27T22:31:00Z \
             --output build/prometheus/jsonld/pysr/sr.jsonld
-      - name: Validate JSON-LD artifact
+      - name: Validate JSON-LD artifact structure
         run: |
           python3 tools/validate_prometheus_jsonld_review.py \
+            build/prometheus/jsonld/pysr/sr.jsonld
+      - name: Validate JSON-LD artifact with SHACL
+        run: |
+          python3 tools/validate_prometheus_jsonld_shacl.py \
             build/prometheus/jsonld/pysr/sr.jsonld

--- a/contracts/ontology/sr-assertion.shacl.ttl
+++ b/contracts/ontology/sr-assertion.shacl.ttl
@@ -1,0 +1,61 @@
+@base <https://socioprophet.github.io/ontogenesis/> .
+@prefix sr: <https://socioprophet.github.io/ontogenesis/symbolic-regression#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<shapes/symbolic-regression/sr-assertion.shacl.ttl> a sh:NodeShape ; sh:targetClass sr:SRAssertionProposal ; sh:message "Symbolic regression assertion proposal SHACL bundle loaded." .
+
+sr:EquationCandidateShape a sh:NodeShape ;
+  sh:targetClass sr:EquationCandidate ;
+  sh:property [ sh:path sr:hasEquation ; sh:minCount 1 ; sh:maxCount 1 ; sh:datatype xsd:string ; sh:minLength 1 ] ;
+  sh:property [ sh:path sr:hasDatasetEvidence ; sh:minCount 1 ; sh:maxCount 1 ] ;
+  sh:property [ sh:path sr:hasFeatureSet ; sh:minCount 1 ; sh:maxCount 1 ] ;
+  sh:property [ sh:path sr:hasOperatorLibrary ; sh:minCount 1 ; sh:maxCount 1 ] ;
+  sh:property [ sh:path sr:hasFitMetric ; sh:minCount 1 ] ;
+  sh:property [ sh:path sr:hasComplexityMetric ; sh:minCount 1 ] ;
+  sh:property [ sh:path sr:hasDimensionalAnalysis ; sh:minCount 1 ; sh:maxCount 1 ] ;
+  sh:property [ sh:path sr:hasPromotionStatus ; sh:minCount 1 ; sh:maxCount 1 ; sh:in (sr:ProposalCandidate sr:ProposalProposed sr:ProposalAdmitted sr:ProposalRejected sr:ProposalFailureCorpus) ] ;
+  sh:property [ sh:path sr:nonAuthorityDeclaration ; sh:minCount 1 ; sh:datatype xsd:string ] .
+
+sr:ProgramCandidateShape a sh:NodeShape ;
+  sh:targetClass sr:ProgramCandidate ;
+  sh:property [ sh:path sr:hasProgramText ; sh:minCount 1 ; sh:maxCount 1 ; sh:datatype xsd:string ; sh:minLength 1 ] ;
+  sh:property [ sh:path sr:hasDatasetEvidence ; sh:minCount 1 ; sh:maxCount 1 ] ;
+  sh:property [ sh:path sr:hasFitMetric ; sh:minCount 1 ] ;
+  sh:property [ sh:path sr:hasComplexityMetric ; sh:minCount 1 ] ;
+  sh:property [ sh:path sr:hasPromotionStatus ; sh:minCount 1 ; sh:maxCount 1 ; sh:in (sr:ProposalCandidate sr:ProposalProposed sr:ProposalAdmitted sr:ProposalRejected sr:ProposalFailureCorpus) ] ;
+  sh:property [ sh:path sr:nonAuthorityDeclaration ; sh:minCount 1 ; sh:datatype xsd:string ] .
+
+sr:SRAssertionProposalShape a sh:NodeShape ;
+  sh:targetClass sr:SRAssertionProposal ;
+  sh:property [ sh:path sr:hasDatasetEvidence ; sh:minCount 1 ; sh:maxCount 1 ] ;
+  sh:property [ sh:path sr:hasFitMetric ; sh:minCount 1 ] ;
+  sh:property [ sh:path sr:hasComplexityMetric ; sh:minCount 1 ] ;
+  sh:property [ sh:path sr:hasDimensionalAnalysis ; sh:minCount 1 ; sh:maxCount 1 ] ;
+  sh:property [ sh:path sr:hasEvidenceReplay ; sh:minCount 1 ; sh:maxCount 1 ] ;
+  sh:property [ sh:path sr:hasDiscoveryMethod ; sh:minCount 1 ; sh:maxCount 1 ] ;
+  sh:property [ sh:path sr:hasPromotionStatus ; sh:minCount 1 ; sh:maxCount 1 ; sh:in (sr:ProposalCandidate sr:ProposalProposed sr:ProposalAdmitted sr:ProposalRejected sr:ProposalFailureCorpus) ] ;
+  sh:property [ sh:path sr:hasAdmissionState ; sh:minCount 1 ; sh:maxCount 1 ; sh:in (sr:AdmissionPendingReview sr:AdmissionAdmitted sr:AdmissionRejected sr:AdmissionBlocked) ] ;
+  sh:property [ sh:path sr:vocabVersion ; sh:minCount 1 ; sh:maxCount 1 ; sh:datatype xsd:string ] ;
+  sh:property [ sh:path sr:vocabularyPromotionState ; sh:minCount 1 ; sh:maxCount 1 ; sh:in (sr:VocabularyDraftState sr:VocabularyStabilizingState sr:VocabularyCanonicalState) ] ;
+  sh:property [ sh:path sr:nonAuthorityDeclaration ; sh:minCount 1 ; sh:datatype xsd:string ] ;
+  sh:not [ sh:property [ sh:path sr:hasDimensionalAnalysis ; sh:qualifiedValueShape [ sh:property [ sh:path sr:hasUnitsStatus ; sh:hasValue sr:UnitsInconsistent ] ] ; sh:qualifiedMinCount 1 ] ; sh:property [ sh:path sr:hasPromotionStatus ; sh:in (sr:ProposalProposed sr:ProposalAdmitted) ] ] ;
+  sh:not [ sh:property [ sh:path sr:hasDimensionalAnalysis ; sh:qualifiedValueShape [ sh:property [ sh:path sr:hasUnitsStatus ; sh:hasValue sr:UnitsInconsistent ] ] ; sh:qualifiedMinCount 1 ] ; sh:property [ sh:path sr:hasAdmissionState ; sh:in (sr:AdmissionPendingReview sr:AdmissionAdmitted) ] ] .
+
+sr:DimensionalAnalysisResultShape a sh:NodeShape ;
+  sh:targetClass sr:DimensionalAnalysisResult ;
+  sh:property [ sh:path sr:hasUnitsStatus ; sh:minCount 1 ; sh:maxCount 1 ; sh:in (sr:UnitsConsistent sr:UnitsInconsistent sr:UnitsUnknown sr:UnitsUnchecked) ] .
+
+sr:FitMetricShape a sh:NodeShape ;
+  sh:targetClass sr:FitMetric ;
+  sh:property [ sh:path sr:metricName ; sh:minCount 1 ; sh:maxCount 1 ; sh:datatype xsd:string ] ;
+  sh:property [ sh:path sr:metricValue ; sh:minCount 1 ; sh:maxCount 1 ; sh:datatype xsd:decimal ] .
+
+sr:ComplexityMetricShape a sh:NodeShape ;
+  sh:targetClass sr:ComplexityMetric ;
+  sh:property [ sh:path sr:metricName ; sh:minCount 1 ; sh:maxCount 1 ; sh:datatype xsd:string ] ;
+  sh:property [ sh:path sr:metricValue ; sh:minCount 1 ; sh:maxCount 1 ; sh:datatype xsd:decimal ] .
+
+sr:SemanticReviewSurfaceShape a sh:NodeShape ;
+  sh:targetClass sr:SemanticReviewSurface ;
+  sh:property [ sh:path sr:reviewSurfaceType ; sh:minCount 1 ; sh:maxCount 1 ; sh:in ("git_pr" "prophet_platform_ui" "cli" "sparql_editor" "automated_shacl_gate" "webprotege") ] .

--- a/tools/validate_prometheus_jsonld_shacl.py
+++ b/tools/validate_prometheus_jsonld_shacl.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from pyshacl import validate as run_shacl
+from rdflib import Graph, Literal, Namespace, RDF, URIRef
+from rdflib.namespace import XSD
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SHAPES = ROOT / "contracts" / "ontology" / "sr-assertion.shacl.ttl"
+SR = Namespace("https://socioprophet.github.io/ontogenesis/symbolic-regression#")
+
+RESOURCES = {
+    "sr:VocabularyDraftState": SR.VocabularyDraftState,
+    "sr:VocabularyStabilizingState": SR.VocabularyStabilizingState,
+    "sr:VocabularyCanonicalState": SR.VocabularyCanonicalState,
+    "sr:ProposalCandidate": SR.ProposalCandidate,
+    "sr:ProposalProposed": SR.ProposalProposed,
+    "sr:ProposalAdmitted": SR.ProposalAdmitted,
+    "sr:ProposalRejected": SR.ProposalRejected,
+    "sr:ProposalFailureCorpus": SR.ProposalFailureCorpus,
+    "sr:AdmissionPendingReview": SR.AdmissionPendingReview,
+    "sr:AdmissionAdmitted": SR.AdmissionAdmitted,
+    "sr:AdmissionRejected": SR.AdmissionRejected,
+    "sr:AdmissionBlocked": SR.AdmissionBlocked,
+    "sr:UnitsConsistent": SR.UnitsConsistent,
+    "sr:UnitsInconsistent": SR.UnitsInconsistent,
+    "sr:UnitsUnknown": SR.UnitsUnknown,
+    "sr:UnitsUnchecked": SR.UnitsUnchecked,
+}
+TYPES = {
+    "sr:DatasetEvidenceRef": SR.DatasetEvidenceRef,
+    "sr:FitMetric": SR.FitMetric,
+    "sr:ComplexityMetric": SR.ComplexityMetric,
+    "sr:DimensionalAnalysisResult": SR.DimensionalAnalysisResult,
+    "sr:EvidenceReplayRef": SR.EvidenceReplayRef,
+    "sr:DiscoveryMethodRef": SR.DiscoveryMethodRef,
+    "sr:SemanticReviewSurface": SR.SemanticReviewSurface,
+}
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"expected JSON object: {path}")
+    return data
+
+
+def rid(value: Any) -> str:
+    if isinstance(value, dict):
+        return str(value.get("@id", ""))
+    return str(value)
+
+
+def ref(value: str) -> URIRef:
+    if value.startswith(("urn:", "http://", "https://")):
+        return URIRef(value)
+    return URIRef("urn:prometheus:local:" + value)
+
+
+def sr(value: Any) -> URIRef:
+    key = rid(value)
+    if key not in RESOURCES:
+        raise SystemExit(f"unknown sr id: {key}")
+    return RESOURCES[key]
+
+
+def child(graph: Graph, parent: URIRef, prop: URIRef, data: dict[str, Any], fallback: str) -> URIRef:
+    n = ref(str(data.get("@id") or fallback))
+    graph.add((parent, prop, n))
+    typ = data.get("@type")
+    if typ in TYPES:
+        graph.add((n, RDF.type, TYPES[typ]))
+    return n
+
+
+def metric(graph: Graph, n: URIRef, data: dict[str, Any]) -> None:
+    graph.add((n, SR.metricName, Literal(str(data["sr:metricName"]), datatype=XSD.string)))
+    graph.add((n, SR.metricValue, Literal(Decimal(str(data["sr:metricValue"])), datatype=XSD.decimal)))
+
+
+def graph_from(document: dict[str, Any]) -> Graph:
+    g = Graph()
+    g.bind("sr", SR)
+    s = ref(str(document["@id"]))
+    g.add((s, RDF.type, SR.SRAssertionProposal))
+    g.add((s, SR.vocabVersion, Literal(str(document["sr:vocabVersion"]), datatype=XSD.string)))
+    g.add((s, SR.vocabularyPromotionState, sr(document["sr:vocabularyPromotionState"])))
+    g.add((s, SR.hasPromotionStatus, sr(document["sr:hasPromotionStatus"])))
+    g.add((s, SR.hasAdmissionState, sr(document["sr:hasAdmissionState"])))
+    g.add((s, SR.nonAuthorityDeclaration, Literal(str(document["sr:nonAuthorityDeclaration"]), datatype=XSD.string)))
+
+    child(g, s, SR.hasDatasetEvidence, document["sr:hasDatasetEvidence"], "dataset")
+    f = child(g, s, SR.hasFitMetric, document["sr:hasFitMetric"], "fit")
+    metric(g, f, document["sr:hasFitMetric"])
+    c = child(g, s, SR.hasComplexityMetric, document["sr:hasComplexityMetric"], "complexity")
+    metric(g, c, document["sr:hasComplexityMetric"])
+    d = child(g, s, SR.hasDimensionalAnalysis, document["sr:hasDimensionalAnalysis"], "dimension")
+    g.add((d, SR.hasUnitsStatus, sr(document["sr:hasDimensionalAnalysis"]["sr:hasUnitsStatus"])))
+    child(g, s, SR.hasEvidenceReplay, document["sr:hasEvidenceReplay"], "replay")
+    child(g, s, SR.hasDiscoveryMethod, document["sr:hasDiscoveryMethod"], "method")
+    surface = child(g, s, SR.hasSemanticReviewSurface, document["sr:hasSemanticReviewSurface"], "surface")
+    g.add((surface, SR.reviewSurfaceType, Literal(str(document["sr:hasSemanticReviewSurface"]["sr:reviewSurfaceType"]))))
+    return g
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("document")
+    parser.add_argument("--shapes", default=str(DEFAULT_SHAPES))
+    args = parser.parse_args()
+    conforms, _report_graph, report_text = run_shacl(
+        data_graph=graph_from(load(Path(args.document))),
+        shacl_graph=str(Path(args.shapes)),
+        inference="rdfs",
+        advanced=True,
+    )
+    if not conforms:
+        print(report_text)
+        raise SystemExit("SHACL validation failed")
+    print(json.dumps({"valid": True, "document": args.document, "shapes": args.shapes}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a real RDF/SHACL validation step for PROMETHEUS `SRAssertionProposal` artifacts.

Changes:

- vendors the pinned Ontogenesis SR assertion SHACL shape at `contracts/ontology/sr-assertion.shacl.ttl`
- adds `tools/validate_prometheus_jsonld_shacl.py`
- updates `prometheus-jsonld` workflow to install `pyshacl`/`rdflib` and run SHACL validation after existing structural JSON validation

## Boundary

This validates emitted proposal artifacts only. It does not mutate Ontogenesis, admit assertions, deploy models, or grant runtime authority.

## Validation path

The workflow still proves:

1. local demo artifacts generate;
2. automated review requires gate evidence;
3. JSON-LD proposal emits;
4. structural validator passes;
5. pinned Ontogenesis SHACL validation passes.

## Notes

The vendored SHACL file is the pinned Ontogenesis shape already referenced by the PROMETHEUS Ontogenesis compatibility manifest.