### PR TITLE
test: add invalid Workroom validation receipt reference fixtures

### DIFF
--- a/tests/fixtures/workroom/devsecops-validation-run-receipt-ref.run-mismatch.invalid.json
+++ b/tests/fixtures/workroom/devsecops-validation-run-receipt-ref.run-mismatch.invalid.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "0.1.0",
+  "adapter_id": "workroom:validation-receipt-adapter:invalid-run-mismatch",
+  "lane": "pre_merge_validation",
+  "authority_boundary": {
+    "execution_authority": "sociosphere_svf",
+    "receipt_authority": "sociosphere_svf",
+    "workroom_authority": "prophet_platform"
+  },
+  "receipt_ref": "svf:receipt:invalid-run-mismatch",
+  "receipt_artifact_ref": "artifacts/svf/runs/invalid/validation-receipt.json",
+  "run_ref": "svf:run:authoritative-run",
+  "run_artifact_ref": "artifacts/svf/runs/invalid/validation-run.json",
+  "plan_ref": "svf:plan:prophet-platform-workroom-fixtures",
+  "policy_ref": "svf:policy:non-production-validation",
+  "verification": {"status": "verified", "verifier": "sociosphere.svf_runner.local", "verified_at": "2026-05-31T19:30:00Z"},
+  "certified_claims": ["schema_conformant", "fixtures_validated", "receipt_integrity_verified"],
+  "non_certified_claims": ["production_readiness", "live_infrastructure_safety", "signadot_vendor_parity"],
+  "workroom_projection": {
+    "source_refs": {"validation_run_ref": "svf:run:projected-other-run"},
+    "runtime_parity_level": "synthetic_observed",
+    "evidence_packet_ref": "evidence://svf/receipt/invalid-run-mismatch",
+    "decision_state": "needs_review"
+  },
+  "non_claims": ["Expected-invalid fixture only."]
+}

--- a/tests/fixtures/workroom/devsecops-validation-run-receipt-ref.runtime-observed-overclaim.invalid.json
+++ b/tests/fixtures/workroom/devsecops-validation-run-receipt-ref.runtime-observed-overclaim.invalid.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0.1.0",
+  "adapter_id": "workroom:validation-receipt-adapter:invalid-runtime-overclaim",
+  "lane": "pre_merge_validation",
+  "authority_boundary": {
+    "execution_authority": "sociosphere_svf",
+    "receipt_authority": "sociosphere_svf",
+    "workroom_authority": "prophet_platform"
+  },
+  "receipt_ref": "svf:receipt:invalid-runtime-overclaim",
+  "run_ref": "svf:run:invalid-runtime-overclaim",
+  "plan_ref": "svf:plan:prophet-platform-workroom-fixtures",
+  "policy_ref": "svf:policy:non-production-validation",
+  "verification": {"status": "verified", "verifier": "sociosphere.svf_runner.local", "verified_at": "2026-05-31T19:30:00Z"},
+  "certified_claims": ["schema_conformant", "fixtures_validated", "receipt_integrity_verified"],
+  "non_certified_claims": ["production_readiness", "live_infrastructure_safety", "signadot_vendor_parity"],
+  "workroom_projection": {
+    "source_refs": {"validation_run_ref": "svf:run:invalid-runtime-overclaim"},
+    "runtime_parity_level": "runtime_observed",
+    "evidence_packet_ref": "evidence://svf/receipt/invalid-runtime-overclaim",
+    "decision_state": "needs_review"
+  },
+  "non_claims": ["Expected-invalid fixture only."]
+}

--- a/tests/fixtures/workroom/devsecops-validation-run-receipt-ref.unsupported-certified-claim.invalid.json
+++ b/tests/fixtures/workroom/devsecops-validation-run-receipt-ref.unsupported-certified-claim.invalid.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0.1.0",
+  "adapter_id": "workroom:validation-receipt-adapter:invalid-unsupported-claim",
+  "lane": "pre_merge_validation",
+  "authority_boundary": {
+    "execution_authority": "sociosphere_svf",
+    "receipt_authority": "sociosphere_svf",
+    "workroom_authority": "prophet_platform"
+  },
+  "receipt_ref": "svf:receipt:invalid-unsupported-claim",
+  "run_ref": "svf:run:invalid-unsupported-claim",
+  "plan_ref": "svf:plan:prophet-platform-workroom-fixtures",
+  "policy_ref": "svf:policy:non-production-validation",
+  "verification": {"status": "verified", "verifier": "sociosphere.svf_runner.local", "verified_at": "2026-05-31T19:30:00Z"},
+  "certified_claims": ["schema_conformant", "unsupported_demo_scope"],
+  "non_certified_claims": ["production_readiness", "live_infrastructure_safety", "signadot_vendor_parity"],
+  "workroom_projection": {
+    "source_refs": {"validation_run_ref": "svf:run:invalid-unsupported-claim"},
+    "runtime_parity_level": "synthetic_observed",
+    "evidence_packet_ref": "evidence://svf/receipt/invalid-unsupported-claim",
+    "decision_state": "needs_review"
+  },
+  "non_claims": ["Expected-invalid fixture only."]
+}

--- a/tests/fixtures/workroom/devsecops-validation-run-receipt-ref.unverified.invalid.json
+++ b/tests/fixtures/workroom/devsecops-validation-run-receipt-ref.unverified.invalid.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0.1.0",
+  "adapter_id": "workroom:validation-receipt-adapter:invalid-unverified",
+  "lane": "pre_merge_validation",
+  "authority_boundary": {
+    "execution_authority": "sociosphere_svf",
+    "receipt_authority": "sociosphere_svf",
+    "workroom_authority": "prophet_platform"
+  },
+  "receipt_ref": "svf:receipt:invalid-unverified",
+  "run_ref": "svf:run:invalid-unverified",
+  "plan_ref": "svf:plan:prophet-platform-workroom-fixtures",
+  "policy_ref": "svf:policy:non-production-validation",
+  "verification": {"status": "not_checked", "verifier": "sociosphere.svf_runner.local", "verified_at": "2026-05-31T19:30:00Z"},
+  "certified_claims": ["schema_conformant", "fixtures_validated", "receipt_integrity_verified"],
+  "non_certified_claims": ["production_readiness", "live_infrastructure_safety", "signadot_vendor_parity"],
+  "workroom_projection": {
+    "source_refs": {"validation_run_ref": "svf:run:invalid-unverified"},
+    "runtime_parity_level": "synthetic_observed",
+    "evidence_packet_ref": "evidence://svf/receipt/invalid-unverified",
+    "decision_state": "needs_review"
+  },
+  "non_claims": ["Expected-invalid fixture only."]
+}

--- a/tools/validate_devsecops_validation_run_receipt_ref.py
+++ b/tools/validate_devsecops_validation_run_receipt_ref.py
@@ -12,6 +12,20 @@ SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-validation-run-receipt-ref
 VALID_FIXTURES = [
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-validation-run-receipt-ref.svf.valid.json",
 ]
+INVALID_FIXTURES = {
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-validation-run-receipt-ref.run-mismatch.invalid.json": [
+        "workroom_projection.source_refs.validation_run_ref must equal run_ref",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-validation-run-receipt-ref.unverified.invalid.json": [
+        "validation run receipt references must be verified before Workroom ingestion",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-validation-run-receipt-ref.unsupported-certified-claim.invalid.json": [
+        "certified_claims contains unsupported scopes",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-validation-run-receipt-ref.runtime-observed-overclaim.invalid.json": [
+        "runtime_observed cannot be projected while Signadot vendor parity is non-certified",
+    ],
+}
 SUPPORTED_CERTIFIED_CLAIMS = {
     "schema_conformant",
     "fixtures_validated",
@@ -86,21 +100,48 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
     return problems
 
 
+def validate_fixture(schema: dict[str, Any], path: Path) -> dict[str, list[str]]:
+    data = load(path)
+    return {
+        "schema": schema_problems(schema, data),
+        "semantic": semantic_problems(data),
+    }
+
+
+def assert_invalid_expectations(path: Path, problems: list[str], expected_substrings: list[str]) -> list[str]:
+    expectation_failures: list[str] = []
+    if not problems:
+        expectation_failures.append(f"{path}: expected invalid fixture to fail, but it passed")
+    for expected in expected_substrings:
+        if not any(expected in problem for problem in problems):
+            expectation_failures.append(f"{path}: expected invalid fixture problem containing {expected!r}")
+    return expectation_failures
+
+
 def main() -> int:
     schema = load(SCHEMA)
     failed = False
     results: dict[str, dict[str, Any]] = {}
 
     for path in VALID_FIXTURES:
-        data = load(path)
-        schema_errors = schema_problems(schema, data)
-        semantic_errors = semantic_problems(data)
-        problems = schema_errors + semantic_errors
+        result = validate_fixture(schema, path)
+        problems = result["schema"] + result["semantic"]
         failed = failed or bool(problems)
         results[str(path.relative_to(ROOT))] = {
             "expected": "valid",
-            "schema": schema_errors,
-            "semantic": semantic_errors,
+            **result,
+        }
+
+    for path, expected_substrings in INVALID_FIXTURES.items():
+        result = validate_fixture(schema, path)
+        problems = result["schema"] + result["semantic"]
+        expectation_failures = assert_invalid_expectations(path.relative_to(ROOT), problems, expected_substrings)
+        failed = failed or bool(expectation_failures)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid",
+            "expected_problem_substrings": expected_substrings,
+            "expectation_failures": expectation_failures,
+            **result,
         }
 
     report = {
@@ -109,6 +150,7 @@ def main() -> int:
         "results": results,
         "non_claims": [
             "Validator checks Workroom references to external validation run receipts.",
+            "Validator asserts invalid receipt-reference fixtures fail for expected governance reasons.",
             "Validator does not execute validation runs.",
             "Validator does not issue Sociosphere or AgentPlane receipts.",
             "Validator does not certify production readiness or Signadot vendor parity.",


### PR DESCRIPTION
Superseded by PR #546.

Reason: `main` advanced again while #545 was open. PR #546 replays the invalid validation receipt-reference fixture hardening onto a fresher branch and preserves the newer Sociosphere external-receipt checks already present upstream.

No runtime execution, receipt issuance, production action authorization, or UI work.