### PR TITLE
Add validate_change receipt repair guidance

### DIFF
--- a/contracts/environment/validate-change-v2-response.environment-failed.json
+++ b/contracts/environment/validate-change-v2-response.environment-failed.json
@@ -37,6 +37,28 @@
     "failure_codes": [
       "svf_receipt_failed"
     ],
+    "repair_guidance": [
+      {
+        "step_id": "repair:failed-receipt:inspect-diagnostics",
+        "action": "Inspect the failed SVF receipt diagnostics and action-result artifact references.",
+        "authority": "sociosphere_svf",
+        "required_before_merge": true,
+        "non_claims": [
+          "Guidance does not authorize production mutation.",
+          "Guidance does not repair the failure by itself."
+        ]
+      },
+      {
+        "step_id": "repair:failed-receipt:patch-and-rerun",
+        "action": "Patch the failing change and rerun the selected SVF plan until a verified receipt is produced.",
+        "authority": "agent_or_operator_with_svf_policy",
+        "required_before_merge": true,
+        "non_claims": [
+          "Rerun must still be governed by SVF policy.",
+          "Rerun does not imply production readiness."
+        ]
+      }
+    ],
     "non_certified_claims": [
       "Failed receipt blocks validation success.",
       "Failed receipt does not certify production readiness.",
@@ -52,7 +74,11 @@
       "svf_receipt_failed",
       "verified_receipt_required"
     ],
-    "summary": "Failed receipt evidence blocks PR readiness.",
+    "summary": "Failed receipt evidence blocks PR readiness. Inspect diagnostics, patch the failure, and rerun the selected SVF plan before merge readiness can be claimed.",
+    "repair_guidance_refs": [
+      "repair:failed-receipt:inspect-diagnostics",
+      "repair:failed-receipt:patch-and-rerun"
+    ],
     "non_claims": [
       "Readiness block is based on failed receipt state.",
       "Readiness block does not authorize remediation."

--- a/contracts/environment/validate-change-v2-response.stale-receipt.json
+++ b/contracts/environment/validate-change-v2-response.stale-receipt.json
@@ -37,6 +37,28 @@
     "failure_codes": [
       "svf_receipt_stale"
     ],
+    "repair_guidance": [
+      {
+        "step_id": "repair:stale-receipt:compare-change-digest",
+        "action": "Compare the stale receipt change/run digest with the current change set before relying on the receipt.",
+        "authority": "sociosphere_svf",
+        "required_before_merge": true,
+        "non_claims": [
+          "Guidance does not make the stale receipt valid.",
+          "Guidance does not certify the current change."
+        ]
+      },
+      {
+        "step_id": "repair:stale-receipt:rerun-selected-plan",
+        "action": "Rerun the selected SVF plan against the current change set and replace the stale receipt with a verified receipt.",
+        "authority": "agent_or_operator_with_svf_policy",
+        "required_before_merge": true,
+        "non_claims": [
+          "Rerun must still be governed by SVF policy.",
+          "Rerun does not imply production readiness."
+        ]
+      }
+    ],
     "non_certified_claims": [
       "Stale receipt does not certify the current change set.",
       "Stale receipt does not certify production readiness.",
@@ -52,7 +74,11 @@
       "svf_receipt_stale",
       "verified_receipt_required"
     ],
-    "summary": "Stale receipt evidence blocks PR readiness for the current change set.",
+    "summary": "Stale receipt evidence blocks PR readiness for the current change set. Compare the stale receipt against the current change and rerun the selected SVF plan before readiness can be claimed.",
+    "repair_guidance_refs": [
+      "repair:stale-receipt:compare-change-digest",
+      "repair:stale-receipt:rerun-selected-plan"
+    ],
     "non_claims": [
       "Readiness block is based on stale receipt state.",
       "Readiness block does not execute validation."

--- a/tools/validate_environment_validate_change_v2.py
+++ b/tools/validate_environment_validate_change_v2.py
@@ -31,6 +31,7 @@ VALIDATION_EVIDENCE_STATES = {
 }
 MERGE_READY_STATES = {"verified_receipt"}
 BLOCKING_STATES = {"not_configured", "selected_only", "missing_evidence", "failed_receipt", "stale_receipt"}
+REPAIR_REQUIRED_STATES = {"failed_receipt", "stale_receipt"}
 
 
 def load(path: Path) -> dict[str, Any]:
@@ -65,6 +66,25 @@ def validate_request(data: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
+def validate_repair_guidance(data: dict[str, Any], evidence_state: str | None) -> list[dict[str, Any]]:
+    evidence_summary = data.get("evidence_summary", {})
+    readiness = data.get("pr_readiness", {})
+    guidance = evidence_summary.get("repair_guidance", []) if isinstance(evidence_summary, dict) else []
+    refs = readiness.get("repair_guidance_refs", []) if isinstance(readiness, dict) else []
+    guidance_ids = {item.get("step_id") for item in guidance if isinstance(item, dict)}
+    results: list[dict[str, Any]] = []
+
+    if evidence_state in REPAIR_REQUIRED_STATES:
+        results.extend([
+            check(f"repair:{evidence_state}:guidance-list", isinstance(guidance, list) and len(guidance) >= 2, [str(guidance)]),
+            check(f"repair:{evidence_state}:readiness-refs", isinstance(refs, list) and len(refs) >= 1, [str(refs)]),
+            check(f"repair:{evidence_state}:refs-resolve", all(ref in guidance_ids for ref in refs), [str(refs), str(sorted(guidance_ids))]),
+            check(f"repair:{evidence_state}:required-before-merge", all(isinstance(item, dict) and item.get("required_before_merge") is True for item in guidance), [str(guidance)]),
+            check(f"repair:{evidence_state}:authority-present", all(isinstance(item, dict) and bool(item.get("authority")) for item in guidance), [str(guidance)]),
+        ])
+    return results
+
+
 def validate_pr_readiness(data: dict[str, Any], evidence_state: str | None) -> list[dict[str, Any]]:
     readiness = data.get("pr_readiness", {})
     blocking_codes = readiness.get("blocking_reason_codes", []) if isinstance(readiness, dict) else []
@@ -87,6 +107,7 @@ def validate_pr_readiness(data: dict[str, Any], evidence_state: str | None) -> l
             check(f"readiness:{evidence_state}:not-ready", readiness_state in {"blocked", "needs_review"}, [str(readiness_state)]),
             check(f"readiness:{evidence_state}:blocking-codes", isinstance(blocking_codes, list) and len(blocking_codes) >= 1, [str(blocking_codes)]),
         ])
+    results.extend(validate_repair_guidance(data, evidence_state))
     return results
 
 


### PR DESCRIPTION
## Summary

Adds explicit repair guidance for failed and stale SVF receipt states in validate_change response fixtures.

## Changes

- Adds repair steps to failed-receipt response evidence summary.
- Adds repair steps to stale-receipt response evidence summary.
- Adds pr_readiness repair_guidance_refs.
- Updates validate_change fixture validator to require repair guidance for failed_receipt and stale_receipt.

Refs #523
Refs #520
Refs #519