### PR TITLE
PROMETHEUS: add negative SHACL fixtures

### DIFF
--- a/.github/workflows/prometheus-jsonld.yml
+++ b/.github/workflows/prometheus-jsonld.yml
@@ -10,6 +10,8 @@ on:
       - "tools/validate_prometheus_jsonld_shacl.py"
       - "tools/run_prometheus_local_demo.py"
       - "tests/fixtures/prometheus/agentplane-sr-gate-policy.valid.json"
+      - "tests/fixtures/prometheus/jsonld-invalid-missing-dataset.jsonld"
+      - "tests/fixtures/prometheus/jsonld-invalid-inconsistent-units-promotion.jsonld"
       - "docs/PROMETHEUS_JSONLD_REVIEW.md"
       - ".github/workflows/prometheus-jsonld.yml"
   push:
@@ -23,6 +25,8 @@ on:
       - "tools/validate_prometheus_jsonld_shacl.py"
       - "tools/run_prometheus_local_demo.py"
       - "tests/fixtures/prometheus/agentplane-sr-gate-policy.valid.json"
+      - "tests/fixtures/prometheus/jsonld-invalid-missing-dataset.jsonld"
+      - "tests/fixtures/prometheus/jsonld-invalid-inconsistent-units-promotion.jsonld"
       - "docs/PROMETHEUS_JSONLD_REVIEW.md"
       - ".github/workflows/prometheus-jsonld.yml"
   workflow_dispatch:
@@ -82,3 +86,11 @@ jobs:
         run: |
           python3 tools/validate_prometheus_jsonld_shacl.py \
             build/prometheus/jsonld/pysr/sr.jsonld
+      - name: Require invalid missing-dataset fixture to fail SHACL
+        run: |
+          ! python3 tools/validate_prometheus_jsonld_shacl.py \
+            tests/fixtures/prometheus/jsonld-invalid-missing-dataset.jsonld
+      - name: Require invalid inconsistent-units fixture to fail SHACL
+        run: |
+          ! python3 tools/validate_prometheus_jsonld_shacl.py \
+            tests/fixtures/prometheus/jsonld-invalid-inconsistent-units-promotion.jsonld

--- a/tests/fixtures/prometheus/jsonld-invalid-inconsistent-units-promotion.jsonld
+++ b/tests/fixtures/prometheus/jsonld-invalid-inconsistent-units-promotion.jsonld
@@ -1,0 +1,48 @@
+{
+  "@context": {
+    "sr": "https://socioprophet.github.io/ontogenesis/symbolic-regression#",
+    "prov": "http://www.w3.org/ns/prov#"
+  },
+  "@id": "urn:prometheus:jsonld:invalid:inconsistent-units-promotion",
+  "@type": "sr:SRAssertionProposal",
+  "sr:vocabVersion": "0.1.0",
+  "sr:vocabularyPromotionState": {"@id": "sr:VocabularyDraftState"},
+  "sr:hasDatasetEvidence": {
+    "@id": "urn:prometheus:dataset:invalid-inconsistent-units",
+    "@type": "sr:DatasetEvidenceRef"
+  },
+  "sr:hasFitMetric": {
+    "@id": "urn:prometheus:metric:fit:invalid-inconsistent-units",
+    "@type": "sr:FitMetric",
+    "sr:metricName": "nmse",
+    "sr:metricValue": 0.0
+  },
+  "sr:hasComplexityMetric": {
+    "@id": "urn:prometheus:metric:complexity:invalid-inconsistent-units",
+    "@type": "sr:ComplexityMetric",
+    "sr:metricName": "complexity",
+    "sr:metricValue": 3
+  },
+  "sr:hasDimensionalAnalysis": {
+    "@id": "urn:prometheus:dimensional-analysis:invalid-inconsistent-units",
+    "@type": "sr:DimensionalAnalysisResult",
+    "sr:hasUnitsStatus": {"@id": "sr:UnitsInconsistent"}
+  },
+  "sr:hasEvidenceReplay": {
+    "@id": "urn:prometheus:replay:invalid-inconsistent-units",
+    "@type": "sr:EvidenceReplayRef"
+  },
+  "sr:hasDiscoveryMethod": {
+    "@id": "urn:prometheus:method:pysr",
+    "@type": "sr:DiscoveryMethodRef"
+  },
+  "sr:hasPromotionStatus": {"@id": "sr:ProposalProposed"},
+  "sr:hasAdmissionState": {"@id": "sr:AdmissionPendingReview"},
+  "sr:hasSemanticReviewSurface": {
+    "@id": "urn:prometheus:review-surface:automated-shacl-gate",
+    "@type": "sr:SemanticReviewSurface",
+    "sr:reviewSurfaceType": "automated_shacl_gate"
+  },
+  "sr:nonAuthorityDeclaration": "Negative fixture: inconsistent units must not be proposed or admitted.",
+  "prov:generatedAtTime": "2026-06-01T11:00:00Z"
+}

--- a/tests/fixtures/prometheus/jsonld-invalid-missing-dataset.jsonld
+++ b/tests/fixtures/prometheus/jsonld-invalid-missing-dataset.jsonld
@@ -1,0 +1,44 @@
+{
+  "@context": {
+    "sr": "https://socioprophet.github.io/ontogenesis/symbolic-regression#",
+    "prov": "http://www.w3.org/ns/prov#"
+  },
+  "@id": "urn:prometheus:jsonld:invalid:missing-dataset",
+  "@type": "sr:SRAssertionProposal",
+  "sr:vocabVersion": "0.1.0",
+  "sr:vocabularyPromotionState": {"@id": "sr:VocabularyDraftState"},
+  "sr:hasFitMetric": {
+    "@id": "urn:prometheus:metric:fit:missing-dataset",
+    "@type": "sr:FitMetric",
+    "sr:metricName": "nmse",
+    "sr:metricValue": 0.0
+  },
+  "sr:hasComplexityMetric": {
+    "@id": "urn:prometheus:metric:complexity:missing-dataset",
+    "@type": "sr:ComplexityMetric",
+    "sr:metricName": "complexity",
+    "sr:metricValue": 3
+  },
+  "sr:hasDimensionalAnalysis": {
+    "@id": "urn:prometheus:dimensional-analysis:missing-dataset",
+    "@type": "sr:DimensionalAnalysisResult",
+    "sr:hasUnitsStatus": {"@id": "sr:UnitsConsistent"}
+  },
+  "sr:hasEvidenceReplay": {
+    "@id": "urn:prometheus:replay:missing-dataset",
+    "@type": "sr:EvidenceReplayRef"
+  },
+  "sr:hasDiscoveryMethod": {
+    "@id": "urn:prometheus:method:pysr",
+    "@type": "sr:DiscoveryMethodRef"
+  },
+  "sr:hasPromotionStatus": {"@id": "sr:ProposalCandidate"},
+  "sr:hasAdmissionState": {"@id": "sr:AdmissionBlocked"},
+  "sr:hasSemanticReviewSurface": {
+    "@id": "urn:prometheus:review-surface:cli",
+    "@type": "sr:SemanticReviewSurface",
+    "sr:reviewSurfaceType": "cli"
+  },
+  "sr:nonAuthorityDeclaration": "Negative fixture: missing dataset evidence must fail SHACL validation.",
+  "prov:generatedAtTime": "2026-06-01T11:00:00Z"
+}

--- a/tools/validate_prometheus_jsonld_shacl.py
+++ b/tools/validate_prometheus_jsonld_shacl.py
@@ -63,14 +63,16 @@ def ref(value: str) -> URIRef:
     return URIRef("urn:prometheus:local:" + value)
 
 
-def sr(value: Any) -> URIRef:
+def sr(value: Any) -> URIRef | None:
     key = rid(value)
     if key not in RESOURCES:
-        raise SystemExit(f"unknown sr id: {key}")
+        return None
     return RESOURCES[key]
 
 
-def child(graph: Graph, parent: URIRef, prop: URIRef, data: dict[str, Any], fallback: str) -> URIRef:
+def child(graph: Graph, parent: URIRef, prop: URIRef, data: Any, fallback: str) -> URIRef | None:
+    if not isinstance(data, dict):
+        return None
     n = ref(str(data.get("@id") or fallback))
     graph.add((parent, prop, n))
     typ = data.get("@type")
@@ -80,32 +82,53 @@ def child(graph: Graph, parent: URIRef, prop: URIRef, data: dict[str, Any], fall
 
 
 def metric(graph: Graph, n: URIRef, data: dict[str, Any]) -> None:
-    graph.add((n, SR.metricName, Literal(str(data["sr:metricName"]), datatype=XSD.string)))
-    graph.add((n, SR.metricValue, Literal(Decimal(str(data["sr:metricValue"])), datatype=XSD.decimal)))
+    if "sr:metricName" in data:
+        graph.add((n, SR.metricName, Literal(str(data["sr:metricName"]), datatype=XSD.string)))
+    if "sr:metricValue" in data:
+        graph.add((n, SR.metricValue, Literal(Decimal(str(data["sr:metricValue"])), datatype=XSD.decimal)))
+
+
+def add_resource_value(graph: Graph, subject: URIRef, prop: URIRef, value: Any) -> None:
+    resource = sr(value)
+    if resource is not None:
+        graph.add((subject, prop, resource))
+
+
+def add_literal_value(graph: Graph, subject: URIRef, prop: URIRef, value: Any) -> None:
+    if value is not None:
+        graph.add((subject, prop, Literal(str(value), datatype=XSD.string)))
 
 
 def graph_from(document: dict[str, Any]) -> Graph:
     g = Graph()
     g.bind("sr", SR)
-    s = ref(str(document["@id"]))
+    s = ref(str(document.get("@id", "urn:prometheus:proposal:missing-id")))
     g.add((s, RDF.type, SR.SRAssertionProposal))
-    g.add((s, SR.vocabVersion, Literal(str(document["sr:vocabVersion"]), datatype=XSD.string)))
-    g.add((s, SR.vocabularyPromotionState, sr(document["sr:vocabularyPromotionState"])))
-    g.add((s, SR.hasPromotionStatus, sr(document["sr:hasPromotionStatus"])))
-    g.add((s, SR.hasAdmissionState, sr(document["sr:hasAdmissionState"])))
-    g.add((s, SR.nonAuthorityDeclaration, Literal(str(document["sr:nonAuthorityDeclaration"]), datatype=XSD.string)))
+    add_literal_value(g, s, SR.vocabVersion, document.get("sr:vocabVersion"))
+    add_resource_value(g, s, SR.vocabularyPromotionState, document.get("sr:vocabularyPromotionState"))
+    add_resource_value(g, s, SR.hasPromotionStatus, document.get("sr:hasPromotionStatus"))
+    add_resource_value(g, s, SR.hasAdmissionState, document.get("sr:hasAdmissionState"))
+    add_literal_value(g, s, SR.nonAuthorityDeclaration, document.get("sr:nonAuthorityDeclaration"))
 
-    child(g, s, SR.hasDatasetEvidence, document["sr:hasDatasetEvidence"], "dataset")
-    f = child(g, s, SR.hasFitMetric, document["sr:hasFitMetric"], "fit")
-    metric(g, f, document["sr:hasFitMetric"])
-    c = child(g, s, SR.hasComplexityMetric, document["sr:hasComplexityMetric"], "complexity")
-    metric(g, c, document["sr:hasComplexityMetric"])
-    d = child(g, s, SR.hasDimensionalAnalysis, document["sr:hasDimensionalAnalysis"], "dimension")
-    g.add((d, SR.hasUnitsStatus, sr(document["sr:hasDimensionalAnalysis"]["sr:hasUnitsStatus"])))
-    child(g, s, SR.hasEvidenceReplay, document["sr:hasEvidenceReplay"], "replay")
-    child(g, s, SR.hasDiscoveryMethod, document["sr:hasDiscoveryMethod"], "method")
-    surface = child(g, s, SR.hasSemanticReviewSurface, document["sr:hasSemanticReviewSurface"], "surface")
-    g.add((surface, SR.reviewSurfaceType, Literal(str(document["sr:hasSemanticReviewSurface"]["sr:reviewSurfaceType"]))))
+    child(g, s, SR.hasDatasetEvidence, document.get("sr:hasDatasetEvidence"), "dataset")
+    f = child(g, s, SR.hasFitMetric, document.get("sr:hasFitMetric"), "fit")
+    if f is not None:
+        metric(g, f, document.get("sr:hasFitMetric", {}))
+    c = child(g, s, SR.hasComplexityMetric, document.get("sr:hasComplexityMetric"), "complexity")
+    if c is not None:
+        metric(g, c, document.get("sr:hasComplexityMetric", {}))
+    d = child(g, s, SR.hasDimensionalAnalysis, document.get("sr:hasDimensionalAnalysis"), "dimension")
+    if d is not None and isinstance(document.get("sr:hasDimensionalAnalysis"), dict):
+        units = sr(document["sr:hasDimensionalAnalysis"].get("sr:hasUnitsStatus"))
+        if units is not None:
+            g.add((d, SR.hasUnitsStatus, units))
+    child(g, s, SR.hasEvidenceReplay, document.get("sr:hasEvidenceReplay"), "replay")
+    child(g, s, SR.hasDiscoveryMethod, document.get("sr:hasDiscoveryMethod"), "method")
+    surface = child(g, s, SR.hasSemanticReviewSurface, document.get("sr:hasSemanticReviewSurface"), "surface")
+    if surface is not None and isinstance(document.get("sr:hasSemanticReviewSurface"), dict):
+        review_surface = document["sr:hasSemanticReviewSurface"].get("sr:reviewSurfaceType")
+        if review_surface is not None:
+            g.add((surface, SR.reviewSurfaceType, Literal(str(review_surface))))
     return g
 
 


### PR DESCRIPTION
## Summary

Adds negative SHACL fixtures proving the PROMETHEUS semantic gate fails closed.

Changes:

- makes `tools/validate_prometheus_jsonld_shacl.py` lenient enough to pass incomplete proposal graphs into pySHACL instead of failing early on missing JSON keys
- adds `jsonld-invalid-missing-dataset.jsonld`
- adds `jsonld-invalid-inconsistent-units-promotion.jsonld`
- updates the `prometheus-jsonld` workflow to require both invalid fixtures to fail SHACL validation

## Validation intent

The negative fixtures cover:

1. missing required `sr:hasDatasetEvidence`
2. inconsistent units with proposed promotion and pending review admission

## Boundary

This is semantic validation only. It does not mutate Ontogenesis, admit SR assertions, deploy models, or grant runtime authority.