### PR TITLE
test: add Workroom post-merge incident investigation guards

### DIFF
--- a/tests/fixtures/workroom/devsecops-workroom.post-merge-missing-topology-context.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.post-merge-missing-topology-context.invalid.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:post-merge-missing-topology-context",
+  "lane": "post_merge_incident",
+  "runtime_parity_level": "contract_only",
+  "source_refs": {
+    "incident_ref": "incident://pagerduty/example/INC-2001",
+    "investigation_run_ref": "investigation-run://prophet-platform/example/INC-2001"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:missing-topology-context",
+    "event_type": "production_incident",
+    "source_lane": "post_merge_incident",
+    "status": "investigating",
+    "summary": "Invalid fixture proving post-merge incident topology context is required.",
+    "evidence_refs": ["evidence://observability/example/5xx-spike"],
+    "claim_refs": ["rca-claim:example:observation"],
+    "decision_state": "needs_review",
+    "non_claims": ["Expected-invalid fixture only."]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://observability/example/5xx-spike",
+      "evidence_type": "metric_observation",
+      "producer": "Fixture observability connector",
+      "summary": "Synthetic metric observation for invalid fixture.",
+      "observed_at": "2026-05-31T16:57:00Z",
+      "provenance": {
+        "source_system": "observability-fixture",
+        "source_ref": "metric://example/api/5xx-rate",
+        "collection_method": "synthetic_fixture"
+      },
+      "non_claims": ["Synthetic fixture evidence only."]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:example:observation",
+      "claim_status": "observation",
+      "statement": "Invalid fixture observation.",
+      "evidence_refs": ["evidence://observability/example/5xx-spike"],
+      "counterevidence_refs": [],
+      "confidence": "low",
+      "non_claims": ["Observation is fixture-scoped."]
+    }
+  ],
+  "action_grants": [],
+  "remediation_plans": [],
+  "regression_fixtures": [
+    {
+      "fixture_id": "regression-fixture:example:invalid-missing-topology-context",
+      "fixture_status": "candidate",
+      "derived_from": "bde:production-incident:missing-topology-context",
+      "summary": "Expected-invalid candidate only.",
+      "target_validation_plan_ref": "validation-plan://example/invalid",
+      "non_claims": ["Candidate only."]
+    }
+  ],
+  "issued_at": "2026-05-31T16:58:00Z",
+  "non_claims": ["This is an expected-failing negative fixture."]
+}

--- a/tests/fixtures/workroom/devsecops-workroom.post-merge-missing-topology-evidence.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.post-merge-missing-topology-evidence.invalid.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:post-merge-missing-topology-evidence",
+  "lane": "post_merge_incident",
+  "runtime_parity_level": "contract_only",
+  "source_refs": {
+    "incident_ref": "incident://pagerduty/example/INC-2002",
+    "investigation_run_ref": "investigation-run://prophet-platform/example/INC-2002",
+    "topology_ref": "topology://gaia/workroom/example/post-merge",
+    "blast_radius_ref": "blast-radius://gaia/workroom/example/INC-2002"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:missing-topology-evidence",
+    "event_type": "production_incident",
+    "source_lane": "post_merge_incident",
+    "status": "investigating",
+    "summary": "Invalid fixture proving topology refs require topology evidence binding.",
+    "topology_ref": "topology://gaia/workroom/example/post-merge",
+    "evidence_refs": ["evidence://observability/example/5xx-spike"],
+    "claim_refs": ["rca-claim:example:observation"],
+    "decision_state": "needs_review",
+    "non_claims": ["Expected-invalid fixture only."]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://observability/example/5xx-spike",
+      "evidence_type": "metric_observation",
+      "producer": "Fixture observability connector",
+      "summary": "Synthetic metric observation without topology snapshot evidence.",
+      "observed_at": "2026-05-31T16:57:00Z",
+      "provenance": {
+        "source_system": "observability-fixture",
+        "source_ref": "metric://example/api/5xx-rate",
+        "collection_method": "synthetic_fixture"
+      },
+      "non_claims": ["Synthetic fixture evidence only."]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:example:observation",
+      "claim_status": "observation",
+      "statement": "Invalid fixture observation.",
+      "evidence_refs": ["evidence://observability/example/5xx-spike"],
+      "counterevidence_refs": [],
+      "confidence": "low",
+      "non_claims": ["Observation is fixture-scoped."]
+    }
+  ],
+  "action_grants": [],
+  "remediation_plans": [],
+  "regression_fixtures": [
+    {
+      "fixture_id": "regression-fixture:example:invalid-missing-topology-evidence",
+      "fixture_status": "candidate",
+      "derived_from": "bde:production-incident:missing-topology-evidence",
+      "summary": "Expected-invalid candidate only.",
+      "target_validation_plan_ref": "validation-plan://example/invalid",
+      "non_claims": ["Candidate only."]
+    }
+  ],
+  "issued_at": "2026-05-31T16:58:00Z",
+  "non_claims": ["This is an expected-failing negative fixture."]
+}

--- a/tools/validate_devsecops_workroom.py
+++ b/tools/validate_devsecops_workroom.py
@@ -30,6 +30,13 @@ INVALID_FIXTURES = {
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.post-merge-missing-investigation-ref.invalid.json": [
         "post_merge_incident lane requires source_refs.investigation_run_ref",
     ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.post-merge-missing-topology-context.invalid.json": [
+        "post_merge_incident lane requires source_refs.topology_ref",
+        "post_merge_incident lane requires source_refs.blast_radius_ref",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.post-merge-missing-topology-evidence.invalid.json": [
+        "post_merge_incident lane requires topology_snapshot evidence with provenance.source_ref",
+    ],
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.approval-posture.invalid.json": [
         "mutation-class actions cannot be allowed without approval requirement",
     ],
@@ -139,7 +146,7 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
         if not validation_state:
             problems.append("pre_merge_validation lane requires validation_evidence_state")
     if lane == "post_merge_incident":
-        for key in ("incident_ref", "investigation_run_ref"):
+        for key in ("incident_ref", "investigation_run_ref", "topology_ref", "blast_radius_ref"):
             if not source_refs.get(key):
                 problems.append(f"post_merge_incident lane requires source_refs.{key}")
 
@@ -149,6 +156,13 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
 
     receipt_ref = source_refs.get("validation_receipt_ref")
     receipt_sources = evidence_sources_by_type(evidence_packets, "runtime_receipt")
+    topology_ref = source_refs.get("topology_ref")
+    topology_sources = evidence_sources_by_type(evidence_packets, "topology_snapshot")
+
+    if lane == "post_merge_incident" and topology_ref and topology_ref not in topology_sources:
+        problems.append(
+            f"post_merge_incident lane requires topology_snapshot evidence with provenance.source_ref {topology_ref}"
+        )
 
     if validation_state in RECEIPT_STATES:
         if not receipt_ref:
@@ -297,6 +311,7 @@ def main() -> int:
             "Validator checks workroom JSON Schema and semantic fixture constraints.",
             "Validator asserts invalid fixtures fail for the expected governance reasons.",
             "Validator checks validation receipt reference semantics for fixture records.",
+            "Validator checks post-merge incident topology and blast-radius evidence bindings.",
             "Validator does not execute live sandbox infrastructure.",
             "Validator does not certify Signadot-style runtime parity.",
             "Validator does not authorize production remediation.",


### PR DESCRIPTION
## Summary

Adds post-merge incident-lane guardrails for the DevSecOps Workroom validator.

This PR adds expected-invalid fixtures for:

- post-merge incident records missing topology and blast-radius context;
- post-merge incident records with topology refs but no matching `topology_snapshot` evidence.

It also updates `tools/validate_devsecops_workroom.py` so post-merge incident records require:

- `source_refs.topology_ref`;
- `source_refs.blast_radius_ref`;
- topology evidence whose `provenance.source_ref` matches `source_refs.topology_ref`.

## Boundary

This is Aurora-style incident investigation contract hardening only.

- No runtime execution.
- No live incident investigation.
- No production action authorization.
- No UI work.

Refs #519
Refs #520