### PR TITLE
contracts: add Workroom investigation run contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
         run: python tools/validate_devsecops_workroom.py
       - name: Validate DevSecOps validation receipt refs
         run: python tools/validate_devsecops_validation_run_receipt_ref.py
+      - name: Validate DevSecOps investigation runs
+        run: python tools/validate_devsecops_investigation_run.py
       - name: Run world-class event loop proof
         run: |
           python specs/orchestration/world_class_event_loop_demo.py --out /tmp/world-class-event-loop --compact

--- a/contracts/workroom/devsecops-investigation-run-v0.1.schema.json
+++ b/contracts/workroom/devsecops-investigation-run-v0.1.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.io/schemas/prophet-platform/devsecops-investigation-run/v0.1.0",
+  "title": "DevSecOpsInvestigationRun",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "investigation_run_ref",
+    "incident_ref",
+    "lane",
+    "authority_boundary",
+    "status",
+    "started_at",
+    "evidence_collection",
+    "topology_context",
+    "blast_radius_context",
+    "workroom_projection",
+    "non_claims"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "0.1.0" },
+    "investigation_run_ref": { "type": "string", "pattern": "^investigation-run://" },
+    "incident_ref": { "type": "string", "pattern": "^incident://" },
+    "lane": { "type": "string", "const": "post_merge_incident" },
+    "authority_boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["investigation_authority", "execution_authority", "workroom_authority"],
+      "properties": {
+        "investigation_authority": { "type": "string", "enum": ["prophet_platform", "agentplane", "sociosphere", "gaia"] },
+        "execution_authority": { "type": "string", "enum": ["agentplane", "external_connector", "none"] },
+        "workroom_authority": { "type": "string", "const": "prophet_platform" }
+      }
+    },
+    "status": { "type": "string", "enum": ["planned", "collecting_evidence", "evidence_collected", "ready_for_rca", "blocked"] },
+    "started_at": { "type": "string", "format": "date-time" },
+    "completed_at": { "type": "string", "format": "date-time" },
+    "evidence_collection": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["evidence_ref", "evidence_type", "source_system", "source_ref", "collection_status", "non_claims"],
+        "properties": {
+          "evidence_ref": { "type": "string", "pattern": "^evidence://" },
+          "evidence_type": {
+            "type": "string",
+            "enum": ["log_observation", "metric_observation", "topology_snapshot", "deployment_metadata", "runbook_excerpt", "manual_observation"]
+          },
+          "source_system": { "type": "string", "minLength": 1 },
+          "source_ref": { "type": "string", "minLength": 1 },
+          "collection_status": { "type": "string", "enum": ["planned", "collected", "failed", "not_authorized"] },
+          "non_claims": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+        }
+      }
+    },
+    "topology_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["topology_ref", "evidence_ref"],
+      "properties": {
+        "topology_ref": { "type": "string", "pattern": "^topology://" },
+        "evidence_ref": { "type": "string", "pattern": "^evidence://" }
+      }
+    },
+    "blast_radius_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["blast_radius_ref", "topology_ref", "status"],
+      "properties": {
+        "blast_radius_ref": { "type": "string", "pattern": "^blast-radius://" },
+        "topology_ref": { "type": "string", "pattern": "^topology://" },
+        "status": { "type": "string", "enum": ["candidate", "estimated", "reviewed", "unknown"] }
+      }
+    },
+    "workroom_projection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workroom_id", "source_refs", "evidence_refs"],
+      "properties": {
+        "workroom_id": { "type": "string", "pattern": "^workroom:devsecops:" },
+        "source_refs": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["incident_ref", "investigation_run_ref", "topology_ref", "blast_radius_ref"],
+          "properties": {
+            "incident_ref": { "type": "string", "pattern": "^incident://" },
+            "investigation_run_ref": { "type": "string", "pattern": "^investigation-run://" },
+            "topology_ref": { "type": "string", "pattern": "^topology://" },
+            "blast_radius_ref": { "type": "string", "pattern": "^blast-radius://" }
+          }
+        },
+        "evidence_refs": { "type": "array", "minItems": 1, "items": { "type": "string", "pattern": "^evidence://" } }
+      }
+    },
+    "non_claims": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+  }
+}

--- a/tests/fixtures/workroom/devsecops-investigation-run.post-merge.valid.json
+++ b/tests/fixtures/workroom/devsecops-investigation-run.post-merge.valid.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "0.1.0",
+  "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-1001",
+  "incident_ref": "incident://pagerduty/scope-d-example/INC-1001",
+  "lane": "post_merge_incident",
+  "authority_boundary": {
+    "investigation_authority": "prophet_platform",
+    "execution_authority": "external_connector",
+    "workroom_authority": "prophet_platform"
+  },
+  "status": "ready_for_rca",
+  "started_at": "2026-05-31T16:56:00Z",
+  "completed_at": "2026-05-31T16:58:00Z",
+  "evidence_collection": [
+    {
+      "evidence_ref": "evidence://observability/scope-d-example/5xx-spike",
+      "evidence_type": "metric_observation",
+      "source_system": "observability-fixture",
+      "source_ref": "metric://scope-d-example/api/5xx-rate",
+      "collection_status": "collected",
+      "non_claims": ["Metric observation does not prove root cause."]
+    },
+    {
+      "evidence_ref": "evidence://deployment/scope-d-example/recent-deploy",
+      "evidence_type": "deployment_metadata",
+      "source_system": "deployment-fixture",
+      "source_ref": "deploy://scope-d-example/api/2026-05-31T16:40:00Z",
+      "collection_status": "collected",
+      "non_claims": ["Deploy timing supports investigation but is not sufficient for confirmed causality."]
+    },
+    {
+      "evidence_ref": "evidence://gaia/topology/scope-d-example/blast-radius",
+      "evidence_type": "topology_snapshot",
+      "source_system": "GAIA fixture",
+      "source_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+      "collection_status": "collected",
+      "non_claims": ["Topology supports blast-radius estimation only."]
+    }
+  ],
+  "topology_context": {
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "evidence_ref": "evidence://gaia/topology/scope-d-example/blast-radius"
+  },
+  "blast_radius_context": {
+    "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-1001",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "status": "estimated"
+  },
+  "workroom_projection": {
+    "workroom_id": "workroom:devsecops:post-merge:scope-d-example",
+    "source_refs": {
+      "incident_ref": "incident://pagerduty/scope-d-example/INC-1001",
+      "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-1001",
+      "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+      "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-1001"
+    },
+    "evidence_refs": [
+      "evidence://observability/scope-d-example/5xx-spike",
+      "evidence://deployment/scope-d-example/recent-deploy",
+      "evidence://gaia/topology/scope-d-example/blast-radius"
+    ]
+  },
+  "non_claims": [
+    "InvestigationRun fixture models evidence collection only.",
+    "InvestigationRun fixture does not execute live incident commands.",
+    "InvestigationRun fixture does not authorize production remediation.",
+    "InvestigationRun fixture does not confirm root cause."
+  ]
+}

--- a/tools/validate_devsecops_investigation_run.py
+++ b/tools/validate_devsecops_investigation_run.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-investigation-run-v0.1.schema.json"
+VALID_FIXTURES = [
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-investigation-run.post-merge.valid.json",
+]
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected object: {path}")
+    return data
+
+
+def schema_problems(schema: dict[str, Any], data: dict[str, Any]) -> list[str]:
+    validator = Draft202012Validator(schema)
+    return [
+        f"schema:{'/'.join(str(part) for part in error.absolute_path) or '<root>'}: {error.message}"
+        for error in sorted(validator.iter_errors(data), key=lambda item: list(item.absolute_path))
+    ]
+
+
+def semantic_problems(data: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    boundary = data.get("authority_boundary", {})
+    evidence = data.get("evidence_collection", [])
+    evidence_refs = {item.get("evidence_ref") for item in evidence if isinstance(item, dict)}
+    collected_refs = {item.get("evidence_ref") for item in evidence if isinstance(item, dict) and item.get("collection_status") == "collected"}
+    topology_sources = {
+        item.get("source_ref")
+        for item in evidence
+        if isinstance(item, dict) and item.get("evidence_type") == "topology_snapshot"
+    }
+    topology_context = data.get("topology_context", {})
+    blast_context = data.get("blast_radius_context", {})
+    projection = data.get("workroom_projection", {})
+    projected_sources = projection.get("source_refs", {}) if isinstance(projection, dict) else {}
+    projected_evidence = set(projection.get("evidence_refs", [])) if isinstance(projection, dict) else set()
+
+    if boundary.get("workroom_authority") != "prophet_platform":
+        problems.append("workroom authority must remain prophet_platform")
+    if boundary.get("execution_authority") == "agentplane" and data.get("status") == "ready_for_rca":
+        problems.append("agentplane execution authority requires explicit execution receipt before ready_for_rca")
+
+    if data.get("lane") != "post_merge_incident":
+        problems.append("InvestigationRun lane must be post_merge_incident")
+    if data.get("investigation_run_ref") != projected_sources.get("investigation_run_ref"):
+        problems.append("projection investigation_run_ref must match InvestigationRun investigation_run_ref")
+    if data.get("incident_ref") != projected_sources.get("incident_ref"):
+        problems.append("projection incident_ref must match InvestigationRun incident_ref")
+
+    topology_ref = topology_context.get("topology_ref")
+    topology_evidence_ref = topology_context.get("evidence_ref")
+    if not topology_ref or topology_ref not in topology_sources:
+        problems.append("topology_context.topology_ref must be backed by topology_snapshot source_ref")
+    if topology_evidence_ref not in evidence_refs:
+        problems.append("topology_context.evidence_ref must reference collected evidence")
+    if topology_evidence_ref not in collected_refs:
+        problems.append("topology_context.evidence_ref must reference collected evidence")
+
+    if blast_context.get("topology_ref") != topology_ref:
+        problems.append("blast_radius_context.topology_ref must match topology_context.topology_ref")
+    if blast_context.get("blast_radius_ref") != projected_sources.get("blast_radius_ref"):
+        problems.append("projection blast_radius_ref must match blast_radius_context.blast_radius_ref")
+    if projected_sources.get("topology_ref") != topology_ref:
+        problems.append("projection topology_ref must match topology_context.topology_ref")
+
+    missing_projected_evidence = sorted(projected_evidence - evidence_refs)
+    if missing_projected_evidence:
+        problems.append(f"projection evidence_refs missing from evidence_collection: {missing_projected_evidence}")
+    if data.get("status") == "ready_for_rca" and not collected_refs:
+        problems.append("ready_for_rca requires at least one collected evidence item")
+
+    return problems
+
+
+def main() -> int:
+    schema = load(SCHEMA)
+    failed = False
+    results: dict[str, dict[str, Any]] = {}
+
+    for path in VALID_FIXTURES:
+        data = load(path)
+        schema_errors = schema_problems(schema, data)
+        semantic_errors = semantic_problems(data)
+        failed = failed or bool(schema_errors or semantic_errors)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "valid",
+            "schema": schema_errors,
+            "semantic": semantic_errors,
+        }
+
+    report = {
+        "validator": "prophet-platform.devsecops-investigation-run.validator.v1",
+        "passed": not failed,
+        "results": results,
+        "non_claims": [
+            "Validator checks InvestigationRun contract and fixture semantics.",
+            "Validator does not execute incident investigation commands.",
+            "Validator does not authorize production remediation.",
+            "Validator does not confirm root cause.",
+        ],
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(("PASS" if not failed else "FAIL") + ": devsecops investigation run fixtures")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Superseded by PR #563.

Reason: the original branch became stale after newer Workroom/SVF work landed on main. Premerge audit failed because the branch was behind base, not because the InvestigationRun contract validator failed.

PR #563 replays the same InvestigationRun contract, fixture, validator, and CI hook onto a fresher base while preserving newer upstream CI steps.