### PR TITLE
contracts: add TritFabric UI readiness labels

### DIFF
--- a/contracts/integrations/tritfabric-ui-labels.v0.json
+++ b/contracts/integrations/tritfabric-ui-labels.v0.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "prophet-platform.tritfabric-ui-labels/v0.1",
+  "contract_id": "tritfabric-ui-labels-v0",
+  "labels": [
+    {
+      "surface_id": "community-learning-intake",
+      "display_label": "Community Learning intake readiness",
+      "status_label": "review-gated",
+      "must_show": ["consent", "license", "lineage", "rubric", "manual-review-before-promotion"],
+      "forbidden_badges": ["training-enabled", "auto-promotion", "economic-credit"]
+    },
+    {
+      "surface_id": "network-atlas-framework-catalog",
+      "display_label": "Network Atlas framework catalog",
+      "status_label": "catalog-intake",
+      "must_show": ["adapter-status", "license-status", "claim-boundary"],
+      "forbidden_badges": ["validated-adapter", "production-supported"]
+    },
+    {
+      "surface_id": "model-card-promotion-evidence",
+      "display_label": "Model-card promotion evidence",
+      "status_label": "evidence-display-only",
+      "must_show": ["mathType", "calcOps", "ledgerRef", "artifactRef", "tritStatus"],
+      "forbidden_badges": ["promotion-executor", "transport-exception-only"]
+    },
+    {
+      "surface_id": "serve-readiness",
+      "display_label": "Serve readiness reporting",
+      "status_label": "readiness-only",
+      "must_show": ["readiness-vs-runtime", "rollback-before-active-loop", "claim-boundary"],
+      "forbidden_badges": ["production-ready", "autoscaler-active", "serve-deployed"]
+    }
+  ],
+  "claim_boundary": "UI/readiness label contract only. This does not implement UI components, runtime behavior, event ingestion, workflow execution, model mutation, artifact promotion, adapter validation, Serve deployment, or production readiness."
+}

--- a/tools/tests/test_tritfabric_ui_labels.py
+++ b/tools/tests/test_tritfabric_ui_labels.py
@@ -1,0 +1,5 @@
+from tools.validate_tritfabric_ui_labels import load_contract, validate_contract
+
+
+def test_tritfabric_ui_label_contract():
+    validate_contract(load_contract())

--- a/tools/validate_tritfabric_ui_labels.py
+++ b/tools/validate_tritfabric_ui_labels.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "contracts" / "integrations" / "tritfabric-ui-labels.v0.json"
+EXPECTED_SURFACES = {
+    "community-learning-intake",
+    "network-atlas-framework-catalog",
+    "model-card-promotion-evidence",
+    "serve-readiness",
+}
+FORBIDDEN_BADGES = {
+    "training-enabled",
+    "auto-promotion",
+    "economic-credit",
+    "validated-adapter",
+    "production-supported",
+    "promotion-executor",
+    "transport-exception-only",
+    "production-ready",
+    "autoscaler-active",
+    "serve-deployed",
+}
+
+
+def load_contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def validate_contract(doc: dict) -> None:
+    if doc.get("schema_version") != "prophet-platform.tritfabric-ui-labels/v0.1":
+        raise AssertionError("unexpected schema_version")
+    if doc.get("contract_id") != "tritfabric-ui-labels-v0":
+        raise AssertionError("unexpected contract_id")
+    labels = doc.get("labels")
+    if not isinstance(labels, list):
+        raise AssertionError("labels must be a list")
+    by_surface = {label.get("surface_id"): label for label in labels}
+    missing = EXPECTED_SURFACES - set(by_surface)
+    extra = set(by_surface) - EXPECTED_SURFACES
+    if missing or extra:
+        raise AssertionError(f"surface mismatch missing={sorted(missing)} extra={sorted(extra)}")
+    for surface_id, label in by_surface.items():
+        for field in ("display_label", "status_label", "must_show", "forbidden_badges"):
+            if field not in label:
+                raise AssertionError(f"{surface_id} missing {field}")
+        if not label["display_label"] or not label["status_label"]:
+            raise AssertionError(f"{surface_id} labels must be non-empty")
+        if not isinstance(label["must_show"], list) or not label["must_show"]:
+            raise AssertionError(f"{surface_id} must_show must be non-empty")
+        forbidden = set(label.get("forbidden_badges", []))
+        if not forbidden:
+            raise AssertionError(f"{surface_id} must declare forbidden_badges")
+        if not forbidden.issubset(FORBIDDEN_BADGES):
+            raise AssertionError(f"{surface_id} has unknown forbidden badges: {sorted(forbidden - FORBIDDEN_BADGES)}")
+    community = by_surface["community-learning-intake"]
+    for gate in ("consent", "license", "lineage", "rubric", "manual-review-before-promotion"):
+        if gate not in community["must_show"]:
+            raise AssertionError(f"community-learning-intake must show {gate}")
+    serve = by_surface["serve-readiness"]
+    if "production-ready" not in serve["forbidden_badges"] or "autoscaler-active" not in serve["forbidden_badges"]:
+        raise AssertionError("serve-readiness must forbid production-ready and autoscaler-active badges")
+    boundary = doc.get("claim_boundary", "")
+    for phrase in ("does not implement UI", "runtime behavior", "production readiness"):
+        if phrase not in boundary:
+            raise AssertionError(f"claim_boundary missing phrase: {phrase}")
+
+
+def main() -> int:
+    validate_contract(load_contract())
+    print("tritfabric UI labels: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a TritFabric UI/readiness label contract
- add a validator for required labels, required visible gates/fields, forbidden badges, and claim boundary wording
- add focused pytest coverage

## Why
The TritFabric consumption API stubs now expose product-facing readiness surfaces. This PR defines the label contract a future UI should use so Community Learning, Network Atlas, model-card evidence, and Serve readiness are not misrepresented as training, promotion, adapter validation, deployment, or production readiness.

## Claim boundary
Contract and validator only. No UI implementation, runtime behavior, event ingestion, workflow execution, model mutation, artifact promotion, adapter validation, Serve deployment, autoscaler activation, or production readiness claim.

## Validation
- `python3 tools/validate_tritfabric_ui_labels.py`
- `python3 -m pytest tools/tests/test_tritfabric_ui_labels.py`
