### PR TITLE
Add agent action trace negative fixtures and runtime notes

### DIFF
--- a/contracts/agent-action-trace/examples/invalid/agent-action-record.missing-receipt.example.v0.1.json
+++ b/contracts/agent-action-trace/examples/invalid/agent-action-record.missing-receipt.example.v0.1.json
@@ -1,0 +1,19 @@
+{
+  "apiVersion": "prophet-platform.socioprophet.org/v0.1",
+  "kind": "AgentActionRecord",
+  "metadata": {
+    "recordId": "action-record-invalid-missing-receipt",
+    "profileRef": "github://SocioProphet/socioprophet-agent-standards/docs/standards/agent-plane/001-agent-action-trace-conformance-profile.md",
+    "standardsRef": "github://SocioProphet/socioprophet-agent-standards@97e3f49ec4b27349f532db27ebaad618d4f9520c",
+    "ontologyRef": "github://SocioProphet/ontogenesis/Middle/action-ontology.ttl"
+  },
+  "spec": {
+    "agentSubjectRef": "agent://platform/agentplane/bootstrap-agent",
+    "actionId": "action.exec.invalid.0001",
+    "actionType": "executeTask",
+    "fromStateRef": "state.awarded",
+    "toStateRef": "state.done",
+    "timestamp": "2026-05-05T18:40:00Z",
+    "policyRef": "policy://platform/action-trace/decision-invalid"
+  }
+}

--- a/contracts/agent-action-trace/examples/invalid/agent-action-trace-conformance-report.bad-bootstrap-ref.example.v0.1.json
+++ b/contracts/agent-action-trace/examples/invalid/agent-action-trace-conformance-report.bad-bootstrap-ref.example.v0.1.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "prophet-platform.socioprophet.org/v0.1",
+  "kind": "AgentActionTraceConformanceReport",
+  "metadata": {
+    "reportId": "agent-action-trace-conformance-invalid-bootstrap",
+    "profileRef": "github://SocioProphet/socioprophet-agent-standards/docs/standards/agent-plane/001-agent-action-trace-conformance-profile.md",
+    "standardsPin": "97e3f49ec4b27349f532db27ebaad618d4f9520c"
+  },
+  "spec": {
+    "implementationRef": "github://SocioProphet/prophet-platform/apps/agentplane",
+    "ontologyRef": "github://SocioProphet/ontogenesis/Middle/action-ontology.ttl",
+    "bootstrapValidatorRef": "github://SocioProphet/prophet-platform/tools/action_ontology_validate_all.sh",
+    "overallStatus": "pass",
+    "checks": [
+      {
+        "id": "bad-bootstrap-ref",
+        "status": "pass",
+        "evidenceRef": "evidence://platform/action-trace/invalid-bootstrap",
+        "summary": "This fixture must fail because bootstrap validator authority points at the wrong repo."
+      }
+    ]
+  }
+}

--- a/contracts/agent-action-trace/examples/invalid/agent-trace-record.authority-true.example.v0.1.json
+++ b/contracts/agent-action-trace/examples/invalid/agent-trace-record.authority-true.example.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "prophet-platform.socioprophet.org/v0.1",
+  "kind": "AgentTraceRecord",
+  "metadata": {
+    "recordId": "trace-record-invalid-authority",
+    "profileRef": "github://SocioProphet/socioprophet-agent-standards/docs/standards/agent-plane/001-agent-action-trace-conformance-profile.md",
+    "standardsRef": "github://SocioProphet/socioprophet-agent-standards@97e3f49ec4b27349f532db27ebaad618d4f9520c",
+    "ontologyRef": "github://SocioProphet/ontogenesis/Middle/action-ontology.ttl"
+  },
+  "spec": {
+    "traceId": "trace.invalid.authority.0001",
+    "pattern": "ContractNet",
+    "traceKind": "done",
+    "medium": "bus:tasks",
+    "timestamp": "2026-05-05T18:40:01Z",
+    "refActionId": "action.exec.invalid.0001",
+    "taskId": "task-invalid",
+    "traceIsAuthority": true
+  }
+}

--- a/docs/generated/agent-action-trace/runtime-consumption-agentplane.md
+++ b/docs/generated/agent-action-trace/runtime-consumption-agentplane.md
@@ -1,0 +1,31 @@
+# AgentPlane Agent Action / Trace Consumption Note
+
+## Purpose
+
+This note defines the first consumption boundary for AgentPlane against the generated Agent Action / Trace contracts.
+
+## Expected future role
+
+AgentPlane should eventually emit or preserve:
+
+- `AgentActionRecord`
+- `AgentTraceRecord`
+- `AgentActionTraceConformanceReport`
+
+## Current boundary
+
+This note is documentation-only. It does not claim AgentPlane runtime conformance.
+
+## Required future evidence
+
+A future AgentPlane implementation PR should include:
+
+- at least one emitted `AgentActionRecord` fixture
+- at least one emitted `AgentTraceRecord` fixture
+- a conformance report fixture
+- linkage to policy decision and receipt references
+- validator execution evidence using `tools/validate_agent_action_trace_contracts.py`
+
+## Non-authority rule
+
+AgentPlane must treat traces as coordination/evidence artifacts, not as authorization.

--- a/docs/generated/agent-action-trace/runtime-consumption-lampstand.md
+++ b/docs/generated/agent-action-trace/runtime-consumption-lampstand.md
@@ -1,0 +1,26 @@
+# Lampstand Agent Action / Trace Consumption Note
+
+## Purpose
+
+This note defines the first consumption boundary for Lampstand against the generated Agent Action / Trace contracts.
+
+## Expected future role
+
+Lampstand should eventually index action/trace records and conformance reports so users and agents can search governed coordination evidence.
+
+## Current boundary
+
+This note is documentation-only. It does not claim Lampstand runtime conformance.
+
+## Required future evidence
+
+A future implementation PR should show:
+
+- indexed action record references
+- indexed trace record references
+- search/result surfaces that identify policy and receipt refs
+- no promotion of trace records into authorization authority
+
+## Indexing rule
+
+Lampstand may index traces as evidence and retrieval context. It must not become the authority for deciding whether an action was allowed.

--- a/docs/generated/agent-action-trace/runtime-consumption-workspace-controller.md
+++ b/docs/generated/agent-action-trace/runtime-consumption-workspace-controller.md
@@ -1,0 +1,26 @@
+# Workspace Controller Agent Action / Trace Consumption Note
+
+## Purpose
+
+This note defines the first consumption boundary for the workspace-controller surface against the generated Agent Action / Trace contracts.
+
+## Expected future role
+
+The workspace controller should eventually preserve or reference action/trace records when workspace orchestration requests trigger governed agent-plane work.
+
+## Current boundary
+
+This note is documentation-only. It does not claim workspace-controller runtime conformance.
+
+## Required future evidence
+
+A future implementation PR should show:
+
+- action records associated with workspace operation requests
+- trace records for coordination outcomes
+- references to policy decisions and receipts
+- no direct treatment of traces as execution authority
+
+## Authority split
+
+Workspace state and orchestration context remain separate from semantic ontology authority and from policy authorization.


### PR DESCRIPTION
## Summary

Clean partial replacement for stale, non-mergeable #437.

This captures the safe additive portion of #437: invalid agent action / trace fixtures and runtime-consumption notes. It deliberately avoids stale validator/index edits and an unrelated Cell Gateway validator file.

## Scope

Adds invalid fixtures:

- `contracts/agent-action-trace/examples/invalid/agent-action-record.missing-receipt.example.v0.1.json`
- `contracts/agent-action-trace/examples/invalid/agent-action-trace-conformance-report.bad-bootstrap-ref.example.v0.1.json`
- `contracts/agent-action-trace/examples/invalid/agent-trace-record.authority-true.example.v0.1.json`

Adds runtime-consumption notes:

- `docs/generated/agent-action-trace/runtime-consumption-agentplane.md`
- `docs/generated/agent-action-trace/runtime-consumption-lampstand.md`
- `docs/generated/agent-action-trace/runtime-consumption-workspace-controller.md`

## Deliberate deviations from #437

Skipped in this replacement:

- `contracts/agent-action-trace/README.md`
- `docs/generated/agent-action-trace/contract-consumption.md`
- `tools/validate_agent_action_trace_contracts.py`
- `tools/validate_cell_gateway_api.py`

Reason: those are existing validator/index/adjacent-system edits and should be handled from a patch-safe/local checkout path. `tools/validate_cell_gateway_api.py` appears unrelated to the agent-action trace tranche and should be triaged separately.

## Validation expectation

```bash
python -m json.tool contracts/agent-action-trace/examples/invalid/agent-action-record.missing-receipt.example.v0.1.json >/dev/null
python -m json.tool contracts/agent-action-trace/examples/invalid/agent-action-trace-conformance-report.bad-bootstrap-ref.example.v0.1.json >/dev/null
python -m json.tool contracts/agent-action-trace/examples/invalid/agent-trace-record.authority-true.example.v0.1.json >/dev/null
```

## Supersedes

Partially supersedes #437 after review/merge. The validator/index wiring remains follow-up work.