### PR TITLE
Add adversarial scenario reference binding contract

### DIFF
--- a/contracts/security/adversarial-scenario-ref.example.json
+++ b/contracts/security/adversarial-scenario-ref.example.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "0.1.0",
+  "scenarioRef": "adversarial-scenario:workspace-transduction-001",
+  "source": {
+    "scenarioRepo": "SocioProphet/SCOPE-D",
+    "scenarioPrRef": "SocioProphet/SCOPE-D#60",
+    "schemaRef": "config/schemas/wargames-adversarial-scenario.schema.json",
+    "ontologyRef": "SocioProphet/ontogenesis#112"
+  },
+  "bindingMode": "reference_only",
+  "platformUse": {
+    "apiSurface": "contract_reference",
+    "uiSurface": "none",
+    "runtimeExecution": false,
+    "reportExport": false,
+    "memoryWriteback": false,
+    "claimPromotion": false
+  },
+  "safetyBoundary": {
+    "nonProductionOnly": true,
+    "syntheticOrRedacted": true,
+    "liveTargetAccess": false,
+    "credentialAccess": false,
+    "payloadDelivery": false,
+    "stateMutation": false,
+    "destructiveBehavior": false,
+    "externalDelivery": false
+  },
+  "authority": {
+    "runtimeAuthority": false,
+    "procedureExecutionAuthority": false,
+    "engagementAuthorizationAuthority": false,
+    "activationAllowed": false
+  },
+  "evidenceRefs": [
+    "evidence:scout-header-summary-001",
+    "negative-evidence:missing-validator-record-001",
+    "proof:scout:profile-001"
+  ],
+  "runtimeDecisionReceiptRefs": ["wargames-runtime-receipt:allow-validate-001"],
+  "policyRefs": [
+    "policy:wargames-runtime-dry-run-v0.1",
+    "policy:scenario-boundary-reference-only"
+  ],
+  "semanticNonClaims": [
+    "does_not_execute_attack_procedure",
+    "does_not_authorize_engagement",
+    "does_not_claim_causal_attribution",
+    "does_not_promote_memory_writeback",
+    "does_not_establish_production_observation"
+  ],
+  "redactionState": "redacted"
+}

--- a/contracts/security/adversarial-scenario-ref.schema.json
+++ b/contracts/security/adversarial-scenario-ref.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/platform/adversarial-scenario-ref.schema.json",
+  "title": "Platform Adversarial Scenario Reference",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "scenarioRef",
+    "source",
+    "bindingMode",
+    "platformUse",
+    "safetyBoundary",
+    "authority",
+    "evidenceRefs",
+    "runtimeDecisionReceiptRefs",
+    "policyRefs",
+    "semanticNonClaims",
+    "redactionState"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "0.1.0" },
+    "scenarioRef": { "type": "string", "pattern": "^adversarial-scenario:[a-z0-9][a-z0-9._:-]*$" },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scenarioRepo", "scenarioPrRef", "schemaRef", "ontologyRef"],
+      "properties": {
+        "scenarioRepo": { "const": "SocioProphet/SCOPE-D" },
+        "scenarioPrRef": { "type": "string" },
+        "schemaRef": { "type": "string" },
+        "ontologyRef": { "type": "string" }
+      }
+    },
+    "bindingMode": { "enum": ["reference_only", "ingest_candidate"] },
+    "platformUse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["apiSurface", "uiSurface", "runtimeExecution", "reportExport", "memoryWriteback", "claimPromotion"],
+      "properties": {
+        "apiSurface": { "enum": ["none", "contract_reference", "future_api_candidate"] },
+        "uiSurface": { "enum": ["none", "future_operator_view_candidate"] },
+        "runtimeExecution": { "const": false },
+        "reportExport": { "const": false },
+        "memoryWriteback": { "const": false },
+        "claimPromotion": { "const": false }
+      }
+    },
+    "safetyBoundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["nonProductionOnly", "syntheticOrRedacted", "liveTargetAccess", "credentialAccess", "payloadDelivery", "stateMutation", "destructiveBehavior", "externalDelivery"],
+      "properties": {
+        "nonProductionOnly": { "const": true },
+        "syntheticOrRedacted": { "const": true },
+        "liveTargetAccess": { "const": false },
+        "credentialAccess": { "const": false },
+        "payloadDelivery": { "const": false },
+        "stateMutation": { "const": false },
+        "destructiveBehavior": { "const": false },
+        "externalDelivery": { "const": false }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runtimeAuthority", "procedureExecutionAuthority", "engagementAuthorizationAuthority", "activationAllowed"],
+      "properties": {
+        "runtimeAuthority": { "const": false },
+        "procedureExecutionAuthority": { "const": false },
+        "engagementAuthorizationAuthority": { "const": false },
+        "activationAllowed": { "const": false }
+      }
+    },
+    "evidenceRefs": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "runtimeDecisionReceiptRefs": { "type": "array", "minItems": 1, "items": { "type": "string", "pattern": "^wargames-runtime-receipt:[a-z0-9][a-z0-9._:-]*$" } },
+    "policyRefs": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "semanticNonClaims": { "type": "array", "minItems": 5, "items": { "type": "string" } },
+    "redactionState": { "enum": ["redacted", "synthetic", "withheld"] }
+  }
+}

--- a/docs/ADVERSARIAL_SCENARIO_PLATFORM_BINDING.md
+++ b/docs/ADVERSARIAL_SCENARIO_PLATFORM_BINDING.md
@@ -1,0 +1,71 @@
+# Adversarial Scenario Platform Binding
+
+Status: draft v0.1
+
+## Purpose
+
+This document defines the Prophet Platform binding for SCOPE-D adversarial scenario references.
+
+The platform binding is intentionally narrow. Prophet Platform may reference upstream governed scenario artifacts, but this tranche does not implement a scenario builder, operator UI, report exporter, runtime executor, live collector, or memory writeback path.
+
+## Ownership
+
+- SCOPE-D owns the executable adversarial scenario JSON contract and Wargames validation.
+- Ontogenesis owns the RDF/SHACL semantic projection.
+- Memory Mesh owns durable learning/writeback governance.
+- Prophet Workspace owns workspace channel/interface substrate contracts.
+- Prophet Platform owns this product/runtime reference binding.
+
+## Contract
+
+The platform-facing contract lives at:
+
+- `contracts/security/adversarial-scenario-ref.schema.json`
+- `contracts/security/adversarial-scenario-ref.example.json`
+- `tools/validate_adversarial_scenario_ref.py`
+
+Validate with:
+
+```bash
+python3 tools/validate_adversarial_scenario_ref.py
+```
+
+## Boundary
+
+The binding is reference-only by default.
+
+It must not grant:
+
+- runtime execution;
+- procedure execution authority;
+- engagement authorization;
+- downstream activation;
+- live target access;
+- credential access;
+- payload delivery;
+- state mutation;
+- destructive behavior;
+- external delivery;
+- report export;
+- claim promotion;
+- memory writeback.
+
+## Required fields
+
+A scenario reference must carry:
+
+- `scenarioRef`;
+- SCOPE-D source repo and PR/schema references;
+- Ontogenesis semantic reference;
+- evidence refs;
+- runtime decision receipt refs;
+- policy refs;
+- explicit semantic non-claims;
+- redaction state;
+- fail-closed safety and authority fields.
+
+## Non-claims
+
+A platform scenario reference is not a finding, not a report, not a policy update, not a memory update, not an execution request, not a client delivery artifact, and not an authorization envelope.
+
+Platform services may later consume scenario references only after separate API/service design and validation gates are added.

--- a/tools/validate_adversarial_scenario_ref.py
+++ b/tools/validate_adversarial_scenario_ref.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "contracts" / "security" / "adversarial-scenario-ref.schema.json"
+EXAMPLE_PATH = ROOT / "contracts" / "security" / "adversarial-scenario-ref.example.json"
+
+REQUIRED_NON_CLAIMS = {
+    "does_not_execute_attack_procedure",
+    "does_not_authorize_engagement",
+    "does_not_claim_causal_attribution",
+    "does_not_promote_memory_writeback",
+    "does_not_establish_production_observation",
+}
+
+
+def fail(message: str) -> int:
+    print(f"ERR: {message}", file=sys.stderr)
+    return 1
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"missing file: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path.relative_to(ROOT)}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{path.relative_to(ROOT)} must be a JSON object")
+    return data
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def require_object(value: Any, name: str) -> dict[str, Any]:
+    require(isinstance(value, dict), f"{name} must be an object")
+    return value
+
+
+def require_false(obj: dict[str, Any], key: str, context: str) -> None:
+    require(obj.get(key) is False, f"{context}.{key} must be false")
+
+
+def validate_schema(schema: dict[str, Any]) -> None:
+    require(schema.get("title") == "Platform Adversarial Scenario Reference", "schema title mismatch")
+    props = require_object(schema.get("properties"), "schema.properties")
+    require(props.get("schemaVersion", {}).get("const") == "0.1.0", "schemaVersion const missing")
+    source = require_object(props.get("source"), "schema.properties.source")
+    source_props = require_object(source.get("properties"), "schema.properties.source.properties")
+    require(source_props.get("scenarioRepo", {}).get("const") == "SocioProphet/SCOPE-D", "scenarioRepo const must point to SCOPE-D")
+
+
+def validate_example(example: dict[str, Any]) -> None:
+    require(example.get("schemaVersion") == "0.1.0", "example schemaVersion mismatch")
+    require(str(example.get("scenarioRef", "")).startswith("adversarial-scenario:"), "scenarioRef must use adversarial-scenario: prefix")
+
+    source = require_object(example.get("source"), "source")
+    require(source.get("scenarioRepo") == "SocioProphet/SCOPE-D", "source.scenarioRepo must be SocioProphet/SCOPE-D")
+    for key in ("scenarioPrRef", "schemaRef", "ontologyRef"):
+        require(isinstance(source.get(key), str) and source[key], f"source.{key} must be non-empty string")
+
+    require(example.get("bindingMode") == "reference_only", "bindingMode must be reference_only in the example")
+
+    platform_use = require_object(example.get("platformUse"), "platformUse")
+    for key in ("runtimeExecution", "reportExport", "memoryWriteback", "claimPromotion"):
+        require_false(platform_use, key, "platformUse")
+    require(platform_use.get("apiSurface") == "contract_reference", "platformUse.apiSurface must be contract_reference")
+    require(platform_use.get("uiSurface") == "none", "platformUse.uiSurface must be none")
+
+    safety = require_object(example.get("safetyBoundary"), "safetyBoundary")
+    require(safety.get("nonProductionOnly") is True, "safetyBoundary.nonProductionOnly must be true")
+    require(safety.get("syntheticOrRedacted") is True, "safetyBoundary.syntheticOrRedacted must be true")
+    for key in ("liveTargetAccess", "credentialAccess", "payloadDelivery", "stateMutation", "destructiveBehavior", "externalDelivery"):
+        require_false(safety, key, "safetyBoundary")
+
+    authority = require_object(example.get("authority"), "authority")
+    for key in ("runtimeAuthority", "procedureExecutionAuthority", "engagementAuthorizationAuthority", "activationAllowed"):
+        require_false(authority, key, "authority")
+
+    for key in ("evidenceRefs", "runtimeDecisionReceiptRefs", "policyRefs", "semanticNonClaims"):
+        value = example.get(key)
+        require(isinstance(value, list) and value, f"{key} must be a non-empty list")
+
+    receipt_refs = example.get("runtimeDecisionReceiptRefs") or []
+    require(all(isinstance(ref, str) and ref.startswith("wargames-runtime-receipt:") for ref in receipt_refs), "runtimeDecisionReceiptRefs must use wargames-runtime-receipt: prefix")
+
+    non_claims = set(example.get("semanticNonClaims") or [])
+    missing = sorted(REQUIRED_NON_CLAIMS - non_claims)
+    require(not missing, f"semanticNonClaims missing required non-claims: {missing}")
+    require(example.get("redactionState") in {"redacted", "synthetic", "withheld"}, "invalid redactionState")
+
+
+def main() -> int:
+    try:
+        schema = load_json(SCHEMA_PATH)
+        example = load_json(EXAMPLE_PATH)
+        validate_schema(schema)
+        validate_example(example)
+    except ValueError as exc:
+        return fail(str(exc))
+
+    print("OK: validated adversarial scenario reference schema and example")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Clean partial replacement for stale, non-mergeable #512.

This captures the self-contained Prophet Platform adversarial scenario reference binding without replaying stale README, Makefile, or workflow wiring.

## Scope

Adds:

- `contracts/security/adversarial-scenario-ref.schema.json`
- `contracts/security/adversarial-scenario-ref.example.json`
- `docs/ADVERSARIAL_SCENARIO_PLATFORM_BINDING.md`
- `tools/validate_adversarial_scenario_ref.py`

## Boundary

Reference-only by default. This contract does not grant runtime execution, procedure execution authority, engagement authorization, downstream activation, live target access, credential access, payload delivery, state mutation, destructive behavior, external delivery, report export, claim promotion, or memory writeback.

## Deliberate deviations from #512

Skipped in this replacement:

- `.github/workflows/adversarial-scenario-ref.yml`
- `Makefile`
- `README.md`

Reason: those are workflow/index/wiring edits and should be handled from a patch-safe/local checkout path after the self-contained contract lands.

## Validation expectation

```bash
python3 tools/validate_adversarial_scenario_ref.py
python -m json.tool contracts/security/adversarial-scenario-ref.schema.json >/dev/null
python -m json.tool contracts/security/adversarial-scenario-ref.example.json >/dev/null
```

## Supersedes

Partially supersedes #512 after review/merge. Workflow, Makefile, and README surfacing remain follow-up work.