### PR TITLE
ui: add TritFabric readiness labels component

### DIFF
--- a/apps/socioprophet-web/src/components/TritFabricReadinessLabels.vue
+++ b/apps/socioprophet-web/src/components/TritFabricReadinessLabels.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import labelContract from '../../../../contracts/integrations/tritfabric-ui-labels.v0.json'
+
+type Label = {
+  surface_id: string
+  display_label: string
+  status_label: string
+  must_show: string[]
+  forbidden_badges: string[]
+}
+
+const labels = labelContract.labels as Label[]
+const claimBoundary = labelContract.claim_boundary
+</script>
+
+<template>
+  <section style="border:1px solid #e2e8f0;border-radius:16px;padding:1rem;margin-top:1.5rem;">
+    <div style="font-size:12px;text-transform:uppercase;letter-spacing:.08em;opacity:.65;font-weight:700;">
+      TritFabric readiness labels
+    </div>
+    <h2 style="margin:.4rem 0 0.6rem 0;font-size:1.4rem;font-weight:700;">
+      Governed product-consumption surfaces
+    </h2>
+    <p style="margin:0 0 1rem 0;opacity:.82;">
+      Label contract for displaying TritFabric-derived Community Learning, Network Atlas, model-card evidence, and Serve readiness surfaces without implying runtime authority.
+    </p>
+
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.75rem;margin-bottom:1rem;">
+      <article v-for="label in labels" :key="label.surface_id" style="border:1px solid #e2e8f0;border-radius:12px;padding:.75rem;">
+        <div style="font-size:12px;text-transform:uppercase;opacity:.65;font-weight:700;">{{ label.status_label }}</div>
+        <h3 style="margin:.35rem 0 .5rem 0;font-size:1rem;font-weight:700;">{{ label.display_label }}</h3>
+        <div style="font-size:.8rem;opacity:.62;margin-bottom:.5rem;">{{ label.surface_id }}</div>
+        <section>
+          <div style="font-size:.82rem;font-weight:700;margin-bottom:.25rem;">Must show</div>
+          <ul style="margin:0 0 .75rem 0;padding-left:1rem;">
+            <li v-for="item in label.must_show" :key="`${label.surface_id}-must-${item}`" style="margin:.25rem 0;">{{ item }}</li>
+          </ul>
+        </section>
+        <section>
+          <div style="font-size:.82rem;font-weight:700;margin-bottom:.25rem;">Forbidden badges</div>
+          <ul style="margin:0;padding-left:1rem;">
+            <li v-for="item in label.forbidden_badges" :key="`${label.surface_id}-forbidden-${item}`" style="margin:.25rem 0;">{{ item }}</li>
+          </ul>
+        </section>
+      </article>
+    </div>
+
+    <section style="border:1px dashed #cbd5e1;border-radius:12px;padding:.75rem;">
+      <div style="font-size:.82rem;font-weight:700;margin-bottom:.25rem;">Claim boundary</div>
+      <p style="margin:0;opacity:.78;">{{ claimBoundary }}</p>
+    </section>
+  </section>
+</template>

--- a/tools/tests/test_tritfabric_ui_component.py
+++ b/tools/tests/test_tritfabric_ui_component.py
@@ -1,0 +1,5 @@
+from tools.validate_tritfabric_ui_component import validate_component
+
+
+def test_tritfabric_ui_component_contract_projection():
+    validate_component()

--- a/tools/validate_tritfabric_ui_component.py
+++ b/tools/validate_tritfabric_ui_component.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "apps" / "socioprophet-web" / "src" / "components" / "TritFabricReadinessLabels.vue"
+CONTRACT = ROOT / "contracts" / "integrations" / "tritfabric-ui-labels.v0.json"
+
+
+def load_contract() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+def validate_component() -> None:
+    text = COMPONENT.read_text(encoding="utf-8")
+    contract = load_contract()
+
+    required_fragments = [
+        "tritfabric-ui-labels.v0.json",
+        "TritFabric readiness labels",
+        "Governed product-consumption surfaces",
+        "Must show",
+        "Forbidden badges",
+        "Claim boundary",
+        "label.must_show",
+        "label.forbidden_badges",
+        "claimBoundary",
+    ]
+    for fragment in required_fragments:
+        if fragment not in text:
+            raise AssertionError(f"component missing required fragment: {fragment}")
+
+    for label in contract.get("labels", []):
+        for field in ("surface_id", "display_label", "status_label"):
+            value = label.get(field)
+            if not value:
+                raise AssertionError(f"label missing {field}")
+        # The component renders these dynamically from the contract rather than
+        # hard-coding each value. We still assert the source contract includes
+        # the labels the component is expected to project.
+        if not label.get("must_show") or not label.get("forbidden_badges"):
+            raise AssertionError(f"label {label['surface_id']} missing gate/badge lists")
+
+    forbidden_runtime_terms = [
+        "fetch(",
+        "POST",
+        "PUT",
+        "DELETE",
+        "artifact_promotion = true",
+        "serve_deployment = true",
+        "autoscaler_active_loop = true",
+    ]
+    for term in forbidden_runtime_terms:
+        if term in text:
+            raise AssertionError(f"component must not introduce runtime behavior: {term}")
+
+
+def main() -> int:
+    validate_component()
+    print("tritfabric UI component: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a detached Vue component for TritFabric readiness labels
- add a validator that checks the component projects the UI/readiness label contract without runtime behavior
- add focused pytest coverage

## Why
The TritFabric UI/readiness label contract has landed. This PR adds the first UI scaffold that consumes that contract while staying detached from production routing.

## Claim boundary
UI component scaffold only. Not mounted in App.vue. No runtime API calls, event ingestion, workflow execution, model mutation, artifact promotion, adapter validation, Serve deployment, autoscaler activation, or production readiness claim.

## Validation
- `python3 tools/validate_tritfabric_ui_component.py`
- `python3 -m pytest tools/tests/test_tritfabric_ui_component.py`
