### PR TITLE
canon: define platform catalog and consolidation plan

### DIFF
--- a/docs/canon/ARCHITECTURE.md
+++ b/docs/canon/ARCHITECTURE.md
@@ -1,0 +1,87 @@
+# Canon Architecture v0.1
+
+Canon is the governed source, dataset, task, application, receipt, and data-product registry inside Prophet Platform.
+
+Canon is not a standalone product repository. It is a deployable platform capability. The prior `prophet-core-catalog` concept is treated as a consolidation candidate and should collapse into the platform unless a separate lifecycle is proven.
+
+## Naming decision
+
+Use `Canon` as the subsystem name.
+
+Avoid `Alexandria`, `Atlas`, `DataHub`, and religious-object names. Canon means accepted authority, rule, measure, and standard. That maps directly to canonical sources, canonical manifests, policy admissibility, source authority, lineage receipts, and data-product eligibility.
+
+## Problem statement
+
+The durable lesson from earlier data-platform work is that users do not primarily care about storage backends, query engines, schemas, lakehouse mechanics, or distributed-system internals. They care about tasks:
+
+- find the right source;
+- ingest data;
+- clean and normalize it;
+- join it with other sources;
+- resolve entities;
+- inspect quality and policy constraints;
+- visualize and explain it;
+- share it with a team;
+- publish it as a governed product;
+- prove where it came from and how it changed.
+
+Canon exists to make those tasks discoverable, auditable, and executable through Prophet Platform.
+
+## Canon object model
+
+Canon defines the following platform objects.
+
+- Source: an external, open, licensed, client-owned, or internal feed with license, auth, freshness, provenance, and policy metadata.
+- Dataset: a versioned, normalized data asset derived from one or more sources.
+- Collection: a workspace-visible grouping of datasets, notebooks, apps, visualizations, and receipts.
+- Task: a user-oriented operation such as ingest, clean, join, enrich, resolve, summarize, visualize, model, publish, audit, or export.
+- Catalog app: a task processor implemented by an API, workflow, notebook, agent, script, container, or external system.
+- Receipt: durable evidence for source access, transform, validation, policy decision, publication, or export.
+- Product pack: governed bundle of datasets, tasks, apps, policies, and receipts exposed through SocioProphet product surfaces.
+
+## Platform placement
+
+Canon should live under Prophet Platform, initially as:
+
+- `services/canon/registry/`
+- `services/canon/sources/`
+- `services/canon/datasets/`
+- `services/canon/tasks/`
+- `services/canon/apps/`
+- `services/canon/receipts/`
+- `services/canon/product-packs/`
+- `docs/canon/`
+
+The current architecture document is the planning anchor before code relocation.
+
+## Integration boundaries
+
+Canon owns registry semantics, object identity, manifest vocabulary, search facets, task metadata, admissibility metadata, and data-product packaging metadata.
+
+Execution is delegated:
+
+- Prophet Platform runs the deployable services.
+- Prophet Core Ingest functionality should collapse into platform ingestion services.
+- Prophet Core Query functionality should collapse into platform query/search services.
+- Prophet Core Infra functionality should collapse into platform deployment/infra modules.
+- Prophet Ledger or `prophet-core-ledger` remains a separate audit candidate until receipt durability and audit lifecycle are settled.
+- Policy Fabric and Guardrail Fabric decide policy admission and guardrail enforcement.
+- AgentPlane runs governed agent tasks.
+- Sherlock, Holmes, SynapseIQ, Slash Topics, New Hope, and Lampstand expose discovery, reasoning, and retrieval surfaces.
+- SocioSphere tracks workspace/service-register awareness and downstream propagation.
+
+## Non-goals
+
+Canon is not a generic metadata list, not a clone of MIT DataHub, not LinkedIn/Acryl DataHub, not CKAN, not a data marketplace by itself, and not a notebook runtime.
+
+Canon is the registry kernel that lets these other systems become coherent, governed, searchable, and productizable.
+
+## First implementation slice
+
+The first slice should remain design-first and low-risk:
+
+1. Establish Canon naming and boundaries.
+2. Define the platform object vocabulary.
+3. Mark standalone core catalog/ingest/query/infra repos as consolidation candidates.
+4. Add a migration map into Prophet Platform.
+5. Delay physical repo archival until import paths, CI, release behavior, and downstream consumers are known.

--- a/docs/canon/PLATFORM_CONSOLIDATION_PLAN.md
+++ b/docs/canon/PLATFORM_CONSOLIDATION_PLAN.md
@@ -1,0 +1,63 @@
+# Canon Platform Consolidation Plan v0.1
+
+## Decision frame
+
+The `prophet-core-*` repositories should not be treated as independent products by default. Several are deployable capabilities of Prophet Platform and should be collapsed into the platform when their lifecycle is not meaningfully independent.
+
+The consolidation target is not immediate deletion. The target is controlled migration with compatibility checks, downstream consumer review, and service-register propagation.
+
+## Recommended disposition
+
+| Repository | Recommended disposition | Rationale |
+|---|---|---|
+| `SocioProphet/prophet-core-catalog` | Collapse into `prophet-platform/services/canon` | Catalog is a platform subsystem, now named Canon. |
+| `SocioProphet/prophet-core-ingest` | Collapse into `prophet-platform/services/ingest` or `services/canon/ingest-adapters` | Ingest is deployed and operated with the platform. |
+| `SocioProphet/prophet-core-infra` | Collapse into `prophet-platform/infra` | Infrastructure belongs with the deployable platform topology. |
+| `SocioProphet/prophet-core-query` | Collapse into `prophet-platform/services/query` unless query release cadence diverges | Query is platform runtime capability and should integrate with Sherlock/Holmes/SynapseIQ. |
+| `SocioProphet/prophet-core-ops-brief` | Collapse into `prophet-platform/ops/briefs` | Ops brief artifacts are platform operations collateral. |
+| `SocioProphet/prophet-core-scaffolder` | Collapse into `prophet-platform/tools/scaffolder` | Scaffolding is a platform developer tool. |
+| `SocioProphet/prophet-core-contracts` | Hold as boundary repo until consumers are mapped | Shared contracts may need independent package/version lifecycle. |
+| `SocioProphet/prophet-core-ledger` | Hold as boundary repo until audit lifecycle is decided | Receipts and evidence durability may justify separate controls. |
+| `SocioProphet/prophet-core-policy` | Review against Policy Fabric and Guardrail Fabric | Could collapse, become compatibility layer, or be absorbed into policy repos. |
+| `SocioProphet/prophet-core-libs` | Review as package boundary | Either publish as libs or collapse into platform internals. |
+
+## Target platform layout
+
+```text
+prophet-platform/
+  services/
+    canon/
+      registry/
+      sources/
+      datasets/
+      tasks/
+      apps/
+      receipts/
+      product-packs/
+    ingest/
+    query/
+  infra/
+  ops/
+    briefs/
+  tools/
+    scaffolder/
+  docs/
+    canon/
+```
+
+## Migration gates
+
+1. Inventory current files, contracts, workflows, issues, and consumers in each candidate repo.
+2. Decide whether each repo contains runtime code, schemas, docs, fixtures, CI, or release artifacts.
+3. Move only after import paths and downstream references are mapped.
+4. Add compatibility stubs or archive notices in retired repos.
+5. Update workspace-inventory canonical estate and SocioSphere service-register mirror after the migration branch is validated.
+6. Do not archive ledger/contracts/policy/libs until lifecycle independence is resolved.
+
+## Immediate next steps
+
+1. Add Canon architecture and consolidation plan to Prophet Platform.
+2. Open consolidation issues in `workspace-inventory` and `sociosphere`.
+3. Mark candidate repos as `collapse-candidate`, not removed.
+4. Create migration inventory reports for catalog, ingest, infra, query, ops-brief, and scaffolder.
+5. Only then mutate canonical repo counts.


### PR DESCRIPTION
## Summary

Defines `Canon` as the governed source, dataset, task, app, receipt, and data-product registry inside Prophet Platform.

This is a design-first consolidation PR. It does not move code or archive repos.

## Decisions

- Use `Canon` as the catalog subsystem name.
- Treat `prophet-core-catalog` as a consolidation candidate, not a standalone product.
- Treat `prophet-core-ingest`, `prophet-core-infra`, `prophet-core-query`, `prophet-core-ops-brief`, and `prophet-core-scaffolder` as likely platform-collapse candidates.
- Hold `prophet-core-contracts`, `prophet-core-ledger`, `prophet-core-policy`, and `prophet-core-libs` for lifecycle review before consolidation.

## Added

- `docs/canon/ARCHITECTURE.md`
- `docs/canon/PLATFORM_CONSOLIDATION_PLAN.md`

## Validation

Documentation-only. No runtime behavior, schema gate, deployment topology, import path, service registry, or canonical repo count is changed in this PR.

## Follow-up

After this lands, workspace-inventory and SocioSphere should track the core-repo collapse candidates without mutating canonical repo counts until migration inventories are complete.