### PR TITLE
test: add invalid Workroom InvestigationRun fixtures

### DIFF
--- a/tests/fixtures/workroom/devsecops-investigation-run.missing-topology-evidence.invalid.json
+++ b/tests/fixtures/workroom/devsecops-investigation-run.missing-topology-evidence.invalid.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "0.1.0",
+  "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-2001",
+  "incident_ref": "incident://pagerduty/scope-d-example/INC-2001",
+  "lane": "post_merge_incident",
+  "authority_boundary": {
+    "investigation_authority": "prophet_platform",
+    "execution_authority": "external_connector",
+    "workroom_authority": "prophet_platform"
+  },
+  "status": "ready_for_rca",
+  "started_at": "2026-05-31T16:56:00Z",
+  "completed_at": "2026-05-31T16:58:00Z",
+  "evidence_collection": [
+    {
+      "evidence_ref": "evidence://observability/scope-d-example/5xx-spike-invalid",
+      "evidence_type": "metric_observation",
+      "source_system": "observability-fixture",
+      "source_ref": "metric://scope-d-example/api/5xx-rate",
+      "collection_status": "collected",
+      "non_claims": ["Expected-invalid metric observation only."]
+    }
+  ],
+  "topology_context": {
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "evidence_ref": "evidence://observability/scope-d-example/5xx-spike-invalid"
+  },
+  "blast_radius_context": {
+    "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-2001",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "status": "estimated"
+  },
+  "workroom_projection": {
+    "workroom_id": "workroom:devsecops:post-merge:scope-d-example-invalid-topology",
+    "source_refs": {
+      "incident_ref": "incident://pagerduty/scope-d-example/INC-2001",
+      "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-2001",
+      "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+      "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-2001"
+    },
+    "evidence_refs": ["evidence://observability/scope-d-example/5xx-spike-invalid"]
+  },
+  "non_claims": ["Expected-invalid fixture: topology context lacks topology_snapshot backing evidence."]
+}

--- a/tests/fixtures/workroom/devsecops-investigation-run.projection-evidence-mismatch.invalid.json
+++ b/tests/fixtures/workroom/devsecops-investigation-run.projection-evidence-mismatch.invalid.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "0.1.0",
+  "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-2002",
+  "incident_ref": "incident://pagerduty/scope-d-example/INC-2002",
+  "lane": "post_merge_incident",
+  "authority_boundary": {
+    "investigation_authority": "prophet_platform",
+    "execution_authority": "external_connector",
+    "workroom_authority": "prophet_platform"
+  },
+  "status": "ready_for_rca",
+  "started_at": "2026-05-31T16:56:00Z",
+  "completed_at": "2026-05-31T16:58:00Z",
+  "evidence_collection": [
+    {
+      "evidence_ref": "evidence://gaia/topology/scope-d-example/blast-radius-invalid",
+      "evidence_type": "topology_snapshot",
+      "source_system": "GAIA fixture",
+      "source_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+      "collection_status": "collected",
+      "non_claims": ["Expected-invalid topology evidence only."]
+    }
+  ],
+  "topology_context": {
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "evidence_ref": "evidence://gaia/topology/scope-d-example/blast-radius-invalid"
+  },
+  "blast_radius_context": {
+    "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-2002",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "status": "estimated"
+  },
+  "workroom_projection": {
+    "workroom_id": "workroom:devsecops:post-merge:scope-d-example-invalid-projection",
+    "source_refs": {
+      "incident_ref": "incident://pagerduty/scope-d-example/INC-2002",
+      "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-2002",
+      "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+      "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-2002"
+    },
+    "evidence_refs": [
+      "evidence://gaia/topology/scope-d-example/blast-radius-invalid",
+      "evidence://observability/scope-d-example/missing-projected-evidence"
+    ]
+  },
+  "non_claims": ["Expected-invalid fixture: projection references evidence not collected by InvestigationRun."]
+}

--- a/tests/fixtures/workroom/devsecops-investigation-run.ready-for-rca-without-collected-evidence.invalid.json
+++ b/tests/fixtures/workroom/devsecops-investigation-run.ready-for-rca-without-collected-evidence.invalid.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "0.1.0",
+  "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-2003",
+  "incident_ref": "incident://pagerduty/scope-d-example/INC-2003",
+  "lane": "post_merge_incident",
+  "authority_boundary": {
+    "investigation_authority": "prophet_platform",
+    "execution_authority": "external_connector",
+    "workroom_authority": "prophet_platform"
+  },
+  "status": "ready_for_rca",
+  "started_at": "2026-05-31T16:56:00Z",
+  "completed_at": "2026-05-31T16:58:00Z",
+  "evidence_collection": [
+    {
+      "evidence_ref": "evidence://gaia/topology/scope-d-example/not-collected",
+      "evidence_type": "topology_snapshot",
+      "source_system": "GAIA fixture",
+      "source_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+      "collection_status": "planned",
+      "non_claims": ["Expected-invalid planned evidence only."]
+    }
+  ],
+  "topology_context": {
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "evidence_ref": "evidence://gaia/topology/scope-d-example/not-collected"
+  },
+  "blast_radius_context": {
+    "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-2003",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "status": "estimated"
+  },
+  "workroom_projection": {
+    "workroom_id": "workroom:devsecops:post-merge:scope-d-example-invalid-ready",
+    "source_refs": {
+      "incident_ref": "incident://pagerduty/scope-d-example/INC-2003",
+      "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-2003",
+      "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+      "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-2003"
+    },
+    "evidence_refs": ["evidence://gaia/topology/scope-d-example/not-collected"]
+  },
+  "non_claims": ["Expected-invalid fixture: ready_for_rca cannot be projected without collected evidence."]
+}

--- a/tools/validate_devsecops_investigation_run.py
+++ b/tools/validate_devsecops_investigation_run.py
@@ -12,6 +12,18 @@ SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-investigation-run-v0.1.sch
 VALID_FIXTURES = [
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-investigation-run.post-merge.valid.json",
 ]
+INVALID_FIXTURES = {
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-investigation-run.missing-topology-evidence.invalid.json": [
+        "topology_context.topology_ref must be backed by topology_snapshot source_ref",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-investigation-run.projection-evidence-mismatch.invalid.json": [
+        "projection evidence_refs missing from evidence_collection",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-investigation-run.ready-for-rca-without-collected-evidence.invalid.json": [
+        "topology_context.evidence_ref must reference collected evidence",
+        "ready_for_rca requires at least one collected evidence item",
+    ],
+}
 
 
 def load(path: Path) -> dict[str, Any]:
@@ -82,6 +94,16 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
     return problems
 
 
+def assert_invalid_expectations(path: Path, problems: list[str], expected_substrings: list[str]) -> list[str]:
+    failures: list[str] = []
+    if not problems:
+        failures.append(f"{path}: expected invalid fixture to fail, but it passed")
+    for expected in expected_substrings:
+        if not any(expected in problem for problem in problems):
+            failures.append(f"{path}: expected invalid fixture problem containing {expected!r}")
+    return failures
+
+
 def main() -> int:
     schema = load(SCHEMA)
     failed = False
@@ -93,6 +115,20 @@ def main() -> int:
         failed = failed or bool(schema_errors or semantic_errors)
         results[str(path.relative_to(ROOT))] = {
             "expected": "valid",
+            "schema": schema_errors,
+            "semantic": semantic_errors,
+        }
+    for path, expected_substrings in INVALID_FIXTURES.items():
+        data = load(path)
+        schema_errors = schema_problems(schema, data)
+        semantic_errors = semantic_problems(data)
+        problems = schema_errors + semantic_errors
+        expectation_failures = assert_invalid_expectations(path.relative_to(ROOT), problems, expected_substrings)
+        failed = failed or bool(expectation_failures)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid",
+            "expected_problem_substrings": expected_substrings,
+            "expectation_failures": expectation_failures,
             "schema": schema_errors,
             "semantic": semantic_errors,
         }


### PR DESCRIPTION
## Summary

Adds expected-invalid coverage for the DevSecOps Workroom `InvestigationRun` validator.

This PR adds invalid fixtures for:

- topology context without topology snapshot backing evidence;
- Workroom projection referencing evidence not collected by the InvestigationRun;
- `ready_for_rca` state without collected evidence.

It also updates `tools/validate_devsecops_investigation_run.py` so invalid fixtures must fail for the expected governance reasons.

## Boundary

Contract and fixture validation only.

- No runtime command execution.
- No live incident investigation.
- No production remediation authorization.
- No RCA confirmation.
- No UI work.

Refs #519
Refs #520