### PR TITLE
test: add Workroom RCA and remediation evidence guards

### DIFF
--- a/tests/fixtures/workroom/devsecops-workroom.confirmed-claim-without-counterevidence.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.confirmed-claim-without-counterevidence.invalid.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:confirmed-claim-without-counterevidence",
+  "lane": "post_merge_incident",
+  "runtime_parity_level": "contract_only",
+  "source_refs": {
+    "incident_ref": "incident://pagerduty/scope-d-example/INC-3002",
+    "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-3002",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-3002"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:invalid-confirmed-claim-no-counterevidence",
+    "event_type": "production_incident",
+    "source_lane": "post_merge_incident",
+    "status": "investigating",
+    "summary": "Expected-invalid fixture for confirmed RCA claim counterevidence handling.",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "evidence_refs": [
+      "evidence://observability/scope-d-example/5xx-spike-invalid-confirmed",
+      "evidence://deployment/scope-d-example/recent-deploy-invalid-confirmed",
+      "evidence://gaia/topology/scope-d-example/blast-radius-invalid-confirmed"
+    ],
+    "claim_refs": ["rca-claim:scope-d-example:confirmed-without-counterevidence"],
+    "decision_state": "needs_review",
+    "non_claims": ["Expected-invalid fixture only."]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://observability/scope-d-example/5xx-spike-invalid-confirmed",
+      "evidence_type": "metric_observation",
+      "producer": "Fixture observability connector",
+      "summary": "Synthetic telemetry fixture.",
+      "observed_at": "2026-05-31T16:57:00Z",
+      "provenance": {"source_system": "observability-fixture", "source_ref": "metric://scope-d-example/api/5xx-rate", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    },
+    {
+      "evidence_ref": "evidence://deployment/scope-d-example/recent-deploy-invalid-confirmed",
+      "evidence_type": "deployment_metadata",
+      "producer": "Fixture deployment connector",
+      "summary": "Synthetic deployment metadata fixture.",
+      "observed_at": "2026-05-31T16:57:10Z",
+      "provenance": {"source_system": "deployment-fixture", "source_ref": "deploy://scope-d-example/api/2026-05-31T16:40:00Z", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    },
+    {
+      "evidence_ref": "evidence://gaia/topology/scope-d-example/blast-radius-invalid-confirmed",
+      "evidence_type": "topology_snapshot",
+      "producer": "GAIA topology fixture",
+      "summary": "Topology fixture.",
+      "observed_at": "2026-05-31T16:57:20Z",
+      "provenance": {"source_system": "GAIA fixture", "source_ref": "topology://gaia/workroom/scope-d-example/post-merge", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:scope-d-example:confirmed-without-counterevidence",
+      "claim_status": "confirmed_causal_claim",
+      "statement": "Expected-invalid confirmed claim omits counterevidence handling.",
+      "evidence_refs": [
+        "evidence://observability/scope-d-example/5xx-spike-invalid-confirmed",
+        "evidence://deployment/scope-d-example/recent-deploy-invalid-confirmed"
+      ],
+      "counterevidence_refs": [],
+      "confidence": "high",
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "action_grants": [
+    {"grant_id": "action-grant:scope-d-example:read-invalid-confirmed", "action_class": "read_only", "status": "allowed", "scope": "Read expected-invalid fixture evidence.", "approval_required": false, "non_claims": ["Read-only fixture grant."]}
+  ],
+  "remediation_plans": [],
+  "regression_fixtures": [
+    {"fixture_id": "regression-fixture:scope-d-example:invalid-confirmed-no-counterevidence", "fixture_status": "candidate", "derived_from": "bde:production-incident:invalid-confirmed-claim-no-counterevidence", "summary": "Expected-invalid candidate only.", "target_validation_plan_ref": "validation-plan://scope-d-example/invalid-confirmed-no-counterevidence", "non_claims": ["Candidate only."]}
+  ],
+  "issued_at": "2026-05-31T16:58:00Z",
+  "non_claims": ["Expected-invalid fixture only."]
+}

--- a/tests/fixtures/workroom/devsecops-workroom.rca-claim-missing-evidence-ref.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.rca-claim-missing-evidence-ref.invalid.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:rca-missing-evidence-ref",
+  "lane": "post_merge_incident",
+  "runtime_parity_level": "contract_only",
+  "source_refs": {
+    "incident_ref": "incident://pagerduty/scope-d-example/INC-3001",
+    "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-3001",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-3001"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:invalid-rca-missing-evidence-ref",
+    "event_type": "production_incident",
+    "source_lane": "post_merge_incident",
+    "status": "investigating",
+    "summary": "Expected-invalid fixture for RCA evidence binding.",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "evidence_refs": ["evidence://gaia/topology/scope-d-example/blast-radius-invalid-rca"],
+    "claim_refs": ["rca-claim:scope-d-example:missing-evidence-ref"],
+    "decision_state": "needs_review",
+    "non_claims": ["Expected-invalid fixture only."]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://gaia/topology/scope-d-example/blast-radius-invalid-rca",
+      "evidence_type": "topology_snapshot",
+      "producer": "GAIA topology fixture",
+      "summary": "Topology fixture for expected-invalid RCA evidence binding.",
+      "observed_at": "2026-05-31T16:57:20Z",
+      "provenance": {
+        "source_system": "GAIA fixture",
+        "source_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+        "collection_method": "synthetic_fixture"
+      },
+      "non_claims": ["Topology supports fixture validation only."]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:scope-d-example:missing-evidence-ref",
+      "claim_status": "supported_causal_claim",
+      "statement": "Expected-invalid RCA claim references evidence absent from the evidence packet set.",
+      "evidence_refs": ["evidence://observability/scope-d-example/not-present"],
+      "counterevidence_refs": [],
+      "confidence": "medium",
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "action_grants": [
+    {
+      "grant_id": "action-grant:scope-d-example:read-invalid-rca",
+      "action_class": "read_only",
+      "status": "allowed",
+      "scope": "Read expected-invalid fixture evidence.",
+      "approval_required": false,
+      "non_claims": ["Read-only fixture grant."]
+    }
+  ],
+  "remediation_plans": [],
+  "regression_fixtures": [
+    {
+      "fixture_id": "regression-fixture:scope-d-example:invalid-rca-missing-evidence-ref",
+      "fixture_status": "candidate",
+      "derived_from": "bde:production-incident:invalid-rca-missing-evidence-ref",
+      "summary": "Expected-invalid candidate only.",
+      "target_validation_plan_ref": "validation-plan://scope-d-example/invalid-rca-missing-evidence-ref",
+      "non_claims": ["Candidate only."]
+    }
+  ],
+  "issued_at": "2026-05-31T16:58:00Z",
+  "non_claims": ["Expected-invalid fixture only."]
+}

--- a/tests/fixtures/workroom/devsecops-workroom.remediation-disconnected-from-causal-evidence.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.remediation-disconnected-from-causal-evidence.invalid.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:remediation-disconnected-from-causal-evidence",
+  "lane": "post_merge_incident",
+  "runtime_parity_level": "contract_only",
+  "source_refs": {
+    "incident_ref": "incident://pagerduty/scope-d-example/INC-3003",
+    "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-3003",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-3003"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:invalid-remediation-disconnected",
+    "event_type": "production_incident",
+    "source_lane": "post_merge_incident",
+    "status": "investigating",
+    "summary": "Expected-invalid fixture for remediation-to-RCA evidence linkage.",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "evidence_refs": [
+      "evidence://observability/scope-d-example/5xx-spike-invalid-remediation",
+      "evidence://deployment/scope-d-example/recent-deploy-invalid-remediation",
+      "evidence://runbook/scope-d-example/unrelated-remediation-note",
+      "evidence://gaia/topology/scope-d-example/blast-radius-invalid-remediation"
+    ],
+    "claim_refs": ["rca-claim:scope-d-example:recent-deploy-supported-invalid-remediation"],
+    "decision_state": "needs_review",
+    "non_claims": ["Expected-invalid fixture only."]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://observability/scope-d-example/5xx-spike-invalid-remediation",
+      "evidence_type": "metric_observation",
+      "producer": "Fixture observability connector",
+      "summary": "Synthetic telemetry fixture.",
+      "observed_at": "2026-05-31T16:57:00Z",
+      "provenance": {"source_system": "observability-fixture", "source_ref": "metric://scope-d-example/api/5xx-rate", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    },
+    {
+      "evidence_ref": "evidence://deployment/scope-d-example/recent-deploy-invalid-remediation",
+      "evidence_type": "deployment_metadata",
+      "producer": "Fixture deployment connector",
+      "summary": "Synthetic deployment metadata fixture.",
+      "observed_at": "2026-05-31T16:57:10Z",
+      "provenance": {"source_system": "deployment-fixture", "source_ref": "deploy://scope-d-example/api/2026-05-31T16:40:00Z", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    },
+    {
+      "evidence_ref": "evidence://runbook/scope-d-example/unrelated-remediation-note",
+      "evidence_type": "runbook_excerpt",
+      "producer": "Fixture runbook connector",
+      "summary": "Synthetic unrelated remediation note.",
+      "observed_at": "2026-05-31T16:57:15Z",
+      "provenance": {"source_system": "runbook-fixture", "source_ref": "runbook://scope-d-example/unrelated", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    },
+    {
+      "evidence_ref": "evidence://gaia/topology/scope-d-example/blast-radius-invalid-remediation",
+      "evidence_type": "topology_snapshot",
+      "producer": "GAIA topology fixture",
+      "summary": "Topology fixture.",
+      "observed_at": "2026-05-31T16:57:20Z",
+      "provenance": {"source_system": "GAIA fixture", "source_ref": "topology://gaia/workroom/scope-d-example/post-merge", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:scope-d-example:recent-deploy-supported-invalid-remediation",
+      "claim_status": "supported_causal_claim",
+      "statement": "Expected-invalid supported claim uses telemetry and deployment evidence.",
+      "evidence_refs": [
+        "evidence://observability/scope-d-example/5xx-spike-invalid-remediation",
+        "evidence://deployment/scope-d-example/recent-deploy-invalid-remediation"
+      ],
+      "counterevidence_refs": [],
+      "confidence": "medium",
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "action_grants": [
+    {"grant_id": "action-grant:scope-d-example:rollback-invalid-remediation", "action_class": "production_change", "status": "requires_human_approval", "scope": "Expected-invalid remediation gate.", "approval_required": true, "non_claims": ["Fixture grant only."]}
+  ],
+  "remediation_plans": [
+    {
+      "plan_id": "remediation-plan:scope-d-example:disconnected-candidate",
+      "plan_status": "candidate",
+      "risk_class": "high",
+      "summary": "Expected-invalid candidate uses unrelated runbook evidence only.",
+      "evidence_refs": ["evidence://runbook/scope-d-example/unrelated-remediation-note"],
+      "required_action_grant_refs": ["action-grant:scope-d-example:rollback-invalid-remediation"],
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "regression_fixtures": [
+    {"fixture_id": "regression-fixture:scope-d-example:invalid-remediation-disconnected", "fixture_status": "candidate", "derived_from": "bde:production-incident:invalid-remediation-disconnected", "summary": "Expected-invalid candidate only.", "target_validation_plan_ref": "validation-plan://scope-d-example/invalid-remediation-disconnected", "non_claims": ["Candidate only."]}
+  ],
+  "issued_at": "2026-05-31T16:58:00Z",
+  "non_claims": ["Expected-invalid fixture only."]
+}

--- a/tools/validate_devsecops_workroom.py
+++ b/tools/validate_devsecops_workroom.py
@@ -44,6 +44,15 @@ INVALID_FIXTURES = {
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.credential-sensitive-allowed.invalid.json": [
         "credential-sensitive actions must escalate rather than be allowed",
     ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.rca-claim-missing-evidence-ref.invalid.json": [
+        "references missing evidence ref",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.confirmed-claim-without-counterevidence.invalid.json": [
+        "confirmed causal claims require counterevidence handling",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.remediation-disconnected-from-causal-evidence.invalid.json": [
+        "high/critical remediation evidence must overlap causal claim evidence",
+    ],
 }
 
 CLAIM_STATUSES = {
@@ -193,6 +202,7 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
     evidence_refs = ref_set(evidence_packets, "evidence_ref") if isinstance(evidence_packets, list) else set()
     claim_ids = ref_set(claims, "claim_id") if isinstance(claims, list) else set()
     grant_ids = ref_set(action_grants, "grant_id") if isinstance(action_grants, list) else set()
+    causal_evidence_refs: set[str] = set()
 
     if not evidence_refs:
         problems.append("at least one evidence packet is required")
@@ -217,6 +227,8 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
             problems.append(f"{claim_id}: invalid claim_status")
         if status in CAUSAL_STATUSES and not refs:
             problems.append(f"{claim_id}: causal claims require evidence refs")
+        if status in CAUSAL_STATUSES and isinstance(refs, list):
+            causal_evidence_refs.update(str(ref) for ref in refs)
         if status == "confirmed_causal_claim" and not counterrefs:
             problems.append(f"{claim_id}: confirmed causal claims require counterevidence handling")
         if status == "unknown" and confidence != "none":
@@ -244,8 +256,11 @@ def semantic_problems(data: dict[str, Any]) -> list[str]:
         plan_id = plan.get("plan_id")
         risk_class = plan.get("risk_class")
         required_grants = plan.get("required_action_grant_refs", [])
+        plan_evidence = set(str(ref) for ref in plan.get("evidence_refs", []) if isinstance(ref, str))
         if risk_class in HIGH_RISK_PLAN_CLASSES and not required_grants:
             problems.append(f"{plan_id}: high/critical remediation requires action grant refs")
+        if risk_class in HIGH_RISK_PLAN_CLASSES and plan_evidence and causal_evidence_refs and not plan_evidence.intersection(causal_evidence_refs):
+            problems.append(f"{plan_id}: high/critical remediation evidence must overlap causal claim evidence")
         for ref in required_grants:
             if ref not in grant_ids:
                 problems.append(f"{plan_id}: references missing action grant {ref}")


### PR DESCRIPTION
Superseded by PR #572.

Reason: the original branch became stale after `main` advanced. Functional checks for #570 were green, but `premerge-audit` failed due to stale base. PR #572 replays the same RCA/remediation fixture intent on a fresher base and uses a dedicated RCA guard validator/workflow instead of replacing the broad Workroom validator.