### PR TITLE
test: add Workroom RCA evidence guard workflow

### DIFF
--- a/.github/workflows/devsecops-workroom-rca-guards.yml
+++ b/.github/workflows/devsecops-workroom-rca-guards.yml
@@ -1,0 +1,33 @@
+name: devsecops-workroom-rca-guards
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'contracts/workroom/**'
+      - 'tests/fixtures/workroom/**'
+      - 'tools/validate_devsecops_workroom.py'
+      - 'tools/validate_devsecops_workroom_rca_guards.py'
+      - '.github/workflows/devsecops-workroom-rca-guards.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'contracts/workroom/**'
+      - 'tests/fixtures/workroom/**'
+      - 'tools/validate_devsecops_workroom.py'
+      - 'tools/validate_devsecops_workroom_rca_guards.py'
+      - '.github/workflows/devsecops-workroom-rca-guards.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install fixture validation dependencies
+        run: python -m pip install jsonschema==4.23.0
+      - name: Validate Workroom RCA guards
+        run: python tools/validate_devsecops_workroom_rca_guards.py

--- a/tests/fixtures/workroom/devsecops-workroom.confirmed-claim-without-counterevidence.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.confirmed-claim-without-counterevidence.invalid.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:confirmed-claim-without-counterevidence",
+  "lane": "post_merge_incident",
+  "runtime_parity_level": "contract_only",
+  "source_refs": {
+    "incident_ref": "incident://pagerduty/scope-d-example/INC-3002",
+    "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-3002",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-3002"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:invalid-confirmed-claim-no-counterevidence",
+    "event_type": "production_incident",
+    "source_lane": "post_merge_incident",
+    "status": "investigating",
+    "summary": "Expected-invalid fixture for confirmed RCA claim counterevidence handling.",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "evidence_refs": [
+      "evidence://observability/scope-d-example/5xx-spike-invalid-confirmed",
+      "evidence://deployment/scope-d-example/recent-deploy-invalid-confirmed",
+      "evidence://gaia/topology/scope-d-example/blast-radius-invalid-confirmed"
+    ],
+    "claim_refs": ["rca-claim:scope-d-example:confirmed-without-counterevidence"],
+    "decision_state": "needs_review",
+    "non_claims": ["Expected-invalid fixture only."]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://observability/scope-d-example/5xx-spike-invalid-confirmed",
+      "evidence_type": "metric_observation",
+      "producer": "Fixture observability connector",
+      "summary": "Synthetic telemetry fixture.",
+      "observed_at": "2026-05-31T16:57:00Z",
+      "provenance": {"source_system": "observability-fixture", "source_ref": "metric://scope-d-example/api/5xx-rate", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    },
+    {
+      "evidence_ref": "evidence://deployment/scope-d-example/recent-deploy-invalid-confirmed",
+      "evidence_type": "deployment_metadata",
+      "producer": "Fixture deployment connector",
+      "summary": "Synthetic deployment metadata fixture.",
+      "observed_at": "2026-05-31T16:57:10Z",
+      "provenance": {"source_system": "deployment-fixture", "source_ref": "deploy://scope-d-example/api/2026-05-31T16:40:00Z", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    },
+    {
+      "evidence_ref": "evidence://gaia/topology/scope-d-example/blast-radius-invalid-confirmed",
+      "evidence_type": "topology_snapshot",
+      "producer": "GAIA topology fixture",
+      "summary": "Topology fixture.",
+      "observed_at": "2026-05-31T16:57:20Z",
+      "provenance": {"source_system": "GAIA fixture", "source_ref": "topology://gaia/workroom/scope-d-example/post-merge", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:scope-d-example:confirmed-without-counterevidence",
+      "claim_status": "confirmed_causal_claim",
+      "statement": "Expected-invalid confirmed claim omits counterevidence handling.",
+      "evidence_refs": [
+        "evidence://observability/scope-d-example/5xx-spike-invalid-confirmed",
+        "evidence://deployment/scope-d-example/recent-deploy-invalid-confirmed"
+      ],
+      "counterevidence_refs": [],
+      "confidence": "high",
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "action_grants": [
+    {"grant_id": "action-grant:scope-d-example:read-invalid-confirmed", "action_class": "read_only", "status": "allowed", "scope": "Read expected-invalid fixture evidence.", "approval_required": false, "non_claims": ["Read-only fixture grant."]}
+  ],
+  "remediation_plans": [],
+  "regression_fixtures": [
+    {"fixture_id": "regression-fixture:scope-d-example:invalid-confirmed-no-counterevidence", "fixture_status": "candidate", "derived_from": "bde:production-incident:invalid-confirmed-claim-no-counterevidence", "summary": "Expected-invalid candidate only.", "target_validation_plan_ref": "validation-plan://scope-d-example/invalid-confirmed-no-counterevidence", "non_claims": ["Candidate only."]}
+  ],
+  "issued_at": "2026-05-31T16:58:00Z",
+  "non_claims": ["Expected-invalid fixture only."]
+}

--- a/tests/fixtures/workroom/devsecops-workroom.rca-claim-missing-evidence-ref.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.rca-claim-missing-evidence-ref.invalid.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:rca-missing-evidence-ref",
+  "lane": "post_merge_incident",
+  "runtime_parity_level": "contract_only",
+  "source_refs": {
+    "incident_ref": "incident://pagerduty/scope-d-example/INC-3001",
+    "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-3001",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-3001"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:invalid-rca-missing-evidence-ref",
+    "event_type": "production_incident",
+    "source_lane": "post_merge_incident",
+    "status": "investigating",
+    "summary": "Expected-invalid fixture for RCA evidence binding.",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "evidence_refs": ["evidence://gaia/topology/scope-d-example/blast-radius-invalid-rca"],
+    "claim_refs": ["rca-claim:scope-d-example:missing-evidence-ref"],
+    "decision_state": "needs_review",
+    "non_claims": ["Expected-invalid fixture only."]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://gaia/topology/scope-d-example/blast-radius-invalid-rca",
+      "evidence_type": "topology_snapshot",
+      "producer": "GAIA topology fixture",
+      "summary": "Topology fixture for expected-invalid RCA evidence binding.",
+      "observed_at": "2026-05-31T16:57:20Z",
+      "provenance": {
+        "source_system": "GAIA fixture",
+        "source_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+        "collection_method": "synthetic_fixture"
+      },
+      "non_claims": ["Topology supports fixture validation only."]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:scope-d-example:missing-evidence-ref",
+      "claim_status": "supported_causal_claim",
+      "statement": "Expected-invalid RCA claim references evidence absent from the evidence packet set.",
+      "evidence_refs": ["evidence://observability/scope-d-example/not-present"],
+      "counterevidence_refs": [],
+      "confidence": "medium",
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "action_grants": [
+    {
+      "grant_id": "action-grant:scope-d-example:read-invalid-rca",
+      "action_class": "read_only",
+      "status": "allowed",
+      "scope": "Read expected-invalid fixture evidence.",
+      "approval_required": false,
+      "non_claims": ["Read-only fixture grant."]
+    }
+  ],
+  "remediation_plans": [],
+  "regression_fixtures": [
+    {
+      "fixture_id": "regression-fixture:scope-d-example:invalid-rca-missing-evidence-ref",
+      "fixture_status": "candidate",
+      "derived_from": "bde:production-incident:invalid-rca-missing-evidence-ref",
+      "summary": "Expected-invalid candidate only.",
+      "target_validation_plan_ref": "validation-plan://scope-d-example/invalid-rca-missing-evidence-ref",
+      "non_claims": ["Candidate only."]
+    }
+  ],
+  "issued_at": "2026-05-31T16:58:00Z",
+  "non_claims": ["Expected-invalid fixture only."]
+}

--- a/tests/fixtures/workroom/devsecops-workroom.remediation-disconnected-from-causal-evidence.invalid.json
+++ b/tests/fixtures/workroom/devsecops-workroom.remediation-disconnected-from-causal-evidence.invalid.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:remediation-disconnected-from-causal-evidence",
+  "lane": "post_merge_incident",
+  "runtime_parity_level": "contract_only",
+  "source_refs": {
+    "incident_ref": "incident://pagerduty/scope-d-example/INC-3003",
+    "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-3003",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-3003"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:invalid-remediation-disconnected",
+    "event_type": "production_incident",
+    "source_lane": "post_merge_incident",
+    "status": "investigating",
+    "summary": "Expected-invalid fixture for remediation-to-RCA evidence linkage.",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "evidence_refs": [
+      "evidence://observability/scope-d-example/5xx-spike-invalid-remediation",
+      "evidence://deployment/scope-d-example/recent-deploy-invalid-remediation",
+      "evidence://runbook/scope-d-example/unrelated-remediation-note",
+      "evidence://gaia/topology/scope-d-example/blast-radius-invalid-remediation"
+    ],
+    "claim_refs": ["rca-claim:scope-d-example:recent-deploy-supported-invalid-remediation"],
+    "decision_state": "needs_review",
+    "non_claims": ["Expected-invalid fixture only."]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://observability/scope-d-example/5xx-spike-invalid-remediation",
+      "evidence_type": "metric_observation",
+      "producer": "Fixture observability connector",
+      "summary": "Synthetic telemetry fixture.",
+      "observed_at": "2026-05-31T16:57:00Z",
+      "provenance": {"source_system": "observability-fixture", "source_ref": "metric://scope-d-example/api/5xx-rate", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    },
+    {
+      "evidence_ref": "evidence://deployment/scope-d-example/recent-deploy-invalid-remediation",
+      "evidence_type": "deployment_metadata",
+      "producer": "Fixture deployment connector",
+      "summary": "Synthetic deployment metadata fixture.",
+      "observed_at": "2026-05-31T16:57:10Z",
+      "provenance": {"source_system": "deployment-fixture", "source_ref": "deploy://scope-d-example/api/2026-05-31T16:40:00Z", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    },
+    {
+      "evidence_ref": "evidence://runbook/scope-d-example/unrelated-remediation-note",
+      "evidence_type": "runbook_excerpt",
+      "producer": "Fixture runbook connector",
+      "summary": "Synthetic unrelated remediation note.",
+      "observed_at": "2026-05-31T16:57:15Z",
+      "provenance": {"source_system": "runbook-fixture", "source_ref": "runbook://scope-d-example/unrelated", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    },
+    {
+      "evidence_ref": "evidence://gaia/topology/scope-d-example/blast-radius-invalid-remediation",
+      "evidence_type": "topology_snapshot",
+      "producer": "GAIA topology fixture",
+      "summary": "Topology fixture.",
+      "observed_at": "2026-05-31T16:57:20Z",
+      "provenance": {"source_system": "GAIA fixture", "source_ref": "topology://gaia/workroom/scope-d-example/post-merge", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:scope-d-example:recent-deploy-supported-invalid-remediation",
+      "claim_status": "supported_causal_claim",
+      "statement": "Expected-invalid supported claim uses telemetry and deployment evidence.",
+      "evidence_refs": [
+        "evidence://observability/scope-d-example/5xx-spike-invalid-remediation",
+        "evidence://deployment/scope-d-example/recent-deploy-invalid-remediation"
+      ],
+      "counterevidence_refs": [],
+      "confidence": "medium",
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "action_grants": [
+    {"grant_id": "action-grant:scope-d-example:rollback-invalid-remediation", "action_class": "production_change", "status": "requires_human_approval", "scope": "Expected-invalid remediation gate.", "approval_required": true, "non_claims": ["Fixture grant only."]}
+  ],
+  "remediation_plans": [
+    {
+      "plan_id": "remediation-plan:scope-d-example:disconnected-candidate",
+      "plan_status": "candidate",
+      "risk_class": "high",
+      "summary": "Expected-invalid candidate uses unrelated runbook evidence only.",
+      "evidence_refs": ["evidence://runbook/scope-d-example/unrelated-remediation-note"],
+      "required_action_grant_refs": ["action-grant:scope-d-example:rollback-invalid-remediation"],
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "regression_fixtures": [
+    {"fixture_id": "regression-fixture:scope-d-example:invalid-remediation-disconnected", "fixture_status": "candidate", "derived_from": "bde:production-incident:invalid-remediation-disconnected", "summary": "Expected-invalid candidate only.", "target_validation_plan_ref": "validation-plan://scope-d-example/invalid-remediation-disconnected", "non_claims": ["Candidate only."]}
+  ],
+  "issued_at": "2026-05-31T16:58:00Z",
+  "non_claims": ["Expected-invalid fixture only."]
+}

--- a/tools/validate_devsecops_workroom_rca_guards.py
+++ b/tools/validate_devsecops_workroom_rca_guards.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import validate_devsecops_workroom as base  # noqa: E402
+
+FIXTURES = {
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.rca-claim-missing-evidence-ref.invalid.json": [
+        "references missing evidence ref",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.confirmed-claim-without-counterevidence.invalid.json": [
+        "confirmed causal claims require counterevidence handling",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.remediation-disconnected-from-causal-evidence.invalid.json": [
+        "remediation evidence must overlap causal claim evidence",
+    ],
+}
+CAUSAL_STATUSES = {"supported_causal_claim", "confirmed_causal_claim"}
+HIGH_RISK_PLAN_CLASSES = {"high", "critical"}
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected object: {path}")
+    return data
+
+
+def rca_linkage_problems(data: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    claims = data.get("rca_claims", [])
+    plans = data.get("remediation_plans", [])
+    causal_evidence: set[str] = set()
+    for claim in claims if isinstance(claims, list) else []:
+        if not isinstance(claim, dict):
+            continue
+        if claim.get("claim_status") in CAUSAL_STATUSES:
+            causal_evidence.update(str(ref) for ref in claim.get("evidence_refs", []) if isinstance(ref, str))
+    for plan in plans if isinstance(plans, list) else []:
+        if not isinstance(plan, dict):
+            continue
+        if plan.get("risk_class") not in HIGH_RISK_PLAN_CLASSES:
+            continue
+        plan_evidence = {str(ref) for ref in plan.get("evidence_refs", []) if isinstance(ref, str)}
+        if plan_evidence and causal_evidence and not plan_evidence.intersection(causal_evidence):
+            problems.append(f"{plan.get('plan_id')}: remediation evidence must overlap causal claim evidence")
+    return problems
+
+
+def expect(path: Path, problems: list[str], expected_substrings: list[str]) -> list[str]:
+    failures: list[str] = []
+    if not problems:
+        failures.append(f"{path}: expected invalid fixture to fail, but it passed")
+    for expected in expected_substrings:
+        if not any(expected in problem for problem in problems):
+            failures.append(f"{path}: expected problem containing {expected!r}")
+    return failures
+
+
+def main() -> int:
+    schema = base.load(base.SCHEMA)
+    failed = False
+    results: dict[str, dict[str, Any]] = {}
+    for path, expected in FIXTURES.items():
+        data = load(path)
+        schema_errors = base.schema_problems(schema, data)
+        semantic_errors = base.semantic_problems(data)
+        linkage_errors = rca_linkage_problems(data)
+        problems = schema_errors + semantic_errors + linkage_errors
+        failures = expect(path.relative_to(ROOT), problems, expected)
+        failed = failed or bool(failures)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid",
+            "expected_problem_substrings": expected,
+            "expectation_failures": failures,
+            "schema": schema_errors,
+            "semantic": semantic_errors,
+            "rca_linkage": linkage_errors,
+        }
+    report = {
+        "validator": "prophet-platform.devsecops-workroom-rca-guards.validator.v1",
+        "passed": not failed,
+        "results": results,
+        "non_claims": [
+            "Validator checks fixture-scoped RCA evidence linkage.",
+            "Validator performs no runtime operations.",
+            "Validator makes no root-cause finding."
+        ],
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(("PASS" if not failed else "FAIL") + ": devsecops workroom RCA guards")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Replacement for #572 after `main` advanced again.

Adds expected-invalid coverage for Aurora-style RCA and remediation evidence linkage in the DevSecOps Workroom without replacing the broad Workroom validator.

This PR adds invalid fixtures for:

- RCA claim references to missing evidence;
- confirmed causal claims without counterevidence handling;
- high-risk remediation whose evidence is disconnected from causal RCA evidence.

It also adds a dedicated RCA guard validator and workflow:

- `tools/validate_devsecops_workroom_rca_guards.py`
- `.github/workflows/devsecops-workroom-rca-guards.yml`

## Boundary

Contract and fixture validation only.

- No runtime command execution.
- No live incident investigation.
- No production remediation authorization.
- No RCA confirmation.
- No UI work.

Refs #519
Refs #520
Supersedes #572