### PR TITLE
test: add DevSecOps regression promotion guards

### DIFF
--- a/.github/workflows/devsecops-regression-promotion.yml
+++ b/.github/workflows/devsecops-regression-promotion.yml
@@ -1,0 +1,33 @@
+name: devsecops-regression-promotion
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'contracts/workroom/**'
+      - 'tests/fixtures/workroom/**'
+      - 'tools/validate_devsecops_workroom.py'
+      - 'tools/validate_devsecops_regression_promotion.py'
+      - '.github/workflows/devsecops-regression-promotion.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'contracts/workroom/**'
+      - 'tests/fixtures/workroom/**'
+      - 'tools/validate_devsecops_workroom.py'
+      - 'tools/validate_devsecops_regression_promotion.py'
+      - '.github/workflows/devsecops-regression-promotion.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install fixture validation dependencies
+        run: python -m pip install jsonschema==4.23.0
+      - name: Validate DevSecOps regression promotion
+        run: python tools/validate_devsecops_regression_promotion.py

--- a/tests/fixtures/workroom/devsecops-regression-promotion.unbacked-regression-candidate.invalid.json
+++ b/tests/fixtures/workroom/devsecops-regression-promotion.unbacked-regression-candidate.invalid.json
@@ -1,0 +1,74 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:regression-unbacked-candidate",
+  "lane": "post_merge_incident",
+  "runtime_parity_level": "contract_only",
+  "source_refs": {
+    "incident_ref": "incident://pagerduty/scope-d-example/INC-4001",
+    "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-4001",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-4001"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:invalid-regression-unbacked",
+    "event_type": "production_incident",
+    "source_lane": "post_merge_incident",
+    "status": "investigating",
+    "summary": "Expected-invalid fixture for regression promotion lineage.",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "evidence_refs": [
+      "evidence://observability/scope-d-example/5xx-spike-invalid-regression",
+      "evidence://gaia/topology/scope-d-example/blast-radius-invalid-regression"
+    ],
+    "claim_refs": ["rca-claim:scope-d-example:regression-supported-causal"],
+    "decision_state": "needs_review",
+    "non_claims": ["Expected-invalid fixture only."]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://observability/scope-d-example/5xx-spike-invalid-regression",
+      "evidence_type": "metric_observation",
+      "producer": "Fixture observability connector",
+      "summary": "Synthetic telemetry fixture.",
+      "observed_at": "2026-05-31T16:57:00Z",
+      "provenance": {"source_system": "observability-fixture", "source_ref": "metric://scope-d-example/api/5xx-rate", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    },
+    {
+      "evidence_ref": "evidence://gaia/topology/scope-d-example/blast-radius-invalid-regression",
+      "evidence_type": "topology_snapshot",
+      "producer": "GAIA topology fixture",
+      "summary": "Topology fixture.",
+      "observed_at": "2026-05-31T16:57:20Z",
+      "provenance": {"source_system": "GAIA fixture", "source_ref": "topology://gaia/workroom/scope-d-example/post-merge", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:scope-d-example:regression-supported-causal",
+      "claim_status": "supported_causal_claim",
+      "statement": "Expected-invalid supported causal claim for regression promotion lineage.",
+      "evidence_refs": ["evidence://observability/scope-d-example/5xx-spike-invalid-regression"],
+      "counterevidence_refs": [],
+      "confidence": "medium",
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "action_grants": [
+    {"grant_id": "action-grant:scope-d-example:read-invalid-regression", "action_class": "read_only", "status": "allowed", "scope": "Read expected-invalid fixture evidence.", "approval_required": false, "non_claims": ["Read-only fixture grant."]}
+  ],
+  "remediation_plans": [],
+  "regression_fixtures": [
+    {
+      "fixture_id": "regression-fixture:scope-d-example:invalid-unbacked-candidate",
+      "fixture_status": "candidate",
+      "derived_from": "evidence://observability/scope-d-example/5xx-spike-invalid-regression",
+      "summary": "Expected-invalid candidate derives directly from evidence instead of BDE or RCA claim.",
+      "target_validation_plan_ref": "validation-plan://scope-d-example/invalid-unbacked-regression",
+      "non_claims": ["Candidate only."]
+    }
+  ],
+  "issued_at": "2026-05-31T16:58:00Z",
+  "non_claims": ["Expected-invalid fixture only."]
+}

--- a/tests/fixtures/workroom/devsecops-regression-promotion.validation-plan-unpromoted-fixture.invalid.json
+++ b/tests/fixtures/workroom/devsecops-regression-promotion.validation-plan-unpromoted-fixture.invalid.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "0.1.0",
+  "workroom_id": "workroom:devsecops:invalid:validation-plan-unpromoted-fixture",
+  "lane": "post_merge_incident",
+  "runtime_parity_level": "contract_only",
+  "source_refs": {
+    "incident_ref": "incident://pagerduty/scope-d-example/INC-4002",
+    "investigation_run_ref": "investigation-run://prophet-platform/scope-d-example/INC-4002",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-4002"
+  },
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:invalid-plan-unpromoted-fixture",
+    "event_type": "production_incident",
+    "source_lane": "post_merge_incident",
+    "status": "investigating",
+    "summary": "Expected-invalid fixture for validation plan promotion linkage.",
+    "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+    "evidence_refs": [
+      "evidence://observability/scope-d-example/5xx-spike-invalid-plan",
+      "evidence://gaia/topology/scope-d-example/blast-radius-invalid-plan"
+    ],
+    "claim_refs": ["rca-claim:scope-d-example:plan-supported-causal"],
+    "decision_state": "needs_review",
+    "non_claims": ["Expected-invalid fixture only."]
+  },
+  "evidence_packets": [
+    {
+      "evidence_ref": "evidence://observability/scope-d-example/5xx-spike-invalid-plan",
+      "evidence_type": "metric_observation",
+      "producer": "Fixture observability connector",
+      "summary": "Synthetic telemetry fixture.",
+      "observed_at": "2026-05-31T16:57:00Z",
+      "provenance": {"source_system": "observability-fixture", "source_ref": "metric://scope-d-example/api/5xx-rate", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    },
+    {
+      "evidence_ref": "evidence://gaia/topology/scope-d-example/blast-radius-invalid-plan",
+      "evidence_type": "topology_snapshot",
+      "producer": "GAIA topology fixture",
+      "summary": "Topology fixture.",
+      "observed_at": "2026-05-31T16:57:20Z",
+      "provenance": {"source_system": "GAIA fixture", "source_ref": "topology://gaia/workroom/scope-d-example/post-merge", "collection_method": "synthetic_fixture"},
+      "non_claims": ["Fixture evidence only."]
+    }
+  ],
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:scope-d-example:plan-supported-causal",
+      "claim_status": "supported_causal_claim",
+      "statement": "Expected-invalid supported causal claim for validation-plan promotion linkage.",
+      "evidence_refs": ["evidence://observability/scope-d-example/5xx-spike-invalid-plan"],
+      "counterevidence_refs": [],
+      "confidence": "medium",
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "action_grants": [
+    {"grant_id": "action-grant:scope-d-example:read-invalid-plan", "action_class": "read_only", "status": "allowed", "scope": "Read expected-invalid fixture evidence.", "approval_required": false, "non_claims": ["Read-only fixture grant."]}
+  ],
+  "remediation_plans": [],
+  "regression_fixtures": [
+    {
+      "fixture_id": "regression-fixture:scope-d-example:invalid-candidate-for-promoted-plan",
+      "fixture_status": "candidate",
+      "derived_from": "rca-claim:scope-d-example:plan-supported-causal",
+      "summary": "Expected-invalid candidate referenced by promoted validation plan.",
+      "target_validation_plan_ref": "validation-plan://scope-d-example/invalid-promoted-plan",
+      "non_claims": ["Candidate only."]
+    }
+  ],
+  "validation_plans": [
+    {
+      "plan_id": "validation-plan://scope-d-example/invalid-promoted-plan",
+      "plan_status": "promoted",
+      "regression_fixture_refs": ["regression-fixture:scope-d-example:invalid-candidate-for-promoted-plan"],
+      "non_claims": ["Expected-invalid plan object only."]
+    }
+  ],
+  "issued_at": "2026-05-31T16:58:00Z",
+  "non_claims": ["Expected-invalid fixture only."]
+}

--- a/tools/validate_devsecops_regression_promotion.py
+++ b/tools/validate_devsecops_regression_promotion.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import validate_devsecops_workroom as workroom  # noqa: E402
+
+VALID_FIXTURES = [
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.post-merge-incident.valid.json",
+]
+INVALID_FIXTURES = {
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-regression-promotion.unbacked-regression-candidate.invalid.json": [
+        "regression fixture derived_from must reference the behavioral divergence event or an RCA claim",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-regression-promotion.validation-plan-unpromoted-fixture.invalid.json": [
+        "promoted validation plan cannot reference candidate regression fixture",
+    ],
+}
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected object: {path}")
+    return data
+
+
+def promotion_problems(data: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    bde = data.get("behavioral_divergence_event", {})
+    event_id = bde.get("event_id") if isinstance(bde, dict) else None
+    claim_ids = {
+        str(claim.get("claim_id"))
+        for claim in data.get("rca_claims", [])
+        if isinstance(claim, dict) and claim.get("claim_id")
+    }
+    regression_fixtures = data.get("regression_fixtures", [])
+    validation_plans = data.get("validation_plans", [])
+    fixture_status_by_id: dict[str, str] = {}
+
+    for fixture in regression_fixtures if isinstance(regression_fixtures, list) else []:
+        if not isinstance(fixture, dict):
+            continue
+        fixture_id = str(fixture.get("fixture_id", ""))
+        fixture_status = str(fixture.get("fixture_status", ""))
+        fixture_status_by_id[fixture_id] = fixture_status
+        derived_from = str(fixture.get("derived_from", ""))
+        if derived_from != event_id and derived_from not in claim_ids:
+            problems.append(
+                f"{fixture_id}: regression fixture derived_from must reference the behavioral divergence event or an RCA claim"
+            )
+
+    for plan in validation_plans if isinstance(validation_plans, list) else []:
+        if not isinstance(plan, dict):
+            continue
+        plan_id = str(plan.get("plan_id", ""))
+        plan_status = str(plan.get("plan_status", ""))
+        for ref in plan.get("regression_fixture_refs", []):
+            status = fixture_status_by_id.get(str(ref))
+            if status is None:
+                problems.append(f"{plan_id}: validation plan references unknown regression fixture {ref}")
+            elif plan_status == "promoted" and status != "promoted":
+                problems.append(f"{plan_id}: promoted validation plan cannot reference candidate regression fixture {ref}")
+    return problems
+
+
+def expect(path: Path, problems: list[str], expected_substrings: list[str]) -> list[str]:
+    failures: list[str] = []
+    if not problems:
+        failures.append(f"{path}: expected invalid fixture to fail, but it passed")
+    for expected in expected_substrings:
+        if not any(expected in problem for problem in problems):
+            failures.append(f"{path}: expected problem containing {expected!r}")
+    return failures
+
+
+def main() -> int:
+    schema = workroom.load(workroom.SCHEMA)
+    failed = False
+    results: dict[str, dict[str, Any]] = {}
+
+    for path in VALID_FIXTURES:
+        data = load(path)
+        schema_errors = workroom.schema_problems(schema, data)
+        semantic_errors = workroom.semantic_problems(data)
+        promotion_errors = promotion_problems(data)
+        failed = failed or bool(schema_errors or semantic_errors or promotion_errors)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "valid",
+            "schema": schema_errors,
+            "semantic": semantic_errors,
+            "promotion": promotion_errors,
+        }
+
+    for path, expected in INVALID_FIXTURES.items():
+        data = load(path)
+        schema_errors = workroom.schema_problems(schema, data)
+        semantic_errors = workroom.semantic_problems(data)
+        promotion_errors = promotion_problems(data)
+        problems = schema_errors + semantic_errors + promotion_errors
+        failures = expect(path.relative_to(ROOT), problems, expected)
+        failed = failed or bool(failures)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid",
+            "expected_problem_substrings": expected,
+            "expectation_failures": failures,
+            "schema": schema_errors,
+            "semantic": semantic_errors,
+            "promotion": promotion_errors,
+        }
+
+    report = {
+        "validator": "prophet-platform.devsecops-regression-promotion.validator.v1",
+        "passed": not failed,
+        "results": results,
+        "non_claims": [
+            "Validator checks fixture-scoped regression promotion linkage.",
+            "Validator performs no runtime operations.",
+            "Validator does not promote fixtures by itself."
+        ],
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(("PASS" if not failed else "FAIL") + ": devsecops regression promotion")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a closed-loop regression promotion guard for the DevSecOps Workroom.

This PR adds:

- `tools/validate_devsecops_regression_promotion.py`;
- `.github/workflows/devsecops-regression-promotion.yml`;
- invalid fixture for a regression candidate not derived from the behavioral divergence event or an RCA claim;
- invalid fixture for a promoted validation plan that references an unpromoted regression candidate.

This advances the closed-loop path:

`Incident/RCA → RegressionFixture → ValidationPlan`

## Boundary

Contract and fixture validation only.

- No runtime execution.
- No fixture promotion is performed by the validator.
- No production action authorization.
- No UI work.

Refs #519
Refs #520