### PR TITLE
Add Health-AI demo readiness fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,3 +223,7 @@ validate-workspace-prophet-membrane-e2e:
 	python3 tools/validate_workspace_prophet_runtime_receipts.py
 	python3 tools/validate_workspace_prophet_value_projection.py
 
+.PHONY: validate-health-ai-demo-readiness
+validate-health-ai-demo-readiness:
+	python3 tools/validate_health_ai_demo_readiness.py
+

--- a/contracts/health-ai/demo/health-ai-demo-readiness.v0.json
+++ b/contracts/health-ai/demo/health-ai-demo-readiness.v0.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": "0.1.0",
+  "demo_id": "health_ai_eval_and_clinical_value_demo_v0",
+  "readiness_state": "ready_for_nonprod_eval",
+  "production_ready": false,
+  "patient_care_action": false,
+  "autonomous_clinical_action": false,
+  "real_clinical_data_processing": false,
+  "customer_facing_healthcare_claim": false,
+  "protected_benchmark_reproduction": false,
+  "source_basis": [
+    {
+      "source_id": "source:ambience-healthcare-pdf",
+      "source_class": "external_competitor_claim",
+      "classification": "source_claim_only",
+      "notes": "Ambience-derived claims are competitive/source claims only; they are not SocioProphet-validated clinical, financial, or production claims."
+    },
+    {
+      "source_id": "source:healthbench-openai-pdf",
+      "source_class": "benchmark_design_claim",
+      "classification": "evaluation_design_only",
+      "notes": "HealthBench-derived material is used only for evaluation design concepts. Protected examples, answer keys, and canary content are not reproduced."
+    }
+  ],
+  "upstream_artifacts": [
+    {
+      "repo": "SocioProphet/prophet-core-contracts",
+      "ref": "PR #18",
+      "artifacts": [
+        "schemas/health-eval-rubric.schema.json",
+        "schemas/clinical-value-claim.schema.json",
+        "examples/health-ai/health-eval-rubric.planning.example.json",
+        "examples/health-ai/clinical-value-claim.ambience-source.example.json"
+      ],
+      "validation": "make validate-health-ai-contracts"
+    },
+    {
+      "repo": "SocioProphet/sherlock-search",
+      "ref": "PR #64",
+      "artifacts": [
+        "schemas/health-ai-search-packet.schema.json",
+        "examples/health-ai/clinical-value-source-search-packet.example.json",
+        "examples/health-ai/health-eval-design-search-packet.example.json"
+      ],
+      "validation": "make validate-health-ai-search-packets"
+    },
+    {
+      "repo": "SocioProphet/sociosphere",
+      "ref": "origin/main",
+      "artifacts": [
+        "registry/health-ai/health-ai-eval-readiness.v0.json",
+        "tests/fixtures/health-ai/health-ai-eval-readiness.planning.json"
+      ],
+      "validation": "python3 tools/validate_health_ai_readiness.py"
+    },
+    {
+      "repo": "SocioProphet/agentplane",
+      "ref": "PR #270",
+      "artifacts": [
+        "schemas/receipts/health-ai-control-receipt.v0.1.schema.json",
+        "tests/fixtures/receipts/health-ai-control-receipt.planning-valid.json"
+      ],
+      "validation": "make validate-health-ai-control-receipt"
+    }
+  ],
+  "demo_surface": {
+    "ui_ready": false,
+    "api_ready": false,
+    "fixture_ready": true,
+    "allowed_views": [
+      "source_claim_summary",
+      "evaluation_design_summary",
+      "readiness_state",
+      "blocked_actions",
+      "evidence_refs",
+      "upstream_validation_refs"
+    ],
+    "blocked_views": [
+      "patient_data_entry",
+      "clinical_recommendation",
+      "diagnosis_or_treatment_advice",
+      "production_roi_claim",
+      "live_ehr_write",
+      "real_clinical_data_processing"
+    ]
+  },
+  "blocked_actions": [
+    "production_ready",
+    "patient_care_action",
+    "autonomous_clinical_action",
+    "real_clinical_data_processing",
+    "customer_facing_healthcare_claim",
+    "protected_benchmark_reproduction",
+    "ehr_write",
+    "clinical_decision_support"
+  ],
+  "eval_readiness_criteria": [
+    {
+      "criterion_id": "contracts_available",
+      "status": "satisfied",
+      "evidence_ref": "SocioProphet/prophet-core-contracts#18"
+    },
+    {
+      "criterion_id": "search_packets_available",
+      "status": "satisfied",
+      "evidence_ref": "SocioProphet/sherlock-search#64"
+    },
+    {
+      "criterion_id": "readiness_registered",
+      "status": "satisfied",
+      "evidence_ref": "SocioProphet/sociosphere:registry/health-ai/health-ai-eval-readiness.v0.json"
+    },
+    {
+      "criterion_id": "control_receipt_available",
+      "status": "satisfied",
+      "evidence_ref": "SocioProphet/agentplane#270"
+    },
+    {
+      "criterion_id": "ui_panel_available",
+      "status": "pending",
+      "evidence_ref": "prophet-platform:future-health-ai-demo-ui"
+    }
+  ],
+  "next_allowed_action": "add_nonprod_ui_panel",
+  "created_at": "2026-06-08T00:00:00Z"
+}

--- a/tools/validate_health_ai_demo_readiness.py
+++ b/tools/validate_health_ai_demo_readiness.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "contracts" / "health-ai" / "demo" / "health-ai-demo-readiness.v0.json"
+
+REQUIRED_BLOCKS = {
+    "production_ready",
+    "patient_care_action",
+    "autonomous_clinical_action",
+    "real_clinical_data_processing",
+    "customer_facing_healthcare_claim",
+    "protected_benchmark_reproduction",
+    "ehr_write",
+    "clinical_decision_support",
+}
+
+REQUIRED_REPOS = {
+    "SocioProphet/prophet-core-contracts",
+    "SocioProphet/sherlock-search",
+    "SocioProphet/sociosphere",
+    "SocioProphet/agentplane",
+}
+
+def main() -> int:
+    try:
+        record = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"ERR: failed to load Health-AI demo readiness fixture: {exc}", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+
+    if record.get("schema_version") != "0.1.0":
+        errors.append("schema_version must be 0.1.0")
+    if record.get("readiness_state") != "ready_for_nonprod_eval":
+        errors.append("readiness_state must be ready_for_nonprod_eval")
+    for key in (
+        "production_ready",
+        "patient_care_action",
+        "autonomous_clinical_action",
+        "real_clinical_data_processing",
+        "customer_facing_healthcare_claim",
+        "protected_benchmark_reproduction",
+    ):
+        if record.get(key) is not False:
+            errors.append(f"{key} must be false")
+
+    blocked = set(record.get("blocked_actions", []))
+    missing_blocks = sorted(REQUIRED_BLOCKS - blocked)
+    if missing_blocks:
+        errors.append(f"missing blocked actions: {missing_blocks}")
+
+    repos = {item.get("repo") for item in record.get("upstream_artifacts", [])}
+    missing_repos = sorted(REQUIRED_REPOS - repos)
+    if missing_repos:
+        errors.append(f"missing upstream repos: {missing_repos}")
+
+    source_classes = {item.get("source_class") for item in record.get("source_basis", [])}
+    if "external_competitor_claim" not in source_classes:
+        errors.append("missing external_competitor_claim source basis")
+    if "benchmark_design_claim" not in source_classes:
+        errors.append("missing benchmark_design_claim source basis")
+
+    demo_surface = record.get("demo_surface", {})
+    if demo_surface.get("fixture_ready") is not True:
+        errors.append("demo_surface.fixture_ready must be true")
+    if demo_surface.get("ui_ready") is not False:
+        errors.append("demo_surface.ui_ready must be false for this slice")
+    if demo_surface.get("api_ready") is not False:
+        errors.append("demo_surface.api_ready must be false for this slice")
+
+    blocked_views = set(demo_surface.get("blocked_views", []))
+    for blocked_view in (
+        "patient_data_entry",
+        "clinical_recommendation",
+        "diagnosis_or_treatment_advice",
+        "production_roi_claim",
+        "live_ehr_write",
+    ):
+        if blocked_view not in blocked_views:
+            errors.append(f"missing blocked demo view: {blocked_view}")
+
+    criteria = {item.get("criterion_id"): item.get("status") for item in record.get("eval_readiness_criteria", [])}
+    for criterion in (
+        "contracts_available",
+        "search_packets_available",
+        "readiness_registered",
+        "control_receipt_available",
+    ):
+        if criteria.get(criterion) != "satisfied":
+            errors.append(f"{criterion} must be satisfied")
+
+    if criteria.get("ui_panel_available") != "pending":
+        errors.append("ui_panel_available must remain pending until UI slice lands")
+
+    if record.get("next_allowed_action") != "add_nonprod_ui_panel":
+        errors.append("next_allowed_action must be add_nonprod_ui_panel")
+
+    text = FIXTURE.read_text(encoding="utf-8")
+    if "healthbench:" in text:
+        errors.append("fixture must not reproduce protected HealthBench canary content")
+
+    if errors:
+        print("ERR: Health-AI demo readiness validation failed", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 2
+
+    print("Health-AI demo readiness validates for nonprod eval.")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds the prophet-platform Health-AI demo readiness fixture for non-production evaluation.

Validation:
- make validate-health-ai-demo-readiness

Readiness posture:
- readiness_state=ready_for_nonprod_eval
- production_ready=false
- patient_care_action=false
- autonomous_clinical_action=false
- real_clinical_data_processing=false
- customer_facing_healthcare_claim=false
- protected_benchmark_reproduction=false

References:
- prophet-core-contracts#18
- sherlock-search#64
- Sociosphere health-ai readiness on origin/main
- agentplane#270

Next allowed action:
- add_nonprod_ui_panel