### PR TITLE
Record Health-AI nonprod demo eval-ready checkpoint

### DIFF
--- a/docs/evidence/health-ai-nonprod-demo-eval-ready-checkpoint-v0.md
+++ b/docs/evidence/health-ai-nonprod-demo-eval-ready-checkpoint-v0.md
@@ -1,0 +1,38 @@
+# Health-AI Nonprod Demo Eval-Ready Checkpoint v0
+
+Status: eval-ready for non-production demonstration.
+
+## Verified state
+
+- `apps/socioprophet-web/src/components/HealthAIDemoReadinessCard.vue` exists.
+- `apps/socioprophet-web/src/App.vue` imports and renders `HealthAIDemoReadinessCard`.
+- `cd apps/socioprophet-web && pnpm build` passes.
+- `make validate-health-ai-demo-readiness` passes.
+- `main` is aligned with `origin/main` at the time of checkpoint handoff.
+
+## Safety posture
+
+- `production_ready=false`
+- `patient_care_action=false`
+- `autonomous_clinical_action=false`
+- `real_clinical_data_processing=false`
+- `customer_facing_healthcare_claim=false`
+- `protected_benchmark_reproduction=false`
+
+## Scope
+
+This checkpoint authorizes only non-production evaluation of the demo surface. It does not authorize clinical use, patient-care action, real clinical data processing, diagnosis, treatment advice, EHR writes, protected benchmark reproduction, or customer-facing healthcare claims.
+
+## Evidence chain
+
+- `prophet-core-contracts`: Health-AI rubric and clinical-value claim contracts.
+- `sherlock-search`: Health-AI search packets.
+- `sociosphere`: Health-AI readiness fixture.
+- `agentplane`: Health-AI control receipt.
+- `prophet-platform`: Health-AI demo readiness fixture and UI card.
+
+## Next product slice
+
+Move from readiness demo to governed runtime demo by integrating the Prophet Mesh conductor/choir runtime path into the demo narrative as a non-actioning, approval-gated readout.
+
+The next surface must remain non-production and must not wire live provider calls, provider secrets, clinical actions, EHR writes, real clinical data processing, or customer-facing healthcare claims.


### PR DESCRIPTION
Records the Health-AI non-production demo as eval-ready after merged UI and readiness validation.

Verified:
- HealthAIDemoReadinessCard exists.
- App.vue renders the Health-AI readiness card.
- cd apps/socioprophet-web && pnpm build passes.
- make validate-health-ai-demo-readiness passes.
- main is aligned with origin/main at handoff.

Safety posture remains non-production only:
- production_ready=false
- patient_care_action=false
- autonomous_clinical_action=false
- real_clinical_data_processing=false
- customer_facing_healthcare_claim=false
- protected_benchmark_reproduction=false

Next product slice:
- integrate Prophet Mesh conductor/choir runtime path as a non-actioning, approval-gated readout.
- do not wire live provider calls, secrets, clinical actions, EHR writes, real clinical data processing, or customer-facing healthcare claims.