### PR TITLE
Record runtime readout checkpoint

### DIFF
--- a/docs/evidence/prophet-mesh-runtime-readout-nonprod-checkpoint-v0.md
+++ b/docs/evidence/prophet-mesh-runtime-readout-nonprod-checkpoint-v0.md
@@ -1,0 +1,70 @@
+# Prophet Mesh Runtime Readout Nonprod Checkpoint v0
+
+Status: eval-ready for non-production demonstration.
+
+## Verified state
+
+- `contracts/prophet-mesh/demo/prophet-mesh-runtime-readiness.v0.json` exists on `main`.
+- `apps/socioprophet-web/src/components/ProphetMeshRuntimeReadinessCard.vue` exists on `main`.
+- `apps/socioprophet-web/src/App.vue` imports and renders `ProphetMeshRuntimeReadinessCard`.
+- `tools/validate_prophet_mesh_demo_readiness.py` exists on `main`.
+- `Makefile` exposes `validate-prophet-mesh-demo-readiness`.
+- PR #581 merged after visible workflows completed successfully.
+
+## Runtime readout posture
+
+- `readiness_state=ready_for_nonprod_eval`
+- `production_ready=false`
+- `external_action_allowed=false`
+- `live_provider_call=false`
+- `provider_secrets_required=false`
+- `real_user_data_processing=false`
+- `customer_facing_claim=false`
+- `requires_human_approval=true`
+
+## Runtime path
+
+- `conductor_id=michael-agent`
+- `request_id=req-router-accepted-001`
+- `task=email_reply`
+- `domain=communications`
+- `memory_scope=relationship_context:approved`
+- `selected_route=anthropic.claude-sonnet-4.6`
+- `fallback_route=openai.gpt-5.4-mini`
+- `policy_decision=requires_approval`
+- `conductor_response_status=awaiting_approval`
+- `execution_trace_status=awaiting_approval`
+- `approval_boundary=human approval required before external send`
+
+## Specialist agents
+
+- `memory-steward`
+- `writing-agent`
+- `governance-sentinel`
+
+## Required controls
+
+- `identity=true`
+- `policy=true`
+- `evidence=true`
+- `attestation=true`
+- `revocation=true`
+- `audit=true`
+- `tenant_isolation=true`
+
+## Evidence chain
+
+- `SocioProphet/prophet-mesh:specs/model-router-interface.yaml`
+- `SocioProphet/prophet-mesh:examples/router-decision.accepted.json`
+- `SocioProphet/prophet-mesh:examples/choir-execution-plan.accepted.json`
+- `SocioProphet/prophet-platform:contracts/prophet-mesh/demo/prophet-mesh-runtime-readiness.v0.json`
+- `SocioProphet/prophet-platform:tools/validate_prophet_mesh_demo_readiness.py`
+- `SocioProphet/prophet-platform:apps/socioprophet-web/src/components/ProphetMeshRuntimeReadinessCard.vue`
+
+## Scope
+
+This checkpoint authorizes only a fixture-backed non-production runtime readout. It does not authorize production use, live provider invocation, provider secret use, external message sending, unapproved memory writeback, tenant crossing, real user data processing, or customer-facing claims.
+
+## Next product slice
+
+Move from static runtime readout to a local dry-run demo package that emits a deterministic readout artifact and validates it against the same approval, evidence, audit, and control invariants.


### PR DESCRIPTION
Records the merged non-production runtime readout checkpoint.

Adds one evidence document for the merged fixture, validator, Makefile target, and web card.

Next slice: deterministic local dry-run package.