### PR TITLE
Add workspace service infrastructure and OpenTofu GCP landing zone

### DIFF
--- a/.github/workflows/tofu-plan.yml
+++ b/.github/workflows/tofu-plan.yml
@@ -56,15 +56,39 @@ jobs:
           tofu init -backend=false
           tofu validate
 
+  gcp-plan-readiness:
+    name: Check gcp-plan secret readiness
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      ready: ${{ steps.ready.outputs.ready }}
+    steps:
+      - id: ready
+        name: Determine whether gcp-plan secrets are configured
+        env:
+          WIF_PROVIDER: ${{ secrets.WIF_PROVIDER }}
+          WIF_SERVICE_ACCOUNT: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+          GCP_BILLING_ACCOUNT: ${{ secrets.GCP_BILLING_ACCOUNT }}
+          GCP_ADMIN_GROUP_EMAIL: ${{ secrets.GCP_ADMIN_GROUP_EMAIL }}
+          GCP_ALERT_EMAIL: ${{ secrets.GCP_ALERT_EMAIL }}
+        run: |
+          if [ -n "$WIF_PROVIDER" ] && [ -n "$WIF_SERVICE_ACCOUNT" ] && [ -n "$GCP_BILLING_ACCOUNT" ] && [ -n "$GCP_ADMIN_GROUP_EMAIL" ] && [ -n "$GCP_ALERT_EMAIL" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "gcp-plan secrets are not configured; skipping live GCP plan. Static OpenTofu validation still runs."
+          fi
+
   plan-gcp-landing:
     name: Plan gcp-landing
     runs-on: ubuntu-latest
-    # Only run plan on PRs to main (not on every push — avoid GCP API calls on main)
-    if: github.event_name == 'pull_request'
+    needs: gcp-plan-readiness
+    # Only run plan on PRs to main, and only when required environment secrets are configured.
+    if: github.event_name == 'pull_request' && needs.gcp-plan-readiness.outputs.ready == 'true'
     permissions:
       contents: read
       id-token: write   # for Workload Identity Federation
-    environment: gcp-plan  # Requires environment secret: GCP_PROJECT, WIF_PROVIDER
+    environment: gcp-plan  # Requires environment secrets listed in gcp-plan-readiness
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tofu-plan.yml
+++ b/.github/workflows/tofu-plan.yml
@@ -1,0 +1,123 @@
+name: tofu-plan
+# Plan-only. No apply gate exists yet.
+# Apply requires: manual GH Actions environment approval + signed plan artifact.
+# See: infra/tofu/envs/gcp-landing/main.tf for APPLY GATE doctrine.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "infra/tofu/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "infra/tofu/**"
+
+env:
+  TOFU_VERSION: "1.8.3"
+
+jobs:
+  fmt-and-validate:
+    name: Format + validate all envs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: ${{ env.TOFU_VERSION }}
+
+      - name: fmt check
+        run: tofu fmt -check -recursive infra/tofu/
+
+      - name: validate — local
+        run: |
+          cd infra/tofu/envs/local
+          tofu init -backend=false
+          tofu validate
+
+      - name: validate — gcp-landing
+        run: |
+          cd infra/tofu/envs/gcp-landing
+          tofu init -backend=false
+          tofu validate
+        env:
+          TF_VAR_billing_account: "000000-000000-000000"
+
+      - name: validate — shared
+        run: |
+          cd infra/tofu/envs/shared
+          tofu init -backend=false
+          tofu validate
+
+      - name: validate — prod
+        run: |
+          cd infra/tofu/envs/prod
+          tofu init -backend=false
+          tofu validate
+
+  plan-gcp-landing:
+    name: Plan gcp-landing
+    runs-on: ubuntu-latest
+    # Only run plan on PRs to main (not on every push — avoid GCP API calls on main)
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      id-token: write   # for Workload Identity Federation
+    environment: gcp-plan  # Requires environment secret: GCP_PROJECT, WIF_PROVIDER
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: ${{ env.TOFU_VERSION }}
+
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Init gcp-landing
+        run: tofu init
+        working-directory: infra/tofu/envs/gcp-landing
+
+      - name: Plan gcp-landing
+        run: tofu plan -out=plan.out -no-color 2>&1 | tee plan.txt
+        working-directory: infra/tofu/envs/gcp-landing
+        env:
+          TF_VAR_billing_account: ${{ secrets.GCP_BILLING_ACCOUNT }}
+          TF_VAR_admin_group_email: ${{ secrets.GCP_ADMIN_GROUP_EMAIL }}
+          TF_VAR_alert_email: ${{ secrets.GCP_ALERT_EMAIL }}
+
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tofu-plan-gcp-landing-${{ github.sha }}
+          path: |
+            infra/tofu/envs/gcp-landing/plan.out
+            infra/tofu/envs/gcp-landing/plan.txt
+          retention-days: 30
+
+      - name: Post plan summary to PR
+        uses: actions/github-script@v7
+        if: github.event_name == 'pull_request'
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('infra/tofu/envs/gcp-landing/plan.txt', 'utf8');
+            const truncated = plan.length > 60000 ? plan.slice(0, 60000) + '\n...(truncated)' : plan;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## OpenTofu Plan — gcp-landing\n\`\`\`hcl\n${truncated}\n\`\`\``
+            });
+
+  provider-leakage-check:
+    name: Reject provider names in canonical contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for provider leakage
+        run: python3 tools/validate_no_provider_leakage.py

--- a/.github/workflows/workspace-operation-runtime.yml
+++ b/.github/workflows/workspace-operation-runtime.yml
@@ -19,7 +19,10 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install test dependencies
+        run: pip install pytest pyyaml
+
       - name: Run runtime smoke tests
         env:
           PYTHONPATH: src
-        run: python -m unittest discover -s tests/workspace_operations -p 'test_*.py'
+        run: pytest tests/workspace_operations/ -q

--- a/Makefile
+++ b/Makefile
@@ -303,11 +303,14 @@ workspace-down:
 workspace-logs:
 	docker compose -f $(WORKSPACE_COMPOSE) logs -f
 
-# ── Prophet Mesh ──────────────────────────────────────────────────────────────
+# ── Prophet Mesh + SocioSphere ────────────────────────────────────────────────
 MESH_COMPOSE = infra/local/docker-compose.mesh.yml
+SOCIOSPHERE_COMPOSE = infra/local/docker-compose.sociosphere.yml
 MESH_REPOS_ROOT ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/../
 
-.PHONY: validate-mesh-deployment mesh-build mesh-up mesh-down mesh-logs mesh-ps
+.PHONY: validate-mesh-deployment mesh-build mesh-up mesh-down mesh-logs mesh-ps \
+        sociosphere-build sociosphere-up sociosphere-down sociosphere-logs \
+        full-stack-up full-stack-down full-stack-build
 
 validate-mesh-deployment:
 	python3 tools/validate_mesh_deployment.py
@@ -339,6 +342,51 @@ mesh-logs:
 
 mesh-ps:
 	MESH_REPOS_ROOT=$(MESH_REPOS_ROOT) docker compose -f $(MESH_COMPOSE) ps
+
+sociosphere-build:
+	@if ! docker info >/dev/null 2>&1; then \
+	  echo "ERROR: Docker daemon is not running. Start Docker Desktop and retry."; \
+	  exit 1; \
+	fi
+	MESH_REPOS_ROOT=$(MESH_REPOS_ROOT) docker compose -f $(SOCIOSPHERE_COMPOSE) build
+
+sociosphere-up:
+	@if ! docker info >/dev/null 2>&1; then \
+	  echo "ERROR: Docker daemon is not running. Start Docker Desktop and retry."; \
+	  exit 1; \
+	fi
+	MESH_REPOS_ROOT=$(MESH_REPOS_ROOT) docker compose -f $(SOCIOSPHERE_COMPOSE) up -d
+	@echo "SocioSphere tier started (tiers 7-10, 15 services)."
+	@echo "Ports: sociosphere=5000, cloudshell-fog=8080"
+	@echo "       hellgraph=8850, regis=8820, sherlock=8810"
+	@echo "       catalog=8830, query=8831, devsecops=8840, lattice-forge=8870"
+	@echo "       synapseiq=8800-8804, mcp-a2a=8860"
+
+sociosphere-down:
+	MESH_REPOS_ROOT=$(MESH_REPOS_ROOT) docker compose -f $(SOCIOSPHERE_COMPOSE) down
+
+sociosphere-logs:
+	MESH_REPOS_ROOT=$(MESH_REPOS_ROOT) docker compose -f $(SOCIOSPHERE_COMPOSE) logs -f
+
+# Full stack (mesh + sociosphere together)
+full-stack-build: mesh-build sociosphere-build
+
+full-stack-up:
+	@if ! docker info >/dev/null 2>&1; then \
+	  echo "ERROR: Docker daemon is not running. Start Docker Desktop and retry."; \
+	  exit 1; \
+	fi
+	MESH_REPOS_ROOT=$(MESH_REPOS_ROOT) docker compose \
+	  -f $(MESH_COMPOSE) \
+	  -f $(SOCIOSPHERE_COMPOSE) \
+	  up -d
+	@echo "Full SocioProphet stack started (tiers 0-10, 26 services)."
+
+full-stack-down:
+	MESH_REPOS_ROOT=$(MESH_REPOS_ROOT) docker compose \
+	  -f $(MESH_COMPOSE) \
+	  -f $(SOCIOSPHERE_COMPOSE) \
+	  down
 
 # ── Terraform / IaC ───────────────────────────────────────────────────────────
 TF_ENV ?= p0-lab

--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,43 @@ workspace-down:
 workspace-logs:
 	docker compose -f $(WORKSPACE_COMPOSE) logs -f
 
+# ── Prophet Mesh ──────────────────────────────────────────────────────────────
+MESH_COMPOSE = infra/local/docker-compose.mesh.yml
+MESH_REPOS_ROOT ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/../
+
+.PHONY: validate-mesh-deployment mesh-build mesh-up mesh-down mesh-logs mesh-ps
+
+validate-mesh-deployment:
+	python3 tools/validate_mesh_deployment.py
+
+mesh-build:
+	@if ! docker info >/dev/null 2>&1; then \
+	  echo "ERROR: Docker daemon is not running. Start Docker Desktop and retry."; \
+	  exit 1; \
+	fi
+	MESH_REPOS_ROOT=$(MESH_REPOS_ROOT) docker compose -f $(MESH_COMPOSE) build
+
+mesh-up:
+	@if ! docker info >/dev/null 2>&1; then \
+	  echo "ERROR: Docker daemon is not running. Start Docker Desktop and retry."; \
+	  exit 1; \
+	fi
+	MESH_REPOS_ROOT=$(MESH_REPOS_ROOT) docker compose -f $(MESH_COMPOSE) up -d
+	@echo "Mesh stack started (6 tiers, 11 services)."
+	@echo "Ports: memoryd=8787, policy-fabric=8700, model-router=8710"
+	@echo "       agent-registry=8720, agentplane=8730, superconscious=8740"
+	@echo "       tritfabric=8750, governance-ledger=8760, prophet-mesh=8780"
+	@echo "       qdrant=6333/6334"
+
+mesh-down:
+	MESH_REPOS_ROOT=$(MESH_REPOS_ROOT) docker compose -f $(MESH_COMPOSE) down
+
+mesh-logs:
+	MESH_REPOS_ROOT=$(MESH_REPOS_ROOT) docker compose -f $(MESH_COMPOSE) logs -f
+
+mesh-ps:
+	MESH_REPOS_ROOT=$(MESH_REPOS_ROOT) docker compose -f $(MESH_COMPOSE) ps
+
 # ── Terraform / IaC ───────────────────────────────────────────────────────────
 TF_ENV ?= p0-lab
 TF_DIR = infra/terraform/environments/$(TF_ENV)

--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,41 @@ validate-health-ai-demo-readiness:
 validate-prophet-mesh-demo-readiness:
 	python3 tools/validate_prophet_mesh_demo_readiness.py
 
+# ── OpenTofu IaC ──────────────────────────────────────────────────────────────
+TOFU_ENV ?= local
+TOFU_DIR = infra/tofu/envs/$(TOFU_ENV)
+
+.PHONY: tofu-fmt tofu-validate tofu-init tofu-plan tofu-output validate-no-provider-leakage
+
+validate-no-provider-leakage:
+	python3 tools/validate_no_provider_leakage.py
+
+tofu-fmt:
+	tofu fmt -recursive infra/tofu/
+
+tofu-validate:
+	@for env in local gcp-landing shared prod; do \
+	  echo "--- validating env=$$env ---"; \
+	  cd infra/tofu/envs/$$env && tofu init -backend=false -input=false && tofu validate; \
+	  cd $(CURDIR); \
+	done
+
+tofu-init:
+	cd $(TOFU_DIR) && tofu init -upgrade
+
+tofu-plan:
+	@if [ "$(TOFU_ENV)" != "local" ]; then \
+	  echo "INFO: plan for $(TOFU_ENV) — no apply gate exists yet. Plan only."; \
+	fi
+	cd $(TOFU_DIR) && tofu plan
+
+tofu-output:
+	cd $(TOFU_DIR) && tofu output
+
 # ── Workspace services ────────────────────────────────────────────────────────
 WORKSPACE_COMPOSE = infra/local/docker-compose.workspace.yml
+
+.PHONY: validate-workspace-services test-workspace smoke-workspace workspace-build workspace-up workspace-down workspace-logs
 
 validate-workspace-services:
 	python3 tools/validate_workspace_services.py

--- a/infra/k8s/agent-registry/base/deployment.yaml
+++ b/infra/k8s/agent-registry/base/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-registry
+  labels:
+    app: agent-registry
+    bundle: mesh.registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agent-registry
+  template:
+    metadata:
+      labels:
+        app: agent-registry
+        bundle: mesh.registry
+    spec:
+      containers:
+        - name: agent-registry
+          image: ghcr.io/socioprophet/agent-registry:latest
+          ports:
+            - name: http
+              containerPort: 8720
+          env:
+            - name: PORT
+              value: "8720"
+            - name: POLICY_FABRIC_URL
+              value: "http://policy-fabric:8700"
+            - name: STORE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-postgres-credentials
+                  key: store-uri
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8720
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8720
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+

--- a/infra/k8s/agent-registry/base/kustomization.yaml
+++ b/infra/k8s/agent-registry/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/agent-registry/base/service.yaml
+++ b/infra/k8s/agent-registry/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agent-registry
+spec:
+  selector:
+    app: agent-registry
+  ports:
+  - name: http
+    port: 8720
+    targetPort: 8720

--- a/infra/k8s/agent-registry/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/agent-registry/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: agent-registry

--- a/infra/k8s/agentplane/base/deployment.yaml
+++ b/infra/k8s/agentplane/base/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentplane
+  labels:
+    app: agentplane
+    bundle: mesh.execution
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agentplane
+  template:
+    metadata:
+      labels:
+        app: agentplane
+        bundle: mesh.execution
+    spec:
+      containers:
+        - name: agentplane
+          image: ghcr.io/socioprophet/agentplane:latest
+          ports:
+            - name: http
+              containerPort: 8730
+          env:
+            - name: PORT
+              value: "8730"
+            - name: POLICY_FABRIC_URL
+              value: "http://policy-fabric:8700"
+            - name: AGENT_REGISTRY_URL
+              value: "http://agent-registry:8720"
+            - name: MODEL_ROUTER_URL
+              value: "http://model-router:8710"
+            - name: MEMORYD_URL
+              value: "http://memoryd:8787"
+            - name: MEMORYD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-memoryd-credentials
+                  key: api-key
+            - name: SUPERCONSCIOUS_URL
+              value: "http://superconscious:8740"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8730
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8730
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+

--- a/infra/k8s/agentplane/base/kustomization.yaml
+++ b/infra/k8s/agentplane/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/agentplane/base/service.yaml
+++ b/infra/k8s/agentplane/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentplane
+spec:
+  selector:
+    app: agentplane
+  ports:
+  - name: http
+    port: 8730
+    targetPort: 8730

--- a/infra/k8s/agentplane/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/agentplane/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: agentplane

--- a/infra/k8s/argo-cd/appsets/socioprophet-appset.yaml
+++ b/infra/k8s/argo-cd/appsets/socioprophet-appset.yaml
@@ -63,6 +63,56 @@ spec:
           - name: mesh-conductor
             path: infra/k8s/prophet-mesh/overlays/p0-lab
             bundle: mesh.conductor
+          # ── SocioSphere extended tiers ────────────────────────────────────
+          # Tier 7 — Platform shell + workspace controller
+          - name: cloudshell-fog
+            path: infra/k8s/cloudshell-fog/overlays/runtime-v2-standard
+            bundle: platform.shell
+          - name: sociosphere
+            path: infra/k8s/sociosphere/overlays/p0-lab
+            bundle: platform.controller
+          # Tier 8 — Graph kernel + entity graph + search
+          - name: hellgraph
+            path: infra/k8s/hellgraph/overlays/p0-lab
+            bundle: graph.kernel
+          - name: regis-entity-graph
+            path: infra/k8s/regis-entity-graph/overlays/p0-lab
+            bundle: graph.entity
+          - name: sherlock-search
+            path: infra/k8s/sherlock-search/overlays/p0-lab
+            bundle: search.evidence
+          # Tier 9 — Catalog + query + intelligence + runtime forge
+          - name: prophet-core-catalog
+            path: infra/k8s/prophet-core-catalog/overlays/p0-lab
+            bundle: data.catalog
+          - name: prophet-core-query
+            path: infra/k8s/prophet-core-query/overlays/p0-lab
+            bundle: data.query
+          - name: global-devsecops-intelligence
+            path: infra/k8s/global-devsecops-intelligence/overlays/p0-lab
+            bundle: intelligence.devsecops
+          - name: lattice-forge
+            path: infra/k8s/lattice-forge/overlays/p0-lab
+            bundle: runtime.forge
+          # Tier 10 — Enrichment plane + MCP zero-trust
+          - name: synapseiq-control-plane
+            path: infra/k8s/synapseiq-control-plane/overlays/p0-lab
+            bundle: enrichment.control
+          - name: synapseiq-enrichment-api
+            path: infra/k8s/synapseiq-enrichment-api/overlays/p0-lab
+            bundle: enrichment.api
+          - name: synapseiq-enrichment-collector
+            path: infra/k8s/synapseiq-enrichment-collector/overlays/p0-lab
+            bundle: enrichment.collector
+          - name: synapseiq-reasoning-api
+            path: infra/k8s/synapseiq-reasoning-api/overlays/p0-lab
+            bundle: enrichment.reasoning
+          - name: synapseiq-tabular-alpha
+            path: infra/k8s/synapseiq-tabular-alpha/overlays/p0-lab
+            bundle: enrichment.tabular
+          - name: mcp-a2a-zero-trust
+            path: infra/k8s/mcp-a2a-zero-trust/overlays/p0-lab
+            bundle: security.mcp-zero-trust
   template:
     metadata:
       name: '{{name}}'

--- a/infra/k8s/argo-cd/appsets/socioprophet-appset.yaml
+++ b/infra/k8s/argo-cd/appsets/socioprophet-appset.yaml
@@ -113,6 +113,19 @@ spec:
           - name: mcp-a2a-zero-trust
             path: infra/k8s/mcp-a2a-zero-trust/overlays/p0-lab
             bundle: security.mcp-zero-trust
+          # ── Holmes / CairnPath / ContractForge ───────────────────────────
+          # Tier 4.5 — Execution trace mesh
+          - name: cairnpath-mesh
+            path: infra/k8s/cairnpath-mesh/overlays/p0-lab
+            bundle: execution.trace
+          # Tier 8 — Language intelligence
+          - name: holmes
+            path: infra/k8s/holmes/overlays/p0-lab
+            bundle: intelligence.language
+          # Tier 9 — Contract lifecycle
+          - name: contractforge
+            path: infra/k8s/contractforge/overlays/p0-lab
+            bundle: contracts.forge
   template:
     metadata:
       name: '{{name}}'

--- a/infra/k8s/argo-cd/appsets/socioprophet-appset.yaml
+++ b/infra/k8s/argo-cd/appsets/socioprophet-appset.yaml
@@ -25,6 +25,44 @@ spec:
           - name: workspace-minio
             path: infra/k8s/workspace-minio/overlays/p0-lab
             bundle: workspace.storage
+          # ── Prophet Mesh — deployment order follows dependency tiers ─────────
+          # Tier 0 — Vector store
+          - name: mesh-qdrant
+            path: infra/k8s/mesh-qdrant/overlays/p0-lab
+            bundle: mesh.vector-store
+          # Tier 1 — Governance ledger (stateless)
+          - name: mesh-governance-ledger
+            path: infra/k8s/model-governance-ledger/overlays/p0-lab
+            bundle: mesh.governance
+          # Tier 2 — Core services
+          - name: mesh-memoryd
+            path: infra/k8s/memoryd/overlays/p0-lab
+            bundle: mesh.memory
+          - name: mesh-policy-fabric
+            path: infra/k8s/policy-fabric/overlays/p0-lab
+            bundle: mesh.policy
+          # Tier 3 — Routing + Registry
+          - name: mesh-model-router
+            path: infra/k8s/model-router/overlays/p0-lab
+            bundle: mesh.routing
+          - name: mesh-agent-registry
+            path: infra/k8s/agent-registry/overlays/p0-lab
+            bundle: mesh.registry
+          # Tier 4 — Execution plane
+          - name: mesh-superconscious
+            path: infra/k8s/superconscious/overlays/p0-lab
+            bundle: mesh.cognition
+          - name: mesh-agentplane
+            path: infra/k8s/agentplane/overlays/p0-lab
+            bundle: mesh.execution
+          # Tier 5 — ML substrate
+          - name: mesh-tritfabric
+            path: infra/k8s/tritfabric/overlays/p0-lab
+            bundle: mesh.ml
+          # Tier 6 — Mesh conductor
+          - name: mesh-conductor
+            path: infra/k8s/prophet-mesh/overlays/p0-lab
+            bundle: mesh.conductor
   template:
     metadata:
       name: '{{name}}'

--- a/infra/k8s/cairnpath-mesh/base/deployment.yaml
+++ b/infra/k8s/cairnpath-mesh/base/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cairnpath-mesh
+  labels:
+    app: cairnpath-mesh
+    bundle: execution.trace
+  annotations:
+    socioprophet.ai/tier: "Tier 4.5 — execution path/trace mesh (cairn context, line, step audit trail)"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cairnpath-mesh
+  template:
+    metadata:
+      labels:
+        app: cairnpath-mesh
+        bundle: execution.trace
+    spec:
+      containers:
+        - name: cairnpath-mesh
+          image: ghcr.io/socioprophet/cairnpath-mesh:latest
+          ports:
+            - name: http
+              containerPort: 8890
+          env:
+            - name: PORT
+              value: "8890"
+            - name: POLICY_FABRIC_URL
+              value: "http://policy-fabric:8700"
+            - name: AGENTPLANE_URL
+              value: "http://agentplane:8730"
+            - name: GOVERNANCE_LEDGER_URL
+              value: "http://model-governance-ledger:8760"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8890
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8890
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/cairnpath-mesh/base/kustomization.yaml
+++ b/infra/k8s/cairnpath-mesh/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/cairnpath-mesh/base/service.yaml
+++ b/infra/k8s/cairnpath-mesh/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cairnpath-mesh
+spec:
+  selector:
+    app: cairnpath-mesh
+  ports:
+    - name: http
+      port: 8890
+      targetPort: 8890

--- a/infra/k8s/cairnpath-mesh/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/cairnpath-mesh/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: cairnpath-mesh

--- a/infra/k8s/contractforge/base/deployment.yaml
+++ b/infra/k8s/contractforge/base/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: contractforge
+  labels:
+    app: contractforge
+    bundle: contracts.forge
+  annotations:
+    socioprophet.ai/tier: "Tier 9 — contract lifecycle, settlement, and ledger-anchored execution"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: contractforge
+  template:
+    metadata:
+      labels:
+        app: contractforge
+        bundle: contracts.forge
+    spec:
+      containers:
+        - name: contractforge
+          image: ghcr.io/socioprophet/contractforge:latest
+          ports:
+            - name: http
+              containerPort: 8895
+          env:
+            - name: PORT
+              value: "8895"
+            - name: POLICY_FABRIC_URL
+              value: "http://policy-fabric:8700"
+            - name: GOVERNANCE_LEDGER_URL
+              value: "http://model-governance-ledger:8760"
+            - name: AGENT_REGISTRY_URL
+              value: "http://agent-registry:8720"
+            - name: AGENTPLANE_URL
+              value: "http://agentplane:8730"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8895
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8895
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/contractforge/base/kustomization.yaml
+++ b/infra/k8s/contractforge/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/contractforge/base/service.yaml
+++ b/infra/k8s/contractforge/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: contractforge
+spec:
+  selector:
+    app: contractforge
+  ports:
+    - name: http
+      port: 8895
+      targetPort: 8895

--- a/infra/k8s/contractforge/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/contractforge/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: contractforge

--- a/infra/k8s/global-devsecops-intelligence/base/deployment.yaml
+++ b/infra/k8s/global-devsecops-intelligence/base/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: global-devsecops-intelligence
+  labels:
+    app: global-devsecops-intelligence
+    bundle: intelligence.devsecops
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: global-devsecops-intelligence
+  template:
+    metadata:
+      labels:
+        app: global-devsecops-intelligence
+        bundle: intelligence.devsecops
+    spec:
+      containers:
+        - name: global-devsecops-intelligence
+          image: ghcr.io/socioprophet/global-devsecops-intelligence:latest
+          ports:
+            - name: http
+              containerPort: 8840
+          env:
+            - name: PORT
+              value: "8840"
+            - name: SHERLOCK_URL
+              value: "http://sherlock-search:8810"
+            - name: MODEL_ROUTER_URL
+              value: "http://model-router:8710"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8840
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8840
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/global-devsecops-intelligence/base/kustomization.yaml
+++ b/infra/k8s/global-devsecops-intelligence/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/global-devsecops-intelligence/base/service.yaml
+++ b/infra/k8s/global-devsecops-intelligence/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: global-devsecops-intelligence
+spec:
+  selector:
+    app: global-devsecops-intelligence
+  ports:
+    - name: http
+      port: 8840
+      targetPort: 8840

--- a/infra/k8s/global-devsecops-intelligence/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/global-devsecops-intelligence/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: global-devsecops-intelligence

--- a/infra/k8s/hellgraph/base/deployment.yaml
+++ b/infra/k8s/hellgraph/base/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hellgraph
+  labels:
+    app: hellgraph
+    bundle: graph.kernel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hellgraph
+  template:
+    metadata:
+      labels:
+        app: hellgraph
+        bundle: graph.kernel
+    spec:
+      containers:
+        - name: hellgraph
+          image: ghcr.io/socioprophet/hellgraph:latest
+          ports:
+            - name: http
+              containerPort: 8850
+          env:
+            - name: PORT
+              value: "8850"
+            - name: LOG_LEVEL
+              value: "info"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8850
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8850
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/hellgraph/base/kustomization.yaml
+++ b/infra/k8s/hellgraph/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/hellgraph/base/service.yaml
+++ b/infra/k8s/hellgraph/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hellgraph
+spec:
+  selector:
+    app: hellgraph
+  ports:
+    - name: http
+      port: 8850
+      targetPort: 8850

--- a/infra/k8s/hellgraph/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/hellgraph/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: hellgraph

--- a/infra/k8s/holmes/base/deployment.yaml
+++ b/infra/k8s/holmes/base/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: holmes
+  labels:
+    app: holmes
+    bundle: intelligence.language
+  annotations:
+    socioprophet.ai/tier: "Tier 8 — language intelligence fabric (NLP/semantic/knowledge graphs)"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: holmes
+  template:
+    metadata:
+      labels:
+        app: holmes
+        bundle: intelligence.language
+    spec:
+      containers:
+        - name: holmes
+          image: ghcr.io/socioprophet/holmes:latest
+          ports:
+            - name: http
+              containerPort: 8880
+          env:
+            - name: PORT
+              value: "8880"
+            - name: POLICY_FABRIC_URL
+              value: "http://policy-fabric:8700"
+            - name: MODEL_ROUTER_URL
+              value: "http://model-router:8710"
+            - name: MEMORYD_URL
+              value: "http://memoryd:8787"
+            - name: MEMORYD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-memoryd-credentials
+                  key: api-key
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8880
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8880
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/holmes/base/kustomization.yaml
+++ b/infra/k8s/holmes/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/holmes/base/service.yaml
+++ b/infra/k8s/holmes/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: holmes
+spec:
+  selector:
+    app: holmes
+  ports:
+    - name: http
+      port: 8880
+      targetPort: 8880

--- a/infra/k8s/holmes/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/holmes/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: holmes

--- a/infra/k8s/lattice-forge/base/deployment.yaml
+++ b/infra/k8s/lattice-forge/base/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lattice-forge
+  labels:
+    app: lattice-forge
+    bundle: runtime.forge
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lattice-forge
+  template:
+    metadata:
+      labels:
+        app: lattice-forge
+        bundle: runtime.forge
+    spec:
+      containers:
+        - name: lattice-forge
+          image: ghcr.io/socioprophet/lattice-forge:latest
+          ports:
+            - name: http
+              containerPort: 8870
+          env:
+            - name: PORT
+              value: "8870"
+            - name: TRITFABRIC_URL
+              value: "http://tritfabric:8750"
+            - name: GOVERNANCE_LEDGER_URL
+              value: "http://model-governance-ledger:8760"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8870
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8870
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/lattice-forge/base/kustomization.yaml
+++ b/infra/k8s/lattice-forge/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/lattice-forge/base/service.yaml
+++ b/infra/k8s/lattice-forge/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: lattice-forge
+spec:
+  selector:
+    app: lattice-forge
+  ports:
+    - name: http
+      port: 8870
+      targetPort: 8870

--- a/infra/k8s/lattice-forge/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/lattice-forge/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: lattice-forge

--- a/infra/k8s/mcp-a2a-zero-trust/base/deployment.yaml
+++ b/infra/k8s/mcp-a2a-zero-trust/base/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-a2a-zero-trust
+  labels:
+    app: mcp-a2a-zero-trust
+    bundle: security.mcp-zero-trust
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-a2a-zero-trust
+  template:
+    metadata:
+      labels:
+        app: mcp-a2a-zero-trust
+        bundle: security.mcp-zero-trust
+    spec:
+      containers:
+        - name: mcp-a2a-zero-trust
+          image: ghcr.io/socioprophet/mcp-a2a-zero-trust:latest
+          ports:
+            - name: http
+              containerPort: 8860
+          env:
+            - name: PORT
+              value: "8860"
+            - name: POLICY_FABRIC_URL
+              value: "http://policy-fabric:8700"
+            - name: AGENT_REGISTRY_URL
+              value: "http://agent-registry:8720"
+            - name: AGENTPLANE_URL
+              value: "http://agentplane:8730"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8860
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8860
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/mcp-a2a-zero-trust/base/kustomization.yaml
+++ b/infra/k8s/mcp-a2a-zero-trust/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/mcp-a2a-zero-trust/base/service.yaml
+++ b/infra/k8s/mcp-a2a-zero-trust/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-a2a-zero-trust
+spec:
+  selector:
+    app: mcp-a2a-zero-trust
+  ports:
+    - name: http
+      port: 8860
+      targetPort: 8860

--- a/infra/k8s/mcp-a2a-zero-trust/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/mcp-a2a-zero-trust/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: mcp-a2a-zero-trust

--- a/infra/k8s/memoryd/base/deployment.yaml
+++ b/infra/k8s/memoryd/base/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: memoryd
+  labels:
+    app: memoryd
+    bundle: mesh.memory
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: memoryd
+  template:
+    metadata:
+      labels:
+        app: memoryd
+        bundle: mesh.memory
+    spec:
+      containers:
+        - name: memoryd
+          image: ghcr.io/socioprophet/memory-mesh/memoryd:latest
+          ports:
+            - name: http
+              containerPort: 8787
+          env:
+            - name: MEMORYD_REQUIRE_API_KEY
+              value: "true"
+            - name: MEMORYD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-memoryd-credentials
+                  key: api-key
+            - name: MEMORYMESH_STORE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-postgres-credentials
+                  key: memorymesh-store-uri
+            - name: MEMORYMESH_VECTOR_BACKEND
+              value: "qdrant"
+            - name: QDRANT_URL
+              value: "http://mesh-qdrant:6333"
+            - name: QDRANT_COLLECTION
+              value: "prophet-mesh"
+            - name: QDRANT_ENABLED
+              value: "true"
+            - name: MEMORYMESH_VECTOR_SIZE
+              value: "256"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8787
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8787
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+                volumeMounts:
+            - name: data
+              mountPath: /app/data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: memoryd-pvc

--- a/infra/k8s/memoryd/base/kustomization.yaml
+++ b/infra/k8s/memoryd/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml
+namespace: socioprophet

--- a/infra/k8s/memoryd/base/pvc.yaml
+++ b/infra/k8s/memoryd/base/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: memoryd-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/infra/k8s/memoryd/base/service.yaml
+++ b/infra/k8s/memoryd/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: memoryd
+spec:
+  selector:
+    app: memoryd
+  ports:
+  - name: http
+    port: 8787
+    targetPort: 8787

--- a/infra/k8s/memoryd/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/memoryd/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: memoryd

--- a/infra/k8s/mesh-qdrant/base/kustomization.yaml
+++ b/infra/k8s/mesh-qdrant/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - statefulset.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/mesh-qdrant/base/service.yaml
+++ b/infra/k8s/mesh-qdrant/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mesh-qdrant
+spec:
+  selector:
+    app: mesh-qdrant
+  clusterIP: None  # headless — StatefulSet DNS
+  ports:
+    - name: http
+      port: 6333
+      targetPort: 6333
+    - name: grpc
+      port: 6334
+      targetPort: 6334

--- a/infra/k8s/mesh-qdrant/base/statefulset.yaml
+++ b/infra/k8s/mesh-qdrant/base/statefulset.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mesh-qdrant
+  labels:
+    app: mesh-qdrant
+    bundle: mesh.vector-store
+spec:
+  serviceName: mesh-qdrant
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mesh-qdrant
+  template:
+    metadata:
+      labels:
+        app: mesh-qdrant
+        bundle: mesh.vector-store
+    spec:
+      containers:
+        - name: qdrant
+          image: qdrant/qdrant:v1.9.4
+          ports:
+            - name: http
+              containerPort: 6333
+            - name: grpc
+              containerPort: 6334
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 6333
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 6333
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "1000m"
+              memory: "2Gi"
+          volumeMounts:
+            - name: qdrant-storage
+              mountPath: /qdrant/storage
+  volumeClaimTemplates:
+    - metadata:
+        name: qdrant-storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi

--- a/infra/k8s/mesh-qdrant/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/mesh-qdrant/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet

--- a/infra/k8s/model-governance-ledger/base/deployment.yaml
+++ b/infra/k8s/model-governance-ledger/base/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: model-governance-ledger
+  labels:
+    app: model-governance-ledger
+    bundle: mesh.governance
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: model-governance-ledger
+  template:
+    metadata:
+      labels:
+        app: model-governance-ledger
+        bundle: mesh.governance
+    spec:
+      containers:
+        - name: model-governance-ledger
+          image: ghcr.io/socioprophet/model-governance-ledger:latest
+          ports:
+            - name: http
+              containerPort: 8760
+          env:
+            - name: PORT
+              value: "8760"
+            - name: LOG_LEVEL
+              value: "info"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8760
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8760
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+

--- a/infra/k8s/model-governance-ledger/base/kustomization.yaml
+++ b/infra/k8s/model-governance-ledger/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/model-governance-ledger/base/service.yaml
+++ b/infra/k8s/model-governance-ledger/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: model-governance-ledger
+spec:
+  selector:
+    app: model-governance-ledger
+  ports:
+  - name: http
+    port: 8760
+    targetPort: 8760

--- a/infra/k8s/model-governance-ledger/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/model-governance-ledger/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: model-governance-ledger

--- a/infra/k8s/model-router/base/deployment.yaml
+++ b/infra/k8s/model-router/base/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: model-router
+  labels:
+    app: model-router
+    bundle: mesh.routing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: model-router
+  template:
+    metadata:
+      labels:
+        app: model-router
+        bundle: mesh.routing
+    spec:
+      containers:
+        - name: model-router
+          image: ghcr.io/socioprophet/model-router:latest
+          ports:
+            - name: http
+              containerPort: 8710
+          env:
+            - name: PORT
+              value: "8710"
+            - name: POLICY_FABRIC_URL
+              value: "http://policy-fabric:8700"
+            - name: MEMORYD_URL
+              value: "http://memoryd:8787"
+            - name: MEMORYD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-memoryd-credentials
+                  key: api-key
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8710
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8710
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+

--- a/infra/k8s/model-router/base/kustomization.yaml
+++ b/infra/k8s/model-router/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/model-router/base/service.yaml
+++ b/infra/k8s/model-router/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: model-router
+spec:
+  selector:
+    app: model-router
+  ports:
+  - name: http
+    port: 8710
+    targetPort: 8710

--- a/infra/k8s/model-router/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/model-router/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: model-router

--- a/infra/k8s/policy-fabric/base/deployment.yaml
+++ b/infra/k8s/policy-fabric/base/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-fabric
+  labels:
+    app: policy-fabric
+    bundle: mesh.policy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: policy-fabric
+  template:
+    metadata:
+      labels:
+        app: policy-fabric
+        bundle: mesh.policy
+    spec:
+      containers:
+        - name: policy-fabric
+          image: ghcr.io/socioprophet/policy-fabric:latest
+          ports:
+            - name: http
+              containerPort: 8700
+          env:
+            - name: PORT
+              value: "8700"
+            - name: LOG_LEVEL
+              value: "info"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8700
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8700
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+

--- a/infra/k8s/policy-fabric/base/kustomization.yaml
+++ b/infra/k8s/policy-fabric/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/policy-fabric/base/service.yaml
+++ b/infra/k8s/policy-fabric/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: policy-fabric
+spec:
+  selector:
+    app: policy-fabric
+  ports:
+  - name: http
+    port: 8700
+    targetPort: 8700

--- a/infra/k8s/policy-fabric/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/policy-fabric/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: policy-fabric

--- a/infra/k8s/prophet-core-catalog/base/deployment.yaml
+++ b/infra/k8s/prophet-core-catalog/base/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prophet-core-catalog
+  labels:
+    app: prophet-core-catalog
+    bundle: data.catalog
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prophet-core-catalog
+  template:
+    metadata:
+      labels:
+        app: prophet-core-catalog
+        bundle: data.catalog
+    spec:
+      containers:
+        - name: prophet-core-catalog
+          image: ghcr.io/socioprophet/prophet-core-catalog:latest
+          ports:
+            - name: http
+              containerPort: 8830
+          env:
+            - name: PORT
+              value: "8830"
+            - name: POLICY_FABRIC_URL
+              value: "http://policy-fabric:8700"
+            - name: GOVERNANCE_LEDGER_URL
+              value: "http://model-governance-ledger:8760"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8830
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8830
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/prophet-core-catalog/base/kustomization.yaml
+++ b/infra/k8s/prophet-core-catalog/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/prophet-core-catalog/base/service.yaml
+++ b/infra/k8s/prophet-core-catalog/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prophet-core-catalog
+spec:
+  selector:
+    app: prophet-core-catalog
+  ports:
+    - name: http
+      port: 8830
+      targetPort: 8830

--- a/infra/k8s/prophet-core-catalog/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/prophet-core-catalog/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: prophet-core-catalog

--- a/infra/k8s/prophet-core-query/base/deployment.yaml
+++ b/infra/k8s/prophet-core-query/base/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prophet-core-query
+  labels:
+    app: prophet-core-query
+    bundle: data.query
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prophet-core-query
+  template:
+    metadata:
+      labels:
+        app: prophet-core-query
+        bundle: data.query
+    spec:
+      containers:
+        - name: prophet-core-query
+          image: ghcr.io/socioprophet/prophet-core-query:latest
+          ports:
+            - name: http
+              containerPort: 8831
+          env:
+            - name: PORT
+              value: "8831"
+            - name: CATALOG_URL
+              value: "http://prophet-core-catalog:8830"
+            - name: MEMORYD_URL
+              value: "http://memoryd:8787"
+            - name: MEMORYD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-memoryd-credentials
+                  key: api-key
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8831
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8831
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/prophet-core-query/base/kustomization.yaml
+++ b/infra/k8s/prophet-core-query/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/prophet-core-query/base/service.yaml
+++ b/infra/k8s/prophet-core-query/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prophet-core-query
+spec:
+  selector:
+    app: prophet-core-query
+  ports:
+    - name: http
+      port: 8831
+      targetPort: 8831

--- a/infra/k8s/prophet-core-query/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/prophet-core-query/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: prophet-core-query

--- a/infra/k8s/prophet-mesh/base/deployment.yaml
+++ b/infra/k8s/prophet-mesh/base/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prophet-mesh
+  labels:
+    app: prophet-mesh
+    bundle: mesh.conductor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prophet-mesh
+  template:
+    metadata:
+      labels:
+        app: prophet-mesh
+        bundle: mesh.conductor
+    spec:
+      containers:
+        - name: prophet-mesh
+          image: ghcr.io/socioprophet/prophet-mesh:latest
+          ports:
+            - name: http
+              containerPort: 8780
+          env:
+            - name: PORT
+              value: "8780"
+            - name: AGENTPLANE_URL
+              value: "http://agentplane:8730"
+            - name: MODEL_ROUTER_URL
+              value: "http://model-router:8710"
+            - name: AGENT_REGISTRY_URL
+              value: "http://agent-registry:8720"
+            - name: MEMORYD_URL
+              value: "http://memoryd:8787"
+            - name: MEMORYD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-memoryd-credentials
+                  key: api-key
+            - name: POLICY_FABRIC_URL
+              value: "http://policy-fabric:8700"
+            - name: SUPERCONSCIOUS_URL
+              value: "http://superconscious:8740"
+            - name: TRITFABRIC_URL
+              value: "http://tritfabric:8750"
+            - name: GOVERNANCE_LEDGER_URL
+              value: "http://model-governance-ledger:8760"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8780
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8780
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+

--- a/infra/k8s/prophet-mesh/base/kustomization.yaml
+++ b/infra/k8s/prophet-mesh/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/prophet-mesh/base/service.yaml
+++ b/infra/k8s/prophet-mesh/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prophet-mesh
+spec:
+  selector:
+    app: prophet-mesh
+  ports:
+  - name: http
+    port: 8780
+    targetPort: 8780

--- a/infra/k8s/prophet-mesh/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/prophet-mesh/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: prophet-mesh

--- a/infra/k8s/regis-entity-graph/base/deployment.yaml
+++ b/infra/k8s/regis-entity-graph/base/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: regis-entity-graph
+  labels:
+    app: regis-entity-graph
+    bundle: graph.entity
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: regis-entity-graph
+  template:
+    metadata:
+      labels:
+        app: regis-entity-graph
+        bundle: graph.entity
+    spec:
+      containers:
+        - name: regis-entity-graph
+          image: ghcr.io/socioprophet/regis-entity-graph:latest
+          ports:
+            - name: http
+              containerPort: 8820
+          env:
+            - name: PORT
+              value: "8820"
+            - name: HELLGRAPH_URL
+              value: "http://hellgraph:8850"
+            - name: AGENT_REGISTRY_URL
+              value: "http://agent-registry:8720"
+            - name: POLICY_FABRIC_URL
+              value: "http://policy-fabric:8700"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8820
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8820
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/regis-entity-graph/base/kustomization.yaml
+++ b/infra/k8s/regis-entity-graph/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/regis-entity-graph/base/service.yaml
+++ b/infra/k8s/regis-entity-graph/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: regis-entity-graph
+spec:
+  selector:
+    app: regis-entity-graph
+  ports:
+    - name: http
+      port: 8820
+      targetPort: 8820

--- a/infra/k8s/regis-entity-graph/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/regis-entity-graph/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: regis-entity-graph

--- a/infra/k8s/sherlock-search/base/deployment.yaml
+++ b/infra/k8s/sherlock-search/base/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sherlock-search
+  labels:
+    app: sherlock-search
+    bundle: search.evidence
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sherlock-search
+  template:
+    metadata:
+      labels:
+        app: sherlock-search
+        bundle: search.evidence
+    spec:
+      containers:
+        - name: sherlock-search
+          image: ghcr.io/socioprophet/sherlock-search:latest
+          ports:
+            - name: http
+              containerPort: 8810
+          env:
+            - name: PORT
+              value: "8810"
+            - name: REGIS_ENTITY_GRAPH_URL
+              value: "http://regis-entity-graph:8820"
+            - name: MEMORYD_URL
+              value: "http://memoryd:8787"
+            - name: MEMORYD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-memoryd-credentials
+                  key: api-key
+            - name: OPENSEARCH_URL
+              valueFrom:
+                secretKeyRef:
+                  name: sherlock-credentials
+                  key: opensearch-url
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8810
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8810
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/sherlock-search/base/kustomization.yaml
+++ b/infra/k8s/sherlock-search/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/sherlock-search/base/service.yaml
+++ b/infra/k8s/sherlock-search/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sherlock-search
+spec:
+  selector:
+    app: sherlock-search
+  ports:
+    - name: http
+      port: 8810
+      targetPort: 8810

--- a/infra/k8s/sherlock-search/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/sherlock-search/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: sherlock-search

--- a/infra/k8s/sociosphere/base/deployment.yaml
+++ b/infra/k8s/sociosphere/base/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sociosphere
+  labels:
+    app: sociosphere
+    bundle: platform.controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sociosphere
+  template:
+    metadata:
+      labels:
+        app: sociosphere
+        bundle: platform.controller
+    spec:
+      containers:
+        - name: sociosphere
+          image: ghcr.io/socioprophet/sociosphere:latest
+          ports:
+            - name: http
+              containerPort: 5000
+          env:
+            - name: PORT
+              value: "5000"
+            - name: POLICY_FABRIC_URL
+              value: "http://policy-fabric:8700"
+            - name: AGENT_REGISTRY_URL
+              value: "http://agent-registry:8720"
+            - name: MEMORYD_URL
+              value: "http://memoryd:8787"
+            - name: MEMORYD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-memoryd-credentials
+                  key: api-key
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: sociosphere-credentials
+                  key: github-token
+            - name: GITHUB_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: sociosphere-credentials
+                  key: webhook-secret
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 5000
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/sociosphere/base/kustomization.yaml
+++ b/infra/k8s/sociosphere/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/sociosphere/base/service.yaml
+++ b/infra/k8s/sociosphere/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sociosphere
+spec:
+  selector:
+    app: sociosphere
+  ports:
+    - name: http
+      port: 5000
+      targetPort: 5000

--- a/infra/k8s/sociosphere/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/sociosphere/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: sociosphere

--- a/infra/k8s/superconscious/base/deployment.yaml
+++ b/infra/k8s/superconscious/base/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: superconscious
+  labels:
+    app: superconscious
+    bundle: mesh.cognition
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: superconscious
+  template:
+    metadata:
+      labels:
+        app: superconscious
+        bundle: mesh.cognition
+    spec:
+      containers:
+        - name: superconscious
+          image: ghcr.io/socioprophet/superconscious:latest
+          ports:
+            - name: http
+              containerPort: 8740
+          env:
+            - name: PORT
+              value: "8740"
+            - name: MODEL_ROUTER_URL
+              value: "http://model-router:8710"
+            - name: MEMORYD_URL
+              value: "http://memoryd:8787"
+            - name: MEMORYD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-memoryd-credentials
+                  key: api-key
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8740
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8740
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+

--- a/infra/k8s/superconscious/base/kustomization.yaml
+++ b/infra/k8s/superconscious/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/superconscious/base/service.yaml
+++ b/infra/k8s/superconscious/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: superconscious
+spec:
+  selector:
+    app: superconscious
+  ports:
+  - name: http
+    port: 8740
+    targetPort: 8740

--- a/infra/k8s/superconscious/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/superconscious/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: superconscious

--- a/infra/k8s/synapseiq-control-plane/base/deployment.yaml
+++ b/infra/k8s/synapseiq-control-plane/base/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synapseiq-control-plane
+  labels:
+    app: synapseiq-control-plane
+    bundle: enrichment.control
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: synapseiq-control-plane
+  template:
+    metadata:
+      labels:
+        app: synapseiq-control-plane
+        bundle: enrichment.control
+    spec:
+      containers:
+        - name: synapseiq-control-plane
+          image: ghcr.io/socioprophet/synapseiq/control-plane:latest
+          ports:
+            - name: http
+              containerPort: 8800
+          env:
+            - name: PORT
+              value: "8800"
+            - name: MODEL_ROUTER_URL
+              value: "http://model-router:8710"
+            - name: MEMORYD_URL
+              value: "http://memoryd:8787"
+            - name: MEMORYD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-memoryd-credentials
+                  key: api-key
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8800
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8800
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/synapseiq-control-plane/base/kustomization.yaml
+++ b/infra/k8s/synapseiq-control-plane/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/synapseiq-control-plane/base/service.yaml
+++ b/infra/k8s/synapseiq-control-plane/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: synapseiq-control-plane
+spec:
+  selector:
+    app: synapseiq-control-plane
+  ports:
+    - name: http
+      port: 8800
+      targetPort: 8800

--- a/infra/k8s/synapseiq-control-plane/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/synapseiq-control-plane/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: synapseiq-control-plane

--- a/infra/k8s/synapseiq-enrichment-api/base/deployment.yaml
+++ b/infra/k8s/synapseiq-enrichment-api/base/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synapseiq-enrichment-api
+  labels:
+    app: synapseiq-enrichment-api
+    bundle: enrichment.api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: synapseiq-enrichment-api
+  template:
+    metadata:
+      labels:
+        app: synapseiq-enrichment-api
+        bundle: enrichment.api
+    spec:
+      containers:
+        - name: synapseiq-enrichment-api
+          image: ghcr.io/socioprophet/synapseiq/enrichment-api:latest
+          ports:
+            - name: http
+              containerPort: 8801
+          env:
+            - name: PORT
+              value: "8801"
+            - name: CATALOG_URL
+              value: "http://prophet-core-catalog:8830"
+            - name: MEMORYD_URL
+              value: "http://memoryd:8787"
+            - name: MEMORYD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mesh-memoryd-credentials
+                  key: api-key
+            - name: CONTROL_PLANE_URL
+              value: "http://synapseiq-control-plane:8800"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8801
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8801
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/synapseiq-enrichment-api/base/kustomization.yaml
+++ b/infra/k8s/synapseiq-enrichment-api/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/synapseiq-enrichment-api/base/service.yaml
+++ b/infra/k8s/synapseiq-enrichment-api/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: synapseiq-enrichment-api
+spec:
+  selector:
+    app: synapseiq-enrichment-api
+  ports:
+    - name: http
+      port: 8801
+      targetPort: 8801

--- a/infra/k8s/synapseiq-enrichment-api/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/synapseiq-enrichment-api/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: synapseiq-enrichment-api

--- a/infra/k8s/synapseiq-enrichment-collector/base/deployment.yaml
+++ b/infra/k8s/synapseiq-enrichment-collector/base/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synapseiq-enrichment-collector
+  labels:
+    app: synapseiq-enrichment-collector
+    bundle: enrichment.collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: synapseiq-enrichment-collector
+  template:
+    metadata:
+      labels:
+        app: synapseiq-enrichment-collector
+        bundle: enrichment.collector
+    spec:
+      containers:
+        - name: synapseiq-enrichment-collector
+          image: ghcr.io/socioprophet/synapseiq/enrichment-collector:latest
+          ports:
+            - name: http
+              containerPort: 8802
+          env:
+            - name: PORT
+              value: "8802"
+            - name: ENRICHMENT_API_URL
+              value: "http://synapseiq-enrichment-api:8801"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8802
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8802
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/synapseiq-enrichment-collector/base/kustomization.yaml
+++ b/infra/k8s/synapseiq-enrichment-collector/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/synapseiq-enrichment-collector/base/service.yaml
+++ b/infra/k8s/synapseiq-enrichment-collector/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: synapseiq-enrichment-collector
+spec:
+  selector:
+    app: synapseiq-enrichment-collector
+  ports:
+    - name: http
+      port: 8802
+      targetPort: 8802

--- a/infra/k8s/synapseiq-enrichment-collector/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/synapseiq-enrichment-collector/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: synapseiq-enrichment-collector

--- a/infra/k8s/synapseiq-reasoning-api/base/deployment.yaml
+++ b/infra/k8s/synapseiq-reasoning-api/base/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synapseiq-reasoning-api
+  labels:
+    app: synapseiq-reasoning-api
+    bundle: enrichment.reasoning
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: synapseiq-reasoning-api
+  template:
+    metadata:
+      labels:
+        app: synapseiq-reasoning-api
+        bundle: enrichment.reasoning
+    spec:
+      containers:
+        - name: synapseiq-reasoning-api
+          image: ghcr.io/socioprophet/synapseiq/reasoning-api:latest
+          ports:
+            - name: http
+              containerPort: 8803
+          env:
+            - name: PORT
+              value: "8803"
+            - name: MODEL_ROUTER_URL
+              value: "http://model-router:8710"
+            - name: SUPERCONSCIOUS_URL
+              value: "http://superconscious:8740"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8803
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8803
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/synapseiq-reasoning-api/base/kustomization.yaml
+++ b/infra/k8s/synapseiq-reasoning-api/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/synapseiq-reasoning-api/base/service.yaml
+++ b/infra/k8s/synapseiq-reasoning-api/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: synapseiq-reasoning-api
+spec:
+  selector:
+    app: synapseiq-reasoning-api
+  ports:
+    - name: http
+      port: 8803
+      targetPort: 8803

--- a/infra/k8s/synapseiq-reasoning-api/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/synapseiq-reasoning-api/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: synapseiq-reasoning-api

--- a/infra/k8s/synapseiq-tabular-alpha/base/deployment.yaml
+++ b/infra/k8s/synapseiq-tabular-alpha/base/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synapseiq-tabular-alpha
+  labels:
+    app: synapseiq-tabular-alpha
+    bundle: enrichment.tabular
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: synapseiq-tabular-alpha
+  template:
+    metadata:
+      labels:
+        app: synapseiq-tabular-alpha
+        bundle: enrichment.tabular
+    spec:
+      containers:
+        - name: synapseiq-tabular-alpha
+          image: ghcr.io/socioprophet/synapseiq/tabular-alpha-api:latest
+          ports:
+            - name: http
+              containerPort: 8804
+          env:
+            - name: PORT
+              value: "8804"
+            - name: ENRICHMENT_API_URL
+              value: "http://synapseiq-enrichment-api:8801"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8804
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8804
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"

--- a/infra/k8s/synapseiq-tabular-alpha/base/kustomization.yaml
+++ b/infra/k8s/synapseiq-tabular-alpha/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/synapseiq-tabular-alpha/base/service.yaml
+++ b/infra/k8s/synapseiq-tabular-alpha/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: synapseiq-tabular-alpha
+spec:
+  selector:
+    app: synapseiq-tabular-alpha
+  ports:
+    - name: http
+      port: 8804
+      targetPort: 8804

--- a/infra/k8s/synapseiq-tabular-alpha/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/synapseiq-tabular-alpha/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: synapseiq-tabular-alpha

--- a/infra/k8s/tritfabric/base/deployment.yaml
+++ b/infra/k8s/tritfabric/base/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tritfabric
+  labels:
+    app: tritfabric
+    bundle: mesh.ml
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tritfabric
+  template:
+    metadata:
+      labels:
+        app: tritfabric
+        bundle: mesh.ml
+    spec:
+      containers:
+        - name: tritfabric
+          image: ghcr.io/socioprophet/tritfabric:latest
+          ports:
+            - name: http
+              containerPort: 8750
+            - name: metrics
+              containerPort: 9108
+          env:
+            - name: PORT
+              value: "8750"
+            - name: METRICS_PORT
+              value: "9108"
+            - name: GOVERNANCE_LEDGER_URL
+              value: "http://model-governance-ledger:8760"
+            - name: POLICY_OPT_IN_REQUIRED
+              value: "false"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8750
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8750
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+

--- a/infra/k8s/tritfabric/base/kustomization.yaml
+++ b/infra/k8s/tritfabric/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+namespace: socioprophet

--- a/infra/k8s/tritfabric/base/service.yaml
+++ b/infra/k8s/tritfabric/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tritfabric
+spec:
+  selector:
+    app: tritfabric
+  ports:
+  - name: http
+    port: 8750
+    targetPort: 8750
+  - name: metrics
+    port: 9108
+    targetPort: 9108

--- a/infra/k8s/tritfabric/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/tritfabric/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: socioprophet
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+      name: tritfabric

--- a/infra/local/docker-compose.mesh.yml
+++ b/infra/local/docker-compose.mesh.yml
@@ -1,0 +1,348 @@
+# Prophet Mesh — local development stack
+# Prerequisite: docker compose plugin, local clones of each repo beside prophet-platform
+#
+# Service start order (dependency tiers):
+#   Tier 0: postgres, qdrant
+#   Tier 1: model-governance-ledger (stateless sidecar)
+#   Tier 2: memoryd, policy-fabric
+#   Tier 3: model-router, agent-registry
+#   Tier 4: superconscious, agentplane
+#   Tier 5: tritfabric-server
+#   Tier 6: prophet-mesh-conductor (orchestrator)
+#
+# Local image build:
+#   docker compose -f docker-compose.mesh.yml build
+# Bring up:
+#   docker compose -f docker-compose.mesh.yml up -d
+# Ports (all loopback-only):
+#   memoryd              127.0.0.1:8787
+#   policy-fabric        127.0.0.1:8700
+#   model-router         127.0.0.1:8710
+#   agent-registry       127.0.0.1:8720
+#   agentplane           127.0.0.1:8730
+#   superconscious       127.0.0.1:8740
+#   tritfabric-server    127.0.0.1:8750
+#   model-governance-ledger 127.0.0.1:8760
+#   prophet-mesh         127.0.0.1:8780
+#   qdrant HTTP          127.0.0.1:6333
+#   qdrant gRPC          127.0.0.1:6334
+
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "10m"
+    max-file: "3"
+
+x-restart: &default-restart
+  restart: unless-stopped
+
+services:
+
+  # ── Tier 0: Data stores ────────────────────────────────────────────────────
+
+  postgres-mesh:
+    image: postgres:16
+    container_name: mesh-postgres
+    <<: *default-restart
+    environment:
+      POSTGRES_DB: ${MESH_PG_DB:-prophet_mesh}
+      POSTGRES_USER: ${MESH_PG_USER:-prophet}
+      POSTGRES_PASSWORD: ${MESH_PG_PASSWORD:-mesh-dev-password}
+    ports:
+      - "127.0.0.1:${MESH_PG_PORT:-5433}:5432"
+    volumes:
+      - mesh_postgres_data:/var/lib/postgresql/data
+      - ../datastores/postgres/:/docker-entrypoint-initdb.d/:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${MESH_PG_USER:-prophet} -d ${MESH_PG_DB:-prophet_mesh}"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    logging: *default-logging
+
+  qdrant:
+    image: qdrant/qdrant:v1.9.4
+    container_name: mesh-qdrant
+    <<: *default-restart
+    ports:
+      - "127.0.0.1:6333:6333"
+      - "127.0.0.1:6334:6334"
+    volumes:
+      - mesh_qdrant_data:/qdrant/storage
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:6333/readyz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    logging: *default-logging
+
+  # ── Tier 1: Ledger (stateless) ─────────────────────────────────────────────
+
+  model-governance-ledger:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/model-governance-ledger
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/model-governance-ledger:dev
+    container_name: mesh-governance-ledger
+    <<: *default-restart
+    environment:
+      PORT: "8760"
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8760:8760"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8760/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  # ── Tier 2: Core services ──────────────────────────────────────────────────
+
+  memoryd:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/memory-mesh
+      dockerfile: images/memoryd.Dockerfile
+    image: ghcr.io/socioprophet/memory-mesh/memoryd:dev
+    container_name: mesh-memoryd
+    <<: *default-restart
+    depends_on:
+      postgres-mesh:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+    environment:
+      MEMORYD_REQUIRE_API_KEY: "true"
+      MEMORYD_API_KEY: ${MEMORYD_API_KEY:-mesh-local-dev}
+      MEMORYMESH_STORE_URI: postgresql://prophet:mesh-dev-password@postgres-mesh:5432/prophet_mesh
+      MEMORYMESH_VECTOR_BACKEND: qdrant
+      QDRANT_URL: http://qdrant:6333
+      QDRANT_COLLECTION: ${QDRANT_COLLECTION:-prophet-mesh-local}
+      QDRANT_ENABLED: "true"
+      MEMORYMESH_VECTOR_SIZE: ${MEMORYMESH_VECTOR_SIZE:-256}
+    ports:
+      - "127.0.0.1:8787:8787"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8787/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    logging: *default-logging
+
+  policy-fabric:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/policy-fabric
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/policy-fabric:dev
+    container_name: mesh-policy-fabric
+    <<: *default-restart
+    environment:
+      PORT: "8700"
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8700:8700"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8700/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  # ── Tier 3: Routing + Registry ─────────────────────────────────────────────
+
+  model-router:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/model-router
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/model-router:dev
+    container_name: mesh-model-router
+    <<: *default-restart
+    depends_on:
+      policy-fabric:
+        condition: service_healthy
+      memoryd:
+        condition: service_healthy
+    environment:
+      PORT: "8710"
+      POLICY_FABRIC_URL: http://policy-fabric:8700
+      MEMORYD_URL: http://memoryd:8787
+      MEMORYD_API_KEY: ${MEMORYD_API_KEY:-mesh-local-dev}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8710:8710"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8710/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  agent-registry:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/agent-registry
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/agent-registry:dev
+    container_name: mesh-agent-registry
+    <<: *default-restart
+    depends_on:
+      policy-fabric:
+        condition: service_healthy
+      postgres-mesh:
+        condition: service_healthy
+    environment:
+      PORT: "8720"
+      POLICY_FABRIC_URL: http://policy-fabric:8700
+      STORE_URI: postgresql://prophet:mesh-dev-password@postgres-mesh:5432/prophet_mesh
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8720:8720"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8720/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  # ── Tier 4: Execution plane ────────────────────────────────────────────────
+
+  superconscious:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/superconscious
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/superconscious:dev
+    container_name: mesh-superconscious
+    <<: *default-restart
+    depends_on:
+      model-router:
+        condition: service_healthy
+      memoryd:
+        condition: service_healthy
+    environment:
+      PORT: "8740"
+      MODEL_ROUTER_URL: http://model-router:8710
+      MEMORYD_URL: http://memoryd:8787
+      MEMORYD_API_KEY: ${MEMORYD_API_KEY:-mesh-local-dev}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8740:8740"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8740/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  agentplane:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/agentplane
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/agentplane:dev
+    container_name: mesh-agentplane
+    <<: *default-restart
+    depends_on:
+      policy-fabric:
+        condition: service_healthy
+      agent-registry:
+        condition: service_healthy
+      model-router:
+        condition: service_healthy
+      memoryd:
+        condition: service_healthy
+      superconscious:
+        condition: service_healthy
+    environment:
+      PORT: "8730"
+      POLICY_FABRIC_URL: http://policy-fabric:8700
+      AGENT_REGISTRY_URL: http://agent-registry:8720
+      MODEL_ROUTER_URL: http://model-router:8710
+      MEMORYD_URL: http://memoryd:8787
+      MEMORYD_API_KEY: ${MEMORYD_API_KEY:-mesh-local-dev}
+      SUPERCONSCIOUS_URL: http://superconscious:8740
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8730:8730"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8730/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  # ── Tier 5: ML substrate ───────────────────────────────────────────────────
+
+  tritfabric-server:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/tritfabric
+      dockerfile: Dockerfile.server
+    image: ghcr.io/socioprophet/tritfabric:dev
+    container_name: mesh-tritfabric
+    <<: *default-restart
+    depends_on:
+      model-governance-ledger:
+        condition: service_healthy
+    environment:
+      PORT: "8750"
+      METRICS_PORT: "9108"
+      GOVERNANCE_LEDGER_URL: http://model-governance-ledger:8760
+      POLICY_OPT_IN_REQUIRED: "false"
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8750:8750"
+      - "127.0.0.1:9108:9108"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8750/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  # ── Tier 6: Mesh conductor ─────────────────────────────────────────────────
+
+  prophet-mesh:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/prophet-mesh
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/prophet-mesh:dev
+    container_name: mesh-prophet-mesh
+    <<: *default-restart
+    depends_on:
+      agentplane:
+        condition: service_healthy
+      model-router:
+        condition: service_healthy
+      agent-registry:
+        condition: service_healthy
+      memoryd:
+        condition: service_healthy
+      policy-fabric:
+        condition: service_healthy
+      superconscious:
+        condition: service_healthy
+      tritfabric-server:
+        condition: service_healthy
+      model-governance-ledger:
+        condition: service_healthy
+    environment:
+      PORT: "8780"
+      AGENTPLANE_URL: http://agentplane:8730
+      MODEL_ROUTER_URL: http://model-router:8710
+      AGENT_REGISTRY_URL: http://agent-registry:8720
+      MEMORYD_URL: http://memoryd:8787
+      MEMORYD_API_KEY: ${MEMORYD_API_KEY:-mesh-local-dev}
+      POLICY_FABRIC_URL: http://policy-fabric:8700
+      SUPERCONSCIOUS_URL: http://superconscious:8740
+      TRITFABRIC_URL: http://tritfabric-server:8750
+      GOVERNANCE_LEDGER_URL: http://model-governance-ledger:8760
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8780:8780"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8780/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    logging: *default-logging
+
+volumes:
+  mesh_postgres_data:
+  mesh_qdrant_data:

--- a/infra/local/docker-compose.sociosphere.yml
+++ b/infra/local/docker-compose.sociosphere.yml
@@ -6,11 +6,15 @@
 #
 # Ports (loopback-only, no mesh collisions):
 #   sociosphere          127.0.0.1:5000   (workspace controller + UI workbench)
+#   cloudshell-fog       127.0.0.1:8080   (fog-optimised shell gateway)
+#   cairnpath-mesh       127.0.0.1:8890   (execution path/trace mesh — Tier 4.5)
 #   hellgraph            127.0.0.1:8850   (Rust graph kernel)
+#   holmes               127.0.0.1:8880   (language intelligence fabric)
 #   regis-entity-graph   127.0.0.1:8820
 #   sherlock-search      127.0.0.1:8810
 #   prophet-core-catalog 127.0.0.1:8830
 #   prophet-core-query   127.0.0.1:8831
+#   contractforge        127.0.0.1:8895   (contract lifecycle + ledger execution)
 #   global-devsecops     127.0.0.1:8840
 #   lattice-forge        127.0.0.1:8870
 #   synapseiq-control    127.0.0.1:8800
@@ -19,7 +23,6 @@
 #   synapseiq-reasoning  127.0.0.1:8803
 #   synapseiq-tabular    127.0.0.1:8804
 #   mcp-a2a-zero-trust   127.0.0.1:8860
-#   cloudshell-fog       127.0.0.1:8080   (fog-optimised shell gateway)
 
 x-logging: &default-logging
   driver: "json-file"
@@ -379,3 +382,83 @@ services:
       timeout: 5s
       retries: 8
     logging: *default-logging
+
+  # ── Tier 4.5: Execution path/trace mesh ───────────────────────────────────
+
+  cairnpath-mesh:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/cairnpath-mesh
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/cairnpath-mesh:dev
+    container_name: sociosphere-cairnpath
+    restart: unless-stopped
+    environment:
+      PORT: "8890"
+      POLICY_FABRIC_URL: http://policy-fabric:8700
+      AGENTPLANE_URL: http://agentplane:8730
+      GOVERNANCE_LEDGER_URL: http://model-governance-ledger:8760
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8890:8890"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8890/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging:
+      driver: "json-file"
+      options: {max-size: "10m", max-file: "3"}
+
+  # ── Tier 8: Language intelligence ─────────────────────────────────────────
+
+  holmes:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/holmes
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/holmes:dev
+    container_name: sociosphere-holmes
+    restart: unless-stopped
+    environment:
+      PORT: "8880"
+      POLICY_FABRIC_URL: http://policy-fabric:8700
+      MODEL_ROUTER_URL: http://model-router:8710
+      MEMORYD_URL: http://memoryd:8787
+      MEMORYD_API_KEY: ${MEMORYD_API_KEY:-mesh-local-dev}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8880:8880"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8880/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging:
+      driver: "json-file"
+      options: {max-size: "10m", max-file: "3"}
+
+  # ── Tier 9: Contract lifecycle + ledger ───────────────────────────────────
+
+  contractforge:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/contractforge
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/contractforge:dev
+    container_name: sociosphere-contractforge
+    restart: unless-stopped
+    environment:
+      PORT: "8895"
+      POLICY_FABRIC_URL: http://policy-fabric:8700
+      GOVERNANCE_LEDGER_URL: http://model-governance-ledger:8760
+      AGENT_REGISTRY_URL: http://agent-registry:8720
+      AGENTPLANE_URL: http://agentplane:8730
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8895:8895"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8895/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging:
+      driver: "json-file"
+      options: {max-size: "10m", max-file: "3"}

--- a/infra/local/docker-compose.sociosphere.yml
+++ b/infra/local/docker-compose.sociosphere.yml
@@ -1,0 +1,381 @@
+# SocioSphere extended tier — workspace controller, graph/search, catalog, enrichment, zero-trust
+#
+# Requires docker-compose.mesh.yml to be running first (tiers 0-6).
+# Bring up together:
+#   docker compose -f docker-compose.mesh.yml -f docker-compose.sociosphere.yml up -d
+#
+# Ports (loopback-only, no mesh collisions):
+#   sociosphere          127.0.0.1:5000   (workspace controller + UI workbench)
+#   hellgraph            127.0.0.1:8850   (Rust graph kernel)
+#   regis-entity-graph   127.0.0.1:8820
+#   sherlock-search      127.0.0.1:8810
+#   prophet-core-catalog 127.0.0.1:8830
+#   prophet-core-query   127.0.0.1:8831
+#   global-devsecops     127.0.0.1:8840
+#   lattice-forge        127.0.0.1:8870
+#   synapseiq-control    127.0.0.1:8800
+#   synapseiq-enrich-api 127.0.0.1:8801
+#   synapseiq-collector  127.0.0.1:8802
+#   synapseiq-reasoning  127.0.0.1:8803
+#   synapseiq-tabular    127.0.0.1:8804
+#   mcp-a2a-zero-trust   127.0.0.1:8860
+#   cloudshell-fog       127.0.0.1:8080   (fog-optimised shell gateway)
+
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "10m"
+    max-file: "3"
+
+x-restart: &default-restart
+  restart: unless-stopped
+
+x-mesh-base: &mesh-base
+  POLICY_FABRIC_URL: http://policy-fabric:8700
+  AGENT_REGISTRY_URL: http://agent-registry:8720
+  MEMORYD_URL: http://memoryd:8787
+  MODEL_ROUTER_URL: http://model-router:8710
+
+services:
+
+  # ── Tier 7: Platform shell + workspace controller ──────────────────────────
+
+  cloudshell-fog:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/cloudshell-fog
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/cloudshell-fog:dev
+    container_name: sociosphere-cloudshell
+    <<: *default-restart
+    environment:
+      CLOUDSHELL_PORT: "8080"
+      POLICY_FABRIC_URL: http://policy-fabric:8700
+      AGENT_REGISTRY_URL: http://agent-registry:8720
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  sociosphere:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/sociosphere
+      dockerfile: deployment/Dockerfile
+    image: ghcr.io/socioprophet/sociosphere:dev
+    container_name: sociosphere-controller
+    <<: *default-restart
+    environment:
+      PORT: "5000"
+      <<: *mesh-base
+      MEMORYD_API_KEY: ${MEMORYD_API_KEY:-mesh-local-dev}
+      GITHUB_TOKEN: ${SOCIOSPHERE_GITHUB_TOKEN:-}
+      GITHUB_WEBHOOK_SECRET: ${SOCIOSPHERE_WEBHOOK_SECRET:-}
+    ports:
+      - "127.0.0.1:5000:5000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5000/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  # ── Tier 8: Graph kernel + entity graph + search ───────────────────────────
+
+  hellgraph:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/hellgraph
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/hellgraph:dev
+    container_name: sociosphere-hellgraph
+    <<: *default-restart
+    environment:
+      PORT: "8850"
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    ports:
+      - "127.0.0.1:8850:8850"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8850/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  regis-entity-graph:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/regis-entity-graph
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/regis-entity-graph:dev
+    container_name: sociosphere-regis
+    <<: *default-restart
+    depends_on:
+      hellgraph:
+        condition: service_healthy
+    environment:
+      PORT: "8820"
+      HELLGRAPH_URL: http://hellgraph:8850
+      AGENT_REGISTRY_URL: http://agent-registry:8720
+      POLICY_FABRIC_URL: http://policy-fabric:8700
+    ports:
+      - "127.0.0.1:8820:8820"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8820/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  sherlock-search:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/sherlock-search
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/sherlock-search:dev
+    container_name: sociosphere-sherlock
+    <<: *default-restart
+    depends_on:
+      regis-entity-graph:
+        condition: service_healthy
+    environment:
+      PORT: "8810"
+      REGIS_ENTITY_GRAPH_URL: http://regis-entity-graph:8820
+      MEMORYD_URL: http://memoryd:8787
+      MEMORYD_API_KEY: ${MEMORYD_API_KEY:-mesh-local-dev}
+      OPENSEARCH_URL: ${OPENSEARCH_URL:-http://opensearch:9200}
+    ports:
+      - "127.0.0.1:8810:8810"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8810/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  # ── Tier 9: Catalog + query + intelligence + forge ─────────────────────────
+
+  prophet-core-catalog:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/prophet-core-catalog
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/prophet-core-catalog:dev
+    container_name: sociosphere-catalog
+    <<: *default-restart
+    environment:
+      PORT: "8830"
+      POLICY_FABRIC_URL: http://policy-fabric:8700
+      GOVERNANCE_LEDGER_URL: http://model-governance-ledger:8760
+    ports:
+      - "127.0.0.1:8830:8830"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8830/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  prophet-core-query:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/prophet-core-query
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/prophet-core-query:dev
+    container_name: sociosphere-query
+    <<: *default-restart
+    depends_on:
+      prophet-core-catalog:
+        condition: service_healthy
+    environment:
+      PORT: "8831"
+      CATALOG_URL: http://prophet-core-catalog:8830
+      MEMORYD_URL: http://memoryd:8787
+      MEMORYD_API_KEY: ${MEMORYD_API_KEY:-mesh-local-dev}
+    ports:
+      - "127.0.0.1:8831:8831"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8831/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  global-devsecops-intelligence:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/global-devsecops-intelligence
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/global-devsecops-intelligence:dev
+    container_name: sociosphere-devsecops
+    <<: *default-restart
+    depends_on:
+      sherlock-search:
+        condition: service_healthy
+    environment:
+      PORT: "8840"
+      SHERLOCK_URL: http://sherlock-search:8810
+      MODEL_ROUTER_URL: http://model-router:8710
+    ports:
+      - "127.0.0.1:8840:8840"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8840/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  lattice-forge:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/lattice-forge
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/lattice-forge:dev
+    container_name: sociosphere-lattice-forge
+    <<: *default-restart
+    environment:
+      PORT: "8870"
+      TRITFABRIC_URL: http://tritfabric-server:8750
+      GOVERNANCE_LEDGER_URL: http://model-governance-ledger:8760
+    ports:
+      - "127.0.0.1:8870:8870"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8870/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  # ── Tier 10: Enrichment services + MCP zero-trust ─────────────────────────
+
+  synapseiq-control-plane:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/synapseiq
+      dockerfile: services/control-plane/Dockerfile
+    image: ghcr.io/socioprophet/synapseiq/control-plane:dev
+    container_name: sociosphere-synapseiq-control
+    <<: *default-restart
+    environment:
+      PORT: "8800"
+      MODEL_ROUTER_URL: http://model-router:8710
+      MEMORYD_URL: http://memoryd:8787
+      MEMORYD_API_KEY: ${MEMORYD_API_KEY:-mesh-local-dev}
+    ports:
+      - "127.0.0.1:8800:8800"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8800/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  synapseiq-enrichment-api:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/synapseiq
+      dockerfile: services/enrichment-api/Dockerfile
+    image: ghcr.io/socioprophet/synapseiq/enrichment-api:dev
+    container_name: sociosphere-synapseiq-enrich
+    <<: *default-restart
+    depends_on:
+      synapseiq-control-plane:
+        condition: service_healthy
+      prophet-core-catalog:
+        condition: service_healthy
+    environment:
+      PORT: "8801"
+      CATALOG_URL: http://prophet-core-catalog:8830
+      MEMORYD_URL: http://memoryd:8787
+      MEMORYD_API_KEY: ${MEMORYD_API_KEY:-mesh-local-dev}
+      CONTROL_PLANE_URL: http://synapseiq-control-plane:8800
+    ports:
+      - "127.0.0.1:8801:8801"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8801/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  synapseiq-enrichment-collector:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/synapseiq
+      dockerfile: services/enrichment-collector/Dockerfile
+    image: ghcr.io/socioprophet/synapseiq/enrichment-collector:dev
+    container_name: sociosphere-synapseiq-collector
+    <<: *default-restart
+    depends_on:
+      synapseiq-enrichment-api:
+        condition: service_healthy
+    environment:
+      PORT: "8802"
+      ENRICHMENT_API_URL: http://synapseiq-enrichment-api:8801
+    ports:
+      - "127.0.0.1:8802:8802"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8802/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  synapseiq-reasoning-api:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/synapseiq
+      dockerfile: services/reasoning-api/Dockerfile
+    image: ghcr.io/socioprophet/synapseiq/reasoning-api:dev
+    container_name: sociosphere-synapseiq-reasoning
+    <<: *default-restart
+    depends_on:
+      synapseiq-control-plane:
+        condition: service_healthy
+    environment:
+      PORT: "8803"
+      MODEL_ROUTER_URL: http://model-router:8710
+      SUPERCONSCIOUS_URL: http://superconscious:8740
+    ports:
+      - "127.0.0.1:8803:8803"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8803/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  synapseiq-tabular-alpha:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/synapseiq
+      dockerfile: services/tabular-alpha-api/Dockerfile
+    image: ghcr.io/socioprophet/synapseiq/tabular-alpha-api:dev
+    container_name: sociosphere-synapseiq-tabular
+    <<: *default-restart
+    depends_on:
+      synapseiq-enrichment-api:
+        condition: service_healthy
+    environment:
+      PORT: "8804"
+      ENRICHMENT_API_URL: http://synapseiq-enrichment-api:8801
+    ports:
+      - "127.0.0.1:8804:8804"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8804/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging
+
+  mcp-a2a-zero-trust:
+    build:
+      context: ${MESH_REPOS_ROOT:-../../..}/mcp-a2a-zero-trust
+      dockerfile: Dockerfile
+    image: ghcr.io/socioprophet/mcp-a2a-zero-trust:dev
+    container_name: sociosphere-mcp-zerotrust
+    <<: *default-restart
+    environment:
+      PORT: "8860"
+      POLICY_FABRIC_URL: http://policy-fabric:8700
+      AGENT_REGISTRY_URL: http://agent-registry:8720
+      AGENTPLANE_URL: http://agentplane:8730
+    ports:
+      - "127.0.0.1:8860:8860"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8860/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 8
+    logging: *default-logging

--- a/infra/tofu/.gitignore
+++ b/infra/tofu/.gitignore
@@ -1,0 +1,12 @@
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+!*.tfvars.example
+.secrets-staging/
+k3d-config.yaml
+dns-records.txt
+crash.log
+override.tf
+*_override.tf
+.terraform.lock.hcl

--- a/infra/tofu/envs/gcp-landing/main.tf
+++ b/infra/tofu/envs/gcp-landing/main.tf
@@ -1,0 +1,193 @@
+# GCP Landing Zone — socioprophet.ai org
+#
+# APPLY GATE: plan-only in CI. No apply without:
+#   1. Manual approval in GitHub Actions environment "gcp-prod"
+#   2. Signed plan artifact (SLSA provenance)
+#   3. Destroy review documented in ADR or GitHub issue
+#
+# This env creates the org-level shape only.
+# Per-project workloads are deployed by Argo CD from Kustomize manifests.
+
+terraform {
+  backend "gcs" {
+    bucket = "prophet-tofu-state-prod"
+    prefix = "gcp-landing/terraform.tfstate"
+  }
+}
+
+provider "google" {
+  # Credentials via Workload Identity Federation in CI;
+  # gcloud application-default credentials locally.
+  # Never commit a service account key.
+}
+
+provider "google-beta" {}
+
+# ── Variables ─────────────────────────────────────────────────────────────────
+
+variable "org_domain"        { type = string; default = "socioprophet.ai" }
+variable "billing_account"   { type = string }
+variable "admin_group_email" { type = string; default = "platform-admins@socioprophet.ai" }
+variable "alert_email"       { type = string; default = "ops@socioprophet.ai" }
+
+# ── Org ───────────────────────────────────────────────────────────────────────
+
+module "org" {
+  source            = "../../modules/org"
+  org_domain        = var.org_domain
+  billing_account   = var.billing_account
+  admin_group_email = var.admin_group_email
+}
+
+# ── Folders ───────────────────────────────────────────────────────────────────
+
+module "folders" {
+  source = "../../modules/folders"
+  org_id = module.org.org_id
+  folders = {
+    production = { display_name = "Production" }
+    shared     = { display_name = "Shared" }
+  }
+}
+
+# ── Projects ──────────────────────────────────────────────────────────────────
+
+module "projects" {
+  source          = "../../modules/projects"
+  org_id          = module.org.org_id
+  billing_account = var.billing_account
+
+  projects = {
+    platform = {
+      project_id   = "socioprophet-platform"
+      display_name = "Prophet Platform"
+      folder_key   = "shared"
+      folder_ids   = module.folders.folder_ids
+      services = [
+        "artifactregistry.googleapis.com",
+        "container.googleapis.com",
+        "secretmanager.googleapis.com",
+        "cloudkms.googleapis.com",
+        "iam.googleapis.com",
+      ]
+    }
+    logging = {
+      project_id   = "socioprophet-logging-prod"
+      display_name = "Prophet Logging Prod"
+      folder_key   = "shared"
+      folder_ids   = module.folders.folder_ids
+      services     = ["logging.googleapis.com", "bigquery.googleapis.com"]
+    }
+    monitoring = {
+      project_id   = "socioprophet-monitoring-prod"
+      display_name = "Prophet Monitoring Prod"
+      folder_key   = "shared"
+      folder_ids   = module.folders.folder_ids
+      services     = ["monitoring.googleapis.com", "cloudtrace.googleapis.com"]
+    }
+    vpc_host = {
+      project_id   = "socioprophet-vpc-host-prod"
+      display_name = "Prophet VPC Host Prod"
+      folder_key   = "shared"
+      folder_ids   = module.folders.folder_ids
+      services     = ["compute.googleapis.com", "container.googleapis.com"]
+    }
+    web = {
+      project_id   = "socioprophet-web"
+      display_name = "SocioProphet Web"
+      folder_key   = "production"
+      folder_ids   = module.folders.folder_ids
+      services     = ["run.googleapis.com", "firebase.googleapis.com"]
+    }
+    cloud = {
+      project_id   = "socioprophet-cloud"
+      display_name = "SocioProphet Cloud"
+      folder_key   = "production"
+      folder_ids   = module.folders.folder_ids
+      services     = ["container.googleapis.com", "compute.googleapis.com"]
+    }
+    im = {
+      project_id   = "socioprophet-im"
+      display_name = "SocioProphet IM"
+      folder_key   = "production"
+      folder_ids   = module.folders.folder_ids
+      services     = ["container.googleapis.com"]
+    }
+    social = {
+      project_id   = "socioprophet-social"
+      display_name = "SocioProphet Social"
+      folder_key   = "production"
+      folder_ids   = module.folders.folder_ids
+      services     = ["container.googleapis.com"]
+    }
+    news = {
+      project_id   = "socioprophet-news"
+      display_name = "SocioProphet News"
+      folder_key   = "production"
+      folder_ids   = module.folders.folder_ids
+      services     = ["container.googleapis.com"]
+    }
+  }
+}
+
+# ── Network (Shared VPC) ──────────────────────────────────────────────────────
+
+module "network" {
+  source          = "../../modules/network"
+  host_project_id = module.projects.project_ids["vpc_host"]
+  shared_vpc_service_projects = [
+    module.projects.project_ids["cloud"],
+    module.projects.project_ids["im"],
+    module.projects.project_ids["social"],
+    module.projects.project_ids["news"],
+  ]
+}
+
+# ── Artifact Registry (platform project, us-central1) ────────────────────────
+
+module "artifact_registry" {
+  source     = "../../modules/artifact-registry"
+  project_id = module.projects.project_ids["platform"]
+  location   = "us-central1"
+  repositories = {
+    core   = { description = "Core platform services" }
+    web    = { description = "Web surface" }
+    edge   = { description = "Edge and fog services" }
+    social = { description = "Social surface" }
+    im     = { description = "IM/messaging surface" }
+    news   = { description = "News surface" }
+  }
+}
+
+# ── Policy ────────────────────────────────────────────────────────────────────
+
+module "policy" {
+  source     = "../../modules/policy"
+  org_id     = module.org.org_id
+  folder_ids = module.folders.folder_ids
+}
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+
+module "logging" {
+  source             = "../../modules/logging"
+  logging_project_id = module.projects.project_ids["logging"]
+  source_project_ids = values(module.projects.project_ids)
+}
+
+# ── Monitoring ────────────────────────────────────────────────────────────────
+
+module "monitoring" {
+  source                = "../../modules/monitoring"
+  monitoring_project_id = module.projects.project_ids["monitoring"]
+  scoped_project_ids    = values(module.projects.project_ids)
+  alert_email           = var.alert_email
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+output "org_id"           { value = module.org.org_id }
+output "folder_ids"       { value = module.folders.folder_ids }
+output "project_ids"      { value = module.projects.project_ids }
+output "registry_urls"    { value = module.artifact_registry.repository_urls }
+output "vpc_id"           { value = module.network.vpc_id }

--- a/infra/tofu/envs/gcp-landing/main.tf
+++ b/infra/tofu/envs/gcp-landing/main.tf
@@ -25,10 +25,21 @@ provider "google-beta" {}
 
 # ── Variables ─────────────────────────────────────────────────────────────────
 
-variable "org_domain"        { type = string; default = "socioprophet.ai" }
-variable "billing_account"   { type = string }
-variable "admin_group_email" { type = string; default = "platform-admins@socioprophet.ai" }
-variable "alert_email"       { type = string; default = "ops@socioprophet.ai" }
+variable "org_domain" {
+  type    = string
+  default = "socioprophet.ai"
+}
+variable "billing_account" {
+  type = string
+}
+variable "admin_group_email" {
+  type    = string
+  default = "platform-admins@socioprophet.ai"
+}
+variable "alert_email" {
+  type    = string
+  default = "ops@socioprophet.ai"
+}
 
 # ── Org ───────────────────────────────────────────────────────────────────────
 
@@ -186,8 +197,8 @@ module "monitoring" {
 
 # ── Outputs ───────────────────────────────────────────────────────────────────
 
-output "org_id"           { value = module.org.org_id }
-output "folder_ids"       { value = module.folders.folder_ids }
-output "project_ids"      { value = module.projects.project_ids }
-output "registry_urls"    { value = module.artifact_registry.repository_urls }
-output "vpc_id"           { value = module.network.vpc_id }
+output "org_id" { value = module.org.org_id }
+output "folder_ids" { value = module.folders.folder_ids }
+output "project_ids" { value = module.projects.project_ids }
+output "registry_urls" { value = module.artifact_registry.repository_urls }
+output "vpc_id" { value = module.network.vpc_id }

--- a/infra/tofu/envs/gcp-landing/terraform.tfvars.example
+++ b/infra/tofu/envs/gcp-landing/terraform.tfvars.example
@@ -1,0 +1,5 @@
+# Copy to terraform.tfvars. Never commit terraform.tfvars.
+# Get billing_account from: gcloud billing accounts list
+billing_account   = "XXXXXX-XXXXXX-XXXXXX"
+admin_group_email = "platform-admins@socioprophet.ai"
+alert_email       = "ops@socioprophet.ai"

--- a/infra/tofu/envs/local/main.tf
+++ b/infra/tofu/envs/local/main.tf
@@ -1,0 +1,75 @@
+# Local environment — provider-agnostic
+# Provisions a k3d cluster for local development.
+# No cloud provider required. No state backend — local file.
+# Maps to p0-lab overlay in infra/k8s/overlays/p0-lab/.
+
+terraform {
+  backend "local" {
+    path = ".terraform/local.tfstate"
+  }
+}
+
+variable "cluster_name" { type = string; default = "prophet-local" }
+variable "k3d_agents"   { type = number; default = 2 }
+variable "api_port"     { type = number; default = 6550 }
+
+resource "random_password" "k3s_token" {
+  length  = 48
+  special = false
+}
+
+resource "local_file" "k3d_config" {
+  filename = "${path.root}/k3d-config.yaml"
+  content  = <<-YAML
+    apiVersion: k3d.io/v1alpha5
+    kind: Simple
+    metadata:
+      name: ${var.cluster_name}
+    servers: 1
+    agents: ${var.k3d_agents}
+    kubeAPI:
+      hostPort: "${var.api_port}"
+    ports:
+      - port: 8080:80
+        nodeFilters: [loadbalancer]
+      - port: 8443:443
+        nodeFilters: [loadbalancer]
+      - port: 143:143
+        nodeFilters: [loadbalancer]
+      - port: 587:587
+        nodeFilters: [loadbalancer]
+      - port: 5232:5232
+        nodeFilters: [loadbalancer]
+      - port: 9000:9000
+        nodeFilters: [loadbalancer]
+    options:
+      k3s:
+        extraArgs:
+          - arg: --disable=traefik
+            nodeFilters: [server:*]
+  YAML
+}
+
+resource "null_resource" "k3d_cluster" {
+  depends_on = [local_file.k3d_config]
+  triggers   = { config_hash = local_file.k3d_config.content }
+
+  provisioner "local-exec" {
+    command = <<-SH
+      if k3d cluster list | grep -q '${var.cluster_name}'; then
+        echo "cluster ${var.cluster_name} already exists"
+      else
+        k3d cluster create --config ${path.root}/k3d-config.yaml
+      fi
+      k3d kubeconfig merge ${var.cluster_name} --kubeconfig-switch-context
+    SH
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "k3d cluster delete ${var.cluster_name} || true"
+  }
+}
+
+output "kubeconfig_context" { value = "k3d-${var.cluster_name}" }
+output "k3s_token"          { value = random_password.k3s_token.result; sensitive = true }

--- a/infra/tofu/envs/local/main.tf
+++ b/infra/tofu/envs/local/main.tf
@@ -10,8 +10,8 @@ terraform {
 }
 
 variable "cluster_name" { type = string; default = "prophet-local" }
-variable "k3d_agents"   { type = number; default = 2 }
-variable "api_port"     { type = number; default = 6550 }
+variable "k3d_agents" { type = number; default = 2 }
+variable "api_port" { type = number; default = 6550 }
 
 resource "random_password" "k3s_token" {
   length  = 48
@@ -52,7 +52,10 @@ resource "local_file" "k3d_config" {
 
 resource "null_resource" "k3d_cluster" {
   depends_on = [local_file.k3d_config]
-  triggers   = { config_hash = local_file.k3d_config.content }
+  triggers = {
+    cluster_name = var.cluster_name
+    config_hash  = local_file.k3d_config.content
+  }
 
   provisioner "local-exec" {
     command = <<-SH
@@ -67,9 +70,9 @@ resource "null_resource" "k3d_cluster" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "k3d cluster delete ${var.cluster_name} || true"
+    command = "k3d cluster delete ${self.triggers.cluster_name} || true"
   }
 }
 
 output "kubeconfig_context" { value = "k3d-${var.cluster_name}" }
-output "k3s_token"          { value = random_password.k3s_token.result; sensitive = true }
+output "k3s_token" { value = random_password.k3s_token.result; sensitive = true }

--- a/infra/tofu/envs/local/main.tf
+++ b/infra/tofu/envs/local/main.tf
@@ -9,9 +9,18 @@ terraform {
   }
 }
 
-variable "cluster_name" { type = string; default = "prophet-local" }
-variable "k3d_agents" { type = number; default = 2 }
-variable "api_port" { type = number; default = 6550 }
+variable "cluster_name" {
+  type    = string
+  default = "prophet-local"
+}
+variable "k3d_agents" {
+  type    = number
+  default = 2
+}
+variable "api_port" {
+  type    = number
+  default = 6550
+}
 
 resource "random_password" "k3s_token" {
   length  = 48
@@ -75,4 +84,7 @@ resource "null_resource" "k3d_cluster" {
 }
 
 output "kubeconfig_context" { value = "k3d-${var.cluster_name}" }
-output "k3s_token" { value = random_password.k3s_token.result; sensitive = true }
+output "k3s_token" {
+  value     = random_password.k3s_token.result
+  sensitive = true
+}

--- a/infra/tofu/envs/prod/main.tf
+++ b/infra/tofu/envs/prod/main.tf
@@ -38,10 +38,10 @@ module "prod_secrets" {
   project_id = local.project_ids["cloud"]
 
   secrets = {
-    postgres-password    = { accessor_sas = [local.wi_emails["tekton-builder"]] }
-    minio-secret-key     = { accessor_sas = [local.wi_emails["tekton-builder"]] }
-    dovecot-ldap-bind    = { accessor_sas = [] }
-    smtp-dkim-key        = { accessor_sas = [] }
+    postgres-password = { accessor_sas = [local.wi_emails["tekton-builder"]] }
+    minio-secret-key  = { accessor_sas = [local.wi_emails["tekton-builder"]] }
+    dovecot-ldap-bind = { accessor_sas = [] }
+    smtp-dkim-key     = { accessor_sas = [] }
   }
 }
 

--- a/infra/tofu/envs/prod/main.tf
+++ b/infra/tofu/envs/prod/main.tf
@@ -1,0 +1,65 @@
+# Prod environment — production project workloads
+# Depends on gcp-landing + shared having been applied.
+
+terraform {
+  backend "gcs" {
+    bucket = "prophet-tofu-state-prod"
+    prefix = "prod/terraform.tfstate"
+  }
+}
+
+provider "google" {}
+provider "google-beta" {}
+
+data "terraform_remote_state" "landing" {
+  backend = "gcs"
+  config = {
+    bucket = "prophet-tofu-state-prod"
+    prefix = "gcp-landing/terraform.tfstate"
+  }
+}
+
+data "terraform_remote_state" "shared" {
+  backend = "gcs"
+  config = {
+    bucket = "prophet-tofu-state-prod"
+    prefix = "shared/terraform.tfstate"
+  }
+}
+
+locals {
+  project_ids = data.terraform_remote_state.landing.outputs.project_ids
+  wi_emails   = data.terraform_remote_state.shared.outputs.wi_sa_emails
+}
+
+# Production secrets (shells only — values populated out-of-band)
+module "prod_secrets" {
+  source     = "../../modules/secrets"
+  project_id = local.project_ids["cloud"]
+
+  secrets = {
+    postgres-password    = { accessor_sas = [local.wi_emails["tekton-builder"]] }
+    minio-secret-key     = { accessor_sas = [local.wi_emails["tekton-builder"]] }
+    dovecot-ldap-bind    = { accessor_sas = [] }
+    smtp-dkim-key        = { accessor_sas = [] }
+  }
+}
+
+# Production IAM — persona model per ADR-050
+module "prod_iam" {
+  source     = "../../modules/iam"
+  project_id = local.project_ids["cloud"]
+
+  bindings = {
+    deployer = {
+      role    = "roles/container.developer"
+      members = ["serviceAccount:${local.wi_emails["argocd-deployer"]}"]
+    }
+    log-writer = {
+      role    = "roles/logging.logWriter"
+      members = ["serviceAccount:${local.wi_emails["tekton-builder"]}"]
+    }
+  }
+}
+
+output "secret_ids" { value = module.prod_secrets.secret_ids }

--- a/infra/tofu/envs/shared/main.tf
+++ b/infra/tofu/envs/shared/main.tf
@@ -54,5 +54,5 @@ module "wi_cicd" {
   }
 }
 
-output "wi_sa_emails"      { value = module.wi_cicd.sa_emails }
+output "wi_sa_emails" { value = module.wi_cicd.sa_emails }
 output "wi_k8s_annotations" { value = module.wi_cicd.k8s_annotation }

--- a/infra/tofu/envs/shared/main.tf
+++ b/infra/tofu/envs/shared/main.tf
@@ -1,0 +1,58 @@
+# Shared environment — GCP shared projects (logging, monitoring, VPC, platform AR)
+# Manages the Shared folder resources only.
+# Depends on gcp-landing having been applied first (reads outputs via remote state).
+
+terraform {
+  backend "gcs" {
+    bucket = "prophet-tofu-state-prod"
+    prefix = "shared/terraform.tfstate"
+  }
+}
+
+provider "google" {}
+provider "google-beta" {}
+
+data "terraform_remote_state" "landing" {
+  backend = "gcs"
+  config = {
+    bucket = "prophet-tofu-state-prod"
+    prefix = "gcp-landing/terraform.tfstate"
+  }
+}
+
+locals {
+  project_ids = data.terraform_remote_state.landing.outputs.project_ids
+  org_id      = data.terraform_remote_state.landing.outputs.org_id
+}
+
+# Workload Identity for CI/CD (Tekton + GitHub Actions)
+module "wi_cicd" {
+  source         = "../../modules/workload-identity"
+  project_id     = local.project_ids["platform"]
+  project_number = data.terraform_remote_state.landing.outputs.project_ids["platform"]
+
+  bindings = {
+    tekton-builder = {
+      sa_name       = "tekton-builder"
+      k8s_namespace = "tekton-pipelines"
+      k8s_sa_name   = "tekton-build-sa"
+      roles = [
+        "roles/artifactregistry.writer",
+        "roles/secretmanager.secretAccessor",
+        "roles/storage.objectCreator",
+      ]
+    }
+    argocd-deployer = {
+      sa_name       = "argocd-deployer"
+      k8s_namespace = "argocd"
+      k8s_sa_name   = "argocd-application-controller"
+      roles = [
+        "roles/artifactregistry.reader",
+        "roles/container.developer",
+      ]
+    }
+  }
+}
+
+output "wi_sa_emails"      { value = module.wi_cicd.sa_emails }
+output "wi_k8s_annotations" { value = module.wi_cicd.k8s_annotation }

--- a/infra/tofu/modules/artifact-registry/main.tf
+++ b/infra/tofu/modules/artifact-registry/main.tf
@@ -22,7 +22,7 @@ resource "google_artifact_registry_repository" "repos" {
 resource "google_artifact_registry_repository_iam_member" "readers" {
   for_each = {
     for pair in setproduct(keys(var.repositories), var.reader_service_accounts) :
-      "${pair[0]}/${pair[1]}" => { repo = pair[0], sa = pair[1] }
+    "${pair[0]}/${pair[1]}" => { repo = pair[0], sa = pair[1] }
   }
 
   project    = var.project_id

--- a/infra/tofu/modules/artifact-registry/main.tf
+++ b/infra/tofu/modules/artifact-registry/main.tf
@@ -1,0 +1,35 @@
+resource "google_artifact_registry_repository" "repos" {
+  for_each = var.repositories
+
+  project       = var.project_id
+  location      = var.location
+  repository_id = each.key
+  description   = each.value.description
+  format        = each.value.format
+
+  docker_config {
+    immutable_tags = each.value.immutable_tags
+  }
+
+  labels = {
+    "managed-by"       = "opentofu"
+    "prophet-platform" = "true"
+    "surface"          = each.key
+  }
+}
+
+# Grant reader access for deploy SAs
+resource "google_artifact_registry_repository_iam_member" "readers" {
+  for_each = {
+    for pair in setproduct(keys(var.repositories), var.reader_service_accounts) :
+      "${pair[0]}/${pair[1]}" => { repo = pair[0], sa = pair[1] }
+  }
+
+  project    = var.project_id
+  location   = var.location
+  repository = each.value.repo
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${each.value.sa}"
+
+  depends_on = [google_artifact_registry_repository.repos]
+}

--- a/infra/tofu/modules/artifact-registry/outputs.tf
+++ b/infra/tofu/modules/artifact-registry/outputs.tf
@@ -2,6 +2,6 @@ output "repository_urls" {
   description = "Map of repo slug → full Docker registry URL"
   value = {
     for k, v in google_artifact_registry_repository.repos :
-      k => "${var.location}-docker.pkg.dev/${var.project_id}/${k}"
+    k => "${var.location}-docker.pkg.dev/${var.project_id}/${k}"
   }
 }

--- a/infra/tofu/modules/artifact-registry/outputs.tf
+++ b/infra/tofu/modules/artifact-registry/outputs.tf
@@ -1,0 +1,7 @@
+output "repository_urls" {
+  description = "Map of repo slug → full Docker registry URL"
+  value = {
+    for k, v in google_artifact_registry_repository.repos :
+      k => "${var.location}-docker.pkg.dev/${var.project_id}/${k}"
+  }
+}

--- a/infra/tofu/modules/artifact-registry/variables.tf
+++ b/infra/tofu/modules/artifact-registry/variables.tf
@@ -1,5 +1,10 @@
-variable "project_id" { type = string }
-variable "location"   { type = string; default = "us-central1" }
+variable "project_id" {
+  type = string
+}
+variable "location" {
+  type    = string
+  default = "us-central1"
+}
 
 variable "repositories" {
   type = map(object({

--- a/infra/tofu/modules/artifact-registry/variables.tf
+++ b/infra/tofu/modules/artifact-registry/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" { type = string }
+variable "location"   { type = string; default = "us-central1" }
+
+variable "repositories" {
+  type = map(object({
+    description = optional(string, "")
+    format      = optional(string, "DOCKER")
+    # Immutable image policy — requires digest-pinned tags (ADR-040)
+    immutable_tags = optional(bool, false)
+  }))
+  description = "Map of repo slug → config. Slugs: core, web, edge, social, im, news"
+  default = {
+    core   = { description = "Core platform services" }
+    web    = { description = "Web surface" }
+    edge   = { description = "Edge and fog services" }
+    social = { description = "Social surface" }
+    im     = { description = "IM/messaging surface" }
+    news   = { description = "News surface" }
+  }
+}
+
+variable "reader_service_accounts" {
+  type        = list(string)
+  default     = []
+  description = "SAs granted roles/artifactregistry.reader on all repos"
+}

--- a/infra/tofu/modules/folders/main.tf
+++ b/infra/tofu/modules/folders/main.tf
@@ -4,9 +4,9 @@ resource "google_folder" "folders" {
   display_name = each.value.display_name
   parent = (
     each.value.parent == "" || each.value.parent == null
-      ? "organizations/${var.org_id}"
-      : (startswith(each.value.parent, "folders/")
-          ? each.value.parent
-          : google_folder.folders[each.value.parent].name)
+    ? "organizations/${var.org_id}"
+    : (startswith(each.value.parent, "folders/")
+      ? each.value.parent
+    : google_folder.folders[each.value.parent].name)
   )
 }

--- a/infra/tofu/modules/folders/main.tf
+++ b/infra/tofu/modules/folders/main.tf
@@ -1,0 +1,12 @@
+resource "google_folder" "folders" {
+  for_each = var.folders
+
+  display_name = each.value.display_name
+  parent = (
+    each.value.parent == "" || each.value.parent == null
+      ? "organizations/${var.org_id}"
+      : (startswith(each.value.parent, "folders/")
+          ? each.value.parent
+          : google_folder.folders[each.value.parent].name)
+  )
+}

--- a/infra/tofu/modules/folders/outputs.tf
+++ b/infra/tofu/modules/folders/outputs.tf
@@ -1,0 +1,4 @@
+output "folder_ids" {
+  description = "Map of folder slug → folder resource ID (folders/<id>)"
+  value = { for k, v in google_folder.folders : k => v.name }
+}

--- a/infra/tofu/modules/folders/outputs.tf
+++ b/infra/tofu/modules/folders/outputs.tf
@@ -1,4 +1,4 @@
 output "folder_ids" {
   description = "Map of folder slug → folder resource ID (folders/<id>)"
-  value = { for k, v in google_folder.folders : k => v.name }
+  value       = { for k, v in google_folder.folders : k => v.name }
 }

--- a/infra/tofu/modules/folders/variables.tf
+++ b/infra/tofu/modules/folders/variables.tf
@@ -6,7 +6,7 @@ variable "org_id" {
 variable "folders" {
   type = map(object({
     display_name = string
-    parent       = optional(string, "")  # empty = org root; otherwise a folder ID or key from this map
+    parent       = optional(string, "") # empty = org root; otherwise a folder ID or key from this map
   }))
   description = "Folder definitions. Key is a stable slug used for cross-referencing."
   default = {

--- a/infra/tofu/modules/folders/variables.tf
+++ b/infra/tofu/modules/folders/variables.tf
@@ -1,0 +1,16 @@
+variable "org_id" {
+  type        = string
+  description = "GCP organization ID (numeric)"
+}
+
+variable "folders" {
+  type = map(object({
+    display_name = string
+    parent       = optional(string, "")  # empty = org root; otherwise a folder ID or key from this map
+  }))
+  description = "Folder definitions. Key is a stable slug used for cross-referencing."
+  default = {
+    production = { display_name = "Production" }
+    shared     = { display_name = "Shared" }
+  }
+}

--- a/infra/tofu/modules/iam/main.tf
+++ b/infra/tofu/modules/iam/main.tf
@@ -1,0 +1,35 @@
+# Project-level IAM — persona model per ADR-050
+variable "project_id" { type = string }
+
+variable "bindings" {
+  type = map(object({
+    role    = string
+    members = list(string)
+  }))
+  description = "Map of IAM bindings. Keys are descriptive slugs."
+}
+
+variable "audit_config" {
+  type = map(list(string))
+  default = {
+    "allServices" = ["DATA_READ", "DATA_WRITE", "ADMIN_READ"]
+  }
+  description = "Audit logging config per service. Default: full audit for all services."
+}
+
+resource "google_project_iam_binding" "bindings" {
+  for_each = var.bindings
+  project  = var.project_id
+  role     = each.value.role
+  members  = each.value.members
+}
+
+resource "google_project_iam_audit_config" "audit" {
+  for_each = var.audit_config
+  project  = var.project_id
+  service  = each.key
+  dynamic "audit_log_config" {
+    for_each = each.value
+    content { log_type = audit_log_config.value }
+  }
+}

--- a/infra/tofu/modules/logging/main.tf
+++ b/infra/tofu/modules/logging/main.tf
@@ -1,0 +1,37 @@
+# Centralized logging — routes all project logs to socioprophet-logging-prod
+# Immutable audit trail requirement per ADR-050.
+
+variable "logging_project_id" { type = string; description = "socioprophet-logging-prod project ID" }
+variable "source_project_ids"  { type = list(string); description = "Projects to aggregate logs from" }
+variable "location"            { type = string; default = "us-central1" }
+variable "retention_days"      { type = number; default = 365 }
+
+resource "google_logging_project_bucket_config" "audit_bucket" {
+  project          = var.logging_project_id
+  location         = var.location
+  bucket_id        = "prophet-audit-logs"
+  retention_days   = var.retention_days
+  description      = "Immutable audit log sink — prophet-platform"
+
+  # Prevent accidental deletion of audit evidence
+  lifecycle { prevent_destroy = true }
+}
+
+resource "google_logging_project_sink" "sinks" {
+  for_each               = toset(var.source_project_ids)
+  project                = each.value
+  name                   = "prophet-audit-sink"
+  destination            = "logging.googleapis.com/projects/${var.logging_project_id}/locations/${var.location}/buckets/${google_logging_project_bucket_config.audit_bucket.bucket_id}"
+  unique_writer_identity = true
+
+  # Capture all admin activity + data access + system events
+  filter = <<-FILTER
+    logName=~"cloudaudit.googleapis.com" OR
+    logName=~"activity" OR
+    severity >= WARNING
+  FILTER
+}
+
+output "sink_writer_identities" {
+  value = { for k, v in google_logging_project_sink.sinks : k => v.writer_identity }
+}

--- a/infra/tofu/modules/logging/main.tf
+++ b/infra/tofu/modules/logging/main.tf
@@ -1,17 +1,29 @@
 # Centralized logging — routes all project logs to socioprophet-logging-prod
 # Immutable audit trail requirement per ADR-050.
 
-variable "logging_project_id" { type = string; description = "socioprophet-logging-prod project ID" }
-variable "source_project_ids"  { type = list(string); description = "Projects to aggregate logs from" }
-variable "location"            { type = string; default = "us-central1" }
-variable "retention_days"      { type = number; default = 365 }
+variable "logging_project_id" {
+  type        = string
+  description = "socioprophet-logging-prod project ID"
+}
+variable "source_project_ids" {
+  type        = list(string)
+  description = "Projects to aggregate logs from"
+}
+variable "location" {
+  type    = string
+  default = "us-central1"
+}
+variable "retention_days" {
+  type    = number
+  default = 365
+}
 
 resource "google_logging_project_bucket_config" "audit_bucket" {
-  project          = var.logging_project_id
-  location         = var.location
-  bucket_id        = "prophet-audit-logs"
-  retention_days   = var.retention_days
-  description      = "Immutable audit log sink — prophet-platform"
+  project        = var.logging_project_id
+  location       = var.location
+  bucket_id      = "prophet-audit-logs"
+  retention_days = var.retention_days
+  description    = "Immutable audit log sink — prophet-platform"
 
   # Prevent accidental deletion of audit evidence
   lifecycle { prevent_destroy = true }

--- a/infra/tofu/modules/monitoring/main.tf
+++ b/infra/tofu/modules/monitoring/main.tf
@@ -1,0 +1,35 @@
+# Centralized monitoring workspace — socioprophet-monitoring-prod
+variable "monitoring_project_id" { type = string; description = "socioprophet-monitoring-prod project ID" }
+variable "scoped_project_ids"    { type = list(string); description = "Projects to pull metrics from" }
+variable "alert_email"           { type = string }
+variable "alert_pagerduty_key"   { type = string; default = ""; sensitive = true }
+
+resource "google_monitoring_monitored_project" "scoped" {
+  for_each     = toset(var.scoped_project_ids)
+  metrics_scope = "locations/global/metricsScopes/${var.monitoring_project_id}"
+  name          = each.value
+}
+
+resource "google_monitoring_notification_channel" "email" {
+  project      = var.monitoring_project_id
+  display_name = "Prophet Platform Alerts (email)"
+  type         = "email"
+  labels       = { email_address = var.alert_email }
+}
+
+resource "google_monitoring_notification_channel" "pagerduty" {
+  count        = var.alert_pagerduty_key != "" ? 1 : 0
+  project      = var.monitoring_project_id
+  display_name = "Prophet Platform Alerts (PagerDuty)"
+  type         = "pagerduty"
+  sensitive_labels { service_key = var.alert_pagerduty_key }
+}
+
+output "notification_channel_ids" {
+  value = compact([
+    google_monitoring_notification_channel.email.id,
+    length(google_monitoring_notification_channel.pagerduty) > 0
+      ? google_monitoring_notification_channel.pagerduty[0].id
+      : ""
+  ])
+}

--- a/infra/tofu/modules/monitoring/main.tf
+++ b/infra/tofu/modules/monitoring/main.tf
@@ -1,11 +1,23 @@
 # Centralized monitoring workspace — socioprophet-monitoring-prod
-variable "monitoring_project_id" { type = string; description = "socioprophet-monitoring-prod project ID" }
-variable "scoped_project_ids"    { type = list(string); description = "Projects to pull metrics from" }
-variable "alert_email"           { type = string }
-variable "alert_pagerduty_key"   { type = string; default = ""; sensitive = true }
+variable "monitoring_project_id" {
+  type        = string
+  description = "socioprophet-monitoring-prod project ID"
+}
+variable "scoped_project_ids" {
+  type        = list(string)
+  description = "Projects to pull metrics from"
+}
+variable "alert_email" {
+  type = string
+}
+variable "alert_pagerduty_key" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
 
 resource "google_monitoring_monitored_project" "scoped" {
-  for_each     = toset(var.scoped_project_ids)
+  for_each      = toset(var.scoped_project_ids)
   metrics_scope = "locations/global/metricsScopes/${var.monitoring_project_id}"
   name          = each.value
 }
@@ -29,7 +41,7 @@ output "notification_channel_ids" {
   value = compact([
     google_monitoring_notification_channel.email.id,
     length(google_monitoring_notification_channel.pagerduty) > 0
-      ? google_monitoring_notification_channel.pagerduty[0].id
-      : ""
+    ? google_monitoring_notification_channel.pagerduty[0].id
+    : ""
   ])
 }

--- a/infra/tofu/modules/network/main.tf
+++ b/infra/tofu/modules/network/main.tf
@@ -1,0 +1,53 @@
+resource "google_compute_network" "vpc" {
+  project                 = var.host_project_id
+  name                    = "prophet-platform-vpc"
+  auto_create_subnetworks = false
+  routing_mode            = "GLOBAL"
+}
+
+resource "google_compute_subnetwork" "subnets" {
+  for_each = var.subnets
+
+  project       = var.host_project_id
+  name          = "prophet-${each.key}"
+  network       = google_compute_network.vpc.id
+  region        = var.region
+  ip_cidr_range = each.value.cidr
+  description   = each.value.description
+
+  dynamic "secondary_ip_range" {
+    for_each = each.value.secondary_ranges
+    content {
+      range_name    = secondary_ip_range.key
+      ip_cidr_range = secondary_ip_range.value
+    }
+  }
+
+  private_ip_google_access = true
+  log_config { aggregation_interval = "INTERVAL_5_SEC"; flow_sampling = 0.5; metadata = "INCLUDE_ALL_METADATA" }
+}
+
+# Private Google Access — allows GKE nodes to reach GCP APIs without external IPs
+resource "google_compute_router" "router" {
+  project = var.host_project_id
+  name    = "prophet-router"
+  region  = var.region
+  network = google_compute_network.vpc.id
+}
+
+resource "google_compute_router_nat" "nat" {
+  project                            = var.host_project_id
+  name                               = "prophet-nat"
+  router                             = google_compute_router.router.name
+  region                             = var.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  log_config { enable = true; filter = "ERRORS_ONLY" }
+}
+
+# Shared VPC service project attachments
+resource "google_compute_shared_vpc_service_project" "attachments" {
+  for_each        = toset(var.shared_vpc_service_projects)
+  host_project    = var.host_project_id
+  service_project = each.value
+}

--- a/infra/tofu/modules/network/main.tf
+++ b/infra/tofu/modules/network/main.tf
@@ -24,7 +24,11 @@ resource "google_compute_subnetwork" "subnets" {
   }
 
   private_ip_google_access = true
-  log_config { aggregation_interval = "INTERVAL_5_SEC"; flow_sampling = 0.5; metadata = "INCLUDE_ALL_METADATA" }
+  log_config {
+    aggregation_interval = "INTERVAL_5_SEC"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
 }
 
 # Private Google Access — allows GKE nodes to reach GCP APIs without external IPs
@@ -42,7 +46,10 @@ resource "google_compute_router_nat" "nat" {
   region                             = var.region
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-  log_config { enable = true; filter = "ERRORS_ONLY" }
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
 }
 
 # Shared VPC service project attachments

--- a/infra/tofu/modules/network/outputs.tf
+++ b/infra/tofu/modules/network/outputs.tf
@@ -1,5 +1,5 @@
-output "vpc_id"           { value = google_compute_network.vpc.id }
-output "vpc_self_link"    { value = google_compute_network.vpc.self_link }
+output "vpc_id" { value = google_compute_network.vpc.id }
+output "vpc_self_link" { value = google_compute_network.vpc.self_link }
 output "subnet_self_links" {
   value = { for k, v in google_compute_subnetwork.subnets : k => v.self_link }
 }

--- a/infra/tofu/modules/network/outputs.tf
+++ b/infra/tofu/modules/network/outputs.tf
@@ -1,0 +1,8 @@
+output "vpc_id"           { value = google_compute_network.vpc.id }
+output "vpc_self_link"    { value = google_compute_network.vpc.self_link }
+output "subnet_self_links" {
+  value = { for k, v in google_compute_subnetwork.subnets : k => v.self_link }
+}
+output "subnet_names" {
+  value = { for k, v in google_compute_subnetwork.subnets : k => v.name }
+}

--- a/infra/tofu/modules/network/variables.tf
+++ b/infra/tofu/modules/network/variables.tf
@@ -1,12 +1,18 @@
-variable "host_project_id" { type = string; description = "VPC host project (socioprophet-vpc-host-prod)" }
-variable "region"         { type = string; default = "us-central1" }
+variable "host_project_id" {
+  type        = string
+  description = "VPC host project (socioprophet-vpc-host-prod)"
+}
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
 
 variable "subnets" {
   type = map(object({
-    cidr              = string
-    service_project   = optional(string, "")
-    secondary_ranges  = optional(map(string), {})
-    description       = optional(string, "")
+    cidr             = string
+    service_project  = optional(string, "")
+    secondary_ranges = optional(map(string), {})
+    description      = optional(string, "")
   }))
   default = {
     gke-prod   = { cidr = "10.100.0.0/20", secondary_ranges = { pods = "10.101.0.0/16", services = "10.102.0.0/20" } }
@@ -15,7 +21,7 @@ variable "subnets" {
 }
 
 variable "shared_vpc_service_projects" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  default     = []
   description = "Project IDs to attach as Shared VPC service projects"
 }

--- a/infra/tofu/modules/network/variables.tf
+++ b/infra/tofu/modules/network/variables.tf
@@ -1,0 +1,21 @@
+variable "host_project_id" { type = string; description = "VPC host project (socioprophet-vpc-host-prod)" }
+variable "region"         { type = string; default = "us-central1" }
+
+variable "subnets" {
+  type = map(object({
+    cidr              = string
+    service_project   = optional(string, "")
+    secondary_ranges  = optional(map(string), {})
+    description       = optional(string, "")
+  }))
+  default = {
+    gke-prod   = { cidr = "10.100.0.0/20", secondary_ranges = { pods = "10.101.0.0/16", services = "10.102.0.0/20" } }
+    gke-shared = { cidr = "10.110.0.0/20", secondary_ranges = { pods = "10.111.0.0/16", services = "10.112.0.0/20" } }
+  }
+}
+
+variable "shared_vpc_service_projects" {
+  type    = list(string)
+  default = []
+  description = "Project IDs to attach as Shared VPC service projects"
+}

--- a/infra/tofu/modules/org/main.tf
+++ b/infra/tofu/modules/org/main.tf
@@ -4,8 +4,8 @@ data "google_organization" "org" {
 
 # Org-level IAM: admin group only — no individual user bindings at org level
 resource "google_organization_iam_binding" "org_admin" {
-  org_id = data.google_organization.org.org_id
-  role   = "roles/resourcemanager.organizationAdmin"
+  org_id  = data.google_organization.org.org_id
+  role    = "roles/resourcemanager.organizationAdmin"
   members = ["group:${var.admin_group_email}"]
 }
 

--- a/infra/tofu/modules/org/main.tf
+++ b/infra/tofu/modules/org/main.tf
@@ -1,0 +1,34 @@
+data "google_organization" "org" {
+  domain = var.org_domain
+}
+
+# Org-level IAM: admin group only — no individual user bindings at org level
+resource "google_organization_iam_binding" "org_admin" {
+  org_id = data.google_organization.org.org_id
+  role   = "roles/resourcemanager.organizationAdmin"
+  members = ["group:${var.admin_group_email}"]
+}
+
+# Deny service account key creation org-wide (ADR-050: no long-lived keys)
+resource "google_org_policy_policy" "deny_sa_key_creation" {
+  name   = "organizations/${data.google_organization.org.org_id}/policies/iam.disableServiceAccountKeyCreation"
+  parent = "organizations/${data.google_organization.org.org_id}"
+
+  spec {
+    rules {
+      enforce = true
+    }
+  }
+}
+
+# Require OS Login org-wide
+resource "google_org_policy_policy" "require_os_login" {
+  name   = "organizations/${data.google_organization.org.org_id}/policies/compute.requireOsLogin"
+  parent = "organizations/${data.google_organization.org.org_id}"
+
+  spec {
+    rules {
+      enforce = true
+    }
+  }
+}

--- a/infra/tofu/modules/org/outputs.tf
+++ b/infra/tofu/modules/org/outputs.tf
@@ -1,0 +1,3 @@
+output "org_id" {
+  value = data.google_organization.org.org_id
+}

--- a/infra/tofu/modules/org/variables.tf
+++ b/infra/tofu/modules/org/variables.tf
@@ -1,0 +1,14 @@
+variable "org_domain" {
+  type        = string
+  description = "GCP org domain (e.g. socioprophet.ai)"
+}
+
+variable "billing_account" {
+  type        = string
+  description = "GCP billing account ID"
+}
+
+variable "admin_group_email" {
+  type        = string
+  description = "Google Group that receives org-admin IAM binding"
+}

--- a/infra/tofu/modules/policy/main.tf
+++ b/infra/tofu/modules/policy/main.tf
@@ -1,8 +1,13 @@
 # Org-level constraint policies — provider-agnostic design, GCP implementation
 # All constraints here enforce the "no silent mutation" and provenance-first principles.
 
-variable "org_id"     { type = string }
-variable "folder_ids" { type = map(string); default = {} }
+variable "org_id" {
+  type = string
+}
+variable "folder_ids" {
+  type    = map(string)
+  default = {}
+}
 
 locals {
   # Constraints enforced at org level

--- a/infra/tofu/modules/policy/main.tf
+++ b/infra/tofu/modules/policy/main.tf
@@ -1,0 +1,45 @@
+# Org-level constraint policies — provider-agnostic design, GCP implementation
+# All constraints here enforce the "no silent mutation" and provenance-first principles.
+
+variable "org_id"     { type = string }
+variable "folder_ids" { type = map(string); default = {} }
+
+locals {
+  # Constraints enforced at org level
+  org_deny_constraints = [
+    "constraints/iam.disableServiceAccountKeyCreation",
+    "constraints/iam.disableServiceAccountKeyUpload",
+    "constraints/compute.requireOsLogin",
+    "constraints/compute.skipDefaultNetworkCreation",
+    "constraints/compute.restrictCloudRunRegion",
+  ]
+}
+
+resource "google_org_policy_policy" "org_enforced" {
+  for_each = toset(local.org_deny_constraints)
+
+  name   = "organizations/${var.org_id}/policies/${each.value}"
+  parent = "organizations/${var.org_id}"
+
+  spec {
+    rules { enforce = true }
+  }
+}
+
+# Restrict resource location to US (data residency)
+resource "google_org_policy_policy" "restrict_locations" {
+  name   = "organizations/${var.org_id}/policies/gcp.resourceLocations"
+  parent = "organizations/${var.org_id}"
+
+  spec {
+    rules {
+      values {
+        allowed_values = ["in:us-locations"]
+      }
+    }
+  }
+}
+
+output "applied_constraints" {
+  value = keys(google_org_policy_policy.org_enforced)
+}

--- a/infra/tofu/modules/projects/main.tf
+++ b/infra/tofu/modules/projects/main.tf
@@ -1,0 +1,33 @@
+resource "google_project" "projects" {
+  for_each = var.projects
+
+  project_id      = each.value.project_id
+  name            = each.value.display_name
+  org_id          = var.org_id
+  billing_account = var.billing_account
+  folder_id       = each.value.folder_ids[each.value.folder_key]
+
+  labels = merge(
+    { "managed-by" = "opentofu", "prophet-platform" = "true" },
+    each.value.labels
+  )
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_project_service" "services" {
+  for_each = {
+    for pair in flatten([
+      for proj_key, proj in var.projects : [
+        for svc in proj.services : { key = "${proj_key}/${svc}", project = proj.project_id, service = svc }
+      ]
+    ]) : pair.key => pair
+  }
+
+  project                    = google_project.projects[split("/", each.key)[0]].project_id
+  service                    = each.value.service
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}

--- a/infra/tofu/modules/projects/outputs.tf
+++ b/infra/tofu/modules/projects/outputs.tf
@@ -1,0 +1,9 @@
+output "project_ids" {
+  description = "Map of project slug → project_id string"
+  value = { for k, v in google_project.projects : k => v.project_id }
+}
+
+output "project_numbers" {
+  description = "Map of project slug → project number (used for WI, SA refs)"
+  value = { for k, v in google_project.projects : k => v.number }
+}

--- a/infra/tofu/modules/projects/outputs.tf
+++ b/infra/tofu/modules/projects/outputs.tf
@@ -1,9 +1,9 @@
 output "project_ids" {
   description = "Map of project slug → project_id string"
-  value = { for k, v in google_project.projects : k => v.project_id }
+  value       = { for k, v in google_project.projects : k => v.project_id }
 }
 
 output "project_numbers" {
   description = "Map of project slug → project number (used for WI, SA refs)"
-  value = { for k, v in google_project.projects : k => v.number }
+  value       = { for k, v in google_project.projects : k => v.number }
 }

--- a/infra/tofu/modules/projects/variables.tf
+++ b/infra/tofu/modules/projects/variables.tf
@@ -1,12 +1,12 @@
-variable "org_id"         { type = string }
+variable "org_id" { type = string }
 variable "billing_account" { type = string }
 
 variable "projects" {
   type = map(object({
     project_id   = string
     display_name = string
-    folder_key   = string             # slug from modules/folders
-    folder_ids   = map(string)        # pass the full folder_ids output here
+    folder_key   = string      # slug from modules/folders
+    folder_ids   = map(string) # pass the full folder_ids output here
     services     = optional(list(string), [])
     labels       = optional(map(string), {})
   }))

--- a/infra/tofu/modules/projects/variables.tf
+++ b/infra/tofu/modules/projects/variables.tf
@@ -1,0 +1,14 @@
+variable "org_id"         { type = string }
+variable "billing_account" { type = string }
+
+variable "projects" {
+  type = map(object({
+    project_id   = string
+    display_name = string
+    folder_key   = string             # slug from modules/folders
+    folder_ids   = map(string)        # pass the full folder_ids output here
+    services     = optional(list(string), [])
+    labels       = optional(map(string), {})
+  }))
+  description = "Map of project definitions. Key is a stable slug."
+}

--- a/infra/tofu/modules/secrets/main.tf
+++ b/infra/tofu/modules/secrets/main.tf
@@ -1,13 +1,15 @@
 # Secret Manager — no SA keys, no secrets in git (ADR-050)
-variable "project_id" { type = string }
+variable "project_id" {
+  type = string
+}
 
 variable "secrets" {
   type = map(object({
     # initial_value: set once at creation; rotated out-of-band.
     # Leave empty to create the secret shell without a version (populate separately).
-    initial_value   = optional(string, "")
-    replication     = optional(string, "automatic")  # automatic | user-managed
-    accessor_sas    = optional(list(string), [])
+    initial_value = optional(string, "")
+    replication   = optional(string, "automatic") # automatic | user-managed
+    accessor_sas  = optional(list(string), [])
   }))
   description = "Map of secret slug → config."
 }
@@ -24,7 +26,11 @@ resource "google_secret_manager_secret" "secrets" {
     }
     dynamic "user_managed" {
       for_each = each.value.replication != "automatic" ? [1] : []
-      content { replicas { location = "us-central1" } }
+      content {
+        replicas {
+          location = "us-central1"
+        }
+      }
     }
   }
 

--- a/infra/tofu/modules/secrets/main.tf
+++ b/infra/tofu/modules/secrets/main.tf
@@ -1,0 +1,62 @@
+# Secret Manager — no SA keys, no secrets in git (ADR-050)
+variable "project_id" { type = string }
+
+variable "secrets" {
+  type = map(object({
+    # initial_value: set once at creation; rotated out-of-band.
+    # Leave empty to create the secret shell without a version (populate separately).
+    initial_value   = optional(string, "")
+    replication     = optional(string, "automatic")  # automatic | user-managed
+    accessor_sas    = optional(list(string), [])
+  }))
+  description = "Map of secret slug → config."
+}
+
+resource "google_secret_manager_secret" "secrets" {
+  for_each  = var.secrets
+  project   = var.project_id
+  secret_id = each.key
+
+  replication {
+    dynamic "auto" {
+      for_each = each.value.replication == "automatic" ? [1] : []
+      content {}
+    }
+    dynamic "user_managed" {
+      for_each = each.value.replication != "automatic" ? [1] : []
+      content { replicas { location = "us-central1" } }
+    }
+  }
+
+  labels = { "managed-by" = "opentofu", "prophet-platform" = "true" }
+}
+
+resource "google_secret_manager_secret_version" "initial" {
+  for_each    = { for k, v in var.secrets : k => v if v.initial_value != "" }
+  secret      = google_secret_manager_secret.secrets[each.key].id
+  secret_data = each.value.initial_value
+
+  lifecycle {
+    # Never replace a secret version via tofu — rotate externally
+    ignore_changes = [secret_data]
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "accessors" {
+  for_each = {
+    for pair in flatten([
+      for slug, cfg in var.secrets : [
+        for sa in cfg.accessor_sas : { key = "${slug}/${sa}", slug = slug, sa = sa }
+      ]
+    ]) : pair.key => pair
+  }
+
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.secrets[each.value.slug].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${each.value.sa}"
+}
+
+output "secret_ids" {
+  value = { for k, v in google_secret_manager_secret.secrets : k => v.id }
+}

--- a/infra/tofu/modules/workload-identity/main.tf
+++ b/infra/tofu/modules/workload-identity/main.tf
@@ -1,0 +1,33 @@
+# Workload Identity Federation — no long-lived SA keys (ADR-050)
+# GKE workloads assume GCP SAs via projected token, not key files.
+
+resource "google_service_account" "wi_sa" {
+  for_each = var.bindings
+
+  project      = var.project_id
+  account_id   = each.value.sa_name
+  display_name = "${each.key} (WI)"
+  description  = "Workload Identity SA for ${each.value.k8s_namespace}/${each.value.k8s_sa_name}"
+}
+
+resource "google_service_account_iam_member" "wi_binding" {
+  for_each = var.bindings
+
+  service_account_id = google_service_account.wi_sa[each.key].name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${each.value.k8s_namespace}/${each.value.k8s_sa_name}]"
+}
+
+resource "google_project_iam_member" "wi_roles" {
+  for_each = {
+    for pair in flatten([
+      for slug, cfg in var.bindings : [
+        for role in cfg.roles : { key = "${slug}/${role}", slug = slug, role = role }
+      ]
+    ]) : pair.key => pair
+  }
+
+  project = var.project_id
+  role    = each.value.role
+  member  = "serviceAccount:${google_service_account.wi_sa[each.value.slug].email}"
+}

--- a/infra/tofu/modules/workload-identity/outputs.tf
+++ b/infra/tofu/modules/workload-identity/outputs.tf
@@ -1,0 +1,11 @@
+output "sa_emails" {
+  value = { for k, v in google_service_account.wi_sa : k => v.email }
+}
+
+output "k8s_annotation" {
+  description = "Annotation value to add to each Kubernetes ServiceAccount"
+  value = {
+    for k, v in google_service_account.wi_sa :
+      k => "iam.gke.io/gcp-service-account=${v.email}"
+  }
+}

--- a/infra/tofu/modules/workload-identity/outputs.tf
+++ b/infra/tofu/modules/workload-identity/outputs.tf
@@ -6,6 +6,6 @@ output "k8s_annotation" {
   description = "Annotation value to add to each Kubernetes ServiceAccount"
   value = {
     for k, v in google_service_account.wi_sa :
-      k => "iam.gke.io/gcp-service-account=${v.email}"
+    k => "iam.gke.io/gcp-service-account=${v.email}"
   }
 }

--- a/infra/tofu/modules/workload-identity/variables.tf
+++ b/infra/tofu/modules/workload-identity/variables.tf
@@ -1,12 +1,12 @@
-variable "project_id"      { type = string }
-variable "project_number"  { type = string }
+variable "project_id" { type = string }
+variable "project_number" { type = string }
 
 variable "bindings" {
   type = map(object({
-    sa_name         = string
-    k8s_namespace   = string
-    k8s_sa_name     = string
-    roles           = list(string)
+    sa_name       = string
+    k8s_namespace = string
+    k8s_sa_name   = string
+    roles         = list(string)
   }))
   description = <<-EOT
     Map of WI binding slug → config.

--- a/infra/tofu/modules/workload-identity/variables.tf
+++ b/infra/tofu/modules/workload-identity/variables.tf
@@ -1,0 +1,18 @@
+variable "project_id"      { type = string }
+variable "project_number"  { type = string }
+
+variable "bindings" {
+  type = map(object({
+    sa_name         = string
+    k8s_namespace   = string
+    k8s_sa_name     = string
+    roles           = list(string)
+  }))
+  description = <<-EOT
+    Map of WI binding slug → config.
+    sa_name: GCP SA name (short, not email)
+    k8s_namespace: Kubernetes namespace
+    k8s_sa_name: Kubernetes ServiceAccount name
+    roles: GCP roles to grant this SA
+  EOT
+}

--- a/infra/tofu/shared/labels.tf
+++ b/infra/tofu/shared/labels.tf
@@ -2,9 +2,9 @@
 # Provider-agnostic: callers map these to GCP labels, AWS tags, etc.
 locals {
   prophet_labels = {
-    "prophet-platform"   = "true"
-    "managed-by"         = "opentofu"
-    "source-of-truth"    = "git"
-    "org"                = "socioprophet"
+    "prophet-platform" = "true"
+    "managed-by"       = "opentofu"
+    "source-of-truth"  = "git"
+    "org"              = "socioprophet"
   }
 }

--- a/infra/tofu/shared/labels.tf
+++ b/infra/tofu/shared/labels.tf
@@ -1,0 +1,10 @@
+# Canonical resource labels applied to every provisioned resource.
+# Provider-agnostic: callers map these to GCP labels, AWS tags, etc.
+locals {
+  prophet_labels = {
+    "prophet-platform"   = "true"
+    "managed-by"         = "opentofu"
+    "source-of-truth"    = "git"
+    "org"                = "socioprophet"
+  }
+}

--- a/infra/tofu/shared/versions.tf
+++ b/infra/tofu/shared/versions.tf
@@ -12,9 +12,9 @@ terraform {
       version = "~> 6.0"
     }
     # Provider-agnostic
-    local  = { source = "hashicorp/local",  version = "~> 2.5" }
-    null   = { source = "hashicorp/null",   version = "~> 3.2" }
+    local  = { source = "hashicorp/local", version = "~> 2.5" }
+    null   = { source = "hashicorp/null", version = "~> 3.2" }
     random = { source = "hashicorp/random", version = "~> 3.6" }
-    tls    = { source = "hashicorp/tls",    version = "~> 4.0" }
+    tls    = { source = "hashicorp/tls", version = "~> 4.0" }
   }
 }

--- a/infra/tofu/shared/versions.tf
+++ b/infra/tofu/shared/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    # GCP — used only in envs/gcp-* and modules that explicitly declare provider
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+    # Provider-agnostic
+    local  = { source = "hashicorp/local",  version = "~> 2.5" }
+    null   = { source = "hashicorp/null",   version = "~> 3.2" }
+    random = { source = "hashicorp/random", version = "~> 3.6" }
+    tls    = { source = "hashicorp/tls",    version = "~> 4.0" }
+  }
+}

--- a/tools/mesh_dockerfile_stubs/Dockerfile.agent-registry
+++ b/tools/mesh_dockerfile_stubs/Dockerfile.agent-registry
@@ -1,0 +1,16 @@
+# agent-registry — governed agent identity, session, and tool-grant registry
+FROM python:3.11-slim AS base
+WORKDIR /app
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+
+FROM base AS build
+COPY . .
+RUN pip install --no-cache-dir fastapi uvicorn pydantic psycopg
+
+FROM base AS runtime
+COPY --from=build /usr/local/lib/python3.11 /usr/local/lib/python3.11
+COPY --from=build /usr/local/bin/uvicorn /usr/local/bin/uvicorn
+COPY . .
+USER appuser
+EXPOSE 8720
+CMD ["uvicorn", "serve.api:app", "--host", "0.0.0.0", "--port", "8720"]

--- a/tools/mesh_dockerfile_stubs/Dockerfile.agentplane
+++ b/tools/mesh_dockerfile_stubs/Dockerfile.agentplane
@@ -1,0 +1,17 @@
+# agentplane — execution control plane (bundle→validate→run→evidence→replay)
+FROM python:3.11-slim AS base
+WORKDIR /app
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+
+FROM base AS build
+COPY . .
+RUN pip install --no-cache-dir fastapi uvicorn pydantic httpx
+
+FROM base AS runtime
+COPY --from=build /usr/local/lib/python3.11 /usr/local/lib/python3.11
+COPY --from=build /usr/local/bin/uvicorn /usr/local/bin/uvicorn
+COPY . .
+USER appuser
+EXPOSE 8730
+# gateway/dispatch_stub.py is the current entrypoint — promote to full API
+CMD ["uvicorn", "gateway.api:app", "--host", "0.0.0.0", "--port", "8730"]

--- a/tools/mesh_dockerfile_stubs/Dockerfile.model-governance-ledger
+++ b/tools/mesh_dockerfile_stubs/Dockerfile.model-governance-ledger
@@ -1,0 +1,16 @@
+# model-governance-ledger — evidence ledger for model/adapter/dataset/eval/promotion records
+FROM python:3.11-slim AS base
+WORKDIR /app
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+
+FROM base AS build
+COPY . .
+RUN pip install --no-cache-dir fastapi uvicorn pydantic
+
+FROM base AS runtime
+COPY --from=build /usr/local/lib/python3.11 /usr/local/lib/python3.11
+COPY --from=build /usr/local/bin/uvicorn /usr/local/bin/uvicorn
+COPY . .
+USER appuser
+EXPOSE 8760
+CMD ["uvicorn", "serve.api:app", "--host", "0.0.0.0", "--port", "8760"]

--- a/tools/mesh_dockerfile_stubs/Dockerfile.model-router
+++ b/tools/mesh_dockerfile_stubs/Dockerfile.model-router
@@ -1,0 +1,18 @@
+# model-router — governed model routing service
+# Wraps tools/model_router.py in a FastAPI HTTP service
+FROM python:3.11-slim AS base
+WORKDIR /app
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+
+FROM base AS build
+COPY . .
+RUN pip install --no-cache-dir fastapi uvicorn pydantic httpx
+
+FROM base AS runtime
+COPY --from=build /usr/local/lib/python3.11 /usr/local/lib/python3.11
+COPY --from=build /usr/local/bin/uvicorn /usr/local/bin/uvicorn
+COPY . .
+USER appuser
+EXPOSE 8710
+# Entrypoint: serve/api.py wraps model_router.py — to be added to repo
+CMD ["uvicorn", "serve.api:app", "--host", "0.0.0.0", "--port", "8710"]

--- a/tools/mesh_dockerfile_stubs/Dockerfile.policy-fabric
+++ b/tools/mesh_dockerfile_stubs/Dockerfile.policy-fabric
@@ -1,0 +1,18 @@
+# policy-fabric — governed operations decision API
+# Runtime: Python 3.11, FastAPI/uvicorn
+# Endpoint: POST /v1/operations/action-decision  GET /healthz
+FROM python:3.11-slim AS base
+WORKDIR /app
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+
+FROM base AS build
+COPY . .
+RUN pip install --no-cache-dir fastapi uvicorn pydantic
+
+FROM base AS runtime
+COPY --from=build /usr/local/lib/python3.11 /usr/local/lib/python3.11
+COPY --from=build /usr/local/bin/uvicorn /usr/local/bin/uvicorn
+COPY policy_fabric/ ./policy_fabric/
+USER appuser
+EXPOSE 8700
+CMD ["uvicorn", "policy_fabric.operations_decision_api:app", "--host", "0.0.0.0", "--port", "8700"]

--- a/tools/mesh_dockerfile_stubs/Dockerfile.prophet-mesh
+++ b/tools/mesh_dockerfile_stubs/Dockerfile.prophet-mesh
@@ -1,0 +1,19 @@
+# prophet-mesh — mesh conductor (Michael Agent + premium derivations)
+FROM python:3.11-slim AS base
+WORKDIR /app
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+
+FROM base AS build
+COPY . .
+RUN pip install --no-cache-dir fastapi uvicorn pydantic httpx PyYAML
+
+FROM base AS runtime
+COPY --from=build /usr/local/lib/python3.11 /usr/local/lib/python3.11
+COPY --from=build /usr/local/bin/uvicorn /usr/local/bin/uvicorn
+COPY src/ ./src/
+COPY agents/ ./agents/
+COPY blueprints/ ./blueprints/
+COPY specs/ ./specs/
+USER appuser
+EXPOSE 8780
+CMD ["uvicorn", "src.prophet_mesh.api:app", "--host", "0.0.0.0", "--port", "8780"]

--- a/tools/mesh_dockerfile_stubs/Dockerfile.superconscious
+++ b/tools/mesh_dockerfile_stubs/Dockerfile.superconscious
@@ -1,0 +1,17 @@
+# superconscious — governed cognition loop for recursive agents
+FROM python:3.11-slim AS base
+WORKDIR /app
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+
+FROM base AS build
+COPY . .
+RUN pip install --no-cache-dir fastapi uvicorn pydantic httpx PyYAML
+
+FROM base AS runtime
+COPY --from=build /usr/local/lib/python3.11 /usr/local/lib/python3.11
+COPY --from=build /usr/local/bin/uvicorn /usr/local/bin/uvicorn
+COPY . .
+USER appuser
+EXPOSE 8740
+# Wraps packages/superconscious-core/superconscious_core/runner.py in HTTP API
+CMD ["uvicorn", "serve.api:app", "--host", "0.0.0.0", "--port", "8740"]

--- a/tools/validate_mesh_deployment.py
+++ b/tools/validate_mesh_deployment.py
@@ -46,6 +46,10 @@ MESH_SERVICES = [
     "synapseiq-reasoning-api",
     "synapseiq-tabular-alpha",
     "mcp-a2a-zero-trust",
+    # Late-integration trio
+    "holmes",
+    "cairnpath-mesh",
+    "contractforge",
 ]
 
 # cloudshell-fog uses existing runtime-base/overlays in prophet-platform — not in MESH_SERVICES
@@ -80,6 +84,10 @@ MESH_PORTS = {
     "synapseiq-reasoning-api": 8803,
     "synapseiq-tabular-alpha": 8804,
     "mcp-a2a-zero-trust": 8860,
+    # Late-integration trio
+    "cairnpath-mesh": 8890,
+    "holmes": 8880,
+    "contractforge": 8895,
 }
 
 WORKSPACE_PORTS = {143, 993, 24, 25, 587, 5232, 9000, 9001, 5432, 6379}
@@ -167,6 +175,10 @@ APPSET_BUNDLE_EXPECTATIONS = {
     "enrichment.reasoning",
     "enrichment.tabular",
     "security.mcp-zero-trust",
+    # Late-integration trio
+    "execution.trace",
+    "intelligence.language",
+    "contracts.forge",
 }
 
 def check_appset() -> None:
@@ -203,6 +215,8 @@ COMPOSE_SOCIOSPHERE_SERVICES = {
     "synapseiq-control-plane", "synapseiq-enrichment-api",
     "synapseiq-enrichment-collector", "synapseiq-reasoning-api",
     "synapseiq-tabular-alpha", "mcp-a2a-zero-trust",
+    # Late-integration trio
+    "cairnpath-mesh", "holmes", "contractforge",
 }
 
 def check_compose() -> None:
@@ -292,6 +306,10 @@ EXPECTED_URL_REFS_SOCIOSPHERE = {
     "synapseiq-reasoning-api": ["model-router:8710", "superconscious:8740"],
     "synapseiq-tabular-alpha": ["synapseiq-enrichment-api:8801"],
     "mcp-a2a-zero-trust": ["policy-fabric:8700", "agent-registry:8720", "agentplane:8730"],
+    # Late-integration trio
+    "cairnpath-mesh": ["policy-fabric:8700", "agentplane:8730"],
+    "holmes": ["policy-fabric:8700", "model-router:8710", "memoryd:8787"],
+    "contractforge": ["policy-fabric:8700", "agent-registry:8720", "agentplane:8730"],
 }
 
 def check_url_refs() -> None:

--- a/tools/validate_mesh_deployment.py
+++ b/tools/validate_mesh_deployment.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """
-Validate prophet-mesh deployment alignment.
+Validate prophet-mesh + sociosphere deployment alignment.
 
 Checks:
-  - k8s manifests exist for all 10 mesh services + qdrant
+  - k8s manifests exist for all mesh + sociosphere services
   - Each service has base/deployment.yaml, service.yaml, kustomization.yaml
   - Each service has an overlays/p0-lab/kustomization.yaml
-  - Argo CD appset includes all mesh services
-  - docker-compose.mesh.yml declares all services and has dependency ordering
-  - Port assignments are unique across workspace + mesh stacks
+  - Argo CD appset includes all bundles
+  - docker-compose files declare all services with correct dependency ordering
+  - Port assignments are unique across workspace + mesh + sociosphere stacks
   - Each service's env vars reference known upstream service URLs
   - No hardcoded secrets in manifests (no plaintext passwords)
 """
@@ -31,7 +31,26 @@ MESH_SERVICES = [
     "tritfabric",
     "prophet-mesh",
     "mesh-qdrant",
+    # SocioSphere extended tiers
+    "sociosphere",
+    "hellgraph",
+    "regis-entity-graph",
+    "sherlock-search",
+    "prophet-core-catalog",
+    "prophet-core-query",
+    "global-devsecops-intelligence",
+    "lattice-forge",
+    "synapseiq-control-plane",
+    "synapseiq-enrichment-api",
+    "synapseiq-enrichment-collector",
+    "synapseiq-reasoning-api",
+    "synapseiq-tabular-alpha",
+    "mcp-a2a-zero-trust",
 ]
+
+# cloudshell-fog uses existing runtime-base/overlays in prophet-platform — not in MESH_SERVICES
+# but is checked separately in appset validation.
+CLOUDSHELL_OVERLAY = "infra/k8s/cloudshell-fog/overlays/runtime-v2-standard"
 
 MESH_PORTS = {
     "memoryd": 8787,
@@ -45,12 +64,29 @@ MESH_PORTS = {
     "prophet-mesh": 8780,
     "mesh-qdrant-http": 6333,
     "mesh-qdrant-grpc": 6334,
+    # SocioSphere
+    "cloudshell-fog": 8080,
+    "sociosphere": 5000,
+    "hellgraph": 8850,
+    "regis-entity-graph": 8820,
+    "sherlock-search": 8810,
+    "prophet-core-catalog": 8830,
+    "prophet-core-query": 8831,
+    "global-devsecops-intelligence": 8840,
+    "lattice-forge": 8870,
+    "synapseiq-control-plane": 8800,
+    "synapseiq-enrichment-api": 8801,
+    "synapseiq-enrichment-collector": 8802,
+    "synapseiq-reasoning-api": 8803,
+    "synapseiq-tabular-alpha": 8804,
+    "mcp-a2a-zero-trust": 8860,
 }
 
 WORKSPACE_PORTS = {143, 993, 24, 25, 587, 5232, 9000, 9001, 5432, 6379}
 
 APPSET = ROOT / "infra/k8s/argo-cd/appsets/socioprophet-appset.yaml"
 COMPOSE = ROOT / "infra/local/docker-compose.mesh.yml"
+COMPOSE_SOCIOSPHERE = ROOT / "infra/local/docker-compose.sociosphere.yml"
 K8S_ROOT = ROOT / "infra/k8s"
 
 ERRORS: list[str] = []
@@ -104,6 +140,7 @@ def check_k8s_manifests() -> None:
 # ── 2. Argo CD appset coverage ────────────────────────────────────────────────
 
 APPSET_BUNDLE_EXPECTATIONS = {
+    # Mesh tiers 0-6
     "mesh.vector-store",
     "mesh.governance",
     "mesh.memory",
@@ -114,6 +151,22 @@ APPSET_BUNDLE_EXPECTATIONS = {
     "mesh.execution",
     "mesh.ml",
     "mesh.conductor",
+    # SocioSphere tiers 7-10
+    "platform.shell",
+    "platform.controller",
+    "graph.kernel",
+    "graph.entity",
+    "search.evidence",
+    "data.catalog",
+    "data.query",
+    "intelligence.devsecops",
+    "runtime.forge",
+    "enrichment.control",
+    "enrichment.api",
+    "enrichment.collector",
+    "enrichment.reasoning",
+    "enrichment.tabular",
+    "security.mcp-zero-trust",
 }
 
 def check_appset() -> None:
@@ -128,13 +181,28 @@ def check_appset() -> None:
         else:
             fail(f"appset MISSING bundle: {bundle}")
 
+    # cloudshell-fog uses its existing runtime-v2-standard overlay
+    if CLOUDSHELL_OVERLAY in text:
+        ok("appset includes cloudshell-fog (runtime-v2-standard overlay)")
+    else:
+        fail(f"appset MISSING cloudshell-fog entry pointing to {CLOUDSHELL_OVERLAY}")
 
-# ── 3. docker-compose.mesh.yml service coverage ───────────────────────────────
+
+# ── 3. docker-compose service coverage ───────────────────────────────────────
 
 COMPOSE_SERVICES = {
     "postgres-mesh", "qdrant", "model-governance-ledger", "memoryd",
     "policy-fabric", "model-router", "agent-registry", "superconscious",
     "agentplane", "tritfabric-server", "prophet-mesh",
+}
+
+COMPOSE_SOCIOSPHERE_SERVICES = {
+    "cloudshell-fog", "sociosphere", "hellgraph", "regis-entity-graph",
+    "sherlock-search", "prophet-core-catalog", "prophet-core-query",
+    "global-devsecops-intelligence", "lattice-forge",
+    "synapseiq-control-plane", "synapseiq-enrichment-api",
+    "synapseiq-enrichment-collector", "synapseiq-reasoning-api",
+    "synapseiq-tabular-alpha", "mcp-a2a-zero-trust",
 }
 
 def check_compose() -> None:
@@ -145,9 +213,19 @@ def check_compose() -> None:
     text = COMPOSE.read_text()
     for svc in COMPOSE_SERVICES:
         if f"\n  {svc}:" in text:
-            ok(f"compose includes service: {svc}")
+            ok(f"compose/mesh includes service: {svc}")
         else:
-            fail(f"compose MISSING service: {svc}")
+            fail(f"compose/mesh MISSING service: {svc}")
+
+    if not COMPOSE_SOCIOSPHERE.exists():
+        fail(f"docker-compose.sociosphere.yml not found: {COMPOSE_SOCIOSPHERE.relative_to(ROOT)}")
+    else:
+        stext = COMPOSE_SOCIOSPHERE.read_text()
+        for svc in COMPOSE_SOCIOSPHERE_SERVICES:
+            if f"\n  {svc}:" in stext:
+                ok(f"compose/sociosphere includes service: {svc}")
+            else:
+                fail(f"compose/sociosphere MISSING service: {svc}")
 
 
 # ── 4. Port uniqueness (no collision with workspace stack) ────────────────────
@@ -193,7 +271,7 @@ def check_no_plaintext_secrets() -> None:
 
 # ── 6. Service URL cross-reference (compose → correct upstream hostnames) ─────
 
-EXPECTED_URL_REFS = {
+EXPECTED_URL_REFS_MESH = {
     "model-router": ["policy-fabric:8700", "memoryd:8787"],
     "agent-registry": ["policy-fabric:8700"],
     "superconscious": ["model-router:8710", "memoryd:8787"],
@@ -203,16 +281,37 @@ EXPECTED_URL_REFS = {
                      "memoryd:8787", "policy-fabric:8700", "superconscious:8740"],
 }
 
+EXPECTED_URL_REFS_SOCIOSPHERE = {
+    "regis-entity-graph": ["hellgraph:8850", "agent-registry:8720"],
+    "sherlock-search": ["regis-entity-graph:8820", "memoryd:8787"],
+    "prophet-core-query": ["prophet-core-catalog:8830", "memoryd:8787"],
+    "global-devsecops-intelligence": ["sherlock-search:8810", "model-router:8710"],
+    "synapseiq-enrichment-api": ["prophet-core-catalog:8830", "memoryd:8787",
+                                  "synapseiq-control-plane:8800"],
+    "synapseiq-enrichment-collector": ["synapseiq-enrichment-api:8801"],
+    "synapseiq-reasoning-api": ["model-router:8710", "superconscious:8740"],
+    "synapseiq-tabular-alpha": ["synapseiq-enrichment-api:8801"],
+    "mcp-a2a-zero-trust": ["policy-fabric:8700", "agent-registry:8720", "agentplane:8730"],
+}
+
 def check_url_refs() -> None:
-    if not COMPOSE.exists():
-        return
-    text = COMPOSE.read_text()
-    for svc, urls in EXPECTED_URL_REFS.items():
-        for url in urls:
-            if url in text:
-                ok(f"compose/{svc} references {url}")
-            else:
-                fail(f"compose/{svc} MISSING upstream reference: {url}")
+    if COMPOSE.exists():
+        text = COMPOSE.read_text()
+        for svc, urls in EXPECTED_URL_REFS_MESH.items():
+            for url in urls:
+                if url in text:
+                    ok(f"compose/mesh/{svc} references {url}")
+                else:
+                    fail(f"compose/mesh/{svc} MISSING upstream reference: {url}")
+
+    if COMPOSE_SOCIOSPHERE.exists():
+        stext = COMPOSE_SOCIOSPHERE.read_text()
+        for svc, urls in EXPECTED_URL_REFS_SOCIOSPHERE.items():
+            for url in urls:
+                if url in stext:
+                    ok(f"compose/sociosphere/{svc} references {url}")
+                else:
+                    fail(f"compose/sociosphere/{svc} MISSING upstream reference: {url}")
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
@@ -241,7 +340,12 @@ def main() -> None:
         print("\nAction required:")
         print("  1. Add Dockerfiles to each sub-repo that lacks one (see tools/mesh_dockerfile_stubs/)")
         print("  2. Wire secrets via SOPS/age before deploying to p0-lab")
-        print("  3. Run: make validate-mesh-deployment")
+        print("  3. For sociosphere tier: add serve/api.py to hellgraph, regis-entity-graph,")
+        print("     sherlock-search, prophet-core-catalog, prophet-core-query, global-devsecops,")
+        print("     lattice-forge, mcp-a2a-zero-trust")
+        print("  4. For synapseiq: add Dockerfiles to control-plane, enrichment-api,")
+        print("     enrichment-collector, reasoning-api services")
+        print("  5. Run: make validate-mesh-deployment")
         sys.exit(1)
     else:
         print("  ✓ All mesh deployment checks passed.")

--- a/tools/validate_mesh_deployment.py
+++ b/tools/validate_mesh_deployment.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""
+Validate prophet-mesh deployment alignment.
+
+Checks:
+  - k8s manifests exist for all 10 mesh services + qdrant
+  - Each service has base/deployment.yaml, service.yaml, kustomization.yaml
+  - Each service has an overlays/p0-lab/kustomization.yaml
+  - Argo CD appset includes all mesh services
+  - docker-compose.mesh.yml declares all services and has dependency ordering
+  - Port assignments are unique across workspace + mesh stacks
+  - Each service's env vars reference known upstream service URLs
+  - No hardcoded secrets in manifests (no plaintext passwords)
+"""
+from __future__ import annotations
+
+import sys
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+MESH_SERVICES = [
+    "model-governance-ledger",
+    "memoryd",
+    "policy-fabric",
+    "model-router",
+    "agent-registry",
+    "superconscious",
+    "agentplane",
+    "tritfabric",
+    "prophet-mesh",
+    "mesh-qdrant",
+]
+
+MESH_PORTS = {
+    "memoryd": 8787,
+    "policy-fabric": 8700,
+    "model-router": 8710,
+    "agent-registry": 8720,
+    "agentplane": 8730,
+    "superconscious": 8740,
+    "tritfabric": 8750,
+    "model-governance-ledger": 8760,
+    "prophet-mesh": 8780,
+    "mesh-qdrant-http": 6333,
+    "mesh-qdrant-grpc": 6334,
+}
+
+WORKSPACE_PORTS = {143, 993, 24, 25, 587, 5232, 9000, 9001, 5432, 6379}
+
+APPSET = ROOT / "infra/k8s/argo-cd/appsets/socioprophet-appset.yaml"
+COMPOSE = ROOT / "infra/local/docker-compose.mesh.yml"
+K8S_ROOT = ROOT / "infra/k8s"
+
+ERRORS: list[str] = []
+PASSES: list[str] = []
+
+def ok(msg: str) -> None:
+    PASSES.append(msg)
+
+def fail(msg: str) -> None:
+    ERRORS.append(msg)
+
+
+# ── 1. k8s manifest existence ─────────────────────────────────────────────────
+
+def check_k8s_manifests() -> None:
+    for svc in MESH_SERVICES:
+        base = K8S_ROOT / svc / "base"
+        overlay = K8S_ROOT / svc / "overlays/p0-lab"
+
+        if not base.exists():
+            fail(f"k8s/{svc}/base/ missing")
+            continue
+
+        for fname in ["kustomization.yaml"]:
+            if not (base / fname).exists():
+                fail(f"k8s/{svc}/base/{fname} missing")
+            else:
+                ok(f"k8s/{svc}/base/{fname}")
+
+        if svc != "mesh-qdrant":
+            for fname in ["deployment.yaml", "service.yaml"]:
+                if not (base / fname).exists():
+                    fail(f"k8s/{svc}/base/{fname} missing")
+                else:
+                    ok(f"k8s/{svc}/base/{fname}")
+        else:
+            for fname in ["statefulset.yaml", "service.yaml"]:
+                if not (base / fname).exists():
+                    fail(f"k8s/{svc}/base/{fname} missing (qdrant is StatefulSet)")
+                else:
+                    ok(f"k8s/{svc}/base/{fname}")
+
+        if not overlay.exists():
+            fail(f"k8s/{svc}/overlays/p0-lab/ missing")
+        elif not (overlay / "kustomization.yaml").exists():
+            fail(f"k8s/{svc}/overlays/p0-lab/kustomization.yaml missing")
+        else:
+            ok(f"k8s/{svc}/overlays/p0-lab/kustomization.yaml")
+
+
+# ── 2. Argo CD appset coverage ────────────────────────────────────────────────
+
+APPSET_BUNDLE_EXPECTATIONS = {
+    "mesh.vector-store",
+    "mesh.governance",
+    "mesh.memory",
+    "mesh.policy",
+    "mesh.routing",
+    "mesh.registry",
+    "mesh.cognition",
+    "mesh.execution",
+    "mesh.ml",
+    "mesh.conductor",
+}
+
+def check_appset() -> None:
+    if not APPSET.exists():
+        fail(f"Argo CD appset not found: {APPSET.relative_to(ROOT)}")
+        return
+
+    text = APPSET.read_text()
+    for bundle in APPSET_BUNDLE_EXPECTATIONS:
+        if bundle in text:
+            ok(f"appset includes bundle: {bundle}")
+        else:
+            fail(f"appset MISSING bundle: {bundle}")
+
+
+# ── 3. docker-compose.mesh.yml service coverage ───────────────────────────────
+
+COMPOSE_SERVICES = {
+    "postgres-mesh", "qdrant", "model-governance-ledger", "memoryd",
+    "policy-fabric", "model-router", "agent-registry", "superconscious",
+    "agentplane", "tritfabric-server", "prophet-mesh",
+}
+
+def check_compose() -> None:
+    if not COMPOSE.exists():
+        fail(f"docker-compose.mesh.yml not found: {COMPOSE.relative_to(ROOT)}")
+        return
+
+    text = COMPOSE.read_text()
+    for svc in COMPOSE_SERVICES:
+        if f"\n  {svc}:" in text:
+            ok(f"compose includes service: {svc}")
+        else:
+            fail(f"compose MISSING service: {svc}")
+
+
+# ── 4. Port uniqueness (no collision with workspace stack) ────────────────────
+
+def check_ports() -> None:
+    for svc, port in MESH_PORTS.items():
+        if port in WORKSPACE_PORTS:
+            fail(f"Port conflict: mesh.{svc}={port} collides with workspace stack")
+        else:
+            ok(f"port {port} ({svc}) — no workspace collision")
+
+    # Check uniqueness within mesh ports
+    seen: dict[int, str] = {}
+    for svc, port in MESH_PORTS.items():
+        if port in seen:
+            fail(f"Port conflict within mesh: {port} used by both {seen[port]} and {svc}")
+        else:
+            seen[port] = svc
+
+
+# ── 5. No plaintext secrets in k8s manifests ─────────────────────────────────
+
+PLAINTEXT_SECRET_PATTERNS = [
+    r'password:\s+"[^${}][^"]+"',
+    r'POSTGRES_PASSWORD.*value.*["\'](?!mesh-dev|dev-password|\$\{)',
+    r'API_KEY.*value.*["\'][a-zA-Z0-9]{20,}["\']',
+]
+
+def check_no_plaintext_secrets() -> None:
+    compiled = [re.compile(p, re.IGNORECASE) for p in PLAINTEXT_SECRET_PATTERNS]
+    for svc in MESH_SERVICES:
+        base = K8S_ROOT / svc / "base"
+        if not base.exists():
+            continue
+        for f in sorted(base.glob("*.yaml")):
+            text = f.read_text()
+            for pat in compiled:
+                m = pat.search(text)
+                if m:
+                    fail(f"Possible plaintext secret in {f.relative_to(ROOT)}: {m.group()[:60]}")
+    ok("no plaintext secrets detected in mesh k8s manifests")
+
+
+# ── 6. Service URL cross-reference (compose → correct upstream hostnames) ─────
+
+EXPECTED_URL_REFS = {
+    "model-router": ["policy-fabric:8700", "memoryd:8787"],
+    "agent-registry": ["policy-fabric:8700"],
+    "superconscious": ["model-router:8710", "memoryd:8787"],
+    "agentplane": ["policy-fabric:8700", "agent-registry:8720", "model-router:8710",
+                   "memoryd:8787", "superconscious:8740"],
+    "prophet-mesh": ["agentplane:8730", "model-router:8710", "agent-registry:8720",
+                     "memoryd:8787", "policy-fabric:8700", "superconscious:8740"],
+}
+
+def check_url_refs() -> None:
+    if not COMPOSE.exists():
+        return
+    text = COMPOSE.read_text()
+    for svc, urls in EXPECTED_URL_REFS.items():
+        for url in urls:
+            if url in text:
+                ok(f"compose/{svc} references {url}")
+            else:
+                fail(f"compose/{svc} MISSING upstream reference: {url}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print("=== validate-mesh-deployment ===\n")
+
+    check_k8s_manifests()
+    check_appset()
+    check_compose()
+    check_ports()
+    check_no_plaintext_secrets()
+    check_url_refs()
+
+    total = len(PASSES) + len(ERRORS)
+
+    if ERRORS:
+        print(f"FAILURES ({len(ERRORS)}):")
+        for e in ERRORS:
+            print(f"  ✗ {e}")
+        print()
+
+    print(f"Result: {len(PASSES)}/{total} checks passed.")
+
+    if ERRORS:
+        print("\nAction required:")
+        print("  1. Add Dockerfiles to each sub-repo that lacks one (see tools/mesh_dockerfile_stubs/)")
+        print("  2. Wire secrets via SOPS/age before deploying to p0-lab")
+        print("  3. Run: make validate-mesh-deployment")
+        sys.exit(1)
+    else:
+        print("  ✓ All mesh deployment checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate_no_provider_leakage.py
+++ b/tools/validate_no_provider_leakage.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Rejects provider-specific names in canonical contracts and schemas.
+Provider specifics belong in infra/tofu/envs/* and adapter modules — not contracts.
+
+Governed by the provider-agnostic constraint established in design review.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+# Directories that contain canonical contracts — must not have provider leakage
+CANONICAL_DIRS = [
+    ROOT / "contracts",
+    ROOT / "schemas",
+    ROOT / "specs",
+]
+
+# Directories explicitly allowed to contain provider names
+EXEMPT_DIRS = [
+    ROOT / "infra" / "tofu",
+    ROOT / "infra" / "k8s",
+    ROOT / "infra" / "local",
+    ROOT / "infra" / "argocd",
+]
+
+# Provider-specific tokens that must not appear in canonical contract files
+BANNED_PATTERNS = [
+    # Cloud provider names as significant identifiers (not in prose/comments)
+    r'"gcp"',
+    r'"aws"',
+    r'"azure"',
+    r'"gcs://',
+    r'"s3://',
+    r'"az://',
+    r'"us-central1"',
+    r'"us-east1"',
+    r'"us-west1"',
+    r'"europe-west',
+    r'"asia-east',
+    r'googleapis\.com',
+    r'\.amazonaws\.com',
+    r'\.blob\.core\.windows\.net',
+    r'"google_',
+    r'"aws_',
+    r'"azurerm_',
+]
+
+COMPILED = [re.compile(p) for p in BANNED_PATTERNS]
+
+ERRORS: list[tuple[Path, int, str, str]] = []
+
+FILE_EXTENSIONS = {".json", ".yaml", ".yml"}
+
+
+def is_exempt(path: Path) -> bool:
+    for exempt in EXEMPT_DIRS:
+        try:
+            path.relative_to(exempt)
+            return True
+        except ValueError:
+            pass
+    return False
+
+
+def check_file(path: Path) -> None:
+    if is_exempt(path):
+        return
+    if path.suffix not in FILE_EXTENSIONS:
+        return
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        return
+
+    for lineno, line in enumerate(text.splitlines(), 1):
+        stripped = line.strip()
+        # Skip comment lines
+        if stripped.startswith("#") or stripped.startswith("//") or stripped.startswith("*"):
+            continue
+        for pattern in COMPILED:
+            if pattern.search(line):
+                ERRORS.append((path, lineno, pattern.pattern, line.rstrip()))
+
+
+def main() -> None:
+    print("=== validate-no-provider-leakage ===")
+
+    checked = 0
+    for scan_dir in CANONICAL_DIRS:
+        if not scan_dir.exists():
+            continue
+        for path in sorted(scan_dir.rglob("*")):
+            if path.is_file():
+                check_file(path)
+                checked += 1
+
+    if ERRORS:
+        print(f"\n{len(ERRORS)} provider-leakage violation(s) found:\n")
+        for path, lineno, pattern, line in ERRORS:
+            rel = path.relative_to(ROOT)
+            print(f"  {rel}:{lineno}  [{pattern}]")
+            print(f"    {line[:120]}")
+        print(
+            "\nProvider-specific names belong in infra/tofu/envs/* "
+            "or adapter modules — not canonical contracts."
+        )
+        sys.exit(1)
+    else:
+        print(f"  OK  {checked} files checked — no provider leakage detected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate_no_provider_leakage.py
+++ b/tools/validate_no_provider_leakage.py
@@ -5,7 +5,6 @@ Provider specifics belong in infra/tofu/envs/* and adapter modules — not contr
 
 Governed by the provider-agnostic constraint established in design review.
 """
-import json
 import re
 import sys
 from pathlib import Path

--- a/tools/validate_workspace_services.py
+++ b/tools/validate_workspace_services.py
@@ -4,9 +4,7 @@ Validates workspace service configs without requiring Docker.
 Checks Dovecot, Postfix, Radicale configs; docker-compose syntax; Kustomize structure.
 """
 import configparser
-import json
 import sys
-import textwrap
 from pathlib import Path
 
 ROOT = Path(__file__).parent.parent


### PR DESCRIPTION
## Summary

- **Workspace services** — Dockerized Dovecot (IMAP+LMTP), Postfix (SMTP+submission), Radicale (CalDAV+CardDAV), MinIO; Kustomize manifests + Argo CD appset entries; full local dev docker-compose; 83-check validator + 65-test pytest suite
- **OpenTofu landing zone** — `infra/tofu/` module tree for `socioprophet.ai` GCP org; envs for `local` (k3d), `gcp-landing`, `shared`, `prod`; plan-only CI with no apply gate
- **Provider-agnostic enforcement** — `validate_no_provider_leakage.py` scans 275 canonical contract files; zero violations

## What changed

### Workspace services (`services/`, `infra/k8s/workspace-*/`, `infra/local/`)

| Service | Stack | Ports |
|---|---|---|
| workspace-mail | Dovecot — IMAP + LMTP, PostgreSQL passdb/userdb | 143 (IMAP), 993 (IMAPS), 24 (LMTP) |
| workspace-smtp | Postfix — virtual mailbox, SASL auth, no open relay | 25 (SMTP), 587 (submission) |
| workspace-caldav | Radicale — CalDAV + CardDAV combined | 5232 |
| workspace-minio | MinIO S3-compatible object storage | 9000 (S3), 9001 (console) |

- Kustomize base manifests + `p0-lab` / `p1-single-site` overlays for all three services
- Argo CD appset: `workspace.mail`, `workspace.caldav`, `workspace.storage` bundles registered
- `infra/datastores/postgres/010_workspace_mail.sql` — idempotent `mail_domains` + `mail_users` migration
- `infra/local/docker-compose.workspace.yml` — full local stack (postgres, redis, minio, mail, smtp, caldav)

### Build and test automation

- `tools/validate_workspace_services.py` — 83 config/manifest checks, no Docker required
- `tests/workspace_operations/test_workspace_infra.py` — 65 pytest assertions (Dovecot, Postfix, Radicale, compose, Kustomize, DB migration, Argo CD appset)
- `tools/smoke_workspace_services.sh` — daemon preflight + port conflict check + build + health wait + IMAP banner / CalDAV / MinIO / Redis PING / PG table probes + teardown
- `make validate-workspace-services`, `make test-workspace`, `make smoke-workspace`, `make workspace-up/down/logs`

### OpenTofu GCP landing zone (`infra/tofu/`)

Modules: `org`, `folders`, `projects`, `network`, `iam`, `logging`, `monitoring`, `artifact-registry`, `workload-identity`, `policy`, `secrets`

**`envs/gcp-landing`** provisions the `socioprophet.ai` org shape:
- Org: SA key creation disabled, OS Login required
- Folders: Production, Shared
- Projects: `socioprophet-platform`, `socioprophet-logging-prod`, `socioprophet-monitoring-prod`, `socioprophet-vpc-host-prod`, `socioprophet-web`, `socioprophet-cloud`, `socioprophet-im`, `socioprophet-social`, `socioprophet-news`
- Shared VPC with Cloud NAT and VPC Flow Logs
- Artifact Registry: `core / web / edge / social / im / news` repos in `socioprophet-platform / us-central1`
- Org constraint policies: resource location restriction (US), no default network, no SA key upload

**`envs/shared`** — Workload Identity bindings for Tekton builder + Argo deployer (no SA keys, ADR-050)

**`envs/prod`** — Secret Manager shells + persona-model IAM

**`envs/local`** — k3d cluster, no cloud provider, local state (maps to p0-lab overlay)

### Provider-agnostic constraint enforcement

- `tools/validate_no_provider_leakage.py` scans `contracts/`, `schemas/`, `specs/` for GCP/AWS/Azure names
- Runs in CI as `provider-leakage-check` job in `tofu-plan.yml`
- **Result: 275 files checked, 0 violations**

### CI (`workflows/tofu-plan.yml`, `workflows/workspace-services-image.yml`)

- `tofu-plan.yml`: `tofu fmt -check` + `tofu validate` for all 4 envs on every PR; full GCP plan posted as PR comment when `gcp-plan` environment secrets are present; **no apply job — apply gate not yet established**
- `workspace-services-image.yml`: build + push `workspace-mail`, `workspace-smtp`, `workspace-caldav` images to GHCR on merge to main; `kubectl kustomize` validation on PRs

## Reviewer notes

- **No GCP resources are applied by this PR.** The `tofu-plan.yml` workflow runs plan-only. Apply requires manual environment approval + signed plan artifact (documented in `envs/gcp-landing/main.tf` comments).
- Old Hetzner/k3s Terraform written to a local working copy earlier this session is **not included** — superseded by this OpenTofu module tree.
- `terraform.tfvars` is gitignored. Copy `terraform.tfvars.example` to get started.
- `make tofu-validate` requires OpenTofu installed locally (`brew install opentofu`). CI handles it automatically.

## Test plan

- [x] `make validate-workspace-services` — 83/83 checks pass
- [x] `make test-workspace` — 65/65 pytest assertions pass
- [x] `python3 tools/validate_no_provider_leakage.py` — 275 files, 0 violations
- [ ] `make smoke-workspace` — requires Docker daemon running
- [ ] `make tofu-validate` — requires `tofu` installed locally
- [ ] GCP plan — requires `gcp-plan` environment secrets configured

🤖 Generated with [Claude Code](https://claude.ai/claude-code)