### PR TITLE
Add workspace services, Hetzner/k3s substrate, and k8s manifests

### DIFF
--- a/.github/workflows/workspace-services-image.yml
+++ b/.github/workflows/workspace-services-image.yml
@@ -1,0 +1,111 @@
+name: workspace-services-image
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/workspace-mail/**"
+      - "services/workspace-smtp/**"
+      - "services/workspace-caldav/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "services/workspace-mail/**"
+      - "services/workspace-smtp/**"
+      - "services/workspace-caldav/**"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/socioprophet/prophet-platform
+
+jobs:
+  build-workspace-mail:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push workspace-mail
+        uses: docker/build-push-action@v5
+        with:
+          context: services/workspace-mail
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/workspace-mail:dev
+            ${{ env.IMAGE_PREFIX }}/workspace-mail:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-workspace-smtp:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push workspace-smtp
+        uses: docker/build-push-action@v5
+        with:
+          context: services/workspace-smtp
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/workspace-smtp:dev
+            ${{ env.IMAGE_PREFIX }}/workspace-smtp:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-workspace-caldav:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push workspace-caldav
+        uses: docker/build-push-action@v5
+        with:
+          context: services/workspace-caldav
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/workspace-caldav:dev
+            ${{ env.IMAGE_PREFIX }}/workspace-caldav:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  kustomize-validate:
+    runs-on: ubuntu-latest
+    needs: [build-workspace-mail, build-workspace-smtp, build-workspace-caldav]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v3
+      - name: Validate workspace-mail kustomize (p0-lab)
+        run: kubectl kustomize infra/k8s/workspace-mail/overlays/p0-lab
+      - name: Validate workspace-caldav kustomize (p0-lab)
+        run: kubectl kustomize infra/k8s/workspace-caldav/overlays/p0-lab
+      - name: Validate workspace-minio kustomize (p0-lab)
+        run: kubectl kustomize infra/k8s/workspace-minio/overlays/p0-lab

--- a/.github/workflows/workspace-terraform-validate.yml
+++ b/.github/workflows/workspace-terraform-validate.yml
@@ -1,0 +1,58 @@
+name: workspace-terraform-validate
+on:
+  push:
+    branches: [main]
+    paths:
+      - "infra/terraform/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "infra/terraform/**"
+
+jobs:
+  terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
+      - name: Check formatting (p0-lab)
+        run: terraform fmt -check -recursive infra/terraform/environments/p0-lab
+      - name: Check formatting (p1-single-site)
+        run: terraform fmt -check -recursive infra/terraform/environments/p1-single-site
+      - name: Check formatting (modules)
+        run: terraform fmt -check -recursive infra/terraform/modules
+
+  terraform-validate-p0-lab:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
+      - name: Init (p0-lab)
+        run: terraform init -backend=false
+        working-directory: infra/terraform/environments/p0-lab
+      - name: Validate (p0-lab)
+        run: terraform validate
+        working-directory: infra/terraform/environments/p0-lab
+
+  terraform-validate-p1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
+      - name: Init (p1-single-site)
+        run: terraform init -backend=false
+        working-directory: infra/terraform/environments/p1-single-site
+      - name: Validate (p1-single-site)
+        run: terraform validate
+        working-directory: infra/terraform/environments/p1-single-site
+        env:
+          TF_VAR_hcloud_token: "dummy-for-validation"
+          TF_VAR_ssh_public_key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 ci-validation"
+          TF_VAR_postgres_password: "dummy"
+          TF_VAR_minio_secret_key: "dummy"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-repo docs-check drift-check standards-check topology-check chronos-evidence-loop-readout-validate lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke validate-workroom-update-contract validate-professional-intelligence-manifest validate-wallguard-professional-workroom validate-svf-agent-contract validate-live-sociosphere-svf-contract validate-fogstack-svf-signadot-adapter-readiness validate-environment-validate-change-v2 validate-trust-chain-contracts validate-channel-runtime-gates test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite trustops-art-runner-smoke
+.PHONY: validate validate-repo docs-check drift-check standards-check topology-check chronos-evidence-loop-readout-validate lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke validate-workroom-update-contract validate-professional-intelligence-manifest validate-wallguard-professional-workroom validate-svf-agent-contract validate-live-sociosphere-svf-contract validate-fogstack-svf-signadot-adapter-readiness validate-environment-validate-change-v2 validate-trust-chain-contracts validate-channel-runtime-gates test-go test-python-apps test-tools smoke smoke-health smoke-eval-fabric smoke-evidence-receipts smoke-evidence-console validate-phase3 lampstand-smoke validate-phase4 lampstand-vertical-slice-smoke lampstand-zone-smoke zone-router-publication-smoke zone-router-publication-enqueue-smoke semantic-bridge-zone-validation-smoke validate-fogstack validate-storage-suite trustops-art-runner-smoke validate-workspace-services test-workspace smoke-workspace workspace-up workspace-down workspace-logs workspace-build
 
 validate: validate-repo drift-check standards-check topology-check chronos-evidence-loop-readout-validate lattice-surfaces-check lattice-surface-ingestor-smoke lattice-studio-smoke validate-ops-fabric validate-search-academy-deploy validate-search-image-release validate-lampstand-lifecycle validate-zone-stack-audit policy-fabric-endpoint-client-smoke policy-fabric-guarded-workflow-smoke zone-router-publication-local-publish-smoke zone-router-publication-failure-evidence-smoke zone-router-publication-retry-state-smoke zone-router-publication-remote-broker-seam-smoke validate-workroom-update-contract validate-professional-intelligence-manifest validate-wallguard-professional-workroom validate-svf-agent-contract validate-live-sociosphere-svf-contract validate-fogstack-svf-signadot-adapter-readiness validate-environment-validate-change-v2 validate-trust-chain-contracts validate-channel-runtime-gates test-go validate-phase4 test-python-apps test-tools validate-fogstack validate-storage-suite trustops-art-runner-smoke
 
@@ -230,3 +230,75 @@ validate-health-ai-demo-readiness:
 .PHONY: validate-prophet-mesh-demo-readiness
 validate-prophet-mesh-demo-readiness:
 	python3 tools/validate_prophet_mesh_demo_readiness.py
+
+# ── Workspace services ────────────────────────────────────────────────────────
+WORKSPACE_COMPOSE = infra/local/docker-compose.workspace.yml
+
+validate-workspace-services:
+	python3 tools/validate_workspace_services.py
+
+test-workspace:
+	test -d .venv-workspace || python3 -m venv .venv-workspace
+	. .venv-workspace/bin/activate && python -m pip install --upgrade pip --quiet && pip install pytest pyyaml --quiet
+	. .venv-workspace/bin/activate && pytest -q tests/workspace_operations/test_workspace_infra.py
+
+smoke-workspace:
+	@if ! docker info >/dev/null 2>&1; then \
+	  echo "ERROR: Docker daemon is not running. Start Docker Desktop and retry."; \
+	  exit 1; \
+	fi
+	bash tools/smoke_workspace_services.sh
+
+workspace-build:
+	@if ! docker info >/dev/null 2>&1; then \
+	  echo "ERROR: Docker daemon is not running."; exit 1; \
+	fi
+	docker compose -f $(WORKSPACE_COMPOSE) build
+
+workspace-up:
+	@if ! docker info >/dev/null 2>&1; then \
+	  echo "ERROR: Docker daemon is not running. Start Docker Desktop and retry."; \
+	  exit 1; \
+	fi
+	docker compose -f $(WORKSPACE_COMPOSE) up -d
+	@echo "Stack started. Logs: make workspace-logs"
+	@echo "Ports: IMAP=143, SMTP=25, SUBMISSION=587, CalDAV=5232, MinIO=9000, MinIO-console=9001"
+
+workspace-down:
+	docker compose -f $(WORKSPACE_COMPOSE) down
+
+workspace-logs:
+	docker compose -f $(WORKSPACE_COMPOSE) logs -f
+
+# ── Terraform / IaC ───────────────────────────────────────────────────────────
+TF_ENV ?= p0-lab
+TF_DIR = infra/terraform/environments/$(TF_ENV)
+
+infra-init:
+	cd $(TF_DIR) && terraform init -upgrade
+
+infra-plan:
+	cd $(TF_DIR) && terraform plan
+
+infra-apply:
+	cd $(TF_DIR) && terraform apply
+
+infra-destroy:
+	cd $(TF_DIR) && terraform destroy
+
+infra-fmt:
+	terraform fmt -recursive infra/terraform/
+
+infra-validate:
+	cd infra/terraform/environments/p0-lab && terraform init -backend=false && terraform validate
+	cd infra/terraform/environments/p1-single-site && terraform init -backend=false && terraform validate
+
+# ── prophet-cli ───────────────────────────────────────────────────────────────
+PROPHET_CLI_DIR ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/../prophet-cli
+
+prophet-cli-install:
+	test -d $(PROPHET_CLI_DIR)/.venv || python3 -m venv $(PROPHET_CLI_DIR)/.venv
+	$(PROPHET_CLI_DIR)/.venv/bin/pip install -e $(PROPHET_CLI_DIR) -q
+	@echo "Installed. Run: source $(PROPHET_CLI_DIR)/.venv/bin/activate && prophet --help"
+
+.PHONY: infra-init infra-plan infra-apply infra-destroy infra-fmt infra-validate prophet-cli-install

--- a/infra/datastores/postgres/010_workspace_mail.sql
+++ b/infra/datastores/postgres/010_workspace_mail.sql
@@ -1,0 +1,17 @@
+-- Prophet Workspace: mail domains and virtual users
+CREATE TABLE IF NOT EXISTS mail_domains (
+    domain       TEXT PRIMARY KEY,
+    active       BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS mail_users (
+    email        TEXT PRIMARY KEY,
+    domain       TEXT NOT NULL REFERENCES mail_domains(domain),
+    password     TEXT NOT NULL,  -- SHA512-CRYPT hash
+    quota_bytes  BIGINT NOT NULL DEFAULT 5368709120,  -- 5 GB
+    active       BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS mail_users_domain_idx ON mail_users(domain);

--- a/infra/k8s/argo-cd/appsets/socioprophet-appset.yaml
+++ b/infra/k8s/argo-cd/appsets/socioprophet-appset.yaml
@@ -16,6 +16,15 @@ spec:
           - name: search-orchestrator-academy-bridge
             path: infra/k8s/search-orchestrator/overlays/policy
             bundle: fogstack.knowledge
+          - name: workspace-mail
+            path: infra/k8s/workspace-mail/overlays/p0-lab
+            bundle: workspace.mail
+          - name: workspace-caldav
+            path: infra/k8s/workspace-caldav/overlays/p0-lab
+            bundle: workspace.caldav
+          - name: workspace-minio
+            path: infra/k8s/workspace-minio/overlays/p0-lab
+            bundle: workspace.storage
   template:
     metadata:
       name: '{{name}}'

--- a/infra/k8s/workspace-caldav/base/deployment.yaml
+++ b/infra/k8s/workspace-caldav/base/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workspace-caldav
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: workspace-caldav
+  template:
+    metadata:
+      labels:
+        app: workspace-caldav
+    spec:
+      containers:
+        - name: radicale
+          image: ghcr.io/socioprophet/prophet-platform/workspace-caldav:dev
+          ports:
+            - name: caldav
+              containerPort: 5232
+          volumeMounts:
+            - name: collections
+              mountPath: /var/lib/radicale/collections
+            - name: config
+              mountPath: /config
+          readinessProbe:
+            httpGet:
+              path: /.well-known/caldav
+              port: 5232
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /.well-known/caldav
+              port: 5232
+            initialDelaySeconds: 15
+            periodSeconds: 20
+      volumes:
+        - name: collections
+          persistentVolumeClaim:
+            claimName: workspace-caldav-pvc
+        - name: config
+          configMap:
+            name: workspace-caldav-config

--- a/infra/k8s/workspace-caldav/base/kustomization.yaml
+++ b/infra/k8s/workspace-caldav/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml
+namespace: socioprophet

--- a/infra/k8s/workspace-caldav/base/pvc.yaml
+++ b/infra/k8s/workspace-caldav/base/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: workspace-caldav-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/infra/k8s/workspace-caldav/base/service.yaml
+++ b/infra/k8s/workspace-caldav/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: workspace-caldav
+spec:
+  selector:
+    app: workspace-caldav
+  ports:
+    - name: caldav
+      port: 5232
+      targetPort: 5232

--- a/infra/k8s/workspace-caldav/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/workspace-caldav/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+patches:
+  - target:
+      kind: Deployment
+      name: workspace-caldav
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1

--- a/infra/k8s/workspace-mail/base/configmap.yaml
+++ b/infra/k8s/workspace-mail/base/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workspace-mail-config
+data:
+  dovecot.conf: |
+    protocols = imap lmtp
+    log_path = /dev/stderr
+    info_log_path = /dev/stderr
+    ssl = no
+    mail_location = maildir:/var/mail/vhosts/%d/%n/Maildir
+    auth_mechanisms = plain login
+    !include conf.d/*.conf
+  10-auth.conf: |
+    passdb { driver = sql; args = /etc/dovecot/conf.d/auth-sql.conf.ext }
+    userdb { driver = sql; args = /etc/dovecot/conf.d/auth-sql.conf.ext }
+  10-mail.conf: |
+    mail_home = /var/mail/vhosts/%d/%n
+    mail_location = maildir:/var/mail/vhosts/%d/%n/Maildir
+    namespace inbox { inbox = yes }

--- a/infra/k8s/workspace-mail/base/deployment-smtp.yaml
+++ b/infra/k8s/workspace-mail/base/deployment-smtp.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workspace-smtp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: workspace-smtp
+  template:
+    metadata:
+      labels:
+        app: workspace-smtp
+    spec:
+      containers:
+        - name: postfix
+          image: ghcr.io/socioprophet/prophet-platform/workspace-smtp:dev
+          ports:
+            - name: smtp
+              containerPort: 25
+            - name: submission
+              containerPort: 587
+          env:
+            - name: SMTP_HOSTNAME
+              value: mail.socioprophet.ai
+            - name: DOVECOT_HOST
+              value: workspace-mail
+            - name: POSTGRES_HOST
+              value: postgres
+            - name: POSTGRES_DB
+              value: prophet_platform
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+          readinessProbe:
+            tcpSocket:
+              port: 25
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/infra/k8s/workspace-mail/base/deployment.yaml
+++ b/infra/k8s/workspace-mail/base/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workspace-mail
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: workspace-mail
+  template:
+    metadata:
+      labels:
+        app: workspace-mail
+    spec:
+      containers:
+        - name: dovecot
+          image: ghcr.io/socioprophet/prophet-platform/workspace-mail:dev
+          ports:
+            - name: imap
+              containerPort: 143
+            - name: imaps
+              containerPort: 993
+            - name: lmtp
+              containerPort: 24
+          env:
+            - name: POSTGRES_HOST
+              value: postgres
+            - name: POSTGRES_DB
+              value: prophet_platform
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+          volumeMounts:
+            - name: mailstore
+              mountPath: /var/mail/vhosts
+            - name: config
+              mountPath: /etc/dovecot/dovecot.conf
+              subPath: dovecot.conf
+          readinessProbe:
+            tcpSocket:
+              port: 143
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 143
+            initialDelaySeconds: 15
+            periodSeconds: 20
+      volumes:
+        - name: mailstore
+          persistentVolumeClaim:
+            claimName: workspace-mail-pvc
+        - name: config
+          configMap:
+            name: workspace-mail-config

--- a/infra/k8s/workspace-mail/base/kustomization.yaml
+++ b/infra/k8s/workspace-mail/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - deployment-smtp.yaml
+  - service.yaml
+  - pvc.yaml
+namespace: socioprophet

--- a/infra/k8s/workspace-mail/base/pvc.yaml
+++ b/infra/k8s/workspace-mail/base/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: workspace-mail-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi

--- a/infra/k8s/workspace-mail/base/service.yaml
+++ b/infra/k8s/workspace-mail/base/service.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: workspace-mail
+spec:
+  selector:
+    app: workspace-mail
+  ports:
+    - name: imap
+      port: 143
+      targetPort: 143
+    - name: imaps
+      port: 993
+      targetPort: 993
+    - name: lmtp
+      port: 24
+      targetPort: 24
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: workspace-smtp
+spec:
+  selector:
+    app: workspace-smtp
+  ports:
+    - name: smtp
+      port: 25
+      targetPort: 25
+    - name: submission
+      port: 587
+      targetPort: 587

--- a/infra/k8s/workspace-mail/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/workspace-mail/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+patches:
+  - target:
+      kind: Deployment
+      name: workspace-mail
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: ghcr.io/socioprophet/prophet-platform/workspace-mail:dev
+  - target:
+      kind: PersistentVolumeClaim
+      name: workspace-mail-pvc
+    patch: |-
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: 10Gi

--- a/infra/k8s/workspace-mail/overlays/p1-single-site/kustomization.yaml
+++ b/infra/k8s/workspace-mail/overlays/p1-single-site/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+patches:
+  - target:
+      kind: Deployment
+      name: workspace-mail
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 2
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: ghcr.io/socioprophet/prophet-platform/workspace-mail:latest
+  - target:
+      kind: Deployment
+      name: workspace-smtp
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 2

--- a/infra/k8s/workspace-minio/base/deployment.yaml
+++ b/infra/k8s/workspace-minio/base/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workspace-minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: workspace-minio
+  template:
+    metadata:
+      labels:
+        app: workspace-minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          args:
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-credentials
+                  key: access-key
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-credentials
+                  key: secret-key
+          ports:
+            - name: s3
+              containerPort: 9000
+            - name: console
+              containerPort: 9001
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /minio/health/ready
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: workspace-minio-pvc

--- a/infra/k8s/workspace-minio/base/kustomization.yaml
+++ b/infra/k8s/workspace-minio/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml
+namespace: socioprophet

--- a/infra/k8s/workspace-minio/base/pvc.yaml
+++ b/infra/k8s/workspace-minio/base/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: workspace-minio-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi

--- a/infra/k8s/workspace-minio/base/service.yaml
+++ b/infra/k8s/workspace-minio/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: workspace-minio
+spec:
+  selector:
+    app: workspace-minio
+  ports:
+    - name: s3
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001

--- a/infra/k8s/workspace-minio/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/workspace-minio/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+patches:
+  - target:
+      kind: PersistentVolumeClaim
+      name: workspace-minio-pvc
+    patch: |-
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: 20Gi

--- a/infra/local/docker-compose.workspace.yml
+++ b/infra/local/docker-compose.workspace.yml
@@ -1,0 +1,84 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: prophet
+      POSTGRES_PASSWORD: prophet
+      POSTGRES_DB: prophet_platform
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ../datastores/postgres:/docker-entrypoint-initdb.d:ro
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redisdata:/data
+    command: redis-server --save 60 1
+
+  minio:
+    image: minio/minio:latest
+    environment:
+      MINIO_ROOT_USER: prophet
+      MINIO_ROOT_PASSWORD: prophet-minio-dev
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - miniodata:/data
+    command: server /data --console-address ":9001"
+
+  workspace-mail:
+    build:
+      context: ../../services/workspace-mail
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_USER: prophet
+      POSTGRES_PASSWORD: prophet
+      POSTGRES_DB: prophet_platform
+    ports:
+      - "143:143"
+      - "993:993"
+      - "24:24"
+    volumes:
+      - maildata:/var/mail/vhosts
+    depends_on:
+      - postgres
+
+  workspace-smtp:
+    build:
+      context: ../../services/workspace-smtp
+    environment:
+      SMTP_HOSTNAME: mail.prophet.local
+      DOVECOT_HOST: workspace-mail
+      POSTGRES_HOST: postgres
+      POSTGRES_USER: prophet
+      POSTGRES_PASSWORD: prophet
+      POSTGRES_DB: prophet_platform
+    ports:
+      - "25:25"
+      - "587:587"
+    depends_on:
+      - postgres
+      - workspace-mail
+
+  workspace-caldav:
+    build:
+      context: ../../services/workspace-caldav
+    ports:
+      - "5232:5232"
+    volumes:
+      - caldavdata:/var/lib/radicale/collections
+      - caldavconfig:/config
+    # Seed users file on first run: docker exec workspace-caldav python -m radicale --config /config/config --verify-storage
+
+volumes:
+  pgdata:
+  redisdata:
+  miniodata:
+  maildata:
+  caldavdata:
+  caldavconfig:

--- a/infra/terraform/.gitignore
+++ b/infra/terraform/.gitignore
@@ -1,0 +1,13 @@
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+!*.tfvars.example
+.secrets-staging/
+k3d-config.yaml
+dns-records.txt
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/infra/terraform/environments/p0-lab/main.tf
+++ b/infra/terraform/environments/p0-lab/main.tf
@@ -77,7 +77,8 @@ resource "null_resource" "k3d_cluster" {
   depends_on = [local_file.k3d_config]
 
   triggers = {
-    config_hash = local_file.k3d_config.content
+    cluster_name = var.k3d_cluster_name
+    config_hash  = local_file.k3d_config.content
   }
 
   provisioner "local-exec" {
@@ -93,7 +94,7 @@ resource "null_resource" "k3d_cluster" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "k3d cluster delete ${var.k3d_cluster_name} || true"
+    command = "k3d cluster delete ${self.triggers.cluster_name} || true"
   }
 }
 

--- a/infra/terraform/environments/p0-lab/main.tf
+++ b/infra/terraform/environments/p0-lab/main.tf
@@ -1,0 +1,123 @@
+# p0-lab — local k3d cluster + local state
+# Prerequisites: k3d, kubectl, docker daemon running
+# Usage: terraform init && terraform apply
+
+terraform {
+  backend "local" {
+    path = ".terraform/p0-lab.tfstate"
+  }
+}
+
+variable "k3d_cluster_name" {
+  type    = string
+  default = "prophet-p0-lab"
+}
+
+variable "k3d_agents" {
+  type    = number
+  default = 2
+}
+
+variable "k3d_api_port" {
+  type    = number
+  default = 6550
+}
+
+variable "postgres_password" {
+  type      = string
+  sensitive = true
+  default   = "prophet-dev"
+}
+
+variable "minio_secret_key" {
+  type      = string
+  sensitive = true
+  default   = "prophet-minio-dev"
+}
+
+resource "random_password" "k3s_token" {
+  length  = 48
+  special = false
+}
+
+# Write a k3d config file and create the cluster via null_resource
+resource "local_file" "k3d_config" {
+  filename = "${path.root}/k3d-config.yaml"
+  content  = <<-YAML
+    apiVersion: k3d.io/v1alpha5
+    kind: Simple
+    metadata:
+      name: ${var.k3d_cluster_name}
+    servers: 1
+    agents: ${var.k3d_agents}
+    kubeAPI:
+      hostPort: "${var.k3d_api_port}"
+    ports:
+      - port: 8080:80
+        nodeFilters: [loadbalancer]
+      - port: 8443:443
+        nodeFilters: [loadbalancer]
+      - port: 143:143
+        nodeFilters: [loadbalancer]
+      - port: 587:587
+        nodeFilters: [loadbalancer]
+      - port: 5232:5232
+        nodeFilters: [loadbalancer]
+      - port: 9000:9000
+        nodeFilters: [loadbalancer]
+    options:
+      k3s:
+        extraArgs:
+          - arg: --disable=traefik
+            nodeFilters: [server:*]
+  YAML
+}
+
+resource "null_resource" "k3d_cluster" {
+  depends_on = [local_file.k3d_config]
+
+  triggers = {
+    config_hash = local_file.k3d_config.content
+  }
+
+  provisioner "local-exec" {
+    command = <<-SH
+      if k3d cluster list | grep -q '${var.k3d_cluster_name}'; then
+        echo "cluster ${var.k3d_cluster_name} already exists, skipping create"
+      else
+        k3d cluster create --config ${path.root}/k3d-config.yaml
+      fi
+      k3d kubeconfig merge ${var.k3d_cluster_name} --kubeconfig-switch-context
+    SH
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "k3d cluster delete ${var.k3d_cluster_name} || true"
+  }
+}
+
+# Namespace
+resource "null_resource" "namespace" {
+  depends_on = [null_resource.k3d_cluster]
+  provisioner "local-exec" {
+    command = "kubectl apply -f ${path.root}/../../../k8s/namespaces/socioprophet.yaml"
+  }
+}
+
+module "workspace_secrets" {
+  source            = "../../modules/workspace-secrets"
+  env               = "p0-lab"
+  postgres_password = var.postgres_password
+  minio_secret_key  = var.minio_secret_key
+  k3s_token         = random_password.k3s_token.result
+}
+
+output "kubeconfig_context" {
+  value = "k3d-${var.k3d_cluster_name}"
+}
+
+output "secrets_dir" {
+  value     = module.workspace_secrets.secrets_dir
+  sensitive = true
+}

--- a/infra/terraform/environments/p1-single-site/main.tf
+++ b/infra/terraform/environments/p1-single-site/main.tf
@@ -240,9 +240,17 @@ output "k8s_api_url" {
   value = "https://${module.control_plane.public_ipv4}:6443"
 }
 
-output "mail_fqdn"   { value = module.dns.mail_fqdn }
-output "caldav_fqdn" { value = module.dns.caldav_fqdn }
-output "minio_fqdn"  { value = module.dns.minio_fqdn }
+output "mail_fqdn" {
+  value = module.dns.mail_fqdn
+}
+
+output "caldav_fqdn" {
+  value = module.dns.caldav_fqdn
+}
+
+output "minio_fqdn" {
+  value = module.dns.minio_fqdn
+}
 
 output "secrets_dir" {
   value     = module.workspace_secrets.secrets_dir

--- a/infra/terraform/environments/p1-single-site/main.tf
+++ b/infra/terraform/environments/p1-single-site/main.tf
@@ -1,0 +1,250 @@
+# p1-single-site — Hetzner Cloud k3s cluster
+# Prerequisites: hcloud CLI, terraform, age/SOPS
+# Usage: cp terraform.tfvars.example terraform.tfvars && terraform init && terraform apply
+
+terraform {
+  backend "s3" {
+    # Fill in bucket/region or switch to a local backend for first run
+    bucket = "prophet-terraform-state"
+    key    = "p1-single-site/terraform.tfstate"
+    region = "us-east-1"
+    # For Hetzner Object Storage (S3-compatible):
+    # endpoint = "https://fsn1.your-objectstorage.com"
+    # force_path_style = true
+  }
+}
+
+provider "hcloud" {
+  token = var.hcloud_token
+}
+
+# ── Variables ─────────────────────────────────────────────────────────────────
+
+variable "hcloud_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "location" {
+  type    = string
+  default = "ash"
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "SSH public key contents (not path)"
+}
+
+variable "domain" {
+  type    = string
+  default = "socioprophet.ai"
+}
+
+variable "postgres_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "minio_secret_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "control_plane_type" {
+  type    = string
+  default = "cpx31"
+}
+
+variable "worker_type" {
+  type    = string
+  default = "cpx21"
+}
+
+variable "worker_count" {
+  type    = number
+  default = 2
+}
+
+# ── Core resources ────────────────────────────────────────────────────────────
+
+resource "random_password" "k3s_token" {
+  length  = 48
+  special = false
+}
+
+resource "hcloud_ssh_key" "prophet" {
+  name       = "prophet-p1"
+  public_key = var.ssh_public_key
+}
+
+resource "hcloud_network" "main" {
+  name     = "prophet-p1-net"
+  ip_range = "10.10.0.0/16"
+}
+
+resource "hcloud_network_subnet" "nodes" {
+  type         = "cloud"
+  network_id   = hcloud_network.main.id
+  network_zone = "us-east"
+  ip_range     = "10.10.1.0/24"
+}
+
+resource "hcloud_firewall" "nodes" {
+  name = "prophet-p1-nodes"
+
+  rule {
+    description = "SSH"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "22"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+  rule {
+    description = "k8s API"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "6443"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+  rule {
+    description = "HTTP"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "80"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+  rule {
+    description = "HTTPS"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "443"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+  rule {
+    description = "IMAP"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "143"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+  rule {
+    description = "IMAPS"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "993"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+  rule {
+    description = "SMTP submission"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "587"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+  }
+  rule {
+    description = "Flannel VXLAN (intra-cluster)"
+    direction   = "in"
+    protocol    = "udp"
+    port        = "8472"
+    source_ips  = ["10.10.0.0/16"]
+  }
+  rule {
+    description = "kubelet metrics (intra-cluster)"
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "10250"
+    source_ips  = ["10.10.0.0/16"]
+  }
+}
+
+# ── Control plane node ────────────────────────────────────────────────────────
+
+module "control_plane" {
+  source = "../../modules/k3s-node"
+
+  name               = "prophet-p1-control-0"
+  server_type        = var.control_plane_type
+  location           = var.location
+  ssh_public_key_id  = hcloud_ssh_key.prophet.id
+  private_network_id = hcloud_network.main.id
+  private_ip         = "10.10.1.10"
+  firewall_ids       = [hcloud_firewall.nodes.id]
+  role               = "control-plane"
+  k3s_token          = random_password.k3s_token.result
+  k3s_server_url     = ""
+  extra_k3s_args     = "--tls-san ${hcloud_server.control_plane_placeholder.ipv4_address}"
+
+  depends_on = [hcloud_network_subnet.nodes]
+}
+
+# Placeholder to get the IP before cloud-init runs (chicken-and-egg workaround)
+resource "hcloud_server" "control_plane_placeholder" {
+  name        = "prophet-p1-control-0-ip-probe"
+  server_type = "cx11"
+  location    = var.location
+  image       = "ubuntu-24.04"
+  ssh_keys    = [hcloud_ssh_key.prophet.id]
+  lifecycle { ignore_changes = [user_data, labels] }
+}
+
+# ── Worker nodes ──────────────────────────────────────────────────────────────
+
+module "workers" {
+  count  = var.worker_count
+  source = "../../modules/k3s-node"
+
+  name               = "prophet-p1-worker-${count.index}"
+  server_type        = var.worker_type
+  location           = var.location
+  ssh_public_key_id  = hcloud_ssh_key.prophet.id
+  private_network_id = hcloud_network.main.id
+  private_ip         = "10.10.1.${20 + count.index}"
+  firewall_ids       = [hcloud_firewall.nodes.id]
+  role               = "worker"
+  k3s_token          = random_password.k3s_token.result
+  k3s_server_url     = "https://${module.control_plane.private_ip}:6443"
+
+  depends_on = [module.control_plane]
+}
+
+# ── Secrets ───────────────────────────────────────────────────────────────────
+
+module "workspace_secrets" {
+  source            = "../../modules/workspace-secrets"
+  env               = "p1-single-site"
+  postgres_password = var.postgres_password
+  minio_secret_key  = var.minio_secret_key
+  k3s_token         = random_password.k3s_token.result
+}
+
+# ── DNS records ───────────────────────────────────────────────────────────────
+
+module "dns" {
+  source           = "../../modules/dns"
+  zone_name        = var.domain
+  control_plane_ip = module.control_plane.public_ipv4
+  subdomain_prefix = ""
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+output "control_plane_ip" {
+  value = module.control_plane.public_ipv4
+}
+
+output "worker_ips" {
+  value = [for w in module.workers : w.public_ipv4]
+}
+
+output "k8s_api_url" {
+  value = "https://${module.control_plane.public_ipv4}:6443"
+}
+
+output "mail_fqdn"   { value = module.dns.mail_fqdn }
+output "caldav_fqdn" { value = module.dns.caldav_fqdn }
+output "minio_fqdn"  { value = module.dns.minio_fqdn }
+
+output "secrets_dir" {
+  value     = module.workspace_secrets.secrets_dir
+  sensitive = true
+}

--- a/infra/terraform/environments/p1-single-site/terraform.tfvars.example
+++ b/infra/terraform/environments/p1-single-site/terraform.tfvars.example
@@ -1,0 +1,10 @@
+# Copy to terraform.tfvars and fill in. Never commit terraform.tfvars.
+hcloud_token       = "your-hetzner-api-token"
+ssh_public_key     = "ssh-ed25519 AAAA... your-key-comment"
+domain             = "socioprophet.ai"
+location           = "ash"
+control_plane_type = "cpx31"
+worker_type        = "cpx21"
+worker_count       = 2
+postgres_password  = "change-me-strong-password"
+minio_secret_key   = "change-me-strong-secret-key"

--- a/infra/terraform/environments/p1-single-site/versions.tf
+++ b/infra/terraform/environments/p1-single-site/versions.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.47"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/infra/terraform/modules/dns/main.tf
+++ b/infra/terraform/modules/dns/main.tf
@@ -1,0 +1,34 @@
+# DNS module — emit a records.tf.json file for manual import into your DNS provider.
+# Swap this for a real provider (cloudflare, route53, hcloud_dns) once API tokens are wired.
+
+locals {
+  fqdn   = var.subdomain_prefix != "" ? "${var.subdomain_prefix}.${var.zone_name}" : var.zone_name
+  # Workspace service FQDNs
+  mail   = "mail.${local.fqdn}"
+  caldav = "caldav.${local.fqdn}"
+  minio  = "storage.${local.fqdn}"
+  argocd = "argocd.${local.fqdn}"
+}
+
+resource "local_file" "dns_records" {
+  filename = "${path.root}/dns-records.txt"
+  content  = <<-TXT
+    # DNS records to create in your provider
+    # Zone: ${var.zone_name}
+    # Control-plane IP: ${var.control_plane_ip}
+
+    ${local.mail}    A  ${var.control_plane_ip}
+    ${local.caldav}  A  ${var.control_plane_ip}
+    ${local.minio}   A  ${var.control_plane_ip}
+    ${local.argocd}  A  ${var.control_plane_ip}
+
+    # IMAP/SMTP MX / SRV records (add in DNS console):
+    # _imap._tcp.${local.fqdn}  SRV 0 1 143 ${local.mail}
+    # _imaps._tcp.${local.fqdn} SRV 0 1 993 ${local.mail}
+    # _submission._tcp.${local.fqdn} SRV 0 1 587 ${local.mail}
+    # _caldavs._tcp.${local.fqdn} SRV 0 1 443 ${local.caldav}
+    # _carddavs._tcp.${local.fqdn} SRV 0 1 443 ${local.caldav}
+    MX  ${var.zone_name}  10  ${local.mail}
+    TXT ${var.zone_name}  "v=spf1 a:${local.mail} ~all"
+  TXT
+}

--- a/infra/terraform/modules/dns/main.tf
+++ b/infra/terraform/modules/dns/main.tf
@@ -2,7 +2,7 @@
 # Swap this for a real provider (cloudflare, route53, hcloud_dns) once API tokens are wired.
 
 locals {
-  fqdn   = var.subdomain_prefix != "" ? "${var.subdomain_prefix}.${var.zone_name}" : var.zone_name
+  fqdn = var.subdomain_prefix != "" ? "${var.subdomain_prefix}.${var.zone_name}" : var.zone_name
   # Workspace service FQDNs
   mail   = "mail.${local.fqdn}"
   caldav = "caldav.${local.fqdn}"

--- a/infra/terraform/modules/dns/outputs.tf
+++ b/infra/terraform/modules/dns/outputs.tf
@@ -1,0 +1,4 @@
+output "mail_fqdn"   { value = local.mail }
+output "caldav_fqdn" { value = local.caldav }
+output "minio_fqdn"  { value = local.minio }
+output "argocd_fqdn" { value = local.argocd }

--- a/infra/terraform/modules/dns/outputs.tf
+++ b/infra/terraform/modules/dns/outputs.tf
@@ -1,4 +1,15 @@
-output "mail_fqdn"   { value = local.mail }
-output "caldav_fqdn" { value = local.caldav }
-output "minio_fqdn"  { value = local.minio }
-output "argocd_fqdn" { value = local.argocd }
+output "mail_fqdn" {
+  value = local.mail
+}
+
+output "caldav_fqdn" {
+  value = local.caldav
+}
+
+output "minio_fqdn" {
+  value = local.minio
+}
+
+output "argocd_fqdn" {
+  value = local.argocd
+}

--- a/infra/terraform/modules/dns/variables.tf
+++ b/infra/terraform/modules/dns/variables.tf
@@ -1,0 +1,15 @@
+variable "zone_name" {
+  type        = string
+  description = "DNS zone (e.g. socioprophet.ai)"
+}
+
+variable "control_plane_ip" {
+  type        = string
+  description = "Public IP of the control-plane / LB"
+}
+
+variable "subdomain_prefix" {
+  type    = string
+  default = ""
+  description = "Optional subdomain prefix (e.g. 'p1' → p1.socioprophet.ai). Empty = apex."
+}

--- a/infra/terraform/modules/dns/variables.tf
+++ b/infra/terraform/modules/dns/variables.tf
@@ -9,7 +9,7 @@ variable "control_plane_ip" {
 }
 
 variable "subdomain_prefix" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Optional subdomain prefix (e.g. 'p1' → p1.socioprophet.ai). Empty = apex."
 }

--- a/infra/terraform/modules/dns/versions.tf
+++ b/infra/terraform/modules/dns/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5"
+    }
+  }
+}

--- a/infra/terraform/modules/k3s-node/cloud-init.tpl
+++ b/infra/terraform/modules/k3s-node/cloud-init.tpl
@@ -1,0 +1,28 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+packages:
+  - curl
+  - ca-certificates
+  - jq
+
+runcmd:
+  - |
+    set -e
+    export K3S_TOKEN="${k3s_token}"
+    export INSTALL_K3S_VERSION="${k3s_version}"
+
+    %{ if role == "control-plane" }
+    curl -sfL https://get.k3s.io | sh -s - server \
+      --cluster-init \
+      --node-name "${node_name}" \
+      --disable traefik \
+      --disable servicelb \
+      --tls-san $(curl -s http://169.254.169.254/hetzner/v1/metadata/public-ipv4) \
+      ${extra_args}
+    %{ else }
+    curl -sfL https://get.k3s.io | sh -s - agent \
+      --server "${k3s_server_url}" \
+      --node-name "${node_name}" \
+      ${extra_args}
+    %{ endif }

--- a/infra/terraform/modules/k3s-node/main.tf
+++ b/infra/terraform/modules/k3s-node/main.tf
@@ -1,8 +1,8 @@
 resource "hcloud_server" "node" {
-  name        = var.name
-  server_type = var.server_type
-  location    = var.location
-  image       = var.image
+  name         = var.name
+  server_type  = var.server_type
+  location     = var.location
+  image        = var.image
   ssh_keys     = [var.ssh_public_key_id]
   firewall_ids = var.firewall_ids
 

--- a/infra/terraform/modules/k3s-node/main.tf
+++ b/infra/terraform/modules/k3s-node/main.tf
@@ -1,0 +1,27 @@
+resource "hcloud_server" "node" {
+  name        = var.name
+  server_type = var.server_type
+  location    = var.location
+  image       = var.image
+  ssh_keys    = [var.ssh_public_key_id]
+  firewall_ids = var.firewall_ids
+
+  network {
+    network_id = var.private_network_id
+    ip         = var.private_ip
+  }
+
+  user_data = templatefile("${path.module}/cloud-init.tpl", {
+    k3s_version    = var.k3s_version
+    k3s_token      = var.k3s_token
+    k3s_server_url = var.k3s_server_url
+    role           = var.role
+    extra_args     = var.extra_k3s_args
+    node_name      = var.name
+  })
+
+  labels = {
+    "prophet.ai/env"  = "p1-single-site"
+    "prophet.ai/role" = var.role
+  }
+}

--- a/infra/terraform/modules/k3s-node/main.tf
+++ b/infra/terraform/modules/k3s-node/main.tf
@@ -3,7 +3,7 @@ resource "hcloud_server" "node" {
   server_type = var.server_type
   location    = var.location
   image       = var.image
-  ssh_keys    = [var.ssh_public_key_id]
+  ssh_keys     = [var.ssh_public_key_id]
   firewall_ids = var.firewall_ids
 
   network {

--- a/infra/terraform/modules/k3s-node/outputs.tf
+++ b/infra/terraform/modules/k3s-node/outputs.tf
@@ -1,0 +1,15 @@
+output "server_id" {
+  value = hcloud_server.node.id
+}
+
+output "public_ipv4" {
+  value = hcloud_server.node.ipv4_address
+}
+
+output "private_ip" {
+  value = var.private_ip
+}
+
+output "name" {
+  value = hcloud_server.node.name
+}

--- a/infra/terraform/modules/k3s-node/variables.tf
+++ b/infra/terraform/modules/k3s-node/variables.tf
@@ -10,8 +10,8 @@ variable "server_type" {
 }
 
 variable "location" {
-  type    = string
-  default = "ash"
+  type        = string
+  default     = "ash"
   description = "Hetzner datacenter location (ash=Ashburn, nbg1=Nuremberg, fsn1=Falkenstein)"
 }
 
@@ -41,8 +41,8 @@ variable "firewall_ids" {
 }
 
 variable "role" {
-  type    = string
-  default = "worker"
+  type        = string
+  default     = "worker"
   description = "Node role: control-plane or worker"
 }
 

--- a/infra/terraform/modules/k3s-node/variables.tf
+++ b/infra/terraform/modules/k3s-node/variables.tf
@@ -1,0 +1,68 @@
+variable "name" {
+  type        = string
+  description = "Node name (e.g. prophet-p1-control-0)"
+}
+
+variable "server_type" {
+  type        = string
+  default     = "cpx21"
+  description = "Hetzner server type. cpx21 = 3vCPU/4GB. cpx31 = 4vCPU/8GB."
+}
+
+variable "location" {
+  type    = string
+  default = "ash"
+  description = "Hetzner datacenter location (ash=Ashburn, nbg1=Nuremberg, fsn1=Falkenstein)"
+}
+
+variable "image" {
+  type    = string
+  default = "ubuntu-24.04"
+}
+
+variable "ssh_public_key_id" {
+  type        = string
+  description = "Hetzner SSH key resource ID"
+}
+
+variable "private_network_id" {
+  type        = string
+  description = "Hetzner private network ID"
+}
+
+variable "private_ip" {
+  type        = string
+  description = "Fixed private IP for this node within the subnet"
+}
+
+variable "firewall_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "role" {
+  type    = string
+  default = "worker"
+  description = "Node role: control-plane or worker"
+}
+
+variable "k3s_version" {
+  type    = string
+  default = "v1.30.2+k3s2"
+}
+
+variable "k3s_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "k3s_server_url" {
+  type        = string
+  default     = ""
+  description = "URL of control-plane node; empty when this node IS the control-plane"
+}
+
+variable "extra_k3s_args" {
+  type    = string
+  default = ""
+}

--- a/infra/terraform/modules/k3s-node/versions.tf
+++ b/infra/terraform/modules/k3s-node/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.47"
+    }
+  }
+}

--- a/infra/terraform/modules/workspace-secrets/main.tf
+++ b/infra/terraform/modules/workspace-secrets/main.tf
@@ -1,0 +1,45 @@
+# Generates Kubernetes Secret manifests as local files for SOPS/age encryption.
+# These are NOT applied directly — they are written to disk, encrypted with SOPS,
+# then committed to the GitOps repo. Never commit the plaintext output.
+
+locals {
+  out_dir = var.secrets_dir != "" ? var.secrets_dir : "${path.root}/.secrets-staging/${var.env}"
+}
+
+resource "local_file" "postgres_secret" {
+  filename        = "${local.out_dir}/postgres-credentials.yaml"
+  file_permission = "0600"
+  content         = <<-YAML
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: postgres-credentials
+      namespace: socioprophet
+    type: Opaque
+    stringData:
+      username: prophet
+      password: "${var.postgres_password}"
+  YAML
+}
+
+resource "local_file" "minio_secret" {
+  filename        = "${local.out_dir}/minio-credentials.yaml"
+  file_permission = "0600"
+  content         = <<-YAML
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: minio-credentials
+      namespace: socioprophet
+    type: Opaque
+    stringData:
+      access-key: prophet
+      secret-key: "${var.minio_secret_key}"
+  YAML
+}
+
+resource "local_file" "k3s_token_secret" {
+  filename        = "${local.out_dir}/k3s-token.txt"
+  file_permission = "0600"
+  content         = var.k3s_token
+}

--- a/infra/terraform/modules/workspace-secrets/outputs.tf
+++ b/infra/terraform/modules/workspace-secrets/outputs.tf
@@ -1,0 +1,3 @@
+output "secrets_dir" {
+  value = local.out_dir
+}

--- a/infra/terraform/modules/workspace-secrets/variables.tf
+++ b/infra/terraform/modules/workspace-secrets/variables.tf
@@ -1,0 +1,25 @@
+variable "env" {
+  type        = string
+  description = "Environment name (p0-lab, p1-single-site, etc.)"
+}
+
+variable "secrets_dir" {
+  type        = string
+  default     = ""
+  description = "Directory where age-encrypted SOPS secret files are written"
+}
+
+variable "postgres_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "minio_secret_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "k3s_token" {
+  type      = string
+  sensitive = true
+}

--- a/infra/terraform/modules/workspace-secrets/versions.tf
+++ b/infra/terraform/modules/workspace-secrets/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5"
+    }
+  }
+}

--- a/infra/terraform/shared/versions.tf
+++ b/infra/terraform/shared/versions.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.47"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/services/workspace-caldav/Dockerfile
+++ b/services/workspace-caldav/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir radicale==3.3.0 passlib bcrypt
+
+RUN useradd -r -s /sbin/nologin radicale \
+    && mkdir -p /var/lib/radicale/collections /config \
+    && chown -R radicale:radicale /var/lib/radicale
+
+COPY radicale/config /config/config
+
+EXPOSE 5232
+
+USER radicale
+CMD ["python", "-m", "radicale", "--config", "/config/config"]

--- a/services/workspace-caldav/radicale/config
+++ b/services/workspace-caldav/radicale/config
@@ -1,0 +1,25 @@
+[server]
+hosts = 0.0.0.0:5232
+max_connections = 20
+max_content_length = 10000000
+timeout = 30
+
+[auth]
+# htpasswd for local dev; swap to remote_user for production behind a proxy
+type = htpasswd
+htpasswd_filename = /config/users
+htpasswd_encryption = bcrypt
+delay = 1
+
+[storage]
+filesystem_folder = /var/lib/radicale/collections
+
+[logging]
+level = info
+
+[headers]
+Access-Control-Allow-Origin = *
+Access-Control-Allow-Methods = GET, HEAD, DELETE, OPTIONS, PROPFIND, PUT, MKCALENDAR, MKCOL, REPORT, PROPPATCH
+Access-Control-Allow-Headers = User-Agent, Authorization, Content-type, Depth, If-Match, If-None-Match, Lock-Token, Timeout, Destination, Overwrite, X-client, X-Requested-With
+Access-Control-Expose-Headers = DAV, content-length, Allow
+Access-Control-Allow-Credentials = true

--- a/services/workspace-mail/Dockerfile
+++ b/services/workspace-mail/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dovecot-core \
+    dovecot-imapd \
+    dovecot-lmtpd \
+    dovecot-pgsql \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY dovecot/dovecot.conf /etc/dovecot/dovecot.conf
+COPY dovecot/conf.d/ /etc/dovecot/conf.d/
+
+RUN mkdir -p /var/mail/vhosts \
+    && groupadd -g 5000 vmail \
+    && useradd -g vmail -u 5000 vmail -d /var/mail \
+    && chown -R vmail:vmail /var/mail
+
+EXPOSE 143 993 24
+
+CMD ["dovecot", "-F"]

--- a/services/workspace-mail/dovecot/conf.d/10-auth.conf
+++ b/services/workspace-mail/dovecot/conf.d/10-auth.conf
@@ -1,0 +1,9 @@
+passdb {
+  driver = sql
+  args = /etc/dovecot/conf.d/auth-sql.conf.ext
+}
+
+userdb {
+  driver = sql
+  args = /etc/dovecot/conf.d/auth-sql.conf.ext
+}

--- a/services/workspace-mail/dovecot/conf.d/10-mail.conf
+++ b/services/workspace-mail/dovecot/conf.d/10-mail.conf
@@ -1,0 +1,5 @@
+mail_home = /var/mail/vhosts/%d/%n
+mail_location = maildir:/var/mail/vhosts/%d/%n/Maildir
+namespace inbox {
+  inbox = yes
+}

--- a/services/workspace-mail/dovecot/conf.d/10-master.conf
+++ b/services/workspace-mail/dovecot/conf.d/10-master.conf
@@ -1,0 +1,22 @@
+service imap-login {
+  inet_listener imap {
+    port = 143
+  }
+  inet_listener imaps {
+    port = 993
+    ssl = yes
+  }
+}
+
+service lmtp {
+  inet_listener lmtp {
+    port = 24
+  }
+}
+
+service auth {
+  unix_listener auth-userdb {
+    mode = 0600
+    user = vmail
+  }
+}

--- a/services/workspace-mail/dovecot/conf.d/auth-sql.conf.ext
+++ b/services/workspace-mail/dovecot/conf.d/auth-sql.conf.ext
@@ -1,0 +1,15 @@
+# Injected at runtime from Secret. Override with env var DOVECOT_PG_DSN.
+driver = pgsql
+connect = host=${POSTGRES_HOST} port=5432 dbname=${POSTGRES_DB} user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}
+
+default_pass_scheme = SHA512-CRYPT
+
+password_query = \
+  SELECT password FROM mail_users WHERE email = '%u' AND active = TRUE
+
+user_query = \
+  SELECT \
+    'vmail' AS uid, \
+    'vmail' AS gid, \
+    '/var/mail/vhosts/%d/%n' AS home \
+  FROM mail_users WHERE email = '%u' AND active = TRUE

--- a/services/workspace-mail/dovecot/dovecot.conf
+++ b/services/workspace-mail/dovecot/dovecot.conf
@@ -1,0 +1,18 @@
+# Prophet Workspace — Dovecot IMAP + LMTP
+protocols = imap lmtp
+
+# Logging
+log_path = /dev/stderr
+info_log_path = /dev/stderr
+
+# TLS: disabled by default in local dev; enable via env/configmap overlay
+ssl = no
+
+# Mail location
+mail_location = maildir:/var/mail/vhosts/%d/%n
+
+# Auth
+auth_mechanisms = plain login
+
+# Include all conf.d files
+!include conf.d/*.conf

--- a/services/workspace-smtp/Dockerfile
+++ b/services/workspace-smtp/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postfix \
+    postfix-pgsql \
+    ca-certificates \
+    libsasl2-modules \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY postfix/main.cf /etc/postfix/main.cf
+COPY postfix/master.cf /etc/postfix/master.cf
+COPY postfix/virtual_domains.cf /etc/postfix/virtual_domains.cf
+COPY postfix/virtual_mailbox.cf /etc/postfix/virtual_mailbox.cf
+
+# Entrypoint: substitute env vars then start
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 25 587
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["postfix", "start-fg"]

--- a/services/workspace-smtp/entrypoint.sh
+++ b/services/workspace-smtp/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Substitute env vars into postfix config files
+sed -i "s/\${SMTP_HOSTNAME}/${SMTP_HOSTNAME:-mail.prophet.local}/g" /etc/postfix/main.cf
+sed -i "s/\${DOVECOT_HOST}/${DOVECOT_HOST:-workspace-mail}/g" /etc/postfix/main.cf
+
+for f in /etc/postfix/virtual_domains.cf /etc/postfix/virtual_mailbox.cf; do
+  sed -i "s/\${POSTGRES_HOST}/${POSTGRES_HOST:-postgres}/g" "$f"
+  sed -i "s/\${POSTGRES_USER}/${POSTGRES_USER:-prophet}/g" "$f"
+  sed -i "s/\${POSTGRES_PASSWORD}/${POSTGRES_PASSWORD:-prophet}/g" "$f"
+  sed -i "s/\${POSTGRES_DB}/${POSTGRES_DB:-prophet_platform}/g" "$f"
+done
+
+exec "$@"

--- a/services/workspace-smtp/postfix/main.cf
+++ b/services/workspace-smtp/postfix/main.cf
@@ -1,0 +1,27 @@
+smtpd_banner = $myhostname ESMTP Prophet Workspace
+biff = no
+append_dot_mydomain = no
+readme_directory = no
+
+myhostname = ${SMTP_HOSTNAME}
+myorigin = ${SMTP_HOSTNAME}
+mydestination = localhost
+mynetworks = 127.0.0.0/8 172.16.0.0/12 10.0.0.0/8
+
+# Virtual mailbox delivery → Dovecot LMTP
+virtual_transport = lmtp:${DOVECOT_HOST}:24
+virtual_mailbox_domains = pgsql:/etc/postfix/virtual_domains.cf
+virtual_mailbox_maps = pgsql:/etc/postfix/virtual_mailbox.cf
+
+# No open relay
+smtpd_relay_restrictions = permit_mynetworks, reject_unauth_destination
+
+# Limits
+message_size_limit = 52428800
+mailbox_size_limit = 0
+
+# SASL auth for submission (port 587)
+smtpd_sasl_type = dovecot
+smtpd_sasl_path = inet:${DOVECOT_HOST}:12
+smtpd_sasl_auth_enable = yes
+smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination

--- a/services/workspace-smtp/postfix/master.cf
+++ b/services/workspace-smtp/postfix/master.cf
@@ -1,0 +1,27 @@
+smtp      inet  n       -       y       -       -       smtpd
+submission inet n       -       y       -       -       smtpd
+  -o smtpd_tls_security_level=encrypt
+  -o smtpd_sasl_auth_enable=yes
+  -o smtpd_reject_unlisted_recipient=no
+  -o smtpd_recipient_restrictions=permit_sasl_authenticated,reject
+pickup    unix  n       -       y       60      1       pickup
+cleanup   unix  n       -       y       -       0       cleanup
+qmgr      unix  n       -       n       300     1       qmgr
+tlsmgr    unix  -       -       y       1000?   1       tlsmgr
+rewrite   unix  -       -       y       -       -       trivial-rewrite
+bounce    unix  -       -       y       -       0       bounce
+defer     unix  -       -       y       -       0       bounce
+trace     unix  -       -       y       -       0       bounce
+verify    unix  -       -       y       -       1       verify
+flush     unix  n       -       y       1000?   0       flush
+proxymap  unix  -       -       n       -       -       proxymap
+smtp      unix  -       -       y       -       -       smtp
+relay     unix  -       -       y       -       -       smtp
+showq     unix  n       -       y       -       -       showq
+error     unix  -       -       y       -       -       error
+retry     unix  -       -       y       -       -       error
+discard   unix  -       -       y       -       -       discard
+local     unix  -       n       n       -       -       local
+lmtp      unix  -       -       y       -       -       lmtp
+anvil     unix  -       -       y       -       1       anvil
+scache    unix  -       -       y       -       1       scache

--- a/services/workspace-smtp/postfix/virtual_domains.cf
+++ b/services/workspace-smtp/postfix/virtual_domains.cf
@@ -1,0 +1,5 @@
+hosts = ${POSTGRES_HOST}
+user = ${POSTGRES_USER}
+password = ${POSTGRES_PASSWORD}
+dbname = ${POSTGRES_DB}
+query = SELECT domain FROM mail_domains WHERE domain = '%s' AND active = TRUE

--- a/services/workspace-smtp/postfix/virtual_mailbox.cf
+++ b/services/workspace-smtp/postfix/virtual_mailbox.cf
@@ -1,0 +1,5 @@
+hosts = ${POSTGRES_HOST}
+user = ${POSTGRES_USER}
+password = ${POSTGRES_PASSWORD}
+dbname = ${POSTGRES_DB}
+query = SELECT 1 FROM mail_users WHERE email = '%s' AND active = TRUE

--- a/tests/workspace_operations/test_workspace_infra.py
+++ b/tests/workspace_operations/test_workspace_infra.py
@@ -1,0 +1,263 @@
+"""
+pytest suite for workspace infrastructure.
+No Docker required — validates config files, manifests, and schema consistency.
+"""
+import configparser
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).parent.parent.parent
+SERVICES = ROOT / "services"
+INFRA_K8S = ROOT / "infra" / "k8s"
+INFRA_LOCAL = ROOT / "infra" / "local"
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def dovecot_main():
+    return (SERVICES / "workspace-mail" / "dovecot" / "dovecot.conf").read_text()
+
+@pytest.fixture
+def dovecot_auth_sql():
+    return (SERVICES / "workspace-mail" / "dovecot" / "conf.d" / "auth-sql.conf.ext").read_text()
+
+@pytest.fixture
+def postfix_main():
+    return (SERVICES / "workspace-smtp" / "postfix" / "main.cf").read_text()
+
+@pytest.fixture
+def postfix_master():
+    return (SERVICES / "workspace-smtp" / "postfix" / "master.cf").read_text()
+
+@pytest.fixture
+def radicale_config():
+    cp = configparser.ConfigParser()
+    cp.read(SERVICES / "workspace-caldav" / "radicale" / "config")
+    return cp
+
+@pytest.fixture
+def compose_doc():
+    with (INFRA_LOCAL / "docker-compose.workspace.yml").open() as f:
+        return yaml.safe_load(f)
+
+@pytest.fixture
+def appset_doc():
+    with (INFRA_K8S / "argo-cd" / "appsets" / "socioprophet-appset.yaml").open() as f:
+        return yaml.safe_load(f)
+
+
+# ── Dovecot tests ─────────────────────────────────────────────────────────────
+
+class TestDovecotConfig:
+    def test_main_conf_exists(self):
+        assert (SERVICES / "workspace-mail" / "dovecot" / "dovecot.conf").exists()
+
+    def test_protocols_declared(self, dovecot_main):
+        assert "protocols = imap lmtp" in dovecot_main
+
+    def test_mail_location_declared(self, dovecot_main):
+        assert "mail_location" in dovecot_main
+
+    def test_auth_mechanisms(self, dovecot_main):
+        assert "auth_mechanisms" in dovecot_main
+
+    def test_includes_conf_d(self, dovecot_main):
+        assert "!include conf.d/*.conf" in dovecot_main
+
+    @pytest.mark.parametrize("fname", [
+        "10-auth.conf", "10-mail.conf", "10-master.conf", "auth-sql.conf.ext"
+    ])
+    def test_conf_d_files_exist(self, fname):
+        assert (SERVICES / "workspace-mail" / "dovecot" / "conf.d" / fname).exists()
+
+    def test_auth_sql_driver_pgsql(self, dovecot_auth_sql):
+        assert "driver = pgsql" in dovecot_auth_sql
+
+    def test_auth_sql_has_password_query(self, dovecot_auth_sql):
+        assert "password_query" in dovecot_auth_sql
+
+    def test_auth_sql_has_user_query(self, dovecot_auth_sql):
+        assert "user_query" in dovecot_auth_sql
+
+    def test_auth_sql_references_env_vars(self, dovecot_auth_sql):
+        for var in ("POSTGRES_HOST", "POSTGRES_USER", "POSTGRES_PASSWORD"):
+            assert var in dovecot_auth_sql, f"missing env var {var} in auth-sql.conf.ext"
+
+    def test_master_conf_services(self):
+        text = (SERVICES / "workspace-mail" / "dovecot" / "conf.d" / "10-master.conf").read_text()
+        for svc in ("imap-login", "lmtp", "auth"):
+            assert f"service {svc}" in text, f"missing 'service {svc}' in 10-master.conf"
+
+    def test_lmtp_port_24(self):
+        text = (SERVICES / "workspace-mail" / "dovecot" / "conf.d" / "10-master.conf").read_text()
+        assert "port = 24" in text
+
+
+# ── Postfix tests ─────────────────────────────────────────────────────────────
+
+class TestPostfixConfig:
+    def test_main_cf_exists(self):
+        assert (SERVICES / "workspace-smtp" / "postfix" / "main.cf").exists()
+
+    def test_virtual_transport_to_dovecot(self, postfix_main):
+        assert "virtual_transport = lmtp:" in postfix_main
+
+    def test_no_open_relay(self, postfix_main):
+        assert "reject_unauth_destination" in postfix_main, \
+            "main.cf must include reject_unauth_destination to prevent open relay"
+
+    def test_virtual_mailbox_domains_pgsql(self, postfix_main):
+        assert "pgsql:" in postfix_main
+
+    def test_submission_port_in_master(self, postfix_master):
+        assert "submission" in postfix_master
+
+    def test_sasl_auth_enabled(self, postfix_main):
+        assert "smtpd_sasl_auth_enable = yes" in postfix_main
+
+    def test_message_size_limit(self, postfix_main):
+        assert "message_size_limit" in postfix_main
+
+    def test_entrypoint_substitutes_env_vars(self):
+        text = (SERVICES / "workspace-smtp" / "entrypoint.sh").read_text()
+        for var in ("SMTP_HOSTNAME", "DOVECOT_HOST", "POSTGRES_HOST",
+                    "POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"):
+            assert var in text, f"entrypoint.sh does not substitute {var}"
+
+    @pytest.mark.parametrize("fname", ["virtual_domains.cf", "virtual_mailbox.cf"])
+    def test_pgsql_map_files_exist(self, fname):
+        assert (SERVICES / "workspace-smtp" / "postfix" / fname).exists()
+
+
+# ── Radicale tests ────────────────────────────────────────────────────────────
+
+class TestRadicaleConfig:
+    def test_config_exists(self):
+        assert (SERVICES / "workspace-caldav" / "radicale" / "config").exists()
+
+    @pytest.mark.parametrize("section", ["server", "auth", "storage", "logging"])
+    def test_required_sections(self, radicale_config, section):
+        assert radicale_config.has_section(section), f"radicale config missing [{section}]"
+
+    def test_listens_on_5232(self, radicale_config):
+        hosts = radicale_config.get("server", "hosts")
+        assert "5232" in hosts
+
+    def test_storage_filesystem(self, radicale_config):
+        fs = radicale_config.get("storage", "filesystem_folder")
+        assert "/var/lib/radicale" in fs
+
+    def test_auth_htpasswd(self, radicale_config):
+        auth_type = radicale_config.get("auth", "type")
+        assert auth_type == "htpasswd"
+
+
+# ── docker-compose tests ───────────────────────────────────────────────────────
+
+class TestDockerCompose:
+    def test_compose_file_exists(self):
+        assert (INFRA_LOCAL / "docker-compose.workspace.yml").exists()
+
+    @pytest.mark.parametrize("svc", [
+        "postgres", "redis", "minio", "workspace-mail", "workspace-smtp", "workspace-caldav"
+    ])
+    def test_required_services_present(self, compose_doc, svc):
+        assert svc in compose_doc["services"], f"compose missing service '{svc}'"
+
+    def test_workspace_mail_depends_on_postgres(self, compose_doc):
+        deps = compose_doc["services"]["workspace-mail"].get("depends_on", [])
+        assert "postgres" in deps
+
+    def test_workspace_smtp_depends_on_dovecot(self, compose_doc):
+        deps = compose_doc["services"]["workspace-smtp"].get("depends_on", [])
+        assert "workspace-mail" in deps
+
+    @pytest.mark.parametrize("vol", ["pgdata", "maildata", "caldavdata", "miniodata"])
+    def test_required_volumes(self, compose_doc, vol):
+        assert vol in compose_doc["volumes"], f"compose missing volume '{vol}'"
+
+    def test_imap_port_exposed(self, compose_doc):
+        ports = compose_doc["services"]["workspace-mail"].get("ports", [])
+        assert any("143" in str(p) for p in ports), "IMAP port 143 not exposed"
+
+    def test_minio_s3_port_exposed(self, compose_doc):
+        ports = compose_doc["services"]["minio"].get("ports", [])
+        assert any("9000" in str(p) for p in ports)
+
+
+# ── Kustomize tests ───────────────────────────────────────────────────────────
+
+class TestKustomize:
+    @pytest.mark.parametrize("service", [
+        "workspace-mail", "workspace-caldav", "workspace-minio"
+    ])
+    def test_base_kustomization_exists(self, service):
+        kust = INFRA_K8S / service / "base" / "kustomization.yaml"
+        assert kust.exists(), f"{service}/base/kustomization.yaml missing"
+
+    @pytest.mark.parametrize("service", [
+        "workspace-mail", "workspace-caldav", "workspace-minio"
+    ])
+    def test_p0_lab_overlay_exists(self, service):
+        kust = INFRA_K8S / service / "overlays" / "p0-lab" / "kustomization.yaml"
+        assert kust.exists(), f"{service}/overlays/p0-lab/kustomization.yaml missing"
+
+    @pytest.mark.parametrize("service", [
+        "workspace-mail", "workspace-caldav", "workspace-minio"
+    ])
+    def test_base_resources_exist(self, service):
+        kust_path = INFRA_K8S / service / "base" / "kustomization.yaml"
+        with kust_path.open() as f:
+            doc = yaml.safe_load(f)
+        base_dir = kust_path.parent
+        for resource in doc.get("resources", []):
+            assert (base_dir / resource).exists(), \
+                f"{service}/base/{resource} listed in kustomization but file missing"
+
+    def test_mail_namespace_socioprophet(self):
+        kust = INFRA_K8S / "workspace-mail" / "base" / "kustomization.yaml"
+        with kust.open() as f:
+            doc = yaml.safe_load(f)
+        assert doc.get("namespace") == "socioprophet"
+
+
+# ── DB migration tests ────────────────────────────────────────────────────────
+
+class TestDBMigration:
+    def test_migration_file_exists(self):
+        assert (ROOT / "infra" / "datastores" / "postgres" / "010_workspace_mail.sql").exists()
+
+    def test_creates_mail_domains(self):
+        sql = (ROOT / "infra" / "datastores" / "postgres" / "010_workspace_mail.sql").read_text()
+        assert "CREATE TABLE IF NOT EXISTS mail_domains" in sql
+
+    def test_creates_mail_users(self):
+        sql = (ROOT / "infra" / "datastores" / "postgres" / "010_workspace_mail.sql").read_text()
+        assert "CREATE TABLE IF NOT EXISTS mail_users" in sql
+
+    def test_mail_users_references_domains(self):
+        sql = (ROOT / "infra" / "datastores" / "postgres" / "010_workspace_mail.sql").read_text()
+        assert "REFERENCES mail_domains" in sql
+
+    def test_migration_uses_if_not_exists(self):
+        sql = (ROOT / "infra" / "datastores" / "postgres" / "010_workspace_mail.sql").read_text()
+        assert sql.count("IF NOT EXISTS") >= 2, "migration must be idempotent (IF NOT EXISTS)"
+
+
+# ── Argo CD AppSet tests ──────────────────────────────────────────────────────
+
+class TestArgoAppSet:
+    def test_workspace_bundles_registered(self, appset_doc):
+        elements = (appset_doc["spec"]["generators"][0]["list"]["elements"])
+        names = {e["name"] for e in elements}
+        for expected in ("workspace-mail", "workspace-caldav", "workspace-minio"):
+            assert expected in names, f"Argo appset missing element '{expected}'"
+
+    def test_workspace_mail_path(self, appset_doc):
+        elements = appset_doc["spec"]["generators"][0]["list"]["elements"]
+        mail = next(e for e in elements if e["name"] == "workspace-mail")
+        assert "workspace-mail" in mail["path"]
+        assert "overlays" in mail["path"]

--- a/tools/smoke_workspace_services.sh
+++ b/tools/smoke_workspace_services.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Smoke test for workspace services (requires Docker daemon).
+# Brings up the stack, waits for health, probes each service, then tears down.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+COMPOSE_FILE="$ROOT/infra/local/docker-compose.workspace.yml"
+PASS=0
+FAIL=0
+
+red()   { echo -e "\033[0;31m$*\033[0m"; }
+green() { echo -e "\033[0;32m$*\033[0m"; }
+info()  { echo -e "\033[0;36m$*\033[0m"; }
+
+ok()   { green "  PASS  $1"; ((PASS++)); }
+fail() { red   "  FAIL  $1"; ((FAIL++)); }
+
+# ── Preflight ─────────────────────────────────────────────────────────────────
+info "\n[preflight]"
+
+if ! command -v docker &>/dev/null; then
+  fail "docker not found in PATH"
+  exit 1
+fi
+ok "docker binary found"
+
+if ! docker info &>/dev/null 2>&1; then
+  fail "Docker daemon is not running. Start Docker Desktop or the Docker daemon and retry."
+  exit 1
+fi
+ok "docker daemon is running"
+
+if ! command -v docker &>/dev/null || ! docker compose version &>/dev/null 2>&1; then
+  fail "docker compose plugin not available"
+  exit 1
+fi
+ok "docker compose available"
+
+# Check required ports are free before binding
+for port in 143 25 587 5232 9000 5432 6379; do
+  if lsof -iTCP:"$port" -sTCP:LISTEN -n -P &>/dev/null 2>&1; then
+    fail "port $port already in use — stop conflicting process before running smoke test"
+    exit 1
+  fi
+  ok "port $port is free"
+done
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+info "\n[build]"
+docker compose -f "$COMPOSE_FILE" build --quiet
+ok "docker compose build succeeded"
+
+# ── Up ────────────────────────────────────────────────────────────────────────
+info "\n[up]"
+
+cleanup() {
+  info "\n[teardown]"
+  docker compose -f "$COMPOSE_FILE" down -v --remove-orphans &>/dev/null
+  ok "stack torn down"
+}
+trap cleanup EXIT
+
+docker compose -f "$COMPOSE_FILE" up -d
+ok "docker compose up -d succeeded"
+
+# ── Wait for services ──────────────────────────────────────────────────────────
+info "\n[waiting for services]"
+
+wait_tcp() {
+  local name="$1" host="$2" port="$3" max_secs="${4:-30}"
+  local elapsed=0
+  while ! nc -z "$host" "$port" &>/dev/null 2>&1; do
+    sleep 2; elapsed=$((elapsed+2))
+    if [ $elapsed -ge $max_secs ]; then
+      fail "$name: timed out after ${max_secs}s waiting for $host:$port"
+      return 1
+    fi
+  done
+  ok "$name: $host:$port open after ${elapsed}s"
+}
+
+wait_http() {
+  local name="$1" url="$2" max_secs="${3:-30}"
+  local elapsed=0
+  while ! curl -sf --max-time 3 "$url" &>/dev/null 2>&1; do
+    sleep 2; elapsed=$((elapsed+2))
+    if [ $elapsed -ge $max_secs ]; then
+      fail "$name: timed out after ${max_secs}s waiting for $url"
+      return 1
+    fi
+  done
+  ok "$name: $url responded after ${elapsed}s"
+}
+
+wait_tcp  "postgres"        127.0.0.1  5432  45
+wait_tcp  "redis"           127.0.0.1  6379  30
+wait_tcp  "dovecot-imap"    127.0.0.1  143   45
+wait_tcp  "postfix-smtp"    127.0.0.1  25    45
+wait_http "minio-health"    "http://127.0.0.1:9000/minio/health/ready" 60
+wait_http "caldav"          "http://127.0.0.1:5232/.well-known/caldav" 45
+
+# ── IMAP banner probe ──────────────────────────────────────────────────────────
+info "\n[imap banner]"
+banner=$(echo -e "A1 LOGOUT\r" | nc -w 3 127.0.0.1 143 2>/dev/null || true)
+if echo "$banner" | grep -qi "IMAP\|Dovecot\|OK"; then
+  ok "IMAP banner received"
+else
+  fail "IMAP banner not received (got: ${banner:0:80})"
+fi
+
+# ── CalDAV well-known redirect ─────────────────────────────────────────────────
+info "\n[caldav well-known]"
+status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:5232/.well-known/caldav" 2>/dev/null || true)
+if [[ "$status" == "302" || "$status" == "301" || "$status" == "200" ]]; then
+  ok "CalDAV well-known returned HTTP $status"
+else
+  fail "CalDAV well-known returned HTTP $status (expected 2xx/3xx)"
+fi
+
+# ── MinIO console ─────────────────────────────────────────────────────────────
+info "\n[minio]"
+minio_status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://127.0.0.1:9001" 2>/dev/null || true)
+if [[ "$minio_status" == "200" || "$minio_status" == "302" ]]; then
+  ok "MinIO console returned HTTP $minio_status"
+else
+  fail "MinIO console returned HTTP $minio_status"
+fi
+
+# ── Redis PING ────────────────────────────────────────────────────────────────
+info "\n[redis]"
+pong=$(docker compose -f "$COMPOSE_FILE" exec -T redis redis-cli ping 2>/dev/null || true)
+if echo "$pong" | grep -q "PONG"; then
+  ok "Redis PING → PONG"
+else
+  fail "Redis PING did not return PONG (got: $pong)"
+fi
+
+# ── PostgreSQL workspace tables ───────────────────────────────────────────────
+info "\n[postgres workspace tables]"
+tables=$(docker compose -f "$COMPOSE_FILE" exec -T postgres \
+  psql -U prophet -d prophet_platform -tc \
+  "SELECT tablename FROM pg_tables WHERE tablename IN ('mail_domains','mail_users');" \
+  2>/dev/null | tr -d ' ' | grep -v '^$' || true)
+for table in mail_domains mail_users; do
+  if echo "$tables" | grep -q "$table"; then
+    ok "postgres table '$table' exists"
+  else
+    fail "postgres table '$table' not found (migration may not have run)"
+  fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "========================="
+echo "Workspace smoke test done"
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+echo "========================="
+
+[ "$FAIL" -eq 0 ]

--- a/tools/validate_workspace_services.py
+++ b/tools/validate_workspace_services.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+Validates workspace service configs without requiring Docker.
+Checks Dovecot, Postfix, Radicale configs; docker-compose syntax; Kustomize structure.
+"""
+import configparser
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+SERVICES = ROOT / "services"
+INFRA_LOCAL = ROOT / "infra" / "local"
+INFRA_K8S = ROOT / "infra" / "k8s"
+
+ERRORS: list[str] = []
+CHECKS: list[str] = []
+
+
+def ok(msg: str) -> None:
+    CHECKS.append(f"  OK  {msg}")
+
+
+def fail(msg: str) -> None:
+    ERRORS.append(f"  FAIL  {msg}")
+    CHECKS.append(f"  FAIL  {msg}")
+
+
+def require_file(path: Path) -> bool:
+    if not path.exists():
+        fail(f"missing file: {path.relative_to(ROOT)}")
+        return False
+    ok(f"exists: {path.relative_to(ROOT)}")
+    return True
+
+
+# ── Dovecot ──────────────────────────────────────────────────────────────────
+
+def check_dovecot() -> None:
+    print("\n[dovecot]")
+    conf_dir = SERVICES / "workspace-mail" / "dovecot"
+
+    main_conf = conf_dir / "dovecot.conf"
+    if not require_file(main_conf):
+        return
+
+    content = main_conf.read_text()
+    for directive in ("protocols", "mail_location", "auth_mechanisms", "!include"):
+        if directive in content:
+            ok(f"dovecot.conf has '{directive}'")
+        else:
+            fail(f"dovecot.conf missing '{directive}'")
+
+    for fname in ("10-auth.conf", "10-mail.conf", "10-master.conf", "auth-sql.conf.ext"):
+        require_file(conf_dir / "conf.d" / fname)
+
+    auth_ext = conf_dir / "conf.d" / "auth-sql.conf.ext"
+    if auth_ext.exists():
+        text = auth_ext.read_text()
+        for key in ("driver", "connect", "password_query", "user_query"):
+            if key in text:
+                ok(f"auth-sql.conf.ext has '{key}'")
+            else:
+                fail(f"auth-sql.conf.ext missing '{key}'")
+
+    master = conf_dir / "conf.d" / "10-master.conf"
+    if master.exists():
+        text = master.read_text()
+        for service in ("imap-login", "lmtp", "auth"):
+            if f"service {service}" in text:
+                ok(f"10-master.conf has service '{service}'")
+            else:
+                fail(f"10-master.conf missing service '{service}'")
+
+
+# ── Postfix ───────────────────────────────────────────────────────────────────
+
+def check_postfix() -> None:
+    print("\n[postfix]")
+    postfix_dir = SERVICES / "workspace-smtp" / "postfix"
+
+    main_cf = postfix_dir / "main.cf"
+    if not require_file(main_cf):
+        return
+
+    content = main_cf.read_text()
+    for key in ("virtual_transport", "virtual_mailbox_domains", "smtpd_relay_restrictions",
+                "smtpd_sasl_auth_enable", "message_size_limit"):
+        if key in content:
+            ok(f"main.cf has '{key}'")
+        else:
+            fail(f"main.cf missing '{key}'")
+
+    # Must not be an open relay
+    if "reject_unauth_destination" in content:
+        ok("main.cf has reject_unauth_destination (no open relay)")
+    else:
+        fail("main.cf missing reject_unauth_destination — open relay risk")
+
+    for fname in ("master.cf", "virtual_domains.cf", "virtual_mailbox.cf"):
+        require_file(postfix_dir / fname)
+
+    entrypoint = SERVICES / "workspace-smtp" / "entrypoint.sh"
+    if require_file(entrypoint):
+        text = entrypoint.read_text()
+        for var in ("SMTP_HOSTNAME", "DOVECOT_HOST", "POSTGRES_HOST"):
+            if var in text:
+                ok(f"entrypoint.sh substitutes {var}")
+            else:
+                fail(f"entrypoint.sh missing substitution for {var}")
+
+
+# ── Radicale ──────────────────────────────────────────────────────────────────
+
+def check_radicale() -> None:
+    print("\n[radicale]")
+    config_path = SERVICES / "workspace-caldav" / "radicale" / "config"
+
+    if not require_file(config_path):
+        return
+
+    cp = configparser.ConfigParser()
+    cp.read(config_path)
+
+    for section in ("server", "auth", "storage", "logging"):
+        if cp.has_section(section):
+            ok(f"radicale config has [{section}]")
+        else:
+            fail(f"radicale config missing [{section}]")
+
+    if cp.has_option("server", "hosts"):
+        ok(f"radicale [server] hosts = {cp.get('server', 'hosts')}")
+    else:
+        fail("radicale [server] missing hosts")
+
+    if cp.has_option("storage", "filesystem_folder"):
+        ok(f"radicale [storage] filesystem_folder = {cp.get('storage', 'filesystem_folder')}")
+    else:
+        fail("radicale [storage] missing filesystem_folder")
+
+
+# ── docker-compose ────────────────────────────────────────────────────────────
+
+def check_compose() -> None:
+    print("\n[docker-compose]")
+    try:
+        import yaml
+    except ImportError:
+        fail("PyYAML not installed — cannot validate docker-compose (pip install pyyaml)")
+        return
+
+    compose_path = INFRA_LOCAL / "docker-compose.workspace.yml"
+    if not require_file(compose_path):
+        return
+
+    with compose_path.open() as f:
+        doc = yaml.safe_load(f)
+
+    services = doc.get("services", {})
+    expected = {"postgres", "redis", "minio", "workspace-mail", "workspace-smtp", "workspace-caldav"}
+    for svc in expected:
+        if svc in services:
+            ok(f"compose has service '{svc}'")
+        else:
+            fail(f"compose missing service '{svc}'")
+
+    volumes = doc.get("volumes", {})
+    for v in ("pgdata", "maildata", "caldavdata", "miniodata"):
+        if v in volumes:
+            ok(f"compose has volume '{v}'")
+        else:
+            fail(f"compose missing volume '{v}'")
+
+    # workspace-mail must depend on postgres
+    mail_deps = services.get("workspace-mail", {}).get("depends_on", [])
+    if "postgres" in mail_deps:
+        ok("workspace-mail depends_on postgres")
+    else:
+        fail("workspace-mail missing depends_on: postgres")
+
+
+# ── Kustomize ─────────────────────────────────────────────────────────────────
+
+def check_kustomize() -> None:
+    print("\n[kustomize]")
+    try:
+        import yaml
+    except ImportError:
+        fail("PyYAML not installed — cannot validate kustomize")
+        return
+
+    for service in ("workspace-mail", "workspace-caldav", "workspace-minio"):
+        kust = INFRA_K8S / service / "base" / "kustomization.yaml"
+        if not require_file(kust):
+            continue
+
+        with kust.open() as f:
+            doc = yaml.safe_load(f)
+
+        resources = doc.get("resources", [])
+        base_dir = kust.parent
+        for r in resources:
+            resource_path = base_dir / r
+            if resource_path.exists():
+                ok(f"{service}/base/{r} exists")
+            else:
+                fail(f"{service}/base/{r} referenced in kustomization but not found")
+
+        for overlay in ("p0-lab", "p1-single-site"):
+            overlay_kust = INFRA_K8S / service / "overlays" / overlay / "kustomization.yaml"
+            if overlay_kust.exists():
+                ok(f"{service}/overlays/{overlay}/kustomization.yaml exists")
+            # p1-single-site not required for all services; just check p0-lab
+            elif overlay == "p0-lab":
+                fail(f"{service}/overlays/p0-lab/kustomization.yaml missing")
+
+
+# ── Dockerfiles ───────────────────────────────────────────────────────────────
+
+def check_dockerfiles() -> None:
+    print("\n[dockerfiles]")
+    for service in ("workspace-mail", "workspace-smtp", "workspace-caldav"):
+        df = SERVICES / service / "Dockerfile"
+        if not require_file(df):
+            continue
+        content = df.read_text()
+        if "FROM" in content:
+            ok(f"{service}/Dockerfile has FROM")
+        else:
+            fail(f"{service}/Dockerfile missing FROM")
+        if "EXPOSE" in content:
+            ok(f"{service}/Dockerfile has EXPOSE")
+        else:
+            fail(f"{service}/Dockerfile missing EXPOSE")
+
+
+# ── DB migration ──────────────────────────────────────────────────────────────
+
+def check_db_migration() -> None:
+    print("\n[db-migration]")
+    migration = ROOT / "infra" / "datastores" / "postgres" / "010_workspace_mail.sql"
+    if not require_file(migration):
+        return
+    sql = migration.read_text()
+    for table in ("mail_domains", "mail_users"):
+        if f"CREATE TABLE IF NOT EXISTS {table}" in sql:
+            ok(f"migration creates table '{table}'")
+        else:
+            fail(f"migration missing CREATE TABLE {table}")
+
+
+# ── Argo CD AppSet ────────────────────────────────────────────────────────────
+
+def check_argocd() -> None:
+    print("\n[argocd-appset]")
+    try:
+        import yaml
+    except ImportError:
+        fail("PyYAML not installed")
+        return
+
+    appset = ROOT / "infra" / "k8s" / "argo-cd" / "appsets" / "socioprophet-appset.yaml"
+    if not require_file(appset):
+        return
+
+    with appset.open() as f:
+        doc = yaml.safe_load(f)
+
+    elements = (doc.get("spec", {})
+                   .get("generators", [{}])[0]
+                   .get("list", {})
+                   .get("elements", []))
+    names = {e["name"] for e in elements}
+    for expected in ("workspace-mail", "workspace-caldav", "workspace-minio"):
+        if expected in names:
+            ok(f"appset has element '{expected}'")
+        else:
+            fail(f"appset missing element '{expected}'")
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print("=== validate-workspace-services ===")
+    check_dockerfiles()
+    check_dovecot()
+    check_postfix()
+    check_radicale()
+    check_compose()
+    check_kustomize()
+    check_db_migration()
+    check_argocd()
+
+    print("\n--- summary ---")
+    for line in CHECKS:
+        print(line)
+
+    if ERRORS:
+        print(f"\n{len(ERRORS)} error(s):")
+        for e in ERRORS:
+            print(f"  {e}")
+        sys.exit(1)
+    else:
+        print(f"\nAll {len(CHECKS)} checks passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Workspace services** — Dockerized Dovecot (IMAP+LMTP), Postfix (SMTP+submission), Radicale (CalDAV+CardDAV), MinIO; Kustomize manifests; Argo CD registration; local docker-compose; 83-check validator + 65-test pytest suite + Docker smoke test
- **Hetzner/k3s Terraform substrate** — `infra/terraform/` modules for local (k3d) and Hetzner Cloud (`p1-single-site`) deployment paths
- **Relationship to PR #585** — the GCP OpenTofu landing zone (`infra/tofu/`) lives in [#585](https://github.com/SocioProphet/prophet-platform/pull/585); this PR covers the local-dev and baremetal/Hetzner paths

## What changed

### Workspace services (`services/`, `infra/k8s/workspace-*/`, `infra/local/`)

| Service | Stack | Ports |
|---|---|---|
| workspace-mail | Dovecot IMAP + LMTP, PostgreSQL passdb/userdb | 143, 993, 24 |
| workspace-smtp | Postfix virtual mailbox, SASL auth, no open relay | 25, 587 |
| workspace-caldav | Radicale CalDAV + CardDAV | 5232 |
| workspace-minio | MinIO S3-compatible object storage | 9000, 9001 |

- Kustomize base + `p0-lab` / `p1-single-site` overlays for all three k8s deployments
- Argo CD appset: `workspace.mail`, `workspace.caldav`, `workspace.storage` bundles
- `infra/datastores/postgres/010_workspace_mail.sql` — idempotent `mail_domains` + `mail_users` migration
- `infra/local/docker-compose.workspace.yml` — full local stack (postgres, redis, minio, mail, smtp, caldav)

### Build and test automation

- `tools/validate_workspace_services.py` — 83 config/manifest checks, no Docker required
- `tests/workspace_operations/test_workspace_infra.py` — 65 pytest assertions
- `tools/smoke_workspace_services.sh` — daemon preflight + port conflict check + health probes + teardown
- `make validate-workspace-services`, `make test-workspace`, `make smoke-workspace`, `make workspace-up/down/logs`

### Hetzner/k3s Terraform substrate (`infra/terraform/`)

| Module | What it provisions |
|---|---|
| `modules/k3s-node` | Hetzner server + cloud-init k3s bootstrap (control-plane or worker) |
| `modules/workspace-secrets` | Kubernetes Secret YAML stubs staged for SOPS/age encryption |
| `modules/dns` | A/MX/SRV/SPF record list for mail, caldav, minio, argocd FQDNs |
| `envs/p0-lab` | k3d local cluster — Docker-based, local state |
| `envs/p1-single-site` | Hetzner Cloud — network, firewall, SSH key, 1 control-plane + N workers (GCS remote state) |

### CI (`workflows/workspace-services-image.yml`, `workflows/workspace-terraform-validate.yml`)

- `workspace-services-image.yml` — build + push `workspace-mail`, `workspace-smtp`, `workspace-caldav` to GHCR on merge; `kubectl kustomize` validate on PRs
- `workspace-terraform-validate.yml` — `terraform fmt -check` + `terraform validate` for both envs on every `infra/terraform/**` PR; plan-only, no apply

## Reviewer notes

- `infra/terraform/` (Hetzner/k3s) and `infra/tofu/` (GCP OpenTofu, PR #585) are complementary — different deployment targets for the same `p0-lab` / `p1-single-site` topology
- No cloud resources are applied by any CI job in this PR — plan-only
- `terraform.tfvars` is gitignored; copy `terraform.tfvars.example` to start
- Workspace service content (Dockerfiles, k8s manifests, tests, tools) is substantively identical to #585 but sourced from a different commit base — whichever merges first, the other will need a rebase

## Test plan

- [x] `make validate-workspace-services` — 83/83 checks pass
- [x] `make test-workspace` — 65/65 pytest assertions pass
- [ ] `make smoke-workspace` — requires Docker daemon running
- [ ] `make infra-validate` — requires `terraform` or `tofu` installed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)