### PR TITLE
test: closed-loop regression promotion schema, valid fixture, and state machine guards

### DIFF
--- a/contracts/workroom/devsecops-regression-promotion-v0.1.schema.json
+++ b/contracts/workroom/devsecops-regression-promotion-v0.1.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "devsecops-regression-promotion-v0.1",
+  "title": "DevSecOps Regression Promotion",
+  "description": "Standalone schema for closed-loop regression promotion: BDE or RCA → RegressionFixture → ValidationPlan. Models promotion state machine for fixture and plan lifecycle.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "promotion_id",
+    "behavioral_divergence_event",
+    "rca_claims",
+    "regression_fixtures",
+    "validation_plans",
+    "non_claims"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1.0"
+    },
+    "promotion_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "behavioral_divergence_event": {
+      "type": "object",
+      "required": ["event_id", "event_type", "summary"],
+      "additionalProperties": false,
+      "properties": {
+        "event_id": {"type": "string", "minLength": 1},
+        "event_type": {"type": "string", "enum": ["production_incident", "synthetic_divergence", "regression_detected", "pre_merge_failure"]},
+        "summary": {"type": "string", "minLength": 1},
+        "source_ref": {"type": "string"},
+        "incident_ref": {"type": "string"},
+        "non_claims": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "rca_claims": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["claim_id", "claim_status", "evidence_refs"],
+        "additionalProperties": false,
+        "properties": {
+          "claim_id": {"type": "string", "minLength": 1},
+          "claim_status": {
+            "type": "string",
+            "enum": [
+              "hypothesized",
+              "supported_causal_claim",
+              "confirmed_causal_claim",
+              "unsupported",
+              "rejected_causal_claim"
+            ]
+          },
+          "statement": {"type": "string"},
+          "evidence_refs": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1
+          },
+          "counterevidence_refs": {
+            "type": "array",
+            "items": {"type": "string"}
+          },
+          "confidence": {
+            "type": "string",
+            "enum": ["none", "low", "medium", "high"]
+          },
+          "non_claims": {"type": "array", "items": {"type": "string"}}
+        }
+      }
+    },
+    "regression_fixtures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["fixture_id", "fixture_status", "derived_from", "target_validation_plan_ref"],
+        "additionalProperties": false,
+        "properties": {
+          "fixture_id": {"type": "string", "minLength": 1},
+          "fixture_status": {
+            "type": "string",
+            "enum": ["candidate", "reviewed", "accepted", "promoted", "deprecated", "superseded", "rejected"]
+          },
+          "derived_from": {"type": "string", "minLength": 1},
+          "summary": {"type": "string"},
+          "target_validation_plan_ref": {"type": "string", "minLength": 1},
+          "successor_fixture_ref": {"type": "string"},
+          "blocking_gate": {
+            "type": "boolean",
+            "description": "If true, this fixture is eligible to block future PRs. Only promoted fixtures may set this to true."
+          },
+          "non_claims": {"type": "array", "items": {"type": "string"}}
+        }
+      }
+    },
+    "validation_plans": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["plan_id", "plan_status", "regression_fixture_refs"],
+        "additionalProperties": false,
+        "properties": {
+          "plan_id": {"type": "string", "minLength": 1},
+          "plan_status": {
+            "type": "string",
+            "enum": ["draft", "reviewed", "promoted", "active", "deprecated", "superseded"]
+          },
+          "regression_fixture_refs": {
+            "type": "array",
+            "items": {"type": "string"}
+          },
+          "non_claims": {"type": "array", "items": {"type": "string"}}
+        }
+      }
+    },
+    "non_claims": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    }
+  }
+}

--- a/tests/fixtures/workroom/devsecops-regression-promotion.candidate-blocking-gate.invalid.json
+++ b/tests/fixtures/workroom/devsecops-regression-promotion.candidate-blocking-gate.invalid.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "0.1.0",
+  "promotion_id": "regression-promotion:devsecops:invalid:candidate-blocking-gate",
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:invalid-candidate-blocking",
+    "event_type": "production_incident",
+    "summary": "Expected-invalid fixture: candidate regression fixture has blocking_gate set to true.",
+    "non_claims": ["Expected-invalid fixture only."]
+  },
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:invalid-candidate-blocking:supported-causal",
+      "claim_status": "supported_causal_claim",
+      "statement": "Expected-invalid claim backing candidate fixture with illegal blocking gate.",
+      "evidence_refs": ["evidence://fixture/invalid-candidate-blocking/metric-observation"],
+      "counterevidence_refs": [],
+      "confidence": "low",
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "regression_fixtures": [
+    {
+      "fixture_id": "regression-fixture:invalid-candidate-blocking:candidate-gate",
+      "fixture_status": "candidate",
+      "derived_from": "rca-claim:invalid-candidate-blocking:supported-causal",
+      "summary": "Candidate fixture improperly claiming blocking gate authority. Only promoted fixtures may block.",
+      "target_validation_plan_ref": "validation-plan://fixture/invalid-candidate-blocking/draft-plan",
+      "blocking_gate": true,
+      "non_claims": ["Expected-invalid: candidate cannot be blocking gate."]
+    }
+  ],
+  "validation_plans": [
+    {
+      "plan_id": "validation-plan://fixture/invalid-candidate-blocking/draft-plan",
+      "plan_status": "draft",
+      "regression_fixture_refs": [
+        "regression-fixture:invalid-candidate-blocking:candidate-gate"
+      ],
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "non_claims": ["Expected-invalid fixture only. Tests: candidate fixture cannot hold blocking_gate authority."]
+}

--- a/tests/fixtures/workroom/devsecops-regression-promotion.closed-loop.valid.json
+++ b/tests/fixtures/workroom/devsecops-regression-promotion.closed-loop.valid.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "0.1.0",
+  "promotion_id": "regression-promotion:devsecops:api-latency-spike:closed-loop",
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:api-latency-spike",
+    "event_type": "production_incident",
+    "summary": "API p99 latency exceeded 2s SLO for 12 minutes following deploy of commit d7a1c3f. Downstream authentication service cascaded.",
+    "source_ref": "incident://pagerduty/prophet-platform/INC-5001",
+    "incident_ref": "incident://pagerduty/prophet-platform/INC-5001",
+    "non_claims": [
+      "Fixture event only. No live PagerDuty integration.",
+      "Event summary does not certify production root cause."
+    ]
+  },
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:api-latency-spike:db-connection-pool-exhaustion",
+      "claim_status": "supported_causal_claim",
+      "statement": "Database connection pool exhaustion caused API latency spike. Fixture metric evidence shows connection count at 100/100 for duration of incident window.",
+      "evidence_refs": [
+        "evidence://observability/prophet-platform/db-connection-pool-saturation-INC-5001",
+        "evidence://observability/prophet-platform/api-p99-latency-INC-5001"
+      ],
+      "counterevidence_refs": [],
+      "confidence": "medium",
+      "non_claims": [
+        "Claim is fixture-based. No live telemetry.",
+        "Medium confidence: single evidence window, no pre-incident baseline."
+      ]
+    }
+  ],
+  "regression_fixtures": [
+    {
+      "fixture_id": "regression-fixture:api-latency-spike:db-pool-exhaustion-regression",
+      "fixture_status": "promoted",
+      "derived_from": "rca-claim:api-latency-spike:db-connection-pool-exhaustion",
+      "summary": "Regression fixture: pre-merge SVF plan must confirm connection pool headroom above 20% under synthetic load. Derived from INC-5001 RCA.",
+      "target_validation_plan_ref": "validation-plan://prophet-platform/svf/db-connection-pool-regression-guard",
+      "blocking_gate": true,
+      "non_claims": [
+        "Fixture is fixture-status promoted for testing only.",
+        "Blocking gate requires active promoted plan before enforcement."
+      ]
+    }
+  ],
+  "validation_plans": [
+    {
+      "plan_id": "validation-plan://prophet-platform/svf/db-connection-pool-regression-guard",
+      "plan_status": "promoted",
+      "regression_fixture_refs": [
+        "regression-fixture:api-latency-spike:db-pool-exhaustion-regression"
+      ],
+      "non_claims": [
+        "Plan is fixture-promoted. No live SVF runner enforcement in v0.1.",
+        "Plan does not certify production readiness."
+      ]
+    }
+  ],
+  "non_claims": [
+    "Closed-loop fixture only. No live incident, telemetry, or production action.",
+    "Validator confirms structural and promotion linkage only.",
+    "Promotion does not execute SVF plans or authorize production changes."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-regression-promotion.rejected-fixture-active-plan.invalid.json
+++ b/tests/fixtures/workroom/devsecops-regression-promotion.rejected-fixture-active-plan.invalid.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "0.1.0",
+  "promotion_id": "regression-promotion:devsecops:invalid:rejected-fixture-active-plan",
+  "behavioral_divergence_event": {
+    "event_id": "bde:production-incident:invalid-rejected-fixture-plan",
+    "event_type": "production_incident",
+    "summary": "Expected-invalid fixture: active validation plan references a rejected regression fixture.",
+    "non_claims": ["Expected-invalid fixture only."]
+  },
+  "rca_claims": [
+    {
+      "claim_id": "rca-claim:invalid-rejected:supported-causal",
+      "claim_status": "supported_causal_claim",
+      "statement": "Expected-invalid claim backing rejected fixture.",
+      "evidence_refs": ["evidence://fixture/invalid-rejected/metric-observation"],
+      "counterevidence_refs": [],
+      "confidence": "medium",
+      "non_claims": ["Expected-invalid fixture only."]
+    }
+  ],
+  "regression_fixtures": [
+    {
+      "fixture_id": "regression-fixture:invalid-rejected:rejected-regression",
+      "fixture_status": "rejected",
+      "derived_from": "rca-claim:invalid-rejected:supported-causal",
+      "summary": "This fixture was rejected after review. No active plan may reference it.",
+      "target_validation_plan_ref": "validation-plan://fixture/invalid-rejected/active-plan",
+      "non_claims": ["Rejected fixture — should not be referenced by active plan."]
+    }
+  ],
+  "validation_plans": [
+    {
+      "plan_id": "validation-plan://fixture/invalid-rejected/active-plan",
+      "plan_status": "active",
+      "regression_fixture_refs": [
+        "regression-fixture:invalid-rejected:rejected-regression"
+      ],
+      "non_claims": ["Expected-invalid: active plan references rejected fixture."]
+    }
+  ],
+  "non_claims": ["Expected-invalid fixture only. Tests: active plan cannot reference rejected regression fixture."]
+}

--- a/tools/validate_devsecops_regression_promotion.py
+++ b/tools/validate_devsecops_regression_promotion.py
@@ -6,20 +6,42 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import jsonschema
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "tools"))
 
 import validate_devsecops_workroom as workroom  # noqa: E402
 
-VALID_FIXTURES = [
+PROMOTION_SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-regression-promotion-v0.1.schema.json"
+
+# Valid fixtures: must pass Workroom broad schema+semantic AND promotion rules.
+WORKROOM_VALID_FIXTURES = [
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-workroom.post-merge-incident.valid.json",
 ]
-INVALID_FIXTURES = {
+
+# Valid fixtures that use the dedicated regression promotion schema.
+PROMOTION_VALID_FIXTURES = [
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-regression-promotion.closed-loop.valid.json",
+]
+
+# Invalid fixtures validated against the broad Workroom schema + promotion rules.
+WORKROOM_INVALID_FIXTURES: dict[Path, list[str]] = {
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-regression-promotion.unbacked-regression-candidate.invalid.json": [
         "regression fixture derived_from must reference the behavioral divergence event or an RCA claim",
     ],
     ROOT / "tests" / "fixtures" / "workroom" / "devsecops-regression-promotion.validation-plan-unpromoted-fixture.invalid.json": [
         "promoted validation plan cannot reference candidate regression fixture",
+    ],
+}
+
+# Invalid fixtures validated against the dedicated promotion schema + promotion rules.
+PROMOTION_INVALID_FIXTURES: dict[Path, list[str]] = {
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-regression-promotion.rejected-fixture-active-plan.invalid.json": [
+        "active validation plan cannot reference rejected regression fixture",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-regression-promotion.candidate-blocking-gate.invalid.json": [
+        "candidate regression fixture cannot hold blocking_gate authority",
     ],
 }
 
@@ -31,8 +53,23 @@ def load(path: Path) -> dict[str, Any]:
     return data
 
 
+def promotion_schema_problems(schema: dict[str, Any], data: dict[str, Any]) -> list[str]:
+    v = jsonschema.Draft7Validator(schema)
+    return [e.message for e in sorted(v.iter_errors(data), key=lambda e: list(e.path))]
+
+
 def promotion_problems(data: dict[str, Any]) -> list[str]:
+    """
+    Checks promotion state machine rules:
+    1. regression_fixture.derived_from must reference BDE event_id or an RCA claim_id.
+    2. promoted validation plan cannot reference non-promoted fixture.
+    3. active validation plan cannot reference rejected fixture.
+    4. active or promoted plan cannot reference deprecated fixture.
+    5. candidate fixture cannot hold blocking_gate authority.
+    6. superseded fixture must identify a successor.
+    """
     problems: list[str] = []
+
     bde = data.get("behavioral_divergence_event", {})
     event_id = bde.get("event_id") if isinstance(bde, dict) else None
     claim_ids = {
@@ -51,9 +88,23 @@ def promotion_problems(data: dict[str, Any]) -> list[str]:
         fixture_status = str(fixture.get("fixture_status", ""))
         fixture_status_by_id[fixture_id] = fixture_status
         derived_from = str(fixture.get("derived_from", ""))
+
+        # Rule 1: derived_from must reference BDE or RCA claim
         if derived_from != event_id and derived_from not in claim_ids:
             problems.append(
                 f"{fixture_id}: regression fixture derived_from must reference the behavioral divergence event or an RCA claim"
+            )
+
+        # Rule 5: candidate fixture cannot hold blocking_gate authority
+        if fixture_status == "candidate" and fixture.get("blocking_gate") is True:
+            problems.append(
+                f"{fixture_id}: candidate regression fixture cannot hold blocking_gate authority"
+            )
+
+        # Rule 6: superseded fixture must identify a successor
+        if fixture_status == "superseded" and not fixture.get("successor_fixture_ref"):
+            problems.append(
+                f"{fixture_id}: superseded regression fixture must identify a successor via successor_fixture_ref"
             )
 
     for plan in validation_plans if isinstance(validation_plans, list) else []:
@@ -64,9 +115,29 @@ def promotion_problems(data: dict[str, Any]) -> list[str]:
         for ref in plan.get("regression_fixture_refs", []):
             status = fixture_status_by_id.get(str(ref))
             if status is None:
-                problems.append(f"{plan_id}: validation plan references unknown regression fixture {ref}")
-            elif plan_status == "promoted" and status != "promoted":
-                problems.append(f"{plan_id}: promoted validation plan cannot reference candidate regression fixture {ref}")
+                problems.append(
+                    f"{plan_id}: validation plan references unknown regression fixture {ref}"
+                )
+                continue
+
+            # Rule 2: promoted plan cannot reference non-promoted fixture
+            if plan_status == "promoted" and status not in ("promoted",):
+                problems.append(
+                    f"{plan_id}: promoted validation plan cannot reference candidate regression fixture {ref}"
+                )
+
+            # Rule 3: active plan cannot reference rejected fixture
+            if plan_status == "active" and status == "rejected":
+                problems.append(
+                    f"{plan_id}: active validation plan cannot reference rejected regression fixture {ref}"
+                )
+
+            # Rule 4: active or promoted plan cannot reference deprecated fixture
+            if plan_status in ("active", "promoted") and status == "deprecated":
+                problems.append(
+                    f"{plan_id}: {plan_status} validation plan cannot reference deprecated regression fixture {ref}"
+                )
+
     return problems
 
 
@@ -81,29 +152,44 @@ def expect(path: Path, problems: list[str], expected_substrings: list[str]) -> l
 
 
 def main() -> int:
-    schema = workroom.load(workroom.SCHEMA)
+    workroom_schema = workroom.load(workroom.SCHEMA)
+    promotion_schema = load(PROMOTION_SCHEMA)
     failed = False
     results: dict[str, dict[str, Any]] = {}
 
-    for path in VALID_FIXTURES:
+    # ── Broad Workroom valid fixtures ────────────────────────────────────────
+    for path in WORKROOM_VALID_FIXTURES:
         data = load(path)
-        schema_errors = workroom.schema_problems(schema, data)
+        schema_errors = workroom.schema_problems(workroom_schema, data)
         semantic_errors = workroom.semantic_problems(data)
-        promotion_errors = promotion_problems(data)
-        failed = failed or bool(schema_errors or semantic_errors or promotion_errors)
+        promo_errors = promotion_problems(data)
+        failed = failed or bool(schema_errors or semantic_errors or promo_errors)
         results[str(path.relative_to(ROOT))] = {
             "expected": "valid",
             "schema": schema_errors,
             "semantic": semantic_errors,
-            "promotion": promotion_errors,
+            "promotion": promo_errors,
         }
 
-    for path, expected in INVALID_FIXTURES.items():
+    # ── Dedicated promotion schema valid fixtures ────────────────────────────
+    for path in PROMOTION_VALID_FIXTURES:
         data = load(path)
-        schema_errors = workroom.schema_problems(schema, data)
+        schema_errors = promotion_schema_problems(promotion_schema, data)
+        promo_errors = promotion_problems(data)
+        failed = failed or bool(schema_errors or promo_errors)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "valid",
+            "schema": schema_errors,
+            "promotion": promo_errors,
+        }
+
+    # ── Broad Workroom invalid fixtures ─────────────────────────────────────
+    for path, expected in WORKROOM_INVALID_FIXTURES.items():
+        data = load(path)
+        schema_errors = workroom.schema_problems(workroom_schema, data)
         semantic_errors = workroom.semantic_problems(data)
-        promotion_errors = promotion_problems(data)
-        problems = schema_errors + semantic_errors + promotion_errors
+        promo_errors = promotion_problems(data)
+        problems = schema_errors + semantic_errors + promo_errors
         failures = expect(path.relative_to(ROOT), problems, expected)
         failed = failed or bool(failures)
         results[str(path.relative_to(ROOT))] = {
@@ -112,17 +198,34 @@ def main() -> int:
             "expectation_failures": failures,
             "schema": schema_errors,
             "semantic": semantic_errors,
-            "promotion": promotion_errors,
+            "promotion": promo_errors,
+        }
+
+    # ── Dedicated promotion schema invalid fixtures ──────────────────────────
+    for path, expected in PROMOTION_INVALID_FIXTURES.items():
+        data = load(path)
+        schema_errors = promotion_schema_problems(promotion_schema, data)
+        promo_errors = promotion_problems(data)
+        problems = schema_errors + promo_errors
+        failures = expect(path.relative_to(ROOT), problems, expected)
+        failed = failed or bool(failures)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid",
+            "expected_problem_substrings": expected,
+            "expectation_failures": failures,
+            "schema": schema_errors,
+            "promotion": promo_errors,
         }
 
     report = {
-        "validator": "prophet-platform.devsecops-regression-promotion.validator.v1",
+        "validator": "prophet-platform.devsecops-regression-promotion.validator.v2",
         "passed": not failed,
         "results": results,
         "non_claims": [
-            "Validator checks fixture-scoped regression promotion linkage.",
+            "Validator checks fixture-scoped regression promotion linkage and state machine rules.",
             "Validator performs no runtime operations.",
-            "Validator does not promote fixtures by itself."
+            "Validator does not promote fixtures by itself.",
+            "Validator does not authorize validation plan enforcement or PR gating."
         ],
     }
     print(json.dumps(report, indent=2, sort_keys=True))


### PR DESCRIPTION
## Summary

- Add `contracts/workroom/devsecops-regression-promotion-v0.1.schema.json` — standalone schema for the RegressionFixture + ValidationPlan promotion lifecycle (candidate → reviewed → accepted → promoted → deprecated / superseded / rejected)
- Add `devsecops-regression-promotion.closed-loop.valid.json` — valid end-to-end closed-loop fixture: BDE → RCA claim → promoted regression fixture → promoted validation plan
- Add two new state machine invalid fixtures: active plan referencing rejected fixture; candidate fixture claiming `blocking_gate` authority
- Expand `validate_devsecops_regression_promotion.py` (v2) with dedicated schema validation path for promotion fixtures and full state machine rule set

## State machine rules added

- Promoted plan cannot reference non-promoted fixture (carried from #574)
- Active plan cannot reference rejected fixture
- Active or promoted plan cannot reference deprecated fixture
- Candidate fixture cannot hold `blocking_gate` authority
- Superseded fixture must name a `successor_fixture_ref`

## Test plan

- [ ] `devsecops-regression-promotion` workflow green
- [ ] `premerge-audit` green
- [ ] Valid closed-loop fixture passes schema + promotion rules with zero errors
- [ ] All four invalid fixtures catch expected errors

## Boundary

Contract and fixture validation only. No runtime execution, fixture promotion, production action authorization, or PR gating.

Refs #519
Refs #520