### PR TITLE
feat(workroom): add ActionGrant standalone contract, fixtures, and validator

### DIFF
--- a/.github/workflows/devsecops-action-grant.yml
+++ b/.github/workflows/devsecops-action-grant.yml
@@ -1,0 +1,31 @@
+name: devsecops-action-grant
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'contracts/workroom/devsecops-action-grant-v0.1.schema.json'
+      - 'tests/fixtures/workroom/devsecops-action-grant.*.json'
+      - 'tools/validate_devsecops_action_grant.py'
+      - '.github/workflows/devsecops-action-grant.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'contracts/workroom/devsecops-action-grant-v0.1.schema.json'
+      - 'tests/fixtures/workroom/devsecops-action-grant.*.json'
+      - 'tools/validate_devsecops_action_grant.py'
+      - '.github/workflows/devsecops-action-grant.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: python -m pip install jsonschema==4.23.0
+      - name: Validate DevSecOps ActionGrant contract
+        run: python tools/validate_devsecops_action_grant.py

--- a/contracts/workroom/devsecops-action-grant-v0.1.schema.json
+++ b/contracts/workroom/devsecops-action-grant-v0.1.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "devsecops-action-grant-v0.1",
+  "title": "DevSecOps Action Grant",
+  "description": "Standalone schema for a policy-bound action grant. Governs what actions may be taken within a Workroom context, under what approval conditions, and with what risk/scope constraints. Prophet Platform validates grant references only — it does not issue or certify grants.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "grant_id",
+    "action_class",
+    "risk_class",
+    "status",
+    "scope",
+    "approval_required",
+    "non_claims"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1.0"
+    },
+    "grant_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action_class": {
+      "type": "string",
+      "enum": [
+        "read_only",
+        "diagnostic_mutation",
+        "reversible_mitigation",
+        "irreversible_mutation",
+        "credential_sensitive",
+        "data_sensitive",
+        "customer_visible",
+        "destructive",
+        "privileged_identity",
+        "network_exposure",
+        "production_change"
+      ]
+    },
+    "risk_class": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "allowed",
+        "requires_human_approval",
+        "denied",
+        "expired",
+        "revoked",
+        "superseded"
+      ]
+    },
+    "scope": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable description of what this grant covers."
+    },
+    "approval_required": {
+      "type": "boolean"
+    },
+    "approver_ref": {
+      "type": "string",
+      "description": "Identity or role reference of the required approver."
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp after which the grant is no longer valid."
+    },
+    "capability_ref": {
+      "type": "string",
+      "description": "Reference to the capability contract that scopes this grant."
+    },
+    "policy_ref": {
+      "type": "string",
+      "description": "Reference to the policy document that governs this grant."
+    },
+    "receipt_required": {
+      "type": "boolean",
+      "description": "If true, execution must produce a verified AgentPlane execution receipt before remediation can be closed."
+    },
+    "workroom_id": {
+      "type": "string",
+      "description": "Workroom context this grant belongs to."
+    },
+    "remediation_plan_ref": {
+      "type": "string",
+      "description": "Remediation plan this grant authorizes."
+    },
+    "non_claims": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    }
+  }
+}

--- a/tests/fixtures/workroom/devsecops-action-grant.credential-sensitive-allowed.invalid.json
+++ b/tests/fixtures/workroom/devsecops-action-grant.credential-sensitive-allowed.invalid.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "0.1.0",
+  "grant_id": "action-grant:devsecops:invalid:credential-sensitive-allowed",
+  "action_class": "credential_sensitive",
+  "risk_class": "critical",
+  "status": "allowed",
+  "scope": "Expected-invalid: credential_sensitive action directly allowed without approval.",
+  "approval_required": false,
+  "receipt_required": false,
+  "workroom_id": "workroom:devsecops:invalid:credential-sensitive",
+  "non_claims": [
+    "Expected-invalid fixture only.",
+    "Tests: credential_sensitive action cannot be status=allowed directly."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-action-grant.expired-status.invalid.json
+++ b/tests/fixtures/workroom/devsecops-action-grant.expired-status.invalid.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "0.1.0",
+  "grant_id": "action-grant:devsecops:invalid:expired-production-change",
+  "action_class": "production_change",
+  "risk_class": "high",
+  "status": "expired",
+  "scope": "Expected-invalid: expired grant used as active remediation authorization.",
+  "approval_required": true,
+  "approver_ref": "identity://sre-on-call",
+  "expires_at": "2026-05-30T00:00:00Z",
+  "receipt_required": true,
+  "workroom_id": "workroom:devsecops:invalid:expired-grant",
+  "remediation_plan_ref": "remediation-plan:devsecops:invalid:expired-grant:rollback",
+  "non_claims": [
+    "Expected-invalid fixture only.",
+    "Tests: expired grant cannot authorize active remediation."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-action-grant.production-change-no-approval.invalid.json
+++ b/tests/fixtures/workroom/devsecops-action-grant.production-change-no-approval.invalid.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "0.1.0",
+  "grant_id": "action-grant:devsecops:invalid:production-change-no-approval",
+  "action_class": "production_change",
+  "risk_class": "high",
+  "status": "allowed",
+  "scope": "Expected-invalid: production_change action without requiring human approval.",
+  "approval_required": false,
+  "receipt_required": false,
+  "workroom_id": "workroom:devsecops:invalid:production-change-no-approval",
+  "non_claims": [
+    "Expected-invalid fixture only.",
+    "Tests: production_change must require human approval."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-action-grant.read-only-allowed.valid.json
+++ b/tests/fixtures/workroom/devsecops-action-grant.read-only-allowed.valid.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "0.1.0",
+  "grant_id": "action-grant:devsecops:workroom:scope-d-example:read-incident-evidence",
+  "action_class": "read_only",
+  "risk_class": "low",
+  "status": "allowed",
+  "scope": "Read fixture incident evidence packets and topology refs for workroom:devsecops:post-merge:scope-d-example.",
+  "approval_required": false,
+  "receipt_required": false,
+  "workroom_id": "workroom:devsecops:post-merge:scope-d-example",
+  "non_claims": [
+    "Grant permits read-only investigation access only.",
+    "Grant does not authorize production mutation, remediation execution, or credential access.",
+    "Grant does not certify Signadot feature parity or production readiness."
+  ]
+}

--- a/tools/validate_devsecops_action_grant.py
+++ b/tools/validate_devsecops_action_grant.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+Validator for DevSecOps ActionGrant fixtures.
+
+Rules:
+  1. credential_sensitive action cannot be status=allowed directly.
+  2. production_change must require human approval (approval_required=true).
+  3. destructive must require human approval.
+  4. expired or revoked grant cannot be the active authorization for a remediation plan.
+  5. read_only should not require approval in v0.1.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-action-grant-v0.1.schema.json"
+
+VALID_FIXTURES = [
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-action-grant.read-only-allowed.valid.json",
+]
+INVALID_FIXTURES: dict[Path, list[str]] = {
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-action-grant.credential-sensitive-allowed.invalid.json": [
+        "credential_sensitive action cannot be status=allowed directly",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-action-grant.production-change-no-approval.invalid.json": [
+        "production_change grant must require human approval",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-action-grant.expired-status.invalid.json": [
+        "expired or revoked grant cannot authorize a remediation plan",
+    ],
+}
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected object: {path}")
+    return data
+
+
+def schema_problems(schema: dict[str, Any], data: dict[str, Any]) -> list[str]:
+    v = jsonschema.Draft7Validator(schema)
+    return [e.message for e in sorted(v.iter_errors(data), key=lambda e: list(e.path))]
+
+
+def semantic_problems(data: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    grant_id = data.get("grant_id", "<unknown>")
+    action_class = data.get("action_class", "")
+    status = data.get("status", "")
+    approval_required = data.get("approval_required", False)
+    remediation_plan_ref = data.get("remediation_plan_ref")
+
+    # Rule 1: credential_sensitive cannot be allowed directly
+    if action_class == "credential_sensitive" and status == "allowed":
+        problems.append(
+            f"{grant_id}: credential_sensitive action cannot be status=allowed directly; requires_human_approval or denied only"
+        )
+
+    # Rule 2: production_change must require approval
+    if action_class == "production_change" and not approval_required:
+        problems.append(
+            f"{grant_id}: production_change grant must require human approval (approval_required must be true)"
+        )
+
+    # Rule 3: destructive must require approval
+    if action_class == "destructive" and not approval_required:
+        problems.append(
+            f"{grant_id}: destructive grant must require human approval (approval_required must be true)"
+        )
+
+    # Rule 4: expired/revoked grant cannot authorize remediation
+    if status in ("expired", "revoked") and remediation_plan_ref:
+        problems.append(
+            f"{grant_id}: expired or revoked grant cannot authorize a remediation plan (remediation_plan_ref must be absent)"
+        )
+
+    return problems
+
+
+def expect(path: Path, problems: list[str], expected_substrings: list[str]) -> list[str]:
+    failures: list[str] = []
+    if not problems:
+        failures.append(f"{path}: expected invalid fixture to fail, but it passed")
+    for expected in expected_substrings:
+        if not any(expected in p for p in problems):
+            failures.append(f"{path}: expected problem containing {expected!r}")
+    return failures
+
+
+def main() -> int:
+    schema = load(SCHEMA)
+    failed = False
+    results: dict[str, dict[str, Any]] = {}
+
+    for path in VALID_FIXTURES:
+        data = load(path)
+        s_errs = schema_problems(schema, data)
+        sem_errs = semantic_problems(data)
+        failed = failed or bool(s_errs or sem_errs)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "valid",
+            "schema": s_errs,
+            "semantic": sem_errs,
+        }
+
+    for path, expected in INVALID_FIXTURES.items():
+        data = load(path)
+        s_errs = schema_problems(schema, data)
+        sem_errs = semantic_problems(data)
+        problems = s_errs + sem_errs
+        failures = expect(path.relative_to(ROOT), problems, expected)
+        failed = failed or bool(failures)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid",
+            "expected_problem_substrings": expected,
+            "expectation_failures": failures,
+            "schema": s_errs,
+            "semantic": sem_errs,
+        }
+
+    report = {
+        "validator": "prophet-platform.devsecops-action-grant.validator.v1",
+        "passed": not failed,
+        "results": results,
+        "non_claims": [
+            "Validator checks grant contract structure and policy invariants only.",
+            "Validator does not issue, approve, or certify grants.",
+            "Validator does not execute actions or authorize production changes.",
+            "Prophet Platform validates grant references; AgentPlane holds execution authority."
+        ],
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(("PASS" if not failed else "FAIL") + ": devsecops action grant")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Tranche C: policy-bound action grant governance.

- `contracts/workroom/devsecops-action-grant-v0.1.schema.json` — standalone schema (11 action classes, 6 statuses, risk_class, approval_required, expires_at, capability_ref, policy_ref, receipt_required)
- Valid fixture: `read_only` / `low` / `allowed` / no approval required
- Invalid fixtures: `credential_sensitive` directly allowed; `production_change` without approval; `expired` grant with `remediation_plan_ref`
- `tools/validate_devsecops_action_grant.py` — checks policy rules
- `.github/workflows/devsecops-action-grant.yml`

## Rules enforced

- `credential_sensitive` → `requires_human_approval` or `denied` only; `allowed` is forbidden
- `production_change` + `destructive` → `approval_required: true` required
- `expired` / `revoked` grant → `remediation_plan_ref` must be absent

## Test plan

- [ ] `devsecops-action-grant` workflow green
- [ ] `premerge-audit` green
- [ ] Valid fixture passes with zero errors
- [ ] All three invalid fixtures catch expected errors

## Boundary

Validator checks contract structure and policy invariants only. Does not issue, approve, certify, or execute grants. AgentPlane holds execution authority.

Refs #519
Refs #520