### PR TITLE
feat(workroom): add AgentPlane execution handoff and receipt reference contracts

### DIFF
--- a/.github/workflows/devsecops-agentplane-handoff.yml
+++ b/.github/workflows/devsecops-agentplane-handoff.yml
@@ -1,0 +1,35 @@
+name: devsecops-agentplane-handoff
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'contracts/workroom/devsecops-action-execution-handoff-v0.1.schema.json'
+      - 'contracts/workroom/devsecops-action-execution-receipt-ref-v0.1.schema.json'
+      - 'tests/fixtures/workroom/devsecops-action-execution-handoff.*.json'
+      - 'tests/fixtures/workroom/devsecops-action-execution-receipt-ref.*.json'
+      - 'tools/validate_devsecops_agentplane_handoff.py'
+      - '.github/workflows/devsecops-agentplane-handoff.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'contracts/workroom/devsecops-action-execution-handoff-v0.1.schema.json'
+      - 'contracts/workroom/devsecops-action-execution-receipt-ref-v0.1.schema.json'
+      - 'tests/fixtures/workroom/devsecops-action-execution-handoff.*.json'
+      - 'tests/fixtures/workroom/devsecops-action-execution-receipt-ref.*.json'
+      - 'tools/validate_devsecops_agentplane_handoff.py'
+      - '.github/workflows/devsecops-agentplane-handoff.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: python -m pip install jsonschema==4.23.0
+      - name: Validate DevSecOps AgentPlane handoff contracts
+        run: python tools/validate_devsecops_agentplane_handoff.py

--- a/contracts/workroom/devsecops-action-execution-handoff-v0.1.schema.json
+++ b/contracts/workroom/devsecops-action-execution-handoff-v0.1.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "devsecops-action-execution-handoff-v0.1",
+  "title": "DevSecOps Action Execution Handoff",
+  "description": "Models the handoff of an approved remediation action from Prophet Platform to AgentPlane for execution. Prophet Platform proposes and tracks the handoff; AgentPlane executes and issues the receipt. Prophet Platform must not execute actions or issue receipts.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "handoff_id",
+    "workroom_id",
+    "remediation_plan_ref",
+    "action_grant_ref",
+    "risk_class",
+    "requires_receipt",
+    "status",
+    "non_claims"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1.0"
+    },
+    "handoff_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "workroom_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "remediation_plan_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "action_grant_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "agentplane_execution_request_ref": {
+      "type": "string",
+      "description": "Reference to the AgentPlane execution request submitted after approval."
+    },
+    "execution_receipt_ref": {
+      "type": "string",
+      "description": "Reference to the AgentPlane execution receipt. Present only when status=receipt_received."
+    },
+    "failure_evidence_ref": {
+      "type": "string",
+      "description": "Reference to failure evidence. Required when status=failed."
+    },
+    "policy_ref": {
+      "type": "string",
+      "description": "Policy document governing this handoff."
+    },
+    "risk_class": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "requires_receipt": {
+      "type": "boolean",
+      "description": "If true, execution must produce a verified receipt before remediation can be closed."
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "proposed",
+        "approved_for_handoff",
+        "submitted",
+        "receipt_received",
+        "failed",
+        "cancelled",
+        "denied"
+      ]
+    },
+    "non_claims": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    }
+  }
+}

--- a/contracts/workroom/devsecops-action-execution-receipt-ref-v0.1.schema.json
+++ b/contracts/workroom/devsecops-action-execution-receipt-ref-v0.1.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "devsecops-action-execution-receipt-ref-v0.1",
+  "title": "DevSecOps Action Execution Receipt Reference",
+  "description": "Reference to an AgentPlane execution receipt. Prophet Platform validates receipt references only — it does not issue or certify execution receipts. Receipt authority belongs to AgentPlane.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "receipt_ref",
+    "execution_request_ref",
+    "grant_ref",
+    "remediation_plan_ref",
+    "status",
+    "verifier",
+    "non_claims"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1.0"
+    },
+    "receipt_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "execution_request_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "grant_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "remediation_plan_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "success",
+        "failed",
+        "partial",
+        "denied",
+        "not_executed"
+      ]
+    },
+    "artifact_digest": {
+      "type": "string",
+      "description": "SHA-256 digest of the execution artifact. Required when status=success."
+    },
+    "failure_evidence_ref": {
+      "type": "string",
+      "description": "Reference to failure evidence. Required when status=failed."
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "verifier": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identity of the AgentPlane authority that issued this receipt."
+    },
+    "non_claims": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    }
+  }
+}

--- a/tests/fixtures/workroom/devsecops-action-execution-handoff.approved.valid.json
+++ b/tests/fixtures/workroom/devsecops-action-execution-handoff.approved.valid.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "0.1.0",
+  "handoff_id": "handoff:devsecops:scope-d-example:rollback-approved",
+  "workroom_id": "workroom:devsecops:post-merge:scope-d-example",
+  "remediation_plan_ref": "remediation-plan:scope-d-example:rollback-candidate",
+  "action_grant_ref": "action-grant:scope-d-example:rollback-production",
+  "agentplane_execution_request_ref": "agentplane-request:scope-d-example:rollback-approved",
+  "policy_ref": "policy://devsecops/production-change-approval-v1",
+  "risk_class": "high",
+  "requires_receipt": true,
+  "status": "approved_for_handoff",
+  "non_claims": [
+    "Handoff is fixture-only. No live AgentPlane submission.",
+    "approved_for_handoff status does not confirm execution or receipt.",
+    "Prophet Platform proposes and tracks handoffs; AgentPlane executes."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-action-execution-handoff.submitted-no-receipt.invalid.json
+++ b/tests/fixtures/workroom/devsecops-action-execution-handoff.submitted-no-receipt.invalid.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "0.1.0",
+  "handoff_id": "handoff:devsecops:invalid:receipt-received-no-ref",
+  "workroom_id": "workroom:devsecops:invalid:receipt-received-no-ref",
+  "remediation_plan_ref": "remediation-plan:invalid:receipt-received-no-ref",
+  "action_grant_ref": "action-grant:invalid:receipt-received-no-ref",
+  "risk_class": "high",
+  "requires_receipt": true,
+  "status": "receipt_received",
+  "non_claims": [
+    "Expected-invalid fixture only.",
+    "Tests: receipt_received status requires execution_receipt_ref."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-action-execution-receipt-ref.not-executed-success.invalid.json
+++ b/tests/fixtures/workroom/devsecops-action-execution-receipt-ref.not-executed-success.invalid.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "0.1.0",
+  "receipt_ref": "agentplane-receipt:invalid:not-executed-treated-as-success",
+  "execution_request_ref": "agentplane-request:invalid:not-executed",
+  "grant_ref": "action-grant:invalid:not-executed",
+  "remediation_plan_ref": "remediation-plan:invalid:not-executed",
+  "status": "not_executed",
+  "artifact_digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "issued_at": "2026-06-09T12:00:00Z",
+  "verifier": "agentplane:authority:scope-d-fixture",
+  "non_claims": [
+    "Expected-invalid fixture only.",
+    "Tests: not_executed receipt with artifact_digest is contradictory — not_executed cannot carry a success artifact."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-action-execution-receipt-ref.success.valid.json
+++ b/tests/fixtures/workroom/devsecops-action-execution-receipt-ref.success.valid.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "0.1.0",
+  "receipt_ref": "agentplane-receipt:scope-d-example:rollback-success",
+  "execution_request_ref": "agentplane-request:scope-d-example:rollback-approved",
+  "grant_ref": "action-grant:scope-d-example:rollback-production",
+  "remediation_plan_ref": "remediation-plan:scope-d-example:rollback-candidate",
+  "status": "success",
+  "artifact_digest": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  "issued_at": "2026-06-09T12:00:00Z",
+  "verifier": "agentplane:authority:scope-d-fixture",
+  "non_claims": [
+    "Receipt is fixture-only. No live AgentPlane execution.",
+    "Prophet Platform validates receipt references only; does not issue or certify.",
+    "success status does not certify production readiness."
+  ]
+}

--- a/tools/validate_devsecops_agentplane_handoff.py
+++ b/tools/validate_devsecops_agentplane_handoff.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Validator for DevSecOps AgentPlane execution handoff and execution receipt reference contracts.
+
+Handoff rules:
+  1. receipt_received status requires execution_receipt_ref.
+  2. failed status requires failure_evidence_ref.
+  3. denied status must not have execution_receipt_ref.
+  4. submitted status requires agentplane_execution_request_ref.
+
+Receipt reference rules:
+  1. success status requires artifact_digest.
+  2. failed status requires failure_evidence_ref.
+  3. not_executed must not carry artifact_digest.
+  4. partial status cannot close remediation (informational warning, not hard failure).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+HANDOFF_SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-action-execution-handoff-v0.1.schema.json"
+RECEIPT_SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-action-execution-receipt-ref-v0.1.schema.json"
+
+HANDOFF_VALID = [
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-action-execution-handoff.approved.valid.json",
+]
+HANDOFF_INVALID: dict[Path, list[str]] = {
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-action-execution-handoff.submitted-no-receipt.invalid.json": [
+        "receipt_received handoff requires execution_receipt_ref",
+    ],
+}
+
+RECEIPT_VALID = [
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-action-execution-receipt-ref.success.valid.json",
+]
+RECEIPT_INVALID: dict[Path, list[str]] = {
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-action-execution-receipt-ref.not-executed-success.invalid.json": [
+        "not_executed receipt must not carry artifact_digest",
+    ],
+}
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected object: {path}")
+    return data
+
+
+def schema_problems(schema: dict[str, Any], data: dict[str, Any]) -> list[str]:
+    v = jsonschema.Draft7Validator(schema)
+    return [e.message for e in sorted(v.iter_errors(data), key=lambda e: list(e.path))]
+
+
+def handoff_semantic_problems(data: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    hid = data.get("handoff_id", "<unknown>")
+    status = data.get("status", "")
+
+    if status == "receipt_received" and not data.get("execution_receipt_ref"):
+        problems.append(f"{hid}: receipt_received handoff requires execution_receipt_ref")
+
+    if status == "failed" and not data.get("failure_evidence_ref"):
+        problems.append(f"{hid}: failed handoff requires failure_evidence_ref")
+
+    if status == "denied" and data.get("execution_receipt_ref"):
+        problems.append(f"{hid}: denied handoff must not have execution_receipt_ref")
+
+    if status == "submitted" and not data.get("agentplane_execution_request_ref"):
+        problems.append(f"{hid}: submitted handoff requires agentplane_execution_request_ref")
+
+    return problems
+
+
+def receipt_semantic_problems(data: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    rid = data.get("receipt_ref", "<unknown>")
+    status = data.get("status", "")
+
+    if status == "success" and not data.get("artifact_digest"):
+        problems.append(f"{rid}: success receipt requires artifact_digest")
+
+    if status == "failed" and not data.get("failure_evidence_ref"):
+        problems.append(f"{rid}: failed receipt requires failure_evidence_ref")
+
+    if status == "not_executed" and data.get("artifact_digest"):
+        problems.append(f"{rid}: not_executed receipt must not carry artifact_digest")
+
+    return problems
+
+
+def expect(path: Path, problems: list[str], expected_substrings: list[str]) -> list[str]:
+    failures: list[str] = []
+    if not problems:
+        failures.append(f"{path}: expected invalid fixture to fail, but it passed")
+    for expected in expected_substrings:
+        if not any(expected in p for p in problems):
+            failures.append(f"{path}: expected problem containing {expected!r}")
+    return failures
+
+
+def main() -> int:
+    handoff_schema = load(HANDOFF_SCHEMA)
+    receipt_schema = load(RECEIPT_SCHEMA)
+    failed = False
+    results: dict[str, dict[str, Any]] = {}
+
+    # ── handoff valid ────────────────────────────────────────────────────────
+    for path in HANDOFF_VALID:
+        data = load(path)
+        s_errs = schema_problems(handoff_schema, data)
+        sem_errs = handoff_semantic_problems(data)
+        failed = failed or bool(s_errs or sem_errs)
+        results[str(path.relative_to(ROOT))] = {"expected": "valid", "schema": s_errs, "semantic": sem_errs}
+
+    # ── handoff invalid ──────────────────────────────────────────────────────
+    for path, expected in HANDOFF_INVALID.items():
+        data = load(path)
+        s_errs = schema_problems(handoff_schema, data)
+        sem_errs = handoff_semantic_problems(data)
+        problems = s_errs + sem_errs
+        failures = expect(path.relative_to(ROOT), problems, expected)
+        failed = failed or bool(failures)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid", "expected_problem_substrings": expected,
+            "expectation_failures": failures, "schema": s_errs, "semantic": sem_errs,
+        }
+
+    # ── receipt valid ────────────────────────────────────────────────────────
+    for path in RECEIPT_VALID:
+        data = load(path)
+        s_errs = schema_problems(receipt_schema, data)
+        sem_errs = receipt_semantic_problems(data)
+        failed = failed or bool(s_errs or sem_errs)
+        results[str(path.relative_to(ROOT))] = {"expected": "valid", "schema": s_errs, "semantic": sem_errs}
+
+    # ── receipt invalid ──────────────────────────────────────────────────────
+    for path, expected in RECEIPT_INVALID.items():
+        data = load(path)
+        s_errs = schema_problems(receipt_schema, data)
+        sem_errs = receipt_semantic_problems(data)
+        problems = s_errs + sem_errs
+        failures = expect(path.relative_to(ROOT), problems, expected)
+        failed = failed or bool(failures)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid", "expected_problem_substrings": expected,
+            "expectation_failures": failures, "schema": s_errs, "semantic": sem_errs,
+        }
+
+    report = {
+        "validator": "prophet-platform.devsecops-agentplane-handoff.validator.v1",
+        "passed": not failed,
+        "results": results,
+        "non_claims": [
+            "Validator checks handoff and receipt reference contract structure only.",
+            "Prophet Platform proposes handoffs and validates receipt references.",
+            "AgentPlane executes actions and issues execution receipts.",
+            "Validator does not execute actions, issue receipts, or authorize production changes.",
+        ],
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(("PASS" if not failed else "FAIL") + ": devsecops agentplane handoff")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Tranche D: Prophet → AgentPlane execution handoff boundary.

- `devsecops-action-execution-handoff-v0.1.schema.json` — handoff lifecycle (proposed → approved_for_handoff → submitted → receipt_received / failed / cancelled / denied)
- `devsecops-action-execution-receipt-ref-v0.1.schema.json` — receipt reference contract (AgentPlane authority; statuses: success / failed / partial / denied / not_executed)
- Valid fixtures: approved handoff, success receipt
- Invalid fixtures: `receipt_received` without receipt ref; `not_executed` receipt carrying artifact_digest
- `tools/validate_devsecops_agentplane_handoff.py`
- `.github/workflows/devsecops-agentplane-handoff.yml`

## Boundary

Prophet Platform proposes and tracks handoffs, validates receipt references. AgentPlane executes and issues receipts.

## Test plan

- [ ] `devsecops-agentplane-handoff` workflow green
- [ ] `premerge-audit` green

Refs #519
Refs #520