### PR TITLE
feat(workroom): add GAIA topology snapshot ref and blast-radius estimate contracts

### DIFF
--- a/.github/workflows/devsecops-gaia-topology.yml
+++ b/.github/workflows/devsecops-gaia-topology.yml
@@ -1,0 +1,35 @@
+name: devsecops-gaia-topology
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'contracts/workroom/devsecops-topology-snapshot-ref-v0.1.schema.json'
+      - 'contracts/workroom/devsecops-blast-radius-estimate-v0.1.schema.json'
+      - 'tests/fixtures/workroom/devsecops-topology-snapshot-ref.*.json'
+      - 'tests/fixtures/workroom/devsecops-blast-radius-estimate.*.json'
+      - 'tools/validate_devsecops_gaia_topology.py'
+      - '.github/workflows/devsecops-gaia-topology.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'contracts/workroom/devsecops-topology-snapshot-ref-v0.1.schema.json'
+      - 'contracts/workroom/devsecops-blast-radius-estimate-v0.1.schema.json'
+      - 'tests/fixtures/workroom/devsecops-topology-snapshot-ref.*.json'
+      - 'tests/fixtures/workroom/devsecops-blast-radius-estimate.*.json'
+      - 'tools/validate_devsecops_gaia_topology.py'
+      - '.github/workflows/devsecops-gaia-topology.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: python -m pip install jsonschema==4.23.0
+      - name: Validate GAIA topology snapshot and blast-radius estimate contracts
+        run: python tools/validate_devsecops_gaia_topology.py

--- a/contracts/workroom/devsecops-blast-radius-estimate-v0.1.schema.json
+++ b/contracts/workroom/devsecops-blast-radius-estimate-v0.1.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "devsecops-blast-radius-estimate-v0.1",
+  "title": "DevSecOps Blast Radius Estimate",
+  "description": "Typed blast-radius estimate derived from a GAIA topology snapshot. Supplies affected service scope, customer impact class, and evidence linkage for Workroom incident investigation. GAIA is the blast-radius authority — Prophet Platform validates estimate references only.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "blast_radius_ref",
+    "topology_ref",
+    "incident_ref",
+    "affected_services",
+    "customer_impact_class",
+    "confidence",
+    "non_claims"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1.0"
+    },
+    "blast_radius_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "topology_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The topology snapshot this blast-radius estimate is derived from."
+    },
+    "incident_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "affected_services": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Service refs confirmed or strongly supported as affected by the incident."
+    },
+    "potentially_affected_services": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Service refs that may be affected based on topology traversal but not confirmed."
+    },
+    "customer_impact_class": {
+      "type": "string",
+      "enum": ["none", "low", "medium", "high", "unknown"],
+      "description": "Estimated customer impact class. 'high' requires evidence_refs."
+    },
+    "confidence": {
+      "type": "string",
+      "enum": ["none", "low", "medium", "high"],
+      "description": "'none' means no causal estimate can be made from available topology."
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Evidence packets supporting this blast-radius estimate."
+    },
+    "non_claims": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    }
+  }
+}

--- a/contracts/workroom/devsecops-topology-snapshot-ref-v0.1.schema.json
+++ b/contracts/workroom/devsecops-topology-snapshot-ref-v0.1.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "devsecops-topology-snapshot-ref-v0.1",
+  "title": "DevSecOps Topology Snapshot Reference",
+  "description": "Typed reference to a GAIA topology snapshot. Supplies versioned, evidence-bound topology context for Workroom incident investigation and blast-radius estimation. GAIA is the topology authority — Prophet Platform validates snapshot references only.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "topology_ref",
+    "gaia_graph_ref",
+    "snapshot_digest",
+    "observed_at",
+    "scope",
+    "non_claims"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1.0"
+    },
+    "topology_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "gaia_graph_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Reference to the GAIA graph from which this snapshot was produced."
+    },
+    "snapshot_digest": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Content-addressable digest of the snapshot payload."
+    },
+    "observed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "scope": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable description of the topology scope (workspace, environment, service boundary)."
+    },
+    "node_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "edge_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "service_refs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Service node refs included in this snapshot."
+    },
+    "dependency_refs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Dependency node refs (databases, queues, external services) included in this snapshot."
+    },
+    "non_claims": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    }
+  }
+}

--- a/tests/fixtures/workroom/devsecops-blast-radius-estimate.high-impact-no-evidence.invalid.json
+++ b/tests/fixtures/workroom/devsecops-blast-radius-estimate.high-impact-no-evidence.invalid.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "0.1.0",
+  "blast_radius_ref": "blast-radius://gaia/workroom/invalid/high-impact-no-evidence",
+  "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+  "incident_ref": "incident://pagerduty/invalid/high-impact-no-evidence",
+  "affected_services": [
+    "service://scope-d/api"
+  ],
+  "potentially_affected_services": [],
+  "customer_impact_class": "high",
+  "confidence": "high",
+  "evidence_refs": [],
+  "non_claims": [
+    "Expected-invalid fixture only.",
+    "Tests: customer_impact_class=high requires at least one evidence_ref."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-blast-radius-estimate.topology-supported.valid.json
+++ b/tests/fixtures/workroom/devsecops-blast-radius-estimate.topology-supported.valid.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "0.1.0",
+  "blast_radius_ref": "blast-radius://gaia/workroom/scope-d-example/INC-1001",
+  "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+  "incident_ref": "incident://pagerduty/scope-d-example/INC-1001",
+  "affected_services": [
+    "service://scope-d/api"
+  ],
+  "potentially_affected_services": [
+    "frontend://scope-d/checkout",
+    "frontend://scope-d/account"
+  ],
+  "customer_impact_class": "medium",
+  "confidence": "medium",
+  "evidence_refs": [
+    "evidence://gaia/topology/scope-d-example/blast-radius",
+    "evidence://observability/scope-d-example/5xx-spike"
+  ],
+  "non_claims": [
+    "Blast-radius estimate is topology-supported, not confirmed by customer impact observation.",
+    "GAIA is the blast-radius authority. Prophet Platform validates estimate references only.",
+    "Estimate does not authorize remediation."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-topology-snapshot-ref.post-merge.valid.json
+++ b/tests/fixtures/workroom/devsecops-topology-snapshot-ref.post-merge.valid.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "0.1.0",
+  "topology_ref": "topology://gaia/workroom/scope-d-example/post-merge",
+  "gaia_graph_ref": "gaia://graph/scope-d-example/post-merge/2026-05-31T16:57:20Z",
+  "snapshot_digest": "sha256:topology0001111122223333444455556666777788889999aaaabbbbccccddddeee",
+  "observed_at": "2026-05-31T16:57:20Z",
+  "scope": "Production workroom topology for scope-d-example, post-merge incident window.",
+  "node_count": 3,
+  "edge_count": 2,
+  "service_refs": [
+    "service://scope-d/api"
+  ],
+  "dependency_refs": [],
+  "non_claims": [
+    "Topology snapshot is fixture-only. GAIA is the topology authority.",
+    "Snapshot does not prove root cause or authorize remediation.",
+    "Prophet Platform validates snapshot references only."
+  ]
+}

--- a/tools/validate_devsecops_gaia_topology.py
+++ b/tools/validate_devsecops_gaia_topology.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Validator for DevSecOps GAIA topology snapshot ref and blast-radius estimate contracts.
+
+Topology snapshot rules:
+  1. snapshot_digest must be non-empty (enforced by schema).
+
+Blast-radius estimate rules:
+  1. customer_impact_class=high requires at least one evidence_ref.
+  2. confidence=none means no causal estimate — affected_services should be empty.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+TOPOLOGY_SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-topology-snapshot-ref-v0.1.schema.json"
+BLAST_SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-blast-radius-estimate-v0.1.schema.json"
+
+TOPOLOGY_VALID = [
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-topology-snapshot-ref.post-merge.valid.json",
+]
+TOPOLOGY_INVALID: dict[Path, list[str]] = {}
+
+BLAST_VALID = [
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-blast-radius-estimate.topology-supported.valid.json",
+]
+BLAST_INVALID: dict[Path, list[str]] = {
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-blast-radius-estimate.high-impact-no-evidence.invalid.json": [
+        "customer_impact_class=high requires at least one evidence_ref",
+    ],
+}
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected object: {path}")
+    return data
+
+
+def schema_problems(schema: dict[str, Any], data: dict[str, Any]) -> list[str]:
+    v = jsonschema.Draft7Validator(schema)
+    return [e.message for e in sorted(v.iter_errors(data), key=lambda e: list(e.path))]
+
+
+def blast_semantic_problems(data: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    rid = data.get("blast_radius_ref", "<unknown>")
+    customer_impact = data.get("customer_impact_class", "")
+    confidence = data.get("confidence", "")
+    evidence_refs = data.get("evidence_refs") or []
+
+    if customer_impact == "high" and not evidence_refs:
+        problems.append(
+            f"{rid}: customer_impact_class=high requires at least one evidence_ref"
+        )
+
+    if confidence == "none" and data.get("affected_services"):
+        problems.append(
+            f"{rid}: confidence=none means no causal estimate; affected_services should be empty"
+        )
+
+    return problems
+
+
+def expect(path: Path, problems: list[str], expected_substrings: list[str]) -> list[str]:
+    failures: list[str] = []
+    if not problems:
+        failures.append(f"{path}: expected invalid fixture to fail, but it passed")
+    for expected in expected_substrings:
+        if not any(expected in p for p in problems):
+            failures.append(f"{path}: expected problem containing {expected!r}")
+    return failures
+
+
+def main() -> int:
+    topo_schema = load(TOPOLOGY_SCHEMA)
+    blast_schema = load(BLAST_SCHEMA)
+    failed = False
+    results: dict[str, dict[str, Any]] = {}
+
+    for path in TOPOLOGY_VALID:
+        data = load(path)
+        s_errs = schema_problems(topo_schema, data)
+        failed = failed or bool(s_errs)
+        results[str(path.relative_to(ROOT))] = {"expected": "valid", "schema": s_errs}
+
+    for path, expected in TOPOLOGY_INVALID.items():
+        data = load(path)
+        s_errs = schema_problems(topo_schema, data)
+        failures = expect(path.relative_to(ROOT), s_errs, expected)
+        failed = failed or bool(failures)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid", "expected_problem_substrings": expected,
+            "expectation_failures": failures, "schema": s_errs,
+        }
+
+    for path in BLAST_VALID:
+        data = load(path)
+        s_errs = schema_problems(blast_schema, data)
+        sem_errs = blast_semantic_problems(data)
+        failed = failed or bool(s_errs or sem_errs)
+        results[str(path.relative_to(ROOT))] = {"expected": "valid", "schema": s_errs, "semantic": sem_errs}
+
+    for path, expected in BLAST_INVALID.items():
+        data = load(path)
+        s_errs = schema_problems(blast_schema, data)
+        sem_errs = blast_semantic_problems(data)
+        problems = s_errs + sem_errs
+        failures = expect(path.relative_to(ROOT), problems, expected)
+        failed = failed or bool(failures)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid", "expected_problem_substrings": expected,
+            "expectation_failures": failures, "schema": s_errs, "semantic": sem_errs,
+        }
+
+    report = {
+        "validator": "prophet-platform.devsecops-gaia-topology.validator.v1",
+        "passed": not failed,
+        "results": results,
+        "non_claims": [
+            "GAIA is the topology and blast-radius authority.",
+            "Validator checks snapshot ref and blast-radius estimate contract structure only.",
+            "Validator does not execute topology probes or query live GAIA graphs.",
+            "Validator does not prove incident root cause or authorize remediation.",
+        ],
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(("PASS" if not failed else "FAIL") + ": devsecops gaia topology")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Tranche E: typed, versioned, evidence-bound topology context.

- `devsecops-topology-snapshot-ref-v0.1.schema.json` — typed snapshot reference (gaia_graph_ref, snapshot_digest, node/edge counts, service_refs, dependency_refs)
- `devsecops-blast-radius-estimate-v0.1.schema.json` — blast-radius estimate (topology_ref linkage, customer_impact_class, confidence, evidence_refs)
- Valid fixtures: post-merge topology snapshot, topology-supported blast-radius estimate
- Invalid fixture: `customer_impact_class=high` without `evidence_refs`
- `tools/validate_devsecops_gaia_topology.py`
- `.github/workflows/devsecops-gaia-topology.yml`

## Boundary

GAIA is topology and blast-radius authority. Prophet Platform validates snapshot and estimate references only.

## Test plan

- [ ] `devsecops-gaia-topology` workflow green
- [ ] `premerge-audit` green

Refs #519
Refs #520