### PR TITLE
feat(workroom): add PostmortemLesson and Alexandrian Academy canonization handoff contracts

### DIFF
--- a/.github/workflows/devsecops-postmortem-lesson.yml
+++ b/.github/workflows/devsecops-postmortem-lesson.yml
@@ -1,0 +1,35 @@
+name: devsecops-postmortem-lesson
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'contracts/workroom/devsecops-postmortem-lesson-v0.1.schema.json'
+      - 'contracts/workroom/devsecops-academy-canonization-handoff-v0.1.schema.json'
+      - 'tests/fixtures/workroom/devsecops-postmortem-lesson.*.json'
+      - 'tests/fixtures/workroom/devsecops-academy-canonization-handoff.*.json'
+      - 'tools/validate_devsecops_postmortem_lesson.py'
+      - '.github/workflows/devsecops-postmortem-lesson.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'contracts/workroom/devsecops-postmortem-lesson-v0.1.schema.json'
+      - 'contracts/workroom/devsecops-academy-canonization-handoff-v0.1.schema.json'
+      - 'tests/fixtures/workroom/devsecops-postmortem-lesson.*.json'
+      - 'tests/fixtures/workroom/devsecops-academy-canonization-handoff.*.json'
+      - 'tools/validate_devsecops_postmortem_lesson.py'
+      - '.github/workflows/devsecops-postmortem-lesson.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: python -m pip install jsonschema==4.23.0
+      - name: Validate PostmortemLesson and Academy canonization handoff contracts
+        run: python tools/validate_devsecops_postmortem_lesson.py

--- a/contracts/workroom/devsecops-academy-canonization-handoff-v0.1.schema.json
+++ b/contracts/workroom/devsecops-academy-canonization-handoff-v0.1.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "devsecops-academy-canonization-handoff-v0.1",
+  "title": "DevSecOps Alexandrian Academy Canonization Handoff",
+  "description": "Models the handoff of a PostmortemLesson candidate bundle from Prophet Platform to the Alexandrian Academy for canonization. Prophet Platform emits candidate bundles. The Alexandrian Academy decides canonize / reject / request more evidence.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "handoff_id",
+    "lesson_ref",
+    "incident_ref",
+    "rca_claim_refs",
+    "evidence_refs",
+    "status",
+    "non_claims"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1.0"
+    },
+    "handoff_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lesson_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "incident_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "rca_claim_refs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    },
+    "regression_fixture_refs": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "validation_plan_refs": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "evidence_packet_summary_refs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Summary digest refs for full evidence packet content submitted to the Academy."
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "candidate_submitted",
+        "academy_reviewing",
+        "canonized",
+        "rejected",
+        "more_evidence_requested",
+        "withdrawn"
+      ]
+    },
+    "academy_decision_ref": {
+      "type": "string",
+      "description": "Reference to the Academy's canonization or rejection record. Present when status=canonized or rejected."
+    },
+    "non_claims": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    }
+  }
+}

--- a/contracts/workroom/devsecops-postmortem-lesson-v0.1.schema.json
+++ b/contracts/workroom/devsecops-postmortem-lesson-v0.1.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "devsecops-postmortem-lesson-v0.1",
+  "title": "DevSecOps Postmortem Lesson",
+  "description": "A postmortem lesson derived from a production incident. Captures the learning outcome — supported by RCA claims and evidence — and tracks its promotion toward canonization by the Alexandrian Academy. Prophet Platform emits lesson candidates; Alexandrian Academy decides canonization.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "lesson_id",
+    "incident_ref",
+    "rca_claim_refs",
+    "evidence_refs",
+    "lesson_status",
+    "non_claims"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.1.0"
+    },
+    "lesson_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "incident_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "rca_claim_refs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1,
+      "description": "RCA claims this lesson is grounded in."
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1,
+      "description": "Evidence packets supporting the lesson."
+    },
+    "remediation_plan_refs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Remediation plans associated with this incident."
+    },
+    "regression_fixture_refs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Regression fixtures promoted from this lesson."
+    },
+    "lesson_status": {
+      "type": "string",
+      "enum": ["draft", "reviewed", "accepted", "canonical", "rejected", "superseded"]
+    },
+    "canonization_target_ref": {
+      "type": "string",
+      "description": "Reference to the Academy canonization record. Present only when lesson_status=canonical."
+    },
+    "academy_ref": {
+      "type": "string",
+      "description": "Reference to the Alexandrian Academy instance or collection this lesson is submitted to."
+    },
+    "successor_lesson_ref": {
+      "type": "string",
+      "description": "Required when lesson_status=superseded."
+    },
+    "non_claims": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    }
+  }
+}

--- a/tests/fixtures/workroom/devsecops-academy-canonization-handoff.submitted.valid.json
+++ b/tests/fixtures/workroom/devsecops-academy-canonization-handoff.submitted.valid.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "0.1.0",
+  "handoff_id": "academy-handoff:devsecops:scope-d-example:api-latency-lesson",
+  "lesson_ref": "postmortem-lesson:devsecops:scope-d-example:api-latency-deploy-correlation",
+  "incident_ref": "incident://pagerduty/scope-d-example/INC-1001",
+  "rca_claim_refs": [
+    "rca-claim:scope-d-example:recent-deploy-supported"
+  ],
+  "evidence_refs": [
+    "evidence://observability/scope-d-example/5xx-spike",
+    "evidence://deployment/scope-d-example/recent-deploy"
+  ],
+  "regression_fixture_refs": [
+    "regression-fixture:scope-d-example:post-deploy-5xx-guard"
+  ],
+  "validation_plan_refs": [
+    "validation-plan://scope-d-example/post-deploy-5xx-guard"
+  ],
+  "evidence_packet_summary_refs": [
+    "evidence-summary://devsecops/scope-d-example/INC-1001/packet-digest"
+  ],
+  "status": "candidate_submitted",
+  "non_claims": [
+    "Handoff is fixture-only. No live Alexandrian Academy integration.",
+    "Prophet Platform emits candidate bundles; Alexandrian Academy decides canonize/reject/request.",
+    "candidate_submitted does not guarantee canonization."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-postmortem-lesson.accepted.valid.json
+++ b/tests/fixtures/workroom/devsecops-postmortem-lesson.accepted.valid.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "0.1.0",
+  "lesson_id": "postmortem-lesson:devsecops:scope-d-example:api-latency-deploy-correlation",
+  "incident_ref": "incident://pagerduty/scope-d-example/INC-1001",
+  "rca_claim_refs": [
+    "rca-claim:scope-d-example:recent-deploy-supported"
+  ],
+  "evidence_refs": [
+    "evidence://observability/scope-d-example/5xx-spike",
+    "evidence://deployment/scope-d-example/recent-deploy"
+  ],
+  "remediation_plan_refs": [
+    "remediation-plan:scope-d-example:rollback-candidate"
+  ],
+  "regression_fixture_refs": [
+    "regression-fixture:scope-d-example:post-deploy-5xx-guard"
+  ],
+  "lesson_status": "accepted",
+  "academy_ref": "alexandrian-academy://devsecops/scope-d-example",
+  "non_claims": [
+    "Lesson is fixture-only. No live incident or Academy integration.",
+    "accepted status does not mean canonized. Alexandrian Academy decides canonization.",
+    "Prophet Platform emits lesson candidates; does not canonize lessons."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-postmortem-lesson.canonical-no-regression-fixture.invalid.json
+++ b/tests/fixtures/workroom/devsecops-postmortem-lesson.canonical-no-regression-fixture.invalid.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "0.1.0",
+  "lesson_id": "postmortem-lesson:devsecops:invalid:canonical-no-regression-fixture",
+  "incident_ref": "incident://pagerduty/invalid/canonical-no-regression-fixture",
+  "rca_claim_refs": [
+    "rca-claim:invalid:canonical-no-regression"
+  ],
+  "evidence_refs": [
+    "evidence://fixture/invalid/canonical-no-regression"
+  ],
+  "regression_fixture_refs": [],
+  "lesson_status": "canonical",
+  "canonization_target_ref": "alexandrian-academy://devsecops/invalid/canonical-no-regression",
+  "non_claims": [
+    "Expected-invalid fixture only.",
+    "Tests: canonical lesson requires at least one regression fixture."
+  ]
+}

--- a/tests/fixtures/workroom/devsecops-postmortem-lesson.superseded-no-successor.invalid.json
+++ b/tests/fixtures/workroom/devsecops-postmortem-lesson.superseded-no-successor.invalid.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "0.1.0",
+  "lesson_id": "postmortem-lesson:devsecops:invalid:superseded-no-successor",
+  "incident_ref": "incident://pagerduty/invalid/superseded-no-successor",
+  "rca_claim_refs": [
+    "rca-claim:invalid:superseded-no-successor"
+  ],
+  "evidence_refs": [
+    "evidence://fixture/invalid/superseded-no-successor"
+  ],
+  "lesson_status": "superseded",
+  "non_claims": [
+    "Expected-invalid fixture only.",
+    "Tests: superseded lesson requires successor_lesson_ref."
+  ]
+}

--- a/tools/validate_devsecops_postmortem_lesson.py
+++ b/tools/validate_devsecops_postmortem_lesson.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Validator for DevSecOps PostmortemLesson and Academy canonization handoff contracts.
+
+PostmortemLesson rules:
+  1. canonical lesson requires at least one regression_fixture_ref.
+  2. canonical lesson requires canonization_target_ref.
+  3. rejected lesson must not have regression_fixture_refs.
+  4. superseded lesson requires successor_lesson_ref.
+
+Academy handoff rules:
+  1. canonized status requires academy_decision_ref.
+  2. rejected status requires academy_decision_ref.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+LESSON_SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-postmortem-lesson-v0.1.schema.json"
+HANDOFF_SCHEMA = ROOT / "contracts" / "workroom" / "devsecops-academy-canonization-handoff-v0.1.schema.json"
+
+LESSON_VALID = [
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-postmortem-lesson.accepted.valid.json",
+]
+LESSON_INVALID: dict[Path, list[str]] = {
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-postmortem-lesson.canonical-no-regression-fixture.invalid.json": [
+        "canonical lesson requires at least one regression_fixture_ref",
+    ],
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-postmortem-lesson.superseded-no-successor.invalid.json": [
+        "superseded lesson requires successor_lesson_ref",
+    ],
+}
+
+HANDOFF_VALID = [
+    ROOT / "tests" / "fixtures" / "workroom" / "devsecops-academy-canonization-handoff.submitted.valid.json",
+]
+HANDOFF_INVALID: dict[Path, list[str]] = {}
+
+
+def load(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"expected object: {path}")
+    return data
+
+
+def schema_problems(schema: dict[str, Any], data: dict[str, Any]) -> list[str]:
+    v = jsonschema.Draft7Validator(schema)
+    return [e.message for e in sorted(v.iter_errors(data), key=lambda e: list(e.path))]
+
+
+def lesson_semantic_problems(data: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    lid = data.get("lesson_id", "<unknown>")
+    status = data.get("lesson_status", "")
+    regression_fixture_refs = data.get("regression_fixture_refs") or []
+
+    if status == "canonical":
+        if not regression_fixture_refs:
+            problems.append(f"{lid}: canonical lesson requires at least one regression_fixture_ref")
+        if not data.get("canonization_target_ref"):
+            problems.append(f"{lid}: canonical lesson requires canonization_target_ref")
+
+    if status == "rejected" and regression_fixture_refs:
+        problems.append(f"{lid}: rejected lesson must not have regression_fixture_refs")
+
+    if status == "superseded" and not data.get("successor_lesson_ref"):
+        problems.append(f"{lid}: superseded lesson requires successor_lesson_ref")
+
+    return problems
+
+
+def handoff_semantic_problems(data: dict[str, Any]) -> list[str]:
+    problems: list[str] = []
+    hid = data.get("handoff_id", "<unknown>")
+    status = data.get("status", "")
+
+    if status in ("canonized", "rejected") and not data.get("academy_decision_ref"):
+        problems.append(f"{hid}: {status} handoff requires academy_decision_ref")
+
+    return problems
+
+
+def expect(path: Path, problems: list[str], expected_substrings: list[str]) -> list[str]:
+    failures: list[str] = []
+    if not problems:
+        failures.append(f"{path}: expected invalid fixture to fail, but it passed")
+    for expected in expected_substrings:
+        if not any(expected in p for p in problems):
+            failures.append(f"{path}: expected problem containing {expected!r}")
+    return failures
+
+
+def main() -> int:
+    lesson_schema = load(LESSON_SCHEMA)
+    handoff_schema = load(HANDOFF_SCHEMA)
+    failed = False
+    results: dict[str, dict[str, Any]] = {}
+
+    for path in LESSON_VALID:
+        data = load(path)
+        s_errs = schema_problems(lesson_schema, data)
+        sem_errs = lesson_semantic_problems(data)
+        failed = failed or bool(s_errs or sem_errs)
+        results[str(path.relative_to(ROOT))] = {"expected": "valid", "schema": s_errs, "semantic": sem_errs}
+
+    for path, expected in LESSON_INVALID.items():
+        data = load(path)
+        s_errs = schema_problems(lesson_schema, data)
+        sem_errs = lesson_semantic_problems(data)
+        problems = s_errs + sem_errs
+        failures = expect(path.relative_to(ROOT), problems, expected)
+        failed = failed or bool(failures)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid", "expected_problem_substrings": expected,
+            "expectation_failures": failures, "schema": s_errs, "semantic": sem_errs,
+        }
+
+    for path in HANDOFF_VALID:
+        data = load(path)
+        s_errs = schema_problems(handoff_schema, data)
+        sem_errs = handoff_semantic_problems(data)
+        failed = failed or bool(s_errs or sem_errs)
+        results[str(path.relative_to(ROOT))] = {"expected": "valid", "schema": s_errs, "semantic": sem_errs}
+
+    for path, expected in HANDOFF_INVALID.items():
+        data = load(path)
+        s_errs = schema_problems(handoff_schema, data)
+        sem_errs = handoff_semantic_problems(data)
+        problems = s_errs + sem_errs
+        failures = expect(path.relative_to(ROOT), problems, expected)
+        failed = failed or bool(failures)
+        results[str(path.relative_to(ROOT))] = {
+            "expected": "invalid", "expected_problem_substrings": expected,
+            "expectation_failures": failures, "schema": s_errs, "semantic": sem_errs,
+        }
+
+    report = {
+        "validator": "prophet-platform.devsecops-postmortem-lesson.validator.v1",
+        "passed": not failed,
+        "results": results,
+        "non_claims": [
+            "Prophet Platform emits lesson candidates; Alexandrian Academy decides canonization.",
+            "Validator checks lesson contract structure and promotion invariants only.",
+            "Validator does not canonize lessons, approve remediation, or authorize production changes.",
+        ],
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(("PASS" if not failed else "FAIL") + ": devsecops postmortem lesson")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Tranche F: institutional learning loop.

- `devsecops-postmortem-lesson-v0.1.schema.json` — lesson lifecycle (draft → reviewed → accepted → canonical / rejected / superseded)
- `devsecops-academy-canonization-handoff-v0.1.schema.json` — handoff of lesson candidate bundle to Alexandrian Academy
- Valid fixtures: accepted lesson, submitted Academy handoff
- Invalid fixtures: canonical lesson without regression fixture; superseded lesson without successor
- `tools/validate_devsecops_postmortem_lesson.py`
- `.github/workflows/devsecops-postmortem-lesson.yml`

## Boundary

Prophet Platform emits lesson candidates. Alexandrian Academy decides canonize / reject / request more evidence.

## Test plan

- [ ] `devsecops-postmortem-lesson` workflow green
- [ ] `premerge-audit` green

Refs #519
Refs #520