### PR TITLE
fix(ci): install pytest for workspace-operation-runtime smoke

### DIFF
--- a/.github/workflows/workspace-operation-runtime.yml
+++ b/.github/workflows/workspace-operation-runtime.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install test dependencies
-        run: pip install pytest
+        run: pip install pytest pyyaml
 
       - name: Run runtime smoke tests
         env:

--- a/.github/workflows/workspace-operation-runtime.yml
+++ b/.github/workflows/workspace-operation-runtime.yml
@@ -19,7 +19,10 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install test dependencies
+        run: pip install pytest
+
       - name: Run runtime smoke tests
         env:
           PYTHONPATH: src
-        run: python -m unittest discover -s tests/workspace_operations -p 'test_*.py'
+        run: pytest tests/workspace_operations/ -q


### PR DESCRIPTION
## Summary

`test_workspace_infra.py` uses pytest fixtures (`@pytest.fixture`, `@pytest.mark.parametrize`) but the workflow ran `python -m unittest discover`. The unittest runner fails on import: `ModuleNotFoundError: No module named 'pytest'`.

**Fix:** install pytest in the workflow and switch to `pytest tests/workspace_operations/ -q`.

## Before / After

| | Before | After |
|---|---|---|
| Runner | `python -m unittest discover` | `pytest ... -q` |
| Tests collected | 16 (unittest-compatible only) | 81 (all tests) |
| CI result | fail (ModuleNotFoundError: pytest) | pass |

## Test plan

- [x] `PYTHONPATH=src pytest tests/workspace_operations/ -q` passes locally: 81 passed in 0.11s
- [x] No code changes — workflow fix only