### PR TITLE
Helm chart + Argo CD deployments for platform, workspace, and fogstack

### DIFF
--- a/charts/socioprophet-service/.helmignore
+++ b/charts/socioprophet-service/.helmignore
@@ -1,0 +1,2 @@
+.DS_Store
+*.tmp

--- a/charts/socioprophet-service/Chart.yaml
+++ b/charts/socioprophet-service/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: socioprophet-service
+description: >-
+  Reusable chart for a SocioProphet / SourceOS estate service: a hardened
+  Deployment + Service (+ optional ConfigMap, HPA, Ingress, ServiceAccount).
+  One chart, many values — every estate service deploys through this.
+type: application
+version: 0.1.0
+# Tracks the estate's release line; per-service image tags come from values.
+appVersion: "26.11"
+maintainers:
+  - name: SocioProphet
+    url: https://github.com/SocioProphet/prophet-platform
+keywords:
+  - socioprophet
+  - sourceos
+  - fogstack

--- a/charts/socioprophet-service/templates/NOTES.txt
+++ b/charts/socioprophet-service/templates/NOTES.txt
@@ -1,0 +1,10 @@
+{{ include "svc.fullname" . }} deployed.
+
+  image:   {{ include "svc.image" . }}
+  service: {{ include "svc.fullname" . }}:{{ .Values.service.port }} ({{ .Values.service.type }})
+{{- if .Values.ingress.enabled }}
+  ingress: {{- range .Values.ingress.hosts }} {{ .host }}{{- end }}
+{{- end }}
+
+Port-forward to test locally:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "svc.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}

--- a/charts/socioprophet-service/templates/_helpers.tpl
+++ b/charts/socioprophet-service/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{- define "svc.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "svc.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "svc.labels" -}}
+app.kubernetes.io/name: {{ include "svc.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: socioprophet
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{- define "svc.selectorLabels" -}}
+app: {{ include "svc.fullname" . }}
+app.kubernetes.io/name: {{ include "svc.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "svc.image" -}}
+{{- $reg := .Values.image.registry | trimSuffix "/" -}}
+{{- $repo := required "image.repository is required" .Values.image.repository -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s/%s:%s" $reg $repo $tag -}}
+{{- end -}}
+
+{{- define "svc.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "svc.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/socioprophet-service/templates/configmap.yaml
+++ b/charts/socioprophet-service/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "svc.fullname" . }}-config
+  labels: {{- include "svc.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := .Values.config }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/socioprophet-service/templates/deployment.yaml
+++ b/charts/socioprophet-service/templates/deployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "svc.fullname" . }}
+  labels: {{- include "svc.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "svc.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "svc.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}{{- toYaml . | nindent 8 }}{{- end }}
+      annotations:
+        {{- if .Values.config }}
+        checksum/config: {{ .Values.config | toYaml | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}{{- toYaml . | nindent 8 }}{{- end }}
+    spec:
+      serviceAccountName: {{ include "svc.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "svc.name" . }}
+          image: {{ include "svc.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: {{ .Values.service.portName }}
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            {{- range .Values.service.extraPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+              protocol: {{ .protocol | default "TCP" }}
+            {{- end }}
+          {{- if or .Values.config .Values.secretEnv .Values.extraEnv }}
+          env:
+            {{- range $k, $v := .Values.config }}
+            - name: {{ $k }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "svc.fullname" $ }}-config
+                  key: {{ $k }}
+            {{- end }}
+            {{- range $k, $s := .Values.secretEnv }}
+            - name: {{ $k }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $s.secretName }}
+                  key: {{ $s.key }}
+                  {{- if hasKey $s "optional" }}
+                  optional: {{ $s.optional }}
+                  {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnv }}{{- toYaml . | nindent 12 }}{{- end }}
+          {{- end }}
+          {{- if .Values.probes.enabled }}
+          {{- if .Values.probes.httpGet }}
+          readinessProbe:
+            httpGet: { path: {{ .Values.probes.path }}, port: {{ .Values.service.portName }} }
+            initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.periodSeconds }}
+          livenessProbe:
+            httpGet: { path: {{ .Values.probes.path }}, port: {{ .Values.service.portName }} }
+            initialDelaySeconds: {{ add .Values.probes.initialDelaySeconds 10 }}
+            periodSeconds: {{ .Values.probes.periodSeconds }}
+          {{- else }}
+          readinessProbe:
+            tcpSocket: { port: {{ .Values.service.portName }} }
+            initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.periodSeconds }}
+          {{- end }}
+          {{- end }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.tmpDir.enabled }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          {{- end }}
+      {{- if .Values.tmpDir.enabled }}
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.tmpDir.sizeLimit }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/socioprophet-service/templates/hpa.yaml
+++ b/charts/socioprophet-service/templates/hpa.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "svc.fullname" . }}
+  labels: {{- include "svc.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "svc.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/socioprophet-service/templates/ingress.yaml
+++ b/charts/socioprophet-service/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "svc.fullname" . }}
+  labels: {{- include "svc.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "svc.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/socioprophet-service/templates/service.yaml
+++ b/charts/socioprophet-service/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "svc.fullname" . }}
+  labels: {{- include "svc.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector: {{- include "svc.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: {{ .Values.service.portName }}
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.portName }}
+      protocol: TCP
+    {{- range .Values.service.extraPorts }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .name }}
+      protocol: {{ .protocol | default "TCP" }}
+    {{- end }}

--- a/charts/socioprophet-service/templates/serviceaccount.yaml
+++ b/charts/socioprophet-service/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "svc.serviceAccountName" . }}
+  labels: {{- include "svc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/socioprophet-service/values.yaml
+++ b/charts/socioprophet-service/values.yaml
@@ -1,0 +1,94 @@
+# Defaults for the reusable socioprophet-service chart.
+# Per-service files in deploy/values/<svc>.yaml override only what differs.
+
+# Logical service name (becomes the workload + Service name and app label).
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  # GAR — the estate registry the build-image reusable workflow pushes to.
+  registry: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet
+  repository: ""          # required per service, e.g. socioprophet-api
+  # Immutable tag = the commit SHA the GitOps promotion writes. "" → chart appVersion.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# Image pull secret(s), if the namespace needs them (GAR via WIF usually doesn't).
+imagePullSecrets: []
+
+replicaCount: 1
+
+# Container port the app listens on (also the Service targetPort).
+service:
+  type: ClusterIP
+  port: 8080
+  # Service port name; keep stable for NetworkPolicy / mesh.
+  portName: http
+  # Optional extra ports: [{ name: tritrpc, port: 9000 }]
+  extraPorts: []
+
+# Plain env (non-secret). Rendered into a ConfigMap and injected.
+config: {}
+#   TRITRPC_LISTEN_ADDR: "tcp://0.0.0.0:9000"
+
+# Secret env: name → existing Secret + key. The Secret is NOT created here
+# (never commit secrets); reference one provisioned out of band / by SOPS.
+secretEnv: {}
+#   TRITRPC_KEY_HEX: { secretName: tritrpc-shared-key, key: TRITRPC_KEY_HEX, optional: true }
+
+# Extra raw env entries passed straight through.
+extraEnv: []
+
+resources:
+  requests: { cpu: 50m, memory: 128Mi }
+  limits:   { cpu: "1",  memory: 512Mi }
+
+# Hardened by default — matches the estate's existing kustomize bases.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  fsGroup: 10001
+  seccompProfile: { type: RuntimeDefault }
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 10001
+  capabilities: { drop: ["ALL"] }
+
+# Writable scratch for readOnlyRootFilesystem services (mounted at /tmp).
+tmpDir:
+  enabled: true
+  sizeLimit: 256Mi
+
+probes:
+  enabled: true
+  path: /healthz
+  # Set false for services with no HTTP health endpoint (e.g. raw TCP daemons).
+  httpGet: true
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 75
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts: []          # [{ host: api.socioprophet.ai, paths: [{ path: /, pathType: Prefix }] }]
+  tls: []
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}    # e.g. iam.gke.io/gcp-service-account for Workload Identity
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podLabels: {}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,63 @@
+# Deployments — Helm chart + Argo CD
+
+How estate services become running workloads on the cluster. One reusable Helm
+chart, per-service values, deployed by Argo CD ApplicationSets.
+
+```
+charts/socioprophet-service/   reusable chart (Deployment+Service+ConfigMap+HPA+Ingress+SA)
+deploy/values/<svc>.yaml        per-service overrides (only what differs)
+deploy/argocd/                  ApplicationSets that sync the chart+values to the cluster
+  platform-services.yaml          core platform apps        → ns: socioprophet
+  workspace-services.yaml         prophet-workspace surfaces → ns: workspace
+  fogstack/fogstack-appset.yaml   fog runtime, standard+federal → ns: fogstack-<tier>
+```
+
+## Why one chart
+
+Across the estate, services share the same shape (a hardened container + a
+Service, sometimes config/secrets/HPA/ingress). Rather than a chart per service
+or hand-written manifests, every service deploys through
+`socioprophet-service` and supplies a small values file. Adding a service is one
+values file + one line in an ApplicationSet.
+
+The chart keeps the hardening already used in the `apps/*/kustomize` bases:
+`runAsNonRoot`, `runAsUser: 10001`, `readOnlyRootFilesystem`, dropped
+capabilities, seccomp `RuntimeDefault`, a writable `/tmp` emptyDir.
+
+## Image promotion (how an update ships)
+
+1. A service repo's CI calls the reusable `build-image` workflow → pushes
+   `…/socioprophet/<image>:<sha>` to Artifact Registry and cosign-signs it.
+2. The release bumps `image.tag` in `deploy/values/<svc>.yaml` (the commit SHA).
+3. Argo CD sees the change and syncs the new revision. The SHA tag is what gets
+   promoted — `latest` is never deployed.
+
+Registry: `us-central1-docker.pkg.dev/socioprophet-platform/socioprophet`.
+
+## Relationship to the existing Kustomize bases
+
+`apps/*/kustomize` and `infra/k8s` are the prior Kustomize manifests. This chart
+supersedes them for the services listed in `deploy/values`; migrate a service by
+adding its values file and removing its bespoke kustomize once Argo is cut over.
+Argo CD consumes the Helm source directly, so this stays within the existing
+GitOps model — no new tooling.
+
+## Add a service
+
+```sh
+cat > deploy/values/my-svc.yaml <<'EOF'
+image: { repository: my-svc }
+service: { port: 8080, portName: http }
+EOF
+# add `- { name: my-svc }` to the relevant ApplicationSet generator
+helm template my-svc charts/socioprophet-service -f deploy/values/my-svc.yaml | kubectl apply --dry-run=client -f -
+```
+
+## fogstack
+
+`fogstack/fogstack-appset.yaml` deploys the fog-tier services into both
+`fogstack-standard` and `fogstack-federal` namespaces (mirrors the existing
+`infra/argocd/cloudshell-fog-stack-{standard,federal}` split) and stamps each
+workload with `socioprophet.ai/compliance-tier`. **Confirm the fog-tier service
+membership** in that file — the current list is the plausible fog-edge runtime
+set, not a finalized bill of materials.

--- a/deploy/argocd/fogstack/fogstack-appset.yaml
+++ b/deploy/argocd/fogstack/fogstack-appset.yaml
@@ -1,0 +1,62 @@
+# Argo CD ApplicationSet — fogstack (the cloudshell-fog runtime stack).
+# Matrix of (service x compliance tier): each fog-tier service is deployed into
+# both fogstack-standard and fogstack-federal namespaces, tagged with its
+# compliance tier. Mirrors the existing infra/argocd/cloudshell-fog-stack-
+# {standard,federal}-application.yaml split, but chart-driven.
+#
+# NOTE: confirm the exact fog-tier service membership below — these are the
+# runtime services that plausibly run at the fog edge; adjust as the fogstack
+# bill-of-materials firms up.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: fogstack
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - matrix:
+        generators:
+          - list:
+              elements:
+                - { name: search-orchestrator }
+                - { name: eval-fabric-api }
+                - { name: hellgraph-service }
+                - { name: reasoning-failure-runner }
+          - list:
+              elements:
+                - { tier: standard }
+                - { tier: federal }
+  template:
+    metadata:
+      name: 'fog-{{.tier}}-{{.name}}'
+      labels:
+        app.kubernetes.io/part-of: fogstack
+        socioprophet.ai/compliance-tier: '{{.tier}}'
+    spec:
+      project: default
+      sources:
+        - repoURL: https://github.com/SocioProphet/prophet-platform
+          targetRevision: main
+          ref: values
+        - repoURL: https://github.com/SocioProphet/prophet-platform
+          targetRevision: main
+          path: charts/socioprophet-service
+          helm:
+            releaseName: '{{.name}}'
+            valueFiles:
+              - '$values/deploy/values/{{.name}}.yaml'
+            values: |
+              podLabels:
+                socioprophet.ai/compliance-tier: "{{.tier}}"
+              config:
+                COMPLIANCE_TIER: "{{.tier}}"
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: 'fogstack-{{.tier}}'
+      syncPolicy:
+        automated: { prune: true, selfHeal: true }
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -1,0 +1,51 @@
+# Argo CD ApplicationSet — core platform services.
+# Each entry renders the reusable socioprophet-service chart with its
+# deploy/values/<name>.yaml. The image tag (commit SHA) is promoted by the
+# build-image workflow / gitops-promote, overriding image.tag per release.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: platform-services
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          - { name: api }
+          - { name: gateway }
+          - { name: socioprophet-web }
+          - { name: evidence-console }
+          - { name: evidence-receipts }
+          - { name: eval-fabric-api }
+          - { name: hellgraph-service }
+          - { name: osm-map-api }
+          - { name: reasoning-failure-runner }
+          - { name: search-orchestrator }
+  template:
+    metadata:
+      name: 'svc-{{.name}}'
+      labels:
+        app.kubernetes.io/part-of: socioprophet
+    spec:
+      project: default
+      sources:
+        - repoURL: https://github.com/SocioProphet/prophet-platform
+          targetRevision: main
+          ref: values
+        - repoURL: https://github.com/SocioProphet/prophet-platform
+          targetRevision: main
+          path: charts/socioprophet-service
+          helm:
+            releaseName: '{{.name}}'
+            valueFiles:
+              - '$values/deploy/values/{{.name}}.yaml'
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: socioprophet
+      syncPolicy:
+        automated: { prune: true, selfHeal: true }
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/deploy/argocd/workspace-services.yaml
+++ b/deploy/argocd/workspace-services.yaml
@@ -1,0 +1,43 @@
+# Argo CD ApplicationSet — prophet-workspace services (mail / calendar / smtp).
+# prophet-workspace owns the product semantics + contracts; the deployment
+# topology lives here in prophet-platform (per the prophet-workspace README).
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: workspace-services
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          - { name: workspace-caldav }
+          - { name: workspace-mail }
+          - { name: workspace-smtp }
+  template:
+    metadata:
+      name: 'ws-{{.name}}'
+      labels:
+        app.kubernetes.io/part-of: prophet-workspace
+    spec:
+      project: default
+      sources:
+        - repoURL: https://github.com/SocioProphet/prophet-platform
+          targetRevision: main
+          ref: values
+        - repoURL: https://github.com/SocioProphet/prophet-platform
+          targetRevision: main
+          path: charts/socioprophet-service
+          helm:
+            releaseName: '{{.name}}'
+            valueFiles:
+              - '$values/deploy/values/{{.name}}.yaml'
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: workspace
+      syncPolicy:
+        automated: { prune: true, selfHeal: true }
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/deploy/values/api.yaml
+++ b/deploy/values/api.yaml
@@ -1,0 +1,9 @@
+# socioprophet-api — tritRPC core API
+image: { repository: socioprophet-api }
+service: { port: 9000, portName: tritrpc }
+probes: { enabled: true, httpGet: false }   # raw tritRPC, no HTTP health
+config:
+  TRITRPC_LISTEN_ADDR: "tcp://0.0.0.0:9000"
+  TRITRPC_ALLOW_INSECURE_DEV_KEY: "0"
+secretEnv:
+  TRITRPC_KEY_HEX: { secretName: tritrpc-shared-key, key: TRITRPC_KEY_HEX, optional: true }

--- a/deploy/values/eval-fabric-api.yaml
+++ b/deploy/values/eval-fabric-api.yaml
@@ -1,0 +1,3 @@
+# eval-fabric-api
+image: { repository: eval-fabric-api }
+service: { port: 8080, portName: http }

--- a/deploy/values/evidence-console.yaml
+++ b/deploy/values/evidence-console.yaml
@@ -1,0 +1,3 @@
+# evidence-console
+image: { repository: evidence-console }
+service: { port: 8080, portName: http }

--- a/deploy/values/evidence-receipts.yaml
+++ b/deploy/values/evidence-receipts.yaml
@@ -1,0 +1,3 @@
+# evidence-receipts
+image: { repository: evidence-receipts }
+service: { port: 8080, portName: http }

--- a/deploy/values/gateway.yaml
+++ b/deploy/values/gateway.yaml
@@ -1,0 +1,8 @@
+# socioprophet-gateway — HTTP edge gateway
+image: { repository: socioprophet-gateway }
+service: { port: 8080, portName: http }
+ingress:
+  enabled: true
+  className: gce
+  hosts: [{ host: api.socioprophet.ai, paths: [{ path: /, pathType: Prefix }] }]
+autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 6 }

--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -1,0 +1,3 @@
+# hellgraph-service
+image: { repository: hellgraph-service }
+service: { port: 8080, portName: http }

--- a/deploy/values/osm-map-api.yaml
+++ b/deploy/values/osm-map-api.yaml
@@ -1,0 +1,3 @@
+# osm-map-api
+image: { repository: osm-map-api }
+service: { port: 8080, portName: http }

--- a/deploy/values/reasoning-failure-runner.yaml
+++ b/deploy/values/reasoning-failure-runner.yaml
@@ -1,0 +1,3 @@
+# reasoning-failure-runner
+image: { repository: reasoning-failure-runner }
+service: { port: 8080, portName: http }

--- a/deploy/values/search-orchestrator.yaml
+++ b/deploy/values/search-orchestrator.yaml
@@ -1,0 +1,4 @@
+# search-orchestrator — search/index daemon
+image: { repository: search-orchestrator }
+service: { port: 8080, portName: http }
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 4 }

--- a/deploy/values/socioprophet-web.yaml
+++ b/deploy/values/socioprophet-web.yaml
@@ -1,0 +1,8 @@
+# socioprophet-web — web portal
+image: { repository: socioprophet-web }
+service: { port: 8080, portName: http }
+ingress:
+  enabled: true
+  className: gce
+  hosts: [{ host: app.socioprophet.ai, paths: [{ path: /, pathType: Prefix }] }]
+autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 6 }

--- a/deploy/values/workspace-caldav.yaml
+++ b/deploy/values/workspace-caldav.yaml
@@ -1,0 +1,4 @@
+# workspace-caldav — calendar/contacts (CalDAV/CardDAV)
+image: { repository: workspace-caldav }
+service: { port: 8080, portName: http }
+config: { WORKSPACE_SURFACE: caldav }

--- a/deploy/values/workspace-mail.yaml
+++ b/deploy/values/workspace-mail.yaml
@@ -1,0 +1,5 @@
+# workspace-mail — IMAP mail store
+image: { repository: workspace-mail }
+service: { port: 143, portName: imap }
+probes: { enabled: true, httpGet: false }
+config: { WORKSPACE_SURFACE: mail }

--- a/deploy/values/workspace-smtp.yaml
+++ b/deploy/values/workspace-smtp.yaml
@@ -1,0 +1,5 @@
+# workspace-smtp — SMTP submission
+image: { repository: workspace-smtp }
+service: { port: 587, portName: submission, extraPorts: [{ name: smtp, port: 25 }] }
+probes: { enabled: true, httpGet: false }
+config: { WORKSPACE_SURFACE: smtp }


### PR DESCRIPTION
Adds the deployment layer the estate was missing: **one reusable Helm chart + per-service values + Argo CD ApplicationSets** for the core platform, prophet-workspace, and fogstack. Stays inside the existing Kustomize+Argo GitOps model — Argo consumes the Helm source directly, no new tooling.

## Chart — `charts/socioprophet-service`
One chart for every estate service (vs. a chart each or hand-written manifests): Deployment + Service + optional ConfigMap / HPA / Ingress / ServiceAccount. Hardened to match the existing `apps/*/kustomize` bases — `runAsNonRoot`, `runAsUser: 10001`, `readOnlyRootFilesystem`, dropped caps, seccomp `RuntimeDefault`, writable `/tmp` emptyDir. Images resolve to **Artifact Registry** (`us-central1-docker.pkg.dev/socioprophet-platform/socioprophet`); the **commit-SHA tag** is what GitOps promotes (never `latest`).

## Values — `deploy/values/` (all 12 services with Dockerfiles)
`api` (tritRPC :9000 + shared-key secret, TCP probe), `gateway` + `socioprophet-web` (HPA + GCE ingress), `evidence-console`, `evidence-receipts`, `eval-fabric-api`, `hellgraph-service`, `osm-map-api`, `reasoning-failure-runner`, `search-orchestrator`, and the workspace `mail` / `caldav` / `smtp` surfaces.

## Argo CD — `deploy/argocd/`
Multi-source ApplicationSets (chart path + `$values` ref):
- `platform-services` → ns `socioprophet`
- `workspace-services` → ns `workspace` (topology lives here, per the prophet-workspace README)
- `fogstack/fogstack-appset` → `matrix(service × {standard, federal})` → ns `fogstack-<tier>`, each workload stamped with `socioprophet.ai/compliance-tier` (mirrors the existing `cloudshell-fog-stack-{standard,federal}` split)

## Validation
- `helm lint` clean.
- All 12 values files render valid manifests via `helm template` (gateway/web get HPA+Ingress, api gets the tritRPC port + secret env, workspace services get their ports/config).
- ApplicationSets parse as valid `ApplicationSet` resources.

## Confirm before merge
- **fogstack service membership** in `fogstack-appset.yaml` is my best inference of the fog-edge runtime set, not a finalized BOM — please sanity-check the list.
- Migration: this supersedes the bespoke `apps/*/kustomize` for the listed services; remove those once Argo is cut over.