### PR TITLE
infra(gke): grant CI SA artifactregistry.writer on the image repo

### DIFF
--- a/infra/tofu/environments/gcp-gke/README.md
+++ b/infra/tofu/environments/gcp-gke/README.md
@@ -1,0 +1,33 @@
+# gcp-gke — GKE Autopilot + Argo CD bootstrap
+
+Stands up the Lane C runtime: a GKE Autopilot cluster, the `socioprophet`
+Artifact Registry, Argo CD, and a root app-of-apps that makes Argo sync the
+ApplicationSets in `deploy/argocd/` (platform-services, workspace-services,
+fogstack). After apply, pushing image SHAs into the chart values is all it takes
+to ship.
+
+## What it creates
+- `google_container_cluster` — Autopilot, REGULAR channel, deletion-protected, Workload Identity on.
+- `google_artifact_registry_repository.socioprophet` — the image registry the `build-image` workflow pushes to.
+- `helm_release.argocd` — Argo CD in the `argocd` namespace.
+- root `Application` — points Argo at `deploy/argocd` (recurse) so the ApplicationSets self-apply.
+
+## Apply (needs an operator with project owner/editor + container.admin)
+```sh
+cd infra/tofu/environments/gcp-gke
+# first run: comment out the gcs backend in versions.tf, or create the state bucket first
+tofu init
+tofu plan      # also runs in CI via .github/workflows/tofu-plan.yml
+tofu apply
+$(tofu output -raw get_credentials)        # point kubectl at the cluster
+kubectl -n argocd get applications          # platform-services / workspace-services / fog-*
+```
+
+## Dependencies / order
+1. Needs `deploy/argocd/*` (PR #657) merged to `main` so the root app finds the ApplicationSets.
+2. Grant the CI service account `roles/artifactregistry.writer` on the repo (the `build-image` push identity) — or let this env own that binding (add a `google_artifact_registry_repository_iam_member`).
+3. This is the cloud-provisioning step that requires your authorization to `apply`; the code is reviewable/plannable without it.
+
+## Notes
+- Autopilot chosen for least ops; switch `enable_autopilot=false` + add node pools for Standard if you need GPUs/daemonsets the fog tier requires.
+- State: GCS backend `prophet-tofu-state-socioprophet` (create the bucket once, or run local for the first apply then migrate).

--- a/infra/tofu/environments/gcp-gke/argocd.tf
+++ b/infra/tofu/environments/gcp-gke/argocd.tf
@@ -1,0 +1,68 @@
+# Argo CD on the cluster + the root "app of apps" that points Argo at the
+# gitops repo's deploy/argocd directory (where the ApplicationSets live).
+
+provider "kubernetes" {
+  host                   = "https://${google_container_cluster.this.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(google_container_cluster.this.master_auth[0].cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${google_container_cluster.this.endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(google_container_cluster.this.master_auth[0].cluster_ca_certificate)
+  }
+}
+
+resource "helm_release" "argocd" {
+  name             = "argocd"
+  namespace        = "argocd"
+  create_namespace = true
+  repository       = "https://argoproj.github.io/argo-helm"
+  chart            = "argo-cd"
+  version          = "7.7.7"
+
+  # Keep CRDs; let Argo self-manage after bootstrap.
+  set {
+    name  = "crds.keep"
+    value = "true"
+  }
+}
+
+# Root app-of-apps: Argo watches deploy/argocd and applies the ApplicationSets
+# (platform-services, workspace-services, fogstack) found there. Applied via
+# kubectl after the CRDs exist (avoids kubernetes_manifest plan-time CRD races).
+resource "null_resource" "root_app" {
+  depends_on = [helm_release.argocd]
+
+  triggers = {
+    repo     = var.gitops_repo_url
+    revision = var.gitops_revision
+    path     = var.gitops_path
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      cat <<'YAML' | kubectl apply -f -
+      apiVersion: argoproj.io/v1alpha1
+      kind: Application
+      metadata:
+        name: root
+        namespace: argocd
+      spec:
+        project: default
+        source:
+          repoURL: ${var.gitops_repo_url}
+          targetRevision: ${var.gitops_revision}
+          path: ${var.gitops_path}
+          directory: { recurse: true }
+        destination:
+          server: https://kubernetes.default.svc
+          namespace: argocd
+        syncPolicy:
+          automated: { prune: true, selfHeal: true }
+      YAML
+    EOT
+  }
+}

--- a/infra/tofu/environments/gcp-gke/main.tf
+++ b/infra/tofu/environments/gcp-gke/main.tf
@@ -39,6 +39,14 @@ resource "google_artifact_registry_repository" "images" {
   depends_on    = [google_project_service.svc]
 }
 
+# Let the CI service account (the build-image push identity) write images.
+resource "google_artifact_registry_repository_iam_member" "ci_push" {
+  location   = google_artifact_registry_repository.images.location
+  repository = google_artifact_registry_repository.images.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:sourceos-ci@socioprophet-platform.iam.gserviceaccount.com"
+}
+
 # Autopilot cluster.
 resource "google_container_cluster" "this" {
   name                = var.cluster_name

--- a/infra/tofu/environments/gcp-gke/main.tf
+++ b/infra/tofu/environments/gcp-gke/main.tf
@@ -1,0 +1,57 @@
+# GKE Autopilot cluster + Artifact Registry for the prophet-platform Lane C
+# runtime. Autopilot = Google-managed nodes (least ops); Workload Identity is on
+# by default so workloads auth to GCP without keys.
+#
+# Labels come from ../../shared/labels.tf conventions (inlined here to keep the
+# env self-contained for `tofu apply` from this directory).
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+locals {
+  labels = {
+    "prophet-platform" = "true"
+    "managed-by"       = "opentofu"
+    "source-of-truth"  = "git"
+    "org"              = "socioprophet"
+  }
+}
+
+# Required APIs.
+resource "google_project_service" "svc" {
+  for_each = toset([
+    "container.googleapis.com",
+    "artifactregistry.googleapis.com",
+  ])
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# Container registry the build-image workflow pushes to.
+resource "google_artifact_registry_repository" "images" {
+  location      = var.region
+  repository_id = "socioprophet"
+  format        = "DOCKER"
+  description   = "SocioProphet/SourceOS estate container images"
+  labels        = local.labels
+  depends_on    = [google_project_service.svc]
+}
+
+# Autopilot cluster.
+resource "google_container_cluster" "this" {
+  name                = var.cluster_name
+  location            = var.region
+  enable_autopilot    = true
+  deletion_protection = true
+
+  # Autopilot manages node pools; Workload Identity is enabled implicitly.
+  release_channel { channel = "REGULAR" }
+
+  resource_labels = local.labels
+  depends_on      = [google_project_service.svc]
+}
+
+# Cluster auth for the kubernetes/helm providers.
+data "google_client_config" "default" {}

--- a/infra/tofu/environments/gcp-gke/outputs.tf
+++ b/infra/tofu/environments/gcp-gke/outputs.tf
@@ -1,0 +1,17 @@
+output "cluster_name" {
+  value = google_container_cluster.this.name
+}
+
+output "cluster_endpoint" {
+  value     = google_container_cluster.this.endpoint
+  sensitive = true
+}
+
+output "registry" {
+  value = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.images.repository_id}"
+}
+
+output "get_credentials" {
+  description = "Run this to point kubectl at the cluster."
+  value       = "gcloud container clusters get-credentials ${google_container_cluster.this.name} --region ${var.region} --project ${var.project_id}"
+}

--- a/infra/tofu/environments/gcp-gke/variables.tf
+++ b/infra/tofu/environments/gcp-gke/variables.tf
@@ -1,0 +1,30 @@
+variable "project_id" {
+  type    = string
+  default = "socioprophet-platform"
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "prophet-platform"
+}
+
+variable "gitops_repo_url" {
+  type    = string
+  default = "https://github.com/SocioProphet/prophet-platform"
+}
+
+variable "gitops_revision" {
+  type    = string
+  default = "main"
+}
+
+# Path in the gitops repo Argo CD watches (the ApplicationSets live here).
+variable "gitops_path" {
+  type    = string
+  default = "deploy/argocd"
+}

--- a/infra/tofu/environments/gcp-gke/versions.tf
+++ b/infra/tofu/environments/gcp-gke/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    google      = { source = "hashicorp/google", version = "~> 6.0" }
+    google-beta = { source = "hashicorp/google-beta", version = "~> 6.0" }
+    helm        = { source = "hashicorp/helm", version = "~> 2.13" }
+    kubernetes  = { source = "hashicorp/kubernetes", version = "~> 2.30" }
+  }
+
+  # First run: comment this out for a local backend, then migrate to GCS.
+  backend "gcs" {
+    bucket = "prophet-tofu-state-socioprophet"
+    prefix = "gcp-gke"
+  }
+}


### PR DESCRIPTION
Closes the gap from #659: the gcp-gke env creates the GAR repo but didn't grant the CI service account (`sourceos-ci@`, the build-image push identity) write access, so `images.yml` (#658) pushes would be rejected. Adds the `artifactregistry.writer` binding. `tofu validate` passes.