### PR TITLE
infra(gke): grant CI SA artifactregistry.writer on the image repo

### DIFF
--- a/infra/tofu/environments/gcp-gke/main.tf
+++ b/infra/tofu/environments/gcp-gke/main.tf
@@ -39,6 +39,14 @@ resource "google_artifact_registry_repository" "images" {
   depends_on    = [google_project_service.svc]
 }
 
+# Let the CI service account (the build-image push identity) write images.
+resource "google_artifact_registry_repository_iam_member" "ci_push" {
+  location   = google_artifact_registry_repository.images.location
+  repository = google_artifact_registry_repository.images.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:sourceos-ci@socioprophet-platform.iam.gserviceaccount.com"
+}
+
 # Autopilot cluster.
 resource "google_container_cluster" "this" {
   name                = var.cluster_name


### PR DESCRIPTION
One-line follow-up to #659: the gcp-gke env creates the GAR repo but didn't grant the CI service account (`sourceos-ci@`, the build-image push identity) write access, so `images.yml` (#658) pushes would be rejected. Adds the `artifactregistry.writer` binding so `tofu apply` wires it.