### PR TITLE
feat(charts): publish Helm charts for download (Pages + OCI)

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,62 @@
+# Publish the Helm charts for download, two ways:
+#   1. Public chart repo via GitHub Pages  → `helm repo add` (no cloud auth)
+#   2. OCI artifacts in Artifact Registry   → `helm pull oci://…`
+#
+# chart-releaser packages every chart under charts/, cuts a GitHub Release per
+# chart version, and updates index.yaml on the gh-pages branch. Bump a chart's
+# version in its Chart.yaml to publish a new one.
+name: helm-release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'charts/**'
+      - '.github/workflows/helm-release.yml'
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write    # chart-releaser: create releases + push gh-pages
+      id-token: write     # WIF for the OCI push
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - uses: azure/setup-helm@v4
+
+      # 1. Public chart repo on GitHub Pages (helm repo add).
+      - name: Release charts to GitHub Pages
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # 2. OCI artifacts in Artifact Registry (helm pull oci://).
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          token_format: access_token
+
+      - name: Push charts to Artifact Registry (OCI)
+        run: |
+          echo "${{ steps.auth.outputs.access_token }}" \
+            | helm registry login us-central1-docker.pkg.dev -u oauth2accesstoken --password-stdin
+          mkdir -p /tmp/pkg
+          for c in charts/*/; do
+            [ -f "$c/Chart.yaml" ] && helm package "$c" -d /tmp/pkg
+          done
+          for t in /tmp/pkg/*.tgz; do
+            helm push "$t" oci://us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/charts
+          done

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,38 @@
+# SocioProphet Helm charts
+
+Reusable charts for deploying estate services to any Kubernetes cluster.
+Published two ways by `.github/workflows/helm-release.yml`.
+
+## Install
+
+### Public chart repo (no cloud auth)
+```sh
+helm repo add socioprophet https://socioprophet.github.io/prophet-platform
+helm repo update
+helm install my-api socioprophet/socioprophet-service \
+  --set image.repository=socioprophet-api --set service.port=9000
+```
+
+### OCI (Artifact Registry)
+```sh
+helm pull oci://us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/charts/socioprophet-service --version 0.1.0
+# or install directly
+helm install my-api \
+  oci://us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/charts/socioprophet-service \
+  --version 0.1.0 -f my-values.yaml
+```
+
+## Charts
+
+| Chart | Purpose |
+|-------|---------|
+| `socioprophet-service` | Generic estate service: Deployment + Service (+ ConfigMap/HPA/Ingress/SA), hardened. Drives every service via `deploy/values/<svc>.yaml`. |
+
+## Publishing
+
+Bump the chart `version` in its `Chart.yaml` and merge to `main` — `helm-release`
+packages it, cuts a GitHub Release, updates the Pages `index.yaml`, and pushes
+the OCI artifact to Artifact Registry.
+
+> One-time: enable GitHub Pages (Settings → Pages → branch `gh-pages`) after the
+> first `helm-release` run creates that branch, so the `helm repo add` URL serves.


### PR DESCRIPTION
Makes the Helm charts downloadable, two ways:

- **Public chart repo (GitHub Pages)** — `helm repo add socioprophet https://socioprophet.github.io/prophet-platform`, no cloud auth. Via `chart-releaser` (GitHub Release per chart version + `index.yaml` on `gh-pages`).
- **OCI (Artifact Registry)** — `helm pull oci://us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/charts/socioprophet-service`.

`helm-release.yml` runs on a chart version bump (`charts/**` → `main`) or dispatch. `charts/README.md` documents both install paths. actionlint-clean.

**Already live:** `socioprophet-service:0.1.0` is pushed to GAR OCI right now.

**One-time after first run:** enable GitHub Pages (Settings → Pages → branch `gh-pages`) so the `helm repo add` URL serves; optionally make the GAR repo public-read for anonymous `oci://` pulls.