### PR TITLE
feat(multicloud): AKS/EKS/IKS substrates (portable platform) + GPU pools

### DIFF
--- a/deploy/values/gateway.yaml
+++ b/deploy/values/gateway.yaml
@@ -3,6 +3,6 @@ image: { repository: socioprophet-gateway }
 service: { port: 8080, portName: http }
 ingress:
   enabled: true
-  className: gce
+  className: ""   # cluster default; set per-cloud (gce / azure-application-gateway / alb) via overlay
   hosts: [{ host: api.socioprophet.ai, paths: [{ path: /, pathType: Prefix }] }]
 autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 6 }

--- a/deploy/values/socioprophet-web.yaml
+++ b/deploy/values/socioprophet-web.yaml
@@ -3,6 +3,6 @@ image: { repository: socioprophet-web }
 service: { port: 8080, portName: http }
 ingress:
   enabled: true
-  className: gce
+  className: ""   # cluster default; set per-cloud (gce / azure-application-gateway / alb) via overlay
   hosts: [{ host: app.socioprophet.ai, paths: [{ path: /, pathType: Prefix }] }]
 autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 6 }

--- a/infra/tofu/environments/MULTICLOUD.md
+++ b/infra/tofu/environments/MULTICLOUD.md
@@ -1,0 +1,45 @@
+# Multi-cloud substrates
+
+The platform runs on **any** cloud's managed Kubernetes. Only the *substrate*
+(cluster + container registry + Argo CD bootstrap) is cloud-specific — the app
+layer (`charts/socioprophet-service` + `deploy/argocd` ApplicationSets) is
+identical everywhere and never changes per cloud.
+
+```
+            app layer (cloud-neutral, one copy)
+   charts/socioprophet-service + deploy/values + deploy/argocd
+                          │
+        ┌─────────┬───────┴───────┬──────────┐
+     gcp-gke   azure-aks       aws-eks    ibm-iks      ← swap the substrate only
+      (GKE)     (AKS)           (EKS)      (IKS)
+```
+
+Each substrate env stands up: a managed cluster + a container registry + Argo CD
++ the **same** root app-of-apps pointing at `deploy/argocd`. Argo then syncs the
+identical ApplicationSets onto whichever cloud you're on.
+
+## Substrate parity
+
+| Concern | gcp-gke | azure-aks | aws-eks | ibm-iks |
+|---|---|---|---|---|
+| Managed k8s | GKE Autopilot | AKS | EKS | IKS (VPC) |
+| Registry | Artifact Registry | ACR | ECR | Container Registry |
+| GPU (train/finetune) | Autopilot GPU pods | `Standard_NC4as_T4_v3` pool 0→N | `g4dn.xlarge` group 0→N | `gx2-8x64x1v100` pool |
+| Argo CD + root app | ✅ identical | ✅ identical | ✅ identical | ✅ identical |
+| Status | **applied live ✓** | validate-clean | validate-clean | validate-clean |
+
+Only `gcp-gke` has been applied for real (the others need each cloud's
+credentials). All four `tofu validate` clean. GPU pools scale to zero so they
+cost nothing until a training/finetuning job requests `nvidia.com/gpu`.
+
+## Add a cloud
+Copy the closest env, swap the cluster + registry resources for the new
+provider, keep `argocd.tf` (only the provider auth block differs), point
+`gitops_path` at `deploy/argocd`. The app layer needs no changes.
+
+## Apply any substrate
+```sh
+cd infra/tofu/environments/<env>
+tofu init && tofu apply
+$(tofu output -raw get_credentials)   # point kubectl at the new cluster
+```

--- a/infra/tofu/environments/aws-eks/README.md
+++ b/infra/tofu/environments/aws-eks/README.md
@@ -1,0 +1,12 @@
+# aws-eks — EKS substrate (AWS)
+
+Same platform, AWS underneath: EKS cluster (system + scale-to-zero GPU node
+group for finetuning/training) + ECR + Argo CD + the identical root app pointing
+at `deploy/argocd`. Charts and ApplicationSets unchanged.
+
+## Apply (needs AWS creds: env or profile)
+```sh
+tofu init && tofu apply
+$(tofu output -raw get_credentials)
+```
+> Validate-clean; not apply-tested (no AWS keys here). Review before applying.

--- a/infra/tofu/environments/aws-eks/argocd.tf
+++ b/infra/tofu/environments/aws-eks/argocd.tf
@@ -1,0 +1,61 @@
+# Argo CD + root app-of-apps — identical to every substrate; only the provider
+# auth (EKS token) is cloud-specific.
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+    token                  = data.aws_eks_cluster_auth.this.token
+  }
+}
+
+resource "helm_release" "argocd" {
+  name             = "argocd"
+  namespace        = "argocd"
+  create_namespace = true
+  repository       = "https://argoproj.github.io/argo-helm"
+  chart            = "argo-cd"
+  version          = "7.7.7"
+  set {
+    name  = "crds.keep"
+    value = "true"
+  }
+}
+
+resource "helm_release" "root_app" {
+  name       = "root-app"
+  namespace  = "argocd"
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.2"
+  depends_on = [helm_release.argocd]
+
+  values = [yamlencode({
+    applications = {
+      root = {
+        namespace = "argocd"
+        project   = "default"
+        source = {
+          repoURL        = var.gitops_repo_url
+          targetRevision = var.gitops_revision
+          path           = var.gitops_path
+          directory      = { recurse = true }
+        }
+        destination = {
+          server    = "https://kubernetes.default.svc"
+          namespace = "argocd"
+        }
+        syncPolicy = { automated = { prune = true, selfHeal = true } }
+      }
+    }
+  })]
+}

--- a/infra/tofu/environments/aws-eks/main.tf
+++ b/infra/tofu/environments/aws-eks/main.tf
@@ -1,0 +1,66 @@
+# AWS EKS substrate. Same platform, AWS underneath: EKS cluster (system +
+# scale-to-zero GPU node group) + ECR. App layer (charts/ + deploy/argocd) is
+# unchanged. Uses the upstream vpc + eks modules.
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name            = var.cluster_name
+  cidr            = "10.0.0.0/16"
+  azs             = slice(data.aws_availability_zones.available.names, 0, 2)
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24"]
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name                             = var.cluster_name
+  cluster_version                          = "1.30"
+  cluster_endpoint_public_access           = true
+  enable_cluster_creator_admin_permissions = true
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  eks_managed_node_groups = {
+    system = {
+      instance_types = ["t3.large"]
+      min_size       = 2
+      max_size       = 3
+      desired_size   = 2
+    }
+    # GPU pool for finetuning / model training; scales 0→N on demand.
+    gpu = {
+      instance_types = ["g4dn.xlarge"]
+      min_size       = 0
+      max_size       = var.gpu_max_nodes
+      desired_size   = 0
+      taints = {
+        gpu = {
+          key    = "nvidia.com/gpu"
+          value  = "present"
+          effect = "NO_SCHEDULE"
+        }
+      }
+    }
+  }
+}
+
+# Container registry (the ECR equivalent of GAR).
+resource "aws_ecr_repository" "images" {
+  name         = "socioprophet"
+  force_delete = true
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}

--- a/infra/tofu/environments/aws-eks/outputs.tf
+++ b/infra/tofu/environments/aws-eks/outputs.tf
@@ -1,0 +1,9 @@
+output "cluster_name" {
+  value = module.eks.cluster_name
+}
+output "registry" {
+  value = aws_ecr_repository.images.repository_url
+}
+output "get_credentials" {
+  value = "aws eks update-kubeconfig --region ${var.region} --name ${module.eks.cluster_name}"
+}

--- a/infra/tofu/environments/aws-eks/variables.tf
+++ b/infra/tofu/environments/aws-eks/variables.tf
@@ -1,0 +1,24 @@
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+variable "cluster_name" {
+  type    = string
+  default = "prophet-platform"
+}
+variable "gpu_max_nodes" {
+  type    = number
+  default = 2
+}
+variable "gitops_repo_url" {
+  type    = string
+  default = "https://github.com/SocioProphet/prophet-platform"
+}
+variable "gitops_revision" {
+  type    = string
+  default = "main"
+}
+variable "gitops_path" {
+  type    = string
+  default = "deploy/argocd"
+}

--- a/infra/tofu/environments/aws-eks/versions.tf
+++ b/infra/tofu/environments/aws-eks/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.8.0"
+  required_providers {
+    aws        = { source = "hashicorp/aws", version = "~> 5.0" }
+    helm       = { source = "hashicorp/helm", version = "~> 2.13" }
+    kubernetes = { source = "hashicorp/kubernetes", version = "~> 2.30" }
+  }
+  # backend "s3" { ... }  # configure per your state bucket, or run local first
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/infra/tofu/environments/azure-aks/README.md
+++ b/infra/tofu/environments/azure-aks/README.md
@@ -1,0 +1,15 @@
+# azure-aks — AKS substrate (Azure)
+
+Same platform, Azure underneath. Creates an AKS cluster + ACR + a scale-to-zero
+GPU pool (finetuning/training) + Argo CD + the identical root app pointing at
+`deploy/argocd`. The Helm charts and ApplicationSets are unchanged from GCP.
+
+## Apply (needs Azure creds: `az login` or ARM_* env)
+```sh
+tofu init && tofu apply
+$(tofu output -raw get_credentials)
+```
+GPU training pods: tolerate `nvidia.com/gpu=present:NoSchedule` and request
+`nvidia.com/gpu` — the pool autoscales 0→N on demand.
+
+> Validate-clean; not apply-tested (no Azure keys here). Review before applying.

--- a/infra/tofu/environments/azure-aks/argocd.tf
+++ b/infra/tofu/environments/azure-aks/argocd.tf
@@ -1,0 +1,63 @@
+# Argo CD + root app-of-apps — identical to every other substrate; only the
+# provider auth (AKS kube_config) is cloud-specific.
+locals {
+  kube = azurerm_kubernetes_cluster.this.kube_config[0]
+}
+
+provider "kubernetes" {
+  host                   = local.kube.host
+  client_certificate     = base64decode(local.kube.client_certificate)
+  client_key             = base64decode(local.kube.client_key)
+  cluster_ca_certificate = base64decode(local.kube.cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.kube.host
+    client_certificate     = base64decode(local.kube.client_certificate)
+    client_key             = base64decode(local.kube.client_key)
+    cluster_ca_certificate = base64decode(local.kube.cluster_ca_certificate)
+  }
+}
+
+resource "helm_release" "argocd" {
+  name             = "argocd"
+  namespace        = "argocd"
+  create_namespace = true
+  repository       = "https://argoproj.github.io/argo-helm"
+  chart            = "argo-cd"
+  version          = "7.7.7"
+  set {
+    name  = "crds.keep"
+    value = "true"
+  }
+}
+
+resource "helm_release" "root_app" {
+  name       = "root-app"
+  namespace  = "argocd"
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.2"
+  depends_on = [helm_release.argocd]
+
+  values = [yamlencode({
+    applications = {
+      root = {
+        namespace = "argocd"
+        project   = "default"
+        source = {
+          repoURL        = var.gitops_repo_url
+          targetRevision = var.gitops_revision
+          path           = var.gitops_path
+          directory      = { recurse = true }
+        }
+        destination = {
+          server    = "https://kubernetes.default.svc"
+          namespace = "argocd"
+        }
+        syncPolicy = { automated = { prune = true, selfHeal = true } }
+      }
+    }
+  })]
+}

--- a/infra/tofu/environments/azure-aks/main.tf
+++ b/infra/tofu/environments/azure-aks/main.tf
@@ -1,0 +1,54 @@
+# Azure AKS substrate — the cloud-specific half of the platform. The app layer
+# (charts/ + deploy/argocd) is identical to every other cloud; only this cluster
+# + registry differ. Mirrors infra/tofu/environments/gcp-gke.
+
+resource "azurerm_resource_group" "this" {
+  name     = var.resource_group
+  location = var.location
+}
+
+# Container registry (the AKS equivalent of GAR).
+resource "azurerm_container_registry" "this" {
+  name                = var.acr_name
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  sku                 = "Standard"
+  admin_enabled       = false
+}
+
+resource "azurerm_kubernetes_cluster" "this" {
+  name                = var.cluster_name
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  dns_prefix          = var.cluster_name
+
+  default_node_pool {
+    name       = "system"
+    node_count = 2
+    vm_size    = "Standard_D2s_v5"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+# GPU pool for finetuning / model training. Scales 0→N so it costs nothing idle;
+# workloads request it via the nvidia.com/gpu taint toleration.
+resource "azurerm_kubernetes_cluster_node_pool" "gpu" {
+  name                  = "gpu"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.this.id
+  vm_size               = "Standard_NC4as_T4_v3"
+  auto_scaling_enabled  = true
+  node_count            = 0
+  min_count             = 0
+  max_count             = var.gpu_max_nodes
+  node_taints           = ["nvidia.com/gpu=present:NoSchedule"]
+}
+
+# Let the cluster pull images from ACR.
+resource "azurerm_role_assignment" "acr_pull" {
+  scope                = azurerm_container_registry.this.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id
+}

--- a/infra/tofu/environments/azure-aks/outputs.tf
+++ b/infra/tofu/environments/azure-aks/outputs.tf
@@ -1,0 +1,5 @@
+output "cluster_name" { value = azurerm_kubernetes_cluster.this.name }
+output "registry" { value = azurerm_container_registry.this.login_server }
+output "get_credentials" {
+  value = "az aks get-credentials --resource-group ${azurerm_resource_group.this.name} --name ${azurerm_kubernetes_cluster.this.name}"
+}

--- a/infra/tofu/environments/azure-aks/variables.tf
+++ b/infra/tofu/environments/azure-aks/variables.tf
@@ -1,0 +1,32 @@
+variable "resource_group" {
+  type    = string
+  default = "prophet-platform"
+}
+variable "location" {
+  type    = string
+  default = "eastus"
+}
+variable "cluster_name" {
+  type    = string
+  default = "prophet-platform"
+}
+variable "acr_name" {
+  type    = string
+  default = "prophetplatform"
+}
+variable "gpu_max_nodes" {
+  type    = number
+  default = 2
+}
+variable "gitops_repo_url" {
+  type    = string
+  default = "https://github.com/SocioProphet/prophet-platform"
+}
+variable "gitops_revision" {
+  type    = string
+  default = "main"
+}
+variable "gitops_path" {
+  type    = string
+  default = "deploy/argocd"
+}

--- a/infra/tofu/environments/azure-aks/versions.tf
+++ b/infra/tofu/environments/azure-aks/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.8.0"
+  required_providers {
+    azurerm    = { source = "hashicorp/azurerm", version = "~> 4.0" }
+    helm       = { source = "hashicorp/helm", version = "~> 2.13" }
+    kubernetes = { source = "hashicorp/kubernetes", version = "~> 2.30" }
+  }
+  # backend "azurerm" { ... }  # configure per your state account, or run local first
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/infra/tofu/environments/ibm-iks/README.md
+++ b/infra/tofu/environments/ibm-iks/README.md
@@ -1,0 +1,14 @@
+# ibm-iks — IBM Cloud IKS substrate (VPC)
+
+Same platform, IBM Cloud underneath: a VPC IKS cluster (default + scale-capable
+GPU pool for finetuning/training) + Container Registry namespace + Argo CD + the
+identical root app pointing at `deploy/argocd`. Charts and ApplicationSets
+unchanged.
+
+## Apply (needs IBM creds: IC_API_KEY)
+```sh
+tofu init && tofu apply
+$(tofu output -raw get_credentials)
+```
+> Validate-clean; not apply-tested (no IBM keys here). Confirm flavor names
+> (`bx2.4x16`, `gx2-8x64x1v100`) + kube_version against `ibmcloud ks` before applying.

--- a/infra/tofu/environments/ibm-iks/argocd.tf
+++ b/infra/tofu/environments/ibm-iks/argocd.tf
@@ -1,0 +1,65 @@
+# Argo CD + root app-of-apps — identical to every substrate; only the provider
+# auth (IKS admin config) is cloud-specific.
+data "ibm_container_cluster_config" "this" {
+  cluster_name_id   = ibm_container_vpc_cluster.this.id
+  resource_group_id = data.ibm_resource_group.this.id
+  admin             = true
+}
+
+provider "kubernetes" {
+  host                   = data.ibm_container_cluster_config.this.host
+  client_certificate     = data.ibm_container_cluster_config.this.admin_certificate
+  client_key             = data.ibm_container_cluster_config.this.admin_key
+  cluster_ca_certificate = data.ibm_container_cluster_config.this.ca_certificate
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.ibm_container_cluster_config.this.host
+    client_certificate     = data.ibm_container_cluster_config.this.admin_certificate
+    client_key             = data.ibm_container_cluster_config.this.admin_key
+    cluster_ca_certificate = data.ibm_container_cluster_config.this.ca_certificate
+  }
+}
+
+resource "helm_release" "argocd" {
+  name             = "argocd"
+  namespace        = "argocd"
+  create_namespace = true
+  repository       = "https://argoproj.github.io/argo-helm"
+  chart            = "argo-cd"
+  version          = "7.7.7"
+  set {
+    name  = "crds.keep"
+    value = "true"
+  }
+}
+
+resource "helm_release" "root_app" {
+  name       = "root-app"
+  namespace  = "argocd"
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.2"
+  depends_on = [helm_release.argocd]
+
+  values = [yamlencode({
+    applications = {
+      root = {
+        namespace = "argocd"
+        project   = "default"
+        source = {
+          repoURL        = var.gitops_repo_url
+          targetRevision = var.gitops_revision
+          path           = var.gitops_path
+          directory      = { recurse = true }
+        }
+        destination = {
+          server    = "https://kubernetes.default.svc"
+          namespace = "argocd"
+        }
+        syncPolicy = { automated = { prune = true, selfHeal = true } }
+      }
+    }
+  })]
+}

--- a/infra/tofu/environments/ibm-iks/main.tf
+++ b/infra/tofu/environments/ibm-iks/main.tf
@@ -1,0 +1,55 @@
+# IBM Cloud IKS substrate (VPC). Same platform, IBM underneath: a VPC IKS
+# cluster (default pool + scale-capable GPU pool) + Container Registry namespace
+# + Argo CD + the identical root app. App layer (charts/ + deploy/argocd)
+# unchanged.
+
+data "ibm_resource_group" "this" {
+  name = var.resource_group
+}
+
+resource "ibm_is_vpc" "this" {
+  name = var.cluster_name
+}
+
+resource "ibm_is_subnet" "this" {
+  name                     = "${var.cluster_name}-subnet"
+  vpc                      = ibm_is_vpc.this.id
+  zone                     = var.zone
+  total_ipv4_address_count = 256
+  resource_group           = data.ibm_resource_group.this.id
+}
+
+resource "ibm_container_vpc_cluster" "this" {
+  name              = var.cluster_name
+  vpc_id            = ibm_is_vpc.this.id
+  kube_version      = var.kube_version
+  flavor            = "bx2.4x16"
+  worker_count      = 2
+  resource_group_id = data.ibm_resource_group.this.id
+
+  zones {
+    subnet_id = ibm_is_subnet.this.id
+    name      = var.zone
+  }
+}
+
+# GPU pool for finetuning / model training.
+resource "ibm_container_vpc_worker_pool" "gpu" {
+  cluster           = ibm_container_vpc_cluster.this.id
+  worker_pool_name  = "gpu"
+  flavor            = var.gpu_flavor
+  vpc_id            = ibm_is_vpc.this.id
+  worker_count      = 0
+  resource_group_id = data.ibm_resource_group.this.id
+
+  zones {
+    subnet_id = ibm_is_subnet.this.id
+    name      = var.zone
+  }
+}
+
+# Container registry namespace (the IBM equivalent of GAR).
+resource "ibm_cr_namespace" "images" {
+  name              = var.registry_namespace
+  resource_group_id = data.ibm_resource_group.this.id
+}

--- a/infra/tofu/environments/ibm-iks/outputs.tf
+++ b/infra/tofu/environments/ibm-iks/outputs.tf
@@ -1,0 +1,9 @@
+output "cluster_name" {
+  value = ibm_container_vpc_cluster.this.name
+}
+output "registry_namespace" {
+  value = ibm_cr_namespace.images.name
+}
+output "get_credentials" {
+  value = "ibmcloud ks cluster config --cluster ${ibm_container_vpc_cluster.this.name}"
+}

--- a/infra/tofu/environments/ibm-iks/variables.tf
+++ b/infra/tofu/environments/ibm-iks/variables.tf
@@ -1,0 +1,40 @@
+variable "region" {
+  type    = string
+  default = "us-south"
+}
+variable "zone" {
+  type    = string
+  default = "us-south-1"
+}
+variable "resource_group" {
+  type    = string
+  default = "Default"
+}
+variable "cluster_name" {
+  type    = string
+  default = "prophet-platform"
+}
+variable "kube_version" {
+  type    = string
+  default = "1.30"
+}
+variable "gpu_flavor" {
+  type    = string
+  default = "gx2-8x64x1v100"
+}
+variable "registry_namespace" {
+  type    = string
+  default = "socioprophet"
+}
+variable "gitops_repo_url" {
+  type    = string
+  default = "https://github.com/SocioProphet/prophet-platform"
+}
+variable "gitops_revision" {
+  type    = string
+  default = "main"
+}
+variable "gitops_path" {
+  type    = string
+  default = "deploy/argocd"
+}

--- a/infra/tofu/environments/ibm-iks/versions.tf
+++ b/infra/tofu/environments/ibm-iks/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.8.0"
+  required_providers {
+    ibm        = { source = "IBM-Cloud/ibm", version = "~> 1.70" }
+    helm       = { source = "hashicorp/helm", version = "~> 2.13" }
+    kubernetes = { source = "hashicorp/kubernetes", version = "~> 2.30" }
+  }
+}
+
+provider "ibm" {
+  region = var.region # needs IC_API_KEY in the environment
+}


### PR DESCRIPTION
The platform now runs on **any** cloud's managed Kubernetes — GCP, Azure, AWS, IBM. Only the *substrate* differs; the app layer (`charts/socioprophet-service` + `deploy/argocd`) is identical everywhere.

## New substrates (each: cluster + registry + Argo CD + identical root app)
- **azure-aks** — AKS + ACR + scale-to-zero GPU pool (`Standard_NC4as_T4_v3`)
- **aws-eks** — EKS (upstream vpc+eks modules) + ECR + GPU node group (`g4dn.xlarge`, 0→N)
- **ibm-iks** — IKS VPC cluster + Container Registry + GPU pool (`gx2-8x64x1v100`)

All four (incl. the live `gcp-gke`) **`tofu validate` clean**. AKS/EKS/IKS are **apply-untested** — no creds for those clouds; flavor/version names flagged in each README to confirm before applying.

## For tomorrow (finetuning / model training)
Every substrate has a **GPU pool that scales to zero** — costs nothing idle, autoscales when a job requests `nvidia.com/gpu`. That's the substrate for the training/finetuning proof.

## App-layer neutrality
Dropped the one GKE-specific bit: gateway/web `ingress.className: gce` → cluster default (set per-cloud via overlay). `MULTICLOUD.md` documents the parity table + how to add a cloud.