### PR TITLE
feat(ray): LoRA training execution on Ray (compounding-loop stage 1)

### DIFF
--- a/deploy/training/ray-lora/README.md
+++ b/deploy/training/ray-lora/README.md
@@ -1,0 +1,70 @@
+# Ray LoRA loop — stage 1: the training execution
+
+The platform declared Ray as its training standard (`RAY_RUNTIME_REF = runtime-asset:prophet-ray-ml`,
+role `ray-train`) across lattice-studio and eval-fabric, and defined the promotion/rollback gates —
+but nothing ever **ran** a fine-tune. This is that missing muscle: a KubeRay **RayJob** that
+LoRA-fine-tunes a base model on rejection-sampled **verified traces**, on an **ephemeral** GPU
+cluster that tears itself down.
+
+This is stage 1 of the compounding loop. The full loop:
+
+```
+harvest verified traces (noetica)  →  /api/tune submit  →  [THIS: Ray LoRA train]
+   →  promotion gate (head-to-head base vs base+adapter, promote-never-demote)
+   →  serve (vLLM --enable-lora) + model-zoo register  →  sharper model  →  repeat
+```
+
+## Files
+| File | Purpose |
+| --- | --- |
+| `ray_lora_train.py` | Ray Train (`TorchTrainer`) + peft LoRA. Reads verified SFT JSONL → adapter → optional GCS. |
+| `lora-rayjob.yaml` | KubeRay `RayJob` — ephemeral cluster, GPU worker, `shutdownAfterJobFinishes`. |
+| `sample.sft.jsonl` | 3-line sample for the local smoke test. |
+
+## One-time: install the KubeRay operator (the Ray substrate)
+
+```bash
+helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+helm install kuberay-operator kuberay/kuberay-operator --version 1.2.2 -n ray-system --create-namespace
+```
+
+## Run a training job
+
+```bash
+# 1. ship the training script as a ConfigMap (source of truth stays ray_lora_train.py)
+kubectl -n training create configmap ray-lora-script \
+    --from-file=deploy/training/ray-lora/ray_lora_train.py
+
+# 2. (the SFT shard of verified traces is staged into the head's /home/ray/data by the submit step)
+
+# 3. launch — GPU worker auto-provisions, trains, uploads the adapter, cluster self-deletes
+kubectl apply -f deploy/training/ray-lora/lora-rayjob.yaml
+kubectl -n training get rayjob lora-verified -w
+kubectl -n training logs -l ray.io/job-name=lora-verified -f
+```
+
+The adapter lands at `ADAPTER_GCS` (default `gs://noetica-brains/adapters/lora-verified`) for the
+promotion gate (stage 3) and serving (`mesh-vllm --enable-lora`, stage 4).
+
+## Cost discipline
+`shutdownAfterJobFinishes: true` deletes the GPU worker the instant the job ends — the GPU bills
+only for the run. Nothing standing.
+
+## Local smoke test ($0, no GPU, no cloud)
+
+The script runs in Ray local mode on CPU with a tiny base model — proves the train path end to end:
+
+```bash
+cd deploy/training/ray-lora
+pip install "ray[train]" torch transformers peft datasets accelerate
+BASE_MODEL=sshleifer/tiny-gpt2 RAY_USE_GPU=0 EPOCHS=1 \
+    SFT_PATH=sample.sft.jsonl ADAPTER_OUT=/tmp/adapter \
+    python ray_lora_train.py
+# → "RAY LORA DONE ... adapter=/tmp/adapter"  and a PEFT adapter on disk
+```
+
+Validate the manifest before applying:
+
+```bash
+kubectl apply --dry-run=client -f deploy/training/ray-lora/lora-rayjob.yaml   # needs KubeRay CRDs
+```

--- a/deploy/training/ray-lora/lora-rayjob.yaml
+++ b/deploy/training/ray-lora/lora-rayjob.yaml
@@ -1,0 +1,93 @@
+# lora-rayjob — the Ray training execution (KubeRay RayJob) that was missing.
+#
+# RAY_RUNTIME_REF (runtime-asset:prophet-ray-ml, role ray-train) is referenced across lattice-studio
+# and eval-fabric, but nothing ran a fine-tune. This is it: a RayJob that LoRA-fine-tunes a base
+# model on rejection-sampled VERIFIED traces, on an EPHEMERAL Ray cluster that tears itself down.
+#
+# COST DISCIPLINE: shutdownAfterJobFinishes deletes the GPU worker the instant the job ends — the
+# A100/L4 bills only for the training run, nothing standing.
+#
+# Prereqs (one-time): KubeRay operator installed (see README), and the script as a ConfigMap:
+#   kubectl -n training create configmap ray-lora-script --from-file=ray_lora_train.py
+#
+# Apply:    kubectl apply -f deploy/training/ray-lora/lora-rayjob.yaml
+# Watch:    kubectl -n training get rayjob lora-verified -w
+# Logs:     kubectl -n training logs -l ray.io/job-name=lora-verified -f
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: lora-verified
+  namespace: training
+spec:
+  entrypoint: python /home/ray/scripts/ray_lora_train.py
+  shutdownAfterJobFinishes: true       # ephemeral cluster — no standing GPU cost
+  ttlSecondsAfterFinished: 600
+  runtimeEnvYAML: |
+    pip:
+      - transformers==4.44.2
+      - peft==0.12.0
+      - datasets==2.21.0
+      - accelerate==0.34.2
+    env_vars:
+      BASE_MODEL: "Qwen/Qwen2.5-Coder-7B-Instruct"
+      # The harvested verified-trace SFT shard (noetica /api/tune submit lands it here):
+      SFT_PATH: "/home/ray/data/verified.sft.jsonl"
+      ADAPTER_OUT: "/home/ray/adapter"
+      # Where the promotion gate + serving step pick up the adapter:
+      ADAPTER_GCS: "gs://noetica-brains/adapters/lora-verified"
+      LORA_R: "16"
+      LORA_ALPHA: "32"
+      EPOCHS: "3"
+      RAY_USE_GPU: "1"
+      RAY_NUM_WORKERS: "1"
+  rayClusterSpec:
+    rayVersion: "2.35.0"
+    headGroupSpec:
+      rayStartParams: {}
+      template:
+        spec:
+          containers:
+            - name: ray-head
+              image: rayproject/ray-ml:2.35.0
+              resources:
+                limits: { cpu: "2", memory: 8Gi }
+                requests: { cpu: "1", memory: 4Gi }
+              volumeMounts:
+                - { name: script, mountPath: /home/ray/scripts }
+                - { name: data, mountPath: /home/ray/data }
+          volumes:
+            - name: script
+              configMap: { name: ray-lora-script }
+            - name: data
+              emptyDir: {}        # SFT shard staged here (initContainer/gsutil pull in production)
+    workerGroupSpecs:
+      - groupName: gpu-workers
+        replicas: 1
+        minReplicas: 1
+        maxReplicas: 1
+        rayStartParams: {}
+        template:
+          spec:
+            # GPU node selection mirrors deploy/training/* and the serving manifest.
+            nodeSelector:
+              cloud.google.com/gke-accelerator: nvidia-l4
+            tolerations:
+              - key: nvidia.com/gpu
+                operator: Exists
+                effect: NoSchedule
+            containers:
+              - name: ray-worker
+                image: rayproject/ray-ml:2.35.0-gpu
+                resources:
+                  limits:
+                    nvidia.com/gpu: "1"
+                    cpu: "6"
+                    memory: 32Gi
+                  requests:
+                    cpu: "4"
+                    memory: 24Gi
+                volumeMounts:
+                  - { name: script, mountPath: /home/ray/scripts }
+            volumes:
+              - name: script
+                configMap: { name: ray-lora-script }

--- a/deploy/training/ray-lora/ray_lora_train.py
+++ b/deploy/training/ray-lora/ray_lora_train.py
@@ -1,0 +1,174 @@
+"""ray_lora_train — LoRA fine-tune of a base model on VERIFIED production traces, on Ray Train.
+
+This is the execution muscle behind RAY_RUNTIME_REF (runtime-asset:prophet-ray-ml, role ray-train):
+the platform declared Ray as the training standard everywhere but never actually ran a fine-tune.
+This does — wrapping the existing peft LoRA logic in ray.train.torch.TorchTrainer so it scales on
+the cluster and reports through Ray, then writes a LoRA adapter (optionally to GCS) for the
+promotion gate + serving step to pick up.
+
+Input: an SFT JSONL of rejection-sampled VERIFIED traces (each line one example). Accepted shapes:
+    {"text": "..."}                      # pre-formatted
+    {"input": "...", "output": "..."}    # noetica verified Trace
+    {"prompt": "...", "completion": "..."}
+Output: a PEFT LoRA adapter at ADAPTER_OUT (and uploaded to ADAPTER_GCS if set).
+
+Config via env (all optional except SFT_PATH):
+    BASE_MODEL      default Qwen/Qwen2.5-Coder-7B-Instruct  (set tiny-gpt2 for a CPU smoke test)
+    SFT_PATH        path to the verified SFT JSONL          (required)
+    ADAPTER_OUT     local adapter dir   (default /tmp/adapter)
+    ADAPTER_GCS     gs://... to upload the adapter          (optional)
+    LORA_R / LORA_ALPHA / EPOCHS / BATCH_SIZE / LR / MAX_LEN
+    RAY_NUM_WORKERS default 1            RAY_USE_GPU default 1 (set 0 for CPU smoke test)
+
+Run (cluster): submitted by the RayJob (lora-rayjob.yaml).
+Run (local CPU smoke, $0):
+    BASE_MODEL=sshleifer/tiny-gpt2 RAY_USE_GPU=0 SFT_PATH=sample.sft.jsonl EPOCHS=1 \
+        python ray_lora_train.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from typing import Any
+
+
+# ── pure data path (no ray/torch — unit-testable at $0) ────────────────────────────────────────
+
+def read_sft_texts(path: str) -> list[str]:
+    """Parse the verified-trace JSONL into flat training texts. Tolerant of the three input shapes;
+    skips blank lines and rows with no usable content."""
+    texts: list[str] = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            text = row.get("text")
+            if not text:
+                left = row.get("input") or row.get("prompt") or ""
+                right = row.get("output") or row.get("completion") or ""
+                text = f"{left}\n{right}".strip()
+            if text:
+                texts.append(text)
+    return texts
+
+
+def _cfg() -> dict[str, Any]:
+    return {
+        "base_model": os.getenv("BASE_MODEL", "Qwen/Qwen2.5-Coder-7B-Instruct"),
+        "sft_path": os.environ["SFT_PATH"],
+        "out_dir": os.getenv("ADAPTER_OUT", "/tmp/adapter"),
+        "r": int(os.getenv("LORA_R", "16")),
+        "alpha": int(os.getenv("LORA_ALPHA", "32")),
+        "epochs": float(os.getenv("EPOCHS", "3")),
+        "bs": int(os.getenv("BATCH_SIZE", "4")),
+        "lr": float(os.getenv("LR", "2e-4")),
+        "max_len": int(os.getenv("MAX_LEN", "1024")),
+    }
+
+
+# ── the per-worker training function (runs under Ray Train) ─────────────────────────────────────
+
+def train_func(config: dict[str, Any]) -> None:
+    import torch  # noqa: F401  (ensures CUDA visibility is logged)
+    from datasets import Dataset
+    from peft import LoraConfig, get_peft_model
+    from transformers import (
+        AutoModelForCausalLM,
+        AutoTokenizer,
+        DataCollatorForLanguageModeling,
+        Trainer,
+        TrainingArguments,
+    )
+
+    tok = AutoTokenizer.from_pretrained(config["base_model"])
+    if tok.pad_token is None:
+        tok.pad_token = tok.eos_token
+
+    model = AutoModelForCausalLM.from_pretrained(config["base_model"])
+    model = get_peft_model(
+        model,
+        LoraConfig(r=config["r"], lora_alpha=config["alpha"], lora_dropout=0.05, task_type="CAUSAL_LM"),
+    )
+    model.print_trainable_parameters()
+
+    texts = read_sft_texts(config["sft_path"])
+    if not texts:
+        raise SystemExit(f"no usable training examples in {config['sft_path']}")
+    ds = Dataset.from_dict({"text": texts}).map(
+        lambda b: tok(b["text"], truncation=True, padding="max_length", max_length=config["max_len"]),
+        batched=True,
+        remove_columns=["text"],
+    )
+
+    args = TrainingArguments(
+        output_dir=config["out_dir"],
+        per_device_train_batch_size=config["bs"],
+        num_train_epochs=config["epochs"],
+        learning_rate=config["lr"],
+        logging_steps=5,
+        save_strategy="no",
+        report_to=[],
+        # Use the GPU only when real CUDA is present (the Ray GPU worker). Off-GPU runs (CPU cluster
+        # or Mac dev, where torch would otherwise grab MPS and mis-place tensors) are pinned to CPU.
+        use_cpu=not torch.cuda.is_available(),
+    )
+    trainer = Trainer(
+        model=model,
+        args=args,
+        train_dataset=ds,
+        data_collator=DataCollatorForLanguageModeling(tok, mlm=False),
+    )
+
+    # Canonical Ray<>HF integration when available — report metrics + checkpoints through Ray Train.
+    try:
+        from ray.train.huggingface.transformers import RayTrainReportCallback, prepare_trainer
+
+        trainer.add_callback(RayTrainReportCallback())
+        trainer = prepare_trainer(trainer)
+    except Exception:  # local/CPU smoke runs without ray.train installed still train fine
+        pass
+
+    trainer.train()
+
+    # Save the adapter on rank 0 only (single-worker LoRA: always rank 0).
+    rank0 = True
+    try:
+        from ray.train import get_context
+
+        rank0 = get_context().get_world_rank() == 0
+    except Exception:
+        pass
+    if rank0:
+        model.save_pretrained(config["out_dir"])
+        tok.save_pretrained(config["out_dir"])
+        print(f"LoRA adapter saved to {config['out_dir']}", flush=True)
+        gcs = os.getenv("ADAPTER_GCS", "").strip()
+        if gcs:
+            subprocess.check_call(["gsutil", "-m", "cp", "-r", f"{config['out_dir']}/.", gcs])
+            print(f"adapter uploaded to {gcs}", flush=True)
+
+
+def main() -> None:
+    config = _cfg()
+    use_gpu = os.getenv("RAY_USE_GPU", "1") == "1"
+    num_workers = int(os.getenv("RAY_NUM_WORKERS", "1"))
+
+    from ray.train import RunConfig, ScalingConfig
+    from ray.train.torch import TorchTrainer
+
+    trainer = TorchTrainer(
+        train_func,
+        train_loop_config=config,
+        scaling_config=ScalingConfig(num_workers=num_workers, use_gpu=use_gpu),
+        run_config=RunConfig(name="lora-verified-traces"),
+    )
+    result = trainer.fit()
+    print(f"RAY LORA DONE — base={config['base_model']} adapter={config['out_dir']} metrics={result.metrics}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/training/ray-lora/ray_lora_train.py
+++ b/deploy/training/ray-lora/ray_lora_train.py
@@ -141,6 +141,8 @@ def train_func(config: dict[str, Any]) -> None:
 
         rank0 = get_context().get_world_rank() == 0
     except Exception:
+        # No Ray train context (local/CPU smoke or single-worker run) — keep the default
+        # rank0=True so the adapter is still saved exactly once.
         pass
     if rank0:
         model.save_pretrained(config["out_dir"])

--- a/deploy/training/ray-lora/sample.sft.jsonl
+++ b/deploy/training/ray-lora/sample.sft.jsonl
@@ -1,0 +1,3 @@
+{"input": "Write a Python function is_even(n) that returns True if n is even.", "output": "```python\ndef is_even(n):\n    return n % 2 == 0\n```"}
+{"prompt": "Reverse a string s in Python.", "completion": "```python\ndef reverse(s):\n    return s[::-1]\n```"}
+{"text": "Q: factorial of n iteratively.\nA: def fact(n):\n    r=1\n    for i in range(2,n+1): r*=i\n    return r"}


### PR DESCRIPTION
Stage 1 of the rejection-sampling → LoRA loop: the **Ray training execution the platform referenced everywhere but never ran**.

`RAY_RUNTIME_REF` (role `ray-train`) is declared across lattice-studio + eval-fabric, the promotion/rollback gates exist — but there was **no KubeRay/RayJob**, and `lora-finetune-job.yaml` was a plain Job on tiny-gpt2. This is the real muscle.

## What's added (`deploy/training/ray-lora/`)
| File | Purpose |
|---|---|
| `ray_lora_train.py` | Ray Train (`TorchTrainer`) + peft LoRA over **verified traces**; tolerant SFT parser; adapter → optional GCS |
| `lora-rayjob.yaml` | KubeRay `RayJob`, **ephemeral** cluster (`shutdownAfterJobFinishes` → zero standing GPU cost), L4 worker |
| `README.md` | KubeRay operator install + run + teardown + $0 local smoke |
| `sample.sft.jsonl` | smoke fixture |

## Validated at $0
- **Full Ray Train LoRA micro-run on CPU** (tiny-gpt2) → trains + saves a real PEFT adapter (`adapter_model.safetensors`)
- RayJob manifest parses; SFT parser handles all 3 trace shapes
- **Nothing applied** — the GPU bills only between apply and the job's self-teardown

## Where it sits in the loop
```
harvest verified traces (noetica) → /api/tune submit → [THIS: Ray LoRA] →
  promotion gate (head-to-head base vs base+adapter, promote-never-demote) →
  serve (vLLM --enable-lora) + model-zoo register → sharper model → repeat
```
Stages 2–4 (harvest/submit, gate via the #667 runner + eval-fabric rollback, serve) are the next builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)