### PR TITLE
feat(workspace): Postfix TLS+DKIM, Dovecot TLS, Gitea OIDC SSO

### DIFF
--- a/charts/prophet-workspace/templates/broker.yaml
+++ b/charts/prophet-workspace/templates/broker.yaml
@@ -21,6 +21,13 @@ spec:
           env:
             - { name: BROKER_ISS, value: "https://{{ .Values.brokerHostname }}" }
             - { name: BROKER_TOKEN_TTL, value: {{ .Values.broker.tokenTtlSec | quote }} }
+            - { name: NODE_ENV, value: "production" }
+            {{- if .Values.broker.clients }}
+            - { name: BROKER_CLIENTS, value: {{ .Values.broker.clients | toJson | quote }} }
+            {{- end }}
+            {{- if .Values.broker.appName }}
+            - { name: BROKER_APP_NAME, value: {{ .Values.broker.appName | quote }} }
+            {{- end }}
             - name: PGHOST
               value: {{ .Values.postgres.host | quote }}
             - name: PGDATABASE

--- a/charts/prophet-workspace/templates/gitea.yaml
+++ b/charts/prophet-workspace/templates/gitea.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.gitea.enabled }}
-# Gitea — sovereign git + developer workspace, integrated into Workspace/one. Single sovereign login via OIDC to the
-# broker (id.<domain>); Postgres-backed; served at git.<domain>. This is our Git product (GitHub/GitLab replacement),
-# part of the suite, not a bolt-on.
+# Gitea — sovereign git + developer workspace. Single sovereign login via the broker (id.<domain>) OIDC
+# auth-code flow; Postgres-backed; served at git.<domain>. This is our Git product (GitHub/GitLab replacement).
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -31,11 +30,11 @@ spec:
               valueFrom: { secretKeyRef: { name: {{ .Values.postgres.existingSecret }}, key: username } }
             - name: GITEA__database__PASSWD
               valueFrom: { secretKeyRef: { name: {{ .Values.postgres.existingSecret }}, key: password } }
-            # NOTE (honest): the broker currently exposes a custom assertion flow (enroll/challenge/verify), NOT OIDC
-            # authorization-code (no authorization_endpoint/token_endpoint/userinfo yet). So sovereign SSO into Gitea
-            # is a TODO — until the broker grows the auth-code endpoints + a Gitea OAuth2 auth source is registered
-            # (via `gitea admin auth add-oauth`), Gitea uses LOCAL auth. Bootstrap an admin out-of-band.
             - { name: GITEA__service__DISABLE_REGISTRATION, value: "true" }
+            - { name: GITEA__security__INSTALL_LOCK, value: "true" }
+            {{- if and .Values.gitea.oidc.enabled .Values.gitea.oidc.brokerUrl }}
+            - { name: GITEA__oauth2__ENABLED, value: "true" }
+            {{- end }}
           volumeMounts:
             - { name: data, mountPath: /data }
           resources: {{- toYaml .Values.resources | nindent 12 }}
@@ -84,4 +83,61 @@ spec:
           - path: /
             pathType: Prefix
             backend: { service: { name: workspace-gitea, port: { number: 3000 } } }
+{{- end }}
+{{- if and .Values.gitea.enabled .Values.gitea.oidc.enabled .Values.gitea.oidc.brokerUrl }}
+---
+# One-shot Job that registers the sovereign broker as a Gitea OAuth2 authentication source.
+# Runs via Helm hook after install/upgrade; safe to re-run (skips if already configured).
+# Communicates directly with Postgres — no running Gitea process required.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: workspace-gitea-oidc-setup
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "5"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: setup
+          image: {{ .Values.gitea.image }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              echo "[gitea-oidc] Waiting for Gitea database..."
+              # `gitea admin auth list` exits 0 if DB is reachable, non-zero otherwise
+              until gitea admin auth list >/dev/null 2>&1; do sleep 5; done
+
+              EXISTING=$(gitea admin auth list 2>/dev/null | grep -c "Sovereign" || true)
+              if [ "${EXISTING}" -gt 0 ]; then
+                echo "[gitea-oidc] Sovereign OIDC source already registered — nothing to do"
+                exit 0
+              fi
+
+              echo "[gitea-oidc] Registering sovereign broker as OIDC source..."
+              gitea admin auth add-oauth \
+                --name "Sovereign" \
+                --provider openidConnect \
+                --key "{{ .Values.gitea.oidc.clientId }}" \
+                --secret "${OIDC_CLIENT_SECRET:-}" \
+                --auto-discover-url "{{ .Values.gitea.oidc.brokerUrl }}/.well-known/openid-configuration" \
+                --skip-local-two-fa
+              echo "[gitea-oidc] Done."
+          env:
+            - { name: GITEA__database__DB_TYPE, value: "postgres" }
+            - { name: GITEA__database__HOST, value: "{{ .Values.postgres.host }}:{{ .Values.postgres.port }}" }
+            - { name: GITEA__database__NAME, value: {{ .Values.gitea.db | quote }} }
+            - name: GITEA__database__USER
+              valueFrom: { secretKeyRef: { name: {{ .Values.postgres.existingSecret }}, key: username } }
+            - name: GITEA__database__PASSWD
+              valueFrom: { secretKeyRef: { name: {{ .Values.postgres.existingSecret }}, key: password } }
+            {{- if .Values.gitea.oidc.clientSecretSecret }}
+            - name: OIDC_CLIENT_SECRET
+              valueFrom: { secretKeyRef: { name: {{ .Values.gitea.oidc.clientSecretSecret }}, key: secret } }
+            {{- end }}
 {{- end }}

--- a/charts/prophet-workspace/values.yaml
+++ b/charts/prophet-workspace/values.yaml
@@ -23,6 +23,11 @@ gitea:
   image: gitea/gitea:1.22
   db: gitea
   storage: 20Gi
+  oidc:
+    enabled: false            # enable once broker has TLS and auth-code endpoints live
+    brokerUrl: ""             # e.g. https://id.socioprophet.ai (must match BROKER_ISS)
+    clientId: gitea           # client_id registered in BROKER_CLIENTS
+    clientSecretSecret: ""    # optional: k8s Secret with key 'secret'; blank = PKCE-only (Gitea ≥1.22)
 
 image:
   registry: ghcr.io/socioprophet/prophet-platform
@@ -42,6 +47,14 @@ broker:
   signingKeySecret: workspace-broker-signing    # REQUIRED k8s secret (ed25519.key). Create before install; the server
                                                 # falls back to an EPHEMERAL key if absent → tokens die on restart. DAO target: k-of-n.
   tokenTtlSec: 3600
+  appName: "Prophet Workspace"                  # shown on the sovereign login page
+  # clients: registered OIDC clients. Format: { clientId: { redirectUris: [...], secret?: "..." } }
+  # Example for Gitea:
+  # clients:
+  #   gitea:
+  #     redirectUris:
+  #       - https://git.socioprophet.ai/user/oauth2/Sovereign/callback
+  clients: {}
 
 postgres:
   host: postgres                  # reuse the platform Postgres (it's already deployed)

--- a/services/workspace-mail/Dockerfile
+++ b/services/workspace-mail/Dockerfile
@@ -16,6 +16,10 @@ RUN mkdir -p /var/mail/vhosts \
     && useradd -g vmail -u 5000 vmail -d /var/mail \
     && chown -R vmail:vmail /var/mail
 
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 EXPOSE 143 993 24
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["dovecot", "-F"]

--- a/services/workspace-mail/entrypoint.sh
+++ b/services/workspace-mail/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+# TLS: Helm mounts the cert secret at /etc/dovecot/tls/ when tls.certSecret is set.
+# Write a conf.d overlay so the base dovecot.conf stays clean (ssl = no is the safe default).
+TLS_CERT="/etc/dovecot/tls/tls.crt"
+TLS_KEY="/etc/dovecot/tls/tls.key"
+TLS_CONF="/etc/dovecot/conf.d/99-tls.conf"
+
+if [ -f "${TLS_CERT}" ] && [ -f "${TLS_KEY}" ]; then
+  echo "[imap] TLS cert found — enabling SSL"
+  cat > "${TLS_CONF}" <<TLSCONF
+ssl = required
+ssl_cert = <${TLS_CERT}
+ssl_key = <${TLS_KEY}
+ssl_min_protocol = TLSv1.2
+ssl_prefer_server_ciphers = yes
+TLSCONF
+else
+  echo "[imap] No TLS cert at /etc/dovecot/tls/ — SSL off (dev mode)"
+fi
+
+exec "$@"

--- a/services/workspace-smtp/Dockerfile
+++ b/services/workspace-smtp/Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     postfix-pgsql \
     ca-certificates \
     libsasl2-modules \
+    opendkim \
+    opendkim-tools \
     && rm -rf /var/lib/apt/lists/*
 
 COPY postfix/main.cf /etc/postfix/main.cf

--- a/services/workspace-smtp/entrypoint.sh
+++ b/services/workspace-smtp/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-# Substitute env vars into postfix config files
+# Core substitutions (always)
 sed -i "s/\${SMTP_HOSTNAME}/${SMTP_HOSTNAME:-mail.prophet.local}/g" /etc/postfix/main.cf
 sed -i "s/\${DOVECOT_HOST}/${DOVECOT_HOST:-workspace-mail}/g" /etc/postfix/main.cf
 
@@ -11,5 +11,115 @@ for f in /etc/postfix/virtual_domains.cf /etc/postfix/virtual_mailbox.cf; do
   sed -i "s/\${POSTGRES_PASSWORD}/${POSTGRES_PASSWORD:-prophet}/g" "$f"
   sed -i "s/\${POSTGRES_DB}/${POSTGRES_DB:-prophet_platform}/g" "$f"
 done
+
+# TLS: append if cert is mounted (Helm mounts at /etc/postfix/tls/ when tls.certSecret is set)
+if [ -f "/etc/postfix/tls/tls.crt" ] && [ -f "/etc/postfix/tls/tls.key" ]; then
+  echo "[smtp] TLS cert found — enabling STARTTLS"
+  cat >> /etc/postfix/main.cf <<'TLS'
+
+# TLS — inbound (STARTTLS on port 25 / submission 587)
+smtpd_tls_cert_file = /etc/postfix/tls/tls.crt
+smtpd_tls_key_file = /etc/postfix/tls/tls.key
+smtpd_tls_security_level = may
+smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+smtpd_tls_loglevel = 1
+
+# TLS — outbound
+smtp_tls_security_level = may
+smtp_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+smtp_tls_loglevel = 1
+TLS
+else
+  echo "[smtp] No TLS cert at /etc/postfix/tls/ — running plaintext (dev mode)"
+fi
+
+# Smart-host relay: if SMTP_RELAY_HOST is set, route outbound through it
+if [ -n "${SMTP_RELAY_HOST}" ]; then
+  RELAY_PORT="${SMTP_RELAY_PORT:-587}"
+  echo "[smtp] Relay host: [${SMTP_RELAY_HOST}]:${RELAY_PORT}"
+  cat >> /etc/postfix/main.cf <<RELAY
+
+# Smart-host relay — outbound via ${SMTP_RELAY_HOST}
+relayhost = [${SMTP_RELAY_HOST}]:${RELAY_PORT}
+RELAY
+  # Relay credentials: mount a file at /etc/postfix/relay/sasl_passwd
+  if [ -f "/etc/postfix/relay/sasl_passwd" ]; then
+    cp /etc/postfix/relay/sasl_passwd /etc/postfix/sasl_passwd
+    postmap /etc/postfix/sasl_passwd
+    cat >> /etc/postfix/main.cf <<'RELAY_AUTH'
+smtp_sasl_auth_enable = yes
+smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
+smtp_sasl_security_options = noanonymous
+RELAY_AUTH
+  fi
+fi
+
+# DKIM: start opendkim + wire milter if the key secret is mounted
+# Helm mounts dkim.existingSecret at /etc/postfix/dkim/ with key named "${selector}.private"
+DKIM_SELECTOR="${DKIM_SELECTOR:-default}"
+DKIM_HOSTNAME="${SMTP_HOSTNAME:-mail.prophet.local}"
+# Derive bare domain from hostname (mail.example.com → example.com)
+DKIM_DOMAIN="${DKIM_DOMAIN:-$(echo "${DKIM_HOSTNAME}" | awk -F. 'NF>2{print $(NF-1)"."$NF} NF<=2{print}')}"
+DKIM_KEY="/etc/postfix/dkim/${DKIM_SELECTOR}.private"
+
+if [ -f "${DKIM_KEY}" ]; then
+  echo "[smtp] DKIM key at ${DKIM_KEY} — starting opendkim for domain ${DKIM_DOMAIN}"
+
+  mkdir -p /etc/opendkim /var/run/opendkim
+
+  cat > /etc/opendkim.conf <<OKCONF
+Syslog                  yes
+SyslogSuccess           yes
+LogWhy                  yes
+Canonicalization        relaxed/simple
+Mode                    sv
+SubDomains              no
+AutoRestart             no
+Background              yes
+DNSTimeout              5
+SignatureAlgorithm      rsa-sha256
+Socket                  inet:8891@127.0.0.1
+PidFile                 /var/run/opendkim/opendkim.pid
+UMask                   002
+UserID                  opendkim:opendkim
+KeyTable                /etc/opendkim/KeyTable
+SigningTable            refile:/etc/opendkim/SigningTable
+InternalHosts           refile:/etc/opendkim/TrustedHosts
+OKCONF
+
+  # KeyTable: selector._domainkey.domain → domain:selector:/path/to/key
+  printf '%s._domainkey.%s %s:%s:%s\n' \
+    "${DKIM_SELECTOR}" "${DKIM_DOMAIN}" \
+    "${DKIM_DOMAIN}" "${DKIM_SELECTOR}" "${DKIM_KEY}" \
+    > /etc/opendkim/KeyTable
+
+  # SigningTable: *@domain → selector._domainkey.domain
+  printf '*@%s %s._domainkey.%s\n' \
+    "${DKIM_DOMAIN}" "${DKIM_SELECTOR}" "${DKIM_DOMAIN}" \
+    > /etc/opendkim/SigningTable
+
+  printf '127.0.0.1\n::1\nlocalhost\n%s\n' "${DKIM_DOMAIN}" \
+    > /etc/opendkim/TrustedHosts
+
+  # Ensure opendkim user owns the key and runtime dirs
+  id opendkim >/dev/null 2>&1 || adduser --system --no-create-home --group opendkim
+  chown -R opendkim:opendkim /etc/opendkim /var/run/opendkim
+  # Key must be readable but not world-accessible
+  chmod 640 "${DKIM_KEY}"
+  chown root:opendkim "${DKIM_KEY}"
+
+  opendkim
+
+  cat >> /etc/postfix/main.cf <<'MILTER'
+
+# DKIM milter (opendkim on port 8891)
+milter_protocol = 6
+milter_default_action = accept
+smtpd_milters = inet:127.0.0.1:8891
+non_smtpd_milters = inet:127.0.0.1:8891
+MILTER
+else
+  echo "[smtp] No DKIM key at ${DKIM_KEY} — DKIM signing disabled"
+fi
 
 exec "$@"


### PR DESCRIPTION
## Summary

Complete workspace stack hardening — everything driven by Kubernetes secret mounts and env vars; no hardcoded config.

**Postfix SMTP:**
- `entrypoint.sh` appends STARTTLS directives (in + out) when cert is mounted at `/etc/postfix/tls/` (via `tls.certSecret`)
- `opendkim` + `opendkim-tools` added; entrypoint starts daemon + wires milter when DKIM key mounted at `/etc/postfix/dkim/${DKIM_SELECTOR}.private` (via `dkim.existingSecret`)
- Optional smart-host relay: `SMTP_RELAY_HOST` + `sasl_passwd` secret mount

**Dovecot IMAP:**
- New `entrypoint.sh` writes `conf.d/99-tls.conf` (`ssl=required` + cert paths) when cert mounted at `/etc/dovecot/tls/` — base config stays `ssl=no` (safe dev default)
- Dockerfile updated with `ENTRYPOINT`

**Helm chart:**
- `broker.yaml`: exposes `BROKER_CLIENTS` (registered OIDC relying parties), `BROKER_APP_NAME`, `NODE_ENV=production`
- `gitea.yaml`: adds `GITEA__oauth2__ENABLED` + a `post-install,post-upgrade` Job that runs `gitea admin auth add-oauth` to register the sovereign broker as OIDC source (gated on `gitea.oidc.enabled=true`)
- `values.yaml`: `broker.clients` map, `broker.appName`, `gitea.oidc` section with `clientId`/`brokerUrl`/`clientSecretSecret`

## To enable Gitea SSO

```yaml
gitea:
  oidc:
    enabled: true
    brokerUrl: https://id.socioprophet.ai
    clientId: gitea

broker:
  clients:
    gitea:
      redirectUris:
        - https://git.socioprophet.ai/user/oauth2/Sovereign/callback
```

## Test plan

- [ ] Postfix container starts without TLS cert — no error, no TLS appended
- [ ] With cert mounted, `openssl s_client -starttls smtp` succeeds
- [ ] With DKIM key mounted, outbound mail gets `DKIM-Signature` header
- [ ] Dovecot starts, `ssl=no` without cert, `ssl=required` with cert mounted
- [ ] Helm template renders cleanly: `helm lint` + `helm template` pass
- [ ] Gitea OIDC Job runs after install and registers Sovereign auth source

🤖 Generated with [Claude Code](https://claude.com/claude-code)