### PR TITLE
AutonomyAdmissionReceipt v0.1 contract + validator (2026 AI-driven-development)

### DIFF
--- a/contracts/AutonomyAdmissionReceipt.v0.1.json
+++ b/contracts/AutonomyAdmissionReceipt.v0.1.json
@@ -76,17 +76,16 @@
     "trust_kernel_gate_order": {
       "type": "array",
       "minItems": 6,
-      "items": {
-        "type": "string",
-        "enum": [
-          "identity",
-          "policy",
-          "evidence",
-          "attestation",
-          "revocation",
-          "audit"
-        ]
-      }
+      "maxItems": 6,
+      "prefixItems": [
+        { "const": "identity" },
+        { "const": "policy" },
+        { "const": "evidence" },
+        { "const": "attestation" },
+        { "const": "revocation" },
+        { "const": "audit" }
+      ],
+      "items": false
     },
     "subject_ref": {
       "type": "string"

--- a/contracts/AutonomyAdmissionReceipt.v0.1.json
+++ b/contracts/AutonomyAdmissionReceipt.v0.1.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/AutonomyAdmissionReceipt.v0.1.json",
+  "title": "AutonomyAdmissionReceipt",
+  "description": "Runtime evidence receipt emitted when prophet-platform admits, demotes, or denies a choir role operating at a requested AI-driven-development autonomy level. Mirrors the canonical ladder in SocioProphet/prophet-mesh:specs/ai-driven-development.yaml and the engine in prophet_mesh.autonomy. This is how the autonomy ladder is enforced AND measured at runtime (enforced_at: prophet-platform).",
+  "type": "object",
+  "required": [
+    "version",
+    "receipt_id",
+    "created_at",
+    "service_ref",
+    "role",
+    "requested_level",
+    "granted_level",
+    "decision",
+    "gate",
+    "evidence_required",
+    "trust_kernel_gate_order",
+    "subject_ref",
+    "hash",
+    "hash_algo"
+  ],
+  "properties": {
+    "version": {
+      "const": "0.1"
+    },
+    "receipt_id": {
+      "type": "string"
+    },
+    "created_at": {
+      "type": "string"
+    },
+    "service_ref": {
+      "type": "string"
+    },
+    "role": {
+      "type": "string",
+      "description": "Choir role requesting autonomy (e.g. conductor, coding, research)."
+    },
+    "requested_level": {
+      "type": "string",
+      "pattern": "^L[0-5]$"
+    },
+    "granted_level": {
+      "type": "string",
+      "pattern": "^L[0-5]$"
+    },
+    "role_ceiling": {
+      "type": "string",
+      "pattern": "^L[0-5]$"
+    },
+    "decision": {
+      "type": "string",
+      "enum": [
+        "admit",
+        "demote",
+        "deny"
+      ]
+    },
+    "gate": {
+      "type": "string",
+      "description": "Name of the gate that governs the granted level."
+    },
+    "evidence_required": {
+      "type": "string"
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "reason": {
+      "type": "string"
+    },
+    "trust_kernel_gate_order": {
+      "type": "array",
+      "minItems": 6,
+      "items": {
+        "type": "string",
+        "enum": [
+          "identity",
+          "policy",
+          "evidence",
+          "attestation",
+          "revocation",
+          "audit"
+        ]
+      }
+    },
+    "subject_ref": {
+      "type": "string"
+    },
+    "envelope_ref": {
+      "type": "string"
+    },
+    "policy_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "hash": {
+      "type": "string"
+    },
+    "hash_algo": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/examples/autonomy-admission-receipt.json
+++ b/contracts/examples/autonomy-admission-receipt.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.1",
+  "receipt_id": "aar-2026-06-28-0001",
+  "created_at": "2026-06-28T17:42:00Z",
+  "service_ref": "svc.platform.autonomy-admission",
+  "role": "coding",
+  "requested_level": "L3",
+  "granted_level": "L2",
+  "role_ceiling": "L4",
+  "decision": "demote",
+  "gate": "tests_or_review",
+  "evidence_required": "test_result_or_review_receipt",
+  "evidence_refs": [
+    "evidence://eval-fabric/replay/job-7f3a/passed"
+  ],
+  "reason": "L3 gate 'evidence_grounded' needs evidence 'evidence_dossier' (absent) -> demote to L2",
+  "trust_kernel_gate_order": [
+    "identity",
+    "policy",
+    "evidence",
+    "attestation",
+    "revocation",
+    "audit"
+  ],
+  "subject_ref": "agent://choir/coding/run-91c2",
+  "envelope_ref": "envelope://conductor/michael/turn-5512",
+  "policy_refs": [
+    "prophet-mesh:specs/ai-driven-development.yaml"
+  ],
+  "hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+  "hash_algo": "sha256"
+}

--- a/contracts/prophet-mesh/ai-driven-development.ladder.json
+++ b/contracts/prophet-mesh/ai-driven-development.ladder.json
@@ -1,0 +1,91 @@
+{
+  "levels": [
+    {
+      "enforced_at": "noetica",
+      "evidence_required": "none",
+      "gate": "none",
+      "label": "manual",
+      "level": "L0",
+      "rank": 0,
+      "roles": []
+    },
+    {
+      "enforced_at": "noetica",
+      "evidence_required": "trail_log",
+      "gate": "surface_disclosure",
+      "label": "assisted",
+      "level": "L1",
+      "rank": 1,
+      "roles": [
+        "coding",
+        "writing"
+      ]
+    },
+    {
+      "enforced_at": "prophet-platform",
+      "evidence_required": "test_result_or_review_receipt",
+      "gate": "tests_or_review",
+      "label": "automated_unit",
+      "level": "L2",
+      "rank": 2,
+      "roles": [
+        "coding",
+        "analytics"
+      ]
+    },
+    {
+      "enforced_at": "prophet-platform",
+      "evidence_required": "evidence_dossier",
+      "gate": "evidence_grounded",
+      "label": "automated_design",
+      "level": "L3",
+      "rank": 3,
+      "roles": [
+        "planning",
+        "research",
+        "analytics"
+      ]
+    },
+    {
+      "enforced_at": "prophet-platform",
+      "evidence_required": "conductor_response_envelope",
+      "gate": "channel_governed",
+      "label": "automated_solution",
+      "level": "L4",
+      "rank": 4,
+      "roles": [
+        "conductor",
+        "planning",
+        "research",
+        "coding",
+        "writing",
+        "analytics",
+        "operations"
+      ]
+    },
+    {
+      "enforced_at": "tritfabric",
+      "evidence_required": "continuous_attestation_with_revocation",
+      "gate": "chartered_envelope",
+      "label": "autonomous_governed",
+      "level": "L5",
+      "rank": 5,
+      "roles": [
+        "conductor",
+        "operations",
+        "governance-sentinel"
+      ]
+    }
+  ],
+  "name": "prophet-mesh-ai-driven-development",
+  "source": "SocioProphet/prophet-mesh:specs/ai-driven-development.yaml",
+  "trust_kernel_gate_order": [
+    "identity",
+    "policy",
+    "evidence",
+    "attestation",
+    "revocation",
+    "audit"
+  ],
+  "version": "0.1.0"
+}

--- a/docs/CHANNEL_GOVERNED_RUNTIME_GATES.md
+++ b/docs/CHANNEL_GOVERNED_RUNTIME_GATES.md
@@ -43,6 +43,26 @@ A platform operation must not route a channel-conditioned percept into durable m
 
 `confirmed_memory`, `graph_edge`, `claim_promotion`, `policy_binding`, `publication`, `export`, and `high_consequence_execution` require stronger provenance, repair/revalidation, policy decision refs, and explicit approval posture.
 
+## Autonomy admission at the gate
+
+When a channel-governed gate guards a high-consequence sink for an `L4`
+(`automated_solution`, gate `channel_governed`) conductor-orchestrated action,
+the platform emits an **AutonomyAdmissionReceipt** (`contracts/AutonomyAdmissionReceipt.v0.1.json`)
+recording the autonomy decision onto the evidence spine. The decision is
+computed from the canonical AI-driven-development ladder vendored from
+prophet-mesh (`contracts/prophet-mesh/ai-driven-development.ladder.json` — the
+single source of truth; do not edit by hand, re-vendor from
+`prophet-mesh export-autonomy-ladder`). Emit with:
+
+```
+python3 tools/emit_autonomy_admission_receipt.py \
+  --role conductor --level L4 --evidence conductor_response_envelope \
+  --channel-gate contracts/channel-governance/runtime-gate.candidate-memory.example.json
+```
+
+The emitter self-validates against the contract and fails closed: it never
+emits a receipt that grants a level above L0 without citing evidence refs.
+
 ## Runtime non-claim
 
 This tranche is a platform contract fixture and validator. It does not create live enforcement middleware, message broker policy, database schema, or API endpoint behavior.

--- a/tools/emit_autonomy_admission_receipt.py
+++ b/tools/emit_autonomy_admission_receipt.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Emit an AutonomyAdmissionReceipt at the channel-governed runtime gate.
+
+This turns the AutonomyAdmissionReceipt contract from a static schema into a
+live emitter on the evidence spine. At a channel-governed runtime gate (where
+an L4 conductor-orchestrated solution wants a high-consequence sink), the
+platform computes the autonomy admission decision from the canonical ladder
+and emits a hashed, self-validated receipt.
+
+Single source of truth: the ladder is the vendored canonical export from
+SocioProphet/prophet-mesh (contracts/prophet-mesh/ai-driven-development.ladder.json),
+NOT a hand-maintained map. Decision semantics mirror prophet_mesh.autonomy:
+authorize by role ceiling, then admit by evidence, demoting toward L0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterable
+
+# Self-validate before emit, using the contract validator that sits beside us.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from validate_autonomy_admission_receipt import validate_receipt  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LADDER = ROOT / "contracts" / "prophet-mesh" / "ai-driven-development.ladder.json"
+DEFAULT_OUTPUT_DIR = ROOT / "build" / "autonomy-admission"
+TRUST_KERNEL_GATE_ORDER = ["identity", "policy", "evidence", "attestation", "revocation", "audit"]
+_NO_EVIDENCE = {"none", ""}
+
+
+# --------------------------------------------------------------------------- #
+# Decision engine (data-driven from the canonical ladder)
+# --------------------------------------------------------------------------- #
+def _rank(level: str) -> int:
+    try:
+        return int(str(level).lstrip("Ll"))
+    except (ValueError, TypeError):
+        return -1
+
+
+class Ladder:
+    def __init__(self, doc: dict[str, Any]) -> None:
+        self.by_rank: dict[int, dict[str, Any]] = {}
+        for lvl in doc.get("levels", []):
+            r = lvl.get("rank", _rank(lvl.get("level", "")))
+            self.by_rank[int(r)] = lvl
+        if 0 not in self.by_rank:
+            self.by_rank[0] = {"level": "L0", "roles": [], "gate": "none", "evidence_required": "none"}
+
+    @classmethod
+    def load(cls, path: Path) -> "Ladder":
+        return cls(json.loads(Path(path).read_text(encoding="utf-8")))
+
+    def role_ceiling(self, role: str) -> int:
+        ceiling = 0
+        for rank, lvl in self.by_rank.items():
+            if role in (lvl.get("roles") or []) and rank > ceiling:
+                ceiling = rank
+        return ceiling
+
+    def _satisfied(self, rank: int, available: set[str]) -> bool:
+        req = self.by_rank[rank].get("evidence_required", "none")
+        return req in _NO_EVIDENCE or req in available
+
+    def evaluate(self, role: str, requested_level: str, evidence: Iterable[str]) -> dict[str, Any]:
+        available = set(evidence)
+        requested = max(_rank(requested_level), 0)
+        ceiling = self.role_ceiling(role)
+        capped = min(requested, ceiling)
+        reasons: list[str] = []
+        if requested > ceiling:
+            reasons.append(f"role '{role}' not authorized above L{ceiling}; capped from L{requested}")
+        granted = 0
+        for rank in range(capped, -1, -1):
+            if rank not in self.by_rank:
+                continue
+            if self._satisfied(rank, available):
+                granted = rank
+                break
+            lvl = self.by_rank[rank]
+            reasons.append(
+                f"L{rank} gate '{lvl.get('gate')}' needs evidence "
+                f"'{lvl.get('evidence_required')}' (absent) -> demote"
+            )
+        g = self.by_rank[granted]
+        decision = "admit" if granted == requested else "deny" if granted == 0 and requested > 0 else "demote"
+        if decision == "admit" and not reasons:
+            reasons.append(f"granted at requested level L{granted}")
+        return {
+            "role": role,
+            "requested_level": f"L{requested}",
+            "granted_level": f"L{granted}",
+            "role_ceiling": f"L{ceiling}",
+            "decision": decision,
+            "gate": g.get("gate", "none"),
+            "evidence_required": g.get("evidence_required", "none"),
+            "reason": "; ".join(reasons),
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Receipt assembly + emit
+# --------------------------------------------------------------------------- #
+def _canonical_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def build_receipt(
+    decision: dict[str, Any],
+    *,
+    subject_ref: str,
+    receipt_id: str,
+    created_at: str,
+    evidence_refs: list[str],
+    envelope_ref: str | None = None,
+    policy_refs: list[str] | None = None,
+) -> dict[str, Any]:
+    receipt: dict[str, Any] = {
+        "version": "0.1",
+        "receipt_id": receipt_id,
+        "created_at": created_at,
+        "service_ref": "svc.platform.autonomy-admission",
+        "role": decision["role"],
+        "requested_level": decision["requested_level"],
+        "granted_level": decision["granted_level"],
+        "role_ceiling": decision["role_ceiling"],
+        "decision": decision["decision"],
+        "gate": decision["gate"],
+        "evidence_required": decision["evidence_required"],
+        "evidence_refs": list(evidence_refs),
+        "reason": decision["reason"],
+        "trust_kernel_gate_order": list(TRUST_KERNEL_GATE_ORDER),
+        "subject_ref": subject_ref,
+    }
+    if envelope_ref:
+        receipt["envelope_ref"] = envelope_ref
+    if policy_refs:
+        receipt["policy_refs"] = list(policy_refs)
+    receipt["hash_algo"] = "sha256"
+    receipt["hash"] = "sha256:" + hashlib.sha256(_canonical_bytes(receipt)).hexdigest()
+    return receipt
+
+
+def _from_channel_gate(path: Path) -> dict[str, Any]:
+    """Pull binding context from a channel-governed runtime-gate record."""
+    gate = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        "subject_ref": gate.get("operation_ref", ""),
+        "envelope_ref": gate.get("gate_id"),
+        "evidence_refs": list(gate.get("evidence_refs", []) or []),
+        "policy_refs": list(gate.get("policy_decision_refs", []) or []),
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Emit an AutonomyAdmissionReceipt at a channel-governed gate.")
+    parser.add_argument("--role", required=True)
+    parser.add_argument("--level", required=True, help="requested autonomy level, e.g. L4")
+    parser.add_argument("--evidence", default="", help="comma-separated evidence tokens present")
+    parser.add_argument("--evidence-refs", default="", help="comma-separated evidence artifact refs")
+    parser.add_argument("--subject-ref", default="", help="subject (overridden by --channel-gate operation_ref)")
+    parser.add_argument("--channel-gate", help="bind to a channel-governed runtime-gate record")
+    parser.add_argument("--ladder", default=str(DEFAULT_LADDER))
+    parser.add_argument("--receipt-id", default=None)
+    parser.add_argument("--out", help="output path (default build/autonomy-admission/<receipt_id>.json)")
+    args = parser.parse_args(argv[1:])
+
+    ladder = Ladder.load(Path(args.ladder))
+    evidence = {t.strip() for t in args.evidence.split(",") if t.strip()}
+    decision = ladder.evaluate(args.role, args.level, evidence)
+
+    evidence_refs = [r.strip() for r in args.evidence_refs.split(",") if r.strip()]
+    subject_ref = args.subject_ref
+    envelope_ref = None
+    policy_refs: list[str] = []
+    if args.channel_gate:
+        ctx = _from_channel_gate(Path(args.channel_gate))
+        subject_ref = subject_ref or ctx["subject_ref"]
+        envelope_ref = ctx["envelope_ref"]
+        evidence_refs = list(dict.fromkeys(evidence_refs + ctx["evidence_refs"]))
+        policy_refs = ctx["policy_refs"]
+    policy_refs = list(dict.fromkeys(policy_refs + ["prophet-mesh:specs/ai-driven-development.yaml"]))
+
+    if not subject_ref:
+        print("ERROR: subject_ref required (pass --subject-ref or --channel-gate)", file=sys.stderr)
+        return 2
+
+    created_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    receipt_id = args.receipt_id or f"aar-{int(time.time())}"
+    receipt = build_receipt(
+        decision,
+        subject_ref=subject_ref,
+        receipt_id=receipt_id,
+        created_at=created_at,
+        evidence_refs=evidence_refs,
+        envelope_ref=envelope_ref,
+        policy_refs=policy_refs,
+    )
+
+    # Fail-closed: never emit a receipt that does not validate against the contract.
+    try:
+        validate_receipt(receipt)
+    except Exception as exc:  # ValidationError
+        print(f"ERROR: emitted receipt failed self-validation: {exc}", file=sys.stderr)
+        return 1
+
+    out = Path(args.out) if args.out else DEFAULT_OUTPUT_DIR / f"{receipt_id}.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"ok": True, "out": str(out), "decision": decision["decision"], "granted_level": decision["granted_level"], "hash": receipt["hash"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/tests/test_emit_autonomy_admission_receipt.py
+++ b/tools/tests/test_emit_autonomy_admission_receipt.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "tools" / "emit_autonomy_admission_receipt.py"
+VALIDATOR = REPO_ROOT / "tools" / "validate_autonomy_admission_receipt.py"
+CHANNEL_GATE = REPO_ROOT / "contracts" / "channel-governance" / "runtime-gate.candidate-memory.example.json"
+
+
+def _emit(tmp_path: Path, *args: str) -> dict:
+    out = tmp_path / "receipt.json"
+    proc = subprocess.run(
+        [sys.executable, str(TOOL), "--out", str(out), *args],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(out.read_text(encoding="utf-8"))
+
+
+def _validates(receipt_path: Path) -> bool:
+    proc = subprocess.run([sys.executable, str(VALIDATOR), str(receipt_path)], capture_output=True, text=True)
+    return proc.returncode == 0
+
+
+def test_emit_admit_l4_with_evidence(tmp_path: Path):
+    out = tmp_path / "r.json"
+    proc = subprocess.run(
+        [sys.executable, str(TOOL), "--out", str(out),
+         "--role", "conductor", "--level", "L4",
+         "--evidence", "conductor_response_envelope",
+         "--evidence-refs", "evidence://envelope/turn-1",
+         "--subject-ref", "agent://choir/conductor/run-1"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    receipt = json.loads(out.read_text(encoding="utf-8"))
+    assert receipt["decision"] == "admit"
+    assert receipt["granted_level"] == "L4"
+    assert receipt["hash"].startswith("sha256:")
+    # The emitted receipt must pass the contract validator.
+    assert _validates(out)
+
+
+def test_emit_demotes_when_evidence_absent(tmp_path: Path):
+    receipt = _emit(
+        tmp_path, "--role", "coding", "--level", "L3",
+        "--evidence", "test_result_or_review_receipt",  # supports L2, not L3
+        "--evidence-refs", "evidence://eval-fabric/replay/job-2/passed",
+        "--subject-ref", "agent://choir/coding/run-2",
+    )
+    assert receipt["decision"] == "demote"
+    assert receipt["granted_level"] == "L2"
+
+
+def test_emit_binds_to_channel_gate(tmp_path: Path):
+    receipt = _emit(
+        tmp_path, "--role", "conductor", "--level", "L4",
+        "--evidence", "conductor_response_envelope",
+        "--channel-gate", str(CHANNEL_GATE),
+    )
+    # subject + envelope + policy refs pulled from the channel-governed gate
+    assert receipt["subject_ref"] == "platform-operation:conversation-ingest-001"
+    assert receipt["envelope_ref"].startswith("channel-runtime-gate:")
+    assert "prophet-mesh:specs/ai-driven-development.yaml" in receipt["policy_refs"]
+
+
+def test_hash_is_deterministic_over_content(tmp_path: Path):
+    common = ["--role", "research", "--level", "L3", "--evidence", "evidence_dossier",
+              "--evidence-refs", "evidence://dossier/x",
+              "--subject-ref", "s://x", "--receipt-id", "fixed-id", "--out", str(tmp_path / "a.json")]
+    p1 = subprocess.run([sys.executable, str(TOOL), *common], capture_output=True, text=True)
+    assert p1.returncode == 0, p1.stderr
+    r1 = json.loads((tmp_path / "a.json").read_text())
+    # recompute hash by stripping it and hashing canonically must match
+    import hashlib
+    body = {k: v for k, v in r1.items() if k != "hash"}
+    recomputed = "sha256:" + hashlib.sha256(
+        json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+    ).hexdigest()
+    assert recomputed == r1["hash"]

--- a/tools/tests/test_validate_autonomy_admission_receipt.py
+++ b/tools/tests/test_validate_autonomy_admission_receipt.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = REPO_ROOT / "tools" / "validate_autonomy_admission_receipt.py"
+SCHEMA = REPO_ROOT / "contracts" / "AutonomyAdmissionReceipt.v0.1.json"
+EXAMPLE = REPO_ROOT / "contracts" / "examples" / "autonomy-admission-receipt.json"
+
+
+def _validate(receipt: dict, tmp_path: Path) -> subprocess.CompletedProcess:
+    p = tmp_path / "r.json"
+    p.write_text(json.dumps(receipt), encoding="utf-8")
+    return subprocess.run([sys.executable, str(VALIDATOR), str(p)], capture_output=True, text=True)
+
+
+def test_example_validates(tmp_path: Path):
+    proc = subprocess.run([sys.executable, str(VALIDATOR), str(EXAMPLE)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_granted_cannot_exceed_role_ceiling(tmp_path: Path):
+    receipt = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+    receipt["role_ceiling"] = "L0"
+    receipt["granted_level"] = "L2"  # exceeds the ceiling
+    proc = _validate(receipt, tmp_path)
+    assert proc.returncode == 1
+    assert "role_ceiling" in proc.stderr
+
+
+def test_schema_rejects_malformed_gate_order():
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    good = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+    jsonschema.validate(good, schema)  # baseline: conforms
+    for bad_order in (
+        ["identity"] * 6,                                                  # duplicates
+        ["audit", "revocation", "attestation", "evidence", "policy", "identity"],  # reversed
+        ["identity", "policy", "evidence", "attestation", "revocation", "audit", "extra"],  # 7 items
+    ):
+        bad = dict(good)
+        bad["trust_kernel_gate_order"] = bad_order
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(bad, schema)

--- a/tools/validate_autonomy_admission_receipt.py
+++ b/tools/validate_autonomy_admission_receipt.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Validate AutonomyAdmissionReceipt v0.1.
+
+Runtime receipt emitted when the platform admits/demotes/denies a choir role at
+a requested autonomy level. The semantics mirror the canonical ladder in
+SocioProphet/prophet-mesh (specs/ai-driven-development.yaml): the decision must
+be internally consistent (granted vs requested vs decision), the trust-kernel
+gate order is fixed, and a non-trivial granted level must cite evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REQUIRED = {
+    "version",
+    "receipt_id",
+    "created_at",
+    "service_ref",
+    "role",
+    "requested_level",
+    "granted_level",
+    "decision",
+    "gate",
+    "evidence_required",
+    "trust_kernel_gate_order",
+    "subject_ref",
+    "hash",
+    "hash_algo",
+}
+DECISIONS = {"admit", "demote", "deny"}
+TRUST_KERNEL_GATE_ORDER = ["identity", "policy", "evidence", "attestation", "revocation", "audit"]
+LEVEL_RE = re.compile(r"^L[0-5]$")
+NO_EVIDENCE = {"none", ""}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        fail(f"{path}: expected JSON object")
+    return payload
+
+
+def _rank(level: str) -> int:
+    return int(level[1:])
+
+
+def validate_receipt(record: dict[str, Any]) -> None:
+    missing = sorted(REQUIRED - set(record))
+    if missing:
+        fail("missing required fields: " + ", ".join(missing))
+
+    if record["version"] != "0.1":
+        fail("version must be '0.1'")
+    for key in ("requested_level", "granted_level"):
+        if not LEVEL_RE.match(str(record[key])):
+            fail(f"{key} must match L0..L5")
+    if "role_ceiling" in record and not LEVEL_RE.match(str(record["role_ceiling"])):
+        fail("role_ceiling must match L0..L5")
+
+    decision = record["decision"]
+    if decision not in DECISIONS:
+        fail(f"decision must be one of {sorted(DECISIONS)}")
+
+    requested = _rank(record["requested_level"])
+    granted = _rank(record["granted_level"])
+    if granted > requested:
+        fail("granted_level cannot exceed requested_level")
+
+    # Decision must be consistent with the level delta (fail-closed semantics).
+    if decision == "admit" and granted != requested:
+        fail("decision 'admit' requires granted_level == requested_level")
+    if decision == "demote" and not (0 < granted < requested):
+        fail("decision 'demote' requires 0 < granted_level < requested_level")
+    if decision == "deny" and granted != 0:
+        fail("decision 'deny' requires granted_level == L0")
+
+    if list(record["trust_kernel_gate_order"]) != TRUST_KERNEL_GATE_ORDER:
+        fail("trust_kernel_gate_order must be " + " -> ".join(TRUST_KERNEL_GATE_ORDER))
+
+    # A granted level above L0 carries a gate that needs evidence; cite it.
+    if granted >= 1 and record["evidence_required"] not in NO_EVIDENCE:
+        refs = record.get("evidence_refs")
+        if not isinstance(refs, list) or not refs:
+            fail("granted level above L0 requires non-empty evidence_refs")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_autonomy_admission_receipt.py <receipt.json>", file=sys.stderr)
+        return 2
+    try:
+        validate_receipt(load_json(Path(argv[1])))
+    except (ValidationError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: {argv[1]} validates as AutonomyAdmissionReceipt v0.1")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/validate_autonomy_admission_receipt.py
+++ b/tools/validate_autonomy_admission_receipt.py
@@ -78,6 +78,8 @@ def validate_receipt(record: dict[str, Any]) -> None:
     granted = _rank(record["granted_level"])
     if granted > requested:
         fail("granted_level cannot exceed requested_level")
+    if "role_ceiling" in record and granted > _rank(record["role_ceiling"]):
+        fail("granted_level cannot exceed role_ceiling")
 
     # Decision must be consistent with the level delta (fail-closed semantics).
     if decision == "admit" and granted != requested:


### PR DESCRIPTION
Runtime admission slice of the four-repo AI-driven-development autonomy change (2026 reframing of Gartner's "Applying AI to the Development Process" onto the prophet stack).

## What
- `contracts/AutonomyAdmissionReceipt.v0.1.json` — evidence-spine receipt emitted when the platform admits/demotes/denies a choir role at a requested autonomy level. This is where levels L2–L4 are `enforced_at: prophet-platform`.
- `tools/validate_autonomy_admission_receipt.py` — house-style validator. Enforces decision/level consistency (`admit`⇒granted==requested, `demote`⇒0<granted<requested, `deny`⇒L0), the fixed trust-kernel gate order, and that any granted level above L0 cites `evidence_refs`.
- `contracts/examples/autonomy-admission-receipt.json` — worked example (validates; an inconsistent variant is rejected).

## Contract
Mirrors the canonical ladder in `SocioProphet/prophet-mesh:specs/ai-driven-development.yaml` and the engine in `prophet_mesh.autonomy`. Companion PRs: prophet-mesh (engine), tritfabric (promotion gate), Noetica (surface).

Follow-up: wire the L4 channel-governance call site to emit this receipt at runtime (currently contract + validator only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)