### PR TITLE
Wave 0 — keyless image verification + Argo sync-waves + promotion gate

### DIFF
--- a/docs/WAVE0_SUPPLY_CHAIN_PROMOTION.md
+++ b/docs/WAVE0_SUPPLY_CHAIN_PROMOTION.md
@@ -1,0 +1,50 @@
+# Wave 0 — supply chain + promotion hardening
+
+The first, no-cluster-risk wave of the E2E deployment plan: make deploys
+**signed, ordered, and gated** without touching running workloads. Three
+self-contained changes.
+
+## 1. Keyless image verification (Kyverno)
+
+`infra/policy/cloudshell-fog/kyverno/verify-signed-images.yaml` no longer carries
+a placeholder public key. It now verifies **keyless** (Sigstore/Fulcio)
+signatures against the estate's GitHub Actions OIDC identity
+(`issuer: https://token.actions.githubusercontent.com`,
+`subject: https://github.com/SocioProphet/*`, Rekor transparency log). Nothing to
+rotate or leak. This enforces the `require_signature_state` promotion requirement
+at admission.
+
+## 2. Argo sync-waves
+
+`infra/k8s/argo-cd/appsets/socioprophet-appset.yaml` now assigns each Application a
+`argocd.argoproj.io/sync-wave` from the dependency tiers already documented in the
+file: storage/vector-store (wave 0) → mesh core → graph kernel (wave 8) → product
+front-ends (waves 11–13). Argo waits for each wave to be Healthy before the next,
+so consumers never start ahead of what they depend on.
+
+## 3. Promotion enforcer
+
+`tools/gitops_promote_image.py` gates channel promotion (dev→stage→prod) against
+the `promotion_requirements` in `contracts/platform/deployment-profiles.yaml`
+(`require_digest` / `require_signature_state` / `require_sbom` /
+`require_provenance`). It refuses to pin a digest into a channel's values unless
+the CI-supplied verification summary satisfies every declared requirement; on pass
+it writes the pinned digest. 6 unit tests in `tools/tests`.
+
+```
+tools/gitops_promote_image.py --service hellgraph-service --channel prod \
+  --digest sha256:<64hex> --values-file deploy/values/hellgraph-service.yaml \
+  --profiles contracts/platform/deployment-profiles.yaml --signed --sbom --provenance
+```
+
+## Depends on (separate repo)
+
+Producing the signatures + SBOM + SLSA provenance is the reusable
+`SocioProphet/.github` `build-image.yml` workflow's job (cosign keyless sign +
+syft SBOM attestation + provenance). This wave makes the platform **require and
+verify** them; wiring the producer side is the paired change there.
+
+## Not in this wave
+
+Observability backend (the keystone), Cilium mesh, Argo Rollouts (A-B/canary),
+Chaos Mesh, HPA/KEDA — see the E2E readiness plan.

--- a/infra/k8s/argo-cd/appsets/socioprophet-appset.yaml
+++ b/infra/k8s/argo-cd/appsets/socioprophet-appset.yaml
@@ -4,131 +4,172 @@ metadata:
   name: socioprophet
   namespace: argocd
 spec:
+  # Deployment order is enforced with Argo sync-waves (argocd.argoproj.io/sync-wave):
+  # lower waves sync (and become Healthy) before higher ones. Waves follow the
+  # dependency tiers already documented below — storage/vector-store first, product
+  # front-ends last — so e.g. HellGraph (wave 8) is up before its consumers.
   generators:
     - list:
         elements:
           - name: socioprophet-api
             path: apps/api/kustomize/overlays/dev
+            wave: "11"
           - name: socioprophet-gateway
             path: apps/gateway/kustomize/overlays/dev
+            wave: "12"
           - name: socioprophet-web
             path: apps/socioprophet-web/kustomize/overlays/dev
+            wave: "13"
           - name: search-orchestrator-academy-bridge
             path: infra/k8s/search-orchestrator/overlays/policy
             bundle: fogstack.knowledge
+            wave: "8"
           - name: workspace-mail
             path: infra/k8s/workspace-mail/overlays/p0-lab
             bundle: workspace.mail
+            wave: "2"
           - name: workspace-caldav
             path: infra/k8s/workspace-caldav/overlays/p0-lab
             bundle: workspace.caldav
+            wave: "2"
           - name: workspace-minio
             path: infra/k8s/workspace-minio/overlays/p0-lab
             bundle: workspace.storage
+            wave: "0"
           # ── Prophet Mesh — deployment order follows dependency tiers ─────────
           # Tier 0 — Vector store
           - name: mesh-qdrant
             path: infra/k8s/mesh-qdrant/overlays/p0-lab
             bundle: mesh.vector-store
+            wave: "0"
           # Tier 1 — Governance ledger (stateless)
           - name: mesh-governance-ledger
             path: infra/k8s/model-governance-ledger/overlays/p0-lab
             bundle: mesh.governance
+            wave: "1"
           # Tier 2 — Core services
           - name: mesh-memoryd
             path: infra/k8s/memoryd/overlays/p0-lab
             bundle: mesh.memory
+            wave: "2"
           - name: mesh-policy-fabric
             path: infra/k8s/policy-fabric/overlays/p0-lab
             bundle: mesh.policy
+            wave: "2"
           # Tier 3 — Routing + Registry
           - name: mesh-model-router
             path: infra/k8s/model-router/overlays/p0-lab
             bundle: mesh.routing
+            wave: "3"
           - name: mesh-agent-registry
             path: infra/k8s/agent-registry/overlays/p0-lab
             bundle: mesh.registry
+            wave: "3"
           # Tier 4 — Execution plane
           - name: mesh-superconscious
             path: infra/k8s/superconscious/overlays/p0-lab
             bundle: mesh.cognition
+            wave: "4"
           - name: mesh-agentplane
             path: infra/k8s/agentplane/overlays/p0-lab
             bundle: mesh.execution
+            wave: "4"
           # Tier 5 — ML substrate
           - name: mesh-tritfabric
             path: infra/k8s/tritfabric/overlays/p0-lab
             bundle: mesh.ml
+            wave: "5"
           # Tier 6 — Mesh conductor
           - name: mesh-conductor
             path: infra/k8s/prophet-mesh/overlays/p0-lab
             bundle: mesh.conductor
+            wave: "6"
           # ── SocioSphere extended tiers ────────────────────────────────────
           # Tier 7 — Platform shell + workspace controller
           - name: cloudshell-fog
             path: infra/k8s/cloudshell-fog/overlays/runtime-v2-standard
             bundle: platform.shell
+            wave: "7"
           - name: sociosphere
             path: infra/k8s/sociosphere/overlays/p0-lab
             bundle: platform.controller
+            wave: "7"
           # Tier 8 — Graph kernel + entity graph + search
           - name: hellgraph
             path: infra/k8s/hellgraph/overlays/p0-lab
             bundle: graph.kernel
+            wave: "8"
           - name: regis-entity-graph
             path: infra/k8s/regis-entity-graph/overlays/p0-lab
             bundle: graph.entity
+            wave: "8"
           - name: sherlock-search
             path: infra/k8s/sherlock-search/overlays/p0-lab
             bundle: search.evidence
+            wave: "8"
           # Tier 9 — Catalog + query + intelligence + runtime forge
           - name: prophet-core-catalog
             path: infra/k8s/prophet-core-catalog/overlays/p0-lab
             bundle: data.catalog
+            wave: "9"
           - name: prophet-core-query
             path: infra/k8s/prophet-core-query/overlays/p0-lab
             bundle: data.query
+            wave: "9"
           - name: global-devsecops-intelligence
             path: infra/k8s/global-devsecops-intelligence/overlays/p0-lab
             bundle: intelligence.devsecops
+            wave: "9"
           - name: lattice-forge
             path: infra/k8s/lattice-forge/overlays/p0-lab
             bundle: runtime.forge
+            wave: "9"
           # Tier 10 — Enrichment plane + MCP zero-trust
           - name: synapseiq-control-plane
             path: infra/k8s/synapseiq-control-plane/overlays/p0-lab
             bundle: enrichment.control
+            wave: "10"
           - name: synapseiq-enrichment-api
             path: infra/k8s/synapseiq-enrichment-api/overlays/p0-lab
             bundle: enrichment.api
+            wave: "10"
           - name: synapseiq-enrichment-collector
             path: infra/k8s/synapseiq-enrichment-collector/overlays/p0-lab
             bundle: enrichment.collector
+            wave: "10"
           - name: synapseiq-reasoning-api
             path: infra/k8s/synapseiq-reasoning-api/overlays/p0-lab
             bundle: enrichment.reasoning
+            wave: "10"
           - name: synapseiq-tabular-alpha
             path: infra/k8s/synapseiq-tabular-alpha/overlays/p0-lab
             bundle: enrichment.tabular
+            wave: "10"
           - name: mcp-a2a-zero-trust
             path: infra/k8s/mcp-a2a-zero-trust/overlays/p0-lab
             bundle: security.mcp-zero-trust
+            wave: "10"
           # ── Holmes / CairnPath / ContractForge ───────────────────────────
           # Tier 4.5 — Execution trace mesh
           - name: cairnpath-mesh
             path: infra/k8s/cairnpath-mesh/overlays/p0-lab
             bundle: execution.trace
+            wave: "4"
           # Tier 8 — Language intelligence
           - name: holmes
             path: infra/k8s/holmes/overlays/p0-lab
             bundle: intelligence.language
+            wave: "8"
           # Tier 9 — Contract lifecycle
           - name: contractforge
             path: infra/k8s/contractforge/overlays/p0-lab
             bundle: contracts.forge
+            wave: "9"
   template:
     metadata:
       name: '{{name}}'
+      annotations:
+        argocd.argoproj.io/sync-wave: '{{wave}}'
     spec:
       project: default
       destination:

--- a/infra/policy/cloudshell-fog/kyverno/verify-signed-images.yaml
+++ b/infra/policy/cloudshell-fog/kyverno/verify-signed-images.yaml
@@ -8,7 +8,9 @@ metadata:
     policies.kyverno.io/severity: high
     policies.kyverno.io/subject: Pod
     policies.kyverno.io/description: >-
-      Verify signatures for approved cloudshell-fog runtime and service images.
+      Verify keyless (Sigstore/Fulcio) signatures for approved cloudshell-fog
+      runtime and service images. Images are signed by the estate's reusable
+      GitHub Actions build workflow via OIDC — no long-lived key to manage.
 spec:
   validationFailureAction: Enforce
   background: false
@@ -30,8 +32,10 @@ spec:
           attestors:
             - count: 1
               entries:
-                - keys:
-                    publicKeys: |-
-                      -----BEGIN PUBLIC KEY-----
-                      REPLACE_WITH_REAL_COSIGN_PUBLIC_KEY
-                      -----END PUBLIC KEY-----
+                # Keyless: trust the estate's GitHub Actions OIDC identity that
+                # cosign-signed the digest. No public key to rotate or leak.
+                - keyless:
+                    subject: "https://github.com/SocioProphet/*"
+                    issuer: "https://token.actions.githubusercontent.com"
+                    rekor:
+                      url: "https://rekor.sigstore.dev"

--- a/tools/gitops_promote_image.py
+++ b/tools/gitops_promote_image.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Promote a container image digest across deployment channels (dev→stage→prod),
+enforcing the promotion_requirements declared in deployment-profiles.yaml.
+
+The contract (require_digest / require_signature_state / require_sbom /
+require_provenance) already exists in contracts/platform/deployment-profiles.yaml
+but nothing enforced it. This tool is the gate: given a digest + a verification
+summary (produced by cosign verify / verify-attestation in CI), it refuses the
+promotion unless every required check is satisfied, then pins the digest into the
+target channel's values file.
+
+Usage:
+  gitops_promote_image.py \
+      --service hellgraph-service --channel prod \
+      --digest sha256:<64hex> \
+      --values-file deploy/values/hellgraph-service.yaml \
+      --profiles contracts/platform/deployment-profiles.yaml \
+      --signed --sbom --provenance
+
+Exit 0 = promoted (values file updated); non-zero = refused (requirements unmet).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+# promotion_requirements key → the verification field that satisfies it.
+REQUIREMENT_TO_CHECK = {
+    "require_digest": "digest_pinned",
+    "require_signature_state": "signed",
+    "require_sbom": "sbom",
+    "require_provenance": "provenance",
+}
+
+
+def check_promotion(requirements: dict[str, Any], verification: dict[str, bool], digest: str) -> list[str]:
+    """Return a list of unmet-requirement errors ([] means promotion is allowed)."""
+    errors: list[str] = []
+    if not DIGEST_RE.match(digest or ""):
+        errors.append(f"digest {digest!r} is not a pinned sha256:<64hex> reference")
+    for req, check in REQUIREMENT_TO_CHECK.items():
+        if requirements.get(req) and not verification.get(check):
+            errors.append(f"{req} is required but verification.{check} is not satisfied")
+    return errors
+
+
+def apply_digest(values_path: Path, digest: str, channel: str, tag: str | None) -> dict[str, Any]:
+    """Pin the digest into the values file's image block; record the channel."""
+    values = yaml.safe_load(values_path.read_text(encoding="utf-8")) or {}
+    image = values.get("image")
+    if not isinstance(image, dict):
+        image = {}
+    image["digest"] = digest
+    if tag:
+        image["tag"] = tag
+    image["channel"] = channel
+    values["image"] = image
+    values_path.write_text(yaml.safe_dump(values, sort_keys=False), encoding="utf-8")
+    return values
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Promote an image digest across channels, enforcing promotion_requirements")
+    parser.add_argument("--service", required=True)
+    parser.add_argument("--channel", required=True)
+    parser.add_argument("--digest", required=True)
+    parser.add_argument("--values-file", required=True, type=Path)
+    parser.add_argument("--profiles", required=True, type=Path)
+    parser.add_argument("--tag", default=None)
+    # Verification summary (from cosign verify / verify-attestation in CI):
+    parser.add_argument("--signed", action="store_true", help="keyless signature verified")
+    parser.add_argument("--sbom", action="store_true", help="SBOM attestation present")
+    parser.add_argument("--provenance", action="store_true", help="SLSA provenance attestation present")
+    args = parser.parse_args()
+
+    profiles = yaml.safe_load(args.profiles.read_text(encoding="utf-8")) or {}
+    channels = profiles.get("channels") or []
+    if channels and args.channel not in channels:
+        print(f"ERR: channel {args.channel!r} not in declared channels {channels}", file=sys.stderr)
+        return 2
+    requirements = profiles.get("promotion_requirements") or {}
+
+    verification = {
+        "digest_pinned": bool(DIGEST_RE.match(args.digest or "")),
+        "signed": args.signed,
+        "sbom": args.sbom,
+        "provenance": args.provenance,
+    }
+    errors = check_promotion(requirements, verification, args.digest)
+    if errors:
+        print(f"REFUSED: promotion of {args.service} to {args.channel} blocked:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    if not args.values_file.exists():
+        print(f"ERR: values file {args.values_file} not found", file=sys.stderr)
+        return 2
+    apply_digest(args.values_file, args.digest, args.channel, args.tag)
+    print(f"OK: promoted {args.service} → {args.channel} at {args.digest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_gitops_promote_image.py
+++ b/tools/tests/test_gitops_promote_image.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "tools" / "gitops_promote_image.py"
+spec = importlib.util.spec_from_file_location("gitops_promote_image", MODULE_PATH)
+promote = importlib.util.module_from_spec(spec)
+sys.modules["gitops_promote_image"] = promote
+spec.loader.exec_module(promote)
+
+GOOD_DIGEST = "sha256:" + "a" * 64
+ALL_REQUIRED = {
+    "require_digest": True,
+    "require_signature_state": True,
+    "require_sbom": True,
+    "require_provenance": True,
+}
+FULL_VERIFICATION = {"digest_pinned": True, "signed": True, "sbom": True, "provenance": True}
+
+
+class CheckPromotionTests(unittest.TestCase):
+    def test_all_requirements_met_passes(self):
+        self.assertEqual(promote.check_promotion(ALL_REQUIRED, FULL_VERIFICATION, GOOD_DIGEST), [])
+
+    def test_missing_signature_is_refused(self):
+        v = {**FULL_VERIFICATION, "signed": False}
+        errors = promote.check_promotion(ALL_REQUIRED, v, GOOD_DIGEST)
+        self.assertTrue(any("require_signature_state" in e for e in errors))
+
+    def test_missing_sbom_and_provenance_both_reported(self):
+        v = {**FULL_VERIFICATION, "sbom": False, "provenance": False}
+        errors = promote.check_promotion(ALL_REQUIRED, v, GOOD_DIGEST)
+        self.assertTrue(any("require_sbom" in e for e in errors))
+        self.assertTrue(any("require_provenance" in e for e in errors))
+
+    def test_unpinned_digest_refused_even_if_signed(self):
+        errors = promote.check_promotion(ALL_REQUIRED, FULL_VERIFICATION, "hellgraph-service:latest")
+        self.assertTrue(any("pinned" in e for e in errors))
+
+    def test_relaxed_profile_only_enforces_declared_requirements(self):
+        relaxed = {"require_digest": True}  # sbom/provenance/signature not required here
+        v = {"digest_pinned": True, "signed": False, "sbom": False, "provenance": False}
+        self.assertEqual(promote.check_promotion(relaxed, v, GOOD_DIGEST), [])
+
+
+class ApplyDigestTests(unittest.TestCase):
+    def test_apply_digest_pins_into_values(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            vf = Path(d) / "hellgraph-service.yaml"
+            vf.write_text("image:\n  repository: hellgraph-service\nservice:\n  port: 8080\n", encoding="utf-8")
+            promote.apply_digest(vf, GOOD_DIGEST, "prod", tag="abc123")
+            out = yaml.safe_load(vf.read_text(encoding="utf-8"))
+            self.assertEqual(out["image"]["digest"], GOOD_DIGEST)
+            self.assertEqual(out["image"]["tag"], "abc123")
+            self.assertEqual(out["image"]["channel"], "prod")
+            self.assertEqual(out["image"]["repository"], "hellgraph-service")  # preserved
+            self.assertEqual(out["service"]["port"], 8080)                      # untouched
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

The first, **no-cluster-risk** wave of the [E2E deployment readiness plan](docs/WAVE0_SUPPLY_CHAIN_PROMOTION.md): make deploys **signed, ordered, and gated**. Three self-contained changes.

### 1. Keyless image verification (Kyverno)
`verify-signed-images.yaml` dropped its `REPLACE_WITH_REAL_COSIGN_PUBLIC_KEY` placeholder and now verifies **keyless** (Sigstore/Fulcio) signatures against the estate's GitHub Actions OIDC identity (`issuer: token.actions.githubusercontent.com`, `subject: github.com/SocioProphet/*`, Rekor). Nothing to rotate or leak — enforces `require_signature_state` at admission.

### 2. Argo sync-waves
`socioprophet-appset.yaml` assigns each Application a `argocd.argoproj.io/sync-wave` **derived from the dependency tiers already documented in the file** — storage/vector-store (0) → mesh core → graph kernel (8) → product front-ends (11–13). Argo waits for each wave to be Healthy before the next, so consumers never start ahead of dependencies.

### 3. Promotion enforcer
`tools/gitops_promote_image.py` gates dev→stage→prod against the `promotion_requirements` **already declared** in `deployment-profiles.yaml` (`require_digest`/`require_signature_state`/`require_sbom`/`require_provenance`) — which nothing enforced before. It refuses to pin a digest into a channel unless the CI verification summary satisfies every declared requirement.

## Verification

- YAML parses (kyverno + appset).
- `6/6` promotion-enforcer unit tests pass (`tools/tests/test_gitops_promote_image.py`).
- Live smoke: a `prod` promote **refused** when SBOM/provenance missing; **allowed** when signed+sbom+provenance. ✅

## Paired change (separate repo)

Producing the signatures + SBOM + SLSA provenance is the reusable `SocioProphet/.github` `build-image.yml` workflow's job (cosign keyless + syft + provenance attestation). This PR makes the platform **require and verify** them.

## Next waves

Observability backend (keystone) → Cilium mesh → Argo Rollouts (A-B/canary) → Chaos Mesh → HPA/KEDA. Plus step 5 (edge/twin sync) for the PKG stack.