### PR TITLE
feat(regis-acr-api): make the Regis/ACR service deployable (Dockerfile + fleet + smoke tests)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -47,6 +47,7 @@ jobs:
           - { image: workspace-caldav,      context: services/workspace-caldav, dockerfile: Dockerfile }
           - { image: workspace-smtp,        context: services/workspace-smtp,   dockerfile: Dockerfile }
           - { image: search-orchestrator,   context: .,                         dockerfile: services/search-orchestrator/Dockerfile }
+          - { image: regis-acr-api,         context: apps/regis-acr-api,        dockerfile: Dockerfile }
     uses: SocioProphet/.github/.github/workflows/build-image.yml@main
     with:
       image: ${{ matrix.image }}

--- a/apps/regis-acr-api/Dockerfile
+++ b/apps/regis-acr-api/Dockerfile
@@ -1,0 +1,15 @@
+# Regis / ACR API — the deployable runtime for the regis-entity-graph domain
+# (per regis-entity-graph docs/specs/prophet-platform-service-binding-v0.1.md:
+#  domain/schemas stay in regis-entity-graph; the service runtime lives here).
+FROM python:3.12-slim
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip \
+ && pip install --no-cache-dir -r requirements.txt
+
+COPY src ./src
+
+ENV PORT=8080
+EXPOSE 8080
+CMD ["uvicorn", "regis_acr_api.main:app", "--host", "0.0.0.0", "--port", "8080", "--app-dir", "src"]

--- a/apps/regis-acr-api/requirements-test.txt
+++ b/apps/regis-acr-api/requirements-test.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==8.3.3

--- a/apps/regis-acr-api/tests/test_smoke.py
+++ b/apps/regis-acr-api/tests/test_smoke.py
@@ -1,0 +1,41 @@
+"""Smoke tests for the Regis/ACR API service — the deployable runtime for regis-entity-graph."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from regis_acr_api.main import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_healthz():
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("service") == "regis-acr-api"
+
+
+def test_source_record_ingest_emits_receipt():
+    r = client.post(
+        "/v1/source-records",
+        json={
+            "source_record_id": "sr-001",
+            "source_system": "test",
+            "raw_payload": {"name": "Example Org"},
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    # every material op emits a platform-conformant receipt (correlation + receipt_ref)
+    assert "receipt_ref" in body or "receipt" in body or "correlation_id" in body
+
+
+def test_promotion_evaluate():
+    r = client.post(
+        "/v1/promotion/evaluate",
+        json={"candidate_id": "c-1", "top_score": 0.9, "runnerup_score": 0.2},
+    )
+    assert r.status_code == 200


### PR DESCRIPTION
Promotes regis-entity-graph's ACR domain from schemas-only to a **running, buildable service** per its service-binding spec. Dockerfile (self-contained) + images.yml fleet entry + smoke tests (3 pass). Next slice: the ER spine endpoints (event-ir/resolve/policy/graph/proof) backed by hellgraph.