### PR TITLE
regis-acr-api: opt-in ER spine (entitlement-gated, local-first boundary)

### DIFF
--- a/.github/workflows/regis-acr-service.yml
+++ b/.github/workflows/regis-acr-service.yml
@@ -29,9 +29,11 @@ jobs:
       - name: Install Regis ACR API dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r apps/regis-acr-api/requirements.txt
+          pip install -r apps/regis-acr-api/requirements-test.txt
           pip install PyYAML==6.0.2
       - name: Validate Regis ACR integration
         run: python tools/validate_regis_acr_integration.py
       - name: Smoke Regis ACR service
         run: python tools/smoke_regis_acr_service.py
+      - name: Unit tests (ER spine, entitlement gate, schema conformance)
+        run: cd apps/regis-acr-api && PYTHONPATH=src python -m pytest -q

--- a/apps/regis-acr-api/requirements-test.txt
+++ b/apps/regis-acr-api/requirements-test.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 pytest==8.3.3
+jsonschema==4.23.0

--- a/apps/regis-acr-api/schemas/edge.schema.json
+++ b/apps/regis-acr-api/schemas/edge.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/regis/edge.schema.json",
+  "title": "Regis Graph Edge",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "edge_id",
+    "kind",
+    "src",
+    "dst",
+    "status",
+    "valid_time",
+    "system_time",
+    "provenance"
+  ],
+  "properties": {
+    "edge_id": {"type": "string", "minLength": 1},
+    "kind": {
+      "type": "string",
+      "enum": [
+        "MATCH_EVIDENCE",
+        "MERGE_PROPOSAL",
+        "MERGE_ACCEPTED",
+        "MERGE_VETOED",
+        "UNMERGE",
+        "SPLIT_FROM",
+        "DISCLOSED_RELATIONSHIP",
+        "DERIVED_RELATIONSHIP",
+        "FORBIDDEN_RELATIONSHIP",
+        "USES_FEATURE",
+        "EMITTED_EVENT",
+        "OCCURS_IN_SCOPE",
+        "HAS_SESSION",
+        "HAS_PROOF_INGRESS",
+        "HAS_SOURCE_AUDIT_RECORD",
+        "MATERIALIZED_AS_SOURCE_GRAPH_VIEW",
+        "DELEGATES_TO",
+        "EXPORTS_TO",
+        "BLOCKED_EXPORT",
+        "ATTESTED_BY_PROOF",
+        "AUTHORIZED_BY_CONSENT"
+      ]
+    },
+    "src": {"type": "string", "minLength": 1},
+    "dst": {"type": "string", "minLength": 1},
+    "status": {
+      "type": "string",
+      "enum": ["PROPOSED", "ACTIVE", "VETOED", "REVOKED", "EXPIRED"]
+    },
+    "confidence": {
+      "anyOf": [
+        {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        {"type": "null"}
+      ],
+      "default": null
+    },
+    "reason": {
+      "anyOf": [
+        {"type": "string"},
+        {"type": "null"}
+      ],
+      "default": null
+    },
+    "artifact_refs": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true,
+      "default": []
+    },
+    "attrs": {
+      "type": "object",
+      "default": {}
+    },
+    "valid_time": {"$ref": "#/$defs/TimeRange"},
+    "system_time": {"$ref": "#/$defs/SystemTimeRange"},
+    "provenance": {"$ref": "#/$defs/Provenance"}
+  },
+  "$defs": {
+    "Timestamp": {"type": "string", "format": "date-time"},
+    "TimeRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to"],
+      "properties": {
+        "from": {"$ref": "#/$defs/Timestamp"},
+        "to": {
+          "anyOf": [
+            {"$ref": "#/$defs/Timestamp"},
+            {"type": "null"}
+          ]
+        }
+      }
+    },
+    "SystemTimeRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from_version", "to_version"],
+      "properties": {
+        "from_version": {"type": "integer", "minimum": 0},
+        "to_version": {
+          "anyOf": [
+            {"type": "integer", "minimum": 0},
+            {"type": "null"}
+          ]
+        }
+      }
+    },
+    "Provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_event_ids", "artifact_ids"],
+      "properties": {
+        "source_event_ids": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true,
+          "default": []
+        },
+        "artifact_ids": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true,
+          "default": []
+        },
+        "witness_ids": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true,
+          "default": []
+        },
+        "delta_ids": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true,
+          "default": []
+        }
+      }
+    }
+  }
+}

--- a/apps/regis-acr-api/schemas/graph_delta.schema.json
+++ b/apps/regis-acr-api/schemas/graph_delta.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/regis/graph_delta.schema.json",
+  "title": "Regis Graph Delta Envelope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "delta_id",
+    "schema_version",
+    "emitted_at",
+    "source_repo",
+    "source_run_id",
+    "trace_hash",
+    "operations"
+  ],
+  "properties": {
+    "delta_id": {"type": "string", "minLength": 1},
+    "schema_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "emitted_at": {"type": "string", "format": "date-time"},
+    "source_repo": {"type": "string", "minLength": 1},
+    "source_run_id": {"type": "string", "minLength": 1},
+    "trace_hash": {"type": "string", "minLength": 1},
+    "analysis_artifact_ids": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "uniqueItems": true,
+      "default": []
+    },
+    "operations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/Operation"}
+    }
+  },
+  "$defs": {
+    "Operation": {
+      "oneOf": [
+        {"$ref": "#/$defs/UpsertNodeOperation"},
+        {"$ref": "#/$defs/UpsertEdgeOperation"},
+        {"$ref": "#/$defs/AttachArtifactOperation"},
+        {"$ref": "#/$defs/AttachWitnessOperation"},
+        {"$ref": "#/$defs/VetoEdgeOperation"},
+        {"$ref": "#/$defs/SplitEntityOperation"},
+        {"$ref": "#/$defs/UnmergeEntityOperation"},
+        {"$ref": "#/$defs/RevokeEdgeOperation"},
+        {"$ref": "#/$defs/ExpireNodeOperation"},
+        {"$ref": "#/$defs/ExpireEdgeOperation"}
+      ]
+    },
+    "UpsertNodeOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "node"],
+      "properties": {
+        "kind": {"const": "UPSERT_NODE"},
+        "node": {"type": "object"}
+      }
+    },
+    "UpsertEdgeOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "edge"],
+      "properties": {
+        "kind": {"const": "UPSERT_EDGE"},
+        "edge": {"type": "object"}
+      }
+    },
+    "AttachArtifactOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "target_id", "target_kind", "artifact_id", "relation"],
+      "properties": {
+        "kind": {"const": "ATTACH_ARTIFACT"},
+        "target_id": {"type": "string", "minLength": 1},
+        "target_kind": {"type": "string", "enum": ["NODE", "EDGE"]},
+        "artifact_id": {"type": "string", "minLength": 1},
+        "relation": {"type": "string", "enum": ["ATTESTED_BY_PROOF"]}
+      }
+    },
+    "AttachWitnessOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "target_id", "target_kind", "witness_id", "relation"],
+      "properties": {
+        "kind": {"const": "ATTACH_WITNESS"},
+        "target_id": {"type": "string", "minLength": 1},
+        "target_kind": {"type": "string", "enum": ["NODE", "EDGE"]},
+        "witness_id": {"type": "string", "minLength": 1},
+        "relation": {"type": "string", "enum": ["AUTHORIZED_BY_CONSENT"]}
+      }
+    },
+    "VetoEdgeOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "target_edge_id", "reason_code", "artifact_id"],
+      "properties": {
+        "kind": {"const": "VETO_EDGE"},
+        "target_edge_id": {"type": "string", "minLength": 1},
+        "reason_code": {"type": "string", "minLength": 1},
+        "reason_detail": {"type": "string"},
+        "artifact_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "SplitEntityOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "entity_id", "replacement_entity_ids", "reason_code", "artifact_id"],
+      "properties": {
+        "kind": {"const": "SPLIT_ENTITY"},
+        "entity_id": {"type": "string", "minLength": 1},
+        "replacement_entity_ids": {
+          "type": "array",
+          "minItems": 2,
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "reason_code": {"type": "string", "minLength": 1},
+        "artifact_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "UnmergeEntityOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "entity_id", "member_node_ids", "reason_code", "artifact_id"],
+      "properties": {
+        "kind": {"const": "UNMERGE_ENTITY"},
+        "entity_id": {"type": "string", "minLength": 1},
+        "member_node_ids": {
+          "type": "array",
+          "minItems": 2,
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true
+        },
+        "reason_code": {"type": "string", "minLength": 1},
+        "artifact_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "RevokeEdgeOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "target_edge_id", "reason_code", "artifact_id"],
+      "properties": {
+        "kind": {"const": "REVOKE_EDGE"},
+        "target_edge_id": {"type": "string", "minLength": 1},
+        "reason_code": {"type": "string", "minLength": 1},
+        "artifact_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "ExpireNodeOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "target_node_id", "effective_valid_to", "artifact_id"],
+      "properties": {
+        "kind": {"const": "EXPIRE_NODE"},
+        "target_node_id": {"type": "string", "minLength": 1},
+        "effective_valid_to": {"type": "string", "format": "date-time"},
+        "artifact_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "ExpireEdgeOperation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "target_edge_id", "effective_valid_to", "artifact_id"],
+      "properties": {
+        "kind": {"const": "EXPIRE_EDGE"},
+        "target_edge_id": {"type": "string", "minLength": 1},
+        "effective_valid_to": {"type": "string", "format": "date-time"},
+        "artifact_id": {"type": "string", "minLength": 1}
+      }
+    }
+  }
+}

--- a/apps/regis-acr-api/schemas/node.schema.json
+++ b/apps/regis-acr-api/schemas/node.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/regis/node.schema.json",
+  "title": "Regis Graph Node",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "node_id",
+    "kind",
+    "valid_time",
+    "system_time",
+    "attrs",
+    "provenance"
+  ],
+  "properties": {
+    "node_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "PERSON",
+        "PSEUDONYM",
+        "RECORD",
+        "FEATURE_ATOM",
+        "EVENT",
+        "DEVICE",
+        "APP",
+        "SCOPE",
+        "SESSION",
+        "ENTITY_CLUSTER",
+        "ORG",
+        "ROLE",
+        "SERVICE_WORKLOAD",
+        "CREDENTIAL",
+        "PROOF_ARTIFACT",
+        "PROOF_INGRESS_RECORD",
+        "POLICY_WITNESS",
+        "CONSENT_WITNESS",
+        "SOURCE_GRAPH_VIEW",
+        "SOURCE_AUDIT_RECORD"
+      ]
+    },
+    "labels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "uniqueItems": true,
+      "default": []
+    },
+    "prime_support": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z][A-Z0-9_]*$"
+      },
+      "uniqueItems": true,
+      "default": []
+    },
+    "scope_tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Z][A-Z0-9_]*$"
+      },
+      "uniqueItems": true,
+      "default": []
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "REVOKED",
+        "EXPIRED"
+      ],
+      "default": "ACTIVE"
+    },
+    "valid_time": {
+      "$ref": "#/$defs/TimeRange"
+    },
+    "system_time": {
+      "$ref": "#/$defs/SystemTimeRange"
+    },
+    "attrs": {
+      "type": "object"
+    },
+    "provenance": {
+      "$ref": "#/$defs/Provenance"
+    }
+  },
+  "$defs": {
+    "Timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "TimeRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "to"],
+      "properties": {
+        "from": {"$ref": "#/$defs/Timestamp"},
+        "to": {
+          "anyOf": [
+            {"$ref": "#/$defs/Timestamp"},
+            {"type": "null"}
+          ]
+        }
+      }
+    },
+    "SystemTimeRange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from_version", "to_version"],
+      "properties": {
+        "from_version": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "to_version": {
+          "anyOf": [
+            {"type": "integer", "minimum": 0},
+            {"type": "null"}
+          ]
+        }
+      }
+    },
+    "Provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_event_ids", "artifact_ids"],
+      "properties": {
+        "source_event_ids": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true,
+          "default": []
+        },
+        "artifact_ids": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true,
+          "default": []
+        },
+        "witness_ids": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true,
+          "default": []
+        },
+        "delta_ids": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true,
+          "default": []
+        }
+      }
+    }
+  }
+}

--- a/apps/regis-acr-api/schemas/proof-certificate.schema.json
+++ b/apps/regis-acr-api/schemas/proof-certificate.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/regis/proof/proof-certificate.schema.json",
+  "title": "ProofCertificate",
+  "type": "object",
+  "required": ["proof_certificate_id", "schema_version", "policy_version", "claim_type", "result", "certificate_hash", "evidence_refs"],
+  "properties": {
+    "proof_certificate_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "policy_version": {"type": "string"},
+    "claim_type": {"type": "string", "enum": ["ProveLinkage", "ProveNoAdmissiblePath", "ProveScopePermission", "ProveTokenNonEscape", "ProveGoldenRecordAtTime", "VerifyCertificate"]},
+    "result": {"type": "string", "enum": ["VERIFIED", "REFUTED", "UNDECIDABLE", "STALE", "REQUIRES_REVIEW"]},
+    "reason_codes": {"type": "array", "items": {"type": "string"}, "default": []},
+    "evidence_refs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+    "ledger_pointers": {"type": "array", "items": {"type": "string"}, "default": []},
+    "graph_pointers": {"type": "array", "items": {"type": "string"}, "default": []},
+    "template_version": {"type": "string"},
+    "resolver_version": {"type": "string"},
+    "simulation_version": {"type": "string"},
+    "case_model_version": {"type": "string"},
+    "index_version": {"type": "string"},
+    "certificate_hash": {"type": "string", "pattern": "^sha256:.+"},
+    "canonical_mutation": {"type": "boolean", "default": false}
+  },
+  "additionalProperties": false
+}

--- a/apps/regis-acr-api/src/regis_acr_api/er_spine.py
+++ b/apps/regis-acr-api/src/regis_acr_api/er_spine.py
@@ -1,0 +1,219 @@
+"""Regis ER spine — the opt-in, subscription-gated entity-resolution plane.
+
+Executable spine (per regis-entity-graph ER/NER integration plan):
+    event-ir/ingest -> resolve/entities -> policy/check -> graph/upsert -> proof
+
+ARCHITECTURAL PRINCIPLE (Michael, 2026-07-03): this is an **opt-in subscription** cloud plane.
+The sovereign **local-first core (Noetica) operates fully without it** — sensitive inference stays
+on-device. This plane activates only under an explicit entitlement, and only ever sees data the
+user opts to share (after local masking / policy-veto). Nothing here is required for Noetica to run.
+
+Emitted envelopes conform to the regis-entity-graph domain schemas (vendored in ../schemas):
+node.schema.json, graph_delta.schema.json, proof-certificate.schema.json.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Header, HTTPException
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/v1", tags=["er-spine"])
+
+SCHEMA_VERSION = "0.1.0"
+POLICY_VERSION = "policy://regis-acr/er-spine@0.1.0"
+SOURCE_REPO = "SocioProphet/regis-entity-graph"
+
+# --- the opt-in / subscription declaration (readable without entitlement) ------------------
+PLANE_INFO: Dict[str, Any] = {
+    "plane": "identity-entity-resolution",
+    "activation": "opt-in-subscription",
+    "local_first_core": "Noetica",
+    "principle": (
+        "This cloud entity-resolution plane is ADDITIVE and OPT-IN. The sovereign local-first core "
+        "(Noetica) operates fully without it; sensitive inference stays on-device. This plane "
+        "activates only under an explicit subscription entitlement and only sees data the user opts "
+        "to share after local masking / policy-veto."
+    ),
+}
+
+# --- entitlement gate: the subscription boundary -------------------------------------------
+def require_entitlement(x_regis_entitlement: Optional[str] = Header(default=None)) -> Dict[str, str]:
+    """Opt-in gate. Without a subscription entitlement the plane is inert (402), which is the
+    point: Noetica never depends on this — you must explicitly turn it on."""
+    if os.environ.get("REGIS_ENTITLEMENT_ALLOW_ALL") == "1":
+        return {"subscription": "dev-allow-all"}
+    if not x_regis_entitlement:
+        raise HTTPException(
+            status_code=402,
+            detail=(
+                "The Regis entity-resolution plane is an opt-in subscription. Provide an "
+                "X-Regis-Entitlement token to activate it. The local-first Noetica core runs "
+                "without this plane."
+            ),
+        )
+    return {"subscription": x_regis_entitlement}
+
+
+# --- in-memory graph (hellgraph backing is the next slice) ---------------------------------
+_NODES: Dict[str, Dict[str, Any]] = {}
+_PROOFS: Dict[str, Dict[str, Any]] = {}
+_EVENT_LOG: List[Dict[str, Any]] = []
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _sha256(obj: Any) -> str:
+    return "sha256:" + hashlib.sha256(json.dumps(obj, sort_keys=True, default=str).encode()).hexdigest()
+
+
+def _make_node(node_id: str, kind: str, attrs: Dict[str, Any], scope: str, event_ids: List[str]) -> Dict[str, Any]:
+    """Conforms to node.schema.json: valid_time=TimeRange{from,to}, system_time=SystemTimeRange
+    {from_version,to_version}, provenance=Provenance{source_event_ids,artifact_ids}. `to`/`to_version`
+    null = open-ended (current). Scope is carried on attrs (schema-open object)."""
+    return {
+        "node_id": node_id,
+        "kind": kind,
+        "valid_time": {"from": _now(), "to": None},
+        "system_time": {"from_version": 0, "to_version": None},
+        "attrs": {**attrs, "scope": scope},
+        "provenance": {"source_event_ids": event_ids, "artifact_ids": []},
+    }
+
+
+def _make_delta(operations: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Conforms to graph_delta.schema.json."""
+    trace = _sha256(operations)
+    return {
+        "delta_id": f"delta-{uuid4()}",
+        "schema_version": SCHEMA_VERSION,
+        "emitted_at": _now(),
+        "source_repo": SOURCE_REPO,
+        "source_run_id": f"regis-acr-{uuid4()}",
+        "trace_hash": trace,
+        "operations": operations,
+    }
+
+
+def _make_proof(claim_type: str, result: str, evidence_refs: List[str]) -> Dict[str, Any]:
+    """Conforms to proof-certificate.schema.json (result/claim_type enums; certificate_hash sha256:)."""
+    body = {
+        "proof_certificate_id": f"proof-{uuid4()}",
+        "schema_version": SCHEMA_VERSION,
+        "policy_version": POLICY_VERSION,
+        "claim_type": claim_type,
+        "result": result,
+        "evidence_refs": evidence_refs or [f"artifact://regis-acr/{uuid4()}"],
+    }
+    body["certificate_hash"] = _sha256(body)
+    _PROOFS[body["proof_certificate_id"]] = body
+    return body
+
+
+# --- request models -------------------------------------------------------------------------
+class EventIR(BaseModel):
+    event_id: str = Field(default_factory=lambda: f"evt-{uuid4()}")
+    scope: str = Field(default="CITIZEN_FOG", description="fog-first scope realm")
+    kind: str = "OBSERVATION"
+    payload: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ResolveRequest(BaseModel):
+    scope: str = "CITIZEN_FOG"
+    mentions: List[Dict[str, Any]] = Field(default_factory=list)
+    candidates: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class PolicyCheckRequest(BaseModel):
+    action: str = "MERGE"
+    src_scope: str = "CITIZEN_FOG"
+    dst_scope: str = "CITIZEN_FOG"
+
+
+# --- the spine ------------------------------------------------------------------------------
+@router.get("/plane-info")
+def plane_info() -> Dict[str, Any]:
+    """Readable without entitlement — states the opt-in / local-first principle."""
+    return PLANE_INFO
+
+
+@router.post("/event-ir/ingest")
+def event_ir_ingest(evt: EventIR, ent=Header(default=None, alias="X-Regis-Entitlement")) -> Dict[str, Any]:
+    require_entitlement(ent)
+    record = {"event_id": evt.event_id, "scope": evt.scope, "kind": evt.kind, "ingested_at": _now()}
+    _EVENT_LOG.append(record)
+    return {"accepted": True, "event": record, "log_len": len(_EVENT_LOG)}
+
+
+@router.post("/policy/check")
+def policy_check(req: PolicyCheckRequest, ent=Header(default=None, alias="X-Regis-Entitlement")) -> Dict[str, Any]:
+    require_entitlement(ent)
+    # policy veto: a merge that crosses a protective scope boundary is vetoed (identity-is-prime:
+    # prime roles must not be silently multiplied across scopes).
+    crossing = req.src_scope != req.dst_scope
+    vetoed = req.action == "MERGE" and crossing
+    decision = "VETOED" if vetoed else "ADMITTED"
+    proof = _make_proof(
+        "ProveScopePermission",
+        "REFUTED" if vetoed else "VERIFIED",
+        [f"scope://{req.src_scope}", f"scope://{req.dst_scope}"],
+    )
+    return {"decision": decision, "vetoed": vetoed, "reason": "cross-scope merge" if vetoed else "same-scope", "proof_ref": proof["proof_certificate_id"]}
+
+
+@router.post("/resolve/entities")
+def resolve_entities(req: ResolveRequest, ent=Header(default=None, alias="X-Regis-Entitlement")) -> Dict[str, Any]:
+    require_entitlement(ent)
+    node_id = f"entity-{uuid4()}"
+    n_ev = max(len(req.mentions), len(req.candidates), 1)
+    result = "VERIFIED" if n_ev >= 2 else "REQUIRES_REVIEW"  # explainable, uncertainty-aware
+    event_ids = [m.get("event_id", f"evt-{i}") for i, m in enumerate(req.mentions)] or ["evt-none"]
+    node = _make_node(node_id, "ENTITY_CLUSTER", {"n_mentions": len(req.mentions), "n_candidates": len(req.candidates)}, req.scope, event_ids)
+    _NODES[node_id] = node
+    delta = _make_delta([{"kind": "UPSERT_NODE", "node": node}])
+    proof = _make_proof("ProveLinkage", result, [f"mention://{i}" for i in range(len(req.mentions))] or ["mention://none"])
+    return {
+        "decision": "MERGE" if result == "VERIFIED" else "POSSIBLE_MATCH",
+        "entity_id": node_id,
+        "confidence": round(min(1.0, 0.5 + 0.2 * n_ev), 3),
+        "result": result,
+        "graph_delta": delta,
+        "proof_ref": proof["proof_certificate_id"],
+    }
+
+
+@router.post("/graph/upsert")
+def graph_upsert(delta: Dict[str, Any], ent=Header(default=None, alias="X-Regis-Entitlement")) -> Dict[str, Any]:
+    require_entitlement(ent)
+    applied = 0
+    for op in delta.get("operations", []):
+        if op.get("kind") == "UPSERT_NODE" and "node" in op:
+            node = op["node"]
+            _NODES[node["node_id"]] = node
+            applied += 1
+    return {"applied": applied, "delta_id": delta.get("delta_id")}
+
+
+@router.get("/graph/entity/{node_id}")
+def get_entity(node_id: str, ent=Header(default=None, alias="X-Regis-Entitlement")) -> Dict[str, Any]:
+    require_entitlement(ent)
+    node = _NODES.get(node_id)
+    if not node:
+        raise HTTPException(status_code=404, detail=f"entity {node_id} not found")
+    return node
+
+
+@router.get("/proof/{proof_id}")
+def get_proof(proof_id: str, ent=Header(default=None, alias="X-Regis-Entitlement")) -> Dict[str, Any]:
+    require_entitlement(ent)
+    proof = _PROOFS.get(proof_id)
+    if not proof:
+        raise HTTPException(status_code=404, detail=f"proof {proof_id} not found")
+    return proof

--- a/apps/regis-acr-api/src/regis_acr_api/main.py
+++ b/apps/regis-acr-api/src/regis_acr_api/main.py
@@ -13,6 +13,12 @@ DEFAULT_POLICY_ID = "policy://regis-acr/default-promotion@0.1.0"
 
 app = FastAPI(title="Regis ACR API", version=SERVICE_VERSION)
 
+# Opt-in, subscription-gated entity-resolution spine. Additive to the ACR endpoints below;
+# the local-first Noetica core never depends on it (see er_spine.PLANE_INFO).
+from regis_acr_api import er_spine  # noqa: E402
+
+app.include_router(er_spine.router)
+
 
 class SourceRecordIngestRequest(BaseModel):
     source_record_id: str = Field(..., description="Stable source record id")

--- a/apps/regis-acr-api/tests/test_er_spine.py
+++ b/apps/regis-acr-api/tests/test_er_spine.py
@@ -1,0 +1,93 @@
+"""ER spine tests: opt-in entitlement gate, spine end-to-end, and schema-conformant emission.
+
+The schema-validation tests are the strong fitness signal — emitted graph_delta / proof-certificate
+envelopes are validated against the vendored regis-entity-graph domain schemas.
+"""
+import json
+import pathlib
+
+import jsonschema
+from fastapi.testclient import TestClient
+
+from regis_acr_api.main import app
+
+client = TestClient(app)
+SCHEMAS = pathlib.Path(__file__).resolve().parents[1] / "schemas"
+ENT = {"X-Regis-Entitlement": "sub-test-token"}
+
+
+def _schema(name: str) -> dict:
+    return json.loads((SCHEMAS / name).read_text())
+
+
+# --- opt-in / subscription gate -------------------------------------------------------------
+def test_plane_info_readable_without_entitlement():
+    r = client.get("/v1/plane-info")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["activation"] == "opt-in-subscription"
+    assert body["local_first_core"] == "Noetica"
+
+
+def test_spine_gated_without_entitlement():
+    # every spine endpoint is inert (402) until the subscription is opted-in
+    assert client.post("/v1/event-ir/ingest", json={}).status_code == 402
+    assert client.post("/v1/resolve/entities", json={}).status_code == 402
+    assert client.post("/v1/policy/check", json={}).status_code == 402
+    r = client.post("/v1/resolve/entities", json={})
+    assert "opt-in subscription" in r.json()["detail"]
+
+
+def test_spine_active_with_entitlement():
+    r = client.post("/v1/event-ir/ingest", json={"scope": "CITIZEN_FOG"}, headers=ENT)
+    assert r.status_code == 200 and r.json()["accepted"] is True
+
+
+# --- spine end-to-end + schema conformance --------------------------------------------------
+def test_resolve_emits_conformant_delta_and_proof():
+    r = client.post(
+        "/v1/resolve/entities",
+        json={"scope": "CITIZEN_FOG", "mentions": [{"text": "a"}, {"text": "b"}]},
+        headers=ENT,
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["result"] == "VERIFIED"  # >=2 evidence
+    # graph_delta validates against the domain schema
+    jsonschema.validate(body["graph_delta"], _schema("graph_delta.schema.json"))
+    # the upserted node validates too
+    node = body["graph_delta"]["operations"][0]["node"]
+    jsonschema.validate(node, _schema("node.schema.json"))
+    # proof-certificate is retrievable and conformant
+    proof = client.get(f"/v1/proof/{body['proof_ref']}", headers=ENT).json()
+    jsonschema.validate(proof, _schema("proof-certificate.schema.json"))
+    assert proof["claim_type"] == "ProveLinkage"
+    assert proof["certificate_hash"].startswith("sha256:")
+
+
+def test_single_mention_requires_review():
+    r = client.post("/v1/resolve/entities", json={"mentions": [{"text": "a"}]}, headers=ENT)
+    assert r.json()["result"] == "REQUIRES_REVIEW"
+
+
+def test_policy_vetoes_cross_scope_merge():
+    r = client.post(
+        "/v1/policy/check",
+        json={"action": "MERGE", "src_scope": "CITIZEN_FOG", "dst_scope": "ADTECH"},
+        headers=ENT,
+    )
+    body = r.json()
+    assert body["vetoed"] is True and body["decision"] == "VETOED"
+    proof = client.get(f"/v1/proof/{body['proof_ref']}", headers=ENT).json()
+    assert proof["result"] == "REFUTED"
+
+
+def test_graph_upsert_roundtrip():
+    delta = client.post(
+        "/v1/resolve/entities", json={"mentions": [{"text": "x"}, {"text": "y"}]}, headers=ENT
+    ).json()["graph_delta"]
+    node_id = delta["operations"][0]["node"]["node_id"]
+    up = client.post("/v1/graph/upsert", json=delta, headers=ENT)
+    assert up.status_code == 200 and up.json()["applied"] == 1
+    got = client.get(f"/v1/graph/entity/{node_id}", headers=ENT)
+    assert got.status_code == 200 and got.json()["node_id"] == node_id

--- a/docs/REGIS_ACR_SERVICE_INTEGRATION.md
+++ b/docs/REGIS_ACR_SERVICE_INTEGRATION.md
@@ -157,3 +157,24 @@ Initial validation should check:
 - The service accepts a source-record fixture and emits an evidence/decision response.
 - Promotion evaluation is policy-gated and does not auto-promote low-margin matches.
 - Ontogenesis relationship hook fixture is emitted but not forced into canonical state.
+
+## Entity-resolution spine — opt-in subscription plane (local-first boundary)
+
+The ER spine (`src/regis_acr_api/er_spine.py`, mounted under `/v1`) implements the executable
+identity flow `event-ir/ingest → resolve/entities → policy/check → graph/upsert → proof/{id}`.
+
+**This is an opt-in, subscription-gated *cloud* plane — not part of the local-first core.**
+
+- Every spine endpoint requires an `X-Regis-Entitlement` subscription token (or
+  `REGIS_ENTITLEMENT_ALLOW_ALL=1` in dev). Without it the plane is inert (HTTP `402`). This is
+  the architectural point: activation is explicit, never implicit.
+- `GET /v1/plane-info` is readable without entitlement and states the principle.
+- **The sovereign local-first core (Noetica) MUST NOT hard-depend on this plane.** Sensitive
+  inference stays on-device; this plane only ever sees data the user opts to share (after local
+  masking / policy-veto). Noetica runs fully with this service absent.
+- Emitted `graph_delta` and `proof-certificate` envelopes conform to the regis-entity-graph domain
+  schemas (vendored under `apps/regis-acr-api/schemas/`); conformance is enforced by `pytest`.
+- Policy veto is explainable: a `MERGE` crossing a protective scope boundary (e.g.
+  `CITIZEN_FOG → ADTECH`) is `VETOED` with a `REFUTED` `ProveScopePermission` certificate.
+- Backing store is in-memory in this slice; the hellgraph EntityNode/EdgeWitness backing is the
+  next slice.


### PR DESCRIPTION
## What

Adds the executable **entity-resolution spine** to `regis-acr-api`, conforming to the regis-entity-graph ER/NER integration plan:

```
POST /v1/event-ir/ingest → POST /v1/resolve/entities → POST /v1/policy/check
     → POST /v1/graph/upsert → GET /v1/proof/{id}   (+ GET /v1/graph/entity/{id})
```

## Architectural principle: opt-in / subscription, local-first core

Per Michael's direction — **these plane services are opt-in/subscription services in our platform; Noetica has to be local-first.**

- Every spine endpoint requires an `X-Regis-Entitlement` subscription token (or `REGIS_ENTITLEMENT_ALLOW_ALL=1` in dev). Without it the plane is **inert (HTTP 402)** — activation is explicit, never implicit.
- `GET /v1/plane-info` (no entitlement needed) declares the boundary: this cloud ER plane is additive/opt-in; the **local-first Noetica core operates fully without it** and never hard-depends on it. Sensitive inference stays on-device; the plane only sees opt-in-shared, post-masking data.

## Conformance (strong fitness signal)

- Emitted `graph_delta` + `proof-certificate` envelopes are **validated against the vendored regis-entity-graph domain schemas** (`node` / `graph_delta` / `proof-certificate`) under `pytest` — not just structurally asserted.
- Explainable policy veto: a `MERGE` crossing a protective scope boundary (`CITIZEN_FOG → ADTECH`) is `VETOED` with a `REFUTED` `ProveScopePermission` certificate.
- Uncertainty-aware: <2 evidence → `REQUIRES_REVIEW` (not silent merge).

## Tests / CI

- 10 unit tests: entitlement gate (402 without / active with), spine end-to-end, graph upsert roundtrip, schema conformance.
- Wired into `regis-acr-service.yml` (new pytest step; existing validate + smoke tools still pass with the router mounted).

## Scope / next slice

In-memory backing in this slice; hellgraph `EntityNode`/`EdgeWitness` backing is the next slice. Domain semantics/schemas remain owned by regis-entity-graph (schemas vendored here per the service-binding doc).