### PR TITLE
regis-acr-api: pluggable graph backend — local-first default, hellgraph opt-in

### DIFF
--- a/apps/regis-acr-api/src/regis_acr_api/er_spine.py
+++ b/apps/regis-acr-api/src/regis_acr_api/er_spine.py
@@ -23,6 +23,8 @@ from uuid import uuid4
 from fastapi import APIRouter, Header, HTTPException
 from pydantic import BaseModel, Field
 
+from regis_acr_api.graph_backend import get_backend
+
 router = APIRouter(prefix="/v1", tags=["er-spine"])
 
 SCHEMA_VERSION = "0.1.0"
@@ -60,8 +62,9 @@ def require_entitlement(x_regis_entitlement: Optional[str] = Header(default=None
     return {"subscription": x_regis_entitlement}
 
 
-# --- in-memory graph (hellgraph backing is the next slice) ---------------------------------
-_NODES: Dict[str, Dict[str, Any]] = {}
+# --- graph backing: in-memory (local-first default) or hellgraph (opt-in, HELLGRAPH_SUPERPEER_URL) ---
+# see graph_backend.get_backend(). Proofs + the event log are receipts, not graph atoms, so they
+# stay in-process here.
 _PROOFS: Dict[str, Dict[str, Any]] = {}
 _EVENT_LOG: List[Dict[str, Any]] = []
 
@@ -141,7 +144,8 @@ class PolicyCheckRequest(BaseModel):
 @router.get("/plane-info")
 def plane_info() -> Dict[str, Any]:
     """Readable without entitlement — states the opt-in / local-first principle."""
-    return PLANE_INFO
+    b = get_backend()
+    return {**PLANE_INFO, "graph_backend": b.name, "graph_backend_health": b.health()}
 
 
 @router.post("/event-ir/ingest")
@@ -176,8 +180,8 @@ def resolve_entities(req: ResolveRequest, ent=Header(default=None, alias="X-Regi
     result = "VERIFIED" if n_ev >= 2 else "REQUIRES_REVIEW"  # explainable, uncertainty-aware
     event_ids = [m.get("event_id", f"evt-{i}") for i, m in enumerate(req.mentions)] or ["evt-none"]
     node = _make_node(node_id, "ENTITY_CLUSTER", {"n_mentions": len(req.mentions), "n_candidates": len(req.candidates)}, req.scope, event_ids)
-    _NODES[node_id] = node
     delta = _make_delta([{"kind": "UPSERT_NODE", "node": node}])
+    get_backend().apply_delta(delta)
     proof = _make_proof("ProveLinkage", result, [f"mention://{i}" for i in range(len(req.mentions))] or ["mention://none"])
     return {
         "decision": "MERGE" if result == "VERIFIED" else "POSSIBLE_MATCH",
@@ -192,19 +196,14 @@ def resolve_entities(req: ResolveRequest, ent=Header(default=None, alias="X-Regi
 @router.post("/graph/upsert")
 def graph_upsert(delta: Dict[str, Any], ent=Header(default=None, alias="X-Regis-Entitlement")) -> Dict[str, Any]:
     require_entitlement(ent)
-    applied = 0
-    for op in delta.get("operations", []):
-        if op.get("kind") == "UPSERT_NODE" and "node" in op:
-            node = op["node"]
-            _NODES[node["node_id"]] = node
-            applied += 1
-    return {"applied": applied, "delta_id": delta.get("delta_id")}
+    applied = get_backend().apply_delta(delta)
+    return {"applied": applied, "delta_id": delta.get("delta_id"), "backend": get_backend().name}
 
 
 @router.get("/graph/entity/{node_id}")
 def get_entity(node_id: str, ent=Header(default=None, alias="X-Regis-Entitlement")) -> Dict[str, Any]:
     require_entitlement(ent)
-    node = _NODES.get(node_id)
+    node = get_backend().get(node_id)
     if not node:
         raise HTTPException(status_code=404, detail=f"entity {node_id} not found")
     return node

--- a/apps/regis-acr-api/src/regis_acr_api/graph_backend.py
+++ b/apps/regis-acr-api/src/regis_acr_api/graph_backend.py
@@ -1,0 +1,150 @@
+"""Graph backing for the ER spine — local-first in-memory by default, hellgraph when opted-in.
+
+Backend selection (opt-in, keeps the plane local-first):
+  - `HELLGRAPH_SUPERPEER_URL` unset  -> InMemoryBackend (default; zero external dependency)
+  - `HELLGRAPH_SUPERPEER_URL` set    -> HellGraphBackend (federated sovereign graph)
+
+hellgraph's SuperPeer HTTP surface is READ + GOVERN only (`GET /health`, `GET /cut`,
+`POST /query`, `POST /admit`) — by design it "cannot forge or rewrite": sovereign writes go
+through a participant's own Hypercore log, never an HTTP write to the index. So the hellgraph
+backend:
+  - READS from the super-peer's materialized view via `POST /query` (Gremlin), and
+  - STAGES writes as graph_delta records in an outbox — the ingest contract a hellgraph
+    sovereign participant-writer (Hypercore append) consumes. It never POSTs writes to the
+    super-peer, which would violate the sovereignty model.
+
+Node <-> hellgraph atom mapping: regis node_id -> atom id (+ a `node_id` property for lookup),
+regis kind -> atom label, and the regis node body is carried in atom properties.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+import httpx
+
+
+@runtime_checkable
+class GraphBackend(Protocol):
+    name: str
+
+    def apply_delta(self, delta: Dict[str, Any]) -> int: ...
+    def get(self, node_id: str) -> Optional[Dict[str, Any]]: ...
+    def health(self) -> Dict[str, Any]: ...
+
+
+def _nodes_of(delta: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return [op["node"] for op in delta.get("operations", []) if op.get("kind") == "UPSERT_NODE" and "node" in op]
+
+
+class InMemoryBackend:
+    """Default local-first backing. Rebuildable, in-process, no external dependency."""
+
+    name = "in-memory"
+
+    def __init__(self) -> None:
+        self._nodes: Dict[str, Dict[str, Any]] = {}
+
+    def apply_delta(self, delta: Dict[str, Any]) -> int:
+        applied = 0
+        for node in _nodes_of(delta):
+            self._nodes[node["node_id"]] = node
+            applied += 1
+        return applied
+
+    def get(self, node_id: str) -> Optional[Dict[str, Any]]:
+        return self._nodes.get(node_id)
+
+    def health(self) -> Dict[str, Any]:
+        return {"backend": self.name, "nodes": len(self._nodes)}
+
+
+def _gremlin_by_id(node_id: str) -> str:
+    # node_id carried as an atom property; escape single quotes defensively.
+    safe = node_id.replace("'", "\\'")
+    return f"g.V().has('node_id', '{safe}')"
+
+
+def _atom_to_node(atom: Any) -> Optional[Dict[str, Any]]:
+    """Map a hellgraph atom {id,labels,properties} back to a regis node. The regis body rides in
+    properties; if that isn't present yet (writer slice not landed), return the raw atom."""
+    if isinstance(atom, dict):
+        props = atom.get("properties")
+        if isinstance(props, dict) and "node_id" in props:
+            return props
+        return atom
+    return None
+
+
+class HellGraphBackend:
+    """Reads the federated sovereign graph via the super-peer; stages writes for a participant-writer."""
+
+    name = "hellgraph"
+
+    def __init__(self, base_url: str, client: Optional[httpx.Client] = None, outbox: Optional[str] = None) -> None:
+        self._url = base_url.rstrip("/")
+        self._client = client or httpx.Client(timeout=5.0)
+        self._outbox = outbox  # optional durable append-only path for the ingest contract
+        self._staged: List[Dict[str, Any]] = []
+        self._mirror: Dict[str, Dict[str, Any]] = {}  # in-process read-after-write mirror
+
+    def apply_delta(self, delta: Dict[str, Any]) -> int:
+        # stage for the sovereign participant-writer; the super-peer is read+govern only.
+        self._staged.append(delta)
+        if self._outbox:
+            with open(self._outbox, "a", encoding="utf-8") as f:
+                f.write(json.dumps(delta) + "\n")
+        applied = 0
+        for node in _nodes_of(delta):
+            self._mirror[node["node_id"]] = node
+            applied += 1
+        return applied
+
+    def get(self, node_id: str) -> Optional[Dict[str, Any]]:
+        # prefer hellgraph's materialized view; fall back to the local write mirror.
+        try:
+            r = self._client.post(
+                f"{self._url}/query", json={"lang": "gremlin", "query": _gremlin_by_id(node_id)}
+            )
+            if r.status_code == 200:
+                values = ((r.json() or {}).get("results") or {}).get("values") or []
+                if values:
+                    node = _atom_to_node(values[0])
+                    if node:
+                        return node
+        except Exception:
+            pass  # federated read is best-effort; fall through to the mirror
+        return self._mirror.get(node_id)
+
+    def health(self) -> Dict[str, Any]:
+        base: Dict[str, Any] = {"backend": self.name, "superpeer_url": self._url, "staged_deltas": len(self._staged)}
+        try:
+            r = self._client.get(f"{self._url}/health")
+            base["reachable"] = r.status_code == 200
+            base["superpeer"] = r.json()
+        except Exception as e:  # opt-in cloud plane may be down; don't crash the service
+            base["reachable"] = False
+            base["error"] = str(e)
+        return base
+
+
+_BACKEND: Optional[GraphBackend] = None
+
+
+def get_backend() -> GraphBackend:
+    global _BACKEND
+    if _BACKEND is None:
+        url = os.environ.get("HELLGRAPH_SUPERPEER_URL")
+        _BACKEND = (
+            HellGraphBackend(url, outbox=os.environ.get("HELLGRAPH_DELTA_OUTBOX"))
+            if url
+            else InMemoryBackend()
+        )
+    return _BACKEND
+
+
+def reset_backend() -> None:
+    """Test/hot-reload hook — clears the memoized backend so env changes take effect."""
+    global _BACKEND
+    _BACKEND = None

--- a/apps/regis-acr-api/tests/test_graph_backend.py
+++ b/apps/regis-acr-api/tests/test_graph_backend.py
@@ -1,0 +1,106 @@
+"""Graph backend seam: in-memory (local-first default) vs hellgraph (opt-in).
+
+The hellgraph tests use httpx.MockTransport — real client code paths, no live super-peer.
+"""
+import os
+
+import httpx
+
+from regis_acr_api.graph_backend import (
+    HellGraphBackend,
+    InMemoryBackend,
+    get_backend,
+    reset_backend,
+)
+
+DELTA = {
+    "delta_id": "delta-1",
+    "operations": [
+        {"kind": "UPSERT_NODE", "node": {"node_id": "entity-x", "kind": "ENTITY_CLUSTER", "attrs": {}}}
+    ],
+}
+
+
+# --- default backend selection is local-first ----------------------------------------------
+def test_default_backend_is_in_memory(monkeypatch):
+    monkeypatch.delenv("HELLGRAPH_SUPERPEER_URL", raising=False)
+    reset_backend()
+    try:
+        assert get_backend().name == "in-memory"
+    finally:
+        reset_backend()
+
+
+def test_env_opts_into_hellgraph(monkeypatch):
+    monkeypatch.setenv("HELLGRAPH_SUPERPEER_URL", "http://superpeer.local:8080")
+    reset_backend()
+    try:
+        assert get_backend().name == "hellgraph"
+    finally:
+        monkeypatch.delenv("HELLGRAPH_SUPERPEER_URL", raising=False)
+        reset_backend()
+
+
+# --- in-memory backend ----------------------------------------------------------------------
+def test_in_memory_apply_get_health():
+    b = InMemoryBackend()
+    assert b.apply_delta(DELTA) == 1
+    assert b.get("entity-x")["kind"] == "ENTITY_CLUSTER"
+    assert b.get("missing") is None
+    assert b.health() == {"backend": "in-memory", "nodes": 1}
+
+
+# --- hellgraph backend: read via super-peer, write staged for sovereign participant ---------
+def _mock_superpeer(handler):
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_hellgraph_health_passthrough():
+    def handler(req: httpx.Request) -> httpx.Response:
+        assert req.url.path == "/health"
+        return httpx.Response(200, json={"ok": True, "nodes": 3, "writers": 2})
+
+    b = HellGraphBackend("http://sp", client=_mock_superpeer(handler))
+    h = b.health()
+    assert h["backend"] == "hellgraph" and h["reachable"] is True
+    assert h["superpeer"]["writers"] == 2
+
+
+def test_hellgraph_read_from_materialized_view():
+    def handler(req: httpx.Request) -> httpx.Response:
+        assert req.url.path == "/query"
+        body = req.read().decode()
+        assert "gremlin" in body and "entity-x" in body  # by-id gremlin query
+        atom = {"id": "entity-x", "labels": ["ENTITY_CLUSTER"], "properties": {"node_id": "entity-x", "kind": "ENTITY_CLUSTER"}}
+        return httpx.Response(200, json={"results": {"values": [atom], "count": 1}})
+
+    b = HellGraphBackend("http://sp", client=_mock_superpeer(handler))
+    node = b.get("entity-x")
+    assert node["node_id"] == "entity-x" and node["kind"] == "ENTITY_CLUSTER"
+
+
+def test_hellgraph_write_stages_and_mirrors(tmp_path):
+    outbox = tmp_path / "deltas.jsonl"
+
+    def empty_view(req: httpx.Request) -> httpx.Response:
+        # super-peer hasn't ingested the staged delta yet -> empty view
+        return httpx.Response(200, json={"results": {"values": [], "count": 0}})
+
+    b = HellGraphBackend("http://sp", client=_mock_superpeer(empty_view), outbox=str(outbox))
+    assert b.apply_delta(DELTA) == 1
+    # staged for the sovereign participant-writer (the ingest contract)
+    assert outbox.read_text().strip() != ""
+    assert len(b._staged) == 1
+    # read-after-write falls back to the local mirror while the view is still empty
+    assert b.get("entity-x")["node_id"] == "entity-x"
+
+
+def test_hellgraph_unreachable_is_soft():
+    def boom(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route")
+
+    b = HellGraphBackend("http://sp", client=_mock_superpeer(boom))
+    h = b.health()
+    assert h["reachable"] is False and "error" in h  # opt-in plane down != service crash
+    b.apply_delta(DELTA)
+    assert b.get("entity-x")["node_id"] == "entity-x"  # mirror still serves the write

--- a/docs/REGIS_ACR_SERVICE_INTEGRATION.md
+++ b/docs/REGIS_ACR_SERVICE_INTEGRATION.md
@@ -176,5 +176,18 @@ identity flow `event-ir/ingest → resolve/entities → policy/check → graph/u
   schemas (vendored under `apps/regis-acr-api/schemas/`); conformance is enforced by `pytest`.
 - Policy veto is explainable: a `MERGE` crossing a protective scope boundary (e.g.
   `CITIZEN_FOG → ADTECH`) is `VETOED` with a `REFUTED` `ProveScopePermission` certificate.
-- Backing store is in-memory in this slice; the hellgraph EntityNode/EdgeWitness backing is the
-  next slice.
+- Backing store is pluggable (`src/regis_acr_api/graph_backend.py`), selected by env — **local-first
+  by default, hellgraph when opted-in**:
+  - `HELLGRAPH_SUPERPEER_URL` **unset** → `InMemoryBackend` (default; rebuildable, no external
+    dependency — keeps the plane runnable standalone).
+  - `HELLGRAPH_SUPERPEER_URL` **set** → `HellGraphBackend`, the federated sovereign graph. hellgraph's
+    SuperPeer is **read + govern only** (`/health`, `/cut`, `/query`, `/admit`) — by design it "cannot
+    forge or rewrite". So the backend **reads** entities from the super-peer's materialized view
+    (`POST /query`, Gremlin) and **stages writes** as `graph_delta` records in an outbox
+    (`HELLGRAPH_DELTA_OUTBOX`) — the ingest contract a hellgraph sovereign participant-writer
+    (Hypercore append) consumes. It never POSTs writes to the super-peer, which would violate the
+    sovereignty model. Read-after-write is served from a local mirror until the writer ingests.
+  - `GET /v1/plane-info` reports the active `graph_backend` + its health; an unreachable super-peer
+    degrades softly (does not crash the service).
+  - Next slice (hellgraph repo): the sovereign participant-writer that tails the delta outbox and
+    appends regis nodes/edges to its Hypercore log (node_id→atom id + `node_id` property, kind→label).


### PR DESCRIPTION
## What

Backs the ER spine's graph with a **pluggable `GraphBackend`** (`src/regis_acr_api/graph_backend.py`), selected by env — local-first by default, hellgraph when opted-in. Follows #687.

| `HELLGRAPH_SUPERPEER_URL` | Backend | Behavior |
|---|---|---|
| unset (default) | `InMemoryBackend` | rebuildable, no external dependency — plane runs standalone |
| set | `HellGraphBackend` | federated sovereign graph via hellgraph SuperPeer |

## Respects hellgraph's sovereignty model

hellgraph's SuperPeer is **read + govern only** (`/health`, `/cut`, `/query`, `/admit`) — by design it *"cannot forge or rewrite"*; sovereign writes go through a participant's own Hypercore log, never an HTTP write to the index. So `HellGraphBackend`:

- **Reads** entities from the super-peer's materialized view via `POST /query` (Gremlin `g.V().has('node_id', …)`).
- **Stages writes** as `graph_delta` records in an outbox (`HELLGRAPH_DELTA_OUTBOX`) — the ingest contract a hellgraph **sovereign participant-writer** (Hypercore append) consumes. It **never POSTs writes** to the super-peer (that would violate the model). Read-after-write is served from a local mirror until the writer ingests.
- Unreachable super-peer **degrades softly** — `/v1/plane-info` reports `reachable: false`, the service doesn't crash.

## Wiring

- `resolve/entities`, `graph/upsert`, `graph/entity/{id}` all route through `get_backend()`.
- `GET /v1/plane-info` now reports the active `graph_backend` + its health.

## Tests

7 new backend tests via `httpx.MockTransport` (real client paths, no live super-peer): backend selection, in-memory apply/get/health, hellgraph health passthrough, Gremlin read from the materialized view, staged-write + outbox + mirror, soft-fail on unreachable. **17 tests total, green** (existing validate + smoke tools still pass).

## Next slice (hellgraph repo, my lane)

The sovereign participant-writer that tails the delta outbox and appends regis nodes/edges to its Hypercore log (`node_id`→atom id + `node_id` property, `kind`→label) — closes the write loop against the real federated graph.