### PR TITLE
feat(mount-intent): declarative storage intent → backend + retention/egress policy

### DIFF
--- a/.github/workflows/mount-intent.yml
+++ b/.github/workflows/mount-intent.yml
@@ -1,0 +1,32 @@
+name: mount-intent
+
+on:
+  push:
+    paths:
+      - 'libs/python/mount-intent/**'
+      - 'tools/validate_mount_intent_egress.py'
+      - 'infra/k8s/edge-twin-sync/**'
+      - '.github/workflows/mount-intent.yml'
+  pull_request:
+    paths:
+      - 'libs/python/mount-intent/**'
+      - 'tools/validate_mount_intent_egress.py'
+      - 'infra/k8s/edge-twin-sync/**'
+      - '.github/workflows/mount-intent.yml'
+
+jobs:
+  test-and-enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r libs/python/mount-intent/requirements-test.txt -e libs/python/mount-intent
+      - name: Unit tests (intents, policy gates, lifecycle, validator)
+        run: cd libs/python/mount-intent && pytest -q
+      - name: Enforce mount-intent egress policy on edge→twin sync
+        run: python tools/validate_mount_intent_egress.py

--- a/infra/k8s/edge-twin-sync/base/sync-cronjob.yaml
+++ b/infra/k8s/edge-twin-sync/base/sync-cronjob.yaml
@@ -15,6 +15,11 @@ metadata:
   namespace: socioprophet
   labels:
     bundle: edge-twin-sync
+  annotations:
+    # Declares what this job may egress to the cloud twin. Every listed intent MUST be
+    # egress-allowed (mount_intent.may_egress); tools/validate_mount_intent_egress.py fails
+    # the build otherwise. The HellGraph store is canonical_data (the source of truth).
+    mount-intent.socioprophet.io/egress: canonical_data
 spec:
   schedule: "*/30 * * * *"
   concurrencyPolicy: Forbid

--- a/libs/python/mount-intent/Makefile
+++ b/libs/python/mount-intent/Makefile
@@ -1,0 +1,11 @@
+.PHONY: install test validate
+
+install:
+	pip install -e ".[dev]"
+
+test:
+	pip install -q -r requirements-test.txt -e .
+	pytest -q
+
+validate:
+	python ../../../tools/validate_mount_intent_egress.py

--- a/libs/python/mount-intent/README.md
+++ b/libs/python/mount-intent/README.md
@@ -1,0 +1,59 @@
+# mount-intent
+
+Declare storage by **intent**, not by mechanism — and get the backend mount **and** the
+retention/egress/caching **policy** by construction. This is the storage-side counterpart to the
+ER plane's egress-masking / fog-scope discipline: sensitive or rebuildable data never leaves the
+device unless an intent explicitly, policy-permitted allows it.
+
+## Why
+
+The layered store model (canonical L1 → derived/rebuildable L2 → vendor-cache/TTL L3 → tool-runtime
+ephemeral L6) and its Policy Engine (gates **egress / caching / deletion**, records to an
+append-only audit log) implied a policy that used to live only in reviewers' heads and hand-wired
+volume manifests. This library makes it code.
+
+## Intent → layer → policy
+
+| intent | layer | retention | may egress | may vendor-cache |
+|--------|-------|-----------|:----------:|:----------------:|
+| `canonical_data` | canonical (L1) | durable | ✅ | ✅ |
+| `curated_corpus` | canonical (L1) | durable | ✅ | ✅ |
+| `derived_index` | derived (L2) | rebuildable | ❌ (rebuild at the twin) | ❌ |
+| `cache` | vendor-cache (L3) | ttl | ❌ | ✅ |
+| `scratch` | ephemeral (L6) | ephemeral | ❌ | ❌ |
+| `secrets` | ephemeral | ephemeral | ❌ **never** | ❌ |
+| `config_ro` | config | managed-ro | ❌ | ❌ |
+| `ipc_bridge` | node-local | ephemeral | ❌ | ❌ |
+
+**Only `canonical_data` and `curated_corpus` may ever egress** (and even then residency/ACLs still
+apply). Everything else is rebuildable, ephemeral, or sensitive and stays on the device.
+
+## Use
+
+```python
+from mount_intent import MountIntent, Runtime, resolve, may_egress, PolicyDecision
+
+resolve(MountIntent.DERIVED_INDEX, Runtime.PODMAN)
+# {'backend': {'kind': 'volume', 'options': 'local'}, 'retention': 'rebuildable',
+#  'policy': {'may_egress': False, 'may_cache': False}, ...}
+
+may_egress(MountIntent.SECRETS)            # False — never leaves the device
+PolicyDecision.egress(MountIntent.SECRETS) # auditable decision (gate, allowed, reason, decided_at)
+```
+
+`resolve` maps to the right backend per runtime — K8s PV/PVC (TopoLVM/local/NFS), emptyDir,
+Secret, configMap; Docker volume/tmpfs/bind/npipe; Podman volume/tmpfs/`:O` overlay/secret/bind.
+
+## Lifecycle
+
+`mount_intent.lifecycle` encodes the artifact state machine
+(`IngestedRaw → Normalized → Extracted → Indexed → Served → {VendorMaterialized, FlaggedRetention,
+LegalHold} → Deleted`). `transition()` refuses illegal moves and **blocks deletion under a legal
+hold**.
+
+## Enforcement
+
+`tools/validate_mount_intent_egress.py` gates the build: any edge→cloud-twin sync Job/CronJob must
+declare `mount-intent.socioprophet.io/egress: <intent>[,...]`, and every declared intent must be
+egress-allowed. Adding `derived_index` or `secrets` to a sync job — or omitting the annotation —
+fails CI. Runs in `mount-intent.yml`.

--- a/libs/python/mount-intent/pyproject.toml
+++ b/libs/python/mount-intent/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prophet-mount-intent"
+version = "0.1.0"
+description = "Declare storage by intent; get backend + retention/egress policy by construction"
+requires-python = ">=3.10"
+dependencies = [
+    "pydantic>=2.5",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.3", "pyyaml>=6"]

--- a/libs/python/mount-intent/pytest.ini
+++ b/libs/python/mount-intent/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/libs/python/mount-intent/requirements-test.txt
+++ b/libs/python/mount-intent/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest==8.3.5
+pydantic>=2.5
+pyyaml>=6

--- a/libs/python/mount-intent/src/mount_intent/__init__.py
+++ b/libs/python/mount-intent/src/mount_intent/__init__.py
@@ -1,0 +1,29 @@
+"""mount_intent — declare storage by intent; get backend + retention/egress policy by construction.
+
+    from mount_intent import MountIntent, Runtime, resolve, may_egress
+
+    resolve(MountIntent.DERIVED_INDEX, Runtime.PODMAN)   # backend + policy
+    may_egress(MountIntent.SECRETS)                       # -> False (never leaves the device)
+"""
+from .intents import (
+    EGRESSABLE_INTENTS,
+    IntentBinding,
+    Layer,
+    MountIntent,
+    Retention,
+    Runtime,
+    binding,
+    may_cache,
+    may_delete,
+    may_egress,
+    resolve,
+)
+from .lifecycle import ArtifactState, can_transition, is_terminal, transition
+from .schema import MountDeclaration, PolicyDecision
+
+__all__ = [
+    "MountIntent", "Layer", "Retention", "Runtime", "IntentBinding",
+    "binding", "resolve", "may_egress", "may_cache", "may_delete", "EGRESSABLE_INTENTS",
+    "ArtifactState", "can_transition", "transition", "is_terminal",
+    "MountDeclaration", "PolicyDecision",
+]

--- a/libs/python/mount-intent/src/mount_intent/intents.py
+++ b/libs/python/mount-intent/src/mount_intent/intents.py
@@ -1,0 +1,182 @@
+"""Mount intent → backend + retention/egress policy.
+
+Storage in the platform is declared by INTENT (what the data means), not by mechanism
+(how it is mounted). The intent determines three things by construction:
+
+  1. the backend mount for the target container runtime (K8s / Docker / Podman-rootful),
+  2. the store LAYER it belongs to, and
+  3. the retention/egress/caching POLICY that governs whether it may ever leave the device.
+
+This encodes the layered store model (diagram: Layer 1 Canonical Object Store → Layer 2 Derived
+Stores [disposable, rebuildable] → Layer 3 Vendor Cache [TTL/GC] → Layer 6 Tool Runtime
+[ephemeral]) and the Policy Engine that gates egress / caching / deletion. It is the storage-side
+counterpart to the ER plane's egress-masking / fog-scope discipline (apps/regis-acr-api): the same
+principle — sensitive data never leaves the device unless explicitly, policy-permitted.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class MountIntent(str, Enum):
+    """What a mounted path MEANS. The only vocabulary workloads should declare."""
+
+    CANONICAL_DATA = "canonical_data"   # source of truth (person-graph, canon)
+    CURATED_CORPUS = "curated_corpus"   # segmented commons (OCW/academy), durable + cacheable
+    DERIVED_INDEX = "derived_index"     # chunks/keyword/vectors — rebuildable from canonical
+    SCRATCH = "scratch"                 # per-run working space
+    CACHE = "cache"                     # vendor/file-handle cache, TTL/GC
+    SECRETS = "secrets"                 # credentials/keys
+    CONFIG_RO = "config_ro"             # read-only configuration
+    IPC_BRIDGE = "ipc_bridge"           # local agent↔agent channel (socket/pipe)
+
+
+class Layer(str, Enum):
+    """Store layer (diagram 1)."""
+
+    CANONICAL = "canonical"       # L1 — durable object store, BYOS, residency-governed
+    DERIVED = "derived"           # L2 — disposable, rebuildable from canonical
+    VENDOR_CACHE = "vendor_cache" # L3 — TTL/GC vendor materialization
+    EPHEMERAL = "ephemeral"       # L6 — tool-runtime scratch, gone at exit
+    CONFIG = "config"             # read-only config plane
+    NODE_LOCAL = "node_local"     # IPC — never leaves the node
+
+
+class Retention(str, Enum):
+    DURABLE = "durable"       # kept; deletion is policy-gated (retention scheduler + legal hold)
+    REBUILDABLE = "rebuildable"  # may be GC'd freely; rebuilt from canonical
+    TTL = "ttl"              # vendor cache: expires on TTL/GC, re-materialized from canonical
+    EPHEMERAL = "ephemeral"  # never persisted beyond the run
+    MANAGED_RO = "managed_ro"  # lifecycle owned by its source (ConfigMap/Secret)
+
+
+class Runtime(str, Enum):
+    KUBERNETES = "kubernetes"
+    DOCKER = "docker"
+    PODMAN = "podman"  # rootful on this Mac
+
+
+@dataclass(frozen=True)
+class IntentBinding:
+    """The full, policy-bearing binding for one intent."""
+
+    intent: MountIntent
+    layer: Layer
+    retention: Retention
+    may_egress: bool   # may this data ever leave the device (e.g. sync to the cloud twin)?
+    may_cache: bool    # may this be vendor-materialized (Layer 3 file handle)?
+    read_only: bool
+    # backend per runtime: (kind, options)
+    kubernetes: tuple[str, str]
+    docker: tuple[str, str]
+    podman: tuple[str, str]
+
+    def backend(self, runtime: Runtime) -> tuple[str, str]:
+        return {
+            Runtime.KUBERNETES: self.kubernetes,
+            Runtime.DOCKER: self.docker,
+            Runtime.PODMAN: self.podman,
+        }[runtime]
+
+
+# The single source of truth. Egress is ALLOWED only for canonical + curated (and even then the
+# Policy Engine still governs it); everything else is rebuildable, ephemeral, or sensitive and
+# MUST NOT leave the device. This is enforcement-by-construction, not documentation.
+_BINDINGS: dict[MountIntent, IntentBinding] = {
+    MountIntent.CANONICAL_DATA: IntentBinding(
+        MountIntent.CANONICAL_DATA, Layer.CANONICAL, Retention.DURABLE,
+        may_egress=True, may_cache=True, read_only=False,
+        kubernetes=("persistentVolumeClaim", "topolvm/local/nfs"),
+        docker=("volume", "local/driver"),
+        podman=("volume", "local"),
+    ),
+    MountIntent.CURATED_CORPUS: IntentBinding(
+        MountIntent.CURATED_CORPUS, Layer.CANONICAL, Retention.DURABLE,
+        may_egress=True, may_cache=True, read_only=True,
+        kubernetes=("persistentVolumeClaim", "topolvm/local/nfs"),
+        docker=("volume", "local/driver"),
+        podman=("volume", "local"),
+    ),
+    MountIntent.DERIVED_INDEX: IntentBinding(
+        MountIntent.DERIVED_INDEX, Layer.DERIVED, Retention.REBUILDABLE,
+        may_egress=False, may_cache=False, read_only=False,
+        kubernetes=("persistentVolumeClaim", "topolvm/local"),
+        docker=("volume", "local"),
+        podman=("volume", "local"),
+    ),
+    MountIntent.SCRATCH: IntentBinding(
+        MountIntent.SCRATCH, Layer.EPHEMERAL, Retention.EPHEMERAL,
+        may_egress=False, may_cache=False, read_only=False,
+        kubernetes=("emptyDir", ""),
+        docker=("tmpfs", ""),
+        podman=("tmpfs", ""),
+    ),
+    MountIntent.CACHE: IntentBinding(
+        MountIntent.CACHE, Layer.VENDOR_CACHE, Retention.TTL,
+        may_egress=False, may_cache=True, read_only=False,
+        kubernetes=("emptyDir", ""),
+        docker=("tmpfs", ""),
+        podman=("overlay", ":O"),
+    ),
+    MountIntent.SECRETS: IntentBinding(
+        MountIntent.SECRETS, Layer.EPHEMERAL, Retention.EPHEMERAL,
+        may_egress=False, may_cache=False, read_only=True,
+        kubernetes=("secret", "tmpfs-copy"),
+        docker=("tmpfs", "secret"),
+        podman=("secret", "mount/env"),
+    ),
+    MountIntent.CONFIG_RO: IntentBinding(
+        MountIntent.CONFIG_RO, Layer.CONFIG, Retention.MANAGED_RO,
+        may_egress=False, may_cache=False, read_only=True,
+        kubernetes=("configMap", "projected"),
+        docker=("bind", "ro"),
+        podman=("bind", "ro"),
+    ),
+    MountIntent.IPC_BRIDGE: IntentBinding(
+        MountIntent.IPC_BRIDGE, Layer.NODE_LOCAL, Retention.EPHEMERAL,
+        may_egress=False, may_cache=False, read_only=False,
+        kubernetes=("emptyDir", "socket"),
+        docker=("npipe", "named-pipe"),
+        podman=("bind", "socket"),
+    ),
+}
+
+
+def binding(intent: MountIntent) -> IntentBinding:
+    return _BINDINGS[intent]
+
+
+def resolve(intent: MountIntent, runtime: Runtime) -> dict:
+    """The backend mount spec + policy for an intent on a given runtime."""
+    b = binding(intent)
+    kind, options = b.backend(runtime)
+    return {
+        "intent": intent.value,
+        "runtime": runtime.value,
+        "layer": b.layer.value,
+        "retention": b.retention.value,
+        "backend": {"kind": kind, "options": options},
+        "read_only": b.read_only,
+        "policy": {"may_egress": b.may_egress, "may_cache": b.may_cache},
+    }
+
+
+# ── Policy gates (Layer 5: the Policy Engine gates egress / caching / deletion) ──────────────
+def may_egress(intent: MountIntent) -> bool:
+    """May data with this intent ever leave the device (e.g. sync to the cloud twin)?"""
+    return binding(intent).may_egress
+
+
+def may_cache(intent: MountIntent) -> bool:
+    """May this be vendor-materialized into a Layer-3 file handle?"""
+    return binding(intent).may_cache
+
+
+def may_delete(intent: MountIntent) -> bool:
+    """May this be GC'd/deleted without a retention decision? Durable data is retention-gated;
+    rebuildable/ttl/ephemeral data is freely collectable."""
+    return binding(intent).retention != Retention.DURABLE
+
+
+EGRESSABLE_INTENTS: frozenset[MountIntent] = frozenset(i for i in MountIntent if may_egress(i))

--- a/libs/python/mount-intent/src/mount_intent/lifecycle.py
+++ b/libs/python/mount-intent/src/mount_intent/lifecycle.py
@@ -1,0 +1,66 @@
+"""Artifact lifecycle state machine (diagram 2).
+
+Grounds retention: every artifact moves through a fixed set of states, and the Retention
+Scheduler / Policy Engine only advances it along permitted transitions. Legal hold and
+abuse/safety flags interpose *before* deletion; vendor materialization is a disposable side
+branch that always re-materializes from canonical.
+
+    IngestedRaw → Normalized → Extracted → Indexed → Served
+    Served ⇄ VendorMaterialized → ExpiredVendorCache → (re-materialize) → Served
+    Served → FlaggedRetention → (window ends) → Deleted
+    Served → LegalHold → (released) → Served | Deleted
+    Normalized|Extracted|Indexed → (retention policy) → Deleted
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ArtifactState(str, Enum):
+    INGESTED_RAW = "IngestedRaw"
+    NORMALIZED = "Normalized"
+    EXTRACTED = "Extracted"
+    INDEXED = "Indexed"
+    SERVED = "Served"
+    VENDOR_MATERIALIZED = "VendorMaterialized"
+    EXPIRED_VENDOR_CACHE = "ExpiredVendorCache"
+    FLAGGED_RETENTION = "FlaggedRetention"
+    LEGAL_HOLD = "LegalHold"
+    DELETED = "Deleted"
+
+
+_S = ArtifactState
+
+# Permitted transitions (edges in diagram 2). Any transition not listed is rejected.
+_TRANSITIONS: dict[ArtifactState, frozenset[ArtifactState]] = {
+    _S.INGESTED_RAW: frozenset({_S.NORMALIZED}),
+    _S.NORMALIZED: frozenset({_S.EXTRACTED, _S.DELETED}),
+    _S.EXTRACTED: frozenset({_S.INDEXED, _S.DELETED}),
+    _S.INDEXED: frozenset({_S.SERVED, _S.DELETED}),
+    _S.SERVED: frozenset({_S.VENDOR_MATERIALIZED, _S.FLAGGED_RETENTION, _S.LEGAL_HOLD}),
+    _S.VENDOR_MATERIALIZED: frozenset({_S.EXPIRED_VENDOR_CACHE}),
+    _S.EXPIRED_VENDOR_CACHE: frozenset({_S.SERVED}),  # re-materialize from canonical
+    _S.FLAGGED_RETENTION: frozenset({_S.DELETED, _S.SERVED}),  # window ends → delete; or cleared
+    _S.LEGAL_HOLD: frozenset({_S.SERVED, _S.DELETED}),  # released → serve; or policy-permitted delete
+    _S.DELETED: frozenset(),  # terminal
+}
+
+# A hold blocks deletion until released — deletion attempts from these states are refused.
+DELETION_BLOCKED_STATES: frozenset[ArtifactState] = frozenset({_S.LEGAL_HOLD})
+
+
+def can_transition(src: ArtifactState, dst: ArtifactState) -> bool:
+    return dst in _TRANSITIONS.get(src, frozenset())
+
+
+def transition(src: ArtifactState, dst: ArtifactState) -> ArtifactState:
+    """Advance state, refusing illegal moves and deletion under a hold."""
+    if dst == ArtifactState.DELETED and src in DELETION_BLOCKED_STATES:
+        raise ValueError(f"deletion blocked: {src.value} must be released before deletion")
+    if not can_transition(src, dst):
+        raise ValueError(f"illegal artifact transition: {src.value} → {dst.value}")
+    return dst
+
+
+def is_terminal(state: ArtifactState) -> bool:
+    return len(_TRANSITIONS.get(state, frozenset())) == 0

--- a/libs/python/mount-intent/src/mount_intent/schema.py
+++ b/libs/python/mount-intent/src/mount_intent/schema.py
@@ -1,0 +1,69 @@
+"""Declaration schema for a mount intent + the auditable policy decision.
+
+A workload declares a MountDeclaration (name → intent → path). The platform resolves it to a
+backend + policy, and every egress/caching/deletion decision produces an auditable
+PolicyDecision (Layer 5: the Policy Engine records events to the append-only Audit Log).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from .intents import MountIntent, Runtime, binding, resolve
+
+
+class MountDeclaration(BaseModel):
+    """What a workload declares for one mounted path."""
+
+    name: str = Field(..., description="volume/mount name")
+    intent: MountIntent
+    mount_path: str = Field(..., description="container path")
+
+    def resolved(self, runtime: Runtime) -> dict:
+        return {"name": self.name, "mount_path": self.mount_path, **resolve(self.intent, runtime)}
+
+
+Gate = Literal["egress", "caching", "deletion"]
+
+
+class PolicyDecision(BaseModel):
+    """An auditable decision by the Policy Engine for one gate on one intent."""
+
+    gate: Gate
+    intent: MountIntent
+    allowed: bool
+    reason: str
+    decided_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    @classmethod
+    def egress(cls, intent: MountIntent) -> "PolicyDecision":
+        b = binding(intent)
+        return cls(
+            gate="egress", intent=intent, allowed=b.may_egress,
+            reason=(
+                f"{intent.value} is layer={b.layer.value}; "
+                + ("egress permitted (still subject to residency/ACL)" if b.may_egress
+                   else "must not leave the device (rebuildable/ephemeral/sensitive)")
+            ),
+        )
+
+    @classmethod
+    def caching(cls, intent: MountIntent) -> "PolicyDecision":
+        b = binding(intent)
+        return cls(
+            gate="caching", intent=intent, allowed=b.may_cache,
+            reason=("vendor-materializable (re-materialized from canonical)" if b.may_cache
+                    else "not eligible for vendor caching"),
+        )
+
+    @classmethod
+    def deletion(cls, intent: MountIntent) -> "PolicyDecision":
+        from .intents import may_delete
+        allowed = may_delete(intent)
+        return cls(
+            gate="deletion", intent=intent, allowed=allowed,
+            reason=("freely collectable (rebuildable/ttl/ephemeral)" if allowed
+                    else "durable — deletion is retention-gated (scheduler + legal hold)"),
+        )

--- a/libs/python/mount-intent/tests/test_egress_validator.py
+++ b/libs/python/mount-intent/tests/test_egress_validator.py
@@ -1,0 +1,51 @@
+"""The egress validator must pass on the real repo and fail-closed on violations."""
+import importlib.util
+import pathlib
+
+import pytest
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[4]
+VALIDATOR = ROOT / "tools" / "validate_mount_intent_egress.py"
+
+
+def _load_validator():
+    spec = importlib.util.spec_from_file_location("veg", VALIDATOR)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_validator_passes_on_repo():
+    assert _load_validator().main() == 0
+
+
+def test_edge_twin_sync_declares_only_canonical():
+    cj = ROOT / "infra/k8s/edge-twin-sync/base/sync-cronjob.yaml"
+    doc = next(d for d in yaml.safe_load_all(cj.read_text()) if isinstance(d, dict) and d.get("kind") == "CronJob")
+    ann = doc["metadata"]["annotations"]["mount-intent.socioprophet.io/egress"]
+    assert ann == "canonical_data"  # only the source of truth crosses
+
+
+def test_validator_rejects_non_egressable(tmp_path, monkeypatch):
+    # a sync job that tries to egress derived_index must be refused
+    mod = _load_validator()
+    bad = tmp_path / "edge-twin-sync"
+    bad.mkdir()
+    (bad / "bad.yaml").write_text(
+        "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: leaky\n"
+        "  annotations:\n    mount-intent.socioprophet.io/egress: derived_index\nspec: {}\n"
+    )
+    monkeypatch.setattr(mod, "SYNC_DIR", bad)
+    assert mod.main() == 1
+
+
+def test_validator_fails_closed_on_missing_annotation(tmp_path, monkeypatch):
+    mod = _load_validator()
+    d = tmp_path / "edge-twin-sync"
+    d.mkdir()
+    (d / "nolabel.yaml").write_text(
+        "apiVersion: batch/v1\nkind: CronJob\nmetadata:\n  name: undeclared\nspec: {}\n"
+    )
+    monkeypatch.setattr(mod, "SYNC_DIR", d)
+    assert mod.main() == 1  # egress must be declared, not implicit

--- a/libs/python/mount-intent/tests/test_intents.py
+++ b/libs/python/mount-intent/tests/test_intents.py
@@ -1,0 +1,99 @@
+from mount_intent import (
+    EGRESSABLE_INTENTS,
+    ArtifactState,
+    Layer,
+    MountDeclaration,
+    MountIntent,
+    PolicyDecision,
+    Retention,
+    Runtime,
+    can_transition,
+    is_terminal,
+    may_cache,
+    may_delete,
+    may_egress,
+    resolve,
+    transition,
+)
+import pytest
+
+
+# ── the core sovereignty invariant: only canonical + curated may egress ─────────────────────
+def test_only_canonical_and_curated_may_egress():
+    assert EGRESSABLE_INTENTS == {MountIntent.CANONICAL_DATA, MountIntent.CURATED_CORPUS}
+
+
+@pytest.mark.parametrize(
+    "intent",
+    [MountIntent.DERIVED_INDEX, MountIntent.SCRATCH, MountIntent.CACHE,
+     MountIntent.SECRETS, MountIntent.CONFIG_RO, MountIntent.IPC_BRIDGE],
+)
+def test_sensitive_and_rebuildable_never_egress(intent):
+    assert may_egress(intent) is False
+
+
+def test_secrets_never_egress_or_cache():
+    assert may_egress(MountIntent.SECRETS) is False
+    assert may_cache(MountIntent.SECRETS) is False
+
+
+# ── every intent resolves to a real backend on every runtime ────────────────────────────────
+@pytest.mark.parametrize("runtime", list(Runtime))
+@pytest.mark.parametrize("intent", list(MountIntent))
+def test_resolve_covers_every_intent_runtime(intent, runtime):
+    spec = resolve(intent, runtime)
+    assert spec["backend"]["kind"]
+    assert spec["policy"]["may_egress"] == may_egress(intent)
+    assert spec["layer"] in {l.value for l in Layer}
+
+
+def test_derived_index_is_rebuildable_and_collectable():
+    assert resolve(MountIntent.DERIVED_INDEX, Runtime.PODMAN)["retention"] == Retention.REBUILDABLE.value
+    assert may_delete(MountIntent.DERIVED_INDEX) is True
+
+
+def test_canonical_is_durable_and_retention_gated():
+    assert may_delete(MountIntent.CANONICAL_DATA) is False  # deletion is retention-gated
+
+
+def test_podman_cache_uses_overlay():
+    assert resolve(MountIntent.CACHE, Runtime.PODMAN)["backend"] == {"kind": "overlay", "options": ":O"}
+
+
+# ── policy decisions are auditable ──────────────────────────────────────────────────────────
+def test_policy_decision_egress_is_auditable():
+    d = PolicyDecision.egress(MountIntent.SECRETS)
+    assert d.gate == "egress" and d.allowed is False and d.decided_at
+    assert PolicyDecision.egress(MountIntent.CANONICAL_DATA).allowed is True
+    assert PolicyDecision.deletion(MountIntent.CANONICAL_DATA).allowed is False
+
+
+def test_mount_declaration_resolves():
+    decl = MountDeclaration(name="store", intent=MountIntent.CANONICAL_DATA, mount_path="/store")
+    r = decl.resolved(Runtime.KUBERNETES)
+    assert r["backend"]["kind"] == "persistentVolumeClaim" and r["mount_path"] == "/store"
+
+
+# ── lifecycle state machine ─────────────────────────────────────────────────────────────────
+def test_happy_path_transitions():
+    s = ArtifactState.INGESTED_RAW
+    for nxt in (ArtifactState.NORMALIZED, ArtifactState.EXTRACTED, ArtifactState.INDEXED, ArtifactState.SERVED):
+        s = transition(s, nxt)
+    assert s == ArtifactState.SERVED
+
+
+def test_legal_hold_blocks_deletion():
+    with pytest.raises(ValueError, match="deletion blocked"):
+        transition(ArtifactState.LEGAL_HOLD, ArtifactState.DELETED)  # must be released first
+    # released path is allowed
+    assert transition(ArtifactState.LEGAL_HOLD, ArtifactState.SERVED) == ArtifactState.SERVED
+
+
+def test_illegal_transition_rejected():
+    with pytest.raises(ValueError, match="illegal artifact transition"):
+        transition(ArtifactState.INGESTED_RAW, ArtifactState.SERVED)
+
+
+def test_vendor_cache_rematerializes():
+    assert can_transition(ArtifactState.EXPIRED_VENDOR_CACHE, ArtifactState.SERVED)
+    assert is_terminal(ArtifactState.DELETED)

--- a/tools/validate_mount_intent_egress.py
+++ b/tools/validate_mount_intent_egress.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Enforce the mount-intent egress policy against edge→cloud-twin sync manifests.
+
+Any Job/CronJob that pushes data to the cloud twin must declare, via the annotation
+`mount-intent.socioprophet.io/egress: <intent>[,<intent>...]`, which mount intents it egresses —
+and every declared intent MUST be egress-allowed (mount_intent.may_egress). This turns the
+sovereignty rule ("derived indexes, secrets, scratch, config, ipc never leave the device") into a
+build-time gate: adding e.g. `derived_index` or `secrets` to a sync job fails CI.
+
+Fail-closed: a sync manifest under infra/k8s/edge-twin-sync that has NO egress annotation is an
+error too — egress must be declared, not implicit.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import yaml
+
+# import the library from libs/python/mount-intent/src without installing it
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "libs" / "python" / "mount-intent" / "src"))
+from mount_intent import EGRESSABLE_INTENTS, MountIntent  # noqa: E402
+
+ANNOTATION = "mount-intent.socioprophet.io/egress"
+SYNC_DIR = _ROOT / "infra" / "k8s" / "edge-twin-sync"
+EGRESS_KINDS = {"Job", "CronJob"}
+
+
+def _docs(path: pathlib.Path):
+    try:
+        return [d for d in yaml.safe_load_all(path.read_text()) if isinstance(d, dict)]
+    except yaml.YAMLError:
+        return []
+
+
+def main() -> int:
+    if not SYNC_DIR.exists():
+        print(f"no sync dir at {SYNC_DIR} — nothing to validate")
+        return 0
+
+    errors: list[str] = []
+    checked = 0
+    for path in sorted(SYNC_DIR.rglob("*.yaml")):
+        for doc in _docs(path):
+            if doc.get("kind") not in EGRESS_KINDS:
+                continue
+            checked += 1
+            name = doc.get("metadata", {}).get("name", "<unnamed>")
+            ann = (doc.get("metadata", {}).get("annotations") or {}).get(ANNOTATION)
+            if not ann:
+                errors.append(f"{path.name}: {doc['kind']}/{name} egresses to the twin but declares "
+                              f"no `{ANNOTATION}` annotation (egress must be declared)")
+                continue
+            for raw in [s.strip() for s in ann.split(",") if s.strip()]:
+                try:
+                    intent = MountIntent(raw)
+                except ValueError:
+                    errors.append(f"{path.name}: {name} declares unknown intent '{raw}'")
+                    continue
+                if intent not in EGRESSABLE_INTENTS:
+                    errors.append(
+                        f"{path.name}: {doc['kind']}/{name} declares egress of '{intent.value}', "
+                        f"which is NOT egress-allowed — it must never leave the device"
+                    )
+
+    if errors:
+        print("mount-intent egress policy VIOLATED:")
+        for e in errors:
+            print(f"  ✗ {e}")
+        return 1
+    print(f"mount-intent egress policy OK ({checked} sync job(s) checked; "
+          f"egress-allowed intents: {sorted(i.value for i in EGRESSABLE_INTENTS)})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Closes the verified gap (2026-07-03) where the mount-intent taxonomy from the storage architecture was **design-only** (`grep -rn 'canonical_data|derived_index|MountIntent'` → zero hits). Workloads now declare storage by **intent**; the library resolves each to the backend **and** the retention/egress/caching **policy** — by construction.

## The invariant it encodes

**Only `canonical_data` + `curated_corpus` may ever egress** (to the cloud twin). Everything else stays on the device:

| intent | layer | retention | egress | vendor-cache |
|--------|-------|-----------|:------:|:------------:|
| canonical_data / curated_corpus | canonical (L1) | durable | ✅ | ✅ |
| derived_index | derived (L2) | rebuildable | ❌ rebuild at twin | ❌ |
| cache | vendor-cache (L3) | ttl | ❌ | ✅ |
| scratch | ephemeral (L6) | ephemeral | ❌ | ❌ |
| secrets | ephemeral | ephemeral | ❌ **never** | ❌ |
| config_ro / ipc_bridge | config / node-local | managed / ephemeral | ❌ | ❌ |

This is the storage-side counterpart to the ER plane's egress-masking / fog-scope discipline.

## Grounded in the two diagrams

- **Layered store model** (canonical L1 / derived-rebuildable L2 / vendor-cache-TTL L3 / tool-runtime-ephemeral L6) → `Layer` + `Retention`.
- **Policy Engine gates** (egress / caching / deletion, records events) → `may_egress` / `may_cache` / `may_delete` + auditable `PolicyDecision`.
- **Artifact lifecycle** (`IngestedRaw → … → Served → {VendorMaterialized, FlaggedRetention, LegalHold} → Deleted`) → `mount_intent.lifecycle`, where `transition()` refuses illegal moves and **blocks deletion under a legal hold**.
- **Per-runtime backends** (K8s PV/PVC·emptyDir·Secret·configMap / Docker volume·tmpfs·bind·npipe / Podman volume·tmpfs·`:O` overlay·secret·bind) → `resolve(intent, runtime)`.

## Enforcement (not just a library)

`tools/validate_mount_intent_egress.py` gates the build: every edge→cloud-twin sync Job/CronJob must declare `mount-intent.socioprophet.io/egress: <intent>[,...]`, and every declared intent must be egress-allowed — **fail-closed** on a missing annotation. Adding `derived_index` or `secrets` to a sync job fails CI. Annotated the existing hellgraph `edge-twin-sync` CronJob (egresses `canonical_data` only); the validator confirms it.

## Tests / CI

**45 tests** (intent×runtime resolution, the egress invariant, policy-decision auditing, lifecycle incl. legal-hold-blocks-deletion, and the validator's pass/fail-closed/reject-non-egressable behavior). New `mount-intent.yml` runs tests + the egress enforcement.

Follow-up (spawned): unify the two edge↔cloud-twin sync stacks so the twin's live graph comes from the hellgraph super-peer federation and rclone→S3 is cold-DR only.