### PR TITLE
feat(twin): hellgraph super-peer replica; demote rclone to cold-DR

### DIFF
--- a/infra/k8s/edge-twin-sync/base/sync-cronjob.yaml
+++ b/infra/k8s/edge-twin-sync/base/sync-cronjob.yaml
@@ -1,12 +1,16 @@
-# Edge → cloud-twin sync (diagram-4). Every 30m the edge rclones the HellGraph
-# RocksDB store to the S3-compatible twin. The twin holds canonical; the edge is
-# authoritative for the live per-person graph. Only non-private projections are
-# meant to cross — private nodes stay on-device (the ProviderProjection membrane
-# governs what may ever be exported).
+# Edge → cloud-twin COLD DISASTER-RECOVERY snapshot. Once daily the edge rclones the HellGraph
+# RocksDB store to the S3-compatible twin as a point-in-time blob backup.
 #
-# The job co-locates on the node holding the HellGraph pod (TopoLVM volumes are
-# node-local) and mounts its store PVC read-only. For strict point-in-time
-# consistency, interpose a VolumeSnapshot (topolvm-snapshots class is provided) —
+# NOTE (sync unification): LIVE convergence is NO LONGER this blob push. The cloud twin runs a
+# hellgraph super-peer (infra/k8s/hellgraph-superpeer) that replicates the edge's sovereign
+# Hypercore log and materializes the graph view via Autobase causal merge — see that README.
+# This CronJob is now belt-and-suspenders cold DR only; it was demoted from */30 to daily.
+#
+# The edge is authoritative for the live per-person graph; the twin super-peer is a read-replica
+# (never admitted as a writer → no split-brain). Only non-private projections cross (the
+# ProviderProjection membrane governs export). The job co-locates on the node holding the
+# HellGraph pod (TopoLVM volumes are node-local) and mounts its store PVC read-only. For strict
+# point-in-time consistency, interpose a VolumeSnapshot (topolvm-snapshots class is provided) —
 # see README. rclone remote + bucket come from the edge-twin-sync secret.
 apiVersion: batch/v1
 kind: CronJob
@@ -21,7 +25,7 @@ metadata:
     # the build otherwise. The HellGraph store is canonical_data (the source of truth).
     mount-intent.socioprophet.io/egress: canonical_data
 spec:
-  schedule: "*/30 * * * *"
+  schedule: "0 3 * * *"   # daily cold-DR (live convergence is via the super-peer federation)
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/infra/k8s/hellgraph-superpeer/README.md
+++ b/infra/k8s/hellgraph-superpeer/README.md
@@ -1,0 +1,40 @@
+# hellgraph-superpeer — the cloud-twin graph replica
+
+Runs in the **cloud-twin cluster**. Makes the twin's graph view come from the hellgraph
+**federation** — a live, causally-merged replica of the edge's sovereign log — instead of
+restoring a periodic RocksDB blob. This unifies the two edge↔cloud-twin sync stacks:
+
+```
+            live convergence (this)                       cold DR (daily)
+edge hellgraph  ──Hypercore log──▶  hellgraph-superpeer      edge rclone ──blob──▶ S3 twin
+(sovereign      (Autobase causal      (read-replica, /query)  (belt-and-suspenders,
+ authority)      merge, no central                             see infra/k8s/edge-twin-sync)
+                 authority)
+```
+
+## Why a Deployment (not a StatefulSet) with emptyDir
+
+The twin is a **disposable index**, not a source of truth. It re-derives from the edge's log via
+the federation on restart, and it is **never admitted as a writer** — so it cannot forge or
+rewrite, and there is **no split-brain**: the edge stays sole authority. The proof is in the
+hellgraph repo (`superpeer-federation.test.ts`): a node written at the edge materializes in the
+twin's `/query` with no blob sync, and the causal cut shows the edge as a writer while the twin is
+absent from it. Storage intent is `derived_index` (rebuildable, never egressed).
+
+## Wiring (prerequisites)
+
+1. **Image mode** — the `ghcr.io/socioprophet/hellgraph` image must include the super-peer
+   entrypoint (`bin/hellgraph-superpeer.mjs`, hellgraph PR #13) and be re-vendored/rebuilt. The
+   Deployment runs it via `command: ["node", "bin/hellgraph-superpeer.mjs"]`. The edge must also
+   run in federation mode (be the federation creator) so it has a base key to publish.
+2. **Base key** — the edge is the federation creator; publish its `baseKey()` once into the
+   `hellgraph-federation` ConfigMap (`data.base-key`):
+   `kubectl -n socioprophet get --raw /api/v1/.../hellgraph:8850/health` → `.baseKey`, or have the
+   edge write it on startup. It is a **public join identity**, not a secret.
+3. Consumers query the twin at `hellgraph-superpeer:8850/query` (SPARQL/Gremlin) — the same
+   read surface as the edge, but served from the replicated view.
+
+## Relationship to edge-twin-sync
+
+`infra/k8s/edge-twin-sync` is demoted to **daily cold DR** (was every 30m). It remains as a blob
+backup for catastrophic recovery; day-to-day convergence is this federation replica.

--- a/infra/k8s/hellgraph-superpeer/base/configmap.yaml
+++ b/infra/k8s/hellgraph-superpeer/base/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hellgraph-federation
+  labels:
+    bundle: graph.twin
+  annotations:
+    # The edge is the federation CREATOR; its baseKey() is the federation identity the twin joins
+    # by. Publish it here once from the edge: `curl http://hellgraph:8850/health | jq -r .baseKey`
+    # (SuperPeerHealth.baseKey), or have the edge write it on startup. Until set, the twin has no
+    # federation to join. This is config, not a secret — the base key is a public join identity.
+    mount-intent.socioprophet.io/note: "edge federation base key (public join identity)"
+data:
+  base-key: "REPLACE_WITH_EDGE_BASE_KEY_64_HEX"

--- a/infra/k8s/hellgraph-superpeer/base/deployment.yaml
+++ b/infra/k8s/hellgraph-superpeer/base/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hellgraph-superpeer
+  labels:
+    app: hellgraph-superpeer
+    bundle: graph.twin
+  annotations:
+    # This runs in the CLOUD-TWIN cluster. It is a read-replica of the edge's sovereign graph:
+    # it bootstraps from the edge federation base key, replicates the edge's Hypercore log, and
+    # serves the causally-merged view. A Deployment (not a StatefulSet) with rebuildable storage
+    # makes the "twin is a disposable index, never a second writer" property structural — it is
+    # never admitted as a writer, so it cannot forge/rewrite and there is no split-brain.
+    mount-intent.socioprophet.io/storage: derived_index
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hellgraph-superpeer
+  template:
+    metadata:
+      labels:
+        app: hellgraph-superpeer
+        bundle: graph.twin
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: superpeer
+          image: ghcr.io/socioprophet/hellgraph:latest
+          # Runs the super-peer entrypoint (hellgraph bin, PR #13) instead of the local service.
+          command: ["node", "bin/hellgraph-superpeer.mjs"]
+          ports:
+            - name: http
+              containerPort: 8850
+          env:
+            - name: HELLGRAPH_HTTP_PORT
+              value: "8850"
+            - name: HELLGRAPH_STORAGE_DIR
+              value: "/var/lib/hellgraph-superpeer"
+            # The edge federation base key — the twin joins THIS federation as a replica.
+            - name: HELLGRAPH_BOOTSTRAP_KEY
+              valueFrom:
+                configMapKeyRef:
+                  name: hellgraph-federation
+                  key: base-key
+          readinessProbe:
+            httpGet: { path: /health, port: 8850 }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /health, port: 8850 }
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests: { cpu: "50m", memory: "128Mi" }
+            limits: { cpu: "500m", memory: "512Mi" }
+          volumeMounts:
+            - name: replica-store
+              mountPath: /var/lib/hellgraph-superpeer
+      volumes:
+        # Rebuildable: the replica re-derives from the edge's log via the federation on restart —
+        # nothing here is a source of truth (mount-intent: derived_index, never egressed).
+        - name: replica-store
+          emptyDir: {}

--- a/infra/k8s/hellgraph-superpeer/base/kustomization.yaml
+++ b/infra/k8s/hellgraph-superpeer/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - configmap.yaml
+  - networkpolicy.yaml

--- a/infra/k8s/hellgraph-superpeer/base/networkpolicy.yaml
+++ b/infra/k8s/hellgraph-superpeer/base/networkpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hellgraph-superpeer-baseline
+  labels:
+    bundle: graph.twin
+spec:
+  podSelector:
+    matchLabels:
+      app: hellgraph-superpeer
+  policyTypes: [Ingress]
+  ingress:
+    # Only same-namespace consumers may query the twin's read view.
+    - from:
+        - podSelector: {}
+      ports:
+        - port: 8850
+          protocol: TCP

--- a/infra/k8s/hellgraph-superpeer/base/service.yaml
+++ b/infra/k8s/hellgraph-superpeer/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hellgraph-superpeer
+  labels:
+    app: hellgraph-superpeer
+    bundle: graph.twin
+spec:
+  selector:
+    app: hellgraph-superpeer
+  ports:
+    - name: http
+      port: 8850
+      targetPort: 8850


### PR DESCRIPTION
## What

Unifies the two edge↔cloud-twin sync stacks — the **platform half** (hellgraph [#13](https://github.com/SocioProphet/hellgraph/pull/13) is the engine + proof).

Today: `edge-twin-sync` rclones the whole RocksDB store to S3 every 30m (a blob), *and* hellgraph has its own Hypercore/Autobase federation. This PR makes the federation the live path and demotes the blob to cold DR.

- **`infra/k8s/hellgraph-superpeer/`** — the cloud-twin graph replica. A **Deployment** (not StatefulSet) with `emptyDir` that runs the super-peer entrypoint (`bin/hellgraph-superpeer.mjs`), bootstraps from the edge federation base key, replicates the edge's sovereign log, and serves the causally-merged view at `:8850/query`. **Never admitted as a writer → structural read-replica, no split-brain.** Storage intent `derived_index` (rebuildable — re-derives from the federation on restart; never egressed). + service + baseline NetworkPolicy.
- **`edge-twin-sync`** — demoted `*/30` → **daily** (`0 3 * * *`) and re-documented as belt-and-suspenders **cold DR only**. Live convergence is the federation.

## Why this is safe

The twin is a replica, not a second writer — proven in hellgraph #13's `superpeer-federation.test.ts`: an edge-written node materializes in the twin's `/query` with no blob sync, and the causal cut shows the edge as a writer while the twin is absent from it. This replaces the previously-deferred "reverse path (twin→edge)" split-brain hazard with causal merge.

## Prerequisites (documented in the README, honestly flagged)

1. The `ghcr.io/socioprophet/hellgraph` image must carry the super-peer entrypoint (#13) and be re-vendored/rebuilt; the edge must run in federation mode (be the creator).
2. Publish the edge's `baseKey()` (a **public** join identity, not a secret) into the `hellgraph-federation` ConfigMap.

## Policy

Egress unchanged — the demoted cron still egresses `canonical_data` only; `validate_mount_intent_egress.py` passes.