### PR TITLE
integ: 2 clean-mergeable branches (socbase-migration + lattice-studio-uv-lock)

### DIFF
--- a/apps/lattice-studio/uv.lock
+++ b/apps/lattice-studio/uv.lock
@@ -1,0 +1,79 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prophet-lattice-studio"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.1.1" }]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]

--- a/charts/socbase-schema/Chart.yaml
+++ b/charts/socbase-schema/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: socbase-schema
+description: One-shot Postgres bootstrap for Socbase (self-hosted Supabase-compatible auth+data layer) — creates the PostgREST role model and application tables on the shared platform Postgres, after GoTrue has created its "auth" schema. GoTrue and PostgREST themselves deploy via the generic charts/socioprophet-service chart (see deploy/values/socbase-auth.yaml, deploy/values/socbase-rest.yaml) — this chart exists only because a migration Job doesn't fit that chart's shape.
+type: application
+version: 0.1.0
+appVersion: "0.1"
+keywords: [postgres, migration, supabase, socbase]

--- a/charts/socbase-schema/files/socbase-schema.sql
+++ b/charts/socbase-schema/files/socbase-schema.sql
@@ -1,0 +1,138 @@
+-- Socbase — self-hosted Supabase (Postgres + GoTrue + PostgREST + Kong)
+-- bootstrap for socioprophet-web's server (SourceOS builder + nlboot fleet).
+--
+-- ORDERING REQUIREMENT: this file must run AFTER GoTrue has booted at least
+-- once and created its "auth" schema (auth.users etc.) — GoTrue owns that
+-- schema entirely and this file's tables have FKs into auth.users. The
+-- schema-job (templates/schema-job.yaml) and the local docker-compose
+-- "socbase-migrate" step both poll for auth.users before applying this, so
+-- do NOT drop this into infra/datastores/postgres/'s initdb.d numbered
+-- scripts — those run at Postgres's very first boot, before GoTrue exists.
+--
+-- We run PLAIN postgres:16 (not the supabase/postgres image), so the roles
+-- PostgREST needs are NOT pre-baked — part 1 of this file creates them.
+
+-- ── Part 1: PostgREST role model ────────────────────────────────────────────
+-- authenticator: the login role PostgREST itself connects as; can SET ROLE
+-- into the other three based on the JWT's "role" claim. anon/authenticated
+-- get NO grants below (default-deny) — the browser never talks to Postgres
+-- directly in this app; only the Express backend does, via service_role.
+--
+-- :'authpw' is a psql variable (-v authpw=...) sourced from a k8s Secret at
+-- apply time — never inline it here or it lands in a Helm-rendered ConfigMap.
+do $$ begin
+  if not exists (select 1 from pg_roles where rolname = 'anon') then
+    create role anon nologin noinherit;
+  end if;
+  if not exists (select 1 from pg_roles where rolname = 'authenticated') then
+    create role authenticated nologin noinherit;
+  end if;
+  if not exists (select 1 from pg_roles where rolname = 'service_role') then
+    create role service_role nologin noinherit bypassrls;
+  end if;
+end $$;
+select format('create role authenticator noinherit login password %L', :'authpw')
+where not exists (select 1 from pg_roles where rolname = 'authenticator')
+\gexec
+alter role authenticator with password :'authpw';
+grant anon, authenticated, service_role to authenticator;
+grant usage on schema public to anon, authenticated, service_role;
+
+-- ── Part 2: application tables ───────────────────────────────────────────────
+-- Compatibility decision: column names are QUOTED CAMELCASE, matching the
+-- prior Firestore field names exactly (createdAt, assignedBuildId, etc), so
+-- contracts.ts validators / the Vue frontend / nlboot devices needed ZERO
+-- field-name changes — only the persistence backend changed underneath.
+--
+-- RLS is enabled with NO policies (default-deny for anon/authenticated);
+-- service_role has BYPASSRLS above and is the only caller (via the Express
+-- backend's SUPABASE_SERVICE_ROLE_KEY), matching the old Firestore Admin-SDK
+-- model where all access was server-only and enforced in application code
+-- (tier gating, ownership checks, daily-build-limit, premium-fleet gating).
+
+create extension if not exists pgcrypto; -- gen_random_uuid()
+
+-- One row per Supabase Auth user (auth.users.id), mirrors the old users/{uid} doc.
+create table if not exists public.profiles (
+  uid uuid primary key references auth.users(id) on delete cascade,
+  "tier" text not null default 'free',
+  "createdAt" timestamptz not null default now()
+);
+alter table public.profiles enable row level security;
+
+-- users/{uid}/builds/{id} → builds, owned by uid.
+create table if not exists public.builds (
+  id uuid primary key default gen_random_uuid(),
+  uid uuid not null references auth.users(id) on delete cascade,
+  "spec" jsonb not null,
+  "tier" text not null,
+  "status" text not null default 'queued',
+  "lane" text,
+  "error" text,
+  "artifact" jsonb,
+  "buildRequest" jsonb,
+  "workOrder" jsonb,
+  "osImage" jsonb,
+  "catalogEntry" jsonb,
+  "evidence" jsonb,
+  "evidenceError" text,
+  "usageReceipt" jsonb,
+  "settlement" jsonb,
+  "createdAt" timestamptz not null default now()
+);
+create index if not exists builds_uid_created_idx on public.builds (uid, "createdAt" desc);
+alter table public.builds enable row level security;
+
+-- users/{uid}/devices/{id} → devices, owned by uid. Client-generated uuid (the
+-- old Firestore .doc() auto-id pattern) so the id is known before insert, since
+-- contracts.deviceIdentity(...) embeds it.
+create table if not exists public.devices (
+  id uuid primary key,
+  uid uuid not null references auth.users(id) on delete cascade,
+  "name" text not null,
+  "claimCode" text not null unique,
+  "assignedBuildId" uuid references public.builds(id),
+  "identity" jsonb not null,
+  "lastSeen" timestamptz,
+  "lastInventory" jsonb,
+  "activeBootPlan" jsonb,
+  "assignedAt" timestamptz,
+  "createdAt" timestamptz not null default now()
+);
+create index if not exists devices_uid_created_idx on public.devices (uid, "createdAt" desc);
+alter table public.devices enable row level security;
+
+-- device_claims/{claim} → top-level, unauthenticated /boot/announce resolves
+-- a claim code to (uid, deviceId) without a token.
+create table if not exists public.device_claims (
+  "claim" text primary key,
+  uid uuid not null references auth.users(id) on delete cascade,
+  "deviceId" uuid not null references public.devices(id) on delete cascade
+);
+alter table public.device_claims enable row level security;
+
+-- users/{uid}/devices/{id}/bootProofs/{id} → boot_proofs, owned by deviceId.
+create table if not exists public.boot_proofs (
+  id uuid primary key default gen_random_uuid(),
+  "deviceId" uuid not null references public.devices(id) on delete cascade,
+  "proof" jsonb not null,
+  "createdAt" timestamptz not null default now()
+);
+create index if not exists boot_proofs_device_idx on public.boot_proofs ("deviceId");
+alter table public.boot_proofs enable row level security;
+
+-- notification_outbox/{id} → top-level outbox the Kafka relay drains (was
+-- functions/publishPendingOutbox; unchanged by this migration).
+create table if not exists public.notification_outbox (
+  id uuid primary key default gen_random_uuid(),
+  "kind" text not null,
+  "event" jsonb not null,
+  "status" text not null default 'pending',
+  "destination" jsonb not null,
+  "createdAt" timestamptz not null default now()
+);
+alter table public.notification_outbox enable row level security;
+
+-- service_role bypasses RLS but still needs table-level grants to touch these.
+grant all on all tables in schema public to service_role;
+grant all on all sequences in schema public to service_role;

--- a/charts/socbase-schema/templates/NOTES.txt
+++ b/charts/socbase-schema/templates/NOTES.txt
@@ -1,0 +1,32 @@
+socbase-schema Job scheduled. Before `helm install`/`upgrade`, these Secrets must exist in the target namespace:
+
+  kubectl create secret generic {{ .Values.authenticator.existingSecret }} \
+    --from-literal=password="$(openssl rand -base64 24)"
+
+  # {{ .Values.postgres.existingSecret }} (username/password) is assumed to already
+  # exist — same shared-Postgres secret prophet-workspace's broker/mail templates reuse.
+
+This Job polls for GoTrue's auth.users table before applying the app schema —
+install/upgrade socbase-auth (deploy/values/socbase-auth.yaml, generic chart)
+FIRST, or this Job will retry for up to 5 minutes then fail.
+
+Once this Job succeeds (kubectl get jobs -w socbase-schema), you also need the
+composed DSN secrets the generic-chart auth/rest releases read from:
+
+  kubectl create secret generic socbase-auth-db-url \
+    --from-literal=url="postgres://<admin>:<pw>@postgres:5432/prophet_platform"
+  kubectl create secret generic socbase-rest-db-url \
+    --from-literal=url="postgres://authenticator:<authenticator-pw-above>@postgres:5432/prophet_platform"
+
+  ./scripts/socbase-mint-keys.sh   # prints JWT_SECRET / ANON_KEY / SERVICE_ROLE_KEY
+  kubectl create secret generic socbase-jwt --from-literal=secret="$JWT_SECRET"
+
+Then wire, once socbase-auth + socbase-rest (deploy/values/*.yaml) are live:
+  - server/.env:                       SUPABASE_URL=https://socbase.socioprophet.ai
+                                        SUPABASE_SERVICE_ROLE_KEY=<SERVICE_ROLE_KEY>
+  - app-vue/public/socbase-config.js:  { url: "https://socbase.socioprophet.ai", anonKey: "<ANON_KEY>" }
+
+This has NOT been smoke-tested against a live cluster or `podman compose up`
+(no podman/docker/kubectl available in the environment that authored it) —
+run infra/local/docker-compose.socbase.yml end-to-end before trusting this in
+production.

--- a/charts/socbase-schema/templates/_helpers.tpl
+++ b/charts/socbase-schema/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "socbase.pgAdminEnv" -}}
+- name: PGHOST
+  value: {{ .Values.postgres.host | quote }}
+- name: PGPORT
+  value: {{ .Values.postgres.port | quote }}
+- name: PGDATABASE
+  value: {{ .Values.postgres.db | quote }}
+- name: PGUSER
+  valueFrom: { secretKeyRef: { name: {{ .Values.postgres.existingSecret }}, key: username } }
+- name: PGPASSWORD
+  valueFrom: { secretKeyRef: { name: {{ .Values.postgres.existingSecret }}, key: password } }
+{{- end -}}

--- a/charts/socbase-schema/templates/schema-job.yaml
+++ b/charts/socbase-schema/templates/schema-job.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: socbase-schema
+data:
+  socbase-schema.sql: |-
+{{ .Files.Get "files/socbase-schema.sql" | indent 4 }}
+---
+# Runs the app schema AFTER GoTrue has created auth.users on its own first
+# boot — GoTrue owns the "auth" schema entirely and our tables FK into it.
+# Polls with a timeout instead of assuming Helm hook ordering vs. a running
+# Deployment (there's no Job-vs-Job ordering to lean on here, unlike two Jobs).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: socbase-schema
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 6
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: postgres:16-alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              echo "waiting for GoTrue's auth.users to exist on {{ .Values.postgres.host }}/{{ .Values.postgres.db }}..."
+              for i in $(seq 1 60); do
+                if psql "host=$PGHOST port=$PGPORT dbname=$PGDATABASE user=$PGUSER" -tAc \
+                  "select to_regclass('auth.users') is not null" 2>/dev/null | grep -q t; then
+                  echo "auth.users found."
+                  break
+                fi
+                echo "  not ready yet (attempt $i/60), sleeping 5s"
+                sleep 5
+              done
+              echo "applying socbase schema..."
+              psql "host=$PGHOST port=$PGPORT dbname=$PGDATABASE user=$PGUSER" \
+                -v ON_ERROR_STOP=1 -v authpw="$AUTHENTICATOR_PASSWORD" \
+                -f /sql/socbase-schema.sql
+              echo "done."
+          env:
+            {{- include "socbase.pgAdminEnv" . | nindent 12 }}
+            - name: AUTHENTICATOR_PASSWORD
+              valueFrom: { secretKeyRef: { name: {{ .Values.authenticator.existingSecret }}, key: password } }
+          volumeMounts:
+            - { name: sql, mountPath: /sql }
+      volumes:
+        - name: sql
+          configMap: { name: socbase-schema }

--- a/charts/socbase-schema/values.yaml
+++ b/charts/socbase-schema/values.yaml
@@ -1,0 +1,22 @@
+# socbase-schema — one-shot Postgres bootstrap Job for Socbase (self-hosted
+# Supabase-compatible auth+data layer). GoTrue and PostgREST deploy separately
+# via the generic charts/socioprophet-service chart (deploy/values/socbase-auth.yaml,
+# deploy/values/socbase-rest.yaml) since they're plain single-container services
+# that chart already handles; this exists only for the migration Job, which
+# doesn't fit that chart's shape (no Job/hook support there). GCP project:
+# socioprophet-platform.
+
+# Reuse the platform Postgres — same convention as charts/prophet-workspace.
+# The schema-job connects with FULL admin rights (creates the authenticator
+# role + application tables; GoTrue itself owns the "auth" schema outright).
+postgres:
+  host: postgres
+  db: prophet_platform
+  port: 5432
+  existingSecret: postgres-credentials     # keys: username, password (admin)
+
+# authenticator is the login role PostgREST connects as (SET ROLE anon /
+# authenticated / service_role per JWT) — this Job creates/repassword's it.
+# Generate: openssl rand -base64 24
+authenticator:
+  existingSecret: socbase-authenticator     # key: password

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -23,6 +23,14 @@ spec:
           - { name: osm-map-api }
           - { name: reasoning-failure-runner }
           - { name: search-orchestrator }
+          # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
+          # postgrest/postgrest) with tags pinned directly in their values files —
+          # NOT touched by the build-image/gitops-promote SHA pipeline above, since
+          # we don't build them. Install the charts/socbase-schema Job (separately;
+          # it isn't part of this ApplicationSet — see its NOTES.txt) AFTER
+          # socbase-auth is live, since it waits on GoTrue's auth schema.
+          - { name: socbase-auth }
+          - { name: socbase-rest }
   template:
     metadata:
       name: 'svc-{{.name}}'

--- a/deploy/values/socbase-auth.yaml
+++ b/deploy/values/socbase-auth.yaml
@@ -1,0 +1,56 @@
+# GoTrue — Socbase's self-hosted Supabase-compatible auth service. Deploys via
+# the generic charts/socioprophet-service chart (plain single-container, all
+# config via env). Owns the "auth" schema (creates it on first boot); the
+# charts/socbase-schema Job depends on that and must run AFTER this is live.
+#
+# Prereqs (see charts/socbase-schema/templates/NOTES.txt for the full sequence):
+#   kubectl create secret generic socbase-auth-db-url --from-literal=url="postgres://<admin>:<pw>@postgres:5432/prophet_platform"
+#   kubectl create secret generic socbase-jwt --from-literal=secret="$(./scripts/socbase-mint-keys.sh | grep JWT_SECRET | cut -d= -f2)"
+nameOverride: socbase-auth
+
+image:
+  registry: docker.io          # third-party image, not this platform's own GAR
+  repository: supabase/gotrue
+  tag: v2.164.0
+
+service:
+  port: 9999
+  portName: http
+
+secretEnv:
+  DATABASE_URL: { secretName: socbase-auth-db-url, key: url }
+  GOTRUE_JWT_SECRET: { secretName: socbase-jwt, key: secret }
+
+config:
+  GOTRUE_API_HOST: "0.0.0.0"
+  GOTRUE_API_PORT: "9999"
+  API_EXTERNAL_URL: "https://socbase.socioprophet.ai/auth/v1"
+  GOTRUE_SITE_URL: "https://app.socioprophet.ai"
+  GOTRUE_URI_ALLOW_LIST: "https://app.socioprophet.ai/**"
+  GOTRUE_DISABLE_SIGNUP: "false"
+  # No transactional-mail sender wired yet — signups are immediately usable,
+  # matching app-vue Login.vue's "Create account" flow. Flip once SMTP exists;
+  # deliberate documented tradeoff, not an oversight.
+  GOTRUE_MAILER_AUTOCONFIRM: "true"
+  GOTRUE_DB_DRIVER: postgres
+  GOTRUE_JWT_EXP: "3600"
+
+probes:
+  path: /health
+
+# Path-routes under one hostname alongside socbase-rest — no gateway needed,
+# nginx-ingress does the prefix-strip natively (both Ingresses share a host;
+# the controller merges them).
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+  hosts:
+    - host: socbase.socioprophet.ai
+      paths:
+        - path: /auth/v1(/|$)(.*)
+          pathType: ImplementationSpecific
+
+replicaCount: 2

--- a/deploy/values/socbase-rest.yaml
+++ b/deploy/values/socbase-rest.yaml
@@ -1,0 +1,45 @@
+# PostgREST — Socbase's REST-over-Postgres layer. Deploys via the generic
+# charts/socioprophet-service chart. Connects as the restricted "authenticator"
+# role (never admin creds) — that role is created by the charts/socbase-schema
+# Job, so this release's DB secret must point at a role that already exists
+# (i.e. install socbase-auth + run the schema Job before this).
+#
+# Prereqs:
+#   kubectl create secret generic socbase-rest-db-url --from-literal=url="postgres://authenticator:<authenticator-pw>@postgres:5432/prophet_platform"
+#   kubectl create secret generic socbase-jwt --from-literal=secret="..."   # same secret socbase-auth uses
+nameOverride: socbase-rest
+
+image:
+  registry: docker.io
+  repository: postgrest/postgrest
+  tag: v12.2.3
+
+service:
+  port: 3000
+  portName: http
+
+secretEnv:
+  PGRST_DB_URI: { secretName: socbase-rest-db-url, key: url }
+  PGRST_JWT_SECRET: { secretName: socbase-jwt, key: secret }
+
+config:
+  PGRST_DB_SCHEMAS: "public"
+  PGRST_DB_ANON_ROLE: "anon"
+  PGRST_DB_USE_LEGACY_GUCS: "false"
+
+probes:
+  path: /
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+  hosts:
+    - host: socbase.socioprophet.ai
+      paths:
+        - path: /rest/v1(/|$)(.*)
+          pathType: ImplementationSpecific
+
+replicaCount: 2

--- a/infra/local/docker-compose.socbase.yml
+++ b/infra/local/docker-compose.socbase.yml
@@ -1,0 +1,114 @@
+# Local self-hosted Supabase stack (Socbase) for developing against
+# socioprophet-web/server without a managed Supabase Cloud project. Mirrors
+# the production topology 1:1: same schema file (charts/socbase-schema/files/
+# socbase-schema.sql), same role model, same /auth/v1 + /rest/v1 path routing
+# under one base URL (prod does this with nginx-ingress annotations on two
+# plain Deployments — deploy/values/socbase-{auth,rest}.yaml; here it's a tiny
+# nginx reverse proxy doing the same rewrite, since there's no Ingress locally).
+#
+# Run (podman preferred, per scripts/build-push-workspace.sh's convention;
+# docker compose works identically):
+#   podman compose -f infra/local/docker-compose.socbase.yml up
+#   ./scripts/socbase-mint-keys.sh some-local-dev-secret   # prints ANON_KEY/SERVICE_ROLE_KEY
+# Then point socioprophet-web/server/.env and app-vue/public/socbase-config.js
+# at http://localhost:8000 with those keys (JWT_SECRET below must match what
+# you pass to the mint script).
+#
+# NOTE on podman: use the native `podman compose` subcommand (podman ≥4.7) or
+# `docker compose` — the older standalone `podman-compose` (Python tool) has
+# historically had gaps in `depends_on: condition:` support, which this file
+# relies on for correct startup ordering (db → auth → migrate → rest).
+#
+# NOT YET SMOKE-TESTED end to end (authored without podman/docker available)
+# — this is the first place to verify the whole Socbase migration for real.
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: socbase
+      POSTGRES_PASSWORD: socbase
+      POSTGRES_DB: socbase
+    ports:
+      - "5433:5432"   # offset from the platform postgres (5432) so both can run at once
+    volumes:
+      - socbase-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U socbase"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  auth:
+    image: supabase/gotrue:v2.164.0
+    depends_on:
+      db: { condition: service_healthy }
+    environment:
+      DATABASE_URL: postgres://socbase:socbase@db:5432/socbase
+      GOTRUE_DB_DRIVER: postgres
+      GOTRUE_API_HOST: 0.0.0.0
+      GOTRUE_API_PORT: "9999"
+      API_EXTERNAL_URL: http://localhost:8000/auth/v1
+      GOTRUE_SITE_URL: http://localhost:5173
+      GOTRUE_URI_ALLOW_LIST: http://localhost:5173/**
+      GOTRUE_DISABLE_SIGNUP: "false"
+      GOTRUE_MAILER_AUTOCONFIRM: "true"   # local dev only — no SMTP wired
+      GOTRUE_JWT_SECRET: ${SOCBASE_JWT_SECRET:-local-dev-socbase-secret-change-me}
+      GOTRUE_JWT_EXP: "3600"
+    ports:
+      - "9999:9999"
+
+  migrate:
+    image: postgres:16-alpine
+    depends_on:
+      auth: { condition: service_started }
+    environment:
+      PGHOST: db
+      PGPORT: "5432"
+      PGDATABASE: socbase
+      PGUSER: socbase
+      PGPASSWORD: socbase
+      AUTHENTICATOR_PASSWORD: ${SOCBASE_AUTHENTICATOR_PASSWORD:-local-dev-authenticator-pw}
+    volumes:
+      - ../../charts/socbase-schema/files/socbase-schema.sql:/sql/socbase-schema.sql:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        echo "waiting for GoTrue's auth.users..."
+        for i in $$(seq 1 60); do
+          if psql "host=$$PGHOST port=$$PGPORT dbname=$$PGDATABASE user=$$PGUSER" -tAc \
+            "select to_regclass('auth.users') is not null" 2>/dev/null | grep -q t; then
+            echo "auth.users found."; break
+          fi
+          echo "  not ready (attempt $$i/60), sleeping 5s"; sleep 5
+        done
+        echo "applying socbase schema..."
+        PGPASSWORD=$$PGPASSWORD psql "host=$$PGHOST port=$$PGPORT dbname=$$PGDATABASE user=$$PGUSER" \
+          -v ON_ERROR_STOP=1 -v authpw="$$AUTHENTICATOR_PASSWORD" -f /sql/socbase-schema.sql
+        echo "done."
+
+  rest:
+    image: postgrest/postgrest:v12.2.3
+    depends_on:
+      migrate: { condition: service_completed_successfully }
+    environment:
+      PGRST_DB_URI: postgres://authenticator:${SOCBASE_AUTHENTICATOR_PASSWORD:-local-dev-authenticator-pw}@db:5432/socbase
+      PGRST_DB_SCHEMAS: public
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: ${SOCBASE_JWT_SECRET:-local-dev-socbase-secret-change-me}
+      PGRST_DB_USE_LEGACY_GUCS: "false"
+    ports:
+      - "3001:3000"   # offset from a bare 3000 to avoid clashing with other local dev servers
+
+  gateway:
+    image: nginx:1.27-alpine
+    depends_on:
+      - auth
+      - rest
+    volumes:
+      - ./socbase/nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "8000:8000"
+
+volumes:
+  socbase-pgdata:

--- a/infra/local/socbase/nginx.conf
+++ b/infra/local/socbase/nginx.conf
@@ -1,0 +1,20 @@
+# Local-dev stand-in for production's native Ingress path-routing (no Kong in
+# either place — see deploy/values/socbase-auth.yaml / socbase-rest.yaml for
+# the prod nginx-ingress annotations this mirrors). @supabase/supabase-js
+# needs ONE base URL that serves both /auth/v1 and /rest/v1.
+events {}
+http {
+  server {
+    listen 8000;
+
+    location /auth/v1/ {
+      rewrite ^/auth/v1/(.*)$ /$1 break;
+      proxy_pass http://auth:9999/;
+    }
+
+    location /rest/v1/ {
+      rewrite ^/rest/v1/(.*)$ /$1 break;
+      proxy_pass http://rest:3000/;
+    }
+  }
+}

--- a/scripts/socbase-mint-keys.sh
+++ b/scripts/socbase-mint-keys.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Mint the Socbase (self-hosted Supabase) demo-style ANON_KEY / SERVICE_ROLE_KEY
+# HS256 JWTs from a JWT secret — no external deps, pure Node `crypto`.
+# Usage: ./scripts/socbase-mint-keys.sh [jwt-secret]
+#   - jwt-secret omitted → generates a fresh one (openssl rand -base64 32) and prints it too.
+# These keys never expire by default (Supabase's own self-host demo keys use
+# a far-future exp) — rotate by re-running with a new secret and redeploying.
+set -euo pipefail
+
+SECRET="${1:-$(openssl rand -base64 32)}"
+
+node -e '
+const crypto = require("crypto");
+const secret = process.argv[1];
+
+function b64url(buf) {
+  return Buffer.from(buf).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function sign(role) {
+  const header = { alg: "HS256", typ: "JWT" };
+  const payload = { role, iss: "socbase", iat: Math.floor(Date.now() / 1000), exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365 * 10 };
+  const signingInput = b64url(JSON.stringify(header)) + "." + b64url(JSON.stringify(payload));
+  const sig = crypto.createHmac("sha256", secret).update(signingInput).digest();
+  return signingInput + "." + b64url(sig);
+}
+
+console.log("JWT_SECRET=" + secret);
+console.log("ANON_KEY=" + sign("anon"));
+console.log("SERVICE_ROLE_KEY=" + sign("service_role"));
+' "$SECRET"
+
+echo
+echo "Wire these into:"
+echo "  - k8s Secret 'socbase-jwt' key 'secret'                → JWT_SECRET"
+echo "  - server/.env: SUPABASE_SERVICE_ROLE_KEY                → SERVICE_ROLE_KEY"
+echo "  - app-vue/public/socbase-config.js: anonKey             → ANON_KEY"
+echo "  - server/.env + socbase-config.js: SUPABASE_URL / url   → https://<gatewayHostname>"


### PR DESCRIPTION
Curate batch of 2 clean-mergeable branches from the frontier (merge-clean; CI is the gate):
- `feat/socbase-migration` — socbase auth/rest deploy values + local docker-compose + nginx + key-mint script (627 lines, new files)
- `chore/lattice-studio-uv-lock` — uv.lock for lattice-studio

Part of the branch-frontier convergence (511→~88 this session). CI-gated.