### PR TITLE
fix(sync): revert premature rclone→daily demotion (federation not yet wired)

### DIFF
--- a/infra/k8s/edge-twin-sync/base/sync-cronjob.yaml
+++ b/infra/k8s/edge-twin-sync/base/sync-cronjob.yaml
@@ -1,13 +1,15 @@
-# Edge → cloud-twin COLD DISASTER-RECOVERY snapshot. Once daily the edge rclones the HellGraph
-# RocksDB store to the S3-compatible twin as a point-in-time blob backup.
+# Edge → cloud-twin sync. Every 30m the edge rclones the HellGraph RocksDB store to the
+# S3-compatible twin as a point-in-time blob backup.
 #
-# NOTE (sync unification): LIVE convergence is NO LONGER this blob push. The cloud twin runs a
-# hellgraph super-peer (infra/k8s/hellgraph-superpeer) that replicates the edge's sovereign
-# Hypercore log and materializes the graph view via Autobase causal merge — see that README.
-# This CronJob is now belt-and-suspenders cold DR only; it was demoted from */30 to daily.
+# NOTE (sync unification — NOT YET ACTIVE): the intended end state is that live convergence moves
+# to the hellgraph super-peer federation (infra/k8s/hellgraph-superpeer) and THIS job drops to a
+# daily cold-DR cadence. That is NOT wired yet: the edge StatefulSet does not run in federation
+# mode (no HELLGRAPH_MODE), so it publishes no base key, and the twin's bootstrap ConfigMap is a
+# placeholder — the super-peer has no federation to replicate. Until the edge is a federation
+# participant AND the twin is verified replicating live, this blob push is the PRIMARY sync and
+# MUST stay frequent. (It was briefly demoted to daily prematurely; reverted here.)
 #
-# The edge is authoritative for the live per-person graph; the twin super-peer is a read-replica
-# (never admitted as a writer → no split-brain). Only non-private projections cross (the
+# The edge is authoritative for the live per-person graph. Only non-private projections cross (the
 # ProviderProjection membrane governs export). The job co-locates on the node holding the
 # HellGraph pod (TopoLVM volumes are node-local) and mounts its store PVC read-only. For strict
 # point-in-time consistency, interpose a VolumeSnapshot (topolvm-snapshots class is provided) —
@@ -25,7 +27,7 @@ metadata:
     # the build otherwise. The HellGraph store is canonical_data (the source of truth).
     mount-intent.socioprophet.io/egress: canonical_data
 spec:
-  schedule: "0 3 * * *"   # daily cold-DR (live convergence is via the super-peer federation)
+  schedule: "*/30 * * * *"   # PRIMARY sync (federation not yet wired — see header). Drop to daily ONLY after the twin is verified replicating live.
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/infra/k8s/hellgraph-superpeer/README.md
+++ b/infra/k8s/hellgraph-superpeer/README.md
@@ -1,8 +1,15 @@
 # hellgraph-superpeer — the cloud-twin graph replica
 
-Runs in the **cloud-twin cluster**. Makes the twin's graph view come from the hellgraph
-**federation** — a live, causally-merged replica of the edge's sovereign log — instead of
-restoring a periodic RocksDB blob. This unifies the two edge↔cloud-twin sync stacks:
+Runs in the **cloud-twin cluster**. **STATUS: staged, NOT yet active.** The manifests + super-peer
+image exist and the federation is proven in hellgraph tests, but the live path is not wired: the
+edge StatefulSet does not run in federation mode (publishes no base key) and the
+`hellgraph-federation` ConfigMap holds a placeholder. Until the edge is a federation participant
+AND the twin is verified replicating, `edge-twin-sync` stays the PRIMARY sync (every 30m) — do
+not demote it before then.
+
+Intended end state — the twin's graph view comes from the hellgraph **federation** (a live,
+causally-merged replica of the edge's sovereign log) instead of a periodic RocksDB blob, unifying
+the two edge↔cloud-twin sync stacks:
 
 ```
             live convergence (this)                       cold DR (daily)


### PR DESCRIPTION
## Audit remediation (finding #1)

Verified gaps: the edge StatefulSet has **no `HELLGRAPH_MODE`** (not a federation participant → publishes no base key), the twin bootstrap ConfigMap is a **placeholder**, and service images aren't built. So the super-peer federation meant to replace the blob sync is **not live** — yet I'd demoted the rclone DR from `*/30` to daily on the premise it was. That weakened backup for no gain.

**Fix:** restore `*/30` (primary sync) and correct the 'cold DR only' docs on the CronJob + superpeer README to **STATUS: staged / not-active**. Demote only after the edge runs federation mode AND the twin is verified replicating live.

Egress policy validator still passes (canonical_data only).