### PR TITLE
fix(hellgraph-service): native build toolchain so super-peer mode actually works

### DIFF
--- a/apps/hellgraph-service/Dockerfile
+++ b/apps/hellgraph-service/Dockerfile
@@ -2,6 +2,12 @@ FROM node:20-slim
 
 WORKDIR /app
 
+# Native deps (rocksdb-native/sodium-native via autobase/corestore/hyperswarm, used by
+# HELLGRAPH_MODE=superpeer) need a build toolchain — node:20-slim lacks one, so the addons
+# silently fail to load at runtime without this. node-gyp needs python3 + make + g++.
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential python3 \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY package.json ./
 # @socioprophet/hellgraph is vendored as a prebuilt tarball (vendor/) — no git, no ssh, no
 # network, no rebuild. Deterministic; re-vendor with `npm pack` in ~/dev/hellgraph on version bump.


### PR DESCRIPTION
## Audit remediation (finding #5) — verified in-container

The mode-aware hellgraph-service image (#691) was **broken** for `HELLGRAPH_MODE=superpeer` — the whole point of the cloud-twin. Building it in podman and *running* it revealed:

```
[hellgraph-service] super-peer failed to start: autobase/corestore not available
REAL ERROR: Cannot find addon '.' from node_modules/rocksdb-native/binding.js
```

`autobase`/`corestore`/`hyperswarm` are `optionalDependencies`; their native addons (rocksdb-native, sodium-native) need node-gyp (**python3 + make + g++**). `node:20-slim` has none, so npm **silently skipped** the failed native builds and super-peer crashed at startup.

**Fix:** install `build-essential` + `python3` before `npm install`. **Verified** in a fresh podman build:
- `autobase+corestore LOAD OK`
- `HELLGRAPH_MODE=superpeer` boots: `[superpeer] role=creator base=020e… listening :8850`

This is why 'green CI' hid it — nothing built or ran the image. Follow-up (non-blocking): multi-stage build to drop the toolchain from the final layer.