### PR TITLE
fix(deploy): pin image tags to :latest (unblock 11 ImagePullBackOff services)

### DIFF
--- a/deploy/values/api.yaml
+++ b/deploy/values/api.yaml
@@ -1,5 +1,5 @@
 # socioprophet-api — tritRPC core API
-image: { repository: socioprophet-api }
+image: { repository: socioprophet-api, tag: latest }
 service: { port: 9000, portName: tritrpc }
 probes: { enabled: true, httpGet: false }   # raw tritRPC, no HTTP health
 config:

--- a/deploy/values/eval-fabric-api.yaml
+++ b/deploy/values/eval-fabric-api.yaml
@@ -1,3 +1,3 @@
 # eval-fabric-api
-image: { repository: eval-fabric-api, tag: sha-8ac9d58a53aaf4a6d1625c67a8bb4623d0186374 }
+image: { repository: eval-fabric-api, tag: latest }
 service: { port: 8080, portName: http }

--- a/deploy/values/evidence-console.yaml
+++ b/deploy/values/evidence-console.yaml
@@ -1,3 +1,3 @@
 # evidence-console
-image: { repository: evidence-console, tag: sha-8ac9d58a53aaf4a6d1625c67a8bb4623d0186374 }
+image: { repository: evidence-console, tag: latest }
 service: { port: 8080, portName: http }

--- a/deploy/values/evidence-receipts.yaml
+++ b/deploy/values/evidence-receipts.yaml
@@ -1,3 +1,3 @@
 # evidence-receipts
-image: { repository: evidence-receipts, tag: sha-8ac9d58a53aaf4a6d1625c67a8bb4623d0186374 }
+image: { repository: evidence-receipts, tag: latest }
 service: { port: 8080, portName: http }

--- a/deploy/values/gateway.yaml
+++ b/deploy/values/gateway.yaml
@@ -1,5 +1,5 @@
 # socioprophet-gateway — HTTP edge gateway
-image: { repository: socioprophet-gateway }
+image: { repository: socioprophet-gateway, tag: latest }
 service: { port: 8080, portName: http }
 ingress:
   enabled: true

--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -1,3 +1,3 @@
 # hellgraph-service
-image: { repository: hellgraph-service }
+image: { repository: hellgraph-service, tag: latest }
 service: { port: 8080, portName: http }

--- a/deploy/values/osm-map-api.yaml
+++ b/deploy/values/osm-map-api.yaml
@@ -1,3 +1,3 @@
 # osm-map-api
-image: { repository: osm-map-api }
+image: { repository: osm-map-api, tag: latest }
 service: { port: 8080, portName: http }

--- a/deploy/values/reasoning-failure-runner.yaml
+++ b/deploy/values/reasoning-failure-runner.yaml
@@ -1,3 +1,3 @@
 # reasoning-failure-runner
-image: { repository: reasoning-failure-runner }
+image: { repository: reasoning-failure-runner, tag: latest }
 service: { port: 8080, portName: http }

--- a/deploy/values/search-orchestrator.yaml
+++ b/deploy/values/search-orchestrator.yaml
@@ -1,4 +1,4 @@
 # search-orchestrator — search/index daemon
-image: { repository: search-orchestrator }
+image: { repository: search-orchestrator, tag: latest }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 4 }

--- a/deploy/values/socioprophet-web.yaml
+++ b/deploy/values/socioprophet-web.yaml
@@ -1,5 +1,5 @@
 # socioprophet-web — web portal
-image: { repository: socioprophet-web }
+image: { repository: socioprophet-web, tag: latest }
 service: { port: 8080, portName: http }
 ingress:
   enabled: true

--- a/deploy/values/workspace-caldav.yaml
+++ b/deploy/values/workspace-caldav.yaml
@@ -1,4 +1,4 @@
 # workspace-caldav — calendar/contacts (CalDAV/CardDAV)
-image: { repository: workspace-caldav, tag: sha-8ac9d58a53aaf4a6d1625c67a8bb4623d0186374 }
+image: { repository: workspace-caldav, tag: latest }
 service: { port: 8080, portName: http }
 config: { WORKSPACE_SURFACE: caldav }

--- a/deploy/values/workspace-mail.yaml
+++ b/deploy/values/workspace-mail.yaml
@@ -1,5 +1,5 @@
 # workspace-mail — IMAP mail store
-image: { repository: workspace-mail, tag: sha-8ac9d58a53aaf4a6d1625c67a8bb4623d0186374 }
+image: { repository: workspace-mail, tag: latest }
 service: { port: 143, portName: imap }
 probes: { enabled: true, httpGet: false }
 config: { WORKSPACE_SURFACE: mail }

--- a/deploy/values/workspace-smtp.yaml
+++ b/deploy/values/workspace-smtp.yaml
@@ -1,5 +1,5 @@
 # workspace-smtp — SMTP submission
-image: { repository: workspace-smtp, tag: sha-8ac9d58a53aaf4a6d1625c67a8bb4623d0186374 }
+image: { repository: workspace-smtp, tag: latest }
 service: { port: 587, portName: submission, extraPorts: [{ name: smtp, port: 25 }] }
 probes: { enabled: true, httpGet: false }
 config: { WORKSPACE_SURFACE: smtp }


### PR DESCRIPTION
The 23-pod cluster-wide ImagePullBackOff root cause: deployments resolve image tag to the chart appVersion `26.11` (or stale `sha-8ac9d58a`) — **neither exists in GAR**. `:latest` exists for all 11 built services. Pin `tag: latest` across `deploy/values/*.yaml`.

Unblocks 11/13 immediately. The 2 genuinely-missing images (`reasoning-failure-runner`, `socioprophet-web`) are built separately. `:latest` is mutable — fine for this short-lived dev bring-up (teardown planned); promote to immutable SHAs before a real env.