### PR TITLE
fix(socioprophet-web): build from repo-root context (resolve root contracts)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -37,7 +37,7 @@ jobs:
           # services keep their own dir as context.
           - { image: socioprophet-api,      context: .,                         dockerfile: apps/api/Dockerfile }
           - { image: socioprophet-gateway,  context: .,                         dockerfile: apps/gateway/Dockerfile }
-          - { image: socioprophet-web,      context: apps/socioprophet-web,     dockerfile: Dockerfile }
+          - { image: socioprophet-web,      context: .,                         dockerfile: apps/socioprophet-web/Dockerfile }
           - { image: evidence-console,      context: apps/evidence-console,     dockerfile: Dockerfile }
           - { image: evidence-receipts,     context: apps/evidence-receipts,    dockerfile: Dockerfile }
           - { image: eval-fabric-api,       context: apps/eval-fabric-api,      dockerfile: Dockerfile }

--- a/apps/socioprophet-web/Dockerfile
+++ b/apps/socioprophet-web/Dockerfile
@@ -1,11 +1,15 @@
 # syntax=docker/dockerfile:1.7
+# BUILD CONTEXT = REPO ROOT (see images.yml). The app imports repo-root contracts via
+# ../../../../contracts/*.json from src/components — those live OUTSIDE apps/socioprophet-web,
+# so the whole repo (contracts + app) must be in context and the app must build from its own dir
+# with the repo root at /app so the relative import resolves to /app/contracts.
 FROM node:20-alpine AS build
 WORKDIR /app
-COPY package.json pnpm-lock.yaml* ./
-RUN corepack enable && pnpm --version || true
-COPY . .
-RUN pnpm install --frozen-lockfile || pnpm install
+COPY contracts ./contracts
+COPY apps/socioprophet-web ./apps/socioprophet-web
+WORKDIR /app/apps/socioprophet-web
+RUN corepack enable && (pnpm install --frozen-lockfile || pnpm install)
 RUN pnpm build
 
 FROM nginx:1.27-alpine
-COPY --from=build /app/dist /usr/share/nginx/html
+COPY --from=build /app/apps/socioprophet-web/dist /usr/share/nginx/html


### PR DESCRIPTION
socioprophet-web was the only service that never built — 3 Vue cards import repo-root `../../../../contracts/*.json` which a `apps/socioprophet-web` context can't see, so vite fails. Fix: `context=.` (repo root), COPY `contracts/` + the app, build from the app dir → the import resolves to `/app/contracts`. **Verified locally** (`pnpm build` succeeds). images.yml updated to `context=.`.