### PR TITLE
fix(deploy): capture live bring-up fixes into GitOps + document ArgoCD sync blocker

### DIFF
--- a/charts/socioprophet-service/templates/deployment.yaml
+++ b/charts/socioprophet-service/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      enableServiceLinks: {{ .Values.enableServiceLinks }}
       containers:
         - name: {{ include "svc.name" . }}
           image: {{ include "svc.image" . | quote }}

--- a/charts/socioprophet-service/values.yaml
+++ b/charts/socioprophet-service/values.yaml
@@ -92,3 +92,6 @@ tolerations: []
 affinity: {}
 podAnnotations: {}
 podLabels: {}
+
+# Legacy docker-link service env vars (<SVC>_PORT=tcp://…) — disable per-service to avoid collisions.
+enableServiceLinks: true

--- a/deploy/DEPLOY_NOTES.md
+++ b/deploy/DEPLOY_NOTES.md
@@ -1,0 +1,29 @@
+# Deploy notes — bring-up state (2026-07-04)
+
+## What's captured here (verified live, moved to GitOps)
+- Image tags pinned to `:latest` (see per-service values) — the ImagePullBackOff root cause was
+  the chart falling back to appVersion `26.11`, which was never pushed. **`:latest` is mutable —
+  promote to immutable commit SHAs before any real environment.**
+- `TRITRPC_ALLOW_INSECURE_DEV_KEY: "1"` on api + gateway — **DEV ONLY**. For a real env, provision
+  a `TRITRPC_KEY_HEX` secret and set this back to `"0"`.
+- `enableServiceLinks: false` on osm-map-api — Kubernetes injects `OSM_MAP_API_PORT=tcp://<svc-ip>`
+  (legacy docker-link env), which the app `int()`s and crashes. Chart now supports the toggle.
+
+## KNOWN BLOCKER — ArgoCD sync is stuck (not fixed here)
+ArgoCD reports every app `Unknown/Degraded` with:
+`error calculating structured merge diff: .status.terminatingReplicas: field not declared in schema`
+This is a k8s-1.35 Deployment status field the installed ArgoCD's schema doesn't know, so it cannot
+compute a diff and **will not sync anything** — which is why today's fixes had to be applied with
+`kubectl set image`/`set env` directly rather than via GitOps.
+
+Fix options (need a live cluster to verify — deliberately NOT shipped unverified):
+1. Upgrade ArgoCD to a build that knows `terminatingReplicas` (preferred).
+2. Set `ServerSideDiff=false` (annotation `argocd.argoproj.io/compare-options: ServerSideDiff=false`)
+   on the appset-generated Applications.
+3. `resource.customizations.ignoreDifferences` in argocd-cm for apps/Deployment `.status`.
+
+Until this is fixed, GitOps sync is inert and changes must be applied imperatively.
+
+## Redeploy from clean
+`tofu apply` (environments/gcp-gke) recreates the cluster; the images are in GAR; ArgoCD then needs
+the sync fix above before it converges the workloads.

--- a/deploy/values/api.yaml
+++ b/deploy/values/api.yaml
@@ -4,6 +4,6 @@ service: { port: 9000, portName: tritrpc }
 probes: { enabled: true, httpGet: false }   # raw tritRPC, no HTTP health
 config:
   TRITRPC_LISTEN_ADDR: "tcp://0.0.0.0:9000"
-  TRITRPC_ALLOW_INSECURE_DEV_KEY: "0"
+  TRITRPC_ALLOW_INSECURE_DEV_KEY: "1"   # DEV ONLY — provision a real TRITRPC_KEY_HEX secret for prod
 secretEnv:
   TRITRPC_KEY_HEX: { secretName: tritrpc-shared-key, key: TRITRPC_KEY_HEX, optional: true }

--- a/deploy/values/gateway.yaml
+++ b/deploy/values/gateway.yaml
@@ -1,6 +1,9 @@
 # socioprophet-gateway — HTTP edge gateway
 image: { repository: socioprophet-gateway, tag: latest }
 service: { port: 8080, portName: http }
+config:
+  # DEV ONLY — provision a real TRITRPC_KEY_HEX secret for prod
+  TRITRPC_ALLOW_INSECURE_DEV_KEY: "1"
 ingress:
   enabled: true
   className: ""   # cluster default; set per-cloud (gce / azure-application-gateway / alb) via overlay

--- a/deploy/values/osm-map-api.yaml
+++ b/deploy/values/osm-map-api.yaml
@@ -1,3 +1,4 @@
 # osm-map-api
 image: { repository: osm-map-api, tag: latest }
 service: { port: 8080, portName: http }
+enableServiceLinks: false   # k8s injects OSM_MAP_API_PORT=tcp://<svc> otherwise → app int() crash


### PR DESCRIPTION
Moves today's imperative bring-up fixes into GitOps so a redeploy comes up further than the hand-patched state (the cluster is being torn down; these are captured, not re-verified live).

- **api + gateway** — `TRITRPC_ALLOW_INSECURE_DEV_KEY: "1"` (**DEV ONLY**; was `"0"` → crashloop "missing shared key"). Provision a real `TRITRPC_KEY_HEX` secret for prod.
- **osm-map-api** — `enableServiceLinks: false`. Kubernetes injected `OSM_MAP_API_PORT=tcp://<svc-ip>` (legacy docker-link env) which the app `int()`s and crashes. Chart now supports the toggle.
  - Caught a Go-template gotcha via `helm template`: `{{ .Values.x | default true }}` renders `true` even when `x=false` (`default` treats false as empty). Fixed to render `false`/`true` correctly.
- **deploy/DEPLOY_NOTES.md** — documents the `:latest`→SHA promotion needed for prod AND the **known ArgoCD sync blocker** (`terminatingReplicas` structured-merge-diff schema error on k8s 1.35 that blocks *all* sync — the reason today's fixes needed `kubectl` not GitOps). Fix options listed but deliberately **not shipped unverified**.

Verified in effect live today (dev key unblocked api; enableServiceLinks fixes osm). True convergence still gated on the ArgoCD sync fix.