### PR TITLE
feat(capability-membrane): unified capability-decision kernel (design C)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -510,3 +510,12 @@ validate-semantic-governance:
 
 validate-orggov-runtime-demo:
 	python3 tools/validate_orggov_runtime_demo.py
+
+validate-capability-membrane:
+	test -d .venv-tools || python3 -m venv .venv-tools
+	. .venv-tools/bin/activate && python -m pip install --upgrade pip pytest >/dev/null && pytest -q tools/tests/test_capability_membrane.py
+	mkdir -p build/capability-membrane
+	# CLI exits 3 on a non-allow (here REQUIRE_SIGNATURE→ask); the gate asserts a
+	# sealed receipt was still emitted for the deferred decision.
+	python3 -m tools.capability_membrane --operation fixtures/capability-membrane/operation-deploy-apply.decision.json --surface deployment --access destructive --tension policy,identity,provenance,evidence,replay,revocation,audit,post_authority_ref --autonomy-level L4 --evidence conductor_response_envelope --out build/capability-membrane/deploy-apply.sealed.json || true
+	test -s build/capability-membrane/deploy-apply.sealed.json

--- a/Makefile
+++ b/Makefile
@@ -513,7 +513,7 @@ validate-orggov-runtime-demo:
 
 validate-capability-membrane:
 	test -d .venv-tools || python3 -m venv .venv-tools
-	. .venv-tools/bin/activate && python -m pip install --upgrade pip pytest cryptography >/dev/null && pytest -q tools/tests/test_capability_membrane.py tools/tests/test_membrane_identity.py tools/tests/test_membrane_adversarial.py tools/tests/test_gapi_edge_policy.py tools/tests/test_ghost_audit.py
+	. .venv-tools/bin/activate && python -m pip install --upgrade pip pytest cryptography >/dev/null && pytest -q tools/tests/test_capability_membrane.py tools/tests/test_membrane_identity.py tools/tests/test_membrane_adversarial.py tools/tests/test_gapi_edge_policy.py tools/tests/test_ghost_audit.py tools/tests/test_proof_of_emptiness.py
 	mkdir -p build/capability-membrane
 	# CLI exits 3 on a non-allow (here REQUIRE_SIGNATURE→ask); the gate asserts a
 	# sealed receipt was still emitted for the deferred decision.

--- a/Makefile
+++ b/Makefile
@@ -513,7 +513,7 @@ validate-orggov-runtime-demo:
 
 validate-capability-membrane:
 	test -d .venv-tools || python3 -m venv .venv-tools
-	. .venv-tools/bin/activate && python -m pip install --upgrade pip pytest >/dev/null && pytest -q tools/tests/test_capability_membrane.py
+	. .venv-tools/bin/activate && python -m pip install --upgrade pip pytest cryptography >/dev/null && pytest -q tools/tests/test_capability_membrane.py tools/tests/test_membrane_identity.py tools/tests/test_membrane_adversarial.py tools/tests/test_gapi_edge_policy.py tools/tests/test_ghost_audit.py
 	mkdir -p build/capability-membrane
 	# CLI exits 3 on a non-allow (here REQUIRE_SIGNATURE→ask); the gate asserts a
 	# sealed receipt was still emitted for the deferred decision.

--- a/fixtures/capability-membrane/gapi-edge-policy.json
+++ b/fixtures/capability-membrane/gapi-edge-policy.json
@@ -1,0 +1,79 @@
+{
+  "provenance": {
+    "derived_from": "gapi-stack-hypergraph.json (Google gapi.iframes/gadgets.rpc recon)",
+    "note": "Each gapi hyperedge annotated with the resolve_capability inputs it demands, turning the recon's descriptive guards into executable membrane policy. 'nominal' = guards satisfied; 'violated' = a guard fails, and the membrane must degrade/deny. The validator runs every case through the kernel with full R5 tension present, so the membrane_decision drives the outcome (radius/tension are proven separately in the board)."
+  },
+  "edges": [
+    {
+      "edge_id": "h1_push_chunk", "gapi_type": "LOAD_CONFIG_CHUNK", "layer": "L1",
+      "gapi_guards": ["parse_ok"],
+      "surface": "filesystem", "action": "config.load", "access_level": "readOnly",
+      "nominal": {"membrane_decision": "ALLOW", "expect_execution": "allow"}
+    },
+    {
+      "edge_id": "h2_merge_cfg", "gapi_type": "MERGE_CONFIG", "layer": "L1",
+      "gapi_guards": ["merge_ok"],
+      "surface": "custom", "action": "config.merge", "access_level": "scopedWrite",
+      "nominal": {"membrane_decision": "ALLOW", "expect_execution": "allow"},
+      "violated": {"why": "untrusted config chunk", "membrane_decision": "QUARANTINE", "expect_execution": "deny"}
+    },
+    {
+      "edge_id": "h3_resolve_session", "gapi_type": "RESOLVE_SESSION_CONTEXT", "layer": "L2",
+      "gapi_guards": ["heuristics_ok"],
+      "surface": "custom", "action": "session.resolve", "access_level": "readOnly",
+      "nominal": {"membrane_decision": "ALLOW", "expect_execution": "allow"}
+    },
+    {
+      "edge_id": "h4_expand_template", "gapi_type": "EXPAND_TEMPLATE", "layer": "L1",
+      "gapi_guards": ["tokens_known"],
+      "surface": "httpApi", "action": "url.expand", "access_level": "draftOnly",
+      "nominal": {"membrane_decision": "ALLOW", "expect_execution": "allow"},
+      "violated": {"why": "unsafe scheme/token → SANITIZE_URL", "membrane_decision": "REDACT", "expect_execution": "rewrite"}
+    },
+    {
+      "edge_id": "h5_oauth_initiate", "gapi_type": "OAUTH_INITIATE", "layer": "L3",
+      "gapi_guards": ["user_action"],
+      "surface": "browser", "action": "oauth.initiate", "access_level": "send",
+      "nominal": {"why": "capability minting requires explicit user consent", "membrane_decision": "REQUIRE_SIGNATURE", "expect_execution": "ask"}
+    },
+    {
+      "edge_id": "h6_oauth_return", "gapi_type": "OAUTH_RETURN_POSTMESSAGE", "layer": "L3",
+      "gapi_guards": ["origin_ok", "state_ok"],
+      "surface": "browser", "action": "oauth.return", "access_level": "scopedWrite",
+      "nominal": {"membrane_decision": "ALLOW", "expect_execution": "allow"},
+      "violated": {"why": "origin/state mismatch (confused deputy)", "membrane_decision": "DENY", "expect_execution": "deny"}
+    },
+    {
+      "edge_id": "h7_issue", "gapi_type": "ISSUE", "layer": "L4",
+      "gapi_guards": ["service_allowed"],
+      "surface": "custom", "action": "rpc.issue", "access_level": "draftOnly",
+      "nominal": {"membrane_decision": "ALLOW", "expect_execution": "allow"}
+    },
+    {
+      "edge_id": "h8_route_select", "gapi_type": "ROUTE_RESOLVE", "layer": "L4",
+      "gapi_guards": ["transport_allowed"],
+      "surface": "custom", "action": "transport.route", "access_level": "scopedWrite",
+      "nominal": {"membrane_decision": "ALLOW", "expect_execution": "allow"}
+    },
+    {
+      "edge_id": "h9_send_deliver_verify", "gapi_type": "TRANSPORT_CHAIN", "layer": "L4",
+      "gapi_guards": ["origin_policy", "token_ok"],
+      "surface": "browser", "action": "rpc.dispatch", "access_level": "control",
+      "nominal": {"membrane_decision": "ALLOW", "expect_execution": "allow"},
+      "violated": {"why": "token_ok fails — cap_token invalid/replayed", "membrane_decision": "DENY", "expect_execution": "deny"}
+    },
+    {
+      "edge_id": "h10_api_batch", "gapi_type": "API_BATCH_RPC", "layer": "L5",
+      "gapi_guards": ["token_present"],
+      "surface": "httpApi", "action": "rpc.batch", "access_level": "send",
+      "nominal": {"membrane_decision": "ALLOW", "expect_execution": "allow"},
+      "violated": {"why": "no cap_token present on the batch", "membrane_decision": "REQUIRE_SIGNATURE", "expect_execution": "ask"}
+    },
+    {
+      "edge_id": "h11_telemetry", "gapi_type": "STORE_LOG", "layer": "L6",
+      "gapi_guards": ["sampled"],
+      "surface": "observability", "action": "telemetry.emit", "access_level": "readOnly",
+      "nominal": {"membrane_decision": "ALLOW", "expect_execution": "allow"}
+    }
+  ]
+}

--- a/fixtures/capability-membrane/operation-deploy-apply.decision.json
+++ b/fixtures/capability-membrane/operation-deploy-apply.decision.json
@@ -1,0 +1,12 @@
+{
+  "kind": "ProphetOperationsActionDecision",
+  "schema_version": "v1",
+  "decision_id": "op-deploy-001",
+  "decided_at": "2026-07-03T00:00:00Z",
+  "recommendation_ref": "urn:srcos:recommendation:deploy-001",
+  "subject": {"id": "urn:srcos:agent:ops-runner", "type": "service"},
+  "proposed_action": {"type": "deployment.apply", "intent": "roll out fogstack v0.1"},
+  "decision": {"outcome": "allow", "risk_level": "high"},
+  "basis": {"policy_refs": ["urn:srcos:policy:ops-default"]},
+  "controls": {"requires_human_approval": true}
+}

--- a/tools/capability_membrane.py
+++ b/tools/capability_membrane.py
@@ -117,6 +117,13 @@ CONNECTOR_RADIUS_FLOOR: Dict[str, str] = {
     "ci": "R4",
 }
 
+# Reserved / internal handler namespaces (gapi §8 "handler namespace collision":
+# only registered services are callable; reserved lifecycle handlers like
+# _g_connect / __cb must not be reachable by ordinary callers). Any action in a
+# reserved namespace floors to R5, so it is admissible only with an explicit
+# post_authority_ref tension member — a normal caller is denied fail-closed.
+RESERVED_ACTION_PREFIXES = ("_", "__", "internal.", "gapi._", "rpc._", "_g_")
+
 # --------------------------------------------------------------------------- #
 # 3. Membrane decision domain — slash-topics v0.2 (superset of platform v0.1)
 # --------------------------------------------------------------------------- #
@@ -214,6 +221,8 @@ class CapabilityRequest:
     machine_ref: str = "urn:srcos:agent-machine:local"
 
     def required_radius(self) -> str:
+        if any(self.action.startswith(p) for p in RESERVED_ACTION_PREFIXES):
+            return "R5"       # reserved/internal handler — top authority only
         floor = CONNECTOR_RADIUS_FLOOR.get(self.surface, "R0")
         base = ACCESS_TO_RADIUS.get(self.access_level, "R0")
         return floor if _rank(floor) >= _rank(base) else base
@@ -310,8 +319,15 @@ _EXECUTION_TO_VERDICT = {
 
 def resolve_capability(request: CapabilityRequest,
                        run_trace_hash: str = "",
-                       events_hash: str = "") -> CapabilityResolution:
-    """Compose the four kernels into one decision + one sealed receipt."""
+                       events_hash: str = "",
+                       signer: Any = None) -> CapabilityResolution:
+    """Compose the four kernels into one decision + one sealed receipt.
+
+    If `signer` (a membrane_identity.IdentityRoot) is supplied, the sealed
+    receipt is additionally signed (detached Ed25519 over the FOG preimage),
+    threading the sovereign DID through the receipt. Absent a signer the kernel
+    stays pure/stdlib-only and emits a valid unsigned receipt.
+    """
     reasons: List[str] = []
     obligations: List[Dict[str, str]] = []
 
@@ -406,6 +422,8 @@ def resolve_capability(request: CapabilityRequest,
     }
 
     sealed = seal_receipt(receipt, run_trace_hash=run_trace_hash, events_hash=events_hash)
+    if signer is not None:
+        sealed = signer.sign_sealed(sealed)
 
     return CapabilityResolution(
         request=request,

--- a/tools/capability_membrane.py
+++ b/tools/capability_membrane.py
@@ -1,0 +1,558 @@
+"""Capability membrane — the unified capability-decision kernel (design "C").
+
+One decision point every capability call routes through, composing FOUR
+already-shipped kernels rather than reinventing them:
+
+  1. Surface taxonomy   — sourceos-spec ConnectorActionScope.connectorKind
+                          (filesystem|shell|computer|browser|deployment|...),
+                          i.e. the same native surfaces a desktop agent exposes.
+  2. Capability radius   — agentplane R0..R5 (docs/specs/capability-radius-v0):
+                          each tier lists REQUIRED tension members; a work
+                          (compression) member never executes without its
+                          policy tension member (Tensegrity Invariant 1) →
+                          fail-closed QUARANTINE when a required member is absent.
+  3. Membrane decision   — slash-topics Membrane_Decision v0.2 /
+                          prophet-platform contracts/MembraneDecision.v0.1
+                          (ALLOW|DENY|QUARANTINE|REDACT|REQUIRE_SIGNATURE)
+                          × scope (user_local|global_platform).
+  4. Autonomy ladder     — tritfabric atlas/autonomy_gate L0..L5, fail-closed:
+                          a level is admitted only if its evidence is present;
+                          promotion BLOCKS rather than silently under-granting.
+
+The kernel collapses those into ONE sourceos-spec ExecutionDecision
+(allow|deny|ask|defer|rewrite) and emits ONE sealed AgentMachineReceipt whose
+`verdict` carries the honest enforce-vs-observe distinction:
+
+  * OWNED surface (ours)      → we enforce; verdict ∈ {allowed,denied,deferred}.
+  * FOREIGN surface (e.g. a  → we cannot enforce inside another process, so we
+    frontier client's           OBSERVE + receipt only; verdict = "observed",
+    computer_use)               enforced = False. Being explicit about this is
+                                the difference between a real membrane and a
+                                false one.
+
+Pure and local-first: no network, stdlib only. A membrane in the hot path of
+every capability call must not take a cloud round-trip.
+
+Conformance notes
+-----------------
+* Hashes are ``sha256:<lowercase-hex>`` over a JCS-style canonical form
+  (RFC 8785 subset: sorted keys, compact separators, UTF-8). Adequate for the
+  string/int/bool/array/object payloads here; floats are not used.
+* Seal binding follows agentplane seal_reasoning_receipt:
+  ``seal_hash = sha256( receipt_canonical || run_trace_hash || events_sha )``.
+* The autonomy ladder is loaded as DATA from the canonical
+  ``tritfabric/configs/autonomy-ladder.yaml`` when reachable, else the embedded
+  copy below (kept byte-equal to the canonical export). The kernel never forks
+  the ladder logic — it mirrors autonomy_gate.evaluate exactly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+SPEC_VERSION = "2.0.0"
+
+# --------------------------------------------------------------------------- #
+# 1. Surface taxonomy — mirrors sourceos-spec ConnectorActionScope.connectorKind
+# --------------------------------------------------------------------------- #
+
+# connectorKinds we treat as "actuating" (side-effecting on the world). The list
+# mirrors the spec enum; the classification here only drives the default radius.
+CONNECTOR_KINDS = (
+    "filesystem", "github", "gitlab", "email", "calendar", "drive", "slack",
+    "linear", "notion", "browser", "computer", "httpApi", "kafka", "rdbms",
+    "objectStore", "lakehouse", "shell", "ci", "deployment", "observability",
+    "custom",
+)
+
+# sourceos-spec ConnectorActionScope.accessLevel
+ACCESS_LEVELS = (
+    "none", "readOnly", "draftOnly", "commentOnly", "scopedWrite",
+    "send", "publish", "merge", "destructive", "control",
+)
+
+# --------------------------------------------------------------------------- #
+# 2. Capability radius — agentplane R0..R5 + required tension members
+#    (docs/specs/capability-radius-v0.md). Fail-closed if a required member
+#    is absent (Tensegrity Invariant 1).
+# --------------------------------------------------------------------------- #
+
+R_TIERS = ("R0", "R1", "R2", "R3", "R4", "R5")
+
+# Cumulative required tension members per radius, verbatim from capability-radius-v0.
+TENSION_REQUIRED: Dict[str, Tuple[str, ...]] = {
+    "R0": ("policy", "identity"),
+    "R1": ("policy", "identity", "provenance"),
+    "R2": ("policy", "identity", "provenance", "evidence", "replay"),
+    "R3": ("policy", "identity", "provenance", "evidence", "replay", "revocation"),
+    "R4": ("policy", "identity", "provenance", "evidence", "replay", "revocation", "audit"),
+    "R5": ("policy", "identity", "provenance", "evidence", "replay", "revocation", "audit", "post_authority_ref"),
+}
+
+# Map an accessLevel to its minimum capability radius. Reading is R0/R1; writing
+# to governed state is R3; deploy is R4; host/prod control is R5.
+ACCESS_TO_RADIUS: Dict[str, str] = {
+    "none": "R0",
+    "readOnly": "R1",
+    "commentOnly": "R1",
+    "draftOnly": "R2",
+    "scopedWrite": "R3",
+    "send": "R3",
+    "publish": "R3",
+    "merge": "R3",
+    "destructive": "R5",
+    "control": "R5",
+}
+
+# A few connector kinds float the floor up regardless of access level: driving
+# the OS or a browser session, or mutating a deployment, is never below these.
+CONNECTOR_RADIUS_FLOOR: Dict[str, str] = {
+    "computer": "R3",     # synthesises input into the live OS
+    "shell": "R3",        # spawns real processes
+    "deployment": "R4",   # stages/mutates environments
+    "ci": "R4",
+}
+
+# --------------------------------------------------------------------------- #
+# 3. Membrane decision domain — slash-topics v0.2 (superset of platform v0.1)
+# --------------------------------------------------------------------------- #
+
+MEMBRANE_DECISIONS = ("ALLOW", "DENY", "QUARANTINE", "REDACT", "REQUIRE_SIGNATURE")
+MEMBRANE_SCOPES = ("user_local", "global_platform")
+
+# --------------------------------------------------------------------------- #
+# 4. Autonomy ladder — mirrors tritfabric atlas/autonomy_gate (fail-closed).
+#    Embedded copy of configs/autonomy-ladder.yaml (canonical export from
+#    prophet-mesh:specs/ai-driven-development.yaml). evidence_required "none"
+#    is always satisfied; otherwise the token must be present.
+# --------------------------------------------------------------------------- #
+
+AUTONOMY_LADDER: List[Dict[str, str]] = [
+    {"level": "L0", "label": "manual", "evidence_required": "none"},
+    {"level": "L1", "label": "assisted", "evidence_required": "trail_log"},
+    {"level": "L2", "label": "automated_unit", "evidence_required": "test_result_or_review_receipt"},
+    {"level": "L3", "label": "automated_design", "evidence_required": "evidence_dossier"},
+    {"level": "L4", "label": "automated_solution", "evidence_required": "conductor_response_envelope"},
+    {"level": "L5", "label": "autonomous_governed", "evidence_required": "continuous_attestation_with_revocation"},
+]
+_LEVEL_RANK = {row["level"]: i for i, row in enumerate(AUTONOMY_LADDER)}
+
+
+@dataclass
+class AutonomyDecision:
+    """Mirror of tritfabric atlas.autonomy_gate.AutonomyDecision."""
+    ok: bool
+    requested_level: str
+    granted_level: str
+    reason: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "requested_level": self.requested_level,
+            "granted_level": self.granted_level,
+            "reason": self.reason,
+        }
+
+
+def evaluate_autonomy(requested_level: str, evidence: Iterable[str]) -> AutonomyDecision:
+    """Fail-closed admission, byte-for-byte semantics of autonomy_gate.evaluate.
+
+    The requested level is admitted only if its required evidence token is
+    present. The reason reports the highest level the evidence actually
+    supports (the ceiling), so a caller can see how far short it fell.
+    """
+    have = set(evidence or ())
+    requested = requested_level if requested_level in _LEVEL_RANK else "L0"
+
+    def satisfied(row: Dict[str, str]) -> bool:
+        need = row["evidence_required"]
+        return need in ("none", "", None) or need in have
+
+    # Ceiling = highest contiguous-independent level whose evidence is present.
+    ceiling = "L0"
+    for row in AUTONOMY_LADDER:
+        if satisfied(row):
+            ceiling = row["level"]
+    requested_row = AUTONOMY_LADDER[_LEVEL_RANK[requested]]
+    ok = satisfied(requested_row)
+    if ok:
+        reason = f"evidence satisfies gate for {requested} ({requested_row['label']})"
+    else:
+        reason = (
+            f"blocked: {requested} requires '{requested_row['evidence_required']}'; "
+            f"evidence supports at most {ceiling}"
+        )
+    return AutonomyDecision(ok=ok, requested_level=requested, granted_level=ceiling, reason=reason)
+
+
+# --------------------------------------------------------------------------- #
+# Request / resolution model
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class CapabilityRequest:
+    """A single capability call arriving at a surface."""
+    surface: str                       # connectorKind, e.g. "shell" | "computer" | "browser"
+    action: str                        # dotted action, e.g. "shell.exec", "computer.screencapture"
+    access_level: str                  # ConnectorActionScope.accessLevel
+    subject_ref: str                   # urn:srcos:agent:... or user
+    scope: str = "user_local"          # user_local | global_platform
+    owned: bool = True                 # do WE control this surface? False => observe-only
+    object_ref: Optional[str] = None
+    tension_members: Sequence[str] = field(default_factory=tuple)  # present governance members
+    requested_autonomy_level: str = "L0"
+    autonomy_evidence: Sequence[str] = field(default_factory=tuple)
+    membrane_decision: str = "ALLOW"   # upstream policy verdict (from policyMembrane.membraneRef)
+    policy_refs: Sequence[str] = field(default_factory=tuple)
+    risk_level: str = "low"            # low|medium|high|critical
+    may_transmit_content: bool = False  # ConnectorActionScope.dataExposure.mayTransmitContent
+    machine_ref: str = "urn:srcos:agent-machine:local"
+
+    def required_radius(self) -> str:
+        floor = CONNECTOR_RADIUS_FLOOR.get(self.surface, "R0")
+        base = ACCESS_TO_RADIUS.get(self.access_level, "R0")
+        return floor if _rank(floor) >= _rank(base) else base
+
+
+@dataclass
+class CapabilityResolution:
+    request: CapabilityRequest
+    radius: str
+    required_tension: Tuple[str, ...]
+    missing_tension: Tuple[str, ...]
+    membrane_decision: str
+    autonomy: AutonomyDecision
+    execution_decision: str            # allow|deny|ask|defer|rewrite (sourceos ExecutionDecision)
+    verdict: str                       # allowed|denied|deferred|failed|observed (AgentMachineReceipt)
+    enforced: bool
+    obligations: List[Dict[str, str]]
+    reasons: List[str]
+    receipt: Dict[str, Any]
+    sealed: Dict[str, Any]
+
+    @property
+    def allowed(self) -> bool:
+        return self.execution_decision == "allow" and self.enforced
+
+
+# --------------------------------------------------------------------------- #
+# Canonicalization + sealing (conforms to FOG_ENVELOPE_CANONICALIZATION + agentplane)
+# --------------------------------------------------------------------------- #
+
+def _canonical(obj: Any) -> bytes:
+    """JCS-style canonical bytes: sorted keys, compact separators, UTF-8."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _rank(tier: str) -> int:
+    return R_TIERS.index(tier) if tier in R_TIERS else 0
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def seal_receipt(receipt: Dict[str, Any], run_trace_hash: str = "", events_hash: str = "") -> Dict[str, Any]:
+    """agentplane seal_reasoning_receipt binding:
+    seal_hash = sha256( receipt_canonical || run_trace_hash || events_sha ).
+    """
+    preimage = _canonical(receipt) + run_trace_hash.encode("utf-8") + events_hash.encode("utf-8")
+    seal_hash = _sha256(preimage)
+    local = seal_hash.split(":", 1)[1][:32]
+    return {
+        "id": f"urn:srcos:evidence:sealed-reasoning:{local}",
+        "type": "SealedReasoningEvidence",
+        "specVersion": SPEC_VERSION,
+        "sealedAt": _now(),
+        "sealingAuthority": "urn:srcos:authority:capability-membrane",
+        "sealHash": seal_hash,
+        "binding": {
+            "receiptHash": _sha256(_canonical(receipt)),
+            "runTraceHash": run_trace_hash,
+            "eventsHash": events_hash,
+        },
+        "receipt": receipt,
+        "verifyHint": "recompute sealHash over receipt||runTraceHash||eventsHash",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# The kernel
+# --------------------------------------------------------------------------- #
+
+# How a membrane decision collapses into a sourceos ExecutionDecision outcome,
+# assuming the surface is owned/enforceable and radius+autonomy are satisfied.
+_MEMBRANE_TO_EXECUTION = {
+    "ALLOW": "allow",
+    "DENY": "deny",
+    "QUARANTINE": "deny",
+    "REDACT": "rewrite",           # proceed, but mask fields (obligation)
+    "REQUIRE_SIGNATURE": "ask",     # proceed only once a signature is attached
+}
+
+_EXECUTION_TO_VERDICT = {
+    "allow": "allowed",
+    "deny": "denied",
+    "ask": "deferred",
+    "defer": "deferred",
+    "rewrite": "allowed",
+}
+
+
+def resolve_capability(request: CapabilityRequest,
+                       run_trace_hash: str = "",
+                       events_hash: str = "") -> CapabilityResolution:
+    """Compose the four kernels into one decision + one sealed receipt."""
+    reasons: List[str] = []
+    obligations: List[Dict[str, str]] = []
+
+    if request.membrane_decision not in MEMBRANE_DECISIONS:
+        raise ValueError(f"unknown membrane decision: {request.membrane_decision!r}")
+    if request.scope not in MEMBRANE_SCOPES:
+        raise ValueError(f"unknown scope: {request.scope!r}")
+
+    # (2) Capability radius + tension-member fail-closed (Tensegrity Invariant 1).
+    radius = request.required_radius()
+    required = TENSION_REQUIRED[radius]
+    present = set(request.tension_members or ())
+    missing = tuple(m for m in required if m not in present)
+    tension_ok = not missing
+    if missing:
+        reasons.append(
+            f"radius {radius} requires tension members {list(required)}; missing {list(missing)}"
+        )
+
+    # (4) Autonomy ladder (fail-closed).
+    autonomy = evaluate_autonomy(request.requested_autonomy_level, request.autonomy_evidence)
+    if not autonomy.ok:
+        reasons.append(autonomy.reason)
+
+    # (3) Membrane decision → base execution outcome.
+    membrane = request.membrane_decision
+    base_outcome = _MEMBRANE_TO_EXECUTION[membrane]
+    if membrane == "REDACT":
+        obligations.append({"name": "mask_fields", "when": "runtime"})
+        reasons.append("membrane REDACT → rewrite with mask_fields obligation")
+    elif membrane == "REQUIRE_SIGNATURE":
+        reasons.append("membrane REQUIRE_SIGNATURE → ask (signature required before release)")
+    elif membrane in ("DENY", "QUARANTINE"):
+        reasons.append(f"membrane {membrane} → deny")
+
+    # Collapse: any fail-closed condition dominates ALLOW/REDACT/REQUIRE_SIGNATURE.
+    if base_outcome == "deny":
+        execution = "deny"
+    elif not tension_ok:
+        execution = "deny"          # fail-closed on missing governance
+    elif not autonomy.ok:
+        execution = "deny"          # over-claimed autonomy
+    else:
+        execution = base_outcome    # allow | rewrite | ask
+
+    # Enforce-vs-observe: on a foreign surface we cannot prevent the action; we
+    # record the decision we WOULD make and mark it advisory.
+    if request.owned:
+        enforced = True
+        verdict = _EXECUTION_TO_VERDICT[execution]
+    else:
+        enforced = False
+        verdict = "observed"
+        reasons.append(
+            "foreign surface: membrane cannot enforce inside another process — "
+            "decision is advisory (observe + receipt only)"
+        )
+
+    # Emit a sourceos-spec AgentMachineReceipt (+ embedded PolicyDecision hash).
+    decision_body = {
+        "surface": request.surface,
+        "action": request.action,
+        "accessLevel": request.access_level,
+        "scope": request.scope,
+        "radius": radius,
+        "requiredTension": list(required),
+        "missingTension": list(missing),
+        "membraneDecision": membrane,
+        "autonomy": autonomy.to_dict(),
+        "executionDecision": execution,
+        "obligations": obligations,
+        "riskLevel": request.risk_level,
+    }
+    decision_hash = _sha256(_canonical(decision_body))
+
+    receipt: Dict[str, Any] = {
+        "id": "urn:srcos:agent-machine-receipt:" + decision_hash.split(":", 1)[1][:24],
+        "type": "AgentMachineReceipt",
+        "specVersion": SPEC_VERSION,
+        "machineRef": request.machine_ref,
+        "receiptClass": "execution" if request.owned else "probe",
+        "issuedAt": _now(),
+        "subjectRef": request.subject_ref,
+        "objectRef": request.object_ref,
+        "verdict": verdict,
+        "enforced": enforced,
+        "policyDecisionRef": list(request.policy_refs),
+        "decisionHash": decision_hash,
+        "evidenceHash": decision_hash,
+        "decision": decision_body,
+        "reasons": reasons,
+    }
+
+    sealed = seal_receipt(receipt, run_trace_hash=run_trace_hash, events_hash=events_hash)
+
+    return CapabilityResolution(
+        request=request,
+        radius=radius,
+        required_tension=required,
+        missing_tension=missing,
+        membrane_decision=membrane,
+        autonomy=autonomy,
+        execution_decision=execution,
+        verdict=verdict,
+        enforced=enforced,
+        obligations=obligations,
+        reasons=reasons,
+        receipt=receipt,
+        sealed=sealed,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Reference wiring — compose over the owned prophet-platform policy-fabric surface
+# (schemas/external/policy-fabric/prophet_operations_action_decision_v1). The
+# policy-fabric produces the ABAC outcome; the membrane then unifies it with
+# radius + tension + autonomy + seal into ONE enforced decision + receipt.
+# --------------------------------------------------------------------------- #
+
+# ProphetOperationsActionDecision.decision.outcome → Membrane decision domain.
+# `unknown` is treated fail-closed (QUARANTINE), never as a silent allow.
+POLICY_FABRIC_OUTCOME_TO_MEMBRANE = {
+    "allow": "ALLOW",
+    "deny": "DENY",
+    "manual_review": "REQUIRE_SIGNATURE",
+    "defer": "REQUIRE_SIGNATURE",
+    "unknown": "QUARANTINE",
+}
+
+
+def request_from_operation_decision(
+    decision: Dict[str, Any],
+    *,
+    surface: str,
+    access_level: str,
+    subject_ref: Optional[str] = None,
+    scope: str = "user_local",
+    owned: bool = True,
+    tension_members: Sequence[str] = (),
+    requested_autonomy_level: str = "L0",
+    autonomy_evidence: Sequence[str] = (),
+    machine_ref: str = "urn:srcos:agent-machine:local",
+) -> CapabilityRequest:
+    """Map a policy-fabric ProphetOperationsActionDecision into a CapabilityRequest.
+
+    This is the seam that lets the membrane enforce OVER the existing owned
+    surface rather than replace it: the policy-fabric outcome becomes the
+    membrane decision input, then radius/tension/autonomy compose on top.
+    """
+    d = decision.get("decision", {}) or {}
+    outcome = d.get("outcome", "unknown")
+    membrane = POLICY_FABRIC_OUTCOME_TO_MEMBRANE.get(outcome, "QUARANTINE")
+
+    controls = decision.get("controls", {}) or {}
+    if membrane == "ALLOW" and controls.get("requires_human_approval"):
+        membrane = "REQUIRE_SIGNATURE"
+
+    action_obj = decision.get("proposed_action", {}) or {}
+    action = action_obj.get("type") or action_obj.get("intent") or "operation.execute"
+    subject = subject_ref or (decision.get("subject", {}) or {}).get("id") or "urn:srcos:subject:unknown"
+    basis = decision.get("basis", {}) or {}
+
+    return CapabilityRequest(
+        surface=surface,
+        action=action,
+        access_level=access_level,
+        subject_ref=subject,
+        scope=scope,
+        owned=owned,
+        tension_members=tuple(tension_members),
+        requested_autonomy_level=requested_autonomy_level,
+        autonomy_evidence=tuple(autonomy_evidence),
+        membrane_decision=membrane,
+        policy_refs=tuple(basis.get("policy_refs", []) or []),
+        risk_level=d.get("risk_level") or "low",
+        machine_ref=machine_ref,
+    )
+
+
+def _cli(argv: Optional[Sequence[str]] = None) -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(description="Resolve a capability call through the unified membrane.")
+    p.add_argument("--operation", type=str, help="path to a ProphetOperationsActionDecision JSON")
+    p.add_argument("--surface", required=True, help="connectorKind, e.g. shell|computer|browser|deployment")
+    p.add_argument("--access", required=True, help="ConnectorActionScope accessLevel")
+    p.add_argument("--subject", default=None)
+    p.add_argument("--scope", default="user_local", choices=list(MEMBRANE_SCOPES))
+    p.add_argument("--foreign", action="store_true", help="surface is NOT ours → observe-only")
+    p.add_argument("--tension", default="", help="comma-separated present tension members")
+    p.add_argument("--membrane", default="ALLOW", choices=list(MEMBRANE_DECISIONS),
+                   help="membrane decision (ignored when --operation is given)")
+    p.add_argument("--autonomy-level", default="L0")
+    p.add_argument("--evidence", default="", help="comma-separated autonomy evidence tokens")
+    p.add_argument("--out", type=str, help="write sealed receipt JSON here (default stdout)")
+    args = p.parse_args(argv)
+
+    tension = tuple(t for t in args.tension.split(",") if t)
+    evidence = tuple(e for e in args.evidence.split(",") if e)
+
+    if args.operation:
+        decision = json.loads(open(args.operation, encoding="utf-8").read())
+        request = request_from_operation_decision(
+            decision, surface=args.surface, access_level=args.access,
+            subject_ref=args.subject, scope=args.scope, owned=not args.foreign,
+            tension_members=tension, requested_autonomy_level=args.autonomy_level,
+            autonomy_evidence=evidence,
+        )
+    else:
+        request = CapabilityRequest(
+            surface=args.surface, action=f"{args.surface}.invoke", access_level=args.access,
+            subject_ref=args.subject or "urn:srcos:subject:cli", scope=args.scope,
+            owned=not args.foreign, tension_members=tension, membrane_decision=args.membrane,
+            requested_autonomy_level=args.autonomy_level, autonomy_evidence=evidence,
+        )
+
+    resolution = resolve_capability(request)
+    out = json.dumps(resolution.sealed, indent=2, sort_keys=True)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            fh.write(out + "\n")
+    else:
+        print(out)
+    # Exit non-zero when the enforced decision is not an allow, so CI/guards can gate on it.
+    return 0 if resolution.allowed else 3
+
+
+__all__ = [
+    "CapabilityRequest",
+    "CapabilityResolution",
+    "AutonomyDecision",
+    "evaluate_autonomy",
+    "resolve_capability",
+    "request_from_operation_decision",
+    "seal_receipt",
+    "TENSION_REQUIRED",
+    "AUTONOMY_LADDER",
+    "MEMBRANE_DECISIONS",
+]
+
+
+if __name__ == "__main__":
+    import sys as _sys
+    raise SystemExit(_cli(_sys.argv[1:]))

--- a/tools/ghost_audit.py
+++ b/tools/ghost_audit.py
@@ -34,6 +34,7 @@ class StateDelta:
     subject: str
     authorized_by: Optional[str] = None   # receipt id it claims authorized it
     at: str = ""
+    is_erasure: bool = False              # a deletion/redaction — needs a Proof-of-Emptiness
 
 
 @dataclass
@@ -94,13 +95,21 @@ def audit(
     count as authorizing (defends against a forged/absent receipt). `verify` is
     a callable (e.g. membrane_identity.verify_sealed) taking the sealed record.
     """
+    from tools.proof_of_emptiness import is_valid_poe
+
     # Index authorizing receipts: enforced ALLOW, optionally signature-verified.
+    # Proof-of-Emptiness receipts are indexed separately — an erasure is authorized
+    # by a *valid PoE*, never by an ordinary enforced-allow (that would be a silent sink).
     authorizing: Dict[str, str] = {}   # receipt_id -> failure reason ("" = ok)
+    poe_ok: Dict[str, bool] = {}       # receipt_id -> is this a valid Proof-of-Emptiness
     signed_ok: Dict[str, bool] = {}
     for entry in journal:
         rc = _receipt_of(entry)
         rid = rc.get("id")
         if not rid:
+            continue
+        if rc.get("type") == "ProofOfEmptiness":
+            poe_ok[rid] = is_valid_poe(entry)
             continue
         if require_signed:
             sig_ok = bool(verify and verify(entry) if isinstance(entry, dict) and "signature" in entry else False)
@@ -116,6 +125,23 @@ def audit(
     attested = 0
     for d in deltas:
         rid = d.authorized_by
+
+        # Erasures obey the stricter no-silent-sinks rule: a certified PoE, or ghost.
+        if d.is_erasure:
+            if not rid:
+                ghosts.append(Ghost(d.id, "uncertified_erase", "deletion with no Proof-of-Emptiness"))
+            elif rid in poe_ok:
+                if poe_ok[rid]:
+                    attested += 1
+                else:
+                    ghosts.append(Ghost(d.id, "uncertified_erase", f"PoE {rid} did not reach ∅ (H(X₀)≠H(∅))"))
+            elif rid in authorizing:
+                ghosts.append(Ghost(d.id, "not_a_proof_of_emptiness",
+                                    f"deletion authorized by ordinary receipt {rid} (silent sink)"))
+            else:
+                ghosts.append(Ghost(d.id, "receipt_missing", f"claims PoE {rid} absent from journal"))
+            continue
+
         if not rid:
             ghosts.append(Ghost(d.id, "no_receipt", "state change with no authorizing receipt"))
             continue
@@ -136,7 +162,8 @@ def audit(
 def _load_deltas(raw: Sequence[Dict[str, Any]]) -> List[StateDelta]:
     return [
         StateDelta(id=d["id"], action=d.get("action", ""), subject=d.get("subject", ""),
-                   authorized_by=d.get("authorized_by"), at=d.get("at", ""))
+                   authorized_by=d.get("authorized_by"), at=d.get("at", ""),
+                   is_erasure=bool(d.get("is_erasure", False)))
         for d in raw
     ]
 

--- a/tools/ghost_audit.py
+++ b/tools/ghost_audit.py
@@ -1,0 +1,177 @@
+"""Ghost audit — the first measurement of "ghostry".
+
+From the gapi→TriTRPC recon: ghostry is the degree to which an actor can cause
+state changes WITHOUT crossing an observable/attestable edge. The capability
+membrane's receipts make that quantifiable: a state change is attested iff a
+membrane receipt ENFORCED an ALLOW for it.
+
+    ghost surface = any state delta with no preceding enforced-allow receipt
+                    (missing, un-enforced/observed, denied, or — under
+                    require_signed — unsigned/forged).
+
+This replays a receipt journal against the observed state deltas and reports the
+ghosts + a ghostry score in [0,1] (0 = fully attested, 1 = every change a ghost).
+Governance you cannot falsify is theater; ghostry you cannot measure is a hope.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+# Only an ENFORCED ALLOW authorizes a state change. Everything else — a deferred
+# ask, a denial, or an OBSERVED (foreign, unenforceable) verdict — leaves any
+# resulting state delta a ghost.
+AUTHORIZING_VERDICT = "allowed"
+
+
+@dataclass
+class StateDelta:
+    """An observed change to durable state that claims some authorizing receipt."""
+    id: str
+    action: str
+    subject: str
+    authorized_by: Optional[str] = None   # receipt id it claims authorized it
+    at: str = ""
+
+
+@dataclass
+class Ghost:
+    delta_id: str
+    reason: str
+    detail: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"deltaId": self.delta_id, "reason": self.reason, "detail": self.detail}
+
+
+@dataclass
+class GhostReport:
+    total_deltas: int
+    attested: int
+    ghosts: List[Ghost] = field(default_factory=list)
+
+    @property
+    def ghostry(self) -> float:
+        return 0.0 if self.total_deltas == 0 else round(len(self.ghosts) / self.total_deltas, 6)
+
+    @property
+    def clean(self) -> bool:
+        return not self.ghosts
+
+    def to_dict(self) -> Dict[str, Any]:
+        by_reason: Dict[str, int] = {}
+        for g in self.ghosts:
+            by_reason[g.reason] = by_reason.get(g.reason, 0) + 1
+        return {
+            "type": "GhostAuditReport",
+            "specVersion": "0.1.0",
+            "totalDeltas": self.total_deltas,
+            "attested": self.attested,
+            "ghostCount": len(self.ghosts),
+            "ghostry": self.ghostry,
+            "byReason": by_reason,
+            "ghosts": [g.to_dict() for g in self.ghosts],
+        }
+
+
+def _receipt_of(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """Journal entries may be sealed records (with .receipt) or bare receipts."""
+    return entry.get("receipt", entry) if isinstance(entry, dict) else {}
+
+
+def audit(
+    journal: Sequence[Dict[str, Any]],
+    deltas: Sequence[StateDelta],
+    *,
+    require_signed: bool = False,
+    verify: Optional[Callable[[Dict[str, Any]], bool]] = None,
+) -> GhostReport:
+    """Replay the journal against the deltas and surface the ghost set.
+
+    require_signed: entries must be sealed records with a valid signature to
+    count as authorizing (defends against a forged/absent receipt). `verify` is
+    a callable (e.g. membrane_identity.verify_sealed) taking the sealed record.
+    """
+    # Index authorizing receipts: enforced ALLOW, optionally signature-verified.
+    authorizing: Dict[str, str] = {}   # receipt_id -> failure reason ("" = ok)
+    signed_ok: Dict[str, bool] = {}
+    for entry in journal:
+        rc = _receipt_of(entry)
+        rid = rc.get("id")
+        if not rid:
+            continue
+        if require_signed:
+            sig_ok = bool(verify and verify(entry) if isinstance(entry, dict) and "signature" in entry else False)
+            signed_ok[rid] = sig_ok
+        if not rc.get("enforced", False):
+            authorizing[rid] = "not_enforced"       # observed / advisory
+        elif rc.get("verdict") != AUTHORIZING_VERDICT:
+            authorizing[rid] = "not_allowed"         # denied / deferred
+        else:
+            authorizing[rid] = ""                    # enforced allow
+
+    ghosts: List[Ghost] = []
+    attested = 0
+    for d in deltas:
+        rid = d.authorized_by
+        if not rid:
+            ghosts.append(Ghost(d.id, "no_receipt", "state change with no authorizing receipt"))
+            continue
+        if rid not in authorizing:
+            ghosts.append(Ghost(d.id, "receipt_missing", f"claims receipt {rid} absent from journal"))
+            continue
+        reason = authorizing[rid]
+        if reason:
+            ghosts.append(Ghost(d.id, reason, f"authorizing receipt {rid} was {reason}"))
+            continue
+        if require_signed and not signed_ok.get(rid, False):
+            ghosts.append(Ghost(d.id, "bad_signature", f"receipt {rid} unsigned or signature invalid"))
+            continue
+        attested += 1
+    return GhostReport(total_deltas=len(deltas), attested=attested, ghosts=ghosts)
+
+
+def _load_deltas(raw: Sequence[Dict[str, Any]]) -> List[StateDelta]:
+    return [
+        StateDelta(id=d["id"], action=d.get("action", ""), subject=d.get("subject", ""),
+                   authorized_by=d.get("authorized_by"), at=d.get("at", ""))
+        for d in raw
+    ]
+
+
+def _cli(argv: Optional[Sequence[str]] = None) -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(description="Measure ghostry: state deltas with no enforced-allow receipt.")
+    p.add_argument("--journal", required=True, help="JSON array of sealed receipts / receipts")
+    p.add_argument("--deltas", required=True, help="JSON array of {id, action, subject, authorized_by}")
+    p.add_argument("--require-signed", action="store_true")
+    p.add_argument("--out", type=str)
+    args = p.parse_args(argv)
+
+    journal = json.loads(open(args.journal, encoding="utf-8").read())
+    deltas = _load_deltas(json.loads(open(args.deltas, encoding="utf-8").read()))
+    verify = None
+    if args.require_signed:
+        try:
+            from tools.membrane_identity import verify_sealed as verify  # type: ignore
+        except Exception:
+            verify = None
+    report = audit(journal, deltas, require_signed=args.require_signed, verify=verify)
+    out = json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    if args.out:
+        open(args.out, "w", encoding="utf-8").write(out + "\n")
+    else:
+        print(out)
+    # Non-zero when any ghost is found, so CI/guards can gate on ghostry == 0.
+    return 0 if report.clean else 4
+
+
+__all__ = ["StateDelta", "Ghost", "GhostReport", "audit"]
+
+
+if __name__ == "__main__":
+    import sys as _sys
+    raise SystemExit(_cli(_sys.argv[1:]))

--- a/tools/membrane_identity.py
+++ b/tools/membrane_identity.py
@@ -1,0 +1,235 @@
+"""IdentityRoot — the single sovereign identity that threads the three layers.
+
+One DID that (a) roots attestation on the twin (SPIRE SVID reference), (b) mints
+capability tokens (the gapi/OAuth "capability minting" plane), and (c) signs the
+membrane's sealed receipt (the CAIRN_COMMIT). Wiring one identity through all
+three turns the wire → decision → ground stack into a single verifiable chain,
+and gives "breach" (hard identity rotation) something concrete to rotate.
+
+    DID (did:key, Ed25519)
+      ├── svid_ref     → SPIRE/SVID attestation on the immutable twin (R0 root)
+      ├── mint_cap_token → CapabilityToken issuer (sourceos-spec shape)
+      └── sign_sealed  → Ed25519 signature over the sealed AgentMachineReceipt
+
+Signing is ADDITIVE: the capability-membrane kernel stays pure/stdlib-only and
+emits valid unsigned receipts; when an IdentityRoot is supplied it attaches a
+detached `ed25519:<base64url>` signature over the sourceos FOG preimage
+(SRCOS-FOG-V1\\n<type>\\n<id>\\n<payload-hash>). Requires the `cryptography`
+package; absent it, HAVE_CRYPTO is False and signing helpers raise clearly so
+callers can skip rather than emit a fake signature.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+try:  # real crypto if available; never fabricate a signature without it
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+        Ed25519PublicKey,
+    )
+    HAVE_CRYPTO = True
+except Exception:  # pragma: no cover - exercised only on stripped envs
+    HAVE_CRYPTO = False
+
+# multicodec varint prefix for an Ed25519 public key (0xed 0x01)
+_ED25519_MULTICODEC = b"\xed\x01"
+_B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+
+def _canonical(obj: Any) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _sha256_hex(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _b64u(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b58encode(data: bytes) -> str:
+    n = int.from_bytes(data, "big")
+    out = ""
+    while n > 0:
+        n, r = divmod(n, 58)
+        out = _B58[r] + out
+    pad = len(data) - len(data.lstrip(b"\x00"))
+    return "1" * pad + out
+
+
+def _b58decode(s: str) -> bytes:
+    n = 0
+    for ch in s:
+        n = n * 58 + _B58.index(ch)
+    body = n.to_bytes((n.bit_length() + 7) // 8, "big")
+    pad = len(s) - len(s.lstrip("1"))
+    return b"\x00" * pad + body
+
+
+def did_key_from_pubkey(pubkey: bytes) -> str:
+    """did:key encoding for an Ed25519 public key (multibase base58btc, 'z')."""
+    return "did:key:z" + _b58encode(_ED25519_MULTICODEC + pubkey)
+
+
+def pubkey_from_did_key(did: str) -> bytes:
+    if not did.startswith("did:key:z"):
+        raise ValueError(f"not a did:key: {did!r}")
+    raw = _b58decode(did[len("did:key:z"):])
+    if not raw.startswith(_ED25519_MULTICODEC):
+        raise ValueError("did:key is not an Ed25519 key")
+    return raw[len(_ED25519_MULTICODEC):]
+
+
+def fog_preimage(obj_type: str, obj_id: str, payload_hash: str) -> bytes:
+    """sourceos FOG domain-separated preimage (FOG_ENVELOPE_CANONICALIZATION)."""
+    return f"SRCOS-FOG-V1\n{obj_type}\n{obj_id}\n{payload_hash}".encode("utf-8")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class IdentityRoot:
+    """A sovereign signing identity. Generate fresh, or restore from a 32-byte seed."""
+    _sk: Any = field(default=None, repr=False)
+    svid_ref: Optional[str] = None          # urn:srcos:svid:... (SPIRE attestation on the twin)
+    _did: str = field(default="", repr=False)
+
+    def __post_init__(self) -> None:
+        if not HAVE_CRYPTO:
+            raise RuntimeError("cryptography not available — cannot mint a signing identity")
+        if self._sk is None:
+            self._sk = Ed25519PrivateKey.generate()
+        self._did = did_key_from_pubkey(self.public_key_bytes)
+
+    @classmethod
+    def from_seed(cls, seed: bytes, svid_ref: Optional[str] = None) -> "IdentityRoot":
+        if not HAVE_CRYPTO:
+            raise RuntimeError("cryptography not available")
+        if len(seed) != 32:
+            raise ValueError("seed must be 32 bytes")
+        return cls(_sk=Ed25519PrivateKey.from_private_bytes(seed), svid_ref=svid_ref)
+
+    @property
+    def public_key_bytes(self) -> bytes:
+        from cryptography.hazmat.primitives import serialization
+        return self._sk.public_key().public_bytes(
+            serialization.Encoding.Raw, serialization.PublicFormat.Raw
+        )
+
+    @property
+    def did(self) -> str:
+        return self._did
+
+    # -- signing -------------------------------------------------------------
+    def sign(self, data: bytes) -> str:
+        return "ed25519:" + _b64u(self._sk.sign(data))
+
+    def sign_sealed(self, sealed: Dict[str, Any]) -> Dict[str, Any]:
+        """Attach a detached signature over the sealed record's FOG preimage.
+
+        The preimage binds to the record's sealHash (which already binds the
+        receipt), so the signature is tamper-evident against any mutation of the
+        receipt, the seal, or the identity.
+        """
+        payload_hash = sealed.get("sealHash") or _sha256_hex(_canonical(sealed))
+        preimage = fog_preimage(sealed.get("type", "SealedReasoningEvidence"), sealed.get("id", ""), payload_hash)
+        signed = dict(sealed)
+        signed["signerDid"] = self.did
+        signed["svidRef"] = self.svid_ref
+        signed["signedAt"] = _now()
+        signed["signature"] = self.sign(preimage)
+        return signed
+
+    # -- capability minting (gapi/OAuth "capability minting" plane) -----------
+    def mint_cap_token(
+        self,
+        *,
+        subject_id: str,
+        operations: Sequence[str],
+        ttl_seconds: int = 900,
+        dataset_ids: Sequence[str] = (),
+        decision_ref: str = "urn:srcos:decision:membrane",
+    ) -> Dict[str, Any]:
+        """Issue a sourceos-spec CapabilityToken, signed by this identity.
+
+        Mirrors the gapi cap_token = f(AgentContract, user policy, time window):
+        scoped, short-lived, and bound to the issuing DID.
+        """
+        body = {
+            "tokenId": "urn:srcos:capability-token:" + hashlib.sha256(
+                f"{self.did}|{subject_id}|{time.time_ns()}".encode()
+            ).hexdigest()[:24],
+            "subject": {"subjectId": subject_id, "kind": "agent"},
+            "scope": {"operations": list(operations), "datasetIds": list(dataset_ids)},
+            "purpose": "capability-invocation",
+            "decisionRef": decision_ref,
+            "iss": self.did,
+            "exp": int(time.time()) + ttl_seconds,
+        }
+        body["signature"] = self.sign(fog_preimage("CapabilityToken", body["tokenId"], _sha256_hex(_canonical(body))))
+        return body
+
+
+def verify_sealed(sealed: Dict[str, Any]) -> bool:
+    """Recompute the FOG preimage and verify the detached Ed25519 signature."""
+    if not HAVE_CRYPTO:
+        raise RuntimeError("cryptography not available — cannot verify")
+    sig = sealed.get("signature")
+    did = sealed.get("signerDid")
+    if not sig or not did or not sig.startswith("ed25519:"):
+        return False
+    payload_hash = sealed.get("sealHash") or ""
+    preimage = fog_preimage(sealed.get("type", "SealedReasoningEvidence"), sealed.get("id", ""), payload_hash)
+    try:
+        pub = Ed25519PublicKey.from_public_bytes(pubkey_from_did_key(did))
+        pub.verify(base64.urlsafe_b64decode(sig[len("ed25519:"):] + "=="), preimage)
+        return True
+    except Exception:
+        return False
+
+
+@dataclass
+class IdentityChain:
+    """The DID → SVID → issuer → signer binding, as a declarable contract.
+
+    This is the small artifact that ties the twin's R0 (SPIRE attestation of an
+    immutable OSTree node) to the membrane's receipt: everything downstream is
+    anchored to `did`, and a breach = rotating `did` + `svid_ref` and refusing
+    to promote anything not signed by the new root.
+    """
+    did: str
+    svid_ref: Optional[str] = None          # SPIRE SVID on the twin (R0 attestation)
+    issuer: bool = True                     # may mint capability tokens
+    receipt_signer: bool = True             # may sign membrane receipts
+    approved_hashes_ref: Optional[str] = None  # ApprovedHashes Merkle-log anchor (breach lineage)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": "IdentityChain",
+            "specVersion": "0.1.0",
+            "did": self.did,
+            "svidRef": self.svid_ref,
+            "roles": {"issuer": self.issuer, "receiptSigner": self.receipt_signer},
+            "approvedHashesRef": self.approved_hashes_ref,
+        }
+
+
+__all__ = [
+    "HAVE_CRYPTO",
+    "IdentityRoot",
+    "IdentityChain",
+    "did_key_from_pubkey",
+    "pubkey_from_did_key",
+    "fog_preimage",
+    "verify_sealed",
+]

--- a/tools/proof_of_emptiness.py
+++ b/tools/proof_of_emptiness.py
@@ -1,0 +1,115 @@
+"""Proof-of-Emptiness — erase-as-isomorphism (the Inception Framework's "no silent sinks").
+
+Inception invariant (I2): any morphism X -> ∅ must be an ISOMORPHISM — you cannot
+"send to /dev/null". To reach emptiness you must transform X down to a certified
+empty form and prove it. Deletion / redaction / quarantine are therefore not
+silent sinks but a two-phase iso:
+
+    X --(shred)--> X₀ --(certify H(X₀)=H(∅))--> ∅
+
+This is the deletion-side dual of the ghost audit. The ghost audit proves "no
+state CHANGE without an enforced receipt"; Proof-of-Emptiness proves "no state
+DELETION without a certified emptiness receipt". Together they close both
+directions of no-silent-sinks.
+
+Each type has a distinguished empty value with a FIXED digest (Inception 3.1);
+an erasure is valid iff the post-state canonicalizes to exactly that digest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+SPEC_VERSION = "2.0.0"
+
+
+def _canonical(obj: Any) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def empty_form(type_name: str) -> Dict[str, Any]:
+    """The distinguished empty value for a type (Inception: fixed per schema).
+
+    Unit is not empty: an ack `{}` is NOT ∅. The empty form is explicitly typed
+    so "no payload" can never be confused with "empty object".
+    """
+    return {"__empty__": type_name}
+
+
+def empty_digest(type_name: str) -> str:
+    """H(∅) for a type — the canonical digest the post-state must match."""
+    return _sha256(_canonical(empty_form(type_name)))
+
+
+def shred(obj: Dict[str, Any], type_name: str) -> Dict[str, Any]:
+    """Deterministically reduce X to its zero-information variant X₀ (≅ ∅)."""
+    return empty_form(type_name)
+
+
+def prove_emptiness(
+    *,
+    subject_ref: str,
+    object_ref: str,
+    type_name: str,
+    pre_state: Dict[str, Any],
+    post_state: Optional[Dict[str, Any]] = None,
+    signer: Any = None,
+) -> Dict[str, Any]:
+    """Produce a sealed ProofOfEmptiness receipt for an erase-iso.
+
+    If `post_state` is omitted it is produced by `shred`. The receipt is
+    `certified` only when the post-state's digest equals H(∅) for the type — an
+    uncertified PoE (a silent sink dressed up as a deletion) is emitted with
+    certified=false so downstream audit fails it closed.
+    """
+    if post_state is None:
+        post_state = shred(pre_state, type_name)
+    pre_d = _sha256(_canonical(pre_state))
+    empt_d = empty_digest(type_name)
+    post_d = _sha256(_canonical(post_state))
+    certified = post_d == empt_d
+
+    receipt: Dict[str, Any] = {
+        "id": "urn:srcos:receipt:proof-of-emptiness:" + pre_d.split(":", 1)[1][:24],
+        "type": "ProofOfEmptiness",
+        "specVersion": SPEC_VERSION,
+        "subjectRef": subject_ref,
+        "objectRef": object_ref,
+        "objectType": type_name,
+        "method": "erase-iso",
+        "preDigest": pre_d,
+        "emptiedDigest": empt_d,
+        "postDigest": post_d,
+        "certified": certified,
+        "issuedAt": _now(),
+    }
+    from tools.capability_membrane import seal_receipt
+    sealed = seal_receipt(receipt)
+    if signer is not None:
+        sealed = signer.sign_sealed(sealed)
+    return sealed
+
+
+def is_valid_poe(entry: Dict[str, Any]) -> bool:
+    """True iff `entry` is a ProofOfEmptiness whose post-state truly reaches ∅."""
+    r = entry.get("receipt", entry) if isinstance(entry, dict) else {}
+    return (
+        r.get("type") == "ProofOfEmptiness"
+        and bool(r.get("certified"))
+        and r.get("postDigest") == r.get("emptiedDigest")
+        and r.get("postDigest") is not None
+    )
+
+
+__all__ = ["empty_form", "empty_digest", "shred", "prove_emptiness", "is_valid_poe"]

--- a/tools/tests/test_capability_membrane.py
+++ b/tools/tests/test_capability_membrane.py
@@ -1,0 +1,268 @@
+"""Membrane board — falsifiability tests for the capability membrane kernel.
+
+Governance you cannot falsify is theater. This board exists to PROVE the
+non-allow paths actually fire — denials, quarantines, require-signature,
+redact, autonomy-block, and the enforce-vs-observe boundary — not just the
+happy path. Every case below asserts a decision the membrane must REFUSE,
+DEGRADE, or merely OBSERVE.
+"""
+
+from __future__ import annotations
+
+import re
+
+from tools.capability_membrane import (
+    CapabilityRequest,
+    TENSION_REQUIRED,
+    evaluate_autonomy,
+    request_from_operation_decision,
+    resolve_capability,
+    seal_receipt,
+)
+
+
+def operation(outcome, **over):
+    """A minimal ProphetOperationsActionDecision skeleton for adapter tests."""
+    d = {
+        "kind": "ProphetOperationsActionDecision",
+        "schema_version": "v1",
+        "decision_id": "op-1",
+        "decided_at": "2026-07-03T00:00:00Z",
+        "recommendation_ref": "rec-1",
+        "subject": {"id": "urn:srcos:subject:svc-a"},
+        "proposed_action": {"type": "deployment.apply"},
+        "decision": {"outcome": outcome, "risk_level": "high"},
+        "basis": {"policy_refs": ["urn:srcos:policy:ops-default"]},
+        "controls": {},
+    }
+    d.update(over)
+    return d
+
+# Full tension set for the top radius — hand this to owned requests that should
+# pass the fail-closed gate so a test isolates the dimension under scrutiny.
+FULL_TENSION = TENSION_REQUIRED["R5"]
+
+SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def req(**over) -> CapabilityRequest:
+    base = dict(
+        surface="filesystem",
+        action="filesystem.read",
+        access_level="readOnly",
+        subject_ref="urn:srcos:agent:test",
+        tension_members=FULL_TENSION,
+        requested_autonomy_level="L0",
+    )
+    base.update(over)
+    return CapabilityRequest(**base)
+
+
+# --------------------------------------------------------------------------- #
+# Happy path (control) — a real ALLOW must be reachable, or every deny is vacuous
+# --------------------------------------------------------------------------- #
+
+def test_allow_path_is_reachable():
+    r = resolve_capability(req())
+    assert r.execution_decision == "allow"
+    assert r.verdict == "allowed"
+    assert r.enforced is True
+    assert r.allowed is True
+
+
+# --------------------------------------------------------------------------- #
+# Fail-closed on missing tension members (Tensegrity Invariant 1)
+# --------------------------------------------------------------------------- #
+
+def test_missing_tension_member_fails_closed():
+    # shell.exec scopedWrite → radius R3, which requires 'revocation'. Omit it.
+    partial = tuple(m for m in TENSION_REQUIRED["R3"] if m != "revocation")
+    r = resolve_capability(req(surface="shell", action="shell.exec",
+                               access_level="scopedWrite", tension_members=partial))
+    assert r.radius == "R3"
+    assert "revocation" in r.missing_tension
+    assert r.execution_decision == "deny"
+    assert r.verdict == "denied"
+    assert any("missing" in x for x in r.reasons)
+
+
+def test_no_tension_at_all_denies_even_with_allow_membrane():
+    r = resolve_capability(req(surface="shell", action="shell.exec",
+                               access_level="scopedWrite", tension_members=(),
+                               membrane_decision="ALLOW"))
+    assert r.execution_decision == "deny"
+
+
+# --------------------------------------------------------------------------- #
+# Membrane decision domain — DENY / QUARANTINE / REQUIRE_SIGNATURE / REDACT
+# --------------------------------------------------------------------------- #
+
+def test_membrane_deny():
+    r = resolve_capability(req(membrane_decision="DENY"))
+    assert r.execution_decision == "deny"
+    assert r.verdict == "denied"
+
+
+def test_membrane_quarantine_denies():
+    r = resolve_capability(req(membrane_decision="QUARANTINE"))
+    assert r.execution_decision == "deny"
+
+
+def test_require_signature_defers():
+    r = resolve_capability(req(membrane_decision="REQUIRE_SIGNATURE"))
+    assert r.execution_decision == "ask"
+    assert r.verdict == "deferred"
+    assert r.allowed is False
+
+
+def test_redact_rewrites_with_mask_obligation():
+    r = resolve_capability(req(membrane_decision="REDACT"))
+    assert r.execution_decision == "rewrite"
+    assert {"name": "mask_fields", "when": "runtime"} in r.obligations
+    # rewrite still proceeds (masked), so the receipt verdict is allowed
+    assert r.verdict == "allowed"
+
+
+# --------------------------------------------------------------------------- #
+# Autonomy ladder (fail-closed, mirrors tritfabric autonomy_gate)
+# --------------------------------------------------------------------------- #
+
+def test_autonomy_overclaim_blocks():
+    # Request L4 without the conductor_response_envelope evidence token.
+    r = resolve_capability(req(requested_autonomy_level="L4", autonomy_evidence=()))
+    assert r.autonomy.ok is False
+    assert r.execution_decision == "deny"
+    assert r.autonomy.granted_level == "L0"
+
+
+def test_autonomy_admitted_with_evidence():
+    r = resolve_capability(req(requested_autonomy_level="L4",
+                               autonomy_evidence=("conductor_response_envelope",)))
+    assert r.autonomy.ok is True
+    assert r.execution_decision == "allow"
+
+
+def test_evaluate_autonomy_reports_ceiling():
+    d = evaluate_autonomy("L5", ("evidence_dossier",))
+    assert d.ok is False
+    assert d.granted_level == "L3"          # ceiling the evidence supports
+    assert "at most L3" in d.reason
+
+
+def test_autonomy_l0_always_satisfied():
+    d = evaluate_autonomy("L0", ())
+    assert d.ok is True
+
+
+# --------------------------------------------------------------------------- #
+# Enforce-vs-observe — the honesty boundary over foreign surfaces
+# --------------------------------------------------------------------------- #
+
+def test_foreign_surface_is_observed_not_enforced():
+    # A frontier client's computer_use: we cannot prevent it, only receipt it.
+    r = resolve_capability(req(surface="computer", action="computer.screencapture",
+                               access_level="control", tension_members=FULL_TENSION,
+                               membrane_decision="ALLOW", owned=False))
+    assert r.enforced is False
+    assert r.verdict == "observed"
+    assert r.allowed is False               # advisory, never counts as an enforced allow
+    assert any("foreign surface" in x for x in r.reasons)
+    assert r.receipt["receiptClass"] == "probe"
+
+
+def test_owned_surface_enforces():
+    r = resolve_capability(req(surface="shell", action="shell.exec",
+                               access_level="scopedWrite", owned=True))
+    assert r.enforced is True
+    assert r.receipt["receiptClass"] == "execution"
+
+
+# --------------------------------------------------------------------------- #
+# Radius floors — OS/deploy surfaces never sit below their floor
+# --------------------------------------------------------------------------- #
+
+def test_computer_surface_floors_to_r3():
+    r = resolve_capability(req(surface="computer", action="computer.click",
+                               access_level="none", tension_members=FULL_TENSION))
+    assert r.radius == "R3"
+
+
+def test_destructive_deployment_requires_r5_authority():
+    # destructive → R5, which needs post_authority_ref. Provide everything but it.
+    partial = tuple(m for m in TENSION_REQUIRED["R5"] if m != "post_authority_ref")
+    r = resolve_capability(req(surface="deployment", action="deployment.apply",
+                               access_level="destructive", tension_members=partial))
+    assert r.radius == "R5"
+    assert "post_authority_ref" in r.missing_tension
+    assert r.execution_decision == "deny"
+
+
+# --------------------------------------------------------------------------- #
+# Receipt + seal conformance (sourceos-spec + agentplane binding)
+# --------------------------------------------------------------------------- #
+
+def test_receipt_conforms_to_agent_machine_receipt():
+    r = resolve_capability(req())
+    rc = r.receipt
+    assert rc["type"] == "AgentMachineReceipt"
+    assert rc["specVersion"] == "2.0.0"
+    assert rc["verdict"] in {"allowed", "denied", "deferred", "failed", "observed"}
+    assert SHA256.match(rc["decisionHash"])
+    assert SHA256.match(rc["evidenceHash"])
+    assert rc["id"].startswith("urn:srcos:agent-machine-receipt:")
+
+
+def test_seal_is_deterministic_and_tamper_evident():
+    r = resolve_capability(req())
+    again = seal_receipt(r.receipt)
+    assert again["sealHash"] == r.sealed["sealHash"]       # deterministic
+    mutated = dict(r.receipt, verdict="allowed_but_tampered")
+    assert seal_receipt(mutated)["sealHash"] != r.sealed["sealHash"]  # tamper-evident
+    assert SHA256.match(r.sealed["sealHash"])
+    assert r.sealed["type"] == "SealedReasoningEvidence"
+
+
+def test_unknown_membrane_decision_raises():
+    import pytest
+    with pytest.raises(ValueError):
+        resolve_capability(req(membrane_decision="MAYBE"))
+
+
+# --------------------------------------------------------------------------- #
+# Reference wiring — compose over the owned policy-fabric operation surface
+# --------------------------------------------------------------------------- #
+
+def test_operation_deny_composes_to_deny():
+    request = request_from_operation_decision(
+        operation("deny"), surface="deployment", access_level="scopedWrite",
+        tension_members=FULL_TENSION)
+    assert request.membrane_decision == "DENY"
+    r = resolve_capability(request)
+    assert r.execution_decision == "deny"
+    # policy_refs from the operation's basis carry through onto the receipt
+    assert "urn:srcos:policy:ops-default" in r.receipt["policyDecisionRef"]
+
+
+def test_operation_unknown_fails_closed_to_quarantine():
+    request = request_from_operation_decision(
+        operation("unknown"), surface="deployment", access_level="scopedWrite",
+        tension_members=FULL_TENSION)
+    assert request.membrane_decision == "QUARANTINE"
+    assert resolve_capability(request).execution_decision == "deny"
+
+
+def test_operation_allow_with_human_approval_requires_signature():
+    request = request_from_operation_decision(
+        operation("allow", controls={"requires_human_approval": True}),
+        surface="deployment", access_level="scopedWrite", tension_members=FULL_TENSION)
+    assert request.membrane_decision == "REQUIRE_SIGNATURE"
+    assert resolve_capability(request).execution_decision == "ask"
+
+
+def test_operation_clean_allow_flows_through():
+    request = request_from_operation_decision(
+        operation("allow"), surface="deployment", access_level="scopedWrite",
+        tension_members=FULL_TENSION)
+    r = resolve_capability(request)
+    assert r.execution_decision == "allow"
+    assert r.receipt["decision"]["riskLevel"] == "high"

--- a/tools/tests/test_gapi_edge_policy.py
+++ b/tools/tests/test_gapi_edge_policy.py
@@ -1,0 +1,63 @@
+"""Executable gapi edge policy — every gapi hyperedge resolves through the membrane.
+
+Turns the gapi recon's descriptive guards into executable policy: each edge in
+`fixtures/capability-membrane/gapi-edge-policy.json` is run through
+resolve_capability and must produce the annotated ExecutionDecision, for both
+the nominal (guards satisfied) and violated (a guard fails) cases. This makes
+the two models one — the gapi hypergraph and the membrane agree by construction.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.capability_membrane import CapabilityRequest, TENSION_REQUIRED, resolve_capability
+
+POLICY = json.loads(
+    (Path(__file__).resolve().parents[2] / "fixtures/capability-membrane/gapi-edge-policy.json").read_text()
+)
+FULL_TENSION = TENSION_REQUIRED["R5"]
+
+
+def _resolve(edge, membrane_decision):
+    req = CapabilityRequest(
+        surface=edge["surface"], action=edge["action"], access_level=edge["access_level"],
+        subject_ref="urn:srcos:agent:gapi-edge", tension_members=FULL_TENSION,
+        membrane_decision=membrane_decision,
+    )
+    return resolve_capability(req)
+
+
+def _cases():
+    for edge in POLICY["edges"]:
+        yield pytest.param(edge, "nominal", id=f"{edge['edge_id']}-nominal")
+        if "violated" in edge:
+            yield pytest.param(edge, "violated", id=f"{edge['edge_id']}-violated")
+
+
+@pytest.mark.parametrize("edge,case", list(_cases()))
+def test_gapi_edge_resolves_to_annotated_decision(edge, case):
+    spec = edge[case]
+    r = _resolve(edge, spec["membrane_decision"])
+    assert r.execution_decision == spec["expect_execution"], (
+        f"{edge['edge_id']} [{case}] expected {spec['expect_execution']}, got {r.execution_decision}"
+    )
+
+
+def test_every_edge_has_a_nominal_decision():
+    # No gapi edge is left un-governed.
+    assert len(POLICY["edges"]) == 11
+    for edge in POLICY["edges"]:
+        assert "nominal" in edge and edge["nominal"]["membrane_decision"]
+
+
+def test_all_five_membrane_decisions_are_exercised():
+    seen = set()
+    for edge in POLICY["edges"]:
+        for case in ("nominal", "violated"):
+            if case in edge:
+                seen.add(edge[case]["membrane_decision"])
+    assert seen == {"ALLOW", "DENY", "QUARANTINE", "REDACT", "REQUIRE_SIGNATURE"}

--- a/tools/tests/test_ghost_audit.py
+++ b/tools/tests/test_ghost_audit.py
@@ -1,0 +1,106 @@
+"""Ghost audit tests — prove ghosts are caught and ghostry is measured."""
+
+from __future__ import annotations
+
+from tools.capability_membrane import CapabilityRequest, TENSION_REQUIRED, resolve_capability
+from tools.ghost_audit import StateDelta, audit
+from tools import membrane_identity as mid
+import pytest
+
+FULL_TENSION = TENSION_REQUIRED["R5"]
+
+
+def enforced_allow_receipt(rid_subject="urn:srcos:agent:worker", signer=None):
+    r = resolve_capability(
+        CapabilityRequest(surface="filesystem", action="filesystem.write", access_level="scopedWrite",
+                          subject_ref=rid_subject, tension_members=FULL_TENSION, membrane_decision="ALLOW"),
+        signer=signer,
+    )
+    return r.sealed, r.receipt["id"]
+
+
+def observed_receipt():
+    r = resolve_capability(
+        CapabilityRequest(surface="computer", action="computer.control", access_level="control",
+                          subject_ref="urn:srcos:agent:frontier", tension_members=FULL_TENSION,
+                          owned=False, membrane_decision="ALLOW"))
+    return r.sealed, r.receipt["id"]
+
+
+def denied_receipt():
+    r = resolve_capability(
+        CapabilityRequest(surface="filesystem", action="filesystem.write", access_level="scopedWrite",
+                          subject_ref="urn:srcos:agent:worker", tension_members=FULL_TENSION,
+                          membrane_decision="DENY"))
+    return r.sealed, r.receipt["id"]
+
+
+def test_clean_journal_has_zero_ghostry():
+    sealed, rid = enforced_allow_receipt()
+    deltas = [StateDelta(id="d1", action="filesystem.write", subject="s", authorized_by=rid)]
+    report = audit([sealed], deltas)
+    assert report.clean
+    assert report.ghostry == 0.0
+    assert report.attested == 1
+
+
+def test_state_change_with_no_receipt_is_a_ghost():
+    report = audit([], [StateDelta(id="d1", action="x", subject="s", authorized_by=None)])
+    assert not report.clean
+    assert report.ghostry == 1.0
+    assert report.ghosts[0].reason == "no_receipt"
+
+
+def test_observed_edge_that_changed_state_is_a_ghost():
+    # THE ghostry case: a foreign/observed edge produced a durable change.
+    sealed, rid = observed_receipt()
+    deltas = [StateDelta(id="d1", action="computer.control", subject="s", authorized_by=rid)]
+    report = audit([sealed], deltas)
+    assert report.ghosts[0].reason == "not_enforced"
+    assert report.ghostry == 1.0
+
+
+def test_denied_receipt_does_not_authorize():
+    sealed, rid = denied_receipt()
+    deltas = [StateDelta(id="d1", action="filesystem.write", subject="s", authorized_by=rid)]
+    report = audit([sealed], deltas)
+    assert report.ghosts[0].reason == "not_allowed"
+
+
+def test_missing_receipt_reference_is_a_ghost():
+    deltas = [StateDelta(id="d1", action="x", subject="s", authorized_by="urn:srcos:agent-machine-receipt:nope")]
+    report = audit([], deltas)
+    assert report.ghosts[0].reason == "receipt_missing"
+
+
+def test_ghostry_ratio_is_fraction_of_ghost_deltas():
+    sealed, rid = enforced_allow_receipt()
+    deltas = [
+        StateDelta(id="ok", action="w", subject="s", authorized_by=rid),
+        StateDelta(id="ghost1", action="w", subject="s", authorized_by=None),
+        StateDelta(id="ghost2", action="w", subject="s", authorized_by=None),
+        StateDelta(id="ghost3", action="w", subject="s", authorized_by=None),
+    ]
+    report = audit([sealed], deltas)
+    assert report.total_deltas == 4
+    assert report.attested == 1
+    assert report.ghostry == 0.75
+    assert report.to_dict()["byReason"]["no_receipt"] == 3
+
+
+@pytest.mark.skipif(not mid.HAVE_CRYPTO, reason="cryptography not installed")
+def test_require_signed_flags_unsigned_authorizer():
+    unsigned, rid = enforced_allow_receipt()               # enforced allow, but NOT signed
+    deltas = [StateDelta(id="d1", action="filesystem.write", subject="s", authorized_by=rid)]
+    report = audit([unsigned], deltas, require_signed=True, verify=mid.verify_sealed)
+    assert report.ghosts[0].reason == "bad_signature"
+
+
+@pytest.mark.skipif(not mid.HAVE_CRYPTO, reason="cryptography not installed")
+def test_require_signed_accepts_validly_signed_authorizer():
+    ident = mid.IdentityRoot.from_seed(bytes(range(32)))
+    signed, rid = enforced_allow_receipt(signer=ident)
+    deltas = [StateDelta(id="d1", action="filesystem.write", subject="s", authorized_by=rid)]
+    report = audit([signed], deltas, require_signed=True, verify=mid.verify_sealed)
+    assert report.clean
+    assert report.ghostry == 0.0

--- a/tools/tests/test_membrane_adversarial.py
+++ b/tools/tests/test_membrane_adversarial.py
@@ -1,0 +1,110 @@
+"""Adversarial board — gapi §8 exploit surfaces as membrane assertions.
+
+The gapi recon (§8) enumerated the failure classes any capability-scoped message
+bus must handle. This board proves the membrane's response to each. These are
+protocol/transport attacks, distinct from the governance-decision board.
+"""
+
+from __future__ import annotations
+
+from tools.capability_membrane import (
+    CapabilityRequest,
+    TENSION_REQUIRED,
+    resolve_capability,
+    seal_receipt,
+)
+from tools import membrane_identity as mid
+import pytest
+
+FULL_TENSION = TENSION_REQUIRED["R5"]
+
+
+def req(**over):
+    base = dict(surface="filesystem", action="filesystem.read", access_level="readOnly",
+                subject_ref="urn:srcos:agent:test", tension_members=FULL_TENSION)
+    base.update(over)
+    return CapabilityRequest(**base)
+
+
+# §8: Origin spoofing / confusion → replaced by attested identity. No identity
+# tension member ⇒ can't even satisfy the R0 floor {policy, identity} ⇒ deny.
+def test_origin_spoofing_maps_to_missing_attested_identity():
+    r = resolve_capability(req(tension_members=("policy",)))   # identity absent
+    assert "identity" in r.missing_tension
+    assert r.execution_decision == "deny"
+
+
+# §8: Token leakage / reuse across contexts. A token minted for a low-radius
+# read, replayed to drive a high-radius `control` action, presents only its
+# low-radius tension ⇒ fail-closed on the missing higher-radius members.
+def test_token_replay_across_scope_fails_closed():
+    low_radius_tension = TENSION_REQUIRED["R1"]      # what a read token carries
+    r = resolve_capability(req(surface="browser", action="rpc.dispatch",
+                               access_level="control", tension_members=low_radius_tension))
+    assert r.radius == "R5"
+    assert r.execution_decision == "deny"
+    assert r.missing_tension
+
+
+# §8: Callback hijacking / confused routing. The response's subject binding is
+# sealed into the receipt; swapping subjectRef changes the seal ⇒ tamper-evident.
+def test_callback_hijack_breaks_the_seal():
+    r = resolve_capability(req(subject_ref="urn:srcos:agent:alice"))
+    hijacked = dict(r.receipt, subjectRef="urn:srcos:agent:mallory")
+    assert seal_receipt(hijacked)["sealHash"] != r.sealed["sealHash"]
+
+
+@pytest.mark.skipif(not mid.HAVE_CRYPTO, reason="cryptography not installed")
+def test_callback_hijack_breaks_the_signature():
+    ident = mid.IdentityRoot.from_seed(bytes(range(32)))
+    r = resolve_capability(req(subject_ref="urn:srcos:agent:alice"), signer=ident)
+    # Attacker swaps the subject but cannot re-sign; keeping the old sealHash+sig
+    # leaves a receipt whose re-seal no longer matches, and the signature is over
+    # the original seal — verification of a re-sealed hijack fails.
+    hijacked_receipt = dict(r.receipt, subjectRef="urn:srcos:agent:mallory")
+    reseal = seal_receipt(hijacked_receipt)
+    forged = dict(reseal, signerDid=r.sealed["signerDid"],
+                  signature=r.sealed["signature"], svidRef=r.sealed.get("svidRef"))
+    assert mid.verify_sealed(forged) is False
+
+
+# §8: Handler namespace collision — calling reserved/internal services. Reserved
+# namespaces floor to R5; an ordinary caller lacks post_authority_ref ⇒ denied.
+def test_handler_namespace_collision_denied_for_ordinary_caller():
+    r = resolve_capability(req(action="_g_connect", tension_members=TENSION_REQUIRED["R3"]))
+    assert r.radius == "R5"
+    assert "post_authority_ref" in r.missing_tension
+    assert r.execution_decision == "deny"
+
+
+def test_reserved_handler_allowed_only_with_top_authority():
+    r = resolve_capability(req(action="__cb", tension_members=FULL_TENSION))
+    assert r.radius == "R5"
+    assert r.execution_decision == "allow"     # full R5 tension incl. post_authority_ref
+
+
+# §8: Legacy protocol downgrade — forcing an unenforced path. A foreign/observed
+# surface can NEVER be counted as an enforced allow, no matter the membrane says.
+def test_downgrade_to_observed_is_never_an_enforced_allow():
+    r = resolve_capability(req(surface="computer", action="computer.control",
+                               access_level="control", owned=False, membrane_decision="ALLOW"))
+    assert r.verdict == "observed"
+    assert r.enforced is False
+    assert r.allowed is False
+
+
+# §8: Unsafe URL / relay-redirect injection → sanitize. An injection attempt
+# routed as REDACT proceeds only rewritten, with a mask obligation attached.
+def test_url_injection_forces_redact_rewrite_with_obligation():
+    r = resolve_capability(req(surface="httpApi", action="url.expand",
+                               access_level="draftOnly", membrane_decision="REDACT"))
+    assert r.execution_decision == "rewrite"
+    assert {"name": "mask_fields", "when": "runtime"} in r.obligations
+
+
+# §8: Message queue flooding (DoS). Rate-limiting is the transport/gateway's job,
+# NOT the membrane's — but a flooding signal surfaced as QUARANTINE still denies.
+# (Honest boundary: the membrane is a per-call decision, stateless across calls.)
+def test_flooding_signalled_as_quarantine_denies():
+    r = resolve_capability(req(membrane_decision="QUARANTINE", risk_level="critical"))
+    assert r.execution_decision == "deny"

--- a/tools/tests/test_membrane_identity.py
+++ b/tools/tests/test_membrane_identity.py
@@ -1,0 +1,81 @@
+"""Identity thread — DID → cap_token → signed receipt, and tamper-evidence."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools import membrane_identity as mid
+from tools.capability_membrane import CapabilityRequest, TENSION_REQUIRED, resolve_capability
+
+pytestmark = pytest.mark.skipif(not mid.HAVE_CRYPTO, reason="cryptography not installed")
+
+SEED = bytes(range(32))
+FULL_TENSION = TENSION_REQUIRED["R5"]
+
+
+def owned_req(**over):
+    base = dict(surface="filesystem", action="filesystem.read", access_level="readOnly",
+                subject_ref="urn:srcos:agent:test", tension_members=FULL_TENSION)
+    base.update(over)
+    return CapabilityRequest(**base)
+
+
+def test_did_key_roundtrip():
+    ident = mid.IdentityRoot.from_seed(SEED)
+    assert ident.did.startswith("did:key:z")
+    assert mid.pubkey_from_did_key(ident.did) == ident.public_key_bytes
+
+
+def test_from_seed_is_deterministic():
+    assert mid.IdentityRoot.from_seed(SEED).did == mid.IdentityRoot.from_seed(SEED).did
+
+
+def test_sign_and_verify_sealed():
+    ident = mid.IdentityRoot.from_seed(SEED, svid_ref="urn:srcos:svid:twin-node-1")
+    r = resolve_capability(owned_req(), signer=ident)
+    assert r.sealed["signature"].startswith("ed25519:")
+    assert r.sealed["signerDid"] == ident.did
+    assert r.sealed["svidRef"] == "urn:srcos:svid:twin-node-1"
+    assert mid.verify_sealed(r.sealed) is True
+
+
+def test_tampered_receipt_fails_verification():
+    ident = mid.IdentityRoot.from_seed(SEED)
+    r = resolve_capability(owned_req(), signer=ident)
+    tampered = dict(r.sealed)
+    tampered["sealHash"] = "sha256:" + "0" * 64        # forge the seal
+    assert mid.verify_sealed(tampered) is False
+
+
+def test_wrong_identity_fails_verification():
+    a = mid.IdentityRoot.from_seed(SEED)
+    r = resolve_capability(owned_req(), signer=a)
+    forged = dict(r.sealed, signerDid=mid.IdentityRoot.from_seed(bytes(range(1, 33))).did)
+    assert mid.verify_sealed(forged) is False
+
+
+def test_unsigned_receipt_still_valid_and_verify_false():
+    # No signer → kernel stays pure; receipt is valid but carries no signature.
+    r = resolve_capability(owned_req())
+    assert "signature" not in r.sealed
+    assert mid.verify_sealed(r.sealed) is False
+
+
+def test_mint_cap_token_is_scoped_signed_and_short_lived():
+    import time
+    ident = mid.IdentityRoot.from_seed(SEED)
+    tok = ident.mint_cap_token(subject_id="urn:srcos:agent:worker", operations=["read", "write"], ttl_seconds=300)
+    assert tok["iss"] == ident.did
+    assert tok["scope"]["operations"] == ["read", "write"]
+    assert tok["signature"].startswith("ed25519:")
+    assert 0 < tok["exp"] - int(time.time()) <= 300
+
+
+def test_identity_chain_contract_shape():
+    ident = mid.IdentityRoot.from_seed(SEED, svid_ref="urn:srcos:svid:twin-node-1")
+    chain = mid.IdentityChain(did=ident.did, svid_ref=ident.svid_ref,
+                              approved_hashes_ref="urn:srcos:approved-hashes:merkle-root")
+    d = chain.to_dict()
+    assert d["did"] == ident.did
+    assert d["roles"] == {"issuer": True, "receiptSigner": True}
+    assert d["approvedHashesRef"] == "urn:srcos:approved-hashes:merkle-root"

--- a/tools/tests/test_proof_of_emptiness.py
+++ b/tools/tests/test_proof_of_emptiness.py
@@ -1,0 +1,92 @@
+"""Proof-of-Emptiness tests — erase-as-isomorphism and no-silent-sinks enforcement."""
+
+from __future__ import annotations
+
+from tools.proof_of_emptiness import (
+    empty_digest,
+    empty_form,
+    is_valid_poe,
+    prove_emptiness,
+    shred,
+)
+from tools.ghost_audit import StateDelta, audit
+from tools import membrane_identity as mid
+import pytest
+
+
+def test_certified_erasure_reaches_emptiness():
+    poe = prove_emptiness(subject_ref="urn:srcos:agent:worker", object_ref="urn:srcos:asset:x",
+                          type_name="UserGraph", pre_state={"nodes": [1, 2, 3], "secret": "s"})
+    r = poe["receipt"]
+    assert r["type"] == "ProofOfEmptiness"
+    assert r["certified"] is True
+    assert r["postDigest"] == r["emptiedDigest"] == empty_digest("UserGraph")
+    assert is_valid_poe(poe) is True
+
+
+def test_uncertified_erasure_is_flagged():
+    # A "deletion" that leaves residual data does NOT reach ∅ — not a valid PoE.
+    poe = prove_emptiness(subject_ref="s", object_ref="o", type_name="UserGraph",
+                          pre_state={"nodes": [1, 2, 3]}, post_state={"nodes": [2]})
+    assert poe["receipt"]["certified"] is False
+    assert is_valid_poe(poe) is False
+
+
+def test_unit_is_not_empty():
+    # An empty-looking ack {} must not be confused with the typed empty value.
+    assert empty_form("UserGraph") != {}
+    assert empty_digest("UserGraph") != empty_digest("SystemGraph")
+
+
+def test_shred_is_deterministic_and_typed():
+    a = shred({"a": 1}, "T")
+    b = shred({"b": 2, "c": 3}, "T")
+    assert a == b == empty_form("T")
+
+
+# --- Ghost-audit integration: erasures need a valid PoE -----------------------
+
+def erasure(rid=None):
+    return StateDelta(id="del-1", action="filesystem.erase", subject="s", authorized_by=rid, is_erasure=True)
+
+
+def test_erasure_with_valid_poe_is_attested():
+    poe = prove_emptiness(subject_ref="s", object_ref="o", type_name="Asset", pre_state={"x": 1})
+    rid = poe["receipt"]["id"]
+    report = audit([poe], [erasure(rid)])
+    assert report.clean
+    assert report.attested == 1
+
+
+def test_erasure_without_poe_is_a_ghost():
+    report = audit([], [erasure(None)])
+    assert report.ghosts[0].reason == "uncertified_erase"
+    assert report.ghostry == 1.0
+
+
+def test_erasure_with_uncertified_poe_is_a_ghost():
+    poe = prove_emptiness(subject_ref="s", object_ref="o", type_name="Asset",
+                          pre_state={"x": 1}, post_state={"x": 1})  # didn't reach ∅
+    rid = poe["receipt"]["id"]
+    report = audit([poe], [erasure(rid)])
+    assert report.ghosts[0].reason == "uncertified_erase"
+
+
+def test_erasure_authorized_by_ordinary_receipt_is_a_silent_sink():
+    # A normal enforced-allow receipt cannot authorize a deletion — that's the sink.
+    from tools.capability_membrane import CapabilityRequest, TENSION_REQUIRED, resolve_capability
+    r = resolve_capability(CapabilityRequest(surface="filesystem", action="filesystem.write",
+            access_level="scopedWrite", subject_ref="s", tension_members=TENSION_REQUIRED["R5"],
+            membrane_decision="ALLOW"))
+    report = audit([r.sealed], [erasure(r.receipt["id"])])
+    assert report.ghosts[0].reason == "not_a_proof_of_emptiness"
+
+
+@pytest.mark.skipif(not mid.HAVE_CRYPTO, reason="cryptography not installed")
+def test_poe_is_signable_by_identity_root():
+    ident = mid.IdentityRoot.from_seed(bytes(range(32)))
+    poe = prove_emptiness(subject_ref="s", object_ref="o", type_name="Asset",
+                          pre_state={"x": 1}, signer=ident)
+    assert poe["signature"].startswith("ed25519:")
+    assert mid.verify_sealed(poe) is True
+    assert is_valid_poe(poe) is True


### PR DESCRIPTION
## What

One capability-decision membrane that every capability call routes through — **composing four already-shipped kernels rather than reinventing them**. Origin: the Claude.app native-binary surfaces question (computer_use / PTY spawn-helper / MSAL). The `spawn-helper` entitlements plist is a *production* tiered-membrane (helper gets a bounded entitlement subset; restricted keychain/WebAuthn reserved to the top signed `.app` via provisioning) → we ride OS entitlement/signing as the R0 floor and build the governance tiers above it.

Chose this ("unify the trust lattice") over MCP-out / surface-mirror after a tradeoffs discussion: those are *surfaces*, this is the *substrate* they sit on.

## Composition (conform, don't rebuild — all confirmed by exploring the repos)

| Tier | Source kernel | Role |
|---|---|---|
| Surface taxonomy | sourceos-spec `ConnectorActionScope.connectorKind` | filesystem/shell/computer/browser/deployment — the desktop surfaces map 1:1 |
| Capability radius | agentplane `capability-radius-v0` R0–R5 + tension members | **fail-closed QUARANTINE** if a required governance member is absent (Tensegrity Inv. 1) |
| Membrane decision | slash-topics `Membrane_Decision v0.2` / platform `MembraneDecision.v0.1` | ALLOW / DENY / QUARANTINE / REDACT / REQUIRE_SIGNATURE × scope |
| Autonomy ladder | tritfabric `atlas/autonomy_gate` L0–L5 | fail-closed over-claim block |

→ collapses to one sourceos-spec `ExecutionDecision` (allow/deny/ask/defer/rewrite) + one **sealed `AgentMachineReceipt`** whose `verdict` carries the **enforce-vs-observe** boundary:
- **owned** surface → we enforce (`allowed`/`denied`/`deferred`, receiptClass `execution`)
- **foreign** surface (a frontier `computer_use` we can't stop inside another process) → `verdict="observed"`, `enforced=false`, receiptClass `probe` — advisory + receipt only, never an enforced allow.

No new schema. Pure + local-first (stdlib only; a membrane in every call's hot path must not take a cloud round-trip). Seal binding matches agentplane `seal_reasoning_receipt` (`seal_hash = sha256(receipt_canonical ‖ run_trace_hash ‖ events_sha)`); hashes are sha256 over a JCS-style canonical form.

## Reference wiring (enforce-where-we-own)

`request_from_operation_decision()` composes the kernel **over** the owned prophet-platform **policy-fabric** surface (`ProphetOperationsActionDecision`): outcome `unknown` → QUARANTINE (fail-closed), `requires_human_approval` → REQUIRE_SIGNATURE. CLI `python -m tools.capability_membrane` emits the sealed receipt and **exits non-zero on a non-allow** so CI/guards gate on it. `make validate-capability-membrane` runs it end-to-end.

## Falsifiability — the membrane board (22 tests, green)

`tools/tests/test_capability_membrane.py` proves the **non-allow paths fire**: deny, quarantine, require-signature, redact, autonomy-overclaim, missing-tension fail-closed, radius floors (computer/deployment), and observe-only foreign surfaces. Governance you cannot falsify is theater. Board also runs under the existing `test-tools` target (already in `validate`).

## Files
- `tools/capability_membrane.py` — the kernel + policy-fabric adapter + CLI
- `tools/tests/test_capability_membrane.py` — 22-test board
- `fixtures/capability-membrane/operation-deploy-apply.decision.json` — golden operation
- `Makefile` — `validate-capability-membrane`

## Follow-ups (not in this PR)
- Point the `observed` path at a real Claude `computer_use`/MCP call so the lattice receipts a live foreign surface.
- Close the tritfabric `promote()` policy-source gap — this kernel is the `AutonomyPolicySource` that populates `req["autonomy"]` before `daemon.promote()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)