### PR TITLE
fix(eval-fabric): migration linter + the 3 more missing tables it found

### DIFF
--- a/.github/workflows/platform-wave1-stubs.yml
+++ b/.github/workflows/platform-wave1-stubs.yml
@@ -27,4 +27,5 @@ jobs:
         run: python tools/lint_eval_fabric_migrations.py
 
       - name: Run platform stub tests
-        run: pytest -q tests/platform_stubs
+        # Scoped to the stdlib-only stubs; the dashboard_bff stubs need httpx (not installed here).
+        run: pytest -q tests/platform_stubs/test_wave1_stubs.py tests/platform_stubs/test_eval_fabric_migration_lint.py

--- a/.github/workflows/platform-wave1-stubs.yml
+++ b/.github/workflows/platform-wave1-stubs.yml
@@ -23,5 +23,8 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install --upgrade pip fastapi==0.115.0 uvicorn==0.30.6 pytest
 
-      - name: Run Wave 1 stub smoke tests
-        run: pytest -q tests/platform_stubs/test_wave1_stubs.py
+      - name: Lint eval-fabric SQL migrations (no DB — static consistency)
+        run: python tools/lint_eval_fabric_migrations.py
+
+      - name: Run platform stub tests
+        run: pytest -q tests/platform_stubs

--- a/infra/datastores/postgres/004a_runtime_seed_prerequisite_ddl.sql
+++ b/infra/datastores/postgres/004a_runtime_seed_prerequisite_ddl.sql
@@ -1,0 +1,37 @@
+-- Missing DDL for tables that 005_eval_fabric_runtime_seed.sql inserts into and the
+-- eval-fabric-api reads, but whose CREATE TABLE existed NOWHERE in version control — so a fresh
+-- eval_fabric_migrate failed at 005 (the same class of gap as metric_crosswalks, fixed in 004).
+-- Surfaced by tools/lint_eval_fabric_migrations.py. Ordered before 005 (sorts 004 < 004a < 005).
+-- Columns are 005's exact insert lists; types from the canonical schemas/eval/*.schema.json
+-- (required -> NOT NULL). No FKs: matches the text-id, LEFT-JOIN convention of source_descriptors
+-- / metric_definitions / metric_crosswalks.
+
+create table if not exists methodology_snapshots (
+  methodology_snapshot_id text primary key,
+  source_descriptor_id text not null,
+  hash text not null,
+  captured_at timestamptz not null,
+  url text,
+  notes text
+);
+
+create table if not exists repro_ledger_entries (
+  repro_ledger_entry_id text primary key,
+  run_id text not null,
+  prompt_pack_id text,
+  fixture_snapshot_id text,
+  tool_bundle_id text,
+  seed_policy text,
+  environment_hash text not null,
+  methodology_snapshot_hash text not null,
+  replay_artifact_id text,
+  notes text
+);
+
+create table if not exists causal_attributions (
+  causal_attribution_id text primary key,
+  subject_id text not null,
+  window text not null,
+  attributions jsonb not null,
+  notes text
+);

--- a/tests/platform_stubs/test_eval_fabric_migration_lint.py
+++ b/tests/platform_stubs/test_eval_fabric_migration_lint.py
@@ -1,0 +1,73 @@
+"""Tests for the eval-fabric migration linter (tools/lint_eval_fabric_migrations.py).
+
+The real-dir test is a regression gate: it fails if any Postgres migration inserts into a
+table with no prior CREATE, or names an insert column absent from the CREATE — the exact bug
+class that shipped four times (metric_crosswalks + methodology_snapshots + repro_ledger_entries
++ causal_attributions). The synthetic tests prove the linter's own logic. No database needed.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _lint():
+    path = ROOT / "tools" / "lint_eval_fabric_migrations.py"
+    spec = importlib.util.spec_from_file_location("lint_eval_fabric_migrations", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_real_postgres_migrations_are_self_consistent():
+    lint = _lint()
+    errors = lint.lint_dir(ROOT / "infra" / "datastores" / "postgres")
+    assert errors == [], "eval-fabric migration inconsistency:\n" + "\n".join(errors)
+
+
+def test_flags_insert_before_create():
+    lint = _lint()
+    errors = lint.lint([("005_x.sql", "insert into ghost (a, b) values ('1', '2');")])
+    assert any("before any CREATE TABLE ghost" in e for e in errors)
+
+
+def test_flags_an_insert_column_absent_from_the_create():
+    lint = _lint()
+    files = [
+        ("001.sql", "create table if not exists t (a text, b text);"),
+        ("002.sql", "insert into t (a, c) values ('1', '2');"),
+    ]
+    errors = lint.lint(files)
+    assert any("column(s) absent" in e and "'c'" in e for e in errors)
+
+
+def test_accepts_a_consistent_create_then_insert():
+    lint = _lint()
+    files = [
+        ("001.sql", "create table if not exists t (a text primary key, b text);"),
+        ("002.sql", "insert into t (a, b) values ('1', '2');"),
+    ]
+    assert lint.lint(files) == []
+
+
+def test_inline_constrained_column_is_a_column_not_a_constraint():
+    # `id text primary key` is a column; a table-level `primary key (id)` is not.
+    lint = _lint()
+    files = [
+        ("001.sql", "create table t (id text primary key, x jsonb not null, primary key (id));"),
+        ("002.sql", "insert into t (id, x) values ('a', '{}');"),
+    ]
+    assert lint.lint(files) == []
+
+
+def test_ignores_comments():
+    lint = _lint()
+    files = [
+        ("001.sql", "-- insert into ghost (a) values ('x');\ncreate table t (a text);"),
+        ("002.sql", "insert into t (a) values ('1');"),
+    ]
+    assert lint.lint(files) == []

--- a/tools/lint_eval_fabric_migrations.py
+++ b/tools/lint_eval_fabric_migrations.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Static consistency lint for the eval-fabric SQL migrations — no database required.
+
+Guards the class of bug that shipped in the metric_crosswalks gap: 005 inserted into a
+`metric_crosswalks` table whose `CREATE TABLE` existed nowhere, so a fresh
+`eval_fabric_migrate` failed at 005. This lint reads the numbered migrations IN ORDER and
+asserts, purely statically:
+
+  1. every `INSERT INTO <t>` targets a table `CREATE`d by an earlier (or same, earlier-in-file)
+     statement — no insert-before-create;
+  2. every column named in an `INSERT ... (cols)` list exists in that table's `CREATE TABLE`.
+
+It is intentionally scoped to the Postgres migrations (where the FK-less, text-id join model
+makes a missing table load-but-not-join, i.e. silent). ClickHouse DDL (ENGINE=..., different
+column grammar) is a follow-up. Stdlib-only; runnable in CI with no DB:
+
+    python3 tools/lint_eval_fabric_migrations.py           # lints infra/datastores/postgres
+    python3 tools/lint_eval_fabric_migrations.py --dir X    # lint another dir
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PG_DIR = ROOT / "infra" / "datastores" / "postgres"
+
+# A part of a CREATE-TABLE body whose first token is one of these is a table-level constraint,
+# not a column (an inline-constrained column still starts with its own name, so it is kept).
+_CONSTRAINT_HEADS = {"primary", "foreign", "unique", "check", "constraint", "exclude"}
+_IDENT = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
+
+
+def _strip_comments(sql: str) -> str:
+    return "\n".join(re.sub(r"--.*$", "", line) for line in sql.splitlines())
+
+
+def _statements(sql: str) -> list[str]:
+    return [s.strip() for s in _strip_comments(sql).split(";") if s.strip()]
+
+
+def _balanced(text: str, open_idx: int) -> str | None:
+    """Return the content between the '(' at `open_idx` and its matching ')', or None."""
+    depth = 0
+    for i in range(open_idx, len(text)):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return text[open_idx + 1 : i]
+    return None
+
+
+def _split_top_level(body: str) -> list[str]:
+    """Split on commas that are not inside nested parentheses."""
+    parts, depth, cur = [], 0, []
+    for ch in body:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        if ch == "," and depth == 0:
+            parts.append("".join(cur))
+            cur = []
+        else:
+            cur.append(ch)
+    if "".join(cur).strip():
+        parts.append("".join(cur))
+    return parts
+
+
+def _parse_create(stmt: str) -> tuple[str, set[str]] | None:
+    m = re.match(r"\s*create\s+table\s+(?:if\s+not\s+exists\s+)?([a-zA-Z_][\w]*)\s*\(", stmt, re.I)
+    if not m:
+        return None
+    body = _balanced(stmt, stmt.index("(", m.end() - 1))
+    if body is None:
+        return None
+    cols: set[str] = set()
+    for part in _split_top_level(body):
+        tok = _IDENT.match(part.strip())
+        if tok and tok.group(0).lower() not in _CONSTRAINT_HEADS:
+            cols.add(tok.group(0))
+    return m.group(1), cols
+
+
+def _parse_insert(stmt: str) -> tuple[str, list[str]] | None:
+    m = re.match(r"\s*insert\s+into\s+([a-zA-Z_][\w]*)\s*\(", stmt, re.I)
+    if not m:
+        return None
+    body = _balanced(stmt, stmt.index("(", m.end() - 1))
+    if body is None:
+        return None
+    cols = [c.strip() for c in _split_top_level(body) if c.strip()]
+    return m.group(1), cols
+
+
+def lint(files: list[tuple[str, str]]) -> list[str]:
+    """`files` = [(name, sql)] in apply order. Returns a list of human-readable errors."""
+    known: dict[str, set[str]] = {}
+    errors: list[str] = []
+    for name, sql in files:
+        for stmt in _statements(sql):
+            created = _parse_create(stmt)
+            if created:
+                known[created[0]] = created[1]
+                continue
+            inserted = _parse_insert(stmt)
+            if inserted:
+                table, cols = inserted
+                if table not in known:
+                    errors.append(f"{name}: INSERT INTO `{table}` before any CREATE TABLE {table}")
+                    continue
+                missing = [c for c in cols if c not in known[table]]
+                if missing:
+                    errors.append(
+                        f"{name}: INSERT INTO `{table}` names column(s) absent from its "
+                        f"CREATE TABLE: {missing}"
+                    )
+    return errors
+
+
+def lint_dir(path: Path) -> list[str]:
+    files = [(p.name, p.read_text(encoding="utf-8")) for p in sorted(path.glob("*.sql"))]
+    return lint(files)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dir", default=str(PG_DIR), help="migration directory to lint")
+    args = parser.parse_args(argv)
+    errors = lint_dir(Path(args.dir))
+    for e in errors:
+        print(f"::error::{e}")
+    if errors:
+        print(f"\n{len(errors)} migration consistency error(s).")
+        return 1
+    print(f"eval-fabric migrations in {args.dir} are self-consistent.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What
A stdlib, **no-DB** static linter (`tools/lint_eval_fabric_migrations.py`) that checks every `INSERT` targets a table `CREATE`d by an earlier migration and names only columns that table declares — guarding the exact bug class that shipped: an insert into a table whose `CREATE` existed nowhere, so a fresh `eval_fabric_migrate` fails.

## It found 3 more of the same bug on its first run
#705 fixed `metric_crosswalks` — but the linter revealed **that was 1 of 4**. `005` also inserts into `methodology_snapshots`, `repro_ledger_entries`, and `causal_attributions`, **none of which had a `CREATE TABLE` anywhere in the repo**. So the migrate was still broken.

`004a_runtime_seed_prerequisite_ddl.sql` adds all three (ordered `004 < 004a < 005`):
- columns = `005`'s exact insert lists,
- types from the canonical `schemas/eval/*.schema.json` (required → `NOT NULL`),
- no FKs (the text-id LEFT-JOIN convention of `source_descriptors`/`metric_definitions`/`metric_crosswalks`).

**The migrate chain is now self-consistent end to end** (linter exits clean on the real dir).

## CI
`platform-wave1-stubs` now runs the linter directly (dependency-free gate) **and** the full `tests/platform_stubs` dir — so this class of bug can't recur silently.

## Tests (6 linter + real-dir regression gate; full stubs dir 25 green)
insert-before-create flagged · unknown-insert-column flagged · inline-constrained columns kept · comments ignored · real dir clean.

## Note
`005` uses `window` (a Postgres reserved word) unquoted as a `causal_attributions` column; `004a` matches it verbatim. If a live migrate rejects unquoted `window`, quote it in both places — a possible linter enhancement (reserved-word check), out of scope here.