### PR TITLE
feat(argocd): wire the hellgraph super-peer Application (one sync from live)

### DIFF
--- a/infra/argocd/hellgraph-superpeer-application.yaml
+++ b/infra/argocd/hellgraph-superpeer-application.yaml
@@ -1,0 +1,31 @@
+# ArgoCD Application for the HellGraph super-peer (federation entrypoint).
+# Wires infra/k8s/hellgraph-superpeer/base into GitOps so the deploy is one
+# `argocd app sync hellgraph-superpeer` (after `gcloud auth` + cluster context) from live.
+#
+# Prereqs the sync depends on (out of band, per the go-live runbook):
+#   - Secret `hellgraph-superpeer-auth` (super-peer auth) in namespace `socioprophet`
+#   - Secret `hellgraph-federation` (edge federation base-key) in namespace `socioprophet`
+# The base ExternalSecret example (…auth.externalsecret.example.yaml) is intentionally NOT in
+# the kustomization; provision the secret before first sync or the pod will wait on it.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hellgraph-superpeer
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: hellgraph-federation
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/SocioProphet/prophet-platform.git
+    targetRevision: main
+    path: infra/k8s/hellgraph-superpeer/base
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: socioprophet
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## What
Adds the ArgoCD `Application` for the HellGraph **super-peer** (federation entrypoint), pointing at `infra/k8s/hellgraph-superpeer/base` (which `kubectl kustomize` builds clean). This was the missing GitOps wiring — **no Application referenced `hellgraph-superpeer` before** (verified). Matches the `cloudshell-fog` Application pattern (project `default`, repo `main`, automated `selfHeal`, `CreateNamespace`); destination namespace `socioprophet`.

## Effect
The deploy is now **one `argocd app sync hellgraph-superpeer` from live**, after the gated out-of-band prereqs (per the go-live runbook, your `gcloud`):
- provision `hellgraph-superpeer-auth` (super-peer auth) + `hellgraph-federation` (edge federation base-key) secrets in namespace `socioprophet`,
- `gcloud auth` + cluster context, then sync.

The base ExternalSecret **example** stays out of the kustomization on purpose — provision the real secret before first sync or the pod waits on it.

Plan item 2 (autonomous half). The apply/sync stays gated on your gcloud, as intended.