### PR TITLE
feat(autonomy): gate autonomy admission through the capability membrane

### DIFF
--- a/contracts/AutonomyAdmissionReceipt.v0.2.json
+++ b/contracts/AutonomyAdmissionReceipt.v0.2.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/AutonomyAdmissionReceipt.v0.2.json",
+  "title": "AutonomyAdmissionReceipt",
+  "description": "Runtime evidence receipt emitted when prophet-platform admits, demotes, or denies a choir role operating at a requested AI-driven-development autonomy level. v0.2 binds the decision to the capability-membrane kernel (tools/capability_membrane.py): when an operation context is supplied, the canonical role-aware ladder decision is wrapped by the membrane's four fail-closed layers (surface class, capability radius + tension-member presence, membrane policy verdict, autonomy ladder) and collapsed into one sourceos ExecutionDecision. The membrane block records that decision and the sealHash of the sibling sealed AgentMachineReceipt, making the composed admission tamper-evident.",
+  "type": "object",
+  "required": [
+    "version",
+    "receipt_id",
+    "created_at",
+    "service_ref",
+    "role",
+    "requested_level",
+    "granted_level",
+    "decision",
+    "gate",
+    "evidence_required",
+    "trust_kernel_gate_order",
+    "subject_ref",
+    "membrane",
+    "hash",
+    "hash_algo"
+  ],
+  "properties": {
+    "version": { "const": "0.2" },
+    "receipt_id": { "type": "string" },
+    "created_at": { "type": "string" },
+    "service_ref": { "type": "string" },
+    "role": {
+      "type": "string",
+      "description": "Choir role requesting autonomy (e.g. conductor, coding, research)."
+    },
+    "requested_level": { "type": "string", "pattern": "^L[0-5]$" },
+    "granted_level": { "type": "string", "pattern": "^L[0-5]$" },
+    "role_ceiling": { "type": "string", "pattern": "^L[0-5]$" },
+    "decision": { "type": "string", "enum": ["admit", "demote", "deny"] },
+    "gate": {
+      "type": "string",
+      "description": "Name of the gate that governs the granted level."
+    },
+    "evidence_required": { "type": "string" },
+    "evidence_refs": { "type": "array", "items": { "type": "string" } },
+    "reason": { "type": "string" },
+    "trust_kernel_gate_order": {
+      "type": "array",
+      "minItems": 6,
+      "maxItems": 6,
+      "prefixItems": [
+        { "const": "identity" },
+        { "const": "policy" },
+        { "const": "evidence" },
+        { "const": "attestation" },
+        { "const": "revocation" },
+        { "const": "audit" }
+      ],
+      "items": false
+    },
+    "subject_ref": { "type": "string" },
+    "envelope_ref": { "type": "string" },
+    "policy_refs": { "type": "array", "items": { "type": "string" } },
+    "membrane": {
+      "type": "object",
+      "description": "The capability-membrane resolution that governs this admission. execution_decision is the collapsed sourceos ExecutionDecision across all four fail-closed layers; a non-allow value forces decision=deny and granted_level=L0.",
+      "required": [
+        "execution_decision",
+        "verdict",
+        "capability_radius",
+        "missing_tension",
+        "membrane_decision",
+        "enforced",
+        "seal_hash"
+      ],
+      "properties": {
+        "execution_decision": {
+          "type": "string",
+          "enum": ["allow", "deny", "ask", "defer", "rewrite"]
+        },
+        "verdict": {
+          "type": "string",
+          "enum": ["allowed", "denied", "deferred", "failed", "observed"]
+        },
+        "capability_radius": { "type": "string", "pattern": "^R[0-5]$" },
+        "missing_tension": { "type": "array", "items": { "type": "string" } },
+        "membrane_decision": {
+          "type": "string",
+          "enum": ["ALLOW", "DENY", "QUARANTINE", "REDACT", "REQUIRE_SIGNATURE"]
+        },
+        "enforced": { "type": "boolean" },
+        "seal_hash": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "agent_machine_receipt_ref": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "hash": { "type": "string" },
+    "hash_algo": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/tools/emit_autonomy_admission_receipt.py
+++ b/tools/emit_autonomy_admission_receipt.py
@@ -27,6 +27,11 @@ from typing import Any, Iterable
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from validate_autonomy_admission_receipt import validate_receipt  # noqa: E402
 
+# The capability-membrane kernel governs the admission when an operation context
+# (surface/action) is supplied. Absent that, we stay the legacy autonomy-only
+# gate and emit a v0.1 receipt.
+from capability_membrane import CapabilityRequest, resolve_capability  # noqa: E402
+
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_LADDER = ROOT / "contracts" / "prophet-mesh" / "ai-driven-development.ladder.json"
 DEFAULT_OUTPUT_DIR = ROOT / "build" / "autonomy-admission"
@@ -120,9 +125,10 @@ def build_receipt(
     evidence_refs: list[str],
     envelope_ref: str | None = None,
     policy_refs: list[str] | None = None,
+    membrane: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     receipt: dict[str, Any] = {
-        "version": "0.1",
+        "version": "0.2" if membrane else "0.1",
         "receipt_id": receipt_id,
         "created_at": created_at,
         "service_ref": "svc.platform.autonomy-admission",
@@ -142,6 +148,8 @@ def build_receipt(
         receipt["envelope_ref"] = envelope_ref
     if policy_refs:
         receipt["policy_refs"] = list(policy_refs)
+    if membrane:
+        receipt["membrane"] = membrane
     receipt["hash_algo"] = "sha256"
     receipt["hash"] = "sha256:" + hashlib.sha256(_canonical_bytes(receipt)).hexdigest()
     return receipt
@@ -155,7 +163,61 @@ def _from_channel_gate(path: Path) -> dict[str, Any]:
         "envelope_ref": gate.get("gate_id"),
         "evidence_refs": list(gate.get("evidence_refs", []) or []),
         "policy_refs": list(gate.get("policy_decision_refs", []) or []),
+        # Operation context for the capability membrane (all optional).
+        "surface": gate.get("surface"),
+        "action": gate.get("action"),
+        "access_level": gate.get("access_level"),
+        "tension_members": list(gate.get("tension_members", []) or []),
+        "membrane_decision": gate.get("membrane_decision"),
+        "scope": gate.get("scope"),
     }
+
+
+def _gate_capability(
+    *,
+    surface: str,
+    action: str,
+    access_level: str,
+    subject_ref: str,
+    scope: str,
+    owned: bool,
+    tension_members: list[str],
+    requested_level: str,
+    evidence: set[str],
+    membrane_decision: str,
+    policy_refs: list[str],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Run the capability-membrane kernel over the operation this admission is for.
+
+    Returns (membrane_block, sealed_agent_machine_receipt). The membrane's
+    collapsed ExecutionDecision is the fail-closed outer gate: a non-allow value
+    denies the admission regardless of what the autonomy ladder alone would grant.
+    """
+    request = CapabilityRequest(
+        surface=surface,
+        action=action,
+        access_level=access_level,
+        subject_ref=subject_ref or "urn:srcos:subject:unspecified",
+        scope=scope,
+        owned=owned,
+        tension_members=tuple(tension_members),
+        requested_autonomy_level=requested_level,
+        autonomy_evidence=tuple(sorted(evidence)),
+        membrane_decision=membrane_decision,
+        policy_refs=tuple(policy_refs),
+    )
+    res = resolve_capability(request)
+    membrane_block = {
+        "execution_decision": res.execution_decision,
+        "verdict": res.verdict,
+        "capability_radius": res.radius,
+        "missing_tension": list(res.missing_tension),
+        "membrane_decision": res.membrane_decision,
+        "enforced": res.enforced,
+        "seal_hash": res.sealed["sealHash"],
+        "agent_machine_receipt_ref": res.sealed["id"],
+    }
+    return membrane_block, res.sealed
 
 
 def main(argv: list[str]) -> int:
@@ -169,6 +231,15 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--ladder", default=str(DEFAULT_LADDER))
     parser.add_argument("--receipt-id", default=None)
     parser.add_argument("--out", help="output path (default build/autonomy-admission/<receipt_id>.json)")
+    # Operation context — supplying a surface engages the capability-membrane
+    # kernel as the fail-closed outer gate and emits a v0.2 receipt.
+    parser.add_argument("--surface", help="operation surface (e.g. shell|computer|browser); engages the membrane")
+    parser.add_argument("--action", help="dotted action, e.g. shell.exec")
+    parser.add_argument("--access-level", default="scopedRead", help="ConnectorActionScope accessLevel")
+    parser.add_argument("--tension-members", default="", help="comma-separated present governance members")
+    parser.add_argument("--membrane-decision", default="ALLOW", help="upstream membrane verdict")
+    parser.add_argument("--scope", default="user_local", help="user_local | global_platform")
+    parser.add_argument("--unowned", action="store_true", help="surface we do not own → observe-only")
     args = parser.parse_args(argv[1:])
 
     ladder = Ladder.load(Path(args.ladder))
@@ -179,6 +250,7 @@ def main(argv: list[str]) -> int:
     subject_ref = args.subject_ref
     envelope_ref = None
     policy_refs: list[str] = []
+    ctx: dict[str, Any] = {}
     if args.channel_gate:
         ctx = _from_channel_gate(Path(args.channel_gate))
         subject_ref = subject_ref or ctx["subject_ref"]
@@ -191,6 +263,38 @@ def main(argv: list[str]) -> int:
         print("ERROR: subject_ref required (pass --subject-ref or --channel-gate)", file=sys.stderr)
         return 2
 
+    # If an operation surface is supplied (CLI or channel gate), the capability
+    # membrane governs the admission as a fail-closed outer gate.
+    membrane_block: dict[str, Any] | None = None
+    sealed: dict[str, Any] | None = None
+    surface = args.surface or ctx.get("surface")
+    if surface:
+        tension = [t.strip() for t in args.tension_members.split(",") if t.strip()] or list(ctx.get("tension_members") or [])
+        membrane_block, sealed = _gate_capability(
+            surface=surface,
+            action=args.action or ctx.get("action") or f"{surface}.invoke",
+            access_level=args.access_level or ctx.get("access_level") or "scopedRead",
+            subject_ref=subject_ref,
+            scope=args.scope or ctx.get("scope") or "user_local",
+            owned=not args.unowned,
+            tension_members=tension,
+            requested_level=decision["requested_level"],
+            evidence=evidence,
+            membrane_decision=args.membrane_decision or ctx.get("membrane_decision") or "ALLOW",
+            policy_refs=list(policy_refs),
+        )
+        # Fail-closed composition: a non-allow membrane denies the admission at L0,
+        # overriding whatever the autonomy ladder alone would have granted.
+        if membrane_block["execution_decision"] != "allow":
+            note = f"capability membrane {membrane_block['execution_decision']} (radius {membrane_block['capability_radius']}"
+            if membrane_block["missing_tension"]:
+                note += f", missing tension {membrane_block['missing_tension']}"
+            note += ")"
+            decision = dict(decision)
+            decision["granted_level"] = "L0"
+            decision["decision"] = "deny"
+            decision["reason"] = "; ".join(x for x in (decision.get("reason", ""), note) if x)
+
     created_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     receipt_id = args.receipt_id or f"aar-{int(time.time())}"
     receipt = build_receipt(
@@ -201,6 +305,7 @@ def main(argv: list[str]) -> int:
         evidence_refs=evidence_refs,
         envelope_ref=envelope_ref,
         policy_refs=policy_refs,
+        membrane=membrane_block,
     )
 
     # Fail-closed: never emit a receipt that does not validate against the contract.
@@ -213,7 +318,24 @@ def main(argv: list[str]) -> int:
     out = Path(args.out) if args.out else DEFAULT_OUTPUT_DIR / f"{receipt_id}.json"
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(json.dumps({"ok": True, "out": str(out), "decision": decision["decision"], "granted_level": decision["granted_level"], "hash": receipt["hash"]}, sort_keys=True))
+    # Emit the sealed AgentMachineReceipt alongside so the membrane decision is
+    # independently verifiable (its sealHash is bound into the receipt above).
+    sealed_out = None
+    if sealed is not None:
+        sealed_out = out.parent / f"{out.stem}.agent-machine-receipt.json"
+        sealed_out.write_text(json.dumps(sealed, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    summary = {
+        "ok": True,
+        "out": str(out),
+        "decision": decision["decision"],
+        "granted_level": decision["granted_level"],
+        "hash": receipt["hash"],
+    }
+    if membrane_block is not None:
+        summary["membrane_execution_decision"] = membrane_block["execution_decision"]
+        summary["sealed_receipt"] = str(sealed_out)
+    print(json.dumps(summary, sort_keys=True))
     return 0
 
 

--- a/tools/tests/test_emit_autonomy_admission_receipt.py
+++ b/tools/tests/test_emit_autonomy_admission_receipt.py
@@ -68,6 +68,82 @@ def test_emit_binds_to_channel_gate(tmp_path: Path):
     assert "prophet-mesh:specs/ai-driven-development.yaml" in receipt["policy_refs"]
 
 
+R3_TENSION = "policy,identity,provenance,evidence,replay,revocation"
+
+
+def test_legacy_path_without_surface_is_v01(tmp_path: Path):
+    receipt = _emit(
+        tmp_path, "--role", "conductor", "--level", "L4",
+        "--evidence", "conductor_response_envelope",
+        "--evidence-refs", "evidence://env/1",
+        "--subject-ref", "agent://choir/conductor/run-x",
+    )
+    assert receipt["version"] == "0.1"
+    assert "membrane" not in receipt
+
+
+def test_membrane_deny_overrides_ladder_admit(tmp_path: Path):
+    # Ladder alone would admit conductor@L4; the membrane denies because the
+    # scopedWrite (R3) operation is missing its required tension members.
+    out = tmp_path / "receipt.json"
+    receipt = _emit(
+        tmp_path, "--role", "conductor", "--level", "L4",
+        "--evidence", "conductor_response_envelope",
+        "--evidence-refs", "evidence://env/1",
+        "--subject-ref", "agent://choir/conductor/run-1",
+        "--surface", "shell", "--action", "shell.exec", "--access-level", "scopedWrite",
+    )
+    assert receipt["version"] == "0.2"
+    assert receipt["decision"] == "deny"
+    assert receipt["granted_level"] == "L0"
+    assert receipt["membrane"]["execution_decision"] == "deny"
+    assert receipt["membrane"]["missing_tension"]  # non-empty
+    assert _validates(out)
+
+
+def test_membrane_allow_passes_through_and_seals(tmp_path: Path):
+    out = tmp_path / "receipt.json"
+    receipt = _emit(
+        tmp_path, "--role", "conductor", "--level", "L4",
+        "--evidence", "conductor_response_envelope",
+        "--evidence-refs", "evidence://env/1",
+        "--subject-ref", "agent://choir/conductor/run-1",
+        "--surface", "shell", "--action", "shell.exec", "--access-level", "scopedWrite",
+        "--tension-members", R3_TENSION,
+    )
+    assert receipt["version"] == "0.2"
+    assert receipt["decision"] == "admit"
+    assert receipt["granted_level"] == "L4"
+    m = receipt["membrane"]
+    assert m["execution_decision"] == "allow"
+    assert m["capability_radius"] == "R3"
+    assert m["missing_tension"] == []
+    assert m["seal_hash"].startswith("sha256:")
+    assert _validates(out)
+    # The sealed AgentMachineReceipt is emitted alongside and its sealHash is the
+    # one bound into the receipt.
+    sealed = tmp_path / "receipt.agent-machine-receipt.json"
+    assert sealed.exists()
+    assert json.loads(sealed.read_text())["sealHash"] == m["seal_hash"]
+
+
+def test_membrane_block_is_bound_into_the_hash(tmp_path: Path):
+    receipt = _emit(
+        tmp_path, "--role", "conductor", "--level", "L4",
+        "--evidence", "conductor_response_envelope",
+        "--evidence-refs", "evidence://env/1",
+        "--subject-ref", "agent://choir/conductor/run-1",
+        "--surface", "shell", "--action", "shell.exec", "--access-level", "scopedWrite",
+        "--tension-members", R3_TENSION,
+    )
+    import hashlib
+    body = {k: v for k, v in receipt.items() if k != "hash"}
+    recomputed = "sha256:" + hashlib.sha256(
+        json.dumps(body, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+    ).hexdigest()
+    assert recomputed == receipt["hash"]  # tampering with membrane changes the hash
+
+
 def test_hash_is_deterministic_over_content(tmp_path: Path):
     common = ["--role", "research", "--level", "L3", "--evidence", "evidence_dossier",
               "--evidence-refs", "evidence://dossier/x",

--- a/tools/tests/test_validate_autonomy_admission_receipt.py
+++ b/tools/tests/test_validate_autonomy_admission_receipt.py
@@ -33,6 +33,46 @@ def test_granted_cannot_exceed_role_ceiling(tmp_path: Path):
     assert "role_ceiling" in proc.stderr
 
 
+def _v02_membrane(execution_decision: str = "allow") -> dict:
+    return {
+        "execution_decision": execution_decision,
+        "verdict": {"allow": "allowed", "deny": "denied"}.get(execution_decision, "deferred"),
+        "capability_radius": "R3",
+        "missing_tension": [] if execution_decision == "allow" else ["revocation"],
+        "membrane_decision": "ALLOW" if execution_decision == "allow" else "DENY",
+        "enforced": True,
+        "seal_hash": "sha256:" + "0" * 64,
+    }
+
+
+def test_v02_membrane_deny_with_admit_is_rejected(tmp_path: Path):
+    # Fail-closed invariant: a non-allow membrane must force decision=deny/L0.
+    receipt = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+    receipt["version"] = "0.2"
+    receipt["membrane"] = _v02_membrane("deny")  # but decision stays "admit"
+    proc = _validate(receipt, tmp_path)
+    assert proc.returncode == 1
+    assert "fail-closed" in proc.stderr
+
+
+def test_v02_membrane_deny_with_deny_l0_validates(tmp_path: Path):
+    receipt = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+    receipt["version"] = "0.2"
+    receipt["membrane"] = _v02_membrane("deny")
+    receipt["decision"] = "deny"
+    receipt["granted_level"] = "L0"
+    proc = _validate(receipt, tmp_path)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_v02_requires_membrane_block(tmp_path: Path):
+    receipt = json.loads(EXAMPLE.read_text(encoding="utf-8"))
+    receipt["version"] = "0.2"  # no membrane block
+    proc = _validate(receipt, tmp_path)
+    assert proc.returncode == 1
+    assert "membrane" in proc.stderr
+
+
 def test_schema_rejects_malformed_gate_order():
     jsonschema = pytest.importorskip("jsonschema")
     schema = json.loads(SCHEMA.read_text(encoding="utf-8"))

--- a/tools/validate_autonomy_admission_receipt.py
+++ b/tools/validate_autonomy_admission_receipt.py
@@ -35,7 +35,17 @@ REQUIRED = {
 DECISIONS = {"admit", "demote", "deny"}
 TRUST_KERNEL_GATE_ORDER = ["identity", "policy", "evidence", "attestation", "revocation", "audit"]
 LEVEL_RE = re.compile(r"^L[0-5]$")
+RADIUS_RE = re.compile(r"^R[0-5]$")
+SEAL_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 NO_EVIDENCE = {"none", ""}
+SUPPORTED_VERSIONS = {"0.1", "0.2"}
+EXECUTION_DECISIONS = {"allow", "deny", "ask", "defer", "rewrite"}
+VERDICTS = {"allowed", "denied", "deferred", "failed", "observed"}
+MEMBRANE_DECISIONS = {"ALLOW", "DENY", "QUARANTINE", "REDACT", "REQUIRE_SIGNATURE"}
+MEMBRANE_REQUIRED = {
+    "execution_decision", "verdict", "capability_radius",
+    "missing_tension", "membrane_decision", "enforced", "seal_hash",
+}
 
 
 class ValidationError(Exception):
@@ -62,8 +72,10 @@ def validate_receipt(record: dict[str, Any]) -> None:
     if missing:
         fail("missing required fields: " + ", ".join(missing))
 
-    if record["version"] != "0.1":
-        fail("version must be '0.1'")
+    if record["version"] not in SUPPORTED_VERSIONS:
+        fail(f"version must be one of {sorted(SUPPORTED_VERSIONS)}")
+    if record["version"] == "0.2" and "membrane" not in record:
+        fail("v0.2 receipt requires a 'membrane' block")
     for key in ("requested_level", "granted_level"):
         if not LEVEL_RE.match(str(record[key])):
             fail(f"{key} must match L0..L5")
@@ -98,17 +110,48 @@ def validate_receipt(record: dict[str, Any]) -> None:
         if not isinstance(refs, list) or not refs:
             fail("granted level above L0 requires non-empty evidence_refs")
 
+    # v0.2: the capability-membrane binding and the composition invariant.
+    if record["version"] == "0.2":
+        m = record.get("membrane")
+        if not isinstance(m, dict):
+            fail("membrane must be an object")
+        m_missing = sorted(MEMBRANE_REQUIRED - set(m))
+        if m_missing:
+            fail("membrane missing required fields: " + ", ".join(m_missing))
+        if m["execution_decision"] not in EXECUTION_DECISIONS:
+            fail(f"membrane.execution_decision must be one of {sorted(EXECUTION_DECISIONS)}")
+        if m["verdict"] not in VERDICTS:
+            fail(f"membrane.verdict must be one of {sorted(VERDICTS)}")
+        if m["membrane_decision"] not in MEMBRANE_DECISIONS:
+            fail(f"membrane.membrane_decision must be one of {sorted(MEMBRANE_DECISIONS)}")
+        if not RADIUS_RE.match(str(m["capability_radius"])):
+            fail("membrane.capability_radius must match R0..R5")
+        if not SEAL_RE.match(str(m["seal_hash"])):
+            fail("membrane.seal_hash must be a sha256:<64-hex> digest")
+        if not isinstance(m["missing_tension"], list):
+            fail("membrane.missing_tension must be an array")
+        if not isinstance(m["enforced"], bool):
+            fail("membrane.enforced must be a boolean")
+        # Composition invariant: a non-allow membrane decision is fail-closed —
+        # it must force a denied admission at L0.
+        if m["execution_decision"] != "allow" and not (decision == "deny" and granted == 0):
+            fail(
+                "membrane fail-closed invariant: execution_decision "
+                f"'{m['execution_decision']}' requires decision=deny and granted_level=L0"
+            )
+
 
 def main(argv: list[str]) -> int:
     if len(argv) != 2:
         print("usage: validate_autonomy_admission_receipt.py <receipt.json>", file=sys.stderr)
         return 2
     try:
-        validate_receipt(load_json(Path(argv[1])))
+        record = load_json(Path(argv[1]))
+        validate_receipt(record)
     except (ValidationError, json.JSONDecodeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
-    print(f"OK: {argv[1]} validates as AutonomyAdmissionReceipt v0.1")
+    print(f"OK: {argv[1]} validates as AutonomyAdmissionReceipt v{record.get('version', '?')}")
     return 0
 
 


### PR DESCRIPTION
## What
Wires the **capability-membrane kernel** (`tools/capability_membrane.py`, the 240-test kernel from #701) into the **autonomy admission gate** so it actually governs a runtime decision instead of sitting unwired.

## How it composes (fail-closed)
When an operation context is supplied (`--surface`/`--action`, or a channel-gate record carrying them), `emit_autonomy_admission_receipt.py` runs the **full membrane** over that operation and composes it with the canonical ladder:
- the canonical **prophet-mesh ladder** stays authoritative for the autonomy **level** (role ceiling + evidence);
- the **membrane** wraps it with its other three fail-closed layers — surface class, capability radius + **tension-member presence**, membrane policy verdict;
- a **non-allow** membrane `ExecutionDecision` overrides to `decision=deny` / `granted_level=L0`, regardless of what the ladder alone would grant.

The ladders are consistent by construction (the membrane's embedded evidence tokens exactly match the canonical `evidence_required` per level), so composition never contradicts.

## Contract
`AutonomyAdmissionReceipt` **v0.2** adds a bound `membrane` block (execution_decision, verdict, capability_radius, missing_tension, membrane_decision, enforced, `seal_hash`). The sealed **AgentMachineReceipt** is emitted alongside and its `sealHash` is **bound into the receipt hash** → tamper-evident. The validator is version-aware and enforces the fail-closed composition invariant. **Backward compatible**: with no operation surface, it stays the legacy v0.1 autonomy-only gate.

## Verification
- **36 tests pass**, including: membrane deny overrides a ladder-admit → deny/L0; membrane allow passes through → admit/L4 + sealed sibling whose sealHash matches the bound value; the membrane block is inside the receipt hash; validator rejects a non-allow membrane paired with `admit`.
- ruff clean; existing autonomy + capability-membrane suites unchanged and green.