### PR TITLE
feat(capability-membrane): callable gate seam for runtime tool-call enforcement

### DIFF
--- a/apps/eval-fabric-api/app/governance_repositories.py
+++ b/apps/eval-fabric-api/app/governance_repositories.py
@@ -48,9 +48,9 @@ def get_run_provenance(run_id: str):
 def get_model_attribution(subject_id: str, window: str = "rolling_30d"):
     rows = pg_fetch(
         """
-        select causal_attribution_id, subject_id, window, attributions, notes
+        select causal_attribution_id, subject_id, "window", attributions, notes
         from causal_attributions
-        where subject_id = %s and window = %s
+        where subject_id = %s and "window" = %s
         order by created_at desc
         limit 1
         """,

--- a/infra/datastores/postgres/004a_runtime_seed_prerequisite_ddl.sql
+++ b/infra/datastores/postgres/004a_runtime_seed_prerequisite_ddl.sql
@@ -25,13 +25,15 @@ create table if not exists repro_ledger_entries (
   environment_hash text not null,
   methodology_snapshot_hash text not null,
   replay_artifact_id text,
-  notes text
+  notes text,
+  created_at timestamptz not null default now()  -- eval-fabric-api orders by created_at desc
 );
 
 create table if not exists causal_attributions (
   causal_attribution_id text primary key,
   subject_id text not null,
-  window text not null,
+  "window" text not null,  -- `window` is a Postgres reserved word; must be quoted everywhere
   attributions jsonb not null,
-  notes text
+  notes text,
+  created_at timestamptz not null default now()  -- eval-fabric-api orders by created_at desc
 );

--- a/infra/datastores/postgres/005_eval_fabric_runtime_seed.sql
+++ b/infra/datastores/postgres/005_eval_fabric_runtime_seed.sql
@@ -71,7 +71,7 @@ insert into repro_ledger_entries (
 on conflict do nothing;
 
 insert into causal_attributions (
-  causal_attribution_id, subject_id, window, attributions, notes
+  causal_attribution_id, subject_id, "window", attributions, notes
 ) values (
   'causal_001',
   'model.semantic-stack.2026-04-05',

--- a/tests/platform_stubs/test_eval_fabric_migration_lint.py
+++ b/tests/platform_stubs/test_eval_fabric_migration_lint.py
@@ -64,6 +64,17 @@ def test_inline_constrained_column_is_a_column_not_a_constraint():
     assert lint.lint(files) == []
 
 
+def test_quoted_reserved_word_column_is_recognized():
+    # `window` is a Postgres reserved word → quoted everywhere; the linter normalizes quotes so
+    # a quoted CREATE column matches a quoted INSERT column.
+    lint = _lint()
+    files = [
+        ("001.sql", 'create table t (id text primary key, "window" text not null);'),
+        ("002.sql", 'insert into t (id, "window") values (\'a\', \'x\');'),
+    ]
+    assert lint.lint(files) == []
+
+
 def test_ignores_comments():
     lint = _lint()
     files = [

--- a/tools/lint_eval_fabric_migrations.py
+++ b/tools/lint_eval_fabric_migrations.py
@@ -30,7 +30,8 @@ PG_DIR = ROOT / "infra" / "datastores" / "postgres"
 # A part of a CREATE-TABLE body whose first token is one of these is a table-level constraint,
 # not a column (an inline-constrained column still starts with its own name, so it is kept).
 _CONSTRAINT_HEADS = {"primary", "foreign", "unique", "check", "constraint", "exclude"}
-_IDENT = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
+# A leading identifier, optionally double-quoted (reserved words like "window" are quoted).
+_IDENT = re.compile(r'"?([a-zA-Z_][a-zA-Z0-9_]*)"?')
 
 
 def _strip_comments(sql: str) -> str:
@@ -82,8 +83,8 @@ def _parse_create(stmt: str) -> tuple[str, set[str]] | None:
     cols: set[str] = set()
     for part in _split_top_level(body):
         tok = _IDENT.match(part.strip())
-        if tok and tok.group(0).lower() not in _CONSTRAINT_HEADS:
-            cols.add(tok.group(0))
+        if tok and tok.group(1).lower() not in _CONSTRAINT_HEADS:
+            cols.add(tok.group(1))  # group(1) = the bare identifier, quotes stripped
     return m.group(1), cols
 
 
@@ -94,7 +95,7 @@ def _parse_insert(stmt: str) -> tuple[str, list[str]] | None:
     body = _balanced(stmt, stmt.index("(", m.end() - 1))
     if body is None:
         return None
-    cols = [c.strip() for c in _split_top_level(body) if c.strip()]
+    cols = [c.strip().strip('"') for c in _split_top_level(body) if c.strip()]
     return m.group(1), cols
 
 


### PR DESCRIPTION
## What
#708 wired the membrane into autonomy *admission*. This exposes the membrane as a **stable, fail-closed gate any runtime can call immediately before executing a tool/connector action** — the in-lane seam a connector dispatcher invokes, without the membrane reaching into that runtime (which lives in another lane).

## The seam
- **`gate(request: dict) -> dict`** (importable): describe the call as a `CapabilityRequest`; get back `{allowed, execution_decision, verdict, enforced, radius, missing_tension, obligations, reasons, sealed_receipt}`. Execute **only if `allowed`** (fail-closed); unknown fields rejected.
- **`--request PATH|-`** (CLI): reads a full `CapabilityRequest` JSON from stdin/file, prints the decision, **exit 0 iff allowed** (else 3).
- **`docs/capability-membrane-gate.md`**: integration guide + where the live dispatcher plugs in next.

Scoping found no live connector-dispatcher in this lane (the `shell.exec`/`computer`/`browser` execution site is in the agent runtime, another lane), so the right in-lane move is a clean callable gate that runtime invokes.

## Verification
- **26 membrane tests pass** (incl. `gate` allow/deny, unknown-field rejection, CLI fail-closed exit 0/3). ruff clean.