### PR TITLE
feat(dashboard-bff): /v1/vdt — serve Value Driver Tree from the canonical engine

### DIFF
--- a/apps/dashboard-bff/contracts.py
+++ b/apps/dashboard-bff/contracts.py
@@ -44,3 +44,46 @@ class IntelligenceSuperiorityResponse(BaseModel):
     reproduced_fact_count: int
     cited_fact_count: int
     disclaimer: str
+
+
+class VdtCell(BaseModel):
+    """One (value-driver × capability-domain) cell of the attribution tensor: the fraction of
+    enterprise value carried by that intersection. The cells sum to ~1.0 for the industry."""
+    driver: str
+    domain: str
+    weight: float
+
+
+class VdtKpiContribution(BaseModel):
+    """A KPI lever and the enterprise-value uplift it produces = improvement × cell weight × EV.
+    polarity is carried so the UI can show that a falling lower_better metric is a positive move."""
+    kpi: str
+    driver: str
+    domain: str
+    delta_pct: float
+    polarity: str
+    value_contribution: float
+
+
+class VdtResponse(BaseModel):
+    """The Value Driver Tree view, served from the canonical economic-prophet engine's OUTPUT (never
+    recomputed here — the value math lives in economic-prophet). The surface renders the driver×domain
+    attribution heatmap (weights), per-driver/-domain uplift bars, and the KPI-lever cards; headline is
+    the engine's computed total. epistemic_status + provenance keep the number honest about being a
+    synthetic, machine-checked illustration rather than a measured business outcome."""
+    service: str
+    industry: str
+    scenario: str
+    enterprise_value_baseline: float
+    drivers: list[str]
+    domains: list[str]
+    weights: list[VdtCell]
+    per_kpi_contribution: list[VdtKpiContribution]
+    per_driver_uplift: dict[str, float]
+    per_domain_uplift: dict[str, float]
+    computed_total_value_uplift: float
+    computed_value_uplift_fraction: float
+    projected_enterprise_value: float
+    epistemic_status: dict
+    provenance: dict
+    headline: str

--- a/apps/dashboard-bff/data/vdt/vdt_software_platforms.metrics.json
+++ b/apps/dashboard-bff/data/vdt/vdt_software_platforms.metrics.json
@@ -1,0 +1,338 @@
+{
+  "_provenance": {
+    "engine": "open_ep_framework.vdt.run_vdt",
+    "framework_version": "0.1.0",
+    "generated_at": "2026-07-05T22:13:57.357179+00:00",
+    "industry": "GICS45_SoftwarePlatforms",
+    "input_hash": "hash://synthetic/input-vdt-software-001",
+    "note": "Engine-produced OUTPUT vendored for the dashboard-bff to serve. The canonical value math lives in economic-prophet; this file is not hand-edited.",
+    "profile_example": "examples/vdt_software_platforms.json",
+    "regen": "cd ~/dev/economic-prophet && python -m open_ep_framework.cli --mode vdt --example examples/vdt_software_platforms.json",
+    "source_repo": "SocioProphet/economic-prophet"
+  },
+  "profile": {
+    "as_of": "2026-07-04T00:00:00Z",
+    "assumptions": [
+      "Cell weights are the GICS45 Software & Platforms driver x capability-domain value attribution (sums to ~1.0).",
+      "A KPI lever moves the value carried by its (driver, domain) cell by the improvement fraction.",
+      "lower_better KPIs (e.g. security_incident_rate) improve as they fall; a negative delta is a positive improvement.",
+      "Enterprise-value baseline is a synthetic $1B for illustration."
+    ],
+    "domains": [
+      "CustomerInterface",
+      "ProductServiceDev",
+      "SupplyDelivery",
+      "OperationsSupport",
+      "RiskSecurity",
+      "GovernanceKnowledge"
+    ],
+    "drivers": [
+      "RevenueGrowth",
+      "CostEfficiency",
+      "Experience",
+      "KnowledgeProductivity",
+      "TrustComplianceResilience",
+      "Innovation"
+    ],
+    "enterprise_value_baseline": 1000000000.0,
+    "epistemic_status": {
+      "confidence": 0.6,
+      "level": "synthetic",
+      "review_status": "machine_checked"
+    },
+    "evidence_refs": [
+      "schemas/vdt_profile.schema.json",
+      "docs/whitepaper.md"
+    ],
+    "framework_version": "0.1.0",
+    "industry": "GICS45_SoftwarePlatforms",
+    "input_hash": "hash://synthetic/input-vdt-software-001",
+    "kpis": [
+      {
+        "delta_pct": 10.0,
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "kpi": "arr_growth_pct",
+        "polarity": "higher_better"
+      },
+      {
+        "delta_pct": 2.0,
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "kpi": "gross_margin_pct",
+        "polarity": "higher_better"
+      },
+      {
+        "delta_pct": -0.5,
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "kpi": "security_incident_rate",
+        "polarity": "lower_better"
+      }
+    ],
+    "limitations": [
+      "Synthetic fixture; not calibrated to a real company.",
+      "No investment, securities, or valuation-opinion conclusion is implied."
+    ],
+    "measurement_boundary": {
+      "mode": "doctrine_measurement_simulation_audit_only",
+      "non_goals": [
+        "live_money_movement",
+        "securities_issuance",
+        "investment_advice",
+        "deposit_taking",
+        "external_token_issuance",
+        "payment_processing"
+      ]
+    },
+    "output_hash": "hash://synthetic/output-vdt-software-001",
+    "replay_plan_ref": "replay://vdt/software-platforms-001",
+    "reported_total_value_uplift": 10201612.903225804,
+    "reported_value_uplift_fraction": 0.010201612903225804,
+    "run_id": "vdt-software-platforms-001",
+    "scenario": "software-platforms-value-driver-tree",
+    "weights": [
+      {
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "weight": 0.09677419354838708
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "RevenueGrowth",
+        "weight": 0.04838709677419354
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "RevenueGrowth",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "RevenueGrowth",
+        "weight": 0.032258064516129024
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "RevenueGrowth",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "RevenueGrowth",
+        "weight": 0.032258064516129024
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "CostEfficiency",
+        "weight": 0.032258064516129024
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "CostEfficiency",
+        "weight": 0.032258064516129024
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "weight": 0.04032258064516128
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "CostEfficiency",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "CostEfficiency",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Experience",
+        "weight": 0.04838709677419354
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Experience",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Experience",
+        "weight": 0.008064516129032256
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Experience",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Experience",
+        "weight": 0.008064516129032256
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Experience",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.032258064516129024
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.04032258064516128
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.008064516129032256
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.04032258064516128
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.04032258064516128
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Innovation",
+        "weight": 0.04032258064516128
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Innovation",
+        "weight": 0.04838709677419354
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Innovation",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Innovation",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Innovation",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Innovation",
+        "weight": 0.02419354838709677
+      }
+    ]
+  },
+  "summary": {
+    "computed_total_value_uplift": 10201612.903225804,
+    "computed_value_uplift_fraction": 0.010201612903225804,
+    "domain_count": 6,
+    "driver_count": 6,
+    "enterprise_value_baseline": 1000000000.0,
+    "industry": "GICS45_SoftwarePlatforms",
+    "kpi_count": 3,
+    "measurement_boundary_mode": "doctrine_measurement_simulation_audit_only",
+    "missing_required_non_goals": [],
+    "per_domain_uplift": {
+      "CustomerInterface": 9677419.354838708,
+      "RiskSecurity": 201612.90322580643,
+      "SupplyDelivery": 322580.64516129025
+    },
+    "per_driver_uplift": {
+      "CostEfficiency": 322580.64516129025,
+      "RevenueGrowth": 9677419.354838708,
+      "TrustComplianceResilience": 201612.90322580643
+    },
+    "per_kpi_contribution": [
+      {
+        "delta_pct": 10.0,
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "kpi": "arr_growth_pct",
+        "polarity": "higher_better",
+        "value_contribution": 9677419.354838708
+      },
+      {
+        "delta_pct": 2.0,
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "kpi": "gross_margin_pct",
+        "polarity": "higher_better",
+        "value_contribution": 322580.64516129025
+      },
+      {
+        "delta_pct": -0.5,
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "kpi": "security_incident_rate",
+        "polarity": "lower_better",
+        "value_contribution": 201612.90322580643
+      }
+    ],
+    "projected_enterprise_value": 1010201612.9032258,
+    "reported_total_value_uplift": 10201612.903225804,
+    "reported_value_uplift_fraction": 0.010201612903225804,
+    "required_non_goals_present": [
+      "deposit_taking",
+      "external_token_issuance",
+      "investment_advice",
+      "live_money_movement",
+      "securities_issuance"
+    ],
+    "run_id": "vdt-software-platforms-001",
+    "scenario": "software-platforms-value-driver-tree",
+    "weight_cell_count": 36,
+    "weight_sum": 0.9999999999999998
+  }
+}

--- a/apps/dashboard-bff/main.py
+++ b/apps/dashboard-bff/main.py
@@ -31,6 +31,7 @@ def _load_module(path: Path, name: str):
 _contracts = _load_module(Path(__file__).with_name('contracts.py'), 'dashboard_bff_contracts')
 OverviewResponse = _contracts.OverviewResponse
 _producer = _load_module(ROOT / 'tools' / 'emit_intelligence_superiority_metrics.py', 'emit_metrics')
+_vdt_producer = _load_module(ROOT / 'tools' / 'emit_vdt_metrics.py', 'emit_vdt_metrics')
 
 app = FastAPI(title='dashboard-bff')
 
@@ -49,7 +50,7 @@ def health() -> dict:
 def overview() -> object:
     return OverviewResponse(
         service='dashboard-bff',
-        views=['overview', 'deepdive', 'cases', 'intelligence-superiority'],
+        views=['overview', 'deepdive', 'cases', 'intelligence-superiority', 'value-drivers'],
         trace_required=True,
         evidence_required=True,
     )
@@ -111,5 +112,41 @@ def intelligence_superiority() -> object:
             'Facts labeled internal_reproduced were measured by us; official_provider facts are cited '
             'vendor/leaderboard numbers we did NOT independently verify. Our metrics and cited metrics are '
             'disjoint by design — no cross-provider superiority is asserted on any single benchmark.'
+        ),
+    )
+
+
+@app.get('/v1/vdt', response_model=_contracts.VdtResponse)
+def value_driver_tree() -> object:
+    """Serve the Value Driver Tree view from the canonical economic-prophet engine's OUTPUT. The value
+    math (EP/UVMC/VDT identities) lives in economic-prophet and is NOT recomputed here — this endpoint
+    reshapes the engine-produced artifact (tensor + computed uplifts, provenance intact) for the cockpit
+    surface, which previously computed from a hand-mirrored TS fixture. epistemic_status travels with the
+    payload so the UI presents the figure as a synthetic, machine-checked illustration, not a measured
+    business result."""
+    v = _vdt_producer.build()
+    uplift = v['computed_total_value_uplift']
+    frac = v['computed_value_uplift_fraction']
+    ev = v['enterprise_value_baseline']
+    return _contracts.VdtResponse(
+        service='dashboard-bff',
+        industry=v['industry'],
+        scenario=v['scenario'],
+        enterprise_value_baseline=ev,
+        drivers=v['drivers'],
+        domains=v['domains'],
+        weights=[_contracts.VdtCell(**c) for c in v['weights']],
+        per_kpi_contribution=[_contracts.VdtKpiContribution(**k) for k in v['per_kpi_contribution']],
+        per_driver_uplift=v['per_driver_uplift'],
+        per_domain_uplift=v['per_domain_uplift'],
+        computed_total_value_uplift=uplift,
+        computed_value_uplift_fraction=frac,
+        projected_enterprise_value=v['projected_enterprise_value'],
+        epistemic_status=v['epistemic_status'],
+        provenance=v['provenance'],
+        headline=(
+            f"{v['industry']}: the modeled KPI levers project +${uplift / 1e6:.2f}M "
+            f"({frac * 100:.2f}%) enterprise-value uplift on a synthetic ${ev / 1e9:.0f}B baseline — "
+            f"machine-checked measurement from the economic-prophet engine, not a business outcome."
         ),
     )

--- a/tests/platform_stubs/test_dashboard_bff_vdt.py
+++ b/tests/platform_stubs/test_dashboard_bff_vdt.py
@@ -1,0 +1,69 @@
+"""Contract + fidelity tests for the dashboard-bff /v1/vdt route.
+
+Guards that the SERVING layer forwards the canonical economic-prophet engine's OUTPUT faithfully:
+the driver×domain tensor sums to ~1.0, the served total equals the sum of the per-KPI contributions
+(the endpoint recomputes nothing — a regression that recomputed or dropped a lever would fail here),
+provenance survives so the number stays attributable to the engine + its input_hash, and the epistemic
+status marks the figure synthetic rather than a measured business outcome."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module(relative_path: str, module_name: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _client():
+    return TestClient(load_module('apps/dashboard-bff/main.py', 'dashboard_bff_main').app)
+
+
+def test_route_returns_200_with_tensor_and_uplift():
+    data = _client().get('/v1/vdt').json()
+    assert data['service'] == 'dashboard-bff'
+    assert data['industry'] == 'GICS45_SoftwarePlatforms'
+    assert len(data['drivers']) == 6 and len(data['domains']) == 6
+    assert len(data['weights']) == 36
+    assert data['computed_total_value_uplift'] > 0
+
+
+def test_tensor_is_a_complete_attribution_distribution():
+    data = _client().get('/v1/vdt').json()
+    assert abs(sum(c['weight'] for c in data['weights']) - 1.0) < 1e-6
+
+
+def test_served_total_equals_sum_of_kpi_contributions():
+    # the endpoint must forward the engine's numbers, not recompute — the served total has to be exactly
+    # the sum of the per-KPI contributions it also serves.
+    data = _client().get('/v1/vdt').json()
+    kpi_sum = sum(k['value_contribution'] for k in data['per_kpi_contribution'])
+    assert abs(data['computed_total_value_uplift'] - kpi_sum) < 1e-3
+    # projected EV = baseline + uplift
+    assert abs(data['projected_enterprise_value']
+               - (data['enterprise_value_baseline'] + data['computed_total_value_uplift'])) < 1e-3
+
+
+def test_per_driver_uplift_rolls_up_to_the_total():
+    data = _client().get('/v1/vdt').json()
+    assert abs(sum(data['per_driver_uplift'].values()) - data['computed_total_value_uplift']) < 1e-3
+
+
+def test_provenance_and_epistemic_status_travel_with_the_payload():
+    data = _client().get('/v1/vdt').json()
+    prov = data['provenance']
+    assert prov['source_repo'] == 'SocioProphet/economic-prophet'
+    assert prov['input_hash']            # attributable to the engine's input
+    assert 'regen' in prov               # regenerable, not hand-authored
+    # the number is honestly framed as a synthetic, machine-checked illustration
+    assert data['epistemic_status'].get('level') == 'synthetic'
+    assert 'machine-checked measurement' in data['headline']

--- a/tools/emit_vdt_metrics.py
+++ b/tools/emit_vdt_metrics.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""emit_vdt_metrics — serve the Value Driver Tree view the dashboard-bff exposes at /v1/vdt.
+
+DESIGN PRINCIPLE — the value math is NOT here. `SocioProphet/economic-prophet` is the canonical
+economic engine (open_ep_framework.vdt.run_vdt); this module only *serves* an artifact that engine
+PRODUCED. We never recompute the EP/UVMC/VDT identities in the BFF (that would fork the value model),
+so `build()` reads the vendored engine output and returns it verbatim, provenance intact.
+
+The vendored artifact (apps/dashboard-bff/data/vdt/*.metrics.json) carries the engine's input_hash and
+a regen command. To refresh after the engine changes:
+
+    cd ~/dev/economic-prophet && \\
+      python -m open_ep_framework.cli --mode vdt --example examples/vdt_software_platforms.json
+
+then re-vendor the {summary, profile} output (see the file's _provenance block).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VDT_DATA_DIR = ROOT / "apps" / "dashboard-bff" / "data" / "vdt"
+DEFAULT_ARTIFACT = VDT_DATA_DIR / "vdt_software_platforms.metrics.json"
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict:
+    """Load one engine-produced VDT artifact ({_provenance, summary, profile})."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build(path: Path = DEFAULT_ARTIFACT) -> dict:
+    """Shape the engine artifact into the /v1/vdt payload.
+
+    Pulls the tensor (weights/drivers/domains/kpis) from the engine's profile and the computed
+    uplifts from the engine's summary. Nothing is recomputed — the numbers are the engine's.
+    """
+    doc = load_artifact(path)
+    summary = doc["summary"]
+    profile = doc["profile"]
+
+    return {
+        "industry": summary["industry"],
+        "scenario": summary["scenario"],
+        "enterprise_value_baseline": summary["enterprise_value_baseline"],
+        "drivers": profile["drivers"],
+        "domains": profile["domains"],
+        "weights": [
+            {"driver": w["driver"], "domain": w["domain"], "weight": float(w["weight"])}
+            for w in profile["weights"]
+        ],
+        "per_kpi_contribution": summary["per_kpi_contribution"],
+        "per_driver_uplift": summary["per_driver_uplift"],
+        "per_domain_uplift": summary["per_domain_uplift"],
+        "computed_total_value_uplift": summary["computed_total_value_uplift"],
+        "computed_value_uplift_fraction": summary["computed_value_uplift_fraction"],
+        "projected_enterprise_value": summary["projected_enterprise_value"],
+        "epistemic_status": profile.get("epistemic_status", {}),
+        "provenance": doc.get("_provenance", {}),
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(build(), indent=2, sort_keys=True))


### PR DESCRIPTION
## What
Adds `GET /v1/vdt` to the dashboard-bff so the client-vue **Value Drivers** cockpit surface can consume the real economic-prophet engine instead of the hand-mirrored `vdtFixture.ts`.

## Why
The Value Driver Tree surface (socioprophet `#413`) shipped computing from a static TS fixture that duplicated the engine's math — drift risk, and not actually "live." This is step 1 of wiring it to the canonical engine.

## How — respects the canonical-engine rule
The value math (EP / UVMC / VDT identities) **stays in `SocioProphet/economic-prophet`** and is not recomputed here.
- `tools/emit_vdt_metrics.py` serves the engine-**produced** artifact, vendored at `apps/dashboard-bff/data/vdt/vdt_software_platforms.metrics.json` with the engine's `input_hash`, `framework_version`, and a `regen` command. Not hand-edited.
- `/v1/vdt` reshapes the tensor + computed uplifts into `VdtResponse`. `epistemic_status` + `provenance` travel with the payload so the UI frames the figure as a **synthetic, machine-checked** illustration, not a business outcome.

## Tests
`tests/platform_stubs/test_dashboard_bff_vdt.py` (5) assert:
- tensor is a complete attribution distribution (36 cells → sum 1.0)
- served total **==** sum of per-KPI contributions (endpoint recomputes nothing → catches drift)
- per-driver uplift rolls up to the total; projected EV = baseline + uplift
- provenance + `input_hash` survive; headline is honestly framed

**10/10 green**, including the existing `/v1/intelligence-superiority` route (no regression).

## Follow-ons
- client-vue: fetch `/v1/vdt` with graceful fallback to the fixture (next PR)
- additional industry tensors beyond GICS45 Software

🤖 Generated with [Claude Code](https://claude.com/claude-code)
