### PR TITLE
feat(dashboard-bff): serve VDT across industries + /v1/vdt/catalog

### DIFF
--- a/apps/dashboard-bff/contracts.py
+++ b/apps/dashboard-bff/contracts.py
@@ -65,6 +65,19 @@ class VdtKpiContribution(BaseModel):
     value_contribution: float
 
 
+class VdtIndustry(BaseModel):
+    """One selectable industry the VDT endpoint can serve."""
+    id: str
+    label: str
+    industry: str
+
+
+class VdtCatalogResponse(BaseModel):
+    """The industries available at /v1/vdt — drives the surface's industry selector."""
+    service: str
+    industries: list[VdtIndustry]
+
+
 class VdtResponse(BaseModel):
     """The Value Driver Tree view, served from the canonical economic-prophet engine's OUTPUT (never
     recomputed here — the value math lives in economic-prophet). The surface renders the driver×domain

--- a/apps/dashboard-bff/data/vdt/banks.metrics.json
+++ b/apps/dashboard-bff/data/vdt/banks.metrics.json
@@ -1,0 +1,338 @@
+{
+  "_provenance": {
+    "engine": "open_ep_framework.vdt.run_vdt",
+    "framework_version": "0.1.0",
+    "generated_at": "2026-07-05T23:34:41.267237+00:00",
+    "industry": "GICS40_BanksDiversifiedFinancials",
+    "input_hash": "hash://synthetic/input-vdt-banks-financials-001",
+    "note": "Engine-produced OUTPUT vendored for the dashboard-bff to serve. Not hand-edited.",
+    "profile_example": "examples/vdt_banks_financials.json",
+    "regen": "cd ~/dev/economic-prophet && python -m open_ep_framework.cli --mode vdt --example examples/vdt_banks_financials.json",
+    "source_repo": "SocioProphet/economic-prophet"
+  },
+  "profile": {
+    "as_of": "2026-07-05T00:00:00Z",
+    "assumptions": [
+      "Cell weights are the GICS40_BanksDiversifiedFinancials driver x capability-domain value attribution (sums to ~1.0).",
+      "A KPI lever moves the value carried by its (driver, domain) cell by the improvement fraction.",
+      "lower_better KPIs improve as they fall; a negative delta is a positive improvement.",
+      "Enterprise-value baseline is a synthetic $1B for illustration."
+    ],
+    "domains": [
+      "CustomerInterface",
+      "ProductServiceDev",
+      "SupplyDelivery",
+      "OperationsSupport",
+      "RiskSecurity",
+      "GovernanceKnowledge"
+    ],
+    "drivers": [
+      "RevenueGrowth",
+      "CostEfficiency",
+      "Experience",
+      "KnowledgeProductivity",
+      "TrustComplianceResilience",
+      "Innovation"
+    ],
+    "enterprise_value_baseline": 1000000000.0,
+    "epistemic_status": {
+      "confidence": 0.55,
+      "level": "synthetic",
+      "review_status": "machine_checked"
+    },
+    "evidence_refs": [
+      "schemas/vdt_profile.schema.json",
+      "docs/whitepaper.md"
+    ],
+    "framework_version": "0.1.0",
+    "industry": "GICS40_BanksDiversifiedFinancials",
+    "input_hash": "hash://synthetic/input-vdt-banks-financials-001",
+    "kpis": [
+      {
+        "delta_pct": 8.0,
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "kpi": "net_interest_margin_pct",
+        "polarity": "higher_better"
+      },
+      {
+        "delta_pct": -3.0,
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "kpi": "cost_income_ratio",
+        "polarity": "lower_better"
+      },
+      {
+        "delta_pct": -0.4,
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "kpi": "loan_loss_rate",
+        "polarity": "lower_better"
+      }
+    ],
+    "limitations": [
+      "Synthetic fixture; not calibrated to a real company.",
+      "No investment, securities, or valuation-opinion conclusion is implied."
+    ],
+    "measurement_boundary": {
+      "mode": "doctrine_measurement_simulation_audit_only",
+      "non_goals": [
+        "live_money_movement",
+        "securities_issuance",
+        "investment_advice",
+        "deposit_taking",
+        "external_token_issuance",
+        "payment_processing"
+      ]
+    },
+    "output_hash": "hash://synthetic/output-vdt-banks-financials-001",
+    "replay_plan_ref": "replay://vdt/vdt-banks-financials-001",
+    "reported_total_value_uplift": 7076923.076923077,
+    "reported_value_uplift_fraction": 0.007076923076923077,
+    "run_id": "vdt-banks-financials-001",
+    "scenario": "banks-financials-value-driver-tree",
+    "weights": [
+      {
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "weight": 0.06153846153846154
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "RevenueGrowth",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "RevenueGrowth",
+        "weight": 0.015384615384615385
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "RevenueGrowth",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "RevenueGrowth",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "RevenueGrowth",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "CostEfficiency",
+        "weight": 0.03076923076923077
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "CostEfficiency",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "weight": 0.015384615384615385
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "weight": 0.06153846153846154
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "CostEfficiency",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "CostEfficiency",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Experience",
+        "weight": 0.046153846153846156
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Experience",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Experience",
+        "weight": 0.007692307692307693
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Experience",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Experience",
+        "weight": 0.015384615384615385
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Experience",
+        "weight": 0.015384615384615385
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.03076923076923077
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.007692307692307693
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.03076923076923077
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.03076923076923077
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.03076923076923077
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.015384615384615385
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.038461538461538464
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.07692307692307693
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.046153846153846156
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Innovation",
+        "weight": 0.03076923076923077
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Innovation",
+        "weight": 0.038461538461538464
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Innovation",
+        "weight": 0.007692307692307693
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Innovation",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Innovation",
+        "weight": 0.023076923076923078
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Innovation",
+        "weight": 0.023076923076923078
+      }
+    ]
+  },
+  "summary": {
+    "computed_total_value_uplift": 7076923.076923077,
+    "computed_value_uplift_fraction": 0.007076923076923077,
+    "domain_count": 6,
+    "driver_count": 6,
+    "enterprise_value_baseline": 1000000000.0,
+    "industry": "GICS40_BanksDiversifiedFinancials",
+    "kpi_count": 3,
+    "measurement_boundary_mode": "doctrine_measurement_simulation_audit_only",
+    "missing_required_non_goals": [],
+    "per_domain_uplift": {
+      "CustomerInterface": 4923076.923076923,
+      "OperationsSupport": 1846153.846153846,
+      "RiskSecurity": 307692.3076923077
+    },
+    "per_driver_uplift": {
+      "CostEfficiency": 1846153.846153846,
+      "RevenueGrowth": 4923076.923076923,
+      "TrustComplianceResilience": 307692.3076923077
+    },
+    "per_kpi_contribution": [
+      {
+        "delta_pct": 8.0,
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "kpi": "net_interest_margin_pct",
+        "polarity": "higher_better",
+        "value_contribution": 4923076.923076923
+      },
+      {
+        "delta_pct": -3.0,
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "kpi": "cost_income_ratio",
+        "polarity": "lower_better",
+        "value_contribution": 1846153.846153846
+      },
+      {
+        "delta_pct": -0.4,
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "kpi": "loan_loss_rate",
+        "polarity": "lower_better",
+        "value_contribution": 307692.3076923077
+      }
+    ],
+    "projected_enterprise_value": 1007076923.0769231,
+    "reported_total_value_uplift": 7076923.076923077,
+    "reported_value_uplift_fraction": 0.007076923076923077,
+    "required_non_goals_present": [
+      "deposit_taking",
+      "external_token_issuance",
+      "investment_advice",
+      "live_money_movement",
+      "securities_issuance"
+    ],
+    "run_id": "vdt-banks-financials-001",
+    "scenario": "banks-financials-value-driver-tree",
+    "weight_cell_count": 36,
+    "weight_sum": 1.0
+  }
+}

--- a/apps/dashboard-bff/data/vdt/catalog.json
+++ b/apps/dashboard-bff/data/vdt/catalog.json
@@ -1,0 +1,19 @@
+{
+  "industries": [
+    {
+      "id": "software",
+      "label": "Software & Platforms",
+      "industry": "GICS45_SoftwarePlatforms"
+    },
+    {
+      "id": "banks",
+      "label": "Banks & Financials",
+      "industry": "GICS40_BanksDiversifiedFinancials"
+    },
+    {
+      "id": "energy",
+      "label": "Energy",
+      "industry": "GICS10_Energy"
+    }
+  ]
+}

--- a/apps/dashboard-bff/data/vdt/energy.metrics.json
+++ b/apps/dashboard-bff/data/vdt/energy.metrics.json
@@ -2,20 +2,20 @@
   "_provenance": {
     "engine": "open_ep_framework.vdt.run_vdt",
     "framework_version": "0.1.0",
-    "generated_at": "2026-07-05T22:13:57.357179+00:00",
-    "industry": "GICS45_SoftwarePlatforms",
-    "input_hash": "hash://synthetic/input-vdt-software-001",
-    "note": "Engine-produced OUTPUT vendored for the dashboard-bff to serve. The canonical value math lives in economic-prophet; this file is not hand-edited.",
-    "profile_example": "examples/vdt_software_platforms.json",
-    "regen": "cd ~/dev/economic-prophet && python -m open_ep_framework.cli --mode vdt --example examples/vdt_software_platforms.json",
+    "generated_at": "2026-07-05T23:34:41.267237+00:00",
+    "industry": "GICS10_Energy",
+    "input_hash": "hash://synthetic/input-vdt-energy-001",
+    "note": "Engine-produced OUTPUT vendored for the dashboard-bff to serve. Not hand-edited.",
+    "profile_example": "examples/vdt_energy.json",
+    "regen": "cd ~/dev/economic-prophet && python -m open_ep_framework.cli --mode vdt --example examples/vdt_energy.json",
     "source_repo": "SocioProphet/economic-prophet"
   },
   "profile": {
-    "as_of": "2026-07-04T00:00:00Z",
+    "as_of": "2026-07-05T00:00:00Z",
     "assumptions": [
-      "Cell weights are the GICS45 Software & Platforms driver x capability-domain value attribution (sums to ~1.0).",
+      "Cell weights are the GICS10_Energy driver x capability-domain value attribution (sums to ~1.0).",
       "A KPI lever moves the value carried by its (driver, domain) cell by the improvement fraction.",
-      "lower_better KPIs (e.g. security_incident_rate) improve as they fall; a negative delta is a positive improvement.",
+      "lower_better KPIs improve as they fall; a negative delta is a positive improvement.",
       "Enterprise-value baseline is a synthetic $1B for illustration."
     ],
     "domains": [
@@ -36,7 +36,7 @@
     ],
     "enterprise_value_baseline": 1000000000.0,
     "epistemic_status": {
-      "confidence": 0.6,
+      "confidence": 0.55,
       "level": "synthetic",
       "review_status": "machine_checked"
     },
@@ -45,28 +45,28 @@
       "docs/whitepaper.md"
     ],
     "framework_version": "0.1.0",
-    "industry": "GICS45_SoftwarePlatforms",
-    "input_hash": "hash://synthetic/input-vdt-software-001",
+    "industry": "GICS10_Energy",
+    "input_hash": "hash://synthetic/input-vdt-energy-001",
     "kpis": [
       {
-        "delta_pct": 10.0,
-        "domain": "CustomerInterface",
+        "delta_pct": 5.0,
+        "domain": "SupplyDelivery",
         "driver": "RevenueGrowth",
-        "kpi": "arr_growth_pct",
+        "kpi": "production_uptime_pct",
         "polarity": "higher_better"
       },
       {
-        "delta_pct": 2.0,
+        "delta_pct": -4.0,
         "domain": "SupplyDelivery",
         "driver": "CostEfficiency",
-        "kpi": "gross_margin_pct",
-        "polarity": "higher_better"
+        "kpi": "opex_per_boe",
+        "polarity": "lower_better"
       },
       {
-        "delta_pct": -0.5,
+        "delta_pct": -6.0,
         "domain": "RiskSecurity",
         "driver": "TrustComplianceResilience",
-        "kpi": "security_incident_rate",
+        "kpi": "emissions_intensity",
         "polarity": "lower_better"
       }
     ],
@@ -85,244 +85,243 @@
         "payment_processing"
       ]
     },
-    "output_hash": "hash://synthetic/output-vdt-software-001",
-    "replay_plan_ref": "replay://vdt/software-platforms-001",
-    "reported_total_value_uplift": 10201612.903225804,
-    "reported_value_uplift_fraction": 0.010201612903225804,
-    "run_id": "vdt-software-platforms-001",
-    "scenario": "software-platforms-value-driver-tree",
+    "output_hash": "hash://synthetic/output-vdt-energy-001",
+    "replay_plan_ref": "replay://vdt/vdt-energy-001",
+    "reported_total_value_uplift": 9473684.210526315,
+    "reported_value_uplift_fraction": 0.009473684210526315,
+    "run_id": "vdt-energy-001",
+    "scenario": "energy-value-driver-tree",
     "weights": [
       {
         "domain": "CustomerInterface",
         "driver": "RevenueGrowth",
-        "weight": 0.09677419354838708
+        "weight": 0.03508771929824561
       },
       {
         "domain": "ProductServiceDev",
         "driver": "RevenueGrowth",
-        "weight": 0.04838709677419354
+        "weight": 0.017543859649122806
       },
       {
         "domain": "SupplyDelivery",
         "driver": "RevenueGrowth",
-        "weight": 0.016129032258064512
+        "weight": 0.05263157894736842
       },
       {
         "domain": "OperationsSupport",
         "driver": "RevenueGrowth",
-        "weight": 0.032258064516129024
+        "weight": 0.03508771929824561
       },
       {
         "domain": "RiskSecurity",
         "driver": "RevenueGrowth",
-        "weight": 0.016129032258064512
+        "weight": 0.017543859649122806
       },
       {
         "domain": "GovernanceKnowledge",
         "driver": "RevenueGrowth",
-        "weight": 0.032258064516129024
+        "weight": 0.017543859649122806
       },
       {
         "domain": "CustomerInterface",
         "driver": "CostEfficiency",
-        "weight": 0.032258064516129024
+        "weight": 0.02631578947368421
       },
       {
         "domain": "ProductServiceDev",
         "driver": "CostEfficiency",
-        "weight": 0.032258064516129024
+        "weight": 0.017543859649122806
       },
       {
         "domain": "SupplyDelivery",
         "driver": "CostEfficiency",
-        "weight": 0.016129032258064512
+        "weight": 0.05263157894736842
       },
       {
         "domain": "OperationsSupport",
         "driver": "CostEfficiency",
-        "weight": 0.04032258064516128
+        "weight": 0.07017543859649122
       },
       {
         "domain": "RiskSecurity",
         "driver": "CostEfficiency",
-        "weight": 0.016129032258064512
+        "weight": 0.02631578947368421
       },
       {
         "domain": "GovernanceKnowledge",
         "driver": "CostEfficiency",
-        "weight": 0.02419354838709677
+        "weight": 0.017543859649122806
       },
       {
         "domain": "CustomerInterface",
         "driver": "Experience",
-        "weight": 0.04838709677419354
+        "weight": 0.017543859649122806
       },
       {
         "domain": "ProductServiceDev",
         "driver": "Experience",
-        "weight": 0.02419354838709677
+        "weight": 0.008771929824561403
       },
       {
         "domain": "SupplyDelivery",
         "driver": "Experience",
-        "weight": 0.008064516129032256
+        "weight": 0.017543859649122806
       },
       {
         "domain": "OperationsSupport",
         "driver": "Experience",
-        "weight": 0.016129032258064512
+        "weight": 0.017543859649122806
       },
       {
         "domain": "RiskSecurity",
         "driver": "Experience",
-        "weight": 0.008064516129032256
+        "weight": 0.008771929824561403
       },
       {
         "domain": "GovernanceKnowledge",
         "driver": "Experience",
-        "weight": 0.016129032258064512
+        "weight": 0.008771929824561403
       },
       {
         "domain": "CustomerInterface",
         "driver": "KnowledgeProductivity",
-        "weight": 0.032258064516129024
+        "weight": 0.017543859649122806
       },
       {
         "domain": "ProductServiceDev",
         "driver": "KnowledgeProductivity",
-        "weight": 0.04032258064516128
+        "weight": 0.02631578947368421
       },
       {
         "domain": "SupplyDelivery",
         "driver": "KnowledgeProductivity",
-        "weight": 0.016129032258064512
+        "weight": 0.02631578947368421
       },
       {
         "domain": "OperationsSupport",
         "driver": "KnowledgeProductivity",
-        "weight": 0.02419354838709677
+        "weight": 0.03508771929824561
       },
       {
         "domain": "RiskSecurity",
         "driver": "KnowledgeProductivity",
-        "weight": 0.016129032258064512
+        "weight": 0.017543859649122806
       },
       {
         "domain": "GovernanceKnowledge",
         "driver": "KnowledgeProductivity",
-        "weight": 0.02419354838709677
+        "weight": 0.02631578947368421
       },
       {
         "domain": "CustomerInterface",
         "driver": "TrustComplianceResilience",
-        "weight": 0.02419354838709677
+        "weight": 0.017543859649122806
       },
       {
         "domain": "ProductServiceDev",
         "driver": "TrustComplianceResilience",
-        "weight": 0.02419354838709677
+        "weight": 0.017543859649122806
       },
       {
         "domain": "SupplyDelivery",
         "driver": "TrustComplianceResilience",
-        "weight": 0.008064516129032256
+        "weight": 0.03508771929824561
       },
       {
         "domain": "OperationsSupport",
         "driver": "TrustComplianceResilience",
-        "weight": 0.016129032258064512
+        "weight": 0.03508771929824561
       },
       {
         "domain": "RiskSecurity",
         "driver": "TrustComplianceResilience",
-        "weight": 0.04032258064516128
+        "weight": 0.07894736842105263
       },
       {
         "domain": "GovernanceKnowledge",
         "driver": "TrustComplianceResilience",
-        "weight": 0.04032258064516128
+        "weight": 0.043859649122807015
       },
       {
         "domain": "CustomerInterface",
         "driver": "Innovation",
-        "weight": 0.04032258064516128
+        "weight": 0.02631578947368421
       },
       {
         "domain": "ProductServiceDev",
         "driver": "Innovation",
-        "weight": 0.04838709677419354
+        "weight": 0.03508771929824561
       },
       {
         "domain": "SupplyDelivery",
         "driver": "Innovation",
-        "weight": 0.016129032258064512
+        "weight": 0.02631578947368421
       },
       {
         "domain": "OperationsSupport",
         "driver": "Innovation",
-        "weight": 0.02419354838709677
+        "weight": 0.02631578947368421
       },
       {
         "domain": "RiskSecurity",
         "driver": "Innovation",
-        "weight": 0.016129032258064512
+        "weight": 0.017543859649122806
       },
       {
         "domain": "GovernanceKnowledge",
         "driver": "Innovation",
-        "weight": 0.02419354838709677
+        "weight": 0.02631578947368421
       }
     ]
   },
   "summary": {
-    "computed_total_value_uplift": 10201612.903225804,
-    "computed_value_uplift_fraction": 0.010201612903225804,
+    "computed_total_value_uplift": 9473684.210526315,
+    "computed_value_uplift_fraction": 0.009473684210526315,
     "domain_count": 6,
     "driver_count": 6,
     "enterprise_value_baseline": 1000000000.0,
-    "industry": "GICS45_SoftwarePlatforms",
+    "industry": "GICS10_Energy",
     "kpi_count": 3,
     "measurement_boundary_mode": "doctrine_measurement_simulation_audit_only",
     "missing_required_non_goals": [],
     "per_domain_uplift": {
-      "CustomerInterface": 9677419.354838708,
-      "RiskSecurity": 201612.90322580643,
-      "SupplyDelivery": 322580.64516129025
+      "RiskSecurity": 4736842.105263158,
+      "SupplyDelivery": 4736842.105263158
     },
     "per_driver_uplift": {
-      "CostEfficiency": 322580.64516129025,
-      "RevenueGrowth": 9677419.354838708,
-      "TrustComplianceResilience": 201612.90322580643
+      "CostEfficiency": 2105263.1578947366,
+      "RevenueGrowth": 2631578.947368421,
+      "TrustComplianceResilience": 4736842.105263158
     },
     "per_kpi_contribution": [
       {
-        "delta_pct": 10.0,
-        "domain": "CustomerInterface",
+        "delta_pct": 5.0,
+        "domain": "SupplyDelivery",
         "driver": "RevenueGrowth",
-        "kpi": "arr_growth_pct",
+        "kpi": "production_uptime_pct",
         "polarity": "higher_better",
-        "value_contribution": 9677419.354838708
+        "value_contribution": 2631578.947368421
       },
       {
-        "delta_pct": 2.0,
+        "delta_pct": -4.0,
         "domain": "SupplyDelivery",
         "driver": "CostEfficiency",
-        "kpi": "gross_margin_pct",
-        "polarity": "higher_better",
-        "value_contribution": 322580.64516129025
+        "kpi": "opex_per_boe",
+        "polarity": "lower_better",
+        "value_contribution": 2105263.1578947366
       },
       {
-        "delta_pct": -0.5,
+        "delta_pct": -6.0,
         "domain": "RiskSecurity",
         "driver": "TrustComplianceResilience",
-        "kpi": "security_incident_rate",
+        "kpi": "emissions_intensity",
         "polarity": "lower_better",
-        "value_contribution": 201612.90322580643
+        "value_contribution": 4736842.105263158
       }
     ],
-    "projected_enterprise_value": 1010201612.9032258,
-    "reported_total_value_uplift": 10201612.903225804,
-    "reported_value_uplift_fraction": 0.010201612903225804,
+    "projected_enterprise_value": 1009473684.2105263,
+    "reported_total_value_uplift": 9473684.210526315,
+    "reported_value_uplift_fraction": 0.009473684210526315,
     "required_non_goals_present": [
       "deposit_taking",
       "external_token_issuance",
@@ -330,9 +329,9 @@
       "live_money_movement",
       "securities_issuance"
     ],
-    "run_id": "vdt-software-platforms-001",
-    "scenario": "software-platforms-value-driver-tree",
+    "run_id": "vdt-energy-001",
+    "scenario": "energy-value-driver-tree",
     "weight_cell_count": 36,
-    "weight_sum": 0.9999999999999998
+    "weight_sum": 1.0
   }
 }

--- a/apps/dashboard-bff/data/vdt/software.metrics.json
+++ b/apps/dashboard-bff/data/vdt/software.metrics.json
@@ -1,0 +1,338 @@
+{
+  "_provenance": {
+    "engine": "open_ep_framework.vdt.run_vdt",
+    "framework_version": "0.1.0",
+    "generated_at": "2026-07-05T23:34:41.267237+00:00",
+    "industry": "GICS45_SoftwarePlatforms",
+    "input_hash": "hash://synthetic/input-vdt-software-001",
+    "note": "Engine-produced OUTPUT vendored for the dashboard-bff to serve. Not hand-edited.",
+    "profile_example": "examples/vdt_software_platforms.json",
+    "regen": "cd ~/dev/economic-prophet && python -m open_ep_framework.cli --mode vdt --example examples/vdt_software_platforms.json",
+    "source_repo": "SocioProphet/economic-prophet"
+  },
+  "profile": {
+    "as_of": "2026-07-04T00:00:00Z",
+    "assumptions": [
+      "Cell weights are the GICS45 Software & Platforms driver x capability-domain value attribution (sums to ~1.0).",
+      "A KPI lever moves the value carried by its (driver, domain) cell by the improvement fraction.",
+      "lower_better KPIs (e.g. security_incident_rate) improve as they fall; a negative delta is a positive improvement.",
+      "Enterprise-value baseline is a synthetic $1B for illustration."
+    ],
+    "domains": [
+      "CustomerInterface",
+      "ProductServiceDev",
+      "SupplyDelivery",
+      "OperationsSupport",
+      "RiskSecurity",
+      "GovernanceKnowledge"
+    ],
+    "drivers": [
+      "RevenueGrowth",
+      "CostEfficiency",
+      "Experience",
+      "KnowledgeProductivity",
+      "TrustComplianceResilience",
+      "Innovation"
+    ],
+    "enterprise_value_baseline": 1000000000.0,
+    "epistemic_status": {
+      "confidence": 0.6,
+      "level": "synthetic",
+      "review_status": "machine_checked"
+    },
+    "evidence_refs": [
+      "schemas/vdt_profile.schema.json",
+      "docs/whitepaper.md"
+    ],
+    "framework_version": "0.1.0",
+    "industry": "GICS45_SoftwarePlatforms",
+    "input_hash": "hash://synthetic/input-vdt-software-001",
+    "kpis": [
+      {
+        "delta_pct": 10.0,
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "kpi": "arr_growth_pct",
+        "polarity": "higher_better"
+      },
+      {
+        "delta_pct": 2.0,
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "kpi": "gross_margin_pct",
+        "polarity": "higher_better"
+      },
+      {
+        "delta_pct": -0.5,
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "kpi": "security_incident_rate",
+        "polarity": "lower_better"
+      }
+    ],
+    "limitations": [
+      "Synthetic fixture; not calibrated to a real company.",
+      "No investment, securities, or valuation-opinion conclusion is implied."
+    ],
+    "measurement_boundary": {
+      "mode": "doctrine_measurement_simulation_audit_only",
+      "non_goals": [
+        "live_money_movement",
+        "securities_issuance",
+        "investment_advice",
+        "deposit_taking",
+        "external_token_issuance",
+        "payment_processing"
+      ]
+    },
+    "output_hash": "hash://synthetic/output-vdt-software-001",
+    "replay_plan_ref": "replay://vdt/software-platforms-001",
+    "reported_total_value_uplift": 10201612.903225804,
+    "reported_value_uplift_fraction": 0.010201612903225804,
+    "run_id": "vdt-software-platforms-001",
+    "scenario": "software-platforms-value-driver-tree",
+    "weights": [
+      {
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "weight": 0.09677419354838708
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "RevenueGrowth",
+        "weight": 0.04838709677419354
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "RevenueGrowth",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "RevenueGrowth",
+        "weight": 0.032258064516129024
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "RevenueGrowth",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "RevenueGrowth",
+        "weight": 0.032258064516129024
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "CostEfficiency",
+        "weight": 0.032258064516129024
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "CostEfficiency",
+        "weight": 0.032258064516129024
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "weight": 0.04032258064516128
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "CostEfficiency",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "CostEfficiency",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Experience",
+        "weight": 0.04838709677419354
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Experience",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Experience",
+        "weight": 0.008064516129032256
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Experience",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Experience",
+        "weight": 0.008064516129032256
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Experience",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.032258064516129024
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.04032258064516128
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.008064516129032256
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.04032258064516128
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.04032258064516128
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Innovation",
+        "weight": 0.04032258064516128
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Innovation",
+        "weight": 0.04838709677419354
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Innovation",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Innovation",
+        "weight": 0.02419354838709677
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Innovation",
+        "weight": 0.016129032258064512
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Innovation",
+        "weight": 0.02419354838709677
+      }
+    ]
+  },
+  "summary": {
+    "computed_total_value_uplift": 10201612.903225804,
+    "computed_value_uplift_fraction": 0.010201612903225804,
+    "domain_count": 6,
+    "driver_count": 6,
+    "enterprise_value_baseline": 1000000000.0,
+    "industry": "GICS45_SoftwarePlatforms",
+    "kpi_count": 3,
+    "measurement_boundary_mode": "doctrine_measurement_simulation_audit_only",
+    "missing_required_non_goals": [],
+    "per_domain_uplift": {
+      "CustomerInterface": 9677419.354838708,
+      "RiskSecurity": 201612.90322580643,
+      "SupplyDelivery": 322580.64516129025
+    },
+    "per_driver_uplift": {
+      "CostEfficiency": 322580.64516129025,
+      "RevenueGrowth": 9677419.354838708,
+      "TrustComplianceResilience": 201612.90322580643
+    },
+    "per_kpi_contribution": [
+      {
+        "delta_pct": 10.0,
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "kpi": "arr_growth_pct",
+        "polarity": "higher_better",
+        "value_contribution": 9677419.354838708
+      },
+      {
+        "delta_pct": 2.0,
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "kpi": "gross_margin_pct",
+        "polarity": "higher_better",
+        "value_contribution": 322580.64516129025
+      },
+      {
+        "delta_pct": -0.5,
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "kpi": "security_incident_rate",
+        "polarity": "lower_better",
+        "value_contribution": 201612.90322580643
+      }
+    ],
+    "projected_enterprise_value": 1010201612.9032258,
+    "reported_total_value_uplift": 10201612.903225804,
+    "reported_value_uplift_fraction": 0.010201612903225804,
+    "required_non_goals_present": [
+      "deposit_taking",
+      "external_token_issuance",
+      "investment_advice",
+      "live_money_movement",
+      "securities_issuance"
+    ],
+    "run_id": "vdt-software-platforms-001",
+    "scenario": "software-platforms-value-driver-tree",
+    "weight_cell_count": 36,
+    "weight_sum": 0.9999999999999998
+  }
+}

--- a/apps/dashboard-bff/main.py
+++ b/apps/dashboard-bff/main.py
@@ -116,15 +116,25 @@ def intelligence_superiority() -> object:
     )
 
 
+@app.get('/v1/vdt/catalog', response_model=_contracts.VdtCatalogResponse)
+def value_driver_tree_catalog() -> object:
+    """The industries the VDT endpoint can serve, so the surface can offer an industry selector
+    without hard-coding the list."""
+    return _contracts.VdtCatalogResponse(
+        service='dashboard-bff',
+        industries=[_contracts.VdtIndustry(**c) for c in _vdt_producer.catalog()],
+    )
+
+
 @app.get('/v1/vdt', response_model=_contracts.VdtResponse)
-def value_driver_tree() -> object:
-    """Serve the Value Driver Tree view from the canonical economic-prophet engine's OUTPUT. The value
-    math (EP/UVMC/VDT identities) lives in economic-prophet and is NOT recomputed here — this endpoint
-    reshapes the engine-produced artifact (tensor + computed uplifts, provenance intact) for the cockpit
-    surface, which previously computed from a hand-mirrored TS fixture. epistemic_status travels with the
-    payload so the UI presents the figure as a synthetic, machine-checked illustration, not a measured
-    business result."""
-    v = _vdt_producer.build()
+def value_driver_tree(industry: str = 'software') -> object:
+    """Serve one industry's Value Driver Tree view from the canonical economic-prophet engine's OUTPUT.
+    The value math (EP/UVMC/VDT identities) lives in economic-prophet and is NOT recomputed here — this
+    endpoint reshapes the engine-produced artifact (tensor + computed uplifts, provenance intact) for the
+    cockpit surface, which previously computed from a hand-mirrored TS fixture. `industry` selects the
+    tensor (software / banks / energy); an unknown id falls back to software. epistemic_status travels
+    with the payload so the UI presents the figure as a synthetic, machine-checked illustration."""
+    v = _vdt_producer.build(industry)
     uplift = v['computed_total_value_uplift']
     frac = v['computed_value_uplift_fraction']
     ev = v['enterprise_value_baseline']

--- a/tests/platform_stubs/test_dashboard_bff_vdt.py
+++ b/tests/platform_stubs/test_dashboard_bff_vdt.py
@@ -37,6 +37,28 @@ def test_route_returns_200_with_tensor_and_uplift():
     assert data['computed_total_value_uplift'] > 0
 
 
+def test_catalog_lists_the_selectable_industries():
+    data = _client().get('/v1/vdt/catalog').json()
+    ids = {i['id'] for i in data['industries']}
+    assert {'software', 'banks', 'energy'} <= ids
+    for i in data['industries']:
+        assert i['label'] and i['industry']
+
+
+def test_industry_param_selects_a_different_tensor():
+    software = _client().get('/v1/vdt?industry=software').json()
+    banks = _client().get('/v1/vdt?industry=banks').json()
+    assert banks['industry'] == 'GICS40_BanksDiversifiedFinancials'
+    # a real, different attribution — the banks tensor is not the software one
+    assert banks['industry'] != software['industry']
+    assert abs(sum(c['weight'] for c in banks['weights']) - 1.0) < 1e-6
+
+
+def test_unknown_industry_falls_back_to_software():
+    data = _client().get('/v1/vdt?industry=not-a-real-industry').json()
+    assert data['industry'] == 'GICS45_SoftwarePlatforms'
+
+
 def test_tensor_is_a_complete_attribution_distribution():
     data = _client().get('/v1/vdt').json()
     assert abs(sum(c['weight'] for c in data['weights']) - 1.0) < 1e-6

--- a/tools/emit_vdt_metrics.py
+++ b/tools/emit_vdt_metrics.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
-"""emit_vdt_metrics — serve the Value Driver Tree view the dashboard-bff exposes at /v1/vdt.
+"""emit_vdt_metrics — serve the Value Driver Tree views the dashboard-bff exposes at /v1/vdt.
 
 DESIGN PRINCIPLE — the value math is NOT here. `SocioProphet/economic-prophet` is the canonical
-economic engine (open_ep_framework.vdt.run_vdt); this module only *serves* an artifact that engine
+economic engine (open_ep_framework.vdt.run_vdt); this module only *serves* artifacts that engine
 PRODUCED. We never recompute the EP/UVMC/VDT identities in the BFF (that would fork the value model),
-so `build()` reads the vendored engine output and returns it verbatim, provenance intact.
+so `build()` reads a vendored engine output and returns it verbatim, provenance intact.
 
-The vendored artifact (apps/dashboard-bff/data/vdt/*.metrics.json) carries the engine's input_hash and
-a regen command. To refresh after the engine changes:
+Multiple industries are vendored under apps/dashboard-bff/data/vdt/<id>.metrics.json, indexed by
+catalog.json. To refresh after the engine changes, regenerate each from the canonical CLI, e.g.:
 
     cd ~/dev/economic-prophet && \\
       python -m open_ep_framework.cli --mode vdt --example examples/vdt_software_platforms.json
 
-then re-vendor the {summary, profile} output (see the file's _provenance block).
+then re-vendor the {summary, profile} output (see each file's _provenance block).
 """
 from __future__ import annotations
 
@@ -21,21 +21,31 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 VDT_DATA_DIR = ROOT / "apps" / "dashboard-bff" / "data" / "vdt"
-DEFAULT_ARTIFACT = VDT_DATA_DIR / "vdt_software_platforms.metrics.json"
+CATALOG_PATH = VDT_DATA_DIR / "catalog.json"
+DEFAULT_INDUSTRY = "software"
 
 
-def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict:
-    """Load one engine-produced VDT artifact ({_provenance, summary, profile})."""
-    return json.loads(path.read_text(encoding="utf-8"))
+def catalog() -> list[dict]:
+    """The industries the BFF can serve: [{id, label, industry}, ...]."""
+    return json.loads(CATALOG_PATH.read_text(encoding="utf-8"))["industries"]
 
 
-def build(path: Path = DEFAULT_ARTIFACT) -> dict:
-    """Shape the engine artifact into the /v1/vdt payload.
+def _artifact_path(industry: str) -> Path:
+    """Resolve an industry id to its engine-produced artifact, defaulting to software
+    when the id is unknown (so the endpoint never 404s on a bad query param)."""
+    known = {c["id"] for c in catalog()}
+    chosen = industry if industry in known else DEFAULT_INDUSTRY
+    return VDT_DATA_DIR / f"{chosen}.metrics.json"
 
-    Pulls the tensor (weights/drivers/domains/kpis) from the engine's profile and the computed
-    uplifts from the engine's summary. Nothing is recomputed — the numbers are the engine's.
-    """
-    doc = load_artifact(path)
+
+def load_artifact(industry: str = DEFAULT_INDUSTRY) -> dict:
+    return json.loads(_artifact_path(industry).read_text(encoding="utf-8"))
+
+
+def build(industry: str = DEFAULT_INDUSTRY) -> dict:
+    """Shape one industry's engine artifact into the /v1/vdt payload. Nothing is recomputed —
+    the tensor + uplifts are the engine's; we only reshape and pass provenance through."""
+    doc = load_artifact(industry)
     summary = doc["summary"]
     profile = doc["profile"]
 
@@ -61,4 +71,4 @@ def build(path: Path = DEFAULT_ARTIFACT) -> dict:
 
 
 if __name__ == "__main__":
-    print(json.dumps(build(), indent=2, sort_keys=True))
+    print(json.dumps({"catalog": catalog(), "default": build()}, indent=2, sort_keys=True))


### PR DESCRIPTION
## What
Makes `/v1/vdt` industry-aware and adds `/v1/vdt/catalog`, so the Value Drivers surface can switch industries.

## How
- `GET /v1/vdt?industry=<id>` selects the tensor (`software` / `banks` / `energy`); an unknown id falls back to `software` (never 404s on a bad param).
- `GET /v1/vdt/catalog` lists the selectable industries (id / label / GICS industry) — drives the surface selector without a hardcoded list.
- Vendors three engine-produced artifacts + `catalog.json`, replacing the single software artifact. Depends on economic-prophet #26 (the new Banks/Energy tensors).
- Still serves engine **output** only — no value math in the BFF.

## Tests
Catalog lists all three, `?industry=banks` returns a distinct tensor summing to 1.0, unknown id falls back to software. **13/13 green** (incl. intelligence-superiority, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)