### PR TITLE
feat(dashboard-bff): serve Real Estate, Materials, Consumer Staples VDT industries

### DIFF
--- a/apps/dashboard-bff/data/vdt/catalog.json
+++ b/apps/dashboard-bff/data/vdt/catalog.json
@@ -14,6 +14,21 @@
       "id": "energy",
       "label": "Energy",
       "industry": "GICS10_Energy"
+    },
+    {
+      "id": "realestate",
+      "label": "Real Estate",
+      "industry": "GICS60_RealEstate"
+    },
+    {
+      "id": "materials",
+      "label": "Materials",
+      "industry": "GICS15_Materials"
+    },
+    {
+      "id": "consumerstaples",
+      "label": "Consumer Staples",
+      "industry": "GICS30_ConsumerStaples"
     }
   ]
 }

--- a/apps/dashboard-bff/data/vdt/consumerstaples.metrics.json
+++ b/apps/dashboard-bff/data/vdt/consumerstaples.metrics.json
@@ -1,0 +1,338 @@
+{
+  "_provenance": {
+    "engine": "open_ep_framework.vdt.run_vdt",
+    "framework_version": "0.1.0",
+    "generated_at": "2026-07-06T18:54:04.575688+00:00",
+    "industry": "GICS30_ConsumerStaples",
+    "input_hash": "hash://synthetic/input-vdt-consumer_staples-001",
+    "note": "Engine-produced OUTPUT vendored for the dashboard-bff to serve. Not hand-edited.",
+    "profile_example": "examples/vdt_consumer_staples.json",
+    "regen": "cd ~/dev/economic-prophet && python -m open_ep_framework.cli --mode vdt --example examples/vdt_consumer_staples.json",
+    "source_repo": "SocioProphet/economic-prophet"
+  },
+  "profile": {
+    "as_of": "2026-07-06T00:00:00Z",
+    "assumptions": [
+      "Cell weights are the GICS30_ConsumerStaples driver x capability-domain value attribution (sums to ~1.0).",
+      "Value concentrates in brand/retail demand (CustomerInterface), distribution/COGS (SupplyDelivery), and product/food safety (TrustComplianceResilience).",
+      "A KPI lever moves the value carried by its (driver, domain) cell by the improvement fraction.",
+      "lower_better KPIs improve as they fall; a negative delta is a positive improvement.",
+      "Enterprise-value baseline is a synthetic $1B for illustration."
+    ],
+    "domains": [
+      "CustomerInterface",
+      "ProductServiceDev",
+      "SupplyDelivery",
+      "OperationsSupport",
+      "RiskSecurity",
+      "GovernanceKnowledge"
+    ],
+    "drivers": [
+      "RevenueGrowth",
+      "CostEfficiency",
+      "Experience",
+      "KnowledgeProductivity",
+      "TrustComplianceResilience",
+      "Innovation"
+    ],
+    "enterprise_value_baseline": 1000000000.0,
+    "epistemic_status": {
+      "confidence": 0.55,
+      "level": "synthetic",
+      "review_status": "machine_checked"
+    },
+    "evidence_refs": [
+      "schemas/vdt_profile.schema.json",
+      "docs/whitepaper.md"
+    ],
+    "framework_version": "0.1.0",
+    "industry": "GICS30_ConsumerStaples",
+    "input_hash": "hash://synthetic/input-vdt-consumer_staples-001",
+    "kpis": [
+      {
+        "delta_pct": 3.0,
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "kpi": "same_store_sales_pct",
+        "polarity": "higher_better"
+      },
+      {
+        "delta_pct": -3.0,
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "kpi": "cogs_per_unit",
+        "polarity": "lower_better"
+      },
+      {
+        "delta_pct": -5.0,
+        "domain": "SupplyDelivery",
+        "driver": "TrustComplianceResilience",
+        "kpi": "product_recall_rate",
+        "polarity": "lower_better"
+      }
+    ],
+    "limitations": [
+      "Synthetic fixture; not calibrated to a real company.",
+      "No investment, securities, or valuation-opinion conclusion is implied."
+    ],
+    "measurement_boundary": {
+      "mode": "doctrine_measurement_simulation_audit_only",
+      "non_goals": [
+        "live_money_movement",
+        "securities_issuance",
+        "investment_advice",
+        "deposit_taking",
+        "external_token_issuance",
+        "payment_processing"
+      ]
+    },
+    "output_hash": "hash://synthetic/output-vdt-consumer_staples-001",
+    "replay_plan_ref": "replay://vdt/vdt-consumer_staples-001",
+    "reported_total_value_uplift": 6666666.666666667,
+    "reported_value_uplift_fraction": 0.006666666666666667,
+    "run_id": "vdt-consumer_staples-001",
+    "scenario": "consumer-staples-value-driver-tree",
+    "weights": [
+      {
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "weight": 0.06666666666666667
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "RevenueGrowth",
+        "weight": 0.04
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "RevenueGrowth",
+        "weight": 0.04
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "RevenueGrowth",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "RevenueGrowth",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "RevenueGrowth",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "CostEfficiency",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "CostEfficiency",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "weight": 0.06666666666666667
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "weight": 0.04
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "CostEfficiency",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "CostEfficiency",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Experience",
+        "weight": 0.05333333333333334
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Experience",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Experience",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Experience",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Experience",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Experience",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.05333333333333334
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.04
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Innovation",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Innovation",
+        "weight": 0.05333333333333334
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Innovation",
+        "weight": 0.02666666666666667
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Innovation",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Innovation",
+        "weight": 0.013333333333333334
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Innovation",
+        "weight": 0.02666666666666667
+      }
+    ]
+  },
+  "summary": {
+    "computed_total_value_uplift": 6666666.666666667,
+    "computed_value_uplift_fraction": 0.006666666666666667,
+    "domain_count": 6,
+    "driver_count": 6,
+    "enterprise_value_baseline": 1000000000.0,
+    "industry": "GICS30_ConsumerStaples",
+    "kpi_count": 3,
+    "measurement_boundary_mode": "doctrine_measurement_simulation_audit_only",
+    "missing_required_non_goals": [],
+    "per_domain_uplift": {
+      "CustomerInterface": 2000000.0,
+      "SupplyDelivery": 4666666.666666667
+    },
+    "per_driver_uplift": {
+      "CostEfficiency": 2000000.0,
+      "RevenueGrowth": 2000000.0,
+      "TrustComplianceResilience": 2666666.666666667
+    },
+    "per_kpi_contribution": [
+      {
+        "delta_pct": 3.0,
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "kpi": "same_store_sales_pct",
+        "polarity": "higher_better",
+        "value_contribution": 2000000.0
+      },
+      {
+        "delta_pct": -3.0,
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "kpi": "cogs_per_unit",
+        "polarity": "lower_better",
+        "value_contribution": 2000000.0
+      },
+      {
+        "delta_pct": -5.0,
+        "domain": "SupplyDelivery",
+        "driver": "TrustComplianceResilience",
+        "kpi": "product_recall_rate",
+        "polarity": "lower_better",
+        "value_contribution": 2666666.666666667
+      }
+    ],
+    "projected_enterprise_value": 1006666666.6666666,
+    "reported_total_value_uplift": 6666666.666666667,
+    "reported_value_uplift_fraction": 0.006666666666666667,
+    "required_non_goals_present": [
+      "deposit_taking",
+      "external_token_issuance",
+      "investment_advice",
+      "live_money_movement",
+      "securities_issuance"
+    ],
+    "run_id": "vdt-consumer_staples-001",
+    "scenario": "consumer-staples-value-driver-tree",
+    "weight_cell_count": 36,
+    "weight_sum": 1.0
+  }
+}

--- a/apps/dashboard-bff/data/vdt/materials.metrics.json
+++ b/apps/dashboard-bff/data/vdt/materials.metrics.json
@@ -1,0 +1,339 @@
+{
+  "_provenance": {
+    "engine": "open_ep_framework.vdt.run_vdt",
+    "framework_version": "0.1.0",
+    "generated_at": "2026-07-06T18:54:04.575688+00:00",
+    "industry": "GICS15_Materials",
+    "input_hash": "hash://synthetic/input-vdt-materials-001",
+    "note": "Engine-produced OUTPUT vendored for the dashboard-bff to serve. Not hand-edited.",
+    "profile_example": "examples/vdt_materials.json",
+    "regen": "cd ~/dev/economic-prophet && python -m open_ep_framework.cli --mode vdt --example examples/vdt_materials.json",
+    "source_repo": "SocioProphet/economic-prophet"
+  },
+  "profile": {
+    "as_of": "2026-07-06T00:00:00Z",
+    "assumptions": [
+      "Cell weights are the GICS15_Materials driver x capability-domain value attribution (sums to ~1.0).",
+      "Value concentrates in production throughput/logistics (SupplyDelivery), plant operations (OperationsSupport), and safety/environmental risk (RiskSecurity).",
+      "A KPI lever moves the value carried by its (driver, domain) cell by the improvement fraction.",
+      "lower_better KPIs improve as they fall; a negative delta is a positive improvement.",
+      "Enterprise-value baseline is a synthetic $1B for illustration."
+    ],
+    "domains": [
+      "CustomerInterface",
+      "ProductServiceDev",
+      "SupplyDelivery",
+      "OperationsSupport",
+      "RiskSecurity",
+      "GovernanceKnowledge"
+    ],
+    "drivers": [
+      "RevenueGrowth",
+      "CostEfficiency",
+      "Experience",
+      "KnowledgeProductivity",
+      "TrustComplianceResilience",
+      "Innovation"
+    ],
+    "enterprise_value_baseline": 1000000000.0,
+    "epistemic_status": {
+      "confidence": 0.55,
+      "level": "synthetic",
+      "review_status": "machine_checked"
+    },
+    "evidence_refs": [
+      "schemas/vdt_profile.schema.json",
+      "docs/whitepaper.md"
+    ],
+    "framework_version": "0.1.0",
+    "industry": "GICS15_Materials",
+    "input_hash": "hash://synthetic/input-vdt-materials-001",
+    "kpis": [
+      {
+        "delta_pct": 4.0,
+        "domain": "SupplyDelivery",
+        "driver": "RevenueGrowth",
+        "kpi": "process_yield_pct",
+        "polarity": "higher_better"
+      },
+      {
+        "delta_pct": -5.0,
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "kpi": "energy_cost_per_ton",
+        "polarity": "lower_better"
+      },
+      {
+        "delta_pct": -6.0,
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "kpi": "safety_incident_rate",
+        "polarity": "lower_better"
+      }
+    ],
+    "limitations": [
+      "Synthetic fixture; not calibrated to a real company.",
+      "No investment, securities, or valuation-opinion conclusion is implied."
+    ],
+    "measurement_boundary": {
+      "mode": "doctrine_measurement_simulation_audit_only",
+      "non_goals": [
+        "live_money_movement",
+        "securities_issuance",
+        "investment_advice",
+        "deposit_taking",
+        "external_token_issuance",
+        "payment_processing"
+      ]
+    },
+    "output_hash": "hash://synthetic/output-vdt-materials-001",
+    "replay_plan_ref": "replay://vdt/vdt-materials-001",
+    "reported_total_value_uplift": 9594594.594594594,
+    "reported_value_uplift_fraction": 0.009594594594594594,
+    "run_id": "vdt-materials-001",
+    "scenario": "materials-value-driver-tree",
+    "weights": [
+      {
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "RevenueGrowth",
+        "weight": 0.02702702702702703
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "RevenueGrowth",
+        "weight": 0.05405405405405406
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "RevenueGrowth",
+        "weight": 0.04054054054054054
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "RevenueGrowth",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "RevenueGrowth",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "CostEfficiency",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "CostEfficiency",
+        "weight": 0.02702702702702703
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "weight": 0.06756756756756757
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "weight": 0.06756756756756757
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "CostEfficiency",
+        "weight": 0.02702702702702703
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "CostEfficiency",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Experience",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Experience",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Experience",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Experience",
+        "weight": 0.02702702702702703
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Experience",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Experience",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02702702702702703
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02702702702702703
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.04054054054054054
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02702702702702703
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.04054054054054054
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.04054054054054054
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.06756756756756757
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.02702702702702703
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Innovation",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Innovation",
+        "weight": 0.05405405405405406
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Innovation",
+        "weight": 0.04054054054054054
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Innovation",
+        "weight": 0.02702702702702703
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Innovation",
+        "weight": 0.013513513513513514
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Innovation",
+        "weight": 0.02702702702702703
+      }
+    ]
+  },
+  "summary": {
+    "computed_total_value_uplift": 9594594.594594594,
+    "computed_value_uplift_fraction": 0.009594594594594594,
+    "domain_count": 6,
+    "driver_count": 6,
+    "enterprise_value_baseline": 1000000000.0,
+    "industry": "GICS15_Materials",
+    "kpi_count": 3,
+    "measurement_boundary_mode": "doctrine_measurement_simulation_audit_only",
+    "missing_required_non_goals": [],
+    "per_domain_uplift": {
+      "OperationsSupport": 3378378.3783783787,
+      "RiskSecurity": 4054054.0540540544,
+      "SupplyDelivery": 2162162.1621621624
+    },
+    "per_driver_uplift": {
+      "CostEfficiency": 3378378.3783783787,
+      "RevenueGrowth": 2162162.1621621624,
+      "TrustComplianceResilience": 4054054.0540540544
+    },
+    "per_kpi_contribution": [
+      {
+        "delta_pct": 4.0,
+        "domain": "SupplyDelivery",
+        "driver": "RevenueGrowth",
+        "kpi": "process_yield_pct",
+        "polarity": "higher_better",
+        "value_contribution": 2162162.1621621624
+      },
+      {
+        "delta_pct": -5.0,
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "kpi": "energy_cost_per_ton",
+        "polarity": "lower_better",
+        "value_contribution": 3378378.3783783787
+      },
+      {
+        "delta_pct": -6.0,
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "kpi": "safety_incident_rate",
+        "polarity": "lower_better",
+        "value_contribution": 4054054.0540540544
+      }
+    ],
+    "projected_enterprise_value": 1009594594.5945946,
+    "reported_total_value_uplift": 9594594.594594594,
+    "reported_value_uplift_fraction": 0.009594594594594594,
+    "required_non_goals_present": [
+      "deposit_taking",
+      "external_token_issuance",
+      "investment_advice",
+      "live_money_movement",
+      "securities_issuance"
+    ],
+    "run_id": "vdt-materials-001",
+    "scenario": "materials-value-driver-tree",
+    "weight_cell_count": 36,
+    "weight_sum": 1.0
+  }
+}

--- a/apps/dashboard-bff/data/vdt/realestate.metrics.json
+++ b/apps/dashboard-bff/data/vdt/realestate.metrics.json
@@ -1,0 +1,339 @@
+{
+  "_provenance": {
+    "engine": "open_ep_framework.vdt.run_vdt",
+    "framework_version": "0.1.0",
+    "generated_at": "2026-07-06T18:54:04.575688+00:00",
+    "industry": "GICS60_RealEstate",
+    "input_hash": "hash://synthetic/input-vdt-real_estate-001",
+    "note": "Engine-produced OUTPUT vendored for the dashboard-bff to serve. Not hand-edited.",
+    "profile_example": "examples/vdt_real_estate.json",
+    "regen": "cd ~/dev/economic-prophet && python -m open_ep_framework.cli --mode vdt --example examples/vdt_real_estate.json",
+    "source_repo": "SocioProphet/economic-prophet"
+  },
+  "profile": {
+    "as_of": "2026-07-06T00:00:00Z",
+    "assumptions": [
+      "Cell weights are the GICS60_RealEstate driver x capability-domain value attribution (sums to ~1.0).",
+      "Value concentrates in leasing/occupancy (CustomerInterface, SupplyDelivery), facilities operations (OperationsSupport), and building/ESG risk (RiskSecurity).",
+      "A KPI lever moves the value carried by its (driver, domain) cell by the improvement fraction.",
+      "lower_better KPIs improve as they fall; a negative delta is a positive improvement.",
+      "Enterprise-value baseline is a synthetic $1B for illustration."
+    ],
+    "domains": [
+      "CustomerInterface",
+      "ProductServiceDev",
+      "SupplyDelivery",
+      "OperationsSupport",
+      "RiskSecurity",
+      "GovernanceKnowledge"
+    ],
+    "drivers": [
+      "RevenueGrowth",
+      "CostEfficiency",
+      "Experience",
+      "KnowledgeProductivity",
+      "TrustComplianceResilience",
+      "Innovation"
+    ],
+    "enterprise_value_baseline": 1000000000.0,
+    "epistemic_status": {
+      "confidence": 0.55,
+      "level": "synthetic",
+      "review_status": "machine_checked"
+    },
+    "evidence_refs": [
+      "schemas/vdt_profile.schema.json",
+      "docs/whitepaper.md"
+    ],
+    "framework_version": "0.1.0",
+    "industry": "GICS60_RealEstate",
+    "input_hash": "hash://synthetic/input-vdt-real_estate-001",
+    "kpis": [
+      {
+        "delta_pct": 3.0,
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "kpi": "occupancy_rate_pct",
+        "polarity": "higher_better"
+      },
+      {
+        "delta_pct": -4.0,
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "kpi": "opex_per_sqft",
+        "polarity": "lower_better"
+      },
+      {
+        "delta_pct": -5.0,
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "kpi": "building_incident_rate",
+        "polarity": "lower_better"
+      }
+    ],
+    "limitations": [
+      "Synthetic fixture; not calibrated to a real company.",
+      "No investment, securities, or valuation-opinion conclusion is implied."
+    ],
+    "measurement_boundary": {
+      "mode": "doctrine_measurement_simulation_audit_only",
+      "non_goals": [
+        "live_money_movement",
+        "securities_issuance",
+        "investment_advice",
+        "deposit_taking",
+        "external_token_issuance",
+        "payment_processing"
+      ]
+    },
+    "output_hash": "hash://synthetic/output-vdt-real_estate-001",
+    "replay_plan_ref": "replay://vdt/vdt-real_estate-001",
+    "reported_total_value_uplift": 7402597.402597402,
+    "reported_value_uplift_fraction": 0.007402597402597402,
+    "run_id": "vdt-real_estate-001",
+    "scenario": "real-estate-value-driver-tree",
+    "weights": [
+      {
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "weight": 0.05194805194805195
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "RevenueGrowth",
+        "weight": 0.025974025974025976
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "RevenueGrowth",
+        "weight": 0.05194805194805195
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "RevenueGrowth",
+        "weight": 0.03896103896103896
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "RevenueGrowth",
+        "weight": 0.012987012987012988
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "RevenueGrowth",
+        "weight": 0.012987012987012988
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "CostEfficiency",
+        "weight": 0.025974025974025976
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "CostEfficiency",
+        "weight": 0.012987012987012988
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "weight": 0.03896103896103896
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "weight": 0.06493506493506493
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "CostEfficiency",
+        "weight": 0.025974025974025976
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "CostEfficiency",
+        "weight": 0.012987012987012988
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Experience",
+        "weight": 0.03896103896103896
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Experience",
+        "weight": 0.012987012987012988
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Experience",
+        "weight": 0.012987012987012988
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Experience",
+        "weight": 0.025974025974025976
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Experience",
+        "weight": 0.012987012987012988
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Experience",
+        "weight": 0.012987012987012988
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.012987012987012988
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.025974025974025976
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.025974025974025976
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.025974025974025976
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.012987012987012988
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.03896103896103896
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.025974025974025976
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.012987012987012988
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.025974025974025976
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.03896103896103896
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.06493506493506493
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.03896103896103896
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Innovation",
+        "weight": 0.025974025974025976
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Innovation",
+        "weight": 0.03896103896103896
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Innovation",
+        "weight": 0.025974025974025976
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Innovation",
+        "weight": 0.025974025974025976
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Innovation",
+        "weight": 0.012987012987012988
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Innovation",
+        "weight": 0.025974025974025976
+      }
+    ]
+  },
+  "summary": {
+    "computed_total_value_uplift": 7402597.402597402,
+    "computed_value_uplift_fraction": 0.007402597402597402,
+    "domain_count": 6,
+    "driver_count": 6,
+    "enterprise_value_baseline": 1000000000.0,
+    "industry": "GICS60_RealEstate",
+    "kpi_count": 3,
+    "measurement_boundary_mode": "doctrine_measurement_simulation_audit_only",
+    "missing_required_non_goals": [],
+    "per_domain_uplift": {
+      "CustomerInterface": 1558441.5584415584,
+      "OperationsSupport": 2597402.5974025973,
+      "RiskSecurity": 3246753.2467532465
+    },
+    "per_driver_uplift": {
+      "CostEfficiency": 2597402.5974025973,
+      "RevenueGrowth": 1558441.5584415584,
+      "TrustComplianceResilience": 3246753.2467532465
+    },
+    "per_kpi_contribution": [
+      {
+        "delta_pct": 3.0,
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "kpi": "occupancy_rate_pct",
+        "polarity": "higher_better",
+        "value_contribution": 1558441.5584415584
+      },
+      {
+        "delta_pct": -4.0,
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "kpi": "opex_per_sqft",
+        "polarity": "lower_better",
+        "value_contribution": 2597402.5974025973
+      },
+      {
+        "delta_pct": -5.0,
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "kpi": "building_incident_rate",
+        "polarity": "lower_better",
+        "value_contribution": 3246753.2467532465
+      }
+    ],
+    "projected_enterprise_value": 1007402597.4025974,
+    "reported_total_value_uplift": 7402597.402597402,
+    "reported_value_uplift_fraction": 0.007402597402597402,
+    "required_non_goals_present": [
+      "deposit_taking",
+      "external_token_issuance",
+      "investment_advice",
+      "live_money_movement",
+      "securities_issuance"
+    ],
+    "run_id": "vdt-real_estate-001",
+    "scenario": "real-estate-value-driver-tree",
+    "weight_cell_count": 36,
+    "weight_sum": 1.0
+  }
+}

--- a/tests/platform_stubs/test_dashboard_bff_vdt.py
+++ b/tests/platform_stubs/test_dashboard_bff_vdt.py
@@ -40,9 +40,19 @@ def test_route_returns_200_with_tensor_and_uplift():
 def test_catalog_lists_the_selectable_industries():
     data = _client().get('/v1/vdt/catalog').json()
     ids = {i['id'] for i in data['industries']}
-    assert {'software', 'banks', 'energy'} <= ids
+    assert {'software', 'banks', 'energy', 'realestate', 'materials', 'consumerstaples'} <= ids
     for i in data['industries']:
         assert i['label'] and i['industry']
+
+
+def test_new_industries_serve_complete_self_consistent_tensors():
+    for vid, gics in (('realestate', 'GICS60_RealEstate'), ('materials', 'GICS15_Materials'),
+                      ('consumerstaples', 'GICS30_ConsumerStaples')):
+        v = _client().get(f'/v1/vdt?industry={vid}').json()
+        assert v['industry'] == gics
+        assert len(v['weights']) == 36
+        assert abs(sum(c['weight'] for c in v['weights']) - 1.0) < 1e-6
+        assert v['computed_total_value_uplift'] > 0
 
 
 def test_industry_param_selects_a_different_tensor():


### PR DESCRIPTION
Vendors three more engine-produced VDT metrics artifacts so the Value Drivers cockpit surface's industry selector offers **six** industries instead of three. Backs SocioProphet/economic-prophet#27 (the engine tensors).

| id | industry | uplift on \$1B |
|---|---|---|
| `realestate` | GICS60 Real Estate | +\$7.40M / +0.74% |
| `materials` | GICS15 Materials | +\$9.59M / +0.96% |
| `consumerstaples` | GICS30 Consumer Staples | +\$6.67M / +0.67% |

Each `<id>.metrics.json` is the `run_vdt` **output** (36-cell tensor summing to 1.0, self-consistent uplift) wrapped with `_provenance` — same structure as software/banks/energy, nothing hand-edited. `catalog.json` gains the three entries.

The bff test now locks all six industries into the catalog and asserts the new tensors are complete + self-consistent through the live `/v1/vdt?industry=<id>` endpoint (verified: all three PASS — 36 cells, weight_sum=1.0, uplift>0). The cockpit selector (#418) is catalog-driven, so the new industries appear automatically once this is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)