### PR TITLE
GCP ephemeral deploy: tofu split + nginx Autopilot fix

### DIFF
--- a/charts/socioprophet-service/templates/deployment.yaml
+++ b/charts/socioprophet-service/templates/deployment.yaml
@@ -79,16 +79,28 @@ spec:
           {{- end }}
           {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.tmpDir.enabled }}
+          {{- if or .Values.tmpDir.enabled .Values.writableDirs }}
           volumeMounts:
+            {{- if .Values.tmpDir.enabled }}
             - name: tmp
               mountPath: /tmp
+            {{- end }}
+            {{- range $i, $p := .Values.writableDirs }}
+            - name: writable-{{ $i }}
+              mountPath: {{ $p }}
+            {{- end }}
           {{- end }}
-      {{- if .Values.tmpDir.enabled }}
+      {{- if or .Values.tmpDir.enabled .Values.writableDirs }}
       volumes:
+        {{- if .Values.tmpDir.enabled }}
         - name: tmp
           emptyDir:
             sizeLimit: {{ .Values.tmpDir.sizeLimit }}
+        {{- end }}
+        {{- range $i, $p := .Values.writableDirs }}
+        - name: writable-{{ $i }}
+          emptyDir: {}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}

--- a/charts/socioprophet-service/values.yaml
+++ b/charts/socioprophet-service/values.yaml
@@ -61,6 +61,11 @@ tmpDir:
   enabled: true
   sizeLimit: 256Mi
 
+# Extra writable emptyDir mounts for services that need to write outside /tmp under a
+# read-only root filesystem (e.g. nginx needs /var/cache/nginx + /var/run). Per-service
+# override in deploy/values/<name>.yaml. Empty by default.
+writableDirs: []
+
 probes:
   enabled: true
   path: /healthz

--- a/deploy/datastores/postgres/postgres.yaml
+++ b/deploy/datastores/postgres/postgres.yaml
@@ -1,0 +1,82 @@
+# Self-hosted Postgres for the estate (socbase auth/rest, workspace, eval-fabric).
+# Bound to the PERSISTENT `postgres-data` disk via a static PV, so the database
+# survives every ephemeral cluster teardown and re-binds on the next spin-up.
+# Sovereign — not managed Cloud SQL.
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: postgres-data-pv
+  labels: { app: postgres }
+spec:
+  capacity: { storage: 50Gi }
+  accessModes: [ReadWriteOnce]
+  persistentVolumeReclaimPolicy: Retain          # never delete the retained disk on PVC removal
+  storageClassName: ""                            # static binding — no dynamic provisioner
+  claimRef: { namespace: socioprophet, name: postgres-data-pvc }
+  csi:
+    driver: pd.csi.storage.gke.io
+    volumeHandle: projects/socioprophet-platform/zones/us-central1-a/disks/postgres-data
+    fsType: ext4
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - { key: topology.gke.io/zone, operator: In, values: [us-central1-a] }
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data-pvc
+  namespace: socioprophet
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: ""
+  volumeName: postgres-data-pv
+  resources: { requests: { storage: 50Gi } }
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: socioprophet
+  labels: { app: postgres }
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector: { matchLabels: { app: postgres } }
+  template:
+    metadata: { labels: { app: postgres } }
+    spec:
+      securityContext: { fsGroup: 999 }          # postgres uid/gid in the official image
+      containers:
+        - name: postgres
+          image: postgres:16
+          ports: [{ containerPort: 5432, name: postgres }]
+          env:
+            - { name: POSTGRES_DB, value: prophet_platform }
+            - { name: POSTGRES_USER, value: postgres }
+            - name: POSTGRES_PASSWORD
+              valueFrom: { secretKeyRef: { name: postgres-admin, key: password } }
+            - { name: PGDATA, value: /var/lib/postgresql/data/pgdata }
+          volumeMounts: [{ name: data, mountPath: /var/lib/postgresql/data }]
+          readinessProbe:
+            exec: { command: ["pg_isready", "-U", "postgres", "-d", "prophet_platform"] }
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            requests: { cpu: "500m", memory: 1Gi }
+            limits: { cpu: "1", memory: 2Gi }
+      volumes:
+        - name: data
+          persistentVolumeClaim: { claimName: postgres-data-pvc }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: socioprophet
+  labels: { app: postgres }
+spec:
+  selector: { app: postgres }
+  ports: [{ port: 5432, targetPort: 5432, name: postgres }]

--- a/deploy/values/gateway.yaml
+++ b/deploy/values/gateway.yaml
@@ -9,3 +9,5 @@ ingress:
   className: ""   # cluster default; set per-cloud (gce / azure-application-gateway / alb) via overlay
   hosts: [{ host: api.socioprophet.ai, paths: [{ path: /, pathType: Prefix }] }]
 autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 6 }
+# nginx needs these writable under the chart's readOnlyRootFilesystem (Autopilot).
+writableDirs: [/var/cache/nginx, /var/run]

--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -1,3 +1,3 @@
-# hellgraph-service
+# hellgraph-service — the engine serves on :8090 (not 8080); align service + probes.
 image: { repository: hellgraph-service, tag: latest }
-service: { port: 8080, portName: http }
+service: { port: 8090, portName: http }

--- a/deploy/values/socioprophet-web.yaml
+++ b/deploy/values/socioprophet-web.yaml
@@ -6,3 +6,5 @@ ingress:
   className: ""   # cluster default; set per-cloud (gce / azure-application-gateway / alb) via overlay
   hosts: [{ host: app.socioprophet.ai, paths: [{ path: /, pathType: Prefix }] }]
 autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 6 }
+# nginx needs these writable under the chart's readOnlyRootFilesystem (Autopilot).
+writableDirs: [/var/cache/nginx, /var/run]

--- a/infra/tofu/environments/gcp-ephemeral/.gitignore
+++ b/infra/tofu/environments/gcp-ephemeral/.gitignore
@@ -1,0 +1,4 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*

--- a/infra/tofu/environments/gcp-ephemeral/argocd.tf
+++ b/infra/tofu/environments/gcp-ephemeral/argocd.tf
@@ -1,0 +1,62 @@
+# Argo CD + the root "app of apps" that points Argo at the gitops repo's
+# deploy/argocd directory (where the platform-services / workspace-services /
+# fogstack ApplicationSets live). On spin-up, Argo re-syncs the whole stack.
+
+provider "kubernetes" {
+  host                   = "https://${google_container_cluster.this.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(google_container_cluster.this.master_auth[0].cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${google_container_cluster.this.endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(google_container_cluster.this.master_auth[0].cluster_ca_certificate)
+  }
+}
+
+resource "helm_release" "argocd" {
+  name             = "argocd"
+  namespace        = "argocd"
+  create_namespace = true
+  repository       = "https://argoproj.github.io/argo-helm"
+  chart            = "argo-cd"
+  version          = "7.7.7"
+
+  set {
+    name  = "crds.keep"
+    value = "true"
+  }
+}
+
+resource "helm_release" "root_app" {
+  name       = "root-app"
+  namespace  = "argocd"
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.2"
+  depends_on = [helm_release.argocd]
+
+  values = [yamlencode({
+    applications = {
+      root = {
+        namespace = "argocd"
+        project   = "default"
+        source = {
+          repoURL        = var.gitops_repo_url
+          targetRevision = var.gitops_revision
+          path           = var.gitops_path
+          directory      = { recurse = true }
+        }
+        destination = {
+          server    = "https://kubernetes.default.svc"
+          namespace = "argocd"
+        }
+        syncPolicy = {
+          automated = { prune = true, selfHeal = true }
+        }
+      }
+    }
+  })]
+}

--- a/infra/tofu/environments/gcp-ephemeral/data.tf
+++ b/infra/tofu/environments/gcp-ephemeral/data.tf
@@ -1,0 +1,10 @@
+# Cross-stack references to the PERSISTENT foundation (decoupled — looked up by
+# name, no remote-state coupling). The node SA and registry are created once in
+# gcp-persistent and reused by every ephemeral cluster.
+
+data "google_service_account" "gke_nodes" {
+  account_id = var.node_sa_account_id
+}
+
+# Cluster auth token for the kubernetes/helm providers.
+data "google_client_config" "default" {}

--- a/infra/tofu/environments/gcp-ephemeral/gke.tf
+++ b/infra/tofu/environments/gcp-ephemeral/gke.tf
@@ -1,0 +1,33 @@
+# GKE Autopilot cluster — Google-managed nodes (least ops), Workload Identity on by
+# default. Uses the persistent node identity (data.google_service_account.gke_nodes)
+# so no SA is created/destroyed on the ephemeral lifecycle. deletion_protection is
+# OFF by design: `tofu destroy` must be able to tear this down cleanly.
+
+locals {
+  labels = {
+    "prophet-platform" = "true"
+    "managed-by"       = "opentofu"
+    "source-of-truth"  = "git"
+    "org"              = "socioprophet"
+    "lifecycle"        = "ephemeral"
+  }
+}
+
+resource "google_container_cluster" "this" {
+  name                = var.cluster_name
+  location            = var.region
+  enable_autopilot    = true
+  deletion_protection = false
+
+  release_channel { channel = "REGULAR" }
+
+  # Autopilot node identity (the long-lived SA from the persistent stack).
+  cluster_autoscaling {
+    auto_provisioning_defaults {
+      service_account = data.google_service_account.gke_nodes.email
+      oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+    }
+  }
+
+  resource_labels = local.labels
+}

--- a/infra/tofu/environments/gcp-ephemeral/outputs.tf
+++ b/infra/tofu/environments/gcp-ephemeral/outputs.tf
@@ -1,0 +1,13 @@
+output "cluster_name" {
+  value = google_container_cluster.this.name
+}
+
+output "cluster_endpoint" {
+  value     = google_container_cluster.this.endpoint
+  sensitive = true
+}
+
+output "get_credentials" {
+  description = "Run this to point kubectl at the cluster (needs gke-gcloud-auth-plugin + a fresh `gcloud auth login`)."
+  value       = "gcloud container clusters get-credentials ${google_container_cluster.this.name} --region ${var.region} --project ${var.project_id}"
+}

--- a/infra/tofu/environments/gcp-ephemeral/variables.tf
+++ b/infra/tofu/environments/gcp-ephemeral/variables.tf
@@ -1,0 +1,36 @@
+variable "project_id" {
+  type    = string
+  default = "socioprophet-platform"
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "prophet-platform"
+}
+
+# Long-lived node identity from the PERSISTENT stack (looked up, not created here).
+variable "node_sa_account_id" {
+  type    = string
+  default = "gke-prophet-nodes"
+}
+
+variable "gitops_repo_url" {
+  type    = string
+  default = "https://github.com/SocioProphet/prophet-platform"
+}
+
+variable "gitops_revision" {
+  type    = string
+  default = "main"
+}
+
+# Path in the gitops repo Argo CD watches (the ApplicationSets live here).
+variable "gitops_path" {
+  type    = string
+  default = "deploy/argocd"
+}

--- a/infra/tofu/environments/gcp-ephemeral/versions.tf
+++ b/infra/tofu/environments/gcp-ephemeral/versions.tf
@@ -1,0 +1,22 @@
+# Ephemeral stack — the CATTLE. GKE Autopilot cluster + Argo CD. `tofu apply` to
+# spin up, `tofu destroy` to tear down. Destroying this leaves the persistent stack
+# (registry, buckets, retained disks, node SA) completely untouched, so images +
+# data survive; the next spin-up re-binds the disks and Argo re-syncs the stack.
+#
+# Backend: LOCAL state (ephemeral — nothing here is precious; destroy removes it).
+# Auth: Application-Default Credentials.
+
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    google     = { source = "hashicorp/google", version = "~> 6.0" }
+    helm       = { source = "hashicorp/helm", version = "~> 2.13" }
+    kubernetes = { source = "hashicorp/kubernetes", version = "~> 2.30" }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/infra/tofu/environments/gcp-persistent/.gitignore
+++ b/infra/tofu/environments/gcp-persistent/.gitignore
@@ -1,0 +1,5 @@
+# Local tofu state (durable — back up terraform.tfstate out-of-band, e.g. to the backups bucket)
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*

--- a/infra/tofu/environments/gcp-persistent/main.tf
+++ b/infra/tofu/environments/gcp-persistent/main.tf
@@ -77,6 +77,30 @@ resource "google_compute_disk" "hellgraph_estate" {
   lifecycle { prevent_destroy = true }
 }
 
+# ─── GKE node identity — long-lived, reused by every ephemeral cluster ──────────
+# MUST be persistent: a service account deleted on cluster teardown can't be
+# re-created with the same account_id for 30 days (GCP soft-deletion), which would
+# break the next spin-up. The project's default compute SA was deleted (hardening),
+# so Autopilot needs this explicit node identity to provision nodes at all.
+resource "google_service_account" "gke_nodes" {
+  account_id   = "gke-prophet-nodes"
+  display_name = "GKE prophet-platform node identity"
+  depends_on   = [google_project_service.svc]
+}
+
+resource "google_project_iam_member" "gke_nodes" {
+  for_each = toset([
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/monitoring.viewer",
+    "roles/stackdriver.resourceMetadata.writer",
+    "roles/artifactregistry.reader", # pull images from GAR
+  ])
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
 resource "google_compute_disk" "postgres_data" {
   name       = "postgres-data"
   type       = "pd-balanced"

--- a/infra/tofu/environments/gcp-persistent/main.tf
+++ b/infra/tofu/environments/gcp-persistent/main.tf
@@ -1,0 +1,89 @@
+locals {
+  labels = {
+    "prophet-platform" = "true"
+    "managed-by"       = "opentofu"
+    "source-of-truth"  = "git"
+    "org"              = "socioprophet"
+    "lifecycle"        = "persistent"
+  }
+}
+
+# Required APIs (enabled via ADC — no gcloud CLI session needed). Never disabled on
+# destroy: turning an API off would ripple across the whole project.
+resource "google_project_service" "svc" {
+  for_each = toset([
+    "artifactregistry.googleapis.com",
+    "compute.googleapis.com",
+    "storage.googleapis.com",
+    "container.googleapis.com",
+    "iam.googleapis.com",
+  ])
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# ─── Container registry — images survive every cluster teardown ────────────────
+resource "google_artifact_registry_repository" "images" {
+  location      = var.region
+  repository_id = "socioprophet"
+  format        = "DOCKER"
+  description   = "SocioProphet/SourceOS estate container images"
+  labels        = local.labels
+  depends_on    = [google_project_service.svc]
+}
+
+# NOTE: the CI push grant (roles/artifactregistry.writer → the build-image identity)
+# is added later, when we wire the image-build pipeline — kept out of the foundation
+# so this stack has zero IAM. See var.ci_service_account for the intended member.
+
+# ─── Object storage — blobs + backups (durable) ────────────────────────────────
+resource "google_storage_bucket" "blobs" {
+  name                        = "prophet-blobs-${var.project_id}"
+  location                    = var.region
+  uniform_bucket_level_access = true
+  labels                      = local.labels
+  depends_on                  = [google_project_service.svc]
+}
+
+resource "google_storage_bucket" "backups" {
+  name                        = "prophet-backups-${var.project_id}"
+  location                    = var.region
+  uniform_bucket_level_access = true
+  versioning { enabled = true }
+  labels     = local.labels
+  depends_on = [google_project_service.svc]
+
+  # Age off old backup versions so the bucket doesn't grow forever.
+  lifecycle_rule {
+    condition { age = 30 }
+    action { type = "Delete" }
+  }
+}
+
+# ─── Retained data disks — the point of the whole split ────────────────────────
+# These zonal PDs hold hellgraph's estate RocksDB store and the self-hosted Postgres
+# data. They are NOT part of the ephemeral cluster stack, so `tofu destroy` on the
+# cluster leaves them intact; the next spin-up statically re-binds them (see the
+# hellgraph/postgres charts' PersistentVolumes) and the data is exactly as it was.
+resource "google_compute_disk" "hellgraph_estate" {
+  name       = "hellgraph-estate-data"
+  type       = "pd-balanced"
+  zone       = var.zone
+  size       = var.hellgraph_disk_gb
+  labels     = local.labels
+  depends_on = [google_project_service.svc]
+
+  # Guard against an accidental `tofu destroy` wiping the estate graph.
+  lifecycle { prevent_destroy = true }
+}
+
+resource "google_compute_disk" "postgres_data" {
+  name       = "postgres-data"
+  type       = "pd-balanced"
+  zone       = var.zone
+  size       = var.postgres_disk_gb
+  labels     = local.labels
+  depends_on = [google_project_service.svc]
+
+  lifecycle { prevent_destroy = true }
+}

--- a/infra/tofu/environments/gcp-persistent/outputs.tf
+++ b/infra/tofu/environments/gcp-persistent/outputs.tf
@@ -1,0 +1,36 @@
+# Consumed by the EPHEMERAL stack (via data sources) and the workload charts
+# (static PVs bind the disks by self-link; services read the bucket names).
+
+output "registry" {
+  description = "Docker registry path for image pushes/pulls."
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.images.repository_id}"
+}
+
+output "blobs_bucket" {
+  value = google_storage_bucket.blobs.name
+}
+
+output "backups_bucket" {
+  value = google_storage_bucket.backups.name
+}
+
+output "hellgraph_disk" {
+  description = "Self-link of the retained hellgraph estate disk (for the static PV volumeHandle)."
+  value       = google_compute_disk.hellgraph_estate.self_link
+}
+
+output "hellgraph_disk_name" {
+  value = google_compute_disk.hellgraph_estate.name
+}
+
+output "postgres_disk" {
+  value = google_compute_disk.postgres_data.self_link
+}
+
+output "postgres_disk_name" {
+  value = google_compute_disk.postgres_data.name
+}
+
+output "zone" {
+  value = var.zone
+}

--- a/infra/tofu/environments/gcp-persistent/outputs.tf
+++ b/infra/tofu/environments/gcp-persistent/outputs.tf
@@ -34,3 +34,8 @@ output "postgres_disk_name" {
 output "zone" {
   value = var.zone
 }
+
+output "gke_node_sa" {
+  description = "Email of the long-lived GKE node identity (consumed by the ephemeral cluster stack)."
+  value       = google_service_account.gke_nodes.email
+}

--- a/infra/tofu/environments/gcp-persistent/variables.tf
+++ b/infra/tofu/environments/gcp-persistent/variables.tf
@@ -1,0 +1,32 @@
+variable "project_id" {
+  type    = string
+  default = "socioprophet-platform"
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
+# Zonal disks pin their consumer pod to this zone (Autopilot honors the PV topology).
+variable "zone" {
+  type    = string
+  default = "us-central1-a"
+}
+
+# CI push identity (the build-image workflow) — granted writer on the registry.
+variable "ci_service_account" {
+  type    = string
+  default = "sourceos-ci@socioprophet-platform.iam.gserviceaccount.com"
+}
+
+# Retained data disks (GB, pd-balanced). Sized for a demo; grow later without recreate.
+variable "hellgraph_disk_gb" {
+  type    = number
+  default = 50
+}
+
+variable "postgres_disk_gb" {
+  type    = number
+  default = 50
+}

--- a/infra/tofu/environments/gcp-persistent/versions.tf
+++ b/infra/tofu/environments/gcp-persistent/versions.tf
@@ -1,0 +1,22 @@
+# Persistent stack — the durable foundation that OUTLIVES every cluster teardown:
+# Artifact Registry (images), GCS buckets (blobs/backups), and retained Persistent
+# Disks (hellgraph estate RocksDB + self-hosted Postgres data). Apply once; you
+# almost never destroy this. `tofu destroy` on the EPHEMERAL stack leaves all of
+# this untouched, so images + data survive across spin-ups.
+#
+# Backend: LOCAL state (this env changes rarely). Back up `terraform.tfstate` —
+# it's the map to the durable resources. Auth: Application-Default Credentials
+# (gcloud auth application-default login), NOT the gcloud CLI session.
+
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    google = { source = "hashicorp/google", version = "~> 6.0" }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}


### PR DESCRIPTION
Ephemeral-compute/persistent-state GCP deploy + nginx CrashLoop fix on Autopilot.

- infra/tofu/environments/gcp-persistent — registry + buckets + retained disks + node SA (applied)
- infra/tofu/environments/gcp-ephemeral — GKE Autopilot + Argo CD (applied; cluster RUNNING)
- charts/socioprophet-service — generic writableDirs emptyDir mounts; socioprophet-web + gateway mount /var/cache/nginx + /var/run so nginx runs under readOnlyRootFilesystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)