### PR TITLE
feat(serving): T4 test-mesh (vLLM + conductor) + runbook

### DIFF
--- a/deploy/serving/RUNBOOK-test-mesh.md
+++ b/deploy/serving/RUNBOOK-test-mesh.md
@@ -1,0 +1,52 @@
+# Runbook — stand up the test mesh and talk to it from Noetica
+
+The shortest real end-to-end: Noetica → `prophet-mesh` conductor → one vLLM seat (T4).
+Everything's built; these are the steps that need **your** approval (IAM / GPU spend / control-plane).
+
+## 0. One-time: let Cloud Build build + push images
+The project's default SAs were hardened away, so grant the Cloud Build agent its roles once:
+```sh
+PN=$(gcloud projects describe socioprophet-platform --format='value(projectNumber)')
+gcloud beta services identity create --service=cloudbuild.googleapis.com --project socioprophet-platform
+for r in roles/cloudbuild.builds.builder roles/artifactregistry.writer roles/logging.logWriter; do
+  gcloud projects add-iam-policy-binding socioprophet-platform \
+    --member="serviceAccount:${PN}@cloudbuild.gserviceaccount.com" --role="$r" --condition=None
+done
+```
+
+## 1. Build + push the conductor image  (~2 min)
+```sh
+cd ~/dev/prophet-mesh
+gcloud builds submit --tag us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/prophet-mesh:latest .
+```
+
+## 2. Deploy the test mesh — vLLM (T4) + conductor  (GPU spins up here; ~5-15 min for weights)
+```sh
+kubectl apply -f ~/dev/prophet-platform/deploy/serving/mesh-test-t4.yaml
+kubectl -n serving rollout status deploy/mesh-vllm --timeout=20m   # T4 node auto-provisions, model loads
+kubectl -n serving rollout status deploy/prophet-mesh --timeout=5m
+```
+
+## 3. Reach it from your laptop (no external TLS needed)
+```sh
+kubectl -n serving port-forward svc/prophet-mesh 8780:8780
+```
+Then in Noetica → **Settings → Models → Prophet Cloud Mesh**: toggle on, endpoint `http://127.0.0.1:8780/v1`, model `prophet-mesh`, key blank. Chat — the turn routes conductor → vLLM and streams back.
+
+Smoke-test the endpoint directly first:
+```sh
+curl -s http://127.0.0.1:8780/v1/models | jq              # lists prophet-mesh + seats
+curl -s http://127.0.0.1:8780/v1/chat/completions -H 'content-type: application/json' \
+  -d '{"model":"prophet-mesh","messages":[{"role":"user","content":"write a python is_prime(n)"}]}' | jq -r '.choices[0].message.content'
+```
+
+## 4. Tear down (stop the GPU spend)
+```sh
+kubectl delete -f ~/dev/prophet-platform/deploy/serving/mesh-test-t4.yaml
+```
+
+---
+### Notes / known limits of THIS test
+- **One seat, not the choir.** The conductor faithfully proxies to a single T4 vLLM (AWQ 7B). Add more seats to `SEAT_BACKENDS` (each its own vLLM Deployment) to conduct across the 7 families — that needs A100/H100 quota (currently 0; request it in the console).
+- **verify→select moat** still runs locally only (Noetica BLOCKER 1). Over-the-mesh neurosymbolic selection belongs in the conductor — a follow-up on `feat/conductor-api`.
+- **Demo surface (nginx/web)** is a separate track — blocked on the Argo CD upgrade (v2.13.1 can't diff on GKE 1.35); not needed for this mesh test.

--- a/deploy/serving/mesh-test-t4.yaml
+++ b/deploy/serving/mesh-test-t4.yaml
@@ -1,0 +1,93 @@
+# mesh-test-t4 — the SHORTEST real cloud-mesh test (1 concurrent user, T4 quota only).
+#
+# One vLLM seat (AWQ 7B, fits a 16GB T4) behind the prophet-mesh conductor, so Noetica's
+# "Prophet Cloud Mesh" toggle can talk to model=prophet-mesh end-to-end. No A100/H100 needed.
+#
+# Spend discipline: the T4 bills only while the vLLM pod is Ready. Deploy for a test, delete after.
+# Access without external TLS: `kubectl -n serving port-forward svc/prophet-mesh 8780:8780`,
+# then point the Noetica toggle at http://127.0.0.1:8780/v1 (the https-guard allows localhost).
+---
+apiVersion: v1
+kind: Namespace
+metadata: { name: serving }
+---
+# ── The seat: one vLLM on a T4, serving an AWQ-quantized 7B coder ──────────────
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mesh-vllm
+  namespace: serving
+  labels: { app: mesh-vllm }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: mesh-vllm } }
+  template:
+    metadata: { labels: { app: mesh-vllm } }
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-tesla-t4   # T4 quota = 4 (A100/H100 = 0)
+      tolerations:
+        - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:v0.6.3
+          args:
+            - "--model=Qwen/Qwen2.5-Coder-7B-Instruct-AWQ"
+            - "--quantization=awq"
+            - "--port=8000"
+            - "--max-model-len=8192"
+            - "--gpu-memory-utilization=0.92"
+            - "--enable-auto-tool-choice"        # so Noetica's agentic tool loop works over the mesh
+            - "--tool-call-parser=hermes"
+          ports: [{ containerPort: 8000 }]
+          resources:
+            limits: { nvidia.com/gpu: 1, cpu: "4", memory: 16Gi }
+          readinessProbe:
+            httpGet: { path: /health, port: 8000 }
+            initialDelaySeconds: 90
+            periodSeconds: 10
+            failureThreshold: 60
+---
+apiVersion: v1
+kind: Service
+metadata: { name: mesh-vllm, namespace: serving }
+spec:
+  selector: { app: mesh-vllm }
+  ports: [{ port: 8000, targetPort: 8000 }]
+---
+# ── The conductor: OpenAI-compatible gateway; maps model=prophet-mesh → the seat ─
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prophet-mesh
+  namespace: serving
+  labels: { app: prophet-mesh }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: prophet-mesh } }
+  template:
+    metadata: { labels: { app: prophet-mesh } }
+    spec:
+      containers:
+        - name: conductor
+          image: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/prophet-mesh:latest
+          ports: [{ containerPort: 8780 }]
+          env:
+            - name: SEAT_BACKENDS
+              value: '{"default":{"url":"http://mesh-vllm.serving.svc:8000/v1","model":"Qwen/Qwen2.5-Coder-7B-Instruct-AWQ"}}'
+            # - name: MESH_AUTH_TOKEN            # uncomment + set a secret to require a bearer token
+            #   valueFrom: { secretKeyRef: { name: prophet-mesh-auth, key: token } }
+          readinessProbe:
+            httpGet: { path: /healthz, port: 8780 }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests: { cpu: "250m", memory: 256Mi }
+            limits: { cpu: "1", memory: 512Mi }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: prophet-mesh, namespace: serving }
+spec:
+  selector: { app: prophet-mesh }
+  ports: [{ port: 8780, targetPort: 8780 }]


### PR DESCRIPTION
The shortest real path to talk to the cloud mesh from Noetica on T4-only quota. One AWQ-7B vLLM seat behind the new prophet-mesh conductor (prophet-mesh#16), reachable via port-forward → http://127.0.0.1:8780/v1. Runbook has the exact IAM/spend-gated deploy sequence. 🤖 Generated with [Claude Code](https://claude.com/claude-code)