### PR TITLE
feat(serving): mesh auth + public https exposure

### DIFF
--- a/deploy/serving/mesh-expose.yaml
+++ b/deploy/serving/mesh-expose.yaml
@@ -1,0 +1,37 @@
+# Public https exposure for the conductor so remote users (Gus) reach the mesh.
+# Requires: a DNS A-record mesh.socioprophet.ai → the Ingress IP (printed after apply),
+# and the conductor running with MESH_AUTH_TOKEN (secret prophet-mesh-auth). The Google-
+# managed cert provisions automatically ~15-60 min after DNS resolves to the Ingress IP.
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata: { name: mesh-cert, namespace: serving }
+spec:
+  domains: [ mesh.socioprophet.ai ]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prophet-mesh-lb
+  namespace: serving
+  annotations: { cloud.google.com/neg: '{"ingress": true}' }
+spec:
+  type: NodePort
+  selector: { app: prophet-mesh }
+  ports: [{ port: 8780, targetPort: 8780 }]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mesh-ingress
+  namespace: serving
+  annotations:
+    networking.gke.io/managed-certificates: mesh-cert
+    kubernetes.io/ingress.class: gce
+spec:
+  rules:
+    - host: mesh.socioprophet.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend: { service: { name: prophet-mesh-lb, port: { number: 8780 } } }

--- a/deploy/serving/mesh-test-t4.yaml
+++ b/deploy/serving/mesh-test-t4.yaml
@@ -28,6 +28,32 @@ spec:
         cloud.google.com/gke-accelerator: nvidia-tesla-t4   # T4 quota = 4 (A100/H100 = 0)
       tolerations:
         - { key: nvidia.com/gpu, operator: Exists, effect: NoSchedule }
+      volumes:
+        - name: hfcache
+          emptyDir: { sizeLimit: 30Gi }
+      # Download the weights RELIABLY *before* vLLM starts. Large HF downloads on GKE break at random
+      # points (hf_transfer hangs; classic breaks mid-stream with IncompleteRead and crashes the engine).
+      # This init loop retries until the download exits 0 — huggingface_hub resumes from the .incomplete
+      # each attempt, so it converges past the flaky breaks. vLLM then loads from a COMPLETE local cache.
+      initContainers:
+        - name: fetch-model
+          image: vllm/vllm-openai:v0.6.3
+          command: ["sh", "-c"]
+          args:
+            - |
+              n=0
+              until HF_HUB_ENABLE_HF_TRANSFER=0 huggingface-cli download Qwen/Qwen2.5-Coder-7B-Instruct-AWQ; do
+                n=$((n+1)); echo "download attempt $n broke — resuming in 5s"; sleep 5
+                [ "$n" -ge 40 ] && echo "gave up after $n attempts" && exit 1
+              done
+              echo "model fully cached ✓"
+          env:
+            - { name: HF_HUB_ENABLE_HF_TRANSFER, value: "0" }
+          volumeMounts:
+            - { name: hfcache, mountPath: /root/.cache/huggingface }
+          resources:
+            requests: { cpu: "1", memory: 2Gi }
+            limits: { cpu: "2", memory: 4Gi }
       containers:
         - name: vllm
           image: vllm/vllm-openai:v0.6.3
@@ -39,12 +65,16 @@ spec:
             - "--gpu-memory-utilization=0.92"
             - "--enable-auto-tool-choice"        # so Noetica's agentic tool loop works over the mesh
             - "--tool-call-parser=hermes"
+          env:
+            - { name: HF_HUB_ENABLE_HF_TRANSFER, value: "0" }   # never download in the serving container; load from cache
+          volumeMounts:
+            - { name: hfcache, mountPath: /root/.cache/huggingface }
           ports: [{ containerPort: 8000 }]
           resources:
             limits: { nvidia.com/gpu: 1, cpu: "4", memory: 16Gi }
           readinessProbe:
             httpGet: { path: /health, port: 8000 }
-            initialDelaySeconds: 90
+            initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 60
 ---
@@ -75,8 +105,9 @@ spec:
           env:
             - name: SEAT_BACKENDS
               value: '{"default":{"url":"http://mesh-vllm.serving.svc:8000/v1","model":"Qwen/Qwen2.5-Coder-7B-Instruct-AWQ"}}'
-            # - name: MESH_AUTH_TOKEN            # uncomment + set a secret to require a bearer token
-            #   valueFrom: { secretKeyRef: { name: prophet-mesh-auth, key: token } }
+            # Require a bearer token — the endpoint is (or will be) publicly reachable; don't run it open.
+            - name: MESH_AUTH_TOKEN
+              valueFrom: { secretKeyRef: { name: prophet-mesh-auth, key: token } }
           readinessProbe:
             httpGet: { path: /healthz, port: 8780 }
             initialDelaySeconds: 5


### PR DESCRIPTION
MESH_AUTH_TOKEN on the conductor + ManagedCertificate/Ingress for mesh.socioprophet.ai. Apply is operator-gated. 🤖 Generated with [Claude Code](https://claude.com/claude-code)