### PR TITLE
feat(gyg): causal-valuation + interactive scenario + location twin (ST006)

### DIFF
--- a/apps/dashboard-bff/data/gyg/locations.json
+++ b/apps/dashboard-bff/data/gyg/locations.json
@@ -1,0 +1,38 @@
+{
+  "_provenance": {
+    "subject": "Guzman y Gomez (ASX:GYG)",
+    "note": "Representative sample of real GYG Australian restaurant suburbs with approximate coordinates and format. NOT the full network; a demo subset for the location/map/twin surface. Formats and ownership are illustrative per-site labels consistent with the disclosed network mix.",
+    "network_totals": {
+      "as_of": "2025-10",
+      "total_au_restaurants": 231,
+      "drive_thru": 117,
+      "strip": 68,
+      "other": 39,
+      "source": "https://www.guzmanygomez.com.au/locations/"
+    },
+    "data_provenance": "public_sourced_sample"
+  },
+  "company": "gyg",
+  "locations": [
+    {"id": "gyg-qld-queenst", "suburb": "Brisbane CBD (Queen St)", "state": "QLD", "lat": -27.4700, "lng": 153.0240, "format": "strip", "ownership": "corporate"},
+    {"id": "gyg-qld-fortitude", "suburb": "Fortitude Valley", "state": "QLD", "lat": -27.4570, "lng": 153.0340, "format": "strip", "ownership": "franchise"},
+    {"id": "gyg-qld-chermside", "suburb": "Chermside", "state": "QLD", "lat": -27.3850, "lng": 153.0310, "format": "shopping_centre", "ownership": "franchise"},
+    {"id": "gyg-qld-carindale", "suburb": "Carindale", "state": "QLD", "lat": -27.5100, "lng": 153.1000, "format": "drive_thru", "ownership": "franchise"},
+    {"id": "gyg-qld-indooroopilly", "suburb": "Indooroopilly", "state": "QLD", "lat": -27.5000, "lng": 152.9730, "format": "drive_thru", "ownership": "franchise"},
+    {"id": "gyg-qld-southport", "suburb": "Southport (Gold Coast)", "state": "QLD", "lat": -27.9670, "lng": 153.4100, "format": "drive_thru", "ownership": "franchise"},
+    {"id": "gyg-qld-maroochydore", "suburb": "Maroochydore (Sunshine Coast)", "state": "QLD", "lat": -26.6600, "lng": 153.0900, "format": "drive_thru", "ownership": "franchise"},
+    {"id": "gyg-nsw-sydcbd", "suburb": "Sydney CBD", "state": "NSW", "lat": -33.8700, "lng": 151.2100, "format": "strip", "ownership": "corporate"},
+    {"id": "gyg-nsw-parramatta", "suburb": "Parramatta", "state": "NSW", "lat": -33.8100, "lng": 151.0000, "format": "drive_thru", "ownership": "franchise"},
+    {"id": "gyg-nsw-bondijunction", "suburb": "Bondi Junction", "state": "NSW", "lat": -33.8900, "lng": 151.2500, "format": "strip", "ownership": "franchise"},
+    {"id": "gyg-nsw-liverpool", "suburb": "Liverpool", "state": "NSW", "lat": -33.9200, "lng": 150.9200, "format": "drive_thru", "ownership": "franchise"},
+    {"id": "gyg-nsw-newcastle", "suburb": "Newcastle", "state": "NSW", "lat": -32.9300, "lng": 151.7800, "format": "drive_thru", "ownership": "franchise"},
+    {"id": "gyg-vic-swanston", "suburb": "Melbourne CBD (Swanston St)", "state": "VIC", "lat": -37.8100, "lng": 144.9670, "format": "strip", "ownership": "corporate"},
+    {"id": "gyg-vic-chadstone", "suburb": "Chadstone", "state": "VIC", "lat": -37.8900, "lng": 145.0830, "format": "shopping_centre", "ownership": "franchise"},
+    {"id": "gyg-vic-geelong", "suburb": "Geelong", "state": "VIC", "lat": -38.1500, "lng": 144.3600, "format": "drive_thru", "ownership": "franchise"},
+    {"id": "gyg-vic-craigieburn", "suburb": "Craigieburn", "state": "VIC", "lat": -37.6000, "lng": 144.9400, "format": "drive_thru", "ownership": "franchise"},
+    {"id": "gyg-wa-perthcbd", "suburb": "Perth CBD", "state": "WA", "lat": -31.9500, "lng": 115.8600, "format": "strip", "ownership": "franchise"},
+    {"id": "gyg-wa-haynes", "suburb": "Haynes (Armadale)", "state": "WA", "lat": -32.1600, "lng": 115.9900, "format": "drive_thru", "ownership": "franchise"},
+    {"id": "gyg-act-canberra", "suburb": "Canberra City", "state": "ACT", "lat": -35.2800, "lng": 149.1300, "format": "drive_thru", "ownership": "franchise"},
+    {"id": "gyg-sa-adelaide", "suburb": "Adelaide CBD", "state": "SA", "lat": -34.9300, "lng": 138.6000, "format": "strip", "ownership": "franchise"}
+  ]
+}

--- a/apps/dashboard-bff/data/vdt/catalog.json
+++ b/apps/dashboard-bff/data/vdt/catalog.json
@@ -29,6 +29,11 @@
       "id": "consumerstaples",
       "label": "Consumer Staples",
       "industry": "GICS30_ConsumerStaples"
+    },
+    {
+      "id": "gyg",
+      "label": "Guzman y Gomez (ASX:GYG)",
+      "industry": "GICS_ConsumerDiscretionary_Restaurants"
     }
   ]
 }

--- a/apps/dashboard-bff/data/vdt/gyg.metrics.json
+++ b/apps/dashboard-bff/data/vdt/gyg.metrics.json
@@ -1,0 +1,403 @@
+{
+  "_provenance": {
+    "engine": "open_ep_framework.vdt.run_vdt",
+    "framework_version": "0.1.0",
+    "generated_at": "2026-07-14T15:34:12.238730+00:00",
+    "industry": "GICS_ConsumerDiscretionary_Restaurants",
+    "input_hash": "hash://public-sourced/input-vdt-gyg-qsr-001",
+    "note": "Engine-produced OUTPUT vendored for the dashboard-bff to serve. Not hand-edited. GYG (ASX:GYG) inputs are public-sourced; see profile.evidence_refs.",
+    "profile_example": "examples/vdt_gyg_qsr.json",
+    "regen": "cd ~/dev/economic-prophet && python -m open_ep_framework.cli --mode vdt --example examples/vdt_gyg_qsr.json",
+    "source_repo": "SocioProphet/economic-prophet",
+    "subject": "Guzman y Gomez (ASX:GYG)",
+    "data_provenance": "public_sourced_scenario"
+  },
+  "profile": {
+    "as_of": "2026-07-14T00:00:00Z",
+    "assumptions": [
+      "All monetary values are in AUD.",
+      "Enterprise-value baseline A$2.08bn is GYG's public enterprise value (market cap ~A$1.95bn + net debt), per market data as of mid-2026.",
+      "FY25 actuals grounding the scenario (year to 30 Jun 2025): global network sales A$1.18bn (+23%), revenue A$436m (+27.4%) = corporate restaurant sales A$359.7m + franchise/other A$78.7m; corporate restaurant margin 17.9%; pro-forma EBITDA A$65m; NPAT A$14.5m; 256 restaurants (39 opened in FY25); franchise AUV A$6.7m drive-thru / A$5.0m strip; median franchisee ROI 50%.",
+      "Cell weights are an analyst attribution of enterprise value across the value-driver x capability-domain tensor (sums to 1.0); they are not disclosed by GYG. Value concentrates in demand/comparable sales (RevenueGrowth x CustomerInterface), network rollout and COGS (SupplyDelivery), restaurant labour (OperationsSupport), and guest experience (Experience x CustomerInterface).",
+      "KPI deltas are a forward operating SCENARIO aligned to GYG's stated medium-term guidance (Australian comparable sales averaging ~4%, continued network rollout), not a forecast, target price, or recommendation.",
+      "A KPI lever moves the value carried by its (driver, domain) cell by the improvement fraction; lower_better KPIs improve as they fall.",
+      "US operations are excluded: GYG announced exit of US operations effective May 2026, refocusing on the core Australian business.",
+      "Multi-period: horizon 5y, discount 9% (illustrative equity rate). compounding levers (comparable sales, rollout, drive-thru AUV) recur and compound; step levers (COGS, labour, supply resilience) are one-time improvements held flat."
+    ],
+    "discount_rate": 0.09,
+    "domains": [
+      "CustomerInterface",
+      "ProductServiceDev",
+      "SupplyDelivery",
+      "OperationsSupport",
+      "RiskSecurity",
+      "GovernanceKnowledge"
+    ],
+    "drivers": [
+      "RevenueGrowth",
+      "CostEfficiency",
+      "Experience",
+      "KnowledgeProductivity",
+      "TrustComplianceResilience",
+      "Innovation"
+    ],
+    "enterprise_value_baseline": 2080000000.0,
+    "epistemic_status": {
+      "confidence": 0.7,
+      "level": "public_sourced_scenario",
+      "review_status": "source_cited"
+    },
+    "evidence_refs": [
+      "https://www.guzmanygomez.com.au/wp-content/uploads/2025/09/2025-GYG-Full-Year-Results-Presentation.pdf",
+      "https://www.guzmanygomez.com.au/wp-content/uploads/2025/08/Guzman-y-Gomez-2025-Annual-Report.pdf",
+      "https://www.proactiveinvestors.com.au/companies/news/1077157/guzman-y-gomez-delivers-record-fy25-results-surpasses-1-billion-milestone-1077157.html",
+      "https://stockanalysis.com/quote/asx/GYG/statistics/",
+      "schemas/vdt_profile.schema.json"
+    ],
+    "framework_version": "0.1.0",
+    "horizon_years": 5,
+    "industry": "GICS_ConsumerDiscretionary_Restaurants",
+    "input_hash": "hash://public-sourced/input-vdt-gyg-qsr-001",
+    "kpis": [
+      {
+        "accumulation": "compounding",
+        "delta_pct": 4.0,
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "kpi": "australian_comparable_sales_pct",
+        "polarity": "higher_better"
+      },
+      {
+        "accumulation": "compounding",
+        "delta_pct": 15.0,
+        "domain": "SupplyDelivery",
+        "driver": "RevenueGrowth",
+        "kpi": "net_new_restaurant_rollout_pct",
+        "polarity": "higher_better"
+      },
+      {
+        "accumulation": "step",
+        "delta_pct": -1.5,
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "kpi": "cogs_pct_of_sales",
+        "polarity": "lower_better"
+      },
+      {
+        "accumulation": "step",
+        "delta_pct": -1.0,
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "kpi": "restaurant_labour_pct_of_sales",
+        "polarity": "lower_better"
+      },
+      {
+        "accumulation": "compounding",
+        "delta_pct": 3.0,
+        "domain": "CustomerInterface",
+        "driver": "Experience",
+        "kpi": "drive_thru_average_unit_volume_pct",
+        "polarity": "higher_better"
+      },
+      {
+        "accumulation": "step",
+        "delta_pct": -5.0,
+        "domain": "SupplyDelivery",
+        "driver": "TrustComplianceResilience",
+        "kpi": "supply_disruption_rate",
+        "polarity": "lower_better"
+      }
+    ],
+    "limitations": [
+      "This is a measurement of a scenario's projected enterprise-value uplift under a value-driver tree; it asserts no securities, investment, or valuation-opinion conclusion.",
+      "The weight tensor is an analyst attribution, not company-disclosed segment economics.",
+      "Not calibrated to GYG internal management accounts; grounded only in public disclosures cited in evidence_refs.",
+      "Currency and period mixing (FY25 actuals vs mid-2026 market EV) is deliberate for illustration and not reconciled to a single valuation date."
+    ],
+    "measurement_boundary": {
+      "mode": "doctrine_measurement_simulation_audit_only",
+      "non_goals": [
+        "live_money_movement",
+        "securities_issuance",
+        "investment_advice",
+        "deposit_taking",
+        "external_token_issuance",
+        "payment_processing"
+      ]
+    },
+    "output_hash": "hash://public-sourced/output-vdt-gyg-qsr-001",
+    "replay_plan_ref": "replay://vdt/vdt-gyg-qsr-001",
+    "reported_total_value_uplift": 55848000.0,
+    "reported_value_uplift_fraction": 0.02685,
+    "run_id": "vdt-gyg-qsr-001",
+    "scenario": "gyg-qsr-value-driver-tree",
+    "weights": [
+      {
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "weight": 0.12
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "RevenueGrowth",
+        "weight": 0.03
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "RevenueGrowth",
+        "weight": 0.1
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "RevenueGrowth",
+        "weight": 0.04
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "RevenueGrowth",
+        "weight": 0.01
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "RevenueGrowth",
+        "weight": 0.03
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "CostEfficiency",
+        "weight": 0.02
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "CostEfficiency",
+        "weight": 0.02
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "weight": 0.09
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "weight": 0.07
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "CostEfficiency",
+        "weight": 0.01
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "CostEfficiency",
+        "weight": 0.01
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Experience",
+        "weight": 0.1
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Experience",
+        "weight": 0.03
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Experience",
+        "weight": 0.01
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Experience",
+        "weight": 0.01
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Experience",
+        "weight": 0.005
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Experience",
+        "weight": 0.005
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.02
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.005
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "KnowledgeProductivity",
+        "weight": 0.015
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.01
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.01
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.04
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.01
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.025
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "TrustComplianceResilience",
+        "weight": 0.005
+      },
+      {
+        "domain": "CustomerInterface",
+        "driver": "Innovation",
+        "weight": 0.02
+      },
+      {
+        "domain": "ProductServiceDev",
+        "driver": "Innovation",
+        "weight": 0.04
+      },
+      {
+        "domain": "SupplyDelivery",
+        "driver": "Innovation",
+        "weight": 0.01
+      },
+      {
+        "domain": "OperationsSupport",
+        "driver": "Innovation",
+        "weight": 0.005
+      },
+      {
+        "domain": "RiskSecurity",
+        "driver": "Innovation",
+        "weight": 0.005
+      },
+      {
+        "domain": "GovernanceKnowledge",
+        "driver": "Innovation",
+        "weight": 0.01
+      }
+    ]
+  },
+  "summary": {
+    "computed_total_value_uplift": 55848000.0,
+    "computed_value_uplift_fraction": 0.02685,
+    "domain_count": 6,
+    "driver_count": 6,
+    "enterprise_value_baseline": 2080000000.0,
+    "industry": "GICS_ConsumerDiscretionary_Restaurants",
+    "kpi_count": 6,
+    "measurement_boundary_mode": "doctrine_measurement_simulation_audit_only",
+    "missing_required_non_goals": [],
+    "per_domain_uplift": {
+      "CustomerInterface": 16224000.0,
+      "OperationsSupport": 1456000.0000000002,
+      "SupplyDelivery": 38168000.0
+    },
+    "per_driver_uplift": {
+      "CostEfficiency": 4264000.0,
+      "Experience": 6240000.0,
+      "RevenueGrowth": 41184000.0,
+      "TrustComplianceResilience": 4160000.0
+    },
+    "per_kpi_contribution": [
+      {
+        "delta_pct": 4.0,
+        "domain": "CustomerInterface",
+        "driver": "RevenueGrowth",
+        "kpi": "australian_comparable_sales_pct",
+        "polarity": "higher_better",
+        "value_contribution": 9984000.0
+      },
+      {
+        "delta_pct": 15.0,
+        "domain": "SupplyDelivery",
+        "driver": "RevenueGrowth",
+        "kpi": "net_new_restaurant_rollout_pct",
+        "polarity": "higher_better",
+        "value_contribution": 31200000.0
+      },
+      {
+        "delta_pct": -1.5,
+        "domain": "SupplyDelivery",
+        "driver": "CostEfficiency",
+        "kpi": "cogs_pct_of_sales",
+        "polarity": "lower_better",
+        "value_contribution": 2807999.9999999995
+      },
+      {
+        "delta_pct": -1.0,
+        "domain": "OperationsSupport",
+        "driver": "CostEfficiency",
+        "kpi": "restaurant_labour_pct_of_sales",
+        "polarity": "lower_better",
+        "value_contribution": 1456000.0000000002
+      },
+      {
+        "delta_pct": 3.0,
+        "domain": "CustomerInterface",
+        "driver": "Experience",
+        "kpi": "drive_thru_average_unit_volume_pct",
+        "polarity": "higher_better",
+        "value_contribution": 6240000.0
+      },
+      {
+        "delta_pct": -5.0,
+        "domain": "SupplyDelivery",
+        "driver": "TrustComplianceResilience",
+        "kpi": "supply_disruption_rate",
+        "polarity": "lower_better",
+        "value_contribution": 4160000.0
+      }
+    ],
+    "projected_enterprise_value": 2135848000.0,
+    "reported_total_value_uplift": 55848000.0,
+    "reported_value_uplift_fraction": 0.02685,
+    "required_non_goals_present": [
+      "deposit_taking",
+      "external_token_issuance",
+      "investment_advice",
+      "live_money_movement",
+      "securities_issuance"
+    ],
+    "run_id": "vdt-gyg-qsr-001",
+    "scenario": "gyg-qsr-value-driver-tree",
+    "weight_cell_count": 36,
+    "weight_sum": 1.0
+  }
+}

--- a/apps/dashboard-bff/main.py
+++ b/apps/dashboard-bff/main.py
@@ -34,6 +34,7 @@ _producer = _load_module(ROOT / 'tools' / 'emit_intelligence_superiority_metrics
 _vdt_producer = _load_module(ROOT / 'tools' / 'emit_vdt_metrics.py', 'emit_vdt_metrics')
 _gyg_causal_producer = _load_module(ROOT / 'tools' / 'emit_gyg_causal.py', 'emit_gyg_causal')
 _gyg_locations_producer = _load_module(ROOT / 'tools' / 'emit_gyg_locations.py', 'emit_gyg_locations')
+_company_financials = _load_module(ROOT / 'tools' / 'emit_company_financials.py', 'emit_company_financials')
 
 app = FastAPI(title='dashboard-bff')
 
@@ -197,3 +198,12 @@ def locations(company: str = 'gyg', q: str = '', state: str = '') -> dict:
     `basis` and the payload carries network_totals so the surface labels model vs measured. `q` filters
     by suburb/state/format; `state` filters by state code."""
     return _gyg_locations_producer.build(company, q, state)
+
+
+@app.get('/v1/company/financials')
+def company_financials(ticker: str = 'GYG.AX') -> dict:
+    """Free, no-key public fundamentals for any exchange:ticker (Value Driver Studio auto-pull).
+    Sourced from Yahoo Finance's public quoteSummary via a server-side cookie+crumb handshake —
+    global coverage incl. ASX. Returns available=false on failure so the Studio falls back to
+    manual entry. Provenance is stamped 'public_market_data'; figures are best-effort, not audited."""
+    return _company_financials.fetch(ticker)

--- a/apps/dashboard-bff/main.py
+++ b/apps/dashboard-bff/main.py
@@ -35,6 +35,7 @@ _vdt_producer = _load_module(ROOT / 'tools' / 'emit_vdt_metrics.py', 'emit_vdt_m
 _gyg_causal_producer = _load_module(ROOT / 'tools' / 'emit_gyg_causal.py', 'emit_gyg_causal')
 _gyg_locations_producer = _load_module(ROOT / 'tools' / 'emit_gyg_locations.py', 'emit_gyg_locations')
 _company_financials = _load_module(ROOT / 'tools' / 'emit_company_financials.py', 'emit_company_financials')
+_studio = _load_module(ROOT / 'tools' / 'emit_studio_valuation.py', 'emit_studio_valuation')
 
 app = FastAPI(title='dashboard-bff')
 
@@ -207,3 +208,34 @@ def company_financials(ticker: str = 'GYG.AX') -> dict:
     global coverage incl. ASX. Returns available=false on failure so the Studio falls back to
     manual entry. Provenance is stamped 'public_market_data'; figures are best-effort, not audited."""
     return _company_financials.fetch(ticker)
+
+
+@app.get('/v1/valuation/studio/templates')
+def studio_templates() -> dict:
+    """The industry value-driver-surface templates the Studio offers (reused VDT tensors)."""
+    return {'templates': _studio.templates()}
+
+
+@app.get('/v1/valuation/studio')
+def studio_valuation(ticker: str = '', template: str = 'software', ev_baseline: float = 0.0,
+                     name: str = '', horizon_years: int = 5, discount_rate: float = 0.09) -> dict:
+    """Value Driver Studio — a causal valuation for ANY company. Pass `ticker` (auto-pull free
+    public financials for the EV baseline) or `ev_baseline`+`name` (private company), plus an
+    industry `template`. Runs the canonical economic-prophet engine; same payload shape as the
+    GYG causal walk. Advisory only — not investment advice."""
+    return _studio.build_valuation(ticker=ticker or None, template=template,
+                                   ev_baseline=ev_baseline or None, name=name or None,
+                                   horizon_years=horizon_years, discount_rate=discount_rate)
+
+
+@app.post('/v1/valuation/studio/recompute')
+def studio_recompute(overrides: dict = Body(default={})) -> dict:
+    """What-if recompute for the Studio: re-runs the engine with assumption/horizon/discount
+    overrides. Body: {ticker?, template, ev_baseline?, name?, horizon_years?, discount_rate?,
+    kpi_overrides?}."""
+    return _studio.build_valuation(
+        ticker=overrides.get('ticker') or None, template=overrides.get('template', 'software'),
+        ev_baseline=overrides.get('ev_baseline'), name=overrides.get('name'),
+        horizon_years=int(overrides.get('horizon_years', 5)),
+        discount_rate=float(overrides.get('discount_rate', 0.09)),
+        kpi_overrides=overrides.get('kpi_overrides'))

--- a/apps/dashboard-bff/main.py
+++ b/apps/dashboard-bff/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Body
 from fastapi.middleware.cors import CORSMiddleware
 from pathlib import Path
 import importlib.util
@@ -32,13 +32,15 @@ _contracts = _load_module(Path(__file__).with_name('contracts.py'), 'dashboard_b
 OverviewResponse = _contracts.OverviewResponse
 _producer = _load_module(ROOT / 'tools' / 'emit_intelligence_superiority_metrics.py', 'emit_metrics')
 _vdt_producer = _load_module(ROOT / 'tools' / 'emit_vdt_metrics.py', 'emit_vdt_metrics')
+_gyg_causal_producer = _load_module(ROOT / 'tools' / 'emit_gyg_causal.py', 'emit_gyg_causal')
+_gyg_locations_producer = _load_module(ROOT / 'tools' / 'emit_gyg_locations.py', 'emit_gyg_locations')
 
 app = FastAPI(title='dashboard-bff')
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_CORS_ORIGINS,
-    allow_methods=['GET'],
+    allow_methods=['GET', 'POST'],
     allow_headers=['*'],
 )
 
@@ -160,3 +162,38 @@ def value_driver_tree(industry: str = 'software') -> object:
             f"machine-checked measurement from the economic-prophet engine, not a business outcome."
         ),
     )
+
+
+@app.get('/v1/valuation/causal')
+def valuation_causal(company: str = 'gyg') -> dict:
+    """Serve the causal-graph valuation walk for a company (GYG use case, portfolio-manager persona).
+
+    Joins the hellgraph supply-chain causal graph (supply-chain node -> causal edge -> value-driver KPI)
+    with the economic-prophet VDT valuation (KPI -> driver -> enterprise-value uplift). Neither the graph
+    topology nor the value math is computed here — both are read verbatim from their canonical artifacts
+    with provenance intact (see tools/emit_gyg_causal.py). The GYG inputs are public-sourced; the payload
+    carries epistemic_status, assumptions, limitations and evidence_refs so the surface presents an
+    advisory measurement, never investment advice."""
+    return _gyg_causal_producer.build(company)
+
+
+@app.post('/v1/valuation/causal/recompute')
+def valuation_causal_recompute(company: str = 'gyg', overrides: dict = Body(default={})) -> dict:
+    """What-if recompute: apply the portfolio-manager's assumption overrides and RE-RUN the canonical
+    economic-prophet engine (open_ep_framework.vdt.summarize_vdt), returning the same causal-walk payload
+    with refreshed valuation and graph numbers. The value math is NOT re-implemented here — the engine is
+    invoked live — so exploring assumptions cannot fork the value model.
+
+    Body: {"ev_baseline": <number?>, "kpi_overrides": {"<kpi_name>": <delta_pct>}}"""
+    return _gyg_causal_producer.recompute(overrides, company)
+
+
+@app.get('/v1/locations')
+def locations(company: str = 'gyg', q: str = '', state: str = '') -> dict:
+    """GYG restaurant locations for the map + org digital-twin surface, with a MODELED per-site
+    demographics/foot-traffic estimate. Locations are a public-sourced representative sample; the
+    per-site sales estimate is anchored to GYG's DISCLOSED format AUV (drive-thru A$6.7m / strip A$5.0m)
+    adjusted by a metro-density tier, and footfall is derived via average ticket — every record carries
+    `basis` and the payload carries network_totals so the surface labels model vs measured. `q` filters
+    by suburb/state/format; `state` filters by state code."""
+    return _gyg_locations_producer.build(company, q, state)

--- a/apps/hellgraph-service/scripts/seed-gyg.mjs
+++ b/apps/hellgraph-service/scripts/seed-gyg.mjs
@@ -13,6 +13,19 @@ import { fileURLToPath } from 'node:url'
 import * as path from 'node:path'
 
 const BASE = process.env.HELLGRAPH_URL ?? 'http://localhost:8090'
+// Only http(s) targets — the request path is a fixed literal, never file-derived.
+if (!/^https?:\/\/[^\s]+$/.test(BASE)) { console.error('[seed-gyg] invalid HELLGRAPH_URL'); process.exit(1) }
+
+// Sanitize file-loaded records into a minimal, well-typed payload before any network
+// request — file data never flows verbatim into the outbound body (CodeQL barrier).
+function cleanNode(n) {
+  if (!n || typeof n.id !== 'string' || !Array.isArray(n.labels)) throw new Error('invalid node in seed')
+  return { id: n.id, labels: n.labels.map(String), properties: (n.properties && typeof n.properties === 'object') ? n.properties : {} }
+}
+function cleanEdge(e) {
+  if (!e || typeof e.label !== 'string' || typeof e.from !== 'string' || typeof e.to !== 'string') throw new Error('invalid edge in seed')
+  return { label: e.label, from: e.from, to: e.to, properties: (e.properties && typeof e.properties === 'object') ? e.properties : {} }
+}
 const here = path.dirname(fileURLToPath(import.meta.url))
 const seedPath = path.join(here, '..', 'seeds', 'gyg-supply-chain-causal.json')
 
@@ -30,8 +43,8 @@ async function main() {
   const seed = JSON.parse(await readFile(seedPath, 'utf8'))
   console.log(`[seed-gyg] loading ${seed.nodes.length} nodes / ${seed.edges.length} edges into ${BASE}`)
 
-  for (const n of seed.nodes) await post('/api/graph/node', n)
-  for (const e of seed.edges) await post('/api/graph/edge', e)
+  for (const n of seed.nodes) await post('/api/graph/node', cleanNode(n))
+  for (const e of seed.edges) await post('/api/graph/edge', cleanEdge(e))
 
   const stats = await (await fetch(BASE + '/api/graph/stats')).json()
   console.log('[seed-gyg] graph stats after load:', stats)

--- a/apps/hellgraph-service/scripts/seed-gyg.mjs
+++ b/apps/hellgraph-service/scripts/seed-gyg.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Load the GYG supply-chain -> causal -> value-driver -> valuation graph into a
+ * running hellgraph-service via its HTTP API. Makes the authored seed a real
+ * AtomSpace graph that PLN forward-chaining (POST /api/graph/reason) can run over.
+ *
+ * Usage:
+ *   node scripts/seed-gyg.mjs                 # targets http://localhost:8090
+ *   HELLGRAPH_URL=http://host:8090 node scripts/seed-gyg.mjs
+ */
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import * as path from 'node:path'
+
+const BASE = process.env.HELLGRAPH_URL ?? 'http://localhost:8090'
+const here = path.dirname(fileURLToPath(import.meta.url))
+const seedPath = path.join(here, '..', 'seeds', 'gyg-supply-chain-causal.json')
+
+async function post(pathname, body) {
+  const res = await fetch(BASE + pathname, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) throw new Error(`${pathname} -> ${res.status} ${await res.text()}`)
+  return res.json()
+}
+
+async function main() {
+  const seed = JSON.parse(await readFile(seedPath, 'utf8'))
+  console.log(`[seed-gyg] loading ${seed.nodes.length} nodes / ${seed.edges.length} edges into ${BASE}`)
+
+  for (const n of seed.nodes) await post('/api/graph/node', n)
+  for (const e of seed.edges) await post('/api/graph/edge', e)
+
+  const stats = await (await fetch(BASE + '/api/graph/stats')).json()
+  console.log('[seed-gyg] graph stats after load:', stats)
+  console.log('[seed-gyg] done — GYG causal graph is live in the AtomSpace')
+}
+
+main().catch((e) => { console.error('[seed-gyg] FAILED:', e.message); process.exit(1) })

--- a/apps/hellgraph-service/seeds/gyg-supply-chain-causal.json
+++ b/apps/hellgraph-service/seeds/gyg-supply-chain-causal.json
@@ -1,0 +1,437 @@
+{
+  "_provenance": {
+    "subject": "Guzman y Gomez (ASX:GYG)",
+    "note": "GYG supply-chain -> causal -> value-driver -> valuation graph. Topology authored; all value numbers sourced from economic-prophet engine output (gyg.metrics.json), never recomputed here.",
+    "value_source": "apps/dashboard-bff/data/vdt/gyg.metrics.json",
+    "engine": "open_ep_framework.vdt.run_vdt",
+    "data_provenance": "public_sourced_scenario",
+    "node_schema": "{ id, labels[], properties } \u2014 matches hellgraph-service POST /api/graph/node",
+    "edge_schema": "{ label, from, to, properties } \u2014 matches hellgraph-service POST /api/graph/edge"
+  },
+  "subject": "gyg",
+  "valuation": {
+    "currency": "AUD",
+    "ev_baseline": 2080000000.0,
+    "projected_ev": 2135848000.0,
+    "value_uplift": 55848000.0,
+    "uplift_fraction": 0.02685
+  },
+  "nodes": [
+    {
+      "id": "gyg:company",
+      "labels": [
+        "Company"
+      ],
+      "properties": {
+        "name": "Guzman y Gomez",
+        "ticker": "ASX:GYG",
+        "sector": "Consumer Discretionary \u2014 Restaurants (QSR)"
+      }
+    },
+    {
+      "id": "gyg:valuation:ev",
+      "labels": [
+        "Valuation"
+      ],
+      "properties": {
+        "name": "GYG Enterprise Value",
+        "currency": "AUD",
+        "ev_baseline": 2080000000.0,
+        "projected_ev": 2135848000.0,
+        "value_uplift": 55848000.0,
+        "uplift_fraction": 0.02685
+      }
+    },
+    {
+      "id": "gyg:sc:suppliers",
+      "labels": [
+        "SupplyChainNode"
+      ],
+      "properties": {
+        "name": "Fresh produce & protein suppliers",
+        "tier": "upstream",
+        "basis": "Australian sourcing"
+      }
+    },
+    {
+      "id": "gyg:sc:commissary",
+      "labels": [
+        "SupplyChainNode"
+      ],
+      "properties": {
+        "name": "Central commissaries / production kitchens",
+        "tier": "production"
+      }
+    },
+    {
+      "id": "gyg:sc:coldchain",
+      "labels": [
+        "SupplyChainNode"
+      ],
+      "properties": {
+        "name": "Cold-chain distribution & 3PL",
+        "tier": "distribution"
+      }
+    },
+    {
+      "id": "gyg:sc:corporate_stores",
+      "labels": [
+        "SupplyChainNode"
+      ],
+      "properties": {
+        "name": "Corporate restaurants",
+        "tier": "retail",
+        "note": "FY25 corporate sales A$359.7m, margin 17.9%"
+      }
+    },
+    {
+      "id": "gyg:sc:franchise_stores",
+      "labels": [
+        "SupplyChainNode"
+      ],
+      "properties": {
+        "name": "Franchise restaurants (drive-thru + strip)",
+        "tier": "retail",
+        "note": "AUV A$6.7m drive-thru / A$5.0m strip; median franchisee ROI 50%"
+      }
+    },
+    {
+      "id": "gyg:sc:drivethru",
+      "labels": [
+        "SupplyChainNode"
+      ],
+      "properties": {
+        "name": "Drive-thru format & digital ordering",
+        "tier": "channel"
+      }
+    },
+    {
+      "id": "gyg:sc:labour",
+      "labels": [
+        "SupplyChainNode"
+      ],
+      "properties": {
+        "name": "Restaurant labour model & kitchen ops",
+        "tier": "operations"
+      }
+    },
+    {
+      "id": "gyg:sc:digital",
+      "labels": [
+        "SupplyChainNode"
+      ],
+      "properties": {
+        "name": "Digital app & delivery aggregators",
+        "tier": "channel"
+      }
+    },
+    {
+      "id": "gyg:kpi:comparable_sales",
+      "labels": [
+        "ValueDriverKPI"
+      ],
+      "properties": {
+        "name": "Australian comparable sales",
+        "kpi": "australian_comparable_sales_pct",
+        "driver": "RevenueGrowth",
+        "value_contribution": 9984000.0
+      }
+    },
+    {
+      "id": "gyg:kpi:rollout",
+      "labels": [
+        "ValueDriverKPI"
+      ],
+      "properties": {
+        "name": "Net new restaurant rollout",
+        "kpi": "net_new_restaurant_rollout_pct",
+        "driver": "RevenueGrowth",
+        "value_contribution": 31200000.0
+      }
+    },
+    {
+      "id": "gyg:kpi:cogs",
+      "labels": [
+        "ValueDriverKPI"
+      ],
+      "properties": {
+        "name": "COGS % of sales",
+        "kpi": "cogs_pct_of_sales",
+        "driver": "CostEfficiency",
+        "value_contribution": 2807999.9999999995
+      }
+    },
+    {
+      "id": "gyg:kpi:labour",
+      "labels": [
+        "ValueDriverKPI"
+      ],
+      "properties": {
+        "name": "Restaurant labour % of sales",
+        "kpi": "restaurant_labour_pct_of_sales",
+        "driver": "CostEfficiency",
+        "value_contribution": 1456000.0000000002
+      }
+    },
+    {
+      "id": "gyg:kpi:drivethru_auv",
+      "labels": [
+        "ValueDriverKPI"
+      ],
+      "properties": {
+        "name": "Drive-thru average unit volume",
+        "kpi": "drive_thru_average_unit_volume_pct",
+        "driver": "Experience",
+        "value_contribution": 6240000.0
+      }
+    },
+    {
+      "id": "gyg:kpi:supply_disruption",
+      "labels": [
+        "ValueDriverKPI"
+      ],
+      "properties": {
+        "name": "Supply disruption rate",
+        "kpi": "supply_disruption_rate",
+        "driver": "TrustComplianceResilience",
+        "value_contribution": 4160000.0
+      }
+    },
+    {
+      "id": "gyg:driver:CostEfficiency",
+      "labels": [
+        "ValueDriver"
+      ],
+      "properties": {
+        "name": "CostEfficiency",
+        "value_uplift": 4264000.0
+      }
+    },
+    {
+      "id": "gyg:driver:Experience",
+      "labels": [
+        "ValueDriver"
+      ],
+      "properties": {
+        "name": "Experience",
+        "value_uplift": 6240000.0
+      }
+    },
+    {
+      "id": "gyg:driver:RevenueGrowth",
+      "labels": [
+        "ValueDriver"
+      ],
+      "properties": {
+        "name": "RevenueGrowth",
+        "value_uplift": 41184000.0
+      }
+    },
+    {
+      "id": "gyg:driver:TrustComplianceResilience",
+      "labels": [
+        "ValueDriver"
+      ],
+      "properties": {
+        "name": "TrustComplianceResilience",
+        "value_uplift": 4160000.0
+      }
+    }
+  ],
+  "edges": [
+    {
+      "label": "SUPPLIES",
+      "from": "gyg:sc:suppliers",
+      "to": "gyg:sc:commissary",
+      "properties": {}
+    },
+    {
+      "label": "DISTRIBUTES_TO",
+      "from": "gyg:sc:commissary",
+      "to": "gyg:sc:coldchain",
+      "properties": {}
+    },
+    {
+      "label": "DISTRIBUTES_TO",
+      "from": "gyg:sc:coldchain",
+      "to": "gyg:sc:corporate_stores",
+      "properties": {}
+    },
+    {
+      "label": "DISTRIBUTES_TO",
+      "from": "gyg:sc:coldchain",
+      "to": "gyg:sc:franchise_stores",
+      "properties": {}
+    },
+    {
+      "label": "FORMAT_OF",
+      "from": "gyg:sc:drivethru",
+      "to": "gyg:sc:franchise_stores",
+      "properties": {}
+    },
+    {
+      "label": "STAFFS",
+      "from": "gyg:sc:labour",
+      "to": "gyg:sc:corporate_stores",
+      "properties": {}
+    },
+    {
+      "label": "CHANNEL_FOR",
+      "from": "gyg:sc:digital",
+      "to": "gyg:sc:corporate_stores",
+      "properties": {}
+    },
+    {
+      "label": "CONSTRAINS",
+      "from": "gyg:sc:commissary",
+      "to": "gyg:kpi:rollout",
+      "properties": {
+        "mechanism": "Commissary + distribution capacity gates the pace of new-restaurant rollout"
+      }
+    },
+    {
+      "label": "CAUSES",
+      "from": "gyg:sc:coldchain",
+      "to": "gyg:kpi:rollout",
+      "properties": {
+        "mechanism": "Cold-chain reach determines how far the network can expand from each hub"
+      }
+    },
+    {
+      "label": "REDUCES",
+      "from": "gyg:sc:coldchain",
+      "to": "gyg:kpi:supply_disruption",
+      "properties": {
+        "mechanism": "Cold-chain resilience & dual-sourcing lower supply disruption"
+      }
+    },
+    {
+      "label": "REDUCES",
+      "from": "gyg:sc:suppliers",
+      "to": "gyg:kpi:cogs",
+      "properties": {
+        "mechanism": "Procurement scale & Australian sourcing lower COGS %"
+      }
+    },
+    {
+      "label": "REDUCES",
+      "from": "gyg:sc:commissary",
+      "to": "gyg:kpi:cogs",
+      "properties": {
+        "mechanism": "Central production scale lowers per-unit food cost"
+      }
+    },
+    {
+      "label": "REDUCES",
+      "from": "gyg:sc:labour",
+      "to": "gyg:kpi:labour",
+      "properties": {
+        "mechanism": "Labour model & kitchen design lower restaurant labour %"
+      }
+    },
+    {
+      "label": "CAUSES",
+      "from": "gyg:sc:drivethru",
+      "to": "gyg:kpi:drivethru_auv",
+      "properties": {
+        "mechanism": "Drive-thru format lifts average unit volume (A$6.7m vs A$5.0m strip)"
+      }
+    },
+    {
+      "label": "CAUSES",
+      "from": "gyg:sc:drivethru",
+      "to": "gyg:kpi:comparable_sales",
+      "properties": {
+        "mechanism": "Drive-thru convenience lifts comparable sales"
+      }
+    },
+    {
+      "label": "CAUSES",
+      "from": "gyg:sc:digital",
+      "to": "gyg:kpi:comparable_sales",
+      "properties": {
+        "mechanism": "Digital app & delivery channel lift comparable sales"
+      }
+    },
+    {
+      "label": "CONTRIBUTES_TO",
+      "from": "gyg:kpi:comparable_sales",
+      "to": "gyg:driver:RevenueGrowth",
+      "properties": {
+        "value_contribution": 9984000.0
+      }
+    },
+    {
+      "label": "CONTRIBUTES_TO",
+      "from": "gyg:kpi:rollout",
+      "to": "gyg:driver:RevenueGrowth",
+      "properties": {
+        "value_contribution": 31200000.0
+      }
+    },
+    {
+      "label": "CONTRIBUTES_TO",
+      "from": "gyg:kpi:cogs",
+      "to": "gyg:driver:CostEfficiency",
+      "properties": {
+        "value_contribution": 2807999.9999999995
+      }
+    },
+    {
+      "label": "CONTRIBUTES_TO",
+      "from": "gyg:kpi:labour",
+      "to": "gyg:driver:CostEfficiency",
+      "properties": {
+        "value_contribution": 1456000.0000000002
+      }
+    },
+    {
+      "label": "CONTRIBUTES_TO",
+      "from": "gyg:kpi:drivethru_auv",
+      "to": "gyg:driver:Experience",
+      "properties": {
+        "value_contribution": 6240000.0
+      }
+    },
+    {
+      "label": "CONTRIBUTES_TO",
+      "from": "gyg:kpi:supply_disruption",
+      "to": "gyg:driver:TrustComplianceResilience",
+      "properties": {
+        "value_contribution": 4160000.0
+      }
+    },
+    {
+      "label": "UPLIFTS",
+      "from": "gyg:driver:CostEfficiency",
+      "to": "gyg:valuation:ev",
+      "properties": {
+        "value_uplift": 4264000.0
+      }
+    },
+    {
+      "label": "UPLIFTS",
+      "from": "gyg:driver:Experience",
+      "to": "gyg:valuation:ev",
+      "properties": {
+        "value_uplift": 6240000.0
+      }
+    },
+    {
+      "label": "UPLIFTS",
+      "from": "gyg:driver:RevenueGrowth",
+      "to": "gyg:valuation:ev",
+      "properties": {
+        "value_uplift": 41184000.0
+      }
+    },
+    {
+      "label": "UPLIFTS",
+      "from": "gyg:driver:TrustComplianceResilience",
+      "to": "gyg:valuation:ev",
+      "properties": {
+        "value_uplift": 4160000.0
+      }
+    }
+  ]
+}

--- a/apps/socioprophet-web/src/App.vue
+++ b/apps/socioprophet-web/src/App.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import GygCausalValuationCard from './components/GygCausalValuationCard.vue'
+import GygLocationsMapCard from './components/GygLocationsMapCard.vue'
 import ChronosEvidenceLoopCard from './components/ChronosEvidenceLoopCard.vue'
 import DevSecOpsWorkroomReportCard from './components/DevSecOpsWorkroomReportCard.vue'
 import HealthAIDemoReadinessCard from './components/HealthAIDemoReadinessCard.vue'
@@ -44,6 +46,8 @@ onMounted(check)
       </div>
     </section>
 
+    <GygCausalValuationCard />
+    <GygLocationsMapCard />
     <HealthAIDemoReadinessCard />
     <ProphetMeshRuntimeReadinessCard />
     <ChronosEvidenceLoopCard />

--- a/apps/socioprophet-web/src/components/GygCausalValuationCard.vue
+++ b/apps/socioprophet-web/src/components/GygCausalValuationCard.vue
@@ -1,0 +1,335 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
+type GraphNode = { id: string; labels: string[]; properties: Record<string, any> }
+type GraphEdge = { label: string; from: string; to: string; properties: Record<string, any> }
+
+type EditableAssumption = { kpi: string; driver: string; domain: string; delta_pct: number; polarity: string }
+
+type CausalValuation = {
+  company: string
+  subject: string
+  recomputed: boolean
+  assumptions_editable: EditableAssumption[]
+  valuation: {
+    currency: string
+    ev_baseline: number
+    projected_ev: number
+    value_uplift: number
+    uplift_fraction: number
+  }
+  timeseries: {
+    horizon_years: number
+    discount_rate: number
+    periods: Array<{ year: number; projected_enterprise_value: number; total_value_uplift: number; value_uplift_fraction: number; incremental_value_uplift: number }>
+    terminal_projected_enterprise_value: number
+    terminal_total_value_uplift: number
+    present_value_of_uplift: number
+  }
+  causal_graph: { nodes: GraphNode[]; edges: GraphEdge[] }
+  vdt: {
+    scenario: string
+    industry: string
+    per_driver_uplift: Record<string, number>
+    per_kpi_contribution: Array<{ kpi: string; driver: string; domain: string; delta_pct: number; polarity: string; value_contribution: number }>
+    epistemic_status: Record<string, any>
+    assumptions: string[]
+    limitations: string[]
+    evidence_refs: string[]
+  }
+  provenance: Record<string, any>
+  headline: string
+}
+
+const data = ref<CausalValuation | null>(null)
+const loading = ref(false)
+const error = ref('')
+const dirty = ref(false)
+// user assumption overrides: kpi name -> delta_pct
+const overrides = ref<Record<string, number>>({})
+const horizon = ref(5)
+const discountPct = ref(9)
+
+async function load() {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await fetch('/bff/v1/valuation/causal?company=gyg')
+    if (!res.ok) throw new Error(`request failed: ${res.status}`)
+    data.value = await res.json()
+    overrides.value = Object.fromEntries((data.value?.assumptions_editable ?? []).map((a) => [a.kpi, a.delta_pct]))
+    horizon.value = data.value?.timeseries.horizon_years ?? 5
+    discountPct.value = Math.round((data.value?.timeseries.discount_rate ?? 0.09) * 100)
+    dirty.value = false
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'request failed'
+    data.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+async function recompute() {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await fetch('/bff/v1/valuation/causal/recompute?company=gyg', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ kpi_overrides: overrides.value, horizon_years: horizon.value, discount_rate: discountPct.value / 100 }),
+    })
+    if (!res.ok) throw new Error(`recompute failed: ${res.status}`)
+    data.value = await res.json()
+    dirty.value = false
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'recompute failed'
+  } finally {
+    loading.value = false
+  }
+}
+
+function onSlide(kpi: string, value: string) {
+  overrides.value[kpi] = Number(value)
+  dirty.value = true
+}
+
+function resetAssumptions() {
+  overrides.value = Object.fromEntries((data.value?.assumptions_editable ?? []).map((a) => [a.kpi, a.delta_pct]))
+  dirty.value = true
+  recompute()
+}
+
+const sliderBounds = (polarity: string) =>
+  polarity === 'lower_better' ? { min: -20, max: 0 } : { min: 0, max: 40 }
+
+onMounted(load)
+
+function money(n: number, currency = 'AUD'): string {
+  const abs = Math.abs(n)
+  if (abs >= 1e9) return `${currency} ${(n / 1e9).toFixed(2)}B`
+  if (abs >= 1e6) return `${currency} ${(n / 1e6).toFixed(1)}M`
+  return `${currency} ${n.toLocaleString()}`
+}
+
+const nodeById = computed(() => {
+  const m = new Map<string, GraphNode>()
+  for (const n of data.value?.causal_graph.nodes ?? []) m.set(n.id, n)
+  return m
+})
+
+const supplyNodes = computed(() =>
+  (data.value?.causal_graph.nodes ?? []).filter((n) => n.labels.includes('SupplyChainNode'))
+)
+
+// causal edges: supply-chain node -> KPI (CAUSES / CONSTRAINS / REDUCES)
+const causalEdges = computed(() =>
+  (data.value?.causal_graph.edges ?? []).filter((e) => ['CAUSES', 'CONSTRAINS', 'REDUCES'].includes(e.label))
+)
+
+// KPI leaves with the driver they roll up to, sorted by contribution
+const kpis = computed(() =>
+  [...(data.value?.vdt.per_kpi_contribution ?? [])].sort((a, b) => b.value_contribution - a.value_contribution)
+)
+
+const drivers = computed(() =>
+  Object.entries(data.value?.vdt.per_driver_uplift ?? {}).sort((a, b) => b[1] - a[1])
+)
+
+// for a supply-chain node, the KPIs it causally drives (with mechanism)
+function drivenBy(nodeId: string) {
+  return causalEdges.value
+    .filter((e) => e.from === nodeId)
+    .map((e) => ({ kpi: nodeById.value.get(e.to)?.properties?.name ?? e.to, mechanism: e.properties?.mechanism ?? '', relation: e.label }))
+}
+
+const maxContribution = computed(() => Math.max(1, ...kpis.value.map((k) => k.value_contribution)))
+
+const periods = computed(() => data.value?.timeseries.periods ?? [])
+const maxProjected = computed(() => Math.max(1, ...periods.value.map((p) => p.projected_enterprise_value)))
+const minBaseline = computed(() => data.value?.valuation.ev_baseline ?? 0)
+</script>
+
+<template>
+  <section style="border:1px solid #cbd5e1;border-radius:16px;padding:1rem;margin-top:1.5rem;background:#f8fafc;">
+    <div style="display:flex;gap:.75rem;align-items:flex-start;justify-content:space-between;">
+      <div>
+        <div style="font-size:12px;text-transform:uppercase;letter-spacing:.08em;opacity:.65;font-weight:700;">
+          Causal Valuation · Portfolio-manager persona
+        </div>
+        <h2 style="margin:.4rem 0 .35rem 0;font-size:1.35rem;font-weight:750;">
+          {{ data?.subject ?? 'Guzman y Gomez (ASX:GYG)' }}
+        </h2>
+        <p style="margin:0;opacity:.78;max-width:820px;">
+          Supply-chain graph → causal drivers → economic-prophet value-driver tree → enterprise value.
+          Advisory measurement of a public-sourced scenario — <strong>not investment advice</strong>.
+        </p>
+      </div>
+      <button @click="load" style="padding:.45rem .75rem;border:1px solid #94a3b8;border-radius:8px;background:white;white-space:nowrap;">
+        {{ loading ? 'Loading…' : 'Reload' }}
+      </button>
+    </div>
+
+    <p v-if="error" style="border:1px solid #fecaca;background:#fef2f2;border-radius:10px;padding:.75rem;margin:1rem 0 0 0;color:#991b1b;">
+      {{ error }}
+    </p>
+
+    <div v-if="data" style="margin-top:1rem;display:grid;gap:1rem;">
+      <!-- Valuation banner -->
+      <section style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.95rem;">
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:.75rem;align-items:end;">
+          <div>
+            <div style="font-size:.78rem;opacity:.6;text-transform:uppercase;letter-spacing:.05em;">Enterprise value (baseline)</div>
+            <div style="font-size:1.4rem;font-weight:700;">{{ money(data.valuation.ev_baseline, data.valuation.currency) }}</div>
+          </div>
+          <div style="font-size:1.6rem;opacity:.4;text-align:center;">→</div>
+          <div>
+            <div style="font-size:.78rem;opacity:.6;text-transform:uppercase;letter-spacing:.05em;">Projected enterprise value</div>
+            <div style="font-size:1.4rem;font-weight:700;color:#065f46;">{{ money(data.valuation.projected_ev, data.valuation.currency) }}</div>
+          </div>
+          <div>
+            <div style="font-size:.78rem;opacity:.6;text-transform:uppercase;letter-spacing:.05em;">Scenario uplift</div>
+            <div style="font-size:1.4rem;font-weight:700;color:#065f46;">
+              +{{ money(data.valuation.value_uplift, data.valuation.currency) }}
+              <span style="font-size:.95rem;opacity:.7;">({{ (data.valuation.uplift_fraction * 100).toFixed(2) }}%)</span>
+            </div>
+          </div>
+        </div>
+        <p style="margin:.85rem 0 0 0;opacity:.82;">{{ data.headline }}</p>
+      </section>
+
+      <!-- Interactive assumptions: re-enter the tree, recompute via the engine -->
+      <section style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+        <div style="display:flex;justify-content:space-between;align-items:center;gap:.5rem;flex-wrap:wrap;">
+          <h3 style="margin:0;font-size:1rem;">Scenario assumptions
+            <span v-if="data.recomputed" style="font-size:.72rem;font-weight:600;color:#065f46;background:#ecfdf5;border:1px solid #a7f3d0;border-radius:999px;padding:.1rem .5rem;margin-left:.4rem;">recomputed via engine</span>
+          </h3>
+          <div style="display:flex;gap:.5rem;">
+            <button @click="resetAssumptions" style="padding:.35rem .7rem;border:1px solid #cbd5e1;border-radius:8px;background:white;">Reset</button>
+            <button @click="recompute" :disabled="!dirty || loading"
+              :style="{ padding:'.35rem .8rem', borderRadius:'8px', border:'1px solid ' + (dirty ? '#10b981' : '#cbd5e1'), background: dirty ? '#10b981' : 'white', color: dirty ? 'white' : '#64748b', cursor: dirty ? 'pointer' : 'default' }">
+              {{ loading ? 'Recomputing…' : 'Recompute valuation' }}
+            </button>
+          </div>
+        </div>
+        <p style="margin:.4rem 0 .75rem 0;font-size:.82rem;opacity:.65;">Move a lever and recompute — the value math runs in the economic-prophet engine, not the browser.</p>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:.5rem 1.25rem;margin-bottom:.75rem;padding-bottom:.75rem;border-bottom:1px solid #eef2f7;">
+          <div>
+            <div style="display:flex;justify-content:space-between;font-size:.82rem;"><span><strong>Time horizon</strong></span><span style="font-weight:650;">{{ horizon }} years</span></div>
+            <input type="range" min="1" max="10" step="1" :value="horizon" @input="horizon = Number(($event.target as HTMLInputElement).value); dirty = true" style="width:100%;margin-top:.25rem;" />
+          </div>
+          <div>
+            <div style="display:flex;justify-content:space-between;font-size:.82rem;"><span><strong>Discount rate</strong></span><span style="font-weight:650;">{{ discountPct }}%</span></div>
+            <input type="range" min="0" max="20" step="0.5" :value="discountPct" @input="discountPct = Number(($event.target as HTMLInputElement).value); dirty = true" style="width:100%;margin-top:.25rem;" />
+          </div>
+        </div>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:.75rem 1.25rem;">
+          <div v-for="a in data.assumptions_editable" :key="a.kpi">
+            <div style="display:flex;justify-content:space-between;font-size:.82rem;">
+              <span><strong>{{ a.driver }}</strong> · {{ a.kpi }}</span>
+              <span style="font-weight:650;">{{ overrides[a.kpi] > 0 ? '+' : '' }}{{ overrides[a.kpi] }}%</span>
+            </div>
+            <input type="range" :min="sliderBounds(a.polarity).min" :max="sliderBounds(a.polarity).max" step="0.5"
+              :value="overrides[a.kpi]" @input="onSlide(a.kpi, ($event.target as HTMLInputElement).value)"
+              style="width:100%;margin-top:.25rem;" />
+            <div style="font-size:.72rem;opacity:.5;">{{ a.domain }} · {{ a.polarity }}</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Causal walk: supply chain -> value drivers -> valuation -->
+      <section style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:1rem;">
+        <!-- Stage 1: supply chain -->
+        <article style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+          <h3 style="margin:0 0 .6rem 0;font-size:1rem;">1 · Supply-chain graph → causal levers</h3>
+          <div v-for="n in supplyNodes" :key="n.id" style="border:1px solid #eef2f7;border-radius:10px;padding:.55rem;margin:.5rem 0;">
+            <div style="font-weight:650;">{{ n.properties.name }}</div>
+            <div v-if="n.properties.note" style="font-size:.8rem;opacity:.62;margin-top:.15rem;">{{ n.properties.note }}</div>
+            <ul style="margin:.4rem 0 0 0;padding-left:1rem;">
+              <li v-for="(d, i) in drivenBy(n.id)" :key="i" style="margin:.25rem 0;font-size:.85rem;">
+                <code style="font-size:.75rem;background:#f1f5f9;padding:.05rem .3rem;border-radius:4px;">{{ d.relation }}</code>
+                <strong> {{ d.kpi }}</strong> — {{ d.mechanism }}
+              </li>
+            </ul>
+          </div>
+        </article>
+
+        <!-- Stage 2: KPI -> driver contributions -->
+        <article style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+          <h3 style="margin:0 0 .6rem 0;font-size:1rem;">2 · Value-driver KPIs (engine contribution)</h3>
+          <div v-for="k in kpis" :key="k.kpi" style="margin:.55rem 0;">
+            <div style="display:flex;justify-content:space-between;gap:.5rem;">
+              <span style="font-size:.88rem;"><strong>{{ k.driver }}</strong> · {{ k.kpi }}</span>
+              <span style="font-size:.85rem;font-weight:650;color:#065f46;white-space:nowrap;">+{{ money(k.value_contribution) }}</span>
+            </div>
+            <div style="height:8px;background:#eef2f7;border-radius:6px;margin-top:.25rem;overflow:hidden;">
+              <div :style="{ width: (k.value_contribution / maxContribution * 100) + '%', height:'100%', background:'#10b981' }"></div>
+            </div>
+            <div style="font-size:.74rem;opacity:.55;margin-top:.15rem;">
+              {{ k.domain }} · Δ {{ k.delta_pct }}% ({{ k.polarity }})
+            </div>
+          </div>
+        </article>
+
+        <!-- Stage 3: driver -> valuation -->
+        <article style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+          <h3 style="margin:0 0 .6rem 0;font-size:1rem;">3 · Driver uplift → enterprise value</h3>
+          <div v-for="[name, uplift] in drivers" :key="name" style="display:flex;justify-content:space-between;gap:.5rem;margin:.5rem 0;padding:.5rem;border:1px solid #eef2f7;border-radius:10px;">
+            <span style="font-weight:650;">{{ name }}</span>
+            <span style="font-weight:700;color:#065f46;white-space:nowrap;">+{{ money(uplift) }}</span>
+          </div>
+          <div style="display:flex;justify-content:space-between;gap:.5rem;margin-top:.75rem;padding:.6rem;border-radius:10px;background:#ecfdf5;border:1px solid #a7f3d0;">
+            <span style="font-weight:750;">GYG enterprise value</span>
+            <span style="font-weight:800;">{{ money(data.valuation.projected_ev, data.valuation.currency) }}</span>
+          </div>
+        </article>
+      </section>
+
+      <!-- Time-span trajectory: multi-period projection -->
+      <section style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+        <div style="display:flex;justify-content:space-between;align-items:baseline;flex-wrap:wrap;gap:.5rem;">
+          <h3 style="margin:0;font-size:1rem;">Projected enterprise value over {{ data.timeseries.horizon_years }} years</h3>
+          <div style="font-size:.85rem;">
+            <span style="opacity:.6;">terminal</span> <strong>{{ money(data.timeseries.terminal_projected_enterprise_value) }}</strong>
+            <span style="opacity:.6;margin-left:.75rem;">PV of uplift @ {{ (data.timeseries.discount_rate*100).toFixed(1) }}%</span> <strong style="color:#065f46;">{{ money(data.timeseries.present_value_of_uplift) }}</strong>
+          </div>
+        </div>
+        <div style="display:flex;align-items:flex-end;gap:.5rem;height:130px;margin-top:1rem;">
+          <div v-for="p in periods" :key="p.year" style="flex:1;display:flex;flex-direction:column;align-items:center;justify-content:flex-end;height:100%;">
+            <div style="font-size:.72rem;font-weight:600;color:#065f46;">{{ money(p.projected_enterprise_value) }}</div>
+            <div :style="{ width:'100%', maxWidth:'46px', height: ((p.projected_enterprise_value - minBaseline*0.98) / (maxProjected - minBaseline*0.98) * 100) + '%', background:'#10b981', borderRadius:'6px 6px 0 0', minHeight:'4px', marginTop:'.2rem' }"></div>
+            <div style="font-size:.74rem;opacity:.6;margin-top:.25rem;">y{{ p.year }}</div>
+          </div>
+        </div>
+        <p style="margin:.5rem 0 0 0;font-size:.76rem;opacity:.55;">Compounding levers (comparable sales, rollout, drive-thru AUV) recur each year; step levers (COGS, labour, supply resilience) are one-time improvements held flat. Present value discounts the incremental uplift stream.</p>
+      </section>
+
+      <!-- Governance: epistemic status + provenance + non-claims -->
+      <section style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;">
+        <article style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+          <h3 style="margin:0 0 .6rem 0;font-size:1rem;">Provenance</h3>
+          <div style="display:grid;gap:.35rem;font-size:.85rem;">
+            <div><strong>Data</strong> — <code>{{ data.vdt.epistemic_status.level }}</code> · confidence {{ data.vdt.epistemic_status.confidence }} · {{ data.vdt.epistemic_status.review_status }}</div>
+            <div><strong>Value engine</strong> — <code>{{ data.provenance.engine }}</code></div>
+            <div><strong>Value source</strong> — <code style="font-size:.72rem;">{{ data.provenance.value_source }}</code></div>
+            <div><strong>Graph source</strong> — <code style="font-size:.72rem;">{{ data.provenance.graph_source }}</code></div>
+          </div>
+          <h4 style="margin:.75rem 0 .35rem 0;font-size:.85rem;">Public sources</h4>
+          <ul style="margin:0;padding-left:1rem;">
+            <li v-for="ref in data.vdt.evidence_refs" :key="ref" style="margin:.2rem 0;font-size:.76rem;word-break:break-all;">
+              <a v-if="ref.startsWith('http')" :href="ref" target="_blank" rel="noopener">{{ ref }}</a>
+              <code v-else>{{ ref }}</code>
+            </li>
+          </ul>
+        </article>
+
+        <article style="border:1px solid #fde68a;border-radius:12px;background:#fffbeb;padding:.85rem;">
+          <h3 style="margin:0 0 .6rem 0;font-size:1rem;">Measurement boundary (non-claims)</h3>
+          <p style="margin:0 0 .5rem 0;font-size:.82rem;">This is an advisory measurement of a scenario, not a recommendation, target price, or valuation opinion.</p>
+          <ul style="margin:0;padding-left:1rem;">
+            <li v-for="lim in data.vdt.limitations" :key="lim" style="margin:.3rem 0;font-size:.82rem;">{{ lim }}</li>
+          </ul>
+        </article>
+      </section>
+    </div>
+  </section>
+</template>

--- a/apps/socioprophet-web/src/components/GygLocationsMapCard.vue
+++ b/apps/socioprophet-web/src/components/GygLocationsMapCard.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
+type Loc = {
+  id: string; suburb: string; state: string; lat: number; lng: number
+  format: string; ownership: string; metro_tier: number; catchment_profile: string
+  est_annual_sales_aud: number; modeled_weekly_footfall: number; basis: string
+}
+type LocationsPayload = {
+  subject: string
+  locations: Loc[]
+  sample_size: number
+  network_totals: { total_au_restaurants: number; drive_thru: number; strip: number; other: number; as_of: string }
+  org_twin: {
+    sample_modeled_annual_sales_aud: number
+    sample_modeled_weekly_footfall: number
+    by_state: Record<string, number>
+    by_format: Record<string, number>
+    network_extrapolation_note: string
+  }
+}
+
+const data = ref<LocationsPayload | null>(null)
+const loading = ref(false)
+const error = ref('')
+const q = ref('')
+const selected = ref<string | null>(null)
+
+async function load() {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await fetch(`/bff/v1/locations?company=gyg&q=${encodeURIComponent(q.value)}`)
+    if (!res.ok) throw new Error(`request failed: ${res.status}`)
+    data.value = await res.json()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'request failed'
+  } finally {
+    loading.value = false
+  }
+}
+onMounted(load)
+
+function money(n: number): string {
+  return n >= 1e9 ? `A$${(n / 1e9).toFixed(2)}B` : `A$${(n / 1e6).toFixed(1)}M`
+}
+
+// project lat/lng -> SVG (Australia bounds)
+const LNG0 = 112.5, LNG1 = 154, LAT_TOP = -10, LAT_BOT = -44, W = 440, H = 360
+function px(lng: number) { return ((lng - LNG0) / (LNG1 - LNG0)) * W }
+function py(lat: number) { return ((LAT_TOP - lat) / (LAT_TOP - LAT_BOT)) * H }
+
+const AU_OUTLINE: number[][] = [
+  [142.5,-10.7],[145.5,-16],[149,-21],[153,-25],[153.5,-28.2],[151,-33.9],[150,-37.5],
+  [146,-38.9],[141,-38.4],[139,-35.5],[135,-34.8],[132,-32],[129,-31.7],[126,-32.3],
+  [123,-33.9],[118,-35],[115,-34.5],[114,-28],[113.5,-24],[114,-22],[116,-20.5],
+  [121,-19.5],[123,-16.5],[126,-14],[129,-15],[130.5,-12],[132,-11.5],[135,-12],
+  [137,-16],[140,-17.5],[141,-16],[141.5,-13],[142.5,-10.7],
+]
+const outlinePoints = computed(() => AU_OUTLINE.map(([lng, lat]) => `${px(lng).toFixed(1)},${py(lat).toFixed(1)}`).join(' '))
+
+const FORMAT_COLOR: Record<string, string> = { drive_thru: '#10b981', strip: '#3b82f6', shopping_centre: '#f59e0b' }
+function dotColor(f: string) { return FORMAT_COLOR[f] ?? '#64748b' }
+function dotR(footfall: number) { return 3 + Math.sqrt(footfall) / 22 }
+
+const selectedLoc = computed(() => data.value?.locations.find((l) => l.id === selected.value) ?? null)
+</script>
+
+<template>
+  <section style="border:1px solid #cbd5e1;border-radius:16px;padding:1rem;margin-top:1.5rem;background:#f8fafc;">
+    <div style="display:flex;gap:.75rem;align-items:flex-start;justify-content:space-between;">
+      <div>
+        <div style="font-size:12px;text-transform:uppercase;letter-spacing:.08em;opacity:.65;font-weight:700;">Location intelligence · org digital twin</div>
+        <h2 style="margin:.4rem 0 .35rem 0;font-size:1.35rem;font-weight:750;">{{ data?.subject ?? 'Guzman y Gomez' }} — network map</h2>
+        <p style="margin:0;opacity:.78;max-width:820px;">Search and plot restaurants, with a <strong>modeled</strong> per-site foot-traffic and sales estimate (anchored to disclosed format AUV, not measured footfall).</p>
+      </div>
+    </div>
+
+    <p v-if="error" style="border:1px solid #fecaca;background:#fef2f2;border-radius:10px;padding:.75rem;margin:1rem 0 0 0;color:#991b1b;">{{ error }}</p>
+
+    <div v-if="data" style="margin-top:1rem;">
+      <div style="display:flex;gap:.5rem;margin-bottom:.75rem;">
+        <input v-model="q" @keyup.enter="load" placeholder="Search suburb, state, or format (e.g. coast, VIC, drive_thru)"
+          style="flex:1;padding:.45rem .7rem;border:1px solid #cbd5e1;border-radius:8px;" />
+        <button @click="load" style="padding:.45rem .8rem;border:1px solid #94a3b8;border-radius:8px;background:white;">{{ loading ? '…' : 'Search' }}</button>
+      </div>
+
+      <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;">
+        <!-- Map -->
+        <article style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:.4rem;">
+            <h3 style="margin:0;font-size:1rem;">Map ({{ data.sample_size }} of {{ data.network_totals.total_au_restaurants }})</h3>
+            <div style="font-size:.72rem;display:flex;gap:.6rem;">
+              <span><span style="display:inline-block;width:9px;height:9px;border-radius:50%;background:#10b981;"></span> drive-thru</span>
+              <span><span style="display:inline-block;width:9px;height:9px;border-radius:50%;background:#3b82f6;"></span> strip</span>
+              <span><span style="display:inline-block;width:9px;height:9px;border-radius:50%;background:#f59e0b;"></span> centre</span>
+            </div>
+          </div>
+          <svg :viewBox="`0 0 ${W} ${H}`" style="width:100%;height:auto;">
+            <polygon :points="outlinePoints" fill="#eef2f7" stroke="#cbd5e1" stroke-width="1" />
+            <g v-for="l in data.locations" :key="l.id">
+              <circle :cx="px(l.lng)" :cy="py(l.lat)" :r="dotR(l.modeled_weekly_footfall)"
+                :fill="dotColor(l.format)" :fill-opacity="selected===l.id ? 1 : 0.7"
+                :stroke="selected===l.id ? '#0f172a' : 'white'" :stroke-width="selected===l.id ? 2 : 1"
+                style="cursor:pointer" @click="selected = l.id" />
+            </g>
+          </svg>
+          <p style="margin:.4rem 0 0 0;font-size:.72rem;opacity:.55;">Dot size ∝ modeled weekly footfall. Click a dot for detail. Coordinates approximate.</p>
+        </article>
+
+        <!-- Org twin rollup -->
+        <article style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+          <h3 style="margin:0 0 .5rem 0;font-size:1rem;">Org digital twin (sample rollup)</h3>
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:.6rem;">
+            <div><div style="font-size:.72rem;opacity:.6;">Modeled annual sales</div><div style="font-size:1.2rem;font-weight:700;">{{ money(data.org_twin.sample_modeled_annual_sales_aud) }}</div></div>
+            <div><div style="font-size:.72rem;opacity:.6;">Modeled weekly footfall</div><div style="font-size:1.2rem;font-weight:700;">{{ data.org_twin.sample_modeled_weekly_footfall.toLocaleString() }}</div></div>
+          </div>
+          <h4 style="margin:.75rem 0 .3rem 0;font-size:.85rem;">By state</h4>
+          <div style="display:flex;flex-wrap:wrap;gap:.35rem;">
+            <span v-for="(n,s) in data.org_twin.by_state" :key="s" style="font-size:.78rem;padding:.15rem .5rem;border:1px solid #e2e8f0;border-radius:999px;">{{ s }} · {{ n }}</span>
+          </div>
+          <p style="margin:.75rem 0 0 0;font-size:.76rem;opacity:.6;">{{ data.org_twin.network_extrapolation_note }}</p>
+        </article>
+      </div>
+
+      <!-- Selected location detail -->
+      <article v-if="selectedLoc" style="border:1px solid #a7f3d0;background:#ecfdf5;border-radius:12px;padding:.85rem;margin-top:1rem;">
+        <div style="display:flex;justify-content:space-between;align-items:baseline;">
+          <h3 style="margin:0;font-size:1.05rem;">{{ selectedLoc.suburb }} <span style="font-size:.8rem;opacity:.6;">· {{ selectedLoc.state }} · {{ selectedLoc.format.replace('_',' ') }} · {{ selectedLoc.ownership }}</span></h3>
+          <button @click="selected = null" style="border:none;background:none;cursor:pointer;font-size:1rem;opacity:.5;">✕</button>
+        </div>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:.6rem;margin-top:.5rem;">
+          <div><div style="font-size:.72rem;opacity:.6;">Modeled annual sales</div><div style="font-size:1.1rem;font-weight:700;">{{ money(selectedLoc.est_annual_sales_aud) }}</div></div>
+          <div><div style="font-size:.72rem;opacity:.6;">Modeled weekly footfall</div><div style="font-size:1.1rem;font-weight:700;">{{ selectedLoc.modeled_weekly_footfall.toLocaleString() }}</div></div>
+          <div><div style="font-size:.72rem;opacity:.6;">Catchment</div><div style="font-size:.9rem;">{{ selectedLoc.catchment_profile }}</div></div>
+        </div>
+        <p style="margin:.6rem 0 0 0;font-size:.74rem;opacity:.6;">Basis: {{ selectedLoc.basis }}</p>
+      </article>
+    </div>
+  </section>
+</template>

--- a/apps/socioprophet-web/vite.config.ts
+++ b/apps/socioprophet-web/vite.config.ts
@@ -10,6 +10,13 @@ export default defineConfig({
         target: 'http://localhost:8080',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, '')
+      },
+      // dashboard-bff (VDT / causal-valuation endpoints). Kept separate from the
+      // gateway on /api so the two can run independently in local dev.
+      '/bff': {
+        target: process.env.VITE_BFF_TARGET ?? 'http://localhost:8077',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/bff/, '')
       }
     }
   }

--- a/deploy/serving/mesh-xl-a100.yaml
+++ b/deploy/serving/mesh-xl-a100.yaml
@@ -1,7 +1,8 @@
 # Prophet Mesh — "XL" seat: Qwen3-32B-AWQ on a single A100 40GB (Spot), scale-to-zero.
 #
-# Kept WARM (replicas: 1) for interactive SLA — no cold start, TTFT ~200-400ms. For a 2-user
-# base that's ~$1.30/hr Spot (~$23-31/day, ~$950/mo if left 24/7 — inside the $1,500 budget).
+# OFF by default (replicas: 0) = $0 idle. Warm on demand for interactive use:
+#   kubectl -n serving scale deploy/mesh-vllm-xl --replicas=1   (weights PVC-cached → ~2-3 min)
+# Warm Spot cost ~$1.30/hr (~$23-31/day, ~$950/mo if left 24/7 — inside the $1,500 budget).
 # Cost guardrails (why this can't run away):
 #   - exactly 1 GPU per pod, 1 replica → hard cap of ONE A100. Cannot scale out.
 #   - Spot (cloud.google.com/gke-spot) → ~$1.30/hr vs ~$3.80 on-demand.
@@ -28,7 +29,7 @@ metadata:
   namespace: serving
   labels: { app: mesh-vllm-xl }
 spec:
-  replicas: 1
+  replicas: 0
   # RWO PVC + single GPU: tear the old pod down before starting the new one,
   # otherwise a rolling update deadlocks on the ReadWriteOnce volume.
   strategy:

--- a/deploy/serving/mesh-xl-a100.yaml
+++ b/deploy/serving/mesh-xl-a100.yaml
@@ -1,0 +1,99 @@
+# Prophet Mesh — "XL" seat: Qwen3-32B-AWQ on a single A100 40GB (Spot), scale-to-zero.
+#
+# Kept WARM (replicas: 1) for interactive SLA — no cold start, TTFT ~200-400ms. For a 2-user
+# base that's ~$1.30/hr Spot (~$23-31/day, ~$950/mo if left 24/7 — inside the $1,500 budget).
+# Cost guardrails (why this can't run away):
+#   - exactly 1 GPU per pod, 1 replica → hard cap of ONE A100. Cannot scale out.
+#   - Spot (cloud.google.com/gke-spot) → ~$1.30/hr vs ~$3.80 on-demand.
+#   - GCP budget ($1,500) with alerts at 50/90/100%.
+#   - Scale to zero when done for a while:  kubectl -n serving scale deploy/mesh-vllm-xl --replicas=0
+#     (weights are cached on the PVC, so re-warm is ~2-3 min, not the ~15 min first load).
+# The T4 "default" seat stays always-on, so chat never breaks even if this is scaled to 0.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mesh-xl-cache
+  namespace: serving
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: standard-rwo
+  resources:
+    requests:
+      storage: 120Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mesh-vllm-xl
+  namespace: serving
+  labels: { app: mesh-vllm-xl }
+spec:
+  replicas: 1
+  # RWO PVC + single GPU: tear the old pod down before starting the new one,
+  # otherwise a rolling update deadlocks on the ReadWriteOnce volume.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: { app: mesh-vllm-xl }
+  template:
+    metadata:
+      labels: { app: mesh-vllm-xl }
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-tesla-a100
+        cloud.google.com/gke-spot: "true"
+        cloud.google.com/gke-gpu-driver-version: latest
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          args:
+            - --model=Qwen/Qwen3-32B-AWQ
+            - --quantization=awq_marlin
+            - --port=8000
+            - --max-model-len=8192
+            - --gpu-memory-utilization=0.92
+            - --enable-auto-tool-choice
+            - --tool-call-parser=hermes
+          ports:
+            - containerPort: 8000
+          env:
+            - name: HF_HOME
+              value: /hf
+          volumeMounts:
+            - name: cache
+              mountPath: /hf
+          readinessProbe:
+            httpGet: { path: /health, port: 8000 }
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            failureThreshold: 60
+          resources:
+            requests:
+              cpu: "10"
+              memory: 40Gi
+              nvidia.com/gpu: "1"
+              ephemeral-storage: 10Gi
+            limits:
+              cpu: "10"
+              memory: 40Gi
+              nvidia.com/gpu: "1"
+              ephemeral-storage: 10Gi
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: mesh-xl-cache
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mesh-vllm-xl
+  namespace: serving
+spec:
+  selector: { app: mesh-vllm-xl }
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/tools/emit_company_financials.py
+++ b/tools/emit_company_financials.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""emit_company_financials — free, no-key public fundamentals for ANY listed company,
+so Value Driver Studio can auto-build a VDT profile for any exchange:ticker.
+
+Source: Yahoo Finance's public quoteSummary, reached via the cookie+crumb handshake
+(unofficial, best-effort, $0). Global coverage incl. ASX (e.g. GYG.AX). Stdlib only
+(urllib + http.cookiejar) so the dashboard-bff gains no new dependency. If the handshake
+fails, the endpoint returns available=false and the Studio falls back to manual entry.
+Never presents estimates as audited figures — the caller labels provenance.
+"""
+from __future__ import annotations
+
+import json
+import http.cookiejar
+import urllib.request
+import urllib.error
+
+_UA = "Mozilla/5.0 (compatible; SocioProphet/1.0)"
+_MODULES = "price,summaryDetail,defaultKeyStatistics,financialData"
+
+
+def _raw(node) -> float | None:
+    if isinstance(node, dict):
+        return node.get("raw")
+    return node if isinstance(node, (int, float)) else None
+
+
+def fetch(ticker: str) -> dict:
+    """Pull public fundamentals for a ticker (e.g. 'GYG.AX', 'AAPL'). Returns a normalized
+    dict with available=True/False and provenance. Never raises to the caller."""
+    t = (ticker or "").strip().upper()
+    if not t:
+        return {"ticker": ticker, "available": False, "error": "no ticker"}
+    jar = http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(jar))
+    opener.addheaders = [("User-Agent", _UA)]
+    try:
+        opener.open("https://fc.yahoo.com", timeout=12).read()
+    except Exception:
+        pass  # cookie may still be set / not required
+    try:
+        crumb = opener.open("https://query1.finance.yahoo.com/v1/test/getcrumb", timeout=12).read().decode().strip()
+        url = f"https://query1.finance.yahoo.com/v10/finance/quoteSummary/{urllib.parse.quote(t)}?modules={_MODULES}&crumb={urllib.parse.quote(crumb)}"
+        body = json.loads(opener.open(url, timeout=15).read().decode())
+        r = (body.get("quoteSummary") or {}).get("result")
+        if not r:
+            return {"ticker": t, "available": False, "error": "no data (bad ticker or blocked)"}
+        q = r[0]
+        price, dks, fd = q.get("price", {}), q.get("defaultKeyStatistics", {}), q.get("financialData", {})
+        return {
+            "ticker": t,
+            "available": True,
+            "name": price.get("longName") or price.get("shortName") or t,
+            "currency": price.get("currency"),
+            "exchange": price.get("exchangeName"),
+            "market_cap": _raw(price.get("marketCap")),
+            "enterprise_value": _raw(dks.get("enterpriseValue")),
+            "revenue_ttm": _raw(fd.get("totalRevenue")),
+            "gross_margin": _raw(fd.get("grossMargins")),
+            "ebitda_margin": _raw(fd.get("ebitdaMargins")),
+            "operating_margin": _raw(fd.get("operatingMargins")),
+            "profit_margin": _raw(dks.get("profitMargins")),
+            "provenance": {
+                "source": "Yahoo Finance public quoteSummary (unofficial, no-key)",
+                "basis": "public_market_data",
+                "note": "Best-effort free data; verify before use. Manual entry available as override.",
+            },
+        }
+    except urllib.error.HTTPError as e:
+        return {"ticker": t, "available": False, "error": f"http {e.code}"}
+    except Exception as e:  # noqa: BLE001
+        return {"ticker": t, "available": False, "error": str(e)[:120]}
+
+
+if __name__ == "__main__":
+    import sys
+    print(json.dumps(fetch(sys.argv[1] if len(sys.argv) > 1 else "GYG.AX"), indent=2))

--- a/tools/emit_gyg_causal.py
+++ b/tools/emit_gyg_causal.py
@@ -15,8 +15,10 @@ import copy
 import json
 from pathlib import Path
 
-from open_ep_framework.vdt import summarize_vdt
-from open_ep_framework.vdt_multiperiod import summarize_vdt_multiperiod
+# NOTE: the economic-prophet engine (open_ep_framework) is imported LAZILY inside the
+# functions that recompute — so importing this module (and the dashboard-bff app) never
+# requires economic-prophet to be installed. The default GET path degrades gracefully to a
+# single-period view if the engine isn't present; recompute requires it and errors clearly.
 
 ROOT = Path(__file__).resolve().parents[1]
 SEED_PATH = ROOT / "apps" / "hellgraph-service" / "seeds" / "gyg-supply-chain-causal.json"
@@ -66,7 +68,15 @@ def _refresh_graph(seed: dict, summary: dict) -> dict:
 
 
 def _timeseries(profile: dict) -> dict:
-    """Multi-period projection of the same profile via the canonical multi-period engine."""
+    """Multi-period projection of the same profile via the canonical multi-period engine.
+    Degrades to an empty projection if economic-prophet isn't installed (e.g. lightweight CI)."""
+    try:
+        from open_ep_framework.vdt_multiperiod import summarize_vdt_multiperiod
+    except ImportError:
+        return {"horizon_years": 1, "discount_rate": 0.0, "periods": [],
+                "terminal_projected_enterprise_value": profile.get("enterprise_value_baseline", 0.0),
+                "terminal_total_value_uplift": 0.0, "present_value_of_uplift": 0.0,
+                "engine_unavailable": True}
     mp = summarize_vdt_multiperiod(profile)
     return {
         "horizon_years": mp["horizon_years"],
@@ -166,7 +176,8 @@ def recompute(overrides: dict, company: str = "gyg") -> dict:
         if kpi["kpi"] in kover and kover[kpi["kpi"]] is not None:
             kpi["delta_pct"] = float(kover[kpi["kpi"]])
 
-    summary = summarize_vdt(profile)  # canonical engine, not re-implemented here
+    from open_ep_framework.vdt import summarize_vdt  # canonical engine, imported lazily
+    summary = summarize_vdt(profile)  # not re-implemented here
     return _compose(summary, profile, seed, vdt, recomputed=True)
 
 

--- a/tools/emit_gyg_causal.py
+++ b/tools/emit_gyg_causal.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""emit_gyg_causal — serve the GYG causal-graph valuation walk the dashboard-bff exposes
+at /v1/valuation/causal, including live "what-if" recompute.
+
+DESIGN PRINCIPLE (same as emit_vdt_metrics): the value math is NOT here. The valuation is
+computed by the canonical economic-prophet engine (open_ep_framework.vdt.summarize_vdt); the
+causal/supply-chain topology comes from the hellgraph seed. This module JOINS the two into one
+walkable payload (supply-chain node -> causal edge -> KPI -> driver -> enterprise value) and, for
+what-if exploration, applies user assumption overrides to the profile and RE-RUNS THE ENGINE.
+We never re-implement the VDT identities here, so recompute cannot fork the value model.
+"""
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from open_ep_framework.vdt import summarize_vdt
+from open_ep_framework.vdt_multiperiod import summarize_vdt_multiperiod
+
+ROOT = Path(__file__).resolve().parents[1]
+SEED_PATH = ROOT / "apps" / "hellgraph-service" / "seeds" / "gyg-supply-chain-causal.json"
+VDT_PATH = ROOT / "apps" / "dashboard-bff" / "data" / "vdt" / "gyg.metrics.json"
+
+
+def load_seed() -> dict:
+    return json.loads(SEED_PATH.read_text(encoding="utf-8"))
+
+
+def load_vdt() -> dict:
+    return json.loads(VDT_PATH.read_text(encoding="utf-8"))
+
+
+def _refresh_graph(seed: dict, summary: dict) -> dict:
+    """Refresh the value annotations on the causal graph from a fresh engine summary.
+    Topology (nodes, edges, mechanisms) is preserved; only the numbers move."""
+    nodes = copy.deepcopy(seed["nodes"])
+    edges = copy.deepcopy(seed["edges"])
+    kpi_by_name = {k["kpi"]: k["value_contribution"] for k in summary["per_kpi_contribution"]}
+    driver_uplift = summary["per_driver_uplift"]
+
+    kpi_name_by_node = {}
+    driver_name_by_node = {}
+    for n in nodes:
+        if "ValueDriverKPI" in n["labels"]:
+            name = n["properties"].get("kpi")
+            kpi_name_by_node[n["id"]] = name
+            n["properties"]["value_contribution"] = kpi_by_name.get(name, 0.0)
+        elif "ValueDriver" in n["labels"]:
+            name = n["properties"].get("name")
+            driver_name_by_node[n["id"]] = name
+            n["properties"]["value_uplift"] = driver_uplift.get(name, 0.0)
+        elif "Valuation" in n["labels"]:
+            n["properties"]["ev_baseline"] = summary["enterprise_value_baseline"]
+            n["properties"]["projected_ev"] = summary["projected_enterprise_value"]
+            n["properties"]["value_uplift"] = summary["computed_total_value_uplift"]
+            n["properties"]["uplift_fraction"] = round(summary["computed_value_uplift_fraction"], 5)
+
+    for e in edges:
+        if e["label"] == "CONTRIBUTES_TO":
+            e["properties"]["value_contribution"] = kpi_by_name.get(kpi_name_by_node.get(e["from"]), 0.0)
+        elif e["label"] == "UPLIFTS":
+            e["properties"]["value_uplift"] = driver_uplift.get(driver_name_by_node.get(e["from"]), 0.0)
+
+    return {"nodes": nodes, "edges": edges}
+
+
+def _timeseries(profile: dict) -> dict:
+    """Multi-period projection of the same profile via the canonical multi-period engine."""
+    mp = summarize_vdt_multiperiod(profile)
+    return {
+        "horizon_years": mp["horizon_years"],
+        "discount_rate": mp["discount_rate"],
+        "periods": [
+            {
+                "year": p["year"],
+                "projected_enterprise_value": p["projected_enterprise_value"],
+                "total_value_uplift": p["total_value_uplift"],
+                "value_uplift_fraction": round(p["value_uplift_fraction"], 5),
+                "incremental_value_uplift": p["incremental_value_uplift"],
+            }
+            for p in mp["periods"]
+        ],
+        "terminal_projected_enterprise_value": mp["terminal_projected_enterprise_value"],
+        "terminal_total_value_uplift": mp["terminal_total_value_uplift"],
+        "present_value_of_uplift": mp["present_value_of_uplift"],
+    }
+
+
+def _compose(summary: dict, profile: dict, seed: dict, vdt_doc: dict, recomputed: bool) -> dict:
+    uplift = summary["computed_total_value_uplift"]
+    frac = summary["computed_value_uplift_fraction"]
+    ev = summary["enterprise_value_baseline"]
+    valuation = {
+        "currency": "AUD",
+        "ev_baseline": ev,
+        "projected_ev": summary["projected_enterprise_value"],
+        "value_uplift": uplift,
+        "uplift_fraction": round(frac, 5),
+    }
+    return {
+        "company": seed["subject"],
+        "subject": seed["_provenance"]["subject"],
+        "recomputed": recomputed,
+        "valuation": valuation,
+        "timeseries": _timeseries(profile),
+        "causal_graph": _refresh_graph(seed, summary),
+        "assumptions_editable": [
+            {"kpi": k["kpi"], "driver": k["driver"], "domain": k["domain"],
+             "delta_pct": k["delta_pct"], "polarity": k["polarity"]}
+            for k in profile["kpis"]
+        ],
+        "vdt": {
+            "scenario": summary["scenario"],
+            "industry": summary["industry"],
+            "per_driver_uplift": summary["per_driver_uplift"],
+            "per_kpi_contribution": summary["per_kpi_contribution"],
+            "epistemic_status": profile.get("epistemic_status", {}),
+            "assumptions": profile.get("assumptions", []),
+            "limitations": profile.get("limitations", []),
+            "evidence_refs": profile.get("evidence_refs", []),
+        },
+        "provenance": {
+            "value_source": seed["_provenance"]["value_source"],
+            "graph_source": "apps/hellgraph-service/seeds/gyg-supply-chain-causal.json",
+            "engine": seed["_provenance"]["engine"],
+            "data_provenance": seed["_provenance"]["data_provenance"],
+            "vdt": vdt_doc.get("_provenance", {}),
+        },
+        "headline": (
+            f"{seed['_provenance']['subject']}: the supply-chain causal graph traces "
+            f"A${uplift / 1e6:.1f}M ({frac * 100:.2f}%) of enterprise-value uplift onto a "
+            f"A${ev / 1e9:.2f}B baseline — advisory measurement from the economic-prophet engine"
+            f"{' (recomputed for your assumptions)' if recomputed else ''}, not investment advice."
+        ),
+    }
+
+
+def build(company: str = "gyg") -> dict:
+    """Default GYG walk from the vendored engine output (no recompute)."""
+    seed = load_seed()
+    vdt = load_vdt()
+    return _compose(vdt["summary"], vdt["profile"], seed, vdt, recomputed=False)
+
+
+def recompute(overrides: dict, company: str = "gyg") -> dict:
+    """Apply user assumption overrides to the GYG profile and RE-RUN the canonical engine.
+
+    overrides = {
+      "ev_baseline": <number>,                       # optional
+      "kpi_overrides": {"<kpi_name>": <delta_pct>}    # optional per-KPI lever
+    }
+    """
+    seed = load_seed()
+    vdt = load_vdt()
+    profile = copy.deepcopy(vdt["profile"])
+
+    if overrides.get("ev_baseline") is not None:
+        profile["enterprise_value_baseline"] = float(overrides["ev_baseline"])
+    if overrides.get("horizon_years") is not None:
+        profile["horizon_years"] = int(overrides["horizon_years"])
+    if overrides.get("discount_rate") is not None:
+        profile["discount_rate"] = float(overrides["discount_rate"])
+    kover = overrides.get("kpi_overrides", {}) or {}
+    for kpi in profile["kpis"]:
+        if kpi["kpi"] in kover and kover[kpi["kpi"]] is not None:
+            kpi["delta_pct"] = float(kover[kpi["kpi"]])
+
+    summary = summarize_vdt(profile)  # canonical engine, not re-implemented here
+    return _compose(summary, profile, seed, vdt, recomputed=True)
+
+
+if __name__ == "__main__":
+    print(json.dumps(build(), indent=2, sort_keys=True))

--- a/tools/emit_gyg_locations.py
+++ b/tools/emit_gyg_locations.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""emit_gyg_locations — serve GYG restaurant locations with a MODELED per-site demographics /
+foot-traffic estimate for the map + org digital-twin surface (/v1/locations).
+
+Honesty contract (per the "modeled estimate, clearly labeled" decision):
+  - Locations (suburb, state, approx lat/lng, format) are a public-sourced representative sample.
+  - est_annual_sales is ANCHORED to GYG's DISCLOSED format average unit volume (drive-thru A$6.7m,
+    strip A$5.0m; shopping-centre interpolated) and adjusted by a metro-density tier. It is a model,
+    not GYG per-site actuals.
+  - modeled_weekly_footfall is DERIVED from est_annual_sales / average ticket — a transparent proxy,
+    not measured mobility data.
+Every record carries `basis` so the surface can label it. No paid/mobility data is used.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOC_PATH = ROOT / "apps" / "dashboard-bff" / "data" / "gyg" / "locations.json"
+
+# GYG-disclosed format AUV (A$m/yr): drive-thru 6.7, strip 5.0; shopping-centre interpolated.
+FORMAT_AUV_AUD = {"drive_thru": 6_700_000.0, "strip": 5_000_000.0, "shopping_centre": 5_500_000.0}
+AVG_TICKET_AUD = 18.0  # QSR average transaction, for footfall derivation
+
+# metro-density tier per location id (1 = dense CBD/major metro, 3 = regional). Tier scales AUV.
+METRO_TIER = {
+    "gyg-qld-queenst": 1, "gyg-qld-fortitude": 1, "gyg-qld-chermside": 2, "gyg-qld-carindale": 2,
+    "gyg-qld-indooroopilly": 2, "gyg-qld-southport": 2, "gyg-qld-maroochydore": 3,
+    "gyg-nsw-sydcbd": 1, "gyg-nsw-parramatta": 1, "gyg-nsw-bondijunction": 1, "gyg-nsw-liverpool": 2,
+    "gyg-nsw-newcastle": 3, "gyg-vic-swanston": 1, "gyg-vic-chadstone": 2, "gyg-vic-geelong": 3,
+    "gyg-vic-craigieburn": 2, "gyg-wa-perthcbd": 1, "gyg-wa-haynes": 2, "gyg-act-canberra": 2,
+    "gyg-sa-adelaide": 1,
+}
+TIER_MULT = {1: 1.2, 2: 1.0, 3: 0.8}
+TIER_LABEL = {1: "dense CBD / major-metro catchment", 2: "suburban catchment", 3: "regional catchment"}
+
+
+def _load() -> dict:
+    return json.loads(LOC_PATH.read_text(encoding="utf-8"))
+
+
+def _enrich(loc: dict) -> dict:
+    tier = METRO_TIER.get(loc["id"], 2)
+    auv = FORMAT_AUV_AUD.get(loc["format"], 5_000_000.0)
+    est_annual_sales = round(auv * TIER_MULT[tier])
+    weekly_footfall = round(est_annual_sales / AVG_TICKET_AUD / 52.0)
+    return {
+        **loc,
+        "metro_tier": tier,
+        "catchment_profile": TIER_LABEL[tier],
+        "est_annual_sales_aud": est_annual_sales,
+        "modeled_weekly_footfall": weekly_footfall,
+        "basis": "modeled: format AUV (GYG-disclosed) x metro tier; footfall = sales / A$18 avg ticket",
+    }
+
+
+def build(company: str = "gyg", q: str = "", state: str = "") -> dict:
+    doc = _load()
+    locs = [_enrich(l) for l in doc["locations"]]
+
+    ql = q.strip().lower()
+    if ql:
+        locs = [l for l in locs if ql in l["suburb"].lower() or ql in l["state"].lower() or ql in l["format"].lower()]
+    if state:
+        locs = [l for l in locs if l["state"].upper() == state.upper()]
+
+    by_state: dict[str, int] = {}
+    by_format: dict[str, int] = {}
+    sample_sales = 0
+    sample_footfall = 0
+    for l in locs:
+        by_state[l["state"]] = by_state.get(l["state"], 0) + 1
+        by_format[l["format"]] = by_format.get(l["format"], 0) + 1
+        sample_sales += l["est_annual_sales_aud"]
+        sample_footfall += l["modeled_weekly_footfall"]
+
+    totals = doc["_provenance"]["network_totals"]
+    return {
+        "company": "gyg",
+        "subject": doc["_provenance"]["subject"],
+        "query": {"q": q, "state": state},
+        "locations": locs,
+        "sample_size": len(locs),
+        "network_totals": totals,
+        "org_twin": {
+            "sample_modeled_annual_sales_aud": sample_sales,
+            "sample_modeled_weekly_footfall": sample_footfall,
+            "by_state": by_state,
+            "by_format": by_format,
+            "network_extrapolation_note": (
+                f"Sample of {len(locs)} of {totals['total_au_restaurants']} AU restaurants. "
+                f"Modeled sales are anchored to disclosed format AUV; a full-network twin would scale to "
+                f"all {totals['total_au_restaurants']} sites."
+            ),
+        },
+        "provenance": doc["_provenance"],
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(build(), indent=2, sort_keys=True))

--- a/tools/emit_studio_valuation.py
+++ b/tools/emit_studio_valuation.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""emit_studio_valuation — Value Driver Studio: a causal valuation for ANY company.
+
+Generalizes the GYG pipeline. Given an exchange:ticker (auto-pull free public financials)
+OR manual inputs for a private company, plus an industry value-driver-surface TEMPLATE
+(reuses the vendored industry VDT tensors), it:
+  1. sets the enterprise-value baseline from the real/entered EV,
+  2. runs the CANONICAL economic-prophet engine on the template's driver x domain tensor,
+  3. builds a causal graph (KPI -> driver -> enterprise value),
+and returns the SAME payload shape the client-vue causal-valuation surface already renders.
+The value math is never re-implemented here. Provenance is stamped; advisory only.
+"""
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VDT_DIR = ROOT / "apps" / "dashboard-bff" / "data" / "vdt"
+
+# Templates the Studio offers = the vendored industry VDT surfaces (drivers x domains x weights).
+TEMPLATES = ["software", "banks", "energy", "realestate", "materials", "consumerstaples", "gyg"]
+DEFAULT_TEMPLATE = "software"
+
+
+def templates() -> list[dict]:
+    out = []
+    for t in TEMPLATES:
+        p = VDT_DIR / f"{t}.metrics.json"
+        if p.exists():
+            prof = json.loads(p.read_text(encoding="utf-8")).get("profile", {})
+            out.append({"id": t, "industry": prof.get("industry", t)})
+    return out
+
+
+def _load_template_profile(tid: str) -> dict:
+    p = VDT_DIR / f"{tid}.metrics.json"
+    if not p.exists():
+        p = VDT_DIR / f"{DEFAULT_TEMPLATE}.metrics.json"
+    return copy.deepcopy(json.loads(p.read_text(encoding="utf-8"))["profile"])
+
+
+def _generic_graph(summary: dict, subject: str, currency: str) -> dict:
+    """Company-agnostic causal graph: value-driver KPI -> driver -> enterprise value.
+    (No physical supply-chain layer — that stays specific to modeled subjects like GYG.)"""
+    nodes = [{
+        "id": "co:valuation", "labels": ["Valuation"],
+        "properties": {"name": f"{subject} enterprise value", "currency": currency,
+                       "ev_baseline": summary["enterprise_value_baseline"],
+                       "projected_ev": summary["projected_enterprise_value"],
+                       "value_uplift": summary["computed_total_value_uplift"],
+                       "uplift_fraction": round(summary["computed_value_uplift_fraction"], 5)}}]
+    edges = []
+    for driver, uplift in summary["per_driver_uplift"].items():
+        nodes.append({"id": f"co:driver:{driver}", "labels": ["ValueDriver"],
+                      "properties": {"name": driver, "value_uplift": uplift}})
+        edges.append({"label": "UPLIFTS", "from": f"co:driver:{driver}", "to": "co:valuation",
+                      "properties": {"value_uplift": uplift}})
+    for k in summary["per_kpi_contribution"]:
+        nid = f"co:kpi:{k['kpi']}"
+        nodes.append({"id": nid, "labels": ["ValueDriverKPI"],
+                      "properties": {"name": k["kpi"], "kpi": k["kpi"], "driver": k["driver"],
+                                     "value_contribution": k["value_contribution"]}})
+        edges.append({"label": "CONTRIBUTES_TO", "from": nid, "to": f"co:driver:{k['driver']}",
+                      "properties": {"value_contribution": k["value_contribution"]}})
+    return {"nodes": nodes, "edges": edges}
+
+
+def _timeseries(profile: dict) -> dict:
+    try:
+        from open_ep_framework.vdt_multiperiod import summarize_vdt_multiperiod
+    except ImportError:
+        ev = profile.get("enterprise_value_baseline", 0.0)
+        return {"horizon_years": 1, "discount_rate": 0.0, "periods": [],
+                "terminal_projected_enterprise_value": ev, "terminal_total_value_uplift": 0.0,
+                "present_value_of_uplift": 0.0, "engine_unavailable": True}
+    mp = summarize_vdt_multiperiod(profile)
+    return {"horizon_years": mp["horizon_years"], "discount_rate": mp["discount_rate"],
+            "periods": [{"year": p["year"], "projected_enterprise_value": p["projected_enterprise_value"],
+                         "total_value_uplift": p["total_value_uplift"],
+                         "value_uplift_fraction": round(p["value_uplift_fraction"], 5),
+                         "incremental_value_uplift": p["incremental_value_uplift"]} for p in mp["periods"]],
+            "terminal_projected_enterprise_value": mp["terminal_projected_enterprise_value"],
+            "terminal_total_value_uplift": mp["terminal_total_value_uplift"],
+            "present_value_of_uplift": mp["present_value_of_uplift"]}
+
+
+def build_valuation(ticker: str | None = None, template: str = DEFAULT_TEMPLATE,
+                    ev_baseline: float | None = None, name: str | None = None,
+                    horizon_years: int = 5, discount_rate: float = 0.09,
+                    kpi_overrides: dict | None = None) -> dict:
+    currency = "USD"
+    financials = None
+    if ticker:
+        from importlib import util as _u
+        spec = _u.spec_from_file_location("emit_company_financials", ROOT / "tools" / "emit_company_financials.py")
+        mod = _u.module_from_spec(spec); spec.loader.exec_module(mod)  # type: ignore
+        financials = mod.fetch(ticker)
+        if financials.get("available"):
+            ev_baseline = financials.get("enterprise_value") or financials.get("market_cap") or ev_baseline
+            name = financials.get("name") or name
+            currency = financials.get("currency") or currency
+
+    profile = _load_template_profile(template)
+    subject = name or ticker or "Private company"
+    profile["scenario"] = f"studio:{subject}"
+    if ev_baseline:
+        profile["enterprise_value_baseline"] = float(ev_baseline)
+    profile["horizon_years"] = int(horizon_years)
+    profile["discount_rate"] = float(discount_rate)
+    for kpi in profile.get("kpis", []):
+        if kpi_overrides and kpi["kpi"] in kpi_overrides and kpi_overrides[kpi["kpi"]] is not None:
+            kpi["delta_pct"] = float(kpi_overrides[kpi["kpi"]])
+
+    from open_ep_framework.vdt import summarize_vdt  # canonical engine, lazy
+    summary = summarize_vdt(profile)
+    ev = summary["enterprise_value_baseline"]
+    uplift = summary["computed_total_value_uplift"]
+    frac = summary["computed_value_uplift_fraction"]
+
+    return {
+        "company": (ticker or subject),
+        "subject": subject,
+        "ticker": ticker,
+        "template": template,
+        "recomputed": bool(kpi_overrides or ticker),
+        "valuation": {"currency": currency, "ev_baseline": ev,
+                      "projected_ev": summary["projected_enterprise_value"],
+                      "value_uplift": uplift, "uplift_fraction": round(frac, 5)},
+        "timeseries": _timeseries(profile),
+        "causal_graph": _generic_graph(summary, subject, currency),
+        "assumptions_editable": [{"kpi": k["kpi"], "driver": k["driver"], "domain": k["domain"],
+                                  "delta_pct": k["delta_pct"], "polarity": k["polarity"]}
+                                 for k in profile["kpis"]],
+        "vdt": {"scenario": profile["scenario"], "industry": summary["industry"],
+                "per_driver_uplift": summary["per_driver_uplift"],
+                "per_kpi_contribution": summary["per_kpi_contribution"],
+                "epistemic_status": {"level": "public_sourced_scenario" if financials and financials.get("available")
+                                     else "template_scenario", "review_status": "engine_computed"},
+                "assumptions": [f"Enterprise-value baseline from {'public market data ('+ticker+')' if financials and financials.get('available') else 'manual entry'}.",
+                                f"Value-driver tensor = the '{template}' industry template (analyst attribution).",
+                                "KPI deltas are a scenario; adjust them to explore. Advisory only — not investment advice."],
+                "limitations": ["Template scenario, not company-specific segment economics.",
+                                "No securities, investment, or valuation-opinion conclusion is implied."],
+                "evidence_refs": (financials.get("provenance", {}).get("source", "") if financials else "manual entry",)},
+        "provenance": {"engine": "open_ep_framework.vdt.summarize_vdt",
+                       "data_provenance": "public_market_data" if financials and financials.get("available") else "manual",
+                       "financials": financials or {"available": False, "note": "manual / private company"}},
+        "headline": (f"{subject}: the '{template}' value-driver scenario projects "
+                     f"{currency} {uplift/1e6:.1f}M ({frac*100:.2f}%) enterprise-value uplift on a "
+                     f"{currency} {ev/1e9:.2f}B baseline — advisory measurement from the economic-prophet "
+                     f"engine, not investment advice."),
+    }
+
+
+if __name__ == "__main__":
+    import sys
+    tk = sys.argv[1] if len(sys.argv) > 1 else "GYG.AX"
+    tpl = sys.argv[2] if len(sys.argv) > 2 else "consumerstaples"
+    print(json.dumps(build_valuation(ticker=tk, template=tpl), indent=2))


### PR DESCRIPTION
## What
The **GYG (ASX:GYG) portfolio-manager demo** for the IFM intro call (sprint ST006): supply-chain causal graph (hellgraph) → economic-prophet value-driver tree → enterprise value, made interactive and given a location digital twin.

### dashboard-bff
- `GET /v1/valuation/causal` — joins the hellgraph causal graph with the economic-prophet VDT valuation.
- `POST /v1/valuation/causal/recompute` — what-if: re-runs the **canonical economic-prophet engine** on user assumption + horizon/discount overrides. The value math is **never re-implemented in the BFF**.
- `GET /v1/locations` — GYG restaurant sample with a **modeled** foot-traffic/sales estimate, anchored to disclosed format AUV (drive-thru A$6.7m / strip A$5.0m) × metro tier, labeled (not measured).

### hellgraph-service
- GYG supply-chain causal graph seed (20 nodes / 26 edges) + HTTP loader. Loads live into the AtomSpace; PLN-reasonable.

### socioprophet-web
- `GygCausalValuationCard` — assumption + time-horizon + discount sliders, causal driver walk, multi-period trajectory.
- `GygLocationsMapCard` — inline SVG Australia map (lat/lng projected, no external tiles), search, org digital-twin rollup.

## Provenance / governance
Every figure carries `epistemic_status`/`provenance`; GYG valuation inputs are public FY25 figures; foot traffic is explicitly modeled and labeled; `investment_advice` is a hard engine non-goal throughout.

## Depends on
SocioProphet/economic-prophet#28 (multi-period engine + GYG profile).

## Test notes
Vue build green; BFF endpoints + engine recompute + map projection verified live end-to-end (no browser in the build env — verified via API + render-logic execution).