### PR TITLE
fix(workspace): deploy real Dovecot/Postfix stack via kustomize, retire hollow Helm stub

### DIFF
--- a/deploy/argocd/workspace-services.yaml
+++ b/deploy/argocd/workspace-services.yaml
@@ -1,6 +1,19 @@
-# Argo CD ApplicationSet — prophet-workspace services (mail / calendar / smtp).
-# prophet-workspace owns the product semantics + contracts; the deployment
-# topology lives here in prophet-platform (per the prophet-workspace README).
+# Argo CD ApplicationSet — prophet-workspace services (Dovecot mail + SMTP + CalDAV, on MinIO storage).
+#
+# prophet-workspace owns the product semantics + capability contracts; the runtime deployment topology
+# lives here in prophet-platform (per the prophet-workspace README / office-plane.md).
+#
+# These are STATEFUL, multi-manifest components — Dovecot IMAP with SQL passdb/userdb auth, a co-located
+# SMTP submission service (workspace-mail/base/deployment-smtp.yaml), and a MinIO object store with its own
+# PVC + backup CronJob + NetworkPolicy. They therefore deploy via KUSTOMIZE (infra/k8s/workspace-*/overlays),
+# the house convention for stateful/infra components — NOT the reusable stateless-service Helm chart
+# (charts/socioprophet-service) that platform-services.yaml uses for build-pipeline-imaged API/gateway/web.
+# Service source + full manifests live at services/workspace-*/ and infra/k8s/workspace-*/, and this set is
+# the source of truth validated by tools/validate_workspace_services.py.
+#
+# Sync-waves mirror infra/k8s/argo-cd/appsets/socioprophet-appset.yaml: storage (wave 0) becomes Healthy
+# before the mail + calendar surfaces (wave 2) that depend on it. SMTP ships inside the workspace-mail
+# overlay, so there is no separate workspace-smtp element.
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
@@ -12,30 +25,25 @@ spec:
   generators:
     - list:
         elements:
-          - { name: workspace-caldav }
-          - { name: workspace-mail }
-          - { name: workspace-smtp }
+          - { name: workspace-minio,  path: infra/k8s/workspace-minio/overlays/p0-lab,  wave: "0" }
+          - { name: workspace-mail,   path: infra/k8s/workspace-mail/overlays/p0-lab,   wave: "2" }
+          - { name: workspace-caldav, path: infra/k8s/workspace-caldav/overlays/p0-lab, wave: "2" }
   template:
     metadata:
       name: 'ws-{{.name}}'
       labels:
         app.kubernetes.io/part-of: prophet-workspace
+      annotations:
+        argocd.argoproj.io/sync-wave: '{{.wave}}'
     spec:
       project: default
-      sources:
-        - repoURL: https://github.com/SocioProphet/prophet-platform
-          targetRevision: main
-          ref: values
-        - repoURL: https://github.com/SocioProphet/prophet-platform
-          targetRevision: main
-          path: charts/socioprophet-service
-          helm:
-            releaseName: '{{.name}}'
-            valueFiles:
-              - '$values/deploy/values/{{.name}}.yaml'
       destination:
         server: https://kubernetes.default.svc
-        namespace: workspace
+        namespace: socioprophet
+      source:
+        repoURL: https://github.com/SocioProphet/prophet-platform
+        targetRevision: main
+        path: '{{.path}}'
       syncPolicy:
         automated: { prune: true, selfHeal: true }
         syncOptions:

--- a/deploy/values/workspace-caldav.yaml
+++ b/deploy/values/workspace-caldav.yaml
@@ -1,4 +1,0 @@
-# workspace-caldav — calendar/contacts (CalDAV/CardDAV)
-image: { repository: workspace-caldav, tag: latest }
-service: { port: 8080, portName: http }
-config: { WORKSPACE_SURFACE: caldav }

--- a/deploy/values/workspace-mail.yaml
+++ b/deploy/values/workspace-mail.yaml
@@ -1,5 +1,0 @@
-# workspace-mail — IMAP mail store
-image: { repository: workspace-mail, tag: latest }
-service: { port: 143, portName: imap }
-probes: { enabled: true, httpGet: false }
-config: { WORKSPACE_SURFACE: mail }

--- a/deploy/values/workspace-smtp.yaml
+++ b/deploy/values/workspace-smtp.yaml
@@ -1,5 +1,0 @@
-# workspace-smtp — SMTP submission
-image: { repository: workspace-smtp, tag: latest }
-service: { port: 587, portName: submission, extraPorts: [{ name: smtp, port: 25 }] }
-probes: { enabled: true, httpGet: false }
-config: { WORKSPACE_SURFACE: smtp }


### PR DESCRIPTION
## Problem
The live ArgoCD root is `deploy/argocd/` (OpenTofu `gitops_path`). Its `workspace-services.yaml` was a **hollow Helm ApplicationSet** — `workspace-{mail,smtp,caldav}` rendered the reusable stateless-service chart against **placeholder images** (`workspace-mail:latest`) that don't exist, so the workspace never stood up. The **real, validator-blessed** implementation — Dovecot IMAP + SQL auth, Postfix SMTP, MinIO store, with PVC/backup/NetworkPolicy — lives in **kustomize** under `infra/k8s/workspace-*/` and was orphaned from the live root.

## Fix — standardize on the house convention
Stateful/multi-manifest components deploy via **kustomize** (`infra/k8s`); the reusable Helm chart stays for stateless build-pipeline services (`platform-services.yaml`, untouched). This:
- Rewrites `deploy/argocd/workspace-services.yaml` as a **kustomize** ApplicationSet pointing at the three workspace overlays, with the same sync-waves as `socioprophet-appset.yaml` (storage wave 0 → mail/caldav wave 2). SMTP ships inside the `workspace-mail` overlay, so there's no separate `workspace-smtp` element.
- Removes the orphaned `deploy/values/workspace-{mail,smtp,caldav}.yaml`.

## Validation
- `tools/validate_workspace_services.py` → **88/88**
- `tools/check_repo_drift.py` → OK
- `kubectl kustomize` renders all three overlays (mail = Dovecot + Postfix, 9 manifests).

## Follow-ups (not in this PR)
- Build/push `workspace-{mail,smtp,caldav}:dev` via `workspace-services-image.yml` — until then those pods `ImagePullBackOff` (MinIO uses upstream `minio/minio`).
- `socioprophet.cloud` DNS (remove Namecheap parking) + ManagedCertificate, after the stack has an ingress IP.
- Separate/known drift: `api`/`gateway`/`socioprophet-web` are declared in **both** the Helm `platform-services` and the kustomize `socioprophet-appset` — its own decision, deliberately out of scope here.