### PR TITLE
ci(workspace): on-demand image builds + fix caldav GHCR login

### DIFF
--- a/.github/workflows/workspace-services-image.yml
+++ b/.github/workflows/workspace-services-image.yml
@@ -1,5 +1,7 @@
 name: workspace-services-image
 on:
+  # On-demand rebuild (first-time image bootstrap, or rebuild without a services/ change).
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -37,7 +39,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: services/workspace-mail
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
           tags: |
             ${{ env.IMAGE_PREFIX }}/workspace-mail:dev
             ${{ env.IMAGE_PREFIX }}/workspace-mail:${{ github.sha }}
@@ -63,7 +65,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: services/workspace-smtp
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
           tags: |
             ${{ env.IMAGE_PREFIX }}/workspace-smtp:dev
             ${{ env.IMAGE_PREFIX }}/workspace-smtp:${{ github.sha }}
@@ -81,7 +83,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -89,7 +91,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: services/workspace-caldav
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
           tags: |
             ${{ env.IMAGE_PREFIX }}/workspace-caldav:dev
             ${{ env.IMAGE_PREFIX }}/workspace-caldav:${{ github.sha }}


### PR DESCRIPTION
## Why
The workspace image workflow only fired on `services/workspace-*` path changes, so the `:dev` images could never be built for a **first-time bootstrap**. They're absent from GHCR, which is why `workspace-mail/smtp/caldav` are in `ImagePullBackOff` now that the kustomize workspace stack is live (PR #719).

## Changes
- **Add `workflow_dispatch`** so the images can be built on demand.
- **Extend each build job's push gate** to also push on a `workflow_dispatch` run on `main` (was `github.event_name == 'push'` only — a dispatch would build but never push).
- **Fix `build-workspace-caldav` GHCR login** — `username` was `${{ secrets.GITHUB_TOKEN }}` (copy-paste bug that would fail auth); corrected to `${{ github.actor }}`.

After merge I'll dispatch this workflow on `main` to build + push `workspace-{mail,smtp,caldav}:dev`, and the pending pods will pull and go Ready.