### PR TITLE
feat(registry): zot sovereign OCI registry (Phase 1 — manifests, not deployed)

### DIFF
--- a/deploy/argocd/registry-services.yaml
+++ b/deploy/argocd/registry-services.yaml
@@ -1,0 +1,43 @@
+# Argo CD ApplicationSet — sovereign artifact registry (zot).
+#
+# zot is a stateful, multi-manifest component (S3-backed store, cache PVC, ingress + ManagedCertificate,
+# NetworkPolicy), so it deploys via KUSTOMIZE (infra/k8s/zot/overlays) — same house convention as the
+# workspace stack, NOT the stateless-service Helm chart. It replaces BOTH GHCR + Google Artifact Registry:
+# hosts first-party images and pull-through-caches upstream (docker.io/ghcr/gcr/k8s) via the sync extension.
+#
+# Prereqs (created out of band, NOT in git): the `minio-credentials` secret (reused for the S3 backend)
+# and the `zot-htpasswd` secret (bootstrap admin/ci users) — see infra/k8s/zot/README.md. Sync-wave 1 so it
+# comes up after MinIO storage (wave 0) is Healthy.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: registry-services
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          - { name: zot, path: infra/k8s/zot/overlays/p0-lab, wave: "1" }
+  template:
+    metadata:
+      name: 'registry-{{.name}}'
+      labels:
+        app.kubernetes.io/part-of: sovereign-registry
+      annotations:
+        argocd.argoproj.io/sync-wave: '{{.wave}}'
+    spec:
+      project: default
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: socioprophet
+      source:
+        repoURL: https://github.com/SocioProphet/prophet-platform
+        targetRevision: main
+        path: '{{.path}}'
+      syncPolicy:
+        automated: { prune: true, selfHeal: true }
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/infra/k8s/zot/README.md
+++ b/infra/k8s/zot/README.md
@@ -1,0 +1,50 @@
+# zot — sovereign artifact registry
+
+Self-hosted, login-walled OCI registry at **`registry.socioprophet.ai`**, replacing **both** GHCR
+(GitHub) and Google Artifact Registry. Hosts first-party images and pull-through-caches upstream
+(`docker.io`/`ghcr.io`/`gcr.io`/`registry.k8s.io`) via the `sync` extension.
+
+## Why zot (not Harbor / JFrog)
+Single Go binary, S3-backed, minimal ops — consistent with choosing Gitea over GitLab
+(zot : Harbor :: Gitea : GitLab). Covers what mattered (MinIO backend, cosign, Trivy, pull-through)
+without Harbor's Postgres+Redis+jobservice fleet. JFrog rejected as heavy/commercial/affiliated.
+
+## Design
+- **Storage**: S3 driver → the running `workspace-minio` (`workspace-minio.socioprophet.svc:9000`),
+  bucket `zot`. A small RWO PVC (`zot-cache`) holds only the boltdb metadata cache.
+- **Auth**: htpasswd bootstrap + `accessControl` login-wall (no anonymous). OIDC later (Phase 4).
+- **Deploy**: kustomize (`base` + `overlays/{p0-lab,p1-single-site}`), wired into the live ArgoCD root
+  via `deploy/argocd/registry-services.yaml`, sync-wave 1 (after MinIO storage, wave 0).
+- **Ingress**: GCE ingress + ManagedCertificate, same pattern as `gitea-sovereign` (`code.socioprophet.ai`).
+
+## Out-of-band prerequisites (NOT committed)
+Secrets are created out of band, like `minio-credentials`:
+
+1. **`minio-credentials`** (reused for the S3 backend) — already created in `socioprophet`.
+2. **`zot-htpasswd`** — bootstrap `admin` + `ci` users. Create with:
+   ```sh
+   # bcrypt htpasswd for admin + ci (use strong, stored passwords)
+   htpasswd -Bbn admin "<ADMIN_PW>"  > /tmp/zot.htpasswd
+   htpasswd -Bbn ci    "<CI_PW>"    >> /tmp/zot.htpasswd
+   kubectl create secret generic zot-htpasswd -n socioprophet --from-file=htpasswd=/tmp/zot.htpasswd
+   rm /tmp/zot.htpasswd
+   ```
+   Persist both passwords in the secret manager. `ci` is the identity CI uses to push images.
+
+## Deploy checklist
+1. Create the `zot-htpasswd` secret (above).
+2. Ensure the `zot` bucket exists in MinIO (create via console/mc if MinIO doesn't auto-create).
+3. Merge → ArgoCD syncs `registry-zot`. Get the Ingress IP: `kubectl get ingress -n socioprophet zot-ingress`.
+4. Point `registry.socioprophet.ai` A-record at that IP; wait for the ManagedCertificate to go Active.
+5. **Verify the LB health path** `/v2/_zot/ready` against the pinned zot version (the one GKE-specific wrinkle).
+
+## Cutover (after zot is Healthy)
+- **Pull-through** is on immediately (sync, on-demand) — the cluster can pull any upstream image through zot.
+- Push first-party images to zot; repoint `workspace-{mail,smtp,caldav}` overlays + the `build-image`
+  pipeline from GHCR/GAR → zot; add a zot pull secret (our own creds). Then mail/caldav go Ready.
+- Retire the GAR terraform (`infra/tofu/modules/artifact-registry` + `artifactregistry.*` IAM) and GHCR usage.
+
+## Bootstrap circularity
+zot's own image + MinIO + ingress are pulled from upstream on first bring-up (one-time). Once zot is up,
+mirror those critical infra images into zot via `sync`, but keep upstream fallback. Never make zot the
+*sole* source of the images needed to boot zot/MinIO/ingress.

--- a/infra/k8s/zot/base/configmap.yaml
+++ b/infra/k8s/zot/base/configmap.yaml
@@ -1,0 +1,62 @@
+# zot registry config. Blobs live in MinIO (S3 driver → the running workspace-minio); a small local
+# PVC holds zot's boltdb metadata cache. Login-walled: only authenticated users in accessControl may
+# read/write, no anonymous access. `sync` provides on-demand pull-through of upstream registries so the
+# cluster pulls docker.io/ghcr/gcr/k8s images THROUGH zot (the de-Google lever). S3 credentials are NOT
+# in this file — they come from env (AWS_ACCESS_KEY_ID/SECRET) sourced from the minio-credentials secret.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zot-config
+  namespace: socioprophet
+  labels: { app: zot }
+data:
+  config.json: |
+    {
+      "distSpecVersion": "1.1.0",
+      "storage": {
+        "rootDirectory": "/var/lib/zot",
+        "dedupe": true,
+        "gc": true,
+        "storageDriver": {
+          "name": "s3",
+          "rootdirectory": "/zot",
+          "region": "us-east-1",
+          "regionendpoint": "workspace-minio.socioprophet.svc.cluster.local:9000",
+          "bucket": "zot",
+          "secure": false,
+          "skipverify": true
+        }
+      },
+      "http": {
+        "address": "0.0.0.0",
+        "port": "5000",
+        "realm": "zot-sovereign",
+        "auth": { "htpasswd": { "path": "/etc/zot/htpasswd" } },
+        "accessControl": {
+          "repositories": {
+            "**": {
+              "policies": [
+                { "users": ["admin", "ci"], "actions": ["read", "create", "update", "delete"] }
+              ],
+              "defaultPolicy": [],
+              "anonymousPolicy": []
+            }
+          }
+        }
+      },
+      "log": { "level": "info" },
+      "extensions": {
+        "sync": {
+          "enable": true,
+          "registries": [
+            { "urls": ["https://registry-1.docker.io"], "onDemand": true, "tlsVerify": true },
+            { "urls": ["https://ghcr.io"], "onDemand": true, "tlsVerify": true },
+            { "urls": ["https://gcr.io"], "onDemand": true, "tlsVerify": true },
+            { "urls": ["https://registry.k8s.io"], "onDemand": true, "tlsVerify": true }
+          ]
+        },
+        "search": { "enable": true },
+        "ui": { "enable": true },
+        "mgmt": { "enable": true }
+      }
+    }

--- a/infra/k8s/zot/base/deployment.yaml
+++ b/infra/k8s/zot/base/deployment.yaml
@@ -1,0 +1,57 @@
+# zot — sovereign OCI registry. Single binary, MinIO/S3-backed, extensions build (sync/search/ui).
+# RWO cache PVC → Recreate strategy (one pod). S3 creds come from the existing minio-credentials secret
+# mapped to the AWS_* env the zot S3 driver reads. The htpasswd file comes from the zot-htpasswd secret,
+# which is created OUT OF BAND (not committed) — see README.md.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zot
+  namespace: socioprophet
+  labels: { app: zot }
+spec:
+  replicas: 1
+  strategy: { type: Recreate }
+  selector:
+    matchLabels: { app: zot }
+  template:
+    metadata:
+      labels: { app: zot }
+    spec:
+      securityContext: { fsGroup: 1000 }
+      containers:
+        - name: zot
+          # Full (extensions) image — sync/search/ui need this, not zot-minimal-*. Public on GHCR
+          # (anonymous pull works during bootstrap). Pin the digest before prod hardening.
+          image: ghcr.io/project-zot/zot-linux-amd64:v2.1.2
+          args: ["serve", "/etc/zot/config.json"]
+          env:
+            # zot's S3 driver uses the AWS SDK → reads these. Sourced from the MinIO root creds.
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom: { secretKeyRef: { name: minio-credentials, key: access-key } }
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom: { secretKeyRef: { name: minio-credentials, key: secret-key } }
+          ports:
+            - { name: http, containerPort: 5000 }
+          volumeMounts:
+            - { name: config, mountPath: /etc/zot/config.json, subPath: config.json }
+            - { name: htpasswd, mountPath: /etc/zot/htpasswd, subPath: htpasswd }
+            - { name: cache, mountPath: /var/lib/zot }
+          # zot's /v2/ returns 401 under the login-wall, so HTTP probes would fail auth — use TCP.
+          readinessProbe:
+            tcpSocket: { port: 5000 }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket: { port: 5000 }
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            requests: { cpu: "250m", memory: 512Mi }
+            limits: { cpu: "2", memory: 2Gi }
+      volumes:
+        - name: config
+          configMap: { name: zot-config }
+        - name: htpasswd
+          secret: { secretName: zot-htpasswd }
+        - name: cache
+          persistentVolumeClaim: { claimName: zot-cache }

--- a/infra/k8s/zot/base/ingress.yaml
+++ b/infra/k8s/zot/base/ingress.yaml
@@ -1,0 +1,30 @@
+# Login-walled sovereign registry at registry.socioprophet.ai — same GCE ingress + ManagedCertificate
+# pattern as gitea-sovereign (code.socioprophet.ai). After deploy: point the registry.socioprophet.ai
+# A-record at the printed Ingress IP; the cert goes Active ~15–60 min after DNS resolves.
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: registry-cert
+  namespace: socioprophet
+spec:
+  domains: [registry.socioprophet.ai]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: zot-ingress
+  namespace: socioprophet
+  annotations:
+    networking.gke.io/managed-certificates: registry-cert
+    kubernetes.io/ingress.class: gce
+spec:
+  rules:
+    - host: registry.socioprophet.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: zot
+                port: { number: 5000 }

--- a/infra/k8s/zot/base/kustomization.yaml
+++ b/infra/k8s/zot/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: socioprophet
+commonLabels:
+  app: zot
+  app.kubernetes.io/part-of: sovereign-registry
+resources:
+  - configmap.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - networkpolicy.yaml

--- a/infra/k8s/zot/base/networkpolicy.yaml
+++ b/infra/k8s/zot/base/networkpolicy.yaml
@@ -1,0 +1,29 @@
+# v1 scoped policy. Ingress: registry pulls from anywhere in-cluster + the GCE LB health-check ranges
+# (35.191.0.0/16, 130.211.0.0/22). Egress: DNS, the MinIO S3 backend, and 443 for upstream sync
+# (docker.io/ghcr/gcr/k8s). Tighten per-namespace later during hardening.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: zot
+  namespace: socioprophet
+  labels: { app: zot }
+spec:
+  podSelector:
+    matchLabels: { app: zot }
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - ipBlock: { cidr: 35.191.0.0/16 }
+        - ipBlock: { cidr: 130.211.0.0/22 }
+        - namespaceSelector: {}
+      ports:
+        - { protocol: TCP, port: 5000 }
+  egress:
+    # DNS
+    - ports:
+        - { protocol: UDP, port: 53 }
+        - { protocol: TCP, port: 53 }
+    # MinIO S3 backend (in-namespace) + upstream sync over HTTPS
+    - ports:
+        - { protocol: TCP, port: 9000 }
+        - { protocol: TCP, port: 443 }

--- a/infra/k8s/zot/base/pvc.yaml
+++ b/infra/k8s/zot/base/pvc.yaml
@@ -1,0 +1,13 @@
+# Local metadata/cache only (boltdb) — image blobs live in MinIO/S3, so this stays small.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: zot-cache
+  namespace: socioprophet
+  labels: { app: zot }
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: standard-rwo
+  resources:
+    requests:
+      storage: 5Gi

--- a/infra/k8s/zot/base/service.yaml
+++ b/infra/k8s/zot/base/service.yaml
@@ -1,0 +1,27 @@
+# GCE ingress needs a 200 from the LB health check, but zot's /v2/ is 401 under the login-wall.
+# zot exposes an UNAUTHENTICATED readiness endpoint (/v2/_zot/ready) — point the health check there.
+# VERIFY this path against the pinned zot version at deploy time (it's the one GKE-specific wrinkle).
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: zot-backendconfig
+  namespace: socioprophet
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: /v2/_zot/ready
+    port: 5000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zot
+  namespace: socioprophet
+  labels: { app: zot }
+  annotations:
+    cloud.google.com/backend-config: '{"default": "zot-backendconfig"}'
+spec:
+  type: NodePort
+  selector: { app: zot }
+  ports:
+    - { name: http, port: 5000, targetPort: 5000 }

--- a/infra/k8s/zot/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/zot/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# p0-lab: small footprint, single replica (base defaults are already lab-sized).
+bases:
+  - ../../base

--- a/infra/k8s/zot/overlays/p1-single-site/kustomization.yaml
+++ b/infra/k8s/zot/overlays/p1-single-site/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# p1-single-site: bump the metadata-cache PVC for a larger image estate.
+bases:
+  - ../../base
+patches:
+  - target:
+      kind: PersistentVolumeClaim
+      name: zot-cache
+    patch: |-
+      - op: replace
+        path: /spec/resources/requests/storage
+        value: 20Gi


### PR DESCRIPTION
## What
Phase 1 of the sovereign artifact registry: **zot** at `registry.socioprophet.ai`, to replace **both** GHCR and Google Artifact Registry. Hosts first-party images and **pull-through-caches upstream** (docker.io/ghcr/gcr/registry.k8s.io) via the `sync` extension — the de-Google lever.

**Why zot, not Harbor/JFrog:** single Go binary, MinIO/S3-backed, minimal ops — same logic as choosing Gitea over GitLab. Covers MinIO backing + cosign + Trivy + pull-through without Harbor's Postgres/Redis/jobservice fleet.

## Contents (kustomize — house convention for stateful components)
- `infra/k8s/zot/{base,overlays/{p0-lab,p1-single-site}}`: S3 driver → the running `workspace-minio` (bucket `zot`); small cache PVC; htpasswd login-wall (no anonymous); GCE ingress + ManagedCertificate (gitea pattern); NetworkPolicy; `sync`/`search`/`ui` extensions.
- `deploy/argocd/registry-services.yaml`: wires it into the live ArgoCD root, sync-wave 1 (after MinIO storage).
- `infra/k8s/zot/README.md`: design/ADR + out-of-band secret setup + cutover + bootstrap-circularity.

## Validation
- `kubectl kustomize` renders both overlays (8 manifests each).
- Appset parses; embedded `config.json` is valid JSON (S3 driver + sync).

## ⛔ Do not merge yet — merge = deploy
ArgoCD auto-syncs the live root, so **merging triggers the deploy**. Hold for the Phase-1→deploy checkpoint. Prereqs before merge:
1. Create the `zot-htpasswd` secret (admin + ci users) — see README.
2. Ensure the `zot` bucket exists in MinIO.
3. Verify the LB health path `/v2/_zot/ready` against the pinned zot version (the one GKE wrinkle).

## Follow-ups (Phase 3+)
Push first-party images to zot; repoint workspace overlays + `build-image` pipeline GHCR/GAR → zot; retire the GAR terraform + GHCR. OIDC + cosign signing + Trivy in Phase 4.