### PR TITLE
fix(registry): zot dedupe=false for S3 (fixes crashloop)

### DIFF
--- a/infra/k8s/zot/base/configmap.yaml
+++ b/infra/k8s/zot/base/configmap.yaml
@@ -15,7 +15,7 @@ data:
       "distSpecVersion": "1.1.0",
       "storage": {
         "rootDirectory": "/var/lib/zot",
-        "dedupe": true,
+        "dedupe": false,
         "gc": true,
         "storageDriver": {
           "name": "s3",


### PR DESCRIPTION
zot crashlooped on boot: `dedupe set to true with remote storage and database, but no remote database configured`. With the S3/MinIO storage driver, `dedupe: true` needs a remote cache DB (DynamoDB) we don't run. Set `dedupe: false` → zot uses its local boltdb cache on the PVC. Unblocks the zot deploy from #721. Validated: config.json valid, overlay renders.