### PR TITLE
fix(registry): zot sync.downloadDir for S3 (fixes crashloop)

### DIFF
--- a/infra/k8s/zot/base/configmap.yaml
+++ b/infra/k8s/zot/base/configmap.yaml
@@ -48,6 +48,7 @@ data:
       "extensions": {
         "sync": {
           "enable": true,
+          "downloadDir": "/var/lib/zot/sync",
           "registries": [
             { "urls": ["https://registry-1.docker.io"], "onDemand": true, "tlsVerify": true },
             { "urls": ["https://ghcr.io"], "onDemand": true, "tlsVerify": true },


### PR DESCRIPTION
Second S3 config requirement after dedupe: zot won't start with `using both sync and remote storage features needs config.Extensions.Sync.DownloadDir`. Adds `extensions.sync.downloadDir: /var/lib/zot/sync` (on the PVC). Config-only. Note: ArgoCD selfHeal enforces this ConfigMap from Git, so the fix must land here (direct kubectl edits get reverted).