### PR TITLE
fix(argocd): ignore resource .status to survive k8s 1.35 schema gap

### DIFF
--- a/infra/tofu/environments/gcp-gke/argocd.tf
+++ b/infra/tofu/environments/gcp-gke/argocd.tf
@@ -28,6 +28,20 @@ resource "helm_release" "argocd" {
     name  = "crds.keep"
     value = "true"
   }
+
+  # ArgoCD 2.13.1's bundled OpenAPI schema predates Kubernetes 1.35's
+  # Deployment.status.terminatingReplicas field, so its structured-merge (server-side-apply)
+  # diff fails to build a typed value from live Deployments — "field not declared in schema" —
+  # and silently stops syncing every app with a Deployment. Ignoring the (non-desired-state)
+  # .status field on all resources sidesteps it cluster-wide. Proper long-term fix: upgrade
+  # ArgoCD to a build whose schema knows this field (tracked separately).
+  values = [yamlencode({
+    configs = {
+      cm = {
+        "resource.compareoptions" = "ignoreResourceStatusField: all\n"
+      }
+    }
+  })]
 }
 
 # Root app-of-apps: Argo watches deploy/argocd and applies the ApplicationSets


### PR DESCRIPTION
## Problem
ArgoCD **v2.13.1** vs Kubernetes **v1.35.5**: ArgoCD's bundled OpenAPI schema predates k8s 1.35's `Deployment.status.terminatingReplicas`, so its SSA/structured-merge diff failed to build typed Deployments (`error building typed value from live resource: .status.terminatingReplicas: field not declared in schema`) and **silently stopped syncing every app with a Deployment** — 21/26 apps stuck `Unknown` (svc-*, fog-*, ws-*, registry-zot).

## Fix
Set `configs.cm."resource.compareoptions" = "ignoreResourceStatusField: all"` — ArgoCD no longer diffs the (non-desired-state) `.status` field, sidestepping the type-building error cluster-wide.

Already applied live (`argocd-cm` patched + app-controller restarted) — **verified 0/26 apps erroring, all recovered**. This commit persists it into the tofu Helm values so a `helm upgrade` won't revert it.

## Proper long-term fix (separate task)
Upgrade ArgoCD to a build whose schema knows `terminatingReplicas` (2.13 is too old for a k8s 1.35 cluster). This `ignoreResourceStatusField` change is correct regardless (status isn't desired state), but the version gap should be closed.