### PR TITLE
fix(socioprophet-web): serve on 8080 with /healthz under non-root, read-only rootfs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Several images build with the repo root as context (see .github/workflows/images.yml),
+# so anything not excluded here is shipped to the builder for every one of them.
+#
+# node_modules must be excluded: each Dockerfile installs its own dependencies, and a
+# local install carries host-native binaries (e.g. @rollup/rollup-darwin-arm64) that
+# silently poison a linux/amd64 build. CI only avoided this by building from a clean
+# checkout — the build was never hermetic.
+**/node_modules
+
+# Build output — every image builds from source in a build stage.
+**/dist
+**/.vitepress/publish
+
+# VCS, local state, and editor noise.
+.git
+.github
+**/.DS_Store
+**/*.log
+
+# Local infra state that must never enter an image layer.
+**/tfplan
+**/.terraform
+**/*.tfstate
+**/*.tfstate.backup

--- a/apps/socioprophet-web/Dockerfile
+++ b/apps/socioprophet-web/Dockerfile
@@ -13,3 +13,12 @@ RUN pnpm build
 
 FROM nginx:1.27-alpine
 COPY --from=build /app/apps/socioprophet-web/dist /usr/share/nginx/html
+# Replaces the stock conf, which listens on 80, serves no /healthz, and writes temp
+# files outside the chart's writable mounts — see nginx.conf for the full contract.
+COPY apps/socioprophet-web/nginx.conf /etc/nginx/nginx.conf
+# The chart runs this as uid 10001 with a read-only root filesystem, so the temp dirs
+# must already exist and be owned by that uid — nginx cannot mkdir them at runtime.
+RUN mkdir -p /var/cache/nginx /var/run \
+    && chown -R 10001:10001 /var/cache/nginx /var/run /usr/share/nginx/html
+EXPOSE 8080
+USER 10001

--- a/apps/socioprophet-web/nginx.conf
+++ b/apps/socioprophet-web/nginx.conf
@@ -1,0 +1,74 @@
+# Serves the built SPA under the socioprophet-service chart contract:
+#   • listen 8080          — chart sets containerPort/Service targetPort from .Values.service.port,
+#                            and the pod runs as uid 10001, which cannot bind privileged port 80.
+#   • GET /healthz -> 200  — chart's readiness/liveness probes hit .Values.probes.path.
+#   • no `user` directive  — the master process is already non-root; the directive would only warn.
+#
+# Under readOnlyRootFilesystem the only writable paths are the chart's emptyDir mounts:
+# /tmp (tmpDir) plus writableDirs from deploy/values/socioprophet-web.yaml (/var/cache/nginx,
+# /var/run). Every path nginx writes to below must stay within those.
+
+worker_processes  auto;
+pid               /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # Log to the container's stdout/stderr so `kubectl logs` sees them.
+    access_log  /dev/stdout;
+    error_log   /dev/stderr warn;
+
+    # All temp paths must live under the writable /var/cache/nginx mount.
+    client_body_temp_path  /var/cache/nginx/client_temp;
+    proxy_temp_path        /var/cache/nginx/proxy_temp;
+    fastcgi_temp_path      /var/cache/nginx/fastcgi_temp;
+    uwsgi_temp_path        /var/cache/nginx/uwsgi_temp;
+    scgi_temp_path         /var/cache/nginx/scgi_temp;
+
+    sendfile           on;
+    tcp_nopush         on;
+    keepalive_timeout  65;
+
+    gzip              on;
+    gzip_vary         on;
+    gzip_proxied      any;
+    gzip_min_length   1024;
+    gzip_types        text/plain text/css application/javascript application/json image/svg+xml;
+
+    server {
+        listen       8080;
+        server_name  _;
+
+        root   /usr/share/nginx/html;
+        index  index.html;
+
+        # Probe endpoint. Must not depend on the SPA build, so the pod stays
+        # healthy even if index.html is missing.
+        location = /healthz {
+            access_log  off;
+            add_header  Content-Type text/plain;
+            return      200 "ok\n";
+        }
+
+        # Hashed build assets are immutable; index.html must never be cached or
+        # clients pin a stale bundle across deploys.
+        location /assets/ {
+            expires    1y;
+            add_header Cache-Control "public, immutable";
+        }
+
+        location = /index.html {
+            add_header Cache-Control "no-cache";
+        }
+
+        # SPA history-mode fallback: unknown paths render the app, not a 404.
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}


### PR DESCRIPTION
## What

`socioprophet-web` has been in **CrashLoopBackOff for 46h (551 restarts)**, and `app.socioprophet.ai` serves nothing. This fixes the cause.

## Why it was broken

The `socioprophet-service` chart defines a contract the image never met:

| Chart requires | Stock `nginx:1.27-alpine` did |
|---|---|
| listen on `.Values.service.port` = **8080** | listened on **80** |
| answer `.Values.probes.path` = **`/healthz`** | no such endpoint (404 fails the probe) |
| `runAsUser: 10001`, `readOnlyRootFilesystem` | ran as root; as non-root it can't bind port 80 at all |

The image was stock nginx with **no config at all**, so it violated all three. The kubelet's liveness probe got `connection refused` on 8080 and killed the container on a loop — nginx exited `0/Completed`, which is why it never looked like a crash.

**This was not GitOps drift.** ArgoCD reports `Synced / Degraded` — it was faithfully deploying a genuinely broken image.

## The fix

- **`apps/socioprophet-web/nginx.conf`** (new) — listens on 8080; `/healthz` returns 200 without depending on the SPA build (so a bad build can't take the pod down); all temp paths stay inside the chart's writable mounts (`/var/cache/nginx`, `/var/run` per `writableDirs`); history-mode fallback so deep links render the app instead of 404ing; `index.html` no-cache + immutable hashed assets.
- **`Dockerfile`** — copies the conf, `EXPOSE 8080`, `USER 10001` so the image matches the chart instead of relying on the pod spec to force it.
- **`.dockerignore`** (new) — several images build with the repo root as context, so a local `node_modules` was shipped to the builder and its host-native binaries (`@rollup/rollup-darwin-arm64`) broke a `linux/amd64` build. CI only avoided this by building from a clean checkout — **the build was never hermetic**. Nothing copies `node_modules`/`dist` from context and neither is tracked, so this is safe.

## Verification

Ran the built image under the chart's exact constraints (`--user 10001 --read-only --cap-drop ALL`, tmpfs at `/tmp`, `/var/cache/nginx`, `/var/run`, with mode emulating the kubelet's `fsGroup: 10001` chown):

| Check | Result |
|---|---|
| container status | `Up` — no crashloop |
| `/healthz` | **200** `ok` |
| `/` | **200** |
| `/control-plane/org` (SPA fallback) | **200**, not 404 |
| identity | `uid=10001 gid=10001`, read-only rootfs |
| startup errors | none |

## Note for the reviewer

The image built here for verification is **arm64**; the amd64 image must come from CI (`images.yml`). An emulated `linux/amd64` build on an arm64 host crashes in esbuild (`fatal error: lfstack.push`) — a known qemu/Go bug, unrelated to this change.

Runtime writability of `/var/cache/nginx` depends on the chart's `fsGroup: 10001` chowning the emptyDir, which is standard kubelet behaviour and what `writableDirs` exists for — worth confirming on the first real rollout.