### PR TITLE
feat(images): push socioprophet-web to the sovereign zot registry

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,9 +1,15 @@
 # Build every service image through the estate's reusable build-image workflow:
-# push to Artifact Registry with the immutable commit-SHA tag (what the Argo
-# ApplicationSets in deploy/argocd promote) + cosign-sign the digest.
+# push with the immutable commit-SHA tag (what the Argo ApplicationSets in
+# deploy/argocd promote) + cosign-sign the digest.
 #
 # Supersedes the per-service GHCR one-offs (socioprophet-api-image.yml etc.):
-# one matrix, one registry (GAR), one signing path.
+# one matrix, one signing path.
+#
+# REGISTRY CUTOVER (in progress): images default to Artifact Registry and move to
+# the sovereign zot registry one at a time, per entry, by setting `registry` +
+# `registry_auth: basic` in the matrix. socioprophet-web goes first — it is the
+# proof of the cutover. The end state is every entry on zot and the GAR terraform
+# (infra/tofu/modules/artifact-registry) retired; until then the two coexist.
 #
 # DEPENDS ON: SocioProphet/.github (the reusable workflow) + the GAR repo. Until
 # those exist this is intentionally not wired to PRs (push/dispatch only), so it
@@ -37,7 +43,10 @@ jobs:
           # services keep their own dir as context.
           - { image: socioprophet-api,      context: .,                         dockerfile: apps/api/Dockerfile }
           - { image: socioprophet-gateway,  context: .,                         dockerfile: apps/gateway/Dockerfile }
-          - { image: socioprophet-web,      context: .,                         dockerfile: apps/socioprophet-web/Dockerfile }
+          # First image on the sovereign registry. Chosen to go first because it is
+          # already broken in-cluster (see the nginx contract fix), so the cutover
+          # can only improve it — no working service is put at risk to prove zot.
+          - { image: socioprophet-web,      context: .,                         dockerfile: apps/socioprophet-web/Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: evidence-console,      context: apps/evidence-console,     dockerfile: Dockerfile }
           - { image: evidence-receipts,     context: apps/evidence-receipts,    dockerfile: Dockerfile }
           - { image: eval-fabric-api,       context: apps/eval-fabric-api,      dockerfile: Dockerfile }
@@ -54,6 +63,15 @@ jobs:
       image: ${{ matrix.image }}
       context: ${{ matrix.context }}
       dockerfile: ${{ matrix.dockerfile }}
+      # Per-entry overrides; entries that set neither keep the Artifact Registry
+      # default, so this cutover moves one image at a time rather than all at once.
+      registry:      ${{ matrix.registry || 'us-central1-docker.pkg.dev/socioprophet-platform/socioprophet' }}
+      registry_auth: ${{ matrix.registry_auth || 'gar' }}
+    # All four are optional in the reusable workflow, which asserts that the ones
+    # its chosen auth path needs are actually present. GAR entries ignore the zot
+    # credentials and vice versa.
     secrets:
       gcp_wif_provider:    ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       gcp_service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      registry_username:   ${{ secrets.ZOT_CI_USERNAME }}
+      registry_password:   ${{ secrets.ZOT_CI_PASSWORD }}


### PR DESCRIPTION
## Why

First image of the **GAR → zot cutover**. zot is now live, HTTPS, and login-walled at `registry.socioprophet.ai` (cert `Active`, `/v2/` → 401), so the build pipeline can finally push there.

**`socioprophet-web` goes first deliberately** — it's already broken in-cluster (nginx never met the chart's port/`/healthz` contract; 551 restarts over 46h, see #726). Pointing a broken service at a new registry can only improve it, so no working service is risked to prove the cutover.

## What

- `socioprophet-web` matrix entry gets `registry: registry.socioprophet.ai` + `registry_auth: basic`.
- Everything else keeps the Artifact Registry default via `${{ matrix.registry || '<GAR>' }}`, so **the cutover moves one image at a time** and the two registries coexist until each is moved deliberately.
- zot credentials are passed for every entry but only consumed by basic-auth ones.

| | |
|---|---|
| matrix entries | 14 |
| moved to zot | **1** (`socioprophet-web`) |
| unchanged on GAR | 13 |

## Scope: push side only

The cluster still **pulls** `socioprophet-web` from GAR. The chart defaults `image.registry` to GAR and the namespace has **no dockerconfigjson secret**, so repointing `deploy/values/socioprophet-web.yaml` before the image exists in zot would just trade a crashloop for an `ImagePullBackOff`. That repoint + the `zot-pull` secret is the follow-up, once this has pushed at least once.

## ⚠️ Merge order — this will go red otherwise

1. **[SocioProphet/.github#1](https://github.com/SocioProphet/.github/pull/1)** must merge first. It adds `registry_auth`; without it this passes an input the reusable workflow doesn't accept.
2. **`ZOT_CI_USERNAME` / `ZOT_CI_PASSWORD` must exist** as prophet-platform repo secrets (the `ci` user from the `zot-htpasswd` secret). Neither exists yet. Without them the assert step fails fast and loud by design — a clear error, but red.
3. Then merge this. Ideally alongside **#726**, so the first image zot ever serves is a working one.

## A tension worth naming

This pushes to the sovereign registry **from GitHub Actions** — the platform the estate is migrating off, and it means zot push credentials live in GitHub secrets. That's acceptable as an interim (it's the only pipeline that exists today), but the end state should be Gitea Actions or Cloud Build doing this push, so the sovereign registry doesn't depend on GitHub for its supply chain. Worth tracking as part of the SCM migration rather than silently inheriting.