### PR TITLE
fix(socioprophet-web): pin the immutable SHA tag so the fix actually rolls out

### DIFF
--- a/deploy/values/socioprophet-web.yaml
+++ b/deploy/values/socioprophet-web.yaml
@@ -1,5 +1,13 @@
 # socioprophet-web — web portal
-image: { repository: socioprophet-web, tag: latest }
+# Pin the immutable commit-SHA tag, per the chart's own contract ("Immutable tag =
+# the commit SHA the GitOps promotion writes"). `latest` is a MOVING tag and the
+# chart sets imagePullPolicy: IfNotPresent — so once a node has cached `latest`,
+# kubelet never pulls a newer one, and even `rollout restart` re-runs the stale
+# image. That is how a broken build survived 574 restarts over 2 days: the fix was
+# published to `latest` in GAR and the nodes kept serving the cached digest.
+# sha-2ff20cbd... = merge of #726 (nginx port/healthz contract fix),
+# digest sha256:50ef50bf14fb64f0eca84ac393bf0124c72840499ed1a0e5daa82182c45d71bf.
+image: { repository: socioprophet-web, tag: sha-2ff20cbd5d4d2571f00e7abb1952835fa22f59bd }
 service: { port: 8080, portName: http }
 ingress:
   enabled: true


### PR DESCRIPTION
## Why the crashloop survived the fix

#726 fixed the image. CI built and published it. **The pods kept crashlooping anyway.**

```
running digest : sha256:965dbe77b4ea...   ← old, broken
:latest in GAR : sha256:50ef50bf14fb...   ← new, fixed
kubelet event  : "image :latest already present on machine"
```

`latest` is a **moving tag** and the chart sets `imagePullPolicy: IfNotPresent`. Once a node has cached `latest`, kubelet **never pulls a newer one**. `rollout restart` doesn't help either — it re-creates pods against the same cached digest. I tried exactly that, and it restarted straight back into the broken image.

**This is the mechanism that let a broken build survive 574 restarts over two days.** The tag looked current; the bytes on the node weren't.

## The fix

Pin `image.tag` to `sha-2ff20cbd5d4d2571f00e7abb1952835fa22f59bd` — the merge commit of #726.

This is not a workaround; it's what the chart already prescribes. `charts/socioprophet-service/values.yaml` says verbatim:

> `# Immutable tag = the commit SHA the GitOps promotion writes.`

An immutable tag is a **new image reference**, so kubelet pulls it even under `IfNotPresent`. It also makes the deployed version auditable from Git instead of dependent on node cache state.

## Verification

```
pinned tag  : sha-2ff20cbd5d4d2571f00e7abb1952835fa22f59bd
resolves to : sha256:50ef50bf14fb64f0eca84ac393bf0124c72840499ed1a0e5daa82182c45d71bf   ← the fixed build
old (broken): sha256:965dbe77b4ea...                                                    ← not this
MATCH -> PASS
```

## Follow-up worth considering (not in this PR)

The other 13 services in `deploy/values/` almost certainly have the same `tag: latest` + `IfNotPresent` combination, which means **any of them could be silently serving a stale cached image right now** — the failure is invisible unless the stale image happens to crash. Worth a sweep to pin them all to SHA tags, which is what the GitOps promotion is supposed to write anyway.