### PR TITLE
fix(zot): grant github-ci push rights so the CI cutover can actually push

### DIFF
--- a/infra/k8s/zot/base/configmap.yaml
+++ b/infra/k8s/zot/base/configmap.yaml
@@ -36,7 +36,7 @@ data:
           "repositories": {
             "**": {
               "policies": [
-                { "users": ["admin", "ci"], "actions": ["read", "create", "update", "delete"] }
+                { "users": ["admin", "ci", "github-ci"], "actions": ["read", "create", "update", "delete"] }
               ],
               "defaultPolicy": [],
               "anonymousPolicy": []


### PR DESCRIPTION
## Why

#727 merged and **its build failed**:

```
failed to push registry.socioprophet.ai/socioprophet-web:latest
  HEAD /v2/socioprophet-web/blobs/sha256:9b14...: 403 Forbidden
```

**403, not 401.** So `registry_auth: basic` was accepted and `docker login` *succeeded* — this is an **authorization** failure, not authentication.

The `github-ci` user was added to zot's **htpasswd** (authn) but never to **`accessControl.policies`** (authz). `defaultPolicy` is `[]`, so it inherits nothing. It could authenticate and read, but never write.

## My verification gap

I tested `GET /v2/` and got 200, and treated that as proof the credential worked. But `/v2/` is the **version endpoint** — it needs authentication and no repo permission. Pushing a blob needs `create`/`update`, which was never granted. The green test couldn't have caught this; a blob write would have.

## The change

One line — add `github-ci` to the policy that already covers `admin` and `ci`:

```json
{ "users": ["admin", "ci", "github-ci"], "actions": ["read", "create", "update", "delete"] }
```

## The wall is unchanged

| | before | after |
|---|---|---|
| `anonymousPolicy` | `[]` | **`[]`** |
| `defaultPolicy` | `[]` | **`[]`** |
| admin / ci | read+write | **unchanged** |

This only grants the CI identity the writes it already needed. Verified by assertion: JSON parses, `github-ci` added, `admin`+`ci` preserved, anonymous still denied, both kustomize overlays render.

## After merge

ArgoCD syncs the configmap → zot reloads → re-run the `images` workflow → `socioprophet-web` pushes to zot, making it the **first first-party image in the sovereign registry**. That completes the push side of the cutover; the pull side (repoint `deploy/values` + `zot-pull` secret) stays a separate follow-up.