### PR TITLE
feat(images): build workspace-{mail,caldav,smtp} into the sovereign registry

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -53,9 +53,9 @@ jobs:
           - { image: agentic-os-api,        context: apps/agentic-os-api,       dockerfile: Dockerfile }
           - { image: hellgraph-service,     context: apps/hellgraph-service,    dockerfile: Dockerfile }
           - { image: osm-map-api,           context: .,                         dockerfile: apps/osm-map-api/Dockerfile }
-          - { image: workspace-mail,        context: services/workspace-mail,   dockerfile: Dockerfile }
-          - { image: workspace-caldav,      context: services/workspace-caldav, dockerfile: Dockerfile }
-          - { image: workspace-smtp,        context: services/workspace-smtp,   dockerfile: Dockerfile }
+          - { image: workspace-mail,        context: services/workspace-mail,   dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
+          - { image: workspace-caldav,      context: services/workspace-caldav, dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
+          - { image: workspace-smtp,        context: services/workspace-smtp,   dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: search-orchestrator,   context: .,                         dockerfile: services/search-orchestrator/Dockerfile }
           - { image: regis-acr-api,         context: apps/regis-acr-api,        dockerfile: Dockerfile }
     uses: SocioProphet/.github/.github/workflows/build-image.yml@main


### PR DESCRIPTION
## The actual bug

`workspace-mail`, `workspace-caldav` and `workspace-smtp` have been in **ImagePullBackOff for ~6 hours**. It was never a credentials problem:

| Image | CI builds to **GAR** | Pods pull from **GHCR** |
|---|---|---|
| workspace-mail | ✅ `latest`, `sha-…` | ❌ **403** |
| workspace-caldav | ✅ `latest`, `sha-…` | ❌ **403** |
| workspace-smtp | ✅ `latest`, `sha-…` | ❌ **403** |

CI has been building these to Artifact Registry while the deployments point at `ghcr.io/socioprophet/prophet-platform/workspace-*:dev` — **a registry they were never published to**. Adding a GHCR pull secret would not have fixed it; there was nothing there to pull.

## What this does

Points the three builds at **zot**, which fixes the mismatch *and* moves them off a hyperscaler registry in one step. `socioprophet-web` already proved the path (`registry_auth: basic` + the `github-ci` identity, cosign signature included).

| | |
|---|---|
| on zot after this | socioprophet-web, workspace-mail, workspace-caldav, workspace-smtp |
| still on GAR | the other 10 |

## Scope: push side only, deliberately

The deployments still reference GHCR. They get repointed to `registry.socioprophet.ai` in a **follow-up**, pinned to the immutable `sha-` tag *this* build produces — because repointing before the images exist in zot just trades one `ImagePullBackOff` for another.

That follow-up also needs a **`zot-pull` secret** in the namespace (zot is login-walled, so kubelet needs credentials).

## Worth deciding in that follow-up

The pull secret should **not** reuse `github-ci` — that identity has `create/update/delete` on every repo. A compromised pod would hold push rights to the sovereign registry. A read-only `k8s-pull` user (htpasswd + an accessControl policy with `["read"]` only) is the right shape.