### PR TITLE
fix(values): revive gateway, osm-map-api, agentic-os-api — dead for 2+ days

### DIFF
--- a/deploy/values/agentic-os-api.yaml
+++ b/deploy/values/agentic-os-api.yaml
@@ -1,3 +1,8 @@
 # agentic-os-api
 image: { repository: agentic-os-api, tag: latest }
 service: { port: 8080, portName: http }
+# The app exposes @app.get("/health") (app/main.py:19), not the chart's default
+# /healthz — so every probe 404'd and the kubelet killed it: 939 restarts over
+# 2 days on a missing "z".
+probes:
+  path: /health

--- a/deploy/values/gateway.yaml
+++ b/deploy/values/gateway.yaml
@@ -1,6 +1,16 @@
 # socioprophet-gateway — HTTP edge gateway
 image: { repository: socioprophet-gateway, tag: latest }
 service: { port: 8080, portName: http }
+# The binary reads GATEWAY_PORT (cmd/tritrpc-gateway/main.go:30) and binds ":"+port.
+# A Service named `gateway` makes Kubernetes inject GATEWAY_PORT=tcp://<clusterIP>:8080
+# as a service link, so the app bound ":tcp://34.118.237.248:8080" and died with
+# "too many colons in address" — 590 restarts over 2 days. Same class as the
+# osm-map-api note. Disabling service links removes the collision.
+enableServiceLinks: false
+# The binary registers mux.HandleFunc("/health") (main.go:43), NOT the chart's
+# default /healthz — so probes 404'd regardless of the bind fix above.
+probes:
+  path: /health
 config:
   # DEV ONLY — provision a real TRITRPC_KEY_HEX secret for prod
   TRITRPC_ALLOW_INSECURE_DEV_KEY: "1"

--- a/deploy/values/osm-map-api.yaml
+++ b/deploy/values/osm-map-api.yaml
@@ -1,4 +1,4 @@
 # osm-map-api
 image: { repository: osm-map-api, tag: latest }
-service: { port: 8080, portName: http }
+service: { port: 8088, portName: http }  # app binds 8088 (uvicorn); chart uses this for containerPort + probes
 enableServiceLinks: false   # k8s injects OSM_MAP_API_PORT=tcp://<svc> otherwise → app int() crash


### PR DESCRIPTION
## CI is green. The cluster is not.

Three services have been in **CrashLoopBackOff since 2026-07-13**:

| Service | Restarts | Age |
|---|---|---|
| `agentic-os-api` | **939** | 2d2h |
| `osm-map-api` | **940** | 2d2h |
| `gateway` | **590** | 2d2h |

Every workflow on `main` passes. **Nothing in CI checks that the chart contract matches what each app actually does**, so these failed silently for two days behind a green pipeline. Three *different* root causes — all one-liners.

---

### 1. `gateway` — it was poisoning itself with its own Service

```go
port := getenv("GATEWAY_PORT", "8080")        // main.go:30
log.Fatal(http.ListenAndServe(":"+port, mux)) // main.go:37
```

A Service named `gateway` makes the kubelet inject the legacy service-link var **`GATEWAY_PORT=tcp://<gateway's own clusterIP>:8080`**. So it bound `":tcp://34.118.237.248:8080"`:

```
listen tcp: address :tcp://34.118.237.248:8080: too many colons in address
```

**Confirmed:** the address in the log is *byte-identical* to the `gateway` Service's clusterIP. The app's env var name collides exactly with the Kubernetes-injected one.

It **also** registers `/health` (main.go:43), not the chart's `/healthz` — so probes would have 404'd even after the bind was fixed. **Both fixes are required; either alone still dies.**

### 2. `osm-map-api` — port mismatch

Uvicorn binds **8088**; values declared **8080**, which the chart uses for `containerPort`, Service `targetPort` **and** both probes. Probes hit a closed port. It *does* serve `/healthz`, so the chart default is correct for it.

### 3. `agentic-os-api` — a missing "z"

`app/main.py:19` exposes `@app.get("/health")`. The chart probes `/healthz`. **939 restarts over one character.**

---

## Why disabling service links is safe

Verified nothing in `apps/` or `services/` reads `_SERVICE_HOST` or `_SERVICE_PORT` — service links are pure liability here. And `osm-map-api` **already carried this exact workaround** with a comment describing the identical failure:

```yaml
enableServiceLinks: false   # k8s injects OSM_MAP_API_PORT=tcp://<svc> otherwise → app int() crash
```

So this is a **known recurring class**, not a one-off — the fix just never propagated to `gateway`.

## ⚠️ Latent time-bomb worth knowing

`eval-fabric-api` does `int(os.getenv("CLICKHOUSE_PORT", "8123"))`. The moment a Service named `clickhouse` exists in that namespace, the kubelet injects `CLICKHOUSE_PORT=tcp://…` and that `int()` throws — the *exact* crash `osm-map-api`'s comment describes. It's fine today only because no such Service exists yet.

**Recommend a follow-up flipping the chart default to `enableServiceLinks: false`**, since 12 of 13 values files lack the workaround and this keeps biting. Kept out of this PR to hold the blast radius to the three broken services.

## Verification

Each fix was checked against the app's real behaviour, not assumed:

| | binds | serves | values now |
|---|---|---|---|
| gateway | 8080 | `/health` | port 8080, links off, probe `/health` |
| osm-map-api | **8088** | `/healthz` | port **8088**, probe default |
| agentic-os-api | 8080 | `/health` | port 8080, probe **`/health`** |