### PR TITLE
fix(gateway): point TriTRPC at the Service that actually exists (api, not socioprophet-api)

### DIFF
--- a/deploy/values/gateway.yaml
+++ b/deploy/values/gateway.yaml
@@ -12,6 +12,14 @@ enableServiceLinks: false
 probes:
   path: /health
 config:
+  # The image bakes ENV TRITRPC_TARGET_ADDR=tcp://socioprophet-api:9000
+  # (apps/gateway/Dockerfile:17), but that Service does not exist: the chart
+  # deploys the tritRPC core as `api` (deploy/values/api.yaml — socioprophet-api
+  # is only the image repository name). So every /health ping died with
+  # "lookup socioprophet-api: no such host" -> 502 -> liveness kill: 620 restarts
+  # over 2 days. Point it at the Service that actually exists (api:9000, verified
+  # reachable from the gateway pod).
+  TRITRPC_TARGET_ADDR: "tcp://api:9000"
   # DEV ONLY — provision a real TRITRPC_KEY_HEX secret for prod
   TRITRPC_ALLOW_INSECURE_DEV_KEY: "1"
 ingress:


### PR DESCRIPTION
## The bug under the bug

#731 fixed the gateway's bind crash and probe path — and revealed what was hiding beneath. It now starts cleanly (`Gateway listening on :8080`) but `/health` 502s and the kubelet keeps killing it:

```
health ping error: dial tcp: lookup socioprophet-api ... no such host
```

## Root cause

```dockerfile
apps/gateway/Dockerfile:17
ENV TRITRPC_TARGET_ADDR=tcp://socioprophet-api:9000
```

**No such Service exists.** The chart deploys the tritRPC core as **`api`** — `socioprophet-api` is only the *image repository* name in `deploy/values/api.yaml`. The Services in the namespace are:

```
api  9000/TCP      ← the real one
gateway, agentic-os-api, evidence-console, evidence-receipts, ...
```

So the image's baked default **has never resolved in this cluster**. 620 restarts over two days against a hostname that was never going to exist.

## Fix

Override in values → `TRITRPC_TARGET_ADDR: tcp://api:9000`. No rebuild needed: the chart's `config:` block renders a ConfigMap whose env overrides the image `ENV`.

**Verified reachable from inside the gateway pod before shipping** — `api:9000` answers.

## ⚠️ Architectural note — deliberately NOT fixed here

`/health` **pings the TriTRPC backend** and 502s when it's unreachable:

```go
mux.HandleFunc("/health", func(...) {
    pong, err := ping(target, key)
    if err != nil { w.WriteHeader(http.StatusBadGateway); return }
})
```

The chart wires that same endpoint to **both readiness and liveness**. **Liveness tied to a dependency means the gateway gets killed whenever its backend is down** — that's a cascading failure, not a self-heal. A dependency check belongs on *readiness* only; liveness should ask "is this process alive".

Left alone here to keep this PR to the one-line unblock, but it's the reason a single wrong hostname could produce 620 restarts instead of one degraded-but-running pod. Worth a follow-up once the estate is green.

## Sequence

This is the third distinct bug in the same service: bind crash (service-link env collision) → probe path (`/healthz` vs `/health`) → wrong target hostname. Each one was masking the next.