### PR TITLE
feat(preflight): gate the deploy contract; land the workspace zot cutover

### DIFF
--- a/.github/workflows/preflight-deploy-contract.yml
+++ b/.github/workflows/preflight-deploy-contract.yml
@@ -1,0 +1,39 @@
+# The gate that was missing on 2026-07-15, when ~9 pods crashlooped for two days
+# behind a 100% green pipeline. Everything CI checked passed; nothing checked that
+# what we DEPLOY matches what we BUILD.
+#
+# Runs on PRs (unlike images.yml, which is push/dispatch-only) because the whole
+# point is to reject the mismatch before it reaches the cluster.
+name: preflight-deploy-contract
+
+on:
+  pull_request:
+    paths:
+      - 'deploy/**'
+      - 'infra/k8s/**'
+      - '.github/workflows/images.yml'
+      - '.github/workflows/preflight-deploy-contract.yml'
+      - 'tools/preflight_deploy_contract.py'
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/**'
+      - 'infra/k8s/**'
+      - '.github/workflows/images.yml'
+      - 'tools/preflight_deploy_contract.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install --quiet pyyaml
+      - name: Every deployed service must reference something that exists
+        run: python3 tools/preflight_deploy_contract.py

--- a/infra/k8s/workspace-caldav/base/deployment.yaml
+++ b/infra/k8s/workspace-caldav/base/deployment.yaml
@@ -12,9 +12,11 @@ spec:
       labels:
         app: workspace-caldav
     spec:
+      imagePullSecrets:
+        - name: zot-pull
       containers:
         - name: radicale
-          image: ghcr.io/socioprophet/prophet-platform/workspace-caldav:dev
+          image: registry.socioprophet.ai/workspace-caldav:sha-8f1bb2f5d6d4d9577113887bbfb79ce8305782b3
           ports:
             - name: caldav
               containerPort: 5232

--- a/infra/k8s/workspace-mail/base/deployment-smtp.yaml
+++ b/infra/k8s/workspace-mail/base/deployment-smtp.yaml
@@ -12,9 +12,11 @@ spec:
       labels:
         app: workspace-smtp
     spec:
+      imagePullSecrets:
+        - name: zot-pull
       containers:
         - name: postfix
-          image: ghcr.io/socioprophet/prophet-platform/workspace-smtp:dev
+          image: registry.socioprophet.ai/workspace-smtp:sha-8f1bb2f5d6d4d9577113887bbfb79ce8305782b3
           ports:
             - name: smtp
               containerPort: 25

--- a/infra/k8s/workspace-mail/base/deployment.yaml
+++ b/infra/k8s/workspace-mail/base/deployment.yaml
@@ -12,9 +12,11 @@ spec:
       labels:
         app: workspace-mail
     spec:
+      imagePullSecrets:
+        - name: zot-pull
       containers:
         - name: dovecot
-          image: ghcr.io/socioprophet/prophet-platform/workspace-mail:dev
+          image: registry.socioprophet.ai/workspace-mail:sha-8f1bb2f5d6d4d9577113887bbfb79ce8305782b3
           ports:
             - name: imap
               containerPort: 143

--- a/infra/k8s/zot/base/configmap.yaml
+++ b/infra/k8s/zot/base/configmap.yaml
@@ -36,7 +36,8 @@ data:
           "repositories": {
             "**": {
               "policies": [
-                { "users": ["admin", "ci", "github-ci"], "actions": ["read", "create", "update", "delete"] }
+                { "users": ["admin", "ci", "github-ci"], "actions": ["read", "create", "update", "delete"] },
+                { "users": ["k8s-pull"], "actions": ["read"] }
               ],
               "defaultPolicy": [],
               "anonymousPolicy": []

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Preflight: every deployed service must reference something that exists.
+
+CI builds images. Nothing checked that the things we DEPLOY line up with the
+things we BUILD — so on 2026-07-15 the cluster had ~9 pods crashlooping for two
+days behind a 100% green pipeline. Every one of those failures passed CI.
+
+Two checks, both static (no registry credentials, runs anywhere):
+
+  1. Every service in a deploy/argocd ApplicationSet has a deploy/values/<name>.yaml.
+  2. Every FIRST-PARTY service is actually built by .github/workflows/images.yml.
+
+First-party vs third-party is decided by image.registry: third-party values pin a
+foreign registry explicitly (socbase-auth -> docker.io/supabase/gotrue), while
+first-party values omit it and inherit the platform default from the chart. So a
+values file with no registry override is claiming "the platform builds this" —
+and this asserts that claim is true.
+
+Caught in the wild: reasoning-failure-runner is deployed, is first-party, has zero
+entries in images.yml, and its image has never existed in GAR. It ImagePullBackOffs
+forever. Same class as workspace-{mail,caldav,smtp}, which CI built to GAR while
+the deployments pulled from GHCR — a registry they were never published to.
+
+Exit 0 = clean, 1 = a deployment references something that will never resolve.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover
+    print("preflight: PyYAML required (pip install pyyaml)", file=sys.stderr)
+    raise SystemExit(1)
+
+ROOT = Path(__file__).resolve().parents[1]
+ARGOCD_DIR = ROOT / "deploy" / "argocd"
+VALUES_DIR = ROOT / "deploy" / "values"
+IMAGES_WF = ROOT / ".github" / "workflows" / "images.yml"
+
+# Services deployed from their own kustomize base under infra/k8s/<name>/ rather
+# than the shared chart + deploy/values. They skip the values checks but are still
+# checked, via their kustomize manifests, by check_kustomize_images().
+NON_CHART_SERVICES = {
+    "zot",
+    "workspace-minio",
+    "workspace-mail",
+    "workspace-caldav",
+    "workspace-smtp",
+}
+
+# Registry hosts this platform actually publishes to. An image ref pointing anywhere
+# else is either third-party (fine) or a mistake (workspace-* pointed at GHCR, which
+# CI has never published to — so the pods could only ever ImagePullBackOff).
+OUR_REGISTRIES = ("us-central1-docker.pkg.dev/socioprophet-platform/", "registry.socioprophet.ai/")
+
+# Ratchet: known-broken services, reported but not failing the build. This exists so
+# the gate can be enforced TODAY — blocking every NEW violation — without waiting on
+# pre-existing debt whose fix is a product decision rather than a config change.
+# Entries must carry a reason. The list should only ever shrink.
+KNOWN_BROKEN = {
+    "reasoning-failure-runner": (
+        "apps/reasoning-failure-runner has src/ and examples/ but NO Dockerfile, so no "
+        "image can exist — yet platform-services.yaml deploys it, giving a permanent "
+        "ImagePullBackOff. It looks like a library that was added to the ApplicationSet "
+        "as if it were a service. Fix = add a Dockerfile + images.yml entry, or drop it "
+        "from the ApplicationSet. Needs an owner decision, not a config tweak."
+    ),
+}
+
+# Registries that are explicitly not ours. A values file naming one of these is
+# declaring "third party, we don't build it" — which is a legitimate answer.
+FOREIGN_REGISTRY_RE = re.compile(r"^(docker\.io|ghcr\.io|quay\.io|registry\.k8s\.io|gcr\.io/(?!socioprophet))")
+
+
+def deployed_services() -> set[str]:
+    """Service names from every ApplicationSet list generator under deploy/argocd."""
+    names: set[str] = set()
+    for path in sorted(ARGOCD_DIR.glob("*.yaml")):
+        text = path.read_text(encoding="utf-8")
+        # Parse loosely: these files are Go-templated, so yaml.safe_load can choke.
+        names |= set(re.findall(r"^\s*-\s*\{\s*name:\s*([a-z0-9][a-z0-9-]*)", text, re.M))
+    return names
+
+
+def built_images() -> set[str]:
+    """Image names from the images.yml build matrix."""
+    if not IMAGES_WF.exists():
+        return set()
+    text = IMAGES_WF.read_text(encoding="utf-8")
+    return set(re.findall(r"^\s*-\s*\{\s*image:\s*([a-z0-9][a-z0-9-]*)\s*,", text, re.M))
+
+
+def check_kustomize_images(name: str, built: set[str]) -> list[str]:
+    """Image refs in a kustomize-deployed service must point at a registry we publish to.
+
+    workspace-{mail,caldav,smtp} referenced ghcr.io/socioprophet/prophet-platform/*
+    while images.yml built them to Artifact Registry. The images were never in GHCR
+    at all, so no pull secret could have helped — the ref was simply wrong.
+    """
+    base = ROOT / "infra" / "k8s" / name
+    if not base.exists():
+        # Some kustomize services live under a sibling's tree (workspace-smtp is
+        # defined inside infra/k8s/workspace-mail/). Nothing to assert here.
+        return []
+    problems: list[str] = []
+    for manifest in sorted(base.rglob("*.yaml")):
+        for ref in re.findall(r"^\s*image:\s*(\S+)", manifest.read_text(encoding="utf-8"), re.M):
+            ref = ref.strip("\"'")
+            if FOREIGN_REGISTRY_RE.match(ref) and not ref.startswith("ghcr.io/socioprophet"):
+                continue  # genuine third-party upstream image
+            if ref.startswith(OUR_REGISTRIES):
+                continue  # points at a registry we publish to
+            repo = ref.split("/")[-1].split(":")[0]
+            if repo in built:
+                problems.append(
+                    f"{name}: {manifest.relative_to(ROOT)} pulls '{ref}' but CI builds "
+                    f"'{repo}' to {OUR_REGISTRIES[0]}… — the pods pull from a registry "
+                    f"the image was never published to."
+                )
+    return problems
+
+
+def main() -> int:
+    services = deployed_services()
+    built = built_images()
+    if not services:
+        print("preflight: found no deployed services — check deploy/argocd/", file=sys.stderr)
+        return 1
+
+    problems: list[str] = []
+    checked = 0
+
+    for name in sorted(services):
+        if name in NON_CHART_SERVICES:
+            problems.extend(check_kustomize_images(name, built))
+            continue
+        values_path = VALUES_DIR / f"{name}.yaml"
+        if not values_path.exists():
+            problems.append(f"{name}: deployed by an ApplicationSet but deploy/values/{name}.yaml is missing")
+            continue
+
+        data = yaml.safe_load(values_path.read_text(encoding="utf-8")) or {}
+        image = data.get("image") or {}
+        repository = image.get("repository")
+        registry = (image.get("registry") or "").strip()
+
+        if not repository:
+            problems.append(f"{name}: values has no image.repository")
+            continue
+
+        if registry and FOREIGN_REGISTRY_RE.match(registry):
+            continue  # third-party, we don't build it — legitimately out of scope
+
+        checked += 1
+        if repository not in built:
+            problems.append(
+                f"{name}: first-party image '{repository}' has NO entry in images.yml — "
+                f"it is deployed but never built, so it can only ImagePullBackOff. "
+                f"Add it to the build matrix, pin a foreign image.registry if it is "
+                f"third-party, or remove the service from the ApplicationSet."
+            )
+
+    # Split real failures from ratcheted, already-known debt.
+    blocking = [p for p in problems if p.split(":")[0] not in KNOWN_BROKEN]
+    known = [p for p in problems if p.split(":")[0] in KNOWN_BROKEN]
+
+    print(f"preflight: {len(services)} deployed, {checked} first-party checked against {len(built)} built images")
+
+    if known:
+        print("\nKNOWN BROKEN (ratcheted — tracked, not blocking):")
+        for p in known:
+            name = p.split(":")[0]
+            print(f"  • {p}")
+            print(f"      why deferred: {KNOWN_BROKEN[name]}")
+
+    stale = sorted(set(KNOWN_BROKEN) - {p.split(":")[0] for p in problems})
+    if stale:
+        print("\nFAIL — these are in KNOWN_BROKEN but now pass. The ratchet only shrinks:", file=sys.stderr)
+        for name in stale:
+            print(f"  • {name}: fixed — delete it from KNOWN_BROKEN", file=sys.stderr)
+        return 1
+
+    if blocking:
+        print("\nFAIL — a deployment references something that will never resolve:\n", file=sys.stderr)
+        for p in blocking:
+            print(f"  • {p}", file=sys.stderr)
+        return 1
+
+    print("OK: every deployed first-party service is built by CI and pulls from a registry we publish to")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Tonight the cluster had **~9 pods crashlooping for two days behind a 100% green pipeline**. Every one of those failures passed CI — because **CI only builds images. Nothing ever checked that what we DEPLOY matches what we BUILD.**

It was never five bugs. It was **one bug, five times**: *a deployment references something that doesn't exist.*

| | |
|---|---|
| wrong **port** | osm-map-api — bound 8088, values said 8080 |
| wrong **probe path** | agentic-os-api, gateway — `/health` vs `/healthz` |
| wrong **service hostname** | gateway — `socioprophet-api`, which has never existed |
| image built where **nothing pulls** | workspace-mail/caldav/smtp — GAR vs GHCR |
| image **never built at all** | reasoning-failure-runner — 0 CI entries |

## The gate

`tools/preflight_deploy_contract.py` — two static checks, **no registry credentials, runs anywhere**:

1. Every service in a `deploy/argocd` ApplicationSet has a `deploy/values/<name>.yaml`.
2. Every **first-party** service is actually built by `images.yml`.

*First-party* is decided by the data, not a hardcoded list: third-party values pin a foreign `image.registry` (`socbase-auth` → `docker.io/supabase/gotrue`), while first-party values omit it and inherit the platform default — i.e. they're **claiming "the platform builds this"**. The gate asserts that claim. Kustomize-deployed services are checked via their manifests instead: their image refs must point at a registry we publish to.

Runs on **pull_request** (unlike `images.yml`, which is push/dispatch-only) — the point is to reject the mismatch *before* it reaches the cluster.

## Ratcheted, not aspirational

A gate that turns main red on day one gets ignored. `KNOWN_BROKEN` carries pre-existing debt **with a written reason**, so the gate is enforceable **today** and blocks every **new** violation.

**The list can only shrink.** If a `KNOWN_BROKEN` entry starts passing, the gate **fails** and demands its removal — so it can't rot into a permanent excuse.

## Also lands the workspace cutover the gate was flagging

- **Repointed** `workspace-{mail,caldav,smtp}` from `ghcr.io/socioprophet/prophet-platform/*:dev` → `registry.socioprophet.ai`, pinned to **`sha-8f1bb2f5…`** (verified **HTTP 200 in zot before pinning**, not assumed) rather than a moving tag.
- **`imagePullSecrets: zot-pull`** — zot is login-walled, so the kubelet needs credentials.
- **New `k8s-pull` identity, read-only.** The cluster must **not** hold `github-ci`, which has `create/update/delete` on every repo — a compromised pod should not be able to poison the sovereign registry. `anonymousPolicy` stays `[]`.

## Verification

| Test | Result |
|---|---|
| Gate on this tree | ✅ exit 0 |
| Revert a workspace ref to GHCR | ✅ **fails** — catches the regression |
| Fake a `KNOWN_BROKEN` fix | ✅ **fails** — *"the ratchet only shrinks"* |
| zot tags exist before pinning | ✅ all three HTTP 200 |
| kustomize overlays | ✅ render |

## ⚠️ Needs an out-of-band step before the workspace pods recover

The `k8s-pull` htpasswd user and the `zot-pull` secret must be created in-cluster (same out-of-band pattern as `zot-htpasswd`/`minio-credentials`). Until then these pods will 401 instead of 404 — **strictly better than today, but still not Ready**.

## Left for an owner decision

`reasoning-failure-runner` stays ratcheted: `apps/reasoning-failure-runner` has `src/` and `examples/` but **no Dockerfile**, so no image can ever exist — yet the ApplicationSet deploys it. It looks like a library added as if it were a service. Build it or drop it; not mine to decide.

## Next gate worth building (not here)

**Alert on restart count / ArgoCD `Degraded`.** The real failure tonight wasn't any single bug — it's that **nobody knew for two days**. 620 restarts is one every four minutes, for 48 hours, in silence.