### PR TITLE
fix(workspace): overlays were patching the image back to GHCR — and the gate missed it

### DIFF
--- a/infra/k8s/workspace-mail/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/workspace-mail/overlays/p0-lab/kustomization.yaml
@@ -12,7 +12,7 @@ patches:
         value: 1
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: ghcr.io/socioprophet/prophet-platform/workspace-mail:dev
+        value: registry.socioprophet.ai/workspace-mail:sha-8f1bb2f5d6d4d9577113887bbfb79ce8305782b3
   - target:
       kind: PersistentVolumeClaim
       name: workspace-mail-pvc

--- a/infra/k8s/workspace-mail/overlays/p1-single-site/kustomization.yaml
+++ b/infra/k8s/workspace-mail/overlays/p1-single-site/kustomization.yaml
@@ -12,7 +12,7 @@ patches:
         value: 2
       - op: replace
         path: /spec/template/spec/containers/0/image
-        value: ghcr.io/socioprophet/prophet-platform/workspace-mail:latest
+        value: registry.socioprophet.ai/workspace-mail:sha-8f1bb2f5d6d4d9577113887bbfb79ce8305782b3
   - target:
       kind: Deployment
       name: workspace-smtp

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -107,7 +107,15 @@ def check_kustomize_images(name: str, built: set[str]) -> list[str]:
         return []
     problems: list[str] = []
     for manifest in sorted(base.rglob("*.yaml")):
-        for ref in re.findall(r"^\s*image:\s*(\S+)", manifest.read_text(encoding="utf-8"), re.M):
+        text = manifest.read_text(encoding="utf-8")
+        # `image: <ref>` in a manifest, AND `value: <ref>` inside a kustomize JSON
+        # patch that replaces .../containers/N/image. The patch form is what bit us:
+        # the base was repointed to zot while overlays/p0-lab silently patched the
+        # image back to GHCR, so the deployed pod never moved and the first version
+        # of this gate — which only looked for `image:` — passed anyway.
+        refs = re.findall(r"^\s*image:\s*(\S+)", text, re.M)
+        refs += re.findall(r"path:\s*\S*/image\s*\n\s*value:\s*(\S+)", text)
+        for ref in refs:
             ref = ref.strip("\"'")
             if FOREIGN_REGISTRY_RE.match(ref) and not ref.startswith("ghcr.io/socioprophet"):
                 continue  # genuine third-party upstream image


### PR DESCRIPTION
## The pods never moved

#733 repointed the workspace **bases** to zot. The pull secret synced. The pods stayed broken:

```
image=ghcr.io/.../workspace-mail:dev     ← unchanged
pullSecret=zot-pull                      ← synced
```

Both came from the **same PR**, so this was never a sync problem.

## Cause

`overlays/p0-lab` — **the overlay ArgoCD actually deploys** — carries a JSON patch that replaces the image, silently overriding the base:

```yaml
- op: replace
  path: /spec/template/spec/containers/0/image
  value: ghcr.io/socioprophet/prophet-platform/workspace-mail:dev
```

Fixing the base was necessary and insufficient. Both overlays (`p0-lab`, `p1-single-site`) now point at `registry.socioprophet.ai`, pinned to `sha-8f1bb2f5…`.

**What actually deploys now:**
```
image: registry.socioprophet.ai/workspace-mail:sha-8f1bb2f5…
imagePullSecrets: [zot-pull]
```

## The uncomfortable part: my own gate passed this

`preflight_deploy_contract.py` **green-lit a tree whose deployed image was still wrong** — precisely the failure it exists to prevent. It scanned for `image:` refs; a kustomize JSON patch expresses the ref as `value:` under `path: .../image`. Different shape, invisible to the grep.

**Reality caught it. The gate didn't.**

It now reads patch values too — verified by reverting the overlay and watching it fail:

```
FAIL — workspace-mail: overlays/p0-lab/kustomization.yaml pulls
'ghcr.io/socioprophet/prophet-platform/workspace-mail:dev' but CI builds
'workspace-mail' to us-central1-docker.pkg.dev/… — the pods pull from a
registry the image was never published to.
```

**Lesson worth keeping:** a gate that greps source is only as good as its knowledge of every way a value can be expressed. `kubectl kustomize <overlay>` is the only thing that renders what actually deploys — a future hardening should assert against *rendered* output, not source text.

## Noted, not fixed here

`workspace-backup` pulls `ghcr.io/.../workspace-backup:dev` and is **absent from images.yml**, so the gate skips it — it only flags refs for images CI builds. Same class as `reasoning-failure-runner`: needs an owner decision (build it or drop it), not a config tweak.