### PR TITLE
fix(socbase-schema): accept the admin secret that actually exists

### DIFF
--- a/charts/socbase-schema/templates/_helpers.tpl
+++ b/charts/socbase-schema/templates/_helpers.tpl
@@ -5,8 +5,13 @@
   value: {{ .Values.postgres.port | quote }}
 - name: PGDATABASE
   value: {{ .Values.postgres.db | quote }}
+{{- if .Values.postgres.username }}
+- name: PGUSER
+  value: {{ .Values.postgres.username | quote }}
+{{- else }}
 - name: PGUSER
   valueFrom: { secretKeyRef: { name: {{ .Values.postgres.existingSecret }}, key: username } }
+{{- end }}
 - name: PGPASSWORD
   valueFrom: { secretKeyRef: { name: {{ .Values.postgres.existingSecret }}, key: password } }
 {{- end -}}

--- a/charts/socbase-schema/values.yaml
+++ b/charts/socbase-schema/values.yaml
@@ -13,7 +13,14 @@ postgres:
   host: postgres
   db: prophet_platform
   port: 5432
-  existingSecret: postgres-credentials     # keys: username, password (admin)
+  # A username is not a secret. The cluster's admin secret (postgres-admin) carries
+  # only `password`, so requiring a `username` key forced a second secret to exist
+  # purely to restate "postgres" — and copying an admin password into a new secret
+  # to satisfy a chart's shape is a bad trade. Set username here; the secret keeps
+  # the part that is actually sensitive. Falls back to the secret's username key if
+  # this is left empty.
+  username: postgres
+  existingSecret: postgres-admin           # key: password
 
 # authenticator is the login role PostgREST connects as (SET ROLE anon /
 # authenticated / service_role per JWT) — this Job creates/repassword's it.


### PR DESCRIPTION
## Why the socbase bootstrap has never run

`charts/socbase-schema` creates the `authenticator`/`anon`/`authenticated`/`service_role` roles. **It has never been installed** — `kubectl get jobs` is empty, and `platform-services.yaml` documents the step as pending.

It *couldn't* run: the chart wants a **`postgres-credentials`** secret with keys `username` + `password`. **No such secret exists.** The cluster has **`postgres-admin`**, with only `password`.

That single mismatch cascades:
- roles never created → **`socbase-rest` fails 623 times** with `password authentication failed for user "authenticator"` — not a wrong password, **no such role**

## The fix, and why not the obvious one

The obvious fix is to create `postgres-credentials`. That means **copying the postgres admin password into a second secret** purely to restate the username `"postgres"` — more copies of an admin credential to satisfy a chart's shape.

**A username is not a secret.** So: allow `postgres.username` as a plain value (falling back to the secret's `username` key when unset) and point values at `postgres-admin`. The admin password still comes from a secret; there's just no second copy of it.

Renders against reality:
```yaml
- name: PGUSER
  value: "postgres"
- name: PGPASSWORD
  valueFrom: { secretKeyRef: { name: postgres-admin, key: password } }
- name: AUTHENTICATOR_PASSWORD
  valueFrom: { secretKeyRef: { name: socbase-authenticator, key: password } }
```

## This does NOT fix socbase yet

The Job **waits for GoTrue's `auth.users`** before applying:
```sh
for i in $(seq 1 60); do ... to_regclass('auth.users') ... done
```
So GoTrue must build the `auth` schema first — and GoTrue is still down with a **separate, upstream bug**:

- `20221003041349` creates the MFA enums **unqualified** → they follow `search_path`
- `20240729123726` alters them **qualified** as `auth.factor_type` → looks only in `auth`
- GoTrue connects as `postgres`; **`GOTRUE_DB_NAMESPACE` is not set** in `socbase-auth-config`

Verified in the live DB before cleanup: `public.factor_type`, `public.factor_status`, `public.aal_level` existed while `auth` had **0 tables**. The enums were being built in the wrong schema.

Setting `search_path` on the role (`alter role postgres in database prophet_platform set search_path = auth, public`) applies — `current_schema()` is now `auth` — but **GoTrue still fails identically**, which means it is overriding `search_path` on its own connection. The likely fix is forcing it in the connection string (`?options=-csearch_path%3Dauth` in `socbase-auth-db-url`) or running GoTrue as a dedicated `supabase_auth_admin` role whose default search_path is `auth`, which is how upstream Supabase avoids this.

That's a secret edit and needs an explicit decision, so it isn't in this PR.