### PR TITLE
feat(runner): sovereign CI runner — our software on rented metal, built to leave

### DIFF
--- a/infra/runner/README.md
+++ b/infra/runner/README.md
@@ -1,0 +1,96 @@
+# Sovereign CI runner
+
+The estate's build/release pipeline is GitHub Actions. **That is the last big piece
+of someone else's software in the critical path** — and it is what feeds zot. Until
+a Gitea Actions runner exists, the SCM cutover cannot happen: flip the repos first
+and the code moves while the pipeline dies.
+
+This directory is that runner.
+
+## The phasing (decided with Michael, 2026-07-15)
+
+Two dependencies get confused as one:
+
+| | What it is | Cost to escape |
+|---|---|---|
+| **GitHub Actions** | their *software* — runtime, policy, telemetry, their view of our builds | **a rewrite** |
+| **A GCE VM running our act_runner** | rented *metal* | **an `scp`** |
+
+So: **kill the software lock-in first, the hardware rental second.** Software
+lock-in is the expensive one; hardware is fungible. Phase 1 puts *our* runner on
+Google's metal — "we have to use Google to kill Google" — and that is only
+acceptable because the exit stays cheap.
+
+**Phase 2 keeps that promise only if we build for it now**, so:
+
+- `install-act-runner.sh` has **nothing Google in it** — no metadata server, no
+  Workload Identity, no `*.googleapis.com`. Linux + systemd + podman, that's all.
+- `provision-gce.sh` is the **only** GCP-shaped file here. Deleting it *is* Phase 2.
+- The VM is created with `--no-service-account --scopes=none` — **it cannot call a
+  single Google API.** It is a dumb Linux box on purpose.
+- The runner is **stateless**. Its only state is a registration token.
+
+**Phase 2:** run `install-act-runner.sh` on the anchor box (compute doctrine: small
+federated nodes + own hardware), then delete the VM. Not a project — a re-run.
+
+## Why not on the cluster
+
+`prophet-platform` is **GKE Autopilot**, which rejects privileged pods outright:
+
+```
+denied by autogke-disallow-privilege: container is privileged; not allowed in Autopilot
+```
+
+(verified empirically, not assumed). The estate's CI *builds images*
+(`docker/setup-buildx-action` + `docker/build-push-action`), so it needs a real
+container runtime. Autopilot is excellent for services and wrong for builders —
+the same reason **mail** can't live there either (no port 25, no PTR). Expect a
+small VM tier alongside the cluster; don't fight Warden.
+
+## Why not on the mail box
+
+**Never.** Mail needs stable IP reputation; CI runs semi-untrusted build code. A
+poisoned build must not be able to touch mail deliverability. Different threat
+models, different machines.
+
+## Usage
+
+**1. Mint a registration token** (as the `git` user — gitea hard-fails as root
+with `mustNotRunAsRoot`):
+
+```sh
+POD=$(kubectl -n scm get pods --no-headers | awk '/gitea/{print $1;exit}')
+kubectl -n scm exec "$POD" -- su git -c 'gitea actions generate-runner-token'
+```
+
+**2. Provision (Phase 1):**
+
+```sh
+GITEA_RUNNER_TOKEN=<token> ./provision-gce.sh
+```
+
+**3. Or install anywhere (Phase 2 / local / anchor box):**
+
+```sh
+GITEA_INSTANCE_URL=https://code.socioprophet.ai \
+GITEA_RUNNER_TOKEN=<token> \
+sudo -E ./install-act-runner.sh
+```
+
+## Cost discipline
+
+The rule is *"we tear down all clusters when we are done — we don't leave shit
+running."* CI is bursty. The VM is **SPOT** with `--instance-termination-action=STOP`.
+Stop it when idle:
+
+```sh
+gcloud compute instances stop  sovereign-ci-runner --zone us-central1-a
+gcloud compute instances start sovereign-ci-runner --zone us-central1-a
+```
+
+## The loop it closes
+
+The runner pulls **its own image from zot** (`registry.socioprophet.ai/gitea/act_runner`
+— zot proxies docker.io on demand, verified HTTP 200) and pushes build results
+**back to zot**. Sovereign CI, sovereign image, sovereign registry — with Docker Hub
+touched only through our own pull-through cache.

--- a/infra/runner/audit-portability.sh
+++ b/infra/runner/audit-portability.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Phase 2 ("migrate the runner off Google") stays real only if install-act-runner.sh
+# never grows a Google dependency. Promises rot; a test doesn't. This is that test.
+#
+# It deliberately ignores comments and the closing help text — prose saying "GCE"
+# is documentation, not a dependency. Only executable code counts.
+set -euo pipefail
+cd "$(dirname "$0")"
+python3 - <<'PY'
+import re, sys
+src = open('install-act-runner.sh').read()
+code = re.sub(r'(?m)^\s*#.*$', '', src)              # strip comments
+code = re.sub(r'cat <<EOF.*?\nEOF', '', code, flags=re.S)  # strip help text
+bad = re.compile(r'googleapis|metadata\.google|\bgcloud\b|workload.identity|169\.254\.169\.254', re.I)
+hits = [l.strip() for l in code.splitlines() if bad.search(l)]
+if hits:
+    print("FAIL: install-act-runner.sh grew a Google dependency — Phase 2 would become a rewrite:")
+    for h in hits: print("  •", h)
+    sys.exit(1)
+print("OK: install-act-runner.sh has no Google dependency in executable code —")
+print("    Phase 2 (anchor box) stays a re-run, not a rewrite.")
+PY

--- a/infra/runner/install-act-runner.sh
+++ b/infra/runner/install-act-runner.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Install a Gitea Actions runner on ANY Linux box.
+#
+# PHASE 1 target is a GCE VM; PHASE 2 is our own hardware. That migration only
+# stays real if this script has nothing Google in it — so it does not:
+#   * read the GCP metadata server
+#   * use Workload Identity, Secret Manager, or any *.googleapis.com
+#   * assume a GCE image, disk layout, or network
+# It needs a Linux host with systemd + podman, and outbound HTTPS. Nothing else.
+# Phase 2 = run this same script on the anchor box. Not a project — a re-run.
+#
+# WHY A VM AT ALL: the estate's CI builds images (docker/setup-buildx-action +
+# docker/build-push-action), which needs a container runtime with build support.
+# The prophet-platform cluster is GKE Autopilot, which REJECTS privileged pods
+# outright ("denied by autogke-disallow-privilege" — verified, not assumed), so
+# the runner cannot live there. See memory: project_gitea_actions_runner.
+#
+# WHY NOT GITHUB ACTIONS: that is their software, their policy, their telemetry.
+# This is our software on rented metal — a dependency you escape with an scp,
+# not a rewrite.
+#
+# The runner is STATELESS: its only state is the registration token. Destroy the
+# box, run this again elsewhere, done.
+#
+# Usage:
+#   GITEA_INSTANCE_URL=https://code.socioprophet.ai \
+#   GITEA_RUNNER_TOKEN=<registration token> \
+#   [RUNNER_NAME=sovereign-ci-1] \
+#   [ACT_RUNNER_IMAGE=registry.socioprophet.ai/gitea/act_runner:<tag>] \
+#   sudo -E ./install-act-runner.sh
+set -euo pipefail
+
+: "${GITEA_INSTANCE_URL:?set GITEA_INSTANCE_URL (e.g. https://code.socioprophet.ai)}"
+: "${GITEA_RUNNER_TOKEN:?set GITEA_RUNNER_TOKEN — mint with: gitea actions generate-runner-token}"
+RUNNER_NAME="${RUNNER_NAME:-sovereign-ci-$(hostname -s)}"
+
+# Pull the runner's own image from OUR registry. zot proxies docker.io on demand
+# (sync onDemand), so this needs no Docker Hub account and no Docker Hub trust —
+# the runner that builds our images is itself served by our registry.
+ACT_RUNNER_IMAGE="${ACT_RUNNER_IMAGE:-registry.socioprophet.ai/gitea/act_runner:0.2.11}"
+
+# Labels map a workflow's `runs-on` to how the job executes. `:docker://` runs each
+# job in a container (what our workflows expect); podman provides the socket, so no
+# privileged DinD daemon is required.
+RUNNER_LABELS="${RUNNER_LABELS:-ubuntu-latest:docker://registry.socioprophet.ai/catthehacker/ubuntu:act-22.04,ubuntu-22.04:docker://registry.socioprophet.ai/catthehacker/ubuntu:act-22.04}"
+
+echo "==> installing podman (rootful, for the job socket)"
+if command -v apt-get >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -qq
+  apt-get install -y -qq podman uidmap curl ca-certificates
+elif command -v dnf >/dev/null 2>&1; then
+  dnf install -y -q podman curl ca-certificates
+else
+  echo "unsupported distro: need apt or dnf" >&2; exit 1
+fi
+
+echo "==> enabling the podman socket (the runner talks to this, not to dockerd)"
+systemctl enable --now podman.socket
+# Our workflows call the docker CLI/API; point DOCKER_HOST at podman's socket.
+DOCKER_SOCK=/run/podman/podman.sock
+
+install -d -m 0750 /etc/act_runner /var/lib/act_runner
+
+echo "==> writing runner config"
+cat >/etc/act_runner/config.yaml <<YAML
+log:
+  level: info
+runner:
+  file: /var/lib/act_runner/.runner
+  capacity: 2
+  timeout: 3h
+  fetch_timeout: 5s
+  fetch_interval: 2s
+container:
+  # podman's socket, not dockerd — Autopilot taught us not to depend on privilege
+  docker_host: "unix://${DOCKER_SOCK}"
+  privileged: false
+  force_pull: false
+cache:
+  enabled: true
+YAML
+
+echo "==> registering with ${GITEA_INSTANCE_URL} as ${RUNNER_NAME}"
+podman run --rm \
+  -v /etc/act_runner:/etc/act_runner \
+  -v /var/lib/act_runner:/var/lib/act_runner \
+  -e CONFIG_FILE=/etc/act_runner/config.yaml \
+  "${ACT_RUNNER_IMAGE}" \
+  act_runner register --no-interactive \
+    --instance "${GITEA_INSTANCE_URL}" \
+    --token "${GITEA_RUNNER_TOKEN}" \
+    --name "${RUNNER_NAME}" \
+    --labels "${RUNNER_LABELS}"
+
+echo "==> installing systemd unit"
+cat >/etc/systemd/system/act-runner.service <<UNIT
+[Unit]
+Description=Gitea Actions runner (sovereign CI)
+After=network-online.target podman.socket
+Wants=network-online.target
+
+[Service]
+Restart=always
+RestartSec=5
+ExecStart=/usr/bin/podman run --rm --name act-runner \\
+  -v /etc/act_runner:/etc/act_runner \\
+  -v /var/lib/act_runner:/var/lib/act_runner \\
+  -v ${DOCKER_SOCK}:${DOCKER_SOCK} \\
+  -e CONFIG_FILE=/etc/act_runner/config.yaml \\
+  -e DOCKER_HOST=unix://${DOCKER_SOCK} \\
+  ${ACT_RUNNER_IMAGE} act_runner daemon
+ExecStop=/usr/bin/podman stop -t 30 act-runner
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now act-runner
+sleep 3
+systemctl --no-pager --lines=10 status act-runner || true
+
+cat <<EOF
+
+==> done. Verify in Gitea: Site Administration -> Actions -> Runners
+    (or per-repo Settings -> Actions -> Runners)
+
+PHASE 2 (off Google): this script is host-agnostic. On the anchor box:
+    GITEA_INSTANCE_URL=... GITEA_RUNNER_TOKEN=<new token> sudo -E ./install-act-runner.sh
+  then delete the GCE VM. The runner is stateless; nothing to migrate but the token.
+
+COST DISCIPLINE ("we don't leave shit running"): this box only needs to be up when
+CI runs. Use a spot/preemptible instance and stop it when idle.
+EOF

--- a/infra/runner/provision-gce.sh
+++ b/infra/runner/provision-gce.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# PHASE 1 ONLY: put the sovereign CI runner on a GCE VM.
+#
+# Read this before assuming it contradicts the estate's direction — it is
+# deliberate sequencing, decided with Michael 2026-07-15:
+#
+#   GitHub Actions is THEIR SOFTWARE — their runtime, policy, telemetry, and view
+#   of our builds. Escaping it is a rewrite.
+#   A GCE VM running OUR act_runner is RENTED METAL. Escaping it is an scp.
+#
+# So: kill the software lock-in first, the hardware rental second. "We have to use
+# Google to kill Google" — but only for one phase, and only because the exit stays
+# cheap. That is why install-act-runner.sh has NOTHING Google in it: no metadata
+# server, no Workload Identity, no *.googleapis.com. This file is the ONLY
+# GCP-shaped thing, and deleting it is the whole of Phase 2.
+#
+# PHASE 2: run install-act-runner.sh on the anchor box (compute doctrine: small
+# federated nodes + own hardware), then `gcloud compute instances delete`. The
+# runner is stateless — its only state is a registration token.
+#
+# WHY NOT ON THE CLUSTER: prophet-platform is GKE Autopilot, which rejects
+# privileged pods outright ("denied by autogke-disallow-privilege" — verified).
+# The estate's CI builds images, so it needs a real container runtime.
+#
+# WHY NOT ON THE MAIL VM: never. Mail needs stable IP reputation; CI runs
+# semi-untrusted build code. A poisoned build must not be able to touch mail
+# deliverability. Different threat models, different boxes.
+#
+# COST DISCIPLINE: SPOT by default and `--no-restart-on-failure`, because the rule
+# is "we tear down all clusters when we are done — we don't leave shit running".
+# CI is bursty; stop the box when idle:
+#   gcloud compute instances stop  ${VM_NAME} --zone ${ZONE}
+#   gcloud compute instances start ${VM_NAME} --zone ${ZONE}
+set -euo pipefail
+
+PROJECT="${PROJECT:-socioprophet-platform}"
+ZONE="${ZONE:-us-central1-a}"
+VM_NAME="${VM_NAME:-sovereign-ci-runner}"
+MACHINE="${MACHINE:-e2-standard-2}"   # 2 vCPU / 8GB — buildx needs headroom
+
+: "${GITEA_RUNNER_TOKEN:?mint one first — see README.md in this dir}"
+GITEA_INSTANCE_URL="${GITEA_INSTANCE_URL:-https://code.socioprophet.ai}"
+
+echo "==> creating SPOT VM ${VM_NAME} (${MACHINE}) in ${ZONE}"
+gcloud compute instances create "${VM_NAME}" \
+  --project="${PROJECT}" \
+  --zone="${ZONE}" \
+  --machine-type="${MACHINE}" \
+  --provisioning-model=SPOT \
+  --instance-termination-action=STOP \
+  --no-restart-on-failure \
+  --image-family=ubuntu-2204-lts \
+  --image-project=ubuntu-os-cloud \
+  --boot-disk-size=50GB \
+  --boot-disk-type=pd-balanced \
+  --scopes=none \
+  --no-service-account \
+  --labels=purpose=sovereign-ci,phase=1-rented-metal,migrate-to=own-hardware \
+  --metadata-from-file=startup-script=<(cat <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export GITEA_INSTANCE_URL="${GITEA_INSTANCE_URL}"
+export GITEA_RUNNER_TOKEN="${GITEA_RUNNER_TOKEN}"
+export RUNNER_NAME="sovereign-ci-gce"
+curl -fsSL "${RUNNER_SCRIPT_URL:-https://code.socioprophet.ai/SocioProphet/prophet-platform/raw/branch/main/infra/runner/install-act-runner.sh}" -o /tmp/install-act-runner.sh
+bash /tmp/install-act-runner.sh
+EOF
+)
+
+cat <<EOF
+
+==> created. Note what this VM deliberately does NOT have:
+      --no-service-account, --scopes=none  -> it cannot call any Google API.
+      It is a dumb Linux box. That is the point: nothing to migrate but the OS.
+
+==> stop it when idle (the rule is: don't leave shit running):
+      gcloud compute instances stop ${VM_NAME} --zone ${ZONE} --project ${PROJECT}
+
+==> PHASE 2 (kill this):
+      run infra/runner/install-act-runner.sh on the anchor box, then
+      gcloud compute instances delete ${VM_NAME} --zone ${ZONE} --project ${PROJECT}
+EOF


### PR DESCRIPTION
## Why this is the cutover blocker

The estate's entire build/release pipeline is **GitHub Actions** — `images.yml`, the reusable `build-image.yml`, the preflight gate, CodeQL, ~60 checks per merge. **None of it exists in gitea.** Flip the 122 mirrored repos to writable first and the code moves while the pipeline dies — which also **starves zot**, since `images.yml` is what feeds it.

So the runner comes first. Everything else in the SCM cutover queues behind it.

## The phasing — two dependencies that were being confused as one

| | What it is | Cost to escape |
|---|---|---|
| **GitHub Actions** | their **software** — runtime, policy, telemetry, their view of our builds | **a rewrite** |
| **GCE VM running our act_runner** | rented **metal** | **an `scp`** |

**Kill the software lock-in first, the hardware rental second.** Software lock-in is expensive; hardware is fungible. Phase 1 puts *our* runner on Google's metal — *"we have to use Google to kill Google"* — and that's only acceptable **because the exit stays cheap**.

## Phase 2 is a promise, so it's enforced by a test

Promises rot. `audit-portability.sh` is the thing that keeps this one:

- **`install-act-runner.sh` has nothing Google in it** — no metadata server, no Workload Identity, no `*.googleapis.com`. Linux + systemd + podman, nothing else.
- **`provision-gce.sh` is the ONLY GCP-shaped file.** Deleting it *is* Phase 2.
- The VM is created **`--no-service-account --scopes=none`** — it cannot call a single Google API. A dumb Linux box, deliberately.
- The runner is **stateless**; its only state is a registration token.

```
$ ./audit-portability.sh
OK: install-act-runner.sh has no Google dependency in executable code —
    Phase 2 (anchor box) stays a re-run, not a rewrite.
```

Verified both directions — inject `gcloud auth print-access-token` and it fails loudly.

**A note on honesty:** the first commit here claimed "verified by an audit". That grep was naive — it ignored `#` comments but not the closing help text, so it flagged the prose *"then delete the GCE VM"* and appeared to fail. The script was fine; **the check was wrong and the claim was stronger than the evidence.** The second commit replaces it with a real test.

## Why not on the cluster

`prophet-platform` is **GKE Autopilot**, which rejects privileged pods outright — verified empirically, not assumed:

```
denied by autogke-disallow-privilege: container p is privileged; not allowed in Autopilot
```

CI **builds images** (`docker/setup-buildx-action` + `docker/build-push-action`), so it needs a real container runtime. Rootless buildkit/kaniko would work on Autopilot but means **rewriting the reusable build workflow** and losing the buildx cache/provenance/sbom that `.github#1` already wires — **a cutover should not also be a CI rewrite.**

**The pattern:** Autopilot is right for *services*, wrong for *builders and mail*. Mail can't live there either (no port 25, no PTR). Expect a small VM tier alongside the cluster; don't fight Warden.

## Why never on the mail box

Mail needs stable **IP reputation**; CI runs **semi-untrusted build code**. A poisoned build must not be able to touch mail deliverability. Different threat models, different machines.

## Cost discipline

Per the rule — *"we tear down all clusters when we are done, we don't leave shit running"* — the VM is **SPOT** with `--instance-termination-action=STOP` and `--no-restart-on-failure`. CI is bursty; stop it when idle (documented in the README).

## The loop it closes

The runner pulls **its own image from zot** (`registry.socioprophet.ai/gitea/act_runner` — zot proxies docker.io on demand, **verified HTTP 200**) and pushes results **back to zot**. Sovereign CI, sovereign image, sovereign registry — Docker Hub touched only through our own pull-through cache.

## Not merged blind

This provisions nothing on its own. Next step is minting a runner token and running it — then proving the full loop (push → PR → CI green → merge) on **one low-stakes repo** before the estate flips.