### PR TITLE
feat(socbase): one base URL for supabase-js — the Kong replacement in ~20 lines of nginx

### DIFF
--- a/deploy/argocd/socbase-services.yaml
+++ b/deploy/argocd/socbase-services.yaml
@@ -1,0 +1,60 @@
+# Argo CD ApplicationSet — socbase gateway (the sovereign auth/data surface).
+#
+# socbase is the Firebase replacement: GoTrue (auth) + PostgREST (data over
+# Postgres). Those two deploy via the stateless Helm chart from
+# deploy/values/socbase-{auth,rest}.yaml and are covered by platform-services.
+#
+# This ApplicationSet carries the GATEWAY, which is multi-manifest (ConfigMap +
+# Deployment + Service + Ingress + ManagedCertificate) and therefore kustomize —
+# same house convention as zot and the workspace stack, not the stateless chart.
+#
+# WHY A GATEWAY EXISTS AT ALL: @supabase/supabase-js needs ONE base URL serving
+# both /auth/v1 (GoTrue) and /rest/v1 (PostgREST), prefix stripped. Real Supabase
+# runs Kong for that; we run ~20 lines of nginx. See infra/local/socbase/nginx.conf
+# — local dev has always done exactly this, and its comment says "no Kong in either
+# place". This is the production half of that intent.
+#
+# WHY NOT AN nginx INGRESS: the original socbase-auth/socbase-rest Ingresses asked
+# for `ingressClassName: nginx` with rewrite-target/use-regex, but no nginx
+# controller has ever existed in this cluster, so they sat at ADDRESS <none>
+# forever and socbase was unreachable despite both services being healthy. This
+# uses the GCE ingress + ManagedCertificate pattern already proven by zot, gitea
+# and socioprophet-web — zero new controllers, no cert-manager.
+#
+# Prereqs (created out of band, NOT in git — same convention as zot):
+#   * `zot-pull` secret — the gateway image is pulled through zot
+#   * socbase-auth / socbase-rest running (platform-services)
+# Sync-wave 2 so the gateway lands after the services it fronts.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: socbase-services
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          - { name: gateway, path: infra/k8s/socbase-gateway/base, wave: "2" }
+  template:
+    metadata:
+      name: 'socbase-{{.name}}'
+      labels:
+        app.kubernetes.io/part-of: socbase
+      annotations:
+        argocd.argoproj.io/sync-wave: '{{.wave}}'
+    spec:
+      project: default
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: socioprophet
+      source:
+        repoURL: https://github.com/SocioProphet/prophet-platform
+        targetRevision: main
+        path: '{{.path}}'
+      syncPolicy:
+        automated: { prune: true, selfHeal: true }
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/infra/k8s/socbase-gateway/base/configmap.yaml
+++ b/infra/k8s/socbase-gateway/base/configmap.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: socbase-gateway
+  namespace: socioprophet
+  labels:
+    app: socbase-gateway
+    app.kubernetes.io/part-of: socbase
+data:
+  # This is the Kong replacement, and it is deliberately ~20 lines.
+  #
+  # @supabase/supabase-js needs ONE base URL serving BOTH /auth/v1 (GoTrue) and
+  # /rest/v1 (PostgREST), with the prefix stripped before the upstream sees it.
+  # Real Supabase runs Kong for this. Kong is a whole API gateway; we need a
+  # prefix strip. This mirrors infra/local/socbase/nginx.conf so local and cluster
+  # route identically — same contract, one config, no drift.
+  #
+  # Why not an nginx-ingress controller: the socbase-auth/socbase-rest Ingresses
+  # declared `ingressClassName: nginx` with rewrite-target/use-regex annotations,
+  # but NO nginx controller has ever existed in this cluster — so they sat with
+  # ADDRESS <none> forever and socbase.socioprophet.ai was unreachable. Installing
+  # ingress-nginx would also drag in cert-manager for TLS. Instead this reuses the
+  # GCE ingress + ManagedCertificate pattern already proven by zot, gitea and
+  # socioprophet-web: zero new controllers, one small pod.
+  nginx.conf: |
+    worker_processes auto;
+    pid /var/run/nginx.pid;
+    events { worker_connections 1024; }
+    http {
+      access_log /dev/stdout;
+      error_log  /dev/stderr warn;
+      # Every temp path must sit under the writable emptyDir mounts below —
+      # the container runs read-only (lesson from the socioprophet-web nginx fix).
+      client_body_temp_path /var/cache/nginx/client_temp;
+      proxy_temp_path       /var/cache/nginx/proxy_temp;
+      fastcgi_temp_path     /var/cache/nginx/fastcgi_temp;
+      uwsgi_temp_path       /var/cache/nginx/uwsgi_temp;
+      scgi_temp_path        /var/cache/nginx/scgi_temp;
+
+      # Required for the $var proxy_pass above. kube-dns is the in-cluster
+      # resolver; valid=10s keeps us honest about Service IP changes.
+      resolver kube-dns.kube-system.svc.cluster.local valid=10s ipv6=off;
+      resolver_timeout 5s;
+
+      server {
+        # 8080, not 80: the pod runs as uid 10001 and cannot bind a privileged port.
+        listen 8080;
+        server_name _;
+
+        # Probe endpoint that does NOT depend on either upstream being healthy.
+        # GoTrue's /health pings its DB and 502s when the DB is down; wiring that
+        # to liveness is how the gateway pod got killed for someone else's outage
+        # (see the tritrpc-gateway fix). Liveness answers "is nginx alive".
+        location = /healthz {
+          access_log off;
+          add_header Content-Type text/plain;
+          return 200 "ok\n";
+        }
+
+        # supabase-js -> GoTrue. Strip /auth/v1 before GoTrue sees it.
+        location /auth/v1/ {
+          rewrite ^/auth/v1/(.*)$ /$1 break;
+          # $var forces resolution at REQUEST time, not startup. With a literal
+          # hostname nginx resolves proxy_pass upstreams while loading config and
+          # REFUSES TO BOOT if one does not resolve ("host not found in upstream")
+          # — so a momentarily-absent socbase-auth would take the whole gateway
+          # down with it. Caught by running nginx -t against this very file.
+          set $upstream_auth socbase-auth;
+          proxy_pass http://$upstream_auth:9999;
+          proxy_set_header Host              $host;
+          proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # supabase-js -> PostgREST. Strip /rest/v1.
+        location /rest/v1/ {
+          rewrite ^/rest/v1/(.*)$ /$1 break;
+          set $upstream_rest socbase-rest;
+          proxy_pass http://$upstream_rest:3000;
+          proxy_set_header Host              $host;
+          proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Anything else is not part of the Supabase surface. Say so plainly rather
+        # than proxying it somewhere surprising.
+        location / { return 404; }
+      }
+    }

--- a/infra/k8s/socbase-gateway/base/deployment.yaml
+++ b/infra/k8s/socbase-gateway/base/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: socbase-gateway
+  namespace: socioprophet
+  labels:
+    app: socbase-gateway
+    app.kubernetes.io/part-of: socbase
+spec:
+  replicas: 2
+  selector:
+    matchLabels: { app: socbase-gateway }
+  template:
+    metadata:
+      labels: { app: socbase-gateway }
+    spec:
+      # Nothing here reads Kubernetes service-link env vars, and leaving them on is
+      # how the tritrpc-gateway bound ":tcp://<its own clusterIP>:8080" and died 620
+      # times. Off by default.
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        fsGroup: 10001
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: nginx
+          # Pulled through zot (which proxies docker.io on demand) so the sovereign
+          # auth surface does not depend on Docker Hub being reachable or friendly.
+          image: registry.socioprophet.ai/library/nginx:1.27-alpine
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            capabilities: { drop: ["ALL"] }
+          ports:
+            - name: http
+              containerPort: 8080
+          # Both probes hit /healthz, which returns 200 from nginx itself and does
+          # NOT touch GoTrue or PostgREST. A dependency check belongs on readiness
+          # at most — never liveness, or one upstream hiccup restarts the gateway.
+          readinessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests: { cpu: 25m, memory: 64Mi }
+            limits:   { cpu: 200m, memory: 128Mi }
+          volumeMounts:
+            - { name: config, mountPath: /etc/nginx/nginx.conf, subPath: nginx.conf, readOnly: true }
+            # nginx must write its pid and temp files; the rootfs is read-only.
+            - { name: run,   mountPath: /var/run }
+            - { name: cache, mountPath: /var/cache/nginx }
+      volumes:
+        - name: config
+          configMap: { name: socbase-gateway }
+        - name: run
+          emptyDir: {}
+        - name: cache
+          emptyDir: {}
+      imagePullSecrets:
+        - name: zot-pull
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: socbase-gateway
+  namespace: socioprophet
+  labels:
+    app: socbase-gateway
+  annotations:
+    # NEG so the GCE ingress load-balances straight to pods (same as zot/gitea).
+    cloud.google.com/neg: '{"ingress": true}'
+spec:
+  type: ClusterIP
+  selector: { app: socbase-gateway }
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/infra/k8s/socbase-gateway/base/ingress.yaml
+++ b/infra/k8s/socbase-gateway/base/ingress.yaml
@@ -1,0 +1,44 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: socbase-cert
+  namespace: socioprophet
+spec:
+  domains: [socbase.socioprophet.ai]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: socbase-gateway
+  namespace: socioprophet
+  annotations:
+    networking.gke.io/managed-certificates: socbase-cert
+    # `gce`, NOT `nginx`. The old socbase-auth/socbase-rest Ingresses asked for
+    # ingressClassName: nginx — a controller that has never existed in this
+    # cluster — so they sat at ADDRESS <none> forever and socbase was unreachable
+    # from outside despite both services being healthy. Every ingress that works
+    # here (zot, gitea, socioprophet-web) uses the built-in GCE controller.
+    #
+    # The nginx-only rewrite those Ingresses needed now lives in the
+    # socbase-gateway pod instead, so we get the Supabase path shape without
+    # installing an ingress controller AND cert-manager.
+    kubernetes.io/ingress.class: gce
+  labels:
+    app: socbase-gateway
+    app.kubernetes.io/part-of: socbase
+spec:
+  rules:
+    - host: socbase.socioprophet.ai
+      http:
+        paths:
+          # One host, one backend. The gateway pod does the /auth/v1 + /rest/v1
+          # split internally — which is exactly what @supabase/supabase-js expects:
+          # ONE base URL. GCE ingress cannot do regex paths or rewrite-target, and
+          # it does not need to.
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: socbase-gateway
+                port:
+                  number: 80

--- a/infra/k8s/socbase-gateway/base/kustomization.yaml
+++ b/infra/k8s/socbase-gateway/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: socioprophet
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - ingress.yaml


### PR DESCRIPTION
## socbase is healthy and unreachable

`socbase-auth` and `socbase-rest` are both **1/1 Running** (after 618/623 restarts — fixed earlier tonight). And socbase is still **unreachable from outside**:

```
socbase-auth   class=nginx   socbase.socioprophet.ai   ADDR <none>
socbase-rest   class=nginx   socbase.socioprophet.ai   ADDR <none>
zot-ingress    class=<none>  registry.socioprophet.ai  34.149.54.111   ← works
gitea-ingress  class=<none>  code.socioprophet.ai      136.68.31.124   ← works
```

Their Ingresses declare **`ingressClassName: nginx`** with `rewrite-target`/`use-regex` annotations — but **no nginx controller has ever existed here**: `kubectl get ingressclass` is empty, zero controller pods. They've sat at `ADDRESS <none>` forever. That's why `socbase.socioprophet.ai` has no DNS: **there was never an IP to point it at.**

## What this adds

`@supabase/supabase-js` needs **ONE base URL** serving both `/auth/v1` (GoTrue) and `/rest/v1` (PostgREST), prefix stripped. Real Supabase runs **Kong** for that. Kong is an entire API gateway; we need a prefix strip.

**The estate already knew this.** `infra/local/socbase/nginx.conf` does exactly this for local dev, and its comment says it plainly:

> *"Local-dev stand-in for production's native Ingress path-routing (**no Kong in either place**)… **@supabase/supabase-js needs ONE base URL** that serves both /auth/v1 and /rest/v1."*

This is the missing **production half** of that intent.

## Why not install ingress-nginx

It'd also drag in **cert-manager** for TLS. Instead this reuses the **GCE ingress + ManagedCertificate** pattern already proven three times (zot, gitea, socioprophet-web): **zero new controllers**, one small nginx pod — and local and cluster now route through the same config, so they can't drift.

| | Supabase | Here |
|---|---|---|
| Routing/rewrite | Kong (+ its config surface) | 20 lines of nginx |
| TLS | cert-manager | GKE ManagedCertificate (already proven) |
| New controllers | ingress-nginx + cert-manager | **none** |

## Tonight's lessons baked in, not rediscovered

- **`listen 8080`** — pod runs as uid 10001, can't bind a privileged port *(socioprophet-web, #726)*
- **`/healthz` answers from nginx itself** and never touches GoTrue/PostgREST — a dependency check on **liveness** is how tritrpc-gateway got killed **620 times** for its backend's outage *(#732)*
- **`enableServiceLinks: false`** — service-link env vars are how that gateway bound `":tcp://<its own clusterIP>:8080"` *(#731)*
- **read-only rootfs**, every nginx temp path inside the writable emptyDirs
- **image pulled through zot** — the sovereign auth surface doesn't depend on Docker Hub

## Verified by running it, and it caught a real bug

Ran under the pod's exact constraints (`--user 10001 --read-only --cap-drop ALL`). The first version **refused to start**:

```
[emerg] host not found in upstream "socbase-auth"
nginx: configuration file test FAILED
```

**nginx resolves `proxy_pass` hostnames at startup.** In-cluster that mostly works — until socbase-auth is briefly unresolvable during a rollout, and then **the gateway won't start at all**. It would die for someone else's outage — the exact failure I'd just criticised in tritrpc-gateway.

Fixed with a **kube-dns resolver + `$variable` proxy_pass** (defers resolution to request time). Re-verified:

| Check | Result |
|---|---|
| nginx up with **no upstreams at all** | ✅ |
| `/healthz` | **200** |
| `/` | **404** (not proxied somewhere surprising) |
| `/auth/v1/*` | routed |
| emerg/denied in log | **0** |

## After merge

DNS `socbase.socioprophet.ai` → the ingress IP → ManagedCertificate provisions → **socbase is reachable at one HTTPS base URL** → `supabase-js` can point at it. That's the unblock for swapping the app's 7 Firebase call sites.

**Follow-up (not here):** delete the two orphaned `class: nginx` Ingresses once this is serving; they can never get an address.