### PR TITLE
fix(socbase-gateway): set must precede rewrite — every proxied call was 500ing

### DIFF
--- a/infra/k8s/socbase-gateway/base/configmap.yaml
+++ b/infra/k8s/socbase-gateway/base/configmap.yaml
@@ -59,13 +59,18 @@ data:
 
         # supabase-js -> GoTrue. Strip /auth/v1 before GoTrue sees it.
         location /auth/v1/ {
-          rewrite ^/auth/v1/(.*)$ /$1 break;
-          # $var forces resolution at REQUEST time, not startup. With a literal
-          # hostname nginx resolves proxy_pass upstreams while loading config and
-          # REFUSES TO BOOT if one does not resolve ("host not found in upstream")
-          # — so a momentarily-absent socbase-auth would take the whole gateway
-          # down with it. Caught by running nginx -t against this very file.
+          # ORDER MATTERS: `set` MUST precede `rewrite ... break`, because break
+          # halts the rewrite phase — and `set` is a rewrite-phase directive. With
+          # set after it, the variable is never assigned and nginx proxies to
+          # "http://:9999" ("no host in upstream"). It fails at REQUEST time, so
+          # the pod looks healthy while every call 500s.
+          #
+          # The $variable itself is deliberate: it defers DNS to request time. A
+          # literal hostname is resolved while loading config, and nginx REFUSES TO
+          # BOOT if it does not resolve — so a momentarily-absent socbase-auth
+          # would take the whole gateway down with it.
           set $upstream_auth socbase-auth;
+          rewrite ^/auth/v1/(.*)$ /$1 break;
           proxy_pass http://$upstream_auth:9999;
           proxy_set_header Host              $host;
           proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -74,8 +79,8 @@ data:
 
         # supabase-js -> PostgREST. Strip /rest/v1.
         location /rest/v1/ {
-          rewrite ^/rest/v1/(.*)$ /$1 break;
           set $upstream_rest socbase-rest;
+          rewrite ^/rest/v1/(.*)$ /$1 break;
           proxy_pass http://$upstream_rest:3000;
           proxy_set_header Host              $host;
           proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Healthy-looking, entirely broken

#737's gateway deployed **1/1 Running**, `/healthz` **200**, ingress got an IP — and **every proxied request 500'd**:

```
[warn]  using uninitialized "upstream_auth" variable
[error] no host in upstream ":9999"
```

**`rewrite ... break` halts the rewrite phase — and `set` is a rewrite-phase directive.** With `set` *after* `rewrite`, the variable is never assigned, so nginx proxies to `http://:9999`. It fails at **request** time, so the pod stays 1/1 and the probe stays green while the actual surface is dead.

That is the same shape as everything else this estate has produced this week: **the thing looks healthy and does nothing.**

## How it got through — worth saying plainly

The pre-merge local run **did** show `500` on `/auth/v1/health`. I labelled it *"502/504 = routed, upstream absent locally = correct"* and shipped. **It was 500, not 502, and it was this bug.** The signal was there; I explained it away because it was roughly the shape I expected.

The harness was also too weak to catch it: **no upstream existed at all**, so no result could distinguish "routed correctly" from "proxying to nowhere". A test that can't fail for the right reason isn't a test.

## Re-verified on behaviour, not status codes

Real upstream that **echoes the path it received**, so the assertion is about what actually arrived:

| Request | Upstream reports |
|---|---|
| `/healthz` | 200 (nginx itself) |
| `/auth/v1/settings` | **`UPSTREAM_GOT:/settings`** |
| `/auth/v1/token` | **`UPSTREAM_GOT:/token`** |
| leftover `uninitialized`/`no host` | **none** |

The prefix is **provably stripped** — the entire reason the gateway exists. No interpretation required.

## Still true from #737

The `$variable` in `proxy_pass` stays, and matters: a literal hostname is resolved at **config load**, and nginx **refuses to boot** if it doesn't resolve — so a momentarily-absent `socbase-auth` would take the gateway down with it. The variable defers DNS to request time. Both properties are needed; the ordering was the missing half.