### PR TITLE
feat(standards): make the immutable-tag and probe contracts executable

### DIFF
--- a/.github/workflows/probe-contract.yml
+++ b/.github/workflows/probe-contract.yml
@@ -1,0 +1,54 @@
+# Ask the image whether it honours the contract the values file promises.
+#
+# The chart says the container listens on .Values.service.port and answers
+# .Values.probes.path. That was true on paper and false in four services at once,
+# while CI stayed green — because the truth lives in the image, not the YAML, and
+# nothing ever started the image and asked.
+#
+# Runs on PRs that touch an app, a service, or a values file: the two places the
+# contract can drift apart.
+name: probe-contract
+
+on:
+  pull_request:
+    paths:
+      - 'apps/**'
+      - 'services/**'
+      - 'deploy/values/**'
+      - 'charts/socioprophet-service/**'
+      - 'tools/verify_probe_contract.py'
+      - '.github/workflows/probe-contract.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Only services whose image can answer a probe unaided. Anything needing a
+        # live DB or backend is listed in NEEDS_DEPENDENCIES in the script and is
+        # skipped there too — a red build that teaches nothing is worse than no build.
+        include:
+          - { service: socioprophet-web, context: ., dockerfile: apps/socioprophet-web/Dockerfile }
+          - { service: osm-map-api,      context: ., dockerfile: apps/osm-map-api/Dockerfile }
+          - { service: agentic-os-api,   context: apps/agentic-os-api, dockerfile: Dockerfile }
+          - { service: evidence-console, context: apps/evidence-console, dockerfile: Dockerfile }
+          - { service: evidence-receipts, context: apps/evidence-receipts, dockerfile: Dockerfile }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - run: pip install --quiet pyyaml
+      - name: Build ${{ matrix.service }}
+        run: |
+          docker build -f "${{ matrix.context }}/${{ matrix.dockerfile }}" \
+            -t "probe-contract/${{ matrix.service }}:pr" "${{ matrix.context }}"
+      - name: Does it honour deploy/values/${{ matrix.service }}.yaml?
+        run: |
+          python3 tools/verify_probe_contract.py \
+            --service "${{ matrix.service }}" \
+            --image "probe-contract/${{ matrix.service }}:pr"

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -5,10 +5,16 @@ CI builds images. Nothing checked that the things we DEPLOY line up with the
 things we BUILD — so on 2026-07-15 the cluster had ~9 pods crashlooping for two
 days behind a 100% green pipeline. Every one of those failures passed CI.
 
-Two checks, both static (no registry credentials, runs anywhere):
+Three checks, all static (no registry credentials, runs anywhere):
 
   1. Every service in a deploy/argocd ApplicationSet has a deploy/values/<name>.yaml.
   2. Every FIRST-PARTY service is actually built by .github/workflows/images.yml.
+  3. No service deploys a MOVING tag (`latest`). The chart already states the rule —
+     "Immutable tag = the commit SHA the GitOps promotion writes" — but a comment is
+     a conclusion, not a gate. `latest` + imagePullPolicy: IfNotPresent means kubelet
+     reuses the node cache forever: a fixed image never rolls out, and `rollout
+     restart` does not re-pull. That is how a broken socioprophet-web build survived
+     574 restarts while `latest` in the registry was already fixed.
 
 First-party vs third-party is decided by image.registry: third-party values pin a
 foreign registry explicitly (socbase-auth -> docker.io/supabase/gotrue), while
@@ -56,23 +62,70 @@ NON_CHART_SERVICES = {
 # CI has never published to — so the pods could only ever ImagePullBackOff).
 OUR_REGISTRIES = ("us-central1-docker.pkg.dev/socioprophet-platform/", "registry.socioprophet.ai/")
 
-# Ratchet: known-broken services, reported but not failing the build. This exists so
-# the gate can be enforced TODAY — blocking every NEW violation — without waiting on
-# pre-existing debt whose fix is a product decision rather than a config change.
-# Entries must carry a reason. The list should only ever shrink.
+# Ratchet: pre-existing debt, reported but not failing the build. This exists so the
+# gate can be enforced TODAY — blocking every NEW violation — without waiting on debt
+# whose fix needs a deliberate, verified rollout rather than a midnight sed.
+#
+# Keyed by "<service>:<check>", NOT by service. Keying on the service alone would mean
+# ratcheting one known problem silently masks every FUTURE, unrelated problem in that
+# same service — a hole wearing a gate's clothes.
+#
+# Entries must carry a reason. The list only ever shrinks: if an entry starts passing,
+# the gate FAILS and demands its removal, so it cannot rot into a permanent excuse.
 KNOWN_BROKEN = {
-    "reasoning-failure-runner": (
+    "reasoning-failure-runner:not-built": (
         "apps/reasoning-failure-runner has src/ and examples/ but NO Dockerfile, so no "
         "image can exist — yet platform-services.yaml deploys it, giving a permanent "
         "ImagePullBackOff. It looks like a library that was added to the ApplicationSet "
         "as if it were a service. Fix = add a Dockerfile + images.yml entry, or drop it "
         "from the ApplicationSet. Needs an owner decision, not a config tweak."
     ),
+    "reasoning-failure-runner:moving-tag": (
+        "Same root cause as reasoning-failure-runner:not-built — the image does not "
+        "exist at all, so its tag is moot until someone decides to build it or drop it."
+    ),
+    # The chart has said "Immutable tag = the commit SHA" since it was written; these
+    # 9 predate the check. Pinning them is mechanical BUT NOT SAFE TO BATCH: `latest`
+    # + IfNotPresent means nodes may be running an older cached digest than `latest`
+    # now resolves to, so pinning ROLLS each service to whatever the newest build is.
+    # That is the correct end state and exactly how a latent breakage surfaces — which
+    # is why it wants a deliberate pass with per-service verification, not one commit
+    # that rolls 9 services at once. Each line here is removed as its service is pinned.
+    **{f"{svc}:moving-tag": (
+        "Pre-existing `tag: latest`. Pin to the sha- tag the build publishes, then "
+        "delete this line. Do it per-service and verify the rollout: pinning changes "
+        "which digest actually runs, because the node cache may be older than `latest`."
+    ) for svc in [
+        "api", "agentic-os-api", "eval-fabric-api", "evidence-console",
+        "evidence-receipts", "gateway", "hellgraph-service", "osm-map-api",
+        "search-orchestrator",
+    ]},
 }
 
 # Registries that are explicitly not ours. A values file naming one of these is
 # declaring "third party, we don't build it" — which is a legitimate answer.
 FOREIGN_REGISTRY_RE = re.compile(r"^(docker\.io|ghcr\.io|quay\.io|registry\.k8s\.io|gcr\.io/(?!socioprophet))")
+
+
+
+# The chart says it plainly (charts/socioprophet-service/values.yaml):
+#     "Immutable tag = the commit SHA the GitOps promotion writes."
+# This is that sentence, made executable. Third-party images pin an upstream version
+# (v2.164.0) which is immutable by convention — only `latest` is the trap.
+MOVING_TAGS = {"latest", "main", "master", "dev", "edge", "stable"}
+
+
+def check_moving_tag(name: str, image: dict) -> str | None:
+    tag = str(image.get("tag") or "").strip()
+    if tag.lower() in MOVING_TAGS:
+        return (
+            f"{name}: image.tag is '{tag}' — a MOVING tag. The chart sets "
+            f"imagePullPolicy: IfNotPresent, so once a node caches '{tag}' kubelet "
+            f"never pulls a newer one and `rollout restart` re-runs the stale image. "
+            f"Pin the immutable sha- tag the build publishes "
+            f"(charts/socioprophet-service/values.yaml: 'Immutable tag = the commit SHA')."
+        )
+    return None
 
 
 def deployed_services() -> set[str]:
@@ -123,11 +176,11 @@ def check_kustomize_images(name: str, built: set[str]) -> list[str]:
                 continue  # points at a registry we publish to
             repo = ref.split("/")[-1].split(":")[0]
             if repo in built:
-                problems.append(
+                problems.append((f"{name}:wrong-registry",
                     f"{name}: {manifest.relative_to(ROOT)} pulls '{ref}' but CI builds "
                     f"'{repo}' to {OUR_REGISTRIES[0]}… — the pods pull from a registry "
                     f"the image was never published to."
-                )
+                ))
     return problems
 
 
@@ -147,7 +200,7 @@ def main() -> int:
             continue
         values_path = VALUES_DIR / f"{name}.yaml"
         if not values_path.exists():
-            problems.append(f"{name}: deployed by an ApplicationSet but deploy/values/{name}.yaml is missing")
+            problems.append((f"{name}:no-values", f"{name}: deployed by an ApplicationSet but deploy/values/{name}.yaml is missing"))
             continue
 
         data = yaml.safe_load(values_path.read_text(encoding="utf-8")) or {}
@@ -156,45 +209,49 @@ def main() -> int:
         registry = (image.get("registry") or "").strip()
 
         if not repository:
-            problems.append(f"{name}: values has no image.repository")
+            problems.append((f"{name}:no-repository", f"{name}: values has no image.repository"))
             continue
+
+        # A moving tag is wrong for anyone — ours or upstream's.
+        moving = check_moving_tag(name, image)
+        if moving:
+            problems.append((f"{name}:moving-tag", moving))
 
         if registry and FOREIGN_REGISTRY_RE.match(registry):
             continue  # third-party, we don't build it — legitimately out of scope
 
         checked += 1
         if repository not in built:
-            problems.append(
+            problems.append((f"{name}:not-built",
                 f"{name}: first-party image '{repository}' has NO entry in images.yml — "
                 f"it is deployed but never built, so it can only ImagePullBackOff. "
                 f"Add it to the build matrix, pin a foreign image.registry if it is "
                 f"third-party, or remove the service from the ApplicationSet."
-            )
+            ))
 
-    # Split real failures from ratcheted, already-known debt.
-    blocking = [p for p in problems if p.split(":")[0] not in KNOWN_BROKEN]
-    known = [p for p in problems if p.split(":")[0] in KNOWN_BROKEN]
+    # Split real failures from ratcheted, already-known debt. Keyed by (service, check).
+    blocking = [(k, m) for k, m in problems if k not in KNOWN_BROKEN]
+    known = [(k, m) for k, m in problems if k in KNOWN_BROKEN]
 
     print(f"preflight: {len(services)} deployed, {checked} first-party checked against {len(built)} built images")
 
     if known:
         print("\nKNOWN BROKEN (ratcheted — tracked, not blocking):")
-        for p in known:
-            name = p.split(":")[0]
-            print(f"  • {p}")
-            print(f"      why deferred: {KNOWN_BROKEN[name]}")
+        for k, m in known:
+            print(f"  • {m}")
+            print(f"      why deferred: {KNOWN_BROKEN[k]}")
 
-    stale = sorted(set(KNOWN_BROKEN) - {p.split(":")[0] for p in problems})
+    stale = sorted(set(KNOWN_BROKEN) - {k for k, _ in problems})
     if stale:
         print("\nFAIL — these are in KNOWN_BROKEN but now pass. The ratchet only shrinks:", file=sys.stderr)
-        for name in stale:
-            print(f"  • {name}: fixed — delete it from KNOWN_BROKEN", file=sys.stderr)
+        for key in stale:
+            print(f"  • {key}: now passes — delete it from KNOWN_BROKEN", file=sys.stderr)
         return 1
 
     if blocking:
         print("\nFAIL — a deployment references something that will never resolve:\n", file=sys.stderr)
-        for p in blocking:
-            print(f"  • {p}", file=sys.stderr)
+        for _, m in blocking:
+            print(f"  • {m}", file=sys.stderr)
         return 1
 
     print("OK: every deployed first-party service is built by CI and pulls from a registry we publish to")

--- a/tools/verify_probe_contract.py
+++ b/tools/verify_probe_contract.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Run each service's image and assert it honours the chart contract.
+
+The chart states a contract: the container listens on `.Values.service.port` and
+answers `.Values.probes.path`, as uid 10001 with a read-only rootfs. That contract
+is correct and was, until now, enforced by nobody — so four services violated it
+simultaneously and CI stayed green the whole time:
+
+  socioprophet-web  nginx listened on 80, chart probed 8080          574 restarts
+  osm-map-api       uvicorn binds 8088, values declared 8080         940 restarts
+  agentic-os-api    serves /health, chart probes /healthz            939 restarts
+  gateway           serves /health, chart probes /healthz            620 restarts
+
+Every one is a two-line diff. None was findable by reading YAML, because the truth
+lives in the image, not the manifest. So: start the container the way Kubernetes
+will, and ask it.
+
+This is the difference between a standard and a gate. `docs` say what should be
+true; this asks whether it IS.
+
+Usage:
+  tools/verify_probe_contract.py --service gateway --image <ref>
+  tools/verify_probe_contract.py --all --registry us-central1-docker.pkg.dev/...
+
+Exit 0 = the image honours what the values file promises.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+try:
+    import yaml
+except ModuleNotFoundError:
+    print("verify_probe_contract: PyYAML required", file=sys.stderr)
+    raise SystemExit(1)
+
+ROOT = Path(__file__).resolve().parents[1]
+VALUES_DIR = ROOT / "deploy" / "values"
+CHART_VALUES = ROOT / "charts" / "socioprophet-service" / "values.yaml"
+
+# Services whose image needs real dependencies (a DB, a backend) to answer a probe
+# at all. Their contract is real but not testable by "docker run" alone — asserting
+# it here would produce a red build that teaches nothing.
+NEEDS_DEPENDENCIES = {
+    "api",              # tritRPC core
+    "socbase-auth",     # GoTrue runs migrations against Postgres on boot
+    "socbase-rest",     # PostgREST refuses to start without a reachable DB
+    "gateway",          # /health pings the TriTRPC backend and 502s without it
+    "eval-fabric-api",  # ClickHouse
+    "reasoning-failure-runner",
+}
+
+
+def runtime() -> str:
+    for exe in ("docker", "podman"):
+        if subprocess.run(["which", exe], capture_output=True).returncode == 0:
+            return exe
+    print("verify_probe_contract: need docker or podman", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def chart_defaults() -> dict:
+    d = yaml.safe_load(CHART_VALUES.read_text()) or {}
+    return {
+        "port": ((d.get("service") or {}).get("port")),
+        "path": ((d.get("probes") or {}).get("path")),
+    }
+
+
+def contract_for(service: str) -> dict | None:
+    """What the values file PROMISES: port + probe path, chart defaults applied."""
+    p = VALUES_DIR / f"{service}.yaml"
+    if not p.exists():
+        return None
+    v = yaml.safe_load(p.read_text()) or {}
+    defaults = chart_defaults()
+    return {
+        "port": (v.get("service") or {}).get("port", defaults["port"]),
+        "path": (v.get("probes") or {}).get("path", defaults["path"]),
+        "repository": (v.get("image") or {}).get("repository"),
+        "registry": ((v.get("image") or {}).get("registry") or "").strip(),
+    }
+
+
+def probe(url: str, timeout: float) -> int | None:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return r.status
+    except urllib.error.HTTPError as e:
+        return e.code
+    except Exception:
+        return None
+
+
+def verify(service: str, image: str, rt: str, wait: int = 45) -> tuple[bool, str]:
+    c = contract_for(service)
+    if not c:
+        return False, f"{service}: no deploy/values/{service}.yaml"
+    port, path = c["port"], c["path"]
+    name = f"probe-contract-{service}-{int(time.time())}"
+
+    # Run it the way Kubernetes will: non-root uid 10001, read-only rootfs, no caps,
+    # writable scratch only where the chart provides emptyDirs. A container that only
+    # passes as root proves nothing about how it will actually be scheduled.
+    cmd = [
+        rt, "run", "-d", "--name", name,
+        "--user", "10001:10001", "--read-only", "--cap-drop", "ALL",
+        "--tmpfs", "/tmp:rw,mode=1777",
+        "--tmpfs", "/var/run:rw,mode=0777",
+        "--tmpfs", "/var/cache/nginx:rw,mode=0777",
+        "-p", f"{port}", image,
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        return False, f"{service}: container failed to start: {r.stderr.strip()[:160]}"
+
+    try:
+        # Find the host port the runtime mapped.
+        pr = subprocess.run([rt, "port", name, str(port)], capture_output=True, text=True)
+        m = re.search(r":(\d+)\s*$", pr.stdout.strip().splitlines()[0]) if pr.stdout.strip() else None
+        if not m:
+            return False, f"{service}: image never published container port {port} — the values file promises it"
+        hostport = m.group(1)
+
+        deadline = time.time() + wait
+        last = None
+        while time.time() < deadline:
+            last = probe(f"http://127.0.0.1:{hostport}{path}", 3)
+            if last and 200 <= last < 400:
+                return True, f"{service}: {path} -> {last} on port {port} — contract honoured"
+            time.sleep(1.5)
+
+        logs = subprocess.run([rt, "logs", "--tail", "6", name], capture_output=True, text=True)
+        detail = (logs.stdout + logs.stderr).strip().replace("\n", " | ")[:200]
+        if last is None:
+            return False, (
+                f"{service}: NOTHING listening on port {port} within {wait}s — the values file "
+                f"promises service.port={port}. This is the osm-map-api bug (bound 8088, "
+                f"declared 8080). Container said: {detail}"
+            )
+        return False, (
+            f"{service}: port {port} answers but {path} -> {last} — the chart probes this path "
+            f"and a non-2xx means the kubelet will kill it on a loop. This is the agentic-os-api "
+            f"bug (serves /health, chart probes /healthz). Container said: {detail}"
+        )
+    finally:
+        subprocess.run([rt, "rm", "-f", name], capture_output=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--service")
+    ap.add_argument("--image")
+    ap.add_argument("--all", action="store_true")
+    ap.add_argument("--registry", default="us-central1-docker.pkg.dev/socioprophet-platform/socioprophet")
+    ap.add_argument("--tag", default="latest")
+    args = ap.parse_args()
+    rt = runtime()
+
+    if args.service and args.image:
+        ok, msg = verify(args.service, args.image, rt)
+        print(("OK: " if ok else "FAIL: ") + msg)
+        return 0 if ok else 1
+
+    if not args.all:
+        ap.print_help()
+        return 2
+
+    failures = 0
+    for p in sorted(VALUES_DIR.glob("*.yaml")):
+        service = p.stem
+        c = contract_for(service)
+        if not c or not c["repository"]:
+            continue
+        if service in NEEDS_DEPENDENCIES:
+            print(f"SKIP: {service} — needs live dependencies to answer a probe (see NEEDS_DEPENDENCIES)")
+            continue
+        registry = c["registry"] or args.registry
+        image = f"{registry}/{c['repository']}:{args.tag}"
+        ok, msg = verify(service, image, rt)
+        print(("OK: " if ok else "FAIL: ") + msg)
+        failures += 0 if ok else 1
+
+    print(f"\nprobe-contract: {failures} violation(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The insight this implements

> *"when you pave the road you drive you have to lay the stones"*

Every bug fixed tonight was **implementation drifting from a documented standard** — not one was a design flaw. The estate had already reasoned it through and left the conclusion in a comment. But **a comment is a conclusion, not a gate**: load-bearing for whoever reads the file, completely inert against a merge.

`osm-map-api.yaml` described the gateway's exact bug in a comment. It prevented nothing.

These are two of those comments, made executable.

---

## Stone 1 — "Immutable tag = the commit SHA"

The chart has said it since it was written:

```yaml
# Immutable tag = the commit SHA the GitOps promotion writes.
tag: ""
```

**10 of 13 values files say `tag: latest`.** With `imagePullPolicy: IfNotPresent`, kubelet reuses the node cache forever — a fixed image never rolls out and `rollout restart` doesn't re-pull. That's how a broken `socioprophet-web` survived **574 restarts** while `latest` in the registry was already correct.

`socbase-auth`/`socbase-rest` pin upstream versions (`v2.164.0`, `v12.2.3`) — immutable by convention, correctly **not** flagged. Only moving tags are.

### And it closed a hole I'd have widened

`KNOWN_BROKEN` was keyed by **service**. Ratcheting these 9 for `latest` would have **blinded the gate to those 9 services entirely** — a hole wearing a gate's clothes. Now keyed by `<service>:<check>`.

Proven, all four properties:

| Test | Result |
|---|---|
| Clean tree | ✅ passes |
| **Ratcheted service, different bug** | ✅ **still fails** — no masking |
| New `latest` on a compliant service | ✅ caught |
| Fix a ratcheted item | ✅ fails until its entry is deleted — **the list only shrinks** |

The 9 are **ratcheted, not fixed**, deliberately: pinning changes *which digest runs* (the node cache may be older than `latest` now resolves to), so it rolls each service to the newest build. That's the right end state and exactly how a latent breakage surfaces — it wants a deliberate pass with per-service verification, not one midnight commit rolling 9 services.

---

## Stone 2 — the probe/port contract

The chart promises: listens on `service.port`, answers `probes.path`, as uid 10001 on a read-only rootfs. **Four services violated it at once and CI stayed green** — because the truth lives in the image, not the YAML, and nothing ever started the image and asked.

So it starts the container **the way Kubernetes will** (`--user 10001 --read-only --cap-drop ALL`, scratch only where the chart mounts emptyDirs) and asks. *A container that only passes as root proves nothing about how it'll be scheduled.*

### Verified against the actual bugs, not asserted

| Image | Contract | Verdict |
|---|---|---|
| **pre-#726 socioprophet-web** (stock nginx, port 80) | socioprophet-web | ✅ **FAIL** — *"never published container port 8080 — the values file promises it"* |
| serves `/health`, no catch-all (**the agentic-os-api bug**) | socioprophet-web (`/healthz`) | ✅ **FAIL** — *"port 8080 answers but /healthz → 404 — the kubelet will kill it on a loop"* |
| **that same image** | agentic-os-api (`/health`) | ✅ **OK** |
| compliant image | socioprophet-web | ✅ **OK** |

Same image, opposite verdicts — it reads **the contract**, not a hardcoded path.

### A confession that improved it

My first negative control **passed when it should have failed**. I'd left `location / { return 200 }` — a catch-all that answered `/healthz` by accident, making the test **unfalsifiable**. Rebuilt without it, like a real FastAPI app where unknown paths 404.

**A test that cannot fail for the right reason is not a test** — the same mistake that let the socbase gateway ship 500ing earlier tonight. Catching it in my own harness is the point of running it.

---

## Scope

Services needing a live DB/backend to answer at all (`api`, `socbase-*`, `gateway`, `eval-fabric-api`) are in `NEEDS_DEPENDENCIES` and skipped — their contract is real but not testable by `docker run` alone, and **a red build that teaches nothing is worse than no build**.

## What's left of the original three

- ✅ *"Immutable tag = the commit SHA"* → this PR
- ✅ *probes.path / port contract* → this PR
- ✅ *"no Google in the runner"* → `audit-portability.sh` (#736)