### PR TITLE
fix(socbase-gateway): FQDN upstreams — an explicit resolver ignores the search list

### DIFF
--- a/infra/k8s/socbase-gateway/base/configmap.yaml
+++ b/infra/k8s/socbase-gateway/base/configmap.yaml
@@ -69,7 +69,13 @@ data:
           # literal hostname is resolved while loading config, and nginx REFUSES TO
           # BOOT if it does not resolve — so a momentarily-absent socbase-auth
           # would take the whole gateway down with it.
-          set $upstream_auth socbase-auth;
+          #
+          # FQDN, not "socbase-auth": once you give nginx an explicit `resolver` it
+          # queries the name VERBATIM and does NOT apply the pod's resolv.conf search
+          # list. The short name resolved against GCE's search domains
+          # (socbase-auth.<zone>.c.<project>.internal) and NXDOMAIN'd, so every call
+          # 502'd with "socbase-auth could not be resolved".
+          set $upstream_auth socbase-auth.socioprophet.svc.cluster.local;
           rewrite ^/auth/v1/(.*)$ /$1 break;
           proxy_pass http://$upstream_auth:9999;
           proxy_set_header Host              $host;
@@ -79,7 +85,7 @@ data:
 
         # supabase-js -> PostgREST. Strip /rest/v1.
         location /rest/v1/ {
-          set $upstream_rest socbase-rest;
+          set $upstream_rest socbase-rest.socioprophet.svc.cluster.local;
           rewrite ^/rest/v1/(.*)$ /$1 break;
           proxy_pass http://$upstream_rest:3000;
           proxy_set_header Host              $host;


### PR DESCRIPTION
## The last hop

With #738's set/rewrite order fixed, every proxied call moved **500 → 502**:

```
[error] socbase-auth could not be resolved (3: Host not found)
nslookup: socbase-auth.us-central1-a.c.socioprophet-platform.internal: NXDOMAIN
```

**Once nginx is given an explicit `resolver`, it queries the name verbatim and does NOT apply the pod's `/etc/resolv.conf` search list.** So `socbase-auth` never expanded to `socbase-auth.socioprophet.svc.cluster.local` — it fell through to *GCE's* internal search domains and NXDOMAIN'd.

Use FQDNs. The `resolver` and the `$variable` both stay — they're what keep the gateway booting when an upstream is briefly absent (#737) — but with an explicit resolver **you own the full name**.

## Three bugs, one config, each hiding the next

| # | Bug | Symptom |
|---|---|---|
| 1 | literal hostname in `proxy_pass` | nginx **refused to boot** — "host not found in upstream" |
| 2 | `set` after `rewrite ... break` | **500** — "uninitialized variable", proxied to `http://:9999` |
| 3 | short name + explicit resolver | **502** — NXDOMAIN against GCE search domains |

Each fix revealed the next, and **each was only findable by running it** — the pod stayed `1/1 Running` with `/healthz` **200** through all three, because the probe deliberately doesn't touch the upstreams. Healthy-looking and completely broken: the estate's signature failure.

That's also the argument for the probe-contract gate in #739 — it asserts the *contract*, and a gateway's contract is that it **proxies**, which is why this needed a real upstream to prove.