### PR TITLE
feat(dashboard-bff): host the /v1 data plane — makes ST012/ST013 demoable from prod

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -53,6 +53,7 @@ jobs:
           - { image: agentic-os-api,        context: apps/agentic-os-api,       dockerfile: Dockerfile }
           - { image: hellgraph-service,     context: apps/hellgraph-service,    dockerfile: Dockerfile }
           - { image: osm-map-api,           context: .,                         dockerfile: apps/osm-map-api/Dockerfile }
+          - { image: dashboard-bff,         context: .,                         dockerfile: apps/dashboard-bff/Dockerfile }
           - { image: workspace-mail,        context: services/workspace-mail,   dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: workspace-caldav,      context: services/workspace-caldav, dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: workspace-smtp,        context: services/workspace-smtp,   dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }

--- a/apps/dashboard-bff/Dockerfile
+++ b/apps/dashboard-bff/Dockerfile
@@ -1,0 +1,34 @@
+# BUILD CONTEXT = REPO ROOT (see .github/workflows/images.yml). main.py loads seven
+# producer modules from ROOT/tools at import time (Path(__file__).parents[2]), and
+# those producers read files from SEVERAL sibling trees at REQUEST time. Every path
+# below was found by running the container and hitting each /v1 route the SPA calls,
+# not by reading imports — the failures only show up at request time:
+#   apps/dashboard-bff        main.py + its data/ (vdt, gyg)
+#   tools                     the 7 emit_* producers (stdlib-only)
+#   apps/hellgraph-service/seeds   gyg-supply-chain-causal.json (/v1/valuation/causal)
+#   schemas/eval              metric-*.schema.json (/v1/intelligence-superiority validates)
+# Missing any one = a 200 on /health and a 500 on the route that needs it — the
+# estate's signature "healthy-looking, broken" shape. Copy exactly these, no more.
+FROM python:3.11-slim
+
+RUN useradd -u 10001 -m -s /usr/sbin/nologin app
+WORKDIR /app
+
+COPY apps/dashboard-bff/requirements.txt ./apps/dashboard-bff/requirements.txt
+RUN pip install --no-cache-dir -r apps/dashboard-bff/requirements.txt
+
+COPY apps/dashboard-bff ./apps/dashboard-bff
+COPY tools ./tools
+COPY apps/hellgraph-service/seeds ./apps/hellgraph-service/seeds
+COPY schemas/eval ./schemas/eval
+
+RUN chown -R 10001:10001 /app
+USER 10001
+
+# 8080 + /health is the chart contract (service.port / probes.path). The values file
+# sets probes.path=/health because that is what main.py serves — asserted by the
+# probe-contract gate, not assumed.
+EXPOSE 8080
+ENV DASHBOARD_BFF_CORS_ORIGINS="https://app.socioprophet.com"
+WORKDIR /app/apps/dashboard-bff
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/apps/dashboard-bff/requirements.txt
+++ b/apps/dashboard-bff/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.115.0
 uvicorn==0.30.6
+jsonschema==4.23.0

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -22,6 +22,7 @@ spec:
           - { name: agentic-os-api }
           - { name: hellgraph-service }
           - { name: osm-map-api }
+          - { name: dashboard-bff }
           - { name: reasoning-failure-runner }
           - { name: search-orchestrator }
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,

--- a/deploy/values/dashboard-bff.yaml
+++ b/deploy/values/dashboard-bff.yaml
@@ -1,0 +1,24 @@
+# dashboard-bff — the /v1/* data plane behind the SocioProphet SPA. Serves the
+# governance test (ST012), provenance/valuation reads (ST013/ST006), VDT, and the
+# intelligence-superiority metrics. Hosting this is what makes those MERGED features
+# actually demoable from app.socioprophet.com — the deployed site cannot serve /v1/*
+# until this runs.
+#
+# Read/display surface only. Two interactive routes degrade by design without the
+# economic-prophet engine (POST /v1/valuation/causal/recompute) or live network
+# (GET /v1/valuation/studio?ticker=) — the code imports the engine lazily and falls
+# back to a stub, exactly as documented in tools/emit_gyg_causal.py. Bundling the
+# engine is a deliberate follow-up, not a blocker for the demo surface.
+image: { repository: dashboard-bff }
+service: { port: 8080, portName: http }
+# main.py serves @app.get('/health'), NOT the chart default /healthz. Asserted by the
+# probe-contract gate.
+probes:
+  path: /health
+config:
+  DASHBOARD_BFF_CORS_ORIGINS: "https://app.socioprophet.com"
+ingress:
+  enabled: true
+  className: ""
+  hosts: [{ host: bff.socioprophet.ai, paths: [{ path: /, pathType: Prefix }] }]
+autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 4 }


### PR DESCRIPTION
## Why

ST012 (governance test) and ST013 (provenance view) are **merged and "done"** — but the deployed prod site **cannot serve `/v1/*`**, so neither is demoable from `app.socioprophet.com`. ST012 exists to answer *"show me governance."* **Undemoable is the same as unbuilt.**

The `dashboard-bff` is a FastAPI app that was never containerized, never built by CI, never deployed. This hosts it — the cheapest way to make finished work count.

## What it serves (verified under the chart's exact pod constraints)

`--user 10001 --read-only --cap-drop ALL` — **8 of 10 GET routes 200**, including everything ST012/ST013/ST006 need:

| Route | | |
|---|---|---|
| `/v1/governance/test` | ✅ 200 | returns a **real sealed AutonomyAdmissionReceipt** (ST012) |
| `/v1/intelligence-superiority` | ✅ 200 | |
| `/v1/valuation/causal` | ✅ 200 | causal-valuation display (ST006/ST013) |
| `/v1/vdt`, `/v1/vdt/catalog` | ✅ 200 | |
| `/v1/locations`, `/v1/overview`, `/v1/valuation/studio/templates` | ✅ 200 | |

## The Dockerfile copy set was found by running it, not reading imports

The producers read files from **four sibling trees at request time**, and each missing one is a **200 on `/health` and a 500 on its route** — the estate's signature "healthy-looking, broken" shape. Found by hitting every SPA route:

```
apps/dashboard-bff, tools, apps/hellgraph-service/seeds, schemas/eval  (+ jsonschema)
```

## The two 500s are BY DESIGN, not build bugs

| Route | Cause |
|---|---|
| `POST /v1/valuation/causal/recompute` | Runs the canonical **economic-prophet engine** (`open_ep_framework`) — a **sister repo**, imported lazily; the code documents it degrades to a stub without it (*"bind economic-prophet, never fork the value model"*) |
| `GET /v1/valuation/studio?ticker=` | Pulls **live Yahoo Finance** |

Both are the *interactive* extras of ST006, not the read/display surface ST012/ST013 need. **Bundling the engine + wiring live market data is a deliberate follow-up**, scoped out honestly rather than shipped half-broken.

## Wiring — all three, so a manifest nothing reads doesn't deploy nothing

- `apps/dashboard-bff/Dockerfile` (repo-root context)
- `deploy/values/dashboard-bff.yaml` — port 8080, **`probes.path=/health`** (what `main.py` serves, not `/healthz`), non-root, read-only
- `images.yml` build matrix
- `platform-services` ApplicationSet

Obeys the contract the **gates now enforce** — both green: preflight (`OK`) and probe-contract (`/health -> 200 on port 8080 — contract honoured`). Ingress at `bff.socioprophet.ai`; needs no cluster secret (CORS env-configured to `app.socioprophet.com`).

## After merge

Add DNS `bff.socioprophet.ai` → the ingress IP → cert provisions → the SPA's governance/provenance/valuation surfaces work **live from prod**, not just locally. That's ST012/ST013 crossing from "merged" to "demoable."