### PR TITLE
fix(socbase): reprovision the stuck cert (socbase-cert → -v2)

### DIFF
--- a/infra/k8s/socbase-gateway/base/ingress.yaml
+++ b/infra/k8s/socbase-gateway/base/ingress.yaml
@@ -1,7 +1,13 @@
 apiVersion: networking.gke.io/v1
+# -v2: the original socbase-cert was created 2026-07-16 01:13 UTC, ~10h BEFORE the
+# socbase DNS A-record existed, so Google's CA spent 10 hours seeing NXDOMAIN and its
+# retry backoff stalled at FailedNotVisible even after DNS went live. A ManagedCertificate
+# cannot be nudged; a NEW name forces a fresh certificate object and a clean validation
+# cycle. If this ever stalls again, confirm DNS is globally visible FIRST (dig @8.8.8.8),
+# then bump the suffix — do not just wait, the clock is already poisoned.
 kind: ManagedCertificate
 metadata:
-  name: socbase-cert
+  name: socbase-cert-v2
   namespace: socioprophet
 spec:
   domains: [socbase.socioprophet.ai]
@@ -12,7 +18,7 @@ metadata:
   name: socbase-gateway
   namespace: socioprophet
   annotations:
-    networking.gke.io/managed-certificates: socbase-cert
+    networking.gke.io/managed-certificates: socbase-cert-v2
     # `gce`, NOT `nginx`. The old socbase-auth/socbase-rest Ingresses asked for
     # ingressClassName: nginx — a controller that has never existed in this
     # cluster — so they sat at ADDRESS <none> forever and socbase was unreachable


### PR DESCRIPTION
## The cert has been stuck 10+ hours

```
socbase-cert created : 2026-07-16 01:13 UTC
now                  : 11:56 UTC   (10h43m in Provisioning)
DNS visible          : 136.68.18.155 @ authoritative NS AND @8.8.8.8  ✅
LB backend           : HEALTHY  ✅
cert status          : Provisioning / FailedNotVisible  ❌
```

DNS resolves globally and the backend is healthy, yet the cert never left `FailedNotVisible`.

## Cause

I created `socbase-cert` at **01:13**, but the `socbase` DNS A-record wasn't added until **~11:00** this morning. So Google's managed-cert CA spent **10 hours seeing NXDOMAIN**, and its retry backoff stalled — it did **not** recover on its own once DNS went live.

## Why rename, not delete

A `ManagedCertificate` isn't nudgeable, and this one is **ArgoCD-managed** — a `kubectl delete` would just trigger `selfHeal` to recreate the *same stale name* with the *same poisoned clock*. A **new name forces a new certificate object and a clean validation cycle** now that DNS is correct.

`socbase-cert` → `socbase-cert-v2`, updated in both the `ManagedCertificate` and the ingress annotation.

## Distinct from last night's judgment call

Last night I *correctly* waited on the zot cert's `FailedNotVisible` — because there the clock was **genuinely fresh** (DNS had just been added, ~20 min in). The lesson held: *don't recreate a fresh cert, the clock starts at DNS-visibility.*

This is the opposite case: **the clock is 10 hours poisoned.** The rule that distinguishes them is now in the manifest comment — *confirm DNS is globally visible first (`dig @8.8.8.8`), then bump the suffix; don't just wait.*

## After merge

ArgoCD applies → `socbase-cert-v2` provisions from a clean state (~15–60 min, DNS already visible so no NXDOMAIN wait) → `https://socbase.socioprophet.ai` goes live → the Firebase auth replacement is reachable, and `supabase-js` can point at it.