### PR TITLE
fix(dashboard-bff): pin the sha tag — appVersion default 26.11 doesn't exist

### DIFF
--- a/deploy/values/dashboard-bff.yaml
+++ b/deploy/values/dashboard-bff.yaml
@@ -9,7 +9,11 @@
 # (GET /v1/valuation/studio?ticker=) — the code imports the engine lazily and falls
 # back to a stub, exactly as documented in tools/emit_gyg_causal.py. Bundling the
 # engine is a deliberate follow-up, not a blocker for the demo surface.
-image: { repository: dashboard-bff }
+# Pin the immutable sha- tag the build published (the chart's appVersion default is
+# 26.11, which this image does not carry — that mismatch is what left it in
+# ImagePullBackOff). This is the very standard tools/preflight_deploy_contract.py now
+# enforces: "Immutable tag = the commit SHA the GitOps promotion writes."
+image: { repository: dashboard-bff, tag: sha-a7a59844953b09b2622adc30d88a0be71456fc1d }
 service: { port: 8080, portName: http }
 # main.py serves @app.get('/health'), NOT the chart default /healthz. Asserted by the
 # probe-contract gate.


### PR DESCRIPTION
## The ImagePullBackOff

dashboard-bff (#741) deployed but sat in **ImagePullBackOff for 108m**:

```
deploy wants : dashboard-bff:26.11        ← chart appVersion default
GAR has      : latest, sha-a7a59844…, .sig
```

My values file **omitted `image.tag`**, so the chart filled its `appVersion` default (`26.11`) — a tag the build never produced. The build pushed `sha-a7a59844…` and `latest`; the deploy looked for `26.11`.

## Fix

Pin the immutable sha tag the build published (**verified present in GAR before pinning**). This is exactly the standard the immutable-tag gate now enforces — the values file should have carried it from the start.

## ⚠️ Gap this exposes in the gate (flagging, not fixing here)

The immutable-tag check in `preflight_deploy_contract.py` catches `latest`/`main`/`dev` — but an **omitted/empty tag** passed clean, because empty isn't in `MOVING_TAGS`. Yet an omitted tag defaults to `appVersion`, which for a first-party service is a tag the build doesn't produce — a real ImagePullBackOff, as this proves. **Follow-up: the gate should also flag first-party services with no explicit `image.tag`.** Worth doing since it would have caught this before merge.

## After merge

ArgoCD re-syncs → pods pull `sha-a7a59844…` → dashboard-bff goes Ready → `/v1/*` served → ST012/ST013 demoable from prod (once `bff.socioprophet.ai` DNS lands).