### PR TITLE
feat(searxng): deploy the sovereign search backend for Noetica web_search

### DIFF
--- a/deploy/argocd/search-services.yaml
+++ b/deploy/argocd/search-services.yaml
@@ -1,0 +1,41 @@
+# Argo CD ApplicationSet — sovereign search (SearXNG).
+#
+# SearXNG is the keyless, self-hosted meta-search backend behind Noetica's web_search
+# tool. It replaces a rented Google-search API (Serper) and the HTML scrapers that
+# search engines block from datacenter IPs — the real "web search came back empty"
+# bug. Same house convention as zot/socbase: kustomize, GCE-free ClusterIP (internal
+# only, NetworkPolicy-restricted), image pulled through zot.
+#
+# Prereqs (out of band, NOT in git): the `searxng-secret` Secret (key: secret) and the
+# `zot-pull` Secret. Noetica points SEARXNG_URL at http://searxng:8080 in-cluster.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: search-services
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          - { name: searxng, path: infra/k8s/searxng/base }
+  template:
+    metadata:
+      name: 'search-{{.name}}'
+      labels:
+        app.kubernetes.io/part-of: sovereign-search
+    spec:
+      project: default
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: socioprophet
+      source:
+        repoURL: https://github.com/SocioProphet/prophet-platform
+        targetRevision: main
+        path: '{{.path}}'
+      syncPolicy:
+        automated: { prune: true, selfHeal: true }
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/infra/k8s/searxng/base/configmap.yaml
+++ b/infra/k8s/searxng/base/configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: searxng-settings
+  namespace: socioprophet
+  labels:
+    app: searxng
+    app.kubernetes.io/part-of: sovereign-search
+data:
+  # SearXNG = the sovereign, keyless meta-search backend for Noetica's web_search tool.
+  # It replaces a rented Google-search API (Serper) and the HTML scrapers that engines
+  # actively block from datacenter IPs — DuckDuckGo returns a 202 challenge with zero
+  # results server-side, which was the real "web search came back empty" bug. Pattern:
+  # zot : registries :: gitea : GitHub :: socbase : Firebase :: SearXNG : Google-search.
+  #
+  # Two settings matter and both were found the hard way (a stock instance 403s the
+  # JSON API):
+  #   formats: [html, json] — the JSON API is DISABLED by default; the agent needs it.
+  #   limiter: false        — the bot-limiter blocks server-side json callers. Safe to
+  #                           disable because this instance is NOT public — a NetworkPolicy
+  #                           restricts it to in-cluster callers (see networkpolicy.yaml).
+  settings.yml: |
+    use_default_settings: true
+    server:
+      # secret_key is injected from the searxng-secret Secret via env at runtime,
+      # not committed here.
+      limiter: false
+      public_instance: false
+      image_proxy: false
+    search:
+      formats:
+        - html
+        - json
+      safe_search: 0
+    engines:
+      # A lean, reliable default set. SearXNG aggregates these; if one is down the
+      # others still answer — the robustness a single scraper never had.
+      - name: wikipedia
+        disabled: false
+      - name: duckduckgo
+        disabled: false
+      - name: brave
+        disabled: false
+      - name: bing
+        disabled: false

--- a/infra/k8s/searxng/base/deployment.yaml
+++ b/infra/k8s/searxng/base/deployment.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: searxng
+  namespace: socioprophet
+  labels:
+    app: searxng
+    app.kubernetes.io/part-of: sovereign-search
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: searxng }
+  template:
+    metadata:
+      labels: { app: searxng }
+    spec:
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 977          # searxng's own uid in the upstream image
+        fsGroup: 977
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: searxng
+          # Pulled through zot (proxies docker.io on demand) so the sovereign search
+          # backend does not depend on Docker Hub being reachable. Pinned by DIGEST —
+          # the most immutable ref there is, and it honours the no-moving-tag standard
+          # (searxng publishes no stable semver tag we can pin, only `latest`, so we
+          # pin the digest `latest` currently resolves to; re-resolve to bump).
+          image: registry.socioprophet.ai/searxng/searxng@sha256:969e3d79c400b26b7b83c023ef48300d9e122e0828ef7160daac990b1ac27d7c
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: SEARXNG_SECRET
+              valueFrom:
+                secretKeyRef: { name: searxng-secret, key: secret }
+            - name: SEARXNG_SETTINGS_PATH
+              value: /etc/searxng/settings.yml
+            # Instance base URL — used by SearXNG for absolute links only.
+            - name: SEARXNG_BASE_URL
+              value: http://searxng.socioprophet.svc.cluster.local:8080/
+          # /healthz is SearXNG's own liveness route and does NOT run a search, so a
+          # slow upstream engine never restarts the pod (the liveness-must-not-check-
+          # dependencies lesson).
+          readinessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          resources:
+            requests: { cpu: 100m, memory: 192Mi }
+            limits:   { cpu: "1",  memory: 512Mi }
+          volumeMounts:
+            - { name: settings, mountPath: /etc/searxng/settings.yml, subPath: settings.yml, readOnly: true }
+            # readOnlyRootFilesystem: searxng writes a small runtime cache + its pid.
+            - { name: cache, mountPath: /var/cache/searxng }
+            - { name: run,   mountPath: /var/run }
+      volumes:
+        - name: settings
+          configMap: { name: searxng-settings }
+        - name: cache
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+      imagePullSecrets:
+        - name: zot-pull
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: searxng
+  namespace: socioprophet
+  labels: { app: searxng }
+spec:
+  type: ClusterIP        # internal only — Noetica reaches it at SEARXNG_URL in-cluster
+  selector: { app: searxng }
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: searxng
+  namespace: socioprophet
+  labels: { app: searxng }
+spec:
+  # limiter:false is only safe because the instance is not publicly reachable. This
+  # is the enforcement of that: ingress to searxng is allowed only from inside the
+  # namespace (the Noetica agent), never from outside the cluster.
+  podSelector: { matchLabels: { app: searxng } }
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels: { kubernetes.io/metadata.name: socioprophet }
+      ports:
+        - { protocol: TCP, port: 8080 }

--- a/infra/k8s/searxng/base/kustomization.yaml
+++ b/infra/k8s/searxng/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: socioprophet
+resources:
+  - configmap.yaml
+  - deployment.yaml

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -55,6 +55,7 @@ NON_CHART_SERVICES = {
     "workspace-mail",
     "workspace-caldav",
     "workspace-smtp",
+    "searxng",   # sovereign meta-search, deploys from infra/k8s/searxng (kustomize)
 }
 
 # Registry hosts this platform actually publishes to. An image ref pointing anywhere


### PR DESCRIPTION
## ST014 (search half) — the sovereign fix, deploy side

Pairs with Noetica **`feat/st014-sovereign-search`**, which points `web_search` at this instance.

### The bug (confirmed live, not assumed)

Noetica's `web_search` degraded to nothing without a **paid Serper (Google) key** — every keyless fallback is an HTML scraper that engines actively block from datacenter IPs:

```
$ curl https://html.duckduckgo.com/html/?q=... (server-side)
HTTP 202  |  result__a matches: 0   ← challenge page, zero results
```

That's *"Gus couldn't get out to search"* — and it's **worse from a cloud-deployed agent** than a laptop.

### The fix

**SearXNG** — self-hosted, keyless meta-search. No API key, no big-tech account, aggregates 70+ engines, JSON API. The search analog of the whole stack:

> zot : registries :: gitea : GitHub :: socbase : Firebase :: **SearXNG : Google-search**

### What ships here

| | |
|---|---|
| `infra/k8s/searxng/` | ConfigMap + Deployment + Service + **NetworkPolicy** (kustomize) |
| `deploy/argocd/search-services.yaml` | its own ApplicationSet |
| Access | **ClusterIP + NetworkPolicy — internal only.** Noetica reaches it at `http://searxng.socioprophet.svc.cluster.local:8080`; nothing outside the cluster can |
| Image | pulled through **zot**, **pinned by digest** (searxng ships no stable semver tag, only `latest`) |

### Two config facts found the hard way (verified in podman — a stock instance 403s the JSON API)

- `formats: [html, json]` — **the JSON API is disabled by default**; the agent needs it
- `limiter: false` — the bot-limiter blocks server-side JSON callers. **Safe only because the NetworkPolicy makes this instance non-public** — which is why that policy is in the same manifest, not an afterthought

### Estate lessons baked in from the start

Non-root uid 977, read-only rootfs (writable emptyDirs for cache + pid), `enableServiceLinks: false`, and `/healthz` probes that **do not run a search** — so a slow upstream engine never restarts the pod.

### Proof

Ran a real SearXNG in podman with this exact config and the exact `searxngSearch()` from the Noetica PR: **"capital of Australia" → Canberra (Wikipedia/Britannica), 53 hits** where DDG returned zero. kustomize renders (4 manifests), preflight gate passes, image digest verified pullable via zot before pinning.

### After merge

`searxng-secret` (out-of-band, like the other bootstrap secrets) → ArgoCD deploys → set `SEARXNG_URL` on the Noetica agent → web_search is sovereign, keyless, and actually works.