### PR TITLE
fix(searxng): writable /tmp — readOnlyRootFilesystem left the worker with no tempdir

### DIFF
--- a/infra/k8s/searxng/base/deployment.yaml
+++ b/infra/k8s/searxng/base/deployment.yaml
@@ -64,12 +64,18 @@ spec:
             # readOnlyRootFilesystem: searxng writes a small runtime cache + its pid.
             - { name: cache, mountPath: /var/cache/searxng }
             - { name: run,   mountPath: /var/run }
+            # readOnlyRootFilesystem: searxng (granian/python) needs a writable /tmp for
+            # tempfile — without it the worker dies "No usable temporary directory found".
+            # podman's --tmpfs /tmp masked this locally; the manifest must be explicit.
+            - { name: tmp,   mountPath: /tmp }
       volumes:
         - name: settings
           configMap: { name: searxng-settings }
         - name: cache
           emptyDir: {}
         - name: run
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
       imagePullSecrets:
         - name: zot-pull


### PR DESCRIPTION
## searxng crashlooped in-cluster

```
FileNotFoundError: No usable temporary directory found in
  ['/tmp', '/var/tmp', '/usr/tmp', '/usr/local/searxng']
[ERROR] Unexpected exit from worker-1
```

granian/python needs a writable `/tmp` for `tempfile`, and `readOnlyRootFilesystem` makes the image's `/tmp` read-only. I mounted emptyDirs at `/var/cache/searxng` and `/var/run` — but **not `/tmp`**.

## Why my local verification missed it

I proved SearXNG worked in podman with `--tmpfs /tmp`, which **masked the gap** — the local harness was more permissive than the pod. Same class as the socbase-gateway (`--resolve` bypassing DNS): a test environment that's kinder than production hides the bug it's supposed to catch.

## Fix

One `/tmp` emptyDir mount + volume. kustomize renders.

## Note (not in this PR)

The pod also hit transient `FailedScheduling: Insufficient memory` on 3 of 4 nodes — the cluster is tight. Not blocking (it scheduled), but worth watching if more services land.