### PR TITLE
feat(commons-search): Phase 1c — internal-only go-live + security hardening

### DIFF
--- a/apps/commons-search/src/auth.ts
+++ b/apps/commons-search/src/auth.ts
@@ -11,8 +11,18 @@
  * by the pseudonym on the token, so no caller can revoke another author's chat.
  */
 import type { IncomingMessage } from 'node:http'
+import { timingSafeEqual } from 'node:crypto'
 
 export interface Principal { author: string }
+
+/** Constant-time token comparison — a plain `!==` short-circuits and leaks the token byte-by-byte via timing,
+ *  which matters once /publish is reachable off-cluster. Length is compared first (timingSafeEqual throws on a
+ *  length mismatch); that only reveals the token LENGTH, not its bytes. */
+function tokenEquals(got: string, need: string): boolean {
+  const a = Buffer.from(got)
+  const b = Buffer.from(need)
+  return a.length === b.length && timingSafeEqual(a, b)
+}
 
 export interface AuthResult { ok: boolean; principal?: Principal; error?: string }
 
@@ -27,7 +37,7 @@ export function authenticatePublish(req: IncomingMessage): AuthResult {
   if (!need) return { ok: false, error: 'commons publishing is not configured (COMMONS_PUBLISH_TOKEN unset)' }
   const auth = req.headers['authorization']
   const got = (Array.isArray(auth) ? auth[0] : auth ?? '').replace(/^Bearer\s+/i, '')
-  if (got !== need) return { ok: false, error: 'invalid or missing publish token' }
+  if (!tokenEquals(got, need)) return { ok: false, error: 'invalid or missing publish token' }
   const sid = req.headers['x-sovereign-id']
   const author = cleanPseudonym(Array.isArray(sid) ? sid[0] ?? '' : sid ?? '')
   if (!author) return { ok: false, error: 'X-Sovereign-Id (author pseudonym) required' }

--- a/apps/commons-search/src/server.test.ts
+++ b/apps/commons-search/src/server.test.ts
@@ -12,6 +12,8 @@ before(async () => {
   process.env['COMMONS_PUBLISH_TOKEN'] = TOKEN
   process.env['COMMONS_RATE_PER_MIN'] = '60'
   process.env['COMMONS_RATE_BURST'] = '3'
+  process.env['COMMONS_SEARCH_RATE_PER_MIN'] = '60'
+  process.env['COMMONS_SEARCH_BURST'] = '3'
   server = makeServer(new InMemoryStore())
   await new Promise<void>((r) => server.listen(0, r))
   base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
@@ -75,4 +77,19 @@ test('per-author publish rate cap returns 429 past the burst', async () => {
     if (r.status === 429) { got429 = true; break }
   }
   assert.ok(got429, 'rate limit never triggered')
+})
+
+test('search is rate-limited (CPU-DoS brake on the public endpoint)', async () => {
+  let got429 = false
+  for (let i = 0; i < 12; i++) {
+    const r = await fetch(`${base}/api/open-chats/search?q=anything`, { headers: { 'x-forwarded-for': '9.9.9.9' } })
+    if (r.status === 429) { got429 = true; break }
+  }
+  assert.ok(got429, 'search rate limit never triggered')
+})
+
+test('a wrong token of the SAME length is still rejected (constant-time compare works)', async () => {
+  const sameLen = 'x'.repeat(TOKEN.length)
+  const r = await publish({ sessionId: 's', title: 't', redacted: 'hi' }, { authorization: `Bearer ${sameLen}` })
+  assert.equal(r.status, 401)
 })

--- a/apps/commons-search/src/server.ts
+++ b/apps/commons-search/src/server.ts
@@ -39,6 +39,9 @@ function readBody(req: http.IncomingMessage): Promise<string> {
 export function makeServer(store: CommonsStore): http.Server {
   // Constructed per-server (not at module load) so config env set by callers/tests is honoured.
   const limiter = new RateLimiter(Number(process.env['COMMONS_RATE_PER_MIN'] ?? 30), Number(process.env['COMMONS_RATE_BURST'] ?? 10))
+  // Search is unauthenticated (a commons is meant to be searchable) and lexicalSearch is O(corpus) per query, so
+  // an un-throttled flood is a CPU-DoS. Cap per client IP — generous, just a brake on abuse.
+  const searchLimiter = new RateLimiter(Number(process.env['COMMONS_SEARCH_RATE_PER_MIN'] ?? 120), Number(process.env['COMMONS_SEARCH_BURST'] ?? 40))
   return http.createServer((req, res) => {
     void (async () => {
       const url = new URL(req.url ?? '/', `http://localhost:${PORT}`)
@@ -77,6 +80,8 @@ export function makeServer(store: CommonsStore): http.Server {
 
         // ── search (public, json_engine shape) ──
         if (req.method === 'GET' && url.pathname === '/api/open-chats/search') {
+          const ip = (req.headers['x-forwarded-for']?.toString().split(',')[0]?.trim()) || req.socket.remoteAddress || 'unknown'
+          if (!searchLimiter.allow(ip)) return json(res, 429, { query: '', number_of_results: 0, results: [], error: 'search rate exceeded' })
           const q = url.searchParams.get('q') ?? ''
           const hits = await store.search(q, 6)
           const results = hits.map((h) => ({

--- a/deploy/argocd/search-services.yaml
+++ b/deploy/argocd/search-services.yaml
@@ -20,6 +20,11 @@ spec:
     - list:
         elements:
           - { name: searxng, path: infra/k8s/searxng/base }
+          # The open-chat commons aggregator — instances publish REDACTED open chats here (floor-gated on
+          # ingest), and SearXNG's json_engine (see the searxng ConfigMap) searches the corpus. ClusterIP +
+          # NetworkPolicy = internal-only; an authenticated external /publish ingress is a separate, deliberate
+          # decision. Prereq (out of band, NOT in git): the `commons-search-secret` Secret (key: publish-token).
+          - { name: commons-search, path: infra/k8s/commons-search/base }
   template:
     metadata:
       name: 'search-{{.name}}'

--- a/infra/k8s/commons-search/base/deployment.yaml
+++ b/infra/k8s/commons-search/base/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: commons-search
+  namespace: socioprophet
+  labels:
+    app: commons-search
+    app.kubernetes.io/part-of: sovereign-search
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: commons-search }
+  template:
+    metadata:
+      labels: { app: commons-search }
+    spec:
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000          # the `node` user in node:20-slim (Dockerfile: USER node)
+        fsGroup: 1000
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: commons-search
+          # First-party image built by .github/workflows/images.yml, pinned by the immutable sha- tag the build
+          # published (the no-moving-tag standard: sha- tag + IfNotPresent is safe because the tag never moves).
+          image: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/commons-search:sha-bbf2abc6e230dca0f86de9fa47818833a49a1f46
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            # Store: memory for this internal-only go-live (per-pod, ephemeral). The corpus is populated only once
+            # publishers exist; switching to a shared/persistent backend (socbase/minio/hellgraph) is an env change.
+            - name: COMMONS_STORE
+              value: "memory"
+            # Publishing is FAIL-CLOSED without this token, so even internally nothing can write anonymously. The
+            # Secret is provisioned out of band (NOT in git), same posture as searxng-secret.
+            - name: COMMONS_PUBLISH_TOKEN
+              valueFrom:
+                secretKeyRef: { name: commons-search-secret, key: publish-token }
+            # tsx/npx + node need a writable HOME (.npm cache) and /tmp under readOnlyRootFilesystem — provide them
+            # explicitly (the searxng "No usable temporary directory" lesson: the manifest must be explicit).
+            - name: HOME
+              value: /home/node
+          readinessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          resources:
+            requests: { cpu: 50m, memory: 128Mi }
+            limits:   { cpu: "1", memory: 512Mi }
+          volumeMounts:
+            - { name: home, mountPath: /home/node }
+            - { name: tmp,  mountPath: /tmp }
+      volumes:
+        - name: home
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: commons-search
+  namespace: socioprophet
+  labels: { app: commons-search }
+spec:
+  type: ClusterIP          # internal only — SearXNG reaches it in-cluster; there is NO external ingress (Phase 1c
+  selector: { app: commons-search }   # is internal-only by design; an authenticated /publish ingress is a
+  ports:                              # separate, deliberate decision, not created here).
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: commons-search
+  namespace: socioprophet
+  labels: { app: commons-search }
+spec:
+  # Ingress ONLY from inside the namespace (SearXNG, and any in-cluster publisher). Nothing outside the cluster can
+  # reach /publish or /search. This is the enforcement of "internal-only" — the commons is not internet-facing.
+  podSelector: { matchLabels: { app: commons-search } }
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels: { kubernetes.io/metadata.name: socioprophet }
+      ports:
+        - { protocol: TCP, port: 8080 }

--- a/infra/k8s/commons-search/base/kustomization.yaml
+++ b/infra/k8s/commons-search/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: socioprophet
+resources:
+  - deployment.yaml

--- a/infra/k8s/searxng/base/configmap.yaml
+++ b/infra/k8s/searxng/base/configmap.yaml
@@ -43,3 +43,20 @@ data:
         disabled: false
       - name: bing
         disabled: false
+      # The open-chat community commons — a sovereign search corpus no rented search API can have, built from
+      # consenting, REDACTED human conversation (commons-search aggregator, internal-only). A declarative
+      # json_engine (no custom Python image needed) queries the internal endpoint, so ONE SearXNG query returns
+      # web results + open-community-chat matches, unified — which is the whole point. The corpus is redacted at
+      # ingest and each snippet is injection-stripped there; results still flow through Noetica's web_search
+      # EXTERNAL marking on the way back.
+      - name: noetica commons
+        engine: json_engine
+        search_url: http://commons-search.socioprophet.svc.cluster.local:8080/api/open-chats/search?q={query}
+        results_query: results
+        url_query: url
+        title_query: title
+        content_query: content
+        categories: [general]
+        shortcut: nc
+        timeout: 4.0
+        disabled: false

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -60,6 +60,7 @@ NON_CHART_SERVICES = {
     "workspace-caldav",
     "workspace-smtp",
     "searxng",   # sovereign meta-search, deploys from infra/k8s/searxng (kustomize)
+    "commons-search",  # open-chat commons aggregator, deploys from infra/k8s/commons-search (kustomize)
 }
 
 # Registry hosts this platform actually publishes to. An image ref pointing anywhere


### PR DESCRIPTION
## What

Deploys the `commons-search` aggregator and wires SearXNG's `json_engine` to it, so one `web_search` unifies web + open-community-chat results. Completes the open-chat commons feature (Noetica #481/#483/#484, prophet-platform #747).

## Internal-only, by design

**ClusterIP + NetworkPolicy** (ingress only from inside the namespace) — there is **no internet-facing endpoint**. An authenticated external `/publish` ingress (which would let *desktop* instances federate) is a **separate, deliberate decision**, flagged by the security review, and not created here. Result: the plumbing is live and SearXNG can query the commons; the corpus populates once publishers exist.

## Security hardening (from the exposure-path review, before go-live)

- **Constant-time token comparison** (`crypto.timingSafeEqual`) — a plain `!==` leaks the publish token byte-by-byte via timing.
- **Per-IP rate limit on `/search`** — it's public and `O(corpus)` per query, so an un-throttled flood is a CPU-DoS. Generous cap, just a brake.

## Deploy (mirrors searxng)

- `infra/k8s/commons-search/base` — Deployment (image pinned to the immutable `sha-bbf2abc6…` tag #747's build published; `readOnlyRootFilesystem` + explicit writable `/tmp` & `HOME` emptyDirs — the searxng no-tempdir lesson), ClusterIP Service, in-namespace-only NetworkPolicy. `COMMONS_STORE=memory` for this go-live; `COMMONS_PUBLISH_TOKEN` from an out-of-band Secret (**fail-closed**).
- `deploy/argocd/search-services.yaml` — commons-search ApplicationSet element.
- `infra/k8s/searxng/base/configmap.yaml` — the `noetica commons` `json_engine`.
- `tools/preflight_deploy_contract.py` — commons-search added to `NON_CHART_SERVICES`.

## Verification

- **26/26 unit** (adds constant-time-compare + search-rate-limit tests) · `tsc` clean
- `kubectl kustomize` builds commons-search **and** searxng; `settings.yml` parses with the engine present
- `preflight_deploy_contract.py` **exit 0**
- image **boots clean via `npx tsx` under a fresh HOME** (healthz OK) — the `readOnlyRootFilesystem` start path validated *before* deploy, not after

## Prereq (out of band, NOT in git)

The `commons-search-secret` Secret (key: `publish-token`), same posture as `searxng-secret`.

## ⚠️ One decision deferred to you

Exposing an authenticated **external `/publish` ingress** so desktop-Noetica instances can federate into the commons. That makes an internet-facing content-ingest endpoint whose security rests on the shared token — I did not create it unilaterally. Until then, the commons is live + searchable but populated only by in-cluster publishers.