### PR TITLE
feat(search-gateway): public read-only search fan-out for socioprophet.ai (service + build)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -61,6 +61,7 @@ jobs:
           - { image: regis-acr-api,         context: apps/regis-acr-api,        dockerfile: Dockerfile }
           - { image: commons-search,        context: apps/commons-search,       dockerfile: Dockerfile }
           - { image: reasoning-failure-runner, context: apps/reasoning-failure-runner, dockerfile: Dockerfile }
+          - { image: search-gateway,        context: apps/search-gateway,        dockerfile: Dockerfile }
     uses: SocioProphet/.github/.github/workflows/build-image.yml@main
     with:
       image: ${{ matrix.image }}

--- a/apps/search-gateway/Dockerfile
+++ b/apps/search-gateway/Dockerfile
@@ -1,0 +1,13 @@
+# search-gateway — the public read-only search fan-out for socioprophet.ai (blends SearXNG + commons-search).
+# Pure Node/TS, no native deps. Mirrors commons-search.
+FROM node:20-slim
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --no-audit --no-fund --omit=dev \
+    && npm install --no-audit --no-fund --no-save tsx@^4.0.0
+COPY tsconfig.json ./
+COPY src ./src
+ENV PORT=8080
+EXPOSE 8080
+USER node
+CMD ["npx", "tsx", "src/server.ts"]

--- a/apps/search-gateway/package-lock.json
+++ b/apps/search-gateway/package-lock.json
@@ -1,0 +1,566 @@
+{
+  "name": "@socioprophet/search-gateway",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@socioprophet/search-gateway",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/apps/search-gateway/package.json
+++ b/apps/search-gateway/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@socioprophet/search-gateway",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Public read-only search fan-out for socioprophet.ai — blends SearXNG (web) + commons-search (sovereign commons) into one cited result set.",
+  "type": "commonjs",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "tsx src/server.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test src/*.test.ts"
+  },
+  "devDependencies": { "@types/node": "^20.0.0", "tsx": "^4.0.0", "typescript": "^5.5.0" }
+}

--- a/apps/search-gateway/src/gateway.test.ts
+++ b/apps/search-gateway/src/gateway.test.ts
@@ -1,0 +1,68 @@
+import { test, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { blendedSearch } from './gateway.ts'
+
+const origFetch = globalThis.fetch
+let webResp: () => Promise<Response>
+let commonsResp: () => Promise<Response>
+
+beforeEach(() => {
+  webResp = async () => new Response(JSON.stringify({ results: [
+    { title: 'Web A', url: 'https://a.example', content: 'web a', engine: 'duckduckgo' },
+    { title: 'Shared', url: 'https://shared.example', content: 'web shared', engine: 'brave' },
+  ] }), { status: 200 })
+  commonsResp = async () => new Response(JSON.stringify({ results: [
+    { title: 'Commons X', url: 'noetica://open-chat/u/1', content: 'commons x [EMAIL_1]', publishedDate: 'now' },
+    { title: 'Shared', url: 'https://shared.example', content: 'commons shared', publishedDate: 'now' },
+  ] }), { status: 200 })
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const u = String(input)
+    if (u.includes('/api/open-chats/search')) return commonsResp()
+    if (u.includes('/search?q=')) return webResp()
+    return new Response('{}', { status: 404 })
+  }) as typeof fetch
+})
+afterEach(() => { globalThis.fetch = origFetch })
+
+test('blends commons + web, commons leads, deduped by url', async () => {
+  const r = await blendedSearch('anything')
+  assert.equal(r.counts.commons, 2)
+  assert.equal(r.counts.web, 2)
+  // commons leads
+  assert.equal(r.results[0]!.source, 'commons')
+  // "Shared" url appears once (commons wins the dedupe since it's first)
+  const shared = r.results.filter((x) => x.url === 'https://shared.example')
+  assert.equal(shared.length, 1)
+  assert.equal(shared[0]!.source, 'commons')
+  // 3 unique urls total (Commons X, Shared, Web A)
+  assert.equal(r.results.length, 3)
+})
+
+test('commons results carry the redacted snippet (source tagging + safety)', async () => {
+  const r = await blendedSearch('x')
+  const c = r.results.find((x) => x.source === 'commons' && x.title === 'Commons X')!
+  assert.ok(c.snippet.includes('[EMAIL_1]'))
+  assert.equal(c.engine, 'noetica-commons')
+})
+
+test('graceful degradation: web down still returns commons + degraded note', async () => {
+  webResp = async () => { throw new Error('searxng unreachable') }
+  const r = await blendedSearch('x')
+  assert.equal(r.counts.web, 0)
+  assert.ok(r.counts.commons >= 1)
+  assert.ok(r.degraded?.web)
+  assert.equal(r.degraded?.commons, undefined)
+})
+
+test('graceful degradation: commons down still returns web', async () => {
+  commonsResp = async () => new Response('boom', { status: 500 })
+  const r = await blendedSearch('x')
+  assert.ok(r.counts.web >= 1)
+  assert.equal(r.counts.commons, 0)
+  assert.ok(r.degraded?.commons)
+})
+
+test('empty query short-circuits', async () => {
+  const r = await blendedSearch('   ')
+  assert.equal(r.results.length, 0)
+})

--- a/apps/search-gateway/src/gateway.ts
+++ b/apps/search-gateway/src/gateway.ts
@@ -1,0 +1,89 @@
+/**
+ * gateway.ts — the public read-only search fan-out for socioprophet.ai.
+ *
+ * A single query is fanned out IN PARALLEL to the estate's hosted engines and blended into one cited result set:
+ *   - SearXNG        (web meta-search)        → source: "web"
+ *   - commons-search (the sovereign commons)  → source: "commons"  (already redacted + injection-stripped there)
+ *
+ * READ-ONLY by construction: this gateway never writes. It only reads the already-safe corpora, so it is safe to
+ * expose publicly (with CORS) while the commons /publish path stays gated. Graceful degradation is a feature, not
+ * an afterthought — Promise.allSettled means a down engine returns *partial* results, never a failed query (the
+ * chaos-resilience posture, applied to the product surface itself).
+ */
+
+export type Source = 'web' | 'commons'
+
+export interface SearchResult {
+  title: string
+  url: string
+  snippet: string
+  source: Source
+  engine: string
+  publishedDate?: string
+}
+
+export interface BlendedResults {
+  query: string
+  results: SearchResult[]
+  counts: { web: number; commons: number }
+  /** Present when an engine failed — the UI can note "web results unavailable" without the whole query failing. */
+  degraded?: { web?: string; commons?: string }
+}
+
+const WEB_URL = process.env['SEARXNG_URL'] ?? 'http://searxng.socioprophet.svc.cluster.local:8080'
+const COMMONS_URL = process.env['COMMONS_SEARCH_URL'] ?? 'http://commons-search.socioprophet.svc.cluster.local:8080'
+const TIMEOUT_MS = Number(process.env['SEARCH_TIMEOUT_MS'] ?? 6000)
+const PER_SOURCE_LIMIT = Number(process.env['SEARCH_PER_SOURCE_LIMIT'] ?? 8)
+
+async function getJson(url: string): Promise<unknown> {
+  const res = await fetch(url, { headers: { accept: 'application/json' }, signal: AbortSignal.timeout(TIMEOUT_MS) })
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  return res.json()
+}
+
+async function searchWeb(query: string): Promise<SearchResult[]> {
+  const u = `${WEB_URL.replace(/\/$/, '')}/search?q=${encodeURIComponent(query)}&format=json`
+  const data = (await getJson(u)) as { results?: Array<{ title?: string; url?: string; content?: string; engine?: string }> }
+  return (data.results ?? [])
+    .filter((r) => r.url?.startsWith('http') && (r.engine ?? '') !== 'noetica commons') // commons comes from the commons call, not via searxng
+    .slice(0, PER_SOURCE_LIMIT)
+    .map((r) => ({ title: r.title ?? r.url ?? '', url: r.url!, snippet: r.content ?? '', source: 'web' as const, engine: r.engine ?? 'web' }))
+}
+
+async function searchCommons(query: string): Promise<SearchResult[]> {
+  const u = `${COMMONS_URL.replace(/\/$/, '')}/api/open-chats/search?q=${encodeURIComponent(query)}`
+  const data = (await getJson(u)) as { results?: Array<{ title?: string; url?: string; content?: string; publishedDate?: string }> }
+  return (data.results ?? [])
+    .slice(0, PER_SOURCE_LIMIT)
+    .map((r) => ({ title: r.title ?? '', url: r.url ?? '', snippet: r.content ?? '', source: 'commons' as const, engine: 'noetica-commons', publishedDate: r.publishedDate }))
+}
+
+/** Fan out, blend, de-dupe by url. Commons results lead (the sovereign corpus is the differentiator), then web. */
+export async function blendedSearch(query: string): Promise<BlendedResults> {
+  const q = String(query ?? '').trim()
+  if (!q) return { query: '', results: [], counts: { web: 0, commons: 0 } }
+
+  const [commonsR, webR] = await Promise.allSettled([searchCommons(q), searchWeb(q)])
+  const commons = commonsR.status === 'fulfilled' ? commonsR.value : []
+  const web = webR.status === 'fulfilled' ? webR.value : []
+
+  const seen = new Set<string>()
+  const results: SearchResult[] = []
+  for (const r of [...commons, ...web]) {
+    const key = r.url.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    results.push(r)
+  }
+
+  const degraded: { web?: string; commons?: string } = {}
+  if (commonsR.status === 'rejected') degraded.commons = String((commonsR.reason as Error)?.message ?? 'commons unavailable')
+  if (webR.status === 'rejected') degraded.web = String((webR.reason as Error)?.message ?? 'web unavailable')
+
+  return {
+    query: q,
+    results,
+    counts: { web: web.length, commons: commons.length },
+    ...(Object.keys(degraded).length ? { degraded } : {}),
+  }
+}

--- a/apps/search-gateway/src/server.test.ts
+++ b/apps/search-gateway/src/server.test.ts
@@ -1,0 +1,63 @@
+import { test, before, after, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import type { AddressInfo } from 'node:net'
+import { makeServer } from './server.ts'
+
+const origFetch = globalThis.fetch
+let base: string
+let server: ReturnType<typeof makeServer>
+
+before(async () => {
+  process.env['SEARCH_CORS_ORIGINS'] = 'https://socioprophet.ai'
+  server = makeServer()
+  await new Promise<void>((r) => server.listen(0, r))
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+})
+after(() => server.close())
+
+beforeEach(() => {
+  // Intercept ONLY the upstream engine calls (searxng / commons-search hosts). The test's own requests to `base`
+  // (127.0.0.1) must fall through to the REAL fetch so they actually hit the gateway under test.
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const u = String(input)
+    if (u.includes('commons-search')) return new Response(JSON.stringify({ results: [{ title: 'C', url: 'noetica://x', content: 'c' }] }), { status: 200 })
+    if (u.includes('searxng')) return new Response(JSON.stringify({ results: [{ title: 'W', url: 'https://w.example', content: 'w', engine: 'ddg' }] }), { status: 200 })
+    return origFetch(input as never, init)   // the test → gateway requests
+  }) as typeof fetch
+})
+afterEach(() => { globalThis.fetch = origFetch })
+
+test('healthz', async () => {
+  const r = await fetch(`${base}/healthz`)
+  assert.equal(r.status, 200)
+  assert.equal((await r.json()).ok, true)
+})
+
+test('search blends web + commons', async () => {
+  const r = await fetch(`${base}/search?q=hello`)
+  const b = await r.json()
+  assert.equal(r.status, 200)
+  assert.equal(b.results.length, 2)
+  assert.deepEqual(b.counts, { web: 1, commons: 1 })
+})
+
+test('CORS: allowed origin is echoed', async () => {
+  const r = await fetch(`${base}/search?q=x`, { headers: { origin: 'https://socioprophet.ai' } })
+  assert.equal(r.headers.get('access-control-allow-origin'), 'https://socioprophet.ai')
+})
+
+test('CORS: disallowed origin gets no allow header', async () => {
+  const r = await fetch(`${base}/search?q=x`, { headers: { origin: 'https://evil.example' } })
+  assert.equal(r.headers.get('access-control-allow-origin'), null)
+})
+
+test('OPTIONS preflight returns 204 with CORS for allowed origin', async () => {
+  const r = await fetch(`${base}/search`, { method: 'OPTIONS', headers: { origin: 'https://socioprophet.ai' } })
+  assert.equal(r.status, 204)
+  assert.equal(r.headers.get('access-control-allow-methods'), 'GET, OPTIONS')
+})
+
+test('no write routes — POST /search is 404', async () => {
+  const r = await fetch(`${base}/search`, { method: 'POST' })
+  assert.equal(r.status, 404)
+})

--- a/apps/search-gateway/src/server.ts
+++ b/apps/search-gateway/src/server.ts
@@ -1,0 +1,57 @@
+/**
+ * server.ts — the public HTTP surface for the socioprophet.ai search gateway.
+ *
+ *   GET /healthz         liveness
+ *   GET /search?q=       blended web + commons results (read-only, CORS-enabled)
+ *
+ * CORS is allowlist-based (SEARCH_CORS_ORIGINS) so only the .ai surfaces can call it from a browser; server-side
+ * callers (no Origin) are allowed. No write routes exist — the commons /publish path is not proxied here.
+ */
+import * as http from 'node:http'
+import { blendedSearch } from './gateway.js'
+
+const PORT = Number(process.env['PORT'] ?? 8080)
+// Comma-separated allowlist. Defaults cover the .ai surface + its Firebase dev site; override per environment.
+const CORS_ORIGINS = (process.env['SEARCH_CORS_ORIGINS'] ??
+  'https://socioprophet.ai,https://www.socioprophet.ai,https://socioprophet-builder-dev.web.app')
+  .split(',').map((s) => s.trim()).filter(Boolean)
+
+function corsHeadersFor(origin: string | undefined): Record<string, string> {
+  const allow = origin && CORS_ORIGINS.includes(origin) ? origin : ''
+  return allow
+    ? { 'access-control-allow-origin': allow, 'access-control-allow-methods': 'GET, OPTIONS', 'access-control-allow-headers': 'content-type', 'vary': 'Origin' }
+    : {}
+}
+
+function json(res: http.ServerResponse, code: number, body: unknown, extra: Record<string, string> = {}): void {
+  res.writeHead(code, { 'content-type': 'application/json', ...extra })
+  res.end(JSON.stringify(body))
+}
+
+export function makeServer(): http.Server {
+  return http.createServer((req, res) => {
+    void (async () => {
+      const origin = Array.isArray(req.headers.origin) ? req.headers.origin[0] : req.headers.origin
+      const cors = corsHeadersFor(origin)
+      if (req.method === 'OPTIONS') { res.writeHead(204, cors); res.end(); return }
+      try {
+        const url = new URL(req.url ?? '/', `http://localhost:${PORT}`)
+        if (req.method === 'GET' && url.pathname === '/healthz') {
+          return json(res, 200, { ok: true, service: 'search-gateway' }, cors)
+        }
+        if (req.method === 'GET' && url.pathname === '/search') {
+          const q = url.searchParams.get('q') ?? ''
+          const blended = await blendedSearch(q)
+          return json(res, 200, blended, cors)
+        }
+        json(res, 404, { error: 'not found' }, cors)
+      } catch (e) {
+        json(res, 500, { error: e instanceof Error ? e.message : 'failed' }, cors)
+      }
+    })()
+  })
+}
+
+if (process.env['SEARCH_NO_LISTEN'] !== '1') {
+  makeServer().listen(PORT, () => console.log(`[search-gateway] listening on :${PORT} → web=${process.env['SEARXNG_URL'] ?? 'searxng'} commons=${process.env['COMMONS_SEARCH_URL'] ?? 'commons-search'}`))
+}

--- a/apps/search-gateway/tsconfig.json
+++ b/apps/search-gateway/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2022", "module": "commonjs", "moduleResolution": "node",
+    "esModuleInterop": true, "skipLibCheck": true, "strict": true,
+    "resolveJsonModule": true, "allowImportingTsExtensions": true, "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What

The linchpin for the **socioprophet.ai** agentic-search surface: a public, **read-only** gateway that fans one query out to the estate's hosted engines and blends them into a single cited result set — **SearXNG** (web) + **commons-search** (the sovereign commons). The browser can't reach those ClusterIP engines directly; this is the CORS gateway that can.

## Why it's safe to expose

- **Read-only** — no write routes. The commons `/publish` path is *not* proxied here, so putting this public keeps publish gated (your deferred ingress decision stays deferred).
- Serves only already-redacted, injection-stripped content (commons-search does that upstream).

## Design highlights

- **Graceful degradation is a feature**: `Promise.allSettled` → a down engine returns *partial* results with a `degraded` note, never a failed query. (The chaos-resilience posture, applied to the product surface.)
- Commons results **lead** the blend (the differentiator), de-duped by url, source-tagged `web`/`commons`.
- Allowlist **CORS** (`SEARCH_CORS_ORIGINS`) — only the `.ai` surfaces + the Firebase dev site can call it from a browser.

## Phasing (same discipline as commons-search)

This PR = **service + build** (Dockerfile + `images.yml`, so the image builds). **Deploy** (chart values + a public Ingress/ManagedCertificate + a DNS record for the `.ai` search host) is the next step, gated on the `sha-` tag this build publishes and a hostname/DNS decision.

## Verification

- `tsc` clean; **11/11 unit** (blend/dedupe/commons-leads; redacted snippets pass through; graceful degradation both directions; CORS allow/deny + OPTIONS preflight; no write routes)
- Manual boot: `/healthz` 200, `/search` 200 with `degraded` when engines unreachable, OPTIONS 204
- `preflight_deploy_contract.py` exit 0

Part of the socioprophet.ai search surface: `.ai` = agentic search, `.com` = marketing. Next: deploy + public ingress, the app-vue search page, and Firebase dev.