### PR TITLE
feat(search-gateway): deploy the search fan-out (ingress held for DNS)

### DIFF
--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -25,6 +25,7 @@ spec:
           - { name: dashboard-bff }
           - { name: reasoning-failure-runner }
           - { name: search-orchestrator }
+          - { name: search-gateway }
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —
           # NOT touched by the build-image/gitops-promote SHA pipeline above, since

--- a/deploy/values/search-gateway.yaml
+++ b/deploy/values/search-gateway.yaml
@@ -1,0 +1,25 @@
+# search-gateway — the public read-only search fan-out for socioprophet.ai (apps/search-gateway).
+# Blends SearXNG (web) + commons-search (the sovereign commons) into one cited result set. READ-ONLY: no write
+# routes, so exposing it publicly keeps the commons /publish path gated.
+#
+# Pin the immutable sha- tag the build published (the no-moving-tag standard). This is the merge-commit sha of
+# PR #751 (the service+build); bump it as the service is rebuilt.
+image: { repository: search-gateway, tag: sha-6c83cf260d2fa00d5969212aa293d8ec347af4e7 }
+service: { port: 8080, portName: http }
+# The server serves /healthz (the chart default) — no probes.path override needed.
+config:
+  # In-cluster engine URLs (ClusterIP, same namespace).
+  SEARXNG_URL: "http://searxng.socioprophet.svc.cluster.local:8080"
+  COMMONS_SEARCH_URL: "http://commons-search.socioprophet.svc.cluster.local:8080"
+  # CORS allowlist — only the .ai surfaces + the Firebase dev/prod app sites may call it from a browser.
+  SEARCH_CORS_ORIGINS: "https://socioprophet.ai,https://www.socioprophet.ai,https://app.socioprophet.com,https://socioprophet-builder.web.app,https://socioprophet-builder-dev.web.app"
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 3 }
+# PUBLIC INGRESS — held OFF until DNS for the search host resolves. A GKE ManagedCertificate's provisioning clock
+# starts at DNS visibility; creating the ingress/cert BEFORE the A record exists poisons it into FailedNotVisible
+# backoff (the socbase-cert lesson). GO-LIVE: (1) Michael adds an A record for search-api.socioprophet.ai → the
+# ingress IP, (2) flip enabled:true + add the managed-certificates annotation + a ManagedCertificate resource.
+# Until then the gateway is deployed + healthy (ClusterIP) and reachable in-cluster for verification.
+ingress:
+  enabled: false
+  # hosts: [{ host: search-api.socioprophet.ai, paths: [{ path: /, pathType: Prefix }] }]
+  # annotations: { networking.gke.io/managed-certificates: search-gateway-cert }


### PR DESCRIPTION
Deploys the `search-gateway` service (merged in #751) via the chart, pinned to the sha- tag that build published, in the `platform-services` ApplicationSet.

- `deploy/values/search-gateway.yaml` — image sha-pinned; in-cluster `SEARXNG_URL`+`COMMONS_SEARCH_URL`; `SEARCH_CORS_ORIGINS` allowlist; `/healthz` probe (chart default the server serves).
- `platform-services` ApplicationSet — + search-gateway.

**Public ingress is held OFF** (`ingress.enabled: false`). A GKE ManagedCertificate's clock starts at DNS visibility — creating it before the A record exists poisons it into `FailedNotVisible` (the socbase-cert lesson). **Go-live** = add an A record for the search host → flip `enabled:true` + the managed-cert annotation + a ManagedCertificate. Until then the gateway runs healthy (ClusterIP), verifiable in-cluster.

`preflight_deploy_contract.py` exit 0. Part of the socioprophet.ai search surface.