### PR TITLE
feat(lattice-studio): deploy the Studio BFF (sha-pinned, live fabric aggregation)

### DIFF
--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -26,6 +26,7 @@ spec:
           - { name: reasoning-failure-runner }
           - { name: search-orchestrator }
           - { name: search-gateway }
+          - { name: lattice-studio }
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —
           # NOT touched by the build-image/gitops-promote SHA pipeline above, since

--- a/deploy/values/lattice-studio.yaml
+++ b/deploy/values/lattice-studio.yaml
@@ -1,0 +1,13 @@
+# lattice-studio — the Studio BFF (apps/lattice-studio server.py). Makes the app-vue Studio surface live: wraps
+# product_spine + aggregates live data from hellgraph-service / tritfabric / search-orchestrator, project-scoped
+# to Noetica proj- collections. Pinned to the sha- tag the #753 build published.
+image: { repository: lattice-studio, tag: sha-08e330a6cc9ce6e1912ee9ac41bf0301aa14cf1d }
+service: { port: 8080, portName: http }
+# server serves /healthz (chart default) — no probes.path override.
+config:
+  HELLGRAPH_URL: "http://hellgraph-service:8090"
+  TRITFABRIC_URL: "http://tritfabric:8750"
+  SEARCH_ORCH_URL: "http://search-orchestrator:8088"
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
+# Internal for now (ClusterIP); the app-vue surface reaches it via the same public-gateway pattern as search — a
+# public ingress + DNS is the go-live step, held (ManagedCert clock starts at DNS).


### PR DESCRIPTION
Deploys the Studio BFF merged in #753 via the chart + platform-services ApplicationSet, pinned to `sha-08e330a6cc9…`. Config points at the in-cluster fabric (`hellgraph-service:8090`, `tritfabric:8750`, `search-orchestrator:8088`) so `/api/studio` returns **live data**. Internal (ClusterIP) for now; public ingress + DNS is the held go-live step. `preflight` exit 0. → verify live in-cluster, then point the surface's `VITE_STUDIO_API` at it.