### PR TITLE
feat(lattice-studio): deploy KE-1 extraction

### DIFF
--- a/deploy/values/lattice-studio.yaml
+++ b/deploy/values/lattice-studio.yaml
@@ -1,7 +1,7 @@
 # lattice-studio — the Studio BFF (apps/lattice-studio server.py). Makes the app-vue Studio surface live: wraps
 # product_spine + aggregates live data from hellgraph-service / tritfabric / search-orchestrator, project-scoped
 # to Noetica proj- collections. Pinned to the sha- tag the #753 build published.
-image: { repository: lattice-studio, tag: sha-3ac612881c60e9b26f510937531e813f7b98d9dd }
+image: { repository: lattice-studio, tag: sha-7da9ac199f169b6a64535af96facf4ea8345030f }
 service: { port: 8080, portName: http }
 # server serves /healthz (chart default) — no probes.path override.
 config:


### PR DESCRIPTION
Pins the KE-1 image (real extraction → HellGraph, proof-carrying) so /api/studio/extract goes live.