### PR TITLE
feat(lattice-studio): deploy KE-1.1 + KE-2 graph read

### DIFF
--- a/deploy/values/lattice-studio.yaml
+++ b/deploy/values/lattice-studio.yaml
@@ -1,7 +1,7 @@
 # lattice-studio — the Studio BFF (apps/lattice-studio server.py). Makes the app-vue Studio surface live: wraps
 # product_spine + aggregates live data from hellgraph-service / tritfabric / search-orchestrator, project-scoped
 # to Noetica proj- collections. Pinned to the sha- tag the #753 build published.
-image: { repository: lattice-studio, tag: sha-7da9ac199f169b6a64535af96facf4ea8345030f }
+image: { repository: lattice-studio, tag: sha-da0e2b2cb6b20bdb29ea2be6a525066bdc2aeb90 }
 service: { port: 8080, portName: http }
 # server serves /healthz (chart default) — no probes.path override.
 config:


### PR DESCRIPTION
Deploys the polished extractor + /api/studio/graph (provenance per node).