### PR TITLE
feat(search-gateway): public HTTPS ingress + ManagedCertificate (search-api.socioprophet.ai)

### DIFF
--- a/deploy/argocd/search-services.yaml
+++ b/deploy/argocd/search-services.yaml
@@ -25,6 +25,8 @@ spec:
           # NetworkPolicy = internal-only; an authenticated external /publish ingress is a separate, deliberate
           # decision. Prereq (out of band, NOT in git): the `commons-search-secret` Secret (key: publish-token).
           - { name: commons-search, path: infra/k8s/commons-search/base }
+            # public HTTPS edge for search-gateway (read-only) → socioprophet.ai search surface
+          - { name: search-gateway-ingress, path: infra/k8s/search-gateway-ingress/base }
   template:
     metadata:
       name: 'search-{{.name}}'

--- a/infra/k8s/search-gateway-ingress/base/ingress.yaml
+++ b/infra/k8s/search-gateway-ingress/base/ingress.yaml
@@ -1,0 +1,31 @@
+# Public HTTPS ingress for search-gateway (READ-ONLY: /search + /healthz only; no write routes) so the
+# socioprophet.ai search surface can reach it from the browser. Mirrors the working socbase/zot/gitea pattern:
+# GCE ingress class + a GKE ManagedCertificate. Held separate from the chart so the chart keeps managing the
+# Deployment/Service; this only adds the public edge.
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: search-gateway-cert
+  namespace: socioprophet
+spec:
+  domains: [search-api.socioprophet.ai]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: search-gateway-public
+  namespace: socioprophet
+  annotations:
+    # `gce` (built-in), NOT nginx — the only controller that exists in this cluster (socbase lesson).
+    kubernetes.io/ingress.class: gce
+    networking.gke.io/managed-certificates: search-gateway-cert
+  labels: { app: search-gateway, app.kubernetes.io/part-of: sovereign-search }
+spec:
+  rules:
+    - host: search-api.socioprophet.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service: { name: search-gateway, port: { number: 8080 } }

--- a/infra/k8s/search-gateway-ingress/base/kustomization.yaml
+++ b/infra/k8s/search-gateway-ingress/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: socioprophet
+resources:
+  - ingress.yaml

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -61,6 +61,7 @@ NON_CHART_SERVICES = {
     "workspace-smtp",
     "searxng",   # sovereign meta-search, deploys from infra/k8s/searxng (kustomize)
     "commons-search",  # open-chat commons aggregator, deploys from infra/k8s/commons-search (kustomize)
+    "search-gateway-ingress",  # public HTTPS edge (ManagedCertificate + Ingress) for search-gateway
 }
 
 # Registry hosts this platform actually publishes to. An image ref pointing anywhere


### PR DESCRIPTION
Public read-only edge for the socioprophet.ai search surface (GCE ingress + ManagedCertificate). GKE assigns the IP on creation → A-record `search-api.socioprophet.ai` → that IP promptly (cert clock starts at DNS).