### PR TITLE
feat(graph): KKO upper ontology + force-directed explorer (induced subgraph) + smoke fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lattice-surface-ingestor-smoke:
 
 lattice-studio-smoke:
 	cd apps/lattice-studio && test -d .venv || python3 -m venv .venv
-	cd apps/lattice-studio && . .venv/bin/activate && python -m pip install --upgrade pip pytest && PYTHONPATH=src pytest -q tests
+	cd apps/lattice-studio && . .venv/bin/activate && python -m pip install --upgrade pip pytest -r requirements.txt && PYTHONPATH=src pytest -q tests
 	mkdir -p build/lattice-studio
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli emit-demo-catalog --output-dir build/lattice-studio/catalog
 	PYTHONPATH=apps/lattice-studio/src python3 -m lattice_studio.cli create-session --project-id demo-project --user-id demo-user --runtime-asset apps/lattice-studio/examples/runtime-asset.prophet-python-ml.json --catalog-input catalog://datasets/demo-csv@0.1.0 --catalog-input catalog://models/demo-classifier@0.1.0 --catalog-input catalog://applications/demo-notebook-app@0.1.0 --catalog-input catalog://services/demo-inference-service@0.1.0 --policy-ref policy://lattice-studio/paas-demo --output-dir build/lattice-studio/session

--- a/apps/hellgraph-service/src/server.test.ts
+++ b/apps/hellgraph-service/src/server.test.ts
@@ -1,0 +1,64 @@
+/**
+ * hellgraph-service HTTP smoke — focuses the new induced-subgraph endpoint that
+ * feeds the Studio graph explorer: nodes for a label + only the edges internal to
+ * them (no dangling), which is the topology a real graph explorer draws.
+ */
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+
+process.env.PORT = String(19091) // free test port, read at module import
+process.env.HELLGRAPH_STORE_DIR = `${process.env.TMPDIR ?? '/tmp'}/hgsvc-test-${process.pid}`
+
+const BASE = `http://127.0.0.1:${process.env.PORT}`
+let srv: { close: (cb?: () => void) => void }
+
+before(async () => {
+  const mod = await import('./server')
+  srv = mod.server as unknown as typeof srv
+  // give the listener a tick
+  await new Promise((r) => setTimeout(r, 150))
+})
+after(() => srv?.close())
+
+async function req(method: string, path: string, body?: unknown) {
+  const r = await fetch(BASE + path, {
+    method,
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  return { status: r.status, json: (await r.json()) as any }
+}
+
+test('healthz is live', async () => {
+  const r = await req('GET', '/healthz')
+  assert.equal(r.status, 200)
+  assert.equal(r.json.ok, true)
+})
+
+test('subgraph returns nodes + only internal edges (induced, no dangling)', async () => {
+  const L = `proj-test${process.pid}`
+  await req('POST', '/api/graph/node', { id: `${L}:a`, labels: [L, 'Entity'], properties: { name: 'A' } })
+  await req('POST', '/api/graph/node', { id: `${L}:b`, labels: [L, 'Entity'], properties: { name: 'B' } })
+  await req('POST', '/api/graph/node', { id: `other:z`, labels: ['other'], properties: { name: 'Z' } })
+  // internal edge (both endpoints in the label set)
+  await req('POST', '/api/graph/edge', { label: 'CO_OCCURS', from: `${L}:a`, to: `${L}:b`, properties: { n: 2 } })
+  // dangling edge (b is in the set, z is not) — must be excluded from the induced subgraph
+  await req('POST', '/api/graph/edge', { label: 'CO_OCCURS', from: `${L}:b`, to: `other:z` })
+
+  const r = await req('GET', `/api/graph/subgraph?label=${L}`)
+  assert.equal(r.status, 200)
+  assert.equal(r.json.count, 2)
+  const ids = new Set(r.json.nodes.map((n: any) => n.id))
+  assert.ok(ids.has(`${L}:a`) && ids.has(`${L}:b`) && !ids.has('other:z'))
+  // exactly the one internal edge; the dangling one is dropped
+  assert.equal(r.json.edges, 1)
+  assert.equal(r.json.edgeList.length, 1)
+  assert.equal(r.json.edgeList[0].from, `${L}:a`)
+  assert.equal(r.json.edgeList[0].to, `${L}:b`)
+})
+
+test('subgraph respects limit', async () => {
+  const r = await req('GET', '/api/graph/subgraph?limit=1')
+  assert.equal(r.status, 200)
+  assert.ok(r.json.nodes.length <= 1)
+})

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -10,6 +10,7 @@
  *   POST /api/graph/node           { id, labels[], properties? } → upsert node
  *   POST /api/graph/edge           { label, from, to, properties? } → add edge
  *   GET  /api/graph/query?label=X  nodes carrying a label
+ *   GET  /api/graph/subgraph?label=X  induced subgraph (nodes + internal edges) for an explorer
  *   POST /api/graph/reason         run PLN forward-chaining → counts
  */
 import * as http from 'node:http'
@@ -79,6 +80,19 @@ const server = http.createServer((req, res) => {
     const label = url.searchParams.get('label') ?? ''
     const nodes = g.allNodes().filter((n) => !label || n.labels.includes(label))
     return json(res, 200, { count: nodes.length, nodes: nodes.slice(0, 200) })
+  }
+
+  // Subgraph read: the topology a real graph explorer draws (nodes + the edges internal to them).
+  // Node facade exposes reads but not a label-scoped induced subgraph — this composes nodesByLabel
+  // with an endpoint-membership filter so an explorer gets exactly one project's proof-carrying graph.
+  if (req.method === 'GET' && url.pathname === '/api/graph/subgraph') {
+    const label = url.searchParams.get('label') ?? ''
+    const limit = Math.min(Number(url.searchParams.get('limit') ?? 400), 2000)
+    const nodes = (label ? g.allNodes().filter((n) => n.labels.includes(label)) : g.allNodes()).slice(0, limit)
+    const ids = new Set(nodes.map((n) => n.id))
+    // induced subgraph: keep an edge only when both endpoints are in the node set (no dangling)
+    const edges = g.allEdges().filter((e) => ids.has(e.from) && ids.has(e.to))
+    return json(res, 200, { count: nodes.length, edges: edges.length, nodes, edgeList: edges })
   }
 
   if (req.method === 'POST' && url.pathname === '/api/graph/reason') {

--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -227,7 +227,11 @@ async def extract(req: ExtractRequest) -> dict[str, Any]:
     src = req.source or ("text:" + hashlib.sha256(req.text.encode()).hexdigest()[:16])
     entities, relations = extract_facts(req.text)
     ent_id = lambda name: f"{coll}:ent:{_norm(name).replace(' ', '_')}"  # noqa: E731
-    prov = {"epistemic_mode": "observed", "source": src, "extractor": "lattice-studio/deterministic-v0", "project": coll}
+    # KKO (KBpedia Knowledge Ontology) is the estate's UPPER ONTOLOGY. Extracted named entities are Peircean
+    # Particulars (Secondness). epistemic_mode="observed" is itself Peircean (KKO formalizes the inference
+    # trichotomy induced/deduced/abduced as kko:Methodeutic) — so the provenance is standards-grounded, not ad-hoc.
+    prov = {"epistemic_mode": "observed", "source": src, "extractor": "lattice-studio/deterministic-v0",
+            "project": coll, "kko_type": "Particulars"}
 
     written_nodes = written_edges = 0
     errors: list[str] = []
@@ -273,6 +277,7 @@ async def _fetch_nodes(coll: str, limit: int = 200) -> tuple[list[dict[str, Any]
             "id": nid, "name": props.get("name", nid),
             "epistemic_mode": props.get("epistemic_mode", "unknown"),
             "source": props.get("source"), "extractor": props.get("extractor"),
+            "kko_type": props.get("kko_type", "Particulars"),  # KKO upper-ontology type
             "labels": n.get("labels", []) if isinstance(n, dict) else [],
         })
     return nodes, err
@@ -308,13 +313,18 @@ async def graph_ttl(project: str = "default", limit: int = 500) -> Response:
     coll = proj_collection(project)
     nodes, _ = await _fetch_nodes(coll, limit)
     g = RDFGraph()
+    # KKO (KBpedia Knowledge Ontology) is the estate's upper ontology — the export types INTO it, so the graph
+    # is grounded in a formal, open (CC-BY-4.0), Peircean upper ontology that Protégé/GraphDB/Anzo/Stardog already
+    # understand. Meet them on standards (KKO/RDF/PROV) AND carry the provenance moat they drop on export.
+    KKO = Namespace("http://kbpedia.org/ontologies/kko#")
     SP = Namespace("https://socioprophet.ai/kg#")
     PROJ = Namespace(f"https://socioprophet.ai/kg/{coll}/")
-    g.bind("sp", SP); g.bind("proj", PROJ); g.bind("prov", PROV); g.bind("dct", DCTERMS)
+    g.bind("kko", KKO); g.bind("sp", SP); g.bind("proj", PROJ); g.bind("prov", PROV); g.bind("dct", DCTERMS)
     for n in nodes:
         u = PROJ[(n["id"].split(":")[-1] or "node")]
-        g.add((u, RDF.type, SP.Entity))
+        g.add((u, RDF.type, KKO[n.get("kko_type", "Particulars")]))  # KKO upper-ontology type (Peircean)
         g.add((u, RDFS.label, Literal(n["name"])))
+        # epistemic_mode is a Peircean inference status (KKO kko:Methodeutic) — provenance grounded in the standard.
         g.add((u, SP.epistemicMode, Literal(n["epistemic_mode"])))
         if n.get("source"): g.add((u, DCTERMS.source, Literal(n["source"])))
         if n.get("extractor"): g.add((u, PROV.wasGeneratedBy, Literal(n["extractor"])))

--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -264,22 +264,41 @@ async def extract(req: ExtractRequest) -> dict[str, Any]:
     }
 
 
-async def _fetch_nodes(coll: str, limit: int = 200) -> tuple[list[dict[str, Any]], str | None]:
-    """Read the project's atoms (by collection label) from the live HellGraph, each with its provenance."""
+def _map_node(n: Any) -> dict[str, Any]:
+    props = n.get("properties", n) if isinstance(n, dict) else {}
+    nid = n.get("id", "") if isinstance(n, dict) else str(n)
+    return {
+        "id": nid, "name": props.get("name", nid),
+        "epistemic_mode": props.get("epistemic_mode", "unknown"),
+        "source": props.get("source"), "extractor": props.get("extractor"),
+        "kko_type": props.get("kko_type", "Particulars"),  # KKO upper-ontology type
+        "labels": n.get("labels", []) if isinstance(n, dict) else [],
+    }
+
+
+async def _fetch_subgraph(coll: str, limit: int = 200) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str | None]:
+    """Read the project's INDUCED SUBGRAPH (nodes + internal edges) from the live HellGraph kernel.
+
+    The kernel returns an induced subgraph (edges only where both endpoints are in the node set), so the
+    explorer draws real topology — not a chip-cloud — and every node still carries its provenance.
+    """
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/query?label={coll}")
-    raw = (res.get("nodes", res) if isinstance(res, dict) else res) if res else []
-    nodes: list[dict[str, Any]] = []
-    for n in (raw if isinstance(raw, list) else [])[:limit]:
-        props = n.get("properties", n) if isinstance(n, dict) else {}
-        nid = n.get("id", "") if isinstance(n, dict) else str(n)
-        nodes.append({
-            "id": nid, "name": props.get("name", nid),
-            "epistemic_mode": props.get("epistemic_mode", "unknown"),
-            "source": props.get("source"), "extractor": props.get("extractor"),
-            "kko_type": props.get("kko_type", "Particulars"),  # KKO upper-ontology type
-            "labels": n.get("labels", []) if isinstance(n, dict) else [],
-        })
+        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit={limit}")
+    raw_nodes = res.get("nodes", []) if isinstance(res, dict) else []
+    raw_edges = res.get("edgeList", []) if isinstance(res, dict) else []
+    nodes = [_map_node(n) for n in (raw_nodes if isinstance(raw_nodes, list) else [])[:limit]]
+    edges = [
+        {"id": e.get("id", ""), "source": e.get("from", ""), "target": e.get("to", ""),
+         "label": e.get("label", ""), "weight": (e.get("properties") or {}).get("n", 1)}
+        for e in (raw_edges if isinstance(raw_edges, list) else [])
+        if isinstance(e, dict) and e.get("from") and e.get("to")
+    ]
+    return nodes, edges, err
+
+
+async def _fetch_nodes(coll: str, limit: int = 200) -> tuple[list[dict[str, Any]], str | None]:
+    """Node-only read (RDF export path) — delegates to the subgraph fetch and drops edges."""
+    nodes, _edges, err = await _fetch_subgraph(coll, limit)
     return nodes, err
 
 
@@ -291,11 +310,12 @@ async def graph(project: str = "default", limit: int = 100) -> dict[str, Any]:
     Neo4j/Bloom explorer can't show natively.
     """
     coll = proj_collection(project)
-    nodes, err = await _fetch_nodes(coll, limit)
+    nodes, edges, err = await _fetch_subgraph(coll, limit)
     dist: dict[str, int] = {}
     for x in nodes:
         dist[x["epistemic_mode"]] = dist.get(x["epistemic_mode"], 0) + 1
-    return {"project": project, "projectCollection": coll, "nodes": nodes, "count": len(nodes),
+    return {"project": project, "projectCollection": coll, "nodes": nodes, "edges": edges,
+            "count": len(nodes), "edge_count": len(edges),
             "epistemic_distribution": dist, "degraded": (err if err else None)}
 
 

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -71,7 +71,39 @@ def test_graph_endpoint_returns_provenance_shape():
     assert r.status_code == 200
     b = r.json()
     assert b["projectCollection"] == "proj-teamx"
+    # nodes AND edges (topology for the force-directed explorer) + provenance distribution
     assert "nodes" in b and "count" in b and "epistemic_distribution" in b
+    assert "edges" in b and "edge_count" in b and isinstance(b["edges"], list)
+
+
+def test_subgraph_maps_induced_edges(monkeypatch):
+    # the BFF must map the kernel's induced-subgraph edgeList (from/to) → explorer edges (source/target)
+    import lattice_studio.server as srv
+
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({
+                "nodes": [
+                    {"id": "proj-teamx:ent:a", "labels": ["proj-teamx", "Entity"],
+                     "properties": {"name": "A", "epistemic_mode": "observed", "kko_type": "Particulars"}},
+                    {"id": "proj-teamx:ent:b", "labels": ["proj-teamx", "Entity"],
+                     "properties": {"name": "B", "epistemic_mode": "observed"}},
+                ],
+                "edgeList": [
+                    {"id": "h:1", "label": "CO_OCCURS", "from": "proj-teamx:ent:a",
+                     "to": "proj-teamx:ent:b", "properties": {"n": 3}},
+                ],
+            }, None)
+        return (None, "unreachable")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.get("/api/studio/graph?project=team-x")
+    assert r.status_code == 200
+    b = r.json()
+    assert b["count"] == 2 and b["edge_count"] == 1
+    e = b["edges"][0]
+    assert e["source"] == "proj-teamx:ent:a" and e["target"] == "proj-teamx:ent:b"
+    assert e["label"] == "CO_OCCURS" and e["weight"] == 3
 
 
 def test_rdf_export_carries_provenance(monkeypatch):

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -80,14 +80,18 @@ def test_rdf_export_carries_provenance(monkeypatch):
 
     async def fake_nodes(coll, limit=200):
         return [{"id": f"{coll}:ent:hellgraph", "name": "HellGraph", "epistemic_mode": "observed",
-                 "source": "doc:kg", "extractor": "lattice-studio/deterministic-v0", "labels": [coll, "Entity"]}], None
+                 "source": "doc:kg", "extractor": "lattice-studio/deterministic-v0",
+                 "kko_type": "Particulars", "labels": [coll, "Entity"]}], None
     monkeypatch.setattr(srv, "_fetch_nodes", fake_nodes)
 
     r = client.get("/api/studio/graph.ttl?project=team-x")
     assert r.status_code == 200
     assert "text/turtle" in r.headers["content-type"]
     ttl = r.text
-    # provenance survives export: epistemic mode + source + generator ride the RDF
+    # KKO upper ontology: the node types INTO KKO (Peircean Particulars) — standards-grounded, not ad-hoc
+    assert "kko:" in ttl and "kko:Particulars" in ttl
+    assert "http://kbpedia.org/ontologies/kko#" in ttl
+    # provenance survives export: epistemic mode + source + generator ride the RDF (the moat, on export)
     assert "sp:epistemicMode" in ttl and '"observed"' in ttl
     assert "dct:source" in ttl and "prov:wasGeneratedBy" in ttl
     assert 'rdfs:label "HellGraph"' in ttl

--- a/docs/LATTICE_KNOWLEDGE_GRAPH_SOTA_V0.md
+++ b/docs/LATTICE_KNOWLEDGE_GRAPH_SOTA_V0.md
@@ -84,3 +84,32 @@ Two-track. Don't rebuild reasoners and query engines that already exist — brid
 ## 6. Honest bottom line
 
 Today we are **behind** Neo4j/Protégé/Anzo on query maturity, reasoners, algorithms, visualization, and scale — and pretending otherwise is a paper tiger. But we are **architecturally ahead of all of them on the one axis that matters for trustworthy, agent-operated knowledge**: proof-carrying provenance, deterministic replay, agent-nativeness, and sovereignty. The plan is to *interoperate* with their standards (RDF/SPARQL/OWL/SHACL) so we lose nothing, and *spend our build budget* making the proof/provenance/agent moat real and visible. That is how our knowledge graph becomes not "another Neo4j" but the first knowledge graph you can **prove and hand to an agent team**.
+
+---
+
+## 7. Strategic doctrine (corrected 2026-07-16) — KKO upper ontology + meet-or-beat, THEN the moat
+
+Two corrections that supersede the more concessive framing above:
+
+**A. KKO / KBpedia is the estate's UPPER ONTOLOGY — the stack standard.** Not a bolt-on alignment; the top typology
+everything types into. KKO (KBpedia Knowledge Ontology v1.60, CC-BY-4.0, ~58k reference concepts, Peirce's universal
+categories) maps Noetica 1:1 (`~/dev/Noetica/agent-machine/canon/kko-alignment.json`, `lib/kko-bridge.ts`).
+Crucially, **KKO formalizes our epistemic moat**: induced/deduced/abduced = Peirce's induction/deduction/abduction,
+and the discovery process is `kko:Methodeutic`. So our provenance/epistemic-mode is **standards-grounded in a
+formal open upper ontology, not proprietary**. Extraction types entities as `kko:Particulars` (Secondness);
+ontogenesis + FIBO/gist sit *under* KKO. Every KG surface (extract, graph, RDF export, retrieval) types into KKO.
+
+**B. MEET OR BEAT them on their turf, THEN overlay the moat.** The goal is not "behind but differentiated." It is
+**parity + moat**: reach Cypher/GDS/reasoner/SPARQL/viz parity, *then* tag it with proof/provenance/agent-native/
+sovereign. Per capability:
+
+| Their capability | Our PARITY move | + Our MOAT overlay |
+|---|---|---|
+| Neo4j Cypher / GDS / Bloom | a graph query surface (Cypher/GQL facade) + PLN/graph algorithms + a force-directed explorer | provenance + epistemic-mode per node/edge |
+| Protégé OWL + reasoners | ontogenesis OWL/SHACL under **KKO** upper ontology + a reasoner | proof-carrying, replayable derivations |
+| Anzo / Stardog SPARQL + virtualization | HellGraph RDF/SPARQL bridge + federation | epistemic-mode triples survive export (KKO-grounded) |
+| KBpedia | we ARE KKO-typed (parity by adoption) | + live extraction, agent-native, sovereign |
+
+**Shipped toward this:** the RDF/Turtle export now types nodes into `kko:Particulars` and carries `sp:epistemicMode`
++ `prov:wasGeneratedBy` + `dct:source` — KKO-grounded interop that keeps the provenance every incumbent drops on
+export. Next parity moves: graph query surface (Cypher/SPARQL), force-directed explorer, a reasoner over KKO.


### PR DESCRIPTION
Bakes in the strategic decision: **KKO/KBpedia is the estate's upper ontology** (stack standard), and KKO formalizes our epistemic moat (induced/deduced/abduced = Peircean inference, `kko:Methodeutic`) — so provenance is **standards-grounded, not proprietary**.

- Extraction → entities typed `kko:Particulars`; RDF/Turtle export types nodes `a kko:Particulars` under `kko:` **while keeping** `sp:epistemicMode` + `prov:wasGeneratedBy` + `dct:source`. Meet the field on KKO/RDF/PROV; carry the provenance they drop.
- Doctrine correction (§7): **meet-or-beat parity THEN the moat** — per-capability parity vs Neo4j/Protégé/Anzo/Stardog + the moat overlay.

8/8 pytest.