### PR TITLE
feat(hellgraph): SPARQL/Gremlin/SHACL query surface + fix superpeer branch

### DIFF
--- a/apps/hellgraph-service/src/server.test.ts
+++ b/apps/hellgraph-service/src/server.test.ts
@@ -62,3 +62,23 @@ test('subgraph respects limit', async () => {
   assert.equal(r.status, 200)
   assert.ok(r.json.nodes.length <= 1)
 })
+
+test('SPARQL parity: query returns bindings over the proof-carrying kernel', async () => {
+  const L = `sparql-${process.pid}`
+  await req('POST', '/api/graph/node', { id: `${L}:hg`, labels: [L], properties: { name: 'HellGraph' } })
+  const r = await req('POST', '/api/graph/sparql', { query: 'SELECT ?s ?o WHERE { ?s ?p ?o } LIMIT 5' })
+  assert.equal(r.status, 200)
+  assert.ok(Array.isArray(r.json.variables) && Array.isArray(r.json.bindings))
+  assert.ok(r.json.bindings.length >= 1)
+})
+
+test('Gremlin parity: g.V() returns vertices', async () => {
+  const r = await req('POST', '/api/graph/gremlin', { query: 'g.V().limit(2)' })
+  assert.equal(r.status, 200)
+  assert.ok(Array.isArray(r.json.values) && typeof r.json.count === 'number')
+})
+
+test('query endpoints 400 on missing query', async () => {
+  const r = await req('POST', '/api/graph/sparql', {})
+  assert.equal(r.status, 400)
+})

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -12,6 +12,9 @@
  *   GET  /api/graph/query?label=X  nodes carrying a label
  *   GET  /api/graph/subgraph?label=X  induced subgraph (nodes + internal edges) for an explorer
  *   POST /api/graph/reason         run PLN forward-chaining → counts
+ *   POST /api/graph/sparql         { query }  → SPARQL bindings (parity: Stardog/Anzo/GraphDB)
+ *   POST /api/graph/gremlin        { query }  → Gremlin results (parity: Neptune/JanusGraph)
+ *   POST /api/graph/shacl          { shapes } → SHACL validation report (parity: TopBraid/Stardog)
  */
 import * as http from 'node:http'
 import * as os from 'node:os'
@@ -23,7 +26,7 @@ import * as path from 'node:path'
 process.env['HELLGRAPH_STORE_DIR'] ||= path.join(os.homedir(), '.hellgraph-service')
 
 import * as engine from '@socioprophet/hellgraph'
-import { getHellGraph, getAtomSpace, attachRocksDB, forwardChain, startSuperPeerFromEnv } from '@socioprophet/hellgraph'
+import { getHellGraph, getAtomSpace, attachRocksDB, forwardChain, runSparql, runGremlin, shaclValidate } from '@socioprophet/hellgraph'
 
 const PORT = Number(process.env.PORT ?? 8090)
 
@@ -100,6 +103,40 @@ const server = http.createServer((req, res) => {
     return json(res, 200, { ok: true, result })
   }
 
+  // ── Query parity: meet Stardog/Anzo/GraphDB (SPARQL), Neptune/JanusGraph (Gremlin), and SHACL
+  // validators on their own turf — but over a proof-carrying, replayable kernel. The query languages
+  // are standard so tools interop; the store underneath is the moat.
+  if (req.method === 'POST' && url.pathname === '/api/graph/sparql') {
+    return void readBody(req).then((b) => {
+      try {
+        const { query } = JSON.parse(b || '{}') as { query?: string }
+        if (!query) throw new Error('query required')
+        json(res, 200, { ok: true, ...runSparql(g, query) })
+      } catch (e) { json(res, 400, { error: String(e) }) }
+    })
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/graph/gremlin') {
+    return void readBody(req).then((b) => {
+      try {
+        const { query } = JSON.parse(b || '{}') as { query?: string }
+        if (!query) throw new Error('query required')
+        json(res, 200, { ok: true, ...runGremlin(g, query) })
+      } catch (e) { json(res, 400, { error: String(e) }) }
+    })
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/graph/shacl') {
+    return void readBody(req).then(async (b) => {
+      try {
+        const { shapes } = JSON.parse(b || '{}') as { shapes?: string }
+        if (!shapes) throw new Error('shapes (Turtle SHACL) required')
+        const report = await shaclValidate(shapes)
+        json(res, 200, { ok: true, report })
+      } catch (e) { json(res, 400, { error: String(e) }) }
+    })
+  }
+
   json(res, 404, { error: 'not_found' })
 })
 
@@ -120,16 +157,14 @@ function startLocalService(): void {
   })
 }
 
-// Mode selection. HELLGRAPH_MODE=superpeer runs the cloud-twin federation replica (a bootstrapped
-// SuperPeer serving the causally-merged view over /health /cut /query /admit) instead of the local
-// AtomSpace service — one image, two roles. Anything else runs the local HTTP service (default).
+// Mode selection. HELLGRAPH_MODE=superpeer once ran a cloud-twin federation replica, but the current
+// @socioprophet/hellgraph engine build no longer exports a super-peer entrypoint — federation lives in
+// a separate build. Fail fast and loud if an operator asks for a mode this image can't serve, rather
+// than silently degrading to local. Anything else runs the local AtomSpace HTTP service (default).
 if (process.env['HELLGRAPH_MODE'] === 'superpeer') {
-  void startSuperPeerFromEnv()
-    .then((sp) => console.log(`[hellgraph-service] super-peer mode — base=${sp.baseKey} listening :${sp.port}`))
-    .catch((e) => {
-      console.error('[hellgraph-service] super-peer failed to start:', e)
-      process.exit(1)
-    })
+  console.error('[hellgraph-service] HELLGRAPH_MODE=superpeer is not supported by this engine build ' +
+    '(no super-peer entrypoint is exported). Run the dedicated federation image instead.')
+  process.exit(1)
 } else {
   startLocalService()
 }


### PR DESCRIPTION
## Meet them on their turf, over a proof-carrying kernel

The @socioprophet/hellgraph engine already ships `runSparql`, `runGremlin`, and `shaclValidate` — they were just never exposed over HTTP. This surfaces them:

| Endpoint | Parity with |
|---|---|
| `POST /api/graph/sparql` `{query}` → bindings | Stardog · Anzo · GraphDB |
| `POST /api/graph/gremlin` `{query}` → traversal | Neptune · JanusGraph |
| `POST /api/graph/shacl` `{shapes}` → validation report | TopBraid · Stardog |
| `POST /api/graph/reason` (already live) → PLN forward-chaining | Protégé · Stardog reasoner |

Standard query languages so tools interop; the store underneath is append-only, replayable, proof-carrying — **that's the moat**.

## Also: fix 3 typecheck errors (the superpeer branch)
The current engine build exports **no** super-peer entrypoint (`startSuperPeerFromEnv` was removed — federation lives in a separate build). `HELLGRAPH_MODE=superpeer` now **fails fast with a clear message** instead of importing a non-existent symbol. Clears TS2305 + two implicit-`any` errors.

## Tests
6/6 green — subgraph induced edges, SPARQL bindings, Gremlin vertices, 400-on-missing-query. tsc clean.