### PR TITLE
deploy(graph): roll lattice-studio + hellgraph-service to the explorer/query build

### DIFF
--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -1,3 +1,3 @@
 # hellgraph-service — the engine serves on :8090 (not 8080); align service + probes.
-image: { repository: hellgraph-service, tag: latest }
+image: { repository: hellgraph-service, tag: sha-a16830db1710748792dbe9c79dab5dddeb3d21ff }
 service: { port: 8090, portName: http }

--- a/deploy/values/lattice-studio.yaml
+++ b/deploy/values/lattice-studio.yaml
@@ -1,7 +1,7 @@
 # lattice-studio — the Studio BFF (apps/lattice-studio server.py). Makes the app-vue Studio surface live: wraps
 # product_spine + aggregates live data from hellgraph-service / tritfabric / search-orchestrator, project-scoped
 # to Noetica proj- collections. Pinned to the sha- tag the #753 build published.
-image: { repository: lattice-studio, tag: sha-da0e2b2cb6b20bdb29ea2be6a525066bdc2aeb90 }
+image: { repository: lattice-studio, tag: sha-a16830db1710748792dbe9c79dab5dddeb3d21ff }
 service: { port: 8080, portName: http }
 # server serves /healthz (chart default) — no probes.path override.
 config:

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -100,9 +100,9 @@ KNOWN_BROKEN = {
         "which digest actually runs, because the node cache may be older than `latest`."
     ) for svc in [
         "api", "agentic-os-api", "eval-fabric-api", "evidence-console",
-        "evidence-receipts", "gateway", "hellgraph-service", "osm-map-api",
+        "evidence-receipts", "gateway", "osm-map-api",
         "search-orchestrator",
-    ]},
+    ]},  # hellgraph-service pinned to an immutable sha- tag → removed from the ratchet
 }
 
 # Registries that are explicitly not ours. A values file naming one of these is


### PR DESCRIPTION
Rolls both services to `sha-a16830db` — the merged KKO + induced-subgraph endpoint + BFF edges + KE-3 RDF export (lattice-studio) and the subgraph + SPARQL/Gremlin/SHACL query surface + superpeer fix (hellgraph-service).

Also fixes the hellgraph-service **moving-tag trap** (was `tag: latest` + IfNotPresent → fix never rolls out); now pinned to an immutable sha and removed from the preflight ratchet. `preflight_deploy_contract.py` exits 0.

Images verified present in GAR. The earlier build failures were the 2026-07-16 GitHub 5xx brownout (metadata-action), not our code.