### PR TITLE
deploy(grlplus): pin to immutable sha + drop preflight allowance

### DIFF
--- a/deploy/values/grlplus-service.yaml
+++ b/deploy/values/grlplus-service.yaml
@@ -2,8 +2,8 @@
 # evaluates semantic-worklist closure/escalation rules against the proof-carrying HellGraph (via the
 # SPARQL surface on hellgraph-service), so GRLPlus actually DECIDES close/keep-open/escalate instead of
 # the standards repo's export shim. This is the symbolic shield over the same graph the Graph-RL loop
-# learns on. tag:latest is temporary — pinned to the sha- tag after the first CI build (see preflight).
-image: { repository: grlplus-service, tag: latest }
+# learns on. Pinned to the immutable sha- tag the first CI build published.
+image: { repository: grlplus-service, tag: sha-9f3e3bad5566cba6b76f6ad641d96e3c1e82d5f9 }
 service: { port: 8080, portName: http }
 # server serves /healthz (chart default) — no probes.path override.
 config:

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -87,11 +87,6 @@ KNOWN_BROKEN = {
         "publishes is now a mechanical follow-up after the first CI build (same as dashboard-bff #743); it "
         "could not be done in the same PR because no sha existed yet. Ratcheted, not moot."
     ),
-    "grlplus-service:moving-tag": (
-        "New service — Dockerfile + images.yml entry added this PR, so it BUILDS. Pinning `tag: latest` → the "
-        "sha- tag is the mechanical follow-up after the first CI build (same chicken-and-egg as "
-        "reasoning-failure-runner/dashboard-bff): no sha exists until this merges and builds once."
-    ),
     # The chart has said "Immutable tag = the commit SHA" since it was written; these
     # 9 predate the check. Pinning them is mechanical BUT NOT SAFE TO BATCH: `latest`
     # + IfNotPresent means nodes may be running an older cached digest than `latest`


### PR DESCRIPTION
First build published `grlplus-service:sha-9f3e3bad`. Pins the values off `tag: latest` (moving-tag+IfNotPresent trap) and removes its preflight KNOWN_BROKEN allowance so it can't regress. GRLPlus goes live in-cluster on merge. preflight exit 0.