### PR TITLE
feat(studio): gate /extract write + public studio.socioprophet.ai ingress

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -23,7 +23,7 @@ import re
 from typing import Any
 
 import httpx
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, Header, HTTPException, Response
 from pydantic import BaseModel
 
 from lattice_studio import product_spine
@@ -33,6 +33,8 @@ HELLGRAPH_URL = os.getenv("HELLGRAPH_URL", "http://hellgraph-service:8090")
 TRITFABRIC_URL = os.getenv("TRITFABRIC_URL", "http://tritfabric:8750")
 SEARCH_ORCH_URL = os.getenv("SEARCH_ORCH_URL", "http://search-orchestrator:8080")
 TIMEOUT = float(os.getenv("STUDIO_TIMEOUT", "5"))
+# Write gate for /api/studio/extract (mutates the graph). Fail-closed: unset → writes refused.
+STUDIO_WRITE_TOKEN = os.getenv("STUDIO_WRITE_TOKEN", "")
 
 app = FastAPI(title="Lattice Studio BFF", version=SERVICE_VERSION)
 
@@ -222,7 +224,14 @@ class ExtractRequest(BaseModel):
 
 
 @app.post("/api/studio/extract")
-async def extract(req: ExtractRequest) -> dict[str, Any]:
+async def extract(req: ExtractRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    # WRITE gate: /extract mutates the shared HellGraph, so it must be authenticated before Studio is
+    # publicly exposed. Fail-CLOSED — if STUDIO_WRITE_TOKEN is unset, writes are refused (reads stay open),
+    # so a public ingress can never accept anonymous graph writes. Token provisioned out-of-band (Secret).
+    if not STUDIO_WRITE_TOKEN:
+        raise HTTPException(status_code=503, detail="studio writes disabled: STUDIO_WRITE_TOKEN unset (fail-closed)")
+    if authorization.removeprefix("Bearer ").strip() != STUDIO_WRITE_TOKEN:
+        raise HTTPException(status_code=401, detail="invalid write token")
     coll = proj_collection(req.project)
     src = req.source or ("text:" + hashlib.sha256(req.text.encode()).hexdigest()[:16])
     entities, relations = extract_facts(req.text)

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -43,9 +43,21 @@ def test_extract_facts_deterministic():
     assert len(rels) >= 1
 
 
-def test_extract_endpoint_writes_proof_carrying_facts():
+def test_extract_write_gate(monkeypatch):
+    # fail-closed: no token configured → writes refused (503), never anonymous graph writes
+    r = client.post("/api/studio/extract", json={"project": "team-x", "text": "HellGraph beats Neo4j."})
+    assert r.status_code == 503
+    # token configured but wrong bearer → 401
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    r = client.post("/api/studio/extract", json={"project": "team-x", "text": "x"}, headers={"authorization": "Bearer nope"})
+    assert r.status_code == 401
+
+
+def test_extract_endpoint_writes_proof_carrying_facts(monkeypatch):
     # hellgraph unreachable in test → written=0 but extraction + provenance still returned (graceful)
-    r = client.post("/api/studio/extract", json={"project": "team-x", "text": "HellGraph beats Neo4j on provenance."})
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    r = client.post("/api/studio/extract", json={"project": "team-x", "text": "HellGraph beats Neo4j on provenance."},
+                    headers={"authorization": "Bearer secret"})
     assert r.status_code == 200
     b = r.json()
     assert b["projectCollection"] == "proj-teamx"

--- a/deploy/argocd/search-services.yaml
+++ b/deploy/argocd/search-services.yaml
@@ -27,6 +27,8 @@ spec:
           - { name: commons-search, path: infra/k8s/commons-search/base }
             # public HTTPS edge for search-gateway (read-only) → socioprophet.ai search surface
           - { name: search-gateway-ingress, path: infra/k8s/search-gateway-ingress/base }
+          # public HTTPS edge for the Studio BFF (reads open; /extract write is fail-closed) → studio.socioprophet.ai
+          - { name: studio-ingress, path: infra/k8s/studio-ingress/base }
   template:
     metadata:
       name: 'search-{{.name}}'

--- a/infra/k8s/studio-ingress/base/ingress.yaml
+++ b/infra/k8s/studio-ingress/base/ingress.yaml
@@ -1,0 +1,31 @@
+# Public HTTPS ingress for lattice-studio (the Studio BFF) so the app-vue Studio surface can reach it
+# from the browser. Reads are open (/api/studio, /graph, /graph.ttl); the one WRITE route (/api/studio/
+# extract) is fail-closed behind STUDIO_WRITE_TOKEN, so exposing all paths here is safe. Mirrors the
+# search-gateway/socbase/zot/gitea pattern: GCE ingress class + a GKE ManagedCertificate. Held separate
+# from the chart so the chart keeps owning the Deployment/Service; this only adds the public edge.
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: studio-cert
+  namespace: socioprophet
+spec:
+  domains: [studio.socioprophet.ai]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: studio-public
+  namespace: socioprophet
+  annotations:
+    kubernetes.io/ingress.class: gce   # built-in GCE controller (socbase lesson: NOT nginx)
+    networking.gke.io/managed-certificates: studio-cert
+  labels: { app: lattice-studio, app.kubernetes.io/part-of: socioprophet }
+spec:
+  rules:
+    - host: studio.socioprophet.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service: { name: lattice-studio, port: { number: 8080 } }

--- a/infra/k8s/studio-ingress/base/kustomization.yaml
+++ b/infra/k8s/studio-ingress/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ingress.yaml

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -62,6 +62,7 @@ NON_CHART_SERVICES = {
     "searxng",   # sovereign meta-search, deploys from infra/k8s/searxng (kustomize)
     "commons-search",  # open-chat commons aggregator, deploys from infra/k8s/commons-search (kustomize)
     "search-gateway-ingress",  # public HTTPS edge (ManagedCertificate + Ingress) for search-gateway
+    "studio-ingress",  # public HTTPS edge (ManagedCertificate + Ingress) for lattice-studio (Studio BFF)
 }
 
 # Registry hosts this platform actually publishes to. An image ref pointing anywhere


### PR DESCRIPTION
Makes Studio publicly reachable, **safely**:
- **`/api/studio/extract` fail-closed** behind `STUDIO_WRITE_TOKEN` (unset→503, wrong bearer→401). Reads stay open. The public ingress can never accept anonymous graph writes.
- **studio-ingress** — ManagedCertificate + GCE Ingress for `studio.socioprophet.ai` → `lattice-studio:8080` (mirrors search-gateway-ingress). In the search-services appset + preflight NON_CHART.

**Deploy order (safe):** merge → build → sha-bump lattice-studio to the gated image → *then* point DNS at the ingress IP (cert provisions after DNS, so the gated image is live before exposure). **151 tests · preflight exit 0.**