### PR TITLE
deploy(grl-mesh): pin to immutable sha + drop preflight allowance

### DIFF
--- a/deploy/values/grl-mesh.yaml
+++ b/deploy/values/grl-mesh.yaml
@@ -4,7 +4,7 @@
 # community learns together without raw data leaving a node. Same envelope as the open-chat commons.
 # Publish is FAIL-CLOSED until the GRL_MESH_TOKEN secret is provisioned out-of-band; reads (the prior)
 # stay open (aggregate, non-identifying). tag:latest → sha-pinned after the first CI build (preflight).
-image: { repository: grl-mesh, tag: latest }
+image: { repository: grl-mesh, tag: sha-84b84f6efc7b8285c033072dcc4ef29cdd498b09 }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
 # Internal (ClusterIP) — nodes reach it in-cluster / via the sovereign edge; no public ingress yet.

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -87,10 +87,6 @@ KNOWN_BROKEN = {
         "publishes is now a mechanical follow-up after the first CI build (same as dashboard-bff #743); it "
         "could not be done in the same PR because no sha existed yet. Ratcheted, not moot."
     ),
-    "grl-mesh:moving-tag": (
-        "New service — Dockerfile + images.yml entry added this PR, so it BUILDS. Pin `tag: latest` → the sha- "
-        "tag after the first CI build (same chicken-and-egg as grlplus-service #766): no sha exists until merge."
-    ),
     # The chart has said "Immutable tag = the commit SHA" since it was written; these
     # 9 predate the check. Pinning them is mechanical BUT NOT SAFE TO BATCH: `latest`
     # + IfNotPresent means nodes may be running an older cached digest than `latest`


### PR DESCRIPTION
First build published `grl-mesh:sha-84b84f6e`. Pins off `tag: latest` (moving-tag trap) + removes the preflight allowance. The learning-signal mesh goes live in-cluster on merge (publish stays **fail-closed** until `GRL_MESH_TOKEN` is set out-of-band). preflight exit 0.