### PR TITLE
feat(grlplus): compliance crosswalk — GRLPlus → NIST AI RMF / EU AI Act (auditor-legible governance)

### DIFF
--- a/apps/grlplus-service/src/grlplus_service/crosswalk.py
+++ b/apps/grlplus-service/src/grlplus_service/crosswalk.py
@@ -1,0 +1,94 @@
+"""GRLPlus → compliance-framework crosswalk.
+
+The estate's governance moat is that GRLPlus DECIDES closure/escalation from evidence counted on the
+proof-carrying graph (evaluator.py). This makes that moat auditor-legible: it maps each GRLPlus rule to
+the NIST AI RMF function/subcategory and EU AI Act article it satisfies — so a GRC buyer sees "your
+control X is our rule Y, and here's the graph evidence that enforced it." Static, defensible mapping;
+no framework text is reproduced, only the control identifiers + a one-line rationale.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# Each GRLPlus rule → the controls it operationalizes. NIST = NIST AI RMF 1.0 function.subcategory;
+# EU = EU AI Act article. Rationale ties the rule's graph-evidence check to the control's intent.
+CROSSWALK: dict[str, dict[str, Any]] = {
+    "CR_MIN_DIRECT_ARGUMENT_1": {
+        "nist_ai_rmf": ["MAP-2.3", "MEASURE-2.9"],
+        "eu_ai_act": ["Art. 11 (technical documentation)"],
+        "rationale": "Requires ≥1 traceable argument on the graph before closure — documented, evidenced decisions.",
+    },
+    "CR_MIN_DIRECT_ARGUMENT_2": {
+        "nist_ai_rmf": ["MAP-2.3", "MEASURE-2.9", "GOVERN-1.2"],
+        "eu_ai_act": ["Art. 11 (technical documentation)"],
+        "rationale": "Two-argument coverage raises the documentation bar for higher-stakes elements.",
+    },
+    "CR_MIN_EVIDENCE_LINK_1": {
+        "nist_ai_rmf": ["MEASURE-2.9", "MEASURE-2.13"],
+        "eu_ai_act": ["Art. 12 (record-keeping / logging)"],
+        "rationale": "An evidence link must support the element — the graph IS the auditable record trail.",
+    },
+    "CR_MIN_TELEMETRY_ARTIFACT_1": {
+        "nist_ai_rmf": ["MEASURE-2.4", "MANAGE-4.1"],
+        "eu_ai_act": ["Art. 12 (record-keeping)", "Art. 15 (accuracy, robustness)"],
+        "rationale": "A telemetry/control artifact must be attached — continuous monitoring evidence.",
+    },
+    "CR_DIVERGENCE_BELOW_WARNING": {
+        "nist_ai_rmf": ["MEASURE-2.5", "MEASURE-2.7"],
+        "eu_ai_act": ["Art. 15 (accuracy, robustness)"],
+        "rationale": "Semantic divergence must fall below threshold before closure — validity/reliability gate.",
+    },
+    "CR_OWNER_APPROVAL_REQUIRED": {
+        "nist_ai_rmf": ["GOVERN-2.1", "MANAGE-2.1"],
+        "eu_ai_act": ["Art. 14 (human oversight)"],
+        "rationale": "A named owner must approve closure — enforced human-in-the-loop accountability.",
+    },
+    "ER_BREACH_SLA_ONCE": {
+        "nist_ai_rmf": ["MANAGE-4.1"],
+        "eu_ai_act": ["Art. 9 (risk management system)"],
+        "rationale": "Escalate on first SLA breach — incident response tied to the risk-management loop.",
+    },
+    "ER_BREACH_SLA_TWICE": {
+        "nist_ai_rmf": ["MANAGE-4.1", "MANAGE-4.3"],
+        "eu_ai_act": ["Art. 9 (risk management system)"],
+        "rationale": "Repeated breach escalation — graduated risk treatment.",
+    },
+    "ER_CRITICAL_IMMEDIATE": {
+        "nist_ai_rmf": ["MANAGE-2.4", "MANAGE-4.1"],
+        "eu_ai_act": ["Art. 9 (risk management)", "Art. 62 (serious-incident reporting)"],
+        "rationale": "Immediate escalation on critical severity — expedited incident handling.",
+    },
+    "ER_PERSISTENT_HIGH_TWO_REVIEWS": {
+        "nist_ai_rmf": ["MANAGE-4.2"],
+        "eu_ai_act": ["Art. 9 (risk management)"],
+        "rationale": "Persistent high severity escalates — trend-based risk treatment.",
+    },
+    "ER_MISSING_DIRECT_ARGUMENT_BLOCKS_CLOSURE": {
+        "nist_ai_rmf": ["GOVERN-1.2", "MAP-2.3"],
+        "eu_ai_act": ["Art. 11 (technical documentation)", "Art. 14 (human oversight)"],
+        "rationale": "Closure is blocked without argument coverage — a hard governance gate, not advisory.",
+    },
+}
+
+FRAMEWORKS = {
+    "nist_ai_rmf": "NIST AI Risk Management Framework 1.0",
+    "eu_ai_act": "EU AI Act (Regulation 2024/1689)",
+}
+
+
+def crosswalk() -> dict[str, Any]:
+    """The full GRLPlus → NIST AI RMF / EU AI Act crosswalk, with reverse indices for auditor lookup."""
+    by_nist: dict[str, list[str]] = {}
+    by_eu: dict[str, list[str]] = {}
+    for rule, m in CROSSWALK.items():
+        for c in m["nist_ai_rmf"]:
+            by_nist.setdefault(c, []).append(rule)
+        for c in m["eu_ai_act"]:
+            by_eu.setdefault(c, []).append(rule)
+    return {
+        "frameworks": FRAMEWORKS,
+        "rules": CROSSWALK,
+        "by_nist_ai_rmf": by_nist,   # control → GRLPlus rules that satisfy it
+        "by_eu_ai_act": by_eu,
+        "coverage": {"rules_mapped": len(CROSSWALK), "nist_controls": len(by_nist), "eu_articles": len(by_eu)},
+    }

--- a/apps/grlplus-service/src/grlplus_service/server.py
+++ b/apps/grlplus-service/src/grlplus_service/server.py
@@ -20,6 +20,7 @@ import httpx
 from fastapi import FastAPI
 from pydantic import BaseModel
 
+from .crosswalk import crosswalk
 from .evaluator import (
     CLOSURE_RULES, ESCALATION_RULES, DIVERGENCE_WARNING,
     GraphEvidence, decide,
@@ -123,3 +124,9 @@ async def evaluate(req: EvaluateRequest) -> dict[str, Any]:
         "graph_degraded": err,  # non-null → decisions were made without graph evidence (fail-safe = keep open)
         "results": results,
     }
+
+
+@app.get("/grlplus/crosswalk")
+def crosswalk_endpoint() -> dict[str, Any]:
+    """GRLPlus rules → NIST AI RMF / EU AI Act controls — makes the proof-carrying governance auditor-legible."""
+    return crosswalk()

--- a/apps/grlplus-service/tests/test_evaluator.py
+++ b/apps/grlplus-service/tests/test_evaluator.py
@@ -55,3 +55,26 @@ def test_decide_keeps_open_and_escalates_when_ungrounded():
             "escalation_rule_code": "ER_MISSING_DIRECT_ARGUMENT_BLOCKS_CLOSURE"}
     d = decide(item, GraphEvidence())  # nothing in the graph
     assert d.decision == "keep_open" and d.grounded is False and d.escalate is True
+
+
+def test_crosswalk_maps_rules_to_frameworks():
+    from grlplus_service.crosswalk import crosswalk, CROSSWALK
+    from grlplus_service.evaluator import CLOSURE_RULES, ESCALATION_RULES
+    cw = crosswalk()
+    # every closure + escalation rule the evaluator implements has a compliance mapping
+    for rule in {**CLOSURE_RULES, **ESCALATION_RULES}:
+        assert rule in CROSSWALK, f"{rule} has no crosswalk"
+        assert cw["rules"][rule]["nist_ai_rmf"] and cw["rules"][rule]["eu_ai_act"]
+    # reverse index works (control → rules)
+    assert cw["by_nist_ai_rmf"] and cw["by_eu_ai_act"]
+    assert cw["coverage"]["rules_mapped"] == len(CROSSWALK)
+
+
+def test_crosswalk_endpoint():
+    from fastapi.testclient import TestClient
+    from grlplus_service.server import app
+    r = TestClient(app).get("/grlplus/crosswalk")
+    assert r.status_code == 200
+    b = r.json()
+    assert "MEASURE-2.9" in b["by_nist_ai_rmf"]  # evidence-link control maps back to rules
+    assert any("Art. 14" in a for a in b["by_eu_ai_act"])  # human-oversight article present


### PR DESCRIPTION
Competitive pass #4 (governance moat-deepener). We have a **unique** governance engine — GRLPlus decides closure/escalation from evidence *counted on the proof-carrying graph* — but no auditor-facing surface. This adds it.

- **`crosswalk.py`** — every GRLPlus rule → the **NIST AI RMF** function/subcategory + **EU AI Act** article it operationalizes, each with a rationale tying the rule's graph-evidence check to the control's intent, plus **reverse indices** (control → rules that satisfy it).
- **`GET /grlplus/crosswalk`** — so a GRC buyer sees *"your control is our rule, and here's the graph evidence that enforced it."*

Converts a unique-but-latent engine into a **compliance-legible product**. **15/15 tests.**