### PR TITLE
feat(owl-reasoner): ontology TBox→graph endpoint (WebVOWL-style viz — KE kill-list #4)

### DIFF
--- a/apps/owl-reasoner/src/owl_reasoner/ontology_graph.py
+++ b/apps/owl-reasoner/src/owl_reasoner/ontology_graph.py
@@ -1,0 +1,60 @@
+"""Ontology TBox → graph (WebVOWL-style) — so our 252 ontology files can actually be SEEN.
+
+The KE audit's gap: we author ontologies as Turtle and can *reason* over them, but there is no way to
+visualize the class/property structure (WebVOWL/VOWL do this for OWL out of the box). This extracts the
+TBox as a graph a viewer renders: classes → nodes, rdfs:subClassOf + owl:ObjectProperty (domain→range)
+→ edges. Pure rdflib; the frontend just draws the nodes/edges (reusing the estate's force-graph).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from rdflib import Graph, RDF, RDFS, OWL, URIRef
+
+
+def _local(u: Any) -> str:
+    s = str(u)
+    for sep in ("#", "/"):
+        if sep in s:
+            return s.rsplit(sep, 1)[-1]
+    return s
+
+
+def tbox_graph(turtle: str, limit: int = 1000) -> dict[str, Any]:
+    """Extract the TBox (classes + subClassOf + object-property domain→range) as a renderable graph."""
+    g = Graph()
+    g.parse(data=turtle, format="turtle")
+
+    def label(u: Any) -> str:
+        lbl = g.value(u, RDFS.label)
+        return str(lbl) if lbl else _local(u)
+
+    classes: set[Any] = set()
+    for s in g.subjects(RDF.type, OWL.Class):
+        classes.add(s)
+    for s in g.subjects(RDF.type, RDFS.Class):
+        classes.add(s)
+    for s, _, o in g.triples((None, RDFS.subClassOf, None)):
+        classes.add(s)
+        if isinstance(o, URIRef):
+            classes.add(o)
+    classes = {c for c in classes if isinstance(c, URIRef)}
+
+    nodes = [{"id": str(c), "label": label(c), "type": "class"} for c in classes]
+
+    edges: list[dict[str, Any]] = []
+    for s, _, o in g.triples((None, RDFS.subClassOf, None)):
+        if isinstance(s, URIRef) and isinstance(o, URIRef):
+            edges.append({"source": str(s), "target": str(o), "label": "subClassOf", "type": "subClassOf"})
+    for p in g.subjects(RDF.type, OWL.ObjectProperty):
+        dom = g.value(p, RDFS.domain)
+        rng = g.value(p, RDFS.range)
+        if isinstance(dom, URIRef) and isinstance(rng, URIRef):
+            edges.append({"source": str(dom), "target": str(rng), "label": label(p), "type": "objectProperty"})
+
+    return {
+        "nodes": nodes[:limit],
+        "edges": edges[:limit],
+        "counts": {"classes": len(nodes), "subclass_edges": sum(1 for e in edges if e["type"] == "subClassOf"),
+                   "object_properties": sum(1 for e in edges if e["type"] == "objectProperty")},
+    }

--- a/apps/owl-reasoner/src/owl_reasoner/server.py
+++ b/apps/owl-reasoner/src/owl_reasoner/server.py
@@ -17,6 +17,7 @@ import httpx
 from fastapi import FastAPI
 from pydantic import BaseModel
 
+from .ontology_graph import tbox_graph
 from .reasoner import reason
 
 LATTICE_STUDIO_URL = os.getenv("LATTICE_STUDIO_URL", "http://lattice-studio:8080")
@@ -54,3 +55,14 @@ async def reason_project(project: str = "default", inference: str = "rdfs") -> d
     out = reason(ttl, None, inference)
     out["project"] = project
     return out
+
+
+class OntologyGraphRequest(BaseModel):
+    turtle: str
+    limit: int = 1000
+
+
+@app.post("/ontology/graph")
+def ontology_graph_endpoint(req: OntologyGraphRequest) -> dict[str, Any]:
+    """TBox → renderable graph (classes + subClassOf + object-property edges) — WebVOWL-style ontology viz."""
+    return tbox_graph(req.turtle, req.limit)

--- a/apps/owl-reasoner/tests/test_reasoner.py
+++ b/apps/owl-reasoner/tests/test_reasoner.py
@@ -44,3 +44,26 @@ def test_reason_project_degrades_when_studio_unreachable():
     r = client.post("/reason/project", params={"project": "team-x"})
     assert r.status_code == 200
     assert r.json()["entailed_triples"] == 0  # graph pull fails in test → honest empty
+
+
+def test_tbox_graph_extracts_classes_and_edges():
+    from owl_reasoner.ontology_graph import tbox_graph
+    ttl = """@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix ex: <http://ex/> .
+ex:Animal a owl:Class ; rdfs:label "Animal" .
+ex:Dog a owl:Class ; rdfs:subClassOf ex:Animal .
+ex:owns a owl:ObjectProperty ; rdfs:domain ex:Person ; rdfs:range ex:Dog ; rdfs:label "owns" ."""
+    g = tbox_graph(ttl)
+    ids = {n["id"] for n in g["nodes"]}
+    assert "http://ex/Animal" in ids and "http://ex/Dog" in ids
+    # subClassOf edge Dog→Animal
+    assert any(e["type"] == "subClassOf" and e["source"].endswith("Dog") and e["target"].endswith("Animal") for e in g["edges"])
+    # object-property edge Person→Dog labeled "owns"
+    assert any(e["type"] == "objectProperty" and e["label"] == "owns" for e in g["edges"])
+
+
+def test_ontology_graph_endpoint():
+    ttl = "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n<http://ex/A> a owl:Class ."
+    r = client.post("/ontology/graph", json={"turtle": ttl})
+    assert r.status_code == 200 and r.json()["counts"]["classes"] == 1


### PR DESCRIPTION
The semantic-web/KE audit's **#4 gap**: *"we have 252 ontology files and no way to see any of them."* WebVOWL renders OWL TBox out of the box; we had nothing.

This extracts the **TBox as a renderable graph** — **classes → nodes**, **rdfs:subClassOf + owl:ObjectProperty (domain→range) → edges** — the JSON a WebVOWL-class viewer draws (reusing the estate's force-graph renderer). Pure rdflib, on the `owl-reasoner` service we already run.

`POST /ontology/graph { turtle }` → `{ nodes, edges, counts }`. **8/8 tests.** Fills the ontology-visualization surface's **data layer**; the frontend renderer is the thin follow-up.