### PR TITLE
er: identity-is-prime conformance (prime-veto, margin gate, survivorship, epistemic edges)

### DIFF
--- a/apps/entity-resolution/src/entity_resolution/resolver.py
+++ b/apps/entity-resolution/src/entity_resolution/resolver.py
@@ -16,8 +16,9 @@ from itertools import combinations
 from typing import Any
 
 # Decision thresholds on the blended similarity score.
-MERGE = 0.90        # ≥ → auto-merge (MERGE_VERIFIED)
+MERGE = 0.90        # ≥ → auto-merge candidate (MERGE_VERIFIED, subject to margin + prime-topic admissibility)
 REVIEW = 0.75       # ≥ → human review queue (REQUIRES_REVIEW)
+MIN_MARGIN = 0.08   # Δ = best − second-best must exceed this to promote (else the match is ambiguous → review)
 NAME_W, ATTR_W = 0.7, 0.3
 
 
@@ -26,6 +27,11 @@ class Record:
     id: str
     name: str
     attributes: dict[str, str] = field(default_factory=dict)
+    # Identity-is-prime: a record belongs to a SCOPE and carries PRIME TOPICS (irreducible roles/contexts,
+    # e.g. patient/parent/citizen/founder). Merges that would multiply disjoint primes across different
+    # scopes are FORBIDDEN even on high evidence (identity-is-prime-reference §Merge admissibility).
+    scope: str = ""
+    primes: frozenset[str] = field(default_factory=frozenset)
 
 
 def _norm(s: str) -> str:
@@ -79,15 +85,15 @@ def jaro_winkler(a: str, b: str, p: float = 0.1) -> float:
     return j + pref * p * (1 - j)
 
 
-def jaccard(a: dict[str, str], b: dict[str, str]) -> float:
-    """Token-Jaccard over the attribute key=value tokens (0 if neither has attributes)."""
-    ta = {f"{k}={_norm(v)}" for k, v in a.items()}
-    tb = {f"{k}={_norm(v)}" for k, v in b.items()}
-    if not ta and not tb:
+def attr_agreement(a: dict[str, str], b: dict[str, str]) -> float:
+    """Agreement over SHARED attribute keys: of the keys BOTH records carry, the fraction whose values match.
+    Extra attributes on one side are neutral, not penalties (a richer record must not score *worse* against a
+    sparse one) — that's the ER-correct signal, unlike raw Jaccard which punishes extra keys. 0 if no shared key."""
+    shared = a.keys() & b.keys()
+    if not shared:
         return 0.0
-    inter = len(ta & tb)
-    union = len(ta | tb)
-    return inter / union if union else 0.0
+    agree = sum(1 for k in shared if _norm(a[k]) == _norm(b[k]) and a[k])
+    return agree / len(shared)
 
 
 def _conflict(a: Record, b: Record) -> str | None:
@@ -96,6 +102,16 @@ def _conflict(a: Record, b: Record) -> str | None:
         va, vb = _norm(a.attributes.get(key, "")), _norm(b.attributes.get(key, ""))
         if va and vb and va != vb:
             return key
+    return None
+
+
+def _prime_veto(a: Record, b: Record) -> str | None:
+    """Identity-is-prime merge admissibility (the doctrine classical ER lacks): some merges are FORBIDDEN
+    even on high evidence. Merging two records with DISJOINT prime topics across DIFFERENT scopes would
+    multiply irreducible roles across contexts (e.g. collapsing a 'patient'-scope record into a 'founder'-
+    scope one just because names match) — cross-context leakage. Vetoed → MERGE_BLOCKED, not merged."""
+    if a.primes and b.primes and not (a.primes & b.primes) and a.scope != b.scope:
+        return "identity_prime_veto"
     return None
 
 
@@ -120,14 +136,16 @@ class PairDecision:
 
 def score_pair(a: Record, b: Record) -> PairDecision:
     name_sim = jaro_winkler(_norm(a.name), _norm(b.name))
-    attr_sim = jaccard(a.attributes, b.attributes)
+    attr_sim = attr_agreement(a.attributes, b.attributes)
     # No attribute signal on either side → the name carries the score (don't dilute it with a 0 attr term).
     has_attrs = bool(a.attributes) or bool(b.attributes)
     score = round(name_sim if not has_attrs else NAME_W * name_sim + ATTR_W * attr_sim, 4)
     matched = sorted({k for k in a.attributes if _norm(a.attributes.get(k, "")) == _norm(b.attributes.get(k, "")) and a.attributes.get(k)})
     exact_name = _norm(a.name) == _norm(b.name)
     conflict = _conflict(a, b)
-    if conflict is not None:
+    veto = _prime_veto(a, b)
+    block_reason = conflict or veto
+    if block_reason is not None:
         decision = "MERGE_BLOCKED"
     # Auto-merge requires CORROBORATION — a strong name match alone (fuzzy) is only a review candidate,
     # because two different people can share a near-identical name. Exact name OR a matched attribute merges.
@@ -140,7 +158,8 @@ def score_pair(a: Record, b: Record) -> PairDecision:
     return PairDecision(
         a=a.id, b=b.id, decision=decision, score=score,
         name_sim=round(name_sim, 4), attr_sim=round(attr_sim, 4),
-        evidence={"blocking_key": blocking_key(a), "conflict_field": conflict, "matched_attributes": matched},
+        evidence={"blocking_key": blocking_key(a), "conflict_field": conflict,
+                  "prime_veto": veto, "matched_attributes": matched},
     )
 
 
@@ -160,37 +179,89 @@ class _UF:
 
 
 def resolve(records: list[Record]) -> dict[str, Any]:
-    """Full ER pass: block → score candidate pairs → union-find MERGE_VERIFIED → emit entities + ledger."""
+    """Full ER pass, identity-is-prime-conformant: block → score → MARGIN-gated + prime-admissible merge →
+    union-find clusters → survivorship → proof-carrying epistemic-edge records."""
     blocks: dict[str, list[Record]] = {}
     for r in records:
         blocks.setdefault(blocking_key(r), []).append(r)
 
-    ledger: list[PairDecision] = []
-    uf = _UF()
-    for r in records:
-        uf.find(r.id)  # every record is at least its own entity
+    pairs: list[PairDecision] = []
     for block in blocks.values():
         for a, b in combinations(block, 2):
             d = score_pair(a, b)
-            if d.decision == "NO_MATCH":
-                continue
-            ledger.append(d)
-            if d.decision == "MERGE_VERIFIED":
-                uf.union(a.id, b.id)
+            if d.decision != "NO_MATCH":
+                pairs.append(d)
 
-    # entities = union-find clusters; each carries its member record ids.
+    # Per-record candidate scores → margin. The spec wants promotion by the score MARGIN Δ = best − second,
+    # not an absolute cutoff: an auto-merge must be DECISIVELY the best match, not one of several near-ties.
+    cand: dict[str, list[tuple[float, str]]] = {}
+    for d in pairs:
+        cand.setdefault(d.a, []).append((d.score, d.b))
+        cand.setdefault(d.b, []).append((d.score, d.a))
+    for lst in cand.values():
+        lst.sort(reverse=True)
+
+    def margin(rid: str, other: str) -> float:
+        lst = cand.get(rid, [])
+        if not lst or lst[0][1] != other:
+            return -1.0  # `other` is not rid's top candidate → not a decisive match from rid's side
+        second = lst[1][0] if len(lst) > 1 else 0.0
+        return lst[0][0] - second
+
+    uf = _UF()
+    for r in records:
+        uf.find(r.id)  # every record is at least its own entity
+    for d in pairs:
+        if d.decision != "MERGE_VERIFIED":
+            continue
+        # Attribute-corroborated merges are safe to auto-apply even amid ties (the matched attribute IS the
+        # disambiguator). But a NAME-ONLY merge amid near-ties is dangerous — many distinct people share a
+        # name — so it must be the MUTUAL decisive best (Δ ≥ MIN_MARGIN both sides) or it goes to review.
+        if d.evidence.get("matched_attributes"):
+            uf.union(d.a, d.b)
+            continue
+        ma, mb = margin(d.a, d.b), margin(d.b, d.a)
+        if ma >= MIN_MARGIN and mb >= MIN_MARGIN:
+            uf.union(d.a, d.b)
+        else:
+            d.decision = "REQUIRES_REVIEW"  # ambiguous name-only match — human review
+            d.evidence["ambiguous_margin"] = round(max(ma, mb), 4)
+
+    # Clusters + SURVIVORSHIP: the surviving record (most attributes, then widest scope, then id) is canonical;
+    # its values win attribute conflicts, other members' attributes fill gaps.
+    by_id = {r.id: r for r in records}
     clusters: dict[str, list[str]] = {}
     for r in records:
         clusters.setdefault(uf.find(r.id), []).append(r.id)
-    entities = [
-        {"entity_id": f"ent:{root}", "members": sorted(members), "size": len(members)}
-        for root, members in clusters.items()
+    entities: list[dict[str, Any]] = []
+    for root, members in clusters.items():
+        recs = [by_id[m] for m in members]
+        survivor = max(recs, key=lambda r: (len(r.attributes), r.scope, r.id))
+        attrs: dict[str, str] = {}
+        for r in recs:
+            for k, v in r.attributes.items():
+                attrs.setdefault(k, v)   # first-seen fills gaps
+        attrs.update(survivor.attributes)  # survivor wins conflicts
+        entities.append({
+            "entity_id": f"ent:{root}", "members": sorted(members), "size": len(members),
+            "canonical": {"survivor": survivor.id, "name": survivor.name, "attributes": attrs},
+        })
+
+    # Proof-carrying epistemic-edge records for each merge (regis epistemic-edge typing): a same_as edge
+    # with its epistemic class + confidence, so a merge is an auditable derived relation, not a black box.
+    edges = [
+        {"subject": d.a, "predicate": "same_as", "object": d.b,
+         "epistemic_class": "derived_relation", "confidence_type": "similarity",
+         "confidence_level": d.score, "evidence": d.evidence}
+        for d in pairs if d.decision == "MERGE_VERIFIED"
     ]
+
     return {
         "records": len(records),
         "entities": entities,
         "merged": sum(1 for e in entities if e["size"] > 1),
-        "decision_ledger": [d.__dict__ for d in ledger],
-        "review_queue": [d.__dict__ for d in ledger if d.decision == "REQUIRES_REVIEW"],
-        "blocked": [d.__dict__ for d in ledger if d.decision == "MERGE_BLOCKED"],
+        "decision_ledger": [d.__dict__ for d in pairs],
+        "epistemic_edges": edges,
+        "review_queue": [d.__dict__ for d in pairs if d.decision == "REQUIRES_REVIEW"],
+        "blocked": [d.__dict__ for d in pairs if d.decision == "MERGE_BLOCKED"],
     }

--- a/apps/entity-resolution/src/entity_resolution/server.py
+++ b/apps/entity-resolution/src/entity_resolution/server.py
@@ -20,6 +20,8 @@ class RecordIn(BaseModel):
     id: str
     name: str
     attributes: dict[str, str] = {}
+    scope: str = ""
+    primes: list[str] = []
 
 
 class ResolveRequest(BaseModel):
@@ -33,5 +35,5 @@ def healthz() -> dict[str, Any]:
 
 @app.post("/resolve")
 def resolve_endpoint(req: ResolveRequest) -> dict[str, Any]:
-    recs = [Record(id=r.id, name=r.name, attributes=r.attributes) for r in req.records]
+    recs = [Record(id=r.id, name=r.name, attributes=r.attributes, scope=r.scope, primes=frozenset(r.primes)) for r in req.records]
     return resolve(recs)

--- a/apps/entity-resolution/tests/test_resolver.py
+++ b/apps/entity-resolution/tests/test_resolver.py
@@ -1,18 +1,18 @@
 """Entity Resolution engine — similarity, blocking, clustering, proof-carrying decisions."""
 from fastapi.testclient import TestClient
 
-from entity_resolution.resolver import Record, jaro_winkler, jaccard, score_pair, resolve
+from entity_resolution.resolver import Record, jaro_winkler, attr_agreement, score_pair, resolve
 from entity_resolution.server import app
 
 client = TestClient(app)
 
 
-def test_jaro_winkler_and_jaccard():
+def test_jaro_winkler_and_attr_agreement():
     assert jaro_winkler("martha", "marhta") > 0.9        # classic JW example
     assert jaro_winkler("acme corp", "acme corp") == 1.0
     assert jaro_winkler("acme", "zzzz") < 0.5
-    assert jaccard({"city": "NYC"}, {"city": "nyc"}) == 1.0   # normalized
-    assert jaccard({"city": "NYC"}, {"city": "LA"}) == 0.0
+    assert attr_agreement({"city": "NYC"}, {"city": "nyc"}) == 1.0   # normalized
+    assert attr_agreement({"city": "NYC"}, {"city": "LA"}) == 0.0
 
 
 def test_merge_verified_on_high_similarity():
@@ -67,3 +67,39 @@ def test_resolve_endpoint():
 
 def test_healthz():
     assert client.get("/healthz").json()["ok"] is True
+
+
+def test_identity_prime_veto_blocks_cross_scope_merge():
+    # identical names + high similarity, but DISJOINT prime topics across DIFFERENT scopes → FORBIDDEN merge
+    a = Record("1", "Jane Doe", {}, scope="clinical", primes=frozenset({"patient"}))
+    b = Record("2", "Jane Doe", {}, scope="corporate", primes=frozenset({"founder"}))
+    d = score_pair(a, b)
+    assert d.decision == "MERGE_BLOCKED"
+    assert d.evidence["prime_veto"] == "identity_prime_veto"
+
+
+def test_same_prime_topic_allows_merge():
+    a = Record("1", "Jane Doe", {"city": "NYC"}, scope="clinical", primes=frozenset({"patient"}))
+    b = Record("2", "Jane Doe", {"city": "NYC"}, scope="clinical", primes=frozenset({"patient"}))
+    assert score_pair(a, b).decision == "MERGE_VERIFIED"
+
+
+def test_ambiguous_margin_downgrades_to_review():
+    # three near-identical "Acme Corp" — each record's best match ties with another → not decisively best → review
+    recs = [Record(str(i), "Acme Corp", {}) for i in range(3)]
+    out = resolve(recs)
+    # with no attributes + tied names, margins are ~0 → merges become REQUIRES_REVIEW, not auto-merged
+    assert out["merged"] == 0
+    assert len(out["review_queue"]) >= 1
+
+
+def test_survivorship_and_epistemic_edges():
+    recs = [
+        Record("a", "Acme Corp", {"city": "NYC"}),
+        Record("b", "Acme Corp", {"city": "NYC", "sector": "tech"}),  # more attributes → survivor
+    ]
+    out = resolve(recs)
+    ent = next(e for e in out["entities"] if e["size"] == 2)
+    assert ent["canonical"]["survivor"] == "b"                    # richer record survives
+    assert ent["canonical"]["attributes"]["sector"] == "tech"     # merged attributes
+    assert out["epistemic_edges"] and out["epistemic_edges"][0]["epistemic_class"] == "derived_relation"


### PR DESCRIPTION
## Why
The v0 entity-resolution engine (#775) matched schemas but not the **identity-is-prime doctrine** the specs actually require. It could collapse irreducible roles across scopes on a strong name match alone — the doctrine's core prohibition ("some merges are FORBIDDEN even when evidence is high", Def. 8 merge admissibility) and the REGIS epistemic-edge model.

## What
- **Prime-topic veto** — DISJOINT prime topics across DIFFERENT scopes → `MERGE_BLOCKED` regardless of similarity (blocks patient-scope ↮ founder-scope cross-context leakage).
- **Margin-gated promotion** — a name-only merge amid near-ties (Δ = best−second < `MIN_MARGIN`) is held for review; attribute-corroborated merges stay auto-applied.
- **`attr_agreement`** replaces raw Jaccard — agreement over *shared* keys, so extra attributes are neutral (a richer record no longer scores worse against a sparse one).
- **Survivorship** — canonical record per cluster (most attrs → widest scope → id); survivor wins conflicts, members fill gaps.
- **Epistemic edges** — each merge emits a proof-carrying `same_as` `derived_relation` with confidence.

## Test
11 tests green — prime-veto blocks cross-scope, same-prime allows, ambiguous name-only → review, survivorship picks the richer record + merges attrs, epistemic edges emitted.

Responds directly to the review challenge: *"did you read the regis entity graph spec or the identity is prime repos to make sure you have it right?"* — now conformant.