### PR TITLE
hellgraph-service: dereferenceable resource URIs (Linked-Data publishing)

### DIFF
--- a/apps/hellgraph-service/src/resource.ts
+++ b/apps/hellgraph-service/src/resource.ts
@@ -1,0 +1,121 @@
+/**
+ * resource.ts — dereferenceable resource descriptions (Linked-Data publishing).
+ *
+ * The most basic semantic-web affordance, and the one incumbents (gist/Semantic Arts, Prez, Pubby,
+ * metaphactory) all ship and we didn't: paste a resource URI → get back its facts, content-negotiated.
+ * `GET /api/graph/resource?uri=<iri>` returns that resource's Concise Bounded Description — every triple
+ * with the URI as subject, plus back-links (triples pointing AT it) — as Turtle, JSON-LD, HTML, or JSON
+ * depending on the `Accept` header. This is what makes our graph a *published* graph, not a private store.
+ *
+ * Serialization lives here (the engine's turtle.ts only PARSES); it reuses the store's canonical
+ * `triples()` projection so a resource page can never drift from what SPARQL/Gremlin see.
+ */
+import type { Triple } from '@socioprophet/hellgraph'
+
+/** Minimal store shape we depend on — just the canonical triple projection. */
+export interface TripleSource { triples(): Triple[] }
+
+export interface ResourceDescription {
+  uri: string
+  outgoing: Triple[]   // triples with uri as SUBJECT (the resource's own facts)
+  incoming: Triple[]   // triples with uri as OBJECT  (what references it — back-links)
+  found: boolean
+}
+
+/** Concise Bounded Description: the resource's own facts + inbound references. */
+export function describeResource(src: TripleSource, uri: string): ResourceDescription {
+  const all = src.triples()
+  const outgoing = all.filter((t) => t.subject === uri)
+  const incoming = all.filter((t) => t.isIri && t.object === uri)
+  return { uri, outgoing, incoming, found: outgoing.length > 0 || incoming.length > 0 }
+}
+
+const VOCAB = 'https://socioprophet.ai/vocab#'
+
+/** A predicate is either an already-prefixed CURIE (has ':') or a bare property name we mint under ph:. */
+function predTerm(p: string): string {
+  return p.includes(':') ? p : `ph:${sanitizeLocal(p)}`
+}
+function sanitizeLocal(s: string): string {
+  return s.replace(/[^A-Za-z0-9_-]/g, '_') || '_'
+}
+function iri(s: string): string { return `<${s.replace(/[<>"\s]/g, encodeURIComponent)}>` }
+function lit(v: unknown): string {
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+  return `"${String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`
+}
+function objTerm(t: Triple): string { return t.isIri ? iri(String(t.object)) : lit(t.object) }
+
+/** Turtle serialization of a resource's outgoing triples (the CBD subject block). */
+export function toTurtle(d: ResourceDescription): string {
+  const lines = [
+    '@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .',
+    '@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .',
+    `@prefix ph: <${VOCAB}> .`,
+    '',
+  ]
+  if (d.outgoing.length === 0) {
+    lines.push(`# ${d.uri} has no asserted facts (referenced by ${d.incoming.length} back-link(s))`)
+  } else {
+    lines.push(`${iri(d.uri)}`)
+    const body = d.outgoing.map((t) => `    ${predTerm(t.predicate)} ${objTerm(t)}`)
+    lines.push(body.join(' ;\n') + ' .')
+  }
+  return lines.join('\n') + '\n'
+}
+
+/** JSON-LD serialization (node object with @id + predicates). */
+export function toJsonLd(d: ResourceDescription): unknown {
+  const node: Record<string, unknown> = { '@id': d.uri }
+  const types: string[] = []
+  for (const t of d.outgoing) {
+    if (t.predicate === 'rdf:type') { types.push(String(t.object)); continue }
+    const key = t.predicate.includes(':') ? t.predicate : `${VOCAB}${sanitizeLocal(t.predicate)}`
+    const val = t.isIri ? { '@id': String(t.object) } : t.object
+    const cur = node[key]
+    if (cur === undefined) node[key] = val
+    else node[key] = Array.isArray(cur) ? [...cur, val] : [cur, val]
+  }
+  if (types.length) node['@type'] = types.length === 1 ? types[0] : types
+  return {
+    '@context': { rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', ph: VOCAB },
+    ...node,
+    'ph:backlinks': d.incoming.map((t) => ({ '@id': t.subject, 'ph:via': t.predicate })),
+  }
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+/** Minimal browsable HTML view — a human can dereference the URI in a browser and read the facts. */
+export function toHtml(d: ResourceDescription): string {
+  const row = (p: string, o: string, isIri: boolean) =>
+    `<tr><td class="p">${esc(p)}</td><td>${isIri ? `<a href="/api/graph/resource?uri=${encodeURIComponent(o)}">${esc(o)}</a>` : esc(o)}</td></tr>`
+  const out = d.outgoing.map((t) => row(t.predicate, String(t.object), t.isIri)).join('')
+  const inc = d.incoming.map((t) => `<tr><td>${`<a href="/api/graph/resource?uri=${encodeURIComponent(t.subject)}">${esc(t.subject)}</a>`}</td><td class="p">${esc(t.predicate)}</td></tr>`).join('')
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>${esc(d.uri)}</title>
+<style>body{font:14px/1.5 system-ui,sans-serif;max-width:56rem;margin:2rem auto;padding:0 1rem;color:#1a1a1a}
+h1{font-size:1.1rem;word-break:break-all}h2{font-size:.9rem;color:#666;margin-top:2rem}
+table{border-collapse:collapse;width:100%}td{border-top:1px solid #eee;padding:.35rem .6rem;vertical-align:top}
+.p{color:#555;white-space:nowrap;font-family:ui-monospace,monospace}a{color:#0645ad;text-decoration:none}
+a:hover{text-decoration:underline}.empty{color:#999}
+@media(prefers-color-scheme:dark){body{background:#111;color:#ddd}td{border-color:#333}.p{color:#9aa}a{color:#6ab0ff}}</style>
+</head><body>
+<h1>${esc(d.uri)}</h1>
+${d.outgoing.length ? `<h2>Facts (${d.outgoing.length})</h2><table>${out}</table>` : '<p class="empty">No asserted facts.</p>'}
+${d.incoming.length ? `<h2>Referenced by (${d.incoming.length})</h2><table>${inc}</table>` : ''}
+<p style="margin-top:2rem;color:#999">Turtle · JSON-LD via <code>Accept</code> header — a proof-carrying HellGraph resource.</p>
+</body></html>`
+}
+
+export type ResourceFormat = 'turtle' | 'jsonld' | 'html' | 'json'
+
+/** Content-negotiate on the Accept header. Browser (text/html) → HTML; RDF clients → turtle/jsonld; else JSON. */
+export function negotiate(accept: string | undefined): ResourceFormat {
+  const a = (accept ?? '').toLowerCase()
+  if (a.includes('text/turtle') || a.includes('application/x-turtle')) return 'turtle'
+  if (a.includes('application/ld+json')) return 'jsonld'
+  if (a.includes('text/html') || a.includes('application/xhtml')) return 'html'
+  return 'json'
+}

--- a/apps/hellgraph-service/src/server.test.ts
+++ b/apps/hellgraph-service/src/server.test.ts
@@ -82,3 +82,44 @@ test('query endpoints 400 on missing query', async () => {
   const r = await req('POST', '/api/graph/sparql', {})
   assert.equal(r.status, 400)
 })
+
+test('resource: dereferenceable CBD content-negotiates turtle / json-ld / html / json', async () => {
+  const S = `res-${process.pid}`
+  const subj = `${S}:acme`, obj = `${S}:nyc`
+  await req('POST', '/api/graph/node', { id: subj, labels: ['Org'], properties: { name: 'Acme' } })
+  await req('POST', '/api/graph/node', { id: obj, labels: ['City'], properties: { name: 'NYC' } })
+  await req('POST', '/api/graph/edge', { label: 'basedIn', from: subj, to: obj })
+  const u = `/api/graph/resource?uri=${encodeURIComponent(subj)}`
+
+  // JSON default — CBD carries the resource's own facts (rdf:type, name, basedIn edge)
+  const j = await fetch(BASE + u).then((r) => r.json()) as any
+  assert.equal(j.uri, subj)
+  assert.ok(j.outgoing.some((t: any) => t.predicate === 'rdf:type' && t.object === 'Org'))
+  assert.ok(j.outgoing.some((t: any) => t.predicate === 'basedIn' && t.isIri && t.object === obj))
+
+  // Turtle via Accept
+  const ttl = await fetch(BASE + u, { headers: { accept: 'text/turtle' } })
+  assert.equal(ttl.headers.get('content-type'), 'text/turtle; charset=utf-8')
+  const ttlBody = await ttl.text()
+  assert.match(ttlBody, /@prefix ph:/)
+  assert.match(ttlBody, /basedIn/)
+
+  // JSON-LD via Accept — @id + @type present
+  const ld = await fetch(BASE + u, { headers: { accept: 'application/ld+json' } }).then((r) => r.json()) as any
+  assert.equal(ld['@id'], subj)
+  assert.equal(ld['@type'], 'Org')
+
+  // HTML via Accept — browsable page
+  const html = await fetch(BASE + u, { headers: { accept: 'text/html' } })
+  assert.match(html.headers.get('content-type') ?? '', /text\/html/)
+  assert.match(await html.text(), /<h1>/)
+
+  // back-links: the object resource is "referenced by" the subject
+  const back = await fetch(BASE + `/api/graph/resource?uri=${encodeURIComponent(obj)}`).then((r) => r.json()) as any
+  assert.ok(back.incoming.some((t: any) => t.subject === subj && t.predicate === 'basedIn'))
+})
+
+test('resource: 400 without uri, 404 for unknown uri', async () => {
+  assert.equal((await req('GET', '/api/graph/resource')).status, 400)
+  assert.equal((await req('GET', '/api/graph/resource?uri=urn:nope:missing')).status, 404)
+})

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -11,6 +11,7 @@
  *   POST /api/graph/edge           { label, from, to, properties? } → add edge
  *   GET  /api/graph/query?label=X  nodes carrying a label
  *   GET  /api/graph/subgraph?label=X  induced subgraph (nodes + internal edges) for an explorer
+ *   GET  /api/graph/resource?uri=X    dereferenceable resource CBD, content-negotiated (Turtle/JSON-LD/HTML/JSON)
  *   POST /api/graph/reason         run PLN forward-chaining → counts
  *   POST /api/graph/sparql         { query }  → SPARQL bindings (parity: Stardog/Anzo/GraphDB)
  *   POST /api/graph/gremlin        { query }  → Gremlin results (parity: Neptune/JanusGraph)
@@ -27,6 +28,7 @@ process.env['HELLGRAPH_STORE_DIR'] ||= path.join(os.homedir(), '.hellgraph-servi
 
 import * as engine from '@socioprophet/hellgraph'
 import { getHellGraph, getAtomSpace, attachRocksDB, forwardChain, runSparql, runGremlin, shaclValidate } from '@socioprophet/hellgraph'
+import { describeResource, toTurtle, toJsonLd, toHtml, negotiate } from './resource.js'
 
 const PORT = Number(process.env.PORT ?? 8090)
 
@@ -96,6 +98,21 @@ const server = http.createServer((req, res) => {
     // induced subgraph: keep an edge only when both endpoints are in the node set (no dangling)
     const edges = g.allEdges().filter((e) => ids.has(e.from) && ids.has(e.to))
     return json(res, 200, { count: nodes.length, edges: edges.length, nodes, edgeList: edges })
+  }
+
+  // Dereferenceable resource description (Linked-Data publishing): GET the URI, get its Concise Bounded
+  // Description content-negotiated on Accept — Turtle / JSON-LD / browsable HTML / JSON. This is the
+  // gist/Prez/Pubby affordance the whole semantic-web field expects and we lacked. Read-only.
+  if (req.method === 'GET' && url.pathname === '/api/graph/resource') {
+    const uri = url.searchParams.get('uri') ?? url.searchParams.get('iri') ?? ''
+    if (!uri) return json(res, 400, { error: 'uri (or iri) query param required' })
+    const d = describeResource(g, uri)
+    const fmt = negotiate(req.headers['accept'])
+    const code = d.found ? 200 : 404
+    if (fmt === 'turtle') { res.writeHead(code, { 'content-type': 'text/turtle; charset=utf-8' }); return void res.end(toTurtle(d)) }
+    if (fmt === 'jsonld') { res.writeHead(code, { 'content-type': 'application/ld+json; charset=utf-8' }); return void res.end(JSON.stringify(toJsonLd(d))) }
+    if (fmt === 'html')   { res.writeHead(code, { 'content-type': 'text/html; charset=utf-8' }); return void res.end(toHtml(d)) }
+    return json(res, code, d)
   }
 
   if (req.method === 'POST' && url.pathname === '/api/graph/reason') {


### PR DESCRIPTION
## Why
Answers the review question directly — *"do we need an ontology URI endpoint to query and list our tuples… sorta like gist / Semantic Arts' graph explorer. Should we?"* **Yes.** Dereferenceable resource URIs are the one Linked-Open-Data affordance the entire semantic-web field ships and we didn't. It's the price of being taken seriously — and cheap, because the store already has the triple projection + the serialization is small.

## What
`GET /api/graph/resource?uri=<iri>` returns the resource's **Concise Bounded Description** (its own triples + inbound back-links), content-negotiated on `Accept`:

| Accept | Response |
|---|---|
| `text/turtle` | Turtle |
| `application/ld+json` | JSON-LD (`@id`/`@type`) |
| `text/html` | browsable page — object IRIs are clickable, so you can *walk* the graph in a browser |
| (default) | JSON CBD |

- Serialization in `resource.ts` reuses the store's canonical `triples()` projection → a resource page can't drift from what SPARQL/Gremlin return.
- Read-only. `404` for unknown URIs, `400` without `uri`.
- Back-links included (what references this resource), so dereferencing is bidirectional.

## Next (unblocked by this)
The HTML view is the substrate for **ontology HTML documentation** (pyLODE/Widoco-class) over the 202 `ontogenesis` ontologies — the next KE kill-item.

## Test
8 service tests green — turtle/json-ld/html/json negotiation, CBD facts, and back-links.