### PR TITLE
hellgraph-service: GraphRAG-for-LLMs, provenance-cited (ask over the graph)

### DIFF
--- a/apps/hellgraph-service/src/graphrag.ts
+++ b/apps/hellgraph-service/src/graphrag.ts
@@ -1,0 +1,128 @@
+/**
+ * graphrag.ts — GraphRAG-for-LLMs, provenance-cited (the moat over MS GraphRAG / Cognee / LlamaIndex).
+ *
+ * "Ask a question, get an answer grounded in the graph" is the dominant 2026 buying motive. Everyone
+ * ships it; nobody ships it with RECEIPTS. This does: graph-native retrieval (seed nodes by lexical
+ * match → 1-hop neighbourhood → the grounded facts) turned into NUMBERED, provenance-carrying citations,
+ * then a sovereign-LLM answer that may only cite those facts — so it cannot hallucinate past what the
+ * graph actually asserts, and every claim traces to a node/edge with its assertion time.
+ *
+ * Opt-in + fail-open: no GRAPHRAG_LLM_URL → returns the grounded facts with no synthesized prose (an
+ * honest extractive answer), and any LLM error degrades the same way. Read-only; never throws.
+ */
+import type { Triple } from '@socioprophet/hellgraph'
+
+export interface GraphNodeLite { id: string; labels: string[]; properties: Record<string, unknown> }
+export interface GraphSource {
+  triples(): Triple[]
+  allNodes(): GraphNodeLite[]
+  allEdges(): { id: string; label: string; from: string; to: string }[]
+}
+
+export interface Citation {
+  n: number
+  fact: string          // human-readable "subject predicate object"
+  subject: string
+  predicate: string
+  object: string
+  isIri: boolean
+  assertedAt: string    // provenance: when the graph asserted this — the receipt
+}
+
+export interface Grounding {
+  seeds: string[]       // node ids that matched the question
+  groundedNodes: string[]
+  citations: Citation[]
+}
+
+export interface AskResult {
+  question: string
+  answer: string
+  citations: Citation[]
+  synthesized: boolean  // false → no LLM configured/failed; the citations ARE the (extractive) answer
+  grounded: boolean     // false → nothing in the graph matched the question
+}
+
+const STOP = new Set(['the', 'a', 'an', 'of', 'is', 'are', 'was', 'to', 'in', 'on', 'and', 'or', 'what', 'who',
+  'where', 'when', 'how', 'why', 'which', 'does', 'do', 'did', 'for', 'with', 'about', 'me', 'tell', 'give'])
+
+function terms(q: string): string[] {
+  return [...new Set(q.toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length > 2 && !STOP.has(t)))]
+}
+
+function nodeText(n: GraphNodeLite): string {
+  return `${n.id} ${n.labels.join(' ')} ${Object.values(n.properties).join(' ')}`.toLowerCase()
+}
+
+const MAX_SEEDS = 12
+const MAX_CITATIONS = 24
+
+/** Retrieve the grounding: seed nodes matching the question, their 1-hop neighbourhood, and the facts within. */
+export function retrieveGrounding(g: GraphSource, question: string, maxCitations = MAX_CITATIONS): Grounding {
+  const qterms = terms(question)
+  const nodes = g.allNodes()
+
+  // 1. seed nodes: score by how many query terms appear in the node's text; keep the top matches.
+  const scored = qterms.length === 0 ? [] : nodes
+    .map((n) => { const t = nodeText(n); return { id: n.id, score: qterms.filter((q) => t.includes(q)).length } })
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_SEEDS)
+  const seeds = scored.map((s) => s.id)
+  const seedSet = new Set(seeds)
+
+  // 2. expand to the 1-hop neighbourhood — the facts a human would cite come from around the seed.
+  const grounded = new Set(seeds)
+  for (const e of g.allEdges()) {
+    if (seedSet.has(e.from)) grounded.add(e.to)
+    if (seedSet.has(e.to)) grounded.add(e.from)
+  }
+
+  // 3. facts = triples whose SUBJECT is a grounded node → numbered, provenance-carrying citations.
+  const facts = g.triples().filter((t) => grounded.has(t.subject))
+  const citations: Citation[] = facts.slice(0, maxCitations).map((t, i) => ({
+    n: i + 1,
+    fact: `${t.subject} ${t.predicate} ${t.object}`,
+    subject: t.subject, predicate: t.predicate, object: String(t.object), isIri: t.isIri,
+    assertedAt: t.assertedAt,
+  }))
+  return { seeds, groundedNodes: [...grounded], citations }
+}
+
+interface LlmConfig { url: string; model: string; key: string }
+function llmConfig(): LlmConfig | null {
+  const url = (process.env['GRAPHRAG_LLM_URL'] ?? '').replace(/\/$/, '')
+  const model = process.env['GRAPHRAG_LLM_MODEL'] ?? ''
+  if (!url || !model) return null   // sovereign LLM not configured → extractive (facts-only) mode
+  return { url, model, key: process.env['GRAPHRAG_LLM_KEY'] ?? '' }
+}
+export function synthesisEnabled(): boolean { return llmConfig() !== null }
+
+/** Ask a question over the graph: retrieve grounding, then synthesize a cited answer (opt-in, fail-open). */
+export async function askGraph(g: GraphSource, question: string, fetchImpl: typeof fetch = fetch): Promise<AskResult> {
+  const { citations } = retrieveGrounding(g, question)
+  const grounded = citations.length > 0
+  const cfg = llmConfig()
+  if (!cfg || !grounded) return { question, answer: '', citations, synthesized: false, grounded }
+
+  const facts = citations.map((c) => `[${c.n}] ${c.fact}`).join('\n')
+  const prompt =
+    `You are a sovereign knowledge-graph assistant. Answer the question using ONLY the numbered graph facts below. ` +
+    `Cite every claim inline as [n] using those numbers. If the facts do not answer it, say so plainly — never use outside knowledge.\n\n` +
+    `Question: ${question}\n\nGraph facts:\n${facts}\n\nAnswer (with [n] citations):`
+  try {
+    const headers: Record<string, string> = { 'content-type': 'application/json' }
+    if (cfg.key) headers['authorization'] = `Bearer ${cfg.key}`
+    const res = await fetchImpl(`${cfg.url}/chat/completions`, {
+      method: 'POST', headers,
+      body: JSON.stringify({ model: cfg.model, temperature: 0.1, max_tokens: 600, messages: [{ role: 'user', content: prompt }] }),
+      signal: AbortSignal.timeout(30_000),
+    })
+    if (!res.ok) return { question, answer: '', citations, synthesized: false, grounded }
+    const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> }
+    const answer = data.choices?.[0]?.message?.content?.trim() ?? ''
+    return { question, answer, citations, synthesized: answer.length > 0, grounded }
+  } catch {
+    return { question, answer: '', citations, synthesized: false, grounded }
+  }
+}

--- a/apps/hellgraph-service/src/server.test.ts
+++ b/apps/hellgraph-service/src/server.test.ts
@@ -123,3 +123,33 @@ test('resource: 400 without uri, 404 for unknown uri', async () => {
   assert.equal((await req('GET', '/api/graph/resource')).status, 400)
   assert.equal((await req('GET', '/api/graph/resource?uri=urn:nope:missing')).status, 404)
 })
+
+test('graphrag: /ground retrieves seeds + 1-hop facts as provenance-carrying citations', async () => {
+  const S = `rag-${process.pid}`
+  const acme = `${S}:acme`, nyc = `${S}:nyc`, jane = `${S}:jane`
+  await req('POST', '/api/graph/node', { id: acme, labels: ['Org'], properties: { name: 'Acme Aerospace' } })
+  await req('POST', '/api/graph/node', { id: nyc, labels: ['City'], properties: { name: 'New York' } })
+  await req('POST', '/api/graph/node', { id: jane, labels: ['Person'], properties: { name: 'Jane' } })
+  await req('POST', '/api/graph/edge', { label: 'basedIn', from: acme, to: nyc })
+  await req('POST', '/api/graph/edge', { label: 'worksAt', from: jane, to: acme })
+
+  const r = await req('GET', `/api/graph/ground?q=${encodeURIComponent('what is Acme Aerospace')}`)
+  assert.equal(r.status, 200)
+  assert.ok(r.json.seeds.includes(acme))                                   // seeded by the query term
+  assert.ok(r.json.groundedNodes.includes(nyc))                           // 1-hop neighbour pulled in
+  assert.ok(r.json.citations.length >= 1)
+  const c = r.json.citations[0]
+  assert.ok('assertedAt' in c && 'fact' in c && 'n' in c)                 // provenance-carrying, numbered
+  assert.ok(r.json.citations.some((x: any) => x.predicate === 'basedIn' && x.object === nyc))
+})
+
+test('graphrag: /ask degrades to facts-only when no sovereign LLM is configured (fail-open, grounded)', async () => {
+  const S = `ask-${process.pid}`
+  await req('POST', '/api/graph/node', { id: `${S}:widget`, labels: ['Product'], properties: { name: 'Widget9000' } })
+  const r = await req('POST', '/api/graph/ask', { question: 'tell me about Widget9000' })
+  assert.equal(r.status, 200)
+  assert.equal(r.json.synthesized, false)      // no GRAPHRAG_LLM_URL in CI → extractive
+  assert.equal(r.json.grounded, true)          // but it DID ground in the graph
+  assert.ok(r.json.citations.length >= 1)
+  assert.equal((await req('POST', '/api/graph/ask', {})).status, 400)     // question required
+})

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -12,6 +12,8 @@
  *   GET  /api/graph/query?label=X  nodes carrying a label
  *   GET  /api/graph/subgraph?label=X  induced subgraph (nodes + internal edges) for an explorer
  *   GET  /api/graph/resource?uri=X    dereferenceable resource CBD, content-negotiated (Turtle/JSON-LD/HTML/JSON)
+ *   GET  /api/graph/ground?q=X        GraphRAG retrieval: seeds + 1-hop facts as provenance-carrying citations
+ *   POST /api/graph/ask            { question } → GraphRAG cited answer grounded in the graph (sovereign LLM, opt-in)
  *   POST /api/graph/reason         run PLN forward-chaining → counts
  *   POST /api/graph/sparql         { query }  → SPARQL bindings (parity: Stardog/Anzo/GraphDB)
  *   POST /api/graph/gremlin        { query }  → Gremlin results (parity: Neptune/JanusGraph)
@@ -29,6 +31,7 @@ process.env['HELLGRAPH_STORE_DIR'] ||= path.join(os.homedir(), '.hellgraph-servi
 import * as engine from '@socioprophet/hellgraph'
 import { getHellGraph, getAtomSpace, attachRocksDB, forwardChain, runSparql, runGremlin, shaclValidate } from '@socioprophet/hellgraph'
 import { describeResource, toTurtle, toJsonLd, toHtml, negotiate } from './resource.js'
+import { askGraph, retrieveGrounding, synthesisEnabled } from './graphrag.js'
 
 const PORT = Number(process.env.PORT ?? 8090)
 
@@ -113,6 +116,24 @@ const server = http.createServer((req, res) => {
     if (fmt === 'jsonld') { res.writeHead(code, { 'content-type': 'application/ld+json; charset=utf-8' }); return void res.end(JSON.stringify(toJsonLd(d))) }
     if (fmt === 'html')   { res.writeHead(code, { 'content-type': 'text/html; charset=utf-8' }); return void res.end(toHtml(d)) }
     return json(res, code, d)
+  }
+
+  // GraphRAG-for-LLMs, provenance-cited: ask a question, get an answer grounded in the graph with every
+  // claim traceable to a node/edge + its assertion time. GET returns the grounding (retrieval only);
+  // POST /ask synthesizes a cited answer via the sovereign LLM (opt-in, fail-open → facts-only otherwise).
+  if (req.method === 'GET' && url.pathname === '/api/graph/ground') {
+    const q = url.searchParams.get('q') ?? ''
+    if (!q) return json(res, 400, { error: 'q (question) required' })
+    return json(res, 200, { question: q, ...retrieveGrounding(g, q) })
+  }
+  if (req.method === 'POST' && url.pathname === '/api/graph/ask') {
+    return void readBody(req).then(async (b) => {
+      try {
+        const { question } = JSON.parse(b || '{}') as { question?: string }
+        if (!question) throw new Error('question required')
+        json(res, 200, { synthesisEnabled: synthesisEnabled(), ...(await askGraph(g, question)) })
+      } catch (e) { json(res, 400, { error: String(e) }) }
+    })
   }
 
   if (req.method === 'POST' && url.pathname === '/api/graph/reason') {


### PR DESCRIPTION
## Why
KE kill-item #1 — the **best offense**. "Ground my agent in a trustworthy graph" is the dominant 2026 buying motive. MS GraphRAG / Cognee / LlamaIndex all ship GraphRAG; none ship it with **receipts**. This rides our moat (proof-carrying provenance) straight into the hottest category.

## What
- **`GET /api/graph/ground?q=`** — retrieval only: seed nodes (lexical match on id/labels/property values) → 1-hop neighbourhood → the grounded facts, each a **numbered citation carrying subject/predicate/object + assertion time** (the provenance receipt).
- **`POST /api/graph/ask { question }`** — synthesize a cited answer over those facts via a **sovereign LLM** (`GRAPHRAG_LLM_URL/MODEL/KEY`). The model may only cite the retrieved facts, so it **cannot hallucinate past what the graph asserts**.

## Sovereign + safe
Opt-in + fail-open: no LLM configured (or any error) → returns the grounded facts as an honest **extractive** answer (`synthesized:false, grounded:true`). Read-only; never throws into the request.

## Differentiator
Every answer traces to node/edge provenance — the auditable-GraphRAG the incumbents don't have.

## Test
10 service tests green — grounding (seeds + 1-hop + provenance-carrying citations) and `/ask` fail-open extractive path.