### PR TITLE
er: REGIS-framework depth (replay key, golden records, concordance, incremental delta)

### DIFF
--- a/apps/entity-resolution/src/entity_resolution/resolver.py
+++ b/apps/entity-resolution/src/entity_resolution/resolver.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from itertools import combinations
 from typing import Any
 
@@ -20,6 +21,22 @@ MERGE = 0.90        # ≥ → auto-merge candidate (MERGE_VERIFIED, subject to m
 REVIEW = 0.75       # ≥ → human review queue (REQUIRES_REVIEW)
 MIN_MARGIN = 0.08   # Δ = best − second-best must exceed this to promote (else the match is ambiguous → review)
 NAME_W, ATTR_W = 0.7, 0.3
+
+# REGIS replay pins — every response carries the (as_of, resolver, policy, template) tuple so a merge is
+# REPLAYABLE: same inputs + same key ⇒ same output. Bump these when the algorithm/policy/survivorship change.
+RESOLVER_VERSION = "1.1.0"   # scoring + margin + prime-veto engine
+POLICY_VERSION = "1.0.0"     # thresholds (MERGE/REVIEW/MIN_MARGIN) + corroboration/prime-admissibility rules
+TEMPLATE_VERSION = "1.0.0"   # survivorship authority template (most-attrs → widest-scope → id)
+
+
+def replay_key(as_of: str | None = None) -> dict[str, str]:
+    """The deterministic replay key pinned on every response (REGIS framework requirement)."""
+    return {
+        "as_of_time": as_of or datetime.now(timezone.utc).isoformat(),
+        "resolver_version": RESOLVER_VERSION,
+        "policy_version": POLICY_VERSION,
+        "template_version": TEMPLATE_VERSION,
+    }
 
 
 @dataclass
@@ -178,9 +195,10 @@ class _UF:
         self.p[self.find(a)] = self.find(b)
 
 
-def resolve(records: list[Record]) -> dict[str, Any]:
+def resolve(records: list[Record], as_of: str | None = None) -> dict[str, Any]:
     """Full ER pass, identity-is-prime-conformant: block → score → MARGIN-gated + prime-admissible merge →
-    union-find clusters → survivorship → proof-carrying epistemic-edge records."""
+    union-find clusters → survivorship → proof-carrying epistemic-edge records. Pins a replay key, and
+    projects golden records + a concordance (source record → canonical entity) per the REGIS framework."""
     blocks: dict[str, list[Record]] = {}
     for r in records:
         blocks.setdefault(blocking_key(r), []).append(r)
@@ -244,8 +262,18 @@ def resolve(records: list[Record]) -> dict[str, Any]:
         attrs.update(survivor.attributes)  # survivor wins conflicts
         entities.append({
             "entity_id": f"ent:{root}", "members": sorted(members), "size": len(members),
-            "canonical": {"survivor": survivor.id, "name": survivor.name, "attributes": attrs},
+            "canonical": {"survivor": survivor.id, "name": survivor.name, "attributes": attrs,
+                          "scope": survivor.scope, "primes": sorted(survivor.primes)},
         })
+
+    # Golden records (canonical projection keyed by entity) + concordance/crosswalk (source id → entity).
+    golden_records = {
+        e["entity_id"]: {**e["canonical"], "members": e["members"]} for e in entities
+    }
+    concordance = [
+        {"record_id": m, "entity_id": e["entity_id"], "survivor": e["canonical"]["survivor"]}
+        for e in entities for m in e["members"]
+    ]
 
     # Proof-carrying epistemic-edge records for each merge (regis epistemic-edge typing): a same_as edge
     # with its epistemic class + confidence, so a merge is an auditable derived relation, not a black box.
@@ -257,11 +285,78 @@ def resolve(records: list[Record]) -> dict[str, Any]:
     ]
 
     return {
+        "replay_key": replay_key(as_of),
         "records": len(records),
         "entities": entities,
+        "golden_records": golden_records,
+        "concordance": concordance,
         "merged": sum(1 for e in entities if e["size"] > 1),
         "decision_ledger": [d.__dict__ for d in pairs],
         "epistemic_edges": edges,
         "review_queue": [d.__dict__ for d in pairs if d.decision == "REQUIRES_REVIEW"],
         "blocked": [d.__dict__ for d in pairs if d.decision == "MERGE_BLOCKED"],
+    }
+
+
+def _anchor_record(golden: dict[str, Any]) -> Record:
+    """Turn a prior golden record into an anchor Record so new inputs can be scored against it."""
+    return Record(
+        id=golden["entity_id"] if "entity_id" in golden else golden["survivor"],
+        name=golden["name"], attributes=dict(golden.get("attributes", {})),
+        scope=golden.get("scope", ""), primes=frozenset(golden.get("primes", [])),
+    )
+
+
+def resolve_incremental(prior_golden: list[dict[str, Any]], new_records: list[Record],
+                        as_of: str | None = None) -> dict[str, Any]:
+    """INCREMENTAL delta resolution: score only the NEW records (against each other + prior golden anchors),
+    never re-resolving the settled estate. Returns which new records attached to an existing entity vs formed
+    new ones — the O(new) update the REGIS framework asks for instead of an O(n²) full re-run."""
+    anchors = [_anchor_record(g) for g in prior_golden]
+    anchor_ids = {a.id for a in anchors}
+    universe = anchors + new_records
+    new_ids = {r.id for r in new_records}
+
+    blocks: dict[str, list[Record]] = {}
+    for r in universe:
+        blocks.setdefault(blocking_key(r), []).append(r)
+
+    uf = _UF()
+    for r in universe:
+        uf.find(r.id)
+    delta_pairs: list[PairDecision] = []
+    for block in blocks.values():
+        for a, b in combinations(block, 2):
+            # Skip anchor↔anchor: the prior estate is already resolved — only NEW-involving pairs are work.
+            if a.id in anchor_ids and b.id in anchor_ids:
+                continue
+            d = score_pair(a, b)
+            if d.decision == "NO_MATCH":
+                continue
+            delta_pairs.append(d)
+            if d.decision == "MERGE_VERIFIED":
+                uf.union(a.id, b.id)
+
+    # Classify each new record: attached to a prior entity (its cluster contains an anchor) or a new entity.
+    by_id = {r.id: r for r in universe}
+    attached: list[dict[str, Any]] = []
+    new_entities: dict[str, list[str]] = {}
+    for r in new_records:
+        root = uf.find(r.id)
+        members = [m for m in by_id if uf.find(m) == root]
+        prior_anchor = next((m for m in members if m in anchor_ids), None)
+        if prior_anchor is not None:
+            attached.append({"record_id": r.id, "entity_id": prior_anchor})
+        else:
+            new_entities.setdefault(root, [])
+            new_entities[root] = sorted(m for m in members if m in new_ids)
+
+    return {
+        "replay_key": replay_key(as_of),
+        "new_records": len(new_records),
+        "attached_to_existing": attached,
+        "new_entities": [{"entity_id": f"ent:{root}", "members": mem} for root, mem in new_entities.items()],
+        "delta_ledger": [d.__dict__ for d in delta_pairs],
+        "review_queue": [d.__dict__ for d in delta_pairs if d.decision == "REQUIRES_REVIEW"],
+        "blocked": [d.__dict__ for d in delta_pairs if d.decision == "MERGE_BLOCKED"],
     }

--- a/apps/entity-resolution/src/entity_resolution/server.py
+++ b/apps/entity-resolution/src/entity_resolution/server.py
@@ -1,8 +1,10 @@
 """entity-resolution service — the real ER resolver (regis had only a validator).
 
   GET  /healthz
-  POST /resolve   { records: [{id, name, attributes?}] } → entities (clusters) + proof-carrying
-                  decision ledger (MERGE_VERIFIED / REQUIRES_REVIEW / MERGE_BLOCKED with field-level evidence)
+  POST /resolve              { records[] , as_of? } → entities + golden_records + concordance +
+                             proof-carrying decision ledger, all pinned with a deterministic replay_key
+  POST /resolve/incremental  { prior_golden[], new_records[], as_of? } → delta: which new records attached
+                             to an existing entity vs formed new ones, without re-resolving the estate (O(new))
 """
 from __future__ import annotations
 
@@ -11,7 +13,7 @@ from typing import Any
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from .resolver import Record, resolve
+from .resolver import Record, resolve, resolve_incremental
 
 app = FastAPI(title="entity-resolution", version="0.1.0")
 
@@ -26,6 +28,17 @@ class RecordIn(BaseModel):
 
 class ResolveRequest(BaseModel):
     records: list[RecordIn]
+    as_of: str | None = None
+
+
+class IncrementalRequest(BaseModel):
+    prior_golden: list[dict[str, Any]]   # golden_records values from a prior /resolve
+    new_records: list[RecordIn]
+    as_of: str | None = None
+
+
+def _rec(r: RecordIn) -> Record:
+    return Record(id=r.id, name=r.name, attributes=r.attributes, scope=r.scope, primes=frozenset(r.primes))
 
 
 @app.get("/healthz")
@@ -35,5 +48,9 @@ def healthz() -> dict[str, Any]:
 
 @app.post("/resolve")
 def resolve_endpoint(req: ResolveRequest) -> dict[str, Any]:
-    recs = [Record(id=r.id, name=r.name, attributes=r.attributes, scope=r.scope, primes=frozenset(r.primes)) for r in req.records]
-    return resolve(recs)
+    return resolve([_rec(r) for r in req.records], as_of=req.as_of)
+
+
+@app.post("/resolve/incremental")
+def resolve_incremental_endpoint(req: IncrementalRequest) -> dict[str, Any]:
+    return resolve_incremental(req.prior_golden, [_rec(r) for r in req.new_records], as_of=req.as_of)

--- a/apps/entity-resolution/tests/test_resolver.py
+++ b/apps/entity-resolution/tests/test_resolver.py
@@ -1,7 +1,10 @@
 """Entity Resolution engine — similarity, blocking, clustering, proof-carrying decisions."""
 from fastapi.testclient import TestClient
 
-from entity_resolution.resolver import Record, jaro_winkler, attr_agreement, score_pair, resolve
+from entity_resolution.resolver import (
+    Record, jaro_winkler, attr_agreement, score_pair, resolve, resolve_incremental,
+    RESOLVER_VERSION,
+)
 from entity_resolution.server import app
 
 client = TestClient(app)
@@ -103,3 +106,61 @@ def test_survivorship_and_epistemic_edges():
     assert ent["canonical"]["survivor"] == "b"                    # richer record survives
     assert ent["canonical"]["attributes"]["sector"] == "tech"     # merged attributes
     assert out["epistemic_edges"] and out["epistemic_edges"][0]["epistemic_class"] == "derived_relation"
+
+
+def test_replay_key_pinned_and_deterministic():
+    recs = [Record("a", "Acme Corp", {"city": "NYC"}), Record("b", "Acme Corp", {"city": "NYC"})]
+    out = resolve(recs, as_of="2026-07-16T00:00:00+00:00")
+    k = out["replay_key"]
+    assert k["as_of_time"] == "2026-07-16T00:00:00+00:00"
+    assert k["resolver_version"] == RESOLVER_VERSION and "policy_version" in k and "template_version" in k
+    # deterministic: same inputs + same as_of ⇒ identical entities/golden projection
+    out2 = resolve(recs, as_of="2026-07-16T00:00:00+00:00")
+    assert out2["golden_records"] == out["golden_records"] and out2["concordance"] == out["concordance"]
+
+
+def test_golden_records_and_concordance():
+    recs = [
+        Record("a", "Acme Corp", {"city": "NYC"}),
+        Record("b", "Acme Corp", {"city": "NYC", "sector": "tech"}),
+        Record("z", "Globex", {"city": "LA"}),
+    ]
+    out = resolve(recs)
+    # golden record for the merged entity carries the survivor's richer attributes + its members
+    ent = next(e for e in out["entities"] if e["size"] == 2)
+    gr = out["golden_records"][ent["entity_id"]]
+    assert gr["survivor"] == "b" and gr["attributes"]["sector"] == "tech"
+    assert set(gr["members"]) == {"a", "b"}
+    # concordance maps every source record to its canonical entity
+    cmap = {c["record_id"]: c["entity_id"] for c in out["concordance"]}
+    assert cmap["a"] == cmap["b"] and cmap["z"] != cmap["a"]
+    assert len(out["concordance"]) == 3
+
+
+def test_incremental_attaches_new_record_to_existing_entity():
+    base = resolve([Record("a", "Acme Corp", {"city": "NYC"}), Record("b", "Acme Corp", {"city": "NYC"})])
+    prior = list(base["golden_records"].values())
+    # a new record that matches the existing Acme entity → attaches, not a new entity, no full re-run
+    delta = resolve_incremental(prior, [Record("c", "Acme Corp", {"city": "NYC"})])
+    assert delta["attached_to_existing"] and delta["attached_to_existing"][0]["record_id"] == "c"
+    assert delta["new_entities"] == []
+    # a new record unrelated to any prior entity → forms a new entity
+    delta2 = resolve_incremental(prior, [Record("d", "Initech", {"city": "Austin"})])
+    assert delta2["attached_to_existing"] == []
+    assert delta2["new_entities"] and "d" in delta2["new_entities"][0]["members"]
+
+
+def test_incremental_endpoint():
+    base = client.post("/resolve", json={"records": [
+        {"id": "a", "name": "Acme Corp", "attributes": {"city": "NYC"}},
+        {"id": "b", "name": "Acme Corp", "attributes": {"city": "NYC"}},
+    ]}).json()
+    prior = list(base["golden_records"].values())
+    r = client.post("/resolve/incremental", json={
+        "prior_golden": prior,
+        "new_records": [{"id": "c", "name": "Acme Corp", "attributes": {"city": "NYC"}}],
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["attached_to_existing"][0]["record_id"] == "c"
+    assert "replay_key" in body


### PR DESCRIPTION
## Why
KE kill-item #2. The resolver (#775/#777) produces proof-carrying merges but lacked the **REGIS framework** around them. `regis-entity-graph-framework.v1` demands version-pinned replay, golden-record projection, a crosswalk, and incremental delta. This adds all four so "replayable, proof-carrying ER" is real.

## What
- **Deterministic replay key** — `(as_of_time, resolver_version, policy_version, template_version)` on every response. Same inputs + same key ⇒ identical output (tested).
- **Golden records** — canonical projection keyed by entity (survivor + merged attributes + scope/primes + members).
- **Concordance / crosswalk** — every source record → its canonical entity + survivor.
- **Incremental delta** — `POST /resolve/incremental { prior_golden, new_records }` scores only NEW-involving pairs against prior golden anchors (**O(new)**, never re-resolving the settled estate) and reports which new records attached to an existing entity vs formed new ones. Prime-veto + margin rules still apply.

## Moat
Where we out-flank Senzing: every incremental update is a **replayable certificate**, not a black-box real-time score.

## Test
15 tests green — replay-key pinning + determinism, golden records, concordance completeness, incremental attach-vs-new-entity, and the `/resolve/incremental` endpoint.