### PR TITLE
owl-reasoner: entailment justifications + OWL2-RL profile naming

### DIFF
--- a/apps/owl-reasoner/src/owl_reasoner/reasoner.py
+++ b/apps/owl-reasoner/src/owl_reasoner/reasoner.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from rdflib import Graph
+from rdflib import OWL, RDF, RDFS, Graph
+from rdflib.term import URIRef
 
 try:
     from owlrl import DeductiveClosure, RDFS_Semantics, OWLRL_Semantics
@@ -27,12 +28,19 @@ except Exception:  # pragma: no cover
     _HAVE_SHACL = False
 
 
-def reason(turtle: str, shapes: str | None = None, inference: str = "rdfs", limit: int = 100) -> dict[str, Any]:
+# OWL2-RL is the profile owlrl's OWLRL_Semantics implements — expose the standard profile name as an alias.
+_PROFILE_ALIASES = {"owl2rl": "owlrl", "owl2-rl": "owlrl", "owl": "owlrl"}
+
+
+def reason(turtle: str, shapes: str | None = None, inference: str = "rdfs",
+           limit: int = 100, explain: bool = False) -> dict[str, Any]:
     """Compute entailments (+ optional SHACL validation) over a Turtle graph.
 
-    inference: 'rdfs' | 'owlrl' | 'both' | 'none'. Returns the input/entailed counts, a sample of the
-    NEW (derived) triples, and — when shapes are supplied — the SHACL conformance report.
+    inference: 'rdfs' | 'owlrl'/'owl2rl' | 'both' | 'none'. Returns input/entailed counts, a sample of the
+    NEW (derived) triples, optional per-triple JUSTIFICATIONS (a 1-step derivation trace: rule + premises —
+    the "why" incumbents' opaque reasoners don't emit), and, when shapes are supplied, the SHACL report.
     """
+    inference = _PROFILE_ALIASES.get(inference, inference)
     g = Graph()
     g.parse(data=turtle, format="turtle")
     baseline = set(g)  # to diff out the entailments
@@ -52,9 +60,13 @@ def reason(turtle: str, shapes: str | None = None, inference: str = "rdfs", limi
         "input_triples": n_in,
         "entailed_triples": len(entailed),
         "inference": mode,
+        "profile": {"rdfs": "RDFS", "owlrl": "OWL 2 RL", "both": "OWL 2 RL + RDFS", "none": "none"}.get(mode, mode),
         # proof-carrying: each entailed triple is a derivation over stated facts + the ontology
         "entailments": [f"{_c(s)} {_c(p)} {_c(o)}" for (s, p, o) in entailed[:limit]],
     }
+    if explain:
+        # Justification = a 1-step derivation trace grounding each entailment in premises the graph holds.
+        result["justifications"] = [j for t in entailed[:limit] if (j := _justify(g, *t)) is not None]
 
     if shapes is not None:
         if not _HAVE_SHACL:
@@ -65,6 +77,62 @@ def reason(turtle: str, shapes: str | None = None, inference: str = "rdfs", limi
             conforms, _report_graph, report_text = pyshacl.validate(g, shacl_graph=sg, inference="none", advanced=True)
             result["shacl"] = {"available": True, "conforms": bool(conforms), "report": report_text[:4000]}
     return result
+
+
+def _justify(g: Graph, s: Any, p: Any, o: Any) -> dict[str, Any] | None:
+    """Find a 1-step justification for an entailed triple: the rule that derives it + the premises the
+    graph holds. Covers the load-bearing RDFS/OWL-RL rules (type propagation, subclass/subproperty
+    transitivity, domain/range). Returns {conclusion, rule, premises[]} or None if not attributable."""
+    def has(a: Any, b: Any, c: Any) -> bool:
+        return (a, b, c) in g
+
+    def prem(a: Any, b: Any, c: Any) -> str:
+        return f"{_c(a)} {_c(b)} {_c(c)}"
+
+    concl = f"{_c(s)} {_c(p)} {_c(o)}"
+
+    if p == RDF.type:
+        # type propagation: s a C , C ⊑ o  ⊢  s a o
+        for c in g.objects(s, RDF.type):
+            if c != o and has(c, RDFS.subClassOf, o):
+                return {"conclusion": concl, "rule": "rdfs9:type-propagation",
+                        "premises": [prem(s, RDF.type, c), prem(c, RDFS.subClassOf, o)]}
+        # domain: s P x , P domain o  ⊢  s a o
+        for pr, x in g.predicate_objects(s):
+            if isinstance(pr, URIRef) and has(pr, RDFS.domain, o):
+                return {"conclusion": concl, "rule": "rdfs2:domain",
+                        "premises": [prem(s, pr, x), prem(pr, RDFS.domain, o)]}
+        # range: x P s , P range o  ⊢  s a o
+        for x, pr in g.subject_predicates(s):
+            if isinstance(pr, URIRef) and has(pr, RDFS.range, o):
+                return {"conclusion": concl, "rule": "rdfs3:range",
+                        "premises": [prem(x, pr, s), prem(pr, RDFS.range, o)]}
+
+    if p == RDFS.subClassOf:
+        # subclass transitivity: s ⊑ M , M ⊑ o  ⊢  s ⊑ o
+        for m in g.objects(s, RDFS.subClassOf):
+            if m not in (s, o) and has(m, RDFS.subClassOf, o):
+                return {"conclusion": concl, "rule": "rdfs11:subClassOf-transitivity",
+                        "premises": [prem(s, RDFS.subClassOf, m), prem(m, RDFS.subClassOf, o)]}
+
+    if p == RDFS.subPropertyOf:
+        for m in g.objects(s, RDFS.subPropertyOf):
+            if m not in (s, o) and has(m, RDFS.subPropertyOf, o):
+                return {"conclusion": concl, "rule": "rdfs5:subPropertyOf-transitivity",
+                        "premises": [prem(s, RDFS.subPropertyOf, m), prem(m, RDFS.subPropertyOf, o)]}
+
+    if isinstance(p, URIRef) and p not in (RDF.type, RDFS.subClassOf, RDFS.subPropertyOf):
+        # subproperty entailment: s Q o , Q ⊑ p  ⊢  s p o
+        for q in g.predicates(s, o):
+            if q != p and isinstance(q, URIRef) and has(q, RDFS.subPropertyOf, p):
+                return {"conclusion": concl, "rule": "rdfs7:subPropertyOf",
+                        "premises": [prem(s, q, o), prem(q, RDFS.subPropertyOf, p)]}
+        # symmetric / inverse (OWL): s' P o with P owl:inverseOf p, or symmetric
+        if has(p, RDF.type, OWL.SymmetricProperty) and has(o, p, s):
+            return {"conclusion": concl, "rule": "owl:SymmetricProperty",
+                    "premises": [prem(o, p, s), prem(p, RDF.type, OWL.SymmetricProperty)]}
+
+    return None
 
 
 def _c(term: Any) -> str:

--- a/apps/owl-reasoner/src/owl_reasoner/server.py
+++ b/apps/owl-reasoner/src/owl_reasoner/server.py
@@ -30,7 +30,8 @@ app = FastAPI(title="owl-reasoner", version="0.1.0")
 class ReasonRequest(BaseModel):
     turtle: str
     shapes: str | None = None
-    inference: str = "rdfs"
+    inference: str = "rdfs"        # 'rdfs' | 'owlrl'/'owl2rl' | 'both' | 'none'
+    explain: bool = False          # emit per-entailment justifications (rule + premises)
 
 
 @app.get("/healthz")
@@ -40,7 +41,7 @@ def healthz() -> dict[str, Any]:
 
 @app.post("/reason")
 def reason_endpoint(req: ReasonRequest) -> dict[str, Any]:
-    return reason(req.turtle, req.shapes, req.inference)
+    return reason(req.turtle, req.shapes, req.inference, explain=req.explain)
 
 
 @app.post("/reason/project")

--- a/apps/owl-reasoner/tests/test_reasoner.py
+++ b/apps/owl-reasoner/tests/test_reasoner.py
@@ -97,3 +97,36 @@ def test_ontology_doc_endpoint_html_and_json():
     assert "<h1>" in body and 'class="badge"' in body      # rendered doc page
     j = client.post("/ontology/doc", json={"turtle": DOC_TTL, "format": "json"})
     assert j.status_code == 200 and j.json()["counts"]["classes"] == 2
+
+
+def test_justification_traces_type_propagation():
+    # ex:acme a kko:Particulars + Particulars ⊑ Entity ⊢ ex:acme a Entity — with a WHY trace
+    out = reason(KKO_TTL, inference="rdfs", explain=True)
+    js = out["justifications"]
+    tp = next(j for j in js if "acme" in j["conclusion"] and "Entity" in j["conclusion"])
+    assert tp["rule"].startswith("rdfs9")
+    # premises ground the conclusion in stated facts
+    assert any("acme" in p and "Particulars" in p for p in tp["premises"])
+    assert any("Particulars" in p and "Entity" in p for p in tp["premises"])
+
+
+def test_owl2rl_profile_alias_and_label():
+    out = reason(KKO_TTL, inference="owl2rl")
+    assert out["inference"] == "owlrl"           # alias normalized
+    assert out["profile"] == "OWL 2 RL"          # human-readable profile label
+
+
+def test_subclass_transitivity_justification():
+    ttl = """@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex: <http://ex/> .
+ex:A rdfs:subClassOf ex:B . ex:B rdfs:subClassOf ex:C ."""
+    out = reason(ttl, inference="rdfs", explain=True)
+    j = next(j for j in out["justifications"] if j["conclusion"] == "A subClassOf C")
+    assert j["rule"].startswith("rdfs11")
+    assert set(j["premises"]) == {"A subClassOf B", "B subClassOf C"}
+
+
+def test_reason_endpoint_explain():
+    r = client.post("/reason", json={"turtle": KKO_TTL, "inference": "rdfs", "explain": True})
+    assert r.status_code == 200
+    assert isinstance(r.json()["justifications"], list) and len(r.json()["justifications"]) >= 1


### PR DESCRIPTION
## Why
KE kill-item #3. The reasoner computed the deductive closure but returned only a *sample of new triples* with no **why** — the same opacity buyers dislike in incumbent reasoners. Justifications lean directly on our provenance moat.

## What
- **`explain: true`** → a 1-step **justification** per entailment: the rule that derived it + the premises the graph holds. Covers the load-bearing RDFS/OWL-RL rules — type propagation (rdfs9), domain/range (rdfs2/3), subClassOf & subPropertyOf transitivity (rdfs11/rdfs5), subPropertyOf entailment (rdfs7), and `owl:SymmetricProperty`.
- **OWL 2 RL profile naming** — `owl2rl` / `owl2-rl` accepted (alias to owlrl) and a human-readable `profile` label ("OWL 2 RL") on every response.

## Example
`ex:acme a kko:Particulars` + `Particulars ⊑ Entity` ⊢ `acme a Entity`, with premises `[acme a Particulars, Particulars subClassOf Entity]` and rule `rdfs9:type-propagation`.

## Test
14 tests green — type-propagation + subclass-transitivity justification traces, profile alias/label, and the `explain` endpoint path.