### PR TITLE
owl-reasoner: tabular → RDF mapping (R2RML-style data-integration on-ramp)

### DIFF
--- a/apps/owl-reasoner/src/owl_reasoner/server.py
+++ b/apps/owl-reasoner/src/owl_reasoner/server.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 from .ontology_doc import extract_ontology, ontology_doc
 from .ontology_graph import tbox_graph
 from .reasoner import reason
+from .tabular_rdf import map_rows
 
 LATTICE_STUDIO_URL = os.getenv("LATTICE_STUDIO_URL", "http://lattice-studio:8080")
 TIMEOUT = float(os.getenv("OWL_TIMEOUT", "8"))
@@ -82,3 +83,22 @@ def ontology_doc_endpoint(req: OntologyDocRequest) -> Any:
     if req.format == "json":
         return extract_ontology(req.turtle)
     return Response(content=ontology_doc(req.turtle), media_type="text/html")
+
+
+class VirtualizeRequest(BaseModel):
+    rows: list[dict[str, Any]]
+    mapping: dict[str, Any]      # R2RML-style: subject_template, class?, predicates, object_iri?, prefixes?
+    format: str = "json"         # "json" → turtle+jsonld+counts; "turtle" → Turtle body
+
+
+@app.post("/virtualize")
+def virtualize_endpoint(req: VirtualizeRequest) -> Any:
+    """Tabular rows → RDF via an R2RML-style mapping — the 'turn my table into the graph' on-ramp.
+    Materializes (not live-DB OBDA), so mapped data is queryable + dereferenceable next to authored ontologies."""
+    try:
+        out = map_rows(req.rows, req.mapping)
+    except ValueError as e:
+        return Response(content=str(e), status_code=400, media_type="text/plain")
+    if req.format == "turtle":
+        return Response(content=out["turtle"], media_type="text/turtle")
+    return out

--- a/apps/owl-reasoner/src/owl_reasoner/tabular_rdf.py
+++ b/apps/owl-reasoner/src/owl_reasoner/tabular_rdf.py
@@ -1,0 +1,102 @@
+"""Tabular → RDF mapping (R2RML-style) — the data-integration on-ramp we had zero of.
+
+The recurring enterprise ask "turn my table/CSV into the graph" (Ontop/eccenca/Stardog sell it as OBDA).
+This is the mapping CORE of that: an R2RML-subset that turns rows into RDF via a declarative map —
+a subject template, an optional class, and column→predicate assignments (literal or IRI-templated object).
+It MATERIALIZES (vs OBDA's live-DB virtualization), which is the honest, dependency-light first step: no
+DB driver, pure rdflib, trivially testable. Reuses the estate's Turtle/JSON-LD serialization so mapped
+data is immediately queryable + dereferenceable alongside authored ontologies.
+
+  map = {
+    "base": "http://ex/",
+    "subject_template": "person/{id}",          # {col} substituted from each row
+    "class": "Person",                            # optional rdf:type (relative to base or absolute IRI)
+    "predicates": {"full_name": "foaf:name"},     # column → predicate (CURIE or IRI); literal object
+    "object_iri": {"employer": "org/{employer}"}, # column → IRI-templated object (a reference, not a literal)
+    "prefixes": {"foaf": "http://xmlns.com/foaf/0.1/"}
+  }
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from rdflib import RDF, Graph, Literal, Namespace, URIRef
+
+_TEMPLATE = re.compile(r"\{([^}]+)\}")
+
+
+def _fill(template: str, row: dict[str, Any]) -> str | None:
+    """Substitute {col} placeholders from the row; None if any referenced column is missing/empty."""
+    missing = False
+
+    def sub(m: re.Match[str]) -> str:
+        nonlocal missing
+        v = row.get(m.group(1))
+        if v is None or v == "":
+            missing = True
+            return ""
+        return str(v)
+
+    out = _TEMPLATE.sub(sub, template)
+    return None if missing else out
+
+
+def _resolve(term: str, base: str, prefixes: dict[str, str]) -> URIRef:
+    """A CURIE (pfx:local), an absolute IRI (has scheme), or a base-relative term → a full IRI."""
+    if term.startswith("http://") or term.startswith("https://") or term.startswith("urn:"):
+        return URIRef(term)
+    if ":" in term:
+        pfx, local = term.split(":", 1)
+        if pfx in prefixes:
+            return URIRef(prefixes[pfx] + local)
+    return URIRef(base + term)
+
+
+def map_rows(rows: list[dict[str, Any]], mapping: dict[str, Any]) -> dict[str, Any]:
+    """Apply an R2RML-style mapping to rows → an RDF graph, returned as Turtle + JSON-LD + counts."""
+    base = mapping.get("base", "http://sovereign.local/")
+    prefixes: dict[str, str] = dict(mapping.get("prefixes", {}))
+    subj_tpl = mapping.get("subject_template")
+    if not subj_tpl:
+        raise ValueError("mapping.subject_template is required")
+    cls = mapping.get("class")
+    preds: dict[str, str] = mapping.get("predicates", {})
+    obj_iri: dict[str, str] = mapping.get("object_iri", {})
+
+    g = Graph()
+    for pfx, ns in prefixes.items():
+        g.bind(pfx, Namespace(ns))
+
+    mapped = 0
+    skipped = 0
+    for row in rows:
+        subj_local = _fill(subj_tpl, row)
+        if subj_local is None:
+            skipped += 1   # row lacks the key(s) needed to mint a subject → cannot map it
+            continue
+        subj = _resolve(subj_local, base, prefixes)
+        mapped += 1
+        if cls:
+            g.add((subj, RDF.type, _resolve(cls, base, prefixes)))
+        for col, pred in preds.items():
+            val = row.get(col)
+            if val is None or val == "":
+                continue
+            g.add((subj, _resolve(pred, base, prefixes), Literal(val)))
+        for col, tpl in obj_iri.items():
+            filled = _fill(tpl, row)
+            if filled is None:
+                continue
+            # the predicate for an IRI object is the column's declared predicate, else a base-relative term
+            pred = preds.get(col, col)
+            g.add((subj, _resolve(pred, base, prefixes), _resolve(filled, base, prefixes)))
+
+    return {
+        "rows_in": len(rows),
+        "mapped": mapped,
+        "skipped": skipped,
+        "triples": len(g),
+        "turtle": g.serialize(format="turtle"),
+        "jsonld": g.serialize(format="json-ld"),
+    }

--- a/apps/owl-reasoner/tests/test_reasoner.py
+++ b/apps/owl-reasoner/tests/test_reasoner.py
@@ -130,3 +130,43 @@ def test_reason_endpoint_explain():
     r = client.post("/reason", json={"turtle": KKO_TTL, "inference": "rdfs", "explain": True})
     assert r.status_code == 200
     assert isinstance(r.json()["justifications"], list) and len(r.json()["justifications"]) >= 1
+
+
+def test_tabular_rdf_maps_rows_with_class_and_predicates():
+    from owl_reasoner.tabular_rdf import map_rows
+    rows = [
+        {"id": "1", "full_name": "Jane Doe", "employer": "acme"},
+        {"id": "2", "full_name": "John Roe", "employer": "acme"},
+        {"full_name": "No Id"},   # lacks subject key → skipped
+    ]
+    mapping = {
+        "base": "http://ex/",
+        "subject_template": "person/{id}",
+        "class": "Person",
+        "predicates": {"full_name": "foaf:name", "employer": "http://ex/employer"},
+        "object_iri": {"employer": "org/{employer}"},
+        "prefixes": {"foaf": "http://xmlns.com/foaf/0.1/"},
+    }
+    out = map_rows(rows, mapping)
+    assert out["mapped"] == 2 and out["skipped"] == 1
+    ttl = out["turtle"]
+    assert "person/1" in ttl and "Jane Doe" in ttl
+    assert "org/acme" in ttl                       # employer mapped as an IRI reference, not a literal
+    assert "foaf:name" in ttl or "name" in ttl     # CURIE-bound predicate
+
+
+def test_virtualize_endpoint_json_and_turtle():
+    body = {
+        "rows": [{"id": "1", "full_name": "Jane"}],
+        "mapping": {"base": "http://ex/", "subject_template": "p/{id}", "class": "Person",
+                    "predicates": {"full_name": "http://ex/name"}},
+    }
+    r = client.post("/virtualize", json=body)
+    assert r.status_code == 200 and r.json()["mapped"] == 1 and r.json()["triples"] >= 2
+    t = client.post("/virtualize", json={**body, "format": "turtle"})
+    assert t.status_code == 200 and "text/turtle" in t.headers["content-type"] and "Jane" in t.text
+
+
+def test_virtualize_400_without_subject_template():
+    r = client.post("/virtualize", json={"rows": [{"id": "1"}], "mapping": {"base": "http://ex/"}})
+    assert r.status_code == 400


### PR DESCRIPTION
## Why
KE kill-item #6 (the tractable core). "Turn my table/CSV into the graph" is a recurring enterprise ask (Ontop/eccenca/Stardog sell it as OBDA) and we had **zero**. This ships the mapping core, honestly scoped.

## What
`POST /virtualize { rows, mapping, format? }` maps tabular rows → RDF via an R2RML-subset declarative map:
- `subject_template` (`{col}` substitution) · optional `class` (rdf:type) · `predicates` (column→predicate, literal object) · `object_iri` (column→IRI-templated object, a reference not a literal) · `prefixes` (CURIE bindings).
- Returns Turtle + JSON-LD + counts (`mapped`/`skipped`/`triples`); `format=turtle` returns the Turtle body.
- Rows missing the subject key are **skipped and counted**, never mis-minted.

## Honest scope
This **materializes** (vs OBDA's live-DB virtualization) — the dependency-light first step: pure rdflib, no DB driver. Mapped data reuses the estate's Turtle/JSON-LD serialization, so it's immediately queryable + dereferenceable next to authored ontologies. Live-DB virtualization stays on the roadmap.

## Test
17 tests green — row mapping with class + literal + IRI-object + skip, and the `/virtualize` json/turtle/400 paths.