### PR TITLE
hellgraph-service: wire Cypher endpoint (Neo4j parity)

### DIFF
--- a/apps/hellgraph-service/src/server.test.ts
+++ b/apps/hellgraph-service/src/server.test.ts
@@ -78,6 +78,16 @@ test('Gremlin parity: g.V() returns vertices', async () => {
   assert.ok(Array.isArray(r.json.values) && typeof r.json.count === 'number')
 })
 
+test('Cypher parity: MATCH returns columns/rows + a proof-carrying queryHash', async () => {
+  const L = `cy-${process.pid}`
+  await req('POST', '/api/graph/node', { id: `${L}:1`, labels: ['Person', L], properties: { name: 'Ada' } })
+  const r = await req('POST', '/api/graph/cypher', { query: 'MATCH (n:Person) RETURN n LIMIT 5' })
+  assert.equal(r.status, 200)
+  assert.ok(Array.isArray(r.json.columns) && Array.isArray(r.json.rows))
+  assert.match(r.json.queryHash, /^sha256:/)              // replayable, proof-carrying result
+  assert.equal((await req('POST', '/api/graph/cypher', {})).status, 400)   // query required
+})
+
 test('query endpoints 400 on missing query', async () => {
   const r = await req('POST', '/api/graph/sparql', {})
   assert.equal(r.status, 400)

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -17,6 +17,7 @@
  *   POST /api/graph/reason         run PLN forward-chaining → counts
  *   POST /api/graph/sparql         { query }  → SPARQL bindings (parity: Stardog/Anzo/GraphDB)
  *   POST /api/graph/gremlin        { query }  → Gremlin results (parity: Neptune/JanusGraph)
+ *   POST /api/graph/cypher         { query, params? } → Cypher results + queryHash (parity: Neo4j)
  *   POST /api/graph/shacl          { shapes } → SHACL validation report (parity: TopBraid/Stardog)
  */
 import * as http from 'node:http'
@@ -29,7 +30,7 @@ import * as path from 'node:path'
 process.env['HELLGRAPH_STORE_DIR'] ||= path.join(os.homedir(), '.hellgraph-service')
 
 import * as engine from '@socioprophet/hellgraph'
-import { getHellGraph, getAtomSpace, attachRocksDB, forwardChain, runSparql, runGremlin, shaclValidate } from '@socioprophet/hellgraph'
+import { getHellGraph, getAtomSpace, attachRocksDB, forwardChain, runSparql, runGremlin, runCypher, shaclValidate } from '@socioprophet/hellgraph'
 import { describeResource, toTurtle, toJsonLd, toHtml, negotiate } from './resource.js'
 import { askGraph, retrieveGrounding, synthesisEnabled } from './graphrag.js'
 
@@ -160,6 +161,18 @@ const server = http.createServer((req, res) => {
         const { query } = JSON.parse(b || '{}') as { query?: string }
         if (!query) throw new Error('query required')
         json(res, 200, { ok: true, ...runGremlin(g, query) })
+      } catch (e) { json(res, 400, { error: String(e) }) }
+    })
+  }
+
+  // Cypher parity (Neo4j) — the engine ships runCypher; the result carries a queryHash + evaluatedAtSeq
+  // so a Cypher read is a replayable, proof-carrying result like every other query surface here.
+  if (req.method === 'POST' && url.pathname === '/api/graph/cypher') {
+    return void readBody(req).then((b) => {
+      try {
+        const { query, params } = JSON.parse(b || '{}') as { query?: string; params?: Record<string, string> }
+        if (!query) throw new Error('query required')
+        json(res, 200, { ok: true, ...runCypher(getAtomSpace(), query, params ?? {}) })
       } catch (e) { json(res, 400, { error: String(e) }) }
     })
   }


### PR DESCRIPTION
## The "blocker" was an illusion
"Cypher needs an engine version-reconcile + re-vendor" — we've deferred this for sessions. It was **stale local `node_modules`**. The vendored engine `vendor/socioprophet-hellgraph-0.4.4.tgz` (already pinned in `package-lock.json`) **exports `runCypher`**; my local `node_modules` was just stuck at an old 0.4.2 build. CI's `npm ci` already installs 0.4.4, so **production had `runCypher` all along** — it was simply never routed. Verified by runtime `require()` on the tarball: `runCypher: function`, 220 exports.

## What
`POST /api/graph/cypher { query, params? }` → `runCypher(getAtomSpace(), query, params)` returning `columns` / `rows` / `evaluatedAtSeq` / a **`sha256` `queryHash`** — a replayable, proof-carrying Cypher read, the same moat as the SPARQL/Gremlin/resource surfaces. Neo4j parity.

## Test
11 service tests green — Cypher `MATCH … RETURN` returns columns/rows + `queryHash`, and 400 on missing query.

## Note
This clears one of the three "engine re-vendor" items with no re-vendor. SPARQL 1.1 breadth and ANN vector remain genuine engine-source work — but the version-reconcile fear was misplaced; the 0.4.4 tarball is current and complete.