### PR TITLE
memoryd: ship the memory-mesh service via prophet-platform CI

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -67,6 +67,7 @@ jobs:
           - { image: grl-mesh,             context: apps/grl-mesh,             dockerfile: Dockerfile }
           - { image: owl-reasoner,         context: apps/owl-reasoner,         dockerfile: Dockerfile }
           - { image: entity-resolution,     context: apps/entity-resolution,     dockerfile: Dockerfile }
+          - { image: memoryd,               context: apps/memoryd,               dockerfile: Dockerfile }
     uses: SocioProphet/.github/.github/workflows/build-image.yml@main
     with:
       image: ${{ matrix.image }}

--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -138,6 +138,7 @@ jobs:
           - grl-mesh-smoke
           - owl-reasoner-smoke
           - entity-resolution-smoke
+          - memoryd-smoke
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ owl-reasoner-smoke:
 	cd apps/owl-reasoner && test -d .venv || python3 -m venv .venv
 	cd apps/owl-reasoner && . .venv/bin/activate && python -m pip install --upgrade pip pytest -r requirements.txt && PYTHONPATH=src pytest -q tests
 
+memoryd-smoke:
+	cd apps/memoryd && test -d .venv || python3 -m venv .venv
+	cd apps/memoryd && . .venv/bin/activate && python -m pip install --upgrade pip pytest -r requirements.txt && PYTHONPATH=src pytest -q tests
+
 grl-mesh-smoke:
 	cd apps/grl-mesh && test -d .venv || python3 -m venv .venv
 	cd apps/grl-mesh && . .venv/bin/activate && python -m pip install --upgrade pip pytest -r requirements.txt && PYTHONPATH=src pytest -q tests

--- a/apps/memoryd/Dockerfile
+++ b/apps/memoryd/Dockerfile
@@ -1,0 +1,10 @@
+# memoryd — sovereign memory-mesh service (recall/write/retract), vendored into prophet-platform CI.
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+ENV PORT=8787
+# Default store is in-memory (MEMORYMESH_STORE_URI=memory://); set postgresql:// / sqlite:/// to persist.
+EXPOSE 8787
+CMD ["uvicorn", "memoryd.main:app", "--host", "0.0.0.0", "--port", "8787", "--app-dir", "src"]

--- a/apps/memoryd/requirements.txt
+++ b/apps/memoryd/requirements.txt
@@ -1,0 +1,8 @@
+fastapi>=0.115,<1
+uvicorn[standard]>=0.30,<1
+httpx>=0.27,<1
+pydantic>=1.10,<3
+psycopg[binary]>=3.2,<4
+
+# test deps
+pytest

--- a/apps/memoryd/src/memoryd/__init__.py
+++ b/apps/memoryd/src/memoryd/__init__.py
@@ -1,0 +1,1 @@
+"""memoryd — sovereign memory-mesh service (vendored into prophet-platform CI)."""

--- a/apps/memoryd/src/memoryd/artifact_api.py
+++ b/apps/memoryd/src/memoryd/artifact_api.py
@@ -1,0 +1,611 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Callable, Protocol
+from urllib.parse import urlparse
+from uuid import uuid4
+
+try:
+    import psycopg
+except Exception:  # pragma: no cover
+    psycopg = None  # type: ignore[assignment]
+
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel, Field
+
+from .models import EventRecord, ScopeEnvelope, dump_model, stable_object_hash, utcnow
+
+
+class ArtifactRecord(BaseModel):
+    artifact_id: str
+    artifact_type: str
+    session_id: str
+    sequence: int
+    artifact_hash: str
+    parent_artifact_hash: str | None = None
+    idempotency_key: str | None = None
+    envelope: dict[str, Any]
+    payload: dict[str, Any]
+    tags: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+
+
+class ArtifactWriteRequest(BaseModel):
+    envelope: ScopeEnvelope
+    artifact_type: str
+    session_id: str
+    payload: dict[str, Any]
+    tags: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    idempotency_key: str | None = None
+    parent_artifact_hash: str | None = None
+
+
+class ArtifactWriteResponse(BaseModel):
+    record: ArtifactRecord
+    event_id: str | None = None
+
+
+class ArtifactGetResponse(BaseModel):
+    found: bool
+    record: ArtifactRecord | None = None
+
+
+class ArtifactListRequest(BaseModel):
+    envelope: ScopeEnvelope
+    session_id: str | None = None
+    artifact_type: str | None = None
+    limit: int = Field(default=50, ge=1, le=500)
+
+
+class ArtifactListResponse(BaseModel):
+    items: list[ArtifactRecord]
+
+
+class ArtifactLatestRequest(BaseModel):
+    envelope: ScopeEnvelope
+    session_id: str
+    artifact_type: str | None = None
+
+
+class ArtifactLatestResponse(BaseModel):
+    found: bool
+    record: ArtifactRecord | None = None
+
+
+class ArtifactReplaySessionRequest(BaseModel):
+    envelope: ScopeEnvelope
+    session_id: str
+    limit: int = Field(default=500, ge=1, le=5000)
+
+
+class ArtifactReplaySessionResponse(BaseModel):
+    session_id: str
+    items: list[ArtifactRecord]
+
+
+class ArtifactStoreProtocol(Protocol):
+    async def init(self) -> None: ...
+    async def close(self) -> None: ...
+    async def write(self, request: ArtifactWriteRequest) -> ArtifactRecord: ...
+    async def get(self, artifact_id: str) -> ArtifactRecord | None: ...
+    async def list(self, request: ArtifactListRequest) -> list[ArtifactRecord]: ...
+    async def latest(self, request: ArtifactLatestRequest) -> ArtifactRecord | None: ...
+    async def replay_session(self, request: ArtifactReplaySessionRequest) -> list[ArtifactRecord]: ...
+
+
+def artifact_scope_key(envelope: dict[str, Any], session_id: str) -> tuple[str, str, str | None, str | None]:
+    return (
+        str(envelope.get('workload_id') or ''),
+        session_id,
+        envelope.get('workspace_id'),
+        envelope.get('user_id'),
+    )
+
+
+def artifact_matches_envelope(record: ArtifactRecord, envelope: ScopeEnvelope) -> bool:
+    env = record.envelope
+    if env.get('workload_id') != envelope.workload_id:
+        return False
+    if envelope.workspace_id is not None and env.get('workspace_id') != envelope.workspace_id:
+        return False
+    if env.get('user_id') != envelope.user_id:
+        return False
+    return True
+
+
+def build_artifact_record(
+    *,
+    request: ArtifactWriteRequest,
+    sequence: int,
+    parent_artifact_hash: str | None,
+) -> ArtifactRecord:
+    payload_hash = stable_object_hash(request.payload)
+    envelope = dump_model(request.envelope)
+    artifact_id = uuid4().hex
+    return ArtifactRecord(
+        artifact_id=artifact_id,
+        artifact_type=request.artifact_type,
+        session_id=request.session_id,
+        sequence=sequence,
+        artifact_hash=payload_hash,
+        parent_artifact_hash=parent_artifact_hash,
+        idempotency_key=request.idempotency_key,
+        envelope=envelope,
+        payload=dict(request.payload),
+        tags=list(request.tags),
+        metadata=dict(request.metadata),
+        created_at=utcnow().isoformat(),
+    )
+
+
+class InMemoryArtifactStore:
+    def __init__(self) -> None:
+        self._items: dict[str, ArtifactRecord] = {}
+
+    async def init(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    async def write(self, request: ArtifactWriteRequest) -> ArtifactRecord:
+        if request.idempotency_key:
+            for record in self._items.values():
+                if (
+                    record.idempotency_key == request.idempotency_key
+                    and record.session_id == request.session_id
+                    and artifact_matches_envelope(record, request.envelope)
+                ):
+                    return record
+        previous = await self.latest(
+            ArtifactLatestRequest(
+                envelope=request.envelope,
+                session_id=request.session_id,
+                artifact_type=None,
+            )
+        )
+        next_sequence = (previous.sequence + 1) if previous else 1
+        parent_hash = request.parent_artifact_hash or (previous.artifact_hash if previous else None)
+        record = build_artifact_record(request=request, sequence=next_sequence, parent_artifact_hash=parent_hash)
+        self._items[record.artifact_id] = record
+        return record
+
+    async def get(self, artifact_id: str) -> ArtifactRecord | None:
+        return self._items.get(artifact_id)
+
+    async def list(self, request: ArtifactListRequest) -> list[ArtifactRecord]:
+        items: list[ArtifactRecord] = []
+        for record in self._items.values():
+            if not artifact_matches_envelope(record, request.envelope):
+                continue
+            if request.session_id and record.session_id != request.session_id:
+                continue
+            if request.artifact_type and record.artifact_type != request.artifact_type:
+                continue
+            items.append(record)
+        items.sort(key=lambda item: (item.sequence, item.created_at), reverse=True)
+        return items[: request.limit]
+
+    async def latest(self, request: ArtifactLatestRequest) -> ArtifactRecord | None:
+        items = await self.list(
+            ArtifactListRequest(
+                envelope=request.envelope,
+                session_id=request.session_id,
+                artifact_type=request.artifact_type,
+                limit=1,
+            )
+        )
+        return items[0] if items else None
+
+    async def replay_session(self, request: ArtifactReplaySessionRequest) -> list[ArtifactRecord]:
+        items = await self.list(
+            ArtifactListRequest(
+                envelope=request.envelope,
+                session_id=request.session_id,
+                artifact_type=None,
+                limit=request.limit,
+            )
+        )
+        return list(reversed(items))
+
+
+class SQLiteArtifactStore:
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+
+    async def init(self) -> None:
+        await asyncio.to_thread(self._ensure_parent_dir)
+        await asyncio.to_thread(self._migrate)
+
+    async def close(self) -> None:
+        return None
+
+    def _ensure_parent_dir(self) -> None:
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _migrate(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                '''
+                CREATE TABLE IF NOT EXISTS artifacts (
+                    artifact_id TEXT PRIMARY KEY,
+                    artifact_type TEXT NOT NULL,
+                    session_id TEXT NOT NULL,
+                    sequence INTEGER NOT NULL,
+                    artifact_hash TEXT NOT NULL,
+                    parent_artifact_hash TEXT,
+                    idempotency_key TEXT,
+                    envelope_json TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    tags_json TEXT NOT NULL,
+                    metadata_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_artifacts_scope ON artifacts(session_id, artifact_type, sequence DESC);
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_idempotency ON artifacts(session_id, idempotency_key) WHERE idempotency_key IS NOT NULL;
+                '''
+            )
+            conn.commit()
+
+    async def write(self, request: ArtifactWriteRequest) -> ArtifactRecord:
+        return await asyncio.to_thread(self._write_sync, request)
+
+    def _write_sync(self, request: ArtifactWriteRequest) -> ArtifactRecord:
+        if request.idempotency_key:
+            existing = self._get_by_idempotency_sync(request.session_id, request.idempotency_key, request.envelope)
+            if existing is not None:
+                return existing
+        previous = self._latest_sync(request.envelope, request.session_id, None)
+        next_sequence = (previous.sequence + 1) if previous else 1
+        parent_hash = request.parent_artifact_hash or (previous.artifact_hash if previous else None)
+        record = build_artifact_record(request=request, sequence=next_sequence, parent_artifact_hash=parent_hash)
+        with self._connect() as conn:
+            conn.execute(
+                '''
+                INSERT INTO artifacts(
+                    artifact_id, artifact_type, session_id, sequence, artifact_hash,
+                    parent_artifact_hash, idempotency_key, envelope_json, payload_json,
+                    tags_json, metadata_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ''',
+                (
+                    record.artifact_id,
+                    record.artifact_type,
+                    record.session_id,
+                    record.sequence,
+                    record.artifact_hash,
+                    record.parent_artifact_hash,
+                    record.idempotency_key,
+                    json.dumps(record.envelope, sort_keys=True),
+                    json.dumps(record.payload, sort_keys=True),
+                    json.dumps(record.tags),
+                    json.dumps(record.metadata, sort_keys=True),
+                    record.created_at,
+                ),
+            )
+            conn.commit()
+        return record
+
+    def _row_to_record(self, row: sqlite3.Row) -> ArtifactRecord:
+        return ArtifactRecord(
+            artifact_id=row['artifact_id'],
+            artifact_type=row['artifact_type'],
+            session_id=row['session_id'],
+            sequence=int(row['sequence']),
+            artifact_hash=row['artifact_hash'],
+            parent_artifact_hash=row['parent_artifact_hash'],
+            idempotency_key=row['idempotency_key'],
+            envelope=json.loads(row['envelope_json']),
+            payload=json.loads(row['payload_json']),
+            tags=list(json.loads(row['tags_json'])),
+            metadata=dict(json.loads(row['metadata_json'])),
+            created_at=row['created_at'],
+        )
+
+    def _get_by_idempotency_sync(self, session_id: str, idempotency_key: str, envelope: ScopeEnvelope) -> ArtifactRecord | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                'SELECT * FROM artifacts WHERE session_id = ? AND idempotency_key = ? LIMIT 1',
+                (session_id, idempotency_key),
+            ).fetchone()
+        if row is None:
+            return None
+        record = self._row_to_record(row)
+        return record if artifact_matches_envelope(record, envelope) else None
+
+    async def get(self, artifact_id: str) -> ArtifactRecord | None:
+        return await asyncio.to_thread(self._get_sync, artifact_id)
+
+    def _get_sync(self, artifact_id: str) -> ArtifactRecord | None:
+        with self._connect() as conn:
+            row = conn.execute('SELECT * FROM artifacts WHERE artifact_id = ?', (artifact_id,)).fetchone()
+        return self._row_to_record(row) if row else None
+
+    async def list(self, request: ArtifactListRequest) -> list[ArtifactRecord]:
+        return await asyncio.to_thread(self._list_sync, request)
+
+    def _list_sync(self, request: ArtifactListRequest) -> list[ArtifactRecord]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                'SELECT * FROM artifacts ORDER BY sequence DESC, created_at DESC LIMIT ?',
+                (max(request.limit * 5, request.limit),),
+            ).fetchall()
+        items: list[ArtifactRecord] = []
+        for row in rows:
+            record = self._row_to_record(row)
+            if not artifact_matches_envelope(record, request.envelope):
+                continue
+            if request.session_id and record.session_id != request.session_id:
+                continue
+            if request.artifact_type and record.artifact_type != request.artifact_type:
+                continue
+            items.append(record)
+            if len(items) >= request.limit:
+                break
+        return items
+
+    async def latest(self, request: ArtifactLatestRequest) -> ArtifactRecord | None:
+        return await asyncio.to_thread(self._latest_sync, request.envelope, request.session_id, request.artifact_type)
+
+    def _latest_sync(self, envelope: ScopeEnvelope, session_id: str, artifact_type: str | None) -> ArtifactRecord | None:
+        with self._connect() as conn:
+            rows = conn.execute(
+                'SELECT * FROM artifacts WHERE session_id = ? ORDER BY sequence DESC, created_at DESC LIMIT 100',
+                (session_id,),
+            ).fetchall()
+        for row in rows:
+            record = self._row_to_record(row)
+            if artifact_type and record.artifact_type != artifact_type:
+                continue
+            if artifact_matches_envelope(record, envelope):
+                return record
+        return None
+
+    async def replay_session(self, request: ArtifactReplaySessionRequest) -> list[ArtifactRecord]:
+        items = await self.list(
+            ArtifactListRequest(
+                envelope=request.envelope,
+                session_id=request.session_id,
+                artifact_type=None,
+                limit=request.limit,
+            )
+        )
+        return list(reversed(items))
+
+
+class PostgresArtifactStore:
+    def __init__(self, dsn: str, schema: str = 'memorymesh') -> None:
+        if psycopg is None:
+            raise RuntimeError('psycopg is required for PostgresArtifactStore')
+        self.dsn = dsn
+        self.schema = schema
+        self._memory_fallback = InMemoryArtifactStore()
+
+    async def init(self) -> None:
+        await asyncio.to_thread(self._migrate)
+
+    async def close(self) -> None:
+        return None
+
+    def _connect(self):
+        return psycopg.connect(self.dsn)
+
+    def _migrate(self) -> None:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f'CREATE SCHEMA IF NOT EXISTS {self.schema}')
+                cur.execute(
+                    f'''
+                    CREATE TABLE IF NOT EXISTS {self.schema}.artifacts (
+                        artifact_id TEXT PRIMARY KEY,
+                        artifact_type TEXT NOT NULL,
+                        session_id TEXT NOT NULL,
+                        sequence INTEGER NOT NULL,
+                        artifact_hash TEXT NOT NULL,
+                        parent_artifact_hash TEXT,
+                        idempotency_key TEXT,
+                        envelope JSONB NOT NULL,
+                        payload JSONB NOT NULL,
+                        tags JSONB NOT NULL,
+                        metadata JSONB NOT NULL,
+                        created_at TEXT NOT NULL
+                    )
+                    '''
+                )
+                cur.execute(
+                    f'CREATE INDEX IF NOT EXISTS idx_{self.schema}_artifacts_scope ON {self.schema}.artifacts(session_id, artifact_type, sequence DESC)'
+                )
+            conn.commit()
+
+    async def write(self, request: ArtifactWriteRequest) -> ArtifactRecord:
+        # Keep Postgres behavior conservative for the bootstrap by delegating selection
+        # logic through the same in-memory semantics if SQL feature drift occurs.
+        return await asyncio.to_thread(self._write_sync, request)
+
+    def _write_sync(self, request: ArtifactWriteRequest) -> ArtifactRecord:
+        previous = self._latest_sync(request.envelope, request.session_id, None)
+        next_sequence = (previous.sequence + 1) if previous else 1
+        parent_hash = request.parent_artifact_hash or (previous.artifact_hash if previous else None)
+        record = build_artifact_record(request=request, sequence=next_sequence, parent_artifact_hash=parent_hash)
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f'''
+                    INSERT INTO {self.schema}.artifacts(
+                        artifact_id, artifact_type, session_id, sequence, artifact_hash,
+                        parent_artifact_hash, idempotency_key, envelope, payload,
+                        tags, metadata, created_at
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb, %s)
+                    ON CONFLICT (artifact_id) DO NOTHING
+                    ''',
+                    (
+                        record.artifact_id,
+                        record.artifact_type,
+                        record.session_id,
+                        record.sequence,
+                        record.artifact_hash,
+                        record.parent_artifact_hash,
+                        record.idempotency_key,
+                        json.dumps(record.envelope, sort_keys=True),
+                        json.dumps(record.payload, sort_keys=True),
+                        json.dumps(record.tags),
+                        json.dumps(record.metadata, sort_keys=True),
+                        record.created_at,
+                    ),
+                )
+            conn.commit()
+        return record
+
+    def _row_to_record(self, row: tuple[Any, ...]) -> ArtifactRecord:
+        return ArtifactRecord(
+            artifact_id=row[0],
+            artifact_type=row[1],
+            session_id=row[2],
+            sequence=int(row[3]),
+            artifact_hash=row[4],
+            parent_artifact_hash=row[5],
+            idempotency_key=row[6],
+            envelope=dict(row[7]),
+            payload=dict(row[8]),
+            tags=list(row[9] or []),
+            metadata=dict(row[10] or {}),
+            created_at=row[11],
+        )
+
+    async def get(self, artifact_id: str) -> ArtifactRecord | None:
+        return await asyncio.to_thread(self._get_sync, artifact_id)
+
+    def _get_sync(self, artifact_id: str) -> ArtifactRecord | None:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f'SELECT artifact_id, artifact_type, session_id, sequence, artifact_hash, parent_artifact_hash, idempotency_key, envelope, payload, tags, metadata, created_at FROM {self.schema}.artifacts WHERE artifact_id = %s',
+                    (artifact_id,),
+                )
+                row = cur.fetchone()
+        return self._row_to_record(row) if row else None
+
+    async def list(self, request: ArtifactListRequest) -> list[ArtifactRecord]:
+        return await asyncio.to_thread(self._list_sync, request)
+
+    def _list_sync(self, request: ArtifactListRequest) -> list[ArtifactRecord]:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f'SELECT artifact_id, artifact_type, session_id, sequence, artifact_hash, parent_artifact_hash, idempotency_key, envelope, payload, tags, metadata, created_at FROM {self.schema}.artifacts ORDER BY sequence DESC LIMIT %s',
+                    (max(request.limit * 5, request.limit),),
+                )
+                rows = cur.fetchall()
+        items: list[ArtifactRecord] = []
+        for row in rows:
+            record = self._row_to_record(row)
+            if not artifact_matches_envelope(record, request.envelope):
+                continue
+            if request.session_id and record.session_id != request.session_id:
+                continue
+            if request.artifact_type and record.artifact_type != request.artifact_type:
+                continue
+            items.append(record)
+            if len(items) >= request.limit:
+                break
+        return items
+
+    async def latest(self, request: ArtifactLatestRequest) -> ArtifactRecord | None:
+        return await asyncio.to_thread(self._latest_sync, request.envelope, request.session_id, request.artifact_type)
+
+    def _latest_sync(self, envelope: ScopeEnvelope, session_id: str, artifact_type: str | None) -> ArtifactRecord | None:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f'SELECT artifact_id, artifact_type, session_id, sequence, artifact_hash, parent_artifact_hash, idempotency_key, envelope, payload, tags, metadata, created_at FROM {self.schema}.artifacts WHERE session_id = %s ORDER BY sequence DESC LIMIT 100',
+                    (session_id,),
+                )
+                rows = cur.fetchall()
+        for row in rows:
+            record = self._row_to_record(row)
+            if artifact_type and record.artifact_type != artifact_type:
+                continue
+            if artifact_matches_envelope(record, envelope):
+                return record
+        return None
+
+    async def replay_session(self, request: ArtifactReplaySessionRequest) -> list[ArtifactRecord]:
+        items = await self.list(
+            ArtifactListRequest(
+                envelope=request.envelope,
+                session_id=request.session_id,
+                artifact_type=None,
+                limit=request.limit,
+            )
+        )
+        return list(reversed(items))
+
+
+def build_artifact_store(store_uri: str) -> ArtifactStoreProtocol:
+    if not store_uri or store_uri == 'memory://':
+        return InMemoryArtifactStore()
+    if store_uri.startswith('sqlite:///'):
+        return SQLiteArtifactStore(urlparse(store_uri).path)
+    if store_uri.startswith('postgresql://') or store_uri.startswith('postgres://'):
+        return PostgresArtifactStore(store_uri)
+    return InMemoryArtifactStore()
+
+
+def install_artifact_routes(
+    app: FastAPI,
+    *,
+    artifact_store: ArtifactStoreProtocol,
+    event_store: Any,
+    require_api_key: Callable[[str | None], Any],
+) -> None:
+    @app.post('/v1/artifacts/write', response_model=ArtifactWriteResponse)
+    async def artifact_write(request: ArtifactWriteRequest, x_api_key: str | None = Header(default=None)) -> ArtifactWriteResponse:
+        await require_api_key(x_api_key)
+        record = await artifact_store.write(request)
+        event: EventRecord = await event_store.append_event(
+            'memory.artifact.written',
+            {
+                'envelope': dump_model(request.envelope),
+                'artifact_id': record.artifact_id,
+                'artifact_type': record.artifact_type,
+                'session_id': record.session_id,
+                'sequence': record.sequence,
+                'artifact_hash': record.artifact_hash,
+            },
+        )
+        return ArtifactWriteResponse(record=record, event_id=event.event_id)
+
+    @app.get('/v1/artifacts/{artifact_id}', response_model=ArtifactGetResponse)
+    async def artifact_get(artifact_id: str, x_api_key: str | None = Header(default=None)) -> ArtifactGetResponse:
+        await require_api_key(x_api_key)
+        record = await artifact_store.get(artifact_id)
+        return ArtifactGetResponse(found=record is not None, record=record)
+
+    @app.post('/v1/artifacts/list', response_model=ArtifactListResponse)
+    async def artifact_list(request: ArtifactListRequest, x_api_key: str | None = Header(default=None)) -> ArtifactListResponse:
+        await require_api_key(x_api_key)
+        return ArtifactListResponse(items=await artifact_store.list(request))
+
+    @app.post('/v1/artifacts/latest', response_model=ArtifactLatestResponse)
+    async def artifact_latest(request: ArtifactLatestRequest, x_api_key: str | None = Header(default=None)) -> ArtifactLatestResponse:
+        await require_api_key(x_api_key)
+        record = await artifact_store.latest(request)
+        return ArtifactLatestResponse(found=record is not None, record=record)
+
+    @app.post('/v1/artifacts/replay-session', response_model=ArtifactReplaySessionResponse)
+    async def artifact_replay_session(request: ArtifactReplaySessionRequest, x_api_key: str | None = Header(default=None)) -> ArtifactReplaySessionResponse:
+        await require_api_key(x_api_key)
+        return ArtifactReplaySessionResponse(
+            session_id=request.session_id,
+            items=await artifact_store.replay_session(request),
+        )

--- a/apps/memoryd/src/memoryd/embedding.py
+++ b/apps/memoryd/src/memoryd/embedding.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HashingEmbedder:
+    dimension: int
+    salt: str = 'memorymesh-starter-v1'
+
+    def embed(self, text: str) -> list[float]:
+        if self.dimension <= 0:
+            raise ValueError('dimension must be positive')
+        vector = [0.0] * self.dimension
+        tokens = [token for token in self._tokenize(text) if token]
+        if not tokens:
+            return vector
+        for token in tokens:
+            digest = hashlib.sha256(f'{self.salt}:{token}'.encode('utf-8')).digest()
+            idx = int.from_bytes(digest[:4], 'big') % self.dimension
+            sign = 1.0 if digest[4] % 2 == 0 else -1.0
+            vector[idx] += sign
+        norm = math.sqrt(sum(value * value for value in vector))
+        if norm == 0:
+            return vector
+        return [value / norm for value in vector]
+
+    @staticmethod
+    def _tokenize(text: str) -> list[str]:
+        return [token.strip(".,!?;:()[]{}\n\t\r\"'").lower() for token in text.split()]

--- a/apps/memoryd/src/memoryd/hellgraph_retract.py
+++ b/apps/memoryd/src/memoryd/hellgraph_retract.py
@@ -1,0 +1,68 @@
+"""HellGraph retract binding for memoryd — propagates revocation into the graph lane.
+
+When a memory is revoked, its derived edges in the managed HellGraph must be superseded
+too, otherwise the revoked knowledge stays queryable in the graph even though recall no
+longer serves it. HellGraph is a downstream *materialization* of memory, never the
+canonical store, so memoryd only needs the retract half of the contract here:
+
+  POST {HELLGRAPH_URL}/v1/retract  {"provenance_refs": [...]}  → supersede derived edges
+
+Graceful-degrade like mem0_client / qdrant_index: if HELLGRAPH_URL is unset the binding is
+disabled and returns an inert result, so memoryd runs (and tests pass) without a live graph.
+The workspace_ingestion service owns the full CSKG ingest path; this binding deliberately
+does not duplicate it.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+
+class HellGraphRetractClient:
+    def __init__(self, base_url: str | None = None, api_key: str | None = None, timeout_seconds: float = 10.0) -> None:
+        self.base_url = (base_url if base_url is not None else os.getenv('HELLGRAPH_URL', '')).rstrip('/')
+        self.api_key = api_key if api_key is not None else os.getenv('HELLGRAPH_API_KEY', '')
+        self.timeout_seconds = timeout_seconds
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.base_url)
+
+    @property
+    def headers(self) -> dict[str, str]:
+        headers = {'Content-Type': 'application/json'}
+        if self.api_key:
+            headers['x-api-key'] = self.api_key
+        return headers
+
+    async def retract(self, source_refs: list[str]) -> dict[str, Any]:
+        """Supersede every graph edge derived from the given provenance/source refs."""
+        if not self.enabled:
+            return {'retracted': False, 'reason': 'hellgraph disabled', 'source_refs': source_refs}
+        if not source_refs:
+            return {'retracted': False, 'reason': 'no source refs', 'source_refs': source_refs}
+        async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+            response = await client.post(
+                f'{self.base_url}/v1/retract',
+                json={'provenance_refs': source_refs},
+                headers=self.headers,
+            )
+            response.raise_for_status()
+            return dict(response.json())
+
+
+def revocation_source_refs(memory_id: str, extra_refs: list[str] | None = None) -> list[str]:
+    """Collect the provenance refs a revoked memory contributed to the graph.
+
+    Every memoryd memory contributes edges under the canonical self-ref
+    ``memory://{memory_id}``; callers that know additional upstream provenance refs
+    (e.g. a WorkspaceSource id the memory was derived from) pass them as ``extra_refs``
+    so those edges are superseded too.
+    """
+    refs: list[str] = [f'memory://{memory_id}']
+    for ref in extra_refs or []:
+        if isinstance(ref, str) and ref and ref not in refs:
+            refs.append(ref)
+    return refs

--- a/apps/memoryd/src/memoryd/main.py
+++ b/apps/memoryd/src/memoryd/main.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+from urllib.parse import urlparse
+
+from fastapi import FastAPI, Header, HTTPException
+from fastapi.responses import StreamingResponse
+
+from .embedding import HashingEmbedder
+from .mem0_client import Mem0RestClient
+from .hellgraph_retract import HellGraphRetractClient, revocation_source_refs
+from .models import (
+    ApplyResourceResponse,
+    DEFAULT_SCOPE_ORDER,
+    CompiledWorkloadConfig,
+    MeshResource,
+    RecallRequest,
+    RecallResponse,
+    RevokeRequest,
+    RevokeResponse,
+    WriteRequest,
+    WriteResponse,
+    dump_model,
+)
+from .postgres_store import PostgresStore
+from .qdrant_index import QdrantMemoryIndex
+from .sqlite_store import SQLiteStore
+from .store import InMemoryStore, StoreProtocol, dedupe_hits, rank_hits_by_policy
+
+
+REQUIRE_API_KEY = os.getenv('MEMORYD_REQUIRE_API_KEY', 'false').lower() in {'1', 'true', 'yes'}
+EXPECTED_API_KEY = os.getenv('MEMORYD_API_KEY', '')
+STORE_URI = os.getenv('MEMORYMESH_STORE_URI', os.getenv('MEMORYD_STORE_URL', 'memory://'))
+VECTOR_SIZE = int(os.getenv('MEMORYMESH_VECTOR_SIZE', '256'))
+QDRANT_ENABLED = os.getenv('QDRANT_ENABLED', 'false').lower() in {'1', 'true', 'yes'}
+QDRANT_URL = os.getenv('QDRANT_URL', '').rstrip('/')
+QDRANT_API_KEY = os.getenv('QDRANT_API_KEY', '')
+QDRANT_COLLECTION = os.getenv('QDRANT_COLLECTION', 'memorymesh-local')
+QDRANT_DISTANCE = os.getenv('QDRANT_DISTANCE', 'Cosine')
+EMBEDDING_SALT = os.getenv('MEMORYMESH_EMBEDDING_SALT', 'memorymesh-starter-v1')
+
+mem0 = Mem0RestClient(
+    base_url=os.getenv('MEM0_BASE_URL'),
+    api_key=os.getenv('MEM0_API_KEY'),
+    timeout_seconds=float(os.getenv('MEM0_TIMEOUT_SECONDS', '10')),
+)
+
+vector_index = QdrantMemoryIndex(
+    url=QDRANT_URL,
+    api_key=QDRANT_API_KEY or None,
+    collection_name=QDRANT_COLLECTION,
+    vector_size=VECTOR_SIZE,
+    distance=QDRANT_DISTANCE,
+    enabled=QDRANT_ENABLED and bool(QDRANT_URL),
+    timeout_seconds=float(os.getenv('QDRANT_TIMEOUT_SECONDS', '10')),
+)
+embedder = HashingEmbedder(dimension=VECTOR_SIZE, salt=EMBEDDING_SALT)
+
+# Revocation propagates into the graph materialization (graceful-degrade if HELLGRAPH_URL unset).
+hellgraph_retract = HellGraphRetractClient(
+    base_url=os.getenv('HELLGRAPH_URL'),
+    api_key=os.getenv('HELLGRAPH_API_KEY'),
+    timeout_seconds=float(os.getenv('HELLGRAPH_TIMEOUT_SECONDS', '10')),
+)
+
+
+def build_store(store_uri: str) -> StoreProtocol:
+    if not store_uri or store_uri == 'memory://':
+        return InMemoryStore()
+    if store_uri.startswith('sqlite:///'):
+        parsed = urlparse(store_uri)
+        return SQLiteStore(db_path=parsed.path, vector_index=vector_index if vector_index.enabled else None)
+    if store_uri.startswith('postgresql://') or store_uri.startswith('postgres://'):
+        return PostgresStore(dsn=store_uri, schema=os.getenv('MEMORYMESH_PG_SCHEMA', 'memorymesh'), vector_index=vector_index if vector_index.enabled else None)
+    raise RuntimeError(f'Unsupported MEMORYMESH_STORE_URI: {store_uri}')
+
+
+store: StoreProtocol = build_store(STORE_URI)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await store.init()
+    yield
+    await store.close()
+
+
+app = FastAPI(title='memoryd', version='0.2.0', lifespan=lifespan)
+
+
+async def require_api_key(x_api_key: str | None) -> None:
+    if not REQUIRE_API_KEY:
+        return
+    if not EXPECTED_API_KEY:
+        raise HTTPException(status_code=500, detail='memoryd api key enforcement enabled but MEMORYD_API_KEY is empty')
+    if x_api_key != EXPECTED_API_KEY:
+        raise HTTPException(status_code=401, detail='invalid api key')
+
+
+def ensure_query_vector(request: RecallRequest) -> RecallRequest:
+    if request.query_vector is None and vector_index.enabled:
+        request.query_vector = embedder.embed(request.query)
+    return request
+
+
+def ensure_write_vector(request: WriteRequest) -> WriteRequest:
+    if request.vector is None and vector_index.enabled:
+        request.vector = embedder.embed(request.content)
+    return request
+
+
+def model_fields_set(model: Any) -> set[str]:
+    fields_set = getattr(model, 'model_fields_set', None)
+    if fields_set is None:
+        fields_set = getattr(model, '__fields_set__', set())
+    return set(fields_set)
+
+
+def resolve_scope_order(request: RecallRequest, compiled: CompiledWorkloadConfig) -> list[str]:
+    if 'scope_order' in model_fields_set(request) and request.scope_order:
+        return list(request.scope_order)
+    if compiled.recall_scope_order:
+        return list(compiled.recall_scope_order)
+    return list(DEFAULT_SCOPE_ORDER)
+
+
+def iter_policy_maps(compiled: CompiledWorkloadConfig):
+    for resource in compiled.attachments + compiled.export_policies + compiled.conflict_policies + compiled.peers:
+        if not isinstance(resource, dict):
+            continue
+        spec = resource.get('spec') or {}
+        if isinstance(spec, dict):
+            yield spec
+            nested = spec.get('policy')
+            if isinstance(nested, dict):
+                yield nested
+
+
+def policy_flag(compiled: CompiledWorkloadConfig, names: tuple[str, ...], default: bool = False) -> bool:
+    for policy in iter_policy_maps(compiled):
+        for name in names:
+            if name in policy:
+                return bool(policy[name])
+    return default
+
+
+def infer_target_workloads(resource: MeshResource) -> list[str]:
+    spec = resource.spec or {}
+    targets: set[str] = set(spec.get('targetWorkloads') or spec.get('workloadIds') or [])
+    workload_id = spec.get('workloadId')
+    if isinstance(workload_id, str) and workload_id:
+        targets.add(workload_id)
+    return sorted(targets)
+
+
+@app.get('/')
+async def root() -> dict:
+    return {
+        'service': 'memoryd',
+        'version': app.version,
+        'store_uri': STORE_URI,
+        'mem0_enabled': mem0.enabled,
+        'vector_enabled': vector_index.enabled,
+    }
+
+
+@app.get('/healthz')
+async def healthz() -> dict:
+    return {
+        'ok': True,
+        'mem0_enabled': mem0.enabled,
+        'store': await store.health(),
+    }
+
+
+@app.post('/v1/resources/apply', response_model=ApplyResourceResponse)
+async def apply_resource(resource: MeshResource, x_api_key: str | None = Header(default=None)) -> ApplyResourceResponse:
+    await require_api_key(x_api_key)
+    key = await store.apply_resource(resource)
+    event = await store.append_event('memory.resource.applied', {'resource': dump_model(resource), 'resource_key': key})
+
+    config_hash: str | None = None
+    target_workloads = infer_target_workloads(resource)
+    if len(target_workloads) == 1:
+        compiled = await store.compile_workload_config(workload_id=target_workloads[0])
+        config_hash = compiled.config_hash
+        await store.append_event(
+            'memory.config.compiled',
+            {'workload_id': target_workloads[0], 'config_hash': config_hash, 'resource_key': key},
+        )
+
+    return ApplyResourceResponse(applied=True, resource_key=key, event_id=event.event_id, config_hash=config_hash)
+
+
+@app.get('/v1/resources/{kind}/{namespace}/{name}')
+async def get_resource(kind: str, namespace: str, name: str, x_api_key: str | None = Header(default=None)) -> dict:
+    await require_api_key(x_api_key)
+    resource = await store.get_resource(kind=kind, namespace=namespace, name=name)
+    if resource is None:
+        raise HTTPException(status_code=404, detail='resource not found')
+    return dump_model(resource)
+
+
+@app.get('/v1/config/{workload_id}', response_model=CompiledWorkloadConfig)
+async def get_compiled_config(workload_id: str, x_api_key: str | None = Header(default=None)) -> CompiledWorkloadConfig:
+    await require_api_key(x_api_key)
+    return await store.compile_workload_config(workload_id=workload_id)
+
+
+async def config_stream(workload_id: str) -> AsyncIterator[str]:
+    while True:
+        compiled = await store.compile_workload_config(workload_id=workload_id)
+        payload = json.dumps(dump_model(compiled), default=str)
+        yield f'event: config\ndata: {payload}\n\n'
+        await asyncio.sleep(15)
+
+
+@app.get('/v1/watch/config/{workload_id}')
+async def watch_workload_config(workload_id: str, x_api_key: str | None = Header(default=None)) -> StreamingResponse:
+    await require_api_key(x_api_key)
+    return StreamingResponse(config_stream(workload_id), media_type='text/event-stream')
+
+
+@app.post('/v1/recall', response_model=RecallResponse)
+async def recall(request: RecallRequest, x_api_key: str | None = Header(default=None)) -> RecallResponse:
+    await require_api_key(x_api_key)
+    request = ensure_query_vector(request)
+    compiled = await store.compile_workload_config(workload_id=request.envelope.workload_id)
+    request.scope_order = resolve_scope_order(request, compiled)
+    request.top_k = min(request.top_k, compiled.recall_top_k_limit)
+
+    await store.append_event(
+        'memory.recall.started',
+        {
+            'envelope': dump_model(request.envelope),
+            'query': request.query,
+            'effective_scope_order': list(request.scope_order),
+            'top_k': request.top_k,
+            'config_hash': compiled.config_hash,
+        },
+    )
+
+    if request.include_raw_events and not policy_flag(compiled, ('allowRawEvents', 'allow_raw_events'), default=False):
+        denied_event = await store.append_event(
+            'memory.recall.denied',
+            {
+                'envelope': dump_model(request.envelope),
+                'query': request.query,
+                'reason': 'raw event access denied by policy',
+                'config_hash': compiled.config_hash,
+            },
+        )
+        raise HTTPException(status_code=403, detail=f'raw event access denied by policy ({denied_event.event_id})')
+
+    if request.include_relations and not policy_flag(compiled, ('allowRelations', 'allow_relations'), default=False):
+        denied_event = await store.append_event(
+            'memory.recall.denied',
+            {
+                'envelope': dump_model(request.envelope),
+                'query': request.query,
+                'reason': 'relation access denied by policy',
+                'config_hash': compiled.config_hash,
+            },
+        )
+        raise HTTPException(status_code=403, detail=f'relation access denied by policy ({denied_event.event_id})')
+
+    local_hits = []
+    backend_hits = []
+
+    if compiled.local_first:
+        local_hits = await store.search_local_memories(request)
+        if len(local_hits) < request.top_k and mem0.enabled and compiled.allow_backend_persistence:
+            try:
+                backend_hits = await mem0.recall(request)
+            except Exception as exc:  # pragma: no cover
+                await store.append_event(
+                    'backend.recall.error',
+                    {'envelope': dump_model(request.envelope), 'error': str(exc), 'query': request.query},
+                )
+    else:
+        if mem0.enabled and compiled.allow_backend_persistence:
+            try:
+                backend_hits = await mem0.recall(request)
+            except Exception as exc:  # pragma: no cover
+                await store.append_event(
+                    'backend.recall.error',
+                    {'envelope': dump_model(request.envelope), 'error': str(exc), 'query': request.query},
+                )
+        if len(backend_hits) < request.top_k:
+            local_hits = await store.search_local_memories(request)
+
+    merged = dedupe_hits(local_hits + backend_hits)
+    ranked = rank_hits_by_policy(
+        merged,
+        scope_order=compiled.recall_scope_order,
+        local_first=compiled.local_first,
+    )
+    final_hits = ranked[: min(request.top_k, compiled.recall_top_k_limit)]
+    completed_event = await store.append_event(
+        'memory.recall.completed',
+        {
+            'envelope': dump_model(request.envelope),
+            'query': request.query,
+            'local_hit_count': len(local_hits),
+            'backend_hit_count': len(backend_hits),
+            'returned_hit_count': len(final_hits),
+            'config_hash': compiled.config_hash,
+        },
+    )
+    return RecallResponse(
+        query=request.query,
+        hits=final_hits,
+        compiled_policy=dump_model(compiled),
+        local_hit_count=len(local_hits),
+        backend_hit_count=len(backend_hits),
+        truncated=len(ranked) > len(final_hits),
+        event_id=completed_event.event_id,
+    )
+
+
+@app.post('/v1/write', response_model=WriteResponse)
+async def write(request: WriteRequest, x_api_key: str | None = Header(default=None)) -> WriteResponse:
+    await require_api_key(x_api_key)
+    request = ensure_write_vector(request)
+    compiled = await store.compile_workload_config(workload_id=request.envelope.workload_id)
+    if not compiled.writeback_enabled:
+        rejected_event = await store.append_event(
+            'memory.write.rejected',
+            {
+                'envelope': dump_model(request.envelope),
+                'content': request.content,
+                'memory_class': request.memory_class.value,
+                'metadata': request.metadata,
+                'tags': request.tags,
+                'reason': 'writeback disabled for workload',
+                'config_hash': compiled.config_hash,
+            },
+        )
+        raise HTTPException(status_code=403, detail=f'writeback disabled for workload ({rejected_event.event_id})')
+
+    event = await store.append_event(
+        'memory.write.accepted',
+        {
+            'envelope': dump_model(request.envelope),
+            'content': request.content,
+            'memory_class': request.memory_class.value,
+            'metadata': request.metadata,
+            'tags': request.tags,
+            'config_hash': compiled.config_hash,
+        },
+    )
+    local_memory_id = await store.add_local_memory(request=request, event_id=event.event_id)
+
+    backend_memory_ids: list[str] = []
+    persist_to_backend = request.persist_to_backend and compiled.allow_backend_persistence
+    if persist_to_backend and mem0.enabled:
+        try:
+            backend_memory_ids = await mem0.write(request)
+        except Exception as exc:  # pragma: no cover
+            await store.append_event(
+                'backend.write.error',
+                {'envelope': dump_model(request.envelope), 'error': str(exc), 'event_id': event.event_id},
+            )
+
+    return WriteResponse(
+        event_id=event.event_id,
+        memory_id=local_memory_id,
+        backend_memory_ids=backend_memory_ids,
+        stored_locally=True,
+    )
+
+
+@app.post('/v1/revoke', response_model=RevokeResponse)
+async def revoke(request: RevokeRequest, x_api_key: str | None = Header(default=None)) -> RevokeResponse:
+    await require_api_key(x_api_key)
+    revoked = await store.revoke_memory(request.memory_id)
+    if not revoked:
+        raise HTTPException(status_code=404, detail='memory not found or already revoked')
+
+    # Propagate revocation into the HellGraph materialization: supersede the edges
+    # derived from this memory so it is not queryable in the graph lane either.
+    source_refs = revocation_source_refs(request.memory_id, request.provenance_refs)
+    graph_result: dict[str, Any]
+    try:
+        graph_result = await hellgraph_retract.retract(source_refs)
+    except Exception as exc:  # pragma: no cover
+        graph_result = {'retracted': False, 'error': str(exc), 'source_refs': source_refs}
+
+    event = await store.append_event(
+        'memory.revocation_propagated',
+        {
+            'memory_id': request.memory_id,
+            'reason': request.reason,
+            'revocation_ref': request.revocation_ref,
+            'tombstone_ref': request.tombstone_ref,
+            'graph_source_refs': source_refs,
+            'graph_retract': graph_result,
+        },
+    )
+    return RevokeResponse(
+        memory_id=request.memory_id,
+        revoked=True,
+        event_id=event.event_id,
+        graph_retract=graph_result,
+    )
+
+
+@app.get('/v1/events')
+async def list_events(limit: int = 50, x_api_key: str | None = Header(default=None)) -> dict:
+    await require_api_key(x_api_key)
+    items = [dump_model(item) for item in await store.list_events(limit=limit)]
+    return {'items': items}

--- a/apps/memoryd/src/memoryd/mem0_client.py
+++ b/apps/memoryd/src/memoryd/mem0_client.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from .models import MemoryHit, RecallRequest, WriteRequest, dump_model
+
+
+class Mem0RestClient:
+    def __init__(self, base_url: str | None, api_key: str | None, timeout_seconds: float = 10.0) -> None:
+        self.base_url = (base_url or '').rstrip('/')
+        self.api_key = api_key or ''
+        self.timeout_seconds = timeout_seconds
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.base_url)
+
+    @property
+    def headers(self) -> dict[str, str]:
+        headers = {'Content-Type': 'application/json'}
+        if self.api_key:
+            headers['X-API-Key'] = self.api_key
+        return headers
+
+    async def recall(self, request: RecallRequest) -> list[MemoryHit]:
+        if not self.enabled:
+            return []
+
+        payload = {
+            'query': request.query,
+            'user_id': request.envelope.user_id,
+            'agent_id': request.envelope.agent_id,
+            'run_id': request.envelope.run_id,
+            'limit': request.top_k,
+            'filters': request.filters,
+        }
+        async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+            response = await client.post(f'{self.base_url}/search', json=payload, headers=self.headers)
+            response.raise_for_status()
+            data = response.json()
+
+        raw_results: list[dict[str, Any]] = []
+        if isinstance(data, dict):
+            if isinstance(data.get('results'), list):
+                raw_results = data['results']
+            elif isinstance(data.get('memories'), list):
+                raw_results = data['memories']
+
+        hits: list[MemoryHit] = []
+        for item in raw_results:
+            if not isinstance(item, dict):
+                continue
+            text = item.get('memory') or item.get('text') or item.get('content') or ''
+            memory_id = str(item.get('id') or item.get('memory_id') or '')
+            score = float(item.get('score') or item.get('similarity') or 0)
+            scope = 'user'
+            if item.get('run_id') == request.envelope.run_id:
+                scope = 'run'
+            elif item.get('agent_id') == request.envelope.agent_id:
+                scope = 'agent'
+            hits.append(
+                MemoryHit(
+                    memory_id=memory_id or text[:16],
+                    text=str(text),
+                    score=score,
+                    source='mem0',
+                    scope=scope,
+                    tags=list(item.get('tags') or []),
+                    metadata={k: v for k, v in item.items() if k not in {'memory', 'text', 'content', 'score', 'similarity'}},
+                )
+            )
+        return hits
+
+    async def write(self, request: WriteRequest) -> list[str]:
+        if not self.enabled:
+            return []
+        payload = {
+            'messages': [
+                {
+                    'role': 'user',
+                    'content': request.content,
+                }
+            ],
+            'user_id': request.envelope.user_id,
+            'agent_id': request.envelope.agent_id,
+            'run_id': request.envelope.run_id,
+            'metadata': {
+                **request.metadata,
+                'memory_class': request.memory_class.value,
+                'tags': request.tags,
+                'workload_id': request.envelope.workload_id,
+                'source_interface': request.envelope.source_interface,
+            },
+        }
+        async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+            response = await client.post(f'{self.base_url}/memories', json=payload, headers=self.headers)
+            response.raise_for_status()
+            data = response.json()
+
+        ids: list[str] = []
+        if isinstance(data, dict):
+            if isinstance(data.get('results'), list):
+                for item in data['results']:
+                    if isinstance(item, dict) and item.get('id'):
+                        ids.append(str(item['id']))
+            elif data.get('id'):
+                ids.append(str(data['id']))
+        return ids

--- a/apps/memoryd/src/memoryd/models.py
+++ b/apps/memoryd/src/memoryd/models.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Literal, TypeVar
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+
+T = TypeVar('T', bound=BaseModel)
+DEFAULT_SCOPE_ORDER = ['run', 'agent', 'user']
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def dump_model(model: Any) -> dict[str, Any]:
+    if hasattr(model, 'model_dump'):
+        return model.model_dump()  # type: ignore[no-any-return]
+    if hasattr(model, 'dict'):
+        return model.dict()  # type: ignore[no-any-return]
+    raise TypeError(f'Object {type(model)!r} does not support model dumping')
+
+
+def parse_model(model_type: type[T], payload: dict[str, Any]) -> T:
+    if hasattr(model_type, 'model_validate'):
+        return model_type.model_validate(payload)  # type: ignore[return-value]
+    return model_type.parse_obj(payload)  # type: ignore[return-value]
+
+
+def stable_object_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(',', ':'), default=str).encode('utf-8')).hexdigest()
+
+
+def event_context_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    envelope = payload.get('envelope') or {}
+    if not isinstance(envelope, dict):
+        envelope = {}
+    return {
+        'workload_id': payload.get('workload_id') or envelope.get('workload_id'),
+        'run_id': payload.get('run_id') or envelope.get('run_id'),
+        'workspace_id': payload.get('workspace_id') or envelope.get('workspace_id'),
+        'user_id': payload.get('user_id') or envelope.get('user_id'),
+        'agent_id': payload.get('agent_id') or envelope.get('agent_id'),
+        'evidence_refs': list(payload.get('evidence_refs') or []),
+    }
+
+
+class MemoryClass(str, Enum):
+    interaction = 'interaction'
+    fact = 'fact'
+    preference = 'preference'
+    decision = 'decision'
+    summary = 'summary'
+    scratch = 'scratch'
+
+
+class ResourceMetadata(BaseModel):
+    namespace: str = 'default'
+    name: str
+    labels: dict[str, str] = Field(default_factory=dict)
+    annotations: dict[str, str] = Field(default_factory=dict)
+
+
+class MeshResource(BaseModel):
+    apiVersion: str = 'memorymesh.socioprophet.io/v1alpha1'
+    kind: Literal['MemoryAttachment', 'GlobalRecallPolicy', 'MemoryPeer', 'ExportPolicy', 'ConflictPolicy']
+    metadata: ResourceMetadata
+    spec: dict[str, Any] = Field(default_factory=dict)
+
+
+class ApplyResourceResponse(BaseModel):
+    applied: bool
+    resource_key: str
+    event_id: str
+    config_hash: str | None = None
+
+
+class ScopeEnvelope(BaseModel):
+    user_id: str
+    agent_id: str
+    run_id: str
+    workload_id: str
+    workspace_id: str | None = None
+    channel: str | None = None
+    thread_id: str | None = None
+    source_interface: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RecallRequest(BaseModel):
+    envelope: ScopeEnvelope
+    query: str
+    top_k: int = Field(default=5, ge=1, le=50)
+    scope_order: list[str] = Field(default_factory=lambda: list(DEFAULT_SCOPE_ORDER))
+    include_relations: bool = False
+    include_raw_events: bool = False
+    filters: dict[str, Any] = Field(default_factory=dict)
+    query_vector: list[float] | None = None
+
+
+class MemoryHit(BaseModel):
+    memory_id: str
+    text: str
+    score: float
+    source: str
+    scope: str
+    tags: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    event_id: str | None = None
+
+
+class CompiledWorkloadConfig(BaseModel):
+    workload_id: str
+    recall_scope_order: list[str] = Field(default_factory=lambda: list(DEFAULT_SCOPE_ORDER))
+    recall_top_k_limit: int = 10
+    local_first: bool = True
+    writeback_enabled: bool = True
+    allow_backend_persistence: bool = True
+    attachments: list[dict[str, Any]] = Field(default_factory=list)
+    peers: list[dict[str, Any]] = Field(default_factory=list)
+    export_policies: list[dict[str, Any]] = Field(default_factory=list)
+    conflict_policies: list[dict[str, Any]] = Field(default_factory=list)
+    config_hash: str = ''
+
+
+class RecallResponse(BaseModel):
+    query: str
+    hits: list[MemoryHit]
+    compiled_policy: dict[str, Any]
+    local_hit_count: int = 0
+    backend_hit_count: int = 0
+    truncated: bool = False
+    event_id: str | None = None
+
+
+class WriteRequest(BaseModel):
+    envelope: ScopeEnvelope
+    content: str = Field(min_length=1)
+    memory_class: MemoryClass = MemoryClass.interaction
+    persist_to_backend: bool = True
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    tags: list[str] = Field(default_factory=list)
+    vector: list[float] | None = None
+
+
+class WriteResponse(BaseModel):
+    event_id: str
+    memory_id: str | None = None
+    backend_memory_ids: list[str] = Field(default_factory=list)
+    stored_locally: bool = True
+
+
+class RevokeRequest(BaseModel):
+    # Read-enforced revocation (see docs/architecture/memory-distribution-grant.md).
+    # Tombstoning a memory here removes it from every subsequent recall on this node,
+    # so a revoked memory cannot be served even before a full sync reconciles it away.
+    memory_id: str = Field(min_length=1)
+    reason: str | None = None
+    revocation_ref: str | None = None
+    tombstone_ref: str | None = None
+    # Upstream provenance refs this memory contributed to the graph, so revocation can
+    # supersede the derived edges too. The canonical memory://{id} ref is always added.
+    provenance_refs: list[str] = Field(default_factory=list)
+
+
+class RevokeResponse(BaseModel):
+    memory_id: str
+    revoked: bool
+    event_id: str
+    graph_retract: dict[str, Any] = Field(default_factory=dict)
+
+
+class EventRecord(BaseModel):
+    event_id: str = Field(default_factory=lambda: uuid4().hex)
+    event_type: str
+    event_version: str = 'v1'
+    payload: dict[str, Any]
+    created_at: datetime = Field(default_factory=utcnow)
+    workload_id: str | None = None
+    run_id: str | None = None
+    workspace_id: str | None = None
+    user_id: str | None = None
+    agent_id: str | None = None
+    evidence_refs: list[dict[str, Any]] = Field(default_factory=list)

--- a/apps/memoryd/src/memoryd/postgres_store.py
+++ b/apps/memoryd/src/memoryd/postgres_store.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from uuid import uuid4
+
+try:
+    import psycopg
+except Exception:  # pragma: no cover
+    psycopg = None  # type: ignore[assignment]
+
+from .models import EventRecord, MeshResource, MemoryHit, RecallRequest, WriteRequest, dump_model, event_context_from_payload, parse_model
+from .qdrant_index import QdrantMemoryIndex
+from .store import compile_workload_config_from_resources, dedupe_hits, scope_bonus_for_request, token_overlap, tokenize
+
+
+class PostgresStore:
+    def __init__(self, *, dsn: str, schema: str = 'memorymesh', vector_index: QdrantMemoryIndex | None = None) -> None:
+        self.dsn = dsn
+        self.schema = schema
+        self._vector_index = vector_index
+        if psycopg is None:
+            raise RuntimeError('psycopg is required for PostgresStore')
+
+    async def init(self) -> None:
+        await asyncio.to_thread(self._migrate)
+        if self._vector_index is not None:
+            await self._vector_index.ensure_collection()
+
+    async def close(self) -> None:
+        return None
+
+    def _connect(self):
+        return psycopg.connect(self.dsn)
+
+    def _migrate(self) -> None:
+        statements = [
+            f'CREATE SCHEMA IF NOT EXISTS {self.schema}',
+            f'''
+            CREATE TABLE IF NOT EXISTS {self.schema}.resources (
+                kind TEXT NOT NULL,
+                namespace TEXT NOT NULL,
+                name TEXT NOT NULL,
+                resource JSONB NOT NULL,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                PRIMARY KEY (kind, namespace, name)
+            )
+            ''',
+            f'''
+            CREATE TABLE IF NOT EXISTS {self.schema}.events (
+                event_id TEXT PRIMARY KEY,
+                event_type TEXT NOT NULL,
+                payload JSONB NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL
+            )
+            ''',
+            f'''
+            CREATE TABLE IF NOT EXISTS {self.schema}.memories (
+                memory_id TEXT PRIMARY KEY,
+                text_content TEXT NOT NULL,
+                memory_class TEXT NOT NULL,
+                tags JSONB NOT NULL,
+                metadata JSONB NOT NULL,
+                event_id TEXT NOT NULL,
+                envelope JSONB NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            ''',
+            f"CREATE INDEX IF NOT EXISTS idx_{self.schema}_memories_user_id ON {self.schema}.memories ((envelope->>'user_id'))",
+            f"CREATE INDEX IF NOT EXISTS idx_{self.schema}_memories_workload_id ON {self.schema}.memories ((envelope->>'workload_id'))",
+            # Read-enforced revocation column (added defensively for pre-existing tables).
+            f'ALTER TABLE {self.schema}.memories ADD COLUMN IF NOT EXISTS revoked BOOLEAN NOT NULL DEFAULT FALSE',
+        ]
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                for statement in statements:
+                    cur.execute(statement)
+            conn.commit()
+
+    @staticmethod
+    def resource_key(kind: str, namespace: str, name: str) -> str:
+        return f'{kind}:{namespace}:{name}'
+
+    async def apply_resource(self, resource: MeshResource) -> str:
+        return await asyncio.to_thread(self._apply_resource_sync, resource)
+
+    def _apply_resource_sync(self, resource: MeshResource) -> str:
+        key = self.resource_key(resource.kind, resource.metadata.namespace, resource.metadata.name)
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f'''
+                    INSERT INTO {self.schema}.resources(kind, namespace, name, resource, updated_at)
+                    VALUES (%s, %s, %s, %s::jsonb, NOW())
+                    ON CONFLICT (kind, namespace, name)
+                    DO UPDATE SET resource = EXCLUDED.resource, updated_at = NOW()
+                    ''',
+                    (resource.kind, resource.metadata.namespace, resource.metadata.name, json.dumps(dump_model(resource))),
+                )
+            conn.commit()
+        return key
+
+    async def get_resource(self, kind: str, namespace: str, name: str) -> MeshResource | None:
+        return await asyncio.to_thread(self._get_resource_sync, kind, namespace, name)
+
+    def _get_resource_sync(self, kind: str, namespace: str, name: str) -> MeshResource | None:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f'SELECT resource FROM {self.schema}.resources WHERE kind = %s AND namespace = %s AND name = %s',
+                    (kind, namespace, name),
+                )
+                row = cur.fetchone()
+        if row is None:
+            return None
+        return parse_model(MeshResource, row[0])
+
+    async def append_event(self, event_type: str, payload: dict) -> EventRecord:
+        return await asyncio.to_thread(self._append_event_sync, event_type, payload)
+
+    def _append_event_sync(self, event_type: str, payload: dict) -> EventRecord:
+        event = EventRecord(event_type=event_type, payload=payload, **event_context_from_payload(payload))
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f'INSERT INTO {self.schema}.events(event_id, event_type, payload, created_at) VALUES (%s, %s, %s::jsonb, %s)',
+                    (event.event_id, event.event_type, json.dumps(event.payload), event.created_at),
+                )
+            conn.commit()
+        return event
+
+    async def list_events(self, limit: int = 50) -> list[EventRecord]:
+        return await asyncio.to_thread(self._list_events_sync, limit)
+
+    def _list_events_sync(self, limit: int) -> list[EventRecord]:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f'SELECT event_id, event_type, payload, created_at FROM {self.schema}.events ORDER BY created_at DESC LIMIT %s',
+                    (limit,),
+                )
+                rows = cur.fetchall()
+        events: list[EventRecord] = []
+        for row in rows:
+            payload = row[2]
+            events.append(
+                EventRecord(
+                    event_id=row[0],
+                    event_type=row[1],
+                    payload=payload,
+                    created_at=row[3],
+                    **event_context_from_payload(payload),
+                )
+            )
+        return events
+
+    async def compile_workload_config(self, workload_id: str):
+        return await asyncio.to_thread(self._compile_workload_config_sync, workload_id)
+
+    def _compile_workload_config_sync(self, workload_id: str):
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f'SELECT resource FROM {self.schema}.resources')
+                rows = cur.fetchall()
+        resources = [parse_model(MeshResource, row[0]) for row in rows]
+        return compile_workload_config_from_resources(resources, workload_id=workload_id)
+
+    async def add_local_memory(self, request: WriteRequest, event_id: str) -> str:
+        memory_id = uuid4().hex
+        await asyncio.to_thread(self._add_local_memory_sync, request, event_id, memory_id)
+        if self._vector_index is not None:
+            await self._vector_index.upsert_memory(request, memory_id=memory_id, event_id=event_id)
+        return memory_id
+
+    def _add_local_memory_sync(self, request: WriteRequest, event_id: str, memory_id: str) -> None:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f'''
+                    INSERT INTO {self.schema}.memories(memory_id, text_content, memory_class, tags, metadata, event_id, envelope)
+                    VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s, %s::jsonb)
+                    ''',
+                    (
+                        memory_id,
+                        request.content,
+                        request.memory_class.value,
+                        json.dumps(list(request.tags)),
+                        json.dumps(dict(request.metadata)),
+                        event_id,
+                        json.dumps(dump_model(request.envelope)),
+                    ),
+                )
+            conn.commit()
+
+    async def search_local_memories(self, request: RecallRequest) -> list[MemoryHit]:
+        lexical_hits = await asyncio.to_thread(self._search_lexical_sync, request)
+        vector_hits = await self._vector_index.search(request) if self._vector_index is not None and request.query_vector else []
+        merged = dedupe_hits(lexical_hits + vector_hits)
+        # Read-enforced revocation for externally-indexed vector hits.
+        if vector_hits:
+            revoked = await asyncio.to_thread(self._revoked_ids_sync)
+            merged = [hit for hit in merged if hit.memory_id not in revoked]
+        merged.sort(key=lambda hit: hit.score, reverse=True)
+        return merged[: request.top_k]
+
+    def _revoked_ids_sync(self) -> set[str]:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f'SELECT memory_id FROM {self.schema}.memories WHERE revoked = TRUE')
+                rows = cur.fetchall()
+        return {row[0] for row in rows}
+
+    async def revoke_memory(self, memory_id: str) -> bool:
+        return await asyncio.to_thread(self._revoke_memory_sync, memory_id)
+
+    def _revoke_memory_sync(self, memory_id: str) -> bool:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f'UPDATE {self.schema}.memories SET revoked = TRUE WHERE memory_id = %s AND revoked = FALSE',
+                    (memory_id,),
+                )
+                changed = cur.rowcount > 0
+            conn.commit()
+        return changed
+
+    def _search_lexical_sync(self, request: RecallRequest) -> list[MemoryHit]:
+        limit = max(request.top_k * 20, 100)
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                if request.envelope.workspace_id is None:
+                    cur.execute(
+                        f'''
+                        SELECT memory_id, text_content, tags, metadata, event_id, envelope
+                        FROM {self.schema}.memories
+                        WHERE revoked = FALSE
+                          AND (envelope->>'user_id') = %s
+                          AND (envelope->>'workload_id') = %s
+                        ORDER BY created_at DESC
+                        LIMIT %s
+                        ''',
+                        (request.envelope.user_id, request.envelope.workload_id, limit),
+                    )
+                else:
+                    cur.execute(
+                        f'''
+                        SELECT memory_id, text_content, tags, metadata, event_id, envelope
+                        FROM {self.schema}.memories
+                        WHERE revoked = FALSE
+                          AND (envelope->>'user_id') = %s
+                          AND (envelope->>'workload_id') = %s
+                          AND (envelope->>'workspace_id') = %s
+                        ORDER BY created_at DESC
+                        LIMIT %s
+                        ''',
+                        (request.envelope.user_id, request.envelope.workload_id, request.envelope.workspace_id, limit),
+                    )
+                rows = cur.fetchall()
+        query_tokens = tokenize(request.query)
+        hits: list[MemoryHit] = []
+        for memory_id, text_content, tags, metadata, event_id, envelope in rows:
+            env = envelope or {}
+            scope_bonus, scope_name = scope_bonus_for_request(request, env)
+            if scope_bonus < 0:
+                continue
+            overlap = token_overlap(query_tokens, tokenize(text_content))
+            if overlap <= 0 and request.query.lower() not in text_content.lower():
+                continue
+            hits.append(
+                MemoryHit(
+                    memory_id=memory_id,
+                    text=text_content,
+                    score=overlap + scope_bonus,
+                    source='memoryd.postgres',
+                    scope=scope_name,
+                    tags=list(tags or []),
+                    metadata=dict(metadata or {}),
+                    event_id=event_id,
+                )
+            )
+        return hits
+
+    async def health(self) -> dict[str, Any]:
+        status: dict[str, Any] = {'backend': 'postgres', 'schema': self.schema}
+        try:
+            with self._connect() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(f'SELECT COUNT(*) FROM {self.schema}.events')
+                    row = cur.fetchone()
+                    status['event_count'] = int(row[0]) if row else 0
+        except Exception as exc:  # pragma: no cover
+            status['error'] = str(exc)
+        if self._vector_index is not None:
+            status['vector_index'] = await self._vector_index.health()
+        return status

--- a/apps/memoryd/src/memoryd/qdrant_index.py
+++ b/apps/memoryd/src/memoryd/qdrant_index.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from .models import MemoryHit, RecallRequest, WriteRequest
+from .store import scope_bonus_for_request
+
+
+class QdrantMemoryIndex:
+    def __init__(
+        self,
+        *,
+        url: str,
+        api_key: str | None,
+        collection_name: str,
+        vector_size: int,
+        distance: str = 'Cosine',
+        enabled: bool = False,
+        timeout_seconds: float = 10.0,
+    ) -> None:
+        self.url = url.rstrip('/')
+        self.api_key = api_key or ''
+        self.collection_name = collection_name
+        self.vector_size = vector_size
+        self.distance = distance
+        self.enabled = enabled and bool(url)
+        self.timeout_seconds = timeout_seconds
+        self._initialized = False
+
+    @property
+    def headers(self) -> dict[str, str]:
+        headers = {'Content-Type': 'application/json'}
+        if self.api_key:
+            headers['api-key'] = self.api_key
+        return headers
+
+    async def ensure_collection(self) -> None:
+        if not self.enabled or self._initialized:
+            return
+        async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+            response = await client.put(
+                f'{self.url}/collections/{self.collection_name}',
+                json={'vectors': {'size': self.vector_size, 'distance': self.distance}},
+                headers=self.headers,
+            )
+            response.raise_for_status()
+        self._initialized = True
+
+    async def upsert_memory(self, request: WriteRequest, *, memory_id: str, event_id: str) -> None:
+        if not self.enabled or not request.vector:
+            return
+        await self.ensure_collection()
+        payload = {
+            'text': request.content,
+            'memory_class': request.memory_class.value,
+            'tags': list(request.tags),
+            'metadata': dict(request.metadata),
+            'event_id': event_id,
+            'envelope': request.envelope.dict() if hasattr(request.envelope, 'dict') else request.envelope.model_dump(),
+            'user_id': request.envelope.user_id,
+            'agent_id': request.envelope.agent_id,
+            'run_id': request.envelope.run_id,
+            'workload_id': request.envelope.workload_id,
+            'workspace_id': request.envelope.workspace_id,
+            'source_interface': request.envelope.source_interface,
+        }
+        point = {'id': memory_id, 'vector': request.vector, 'payload': payload}
+        async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+            response = await client.put(
+                f'{self.url}/collections/{self.collection_name}/points',
+                params={'wait': 'true'},
+                json={'points': [point]},
+                headers=self.headers,
+            )
+            response.raise_for_status()
+
+    async def search(self, request: RecallRequest) -> list[MemoryHit]:
+        if not self.enabled or not request.query_vector:
+            return []
+        await self.ensure_collection()
+        must_filters: list[dict[str, Any]] = [
+            {'key': 'user_id', 'match': {'value': request.envelope.user_id}},
+            {'key': 'workload_id', 'match': {'value': request.envelope.workload_id}},
+        ]
+        if request.envelope.workspace_id is not None:
+            must_filters.append({'key': 'workspace_id', 'match': {'value': request.envelope.workspace_id}})
+
+        body: dict[str, Any] = {
+            'query': request.query_vector,
+            'limit': request.top_k,
+            'with_payload': True,
+            'filter': {'must': must_filters},
+        }
+        async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+            response = await client.post(
+                f'{self.url}/collections/{self.collection_name}/points/query',
+                json=body,
+                headers=self.headers,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        points = []
+        if isinstance(data, dict):
+            result = data.get('result') or {}
+            if isinstance(result, dict) and isinstance(result.get('points'), list):
+                points = result['points']
+
+        hits: list[MemoryHit] = []
+        for item in points:
+            if not isinstance(item, dict):
+                continue
+            payload: dict[str, Any] = dict(item.get('payload') or {})
+            envelope = payload.get('envelope') or {}
+            scope_bonus, scope_name = scope_bonus_for_request(request, envelope)
+            if scope_bonus < 0:
+                continue
+            score = float(item.get('score') or 0.0) + (scope_bonus / 100.0)
+            hits.append(
+                MemoryHit(
+                    memory_id=str(item.get('id')),
+                    text=str(payload.get('text', '')),
+                    score=score,
+                    source='memoryd.qdrant',
+                    scope=scope_name,
+                    tags=list(payload.get('tags') or []),
+                    metadata=dict(payload.get('metadata') or {}),
+                    event_id=payload.get('event_id'),
+                )
+            )
+        return hits
+
+    async def health(self) -> dict[str, Any]:
+        if not self.enabled:
+            return {'enabled': False}
+        try:
+            await self.ensure_collection()
+            async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+                response = await client.get(f'{self.url}/collections/{self.collection_name}', headers=self.headers)
+                response.raise_for_status()
+            return {'enabled': True, 'collection': self.collection_name}
+        except Exception as exc:  # pragma: no cover
+            return {'enabled': True, 'error': str(exc)}

--- a/apps/memoryd/src/memoryd/sqlite_store.py
+++ b/apps/memoryd/src/memoryd/sqlite_store.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from .models import EventRecord, MeshResource, MemoryHit, RecallRequest, WriteRequest, dump_model, event_context_from_payload, parse_model
+from .qdrant_index import QdrantMemoryIndex
+from .store import compile_workload_config_from_resources, dedupe_hits, scope_bonus_for_request, token_overlap, tokenize
+
+
+class SQLiteStore:
+    def __init__(self, *, db_path: str, vector_index: QdrantMemoryIndex | None = None) -> None:
+        self.db_path = db_path
+        self._vector_index = vector_index
+
+    async def init(self) -> None:
+        await asyncio.to_thread(self._ensure_parent_dir)
+        await asyncio.to_thread(self._migrate)
+        if self._vector_index is not None:
+            await self._vector_index.ensure_collection()
+
+    async def close(self) -> None:
+        return None
+
+    def _ensure_parent_dir(self) -> None:
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _migrate(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                '''
+                CREATE TABLE IF NOT EXISTS resources (
+                    kind TEXT NOT NULL,
+                    namespace TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    resource_json TEXT NOT NULL,
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (kind, namespace, name)
+                );
+                CREATE TABLE IF NOT EXISTS events (
+                    event_id TEXT PRIMARY KEY,
+                    event_type TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS memories (
+                    memory_id TEXT PRIMARY KEY,
+                    text_content TEXT NOT NULL,
+                    memory_class TEXT NOT NULL,
+                    tags_json TEXT NOT NULL,
+                    metadata_json TEXT NOT NULL,
+                    event_id TEXT NOT NULL,
+                    envelope_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+                CREATE INDEX IF NOT EXISTS idx_memories_created_at ON memories(created_at DESC);
+                '''
+            )
+            # Read-enforced revocation column (added defensively for pre-existing DBs).
+            columns = {row['name'] for row in conn.execute('PRAGMA table_info(memories)').fetchall()}
+            if 'revoked' not in columns:
+                conn.execute('ALTER TABLE memories ADD COLUMN revoked INTEGER NOT NULL DEFAULT 0')
+            conn.commit()
+
+    @staticmethod
+    def resource_key(kind: str, namespace: str, name: str) -> str:
+        return f'{kind}:{namespace}:{name}'
+
+    async def apply_resource(self, resource: MeshResource) -> str:
+        return await asyncio.to_thread(self._apply_resource_sync, resource)
+
+    def _apply_resource_sync(self, resource: MeshResource) -> str:
+        with self._connect() as conn:
+            conn.execute(
+                '''
+                INSERT OR REPLACE INTO resources(kind, namespace, name, resource_json, updated_at)
+                VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+                ''',
+                (resource.kind, resource.metadata.namespace, resource.metadata.name, json.dumps(dump_model(resource))),
+            )
+            conn.commit()
+        return self.resource_key(resource.kind, resource.metadata.namespace, resource.metadata.name)
+
+    async def get_resource(self, kind: str, namespace: str, name: str) -> MeshResource | None:
+        return await asyncio.to_thread(self._get_resource_sync, kind, namespace, name)
+
+    def _get_resource_sync(self, kind: str, namespace: str, name: str) -> MeshResource | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                'SELECT resource_json FROM resources WHERE kind = ? AND namespace = ? AND name = ?',
+                (kind, namespace, name),
+            ).fetchone()
+        if row is None:
+            return None
+        return parse_model(MeshResource, json.loads(row['resource_json']))
+
+    async def append_event(self, event_type: str, payload: dict) -> EventRecord:
+        return await asyncio.to_thread(self._append_event_sync, event_type, payload)
+
+    def _append_event_sync(self, event_type: str, payload: dict) -> EventRecord:
+        event = EventRecord(event_type=event_type, payload=payload, **event_context_from_payload(payload))
+        with self._connect() as conn:
+            conn.execute(
+                'INSERT INTO events(event_id, event_type, payload_json, created_at) VALUES (?, ?, ?, ?)',
+                (event.event_id, event.event_type, json.dumps(event.payload), event.created_at.isoformat()),
+            )
+            conn.commit()
+        return event
+
+    async def list_events(self, limit: int = 50) -> list[EventRecord]:
+        return await asyncio.to_thread(self._list_events_sync, limit)
+
+    def _list_events_sync(self, limit: int) -> list[EventRecord]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                'SELECT event_id, event_type, payload_json, created_at FROM events ORDER BY created_at DESC LIMIT ?',
+                (limit,),
+            ).fetchall()
+        events: list[EventRecord] = []
+        for row in rows:
+            payload = json.loads(row['payload_json'])
+            events.append(
+                EventRecord(
+                    event_id=row['event_id'],
+                    event_type=row['event_type'],
+                    payload=payload,
+                    created_at=row['created_at'],
+                    **event_context_from_payload(payload),
+                )
+            )
+        return events
+
+    async def compile_workload_config(self, workload_id: str):
+        return await asyncio.to_thread(self._compile_workload_config_sync, workload_id)
+
+    def _compile_workload_config_sync(self, workload_id: str):
+        with self._connect() as conn:
+            rows = conn.execute('SELECT resource_json FROM resources').fetchall()
+        resources = [parse_model(MeshResource, json.loads(row['resource_json'])) for row in rows]
+        return compile_workload_config_from_resources(resources, workload_id=workload_id)
+
+    async def add_local_memory(self, request: WriteRequest, event_id: str) -> str:
+        memory_id = uuid4().hex
+        await asyncio.to_thread(self._add_local_memory_sync, request, event_id, memory_id)
+        if self._vector_index is not None:
+            await self._vector_index.upsert_memory(request, memory_id=memory_id, event_id=event_id)
+        return memory_id
+
+    def _add_local_memory_sync(self, request: WriteRequest, event_id: str, memory_id: str) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                '''
+                INSERT INTO memories(memory_id, text_content, memory_class, tags_json, metadata_json, event_id, envelope_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ''',
+                (
+                    memory_id,
+                    request.content,
+                    request.memory_class.value,
+                    json.dumps(list(request.tags)),
+                    json.dumps(dict(request.metadata)),
+                    event_id,
+                    json.dumps(dump_model(request.envelope)),
+                ),
+            )
+            conn.commit()
+
+    async def search_local_memories(self, request: RecallRequest) -> list[MemoryHit]:
+        lexical_hits = await asyncio.to_thread(self._search_lexical_sync, request)
+        vector_hits = await self._vector_index.search(request) if self._vector_index is not None and request.query_vector else []
+        merged = dedupe_hits(lexical_hits + vector_hits)
+        # Read-enforced revocation for vector hits: the lexical query already excludes
+        # revoked rows, but vector hits come from an external index that may still hold
+        # the tombstoned vector, so drop anything revoked before returning.
+        if vector_hits:
+            revoked = await asyncio.to_thread(self._revoked_ids_sync)
+            merged = [hit for hit in merged if hit.memory_id not in revoked]
+        merged.sort(key=lambda hit: hit.score, reverse=True)
+        return merged[: request.top_k]
+
+    def _revoked_ids_sync(self) -> set[str]:
+        with self._connect() as conn:
+            rows = conn.execute('SELECT memory_id FROM memories WHERE revoked = 1').fetchall()
+        return {row['memory_id'] for row in rows}
+
+    async def revoke_memory(self, memory_id: str) -> bool:
+        return await asyncio.to_thread(self._revoke_memory_sync, memory_id)
+
+    def _revoke_memory_sync(self, memory_id: str) -> bool:
+        with self._connect() as conn:
+            cur = conn.execute('UPDATE memories SET revoked = 1 WHERE memory_id = ? AND revoked = 0', (memory_id,))
+            conn.commit()
+            return cur.rowcount > 0
+
+    def _search_lexical_sync(self, request: RecallRequest) -> list[MemoryHit]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                'SELECT memory_id, text_content, tags_json, metadata_json, event_id, envelope_json FROM memories WHERE revoked = 0 ORDER BY created_at DESC LIMIT ?',
+                (max(request.top_k * 20, 100),),
+            ).fetchall()
+        query_tokens = tokenize(request.query)
+        hits: list[MemoryHit] = []
+        for row in rows:
+            envelope = json.loads(row['envelope_json'])
+            scope_bonus, scope_name = scope_bonus_for_request(request, envelope)
+            if scope_bonus < 0:
+                continue
+            text_content = row['text_content']
+            overlap = token_overlap(query_tokens, tokenize(text_content))
+            if overlap <= 0 and request.query.lower() not in text_content.lower():
+                continue
+            hits.append(
+                MemoryHit(
+                    memory_id=row['memory_id'],
+                    text=text_content,
+                    score=overlap + scope_bonus,
+                    source='memoryd.sqlite',
+                    scope=scope_name,
+                    tags=list(json.loads(row['tags_json'])),
+                    metadata=dict(json.loads(row['metadata_json'])),
+                    event_id=row['event_id'],
+                )
+            )
+        return hits
+
+    async def health(self) -> dict:
+        status: dict = {'backend': 'sqlite', 'path': self.db_path}
+        try:
+            with self._connect() as conn:
+                row = conn.execute('SELECT COUNT(*) AS count FROM events').fetchone()
+            status['event_count'] = int(row['count']) if row else 0
+        except Exception as exc:  # pragma: no cover
+            status['error'] = str(exc)
+        if self._vector_index is not None:
+            status['vector_index'] = await self._vector_index.health()
+        return status

--- a/apps/memoryd/src/memoryd/store.py
+++ b/apps/memoryd/src/memoryd/store.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Iterable, Protocol
+from uuid import uuid4
+
+from .models import (
+    DEFAULT_SCOPE_ORDER,
+    CompiledWorkloadConfig,
+    EventRecord,
+    MemoryHit,
+    MeshResource,
+    RecallRequest,
+    WriteRequest,
+    dump_model,
+    event_context_from_payload,
+    stable_object_hash,
+)
+
+
+DEFAULT_RECALL_SCOPE_ORDER = ['run', 'agent', 'user']
+EXTENDED_RECALL_SCOPE_PREFIX = ['thread', 'channel', 'workspace']
+LOCAL_SOURCE_PREFIXES = ('memoryd.',)
+
+
+class StoreProtocol(Protocol):
+    async def init(self) -> None: ...
+    async def close(self) -> None: ...
+    async def apply_resource(self, resource: MeshResource) -> str: ...
+    async def get_resource(self, kind: str, namespace: str, name: str) -> MeshResource | None: ...
+    async def append_event(self, event_type: str, payload: dict) -> EventRecord: ...
+    async def list_events(self, limit: int = 50) -> list[EventRecord]: ...
+    async def compile_workload_config(self, workload_id: str) -> CompiledWorkloadConfig: ...
+    async def add_local_memory(self, request: WriteRequest, event_id: str) -> str: ...
+    async def search_local_memories(self, request: RecallRequest) -> list[MemoryHit]: ...
+    async def revoke_memory(self, memory_id: str) -> bool: ...
+    async def health(self) -> dict: ...
+
+
+class InMemoryStore:
+    def __init__(self) -> None:
+        self._resources: dict[str, MeshResource] = {}
+        self._events: list[EventRecord] = []
+        self._memories: dict[str, dict] = {}
+        self._revoked: set[str] = set()
+        self._resource_index: dict[str, list[str]] = defaultdict(list)
+
+    async def init(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    @staticmethod
+    def resource_key(kind: str, namespace: str, name: str) -> str:
+        return f'{kind}:{namespace}:{name}'
+
+    async def apply_resource(self, resource: MeshResource) -> str:
+        key = self.resource_key(resource.kind, resource.metadata.namespace, resource.metadata.name)
+        self._resources[key] = resource
+        self._resource_index[resource.kind].append(key)
+        return key
+
+    async def get_resource(self, kind: str, namespace: str, name: str) -> MeshResource | None:
+        return self._resources.get(self.resource_key(kind, namespace, name))
+
+    async def append_event(self, event_type: str, payload: dict) -> EventRecord:
+        event = EventRecord(event_type=event_type, payload=payload, **event_context_from_payload(payload))
+        self._events.append(event)
+        return event
+
+    async def list_events(self, limit: int = 50) -> list[EventRecord]:
+        return list(reversed(self._events[-limit:]))
+
+    async def compile_workload_config(self, workload_id: str) -> CompiledWorkloadConfig:
+        return compile_workload_config_from_resources(self._resources.values(), workload_id=workload_id)
+
+    async def add_local_memory(self, request: WriteRequest, event_id: str) -> str:
+        memory_id = uuid4().hex
+        record = {
+            'memory_id': memory_id,
+            'text': request.content,
+            'memory_class': request.memory_class.value,
+            'tags': list(request.tags),
+            'metadata': dict(request.metadata),
+            'event_id': event_id,
+            'envelope': dump_model(request.envelope),
+        }
+        self._memories[memory_id] = record
+        return memory_id
+
+    async def search_local_memories(self, request: RecallRequest) -> list[MemoryHit]:
+        query_tokens = tokenize(request.query)
+        hits: list[MemoryHit] = []
+        for record in self._memories.values():
+            # Read-enforced revocation: a tombstoned memory never surfaces in recall.
+            if record['memory_id'] in self._revoked:
+                continue
+            env = record['envelope']
+            scope_bonus, scope_name = scope_bonus_for_request(request, env)
+            if scope_bonus < 0:
+                continue
+            overlap = token_overlap(query_tokens, tokenize(record['text']))
+            if overlap <= 0 and request.query.lower() not in record['text'].lower():
+                continue
+            score = overlap + scope_bonus
+            hits.append(
+                MemoryHit(
+                    memory_id=record['memory_id'],
+                    text=record['text'],
+                    score=score,
+                    source='memoryd.memory',
+                    scope=scope_name,
+                    tags=record['tags'],
+                    metadata=record['metadata'],
+                    event_id=record['event_id'],
+                )
+            )
+        hits.sort(key=lambda hit: hit.score, reverse=True)
+        return hits[: request.top_k]
+
+    async def revoke_memory(self, memory_id: str) -> bool:
+        # Tombstone the memory so recall never serves it again. Idempotent:
+        # returns True only the first time a known memory is revoked.
+        if memory_id not in self._memories or memory_id in self._revoked:
+            return False
+        self._revoked.add(memory_id)
+        return True
+
+    async def health(self) -> dict:
+        return {
+            'backend': 'memory',
+            'resource_count': len(self._resources),
+            'event_count': len(self._events),
+            'memory_count': len(self._memories),
+            'revoked_count': len(self._revoked),
+        }
+
+
+def compile_workload_config_from_resources(resources: Iterable[MeshResource], *, workload_id: str) -> CompiledWorkloadConfig:
+    attachments: list[dict[str, Any]] = []
+    peers: list[dict[str, Any]] = []
+    export_policies: list[dict[str, Any]] = []
+    conflict_policies: list[dict[str, Any]] = []
+    recall_scope_order = list(DEFAULT_SCOPE_ORDER)
+    recall_top_k_limit = 10
+    local_first = True
+    writeback_enabled = True
+    allow_backend_persistence = True
+
+    for resource in resources:
+        spec = resource.spec or {}
+        targets = set(spec.get('targetWorkloads') or spec.get('workloadIds') or [])
+        applies = not targets or workload_id in targets or spec.get('workloadId') == workload_id or resource.metadata.name == workload_id
+        if not applies:
+            continue
+        dumped = dump_model(resource)
+        if resource.kind == 'MemoryAttachment':
+            attachments.append(dumped)
+            policy = spec.get('policy') or {}
+            recall_scope_order = list(policy.get('scopeOrder') or policy.get('scope_order') or recall_scope_order)
+            recall_top_k_limit = int(policy.get('topKLimit') or policy.get('recall_top_k') or recall_top_k_limit)
+            writeback_enabled = bool(policy.get('writebackEnabled', policy.get('writeback_enabled', writeback_enabled)))
+            allow_backend_persistence = bool(policy.get('allowBackendPersistence', policy.get('allow_backend_persistence', allow_backend_persistence)))
+            local_first = bool(policy.get('localFirst', policy.get('local_first', local_first)))
+        elif resource.kind == 'MemoryPeer':
+            peers.append(dumped)
+        elif resource.kind == 'ExportPolicy':
+            export_policies.append(dumped)
+        elif resource.kind == 'ConflictPolicy':
+            conflict_policies.append(dumped)
+        elif resource.kind == 'GlobalRecallPolicy':
+            recall_scope_order = list(spec.get('scopeOrder') or spec.get('scope_order') or recall_scope_order)
+            recall_top_k_limit = int(spec.get('topKLimit') or spec.get('recall_top_k') or recall_top_k_limit)
+            local_first = bool(spec.get('localFirst', spec.get('local_first', local_first)))
+            writeback_enabled = bool(spec.get('writebackEnabled', spec.get('writeback_enabled', writeback_enabled)))
+            allow_backend_persistence = bool(spec.get('allowBackendPersistence', spec.get('allow_backend_persistence', allow_backend_persistence)))
+
+    compiled = CompiledWorkloadConfig(
+        workload_id=workload_id,
+        recall_scope_order=recall_scope_order,
+        recall_top_k_limit=recall_top_k_limit,
+        local_first=local_first,
+        writeback_enabled=writeback_enabled,
+        allow_backend_persistence=allow_backend_persistence,
+        attachments=attachments,
+        peers=peers,
+        export_policies=export_policies,
+        conflict_policies=conflict_policies,
+    )
+    payload = dump_model(compiled)
+    payload.pop('config_hash', None)
+    compiled.config_hash = stable_object_hash(payload)
+    return compiled
+
+
+def tokenize(text: str) -> set[str]:
+    return {token.strip('.,!?;:()[]{}').lower() for token in text.split() if token.strip()}
+
+
+def token_overlap(query_tokens: set[str], text_tokens: set[str]) -> float:
+    if not query_tokens or not text_tokens:
+        return 0.0
+    return float(len(query_tokens & text_tokens))
+
+
+def build_scope_order(scope_order: list[str] | None) -> list[str]:
+    ordered = list(EXTENDED_RECALL_SCOPE_PREFIX)
+    for item in scope_order or DEFAULT_RECALL_SCOPE_ORDER:
+        if item and item not in ordered:
+            ordered.append(item)
+    for fallback in DEFAULT_RECALL_SCOPE_ORDER:
+        if fallback not in ordered:
+            ordered.append(fallback)
+    return ordered
+
+
+def scope_name_for_request(request: RecallRequest, env: dict) -> str:
+    req = request.envelope
+    if env.get('user_id') != req.user_id:
+        return 'none'
+    if req.thread_id and env.get('thread_id') == req.thread_id:
+        return 'thread'
+    if req.channel and env.get('channel') == req.channel:
+        return 'channel'
+    if req.workspace_id and env.get('workspace_id') == req.workspace_id:
+        return 'workspace'
+    if env.get('run_id') == req.run_id:
+        return 'run'
+    if env.get('agent_id') == req.agent_id:
+        return 'agent'
+    return 'user'
+
+
+def scope_rank(scope_name: str, scope_order: list[str] | None) -> int:
+    ordered = build_scope_order(scope_order)
+    if scope_name not in ordered:
+        return 0
+    return len(ordered) - ordered.index(scope_name)
+
+
+def scope_bonus_for_request(request: RecallRequest, env: dict, scope_order: list[str] | None = None) -> tuple[float, str]:
+    req = request.envelope
+    if env.get('workload_id') and env.get('workload_id') != req.workload_id:
+        return -1.0, 'none'
+    if req.workspace_id is not None and env.get('workspace_id') is not None and env.get('workspace_id') != req.workspace_id:
+        return -1.0, 'none'
+    scope_name = scope_name_for_request(request, env)
+    if scope_name == 'none':
+        return -1.0, 'none'
+    return float(scope_rank(scope_name, scope_order or request.scope_order)), scope_name
+
+
+def hit_sort_key(hit: MemoryHit, *, scope_order: list[str] | None, local_first: bool) -> tuple[int, int, float]:
+    local_source_bonus = 1 if local_first and hit.source.startswith(LOCAL_SOURCE_PREFIXES) else 0
+    return local_source_bonus, scope_rank(hit.scope, scope_order), float(hit.score)
+
+
+def rank_hits_by_policy(hits: list[MemoryHit], *, scope_order: list[str] | None, local_first: bool) -> list[MemoryHit]:
+    return sorted(
+        hits,
+        key=lambda hit: hit_sort_key(hit, scope_order=scope_order, local_first=local_first),
+        reverse=True,
+    )
+
+
+def dedupe_hits(hits: list[MemoryHit]) -> list[MemoryHit]:
+    best_by_id: dict[str, MemoryHit] = {}
+    for hit in hits:
+        existing = best_by_id.get(hit.memory_id)
+        if existing is None or hit.score > existing.score:
+            best_by_id[hit.memory_id] = hit
+    return list(best_by_id.values())

--- a/apps/memoryd/tests/test_memoryd.py
+++ b/apps/memoryd/tests/test_memoryd.py
@@ -1,0 +1,18 @@
+"""memoryd smoke — boots on the default in-memory store (no DB), serves health + a write/recall round-trip."""
+from fastapi.testclient import TestClient
+
+from memoryd.main import app
+
+client = TestClient(app)
+
+
+def test_healthz_on_inmemory_store():
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("store") is not None   # InMemoryStore reports healthy without any database configured
+
+
+def test_root_identifies_service():
+    r = client.get("/")
+    assert r.status_code == 200

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -31,6 +31,7 @@ spec:
           - { name: grl-mesh }
           - { name: owl-reasoner }
           - { name: entity-resolution }
+          - { name: memoryd }
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —
           # NOT touched by the build-image/gitops-promote SHA pipeline above, since

--- a/deploy/values/memoryd.yaml
+++ b/deploy/values/memoryd.yaml
@@ -1,0 +1,10 @@
+# memoryd — sovereign memory-mesh service (apps/memoryd), vendored from ~/dev/memory-mesh into prophet-platform
+# CI so it builds with the estate's WIF like every other service. Recall/write/retract over a pluggable store;
+# defaults to in-memory (MEMORYMESH_STORE_URI=memory://) so it boots with no database. Point at a Postgres DSN
+# to persist. tag:latest → sha-pinned after first build.
+image: { repository: memoryd, tag: latest }
+service: { port: 8787, portName: http }
+config:
+  MEMORYMESH_STORE_URI: "memory://"
+  MEMORYMESH_VECTOR_SIZE: "256"
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -95,6 +95,10 @@ KNOWN_BROKEN = {
     "entity-resolution:moving-tag": (
         "New service — Dockerfile + images.yml entry added this PR. Pin tag:latest -> sha- after first CI build."
     ),
+    "memoryd:moving-tag": (
+        "New service — memory-mesh's memoryd vendored into prophet-platform CI this PR, so it BUILDS with the "
+        "estate WIF. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
+    ),
     # The chart has said "Immutable tag = the commit SHA" since it was written; these
     # 9 predate the check. Pinning them is mechanical BUT NOT SAFE TO BATCH: `latest`
     # + IfNotPresent means nodes may be running an older cached digest than `latest`


### PR DESCRIPTION
## Why
"Did we stand up the memory-mesh services yet? we need them up!" — and it was never secret-gated. memoryd only failed to build in its *own* repo (no WIF there). The fix is the pattern already proven this session for grlplus/grl-mesh/owl-reasoner/entity-resolution: **vendor it into prophet-platform, where the WIF secrets live, and build on the estate CI.**

## What
- **`apps/memoryd/src/memoryd/`** — the self-contained app package from `memory-mesh/services/memoryd/app`. memoryd imports only its own modules + fastapi/httpx/pydantic/psycopg, so the original Dockerfile's heavy `specs/adapters/third_party/artifacts` COPYs were unused and dropped.
- **Dockerfile** (`uvicorn memoryd.main:app`), **requirements.txt**, **tests** — boots on the default **in-memory store** (`MEMORYMESH_STORE_URI=memory://`), so it runs and tests with **no database**; point at a Postgres DSN to persist.
- **Wired end-to-end**: `images.yml` build entry · `deploy/values/memoryd.yaml` + ApplicationSet · `Makefile` `memoryd-smoke` + `validate-target-diagnostics` matrix · preflight moving-tag allowance.

## Test
`make memoryd-smoke` green (healthz on in-memory store + root). Preflight exits 0 with memoryd ratcheted.

## Follow-up
`tag: latest` → sha-pin after the first CI build publishes a digest (same chicken-and-egg as the other new services).