### PR TITLE
tritfabric-consumption-api: ship via prophet-platform CI (containerize + deploy)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -68,6 +68,7 @@ jobs:
           - { image: owl-reasoner,         context: apps/owl-reasoner,         dockerfile: Dockerfile }
           - { image: entity-resolution,     context: apps/entity-resolution,     dockerfile: Dockerfile }
           - { image: memoryd,               context: apps/memoryd,               dockerfile: Dockerfile }
+          - { image: tritfabric-consumption-api, context: ., dockerfile: apps/tritfabric-consumption-api/Dockerfile }
     uses: SocioProphet/.github/.github/workflows/build-image.yml@main
     with:
       image: ${{ matrix.image }}

--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -139,6 +139,7 @@ jobs:
           - owl-reasoner-smoke
           - entity-resolution-smoke
           - memoryd-smoke
+          - tritfabric-consumption-api-smoke
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ memoryd-smoke:
 	cd apps/memoryd && test -d .venv || python3 -m venv .venv
 	cd apps/memoryd && . .venv/bin/activate && python -m pip install --upgrade pip pytest -r requirements.txt && PYTHONPATH=src pytest -q tests
 
+tritfabric-consumption-api-smoke:
+	cd apps/tritfabric-consumption-api && test -d .venv || python3 -m venv .venv
+	cd apps/tritfabric-consumption-api && . .venv/bin/activate && python -m pip install --upgrade pip pytest -r requirements.txt && pytest -q tests
+
 grl-mesh-smoke:
 	cd apps/grl-mesh && test -d .venv || python3 -m venv .venv
 	cd apps/grl-mesh && . .venv/bin/activate && python -m pip install --upgrade pip pytest -r requirements.txt && PYTHONPATH=src pytest -q tests

--- a/apps/tritfabric-consumption-api/Dockerfile
+++ b/apps/tritfabric-consumption-api/Dockerfile
@@ -1,0 +1,12 @@
+# tritfabric-consumption-api — the prophet-platform consumption surface for TritFabric (readiness/contract
+# reporting; deliberately non-mutating). Root build context so the integration contract travels with the app.
+FROM python:3.11-slim
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY apps/tritfabric-consumption-api/requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r /app/requirements.txt
+COPY apps/tritfabric-consumption-api /app/apps/tritfabric-consumption-api
+COPY contracts/integrations/tritfabric-consumption.v0.json /app/contracts/integrations/tritfabric-consumption.v0.json
+ENV PORT=8080
+EXPOSE 8080
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", "--app-dir", "apps/tritfabric-consumption-api"]

--- a/apps/tritfabric-consumption-api/requirements.txt
+++ b/apps/tritfabric-consumption-api/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.115,<1
+uvicorn[standard]>=0.30,<1
+httpx>=0.27,<1
+pytest

--- a/apps/tritfabric-consumption-api/tests/test_consumption_api.py
+++ b/apps/tritfabric-consumption-api/tests/test_consumption_api.py
@@ -1,0 +1,30 @@
+"""tritfabric-consumption-api smoke — the readiness surfaces load their contract and stay non-mutating."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # import main.py
+from fastapi.testclient import TestClient  # noqa: E402
+from main import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_healthz():
+    r = client.get("/healthz")
+    assert r.status_code == 200 and r.json()["ok"] is True
+    assert r.json()["mutation_authorized"] is False
+
+
+def test_summary_lists_all_four_surfaces_non_mutating():
+    r = client.get("/tritfabric")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mutation_authorized"] is False and body["runtime_execution_authorized"] is False
+    ids = {s["surface"]["id"] for s in body["surfaces"]}
+    assert {"community-learning-intake", "network-atlas-framework-catalog",
+            "model-card-promotion-evidence", "serve-readiness"} <= ids
+
+
+def test_serve_readiness_does_not_claim_production():
+    r = client.get("/tritfabric/serve-readiness")
+    assert r.status_code == 200 and r.json()["serve_deployment"] is False

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -32,6 +32,7 @@ spec:
           - { name: owl-reasoner }
           - { name: entity-resolution }
           - { name: memoryd }
+          - { name: tritfabric-consumption-api }
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —
           # NOT touched by the build-image/gitops-promote SHA pipeline above, since

--- a/deploy/values/tritfabric-consumption-api.yaml
+++ b/deploy/values/tritfabric-consumption-api.yaml
@@ -1,0 +1,7 @@
+# tritfabric-consumption-api — prophet-platform consumption surface for TritFabric (apps/tritfabric-consumption-api).
+# Reports readiness for the four TritFabric surfaces (community-learning intake, framework catalog, promotion
+# evidence, serve readiness) from the integration contract — deliberately NON-mutating (mutation_authorized:false),
+# a pre-infrastructure readiness reporter, not the Serve runtime. tag:latest → sha-pinned after first build.
+image: { repository: tritfabric-consumption-api, tag: latest }
+service: { port: 8080, portName: http }
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -99,6 +99,10 @@ KNOWN_BROKEN = {
         "New service — memory-mesh's memoryd vendored into prophet-platform CI this PR, so it BUILDS with the "
         "estate WIF. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
     ),
+    "tritfabric-consumption-api:moving-tag": (
+        "New service — TritFabric consumption API containerized + wired to prophet-platform CI this PR (it had "
+        "app code but no image build). Pin tag:latest -> the sha- tag after the first CI build; none exists yet."
+    ),
     # The chart has said "Immutable tag = the commit SHA" since it was written; these
     # 9 predate the check. Pinning them is mechanical BUT NOT SAFE TO BATCH: `latest`
     # + IfNotPresent means nodes may be running an older cached digest than `latest`


### PR DESCRIPTION
## Why
Completes the "ship everything via CI, no secrets needed" pass. The TritFabric consumption API had real app code (`apps/tritfabric-consumption-api/main.py` — FastAPI readiness surfaces) but **no image build**, so it never deployed. Same fix as memoryd: containerize + wire the estate CI.

## What
- **Root-context Dockerfile** so the integration contract (`contracts/integrations/tritfabric-consumption.v0.json`) travels with the app.
- **requirements.txt + tests** — healthz, all four readiness surfaces present, and serve-readiness stays non-mutating.
- **Wired**: `images.yml` build · `deploy/values` + ApplicationSet · Makefile `-smoke` + diagnostics matrix · preflight moving-tag allowance.

## Honest scope
This is the **consumption/readiness surface** — deliberately non-mutating (`mutation_authorized:false`, a pre-infrastructure reporter for community-learning intake / framework catalog / promotion evidence / serve readiness). It is **not** the TritFabric Serve runtime (the full Go server), which is separate infra.

## Test
`make tritfabric-consumption-api-smoke` green (3 tests). Preflight exit 0, ratcheted.

## Stacked on #785 (memoryd)
Shares the images.yml/ApplicationSet/preflight/diagnostics edits; merge #785 first, then this rebases clean.