### PR TITLE
lattice-studio: graph.ttl exports edges (not nodes-only) + PROV-O activity resource

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -336,11 +336,11 @@ async def graph_ttl(project: str = "default", limit: int = 500) -> Response:
     dct:source, prov:wasGeneratedBy. Their RDF exports drop provenance; ours doesn't — epistemic status + origin
     ride the standard triples, so a proof-carrying graph stays proof-carrying when it leaves us.
     """
-    from rdflib import Graph as RDFGraph, Literal, Namespace
+    from rdflib import Graph as RDFGraph, Literal, Namespace, URIRef
     from rdflib.namespace import DCTERMS, PROV, RDF, RDFS
 
     coll = proj_collection(project)
-    nodes, _ = await _fetch_nodes(coll, limit)
+    nodes, edges, _ = await _fetch_subgraph(coll, limit)   # nodes AND edges — the reasoner needs relations
     g = RDFGraph()
     # KKO (KBpedia Knowledge Ontology) is the estate's upper ontology — the export types INTO it, so the graph
     # is grounded in a formal, open (CC-BY-4.0), Peircean upper ontology that Protégé/GraphDB/Anzo/Stardog already
@@ -349,12 +349,28 @@ async def graph_ttl(project: str = "default", limit: int = 500) -> Response:
     SP = Namespace("https://socioprophet.ai/kg#")
     PROJ = Namespace(f"https://socioprophet.ai/kg/{coll}/")
     g.bind("kko", KKO); g.bind("sp", SP); g.bind("proj", PROJ); g.bind("prov", PROV); g.bind("dct", DCTERMS)
+
+    def _local(node_id: str) -> URIRef:
+        return PROJ[(node_id.split(":")[-1] or "node")]
+
     for n in nodes:
-        u = PROJ[(n["id"].split(":")[-1] or "node")]
+        u = _local(n["id"])
         g.add((u, RDF.type, KKO[n.get("kko_type", "Particulars")]))  # KKO upper-ontology type (Peircean)
         g.add((u, RDFS.label, Literal(n["name"])))
         # epistemic_mode is a Peircean inference status (KKO kko:Methodeutic) — provenance grounded in the standard.
         g.add((u, SP.epistemicMode, Literal(n["epistemic_mode"])))
         if n.get("source"): g.add((u, DCTERMS.source, Literal(n["source"])))
-        if n.get("extractor"): g.add((u, PROV.wasGeneratedBy, Literal(n["extractor"])))
+        # PROV-O: wasGeneratedBy must reference a prov:Activity RESOURCE, not a bare literal.
+        if n.get("extractor"):
+            act = SP[f"activity/{str(n['extractor']).replace(' ', '_')}"]
+            g.add((act, RDF.type, PROV.Activity))
+            g.add((u, PROV.wasGeneratedBy, act))
+    # Edges — WITHOUT these the exported graph is a bag of typed nodes with NO relations, and a reasoner
+    # pulling graph.ttl has nothing to reason over. Each edge becomes a real predicate triple; the label
+    # (e.g. co_occurs) is minted under the sp: vocabulary so it is a dereferenceable property.
+    for e in edges:
+        src, tgt, label = e.get("source"), e.get("target"), e.get("label") or "relatedTo"
+        if not src or not tgt:
+            continue
+        g.add((_local(src), SP[str(label)], _local(tgt)))
     return Response(content=g.serialize(format="turtle"), media_type="text/turtle")

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -118,27 +118,34 @@ def test_subgraph_maps_induced_edges(monkeypatch):
     assert e["label"] == "CO_OCCURS" and e["weight"] == 3
 
 
-def test_rdf_export_carries_provenance(monkeypatch):
-    # KE-3: the RDF/Turtle export must carry epistemic_mode + provenance as standard triples (PROV-O / DCT).
+def test_rdf_export_carries_provenance_AND_edges(monkeypatch):
+    # KE-3: the RDF/Turtle export must carry epistemic_mode + provenance AND the RELATIONS (edges) — without
+    # edges the exported graph is a bag of typed nodes a reasoner can't reason over (the compounding bug).
     import lattice_studio.server as srv
 
-    async def fake_nodes(coll, limit=200):
-        return [{"id": f"{coll}:ent:hellgraph", "name": "HellGraph", "epistemic_mode": "observed",
-                 "source": "doc:kg", "extractor": "lattice-studio/deterministic-v0",
-                 "kko_type": "Particulars", "labels": [coll, "Entity"]}], None
-    monkeypatch.setattr(srv, "_fetch_nodes", fake_nodes)
+    async def fake_subgraph(coll, limit=200):
+        nodes = [
+            {"id": f"{coll}:ent:hellgraph", "name": "HellGraph", "epistemic_mode": "observed",
+             "source": "doc:kg", "extractor": "lattice-studio/deterministic-v0", "kko_type": "Particulars"},
+            {"id": f"{coll}:ent:atomspace", "name": "AtomSpace", "epistemic_mode": "observed", "kko_type": "Particulars"},
+        ]
+        edges = [{"id": "e1", "source": f"{coll}:ent:hellgraph", "target": f"{coll}:ent:atomspace",
+                  "label": "co_occurs", "weight": 3}]
+        return nodes, edges, None
+    monkeypatch.setattr(srv, "_fetch_subgraph", fake_subgraph)
 
     r = client.get("/api/studio/graph.ttl?project=team-x")
-    assert r.status_code == 200
-    assert "text/turtle" in r.headers["content-type"]
+    assert r.status_code == 200 and "text/turtle" in r.headers["content-type"]
     ttl = r.text
-    # KKO upper ontology: the node types INTO KKO (Peircean Particulars) — standards-grounded, not ad-hoc
-    assert "kko:" in ttl and "kko:Particulars" in ttl
-    assert "http://kbpedia.org/ontologies/kko#" in ttl
-    # provenance survives export: epistemic mode + source + generator ride the RDF (the moat, on export)
+    assert "kko:Particulars" in ttl and "http://kbpedia.org/ontologies/kko#" in ttl
     assert "sp:epistemicMode" in ttl and '"observed"' in ttl
-    assert "dct:source" in ttl and "prov:wasGeneratedBy" in ttl
-    assert 'rdfs:label "HellGraph"' in ttl
-    # and it's valid Turtle a semantic-web tool can parse
-    from rdflib import Graph as RDFGraph
-    assert len(RDFGraph().parse(data=ttl, format="turtle")) >= 4
+    assert "dct:source" in ttl and "prov:wasGeneratedBy" in ttl and 'rdfs:label "HellGraph"' in ttl
+    # PROV-O correctness: wasGeneratedBy points at a prov:Activity RESOURCE, not a bare literal
+    assert "prov:Activity" in ttl
+    # THE FIX: the co_occurs RELATION is exported as a real predicate triple between the two entities
+    from rdflib import Graph as RDFGraph, Namespace
+    rg = RDFGraph().parse(data=ttl, format="turtle")
+    SP = Namespace("https://socioprophet.ai/kg#")
+    rels = [(s, o) for s, p, o in rg if p == SP["co_occurs"]]
+    assert len(rels) == 1, "the co_occurs edge must be exported as an RDF relation"
+    assert "hellgraph" in str(rels[0][0]) and "atomspace" in str(rels[0][1])


### PR DESCRIPTION
## Why (deep audit — compounding bug)
`/api/studio/graph.ttl` called `_fetch_nodes` and emitted a **bag of typed nodes with zero relations**. The owl-reasoner's `/reason/project` pulls exactly this TTL — so **it had nothing to reason over** (entailments on real project graphs were near-trivial), and the `co_occurs` relations the extractor writes never left the graph. Plus `prov:wasGeneratedBy` pointed at a **literal** (PROV-O misuse).

## Fix
- `graph.ttl` now reads the **induced subgraph (nodes AND edges)** and emits each edge as a real predicate triple `proj:src sp:<label> proj:tgt` — relations survive export, so a puller can reason/traverse.
- `prov:wasGeneratedBy` now references a `prov:Activity` **resource**, not a bare literal.

## Test
151 green — the export test now asserts the `co_occurs` edge round-trips as an RDF relation and `prov:Activity` is present.