### PR TITLE
memoryd: real semantic embeddings via a sovereign endpoint (replace the hashing toy)

### DIFF
--- a/apps/memoryd/src/memoryd/embedding.py
+++ b/apps/memoryd/src/memoryd/embedding.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import math
+import os
 from dataclasses import dataclass
+
+import httpx
 
 
 @dataclass(frozen=True)
@@ -30,3 +33,68 @@ class HashingEmbedder:
     @staticmethod
     def _tokenize(text: str) -> list[str]:
         return [token.strip(".,!?;:()[]{}\n\t\r\"'").lower() for token in text.split()]
+
+
+@dataclass(frozen=True)
+class RemoteEmbedder:
+    """Real SEMANTIC embeddings from a SOVEREIGN embedding endpoint (a local Ollama or any OpenAI-compatible
+    /v1/embeddings server — no vendor lock, runs on the node). This is what makes 'car' ≈ 'automobile' instead
+    of orthogonal, the thing the hashing embedder structurally cannot do. Handles both the OpenAI shape
+    ({data:[{embedding}]}) and the Ollama native shape ({embedding} / {embeddings:[...]})."""
+
+    url: str
+    model: str
+    dimension: int
+    api_key: str = ''
+    timeout: float = 10.0
+
+    def embed(self, text: str) -> list[float]:
+        headers = {'content-type': 'application/json'}
+        if self.api_key:
+            headers['authorization'] = f'Bearer {self.api_key}'
+        r = httpx.post(self.url, json={'model': self.model, 'input': text}, headers=headers, timeout=self.timeout)
+        r.raise_for_status()
+        vec = _extract_embedding(r.json())
+        if not vec:
+            raise ValueError('embedding endpoint returned no vector')
+        return vec
+
+    def probe(self) -> bool:
+        """One startup probe — is the endpoint reachable and returning vectors? Decides embedder selection ONCE
+        so the whole store shares one vector space (never mix semantic + hashed vectors, which are incomparable)."""
+        try:
+            return len(self.embed('probe')) > 0
+        except Exception:  # noqa: BLE001
+            return False
+
+
+def _extract_embedding(body: object) -> list[float]:
+    if isinstance(body, dict):
+        if isinstance(body.get('embedding'), list):                       # Ollama native
+            return [float(x) for x in body['embedding']]
+        emb = body.get('embeddings')
+        if isinstance(emb, list) and emb and isinstance(emb[0], list):    # Ollama batch
+            return [float(x) for x in emb[0]]
+        data = body.get('data')
+        if isinstance(data, list) and data and isinstance(data[0], dict): # OpenAI shape
+            return [float(x) for x in data[0].get('embedding', [])]
+    return []
+
+
+def build_embedder(dimension: int, salt: str) -> object:
+    """Select the embedder ONCE at startup. If EMBEDDINGS_URL is set AND reachable → real semantic vectors;
+    otherwise the deterministic hashing fallback (honest: logs which, so retrieval quality is never a mystery)."""
+    url = os.getenv('EMBEDDINGS_URL', '').strip()
+    if url:
+        remote = RemoteEmbedder(
+            url=url,
+            model=os.getenv('EMBEDDINGS_MODEL', 'nomic-embed-text'),
+            dimension=dimension,
+            api_key=os.getenv('EMBEDDINGS_API_KEY', ''),
+            timeout=float(os.getenv('EMBEDDINGS_TIMEOUT', '10')),
+        )
+        if remote.probe():
+            print(f'[memoryd] semantic embeddings ACTIVE via {url} ({remote.model})')
+            return remote
+        print(f'[memoryd] EMBEDDINGS_URL set ({url}) but unreachable — falling back to hashing embedder')
+    return HashingEmbedder(dimension=dimension, salt=salt)

--- a/apps/memoryd/src/memoryd/main.py
+++ b/apps/memoryd/src/memoryd/main.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 from fastapi import FastAPI, Header, HTTPException
 from fastapi.responses import StreamingResponse
 
-from .embedding import HashingEmbedder
+from .embedding import HashingEmbedder, build_embedder
 from .mem0_client import Mem0RestClient
 from .hellgraph_retract import HellGraphRetractClient, revocation_source_refs
 from .models import (
@@ -58,7 +58,7 @@ vector_index = QdrantMemoryIndex(
     enabled=QDRANT_ENABLED and bool(QDRANT_URL),
     timeout_seconds=float(os.getenv('QDRANT_TIMEOUT_SECONDS', '10')),
 )
-embedder = HashingEmbedder(dimension=VECTOR_SIZE, salt=EMBEDDING_SALT)
+embedder = build_embedder(dimension=VECTOR_SIZE, salt=EMBEDDING_SALT)
 
 # Revocation propagates into the graph materialization (graceful-degrade if HELLGRAPH_URL unset).
 hellgraph_retract = HellGraphRetractClient(

--- a/apps/memoryd/tests/test_memoryd.py
+++ b/apps/memoryd/tests/test_memoryd.py
@@ -16,3 +16,43 @@ def test_healthz_on_inmemory_store():
 def test_root_identifies_service():
     r = client.get("/")
     assert r.status_code == 200
+
+
+# ── Semantic embeddings (sovereign endpoint) ──────────────────────────────────
+def test_extract_embedding_handles_openai_and_ollama_shapes():
+    from memoryd.embedding import _extract_embedding
+    assert _extract_embedding({"embedding": [1.0, 2.0]}) == [1.0, 2.0]            # Ollama native
+    assert _extract_embedding({"embeddings": [[3.0, 4.0]]}) == [3.0, 4.0]         # Ollama batch
+    assert _extract_embedding({"data": [{"embedding": [5.0, 6.0]}]}) == [5.0, 6.0]  # OpenAI
+    assert _extract_embedding({"nope": 1}) == []
+
+
+def test_build_embedder_defaults_to_hashing_without_url(monkeypatch):
+    monkeypatch.delenv("EMBEDDINGS_URL", raising=False)
+    from memoryd.embedding import build_embedder, HashingEmbedder
+    e = build_embedder(dimension=8, salt="s")
+    assert isinstance(e, HashingEmbedder)
+
+
+def test_build_embedder_uses_remote_when_reachable(monkeypatch):
+    monkeypatch.setenv("EMBEDDINGS_URL", "http://sovereign-embed/v1/embeddings")
+    monkeypatch.setenv("EMBEDDINGS_MODEL", "nomic-embed-text")
+    import memoryd.embedding as emb
+
+    class FakeResp:
+        def raise_for_status(self): pass
+        def json(self): return {"data": [{"embedding": [0.1, 0.2, 0.3]}]}
+    monkeypatch.setattr(emb.httpx, "post", lambda *a, **k: FakeResp())
+
+    e = emb.build_embedder(dimension=3, salt="s")
+    assert isinstance(e, emb.RemoteEmbedder)
+    assert e.embed("car") == [0.1, 0.2, 0.3]        # real semantic vector, not a hash
+
+
+def test_build_embedder_falls_back_when_endpoint_unreachable(monkeypatch):
+    monkeypatch.setenv("EMBEDDINGS_URL", "http://down/v1/embeddings")
+    import memoryd.embedding as emb
+    def boom(*a, **k): raise RuntimeError("connection refused")
+    monkeypatch.setattr(emb.httpx, "post", boom)
+    e = emb.build_embedder(dimension=4, salt="s")
+    assert isinstance(e, emb.HashingEmbedder)        # consistent vector space, never mixed


### PR DESCRIPTION
## Why (deep audit — the #1 feature gap)
memoryd's only embedder was `HashingEmbedder` — signed feature-hashing, so **"car" and "automobile" are orthogonal** (cosine 0). Recall was lexical-with-collisions, strictly worse than BM25. Even the Qdrant path was fed these toy vectors.

## What
- **`RemoteEmbedder`** — real vectors from a **sovereign embeddings endpoint** (a local Ollama, or any OpenAI-compatible `/v1/embeddings` server — no vendor lock, runs on the node). Handles both the OpenAI (`{data:[{embedding}]}`) and Ollama (`{embedding}`/`{embeddings}`) response shapes.
- **`build_embedder()`** selects **once at startup** with a probe: `EMBEDDINGS_URL` set + reachable → semantic vectors for the whole store; otherwise the deterministic hashing fallback. It **never mixes the two incomparable vector spaces**, and logs which is active so retrieval quality is never a mystery.

Opt-in (`EMBEDDINGS_URL`/`EMBEDDINGS_MODEL`/`EMBEDDINGS_API_KEY`), fail-safe.

## Test
6 tests green — response-shape parsing for both providers, default-to-hashing without a URL, remote-when-reachable (returns the real vector), and fallback-on-unreachable (consistent space).

## Same pattern next
commons-search + hellgraph-service GraphRAG get the identical sovereign-embedding wiring (follow-up PRs) — "one embedding model fixes all three."