### PR TITLE
graphrag: semantic (embedding) retrieval + configurable multi-hop

### DIFF
--- a/apps/hellgraph-service/src/graphrag.ts
+++ b/apps/hellgraph-service/src/graphrag.ts
@@ -71,14 +71,23 @@ export function retrieveGrounding(g: GraphSource, question: string, maxCitations
   const seeds = scored.map((s) => s.id)
   const seedSet = new Set(seeds)
 
-  // 2. expand to the 1-hop neighbourhood — the facts a human would cite come from around the seed.
-  const grounded = new Set(seeds)
-  for (const e of g.allEdges()) {
-    if (seedSet.has(e.from)) grounded.add(e.to)
-    if (seedSet.has(e.to)) grounded.add(e.from)
-  }
+  return groundingFromSeeds(g, seeds, 1, maxCitations)
+}
 
-  // 3. facts = triples whose SUBJECT is a grounded node → numbered, provenance-carrying citations.
+/** From seed node ids: expand `hops` neighbourhood, then emit the grounded facts as numbered citations. */
+function groundingFromSeeds(g: GraphSource, seeds: string[], hops: number, maxCitations: number): Grounding {
+  const grounded = new Set(seeds)
+  const edges = g.allEdges()
+  let frontier = new Set(seeds)
+  for (let h = 0; h < Math.max(1, hops); h++) {
+    const next = new Set<string>()
+    for (const e of edges) {
+      if (frontier.has(e.from) && !grounded.has(e.to)) { grounded.add(e.to); next.add(e.to) }
+      if (frontier.has(e.to) && !grounded.has(e.from)) { grounded.add(e.from); next.add(e.from) }
+    }
+    if (next.size === 0) break
+    frontier = next
+  }
   const facts = g.triples().filter((t) => grounded.has(t.subject))
   const citations: Citation[] = facts.slice(0, maxCitations).map((t, i) => ({
     n: i + 1,
@@ -87,6 +96,60 @@ export function retrieveGrounding(g: GraphSource, question: string, maxCitations
     assertedAt: t.assertedAt,
   }))
   return { seeds, groundedNodes: [...grounded], citations }
+}
+
+// ── Semantic retrieval over a sovereign embeddings endpoint (opt-in) ────────────────────────────────
+interface EmbedConfig { url: string; model: string; key: string }
+function embedConfig(): EmbedConfig | null {
+  const url = (process.env['EMBEDDINGS_URL'] ?? '').trim()
+  if (!url) return null
+  return { url, model: process.env['EMBEDDINGS_MODEL'] ?? 'nomic-embed-text', key: process.env['EMBEDDINGS_API_KEY'] ?? '' }
+}
+export function semanticEnabled(): boolean { return embedConfig() !== null }
+
+const embedCache = new Map<string, number[]>()
+async function embed(text: string, cfg: EmbedConfig, fetchImpl: typeof fetch): Promise<number[] | null> {
+  const cached = embedCache.get(text); if (cached) return cached
+  try {
+    const headers: Record<string, string> = { 'content-type': 'application/json' }
+    if (cfg.key) headers['authorization'] = `Bearer ${cfg.key}`
+    const res = await fetchImpl(cfg.url, { method: 'POST', headers, body: JSON.stringify({ model: cfg.model, input: text }), signal: AbortSignal.timeout(10_000) })
+    if (!res.ok) return null
+    const body = await res.json() as any
+    const v: number[] = body?.embedding ?? body?.embeddings?.[0] ?? body?.data?.[0]?.embedding ?? []
+    if (!Array.isArray(v) || v.length === 0) return null
+    if (embedCache.size < 50_000) embedCache.set(text, v)
+    return v
+  } catch { return null }
+}
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0, na = 0, nb = 0
+  const n = Math.min(a.length, b.length)
+  for (let i = 0; i < n; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i] }
+  return na && nb ? dot / (Math.sqrt(na) * Math.sqrt(nb)) : 0
+}
+
+/** Auto retrieval: SEMANTIC (embedding cosine) seeding when EMBEDDINGS_URL is configured + reachable, else the
+ * lexical substring path. `hops` configurable (default 1). Fixes the audit's "substring + fixed-1-hop" finding. */
+export async function retrieveGroundingAuto(g: GraphSource, question: string, hops = 1, maxCitations = MAX_CITATIONS, fetchImpl: typeof fetch = fetch): Promise<Grounding & { retrieval: string }> {
+  const cfg = embedConfig()
+  if (cfg) {
+    const qv = await embed(question, cfg, fetchImpl)
+    if (qv) {
+      const nodes = g.allNodes()
+      const scored: { id: string; score: number }[] = []
+      for (const nd of nodes) {
+        const nv = await embed(nodeText(nd), cfg, fetchImpl)
+        if (nv) scored.push({ id: nd.id, score: cosine(qv, nv) })
+      }
+      if (scored.length) {
+        const seeds = scored.sort((a, b) => b.score - a.score).slice(0, MAX_SEEDS).filter((s) => s.score > 0.2).map((s) => s.id)
+        return { ...groundingFromSeeds(g, seeds, hops, maxCitations), retrieval: `semantic (${cfg.model})` }
+      }
+    }
+  }
+  return { ...groundingFromSeeds(g, retrieveGrounding(g, question, maxCitations).seeds, hops, maxCitations), retrieval: 'lexical (substring)' }
 }
 
 interface LlmConfig { url: string; model: string; key: string }
@@ -100,7 +163,7 @@ export function synthesisEnabled(): boolean { return llmConfig() !== null }
 
 /** Ask a question over the graph: retrieve grounding, then synthesize a cited answer (opt-in, fail-open). */
 export async function askGraph(g: GraphSource, question: string, fetchImpl: typeof fetch = fetch): Promise<AskResult> {
-  const { citations } = retrieveGrounding(g, question)
+  const { citations } = await retrieveGroundingAuto(g, question, 1, MAX_CITATIONS, fetchImpl)
   const grounded = citations.length > 0
   const cfg = llmConfig()
   if (!cfg || !grounded) return { question, answer: '', citations, synthesized: false, grounded }

--- a/apps/hellgraph-service/src/server.test.ts
+++ b/apps/hellgraph-service/src/server.test.ts
@@ -5,6 +5,7 @@
  */
 import { test, before, after } from 'node:test'
 import assert from 'node:assert/strict'
+import { retrieveGroundingAuto } from './graphrag.js'
 
 process.env.PORT = String(19091) // free test port, read at module import
 process.env.HELLGRAPH_STORE_DIR = `${process.env.TMPDIR ?? '/tmp'}/hgsvc-test-${process.pid}`
@@ -213,4 +214,42 @@ test('graphrag: /ask degrades to facts-only when no sovereign LLM is configured 
   assert.equal(r.json.grounded, true)          // but it DID ground in the graph
   assert.ok(r.json.citations.length >= 1)
   assert.equal((await req('POST', '/api/graph/ask', {})).status, 400)     // question required
+})
+
+test('graphrag: SEMANTIC retrieval seeds by embedding cosine, not substring (fake sovereign endpoint)', async () => {
+  const nodes = [
+    { id: 'n:cat', labels: ['Topic'], properties: { name: 'feline pets' } },
+    { id: 'n:fin', labels: ['Topic'], properties: { name: 'stock market' } },
+  ]
+  const triples = [
+    { subject: 'n:cat', predicate: 'name', object: 'feline pets', isIri: false, assertedAt: 't' },
+    { subject: 'n:fin', predicate: 'name', object: 'stock market', isIri: false, assertedAt: 't' },
+  ]
+  const g = { allNodes: () => nodes, allEdges: () => [], triples: () => triples } as any
+  // fake embeddings: anything about cats → [1,0]; finance → [0,1]. The QUERY word "kitten" shares no
+  // substring with "feline pets" — only a semantic embedder can connect them.
+  const fakeFetch = (async (_u: any, opts: any) => {
+    const text = JSON.parse(opts.body).input as string
+    const vec = /kitten|feline|cat|pet/i.test(text) ? [1, 0] : [0, 1]
+    return { ok: true, json: async () => ({ data: [{ embedding: vec }] }) }
+  }) as any
+  process.env.EMBEDDINGS_URL = 'http://fake/embed'
+  try {
+    const gr = await retrieveGroundingAuto(g, 'tell me about a kitten', 1, 24, fakeFetch)
+    assert.match(gr.retrieval, /semantic/)
+    assert.ok(gr.seeds.includes('n:cat') && !gr.seeds.includes('n:fin'), 'semantic seed = cat, not finance')
+  } finally { delete process.env.EMBEDDINGS_URL }
+})
+
+test('graphrag: multi-hop grounding reaches beyond 1 hop (?hops=2)', async () => {
+  const S = `hop-${process.pid}`
+  await req('POST', '/api/graph/node', { id: `${S}:a`, labels: ['N'], properties: { name: 'Alpha' } })
+  await req('POST', '/api/graph/node', { id: `${S}:b`, labels: ['N'] })
+  await req('POST', '/api/graph/node', { id: `${S}:c`, labels: ['N'] })
+  await req('POST', '/api/graph/edge', { label: 'to', from: `${S}:a`, to: `${S}:b` })
+  await req('POST', '/api/graph/edge', { label: 'to', from: `${S}:b`, to: `${S}:c` })
+  const r1 = await req('GET', `/api/graph/ground?q=Alpha&hops=1`)
+  const r2 = await req('GET', `/api/graph/ground?q=Alpha&hops=2`)
+  assert.ok(r1.json.groundedNodes.includes(`${S}:b`) && !r1.json.groundedNodes.includes(`${S}:c`))
+  assert.ok(r2.json.groundedNodes.includes(`${S}:c`), '2-hop must reach c through b')
 })

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -13,7 +13,7 @@
  *   GET  /api/graph/query?label=X  nodes carrying a label
  *   GET  /api/graph/subgraph?label=X  induced subgraph (nodes + internal edges) for an explorer
  *   GET  /api/graph/resource?uri=X    dereferenceable resource CBD, content-negotiated (Turtle/JSON-LD/HTML/JSON)
- *   GET  /api/graph/ground?q=X        GraphRAG retrieval: seeds + 1-hop facts as provenance-carrying citations
+ *   GET  /api/graph/ground?q=X&hops=N  GraphRAG retrieval: semantic (embedding) or lexical seeds + N-hop facts as citations
  *   POST /api/graph/ask            { question } → GraphRAG cited answer grounded in the graph (sovereign LLM, opt-in)
  *   POST /api/graph/reason         run PLN forward-chaining → counts
  *   POST /api/graph/sparql         { query }  → SPARQL 1.1 SELECT/CONSTRUCT subset (BGP, FILTER, OPTIONAL,
@@ -35,7 +35,7 @@ process.env['HELLGRAPH_STORE_DIR'] ||= path.join(os.homedir(), '.hellgraph-servi
 import * as engine from '@socioprophet/hellgraph'
 import { getHellGraph, getAtomSpace, attachRocksDB, forwardChain, runSparql, runGremlin, runCypher, shaclValidate } from '@socioprophet/hellgraph'
 import { describeResource, toTurtle, toJsonLd, toHtml, negotiate } from './resource.js'
-import { askGraph, retrieveGrounding, synthesisEnabled } from './graphrag.js'
+import { askGraph, retrieveGrounding, retrieveGroundingAuto, synthesisEnabled, semanticEnabled } from './graphrag.js'
 import { pagerank, connectedComponents, analyticsBackend } from './analytics.js'
 
 const PORT = Number(process.env.PORT ?? 8090)
@@ -140,7 +140,9 @@ const server = http.createServer((req, res) => {
   if (req.method === 'GET' && url.pathname === '/api/graph/ground') {
     const q = url.searchParams.get('q') ?? ''
     if (!q) return json(res, 400, { error: 'q (question) required' })
-    return json(res, 200, { question: q, ...retrieveGrounding(g, q) })
+    const hops = Math.min(Math.max(Number(url.searchParams.get('hops') ?? 1), 1), 4)
+    return void retrieveGroundingAuto(g, q, hops).then((grounding) =>
+      json(res, 200, { question: q, semanticEnabled: semanticEnabled(), ...grounding }))
   }
   if (req.method === 'POST' && url.pathname === '/api/graph/ask') {
     return void readBody(req).then(async (b) => {


### PR DESCRIPTION
## Why (deep audit)
GraphRAG retrieval was **substring-match** on node text (no stemming, spurious hits like `art`⊂`Bart`, blind to paraphrase) and **fixed at 1 hop** — MS-GraphRAG/Cognee use embeddings + multi-hop.

## What
- **`retrieveGroundingAuto`** — when `EMBEDDINGS_URL` is configured + reachable, seeds by **embedding cosine** over a sovereign endpoint (Ollama / OpenAI-compatible, same client as memoryd #793), so *"kitten"* retrieves a *"feline pets"* node it shares no substring with. Falls back to the lexical path otherwise and **reports which retrieval served the result**. Embedding cache bounds endpoint calls.
- **Configurable N-hop** (`?hops=1..4`) instead of hardcoded 1-hop.
- Wired into `/api/graph/ground` and `/api/graph/ask`.

## Test
17 service tests green (+2): semantic seeding via a fake sovereign endpoint picks the semantically-nearest node (not the substring one); 2-hop reaches `c` through `b`.

Pairs with memoryd #793 — the same sovereign embedding wiring, "one model fixes all three" (commons-search next).