### PR TITLE
socioprophet-web: Prophet Studio — a real multi-workbench console over the live services

### DIFF
--- a/apps/socioprophet-web/nginx.conf
+++ b/apps/socioprophet-web/nginx.conf
@@ -67,6 +67,14 @@ http {
         }
 
         # SPA history-mode fallback: unknown paths render the app, not a 404.
+        # Prophet Studio → platform services (same namespace; Service DNS resolves in-cluster).
+        # The trailing slash on proxy_pass strips the /svc/<name> prefix, so /svc/hellgraph/api/graph/stats
+        # → http://hellgraph-service:8090/api/graph/stats.
+        location /svc/hellgraph/ { proxy_pass http://hellgraph-service:8090/; proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /svc/reason/    { proxy_pass http://owl-reasoner:8080/;      proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /svc/er/        { proxy_pass http://entity-resolution:8080/; proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /svc/studio/    { proxy_pass http://lattice-studio:8080/;    proxy_http_version 1.1; proxy_set_header Host $host; }
+
         location / {
             try_files $uri $uri/ /index.html;
         }

--- a/apps/socioprophet-web/src/App.vue
+++ b/apps/socioprophet-web/src/App.vue
@@ -1,56 +1,72 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import GygCausalValuationCard from './components/GygCausalValuationCard.vue'
-import GygLocationsMapCard from './components/GygLocationsMapCard.vue'
-import ChronosEvidenceLoopCard from './components/ChronosEvidenceLoopCard.vue'
-import DevSecOpsWorkroomReportCard from './components/DevSecOpsWorkroomReportCard.vue'
-import HealthAIDemoReadinessCard from './components/HealthAIDemoReadinessCard.vue'
-import ProphetMeshRuntimeReadinessCard from './components/ProphetMeshRuntimeReadinessCard.vue'
+import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
+import './studio/studio.css'
+import Overview from './views/Overview.vue'
+import GraphExplorer from './views/GraphExplorer.vue'
+import QueryConsole from './views/QueryConsole.vue'
+import Analytics from './views/Analytics.vue'
+import GraphRAG from './views/GraphRAG.vue'
+import Reasoner from './views/Reasoner.vue'
+import EntityResolution from './views/EntityResolution.vue'
+import ResourceBrowser from './views/ResourceBrowser.vue'
+import Ontology from './views/Ontology.vue'
 
-const status = ref<'idle'|'ok'|'err'>('idle')
-const pong = ref('')
+const NAV = [
+  { group: 'Explore', items: [
+    { id: 'overview', label: 'Overview', ic: '◱', comp: Overview, sub: 'Platform health & program readouts' },
+    { id: 'explorer', label: 'Graph Explorer', ic: '⟡', comp: GraphExplorer, sub: 'Force-directed graph + provenance inspector' },
+    { id: 'resource', label: 'Resource Browser', ic: '◈', comp: ResourceBrowser, sub: 'Dereferenceable Linked Data' },
+  ]},
+  { group: 'Query & Analyze', items: [
+    { id: 'query', label: 'Query Console', ic: '⌘', comp: QueryConsole, sub: 'SPARQL · Cypher · Gremlin' },
+    { id: 'analytics', label: 'Analytics', ic: '📈', comp: Analytics, sub: 'PageRank / components on the Rust kernel' },
+    { id: 'graphrag', label: 'GraphRAG', ic: '✦', comp: GraphRAG, sub: 'Ask the graph, cited answers' },
+  ]},
+  { group: 'Reason & Resolve', items: [
+    { id: 'reasoner', label: 'Reasoner', ic: '⊢', comp: Reasoner, sub: 'RDFS/OWL entailment + proof trees' },
+    { id: 'er', label: 'Entity Resolution', ic: '⚭', comp: EntityResolution, sub: 'Proof-carrying record linkage' },
+    { id: 'ontology', label: 'Ontology', ic: '❖', comp: Ontology, sub: 'Docs + TBox graph' },
+  ]},
+]
+const flat = NAV.flatMap((g) => g.items)
+const current = ref('overview')
+const active = computed(() => flat.find((i) => i.id === current.value) ?? flat[0])
 
-async function check() {
-  try {
-    const res = await fetch('/api/health')
-    const j = await res.json()
-    status.value = j.ok ? 'ok' : 'err'
-    pong.value = j.pong || ''
-  } catch (e) {
-    status.value = 'err'
-    pong.value = ''
-  }
+function route() {
+  const id = location.hash.replace(/^#/, '').split(':')[0]
+  if (flat.some((i) => i.id === id)) current.value = id
 }
-onMounted(check)
+function go(id: string) { location.hash = id; current.value = id }
+onMounted(() => { route(); window.addEventListener('hashchange', route) })
+onBeforeUnmount(() => window.removeEventListener('hashchange', route))
 </script>
 
 <template>
-  <main style="font-family: ui-sans-serif, system-ui; padding: 2rem; max-width: 1100px; margin: 0 auto;">
-    <header style="display:flex; align-items:center; gap:0.75rem; margin-bottom: 1rem;">
-      <svg width="32" height="32" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5"/>
-        <path d="M7 12h10M12 7v10" stroke="currentColor" stroke-width="1.5"/>
-      </svg>
-      <h1 style="font-size: 1.5rem; font-weight: 700;">SocioProphet</h1>
-      <span v-if="status==='ok'" style="margin-left:auto; padding:0.2rem 0.5rem; border-radius:999px; border:1px solid #cbd5e1;">Connected</span>
-      <span v-else-if="status==='err'" style="margin-left:auto; padding:0.2rem 0.5rem; border-radius:999px; border:1px solid #cbd5e1;">Disconnected</span>
-      <span v-else style="margin-left:auto; padding:0.2rem 0.5rem; border-radius:999px; border:1px solid #cbd5e1;">Checking…</span>
-    </header>
-
-    <section style="border:1px solid #e2e8f0; border-radius: 12px; padding: 1rem;">
-      <h2 style="font-size:1.1rem; font-weight:600; margin:0 0 .5rem 0;">Health</h2>
-      <p style="margin:0 0 1rem 0;">Gateway → TritRPC/UDS check. Expect <code>PONG</code>.</p>
-      <div style="display:flex; gap:.5rem; align-items:center;">
-        <button @click="check" style="padding:.4rem .8rem; border:1px solid #cbd5e1; border-radius:8px; background:white;">Recheck</button>
-        <code>{{ pong.trim() }}</code>
+  <div class="studio">
+    <aside class="sidebar">
+      <div class="brand">
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="var(--accent)" stroke-width="1.6"/><path d="M7 12h10M12 7v10" stroke="var(--accent)" stroke-width="1.6"/></svg>
+        <div><b>Prophet Studio</b><br><small>sovereign data + AI platform</small></div>
       </div>
-    </section>
+      <nav class="nav">
+        <template v-for="g in NAV" :key="g.group">
+          <div class="nav-group">{{ g.group }}</div>
+          <a v-for="i in g.items" :key="i.id" :class="{ active: current === i.id }" @click="go(i.id)">
+            <span class="ic">{{ i.ic }}</span>{{ i.label }}
+          </a>
+        </template>
+      </nav>
+      <div class="foot">Every panel is a live service — proof-carrying, sovereign.</div>
+    </aside>
 
-    <GygCausalValuationCard />
-    <GygLocationsMapCard />
-    <HealthAIDemoReadinessCard />
-    <ProphetMeshRuntimeReadinessCard />
-    <ChronosEvidenceLoopCard />
-    <DevSecOpsWorkroomReportCard />
-  </main>
+    <div class="main">
+      <div class="topbar">
+        <h1>{{ active.label }}</h1>
+        <span class="sub">{{ active.sub }}</span>
+        <span class="spacer"></span>
+        <span class="pill accent">prophet-platform</span>
+      </div>
+      <div class="view"><component :is="active.comp" :key="active.id" /></div>
+    </div>
+  </div>
 </template>

--- a/apps/socioprophet-web/src/studio/ForceGraph.vue
+++ b/apps/socioprophet-web/src/studio/ForceGraph.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+/** Dependency-free force-directed graph on <canvas> — Fruchterman-Reingold-ish, with drag + click-to-select. */
+import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
+
+const props = defineProps<{ nodes: { id: string; label?: string; group?: string }[]; edges: { source: string; target: string }[] }>()
+const emit = defineEmits<{ (e: 'select', id: string): void }>()
+
+const canvas = ref<HTMLCanvasElement | null>(null)
+let raf = 0
+type P = { id: string; label: string; group?: string; x: number; y: number; vx: number; vy: number }
+let pts: P[] = []
+let idx = new Map<string, P>()
+let links: { a: P; b: P }[] = []
+let dragging: P | null = null
+let hover: P | null = null
+const PALETTE = ['#4f8cff', '#6ad2b0', '#f0b849', '#c98bff', '#ff8fa3', '#66d9e8', '#9ae66e']
+const groupColor = new Map<string, string>()
+function colorFor(g?: string): string {
+  const key = g ?? '·'
+  if (!groupColor.has(key)) groupColor.set(key, PALETTE[groupColor.size % PALETTE.length])
+  return groupColor.get(key)!
+}
+
+function build() {
+  const c = canvas.value!; const w = c.width, h = c.height
+  pts = props.nodes.slice(0, 600).map((n, i) => ({
+    id: n.id, label: n.label ?? n.id.split(/[:/#]/).pop() ?? n.id, group: n.group,
+    x: w / 2 + Math.cos(i) * (80 + i % 120), y: h / 2 + Math.sin(i) * (80 + i % 120), vx: 0, vy: 0,
+  }))
+  idx = new Map(pts.map((p) => [p.id, p]))
+  links = props.edges.map((e) => ({ a: idx.get(e.source)!, b: idx.get(e.target)! })).filter((l) => l.a && l.b)
+}
+
+function step() {
+  const c = canvas.value; if (!c) return
+  const w = c.width, h = c.height, ctx = c.getContext('2d')!
+  const k = 42 // ideal edge length scale
+  // repulsion
+  for (let i = 0; i < pts.length; i++) for (let j = i + 1; j < pts.length; j++) {
+    const a = pts[i], b = pts[j]; let dx = a.x - b.x, dy = a.y - b.y; let d2 = dx * dx + dy * dy || 0.01
+    const f = (k * k) / d2; const d = Math.sqrt(d2)
+    const fx = (dx / d) * f, fy = (dy / d) * f
+    a.vx += fx; a.vy += fy; b.vx -= fx; b.vy -= fy
+  }
+  // attraction along edges
+  for (const l of links) {
+    let dx = l.a.x - l.b.x, dy = l.a.y - l.b.y; const d = Math.sqrt(dx * dx + dy * dy) || 0.01
+    const f = (d * d) / k / 8; const fx = (dx / d) * f, fy = (dy / d) * f
+    l.a.vx -= fx; l.a.vy -= fy; l.b.vx += fx; l.b.vy += fy
+  }
+  // integrate + gravity to center + damping
+  for (const p of pts) {
+    if (p === dragging) { p.vx = p.vy = 0; continue }
+    p.vx += (w / 2 - p.x) * 0.002; p.vy += (h / 2 - p.y) * 0.002
+    p.vx *= 0.86; p.vy *= 0.86
+    p.x += Math.max(-8, Math.min(8, p.vx)); p.y += Math.max(-8, Math.min(8, p.vy))
+    p.x = Math.max(14, Math.min(w - 14, p.x)); p.y = Math.max(14, Math.min(h - 14, p.y))
+  }
+  // draw
+  ctx.clearRect(0, 0, w, h)
+  ctx.strokeStyle = 'rgba(120,140,170,0.22)'; ctx.lineWidth = 1
+  for (const l of links) { ctx.beginPath(); ctx.moveTo(l.a.x, l.a.y); ctx.lineTo(l.b.x, l.b.y); ctx.stroke() }
+  for (const p of pts) {
+    const r = p === hover ? 7 : 5
+    ctx.beginPath(); ctx.arc(p.x, p.y, r, 0, Math.PI * 2); ctx.fillStyle = colorFor(p.group); ctx.fill()
+    if (p === hover || pts.length < 60) {
+      ctx.fillStyle = '#c7d2e0'; ctx.font = '11px ui-monospace, monospace'
+      ctx.fillText(p.label.slice(0, 22), p.x + 8, p.y + 3)
+    }
+  }
+  raf = requestAnimationFrame(step)
+}
+
+function at(ev: MouseEvent): P | null {
+  const c = canvas.value!; const rect = c.getBoundingClientRect()
+  const x = (ev.clientX - rect.left) * (c.width / rect.width), y = (ev.clientY - rect.top) * (c.height / rect.height)
+  let best: P | null = null, bd = 144
+  for (const p of pts) { const d = (p.x - x) ** 2 + (p.y - y) ** 2; if (d < bd) { bd = d; best = p } }
+  return best
+}
+function down(e: MouseEvent) { dragging = at(e); if (dragging) emit('select', dragging.id) }
+function move(e: MouseEvent) {
+  hover = at(e)
+  if (dragging) { const c = canvas.value!, rect = c.getBoundingClientRect()
+    dragging.x = (e.clientX - rect.left) * (c.width / rect.width); dragging.y = (e.clientY - rect.top) * (c.height / rect.height) }
+}
+function up() { dragging = null }
+
+function resize() { const c = canvas.value; if (!c) return; const r = c.parentElement!.getBoundingClientRect(); c.width = r.width; c.height = r.height }
+onMounted(() => { resize(); build(); step(); window.addEventListener('resize', resize) })
+onBeforeUnmount(() => { cancelAnimationFrame(raf); window.removeEventListener('resize', resize) })
+watch(() => [props.nodes, props.edges], () => { resize(); build() }, { deep: true })
+</script>
+
+<template>
+  <div style="position:relative; width:100%; height:100%; min-height:420px;">
+    <canvas ref="canvas" style="width:100%; height:100%; display:block; cursor:grab;"
+      @mousedown="down" @mousemove="move" @mouseup="up" @mouseleave="up" />
+  </div>
+</template>

--- a/apps/socioprophet-web/src/studio/api.ts
+++ b/apps/socioprophet-web/src/studio/api.ts
@@ -1,0 +1,72 @@
+/**
+ * api.ts — the Prophet Studio client for the platform's real services.
+ *
+ * Every call goes to a same-origin `/svc/<service>/…` path that nginx (prod) or the Vite dev server proxies
+ * to the in-cluster service — so no CORS, no hard-coded hosts. Each service base is overridable at runtime
+ * via window.__PROPHET_API__ for bespoke ingress topologies. Errors are surfaced, never swallowed.
+ */
+type ApiMap = { hellgraph: string; reason: string; er: string; studio: string }
+const DEFAULTS: ApiMap = { hellgraph: '/svc/hellgraph', reason: '/svc/reason', er: '/svc/er', studio: '/svc/studio' }
+const CFG: ApiMap = { ...DEFAULTS, ...((globalThis as any).__PROPHET_API__ ?? {}) }
+
+export class ApiError extends Error {
+  constructor(public status: number, message: string) { super(message) }
+}
+
+async function call<T>(base: string, path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(base + path, {
+    ...init,
+    headers: { ...(init?.body ? { 'content-type': 'application/json' } : {}), ...(init?.headers ?? {}) },
+  })
+  const text = await res.text()
+  let body: any = text
+  try { body = text ? JSON.parse(text) : null } catch { /* keep raw text (e.g. turtle/html) */ }
+  if (!res.ok) throw new ApiError(res.status, (body && body.error) || text || `HTTP ${res.status}`)
+  return body as T
+}
+
+// ── hellgraph-service ────────────────────────────────────────────────────────────
+export const graph = {
+  stats: () => call<{ nodes: number; edges: number }>(CFG.hellgraph, '/api/graph/stats'),
+  subgraph: (label = '', limit = 400) =>
+    call<{ count: number; edges: number; nodes: any[]; edgeList: any[] }>(CFG.hellgraph, `/api/graph/subgraph?label=${encodeURIComponent(label)}&limit=${limit}`),
+  addNode: (id: string, labels: string[], properties: Record<string, unknown> = {}) =>
+    call(CFG.hellgraph, '/api/graph/node', { method: 'POST', body: JSON.stringify({ id, labels, properties }) }),
+  addEdge: (label: string, from: string, to: string, properties: Record<string, unknown> = {}) =>
+    call(CFG.hellgraph, '/api/graph/edge', { method: 'POST', body: JSON.stringify({ label, from, to, properties }) }),
+  sparql: (query: string) => call<any>(CFG.hellgraph, '/api/graph/sparql', { method: 'POST', body: JSON.stringify({ query }) }),
+  cypher: (query: string) => call<any>(CFG.hellgraph, '/api/graph/cypher', { method: 'POST', body: JSON.stringify({ query }) }),
+  gremlin: (query: string) => call<any>(CFG.hellgraph, '/api/graph/gremlin', { method: 'POST', body: JSON.stringify({ query }) }),
+  analytics: (metric: 'pagerank' | 'components', limit = 25) =>
+    call<any>(CFG.hellgraph, `/api/graph/analytics?metric=${metric}&limit=${limit}`),
+  resource: (uri: string) => call<any>(CFG.hellgraph, `/api/graph/resource?uri=${encodeURIComponent(uri)}`),
+  ground: (q: string, hops = 1) => call<any>(CFG.hellgraph, `/api/graph/ground?q=${encodeURIComponent(q)}&hops=${hops}`),
+  ask: (question: string) => call<any>(CFG.hellgraph, '/api/graph/ask', { method: 'POST', body: JSON.stringify({ question }) }),
+}
+
+// ── owl-reasoner ─────────────────────────────────────────────────────────────────
+export const reasoner = {
+  reason: (turtle: string, inference = 'rdfs', explain = true, shapes?: string) =>
+    call<any>(CFG.reason, '/reason', { method: 'POST', body: JSON.stringify({ turtle, inference, explain, shapes }) }),
+  ontologyDoc: (turtle: string) => call<any>(CFG.reason, '/ontology/doc', { method: 'POST', body: JSON.stringify({ turtle, format: 'json' }) }),
+  ontologyGraph: (turtle: string) => call<any>(CFG.reason, '/ontology/graph', { method: 'POST', body: JSON.stringify({ turtle }) }),
+  virtualize: (rows: any[], mapping: any) => call<any>(CFG.reason, '/virtualize', { method: 'POST', body: JSON.stringify({ rows, mapping }) }),
+}
+
+// ── entity-resolution ────────────────────────────────────────────────────────────
+export const er = {
+  resolve: (records: any[]) => call<any>(CFG.er, '/resolve', { method: 'POST', body: JSON.stringify({ records }) }),
+}
+
+export interface Health { name: string; ok: boolean; detail?: string }
+export async function health(): Promise<Health[]> {
+  const probes: [string, string, string][] = [
+    ['hellgraph', CFG.hellgraph, '/healthz'],
+    ['owl-reasoner', CFG.reason, '/healthz'],
+    ['entity-resolution', CFG.er, '/healthz'],
+    ['lattice-studio', CFG.studio, '/healthz'],
+  ]
+  return Promise.all(probes.map(async ([name, base, p]) => {
+    try { await call(base, p); return { name, ok: true } } catch (e: any) { return { name, ok: false, detail: e?.message } }
+  }))
+}

--- a/apps/socioprophet-web/src/studio/studio.css
+++ b/apps/socioprophet-web/src/studio/studio.css
@@ -1,0 +1,72 @@
+/* Prophet Studio — a data/AI-platform workbench design system (Foundry/Databricks-class shell). */
+:root {
+  --bg: #0b0e14; --panel: #121722; --panel-2: #161c28; --border: #232b3a; --border-2: #2e3849;
+  --text: #e6edf3; --muted: #8b98ad; --faint: #5b6676;
+  --accent: #4f8cff; --accent-2: #6ad2b0; --warn: #f0b849; --bad: #ff6b6b; --good: #43d17a;
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+* { box-sizing: border-box; }
+html, body, #app { height: 100%; margin: 0; }
+body { background: var(--bg); color: var(--text); font-family: var(--sans); font-size: 14px; }
+
+.studio { display: grid; grid-template-columns: 232px 1fr; height: 100vh; }
+.sidebar { background: var(--panel); border-right: 1px solid var(--border); display: flex; flex-direction: column; overflow: hidden; }
+.brand { display: flex; align-items: center; gap: .6rem; padding: 1rem 1.1rem; border-bottom: 1px solid var(--border); }
+.brand b { font-size: 1.05rem; letter-spacing: -.01em; }
+.brand small { color: var(--faint); font-size: .68rem; text-transform: uppercase; letter-spacing: .08em; }
+.nav { padding: .5rem; overflow-y: auto; flex: 1; }
+.nav-group { color: var(--faint); font-size: .66rem; text-transform: uppercase; letter-spacing: .09em; padding: .9rem .6rem .3rem; }
+.nav a { display: flex; align-items: center; gap: .55rem; padding: .5rem .6rem; border-radius: 8px; color: var(--muted);
+  cursor: pointer; font-size: .86rem; user-select: none; }
+.nav a:hover { background: var(--panel-2); color: var(--text); }
+.nav a.active { background: #1b2740; color: var(--text); }
+.nav a .ic { width: 16px; text-align: center; opacity: .85; }
+.sidebar .foot { padding: .7rem 1rem; border-top: 1px solid var(--border); font-size: .72rem; color: var(--faint); }
+
+.main { display: flex; flex-direction: column; overflow: hidden; }
+.topbar { display: flex; align-items: center; gap: .8rem; padding: .7rem 1.2rem; border-bottom: 1px solid var(--border); background: var(--panel); }
+.topbar h1 { font-size: 1rem; margin: 0; font-weight: 600; }
+.topbar .sub { color: var(--muted); font-size: .82rem; }
+.topbar .spacer { flex: 1; }
+.view { flex: 1; overflow: auto; padding: 1.2rem; }
+
+.card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 1rem 1.1rem; }
+.card + .card { margin-top: 1rem; }
+.card h3 { margin: 0 0 .3rem; font-size: .92rem; font-weight: 600; }
+.card .desc { color: var(--muted); font-size: .82rem; margin: 0 0 .8rem; }
+.grid { display: grid; gap: 1rem; }
+.grid.cols-2 { grid-template-columns: 1fr 1fr; }
+.grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 900px) { .grid.cols-2, .grid.cols-3 { grid-template-columns: 1fr; } }
+
+label.fld { display: block; color: var(--muted); font-size: .74rem; text-transform: uppercase; letter-spacing: .05em; margin: 0 0 .3rem; }
+textarea, input[type=text], select {
+  width: 100%; background: var(--bg); color: var(--text); border: 1px solid var(--border-2); border-radius: 8px;
+  padding: .55rem .65rem; font-family: var(--mono); font-size: .82rem; resize: vertical;
+}
+textarea:focus, input:focus, select:focus { outline: none; border-color: var(--accent); }
+button.btn { background: var(--accent); color: #04122e; border: 0; border-radius: 8px; padding: .5rem .9rem; font-weight: 600;
+  cursor: pointer; font-size: .84rem; }
+button.btn:hover { filter: brightness(1.08); }
+button.btn.ghost { background: transparent; color: var(--text); border: 1px solid var(--border-2); }
+button.btn:disabled { opacity: .5; cursor: default; }
+.row { display: flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
+
+table.tbl { width: 100%; border-collapse: collapse; font-size: .82rem; }
+table.tbl th { text-align: left; color: var(--muted); font-weight: 500; border-bottom: 1px solid var(--border-2); padding: .4rem .5rem; position: sticky; top: 0; background: var(--panel); }
+table.tbl td { border-bottom: 1px solid var(--border); padding: .4rem .5rem; font-family: var(--mono); vertical-align: top; }
+.scroll { overflow: auto; max-height: 52vh; border: 1px solid var(--border); border-radius: 8px; }
+
+.pill { display: inline-block; padding: .1rem .5rem; border-radius: 999px; font-size: .7rem; border: 1px solid var(--border-2); color: var(--muted); }
+.pill.good { color: var(--good); border-color: #1e4d34; background: #0f2a1c; }
+.pill.bad { color: var(--bad); border-color: #4d1e1e; background: #2a0f0f; }
+.pill.accent { color: var(--accent); border-color: #23406e; background: #0f1c33; }
+.kpi { font-size: 1.6rem; font-weight: 700; letter-spacing: -.02em; }
+.kpi-l { color: var(--muted); font-size: .74rem; text-transform: uppercase; letter-spacing: .05em; }
+code, .mono { font-family: var(--mono); }
+pre.out { background: var(--bg); border: 1px solid var(--border); border-radius: 8px; padding: .7rem; overflow: auto; font-size: .78rem; max-height: 40vh; }
+.err { color: var(--bad); font-size: .82rem; }
+.muted { color: var(--muted); }
+a.link { color: var(--accent); cursor: pointer; text-decoration: none; }
+a.link:hover { text-decoration: underline; }

--- a/apps/socioprophet-web/src/views/Analytics.vue
+++ b/apps/socioprophet-web/src/views/Analytics.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { graph, ApiError } from '../studio/api'
+
+const busy = ref(false)
+const err = ref('')
+const pr = ref<any | null>(null)
+const cc = ref<any | null>(null)
+
+async function runPr() { busy.value = true; err.value = ''; try { pr.value = await graph.analytics('pagerank', 25) } catch (e) { err.value = fmt(e) } finally { busy.value = false } }
+async function runCc() { busy.value = true; err.value = ''; try { cc.value = await graph.analytics('components', 1) } catch (e) { err.value = fmt(e) } finally { busy.value = false } }
+function fmt(e: unknown) { return e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+</script>
+
+<template>
+  <div class="card">
+    <h3>Graph analytics — the benchmarked Rust CSR kernel</h3>
+    <p class="desc">PageRank &amp; connected components run on the <code>hg_analytics</code> kernel measured in the published benchmark, compiled into the service via N-API. Every result reports which backend served it.</p>
+    <div class="row"><button class="btn" :disabled="busy" @click="runPr">Run PageRank</button><button class="btn ghost" :disabled="busy" @click="runCc">Connected components</button></div>
+    <div v-if="err" class="err" style="margin-top:.6rem">⚠ {{ err }}</div>
+  </div>
+
+  <div class="grid cols-2" v-if="pr || cc">
+    <div class="card" v-if="pr">
+      <div class="row" style="justify-content:space-between"><h3>PageRank</h3><span class="pill accent">{{ pr.backend }}</span></div>
+      <div class="row" style="gap:2rem; margin:.5rem 0 .8rem">
+        <div><div class="kpi">{{ pr.nodes }}</div><div class="kpi-l">nodes</div></div>
+        <div><div class="kpi">{{ pr.edges }}</div><div class="kpi-l">edges</div></div>
+      </div>
+      <div class="scroll"><table class="tbl"><thead><tr><th>#</th><th>node</th><th>score</th></tr></thead>
+        <tbody><tr v-for="(t,i) in pr.top" :key="t.id"><td>{{ i+1 }}</td><td style="word-break:break-all">{{ t.id }}</td><td>{{ t.score }}</td></tr></tbody></table></div>
+    </div>
+    <div class="card" v-if="cc">
+      <div class="row" style="justify-content:space-between"><h3>Connected components</h3><span class="pill accent">{{ cc.backend }}</span></div>
+      <div class="row" style="gap:2rem; margin-top:.6rem">
+        <div><div class="kpi">{{ cc.components }}</div><div class="kpi-l">components</div></div>
+        <div><div class="kpi">{{ cc.largest }}</div><div class="kpi-l">largest</div></div>
+        <div><div class="kpi">{{ cc.nodes }}</div><div class="kpi-l">nodes</div></div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/socioprophet-web/src/views/EntityResolution.vue
+++ b/apps/socioprophet-web/src/views/EntityResolution.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { er, ApiError } from '../studio/api'
+
+const SAMPLE = JSON.stringify([
+  { id: 'r1', name: 'Acme Corporation', attributes: { city: 'NYC', email: 'info@acme.com' } },
+  { id: 'r2', name: 'Acme Corp', attributes: { city: 'NYC' } },
+  { id: 'r3', name: 'Acme Corporation', attributes: { city: 'NYC', email: 'other@acme.com' } },
+], null, 2)
+const input = ref(SAMPLE)
+const busy = ref(false)
+const err = ref('')
+const res = ref<any | null>(null)
+
+async function run() {
+  busy.value = true; err.value = ''; res.value = null
+  try { res.value = await er.resolve(JSON.parse(input.value)) }
+  catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+const decisionClass = (d: string) => d === 'MERGE_VERIFIED' ? 'good' : d === 'MERGE_BLOCKED' ? 'bad' : ''
+</script>
+
+<template>
+  <div class="card">
+    <h3>Entity resolution — proof-carrying, identity-is-prime-conformant</h3>
+    <p class="desc">Blocking → similarity → margin-gated + conflict-aware clustering. Records with conflicting exclusive keys can never merge (not even transitively), and every decision is a replayable certificate.</p>
+    <textarea v-model="input" rows="9" spellcheck="false"></textarea>
+    <div class="row" style="margin-top:.6rem"><button class="btn" :disabled="busy" @click="run">{{ busy ? 'Resolving…' : 'Resolve ▶' }}</button></div>
+    <div v-if="err" class="err" style="margin-top:.6rem">⚠ {{ err }}</div>
+  </div>
+
+  <template v-if="res">
+    <div class="card">
+      <div class="row" style="gap:2rem">
+        <div><div class="kpi">{{ res.records }}</div><div class="kpi-l">records</div></div>
+        <div><div class="kpi">{{ res.entities.length }}</div><div class="kpi-l">entities</div></div>
+        <div><div class="kpi">{{ res.merged }}</div><div class="kpi-l">merged</div></div>
+        <div><div class="kpi">{{ (res.review_queue||[]).length }}</div><div class="kpi-l">review</div></div>
+        <div><div class="kpi">{{ (res.blocked||[]).length }}</div><div class="kpi-l">blocked</div></div>
+      </div>
+      <div class="muted mono" style="margin-top:.6rem; font-size:.72rem" v-if="res.replay_key">replay key · {{ res.replay_key.resolver_version }} / {{ res.replay_key.policy_version }} / {{ res.replay_key.template_version }}</div>
+    </div>
+    <div class="card">
+      <h3>Golden records</h3>
+      <div class="scroll"><table class="tbl"><thead><tr><th>entity</th><th>survivor</th><th>name</th><th>members</th></tr></thead>
+        <tbody><tr v-for="(g,eid) in res.golden_records" :key="eid"><td>{{ eid }}</td><td>{{ g.survivor }}</td><td>{{ g.name }}</td><td>{{ (g.members||[]).join(', ') }}</td></tr></tbody></table></div>
+    </div>
+    <div class="card">
+      <h3>Decision ledger</h3>
+      <div class="scroll"><table class="tbl"><thead><tr><th>a</th><th>b</th><th>decision</th><th>score</th><th>evidence</th></tr></thead>
+        <tbody><tr v-for="(d,i) in res.decision_ledger" :key="i">
+          <td>{{ d.a }}</td><td>{{ d.b }}</td><td><span class="pill" :class="decisionClass(d.decision)">{{ d.decision }}</span></td>
+          <td>{{ d.score }}</td><td class="muted">{{ d.evidence?.conflict_field ? 'conflict:'+d.evidence.conflict_field : (d.evidence?.prime_veto || (d.evidence?.matched_attributes||[]).join(',')) }}</td>
+        </tr></tbody></table></div>
+    </div>
+  </template>
+</template>

--- a/apps/socioprophet-web/src/views/GraphExplorer.vue
+++ b/apps/socioprophet-web/src/views/GraphExplorer.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { graph, ApiError } from '../studio/api'
+import ForceGraph from '../studio/ForceGraph.vue'
+
+const label = ref('')
+const limit = ref(300)
+const busy = ref(false)
+const err = ref('')
+const nodes = ref<{ id: string; label?: string; group?: string }[]>([])
+const edges = ref<{ source: string; target: string }[]>([])
+const stats = ref<{ count: number; edges: number }>({ count: 0, edges: 0 })
+const selected = ref<any | null>(null)
+const rawNodes = ref<Record<string, any>>({})
+
+async function load() {
+  busy.value = true; err.value = ''; selected.value = null
+  try {
+    const r = await graph.subgraph(label.value, limit.value)
+    stats.value = { count: r.count, edges: r.edges }
+    rawNodes.value = Object.fromEntries(r.nodes.map((n: any) => [n.id, n]))
+    nodes.value = r.nodes.map((n: any) => ({ id: n.id, label: n.properties?.name ?? n.labels?.[0] ?? n.id, group: n.labels?.[0] }))
+    edges.value = r.edgeList.map((e: any) => ({ source: e.from, target: e.to }))
+  } catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+function onSelect(id: string) { selected.value = rawNodes.value[id] ?? { id } }
+onMounted(load)
+</script>
+
+<template>
+  <div class="grid" style="grid-template-columns: 1fr 320px; height: calc(100vh - 132px)">
+    <div class="card" style="display:flex; flex-direction:column; min-height:0">
+      <div class="row" style="margin-bottom:.7rem">
+        <input v-model="label" type="text" placeholder="filter by label (blank = whole graph)" style="max-width:280px" @keyup.enter="load" />
+        <select v-model.number="limit" style="width:auto"><option :value="100">100</option><option :value="300">300</option><option :value="600">600</option></select>
+        <button class="btn" :disabled="busy" @click="load">{{ busy ? 'Loading…' : 'Explore' }}</button>
+        <span class="muted">·</span>
+        <span class="pill">{{ stats.count }} nodes</span><span class="pill">{{ stats.edges }} edges</span>
+      </div>
+      <div v-if="err" class="err" style="margin-bottom:.5rem">⚠ {{ err }}</div>
+      <div style="flex:1; min-height:0; border:1px solid var(--border); border-radius:8px; overflow:hidden">
+        <ForceGraph :nodes="nodes" :edges="edges" @select="onSelect" />
+      </div>
+    </div>
+
+    <div class="card" style="overflow:auto">
+      <h3>Inspector</h3>
+      <p class="desc">Click a node. Every node carries its provenance — the moat a plain graph viewer can't show.</p>
+      <div v-if="!selected" class="muted">No selection.</div>
+      <template v-else>
+        <div class="kpi-l">ID</div>
+        <div class="mono" style="word-break:break-all; margin-bottom:.6rem">{{ selected.id }}</div>
+        <div class="kpi-l">Labels</div>
+        <div class="row" style="margin-bottom:.6rem"><span v-for="l in (selected.labels ?? [])" :key="l" class="pill accent">{{ l }}</span></div>
+        <div class="kpi-l">Properties</div>
+        <table class="tbl" style="margin-top:.3rem"><tbody>
+          <tr v-for="(v,k) in (selected.properties ?? {})" :key="k"><td class="muted">{{ k }}</td><td>{{ v }}</td></tr>
+        </tbody></table>
+        <div style="margin-top:.8rem"><a class="link" :href="`#resource:${encodeURIComponent(selected.id)}`">Open in Resource Browser →</a></div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/apps/socioprophet-web/src/views/GraphRAG.vue
+++ b/apps/socioprophet-web/src/views/GraphRAG.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { graph, ApiError } from '../studio/api'
+
+const q = ref('')
+const hops = ref(1)
+const busy = ref(false)
+const err = ref('')
+const res = ref<any | null>(null)
+
+async function ask() {
+  if (!q.value.trim()) return
+  busy.value = true; err.value = ''; res.value = null
+  try { res.value = await graph.ask(q.value) } catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+async function ground() {
+  if (!q.value.trim()) return
+  busy.value = true; err.value = ''; res.value = null
+  try { res.value = { grounding: await graph.ground(q.value, hops.value) } } catch (e) { err.value = String(e) } finally { busy.value = false }
+}
+</script>
+
+<template>
+  <div class="card">
+    <h3>GraphRAG — ask the graph, get a provenance-cited answer</h3>
+    <p class="desc">Retrieval seeds semantically (embedding cosine) when a sovereign embeddings endpoint is configured, else lexically; the answer may only cite retrieved facts — every citation carries an assertion-time receipt.</p>
+    <textarea v-model="q" rows="2" placeholder="e.g. what is Acme Aerospace connected to?" @keyup.ctrl.enter="ask"></textarea>
+    <div class="row" style="margin-top:.6rem">
+      <button class="btn" :disabled="busy" @click="ask">Ask ▶</button>
+      <button class="btn ghost" :disabled="busy" @click="ground">Show grounding</button>
+      <span class="muted">hops</span>
+      <select v-model.number="hops" style="width:auto"><option :value="1">1</option><option :value="2">2</option><option :value="3">3</option></select>
+    </div>
+    <div v-if="err" class="err" style="margin-top:.6rem">⚠ {{ err }}</div>
+  </div>
+
+  <div class="card" v-if="res && res.answer">
+    <div class="row" style="justify-content:space-between"><h3>Answer</h3>
+      <span class="pill" :class="res.synthesized ? 'good' : ''">{{ res.synthesized ? 'synthesized' : 'extractive (no LLM configured)' }}</span></div>
+    <p v-if="res.answer" style="line-height:1.55; white-space:pre-wrap">{{ res.answer }}</p>
+    <p v-else class="muted">No LLM configured — the citations below are the grounded answer.</p>
+  </div>
+
+  <div class="card" v-if="res">
+    <div class="row" style="justify-content:space-between"><h3>Citations ({{ (res.citations ?? res.grounding?.citations ?? []).length }})</h3>
+      <span v-if="res.grounding?.retrieval || res.retrieval" class="pill accent">{{ res.grounding?.retrieval || res.retrieval }}</span></div>
+    <div class="scroll"><table class="tbl"><thead><tr><th>#</th><th>fact</th><th>asserted</th></tr></thead>
+      <tbody><tr v-for="c in (res.citations ?? res.grounding?.citations ?? [])" :key="c.n">
+        <td>{{ c.n }}</td><td style="word-break:break-word">{{ c.fact }}</td><td class="muted">{{ (c.assertedAt||'').slice(0,19) }}</td>
+      </tr></tbody></table></div>
+  </div>
+</template>

--- a/apps/socioprophet-web/src/views/Ontology.vue
+++ b/apps/socioprophet-web/src/views/Ontology.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { reasoner, ApiError } from '../studio/api'
+import ForceGraph from '../studio/ForceGraph.vue'
+
+const SAMPLE = `@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix ex: <http://ex/> .
+ex: a owl:Ontology ; rdfs:label "Example" .
+ex:Animal a owl:Class ; rdfs:label "Animal" ; rdfs:comment "A living creature." .
+ex:Dog a owl:Class ; rdfs:label "Dog" ; rdfs:subClassOf ex:Animal .
+ex:Person a owl:Class ; rdfs:label "Person" .
+ex:owns a owl:ObjectProperty ; rdfs:label "owns" ; rdfs:domain ex:Person ; rdfs:range ex:Dog .`
+const turtle = ref(SAMPLE)
+const busy = ref(false)
+const err = ref('')
+const doc = ref<any | null>(null)
+const gnodes = ref<any[]>([])
+const gedges = ref<any[]>([])
+
+async function run() {
+  busy.value = true; err.value = ''; doc.value = null
+  try {
+    const [d, g] = await Promise.all([reasoner.ontologyDoc(turtle.value), reasoner.ontologyGraph(turtle.value)])
+    doc.value = d
+    gnodes.value = (g.nodes || []).map((n: any) => ({ id: n.id, label: n.label, group: n.type }))
+    gedges.value = (g.edges || []).map((e: any) => ({ source: e.source, target: e.target }))
+  } catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+</script>
+
+<template>
+  <div class="card">
+    <h3>Ontology workbench — docs + VOWL-style class graph</h3>
+    <p class="desc">Paste OWL/Turtle → browsable documentation (pyLODE/Widoco-class) and a rendered TBox graph of classes and object-property domain→range.</p>
+    <textarea v-model="turtle" rows="8" spellcheck="false"></textarea>
+    <div class="row" style="margin-top:.6rem"><button class="btn" :disabled="busy" @click="run">{{ busy ? 'Building…' : 'Render' }}</button></div>
+    <div v-if="err" class="err" style="margin-top:.6rem">⚠ {{ err }}</div>
+  </div>
+
+  <div class="grid cols-2" v-if="doc" style="height: 60vh">
+    <div class="card" style="display:flex; flex-direction:column; min-height:0">
+      <h3>{{ doc.header?.title || 'Ontology' }}</h3>
+      <p class="desc">{{ doc.counts?.classes }} classes · {{ doc.counts?.properties }} properties</p>
+      <div class="scroll" style="flex:1">
+        <table class="tbl"><thead><tr><th>class</th><th>super-classes</th><th>comment</th></tr></thead>
+          <tbody><tr v-for="c in doc.classes" :key="c.uri"><td>{{ c.label }}</td><td class="muted">{{ (c.superClasses||[]).map((s:string)=>s.split(/[#/]/).pop()).join(', ') }}</td><td class="muted">{{ c.comment }}</td></tr></tbody></table>
+      </div>
+    </div>
+    <div class="card" style="display:flex; flex-direction:column; min-height:0">
+      <h3>TBox graph</h3>
+      <div style="flex:1; min-height:0; border:1px solid var(--border); border-radius:8px; overflow:hidden"><ForceGraph :nodes="gnodes" :edges="gedges" /></div>
+    </div>
+  </div>
+</template>

--- a/apps/socioprophet-web/src/views/Overview.vue
+++ b/apps/socioprophet-web/src/views/Overview.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { health, graph, type Health } from '../studio/api'
+import GygCausalValuationCard from '../components/GygCausalValuationCard.vue'
+import ProphetMeshRuntimeReadinessCard from '../components/ProphetMeshRuntimeReadinessCard.vue'
+import ChronosEvidenceLoopCard from '../components/ChronosEvidenceLoopCard.vue'
+
+const svc = ref<Health[]>([])
+const stats = ref<{ nodes: number; edges: number } | null>(null)
+const loading = ref(true)
+
+async function load() {
+  loading.value = true
+  svc.value = await health()
+  try { stats.value = await graph.stats() } catch { stats.value = null }
+  loading.value = false
+}
+onMounted(load)
+</script>
+
+<template>
+  <div class="grid cols-3">
+    <div class="card"><div class="kpi">{{ stats?.nodes ?? '—' }}</div><div class="kpi-l">graph nodes</div></div>
+    <div class="card"><div class="kpi">{{ stats?.edges ?? '—' }}</div><div class="kpi-l">graph edges</div></div>
+    <div class="card"><div class="kpi">{{ svc.filter(s=>s.ok).length }}/{{ svc.length }}</div><div class="kpi-l">services healthy</div></div>
+  </div>
+
+  <div class="card">
+    <div class="row" style="justify-content:space-between"><h3>Platform services</h3><button class="btn ghost" @click="load">{{ loading ? '…' : 'Refresh' }}</button></div>
+    <p class="desc">Live health of the workbench backends. Every capability below is a real service — not a mock.</p>
+    <div class="grid cols-2">
+      <div v-for="s in svc" :key="s.name" class="row" style="justify-content:space-between; padding:.5rem .7rem; border:1px solid var(--border); border-radius:8px">
+        <span class="mono">{{ s.name }}</span>
+        <span class="pill" :class="s.ok ? 'good' : 'bad'">{{ s.ok ? 'healthy' : 'unreachable' }}</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <h3>Program readouts</h3>
+    <p class="desc">Governed program evidence surfaces.</p>
+    <GygCausalValuationCard />
+    <ProphetMeshRuntimeReadinessCard />
+    <ChronosEvidenceLoopCard />
+  </div>
+</template>

--- a/apps/socioprophet-web/src/views/QueryConsole.vue
+++ b/apps/socioprophet-web/src/views/QueryConsole.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { graph, ApiError } from '../studio/api'
+
+const lang = ref<'sparql' | 'cypher' | 'gremlin'>('sparql')
+const samples: Record<string, string> = {
+  sparql: 'SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 25',
+  cypher: 'MATCH (n) RETURN n LIMIT 25',
+  gremlin: 'g.V().limit(25)',
+}
+const q = ref(samples.sparql)
+const busy = ref(false)
+const err = ref('')
+const cols = ref<string[]>([])
+const rows = ref<any[]>([])
+const meta = ref<Record<string, any>>({})
+
+function pick(l: 'sparql' | 'cypher' | 'gremlin') { lang.value = l; q.value = samples[l]; cols.value = []; rows.value = []; err.value = '' }
+
+async function run() {
+  busy.value = true; err.value = ''; cols.value = []; rows.value = []; meta.value = {}
+  try {
+    const r = lang.value === 'sparql' ? await graph.sparql(q.value)
+      : lang.value === 'cypher' ? await graph.cypher(q.value)
+        : await graph.gremlin(q.value)
+    if (lang.value === 'sparql') { cols.value = r.variables ?? []; rows.value = (r.bindings ?? []).map((b: any) => cols.value.map((c) => b[c])) ; meta.value = { evaluatedAtSeq: r.evaluatedAtSeq } }
+    else if (lang.value === 'cypher') { cols.value = r.columns ?? []; rows.value = (r.rows ?? []).map((row: any) => cols.value.map((c) => row[c])); meta.value = { queryHash: r.queryHash, evaluatedAtSeq: r.evaluatedAtSeq } }
+    else { cols.value = ['value']; rows.value = (r.values ?? []).map((v: any) => [typeof v === 'object' ? JSON.stringify(v) : v]); meta.value = { count: r.count } }
+  } catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+</script>
+
+<template>
+  <div class="card">
+    <div class="row" style="justify-content:space-between">
+      <div class="row">
+        <button v-for="l in (['sparql','cypher','gremlin'] as const)" :key="l" class="btn ghost"
+          :style="lang===l ? 'border-color:var(--accent); color:var(--accent)' : ''" @click="pick(l)">{{ l.toUpperCase() }}</button>
+      </div>
+      <button class="btn" :disabled="busy" @click="run">{{ busy ? 'Running…' : 'Run ▶' }}</button>
+    </div>
+    <p class="desc" style="margin-top:.7rem">Proof-carrying query surface. Unsupported syntax throws an explicit error — never a silently-wrong empty result.</p>
+    <textarea v-model="q" rows="5" spellcheck="false"></textarea>
+  </div>
+
+  <div class="card" v-if="err"><div class="err">⚠ {{ err }}</div></div>
+
+  <div class="card" v-if="cols.length">
+    <div class="row" style="justify-content:space-between; margin-bottom:.6rem">
+      <h3>{{ rows.length }} rows</h3>
+      <div class="row">
+        <span v-if="meta.queryHash" class="pill accent mono" :title="meta.queryHash">⛓ {{ String(meta.queryHash).slice(0, 18) }}…</span>
+        <span v-if="meta.evaluatedAtSeq!=null" class="pill">seq {{ meta.evaluatedAtSeq }}</span>
+      </div>
+    </div>
+    <div class="scroll">
+      <table class="tbl">
+        <thead><tr><th v-for="c in cols" :key="c">{{ c }}</th></tr></thead>
+        <tbody><tr v-for="(r,i) in rows" :key="i"><td v-for="(cell,j) in r" :key="j">{{ cell }}</td></tr></tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/apps/socioprophet-web/src/views/Reasoner.vue
+++ b/apps/socioprophet-web/src/views/Reasoner.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { reasoner, ApiError } from '../studio/api'
+
+const SAMPLE = `@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex: <http://ex/> .
+ex:A rdfs:subClassOf ex:B .
+ex:B rdfs:subClassOf ex:C .
+ex:C rdfs:subClassOf ex:D .
+ex:x a ex:A .`
+const turtle = ref(SAMPLE)
+const inference = ref('rdfs')
+const busy = ref(false)
+const err = ref('')
+const res = ref<any | null>(null)
+
+async function run() {
+  busy.value = true; err.value = ''; res.value = null
+  try { res.value = await reasoner.reason(turtle.value, inference.value, true) }
+  catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+function renderProof(node: any, depth = 0): string {
+  const pad = '  '.repeat(depth)
+  if (node.asserted) return `${pad}• ${node.conclusion}  (asserted)`
+  const head = `${pad}⊢ ${node.conclusion}   [${node.rule}]`
+  return [head, ...(node.premises ?? []).map((p: any) => renderProof(p, depth + 1))].join('\n')
+}
+</script>
+
+<template>
+  <div class="card">
+    <h3>Reasoner — RDFS / OWL 2 RL entailment with SOUND proof trees</h3>
+    <p class="desc">Every entailment is justified by a proof grounded in <em>asserted</em> facts (never underived premises), and coverage is reported honestly — the "why" opaque reasoners hide.</p>
+    <textarea v-model="turtle" rows="7" spellcheck="false"></textarea>
+    <div class="row" style="margin-top:.6rem">
+      <select v-model="inference" style="width:auto"><option value="rdfs">RDFS</option><option value="owl2rl">OWL 2 RL</option><option value="both">Both</option></select>
+      <button class="btn" :disabled="busy" @click="run">{{ busy ? 'Reasoning…' : 'Reason ▶' }}</button>
+    </div>
+    <div v-if="err" class="err" style="margin-top:.6rem">⚠ {{ err }}</div>
+  </div>
+
+  <div class="grid cols-2" v-if="res">
+    <div class="card">
+      <div class="row" style="gap:2rem">
+        <div><div class="kpi">{{ res.entailed_triples }}</div><div class="kpi-l">entailed</div></div>
+        <div><div class="kpi">{{ res.justification_coverage?.explained ?? '—' }}</div><div class="kpi-l">explained</div></div>
+        <div><div class="kpi">{{ res.profile }}</div><div class="kpi-l">profile</div></div>
+      </div>
+      <h3 style="margin-top:1rem">Entailments</h3>
+      <div class="scroll"><table class="tbl"><tbody><tr v-for="(e,i) in res.entailments" :key="i"><td>{{ e }}</td></tr></tbody></table></div>
+    </div>
+    <div class="card">
+      <h3>Proof trees</h3>
+      <p class="desc" v-if="res.justification_coverage">{{ res.justification_coverage.explained }} of {{ res.justification_coverage.of }} explained; the rest are OWL-RL axiomatic noise or rules outside the covered subset — counted, not hidden.</p>
+      <pre class="out" v-for="(j,i) in (res.justifications ?? [])" :key="i">{{ renderProof(j) }}</pre>
+      <div v-if="!(res.justifications ?? []).length" class="muted">No attributable proofs for this input.</div>
+    </div>
+  </div>
+</template>

--- a/apps/socioprophet-web/src/views/ResourceBrowser.vue
+++ b/apps/socioprophet-web/src/views/ResourceBrowser.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { graph, ApiError } from '../studio/api'
+
+const uri = ref('')
+const busy = ref(false)
+const err = ref('')
+const cbd = ref<any | null>(null)
+
+async function load() {
+  if (!uri.value.trim()) return
+  busy.value = true; err.value = ''; cbd.value = null
+  try { cbd.value = await graph.resource(uri.value) }
+  catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+function open(u: string) { uri.value = u; load() }
+onMounted(() => {
+  const m = location.hash.match(/^#resource:(.+)$/)
+  if (m) { uri.value = decodeURIComponent(m[1]); load() }
+})
+</script>
+
+<template>
+  <div class="card">
+    <h3>Resource browser — dereferenceable Linked Data</h3>
+    <p class="desc">Paste any resource URI → its Concise Bounded Description (facts + back-links), the gist/Prez/Pubby affordance. Object IRIs are clickable — walk the graph.</p>
+    <div class="row"><input v-model="uri" type="text" placeholder="e.g. proj-x:ent:acme" @keyup.enter="load" /><button class="btn" :disabled="busy" @click="load">Resolve</button></div>
+    <div v-if="err" class="err" style="margin-top:.6rem">⚠ {{ err }}</div>
+  </div>
+
+  <div class="grid cols-2" v-if="cbd">
+    <div class="card">
+      <h3>Facts ({{ (cbd.outgoing||[]).length }})</h3>
+      <div class="scroll"><table class="tbl"><thead><tr><th>predicate</th><th>object</th></tr></thead>
+        <tbody><tr v-for="(t,i) in cbd.outgoing" :key="i"><td class="muted">{{ t.predicate }}</td>
+          <td><a v-if="t.isIri" class="link" @click="open(String(t.object))">{{ t.object }}</a><span v-else>{{ t.object }}</span></td></tr></tbody></table></div>
+    </div>
+    <div class="card">
+      <h3>Referenced by ({{ (cbd.incoming||[]).length }})</h3>
+      <div class="scroll"><table class="tbl"><thead><tr><th>subject</th><th>via</th></tr></thead>
+        <tbody><tr v-for="(t,i) in cbd.incoming" :key="i"><td><a class="link" @click="open(t.subject)">{{ t.subject }}</a></td><td class="muted">{{ t.predicate }}</td></tr></tbody></table></div>
+    </div>
+  </div>
+</template>

--- a/apps/socioprophet-web/vite.config.ts
+++ b/apps/socioprophet-web/vite.config.ts
@@ -17,7 +17,13 @@ export default defineConfig({
         target: process.env.VITE_BFF_TARGET ?? 'http://localhost:8077',
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/bff/, '')
-      }
+      },
+      // Prophet Studio → platform services (nginx proxies these same prefixes in prod). Dev targets are
+      // overridable via env so `vite dev` can point at port-forwarded services.
+      '/svc/hellgraph': { target: process.env.VITE_HELLGRAPH ?? 'http://localhost:8090', changeOrigin: true, rewrite: (p) => p.replace(/^\/svc\/hellgraph/, '') },
+      '/svc/reason': { target: process.env.VITE_REASON ?? 'http://localhost:8081', changeOrigin: true, rewrite: (p) => p.replace(/^\/svc\/reason/, '') },
+      '/svc/er': { target: process.env.VITE_ER ?? 'http://localhost:8082', changeOrigin: true, rewrite: (p) => p.replace(/^\/svc\/er/, '') },
+      '/svc/studio': { target: process.env.VITE_STUDIO ?? 'http://localhost:8083', changeOrigin: true, rewrite: (p) => p.replace(/^\/svc\/studio/, '') },
     }
   }
 })


### PR DESCRIPTION
## Why (deep audit — the #1 strategic gap)
`socioprophet-web` was a **57-line health-check demo**. The platform had ~20 real services but **no application** over them — "APIs without an application," the exact integration gap vs Palantir Foundry / Databricks / MS Fabric. This is the product surface that turns the capability into a workbench.

## What — 8 real workbenches, each driving a live service
- **Graph Explorer** — dependency-free force-directed canvas over `/api/graph/subgraph` + a provenance inspector (click a node → its labels/properties, jump to Resource Browser).
- **Query Console** — SPARQL / Cypher / Gremlin editor → results table, surfacing the proof-carrying `queryHash`.
- **Analytics** — PageRank / connected components on the **benchmarked Rust CSR kernel**; reports which backend served it.
- **GraphRAG** — ask the graph, **provenance-cited** answers; semantic-or-lexical retrieval, configurable hops.
- **Reasoner** — RDFS / OWL 2 RL entailment with **sound proof trees** + honest coverage.
- **Entity Resolution** — golden records + decision ledger + replay key; conflict-aware, identity-is-prime.
- **Resource Browser** — dereferenceable CBD (facts + back-links); clickable IRIs walk the graph.
- **Ontology** — pyLODE/Widoco-class docs + a rendered TBox class graph.

## Plumbing
- Typed API client (`src/studio/api.ts`) → same-origin `/svc/<service>/` paths that **nginx (prod)** and **Vite (dev)** proxy to the in-cluster services (no CORS, no hard-coded hosts, runtime-overridable via `window.__PROPHET_API__`).
- Workbench design system (`studio.css`), hash-routed shell with grouped nav, graceful per-panel error states.
- **Zero new deps** (Vue only). Existing program-readout cards preserved under Overview.

## Build
`vite build` green — 40 modules, 129 KB JS / 44 KB gzip.