### PR TITLE
feat(embeddings): sovereign Ollama /v1/embeddings — flip memoryd to real semantic

### DIFF
--- a/deploy/argocd/search-services.yaml
+++ b/deploy/argocd/search-services.yaml
@@ -20,6 +20,10 @@ spec:
     - list:
         elements:
           - { name: searxng, path: infra/k8s/searxng/base }
+          # Sovereign embeddings backend (Ollama + nomic-embed-text, OpenAI-compatible /v1/embeddings).
+          # Flips memoryd — and, once the engine owner sets EMBEDDINGS_URL on hellgraph-service, GraphRAG +
+          # commons retrieval — from lexical/hashing fallback to real semantic vectors. ClusterIP, internal only.
+          - { name: embeddings, path: infra/k8s/embeddings/base }
           # The open-chat commons aggregator — instances publish REDACTED open chats here (floor-gated on
           # ingest), and SearXNG's json_engine (see the searxng ConfigMap) searches the corpus. ClusterIP +
           # NetworkPolicy = internal-only; an authenticated external /publish ingress is a separate, deliberate

--- a/deploy/values/memoryd.yaml
+++ b/deploy/values/memoryd.yaml
@@ -6,5 +6,12 @@ image: { repository: memoryd, tag: latest }
 service: { port: 8787, portName: http }
 config:
   MEMORYMESH_STORE_URI: "memory://"
-  MEMORYMESH_VECTOR_SIZE: "256"
+  # 768 = nomic-embed-text's output dimension. RemoteEmbedder returns the raw model vector (it does NOT
+  # resize to this), so the store MUST match the embedder or inserts mismatch. HashingEmbedder honours it
+  # too, so this is safe whether the semantic endpoint is reachable at boot or not.
+  MEMORYMESH_VECTOR_SIZE: "768"
+  # Sovereign semantic embeddings (Ollama /v1/embeddings). If unreachable at startup, memoryd logs and
+  # falls back to the hashing embedder — never mixes vector spaces. See infra/k8s/embeddings/base.
+  EMBEDDINGS_URL: "http://embeddings.socioprophet.svc.cluster.local:11434/v1/embeddings"
+  EMBEDDINGS_MODEL: "nomic-embed-text"
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }

--- a/infra/k8s/embeddings/base/deployment.yaml
+++ b/infra/k8s/embeddings/base/deployment.yaml
@@ -1,0 +1,110 @@
+# Sovereign embeddings service — Ollama serving nomic-embed-text, exposing an OpenAI-compatible
+# /v1/embeddings endpoint. This is what flips memoryd (and, once the engine owner sets EMBEDDINGS_URL
+# on hellgraph-service, GraphRAG + commons retrieval) from the lexical/hashing fallback to REAL semantic
+# vectors — 'car' ≈ 'automobile'. Keyless, node-local, no vendor lock. Image pulled THROUGH zot
+# (docker.io on-demand sync), same house convention as searxng.
+#
+# Prereq (out of band, already present for searxng): the `zot-pull` imagePullSecret.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embeddings
+  namespace: socioprophet
+  labels:
+    app: embeddings
+    app.kubernetes.io/part-of: socioprophet
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate          # single RWO model PVC — never two writers
+  selector:
+    matchLabels: { app: embeddings }
+  template:
+    metadata:
+      labels: { app: embeddings }
+    spec:
+      enableServiceLinks: false
+      securityContext:
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: ollama
+          # ollama/ollama:0.9.0 pinned by digest (anti moving-tag), pulled through the sovereign registry.
+          image: registry.socioprophet.ai/ollama/ollama@sha256:2ea3b768a8f2dcd4d910f838d79702bb952089414dd578146619c0a939647ac6
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+          # Serve, wait for the API, pull the embed model into the PVC (idempotent — skipped if already
+          # present on restart), then hand the foreground back to the server.
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              ollama serve &
+              pid=$!
+              until ollama list >/dev/null 2>&1; do sleep 1; done
+              ollama pull nomic-embed-text
+              wait $pid
+          ports:
+            - name: http
+              containerPort: 11434
+          env:
+            - { name: OLLAMA_HOST, value: "0.0.0.0:11434" }
+            - { name: OLLAMA_KEEP_ALIVE, value: "-1" }   # keep the embed model resident (low-latency probes)
+            - { name: HOME, value: /root }
+          # Ready ONLY once the model is actually pulled — so consumers never hit a 404/empty-vector window
+          # and fall back to hashing. First pull (~275 MB) is allowed up to ~5 min.
+          readinessProbe:
+            exec:
+              command: ["/bin/sh", "-c", "ollama list | grep -q nomic-embed-text"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            httpGet: { path: /, port: http }
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 6
+          resources:
+            requests: { cpu: 250m, memory: 1Gi }
+            limits:   { cpu: "2",  memory: 2Gi }
+          volumeMounts:
+            - { name: models, mountPath: /root/.ollama }
+            - { name: tmp,    mountPath: /tmp }
+      volumes:
+        - name: models
+          persistentVolumeClaim: { claimName: embeddings-models }
+        - name: tmp
+          emptyDir: {}
+      imagePullSecrets:
+        - name: zot-pull
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: embeddings
+  namespace: socioprophet
+  labels: { app: embeddings }
+spec:
+  type: ClusterIP           # internal only — consumers reach it at EMBEDDINGS_URL in-cluster
+  selector: { app: embeddings }
+  ports:
+    - name: http
+      port: 11434
+      targetPort: http
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: embeddings
+  namespace: socioprophet
+  labels: { app: embeddings }
+spec:
+  podSelector: { matchLabels: { app: embeddings } }
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels: { kubernetes.io/metadata.name: socioprophet }
+      ports:
+        - { protocol: TCP, port: 11434 }

--- a/infra/k8s/embeddings/base/kustomization.yaml
+++ b/infra/k8s/embeddings/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: socioprophet
+resources:
+  - pvc.yaml
+  - deployment.yaml

--- a/infra/k8s/embeddings/base/pvc.yaml
+++ b/infra/k8s/embeddings/base/pvc.yaml
@@ -1,0 +1,12 @@
+# Persists pulled models (nomic-embed-text ~275 MB) so a pod restart doesn't re-download.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: embeddings-models
+  namespace: socioprophet
+  labels: { app: embeddings }
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 5Gi

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -59,6 +59,7 @@ NON_CHART_SERVICES = {
     "workspace-mail",
     "workspace-caldav",
     "workspace-smtp",
+    "embeddings",  # sovereign Ollama /v1/embeddings backend, deploys from infra/k8s/embeddings (kustomize)
     "searxng",   # sovereign meta-search, deploys from infra/k8s/searxng (kustomize)
     "commons-search",  # open-chat commons aggregator, deploys from infra/k8s/commons-search (kustomize)
     "search-gateway-ingress",  # public HTTPS edge (ManagedCertificate + Ingress) for search-gateway


### PR DESCRIPTION
## What
Stands up a **sovereign embeddings service** (Ollama serving `nomic-embed-text`, OpenAI-compatible `/v1/embeddings`) as an internal ClusterIP app, and wires **memoryd** to it — flipping the memoryd leg of the embedding trio from the lexical/**hashing fallback** to **real semantic vectors**.

## Changes
- `infra/k8s/embeddings/base/` — Deployment + Service + NetworkPolicy + PVC (kustomize, same house pattern as searxng).
  - Image `ollama/ollama:0.9.0` **pinned by digest**, pulled **through zot** (docker.io on-demand sync).
  - Serves + `ollama pull nomic-embed-text` into a **PVC** (survives restarts); **readiness gated on the model being present** so consumers never hit an empty-vector window.
- `deploy/argocd/search-services.yaml` — register the `embeddings` app.
- `deploy/values/memoryd.yaml` — set `EMBEDDINGS_URL`/`EMBEDDINGS_MODEL`; bump `MEMORYMESH_VECTOR_SIZE` **256→768** (nomic's dim — `RemoteEmbedder` returns the raw vector without resizing, so the store must match; `HashingEmbedder` honours it too, so it's safe whichever embedder is selected).

## Safety
memoryd selects the embedder **once at startup** and falls back to hashing if the endpoint is unreachable (it never mixes vector spaces). Validated: kustomize renders + **server-side dry-run against the live cluster passes**.

## Operational notes
1. memoryd picks its embedder at boot → **restart memoryd after `embeddings` is Ready** so it picks up the live endpoint.
2. **Owner hand-off (not this PR's lane):** setting `EMBEDDINGS_URL` on **hellgraph-service** flips **GraphRAG + commons retrieval** semantic too.
3. First image pull is zot's first on-demand mirror of `ollama/ollama` — watch the initial sync.