### PR TITLE
fix(workspace): repair mail/caldav/backup deploy config (3 crashlooping pods)

### DIFF
--- a/infra/k8s/workspace-caldav/base/configmap.yaml
+++ b/infra/k8s/workspace-caldav/base/configmap.yaml
@@ -1,0 +1,38 @@
+# workspace-caldav-config — the Radicale config the deployment mounts at /config. It was never created
+# (the base shipped without it) → the pod was stuck ContainerCreating for 37h on FailedMount. Content
+# tracks services/workspace-caldav/radicale/config. `users` is an (empty) htpasswd so Radicale starts;
+# populate it (or switch [auth] to remote_user behind the proxy) before any real CalDAV use.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workspace-caldav-config
+data:
+  config: |
+    [server]
+    hosts = 0.0.0.0:5232
+    max_connections = 20
+    max_content_length = 10000000
+    timeout = 30
+
+    [auth]
+    # htpasswd for local dev; swap to remote_user for production behind a proxy
+    type = htpasswd
+    htpasswd_filename = /config/users
+    htpasswd_encryption = bcrypt
+    delay = 1
+
+    [storage]
+    filesystem_folder = /var/lib/radicale/collections
+
+    [logging]
+    level = info
+
+    [headers]
+    Access-Control-Allow-Origin = *
+    Access-Control-Allow-Methods = GET, HEAD, DELETE, OPTIONS, PROPFIND, PUT, MKCALENDAR, MKCOL, REPORT, PROPPATCH
+    Access-Control-Allow-Headers = User-Agent, Authorization, Content-type, Depth, If-Match, If-None-Match, Lock-Token, Timeout, Destination, Overwrite, X-client, X-Requested-With
+    Access-Control-Expose-Headers = DAV, content-length, Allow
+    Access-Control-Allow-Credentials = true
+  # Empty htpasswd — Radicale starts, but no principals exist yet. Populate out-of-band (bcrypt) or move
+  # [auth] to remote_user before exposing CalDAV to clients.
+  users: |

--- a/infra/k8s/workspace-caldav/base/kustomization.yaml
+++ b/infra/k8s/workspace-caldav/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - networkpolicy.yaml
+  - configmap.yaml
   - deployment.yaml
   - service.yaml
   - pvc.yaml

--- a/infra/k8s/workspace-mail/base/backup-cronjob.yaml
+++ b/infra/k8s/workspace-mail/base/backup-cronjob.yaml
@@ -49,7 +49,9 @@ spec:
           volumes:
             - name: mail-data
               persistentVolumeClaim:
-                claimName: workspace-mail-data
+                # The mail data PVC is named workspace-mail-pvc (see pvc.yaml + the deployment's mailstore
+                # volume). 'workspace-mail-data' never existed → the backup pod was unschedulable for 33h.
+                claimName: workspace-mail-pvc
             - name: backup-target
               persistentVolumeClaim:
                 claimName: workspace-mail-backup

--- a/infra/k8s/workspace-mail/base/deployment.yaml
+++ b/infra/k8s/workspace-mail/base/deployment.yaml
@@ -29,15 +29,15 @@ spec:
               value: postgres
             - name: POSTGRES_DB
               value: prophet_platform
+            # postgres-credentials never existed → CreateContainerConfigError. Reference the real cluster
+            # secret (postgres-admin, key: password) and the literal superuser that the postgres StatefulSet
+            # itself uses (POSTGRES_USER=postgres). TODO: give mail a dedicated, least-privilege DB role.
             - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgres-credentials
-                  key: username
+              value: postgres
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: postgres-credentials
+                  name: postgres-admin
                   key: password
           volumeMounts:
             - name: mailstore


### PR DESCRIPTION
Three independent config bugs left workspace-mail, workspace-caldav, and the mail-backup CronJob broken for 33–37h behind a green pipeline — the exact class `preflight_deploy_contract.py` exists to catch, but these are *reference-to-missing-object* bugs inside kustomize bases that preflight doesn't reach.

| Pod | Symptom | Root cause | Fix |
|---|---|---|---|
| **workspace-mail** | `CreateContainerConfigError` ×9947 / 35h | env refs secret `postgres-credentials` — never existed | ref real `postgres-admin`/password + literal `POSTGRES_USER=postgres` (what the postgres StatefulSet uses) |
| **mail-backup** | `FailedScheduling` (unbound PVC) / 33h | mounts PVC `workspace-mail-data` — never existed | claimName → `workspace-mail-pvc` (the real data PVC) |
| **workspace-caldav** | `ContainerCreating`/`FailedMount` ×1127 / 37h | mounts configMap `workspace-caldav-config` — base never defined it | add `configmap.yaml` (Radicale config from `services/workspace-caldav/radicale/config`) + wire kustomization |

### Validation
- Both kustomize bases render; **server-side apply as `argocd-controller` applies cleanly** (the mail `value`↔`valueFrom` transition is resolved by the field owner — a plain `kubectl apply` shows a false conflict, ArgoCD's SSA does not).
- **preflight passes.**

### Follow-ups (flagged, not blocking)
- workspace-mail should get a **dedicated least-privilege DB role** instead of the postgres superuser.
- workspace-caldav ships an **empty htpasswd** — it starts, but populate `users` (bcrypt) or switch `[auth]` to `remote_user` behind the proxy before real CalDAV use.