### PR TITLE
fix(socbase-rest): derive DB creds from the authenticator secret (kill the 642× crash-loop's root)

### DIFF
--- a/deploy/values/socbase-rest.yaml
+++ b/deploy/values/socbase-rest.yaml
@@ -4,8 +4,14 @@
 # Job, so this release's DB secret must point at a role that already exists
 # (i.e. install socbase-auth + run the schema Job before this).
 #
+# The DB password is sourced from the SAME secret the schema Job sets the authenticator role's
+# password from (socbase-authenticator) — one source of truth, so PostgREST's creds can never drift
+# from the role's. The previous design baked the password into a SECOND secret (socbase-rest-db-url);
+# the two drifted and PostgREST crash-looped 642× ("password authentication failed for user
+# authenticator") until they were manually re-synced. socbase-rest-db-url is no longer used.
+#
 # Prereqs:
-#   kubectl create secret generic socbase-rest-db-url --from-literal=url="postgres://authenticator:<authenticator-pw>@postgres:5432/prophet_platform"
+#   kubectl create secret generic socbase-authenticator --from-literal=password="..."  # same one the schema Job uses
 #   kubectl create secret generic socbase-jwt --from-literal=secret="..."   # same secret socbase-auth uses
 nameOverride: socbase-rest
 
@@ -19,13 +25,20 @@ service:
   portName: http
 
 secretEnv:
-  PGRST_DB_URI: { secretName: socbase-rest-db-url, key: url }
+  SOCBASE_AUTHENTICATOR_PW: { secretName: socbase-authenticator, key: password }
   PGRST_JWT_SECRET: { secretName: socbase-jwt, key: secret }
 
 config:
   PGRST_DB_SCHEMAS: "public"
   PGRST_DB_ANON_ROLE: "anon"
   PGRST_DB_USE_LEGACY_GUCS: "false"
+
+# PGRST_DB_URI is built HERE (extraEnv is rendered AFTER secretEnv by the chart) so the k8s env-var
+# reference $(SOCBASE_AUTHENTICATOR_PW) resolves against the secretEnv var above. libpq keyword format
+# (not a URI) avoids percent-encoding pitfalls for base64 passwords containing +, /, =.
+extraEnv:
+  - name: PGRST_DB_URI
+    value: "host=postgres port=5432 dbname=prophet_platform user=authenticator password=$(SOCBASE_AUTHENTICATOR_PW)"
 
 probes:
   path: /


### PR DESCRIPTION
## Investigation (spawned socbase-rest task)
`socbase-rest` shows 641–642 restarts. Diagnosis: **not OOM, not a probe** — the previous-container logs are:
```
FATAL: password authentication failed for user "authenticator"
```
**It is currently healthy** — connected to PostgreSQL since 2026-07-16 00:34 (~31h stable). The restart count is historical.

## Root cause — a duplicated password that drifted
The `authenticator` password lived in **two independent out-of-band secrets**:
- `socbase-authenticator` → the schema Job sets the **role**'s password from it (`charts/socbase-schema`, `alter role authenticator ... password :'authpw'`).
- `socbase-rest-db-url` → PostgREST read a **separate** secret with the password **baked into a connection URL**.

They drifted (PostgREST's copy ≠ the role's) → 642 crash-loops until someone manually re-synced them (~31h ago). Verified now: both secrets match and both authenticate.

## Fix — one source of truth
Build `PGRST_DB_URI` from the **same** `socbase-authenticator` secret, via a k8s env-var reference:
- `secretEnv.SOCBASE_AUTHENTICATOR_PW` ← `socbase-authenticator/password`
- `extraEnv.PGRST_DB_URI` = `host=postgres ... user=authenticator password=$(SOCBASE_AUTHENTICATOR_PW)` (extraEnv renders **after** secretEnv, so the ref resolves; libpq keyword format avoids URI percent-encoding pitfalls). **`socbase-rest-db-url` is retired.**

Now PostgREST's creds can never drift from the role's — rotating `socbase-authenticator` + re-running the schema Job + restarting socbase-rest keeps all three consistent.

## Validation
- Chart renders with `SOCBASE_AUTHENTICATOR_PW` ordered before `PGRST_DB_URI` (verified in `helm template`).
- The libpq keyword string **authenticates as `authenticator` against the live DB** (tested).
- preflight passes; server-side apply (as `argocd-controller`) is clean.

## ⚠️ Rollout note — auth-critical, merge deliberately
This touches live sovereign auth. Safe failure mode: a bad roll **stalls on new pods** (readiness gate) without terminating the healthy old ones, so auth stays up. Still — **merge when you can watch the roll**; confirm new pods log `Successfully connected to PostgreSQL`. **Prereq:** `socbase-authenticator` secret must exist (it does).