### PR TITLE
fix(embeddings): mirror ollama into the sovereign registry via CI (no docker.io at runtime)

### DIFF
--- a/.github/workflows/mirror-external-images.yml
+++ b/.github/workflows/mirror-external-images.yml
@@ -34,8 +34,11 @@ jobs:
           set -euo pipefail
           SRC='${{ matrix.image }}'
           DEST="registry.socioprophet.ai/${SRC#*/}"   # strip the "docker.io/" host prefix
-          echo "mirroring $SRC -> $DEST (linux/amd64)"
-          skopeo copy --override-os linux --override-arch amd64 \
+          echo "mirroring $SRC -> $DEST (single-arch = runner system, linux/amd64)"
+          # --multi-arch system copies ONLY the runner-matching image as a single manifest (not the
+          # multi-arch index). --override-arch tries to preserve the index and zot rejects it ("manifest
+          # invalid" / unsupported index conversion). --format v2s2 keeps it in the widely-accepted schema.
+          skopeo copy --multi-arch system --format v2s2 \
             --dest-creds "$ZOT_USER:$ZOT_PASS" \
             "docker://$SRC" "docker://$DEST"
           echo "verifying $DEST is present in the sovereign registry…"

--- a/.github/workflows/mirror-external-images.yml
+++ b/.github/workflows/mirror-external-images.yml
@@ -35,10 +35,11 @@ jobs:
           SRC='${{ matrix.image }}'
           DEST="registry.socioprophet.ai/${SRC#*/}"   # strip the "docker.io/" host prefix
           echo "mirroring $SRC -> $DEST (single-arch = runner system, linux/amd64)"
-          # --multi-arch system copies ONLY the runner-matching image as a single manifest (not the
-          # multi-arch index). --override-arch tries to preserve the index and zot rejects it ("manifest
-          # invalid" / unsupported index conversion). --format v2s2 keeps it in the widely-accepted schema.
-          skopeo copy --multi-arch system --format v2s2 \
+          # --multi-arch system copies ONLY the runner-matching image (linux/amd64) as a single manifest.
+          # Do NOT pass --format or --override-arch: they make skopeo RE-SERIALIZE the manifest, which zot
+          # then rejects (schema2 → 415 Unsupported Media Type; a re-serialized OCI manifest → invalid).
+          # Preserving the source manifest bytes is what zot accepts (same as images.yml's buildx pushes).
+          skopeo copy --multi-arch system \
             --dest-creds "$ZOT_USER:$ZOT_PASS" \
             "docker://$SRC" "docker://$DEST"
           echo "verifying $DEST is present in the sovereign registry…"

--- a/.github/workflows/mirror-external-images.yml
+++ b/.github/workflows/mirror-external-images.yml
@@ -1,0 +1,43 @@
+name: mirror-external-images
+
+# Mirror third-party images INTO the sovereign registry (zot) via CI — so the cluster never depends
+# on docker.io pull-through at runtime. zot's on-demand sync is anonymous and hits docker.io's
+# anonymous rate limit on large images (ollama couldn't mirror that way). CI pulls once and pushes
+# with the same ZOT_CI creds images.yml uses. Add an entry to the matrix + run this, then reference
+# registry.socioprophet.ai/<path> in your deploy manifests (pulled with the existing zot-pull secret).
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/mirror-external-images.yml
+
+permissions:
+  contents: read
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # upstream ref → registry.socioprophet.ai/<same repo path>. linux/amd64 only (cluster nodes are amd64).
+        image:
+          - docker.io/ollama/ollama:0.9.0
+    steps:
+      - name: Install skopeo
+        run: sudo apt-get update && sudo apt-get install -y skopeo
+      - name: Mirror ${{ matrix.image }} → sovereign registry (amd64)
+        env:
+          ZOT_USER: ${{ secrets.ZOT_CI_USERNAME }}
+          ZOT_PASS: ${{ secrets.ZOT_CI_PASSWORD }}
+        run: |
+          set -euo pipefail
+          SRC='${{ matrix.image }}'
+          DEST="registry.socioprophet.ai/${SRC#*/}"   # strip the "docker.io/" host prefix
+          echo "mirroring $SRC -> $DEST (linux/amd64)"
+          skopeo copy --override-os linux --override-arch amd64 \
+            --dest-creds "$ZOT_USER:$ZOT_PASS" \
+            "docker://$SRC" "docker://$DEST"
+          echo "verifying $DEST is present in the sovereign registry…"
+          skopeo inspect --creds "$ZOT_USER:$ZOT_PASS" "docker://$DEST" >/dev/null
+          echo "✓ mirrored $DEST"

--- a/infra/k8s/embeddings/base/deployment.yaml
+++ b/infra/k8s/embeddings/base/deployment.yaml
@@ -28,8 +28,11 @@ spec:
         seccompProfile: { type: RuntimeDefault }
       containers:
         - name: ollama
-          # ollama/ollama:0.9.0 pinned by digest (anti moving-tag), pulled through the sovereign registry.
-          image: registry.socioprophet.ai/ollama/ollama@sha256:2ea3b768a8f2dcd4d910f838d79702bb952089414dd578146619c0a939647ac6
+          # ollama/ollama pinned to the immutable version tag 0.9.0 (not `latest`), pulled through the
+          # sovereign registry. Must be a TAG, not a bare @sha256 digest: zot's on-demand sync fetches an
+          # un-cached upstream image by tag/reference — a digest for a repo zot has never synced resolves
+          # to NotFound (this bit the first roll). The version tag is immutable, so IfNotPresent is safe.
+          image: registry.socioprophet.ai/ollama/ollama:0.9.0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
The embeddings pod couldn't pull ollama: zot's on-demand docker.io pull-through is **anonymous** and hit docker.io's rate limit on the large ollama image. Instead of adding a Docker Hub credential (off-pattern), **mirror it into the sovereign registry with CI** — the same path we push every other image through.

- **`.github/workflows/mirror-external-images.yml`** — `skopeo copy docker.io/ollama/ollama:0.9.0 → registry.socioprophet.ai/ollama/ollama:0.9.0` (linux/amd64) using the existing `ZOT_CI` creds. One pull in CI; **no docker.io dependency at cluster runtime, no new secret.** Extensible matrix for future third-party images.
- **embeddings** references ollama by tag `0.9.0`, pulled from zot with the existing `zot-pull` secret.

No changes to zot itself — the earlier Docker Hub-auth approach is dropped. Safe to merge; the mirror job runs on push, then the embeddings pod pulls the mirrored image and memoryd goes semantic.