### PR TITLE
hellgraph-service: roll out engine 0.4.23 image (activate EMBEDDINGS_URL)

### DIFF
--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -1,5 +1,8 @@
 # hellgraph-service — the engine serves on :8090 (not 8080); align service + probes.
-image: { repository: hellgraph-service, tag: sha-a16830db1710748792dbe9c79dab5dddeb3d21ff }
+# tag bumped to the b04eac8f build — the first image carrying engine 0.4.23 (which reads
+# EMBEDDINGS_URL). The prior sha-a16830db predated 0.4.22, so the EMBEDDINGS_URL config below was
+# inert on the cluster until this rolls out. hellgraph-service content is unchanged since b04eac8f.
+image: { repository: hellgraph-service, tag: sha-b04eac8f879e3c508b1061a2016aa400b23e0bae }
 service: { port: 8090, portName: http }
 config:
   # Estate sovereign embeddings contract (matches memoryd + prophet-platform #799): the engine


### PR DESCRIPTION
Follow-on to #804. The socioprophet hellgraph-service pod was pinned to `sha-a16830db` (pre-0.4.22) — which doesn't read `EMBEDDINGS_URL` — so the semantic config from #804 was inert on-cluster (the stale-image / rotting-cluster pattern). This bumps the values `image.tag` to `sha-b04eac8f`, the first built image carrying engine **0.4.23** (the estate `EMBEDDINGS_URL` → `/v1/embeddings` contract). ArgoCD rolls it out → socioprophet GraphRAG + commons retrieval go real-semantic. hellgraph-service content is unchanged since b04eac8f; the 2 red checks are the pre-existing socioprophet-web ones (not this diff).