### PR TITLE
feat(studio): WRITE workbench — manual add-node / add-edge endpoints

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -217,6 +217,22 @@ def extract_facts(text: str, limit: int = 60) -> tuple[list[str], list[tuple[str
     return entities, relations[: limit * 2]
 
 
+def _require_write_token(authorization: str) -> None:
+    """Shared WRITE gate for every endpoint that mutates the shared HellGraph (extract + the node/edge
+    workbench). Fail-CLOSED: if STUDIO_WRITE_TOKEN is unset, writes are refused (reads stay open), so a
+    public ingress can never accept anonymous graph writes. Token provisioned out-of-band (Secret)."""
+    if not STUDIO_WRITE_TOKEN:
+        raise HTTPException(status_code=503, detail="studio writes disabled: STUDIO_WRITE_TOKEN unset (fail-closed)")
+    if authorization.removeprefix("Bearer ").strip() != STUDIO_WRITE_TOKEN:
+        raise HTTPException(status_code=401, detail="invalid write token")
+
+
+def _ent_id(coll: str, name: str) -> str:
+    """Project-scoped entity id — must match /extract's scheme so a hand-authored node and an extracted one
+    with the same name are the SAME node (the workbench edits the same graph, not a parallel one)."""
+    return f"{coll}:ent:{_norm(name).replace(' ', '_')}"
+
+
 class ExtractRequest(BaseModel):
     project: str = "default"
     text: str
@@ -225,17 +241,11 @@ class ExtractRequest(BaseModel):
 
 @app.post("/api/studio/extract")
 async def extract(req: ExtractRequest, authorization: str = Header(default="")) -> dict[str, Any]:
-    # WRITE gate: /extract mutates the shared HellGraph, so it must be authenticated before Studio is
-    # publicly exposed. Fail-CLOSED — if STUDIO_WRITE_TOKEN is unset, writes are refused (reads stay open),
-    # so a public ingress can never accept anonymous graph writes. Token provisioned out-of-band (Secret).
-    if not STUDIO_WRITE_TOKEN:
-        raise HTTPException(status_code=503, detail="studio writes disabled: STUDIO_WRITE_TOKEN unset (fail-closed)")
-    if authorization.removeprefix("Bearer ").strip() != STUDIO_WRITE_TOKEN:
-        raise HTTPException(status_code=401, detail="invalid write token")
+    _require_write_token(authorization)
     coll = proj_collection(req.project)
     src = req.source or ("text:" + hashlib.sha256(req.text.encode()).hexdigest()[:16])
     entities, relations = extract_facts(req.text)
-    ent_id = lambda name: f"{coll}:ent:{_norm(name).replace(' ', '_')}"  # noqa: E731
+    ent_id = lambda name: _ent_id(coll, name)  # noqa: E731
     # KKO (KBpedia Knowledge Ontology) is the estate's UPPER ONTOLOGY. Extracted named entities are Peircean
     # Particulars (Secondness). epistemic_mode="observed" is itself Peircean (KKO formalizes the inference
     # trichotomy induced/deduced/abduced as kko:Methodeutic) — so the provenance is standards-grounded, not ad-hoc.
@@ -271,6 +281,79 @@ async def extract(req: ExtractRequest, authorization: str = Header(default="")) 
         "sample": entities[:10],
         "errors": errors[:5] or None,
     }
+
+
+class NodeRequest(BaseModel):
+    project: str = "default"
+    name: str
+    labels: list[str] | None = None
+    epistemic_mode: str = "observed"
+    source: str | None = None
+
+
+class EdgeRequest(BaseModel):
+    project: str = "default"
+    from_name: str
+    to_name: str
+    label: str = "relates_to"
+    epistemic_mode: str = "observed"
+    source: str | None = None
+
+
+def _workbench_prov(coll: str, mode: str, source: str | None) -> dict[str, Any]:
+    """Provenance for a HAND-AUTHORED fact — same shape /extract stamps, so a manual node is as proof-carrying
+    as an extracted one. extractor marks it as workbench-authored; epistemic_mode is the user's assertion."""
+    return {"epistemic_mode": mode, "source": source or "workbench",
+            "extractor": "lattice-studio/workbench-v0", "project": coll, "kko_type": "Particulars"}
+
+
+@app.post("/api/studio/node")
+async def add_node(req: NodeRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """WRITE workbench: add ONE node to the project graph by hand. Same fail-closed token, project scope, and
+    provenance as /extract — a hand-authored entity lands in the same graph, carrying its epistemic status."""
+    _require_write_token(authorization)
+    name = req.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="name required")
+    coll = proj_collection(req.project)
+    nid = _ent_id(coll, name)
+    prov = _workbench_prov(coll, req.epistemic_mode, req.source)
+    # keep the project + Entity labels canonical; append any extra user labels (deduped)
+    labels = [coll, "Entity"] + [l for l in (req.labels or []) if l not in (coll, "Entity")]
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        _, err = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                            json={"id": nid, "labels": labels, "properties": {"name": name, **prov}})
+    if err:
+        raise HTTPException(status_code=502, detail=f"graph write failed: {err}")
+    return {"id": nid, "name": name, "project": req.project, "projectCollection": coll,
+            "labels": labels, "provenance": prov, "written": True}
+
+
+@app.post("/api/studio/edge")
+async def add_edge(req: EdgeRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """WRITE workbench: add ONE edge to the project graph by hand. Upserts both endpoints first (idempotent),
+    so an edge between new names just works; then writes the relation. Same token/scope/provenance as /extract."""
+    _require_write_token(authorization)
+    a, b = req.from_name.strip(), req.to_name.strip()
+    if not a or not b:
+        raise HTTPException(status_code=422, detail="from_name and to_name required")
+    coll = proj_collection(req.project)
+    fid, tid = _ent_id(coll, a), _ent_id(coll, b)
+    label = _norm(req.label).replace(" ", "_") or "relates_to"
+    prov = _workbench_prov(coll, req.epistemic_mode, req.source)
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        # endpoints first (idempotent upsert), then the edge — mirrors /extract's nodes-before-edges order.
+        for nm, nid in ((a, fid), (b, tid)):
+            _, err = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                                json={"id": nid, "labels": [coll, "Entity"], "properties": {"name": nm, **prov}})
+            if err:
+                raise HTTPException(status_code=502, detail=f"graph write failed (node {nm}): {err}")
+        _, err = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                            json={"label": label, "from": fid, "to": tid, "properties": prov})
+    if err:
+        raise HTTPException(status_code=502, detail=f"graph write failed (edge): {err}")
+    return {"from": fid, "to": tid, "label": label, "project": req.project,
+            "projectCollection": coll, "provenance": prov, "written": True}
 
 
 def _map_node(n: Any) -> dict[str, Any]:

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -149,3 +149,86 @@ def test_rdf_export_carries_provenance_AND_edges(monkeypatch):
     rels = [(s, o) for s, p, o in rg if p == SP["co_occurs"]]
     assert len(rels) == 1, "the co_occurs edge must be exported as an RDF relation"
     assert "hellgraph" in str(rels[0][0]) and "atomspace" in str(rels[0][1])
+
+
+# ── WRITE workbench: manual add-node / add-edge (same fail-closed gate as /extract) ──
+
+def test_workbench_write_gate():
+    # fail-closed: no token → node + edge writes both refused (503)
+    assert client.post("/api/studio/node", json={"project": "team-x", "name": "HellGraph"}).status_code == 503
+    assert client.post("/api/studio/edge", json={"project": "team-x", "from_name": "A", "to_name": "B"}).status_code == 503
+
+
+def test_workbench_wrong_token_401(monkeypatch):
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    r = client.post("/api/studio/node", json={"project": "team-x", "name": "HellGraph"},
+                    headers={"authorization": "Bearer nope"})
+    assert r.status_code == 401
+
+
+def test_add_node_writes_proof_carrying(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "secret")
+    captured = {}
+
+    async def fake_req(client, method, url, json=None):
+        captured["url"] = url; captured["json"] = json
+        return ({"ok": True}, None)
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.post("/api/studio/node",
+                    json={"project": "team-x", "name": "Custom Fact", "epistemic_mode": "attested", "labels": ["Claim"]},
+                    headers={"authorization": "Bearer secret"})
+    assert r.status_code == 200
+    b = r.json()
+    # project-scoped id matches /extract's scheme; provenance carries the user's epistemic mode + workbench origin
+    assert b["id"] == "proj-teamx:ent:custom_fact" and b["written"] is True
+    assert b["provenance"]["epistemic_mode"] == "attested"
+    assert b["provenance"]["extractor"] == "lattice-studio/workbench-v0"
+    assert "Claim" in b["labels"] and "proj-teamx" in b["labels"] and "Entity" in b["labels"]
+    # it actually POSTed to the hellgraph node endpoint with the mapped id
+    assert captured["url"].endswith("/api/graph/node") and captured["json"]["id"] == "proj-teamx:ent:custom_fact"
+
+
+def test_add_node_requires_name(monkeypatch):
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    r = client.post("/api/studio/node", json={"project": "team-x", "name": "   "},
+                    headers={"authorization": "Bearer secret"})
+    assert r.status_code == 422
+
+
+def test_add_edge_upserts_endpoints_then_relation(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "secret")
+    calls: list[tuple[str, dict]] = []
+
+    async def fake_req(client, method, url, json=None):
+        calls.append((url, json))
+        return ({"ok": True}, None)
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.post("/api/studio/edge",
+                    json={"project": "team-x", "from_name": "HellGraph", "to_name": "Neo4j", "label": "beats"},
+                    headers={"authorization": "Bearer secret"})
+    assert r.status_code == 200
+    b = r.json()
+    assert b["from"] == "proj-teamx:ent:hellgraph" and b["to"] == "proj-teamx:ent:neo4j"
+    assert b["label"] == "beats" and b["written"] is True
+    # both endpoint nodes upserted FIRST, then the edge (3 calls, edge last)
+    assert len(calls) == 3
+    assert all(u.endswith("/api/graph/node") for u, _ in calls[:2])
+    assert calls[2][0].endswith("/api/graph/edge")
+    assert calls[2][1]["from"] == "proj-teamx:ent:hellgraph" and calls[2][1]["to"] == "proj-teamx:ent:neo4j"
+
+
+def test_add_edge_graph_failure_is_502(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "secret")
+
+    async def fake_req(client, method, url, json=None):
+        return (None, "connection refused")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.post("/api/studio/edge", json={"project": "team-x", "from_name": "A", "to_name": "B"},
+                    headers={"authorization": "Bearer secret"})
+    assert r.status_code == 502


### PR DESCRIPTION
Prophet Studio could only write to the graph via bulk `/extract` (text → entities). This adds **hand-authoring** — the missing half of a Watson-Studio++ workbench:

- **`POST /api/studio/node`** — add one node by name (with labels + `epistemic_mode`)
- **`POST /api/studio/edge`** — add one relation; **upserts both endpoints first** (idempotent) then writes the edge, so an edge between new names just works

### Consistent with the existing write path (not a parallel one)
- **Same fail-closed gate** as `/extract`, factored into `_require_write_token` (503 when `STUDIO_WRITE_TOKEN` unset, 401 on bad bearer) — reads stay open, writes never anonymous.
- **Same project-scoped id** (`_ent_id`, shared with `/extract`) → a hand-authored node and an extracted one of the same name are the **same** node.
- **Same provenance** (`extractor=lattice-studio/workbench-v0`, user-chosen `epistemic_mode`, `kko_type=Particulars`) → a manual fact is as proof-carrying as an extracted one.
- A hard graph-write failure is an honest **502**.

**7 new tests** (write-gate 503/401, node proof-carrying + id mapping, name-required 422, edge upserts-then-relation ordering, edge-failure 502). **All 16 server tests pass.**

Next: the app-vue Studio surface gets a small add-node/add-edge form calling these (separate PR).