### PR TITLE
hellgraph-service: fix embeddings port 11434→8080

### DIFF
--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -12,5 +12,5 @@ config:
   # nomic-embed-text's 768-dim vectors as-is), so no fixed vector-size var is needed here — unlike
   # memoryd's MEMORYMESH_VECTOR_SIZE. The fogstack (federal/standard) tiers override EMBEDDINGS_URL
   # to "" in the appset so a sovereign tier never reaches this socioprophet-namespace service.
-  EMBEDDINGS_URL: "http://embeddings.socioprophet.svc.cluster.local:11434/v1/embeddings"
+  EMBEDDINGS_URL: "http://embeddings.socioprophet.svc.cluster.local:8080/v1/embeddings"
   EMBEDDINGS_MODEL: "nomic-embed-text"


### PR DESCRIPTION
Follow-on to #804/#805. The engine 0.4.23 pod is live with real semantic wiring, but the URL pointed at Ollama's old `:11434`; the current first-party embeddings service (#803) listens on **:8080** (memoryd already uses it). Live-verified: the socioprophet hellgraph pod reaches `:8080/v1/embeddings` and gets a **768-dim** vector, while `:11434` timed out. Config-only (no image rebuild). Red checks are the pre-existing socioprophet-web ones.