### PR TITLE
feat(studio): wire STUDIO_WRITE_TOKEN — activate the write workbench

### DIFF
--- a/deploy/values/lattice-studio.yaml
+++ b/deploy/values/lattice-studio.yaml
@@ -8,6 +8,11 @@ config:
   HELLGRAPH_URL: "http://hellgraph-service:8090"
   TRITFABRIC_URL: "http://tritfabric:8750"
   SEARCH_ORCH_URL: "http://search-orchestrator:8080"
+# Activates the WRITE workbench (/api/studio/extract + /node + /edge). Fail-closed: without this, writes
+# return 503 and reads stay open. Secret provisioned out-of-band: `kubectl -n socioprophet create secret
+# generic studio-write-token --from-literal=token=...`.
+secretEnv:
+  STUDIO_WRITE_TOKEN: { secretName: studio-write-token, key: token }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
 # Internal for now (ClusterIP); the app-vue surface reaches it via the same public-gateway pattern as search — a
 # public ingress + DNS is the go-live step, held (ManagedCert clock starts at DNS).


### PR DESCRIPTION
Activates the Studio WRITE workbench (#806). `/api/studio/extract` + `/node` + `/edge` are fail-closed on `STUDIO_WRITE_TOKEN` — unset → 503, reads stay open. Wires it from the `studio-write-token` Secret (created out-of-band). Once merged + rolled, the app-vue ＋ workbench form can write governed facts. Chart renders the secretEnv; preflight passes.