### PR TITLE
feat(studio): 'How derived?' proof-replay endpoint (surface the moat)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -411,6 +411,56 @@ async def graph(project: str = "default", limit: int = 100) -> dict[str, Any]:
             "epistemic_distribution": dist, "degraded": (err if err else None)}
 
 
+def _derivation_summary(node: dict[str, Any], derivations: list[dict[str, Any]]) -> str:
+    """One human sentence: how this fact came to be known — its epistemic status, who/what produced it, and how
+    many other facts it's connected to. The 'How derived?' answer a Bloom/Stardog node inspector can't give."""
+    mode = node.get("epistemic_mode", "unknown")
+    by = node.get("extractor") or "an unknown process"
+    src = node.get("source")
+    origin = f" from {src}" if src else ""
+    n = len(derivations)
+    rel = "no other facts yet" if n == 0 else f"{n} related fact{'s' if n != 1 else ''}"
+    return f"‘{node.get('name', node['id'])}’ is held as {mode}, produced by {by}{origin}, and connected to {rel}."
+
+
+@app.get("/api/studio/provenance")
+async def provenance(project: str = "default", id: str = "") -> dict[str, Any]:
+    """KE-5: 'How derived?' — the derivation of ONE fact. Its provenance (epistemic status + source + extractor +
+    KKO upper-ontology type) plus the edges that connect it (what it was co-observed / reasoned with), read from
+    the live project subgraph. This is the proof-carrying lineage a Neo4j Bloom / Stardog node inspector can't
+    show: not just properties, but where the fact came from and how well it's known."""
+    if not id:
+        raise HTTPException(status_code=422, detail="id required")
+    coll = proj_collection(project)
+    nodes, edges, err = await _fetch_subgraph(coll, 500)
+    node = next((n for n in nodes if n["id"] == id), None)
+    if node is None:
+        return {"id": id, "project": project, "projectCollection": coll, "found": False, "degraded": err}
+    by_id = {n["id"]: n for n in nodes}
+    derivations = []
+    for e in edges:
+        if e["source"] != id and e["target"] != id:
+            continue
+        out = e["source"] == id
+        other = by_id.get(e["target"] if out else e["source"], {})
+        derivations.append({
+            "relation": e["label"], "direction": "out" if out else "in",
+            "with": {"id": other.get("id", ""), "name": other.get("name", ""),
+                     "epistemic_mode": other.get("epistemic_mode", "unknown"), "source": other.get("source")},
+            "weight": e.get("weight", 1),
+        })
+    derivations.sort(key=lambda d: d["weight"], reverse=True)
+    return {
+        "id": id, "project": project, "projectCollection": coll, "found": True, "name": node["name"],
+        "epistemic_mode": node["epistemic_mode"], "source": node.get("source"),
+        "extractor": node.get("extractor"), "kko_type": node.get("kko_type", "Particulars"),
+        "labels": node.get("labels", []),
+        "derivations": derivations, "derivation_count": len(derivations),
+        "summary": _derivation_summary(node, derivations),
+        "degraded": err,
+    }
+
+
 @app.get("/api/studio/graph.ttl")
 async def graph_ttl(project: str = "default", limit: int = 500) -> Response:
     """KE-3: RDF/Turtle export — standards interop (Protégé / GraphDB / Anzo / Stardog) that CARRIES provenance.

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -232,3 +232,51 @@ def test_add_edge_graph_failure_is_502(monkeypatch):
     r = client.post("/api/studio/edge", json={"project": "team-x", "from_name": "A", "to_name": "B"},
                     headers={"authorization": "Bearer secret"})
     assert r.status_code == 502
+
+
+# ── KE-5 "How derived?": proof-carrying provenance/lineage for one fact ──
+
+def test_provenance_requires_id():
+    assert client.get("/api/studio/provenance?project=team-x").status_code == 422
+
+
+def test_provenance_not_found_is_graceful(monkeypatch):
+    import lattice_studio.server as srv
+
+    async def fake_req(client, method, url, json=None):
+        return ({"nodes": [], "edgeList": []}, None)
+    monkeypatch.setattr(srv, "_req", fake_req)
+    b = client.get("/api/studio/provenance?project=team-x&id=proj-teamx:ent:ghost").json()
+    assert b["found"] is False and b["id"] == "proj-teamx:ent:ghost"
+
+
+def test_provenance_returns_derivation_and_summary(monkeypatch):
+    import lattice_studio.server as srv
+
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({
+                "nodes": [
+                    {"id": "proj-teamx:ent:hellgraph", "labels": ["proj-teamx", "Entity"],
+                     "properties": {"name": "HellGraph", "epistemic_mode": "verified", "source": "doc:spec",
+                                    "extractor": "lattice-studio/workbench-v0", "kko_type": "Particulars"}},
+                    {"id": "proj-teamx:ent:neo4j", "labels": ["proj-teamx", "Entity"],
+                     "properties": {"name": "Neo4j", "epistemic_mode": "observed"}},
+                ],
+                "edgeList": [
+                    {"id": "h:1", "label": "beats", "from": "proj-teamx:ent:hellgraph",
+                     "to": "proj-teamx:ent:neo4j", "properties": {"n": 4}},
+                ],
+            }, None)
+        return (None, "unreachable")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    b = client.get("/api/studio/provenance?project=team-x&id=proj-teamx:ent:hellgraph").json()
+    assert b["found"] is True and b["name"] == "HellGraph"
+    assert b["epistemic_mode"] == "verified" and b["extractor"] == "lattice-studio/workbench-v0"
+    assert b["kko_type"] == "Particulars" and b["source"] == "doc:spec"
+    assert b["derivation_count"] == 1
+    d = b["derivations"][0]
+    assert d["relation"] == "beats" and d["direction"] == "out" and d["weight"] == 4
+    assert d["with"]["name"] == "Neo4j" and d["with"]["epistemic_mode"] == "observed"
+    assert "verified" in b["summary"] and "HellGraph" in b["summary"]


### PR DESCRIPTION
**Workstream: surface the moat** (make our differentiators legible — the #1 gap).

`GET /api/studio/provenance?project=&id=` answers **'How derived?'** for one fact:
- its **provenance** — epistemic status + source + extractor + KKO upper-ontology type
- its **derivation edges** — the facts it was co-observed/reasoned with, **each carrying its own epistemic status**
- a human **summary** sentence

Read from the live project subgraph; graceful `found:false` when absent. This is the proof-carrying lineage a **Neo4j Bloom / Stardog node inspector can't show** — not just properties, but where a fact came from and how well it's known.

3 new tests (id-required 422, not-found graceful, derivation+summary). **19 server tests pass.** Frontend wires the existing 'How derived?' button to this (follow-up PR).