### PR TITLE
feat(studio): surface the moat — verified-compute receipts + live moat header (WS#29)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -40,6 +40,13 @@ STUDIO_WRITE_TOKEN = os.getenv("STUDIO_WRITE_TOKEN", "")
 # OPT-IN — unset → reads stay open (backward compatible); set → every read requires a valid socbase-issued
 # bearer token. Governance without a bolt-on: Studio reads are gated by the same identity that runs the estate.
 STUDIO_JWT_SECRET = os.getenv("STUDIO_JWT_SECRET", "")
+# Evidence fabric — verified-compute RECEIPTS. Studio surfaces the replayable proof-of-work behind its services:
+# not "the job ran" (a TEE attestation), but a sealed record of exactly WHAT ran and its verdict, per correlation.
+EVIDENCE_RECEIPTS_URL = os.getenv("EVIDENCE_RECEIPTS_URL", "http://evidence-receipts:8080")
+RECEIPT_SERVICES = [s.strip() for s in os.getenv(
+    "STUDIO_RECEIPT_SERVICES",
+    "hellgraph-service,lattice-studio,search-orchestrator,owl-reasoner,entity-resolution,eval-fabric-api",
+).split(",") if s.strip()]
 
 app = FastAPI(title="Lattice Studio BFF", version=SERVICE_VERSION)
 
@@ -106,12 +113,34 @@ async def studio(project: str = "default", _auth: dict[str, Any] | None = Depend
 
     # ── CONCURRENT live fan-out to the running fabric ──
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        (gstats, gerr), (reg, rerr), (sher, serr) = await asyncio.gather(
+        (gstats, gerr), (reg, rerr), (sher, serr), (subg, _suberr), (rec, _recerr) = await asyncio.gather(
             _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/stats"),
             _req(client, "GET", f"{TRITFABRIC_URL}/v1/registry"),
             _req(client, "POST", f"{SEARCH_ORCH_URL}/v0/search/query", json=_sherlock_request(project)),
+            _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit=300"),
+            _req(client, "GET", f"{EVIDENCE_RECEIPTS_URL}/v1/receipts/recent?service=hellgraph-service&limit=10"),
         )
     degraded = {k: v for k, v in {"graph": gerr, "models": rerr, "extraction": serr}.items() if v}
+
+    # ── The MOAT header, computed live on every load: epistemic distribution + provenance coverage across the
+    # project's facts, plus whether the verified-compute evidence fabric is answering. This governance readout
+    # rides ABOVE every section — the proof-carrying identity of the whole workspace, not just the graph panel.
+    epi_nodes = [_map_node(n) for n in ((subg.get("nodes") if isinstance(subg, dict) else None) or [])]
+    epi_dist: dict[str, int] = {}
+    prov_have = 0
+    for n in epi_nodes:
+        epi_dist[n["epistemic_mode"]] = epi_dist.get(n["epistemic_mode"], 0) + 1
+        if n.get("source"):
+            prov_have += 1
+    moat = {
+        "epistemic_distribution": epi_dist,
+        "fact_count": len(epi_nodes),
+        "provenance_coverage": round(prov_have / len(epi_nodes), 3) if epi_nodes else 0.0,
+        "verified_compute": rec is not None,
+        "receipts_recent": len((rec.get("items") if isinstance(rec, dict) else None) or []),
+        "governed_writes": bool(STUDIO_WRITE_TOKEN),
+        "read_auth": bool(STUDIO_JWT_SECRET),
+    }
 
     # ── Workbench: product_spine object model, bound to the Noetica project ──
     session = dict(spine.get("notebookSession", {}))
@@ -179,10 +208,51 @@ async def studio(project: str = "default", _auth: dict[str, Any] | None = Depend
 
     return {
         "project": project, "projectCollection": coll,
+        "moat": moat,
         "notebooks": notebooks, "data": data, "models": models, "tuning": [], "experiments": experiments,
         "extraction": extraction, "ontology": ontology, "graph": graph, "retrieval": retrieval, "generation": generation,
-        "live": {"hellgraph": gstats is not None, "tritfabric": reg is not None, "search_orchestrator": sher is not None},
+        "live": {"hellgraph": gstats is not None, "tritfabric": reg is not None,
+                 "search_orchestrator": sher is not None, "evidence": rec is not None},
         "degraded": (degraded or None),
+    }
+
+
+def _receipt_verdict(item: dict[str, Any]) -> Any:
+    rc = item.get("receipt") if isinstance(item.get("receipt"), dict) else {}
+    return item.get("verdict") or rc.get("verdict")
+
+
+@app.get("/api/studio/receipts")
+async def receipts(limit: int = 12, _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """Verified-compute RECEIPTS from the evidence fabric — the replayable proof-of-work behind Studio's services,
+    aggregated across the estate. Each is a sealed record (fetch the full bundle at /v1/receipts/{service}/{cid}):
+    not a TEE's 'it ran privately', but 'here is exactly WHAT ran and its verdict'. No incumbent studio has this.
+    Graceful: a down evidence fabric or service degrades only its own slice."""
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        results = await asyncio.gather(*[
+            _req(client, "GET", f"{EVIDENCE_RECEIPTS_URL}/v1/receipts/recent?service={s}&limit={limit}")
+            for s in RECEIPT_SERVICES
+        ])
+    out: list[dict[str, Any]] = []
+    live: dict[str, bool] = {}
+    for svc, (res, err) in zip(RECEIPT_SERVICES, results):
+        live[svc] = err is None
+        items = (res.get("items") if isinstance(res, dict) else None) or []
+        for it in (items if isinstance(items, list) else [])[:limit]:
+            it = it if isinstance(it, dict) else {}
+            cid = str(it.get("correlation_id") or it.get("id") or "")
+            out.append({
+                "service": svc, "correlation_id": cid,
+                "received_at": it.get("received_at") or it.get("timestamp") or it.get("created_at"),
+                "verdict": _receipt_verdict(it),
+                "kind": it.get("kind") or it.get("type"),
+                "bundle_ref": f"/v1/receipts/{svc}/{cid}" if cid else None,
+            })
+    out.sort(key=lambda r: str(r.get("received_at") or ""), reverse=True)
+    return {
+        "receipts": out[: max(limit, 20)], "count": len(out),
+        "services": live, "services_reachable": sum(1 for v in live.values() if v),
+        "detail_endpoint": f"{EVIDENCE_RECEIPTS_URL}/v1/receipts/{{service}}/{{correlation_id}}",
     }
 
 

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -28,7 +28,9 @@ def test_studio_bundle_project_scoped_and_complete():
     for s in ["notebooks", "data", "models", "experiments", "extraction", "ontology", "graph", "retrieval", "generation"]:
         assert s in b and isinstance(b[s], list)
     # graceful degrade: live flags exist; services unreachable in test → False, response still 200
-    assert set(b["live"]) == {"hellgraph", "tritfabric", "search_orchestrator"}
+    assert set(b["live"]) == {"hellgraph", "tritfabric", "search_orchestrator", "evidence"}
+    # the MOAT header rides above every section
+    assert "moat" in b and set(b["moat"]) >= {"epistemic_distribution", "provenance_coverage", "verified_compute", "governed_writes"}
     # retrieval names the real engines
     engines = {r["engine"] for r in b["retrieval"]}
     assert {"fibered-retrieval", "hellgraph", "slash-topics"} <= engines
@@ -304,3 +306,50 @@ def test_reads_accept_valid_socbase_jwt(monkeypatch):
     assert r.status_code == 200 and r.json()["project"] == "team-x"
     bad = jwt.encode({"sub": "x"}, "other-secret", algorithm="HS256")
     assert client.get("/api/studio?project=team-x", headers={"authorization": f"Bearer {bad}"}).status_code == 401
+
+
+# ── WS#29 surface-the-moat: verified-compute receipts + epistemic status on every load ──
+
+def test_moat_header_computes_epistemic_and_verified(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "w")  # governed_writes → True
+
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({"nodes": [
+                {"id": "proj-x:ent:a", "labels": ["proj-x", "Entity"], "properties": {"name": "A", "epistemic_mode": "verified", "source": "doc:1"}},
+                {"id": "proj-x:ent:b", "labels": ["proj-x", "Entity"], "properties": {"name": "B", "epistemic_mode": "observed", "source": "doc:2"}},
+                {"id": "proj-x:ent:c", "labels": ["proj-x", "Entity"], "properties": {"name": "C", "epistemic_mode": "observed"}},
+            ], "edgeList": []}, None)
+        if "receipts/recent" in url:
+            return ({"items": [{"correlation_id": "c1"}, {"correlation_id": "c2"}]}, None)
+        return (None, "unreachable")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    m = client.get("/api/studio?project=x").json()["moat"]
+    assert m["fact_count"] == 3
+    assert m["epistemic_distribution"] == {"verified": 1, "observed": 2}
+    assert m["provenance_coverage"] == round(2 / 3, 3)   # 2 of 3 carry a source
+    assert m["verified_compute"] is True and m["receipts_recent"] == 2
+    assert m["governed_writes"] is True
+
+
+def test_receipts_aggregate_across_the_evidence_fabric(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "RECEIPT_SERVICES", ["hellgraph-service", "owl-reasoner", "down-svc"])
+
+    async def fake_req(client, method, url, json=None):
+        if "service=hellgraph-service" in url:
+            return ({"items": [{"correlation_id": "hg-1", "received_at": "2026-07-17T10:00:00Z", "verdict": "ok"}]}, None)
+        if "service=owl-reasoner" in url:
+            return ({"items": [{"correlation_id": "owl-1", "received_at": "2026-07-17T11:00:00Z", "receipt": {"verdict": "sound"}}]}, None)
+        return (None, "connection refused")   # down-svc degrades only itself
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    b = client.get("/api/studio/receipts").json()
+    assert b["count"] == 2 and b["services_reachable"] == 2
+    assert b["services"] == {"hellgraph-service": True, "owl-reasoner": True, "down-svc": False}
+    # newest first + nested verdict extracted + a replayable bundle ref
+    assert b["receipts"][0]["correlation_id"] == "owl-1" and b["receipts"][0]["verdict"] == "sound"
+    assert b["receipts"][0]["bundle_ref"] == "/v1/receipts/owl-reasoner/owl-1"
+    assert b["receipts"][1]["correlation_id"] == "hg-1" and b["receipts"][1]["verdict"] == "ok"


### PR DESCRIPTION
**Wave 1 · WS#29** — make the proof-carrying edge legible across the whole surface, not just the graph.

**1. `moat` header on `/api/studio`** — computed live from the project subgraph + the evidence fabric on every load: `epistemic_distribution`, `fact_count`, `provenance_coverage` (fraction of facts carrying a source), `verified_compute` (evidence fabric answering?), `receipts_recent`, `governed_writes`, `read_auth`. The governance identity of the *workspace*, riding above every section.

**2. `GET /api/studio/receipts`** — aggregates **real** verified-compute receipts from the evidence fabric (`/v1/receipts/recent`) across the estate's services, newest-first, each with a replayable `bundle_ref` → `/v1/receipts/{service}/{cid}`. Not a TEE's *"it ran privately"* — a sealed record of *exactly what ran and its verdict.* **No incumbent studio surfaces this.** Graceful per-service degrade.

3 new tests; **24 server tests pass.** Frontend moat-strip + receipts panel is the paired PR.