### PR TITLE
feat(studio): experiment tracking — runs as proof-carrying graph facts (WS#32)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -18,8 +18,11 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import os
 import re
+import uuid
+from datetime import datetime, timezone
 from typing import Any
 
 import httpx
@@ -330,6 +333,87 @@ async def query(req: QueryRequest, _auth: dict[str, Any] | None = Depends(requir
         "epistemic": epistemic, "proof": proof,
         "raw": {k: v for k, v in res.items() if k not in ("queryHash", "evaluatedAtSeq", "ok")},
     }
+
+
+# ── WS#32: experiment tracking — runs persisted as FIRST-CLASS proof-carrying graph facts (not a side DB) ──────────
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_json(s: Any) -> Any:
+    if isinstance(s, (dict, list)):
+        return s
+    try:
+        return json.loads(s) if s else {}
+    except (ValueError, TypeError):
+        return {}
+
+
+async def _fetch_raw_nodes(coll: str, limit: int = 500) -> tuple[list[dict[str, Any]], str | None]:
+    """Raw project nodes (properties preserved — unlike _map_node, which projects to a fixed field set)."""
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit={limit}")
+    raw = (res.get("nodes") if isinstance(res, dict) else None) or []
+    return (raw if isinstance(raw, list) else []), err
+
+
+class ExperimentRun(BaseModel):
+    project: str = "default"
+    name: str
+    params: dict[str, Any] = {}
+    metrics: dict[str, float] = {}
+    status: str = "finished"   # running | finished | failed
+    source: str | None = None
+
+
+@app.post("/api/studio/experiments")
+async def create_experiment(req: ExperimentRun, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Track an experiment RUN. MEET MLflow/W&B: params + metrics + status per run. BEAT: the run is persisted as
+    a node in the PROOF-CARRYING graph (labels Run+Experiment), so it isn't a row in a side database — it's a FACT
+    carrying epistemic status + provenance, queryable via the query IDE and linkable to the data/models it touched.
+    Token-gated (it writes the graph)."""
+    _require_write_token(authorization)
+    name = req.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="name required")
+    coll = proj_collection(req.project)
+    run_id = f"{coll}:run:{uuid.uuid4().hex[:12]}"
+    prov = _workbench_prov(coll, "observed", req.source or "studio/experiment")
+    prov["extractor"] = "studio/experiment-v0"
+    props = {
+        "name": name, "run_id": run_id, "status": req.status,
+        "params_json": json.dumps(req.params, default=str), "metrics_json": json.dumps(req.metrics, default=str),
+        "created_at": _now_iso(), **prov,
+    }
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        _, err = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                            json={"id": run_id, "labels": [coll, "Run", "Experiment"], "properties": props})
+    if err:
+        raise HTTPException(status_code=502, detail=f"graph write failed: {err}")
+    return {"run_id": run_id, "project": req.project, "name": name, "status": req.status,
+            "params": req.params, "metrics": req.metrics, "provenance": prov, "written": True}
+
+
+@app.get("/api/studio/experiments")
+async def list_experiments(project: str = "default", limit: int = 200,
+                           _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """List the project's experiment runs — read back from the graph, params/metrics parsed, each run carrying its
+    epistemic status + provenance. These are graph facts you can also query in the IDE (SPARQL/Cypher over runs)."""
+    coll = proj_collection(project)
+    raw, err = await _fetch_raw_nodes(coll, limit)
+    runs: list[dict[str, Any]] = []
+    for n in raw:
+        if "Run" not in (n.get("labels") or []):
+            continue
+        p = n.get("properties") or {}
+        runs.append({
+            "run_id": p.get("run_id") or n.get("id"), "name": p.get("name"), "status": p.get("status", "unknown"),
+            "params": _safe_json(p.get("params_json")), "metrics": _safe_json(p.get("metrics_json")),
+            "created_at": p.get("created_at"), "epistemic_mode": p.get("epistemic_mode", "observed"),
+            "source": p.get("source"), "extractor": p.get("extractor"),
+        })
+    runs.sort(key=lambda r: str(r.get("created_at") or ""), reverse=True)
+    return {"project": project, "projectCollection": coll, "runs": runs, "count": len(runs), "degraded": err}
 
 
 # ── KE-1: the real extraction → HellGraph loop (proof-carrying, project-scoped) ──────────────────────────────────

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -402,3 +402,56 @@ def test_query_is_proof_carrying_and_epistemically_enriched(monkeypatch):
     assert b["proof"]["query_hash"] == "qh-abc" and b["proof"]["evaluated_at_seq"] == 42 and b["proof"]["replayable"] is True
     # THE BEAT #2: the referenced fact carries its epistemic status
     assert b["epistemic"] == {"proj-teamx:ent:hellgraph": "verified"}
+
+
+# ── WS#32: experiment tracking — runs as first-class proof-carrying graph facts ──
+
+def test_experiment_create_is_write_gated():
+    assert client.post("/api/studio/experiments", json={"project": "p", "name": "run-1"}).status_code == 503
+
+
+def test_experiment_persists_run_as_graph_fact(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "w")
+    captured = {}
+
+    async def fake_req(client, method, url, json=None):
+        captured["url"] = url; captured["json"] = json
+        return ({"ok": True}, None)
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.post("/api/studio/experiments",
+                    json={"project": "team-x", "name": "sweep-lr", "params": {"lr": 0.01}, "metrics": {"acc": 0.91}, "status": "finished"},
+                    headers={"authorization": "Bearer w"})
+    assert r.status_code == 200
+    b = r.json()
+    assert b["run_id"].startswith("proj-teamx:run:") and b["written"] is True
+    # persisted to the GRAPH as a Run+Experiment fact carrying provenance
+    assert captured["url"].endswith("/api/graph/node")
+    node = captured["json"]
+    assert node["labels"] == ["proj-teamx", "Run", "Experiment"]
+    assert '"lr": 0.01' in node["properties"]["params_json"] and '"acc": 0.91' in node["properties"]["metrics_json"]
+    assert node["properties"]["extractor"] == "studio/experiment-v0" and node["properties"]["epistemic_mode"] == "observed"
+
+
+def test_experiments_list_reads_runs_with_epistemic(monkeypatch):
+    import lattice_studio.server as srv
+
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({"nodes": [
+                {"id": "proj-teamx:run:abc", "labels": ["proj-teamx", "Run", "Experiment"],
+                 "properties": {"name": "sweep-lr", "run_id": "proj-teamx:run:abc", "status": "finished",
+                                "params_json": "{\"lr\": 0.01}", "metrics_json": "{\"acc\": 0.91}",
+                                "created_at": "2026-07-17T12:00:00Z", "epistemic_mode": "observed", "extractor": "studio/experiment-v0"}},
+                {"id": "proj-teamx:ent:x", "labels": ["proj-teamx", "Entity"], "properties": {"name": "not-a-run"}},
+            ], "edgeList": []}, None)
+        return (None, "unreachable")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    b = client.get("/api/studio/experiments?project=team-x").json()
+    assert b["count"] == 1   # the Entity node is filtered out
+    run = b["runs"][0]
+    assert run["name"] == "sweep-lr" and run["status"] == "finished"
+    assert run["params"] == {"lr": 0.01} and run["metrics"] == {"acc": 0.91}
+    assert run["epistemic_mode"] == "observed" and run["run_id"] == "proj-teamx:run:abc"


### PR DESCRIPTION
**Wave 3 · WS#32** — closes an ML-studio LAG (experiment tracking, −3). **MEET** MLflow/W&B: `POST /api/studio/experiments` logs a run (name · params · metrics · status); `GET` lists the project's runs.

**BEAT:** a run is **not a row in a side database** — it's persisted as a node in the **proof-carrying graph** (labels `Run`+`Experiment`), carrying epistemic status + provenance. So a run is:
- **queryable in the query IDE** we just shipped (SPARQL/Cypher over runs),
- **linkable** to the data/models it touched (graph edges),
- **proof-carrying** — every metric traceable to a fact with lineage.

MLflow's runs live in its own store; ours live in the knowledge graph. Create is token-gated; list parses params/metrics + each run's epistemic status. 3 tests; **30 server tests pass.** Frontend experiments view + log-run is the paired PR.