### PR TITLE
feat(studio): immutable preservation + versioning (WS#36)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -507,6 +507,91 @@ async def resolve(pid: str = "", _auth: dict[str, Any] | None = Depends(require_
     return {"pid": pid, "found": False, "degraded": err}
 
 
+# ── WS#36: immutable preservation + versioning. A tamper-evident, content-addressed snapshot of a knowledge
+# artifact, versioned in a chain (each links to its predecessor). Idempotent: re-preserving unchanged state
+# returns the existing version. The snapshot carries the provenance chain — an archived fact stays proof-carrying. ──
+class PreserveRequest(BaseModel):
+    project: str = "default"
+    target: str = ""        # "" = the whole-project graph; else a label/id to scope the snapshot
+    note: str | None = None
+
+
+def _state_hash(raw: list[dict[str, Any]], target: str) -> str:
+    """A stable content hash over the CURRENT state of the target — the sorted (id, content_hash-of-props) of the
+    nodes in scope. Deterministic, so identical state → identical hash (tamper-evidence + idempotent versioning)."""
+    def in_scope(n: dict[str, Any]) -> bool:
+        if not target:
+            return "Snapshot" not in (n.get("labels") or [])   # don't hash prior snapshots into the state
+        return target in (n.get("labels") or []) or n.get("id") == target
+    parts = []
+    for n in sorted((x for x in raw if in_scope(x)), key=lambda n: str(n.get("id", ""))):
+        props = json.dumps(n.get("properties") or {}, sort_keys=True, default=str)
+        parts.append(f"{n.get('id','')}={hashlib.sha256(props.encode()).hexdigest()[:16]}")
+    return hashlib.sha256("|".join(parts).encode()).hexdigest()
+
+
+@app.post("/api/studio/preserve")
+async def preserve(req: PreserveRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Seal an immutable, versioned snapshot of a knowledge artifact. MEET Zenodo/OSF versioning. BEAT: the
+    snapshot is content-addressed + tamper-evident (re-hash to verify), chained to its predecessor, and carries
+    the provenance chain (epistemic=attested) so an archived fact stays proof-carrying. Idempotent — preserving
+    unchanged state returns the existing version, never a duplicate."""
+    _require_write_token(authorization)
+    coll = proj_collection(req.project)
+    target = req.target or coll
+    raw, err = await _fetch_raw_nodes(coll, 1000)
+    if err:
+        raise HTTPException(status_code=502, detail=f"graph read failed: {err}")
+    content_hash = _state_hash(raw, req.target)
+    snaps = [n for n in raw if "Snapshot" in (n.get("labels") or []) and (n.get("properties") or {}).get("target") == target]
+    snaps.sort(key=lambda n: (n.get("properties") or {}).get("version", 0))
+    # idempotent: unchanged state → return the existing head version
+    if snaps and (snaps[-1].get("properties") or {}).get("content_hash") == content_hash:
+        p = snaps[-1]["properties"]
+        return {"snapshot_id": snaps[-1].get("id"), "version": p.get("version"), "content_hash": content_hash,
+                "target": target, "sealed_at": p.get("sealed_at"), "unchanged": True, "proof_carrying": True}
+    version = len(snaps) + 1
+    parent = snaps[-1].get("id") if snaps else None
+    sealed_at = _now_iso()
+    snap_id = f"{coll}:snap:{content_hash[:12]}"
+    prov = _workbench_prov(coll, "attested", "studio/preserve")
+    prov["extractor"] = "studio/preserve-v0"
+    props = {"target": target, "version": version, "content_hash": content_hash, "sealed_at": sealed_at,
+             "parent": parent or "", "note": req.note or "", **prov}
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        _, werr = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": snap_id, "labels": [coll, "Snapshot", "Preservation"], "properties": props})
+        if werr:
+            raise HTTPException(status_code=502, detail=f"graph write failed: {werr}")
+        if parent:  # chain to predecessor (version lineage)
+            await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                       json={"label": "supersedes", "from": snap_id, "to": parent, "properties": prov})
+    return {"snapshot_id": snap_id, "version": version, "content_hash": content_hash, "target": target,
+            "sealed_at": sealed_at, "parent": parent, "unchanged": False, "proof_carrying": True}
+
+
+@app.get("/api/studio/versions")
+async def versions(project: str = "default", target: str = "",
+                   _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """The version history of a preserved artifact — the immutable chain, newest first, each sealed with its
+    content hash + timestamp. Verify integrity by re-hashing the state against a version's content_hash."""
+    coll = proj_collection(project)
+    tgt = target or coll
+    raw, err = await _fetch_raw_nodes(coll, 1000)
+    snaps = []
+    for n in raw:
+        if "Snapshot" not in (n.get("labels") or []):
+            continue
+        p = n.get("properties") or {}
+        if p.get("target") != tgt:
+            continue
+        snaps.append({"snapshot_id": n.get("id"), "version": p.get("version"), "content_hash": p.get("content_hash"),
+                      "sealed_at": p.get("sealed_at"), "parent": p.get("parent") or None, "note": p.get("note") or None,
+                      "epistemic_mode": p.get("epistemic_mode", "attested")})
+    snaps.sort(key=lambda s: s.get("version") or 0, reverse=True)
+    return {"project": project, "target": tgt, "versions": snaps, "count": len(snaps), "degraded": err}
+
+
 # ── KE-1: the real extraction → HellGraph loop (proof-carrying, project-scoped) ──────────────────────────────────
 # Deterministic entity + co-occurrence extraction (honest: not LLM). Every fact is written as a HellGraph atom with
 # epistemic_mode="observed" + source provenance + the project label — the moat made real: not "entity X", but

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -521,3 +521,70 @@ def test_resolve_returns_proof_carrying_record(monkeypatch):
     # resolves to a VERIFIABLE record, not a landing page
     assert b["proof_carrying"] is True and b["content_hash"] == "abc123def456"
     assert b["provenance"]["epistemic_mode"] == "attested" and b["creators"] == ["M. Heller"]
+
+
+# ── WS#36: immutable preservation + versioning (content-addressed, chained, tamper-evident) ──
+
+def test_preserve_is_write_gated():
+    assert client.post("/api/studio/preserve", json={"project": "p"}).status_code == 503
+
+
+def test_preserve_seals_v1_snapshot(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "w")
+    posts = []
+    nodes = [
+        {"id": "proj-teamx:ent:a", "labels": ["proj-teamx", "Entity"], "properties": {"name": "A", "epistemic_mode": "observed"}},
+        {"id": "proj-teamx:ent:b", "labels": ["proj-teamx", "Entity"], "properties": {"name": "B", "epistemic_mode": "observed"}},
+    ]
+
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({"nodes": nodes, "edgeList": []}, None)
+        posts.append((url, json)); return ({"ok": True}, None)
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    b = client.post("/api/studio/preserve", json={"project": "team-x", "note": "first seal"}, headers={"authorization": "Bearer w"}).json()
+    assert b["version"] == 1 and b["content_hash"] == srv._state_hash(nodes, "") and b["unchanged"] is False and b["parent"] is None
+    node_post = next(p for u, p in posts if u.endswith("/api/graph/node"))
+    assert node_post["labels"] == ["proj-teamx", "Snapshot", "Preservation"]
+    assert node_post["properties"]["version"] == 1 and node_post["properties"]["epistemic_mode"] == "attested"
+
+
+def test_preserve_is_idempotent_on_unchanged_state(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "w")
+    ents = [{"id": "proj-teamx:ent:a", "labels": ["proj-teamx", "Entity"], "properties": {"name": "A"}}]
+    h = srv._state_hash(ents, "")
+    snap = {"id": "proj-teamx:snap:x", "labels": ["proj-teamx", "Snapshot", "Preservation"],
+            "properties": {"target": "proj-teamx", "version": 1, "content_hash": h, "sealed_at": "t0"}}
+    created = []
+
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({"nodes": ents + [snap], "edgeList": []}, None)
+        created.append(url); return ({"ok": True}, None)
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    b = client.post("/api/studio/preserve", json={"project": "team-x"}, headers={"authorization": "Bearer w"}).json()
+    assert b["unchanged"] is True and b["version"] == 1
+    assert not any(u.endswith("/api/graph/node") for u in created)   # no duplicate snapshot written
+
+
+def test_versions_lists_the_chain_newest_first(monkeypatch):
+    import lattice_studio.server as srv
+
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({"nodes": [
+                {"id": "proj-teamx:snap:1", "labels": ["proj-teamx", "Snapshot"],
+                 "properties": {"target": "proj-teamx", "version": 1, "content_hash": "h1", "sealed_at": "t1", "epistemic_mode": "attested"}},
+                {"id": "proj-teamx:snap:2", "labels": ["proj-teamx", "Snapshot"],
+                 "properties": {"target": "proj-teamx", "version": 2, "content_hash": "h2", "sealed_at": "t2", "parent": "proj-teamx:snap:1", "epistemic_mode": "attested"}},
+            ], "edgeList": []}, None)
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    b = client.get("/api/studio/versions?project=team-x").json()
+    assert b["count"] == 2 and b["versions"][0]["version"] == 2   # newest first
+    assert b["versions"][0]["parent"] == "proj-teamx:snap:1" and b["versions"][1]["content_hash"] == "h1"


### PR DESCRIPTION
**Wave 5 · WS#36** — closes the preservation gap (−3). **MEET Zenodo/OSF** versioning: `POST /api/studio/preserve` seals a content-addressed, tamper-evident snapshot; `GET /api/studio/versions` returns the history (newest first).

**BEAT:** the snapshot is **chained** to its predecessor (`supersedes` edge = version lineage), carries the **provenance chain** (epistemic=`attested`), and is **idempotent** — re-preserving unchanged state returns the existing version, never a duplicate. Verify integrity by re-hashing state against a version's `content_hash`. Builds directly on WS#35's content-hashing. 4 tests; **38 server tests pass.**