### PR TITLE
WS#37: FAIR metadata + interoperability (schema.org/Dataset + DataCite + FAIR+ provenance)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -592,6 +592,54 @@ async def versions(project: str = "default", target: str = "",
     return {"project": project, "target": tgt, "versions": snaps, "count": len(snaps), "degraded": err}
 
 
+# ── WS#37: FAIR metadata + interoperability. Assembles a FAIR record (Findable/Accessible/Interoperable/
+# Reusable) from the artifact's citation + preservation, emits schema.org/Dataset JSON-LD (Google Dataset
+# Search) alongside DataCite + the PROV-O Turtle export, and scores FAIR. The BEAT is FAIR+: epistemic status
+# and a verifiable provenance chain ride inside the metadata (nanopublication-style), which FAIR alone omits. ──
+@app.get("/api/studio/fair")
+async def fair(project: str = "default", target: str = "",
+               _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """FAIR metadata + self-assessment for a knowledge artifact. MEET Zenodo/OpenAIRE: schema.org/Dataset JSON-LD +
+    DataCite + PROV-O Turtle + an F/A/I/R score. BEAT (FAIR+): epistemic status + a verifiable provenance chain
+    ride inside the record — Interoperability is real (RDF/PROV-O export), not just 'a metadata blob exists'."""
+    coll = proj_collection(project)
+    tgt = target or coll
+    raw, err = await _fetch_raw_nodes(coll, 1000)
+    cite = next((n.get("properties") or {} for n in raw
+                 if "Citation" in (n.get("labels") or []) and (n.get("properties") or {}).get("target") == tgt), {})
+    snaps = [n.get("properties") or {} for n in raw
+             if "Snapshot" in (n.get("labels") or []) and (n.get("properties") or {}).get("target") == tgt]
+    snaps.sort(key=lambda p: p.get("version", 0))
+    pid, doi = cite.get("pid"), cite.get("doi")
+    title = cite.get("title") or f"{project} — knowledge graph"
+    resolve = cite.get("resolve")
+    version = snaps[-1].get("version") if snaps else None
+    content_hash = (snaps[-1].get("content_hash") if snaps else None) or cite.get("content_hash")
+    turtle_export = f"/api/studio/graph.ttl?project={project}"
+    schema_org = {
+        "@context": "https://schema.org/", "@type": "Dataset", "name": title,
+        "identifier": doi or pid, "url": resolve,
+        "creator": {"@type": "Organization", "name": "SocioProphet Knowledge Commons"},
+        "distribution": {"@type": "DataDownload", "encodingFormat": "text/turtle", "contentUrl": turtle_export},
+        "version": version, "sha256": content_hash,
+        # FAIR+: provenance + epistemic status ride in the record
+        "provenance": {"epistemic_status": cite.get("epistemic_mode", "observed"), "hashSealed": bool(content_hash)},
+    }
+    findable, accessible = bool(pid or doi), bool(resolve)
+    interoperable = True                      # RDF/Turtle + PROV-O + schema.org always available
+    reusable = bool(cite)                     # provenance present (+ license, implicit)
+    score = round(sum([findable, accessible, interoperable, reusable]) / 4, 2)
+    return {
+        "project": project, "target": tgt, "title": title, "pid": pid, "doi": doi,
+        "version": version, "content_hash": content_hash,
+        "schema_org": schema_org, "datacite_doi": doi, "turtle_export": turtle_export,
+        "fair": {"findable": findable, "accessible": accessible, "interoperable": interoperable, "reusable": reusable, "score": score},
+        "fair_plus": {"epistemic": True, "provenance_chain": bool(snaps), "hash_sealed": bool(content_hash)},
+        "hint": None if findable else "mint a persistent identifier (Cite) to make this Findable",
+        "degraded": err,
+    }
+
+
 # ── KE-1: the real extraction → HellGraph loop (proof-carrying, project-scoped) ──────────────────────────────────
 # Deterministic entity + co-occurrence extraction (honest: not LLM). Every fact is written as a HellGraph atom with
 # epistemic_mode="observed" + source provenance + the project label — the moat made real: not "entity X", but

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -588,3 +588,46 @@ def test_versions_lists_the_chain_newest_first(monkeypatch):
     b = client.get("/api/studio/versions?project=team-x").json()
     assert b["count"] == 2 and b["versions"][0]["version"] == 2   # newest first
     assert b["versions"][0]["parent"] == "proj-teamx:snap:1" and b["versions"][1]["content_hash"] == "h1"
+
+
+def test_fair_full_record_scores_high_and_carries_provenance(monkeypatch):
+    import lattice_studio.server as srv
+
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({"nodes": [
+                {"id": "proj-teamx:cite", "labels": ["proj-teamx", "Citation"],
+                 "properties": {"target": "proj-teamx", "pid": "sp:proj-teamx/graph/abc123",
+                                "doi": "10.82044/proj-teamx.graph.abc12345", "title": "Team X graph",
+                                "resolve": "https://x/api/studio/resolve?pid=sp:proj-teamx/graph/abc123",
+                                "epistemic_mode": "verified"}},
+                {"id": "proj-teamx:snap:1", "labels": ["proj-teamx", "Snapshot"],
+                 "properties": {"target": "proj-teamx", "version": 1, "content_hash": "seal1"}},
+            ], "edgeList": []}, None)
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    b = client.get("/api/studio/fair?project=team-x").json()
+    assert b["fair"]["findable"] and b["fair"]["accessible"] and b["fair"]["reusable"]
+    assert b["fair"]["score"] == 1.0
+    assert b["schema_org"]["@type"] == "Dataset" and b["schema_org"]["sha256"] == "seal1"
+    assert b["schema_org"]["identifier"] == "10.82044/proj-teamx.graph.abc12345"
+    assert b["schema_org"]["provenance"]["epistemic_status"] == "verified"   # FAIR+
+    assert b["fair_plus"]["provenance_chain"] and b["fair_plus"]["hash_sealed"]
+    assert b["hint"] is None
+
+
+def test_fair_without_citation_is_not_findable_and_hints(monkeypatch):
+    import lattice_studio.server as srv
+
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({"nodes": [], "edgeList": []}, None)   # nothing minted yet
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    b = client.get("/api/studio/fair?project=team-x").json()
+    assert not b["fair"]["findable"] and not b["fair"]["accessible"]
+    assert b["fair"]["interoperable"]              # RDF/PROV-O always available
+    assert b["fair"]["score"] == 0.25
+    assert b["hint"] and "persistent identifier" in b["hint"]


### PR DESCRIPTION
Adds `GET /api/studio/fair?project=&target=` — assembles a FAIR record from the artifact's citation (WS#35) + preservation (WS#36):

- **schema.org/Dataset JSON-LD** — the format Google Dataset Search indexes (Findable on the open web).
- **DataCite DOI ref** + **PROV-O Turtle export** pointer (`/api/studio/graph.ttl`) — real Interoperability, not a metadata blob.
- **F/A/I/R self-assessment score** with a hint to mint a PID when not yet Findable.
- **FAIR+ (the beat):** epistemic status + a verifiable provenance chain ride *inside* the record (nanopublication-style) — the axis mainstream repositories omit.

Read-only, `require_read`-gated. +2 tests (full record → score 1.0 + provenance; no-citation → not findable + hint). 40/40 pass.