### PR TITLE
WS#39: commons at scale + community curation (epistemic-weighted, governed)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -697,6 +697,129 @@ async def ecosystem(project: str = "default", target: str = "",
             "agent_manifest": agent_manifest, "degraded": err}
 
 
+# ── WS#39: commons at scale + community curation. MEET Zenodo/Wikidata: a commons overview (scale + community
+# stats) and community endorsement of records. BEAT (epistemic curation): endorsements are governed, proof-
+# carrying facts (identified endorser, revocable), and the curation score is EPISTEMIC-WEIGHTED — trust follows
+# the epistemic status of the underlying facts (attested > verified > observed …), not raw popularity. ──────────
+# epistemic ladder → curation weight (higher = more trustworthy grounding). Mirrors studioApi EPISTEMIC_ORDER.
+EPISTEMIC_WEIGHT = {"attested": 1.0, "verified": 0.85, "observed": 0.6,
+                    "derived": 0.45, "hypothesis": 0.25, "simulated": 0.1}
+
+
+@app.get("/api/studio/commons")
+async def commons(project: str = "default",
+                  _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """Commons-at-scale overview for a project: node/edge counts, the epistemic-status distribution, and the
+    community signals (citations, preserved versions, endorsements, contributors). The scale + health story —
+    every count is grounded in the graph, and the epistemic distribution is the quality signal repos lack."""
+    coll = proj_collection(project)
+    raw, err = await _fetch_raw_nodes(coll, 2000)
+    epistemic: dict[str, int] = {}
+    citations = versions = endorsements = 0
+    contributors: set[str] = set()
+    facts = 0
+    for n in raw:
+        labels = n.get("labels") or []
+        p = n.get("properties") or {}
+        if "Citation" in labels:
+            citations += 1
+        elif "Snapshot" in labels:
+            versions += 1
+        elif "Endorsement" in labels:
+            endorsements += 1
+        else:
+            facts += 1
+            mode = p.get("epistemic_mode")
+            if mode:
+                epistemic[mode] = epistemic.get(mode, 0) + 1
+        if p.get("orcid"):
+            contributors.add(p["orcid"])
+    # a single epistemic-weighted quality index over the project's facts (0..1)
+    graded = sum(EPISTEMIC_WEIGHT.get(m, 0.3) * c for m, c in epistemic.items())
+    total_graded = sum(epistemic.values())
+    quality_index = round(graded / total_graded, 3) if total_graded else None
+    return {
+        "project": project, "collection": coll,
+        "scale": {"facts": facts, "citations": citations, "preserved_versions": versions,
+                  "endorsements": endorsements, "contributors": len(contributors)},
+        "epistemic_distribution": epistemic,
+        "epistemic_quality_index": quality_index,   # the beat: quality, not just volume
+        "degraded": err,
+    }
+
+
+class EndorseRequest(BaseModel):
+    project: str = "default"
+    target: str            # node id (or label) being endorsed
+    endorser: str          # identified endorser (orcid / sovereign id / handle) — no anonymous curation
+    note: str | None = None
+    revoke: bool = False    # governed: an endorsement can be withdrawn
+
+
+@app.post("/api/studio/endorse")
+async def endorse(req: EndorseRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Community curation: an identified endorser endorses (or revokes) a record. BEAT: the endorsement is a
+    governed, proof-carrying graph fact — identified endorser, timestamped, revocable — not an anonymous vote.
+    Idempotent per (target, endorser): re-endorsing updates; revoke marks it withdrawn."""
+    _require_write_token(authorization)
+    if not req.target.strip() or not req.endorser.strip():
+        raise HTTPException(status_code=422, detail="target and endorser required")
+    coll = proj_collection(req.project)
+    endorser_key = hashlib.sha256(req.endorser.encode()).hexdigest()[:12]
+    end_id = f"{coll}:endorse:{hashlib.sha256(req.target.encode()).hexdigest()[:8]}:{endorser_key}"
+    prov = _workbench_prov(coll, "attested", "studio/endorse")
+    prov["extractor"] = "lattice-studio/endorse-v0"
+    props = {"target": req.target, "endorser": req.endorser, "note": req.note or "",
+             "revoked": req.revoke, "at": _now_iso(), **prov}
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        _, werr = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": end_id, "labels": [coll, "Endorsement", "Curation"], "properties": props})
+        if werr:
+            raise HTTPException(status_code=502, detail=f"graph write failed: {werr}")
+        if not req.revoke:      # link the endorsement to what it endorses (revoked ones stay as tombstones)
+            await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                       json={"label": "endorses", "from": end_id, "to": req.target, "properties": prov})
+    return {"endorsement_id": end_id, "target": req.target, "endorser": req.endorser,
+            "revoked": req.revoke, "proof_carrying": True}
+
+
+@app.get("/api/studio/curation")
+async def curation(project: str = "default", target: str = "",
+                   _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """The curation signals for a target: the identified, non-revoked endorsements and an epistemic-weighted
+    curation score. BEAT: the score weights each endorsement by the epistemic status of the endorsed fact —
+    an endorsement of an attested fact counts more than one of a hypothesis. Governance is read-enforced:
+    revoked endorsements never contribute."""
+    coll = proj_collection(project)
+    raw, err = await _fetch_raw_nodes(coll, 2000)
+    by_id = {n.get("id"): (n.get("properties") or {}) for n in raw}
+    fact_mode = {nid: p.get("epistemic_mode") for nid, p in by_id.items()}
+    endorsements = []
+    seen: set[str] = set()
+    for n in raw:
+        if "Endorsement" not in (n.get("labels") or []):
+            continue
+        p = n.get("properties") or {}
+        if target and p.get("target") != target:
+            continue
+        if p.get("revoked"):        # governance: withdrawn curation never counts
+            continue
+        key = f"{p.get('target')}|{p.get('endorser')}"
+        if key in seen:
+            continue
+        seen.add(key)
+        endorsements.append({"target": p.get("target"), "endorser": p.get("endorser"),
+                             "note": p.get("note") or None, "at": p.get("at")})
+    # epistemic-weighted curation score: each endorsement scaled by the grounding of the fact it endorses
+    score = 0.0
+    for e in endorsements:
+        mode = fact_mode.get(e["target"]) or "observed"
+        score += EPISTEMIC_WEIGHT.get(mode, 0.3)
+    return {"project": project, "target": target or None, "endorsements": endorsements,
+            "count": len(endorsements), "curation_score": round(score, 3),
+            "epistemic_weighted": True, "degraded": err}
+
+
 # ── KE-1: the real extraction → HellGraph loop (proof-carrying, project-scoped) ──────────────────────────────────
 # Deterministic entity + co-occurrence extraction (honest: not LLM). Every fact is written as a HellGraph atom with
 # epistemic_mode="observed" + source provenance + the project label — the moat made real: not "entity X", but

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -659,3 +659,62 @@ def test_ecosystem_links_scholarly_and_emits_agent_manifest(monkeypatch):
     verbs = {v["name"]: v for v in m["access"]}
     assert verbs["resolve"]["endpoint"] and all(v["verifiable"] for v in m["access"])
     assert "receipts" in verbs and "query" in verbs
+
+
+def test_commons_overview_counts_scale_and_epistemic_quality(monkeypatch):
+    import lattice_studio.server as srv
+
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({"nodes": [
+                {"id": "proj-teamx:a", "labels": ["proj-teamx", "Entity"], "properties": {"epistemic_mode": "attested", "orcid": "0000-0001-0000-0001"}},
+                {"id": "proj-teamx:b", "labels": ["proj-teamx", "Entity"], "properties": {"epistemic_mode": "hypothesis"}},
+                {"id": "proj-teamx:cite", "labels": ["proj-teamx", "Citation"], "properties": {"target": "proj-teamx"}},
+                {"id": "proj-teamx:snap:1", "labels": ["proj-teamx", "Snapshot"], "properties": {"target": "proj-teamx", "version": 1}},
+                {"id": "proj-teamx:endorse:x", "labels": ["proj-teamx", "Endorsement"], "properties": {"target": "proj-teamx:a", "endorser": "kim"}},
+            ], "edgeList": []}, None)
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    b = client.get("/api/studio/commons?project=team-x").json()
+    assert b["scale"] == {"facts": 2, "citations": 1, "preserved_versions": 1, "endorsements": 1, "contributors": 1}
+    assert b["epistemic_distribution"] == {"attested": 1, "hypothesis": 1}
+    assert b["epistemic_quality_index"] == round((1.0 + 0.25) / 2, 3)   # attested + hypothesis
+
+
+def test_endorse_requires_write_token(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "")
+    r = client.post("/api/studio/endorse", json={"project": "team-x", "target": "proj-teamx:a", "endorser": "kim"})
+    assert r.status_code == 503   # fail-closed
+
+
+def test_endorse_writes_governed_fact_and_curation_is_epistemic_weighted(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    writes = []
+
+    async def fake_req(client, method, url, json=None):
+        if "/api/graph/node" in url or "/api/graph/edge" in url:
+            writes.append(json)
+            return ({"ok": True}, None)
+        if "subgraph" in url:
+            return ({"nodes": [
+                {"id": "proj-teamx:a", "labels": ["proj-teamx", "Entity"], "properties": {"epistemic_mode": "attested"}},
+                {"id": "e1", "labels": ["proj-teamx", "Endorsement"], "properties": {"target": "proj-teamx:a", "endorser": "kim", "revoked": False, "at": "t"}},
+                {"id": "e2", "labels": ["proj-teamx", "Endorsement"], "properties": {"target": "proj-teamx:a", "endorser": "sam", "revoked": True, "at": "t"}},
+            ], "edgeList": []}, None)
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.post("/api/studio/endorse", json={"project": "team-x", "target": "proj-teamx:a", "endorser": "kim"},
+                    headers={"Authorization": "Bearer T"})
+    assert r.status_code == 200 and r.json()["proof_carrying"]
+    node = next(w for w in writes if "labels" in w)
+    assert "Endorsement" in node["labels"] and "Curation" in node["labels"]
+
+    c = client.get("/api/studio/curation?project=team-x&target=proj-teamx:a").json()
+    assert c["count"] == 1                          # revoked endorsement excluded
+    assert c["endorsements"][0]["endorser"] == "kim"
+    assert c["curation_score"] == 1.0               # endorsing an attested fact = full weight
+    assert c["epistemic_weighted"]


### PR DESCRIPTION
Closes Wave 5 — the proof-carrying knowledge commons at scale.

- **`GET /api/studio/commons`** — commons overview: facts / citations / preserved versions / endorsements / contributors, the **epistemic-status distribution**, and an **epistemic quality index** (the beat: quality signal, not just volume — the thing Zenodo/Wikidata counts can't show).
- **`POST /api/studio/endorse`** — community curation as a **governed, proof-carrying graph fact**: identified endorser (no anonymous votes), timestamped, **revocable**. Fail-closed write token; idempotent per (target, endorser).
- **`GET /api/studio/curation`** — non-revoked endorsements + an **epistemic-weighted curation score**: each endorsement is scaled by the epistemic status of the fact it endorses (attested > verified > observed > …), so curation follows grounding, not popularity. Revocation is read-enforced.

Read-only reads are `require_read`-gated; writes are `_require_write_token` fail-closed. +3 tests (scale/quality index, write-gate, governed endorse + epistemic-weighted curation). 44/44 pass.