### PR TITLE
Agora — sovereign work + knowledge plane (Jira/Confluence killer) over HellGraph [build stage]

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -72,6 +72,7 @@ jobs:
           - { image: node-commander,        context: apps/node-commander,        dockerfile: Dockerfile }
           - { image: liberty-stack-readout, context: apps/liberty-stack-readout, dockerfile: Dockerfile }
           - { image: tritfabric-consumption-api, context: ., dockerfile: apps/tritfabric-consumption-api/Dockerfile }
+          - { image: agora,                 context: apps/agora,                 dockerfile: Dockerfile }
     uses: SocioProphet/.github/.github/workflows/build-image.yml@main
     with:
       image: ${{ matrix.image }}

--- a/apps/agora/Dockerfile
+++ b/apps/agora/Dockerfile
@@ -1,0 +1,11 @@
+# agora — the sovereign work + knowledge plane (Jira/Confluence killer). Work items + wiki pages as proof-
+# carrying HellGraph facts. Alongside zot (registry) & gitea-sovereign (SCM) in the estate.
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+ENV PORT=8080
+EXPOSE 8080
+# 8080 + /healthz = the chart contract.
+CMD ["uvicorn", "agora.server:app", "--host", "0.0.0.0", "--port", "8080", "--app-dir", "src"]

--- a/apps/agora/pyproject.toml
+++ b/apps/agora/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "prophet-agora"
+version = "0.1.0"
+description = "Agora — the sovereign work + knowledge plane (Jira/Confluence killer): work items + wiki pages as proof-carrying HellGraph facts."
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+    "httpx>=0.27.0",
+    "pyjwt>=2.9.0",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+]

--- a/apps/agora/requirements.txt
+++ b/apps/agora/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.115.0
+uvicorn>=0.30.0
+httpx>=0.27.0
+pyjwt>=2.9.0

--- a/apps/agora/src/agora/server.py
+++ b/apps/agora/src/agora/server.py
@@ -1,0 +1,328 @@
+"""Agora — the sovereign work + knowledge plane (Jira/Confluence killer) for the SocioProphet estate.
+
+Sits alongside zot (sovereign registry) and gitea-sovereign (source control). Where those two are the
+build & code substrate, Agora is the WORK & KNOWLEDGE substrate that bridges Knowledge Engineering ⇄ the
+Knowledge Commons: issues / tasks / sprints (the Jira side) and wiki pages (the Confluence side) are not rows
+in a side database — they are persisted as PROOF-CARRYING GRAPH FACTS over HellGraph, in the very same `proj-`
+collection that Noetica and lattice-studio already share. That means every work item and page is, for free:
+
+  • project- and team-aligned (it lives in the project's collection, which the agent team already reads),
+  • citable (Studio /cite mints a sovereign DOI over it),
+  • preservable + versionable (Studio /preserve seals it),
+  • curatable (Studio /endorse + epistemic-weighted curation apply to it),
+  • queryable live by any agent (SPARQL/Cypher/Gremlin over the kernel).
+
+It reuses Noetica's native work model (lib/types/work.ts: WorkItem / Sprint / Project — "native = source of
+truth, Jira/Linear/GitHub Issues = optional external connectors only"), moving it off localStorage and onto the
+graph. Team and Page are greenfield here (neither existed in Noetica). Writes are fail-closed behind
+AGORA_WRITE_TOKEN; reads follow the estate's sovereign-identity gate (socbase HS256 JWT), opt-in.
+"""
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+import jwt
+from fastapi import Depends, FastAPI, Header, HTTPException
+from pydantic import BaseModel
+
+SERVICE_VERSION = "0.1.0"
+HELLGRAPH_URL = os.getenv("HELLGRAPH_URL", "http://hellgraph-service:8090")
+TIMEOUT = float(os.getenv("AGORA_TIMEOUT", "5"))
+# Fail-closed write gate — unset → all writes refused (reads stay open), so a public ingress can never accept an
+# anonymous work/page write. Token provisioned out-of-band (Secret), same posture as lattice-studio.
+AGORA_WRITE_TOKEN = os.getenv("AGORA_WRITE_TOKEN", "")
+# Opt-in read gate tied to the sovereign identity plane (socbase/GoTrue HS256). Unset → reads open (compatible).
+AGORA_JWT_SECRET = os.getenv("AGORA_JWT_SECRET", "")
+
+# The Jira board columns (mirrors Noetica WorkItem.status).
+WORK_STATUSES = ["backlog", "todo", "in_progress", "in_review", "done", "cancelled"]
+WORK_TYPES = ["task", "epic", "story", "bug", "spike", "milestone"]
+
+app = FastAPI(title="Agora — work + knowledge plane", version=SERVICE_VERSION)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def proj_collection(project: str) -> str:
+    """Mirror Noetica projectCollectionId / lattice-studio proj_collection — proj-<12 hex, dashes stripped>,
+    so Agora facts co-locate with the project's KB, extracted entities, citations and snapshots."""
+    return "proj-" + re.sub(r"-", "", project)[:12]
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", s.strip().lower()).strip("-") or "untitled"
+
+
+def require_read(authorization: str = Header(default="")) -> dict[str, Any] | None:
+    """READ dependency: unset secret → open; else require a valid socbase-issued HS256 bearer token."""
+    if not AGORA_JWT_SECRET:
+        return None
+    token = authorization.removeprefix("Bearer ").strip()
+    if not token:
+        raise HTTPException(status_code=401, detail="read requires a bearer token (AGORA_JWT_SECRET is set)")
+    try:
+        return jwt.decode(token, AGORA_JWT_SECRET, algorithms=["HS256"], options={"verify_aud": False})
+    except jwt.PyJWTError as exc:
+        raise HTTPException(status_code=401, detail=f"invalid token: {exc}") from exc
+
+
+def _require_write(authorization: str) -> None:
+    if not AGORA_WRITE_TOKEN:
+        raise HTTPException(status_code=503, detail="agora writes disabled: AGORA_WRITE_TOKEN unset (fail-closed)")
+    if authorization.removeprefix("Bearer ").strip() != AGORA_WRITE_TOKEN:
+        raise HTTPException(status_code=401, detail="invalid write token")
+
+
+async def _req(client: httpx.AsyncClient, method: str, url: str, json: Any = None) -> tuple[Any, str | None]:
+    """The one resilient upstream call to hellgraph-service. Returns (json_or_None, error_or_None); never raises,
+    so a graph blip degrades gracefully instead of 500-ing the work board."""
+    try:
+        r = await client.request(method, url, json=json)
+        r.raise_for_status()
+        return (r.json() if r.content else {}), None
+    except Exception as exc:  # noqa: BLE001 — deliberately broad; upstream health is not our contract
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+async def _fetch_nodes(coll: str, limit: int = 1000) -> tuple[list[dict[str, Any]], str | None]:
+    """Read the project's induced subgraph and return its raw nodes (each {id, labels, properties})."""
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        data, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit={limit}")
+    if err or not data:
+        return [], err
+    return data.get("nodes") or [], None
+
+
+def _prov(coll: str, extractor: str, actor: str | None) -> dict[str, Any]:
+    """Provenance stamped on every Agora fact — same shape lattice-studio uses, so a work item / page is as
+    proof-carrying as an extracted entity. epistemic_mode=attested: a work item is an ASSERTED operational fact
+    (someone declared this state), which is exactly the Peircean 'attested' rung, not an observation."""
+    return {"epistemic_mode": "attested", "source": actor or "agora",
+            "extractor": extractor, "project": coll, "kko_type": "Particulars"}
+
+
+# ── health ───────────────────────────────────────────────────────────────────────────────────────────────────
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    return {"status": "ok", "service": "agora", "version": SERVICE_VERSION}
+
+
+# ── work items (the Jira side) ─────────────────────────────────────────────────────────────────────────────────
+class WorkItemRequest(BaseModel):
+    project: str = "default"
+    title: str
+    type: str = "task"                 # task | epic | story | bug | spike | milestone
+    description: str | None = None
+    status: str = "backlog"
+    priority: str | None = None
+    assignee: str | None = None        # human or agent id
+    team: str | None = None
+    sprint: str | None = None
+    epic: str | None = None            # parent epic id (links to another WorkItem)
+    tags: list[str] | None = None
+    actor: str | None = None           # who authored this change (provenance)
+
+
+@app.post("/api/agora/work")
+async def upsert_work(req: WorkItemRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Create or update a work item, persisted as a proof-carrying HellGraph node (+ in_project / in_sprint /
+    in_team / assigned_to / child_of edges). Idempotent per (project, title). Reuses Noetica's WorkItem shape."""
+    _require_write(authorization)
+    title = req.title.strip()
+    if not title:
+        raise HTTPException(status_code=422, detail="title required")
+    if req.status not in WORK_STATUSES:
+        raise HTTPException(status_code=422, detail=f"status must be one of {WORK_STATUSES}")
+    if req.type not in WORK_TYPES:
+        raise HTTPException(status_code=422, detail=f"type must be one of {WORK_TYPES}")
+    coll = proj_collection(req.project)
+    wid = f"{coll}:work:{_slug(title)}"
+    prov = _prov(coll, "agora/work-v0", req.actor)
+    props = {"title": title, "type": req.type, "description": req.description or "", "status": req.status,
+             "priority": req.priority or "", "assignee": req.assignee or "", "team": req.team or "",
+             "sprint": req.sprint or "", "epic": req.epic or "", "tags": ",".join(req.tags or []),
+             "updated_at": _now_iso(), **prov}
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        _, werr = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": wid, "labels": [coll, "WorkItem", req.type.capitalize()], "properties": props})
+        if werr:
+            raise HTTPException(status_code=502, detail=f"graph write failed: {werr}")
+        edges = [("in_project", coll)]
+        if req.sprint:
+            edges.append(("in_sprint", f"{coll}:sprint:{_slug(req.sprint)}"))
+        if req.team:
+            edges.append(("in_team", f"{coll}:team:{_slug(req.team)}"))
+        if req.assignee:
+            edges.append(("assigned_to", f"{coll}:actor:{_slug(req.assignee)}"))
+        if req.epic:
+            edges.append(("child_of", f"{coll}:work:{_slug(req.epic)}"))
+        for label, to in edges:
+            await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                       json={"label": label, "from": wid, "to": to, "properties": prov})
+    return {"work_id": wid, "title": title, "status": req.status, "project": req.project,
+            "proof_carrying": True, "citable": True}
+
+
+def _work_view(n: dict[str, Any]) -> dict[str, Any]:
+    p = n.get("properties") or {}
+    return {"work_id": n.get("id"), "title": p.get("title"), "type": p.get("type", "task"),
+            "status": p.get("status", "backlog"), "priority": p.get("priority") or None,
+            "assignee": p.get("assignee") or None, "team": p.get("team") or None,
+            "sprint": p.get("sprint") or None, "epic": p.get("epic") or None,
+            "tags": [t for t in (p.get("tags") or "").split(",") if t], "updated_at": p.get("updated_at"),
+            "epistemic_mode": p.get("epistemic_mode", "attested")}
+
+
+@app.get("/api/agora/board")
+async def board(project: str = "default", team: str = "",
+                _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """The board: work items grouped into status columns (backlog → done). Optionally filtered to a team. Every
+    card is a live graph fact — cite it, preserve it, query it, or hand it to the agent team, no export needed."""
+    coll = proj_collection(project)
+    raw, err = await _fetch_nodes(coll)
+    columns: dict[str, list[dict[str, Any]]] = {s: [] for s in WORK_STATUSES}
+    total = 0
+    for n in raw:
+        if "WorkItem" not in (n.get("labels") or []):
+            continue
+        v = _work_view(n)
+        if team and v["team"] != team:
+            continue
+        columns.setdefault(v["status"], []).append(v)
+        total += 1
+    for s in columns:
+        columns[s].sort(key=lambda x: x.get("updated_at") or "", reverse=True)
+    return {"project": project, "team": team or None, "columns": columns, "count": total, "degraded": err}
+
+
+# ── wiki pages (the Confluence side) ───────────────────────────────────────────────────────────────────────────
+class PageRequest(BaseModel):
+    project: str = "default"
+    title: str
+    body: str = ""                     # markdown
+    parent: str | None = None          # parent page title (page tree)
+    tags: list[str] | None = None
+    actor: str | None = None
+
+
+@app.post("/api/agora/page")
+async def upsert_page(req: PageRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Create or update a wiki page, persisted as a proof-carrying HellGraph node (+ in_project / child_of edges
+    for the page tree). Idempotent per (project, title). The Confluence side — but every page is a graph fact,
+    so it's citable, preservable, and linkable to the work items and entities in the same project."""
+    _require_write(authorization)
+    title = req.title.strip()
+    if not title:
+        raise HTTPException(status_code=422, detail="title required")
+    coll = proj_collection(req.project)
+    pid = f"{coll}:page:{_slug(title)}"
+    prov = _prov(coll, "agora/page-v0", req.actor)
+    props = {"title": title, "body": req.body or "", "parent": req.parent or "",
+             "tags": ",".join(req.tags or []), "updated_at": _now_iso(), **prov}
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        _, werr = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": pid, "labels": [coll, "Page", "Wiki"], "properties": props})
+        if werr:
+            raise HTTPException(status_code=502, detail=f"graph write failed: {werr}")
+        await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                   json={"label": "in_project", "from": pid, "to": coll, "properties": prov})
+        if req.parent:
+            await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                       json={"label": "child_of", "from": pid, "to": f"{coll}:page:{_slug(req.parent)}", "properties": prov})
+    return {"page_id": pid, "title": title, "project": req.project, "proof_carrying": True, "citable": True}
+
+
+@app.get("/api/agora/pages")
+async def pages(project: str = "default",
+                _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """The wiki: project pages, newest first, each with its parent (for the page tree) and tags."""
+    coll = proj_collection(project)
+    raw, err = await _fetch_nodes(coll)
+    out = []
+    for n in raw:
+        if "Page" not in (n.get("labels") or []):
+            continue
+        p = n.get("properties") or {}
+        out.append({"page_id": n.get("id"), "title": p.get("title"), "parent": p.get("parent") or None,
+                    "tags": [t for t in (p.get("tags") or "").split(",") if t], "updated_at": p.get("updated_at"),
+                    "excerpt": (p.get("body") or "")[:280]})
+    out.sort(key=lambda x: x.get("updated_at") or "", reverse=True)
+    return {"project": project, "pages": out, "count": len(out), "degraded": err}
+
+
+# ── teams (greenfield — align work to teams) ───────────────────────────────────────────────────────────────────
+class TeamRequest(BaseModel):
+    project: str = "default"
+    name: str
+    members: list[str] | None = None
+    actor: str | None = None
+
+
+@app.post("/api/agora/team")
+async def upsert_team(req: TeamRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Create or update a team, persisted as a HellGraph node with member edges. Work items align to a team via
+    their in_team edge, so a board can scope to a team and the agent team reads the same graph."""
+    _require_write(authorization)
+    name = req.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="name required")
+    coll = proj_collection(req.project)
+    tid = f"{coll}:team:{_slug(name)}"
+    prov = _prov(coll, "agora/team-v0", req.actor)
+    props = {"name": name, "members": ",".join(req.members or []), "updated_at": _now_iso(), **prov}
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        _, werr = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": tid, "labels": [coll, "Team"], "properties": props})
+        if werr:
+            raise HTTPException(status_code=502, detail=f"graph write failed: {werr}")
+        await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                   json={"label": "in_project", "from": tid, "to": coll, "properties": prov})
+        for m in (req.members or []):
+            await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                       json={"label": "member_of", "from": f"{coll}:actor:{_slug(m)}", "to": tid, "properties": prov})
+    return {"team_id": tid, "name": name, "project": req.project, "members": req.members or [], "proof_carrying": True}
+
+
+# ── the bundle (one call for the surface) ──────────────────────────────────────────────────────────────────────
+@app.get("/api/agora")
+async def bundle(project: str = "default",
+                 _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """One call for the Agora surface: the board (by status), the wiki page list, the teams, and a stats block —
+    all read from the project's proj- collection, and all citable/preservable/curatable via Studio's commons."""
+    coll = proj_collection(project)
+    raw, err = await _fetch_nodes(coll)
+    columns: dict[str, list[dict[str, Any]]] = {s: [] for s in WORK_STATUSES}
+    page_list, teams = [], []
+    work_n = 0
+    for n in raw:
+        labels = n.get("labels") or []
+        p = n.get("properties") or {}
+        if "WorkItem" in labels:
+            v = _work_view(n)
+            columns.setdefault(v["status"], []).append(v)
+            work_n += 1
+        elif "Page" in labels:
+            page_list.append({"page_id": n.get("id"), "title": p.get("title"), "parent": p.get("parent") or None,
+                              "updated_at": p.get("updated_at")})
+        elif "Team" in labels:
+            teams.append({"team_id": n.get("id"), "name": p.get("name"),
+                          "members": [m for m in (p.get("members") or "").split(",") if m]})
+    for s in columns:
+        columns[s].sort(key=lambda x: x.get("updated_at") or "", reverse=True)
+    page_list.sort(key=lambda x: x.get("updated_at") or "", reverse=True)
+    return {
+        "project": project, "collection": coll,
+        "board": {"columns": columns, "count": work_n},
+        "pages": page_list, "teams": teams,
+        "stats": {"work_items": work_n, "pages": len(page_list), "teams": len(teams)},
+        # the bridge: everything here is a graph fact in the project collection, so the commons applies as-is.
+        "commons": {"citable": True, "preservable": True, "curatable": True,
+                    "note": "work items & pages are proof-carrying graph facts — cite/preserve/curate via Studio"},
+        "degraded": err,
+    }

--- a/apps/agora/tests/test_server.py
+++ b/apps/agora/tests/test_server.py
@@ -1,0 +1,127 @@
+"""Agora BFF tests — work items + wiki pages + teams as proof-carrying HellGraph facts. The graph is faked by
+monkeypatching srv._req, routed by URL substring (the lattice-studio test pattern)."""
+from fastapi.testclient import TestClient
+
+import agora.server as srv
+from agora.server import app
+
+client = TestClient(app)
+
+
+def test_healthz():
+    b = client.get("/healthz").json()
+    assert b["status"] == "ok" and b["service"] == "agora"
+
+
+def test_work_write_requires_token(monkeypatch):
+    monkeypatch.setattr(srv, "AGORA_WRITE_TOKEN", "")
+    r = client.post("/api/agora/work", json={"project": "team-x", "title": "Ship Agora"})
+    assert r.status_code == 503   # fail-closed
+
+
+def test_upsert_work_writes_node_and_edges(monkeypatch):
+    monkeypatch.setattr(srv, "AGORA_WRITE_TOKEN", "T")
+    writes = []
+
+    async def fake_req(client, method, url, json=None):
+        if "/api/graph/node" in url or "/api/graph/edge" in url:
+            writes.append(json)
+            return ({"ok": True}, None)
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.post("/api/agora/work",
+                    json={"project": "team-x", "title": "Ship Agora", "type": "story", "status": "in_progress",
+                          "assignee": "claude", "team": "platform", "sprint": "s1", "epic": "Estate",
+                          "tags": ["estate", "graph"], "actor": "mdheller"},
+                    headers={"Authorization": "Bearer T"})
+    b = r.json()
+    assert r.status_code == 200 and b["proof_carrying"] and b["citable"]
+    assert b["work_id"] == "proj-teamx:work:ship-agora"
+    node = next(w for w in writes if "labels" in w)
+    assert node["labels"] == ["proj-teamx", "WorkItem", "Story"]
+    assert node["properties"]["epistemic_mode"] == "attested"       # proof-carrying
+    assert node["properties"]["source"] == "mdheller"               # actor → provenance
+    edge_labels = {w["label"] for w in writes if "label" in w}
+    assert {"in_project", "in_sprint", "in_team", "assigned_to", "child_of"} <= edge_labels
+
+
+def test_upsert_work_rejects_bad_status(monkeypatch):
+    monkeypatch.setattr(srv, "AGORA_WRITE_TOKEN", "T")
+    r = client.post("/api/agora/work", json={"project": "team-x", "title": "x", "status": "wip"},
+                    headers={"Authorization": "Bearer T"})
+    assert r.status_code == 422
+
+
+def test_board_groups_by_status_and_filters_team(monkeypatch):
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({"nodes": [
+                {"id": "proj-teamx:work:a", "labels": ["proj-teamx", "WorkItem", "Task"],
+                 "properties": {"title": "A", "status": "todo", "team": "platform", "updated_at": "t2"}},
+                {"id": "proj-teamx:work:b", "labels": ["proj-teamx", "WorkItem", "Bug"],
+                 "properties": {"title": "B", "status": "done", "team": "platform", "updated_at": "t1"}},
+                {"id": "proj-teamx:work:c", "labels": ["proj-teamx", "WorkItem", "Task"],
+                 "properties": {"title": "C", "status": "todo", "team": "noetica", "updated_at": "t3"}},
+                {"id": "proj-teamx:page:x", "labels": ["proj-teamx", "Page", "Wiki"], "properties": {"title": "X"}},
+            ], "edgeList": []}, None)
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    b = client.get("/api/agora/board?project=team-x&team=platform").json()
+    assert b["count"] == 2                       # C (noetica) filtered out; page ignored
+    assert [w["title"] for w in b["columns"]["todo"]] == ["A"]
+    assert [w["title"] for w in b["columns"]["done"]] == ["B"]
+
+
+def test_page_upsert_and_list(monkeypatch):
+    monkeypatch.setattr(srv, "AGORA_WRITE_TOKEN", "T")
+    writes = []
+
+    async def fake_req(client, method, url, json=None):
+        if "/api/graph/node" in url or "/api/graph/edge" in url:
+            writes.append(json)
+            return ({"ok": True}, None)
+        if "subgraph" in url:
+            return ({"nodes": [
+                {"id": "proj-teamx:page:arch", "labels": ["proj-teamx", "Page", "Wiki"],
+                 "properties": {"title": "Architecture", "body": "The estate has zot, gitea, agora.",
+                                "parent": "", "updated_at": "t1"}},
+            ], "edgeList": []}, None)
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.post("/api/agora/page",
+                    json={"project": "team-x", "title": "Architecture", "body": "The estate has zot, gitea, agora.",
+                          "parent": "Home", "tags": ["design"]},
+                    headers={"Authorization": "Bearer T"})
+    b = r.json()
+    assert b["page_id"] == "proj-teamx:page:architecture" and b["citable"]
+    node = next(w for w in writes if "labels" in w)
+    assert node["labels"] == ["proj-teamx", "Page", "Wiki"]
+    assert any(w.get("label") == "child_of" for w in writes)   # page-tree edge to parent
+
+    lst = client.get("/api/agora/pages?project=team-x").json()
+    assert lst["count"] == 1 and lst["pages"][0]["title"] == "Architecture"
+    assert lst["pages"][0]["excerpt"].startswith("The estate")
+
+
+def test_bundle_reports_board_pages_teams_and_commons_bridge(monkeypatch):
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({"nodes": [
+                {"id": "proj-teamx:work:a", "labels": ["proj-teamx", "WorkItem", "Task"],
+                 "properties": {"title": "A", "status": "todo", "updated_at": "t1"}},
+                {"id": "proj-teamx:page:x", "labels": ["proj-teamx", "Page", "Wiki"],
+                 "properties": {"title": "X", "updated_at": "t1"}},
+                {"id": "proj-teamx:team:platform", "labels": ["proj-teamx", "Team"],
+                 "properties": {"name": "platform", "members": "claude,mdheller"}},
+            ], "edgeList": []}, None)
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    b = client.get("/api/agora?project=team-x").json()
+    assert b["stats"] == {"work_items": 1, "pages": 1, "teams": 1}
+    assert b["teams"][0]["members"] == ["claude", "mdheller"]
+    assert b["commons"]["citable"] and b["commons"]["curatable"]   # the KE⇄Commons bridge
+    assert b["board"]["columns"]["todo"][0]["title"] == "A"

--- a/contracts/PlatformServiceManifest.svc.substrate.work-knowledge.v0.1.json
+++ b/contracts/PlatformServiceManifest.svc.substrate.work-knowledge.v0.1.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "0.1",
+  "kind": "PlatformServiceManifest",
+  "service_id": "svc.substrate.work-knowledge",
+  "display_name": "Agora — Work + Knowledge Plane",
+  "description": "The sovereign Jira/Confluence-killer of the estate, alongside zot (registry) and gitea-sovereign (source control). Work items, sprints and teams (the Jira side) and wiki pages (the Confluence side) are persisted as proof-carrying HellGraph facts in the project's proj- collection — the same collection Noetica and lattice-studio share — so every card and page is project/team-aligned, citable, preservable, curatable, and readable live by the agent team. Bridges Knowledge Engineering to the Knowledge Commons. Reuses Noetica's native work model (native = source of truth; Jira/Linear/GitHub Issues = optional external connectors only).",
+  "scaffold_baseline": {
+    "repo": "SocioProphet/prophet-platform",
+    "path": "apps/agora",
+    "status": "PR-A scaffold — BFF over hellgraph-service; does not imply deployment readiness"
+  },
+  "runtime_posture": "cluster_internal",
+  "deployment_topology": {
+    "agora_bff": {
+      "description": "FastAPI BFF (apps/agora) — /api/agora/{work,board,page,pages,team,''}. Stateless; will render charts/socioprophet-service via deploy/values/agora.yaml (pinned to the CI-published sha- tag) + a { name: agora } entry in deploy/argocd/platform-services.yaml. This PR builds the image only; the deploy wiring lands in a follow-up once the sha- tag exists (avoids the moving-:latest trap).",
+      "binding": "org.substrate.work-knowledge.agora-bff"
+    },
+    "hellgraph_substrate": {
+      "description": "hellgraph-service is the system of record — work items / pages / teams are graph nodes + edges, NOT a side database.",
+      "binding": "org.substrate.hellgraph"
+    }
+  },
+  "identity_bindings": {
+    "noetica_workspaces": "Consumes Noetica's WorkItem/Sprint/Project model (lib/types/work.ts), moving it off localStorage onto the graph; cowork/workroom agents map to assignee/member edges.",
+    "project_collection": "proj_collection(project) === Noetica projectCollectionId — proj-<12hex>. Agora facts co-locate with the project KB.",
+    "team_alignment": "Teams are first-class nodes; work items align via in_team edges; boards scope by team."
+  },
+  "commons_bridge": {
+    "citable": "Studio /api/studio/cite mints a sovereign PID + DataCite DOI over any work item or page.",
+    "preservable": "Studio /api/studio/preserve seals a tamper-evident version snapshot.",
+    "curatable": "Studio /api/studio/endorse + epistemic-weighted curation apply to work items and pages."
+  },
+  "policy_dependencies": [
+    "policy://work-knowledge/write-token-v0.1"
+  ],
+  "evidence_receipts": [
+    "receipt://work-knowledge/work-write-receipt-v0.1",
+    "receipt://work-knowledge/page-write-receipt-v0.1"
+  ],
+  "pr_a_status": {
+    "is_pr_a": true,
+    "note": "PR-A introduces the BFF + estate registration. Does NOT imply deployment readiness. First CI build publishes a sha- image tag; gitops-promote pins deploy/values/agora.yaml before it goes live.",
+    "deployment_ready": false
+  },
+  "runtime_prerequisites": [
+    {
+      "id": "prereq_write_token",
+      "description": "agora-write-token Secret must exist in namespace socioprophet before writes are accepted (fail-closed until then).",
+      "status": "pending"
+    },
+    {
+      "id": "prereq_image_pin",
+      "description": "deploy/values/agora.yaml image.tag must be pinned to the CI-published sha- tag (not a moving :latest) before rollout.",
+      "status": "pending"
+    }
+  ],
+  "authority_boundary": {
+    "owner": "prophet-platform",
+    "note": "prophet-platform owns the runtime deployment and API contract; Noetica owns the client-side work UX and is the upstream of the WorkItem/Sprint/Project model."
+  }
+}


### PR DESCRIPTION
Adds **Agora** to the sovereign estate, alongside **zot** (registry) and **gitea-sovereign** (source control). Where those are the build & code substrate, Agora is the **work & knowledge** substrate — the piece that bridges **Knowledge Engineering ⇄ the Knowledge Commons**.

### What it is
`apps/agora` — a FastAPI BFF that persists the Jira side (**work items · sprints · teams**) and the Confluence side (**wiki pages**) as **proof-carrying HellGraph facts**, not rows in a side DB. Everything lands in the project's `proj-<12hex>` collection — the *same* one Noetica (`projectCollectionId`) and lattice-studio (`proj_collection`) already share.

### Why graph facts (the beat)
A work item / page is a graph fact in the project collection, so it is — for free — **project/team-aligned** (in_project / in_team / assigned_to / in_sprint / child_of edges), **citable** (Studio `/cite`), **preservable** (`/preserve`), **curatable** (`/endorse`), and **queryable live** by the agent team — no export.

### Alignment
Reuses Noetica's native model (`lib/types/work.ts`: WorkItem/Sprint/Project — *native = source of truth; Jira/Linear/GitHub Issues = connectors only*), moving it off localStorage onto the graph. Team + wiki Page (greenfield in Noetica) added here.

### Endpoints
`/healthz` · `POST /api/agora/{work,page,team}` · `GET /api/agora/{board,pages,''}`. Fail-closed writes (`AGORA_WRITE_TOKEN`); opt-in sovereign-identity read gate (`AGORA_JWT_SECRET`).

### Staged rollout (why this PR is build-only)
This PR **builds the image** (`images.yml` matrix) + lands the code + the `PlatformServiceManifest` estate contract. It **deliberately does NOT** add `deploy/values/agora.yaml` or the `platform-services` ApplicationSet entry yet — a brand-new service has no immutable `sha-` tag until CI builds it, and `preflight` (correctly) rejects a moving `:latest` on a deployed service. **Follow-up PR** pins `image.tag` to the sha this build publishes + registers the ApplicationSet element = actual deploy.

7 tests pass. (Pre-existing red checks `orchestration-fixtures` (missing DevSecOps card in socioprophet-web) and `preflight`/`reasoning-failure-runner:latest` are on main already, unrelated to this change.)