### PR TITLE
Agora deploy: pin sha- tag + register in platform-services (read-only)

### DIFF
--- a/contracts/PlatformServiceManifest.svc.substrate.work-knowledge.v0.1.json
+++ b/contracts/PlatformServiceManifest.svc.substrate.work-knowledge.v0.1.json
@@ -39,19 +39,19 @@
   ],
   "pr_a_status": {
     "is_pr_a": true,
-    "note": "PR-A introduces the BFF + estate registration. Does NOT imply deployment readiness. First CI build publishes a sha- image tag; gitops-promote pins deploy/values/agora.yaml before it goes live.",
-    "deployment_ready": false
+    "note": "Build stage (image + estate contract) landed in PR-A. Deploy stage pins deploy/values/agora.yaml to the sha- tag + registers the platform-services ApplicationSet entry — deploying READ-ONLY (writes fail-closed until the Secret exists).",
+    "deployment_ready": true
   },
   "runtime_prerequisites": [
     {
       "id": "prereq_write_token",
-      "description": "agora-write-token Secret must exist in namespace socioprophet before writes are accepted (fail-closed until then).",
+      "description": "agora-write-token Secret must exist in namespace socioprophet before the WRITE surface (/api/agora/{work,page,team}) is enabled. Deployed read-only until then (writes fail-closed 503; reads work).",
       "status": "pending"
     },
     {
       "id": "prereq_image_pin",
-      "description": "deploy/values/agora.yaml image.tag must be pinned to the CI-published sha- tag (not a moving :latest) before rollout.",
-      "status": "pending"
+      "description": "deploy/values/agora.yaml image.tag pinned to sha-92f471015ea5fd8c4f7831f6e4be72c05e4011e4 (the apps/agora build's immutable tag) — not a moving :latest.",
+      "status": "satisfied"
     }
   ],
   "authority_boundary": {

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -37,6 +37,7 @@ spec:
           - { name: node-commander }
           - { name: liberty-stack-readout }
           - { name: tritfabric-consumption-api }
+          - { name: agora }
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —
           # NOT touched by the build-image/gitops-promote SHA pipeline above, since

--- a/deploy/values/agora.yaml
+++ b/deploy/values/agora.yaml
@@ -1,0 +1,16 @@
+# agora — the sovereign work + knowledge plane (apps/agora server.py). The Jira/Confluence killer of the estate,
+# alongside zot (registry) and gitea-sovereign (SCM). Work items + wiki pages + teams are persisted as proof-
+# carrying HellGraph facts in the project's proj- collection — the same one Noetica and lattice-studio share — so
+# every card and page is citable / preservable / curatable via the Studio commons, and readable by the agent team.
+# Pinned to the immutable sha- tag the apps/agora build published (PR #821 merge commit) — never a moving :latest.
+image: { repository: agora, tag: sha-92f471015ea5fd8c4f7831f6e4be72c05e4011e4 }
+service: { port: 8080, portName: http }
+# server serves /healthz (chart default) — no probes.path override.
+config:
+  HELLGRAPH_URL: "http://hellgraph-service:8090"
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
+# Deploys READ-ONLY: AGORA_WRITE_TOKEN is unset, so writes fail-closed (503) while reads (board/pages/bundle) work.
+# To enable the WRITE surface (/api/agora/{work,page,team}), create the Secret and add the secretEnv block:
+#   kubectl -n socioprophet create secret generic agora-write-token --from-literal=token=...
+#   secretEnv: { AGORA_WRITE_TOKEN: { secretName: agora-write-token, key: token } }
+# Internal (ClusterIP) for now; the surface reaches it via the same public-gateway pattern as the Studio BFF.


### PR DESCRIPTION
Deploy stage for **Agora** (build landed in #821). This is the sha-pinned follow-up the build-stage PR promised.

- **`deploy/values/agora.yaml`** — `image.tag: sha-92f471015ea5fd8c4f7831f6e4be72c05e4011e4` (the apps/agora build's immutable tag). No moving `:latest` → `preflight` passes and the IfNotPresent rollout trap can't bite.
- **`{ name: agora }`** added to the `platform-services` ApplicationSet → Argo renders `charts/socioprophet-service` with these values into ns `socioprophet`.
- **Deploys READ-ONLY:** `AGORA_WRITE_TOKEN` is intentionally unset (no `secretEnv`), so there's no missing-Secret crash and no preflight secret-ref failure — writes fail-closed (503), reads (board/pages/bundle) work. Enabling writes = `kubectl -n socioprophet create secret generic agora-write-token …` + add the `secretEnv` block (documented inline).
- Estate contract `deployment_ready: true`, `prereq_image_pin: satisfied`.

Agora now stands in the estate alongside zot + gitea-sovereign.