### PR TITLE
fix(deploy): pin reasoning-failure-runner to sha- tag (drop moving :latest)

### DIFF
--- a/deploy/values/reasoning-failure-runner.yaml
+++ b/deploy/values/reasoning-failure-runner.yaml
@@ -1,3 +1,7 @@
 # reasoning-failure-runner
-image: { repository: reasoning-failure-runner, tag: latest }
+# Pinned to an immutable sha- tag (never `:latest`): the socioprophet-service chart sets
+# imagePullPolicy: IfNotPresent, so a moving tag means a node that cached `latest` never pulls a newer
+# image and `rollout restart` re-runs the stale one. sha-92f471… = the last green images.yml build's
+# full-matrix publish of this image. Bump to a newer sha- tag on each release.
+image: { repository: reasoning-failure-runner, tag: sha-92f471015ea5fd8c4f7831f6e4be72c05e4011e4 }
 service: { port: 8080, portName: http }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -81,13 +81,9 @@ OUR_REGISTRIES = ("us-central1-docker.pkg.dev/socioprophet-platform/", "registry
 # Entries must carry a reason. The list only ever shrinks: if an entry starts passing,
 # the gate FAILS and demands its removal, so it cannot rot into a permanent excuse.
 KNOWN_BROKEN = {
-    # reasoning-failure-runner:not-built is RESOLVED — it now has a Dockerfile + images.yml entry and is a real
-    # FastAPI service (the Chaos & Resilience Fabric orchestrator, CHAOS_RESILIENCE_FABRIC_V0.md).
-    "reasoning-failure-runner:moving-tag": (
-        "The image now BUILDS (Dockerfile + images.yml added). Pinning `tag: latest` → the sha- tag the build "
-        "publishes is now a mechanical follow-up after the first CI build (same as dashboard-bff #743); it "
-        "could not be done in the same PR because no sha existed yet. Ratcheted, not moot."
-    ),
+    # reasoning-failure-runner:moving-tag is RESOLVED — deploy/values/reasoning-failure-runner.yaml is now pinned
+    # to a sha- tag (the Chaos & Resilience Fabric orchestrator, CHAOS_RESILIENCE_FABRIC_V0.md). The ratchet only
+    # shrinks: fixed → removed from KNOWN_BROKEN so it can never silently regress to `:latest` again.
     "owl-reasoner:moving-tag": (
         "New service — Dockerfile + images.yml entry added this PR, so it BUILDS. Pin `tag: latest` → the sha- "
         "tag after the first CI build (same chicken-and-egg as grlplus-service/grl-mesh): no sha exists until merge."


### PR DESCRIPTION
`deploy/values/reasoning-failure-runner.yaml` had `image.tag: latest` — a **moving tag**. The `socioprophet-service` chart sets `imagePullPolicy: IfNotPresent`, so once a node caches `latest` the kubelet never pulls a newer image and `rollout restart` re-runs the stale one (the documented moving-tag/IfNotPresent trap). The estate **preflight** check was failing on it.

Pinned to `sha-92f471015ea5fd8c4f7831f6e4be72c05e4011e4` — the last green `images.yml` full-matrix build (which publishes every image, including this one, at that immutable tag). This is a regression of task #13's earlier fix; bump to a newer sha- tag on release.