### PR TITLE
WS#50: GAIA stewardship writeback — governance and the epistemic moat as one mechanism

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/gaia.py
+++ b/apps/lattice-studio/src/lattice_studio/gaia.py
@@ -1,0 +1,65 @@
+"""GAIA Ontogenesis Stewardship Graph — vocabulary + the epistemic invariant.
+
+Ported from Noetica/agent-machine/lib/gaia-ontology.ts (vendored from regis-entity-graph). GAIA is the estate's
+canonical living-knowledge ontology (IOES: Identity, Ontogenesis, Ecology, Stewardship). It already defines a
+governed writeback pattern — a steward's decision (keeper / successor / developmental phase / acknowledged
+abandonment signals) persisted on the node as gaia_* properties and honored on read.
+
+The one that matters for the moat: GAIA invariant #2 — "Model inference alone must not promote developmental
+state to canonical human-impacting truth." We enforce it *through our epistemic status*: a phase set by a
+human steward is `attested`; a phase set by a model/agent is `derived` (it can observe staleness, not canonize
+it). GAIA governance and the proof-carrying moat become the same mechanism.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+GAIA_NODE_KINDS = [
+    "LIVING_ENTITY", "ONTOGENESIS_STATE", "GAIA_DEPENDENCY_RECORD", "STEWARDSHIP_RECORD", "KEEPER_LOG",
+    "SUCCESSION_RULE", "ABANDONMENT_SIGNAL", "LEARNING_ARTIFACT", "DELIVERY_OUTCOME_RECORD", "POLICY_DECISION",
+    "CONSENT_RECEIPT", "PROJECTION_RECORD",
+]
+GAIA_EDGE_KINDS = [
+    "STEWARD_OF", "GUARDIAN_OF", "MENTOR_OF", "APPRENTICE_OF", "SUCCESSOR_OF", "PRESERVES", "TRANSMITS_TO",
+    "CARES_FOR", "HAS_KEEPER_LOG", "HAS_SUCCESSION_RULE", "HAS_ABANDONMENT_SIGNAL", "HAS_ONTOGENESIS_STATE",
+    "DEPENDS_ON", "CONTRIBUTES_TO", "IMPACTS", "CO_EVOLVES_WITH", "REGENERATES", "DEGRADES",
+    "AUTHORIZED_BY_CONSENT", "ALLOWED_BY_POLICY", "DENIED_BY_POLICY", "ATTESTED_BY_PROOF", "EMITTED_BY_EXECUTION",
+    "HAS_DELIVERY_OUTCOME", "HAS_LEARNING_CHANGESET",
+]
+ONTOGENESIS_PHASES = ["seed", "formation", "growth", "maturity", "transmission", "transformation",
+                      "decline", "succession", "archive", "termination"]
+ABANDONMENT_SIGNALS = ["no_active_keeper", "no_successor", "review_overdue", "broken_contact", "stale_evidence",
+                       "contested_authority", "critical_dependency_failed", "orphaned_artifact"]
+GAIA_INVARIANTS = [
+    "Stewardship must not imply ownership without a separate ownership/authority artifact.",
+    "Model inference alone must not promote developmental state to canonical human-impacting truth.",
+    "Material dependencies must not be stripped merely to simplify projection.",
+    "A stewardship record without an active keeper becomes needs_review or orphaned, not silently healthy.",
+    "Abandonment is a graph state, not absence of graph data.",
+]
+
+# actor_kind → the epistemic status a developmental-phase assertion carries (invariant #2).
+_HUMAN_KINDS = {"human", "steward", "keeper"}
+
+
+def phase_epistemic(actor_kind: str) -> str:
+    """A phase set by a human steward is `attested` (canonical); by a model/agent it is `derived` — observed,
+    not promoted to canonical human-impacting truth. This IS GAIA invariant #2, enforced through epistemic status."""
+    return "attested" if (actor_kind or "human").lower() in _HUMAN_KINDS else "derived"
+
+
+def stewardship_of(props: dict[str, Any] | None) -> dict[str, Any]:
+    """Read the persisted stewardship decision off a node's gaia_* properties (what the census honors)."""
+    p = props or {}
+    resolved = [s.strip() for s in str(p.get("gaia_resolved_signals", "")).split(",") if s.strip()]
+    keeper = p.get("gaia_keeper") or None
+    return {
+        "keeper": keeper,
+        "successor": p.get("gaia_successor") or None,
+        "phase_override": p.get("gaia_phase_override") or None,
+        "phase_epistemic": p.get("gaia_phase_epistemic") or None,
+        "resolved_signals": resolved,
+        "reviewed_at": p.get("gaia_reviewed_at") or None,
+        "note": p.get("gaia_steward_note") or None,
+        "stewarded": bool(keeper or resolved or p.get("gaia_phase_override") or p.get("gaia_reviewed_at")),
+    }

--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -32,7 +32,7 @@ import jwt
 from fastapi import Depends, FastAPI, Header, HTTPException, Response
 from pydantic import BaseModel
 
-from lattice_studio import ontology, product_spine, shacl
+from lattice_studio import gaia, ontology, product_spine, shacl
 
 SERVICE_VERSION = "0.2.0"
 HELLGRAPH_URL = os.getenv("HELLGRAPH_URL", "http://hellgraph-service:8090")
@@ -1637,6 +1637,111 @@ async def executions(project: str = "default",
                     "submitted_at": p.get("submitted_at")})
     out.sort(key=lambda x: x.get("submitted_at") or "", reverse=True)
     return {"project": project, "executions": out, "count": len(out), "degraded": err}
+
+
+# ── WS#50: GAIA stewardship writeback — the estate's canonical living-knowledge governance, wired to the moat.
+# A steward's decision (keeper / successor / developmental phase / acknowledged abandonment signals) is persisted
+# as gaia_* properties (the applyStewardship pattern), proof-carrying + receipted + reversible. THE alignment:
+# GAIA invariant #2 ("model inference must not promote developmental state to canonical human-impacting truth")
+# is enforced THROUGH epistemic status — a phase from a human steward is `attested`, from a model/agent `derived`.
+# GAIA governance and the proof-carrying moat are the same mechanism. ────────────────────────────────────────────
+class StewardRequest(BaseModel):
+    project: str = "default"
+    target: str                            # the node being stewarded (a GAIA LIVING_ENTITY / any node)
+    keeper: str | None = None
+    successor: str | None = None
+    phase: str | None = None               # an OntogenesisState phase (seed…termination)
+    resolve_signals: list[str] = []        # abandonment signals acknowledged/handled
+    note: str | None = None
+    actor: str | None = None
+    actor_kind: str = "human"              # human | steward | keeper → attested; model | agent → derived
+
+
+@app.post("/api/studio/steward")
+async def steward(req: StewardRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Apply a GAIA steward decision to a node — governed, proof-carrying, receipted, reversible. Enforces the
+    GAIA invariants: a developmental phase asserted by a model/agent is recorded as `derived`, not `attested`
+    (invariant #2, via epistemic status). Fail-closed."""
+    _require_write_token(authorization)
+    if req.phase and req.phase not in gaia.ONTOGENESIS_PHASES:
+        raise HTTPException(status_code=422, detail=f"phase must be one of {gaia.ONTOGENESIS_PHASES}")
+    bad = [s for s in req.resolve_signals if s not in gaia.ABANDONMENT_SIGNALS]
+    if bad:
+        raise HTTPException(status_code=422, detail=f"unknown abandonment signals: {bad}")
+    coll = proj_collection(req.project)
+    raw, err = await _fetch_raw_nodes(coll, 2000)
+    target_node = next((n for n in raw if n.get("id") == req.target), None)
+    before = dict((target_node.get("properties") if target_node else {}) or {})
+    labels = (target_node.get("labels") if target_node else None) or [coll, "LIVING_ENTITY"]
+
+    # the writeback's epistemic status honors the invariant: a model steward-decision is derived, not canonical
+    phase_epi = gaia.phase_epistemic(req.actor_kind)
+    invariant = req.phase and phase_epi == "derived"
+    prov = _workbench_prov(coll, "attested" if gaia.phase_epistemic(req.actor_kind) == "attested" else "derived",
+                           req.actor or "studio/steward")
+    prov["extractor"] = "lattice-studio/gaia-steward-v0"
+
+    new_props = dict(before)
+    changed: list[str] = []
+    if req.keeper is not None:
+        new_props["gaia_keeper"] = req.keeper; changed.append("keeper")
+    if req.successor is not None:
+        new_props["gaia_successor"] = req.successor; changed.append("successor")
+    if req.phase:
+        new_props["gaia_phase_override"] = req.phase
+        new_props["gaia_phase_epistemic"] = phase_epi                 # invariant #2 in the data
+        changed.append(f"phase={req.phase} ({phase_epi})")
+    if req.resolve_signals:
+        merged = sorted({*[s for s in str(before.get("gaia_resolved_signals", "")).split(",") if s], *req.resolve_signals})
+        new_props["gaia_resolved_signals"] = ",".join(merged); changed.append("resolved_signals")
+    if req.note is not None:
+        new_props["gaia_steward_note"] = req.note
+    new_props["gaia_reviewed_at"] = _now_iso()
+    new_props.update(prov)
+
+    dhash = hashlib.sha256((req.target + _now_iso() + ",".join(changed)).encode()).hexdigest()
+    correlation = f"stw-{dhash[:12]}"
+    dec_id = f"{coll}:stewardship:{dhash[:12]}"
+    receipt = {"correlation_id": correlation, "service": "lattice-studio", "kind": "gaia-steward",
+               "replayable": True, "bundle_ref": f"/v1/receipts/lattice-studio/{correlation}"}
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        _, werr = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": req.target, "labels": labels, "properties": new_props})
+        if werr:
+            raise HTTPException(status_code=502, detail=f"stewardship writeback failed: {werr}")
+        dec_props = {"target": req.target, "changed": ", ".join(changed), "actor_kind": req.actor_kind,
+                     "before_state": json.dumps(before, default=str), "correlation_id": correlation,
+                     "receipt_bundle": receipt["bundle_ref"], "revoked": False, "at": _now_iso(), **prov}
+        await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                   json={"id": dec_id, "labels": [coll, "STEWARDSHIP_RECORD", "Run"], "properties": dec_props})
+        await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                   json={"label": "STEWARD_OF", "from": dec_id, "to": req.target, "properties": prov})
+    return {"stewardship_id": dec_id, "target": req.target, "state": gaia.stewardship_of(new_props),
+            "changed": changed, "receipt": receipt, "reversible": True, "proof_carrying": True,
+            "epistemic_mode": prov["epistemic_mode"],
+            "invariant_applied": ("GAIA-2: model inference recorded as `derived`, not promoted to canonical truth"
+                                  if invariant else None),
+            "degraded": err}
+
+
+@app.get("/api/studio/steward")
+async def steward_state(project: str = "default", target: str = "",
+                        _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """Read a node's persisted GAIA stewardship state — keeper, successor, developmental phase (+ its epistemic
+    status), acknowledged abandonment signals. Also surfaces a light derived signal (orphaned if it has no edges)."""
+    if not target:
+        raise HTTPException(status_code=422, detail="target node id required")
+    coll = proj_collection(project)
+    nodes, edges, err = await _fetch_graph(coll, 3000)
+    node = next((n for n in nodes if n.get("id") == target), None)
+    state = gaia.stewardship_of(node.get("properties") if node else {})
+    degree = sum(1 for e in edges if e.get("from") == target or e.get("to") == target)
+    derived_signals = ["orphaned_artifact"] if degree == 0 else []
+    derived_signals = [s for s in derived_signals if s not in state["resolved_signals"]]   # honor acknowledgements
+    return {"project": project, "target": target, "stewardship": state,
+            "derived_signals": derived_signals, "degree": degree,
+            "phases": gaia.ONTOGENESIS_PHASES, "abandonment_signals": gaia.ABANDONMENT_SIGNALS,
+            "invariants": gaia.GAIA_INVARIANTS, "degraded": err}
 
 
 # ── WS#49: ONTOLOGY ACTIONS + writeback — the Foundry crown jewel (Workshop apps are built on Actions). A typed

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -1265,3 +1265,69 @@ def test_action_invoke_shacl_rejects_nonconformant_writeback(monkeypatch):
     assert "SHACL" in detail["message"] and detail["class"] == "sp:Surface" and len(detail["violations"]) >= 1
     # fail-closed: the target was NOT mutated
     assert state["nodes"]["proj-teamx:surface:1"]["properties"] == {}
+
+
+# ── WS#50: GAIA stewardship writeback + the epistemic invariant ──
+def test_steward_human_decision_is_attested(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    state, fake_req = _stateful_graph({
+        "proj-teamx:entity:1": {"id": "proj-teamx:entity:1", "labels": ["proj-teamx", "LIVING_ENTITY"],
+                                "properties": {}},
+    })
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.post("/api/studio/steward",
+                    json={"project": "team-x", "target": "proj-teamx:entity:1", "keeper": "kim",
+                          "phase": "maturity", "resolve_signals": ["stale_evidence"], "actor_kind": "human"},
+                    headers={"Authorization": "Bearer T"}).json()
+    assert r["proof_carrying"] and r["reversible"]
+    assert r["epistemic_mode"] == "attested" and r["invariant_applied"] is None      # human → canonical
+    assert r["state"]["keeper"] == "kim" and r["state"]["phase_override"] == "maturity"
+    tgt = state["nodes"]["proj-teamx:entity:1"]["properties"]
+    assert tgt["gaia_keeper"] == "kim" and tgt["gaia_phase_override"] == "maturity"
+    assert tgt["gaia_phase_epistemic"] == "attested" and tgt["gaia_resolved_signals"] == "stale_evidence"
+
+
+def test_steward_model_phase_is_derived_not_canonical(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    state, fake_req = _stateful_graph({
+        "proj-teamx:entity:2": {"id": "proj-teamx:entity:2", "labels": ["proj-teamx", "LIVING_ENTITY"], "properties": {}},
+    })
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.post("/api/studio/steward",
+                    json={"project": "team-x", "target": "proj-teamx:entity:2", "phase": "decline", "actor_kind": "model"},
+                    headers={"Authorization": "Bearer T"}).json()
+    # GAIA invariant #2: a model may OBSERVE the phase but not PROMOTE it to canonical truth → derived
+    assert r["epistemic_mode"] == "derived"
+    assert r["invariant_applied"] and "GAIA-2" in r["invariant_applied"]
+    assert state["nodes"]["proj-teamx:entity:2"]["properties"]["gaia_phase_epistemic"] == "derived"
+
+
+def test_steward_validates_phase_and_signals(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    assert client.post("/api/studio/steward", json={"project": "team-x", "target": "x", "phase": "bogus"},
+                       headers={"Authorization": "Bearer T"}).status_code == 422
+    assert client.post("/api/studio/steward", json={"project": "team-x", "target": "x", "resolve_signals": ["nope"]},
+                       headers={"Authorization": "Bearer T"}).status_code == 422
+
+
+def test_steward_state_reads_back_and_derives_orphan(monkeypatch):
+    import lattice_studio.server as srv
+
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            return ({"nodes": [
+                {"id": "proj-teamx:entity:3", "labels": ["proj-teamx", "LIVING_ENTITY"],
+                 "properties": {"gaia_keeper": "sam", "gaia_phase_override": "growth", "gaia_phase_epistemic": "attested"}},
+            ], "edgeList": []}, None)   # no edges → orphaned
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    b = client.get("/api/studio/steward?project=team-x&target=proj-teamx:entity:3").json()
+    assert b["stewardship"]["keeper"] == "sam" and b["stewardship"]["phase_override"] == "growth"
+    assert b["derived_signals"] == ["orphaned_artifact"] and b["degree"] == 0
+    assert "maturity" in b["phases"]


### PR DESCRIPTION
The deepening, part 2 — align the writeback to the estate's canonical living-knowledge ontology, **GAIA**, and wire its governance straight into our epistemic moat.

- **`lattice_studio/gaia.py`** — the GAIA Ontogenesis Stewardship Graph vocabulary (node/edge kinds, the ONTOGENESIS_PHASES seed→termination, ABANDONMENT_SIGNALS, invariants), ported from `Noetica/agent-machine/lib/gaia-ontology.ts`.
- **`POST /api/studio/steward`** — apply a steward decision (keeper / successor / developmental **phase** / acknowledged **abandonment signals**) as the `gaia_*` writeback (the `applyStewardship` pattern) — **proof-carrying, receipted, reversible**.
- **`GET /api/studio/steward`** — the persisted stewardship state + a light **derived** signal (orphaned if the node has no edges), honoring acknowledged signals.

### The alignment that matters
**GAIA invariant #2** — *"model inference alone must not promote developmental state to canonical human-impacting truth"* — is enforced **through our epistemic status**: a phase set by a **human steward** is `attested`; a phase set by a **model/agent** is `derived` (it may *observe* staleness, not *canonize* it). The response flags `invariant_applied`. **GAIA governance and the proof-carrying moat are the same mechanism** — which is exactly the thing Foundry (lineage-of-transforms, no epistemic status, no living-knowledge model) structurally cannot do.

+4 tests (human→attested, model-phase→derived + invariant, phase/signal validation, state read-back + orphan derivation). **74 pass**.

> Next in the deepening: HDT OmegaState alignment; type extracted nodes to real classes (+rdf:type); un-mock the bundle ontology section.