### PR TITLE
WS#51: GAIA World Model — the promotion membrane AS epistemic status (three-twin unification)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/data/gaia_shapes.ttl
+++ b/apps/lattice-studio/src/lattice_studio/data/gaia_shapes.ttl
@@ -1,0 +1,116 @@
+@prefix gaia: <https://schemas.socioprophet.org/gaia/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Minimal SHACL stubs for decision-grade world signals.
+# These are intentionally small v0.1 constraints. They establish the promotion membrane
+# and give CI a concrete validation target before richer shapes are added.
+
+gaia:FeatureRegistryEntryShape
+    a sh:NodeShape ;
+    sh:targetClass gaia:FeatureRegistryEntry ;
+    sh:property [
+        sh:path gaia:hasFeatureId ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path gaia:hasPromotionState ;
+        sh:class gaia:PromotionState ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] .
+
+gaia:EnergyLedgerEntryShape
+    a sh:NodeShape ;
+    sh:targetClass gaia:EnergyLedgerEntry ;
+    sh:property [
+        sh:path gaia:hasMarginDelta ;
+        sh:datatype xsd:decimal ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path gaia:hasPerturbationFlipRate ;
+        sh:datatype xsd:decimal ;
+        sh:minInclusive 0.0 ;
+        sh:maxInclusive 1.0 ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path gaia:hasPromotionState ;
+        sh:class gaia:PromotionState ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] .
+
+gaia:ConcordanceLinkShape
+    a sh:NodeShape ;
+    sh:targetClass gaia:ConcordanceLink ;
+    sh:property [
+        sh:path gaia:hasSourceRecordId ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path gaia:mapsSourceRecordToEntity ;
+        sh:class gaia:CanonicalEntity ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path gaia:hasDecisionLedgerEntry ;
+        sh:class gaia:DecisionLedgerEntry ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] .
+
+gaia:DecisionLedgerEntryShape
+    a sh:NodeShape ;
+    sh:targetClass gaia:DecisionLedgerEntry ;
+    sh:property [
+        sh:path gaia:hasDecisionId ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path gaia:hasDecisionType ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] .
+
+gaia:ProofArtifactShape
+    a sh:NodeShape ;
+    sh:targetClass gaia:ProofArtifact ;
+    sh:property [
+        sh:path gaia:hasClaimName ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path gaia:hasResultStatus ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] .
+
+gaia:PromotionDecisionShape
+    a sh:NodeShape ;
+    sh:targetClass gaia:PromotionDecision ;
+    sh:property [
+        sh:path gaia:hasPolicyId ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path gaia:promotesSignal ;
+        sh:class gaia:WorldSignal ;
+        sh:minCount 1 ;
+    ] .

--- a/apps/lattice-studio/src/lattice_studio/data/gaia_world_signals.ttl
+++ b/apps/lattice-studio/src/lattice_studio/data/gaia_world_signals.ttl
@@ -1,0 +1,137 @@
+@prefix gaia: <https://schemas.socioprophet.org/gaia/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://schemas.socioprophet.org/gaia/world-signals/v0.1>
+    a owl:Ontology ;
+    dcterms:title "GAIA Decision-Grade World Signals Ontology Module v0.1" ;
+    dcterms:description "Ontology stubs for governed world signals, feature registry entries, foot-traffic/weather features, entity concordance, energy ledgers, proof artifacts, and promotion decisions." ;
+    owl:versionInfo "0.1.0" .
+
+gaia:WorldSignal a owl:Class ;
+    rdfs:label "World Signal" ;
+    rdfs:comment "A governed observation, derived feature, model output, or external signal that may inform the GAIA world model but is not canonical truth until promoted by policy." .
+
+gaia:FeatureRegistryEntry a owl:Class ;
+    rdfs:label "Feature Registry Entry" ;
+    rdfs:subClassOf gaia:WorldSignal ;
+    rdfs:comment "A contract-described provisionable signal feature with explicit semantics, temporal grain, spatial type, format, provenance, and validation expectations." .
+
+gaia:FootTrafficIndex a owl:Class ;
+    rdfs:label "Foot Traffic Index" ;
+    rdfs:subClassOf gaia:WorldSignal ;
+    rdfs:comment "A normalized observed-population mobility index computed from a POI-scoped observed population over a denominator population." .
+
+gaia:WeatherFeature a owl:Class ;
+    rdfs:label "Weather Feature" ;
+    rdfs:subClassOf gaia:FeatureRegistryEntry ;
+    rdfs:comment "A weather observation, forecast, nowcast, gridded layer, or derived weather index exposed as a governed feature." .
+
+gaia:CanonicalEntity a owl:Class ;
+    rdfs:label "Canonical Entity" ;
+    rdfs:comment "A governed entity identity selected through an explicit concordance, survivorship, and promotion process." .
+
+gaia:ConcordanceLink a owl:Class ;
+    rdfs:label "Concordance Link" ;
+    rdfs:comment "A first-class crosswalk from a source record to a canonical entity, backed by resolver run, policy, confidence, and decision ledger references." .
+
+gaia:EnergyLedgerEntry a owl:Class ;
+    rdfs:label "Energy Ledger Entry" ;
+    rdfs:comment "A ledger entry recording top candidate, runner-up candidate, score margin, perturbation stability, and promotion decision for ambiguous evidence or entity-resolution outputs." .
+
+gaia:DecisionLedgerEntry a owl:Class ;
+    rdfs:label "Decision Ledger Entry" ;
+    rdfs:comment "A replayable policy-governed decision record for match, merge, split, feature promotion, action admission, or policy block events." .
+
+gaia:ProofArtifact a owl:Class ;
+    rdfs:label "Proof Artifact" ;
+    rdfs:comment "A replayable evidence pack for claims used by policy, security, validation, or action admission." .
+
+gaia:PromotionDecision a owl:Class ;
+    rdfs:label "Promotion Decision" ;
+    rdfs:comment "A policy decision that determines whether a signal remains evidence-only, requires review, is rejected, or is promoted to canonical operational use." .
+
+gaia:PromotionState a owl:Class ;
+    rdfs:label "Promotion State" ;
+    rdfs:comment "The lifecycle state of a governed signal or evidence item at the promotion membrane." .
+
+gaia:EvidenceOnly a gaia:PromotionState ;
+    rdfs:label "Evidence Only" .
+
+gaia:ReviewRequired a gaia:PromotionState ;
+    rdfs:label "Review Required" .
+
+gaia:Rejected a gaia:PromotionState ;
+    rdfs:label "Rejected" .
+
+gaia:Promoted a gaia:PromotionState ;
+    rdfs:label "Promoted" .
+
+gaia:hasFeatureId a owl:DatatypeProperty ;
+    rdfs:domain gaia:FeatureRegistryEntry ;
+    rdfs:range xsd:string ;
+    rdfs:label "has feature id" .
+
+gaia:hasPolicyId a owl:DatatypeProperty ;
+    rdfs:range xsd:string ;
+    rdfs:label "has policy id" .
+
+gaia:hasConfidence a owl:DatatypeProperty ;
+    rdfs:range xsd:decimal ;
+    rdfs:label "has confidence" .
+
+gaia:hasMarginDelta a owl:DatatypeProperty ;
+    rdfs:domain gaia:EnergyLedgerEntry ;
+    rdfs:range xsd:decimal ;
+    rdfs:label "has margin delta" .
+
+gaia:hasPerturbationFlipRate a owl:DatatypeProperty ;
+    rdfs:domain gaia:EnergyLedgerEntry ;
+    rdfs:range xsd:decimal ;
+    rdfs:label "has perturbation flip rate" .
+
+gaia:hasDecisionId a owl:DatatypeProperty ;
+    rdfs:domain gaia:DecisionLedgerEntry ;
+    rdfs:range xsd:string ;
+    rdfs:label "has decision id" .
+
+gaia:hasDecisionType a owl:DatatypeProperty ;
+    rdfs:domain gaia:DecisionLedgerEntry ;
+    rdfs:range xsd:string ;
+    rdfs:label "has decision type" .
+
+gaia:hasClaimName a owl:DatatypeProperty ;
+    rdfs:domain gaia:ProofArtifact ;
+    rdfs:range xsd:string ;
+    rdfs:label "has claim name" .
+
+gaia:hasResultStatus a owl:DatatypeProperty ;
+    rdfs:domain gaia:ProofArtifact ;
+    rdfs:range xsd:string ;
+    rdfs:label "has result status" .
+
+gaia:hasSourceRecordId a owl:DatatypeProperty ;
+    rdfs:domain gaia:ConcordanceLink ;
+    rdfs:range xsd:string ;
+    rdfs:label "has source record id" .
+
+gaia:hasPromotionState a owl:ObjectProperty ;
+    rdfs:range gaia:PromotionState ;
+    rdfs:label "has promotion state" .
+
+gaia:promotesSignal a owl:ObjectProperty ;
+    rdfs:domain gaia:PromotionDecision ;
+    rdfs:range gaia:WorldSignal ;
+    rdfs:label "promotes signal" .
+
+gaia:mapsSourceRecordToEntity a owl:ObjectProperty ;
+    rdfs:domain gaia:ConcordanceLink ;
+    rdfs:range gaia:CanonicalEntity ;
+    rdfs:label "maps source record to entity" .
+
+gaia:hasDecisionLedgerEntry a owl:ObjectProperty ;
+    rdfs:range gaia:DecisionLedgerEntry ;
+    rdfs:label "has decision ledger entry" .

--- a/apps/lattice-studio/src/lattice_studio/gaia.py
+++ b/apps/lattice-studio/src/lattice_studio/gaia.py
@@ -48,6 +48,44 @@ def phase_epistemic(actor_kind: str) -> str:
     return "attested" if (actor_kind or "human").lower() in _HUMAN_KINDS else "derived"
 
 
+# ── GAIA World Model — the decision-grade world-signals promotion membrane (the Earth-twin discipline) ──────────
+# A gaia:WorldSignal is "a governed observation/derived-feature/model-output … NOT canonical truth until promoted
+# by policy." The promotion membrane IS our epistemic ladder: EvidenceOnly/ReviewRequired = not canonical
+# (observed/derived), Promoted = canonical (attested), and — invariant #2 — a model may propose but never promote.
+GAIA_NS = "https://schemas.socioprophet.org/gaia/"
+PROMOTION_STATES = ["EvidenceOnly", "ReviewRequired", "Rejected", "Promoted"]
+SIGNAL_TYPES = {                                    # our signal_type → the GAIA world-signals class
+    "feature_registry": "gaia:FeatureRegistryEntry",
+    "foot_traffic": "gaia:FootTrafficIndex",
+    "weather": "gaia:WeatherFeature",
+    "concordance": "gaia:ConcordanceLink",
+    "energy_ledger": "gaia:EnergyLedgerEntry",
+    "proof_artifact": "gaia:ProofArtifact",
+    "world_signal": "gaia:WorldSignal",
+}
+
+
+def is_human(actor_kind: str) -> bool:
+    return (actor_kind or "human").lower() in _HUMAN_KINDS
+
+
+def epistemic_for_promotion(state: str, actor_kind: str) -> str:
+    """The promotion membrane mapped to epistemic status — the SAME mechanism across all three twins.
+    EvidenceOnly / ReviewRequired = not canonical → observed (human) or derived (model); Promoted = canonical →
+    attested (only ever reached by a human/policy decision); Rejected = simulated (kept as a tombstone)."""
+    if state == "Promoted":
+        return "attested"
+    if state == "Rejected":
+        return "simulated"
+    return "observed" if is_human(actor_kind) else "derived"
+
+
+def can_promote_to(actor_kind: str, target_state: str) -> bool:
+    """GAIA invariant #2: model inference alone must not promote developmental/world state to canonical truth.
+    A model/agent may move a signal to ReviewRequired or Rejected, but only a human/policy actor may Promote."""
+    return not (target_state == "Promoted" and not is_human(actor_kind))
+
+
 def stewardship_of(props: dict[str, Any] | None) -> dict[str, Any]:
     """Read the persisted stewardship decision off a node's gaia_* properties (what the census honors)."""
     p = props or {}

--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -1744,6 +1744,180 @@ async def steward_state(project: str = "default", target: str = "",
             "invariants": gaia.GAIA_INVARIANTS, "degraded": err}
 
 
+# ── WS#51: GAIA World Model — the decision-grade world-signal + the PROMOTION MEMBRANE as epistemic status. This
+# is the three-twin unification made real: a gaia:WorldSignal (a governed Earth observation) is a proof-carrying
+# HellGraph fact whose promotion state (EvidenceOnly → ReviewRequired → Promoted) IS its epistemic status. It is
+# SHACL-validated against the real GAIA world-signals shapes on submit, and — invariant #2 — a model may propose
+# but only a human/policy actor may Promote to canonical. Same discipline as the knowledge & human twins. ────────
+class WorldSignalRequest(BaseModel):
+    project: str = "default"
+    feature_id: str
+    signal_type: str = "feature_registry"     # feature_registry | foot_traffic | weather | concordance | …
+    value: Any = None
+    confidence: float | None = None
+    geo_anchor: str | None = None             # a spatial-temporal anchor id/ref (GeoAnchor)
+    evidence_refs: list[str] = []             # SourceEvidence ids — required to ever be Promoted
+    actor: str | None = None
+    actor_kind: str = "human"
+
+
+def _ws_local(class_curie: str) -> str:
+    return class_curie.split(":", 1)[-1]
+
+
+@app.post("/api/studio/worldsignal")
+async def submit_worldsignal(req: WorldSignalRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Submit a governed GAIA world-signal. It enters at PromotionState=EvidenceOnly (NOT canonical) — the writeback
+    is SHACL-validated against the real GAIA shapes, and its epistemic status is derived from the promotion state
+    (evidence-only → observed/derived by actor). Fail-closed."""
+    _require_write_token(authorization)
+    if req.signal_type not in gaia.SIGNAL_TYPES:
+        raise HTTPException(status_code=422, detail=f"signal_type must be one of {sorted(gaia.SIGNAL_TYPES)}")
+    fid = req.feature_id.strip()
+    if not fid:
+        raise HTTPException(status_code=422, detail="feature_id required")
+    class_curie = gaia.SIGNAL_TYPES[req.signal_type]
+    coll = proj_collection(req.project)
+    state = "EvidenceOnly"                     # a fresh signal is always evidence-only, never born canonical
+    epi = gaia.epistemic_for_promotion(state, req.actor_kind)
+    sid = f"{coll}:worldsignal:{_norm(fid).replace(' ', '_')}"
+    prov = _workbench_prov(coll, epi, req.actor or "gaia/worldsignal")
+    prov["extractor"] = "lattice-studio/gaia-worldsignal-v0"
+    gaia_props = {"gaia:hasFeatureId": fid, "gaia:hasPromotionState": state}
+    if req.confidence is not None:
+        gaia_props["gaia:hasConfidence"] = req.confidence
+    conforms, violations = shacl.validate_gaia(class_curie, gaia_props)
+    if not conforms:
+        raise HTTPException(status_code=422, detail={"message": "world-signal rejected — not conformant to the GAIA shapes",
+                                                     "class": class_curie, "violations": violations})
+    props = {**gaia_props, "signal_type": req.signal_type, "gaia_class": class_curie,
+             "promotion_state": state, "feature_id": fid, "value": req.value if req.value is not None else "",
+             "confidence": req.confidence if req.confidence is not None else "",
+             "geo_anchor": req.geo_anchor or "", "evidence_refs": json.dumps(req.evidence_refs),
+             "actor_kind": req.actor_kind, "submitted_at": _now_iso(), **prov}
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        _, werr = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": sid, "labels": [coll, "WorldSignal", _ws_local(class_curie)], "properties": props})
+        if werr:
+            raise HTTPException(status_code=502, detail=f"graph write failed: {werr}")
+        for ev in req.evidence_refs:
+            await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                       json={"label": "has_evidence", "from": sid, "to": ev, "properties": prov})
+    return {"signal_id": sid, "class": class_curie, "promotion_state": state, "epistemic_mode": epi,
+            "admissible_for_promotion": bool(req.evidence_refs), "proof_carrying": True,
+            "note": "a world-signal is evidence-only until a policy decision Promotes it — its promotion state IS its epistemic status"}
+
+
+class PromoteSignalRequest(BaseModel):
+    project: str = "default"
+    signal: str                               # world-signal node id
+    to_state: str                             # ReviewRequired | Rejected | Promoted
+    policy_id: str | None = None
+    actor: str | None = None
+    actor_kind: str = "human"
+
+
+@app.post("/api/studio/worldsignal/promote")
+async def promote_worldsignal(req: PromoteSignalRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """A GAIA PromotionDecision — move a world-signal across the promotion membrane, recording a replayable
+    DecisionLedgerEntry. Enforces invariant #2 (a model/agent may NOT Promote to canonical) and admissibility (a
+    signal cannot be Promoted without source evidence). Promotion updates the signal's epistemic status."""
+    _require_write_token(authorization)
+    if req.to_state not in ("ReviewRequired", "Rejected", "Promoted"):
+        raise HTTPException(status_code=422, detail="to_state must be ReviewRequired | Rejected | Promoted")
+    if not gaia.can_promote_to(req.actor_kind, req.to_state):
+        raise HTTPException(status_code=403, detail={
+            "message": "GAIA invariant #2 — model inference may not promote to canonical truth; only a human/policy actor Promotes",
+            "actor_kind": req.actor_kind, "to_state": req.to_state})
+    coll = proj_collection(req.project)
+    raw, err = await _fetch_raw_nodes(coll, 2000)
+    node = next((n for n in raw if n.get("id") == req.signal), None)
+    if not node:
+        raise HTTPException(status_code=404, detail=f"world-signal not found: {req.signal}")
+    p = dict(node.get("properties") or {})
+    try:
+        evidence = json.loads(p.get("evidence_refs") or "[]")
+    except (ValueError, TypeError):
+        evidence = []
+    if req.to_state == "Promoted" and not evidence:
+        raise HTTPException(status_code=422, detail="not admissible — a world-signal cannot be Promoted without source evidence")
+    prev = p.get("promotion_state", "EvidenceOnly")
+    new_epi = gaia.epistemic_for_promotion(req.to_state, p.get("actor_kind", "human"))
+    p["gaia:hasPromotionState"] = req.to_state
+    p["promotion_state"] = req.to_state
+    p["epistemic_mode"] = new_epi
+    p["promoted_at"] = _now_iso()
+    dhash = hashlib.sha256((req.signal + req.to_state + _now_iso()).encode()).hexdigest()
+    correlation = f"dec-{dhash[:12]}"
+    dec_id = f"{coll}:decision:{dhash[:12]}"
+    prov = _workbench_prov(coll, "attested" if gaia.is_human(req.actor_kind) else "derived", req.actor or "gaia/policy")
+    prov["extractor"] = "lattice-studio/gaia-promotion-v0"
+    receipt = {"correlation_id": correlation, "service": "lattice-studio", "kind": "gaia-promotion",
+               "replayable": True, "bundle_ref": f"/v1/receipts/lattice-studio/{correlation}"}
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        _, werr = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": req.signal, "labels": node.get("labels") or [coll, "WorldSignal"], "properties": p})
+        if werr:
+            raise HTTPException(status_code=502, detail=f"promotion writeback failed: {werr}")
+        dec_props = {"gaia:hasDecisionId": correlation, "gaia:hasDecisionType": "feature_promotion",
+                     "gaia:hasPolicyId": req.policy_id or "policy/default",
+                     "from_state": prev, "to_state": req.to_state, "signal": req.signal,
+                     "correlation_id": correlation, "receipt_bundle": receipt["bundle_ref"], "at": _now_iso(), **prov}
+        await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                   json={"id": dec_id, "labels": [coll, "DecisionLedgerEntry", "PromotionDecision", "Run"], "properties": dec_props})
+        await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                   json={"label": "promotesSignal", "from": dec_id, "to": req.signal, "properties": prov})
+    return {"decision_id": dec_id, "signal": req.signal, "from_state": prev, "to_state": req.to_state,
+            "epistemic_mode": new_epi, "receipt": receipt, "proof_carrying": True,
+            "canonical": req.to_state == "Promoted"}
+
+
+@app.get("/api/studio/worldsignals")
+async def worldsignals(project: str = "default", state: str = "",
+                       _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """The project's GAIA world-signals with their promotion state + epistemic status + evidence."""
+    coll = proj_collection(project)
+    raw, err = await _fetch_raw_nodes(coll, 2000)
+    out = []
+    for n in raw:
+        if "WorldSignal" not in (n.get("labels") or []):
+            continue
+        p = n.get("properties") or {}
+        if state and p.get("promotion_state") != state:
+            continue
+        try:
+            evidence = json.loads(p.get("evidence_refs") or "[]")
+        except (ValueError, TypeError):
+            evidence = []
+        out.append({"signal_id": n.get("id"), "feature_id": p.get("feature_id"), "signal_type": p.get("signal_type"),
+                    "promotion_state": p.get("promotion_state", "EvidenceOnly"), "epistemic_mode": p.get("epistemic_mode"),
+                    "canonical": p.get("promotion_state") == "Promoted", "evidence_count": len(evidence),
+                    "confidence": p.get("confidence") or None, "submitted_at": p.get("submitted_at")})
+    out.sort(key=lambda x: x.get("submitted_at") or "", reverse=True)
+    return {"project": project, "world_signals": out, "count": len(out), "degraded": err}
+
+
+@app.get("/api/studio/gaia/ontology")
+async def gaia_ontology(_auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """The GAIA world-signals promotion membrane — and the mapping that unifies the estate: a promotion state IS
+    an epistemic status. The same governed-evidence discipline runs across all three digital twins."""
+    membrane = [{"state": s, "epistemic_human": gaia.epistemic_for_promotion(s, "human"),
+                 "epistemic_model": gaia.epistemic_for_promotion(s, "model"),
+                 "canonical": s == "Promoted"} for s in gaia.PROMOTION_STATES]
+    return {
+        "ontology": "GAIA World Model — decision-grade world-signals", "namespace": gaia.GAIA_NS,
+        "signal_types": gaia.SIGNAL_TYPES, "promotion_states": gaia.PROMOTION_STATES,
+        "promotion_epistemic_membrane": membrane,
+        "invariant": "GAIA-2: a model may propose (EvidenceOnly/ReviewRequired) but only a human/policy actor may Promote to canonical (attested)",
+        "three_twins": {
+            "knowledge": "HellGraph fact · epistemic status observed→attested",
+            "human": "HDT Observation → OmegaState ABSENT→DELIVERED",
+            "earth": "GAIA WorldSignal → PromotionState EvidenceOnly→Promoted",
+            "note": "one governed-evidence discipline; the promotion membrane and the epistemic ladder are the same mechanism",
+        },
+    }
+
+
 # ── WS#49: ONTOLOGY ACTIONS + writeback — the Foundry crown jewel (Workshop apps are built on Actions). A typed
 # action defines a governed edit on an object type (set a property, set status, add a relation), and invoking it
 # writes back to the graph. BEAT Foundry on every axis: their edits are bare edits; ours are PROOF-CARRYING

--- a/apps/lattice-studio/src/lattice_studio/shacl.py
+++ b/apps/lattice-studio/src/lattice_studio/shacl.py
@@ -19,6 +19,9 @@ from rdflib.namespace import RDF, XSD
 from lattice_studio import ontology
 
 _SHAPES_PATH = os.path.join(os.path.dirname(__file__), "data", "ontogenesis_shapes.ttl")
+_GAIA_SHAPES_PATH = os.path.join(os.path.dirname(__file__), "data", "gaia_shapes.ttl")
+_GAIA_ONT_PATH = os.path.join(os.path.dirname(__file__), "data", "gaia_world_signals.ttl")
+_GAIA_NS = "https://schemas.socioprophet.org/gaia/"
 _NODE = URIRef("urn:studio:candidate")
 
 
@@ -99,3 +102,64 @@ def ontology_curie(iri: str) -> str:
         if iri.startswith(ns):
             return f"{p}:{iri[len(ns):]}"
     return iri
+
+
+# ── GAIA world-signals validation (the Earth-twin promotion membrane) ──────────────────────────────────────────
+_GAIA_OBJECT_PROPS = {"gaia:hasPromotionState", "gaia:promotesSignal",
+                      "gaia:mapsSourceRecordToEntity", "gaia:hasDecisionLedgerEntry"}
+
+
+@lru_cache(maxsize=1)
+def _gaia() -> tuple[rdflib.Graph, rdflib.Graph] | None:
+    """Parse the vendored GAIA shapes + world-signals ontology once (the ontology is the type graph so that
+    `sh:class gaia:PromotionState` on a value like gaia:EvidenceOnly resolves). None if unavailable."""
+    try:
+        shapes = rdflib.Graph(); shapes.parse(_GAIA_SHAPES_PATH, format="turtle")
+        ont = rdflib.Graph(); ont.parse(_GAIA_ONT_PATH, format="turtle")
+        return shapes, ont
+    except (OSError, ValueError):
+        return None
+
+
+def _gaia_expand(curie: str) -> str:
+    return _GAIA_NS + curie[5:] if curie.startswith("gaia:") else ontology.expand(curie)
+
+
+def validate_gaia(class_curie: str, props: dict[str, Any]) -> tuple[bool, list[str]]:
+    """Validate a GAIA world-signal (typed class_curie, carrying gaia:* props) against the GAIA world-signals
+    SHACL shapes. Object props (hasPromotionState, …) become IRIs (a promotion state → gaia:<State>); datatype
+    props become literals. Degrades OPEN if the shapes/pyshacl are unavailable."""
+    g = _gaia()
+    if g is None:
+        return True, []
+    try:
+        import pyshacl
+    except ImportError:
+        return True, []
+    shapes, ont = g
+    data = rdflib.Graph()
+    data.add((_NODE, RDF.type, URIRef(_gaia_expand(class_curie))))
+    for key, val in props.items():
+        if val is None or not str(key).startswith("gaia:"):
+            continue
+        piri = URIRef(_gaia_expand(str(key)))
+        if key in _GAIA_OBJECT_PROPS:
+            ref = _gaia_expand(f"gaia:{val}") if key == "gaia:hasPromotionState" else str(val)
+            data.add((_NODE, piri, URIRef(ref)))
+        else:
+            data.add((_NODE, piri, Literal(str(val))))
+    try:
+        conforms, results_graph, _ = pyshacl.validate(
+            data, shacl_graph=shapes, ont_graph=ont, inference="rdfs", advanced=True, meta_shacl=False)
+    except Exception:  # noqa: BLE001
+        return True, []
+    if conforms:
+        return True, []
+    SH = rdflib.Namespace("http://www.w3.org/ns/shacl#")
+    out = []
+    for res in results_graph.subjects(RDF.type, SH.ValidationResult):
+        msg = results_graph.value(res, SH.resultMessage)
+        path = results_graph.value(res, SH.resultPath)
+        pc = str(path).replace(_GAIA_NS, "gaia:") if path else ""
+        out.append(f"{pc}: {msg}".strip(": ") or str(msg))
+    return False, out[:12]

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -1331,3 +1331,93 @@ def test_steward_state_reads_back_and_derives_orphan(monkeypatch):
     assert b["stewardship"]["keeper"] == "sam" and b["stewardship"]["phase_override"] == "growth"
     assert b["derived_signals"] == ["orphaned_artifact"] and b["degree"] == 0
     assert "maturity" in b["phases"]
+
+
+# ── WS#51: GAIA World Model — world-signals + the promotion membrane as epistemic status ──
+def test_worldsignal_submit_is_evidence_only_and_epistemic_maps(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    writes = []
+    async def fake_req(client, method, url, json=None):
+        if "/api/graph/node" in url or "/api/graph/edge" in url:
+            writes.append(json); return ({"ok": True}, None)
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    # human submit → observed (not canonical)
+    h = client.post("/api/studio/worldsignal",
+                    json={"project": "team-x", "feature_id": "foot-traffic-poi-42", "signal_type": "feature_registry",
+                          "actor_kind": "human"}, headers={"Authorization": "Bearer T"}).json()
+    assert h["promotion_state"] == "EvidenceOnly" and h["epistemic_mode"] == "observed"
+    assert h["admissible_for_promotion"] is False                       # no evidence yet
+    node = next(w for w in writes if "labels" in w)
+    assert "WorldSignal" in node["labels"] and node["properties"]["gaia:hasPromotionState"] == "EvidenceOnly"
+
+    # model submit → derived (a model observes, doesn't canonize)
+    m = client.post("/api/studio/worldsignal",
+                    json={"project": "team-x", "feature_id": "weather-x", "signal_type": "weather", "actor_kind": "model"},
+                    headers={"Authorization": "Bearer T"}).json()
+    assert m["epistemic_mode"] == "derived"
+
+
+def test_worldsignal_shacl_rejects_incomplete_energy_ledger(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    async def fake_req(client, method, url, json=None):
+        if "/api/graph/node" in url or "/api/graph/edge" in url: return ({"ok": True}, None)
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+    # energy_ledger requires gaia:hasMarginDelta + gaia:hasPerturbationFlipRate — we don't supply them → SHACL 422
+    r = client.post("/api/studio/worldsignal",
+                    json={"project": "team-x", "feature_id": "e1", "signal_type": "energy_ledger"},
+                    headers={"Authorization": "Bearer T"})
+    assert r.status_code == 422 and "GAIA shapes" in r.json()["detail"]["message"]
+
+
+def test_worldsignal_model_cannot_promote_to_canonical(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    r = client.post("/api/studio/worldsignal/promote",
+                    json={"project": "team-x", "signal": "s1", "to_state": "Promoted", "actor_kind": "model"},
+                    headers={"Authorization": "Bearer T"})
+    assert r.status_code == 403 and "invariant #2" in r.json()["detail"]["message"]
+
+
+def test_worldsignal_promotion_admissibility_and_canonical(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+
+    # a signal with NO evidence → cannot be Promoted
+    state, fake_req = _stateful_graph({
+        "proj-teamx:worldsignal:noev": {"id": "proj-teamx:worldsignal:noev", "labels": ["proj-teamx", "WorldSignal"],
+                                        "properties": {"promotion_state": "EvidenceOnly", "evidence_refs": "[]", "actor_kind": "human"}},
+        "proj-teamx:worldsignal:ok": {"id": "proj-teamx:worldsignal:ok", "labels": ["proj-teamx", "WorldSignal"],
+                                     "properties": {"promotion_state": "EvidenceOnly",
+                                                    "evidence_refs": "[\"proj-teamx:evidence:1\"]", "actor_kind": "human"}},
+    })
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.post("/api/studio/worldsignal/promote",
+                    json={"project": "team-x", "signal": "proj-teamx:worldsignal:noev", "to_state": "Promoted", "actor_kind": "human"},
+                    headers={"Authorization": "Bearer T"})
+    assert r.status_code == 422 and "source evidence" in r.json()["detail"]
+
+    # a signal WITH evidence, promoted by a human → Promoted + attested + a DecisionLedgerEntry
+    ok = client.post("/api/studio/worldsignal/promote",
+                     json={"project": "team-x", "signal": "proj-teamx:worldsignal:ok", "to_state": "Promoted",
+                           "policy_id": "policy/geo-v1", "actor_kind": "human"},
+                     headers={"Authorization": "Bearer T"}).json()
+    assert ok["to_state"] == "Promoted" and ok["epistemic_mode"] == "attested" and ok["canonical"]
+    assert ok["receipt"]["replayable"]
+    signal = state["nodes"]["proj-teamx:worldsignal:ok"]["properties"]
+    assert signal["promotion_state"] == "Promoted" and signal["epistemic_mode"] == "attested"
+    dec = next(w for w in state["nodes"].values() if "DecisionLedgerEntry" in (w.get("labels") or []))
+    assert dec["properties"]["to_state"] == "Promoted"
+
+
+def test_gaia_ontology_serves_the_three_twin_membrane():
+    b = client.get("/api/studio/gaia/ontology").json()
+    assert b["promotion_states"] == ["EvidenceOnly", "ReviewRequired", "Rejected", "Promoted"]
+    prom = next(m for m in b["promotion_epistemic_membrane"] if m["state"] == "Promoted")
+    assert prom["epistemic_human"] == "attested" and prom["canonical"]
+    assert set(b["three_twins"]) >= {"knowledge", "human", "earth"}


### PR DESCRIPTION
The real GAIA integration (not the stewardship slice) — and the point where the estate's architecture becomes visible: **one governed-evidence discipline across three digital twins.**

Re-synced `prophet-domain-gaia-ontology` from upstream first (my local was **9 commits behind — initial-commit only**; I'd been building against an empty repo), then vendored the real GAIA world-signals ontology + SHACL shapes.

### What it does
- **`POST /api/studio/worldsignal`** — submit a governed `gaia:WorldSignal` (an Earth observation). It is born **EvidenceOnly** (never canonical), **SHACL-validated against the real GAIA shapes** (`data/gaia_shapes.ttl`), and its **epistemic status is derived from the promotion state**: EvidenceOnly → `observed` (human) / `derived` (model).
- **`POST /api/studio/worldsignal/promote`** — a **PromotionDecision** across the membrane (EvidenceOnly→ReviewRequired→Promoted), recording a replayable **DecisionLedgerEntry**. Enforces **GAIA invariant #2** (a model/agent may propose but **only a human/policy actor may Promote** to canonical=`attested` → **403**) and **admissibility** (no Promotion without **source evidence** → **422**).
- **`GET /api/studio/worldsignals`** — the signals with promotion state + epistemic + evidence.
- **`GET /api/studio/gaia/ontology`** — the promotion membrane + the mapping that unifies everything.

### Why it matters
GAIA's PromotionState membrane **is** our epistemic ladder. The estate now runs **one discipline across three twins**:

| Twin | Fact | Membrane |
|---|---|---|
| Knowledge (HellGraph) | proof-carrying node | observed→attested |
| Human (HDT) | Observation → OmegaState | ABSENT→DELIVERED |
| **Earth (GAIA)** | WorldSignal → PromotionState | EvidenceOnly→Promoted |

That is the thing no incumbent (Databricks/Foundry/Watson) has — and it's now real, not a claim.

+5 tests (submit→EvidenceOnly + epistemic mapping; SHACL-reject incomplete energy-ledger; model-can't-Promote→403; admissibility→422; human-Promote→attested + DecisionLedgerEntry; membrane readout). **79 pass**.