### PR TITLE
spark-runner: sovereign Apache Spark execution backend (build stage)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -73,6 +73,7 @@ jobs:
           - { image: liberty-stack-readout, context: apps/liberty-stack-readout, dockerfile: Dockerfile }
           - { image: tritfabric-consumption-api, context: ., dockerfile: apps/tritfabric-consumption-api/Dockerfile }
           - { image: agora,                 context: apps/agora,                 dockerfile: Dockerfile }
+          - { image: spark-runner,          context: apps/spark-runner,          dockerfile: Dockerfile }
     uses: SocioProphet/.github/.github/workflows/build-image.yml@main
     with:
       image: ${{ matrix.image }}

--- a/apps/spark-runner/Dockerfile
+++ b/apps/spark-runner/Dockerfile
@@ -1,0 +1,13 @@
+# spark-runner — the sovereign Apache Spark execution backend for the Studio execution plane.
+FROM python:3.12-slim
+# Spark needs a JRE.
+RUN apt-get update && apt-get install -y --no-install-recommends default-jre-headless procps \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+ENV PORT=8080
+EXPOSE 8080
+# 8080 + /healthz = the chart contract.
+CMD ["uvicorn", "spark_runner.server:app", "--host", "0.0.0.0", "--port", "8080", "--app-dir", "src"]

--- a/apps/spark-runner/pyproject.toml
+++ b/apps/spark-runner/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "prophet-spark-runner"
+version = "0.1.0"
+description = "spark-runner — sovereign Apache Spark execution backend for the Studio execution plane (governed, receipted)."
+requires-python = ">=3.11"
+dependencies = ["fastapi>=0.115.0", "uvicorn>=0.30.0", "pyspark>=3.5.0"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/apps/spark-runner/requirements-test.txt
+++ b/apps/spark-runner/requirements-test.txt
@@ -1,0 +1,4 @@
+fastapi>=0.115.0
+uvicorn>=0.30.0
+httpx>=0.27.0
+pytest>=8.0.0

--- a/apps/spark-runner/requirements.txt
+++ b/apps/spark-runner/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.115.0
+uvicorn>=0.30.0
+pyspark>=3.5.0

--- a/apps/spark-runner/src/spark_runner/server.py
+++ b/apps/spark-runner/src/spark_runner/server.py
@@ -1,0 +1,111 @@
+"""spark-runner — the sovereign distributed-compute backend for the Studio execution plane.
+
+The answer to "they run Spark, we don't": a real Apache Spark execution service. It runs a submitted SQL/
+dataframe job on a Spark session (local[*] by default; SPARK_MASTER points it at a standalone/k8s cluster in
+the paid mesh), and emits a governed, replayable receipt — input/output row counts, duration, and a payload
+hash. lattice-studio's execution plane (backend="spark", once entitled) dispatches here.
+
+Governance: fail-closed write token (SPARK_RUNNER_TOKEN). Degrades honestly — if the Spark runtime is not
+present it returns 503, it never fakes a result. The Spark execution itself is behind `run_sql`, so the HTTP
+contract + receipts are testable without a Spark cluster, while the real engine runs in the deployed image.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel
+
+SERVICE_VERSION = "0.1.0"
+SPARK_MASTER = os.getenv("SPARK_MASTER", "local[*]")          # cluster URL in the mesh, or local
+SPARK_RUNNER_TOKEN = os.getenv("SPARK_RUNNER_TOKEN", "")      # fail-closed submit gate
+MAX_ROWS = int(os.getenv("SPARK_MAX_RESULT_ROWS", "10000"))
+
+app = FastAPI(title="spark-runner", version=SERVICE_VERSION)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def spark_available() -> bool:
+    try:
+        import pyspark  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+_session: Any = None
+
+
+def _get_session() -> Any:
+    """Lazily create a single SparkSession (local[*] or the configured master)."""
+    global _session
+    if _session is None:
+        from pyspark.sql import SparkSession
+        _session = (SparkSession.builder
+                    .appName("spark-runner")
+                    .master(SPARK_MASTER)
+                    .config("spark.ui.enabled", "false")
+                    .getOrCreate())
+    return _session
+
+
+def run_sql(sql: str, rows: list[dict[str, Any]], table: str) -> list[dict[str, Any]]:
+    """Execute a Spark SQL query over inline rows registered as a temp view. Real distributed compute — this is
+    what runs in the deployed image. Isolated so the HTTP contract is testable without a Spark cluster."""
+    spark = _get_session()
+    df = spark.createDataFrame(rows) if rows else spark.createDataFrame([], schema="_empty string")
+    df.createOrReplaceTempView(table)
+    result = spark.sql(sql).limit(MAX_ROWS)
+    return [r.asDict(recursive=True) for r in result.collect()]
+
+
+def _require_token(authorization: str) -> None:
+    if not SPARK_RUNNER_TOKEN:
+        raise HTTPException(status_code=503, detail="spark-runner submit disabled: SPARK_RUNNER_TOKEN unset (fail-closed)")
+    if authorization.removeprefix("Bearer ").strip() != SPARK_RUNNER_TOKEN:
+        raise HTTPException(status_code=401, detail="invalid token")
+
+
+@app.get("/healthz")
+async def healthz() -> dict[str, Any]:
+    return {"status": "ok", "service": "spark-runner", "version": SERVICE_VERSION,
+            "spark_available": spark_available(), "master": SPARK_MASTER}
+
+
+class SubmitRequest(BaseModel):
+    sql: str
+    data: list[dict[str, Any]] = []       # inline rows registered as `table`
+    table: str = "t"
+    job_id: str | None = None
+
+
+@app.post("/v1/submit")
+async def submit(req: SubmitRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Run a Spark SQL job and return its rows + a governed, replayable receipt. Fail-closed on the token; 503 if
+    the Spark runtime is unavailable (never a faked result)."""
+    _require_token(authorization)
+    if not req.sql.strip():
+        raise HTTPException(status_code=422, detail="sql required")
+    if not spark_available():
+        raise HTTPException(status_code=503, detail="spark runtime unavailable (pyspark not installed in this image)")
+    payload_hash = hashlib.sha256((req.sql + json.dumps(req.data, sort_keys=True, default=str)).encode()).hexdigest()
+    correlation = req.job_id or f"spark-{payload_hash[:12]}"
+    started = time.time()
+    try:
+        result = run_sql(req.sql, req.data, req.table)
+    except Exception as exc:  # noqa: BLE001 — surface the Spark error to the caller, don't 500 opaquely
+        raise HTTPException(status_code=400, detail=f"spark job failed: {type(exc).__name__}: {exc}") from exc
+    duration_ms = int((time.time() - started) * 1000)
+    receipt = {"correlation_id": correlation, "service": "spark-runner", "engine": "apache-spark",
+               "master": SPARK_MASTER, "input_rows": len(req.data), "output_rows": len(result),
+               "duration_ms": duration_ms, "payload_sha256": payload_hash, "replayable": True,
+               "ran_at": _now_iso()}
+    return {"job_id": correlation, "rows": result, "row_count": len(result), "receipt": receipt}

--- a/apps/spark-runner/tests/test_server.py
+++ b/apps/spark-runner/tests/test_server.py
@@ -1,0 +1,54 @@
+"""spark-runner contract + governance tests. The Spark execution (`run_sql`) and `spark_available` are injected,
+so the HTTP contract, fail-closed gate, and receipt are verified without a Spark cluster; the real engine runs in
+the deployed image."""
+from fastapi.testclient import TestClient
+
+import spark_runner.server as srv
+from spark_runner.server import app
+
+client = TestClient(app)
+
+
+def test_healthz_reports_spark_state():
+    b = client.get("/healthz").json()
+    assert b["service"] == "spark-runner" and "spark_available" in b and b["master"]
+
+
+def test_submit_fail_closed_without_token(monkeypatch):
+    monkeypatch.setattr(srv, "SPARK_RUNNER_TOKEN", "")
+    r = client.post("/v1/submit", json={"sql": "select 1"})
+    assert r.status_code == 503   # fail-closed
+
+
+def test_submit_503_when_spark_runtime_absent(monkeypatch):
+    monkeypatch.setattr(srv, "SPARK_RUNNER_TOKEN", "T")
+    monkeypatch.setattr(srv, "spark_available", lambda: False)
+    r = client.post("/v1/submit", json={"sql": "select 1"}, headers={"Authorization": "Bearer T"})
+    assert r.status_code == 503 and "unavailable" in r.json()["detail"]   # honest, never faked
+
+
+def test_submit_rejects_empty_sql(monkeypatch):
+    monkeypatch.setattr(srv, "SPARK_RUNNER_TOKEN", "T")
+    r = client.post("/v1/submit", json={"sql": "   "}, headers={"Authorization": "Bearer T"})
+    assert r.status_code == 422
+
+
+def test_submit_runs_job_and_emits_governed_receipt(monkeypatch):
+    monkeypatch.setattr(srv, "SPARK_RUNNER_TOKEN", "T")
+    monkeypatch.setattr(srv, "spark_available", lambda: True)
+    seen = {}
+
+    def fake_run_sql(sql, rows, table):
+        seen["sql"] = sql; seen["rows"] = rows; seen["table"] = table
+        return [{"n": len(rows)}]                       # a canned aggregate result
+    monkeypatch.setattr(srv, "run_sql", fake_run_sql)
+
+    r = client.post("/v1/submit",
+                    json={"sql": "select count(*) n from t", "data": [{"x": 1}, {"x": 2}, {"x": 3}], "table": "t"},
+                    headers={"Authorization": "Bearer T"})
+    b = r.json()
+    assert r.status_code == 200 and b["row_count"] == 1 and b["rows"] == [{"n": 3}]
+    assert seen["sql"].startswith("select count") and seen["table"] == "t" and len(seen["rows"]) == 3
+    rec = b["receipt"]
+    assert rec["engine"] == "apache-spark" and rec["input_rows"] == 3 and rec["output_rows"] == 1
+    assert rec["replayable"] and rec["payload_sha256"] and "duration_ms" in rec

--- a/contracts/PlatformServiceManifest.svc.compute.spark-runner.v0.1.json
+++ b/contracts/PlatformServiceManifest.svc.compute.spark-runner.v0.1.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "0.1",
+  "kind": "PlatformServiceManifest",
+  "service_id": "svc.compute.spark-runner",
+  "display_name": "spark-runner — Sovereign Apache Spark Execution Backend",
+  "description": "The distributed-compute backend for the Studio execution plane. Runs a submitted Spark SQL/dataframe job on a Spark session (local[*] by default; SPARK_MASTER points at a standalone/k8s Spark cluster in the paid mesh) and emits a governed, replayable receipt (input/output row counts, duration, payload hash). lattice-studio's execution plane, with backend='spark' and a compute entitlement, dispatches here. This is the answer to 'they run Spark at scale, we don't' — a real, sovereign, receipted Spark engine.",
+  "scaffold_baseline": {
+    "repo": "SocioProphet/prophet-platform",
+    "path": "apps/spark-runner",
+    "status": "PR-A scaffold — FastAPI over pyspark; builds the image, not yet deployed"
+  },
+  "runtime_posture": "cluster_internal",
+  "deployment_topology": {
+    "spark_runner_svc": {
+      "description": "FastAPI service (apps/spark-runner) — /healthz, POST /v1/submit. Renders charts/socioprophet-service via deploy/values/spark-runner.yaml (pinned to the sha- tag) + a { name: spark-runner } entry in platform-services. Image carries a JRE + pyspark.",
+      "binding": "org.compute.spark-runner"
+    },
+    "spark_cluster": {
+      "description": "SPARK_MASTER selects the engine: local[*] (single-pod) or spark://… / k8s:// for a standalone/k8s Spark cluster provisioned in the paid mesh — the horizontal-scale path.",
+      "binding": "org.compute.spark-cluster"
+    }
+  },
+  "consumers": {
+    "lattice_studio_execution_plane": "POST /api/studio/execute (backend='spark') dispatches a job here once the project holds a compute entitlement (STUDIO_COMPUTE_ENTITLEMENTS). The execution stays entitlement-gated; the receipt chains studio→spark-runner."
+  },
+  "policy_dependencies": ["policy://compute/submit-token-v0.1"],
+  "evidence_receipts": ["receipt://compute/spark-job-receipt-v0.1"],
+  "pr_a_status": {
+    "is_pr_a": true,
+    "note": "Build stage — image + estate contract. Not deployment-ready. First CI build publishes a sha- tag; a follow-up pins deploy/values/spark-runner.yaml + registers the ApplicationSet element + creates the spark-runner-token Secret (fail-closed until then).",
+    "deployment_ready": false
+  },
+  "runtime_prerequisites": [
+    {"id": "prereq_submit_token", "description": "spark-runner-token Secret must exist in ns socioprophet before /v1/submit accepts jobs (fail-closed until then).", "status": "pending"},
+    {"id": "prereq_image_pin", "description": "deploy/values/spark-runner.yaml image.tag pinned to the CI-published sha- tag (not moving :latest).", "status": "pending"},
+    {"id": "prereq_master", "description": "SPARK_MASTER set to local[*] (single-pod) or a mesh Spark cluster URL for horizontal scale.", "status": "pending"}
+  ],
+  "authority_boundary": {
+    "owner": "prophet-platform",
+    "note": "prophet-platform owns runtime deployment + API contract; the execution plane (lattice-studio) is the governed caller."
+  }
+}


### PR DESCRIPTION
**"They run Spark at scale, we don't" — this is the engine.** A real, sovereign, governed Apache Spark execution backend for the Studio execution plane.

- **`apps/spark-runner`** — FastAPI over **pyspark**. `POST /v1/submit` runs a Spark SQL/dataframe job on a Spark session and returns rows + a **governed, replayable receipt** (input/output row counts, duration, payload sha256).
- **Scales the sovereign way:** `SPARK_MASTER` selects the engine — `local[*]` (single pod) or `spark://…`/`k8s://…` for a **standalone/k8s Spark cluster in the paid mesh**. Same pay-gated model as Databricks, but yours.
- **Governed + honest:** fail-closed submit token (`SPARK_RUNNER_TOKEN`); **503 if the Spark runtime is absent — never a faked result.** The Spark execution is behind `run_sql`, so the HTTP contract + receipts are tested without a cluster while the real engine runs in the deployed image (Dockerfile carries a JRE + pyspark).

Wires into the execution plane: `POST /api/studio/execute` with `backend='spark'` + a compute entitlement dispatches here (receipt chains studio→spark-runner) — that dispatch + the deploy (sha-pinned values, ApplicationSet, `spark-runner-token` secret) are the follow-up once this build publishes the tag.

Build stage only (image + `images.yml` + `PlatformServiceManifest` contract; no deploy values → preflight clean). **5 tests pass.**