### PR TITLE
spark-runner: deploy (sha-pinned) + wire the execution plane's spark dispatch

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -48,6 +48,10 @@ STUDIO_JWT_SECRET = os.getenv("STUDIO_JWT_SECRET", "")
 # Evidence fabric — verified-compute RECEIPTS. Studio surfaces the replayable proof-of-work behind its services:
 # not "the job ran" (a TEE attestation), but a sealed record of exactly WHAT ran and its verdict, per correlation.
 EVIDENCE_RECEIPTS_URL = os.getenv("EVIDENCE_RECEIPTS_URL", "http://evidence-receipts:8080")
+# The sovereign Spark execution backend (apps/spark-runner). When backend='spark' + entitled, execute dispatches
+# the job here and chains its receipt. Unset/unreachable → the run degrades to the governed ledger (dispatched).
+SPARK_RUNNER_URL = os.getenv("SPARK_RUNNER_URL", "")
+SPARK_RUNNER_TOKEN = os.getenv("SPARK_RUNNER_TOKEN", "")
 RECEIPT_SERVICES = [s.strip() for s in os.getenv(
     "STUDIO_RECEIPT_SERVICES",
     "hellgraph-service,lattice-studio,search-orchestrator,owl-reasoner,entity-resolution,eval-fabric-api",
@@ -1573,9 +1577,25 @@ class ExecuteRequest(BaseModel):
     kind: str = "notebook-cell"            # notebook-cell | pipeline-step | job | query
     backend: str = "mesh-k8s"
     ref: str | None = None                 # what to run (notebook/cell/pipeline id)
-    code: str | None = None                # optional inline payload (hashed into the receipt, not stored verbatim)
+    code: str | None = None                # inline payload — for backend='spark' this is the Spark SQL
+    data: list[dict[str, Any]] = []        # inline rows for the spark job (registered as table `t`)
     note: str | None = None
     actor: str | None = None
+
+
+async def _spark_submit(sql: str, data: list[dict[str, Any]], correlation: str) -> dict[str, Any] | None:
+    """Dispatch a job to the spark-runner service. Returns its {rows, receipt} on success, else None (unset URL,
+    unreachable, or a non-200 — the caller then degrades to the run-ledger). Isolated so execute() is testable."""
+    if not SPARK_RUNNER_URL:
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=float(os.getenv("SPARK_TIMEOUT", "30"))) as sc:
+            r = await sc.post(f"{SPARK_RUNNER_URL}/v1/submit",
+                              json={"sql": sql, "data": data, "job_id": correlation},
+                              headers={"authorization": f"Bearer {SPARK_RUNNER_TOKEN}"})
+        return r.json() if r.status_code == 200 else None
+    except Exception:  # noqa: BLE001 — spark-runner health is not our contract; degrade to the ledger
+        return None
 
 
 @app.post("/api/studio/execute")
@@ -1604,7 +1624,19 @@ async def execute(req: ExecuteRequest, authorization: str = Header(default="")) 
     receipt = {"correlation_id": correlation, "service": "lattice-studio", "kind": req.kind,
                "backend": req.backend, "replayable": True, "payload_sha256": payload_hash,
                "bundle_ref": f"/v1/receipts/lattice-studio/{correlation}"}
-    props = {"kind": req.kind, "backend": req.backend, "ref": req.ref or "", "status": "dispatched",
+    # backend='spark' → actually RUN the job on the sovereign spark-runner and chain its receipt; otherwise (or if
+    # spark-runner is unreachable) the run is recorded in the governed ledger for the backend's runtime to pick up.
+    status = "dispatched"
+    rows = None
+    spark_receipt = None
+    if req.backend == "spark" and (req.code or "").strip():
+        out = await _spark_submit(req.code, req.data, correlation)
+        if out:
+            status = "completed"
+            rows = out.get("rows")
+            spark_receipt = out.get("receipt")
+            receipt["chained"] = spark_receipt.get("correlation_id") if isinstance(spark_receipt, dict) else None
+    props = {"kind": req.kind, "backend": req.backend, "ref": req.ref or "", "status": status,
              "correlation_id": correlation, "receipt_bundle": receipt["bundle_ref"],
              "payload_sha256": payload_hash, "note": req.note or "", "submitted_at": _now_iso(), **prov}
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
@@ -1615,9 +1647,10 @@ async def execute(req: ExecuteRequest, authorization: str = Header(default="")) 
         if req.ref:                          # lineage: the execution ran a pipeline/notebook/etc
             await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
                        json={"label": "executed", "from": eid, "to": req.ref, "properties": prov})
-    return {"execution_id": eid, "backend": req.backend, "kind": req.kind, "status": "dispatched",
-            "receipt": receipt, "proof_carrying": True,
-            "note": f"run recorded + receipt emitted; compute executes on the entitled {req.backend} runtime"}
+    return {"execution_id": eid, "backend": req.backend, "kind": req.kind, "status": status,
+            "receipt": receipt, "spark_receipt": spark_receipt, "rows": rows, "proof_carrying": True,
+            "note": (f"ran on the sovereign spark-runner; receipt chained" if status == "completed"
+                     else f"run recorded + receipt emitted; compute executes on the entitled {req.backend} runtime")}
 
 
 @app.get("/api/studio/executions")

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -1421,3 +1421,43 @@ def test_gaia_ontology_serves_the_three_twin_membrane():
     prom = next(m for m in b["promotion_epistemic_membrane"] if m["state"] == "Promoted")
     assert prom["epistemic_human"] == "attested" and prom["canonical"]
     assert set(b["three_twins"]) >= {"knowledge", "human", "earth"}
+
+
+def test_execute_spark_dispatches_to_runner_and_chains_receipt(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    monkeypatch.setattr(srv, "STUDIO_COMPUTE_ENTITLEMENTS", "team-x:spark")
+    async def fake_req(client, method, url, json=None):
+        if "/api/graph/node" in url or "/api/graph/edge" in url: return ({"ok": True}, None)
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    async def fake_spark(sql, data, correlation):
+        assert "select" in sql.lower() and len(data) == 3
+        return {"rows": [{"n": 3}], "receipt": {"correlation_id": "spark-abc", "engine": "apache-spark"}}
+    monkeypatch.setattr(srv, "_spark_submit", fake_spark)
+
+    r = client.post("/api/studio/execute",
+                    json={"project": "team-x", "kind": "query", "backend": "spark",
+                          "code": "select count(*) n from t", "data": [{"x": 1}, {"x": 2}, {"x": 3}]},
+                    headers={"Authorization": "Bearer T"}).json()
+    assert r["status"] == "completed" and r["rows"] == [{"n": 3}]        # it actually ran on Spark
+    assert r["spark_receipt"]["engine"] == "apache-spark"
+    assert r["receipt"]["chained"] == "spark-abc"                        # receipt chained studio→spark-runner
+
+
+def test_execute_spark_degrades_to_ledger_when_runner_absent(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    monkeypatch.setattr(srv, "STUDIO_COMPUTE_ENTITLEMENTS", "*")
+    async def fake_req(client, method, url, json=None):
+        if "/api/graph/node" in url: return ({"ok": True}, None)
+        return (None, "x")
+    monkeypatch.setattr(srv, "_req", fake_req)
+    async def no_spark(sql, data, correlation): return None            # runner unreachable / no token
+    monkeypatch.setattr(srv, "_spark_submit", no_spark)
+
+    r = client.post("/api/studio/execute",
+                    json={"project": "team-x", "kind": "query", "backend": "spark", "code": "select 1"},
+                    headers={"Authorization": "Bearer T"}).json()
+    assert r["status"] == "dispatched" and r["rows"] is None            # honest degrade to the governed ledger

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -38,6 +38,7 @@ spec:
           - { name: liberty-stack-readout }
           - { name: tritfabric-consumption-api }
           - { name: agora }
+          - { name: spark-runner }
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —
           # NOT touched by the build-image/gitops-promote SHA pipeline above, since

--- a/deploy/values/spark-runner.yaml
+++ b/deploy/values/spark-runner.yaml
@@ -1,0 +1,17 @@
+# spark-runner — the sovereign Apache Spark execution backend for the Studio execution plane (apps/spark-runner).
+# Pinned to the immutable sha- tag from the apps/spark-runner build (never a moving :latest).
+image: { repository: spark-runner, tag: sha-7eb70ba19a6966bd46a133444f6b6e761bb8a5d6 }
+service: { port: 8080, portName: http }
+# server serves /healthz (chart default).
+config:
+  SPARK_MASTER: "local[*]"          # single-pod Spark; set to spark://…/k8s:// for a mesh cluster (horizontal scale)
+# Spark needs a JVM heap — give the pod real memory.
+resources:
+  requests: { cpu: "250m", memory: "768Mi" }
+  limits: { cpu: "2", memory: "2Gi" }
+autoscaling: { enabled: false }     # a Spark local session is per-pod; scale via SPARK_MASTER → a cluster, not replicas
+# Deploys with /v1/submit FAIL-CLOSED: SPARK_RUNNER_TOKEN is unset, so submit returns 503 (only /healthz works)
+# until the Secret exists. To enable job submission, create the Secret and add the secretEnv block:
+#   kubectl -n socioprophet create secret generic spark-runner-token --from-literal=token=...
+#   secretEnv: { SPARK_RUNNER_TOKEN: { secretName: spark-runner-token, key: token } }
+# lattice-studio then dispatches here when the same token is set on it (SPARK_RUNNER_URL + SPARK_RUNNER_TOKEN).


### PR DESCRIPTION
Makes the Spark engine real end-to-end — deploy + the `backend='spark'` dispatch.

- **Deploy:** `deploy/values/spark-runner.yaml` pinned to `sha-7eb70ba1…` (the apps/spark-runner build), `SPARK_MASTER=local[*]`, real memory (768Mi/2Gi), + `{ name: spark-runner }` in the `platform-services` ApplicationSet. Deploys **fail-closed**: `/v1/submit` returns 503 (only `/healthz` works) until the `spark-runner-token` Secret exists.
- **Wiring:** `POST /api/studio/execute` with `backend='spark'` + a compute entitlement now **dispatches the job to spark-runner** (`_spark_submit` → `/v1/submit`), chains its receipt (`studio→spark-runner`), and returns the **real rows**. If spark-runner is unset/unreachable it **degrades honestly** to the governed run-ledger (`status=dispatched`).

So the Governance/Ops cockpit's **"Submit compute · spark"** runs an actual Spark job end-to-end once the token is set on both sides.

> To go fully live: `kubectl -n socioprophet create secret generic spark-runner-token …`, add the `secretEnv` to spark-runner's values, and set `SPARK_RUNNER_URL`/`SPARK_RUNNER_TOKEN` on lattice-studio. For horizontal scale, point `SPARK_MASTER` at a mesh Spark cluster.

preflight green (sha-pinned, no moving tag). +2 tests (spark dispatch chains the receipt + returns rows; unreachable degrades to the ledger). **81 pass.**