### PR TITLE
deploy: bump lattice-studio to current main (WS#35–52 LIVE) + wire spark URL

### DIFF
--- a/deploy/values/lattice-studio.yaml
+++ b/deploy/values/lattice-studio.yaml
@@ -1,13 +1,22 @@
 # lattice-studio — the Studio BFF (apps/lattice-studio server.py). Makes the app-vue Studio surface live: wraps
 # product_spine + aggregates live data from hellgraph-service / tritfabric / search-orchestrator, project-scoped
-# to Noetica proj- collections. Pinned to the sha- tag the #753 build published.
-image: { repository: lattice-studio, tag: sha-a16830db1710748792dbe9c79dab5dddeb3d21ff }
+# to Noetica proj- collections.
+# Bumped from the stale #753 pin (sha-a16830db) to origin/main HEAD (the HDT #836 merge) — brings the WHOLE
+# governance stack LIVE: pipelines/catalog/lineage/registry/connections (WS#33/41/45-47), community detection
+# (#48), the pay-gated execution plane (#31), ontology-typed + SHACL-validated actions (#49/#830/#831), GAIA
+# stewardship + world-signals (#50/#51), the HDT twin (#52). NB there is NO gitops-promote workflow, so this pin
+# was never auto-bumped after those merges — hence a stale deploy. A promote job is the real fix (flagged).
+image: { repository: lattice-studio, tag: sha-c1af42503a6a3d6d253280a9b8d42c4d8e52e4fe }
 service: { port: 8080, portName: http }
 # server serves /healthz (chart default) — no probes.path override.
 config:
   HELLGRAPH_URL: "http://hellgraph-service:8090"
   TRITFABRIC_URL: "http://tritfabric:8750"
   SEARCH_ORCH_URL: "http://search-orchestrator:8080"
+  # The sovereign Spark backend. lattice-studio dispatches backend='spark' jobs here; until the shared token is
+  # set (secretEnv follow-up, after the spark-runner-token secret exists) it 401s and degrades to the governed
+  # run-ledger — safe. Full end-to-end loop = add SPARK_RUNNER_TOKEN secretEnv here + on spark-runner.
+  SPARK_RUNNER_URL: "http://spark-runner:8080"
 # Activates the WRITE workbench (/api/studio/extract + /node + /edge). Fail-closed: without this, writes
 # return 503 and reads stay open. Secret provisioned out-of-band: `kubectl -n socioprophet create secret
 # generic studio-write-token --from-literal=token=...`.


### PR DESCRIPTION
**Make it real.** The deployed lattice-studio was pinned to `sha-a16830db` (from #753) — **stale by dozens of merges**, so *none* of the governance stack was actually running in the cluster: pipelines, catalog+lineage, model registry, connections, community detection, the pay-gated execution plane, **ontology-typed + SHACL-validated actions**, **GAIA** stewardship + world-signals, and the **HDT** twin.

- **Bumps `image.tag` → `sha-c1af4250…`** (origin/main HEAD = the HDT #836 merge, green build) — brings the whole thing **LIVE**.
- **Adds `SPARK_RUNNER_URL`** so `backend='spark'` executions dispatch to the deployed spark-runner (degrades safely to the governed run-ledger until the shared token is set).

**Root cause flagged:** there's **no gitops-promote workflow**, so the pin was never auto-bumped after merges — that's why it went stale. A promote job (bump values on each release build) is the real fix; without it, every service pin drifts.

Safe to merge (sha-pinned, no secretEnv → no missing-secret crash; preflight green). Follow-up to close the spark loop end-to-end: create the `spark-runner-token` secret, then add `SPARK_RUNNER_TOKEN` secretEnv to both lattice-studio and spark-runner.