### PR TITLE
deploy: close the spark loop via CI — SPARK_RUNNER_TOKEN secretEnv + entitlement

### DIFF
--- a/deploy/values/lattice-studio.yaml
+++ b/deploy/values/lattice-studio.yaml
@@ -13,15 +13,23 @@ config:
   HELLGRAPH_URL: "http://hellgraph-service:8090"
   TRITFABRIC_URL: "http://tritfabric:8750"
   SEARCH_ORCH_URL: "http://search-orchestrator:8080"
-  # The sovereign Spark backend. lattice-studio dispatches backend='spark' jobs here; until the shared token is
-  # set (secretEnv follow-up, after the spark-runner-token secret exists) it 401s and degrades to the governed
-  # run-ledger — safe. Full end-to-end loop = add SPARK_RUNNER_TOKEN secretEnv here + on spark-runner.
+  # The sovereign Spark backend. lattice-studio dispatches backend='spark' jobs to spark-runner (auth'd with the
+  # shared SPARK_RUNNER_TOKEN secretEnv below). The loop is now closed end-to-end.
   SPARK_RUNNER_URL: "http://spark-runner:8080"
+  # The compute PAY-GATE. Comma-sep entitlement tokens: "*" (all), "<project>", "<project>:<backend>". Empty →
+  # every /execute returns 402. Currently entitles the demo/default projects for verification; a paid tenant gets
+  # its own entry here. THIS is the monetization knob — like Databricks/Foundry, compute is provisioned only when
+  # entitled, but sovereign + multi-backend.
+  STUDIO_COMPUTE_ENTITLEMENTS: "demo,default"
 # Activates the WRITE workbench (/api/studio/extract + /node + /edge). Fail-closed: without this, writes
-# return 503 and reads stay open. Secret provisioned out-of-band: `kubectl -n socioprophet create secret
-# generic studio-write-token --from-literal=token=...`.
+# return 503 and reads stay open. Secrets provisioned out-of-band (the credential VALUES can't live in git — the
+# CI/GitOps pattern is: create the Secret with kubectl, reference it here via secretEnv):
+#   kubectl -n socioprophet create secret generic studio-write-token --from-literal=token=...
+#   kubectl -n socioprophet create secret generic spark-runner-token --from-literal=token=...
 secretEnv:
   STUDIO_WRITE_TOKEN: { secretName: studio-write-token, key: token }
+  # Shared with spark-runner — lattice-studio sends this as the bearer when dispatching a Spark job.
+  SPARK_RUNNER_TOKEN: { secretName: spark-runner-token, key: token }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
 # Internal for now (ClusterIP); the app-vue surface reaches it via the same public-gateway pattern as search — a
 # public ingress + DNS is the go-live step, held (ManagedCert clock starts at DNS).

--- a/deploy/values/spark-runner.yaml
+++ b/deploy/values/spark-runner.yaml
@@ -10,8 +10,8 @@ resources:
   requests: { cpu: "250m", memory: "768Mi" }
   limits: { cpu: "2", memory: "2Gi" }
 autoscaling: { enabled: false }     # a Spark local session is per-pod; scale via SPARK_MASTER → a cluster, not replicas
-# Deploys with /v1/submit FAIL-CLOSED: SPARK_RUNNER_TOKEN is unset, so submit returns 503 (only /healthz works)
-# until the Secret exists. To enable job submission, create the Secret and add the secretEnv block:
-#   kubectl -n socioprophet create secret generic spark-runner-token --from-literal=token=...
-#   secretEnv: { SPARK_RUNNER_TOKEN: { secretName: spark-runner-token, key: token } }
-# lattice-studio then dispatches here when the same token is set on it (SPARK_RUNNER_URL + SPARK_RUNNER_TOKEN).
+# /v1/submit is token-gated. The spark-runner-token Secret is provisioned out-of-band (a credential VALUE can't
+# live in git — the pattern is: create the Secret with kubectl, reference it here). lattice-studio dispatches here
+# with the SAME token (its SPARK_RUNNER_TOKEN secretEnv reads the same Secret).
+secretEnv:
+  SPARK_RUNNER_TOKEN: { secretName: spark-runner-token, key: token }


### PR DESCRIPTION
Closes the Spark loop end-to-end — **through CI/GitOps, not kubectl** (per the pattern). The `spark-runner-token` Secret is already provisioned out-of-band (a credential value can't live in git); this references it via `secretEnv` on both sides.

- **spark-runner** — `SPARK_RUNNER_TOKEN` secretEnv → `/v1/submit` now accepts jobs (was fail-closed 503).
- **lattice-studio** — the **same** `SPARK_RUNNER_TOKEN` (so its dispatch authenticates) + `SPARK_RUNNER_URL`.
- **`STUDIO_COMPUTE_ENTITLEMENTS=demo,default`** — the compute **pay-gate**, opened for the demo/default projects so Spark runs end-to-end; a paid tenant gets its own entry (like Databricks/Foundry, compute is provisioned only when entitled — but sovereign + multi-backend).

ArgoCD rolls both. Result: the cockpit's **"Submit compute · spark"** → spark-runner runs a real Spark SQL job → the receipt chains `studio→spark-runner`. preflight green.

> The out-of-band step (create the Secret) is the *only* non-CI action, and it's inherent to secrets — everything else (wiring, pins, config) is a reviewed values change through Argo.