### PR TITLE
Governed interactive JupyterLab edge (in-browser Lab)

### DIFF
--- a/apps/lattice-forge/src/lattice_forge/server.py
+++ b/apps/lattice-forge/src/lattice_forge/server.py
@@ -25,6 +25,11 @@ app = FastAPI(title="lattice-forge", version="0.1.0")
 
 FORGE_TOKEN = os.environ.get("FORGE_TOKEN", "")
 JUPYTERLAB_URL = os.environ.get("JUPYTERLAB_URL", "").rstrip("/")
+# Browser-facing Lab URL (governed GCE ingress, e.g. https://lab.socioprophet.ai). The forge lives in the
+# same namespace as the Lab, so it holds the Lab token and hands an authed user a ready-to-open URL — the
+# token only ever reaches a user who already passed the BFF's auth to reach this broker.
+JUPYTERLAB_PUBLIC_URL = os.environ.get("JUPYTERLAB_PUBLIC_URL", "").rstrip("/")
+JUPYTER_TOKEN = os.environ.get("JUPYTER_TOKEN", "")
 DEFAULT_TIMEOUT = int(os.environ.get("FORGE_EXEC_TIMEOUT", "60"))
 
 # in-memory session store (v1). project -> {id -> session}. Persistence = follow-up.
@@ -75,7 +80,14 @@ def create_session(req: SessionReq, _: None = Depends(require_token)) -> dict:
         raise HTTPException(status_code=422, detail=f"unknown adapter: {req.adapter}")
     sid = receipts.new_id()
     # a jupyterlab/zeppelin adapter is a brokered surface: point at the runtime URL.
-    url = f"{JUPYTERLAB_URL}/lab/tree/{req.project}" if (meta["mode"] == "session" and JUPYTERLAB_URL) else None
+    # brokered surfaces (jupyterlab/zeppelin) → a browser-openable URL. Prefer the public ingress; append the
+    # Lab token so an authed user lands straight in. Fall back to the in-cluster URL (BFF-proxy path) if no edge.
+    if meta["mode"] == "session" and JUPYTERLAB_PUBLIC_URL:
+        url = f"{JUPYTERLAB_PUBLIC_URL}/lab" + (f"?token={JUPYTER_TOKEN}" if JUPYTER_TOKEN else "")
+    elif meta["mode"] == "session" and JUPYTERLAB_URL:
+        url = f"{JUPYTERLAB_URL}/lab/tree/{req.project}"
+    else:
+        url = None
     session = {
         "id": sid, "project": req.project, "adapter": name, "role": meta["role"],
         "mode": meta["mode"], "kernel": meta["kernels"][0], "name": req.name or f"{name} session",

--- a/deploy/values/lattice-forge.yaml
+++ b/deploy/values/lattice-forge.yaml
@@ -39,8 +39,10 @@ secretEnv:
 resources:
   requests: { cpu: "150m", memory: "384Mi" }
   limits:   { cpu: "1500m", memory: "1536Mi" }
+# /tmp emptyDir (readOnlyRootFilesystem is true) — the only writable dir the
+# kernels need; HOME/JUPYTER_RUNTIME_DIR/IPYTHONDIR all live under it. (Do NOT
+# also list /tmp in writableDirs — the chart would mount it twice → invalid pod.)
 tmpDir: { enabled: true, sizeLimit: "512Mi" }
-writableDirs: ["/tmp"]
 
 probes:
   readiness: { path: /healthz, port: 8870 }

--- a/deploy/values/lattice-forge.yaml
+++ b/deploy/values/lattice-forge.yaml
@@ -18,6 +18,8 @@ config:
   # JupyterLab broker target (the jupyterlab adapter) — the real Lab deployed in
   # this namespace (infra/k8s/sovereign-runtime/jupyterlab.yaml). The BFF proxies it.
   JUPYTERLAB_URL: "http://jupyterlab.sovereign-runtime.svc.cluster.local:8888"
+  # Browser-facing Lab edge (governed GCE ingress). Live once lab.socioprophet.ai DNS + cert resolve.
+  JUPYTERLAB_PUBLIC_URL: "https://lab.socioprophet.ai"
   FORGE_EXEC_TIMEOUT: "60"
   # readOnlyRootFilesystem is true (chart default) → keep kernel scratch on the tmpfs
   JUPYTER_RUNTIME_DIR: "/tmp/jupyter"
@@ -29,6 +31,9 @@ config:
 # Absent → the service is fail-closed (503 on protected routes).
 secretEnv:
   FORGE_TOKEN: { secretName: lattice-forge-token, key: token }
+  # the Lab's token (same secret the JupyterLab pod uses) — the forge hands it to an
+  # already-authed user so "Open JupyterLab" lands them straight in.
+  JUPYTER_TOKEN: { secretName: jupyterlab-token, key: token }
 
 # executes user code → give it real but bounded headroom; tmpfs for kernels.
 resources:

--- a/infra/k8s/sovereign-runtime/jupyterlab-ingress.yaml
+++ b/infra/k8s/sovereign-runtime/jupyterlab-ingress.yaml
@@ -1,0 +1,35 @@
+# Governed public edge for interactive JupyterLab — the full Lab in the browser.
+# Mirrors studio-ingress: GCE ingress class + a GKE ManagedCertificate (GCE L7
+# supports the WebSockets Jupyter kernels need). The Lab stays inside the
+# locked-down sovereign-runtime namespace; only this edge + the GKE LB reach it.
+# Access still requires the Lab token, which the forge hands to an already-authed
+# user (it never leaves the cluster except to a user who passed the BFF's auth).
+#
+# GO-LIVE: create the lab.socioprophet.ai DNS A-record → the ingress IP (the
+# ManagedCertificate clock starts at DNS), exactly like studio.socioprophet.ai.
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: jupyterlab-cert
+  namespace: sovereign-runtime
+spec:
+  domains: [lab.socioprophet.ai]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jupyterlab-public
+  namespace: sovereign-runtime
+  annotations:
+    kubernetes.io/ingress.class: gce
+    networking.gke.io/managed-certificates: jupyterlab-cert
+  labels: { app: jupyterlab, app.kubernetes.io/part-of: socioprophet }
+spec:
+  rules:
+    - host: lab.socioprophet.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service: { name: jupyterlab, port: { number: 8888 } }

--- a/infra/k8s/sovereign-runtime/kustomization.yaml
+++ b/infra/k8s/sovereign-runtime/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - networkpolicy.yaml
   - resourcequota.yaml
   - jupyterlab.yaml
+  - jupyterlab-ingress.yaml

--- a/infra/k8s/sovereign-runtime/networkpolicy.yaml
+++ b/infra/k8s/sovereign-runtime/networkpolicy.yaml
@@ -84,3 +84,22 @@ spec:
       ports:
         - { protocol: TCP, port: 8870 }
         - { protocol: TCP, port: 8888 }
+---
+# GKE L7 load balancer (the JupyterLab GCE ingress): health checks + proxied
+# client traffic arrive from Google's LB ranges. Scoped to the Lab pod + 8888.
+# This is the ONLY internet-adjacent ingress into the namespace, and it still
+# lands on a token-protected Lab.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-gke-lb-to-jupyterlab
+  namespace: sovereign-runtime
+spec:
+  podSelector: { matchLabels: { app: jupyterlab } }
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - ipBlock: { cidr: 130.211.0.0/22 }
+        - ipBlock: { cidr: 35.191.0.0/16 }
+      ports:
+        - { protocol: TCP, port: 8888 }


### PR DESCRIPTION
Opens the full JupyterLab in-browser, the governed way — the last big notebook gap.

- **GCE ingress + GKE ManagedCertificate** (`lab.socioprophet.ai`), mirroring `studio-ingress`. GCE L7 carries the WebSockets kernels need. The Lab stays inside the locked-down `sovereign-runtime` namespace.
- **NetworkPolicy** `allow-gke-lb-to-jupyterlab` — only the GKE LB ranges (130.211.0.0/22, 35.191.0.0/16) reach the Lab pod:8888. The single internet-adjacent ingress, still landing on a token-protected Lab.
- **forge** hands an already-authed user a ready-to-open URL *with* the Lab token (it shares the Lab's namespace + `jupyterlab-token`), so the token only reaches a user who passed the BFF's auth.

**Go-live:** point `lab.socioprophet.ai` DNS at the ingress IP (ManagedCert clock starts at DNS) — the same gated step as `studio.socioprophet.ai`.
**Next hardening:** per-user isolation via JupyterHub (this is one governed shared Lab).

9 forge tests green; kustomize builds.