### PR TITLE
Move Spark runtime into sovereign-runtime isolation

### DIFF
--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -38,7 +38,7 @@ spec:
           - { name: liberty-stack-readout }
           - { name: tritfabric-consumption-api }
           - { name: agora }
-          - { name: spark-runner }
+          # spark-runner MOVED to runtime-services → sovereign-runtime (executes user Spark jobs).
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —
           # NOT touched by the build-image/gitops-promote SHA pipeline above, since

--- a/deploy/argocd/runtime-services.yaml
+++ b/deploy/argocd/runtime-services.yaml
@@ -15,6 +15,7 @@ spec:
     - list:
         elements:
           - { name: lattice-forge }
+          - { name: spark-runner }
   template:
     metadata:
       name: 'svc-{{.name}}'

--- a/deploy/values/lattice-studio.yaml
+++ b/deploy/values/lattice-studio.yaml
@@ -15,7 +15,7 @@ config:
   SEARCH_ORCH_URL: "http://search-orchestrator:8080"
   # The sovereign Spark backend. lattice-studio dispatches backend='spark' jobs to spark-runner (auth'd with the
   # shared SPARK_RUNNER_TOKEN secretEnv below). The loop is now closed end-to-end.
-  SPARK_RUNNER_URL: "http://spark-runner:8080"
+  SPARK_RUNNER_URL: "http://spark-runner.sovereign-runtime.svc.cluster.local:8080"
   # The compute PAY-GATE. Comma-sep entitlement tokens: "*" (all), "<project>", "<project>:<backend>". Empty →
   # every /execute returns 402. Currently entitles the demo/default projects for verification; a paid tenant gets
   # its own entry here. THIS is the monetization knob — like Databricks/Foundry, compute is provisioned only when

--- a/deploy/values/spark-runner.yaml
+++ b/deploy/values/spark-runner.yaml
@@ -16,8 +16,9 @@ resources:
   requests: { cpu: "250m", memory: "768Mi" }
   limits: { cpu: "2", memory: "2Gi" }
 autoscaling: { enabled: false }     # a Spark local session is per-pod; scale via SPARK_MASTER → a cluster, not replicas
-# /v1/submit is token-gated. The spark-runner-token Secret is provisioned out-of-band (a credential VALUE can't
-# live in git — the pattern is: create the Secret with kubectl, reference it here). lattice-studio dispatches here
-# with the SAME token (its SPARK_RUNNER_TOKEN secretEnv reads the same Secret).
+# /v1/submit is token-gated. The spark-runner-token Secret is provisioned THROUGH CI — the value lives in a GitHub
+# Actions secret (SPARK_RUNNER_TOKEN) and the `provision-secrets` workflow materializes it here via the estate WIF
+# (into sovereign-runtime AND socioprophet). Run that workflow, then sync this app. lattice-studio dispatches here
+# with the SAME token (its SPARK_RUNNER_TOKEN secretEnv reads the same Secret in socioprophet).
 secretEnv:
   SPARK_RUNNER_TOKEN: { secretName: spark-runner-token, key: token }

--- a/deploy/values/spark-runner.yaml
+++ b/deploy/values/spark-runner.yaml
@@ -1,10 +1,16 @@
 # spark-runner — the sovereign Apache Spark execution backend for the Studio execution plane (apps/spark-runner).
 # Pinned to the immutable sha- tag from the apps/spark-runner build (never a moving :latest).
+# ISOLATION: deployed by the runtime-services ApplicationSet into the sovereign-runtime namespace (default-deny
+# NetworkPolicy, restricted PSA, no metadata egress) — it executes user Spark jobs = same trust boundary as notebooks.
 image: { repository: spark-runner, tag: sha-d42ff8afb1e6694a8e29066432a7260b31654e5e }
 service: { port: 8080, portName: http }
 # server serves /healthz (chart default).
 config:
   SPARK_MASTER: "local[*]"          # single-pod Spark; set to spark://…/k8s:// for a mesh cluster (horizontal scale)
+  SPARK_LOCAL_DIRS: "/tmp"          # Spark scratch on the tmpfs (readOnlyRootFilesystem is on)
+# writable scratch for Spark (readOnlyRootFilesystem:true). tmpDir mounts /tmp — do NOT also list /tmp in
+# writableDirs (the chart would mount it twice → invalid pod).
+tmpDir: { enabled: true, sizeLimit: "1Gi" }
 # Spark needs a JVM heap — give the pod real memory.
 resources:
   requests: { cpu: "250m", memory: "768Mi" }

--- a/infra/k8s/sovereign-runtime/networkpolicy.yaml
+++ b/infra/k8s/sovereign-runtime/networkpolicy.yaml
@@ -82,8 +82,9 @@ spec:
         - namespaceSelector:
             matchLabels: { kubernetes.io/metadata.name: socioprophet }
       ports:
-        - { protocol: TCP, port: 8870 }
-        - { protocol: TCP, port: 8888 }
+        - { protocol: TCP, port: 8870 }   # lattice-forge
+        - { protocol: TCP, port: 8888 }   # jupyterlab (BFF proxy path)
+        - { protocol: TCP, port: 8080 }   # spark-runner
 ---
 # GKE L7 load balancer (the JupyterLab GCE ingress): health checks + proxied
 # client traffic arrive from Google's LB ranges. Scoped to the Lab pod + 8888.


### PR DESCRIPTION
Finishes the isolation story: Spark executes user jobs → same trust boundary as notebooks, so it moves out of the shared `socioprophet` namespace into the locked-down `sovereign-runtime` (default-deny networking, restricted PSA, no metadata egress).

- **platform-services → runtime-services** ApplicationSet (destination `sovereign-runtime`).
- **spark-runner values:** `SPARK_LOCAL_DIRS=/tmp` + `tmpDir` (writable scratch under readOnlyRootFS; **no** `writableDirs` overlap — avoids the /tmp double-mount bug I just fixed on the forge).
- **NetworkPolicy:** allow `socioprophet`→:8080 (the BFF dispatch path).
- **lattice-studio** `SPARK_RUNNER_URL` → `spark-runner.sovereign-runtime.svc.cluster.local:8080`.

**Go-live (secret ordering matters):** replicate `spark-runner-token` into `sovereign-runtime` with the SAME value as `socioprophet` BEFORE this syncs (else fail-closed) — one-liner in the commit body. Then the old socioprophet spark-runner prunes and the isolated one comes up.

yaml + kustomize validated.