### PR TITLE
Governed notebook scheduling for lattice-forge (proof-carrying run-due)

### DIFF
--- a/apps/lattice-forge/src/lattice_forge/schedules.py
+++ b/apps/lattice-forge/src/lattice_forge/schedules.py
@@ -1,0 +1,87 @@
+"""Governed notebook SCHEDULING — Databricks-Jobs parity, but proof-carrying.
+
+A schedule is a cell (or notebook) pinned to a recurring interval. Every run is
+executed through the SAME governed path an interactive cell takes — the run
+seals a hash-chained receipt (see receipts.seal) — so a scheduled job is exactly
+as tamper-evident and replayable as one a human triggered. The difference is who
+pulls the trigger: a Kubernetes CronJob hits POST /v1/run-due once a minute, and
+this store decides which schedules are due.
+
+Kept pure and in-memory (v1): a plain dict keyed by schedule id, no wall-clock
+reads inside the store (`now` is always injected in the hot paths) so it is fully
+testable. State is pod-local — like the kernels in execn — so the forge runs a
+single replica and `due()`/`mark_ran()` never race across pods.
+"""
+from __future__ import annotations
+
+import time
+
+from . import receipts
+
+# keep a handle to the builtin: `list` below is the public schedule-list function.
+_list = list
+
+# minimum interval — a floor on how hot a governed job may run (the CronJob ticks
+# once a minute anyway, so anything under this can never fire faster in practice).
+MIN_INTERVAL_SECONDS = 30
+
+# in-memory schedule store (v1). id -> schedule. Persistence = follow-up.
+_SCHEDULES: dict[str, dict] = {}
+
+
+def create(project: str, name: str, code: str, interval_seconds: int, *,
+           language: str = "python", adapter: str | None = None,
+           session_id: str | None = None, now: float | None = None) -> dict:
+    """Register a recurring governed job. First run is due one interval from now."""
+    now = time.time() if now is None else now
+    sid = receipts.new_id()
+    schedule = {
+        "id": sid, "project": project, "name": name, "code": code,
+        "language": language, "adapter": adapter,
+        # default to a per-schedule kernel so scheduled runs don't collide with a
+        # user's interactive `<project>:default` session (they can opt into sharing).
+        "session_id": session_id or f"{project}:sched:{sid}",
+        "interval_seconds": interval_seconds,
+        "next_run": now + interval_seconds, "last_run": None, "last_status": None,
+        "created_at": now, "enabled": True,
+    }
+    _SCHEDULES[sid] = schedule
+    return schedule
+
+
+def list(project: str) -> _list[dict]:
+    return [s for s in _SCHEDULES.values() if s["project"] == project]
+
+
+def get(sid: str) -> dict | None:
+    return _SCHEDULES.get(sid)
+
+
+def delete(sid: str) -> bool:
+    return _SCHEDULES.pop(sid, None) is not None
+
+
+def due(now: float | None = None) -> _list[dict]:
+    """Enabled schedules whose next_run has arrived — what the CronJob fires."""
+    now = time.time() if now is None else now
+    return [s for s in _SCHEDULES.values() if s["enabled"] and s["next_run"] <= now]
+
+
+def mark_ran(sid: str, status: str, now: float | None = None) -> dict | None:
+    """Record a run and advance next_run by one interval.
+
+    Advance from the scheduled `next_run`, not from `now`, so a late tick (the
+    CronJob is best-effort) doesn't let cadence drift; if we've fallen more than a
+    full interval behind, snap forward past `now` to avoid a thundering catch-up.
+    """
+    now = time.time() if now is None else now
+    s = _SCHEDULES.get(sid)
+    if s is None:
+        return None
+    s["last_run"] = now
+    s["last_status"] = status
+    nxt = s["next_run"] + s["interval_seconds"]
+    while nxt <= now:
+        nxt += s["interval_seconds"]
+    s["next_run"] = nxt
+    return s

--- a/apps/lattice-forge/src/lattice_forge/server.py
+++ b/apps/lattice-forge/src/lattice_forge/server.py
@@ -19,7 +19,7 @@ import os
 from fastapi import Depends, FastAPI, Header, HTTPException
 from pydantic import BaseModel, Field
 
-from . import adapters, execn, receipts
+from . import adapters, execn, receipts, schedules
 
 app = FastAPI(title="lattice-forge", version="0.1.0")
 
@@ -60,6 +60,17 @@ class ExecReq(BaseModel):
     session_id: str | None = None
     actor: str = "user"
     timeout: int = Field(default=0)
+
+
+class ScheduleReq(BaseModel):
+    project: str
+    name: str
+    code: str
+    language: str = "python"
+    adapter: str | None = None
+    session_id: str | None = None
+    interval_seconds: int
+    actor: str = "user"
 
 
 @app.get("/healthz")
@@ -109,6 +120,28 @@ def delete_session(sid: str, project: str, _: None = Depends(require_token)) -> 
     return {"ok": True}
 
 
+def _run_and_seal(project: str, code: str, language: str, adapter_name: str,
+                  runtime: str, session_id: str, timeout: int, actor: str) -> tuple[dict, str | None, dict]:
+    """Run a cell through the governed path and seal its receipt.
+
+    The single choke-point shared by interactive `/v1/execute` and the scheduled
+    `/v1/run-due` tick: identical execution, identical degradation, identical seal —
+    a scheduled job is exactly as proof-carrying as a human-triggered one.
+    """
+    try:
+        result = execn.run_cell(code, language, timeout or DEFAULT_TIMEOUT, session_id)
+        degraded = None
+    except execn.ForgeUnavailable as e:
+        # honest degradation — never fake a result. Still seals a receipt of the attempt.
+        result = {"status": "degraded", "outputs": [], "error": str(e)}
+        degraded = str(e)
+    receipt = receipts.seal(
+        project, adapter=adapter_name, language=language, runtime=runtime,
+        code=code, outputs=result["outputs"], status=result["status"], actor=actor,
+    )
+    return result, degraded, receipt
+
+
 @app.post("/v1/execute")
 def execute(req: ExecReq, _: None = Depends(require_token)) -> dict:
     try:
@@ -118,17 +151,8 @@ def execute(req: ExecReq, _: None = Depends(require_token)) -> dict:
     runtime = meta["kernels"][0]
     # persistent per-session kernel → cells share state (a real notebook, not one-shot cells)
     session_id = req.session_id or f"{req.project}:default"
-    try:
-        result = execn.run_cell(req.code, req.language, req.timeout or DEFAULT_TIMEOUT, session_id)
-        degraded = None
-    except execn.ForgeUnavailable as e:
-        # honest degradation — never fake a result. Still seals a receipt of the attempt.
-        result = {"status": "degraded", "outputs": [], "error": str(e)}
-        degraded = str(e)
-
-    receipt = receipts.seal(
-        req.project, adapter=name, language=req.language, runtime=runtime,
-        code=req.code, outputs=result["outputs"], status=result["status"], actor=req.actor,
+    result, degraded, receipt = _run_and_seal(
+        req.project, req.code, req.language, name, runtime, session_id, req.timeout, req.actor,
     )
     return {
         "status": result["status"], "outputs": result["outputs"],
@@ -141,3 +165,57 @@ def execute(req: ExecReq, _: None = Depends(require_token)) -> dict:
 def get_receipts(project: str, _: None = Depends(require_token)) -> dict:
     ch = receipts.chain(project)
     return {"project": project, "count": len(ch), "receipts": ch}
+
+
+@app.post("/v1/schedule")
+def create_schedule(req: ScheduleReq, _: None = Depends(require_token)) -> dict:
+    """Register a recurring governed job. The CronJob fires it via /v1/run-due."""
+    if req.adapter is not None and req.adapter not in adapters.ADAPTERS:
+        raise HTTPException(status_code=422, detail=f"unknown adapter: {req.adapter}")
+    if req.interval_seconds < schedules.MIN_INTERVAL_SECONDS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"interval_seconds must be >= {schedules.MIN_INTERVAL_SECONDS}",
+        )
+    return schedules.create(
+        req.project, req.name, req.code, req.interval_seconds,
+        language=req.language, adapter=req.adapter, session_id=req.session_id,
+    )
+
+
+@app.get("/v1/schedules")
+def list_schedules(project: str, _: None = Depends(require_token)) -> dict:
+    sch = schedules.list(project)
+    return {"project": project, "count": len(sch), "schedules": sch}
+
+
+@app.delete("/v1/schedule/{sid}")
+def delete_schedule(sid: str, project: str, _: None = Depends(require_token)) -> dict:
+    return {"ok": schedules.delete(sid)}
+
+
+@app.post("/v1/run-due")
+def run_due(_: None = Depends(require_token)) -> dict:
+    """Run every due schedule NOW — the endpoint the Kubernetes CronJob ticks.
+
+    Each due schedule takes the same governed path as an interactive cell: run →
+    seal a receipt (degraded if the kernel is down, never faked) → advance next_run.
+    """
+    ran: list[dict] = []
+    for s in schedules.due():
+        try:
+            name, meta = adapters.resolve(s["adapter"])
+        except KeyError:
+            # adapter went away since the schedule was created — record, don't crash.
+            schedules.mark_ran(s["id"], "error")
+            ran.append({"id": s["id"], "status": "error", "receipt": None})
+            continue
+        runtime = meta["kernels"][0]
+        result, degraded, receipt = _run_and_seal(
+            s["project"], s["code"], s["language"], name, runtime,
+            s["session_id"], DEFAULT_TIMEOUT, "scheduler",
+        )
+        schedules.mark_ran(s["id"], result["status"])
+        ran.append({"id": s["id"], "status": result["status"],
+                    "degraded": degraded, "receipt": receipt["id"]})
+    return {"ran": [r["id"] for r in ran], "count": len(ran), "runs": ran}

--- a/apps/lattice-forge/tests/test_schedules.py
+++ b/apps/lattice-forge/tests/test_schedules.py
@@ -1,0 +1,140 @@
+"""lattice-forge scheduling tests — governed recurring jobs, no live kernel needed.
+
+Covers the pure store (schedules.py) and the token-gated HTTP surface, including
+the /v1/run-due tick a Kubernetes CronJob fires: it must execute only due jobs,
+seal a receipt per run, and advance next_run. Executor is injected (no kernel).
+"""
+import importlib
+import os
+
+os.environ["FORGE_TOKEN"] = "test-token"  # set before server import (fail-closed gate)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from lattice_forge import execn, schedules, server  # noqa: E402
+
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer test-token"}
+
+
+def setup_function():
+    # deterministic fake executor (same shape as test_forge) + clean schedule store
+    # so runs are isolated across tests (the store is pod-local, module-level state).
+    def fake(code, lang, to, session_id):
+        return {"status": "ok",
+                "outputs": [{"type": "stream", "name": "stdout", "text": f"ran:{code}|sid={session_id}"}],
+                "error": None}
+    execn.set_executor(fake)
+    schedules._SCHEDULES.clear()
+
+
+# ── pure store ───────────────────────────────────────────────────────────────
+
+def test_create_sets_next_run_and_defaults():
+    s = schedules.create("p", "nightly", "print(1)", 60, now=1000.0)
+    assert s["enabled"] is True
+    assert s["next_run"] == 1060.0 and s["last_run"] is None and s["last_status"] is None
+    assert s["session_id"].startswith("p:sched:")   # isolated from interactive session
+
+
+def test_due_returns_only_past_due_and_enabled():
+    past = schedules.create("p", "a", "x", 30, now=100.0)      # next_run = 130
+    future = schedules.create("p", "b", "y", 300, now=100.0)   # next_run = 400
+    off = schedules.create("p", "c", "z", 30, now=100.0)       # next_run = 130
+    schedules.get(off["id"])["enabled"] = False
+    due_ids = {s["id"] for s in schedules.due(now=200.0)}
+    assert due_ids == {past["id"]}                              # future not yet, off disabled
+    assert future["id"] not in due_ids
+
+
+def test_mark_ran_advances_and_records():
+    s = schedules.create("p", "a", "x", 60, now=100.0)         # next_run = 160
+    schedules.mark_ran(s["id"], "ok", now=165.0)
+    got = schedules.get(s["id"])
+    assert got["last_run"] == 165.0 and got["last_status"] == "ok"
+    assert got["next_run"] == 220.0                            # 160 + 60, still ahead of 165
+
+
+def test_mark_ran_snaps_past_now_when_badly_behind():
+    s = schedules.create("p", "a", "x", 60, now=100.0)         # next_run = 160
+    schedules.mark_ran(s["id"], "ok", now=500.0)               # very late tick
+    assert schedules.get(s["id"])["next_run"] > 500.0          # no thundering catch-up
+
+
+def test_delete_removes():
+    s = schedules.create("p", "a", "x", 30, now=0.0)
+    assert schedules.delete(s["id"]) is True
+    assert schedules.get(s["id"]) is None
+    assert schedules.delete(s["id"]) is False                  # idempotent
+
+
+# ── HTTP surface ─────────────────────────────────────────────────────────────
+
+def test_schedule_endpoints_token_gated():
+    assert client.post("/v1/schedule", json={}).status_code == 401
+    assert client.get("/v1/schedules", params={"project": "p"}).status_code == 401
+    assert client.post("/v1/run-due").status_code == 401
+
+
+def test_create_validates_interval():
+    r = client.post("/v1/schedule", json={
+        "project": "p", "name": "too-hot", "code": "x", "interval_seconds": 5,
+    }, headers=AUTH)
+    assert r.status_code == 422                                 # below MIN_INTERVAL_SECONDS
+
+
+def test_create_rejects_unknown_adapter():
+    r = client.post("/v1/schedule", json={
+        "project": "p", "name": "n", "code": "x", "interval_seconds": 60, "adapter": "excel",
+    }, headers=AUTH)
+    assert r.status_code == 422
+
+
+def test_create_list_delete_roundtrip():
+    c = client.post("/v1/schedule", json={
+        "project": "p1", "name": "nightly", "code": "print(1)", "interval_seconds": 60,
+    }, headers=AUTH).json()
+    assert c["name"] == "nightly" and c["interval_seconds"] == 60
+    lst = client.get("/v1/schedules", params={"project": "p1"}, headers=AUTH).json()
+    assert lst["count"] == 1 and lst["schedules"][0]["id"] == c["id"]
+    # a different project is isolated
+    assert client.get("/v1/schedules", params={"project": "other"}, headers=AUTH).json()["count"] == 0
+    client.delete(f"/v1/schedule/{c['id']}", params={"project": "p1"}, headers=AUTH)
+    assert client.get("/v1/schedules", params={"project": "p1"}, headers=AUTH).json()["count"] == 0
+
+
+def test_run_due_executes_seals_and_advances():
+    # create a schedule already past-due by backdating next_run, then tick /v1/run-due.
+    c = client.post("/v1/schedule", json={
+        "project": "sched", "name": "job", "code": "1+1", "interval_seconds": 60,
+    }, headers=AUTH).json()
+    schedules.get(c["id"])["next_run"] = 0.0                   # force due now
+
+    out = client.post("/v1/run-due", headers=AUTH).json()
+    assert out["count"] == 1 and out["ran"] == [c["id"]]
+    assert out["runs"][0]["status"] == "ok" and out["runs"][0]["receipt"].startswith("sha256:")
+
+    # a receipt was sealed on the schedule's project chain (proof-carrying)
+    ch = client.get("/v1/receipts", params={"project": "sched"}, headers=AUTH).json()
+    assert ch["count"] == 1
+    # next_run advanced past 0 → no longer due on the next tick
+    assert schedules.get(c["id"])["next_run"] > 0.0
+    assert schedules.get(c["id"])["last_status"] == "ok"
+    assert client.post("/v1/run-due", headers=AUTH).json()["count"] == 0
+
+
+def test_run_due_seals_degraded_when_kernel_unavailable():
+    def boom(code, lang, to):
+        raise execn.ForgeUnavailable("no kernel")
+    execn.set_executor(boom)
+    c = client.post("/v1/schedule", json={
+        "project": "degr", "name": "job", "code": "x", "interval_seconds": 60,
+    }, headers=AUTH).json()
+    schedules.get(c["id"])["next_run"] = 0.0
+
+    out = client.post("/v1/run-due", headers=AUTH).json()
+    assert out["runs"][0]["status"] == "degraded"              # honest, not faked
+    ch = client.get("/v1/receipts", params={"project": "degr"}, headers=AUTH).json()
+    assert ch["count"] == 1 and ch["receipts"][0]["status"] == "degraded"
+    assert schedules.get(c["id"])["last_status"] == "degraded"

--- a/infra/k8s/sovereign-runtime/kustomization.yaml
+++ b/infra/k8s/sovereign-runtime/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - resourcequota.yaml
   - jupyterlab.yaml
   - jupyterlab-ingress.yaml
+  - schedule-tick.yaml

--- a/infra/k8s/sovereign-runtime/schedule-tick.yaml
+++ b/infra/k8s/sovereign-runtime/schedule-tick.yaml
@@ -1,0 +1,62 @@
+# schedule-tick — the governed scheduler for lattice-forge notebook jobs.
+#
+# Every minute this CronJob POSTs /v1/run-due on the forge; the forge runs every
+# due schedule NOW and seals a hash-chained receipt per run (see
+# apps/lattice-forge/src/lattice_forge/schedules.py). This is the ONLY trigger —
+# the forge holds the schedules, this tick just pulls them. Databricks-Jobs
+# parity, but proof-carrying: a scheduled run is as replayable as an interactive one.
+#
+# It stays inside the isolated sovereign-runtime namespace (default-deny +
+# intra-namespace allow), so `http://lattice-forge:8870` resolves without any new
+# egress. It carries the SAME lattice-forge-token secret the forge validates, so a
+# tick is authenticated exactly like a user call — no unauthenticated backdoor.
+#
+# PodSecurity: the namespace enforces `restricted`, so the pod is non-root, drops
+# all caps, forbids privilege escalation, and runs a read-only root filesystem.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: forge-schedule-tick
+  namespace: sovereign-runtime
+  labels: { app: lattice-forge, component: schedule-tick }
+spec:
+  schedule: "* * * * *"            # every minute; the forge decides what is actually due
+  concurrencyPolicy: Forbid        # never overlap ticks — one governed sweep at a time
+  startingDeadlineSeconds: 30
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0              # a missed tick is caught by the next minute; don't pile up retries
+      activeDeadlineSeconds: 50    # stay well under the 1-minute cadence
+      template:
+        metadata:
+          labels: { app: lattice-forge, component: schedule-tick }
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile: { type: RuntimeDefault }
+          containers:
+            - name: tick
+              # third-party image — pin to a digest before prod (not on our sha pipeline).
+              image: curlimages/curl:8.11.1
+              command: ["/bin/sh", "-c"]
+              args:
+                # fail loudly on a non-2xx so a broken tick shows up as a failed Job.
+                - >
+                  curl -sS --fail --max-time 40
+                  -X POST
+                  -H "Authorization: Bearer ${FORGE_TOKEN}"
+                  http://lattice-forge:8870/v1/run-due
+              env:
+                - name: FORGE_TOKEN
+                  valueFrom: { secretKeyRef: { name: lattice-forge-token, key: token } }
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities: { drop: ["ALL"] }
+              resources:
+                requests: { cpu: "10m", memory: "32Mi" }
+                limits:   { cpu: "100m", memory: "64Mi" }


### PR DESCRIPTION
## What

Adds **governed notebook scheduling** to `apps/lattice-forge` — Databricks-Jobs parity, but proof-carrying. A cell/notebook can be pinned to a recurring interval as a governed job, and **every scheduled run seals a hash-chained receipt** exactly like an interactive cell does. A Kubernetes CronJob is the only trigger; the forge holds the schedules and decides what is due.

## Changes

**`src/lattice_forge/schedules.py`** (new) — pure, in-memory per-project schedule store. `create / list / get / delete / due(now) / mark_ran(id, status, now)`. `now` is injectable in the hot paths so it is fully testable with no wall clock. `next_run` advances by `interval_seconds` from the scheduled time (not from `now`) so a late tick doesn't drift, and snaps past `now` if badly behind to avoid a catch-up storm. State is pod-local, matching the single-replica kernel model in `execn`.

**`src/lattice_forge/server.py`** — new token-gated endpoints:
- `POST /v1/schedule` — validates `interval_seconds >= 30` (422 otherwise) and the adapter, then registers the job.
- `GET /v1/schedules?project=` — list (project-isolated).
- `DELETE /v1/schedule/{id}?project=`.
- `POST /v1/run-due` — runs every due schedule NOW; this is the endpoint the CronJob ticks. Each run takes the **same governed path** as an interactive cell: `execn.run_cell(...)` → `receipts.seal(...)` → `schedules.mark_ran(...)`. `/v1/execute` and `/v1/run-due` now share one `_run_and_seal` choke point, so a `ForgeUnavailable` kernel outage seals a **degraded receipt (never faked)** identically in both.

**`infra/k8s/sovereign-runtime/schedule-tick.yaml`** (new) — every-minute CronJob that `curl`s `POST http://lattice-forge:8870/v1/run-due` with the `lattice-forge-token` secret as a bearer header (mounted as env `FORGE_TOKEN`). Stays inside the isolated `sovereign-runtime` namespace so no new egress is needed. Restricted PodSecurity: `runAsNonRoot: true`, `runAsUser: 10001`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`, `readOnlyRootFilesystem: true`; pinned `curlimages/curl:8.11.1`; `concurrencyPolicy: Forbid`. Wired into `kustomization.yaml`.

## Tests

`tests/test_schedules.py` (new, 11 tests): store semantics (`create`/`due`/`mark_ran` incl. late-tick snap/`delete`), interval + adapter validation, token gating, list/delete project isolation, and `POST /v1/run-due` executing due jobs → sealing receipts → advancing `next_run` (incl. the degraded-kernel path). Executor is injected via `execn.set_executor` — no live kernel.

**Full suite: 20 passed** (9 existing + 11 new). `kubectl kustomize infra/k8s/sovereign-runtime` builds clean; `schedule-tick.yaml` validates as YAML.

## Notes
- No secrets created/modified; the `lattice-forge-token` secret is provisioned out-of-band (same one the forge already validates).
- Scope limited to `apps/lattice-forge/**` and `infra/k8s/sovereign-runtime/{schedule-tick,kustomization}.yaml`.