### PR TITLE
Harden lattice-forge: provable receipt-chain verify, /v1/stats, digest-pinned tick

### DIFF
--- a/apps/lattice-forge/src/lattice_forge/execn.py
+++ b/apps/lattice-forge/src/lattice_forge/execn.py
@@ -107,6 +107,18 @@ def run_cell(code: str, language: str = "python", timeout: int = 60, session_id:
     return _EXECUTOR(code, language, timeout, session_id)
 
 
+def live_kernels(project: str | None = None) -> int:
+    """Count live persistent kernels — all of them, or just one project's.
+
+    Cheap and side-effect-free (for /v1/stats). Project scoping matches on the
+    session_id convention used by the server (`<project>:default`,
+    `<project>:sched:<id>`), so ops can see a single project's kernel footprint.
+    """
+    if project is None:
+        return len(_KERNELS)
+    return sum(1 for sid in _KERNELS if sid == project or sid.startswith(project + ":"))
+
+
 def kernel_available() -> bool:
     """True when a real execution kernel is importable (for /healthz)."""
     if _EXECUTOR is not _live_run:

--- a/apps/lattice-forge/src/lattice_forge/receipts.py
+++ b/apps/lattice-forge/src/lattice_forge/receipts.py
@@ -48,6 +48,32 @@ def chain(project: str) -> list[dict]:
     return list(_CHAINS.get(project, []))
 
 
+def verify(project: str) -> dict:
+    """Re-prove the chain: recompute every id from its body and re-walk every prev.
+
+    The moat made checkable. For each stored receipt we rebuild the exact body
+    `seal` hashed (everything the receipt carries EXCEPT its own `id` and
+    `project`), recompute `_sha(body)`, and confirm it equals the stored `id` —
+    catching any tampered field (code, outputs, status, actor, timestamp). We
+    also confirm each `prev` points at the previous receipt's `id` (the first is
+    None), catching reordered or excised links. Returns at the FIRST break so
+    `broken_at` names the earliest compromised receipt — something a mutable
+    audit log (Databricks) structurally cannot offer.
+    """
+    ch = _CHAINS.get(project, [])
+    prev_id: str | None = None
+    for r in ch:
+        body = {k: v for k, v in r.items() if k not in ("id", "project")}
+        if _sha(body) != r["id"]:
+            return {"valid": False, "count": len(ch), "broken_at": r["id"],
+                    "reason": "id does not match recomputed body hash (tampered receipt)"}
+        if r["prev"] != prev_id:
+            return {"valid": False, "count": len(ch), "broken_at": r["id"],
+                    "reason": "prev does not link to the previous receipt (broken chain)"}
+        prev_id = r["id"]
+    return {"valid": True, "count": len(ch), "broken_at": None, "reason": None}
+
+
 def _mirror(receipt: dict) -> None:
     """Best-effort mirror to the governance ledger; never blocks execution."""
     if not LEDGER_URL:

--- a/apps/lattice-forge/src/lattice_forge/server.py
+++ b/apps/lattice-forge/src/lattice_forge/server.py
@@ -167,6 +167,34 @@ def get_receipts(project: str, _: None = Depends(require_token)) -> dict:
     return {"project": project, "count": len(ch), "receipts": ch}
 
 
+@app.get("/v1/receipts/verify")
+def verify_receipts(project: str, _: None = Depends(require_token)) -> dict:
+    """Re-prove the project's receipt chain (tamper-evidence, programmatically).
+
+    Recomputes every receipt id from its body and re-walks every prev-link, so a
+    single mutated field or a broken link fails verification with `broken_at`
+    naming the earliest compromised receipt — the moat, made checkable.
+    """
+    return {"project": project, **receipts.verify(project)}
+
+
+@app.get("/v1/stats")
+def stats(project: str, _: None = Depends(require_token)) -> dict:
+    """Read-only forge introspection for the Operations surface.
+
+    Cheap and side-effect-free: live kernel count for the project, its sealed
+    receipt-chain length, the registered adapters, and whether a real execution
+    kernel is available. Nothing here mutates state or touches a kernel.
+    """
+    return {
+        "project": project,
+        "sessions": execn.live_kernels(project),
+        "receipts": len(receipts.chain(project)),
+        "adapters": list(adapters.ADAPTERS),
+        "kernel_ready": execn.kernel_available(),
+    }
+
+
 @app.post("/v1/schedule")
 def create_schedule(req: ScheduleReq, _: None = Depends(require_token)) -> dict:
     """Register a recurring governed job. The CronJob fires it via /v1/run-due."""

--- a/apps/lattice-forge/tests/test_forge.py
+++ b/apps/lattice-forge/tests/test_forge.py
@@ -91,3 +91,57 @@ def test_degrades_when_kernel_unavailable():
     r = client.post("/v1/execute", json={"project": "p3", "code": "x"}, headers=AUTH).json()
     assert r["status"] == "degraded" and r["degraded"] == "no kernel"
     assert r["receipt"]["status"] == "degraded"      # still sealed — honest, not faked
+
+
+def test_verify_clean_chain_is_valid():
+    for code in ["a=1", "b=2", "c=3"]:
+        client.post("/v1/execute", json={"project": "vok", "code": code}, headers=AUTH)
+    v = client.get("/v1/receipts/verify", params={"project": "vok"}, headers=AUTH).json()
+    assert v["valid"] is True and v["count"] == 3
+    assert v["broken_at"] is None and v["reason"] is None
+
+
+def test_verify_detects_tampered_receipt():
+    # mutate a stored field → recomputed id no longer matches → tamper-evident.
+    for code in ["a=1", "b=2", "c=3"]:
+        client.post("/v1/execute", json={"project": "vtamper", "code": code}, headers=AUTH)
+    from lattice_forge import receipts
+    victim = receipts._CHAINS["vtamper"][1]
+    victim["code_sha"] = "sha256:deadbeef"           # forge the sealed code hash
+    v = client.get("/v1/receipts/verify", params={"project": "vtamper"}, headers=AUTH).json()
+    assert v["valid"] is False and v["broken_at"] == victim["id"]
+    assert "recomputed" in v["reason"]
+
+
+def test_verify_detects_broken_prev_link():
+    # excise the middle receipt: the survivors' ids still match their own bodies,
+    # but the last one's prev now points at a receipt that isn't its predecessor —
+    # the walk catches the severed link (not just field tampering).
+    for code in ["a=1", "b=2", "c=3"]:
+        client.post("/v1/execute", json={"project": "vlink", "code": code}, headers=AUTH)
+    from lattice_forge import receipts
+    ch = receipts._CHAINS["vlink"]
+    orphan_id = ch[2]["id"]
+    del ch[1]                                          # remove the middle link
+    v = client.get("/v1/receipts/verify", params={"project": "vlink"}, headers=AUTH).json()
+    assert v["valid"] is False and v["broken_at"] == orphan_id
+    assert "prev" in v["reason"]
+
+
+def test_verify_empty_chain_is_valid():
+    v = client.get("/v1/receipts/verify", params={"project": "vempty"}, headers=AUTH).json()
+    assert v["valid"] is True and v["count"] == 0
+
+
+def test_stats_introspection():
+    for code in ["a=1", "b=2"]:
+        client.post("/v1/execute", json={"project": "statp", "code": code}, headers=AUTH)
+    st = client.get("/v1/stats", params={"project": "statp"}, headers=AUTH).json()
+    assert st["receipts"] == 2
+    assert st["sessions"] == 0                        # injected executor → no live kernels
+    assert "jupyterlab" in st["adapters"] and isinstance(st["kernel_ready"], bool)
+
+
+def test_stats_token_gated():
+    assert client.get("/v1/stats", params={"project": "x"}).status_code == 401
+    assert client.get("/v1/receipts/verify", params={"project": "x"}).status_code == 401

--- a/infra/k8s/sovereign-runtime/schedule-tick.yaml
+++ b/infra/k8s/sovereign-runtime/schedule-tick.yaml
@@ -40,8 +40,10 @@ spec:
             seccompProfile: { type: RuntimeDefault }
           containers:
             - name: tick
-              # third-party image — pin to a digest before prod (not on our sha pipeline).
-              image: curlimages/curl:8.11.1
+              # third-party image — digest-pinned (immutable) since it is not on our sha- pipeline.
+              # Tag kept alongside for humans; the @sha256 is what actually gets pulled, so a
+              # re-pushed tag can never silently swap the tick binary (moving-tag/IfNotPresent trap).
+              image: curlimages/curl:8.11.1@sha256:c1fe1679c34d9784c1b0d1e5f62ac0a79fca01fb6377cdd33e90473c6f9f9a69
               command: ["/bin/sh", "-c"]
               args:
                 # fail loudly on a non-2xx so a broken tick shows up as a failed Job.


### PR DESCRIPTION
Three REAL, tested backend/runtime hardening improvements to `apps/lattice-forge` (the governed notebook runtime in `sovereign-runtime`). No merge intended yet.

## 1. Provable receipt-chain integrity — the moat, made checkable
- `receipts.verify(project) -> {valid, count, broken_at, reason}`: recomputes every stored receipt's id from its body (exactly as `seal` computes `_sha(body)` — everything except `id`/`project`) and re-walks every `prev` link. Returns at the first break so `broken_at` names the earliest compromised receipt.
- `GET /v1/receipts/verify?project=` (token-gated) exposes it.
- Proves tamper-evidence *programmatically* — a mutated field or a severed link fails verification. A mutable audit log (Databricks) structurally cannot do this.

## 2. Deploy hygiene — digest-pin the CronJob image
- `infra/k8s/sovereign-runtime/schedule-tick.yaml`: `curlimages/curl:8.11.1` → `curlimages/curl:8.11.1@sha256:c1fe1679c34d9784c1b0d1e5f62ac0a79fca01fb6377cdd33e90473c6f9f9a69`.
- docker/crane were unavailable, so the digest was fetched from the Docker registry `Docker-Content-Digest` header **and independently cross-checked** by recomputing the sha256 of the manifest body (both match — not a guess). Closes the moving-tag/IfNotPresent swap window on a third-party image not on our `sha-` pipeline.

## 3. Forge introspection for ops
- `GET /v1/stats?project=` (token-gated, read-only, side-effect-free): `{sessions: <live kernels>, receipts: <chain length>, adapters: <list>, kernel_ready: bool}`. Adds `execn.live_kernels()` helper (project-scoped by session_id convention).

## Verification
- Tests: **26 passed** (20 existing + 6 new: clean chain valid, tampered `code_sha` → invalid w/ `broken_at`, excised-link → invalid, empty chain valid, stats shape, token-gating).
- `schedule-tick.yaml` validated via `yaml.safe_load_all` and `kubectl kustomize infra/k8s/sovereign-runtime` (OK).
- Scope: only `apps/lattice-forge/**` and `infra/k8s/sovereign-runtime/schedule-tick.yaml` touched. No `deploy/**`, no `argocd/**`, no `lattice-studio`.