### PR TITLE
Sha-pin lattice-forge (escape the :latest trap → roll forge onto real code)

### DIFF
--- a/deploy/values/lattice-forge.yaml
+++ b/deploy/values/lattice-forge.yaml
@@ -8,7 +8,7 @@
 # ResourceQuota) because it executes untrusted user code. See
 # deploy/argocd/runtime-services.yaml + infra/k8s/sovereign-runtime/.
 # tag:latest → sha-pinned by gitops-promote after first build.
-image: { repository: lattice-forge, tag: latest }
+image: { repository: lattice-forge, tag: sha-e69549d48820c5ff34f0dd03c1ceadc9967c9ed7 }
 service: { port: 8870, portName: http }
 
 config:


### PR DESCRIPTION
The live forge pod cached an older `:latest` at start; `IfNotPresent` never re-pulls, so #841/#843 forge code was **not actually running**. Pin to `sha-e69549d4` (the #843 build) so ArgoCD rolls the pod onto real code. Also bootstraps gitops-promote to maintain the pin (it only repins files ALREADY `sha-`-tagged — a new `tag:latest` service is stranded; root gap flagged for the estate).