### PR TITLE
Fix schedule-tick DNS + forge Recreate rollout (two live bugs)

### DIFF
--- a/charts/socioprophet-service/templates/deployment.yaml
+++ b/charts/socioprophet-service/templates/deployment.yaml
@@ -7,6 +7,9 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy: {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels: {{- include "svc.selectorLabels" . | nindent 6 }}
   template:

--- a/charts/socioprophet-service/values.yaml
+++ b/charts/socioprophet-service/values.yaml
@@ -17,6 +17,9 @@ image:
 imagePullSecrets: []
 
 replicaCount: 1
+# Deployment rollout strategy (empty = k8s default RollingUpdate). Set { type: Recreate }
+# for single-replica services on tight clusters to avoid a 2x-memory surge.
+strategy: {}
 
 # Container port the app listens on (also the Service targetPort).
 service:

--- a/deploy/values/lattice-forge.yaml
+++ b/deploy/values/lattice-forge.yaml
@@ -52,3 +52,6 @@ probes:
 # (Horizontal scale needs sticky sessions / a per-user JupyterHub spawner — next step.)
 replicaCount: 1
 autoscaling: { enabled: false }
+# Single replica on a memory-tight cluster: Recreate (kill-then-create) so a rollout does
+# NOT need 2x memory for a surge pod — which was leaving new pods Pending/Insufficient-memory.
+strategy: { type: Recreate }

--- a/infra/k8s/sovereign-runtime/schedule-tick.yaml
+++ b/infra/k8s/sovereign-runtime/schedule-tick.yaml
@@ -8,7 +8,7 @@
 #
 # It stays inside the isolated sovereign-runtime namespace (default-deny +
 # intra-namespace allow), so `http://lattice-forge:8870` resolves without any new
-# egress. It carries the SAME lattice-forge-token secret the forge validates, so a
+# egress (use the FQDN — a musl/curl pod does not resolve the bare single-label name via search domains). It carries the SAME lattice-forge-token secret the forge validates, so a
 # tick is authenticated exactly like a user call — no unauthenticated backdoor.
 #
 # PodSecurity: the namespace enforces `restricted`, so the pod is non-root, drops
@@ -49,7 +49,7 @@ spec:
                   curl -sS --fail --max-time 40
                   -X POST
                   -H "Authorization: Bearer ${FORGE_TOKEN}"
-                  http://lattice-forge:8870/v1/run-due
+                  http://lattice-forge.sovereign-runtime.svc.cluster.local:8870/v1/run-due
               env:
                 - name: FORGE_TOKEN
                   valueFrom: { secretKeyRef: { name: lattice-forge-token, key: token } }


### PR DESCRIPTION
**Two live-cluster bugs, fixed:**
1. `forge-schedule-tick` CronJob errored every minute — `curl: (6) Could not resolve host: lattice-forge`. A musl/`curlimages/curl` pod doesn't resolve the bare single-label name via search domains → switched to the FQDN.
2. The forge rollout sat `Pending / Insufficient memory`: the chart had no rollout-strategy control, so a single-replica service still surged a second pod (2× memory) on a full cluster. Added opt-in `.Values.strategy` (default `{}` = RollingUpdate, no behavior change for anyone) and set `lattice-forge` → `Recreate`.

helm renders clean; kustomize + yaml validated.