### PR TITLE
Fix broken DNS in sovereign-runtime (NodeLocal DNSCache)

### DIFF
--- a/infra/k8s/sovereign-runtime/networkpolicy.yaml
+++ b/infra/k8s/sovereign-runtime/networkpolicy.yaml
@@ -27,10 +27,11 @@ spec:
   podSelector: {}
   policyTypes: [Egress]
   egress:
-    - to:
-        - namespaceSelector:
-            matchLabels: { kubernetes.io/metadata.name: kube-system }
-      ports:
+    # DNS to ANY destination on port 53 — GKE NodeLocal DNSCache means pods resolve
+    # via the node-local link-local IP (169.254.20.10), NOT a kube-system pod, so a
+    # namespaceSelector rule silently blocks ALL DNS. Port-53-to-anywhere is the
+    # standard robust NetworkPolicy DNS allow; everything else stays default-denied.
+    - ports:
         - { protocol: UDP, port: 53 }
         - { protocol: TCP, port: 53 }
 ---


### PR DESCRIPTION
**Real bug I introduced with the isolation policy.** GKE runs NodeLocal DNSCache; every `sovereign-runtime` pod resolves via the node-local link-local IP `169.254.20.10`, which is **not** a `kube-system` pod — so my `allow-dns` (a `namespaceSelector`) never matched it and default-deny dropped **all** DNS. Verified: JupyterLab in-namespace → `Temporary failure in name resolution`. The schedule-tick 'could not resolve host' was a symptom. Fix: allow egress on port 53 to any destination (the standard robust NetworkPolicy DNS allow); everything else stays default-denied. The notebook demo worked only because kernel exec is local and the BFF resolves from its own namespace.