### PR TITLE
Universal Compute Contract gateway (any compute, one governed door)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -65,6 +65,7 @@ jobs:
           - { image: search-gateway,        context: apps/search-gateway,        dockerfile: Dockerfile }
           - { image: lattice-studio,        context: apps/lattice-studio,        dockerfile: Dockerfile }
           - { image: lattice-forge,         context: apps/lattice-forge,         dockerfile: Dockerfile }
+          - { image: compute-gateway,       context: apps/compute-gateway,       dockerfile: Dockerfile }
           - { image: grlplus-service,       context: apps/grlplus-service,       dockerfile: Dockerfile }
           - { image: grl-mesh,             context: apps/grl-mesh,             dockerfile: Dockerfile }
           - { image: owl-reasoner,         context: apps/owl-reasoner,         dockerfile: Dockerfile }

--- a/apps/compute-gateway/Dockerfile
+++ b/apps/compute-gateway/Dockerfile
@@ -1,0 +1,13 @@
+# compute-gateway — the Universal Compute Contract router. Control-plane only
+# (routes to backend runtimes; executes no user code itself), so it lives in the
+# platform namespace, not sovereign-runtime.
+FROM python:3.12-slim
+RUN useradd -m -u 10001 gateway
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+ENV PORT=8080 PYTHONUNBUFFERED=1
+EXPOSE 8080
+USER gateway
+CMD ["uvicorn", "compute_gateway.server:app", "--host", "0.0.0.0", "--port", "8080", "--app-dir", "src"]

--- a/apps/compute-gateway/pyproject.toml
+++ b/apps/compute-gateway/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "compute-gateway"
+version = "0.1.0"
+description = "The Universal Compute Contract gateway — any compute, one governed door, one receipt."
+requires-python = ">=3.11"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/apps/compute-gateway/requirements.txt
+++ b/apps/compute-gateway/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.110
+uvicorn[standard]>=0.29
+pydantic>=2.6
+httpx>=0.27

--- a/apps/compute-gateway/src/compute_gateway/__init__.py
+++ b/apps/compute-gateway/src/compute_gateway/__init__.py
@@ -1,0 +1,2 @@
+"""compute-gateway — one governed door for every kind of compute."""
+__version__ = "0.1.0"

--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -1,0 +1,136 @@
+"""Backend adapters — the thin shims that make a heterogeneous backend speak the
+one contract. Each returns raw `(outputs, runtime, status, error, degraded)`;
+the gateway seals the receipt and types the warrant. New compute kind = new
+adapter here + a registry row.
+
+Adapters are injectable (`set_backend`) so tests never need a live forge/graph.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Awaitable, Callable
+
+import httpx
+
+from .contract import ComputeOutput, GraphDelta, GraphEdge, GraphNode
+
+FORGE_URL = os.getenv("FORGE_URL", "http://lattice-forge.sovereign-runtime.svc.cluster.local:8870").rstrip("/")
+FORGE_TOKEN = os.getenv("FORGE_TOKEN", "")
+HELLGRAPH_URL = os.getenv("HELLGRAPH_URL", "http://hellgraph-service:8090").rstrip("/")
+TIMEOUT = float(os.getenv("GATEWAY_TIMEOUT", "90"))
+
+# adapter result shape: dict(outputs=[ComputeOutput], runtime, status, error, degraded)
+AdapterResult = dict[str, Any]
+
+
+async def _forge(req_spec: dict, project: str, session: str | None) -> AdapterResult:
+    body = {"project": project, "code": req_spec.get("code", ""),
+            "language": req_spec.get("language", "python"),
+            "adapter": req_spec.get("adapter"), "session_id": session}
+    headers = {"Authorization": f"Bearer {FORGE_TOKEN}"} if FORGE_TOKEN else {}
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT, headers=headers) as c:
+            r = await c.post(f"{FORGE_URL}/v1/execute", json=body)
+            if r.status_code != 200:
+                return {"outputs": [], "runtime": "python3", "status": "error",
+                        "error": f"forge HTTP {r.status_code}", "degraded": None}
+            d = r.json()
+            outs = [ComputeOutput(**o) if not isinstance(o, ComputeOutput) else o
+                    for o in _shape_forge(d.get("outputs", []))]
+            return {"outputs": outs, "runtime": d.get("runtime", "python3"),
+                    "status": d.get("status", "ok"), "error": d.get("error"),
+                    "degraded": d.get("degraded")}
+    except Exception as e:  # noqa: BLE001
+        return {"outputs": [], "runtime": "python3", "status": "degraded",
+                "error": None, "degraded": f"forge unreachable: {e}"}
+
+
+def _shape_forge(outputs: list[dict]) -> list[dict]:
+    shaped = []
+    for o in outputs:
+        shaped.append({"type": o.get("type", "result"), "text": o.get("text"),
+                       "data": {k: o[k] for k in ("png", "svg", "html", "mime") if o.get(k)} or None,
+                       "mime": o.get("mime")})
+    return shaped
+
+
+async def _hellgraph_query(req_spec: dict, project: str) -> AdapterResult:
+    label = req_spec.get("label") or project
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT) as c:
+            r = await c.get(f"{HELLGRAPH_URL}/api/graph/query", params={"label": label})
+            if r.status_code != 200:
+                return {"outputs": [], "runtime": "hellgraph", "status": "error",
+                        "error": f"hellgraph HTTP {r.status_code}", "degraded": None}
+            data = r.json()
+            nodes = data.get("nodes", data if isinstance(data, list) else [])
+            return {"outputs": [ComputeOutput(type="graph", data={"nodes": nodes, "count": len(nodes)})],
+                    "runtime": "hellgraph", "status": "ok", "error": None, "degraded": None}
+    except Exception as e:  # noqa: BLE001
+        return {"outputs": [], "runtime": "hellgraph", "status": "degraded",
+                "error": None, "degraded": f"hellgraph unreachable: {e}"}
+
+
+async def _hellgraph_stats(req_spec: dict, project: str) -> AdapterResult:
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT) as c:
+            r = await c.get(f"{HELLGRAPH_URL}/api/graph/stats")
+            if r.status_code != 200:
+                return {"outputs": [], "runtime": "hellgraph", "status": "error",
+                        "error": f"hellgraph HTTP {r.status_code}", "degraded": None}
+            return {"outputs": [ComputeOutput(type="table", data=r.json())],
+                    "runtime": "hellgraph", "status": "ok", "error": None, "degraded": None}
+    except Exception as e:  # noqa: BLE001
+        return {"outputs": [], "runtime": "hellgraph", "status": "degraded",
+                "error": None, "degraded": f"hellgraph unreachable: {e}"}
+
+
+# kind → adapter coroutine. Overridable in tests.
+_BACKENDS: dict[str, Callable[..., Awaitable[AdapterResult]]] = {
+    "forge": lambda spec, project, session: _forge(spec, project, session),
+    "hellgraph:graph-query": lambda spec, project, session: _hellgraph_query(spec, project),
+    "hellgraph:graph-stats": lambda spec, project, session: _hellgraph_stats(spec, project),
+}
+
+
+def set_backend(key: str, fn: Callable[..., Awaitable[AdapterResult]]) -> None:
+    _BACKENDS[key] = fn
+
+
+async def dispatch(kind: str, backend: str, spec: dict, project: str, session: str | None) -> AdapterResult:
+    fn = _BACKENDS.get(f"{backend}:{kind}") or _BACKENDS.get(backend)
+    if fn is None:
+        return {"outputs": [], "runtime": backend, "status": "degraded", "error": None,
+                "degraded": f"backend '{backend}' for kind '{kind}' not wired yet"}
+    return await fn(spec, project, session)
+
+
+# ── provenance write-back: every run becomes nodes+edges in the graph ──
+async def write_provenance(delta: GraphDelta) -> bool:
+    """Best-effort: persist the run's subgraph to hellgraph. Never fails the compute."""
+    if not delta.nodes:
+        return False
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as c:
+            for n in delta.nodes:
+                await c.post(f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": n.id, "labels": n.labels, "properties": n.properties})
+            for e in delta.edges:
+                await c.post(f"{HELLGRAPH_URL}/api/graph/edge",
+                             json={"label": e.label, "from": e.from_, "to": e.to, "properties": e.properties})
+        return True
+    except Exception:  # noqa: BLE001 — provenance write is best-effort
+        return False
+
+
+def build_delta(project: str, kind: str, backend: str, receipt_id: str, epistemic: str) -> GraphDelta:
+    run_id = f"proj-{project}:compute:{receipt_id.replace('sha256:', '')[:12]}"
+    rc_id = f"proj-{project}:receipt:{receipt_id.replace('sha256:', '')[:12]}"
+    return GraphDelta(
+        nodes=[
+            GraphNode(id=run_id, labels=[project, "ComputeRun", kind],
+                      properties={"kind": kind, "backend": backend, "epistemic_mode": epistemic}),
+            GraphNode(id=rc_id, labels=[project, "Receipt"], properties={"receipt": receipt_id}),
+        ],
+        edges=[GraphEdge.model_validate({"label": "HAS_RECEIPT", "from": run_id, "to": rc_id})],
+    )

--- a/apps/compute-gateway/src/compute_gateway/contract.py
+++ b/apps/compute-gateway/src/compute_gateway/contract.py
@@ -1,0 +1,89 @@
+"""The Universal Compute Contract.
+
+One shape for every kind of compute — a notebook cell, a graph query, a Spark
+job, a model inference, an agent run. Databricks welded one paradigm (Spark) to
+one surface (notebook). This is the generalization: `submit(spec, backend,
+entitlement) -> result`, where the result is uniform not just in shape but in
+GOVERNANCE — every compute emits the same hash-chained receipt and carries an
+epistemic status. Heterogeneous compute, homogeneous evidence.
+"""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+# The epistemic ladder — the warrant a compute output carries. A graph read is
+# `observed`; a model/derived computation is `derived`; a checked result is
+# `verified`; only a human/policy promotion reaches `attested`.
+EpistemicStatus = Literal[
+    "hypothesis", "observed", "derived", "verified", "attested", "simulated", "unknown"
+]
+
+
+class ComputeOutput(BaseModel):
+    type: str                                   # stream | result | table | graph | error | degraded
+    text: str | None = None
+    data: dict[str, Any] | None = None          # rich payload (rows, png, html, nodes…)
+    mime: list[str] | None = None
+
+
+class Receipt(BaseModel):
+    """The universal, hash-chained, replayable unit. Identical across all kinds."""
+    id: str
+    project: str
+    kind: str
+    backend: str
+    runtime: str
+    inputs_sha: str
+    outputs_sha: str
+    status: str
+    actor: str
+    epistemic_status: EpistemicStatus
+    prev: str | None = None
+    ts: float
+
+
+class GraphNode(BaseModel):
+    id: str
+    labels: list[str] = []
+    properties: dict[str, Any] = {}
+
+
+class GraphEdge(BaseModel):
+    label: str
+    from_: str = Field(alias="from")
+    to: str
+    properties: dict[str, Any] = {}
+    model_config = {"populate_by_name": True}
+
+
+class GraphDelta(BaseModel):
+    """The provenance subgraph a run produces. Compute + knowledge, one object model."""
+    nodes: list[GraphNode] = []
+    edges: list[GraphEdge] = []
+    written: bool = False                       # did we persist it to the graph?
+
+
+class ComputeRequest(BaseModel):
+    kind: str                                   # notebook | graph-query | graph-stats | spark | …
+    spec: dict[str, Any] = {}                   # kind-specific payload (code, query, label…)
+    backend: str | None = None                  # explicit backend, else the kind's default
+    project: str = "default"
+    entitlement: str | None = None              # caller-presented paid entitlement token
+    actor: str = "user"
+    session: str | None = None                  # session/kernel id for stateful kinds
+
+
+class ComputeResult(BaseModel):
+    status: str                                 # ok | error | degraded | entitlement_required
+    kind: str
+    backend: str
+    epistemic_status: EpistemicStatus
+    outputs: list[ComputeOutput] = []
+    receipt: Receipt | None = None
+    graph_delta: GraphDelta | None = None
+    error: str | None = None
+    degraded: str | None = None
+    entitlement_required: bool = False
+    message: str | None = None

--- a/apps/compute-gateway/src/compute_gateway/receipts.py
+++ b/apps/compute-gateway/src/compute_gateway/receipts.py
@@ -1,0 +1,58 @@
+"""The universal receipt sealer — the ONE place the compute plane mints proof.
+
+Backends return raw outputs; the gateway seals. So a Spark job, a notebook cell,
+and a graph query all get the identical hash-chained receipt, tamper-evident per
+project. (This is the future `libs/receipts` — extracted here as the canonical
+owner; lattice-forge keeps its own for its direct path until we unify.)
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from typing import Any
+
+from .contract import EpistemicStatus, Receipt
+
+# per-project hash chain
+_CHAINS: dict[str, list[Receipt]] = {}
+
+
+def sha(obj: Any) -> str:
+    return "sha256:" + hashlib.sha256(
+        json.dumps(obj, sort_keys=True, default=str, ensure_ascii=False).encode()
+    ).hexdigest()
+
+
+def seal(project: str, *, kind: str, backend: str, runtime: str, inputs: Any,
+         outputs: Any, status: str, actor: str, epistemic_status: EpistemicStatus) -> Receipt:
+    chain = _CHAINS.setdefault(project, [])
+    prev = chain[-1].id if chain else None
+    body = {
+        "project": project, "kind": kind, "backend": backend, "runtime": runtime,
+        "inputs_sha": sha(inputs), "outputs_sha": sha(outputs), "status": status,
+        "actor": actor, "epistemic_status": epistemic_status, "prev": prev, "ts": time.time(),
+    }
+    receipt = Receipt(id=sha(body), **body)
+    chain.append(receipt)
+    return receipt
+
+
+def chain(project: str) -> list[Receipt]:
+    return list(_CHAINS.get(project, []))
+
+
+def verify(project: str) -> dict:
+    """Recompute every id + re-walk every prev-link. Tamper-evidence, checkable."""
+    ch = _CHAINS.get(project, [])
+    prev: str | None = None
+    for r in ch:
+        body = {k: getattr(r, k) for k in (
+            "project", "kind", "backend", "runtime", "inputs_sha", "outputs_sha",
+            "status", "actor", "epistemic_status", "prev", "ts")}
+        if sha(body) != r.id:
+            return {"valid": False, "count": len(ch), "broken_at": r.id, "reason": "id-hash mismatch"}
+        if r.prev != prev:
+            return {"valid": False, "count": len(ch), "broken_at": r.id, "reason": "prev-link broken"}
+        prev = r.id
+    return {"valid": True, "count": len(ch), "broken_at": None, "reason": None}

--- a/apps/compute-gateway/src/compute_gateway/registry.py
+++ b/apps/compute-gateway/src/compute_gateway/registry.py
@@ -1,0 +1,97 @@
+"""The compute registry — kind → backends, capabilities, warrant, entitlement.
+
+This is the forge's adapter registry, generalized from "notebook adapters" to
+"every kind of compute." Adding a compute type is a row here + an adapter. The
+registry is discoverable (`/v1/registry`) so the surface renders itself and an
+agent planner treats it as an action space.
+"""
+from __future__ import annotations
+
+import os
+
+from .contract import EpistemicStatus
+
+# kind → definition. `executes_user_code` decides trust-boundary placement;
+# `epistemic` is the default warrant of the kind's output.
+KINDS: dict[str, dict] = {
+    "notebook": {
+        "backends": ["forge"], "default": "forge",
+        "capabilities": ["python", "r", "julia", "stateful-kernel"],
+        "epistemic": "derived", "executes_user_code": True, "status": "live",
+    },
+    "graph-query": {
+        "backends": ["hellgraph"], "default": "hellgraph",
+        "capabilities": ["label-query", "subgraph"],
+        "epistemic": "observed", "executes_user_code": False, "status": "live",
+    },
+    "graph-stats": {
+        "backends": ["hellgraph"], "default": "hellgraph",
+        "capabilities": ["counts", "analytics"],
+        "epistemic": "observed", "executes_user_code": False, "status": "live",
+    },
+    # declared, wired incrementally — the point is the contract already admits them
+    "spark": {
+        "backends": ["spark-runner"], "default": "spark-runner",
+        "capabilities": ["sql", "dataframe"],
+        "epistemic": "derived", "executes_user_code": True, "status": "declared",
+    },
+    "inference": {
+        "backends": ["model-server"], "default": "model-server",
+        "capabilities": ["chat", "embed"],
+        "epistemic": "derived", "executes_user_code": False, "status": "declared",
+    },
+}
+
+
+class UnknownKind(KeyError):
+    pass
+
+
+class UnknownBackend(KeyError):
+    pass
+
+
+def resolve(kind: str, backend: str | None) -> tuple[str, dict, str]:
+    """(kind, definition, backend). Raises on unknown kind/backend."""
+    if kind not in KINDS:
+        raise UnknownKind(kind)
+    d = KINDS[kind]
+    b = backend or d["default"]
+    if b not in d["backends"]:
+        raise UnknownBackend(f"{b} not a backend for {kind}")
+    return kind, d, b
+
+
+def epistemic_for(kind: str) -> EpistemicStatus:
+    return KINDS.get(kind, {}).get("epistemic", "unknown")
+
+
+# ── the uniform entitlement gate (generalizes STUDIO_COMPUTE_ENTITLEMENTS) ──
+# Comma-sep tokens. A request is entitled if the set contains any of:
+#   "*", kind, "kind:backend", project, "project:kind", "project:kind:backend",
+# OR the caller presents an entitlement token that is itself in the set (paid tenants).
+def _entitlements() -> set[str]:
+    return {t.strip() for t in os.getenv("COMPUTE_ENTITLEMENTS", "").split(",") if t.strip()}
+
+
+def entitled(project: str, kind: str, backend: str, presented: str | None) -> bool:
+    ents = _entitlements()
+    if "*" in ents:
+        return True
+    keys = {kind, f"{kind}:{backend}", project, f"{project}:{kind}", f"{project}:{kind}:{backend}"}
+    if keys & ents:
+        return True
+    return bool(presented and presented in ents)
+
+
+def catalog(project: str, presented: str | None) -> list[dict]:
+    """The registry as the surface/planner sees it: kinds + backends + entitlement."""
+    out = []
+    for kind, d in KINDS.items():
+        out.append({
+            "kind": kind, "backends": d["backends"], "default": d["default"],
+            "capabilities": d["capabilities"], "epistemic": d["epistemic"],
+            "executes_user_code": d["executes_user_code"], "status": d["status"],
+            "entitled": entitled(project, kind, d["default"], presented),
+        })
+    return out

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -1,0 +1,98 @@
+"""compute-gateway — one governed door for every kind of compute.
+
+POST /v1/compute takes a ComputeRequest, gates it (auth + uniform entitlement),
+routes it to the owning backend adapter, seals the universal hash-chained
+receipt, types the output's warrant, and writes the run's provenance subgraph
+back to the graph. Notebook and graph queries go through the exact same path —
+the walking skeleton of "any compute, one contract".
+"""
+from __future__ import annotations
+
+import os
+
+from fastapi import Depends, FastAPI, Header, HTTPException
+
+from . import adapters, receipts, registry
+from .contract import ComputeRequest, ComputeResult
+
+app = FastAPI(title="compute-gateway", version="0.1.0")
+
+GATEWAY_TOKEN = os.getenv("GATEWAY_TOKEN", "")
+WRITE_PROVENANCE = os.getenv("GATEWAY_WRITE_PROVENANCE", "true").lower() == "true"
+
+
+def require_token(authorization: str = Header(default="")) -> None:
+    if not GATEWAY_TOKEN:
+        raise HTTPException(status_code=503, detail="gateway token not configured (fail-closed)")
+    if authorization.removeprefix("Bearer ").strip() != GATEWAY_TOKEN:
+        raise HTTPException(status_code=401, detail="unauthorized")
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"ok": True, "service": "compute-gateway", "kinds": list(registry.KINDS)}
+
+
+@app.get("/v1/contract")
+def contract() -> dict:
+    """The contract itself, as JSON schema — the spine everything conforms to."""
+    return {"request": ComputeRequest.model_json_schema(),
+            "result": ComputeResult.model_json_schema()}
+
+
+@app.get("/v1/registry")
+def registry_view(project: str = "default", entitlement: str | None = None,
+                  _: None = Depends(require_token)) -> dict:
+    return {"project": project, "kinds": registry.catalog(project, entitlement)}
+
+
+@app.post("/v1/compute", response_model=ComputeResult)
+async def compute(req: ComputeRequest, _: None = Depends(require_token)) -> ComputeResult:
+    # 1) resolve kind + backend
+    try:
+        kind, _def, backend = registry.resolve(req.kind, req.backend)
+    except registry.UnknownKind:
+        raise HTTPException(status_code=422, detail=f"unknown compute kind: {req.kind}")
+    except registry.UnknownBackend as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    # 2) the UNIFORM pay-gate — one gate for all compute (like Databricks/Foundry,
+    #    but sovereign + per-kind/per-backend). Fail-closed with an honest 402.
+    if not registry.entitled(req.project, kind, backend, req.entitlement):
+        return ComputeResult(
+            status="entitlement_required", kind=kind, backend=backend,
+            epistemic_status=registry.epistemic_for(kind), entitlement_required=True,
+            message=f"compute '{kind}:{backend}' is a provisioned service — no entitlement for "
+                    f"project '{req.project}' (set COMPUTE_ENTITLEMENTS)")
+
+    # 3) route to the backend adapter (raw outputs; no receipt yet)
+    raw = await adapters.dispatch(kind, backend, req.spec, req.project, req.session)
+    epistemic = registry.epistemic_for(kind)
+    status = raw["status"]
+
+    # 4) SEAL the universal receipt — the same for a cell, a query, anything
+    receipt = receipts.seal(
+        req.project, kind=kind, backend=backend, runtime=raw["runtime"],
+        inputs=req.spec, outputs=[o.model_dump() for o in raw["outputs"]],
+        status=status, actor=req.actor, epistemic_status=epistemic)
+
+    # 5) provenance subgraph — compute + knowledge, one object model
+    delta = adapters.build_delta(req.project, kind, backend, receipt.id, epistemic)
+    if WRITE_PROVENANCE and status == "ok":
+        delta.written = await adapters.write_provenance(delta)
+
+    return ComputeResult(
+        status=status, kind=kind, backend=backend, epistemic_status=epistemic,
+        outputs=raw["outputs"], receipt=receipt, graph_delta=delta,
+        error=raw.get("error"), degraded=raw.get("degraded"))
+
+
+@app.get("/v1/receipts")
+def receipts_view(project: str = "default", _: None = Depends(require_token)) -> dict:
+    ch = receipts.chain(project)
+    return {"project": project, "count": len(ch), "receipts": [r.model_dump() for r in ch]}
+
+
+@app.get("/v1/receipts/verify")
+def receipts_verify(project: str = "default", _: None = Depends(require_token)) -> dict:
+    return receipts.verify(project)

--- a/apps/compute-gateway/tests/test_gateway.py
+++ b/apps/compute-gateway/tests/test_gateway.py
@@ -1,0 +1,92 @@
+"""compute-gateway tests — no live forge/graph needed (adapters injected)."""
+import importlib
+import os
+
+# module-level config is read at import → set before importing server
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo,graph-query,graph-stats"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"          # no network in tests
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import adapters, receipts, server  # noqa: E402
+from compute_gateway.contract import ComputeOutput  # noqa: E402
+
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+
+def setup_function():
+    receipts._CHAINS.clear()
+    # deterministic fakes for both backends
+    async def fake_forge(spec, project, session):
+        return {"outputs": [ComputeOutput(type="result", text=f"ran:{spec.get('code')}")],
+                "runtime": "python3", "status": "ok", "error": None, "degraded": None}
+    async def fake_graph(spec, project, session):
+        return {"outputs": [ComputeOutput(type="graph", data={"nodes": [{"id": "n1"}], "count": 1})],
+                "runtime": "hellgraph", "status": "ok", "error": None, "degraded": None}
+    adapters.set_backend("forge", fake_forge)
+    adapters.set_backend("hellgraph:graph-query", fake_graph)
+
+
+def test_healthz():
+    assert client.get("/healthz").json()["service"] == "compute-gateway"
+
+
+def test_token_fail_closed():
+    assert client.get("/v1/registry").status_code == 401
+    assert client.post("/v1/compute", json={"kind": "notebook"}).status_code == 401
+
+
+def test_contract_exposes_schemas():
+    d = client.get("/v1/contract").json()
+    assert "properties" in d["request"] and "properties" in d["result"]
+
+
+def test_registry_shows_entitlement():
+    ks = {k["kind"]: k for k in client.get("/v1/registry", params={"project": "demo"}, headers=AUTH).json()["kinds"]}
+    assert ks["notebook"]["entitled"] is True          # project 'demo' entitled
+    assert ks["graph-query"]["entitled"] is True        # kind entitled globally
+    assert "spark" in ks and ks["spark"]["status"] == "declared"
+
+
+def test_notebook_routes_to_forge_with_receipt_and_warrant():
+    r = client.post("/v1/compute", json={"kind": "notebook", "project": "demo", "spec": {"code": "1+1"}}, headers=AUTH).json()
+    assert r["status"] == "ok" and r["backend"] == "forge"
+    assert r["epistemic_status"] == "derived"           # a cell is derived
+    assert r["outputs"][0]["text"] == "ran:1+1"
+    assert r["receipt"]["id"].startswith("sha256:") and r["receipt"]["kind"] == "notebook"
+    assert r["graph_delta"]["nodes"]                    # provenance subgraph built
+
+
+def test_graph_query_same_door_different_warrant():
+    r = client.post("/v1/compute", json={"kind": "graph-query", "project": "demo", "spec": {"label": "demo"}}, headers=AUTH).json()
+    assert r["status"] == "ok" and r["backend"] == "hellgraph"
+    assert r["epistemic_status"] == "observed"          # a graph read is observed, not derived
+    assert r["outputs"][0]["type"] == "graph"
+
+
+def test_uniform_entitlement_gate():
+    r = client.post("/v1/compute", json={"kind": "notebook", "project": "locked", "spec": {"code": "x"}}, headers=AUTH).json()
+    assert r["status"] == "entitlement_required" and r["entitlement_required"] is True
+
+
+def test_unknown_kind_422():
+    assert client.post("/v1/compute", json={"kind": "quantum", "project": "demo"}, headers=AUTH).status_code == 422
+
+
+def test_receipt_chain_and_verify():
+    for code in ["a=1", "b=2", "c=3"]:
+        client.post("/v1/compute", json={"kind": "notebook", "project": "demo", "spec": {"code": code}}, headers=AUTH)
+    ch = client.get("/v1/receipts", params={"project": "demo"}, headers=AUTH).json()
+    assert ch["count"] == 3
+    assert ch["receipts"][1]["prev"] == ch["receipts"][0]["id"]     # chained
+    assert client.get("/v1/receipts/verify", params={"project": "demo"}, headers=AUTH).json()["valid"] is True
+
+
+def test_verify_detects_tamper():
+    client.post("/v1/compute", json={"kind": "notebook", "project": "demo", "spec": {"code": "x"}}, headers=AUTH)
+    receipts._CHAINS["demo"][0].outputs_sha = "sha256:deadbeef"     # tamper
+    v = client.get("/v1/receipts/verify", params={"project": "demo"}, headers=AUTH).json()
+    assert v["valid"] is False and v["broken_at"] is not None

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -38,6 +38,7 @@ spec:
           - { name: liberty-stack-readout }
           - { name: tritfabric-consumption-api }
           - { name: agora }
+          - { name: compute-gateway }
           - { name: spark-runner }
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —

--- a/deploy/values/compute-gateway.yaml
+++ b/deploy/values/compute-gateway.yaml
@@ -1,0 +1,24 @@
+# compute-gateway — the Universal Compute Contract router (apps/compute-gateway).
+# One governed door for every kind of compute: routes notebook→lattice-forge and
+# graph→hellgraph-service through a single ComputeRequest→ComputeResult, applies
+# ONE uniform entitlement gate, seals ONE universal hash-chained receipt per run,
+# types the output's warrant, and writes the run's provenance subgraph back to the
+# graph. Control-plane only (executes no user code) → platform namespace.
+# tag:latest is a bootstrap; sha-pin after first build (gitops-promote only
+# MAINTAINS an existing sha- pin — a new latest service must be pinned once).
+image: { repository: compute-gateway, tag: latest }
+service: { port: 8080, portName: http }
+config:
+  FORGE_URL: "http://lattice-forge.sovereign-runtime.svc.cluster.local:8870"
+  HELLGRAPH_URL: "http://hellgraph-service:8090"
+  # THE uniform pay-gate across ALL compute kinds (generalizes STUDIO_COMPUTE_ENTITLEMENTS).
+  # Tokens: "*" | "<kind>" | "<kind>:<backend>" | "<project>" | "<project>:<kind>" | "<project>:<kind>:<backend>".
+  COMPUTE_ENTITLEMENTS: "demo,default,graph-query,graph-stats"
+  # every ok run writes its ComputeRun/Receipt subgraph to hellgraph (best-effort).
+  GATEWAY_WRITE_PROVENANCE: "true"
+# GATEWAY_TOKEN provisioned out-of-band; FORGE_TOKEN is the SAME lattice-forge-token
+# already present in socioprophet (the gateway authenticates to the forge with it).
+secretEnv:
+  GATEWAY_TOKEN: { secretName: compute-gateway-token, key: token }
+  FORGE_TOKEN: { secretName: lattice-forge-token, key: token }
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }


### PR DESCRIPTION
The thesis, in code: Databricks welded Spark to a notebook; the killer PaaS is **every kind of compute reached the same way — and proof-carrying by construction.**

**apps/compute-gateway** (FastAPI, 10 tests green):
- **contract.py** — `ComputeRequest → ComputeResult`, one shape for cell/query/Spark/inference/agent; JSON schema at `/v1/contract`.
- **registry.py** — `kind → {backends, capabilities, warrant, entitlement}` (the forge adapter registry, generalized). Discoverable at `/v1/registry`; includes the **uniform pay-gate** (one 402 for all compute).
- **adapters.py** — thin shims: notebook→**lattice-forge**, graph→**hellgraph-service** (real endpoints). `write_provenance()` turns every run into `ComputeRun`+`Receipt` nodes/edges — compute + knowledge, one object model.
- **receipts.py** — the ONE universal hash-chained, tamper-verifiable receipt for every kind (`/v1/receipts/verify`).
- **server.py** — `POST /v1/compute`: gate → route → seal → type warrant (`derived` cell vs `observed` graph read) → write provenance. Same path for both kinds.

Control-plane only (no user code) → platform namespace; reaches forge via the existing NetworkPolicy; `FORGE_TOKEN` = the existing `lattice-forge-token`.

**Go-live:** create `compute-gateway-token`. **Flagged:** pin it after first build + fix gitops-promote to bootstrap new `tag:latest` services.