### PR TITLE
Revert bad gitops catch-up (28 services pinned to an imageless sha)

### DIFF
--- a/deploy/values/agentic-os-api.yaml
+++ b/deploy/values/agentic-os-api.yaml
@@ -1,5 +1,5 @@
 # agentic-os-api
-image: { repository: agentic-os-api, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: agentic-os-api, tag: latest }
 service: { port: 8080, portName: http }
 # The app exposes @app.get("/health") (app/main.py:19), not the chart's default
 # /healthz — so every probe 404'd and the kubelet killed it: 939 restarts over

--- a/deploy/values/agora.yaml
+++ b/deploy/values/agora.yaml
@@ -3,7 +3,7 @@
 # carrying HellGraph facts in the project's proj- collection — the same one Noetica and lattice-studio share — so
 # every card and page is citable / preservable / curatable via the Studio commons, and readable by the agent team.
 # Pinned to the immutable sha- tag the apps/agora build published (PR #821 merge commit) — never a moving :latest.
-image: { repository: agora, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: agora, tag: sha-e69549d48820c5ff34f0dd03c1ceadc9967c9ed7 }
 service: { port: 8080, portName: http }
 # server serves /healthz (chart default) — no probes.path override.
 config:

--- a/deploy/values/api.yaml
+++ b/deploy/values/api.yaml
@@ -1,5 +1,5 @@
 # socioprophet-api — tritRPC core API
-image: { repository: socioprophet-api, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: socioprophet-api, tag: latest }
 service: { port: 9000, portName: tritrpc }
 probes: { enabled: true, httpGet: false }   # raw tritRPC, no HTTP health
 config:

--- a/deploy/values/compute-gateway.yaml
+++ b/deploy/values/compute-gateway.yaml
@@ -6,7 +6,7 @@
 # graph. Control-plane only (executes no user code) → platform namespace.
 # tag:latest is a bootstrap; sha-pin after first build (gitops-promote only
 # MAINTAINS an existing sha- pin — a new latest service must be pinned once).
-image: { repository: compute-gateway, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: compute-gateway, tag: latest }
 service: { port: 8080, portName: http }
 config:
   FORGE_URL: "http://lattice-forge.sovereign-runtime.svc.cluster.local:8870"

--- a/deploy/values/dashboard-bff.yaml
+++ b/deploy/values/dashboard-bff.yaml
@@ -13,7 +13,7 @@
 # 26.11, which this image does not carry — that mismatch is what left it in
 # ImagePullBackOff). This is the very standard tools/preflight_deploy_contract.py now
 # enforces: "Immutable tag = the commit SHA the GitOps promotion writes."
-image: { repository: dashboard-bff, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: dashboard-bff, tag: sha-e69549d48820c5ff34f0dd03c1ceadc9967c9ed7 }
 service: { port: 8080, portName: http }
 # main.py serves @app.get('/health'), NOT the chart default /healthz. Asserted by the
 # probe-contract gate.

--- a/deploy/values/embeddings.yaml
+++ b/deploy/values/embeddings.yaml
@@ -3,7 +3,7 @@
 # vectors. The model is baked into the image (no runtime HuggingFace egress, no PVC). tag:latest is
 # sha-pinned by gitops-promote after the first CI build.
 nameOverride: embeddings
-image: { repository: embeddings, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: embeddings, tag: latest }
 service: { port: 8080, portName: http }
 
 probes:

--- a/deploy/values/entity-resolution.yaml
+++ b/deploy/values/entity-resolution.yaml
@@ -1,7 +1,7 @@
 # entity-resolution — the ER resolver (apps/entity-resolution). Turns regis-entity-graph from a validator
 # into a real engine: blocking → Jaro-Winkler+Jaccard similarity → union-find clustering → proof-carrying
 # decisions (MERGE_VERIFIED/REQUIRES_REVIEW/MERGE_BLOCKED with field-level evidence). tag:latest → sha after first build.
-image: { repository: entity-resolution, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: entity-resolution, tag: latest }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
 networkPolicy: { enabled: true, ports: [8080] }

--- a/deploy/values/eval-fabric-api.yaml
+++ b/deploy/values/eval-fabric-api.yaml
@@ -1,3 +1,3 @@
 # eval-fabric-api
-image: { repository: eval-fabric-api, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: eval-fabric-api, tag: latest }
 service: { port: 8080, portName: http }

--- a/deploy/values/evidence-console.yaml
+++ b/deploy/values/evidence-console.yaml
@@ -1,3 +1,3 @@
 # evidence-console
-image: { repository: evidence-console, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: evidence-console, tag: latest }
 service: { port: 8080, portName: http }

--- a/deploy/values/evidence-receipts.yaml
+++ b/deploy/values/evidence-receipts.yaml
@@ -1,3 +1,3 @@
 # evidence-receipts
-image: { repository: evidence-receipts, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: evidence-receipts, tag: latest }
 service: { port: 8080, portName: http }

--- a/deploy/values/gateway.yaml
+++ b/deploy/values/gateway.yaml
@@ -1,5 +1,5 @@
 # socioprophet-gateway — HTTP edge gateway
-image: { repository: socioprophet-gateway, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: socioprophet-gateway, tag: latest }
 service: { port: 8080, portName: http }
 # The binary reads GATEWAY_PORT (cmd/tritrpc-gateway/main.go:30) and binds ":"+port.
 # A Service named `gateway` makes Kubernetes inject GATEWAY_PORT=tcp://<clusterIP>:8080

--- a/deploy/values/grl-mesh.yaml
+++ b/deploy/values/grl-mesh.yaml
@@ -4,7 +4,7 @@
 # community learns together without raw data leaving a node. Same envelope as the open-chat commons.
 # Publish is FAIL-CLOSED until the GRL_MESH_TOKEN secret is provisioned out-of-band; reads (the prior)
 # stay open (aggregate, non-identifying). tag:latest → sha-pinned after the first CI build (preflight).
-image: { repository: grl-mesh, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: grl-mesh, tag: sha-e69549d48820c5ff34f0dd03c1ceadc9967c9ed7 }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
 # Internal (ClusterIP) — nodes reach it in-cluster / via the sovereign edge; no public ingress yet.

--- a/deploy/values/grlplus-service.yaml
+++ b/deploy/values/grlplus-service.yaml
@@ -3,7 +3,7 @@
 # SPARQL surface on hellgraph-service), so GRLPlus actually DECIDES close/keep-open/escalate instead of
 # the standards repo's export shim. This is the symbolic shield over the same graph the Graph-RL loop
 # learns on. Pinned to the immutable sha- tag the first CI build published.
-image: { repository: grlplus-service, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: grlplus-service, tag: sha-e69549d48820c5ff34f0dd03c1ceadc9967c9ed7 }
 service: { port: 8080, portName: http }
 # server serves /healthz (chart default) — no probes.path override.
 config:

--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -2,7 +2,7 @@
 # tag bumped to the b04eac8f build — the first image carrying engine 0.4.23 (which reads
 # EMBEDDINGS_URL). The prior sha-a16830db predated 0.4.22, so the EMBEDDINGS_URL config below was
 # inert on the cluster until this rolls out. hellgraph-service content is unchanged since b04eac8f.
-image: { repository: hellgraph-service, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: hellgraph-service, tag: sha-e69549d48820c5ff34f0dd03c1ceadc9967c9ed7 }
 service: { port: 8090, portName: http }
 config:
   # Estate sovereign embeddings contract (matches memoryd + prophet-platform #799): the engine

--- a/deploy/values/lattice-forge.yaml
+++ b/deploy/values/lattice-forge.yaml
@@ -8,7 +8,7 @@
 # ResourceQuota) because it executes untrusted user code. See
 # deploy/argocd/runtime-services.yaml + infra/k8s/sovereign-runtime/.
 # tag:latest → sha-pinned by gitops-promote after first build.
-image: { repository: lattice-forge, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: lattice-forge, tag: sha-7fb1c5ab7357d65ed2c226b47f783d805f8d492d }
 service: { port: 8870, portName: http }
 
 config:

--- a/deploy/values/lattice-studio.yaml
+++ b/deploy/values/lattice-studio.yaml
@@ -6,7 +6,7 @@
 # (#48), the pay-gated execution plane (#31), ontology-typed + SHACL-validated actions (#49/#830/#831), GAIA
 # stewardship + world-signals (#50/#51), the HDT twin (#52). NB there is NO gitops-promote workflow, so this pin
 # was never auto-bumped after those merges — hence a stale deploy. A promote job is the real fix (flagged).
-image: { repository: lattice-studio, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: lattice-studio, tag: sha-e69549d48820c5ff34f0dd03c1ceadc9967c9ed7 }
 service: { port: 8080, portName: http }
 # server serves /healthz (chart default) — no probes.path override.
 config:

--- a/deploy/values/liberty-stack-readout.yaml
+++ b/deploy/values/liberty-stack-readout.yaml
@@ -1,5 +1,5 @@
 # liberty-stack-readout — Liberty Stack subject/combined readout API (apps/liberty-stack-readout). Real FastAPI
 # service (built + 9 tests but never shipped). Vendored into CI this PR. tag:latest → sha-pin next build.
-image: { repository: liberty-stack-readout, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: liberty-stack-readout, tag: latest }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }

--- a/deploy/values/memoryd.yaml
+++ b/deploy/values/memoryd.yaml
@@ -2,7 +2,7 @@
 # CI so it builds with the estate's WIF like every other service. Recall/write/retract over a pluggable store;
 # defaults to in-memory (MEMORYMESH_STORE_URI=memory://) so it boots with no database. Point at a Postgres DSN
 # to persist. tag:latest → sha-pinned after first build.
-image: { repository: memoryd, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: memoryd, tag: latest }
 service: { port: 8787, portName: http }
 config:
   MEMORYMESH_STORE_URI: "memory://"

--- a/deploy/values/node-commander.yaml
+++ b/deploy/values/node-commander.yaml
@@ -1,5 +1,5 @@
 # node-commander — node runtime control API (status/heartbeat over the node runtime), vendored into CI this PR.
 # apps/node-commander. Real FastAPI service (was built + tested but never shipped). tag:latest → sha-pin next build.
-image: { repository: node-commander, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: node-commander, tag: latest }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }

--- a/deploy/values/osm-map-api.yaml
+++ b/deploy/values/osm-map-api.yaml
@@ -1,4 +1,4 @@
 # osm-map-api
-image: { repository: osm-map-api, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: osm-map-api, tag: latest }
 service: { port: 8088, portName: http }  # app binds 8088 (uvicorn); chart uses this for containerPort + probes
 enableServiceLinks: false   # k8s injects OSM_MAP_API_PORT=tcp://<svc> otherwise → app int() crash

--- a/deploy/values/owl-reasoner.yaml
+++ b/deploy/values/owl-reasoner.yaml
@@ -2,7 +2,7 @@
 # Ontogenesis-class inference (rdflib/owlrl/pyshacl) onto the graph: entails knowledge derivable but not
 # stated, over the KKO upper ontology — Protégé/Stardog reasoner parity, proof-carrying. Reasons over raw
 # Turtle or pulls a project's KKO-typed graph from lattice-studio. tag:latest → sha-pinned after first build.
-image: { repository: owl-reasoner, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: owl-reasoner, tag: latest }
 service: { port: 8080, portName: http }
 config:
   LATTICE_STUDIO_URL: "http://lattice-studio:8080"

--- a/deploy/values/reasoning-failure-runner.yaml
+++ b/deploy/values/reasoning-failure-runner.yaml
@@ -3,5 +3,5 @@
 # imagePullPolicy: IfNotPresent, so a moving tag means a node that cached `latest` never pulls a newer
 # image and `rollout restart` re-runs the stale one. sha-92f471… = the last green images.yml build's
 # full-matrix publish of this image. Bump to a newer sha- tag on each release.
-image: { repository: reasoning-failure-runner, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: reasoning-failure-runner, tag: sha-e69549d48820c5ff34f0dd03c1ceadc9967c9ed7 }
 service: { port: 8080, portName: http }

--- a/deploy/values/regis-acr-api.yaml
+++ b/deploy/values/regis-acr-api.yaml
@@ -1,6 +1,6 @@
 # regis-acr-api — Regis Attested Concordance Record API (apps/regis-acr-api). The provenance/registry surface
 # for the entity-resolution + evidence spine (ACR concordance records, decision-ledger reads). It BUILDS in CI
 # but was never scheduled — this wires it into the ApplicationSet. tag:latest → sha-pinned after next build.
-image: { repository: regis-acr-api, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: regis-acr-api, tag: latest }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }

--- a/deploy/values/search-gateway.yaml
+++ b/deploy/values/search-gateway.yaml
@@ -4,7 +4,7 @@
 #
 # Pin the immutable sha- tag the build published (the no-moving-tag standard). This is the merge-commit sha of
 # PR #751 (the service+build); bump it as the service is rebuilt.
-image: { repository: search-gateway, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: search-gateway, tag: sha-e69549d48820c5ff34f0dd03c1ceadc9967c9ed7 }
 service: { port: 8080, portName: http }
 # The server serves /healthz (the chart default) — no probes.path override needed.
 config:

--- a/deploy/values/search-orchestrator.yaml
+++ b/deploy/values/search-orchestrator.yaml
@@ -1,4 +1,4 @@
 # search-orchestrator — search/index daemon
-image: { repository: search-orchestrator, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: search-orchestrator, tag: latest }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 4 }

--- a/deploy/values/socioprophet-web.yaml
+++ b/deploy/values/socioprophet-web.yaml
@@ -7,7 +7,7 @@
 # published to `latest` in GAR and the nodes kept serving the cached digest.
 # sha-2ff20cbd... = merge of #726 (nginx port/healthz contract fix),
 # digest sha256:50ef50bf14fb64f0eca84ac393bf0124c72840499ed1a0e5daa82182c45d71bf.
-image: { repository: socioprophet-web, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: socioprophet-web, tag: sha-e69549d48820c5ff34f0dd03c1ceadc9967c9ed7 }
 service: { port: 8080, portName: http }
 ingress:
   enabled: true

--- a/deploy/values/spark-runner.yaml
+++ b/deploy/values/spark-runner.yaml
@@ -1,6 +1,6 @@
 # spark-runner — the sovereign Apache Spark execution backend for the Studio execution plane (apps/spark-runner).
 # Pinned to the immutable sha- tag from the apps/spark-runner build (never a moving :latest).
-image: { repository: spark-runner, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: spark-runner, tag: sha-e69549d48820c5ff34f0dd03c1ceadc9967c9ed7 }
 service: { port: 8080, portName: http }
 # server serves /healthz (chart default).
 config:

--- a/deploy/values/tritfabric-consumption-api.yaml
+++ b/deploy/values/tritfabric-consumption-api.yaml
@@ -2,6 +2,6 @@
 # Reports readiness for the four TritFabric surfaces (community-learning intake, framework catalog, promotion
 # evidence, serve readiness) from the integration contract — deliberately NON-mutating (mutation_authorized:false),
 # a pre-infrastructure readiness reporter, not the Serve runtime. tag:latest → sha-pinned after first build.
-image: { repository: tritfabric-consumption-api, tag: sha-20e0586644fdbb5d46b73bef0017f3ee3fba7bca }
+image: { repository: tritfabric-consumption-api, tag: latest }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }


### PR DESCRIPTION
Prod-fragility fix (self-inflicted). The gitops catch-up commit a15978e pinned all 28 services to sha-20e0586644fd — the sha of the workflow-only #849 commit. images.yml is path-filtered, so that commit built NO app images, leaving every service pointing at a non-existent image -> estate-wide ImagePullBackOff on new pods (old pods kept serving, so no outage, but every rollout wedged). Reverting restores each service to its previous valid pin. Follow-up: the catch-up must verify image existence before pinning, and must not be triggered after non-image commits.