### PR TITLE
gitops-promote: never promote to a commit that built no images (root-cause guard)

### DIFF
--- a/.github/workflows/gitops-promote.yml
+++ b/.github/workflows/gitops-promote.yml
@@ -51,6 +51,13 @@ jobs:
           fi
           echo "promoting to sha-$SHA (all=$ALL)"
 
+          # GUARD: a commit that changed no app/service source built NO images, so
+          # promoting to it creates dangling pins → estate-wide ImagePullBackOff.
+          # (This is the root cause of the 2026-07-18 incident.) Bail out cleanly.
+          if ! git show --name-only --pretty="" "$SHA" | grep -qE '^(apps|services)/'; then
+            echo "sha-$SHA changed no service source → no images built → nothing to promote"; exit 0
+          fi
+
           if [ "$ALL" = "true" ]; then
             # one-time catch-up: every values file that pins a sha- tag
             FILES=$(grep -lE 'tag: (sha-[0-9a-f]+|latest)\b' deploy/values/*.yaml 2>/dev/null || true)


### PR DESCRIPTION
Root cause of the dangling-pin incident: a workflow-only commit built no images, but the catch-up still pinned all 28 services to its sha → estate-wide ImagePullBackOff. Guard: if the target sha changed no `apps/**`|`services/**` source, exit 0. Safe for both per-commit and catch-up paths.