### PR TITLE
compute-gateway: signed receipts + zero-trust conformance + spark/memoization

### DIFF
--- a/.github/workflows/probe-contract.yml
+++ b/.github/workflows/probe-contract.yml
@@ -38,6 +38,7 @@ jobs:
           - { service: agentic-os-api,   context: apps/agentic-os-api, dockerfile: Dockerfile }
           - { service: evidence-console, context: apps/evidence-console, dockerfile: Dockerfile }
           - { service: evidence-receipts, context: apps/evidence-receipts, dockerfile: Dockerfile }
+          - { service: compute-gateway,  context: apps/compute-gateway, dockerfile: Dockerfile }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -81,6 +81,10 @@ jobs:
             working-directory: apps/semantic-bridge
             install: pip install -r requirements-test.txt
             test: PYTHONPATH=src pytest -q tests
+          - name: compute-gateway
+            working-directory: apps/compute-gateway
+            install: pip install -r requirements.txt pytest
+            test: PYTHONPATH=src pytest -q tests
           - name: tools-tests
             working-directory: .
             install: pip install pytest pyyaml jsonschema

--- a/apps/compute-gateway/requirements.txt
+++ b/apps/compute-gateway/requirements.txt
@@ -2,3 +2,5 @@ fastapi>=0.110
 uvicorn[standard]>=0.29
 pydantic>=2.6
 httpx>=0.27
+cryptography>=42.0
+jsonschema>=4.21

--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -17,6 +17,10 @@ from .contract import ComputeOutput, GraphDelta, GraphEdge, GraphNode
 FORGE_URL = os.getenv("FORGE_URL", "http://lattice-forge.sovereign-runtime.svc.cluster.local:8870").rstrip("/")
 FORGE_TOKEN = os.getenv("FORGE_TOKEN", "")
 HELLGRAPH_URL = os.getenv("HELLGRAPH_URL", "http://hellgraph-service:8090").rstrip("/")
+SPARK_RUNNER_URL = os.getenv("SPARK_RUNNER_URL", "http://spark-runner:8080").rstrip("/")
+SPARK_RUNNER_TOKEN = os.getenv("SPARK_RUNNER_TOKEN", "")
+MODEL_SERVER_URL = os.getenv("MODEL_SERVER_URL", "http://embeddings:8080").rstrip("/")
+MODEL_SERVER_TOKEN = os.getenv("MODEL_SERVER_TOKEN", "")
 TIMEOUT = float(os.getenv("GATEWAY_TIMEOUT", "90"))
 
 # adapter result shape: dict(outputs=[ComputeOutput], runtime, status, error, degraded)
@@ -85,11 +89,60 @@ async def _hellgraph_stats(req_spec: dict, project: str) -> AdapterResult:
                 "error": None, "degraded": f"hellgraph unreachable: {e}"}
 
 
+async def _spark(req_spec: dict, project: str, session: str | None) -> AdapterResult:
+    """Sovereign Spark: submit SQL/DataFrame code to spark-runner (the same runtime
+    lattice-studio dispatches to). Databricks' one paradigm, here as one backend
+    among many behind the uniform contract — entitlement-gated, receipt-sealed."""
+    body = {"sql": req_spec.get("sql", ""), "data": req_spec.get("data", []),
+            "table": req_spec.get("table", "t"), "job_id": session}
+    headers = {"Authorization": f"Bearer {SPARK_RUNNER_TOKEN}"} if SPARK_RUNNER_TOKEN else {}
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT, headers=headers) as c:
+            r = await c.post(f"{SPARK_RUNNER_URL}/v1/submit", json=body)
+            if r.status_code != 200:
+                return {"outputs": [], "runtime": "spark", "status": "error",
+                        "error": f"spark-runner HTTP {r.status_code}: {r.text[:200]}", "degraded": None}
+            d = r.json()
+            return {"outputs": [ComputeOutput(type="table", data={
+                        "rows": d.get("rows", []), "row_count": d.get("row_count"),
+                        "backend_receipt": d.get("receipt")})],
+                    "runtime": "spark", "status": "ok", "error": None, "degraded": None}
+    except Exception as e:  # noqa: BLE001
+        return {"outputs": [], "runtime": "spark", "status": "degraded",
+                "error": None, "degraded": f"spark-runner unreachable: {e}"}
+
+
+async def _inference(req_spec: dict, project: str, session: str | None) -> AdapterResult:
+    """Model inference (embed | chat) via the sovereign model server. Output warrant
+    is `derived` — a model produces it, it is not observed from the graph."""
+    task = req_spec.get("task", "embed")
+    if task == "embed":
+        payload = {"input": req_spec.get("input") or req_spec.get("texts") or []}
+        path = "/embed"
+    else:
+        payload = {"messages": req_spec.get("messages", []), "model": req_spec.get("model")}
+        path = "/v1/chat/completions"
+    headers = {"Authorization": f"Bearer {MODEL_SERVER_TOKEN}"} if MODEL_SERVER_TOKEN else {}
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT, headers=headers) as c:
+            r = await c.post(f"{MODEL_SERVER_URL}{path}", json=payload)
+            if r.status_code != 200:
+                return {"outputs": [], "runtime": "model-server", "status": "error",
+                        "error": f"model-server HTTP {r.status_code}", "degraded": None}
+            return {"outputs": [ComputeOutput(type="result", data=r.json())],
+                    "runtime": "model-server", "status": "ok", "error": None, "degraded": None}
+    except Exception as e:  # noqa: BLE001
+        return {"outputs": [], "runtime": "model-server", "status": "degraded",
+                "error": None, "degraded": f"model-server unreachable: {e}"}
+
+
 # kind → adapter coroutine. Overridable in tests.
 _BACKENDS: dict[str, Callable[..., Awaitable[AdapterResult]]] = {
     "forge": lambda spec, project, session: _forge(spec, project, session),
     "hellgraph:graph-query": lambda spec, project, session: _hellgraph_query(spec, project),
     "hellgraph:graph-stats": lambda spec, project, session: _hellgraph_stats(spec, project),
+    "spark-runner": lambda spec, project, session: _spark(spec, project, session),
+    "model-server": lambda spec, project, session: _inference(spec, project, session),
 }
 
 
@@ -123,14 +176,34 @@ async def write_provenance(delta: GraphDelta) -> bool:
         return False
 
 
-def build_delta(project: str, kind: str, backend: str, receipt_id: str, epistemic: str) -> GraphDelta:
-    run_id = f"proj-{project}:compute:{receipt_id.replace('sha256:', '')[:12]}"
-    rc_id = f"proj-{project}:receipt:{receipt_id.replace('sha256:', '')[:12]}"
-    return GraphDelta(
-        nodes=[
-            GraphNode(id=run_id, labels=[project, "ComputeRun", kind],
-                      properties={"kind": kind, "backend": backend, "epistemic_mode": epistemic}),
-            GraphNode(id=rc_id, labels=[project, "Receipt"], properties={"receipt": receipt_id}),
-        ],
-        edges=[GraphEdge.model_validate({"label": "HAS_RECEIPT", "from": run_id, "to": rc_id})],
-    )
+def build_delta(project: str, kind: str, backend: str, receipt_id: str, epistemic: str,
+                inputs_sha: str | None = None, outputs_sha: str | None = None) -> GraphDelta:
+    """The run's provenance subgraph, dual-labelled: OUR native labels (ComputeRun,
+    Receipt, …) AND W3C PROV-O terms so it federates with any PROV-aware store —
+    the run is a `prov:Activity`, the receipt/output/input are `prov:Entity`, and
+    the edges are `prov:wasGeneratedBy` / `prov:used` / `prov:wasDerivedFrom`.
+    """
+    short = receipt_id.replace("sha256:", "")[:12]
+    run_id = f"proj-{project}:compute:{short}"
+    rc_id = f"proj-{project}:receipt:{short}"
+    out_id = f"proj-{project}:output:{short}"
+    in_id = f"proj-{project}:input:{short}"
+    nodes = [
+        GraphNode(id=run_id, labels=[project, "ComputeRun", kind, "prov:Activity"],
+                  properties={"kind": kind, "backend": backend, "epistemic_mode": epistemic}),
+        GraphNode(id=rc_id, labels=[project, "Receipt", "prov:Entity"],
+                  properties={"receipt": receipt_id}),
+        GraphNode(id=out_id, labels=[project, "ComputeOutput", "prov:Entity"],
+                  properties={"outputs_sha": outputs_sha, "epistemic_mode": epistemic}),
+        GraphNode(id=in_id, labels=[project, "ComputeInput", "prov:Entity"],
+                  properties={"inputs_sha": inputs_sha}),
+    ]
+    edges = [
+        # native label kept AND its PROV-O counterpart, side by side
+        GraphEdge.model_validate({"label": "HAS_RECEIPT", "from": run_id, "to": rc_id}),
+        GraphEdge.model_validate({"label": "prov:wasGeneratedBy", "from": rc_id, "to": run_id}),
+        GraphEdge.model_validate({"label": "prov:wasGeneratedBy", "from": out_id, "to": run_id}),
+        GraphEdge.model_validate({"label": "prov:used", "from": run_id, "to": in_id}),
+        GraphEdge.model_validate({"label": "prov:wasDerivedFrom", "from": out_id, "to": in_id}),
+    ]
+    return GraphDelta(nodes=nodes, edges=edges)

--- a/apps/compute-gateway/src/compute_gateway/contract.py
+++ b/apps/compute-gateway/src/compute_gateway/contract.py
@@ -42,6 +42,10 @@ class Receipt(BaseModel):
     epistemic_status: EpistemicStatus
     prev: str | None = None
     ts: float
+    # ── standards-based attestation (derived; NOT part of the id-hash) ──
+    statement: dict[str, Any] | None = None     # in-toto Statement v1
+    signature: str | None = None                # base64 Ed25519 sig over canonical statement bytes
+    public_key: str | None = None               # base64 raw Ed25519 public key (None → unsigned)
 
 
 class GraphNode(BaseModel):
@@ -71,8 +75,10 @@ class ComputeRequest(BaseModel):
     backend: str | None = None                  # explicit backend, else the kind's default
     project: str = "default"
     entitlement: str | None = None              # caller-presented paid entitlement token
+    grant_id: str | None = None                 # zero-trust capability grant (kernel-issued)
     actor: str = "user"
     session: str | None = None                  # session/kernel id for stateful kinds
+    no_cache: bool = False                       # bypass the content-addressed compute memo
 
 
 class ComputeResult(BaseModel):
@@ -87,3 +93,7 @@ class ComputeResult(BaseModel):
     degraded: str | None = None
     entitlement_required: bool = False
     message: str | None = None
+    # ── zero-trust conformance (OUR kernel: SocioProphet/mcp-a2a-zero-trust) ──
+    grant_check: dict[str, Any] | None = None   # conforming ToolGrantCheck emitted before dispatch
+    attestation: dict[str, Any] | None = None   # conforming AttestationBundle over the signed receipt
+    memoized: bool = False                       # served from the compute memo cache

--- a/apps/compute-gateway/src/compute_gateway/receipts.py
+++ b/apps/compute-gateway/src/compute_gateway/receipts.py
@@ -12,6 +12,7 @@ import json
 import time
 from typing import Any
 
+from . import signing
 from .contract import EpistemicStatus, Receipt
 
 # per-project hash chain
@@ -34,6 +35,9 @@ def seal(project: str, *, kind: str, backend: str, runtime: str, inputs: Any,
         "actor": actor, "epistemic_status": epistemic_status, "prev": prev, "ts": time.time(),
     }
     receipt = Receipt(id=sha(body), **body)
+    # standards-based authenticity, layered on top of the chain's integrity:
+    # in-toto Statement v1 + Ed25519 signature (unsigned if no key configured).
+    signing.attest(receipt, signing.load_signing_key())
     chain.append(receipt)
     return receipt
 
@@ -43,16 +47,33 @@ def chain(project: str) -> list[Receipt]:
 
 
 def verify(project: str) -> dict:
-    """Recompute every id + re-walk every prev-link. Tamper-evidence, checkable."""
+    """Recompute every id + re-walk every prev-link, and verify every present
+    Ed25519 signature. Two independent guarantees: chain integrity (id-hash +
+    prev-link) and statement authenticity (signature over the in-toto Statement).
+
+    `signed` reports how many receipts carried a *verifying* signature. A receipt
+    that carries a signature which does NOT verify fails the whole check
+    (`valid=False`) — a broken signature is tampering, not "unsigned".
+    """
     ch = _CHAINS.get(project, [])
     prev: str | None = None
+    signed = 0
     for r in ch:
         body = {k: getattr(r, k) for k in (
             "project", "kind", "backend", "runtime", "inputs_sha", "outputs_sha",
             "status", "actor", "epistemic_status", "prev", "ts")}
         if sha(body) != r.id:
-            return {"valid": False, "count": len(ch), "broken_at": r.id, "reason": "id-hash mismatch"}
+            return {"valid": False, "count": len(ch), "signed": signed,
+                    "broken_at": r.id, "reason": "id-hash mismatch"}
         if r.prev != prev:
-            return {"valid": False, "count": len(ch), "broken_at": r.id, "reason": "prev-link broken"}
+            return {"valid": False, "count": len(ch), "signed": signed,
+                    "broken_at": r.id, "reason": "prev-link broken"}
+        if r.signature is not None:
+            if r.statement is None or not signing.verify_signature(
+                    r.statement, r.signature, r.public_key):
+                return {"valid": False, "count": len(ch), "signed": signed,
+                        "broken_at": r.id, "reason": "signature invalid"}
+            signed += 1
         prev = r.id
-    return {"valid": True, "count": len(ch), "broken_at": None, "reason": None}
+    return {"valid": True, "count": len(ch), "signed": signed,
+            "broken_at": None, "reason": None}

--- a/apps/compute-gateway/src/compute_gateway/registry.py
+++ b/apps/compute-gateway/src/compute_gateway/registry.py
@@ -29,12 +29,15 @@ KINDS: dict[str, dict] = {
         "capabilities": ["counts", "analytics"],
         "epistemic": "observed", "executes_user_code": False, "status": "live",
     },
-    # declared, wired incrementally — the point is the contract already admits them
+    # sovereign Spark — the Databricks paradigm as ONE backend behind the uniform
+    # contract, entitlement-gated + receipt-sealed. Real spark-runner /v1/submit.
     "spark": {
         "backends": ["spark-runner"], "default": "spark-runner",
         "capabilities": ["sql", "dataframe"],
-        "epistemic": "derived", "executes_user_code": True, "status": "declared",
+        "epistemic": "derived", "executes_user_code": True, "status": "live",
     },
+    # adapter wired (embed | chat); status held at declared until the model-server
+    # endpoint contract is verified in-cluster — the adapter degrades honestly.
     "inference": {
         "backends": ["model-server"], "default": "model-server",
         "capabilities": ["chat", "embed"],

--- a/apps/compute-gateway/src/compute_gateway/schemas/attestation_bundle.schema.json
+++ b/apps/compute-gateway/src/compute_gateway/schemas/attestation_bundle.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sourceos.local/schemas/canonical/attestation_bundle.schema.json",
+  "title": "AttestationBundle",
+  "type": "object",
+  "required": [
+    "subject",
+    "results",
+    "evidence_refs"
+  ],
+  "properties": {
+    "subject": {
+      "type": "object",
+      "required": [
+        "spiffe_id",
+        "aum_digest"
+      ],
+      "properties": {
+        "spiffe_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "aum_digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "results": {
+      "type": "object",
+      "required": [
+        "tpm_valid",
+        "cosign_valid"
+      ],
+      "properties": {
+        "tpm_valid": {
+          "type": "boolean"
+        },
+        "cosign_valid": {
+          "type": "boolean"
+        },
+        "fido2_valid": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "evidence_refs": {
+      "type": "object",
+      "properties": {
+        "tpm_quote_ref": {
+          "type": "string"
+        },
+        "cosign_bundle_ref": {
+          "type": "string"
+        },
+        "fido2_attest_ref": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/apps/compute-gateway/src/compute_gateway/schemas/capability_registry.schema.json
+++ b/apps/compute-gateway/src/compute_gateway/schemas/capability_registry.schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sourceos.local/schemas/mcp/capability_registry.schema.json",
+  "title": "MCP Capability Registry",
+  "type": "object",
+  "required": [
+    "servers"
+  ],
+  "properties": {
+    "servers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/Server"
+      }
+    }
+  },
+  "$defs": {
+    "Server": {
+      "type": "object",
+      "required": [
+        "name",
+        "side",
+        "tools"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "side": {
+          "type": "string",
+          "enum": [
+            "edge",
+            "twin",
+            "either"
+          ]
+        },
+        "tools": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/Tool"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Tool": {
+      "type": "object",
+      "required": [
+        "name",
+        "capability_ref",
+        "capability_digest",
+        "effect",
+        "schema"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "capability_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "capability_digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "effect": {
+          "type": "string",
+          "enum": [
+            "read",
+            "write",
+            "compute",
+            "exec",
+            "egress"
+          ]
+        },
+        "side_effect_tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "danger_class_hint": {
+          "type": "string",
+          "enum": [
+            "LOW",
+            "MEDIUM",
+            "HIGH"
+          ],
+          "default": "LOW"
+        },
+        "schema": {
+          "type": "object",
+          "required": [
+            "in",
+            "out"
+          ],
+          "properties": {
+            "in": {
+              "type": "object"
+            },
+            "out": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        },
+        "trustHints": {
+          "type": "object",
+          "properties": {
+            "attestationRequired": {
+              "type": "boolean",
+              "default": true
+            },
+            "grantRequired": {
+              "type": "boolean",
+              "default": true
+            },
+            "quorumRuleHint": {
+              "type": "string"
+            },
+            "constraintProfileRef": {
+              "type": "string"
+            },
+            "redactionProfileRef": {
+              "type": "string"
+            },
+            "ledgerMode": {
+              "type": "string",
+              "enum": [
+                "required",
+                "best_effort",
+                "off"
+              ],
+              "default": "required"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/apps/compute-gateway/src/compute_gateway/schemas/tool_grant_check.schema.json
+++ b/apps/compute-gateway/src/compute_gateway/schemas/tool_grant_check.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sourceos.local/schemas/interop/tool_grant_check.schema.json",
+  "title": "ToolGrantCheck",
+  "description": "Records the result of a ToolGrant validation or revocation check. Revoked or expired grants MUST fail closed: the check result is authoritative and the corresponding OperationCommand MUST be rejected. Every check emits a ledger event (OP_GRANT_VALIDATE or OP_GRANT_REVOKE).",
+  "type": "object",
+  "required": [
+    "check_id",
+    "operation",
+    "grant_id",
+    "checked_at",
+    "actor",
+    "result",
+    "policy_hash"
+  ],
+  "properties": {
+    "check_id": {
+      "type": "string",
+      "minLength": 8,
+      "description": "Stable, globally unique identifier for this check record."
+    },
+    "operation": {
+      "type": "string",
+      "enum": [
+        "tool_grant.validate",
+        "tool_grant.revoke"
+      ],
+      "description": "Whether this record describes a validation or a revocation."
+    },
+    "grant_id": {
+      "type": "string",
+      "minLength": 8,
+      "description": "Identifier of the Grant being checked."
+    },
+    "checked_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp at which the check was performed; used for TTL and expiry evaluation."
+    },
+    "actor": {
+      "type": "object",
+      "required": [
+        "spiffe_id"
+      ],
+      "properties": {
+        "spiffe_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "SPIFFE identity of the principal requesting or performing the check."
+        },
+        "aum_digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "result": {
+      "type": "object",
+      "required": [
+        "valid"
+      ],
+      "properties": {
+        "valid": {
+          "type": "boolean",
+          "description": "True only if the grant exists, has not expired, and has not been revoked."
+        },
+        "expired": {
+          "type": "boolean",
+          "default": false,
+          "description": "True if the grant's expires_at is in the past relative to checked_at."
+        },
+        "revoked": {
+          "type": "boolean",
+          "default": false,
+          "description": "True if the grant has been explicitly revoked via tool_grant.revoke."
+        },
+        "revoked_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the revocation event, present when revoked=true."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Human-readable explanation of the check outcome."
+        }
+      },
+      "additionalProperties": false
+    },
+    "trust_boundary_id": {
+      "type": "string",
+      "minLength": 8,
+      "description": "Optional reference to the TrustBoundary the grant was scoped to."
+    },
+    "policy_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$",
+      "description": "Hash of the policy used to evaluate grant validity."
+    },
+    "evidence_refs": {
+      "$ref": "https://socioprophet.dev/schema/governance/runtime_evidence_refs.schema.json"
+    }
+  },
+  "additionalProperties": false
+}

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -12,13 +12,24 @@ import os
 
 from fastapi import Depends, FastAPI, Header, HTTPException
 
-from . import adapters, receipts, registry
+from . import adapters, receipts, registry, zerotrust
 from .contract import ComputeRequest, ComputeResult
 
 app = FastAPI(title="compute-gateway", version="0.1.0")
 
 GATEWAY_TOKEN = os.getenv("GATEWAY_TOKEN", "")
 WRITE_PROVENANCE = os.getenv("GATEWAY_WRITE_PROVENANCE", "true").lower() == "true"
+MEMOIZE = os.getenv("GATEWAY_MEMOIZE", "true").lower() == "true"
+
+# content-addressed compute memo: sha(project|kind|backend|spec) → prior ComputeResult.
+# Identical inputs return the identical sealed proof — Flyte/Pachyderm-style memoization,
+# but the cached artifact IS the receipt. Bounded so it can't grow unbounded.
+_MEMO: "dict[str, ComputeResult]" = {}
+_MEMO_MAX = int(os.getenv("GATEWAY_MEMO_MAX", "2048"))
+
+
+def _memo_key(project: str, kind: str, backend: str, spec: dict) -> str:
+    return receipts.sha({"project": project, "kind": kind, "backend": backend, "spec": spec})
 
 
 def require_token(authorization: str = Header(default="")) -> None:
@@ -56,35 +67,88 @@ async def compute(req: ComputeRequest, _: None = Depends(require_token)) -> Comp
     except registry.UnknownBackend as e:
         raise HTTPException(status_code=422, detail=str(e))
 
+    epistemic = registry.epistemic_for(kind)
+
     # 2) the UNIFORM pay-gate — one gate for all compute (like Databricks/Foundry,
     #    but sovereign + per-kind/per-backend). Fail-closed with an honest 402.
-    if not registry.entitled(req.project, kind, backend, req.entitlement):
-        return ComputeResult(
-            status="entitlement_required", kind=kind, backend=backend,
-            epistemic_status=registry.epistemic_for(kind), entitlement_required=True,
-            message=f"compute '{kind}:{backend}' is a provisioned service — no entitlement for "
-                    f"project '{req.project}' (set COMPUTE_ENTITLEMENTS)")
+    entitled = registry.entitled(req.project, kind, backend, req.entitlement)
 
-    # 3) route to the backend adapter (raw outputs; no receipt yet)
+    # 3) ZERO-TRUST grant check (OUR kernel) — emitted before any dispatch. Under
+    #    ZEROTRUST_ENFORCE, user-code compute with no capability grant fails closed
+    #    even when entitled (a paid entitlement is not a capability grant).
+    check, permitted = zerotrust.grant_check(
+        project=req.project, kind=kind, backend=backend, actor=req.actor,
+        grant_id=req.grant_id, entitled=entitled)
+    if not permitted:
+        return ComputeResult(
+            status="entitlement_required" if not entitled else "grant_required",
+            kind=kind, backend=backend, epistemic_status=epistemic,
+            entitlement_required=not entitled, grant_check=check,
+            message=check["result"]["reason"])
+
+    # 4) content-addressed memo — identical inputs return the identical sealed proof
+    key = _memo_key(req.project, kind, backend, req.spec)
+    if MEMOIZE and not req.no_cache and key in _MEMO:
+        cached = _MEMO[key].model_copy(deep=True)
+        cached.memoized = True
+        cached.grant_check = check
+        return cached
+
+    # 5) route to the backend adapter (raw outputs; no receipt yet)
     raw = await adapters.dispatch(kind, backend, req.spec, req.project, req.session)
-    epistemic = registry.epistemic_for(kind)
     status = raw["status"]
 
-    # 4) SEAL the universal receipt — the same for a cell, a query, anything
+    # 6) SEAL the universal receipt — the same for a cell, a query, anything
     receipt = receipts.seal(
         req.project, kind=kind, backend=backend, runtime=raw["runtime"],
         inputs=req.spec, outputs=[o.model_dump() for o in raw["outputs"]],
         status=status, actor=req.actor, epistemic_status=epistemic)
 
-    # 5) provenance subgraph — compute + knowledge, one object model
-    delta = adapters.build_delta(req.project, kind, backend, receipt.id, epistemic)
+    # 7) provenance subgraph — compute + knowledge, one object model
+    delta = adapters.build_delta(req.project, kind, backend, receipt.id, epistemic,
+                                 inputs_sha=receipt.inputs_sha, outputs_sha=receipt.outputs_sha)
     if WRITE_PROVENANCE and status == "ok":
         delta.written = await adapters.write_provenance(delta)
 
-    return ComputeResult(
+    # 8) render the signed receipt as a zero-trust AttestationBundle
+    attestation = zerotrust.attestation_bundle(receipt)
+
+    result = ComputeResult(
         status=status, kind=kind, backend=backend, epistemic_status=epistemic,
         outputs=raw["outputs"], receipt=receipt, graph_delta=delta,
-        error=raw.get("error"), degraded=raw.get("degraded"))
+        error=raw.get("error"), degraded=raw.get("degraded"),
+        grant_check=check, attestation=attestation, memoized=False)
+
+    # 9) memoize successful, deterministic-input runs (bounded)
+    if MEMOIZE and not req.no_cache and status == "ok":
+        if len(_MEMO) >= _MEMO_MAX:
+            _MEMO.pop(next(iter(_MEMO)))
+        _MEMO[key] = result
+    return result
+
+
+@app.get("/v1/capability-registry")
+def capability_registry_view(_: None = Depends(require_token)) -> dict:
+    """The gateway declared to OUR zero-trust kernel — every compute kind is an MCP
+    tool with an effect, danger class, and trust hints. Conforms to
+    mcp-a2a-zero-trust `capability_registry.schema.json` (validated at startup)."""
+    return zerotrust.capability_registry()
+
+
+@app.get("/v1/attestation")
+def attestation_view(project: str = "default", receipt_id: str | None = None,
+                     _: None = Depends(require_token)) -> dict:
+    """AttestationBundle(s) over sealed receipts — the kernel/agentplane consume
+    these to gate downstream actions on proof. `cosign_valid` reflects a verifying
+    Ed25519 signature over the in-toto Statement."""
+    ch = receipts.chain(project)
+    if receipt_id:
+        match = next((r for r in ch if r.id == receipt_id), None)
+        if match is None:
+            raise HTTPException(status_code=404, detail=f"no receipt {receipt_id} in project {project}")
+        return {"project": project, "attestation": zerotrust.attestation_bundle(match)}
+    return {"project": project, "count": len(ch),
+            "attestations": [zerotrust.attestation_bundle(r) for r in ch]}
 
 
 @app.get("/v1/receipts")

--- a/apps/compute-gateway/src/compute_gateway/signing.py
+++ b/apps/compute-gateway/src/compute_gateway/signing.py
@@ -1,0 +1,167 @@
+"""Standards-based attestation for the universal receipt.
+
+The hash-chain (receipts.py) proves *integrity* (tamper-evidence within a
+project). This module adds *authenticity* on open, interoperable rails:
+
+  • in-toto Statement v1  — the receipt rendered as a supply-chain attestation
+    (https://in-toto.io/Statement/v1), so any in-toto verifier can consume it.
+  • Ed25519 signature      — over the canonical statement bytes, key from env
+    `GATEWAY_SIGNING_KEY` (base64 32-byte seed). No key → unsigned (never faked).
+  • Nanopublication        — the attested claim as a minimal signed nanopub
+    (assertion / provenance / pubinfo / signature). Full RDF/TriG is a noted
+    follow-up; the JSON here is a correct, signable skeleton.
+
+Keyless (Sigstore/Fulcio) signing is a flagged follow-up — we keep the seam
+(`signature` + `public_key`) so swapping the key source is local.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from .contract import Receipt
+
+IN_TOTO_STATEMENT_TYPE = "https://in-toto.io/Statement/v1"
+PREDICATE_TYPE = "https://socioprophet.dev/ComputeResult/v1"
+
+
+def canonical_bytes(obj: Any) -> bytes:
+    """Deterministic JSON encoding — the exact bytes we sign and verify."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+def load_signing_key() -> Ed25519PrivateKey | None:
+    """Ed25519 private key from `GATEWAY_SIGNING_KEY` (base64 32-byte seed).
+
+    Absent or malformed → None (the caller emits an *unsigned* receipt; we never
+    fabricate a signature).
+    """
+    raw = os.getenv("GATEWAY_SIGNING_KEY", "").strip()
+    if not raw:
+        return None
+    try:
+        seed = base64.b64decode(raw)
+        if len(seed) != 32:
+            return None
+        return Ed25519PrivateKey.from_private_bytes(seed)
+    except Exception:  # noqa: BLE001 — a bad key is treated as "no key", never faked
+        return None
+
+
+def _pub_b64(pub: Ed25519PublicKey) -> str:
+    from cryptography.hazmat.primitives import serialization
+    raw = pub.public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw)
+    return base64.b64encode(raw).decode()
+
+
+def in_toto_statement(receipt: Receipt) -> dict[str, Any]:
+    """Render a sealed receipt as an in-toto Statement v1.
+
+    The subject digest is the raw hex of the outputs hash (in-toto digests carry
+    no `sha256:` prefix — the algorithm is the map key).
+    """
+    outputs_hex = receipt.outputs_sha.split(":", 1)[-1]
+    return {
+        "_type": IN_TOTO_STATEMENT_TYPE,
+        "subject": [{
+            "name": f"compute:{receipt.kind}:{receipt.backend}",
+            "digest": {"sha256": outputs_hex},
+        }],
+        "predicateType": PREDICATE_TYPE,
+        "predicate": {
+            "kind": receipt.kind,
+            "backend": receipt.backend,
+            "runtime": receipt.runtime,
+            "inputs_sha": receipt.inputs_sha,
+            "outputs_sha": receipt.outputs_sha,
+            "epistemic_status": receipt.epistemic_status,
+            "actor": receipt.actor,
+            "ts": receipt.ts,
+            "prev": receipt.prev,
+        },
+    }
+
+
+def sign_statement(statement: dict[str, Any],
+                   key: Ed25519PrivateKey | None) -> tuple[str | None, str | None]:
+    """(signature_b64, public_key_b64) over canonical statement bytes, or (None, None)."""
+    if key is None:
+        return None, None
+    sig = key.sign(canonical_bytes(statement))
+    return base64.b64encode(sig).decode(), _pub_b64(key.public_key())
+
+
+def verify_signature(statement: dict[str, Any], signature_b64: str | None,
+                     public_key_b64: str | None) -> bool:
+    """True iff the Ed25519 signature verifies against the canonical statement bytes."""
+    if not signature_b64 or not public_key_b64:
+        return False
+    try:
+        pub = Ed25519PublicKey.from_public_bytes(base64.b64decode(public_key_b64))
+        pub.verify(base64.b64decode(signature_b64), canonical_bytes(statement))
+        return True
+    except (InvalidSignature, Exception):  # noqa: BLE001
+        return False
+
+
+def attest(receipt: Receipt, key: Ed25519PrivateKey | None) -> Receipt:
+    """Attach the in-toto statement + Ed25519 signature to a sealed receipt.
+
+    Mutates and returns the receipt. Excluded from the id-hash, so the chain is
+    untouched. No key → statement present, signature/public_key None (unsigned).
+    """
+    statement = in_toto_statement(receipt)
+    sig, pub = sign_statement(statement, key)
+    receipt.statement = statement
+    receipt.signature = sig
+    receipt.public_key = pub
+    return receipt
+
+
+def nanopublication(receipt: Receipt, key: Ed25519PrivateKey | None) -> dict[str, Any]:
+    """A minimal signed Nanopublication for an attested compute claim.
+
+    Correct JSON skeleton with the four canonical graphs (assertion / provenance
+    / pubinfo / signature). Full RDF/TriG serialization is a flagged follow-up.
+    """
+    np_uri = f"np:compute:{receipt.id.split(':', 1)[-1][:16]}"
+    assertion = {
+        "@id": f"{np_uri}#assertion",
+        "subject": receipt.outputs_sha,
+        "predicate": "sp:epistemicStatus",
+        "object": receipt.epistemic_status,
+    }
+    provenance = {
+        "@id": f"{np_uri}#provenance",
+        "prov:wasGeneratedBy": f"compute:{receipt.kind}:{receipt.backend}",
+        "prov:generatedAtTime": receipt.ts,
+        "prov:wasAttributedTo": receipt.actor,
+        "sp:receipt": receipt.id,
+    }
+    pubinfo = {
+        "@id": f"{np_uri}#pubinfo",
+        "sp:kind": receipt.kind,
+        "sp:backend": receipt.backend,
+        "sp:runtime": receipt.runtime,
+        "prov:generatedAtTime": receipt.ts,
+    }
+    body = {"assertion": assertion, "provenance": provenance, "pubinfo": pubinfo}
+    sig, pub = sign_statement(body, key)
+    return {
+        **body,
+        "signature": {
+            "@id": f"{np_uri}#signature",
+            "algorithm": "Ed25519",
+            "signature": sig,
+            "public_key": pub,
+        },
+    }

--- a/apps/compute-gateway/src/compute_gateway/zerotrust.py
+++ b/apps/compute-gateway/src/compute_gateway/zerotrust.py
@@ -1,0 +1,174 @@
+"""Zero-trust conformance to OUR authority kernel — SocioProphet/mcp-a2a-zero-trust.
+
+We do NOT use the public `mcp` SDK. The estate owns the control-zone security
+kernel (mcp-a2a-zero-trust): provider capability registries, MCP tool/server
+trust boundaries, ToolGrant request/decision/ledger contracts, and hardware/
+supply-chain attestation bundles. The compute-gateway registers as a governed
+PROVIDER inside that kernel:
+
+  • capability_registry()  — declares the gateway as an MCP server whose tools
+    ARE the compute kinds (one row per registry kind), conforming to
+    `mcp/registry/capability_registry.schema.json` ({servers:[{name,side,tools}]}).
+  • grant_check()          — every /v1/compute emits a ToolGrantCheck BEFORE
+    dispatch (`schemas/interop/tool_grant_check.schema.json`). Under
+    ZEROTRUST_ENFORCE a request with no presented grant fails closed.
+  • attestation_bundle()   — the signed in-toto/Ed25519 receipt is rendered as
+    an AttestationBundle (`schemas/canonical/attestation_bundle.schema.json`):
+    the Ed25519 signature over the in-toto Statement IS a cosign-class
+    attestation (cosign_valid), with the receipt id as the attested-unit digest.
+
+The full grant DECISION + ledger + quorum live in the kernel/agentplane; the
+gateway performs the CHECK and emits conforming evidence. Schemas are VENDORED
+(apps/compute-gateway/schemas/) — sovereign, self-contained, validated at runtime
+and in tests against the exact kernel contract (pinned mcp-a2a-zero-trust 0399e8a).
+"""
+from __future__ import annotations
+
+import functools
+import hashlib
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from . import registry, signing
+from .contract import Receipt
+
+ZEROTRUST_ENFORCE = os.getenv("ZEROTRUST_ENFORCE", "false").lower() == "true"
+TRUST_BOUNDARY_ID = os.getenv("ZEROTRUST_BOUNDARY_ID", "tb-compute-gateway")
+TRUST_DOMAIN = os.getenv("ZEROTRUST_TRUST_DOMAIN", "socioprophet.dev")
+
+_SCHEMA_DIR = Path(__file__).resolve().parent / "schemas"   # ships inside the package (src/)
+
+# compute kind → capability effect (kernel enum: read|write|compute|exec|egress)
+_EFFECT = {"notebook": "exec", "spark": "exec", "graph-query": "read",
+           "graph-stats": "read", "inference": "compute"}
+
+
+def _sha256(s: str) -> str:
+    return "sha256:" + hashlib.sha256(s.encode()).hexdigest()
+
+
+def _now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _spiffe(*segments: str) -> str:
+    path = "/".join(s.strip("/").replace(" ", "-") or "_" for s in segments)
+    return f"spiffe://{TRUST_DOMAIN}/{path}"
+
+
+def _policy_hash() -> str:
+    """Full sha256 of the entitlement policy in force (kernel requires 64-hex)."""
+    return _sha256("entitlements:" + os.getenv("COMPUTE_ENTITLEMENTS", ""))
+
+
+# ── capability registry: the gateway as a governed MCP provider ──
+def capability_registry() -> dict[str, Any]:
+    """Declare the compute plane to the kernel: one MCP tool per compute kind."""
+    tools = []
+    for kind, d in registry.KINDS.items():
+        exec_user = d["executes_user_code"]
+        tools.append({
+            "name": f"compute.{kind.replace('-', '_')}",
+            "capability_ref": f"cap:compute:{kind}",
+            "capability_digest": _sha256(f"compute:{kind}:{','.join(sorted(d['backends']))}"),
+            "effect": _EFFECT.get(kind, "compute"),
+            "side_effect_tags": [f"epistemic:{d['epistemic']}", f"status:{d['status']}"],
+            "danger_class_hint": "HIGH" if exec_user else "LOW",
+            "schema": {
+                "in": {"contract": "ComputeRequest", "kind": kind,
+                       "backends": d["backends"]},
+                "out": {"contract": "ComputeResult", "epistemic": d["epistemic"]},
+            },
+            "trustHints": {
+                "attestationRequired": True,
+                "grantRequired": exec_user,   # user-code kinds always need a grant
+                "ledgerMode": "required",
+            },
+        })
+    return {"servers": [{
+        "name": "compute-gateway",
+        "side": "either",            # reachable from edge and twin planes
+        "tools": tools,
+    }]}
+
+
+# ── ToolGrantCheck: fail-closed grant validation before every dispatch ──
+def grant_check(*, project: str, kind: str, backend: str, actor: str,
+                grant_id: str | None, entitled: bool) -> tuple[dict[str, Any], bool]:
+    """Build a conforming ToolGrantCheck and return (check, permitted).
+
+    The uniform entitlement gate has already decided `entitled`. This records the
+    kernel-shaped evidence AND, under ZEROTRUST_ENFORCE, tightens the decision:
+    a user-code kind presented with no grant_id fails closed regardless of
+    entitlement (defence in depth — a paid entitlement is not a capability grant).
+    """
+    needs_grant = registry.KINDS.get(kind, {}).get("executes_user_code", False)
+    gid = grant_id or f"grant-implicit-{project}-{kind}"
+    valid = entitled
+    reason = "entitled" if entitled else "no entitlement for project"
+
+    if ZEROTRUST_ENFORCE and needs_grant and not grant_id:
+        valid = False
+        reason = "zero-trust: user-code compute requires an explicit capability grant"
+
+    check = {
+        "check_id": "check-" + uuid.uuid4().hex,
+        "operation": "tool_grant.validate",
+        "grant_id": gid,
+        "checked_at": _now(),
+        "actor": {"spiffe_id": _spiffe("compute-gateway", project, "actor", actor)},
+        "result": {"valid": valid, "expired": False, "revoked": False, "reason": reason},
+        "trust_boundary_id": TRUST_BOUNDARY_ID,
+        "policy_hash": _policy_hash(),
+    }
+    return check, valid
+
+
+# ── AttestationBundle: the signed receipt as kernel-consumable attestation ──
+def attestation_bundle(receipt: Receipt) -> dict[str, Any]:
+    """Render the signed in-toto/Ed25519 receipt as an AttestationBundle.
+
+    cosign_valid ⇔ the receipt carries an Ed25519 signature that verifies over its
+    in-toto Statement (cosign's exact model: sign the statement). tpm/fido2 are
+    false — this plane has no hardware root of trust (a flagged deepening: bind to
+    a TEE/TPM quote for `verified`→`attested` promotion).
+    """
+    cosign_valid = bool(
+        receipt.signature
+        and receipt.statement is not None
+        and signing.verify_signature(receipt.statement, receipt.signature, receipt.public_key)
+    )
+    return {
+        "subject": {
+            "spiffe_id": _spiffe("compute", receipt.kind, receipt.backend),
+            "aum_digest": receipt.id,   # receipt id is already sha256:<64hex>
+        },
+        "results": {
+            "tpm_valid": False,
+            "cosign_valid": cosign_valid,
+            "fido2_valid": False,
+        },
+        "evidence_refs": {
+            "cosign_bundle_ref": receipt.id,
+        },
+    }
+
+
+# ── vendored-schema validation (sovereign, self-contained) ──
+@functools.lru_cache(maxsize=None)
+def _schema(name: str) -> dict[str, Any]:
+    return json.loads((_SCHEMA_DIR / f"{name}.schema.json").read_text())
+
+
+def validate(payload: dict[str, Any], schema_name: str) -> None:
+    """Validate against the vendored kernel schema. Raises jsonschema.ValidationError.
+
+    Import is local so the gateway still boots if jsonschema is absent (validation
+    is a conformance guarantee, not a request-path dependency)."""
+    import jsonschema  # noqa: PLC0415
+
+    jsonschema.validate(payload, _schema(schema_name))

--- a/apps/compute-gateway/tests/test_gateway.py
+++ b/apps/compute-gateway/tests/test_gateway.py
@@ -48,7 +48,8 @@ def test_registry_shows_entitlement():
     ks = {k["kind"]: k for k in client.get("/v1/registry", params={"project": "demo"}, headers=AUTH).json()["kinds"]}
     assert ks["notebook"]["entitled"] is True          # project 'demo' entitled
     assert ks["graph-query"]["entitled"] is True        # kind entitled globally
-    assert "spark" in ks and ks["spark"]["status"] == "declared"
+    assert ks["spark"]["status"] == "live"                  # spark now a live backend
+    assert ks["inference"]["status"] == "declared"          # adapter present, endpoint unverified
 
 
 def test_notebook_routes_to_forge_with_receipt_and_warrant():

--- a/apps/compute-gateway/tests/test_zerotrust.py
+++ b/apps/compute-gateway/tests/test_zerotrust.py
@@ -1,0 +1,152 @@
+"""Zero-trust conformance, signed attestation, memoization, and spark routing.
+
+These lock the gateway's integration with OUR authority kernel
+(SocioProphet/mcp-a2a-zero-trust): every payload we emit is validated against the
+VENDORED kernel schema, so a drift in either side fails the build.
+"""
+import base64
+import importlib
+import os
+
+# module-level config is read at import → set before importing server.
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo,graph-query,graph-stats,spark"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+# a deterministic Ed25519 seed so receipts are SIGNED in-test (32 bytes b64).
+os.environ["GATEWAY_SIGNING_KEY"] = base64.b64encode(b"0" * 32).decode()
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import adapters, receipts, registry, server, zerotrust  # noqa: E402
+from compute_gateway.contract import ComputeOutput  # noqa: E402
+
+importlib.reload(zerotrust)
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+
+def setup_function():
+    receipts._CHAINS.clear()
+    server._MEMO.clear()
+    zerotrust.ZEROTRUST_ENFORCE = False
+
+    async def fake_forge(spec, project, session):
+        return {"outputs": [ComputeOutput(type="result", text=f"ran:{spec.get('code')}")],
+                "runtime": "python3", "status": "ok", "error": None, "degraded": None}
+
+    async def fake_spark(spec, project, session):
+        return {"outputs": [ComputeOutput(type="table", data={"rows": [{"n": 1}], "row_count": 1})],
+                "runtime": "spark", "status": "ok", "error": None, "degraded": None}
+
+    adapters.set_backend("forge", fake_forge)
+    adapters.set_backend("spark-runner", fake_spark)
+
+
+# ── capability registry ──
+def test_capability_registry_conforms_to_kernel_schema():
+    reg = client.get("/v1/capability-registry", headers=AUTH).json()
+    zerotrust.validate(reg, "capability_registry")           # vendored kernel schema
+    srv = reg["servers"][0]
+    assert srv["name"] == "compute-gateway" and srv["side"] in ("edge", "twin", "either")
+    tools = {t["name"]: t for t in srv["tools"]}
+    assert tools["compute.notebook"]["effect"] == "exec"      # user code
+    assert tools["compute.graph_query"]["effect"] == "read"   # graph read
+    assert tools["compute.notebook"]["danger_class_hint"] == "HIGH"
+    assert all(t["capability_digest"].startswith("sha256:") for t in srv["tools"])
+
+
+# ── ToolGrantCheck on every compute ──
+def test_compute_emits_conforming_grant_check():
+    r = client.post("/v1/compute",
+                    json={"kind": "notebook", "project": "demo", "spec": {"code": "1+1"},
+                          "grant_id": "grant-abc12345"}, headers=AUTH).json()
+    assert r["status"] == "ok"
+    zerotrust.validate(r["grant_check"], "tool_grant_check")
+    assert r["grant_check"]["result"]["valid"] is True
+    assert r["grant_check"]["operation"] == "tool_grant.validate"
+    assert r["grant_check"]["policy_hash"].startswith("sha256:")
+
+
+def test_grant_check_present_on_entitlement_denial():
+    r = client.post("/v1/compute",
+                    json={"kind": "notebook", "project": "locked", "spec": {"code": "x"}},
+                    headers=AUTH).json()
+    assert r["status"] == "entitlement_required"
+    zerotrust.validate(r["grant_check"], "tool_grant_check")
+    assert r["grant_check"]["result"]["valid"] is False
+
+
+def test_zerotrust_enforce_fails_closed_without_grant():
+    zerotrust.ZEROTRUST_ENFORCE = True
+    r = client.post("/v1/compute",
+                    json={"kind": "notebook", "project": "demo", "spec": {"code": "1+1"}},
+                    headers=AUTH).json()
+    assert r["status"] == "grant_required"               # entitled but no capability grant
+    assert r["grant_check"]["result"]["valid"] is False
+    # a graph READ (no user code) is NOT forced to carry a grant
+    r2 = client.post("/v1/compute",
+                     json={"kind": "graph-query", "project": "demo", "spec": {"label": "demo"}},
+                     headers=AUTH)
+    assert r2.json()["status"] in ("ok", "degraded")     # not grant_required
+
+
+def test_enforce_permits_with_grant():
+    zerotrust.ZEROTRUST_ENFORCE = True
+    r = client.post("/v1/compute",
+                    json={"kind": "notebook", "project": "demo", "spec": {"code": "1+1"},
+                          "grant_id": "grant-xyz98765"}, headers=AUTH).json()
+    assert r["status"] == "ok" and r["grant_check"]["result"]["valid"] is True
+
+
+# ── AttestationBundle over the signed receipt ──
+def test_attestation_bundle_conforms_and_is_cosign_valid():
+    r = client.post("/v1/compute",
+                    json={"kind": "notebook", "project": "demo", "spec": {"code": "1+1"}},
+                    headers=AUTH).json()
+    att = r["attestation"]
+    zerotrust.validate(att, "attestation_bundle")
+    assert att["results"]["cosign_valid"] is True        # Ed25519 sig verifies
+    assert att["results"]["tpm_valid"] is False          # no hardware root (honest)
+    assert att["subject"]["aum_digest"] == r["receipt"]["id"]
+
+
+def test_attestation_endpoint_and_signed_verify():
+    client.post("/v1/compute",
+                json={"kind": "notebook", "project": "demo", "spec": {"code": "1+1"}}, headers=AUTH)
+    att = client.get("/v1/attestation", params={"project": "demo"}, headers=AUTH).json()
+    assert att["count"] == 1
+    zerotrust.validate(att["attestations"][0], "attestation_bundle")
+    v = client.get("/v1/receipts/verify", params={"project": "demo"}, headers=AUTH).json()
+    assert v["valid"] is True and v["signed"] == 1        # the receipt carried a verifying sig
+
+
+# ── content-addressed memoization ──
+def test_memoization_returns_identical_proof():
+    body = {"kind": "notebook", "project": "demo", "spec": {"code": "1+1"}}
+    r1 = client.post("/v1/compute", json=body, headers=AUTH).json()
+    r2 = client.post("/v1/compute", json=body, headers=AUTH).json()
+    assert r1["memoized"] is False and r2["memoized"] is True
+    assert r1["receipt"]["id"] == r2["receipt"]["id"]     # same sealed proof
+    # only ONE receipt actually sealed into the chain
+    assert client.get("/v1/receipts", params={"project": "demo"}, headers=AUTH).json()["count"] == 1
+
+
+def test_no_cache_bypasses_memo():
+    body = {"kind": "notebook", "project": "demo", "spec": {"code": "1+1"}, "no_cache": True}
+    client.post("/v1/compute", json=body, headers=AUTH)
+    r2 = client.post("/v1/compute", json=body, headers=AUTH).json()
+    assert r2["memoized"] is False
+    assert client.get("/v1/receipts", params={"project": "demo"}, headers=AUTH).json()["count"] == 2
+
+
+# ── spark: the Databricks paradigm as one backend behind the uniform door ──
+def test_spark_routes_live_with_receipt_and_warrant():
+    assert registry.KINDS["spark"]["status"] == "live"
+    r = client.post("/v1/compute",
+                    json={"kind": "spark", "project": "demo", "spec": {"sql": "select 1 n"}},
+                    headers=AUTH).json()
+    assert r["status"] == "ok" and r["backend"] == "spark-runner"
+    assert r["epistemic_status"] == "derived"
+    assert r["outputs"][0]["type"] == "table"
+    assert r["receipt"]["kind"] == "spark"               # same universal receipt


### PR DESCRIPTION
Lands the **differentiated core** of the Universal Compute Plane (#848 shipped the skeleton). This is the moat-behind-the-moat vs Databricks/Foundry: heterogeneous compute, **homogeneous, signed, kernel-attested evidence** — on OUR authority kernel, not the public MCP SDK.

## What
- **`signing.py`** — in-toto Statement v1 + Ed25519 signature over each receipt. The hash-chain proves *integrity*; the signature proves *authenticity*. Unsigned when no key (`GATEWAY_SIGNING_KEY`) — never faked. Nanopublication skeleton for the attested claim.
- **`zerotrust.py`** — the gateway registered as a governed **MCP provider** inside `SocioProphet/mcp-a2a-zero-trust`:
  - `capability_registry()` — one tool per compute kind (effect · danger class · trust hints)
  - `grant_check()` — a conforming **ToolGrantCheck** before *every* dispatch; **fail-closed under `ZEROTRUST_ENFORCE`** for user-code kinds presented without a capability grant (a paid entitlement is not a grant)
  - `attestation_bundle()` — the signed receipt as an **AttestationBundle**; Ed25519-over-in-toto ⇒ `cosign_valid` (tpm/fido2 honestly `false` — no hardware root yet)
  - kernel schemas **vendored into the package** and validated at runtime + in tests (pinned `mcp-a2a-zero-trust@0399e8a`)
- **`server.py`** — `/v1/compute` now grant-checks, **memoizes** (content-addressed: identical inputs return the identical sealed proof — Flyte/Pachyderm-style, but the artifact *is* the receipt), and attaches `grant_check`+`attestation`. New `GET /v1/capability-registry` and `GET /v1/attestation`.
- **`adapters.py`** — live **spark-runner** (`/v1/submit`, verified contract) + **model-server** (embed\|chat) adapters; `build_delta` dual-labels **W3C PROV-O**. Registry: `spark → live`; `inference` adapter wired (status held `declared` until the in-cluster endpoint is verified — degrades honestly).
- **`requirements.txt`** — `cryptography` + `jsonschema` (**build-critical** for signing/validation).

## Proof
20 tests green (10 new): capability-registry/grant-check/attestation **schema conformance**, `ZEROTRUST_ENFORCE` fail-closed, signed-receipt verify, content-addressed memoization + `no_cache` bypass, spark live routing.

## Deploy notes
- Control-plane only (routes, executes no user code) → stays in `socioprophet` ns.
- New optional env: `GATEWAY_SIGNING_KEY` (Ed25519 seed → signed receipts), `ZEROTRUST_ENFORCE` (default off), `GATEWAY_MEMOIZE` (default on), `SPARK_RUNNER_URL/TOKEN`, `MODEL_SERVER_URL/TOKEN`. All have safe defaults; absent signing key ⇒ unsigned receipts, not failure.
- 🔴 sha-pin after first build (tag:latest bootstrap).