### PR TITLE
compute-gateway: workflow kind — governed compute composition

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/engine.py
+++ b/apps/compute-gateway/src/compute_gateway/engine.py
@@ -1,0 +1,197 @@
+"""The compute execution engine — the one gate→grant→memo→route→seal→attest→
+provenance pipeline behind /v1/compute.
+
+Extracted from the endpoint so that COMPOSITE kinds can invoke governed
+sub-computes through the EXACT same path. A `workflow` is a DAG of steps; every
+step is itself a fully-gated, memoized, receipt-sealed, attested compute — so a
+pipeline is heterogeneous compute bound by homogeneous, chained evidence (the
+Flyte/Dagster/Nextflow answer, but proof-carrying + sovereign by construction).
+The workflow seals a COMPOSITE receipt over its ordered step receipts, and its
+epistemic warrant is the WEAKEST link — a pipeline is only as warranted as its
+least-warranted step.
+"""
+from __future__ import annotations
+
+import os
+
+from . import adapters, receipts, registry, zerotrust
+from .contract import ComputeOutput, ComputeRequest, ComputeResult, GraphEdge
+
+MEMOIZE = os.getenv("GATEWAY_MEMOIZE", "true").lower() == "true"
+WRITE_PROVENANCE = os.getenv("GATEWAY_WRITE_PROVENANCE", "true").lower() == "true"
+MAX_WORKFLOW_DEPTH = int(os.getenv("GATEWAY_MAX_WORKFLOW_DEPTH", "3"))
+
+# content-addressed compute memo: sha(project|kind|backend|spec) → prior ComputeResult.
+_MEMO: dict[str, ComputeResult] = {}
+_MEMO_MAX = int(os.getenv("GATEWAY_MEMO_MAX", "2048"))
+
+# the epistemic ladder, weakest → strongest (for the workflow weakest-link warrant)
+_LADDER = ["unknown", "hypothesis", "simulated", "observed", "derived", "verified", "attested"]
+
+
+def memo_key(project: str, kind: str, backend: str, spec: dict) -> str:
+    return receipts.sha({"project": project, "kind": kind, "backend": backend, "spec": spec})
+
+
+def _weakest(warrants: list[str]) -> str:
+    if not warrants:
+        return "unknown"
+    return min(warrants, key=lambda w: _LADDER.index(w) if w in _LADDER else 0)
+
+
+class WorkflowError(ValueError):
+    pass
+
+
+def _topo_order(steps: list[dict]) -> list[dict]:
+    """Kahn topological sort of steps by their `needs`. Raises on unknown dep or cycle."""
+    by_id = {}
+    for s in steps:
+        sid = s.get("id")
+        if not sid or sid in by_id:
+            raise WorkflowError(f"each step needs a unique 'id' (offender: {sid!r})")
+        by_id[sid] = s
+    indeg = {sid: 0 for sid in by_id}
+    for s in steps:
+        for dep in s.get("needs", []) or []:
+            if dep not in by_id:
+                raise WorkflowError(f"step '{s['id']}' needs unknown step '{dep}'")
+            indeg[s["id"]] += 1
+    ready = [sid for sid, d in indeg.items() if d == 0]
+    order: list[dict] = []
+    while ready:
+        sid = ready.pop(0)
+        order.append(by_id[sid])
+        for s in steps:
+            if sid in (s.get("needs", []) or []):
+                indeg[s["id"]] -= 1
+                if indeg[s["id"]] == 0:
+                    ready.append(s["id"])
+    if len(order) != len(steps):
+        raise WorkflowError("workflow steps contain a cycle")
+    return order
+
+
+async def _orchestrate(req: ComputeRequest, depth: int) -> tuple[dict, list[dict], list[str]]:
+    """Run the workflow DAG. Returns (raw-adapter-shaped result, step summaries,
+    step receipt ids). Fail-fast: a non-ok step stops the run (dependents skipped)."""
+    if depth >= MAX_WORKFLOW_DEPTH:
+        return ({"outputs": [], "runtime": "workflow", "status": "error",
+                 "error": f"workflow nesting exceeds max depth {MAX_WORKFLOW_DEPTH}", "degraded": None},
+                [], [])
+    steps = req.spec.get("steps")
+    if not isinstance(steps, list) or not steps:
+        return ({"outputs": [], "runtime": "workflow", "status": "error",
+                 "error": "workflow spec needs a non-empty 'steps' list", "degraded": None}, [], [])
+    try:
+        ordered = _topo_order(steps)
+    except WorkflowError as e:
+        return ({"outputs": [], "runtime": "workflow", "status": "error",
+                 "error": str(e), "degraded": None}, [], [])
+
+    summaries: list[dict] = []
+    receipt_ids: list[str] = []
+    status = "ok"
+    for s in ordered:
+        step_req = ComputeRequest(
+            kind=s.get("kind", ""), spec=s.get("spec", {}) or {}, backend=s.get("backend"),
+            project=req.project, entitlement=req.entitlement, grant_id=req.grant_id,
+            actor=req.actor, session=req.session, no_cache=req.no_cache)
+        res = await execute(step_req, _depth=depth + 1)
+        summaries.append({
+            "id": s["id"], "kind": res.kind, "backend": res.backend, "status": res.status,
+            "epistemic_status": res.epistemic_status,
+            "receipt": res.receipt.id if res.receipt else None,
+            "memoized": res.memoized,
+        })
+        if res.receipt:
+            receipt_ids.append(res.receipt.id)
+        if res.status not in ("ok",):
+            status = "error" if res.status in ("error", "grant_required", "entitlement_required") else "degraded"
+            break   # fail-fast: dependents are not run
+
+    warrant = _weakest([x["epistemic_status"] for x in summaries]) if status == "ok" else "unknown"
+    raw = {
+        "outputs": [ComputeOutput(type="workflow", data={
+            "steps": summaries, "ran": len(summaries), "total": len(ordered),
+            "warrant": warrant})],
+        "runtime": "workflow", "status": status,
+        "error": None if status == "ok" else f"workflow halted at step {summaries[-1]['id']}",
+        "degraded": None,
+        "_warrant": warrant, "_receipt_ids": receipt_ids,
+    }
+    return raw, summaries, receipt_ids
+
+
+async def execute(req: ComputeRequest, _depth: int = 0) -> ComputeResult:
+    """The universal compute path: resolve → entitle → zero-trust grant → memo →
+    route (or orchestrate) → seal → attest → provenance. One shape for a cell, a
+    query, a spark job, or a whole workflow."""
+    try:
+        kind, _def, backend = registry.resolve(req.kind, req.backend)
+    except registry.UnknownKind:
+        return ComputeResult(status="error", kind=req.kind, backend=req.backend or "—",
+                             epistemic_status="unknown", error=f"unknown compute kind: {req.kind}")
+    except registry.UnknownBackend as e:
+        return ComputeResult(status="error", kind=req.kind, backend=req.backend or "—",
+                             epistemic_status="unknown", error=str(e))
+
+    epistemic = registry.epistemic_for(kind)
+    entitled = registry.entitled(req.project, kind, backend, req.entitlement)
+    check, permitted = zerotrust.grant_check(
+        project=req.project, kind=kind, backend=backend, actor=req.actor,
+        grant_id=req.grant_id, entitled=entitled)
+    if not permitted:
+        return ComputeResult(
+            status="entitlement_required" if not entitled else "grant_required",
+            kind=kind, backend=backend, epistemic_status=epistemic,
+            entitlement_required=not entitled, grant_check=check,
+            message=check["result"]["reason"])
+
+    key = memo_key(req.project, kind, backend, req.spec)
+    if MEMOIZE and not req.no_cache and key in _MEMO:
+        cached = _MEMO[key].model_copy(deep=True)
+        cached.memoized = True
+        cached.grant_check = check
+        return cached
+
+    # route: a workflow orchestrates governed sub-computes through THIS engine;
+    # everything else dispatches to its backend adapter.
+    if kind == "workflow":
+        raw, _summaries, step_receipt_ids = await _orchestrate(req, _depth)
+        epistemic = raw.get("_warrant", epistemic) if raw["status"] == "ok" else epistemic
+    else:
+        raw = await adapters.dispatch(kind, backend, req.spec, req.project, req.session)
+        step_receipt_ids = []
+    status = raw["status"]
+
+    receipt = receipts.seal(
+        req.project, kind=kind, backend=backend, runtime=raw["runtime"],
+        inputs=req.spec, outputs=[o.model_dump() for o in raw["outputs"]],
+        status=status, actor=req.actor, epistemic_status=epistemic)
+
+    delta = adapters.build_delta(req.project, kind, backend, receipt.id, epistemic,
+                                 inputs_sha=receipt.inputs_sha, outputs_sha=receipt.outputs_sha)
+    # a workflow's provenance links its run to each step's run (lineage is emergent)
+    if kind == "workflow" and step_receipt_ids:
+        run_id = delta.nodes[0].id
+        for rid in step_receipt_ids:
+            short = rid.replace("sha256:", "")[:12]
+            step_run = f"proj-{req.project}:compute:{short}"
+            delta.edges.append(GraphEdge.model_validate({"label": "HAS_STEP", "from": run_id, "to": step_run}))
+            delta.edges.append(GraphEdge.model_validate({"label": "prov:wasInformedBy", "from": step_run, "to": run_id}))
+    if WRITE_PROVENANCE and status == "ok":
+        delta.written = await adapters.write_provenance(delta)
+
+    attestation = zerotrust.attestation_bundle(receipt)
+    result = ComputeResult(
+        status=status, kind=kind, backend=backend, epistemic_status=epistemic,
+        outputs=raw["outputs"], receipt=receipt, graph_delta=delta,
+        error=raw.get("error"), degraded=raw.get("degraded"),
+        grant_check=check, attestation=attestation, memoized=False)
+
+    if MEMOIZE and not req.no_cache and status == "ok":
+        if len(_MEMO) >= _MEMO_MAX:
+            _MEMO.pop(next(iter(_MEMO)))
+        _MEMO[key] = result
+    return result

--- a/apps/compute-gateway/src/compute_gateway/registry.py
+++ b/apps/compute-gateway/src/compute_gateway/registry.py
@@ -43,6 +43,14 @@ KINDS: dict[str, dict] = {
         "capabilities": ["chat", "embed"],
         "epistemic": "derived", "executes_user_code": False, "status": "declared",
     },
+    # the COMPOSITE kind: a DAG of governed sub-computes, each sealing its own
+    # receipt, bound by one composite receipt. Orchestrated by the engine itself
+    # (backend "gateway") — no external runtime. Its warrant is the weakest step.
+    "workflow": {
+        "backends": ["gateway"], "default": "gateway",
+        "capabilities": ["dag", "compose", "fan-in", "memoized-steps"],
+        "epistemic": "derived", "executes_user_code": False, "status": "live",
+    },
 }
 
 

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -12,24 +12,12 @@ import os
 
 from fastapi import Depends, FastAPI, Header, HTTPException
 
-from . import adapters, receipts, registry, zerotrust
+from . import engine, receipts, registry, zerotrust
 from .contract import ComputeRequest, ComputeResult
 
 app = FastAPI(title="compute-gateway", version="0.1.0")
 
 GATEWAY_TOKEN = os.getenv("GATEWAY_TOKEN", "")
-WRITE_PROVENANCE = os.getenv("GATEWAY_WRITE_PROVENANCE", "true").lower() == "true"
-MEMOIZE = os.getenv("GATEWAY_MEMOIZE", "true").lower() == "true"
-
-# content-addressed compute memo: sha(project|kind|backend|spec) → prior ComputeResult.
-# Identical inputs return the identical sealed proof — Flyte/Pachyderm-style memoization,
-# but the cached artifact IS the receipt. Bounded so it can't grow unbounded.
-_MEMO: "dict[str, ComputeResult]" = {}
-_MEMO_MAX = int(os.getenv("GATEWAY_MEMO_MAX", "2048"))
-
-
-def _memo_key(project: str, kind: str, backend: str, spec: dict) -> str:
-    return receipts.sha({"project": project, "kind": kind, "backend": backend, "spec": spec})
 
 
 def require_token(authorization: str = Header(default="")) -> None:
@@ -59,72 +47,17 @@ def registry_view(project: str = "default", entitlement: str | None = None,
 
 @app.post("/v1/compute", response_model=ComputeResult)
 async def compute(req: ComputeRequest, _: None = Depends(require_token)) -> ComputeResult:
-    # 1) resolve kind + backend
+    """One governed door for every kind of compute. Unknown kind/backend is a 422
+    (client error); everything else the engine resolves, gates (entitlement +
+    zero-trust grant), memoizes, routes (or, for a `workflow`, orchestrates a DAG
+    of governed sub-computes), seals, attests, and writes provenance for."""
     try:
-        kind, _def, backend = registry.resolve(req.kind, req.backend)
+        registry.resolve(req.kind, req.backend)
     except registry.UnknownKind:
         raise HTTPException(status_code=422, detail=f"unknown compute kind: {req.kind}")
     except registry.UnknownBackend as e:
         raise HTTPException(status_code=422, detail=str(e))
-
-    epistemic = registry.epistemic_for(kind)
-
-    # 2) the UNIFORM pay-gate — one gate for all compute (like Databricks/Foundry,
-    #    but sovereign + per-kind/per-backend). Fail-closed with an honest 402.
-    entitled = registry.entitled(req.project, kind, backend, req.entitlement)
-
-    # 3) ZERO-TRUST grant check (OUR kernel) — emitted before any dispatch. Under
-    #    ZEROTRUST_ENFORCE, user-code compute with no capability grant fails closed
-    #    even when entitled (a paid entitlement is not a capability grant).
-    check, permitted = zerotrust.grant_check(
-        project=req.project, kind=kind, backend=backend, actor=req.actor,
-        grant_id=req.grant_id, entitled=entitled)
-    if not permitted:
-        return ComputeResult(
-            status="entitlement_required" if not entitled else "grant_required",
-            kind=kind, backend=backend, epistemic_status=epistemic,
-            entitlement_required=not entitled, grant_check=check,
-            message=check["result"]["reason"])
-
-    # 4) content-addressed memo — identical inputs return the identical sealed proof
-    key = _memo_key(req.project, kind, backend, req.spec)
-    if MEMOIZE and not req.no_cache and key in _MEMO:
-        cached = _MEMO[key].model_copy(deep=True)
-        cached.memoized = True
-        cached.grant_check = check
-        return cached
-
-    # 5) route to the backend adapter (raw outputs; no receipt yet)
-    raw = await adapters.dispatch(kind, backend, req.spec, req.project, req.session)
-    status = raw["status"]
-
-    # 6) SEAL the universal receipt — the same for a cell, a query, anything
-    receipt = receipts.seal(
-        req.project, kind=kind, backend=backend, runtime=raw["runtime"],
-        inputs=req.spec, outputs=[o.model_dump() for o in raw["outputs"]],
-        status=status, actor=req.actor, epistemic_status=epistemic)
-
-    # 7) provenance subgraph — compute + knowledge, one object model
-    delta = adapters.build_delta(req.project, kind, backend, receipt.id, epistemic,
-                                 inputs_sha=receipt.inputs_sha, outputs_sha=receipt.outputs_sha)
-    if WRITE_PROVENANCE and status == "ok":
-        delta.written = await adapters.write_provenance(delta)
-
-    # 8) render the signed receipt as a zero-trust AttestationBundle
-    attestation = zerotrust.attestation_bundle(receipt)
-
-    result = ComputeResult(
-        status=status, kind=kind, backend=backend, epistemic_status=epistemic,
-        outputs=raw["outputs"], receipt=receipt, graph_delta=delta,
-        error=raw.get("error"), degraded=raw.get("degraded"),
-        grant_check=check, attestation=attestation, memoized=False)
-
-    # 9) memoize successful, deterministic-input runs (bounded)
-    if MEMOIZE and not req.no_cache and status == "ok":
-        if len(_MEMO) >= _MEMO_MAX:
-            _MEMO.pop(next(iter(_MEMO)))
-        _MEMO[key] = result
-    return result
+    return await engine.execute(req)
 
 
 @app.get("/v1/capability-registry")

--- a/apps/compute-gateway/tests/test_workflow.py
+++ b/apps/compute-gateway/tests/test_workflow.py
@@ -1,0 +1,114 @@
+"""The `workflow` composite kind — a DAG of governed sub-computes bound by one
+composite receipt. Every step is itself gated, memoized, and receipt-sealed."""
+import importlib
+import os
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo"          # project 'demo' → all kinds entitled
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import adapters, engine, receipts, server, zerotrust  # noqa: E402
+from compute_gateway.contract import ComputeOutput  # noqa: E402
+
+importlib.reload(zerotrust)
+importlib.reload(engine)
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+
+def setup_function():
+    receipts._CHAINS.clear()
+    engine._MEMO.clear()
+    zerotrust.ZEROTRUST_ENFORCE = False
+
+    async def fake_forge(spec, project, session):
+        return {"outputs": [ComputeOutput(type="result", text=f"ran:{spec.get('code')}")],
+                "runtime": "python3", "status": "ok", "error": None, "degraded": None}
+
+    async def fake_graph(spec, project, session):
+        return {"outputs": [ComputeOutput(type="graph", data={"nodes": [], "count": 0})],
+                "runtime": "hellgraph", "status": "ok", "error": None, "degraded": None}
+
+    adapters.set_backend("forge", fake_forge)
+    adapters.set_backend("hellgraph:graph-query", fake_graph)
+
+
+def _wf(steps, project="demo", **extra):
+    return client.post("/v1/compute",
+                       json={"kind": "workflow", "project": project, "spec": {"steps": steps}, **extra},
+                       headers=AUTH).json()
+
+
+def test_workflow_runs_dag_and_seals_composite_receipt():
+    r = _wf([
+        {"id": "read", "kind": "graph-query", "spec": {"label": "demo"}},
+        {"id": "cell", "kind": "notebook", "spec": {"code": "1+1"}, "needs": ["read"]},
+    ])
+    assert r["status"] == "ok" and r["kind"] == "workflow" and r["backend"] == "gateway"
+    steps = r["outputs"][0]["data"]["steps"]
+    assert [s["id"] for s in steps] == ["read", "cell"]       # topological order honoured
+    assert all(s["receipt"] for s in steps)                    # each step sealed its own receipt
+    # composite receipt + two step receipts all landed in the chain
+    assert client.get("/v1/receipts", params={"project": "demo"}, headers=AUTH).json()["count"] == 3
+    assert r["receipt"]["kind"] == "workflow"
+
+
+def test_workflow_warrant_is_weakest_link():
+    # graph-query is 'observed', notebook is 'derived'. weakest(observed, derived) = observed.
+    r = _wf([
+        {"id": "read", "kind": "graph-query", "spec": {"label": "demo"}},
+        {"id": "cell", "kind": "notebook", "spec": {"code": "x"}},
+    ])
+    assert r["epistemic_status"] == "observed"
+    assert r["outputs"][0]["data"]["warrant"] == "observed"
+
+
+def test_workflow_provenance_links_steps():
+    r = _wf([{"id": "a", "kind": "notebook", "spec": {"code": "1"}},
+             {"id": "b", "kind": "notebook", "spec": {"code": "2"}, "needs": ["a"]}])
+    labels = [e["label"] for e in r["graph_delta"]["edges"]]
+    assert "HAS_STEP" in labels and "prov:wasInformedBy" in labels
+
+
+def test_workflow_fail_fast_stops_dependents():
+    async def boom(spec, project, session):
+        return {"outputs": [], "runtime": "python3", "status": "error",
+                "error": "kaboom", "degraded": None}
+    adapters.set_backend("forge", boom)
+    r = _wf([
+        {"id": "bad", "kind": "notebook", "spec": {"code": "x"}},
+        {"id": "never", "kind": "notebook", "spec": {"code": "y"}, "needs": ["bad"]},
+    ])
+    assert r["status"] == "error"
+    ran = [s["id"] for s in r["outputs"][0]["data"]["steps"]]
+    assert ran == ["bad"] and "never" not in ran               # dependent skipped
+
+
+def test_workflow_rejects_cycle():
+    r = _wf([{"id": "a", "kind": "notebook", "spec": {}, "needs": ["b"]},
+             {"id": "b", "kind": "notebook", "spec": {}, "needs": ["a"]}])
+    assert r["status"] == "error" and "cycle" in (r["error"] or "")
+
+
+def test_workflow_rejects_unknown_dependency():
+    r = _wf([{"id": "a", "kind": "notebook", "spec": {}, "needs": ["ghost"]}])
+    assert r["status"] == "error" and "unknown step" in (r["error"] or "")
+
+
+def test_workflow_memoized_end_to_end():
+    steps = [{"id": "a", "kind": "notebook", "spec": {"code": "1+1"}}]
+    r1 = _wf(steps)
+    r2 = _wf(steps)
+    assert r1["memoized"] is False and r2["memoized"] is True
+    assert r1["receipt"]["id"] == r2["receipt"]["id"]
+
+
+def test_workflow_in_registry_and_capability():
+    ks = {k["kind"]: k for k in client.get("/v1/registry", params={"project": "demo"}, headers=AUTH).json()["kinds"]}
+    assert ks["workflow"]["status"] == "live" and ks["workflow"]["backends"] == ["gateway"]
+    reg = client.get("/v1/capability-registry", headers=AUTH).json()
+    zerotrust.validate(reg, "capability_registry")
+    assert any(t["name"] == "compute.workflow" for t in reg["servers"][0]["tools"])

--- a/apps/compute-gateway/tests/test_zerotrust.py
+++ b/apps/compute-gateway/tests/test_zerotrust.py
@@ -17,10 +17,11 @@ os.environ["GATEWAY_SIGNING_KEY"] = base64.b64encode(b"0" * 32).decode()
 
 from fastapi.testclient import TestClient  # noqa: E402
 
-from compute_gateway import adapters, receipts, registry, server, zerotrust  # noqa: E402
+from compute_gateway import adapters, engine, receipts, registry, server, zerotrust  # noqa: E402
 from compute_gateway.contract import ComputeOutput  # noqa: E402
 
 importlib.reload(zerotrust)
+importlib.reload(engine)
 importlib.reload(server)
 client = TestClient(server.app)
 AUTH = {"Authorization": "Bearer t"}
@@ -28,7 +29,7 @@ AUTH = {"Authorization": "Bearer t"}
 
 def setup_function():
     receipts._CHAINS.clear()
-    server._MEMO.clear()
+    engine._MEMO.clear()
     zerotrust.ZEROTRUST_ENFORCE = False
 
     async def fake_forge(spec, project, session):


### PR DESCRIPTION
Extends the Universal Compute Plane (#848 skeleton, #853 signed+zero-trust) from *"any compute, one door"* into **"compose any computes, one chained proof."** This is the Flyte/Dagster/Nextflow answer — but proof-carrying, epistemically-typed, and sovereign by construction.

## What
- **`engine.py`** — the gate→grant→memo→route→seal→attest→provenance pipeline, extracted into a reusable `execute()` so **composite kinds invoke governed sub-computes through the exact same path**. `/v1/compute` is now a thin delegator (422 on unknown kind, else `engine.execute`).
- **`workflow` kind** (backend `gateway`, **live**) — a DAG of steps `{id, kind, spec, backend?, needs}`:
  - Kahn **topological sort** (rejects cycles + unknown deps)
  - **every step is itself a fully-gated, memoized, receipt-sealed, attested compute** — recursion bounded by `GATEWAY_MAX_WORKFLOW_DEPTH`
  - **fail-fast**: a non-ok step halts dependents
  - seals a **composite receipt** over the ordered step receipts (tamper-evident over its steps)
  - its **epistemic warrant is the weakest link** — a pipeline is only as warranted as its least-warranted step
  - provenance links the workflow run to each step (`HAS_STEP` / `prov:wasInformedBy`) — lineage is emergent
  - per-step **and** whole-workflow content-addressed memoization

## Why it matters
Databricks welds one paradigm (Spark) to one surface (notebook). A workflow here can fan a graph read → a notebook cell → a spark job → an inference call, each entitlement-gated and individually attested, bound by one composite proof. Heterogeneous compute, homogeneous chained evidence.

## Proof
28 tests green (8 new): DAG order, weakest-link warrant, provenance links, fail-fast, cycle & unknown-dep rejection, end-to-end memoization, registry + capability-registry conformance. compute-gateway CI (pytest + Docker build, added in #853) now covers this.