### PR TITLE
compute-gateway: planner — the capability registry as an agent action space (layer 6)

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/planner.py
+++ b/apps/compute-gateway/src/compute_gateway/planner.py
@@ -1,0 +1,108 @@
+"""The planner — the capability registry as an agent ACTION SPACE (layer 6).
+
+Given a goal (a set of desired CAPABILITIES + an intent label), the planner
+treats the registry as an action space: it selects the kinds that PROVIDE those
+capabilities and composes them into a governed `workflow` plan — observed reads
+first (fan-out), then derivations that depend on them (fan-in). Compute becomes
+something an agent can PLAN over, not just invoke.
+
+The plan is a PREVIEW; it is never executed here. The client hands the returned
+workflow spec to /v1/compute to run it under full governance (entitlement +
+zero-trust grant + signed receipts). Planning is free — you may plan before you
+pay; only execution is gated. That separation IS the governance property.
+
+This ships a DETERMINISTIC capability planner (`strategy=capability-dag`, no
+model in the request path — testable, explainable). It is a pluggable seam: an
+LLM / noetica-mcp reasoner can register another strategy that emits the SAME
+workflow-plan shape, so the surface and the governance never change.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from . import registry
+
+# a kind's spec skeleton — a plan is a scaffold; the human/agent fills the payloads.
+_SPEC_SKELETON: dict[str, dict[str, Any]] = {
+    "graph-stats": {},
+    "graph-query": {"label": ""},
+    "notebook": {"code": ""},
+    "spark": {"sql": ""},
+    "inference": {"task": "embed", "input": []},
+}
+
+_LADDER = ["unknown", "hypothesis", "simulated", "observed", "derived", "verified", "attested"]
+
+
+def _weakest(warrants: list[str]) -> str:
+    if not warrants:
+        return "unknown"
+    return min(warrants, key=lambda w: _LADDER.index(w) if w in _LADDER else 0)
+
+
+def plan(*, capabilities: list[str], project: str, intent: str | None,
+         entitlement: str | None) -> dict[str, Any]:
+    """Compose a governed workflow plan that satisfies the desired capabilities.
+
+    Reads (observed, no user code) are scheduled first as a fan-out; everything
+    else depends on them (fan-in) — the natural gather-then-derive shape. Returns
+    a runnable `workflow` spec plus a per-step preview (entitlement + warrant) and
+    an honest account of what could NOT be satisfied.
+    """
+    chosen: list[tuple[str, str]] = []   # (kind, capability) preserving request order
+    seen_kinds: set[str] = set()
+    unmet_caps: list[str] = []
+    for cap in capabilities:
+        kinds = registry.kinds_providing(cap)
+        if not kinds:
+            unmet_caps.append(cap)
+            continue
+        kind = kinds[0]                  # live-first (registry.kinds_providing orders)
+        if kind not in seen_kinds:
+            seen_kinds.add(kind)
+            chosen.append((kind, cap))
+
+    # partition into reads (observed + no user code) and derivations
+    reads = [(k, c) for k, c in chosen if registry.KINDS[k]["epistemic"] == "observed"
+             and not registry.KINDS[k]["executes_user_code"]]
+    derives = [(k, c) for k, c in chosen if (k, c) not in reads]
+
+    steps: list[dict] = []
+    previews: list[dict] = []
+    read_ids: list[str] = []
+    for i, (kind, cap) in enumerate(reads):
+        sid = f"read-{i+1}-{kind}"
+        read_ids.append(sid)
+        steps.append({"id": sid, "kind": kind, "spec": dict(_SPEC_SKELETON.get(kind, {}))})
+        previews.append(_preview(sid, kind, cap, project, entitlement))
+    for i, (kind, cap) in enumerate(derives):
+        sid = f"derive-{i+1}-{kind}"
+        # a derivation depends on every read (fan-in); if there are no reads it is a root
+        steps.append({"id": sid, "kind": kind, "spec": dict(_SPEC_SKELETON.get(kind, {})),
+                      **({"needs": list(read_ids)} if read_ids else {})})
+        previews.append(_preview(sid, kind, cap, project, entitlement))
+
+    unmet_ent = [p["id"] for p in previews if not p["entitled"]]
+    warrant = _weakest([p["epistemic"] for p in previews])
+    return {
+        "strategy": "capability-dag",
+        "intent": intent,
+        "requested_capabilities": capabilities,
+        "plan": {"kind": "workflow", "project": project, "spec": {"steps": steps}},
+        "steps": previews,
+        "warrant_preview": warrant,
+        "unmet_capabilities": unmet_caps,
+        "unmet_entitlements": unmet_ent,
+        "runnable": not unmet_caps and not unmet_ent and bool(steps),
+    }
+
+
+def _preview(sid: str, kind: str, cap: str, project: str, entitlement: str | None) -> dict[str, Any]:
+    d = registry.KINDS[kind]
+    backend = d["default"]
+    return {
+        "id": sid, "kind": kind, "backend": backend, "satisfies": cap,
+        "epistemic": d["epistemic"], "executes_user_code": d["executes_user_code"],
+        "status": d["status"],
+        "entitled": registry.entitled(project, kind, backend, entitlement),
+    }

--- a/apps/compute-gateway/src/compute_gateway/registry.py
+++ b/apps/compute-gateway/src/compute_gateway/registry.py
@@ -95,6 +95,13 @@ def entitled(project: str, kind: str, backend: str, presented: str | None) -> bo
     return bool(presented and presented in ents)
 
 
+def kinds_providing(capability: str) -> list[str]:
+    """The kinds whose capability set includes `capability`, live kinds first —
+    the reverse index the planner treats as an action space over the registry."""
+    hits = [k for k, d in KINDS.items() if capability in d["capabilities"]]
+    return sorted(hits, key=lambda k: (KINDS[k]["status"] != "live", k))
+
+
 def catalog(project: str, presented: str | None) -> list[dict]:
     """The registry as the surface/planner sees it: kinds + backends + entitlement."""
     out = []

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -12,7 +12,9 @@ import os
 
 from fastapi import Depends, FastAPI, Header, HTTPException
 
-from . import engine, receipts, registry, zerotrust
+from pydantic import BaseModel
+
+from . import engine, planner, receipts, registry, zerotrust
 from .contract import ComputeRequest, ComputeResult
 
 app = FastAPI(title="compute-gateway", version="0.1.0")
@@ -58,6 +60,23 @@ async def compute(req: ComputeRequest, _: None = Depends(require_token)) -> Comp
     except registry.UnknownBackend as e:
         raise HTTPException(status_code=422, detail=str(e))
     return await engine.execute(req)
+
+
+class PlanRequest(BaseModel):
+    capabilities: list[str] = []
+    project: str = "default"
+    intent: str | None = None
+    entitlement: str | None = None
+
+
+@app.post("/v1/plan")
+def plan_view(req: PlanRequest, _: None = Depends(require_token)) -> dict:
+    """Plan a governed workflow over the capability registry (layer 6 — the
+    registry as an agent action space). A PREVIEW: returns a runnable `workflow`
+    spec + per-step entitlement/warrant, but executes nothing. Planning is free;
+    hand `plan` to POST /v1/compute to run it under full governance."""
+    return planner.plan(capabilities=req.capabilities, project=req.project,
+                        intent=req.intent, entitlement=req.entitlement)
 
 
 @app.get("/v1/capability-registry")

--- a/apps/compute-gateway/tests/test_planner.py
+++ b/apps/compute-gateway/tests/test_planner.py
@@ -1,0 +1,90 @@
+"""The planner — the capability registry as an agent action space (layer 6).
+
+A plan is a preview (free, ungated); the emitted workflow spec runs under full
+governance through /v1/compute. These lock the plan→execute round-trip."""
+import importlib
+import os
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo"          # only project 'demo' entitled
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import adapters, engine, receipts, server, zerotrust  # noqa: E402
+from compute_gateway.contract import ComputeOutput  # noqa: E402
+
+importlib.reload(zerotrust)
+importlib.reload(engine)
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+
+def setup_function():
+    receipts._CHAINS.clear()
+    engine._MEMO.clear()
+    zerotrust.ZEROTRUST_ENFORCE = False
+    os.environ["COMPUTE_ENTITLEMENTS"] = "demo"       # pin: sibling test modules widen the shared env
+
+    async def fake_forge(spec, project, session):
+        return {"outputs": [ComputeOutput(type="result", text="ok")],
+                "runtime": "python3", "status": "ok", "error": None, "degraded": None}
+
+    async def fake_stats(spec, project, session):
+        return {"outputs": [ComputeOutput(type="table", data={"n": 1})],
+                "runtime": "hellgraph", "status": "ok", "error": None, "degraded": None}
+
+    adapters.set_backend("forge", fake_forge)
+    adapters.set_backend("hellgraph:graph-stats", fake_stats)
+
+
+def _plan(caps, project="demo", **extra):
+    return client.post("/v1/plan", json={"capabilities": caps, "project": project, **extra},
+                       headers=AUTH).json()
+
+
+def test_plan_composes_read_then_derive_dag():
+    p = _plan(["counts", "python"], intent="profile the cohort")
+    assert p["strategy"] == "capability-dag" and p["intent"] == "profile the cohort"
+    steps = p["plan"]["spec"]["steps"]
+    kinds = [s["kind"] for s in steps]
+    assert kinds == ["graph-stats", "notebook"]           # observed read first, then derive
+    # the derive fans in on the read
+    derive = next(s for s in steps if s["kind"] == "notebook")
+    assert derive["needs"] == ["read-1-graph-stats"]
+    assert p["warrant_preview"] == "observed"             # weakest link
+    assert p["runnable"] is True and not p["unmet_capabilities"]
+
+
+def test_plan_output_is_a_runnable_workflow():
+    p = _plan(["counts", "python"])
+    # hand the plan straight to /v1/compute — the round-trip the layer promises
+    r = client.post("/v1/compute", json=p["plan"], headers=AUTH).json()
+    assert r["status"] == "ok" and r["kind"] == "workflow"
+    ran = [s["id"] for s in r["outputs"][0]["data"]["steps"]]
+    assert ran == ["read-1-graph-stats", "derive-1-notebook"]
+
+
+def test_plan_reports_unmet_capability():
+    p = _plan(["counts", "teleportation"])
+    assert p["unmet_capabilities"] == ["teleportation"]
+    assert p["runnable"] is False                          # can't satisfy the goal
+
+
+def test_planning_is_free_but_flags_unentitled():
+    # project 'locked' is NOT entitled — planning still returns 200 (free preview),
+    # but every step is flagged unentitled and the plan is not runnable.
+    p = _plan(["counts"], project="locked")
+    assert p["steps"][0]["entitled"] is False
+    assert p["unmet_entitlements"] and p["runnable"] is False
+
+
+def test_plan_dedupes_kinds_across_capabilities():
+    # both 'counts' and 'analytics' are provided by graph-stats → one step, not two
+    p = _plan(["counts", "analytics"])
+    assert [s["kind"] for s in p["plan"]["spec"]["steps"]] == ["graph-stats"]
+
+
+def test_plan_requires_auth():
+    assert client.post("/v1/plan", json={"capabilities": ["counts"]}).status_code == 401


### PR DESCRIPTION
The thesis capstone (layer 6): compute becomes something an agent can **plan over**, not just invoke — the registry as an action space, the OS for governed autonomy. Composes directly with the `workflow` kind (#854).

## What
- **`planner.py`** — a **capability-driven** planner (not keyword templates). Given desired **capabilities** + an intent, it selects the registry kinds that *provide* them and composes a governed workflow: **observed reads first (fan-out), then derivations that depend on them (fan-in)** — the natural gather-then-derive shape.
- **`POST /v1/plan`** — a **preview**: returns a runnable `workflow` spec + a per-step entitlement/warrant preview + an honest account of **unmet capabilities / unmet entitlements** + the **weakest-link warrant**. Executes nothing.
- **Planning is free** (auth only, *not* entitlement-gated) — you may plan before you pay; only execution (handing `plan` to `/v1/compute`) is gated. **That separation is the governance property.**
- Deterministic (`strategy=capability-dag`, no model in the request path — testable, explainable). **Pluggable seam**: an LLM / noetica-mcp reasoner can register another strategy emitting the same plan shape; the surface and governance never change.

## Round-trip
`/v1/plan` → a `workflow` spec → `/v1/compute` runs it under full governance (entitlement + zero-trust grant + signed composite receipt). The test suite locks this end-to-end.

## Proof
34 tests green (6 new): read→derive DAG composition, plan→execute round-trip, unmet-capability reporting, free-but-unentitled preview, kind dedup across capabilities, auth. compute-gateway CI (pytest + Docker build) covers it.