### PR TITLE
compute-gateway: content-addressed artifact store — data-level lineage + diff

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/artifacts.py
+++ b/apps/compute-gateway/src/compute_gateway/artifacts.py
@@ -1,0 +1,115 @@
+"""Content-addressed artifact store — the data substrate (Pachyderm/lakeFS answer).
+
+Run lineage says which run produced which receipt. DATA lineage says which exact
+bytes flowed through — and lets identical data be stored once and any two runs be
+diffed at the data level. Every compute output is put by its content digest
+(sha256); identical content dedupes to one blob; the receipt references the
+digests. So provenance is not just "run X ran" but "run X consumed blob a…,
+produced blob b…", and `diff(run_a, run_b)` is a set operation over digests.
+
+This ships an in-process store (the walking skeleton) behind a `Backend`
+interface, so a sovereign persistent backend (zot/MinIO object store — the same
+substrate as the sovereign registry) drops in without touching callers.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Protocol
+
+
+def digest(obj: Any) -> str:
+    """The content address — sha256 of the canonical JSON encoding."""
+    return "sha256:" + hashlib.sha256(
+        json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str, ensure_ascii=False).encode()
+    ).hexdigest()
+
+
+class Backend(Protocol):
+    def put(self, digest: str, blob: Any) -> bool: ...   # True if newly stored, False if already present
+    def get(self, digest: str) -> Any | None: ...
+    def has(self, digest: str) -> bool: ...
+
+
+class MemoryBackend:
+    """In-process content-addressed blob store. Bounded (FIFO) so it can't grow
+    without limit — the persistent backend removes the bound."""
+
+    def __init__(self, max_blobs: int = 4096) -> None:
+        self._blobs: dict[str, Any] = {}
+        self._max = max_blobs
+
+    def put(self, d: str, blob: Any) -> bool:
+        if d in self._blobs:
+            return False
+        if len(self._blobs) >= self._max:
+            self._blobs.pop(next(iter(self._blobs)))
+        self._blobs[d] = blob
+        return True
+
+    def get(self, d: str) -> Any | None:
+        return self._blobs.get(d)
+
+    def has(self, d: str) -> bool:
+        return d in self._blobs
+
+
+_backend: Backend = MemoryBackend()
+# receipt id → the ordered artifact digests it produced (the data-lineage index)
+_by_receipt: dict[str, list[str]] = {}
+_stats = {"puts": 0, "dedup_hits": 0}
+
+
+def set_backend(b: Backend) -> None:
+    global _backend
+    _backend = b
+
+
+def store_outputs(receipt_id: str, outputs: list[Any]) -> list[str]:
+    """Put each output by content digest (dedup), index it under the receipt, and
+    return the ordered digests."""
+    digests: list[str] = []
+    for o in outputs:
+        d = digest(o)
+        newly = _backend.put(d, o)
+        _stats["puts"] += 1
+        if not newly:
+            _stats["dedup_hits"] += 1
+        digests.append(d)
+    _by_receipt[receipt_id] = digests
+    return digests
+
+
+def get(d: str) -> Any | None:
+    return _backend.get(d)
+
+
+def for_receipt(receipt_id: str) -> list[str]:
+    return list(_by_receipt.get(receipt_id, []))
+
+
+def diff(a_receipt: str, b_receipt: str) -> dict[str, list[str]]:
+    """Data-level diff of two runs: which output blobs are shared, added, removed.
+    A pure set operation over content digests — reproducibility you can SEE."""
+    a = set(_by_receipt.get(a_receipt, []))
+    b = set(_by_receipt.get(b_receipt, []))
+    return {
+        "a": a_receipt, "b": b_receipt,
+        "shared": sorted(a & b),
+        "added": sorted(b - a),      # in b, not a
+        "removed": sorted(a - b),    # in a, not b
+        "identical": a == b and bool(a),
+    }
+
+
+def stats() -> dict[str, Any]:
+    unique = len({d for ds in _by_receipt.values() for d in ds})
+    return {"unique_blobs": unique, "puts": _stats["puts"],
+            "dedup_hits": _stats["dedup_hits"], "receipts_indexed": len(_by_receipt)}
+
+
+def _reset() -> None:   # test hook
+    global _backend
+    _backend = MemoryBackend()
+    _by_receipt.clear()
+    _stats.update(puts=0, dedup_hits=0)

--- a/apps/compute-gateway/src/compute_gateway/contract.py
+++ b/apps/compute-gateway/src/compute_gateway/contract.py
@@ -97,3 +97,4 @@ class ComputeResult(BaseModel):
     grant_check: dict[str, Any] | None = None   # conforming ToolGrantCheck emitted before dispatch
     attestation: dict[str, Any] | None = None   # conforming AttestationBundle over the signed receipt
     memoized: bool = False                       # served from the compute memo cache
+    artifacts: list[str] = []                    # content-addressed digests of each output blob

--- a/apps/compute-gateway/src/compute_gateway/engine.py
+++ b/apps/compute-gateway/src/compute_gateway/engine.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import os
 
-from . import adapters, receipts, registry, zerotrust
+from . import adapters, artifacts, receipts, registry, zerotrust
 from .contract import ComputeOutput, ComputeRequest, ComputeResult, GraphEdge
 
 MEMOIZE = os.getenv("GATEWAY_MEMOIZE", "true").lower() == "true"
@@ -184,11 +184,13 @@ async def execute(req: ComputeRequest, _depth: int = 0) -> ComputeResult:
         delta.written = await adapters.write_provenance(delta)
 
     attestation = zerotrust.attestation_bundle(receipt)
+    # content-address each output blob (dedup) → data-level lineage + diff
+    art = artifacts.store_outputs(receipt.id, [o.model_dump() for o in raw["outputs"]]) if status == "ok" else []
     result = ComputeResult(
         status=status, kind=kind, backend=backend, epistemic_status=epistemic,
         outputs=raw["outputs"], receipt=receipt, graph_delta=delta,
         error=raw.get("error"), degraded=raw.get("degraded"),
-        grant_check=check, attestation=attestation, memoized=False)
+        grant_check=check, attestation=attestation, memoized=False, artifacts=art)
 
     if MEMOIZE and not req.no_cache and status == "ok":
         if len(_MEMO) >= _MEMO_MAX:

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -14,7 +14,7 @@ from fastapi import Depends, FastAPI, Header, HTTPException
 
 from pydantic import BaseModel
 
-from . import engine, planner, receipts, registry, rocrate, zerotrust
+from . import artifacts, engine, planner, receipts, registry, rocrate, zerotrust
 from .contract import ComputeRequest, ComputeResult
 
 app = FastAPI(title="compute-gateway", version="0.1.0")
@@ -101,6 +101,33 @@ def attestation_view(project: str = "default", receipt_id: str | None = None,
         return {"project": project, "attestation": zerotrust.attestation_bundle(match)}
     return {"project": project, "count": len(ch),
             "attestations": [zerotrust.attestation_bundle(r) for r in ch]}
+
+
+@app.get("/v1/artifacts/stats")
+def artifacts_stats(_: None = Depends(require_token)) -> dict:
+    """Content-addressed store stats — unique blobs vs total puts (dedup at work)."""
+    return artifacts.stats()
+
+
+@app.get("/v1/artifacts/{digest}")
+def artifact_get(digest: str, _: None = Depends(require_token)) -> dict:
+    """Fetch a blob by its content address. Digest carries the `sha256:` prefix."""
+    blob = artifacts.get(digest)
+    if blob is None:
+        raise HTTPException(status_code=404, detail=f"no artifact {digest}")
+    return {"digest": digest, "blob": blob}
+
+
+@app.get("/v1/diff")
+def diff_view(a: str, b: str, _: None = Depends(require_token)) -> dict:
+    """Data-level diff of two runs by their receipt ids — shared/added/removed
+    output blobs. Reproducibility you can see: identical inputs ⇒ identical digests."""
+    return artifacts.diff(a, b)
+
+
+@app.get("/v1/receipts/{receipt_id}/artifacts")
+def receipt_artifacts(receipt_id: str, _: None = Depends(require_token)) -> dict:
+    return {"receipt": receipt_id, "artifacts": artifacts.for_receipt(receipt_id)}
 
 
 @app.get("/v1/receipts/{receipt_id}/ro-crate")

--- a/apps/compute-gateway/tests/test_artifacts.py
+++ b/apps/compute-gateway/tests/test_artifacts.py
@@ -1,0 +1,78 @@
+"""Content-addressed artifact store — dedup + data-level lineage/diff."""
+import importlib
+import os
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "*"          # entitle every project (dedup across projects)
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import adapters, artifacts, engine, receipts, server, zerotrust  # noqa: E402
+from compute_gateway.contract import ComputeOutput  # noqa: E402
+
+importlib.reload(zerotrust)
+importlib.reload(engine)
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+
+def setup_function():
+    receipts._CHAINS.clear()
+    engine._MEMO.clear()
+    artifacts._reset()
+    os.environ["COMPUTE_ENTITLEMENTS"] = "*"
+
+    async def fake(spec, project, session):
+        # output depends on spec.code → different code ⇒ different content digest
+        return {"outputs": [ComputeOutput(type="result", text=f"out:{spec.get('code')}")],
+                "runtime": "python3", "status": "ok", "error": None, "degraded": None}
+    adapters.set_backend("forge", fake)
+
+
+def _run(code, project="demo"):
+    return client.post("/v1/compute",
+                       json={"kind": "notebook", "project": project, "spec": {"code": code}},
+                       headers=AUTH).json()
+
+
+def test_output_is_content_addressed_on_the_result():
+    r = _run("1+1")
+    assert len(r["artifacts"]) == 1 and r["artifacts"][0].startswith("sha256:")
+    # the blob is retrievable by its content address
+    got = client.get(f"/v1/artifacts/{r['artifacts'][0]}", headers=AUTH).json()
+    assert got["blob"]["text"] == "out:1+1"
+
+
+def test_identical_output_dedupes_across_runs():
+    # same output content from two DIFFERENT projects (distinct memo keys → both execute)
+    a = _run("SAME", project="demo")
+    b = _run("SAME", project="demo2")
+    assert a["artifacts"] == b["artifacts"]                 # same content ⇒ same digest
+    st = client.get("/v1/artifacts/stats", headers=AUTH).json()
+    assert st["puts"] == 2 and st["dedup_hits"] == 1 and st["unique_blobs"] == 1
+
+
+def test_receipt_artifacts_index():
+    r = _run("x")
+    idx = client.get(f"/v1/receipts/{r['receipt']['id']}/artifacts", headers=AUTH).json()
+    assert idx["artifacts"] == r["artifacts"]
+
+
+def test_diff_identical_and_changed():
+    a = _run("SAME", project="demo")
+    b = _run("SAME", project="demo2")
+    d = client.get("/v1/diff", params={"a": a["receipt"]["id"], "b": b["receipt"]["id"]}, headers=AUTH).json()
+    assert d["identical"] is True and d["shared"] and not d["added"] and not d["removed"]
+
+    c = _run("DIFFERENT", project="demo3")
+    d2 = client.get("/v1/diff", params={"a": a["receipt"]["id"], "b": c["receipt"]["id"]}, headers=AUTH).json()
+    assert d2["identical"] is False and d2["added"] and d2["removed"]
+
+
+def test_artifact_404_and_auth():
+    _run("x")
+    assert client.get("/v1/artifacts/sha256:nope", headers=AUTH).status_code == 404
+    assert client.get("/v1/artifacts/stats").status_code == 401
+    assert client.get("/v1/diff", params={"a": "x", "b": "y"}).status_code == 401

--- a/apps/compute-gateway/tests/test_gateway.py
+++ b/apps/compute-gateway/tests/test_gateway.py
@@ -9,7 +9,7 @@ os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"          # no network in tests
 
 from fastapi.testclient import TestClient  # noqa: E402
 
-from compute_gateway import adapters, receipts, server  # noqa: E402
+from compute_gateway import adapters, engine, receipts, server  # noqa: E402
 from compute_gateway.contract import ComputeOutput  # noqa: E402
 
 importlib.reload(server)
@@ -18,7 +18,9 @@ AUTH = {"Authorization": "Bearer t"}
 
 
 def setup_function():
+    os.environ["COMPUTE_ENTITLEMENTS"] = "demo,graph-query,graph-stats"   # pin: sibling modules mutate the shared env
     receipts._CHAINS.clear()
+    engine._MEMO.clear()                                                  # memo persists across modules → clear it
     # deterministic fakes for both backends
     async def fake_forge(spec, project, session):
         return {"outputs": [ComputeOutput(type="result", text=f"ran:{spec.get('code')}")],

--- a/apps/compute-gateway/tests/test_workflow.py
+++ b/apps/compute-gateway/tests/test_workflow.py
@@ -20,6 +20,7 @@ AUTH = {"Authorization": "Bearer t"}
 
 
 def setup_function():
+    os.environ["COMPUTE_ENTITLEMENTS"] = "demo"       # pin: shared env
     receipts._CHAINS.clear()
     engine._MEMO.clear()
     zerotrust.ZEROTRUST_ENFORCE = False

--- a/apps/compute-gateway/tests/test_zerotrust.py
+++ b/apps/compute-gateway/tests/test_zerotrust.py
@@ -28,6 +28,7 @@ AUTH = {"Authorization": "Bearer t"}
 
 
 def setup_function():
+    os.environ["COMPUTE_ENTITLEMENTS"] = "demo,graph-query,graph-stats,spark"   # pin: shared env
     receipts._CHAINS.clear()
     engine._MEMO.clear()
     zerotrust.ZEROTRUST_ENFORCE = False


### PR DESCRIPTION
Tranche 5. Run lineage says *which run* produced which receipt; **data lineage** says *which exact bytes* flowed through — and lets identical data be stored once and any two runs be diffed at the data level. The Pachyderm/lakeFS answer, made proof-native.

## What
- **`artifacts.py`** — a content-addressed store behind a `Backend` Protocol (in-process `MemoryBackend` now; a sovereign **zot/MinIO** object store — the same substrate as the sovereign registry — drops in without touching callers). Every output is put by its **sha256 content digest**; identical content **dedupes** to one blob; a `receipt → digests` index gives data lineage.
- **engine** — each ok run content-addresses its outputs → `ComputeResult.artifacts = [digests]`.
- **endpoints** — `GET /v1/artifacts/{digest}` (fetch by content address), `/v1/artifacts/stats` (unique blobs vs puts — dedup at work), `/v1/receipts/{id}/artifacts`, and **`/v1/diff?a=&b=`** (data-level diff of two runs: shared / added / removed blobs — reproducibility you can *see*).

## Proof
45 tests green (5 new: content-addressing, cross-run dedup, receipt index, identical + changed diff, 404/auth). Also hardened cross-module test isolation (pin `COMPUTE_ENTITLEMENTS` + clear the engine memo per module — latent shared-env bugs surfaced as the suite grew).