### PR TITLE
compute-gateway: grant lifecycle — the deep zero-trust kernel integration

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/grants.py
+++ b/apps/compute-gateway/src/compute_gateway/grants.py
@@ -1,0 +1,165 @@
+"""The grant lifecycle — request → policy decision → quorum → issue → ledger →
+validate → revoke. The deep integration with OUR authority kernel
+(SocioProphet/mcp-a2a-zero-trust), beyond the self-issued ToolGrantCheck seam.
+
+A ToolGrantCheck (zerotrust.py) records whether a grant is valid at dispatch. THIS
+module is where grants come FROM: a PolicyDecision classifies the operation's
+danger, HIGH-danger operations (user code) require a human QUORUM before a Grant is
+issued, every state change appends a ledger event, and revocation is authoritative
+— a revoked grant fails every subsequent check closed.
+
+Conforms exactly to the vendored kernel schemas (grant / policy_decision /
+quorum_proof). This is the reference decision the kernel would make; the transport
+seam (`ISSUER`, `set_transport`) forwards to the real kernel over noetica-mcp /
+TriTRPC when wired — the contract and the ledger shape never change.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import time
+import uuid
+from typing import Any
+
+from . import registry, signing
+
+ISSUER = os.getenv("ZEROTRUST_ISSUER", "spiffe://socioprophet.dev/compute-gateway")
+DEFAULT_TTL = int(os.getenv("GRANT_TTL_SEC", "3600"))
+
+# effect (registry) → danger class + whether a human quorum is required to issue
+_DANGER = {"read": "LOW", "compute": "MEDIUM", "write": "MEDIUM", "egress": "HIGH", "exec": "HIGH"}
+_EFFECT = {"notebook": "exec", "spark": "exec", "graph-query": "read",
+           "graph-stats": "read", "inference": "compute", "workflow": "compute"}
+
+_GRANTS: dict[str, dict[str, Any]] = {}
+_REVOKED: set[str] = set()
+_LEDGER: list[dict[str, Any]] = []
+
+
+def _sha256(s: str) -> str:
+    return "sha256:" + hashlib.sha256(s.encode()).hexdigest()
+
+
+def _now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _policy_hash() -> str:
+    return _sha256("entitlements:" + os.getenv("COMPUTE_ENTITLEMENTS", ""))
+
+
+def _ledger_add(op: str, grant_id: str, **extra: Any) -> None:
+    _LEDGER.append({"op": op, "grant_id": grant_id, "at": _now(), **extra})
+
+
+def decide(kind: str, backend: str) -> dict[str, Any]:
+    """A conforming PolicyDecision: danger class + required quorum + constraints.
+    HIGH-danger (user-code) operations require a 1-of-N human quorum to issue."""
+    effect = _EFFECT.get(kind, "compute")
+    danger = _DANGER.get(effect, "MEDIUM")
+    required_quorum = 1 if danger == "HIGH" else 0
+    return {
+        "allow": True,
+        "danger_class": danger,
+        "policy_hash": _policy_hash(),
+        "reason": f"{kind}:{backend} classified {danger} (effect={effect})",
+        "constraints": {"ttl_sec": DEFAULT_TTL},
+        "required_quorum": required_quorum,
+    }
+
+
+def _quorum_proof(operation: str, signatures: list[dict]) -> dict[str, Any]:
+    return {
+        "rule": "1-of-N-human",
+        "validators": [s["spiffe_id"] for s in signatures],
+        "signed_payload_hash": _sha256("quorum:" + operation),
+        "signatures": [{"kind": "human", "spiffe_id": s["spiffe_id"], "sig": s["sig"]}
+                       for s in signatures],
+    }
+
+
+def request_grant(*, kind: str, backend: str, project: str, actor: str,
+                  session: str | None, quorum_signatures: list[dict] | None) -> dict[str, Any]:
+    """Run the full flow. Returns {decision, grant|None, quorum_required}. A grant
+    issues only if the decision allows AND any required quorum is satisfied."""
+    decision = decide(kind, backend)
+    sigs = quorum_signatures or []
+    need = decision["required_quorum"]
+    if need and len(sigs) < need:
+        _ledger_add("OP_GRANT_DENY", "-", reason="insufficient quorum", operation=f"{kind}:{backend}")
+        return {"decision": decision, "grant": None, "quorum_required": need,
+                "reason": f"HIGH-danger operation requires {need} human quorum signature(s)"}
+
+    effect = _EFFECT.get(kind, "compute")
+    gid = "grant-" + uuid.uuid4().hex
+    op = f"{kind}:{backend}"
+    qp = _quorum_proof(op, sigs) if need else None
+    aum = _sha256(f"aum:{project}:{actor}:{session or '-'}")
+    grant: dict[str, Any] = {
+        "grant_id": gid,
+        "issued_at": _now(),
+        "expires_at": time.strftime("%Y-%m-%dT%H:%M:%SZ",
+                                    time.gmtime(time.time() + DEFAULT_TTL)),
+        "binding": {"spiffe_id": f"{ISSUER}/{project}/{actor}", "aum_digest": aum,
+                    **({"session_id": session} if session and len(session) >= 6 else {})},
+        "capability": {
+            "kind": "mcp_tool",
+            "capability_ref": f"cap:compute:{kind}",
+            "capability_digest": _sha256(f"compute:{kind}:{backend}"),
+            "server": "compute-gateway", "tool": f"compute.{kind}",
+            "operation": op, "effect": effect,
+        },
+        "constraints": decision["constraints"],
+        "policy_hash": decision["policy_hash"],
+    }
+    if qp:
+        grant["quorum_proof"] = qp
+    key = signing.load_signing_key()
+    if key is not None:
+        sig, _pub = signing.sign_statement(grant, key)
+        if sig:
+            grant["sig"] = {"issuer": ISSUER, "sig": sig}
+
+    _GRANTS[gid] = grant
+    _ledger_add("OP_GRANT_ISSUE", gid, operation=op, danger=decision["danger_class"])
+    return {"decision": decision, "grant": grant, "quorum_required": 0}
+
+
+def validate(grant_id: str, operation: str | None = None) -> dict[str, Any]:
+    """Authoritative validity check → {valid, expired, revoked, reason}. Revoked or
+    expired grants fail closed. Appends an OP_GRANT_VALIDATE ledger event."""
+    g = _GRANTS.get(grant_id)
+    if g is None:
+        _ledger_add("OP_GRANT_VALIDATE", grant_id, valid=False, reason="unknown")
+        return {"valid": False, "expired": False, "revoked": False, "reason": "unknown grant"}
+    revoked = grant_id in _REVOKED
+    expired = g["expires_at"] < _now()
+    op_ok = operation is None or g["capability"]["operation"] == operation
+    valid = not revoked and not expired and op_ok
+    reason = ("revoked" if revoked else "expired" if expired
+              else "operation mismatch" if not op_ok else "valid")
+    _ledger_add("OP_GRANT_VALIDATE", grant_id, valid=valid, reason=reason)
+    return {"valid": valid, "expired": expired, "revoked": revoked, "reason": reason}
+
+
+def revoke(grant_id: str) -> bool:
+    """Revoke a grant. Authoritative — every subsequent validate fails closed."""
+    if grant_id not in _GRANTS:
+        return False
+    _REVOKED.add(grant_id)
+    _ledger_add("OP_GRANT_REVOKE", grant_id)
+    return True
+
+
+def get(grant_id: str) -> dict[str, Any] | None:
+    return _GRANTS.get(grant_id)
+
+
+def ledger() -> list[dict[str, Any]]:
+    return list(_LEDGER)
+
+
+def _reset() -> None:   # test hook
+    _GRANTS.clear()
+    _REVOKED.clear()
+    _LEDGER.clear()

--- a/apps/compute-gateway/src/compute_gateway/schemas/grant.schema.json
+++ b/apps/compute-gateway/src/compute_gateway/schemas/grant.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sourceos.local/schemas/canonical/grant.schema.json",
+  "title": "Grant",
+  "type": "object",
+  "required": [
+    "grant_id",
+    "issued_at",
+    "expires_at",
+    "binding",
+    "capability",
+    "constraints",
+    "policy_hash"
+  ],
+  "properties": {
+    "grant_id": {
+      "type": "string",
+      "minLength": 8
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "binding": {
+      "type": "object",
+      "required": [
+        "spiffe_id",
+        "aum_digest"
+      ],
+      "properties": {
+        "spiffe_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "aum_digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "session_id": {
+          "type": "string",
+          "minLength": 6
+        }
+      },
+      "additionalProperties": false
+    },
+    "capability": {
+      "type": "object",
+      "required": [
+        "kind",
+        "capability_ref",
+        "capability_digest",
+        "effect"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "mcp_tool",
+            "a2a_skill",
+            "deployment",
+            "runner_action"
+          ]
+        },
+        "capability_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "capability_digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "server": {
+          "type": "string"
+        },
+        "tool": {
+          "type": "string"
+        },
+        "agent_id": {
+          "type": "string"
+        },
+        "skill": {
+          "type": "string"
+        },
+        "deployment_id": {
+          "type": "string"
+        },
+        "operation": {
+          "type": "string"
+        },
+        "executor_ref": {
+          "type": "string"
+        },
+        "effect": {
+          "type": "string",
+          "enum": [
+            "read",
+            "write",
+            "compute",
+            "exec",
+            "egress"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "constraints": {
+      "type": "object"
+    },
+    "policy_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "quorum_proof": {
+      "$ref": "quorum_proof.schema.json"
+    },
+    "evidence_refs": {
+      "$ref": "https://socioprophet.dev/schema/governance/runtime_evidence_refs.schema.json"
+    },
+    "sig": {
+      "type": "object",
+      "required": [
+        "issuer",
+        "sig"
+      ],
+      "properties": {
+        "issuer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sig": {
+          "type": "string",
+          "minLength": 16
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/apps/compute-gateway/src/compute_gateway/schemas/policy_decision.schema.json
+++ b/apps/compute-gateway/src/compute_gateway/schemas/policy_decision.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sourceos.local/schemas/canonical/policy_decision.schema.json",
+  "title": "PolicyDecision",
+  "type": "object",
+  "required": [
+    "allow",
+    "danger_class",
+    "policy_hash",
+    "reason",
+    "constraints"
+  ],
+  "properties": {
+    "allow": {
+      "type": "boolean"
+    },
+    "danger_class": {
+      "type": "string",
+      "enum": [
+        "LOW",
+        "MEDIUM",
+        "HIGH"
+      ]
+    },
+    "policy_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "reason": {
+      "type": "string"
+    },
+    "constraints": {
+      "type": "object",
+      "properties": {
+        "ttl_sec": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 86400
+        },
+        "paths_allow": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "paths_deny": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "bytes_max": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "rate_per_min": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        },
+        "allow_domains": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "deny_methods": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": true
+    },
+    "required_quorum": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9,
+      "default": 0
+    },
+    "quorum_proof": {
+      "$ref": "quorum_proof.schema.json"
+    },
+    "evidence_refs": {
+      "$ref": "https://socioprophet.dev/schema/governance/runtime_evidence_refs.schema.json"
+    }
+  },
+  "additionalProperties": false
+}

--- a/apps/compute-gateway/src/compute_gateway/schemas/quorum_proof.schema.json
+++ b/apps/compute-gateway/src/compute_gateway/schemas/quorum_proof.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sourceos.local/schemas/canonical/quorum_proof.schema.json",
+  "title": "QuorumProof",
+  "type": "object",
+  "required": [
+    "rule",
+    "validators",
+    "signed_payload_hash",
+    "signatures"
+  ],
+  "properties": {
+    "rule": {
+      "type": "string",
+      "minLength": 1
+    },
+    "validators": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "signed_payload_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "signatures": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "kind",
+          "spiffe_id",
+          "sig"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "human"
+            ]
+          },
+          "spiffe_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sig": {
+            "type": "string",
+            "minLength": 16
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -14,7 +14,7 @@ from fastapi import Depends, FastAPI, Header, HTTPException
 
 from pydantic import BaseModel
 
-from . import artifacts, engine, planner, receipts, registry, rocrate, zerotrust
+from . import artifacts, engine, grants, planner, receipts, registry, rocrate, zerotrust
 from .contract import ComputeRequest, ComputeResult
 
 app = FastAPI(title="compute-gateway", version="0.1.0")
@@ -77,6 +77,54 @@ def plan_view(req: PlanRequest, _: None = Depends(require_token)) -> dict:
     hand `plan` to POST /v1/compute to run it under full governance."""
     return planner.plan(capabilities=req.capabilities, project=req.project,
                         intent=req.intent, entitlement=req.entitlement)
+
+
+class GrantRequestBody(BaseModel):
+    kind: str
+    backend: str | None = None
+    project: str = "default"
+    actor: str = "user"
+    session: str | None = None
+    quorum_signatures: list[dict] | None = None   # [{spiffe_id, sig}] for HIGH-danger
+
+
+@app.post("/v1/grants")
+def grant_request(req: GrantRequestBody, _: None = Depends(require_token)) -> dict:
+    """The full grant flow (deep kernel): PolicyDecision → (human quorum if HIGH) →
+    issued Grant + ledger event. A HIGH-danger (user-code) op with no quorum
+    signatures returns the decision + `quorum_required`, no grant. Present the
+    returned grant_id on /v1/compute under ZEROTRUST_ENFORCE."""
+    try:
+        kind, _d, backend = registry.resolve(req.kind, req.backend)
+    except (registry.UnknownKind, registry.UnknownBackend) as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    return grants.request_grant(kind=kind, backend=backend, project=req.project,
+                                actor=req.actor, session=req.session,
+                                quorum_signatures=req.quorum_signatures)
+
+
+@app.get("/v1/grants/ledger")
+def grant_ledger(_: None = Depends(require_token)) -> dict:
+    """The append-only grant ledger — issue / validate / revoke / deny events."""
+    led = grants.ledger()
+    return {"count": len(led), "events": led}
+
+
+@app.post("/v1/grants/{grant_id}/revoke")
+def grant_revoke(grant_id: str, _: None = Depends(require_token)) -> dict:
+    """Revoke a grant. Authoritative — every subsequent check fails closed."""
+    ok = grants.revoke(grant_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"no grant {grant_id}")
+    return {"grant_id": grant_id, "revoked": True}
+
+
+@app.get("/v1/grants/{grant_id}")
+def grant_get(grant_id: str, _: None = Depends(require_token)) -> dict:
+    g = grants.get(grant_id)
+    if g is None:
+        raise HTTPException(status_code=404, detail=f"no grant {grant_id}")
+    return {"grant": g, "validity": grants.validate(grant_id)}
 
 
 @app.get("/v1/capability-registry")

--- a/apps/compute-gateway/src/compute_gateway/zerotrust.py
+++ b/apps/compute-gateway/src/compute_gateway/zerotrust.py
@@ -110,10 +110,19 @@ def grant_check(*, project: str, kind: str, backend: str, actor: str,
     gid = grant_id or f"grant-implicit-{project}-{kind}"
     valid = entitled
     reason = "entitled" if entitled else "no entitlement for project"
+    expired = revoked = False
 
-    if ZEROTRUST_ENFORCE and needs_grant and not grant_id:
-        valid = False
-        reason = "zero-trust: user-code compute requires an explicit capability grant"
+    if ZEROTRUST_ENFORCE:
+        if grant_id:
+            # a presented grant is AUTHORITATIVE — validate it against the grant
+            # store (issued? unexpired? unrevoked? operation matches?). Revoked or
+            # expired grants fail closed regardless of entitlement.
+            from . import grants  # local import avoids a module cycle
+            v = grants.validate(grant_id, operation=f"{kind}:{backend}")
+            valid, expired, revoked, reason = v["valid"], v["expired"], v["revoked"], v["reason"]
+        elif needs_grant:
+            valid = False
+            reason = "zero-trust: user-code compute requires an explicit capability grant"
 
     check = {
         "check_id": "check-" + uuid.uuid4().hex,
@@ -121,7 +130,7 @@ def grant_check(*, project: str, kind: str, backend: str, actor: str,
         "grant_id": gid,
         "checked_at": _now(),
         "actor": {"spiffe_id": _spiffe("compute-gateway", project, "actor", actor)},
-        "result": {"valid": valid, "expired": False, "revoked": False, "reason": reason},
+        "result": {"valid": valid, "expired": expired, "revoked": revoked, "reason": reason},
         "trust_boundary_id": TRUST_BOUNDARY_ID,
         "policy_hash": _policy_hash(),
     }
@@ -164,6 +173,21 @@ def _schema(name: str) -> dict[str, Any]:
     return json.loads((_SCHEMA_DIR / f"{name}.schema.json").read_text())
 
 
+@functools.lru_cache(maxsize=1)
+def _registry() -> Any:
+    """A referencing registry of every vendored schema (keyed by $id) so canonical
+    cross-refs — e.g. grant → quorum_proof.schema.json — resolve locally, sovereignly."""
+    from referencing import Registry, Resource  # noqa: PLC0415
+
+    resources = []
+    for p in _SCHEMA_DIR.glob("*.schema.json"):
+        s = json.loads(p.read_text())
+        res = Resource.from_contents(s)
+        if "$id" in s:
+            resources.append((s["$id"], res))
+    return Registry().with_resources(resources)
+
+
 def validate(payload: dict[str, Any], schema_name: str) -> None:
     """Validate against the vendored kernel schema. Raises jsonschema.ValidationError.
 
@@ -171,4 +195,4 @@ def validate(payload: dict[str, Any], schema_name: str) -> None:
     is a conformance guarantee, not a request-path dependency)."""
     import jsonschema  # noqa: PLC0415
 
-    jsonschema.validate(payload, _schema(schema_name))
+    jsonschema.Draft202012Validator(_schema(schema_name), registry=_registry()).validate(payload)

--- a/apps/compute-gateway/tests/test_grants.py
+++ b/apps/compute-gateway/tests/test_grants.py
@@ -1,0 +1,69 @@
+"""The grant lifecycle — request → decision → quorum → issue → ledger → revoke.
+Conforms to the vendored kernel schemas (grant / policy_decision / quorum_proof)."""
+import importlib
+import os
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import grants, server, zerotrust  # noqa: E402
+
+importlib.reload(zerotrust)
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+
+def setup_function():
+    grants._reset()
+
+
+def _validate_schema(payload, name):
+    zerotrust.validate(payload, name)
+
+
+def test_low_danger_grant_issues_without_quorum():
+    r = client.post("/v1/grants", json={"kind": "graph-query", "project": "demo"}, headers=AUTH).json()
+    assert r["decision"]["danger_class"] == "LOW" and r["decision"]["required_quorum"] == 0
+    g = r["grant"]
+    assert g is not None and g["grant_id"].startswith("grant-")
+    _validate_schema(r["decision"], "policy_decision")
+    _validate_schema(g, "grant")
+    assert g["capability"]["operation"] == "graph-query:hellgraph"
+
+
+def test_high_danger_requires_quorum_then_issues():
+    # notebook = user code = HIGH → no signatures ⇒ no grant, decision returned
+    denied = client.post("/v1/grants", json={"kind": "notebook", "project": "demo"}, headers=AUTH).json()
+    assert denied["grant"] is None and denied["quorum_required"] == 1
+    assert denied["decision"]["danger_class"] == "HIGH"
+    # with a human quorum signature ⇒ grant issues, carrying a conforming quorum_proof
+    ok = client.post("/v1/grants", json={"kind": "notebook", "project": "demo",
+                     "quorum_signatures": [{"spiffe_id": "spiffe://ops/alice", "sig": "s" * 24}]},
+                     headers=AUTH).json()
+    g = ok["grant"]
+    assert g is not None
+    _validate_schema(g, "grant")
+    _validate_schema(g["quorum_proof"], "quorum_proof")
+    assert g["quorum_proof"]["rule"] == "1-of-N-human"
+
+
+def test_validate_revoke_and_ledger():
+    gid = client.post("/v1/grants", json={"kind": "graph-stats", "project": "demo"},
+                      headers=AUTH).json()["grant"]["grant_id"]
+    v = client.get(f"/v1/grants/{gid}", headers=AUTH).json()
+    assert v["validity"]["valid"] is True
+    assert client.post(f"/v1/grants/{gid}/revoke", headers=AUTH).json()["revoked"] is True
+    assert client.get(f"/v1/grants/{gid}", headers=AUTH).json()["validity"]["revoked"] is True
+    # the ledger recorded issue → validate → revoke
+    ops = [e["op"] for e in client.get("/v1/grants/ledger", headers=AUTH).json()["events"]]
+    assert "OP_GRANT_ISSUE" in ops and "OP_GRANT_REVOKE" in ops
+
+
+def test_revoke_unknown_404_and_auth():
+    assert client.post("/v1/grants/nope/revoke", headers=AUTH).status_code == 404
+    assert client.post("/v1/grants", json={"kind": "graph-query"}).status_code == 401
+    assert client.get("/v1/grants/ledger").status_code == 401

--- a/apps/compute-gateway/tests/test_zerotrust.py
+++ b/apps/compute-gateway/tests/test_zerotrust.py
@@ -17,7 +17,7 @@ os.environ["GATEWAY_SIGNING_KEY"] = base64.b64encode(b"0" * 32).decode()
 
 from fastapi.testclient import TestClient  # noqa: E402
 
-from compute_gateway import adapters, engine, receipts, registry, server, zerotrust  # noqa: E402
+from compute_gateway import adapters, engine, grants, receipts, registry, server, zerotrust  # noqa: E402
 from compute_gateway.contract import ComputeOutput  # noqa: E402
 
 importlib.reload(zerotrust)
@@ -31,6 +31,7 @@ def setup_function():
     os.environ["COMPUTE_ENTITLEMENTS"] = "demo,graph-query,graph-stats,spark"   # pin: shared env
     receipts._CHAINS.clear()
     engine._MEMO.clear()
+    grants._reset()
     zerotrust.ZEROTRUST_ENFORCE = False
 
     async def fake_forge(spec, project, session):
@@ -93,12 +94,35 @@ def test_zerotrust_enforce_fails_closed_without_grant():
     assert r2.json()["status"] in ("ok", "degraded")     # not grant_required
 
 
-def test_enforce_permits_with_grant():
+def test_enforce_permits_with_real_grant():
+    # the full deep flow: request a grant (notebook is HIGH → needs a human quorum
+    # signature), then present it on /v1/compute under enforce.
+    gr = client.post("/v1/grants", json={"kind": "notebook", "project": "demo",
+                     "quorum_signatures": [{"spiffe_id": "spiffe://x/human", "sig": "0" * 16}]},
+                     headers=AUTH).json()
+    gid = gr["grant"]["grant_id"]
     zerotrust.ZEROTRUST_ENFORCE = True
     r = client.post("/v1/compute",
                     json={"kind": "notebook", "project": "demo", "spec": {"code": "1+1"},
-                          "grant_id": "grant-xyz98765"}, headers=AUTH).json()
+                          "grant_id": gid}, headers=AUTH).json()
     assert r["status"] == "ok" and r["grant_check"]["result"]["valid"] is True
+
+
+def test_enforce_denies_unknown_and_revoked_grant():
+    zerotrust.ZEROTRUST_ENFORCE = True
+    # an unknown grant fails closed
+    r = client.post("/v1/compute", json={"kind": "notebook", "project": "demo",
+                    "spec": {"code": "x"}, "grant_id": "grant-does-not-exist"}, headers=AUTH).json()
+    assert r["status"] == "grant_required" and r["grant_check"]["result"]["reason"] == "unknown grant"
+    # a revoked grant fails closed too
+    zerotrust.ZEROTRUST_ENFORCE = False
+    gr = client.post("/v1/grants", json={"kind": "graph-query", "project": "demo"}, headers=AUTH).json()
+    gid = gr["grant"]["grant_id"]
+    client.post(f"/v1/grants/{gid}/revoke", headers=AUTH)
+    zerotrust.ZEROTRUST_ENFORCE = True
+    r2 = client.post("/v1/compute", json={"kind": "graph-query", "project": "demo",
+                     "spec": {"label": "demo"}, "grant_id": gid}, headers=AUTH).json()
+    assert r2["status"] == "grant_required" and r2["grant_check"]["result"]["revoked"] is True
 
 
 # ── AttestationBundle over the signed receipt ──


### PR DESCRIPTION
Final tranche. Beyond the self-issued ToolGrantCheck (#853): the **full grant flow** our authority kernel (`mcp-a2a-zero-trust`) defines — **PolicyDecision → human quorum (HIGH danger) → issued Grant → ledger → validate → revoke**. Grants become **authoritative**.

## What
- **`grants.py`** — the lifecycle:
  - `decide()` → a conforming **PolicyDecision** (danger class · required quorum · constraints)
  - `request_grant()` → a **HIGH-danger** (user-code) op requires a **1-of-N human quorum** before a Grant issues; the Grant is Ed25519-signed when a key is present, and carries a conforming **quorum_proof**
  - `validate()` → **authoritative**: revoked / expired / unknown grants **fail closed**
  - `revoke()` + an **append-only ledger** (`OP_GRANT_ISSUE / VALIDATE / REVOKE / DENY`)
  - conforms to the **vendored** `grant` / `policy_decision` / `quorum_proof` schemas
  - **transport seam** (`ISSUER`) forwards to the real kernel over **noetica-mcp / TriTRPC** when wired — the contract and ledger shape never change
- **`zerotrust.grant_check`** now consults `grants.validate()` when a grant_id is presented under `ZEROTRUST_ENFORCE` — the check is chained to the real grant lifecycle (a revoked grant fails every subsequent compute closed).
- **endpoints** — `POST /v1/grants`, `POST /v1/grants/{id}/revoke`, `GET /v1/grants/{id}`, `GET /v1/grants/ledger`.
- **`zerotrust.validate`** now uses a `referencing` registry over the vendored schemas so canonical cross-refs (grant → quorum_proof) resolve locally + sovereignly.

## Proof
50 tests green (7 new + updated enforce tests): schema-conformant decision/grant/quorum, HIGH-danger quorum gating, validate/revoke/ledger, enforce denies unknown + revoked grants.