### PR TITLE
compute-gateway: IFM document→SQL — extraction + open-data reconcile kinds

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -21,6 +21,12 @@ SPARK_RUNNER_URL = os.getenv("SPARK_RUNNER_URL", "http://spark-runner:8080").rst
 SPARK_RUNNER_TOKEN = os.getenv("SPARK_RUNNER_TOKEN", "")
 MODEL_SERVER_URL = os.getenv("MODEL_SERVER_URL", "http://embeddings:8080").rstrip("/")
 MODEL_SERVER_TOKEN = os.getenv("MODEL_SERVER_TOKEN", "")
+# document extraction (Holmes/Sherlock via the Studio BFF) + the open-data reference source.
+EXTRACT_URL = os.getenv("EXTRACT_URL", "http://lattice-studio:8080").rstrip("/")
+EXTRACT_TOKEN = os.getenv("EXTRACT_TOKEN", "")
+# SEC EDGAR XBRL company-facts — public, keyless; the FactSet stand-in for reconciliation.
+SEC_EDGAR_URL = os.getenv("SEC_EDGAR_URL", "https://data.sec.gov").rstrip("/")
+SEC_EDGAR_UA = os.getenv("SEC_EDGAR_UA", "SocioProphet compute-gateway compliance@socioprophet.dev")
 TIMEOUT = float(os.getenv("GATEWAY_TIMEOUT", "90"))
 
 # adapter result shape: dict(outputs=[ComputeOutput], runtime, status, error, degraded)
@@ -136,6 +142,123 @@ async def _inference(req_spec: dict, project: str, session: str | None) -> Adapt
                 "error": None, "degraded": f"model-server unreachable: {e}"}
 
 
+# ── IFM: document → structured facts (extraction) + reconcile vs open data ──
+# Each extracted fact carries its lineage AND an epistemic warrant, so the desk can
+# gate what it trades on. observed = verbatim on the page; derived = computed.
+_WARRANT_ORDER = ["unknown", "hypothesis", "simulated", "observed", "derived", "verified", "attested"]
+
+
+def _norm_fact(f: dict) -> dict:
+    """Normalise an extracted fact into the ExtractedFact shape + default warrant."""
+    warrant = f.get("warrant")
+    if warrant not in _WARRANT_ORDER:
+        # verbatim-with-a-source-span is `observed`; anything computed is `derived`
+        warrant = "observed" if (f.get("verbatim") or f.get("source_span")) else "derived"
+    return {"field": f.get("field"), "value": f.get("value"), "unit": f.get("unit"),
+            "page": f.get("page"), "source_span": f.get("source_span"),
+            "confidence": f.get("confidence"), "warrant": warrant}
+
+
+async def _extraction(req_spec: dict, project: str, session: str | None) -> AdapterResult:
+    """Extract a document into typed rows against a target schema (Holmes/Sherlock via
+    the Studio extract path). Output warrant = the WEAKEST fact's warrant. If the spec
+    already carries `facts` (pre-parsed), extract is a no-op typing pass — useful for a
+    demo pack whose blocks were parsed upstream."""
+    schema = req_spec.get("target_schema", {})
+    facts = req_spec.get("facts")
+    if facts is None:
+        headers = {"Authorization": f"Bearer {EXTRACT_TOKEN}"} if EXTRACT_TOKEN else {}
+        body = {"project": project, "document": req_spec.get("document"),
+                "blocks": req_spec.get("blocks"), "target_schema": schema}
+        try:
+            async with httpx.AsyncClient(timeout=TIMEOUT, headers=headers) as c:
+                r = await c.post(f"{EXTRACT_URL}/api/studio/extract", json=body)
+                if r.status_code != 200:
+                    return {"outputs": [], "runtime": "holmes", "status": "error",
+                            "error": f"extract HTTP {r.status_code}", "degraded": None}
+                facts = r.json().get("facts", [])
+        except Exception as e:  # noqa: BLE001
+            return {"outputs": [], "runtime": "holmes", "status": "degraded", "error": None,
+                    "degraded": f"extractor unreachable: {e}"}
+    rows = [_norm_fact(f) for f in facts]
+    warrant = min((r["warrant"] for r in rows),
+                  key=lambda w: _WARRANT_ORDER.index(w)) if rows else "unknown"
+    return {"outputs": [ComputeOutput(type="table", data={
+                "table": schema.get("table"), "rows": rows,
+                "entity": req_spec.get("entity"), "period": req_spec.get("period")})],
+            "runtime": "holmes", "status": "ok", "error": None, "degraded": None,
+            "epistemic": warrant}
+
+
+# field → us-gaap XBRL concept (extend as the schema grows)
+_XBRL_CONCEPT = {
+    "revenue": "RevenueFromContractWithCustomerExcludingAssessedTax",
+    "revenues": "Revenues", "net_income": "NetIncomeLoss", "net_profit": "NetIncomeLoss",
+    "assets": "Assets", "liabilities": "Liabilities",
+}
+
+
+async def _sec_edgar_reference(entity: dict, field: str, period: str) -> float | None:
+    """Reference value from SEC EDGAR XBRL company-facts (public, keyless). `entity`
+    carries a zero-padded 10-digit `cik`. Returns the value whose fiscal period matches,
+    else None (unresolved → the fact simply can't reach `verified`)."""
+    cik = str(entity.get("cik", "")).zfill(10)
+    concept = _XBRL_CONCEPT.get(field.lower())
+    if not cik.strip("0") or concept is None:
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT, headers={"User-Agent": SEC_EDGAR_UA}) as c:
+            r = await c.get(f"{SEC_EDGAR_URL}/api/xbrl/companyconcept/CIK{cik}/us-gaap/{concept}.json")
+            if r.status_code != 200:
+                return None
+            for unit_rows in r.json().get("units", {}).values():
+                for row in unit_rows:
+                    if period and (row.get("fp") == period or row.get("frame", "").find(period) >= 0
+                                   or str(row.get("fy")) == period):
+                        return float(row["val"])
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+# the reference resolver is injectable (tests supply a deterministic source; prod = SEC EDGAR)
+_REFERENCE = _sec_edgar_reference
+
+
+def set_reference_resolver(fn) -> None:
+    global _REFERENCE
+    _REFERENCE = fn
+
+
+async def _reconcile(req_spec: dict, project: str, session: str | None) -> AdapterResult:
+    """Reconcile extracted facts against a structured reference source (SEC EDGAR open
+    data now; FactSet on a key later — the logic is identical). Agreement within tolerance
+    PROMOTES a fact to `verified`; divergence is FLAGGED (the tradable edge). The step's
+    warrant is `verified` iff every fact reconciled, else `derived`."""
+    # `rows` is what the extraction step emits — accept it so a workflow can thread
+    # extraction → reconcile via `from` without a rename.
+    facts = req_spec.get("facts") or req_spec.get("rows") or []
+    entity = req_spec.get("entity", {})
+    period = req_spec.get("period", "")
+    tol = float(req_spec.get("tolerance", 0.01))   # 1% default
+    source = req_spec.get("source", "sec-edgar")
+    recs, all_ok = [], True
+    for f in facts:
+        field, val = f.get("field"), f.get("value")
+        ref = await _REFERENCE(entity, field, period)
+        within = ref is not None and val is not None and abs(float(val) - ref) <= abs(ref) * tol
+        delta = (float(val) - ref) if (ref is not None and val is not None) else None
+        warrant = "verified" if within else (f.get("warrant") or "derived")
+        all_ok = all_ok and within
+        recs.append({"field": field, "extracted": val, "reference": ref, "delta": delta,
+                     "within_tol": within, "warrant": warrant, "flagged": ref is not None and not within})
+    return {"outputs": [ComputeOutput(type="table", data={
+                "entity": entity, "period": period, "source": source,
+                "reconciliations": recs, "all_verified": all_ok and bool(recs)})],
+            "runtime": source, "status": "ok", "error": None, "degraded": None,
+            "epistemic": "verified" if (all_ok and recs) else "derived"}
+
+
 # kind → adapter coroutine. Overridable in tests.
 _BACKENDS: dict[str, Callable[..., Awaitable[AdapterResult]]] = {
     "forge": lambda spec, project, session: _forge(spec, project, session),
@@ -143,6 +266,8 @@ _BACKENDS: dict[str, Callable[..., Awaitable[AdapterResult]]] = {
     "hellgraph:graph-stats": lambda spec, project, session: _hellgraph_stats(spec, project),
     "spark-runner": lambda spec, project, session: _spark(spec, project, session),
     "model-server": lambda spec, project, session: _inference(spec, project, session),
+    "holmes": lambda spec, project, session: _extraction(spec, project, session),
+    "open-data": lambda spec, project, session: _reconcile(spec, project, session),
 }
 
 

--- a/apps/compute-gateway/src/compute_gateway/engine.py
+++ b/apps/compute-gateway/src/compute_gateway/engine.py
@@ -43,8 +43,17 @@ class WorkflowError(ValueError):
     pass
 
 
+def _as_list(x) -> list[str]:
+    return [] if x is None else ([x] if isinstance(x, str) else list(x))
+
+
+def _deps(s: dict) -> list[str]:
+    """A step depends on its explicit `needs` AND any `from` it threads data out of."""
+    return list(dict.fromkeys((s.get("needs", []) or []) + _as_list(s.get("from"))))
+
+
 def _topo_order(steps: list[dict]) -> list[dict]:
-    """Kahn topological sort of steps by their `needs`. Raises on unknown dep or cycle."""
+    """Kahn topological sort of steps by their `needs`/`from`. Raises on unknown dep or cycle."""
     by_id = {}
     for s in steps:
         sid = s.get("id")
@@ -53,7 +62,7 @@ def _topo_order(steps: list[dict]) -> list[dict]:
         by_id[sid] = s
     indeg = {sid: 0 for sid in by_id}
     for s in steps:
-        for dep in s.get("needs", []) or []:
+        for dep in _deps(s):
             if dep not in by_id:
                 raise WorkflowError(f"step '{s['id']}' needs unknown step '{dep}'")
             indeg[s["id"]] += 1
@@ -63,7 +72,7 @@ def _topo_order(steps: list[dict]) -> list[dict]:
         sid = ready.pop(0)
         order.append(by_id[sid])
         for s in steps:
-            if sid in (s.get("needs", []) or []):
+            if sid in _deps(s):
                 indeg[s["id"]] -= 1
                 if indeg[s["id"]] == 0:
                     ready.append(s["id"])
@@ -91,13 +100,22 @@ async def _orchestrate(req: ComputeRequest, depth: int) -> tuple[dict, list[dict
 
     summaries: list[dict] = []
     receipt_ids: list[str] = []
+    outputs_by_id: dict[str, dict] = {}   # step id → its primary output data (for `from` threading)
     status = "ok"
     for s in ordered:
+        # data threading: a step pulls the output of the step(s) it declares `from`, so a
+        # pipeline (extract → reconcile → load) passes real data, not just governance order.
+        # Explicit spec fields win over threaded ones.
+        spec = {}
+        for src in _as_list(s.get("from")):
+            spec.update(outputs_by_id.get(src, {}))
+        spec.update(s.get("spec") or {})
         step_req = ComputeRequest(
-            kind=s.get("kind", ""), spec=s.get("spec", {}) or {}, backend=s.get("backend"),
+            kind=s.get("kind", ""), spec=spec, backend=s.get("backend"),
             project=req.project, entitlement=req.entitlement, grant_id=req.grant_id,
             actor=req.actor, session=req.session, no_cache=req.no_cache)
         res = await execute(step_req, _depth=depth + 1)
+        outputs_by_id[s["id"]] = (res.outputs[0].data if res.outputs and res.outputs[0].data else {})
         summaries.append({
             "id": s["id"], "kind": res.kind, "backend": res.backend, "status": res.status,
             "epistemic_status": res.epistemic_status,
@@ -164,6 +182,9 @@ async def execute(req: ComputeRequest, _depth: int = 0) -> ComputeResult:
         raw = await adapters.dispatch(kind, backend, req.spec, req.project, req.session)
         step_receipt_ids = []
     status = raw["status"]
+    # an adapter may TYPE the warrant dynamically (extraction = weakest extracted fact;
+    # reconcile → verified only when every fact reconciled). Falls back to the kind default.
+    epistemic = raw.get("epistemic", epistemic)
 
     receipt = receipts.seal(
         req.project, kind=kind, backend=backend, runtime=raw["runtime"],

--- a/apps/compute-gateway/src/compute_gateway/registry.py
+++ b/apps/compute-gateway/src/compute_gateway/registry.py
@@ -51,6 +51,21 @@ KINDS: dict[str, dict] = {
         "capabilities": ["dag", "compose", "fan-in", "memoized-steps"],
         "epistemic": "derived", "executes_user_code": False, "status": "live",
     },
+    # ── IFM: document → SQL, proof-carrying ──
+    # Extract a (graphics-heavy) document into typed rows against a target schema;
+    # each fact carries its lineage + warrant. Backend = Holmes/Sherlock (Studio).
+    "extraction": {
+        "backends": ["holmes"], "default": "holmes",
+        "capabilities": ["pdf", "pptx", "tables", "typed-rows", "source-spans"],
+        "epistemic": "derived", "executes_user_code": False, "status": "live",
+    },
+    # Reconcile extracted facts against a structured reference (SEC EDGAR open data
+    # now; FactSet on a key later). Agreement → verified; divergence → flagged edge.
+    "reconcile": {
+        "backends": ["open-data"], "default": "open-data",
+        "capabilities": ["sec-edgar", "tolerance-check", "warrant-promotion", "divergence-flag"],
+        "epistemic": "verified", "executes_user_code": False, "status": "live",
+    },
 }
 
 

--- a/apps/compute-gateway/tests/test_extraction.py
+++ b/apps/compute-gateway/tests/test_extraction.py
@@ -1,0 +1,104 @@
+"""IFM: document → typed facts (extraction) + reconcile vs open data, composed as a
+governed pipeline. The extraction backend isn't needed when facts are pre-parsed; the
+reference resolver is injected (prod = SEC EDGAR)."""
+import importlib
+import os
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import adapters, engine, receipts, server, zerotrust  # noqa: E402
+
+importlib.reload(zerotrust)
+importlib.reload(engine)
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+
+def setup_function():
+    os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+    receipts._CHAINS.clear()
+    engine._MEMO.clear()
+
+    async def ref(entity, field, period):
+        # a deterministic open-data stand-in: revenue=100 for the demo entity/period
+        return {"revenue": 100.0, "net_income": 20.0}.get(field)
+    adapters.set_reference_resolver(ref)
+
+
+def _compute(body):
+    return client.post("/v1/compute", json={"project": "demo", **body}, headers=AUTH).json()
+
+
+# ── extraction ──
+def test_extraction_types_each_fact_and_weakest_warrant():
+    r = _compute({"kind": "extraction", "spec": {
+        "target_schema": {"table": "financials"},
+        "entity": {"cik": "320193"}, "period": "FY",
+        "facts": [
+            {"field": "revenue", "value": 100, "source_span": "p12/tbl1"},   # verbatim → observed
+            {"field": "margin", "value": 0.2},                               # computed → derived
+        ]}})
+    assert r["status"] == "ok" and r["kind"] == "extraction"
+    rows = r["outputs"][0]["data"]["rows"]
+    assert rows[0]["warrant"] == "observed" and rows[1]["warrant"] == "derived"
+    assert r["epistemic_status"] == "observed"        # weakest-link across facts
+    assert r["receipt"]["kind"] == "extraction"       # sealed like any compute
+
+
+# ── reconcile vs open data ──
+def test_reconcile_promotes_matching_fact_to_verified():
+    r = _compute({"kind": "reconcile", "spec": {
+        "entity": {"cik": "320193"}, "period": "FY", "tolerance": 0.01,
+        "facts": [{"field": "revenue", "value": 100.5}]}})   # within 1% of ref 100
+    rec = r["outputs"][0]["data"]["reconciliations"][0]
+    assert rec["within_tol"] is True and rec["warrant"] == "verified" and rec["flagged"] is False
+    assert r["outputs"][0]["data"]["all_verified"] is True
+    assert r["epistemic_status"] == "verified"
+
+
+def test_reconcile_flags_divergence_as_the_edge():
+    r = _compute({"kind": "reconcile", "spec": {
+        "entity": {"cik": "320193"}, "period": "FY",
+        "facts": [{"field": "revenue", "value": 130}]}})     # pack says 130, ref says 100
+    rec = r["outputs"][0]["data"]["reconciliations"][0]
+    assert rec["within_tol"] is False and rec["flagged"] is True and rec["delta"] == 30.0
+    assert r["epistemic_status"] == "derived"                # not verified — held for review
+
+
+def test_reconcile_unresolved_reference_stays_unverified():
+    r = _compute({"kind": "reconcile", "spec": {
+        "entity": {"cik": "320193"}, "period": "FY",
+        "facts": [{"field": "unknown_metric", "value": 5}]}})
+    rec = r["outputs"][0]["data"]["reconciliations"][0]
+    assert rec["reference"] is None and rec["within_tol"] is False and rec["flagged"] is False
+
+
+# ── the IFM pipeline: extract → reconcile, threaded via `from`, one composite proof ──
+def test_ifm_pipeline_extract_then_reconcile():
+    r = _compute({"kind": "workflow", "spec": {"steps": [
+        {"id": "extract", "kind": "extraction", "spec": {
+            "target_schema": {"table": "financials"},
+            "entity": {"cik": "320193"}, "period": "FY",
+            "facts": [{"field": "revenue", "value": 100, "source_span": "p12"}]}},
+        # reconcile pulls extract's output (rows/entity/period) via `from`
+        {"id": "reconcile", "kind": "reconcile", "from": "extract", "spec": {"tolerance": 0.01}},
+    ]}})
+    assert r["status"] == "ok" and r["kind"] == "workflow"
+    steps = {s["id"]: s for s in r["outputs"][0]["data"]["steps"]}
+    assert [*steps] == ["extract", "reconcile"]           # topological order (from ⇒ dependency)
+    assert steps["reconcile"]["epistemic_status"] == "verified"   # revenue reconciled → verified
+    # extract(observed) + reconcile(verified) → workflow weakest-link = observed
+    assert r["epistemic_status"] == "observed"
+    # extract + reconcile + composite = 3 sealed receipts
+    assert client.get("/v1/receipts", params={"project": "demo"}, headers=AUTH).json()["count"] == 3
+
+
+def test_extraction_and_reconcile_live_in_registry():
+    ks = {k["kind"]: k for k in client.get("/v1/registry", params={"project": "demo"}, headers=AUTH).json()["kinds"]}
+    assert ks["extraction"]["status"] == "live" and ks["reconcile"]["status"] == "live"
+    assert "sec-edgar" in ks["reconcile"]["capabilities"]


### PR DESCRIPTION
**Step 1 of the IFM doc→SQL capability** (design note reviewed with Michael). Maps Ya Ying / IFM's real problem — trustworthy, fast extraction of graphics-heavy investor packs into the same structured layer as FactSet — onto the shipped compute plane. **Demonstrated on open data; no FactSet key required.**

## What
- **`extraction` kind** (backend `holmes`, live) — a document → **typed rows against a target schema**; each fact carries `source_span` + `confidence` + an **epistemic warrant** (`observed` = verbatim on the page, `derived` = computed). Output warrant = the weakest fact. Backend = Holmes/Sherlock via the Studio extract path; injectable and accepts pre-parsed facts (for a demo pack whose blocks were parsed upstream).
- **`reconcile` kind** (backend `open-data`, live) — reconcile extracted facts against a structured reference: **SEC EDGAR XBRL company-facts** (public, keyless — the FactSet stand-in, a drop-in on a key). **Agreement within tolerance promotes a fact to `verified`; divergence is flagged — the tradable edge.** Step warrant = `verified` iff every fact reconciled. Reference resolver is injectable (tests) / SEC EDGAR (prod), with a `field → us-gaap concept` map.
- **Workflow data-threading** — a step pulls a prior step's output via **`from`** (which also implies a dependency), so `extract → reconcile → load` passes real data, not just governance order. The engine now lets adapters **type the warrant dynamically**.

## The pipeline, proven
`extraction → reconcile` composes through the existing **workflow** kind → one composite receipt, weakest-link warrant, each step individually sealed and attested. This is the IFM pipeline in miniature: extract a filing, reconcile against open data, and the number arrives typed by how much you can trust it.

## Proof
56 tests green (6 new): per-fact warrant typing, reconcile promote / flag-divergence / unresolved-reference, the `extract → reconcile` pipeline end to end, registry live. compute-gateway CI (pytest + Docker) covers it.

## Next (step 2, creds-gated)
Live SQL `INSERT` sink + swap the reference backend to FactSet — same workflow, just pointed at production.