### PR TITLE
compute-gateway: IFM SQL load sink — close the doc→SQL loop

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -8,6 +8,8 @@ Adapters are injectable (`set_backend`) so tests never need a live forge/graph.
 from __future__ import annotations
 
 import os
+import sqlite3
+import time
 from typing import Any, Awaitable, Callable
 
 import httpx
@@ -259,6 +261,73 @@ async def _reconcile(req_spec: dict, project: str, session: str | None) -> Adapt
             "epistemic": "verified" if (all_ok and recs) else "derived"}
 
 
+# ── IFM: load reconciled facts into the structured SQL layer (the doc→SQL sink) ──
+SQL_LOAD_DSN = os.getenv("SQL_LOAD_DSN", "sqlite:////tmp/ifm_extract.db")
+
+
+def _sqlite_path(dsn: str) -> str:
+    return dsn[len("sqlite:///"):] if dsn.startswith("sqlite:///") else dsn
+
+
+async def _sql_load(req_spec: dict, project: str, session: str | None) -> AdapterResult:
+    """Upsert reconciled facts into the consolidated SQL layer, keyed by (entity, period,
+    field), each row carrying its warrant + reference + source. Demonstrated against a
+    sovereign SQLite file (no creds); a Postgres DSN is the production swap. The load
+    step's warrant is the WEAKEST row loaded — you can't trust the table more than its
+    least-trustworthy cell."""
+    rows = req_spec.get("rows") or req_spec.get("reconciliations") or req_spec.get("facts") or []
+    table = req_spec.get("table") or (req_spec.get("target_schema") or {}).get("table") or "extracted_facts"
+    if not table.replace("_", "").isalnum():
+        return {"outputs": [], "runtime": "sql", "status": "error",
+                "error": f"unsafe table name: {table!r}", "degraded": None}
+    entity = req_spec.get("entity", {})
+    ent_id = str(entity.get("cik") or entity.get("name") or entity) if isinstance(entity, dict) else str(entity)
+    period, source = str(req_spec.get("period", "")), str(req_spec.get("source", "extraction"))
+    if not rows:
+        return {"outputs": [], "runtime": "sql", "status": "degraded", "error": None,
+                "degraded": "no rows to load"}
+    dsn = req_spec.get("dsn") or SQL_LOAD_DSN
+    if not dsn.startswith("sqlite"):
+        # Postgres/other = the production sink; the driver isn't vendored in the gateway.
+        return {"outputs": [], "runtime": "sql", "status": "degraded", "error": None,
+                "degraded": f"non-sqlite DSN needs the production driver (swap here): {dsn.split('://')[0]}"}
+    warrants = []
+    try:
+        con = sqlite3.connect(_sqlite_path(dsn))
+        con.execute(f"CREATE TABLE IF NOT EXISTS {table} (entity TEXT, period TEXT, field TEXT, "
+                    "value TEXT, warrant TEXT, reference TEXT, within_tol INTEGER, source TEXT, "
+                    "loaded_at TEXT, PRIMARY KEY(entity, period, field))")
+        inserted = updated = 0
+        now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        for r in rows:
+            field = r.get("field")
+            value = r.get("extracted", r.get("value"))
+            warrant = r.get("warrant") or "derived"
+            warrants.append(warrant)
+            exists = con.execute(f"SELECT 1 FROM {table} WHERE entity=? AND period=? AND field=?",
+                                 (ent_id, period, field)).fetchone() is not None
+            con.execute(
+                f"INSERT INTO {table}(entity,period,field,value,warrant,reference,within_tol,source,loaded_at) "
+                "VALUES(?,?,?,?,?,?,?,?,?) ON CONFLICT(entity,period,field) DO UPDATE SET "
+                "value=excluded.value, warrant=excluded.warrant, reference=excluded.reference, "
+                "within_tol=excluded.within_tol, source=excluded.source, loaded_at=excluded.loaded_at",
+                (ent_id, period, field, str(value), warrant,
+                 str(r.get("reference")), 1 if r.get("within_tol") else 0, source, now))
+            inserted, updated = (inserted, updated + 1) if exists else (inserted + 1, updated)
+        con.commit()
+        total = con.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+        con.close()
+    except Exception as e:  # noqa: BLE001
+        return {"outputs": [], "runtime": "sql", "status": "error",
+                "error": f"sql load failed: {e}", "degraded": None}
+    weakest = min(warrants, key=lambda w: _WARRANT_ORDER.index(w) if w in _WARRANT_ORDER else 0)
+    return {"outputs": [ComputeOutput(type="table", data={
+                "table": table, "target": dsn, "inserted": inserted, "updated": updated,
+                "rows_written": inserted + updated, "table_total": total,
+                "entity": ent_id, "period": period})],
+            "runtime": "sql", "status": "ok", "error": None, "degraded": None, "epistemic": weakest}
+
+
 # kind → adapter coroutine. Overridable in tests.
 _BACKENDS: dict[str, Callable[..., Awaitable[AdapterResult]]] = {
     "forge": lambda spec, project, session: _forge(spec, project, session),
@@ -268,6 +337,7 @@ _BACKENDS: dict[str, Callable[..., Awaitable[AdapterResult]]] = {
     "model-server": lambda spec, project, session: _inference(spec, project, session),
     "holmes": lambda spec, project, session: _extraction(spec, project, session),
     "open-data": lambda spec, project, session: _reconcile(spec, project, session),
+    "sql": lambda spec, project, session: _sql_load(spec, project, session),
 }
 
 

--- a/apps/compute-gateway/src/compute_gateway/registry.py
+++ b/apps/compute-gateway/src/compute_gateway/registry.py
@@ -66,6 +66,13 @@ KINDS: dict[str, dict] = {
         "capabilities": ["sec-edgar", "tolerance-check", "warrant-promotion", "divergence-flag"],
         "epistemic": "verified", "executes_user_code": False, "status": "live",
     },
+    # Load reconciled facts into the structured SQL layer (the doc→SQL sink), keyed by
+    # (entity, period, field) + warrant. Sovereign SQLite now; Postgres DSN = prod swap.
+    "load": {
+        "backends": ["sql"], "default": "sql",
+        "capabilities": ["upsert", "sqlite", "keyed-by-entity-period", "warrant-tagged"],
+        "epistemic": "derived", "executes_user_code": False, "status": "live",
+    },
 }
 
 

--- a/apps/compute-gateway/tests/test_sql_load.py
+++ b/apps/compute-gateway/tests/test_sql_load.py
@@ -1,0 +1,103 @@
+"""IFM step 2: the SQL load sink — reconciled facts into the structured layer, with a
+REAL SQLite write (sovereign, no creds). Closes the doc→SQL loop end to end."""
+import importlib
+import os
+import pathlib
+
+_DB = f"/tmp/test_ifm_{os.getpid()}.db"
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+os.environ["SQL_LOAD_DSN"] = f"sqlite:///{_DB}"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import adapters, engine, receipts, server, zerotrust  # noqa: E402
+
+importlib.reload(zerotrust)
+importlib.reload(engine)
+importlib.reload(adapters)
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+
+def setup_function():
+    os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+    receipts._CHAINS.clear()
+    engine._MEMO.clear()
+    pathlib.Path(_DB).unlink(missing_ok=True)   # fresh DB per test
+
+    async def ref(entity, field, period):
+        return {"revenue": 100.0, "net_income": 20.0}.get(field)
+    adapters.set_reference_resolver(ref)
+
+
+def _compute(body):
+    return client.post("/v1/compute", json={"project": "demo", **body}, headers=AUTH).json()
+
+
+def _rows():
+    import sqlite3
+    con = sqlite3.connect(_DB)
+    out = con.execute("SELECT entity, period, field, value, warrant FROM financials ORDER BY field").fetchall()
+    con.close()
+    return out
+
+
+def test_load_writes_rows_and_upserts():
+    body = {"kind": "load", "spec": {
+        "table": "financials", "entity": {"cik": "320193"}, "period": "FY",
+        "rows": [{"field": "revenue", "value": 100, "warrant": "verified"},
+                 {"field": "net_income", "value": 20, "warrant": "derived"}]}}
+    r = _compute(body)
+    assert r["status"] == "ok" and r["kind"] == "load"
+    d = r["outputs"][0]["data"]
+    assert d["inserted"] == 2 and d["updated"] == 0 and d["table_total"] == 2
+    assert len(_rows()) == 2
+    # re-load with a changed value → upsert (update, not duplicate)
+    body["spec"]["rows"][0]["value"] = 105
+    d2 = _compute(body)["outputs"][0]["data"]
+    assert d2["inserted"] == 0 and d2["updated"] == 2 and d2["table_total"] == 2
+    assert dict((f, v) for _, _, f, v, _ in _rows())["revenue"] == "105"
+
+
+def test_load_warrant_is_weakest_row():
+    r = _compute({"kind": "load", "spec": {
+        "table": "financials", "entity": {"cik": "1"}, "period": "FY",
+        "rows": [{"field": "revenue", "value": 1, "warrant": "verified"},
+                 {"field": "margin", "value": 0.2, "warrant": "derived"}]}})
+    assert r["epistemic_status"] == "derived"   # weakest of {verified, derived}
+
+
+def test_load_non_sqlite_dsn_degrades_honestly():
+    r = _compute({"kind": "load", "spec": {
+        "table": "financials", "entity": {"cik": "1"}, "period": "FY", "dsn": "postgres://prod/db",
+        "rows": [{"field": "revenue", "value": 1, "warrant": "verified"}]}})
+    assert r["status"] == "degraded" and "production driver" in r["degraded"]
+
+
+def test_full_ifm_pipeline_extract_reconcile_load():
+    r = _compute({"kind": "workflow", "spec": {"steps": [
+        {"id": "extract", "kind": "extraction", "spec": {
+            "target_schema": {"table": "financials"},
+            "entity": {"cik": "320193"}, "period": "FY",
+            "facts": [{"field": "revenue", "value": 100, "source_span": "p12"}]}},
+        {"id": "reconcile", "kind": "reconcile", "from": "extract", "spec": {"tolerance": 0.01}},
+        {"id": "load", "kind": "load", "from": "reconcile", "spec": {"table": "financials"}},
+    ]}})
+    assert r["status"] == "ok" and r["kind"] == "workflow"
+    steps = {s["id"]: s for s in r["outputs"][0]["data"]["steps"]}
+    assert [*steps] == ["extract", "reconcile", "load"]        # topological
+    assert steps["reconcile"]["epistemic_status"] == "verified"
+    assert steps["load"]["status"] == "ok"
+    # the row landed in the SQL layer, tagged verified (it reconciled with open data)
+    rows = _rows()
+    assert len(rows) == 1 and rows[0][2] == "revenue" and rows[0][4] == "verified"
+    # extract + reconcile + load + composite = 4 sealed receipts
+    assert client.get("/v1/receipts", params={"project": "demo"}, headers=AUTH).json()["count"] == 4
+
+
+def test_load_live_in_registry():
+    ks = {k["kind"]: k for k in client.get("/v1/registry", params={"project": "demo"}, headers=AUTH).json()["kinds"]}
+    assert ks["load"]["status"] == "live" and "upsert" in ks["load"]["capabilities"]


### PR DESCRIPTION
**Step 2 of the IFM capability.** Reconciled facts now land in the structured SQL layer, completing **ingest → extract → reconcile → load** as one governed pipeline. Demonstrated end to end on **open data with a real SQLite write — no creds**.

## What
- **`load` kind** (backend `sql`, live) — upsert reconciled facts into the SQL layer, keyed by **(entity, period, field)**, each row tagged with its **warrant + reference + source**. A real, sovereign **SQLite** write now; a **Postgres DSN is the production swap** (degrades honestly on a non-sqlite DSN — the driver isn't vendored in the gateway). Table name validated against injection. Load-step warrant = the **weakest row** (you can't trust the table more than its least-trustworthy cell).

## The full loop, proven
```
extract  → warrant-typed rows from the document
reconcile → vs SEC EDGAR open data → verified / flagged
load     → upsert into SQL, keyed + warrant-tagged
```
composed through the **workflow** kind, threaded with `from`, sealed into **4 receipts** (one per step + composite). The row lands in SQLite tagged `verified` because it reconciled with open data.

## Proof
61 tests green (5 new): insert + upsert (re-load updates, no duplicate), weakest-row warrant, non-sqlite honest-degrade, registry live, and **the full extract→reconcile→load pipeline**.

## Production
Swap the `load` DSN to IFM's consolidated DB + the reconcile reference to FactSet — same workflow, no rework.