### PR TITLE
ci: provision-secrets — send app tokens through CI, not out-of-band

### DIFF
--- a/.github/workflows/provision-secrets.yml
+++ b/.github/workflows/provision-secrets.yml
@@ -1,0 +1,75 @@
+name: provision-secrets
+
+# Provision app-token Secrets into the cluster THROUGH CI — no out-of-band kubectl.
+# The token VALUES live in GitHub Actions secrets (set once in repo/org settings); this
+# workflow materializes them as Kubernetes Secrets in the right namespaces using the
+# estate's GCP Workload Identity Federation (the same WIF helm-release.yml uses).
+# Idempotent: `kubectl create ... --dry-run=client | kubectl apply -f -`.
+#
+# One-time setup (repo settings):
+#   • Variables:  GKE_CLUSTER, GKE_LOCATION  (the prophet-platform GKE Autopilot cluster)
+#   • Secrets:    GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT  (already set),
+#                 plus the token values: SPARK_RUNNER_TOKEN, LATTICE_FORGE_TOKEN,
+#                 COMPUTE_GATEWAY_TOKEN, STUDIO_WRITE_TOKEN
+#
+# Run: Actions → provision-secrets → Run workflow (optionally scope with `only`).
+# Rotate a token = update the GitHub secret, re-run. A missing value is skipped, not errored.
+
+on:
+  workflow_dispatch:
+    inputs:
+      only:
+        description: "Comma-separated secret names to provision (blank = all)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  id-token: write   # required for WIF
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    steps:
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER }}
+          location: ${{ vars.GKE_LOCATION }}
+
+      - name: Materialize token Secrets
+        env:
+          SPARK_RUNNER_TOKEN: ${{ secrets.SPARK_RUNNER_TOKEN }}
+          LATTICE_FORGE_TOKEN: ${{ secrets.LATTICE_FORGE_TOKEN }}
+          COMPUTE_GATEWAY_TOKEN: ${{ secrets.COMPUTE_GATEWAY_TOKEN }}
+          STUDIO_WRITE_TOKEN: ${{ secrets.STUDIO_WRITE_TOKEN }}
+          ONLY: ${{ inputs.only }}
+        run: |
+          set -euo pipefail
+
+          # sync <secret-name> <key> <value> <namespace...>
+          sync() {
+            local name="$1" key="$2" val="$3"; shift 3
+            if [ -z "$val" ]; then echo "· skip $name (no value in GitHub secrets)"; return 0; fi
+            if [ -n "$ONLY" ] && ! printf ',%s,' "$ONLY" | grep -q ",$name,"; then
+              echo "· skip $name (not in 'only' filter)"; return 0
+            fi
+            for ns in "$@"; do
+              kubectl create secret generic "$name" -n "$ns" \
+                --from-literal="$key=$val" --dry-run=client -o yaml | kubectl apply -f -
+              echo "✔ $name → namespace/$ns"
+            done
+          }
+
+          # name                     key    value                     namespaces
+          sync spark-runner-token    token "$SPARK_RUNNER_TOKEN"    sovereign-runtime socioprophet
+          sync lattice-forge-token   token "$LATTICE_FORGE_TOKEN"   sovereign-runtime socioprophet
+          sync compute-gateway-token token "$COMPUTE_GATEWAY_TOKEN" socioprophet
+          sync studio-write-token    token "$STUDIO_WRITE_TOKEN"    socioprophet
+
+          echo "done."


### PR DESCRIPTION
We provision secrets **through CI** — but the repo had no workflow for it, and several deploy comments said secrets are "created out of band, NOT in git." That stale framing is what keeps producing manual-kubectl regressions. This adds the missing path.

## What
`provision-secrets` (`workflow_dispatch`) materializes the app token Secrets into their namespaces using the estate's **GCP WIF** (same auth as `helm-release.yml`):

| Secret | Key | Namespaces |
|---|---|---|
| `spark-runner-token` | token | sovereign-runtime, socioprophet |
| `lattice-forge-token` | token | sovereign-runtime, socioprophet |
| `compute-gateway-token` | token | socioprophet |
| `studio-write-token` | token | socioprophet |

- Token **values** live in GitHub Actions secrets (`SPARK_RUNNER_TOKEN`, …) — never git.
- Idempotent: `kubectl create … --dry-run=client | kubectl apply -f -`.
- Scope a run with the `only` input; rotate a token = update the GitHub secret + re-run; a missing value is skipped, not errored.

## One-time setup
Repo **variables**: `GKE_CLUSTER`, `GKE_LOCATION`. Repo **secrets**: the `*_TOKEN` values (`GCP_WORKLOAD_IDENTITY_PROVIDER`/`GCP_SERVICE_ACCOUNT` already exist).

## Why now
Unblocks the spark-runner → `sovereign-runtime` move (#842): provision `spark-runner-token` there via CI, no manual kubectl. Also gives compute-gateway-token/forge-token a real CI home.