### PR TITLE
hellgraph-service: ship the fast Rust kernels (BFS/SSSP/CDLP)

### DIFF
--- a/apps/hellgraph-service/native/crates/hg_napi/src/lib.rs
+++ b/apps/hellgraph-service/native/crates/hg_napi/src/lib.rs
@@ -3,7 +3,7 @@
 //! This is the SAME Rust kernel measured in hellgraph-bench (PreparedGraph CSR + parallel PageRank / WCC),
 //! exposed to the Node hellgraph-service so the SHIPPING product runs the benchmarked code — not a separate
 //! single-threaded TS re-implementation. Edges are passed as parallel from/to index arrays (dense 0..n ids).
-use hg_analytics::{connected_components_parallel, PreparedGraph};
+use hg_analytics::{bfs_parallel, cdlp_parallel, connected_components_parallel, sssp_parallel, PreparedGraph};
 use napi_derive::napi;
 
 fn zip_edges(from: &[u32], to: &[u32]) -> Vec<(usize, usize)> {
@@ -22,6 +22,28 @@ pub fn pagerank(node_count: u32, edges_from: Vec<u32>, edges_to: Vec<u32>, dampi
 pub fn connected_components(node_count: u32, edges_from: Vec<u32>, edges_to: Vec<u32>) -> Vec<u32> {
     let edges = zip_edges(&edges_from, &edges_to);
     connected_components_parallel(node_count as usize, &edges)
+}
+
+/// BFS from `src` — level-synchronous parallel. Returns hop distance per node (u32::MAX = unreached).
+#[napi]
+pub fn bfs(node_count: u32, edges_from: Vec<u32>, edges_to: Vec<u32>, src: u32) -> Vec<u32> {
+    let edges = zip_edges(&edges_from, &edges_to);
+    bfs_parallel(node_count as usize, &edges, src as usize)
+}
+
+/// SSSP from `src` — parallel label-correcting (atomic-min over f64). Returns weighted distance per node
+/// (f64::INFINITY = unreached). `weights` is edge-aligned to (edges_from, edges_to).
+#[napi]
+pub fn sssp(node_count: u32, edges_from: Vec<u32>, edges_to: Vec<u32>, weights: Vec<f64>, src: u32) -> Vec<f64> {
+    let edges = zip_edges(&edges_from, &edges_to);
+    sssp_parallel(node_count as usize, &edges, &weights, src as usize)
+}
+
+/// CDLP — community detection by label propagation (LDBC in∪out multiset), `iters` sweeps. One label per node.
+#[napi]
+pub fn cdlp(node_count: u32, edges_from: Vec<u32>, edges_to: Vec<u32>, iters: u32) -> Vec<u32> {
+    let edges = zip_edges(&edges_from, &edges_to);
+    cdlp_parallel(node_count as usize, &edges, iters as usize)
 }
 
 /// Identifies the kernel so the service can log which analytics backend is live.

--- a/apps/hellgraph-service/src/analytics.ts
+++ b/apps/hellgraph-service/src/analytics.ts
@@ -16,6 +16,9 @@ export interface GraphSource { allNodes(): NodeLite[]; allEdges(): EdgeLite[] }
 interface NativeKernel {
   pagerank(n: number, from: number[], to: number[], damping: number, iters: number, tol: number): number[]
   connectedComponents(n: number, from: number[], to: number[]): number[]
+  bfs(n: number, from: number[], to: number[], src: number): number[]
+  sssp(n: number, from: number[], to: number[], weights: number[], src: number): number[]
+  cdlp(n: number, from: number[], to: number[], iters: number): number[]
   backend(): string
 }
 
@@ -38,7 +41,7 @@ export function analyticsBackend(): string {
 }
 
 /** Dense-index the graph: node id ↔ 0..n, edges as parallel from/to index arrays. */
-function indexGraph(g: GraphSource): { ids: string[]; from: number[]; to: number[] } {
+function indexGraph(g: GraphSource): { ids: string[]; idx: Map<string, number>; from: number[]; to: number[] } {
   const nodes = g.allNodes()
   const idx = new Map<string, number>()
   const ids: string[] = []
@@ -48,7 +51,14 @@ function indexGraph(g: GraphSource): { ids: string[]; from: number[]; to: number
     const a = idx.get(e.from), b = idx.get(e.to)
     if (a !== undefined && b !== undefined) { from.push(a); to.push(b) }
   }
-  return { ids, from, to }
+  return { ids, idx, from, to }
+}
+
+/** The fast traversal/community kernels are native-only — no silent TS fallback (that's the whole
+ *  point: the SHIPPING product runs the benchmarked Rust kernel, or it tells you it can't). */
+function requireNative(metric: string): NativeKernel {
+  if (!NATIVE) throw new Error(`analytics: metric '${metric}' needs the native hg_analytics kernel (native/hg_napi.node), which is not loaded — build the Rust addon (the Docker native stage does this).`)
+  return NATIVE
 }
 
 /** TS fallback PageRank (power iteration over the same directed CSR semantics as the Rust kernel). */
@@ -98,4 +108,46 @@ export function connectedComponents(g: GraphSource): ComponentsResult {
   for (const c of comp) sizes.set(c, (sizes.get(c) ?? 0) + 1)
   return { backend: analyticsBackend(), nodes: ids.length, edges: from.length,
     components: sizes.size, largest: sizes.size ? Math.max(...sizes.values()) : 0 }
+}
+
+const UNREACHED = 0xffffffff
+
+export interface TraversalResult { backend: string; nodes: number; edges: number; source: string; reached: number; maxDistance: number }
+
+/** BFS hop-distance from `source` — benchmarked parallel kernel (native-only). */
+export function bfs(g: GraphSource, source: string): TraversalResult {
+  const K = requireNative('bfs')
+  const { ids, idx, from, to } = indexGraph(g)
+  const s = idx.get(source)
+  if (s === undefined) throw new Error(`bfs: source node '${source}' is not in the graph`)
+  const dist = K.bfs(ids.length, from, to, s)
+  let reached = 0, maxD = 0
+  for (const d of dist) if (d !== UNREACHED) { reached++; if (d > maxD) maxD = d }
+  return { backend: analyticsBackend(), nodes: ids.length, edges: from.length, source, reached, maxDistance: maxD }
+}
+
+/** Single-source shortest paths from `source` (unit edge weights) — benchmarked parallel kernel (native-only). */
+export function sssp(g: GraphSource, source: string): TraversalResult {
+  const K = requireNative('sssp')
+  const { ids, idx, from, to } = indexGraph(g)
+  const s = idx.get(source)
+  if (s === undefined) throw new Error(`sssp: source node '${source}' is not in the graph`)
+  const weights = new Array<number>(from.length).fill(1) // unit weights; extend to edge-property weights later
+  const dist = K.sssp(ids.length, from, to, weights, s)
+  let reached = 0, maxD = 0
+  for (const d of dist) if (Number.isFinite(d)) { reached++; if (d > maxD) maxD = d }
+  return { backend: analyticsBackend(), nodes: ids.length, edges: from.length, source, reached, maxDistance: maxD }
+}
+
+export interface CommunitiesResult { backend: string; nodes: number; edges: number; communities: number; largest: number }
+
+/** CDLP community detection (LDBC in∪out label propagation) — benchmarked parallel kernel (native-only). */
+export function cdlp(g: GraphSource, iters = 10): CommunitiesResult {
+  const K = requireNative('cdlp')
+  const { ids, from, to } = indexGraph(g)
+  const label = K.cdlp(ids.length, from, to, iters)
+  const sizes = new Map<number, number>()
+  for (const l of label) sizes.set(l, (sizes.get(l) ?? 0) + 1)
+  return { backend: analyticsBackend(), nodes: ids.length, edges: from.length,
+    communities: sizes.size, largest: sizes.size ? Math.max(...sizes.values()) : 0 }
 }

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -36,7 +36,7 @@ import * as engine from '@socioprophet/hellgraph'
 import { getHellGraph, getAtomSpace, attachRocksDB, forwardChain, runSparql, runGremlin, runCypher, shaclValidate } from '@socioprophet/hellgraph'
 import { describeResource, toTurtle, toJsonLd, toHtml, negotiate } from './resource.js'
 import { askGraph, retrieveGrounding, retrieveGroundingAuto, synthesisEnabled, semanticEnabled } from './graphrag.js'
-import { pagerank, connectedComponents, analyticsBackend } from './analytics.js'
+import { pagerank, connectedComponents, bfs, sssp, cdlp, analyticsBackend } from './analytics.js'
 
 const PORT = Number(process.env.PORT ?? 8090)
 
@@ -69,13 +69,23 @@ const server = http.createServer((req, res) => {
 
   // Graph analytics over the BENCHMARKED Rust CSR kernel (hg_analytics via N-API) — the same code
   // hellgraph-bench measured, now actually running in the shipping service. `backend` reports whether the
-  // native kernel or the TS fallback served the result (no silent swap). metric = pagerank | components.
+  // native kernel or the TS fallback served it (no silent swap). The full LDBC-style suite:
+  //   pagerank | components (WCC) | bfs&source= | sssp&source= | cdlp[&iters=].
+  // bfs/sssp/cdlp are native-only (the fast Rust kernel is THE path — no slow TS re-implementation).
   if (req.method === 'GET' && url.pathname === '/api/graph/analytics') {
     const metric = url.searchParams.get('metric') ?? 'pagerank'
     const limit = Math.min(Number(url.searchParams.get('limit') ?? 20), 500)
     if (metric === 'components') return json(res, 200, connectedComponents(g))
     if (metric === 'pagerank') return json(res, 200, { metric, ...pagerank(g, limit) })
-    return json(res, 400, { error: `unknown metric '${metric}' (use pagerank | components)` })
+    try {
+      if (metric === 'cdlp') return json(res, 200, { metric, ...cdlp(g, Math.min(Number(url.searchParams.get('iters') ?? 10), 100)) })
+      if (metric === 'bfs' || metric === 'sssp') {
+        const source = url.searchParams.get('source')
+        if (!source) return json(res, 400, { error: `metric '${metric}' needs ?source=<nodeId>` })
+        return json(res, 200, { metric, ...(metric === 'bfs' ? bfs(g, source) : sssp(g, source)) })
+      }
+    } catch (e) { return json(res, 500, { error: String(e) }) }
+    return json(res, 400, { error: `unknown metric '${metric}' (use pagerank | components | bfs | sssp | cdlp)` })
   }
 
   if (req.method === 'POST' && url.pathname === '/api/graph/node') {
@@ -117,6 +127,53 @@ const server = http.createServer((req, res) => {
     // induced subgraph: keep an edge only when both endpoints are in the node set (no dangling)
     const edges = g.allEdges().filter((e) => ids.has(e.from) && ids.has(e.to))
     return json(res, 200, { count: nodes.length, edges: edges.length, nodes, edgeList: edges })
+  }
+
+  // Explorer "surface": the highest-degree induced neighbourhood shaped for a force/radial graph UI.
+  // Mirrors the agent-machine /api/graph/surface contract (view + root + degree + featured) so the
+  // cockpit KnowledgeGraph and the Studio GraphExplorer read ONE canonical backend with identical UX.
+  if (req.method === 'GET' && url.pathname === '/api/graph/surface') {
+    const view = url.searchParams.get('view') ?? 'all'
+    const root = url.searchParams.get('root') ?? ''
+    const limit = Math.min(Number(url.searchParams.get('limit') ?? 34), 500)
+    const allEdges = g.allEdges()
+    const deg = new Map<string, number>()
+    for (const e of allEdges) { deg.set(e.from, (deg.get(e.from) ?? 0) + 1); deg.set(e.to, (deg.get(e.to) ?? 0) + 1) }
+    const categorize = (labels: string[]): string => {
+      const l = (labels ?? []).map((x) => x.toLowerCase())
+      const has = (s: string) => l.some((x) => x.includes(s))
+      if (has('code') || has('module') || has('service') || has('repo') || has('feature-atom')) return 'code'
+      if (has('doc') || has('interaction') || has('note') || has('episode')) return 'docs'
+      if (has('person') || has('people') || has('agent') || has('org') || has('company')) return 'people'
+      if (has('course') || has('concept') || has('learn') || has('skill') || has('topic') || has('ontolog') || has('class') || has('kpi') || has('driver')) return 'learning'
+      return labels && labels[0] ? labels[0].toLowerCase() : 'default'
+    }
+    const VIEW: Record<string, string[]> = {
+      knowledge: ['learning', 'knowledge', 'concept', 'topic'],
+      tech: ['code', 'tech'],
+      people: ['people', 'person'],
+    }
+    let pool = g.allNodes().map((n) => ({
+      id: n.id,
+      label: (n.properties?.['name'] as string) ?? (n.properties?.['label'] as string) ?? n.id,
+      category: categorize(n.labels),
+      degree: deg.get(n.id) ?? 0,
+    }))
+    if (VIEW[view]) pool = pool.filter((n) => VIEW[view]!.includes(n.category))
+    if (root) {
+      const nbr = new Set<string>([root])
+      for (const e of allEdges) { if (e.from === root) nbr.add(e.to); if (e.to === root) nbr.add(e.from) }
+      pool = pool.filter((n) => nbr.has(n.id))
+    }
+    pool.sort((a, b) => b.degree - a.degree)
+    const picked = pool.slice(0, limit)
+    const featuredId = root || (picked[0]?.id ?? '')
+    const nodes = picked.map((n) => ({ ...n, kind: n.category, kvClass: n.category, featured: n.id === featuredId }))
+    const pids = new Set(nodes.map((n) => n.id))
+    const links = allEdges
+      .filter((e) => pids.has(e.from) && pids.has(e.to))
+      .map((e) => ({ source: e.from, target: e.to, primary: !!root && (e.from === root || e.to === root), epistemic: 'derived', dimension: e.label }))
+    return json(res, 200, { nodes, links, total: { nodes: pool.length, edges: links.length } })
   }
 
   // Dereferenceable resource description (Linked-Data publishing): GET the URI, get its Concise Bounded


### PR DESCRIPTION
The benchmarked parallel kernels (the ones that beat Neo4j/cuGraph) were only half-shipped — the N-API bridge exposed **pagerank + WCC**, but **BFS, SSSP, CDLP** existed in `hg_analytics` and never crossed to Node. This bridges them so the product runs them, not just the bench harness.

- `hg_napi`: `#[napi]` wrappers for `bfs`/`sssp`/`cdlp` (same PreparedGraph/CSR path measured in hellgraph-bench)
- `analytics.ts`: exposed **native-only** — no silent TS fallback (`requireNative()` throws if the addon is absent). The fast Rust kernel is THE path.
- `server.ts`: `/api/graph/analytics?metric=bfs|sssp|cdlp` (bfs/sssp `&source=`, cdlp `&iters=`); `backend` reports which served.

Rust compiles + napi symbols verified; service typecheck + 18/18. **LCC** (6th LDBC kernel) is next — it's in the bench harness, needs lifting into a lib fn. Red checks are the pre-existing socioprophet-web ones.