### PR TITLE
hellgraph-service: ship LCC — complete the LDBC-6 fast kernels

### DIFF
--- a/apps/hellgraph-service/native/crates/hg_analytics/src/lib.rs
+++ b/apps/hellgraph-service/native/crates/hg_analytics/src/lib.rs
@@ -1121,6 +1121,52 @@ fn brandes_source(s: usize, adj: &[Vec<usize>], n: usize, bc: &mut [f64]) {
     }
 }
 
+/// LCC — local clustering coefficient per node, on the SIMPLE undirected graph (parallel edges deduped,
+/// self-loops dropped). Per node: triangles among its neighbours / (d·(d−1)). Neighbour rows are sorted
+/// so each triangle count is a linear merge-intersection; the per-node loop is rayon-parallel. `tri` counts
+/// each triangle from both endpoints, so the d·(d−1) denominator (not d·(d−1)/2) yields the standard value.
+pub fn lcc_parallel(n: usize, edges: &[(usize, usize)]) -> Vec<f64> {
+    let mut adj: Vec<Vec<u32>> = vec![Vec::new(); n];
+    for &(u, v) in edges {
+        if u < n && v < n && u != v {
+            adj[u].push(v as u32);
+            adj[v].push(u as u32);
+        }
+    }
+    adj.par_iter_mut().for_each(|row| {
+        row.sort_unstable();
+        row.dedup();
+    });
+    let adj_ref = &adj;
+    (0..n)
+        .into_par_iter()
+        .map(|v| {
+            let nb = &adj_ref[v];
+            let d = nb.len();
+            if d < 2 {
+                return 0.0;
+            }
+            let mut tri = 0usize;
+            for &a in nb {
+                let na = &adj_ref[a as usize];
+                let (mut i, mut j) = (0usize, 0usize);
+                while i < nb.len() && j < na.len() {
+                    match nb[i].cmp(&na[j]) {
+                        std::cmp::Ordering::Less => i += 1,
+                        std::cmp::Ordering::Greater => j += 1,
+                        std::cmp::Ordering::Equal => {
+                            tri += 1;
+                            i += 1;
+                            j += 1;
+                        }
+                    }
+                }
+            }
+            tri as f64 / (d as f64 * (d as f64 - 1.0))
+        })
+        .collect()
+}
+
 /// Parallel (rayon) Brandes betweenness — the source loop is embarrassingly parallel and
 /// COMPUTE-bound (each BFS is real work, not a memory gather), so this scales near-linearly in
 /// cores. Determinism is preserved: sources are split into fixed contiguous chunks, each chunk

--- a/apps/hellgraph-service/native/crates/hg_napi/src/lib.rs
+++ b/apps/hellgraph-service/native/crates/hg_napi/src/lib.rs
@@ -3,7 +3,7 @@
 //! This is the SAME Rust kernel measured in hellgraph-bench (PreparedGraph CSR + parallel PageRank / WCC),
 //! exposed to the Node hellgraph-service so the SHIPPING product runs the benchmarked code — not a separate
 //! single-threaded TS re-implementation. Edges are passed as parallel from/to index arrays (dense 0..n ids).
-use hg_analytics::{bfs_parallel, cdlp_parallel, connected_components_parallel, sssp_parallel, PreparedGraph};
+use hg_analytics::{bfs_parallel, cdlp_parallel, connected_components_parallel, lcc_parallel, sssp_parallel, PreparedGraph};
 use napi_derive::napi;
 
 fn zip_edges(from: &[u32], to: &[u32]) -> Vec<(usize, usize)> {
@@ -44,6 +44,13 @@ pub fn sssp(node_count: u32, edges_from: Vec<u32>, edges_to: Vec<u32>, weights: 
 pub fn cdlp(node_count: u32, edges_from: Vec<u32>, edges_to: Vec<u32>, iters: u32) -> Vec<u32> {
     let edges = zip_edges(&edges_from, &edges_to);
     cdlp_parallel(node_count as usize, &edges, iters as usize)
+}
+
+/// LCC — local clustering coefficient per node (simple undirected graph, triangle counting). One value in [0,1] per node.
+#[napi]
+pub fn lcc(node_count: u32, edges_from: Vec<u32>, edges_to: Vec<u32>) -> Vec<f64> {
+    let edges = zip_edges(&edges_from, &edges_to);
+    lcc_parallel(node_count as usize, &edges)
 }
 
 /// Identifies the kernel so the service can log which analytics backend is live.

--- a/apps/hellgraph-service/src/analytics.ts
+++ b/apps/hellgraph-service/src/analytics.ts
@@ -19,6 +19,7 @@ interface NativeKernel {
   bfs(n: number, from: number[], to: number[], src: number): number[]
   sssp(n: number, from: number[], to: number[], weights: number[], src: number): number[]
   cdlp(n: number, from: number[], to: number[], iters: number): number[]
+  lcc(n: number, from: number[], to: number[]): number[]
   backend(): string
 }
 
@@ -150,4 +151,15 @@ export function cdlp(g: GraphSource, iters = 10): CommunitiesResult {
   for (const l of label) sizes.set(l, (sizes.get(l) ?? 0) + 1)
   return { backend: analyticsBackend(), nodes: ids.length, edges: from.length,
     communities: sizes.size, largest: sizes.size ? Math.max(...sizes.values()) : 0 }
+}
+
+export interface LccResult { backend: string; nodes: number; edges: number; averageCoefficient: number }
+
+/** LCC — average local clustering coefficient (simple undirected graph) — benchmarked parallel kernel (native-only). */
+export function lcc(g: GraphSource): LccResult {
+  const K = requireNative('lcc')
+  const { ids, from, to } = indexGraph(g)
+  const coeff = K.lcc(ids.length, from, to)
+  const avg = coeff.length ? coeff.reduce((s, c) => s + c, 0) / coeff.length : 0
+  return { backend: analyticsBackend(), nodes: ids.length, edges: from.length, averageCoefficient: Math.round(avg * 1e6) / 1e6 }
 }

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -36,7 +36,7 @@ import * as engine from '@socioprophet/hellgraph'
 import { getHellGraph, getAtomSpace, attachRocksDB, forwardChain, runSparql, runGremlin, runCypher, shaclValidate } from '@socioprophet/hellgraph'
 import { describeResource, toTurtle, toJsonLd, toHtml, negotiate } from './resource.js'
 import { askGraph, retrieveGrounding, retrieveGroundingAuto, synthesisEnabled, semanticEnabled } from './graphrag.js'
-import { pagerank, connectedComponents, bfs, sssp, cdlp, analyticsBackend } from './analytics.js'
+import { pagerank, connectedComponents, bfs, sssp, cdlp, lcc, analyticsBackend } from './analytics.js'
 
 const PORT = Number(process.env.PORT ?? 8090)
 
@@ -79,13 +79,14 @@ const server = http.createServer((req, res) => {
     if (metric === 'pagerank') return json(res, 200, { metric, ...pagerank(g, limit) })
     try {
       if (metric === 'cdlp') return json(res, 200, { metric, ...cdlp(g, Math.min(Number(url.searchParams.get('iters') ?? 10), 100)) })
+      if (metric === 'lcc') return json(res, 200, { metric, ...lcc(g) })
       if (metric === 'bfs' || metric === 'sssp') {
         const source = url.searchParams.get('source')
         if (!source) return json(res, 400, { error: `metric '${metric}' needs ?source=<nodeId>` })
         return json(res, 200, { metric, ...(metric === 'bfs' ? bfs(g, source) : sssp(g, source)) })
       }
     } catch (e) { return json(res, 500, { error: String(e) }) }
-    return json(res, 400, { error: `unknown metric '${metric}' (use pagerank | components | bfs | sssp | cdlp)` })
+    return json(res, 400, { error: `unknown metric '${metric}' (use pagerank | components | bfs | sssp | cdlp | lcc)` })
   }
 
   if (req.method === 'POST' && url.pathname === '/api/graph/node') {


### PR DESCRIPTION
Completes the fast-kernel suite. LCC only lived in the bench harness; lifted into a parallel `lcc_parallel` lib fn (simple undirected CSR + rayon triangle-count) in **both** the service crate and `~/dev/hellgraph-rust` (byte-identical), bridged via `#[napi] lcc` + `/api/graph/analytics?metric=lcc` (native-only). All 6 LDBC kernels now run through the benchmarked Rust engine. Rust compiles + napi symbol verified; typecheck + 18/18. Red checks are the pre-existing socioprophet-web ones.