### PR TITLE
integ: land the rebase-clean backlog batch (53 branches)

### DIFF
--- a/docs/capability-membrane-gate.md
+++ b/docs/capability-membrane-gate.md
@@ -1,0 +1,76 @@
+# Gating a tool call through the capability membrane
+
+The capability membrane (`tools/capability_membrane.py`) is the fail-closed
+kernel that decides whether a single tool/connector action may run. This is the
+**runtime seam**: a runtime (an agent-machine, a connector dispatcher, a
+service) calls the membrane *immediately before executing* a connector action.
+If the decision is not `allowed`, **the runtime must not execute the action.**
+
+The membrane lives in `prophet-platform` and does not reach into any runtime.
+Any runtime — including one in another repo — integrates by calling this seam.
+
+## In-process (Python)
+
+```python
+from capability_membrane import gate
+
+decision = gate({
+    "surface": "shell",              # connectorKind
+    "action": "shell.exec",          # the real action about to run
+    "access_level": "scopedWrite",   # ConnectorActionScope.accessLevel
+    "subject_ref": "urn:srcos:agent:conductor",
+    "tension_members": ["policy", "identity", "provenance",
+                        "evidence", "replay", "revocation"],
+    "requested_autonomy_level": "L4",
+    "autonomy_evidence": ["conductor_response_envelope"],
+    # optional: scope, owned, object_ref, membrane_decision, risk_level,
+    #           may_transmit_content, policy_refs, machine_ref
+})
+
+if not decision["allowed"]:
+    raise PermissionError(decision["reasons"])
+# ... only now execute the action ...
+persist(decision["sealed_receipt"])   # tamper-evident evidence
+```
+
+`decision` carries `allowed`, `execution_decision` (allow|deny|ask|defer|
+rewrite), `verdict`, `enforced`, `radius`, `missing_tension`, `obligations`
+(e.g. `mask_fields` for a REDACT), `reasons`, and the sealed
+`AgentMachineReceipt`.
+
+## Out-of-process (any language)
+
+Pipe a `CapabilityRequest` JSON to the CLI. **Exit 0 iff allowed** (exit 3 on a
+denied/deferred decision), so a shell or non-Python runtime gates on the exit
+code and reads the decision on stdout:
+
+```bash
+echo '{"surface":"shell","action":"shell.exec","access_level":"scopedWrite",
+       "subject_ref":"urn:srcos:agent:conductor",
+       "tension_members":["policy","identity","provenance","evidence","replay","revocation"]}' \
+  | python3 tools/capability_membrane.py --request -   # exit 0 → run; non-0 → refuse
+```
+
+## What it enforces (fail-closed, all four layers)
+
+1. **Surface class** — owned surfaces are *enforced*; foreign surfaces are
+   *observed* (`verdict: observed`, advisory only — never a substitute for
+   prevention).
+2. **Capability radius + tension members** — the action's radius (R0–R5)
+   requires a specific set of governance members present; any missing → deny.
+3. **Membrane policy verdict** — ALLOW / DENY / QUARANTINE / REDACT /
+   REQUIRE_SIGNATURE.
+4. **Autonomy ladder** — the requested L0–L5 level must be backed by its
+   evidence token.
+
+Any single fail-closed condition dominates. See
+`tools/tests/test_capability_membrane.py` for the falsifiability board that
+proves each refuse/degrade/observe path fires.
+
+## Where this plugs in next
+
+The autonomy-*admission* gate already composes with the membrane
+(`tools/emit_autonomy_admission_receipt.py`, `--surface`). The remaining
+integration is the **live connector dispatcher** calling `gate()` before it
+runs `shell.exec` / `computer.*` / `browser.*`. That dispatcher lives in the
+agent runtime; this seam is what it calls.

--- a/tools/capability_membrane.py
+++ b/tools/capability_membrane.py
@@ -509,13 +509,54 @@ def request_from_operation_decision(
     )
 
 
+# --------------------------------------------------------------------------- #
+# Callable gate seam
+#
+# The stable entrypoint a runtime (an agent-machine, a connector dispatcher, a
+# service) calls immediately BEFORE executing a tool/connector action. Describe
+# the call as a CapabilityRequest-shaped dict; if the returned decision is not
+# `allowed`, the caller MUST NOT execute the action (fail-closed). The sealed
+# AgentMachineReceipt travels back for the caller's evidence spine.
+# --------------------------------------------------------------------------- #
+
+_REQUEST_FIELDS = set(CapabilityRequest.__dataclass_fields__)
+
+
+def gate(request: Dict[str, Any]) -> Dict[str, Any]:
+    """Gate one tool/connector call. Fail-closed: execute only if ``allowed``.
+
+    >>> gate({"surface": "shell", "action": "shell.exec", "access_level": "scopedWrite",
+    ...       "subject_ref": "urn:srcos:agent:x",
+    ...       "tension_members": ["policy", "identity"]})["allowed"]
+    False
+    """
+    unknown = set(request) - _REQUEST_FIELDS
+    if unknown:
+        raise ValueError(f"unknown CapabilityRequest fields: {sorted(unknown)}")
+    resolution = resolve_capability(CapabilityRequest(**request))
+    return {
+        "allowed": resolution.allowed,
+        "execution_decision": resolution.execution_decision,
+        "verdict": resolution.verdict,
+        "enforced": resolution.enforced,
+        "radius": resolution.radius,
+        "missing_tension": list(resolution.missing_tension),
+        "obligations": resolution.obligations,
+        "reasons": resolution.reasons,
+        "sealed_receipt": resolution.sealed,
+    }
+
+
 def _cli(argv: Optional[Sequence[str]] = None) -> int:
     import argparse
 
     p = argparse.ArgumentParser(description="Resolve a capability call through the unified membrane.")
+    p.add_argument("--request", type=str,
+                   help="path (or - for stdin) to a full CapabilityRequest JSON; gates that call and "
+                        "prints the decision. Exit 0 iff allowed. The runtime seam.")
     p.add_argument("--operation", type=str, help="path to a ProphetOperationsActionDecision JSON")
-    p.add_argument("--surface", required=True, help="connectorKind, e.g. shell|computer|browser|deployment")
-    p.add_argument("--access", required=True, help="ConnectorActionScope accessLevel")
+    p.add_argument("--surface", help="connectorKind, e.g. shell|computer|browser|deployment")
+    p.add_argument("--access", help="ConnectorActionScope accessLevel")
     p.add_argument("--subject", default=None)
     p.add_argument("--scope", default="user_local", choices=list(MEMBRANE_SCOPES))
     p.add_argument("--foreign", action="store_true", help="surface is NOT ours → observe-only")
@@ -526,6 +567,22 @@ def _cli(argv: Optional[Sequence[str]] = None) -> int:
     p.add_argument("--evidence", default="", help="comma-separated autonomy evidence tokens")
     p.add_argument("--out", type=str, help="write sealed receipt JSON here (default stdout)")
     args = p.parse_args(argv)
+
+    # Runtime seam: gate a fully-described call and print the decision, fail-closed.
+    if args.request:
+        import sys as _sys
+        raw = _sys.stdin.read() if args.request == "-" else open(args.request, encoding="utf-8").read()
+        decision = gate(json.loads(raw))
+        out = json.dumps(decision, indent=2, sort_keys=True)
+        if args.out:
+            with open(args.out, "w", encoding="utf-8") as fh:
+                fh.write(out + "\n")
+        else:
+            print(out)
+        return 0 if decision["allowed"] else 3
+
+    if not (args.surface and args.access):
+        p.error("--surface and --access are required unless --request is given")
 
     tension = tuple(t for t in args.tension.split(",") if t)
     evidence = tuple(e for e in args.evidence.split(",") if e)
@@ -563,6 +620,7 @@ __all__ = [
     "AutonomyDecision",
     "evaluate_autonomy",
     "resolve_capability",
+    "gate",
     "request_from_operation_decision",
     "seal_receipt",
     "TENSION_REQUIRED",

--- a/tools/tests/test_capability_membrane.py
+++ b/tools/tests/test_capability_membrane.py
@@ -11,14 +11,22 @@ from __future__ import annotations
 
 import re
 
+import json
+import subprocess
+import sys
+from pathlib import Path
+
 from tools.capability_membrane import (
     CapabilityRequest,
     TENSION_REQUIRED,
     evaluate_autonomy,
+    gate,
     request_from_operation_decision,
     resolve_capability,
     seal_receipt,
 )
+
+_MEMBRANE = Path(__file__).resolve().parents[1] / "capability_membrane.py"
 
 
 def operation(outcome, **over):
@@ -266,3 +274,56 @@ def test_operation_clean_allow_flows_through():
     r = resolve_capability(request)
     assert r.execution_decision == "allow"
     assert r.receipt["decision"]["riskLevel"] == "high"
+
+
+# --------------------------------------------------------------------------- #
+# The callable gate seam a runtime invokes before executing a tool call.
+# --------------------------------------------------------------------------- #
+
+_FULL = ["policy", "identity", "provenance", "evidence", "replay", "revocation", "audit", "post_authority_ref"]
+
+
+def test_gate_allows_and_returns_sealed_receipt():
+    d = gate({
+        "surface": "filesystem", "action": "filesystem.read", "access_level": "readOnly",
+        "subject_ref": "urn:srcos:agent:x", "tension_members": ["policy", "identity", "provenance"],
+    })
+    assert d["allowed"] is True
+    assert d["execution_decision"] == "allow"
+    assert d["sealed_receipt"]["sealHash"].startswith("sha256:")
+
+
+def test_gate_denies_fail_closed_on_missing_tension():
+    d = gate({
+        "surface": "shell", "action": "shell.exec", "access_level": "scopedWrite",
+        "subject_ref": "urn:srcos:agent:x", "tension_members": ["policy", "identity"],
+    })
+    assert d["allowed"] is False
+    assert d["execution_decision"] == "deny"
+    assert d["missing_tension"]  # non-empty
+
+
+def test_gate_rejects_unknown_fields():
+    import pytest
+    with pytest.raises(ValueError):
+        gate({"surface": "shell", "access_level": "readOnly", "not_a_field": 1})
+
+
+def _cli_request(payload: dict) -> int:
+    proc = subprocess.run(
+        [sys.executable, str(_MEMBRANE), "--request", "-"],
+        input=json.dumps(payload), capture_output=True, text=True,
+    )
+    return proc.returncode
+
+
+def test_cli_request_mode_is_fail_closed():
+    # allowed → exit 0; denied → exit 3 (a runtime gates on the exit code).
+    assert _cli_request({
+        "surface": "filesystem", "action": "filesystem.read", "access_level": "readOnly",
+        "subject_ref": "urn:srcos:agent:x", "tension_members": ["policy", "identity", "provenance"],
+    }) == 0
+    assert _cli_request({
+        "surface": "shell", "action": "shell.exec", "access_level": "scopedWrite",
+        "subject_ref": "urn:srcos:agent:x", "tension_members": ["policy", "identity"],
+    }) == 3


### PR DESCRIPTION
Second backlog batch: **53 branches** that CONFLICTed with `main` but **rebase cleanly** onto today's `main` (after batch #869 landed). All 53 compose with 0 inter-branch conflicts; `tools/tests` green locally (239 passed, 0 failed).

Themes: SPARQL-1.1 engine, GraphRAG semantic + provenance, cypher endpoints, dereferenceable resource URIs, ontology HTML docs, reasoning explanations, ER identity-prime/regis-depth, memoryd ship, universal-compute-gateway, tritfabric consumption, the Studio suite (query-ide, read-auth, receipts-moat, provenance-replay, persistent-ids, preservation, experiments, write-token/workbench), rust-analytics wiring, preflight-deploy-contract gate, dashboard-bff hosting/vdt, socbase/socioprophet-web/zot/gke deploy fixes.

Sibling to #869 (the 40 clean branches). Remaining after this: 24 branches with genuine rebase conflicts (per-branch resolution) + 2 integ branches (fogstack-parity artifact regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
