### PR TITLE
hellgraph-service: WO-2 — HNSW+BM25 hybrid retrieval on the grounding path

### DIFF
--- a/apps/hellgraph-service/src/graphrag.ts
+++ b/apps/hellgraph-service/src/graphrag.ts
@@ -11,6 +11,9 @@
  * honest extractive answer), and any LLM error degrades the same way. Read-only; never throws.
  */
 import type { Triple } from '@socioprophet/hellgraph'
+// WO-2: the built-but-dark hybrid retrieval primitives — HNSW dense index, BM25 lexical index, and the
+// RRF fusion entrypoint — now ON the retrieval path (they were exported but never wired).
+import { HnswIndex, BM25Index, hybridRetrieve } from '@socioprophet/hellgraph'
 
 export interface GraphNodeLite { id: string; labels: string[]; properties: Record<string, unknown> }
 export interface GraphSource {
@@ -132,20 +135,47 @@ function cosine(a: number[], b: number[]): number {
 
 /** Auto retrieval: SEMANTIC (embedding cosine) seeding when EMBEDDINGS_URL is configured + reachable, else the
  * lexical substring path. `hops` configurable (default 1). Fixes the audit's "substring + fixed-1-hop" finding. */
+// ── WO-2 hybrid retrieval index: HNSW dense ⊕ BM25 lexical, built ONCE over the node corpus and cached
+// (rebuilt only when the node count changes). A query then embeds the QUERY alone + does one ANN + one
+// BM25 lookup — instead of the old path that re-embedded EVERY node on EVERY query (O(n) embeds/query).
+// Rebuilds reuse embedCache, so they're near-free after the first pass. vecOf keeps the node vectors so
+// seeds can still be cosine-gated for grounding quality.
+let hybridIndex: { hnsw: HnswIndex; bm25: BM25Index; vecOf: Map<string, number[]>; signature: string } | null = null
+
+async function getHybridIndex(g: GraphSource, cfg: EmbedConfig, fetchImpl: typeof fetch) {
+  const nodes = g.allNodes()
+  // signature = count + a cheap rolling hash of node ids, so a different corpus (added/removed nodes)
+  // rebuilds — count alone would collide two distinct same-size graphs (and break test isolation).
+  let h = 0
+  for (const nd of nodes) for (let i = 0; i < nd.id.length; i++) h = (Math.imul(h, 31) + nd.id.charCodeAt(i)) | 0
+  const signature = `${nodes.length}:${h >>> 0}`
+  if (hybridIndex && hybridIndex.signature === signature) return hybridIndex
+  const hnsw = new HnswIndex()
+  const bm25 = new BM25Index()
+  const vecOf = new Map<string, number[]>()
+  for (const nd of nodes) {
+    const text = nodeText(nd)
+    bm25.add(nd.id, text)
+    const nv = await embed(text, cfg, fetchImpl)
+    if (nv) { hnsw.add(nd.id, nv); vecOf.set(nd.id, nv) }
+  }
+  hybridIndex = { hnsw, bm25, vecOf, signature }
+  return hybridIndex
+}
+
 export async function retrieveGroundingAuto(g: GraphSource, question: string, hops = 1, maxCitations = MAX_CITATIONS, fetchImpl: typeof fetch = fetch): Promise<Grounding & { retrieval: string }> {
   const cfg = embedConfig()
   if (cfg) {
     const qv = await embed(question, cfg, fetchImpl)
     if (qv) {
-      const nodes = g.allNodes()
-      const scored: { id: string; score: number }[] = []
-      for (const nd of nodes) {
-        const nv = await embed(nodeText(nd), cfg, fetchImpl)
-        if (nv) scored.push({ id: nd.id, score: cosine(qv, nv) })
-      }
-      if (scored.length) {
-        const seeds = scored.sort((a, b) => b.score - a.score).slice(0, MAX_SEEDS).filter((s) => s.score > 0.2).map((s) => s.id)
-        return { ...groundingFromSeeds(g, seeds, hops, maxCitations), retrieval: `semantic (${cfg.model})` }
+      const idx = await getHybridIndex(g, cfg, fetchImpl)
+      // dense (HNSW ANN) ⊕ lexical (BM25), fused with Reciprocal Rank Fusion — one ANN + one BM25 lookup.
+      const fused = hybridRetrieve({ dense: idx.hnsw, bm25: idx.bm25 }, { vector: qv, text: question, topK: MAX_SEEDS })
+      // Keep grounding honest: a seed WITH an embedding must clear the cosine relevance bar; BM25-only
+      // (unembedded) hits pass on their lexical match. Empty → fall through to the lexical path.
+      const seeds = fused.map((s) => s.id).filter((id) => { const v = idx.vecOf.get(id); return v ? cosine(qv, v) > 0.2 : true })
+      if (seeds.length) {
+        return { ...groundingFromSeeds(g, seeds, hops, maxCitations), retrieval: `hybrid HNSW+BM25 RRF (${cfg.model})` }
       }
     }
   }

--- a/apps/hellgraph-service/src/server.test.ts
+++ b/apps/hellgraph-service/src/server.test.ts
@@ -216,7 +216,7 @@ test('graphrag: /ask degrades to facts-only when no sovereign LLM is configured 
   assert.equal((await req('POST', '/api/graph/ask', {})).status, 400)     // question required
 })
 
-test('graphrag: SEMANTIC retrieval seeds by embedding cosine, not substring (fake sovereign endpoint)', async () => {
+test('graphrag: HYBRID retrieval (HNSW+BM25 RRF) seeds by embedding, not substring (fake sovereign endpoint)', async () => {
   const nodes = [
     { id: 'n:cat', labels: ['Topic'], properties: { name: 'feline pets' } },
     { id: 'n:fin', labels: ['Topic'], properties: { name: 'stock market' } },
@@ -236,8 +236,8 @@ test('graphrag: SEMANTIC retrieval seeds by embedding cosine, not substring (fak
   process.env.EMBEDDINGS_URL = 'http://fake/embed'
   try {
     const gr = await retrieveGroundingAuto(g, 'tell me about a kitten', 1, 24, fakeFetch)
-    assert.match(gr.retrieval, /semantic/)
-    assert.ok(gr.seeds.includes('n:cat') && !gr.seeds.includes('n:fin'), 'semantic seed = cat, not finance')
+    assert.match(gr.retrieval, /hybrid/)
+    assert.ok(gr.seeds.includes('n:cat') && !gr.seeds.includes('n:fin'), 'embedding seed = cat, not finance (BM25 leg adds nothing here; cosine gate drops finance)')
   } finally { delete process.env.EMBEDDINGS_URL }
 })
 


### PR DESCRIPTION
**WO-2.** GraphRAG's `retrieveGroundingAuto` re-embedded **every node on every query** (O(n) embeds/query) then linear-cosine-scanned. The engine already exports `HnswIndex`/`BM25Index`/`hybridRetrieve` — they were just never wired. Now: a dense HNSW ⊕ lexical BM25 index is built **once** over the corpus and cached (count+id-hash signature; rebuilt on change, reusing embedCache), so a query embeds the **query alone** → `hybridRetrieve` (RRF) → cosine-gated seeds (>0.2 bar kept, so grounding stays honest). Service-only (no engine change). typecheck + 18/18. Should **auto-deploy** now that gitops-promote #867 handles merges. Red checks are the pre-existing socioprophet-web ones.