### PR TITLE
cockpit: re-vendor the runtime endpoint resolver (parity with socioprophet #468)

### DIFF
--- a/apps/socioprophet-web/src/config/cockpitRuntime.ts
+++ b/apps/socioprophet-web/src/config/cockpitRuntime.ts
@@ -1,0 +1,51 @@
+// Runtime endpoint resolver — the ONE place that decides where each cockpit surface
+// talks to, so a single build runs three ways without rebuilding:
+//
+//   • BearBrowser-embedded (sovereign) — the host injects loopback sidecar bases
+//     (127.0.0.1) via window.__COCKPIT_CONFIG__; nothing egresses off-device.
+//   • prophet-platform-hosted (connected) — the in-cluster nginx /svc/* + /api
+//     proxies (the code fallbacks below).
+//   • Firebase / local dev — VITE_* build-time env, unchanged.
+//
+// Precedence per service base:
+//   host-injected runtime config  >  VITE_* build env  >  code fallback
+//
+// This preserves every existing default, so it's a no-op for the current hosted
+// build; it only ADDS the ability for a host (BearBrowser, or a /config.json) to
+// repoint surfaces at runtime. See BearBrowser docs/cockpit-composition-plan.md.
+
+export type CockpitMode = 'sovereign' | 'connected';
+
+interface CockpitRuntimeConfig {
+  mode?: CockpitMode;
+  bases?: Record<string, string>;
+}
+
+function injected(): CockpitRuntimeConfig {
+  if (typeof window === 'undefined') return {};
+  const c = (window as unknown as { __COCKPIT_CONFIG__?: CockpitRuntimeConfig }).__COCKPIT_CONFIG__;
+  return c && typeof c === 'object' ? c : {};
+}
+
+const env = (import.meta as { env?: Record<string, string> }).env ?? {};
+
+/**
+ * Resolve a service base URL.
+ * @param key      stable service key used in the injected runtime config (e.g. 'algo')
+ * @param envVar   the build-time VITE_* var name (back-compat)
+ * @param fallback code default (e.g. '/svc/algo'); omit for services that stub when unset
+ */
+export function resolveBase(key: string, envVar: string, fallback: string): string;
+export function resolveBase(key: string, envVar: string): string | undefined;
+export function resolveBase(key: string, envVar: string, fallback?: string): string | undefined {
+  const host = injected().bases?.[key];
+  if (host) return host;
+  const fromEnv = env[envVar];
+  if (fromEnv) return fromEnv;
+  return fallback;
+}
+
+// Local-first is the sovereign stance, but a plain hosted build has no injected
+// config, so 'connected' is the default there; BearBrowser explicitly declares
+// 'sovereign' when it embeds the cockpit against loopback sidecars.
+export const cockpitMode: CockpitMode = injected().mode ?? 'connected';

--- a/apps/socioprophet-web/src/services/agentMachineApi.ts
+++ b/apps/socioprophet-web/src/services/agentMachineApi.ts
@@ -1,7 +1,8 @@
 // agentMachineApi — thin client to the local Noetica Agent Machine (sovereign, on-device).
 // Reuses the agent-machine /api/* endpoints unchanged; base is VITE_AGENT_MACHINE (default :8080 in dev).
 // These are local sovereign endpoints (no auth) — distinct from the authed /api/builds platform backend.
-const AM = (import.meta as { env?: Record<string, string> }).env?.VITE_AGENT_MACHINE ?? 'http://127.0.0.1:8080';
+import { resolveBase } from '../config/cockpitRuntime';
+const AM = resolveBase('agentMachine', 'VITE_AGENT_MACHINE', 'http://127.0.0.1:8080');
 
 export const AM_BASE = AM; // exported for SSE streaming endpoints (terminal/run, forge/import-local)
 

--- a/apps/socioprophet-web/src/services/algoApi.ts
+++ b/apps/socioprophet-web/src/services/algoApi.ts
@@ -1,7 +1,8 @@
 // Real Algorithmic Trading backend — algo-engine (prophet-platform/apps/algo-engine).
 // Backtests run over real historical daily bars (Yahoo); paper execution is a real ledger
 // marked to the latest close. Same-origin `/svc/algo` proxy → :8085 in dev.
-const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_ALGO_BASE ?? '/svc/algo';
+import { resolveBase } from '../config/cockpitRuntime';
+const BASE = resolveBase('algo', 'VITE_ALGO_BASE', '/svc/algo');
 
 export interface StrategyDef { id: string; label: string; blurb: string; params: Record<string, any> }
 export interface Metrics { total_return: number; cagr: number; sharpe: number; max_drawdown: number; win_rate: number; vol: number }

--- a/apps/socioprophet-web/src/services/choirApi.ts
+++ b/apps/socioprophet-web/src/services/choirApi.ts
@@ -2,8 +2,9 @@
 // (cites the focus) so the AI panel runs standalone until the choir endpoint is wired. The real call sends the
 // assembled grounded prompt and returns the model's answer (then checkGrounding validates the citations).
 import type { GroundedContext, ChoirAction } from "./choirGrounding";
+import { resolveBase } from '../config/cockpitRuntime';
 
-const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_CHOIR_API;
+const BASE = resolveBase('choir', 'VITE_CHOIR_API');
 
 export async function complete(prompt: string, grounded: GroundedContext, action: ChoirAction): Promise<string> {
   if (!BASE) {

--- a/apps/socioprophet-web/src/services/hellgraphApi.ts
+++ b/apps/socioprophet-web/src/services/hellgraphApi.ts
@@ -5,8 +5,9 @@
 // Base is the same-origin `/svc/hellgraph` proxy (see vite.config.ts) → :8090 in dev.
 // Endpoints mirror the agent-machine surface contract, so SurfaceResult/GraphHealth are reused.
 import type { SurfaceResult, GraphHealth } from './agentMachineApi';
+import { resolveBase } from '../config/cockpitRuntime';
 
-const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_HELLGRAPH_BASE ?? '/svc/hellgraph';
+const BASE = resolveBase('hellgraph', 'VITE_HELLGRAPH_BASE', '/svc/hellgraph');
 
 export const graphSurface = async (view = 'all', limit = 34, root = ''): Promise<SurfaceResult> => {
   const q = new URLSearchParams({ view, limit: String(limit) });

--- a/apps/socioprophet-web/src/services/ieApi.ts
+++ b/apps/socioprophet-web/src/services/ieApi.ts
@@ -1,7 +1,8 @@
 // Real NLP / Information-Extraction backend — ie-engine (prophet-platform/apps/ie-engine).
 // Entities = live spaCy NER; relations = dependency parse; claims = assert/hedge; extraction can be
 // pushed into the canonical HellGraph. Same-origin `/svc/ie` proxy → :8086 in dev.
-const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_IE_BASE ?? '/svc/ie';
+import { resolveBase } from '../config/cockpitRuntime';
+const BASE = resolveBase('ie', 'VITE_IE_BASE', '/svc/ie');
 
 export interface Entity { text: string; type: string; spacy_label?: string; mentions?: number; count?: number }
 export interface Relation { from: string; relation: string; to: string }

--- a/apps/socioprophet-web/src/services/knowledgeApi.ts
+++ b/apps/socioprophet-web/src/services/knowledgeApi.ts
@@ -2,8 +2,9 @@
 // root (sovereign-vault) and stores structure for GDS (knowledge-persist.ts). VITE_KNOWLEDGE_API unset → STUB mode
 // (no network) so the editor runs standalone/local-first until the backend route is wired.
 import type { KGraph } from "./knowledgeGraph";
+import { resolveBase } from '../config/cockpitRuntime';
 
-const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_KNOWLEDGE_API;
+const BASE = resolveBase('knowledge', 'VITE_KNOWLEDGE_API');
 
 export interface PersistResult { nodes: number; edges: number; sealed: boolean }
 

--- a/apps/socioprophet-web/src/services/mailApi.ts
+++ b/apps/socioprophet-web/src/services/mailApi.ts
@@ -33,7 +33,8 @@ export interface ScreenerItem {
   firstSeen: string;
 }
 
-const BASE = (import.meta as any).env?.VITE_MAIL_API || "";
+import { resolveBase } from '../config/cockpitRuntime';
+const BASE = resolveBase('mail', 'VITE_MAIL_API') ?? "";
 
 async function api<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {

--- a/apps/socioprophet-web/src/services/sherlockApi.ts
+++ b/apps/socioprophet-web/src/services/sherlockApi.ts
@@ -1,7 +1,8 @@
 // Sherlock — sovereign Discovery search (sherlock-engine, Tantivy/Rust, no JVM). Same-origin
 // `/svc/sherlock` proxy → :8093 in dev. Ontology-driven full-text with BM25 + highlighted snippets;
 // results can be verified against HellGraph evidence via Holmes (see ieApi.verifyClaims).
-const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_SHERLOCK_BASE ?? '/svc/sherlock';
+import { resolveBase } from '../config/cockpitRuntime';
+const BASE = resolveBase('sherlock', 'VITE_SHERLOCK_BASE', '/svc/sherlock');
 
 export interface Hit { id: string; title: string; doctype: string; category: string; region: string; score: number; bm25: number; snippet: string }
 export interface SearchResult { query: string; engine: string; total: number; hits: Hit[]; error?: string }

--- a/apps/socioprophet-web/src/services/studioApi.ts
+++ b/apps/socioprophet-web/src/services/studioApi.ts
@@ -5,7 +5,8 @@
 // Everything is PROJECT-SCOPED: a projectId (Noetica proj- collection) threads through so notebooks/data/models/
 // experiments live in the same knowledge scope an agent team already retrieves.
 
-const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_STUDIO_API;
+import { resolveBase } from '../config/cockpitRuntime';
+const BASE = resolveBase('studio', 'VITE_STUDIO_API');
 
 export type StudioSection =
   | "notebooks" | "data" | "models" | "tuning" | "experiments"                 // Workbench


### PR DESCRIPTION
Parity re-vendor — done overnight while the field was quiet. Applies the Lane-1 runtime resolver ([socioprophet #468](https://github.com/SocioProphet/socioprophet/pull/468)) to prophet-platform's vendored client-vue, ending the drift that caused two separate fixes this session (the Analytics typecheck + the nav findability both had to be applied twice).

**What:** `resolveBase(key, envVar, fallback?)` — precedence **host-injected `window.__COCKPIT_CONFIG__` > `VITE_*` env > fallback** — replacing build-time `VITE_X ?? default` across the 9 service clients.

**Safety:** backward-compatible / **no-op for the live GKE cockpit** — every default preserved, and `.env.production`'s `VITE_STUDIO_API=/svc/studio` still wins through the resolver's env layer. Verified: `vue-tsc` 0 errors, `vite build` clean, `/svc/*` + `/svc/studio` + `127.0.0.1` all still baked in the bundle.

**Why it matters:** with this + #468, the same client-vue codebase runs identically across GKE-hosted, Firebase, and BearBrowser-embedded — and BearBrowser can inject sidecar ports into the GKE-built cockpit too. Companion to the composition PRs (BearBrowser #69/#70/#71/#72).

No merges/deploys touched — staged for review.