### PR TITLE
fix(cockpit): nginx /svc proxies must use FQDNs, not bare service names

### DIFF
--- a/apps/socioprophet-web/nginx.conf
+++ b/apps/socioprophet-web/nginx.conf
@@ -73,24 +73,24 @@ http {
         # /svc/hellgraph/api/graph/stats → http://hellgraph-service:8090/api/graph/stats.
         resolver 169.254.20.10 valid=30s ipv6=off;   # GKE NodeLocal DNSCache (per-node, :53)
 
-        location /svc/hellgraph/ { set $u hellgraph-service; rewrite ^/svc/hellgraph/(.*)$ /$1 break; proxy_pass http://$u:8090; proxy_http_version 1.1; proxy_set_header Host $host; }
-        location /svc/reason/    { set $u owl-reasoner;      rewrite ^/svc/reason/(.*)$    /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
-        location /svc/er/        { set $u entity-resolution; rewrite ^/svc/er/(.*)$        /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
-        location /svc/algo/      { set $u algo-engine;       rewrite ^/svc/algo/(.*)$      /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
-        location /svc/ie/        { set $u ie-engine;         rewrite ^/svc/ie/(.*)$        /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
-        location /svc/sherlock/  { set $u sherlock-engine;   rewrite ^/svc/sherlock/(.*)$  /$1 break; proxy_pass http://$u:8093; proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /svc/hellgraph/ { set $u hellgraph-service.socioprophet.svc.cluster.local; rewrite ^/svc/hellgraph/(.*)$ /$1 break; proxy_pass http://$u:8090; proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /svc/reason/    { set $u owl-reasoner.socioprophet.svc.cluster.local;      rewrite ^/svc/reason/(.*)$    /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /svc/er/        { set $u entity-resolution.socioprophet.svc.cluster.local; rewrite ^/svc/er/(.*)$        /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /svc/algo/      { set $u algo-engine.socioprophet.svc.cluster.local;       rewrite ^/svc/algo/(.*)$      /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /svc/ie/        { set $u ie-engine.socioprophet.svc.cluster.local;         rewrite ^/svc/ie/(.*)$        /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /svc/sherlock/  { set $u sherlock-engine.socioprophet.svc.cluster.local;   rewrite ^/svc/sherlock/(.*)$  /$1 break; proxy_pass http://$u:8093; proxy_http_version 1.1; proxy_set_header Host $host; }
         # Studio API → lattice-studio (Notebooks, Compute Plane, Governance, Commons, Experiments,
         # FAIR/cite/versions/receipts). The client sets VITE_STUDIO_API=/svc/studio (see .env.production),
         # so studioApi requests /svc/studio/api/studio/* — the rewrite strips /svc/studio and lattice-studio
         # serves /api/studio/*. lattice-studio is deployed (ApplicationSet) on :8080.
-        location /svc/studio/    { set $u lattice-studio;    rewrite ^/svc/studio/(.*)$    /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /svc/studio/    { set $u lattice-studio.socioprophet.svc.cluster.local;    rewrite ^/svc/studio/(.*)$    /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
         # holmes + synapse-bridge are not deployed to the cluster yet — these route so they "just work"
         # once deployed; until then they 502 at request time and the Holmes/SynapseIQ buttons degrade
         # gracefully (the surfaces are built to handle an unavailable verifier).
-        location /svc/holmes/    { set $u holmes;            rewrite ^/svc/holmes/(.*)$    /$1 break; proxy_pass http://$u:8091; proxy_http_version 1.1; proxy_set_header Host $host; }
-        location /svc/synapse/   { set $u synapse-bridge;    rewrite ^/svc/synapse/(.*)$   /$1 break; proxy_pass http://$u:8092; proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /svc/holmes/    { set $u holmes.socioprophet.svc.cluster.local;            rewrite ^/svc/holmes/(.*)$    /$1 break; proxy_pass http://$u:8091; proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /svc/synapse/   { set $u synapse-bridge.socioprophet.svc.cluster.local;    rewrite ^/svc/synapse/(.*)$   /$1 break; proxy_pass http://$u:8092; proxy_http_version 1.1; proxy_set_header Host $host; }
         # /api → dashboard-bff (valuation / GYG / chat / governance surfaces), prefix stripped.
-        location /api/           { set $u dashboard-bff;     rewrite ^/api/(.*)$           /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
+        location /api/           { set $u dashboard-bff.socioprophet.svc.cluster.local;     rewrite ^/api/(.*)$           /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
 
         location / {
             try_files $uri $uri/ /index.html;


### PR DESCRIPTION
**The cockpit renders but its data surfaces have 502'd since #882** — green CI, broken proxy. Found by finally curling the live `/svc/*` path through the ingress.

**Root cause:** the nginx variable-proxy used **bare service names** (`set $u hellgraph-service`) with `resolver 169.254.20.10` (NodeLocal DNS). nginx's `resolver` doesn't apply the pod's resolv.conf **search domain**, so bare names get NXDOMAIN:
```
[error] hellgraph-service could not be resolved (3: Host not found)  → 502
```

**Fix:** full in-cluster **FQDN** for every upstream (`<svc>.socioprophet.svc.cluster.local`) — hellgraph/reason/er/algo/ie/sherlock/studio/holmes/synapse + `/api`→dashboard-bff. This is the same lesson the socbase-gateway already learned.

**Verified in-cluster** (throwaway curl pod): FQDNs resolve + services respond — hellgraph `200`, lattice-studio `200`, algo-engine `200`, dashboard-bff reachable. On rollout the cockpit's `/svc` + `/api` surfaces return real data.

This is the prerequisite for the socioprophet.com → login → **operating** cockpit work.