### PR TITLE
socioprophet-web: cockpit on app.socioprophet.com + real login

### DIFF
--- a/apps/socioprophet-web/public/firebase-config.js
+++ b/apps/socioprophet-web/public/firebase-config.js
@@ -1,18 +1,26 @@
 // Runtime Firebase web config, injected per environment at DEPLOY time.
 //
-//   • Empty values (below) → local dev: the auth store's DEV_AUTH_BYPASS supplies a
+//   • Empty values → local dev: the auth store's DEV_AUTH_BYPASS supplies a
 //     stub signed-in user (dev@localhost), so `npm run dev` works with no project.
-//   • Real values → real Google/email login against that Firebase project.
+//   • Real values (below) → real Google/email login against the socioprophet-web
+//     Firebase project. hasConfig=true flips the router guard to real auth, so an
+//     unauthenticated visitor lands on /login (Google + email/password) and only
+//     reaches the cockpit after signing in.
 //
 // This is the Firebase *web* config (apiKey etc.) — NOT a secret; it ships in client
-// code by design. To log in for real, fill the values before `firebase deploy --only
-// hosting:app` (dev project first: socioprophet-web-dev-env). CI may overwrite this
-// file at deploy so the repo copy stays empty.
+// code by design (these are the authoritative values served at
+// https://socioprophet-web.firebaseapp.com/__/firebase/init.json).
+//
+// authDomain stays on the firebaseapp.com handler domain: the OAuth handler
+// (/__/auth/*) is served there, so sign-in works from any *authorized* origin
+// (app.socioprophet.ai / app.socioprophet.com). Those origins must be listed under
+// Firebase Console → Authentication → Settings → Authorized domains, else
+// signInWithPopup fails with auth/unauthorized-domain.
 window.__FIREBASE_CONFIG__ = {
-  apiKey: "",
-  authDomain: "",
-  projectId: "",
-  storageBucket: "",
-  messagingSenderId: "",
-  appId: "",
+  apiKey: "AIzaSyCBYZl-mFBeDizhOzH2GePn-xJsd26g1O0",
+  authDomain: "socioprophet-web.firebaseapp.com",
+  projectId: "socioprophet-web",
+  storageBucket: "socioprophet-web.firebasestorage.app",
+  messagingSenderId: "392608809931",
+  appId: "1:392608809931:web:fcc04db9c0fdf782662c4e",
 };

--- a/charts/socioprophet-service/templates/managed-certificate.yaml
+++ b/charts/socioprophet-service/templates/managed-certificate.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.ingress.enabled .Values.ingress.managedCertificate }}
+# GKE-managed TLS cert for the ingress's public domain(s). Opt-in: only a values file that sets
+# `ingress.managedCertificate` renders this (socioprophet-web does, for app.socioprophet.com), so every
+# other chart consumer is unaffected. Pairs with the `networking.gke.io/managed-certificates` annotation
+# on the Ingress. Google provisions the cert only AFTER the domain's A record resolves to the ingress IP
+# (STATUS Provisioning → Active), so it's safe to ship before the DNS cutover.
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: {{ .Values.ingress.managedCertificate.name | quote }}
+  labels: {{- include "svc.labels" . | nindent 4 }}
+spec:
+  domains: {{- toYaml .Values.ingress.managedCertificate.domains | nindent 4 }}
+{{- end }}

--- a/deploy/values/socioprophet-web.yaml
+++ b/deploy/values/socioprophet-web.yaml
@@ -17,11 +17,24 @@ service: { port: 8080, portName: http }
 ingress:
   enabled: true
   className: ""   # cluster default; set per-cloud (gce / azure-application-gateway / alb) via overlay
-  # Bind the ingress to the reserved GLOBAL static IP (8.233.245.238) so app.socioprophet.ai's A record
-  # stays stable across ingress re-creates. Reserved as `socioprophet-web-app-ip` (IN_USE).
+  # Bind the ingress to the reserved GLOBAL static IP (8.233.245.238) so the A records
+  # stay stable across ingress re-creates. Reserved as `socioprophet-web-app-ip` (IN_USE).
   annotations:
     kubernetes.io/ingress.global-static-ip-name: socioprophet-web-app-ip
-  hosts: [{ host: app.socioprophet.ai, paths: [{ path: /, pathType: Prefix }] }]
+    # HTTPS for the public prod domain. The GKE-managed cert (below) provisions once
+    # app.socioprophet.com's A record points at 8.233.245.238 — decoupled from .ai (which
+    # has no public A record yet), so it's its OWN single-domain cert, not a shared one.
+    networking.gke.io/managed-certificates: socioprophet-web-com-cert
+  # GKE ManagedCertificate rendered by the chart (templates/managed-certificate.yaml) —
+  # only socioprophet-web sets this, so no other chart consumer emits a cert.
+  managedCertificate:
+    name: socioprophet-web-com-cert
+    domains: [app.socioprophet.com]
+  # app.socioprophet.com = the prod login URL (marketing "Sign in" button → here). app.socioprophet.ai
+  # stays as the .ai alias (HTTP for now; no public A record). Same backend/cockpit for both.
+  hosts:
+    - { host: app.socioprophet.ai,  paths: [{ path: /, pathType: Prefix }] }
+    - { host: app.socioprophet.com, paths: [{ path: /, pathType: Prefix }] }
 autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 6 }
 # nginx needs these writable under the chart's readOnlyRootFilesystem (Autopilot).
 writableDirs: [/var/cache/nginx, /var/run]


### PR DESCRIPTION
Makes **app.socioprophet.com** serve the GKE analyst cockpit (client-vue) with real Firebase login — the target of the marketing site's 'Sign in' button.

## What
- **Ingress**: add `app.socioprophet.com` as a second host on the `socioprophet-web` ingress — same static IP (`8.233.245.238`), same backend as `app.socioprophet.ai`.
- **TLS**: new gated `ManagedCertificate` chart template + values (`socioprophet-web-com-cert` → app.socioprophet.com). Only socioprophet-web sets `ingress.managedCertificate`; every other consumer renders 0 certs (verified via `helm template`).
- **Login**: inject the authoritative Firebase web config into `public/firebase-config.js` (pulled from `/__/firebase/init.json`). `hasConfig=true` flips the router guard to real auth → unauthenticated visitor hits `/login` (Google + email/password) → cockpit. `authDomain` stays on `socioprophet-web.firebaseapp.com` (OAuth handler works from any authorized origin).

## Rollout / DNS
Managed certs provision **after** DNS resolves to the ingress. Sequence:
1. Merge → images.yml rebuilds socioprophet-web (baked firebase-config) → gitops-promote pins the sha.
2. Flip Namecheap `app` A-record: `199.36.158.100` (Firebase) → `8.233.245.238` (GKE ingress).
3. HTTP app.socioprophet.com serves the cockpit immediately; `socioprophet-web-com-cert` goes Provisioning → Active (~15–60 min) → HTTPS + login live.

## Firebase console check (manual)
`app.socioprophet.com` must be in **Authentication → Settings → Authorized domains** (likely already, since it was the intended login origin). Do NOT add the unowned `socioprophet.id` / netlify domains.

Preflight: exit 0. helm lint: clean.