### PR TITLE
socioprophet-web: move Firebase web config out of git (ConfigMap injection)

### DIFF
--- a/apps/socioprophet-web/public/firebase-config.js
+++ b/apps/socioprophet-web/public/firebase-config.js
@@ -1,26 +1,26 @@
-// Runtime Firebase web config, injected per environment at DEPLOY time.
+// Runtime Firebase web config — injected at DEPLOY time, NOT committed here.
 //
-//   • Empty values → local dev: the auth store's DEV_AUTH_BYPASS supplies a
-//     stub signed-in user (dev@localhost), so `npm run dev` works with no project.
-//   • Real values (below) → real Google/email login against the socioprophet-web
-//     Firebase project. hasConfig=true flips the router guard to real auth, so an
-//     unauthenticated visitor lands on /login (Google + email/password) and only
-//     reaches the cockpit after signing in.
+//   • Empty values (this repo copy) → local dev: the auth store's DEV_AUTH_BYPASS
+//     supplies a stub signed-in user (dev@localhost), so `npm run dev` works with no
+//     project. This is also what ships in the image layer (so nothing lands in git or
+//     the image).
+//   • In-cluster, this file is OVERLAID by a ConfigMap-mounted copy holding the real
+//     socioprophet-web Firebase web config (see deploy/values/socioprophet-web.yaml
+//     `extraFileMounts` → configMap `socioprophet-web-firebase-config`). hasConfig=true
+//     then flips the router guard to real auth: an unauthenticated visitor lands on
+//     /login (Google + email/password), then the cockpit.
 //
-// This is the Firebase *web* config (apiKey etc.) — NOT a secret; it ships in client
-// code by design (these are the authoritative values served at
-// https://socioprophet-web.firebaseapp.com/__/firebase/init.json).
-//
-// authDomain stays on the firebaseapp.com handler domain: the OAuth handler
-// (/__/auth/*) is served there, so sign-in works from any *authorized* origin
-// (app.socioprophet.ai / app.socioprophet.com). Those origins must be listed under
-// Firebase Console → Authentication → Settings → Authorized domains, else
-// signInWithPopup fails with auth/unauthorized-domain.
+// Why injected, not committed: the Firebase *web* config (apiKey etc.) is public by
+// design — it ships in the browser bundle and Google serves it at
+// /__/firebase/init.json — but committing it trips automated secret scanners and puts
+// it in git history for no benefit. The ConfigMap lives in the cluster, out of git.
+// The key's real protection is API-key restrictions + Firebase Security Rules +
+// Auth authorized domains, not secrecy of this string.
 window.__FIREBASE_CONFIG__ = {
-  apiKey: "AIzaSyCBYZl-mFBeDizhOzH2GePn-xJsd26g1O0",
-  authDomain: "socioprophet-web.firebaseapp.com",
-  projectId: "socioprophet-web",
-  storageBucket: "socioprophet-web.firebasestorage.app",
-  messagingSenderId: "392608809931",
-  appId: "1:392608809931:web:fcc04db9c0fdf782662c4e",
+  apiKey: "",
+  authDomain: "",
+  projectId: "",
+  storageBucket: "",
+  messagingSenderId: "",
+  appId: "",
 };

--- a/charts/socioprophet-service/templates/deployment.yaml
+++ b/charts/socioprophet-service/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
           {{- end }}
           {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.tmpDir.enabled .Values.writableDirs }}
+          {{- if or .Values.tmpDir.enabled .Values.writableDirs .Values.extraFileMounts }}
           volumeMounts:
             {{- if .Values.tmpDir.enabled }}
             - name: tmp
@@ -92,8 +92,17 @@ spec:
             - name: writable-{{ $i }}
               mountPath: {{ $p }}
             {{- end }}
+            {{- range $i, $m := .Values.extraFileMounts }}
+            # Overlay a single file (e.g. firebase-config.js) from a ConfigMap onto the built image.
+            # Injected at deploy, NOT baked into the image — keeps public-but-not-secret runtime config
+            # (Firebase web config) out of the git-tracked source + image layers. readOnly by nature.
+            - name: filemount-{{ $i }}
+              mountPath: {{ $m.mountPath }}
+              subPath: {{ $m.subPath | default $m.key }}
+              readOnly: true
+            {{- end }}
           {{- end }}
-      {{- if or .Values.tmpDir.enabled .Values.writableDirs }}
+      {{- if or .Values.tmpDir.enabled .Values.writableDirs .Values.extraFileMounts }}
       volumes:
         {{- if .Values.tmpDir.enabled }}
         - name: tmp
@@ -103,6 +112,14 @@ spec:
         {{- range $i, $p := .Values.writableDirs }}
         - name: writable-{{ $i }}
           emptyDir: {}
+        {{- end }}
+        {{- range $i, $m := .Values.extraFileMounts }}
+        - name: filemount-{{ $i }}
+          configMap:
+            name: {{ $m.configMap }}
+            items:
+              - key: {{ $m.key }}
+                path: {{ $m.subPath | default $m.key }}
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/deploy/values/socioprophet-web.yaml
+++ b/deploy/values/socioprophet-web.yaml
@@ -38,3 +38,13 @@ ingress:
 autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 6 }
 # nginx needs these writable under the chart's readOnlyRootFilesystem (Autopilot).
 writableDirs: [/var/cache/nginx, /var/run]
+# Overlay the REAL Firebase web config at runtime from an out-of-git ConfigMap, so the
+# public-but-not-secret key never lands in source or image layers. The ConfigMap
+# `socioprophet-web-firebase-config` (key firebase-config.js) is created out-of-band in
+# the cluster (NOT committed) — see the deploy runbook. Empty repo copy → local dev bypass;
+# this mount → real login in-cluster.
+extraFileMounts:
+  - configMap: socioprophet-web-firebase-config
+    key: firebase-config.js
+    mountPath: /usr/share/nginx/html/firebase-config.js
+    subPath: firebase-config.js


### PR DESCRIPTION
Follow-up to #885. Google's scanner flagged the committed `apiKey` in firebase-config.js.

**It's a Firebase _web_ config key — public by design** (ships in the browser bundle; already served at https://socioprophet-web.firebaseapp.com/__/firebase/init.json). Not a data credential; it can't read Firestore/Storage or bypass auth. But a committed key trips scanners and sits in git history for no benefit, so this pulls it back out.

## Changes
- `public/firebase-config.js` → back to **empty** (local-dev bypass only; nothing in source/image layers).
- chart: generic `extraFileMounts` — overlay one file from a ConfigMap onto the image (readOnly subPath). Only socioprophet-web sets it (other consumers render 0 — verified).
- values: mount `socioprophet-web-firebase-config` at `/usr/share/nginx/html/firebase-config.js`.

## Requires (one out-of-band cluster step — created NOT in git)
```
kubectl create configmap socioprophet-web-firebase-config -n socioprophet \
  --from-file=firebase-config.js=<the real web config>
```
Rollout is safe before that exists: new pods wait, old pods keep serving (no outage).

## The real fix (console, follow-up)
Restrict the key (HTTP-referrer: `*.socioprophet.com/.ai/.firebaseapp.com/.web.app` + API: Identity Toolkit / Token Service). **Do NOT rotate** — the live Firebase-hosted socioprophet.com uses this same key; rotating breaks prod login until every surface redeploys.

Preflight exit 0, helm lint clean.