### PR TITLE
sherlock-engine: bind 0.0.0.0 (fix 385-restart CrashLoop)

### DIFF
--- a/apps/sherlock-engine/src/main.rs
+++ b/apps/sherlock-engine/src/main.rs
@@ -195,7 +195,10 @@ fn main() {
     };
 
     let port = std::env::var("PORT").unwrap_or_else(|_| "8093".into());
-    let server = tiny_http::Server::http(format!("127.0.0.1:{}", port)).unwrap();
+    // Bind 0.0.0.0, not 127.0.0.1: in-cluster the kubelet liveness/readiness probe hits the POD IP,
+    // so a localhost-only bind returns "connection refused" → failed liveness → SIGKILL (137) → CrashLoop
+    // (385 restarts observed). 0.0.0.0 lets the probe on :8093/healthz reach the server.
+    let server = tiny_http::Server::http(format!("0.0.0.0:{}", port)).unwrap();
     eprintln!("sherlock-engine on :{} — {} docs, mode={}", port, docs.len(), if dense { "hybrid (tantivy+qdrant/RRF)" } else { "tantivy BM25" });
 
     for request in server.incoming_requests() {


### PR DESCRIPTION
**Cockpit `/svc/sherlock` has been dead on the live cluster** — sherlock-engine in CrashLoopBackOff (385 restarts) + a stale ImagePullBackOff orphan RS.

## Root cause
`main.rs` bound `127.0.0.1:8093`. The kubelet liveness/readiness probe hits the **pod IP**, not localhost → `connection refused` → failed liveness → SIGKILL (exit **137**) → CrashLoop. The image is otherwise healthy (boots, indexes 12 docs, serves tantivy BM25). One-line fix: bind `0.0.0.0`.

## Rollout
sherlock **is** in images.yml (builds succeed), and gitops-promote rewrites `tag: latest → sha-<commit>` for changed services — so this source change auto-pins a fresh image and forces the rollout past the `latest`+IfNotPresent trap. The stale `sha-REPLACE_ON_FIRST_BUILD` orphan RS gets superseded.

`cargo check` clean. Follow-up (not here): cut sherlock's registry GAR→zot, and its dense mode needs embeddings/qdrant reachable (currently BM25-only).