### PR TITLE
hellgraph-service: auto-seed graph on boot (cockpit was showing an empty graph)

### DIFF
--- a/apps/hellgraph-service/Dockerfile
+++ b/apps/hellgraph-service/Dockerfile
@@ -25,6 +25,9 @@ RUN npm install --no-audit --no-fund
 
 COPY tsconfig.json ./
 COPY src ./src
+# Seed corpus for auto-seed-on-boot (server.ts seedIfEmpty): populates an empty graph so the cockpit's
+# knowledge surfaces aren't blank. Resolved relative to the module → /app/seeds.
+COPY seeds ./seeds
 # the compiled benchmarked analytics kernel (native/hg_napi.node) — analytics.ts loads it, TS fallback if absent
 COPY --from=native /native/hg_napi.node ./native/hg_napi.node
 

--- a/apps/hellgraph-service/src/server.test.ts
+++ b/apps/hellgraph-service/src/server.test.ts
@@ -9,6 +9,7 @@ import { retrieveGroundingAuto } from './graphrag.js'
 
 process.env.PORT = String(19091) // free test port, read at module import
 process.env.HELLGRAPH_STORE_DIR = `${process.env.TMPDIR ?? '/tmp'}/hgsvc-test-${process.pid}`
+process.env.HELLGRAPH_SEED = 'off' // tests build their own graphs — don't auto-seed the boot corpus
 
 const BASE = `http://127.0.0.1:${process.env.PORT}`
 let srv: { close: (cb?: () => void) => void }

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -26,6 +26,8 @@
 import * as http from 'node:http'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import * as fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
 
 // Storage isolation: this service must NOT share Noetica's single-writer JSONL
 // store. Set a service-local store dir BEFORE the engine's lazy getAtomSpace()
@@ -267,6 +269,43 @@ const server = http.createServer((req, res) => {
   json(res, 404, { error: 'not_found' })
 })
 
+// Auto-seed on boot (idempotent): a fresh pod starts with an empty store (the /data VOLUME is
+// ephemeral — no PVC is mounted — so nothing persists across restarts), which leaves every knowledge
+// surface blank: Graph Explorer, Query Console, Analytics, GraphRAG all render nothing. When the graph
+// has zero nodes, ingest the bundled seed corpus (apps/hellgraph-service/seeds/*.json, schema matches
+// POST /api/graph/node|edge) so the cockpit shows a coherent graph. Skipped when the store is already
+// populated (idempotent — safe once a volume is mounted) or when HELLGRAPH_SEED=off (tests / clean box).
+function seedIfEmpty(): void {
+  if (process.env['HELLGRAPH_SEED'] === 'off') return
+  try {
+    const g = getHellGraph()
+    if (g.allNodes().length > 0) return
+    const seedDir = process.env['HELLGRAPH_SEED_DIR'] ||
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'seeds')
+    if (!fs.existsSync(seedDir)) return
+    const files = fs.readdirSync(seedDir).filter((f) => f.endsWith('.json')).sort()
+    let nodes = 0, edges = 0
+    for (const f of files) {
+      const seed = JSON.parse(fs.readFileSync(path.join(seedDir, f), 'utf8')) as {
+        nodes?: Array<{ id: string; labels: string[]; properties?: Record<string, unknown> }>
+        edges?: Array<{ label: string; from: string; to: string; properties?: Record<string, unknown> }>
+      }
+      for (const n of seed.nodes ?? []) {
+        if (!n?.id || !Array.isArray(n.labels)) continue
+        g.addNode(n.id, n.labels, (n.properties ?? {}) as Record<string, never>); nodes++
+      }
+      for (const e of seed.edges ?? []) {
+        if (!e?.label || !e.from || !e.to) continue
+        g.addEdge(e.label, e.from, e.to, (e.properties ?? {}) as Record<string, never>); edges++
+      }
+    }
+    if (nodes || edges) console.log(`[hellgraph-service] auto-seeded ${nodes} nodes / ${edges} edges from ${files.length} seed file(s)`)
+  } catch (e) {
+    // Never let a seed error take the service down — log and serve whatever is there.
+    console.error('[hellgraph-service] auto-seed skipped (error):', e instanceof Error ? e.message : String(e))
+  }
+}
+
 function startLocalService(): void {
   server.listen(PORT, () => {
     console.log(`[hellgraph-service] listening on :${PORT} (engine exports: ${Object.keys(engine).length})`)
@@ -279,7 +318,11 @@ function startLocalService(): void {
         console.log(rocks
           ? `[hellgraph-service] RocksDB backend active — ${rocks.storagePath()}`
           : '[hellgraph-service] RocksDB requested but binding unavailable — using JSONL')
+        // Seed AFTER the persisted store is attached, so the emptiness check sees existing data.
+        seedIfEmpty()
       })
+    } else {
+      seedIfEmpty()
     }
   })
 }


### PR DESCRIPTION
The live graph is **empty** (`{nodes:0,edges:0}`), so the cockpit's Graph Explorer / Query Console / Analytics / GraphRAG all render blank — the recurring 'the surfaces feel worthless' complaint, and it matters now that the cockpit is the prod login surface.

## Root cause
hellgraph-service's store is **ephemeral** (Dockerfile `VOLUME /data`, but no PVC is mounted → wiped every restart) **and nothing ever ingested the bundled seed** (`seeds/gyg-supply-chain-causal.json` wasn't even COPY'd into the image).

## Fix
`seedIfEmpty()` on boot: if the graph has 0 nodes, ingest `seeds/*.json` (schema already matches `POST /api/graph/node|edge`).
- **Idempotent** — skips when already populated, so it's a no-op once a PVC is mounted.
- **Fail-safe** — a seed error logs and the service still serves (never crashes on seed).
- **Opt-out** — `HELLGRAPH_SEED=off` (the test suite uses it to keep isolated graphs).
- Dockerfile now `COPY seeds ./seeds`.

## Verified locally
- Fresh store → `auto-seeded 20 nodes / 26 edges`; `/api/graph/stats` → `{nodes:20,edges:26}`; subgraph query returns real nodes.
- Restart on same store → seed **skipped** (idempotent).
- Test suite **18/18 green** (PageRank test passes with seed off).

Follow-up (not here): mount a PVC for true persistence + a richer/real seed corpus beyond the GYG demo.