### PR TITLE
provision-secrets: add postgres-credentials (CI-native, unblocks workspace-mail)

### DIFF
--- a/.github/workflows/provision-secrets.yml
+++ b/.github/workflows/provision-secrets.yml
@@ -73,3 +73,23 @@ jobs:
           sync studio-write-token    token "$STUDIO_WRITE_TOKEN"    socioprophet
 
           echo "done."
+
+      # postgres-credentials is a TWO-key secret (username + password) shared by workspace-smtp,
+      # memoryd, and agent-registry to reach the `postgres` StatefulSet (DB prophet_platform).
+      # Rather than duplicate the password into a GitHub secret (and risk it drifting from the
+      # running DB), DERIVE it from the in-cluster `postgres-admin` secret — the same value the
+      # postgres pod itself uses — so it always matches. Idempotent (create --dry-run | apply).
+      - name: Derive postgres-credentials from postgres-admin
+        env:
+          ONLY: ${{ inputs.only }}
+        run: |
+          set -euo pipefail
+          if [ -n "$ONLY" ] && ! printf ',%s,' "$ONLY" | grep -q ',postgres-credentials,'; then
+            echo "· skip postgres-credentials (not in 'only' filter)"; exit 0
+          fi
+          PW=$(kubectl get secret postgres-admin -n socioprophet -o jsonpath='{.data.password}' | base64 -d)
+          if [ -z "$PW" ]; then echo "✗ postgres-admin has no password — aborting"; exit 1; fi
+          kubectl create secret generic postgres-credentials -n socioprophet \
+            --from-literal=username=postgres --from-literal=password="$PW" \
+            --dry-run=client -o yaml | kubectl apply -f -
+          echo "✔ postgres-credentials → namespace/socioprophet (derived from postgres-admin)"


### PR DESCRIPTION
Fixes #2 the estate way. `workspace-smtp`/memoryd/agent-registry need a shared `postgres-credentials` secret that was never created (→ `CreateContainerConfigError`, mail plane down 5d). Instead of a manual `kubectl create secret`, this adds a step to `provision-secrets.yml` that **derives it from the in-cluster `postgres-admin`** (the same password the postgres pod uses) — matches the running DB, no new GitHub secret, can't drift, idempotent.

After merge: **Actions → provision-secrets → Run workflow** (`only=postgres-credentials`). Then workspace-smtp starts; the stale GHCR orphan RS ages out.