### PR TITLE
provision-secrets: default GKE cluster coords so it can actually run

### DIFF
--- a/.github/workflows/provision-secrets.yml
+++ b/.github/workflows/provision-secrets.yml
@@ -39,8 +39,12 @@ jobs:
 
       - uses: google-github-actions/get-gke-credentials@v2
         with:
-          cluster_name: ${{ vars.GKE_CLUSTER }}
-          location: ${{ vars.GKE_LOCATION }}
+          # Default to the known prophet-platform coordinates so the workflow is self-sufficient
+          # even when the repo Variables were never set (they weren't — this is why the first run
+          # failed with "input required and not supplied: cluster_name"). Setting vars.GKE_CLUSTER /
+          # vars.GKE_LOCATION still overrides these.
+          cluster_name: ${{ vars.GKE_CLUSTER || 'prophet-platform' }}
+          location: ${{ vars.GKE_LOCATION || 'us-central1' }}
 
       - name: Materialize token Secrets
         env:


### PR DESCRIPTION
Follow-up to #889. The provision-secrets workflow had never run successfully — repo Variables `GKE_CLUSTER`/`GKE_LOCATION` were never set, so `get-gke-credentials` failed with `input required and not supplied: cluster_name`. Default them to the known `prophet-platform`/`us-central1` (still overridable via repo Variables). Then postgres-credentials provisioning works.