### PR TITLE
cockpit: ubiquitous IE — global Extract dock (⌘E) on every surface

### DIFF
--- a/apps/socioprophet-web/src/App.vue
+++ b/apps/socioprophet-web/src/App.vue
@@ -174,6 +174,13 @@
         >◈ Graph</button>
         <button
           type="button"
+          class="sp-graph-toggle"
+          :class="{ on: cockpit.extractOpen }"
+          title="Toggle extraction — live entities/claims + promote to graph (⌘E / Ctrl+E)"
+          @click="cockpit.toggleExtract()"
+        >⌖ Extract</button>
+        <button
+          type="button"
           class="sp-noetica-toggle"
           :class="{ on: cockpit.dockOpen }"
           title="Toggle Noetica assistant (⌘J / Ctrl+J)"
@@ -221,6 +228,9 @@
 
     <!-- Global knowledge-graph dock (⌘G / Ctrl+G) -->
     <GraphDock :open="cockpit.graphOpen" @close="cockpit.closeGraph()" />
+
+    <!-- Ubiquitous IE: global extraction dock on every surface (⌘E / Ctrl+E) -->
+    <ExtractDock :open="cockpit.extractOpen" @close="cockpit.closeExtract()" />
   </div>
 </template>
 
@@ -236,6 +246,7 @@ import QuakeTerminal from './components/QuakeTerminal.vue';
 import CommandPalette from './components/CommandPalette.vue';
 import NoeticaDock from './components/NoeticaDock.vue';
 import GraphDock from './components/GraphDock.vue';
+import ExtractDock from './components/ExtractDock.vue';
 import { useOperatorTerminal } from './composables/useOperatorTerminal';
 import { useNoeticaChat } from './composables/useNoeticaChat';
 import { domainSurfaces, surfaceForRoute, surfacesForDomain } from './config/domainRoutes';
@@ -380,6 +391,12 @@ function onTermHotkey(e: KeyboardEvent) {
   if ((e.metaKey || e.ctrlKey) && (e.key === 'g' || e.key === 'G')) {
     e.preventDefault();
     cockpit.toggleGraph();
+    return;
+  }
+  // Cmd/Ctrl+E — toggle the ubiquitous extraction dock (live IE, every surface).
+  if ((e.metaKey || e.ctrlKey) && (e.key === 'e' || e.key === 'E')) {
+    e.preventDefault();
+    cockpit.toggleExtract();
     return;
   }
   if (e.key === 'Escape' && cockpit.dockOpen && !termOpen.value) { cockpit.closeDock(); return; }

--- a/apps/socioprophet-web/src/components/ExtractDock.vue
+++ b/apps/socioprophet-web/src/components/ExtractDock.vue
@@ -1,0 +1,77 @@
+<template>
+  <!-- Ubiquitous IE: the live extraction stack (entities / claims / topics + promote-to-graph)
+       as a global slide-in dock, available on EVERY surface (⌘E / Ctrl+E) — mirror of the Graph
+       and Noetica docks. Seeds from the current surface's context text; editable so you can extract
+       any selection or pasted text anywhere. -->
+  <Transition name="xdock">
+    <aside v-if="open" class="xdock" role="complementary" aria-label="Extraction">
+      <header class="xdock-head">
+        <span class="xdock-glyph" aria-hidden="true">⌖</span>
+        <span class="xdock-title">Extract</span>
+        <span v-if="ctx.surface" class="xdock-ctx">{{ ctx.surface }}</span>
+        <button class="xdock-x" type="button" aria-label="Close extraction" @click="$emit('close')">✕</button>
+      </header>
+
+      <label class="xdock-in">
+        <span class="xdock-in-h">Text</span>
+        <textarea
+          v-model="text"
+          rows="3"
+          spellcheck="false"
+          placeholder="Extract from this surface, a selection, or paste any text…"
+        ></textarea>
+      </label>
+
+      <div class="xdock-body">
+        <ExtractionPanel v-if="text.trim()" :text="text" :source="ctx.surface || 'Extract dock'" />
+        <p v-else class="xdock-empty">Type or paste text — or open a surface with a selected item — to pull live entities, claims, and topics, and promote them into the graph.</p>
+      </div>
+    </aside>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+import ExtractionPanel from './ExtractionPanel.vue';
+import { useCockpit } from '../stores/cockpit';
+
+const props = defineProps<{ open: boolean }>();
+defineEmits<{ (e: 'close'): void }>();
+const cockpit = useCockpit();
+const ctx = computed(() => cockpit.context);
+
+// Seed the textarea from the surface's context text (or its entity label) whenever the dock opens
+// or the context changes — but keep it editable so the user can extract anything on any page.
+const text = ref('');
+function seed() {
+  const c = cockpit.context;
+  const from = c.text || [c.entityLabel, c.detail].filter(Boolean).join(' — ');
+  if (from && from.trim()) text.value = from;
+}
+watch(() => props.open, (o) => { if (o) seed(); });
+watch(() => cockpit.context, () => { if (props.open) seed(); }, { deep: true });
+</script>
+
+<style scoped>
+.xdock {
+  position: fixed; top: 0; right: 0; bottom: 0; width: min(400px, 92vw); z-index: 60;
+  display: flex; flex-direction: column; gap: 0.6rem;
+  background: var(--surface); border-left: 1px solid var(--line-2);
+  box-shadow: -18px 0 44px rgba(0, 0, 0, 0.45); padding: 0.85rem 0.95rem;
+}
+.xdock-head { display: flex; align-items: center; gap: 0.5rem; }
+.xdock-glyph { color: var(--accent); }
+.xdock-title { font-size: 0.8rem; font-weight: 700; letter-spacing: 0.02em; }
+.xdock-ctx { margin-left: auto; font-size: 0.68rem; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.06em; }
+.xdock-x { border: none; background: transparent; color: var(--text-3); cursor: pointer; font-size: 0.8rem; }
+.xdock-x:hover { color: var(--text); }
+.xdock-in { display: flex; flex-direction: column; gap: 0.25rem; }
+.xdock-in-h { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-3); }
+.xdock-in textarea { resize: vertical; background: var(--bg); border: 1px solid var(--line-2); border-radius: 8px; color: var(--text); font: inherit; font-size: 0.82rem; line-height: 1.5; padding: 0.45rem 0.6rem; outline: none; }
+.xdock-in textarea:focus { border-color: color-mix(in srgb, var(--accent) 45%, transparent); }
+.xdock-body { min-height: 0; overflow-y: auto; }
+.xdock-empty { font-size: 0.8rem; color: var(--text-3); line-height: 1.5; padding: 0.5rem 0.1rem; }
+
+.xdock-enter-active, .xdock-leave-active { transition: transform 0.18s ease, opacity 0.18s ease; }
+.xdock-enter-from, .xdock-leave-to { transform: translateX(16px); opacity: 0; }
+</style>

--- a/apps/socioprophet-web/src/stores/cockpit.ts
+++ b/apps/socioprophet-web/src/stores/cockpit.ts
@@ -12,11 +12,13 @@ export interface SurfaceContext {
   entityLabel?: string;   // e.g. 'SPX · S&P 500'
   detail?: string;        // e.g. '5,259.71 · -1.14%'
   route?: string;         // current path
+  text?: string;          // the surface's primary text — feeds the ubiquitous Extract dock (live IE)
 }
 
 export const useCockpit = defineStore('cockpit', () => {
   const dockOpen = ref(false);
   const graphOpen = ref(false);
+  const extractOpen = ref(false);
   const context = ref<SurfaceContext>({ surface: '' });
 
   function setContext(c: SurfaceContext) { context.value = c; }
@@ -25,6 +27,9 @@ export const useCockpit = defineStore('cockpit', () => {
   function toggleDock() { dockOpen.value = !dockOpen.value; }
   function toggleGraph() { graphOpen.value = !graphOpen.value; }
   function closeGraph() { graphOpen.value = false; }
+  // Ubiquitous IE: the Extract dock (live ie-engine) is available on every surface.
+  function toggleExtract() { extractOpen.value = !extractOpen.value; }
+  function closeExtract() { extractOpen.value = false; }
 
   // One-tap "ask Noetica about what I'm looking at": open the dock + send a
   // context-framed prompt into the shared chat session.
@@ -33,5 +38,5 @@ export const useCockpit = defineStore('cockpit', () => {
     useNoeticaChat().send(prompt);
   }
 
-  return { dockOpen, graphOpen, context, setContext, openDock, closeDock, toggleDock, toggleGraph, closeGraph, askAbout };
+  return { dockOpen, graphOpen, extractOpen, context, setContext, openDock, closeDock, toggleDock, toggleGraph, closeGraph, toggleExtract, closeExtract, askAbout };
 });


### PR DESCRIPTION
'Make our NLP/IE stack available on every surface — it's a ubiquitous feature.' Done.

New global **Extract dock** (mirror of the Graph ⌘G / Noetica ⌘J docks): toolbar **⌖ Extract** + **⌘E/Ctrl+E**, available on **every** surface. Reuses the live `ExtractionPanel` (real spaCy entities/claims/topics via `/svc/ie` + **⇪ promote-to-graph**). Seeds from the surface's context text (`cockpit.context.text`), editable so you can extract any selection or pasted text anywhere. Build clean.

Next: surfaces set `context.text` on selection so the dock auto-fills (News/Law already have inline panels; this makes it universal).