### PR TITLE
cockpit: reusable EvidenceGraph ego-net (People wired; Law reuses next)

### DIFF
--- a/apps/socioprophet-web/src/components/EvidenceGraph.vue
+++ b/apps/socioprophet-web/src/components/EvidenceGraph.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+// EvidenceGraph — the reusable ego-network. Radial focus+context: an ego node centered, its
+// 1-hop neighbours on a ring, typed by colour, edges labelled by relation and STYLED BY PROVENANCE
+// (solid = record/org, dashed = news-derived, dotted = personal). Click a node to re-centre, click
+// an edge to open its evidence. This is the moat applied to any entity: LinkedIn/Palantir show
+// connections; we show why to believe each one. Powers both the People associates graph and the Law
+// citation panel (cites / cited-by). Pure SVG, no graph lib.
+import { computed } from 'vue';
+
+export interface EgoNode { id: string; label: string; type?: string }
+export interface EgoLink { node: EgoNode; rel?: string; provenance?: 'record' | 'news' | 'personal' | 'derived'; evidence?: string; dir?: 'in' | 'out' }
+
+const props = withDefaults(
+  defineProps<{ center: EgoNode; links: EgoLink[]; w?: number; h?: number }>(),
+  { w: 320, h: 240 },
+);
+const emit = defineEmits<{ (e: 'select', node: EgoNode): void; (e: 'evidence', link: EgoLink): void }>();
+
+const TYPE_COLORS: Record<string, string> = {
+  person: '#5aa9ff', org: '#c9a3ff', company: '#c9a3ff', gov: '#e3b341', place: '#6fbf8b',
+  topic: '#a3e635', rule: '#8fb0ff', law: '#d8a250', money: '#e3b341', default: '#8b949e',
+};
+const col = (t?: string) => TYPE_COLORS[(t || 'default').toLowerCase()] || TYPE_COLORS.default;
+const initials = (s: string) => s.split(/\s+/).slice(0, 2).map((w) => w[0]?.toUpperCase() ?? '').join('');
+const short = (s: string) => (s.length > 14 ? s.slice(0, 13) + '…' : s);
+const dash = (p?: string) => (p === 'news' || p === 'derived' ? '5 4' : p === 'personal' ? '1.5 4' : '0');
+
+const layout = computed(() => {
+  const cx = props.w / 2, cy = props.h / 2;
+  const R = Math.min(props.w, props.h) * 0.34;
+  const n = props.links.length || 1;
+  return {
+    cx, cy,
+    nodes: props.links.map((lk, i) => {
+      const ang = -Math.PI / 2 + (i / n) * Math.PI * 2;
+      return { lk, x: +(cx + R * Math.cos(ang)).toFixed(1), y: +(cy + R * Math.sin(ang)).toFixed(1) };
+    }),
+  };
+});
+</script>
+
+<template>
+  <svg class="eg" :viewBox="`0 0 ${w} ${h}`" role="img" aria-label="Evidence-backed relationship graph">
+    <g v-for="(nd, i) in layout.nodes" :key="'e' + i">
+      <line class="eg-edge" :x1="layout.cx" :y1="layout.cy" :x2="nd.x" :y2="nd.y" :stroke-dasharray="dash(nd.lk.provenance)"
+            @click.stop="emit('evidence', nd.lk)" />
+      <text v-if="nd.lk.rel" class="eg-rel" :x="(layout.cx + nd.x) / 2" :y="(layout.cy + nd.y) / 2 - 3" text-anchor="middle">{{ nd.lk.rel }}</text>
+    </g>
+    <g v-for="(nd, i) in layout.nodes" :key="'n' + i" class="eg-node" @click.stop="emit('select', nd.lk.node)">
+      <title>{{ nd.lk.node.label }}{{ nd.lk.evidence ? ' · evidence: ' + nd.lk.evidence : '' }}</title>
+      <circle :cx="nd.x" :cy="nd.y" r="13" :fill="col(nd.lk.node.type)" />
+      <text :x="nd.x" :y="nd.y + 3.5" text-anchor="middle" class="eg-init">{{ initials(nd.lk.node.label) }}</text>
+      <text :x="nd.x" :y="nd.y + 27" text-anchor="middle" class="eg-lab">{{ short(nd.lk.node.label) }}</text>
+    </g>
+    <circle :cx="layout.cx" :cy="layout.cy" r="18" :fill="col(center.type)" stroke="#fff" stroke-width="1.5" />
+    <text :x="layout.cx" :y="layout.cy + 4.5" text-anchor="middle" class="eg-init ego">{{ initials(center.label) }}</text>
+  </svg>
+</template>
+
+<style scoped>
+.eg { width: 100%; height: auto; display: block; }
+.eg-edge { stroke: rgba(237, 238, 242, 0.28); stroke-width: 1.3; cursor: pointer; }
+.eg-edge:hover { stroke: var(--accent); }
+.eg-rel { fill: rgba(237, 238, 242, 0.42); font-size: 7.5px; text-transform: uppercase; letter-spacing: 0.04em; pointer-events: none; }
+.eg-node { cursor: pointer; }
+.eg-node:hover circle { stroke: #fff; stroke-width: 1.2; }
+.eg-init { fill: #0d0f13; font-size: 9px; font-weight: 700; pointer-events: none; }
+.eg-init.ego { fill: #0d0f13; font-size: 11px; }
+.eg-lab { fill: rgba(237, 238, 242, 0.6); font-size: 8.5px; pointer-events: none; }
+</style>

--- a/apps/socioprophet-web/src/pages/PeopleDirectory.vue
+++ b/apps/socioprophet-web/src/pages/PeopleDirectory.vue
@@ -84,19 +84,15 @@
         <!-- Ego graph -->
         <div class="pd-block">
           <div class="pd-block-h">Relationships</div>
-          <svg class="pd-ego" viewBox="0 0 300 210" role="img" aria-label="relationship graph">
-            <line v-for="(n, i) in egoNodes" :key="'e' + i" x1="150" y1="105" :x2="n.x" :y2="n.y" class="pd-edge" />
-            <g v-for="(n, i) in egoNodes" :key="'n' + i" :transform="`translate(${n.x},${n.y})`" :class="{ link: n.exists }" @click="n.exists && (selectedId = n.id)">
-              <circle r="15" :fill="kindColor(n.kind)" />
-              <text class="pd-ego-init" y="4" text-anchor="middle">{{ initials(n.name) }}</text>
-              <text class="pd-ego-lbl" y="30" text-anchor="middle">{{ n.short }}</text>
-              <text class="pd-ego-rel" y="-20" text-anchor="middle">{{ n.label }}</text>
-            </g>
-            <g transform="translate(150,105)">
-              <circle r="22" :fill="kindColor(selected.kind)" stroke="var(--bg)" stroke-width="2" />
-              <text class="pd-ego-init self" y="5" text-anchor="middle">{{ initials(selected.name) }}</text>
-            </g>
-          </svg>
+          <EvidenceGraph
+            :center="{ id: selected.id, label: selected.name, type: selected.kind }"
+            :links="egoLinks"
+            :w="300"
+            :h="210"
+            @select="onEgoSelect"
+            @evidence="onEgoEvidence"
+          />
+          <div class="pd-ego-cap"><span class="d solid"></span>record <span class="d dash"></span>news-derived · click a node to open · click an edge for evidence</div>
         </div>
 
         <!-- OSINT: social accounts -->
@@ -175,6 +171,8 @@
 import SurfaceHeader from '../components/SurfaceHeader.vue';
 import LiveToggle from '../components/LiveToggle.vue';
 import EmptyState from '../components/EmptyState.vue';
+import EvidenceGraph from '../components/EvidenceGraph.vue';
+import { useCockpit } from '../stores/cockpit';
 import { ref, computed, watch, onMounted } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import SplitPane from '../components/SplitPane.vue';
@@ -290,6 +288,28 @@ const egoNodes = computed(() => {
   });
 });
 
+// Ego-net links for the reusable EvidenceGraph: resolve each relation to its entity, tag a
+// provenance (co-author/employ/advise = record → solid; brief/testify = news-derived → dashed).
+const cockpit = useCockpit();
+const egoLinks = computed(() =>
+  (selected.value?.relations ?? []).map((rel) => {
+    const target = byId.value.get(rel.to);
+    const l = rel.label.toLowerCase();
+    const provenance: 'record' | 'news' | 'personal' | 'derived' =
+      /brief|testif|advised by/.test(l) ? 'derived' : /co-?author/.test(l) ? 'personal' : 'record';
+    return {
+      node: { id: rel.to, label: target?.name ?? rel.to, type: (target?.kind ?? 'org') as string },
+      rel: rel.label,
+      provenance,
+      evidence: target ? `dir:${rel.to}` : undefined,
+    };
+  }),
+);
+function onEgoSelect(n: { id: string }) { if (byId.value.has(n.id)) selectedId.value = n.id; }
+function onEgoEvidence(lk: { rel?: string; node: { label: string } }) {
+  cockpit.askAbout(`What is the evidence that ${selected.value?.name} ${lk.rel ?? 'is connected to'} ${lk.node.label}? Cite the news, filings, or graph facts.`);
+}
+
 const asOfLabel = new Date(asOf).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
 </script>
 
@@ -330,6 +350,9 @@ const asOfLabel = new Date(asOf).toLocaleString('en-US', { month: 'short', day: 
 .pd-block { margin-top: 0.9rem; border-top: 1px solid var(--line-2); padding-top: 0.8rem; }
 .pd-block-h { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.1em; color: rgba(255, 255, 255, 0.4); margin-bottom: 0.5rem; }
 .pd-ego { width: 100%; height: 210px; }
+.pd-ego-cap { display: flex; align-items: center; flex-wrap: wrap; gap: 0.35rem 0.6rem; margin-top: 0.3rem; font-size: 0.62rem; color: var(--text-3); }
+.pd-ego-cap .d { display: inline-block; width: 12px; height: 0; }
+.pd-ego-cap .d.solid { border-top: 1.5px solid var(--text-2); } .pd-ego-cap .d.dash { border-top: 1.5px dashed var(--accent); }
 .pd-edge { stroke: rgba(255, 255, 255, 0.14); stroke-width: 1; }
 .pd-ego .link { cursor: pointer; } .pd-ego .link:hover circle { stroke: #fff; stroke-width: 2; }
 .pd-ego circle { stroke: var(--bg); stroke-width: 1.5; }


### PR DESCRIPTION
The shared ego-network component — one build, two surfaces. **The moat applied to relationships:** every edge is **provenance-styled** (solid=record / dashed=news-derived / dotted=personal) and **click-to-evidence**. LinkedIn/Palantir show connections; we show *why to believe each one*.

- New `<EvidenceGraph>`: radial focus+context, typed nodes, relation-labelled edges, emits `select` (re-centre) + `evidence`. Pure SVG, reusable.
- **People page** now uses it: relations → resolved entities + provenance; click node → open, click edge → Noetica cites the evidence.
- **Law citation panel** (cites/cited-by) reuses the exact component next.

Build clean.