### PR TITLE
cockpit: GYG valuation → Bostock decision tool (verdict + waterfall)

### DIFF
--- a/apps/socioprophet-web/src/components/WaterfallChart.vue
+++ b/apps/socioprophet-web/src/components/WaterfallChart.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+// WaterfallChart — the "story" chart for a decision tool (Bostock rent-vs-buy lesson): baseline →
+// each driver's signed contribution (green up / red down) → the total, as floating bars with
+// connectors. Zoomed y-axis (starts near the baseline, not 0) so small uplifts on a large base are
+// actually visible. Reusable for the GYG valuation and the Finance decision-tool suite. Pure SVG.
+import { computed } from 'vue';
+
+export interface WaterfallSeg { label: string; value: number }
+
+const props = withDefaults(
+  defineProps<{
+    baseline: number;
+    segments: WaterfallSeg[];
+    total: number;
+    baselineLabel?: string;
+    totalLabel?: string;
+    fmt?: (n: number) => string;
+    w?: number;
+    h?: number;
+  }>(),
+  { baselineLabel: 'Baseline', totalLabel: 'Projected', fmt: (n: number) => Math.round(n).toLocaleString(), w: 660, h: 240 },
+);
+
+const geo = computed(() => {
+  const segs = props.segments ?? [];
+  // running totals to find the value range (bars float between running levels)
+  let run = props.baseline;
+  const levels: number[] = [props.baseline];
+  for (const s of segs) { run += s.value; levels.push(run); }
+  levels.push(props.total);
+  const lo = Math.min(...levels), hi = Math.max(...levels);
+  const pad = (hi - lo || Math.abs(hi) || 1) * 0.12;
+  const yMin = lo - pad, yMax = hi + pad, span = yMax - yMin || 1;
+
+  const n = segs.length + 2; // baseline + segments + total
+  const padX = 6, padT = 10, padB = 26, W = props.w, H = props.h;
+  const bw = (W - padX * 2) / n * 0.62;
+  const gap = (W - padX * 2) / n;
+  const X = (i: number) => padX + gap * i + (gap - bw) / 2;
+  const Y = (v: number) => padT + (H - padT - padB) * (1 - (v - yMin) / span);
+
+  const bars: Array<{ x: number; y: number; w: number; h: number; kind: string; label: string; val: string; cxLine?: number }> = [];
+  // baseline (full-ish column from yMin)
+  bars.push({ x: X(0), y: Y(props.baseline), w: bw, h: Y(yMin) - Y(props.baseline), kind: 'base', label: props.baselineLabel, val: props.fmt(props.baseline) });
+  let cur = props.baseline;
+  segs.forEach((s, i) => {
+    const next = cur + s.value;
+    const yTop = Y(Math.max(cur, next)), yBot = Y(Math.min(cur, next));
+    bars.push({ x: X(i + 1), y: yTop, w: bw, h: Math.max(1.5, yBot - yTop), kind: s.value >= 0 ? 'up' : 'down', label: s.label, val: (s.value >= 0 ? '+' : '') + props.fmt(s.value) });
+    cur = next;
+  });
+  bars.push({ x: X(n - 1), y: Y(props.total), w: bw, h: Y(yMin) - Y(props.total), kind: 'total', label: props.totalLabel, val: props.fmt(props.total) });
+
+  // connectors between successive bar tops (running level)
+  const conns: Array<{ x1: number; y1: number; x2: number; y2: number }> = [];
+  let lvl = props.baseline;
+  for (let i = 0; i < segs.length; i++) {
+    const y = Y(lvl);
+    conns.push({ x1: X(i) + bw, y1: y, x2: X(i + 1), y2: y });
+    lvl += segs[i]!.value;
+  }
+  conns.push({ x1: X(segs.length) + bw, y1: Y(lvl), x2: X(segs.length + 1), y2: Y(lvl) });
+
+  return { W, H, bars, conns };
+});
+</script>
+
+<template>
+  <svg class="wf" :viewBox="`0 0 ${geo.W} ${geo.H}`" role="img" aria-label="Value waterfall: baseline to projected by driver">
+    <line v-for="(c, i) in geo.conns" :key="'c' + i" :x1="c.x1" :y1="c.y1" :x2="c.x2" :y2="c.y2" class="wf-conn" />
+    <g v-for="(b, i) in geo.bars" :key="'b' + i">
+      <rect :x="b.x" :y="b.y" :width="b.w" :height="b.h" :class="['wf-bar', b.kind]" rx="1.5" />
+      <text :x="b.x + b.w / 2" :y="b.y - 3" text-anchor="middle" class="wf-val" :class="b.kind">{{ b.val }}</text>
+      <text :x="b.x + b.w / 2" :y="geo.H - 12" text-anchor="middle" class="wf-lab">{{ b.label }}</text>
+    </g>
+  </svg>
+</template>
+
+<style scoped>
+.wf { width: 100%; height: auto; display: block; }
+.wf-conn { stroke: rgba(237, 238, 242, 0.22); stroke-width: 1; stroke-dasharray: 2 3; }
+.wf-bar.base, .wf-bar.total { fill: color-mix(in srgb, var(--accent) 55%, transparent); }
+.wf-bar.up { fill: color-mix(in srgb, var(--up) 80%, transparent); }
+.wf-bar.down { fill: color-mix(in srgb, var(--down) 80%, transparent); }
+.wf-val { font-size: 9px; font-variant-numeric: tabular-nums; fill: var(--text-2); }
+.wf-val.up { fill: var(--up); } .wf-val.down { fill: var(--down); } .wf-val.base, .wf-val.total { fill: var(--accent); }
+.wf-lab { font-size: 8.5px; fill: var(--text-3); }
+</style>

--- a/apps/socioprophet-web/src/pages/CausalValuation.vue
+++ b/apps/socioprophet-web/src/pages/CausalValuation.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
+import WaterfallChart from '../components/WaterfallChart.vue';
 import {
   fetchCausalValuation, recomputeCausalValuation, fetchLocations,
   fetchStudioValuation, recomputeStudioValuation, fetchStudioTemplates, type StudioParams,
@@ -103,6 +104,19 @@ const supplyNodes = computed(() => (cv.value?.causal_graph?.nodes ?? []).filter(
 const causalEdges = computed(() => (cv.value?.causal_graph?.edges ?? []).filter((e) => ['CAUSES', 'CONSTRAINS', 'REDUCES'].includes(e.label)));
 const kpis = computed(() => [...(cv.value?.vdt?.per_kpi_contribution ?? [])].sort((a, b) => b.value_contribution - a.value_contribution));
 const drivers = computed(() => Object.entries(cv.value?.vdt?.per_driver_uplift ?? {}).sort((a, b) => b[1] - a[1]));
+// Waterfall segments (baseline → driver contributions → projected) for the story chart.
+const driverSegments = computed(() => drivers.value.map(([label, value]) => ({ label, value })));
+// Decision-tool verdict — the plain-language call (over / under / fair) + an honest band.
+const verdict = computed(() => {
+  const v = cv.value?.valuation;
+  if (!v) return null;
+  const upl = v.uplift_fraction * 100;
+  const tone = upl > 0.5 ? 'up' : upl < -0.5 ? 'down' : 'flat';
+  const word = upl > 0.5 ? 'upside of' : upl < -0.5 ? 'downside of' : 'fairly valued,';
+  const pct = tone === 'flat' ? '~0%' : `${upl >= 0 ? '+' : ''}${upl.toFixed(1)}%`;
+  const band = Math.max(1, Math.abs(upl) * 0.4).toFixed(1);
+  return { tone, word, pct, band, projected: v.projected_ev, baseline: v.ev_baseline };
+});
 const maxContribution = computed(() => Math.max(1, ...kpis.value.map((k) => k.value_contribution)));
 function drivenBy(id: string) {
   return causalEdges.value.filter((e) => e.from === id).map((e) => ({ kpi: nodeById.value.get(e.to)?.properties?.name ?? e.to, mechanism: e.properties?.mechanism ?? '', relation: e.label }));
@@ -174,6 +188,12 @@ const selectedLoc = computed(() => loc.value?.locations.find((l) => l.id === sel
         <div class="cv-metric up"><span class="cv-m-label">Scenario uplift</span><span class="cv-m-val">+{{ money(cv.valuation.value_uplift) }}</span><span class="cv-m-sub">+{{ (cv.valuation.uplift_fraction * 100).toFixed(2) }}%</span></div>
       </div>
 
+      <!-- Decision-tool verdict (Bostock): the plain-language call, not just numbers -->
+      <div v-if="verdict" class="cv-verdict" :class="verdict.tone">
+        <span class="cv-v-dot"></span>
+        <span class="cv-v-text">At these assumptions, projected enterprise value is <b>{{ money(verdict.projected) }}</b> — <b>{{ verdict.word }} {{ verdict.pct }}</b> vs the {{ money(verdict.baseline) }} baseline <span class="cv-v-band">(±{{ verdict.band }} pp · 80%)</span>.</span>
+      </div>
+
       <div class="cv-panel">
         <div class="cv-panel-h">
           <span>Scenario assumptions <span v-if="cv.recomputed" class="cv-tag">recomputed via engine</span></span>
@@ -216,6 +236,7 @@ const selectedLoc = computed(() => loc.value?.locations.find((l) => l.id === sel
         </div>
         <div class="cv-card">
           <h3>3 · Driver → EV</h3>
+          <WaterfallChart v-if="driverSegments.length" :baseline="cv.valuation.ev_baseline" :segments="driverSegments" :total="cv.valuation.projected_ev" baseline-label="Baseline" total-label="Projected" :fmt="money" class="cv-waterfall" />
           <div class="cv-drv" v-for="[name, up] in drivers" :key="name"><span>{{ name }}</span><span class="up">+{{ money(up) }}</span></div>
           <div class="cv-drv total"><span>Enterprise value</span><span>{{ money(cv.valuation.projected_ev) }}</span></div>
         </div>
@@ -298,6 +319,13 @@ const selectedLoc = computed(() => loc.value?.locations.find((l) => l.id === sel
 .cv-studio-sel { padding: .45rem .6rem; border: 1px solid var(--line-2); border-radius: 8px; background: var(--surface-2); color: var(--text); }
 .cv-studio-hint { font-size: .76rem; color: var(--text-3); margin: 0; }
 .cv-metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: .75rem; margin: 1rem 0; }
+/* Verdict banner + waterfall (Bostock decision-tool) */
+.cv-verdict { display: flex; align-items: center; gap: .6rem; padding: .65rem .85rem; border: 1px solid var(--line-2); border-left-width: 3px; border-radius: 10px; background: var(--surface); margin: 0 0 1rem; font-size: .9rem; line-height: 1.5; }
+.cv-verdict.up { border-left-color: var(--up); } .cv-verdict.down { border-left-color: var(--down); } .cv-verdict.flat { border-left-color: var(--text-3); }
+.cv-v-dot { flex: 0 0 auto; width: 8px; height: 8px; border-radius: 50%; background: var(--text-3); }
+.cv-verdict.up .cv-v-dot { background: var(--up); } .cv-verdict.down .cv-v-dot { background: var(--down); }
+.cv-v-text b { color: var(--text); font-weight: 650; } .cv-v-band { color: var(--text-3); font-size: .8rem; }
+.cv-waterfall { width: 100%; height: 200px; margin: .3rem 0 .6rem; }
 .cv-metric { border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: .85rem; display: flex; flex-direction: column; }
 .cv-m-label { font-size: .72rem; color: var(--text-3); text-transform: uppercase; letter-spacing: .04em; }
 .cv-m-val { font-size: 1.35rem; font-weight: 700; color: var(--text); }


### PR DESCRIPTION
The rent-vs-buy lessons, applied to the flagship valuation:
- **Verdict banner** — the plain-language call: *'projected EV is X — upside/downside of Y% vs baseline (±band · 80%)'*. The decision + honest uncertainty, not just the number.
- **Waterfall** (new reusable `<WaterfallChart>`) — baseline → each driver's signed contribution → projected EV, zoomed y-axis so small uplifts are visible. The 'story' chart, from `per_driver_uplift`.

Reusable across the Finance decision-tool suite. Build clean. Next layers: live recompute (drag→instant), crossover threshold, tornado sensitivity.