### PR TITLE
cockpit(portfolio): our own proof-carrying portfolio agent

### DIFF
--- a/apps/socioprophet-web/src/pages/PortfolioBoard.vue
+++ b/apps/socioprophet-web/src/pages/PortfolioBoard.vue
@@ -4,6 +4,7 @@
       <template #badge><span class="pf-pill">paper</span></template>
       <template #actions>
         <div class="pf-actions">
+        <button class="pf-agent-btn" type="button" @click="runAgent" title="Run our proof-carrying portfolio agent">◆ Run agent</button>
         <button class="pf-ask" type="button" @click="askNoetica">◇ Ask Noetica</button>
         <button class="pf-reset" type="button" @click="portfolio.reset()" title="Clear the paper book">Reset book</button>
         </div>
@@ -32,6 +33,59 @@
         <span class="pf-s-val" :class="pnlDir(portfolio.realized)">{{ signed(portfolio.realized) }}</span>
         <span class="pf-s-sub">{{ rows.length }} position(s) · {{ portfolio.blotter.length }} fill(s)</span>
       </div>
+    </div>
+
+    <!-- Portfolio agent — our tool layer, run in-cockpit (not a cloud provider). -->
+    <div v-if="agentOpen" class="pf-agent">
+      <div class="pf-agent-bar">
+        <input
+          v-model="agentGoal"
+          class="pf-agent-goal"
+          type="text"
+          placeholder="Goal for the agent…"
+          @keydown.enter="runAgent"
+        />
+        <button class="pf-agent-run" type="button" @click="runAgent">Run</button>
+        <button class="pf-agent-x" type="button" title="Close" @click="agentOpen = false">×</button>
+      </div>
+
+      <template v-if="agentResult">
+        <p class="pf-agent-narrative">
+          {{ agentResult.narrative }}
+          <ProvenanceBadge :p="agentResult.prov" compact />
+        </p>
+        <p class="pf-agent-tools">
+          Tools run: <span v-for="t in agentResult.tools" :key="t" class="pf-tool-chip">{{ t }}</span>
+          <span class="pf-tool-sep">·</span>
+          <span class="pf-tool-note">same functions the mesh calls ({{ PORTFOLIO_TOOLS.length }} published)</span>
+        </p>
+
+        <div v-if="agentResult.findings.length" class="pf-findings">
+          <div v-for="f in agentResult.findings" :key="f.id" class="pf-finding" :class="f.severity">
+            <span class="pf-f-sev">{{ sevGlyph(f.severity) }}</span>
+            <div class="pf-f-body">
+              <div class="pf-f-title">{{ f.title }} <ProvenanceBadge :p="f.prov" compact /></div>
+              <div class="pf-f-detail">{{ f.detail }}</div>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="agentResult.actions.length" class="pf-proposed">
+          <div class="pf-proposed-h">Proposed orders <span class="pf-hint">stage into the paper book</span></div>
+          <div v-for="(a, i) in agentResult.actions" :key="`${a.symbol}-${i}`" class="pf-proposed-row">
+            <span class="pf-fill-side" :class="a.side">{{ a.side === 'buy' ? 'BUY' : 'SELL' }}</span>
+            <span class="pf-p-sym">{{ a.symbol }}</span>
+            <span class="pf-p-qty">{{ a.qty }} @ {{ num(a.price) }}</span>
+            <span class="pf-p-why">{{ a.rationale }}</span>
+            <button
+              class="pf-p-stage"
+              type="button"
+              :disabled="staged.has(`${a.symbol}-${i}`)"
+              @click="stageOrder(a, i)"
+            >{{ staged.has(`${a.symbol}-${i}`) ? '✓ staged' : 'Stage' }}</button>
+          </div>
+        </div>
+      </template>
     </div>
 
     <SplitPane storage-key="portfolio" label="holdings" :initial="380">
@@ -84,13 +138,14 @@
 <script setup lang="ts">
 import SurfaceHeader from '../components/SurfaceHeader.vue';
 import SplitPane from '../components/SplitPane.vue';
-import { computed, onMounted } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { instruments } from '../data/marketsFixture';
 import { usePortfolio } from '../stores/portfolio';
 import { useCockpit } from '../stores/cockpit';
 import ProvenanceBadge from '../components/ProvenanceBadge.vue';
 import { prov } from '../features/provenance/types';
+import { runPortfolioAgent, bookFromPositions, PORTFOLIO_TOOLS, type AgentResult, type ProposedOrder } from '../services/portfolioAgent';
 
 // P&L is deterministic compute from the blotter + marks — the verified-compute moat.
 const pnlProv = prov('computed', {
@@ -128,6 +183,23 @@ const signed = (n: number): string => `${n >= 0 ? '+' : '−'}${money(Math.abs(n
 const pnlDir = (n: number): 'up' | 'down' | 'flat' => (n > 0.005 ? 'up' : n < -0.005 ? 'down' : 'flat');
 const time = (ts: number): string => new Date(ts).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
 
+// --- Portfolio agent (OUR tool layer — deterministic, proof-carrying) --------
+const agentGoal = ref('Reduce concentration and size my downside risk');
+const agentResult = ref<AgentResult | null>(null);
+const agentOpen = ref(false);
+const staged = ref<Set<string>>(new Set());
+function runAgent() {
+  const book = bookFromPositions(portfolio.positions);
+  agentResult.value = runPortfolioAgent(agentGoal.value, book, equity.value);
+  staged.value = new Set();
+  agentOpen.value = true;
+}
+function stageOrder(a: ProposedOrder, i: number) {
+  const res = portfolio.placeOrder({ symbol: a.symbol, name: a.name, side: a.side, qty: a.qty, price: a.price, source: 'agent:rebalance' });
+  if (res.ok) staged.value = new Set(staged.value).add(`${a.symbol}-${i}`);
+}
+const sevGlyph = (s: string): string => (s === 'alert' ? '●' : s === 'watch' ? '◐' : '○');
+
 function openSymbol(sym: string) { router.push({ path: '/markets/indices-funds', query: { sym } }); }
 function askNoetica() {
   cockpit.askAbout(`Review my portfolio: ${rows.value.length} positions, equity ${money(equity.value)}, unrealized ${signed(unrealized.value)}, realized ${signed(portfolio.realized)}. Where's my concentration and risk, and what would you rebalance?`);
@@ -150,6 +222,36 @@ onMounted(() => cockpit.setContext({
 .pf-actions { display: flex; gap: 0.5rem; }
 .pf-ask { border: 1px solid rgba(120, 160, 255, 0.45); background: rgba(120, 160, 255, 0.08); color: #93b4ff; border-radius: 8px; padding: 0.35rem 0.7rem; font-size: 0.76rem; cursor: pointer; } .pf-ask:hover { background: rgba(120, 160, 255, 0.16); color: #fff; }
 .pf-reset { border: 1px solid var(--line-2); background: transparent; color: var(--text-3); border-radius: 8px; padding: 0.35rem 0.7rem; font-size: 0.76rem; cursor: pointer; } .pf-reset:hover { color: var(--text); border-color: var(--line-2); }
+.pf-agent-btn { border: 1px solid rgba(110, 231, 183, 0.45); background: rgba(16, 185, 129, 0.1); color: #6ee7b7; border-radius: 8px; padding: 0.35rem 0.7rem; font-size: 0.76rem; font-weight: 600; cursor: pointer; } .pf-agent-btn:hover { background: rgba(16, 185, 129, 0.2); color: #fff; }
+
+/* Agent panel — deterministic, proof-carrying findings + stageable orders */
+.pf-agent { border: 1px solid rgba(110, 231, 183, 0.3); border-radius: 12px; background: var(--surface); padding: 0.7rem 0.85rem; display: flex; flex-direction: column; gap: 0.6rem; }
+.pf-agent-bar { display: flex; gap: 0.5rem; align-items: center; }
+.pf-agent-goal { flex: 1; min-width: 0; border: 1px solid var(--line-2); background: var(--surface-2, rgba(255,255,255,0.02)); color: var(--text); border-radius: 8px; padding: 0.4rem 0.6rem; font-size: 0.82rem; }
+.pf-agent-goal:focus { outline: none; border-color: rgba(110, 231, 183, 0.5); }
+.pf-agent-run { border: 1px solid rgba(110, 231, 183, 0.45); background: rgba(16, 185, 129, 0.14); color: #6ee7b7; border-radius: 8px; padding: 0.4rem 0.9rem; font-size: 0.78rem; font-weight: 600; cursor: pointer; } .pf-agent-run:hover { background: rgba(16, 185, 129, 0.24); }
+.pf-agent-x { border: none; background: transparent; color: var(--text-3); font-size: 1.1rem; line-height: 1; cursor: pointer; padding: 0 0.3rem; } .pf-agent-x:hover { color: var(--text); }
+.pf-agent-narrative { margin: 0; font-size: 0.86rem; line-height: 1.55; color: var(--text); display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; }
+.pf-agent-tools { margin: 0; font-size: 0.66rem; color: var(--text-3); display: flex; align-items: center; gap: 0.3rem; flex-wrap: wrap; }
+.pf-tool-chip { font-family: var(--mono, ui-monospace, monospace); font-size: 0.62rem; color: var(--text-2); border: 1px solid var(--line-2); border-radius: 4px; padding: 0.02rem 0.3rem; }
+.pf-tool-sep { color: var(--line-2); } .pf-tool-note { font-style: italic; }
+
+.pf-findings { display: flex; flex-direction: column; gap: 0.4rem; }
+.pf-finding { display: flex; gap: 0.55rem; align-items: flex-start; border: 1px solid var(--line-2); border-left-width: 3px; border-radius: 8px; padding: 0.5rem 0.65rem; background: var(--surface-2, rgba(255,255,255,0.015)); }
+.pf-finding.info { border-left-color: var(--text-3); }
+.pf-finding.watch { border-left-color: #fbbf24; }
+.pf-finding.alert { border-left-color: var(--down); }
+.pf-f-sev { font-size: 0.7rem; margin-top: 0.15rem; } .pf-finding.watch .pf-f-sev { color: #fbbf24; } .pf-finding.alert .pf-f-sev { color: var(--down); } .pf-finding.info .pf-f-sev { color: var(--text-3); }
+.pf-f-body { min-width: 0; }
+.pf-f-title { display: flex; align-items: center; gap: 0.4rem; font-size: 0.82rem; font-weight: 650; color: var(--text); flex-wrap: wrap; }
+.pf-f-detail { font-size: 0.76rem; color: var(--text-2); line-height: 1.5; margin-top: 0.1rem; }
+
+.pf-proposed { border: 1px solid var(--line-2); border-radius: 8px; overflow: hidden; }
+.pf-proposed-h { padding: 0.45rem 0.65rem; font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); border-bottom: 1px solid var(--line-2); }
+.pf-proposed-row { display: grid; grid-template-columns: 2.6rem 3.5rem auto 1fr auto; align-items: center; gap: 0.55rem; padding: 0.45rem 0.65rem; border-bottom: 1px solid var(--line); font-size: 0.76rem; }
+.pf-proposed-row:last-child { border-bottom: none; }
+.pf-p-sym { font-weight: 700; } .pf-p-qty { color: var(--text-2); font-variant-numeric: tabular-nums; } .pf-p-why { color: var(--text-3); font-size: 0.7rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pf-p-stage { border: 1px solid rgba(110, 231, 183, 0.45); background: rgba(16, 185, 129, 0.12); color: #6ee7b7; border-radius: 6px; padding: 0.25rem 0.7rem; font-size: 0.72rem; font-weight: 600; cursor: pointer; } .pf-p-stage:hover:not(:disabled) { background: rgba(16, 185, 129, 0.22); } .pf-p-stage:disabled { opacity: 0.6; cursor: default; border-color: var(--line-2); color: var(--text-3); background: transparent; }
 
 .pf-summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr)); gap: 0.6rem; }
 .pf-stat { display: flex; flex-direction: column; gap: 0.1rem; border: 1px solid var(--line-2); border-radius: 10px; padding: 0.55rem 0.8rem; background: var(--surface); }

--- a/apps/socioprophet-web/src/services/portfolioAgent.ts
+++ b/apps/socioprophet-web/src/services/portfolioAgent.ts
@@ -1,0 +1,230 @@
+// Portfolio agent — OUR agent, not a cloud provider's. A small registry of
+// deterministic, proof-carrying tools plus a driver that runs them over the
+// paper book. Every finding is verified-compute (replayable from its inputs);
+// the tools are also published as a manifest so the mesh / Noetica can call the
+// exact same functions the cockpit panel does — one tool layer, two callers.
+import { instruments } from '../data/marketsFixture';
+import { prov, type Provenance } from '../features/provenance/types';
+
+// ---- Types -----------------------------------------------------------------
+export interface BookPosition {
+  symbol: string; name: string; qty: number; avgCost: number;
+  last: number; mv: number; upl: number; klass: string; series: number[];
+}
+export type Severity = 'info' | 'watch' | 'alert';
+export interface Finding { id: string; severity: Severity; title: string; detail: string; prov: Provenance; }
+export interface ProposedOrder {
+  symbol: string; name: string; side: 'buy' | 'sell'; qty: number; price: number; rationale: string;
+}
+export interface AgentResult {
+  goal: string; findings: Finding[]; actions: ProposedOrder[];
+  narrative: string; tools: string[]; prov: Provenance;
+}
+
+// Tool manifest — the contract the mesh / Noetica calls against (same fns below).
+export interface ToolSpec { name: string; description: string; params: string; returns: string; }
+export const PORTFOLIO_TOOLS: ToolSpec[] = [
+  { name: 'exposure',      description: 'Net weight by asset class', params: 'book', returns: 'weights[]' },
+  { name: 'concentration', description: 'Herfindahl index + top-name weight; flags single-name risk', params: 'book', returns: 'finding' },
+  { name: 'risk',          description: '1-day 95% parametric VaR from realized vol (correlation=1, conservative)', params: 'book, equity', returns: 'finding' },
+  { name: 'rebalance',     description: 'Trim overweight names to a target max weight; returns paper orders', params: 'book, equity, maxWeight', returns: 'orders[]' },
+];
+
+// ---- Deterministic primitives ---------------------------------------------
+const priceMap = new Map(instruments.map((i) => [i.symbol, i]));
+
+// djb2 content id over the tool inputs — an honest deterministic receipt (not a
+// cryptographic claim): same inputs → same id, so a finding is replay-checkable.
+function contentId(input: unknown): string {
+  const s = JSON.stringify(input);
+  let h = 5381; for (let i = 0; i < s.length; i += 1) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return `id:pf-${(h >>> 0).toString(16).padStart(8, '0')}`;
+}
+
+// Daily-return stdev from a price series (sample stdev), scaled to a 1-day move.
+function dailyVol(series: number[]): number {
+  if (!series || series.length < 3) return 0.02; // fixture fallback
+  const rets: number[] = [];
+  for (let i = 1; i < series.length; i += 1) {
+    const prev = series[i - 1]!; if (prev) rets.push(series[i]! / prev - 1);
+  }
+  const mean = rets.reduce((a, b) => a + b, 0) / rets.length;
+  const varc = rets.reduce((a, r) => a + (r - mean) ** 2, 0) / Math.max(1, rets.length - 1);
+  return Math.sqrt(varc);
+}
+
+const CLASS_LABEL: Record<string, string> = {
+  index: 'Indices', equity: 'Equities', preferred: 'Preferreds', bond: 'Bonds',
+  rate: 'Rates', option: 'Options', fx: 'FX', crypto: 'Crypto',
+  commodity: 'Commodities', 'real-asset': 'Real assets', alt: 'Alternatives',
+};
+
+// ---- Tools -----------------------------------------------------------------
+export interface ExposureRow { klass: string; label: string; weight: number; mv: number; }
+export function exposure(book: BookPosition[]): ExposureRow[] {
+  const total = book.reduce((s, p) => s + p.mv, 0) || 1;
+  const byClass = new Map<string, number>();
+  for (const p of book) byClass.set(p.klass, (byClass.get(p.klass) ?? 0) + p.mv);
+  return [...byClass.entries()]
+    .map(([klass, mv]) => ({ klass, label: CLASS_LABEL[klass] ?? klass, mv, weight: mv / total }))
+    .sort((a, b) => b.weight - a.weight);
+}
+
+export function concentration(book: BookPosition[]): Finding {
+  const total = book.reduce((s, p) => s + p.mv, 0) || 1;
+  const weights = book.map((p) => ({ symbol: p.symbol, w: p.mv / total }));
+  const hhi = weights.reduce((s, x) => s + x.w * x.w, 0);
+  const top = weights.slice().sort((a, b) => b.w - a.w)[0];
+  const effN = hhi ? 1 / hhi : 0;
+  const sev: Severity = top && top.w > 0.4 ? 'alert' : top && top.w > 0.25 ? 'watch' : 'info';
+  const topPct = top ? (top.w * 100).toFixed(1) : '0';
+  return {
+    id: 'concentration',
+    severity: sev,
+    title: sev === 'info' ? 'Diversified book' : `Concentrated in ${top?.symbol}`,
+    detail: `Herfindahl index ${hhi.toFixed(3)} (~${effN.toFixed(1)} effective names). Largest position ${top?.symbol ?? '—'} is ${topPct}% of the book`
+      + (sev === 'info' ? '.' : sev === 'watch' ? ' — above the 25% single-name guardrail.' : ' — a dominant single-name exposure.'),
+    prov: prov('computed', {
+      verifier: 'portfolio agent',
+      formula: 'HHI = Σ wᵢ² ; effective names = 1/HHI ; wᵢ = mvᵢ / Σmv',
+      sources: ['order blotter', 'Market Monitor marks'],
+      receipt: contentId(weights),
+      note: 'Deterministic — replayable from the position weights.',
+    }),
+  };
+}
+
+export function risk(book: BookPosition[], equity: number): Finding {
+  const total = book.reduce((s, p) => s + p.mv, 0) || 1;
+  // correlation=1 (conservative): portfolio 1-day σ = Σ wᵢ·σᵢ
+  const portDailyVol = book.reduce((s, p) => s + (p.mv / total) * dailyVol(p.series), 0);
+  const z = 1.645; // 95% one-tailed
+  const marketValue = book.reduce((s, p) => s + p.mv, 0);
+  const var95 = z * portDailyVol * marketValue;
+  const varPctEq = equity ? (var95 / equity) * 100 : 0;
+  const sev: Severity = varPctEq > 5 ? 'alert' : varPctEq > 2.5 ? 'watch' : 'info';
+  return {
+    id: 'risk',
+    severity: sev,
+    title: `1-day VaR ≈ ${fmtMoney(var95)} (95%)`,
+    detail: `At 95% confidence the book should not lose more than ~${fmtMoney(var95)} in a day `
+      + `(${varPctEq.toFixed(1)}% of equity). Portfolio 1-day σ ${(portDailyVol * 100).toFixed(2)}%, `
+      + `realized from each holding's price series, aggregated correlation=1 (conservative).`,
+    prov: prov('computed', {
+      verifier: 'portfolio agent',
+      formula: 'VaR₉₅ = 1.645 · σ_p · MV ; σ_p = Σ wᵢ·σᵢ ; σᵢ = stdev(daily returns)',
+      sources: ['order blotter', 'Market Monitor price series'],
+      receipt: contentId(book.map((p) => [p.symbol, p.mv, dailyVol(p.series)])),
+      note: 'Parametric VaR, correlation=1 upper bound. Deterministic from the marks.',
+    }),
+  };
+}
+
+export function rebalance(book: BookPosition[], equity: number, maxWeight = 0.2): ProposedOrder[] {
+  const total = book.reduce((s, p) => s + p.mv, 0) || 1;
+  const cap = maxWeight * total;
+  const orders: ProposedOrder[] = [];
+  for (const p of book) {
+    if (p.mv <= cap) continue;
+    const sellMv = p.mv - cap;
+    const qty = Math.floor(sellMv / (p.last || p.avgCost || 1));
+    if (qty <= 0) continue;
+    orders.push({
+      symbol: p.symbol, name: p.name, side: 'sell', qty, price: p.last,
+      rationale: `Trim to ${(maxWeight * 100).toFixed(0)}% max weight (was ${((p.mv / total) * 100).toFixed(1)}%).`,
+    });
+  }
+  return orders;
+}
+
+// ---- Driver ----------------------------------------------------------------
+// Given a plain-language goal, select + run the relevant tools and assemble a
+// proof-carrying result. Pure and synchronous — no cloud round-trip.
+export function runPortfolioAgent(goal: string, book: BookPosition[], equity: number): AgentResult {
+  const g = goal.toLowerCase();
+  const used: string[] = [];
+  const findings: Finding[] = [];
+  let actions: ProposedOrder[] = [];
+
+  if (book.length === 0) {
+    return {
+      goal, findings: [], actions: [], tools: [],
+      narrative: 'The paper book is empty — open the Market Monitor and place an order, then rerun the agent to get a risk and concentration read.',
+      prov: prov('computed', { verifier: 'portfolio agent', note: 'No positions to analyze.' }),
+    };
+  }
+
+  // Always assay concentration + risk (the core read).
+  const conc = concentration(book); findings.push(conc); used.push('concentration');
+  const rk = risk(book, equity); findings.push(rk); used.push('risk');
+
+  // Exposure finding (informational).
+  const exp = exposure(book); used.push('exposure');
+  const topExp = exp[0];
+  if (topExp) {
+    findings.push({
+      id: 'exposure',
+      severity: topExp.weight > 0.6 ? 'watch' : 'info',
+      title: `${(topExp.weight * 100).toFixed(0)}% ${topExp.label}`,
+      detail: `Asset-class mix: ${exp.map((e) => `${e.label} ${(e.weight * 100).toFixed(0)}%`).join(' · ')}.`,
+      prov: prov('computed', {
+        verifier: 'portfolio agent',
+        formula: 'weight_class = Σ mv(class) / Σ mv',
+        sources: ['order blotter', 'instrument asset-class tags'],
+        receipt: contentId(exp.map((e) => [e.klass, +e.weight.toFixed(4)])),
+      }),
+    });
+  }
+
+  // If the goal is about de-risking/rebalancing/trimming, propose orders.
+  const wantsRebalance = /rebalanc|trim|reduce|de-?risk|concentrat|risk|diversif|cut/.test(g);
+  if (wantsRebalance) {
+    actions = rebalance(book, equity, 0.2); used.push('rebalance');
+  }
+
+  // Narrative — a plain call built from the assayed findings (no free generation).
+  const parts: string[] = [];
+  parts.push(conc.severity === 'info'
+    ? 'The book is reasonably diversified.'
+    : `Concentration is elevated — ${conc.title.toLowerCase()}.`);
+  parts.push(rk.severity === 'info'
+    ? `Daily downside looks contained (${rk.title}).`
+    : `Daily downside is meaningful (${rk.title}).`);
+  if (actions.length) {
+    parts.push(`Proposed ${actions.length} trim${actions.length === 1 ? '' : 's'} to a 20% single-name cap — stage any you accept into the paper book.`);
+  } else if (wantsRebalance) {
+    parts.push('No position breaches the 20% cap, so no trims are needed.');
+  }
+
+  return {
+    goal,
+    findings,
+    actions,
+    tools: used,
+    narrative: parts.join(' '),
+    prov: prov('computed', {
+      verifier: 'portfolio agent',
+      sources: ['order blotter', 'Market Monitor marks'],
+      receipt: contentId({ goal, book: book.map((p) => [p.symbol, p.qty, p.last]), equity }),
+      note: 'Every finding is deterministic verified-compute; the agent selects tools, it does not invent numbers.',
+    }),
+  };
+}
+
+export function bookFromPositions(
+  positions: { symbol: string; name: string; qty: number; avgCost: number }[],
+): BookPosition[] {
+  return positions.filter((p) => p.qty > 0).map((p) => {
+    const inst = priceMap.get(p.symbol);
+    const last = inst?.price ?? p.avgCost;
+    return {
+      symbol: p.symbol, name: p.name, qty: p.qty, avgCost: p.avgCost,
+      last, mv: last * p.qty, upl: (last - p.avgCost) * p.qty,
+      klass: inst?.klass ?? 'equity', series: inst?.series ?? [],
+    };
+  });
+}
+
+function fmtMoney(n: number): string {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', notation: 'compact', maximumFractionDigits: 1 }).format(n);
+}


### PR DESCRIPTION
## Why
"We don't yield to the cloud agent providers — we roll our own." This is **Portfolio ①**: a cockpit-side agent that reasons over the paper book using **our** deterministic tool layer, not an opaque cloud call.

## What
New `services/portfolioAgent.ts` — a tool registry + driver:
| tool | does |
|---|---|
| `exposure` | net weight by asset class |
| `concentration` | Herfindahl index + top-name weight (25% watch / 40% alert) |
| `risk` | 1-day 95% parametric VaR from each holding's realized vol (correlation=1, conservative) |
| `rebalance` | trim overweight names to a 20% cap → proposed paper orders |

Wired into `PortfolioBoard.vue`:
- **◆ Run agent** → a goal box + findings, each carrying its **formula + a deterministic content-id receipt** (`ProvenanceBadge`) — verified-compute, replayable, not model-invented.
- Proposed trims are **one-click Stage** into the paper book (`source: agent:rebalance`) — same blotter/P&L path as manual + algo fills.
- Tools are published as `PORTFOLIO_TOOLS` (a manifest) so **the mesh / Noetica call the same layer** the panel does.

## Verify
`vue-tsc --noEmit` clean · `npm run build` clean. Additive (one new service + Portfolio board wiring).