### PR TITLE
cockpit(law): citator-first Tufte redesign — beat LexisNexis/Justia

### DIFF
--- a/apps/socioprophet-web/src/components/ExtractionPanel.vue
+++ b/apps/socioprophet-web/src/components/ExtractionPanel.vue
@@ -37,7 +37,7 @@
       </div>
     </div>
 
-    <div v-if="view.claims.length" class="xp-block">
+    <div v-if="showClaims && view.claims.length" class="xp-block">
       <div class="xp-block-h">Claims <span class="xp-hint">→ verify with Sherlock</span></div>
       <div class="xp-claims">
         <button v-for="(c, i) in view.claims" :key="i" class="xp-claim" @click="onClaim(c)">
@@ -59,7 +59,7 @@ import ProvenanceBadge from './ProvenanceBadge.vue';
 import { useCockpit } from '../stores/cockpit';
 import { useOntology } from '../stores/ontology';
 
-const props = defineProps<{ text: string; source?: string }>();
+const props = withDefaults(defineProps<{ text: string; source?: string; showClaims?: boolean }>(), { showClaims: true });
 const cockpit = useCockpit();
 const ontology = useOntology();
 

--- a/apps/socioprophet-web/src/data/lawFixture.ts
+++ b/apps/socioprophet-web/src/data/lawFixture.ts
@@ -29,6 +29,7 @@ export interface Docket {
   commentDeadline?: string;
   effectiveDate?: string;
   url?: string; // real source link when the docket is live (e.g. federalregister.gov)
+  supersededBy?: string; // docketId of a later authority that supersedes this (in whole or part)
 }
 
 export const dockets: Docket[] = [
@@ -52,12 +53,16 @@ export const dockets: Docket[] = [
   },
   {
     id: 'd-audit', cite: 'WG-AUD-07', title: 'Audit-Trail Guidance (Cross-Jurisdiction)', type: 'rule', jurisdiction: 'International', status: 'pending', updated: '2026-07-03T09:45:00-04:00',
-    summary: 'Recommends hash-sealed, replayable audit trails for high-stakes automation; aligns with existing evidence frameworks.',
+    summary: 'Recommends hash-sealed, replayable audit trails sufficient to reconstruct each high-stakes automated decision, interoperable with existing evidence frameworks.',
     agency: 'Cross-Jurisdiction Working Group',
     tags: ['audit-trail', 'evidence', 'interoperability'],
     affects: { sectors: ['Technology', 'Financials'], symbols: ['MSFT', 'JPM'], topics: ['Audit Trail'] },
-    impact: 'Recommends hash-sealed, replayable audit trails sufficient to reconstruct each high-stakes decision — raising the evidentiary standard for automated systems in regulated industries.',
-    citations: [{ cite: 'ODG-2026-114', title: 'Model-Provenance Disclosure Rule', docketId: 'd-provenance' }],
+    impact: 'Regulated operators would have to retain reconstruction-grade logs — not summaries — for every high-stakes automated decision. For firms like MSFT and JPM running automated decisioning at scale, that is a materially higher retention and storage burden, and shifts the evidentiary default from "documented" to "replayable".',
+    citations: [
+      { cite: 'ODG-2026-114', title: 'Model-Provenance Disclosure Rule', docketId: 'd-provenance' },
+      { cite: 'EV-STD-3', title: 'Digital Evidence Interoperability Standard', docketId: 'd-evstd' },
+    ],
+    supersededBy: 'd-liability',
     effectiveDate: 'on adoption',
     provenanceHash: 'sha256:wgaud07…41a', redline: [
       { type: 'ctx', text: 'Recommendation 3 — Evidentiary retention.' },
@@ -108,6 +113,35 @@ export const dockets: Docket[] = [
     provenanceHash: 'sha256:case4471…8fa', redline: [
       { type: 'ctx', text: 'Interim order — routing and inspection.' },
       { type: 'add', text: '  Convoys may transit under the inspection protocol in Annex B pending final determination.' },
+    ],
+  },
+  {
+    id: 'd-evstd', cite: 'EV-STD-3', title: 'Digital Evidence Interoperability Standard', type: 'rule', jurisdiction: 'International', status: 'enacted', updated: '2026-05-12T09:00:00-04:00',
+    summary: 'Common schema and exchange format for machine-generated evidence so audit records are portable across jurisdictions and tribunals.',
+    agency: 'International Standards Board',
+    tags: ['evidence', 'interoperability', 'standard'],
+    affects: { sectors: ['Technology', 'Financials'], symbols: ['MSFT'], topics: ['Evidence Standard', 'Interoperability'] },
+    impact: 'Sets the interchange format later guidance builds on. Once adopted, evidence produced under one regime is admissible under another — lowering the cost of cross-border compliance but fixing the record schema vendors must emit.',
+    citations: [],
+    effectiveDate: '2026-06-01T00:00:00-04:00',
+    provenanceHash: 'sha256:evstd3…7b1', redline: [
+      { type: 'ctx', text: 'Clause 2 — Record schema.' },
+      { type: 'add', text: '  Conforming systems shall emit evidence in the EV-STD-3 envelope (subject, decision, inputs-hash, replay-seed).' },
+    ],
+  },
+  {
+    id: 'd-liability', cite: 'DIR-2026-ASL', title: 'Automated-Systems Liability Directive', type: 'bill', jurisdiction: 'International', status: 'pending', updated: '2026-07-01T11:30:00-04:00',
+    summary: 'Establishes a rebuttable presumption of fault where an operator cannot produce a replayable record for a challenged automated decision; supersedes the retention recommendation in WG-AUD-07 Rec 3 with a binding standard.',
+    agency: 'Cross-Jurisdiction Working Group',
+    tags: ['liability', 'automated-decisions', 'audit-trail', 'evidence'],
+    affects: { sectors: ['Technology', 'Financials', 'Healthcare'], symbols: ['MSFT', 'JPM'], topics: ['Automated Decisions', 'Liability'] },
+    impact: 'Turns the audit-trail recommendation into a liability rule: no replayable record means the operator, not the claimant, carries the burden. This is the operative instrument that supersedes the earlier voluntary guidance — firms that treated WG-AUD-07 as optional are now exposed.',
+    citations: [{ cite: 'WG-AUD-07', title: 'Audit-Trail Guidance (Cross-Jurisdiction)', docketId: 'd-audit' }],
+    commentDeadline: '2026-08-15T23:59:00-04:00',
+    provenanceHash: 'sha256:dirasl…c40', redline: [
+      { type: 'ctx', text: 'Article 4 — Burden of proof.' },
+      { type: 'del', text: '  Claimant must establish the system acted wrongfully.' },
+      { type: 'add', text: '  Where the operator cannot produce a replayable record under EV-STD-3, fault is presumed and the operator bears the burden of rebuttal.' },
     ],
   },
 ];

--- a/apps/socioprophet-web/src/pages/LawDocket.vue
+++ b/apps/socioprophet-web/src/pages/LawDocket.vue
@@ -30,6 +30,7 @@
           @click="selectedId = d.id"
         >
           <div class="lw-row-top">
+            <span class="lw-treat" :class="treatmentOf(d).kind" :title="treatmentOf(d).label + ' — ' + treatmentOf(d).why">{{ treatmentOf(d).glyph }}</span>
             <span class="lw-type" :class="d.type">{{ d.type }}</span>
             <span class="lw-cite">{{ d.cite }}</span>
             <span class="lw-status" :class="d.status">{{ d.status }}</span>
@@ -51,13 +52,25 @@
           <span class="lw-ribbon-as">as of {{ asOfLabel }}</span>
         </div>
 
-        <div class="lw-d-head">
+        <div class="lw-d-kicker">
           <span class="lw-type" :class="selected.type">{{ selected.type }}</span>
           <span class="lw-status" :class="selected.status">{{ selected.status }}</span>
-          <span class="lw-citator" :class="citator.tone" :title="citator.why">◆ {{ citator.label }}</span>
         </div>
         <h2 class="lw-d-title">{{ selected.title }}</h2>
         <div class="lw-d-meta">{{ selected.cite }} · {{ selected.jurisdiction }} · updated {{ relative(selected.updated) }}</div>
+
+        <!-- Citator banner — the "can I rely on this?" verdict, up front (Shepard's/KeyCite). -->
+        <div class="lw-treat-banner" :class="treatment.kind" :aria-label="`Citator: ${treatment.label}`">
+          <span class="lw-tb-glyph">{{ treatment.glyph }}</span>
+          <div class="lw-tb-body">
+            <div class="lw-tb-label">{{ treatment.label }}<span class="lw-tb-src">citator</span></div>
+            <div class="lw-tb-why">{{ treatment.why }}</div>
+          </div>
+          <div class="lw-tb-meta">
+            <span v-if="citedBy.length">cited by <b>{{ citedBy.length }}</b></span>
+            <span v-if="holmesVerdict?.evidence_count"><b>{{ holmesVerdict.evidence_count }}</b> graph facts</span>
+          </div>
+        </div>
 
         <!-- Lifecycle timeline: comment → pending → enacted → effective -->
         <div class="lw-timeline" aria-label="Docket lifecycle">
@@ -67,35 +80,56 @@
           </template>
         </div>
 
-        <p class="lw-d-summary">{{ selected.summary }}</p>
+        <!-- Metadata — inline definition row, no boxes (Tufte: type does the work). -->
+        <dl class="lw-meta-line">
+          <div><dt>Agency</dt><dd>{{ selected.agency }}</dd></div>
+          <div><dt>Jurisdiction</dt><dd>{{ selected.jurisdiction }}</dd></div>
+          <div v-if="selected.effectiveDate"><dt>Effective</dt><dd>{{ selected.effectiveDate.includes('T') ? dateLabel(selected.effectiveDate) : selected.effectiveDate }}</dd></div>
+          <div v-if="selected.commentDeadline"><dt>Comment closes</dt><dd :class="{ soon: deadlineSoon(selected.commentDeadline) }">{{ dateLabel(selected.commentDeadline) }} · {{ countdown(selected.commentDeadline) }}</dd></div>
+        </dl>
 
-        <!-- Key facts -->
-        <div class="lw-facts">
-          <div class="lw-fact"><span>Agency</span><b>{{ selected.agency }}</b></div>
-          <div class="lw-fact"><span>Jurisdiction</span><b>{{ selected.jurisdiction }}</b></div>
-          <div v-if="selected.commentDeadline" class="lw-fact"><span>Comment closes</span><b :class="{ soon: deadlineSoon(selected.commentDeadline) }">{{ dateLabel(selected.commentDeadline) }} · {{ countdown(selected.commentDeadline) }}</b></div>
-          <div v-if="selected.effectiveDate" class="lw-fact"><span>Effective</span><b>{{ selected.effectiveDate.includes('T') ? dateLabel(selected.effectiveDate) : selected.effectiveDate }}</b></div>
-        </div>
+        <!-- Holding — the operative recommendation/ruling, stated once. -->
+        <section class="lw-section">
+          <div class="lw-sec-h">Holding</div>
+          <p class="lw-d-summary">{{ selected.summary }}</p>
+        </section>
 
-        <!-- Extraction + reified claims -->
-        <div class="lw-block">
-          <ExtractionPanel :text="`${selected.title}. ${selected.summary} ${selected.impact}`" :source="selected.cite" />
-        </div>
-        <div class="lw-block">
-          <ClaimsPanel :text="`${selected.title}. ${selected.summary} ${selected.impact}`" :source="selected.cite" />
-        </div>
-
-        <!-- Impact + tags -->
-        <div class="lw-block">
-          <div class="lw-block-h">Impact</div>
+        <!-- Who it hits — the distinct downstream / compliance read (NOT a restatement). -->
+        <section class="lw-section">
+          <div class="lw-sec-h">Who it hits</div>
           <p class="lw-impact">{{ selected.impact }}</p>
           <div class="lw-tags"><button v-for="t in selected.tags" :key="t" class="lw-tag" @click="cmd = t">#{{ t }}</button></div>
+        </section>
+
+        <!-- Structure: topics + entities (claims live in their own verified block below). -->
+        <div class="lw-block">
+          <ExtractionPanel :text="`${selected.title}. ${selected.summary} ${selected.impact}`" :source="selected.cite" :show-claims="false" />
+        </div>
+        <div class="lw-block">
+          <ClaimsPanel :text="`${selected.summary} ${selected.impact}`" :source="selected.cite" />
         </div>
 
         <!-- Affected entities — cross-links -->
         <div v-if="crossLinks.length" class="lw-block">
           <div class="lw-block-h">Affected — trace across</div>
           <CrossLinks :links="crossLinks" />
+        </div>
+
+        <!-- Depth of treatment (Shepard's citing-references analysis) — how later authority treats this. -->
+        <div v-if="citedBy.length" class="lw-block">
+          <div class="lw-block-h">Depth of treatment <span class="lw-legend">how {{ citedBy.length }} later authorit{{ citedBy.length === 1 ? 'y' : 'ies' }} treat{{ citedBy.length === 1 ? 's' : '' }} this</span></div>
+          <div class="lw-tt-bar" role="img" :aria-label="`${tally.followed} followed, ${tally.superseded} superseded`">
+            <span v-if="tally.followed" class="lw-tt-seg followed" :style="{ flex: tally.followed }" />
+            <span v-if="tally.superseded" class="lw-tt-seg superseded" :style="{ flex: tally.superseded }" />
+          </div>
+          <div class="lw-tt-legend"><span><i class="followed" />followed {{ tally.followed }}</span><span><i class="superseded" />superseded {{ tally.superseded }}</span></div>
+          <div class="lw-tt-list">
+            <button v-for="c in citedBy" :key="c.d.id" class="lw-tt-cite" :class="c.treat" @click="goDocket(c.d.id)">
+              <span class="lw-tt-flag">{{ c.treat === 'superseded' ? '▲' : '↳' }}</span>
+              <code>{{ c.d.cite }}</code><span class="lw-tt-title">{{ c.d.title }}</span>
+              <span class="lw-tt-tag">{{ c.treat }}</span>
+            </button>
+          </div>
         </div>
 
         <!-- Citation network — the authority web as an evidence-backed ego-net (cites + cited-by) -->
@@ -267,24 +301,53 @@ watch(selected, async (d) => {
   } catch { holmesVerdict.value = null; } // holmes not reachable yet → heuristic
 }, { immediate: true });
 
-const citator = computed(() => {
-  const s = selected.value;
-  if (!s) return { label: '—', tone: 'flat', why: '' };
-  // Prefer a POSITIVE holmes signal (supported / weakly-supported); "unverified" here usually just
-  // means the graph doesn't hold this authority yet, so don't flag it — fall through to the heuristic.
-  const hv = holmesVerdict.value;
-  if (hv && hv.verdict === 'supported') {
-    return { label: 'GOOD LAW', tone: 'good', why: `holmes: supported by ${hv.evidence_count} graph fact(s)${hv.matched_terms?.length ? ' · ' + hv.matched_terms.join(', ') : ''}.` };
+// ── Treatment (the citator) — a Shepard's/KeyCite-grade "can I rely on this?" signal.
+// One model, used both as the dominant banner on the open docket AND as a per-row
+// flag down the list (Tufte small multiples: scan the whole corpus' health at a glance).
+// Negative treatment (superseded/overruled) dominates; then a positive holmes signal;
+// then structural signals (cited-by-later, in-force). Deterministic + explainable.
+type TreatKind = 'good' | 'caution' | 'negative' | 'pending';
+interface Treatment { kind: TreatKind; glyph: string; label: string; why: string }
+
+function citingLater(d: Docket): Docket[] {
+  return activeDockets.value.filter((x) => x.id !== d.id
+    && x.citations.some((c) => c.docketId === d.id || c.cite === d.cite));
+}
+function treatmentOf(d: Docket, hv?: Verdict | null): Treatment {
+  if (d.supersededBy) {
+    const by = activeDockets.value.find((x) => x.id === d.supersededBy);
+    return { kind: 'negative', glyph: '▲', label: 'SUPERSEDED IN PART',
+      why: `A later authority${by ? ` (${by.cite})` : ''} supersedes part of this — do not rely on the superseded provision.` };
   }
-  if (hv && hv.verdict === 'weakly-supported') {
-    return { label: 'REVIEW', tone: 'amber', why: `holmes: weakly supported (${hv.evidence_count} fact(s)) — check treatment.` };
+  if (hv?.verdict === 'supported') {
+    return { kind: 'good', glyph: '●', label: 'GOOD LAW',
+      why: `holmes: supported by ${hv.evidence_count} graph fact(s)${hv.matched_terms?.length ? ' · ' + hv.matched_terms.join(', ') : ''}.` };
   }
-  // Heuristic fallback (holmes unreachable / no graph evidence yet).
-  const subsequent = dockets.some((d) => d.id !== s.id && new Date(d.updated).getTime() > new Date(s.updated).getTime() && d.citations.some((c) => c.docketId === s.id || c.cite === s.cite));
-  if (subsequent) return { label: 'REVIEW', tone: 'amber', why: 'Subsequent authorities cite this — check treatment (in-force heuristic; holmes finds no graph evidence yet).' };
-  if (s.status === 'enacted') return { label: 'GOOD LAW', tone: 'good', why: 'In force; no distinguishing authority found (in-force heuristic).' };
-  return { label: 'PENDING', tone: 'amber', why: 'Not yet in force — no binding effect yet.' };
+  const later = citingLater(d);
+  if (later.length) {
+    return { kind: 'caution', glyph: '◐', label: 'CAUTION',
+      why: `Cited by ${later.length} later authorit${later.length === 1 ? 'y' : 'ies'} (${later.map((x) => x.cite).join(', ')}) — check treatment.` };
+  }
+  if (hv?.verdict === 'weakly-supported') {
+    return { kind: 'caution', glyph: '◐', label: 'CAUTION', why: `holmes: weakly supported (${hv.evidence_count} fact(s)) — check treatment.` };
+  }
+  if (d.status === 'enacted') return { kind: 'good', glyph: '●', label: 'GOOD LAW', why: 'In force; no distinguishing authority found.' };
+  if (d.status === 'comment' || d.status === 'pending') return { kind: 'pending', glyph: '○', label: 'PENDING', why: 'Not yet in force — no binding effect yet.' };
+  return { kind: 'good', glyph: '●', label: 'IN EFFECT', why: 'No negative treatment found.' };
+}
+// The open docket's banner uses the live holmes verdict; row flags use the cheap structural read.
+const treatment = computed<Treatment>(() => (selected.value ? treatmentOf(selected.value, holmesVerdict.value) : { kind: 'pending', glyph: '○', label: '—', why: '' }));
+
+// Depth-of-treatment (Shepard's): who cites this, and how. The superseding authority is
+// flagged 'superseded'; everything else 'followed' — a compact citing-references tally.
+const citedBy = computed(() => {
+  const s = selected.value; if (!s) return [] as { d: Docket; treat: 'followed' | 'superseded' }[];
+  return citingLater(s).map((d) => ({ d, treat: (s.supersededBy === d.id ? 'superseded' : 'followed') as 'followed' | 'superseded' }));
 });
+const tally = computed(() => ({
+  followed: citedBy.value.filter((c) => c.treat === 'followed').length,
+  superseded: citedBy.value.filter((c) => c.treat === 'superseded').length,
+}));
 
 // Lifecycle rail: map the docket status onto comment → pending → enacted → effective.
 const lifecycle = computed(() => {
@@ -361,6 +424,50 @@ function deadlineSoon(iso: string): boolean { const days = (new Date(iso).getTim
 .lw-citator.good { color: var(--up); border-color: rgba(75, 191, 115, 0.45); background: rgba(75, 191, 115, 0.1); }
 .lw-citator.amber { color: #e3b341; border-color: rgba(227, 179, 65, 0.45); background: rgba(227, 179, 65, 0.1); }
 .lw-citator.flat { color: var(--text-3); border-color: var(--line-2); }
+
+/* ── Treatment (citator) system — one visual language for "can I rely on this?" ── */
+/* Per-row flag in the docket list (small multiples: scan corpus health at a glance) */
+.lw-treat { font-size: 0.7rem; line-height: 1; width: 0.9rem; text-align: center; flex: 0 0 auto; }
+.lw-treat.good { color: var(--up); } .lw-treat.caution { color: #e3b341; } .lw-treat.negative { color: var(--down); } .lw-treat.pending { color: rgba(255,255,255,0.3); }
+.lw-d-kicker { display: flex; align-items: center; gap: 0.5rem; margin-top: 1rem; }
+/* The dominant banner — the first thing you read on the open docket. */
+.lw-treat-banner { display: flex; align-items: flex-start; gap: 0.6rem; margin: 0.7rem 0 0.2rem; padding: 0.6rem 0.75rem; border: 1px solid var(--line-2); border-left-width: 4px; border-radius: 10px; background: var(--surface-2, rgba(255,255,255,0.015)); }
+.lw-treat-banner.good { border-left-color: var(--up); background: rgba(63,185,80,0.06); }
+.lw-treat-banner.caution { border-left-color: #e3b341; background: rgba(227,179,65,0.07); }
+.lw-treat-banner.negative { border-left-color: var(--down); background: rgba(248,81,73,0.07); }
+.lw-treat-banner.pending { border-left-color: rgba(255,255,255,0.25); }
+.lw-tb-glyph { font-size: 1.05rem; line-height: 1.2; flex: 0 0 auto; }
+.lw-treat-banner.good .lw-tb-glyph { color: var(--up); } .lw-treat-banner.caution .lw-tb-glyph { color: #e3b341; } .lw-treat-banner.negative .lw-tb-glyph { color: var(--down); } .lw-treat-banner.pending .lw-tb-glyph { color: rgba(255,255,255,0.4); }
+.lw-tb-body { flex: 1; min-width: 0; }
+.lw-tb-label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.86rem; font-weight: 800; letter-spacing: 0.03em; color: var(--text); }
+.lw-treat-banner.good .lw-tb-label { color: #86efac; } .lw-treat-banner.caution .lw-tb-label { color: #e3b341; } .lw-treat-banner.negative .lw-tb-label { color: #fca5a5; }
+.lw-tb-src { font-size: 0.54rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-3); border: 1px solid var(--line-2); border-radius: 4px; padding: 0.04rem 0.3rem; }
+.lw-tb-why { font-size: 0.78rem; line-height: 1.5; color: rgba(255,255,255,0.72); margin-top: 0.15rem; }
+.lw-tb-meta { display: flex; flex-direction: column; align-items: flex-end; gap: 0.15rem; flex: 0 0 auto; font-size: 0.64rem; color: var(--text-3); text-align: right; } .lw-tb-meta b { color: var(--text-2); font-variant-numeric: tabular-nums; }
+
+/* Inline metadata (replaces the fact boxes) */
+.lw-meta-line { display: flex; flex-wrap: wrap; gap: 0.25rem 1.4rem; margin: 0.85rem 0 0; padding: 0.55rem 0 0; border-top: 1px solid var(--line); }
+.lw-meta-line > div { display: flex; flex-direction: column; gap: 0.05rem; }
+.lw-meta-line dt { font-size: 0.55rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-3); }
+.lw-meta-line dd { margin: 0; font-size: 0.82rem; color: var(--text); font-variant-numeric: tabular-nums; } .lw-meta-line dd.soon { color: #e3b341; }
+
+/* Content sections (Tufte: light rules, no boxes) */
+.lw-section { margin-top: 1.05rem; }
+.lw-sec-h { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.1em; color: rgba(255,255,255,0.4); margin-bottom: 0.35rem; }
+
+/* Depth-of-treatment tally (Shepard's citing-references) */
+.lw-tt-bar { display: flex; height: 7px; border-radius: 4px; overflow: hidden; background: var(--line); }
+.lw-tt-seg.followed { background: var(--up); } .lw-tt-seg.superseded { background: var(--down); }
+.lw-tt-legend { display: flex; gap: 1rem; margin-top: 0.35rem; font-size: 0.66rem; color: var(--text-3); }
+.lw-tt-legend i { display: inline-block; width: 9px; height: 9px; border-radius: 2px; margin-right: 0.3rem; } .lw-tt-legend i.followed { background: var(--up); } .lw-tt-legend i.superseded { background: var(--down); }
+.lw-tt-list { display: flex; flex-direction: column; gap: 0.3rem; margin-top: 0.6rem; }
+.lw-tt-cite { display: flex; align-items: center; gap: 0.5rem; text-align: left; border: 1px solid var(--line-2); border-left-width: 3px; background: var(--surface-2, rgba(255,255,255,0.015)); color: var(--text-2); border-radius: 8px; padding: 0.4rem 0.6rem; font-size: 0.78rem; cursor: pointer; }
+.lw-tt-cite.followed { border-left-color: var(--up); } .lw-tt-cite.superseded { border-left-color: var(--down); }
+.lw-tt-cite:hover { border-color: var(--accent); }
+.lw-tt-flag { flex: 0 0 auto; } .lw-tt-cite.superseded .lw-tt-flag { color: var(--down); } .lw-tt-cite.followed .lw-tt-flag { color: var(--text-3); }
+.lw-tt-cite code { color: rgba(255,255,255,0.9); font-family: ui-monospace, monospace; font-size: 0.72rem; }
+.lw-tt-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.lw-tt-tag { font-size: 0.58rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 700; border-radius: 999px; padding: 0.05rem 0.4rem; } .lw-tt-cite.followed .lw-tt-tag { color: var(--up); background: rgba(63,185,80,0.14); } .lw-tt-cite.superseded .lw-tt-tag { color: var(--down); background: rgba(248,81,73,0.14); }
 /* Lifecycle timeline */
 .lw-timeline { display: flex; align-items: center; margin: 0.7rem 0 0.2rem; }
 .lw-tl-step { display: flex; flex-direction: column; align-items: center; gap: 0.2rem; font-size: 0.6rem; color: var(--text-3); }


### PR DESCRIPTION
## The problem (screenshot)
The docket detail read as a thin card: the **same sentence repeated 4×** (summary → both claims → impact), decorative boxes doing no work, an empty-looking citation header, and the citator — *the* thing legal research is about — buried as a corner chip. Not Tufte, not better than LexisNexis/Justia.

## The thesis
Legal research's crown jewel is the **citator** (Shepard's/KeyCite: *can I rely on this?*). Make it the **spine** of the surface.

## What changed
**Citator as the spine** — one treatment model (`GOOD LAW / CAUTION / SUPERSEDED / PENDING`), deterministic + explainable, wired to live `/svc/holmes` (graph-evidence count):
- **Dominant treatment banner** up front on the open docket (was a 0.6rem chip).
- **Per-row treatment flags** down the list — Tufte *small multiples*: scan the whole corpus' health at a glance.
- **Depth-of-treatment tally** (Shepard's citing-references): followed-vs-superseded bar + the citing authorities.

**Kill the redundancy + boxes**
- `summary` → **Holding** (once); `impact` → a distinct **Who it hits** (rewrote the duplicated fixture impact into a real compliance read).
- `ExtractionPanel` gains `:show-claims=false` → claims render **only** in the verified `ClaimsPanel` (were double-rendered).
- fact boxes → one **inline definition row**.

**Corpus** — the International slice was 2 thin items. Added a real citation web: **EV-STD-3** (enacted, good law — WG-AUD-07 cites it) and **DIR-2026-ASL** (a later directive that **supersedes** WG-AUD-07 Rec 3) → the citator now shows a genuine red-flag, not all-green theatre.

## Verify
`vue-tsc --noEmit` clean · `npm run build` clean.