### PR TITLE
cockpit(law): citator-first pass across Case-law + Federal slices

### DIFF
--- a/apps/socioprophet-web/src/data/lawFixture.ts
+++ b/apps/socioprophet-web/src/data/lawFixture.ts
@@ -144,6 +144,54 @@ export const dockets: Docket[] = [
       { type: 'add', text: '  Where the operator cannot produce a replayable record under EV-STD-3, fault is presumed and the operator bears the burden of rebuttal.' },
     ],
   },
+
+  // ── Case-law citator chain — the canonical Shepard's demo: a foundational precedent,
+  // a decision that distinguishes it, and a later decision that OVERRULES it. The citator
+  // flags the precedent red ("overruled") and the depth-of-treatment tally shows the split.
+  {
+    id: 'd-meridian', cite: 'Meridian Logistics v. State', title: 'Meridian Logistics v. State', type: 'case', jurisdiction: 'Federal', status: 'enacted', updated: '2024-03-11T10:00:00-04:00',
+    summary: 'Held that an operator of an automated decision system is liable only where the claimant proves the system departed from a documented internal standard.',
+    agency: 'Court of Appeals (9th Cir.)',
+    tags: ['automated-decisions', 'liability', 'precedent'],
+    affects: { sectors: ['Technology', 'Financials'], symbols: ['MSFT'], topics: ['Automated Decisions', 'Liability'] },
+    impact: 'For a decade this was the controlling standard: plaintiffs had to reverse-engineer an internal deviation to recover, which in practice shielded operators that kept only summary documentation.',
+    citations: [],
+    supersededBy: 'd-calder',
+    effectiveDate: '2024-03-11T00:00:00-04:00',
+    provenanceHash: 'sha256:meridian…a11', redline: [
+      { type: 'ctx', text: 'Holding — standard of liability.' },
+      { type: 'add', text: '  Liability attaches only on proof of departure from a documented internal standard.' },
+    ],
+  },
+  {
+    id: 'd-doe', cite: 'Doe v. Data Authority', title: 'Doe v. Data Authority', type: 'case', jurisdiction: 'Federal', status: 'enacted', updated: '2025-06-20T10:00:00-04:00',
+    summary: 'Distinguished Meridian on its facts: where no internal standard exists at all, the documented-deviation test cannot apply and the operator must show its process was reasonable.',
+    agency: 'District Court (S.D.N.Y.)',
+    tags: ['automated-decisions', 'liability', 'distinguished'],
+    affects: { sectors: ['Technology'], symbols: ['GOOGL'], topics: ['Automated Decisions'] },
+    impact: 'Carved out the "no-standard" case from Meridian without disturbing it — the first crack, narrowing where operators could hide behind the absence of documentation.',
+    citations: [{ cite: 'Meridian Logistics v. State', title: 'Meridian Logistics v. State', docketId: 'd-meridian' }],
+    effectiveDate: '2025-06-20T00:00:00-04:00',
+    provenanceHash: 'sha256:doe…b20', redline: [
+      { type: 'ctx', text: 'Holding — scope of Meridian.' },
+      { type: 'add', text: '  Where no internal standard exists, the operator must affirmatively show a reasonable process.' },
+    ],
+  },
+  {
+    id: 'd-calder', cite: 'Calder v. Meridian Logistics', title: 'Calder v. Meridian Logistics', type: 'case', jurisdiction: 'Federal', status: 'enacted', updated: '2026-06-15T10:00:00-04:00',
+    summary: 'Overruled Meridian: an operator that cannot produce a replayable record of a challenged automated decision is presumed at fault, aligning the common-law standard with the DIR-2026-ASL evidence regime.',
+    agency: 'Supreme Court',
+    tags: ['automated-decisions', 'liability', 'overruled', 'audit-trail'],
+    affects: { sectors: ['Technology', 'Financials', 'Healthcare'], symbols: ['MSFT', 'JPM'], topics: ['Automated Decisions', 'Liability'] },
+    impact: 'Flips the decade-old default: the burden now sits with the operator, and "we only kept summaries" is no longer a defense. Every firm relying on Meridian must revisit its retention posture.',
+    citations: [{ cite: 'Meridian Logistics v. State', title: 'Meridian Logistics v. State', docketId: 'd-meridian' }],
+    effectiveDate: '2026-06-15T00:00:00-04:00',
+    provenanceHash: 'sha256:calder…c15', redline: [
+      { type: 'ctx', text: 'Holding — overruling Meridian.' },
+      { type: 'del', text: '  Liability attaches only on proof of departure from a documented internal standard.' },
+      { type: 'add', text: '  Absent a replayable record, fault is presumed and the burden shifts to the operator.' },
+    ],
+  },
 ];
 
 export const asOf = '2026-07-03T14:00:00-04:00';

--- a/apps/socioprophet-web/src/pages/LawDocket.vue
+++ b/apps/socioprophet-web/src/pages/LawDocket.vue
@@ -122,10 +122,10 @@
             <span v-if="tally.followed" class="lw-tt-seg followed" :style="{ flex: tally.followed }" />
             <span v-if="tally.superseded" class="lw-tt-seg superseded" :style="{ flex: tally.superseded }" />
           </div>
-          <div class="lw-tt-legend"><span><i class="followed" />followed {{ tally.followed }}</span><span><i class="superseded" />superseded {{ tally.superseded }}</span></div>
+          <div class="lw-tt-legend"><span><i class="followed" />followed {{ tally.followed }}</span><span><i class="superseded" />negative {{ tally.superseded }}</span></div>
           <div class="lw-tt-list">
             <button v-for="c in citedBy" :key="c.d.id" class="lw-tt-cite" :class="c.treat" @click="goDocket(c.d.id)">
-              <span class="lw-tt-flag">{{ c.treat === 'superseded' ? '▲' : '↳' }}</span>
+              <span class="lw-tt-flag">{{ c.treat === 'followed' ? '↳' : '▲' }}</span>
               <code>{{ c.d.cite }}</code><span class="lw-tt-title">{{ c.d.title }}</span>
               <span class="lw-tt-tag">{{ c.treat }}</span>
             </button>
@@ -316,8 +316,11 @@ function citingLater(d: Docket): Docket[] {
 function treatmentOf(d: Docket, hv?: Verdict | null): Treatment {
   if (d.supersededBy) {
     const by = activeDockets.value.find((x) => x.id === d.supersededBy);
-    return { kind: 'negative', glyph: '▲', label: 'SUPERSEDED IN PART',
-      why: `A later authority${by ? ` (${by.cite})` : ''} supersedes part of this — do not rely on the superseded provision.` };
+    const overruled = d.type === 'case';
+    return { kind: 'negative', glyph: '▲', label: overruled ? 'OVERRULED' : 'SUPERSEDED IN PART',
+      why: overruled
+        ? `Overruled by a later decision${by ? ` (${by.cite})` : ''} — no longer good law on the point.`
+        : `A later authority${by ? ` (${by.cite})` : ''} supersedes part of this — do not rely on the superseded provision.` };
   }
   if (hv?.verdict === 'supported') {
     return { kind: 'good', glyph: '●', label: 'GOOD LAW',
@@ -340,13 +343,17 @@ const treatment = computed<Treatment>(() => (selected.value ? treatmentOf(select
 
 // Depth-of-treatment (Shepard's): who cites this, and how. The superseding authority is
 // flagged 'superseded'; everything else 'followed' — a compact citing-references tally.
+type CiteTreat = 'followed' | 'superseded' | 'overruled';
 const citedBy = computed(() => {
-  const s = selected.value; if (!s) return [] as { d: Docket; treat: 'followed' | 'superseded' }[];
-  return citingLater(s).map((d) => ({ d, treat: (s.supersededBy === d.id ? 'superseded' : 'followed') as 'followed' | 'superseded' }));
+  const s = selected.value; if (!s) return [] as { d: Docket; treat: CiteTreat }[];
+  return citingLater(s).map((d) => {
+    const treat: CiteTreat = s.supersededBy === d.id ? (s.type === 'case' ? 'overruled' : 'superseded') : 'followed';
+    return { d, treat };
+  });
 });
 const tally = computed(() => ({
   followed: citedBy.value.filter((c) => c.treat === 'followed').length,
-  superseded: citedBy.value.filter((c) => c.treat === 'superseded').length,
+  superseded: citedBy.value.filter((c) => c.treat !== 'followed').length, // superseded | overruled
 }));
 
 // Lifecycle rail: map the docket status onto comment → pending → enacted → effective.
@@ -462,7 +469,7 @@ function deadlineSoon(iso: string): boolean { const days = (new Date(iso).getTim
 .lw-tt-legend i { display: inline-block; width: 9px; height: 9px; border-radius: 2px; margin-right: 0.3rem; } .lw-tt-legend i.followed { background: var(--up); } .lw-tt-legend i.superseded { background: var(--down); }
 .lw-tt-list { display: flex; flex-direction: column; gap: 0.3rem; margin-top: 0.6rem; }
 .lw-tt-cite { display: flex; align-items: center; gap: 0.5rem; text-align: left; border: 1px solid var(--line-2); border-left-width: 3px; background: var(--surface-2, rgba(255,255,255,0.015)); color: var(--text-2); border-radius: 8px; padding: 0.4rem 0.6rem; font-size: 0.78rem; cursor: pointer; }
-.lw-tt-cite.followed { border-left-color: var(--up); } .lw-tt-cite.superseded { border-left-color: var(--down); }
+.lw-tt-cite.followed { border-left-color: var(--up); } .lw-tt-cite.superseded, .lw-tt-cite.overruled { border-left-color: var(--down); }
 .lw-tt-cite:hover { border-color: var(--accent); }
 .lw-tt-flag { flex: 0 0 auto; } .lw-tt-cite.superseded .lw-tt-flag { color: var(--down); } .lw-tt-cite.followed .lw-tt-flag { color: var(--text-3); }
 .lw-tt-cite code { color: rgba(255,255,255,0.9); font-family: ui-monospace, monospace; font-size: 0.72rem; }


### PR DESCRIPTION
## Why
#910 made the citator the spine, but only the **International** slice had a real citation web. **Case-law was one item; Federal had no negative treatment** — so the citator had nothing to show there.

## Case-law → the canonical Shepard's chain
- **Meridian Logistics v. State** (2024) — foundational precedent
- **Doe v. Data Authority** (2025) — *distinguishes* it → tallied `followed`
- **Calder v. Meridian Logistics** (2026) — *overrules* it → tallied `overruled`

Meridian now leads with a red **OVERRULED** treatment banner and a **depth-of-treatment split** (1 followed / 1 overruled), each citing decision click-through. Since the three are `jurisdiction: Federal` cases, the **Federal** slice gains the same chain.

## Type-aware treatment
Cases now read **OVERRULED** (not "superseded in part"); the citing-references tally distinguishes **followed** vs **negative** (superseded | overruled). Distinct `summary` vs `impact` throughout — no restatement.

## Verify
`vue-tsc --noEmit` clean · `npm run build` clean.