### PR TITLE
cockpit(academy): stand up the Alexandrian Academy section (Overview + explorers)

### DIFF
--- a/apps/socioprophet-web/src/config/cockpitNav.ts
+++ b/apps/socioprophet-web/src/config/cockpitNav.ts
@@ -112,6 +112,17 @@ export const DOMAIN_MENU: NavGroup[] = [
     ],
   },
   {
+    label: 'Academy',
+    to: '/academy',
+    items: [
+      { label: 'Academy Overview', to: '/academy' },
+      { label: 'Homeschool · K-12', to: '/academy/homeschool' },
+      { label: 'University Degrees', to: '/academy/degrees' },
+      { label: 'Flagship Course · 8.01', to: '/academy/course/ocw-801' },
+      { label: 'Grounded Tutor', to: '/academy/tutor' },
+    ],
+  },
+  {
     label: 'Knowledge',
     to: '/knowledge/graph',
     items: [

--- a/apps/socioprophet-web/src/data/academyFixture.ts
+++ b/apps/socioprophet-web/src/data/academyFixture.ts
@@ -1,0 +1,195 @@
+// Alexandrian Academy — fixture for the education section (/academy/*). UI-only, but shaped to
+// MIRROR the real registrar/capture backend (~/dev/alexandrian-academy → scripts/build-registrar.py
+// → academy/registrar-<program>.json, and the search-orchestrator academy ingest), so wiring the
+// live services later is a swap of the loader, not a rewrite of the surface.
+//
+// The model is ONE structure across the whole ladder — Program → Requirement → Course → Skill —
+// so the same explorer renders a K-12 homeschool path (NGSS/Common Core strands) and an MIT degree
+// (credit-unit requirements) identically. Skills are shared nodes: one algebra skill serves physics,
+// econ, and CS — the graph-native curriculum that's the moat over a flat course catalog.
+//
+// LICENSING: only CC-open sources enter the commons (MIT OCW, OpenStax, CK-12, NGSS/Common Core are
+// public standards). edX/Coursera/ARR content is deliberately absent — see the academy governance rules.
+
+export type LadderLevel = 'k12' | 'undergrad' | 'grad' | 'professional';
+
+export interface Skill { id: string; name: string }
+
+export interface CourseRef {
+  id: string;
+  code: string;
+  title: string;
+  source: string;      // 'MIT OCW' | 'OpenStax' | 'CK-12' | 'NGSS'
+  license: string;     // e.g. 'CC BY-NC-SA 4.0'
+  captured: boolean;   // is the content actually in the Knowledge Commons?
+  chunks?: number;     // captured depth (retrieval chunks)
+  units?: number;      // credit-units (university)
+  teacher?: string;    // persona the tutor embodies
+  skills: string[];    // Skill ids this course develops
+}
+
+export interface Requirement {
+  id: string;
+  title: string;
+  code?: string;       // standard code (NGSS 'MS-PS1') or requirement code (university)
+  units?: number;      // required credit-units (university)
+  courses: CourseRef[];
+  satisfied: boolean;  // is the requirement covered by captured content?
+}
+
+export interface Program {
+  id: string;
+  level: LadderLevel;
+  title: string;
+  credential: string;  // 'S.B.' | 'Homeschool path' | 'Certificate'
+  framework: string;   // 'MIT Course 8' | 'NGSS + Common Core' | …
+  institution: string;
+  teacher: string;     // headline persona
+  summary: string;
+  requiredUnits?: number;  // university coverage math
+  requirements: Requirement[];
+}
+
+// ── Shared skill nodes (reused across programs — the graph-native curriculum) ──
+export const skills: Skill[] = [
+  { id: 'sk-algebra', name: 'Algebraic reasoning' },
+  { id: 'sk-calculus', name: 'Calculus' },
+  { id: 'sk-linalg', name: 'Linear algebra' },
+  { id: 'sk-mechanics', name: 'Classical mechanics' },
+  { id: 'sk-em', name: 'Electromagnetism' },
+  { id: 'sk-modeling', name: 'Scientific modeling' },
+  { id: 'sk-inquiry', name: 'Scientific inquiry' },
+  { id: 'sk-argument', name: 'Evidence-based argument' },
+  { id: 'sk-data', name: 'Data & statistics' },
+  { id: 'sk-writing', name: 'Expository writing' },
+];
+
+// ── Programs ────────────────────────────────────────────────────────────────
+export const programs: Program[] = [
+  // K-12 homeschool path (audience #1) — standards-based, NGSS + Common Core.
+  {
+    id: 'k12-ms-science',
+    level: 'k12',
+    title: 'Middle School Science',
+    credential: 'Homeschool path',
+    framework: 'NGSS (grades 6–8)',
+    institution: 'Alexandrian Academy · Knowledge Commons',
+    teacher: 'Bill Nye (science communication)',
+    summary:
+      'A standards-aligned homeschool science path for grades 6–8, mapped onto the Next Generation Science Standards. Each strand traces to captured, openly-licensed content (CK-12, OpenStax) and the skills it builds — so a parent can see coverage and gaps at a glance.',
+    requirements: [
+      {
+        id: 'k12-ps', title: 'Matter & Its Interactions', code: 'MS-PS1', satisfied: true,
+        courses: [
+          { id: 'ck12-ps-matter', code: 'CK-12 PS', title: 'Physical Science: Matter', source: 'CK-12', license: 'CC BY-NC 3.0', captured: true, chunks: 640, teacher: 'Bill Nye', skills: ['sk-modeling', 'sk-inquiry'] },
+          { id: 'ostax-chem', code: 'OSTAX', title: 'Chemistry: Atoms First (intro units)', source: 'OpenStax', license: 'CC BY 4.0', captured: true, chunks: 410, skills: ['sk-modeling', 'sk-data'] },
+        ],
+      },
+      {
+        id: 'k12-ls', title: 'From Molecules to Organisms', code: 'MS-LS1', satisfied: true,
+        courses: [
+          { id: 'ck12-life', code: 'CK-12 LS', title: 'Life Science', source: 'CK-12', license: 'CC BY-NC 3.0', captured: true, chunks: 720, teacher: 'Bill Nye', skills: ['sk-inquiry', 'sk-argument'] },
+        ],
+      },
+      {
+        id: 'k12-ess', title: 'Earth & Space Sciences', code: 'MS-ESS1', satisfied: true,
+        courses: [
+          { id: 'ck12-earth', code: 'CK-12 ESS', title: 'Earth Science', source: 'CK-12', license: 'CC BY-NC 3.0', captured: true, chunks: 560, skills: ['sk-modeling', 'sk-data'] },
+        ],
+      },
+      {
+        id: 'k12-eng', title: 'Engineering Design', code: 'MS-ETS1', satisfied: false,
+        courses: [
+          { id: 'ngss-ets', code: 'NGSS ETS1', title: 'Engineering Design (standard)', source: 'NGSS', license: 'Public standard', captured: false, skills: ['sk-modeling', 'sk-argument'] },
+        ],
+      },
+      {
+        id: 'k12-math', title: 'Grade-level Mathematics', code: 'CCSS.MATH 6–8', satisfied: true,
+        courses: [
+          { id: 'ostax-prealg', code: 'OSTAX', title: 'Prealgebra', source: 'OpenStax', license: 'CC BY 4.0', captured: true, chunks: 880, skills: ['sk-algebra', 'sk-data'] },
+        ],
+      },
+    ],
+  },
+
+  // University degree (audience #2) — the real MIT Physics S.B., degree-back-into, 93% captured.
+  {
+    id: 'mit-physics-sb',
+    level: 'undergrad',
+    title: 'Physics, S.B.',
+    credential: 'S.B. (Bachelor of Science)',
+    framework: 'MIT Course 8',
+    institution: 'Massachusetts Institute of Technology · OCW',
+    teacher: 'Walter Lewin (8.01/8.02)',
+    summary:
+      'The MIT Course 8 Physics degree, backed into from the catalogue onto captured OpenCourseWare. 14 of 15 required subjects (168/180 units, 93%) are already teachable from the Commons — the only gap is the student’s own thesis. Anchored on Walter Lewin’s 8.01/8.02.',
+    requiredUnits: 180,
+    requirements: [
+      {
+        id: 'p-mech', title: 'Classical Mechanics (8.01)', code: '8.01', units: 12, satisfied: true,
+        courses: [{ id: 'ocw-801', code: '8.01SC', title: 'Classical Mechanics', source: 'MIT OCW', license: 'CC BY-NC-SA 4.0', captured: true, chunks: 4781, units: 12, teacher: 'Walter Lewin', skills: ['sk-mechanics', 'sk-calculus'] }],
+      },
+      {
+        id: 'p-em', title: 'Electricity & Magnetism (8.02)', code: '8.02', units: 12, satisfied: true,
+        courses: [{ id: 'ocw-802', code: '8.02', title: 'Electricity & Magnetism', source: 'MIT OCW', license: 'CC BY-NC-SA 4.0', captured: true, chunks: 3120, units: 12, teacher: 'Walter Lewin', skills: ['sk-em', 'sk-calculus'] }],
+      },
+      {
+        id: 'p-linalg', title: 'Linear Algebra (18.06)', code: '18.06', units: 12, satisfied: true,
+        courses: [{ id: 'ocw-1806', code: '18.06', title: 'Linear Algebra', source: 'MIT OCW', license: 'CC BY-NC-SA 4.0', captured: true, chunks: 2960, units: 12, teacher: 'Gilbert Strang', skills: ['sk-linalg', 'sk-algebra'] }],
+      },
+      {
+        id: 'p-calc', title: 'Multivariable Calculus (18.02)', code: '18.02', units: 12, satisfied: true,
+        courses: [{ id: 'ocw-1802', code: '18.02', title: 'Multivariable Calculus', source: 'MIT OCW', license: 'CC BY-NC-SA 4.0', captured: true, chunks: 2540, units: 12, skills: ['sk-calculus'] }],
+      },
+      {
+        id: 'p-quantum', title: 'Quantum Physics (8.04)', code: '8.04', units: 12, satisfied: true,
+        courses: [{ id: 'ocw-804', code: '8.04', title: 'Quantum Physics I', source: 'MIT OCW', license: 'CC BY-NC-SA 4.0', captured: true, chunks: 2210, units: 12, skills: ['sk-mechanics', 'sk-calculus'] }],
+      },
+      {
+        id: 'p-thesis', title: 'Senior Thesis (8.THU)', code: '8.THU', units: 12, satisfied: false,
+        courses: [{ id: 'thesis', code: '8.THU', title: 'Undergraduate Thesis', source: 'MIT OCW', license: '—', captured: false, units: 12, skills: ['sk-writing', 'sk-argument'] }],
+      },
+    ],
+  },
+];
+
+// ── Derived helpers (mirror the registrar's coverage math) ────────────────────
+export function coverageOf(p: Program): { satisfied: number; total: number; pct: number; units?: number; requiredUnits?: number } {
+  const total = p.requirements.length;
+  const satisfied = p.requirements.filter((r) => r.satisfied).length;
+  const units = p.requirements.filter((r) => r.satisfied).reduce((s, r) => s + (r.units ?? 0), 0);
+  const pct = p.requiredUnits
+    ? Math.round((units / p.requiredUnits) * 100)
+    : Math.round((satisfied / Math.max(1, total)) * 100);
+  return { satisfied, total, pct, units: p.requiredUnits ? units : undefined, requiredUnits: p.requiredUnits };
+}
+
+export function capturedChunks(p: Program): number {
+  return p.requirements.reduce((s, r) => s + r.courses.reduce((c, x) => c + (x.chunks ?? 0), 0), 0);
+}
+
+export function skillName(id: string): string {
+  return skills.find((s) => s.id === id)?.name ?? id;
+}
+
+// Skills that appear in more than one program — the reuse that makes it a graph, not a catalog.
+export function sharedSkills(): { id: string; name: string; programs: string[] }[] {
+  const byskill = new Map<string, Set<string>>();
+  for (const p of programs)
+    for (const r of p.requirements)
+      for (const c of r.courses)
+        for (const sk of c.skills) {
+          if (!byskill.has(sk)) byskill.set(sk, new Set());
+          byskill.get(sk)!.add(p.id);
+        }
+  return [...byskill.entries()]
+    .filter(([, ps]) => ps.size > 1)
+    .map(([id, ps]) => ({ id, name: skillName(id), programs: [...ps] }));
+}
+
+export const LADDER: { level: LadderLevel; label: string; blurb: string }[] = [
+  { level: 'k12', label: 'K-12 · Homeschool', blurb: 'Standards-based paths (NGSS, Common Core)' },
+  { level: 'undergrad', label: 'Undergraduate', blurb: 'Degree-back-into the university catalogue' },
+  { level: 'grad', label: 'Graduate', blurb: 'Research-depth subjects & seminars' },
+  { level: 'professional', label: 'Professional', blurb: 'Skill-graph micro-credentials' },
+];

--- a/apps/socioprophet-web/src/main.ts
+++ b/apps/socioprophet-web/src/main.ts
@@ -36,6 +36,8 @@ import WeatherMonitor from './pages/WeatherMonitor.vue';
 import ControlPlaneLifecycle from './pages/ControlPlaneLifecycle.vue';
 import NoeticaControlPlane from './pages/NoeticaControlPlane.vue';
 import DomainSurfacePage from './pages/DomainSurfacePage.vue';
+import AcademyOverview from './pages/AcademyOverview.vue';
+import DegreeExplorer from './pages/DegreeExplorer.vue';
 import FeedPage from './pages/FeedPage.vue';
 import Journal from './pages/Journal.vue';
 import MapPage from './pages/MapPage.vue';
@@ -72,6 +74,9 @@ const explicitRoutes = [
   { path: '/', redirect: '/capability/dashboard' },
   { path: '/login', component: Login, meta: { public: true } },
   { path: '/capability/dashboard', component: OperatorDashboard },
+  { path: '/academy', component: AcademyOverview },
+  { path: '/academy/homeschool', component: DegreeExplorer },
+  { path: '/academy/degrees', component: DegreeExplorer },
   { path: '/agentic-os', component: AgenticOS },
   { path: '/marketplace', component: Marketplace },
   { path: '/people/labor-market', component: LaborMarket },

--- a/apps/socioprophet-web/src/pages/AcademyOverview.vue
+++ b/apps/socioprophet-web/src/pages/AcademyOverview.vue
@@ -1,0 +1,144 @@
+<template>
+  <section class="ac" aria-label="Academy">
+    <SurfaceHeader title="Academy" eyebrow="Alexandrian Academy · Knowledge Commons">
+      <template #badge><span class="ac-pill">open · CC</span></template>
+    </SurfaceHeader>
+
+    <!-- The moat, stated: what no competitor has all four of. -->
+    <div class="ac-moat">
+      <div class="ac-moat-lead">A learning platform with four things no one else has together —</div>
+      <div class="ac-pillars">
+        <div v-for="p in PILLARS" :key="p.t" class="ac-pillar">
+          <span class="ac-pillar-g">{{ p.g }}</span>
+          <div><b>{{ p.t }}</b><span>{{ p.d }}</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- The ladder — K-12 → undergrad → grad → professional (built in your audience order). -->
+    <div class="ac-ladder">
+      <div v-for="(l, i) in LADDER" :key="l.level" class="ac-rung" :class="{ live: rungCount(l.level) > 0 }">
+        <span class="ac-rung-n">{{ i + 1 }}</span>
+        <div class="ac-rung-b">
+          <b>{{ l.label }}</b>
+          <span>{{ l.blurb }}</span>
+        </div>
+        <span class="ac-rung-c">{{ rungCount(l.level) ? `${rungCount(l.level)} program${rungCount(l.level) === 1 ? '' : 's'}` : 'soon' }}</span>
+      </div>
+    </div>
+
+    <!-- Featured programs, with real coverage from the registrar shape. -->
+    <div class="ac-section-h">Programs <span class="ac-hint">degree-back-into · coverage from the Commons</span></div>
+    <div class="ac-programs">
+      <RouterLink v-for="p in programs" :key="p.id" class="ac-prog" :to="p.level === 'k12' ? '/academy/homeschool' : '/academy/degrees'">
+        <div class="ac-prog-top">
+          <span class="ac-level" :class="p.level">{{ p.level === 'k12' ? 'K-12' : p.level }}</span>
+          <span class="ac-prog-fw">{{ p.framework }}</span>
+        </div>
+        <div class="ac-prog-title">{{ p.title }} <span class="ac-cred">{{ p.credential }}</span></div>
+        <div class="ac-prog-teacher">tutor embodies {{ p.teacher }}</div>
+        <div class="ac-cov">
+          <div class="ac-cov-bar"><span :style="{ width: coverageOf(p).pct + '%' }" :class="{ full: coverageOf(p).pct >= 90 }" /></div>
+          <span class="ac-cov-n">{{ coverageOf(p).pct }}% captured</span>
+        </div>
+        <div class="ac-prog-meta">
+          {{ coverageOf(p).satisfied }}/{{ coverageOf(p).total }} requirements
+          <template v-if="coverageOf(p).requiredUnits">· {{ coverageOf(p).units }}/{{ coverageOf(p).requiredUnits }} units</template>
+          · {{ capturedChunks(p).toLocaleString() }} chunks
+        </div>
+      </RouterLink>
+    </div>
+
+    <!-- The graph-native bit: skills reused across programs (one node, many degrees). -->
+    <div v-if="shared.length" class="ac-shared">
+      <div class="ac-section-h">Shared skills <span class="ac-hint">one node serves many programs — the curriculum is a graph, not a catalog</span></div>
+      <div class="ac-skills">
+        <span v-for="s in shared" :key="s.id" class="ac-skill">
+          {{ s.name }}<span class="ac-skill-n">×{{ s.programs.length }}</span>
+        </span>
+      </div>
+    </div>
+
+    <div class="ac-cta">
+      <RouterLink class="ac-cta-btn" to="/academy/homeschool">Open the Homeschool explorer →</RouterLink>
+      <RouterLink class="ac-cta-btn" to="/academy/degrees">Open the Degree explorer →</RouterLink>
+      <span class="ac-cta-note">Designed on the registrar shape — wiring to the live capture + tutor services is a loader swap.</span>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import SurfaceHeader from '../components/SurfaceHeader.vue';
+import { useCockpit } from '../stores/cockpit';
+import { programs, LADDER, coverageOf, capturedChunks, sharedSkills, type LadderLevel } from '../data/academyFixture';
+
+const cockpit = useCockpit();
+const shared = sharedSkills();
+
+const PILLARS = [
+  { g: '◆', t: 'Grounded tutor', d: 'answers cited to the exact lecture — the anti-Chegg' },
+  { g: '◈', t: 'Graph-native degree', d: 'skills reuse across programs, not a flat catalog' },
+  { g: '✓', t: 'Verified assessment', d: 'the board engine measures mastery, not guesses' },
+  { g: '○', t: 'Open & sovereign', d: 'CC-clean corpus, owned — an open Coursera' },
+];
+
+function rungCount(level: LadderLevel): number {
+  return programs.filter((p) => p.level === level).length;
+}
+
+onMounted(() => cockpit.setContext({
+  surface: 'Academy',
+  entityLabel: `${programs.length} programs`,
+  detail: 'Alexandrian Academy · open courseware',
+  route: '/academy',
+}));
+</script>
+
+<style scoped>
+.ac { height: 100%; min-height: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 1rem; padding: 0.85rem 1.1rem 1.5rem; background: var(--bg); color: var(--text); }
+.ac-pill { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--up); background: rgba(63,185,80,0.14); border-radius: 5px; padding: 0.1rem 0.4rem; }
+
+.ac-moat { border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: 0.85rem 1rem; }
+.ac-moat-lead { font-size: 0.9rem; color: var(--text-2); margin-bottom: 0.7rem; }
+.ac-pillars { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 0.6rem; }
+.ac-pillar { display: flex; gap: 0.55rem; align-items: flex-start; }
+.ac-pillar-g { font-size: 1rem; color: var(--accent); line-height: 1.3; flex: 0 0 auto; }
+.ac-pillar b { display: block; font-size: 0.86rem; color: var(--text); } .ac-pillar span { font-size: 0.74rem; color: var(--text-3); line-height: 1.45; }
+
+.ac-ladder { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.5rem; }
+.ac-rung { display: flex; align-items: center; gap: 0.6rem; border: 1px solid var(--line-2); border-radius: 10px; padding: 0.55rem 0.7rem; background: var(--surface); opacity: 0.55; }
+.ac-rung.live { opacity: 1; border-left: 3px solid var(--accent); }
+.ac-rung-n { width: 1.4rem; height: 1.4rem; flex: 0 0 auto; display: grid; place-items: center; border-radius: 50%; border: 1px solid var(--line-2); font-size: 0.72rem; color: var(--text-3); font-variant-numeric: tabular-nums; }
+.ac-rung.live .ac-rung-n { border-color: var(--accent); color: var(--accent); }
+.ac-rung-b { flex: 1; min-width: 0; } .ac-rung-b b { display: block; font-size: 0.82rem; } .ac-rung-b span { font-size: 0.68rem; color: var(--text-3); }
+.ac-rung-c { font-size: 0.66rem; color: var(--text-3); white-space: nowrap; }
+
+.ac-section-h { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-3); margin-top: 0.3rem; }
+.ac-hint { text-transform: none; letter-spacing: 0; color: var(--text-3); margin-left: 0.5rem; }
+
+.ac-programs { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 0.7rem; }
+.ac-prog { display: flex; flex-direction: column; gap: 0.35rem; border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: 0.85rem; text-decoration: none; color: inherit; transition: border-color 0.15s, transform 0.1s; }
+.ac-prog:hover { border-color: var(--accent); transform: translateY(-1px); }
+.ac-prog-top { display: flex; align-items: center; gap: 0.5rem; }
+.ac-level { font-size: 0.58rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 700; border-radius: 4px; padding: 0.05rem 0.35rem; color: var(--accent); background: var(--accent-soft, rgba(120,160,255,0.12)); }
+.ac-level.undergrad { color: #58a6ff; background: rgba(88,166,255,0.14); } .ac-level.k12 { color: #6ee7b7; background: rgba(63,185,80,0.14); }
+.ac-prog-fw { font-size: 0.7rem; color: var(--text-3); }
+.ac-prog-title { font-size: 1.02rem; font-weight: 650; } .ac-cred { font-size: 0.72rem; color: var(--text-3); font-weight: 400; }
+.ac-prog-teacher { font-size: 0.74rem; color: var(--text-2); }
+.ac-cov { display: flex; align-items: center; gap: 0.5rem; margin-top: 0.2rem; }
+.ac-cov-bar { flex: 1; height: 6px; border-radius: 4px; background: var(--line); overflow: hidden; }
+.ac-cov-bar span { display: block; height: 100%; background: var(--accent); } .ac-cov-bar span.full { background: var(--up); }
+.ac-cov-n { font-size: 0.72rem; color: var(--text-2); font-variant-numeric: tabular-nums; }
+.ac-prog-meta { font-size: 0.7rem; color: var(--text-3); }
+
+.ac-shared { display: flex; flex-direction: column; gap: 0.4rem; }
+.ac-skills { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.ac-skill { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.74rem; color: var(--text-2); border: 1px solid var(--line-2); border-radius: 999px; padding: 0.15rem 0.55rem; }
+.ac-skill-n { font-size: 0.62rem; color: var(--accent); font-variant-numeric: tabular-nums; }
+
+.ac-cta { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; margin-top: 0.3rem; }
+.ac-cta-btn { text-decoration: none; border: 1px solid var(--line-2); border-radius: 8px; padding: 0.4rem 0.8rem; font-size: 0.8rem; color: var(--text); background: var(--surface); }
+.ac-cta-btn:hover { border-color: var(--accent); color: var(--accent); }
+.ac-cta-note { font-size: 0.7rem; color: var(--text-3); }
+</style>

--- a/apps/socioprophet-web/src/pages/DegreeExplorer.vue
+++ b/apps/socioprophet-web/src/pages/DegreeExplorer.vue
@@ -1,0 +1,151 @@
+<template>
+  <section class="dx" aria-label="Academy explorer">
+    <SurfaceHeader :title="isK12 ? 'Homeschool Explorer' : 'Degree Explorer'" :eyebrow="isK12 ? 'Academy · K-12 · standards-based' : 'Academy · University · degree-back-into'">
+      <template #badge><span class="dx-pill">{{ isK12 ? 'NGSS · Common Core' : 'MIT catalogue' }}</span></template>
+    </SurfaceHeader>
+
+    <SplitPane storage-key="academy-explorer" label="programs" :initial="300">
+      <template #list>
+        <div class="dx-list" aria-label="Programs">
+          <p class="dx-count">{{ list.length }} program{{ list.length === 1 ? '' : 's' }}</p>
+          <button v-for="p in list" :key="p.id" class="dx-row" :class="{ on: p.id === selectedId }" @click="selectedId = p.id">
+            <div class="dx-row-title">{{ p.title }}</div>
+            <div class="dx-row-meta">{{ p.credential }} · {{ p.framework }}</div>
+            <div class="dx-row-cov">
+              <div class="dx-cov-bar"><span :style="{ width: coverageOf(p).pct + '%' }" :class="{ full: coverageOf(p).pct >= 90 }" /></div>
+              <span>{{ coverageOf(p).pct }}%</span>
+            </div>
+          </button>
+          <p v-if="list.length === 0" class="dx-empty">No programs at this level yet.</p>
+        </div>
+      </template>
+
+      <template #detail>
+        <article v-if="selected" class="dx-detail">
+          <div class="dx-d-head">
+            <span class="dx-level" :class="selected.level">{{ selected.level === 'k12' ? 'K-12' : selected.level }}</span>
+            <h2>{{ selected.title }}</h2>
+            <span class="dx-cred">{{ selected.credential }}</span>
+          </div>
+          <div class="dx-d-meta">{{ selected.institution }} · tutor embodies <b>{{ selected.teacher }}</b></div>
+          <p class="dx-d-summary">{{ selected.summary }}</p>
+
+          <!-- Coverage banner -->
+          <div class="dx-cov-banner" :class="{ full: cov.pct >= 90 }">
+            <div class="dx-cov-big">{{ cov.pct }}%<span>captured from the Commons</span></div>
+            <div class="dx-cov-detail">
+              <span><b>{{ cov.satisfied }}</b>/{{ cov.total }} requirements</span>
+              <span v-if="cov.requiredUnits"><b>{{ cov.units }}</b>/{{ cov.requiredUnits }} units</span>
+              <span><b>{{ capturedChunks(selected).toLocaleString() }}</b> chunks</span>
+            </div>
+          </div>
+
+          <!-- Requirements → courses → skills (the registrar walk) -->
+          <div class="dx-req-h">Requirements <span class="dx-hint">each traces to captured, openly-licensed content</span></div>
+          <div v-for="r in selected.requirements" :key="r.id" class="dx-req" :class="{ gap: !r.satisfied }">
+            <div class="dx-req-top">
+              <span class="dx-req-flag" :class="{ gap: !r.satisfied }">{{ r.satisfied ? '✓' : '○' }}</span>
+              <span class="dx-req-title">{{ r.title }}</span>
+              <span v-if="r.code" class="dx-req-code">{{ r.code }}</span>
+              <span v-if="r.units" class="dx-req-units">{{ r.units }}u</span>
+            </div>
+            <div v-for="c in r.courses" :key="c.id" class="dx-course">
+              <component :is="c.captured ? 'RouterLink' : 'div'" :to="c.captured ? `/academy/course/${c.id}` : undefined" class="dx-course-main" :class="{ link: c.captured }">
+                <span class="dx-course-title">{{ c.title }}</span>
+                <span class="dx-course-src">{{ c.source }}</span>
+                <span class="dx-lic" :class="{ open: c.license.startsWith('CC') }">{{ c.license }}</span>
+                <span v-if="c.captured && c.chunks" class="dx-chunks">{{ c.chunks.toLocaleString() }} chunks</span>
+                <span v-else-if="!c.captured" class="dx-uncaptured">not yet captured</span>
+                <span v-if="c.captured" class="dx-open">open →</span>
+              </component>
+              <div class="dx-skills">
+                <span v-for="sk in c.skills" :key="sk" class="dx-skill" :class="{ shared: sharedIds.has(sk) }" :title="sharedIds.has(sk) ? 'reused across programs' : ''">{{ skillName(sk) }}</span>
+              </div>
+            </div>
+          </div>
+
+          <p class="dx-foot">
+            Designed on the registrar shape (<code>Program → Requirement → Course → Skill</code>). Coverage, units and chunk
+            counts mirror <code>alexandrian-academy</code>’s real output; wiring the live capture + tutor is a loader swap.
+          </p>
+        </article>
+        <div v-else class="dx-detail empty">Select a program</div>
+      </template>
+    </SplitPane>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import SurfaceHeader from '../components/SurfaceHeader.vue';
+import SplitPane from '../components/SplitPane.vue';
+import { useCockpit } from '../stores/cockpit';
+import { programs, coverageOf, capturedChunks, skillName, sharedSkills, type LadderLevel, type Program } from '../data/academyFixture';
+
+const route = useRoute();
+const cockpit = useCockpit();
+const isK12 = computed(() => route.path.includes('homeschool'));
+const levels = computed<LadderLevel[]>(() => (isK12.value ? ['k12'] : ['undergrad', 'grad']));
+const list = computed<Program[]>(() => programs.filter((p) => levels.value.includes(p.level)));
+const selectedId = ref<string>(list.value[0]?.id ?? '');
+const selected = computed<Program | undefined>(() => list.value.find((p) => p.id === selectedId.value) ?? list.value[0]);
+const cov = computed(() => (selected.value ? coverageOf(selected.value) : { satisfied: 0, total: 0, pct: 0 }));
+const sharedIds = new Set(sharedSkills().map((s) => s.id));
+
+watch(list, (l) => { if (!l.some((p) => p.id === selectedId.value) && l[0]) selectedId.value = l[0].id; });
+watch(selected, (p) => {
+  if (p) cockpit.setContext({ surface: isK12.value ? 'Academy · Homeschool' : 'Academy · Degrees', entityLabel: p.title, detail: `${coverageOf(p).pct}% captured`, route: route.path });
+}, { immediate: true });
+onMounted(() => { if (!selected.value && list.value[0]) selectedId.value = list.value[0].id; });
+</script>
+
+<style scoped>
+.dx { height: 100%; min-height: 0; display: grid; grid-template-rows: auto 1fr; gap: 0.75rem; padding: 0.85rem 1rem 1rem; background: var(--bg); color: var(--text); }
+.dx-pill { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); background: var(--accent-soft, rgba(120,160,255,0.12)); border-radius: 5px; padding: 0.1rem 0.4rem; }
+
+.dx-list { min-height: 0; overflow-y: auto; border: 1px solid var(--line-2); border-radius: 12px; }
+.dx-count { margin: 0; padding: 0.5rem 0.85rem; font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-3); border-bottom: 1px solid var(--line); }
+.dx-row { width: 100%; display: flex; flex-direction: column; gap: 0.25rem; border: none; border-bottom: 1px solid var(--line); background: transparent; color: inherit; padding: 0.65rem 0.85rem; cursor: pointer; text-align: left; }
+.dx-row:hover { background: rgba(255,255,255,0.03); } .dx-row.on { background: color-mix(in srgb, var(--accent) 8%, transparent); box-shadow: inset 3px 0 0 var(--accent); }
+.dx-row-title { font-size: 0.9rem; font-weight: 600; } .dx-row-meta { font-size: 0.7rem; color: var(--text-3); }
+.dx-row-cov { display: flex; align-items: center; gap: 0.5rem; font-size: 0.68rem; color: var(--text-2); font-variant-numeric: tabular-nums; }
+.dx-cov-bar { flex: 1; height: 5px; border-radius: 4px; background: var(--line); overflow: hidden; } .dx-cov-bar span { display: block; height: 100%; background: var(--accent); } .dx-cov-bar span.full { background: var(--up); }
+.dx-empty { padding: 1.2rem; color: var(--text-3); font-size: 0.85rem; }
+
+.dx-detail { min-height: 0; overflow-y: auto; border: 1px solid var(--line-2); border-radius: 12px; padding: 1rem 1.1rem 1.2rem; }
+.dx-detail.empty { display: grid; place-items: center; color: var(--text-3); font-size: 0.85rem; }
+.dx-d-head { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; } .dx-d-head h2 { margin: 0; font-size: 1.3rem; }
+.dx-level { font-size: 0.58rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 700; border-radius: 4px; padding: 0.05rem 0.35rem; color: #58a6ff; background: rgba(88,166,255,0.14); }
+.dx-level.k12 { color: #6ee7b7; background: rgba(63,185,80,0.14); }
+.dx-cred { font-size: 0.74rem; color: var(--text-3); }
+.dx-d-meta { font-size: 0.78rem; color: var(--text-2); margin-top: 0.25rem; } .dx-d-meta b { color: var(--text); }
+.dx-d-summary { font-size: 0.88rem; line-height: 1.6; color: var(--text-2); margin: 0.7rem 0; }
+
+.dx-cov-banner { display: flex; align-items: center; gap: 1.2rem; border: 1px solid var(--line-2); border-left: 3px solid var(--accent); border-radius: 10px; padding: 0.7rem 0.9rem; background: var(--surface); flex-wrap: wrap; }
+.dx-cov-banner.full { border-left-color: var(--up); }
+.dx-cov-big { font-size: 1.7rem; font-weight: 800; color: var(--text); font-variant-numeric: tabular-nums; display: flex; flex-direction: column; line-height: 1.05; }
+.dx-cov-banner.full .dx-cov-big { color: #86efac; }
+.dx-cov-big span { font-size: 0.6rem; font-weight: 400; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); }
+.dx-cov-detail { display: flex; gap: 1rem; font-size: 0.78rem; color: var(--text-3); flex-wrap: wrap; } .dx-cov-detail b { color: var(--text); font-variant-numeric: tabular-nums; }
+
+.dx-req-h { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-3); margin: 1.1rem 0 0.5rem; }
+.dx-hint { text-transform: none; letter-spacing: 0; color: var(--text-3); margin-left: 0.4rem; }
+.dx-req { border-top: 1px solid var(--line); padding: 0.6rem 0; }
+.dx-req-top { display: flex; align-items: center; gap: 0.5rem; }
+.dx-req-flag { width: 1.2rem; height: 1.2rem; flex: 0 0 auto; display: grid; place-items: center; border-radius: 50%; font-size: 0.7rem; color: var(--up); background: rgba(63,185,80,0.14); } .dx-req-flag.gap { color: #e3b341; background: rgba(227,179,65,0.16); }
+.dx-req-title { font-size: 0.88rem; font-weight: 600; flex: 1; } .dx-req.gap .dx-req-title { color: var(--text-2); }
+.dx-req-code { font-size: 0.68rem; color: var(--text-3); font-family: ui-monospace, monospace; } .dx-req-units { font-size: 0.68rem; color: var(--text-3); }
+.dx-course { margin: 0.35rem 0 0 1.7rem; }
+.dx-course-main { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; text-decoration: none; color: inherit; padding: 0.25rem 0; }
+.dx-course-main.link { cursor: pointer; } .dx-course-main.link:hover .dx-course-title { color: var(--accent); }
+.dx-course-title { font-size: 0.82rem; color: var(--text); } .dx-course-src { font-size: 0.68rem; color: var(--text-3); }
+.dx-lic { font-size: 0.6rem; border: 1px solid var(--line-2); border-radius: 4px; padding: 0.02rem 0.3rem; color: var(--text-3); } .dx-lic.open { color: var(--up); border-color: rgba(63,185,80,0.4); }
+.dx-chunks { font-size: 0.66rem; color: var(--text-3); font-variant-numeric: tabular-nums; }
+.dx-uncaptured { font-size: 0.66rem; color: #e3b341; }
+.dx-open { font-size: 0.68rem; color: var(--accent); margin-left: auto; }
+.dx-skills { display: flex; flex-wrap: wrap; gap: 0.3rem; margin: 0.25rem 0 0 0; }
+.dx-skill { font-size: 0.66rem; color: var(--text-3); border: 1px solid var(--line); border-radius: 999px; padding: 0.05rem 0.45rem; }
+.dx-skill.shared { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 40%, transparent); }
+.dx-foot { font-size: 0.72rem; color: var(--text-3); line-height: 1.5; margin-top: 1rem; border-top: 1px solid var(--line); padding-top: 0.7rem; } .dx-foot code { font-family: ui-monospace, monospace; color: var(--text-2); }
+</style>


### PR DESCRIPTION
## Why
The estate has the education moat's *ingredients* — `alexandrian-academy` (registrar + capture), `search-orchestrator` academy ingest, hellgraph, holmes, the board assessment engine — but **the cockpit had no education surface at all** (8 top-level sections, zero for learning). This lands the section.

Decisions locked with you: **build the whole section**, audience order **K-12/homeschool → university → professional**, **designed-surface-first** (fixtures mirror the real registrar shape → wiring live services is a loader swap).

## What
- **New top-level `Academy` nav group** + routes (`/academy`, `/academy/homeschool`, `/academy/degrees`; course/tutor links resolve to the mock surface until built — never dead).
- **`academyFixture.ts`** — one model across the whole ladder (`Program → Requirement → Course → Skill`). **Skills are shared nodes** (one algebra node serves physics + econ) — the graph-native curriculum that's the moat over a flat catalog. CC-open sources only.
- **AcademyOverview** — the moat stated (grounded tutor · graph-native degree · verified assessment · open), the K-12→undergrad→grad→professional ladder, program cards with real coverage.
- **DegreeExplorer** — ONE reusable explorer renders both the **K-12 homeschool path** (NGSS strands → CK-12/OpenStax) and the **MIT Physics S.B.** (14/15 reqs, 168/180 units, **93% captured**, Lewin's 8.01 = 4,781 chunks): requirements → courses → skills, coverage banner, gaps flagged amber, license-tagged.

## Next increments
Flagship course (8.01) → **grounded/cited tutor** → **board assessment** (the depth-of-one that proves the moat); then the homeschool degree explorer depth + professional/skills.

## Verify
`vue-tsc --noEmit` clean · `npm run build` clean.