### PR TITLE
cockpit(academy): flagship course 8.01 + grounded tutor + board mastery check

### DIFF
--- a/apps/socioprophet-web/src/components/GroundedTutor.vue
+++ b/apps/socioprophet-web/src/components/GroundedTutor.vue
@@ -1,0 +1,138 @@
+<template>
+  <div class="gt">
+    <div class="gt-head">
+      <span class="gt-title">Grounded Tutor</span>
+      <span class="gt-persona">in the voice of {{ course.teacher }}</span>
+    </div>
+    <p class="gt-blurb">Ask about the course. Every answer is <b>quoted and cited</b> to a captured lecture segment — it never invents.</p>
+
+    <form class="gt-ask" @submit.prevent="ask">
+      <input v-model="qText" class="gt-input" type="text" placeholder="e.g. why doesn't a ball fall faster if you throw it sideways?" aria-label="Ask the tutor" />
+      <button class="gt-go" type="submit" :disabled="!qText.trim()">Ask</button>
+    </form>
+
+    <div v-if="!answer" class="gt-seeds">
+      <span class="gt-seeds-h">try:</span>
+      <button v-for="s in SEEDS" :key="s" class="gt-seed" @click="qText = s; ask()">{{ s }}</button>
+    </div>
+
+    <div v-if="answer" class="gt-answer" :class="{ nomatch: !answer.cited }">
+      <template v-if="answer.cited">
+        <p class="gt-persona-line">{{ answer.intro }}</p>
+        <blockquote class="gt-quote">“{{ answer.quote }}”</blockquote>
+        <button class="gt-cite" @click="$emit('jump', answer.lessonId)">
+          <span class="gt-cite-g">◆</span>
+          <span>Lecture {{ answer.lessonN }} · {{ answer.title }}</span>
+          <code>{{ answer.chunkRef }}</code>
+          <span class="gt-cite-open">open →</span>
+        </button>
+        <div class="gt-prov">
+          <span class="gt-prov-tag">extractive · quoted, not generated</span>
+          <span v-if="answer.concepts.length" class="gt-prov-concepts">on {{ answer.concepts.join(', ') }}</span>
+        </div>
+      </template>
+      <template v-else>
+        <p class="gt-nomatch">I answer only from the captured lectures, and I don’t find this in the corpus. Try one of these topics: <b>{{ topConcepts.join(', ') }}</b>.</p>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import type { Course } from '../data/courseFixture';
+
+const props = defineProps<{ course: Course }>();
+defineEmits<{ (e: 'jump', lessonId: string): void }>();
+
+const qText = ref('');
+const SEEDS = [
+  'what is the difference between velocity and acceleration?',
+  'why do action and reaction forces not cancel?',
+  'is there a centrifugal force?',
+];
+
+const STOP = new Set(['the', 'a', 'an', 'is', 'are', 'of', 'to', 'in', 'on', 'and', 'or', 'do', 'does', 'why', 'what', 'how', 'if', 'you', 'your', 'it', 'its', 'be', 'for', 'that', 'this', 'at', 'as', 'with', 'not', 'no', 'they', 'them', 'from', 'by', 'can', 'we', 'i', 'me', 'my']);
+function tokens(s: string): string[] {
+  return s.toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter((t) => t.length > 1 && !STOP.has(t));
+}
+
+const topConcepts = computed(() => {
+  const all = props.course.lessons.flatMap((l) => l.concepts);
+  return [...new Set(all)].slice(0, 5);
+});
+
+interface Answer { cited: boolean; intro: string; quote: string; lessonId: string; lessonN: number; title: string; chunkRef: string; concepts: string[] }
+const answer = ref<Answer | null>(null);
+
+function ask() {
+  const query = qText.value.trim();
+  if (!query) return;
+  const qt = tokens(query);
+  if (qt.length === 0) { answer.value = { cited: false } as Answer; return; }
+
+  // Score each lesson: concept hits weigh most, then title, then transcript.
+  let best: { lesson: typeof props.course.lessons[number]; score: number } | null = null;
+  for (const lesson of props.course.lessons) {
+    const conceptToks = new Set(lesson.concepts.flatMap(tokens));
+    const titleToks = new Set(tokens(lesson.title));
+    const bodyToks = new Set(tokens(lesson.transcript));
+    let score = 0;
+    for (const t of qt) {
+      if (conceptToks.has(t)) score += 3;
+      if (titleToks.has(t)) score += 2;
+      if (bodyToks.has(t)) score += 1;
+    }
+    if (!best || score > best.score) best = { lesson, score };
+  }
+
+  if (!best || best.score === 0) { answer.value = { cited: false } as Answer; return; }
+
+  // Extract the single most relevant sentence from the winning transcript.
+  const sentences = best.lesson.transcript.split(/(?<=[.!?])\s+/).filter((s) => s.trim().length > 0);
+  let bestSentence = sentences[0] ?? best.lesson.transcript;
+  let sScore = -1;
+  for (const s of sentences) {
+    const st = new Set(tokens(s));
+    const overlap = qt.reduce((n, t) => n + (st.has(t) ? 1 : 0), 0);
+    if (overlap > sScore) { sScore = overlap; bestSentence = s; }
+  }
+  const hitConcepts = best.lesson.concepts.filter((c) => tokens(c).some((t) => qt.includes(t)));
+
+  answer.value = {
+    cited: true,
+    intro: `Here's what ${props.course.teacher} says on this:`,
+    quote: bestSentence.trim(),
+    lessonId: best.lesson.id,
+    lessonN: best.lesson.n,
+    title: best.lesson.title,
+    chunkRef: best.lesson.chunkRef,
+    concepts: hitConcepts.length ? hitConcepts : best.lesson.concepts.slice(0, 2),
+  };
+}
+</script>
+
+<style scoped>
+.gt { border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: 0.85rem; display: flex; flex-direction: column; gap: 0.6rem; }
+.gt-head { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; }
+.gt-title { font-size: 0.9rem; font-weight: 700; color: var(--text); }
+.gt-persona { font-size: 0.7rem; color: var(--accent); }
+.gt-blurb { margin: 0; font-size: 0.74rem; color: var(--text-3); line-height: 1.5; } .gt-blurb b { color: var(--text-2); }
+.gt-ask { display: flex; gap: 0.5rem; }
+.gt-input { flex: 1; min-width: 0; border: 1px solid var(--line-2); background: var(--surface-2, rgba(255,255,255,0.02)); color: var(--text); border-radius: 8px; padding: 0.45rem 0.6rem; font-size: 0.82rem; }
+.gt-input:focus { outline: none; border-color: var(--accent); }
+.gt-go { border: 1px solid var(--accent); background: var(--accent-soft, rgba(120,160,255,0.14)); color: var(--accent); border-radius: 8px; padding: 0.45rem 0.9rem; font-size: 0.8rem; font-weight: 600; cursor: pointer; } .gt-go:disabled { opacity: 0.5; cursor: default; }
+.gt-seeds { display: flex; flex-wrap: wrap; gap: 0.35rem; align-items: center; }
+.gt-seeds-h { font-size: 0.68rem; color: var(--text-3); }
+.gt-seed { border: 1px solid var(--line-2); background: transparent; color: var(--text-2); border-radius: 999px; padding: 0.18rem 0.55rem; font-size: 0.7rem; cursor: pointer; text-align: left; } .gt-seed:hover { border-color: var(--accent); color: var(--accent); }
+
+.gt-answer { border-top: 1px solid var(--line); padding-top: 0.6rem; }
+.gt-persona-line { margin: 0 0 0.4rem; font-size: 0.78rem; color: var(--text-2); }
+.gt-quote { margin: 0 0 0.55rem; padding: 0.5rem 0.7rem; border-left: 3px solid var(--accent); background: var(--surface-2, rgba(255,255,255,0.015)); border-radius: 0 8px 8px 0; font-size: 0.9rem; line-height: 1.6; color: var(--text); }
+.gt-cite { display: flex; align-items: center; gap: 0.5rem; width: 100%; text-align: left; border: 1px solid var(--line-2); border-radius: 8px; padding: 0.4rem 0.6rem; background: transparent; color: var(--text-2); cursor: pointer; font-size: 0.76rem; } .gt-cite:hover { border-color: var(--accent); }
+.gt-cite-g { color: var(--accent); } .gt-cite code { font-family: ui-monospace, monospace; font-size: 0.68rem; color: var(--text-3); } .gt-cite-open { margin-left: auto; color: var(--accent); }
+.gt-prov { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; margin-top: 0.4rem; }
+.gt-prov-tag { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 700; color: var(--up); background: rgba(63,185,80,0.12); border: 1px solid rgba(63,185,80,0.35); border-radius: 4px; padding: 0.05rem 0.4rem; }
+.gt-prov-concepts { font-size: 0.68rem; color: var(--text-3); }
+.gt-nomatch { margin: 0; font-size: 0.8rem; color: var(--text-2); line-height: 1.55; } .gt-nomatch b { color: var(--text); }
+</style>

--- a/apps/socioprophet-web/src/data/courseFixture.ts
+++ b/apps/socioprophet-web/src/data/courseFixture.ts
@@ -1,0 +1,118 @@
+// Flagship course fixture — MIT 8.01 Classical Mechanics (Walter Lewin), the depth-of-one that
+// proves the Academy moat: a lesson stream + a GROUNDED tutor that answers by citing the exact
+// captured lecture passage, and a board-style mastery check. UI-only, but shaped like the real
+// captured-chunk retrieval (search-orchestrator academy ingest) so the tutor's retrieval backend
+// is a later swap. Content is OpenCourseWare (CC BY-NC-SA 4.0); the tutor is EXTRACTIVE over these
+// transcripts — it quotes a real segment rather than generating, so it cannot hallucinate.
+
+export interface Lesson {
+  id: string;
+  n: number;
+  title: string;
+  durationMin: number;
+  chunkRef: string;      // provenance handle, e.g. '8.01SC · L01 · seg 12'
+  objectives: string[];
+  concepts: string[];    // key terms — power the concept map + tutor retrieval
+  transcript: string;    // the captured lecture segment the tutor quotes from
+}
+
+export interface AssessmentItem {
+  id: string;
+  concept: string;
+  q: string;
+  options: string[];
+  answer: number;        // index into options
+  explain: string;
+}
+
+export interface Course {
+  id: string;
+  code: string;
+  title: string;
+  program: string;
+  teacher: string;
+  source: string;
+  license: string;
+  summary: string;
+  lessons: Lesson[];
+  assessment: AssessmentItem[];
+}
+
+const PHYSICS_801: Course = {
+  id: 'ocw-801',
+  code: '8.01SC',
+  title: 'Classical Mechanics',
+  program: 'Physics, S.B. (MIT Course 8)',
+  teacher: 'Walter Lewin',
+  source: 'MIT OpenCourseWare',
+  license: 'CC BY-NC-SA 4.0',
+  summary:
+    'The first-semester MIT physics course, taught by Walter Lewin. Units and scaling, kinematics in one and three dimensions, Newton’s laws, and circular motion — the foundation the whole degree stands on.',
+  lessons: [
+    {
+      id: 'l01', n: 1, title: 'Units, Dimensions & Powers of Ten', durationMin: 50, chunkRef: '8.01SC · L01 · seg 12',
+      objectives: ['Reason in SI units', 'Use dimensional analysis to check equations', 'Estimate with orders of magnitude'],
+      concepts: ['units', 'dimensions', 'dimensional analysis', 'powers of ten', 'uncertainty', 'scaling'],
+      transcript:
+        'Any measurement you make without knowledge of its uncertainty is meaningless. In physics we express every quantity in SI units — the meter for length, the kilogram for mass, the second for time. Dimensional analysis is a powerful check: the dimensions on the left of an equation must equal the dimensions on the right, or the equation is simply wrong. If a result for a length comes out with dimensions of time, you have made a mistake, and no amount of algebra will fix it.',
+    },
+    {
+      id: 'l02', n: 2, title: 'One-Dimensional Kinematics', durationMin: 50, chunkRef: '8.01SC · L02 · seg 07',
+      objectives: ['Distinguish position, velocity, acceleration', 'Read motion from x–t and v–t graphs', 'Apply constant-acceleration equations'],
+      concepts: ['position', 'velocity', 'acceleration', 'displacement', 'average velocity', 'instantaneous velocity'],
+      transcript:
+        'Velocity is the rate of change of position with time, and acceleration is the rate of change of velocity with time. Average velocity is displacement divided by the elapsed time, whereas instantaneous velocity is the slope of the position–time curve at a single instant. A crucial point: an object can have zero velocity yet non-zero acceleration — at the top of its flight a ball thrown straight up is momentarily at rest, but gravity is still accelerating it downward at 9.8 meters per second squared.',
+    },
+    {
+      id: 'l03', n: 3, title: 'Vectors & Projectile Motion', durationMin: 50, chunkRef: '8.01SC · L03 · seg 15',
+      objectives: ['Decompose vectors into components', 'Treat horizontal and vertical motion independently', 'Predict the trajectory of a projectile'],
+      concepts: ['vectors', 'components', 'projectile motion', 'trajectory', 'independence of motion', 'range'],
+      transcript:
+        'The great insight of projectile motion is that the horizontal and vertical motions are completely independent. Gravity acts only vertically, so the horizontal velocity is constant while the vertical velocity changes at 9.8 meters per second squared. Because the two are independent, a bullet fired horizontally and a bullet dropped from the same height hit the ground at exactly the same time. The path traced out is a parabola.',
+    },
+    {
+      id: 'l04', n: 4, title: 'Newton’s Laws of Motion', durationMin: 50, chunkRef: '8.01SC · L04 · seg 09',
+      objectives: ['State the three laws', 'Identify action–reaction pairs', 'Build free-body diagrams'],
+      concepts: ['force', 'inertia', 'Newton’s first law', 'Newton’s second law', 'Newton’s third law', 'free-body diagram', 'net force'],
+      transcript:
+        'Newton’s first law says an object stays at rest, or moves at constant velocity, unless a net force acts on it — this is inertia. The second law makes it quantitative: the net force equals mass times acceleration, F equals m a. The third law says that if body A pushes on body B, then B pushes back on A with equal magnitude and opposite direction. These action–reaction forces act on different objects, which is why they never cancel.',
+    },
+    {
+      id: 'l05', n: 5, title: 'Uniform Circular Motion', durationMin: 50, chunkRef: '8.01SC · L05 · seg 04',
+      objectives: ['Explain centripetal acceleration', 'Relate speed, radius and period', 'Identify the force providing the centripetal pull'],
+      concepts: ['circular motion', 'centripetal acceleration', 'centripetal force', 'period', 'angular velocity'],
+      transcript:
+        'An object moving in a circle at constant speed is still accelerating, because the direction of its velocity is always changing. That acceleration points toward the center of the circle and is called centripetal acceleration; its magnitude is v squared divided by r. There is no such thing as centrifugal force pushing you outward — what you feel is your own inertia, and some real force, such as tension or friction, must point inward to keep you on the circular path.',
+    },
+  ],
+  assessment: [
+    {
+      id: 'a1', concept: 'acceleration', q: 'A ball is thrown straight up. At the highest point of its flight, what is true?',
+      options: ['Velocity and acceleration are both zero', 'Velocity is zero, acceleration is 9.8 m/s² downward', 'Velocity is maximum, acceleration is zero', 'Both point upward'],
+      answer: 1, explain: 'At the top the ball is momentarily at rest (v = 0) but gravity never stops — acceleration is 9.8 m/s² downward throughout (Lecture 2).',
+    },
+    {
+      id: 'a2', concept: 'projectile motion', q: 'A bullet fired horizontally and a bullet dropped from the same height — which lands first?',
+      options: ['The fired bullet', 'The dropped bullet', 'They land at the same time', 'Depends on the muzzle speed'],
+      answer: 2, explain: 'Horizontal and vertical motion are independent; both have the same vertical drop under gravity, so they land together (Lecture 3).',
+    },
+    {
+      id: 'a3', concept: 'Newton’s third law', q: 'Why do action–reaction force pairs never cancel each other out?',
+      options: ['They are unequal', 'They act on different objects', 'One is always larger', 'They act at different times'],
+      answer: 1, explain: 'Newton’s third-law pairs are equal and opposite but act on different bodies, so they can’t cancel on a single object (Lecture 4).',
+    },
+    {
+      id: 'a4', concept: 'centripetal force', q: 'What keeps an object moving in a circle at constant speed?',
+      options: ['An outward centrifugal force', 'No force — it moves freely', 'A net force directed toward the center', 'Its own momentum only'],
+      answer: 2, explain: 'A centripetal (center-pointing) net force is required; “centrifugal force” is just felt inertia, not a real inward force (Lecture 5).',
+    },
+  ],
+};
+
+export const courses: Course[] = [PHYSICS_801];
+
+// Resolve a course by id; unknown ids fall back to the flagship exemplar (so any
+// explorer link lands on a real, tutor-ready course while the rest are authored).
+export function getCourse(id: string): Course {
+  return courses.find((c) => c.id === id) ?? PHYSICS_801;
+}

--- a/apps/socioprophet-web/src/main.ts
+++ b/apps/socioprophet-web/src/main.ts
@@ -38,6 +38,7 @@ import NoeticaControlPlane from './pages/NoeticaControlPlane.vue';
 import DomainSurfacePage from './pages/DomainSurfacePage.vue';
 import AcademyOverview from './pages/AcademyOverview.vue';
 import DegreeExplorer from './pages/DegreeExplorer.vue';
+import CourseView from './pages/CourseView.vue';
 import FeedPage from './pages/FeedPage.vue';
 import Journal from './pages/Journal.vue';
 import MapPage from './pages/MapPage.vue';
@@ -77,6 +78,8 @@ const explicitRoutes = [
   { path: '/academy', component: AcademyOverview },
   { path: '/academy/homeschool', component: DegreeExplorer },
   { path: '/academy/degrees', component: DegreeExplorer },
+  { path: '/academy/course/:id', component: CourseView },
+  { path: '/academy/tutor', component: CourseView },
   { path: '/agentic-os', component: AgenticOS },
   { path: '/marketplace', component: Marketplace },
   { path: '/people/labor-market', component: LaborMarket },

--- a/apps/socioprophet-web/src/pages/CourseView.vue
+++ b/apps/socioprophet-web/src/pages/CourseView.vue
@@ -1,0 +1,161 @@
+<template>
+  <section class="cvw" aria-label="Course">
+    <SurfaceHeader :title="course.title" :eyebrow="`Academy · ${course.program}`">
+      <template #badge><span class="cvw-pill">{{ course.code }} · {{ course.license }}</span></template>
+    </SurfaceHeader>
+
+    <div class="cvw-body">
+      <!-- Lessons rail -->
+      <aside class="cvw-rail" aria-label="Lessons">
+        <div class="cvw-rail-h">{{ course.teacher }} · {{ course.lessons.length }} lectures</div>
+        <button v-for="l in course.lessons" :key="l.id" class="cvw-lrow" :class="{ on: l.id === selectedId && tab === 'lesson' }" @click="openLesson(l.id)">
+          <span class="cvw-ln">{{ l.n }}</span>
+          <span class="cvw-lt"><b>{{ l.title }}</b><small>{{ l.durationMin }} min</small></span>
+        </button>
+        <button class="cvw-lrow quiz" :class="{ on: tab === 'quiz' }" @click="tab = 'quiz'">
+          <span class="cvw-ln">✓</span>
+          <span class="cvw-lt"><b>Mastery check</b><small>board · {{ course.assessment.length }} items</small></span>
+        </button>
+      </aside>
+
+      <!-- Main: lesson OR mastery check -->
+      <div class="cvw-main">
+        <template v-if="tab === 'lesson' && lesson">
+          <div class="cvw-lesson-h">Lecture {{ lesson.n }} · <span>{{ lesson.chunkRef }}</span></div>
+          <h2 class="cvw-lesson-title">{{ lesson.title }}</h2>
+          <div class="cvw-obj">
+            <div class="cvw-obj-h">You'll be able to</div>
+            <ul><li v-for="o in lesson.objectives" :key="o">{{ o }}</li></ul>
+          </div>
+          <p class="cvw-transcript" ref="transcriptEl">{{ lesson.transcript }}</p>
+          <div class="cvw-concepts">
+            <span v-for="c in lesson.concepts" :key="c" class="cvw-concept">{{ c }}</span>
+          </div>
+          <p class="cvw-src">Captured from {{ course.source }} · {{ course.license }} · quoted verbatim by the tutor, never paraphrased.</p>
+        </template>
+
+        <template v-else-if="tab === 'quiz'">
+          <div class="cvw-lesson-h">Mastery check <span>board engine · deterministic scoring</span></div>
+          <div class="cvw-score" :class="{ done: answered === course.assessment.length }">
+            <b>{{ correct }}</b> / {{ course.assessment.length }} correct
+            <span v-if="answered < course.assessment.length">· {{ course.assessment.length - answered }} to go</span>
+            <span v-else class="cvw-score-tag">{{ correct === course.assessment.length ? 'mastered' : 'keep going' }}</span>
+          </div>
+          <div v-for="item in course.assessment" :key="item.id" class="cvw-q">
+            <div class="cvw-q-text">{{ item.q }}</div>
+            <div class="cvw-opts">
+              <button
+                v-for="(opt, i) in item.options" :key="i"
+                class="cvw-opt"
+                :class="optClass(item, i)"
+                :disabled="picks[item.id] !== undefined"
+                @click="pick(item.id, i)"
+              >
+                <span class="cvw-opt-mark">{{ optMark(item, i) }}</span>{{ opt }}
+              </button>
+            </div>
+            <div v-if="picks[item.id] !== undefined" class="cvw-explain" :class="{ ok: picks[item.id] === item.answer }">
+              {{ picks[item.id] === item.answer ? '✓ ' : '✗ ' }}{{ item.explain }}
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <!-- Grounded tutor -->
+      <aside class="cvw-tutor" aria-label="Tutor">
+        <GroundedTutor :course="course" @jump="openLesson" />
+      </aside>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, nextTick } from 'vue';
+import { useRoute } from 'vue-router';
+import SurfaceHeader from '../components/SurfaceHeader.vue';
+import GroundedTutor from '../components/GroundedTutor.vue';
+import { useCockpit } from '../stores/cockpit';
+import { getCourse, type AssessmentItem } from '../data/courseFixture';
+
+const route = useRoute();
+const cockpit = useCockpit();
+const course = computed(() => getCourse(typeof route.params.id === 'string' ? route.params.id : ''));
+
+const tab = ref<'lesson' | 'quiz'>('lesson');
+const selectedId = ref<string>(course.value.lessons[0]?.id ?? '');
+const lesson = computed(() => course.value.lessons.find((l) => l.id === selectedId.value));
+const transcriptEl = ref<HTMLElement | null>(null);
+
+function openLesson(id: string) {
+  selectedId.value = id;
+  tab.value = 'lesson';
+  nextTick(() => transcriptEl.value?.scrollIntoView({ block: 'nearest', behavior: 'smooth' }));
+}
+
+// Mastery check state
+const picks = ref<Record<string, number>>({});
+function pick(itemId: string, i: number) { if (picks.value[itemId] === undefined) picks.value = { ...picks.value, [itemId]: i }; }
+const answered = computed(() => Object.keys(picks.value).length);
+const correct = computed(() => course.value.assessment.filter((it) => picks.value[it.id] === it.answer).length);
+function optClass(item: AssessmentItem, i: number) {
+  const p = picks.value[item.id];
+  if (p === undefined) return '';
+  if (i === item.answer) return 'correct';
+  if (i === p) return 'wrong';
+  return 'muted';
+}
+function optMark(item: AssessmentItem, i: number): string {
+  const p = picks.value[item.id];
+  if (p === undefined) return '○';
+  if (i === item.answer) return '✓';
+  if (i === p) return '✗';
+  return '○';
+}
+
+watch(course, (c) => { selectedId.value = c.lessons[0]?.id ?? ''; tab.value = 'lesson'; picks.value = {}; });
+watch([() => route.path, tab, selectedId], () => {
+  cockpit.setContext({ surface: 'Academy · Course', entityLabel: course.value.title, detail: tab.value === 'quiz' ? 'mastery check' : (lesson.value?.title ?? ''), route: route.path });
+}, { immediate: true });
+onMounted(() => { if (route.path.endsWith('/tutor')) { /* land on flagship with tutor visible */ } });
+</script>
+
+<style scoped>
+.cvw { height: 100%; min-height: 0; display: grid; grid-template-rows: auto 1fr; gap: 0.75rem; padding: 0.85rem 1rem 1rem; background: var(--bg); color: var(--text); }
+.cvw-pill { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--up); background: rgba(63,185,80,0.14); border-radius: 5px; padding: 0.1rem 0.4rem; }
+.cvw-body { min-height: 0; display: grid; grid-template-columns: 220px minmax(360px, 1.5fr) minmax(300px, 1fr); gap: 0.75rem; }
+@media (max-width: 1100px) { .cvw-body { grid-template-columns: 190px 1fr; } .cvw-tutor { display: none; } }
+
+.cvw-rail { min-height: 0; overflow-y: auto; border: 1px solid var(--line-2); border-radius: 12px; padding: 0.3rem; display: flex; flex-direction: column; gap: 0.15rem; }
+.cvw-rail-h { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); padding: 0.4rem 0.5rem; }
+.cvw-lrow { display: flex; align-items: center; gap: 0.55rem; border: none; background: transparent; color: inherit; border-radius: 8px; padding: 0.45rem 0.5rem; cursor: pointer; text-align: left; } .cvw-lrow:hover { background: rgba(255,255,255,0.03); } .cvw-lrow.on { background: color-mix(in srgb, var(--accent) 10%, transparent); box-shadow: inset 2px 0 0 var(--accent); }
+.cvw-lrow.quiz { margin-top: 0.3rem; border-top: 1px solid var(--line); border-radius: 0 0 8px 8px; padding-top: 0.55rem; }
+.cvw-ln { width: 1.5rem; height: 1.5rem; flex: 0 0 auto; display: grid; place-items: center; border-radius: 50%; border: 1px solid var(--line-2); font-size: 0.72rem; color: var(--text-3); }
+.cvw-lrow.on .cvw-ln { border-color: var(--accent); color: var(--accent); }
+.cvw-lt { display: flex; flex-direction: column; min-width: 0; } .cvw-lt b { font-size: 0.8rem; font-weight: 600; } .cvw-lt small { font-size: 0.64rem; color: var(--text-3); }
+
+.cvw-main { min-height: 0; overflow-y: auto; border: 1px solid var(--line-2); border-radius: 12px; padding: 1rem 1.1rem 1.2rem; }
+.cvw-lesson-h { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-3); } .cvw-lesson-h span { font-family: ui-monospace, monospace; color: var(--text-3); text-transform: none; letter-spacing: 0; }
+.cvw-lesson-title { margin: 0.3rem 0 0.7rem; font-size: 1.35rem; }
+.cvw-obj { border: 1px solid var(--line-2); border-radius: 10px; padding: 0.55rem 0.75rem; background: var(--surface); margin-bottom: 0.8rem; }
+.cvw-obj-h { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); margin-bottom: 0.25rem; }
+.cvw-obj ul { margin: 0; padding-left: 1.1rem; } .cvw-obj li { font-size: 0.82rem; color: var(--text-2); line-height: 1.6; }
+.cvw-transcript { font-size: 0.95rem; line-height: 1.7; color: var(--text); margin: 0 0 0.8rem; }
+.cvw-concepts { display: flex; flex-wrap: wrap; gap: 0.35rem; margin-bottom: 0.8rem; }
+.cvw-concept { font-size: 0.68rem; color: var(--text-2); border: 1px solid var(--line-2); border-radius: 999px; padding: 0.08rem 0.5rem; }
+.cvw-src { font-size: 0.7rem; color: var(--text-3); border-top: 1px solid var(--line); padding-top: 0.7rem; }
+
+.cvw-score { font-size: 0.95rem; color: var(--text-2); margin: 0.5rem 0 0.9rem; } .cvw-score b { font-size: 1.4rem; color: var(--text); font-variant-numeric: tabular-nums; }
+.cvw-score-tag { margin-left: 0.5rem; font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 700; color: var(--up); background: rgba(63,185,80,0.14); border-radius: 4px; padding: 0.08rem 0.4rem; }
+.cvw-score.done b { color: #86efac; }
+.cvw-q { border-top: 1px solid var(--line); padding: 0.75rem 0; }
+.cvw-q-text { font-size: 0.88rem; font-weight: 600; margin-bottom: 0.5rem; }
+.cvw-opts { display: flex; flex-direction: column; gap: 0.35rem; }
+.cvw-opt { display: flex; align-items: center; gap: 0.5rem; text-align: left; border: 1px solid var(--line-2); background: var(--surface); color: var(--text-2); border-radius: 8px; padding: 0.45rem 0.6rem; font-size: 0.82rem; cursor: pointer; } .cvw-opt:hover:not(:disabled) { border-color: var(--accent); } .cvw-opt:disabled { cursor: default; }
+.cvw-opt-mark { flex: 0 0 auto; color: var(--text-3); }
+.cvw-opt.correct { border-color: rgba(63,185,80,0.5); background: rgba(63,185,80,0.08); color: #86efac; } .cvw-opt.correct .cvw-opt-mark { color: var(--up); }
+.cvw-opt.wrong { border-color: rgba(248,81,73,0.5); background: rgba(248,81,73,0.08); color: #fca5a5; } .cvw-opt.wrong .cvw-opt-mark { color: var(--down); }
+.cvw-opt.muted { opacity: 0.5; }
+.cvw-explain { margin-top: 0.4rem; font-size: 0.76rem; line-height: 1.5; color: var(--text-3); } .cvw-explain.ok { color: #86efac; }
+
+.cvw-tutor { min-height: 0; overflow-y: auto; }
+</style>


### PR DESCRIPTION
## The moat, made visible
The depth-of-one that no competitor can show: **MIT 8.01 (Walter Lewin)** as a full loop — **lecture stream → grounded tutor → mastery check**.

## What
- **`courseFixture.ts`** — 8.01 with 5 authored lectures (units, 1D kinematics, projectile motion, Newton's laws, circular motion), each a captured transcript segment with a `chunkRef`, objectives, and concepts; plus a 4-item board assessment with explanations. Shaped like real captured-chunk retrieval → tutor backend is a later swap.
- **`GroundedTutor.vue`** — **extractive** QA: scores lectures by concept/title/body overlap, extracts the single most relevant sentence, and **quotes it with a citation** to `Lecture N · chunkRef` (click → jumps to the lecture). **It cannot hallucinate** — it quotes captured content, never generates. No-match → honest *"I answer only from the captured lectures"* with topic suggestions. The **anti-Chegg**.
- **`CourseView.vue`** — lectures rail │ lesson (objectives + transcript + concepts) │ tutor; a **Mastery check** tab = the board engine (deterministic scoring, per-item explanations, live score). At `/academy/course/:id` and `/academy/tutor`.

## Why it's the moat
Every claim the tutor makes is **quoted and cited to a real lecture segment** — the one thing Chegg (ungrounded answer-mill), Coursera (auto-grader, no tutor), and ChatGPT-as-tutor (hallucinates) structurally cannot do. Grounded tutor + verified mastery check over a real degree, all open.

## Next
Wire the tutor's retrieval to the live captured chunks (search-orchestrator academy ingest) and the mastery check to the real board engine — a backend swap, the surface stays.

## Verify
`vue-tsc --noEmit` clean · `npm run build` clean.