### PR TITLE
cockpit(academy): wire grounded tutor to live retrieval — local + cloud, both ways

### DIFF
--- a/apps/socioprophet-web/nginx.conf
+++ b/apps/socioprophet-web/nginx.conf
@@ -79,6 +79,8 @@ http {
         location /svc/algo/      { set $u algo-engine.socioprophet.svc.cluster.local;       rewrite ^/svc/algo/(.*)$      /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
         location /svc/ie/        { set $u ie-engine.socioprophet.svc.cluster.local;         rewrite ^/svc/ie/(.*)$        /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
         location /svc/sherlock/  { set $u sherlock-engine.socioprophet.svc.cluster.local;   rewrite ^/svc/sherlock/(.*)$  /$1 break; proxy_pass http://$u:8093; proxy_http_version 1.1; proxy_set_header Host $host; }
+        # Academy retrieval → search-orchestrator (POST /v0/search/query fans in the captured academy chunks).
+        location /svc/search/    { set $u search-orchestrator.socioprophet.svc.cluster.local; rewrite ^/svc/search/(.*)$   /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
         # Studio API → lattice-studio (Notebooks, Compute Plane, Governance, Commons, Experiments,
         # FAIR/cite/versions/receipts). The client sets VITE_STUDIO_API=/svc/studio (see .env.production),
         # so studioApi requests /svc/studio/api/studio/* — the rewrite strips /svc/studio and lattice-studio

--- a/apps/socioprophet-web/src/components/GroundedTutor.vue
+++ b/apps/socioprophet-web/src/components/GroundedTutor.vue
@@ -8,26 +8,42 @@
 
     <form class="gt-ask" @submit.prevent="ask">
       <input v-model="qText" class="gt-input" type="text" placeholder="e.g. why doesn't a ball fall faster if you throw it sideways?" aria-label="Ask the tutor" />
-      <button class="gt-go" type="submit" :disabled="!qText.trim()">Ask</button>
+      <button class="gt-go" type="submit" :disabled="!qText.trim() || loading">Ask</button>
     </form>
 
-    <div v-if="!answer" class="gt-seeds">
+    <!-- Engine switch — the local+cloud seam: Auto tries cloud academy ingest → local Noetica → Commons. -->
+    <div class="gt-src" role="group" aria-label="Retrieval engine">
+      <span class="gt-src-h">engine</span>
+      <button v-for="s in SOURCES" :key="s.v" type="button" class="gt-src-btn" :class="{ on: source === s.v }" @click="source = s.v">{{ s.label }}</button>
+    </div>
+
+    <div v-if="loading" class="gt-loading"><span class="gt-load-dot" /> grounding…</div>
+
+    <div v-else-if="!answer" class="gt-seeds">
       <span class="gt-seeds-h">try:</span>
       <button v-for="s in SEEDS" :key="s" class="gt-seed" @click="qText = s; ask()">{{ s }}</button>
     </div>
 
-    <div v-if="answer" class="gt-answer" :class="{ nomatch: !answer.cited }">
+    <div v-else class="gt-answer" :class="{ nomatch: !answer.cited }">
       <template v-if="answer.cited">
         <p class="gt-persona-line">{{ answer.intro }}</p>
         <blockquote class="gt-quote">“{{ answer.quote }}”</blockquote>
-        <button class="gt-cite" @click="$emit('jump', answer.lessonId)">
+        <!-- Commons: jump to the in-app lecture. Cloud/local with a URL: open it. Else: static ref. -->
+        <button v-if="answer.lessonId" class="gt-cite" @click="$emit('jump', answer.lessonId)">
           <span class="gt-cite-g">◆</span>
           <span>Lecture {{ answer.lessonN }} · {{ answer.title }}</span>
           <code>{{ answer.chunkRef }}</code>
           <span class="gt-cite-open">open →</span>
         </button>
+        <a v-else-if="answer.uri" class="gt-cite" :href="answer.uri" target="_blank" rel="noreferrer">
+          <span class="gt-cite-g">◆</span><span>{{ answer.title }}</span><code>{{ answer.chunkRef }}</code><span class="gt-cite-open">open ↗</span>
+        </a>
+        <div v-else class="gt-cite static">
+          <span class="gt-cite-g">◆</span><span>{{ answer.title }}</span><code>{{ answer.chunkRef }}</code>
+        </div>
         <div class="gt-prov">
           <span class="gt-prov-tag">extractive · quoted, not generated</span>
+          <span class="gt-origin" :class="answer.origin" :title="originMeta[answer.origin].label">{{ originMeta[answer.origin].glyph }} {{ originMeta[answer.origin].label }}</span>
           <span v-if="answer.concepts.length" class="gt-prov-concepts">on {{ answer.concepts.join(', ') }}</span>
         </div>
       </template>
@@ -41,6 +57,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import type { Course } from '../data/courseFixture';
+import { retrievePassages, ORIGIN_META, type AcademySource, type PassageOrigin } from '../services/academyApi';
 
 const props = defineProps<{ course: Course }>();
 defineEmits<{ (e: 'jump', lessonId: string): void }>();
@@ -62,16 +79,29 @@ const topConcepts = computed(() => {
   return [...new Set(all)].slice(0, 5);
 });
 
-interface Answer { cited: boolean; intro: string; quote: string; lessonId: string; lessonN: number; title: string; chunkRef: string; concepts: string[] }
+interface Answer { cited: boolean; intro: string; quote: string; lessonId: string; lessonN: number; title: string; chunkRef: string; concepts: string[]; origin: PassageOrigin; uri?: string }
 const answer = ref<Answer | null>(null);
+const loading = ref(false);
+const source = ref<AcademySource>('auto');
+const SOURCES: { v: AcademySource; label: string }[] = [
+  { v: 'auto', label: 'Auto' }, { v: 'cloud', label: 'Cloud' }, { v: 'local', label: 'Local' }, { v: 'fixture', label: 'Commons' },
+];
+const originMeta = ORIGIN_META;
 
-function ask() {
-  const query = qText.value.trim();
-  if (!query) return;
-  const qt = tokens(query);
-  if (qt.length === 0) { answer.value = { cited: false } as Answer; return; }
+// Pick the single most query-relevant sentence from a passage (tightest quote).
+function sentenceOf(text: string, qt: string[]): string {
+  const sentences = text.split(/(?<=[.!?])\s+/).filter((s) => s.trim().length > 0);
+  let best = sentences[0] ?? text; let sc = -1;
+  for (const s of sentences) {
+    const st = new Set(tokens(s));
+    const overlap = qt.reduce((n, t) => n + (st.has(t) ? 1 : 0), 0);
+    if (overlap > sc) { sc = overlap; best = s; }
+  }
+  return best.trim();
+}
 
-  // Score each lesson: concept hits weigh most, then title, then transcript.
+// Commons grounding — extractive over the in-app captured transcripts (the guaranteed fallback).
+function fixtureAnswer(qt: string[]): Answer {
   let best: { lesson: typeof props.course.lessons[number]; score: number } | null = null;
   for (const lesson of props.course.lessons) {
     const conceptToks = new Set(lesson.concepts.flatMap(tokens));
@@ -85,30 +115,47 @@ function ask() {
     }
     if (!best || score > best.score) best = { lesson, score };
   }
-
-  if (!best || best.score === 0) { answer.value = { cited: false } as Answer; return; }
-
-  // Extract the single most relevant sentence from the winning transcript.
-  const sentences = best.lesson.transcript.split(/(?<=[.!?])\s+/).filter((s) => s.trim().length > 0);
-  let bestSentence = sentences[0] ?? best.lesson.transcript;
-  let sScore = -1;
-  for (const s of sentences) {
-    const st = new Set(tokens(s));
-    const overlap = qt.reduce((n, t) => n + (st.has(t) ? 1 : 0), 0);
-    if (overlap > sScore) { sScore = overlap; bestSentence = s; }
+  if (!best || best.score === 0) {
+    return { cited: false, intro: '', quote: '', lessonId: '', lessonN: 0, title: '', chunkRef: '', concepts: [], origin: 'fixture' };
   }
   const hitConcepts = best.lesson.concepts.filter((c) => tokens(c).some((t) => qt.includes(t)));
-
-  answer.value = {
+  return {
     cited: true,
     intro: `Here's what ${props.course.teacher} says on this:`,
-    quote: bestSentence.trim(),
-    lessonId: best.lesson.id,
-    lessonN: best.lesson.n,
-    title: best.lesson.title,
-    chunkRef: best.lesson.chunkRef,
+    quote: sentenceOf(best.lesson.transcript, qt),
+    lessonId: best.lesson.id, lessonN: best.lesson.n, title: best.lesson.title, chunkRef: best.lesson.chunkRef,
     concepts: hitConcepts.length ? hitConcepts : best.lesson.concepts.slice(0, 2),
+    origin: 'fixture',
   };
+}
+
+async function ask() {
+  const query = qText.value.trim();
+  if (!query) return;
+  const qt = tokens(query);
+  if (qt.length === 0) { answer.value = fixtureAnswer(qt); return; }
+  loading.value = true;
+  try {
+    // Try the live engine(s) first (cloud academy ingest / local Noetica), unless Commons is forced.
+    if (source.value !== 'fixture') {
+      const { passages, origin } = await retrievePassages(query, source.value);
+      if (passages.length) {
+        const top = passages[0]!;
+        answer.value = {
+          cited: true,
+          intro: `From the ${originMeta[origin].label}:`,
+          quote: sentenceOf(top.text, qt) || top.text,
+          lessonId: '', lessonN: 0, title: top.title, chunkRef: top.chunkRef, concepts: [],
+          origin, uri: top.uri,
+        };
+        return;
+      }
+    }
+    // Nothing live (or Commons forced) → extractive over the captured transcripts.
+    answer.value = fixtureAnswer(qt);
+  } finally {
+    loading.value = false;
+  }
 }
 </script>
 
@@ -135,4 +182,18 @@ function ask() {
 .gt-prov-tag { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 700; color: var(--up); background: rgba(63,185,80,0.12); border: 1px solid rgba(63,185,80,0.35); border-radius: 4px; padding: 0.05rem 0.4rem; }
 .gt-prov-concepts { font-size: 0.68rem; color: var(--text-3); }
 .gt-nomatch { margin: 0; font-size: 0.8rem; color: var(--text-2); line-height: 1.55; } .gt-nomatch b { color: var(--text); }
+
+/* Engine switch (local + cloud seam) */
+.gt-src { display: flex; align-items: center; gap: 0.3rem; }
+.gt-src-h { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); margin-right: 0.15rem; }
+.gt-src-btn { border: 1px solid var(--line-2); background: transparent; color: var(--text-3); border-radius: 6px; padding: 0.14rem 0.5rem; font-size: 0.68rem; cursor: pointer; } .gt-src-btn.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft, rgba(120,160,255,0.12)); }
+.gt-loading { display: flex; align-items: center; gap: 0.4rem; font-size: 0.76rem; color: var(--text-3); padding: 0.3rem 0; }
+.gt-load-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); animation: gtPulse 0.9s ease-in-out infinite; }
+@keyframes gtPulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+@media (prefers-reduced-motion: reduce) { .gt-load-dot { animation: none; } }
+.gt-cite.static { cursor: default; }
+.gt-origin { display: inline-flex; align-items: center; gap: 0.25rem; font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 700; border-radius: 4px; padding: 0.05rem 0.4rem; border: 1px solid var(--line-2); color: var(--text-3); }
+.gt-origin.cloud { color: #58a6ff; border-color: rgba(88,166,255,0.4); }
+.gt-origin.local { color: #6ee7b7; border-color: rgba(63,185,80,0.4); }
+.gt-origin.fixture { color: var(--text-3); }
 </style>

--- a/apps/socioprophet-web/src/services/academyApi.ts
+++ b/apps/socioprophet-web/src/services/academyApi.ts
@@ -1,0 +1,95 @@
+// Academy retrieval — the tutor's grounding backend, abstracted over BOTH offerings:
+//   • cloud  → search-orchestrator (POST /v0/search/query), the deployed academy ingest over the
+//              captured Commons chunks.
+//   • local  → on-device Noetica (agent-machine :8080), which is building the same academy path —
+//              so the cockpit tutor can ground against the user's LOCAL corpus too.
+//   • fixture→ the in-app course transcripts (the guaranteed offline fallback).
+//
+// This is the "integrate both ways" seam: one tutor, either engine, same cited-passage contract.
+// 'auto' tries cloud then local then falls back to fixture — always best-effort, never breaks.
+import { resolveBase } from '../config/cockpitRuntime';
+
+export type AcademySource = 'auto' | 'cloud' | 'local' | 'fixture';
+export type PassageOrigin = 'cloud' | 'local' | 'fixture';
+
+export interface TutorPassage {
+  text: string;
+  title: string;
+  chunkRef: string;
+  score: number;
+  origin: PassageOrigin;
+  uri?: string;
+}
+export interface RetrieveResult { passages: TutorPassage[]; origin: PassageOrigin }
+
+const CLOUD = resolveBase('search', 'VITE_SEARCH_BASE', '/svc/search');
+// On-device Noetica — the SAME base the cockpit already uses for the sovereign agent-machine.
+const LOCAL = resolveBase('agentMachine', 'VITE_AGENT_MACHINE', 'http://127.0.0.1:8080');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isAcademy(r: any): boolean {
+  return /academy|learning|course|lecture|ocw/i.test(String(r?.source ?? r?.entity_type ?? ''));
+}
+
+// Cloud: search-orchestrator fans academy records into /v0/search/query.
+async function cloudRetrieve(query: string, limit: number): Promise<TutorPassage[]> {
+  const body = { query_id: `tutor-${Date.now()}`, actor_id: 'cockpit-tutor', text: query, mode: 'academy', limit };
+  const res = await fetch(`${CLOUD}/v0/search/query`, {
+    method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`search ${res.status}`);
+  const d = (await res.json()) as { results?: unknown[] };
+  return (d.results ?? [])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .filter((r: any) => isAcademy(r))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((r: any) => ({
+      text: String(r.snippet ?? r.title ?? ''),
+      title: String(r.title ?? 'Lecture'),
+      chunkRef: String(r.path_or_uri ?? r.result_id ?? r.object_id ?? ''),
+      score: Number(r.score?.final ?? 0),
+      origin: 'cloud' as const,
+      uri: typeof r.path_or_uri === 'string' && /^https?:/.test(r.path_or_uri) ? r.path_or_uri : undefined,
+    }))
+    .filter((p: TutorPassage) => p.text.length > 0);
+}
+
+// Local: on-device Noetica. Contract mirrors the cloud shape; when Noetica exposes its academy
+// retrieval this lights up with the user's local corpus. Best-effort — fails closed.
+async function localRetrieve(query: string, limit: number): Promise<TutorPassage[]> {
+  const res = await fetch(`${LOCAL}/api/academy/retrieve`, {
+    method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ text: query, limit }),
+  });
+  if (!res.ok) throw new Error(`noetica ${res.status}`);
+  const d = (await res.json()) as { passages?: unknown[] };
+  return (d.passages ?? [])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((p: any) => ({
+      text: String(p.text ?? p.snippet ?? ''),
+      title: String(p.title ?? 'Lecture'),
+      chunkRef: String(p.chunkRef ?? p.ref ?? ''),
+      score: Number(p.score ?? 0),
+      origin: 'local' as const,
+    }))
+    .filter((p: TutorPassage) => p.text.length > 0);
+}
+
+export async function retrievePassages(query: string, source: AcademySource = 'auto', limit = 4): Promise<RetrieveResult> {
+  const order: PassageOrigin[] = source === 'cloud' ? ['cloud']
+    : source === 'local' ? ['local']
+    : source === 'fixture' ? []
+    : ['cloud', 'local'];
+  for (const o of order) {
+    try {
+      const passages = o === 'cloud' ? await cloudRetrieve(query, limit) : await localRetrieve(query, limit);
+      if (passages.length) return { passages: passages.sort((a, b) => b.score - a.score), origin: o };
+    } catch { /* try the next provider, then fixture */ }
+  }
+  return { passages: [], origin: 'fixture' };
+}
+
+export const ORIGIN_META: Record<PassageOrigin, { glyph: string; label: string }> = {
+  cloud: { glyph: '☁', label: 'cloud · academy ingest' },
+  local: { glyph: '⌂', label: 'local · on-device Noetica' },
+  fixture: { glyph: '○', label: 'commons · captured transcript' },
+};

--- a/apps/socioprophet-web/vite.config.ts
+++ b/apps/socioprophet-web/vite.config.ts
@@ -77,6 +77,12 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/svc\/sherlock/, ''),
         },
+        // Academy retrieval — search-orchestrator (academy ingest over the captured Commons chunks).
+        '/svc/search': {
+          target: env.VITE_SEARCH_BASE || 'http://localhost:8080',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/search/, ''),
+        },
         // Same-origin proxy to the live Prophet Mesh (mesh.socioprophet.ai has no CORS).
         '/mesh': {
           target: env.VITE_MESH_BASE || 'https://mesh.socioprophet.ai',


### PR DESCRIPTION
## Why
The grounded tutor was extractive over the in-app fixture only. This wires it to **live retrieval** and builds in the **local+cloud duality** — Noetica is moving along the same academy path, so the tutor grounds against **either engine**, same contract.

## The provider seam
`academyApi.ts` · `retrievePassages(query, source)` over three providers:
| source | engine |
|---|---|
| **cloud** | `search-orchestrator` `POST /v0/search/query` — the deployed academy ingest over the captured Commons chunks |
| **local** | on-device **Noetica** (agent-machine :8080), the same base the cockpit already uses — grounds on the **user's local corpus** |
| **fixture** | in-app transcripts — the guaranteed offline fallback |

`auto` tries **cloud → local → fixture**; every path is best-effort and never breaks.

## Tutor UX
- An **engine switch** (Auto / Cloud / Local / Commons).
- An **origin chip** on every citation (☁ cloud · ⌂ local Noetica · ○ commons) — which engine answered is always visible.
- Still **extractive** — quotes the retrieved passage, never generates. The answer contract is identical across engines, so **local and cloud integrate both ways**.

## Proxies
`/svc/search` → `search-orchestrator:8080` (vite dev + prod nginx). Until the nginx roll lands, cloud 405s and the tutor falls back to Commons — **verified graceful**.

## Verify
`vue-tsc --noEmit` clean · `npm run build` clean.