### PR TITLE
cockpit(news): broadsheet front page — kill the dead column, add masthead + lead + river

### DIFF
--- a/apps/socioprophet-web/src/pages/NewsFeed.vue
+++ b/apps/socioprophet-web/src/pages/NewsFeed.vue
@@ -31,7 +31,18 @@
       </div>
     </header>
 
-    <!-- Body: sources rail · story stream · reader -->
+    <!-- Masthead: flag · dateline · live tick · market ticker (broadsheet + Bloomberg data discipline) -->
+    <div v-if="mode !== 'calendar'" class="nf-masthead">
+      <div class="nf-flag">The SocioProphet</div>
+      <div class="nf-dateline">{{ dateline }}<span v-if="liveState === 'live'" class="nf-dl-live"> · updated {{ liveAgo }}</span></div>
+      <div class="nf-ticker" aria-label="Markets">
+        <span v-for="t in ticker" :key="t.symbol" class="nf-tk" :class="t.changePct >= 0 ? 'up' : 'down'">
+          <b>{{ t.symbol }}</b> {{ t.price }} <i>{{ t.changePct >= 0 ? '▲' : '▼' }}{{ Math.abs(t.changePct).toFixed(1) }}%</i>
+        </span>
+      </div>
+    </div>
+
+    <!-- Body: sources rail · front page · reader overlay -->
     <div class="nf-body">
       <!-- Feedly rail: subscribed sources -->
       <aside class="nf-rail" aria-label="Sources">
@@ -68,79 +79,58 @@
           </section>
         </template>
 
-        <!-- Story rows -->
+        <!-- Front page: a lead well + a multi-column river (broadsheet + BBG data discipline) -->
         <template v-else>
-          <!-- Twitter-style "N new" streamer — click to pull staged items in without yanking scroll -->
           <button v-if="pendingNew.length" class="nf-newpill" @click="showPending">
             <span class="nf-newpill-dot" /> {{ pendingNew.length }} new stor{{ pendingNew.length === 1 ? 'y' : 'ies' }} — show
           </button>
-          <article v-for="it in visibleItems" :key="it.id" class="nf-story" :class="{ on: it.id === selectedId, social: !!bskyOf(it), flash: flashIds.has(it.id) }" @click="select(it.id)">
-            <!-- Bluesky (ATProto) social card -->
-            <div v-if="bskyOf(it)" class="nf-bsky">
-              <div class="nf-bsky-av" aria-hidden="true">{{ initials(bskyOf(it)!.actor.displayName) }}</div>
-              <div class="nf-bsky-main">
-                <div class="nf-bsky-id">
-                  <span class="nf-bsky-name">{{ bskyOf(it)!.actor.displayName }}</span>
-                  <span class="nf-bsky-handle">@{{ bskyOf(it)!.actor.handle }}</span>
-                  <span class="nf-bsky-did" :title="bskyOf(it)!.actor.did">did ✓</span>
-                  <ReputationBadge :subject="bskyOf(it)!.actor.handle" />
-                  <span class="nf-time">· {{ relative(it.publishedAt) }}</span>
-                  <span v-if="it.membraneDecision !== 'admit'" class="nf-mem" :class="it.membraneDecision">{{ it.membraneDecision }}</span>
-                </div>
-                <p v-if="bskyOf(it)!.isReply" class="nf-bsky-reply">↳ reply in thread</p>
-                <p class="nf-bsky-text">{{ bskyOf(it)!.text }}</p>
-                <div class="nf-bsky-eng">
-                  <span class="nf-q" :class="metaOf(it).qualityBand" title="Truth rating">{{ Math.round(metaOf(it).quality * 100) }} truth</span>
-                  <span class="nf-bsky-rail" title="Mirror rail · lane">mirror → {{ bskyOf(it)!.lane }}</span>
-                  <span class="nf-eng-n" title="Replies">{{ bskyOf(it)!.replyCount }} replies</span>
-                  <span class="nf-eng-n" title="Shares">{{ bskyOf(it)!.repostCount }} shares</span>
-                  <span class="nf-eng-n" title="Signals">{{ bskyOf(it)!.likeCount }} signals</span>
-                </div>
-              </div>
-            </div>
 
-            <!-- Vote gutter — upvote only (content is never downvoted) -->
-            <div v-else class="nf-vote" @click.stop>
-              <button class="nf-up" :class="{ on: upvoted.has(it.id) }" :aria-pressed="upvoted.has(it.id)" title="Upvote" @click="toggleUp(it.id)">▲</button>
-              <span class="nf-score">{{ scoreOf(it) }}</span>
+          <!-- Lead well — the day's biggest story, broadsheet-scale. -->
+          <article v-if="lead" class="nf-lead" :class="{ on: lead.id === selectedId, flash: flashIds.has(lead.id), social: !!bskyOf(lead) }" @click="select(lead.id)">
+            <div class="nf-kicker">
+              <span class="nf-kick-src" :style="{ color: sourceColor(lead.sourceId) }">{{ bskyOf(lead) ? '@' + bskyOf(lead)!.actor.handle : sourceOf(lead)?.title }}</span>
+              <span class="nf-q" :class="metaOf(lead).qualityBand">{{ pct(metaOf(lead).quality) }} truth</span>
+              <span v-if="lead.membraneDecision !== 'admit'" class="nf-mem" :class="lead.membraneDecision">{{ lead.membraneDecision }}</span>
+              <span class="nf-time">{{ relative(lead.publishedAt) }}</span>
             </div>
-
-            <div v-if="!bskyOf(it)" class="nf-story-main">
-              <div class="nf-story-head">
-                <a class="nf-story-title" :href="it.canonicalUrl" target="_blank" rel="noreferrer" @click.stop>{{ it.title }}</a>
-                <span class="nf-domain">{{ domainOf(it.canonicalUrl) }}</span>
-              </div>
-              <div class="nf-story-meta">
-                <button v-for="t in metaOf(it).tags" :key="t" class="nf-tag" @click.stop="toggleTag(t)">{{ t }}</button>
-                <span class="nf-q" :class="metaOf(it).qualityBand" :title="`Truth rating · membrane ${it.membraneDecision}`">{{ Math.round(metaOf(it).quality * 100) }} truth</span>
-                <span v-if="it.membraneDecision !== 'admit'" class="nf-mem" :class="it.membraneDecision">{{ it.membraneDecision }}</span>
-              </div>
-              <div class="nf-story-by">
-                <span class="nf-src-tag" :style="{ color: sourceColor(it.sourceId) }">{{ sourceOf(it)?.title }}</span>
-                <span class="nf-time">{{ relative(it.publishedAt) }}</span>
-                <span class="nf-auth">by {{ metaOf(it).submitter }}<span v-if="metaOf(it).hat" class="nf-hat" :class="metaOf(it).hat!.kind">{{ metaOf(it).hat!.label }}</span></span>
-                <button class="nf-link" @click.stop="select(it.id)">{{ metaOf(it).comments }} comments</button>
-                <button class="nf-flag" :class="{ done: flags.has(it.id) }" title="Flag with a reason" @click.stop="openFlag = openFlag === it.id ? '' : it.id">
-                  {{ flags.has(it.id) ? `flagged: ${flags.get(it.id)}` : '⚑ flag' }}
-                </button>
-              </div>
-              <!-- flag = reason-required (stories are flagged, never downvoted) -->
-              <div v-if="openFlag === it.id" class="nf-reasons" @click.stop>
-                <button v-for="r in FLAG_REASONS" :key="r" @click="setFlag(it.id, r)">{{ r }}</button>
-              </div>
+            <h2 class="nf-lead-title">{{ bskyOf(lead) ? bskyOf(lead)!.text : lead.title }}</h2>
+            <p class="nf-lead-deck">{{ bskyOf(lead) ? bskyOf(lead)!.actor.displayName + (bskyOf(lead)!.actor.did ? ' · verified DID' : '') : lead.summary }}</p>
+            <div class="nf-lead-foot">
+              <span class="nf-auth">{{ bskyOf(lead) ? 'On Bluesky' : 'By ' + metaOf(lead).submitter }}</span>
+              <span class="nf-foot-sep">·</span>
+              <button class="nf-link" @click.stop="select(lead.id)">{{ metaOf(lead).comments }} comments</button>
             </div>
           </article>
 
-          <!-- Infinite-scroll sentinel + footer -->
-          <div ref="sentinelEl" class="nf-sentinel" aria-hidden="true"></div>
+          <!-- River — the multi-column broadsheet run, hairline column rules. -->
+          <div class="nf-river">
+            <article v-for="it in river" :key="it.id" class="nf-art" :class="{ on: it.id === selectedId, flash: flashIds.has(it.id), social: !!bskyOf(it) }" @click="select(it.id)">
+              <div class="nf-kicker">
+                <span class="nf-kick-src" :style="{ color: sourceColor(it.sourceId) }">{{ bskyOf(it) ? '@' + bskyOf(it)!.actor.handle : sourceOf(it)?.title }}</span>
+                <span class="nf-time">{{ relative(it.publishedAt) }}</span>
+              </div>
+              <h3 class="nf-art-title">{{ bskyOf(it) ? bskyOf(it)!.text : it.title }}</h3>
+              <p v-if="!bskyOf(it) && it.summary" class="nf-art-deck">{{ it.summary }}</p>
+              <div class="nf-art-meta">
+                <span class="nf-q sm" :class="metaOf(it).qualityBand" title="Truth rating">{{ pct(metaOf(it).quality) }}</span>
+                <span v-if="it.membraneDecision !== 'admit'" class="nf-mem" :class="it.membraneDecision">{{ it.membraneDecision }}</span>
+                <button v-for="t in metaOf(it).tags.slice(0, 2)" :key="t" class="nf-tag" @click.stop="toggleTag(t)">{{ t }}</button>
+              </div>
+            </article>
+            <div ref="sentinelEl" class="nf-sentinel" aria-hidden="true"></div>
+          </div>
+
           <div v-if="visibleCount < items.length" class="nf-more" @click="loadMore">Load more ({{ items.length - visibleCount }} more)</div>
           <div v-else-if="liveState === 'live'" class="nf-more streaming"><span class="nf-pulse-dot" /> streaming live — scroll for older stories</div>
           <div v-else-if="items.length" class="nf-more end">· end of feed · <button class="nf-more-live" @click="goLive">go live for more →</button></div>
         </template>
       </div>
 
-      <!-- Reader -->
-      <article v-if="selected" class="nf-reader" aria-label="Reader">
+      <!-- Reader — slide-over overlay (opens on click; the front page keeps full width). -->
+      <transition name="nf-slide">
+      <div v-if="selected" class="nf-reader-wrap">
+      <div class="nf-reader-scrim" @click="closeReader"></div>
+      <article class="nf-reader" aria-label="Reader">
         <div class="nf-reader-meta">
           <span class="nf-src-tag" :style="{ color: sourceColor(selected.sourceId) }">{{ sourceOf(selected)?.title }}</span>
           <span class="nf-time">{{ relative(selected.publishedAt) }}</span>
@@ -222,7 +212,8 @@
           </div>
         </div>
       </article>
-      <div v-else class="nf-reader empty">Select a story</div>
+      </div>
+      </transition>
     </div>
   </section>
 </template>
@@ -232,6 +223,7 @@ import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue';
 import { useRoute } from 'vue-router';
 import { navScopeForPath } from '../config/cockpitNav';
 import { newsSources, newsItems } from '../data/newsFeedFixture';
+import { instruments } from '../data/marketsFixture';
 import { blueskySources, blueskyItems, blueskyMeta, type BskyPost } from '../data/blueskyFixture';
 import { fetchBlueskyLive, BSKY_LIVE_SOURCE } from '../data/adapters/blueskyLive';
 import { fetchHackerNews, HN_LIVE_SOURCE } from '../data/adapters/newsLive';
@@ -441,11 +433,18 @@ const items = computed<FeedItem[]>(() => {
 });
 // Progressive slice shown in the stream (grown by the scroll sentinel).
 const visibleItems = computed<FeedItem[]>(() => items.value.slice(0, visibleCount.value));
+// Front-page split: a lead well + the multi-column river below it.
+const lead = computed<FeedItem | undefined>(() => (mode.value === 'calendar' ? undefined : visibleItems.value[0]));
+const river = computed<FeedItem[]>(() => (mode.value === 'calendar' ? [] : visibleItems.value.slice(1)));
+const ticker = instruments.slice(0, 9);
+const pct = (n: number) => Math.round(n * 100);
 // Reset the window when the filter set changes so you always see the top of the new list.
 watch([activeSourceId, activeTag, governedOnly, q, sort], () => { visibleCount.value = PAGE; });
 
-const readerClosed = ref(false);
-const selected = computed<FeedItem | undefined>(() => (readerClosed.value ? undefined : (all.value.find((i) => i.id === selectedId.value) ?? items.value[0])));
+// Reader is a slide-over overlay: closed by default (front page uses full width), opens on click.
+const readerClosed = ref(true);
+const selected = computed<FeedItem | undefined>(() => (readerClosed.value ? undefined : all.value.find((i) => i.id === selectedId.value)));
+function focus(id: string) { selectedId.value = id; }
 
 const sourceById = computed(() => new Map(sources.value.map((s) => [s.id, s])));
 const sourceOf = (it: FeedItem) => sourceById.value.get(it.sourceId);
@@ -500,6 +499,7 @@ function commentsFor(it: FeedItem): CommentVM[] {
 }
 
 const NOW = new Date('2026-07-03T14:00:00-04:00').getTime();
+const dateline = new Date(NOW).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
 function relative(iso: string): string {
   // When streaming, measure against the live reactive clock so times tick; otherwise
   // against the fixture's frozen "now" so the corpus reads consistently.
@@ -532,15 +532,18 @@ function onKey(e: KeyboardEvent) {
   const list = visibleItems.value;
   if (!list.length) return;
   const idx = list.findIndex((i) => i.id === selectedId.value);
-  if (e.key === 'j') { e.preventDefault(); const n = Math.min(list.length - 1, idx + 1); if (n === list.length - 1) void loadMore(); select(list[n]!.id); }
-  else if (e.key === 'k') { e.preventDefault(); select(list[Math.max(0, idx < 0 ? 0 : idx - 1)]!.id); }
-  else if (e.key === 'o' || e.key === 'Enter') { if (selected.value) window.open(selected.value.canonicalUrl, '_blank', 'noreferrer'); }
-  else if (e.key === 'u') { if (selected.value) toggleUp(selected.value.id); }
+  const cur = all.value.find((i) => i.id === selectedId.value);
+  if (e.key === 'j') { e.preventDefault(); const n = Math.min(list.length - 1, idx + 1); if (n === list.length - 1) void loadMore(); focus(list[n]!.id); }
+  else if (e.key === 'k') { e.preventDefault(); focus(list[Math.max(0, idx < 0 ? 0 : idx - 1)]!.id); }
+  else if (e.key === 'Enter') { e.preventDefault(); if (selectedId.value) select(selectedId.value); }
+  else if (e.key === 'o') { if (cur) window.open(cur.canonicalUrl, '_blank', 'noreferrer'); }
+  else if (e.key === 'u') { if (cur) toggleUp(cur.id); }
 }
 
-watch(selectedId, async () => { await nextTick(); listEl.value?.querySelector('.nf-story.on')?.scrollIntoView({ block: 'nearest' }); });
+watch(selectedId, async () => { await nextTick(); listEl.value?.querySelector('.nf-art.on, .nf-lead.on')?.scrollIntoView({ block: 'nearest' }); });
 watch(mode, (m) => { if (m === 'feed' && route.path.endsWith('/recent')) sort.value = 'newest'; }, { immediate: true });
-watch(selected, (it) => {
+watch(selectedId, (id) => {
+  const it = all.value.find((i) => i.id === id);
   if (!it) return;
   const b = bskyOf(it);
   cockpit.setContext({ surface: 'News', entityLabel: b ? `@${b.actor.handle}` : (sourceOf(it)?.title ?? 'story'), detail: it.title.slice(0, 60), route: route.path });
@@ -614,8 +617,16 @@ onUnmounted(() => {
 .nf-seg button { border: none; background: transparent; color: rgba(255, 255, 255, 0.6); padding: 0.3rem 0.7rem; font-size: 0.78rem; cursor: pointer; } .nf-seg button.on { background: rgba(88, 166, 255, 0.18); color: #58a6ff; }
 .nf-btn { border: 1px solid var(--line-2); background: transparent; color: rgba(255, 255, 255, 0.7); border-radius: 8px; padding: 0.3rem 0.6rem; font-size: 0.76rem; cursor: pointer; } .nf-btn.on { border-color: #58a6ff; color: #58a6ff; background: rgba(88, 166, 255, 0.12); }
 
-.nf-body { min-height: 0; display: grid; grid-template-columns: 208px minmax(360px, 1.4fr) minmax(320px, 1fr); gap: 0.75rem; }
-@media (max-width: 1080px) { .nf-body { grid-template-columns: 170px 1fr; } .nf-reader:not(.empty) { display: none; } .nf-reader.empty { display: none; } }
+.nf-body { min-height: 0; display: grid; grid-template-columns: 176px 1fr; gap: 0; position: relative; }
+@media (max-width: 900px) { .nf-body { grid-template-columns: 1fr; } .nf-rail { display: none; } }
+
+/* Masthead — broadsheet flag + dateline + Bloomberg ticker strip */
+.nf-masthead { display: grid; grid-template-columns: auto 1fr auto; align-items: baseline; gap: 1rem; padding: 0.2rem 0.25rem 0.5rem; border-bottom: 2px solid var(--text); }
+.nf-flag { font-family: Georgia, 'Times New Roman', serif; font-size: 1.45rem; font-weight: 700; letter-spacing: -0.02em; color: var(--text); }
+.nf-dateline { font-size: 0.72rem; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.06em; } .nf-dl-live { color: var(--live); text-transform: none; letter-spacing: 0; }
+.nf-ticker { display: flex; gap: 0.9rem; overflow: hidden; justify-content: flex-end; font-variant-numeric: tabular-nums; }
+.nf-tk { font-size: 0.68rem; color: var(--text-2); white-space: nowrap; } .nf-tk b { font-weight: 700; color: var(--text); margin-right: 0.15rem; } .nf-tk i { font-style: normal; font-size: 0.62rem; }
+.nf-tk.up i { color: var(--up); } .nf-tk.down i { color: var(--down); }
 
 /* Tufte pass: de-box the three panels — no rounded borders/fills; columns read from content
    + quiet hairline dividers in the grid gap (data-ink, not chartjunk). */
@@ -629,7 +640,37 @@ onUnmounted(() => {
 .nf-hash { color: var(--text-3); }
 .nf-rail-hint { margin-top: auto; padding: 0.5rem; font-size: 0.64rem; color: var(--text-3); line-height: 1.5; }
 
-.nf-list { min-height: 0; overflow-y: auto; border-right: 1px solid var(--line); }
+.nf-list { min-height: 0; overflow-y: auto; padding: 0.6rem 1.3rem 1rem; }
+
+/* Shared editorial kicker (source · truth · time) */
+.nf-kicker { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.3rem; }
+.nf-kick-src { font-size: 0.64rem; text-transform: uppercase; letter-spacing: 0.07em; font-weight: 700; }
+
+/* Lead well — the day's dominant story */
+.nf-lead { border-bottom: 2px solid var(--line-2); padding: 0.4rem 0 1.1rem; margin-bottom: 1rem; cursor: pointer; }
+.nf-lead:hover .nf-lead-title, .nf-lead.on .nf-lead-title { color: var(--accent); }
+.nf-lead-title { font-family: Georgia, 'Times New Roman', serif; font-size: 2.3rem; line-height: 1.1; letter-spacing: -0.02em; font-weight: 700; color: var(--text); margin: 0.1rem 0 0.45rem; text-wrap: balance; }
+.nf-lead.social .nf-lead-title { font-size: 1.7rem; font-style: italic; }
+.nf-lead-deck { font-size: 1.02rem; line-height: 1.55; color: var(--text-2); margin: 0 0 0.6rem; max-width: 62ch; }
+.nf-lead-foot { font-size: 0.74rem; color: var(--text-3); display: flex; align-items: center; gap: 0.5rem; } .nf-lead-foot .nf-auth { font-weight: 600; color: var(--text-2); } .nf-foot-sep { opacity: 0.5; }
+
+/* River — the multi-column broadsheet run with hairline column rules */
+.nf-river { columns: 3 300px; column-gap: 1.6rem; column-rule: 1px solid var(--line); }
+@media (max-width: 1400px) { .nf-river { columns: 2 300px; } }
+.nf-art { break-inside: avoid; -webkit-column-break-inside: avoid; padding: 0.7rem 0 0.8rem; border-top: 1px solid var(--line); cursor: pointer; }
+.nf-art:hover .nf-art-title, .nf-art.on .nf-art-title { color: var(--accent); }
+.nf-art.on { box-shadow: inset 3px 0 0 var(--accent); padding-left: 0.5rem; }
+.nf-art-title { font-family: Georgia, 'Times New Roman', serif; font-size: 1.08rem; line-height: 1.25; font-weight: 700; color: var(--text); margin: 0 0 0.25rem; text-wrap: pretty; }
+.nf-art.social .nf-art-title { font-size: 0.95rem; font-style: italic; font-weight: 600; color: var(--text-2); }
+.nf-art-deck { font-size: 0.82rem; line-height: 1.5; color: var(--text-3); margin: 0 0 0.35rem; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+.nf-art-meta { display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; }
+.nf-q.sm { font-size: 0.62rem; padding: 0.02rem 0.28rem; }
+
+/* Reader → slide-over overlay + scrim */
+.nf-reader-wrap { position: absolute; inset: 0; z-index: 20; display: grid; grid-template-columns: 1fr minmax(420px, 40%); }
+.nf-reader-scrim { background: rgba(0,0,0,0.4); }
+.nf-slide-enter-active, .nf-slide-leave-active { transition: opacity 0.18s ease; } .nf-slide-enter-from, .nf-slide-leave-to { opacity: 0; }
+@media (prefers-reduced-motion: reduce) { .nf-slide-enter-active, .nf-slide-leave-active { transition: none; } }
 
 /* Lobsters story row */
 .nf-story { display: flex; gap: 0.7rem; padding: 0.7rem 0.85rem; border-bottom: 1px solid var(--line); cursor: pointer; } .nf-story:hover { background: rgba(255, 255, 255, 0.03); } .nf-story.on { background: color-mix(in srgb, var(--accent) 7%, transparent); box-shadow: inset 2px 0 0 var(--accent); }
@@ -699,8 +740,7 @@ onUnmounted(() => {
 .nf-agenda-src { flex: 0 0 auto; font-size: 0.72rem; }
 
 /* Reader */
-.nf-reader { min-height: 0; overflow-y: auto; padding: 0.4rem 0.35rem 1rem 1.1rem; }
-.nf-reader.empty { display: grid; place-items: center; color: var(--text-3); font-size: 0.85rem; }
+.nf-reader { min-height: 0; overflow-y: auto; padding: 0.9rem 1.15rem 1.4rem; background: var(--bg); border-left: 1px solid var(--line-2); box-shadow: -14px 0 44px rgba(0,0,0,0.38); }
 .nf-reader-meta { display: flex; align-items: center; gap: 0.6rem; font-size: 0.72rem; }
 .nf-reader-close { margin-left: auto; display: grid; place-items: center; width: 1.55rem; height: 1.55rem; border-radius: 8px; border: 1px solid var(--line-2); background: transparent; color: var(--text-2); font-size: 0.8rem; cursor: pointer; transition: background 0.12s ease, color 0.12s ease; }
 .nf-reader-close:hover { background: rgba(255, 255, 255, 0.08); color: var(--text); }


### PR DESCRIPTION
## The problem
It was a **feed reader, not a front page**: a permanently-empty "Select a story" reader ate ~35% of the width, every story was one column at one size, and there was no masthead. Doesn't read like NYT/WSJ/BBG/WaPo.

## The redesign (hybrid: broadsheet + Bloomberg data discipline — your pick)
- **Reader → slide-over overlay** (opens on click, scrim behind) — the front page now uses **full width**. The dead column is gone.
- **Masthead** — serif flag + dateline + a **live market ticker** strip (mono numerals, up/down colored). The Bloomberg touch.
- **Lead well** — the day's top story at broadsheet scale (**2.3rem serif headline** + deck), then a **multi-column river** with **hairline column rules** and descending prominence. A real front page, ~3× the density.
- **Serif display headlines** (Georgia stack, no webfont); truth/provenance/membrane demoted to quiet data.
- Everything from the live rebuild preserved: streaming "N new" pill, flash-in, infinite scroll, live pulse. `j/k` now moves a highlight; **Enter/click opens** the reader; `o` opens the source.

## Verify
`vue-tsc --noEmit` clean · `npm run build` clean.