### PR TITLE
cockpit(design): unified type system + de-box primitives (Tufte pass #1)

### DIFF
--- a/apps/socioprophet-web/src/pages/AcademyOverview.vue
+++ b/apps/socioprophet-web/src/pages/AcademyOverview.vue
@@ -99,7 +99,8 @@ onMounted(() => cockpit.setContext({
 .ac { height: 100%; min-height: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 1rem; padding: 0.85rem 1.1rem 1.5rem; background: var(--bg); color: var(--text); }
 .ac-pill { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--up); background: rgba(63,185,80,0.14); border-radius: 5px; padding: 0.1rem 0.4rem; }
 
-.ac-moat { border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: 0.85rem 1rem; }
+/* De-boxed (Tufte): the moat reads from a hairline rule + whitespace, not a bordered card. */
+.ac-moat { border: 0; border-top: 2px solid var(--text); border-radius: 0; background: transparent; padding: 0.7rem 0 0.2rem; }
 .ac-moat-lead { font-size: 0.9rem; color: var(--text-2); margin-bottom: 0.7rem; }
 .ac-pillars { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 0.6rem; }
 .ac-pillar { display: flex; gap: 0.55rem; align-items: flex-start; }

--- a/apps/socioprophet-web/src/pages/NewsFeed.vue
+++ b/apps/socioprophet-web/src/pages/NewsFeed.vue
@@ -622,7 +622,7 @@ onUnmounted(() => {
 
 /* Masthead — broadsheet flag + dateline + Bloomberg ticker strip */
 .nf-masthead { display: grid; grid-template-columns: auto 1fr auto; align-items: baseline; gap: 1rem; padding: 0.2rem 0.25rem 0.5rem; border-bottom: 2px solid var(--text); }
-.nf-flag { font-family: Georgia, 'Times New Roman', serif; font-size: 1.45rem; font-weight: 700; letter-spacing: -0.02em; color: var(--text); }
+.nf-flag { font-family: var(--font-serif); font-size: 1.45rem; font-weight: 700; letter-spacing: -0.02em; color: var(--text); }
 .nf-dateline { font-size: 0.72rem; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.06em; } .nf-dl-live { color: var(--live); text-transform: none; letter-spacing: 0; }
 .nf-ticker { display: flex; gap: 0.9rem; overflow: hidden; justify-content: flex-end; font-variant-numeric: tabular-nums; }
 .nf-tk { font-size: 0.68rem; color: var(--text-2); white-space: nowrap; } .nf-tk b { font-weight: 700; color: var(--text); margin-right: 0.15rem; } .nf-tk i { font-style: normal; font-size: 0.62rem; }
@@ -649,7 +649,7 @@ onUnmounted(() => {
 /* Lead well — the day's dominant story */
 .nf-lead { border-bottom: 2px solid var(--line-2); padding: 0.4rem 0 1.1rem; margin-bottom: 1rem; cursor: pointer; }
 .nf-lead:hover .nf-lead-title, .nf-lead.on .nf-lead-title { color: var(--accent); }
-.nf-lead-title { font-family: Georgia, 'Times New Roman', serif; font-size: 2.3rem; line-height: 1.1; letter-spacing: -0.02em; font-weight: 700; color: var(--text); margin: 0.1rem 0 0.45rem; text-wrap: balance; }
+.nf-lead-title { font-family: var(--font-serif); font-size: 2.3rem; line-height: 1.1; letter-spacing: -0.02em; font-weight: 700; color: var(--text); margin: 0.1rem 0 0.45rem; text-wrap: balance; }
 .nf-lead.social .nf-lead-title { font-size: 1.7rem; font-style: italic; }
 .nf-lead-deck { font-size: 1.02rem; line-height: 1.55; color: var(--text-2); margin: 0 0 0.6rem; max-width: 62ch; }
 .nf-lead-foot { font-size: 0.74rem; color: var(--text-3); display: flex; align-items: center; gap: 0.5rem; } .nf-lead-foot .nf-auth { font-weight: 600; color: var(--text-2); } .nf-foot-sep { opacity: 0.5; }
@@ -660,7 +660,7 @@ onUnmounted(() => {
 .nf-art { break-inside: avoid; -webkit-column-break-inside: avoid; padding: 0.7rem 0 0.8rem; border-top: 1px solid var(--line); cursor: pointer; }
 .nf-art:hover .nf-art-title, .nf-art.on .nf-art-title { color: var(--accent); }
 .nf-art.on { box-shadow: inset 3px 0 0 var(--accent); padding-left: 0.5rem; }
-.nf-art-title { font-family: Georgia, 'Times New Roman', serif; font-size: 1.08rem; line-height: 1.25; font-weight: 700; color: var(--text); margin: 0 0 0.25rem; text-wrap: pretty; }
+.nf-art-title { font-family: var(--font-serif); font-size: 1.08rem; line-height: 1.25; font-weight: 700; color: var(--text); margin: 0 0 0.25rem; text-wrap: pretty; }
 .nf-art.social .nf-art-title { font-size: 0.95rem; font-style: italic; font-weight: 600; color: var(--text-2); }
 .nf-art-deck { font-size: 0.82rem; line-height: 1.5; color: var(--text-3); margin: 0 0 0.35rem; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
 .nf-art-meta { display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; }

--- a/apps/socioprophet-web/src/styles.css
+++ b/apps/socioprophet-web/src/styles.css
@@ -38,7 +38,14 @@
   --fs-md: 0.95rem;
   --fs-lg: 1.05rem;
   --fs-xl: 1.25rem;        /* surface title */
+  --fs-2xl: 1.7rem;        /* section lead / feature headline */
+  --fs-3xl: 2.3rem;        /* editorial lead headline (News front page) */
   --ls-eyebrow: 0.1em;
+  /* Font families — one deliberate pairing across the whole cockpit: Inter for UI + data,
+     a serif for editorial/publication headlines (News, features), mono for code + figures. */
+  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-serif: 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, 'Times New Roman', serif;
+  --font-mono: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --radius: 14px;
   --radius-sm: 10px;
   --shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
@@ -58,13 +65,19 @@ html, body, #app { height: 100%; margin: 0; }
 body {
   background: var(--bg);
   color: var(--text);
-  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   letter-spacing: -0.011em;
 }
 button, input, select, textarea { font: inherit; }
 a { color: inherit; }
+/* Editorial display type — the shared "publication" voice (News front page, feature headlines).
+   Adopt via class rather than inlining a serif stack, so the pairing stays unified estate-wide. */
+.u-display { font-family: var(--font-serif); font-weight: 700; letter-spacing: -0.02em; line-height: 1.12; text-wrap: balance; }
+.u-eyebrow { font-size: var(--fs-eyebrow); text-transform: uppercase; letter-spacing: var(--ls-eyebrow); color: var(--text-3); }
+/* De-box primitive (Tufte): a section carried by a hairline rule + whitespace, not a bordered card. */
+.u-ruled { border: 0; border-top: 1px solid var(--line-2); border-radius: 0; background: transparent; padding: 0.85rem 0 0; }
 /* Visible keyboard focus across the shell chrome + palette (mouse clicks stay clean via :focus-visible). */
 .sp-shell a:focus-visible, .sp-shell button:focus-visible, .cp a:focus-visible, .cp button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; border-radius: 6px; }
 /* Low-specificity baseline: every interactive control gets a crisp, consistent ring instead of
@@ -81,7 +94,7 @@ a { color: inherit; }
     transition: background-color 0.13s ease, border-color 0.13s ease, color 0.13s ease, box-shadow 0.13s ease, opacity 0.13s ease;
   }
 }
-code, pre, .mono { font-family: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+code, pre, .mono { font-family: var(--font-mono); }
 
 .sp-shell {
   /* Grounded edge-to-edge to the viewport (dvh survives zoom + mobile chrome),


### PR DESCRIPTION
## Why
The type was mostly Inter already, but News had inlined its own Georgia serif and there were no shared serif/display tokens — so "the publication" wasn't a system. This establishes one.

## What
- **Font-family tokens** in `:root`: `--font-sans` (Inter — UI + data), `--font-serif` (editorial headlines), `--font-mono`. `body` + `code` now reference them.
- **Display scale** — added `--fs-2xl` / `--fs-3xl` for feature/lead headlines.
- **Utilities** — `.u-display` (serif editorial voice), `.u-eyebrow`, and `.u-ruled` — the **de-box primitive** (a section carried by a hairline rule + whitespace, not a bordered card).
- **News** — its three inline `Georgia` stacks now use `var(--font-serif)`; the serif is defined **once**, estate-wide.
- **Academy Overview** — de-boxed the moat block (bordered card → top rule) as the demonstrator.

## Scope note
This is the **foundation** for pass #1. The iterative de-box + serif adoption across the remaining surfaces (Dashboard, explorers, Economy/Portfolio summary tiles) rides on these tokens — a broader, deliberate rollout on top.

## Verify
`vue-tsc --noEmit` clean · `npm run build` clean.