### PR TITLE
cockpit(academy): homeschool standards-planner — the K-12 depth pass

### DIFF
--- a/apps/socioprophet-web/src/data/homeschoolFixture.ts
+++ b/apps/socioprophet-web/src/data/homeschoolFixture.ts
@@ -1,0 +1,116 @@
+// Homeschool planner fixture (/academy/homeschool). Standards-based (NGSS + Common Core), the K-12
+// analog of the university registrar: Grade band → Subject → Standard → captured resource → Skill.
+// UI-only, shaped so a real standards corpus (CK-12 / OpenStax / NGSS·CCSS public standards) can swap
+// in later. CC-open sources only. A parent builds a plan against the standards and tracks coverage.
+
+export interface ResourceRef {
+  title: string;
+  source: string;   // 'CK-12' | 'OpenStax' | 'NGSS' | 'Common Core'
+  license: string;
+  captured: boolean;
+}
+export interface Standard {
+  code: string;         // 'MS-PS1-1', 'CCSS.MATH.6.RP.A.1', …
+  title: string;
+  description: string;
+  resources: ResourceRef[];
+  skills: string[];
+}
+export interface SubjectStrand {
+  subject: string;
+  framework: string;    // 'NGSS' | 'Common Core'
+  standards: Standard[];
+}
+export interface GradeProgram {
+  band: string;         // 'K-5' | '6-8' | '9-12'
+  label: string;
+  subjects: SubjectStrand[];
+}
+
+const CK12 = (title: string, captured = true): ResourceRef => ({ title, source: 'CK-12', license: 'CC BY-NC 3.0', captured });
+const OSTAX = (title: string, captured = true): ResourceRef => ({ title, source: 'OpenStax', license: 'CC BY 4.0', captured });
+
+export const gradePrograms: GradeProgram[] = [
+  {
+    band: 'K-5', label: 'Elementary (K–5)',
+    subjects: [
+      {
+        subject: 'Science', framework: 'NGSS',
+        standards: [
+          { code: '3-LS1-1', title: 'Life cycles', description: 'Develop models to describe that organisms have unique and diverse life cycles.', resources: [CK12('CK-12 Life Science: Life Cycles')], skills: ['sk-inquiry', 'sk-modeling'] },
+          { code: '4-PS3-2', title: 'Energy transfer', description: 'Observe energy being transferred from place to place by sound, light, heat, and electric currents.', resources: [CK12('CK-12 Physical Science: Energy')], skills: ['sk-inquiry'] },
+          { code: '5-ESS1-1', title: 'Stars & brightness', description: 'Support an argument that differences in apparent brightness of the sun vs. other stars is due to their relative distances.', resources: [CK12('CK-12 Earth Science: Stars', false)], skills: ['sk-argument', 'sk-modeling'] },
+        ],
+      },
+      {
+        subject: 'Mathematics', framework: 'Common Core',
+        standards: [
+          { code: '3.OA.A.1', title: 'Interpret products', description: 'Interpret products of whole numbers (e.g., 5 × 7 as 5 groups of 7).', resources: [OSTAX('OpenStax Prealgebra: Multiplication')], skills: ['sk-algebra'] },
+          { code: '4.NF.A.1', title: 'Equivalent fractions', description: 'Explain why a fraction a/b is equivalent to (n×a)/(n×b).', resources: [OSTAX('OpenStax Prealgebra: Fractions')], skills: ['sk-algebra'] },
+          { code: '5.NBT.A.3', title: 'Read & write decimals', description: 'Read, write, and compare decimals to thousandths.', resources: [OSTAX('OpenStax Prealgebra: Decimals')], skills: ['sk-data'] },
+        ],
+      },
+      {
+        subject: 'English/Language Arts', framework: 'Common Core',
+        standards: [
+          { code: 'RL.3.1', title: 'Ask & answer questions', description: 'Ask and answer questions to demonstrate understanding of a text, referring explicitly to the text.', resources: [CK12('CK-12 Reading: Comprehension', false)], skills: ['sk-argument', 'sk-writing'] },
+          { code: 'W.4.1', title: 'Opinion writing', description: 'Write opinion pieces supporting a point of view with reasons and information.', resources: [CK12('CK-12 Writing: Opinion', false)], skills: ['sk-writing', 'sk-argument'] },
+        ],
+      },
+    ],
+  },
+  {
+    band: '6-8', label: 'Middle School (6–8)',
+    subjects: [
+      {
+        subject: 'Science', framework: 'NGSS',
+        standards: [
+          { code: 'MS-PS1-1', title: 'Structure of matter', description: 'Develop models to describe the atomic composition of simple molecules and extended structures.', resources: [CK12('CK-12 Physical Science: Matter'), OSTAX('OpenStax Chemistry: Atoms First (intro)')], skills: ['sk-modeling', 'sk-inquiry'] },
+          { code: 'MS-LS1-1', title: 'Cells as the unit of life', description: 'Conduct an investigation to provide evidence that living things are made of cells.', resources: [CK12('CK-12 Life Science: Cells')], skills: ['sk-inquiry', 'sk-argument'] },
+          { code: 'MS-ESS1-1', title: 'Earth–sun–moon system', description: 'Develop and use a model of the Earth-sun-moon system to explain cyclic patterns of eclipses and seasons.', resources: [CK12('CK-12 Earth Science: Astronomy')], skills: ['sk-modeling', 'sk-data'] },
+          { code: 'MS-ETS1-1', title: 'Engineering design', description: 'Define the criteria and constraints of a design problem with precision.', resources: [{ title: 'NGSS ETS1 (standard)', source: 'NGSS', license: 'Public standard', captured: false }], skills: ['sk-modeling', 'sk-argument'] },
+        ],
+      },
+      {
+        subject: 'Mathematics', framework: 'Common Core',
+        standards: [
+          { code: '6.RP.A.1', title: 'Ratios', description: 'Understand the concept of a ratio and use ratio language to describe a relationship.', resources: [OSTAX('OpenStax Prealgebra: Ratios')], skills: ['sk-algebra', 'sk-data'] },
+          { code: '7.EE.B.4', title: 'Equations & inequalities', description: 'Use variables to represent quantities and construct simple equations and inequalities to solve problems.', resources: [OSTAX('OpenStax Elementary Algebra: Equations')], skills: ['sk-algebra'] },
+          { code: '8.F.A.1', title: 'Functions', description: 'Understand that a function assigns to each input exactly one output.', resources: [OSTAX('OpenStax Elementary Algebra: Functions')], skills: ['sk-algebra'] },
+        ],
+      },
+      {
+        subject: 'English/Language Arts', framework: 'Common Core',
+        standards: [
+          { code: 'RI.7.1', title: 'Cite textual evidence', description: 'Cite several pieces of textual evidence to support analysis of what the text says explicitly and inferentially.', resources: [CK12('CK-12 Reading: Informational Text', false)], skills: ['sk-argument', 'sk-writing'] },
+          { code: 'W.8.1', title: 'Argumentative writing', description: 'Write arguments to support claims with clear reasons and relevant evidence.', resources: [CK12('CK-12 Writing: Argument', false)], skills: ['sk-writing', 'sk-argument'] },
+        ],
+      },
+    ],
+  },
+  {
+    band: '9-12', label: 'High School (9–12)',
+    subjects: [
+      {
+        subject: 'Science', framework: 'NGSS',
+        standards: [
+          { code: 'HS-PS2-1', title: "Newton's second law", description: "Analyze data to support the claim that Newton's second law of motion describes the relationship among force, mass, and acceleration.", resources: [OSTAX('OpenStax College Physics: Dynamics'), { title: 'MIT 8.01 (bridge to university)', source: 'MIT OCW', license: 'CC BY-NC-SA 4.0', captured: true }], skills: ['sk-mechanics', 'sk-data'] },
+          { code: 'HS-LS1-2', title: 'Systems in organisms', description: 'Develop and use a model to illustrate the hierarchical organization of interacting systems in multicellular organisms.', resources: [OSTAX('OpenStax Biology: Systems')], skills: ['sk-modeling', 'sk-inquiry'] },
+        ],
+      },
+      {
+        subject: 'Mathematics', framework: 'Common Core',
+        standards: [
+          { code: 'A-REI.B.4', title: 'Quadratic equations', description: 'Solve quadratic equations in one variable by inspection, completing the square, the quadratic formula, and factoring.', resources: [OSTAX('OpenStax Intermediate Algebra: Quadratics')], skills: ['sk-algebra'] },
+          { code: 'F-IF.C.7', title: 'Graphing functions', description: 'Graph functions expressed symbolically and show key features of the graph.', resources: [OSTAX('OpenStax Precalculus: Functions')], skills: ['sk-algebra', 'sk-calculus'] },
+        ],
+      },
+    ],
+  },
+];
+
+export function coverageOfSubject(s: SubjectStrand): { captured: number; total: number; pct: number } {
+  const total = s.standards.length;
+  const captured = s.standards.filter((st) => st.resources.some((r) => r.captured)).length;
+  return { captured, total, pct: total ? Math.round((captured / total) * 100) : 0 };
+}

--- a/apps/socioprophet-web/src/main.ts
+++ b/apps/socioprophet-web/src/main.ts
@@ -39,6 +39,7 @@ import DomainSurfacePage from './pages/DomainSurfacePage.vue';
 import AcademyOverview from './pages/AcademyOverview.vue';
 import DegreeExplorer from './pages/DegreeExplorer.vue';
 import CourseView from './pages/CourseView.vue';
+import HomeschoolPlanner from './pages/HomeschoolPlanner.vue';
 import FeedPage from './pages/FeedPage.vue';
 import Journal from './pages/Journal.vue';
 import MapPage from './pages/MapPage.vue';
@@ -76,7 +77,7 @@ const explicitRoutes = [
   { path: '/login', component: Login, meta: { public: true } },
   { path: '/capability/dashboard', component: OperatorDashboard },
   { path: '/academy', component: AcademyOverview },
-  { path: '/academy/homeschool', component: DegreeExplorer },
+  { path: '/academy/homeschool', component: HomeschoolPlanner },
   { path: '/academy/degrees', component: DegreeExplorer },
   { path: '/academy/course/:id', component: CourseView },
   { path: '/academy/tutor', component: CourseView },

--- a/apps/socioprophet-web/src/pages/HomeschoolPlanner.vue
+++ b/apps/socioprophet-web/src/pages/HomeschoolPlanner.vue
@@ -1,0 +1,172 @@
+<template>
+  <section class="hp" aria-label="Homeschool planner">
+    <SurfaceHeader title="Homeschool Planner" eyebrow="Academy · K-12 · standards-based">
+      <template #badge><span class="hp-pill">NGSS · Common Core</span></template>
+      <template #actions>
+        <button v-if="plan.size" class="hp-reset" @click="resetPlan">Clear plan</button>
+      </template>
+    </SurfaceHeader>
+
+    <!-- Grade band + subject selectors -->
+    <div class="hp-selectors">
+      <div class="hp-bands">
+        <button v-for="g in gradePrograms" :key="g.band" class="hp-band" :class="{ on: g.band === band }" @click="band = g.band">{{ g.label }}</button>
+      </div>
+      <div class="hp-subjects">
+        <button v-for="s in program.subjects" :key="s.subject" class="hp-subject" :class="{ on: s.subject === subject }" @click="subject = s.subject">
+          {{ s.subject }}<span class="hp-subj-cov">{{ coverageOfSubject(s).pct }}%</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="hp-body">
+      <!-- Standards for the chosen band + subject -->
+      <div class="hp-standards" aria-label="Standards">
+        <div class="hp-std-h">{{ strand?.framework }} · {{ subject }} <span>{{ strand?.standards.length }} standards</span></div>
+        <div v-for="st in strand?.standards ?? []" :key="st.code" class="hp-std" :class="{ planned: plan.has(st.code), covered: covered.has(st.code) }">
+          <div class="hp-std-top">
+            <code class="hp-code">{{ st.code }}</code>
+            <span class="hp-std-title">{{ st.title }}</span>
+            <span class="hp-std-actions">
+              <button class="hp-chip" :class="{ on: plan.has(st.code) }" @click="togglePlan(st.code)">{{ plan.has(st.code) ? '✓ in plan' : '+ plan' }}</button>
+              <button class="hp-chip cov" :class="{ on: covered.has(st.code) }" :disabled="!plan.has(st.code)" :title="plan.has(st.code) ? 'Mark this standard covered' : 'Add to plan first'" @click="toggleCovered(st.code)">{{ covered.has(st.code) ? '● covered' : '○ covered' }}</button>
+            </span>
+          </div>
+          <p class="hp-std-desc">{{ st.description }}</p>
+          <div class="hp-std-foot">
+            <span v-for="(r, i) in st.resources" :key="i" class="hp-res" :class="{ uncaptured: !r.captured }">
+              {{ r.title }} <em>{{ r.source }}</em><span v-if="!r.captured" class="hp-res-x"> · not yet captured</span>
+            </span>
+            <span class="hp-skills"><span v-for="sk in st.skills" :key="sk" class="hp-skill">{{ skillName(sk) }}</span></span>
+          </div>
+        </div>
+      </div>
+
+      <!-- My Plan -->
+      <aside class="hp-plan" aria-label="My plan">
+        <div class="hp-plan-h">My plan</div>
+        <template v-if="plan.size">
+          <div class="hp-progress">
+            <div class="hp-prog-num"><b>{{ covered.size }}</b> / {{ plan.size }}<span>covered</span></div>
+            <div class="hp-prog-bar"><span :style="{ width: planPct + '%' }" :class="{ full: planPct >= 100 }" /></div>
+            <div class="hp-prog-pct">{{ planPct }}%</div>
+          </div>
+          <div v-for="grp in planBySubject" :key="grp.subject" class="hp-plan-grp">
+            <div class="hp-plan-grp-h">{{ grp.subject }}</div>
+            <button v-for="c in grp.codes" :key="c.code" class="hp-plan-item" :class="{ done: covered.has(c.code) }" @click="toggleCovered(c.code)">
+              <span class="hp-plan-mark">{{ covered.has(c.code) ? '●' : '○' }}</span>
+              <code>{{ c.code }}</code> {{ c.title }}
+            </button>
+          </div>
+          <p class="hp-plan-note">A parent-owned plan against the public standards — coverage tracked locally. As the Commons captures each standard's OER, the tutor grounds on it.</p>
+        </template>
+        <p v-else class="hp-plan-empty">Add standards to build a term plan. Track what you've covered, see the gaps, and let the grounded tutor teach each one.</p>
+      </aside>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import SurfaceHeader from '../components/SurfaceHeader.vue';
+import { useCockpit } from '../stores/cockpit';
+import { gradePrograms, coverageOfSubject, type SubjectStrand } from '../data/homeschoolFixture';
+import { skillName } from '../data/academyFixture';
+
+const cockpit = useCockpit();
+const STORE = 'sp-homeschool-v1';
+
+const band = ref<string>('6-8');
+const program = computed(() => gradePrograms.find((g) => g.band === band.value) ?? gradePrograms[0]!);
+const subject = ref<string>(program.value.subjects[0]?.subject ?? '');
+const strand = computed<SubjectStrand | undefined>(() => program.value.subjects.find((s) => s.subject === subject.value) ?? program.value.subjects[0]);
+
+const plan = ref<Set<string>>(new Set());
+const covered = ref<Set<string>>(new Set());
+function persist() {
+  try { localStorage.setItem(STORE, JSON.stringify({ plan: [...plan.value], covered: [...covered.value] })); } catch { /* */ }
+}
+function togglePlan(code: string) {
+  const p = new Set(plan.value);
+  if (p.has(code)) { p.delete(code); const c = new Set(covered.value); c.delete(code); covered.value = c; } else p.add(code);
+  plan.value = p; persist();
+}
+function toggleCovered(code: string) {
+  if (!plan.value.has(code)) return;
+  const c = new Set(covered.value); c.has(code) ? c.delete(code) : c.add(code); covered.value = c; persist();
+}
+function resetPlan() { plan.value = new Set(); covered.value = new Set(); persist(); }
+
+const planPct = computed(() => (plan.value.size ? Math.round((covered.value.size / plan.value.size) * 100) : 0));
+// Codes in the plan, resolved to titles + grouped by subject (across all bands).
+const planBySubject = computed(() => {
+  const byCode = new Map<string, { code: string; title: string; subject: string }>();
+  for (const g of gradePrograms) for (const s of g.subjects) for (const st of s.standards) byCode.set(st.code, { code: st.code, title: st.title, subject: s.subject });
+  const groups = new Map<string, { code: string; title: string }[]>();
+  for (const code of plan.value) {
+    const info = byCode.get(code); if (!info) continue;
+    if (!groups.has(info.subject)) groups.set(info.subject, []);
+    groups.get(info.subject)!.push({ code: info.code, title: info.title });
+  }
+  return [...groups.entries()].map(([subject, codes]) => ({ subject, codes }));
+});
+
+watch(band, () => { if (!program.value.subjects.some((s) => s.subject === subject.value)) subject.value = program.value.subjects[0]?.subject ?? ''; });
+watch([band, subject], () => cockpit.setContext({ surface: 'Academy · Homeschool', entityLabel: `${program.value.label} · ${subject.value}`, detail: `${plan.value.size} in plan`, route: '/academy/homeschool' }), { immediate: true });
+onMounted(() => {
+  try {
+    const raw = localStorage.getItem(STORE);
+    if (raw) { const d = JSON.parse(raw) as { plan?: string[]; covered?: string[] }; plan.value = new Set(d.plan ?? []); covered.value = new Set(d.covered ?? []); }
+  } catch { /* */ }
+});
+</script>
+
+<style scoped>
+.hp { height: 100%; min-height: 0; display: grid; grid-template-rows: auto auto 1fr; gap: 0.75rem; padding: 0.85rem 1rem 1rem; background: var(--bg); color: var(--text); }
+.hp-pill { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.06em; color: #6ee7b7; background: rgba(63,185,80,0.14); border-radius: 5px; padding: 0.1rem 0.4rem; }
+.hp-reset { border: 1px solid var(--line-2); background: transparent; color: var(--text-3); border-radius: 8px; padding: 0.3rem 0.7rem; font-size: 0.76rem; cursor: pointer; } .hp-reset:hover { color: var(--text); }
+
+.hp-selectors { display: flex; flex-direction: column; gap: 0.5rem; }
+.hp-bands { display: flex; gap: 0.4rem; }
+.hp-band { border: 1px solid var(--line-2); background: transparent; color: var(--text-2); border-radius: 8px; padding: 0.35rem 0.75rem; font-size: 0.8rem; cursor: pointer; } .hp-band.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft, rgba(120,160,255,0.12)); }
+.hp-subjects { display: flex; gap: 0.35rem; flex-wrap: wrap; }
+.hp-subject { display: inline-flex; align-items: center; gap: 0.4rem; border: 1px solid var(--line-2); background: transparent; color: var(--text-3); border-radius: 999px; padding: 0.25rem 0.7rem; font-size: 0.78rem; cursor: pointer; } .hp-subject.on { border-color: var(--accent); color: var(--text); }
+.hp-subj-cov { font-size: 0.64rem; color: var(--text-3); font-variant-numeric: tabular-nums; }
+
+.hp-body { min-height: 0; display: grid; grid-template-columns: 1fr minmax(280px, 340px); gap: 1.1rem; }
+@media (max-width: 980px) { .hp-body { grid-template-columns: 1fr; } .hp-plan { display: none; } }
+
+.hp-standards { min-height: 0; overflow-y: auto; }
+.hp-std-h { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-3); margin-bottom: 0.5rem; } .hp-std-h span { color: var(--text-3); text-transform: none; letter-spacing: 0; }
+.hp-std { border-top: 1px solid var(--line); padding: 0.7rem 0; }
+.hp-std.planned { box-shadow: inset 3px 0 0 var(--accent); padding-left: 0.6rem; }
+.hp-std.covered { box-shadow: inset 3px 0 0 var(--up); }
+.hp-std-top { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; }
+.hp-code { font-family: var(--font-mono); font-size: 0.68rem; color: var(--text-3); }
+.hp-std-title { font-size: 0.92rem; font-weight: 650; flex: 1; }
+.hp-std-actions { display: flex; gap: 0.35rem; }
+.hp-chip { border: 1px solid var(--line-2); background: transparent; color: var(--text-3); border-radius: 6px; padding: 0.15rem 0.5rem; font-size: 0.7rem; cursor: pointer; } .hp-chip:hover { border-color: var(--accent); color: var(--accent); }
+.hp-chip.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft, rgba(120,160,255,0.12)); }
+.hp-chip.cov.on { border-color: rgba(63,185,80,0.5); color: #6ee7b7; background: rgba(63,185,80,0.1); }
+.hp-chip:disabled { opacity: 0.4; cursor: default; }
+.hp-std-desc { font-size: 0.82rem; line-height: 1.55; color: var(--text-2); margin: 0.35rem 0; }
+.hp-std-foot { display: flex; align-items: center; gap: 0.5rem 0.9rem; flex-wrap: wrap; font-size: 0.72rem; color: var(--text-3); }
+.hp-res em { font-style: normal; color: var(--up); } .hp-res.uncaptured em { color: #e3b341; } .hp-res-x { color: #e3b341; }
+.hp-skills { display: flex; gap: 0.3rem; flex-wrap: wrap; margin-left: auto; }
+.hp-skill { font-size: 0.64rem; color: var(--text-3); border: 1px solid var(--line); border-radius: 999px; padding: 0.03rem 0.45rem; }
+
+.hp-plan { min-height: 0; overflow-y: auto; border-left: 1px solid var(--line-2); padding-left: 1.1rem; }
+.hp-plan-h { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-3); margin-bottom: 0.6rem; }
+.hp-progress { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.9rem; }
+.hp-prog-num { font-size: 0.8rem; color: var(--text-2); } .hp-prog-num b { font-size: 1.5rem; color: var(--text); font-variant-numeric: tabular-nums; } .hp-prog-num span { display: block; font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-3); }
+.hp-prog-bar { flex: 1; height: 7px; border-radius: 4px; background: var(--line); overflow: hidden; } .hp-prog-bar span { display: block; height: 100%; background: var(--accent); } .hp-prog-bar span.full { background: var(--up); }
+.hp-prog-pct { font-size: 0.82rem; font-weight: 700; color: var(--text); font-variant-numeric: tabular-nums; }
+.hp-plan-grp { margin-bottom: 0.7rem; }
+.hp-plan-grp-h { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-3); margin-bottom: 0.25rem; }
+.hp-plan-item { display: flex; align-items: baseline; gap: 0.4rem; width: 100%; text-align: left; border: none; background: transparent; color: var(--text-2); padding: 0.28rem 0; font-size: 0.78rem; cursor: pointer; border-bottom: 1px solid var(--line); }
+.hp-plan-item:hover { color: var(--text); } .hp-plan-item.done { color: var(--text-3); } .hp-plan-item.done code { text-decoration: line-through; }
+.hp-plan-mark { color: var(--text-3); } .hp-plan-item.done .hp-plan-mark { color: var(--up); }
+.hp-plan-item code { font-family: var(--font-mono); font-size: 0.68rem; color: var(--text-3); }
+.hp-plan-note { font-size: 0.72rem; color: var(--text-3); line-height: 1.5; margin-top: 0.6rem; }
+.hp-plan-empty { font-size: 0.82rem; color: var(--text-3); line-height: 1.6; }
+</style>


### PR DESCRIPTION
## Why
The K-12 slice (your #1 audience) was rendered by the *generic* explorer — not a real planner. This makes `/academy/homeschool` a **standards-based planner** a homeschool parent actually uses.

## What
- **`homeschoolFixture.ts`** — the K-12 analog of the university registrar: **Grade band** (K-5 / 6-8 / 9-12) → **Subject** (Science·NGSS, Math·CCSS, ELA·CCSS) → **Standard** (code + description) → captured **OER resource** → **Skill**. CC-open sources only; skills reuse the shared academy skill nodes.
- **`HomeschoolPlanner.vue`** — grade-band + subject selectors; each standard with **add-to-plan / mark-covered** toggles, resource links, and capture flags; a **"My Plan"** side panel with live **coverage %**, grouped by subject, **progress persisted to localStorage**.

Standards show whether their OER is captured yet (so gaps are honest), and the note ties it back to the grounded tutor once the Commons captures each standard.

## Verify
`vue-tsc --noEmit` clean · `npm run build` clean.