### PR TITLE
cockpit(academy): de-paper-tiger the homeschool planner — standards really taught

### DIFF
--- a/apps/socioprophet-web/src/components/GroundedTutor.vue
+++ b/apps/socioprophet-web/src/components/GroundedTutor.vue
@@ -2,9 +2,9 @@
   <div class="gt">
     <div class="gt-head">
       <span class="gt-title">Grounded Tutor</span>
-      <span class="gt-persona">in the voice of {{ course.teacher }}</span>
+      <span v-if="course" class="gt-persona">in the voice of {{ course.teacher }}</span>
     </div>
-    <p class="gt-blurb">Ask about the course. Every answer is <b>quoted and cited</b> to a captured lecture segment — it never invents.</p>
+    <p class="gt-blurb">{{ course ? 'Ask about the course.' : 'Ask about this standard.' }} Every answer is <b>quoted and cited</b> to captured material — it never invents.</p>
 
     <form class="gt-ask" @submit.prevent="ask">
       <input v-model="qText" class="gt-input" type="text" placeholder="e.g. why doesn't a ball fall faster if you throw it sideways?" aria-label="Ask the tutor" />
@@ -48,18 +48,21 @@
         </div>
       </template>
       <template v-else>
-        <p class="gt-nomatch">I answer only from the captured lectures, and I don’t find this in the corpus. Try one of these topics: <b>{{ topConcepts.join(', ') }}</b>.</p>
+        <p class="gt-nomatch">I answer only from the captured corpus, and I don’t find this yet. This standard’s material isn’t captured — the Commons is still filling in.<span v-if="topConcepts.length"> Try: <b>{{ topConcepts.join(', ') }}</b>.</span></p>
       </template>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import type { Course } from '../data/courseFixture';
 import { retrievePassages, ORIGIN_META, type AcademySource, type PassageOrigin } from '../services/academyApi';
 
-const props = defineProps<{ course: Course }>();
+// `course` is optional: with it, Commons falls back to the in-app lecture transcripts; without it
+// (e.g. the Homeschool planner teaching a standard) the tutor grounds purely on the live academy
+// ingest / local Noetica. `seed` prefills + auto-asks a question — used to teach a specific standard.
+const props = defineProps<{ course?: Course; seed?: string }>();
 defineEmits<{ (e: 'jump', lessonId: string): void }>();
 
 const qText = ref('');
@@ -75,7 +78,7 @@ function tokens(s: string): string[] {
 }
 
 const topConcepts = computed(() => {
-  const all = props.course.lessons.flatMap((l) => l.concepts);
+  const all = (props.course?.lessons ?? []).flatMap((l) => l.concepts);
   return [...new Set(all)].slice(0, 5);
 });
 
@@ -102,8 +105,10 @@ function sentenceOf(text: string, qt: string[]): string {
 
 // Commons grounding — extractive over the in-app captured transcripts (the guaranteed fallback).
 function fixtureAnswer(qt: string[]): Answer {
-  let best: { lesson: typeof props.course.lessons[number]; score: number } | null = null;
-  for (const lesson of props.course.lessons) {
+  const lessons = props.course?.lessons ?? [];
+  if (lessons.length === 0) return { cited: false, intro: '', quote: '', lessonId: '', lessonN: 0, title: '', chunkRef: '', concepts: [], origin: 'fixture' };
+  let best: { lesson: typeof lessons[number]; score: number } | null = null;
+  for (const lesson of lessons) {
     const conceptToks = new Set(lesson.concepts.flatMap(tokens));
     const titleToks = new Set(tokens(lesson.title));
     const bodyToks = new Set(tokens(lesson.transcript));
@@ -121,7 +126,7 @@ function fixtureAnswer(qt: string[]): Answer {
   const hitConcepts = best.lesson.concepts.filter((c) => tokens(c).some((t) => qt.includes(t)));
   return {
     cited: true,
-    intro: `Here's what ${props.course.teacher} says on this:`,
+    intro: `Here's what ${props.course?.teacher ?? 'the source'} says on this:`,
     quote: sentenceOf(best.lesson.transcript, qt),
     lessonId: best.lesson.id, lessonN: best.lesson.n, title: best.lesson.title, chunkRef: best.lesson.chunkRef,
     concepts: hitConcepts.length ? hitConcepts : best.lesson.concepts.slice(0, 2),
@@ -157,6 +162,9 @@ async function ask() {
     loading.value = false;
   }
 }
+
+// Teach a specific standard/topic: when `seed` changes, prefill and ask against the live corpus.
+watch(() => props.seed, (s) => { if (s) { qText.value = s; void ask(); } }, { immediate: true });
 </script>
 
 <style scoped>

--- a/apps/socioprophet-web/src/pages/HomeschoolPlanner.vue
+++ b/apps/socioprophet-web/src/pages/HomeschoolPlanner.vue
@@ -28,6 +28,7 @@
             <code class="hp-code">{{ st.code }}</code>
             <span class="hp-std-title">{{ st.title }}</span>
             <span class="hp-std-actions">
+              <button class="hp-chip teach" :class="{ on: teaching?.code === st.code }" title="Teach this standard with the grounded tutor" @click="teach(st)">◆ teach</button>
               <button class="hp-chip" :class="{ on: plan.has(st.code) }" @click="togglePlan(st.code)">{{ plan.has(st.code) ? '✓ in plan' : '+ plan' }}</button>
               <button class="hp-chip cov" :class="{ on: covered.has(st.code) }" :disabled="!plan.has(st.code)" :title="plan.has(st.code) ? 'Mark this standard covered' : 'Add to plan first'" @click="toggleCovered(st.code)">{{ covered.has(st.code) ? '● covered' : '○ covered' }}</button>
             </span>
@@ -42,8 +43,17 @@
         </div>
       </div>
 
-      <!-- My Plan -->
-      <aside class="hp-plan" aria-label="My plan">
+      <!-- Right panel: the grounded tutor teaching a standard (real retrieval), else the plan. -->
+      <aside class="hp-plan" aria-label="Plan and tutor">
+        <template v-if="teaching">
+          <div class="hp-teach-h">
+            <span><code>{{ teaching.code }}</code> {{ teaching.title }}</span>
+            <button class="hp-teach-x" title="Back to plan" @click="teaching = null">×</button>
+          </div>
+          <GroundedTutor :seed="teachQuery" />
+          <p class="hp-teach-note">Grounded in the live academy corpus — the tutor quotes and cites real captured material for this standard, or says plainly when none is captured yet.</p>
+        </template>
+        <template v-else>
         <div class="hp-plan-h">My plan</div>
         <template v-if="plan.size">
           <div class="hp-progress">
@@ -60,7 +70,8 @@
           </div>
           <p class="hp-plan-note">A parent-owned plan against the public standards — coverage tracked locally. As the Commons captures each standard's OER, the tutor grounds on it.</p>
         </template>
-        <p v-else class="hp-plan-empty">Add standards to build a term plan. Track what you've covered, see the gaps, and let the grounded tutor teach each one.</p>
+        <p v-else class="hp-plan-empty">Add standards to build a term plan. Track what you've covered, see the gaps, and hit <b>teach</b> on any standard to have the grounded tutor teach it from the live corpus.</p>
+        </template>
       </aside>
     </div>
   </section>
@@ -70,10 +81,18 @@
 import { ref, computed, watch, onMounted } from 'vue';
 import SurfaceHeader from '../components/SurfaceHeader.vue';
 import { useCockpit } from '../stores/cockpit';
-import { gradePrograms, coverageOfSubject, type SubjectStrand } from '../data/homeschoolFixture';
+import { gradePrograms, coverageOfSubject, type SubjectStrand, type Standard } from '../data/homeschoolFixture';
 import { skillName } from '../data/academyFixture';
+import GroundedTutor from '../components/GroundedTutor.vue';
 
 const cockpit = useCockpit();
+
+// Teach a standard with the real grounded tutor: the standard's title + description seeds a live
+// retrieval over the academy corpus (cloud ingest / local Noetica), quoted + cited — or an honest
+// "not captured yet" when the Commons has no material for it.
+const teaching = ref<Standard | null>(null);
+function teach(st: Standard) { teaching.value = teaching.value?.code === st.code ? null : st; }
+const teachQuery = computed(() => (teaching.value ? `${teaching.value.title}. ${teaching.value.description}` : ''));
 const STORE = 'sp-homeschool-v1';
 
 const band = ref<string>('6-8');
@@ -149,6 +168,10 @@ onMounted(() => {
 .hp-chip.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft, rgba(120,160,255,0.12)); }
 .hp-chip.cov.on { border-color: rgba(63,185,80,0.5); color: #6ee7b7; background: rgba(63,185,80,0.1); }
 .hp-chip:disabled { opacity: 0.4; cursor: default; }
+.hp-chip.teach { border-color: color-mix(in srgb, var(--accent) 45%, transparent); color: var(--accent); } .hp-chip.teach.on { background: var(--accent-soft, rgba(120,160,255,0.12)); }
+.hp-teach-h { display: flex; align-items: baseline; justify-content: space-between; gap: 0.5rem; margin-bottom: 0.6rem; font-size: 0.82rem; font-weight: 600; color: var(--text); } .hp-teach-h code { font-family: var(--font-mono); font-size: 0.7rem; color: var(--text-3); margin-right: 0.35rem; }
+.hp-teach-x { border: none; background: transparent; color: var(--text-3); font-size: 1.1rem; line-height: 1; cursor: pointer; } .hp-teach-x:hover { color: var(--text); }
+.hp-teach-note { font-size: 0.72rem; color: var(--text-3); line-height: 1.5; margin-top: 0.6rem; }
 .hp-std-desc { font-size: 0.82rem; line-height: 1.55; color: var(--text-2); margin: 0.35rem 0; }
 .hp-std-foot { display: flex; align-items: center; gap: 0.5rem 0.9rem; flex-wrap: wrap; font-size: 0.72rem; color: var(--text-3); }
 .hp-res em { font-style: normal; color: var(--up); } .hp-res.uncaptured em { color: #e3b341; } .hp-res-x { color: #e3b341; }


### PR DESCRIPTION
## The problem (fair critique)
The Homeschool Planner was a **fixture checklist** — its "let the grounded tutor teach each one" line connected to **nothing**. A paper tiger.

## The fix — each standard is now really teachable
Every standard gets a **`◆ teach`** action that drives the **real grounded tutor**: the standard's title + description seeds a **live query against the deployed academy ingest** (the 1,421-chunk 8.01 corpus) / local Noetica. The tutor **quotes and cites an actual captured passage**, with the cloud/local/commons origin chip — or says plainly when nothing is captured for that standard yet.

- `GroundedTutor`: `course` is now optional + a `seed` prop auto-asks; with no course it grounds purely on the live corpus (no fixture fallback), honest empty state.
- `HomeschoolPlanner`: `teach(standard)` opens the tutor in the right panel, seeded with the standard.

## Proof it's real (not fixture)
Live `/svc/search` query for *"Structure of matter… atomic composition of molecules"* → returns a real 8.01 chunk: *"the size (10⁻¹⁰ m) of any typical atom or molecule…"*.

## Verify
`vue-tsc --noEmit` clean · `npm run build` clean.