### PR TITLE
portfolio: our own sovereign cloud agent (Portfolio ②) + both-ways integration

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -75,6 +75,7 @@ jobs:
           - { image: ie-engine,             context: apps/ie-engine,             dockerfile: Dockerfile }
           - { image: synapse-bridge,        context: apps/synapse-bridge,        dockerfile: Dockerfile }
           - { image: holmes,                context: apps/holmes,                dockerfile: Dockerfile }
+          - { image: portfolio-agent,       context: apps/portfolio-agent,       dockerfile: Dockerfile }
           - { image: memoryd,               context: apps/memoryd,               dockerfile: Dockerfile }
           - { image: node-commander,        context: apps/node-commander,        dockerfile: Dockerfile }
           - { image: liberty-stack-readout, context: apps/liberty-stack-readout, dockerfile: Dockerfile }

--- a/apps/portfolio-agent/Dockerfile
+++ b/apps/portfolio-agent/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1.7
+# portfolio-agent — the sovereign cloud portfolio agent (Portfolio ②) on :8094. Same proof-carrying
+# tool layer the cockpit runs in-browser (①), server-side. No native deps. Runs as uid 10001 under the
+# chart's readOnlyRootFilesystem — tsx/esbuild writes only to /tmp (values sets tmpDir.enabled).
+# http.listen(PORT) binds 0.0.0.0 by default (no localhost-bind CrashLoop trap).
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --no-audit --no-fund && chown -R 10001:10001 /app
+COPY src ./src
+ENV PORT=8094
+EXPOSE 8094
+USER 10001
+CMD ["npx", "tsx", "src/server.ts"]

--- a/apps/portfolio-agent/package-lock.json
+++ b/apps/portfolio-agent/package-lock.json
@@ -1,0 +1,504 @@
+{
+  "name": "portfolio-agent",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "portfolio-agent",
+      "version": "0.1.0",
+      "dependencies": {
+        "tsx": "^4.19.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    }
+  }
+}

--- a/apps/portfolio-agent/package.json
+++ b/apps/portfolio-agent/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "portfolio-agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Sovereign cloud portfolio agent (Portfolio ②) — concentration / VaR / rebalance as a proof-carrying HTTP service",
+  "dependencies": {
+    "tsx": "^4.19.2"
+  }
+}

--- a/apps/portfolio-agent/src/agent.ts
+++ b/apps/portfolio-agent/src/agent.ts
@@ -1,0 +1,127 @@
+// Portfolio agent — the sovereign CLOUD agent (Portfolio ②). Same proof-carrying tool layer the
+// cockpit runs in-browser (①), but server-side so it can run autonomously / on a schedule and the
+// cockpit can call OUR agent instead of yielding to a third-party cloud agent. Pure + deterministic:
+// every finding is verified-compute (replayable from its inputs), carrying a content-id receipt.
+
+export interface Position {
+  symbol: string;
+  name: string;
+  qty: number;
+  avgCost: number;
+  last: number;
+  klass?: string;
+  series?: number[];
+}
+export type Severity = 'info' | 'watch' | 'alert';
+export interface Finding { id: string; severity: Severity; title: string; detail: string; formula: string; receipt: string }
+export interface ProposedOrder { symbol: string; name: string; side: 'buy' | 'sell'; qty: number; price: number; rationale: string }
+export interface AgentResult {
+  goal: string;
+  findings: Finding[];
+  actions: ProposedOrder[];
+  narrative: string;
+  tools: string[];
+  receipt: string;
+  engine: string;
+  attested: boolean;
+}
+
+// djb2 content id over inputs — an honest deterministic receipt (same inputs → same id, replay-checkable).
+function contentId(input: unknown): string {
+  const s = JSON.stringify(input);
+  let h = 5381;
+  for (let i = 0; i < s.length; i += 1) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return `id:pf-${(h >>> 0).toString(16).padStart(8, '0')}`;
+}
+
+// Sample stdev of daily returns from a price series, scaled to a 1-day move.
+function dailyVol(series?: number[]): number {
+  if (!series || series.length < 3) return 0.02;
+  const rets: number[] = [];
+  for (let i = 1; i < series.length; i += 1) { const p = series[i - 1]!; if (p) rets.push(series[i]! / p - 1); }
+  const mean = rets.reduce((a, b) => a + b, 0) / rets.length;
+  const varc = rets.reduce((a, r) => a + (r - mean) ** 2, 0) / Math.max(1, rets.length - 1);
+  return Math.sqrt(varc);
+}
+
+function mv(p: Position): number { return p.last * p.qty; }
+
+export function concentration(book: Position[]): Finding {
+  const total = book.reduce((s, p) => s + mv(p), 0) || 1;
+  const weights = book.map((p) => ({ symbol: p.symbol, w: mv(p) / total }));
+  const hhi = weights.reduce((s, x) => s + x.w * x.w, 0);
+  const top = weights.slice().sort((a, b) => b.w - a.w)[0];
+  const effN = hhi ? 1 / hhi : 0;
+  const sev: Severity = top && top.w > 0.4 ? 'alert' : top && top.w > 0.25 ? 'watch' : 'info';
+  const topPct = top ? (top.w * 100).toFixed(1) : '0';
+  return {
+    id: 'concentration', severity: sev,
+    title: sev === 'info' ? 'Diversified book' : `Concentrated in ${top?.symbol}`,
+    detail: `Herfindahl index ${hhi.toFixed(3)} (~${effN.toFixed(1)} effective names). Largest position ${top?.symbol ?? '—'} is ${topPct}% of the book`
+      + (sev === 'info' ? '.' : sev === 'watch' ? ' — above the 25% single-name guardrail.' : ' — a dominant single-name exposure.'),
+    formula: 'HHI = Σ wᵢ² ; effective names = 1/HHI ; wᵢ = mvᵢ / Σmv',
+    receipt: contentId(weights),
+  };
+}
+
+export function risk(book: Position[], equity: number): Finding {
+  const total = book.reduce((s, p) => s + mv(p), 0) || 1;
+  const portDailyVol = book.reduce((s, p) => s + (mv(p) / total) * dailyVol(p.series), 0);
+  const marketValue = book.reduce((s, p) => s + mv(p), 0);
+  const var95 = 1.645 * portDailyVol * marketValue;
+  const varPctEq = equity ? (var95 / equity) * 100 : 0;
+  const sev: Severity = varPctEq > 5 ? 'alert' : varPctEq > 2.5 ? 'watch' : 'info';
+  return {
+    id: 'risk', severity: sev,
+    title: `1-day VaR ≈ ${fmtMoney(var95)} (95%)`,
+    detail: `At 95% confidence the book should not lose more than ~${fmtMoney(var95)} in a day (${varPctEq.toFixed(1)}% of equity). `
+      + `Portfolio 1-day σ ${(portDailyVol * 100).toFixed(2)}%, realized per holding, aggregated correlation=1 (conservative).`,
+    formula: 'VaR₉₅ = 1.645 · σ_p · MV ; σ_p = Σ wᵢ·σᵢ ; σᵢ = stdev(daily returns)',
+    receipt: contentId(book.map((p) => [p.symbol, mv(p), dailyVol(p.series)])),
+  };
+}
+
+export function rebalance(book: Position[], maxWeight = 0.2): ProposedOrder[] {
+  const total = book.reduce((s, p) => s + mv(p), 0) || 1;
+  const cap = maxWeight * total;
+  const orders: ProposedOrder[] = [];
+  for (const p of book) {
+    if (mv(p) <= cap) continue;
+    const qty = Math.floor((mv(p) - cap) / (p.last || p.avgCost || 1));
+    if (qty <= 0) continue;
+    orders.push({ symbol: p.symbol, name: p.name, side: 'sell', qty, price: p.last,
+      rationale: `Trim to ${(maxWeight * 100).toFixed(0)}% max weight (was ${((mv(p) / total) * 100).toFixed(1)}%).` });
+  }
+  return orders;
+}
+
+export function runPortfolioAgent(goal: string, book: Position[], equity: number): AgentResult {
+  const engine = 'portfolio-agent (sovereign cloud)';
+  if (book.length === 0) {
+    return { goal, findings: [], actions: [], tools: [], narrative: 'Empty book — nothing to analyze.', receipt: contentId({ goal }), engine, attested: true };
+  }
+  const used: string[] = [];
+  const conc = concentration(book); used.push('concentration');
+  const rk = risk(book, equity); used.push('risk');
+  const findings = [conc, rk];
+
+  let actions: ProposedOrder[] = [];
+  if (/rebalanc|trim|reduce|de-?risk|concentrat|risk|diversif|cut/.test(goal.toLowerCase())) {
+    actions = rebalance(book, 0.2); used.push('rebalance');
+  }
+
+  const parts: string[] = [];
+  parts.push(conc.severity === 'info' ? 'The book is reasonably diversified.' : `Concentration is elevated — ${conc.title.toLowerCase()}.`);
+  parts.push(rk.severity === 'info' ? `Daily downside looks contained (${rk.title}).` : `Daily downside is meaningful (${rk.title}).`);
+  if (actions.length) parts.push(`Proposed ${actions.length} trim${actions.length === 1 ? '' : 's'} to a 20% single-name cap.`);
+
+  return {
+    goal, findings, actions, tools: used, narrative: parts.join(' '),
+    receipt: contentId({ goal, book: book.map((p) => [p.symbol, p.qty, p.last]), equity }),
+    engine, attested: true,
+  };
+}
+
+function fmtMoney(n: number): string {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', notation: 'compact', maximumFractionDigits: 1 }).format(n);
+}

--- a/apps/portfolio-agent/src/server.ts
+++ b/apps/portfolio-agent/src/server.ts
@@ -1,0 +1,45 @@
+// portfolio-agent — the sovereign CLOUD portfolio agent (Portfolio ②) over HTTP, so the same
+// proof-carrying tool layer the cockpit runs in-browser (①) can run server-side / autonomously.
+// The cockpit's cloud path calls this on :8094; every response carries a deterministic receipt.
+import * as http from 'node:http';
+import { runPortfolioAgent, type Position } from './agent.js';
+
+const PORT = Number(process.env.PORT ?? 8094);
+
+function json(res: http.ServerResponse, code: number, body: unknown): void {
+  res.writeHead(code, {
+    'content-type': 'application/json',
+    'access-control-allow-origin': '*',
+    'access-control-allow-methods': 'GET, POST, OPTIONS',
+    'access-control-allow-headers': 'content-type',
+  });
+  res.end(JSON.stringify(body));
+}
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve) => { let d = ''; req.on('data', (c) => (d += c)); req.on('end', () => resolve(d)); });
+}
+
+http.createServer(async (req, res) => {
+  const url = new URL(req.url ?? '/', `http://localhost:${PORT}`);
+  if (req.method === 'OPTIONS') return json(res, 204, {});
+  if (url.pathname === '/healthz') {
+    return json(res, 200, { ok: true, service: 'portfolio-agent', capabilities: ['analyze'] });
+  }
+  // POST /analyze { positions:[{symbol,name,qty,avgCost,last,series?}], goal?, equity? }
+  if (req.method === 'POST' && url.pathname === '/analyze') {
+    try {
+      const body = JSON.parse((await readBody(req)) || '{}') as { positions?: Position[]; goal?: string; equity?: number };
+      const book = (body.positions ?? []).filter((p) => p && p.qty > 0);
+      const equity = typeof body.equity === 'number' ? body.equity : book.reduce((s, p) => s + p.last * p.qty, 0);
+      const result = runPortfolioAgent(body.goal ?? 'Assess concentration and downside risk', book, equity);
+      return json(res, 200, result);
+    } catch (e) {
+      return json(res, 400, { error: 'bad request', detail: e instanceof Error ? e.message : String(e) });
+    }
+  }
+  return json(res, 404, { error: 'not_found' });
+}).listen(PORT, () => {
+  // http.listen(PORT) binds 0.0.0.0 by default — no localhost-bind CrashLoop trap.
+  // eslint-disable-next-line no-console
+  console.log(`portfolio-agent serving on :${PORT}`);
+});

--- a/apps/socioprophet-web/nginx.conf
+++ b/apps/socioprophet-web/nginx.conf
@@ -81,6 +81,8 @@ http {
         location /svc/sherlock/  { set $u sherlock-engine.socioprophet.svc.cluster.local;   rewrite ^/svc/sherlock/(.*)$  /$1 break; proxy_pass http://$u:8093; proxy_http_version 1.1; proxy_set_header Host $host; }
         # Academy retrieval → search-orchestrator (POST /v0/search/query fans in the captured academy chunks).
         location /svc/search/    { set $u search-orchestrator.socioprophet.svc.cluster.local; rewrite ^/svc/search/(.*)$   /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
+        # Sovereign cloud portfolio agent (Portfolio ②) → concentration/VaR/rebalance on :8094.
+        location /svc/portfolio/ { set $u portfolio-agent.socioprophet.svc.cluster.local;   rewrite ^/svc/portfolio/(.*)$ /$1 break; proxy_pass http://$u:8094; proxy_http_version 1.1; proxy_set_header Host $host; }
         # Studio API → lattice-studio (Notebooks, Compute Plane, Governance, Commons, Experiments,
         # FAIR/cite/versions/receipts). The client sets VITE_STUDIO_API=/svc/studio (see .env.production),
         # so studioApi requests /svc/studio/api/studio/* — the rewrite strips /svc/studio and lattice-studio

--- a/apps/socioprophet-web/src/pages/PortfolioBoard.vue
+++ b/apps/socioprophet-web/src/pages/PortfolioBoard.vue
@@ -45,9 +45,14 @@
           placeholder="Goal for the agent…"
           @keydown.enter="runAgent"
         />
-        <button class="pf-agent-run" type="button" @click="runAgent">Run</button>
+        <div class="pf-agent-engine" role="group" aria-label="Agent engine">
+          <button class="pf-eng-btn" :class="{ on: engine === 'local' }" title="Run in-browser (①)" @click="engine = 'local'">Local ①</button>
+          <button class="pf-eng-btn" :class="{ on: engine === 'cloud' }" title="Run our own sovereign cloud agent (②)" @click="engine = 'cloud'">Cloud ②</button>
+        </div>
+        <button class="pf-agent-run" type="button" :disabled="agentRunning" @click="runAgent">{{ agentRunning ? '…' : 'Run' }}</button>
         <button class="pf-agent-x" type="button" title="Close" @click="agentOpen = false">×</button>
       </div>
+      <p v-if="ranVia" class="pf-ran-via">ran via <b>{{ ranVia }}</b></p>
 
       <template v-if="agentResult">
         <p class="pf-agent-narrative">
@@ -147,7 +152,7 @@ import { useCockpit } from '../stores/cockpit';
 import ProvenanceBadge from '../components/ProvenanceBadge.vue';
 import Sparkline from '../components/Sparkline.vue';
 import { prov } from '../features/provenance/types';
-import { runPortfolioAgent, bookFromPositions, PORTFOLIO_TOOLS, type AgentResult, type ProposedOrder } from '../services/portfolioAgent';
+import { runPortfolioAgent, runCloudAgent, bookFromPositions, PORTFOLIO_TOOLS, type AgentResult, type ProposedOrder } from '../services/portfolioAgent';
 
 // P&L is deterministic compute from the blotter + marks — the verified-compute moat.
 const pnlProv = prov('computed', {
@@ -190,11 +195,27 @@ const agentGoal = ref('Reduce concentration and size my downside risk');
 const agentResult = ref<AgentResult | null>(null);
 const agentOpen = ref(false);
 const staged = ref<Set<string>>(new Set());
-function runAgent() {
+// Both ways: ① in-browser tool layer, or ② our own sovereign cloud agent (/svc/portfolio).
+const engine = ref<'local' | 'cloud'>('local');
+const agentRunning = ref(false);
+const ranVia = ref('');
+async function runAgent() {
   const book = bookFromPositions(portfolio.positions);
-  agentResult.value = runPortfolioAgent(agentGoal.value, book, equity.value);
-  staged.value = new Set();
   agentOpen.value = true;
+  agentRunning.value = true;
+  try {
+    if (engine.value === 'cloud') {
+      const cloud = await runCloudAgent(agentGoal.value, book, equity.value);
+      agentResult.value = cloud ?? runPortfolioAgent(agentGoal.value, book, equity.value);
+      ranVia.value = cloud ? 'our sovereign cloud agent ②' : 'local ① (cloud unreachable)';
+    } else {
+      agentResult.value = runPortfolioAgent(agentGoal.value, book, equity.value);
+      ranVia.value = 'the in-browser tool layer ①';
+    }
+    staged.value = new Set();
+  } finally {
+    agentRunning.value = false;
+  }
 }
 function stageOrder(a: ProposedOrder, i: number) {
   const res = portfolio.placeOrder({ symbol: a.symbol, name: a.name, side: a.side, qty: a.qty, price: a.price, source: 'agent:rebalance' });
@@ -231,7 +252,10 @@ onMounted(() => cockpit.setContext({
 .pf-agent-bar { display: flex; gap: 0.5rem; align-items: center; }
 .pf-agent-goal { flex: 1; min-width: 0; border: 1px solid var(--line-2); background: var(--surface-2, rgba(255,255,255,0.02)); color: var(--text); border-radius: 8px; padding: 0.4rem 0.6rem; font-size: 0.82rem; }
 .pf-agent-goal:focus { outline: none; border-color: rgba(110, 231, 183, 0.5); }
-.pf-agent-run { border: 1px solid rgba(110, 231, 183, 0.45); background: rgba(16, 185, 129, 0.14); color: #6ee7b7; border-radius: 8px; padding: 0.4rem 0.9rem; font-size: 0.78rem; font-weight: 600; cursor: pointer; } .pf-agent-run:hover { background: rgba(16, 185, 129, 0.24); }
+.pf-agent-run { border: 1px solid rgba(110, 231, 183, 0.45); background: rgba(16, 185, 129, 0.14); color: #6ee7b7; border-radius: 8px; padding: 0.4rem 0.9rem; font-size: 0.78rem; font-weight: 600; cursor: pointer; } .pf-agent-run:hover { background: rgba(16, 185, 129, 0.24); } .pf-agent-run:disabled { opacity: 0.6; cursor: default; }
+.pf-agent-engine { display: inline-flex; border: 1px solid var(--line-2); border-radius: 8px; overflow: hidden; }
+.pf-eng-btn { border: none; background: transparent; color: var(--text-3); font-size: 0.72rem; padding: 0.35rem 0.6rem; cursor: pointer; } .pf-eng-btn.on { background: var(--accent-soft, rgba(120,160,255,0.14)); color: var(--accent); font-weight: 600; }
+.pf-ran-via { margin: 0.1rem 0 0; font-size: 0.68rem; color: var(--text-3); } .pf-ran-via b { color: var(--text-2); }
 .pf-agent-x { border: none; background: transparent; color: var(--text-3); font-size: 1.1rem; line-height: 1; cursor: pointer; padding: 0 0.3rem; } .pf-agent-x:hover { color: var(--text); }
 .pf-agent-narrative { margin: 0; font-size: 0.86rem; line-height: 1.55; color: var(--text); display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; }
 .pf-agent-tools { margin: 0; font-size: 0.66rem; color: var(--text-3); display: flex; align-items: center; gap: 0.3rem; flex-wrap: wrap; }

--- a/apps/socioprophet-web/src/services/portfolioAgent.ts
+++ b/apps/socioprophet-web/src/services/portfolioAgent.ts
@@ -228,3 +228,44 @@ export function bookFromPositions(
 function fmtMoney(n: number): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', notation: 'compact', maximumFractionDigits: 1 }).format(n);
 }
+
+// ── Portfolio ② — our OWN sovereign cloud agent. The same tool layer, run server-side by the
+// deployed portfolio-agent service (/svc/portfolio). "Both ways": ① is this in-browser, ② is the
+// cloud. Best-effort — returns null on failure so the caller can fall back to the local ① run.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function cloudFinding(f: any): Finding {
+  return {
+    id: String(f.id), severity: f.severity, title: String(f.title), detail: String(f.detail),
+    prov: prov('computed', {
+      verifier: 'portfolio-agent (sovereign cloud)', formula: f.formula, receipt: f.receipt,
+      note: 'Computed by our own cloud agent — replayable from its inputs, not a third-party.',
+    }),
+  };
+}
+export async function runCloudAgent(goal: string, book: BookPosition[], equity: number): Promise<AgentResult | null> {
+  try {
+    const res = await fetch('/svc/portfolio/analyze', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        goal, equity,
+        positions: book.map((p) => ({ symbol: p.symbol, name: p.name, qty: p.qty, avgCost: p.avgCost, last: p.last, series: p.series })),
+      }),
+    });
+    if (!res.ok) return null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const d = (await res.json()) as any;
+    return {
+      goal: d.goal ?? goal,
+      findings: (d.findings ?? []).map(cloudFinding),
+      actions: d.actions ?? [],
+      narrative: d.narrative ?? '',
+      tools: d.tools ?? [],
+      prov: prov('computed', {
+        verifier: d.engine ?? 'portfolio-agent (sovereign cloud)', receipt: d.receipt,
+        note: 'Our own cloud agent — we roll our own, not a third-party cloud provider.',
+      }),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/socioprophet-web/vite.config.ts
+++ b/apps/socioprophet-web/vite.config.ts
@@ -83,6 +83,12 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/svc\/search/, ''),
         },
+        // Sovereign cloud portfolio agent (Portfolio ②).
+        '/svc/portfolio': {
+          target: env.VITE_PORTFOLIO_BASE || 'http://localhost:8094',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/portfolio/, ''),
+        },
         // Same-origin proxy to the live Prophet Mesh (mesh.socioprophet.ai has no CORS).
         '/mesh': {
           target: env.VITE_MESH_BASE || 'https://mesh.socioprophet.ai',

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -36,6 +36,7 @@ spec:
           - { name: ie-engine }
           - { name: synapse-bridge }
           - { name: holmes }
+          - { name: portfolio-agent }
           - { name: memoryd }
           - { name: embeddings }
           - { name: regis-acr-api }

--- a/deploy/values/portfolio-agent.yaml
+++ b/deploy/values/portfolio-agent.yaml
@@ -1,0 +1,11 @@
+# portfolio-agent — the sovereign cloud portfolio agent (Portfolio ②). The same proof-carrying tool
+# layer the cockpit runs in-browser (①: concentration / VaR / rebalance), served over HTTP so it can
+# run server-side / autonomously. The cockpit's cloud path → nginx /svc/portfolio → this on :8094.
+# Node binds 0.0.0.0 (no localhost-bind CrashLoop trap).
+#
+# tag:latest → gitops-promote pins the sha- tag on the first successful build (new-service pattern,
+# same as synapse-bridge/holmes).
+image: { repository: portfolio-agent, tag: latest }
+service: { port: 8094, portName: http }
+# tsx/esbuild needs a writable /tmp under the chart's readOnlyRootFilesystem.
+tmpDir: { enabled: true }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -115,6 +115,11 @@ KNOWN_BROKEN = {
         "New service — first-party embeddings image (apps/embeddings, FastAPI + nomic-embed-text) added to CI "
         "this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
     ),
+    "portfolio-agent:moving-tag": (
+        "New service — the sovereign cloud portfolio agent (Portfolio ②, apps/portfolio-agent: concentration/VaR/"
+        "rebalance on :8094) added to CI this PR. Pin tag:latest -> the sha- tag gitops-promote writes after the "
+        "first CI build; no sha exists until merge."
+    ),
     # sherlock-engine pinned to a sha- tag by gitops-promote after the 0.0.0.0 bind fix (#887) → removed
     # from the ratchet (it only shrinks). Same for synapse-bridge + holmes: gitops-promote sha-pinned both
     # after their first builds landed (#905/#906), so their moving-tag entries now pass and are removed.
@@ -135,8 +140,7 @@ KNOWN_BROKEN = {
     ) for svc in [
         "api", "agentic-os-api", "eval-fabric-api",
         "evidence-receipts", "gateway", "osm-map-api",
-        "search-orchestrator",
-    ]},  # hellgraph-service + evidence-console pinned to immutable sha- tags → removed from the ratchet
+    ]},  # hellgraph-service + evidence-console + search-orchestrator (academy sha-pin) → removed from the ratchet
 }
 
 # Registries that are explicitly not ours. A values file naming one of these is


### PR DESCRIPTION
## Why
You asked for **both** ① the cockpit tool layer (shipped, #909) **and** ② our own cloud agent — *"we don't yield to the cloud agent providers, we roll our own."* This is **②**.

## What
- **`apps/portfolio-agent`** — a deployed service (Node http, :8094): `POST /analyze {positions, goal, equity}` → **concentration (HHI) / 1-day 95% VaR / rebalance**, each finding carrying its **formula + a deterministic content-id receipt**. The same proof-carrying tool layer as ①, server-side so it can run autonomously. Binds `0.0.0.0`. **Verified e2e** (returns real narrative + receipt).
- **Deploy** (the holmes/synapse pattern): Dockerfile · `images.yml` · `values` (:8094) · ArgoCD ApplicationSet · preflight ratchet entry · nginx + vite `/svc/portfolio`.
- **Both ways** — the cockpit agent panel gets a **Local ① / Cloud ②** toggle; `runCloudAgent()` calls `/svc/portfolio`, best-effort with fallback to the local ① run, and shows which engine answered. **Same `AgentResult` contract either way.**
- Cleared the stale `search-orchestrator` ratchet entry (academy sha-pin).

## Verify
`vue-tsc` + `npm run build` + `preflight` clean; local `/analyze` returns `engine: portfolio-agent (sovereign cloud)` with a real narrative + receipt. Cloud path lights up once the image builds + rolls.