### PR TITLE
academy: real sovereign board engine — kill the mastery-check paper tiger

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -76,6 +76,7 @@ jobs:
           - { image: synapse-bridge,        context: apps/synapse-bridge,        dockerfile: Dockerfile }
           - { image: holmes,                context: apps/holmes,                dockerfile: Dockerfile }
           - { image: portfolio-agent,       context: apps/portfolio-agent,       dockerfile: Dockerfile }
+          - { image: academy-board,         context: apps/academy-board,         dockerfile: Dockerfile }
           - { image: memoryd,               context: apps/memoryd,               dockerfile: Dockerfile }
           - { image: node-commander,        context: apps/node-commander,        dockerfile: Dockerfile }
           - { image: liberty-stack-readout, context: apps/liberty-stack-readout, dockerfile: Dockerfile }

--- a/apps/academy-board/Dockerfile
+++ b/apps/academy-board/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.7
+# academy-board — the sovereign scoring service behind the Academy mastery check, on :8095.
+# The answer key lives in the image, never in the browser bundle, so grading is a real authority
+# a client cannot read or forge; each verdict carries a deterministic receipt. No native deps.
+# Runs as uid 10001 under the chart's readOnlyRootFilesystem — tsx/esbuild writes only to /tmp
+# (values sets tmpDir.enabled). http.listen(PORT) binds 0.0.0.0 (no localhost-bind CrashLoop trap).
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --no-audit --no-fund && chown -R 10001:10001 /app
+COPY src ./src
+ENV PORT=8095
+EXPOSE 8095
+USER 10001
+CMD ["npx", "tsx", "src/server.ts"]

--- a/apps/academy-board/package.json
+++ b/apps/academy-board/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "academy-board",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Sovereign Academy board engine — server-authoritative mastery-check grading with deterministic receipts (answer key never ships to the browser)",
+  "dependencies": {
+    "tsx": "^4.19.2"
+  }
+}

--- a/apps/academy-board/src/board.ts
+++ b/apps/academy-board/src/board.ts
@@ -1,0 +1,90 @@
+// The board engine: deterministic, server-authoritative grading with a content-id receipt.
+// A verdict is a fact about (course, item, pick) that any party can recompute and check —
+// the same proof-carrying posture as the rest of the estate (portfolio-agent, holmes).
+
+import { ANSWER_KEY, type KeyItem } from './keys.js';
+
+// djb2 — a small, dependency-free content hash. The receipt id is a function of the exact
+// inputs + verdict, so an identical submission yields an identical receipt (deterministic),
+// and any tampering with what was asked/answered changes the id.
+function djb2(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff;
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+export interface Receipt {
+  id: string;
+  verifier: 'academy-board';
+  formula: string;
+  at: string;
+}
+
+export interface ItemVerdict {
+  itemId: string;
+  correct: boolean;
+  answer: number;     // the authoritative correct index — only revealed by a graded response
+  explain: string;
+  concept: string;
+  chunkRef: string;   // what the mastery was measured against
+  receipt: Receipt;
+}
+
+export interface BoardVerdict {
+  courseId: string;
+  total: number;
+  correct: number;
+  scored: number;     // how many of the board's items this submission covered
+  mastered: boolean;  // every item on the board answered correctly
+  items: ItemVerdict[];
+  receipt: Receipt;
+}
+
+function key(courseId: string): Record<string, KeyItem> | null {
+  return ANSWER_KEY[courseId] ?? null;
+}
+
+export function courseKnown(courseId: string): boolean {
+  return key(courseId) !== null;
+}
+
+// Grade one pick. Returns null for an unknown course/item so the caller answers 404 rather
+// than inventing a verdict.
+export function gradeItem(courseId: string, itemId: string, pick: number): ItemVerdict | null {
+  const k = key(courseId);
+  const it = k?.[itemId];
+  if (!it) return null;
+  const correct = pick === it.answer;
+  const at = new Date().toISOString();
+  const receipt: Receipt = {
+    id: `bd-${djb2([courseId, itemId, String(pick), String(it.answer), it.chunkRef].join('|'))}`,
+    verifier: 'academy-board',
+    formula: 'verdict = (pick === answer); grounded in ' + it.chunkRef,
+    at,
+  };
+  return { itemId, correct, answer: it.answer, explain: it.explain, concept: it.concept, chunkRef: it.chunkRef, receipt };
+}
+
+// Grade a whole board submission. The board receipt binds the per-item verdicts, so a "mastered"
+// claim is itself checkable — its id is a function of every (item, pick) and the resulting score.
+export function gradeBoard(courseId: string, submissions: Array<{ itemId: string; pick: number }>): BoardVerdict | null {
+  const k = key(courseId);
+  if (!k) return null;
+  const total = Object.keys(k).length;
+  const items: ItemVerdict[] = [];
+  for (const s of submissions) {
+    const v = gradeItem(courseId, s.itemId, s.pick);
+    if (v) items.push(v);
+  }
+  const correct = items.filter((v) => v.correct).length;
+  const scored = items.length;
+  const mastered = scored === total && correct === total;
+  const at = new Date().toISOString();
+  const receipt: Receipt = {
+    id: `bd-board-${djb2([courseId, String(total), String(correct), ...items.map((v) => `${v.itemId}:${v.correct ? 1 : 0}`)].join('|'))}`,
+    verifier: 'academy-board',
+    formula: `score = Σ(pick === answer) over ${total} grounded items; mastered = score === total`,
+    at,
+  };
+  return { courseId, total, correct, scored, mastered, items, receipt };
+}

--- a/apps/academy-board/src/keys.ts
+++ b/apps/academy-board/src/keys.ts
@@ -1,0 +1,38 @@
+// Server-side answer key for the Academy mastery check. This is the whole point of the
+// service: the correct-answer index and explanation live HERE, never in the browser bundle,
+// so the "board engine" is a real authority a client cannot read or forge. Each item is
+// GROUNDED — it carries the captured-lecture chunkRef the mastery is measured against, so a
+// verdict cites the same OpenCourseWare segment the tutor quotes from.
+//
+// Seeded from MIT 8.01 Classical Mechanics (Walter Lewin, OCW CC BY-NC-SA 4.0). Adding a
+// course is data-only: a new courseId block.
+
+export interface KeyItem {
+  answer: number;   // index into the options the client renders
+  explain: string;  // shown only AFTER a pick, returned by the grade response
+  concept: string;
+  chunkRef: string; // captured-lecture provenance the item is grounded in
+}
+
+export type CourseKey = Record<string, KeyItem>;
+
+export const ANSWER_KEY: Record<string, CourseKey> = {
+  'ocw-801': {
+    a1: {
+      answer: 1, concept: 'acceleration', chunkRef: '8.01SC · L02 · seg 07',
+      explain: 'At the top the ball is momentarily at rest (v = 0) but gravity never stops — acceleration is 9.8 m/s² downward throughout (Lecture 2).',
+    },
+    a2: {
+      answer: 2, concept: 'projectile motion', chunkRef: '8.01SC · L03 · seg 15',
+      explain: 'Horizontal and vertical motion are independent; both have the same vertical drop under gravity, so they land together (Lecture 3).',
+    },
+    a3: {
+      answer: 1, concept: 'Newton’s third law', chunkRef: '8.01SC · L04 · seg 09',
+      explain: 'Newton’s third-law pairs are equal and opposite but act on different bodies, so they can’t cancel on a single object (Lecture 4).',
+    },
+    a4: {
+      answer: 2, concept: 'centripetal force', chunkRef: '8.01SC · L05 · seg 04',
+      explain: 'A centripetal (center-pointing) net force is required; “centrifugal force” is just felt inertia, not a real inward force (Lecture 5).',
+    },
+  },
+};

--- a/apps/academy-board/src/server.ts
+++ b/apps/academy-board/src/server.ts
@@ -1,0 +1,68 @@
+// academy-board — the sovereign scoring service behind the Academy mastery check.
+// The cockpit posts a pick (or a whole board); the answer key lives here, and every verdict
+// comes back with a deterministic receipt. Node http, no framework, binds 0.0.0.0 so the
+// kubelet liveness probe reaches it (a 127.0.0.1 bind → CrashLoop 137).
+
+import http from 'node:http';
+import { gradeItem, gradeBoard, courseKnown } from './board.js';
+
+const PORT = Number(process.env.PORT ?? 8095);
+
+function send(res: http.ServerResponse, code: number, body: unknown) {
+  const s = JSON.stringify(body);
+  res.writeHead(code, {
+    'content-type': 'application/json',
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'content-type',
+    'access-control-allow-methods': 'POST, GET, OPTIONS',
+  });
+  res.end(s);
+}
+
+function readJson(req: http.IncomingMessage): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let raw = '';
+    req.on('data', (c) => { raw += c; if (raw.length > 1_000_000) req.destroy(); });
+    req.on('end', () => { try { resolve(raw ? JSON.parse(raw) : {}); } catch (e) { reject(e); } });
+    req.on('error', reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+  if (req.method === 'OPTIONS') return send(res, 204, {});
+
+  if (req.method === 'GET' && url.pathname === '/healthz') return send(res, 200, { ok: true, service: 'academy-board' });
+
+  if (req.method === 'POST' && url.pathname === '/grade') {
+    try {
+      const b = await readJson(req);
+      const courseId = String(b.courseId ?? '');
+      const itemId = String(b.itemId ?? '');
+      const pick = Number(b.pick);
+      if (!courseKnown(courseId)) return send(res, 404, { error: `unknown course ${courseId}` });
+      if (!Number.isInteger(pick)) return send(res, 400, { error: 'pick must be an integer index' });
+      const v = gradeItem(courseId, itemId, pick);
+      if (!v) return send(res, 404, { error: `unknown item ${itemId}` });
+      return send(res, 200, v);
+    } catch { return send(res, 400, { error: 'bad json' }); }
+  }
+
+  if (req.method === 'POST' && url.pathname === '/grade-board') {
+    try {
+      const b = await readJson(req);
+      const courseId = String(b.courseId ?? '');
+      const subs = Array.isArray(b.submissions) ? b.submissions : [];
+      const v = gradeBoard(courseId, subs.map((s: any) => ({ itemId: String(s.itemId), pick: Number(s.pick) })));
+      if (!v) return send(res, 404, { error: `unknown course ${courseId}` });
+      return send(res, 200, v);
+    } catch { return send(res, 400, { error: 'bad json' }); }
+  }
+
+  send(res, 404, { error: 'not found' });
+});
+
+server.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`academy-board listening on :${PORT}`);
+});

--- a/apps/socioprophet-web/nginx.conf
+++ b/apps/socioprophet-web/nginx.conf
@@ -83,6 +83,8 @@ http {
         location /svc/search/    { set $u search-orchestrator.socioprophet.svc.cluster.local; rewrite ^/svc/search/(.*)$   /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
         # Sovereign cloud portfolio agent (Portfolio ②) → concentration/VaR/rebalance on :8094.
         location /svc/portfolio/ { set $u portfolio-agent.socioprophet.svc.cluster.local;   rewrite ^/svc/portfolio/(.*)$ /$1 break; proxy_pass http://$u:8094; proxy_http_version 1.1; proxy_set_header Host $host; }
+        # Sovereign Academy board engine → server-authoritative mastery-check grading + receipts on :8095.
+        location /svc/board/     { set $u academy-board.socioprophet.svc.cluster.local;      rewrite ^/svc/board/(.*)$     /$1 break; proxy_pass http://$u:8095; proxy_http_version 1.1; proxy_set_header Host $host; }
         # Studio API → lattice-studio (Notebooks, Compute Plane, Governance, Commons, Experiments,
         # FAIR/cite/versions/receipts). The client sets VITE_STUDIO_API=/svc/studio (see .env.production),
         # so studioApi requests /svc/studio/api/studio/* — the rewrite strips /svc/studio and lattice-studio

--- a/apps/socioprophet-web/src/data/courseFixture.ts
+++ b/apps/socioprophet-web/src/data/courseFixture.ts
@@ -16,13 +16,15 @@ export interface Lesson {
   transcript: string;    // the captured lecture segment the tutor quotes from
 }
 
+// The mastery-check question as the browser sees it — question + options ONLY. The correct-answer
+// index and the explanation are NOT here: they live in the academy-board service and are revealed
+// only in a graded verdict (see services/academyBoard.ts). Shipping the answer key to the client
+// would make the board trivially cheatable and the "verified assessment" claim a paper tiger.
 export interface AssessmentItem {
   id: string;
   concept: string;
   q: string;
   options: string[];
-  answer: number;        // index into options
-  explain: string;
 }
 
 export interface Course {
@@ -85,26 +87,23 @@ const PHYSICS_801: Course = {
         'An object moving in a circle at constant speed is still accelerating, because the direction of its velocity is always changing. That acceleration points toward the center of the circle and is called centripetal acceleration; its magnitude is v squared divided by r. There is no such thing as centrifugal force pushing you outward — what you feel is your own inertia, and some real force, such as tension or friction, must point inward to keep you on the circular path.',
     },
   ],
+  // Questions + options only — the answer key lives server-side in academy-board (keys.ts).
   assessment: [
     {
       id: 'a1', concept: 'acceleration', q: 'A ball is thrown straight up. At the highest point of its flight, what is true?',
       options: ['Velocity and acceleration are both zero', 'Velocity is zero, acceleration is 9.8 m/s² downward', 'Velocity is maximum, acceleration is zero', 'Both point upward'],
-      answer: 1, explain: 'At the top the ball is momentarily at rest (v = 0) but gravity never stops — acceleration is 9.8 m/s² downward throughout (Lecture 2).',
     },
     {
       id: 'a2', concept: 'projectile motion', q: 'A bullet fired horizontally and a bullet dropped from the same height — which lands first?',
       options: ['The fired bullet', 'The dropped bullet', 'They land at the same time', 'Depends on the muzzle speed'],
-      answer: 2, explain: 'Horizontal and vertical motion are independent; both have the same vertical drop under gravity, so they land together (Lecture 3).',
     },
     {
       id: 'a3', concept: 'Newton’s third law', q: 'Why do action–reaction force pairs never cancel each other out?',
       options: ['They are unequal', 'They act on different objects', 'One is always larger', 'They act at different times'],
-      answer: 1, explain: 'Newton’s third-law pairs are equal and opposite but act on different bodies, so they can’t cancel on a single object (Lecture 4).',
     },
     {
       id: 'a4', concept: 'centripetal force', q: 'What keeps an object moving in a circle at constant speed?',
       options: ['An outward centrifugal force', 'No force — it moves freely', 'A net force directed toward the center', 'Its own momentum only'],
-      answer: 2, explain: 'A centripetal (center-pointing) net force is required; “centrifugal force” is just felt inertia, not a real inward force (Lecture 5).',
     },
   ],
 };

--- a/apps/socioprophet-web/src/pages/CourseView.vue
+++ b/apps/socioprophet-web/src/pages/CourseView.vue
@@ -35,11 +35,14 @@
         </template>
 
         <template v-else-if="tab === 'quiz'">
-          <div class="cvw-lesson-h">Mastery check <span>board engine · deterministic scoring</span></div>
+          <div class="cvw-lesson-h">Mastery check <span>board engine · server-scored · receipts</span></div>
           <div class="cvw-score" :class="{ done: answered === course.assessment.length }">
             <b>{{ correct }}</b> / {{ course.assessment.length }} correct
             <span v-if="answered < course.assessment.length">· {{ course.assessment.length - answered }} to go</span>
-            <span v-else class="cvw-score-tag">{{ correct === course.assessment.length ? 'mastered' : 'keep going' }}</span>
+            <template v-else>
+              <span class="cvw-score-tag">{{ board?.mastered ? 'mastered' : 'keep going' }}</span>
+              <span v-if="board" class="cvw-receipt" :title="board.receipt.formula">▪ {{ board.receipt.id }}</span>
+            </template>
           </div>
           <div v-for="item in course.assessment" :key="item.id" class="cvw-q">
             <div class="cvw-q-text">{{ item.q }}</div>
@@ -54,8 +57,11 @@
                 <span class="cvw-opt-mark">{{ optMark(item, i) }}</span>{{ opt }}
               </button>
             </div>
-            <div v-if="picks[item.id] !== undefined" class="cvw-explain" :class="{ ok: picks[item.id] === item.answer }">
-              {{ picks[item.id] === item.answer ? '✓ ' : '✗ ' }}{{ item.explain }}
+            <div v-if="grading[item.id]" class="cvw-explain">Grading on the board engine…</div>
+            <div v-else-if="unavailable[item.id]" class="cvw-explain unavail">Board engine unavailable — click an option to retry.</div>
+            <div v-else-if="verdicts[item.id]" class="cvw-explain" :class="{ ok: verdicts[item.id].correct }">
+              {{ verdicts[item.id].correct ? '✓ ' : '✗ ' }}{{ verdicts[item.id].explain }}
+              <span class="cvw-receipt" :title="verdicts[item.id].receipt.formula">▪ {{ verdicts[item.id].receipt.id }} · {{ verdicts[item.id].chunkRef }}</span>
             </div>
           </div>
         </template>
@@ -76,6 +82,7 @@ import SurfaceHeader from '../components/SurfaceHeader.vue';
 import GroundedTutor from '../components/GroundedTutor.vue';
 import { useCockpit } from '../stores/cockpit';
 import { getCourse, type AssessmentItem } from '../data/courseFixture';
+import { gradeItem, gradeBoard, type ItemVerdict, type BoardVerdict } from '../services/academyBoard';
 
 const route = useRoute();
 const cockpit = useCockpit();
@@ -92,27 +99,62 @@ function openLesson(id: string) {
   nextTick(() => transcriptEl.value?.scrollIntoView({ block: 'nearest', behavior: 'smooth' }));
 }
 
-// Mastery check state
+// Mastery check state. The correct answer is NOT in this bundle — every verdict comes from the
+// academy-board service, so `picks` only records which option the learner chose; the graded
+// verdict (with its receipt + the authoritative answer index) lands in `verdicts`.
 const picks = ref<Record<string, number>>({});
-function pick(itemId: string, i: number) { if (picks.value[itemId] === undefined) picks.value = { ...picks.value, [itemId]: i }; }
-const answered = computed(() => Object.keys(picks.value).length);
-const correct = computed(() => course.value.assessment.filter((it) => picks.value[it.id] === it.answer).length);
+const verdicts = ref<Record<string, ItemVerdict>>({});
+const grading = ref<Record<string, boolean>>({});
+const unavailable = ref<Record<string, boolean>>({});
+const board = ref<BoardVerdict | null>(null);
+
+async function pick(itemId: string, i: number) {
+  if (picks.value[itemId] !== undefined) return;
+  picks.value = { ...picks.value, [itemId]: i };
+  unavailable.value = { ...unavailable.value, [itemId]: false };
+  grading.value = { ...grading.value, [itemId]: true };
+  const v = await gradeItem(course.value.id, itemId, i);
+  grading.value = { ...grading.value, [itemId]: false };
+  if (v) {
+    verdicts.value = { ...verdicts.value, [itemId]: v };
+  } else {
+    // Board engine unreachable — degrade honestly, never fake a verdict. Re-enable for retry.
+    unavailable.value = { ...unavailable.value, [itemId]: true };
+    const { [itemId]: _drop, ...rest } = picks.value;
+    picks.value = rest;
+  }
+}
+
+const answered = computed(() => Object.keys(verdicts.value).length);
+const correct = computed(() => Object.values(verdicts.value).filter((v) => v.correct).length);
 function optClass(item: AssessmentItem, i: number) {
-  const p = picks.value[item.id];
-  if (p === undefined) return '';
-  if (i === item.answer) return 'correct';
-  if (i === p) return 'wrong';
+  const v = verdicts.value[item.id];
+  if (!v) return '';
+  if (i === v.answer) return 'correct';
+  if (i === picks.value[item.id]) return 'wrong';
   return 'muted';
 }
 function optMark(item: AssessmentItem, i: number): string {
-  const p = picks.value[item.id];
-  if (p === undefined) return '○';
-  if (i === item.answer) return '✓';
-  if (i === p) return '✗';
+  const v = verdicts.value[item.id];
+  if (!v) return '○';
+  if (i === v.answer) return '✓';
+  if (i === picks.value[item.id]) return '✗';
   return '○';
 }
 
-watch(course, (c) => { selectedId.value = c.lessons[0]?.id ?? ''; tab.value = 'lesson'; picks.value = {}; });
+// Once every item is graded, fetch the board-level receipt that binds the per-item verdicts —
+// so a "mastered" claim is itself checkable, not just a client-side count.
+watch(answered, async (n) => {
+  if (n === course.value.assessment.length && !board.value) {
+    board.value = await gradeBoard(course.value.id, Object.entries(picks.value).map(([itemId, p]) => ({ itemId, pick: p })));
+  }
+});
+
+watch(course, (c) => {
+  selectedId.value = c.lessons[0]?.id ?? '';
+  tab.value = 'lesson';
+  picks.value = {}; verdicts.value = {}; grading.value = {}; unavailable.value = {}; board.value = null;
+});
 watch([() => route.path, tab, selectedId], () => {
   cockpit.setContext({ surface: 'Academy · Course', entityLabel: course.value.title, detail: tab.value === 'quiz' ? 'mastery check' : (lesson.value?.title ?? ''), route: route.path });
 }, { immediate: true });
@@ -155,7 +197,8 @@ onMounted(() => { if (route.path.endsWith('/tutor')) { /* land on flagship with 
 .cvw-opt.correct { border-color: rgba(63,185,80,0.5); background: rgba(63,185,80,0.08); color: #86efac; } .cvw-opt.correct .cvw-opt-mark { color: var(--up); }
 .cvw-opt.wrong { border-color: rgba(248,81,73,0.5); background: rgba(248,81,73,0.08); color: #fca5a5; } .cvw-opt.wrong .cvw-opt-mark { color: var(--down); }
 .cvw-opt.muted { opacity: 0.5; }
-.cvw-explain { margin-top: 0.4rem; font-size: 0.76rem; line-height: 1.5; color: var(--text-3); } .cvw-explain.ok { color: #86efac; }
+.cvw-explain { margin-top: 0.4rem; font-size: 0.76rem; line-height: 1.5; color: var(--text-3); } .cvw-explain.ok { color: #86efac; } .cvw-explain.unavail { color: var(--down); }
+.cvw-receipt { margin-left: 0.4rem; font-family: ui-monospace, monospace; font-size: 0.64rem; color: var(--text-3); white-space: nowrap; }
 
 .cvw-tutor { min-height: 0; overflow-y: auto; }
 </style>

--- a/apps/socioprophet-web/src/services/academyBoard.ts
+++ b/apps/socioprophet-web/src/services/academyBoard.ts
@@ -1,0 +1,65 @@
+// Academy mastery-check client → academy-board, the sovereign scoring service. The correct-answer
+// index and explanation are NOT in this bundle — they live in the service, which returns a verdict
+// only after a pick, each carrying a deterministic receipt. That's the whole point: grading is a
+// real server authority (not client-side `pick === answer`), so a "mastered" claim is checkable and
+// the answer key can't be read out of the page.
+//
+// Best-effort: if the board engine is unreachable the caller gets null and the UI degrades honestly
+// ("grading unavailable") rather than inventing a verdict — we never re-ship the answers to fake it.
+import { resolveBase } from '../config/cockpitRuntime';
+
+const BOARD = resolveBase('board', 'VITE_BOARD_BASE', '/svc/board');
+
+export interface BoardReceipt {
+  id: string;
+  verifier: 'academy-board';
+  formula: string;
+  at: string;
+}
+
+export interface ItemVerdict {
+  itemId: string;
+  correct: boolean;
+  answer: number;   // authoritative correct index — revealed only by a graded response
+  explain: string;
+  concept: string;
+  chunkRef: string; // captured-lecture segment the item is grounded in
+  receipt: BoardReceipt;
+}
+
+export interface BoardVerdict {
+  courseId: string;
+  total: number;
+  correct: number;
+  scored: number;
+  mastered: boolean;
+  items: ItemVerdict[];
+  receipt: BoardReceipt;
+}
+
+async function post<T>(path: string, body: unknown): Promise<T | null> {
+  try {
+    const res = await fetch(`${BOARD}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Grade a single pick. Returns the verdict (with receipt) or null if the board engine is down. */
+export function gradeItem(courseId: string, itemId: string, pick: number): Promise<ItemVerdict | null> {
+  return post<ItemVerdict>('/grade', { courseId, itemId, pick });
+}
+
+/** Grade a whole board submission; the board receipt binds every per-item verdict. */
+export function gradeBoard(
+  courseId: string,
+  submissions: Array<{ itemId: string; pick: number }>,
+): Promise<BoardVerdict | null> {
+  return post<BoardVerdict>('/grade-board', { courseId, submissions });
+}

--- a/apps/socioprophet-web/vite.config.ts
+++ b/apps/socioprophet-web/vite.config.ts
@@ -89,6 +89,12 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/svc\/portfolio/, ''),
         },
+        // Sovereign Academy board engine (server-authoritative mastery-check grading + receipts).
+        '/svc/board': {
+          target: env.VITE_BOARD_BASE || 'http://localhost:8095',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/board/, ''),
+        },
         // Same-origin proxy to the live Prophet Mesh (mesh.socioprophet.ai has no CORS).
         '/mesh': {
           target: env.VITE_MESH_BASE || 'https://mesh.socioprophet.ai',

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -37,6 +37,7 @@ spec:
           - { name: synapse-bridge }
           - { name: holmes }
           - { name: portfolio-agent }
+          - { name: academy-board }
           - { name: memoryd }
           - { name: embeddings }
           - { name: regis-acr-api }

--- a/deploy/values/academy-board.yaml
+++ b/deploy/values/academy-board.yaml
@@ -1,0 +1,11 @@
+# academy-board — the sovereign scoring service behind the Academy mastery check. The answer key
+# lives in the image, never in the browser bundle, so grading is a real authority (not client-side
+# `pick === answer`), and each verdict carries a deterministic receipt. The cockpit's mastery check
+# → nginx /svc/board → this on :8095. Node binds 0.0.0.0 (no localhost-bind CrashLoop trap).
+#
+# tag:latest → gitops-promote pins the sha- tag on the first successful build (new-service pattern,
+# same as portfolio-agent/synapse-bridge/holmes).
+image: { repository: academy-board, tag: latest }
+service: { port: 8095, portName: http }
+# tsx/esbuild needs a writable /tmp under the chart's readOnlyRootFilesystem.
+tmpDir: { enabled: true }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -115,10 +115,12 @@ KNOWN_BROKEN = {
         "New service — first-party embeddings image (apps/embeddings, FastAPI + nomic-embed-text) added to CI "
         "this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
     ),
-    "portfolio-agent:moving-tag": (
-        "New service — the sovereign cloud portfolio agent (Portfolio ②, apps/portfolio-agent: concentration/VaR/"
-        "rebalance on :8094) added to CI this PR. Pin tag:latest -> the sha- tag gitops-promote writes after the "
-        "first CI build; no sha exists until merge."
+    # portfolio-agent pinned to a sha- tag by gitops-promote after its first CI build (#925,
+    # sha-a6d8311383) → removed from the ratchet (it only shrinks).
+    "academy-board:moving-tag": (
+        "New service — the sovereign Academy board engine (apps/academy-board: server-authoritative mastery-check "
+        "grading + receipts on :8095, answer key never ships to the browser) added to CI this PR. Pin tag:latest -> "
+        "the sha- tag gitops-promote writes after the first CI build; no sha exists until merge."
     ),
     # sherlock-engine pinned to a sha- tag by gitops-promote after the 0.0.0.0 bind fix (#887) → removed
     # from the ratchet (it only shrinks). Same for synapse-bridge + holmes: gitops-promote sha-pinned both


### PR DESCRIPTION
## Why
The Academy mastery check called itself **"board engine · deterministic scoring / verified assessment"** but was UI-only: the correct-answer index **shipped in the browser bundle** and scoring was client-side `picks[id] === item.answer`. Trivially cheatable, and an **unattested claim** in a cockpit where every other surface is proof-carrying. A paper tiger.

## What
- **`apps/academy-board`** — a sovereign scoring service (Node http, :8095). The **answer key lives in the image, never in the browser**. `POST /grade {courseId,itemId,pick}` and `POST /grade-board` return a verdict per item, each **grounded** in the captured-lecture `chunkRef` it measures and carrying a **deterministic content-id receipt**; the board receipt binds the per-item verdicts so a *mastered* claim is itself checkable. Binds `0.0.0.0`. **Verified e2e** — correct/wrong verdicts, grounded chunkRefs, board `mastered:true`, 404 on unknown course.
- **Deploy** (holmes/portfolio-agent pattern): Dockerfile · `images.yml` · `values` (:8095) · ArgoCD ApplicationSet · preflight ratchet · nginx + vite `/svc/board`.
- **Cockpit** — `courseFixture` drops `answer`/`explain` (**answer key out of the bundle**); `CourseView` grades each pick against the service, renders the **receipt + grounding**, and **degrades honestly** (`board engine unavailable — retry`) rather than faking a verdict when the service is down.

## Verify
`vue-tsc` + `npm run build` + `preflight` clean. Local: `/grade` returns a grounded verdict + `bd-…` receipt; `/grade-board` returns `mastered:true` + a binding `bd-board-…` receipt; unknown course → 404. Cloud path lights up once the image builds + rolls.