### PR TITLE
studio: design-language anneal (1/N) — Carbon shell + Data Catalog

### DIFF
--- a/apps/socioprophet-web/src/config/cockpitNav.ts
+++ b/apps/socioprophet-web/src/config/cockpitNav.ts
@@ -218,6 +218,7 @@ export const AGENT_COCKPIT: NavGroup[] = [
     items: [
       { label: 'Notebooks', to: '/studio?section=notebooks' },
       { label: 'Compute Plane', to: '/studio?section=compute' },
+      { label: 'Data Catalog', to: '/studio?section=catalog' },
       { label: 'Graph Explorer', to: '/studio?section=graph' },
       { label: 'Query Console', to: '/studio?section=query' },
       { label: 'Analytics', to: '/studio?section=analytics' },

--- a/apps/socioprophet-web/src/pages/Studio.vue
+++ b/apps/socioprophet-web/src/pages/Studio.vue
@@ -9,6 +9,7 @@ import { useRoute, useRouter } from 'vue-router';
 import './studio/studio-tokens.css';
 import StudioNotebooks from './studio/StudioNotebooks.vue';
 import StudioCompute from './studio/StudioCompute.vue';
+import StudioCatalog from './studio/StudioCatalog.vue';
 import GraphExplorer from './studio/GraphExplorer.vue';
 import QueryConsole from './studio/QueryConsole.vue';
 import Analytics from './studio/Analytics.vue';
@@ -27,6 +28,7 @@ const GROUPS: { group: string; items: Sec[] }[] = [
   { group: 'Workbench', items: [
     { id: 'notebooks', label: 'Notebooks', ic: '⬢', comp: markRaw(StudioNotebooks), project: true, sub: 'Ray-backed governed notebooks — receipt per cell' },
     { id: 'compute', label: 'Compute Plane', ic: '⛩', comp: markRaw(StudioCompute), project: true, sub: 'Universal Compute Plane — one governed, proof-carrying door' },
+    { id: 'catalog', label: 'Data Catalog', ic: '▤', comp: markRaw(StudioCatalog), project: true, sub: 'Datasets as proof-carrying nodes — epistemic status + ingest volume' },
   ]},
   { group: 'Knowledge engineering', items: [
     { id: 'graph', label: 'Graph Explorer', ic: '⟡', comp: markRaw(GraphExplorer), sub: 'Force-directed graph + provenance inspector' },
@@ -65,20 +67,28 @@ function go(id: string) { current.value = id; router.replace({ query: { ...route
 <template>
   <div class="studio-scope studio-shell">
     <aside class="st-rail">
-      <div class="st-brand"><b>Studio</b><small>sovereign data + AI workbench</small></div>
-      <nav class="st-nav">
+      <div class="st-brand">
+        <span class="st-brand-mark">◈</span>
+        <span class="st-brand-txt"><b>Studio</b><small>sovereign data + AI workbench</small></span>
+      </div>
+      <nav class="st-nav" aria-label="Studio sections">
         <template v-for="g in GROUPS" :key="g.group">
           <div class="st-group">{{ g.group }}</div>
-          <a v-for="i in g.items" :key="i.id" :class="{ on: current === i.id }" @click="go(i.id)">
-            <span class="st-ic">{{ i.ic }}</span>{{ i.label }}
+          <a
+            v-for="i in g.items" :key="i.id" class="st-link" :class="{ on: current === i.id }"
+            role="button" tabindex="0" :aria-current="current === i.id ? 'page' : undefined"
+            @click="go(i.id)" @keydown.enter.prevent="go(i.id)" @keydown.space.prevent="go(i.id)"
+          >
+            <span class="st-ic">{{ i.ic }}</span><span class="st-link-t">{{ i.label }}</span>
           </a>
         </template>
       </nav>
     </aside>
     <section class="st-main">
       <header class="st-top">
-        <div><h1>{{ active.label }}</h1><span class="st-sub">{{ active.sub }}</span></div>
-        <span class="pill accent">proof-carrying · sovereign</span>
+        <span class="st-top-ic">{{ active.ic }}</span>
+        <div class="st-top-h"><h1>{{ active.label }}</h1><span class="st-sub">{{ active.sub }}</span></div>
+        <span class="pill accent st-top-badge">proof-carrying · sovereign</span>
       </header>
       <div class="st-view">
         <component :is="active.comp" :key="active.id" v-bind="active.project ? { project } : {}" />
@@ -88,20 +98,37 @@ function go(id: string) { current.value = id; router.replace({ query: { ...route
 </template>
 
 <style scoped>
-.studio-shell { display: grid; grid-template-columns: 216px 1fr; height: calc(100vh - 7rem); min-height: 520px; border: 1px solid var(--border); border-radius: 14px; overflow: hidden; background: var(--bg); color: var(--text); }
-.st-rail { background: var(--panel); border-right: 1px solid var(--border); display: flex; flex-direction: column; overflow: hidden; }
-.st-brand { padding: .9rem 1rem; border-bottom: 1px solid var(--border); }
-.st-brand b { font-size: 1rem; }
-.st-brand small { display: block; color: var(--faint); font-size: .62rem; text-transform: uppercase; letter-spacing: .08em; margin-top: .1rem; }
-.st-nav { padding: .5rem; overflow-y: auto; flex: 1; }
-.st-group { color: var(--faint); font-size: .62rem; text-transform: uppercase; letter-spacing: .09em; padding: .8rem .6rem .25rem; }
-.st-nav a { display: flex; align-items: center; gap: .55rem; padding: .45rem .6rem; border-radius: 8px; color: var(--muted); cursor: pointer; font-size: .84rem; user-select: none; }
-.st-nav a:hover { background: var(--panel-2); color: var(--text); }
-.st-nav a.on { background: #1b2740; color: var(--text); }
-.st-ic { width: 16px; text-align: center; opacity: .85; }
-.st-main { display: flex; flex-direction: column; overflow: hidden; }
-.st-top { display: flex; align-items: center; justify-content: space-between; gap: .8rem; padding: .7rem 1.1rem; border-bottom: 1px solid var(--border); background: var(--panel); }
-.st-top h1 { font-size: 1rem; margin: 0; font-weight: 600; }
-.st-sub { color: var(--muted); font-size: .8rem; }
-.st-view { flex: 1; overflow: auto; padding: 1.1rem 1.2rem; }
+/* Carbon UI-Shell chrome, driven entirely by studio-tokens: a dark shell bar (--bar) for the
+   SideNav + header, content on --bg, and the signature Carbon active treatment (accent-wash fill
+   + a 3px accent left indicator). Square-ish chrome, token spacing, real focus rings. */
+.studio-shell { display: grid; grid-template-columns: 256px 1fr; height: calc(100vh - 7rem); min-height: 520px; border: 1px solid var(--hairline); border-radius: var(--r-3); overflow: hidden; background: var(--bg); color: var(--text); }
+
+/* SideNav */
+.st-rail { background: var(--bar); border-right: 1px solid var(--bar-line); display: flex; flex-direction: column; overflow: hidden; }
+.st-brand { display: flex; align-items: center; gap: var(--sp-3); height: 3rem; padding: 0 var(--sp-4); border-bottom: 1px solid var(--bar-line); flex: 0 0 auto; }
+.st-brand-mark { color: var(--accent); font-size: 1rem; }
+.st-brand-txt { display: flex; flex-direction: column; line-height: 1.1; }
+.st-brand-txt b { font-size: .9rem; color: var(--bar-ink); letter-spacing: .01em; }
+.st-brand-txt small { color: var(--faint); font-size: .58rem; text-transform: uppercase; letter-spacing: .09em; margin-top: 2px; }
+.st-nav { padding: var(--sp-2) 0 var(--sp-3); overflow-y: auto; flex: 1; }
+.st-group { color: var(--faint); font-size: .6rem; text-transform: uppercase; letter-spacing: .1em; padding: var(--sp-4) var(--sp-4) var(--sp-1); }
+.st-group:first-child { padding-top: var(--sp-2); }
+.st-link { display: flex; align-items: center; gap: var(--sp-3); min-height: 2rem; padding: var(--sp-2) var(--sp-4); color: var(--bar-muted); cursor: pointer; font-size: .82rem; user-select: none; border-left: 2px solid transparent; transition: background .08s ease, color .08s ease; }
+.st-link:hover { background: var(--surface); color: var(--ink); }
+.st-link:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.st-link.on { background: var(--accent-wash); color: var(--accent-ink); border-left-color: var(--accent); }
+.st-ic { width: 16px; text-align: center; opacity: .9; flex: 0 0 auto; }
+.st-link-t { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Header + content */
+.st-main { display: flex; flex-direction: column; overflow: hidden; background: var(--bg); }
+.st-top { display: flex; align-items: center; gap: var(--sp-3); min-height: 3rem; padding: .4rem var(--sp-5); border-bottom: 1px solid var(--hairline); background: var(--bar); flex: 0 0 auto; }
+.st-top-ic { color: var(--accent); font-size: 1rem; flex: 0 0 auto; }
+.st-top-h { display: flex; flex-direction: column; line-height: 1.15; min-width: 0; }
+.st-top h1 { font-size: .95rem; margin: 0; font-weight: 600; color: var(--bar-ink); white-space: nowrap; }
+.st-sub { color: var(--bar-muted); font-size: .72rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.st-top-badge { margin-left: auto; flex: 0 0 auto; }
+.st-view { flex: 1; overflow: auto; padding: var(--sp-5); background: var(--bg); }
+
+@media (max-width: 900px) { .studio-shell { grid-template-columns: 200px 1fr; } }
 </style>

--- a/apps/socioprophet-web/src/pages/studio/StudioCatalog.vue
+++ b/apps/socioprophet-web/src/pages/studio/StudioCatalog.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+// Data catalog — a dense, scannable inventory of the project's datasets. Every row carries the two
+// things a sovereign catalog has that a bolt-on catalog (Purview/Collibra) doesn't: an epistemic
+// stripe (the row's proof-status, the moat made visible) and provenance-native fields. Density +
+// tabular alignment (Tufte), an inline ingest-volume sparkline per row, and a real connector facet.
+// Backed by the live catalog (studioApi.loadCatalog → /svc dashboard-bff) with a fixture fallback.
+import { ref, computed, onMounted, watch } from 'vue';
+import { loadCatalog, EPISTEMIC_COLORS, type Dataset } from '../../services/studioApi';
+import Sparkline from '../../components/Sparkline.vue';
+
+const props = defineProps<{ project: string }>();
+
+const datasets = ref<Dataset[]>([]);
+const loading = ref(true);
+const err = ref('');
+const facet = ref<string>('all');       // connector filter
+const expanded = ref<string>('');       // dataset id whose schema is open
+
+async function load() {
+  loading.value = true; err.value = '';
+  try { datasets.value = (await loadCatalog(props.project)).datasets; }
+  catch (e) { err.value = e instanceof Error ? e.message : 'failed to load catalog'; }
+  finally { loading.value = false; }
+}
+onMounted(load);
+watch(() => props.project, load);
+
+function color(mode?: string): string { return EPISTEMIC_COLORS[mode || 'observed'] || 'var(--epi-unknown)'; }
+
+// Distinct connectors present → a real facet bar (not invented).
+const connectors = computed(() => {
+  const s = new Set<string>();
+  for (const d of datasets.value) if (d.connector) s.add(d.connector);
+  return [...s].sort();
+});
+// Epistemic modes present → a legend built from the actual data.
+const modes = computed(() => {
+  const s = new Set<string>();
+  for (const d of datasets.value) s.add(d.epistemic_mode || 'observed');
+  return [...s];
+});
+const shown = computed(() => facet.value === 'all' ? datasets.value : datasets.value.filter((d) => d.connector === facet.value));
+
+// Ingest-volume series: live from volume_trend when the backend provides it, else a deterministic
+// demo series derived from the dataset id (stable across renders, clearly marked ~ in the header).
+function demoSeries(id: string): number[] {
+  let h = 2166136261;
+  for (let i = 0; i < id.length; i++) { h ^= id.charCodeAt(i); h = Math.imul(h, 16777619); }
+  const out: number[] = []; let v = 40 + (Math.abs(h) % 40);
+  for (let i = 0; i < 14; i++) { h = Math.imul(h ^ (h >>> 13), 16777619); v = Math.max(6, v + ((Math.abs(h) % 21) - 9)); out.push(v); }
+  return out;
+}
+function series(d: Dataset): number[] { return d.volume_trend?.length ? d.volume_trend : demoSeries(d.id); }
+function isLive(d: Dataset): boolean { return !!d.volume_trend?.length; }
+function last(s: number[]): number { return s[s.length - 1] ?? 0; }
+function toggle(id: string) { expanded.value = expanded.value === id ? '' : id; }
+</script>
+
+<template>
+  <div class="cat">
+    <div class="cbar">
+      <div class="facets">
+        <button class="facet" :class="{ on: facet === 'all' }" @click="facet = 'all'">All <i>{{ datasets.length }}</i></button>
+        <button v-for="c in connectors" :key="c" class="facet" :class="{ on: facet === c }" @click="facet = c">{{ c }}</button>
+      </div>
+      <div class="legend">
+        <span v-for="m in modes" :key="m" class="lg"><i class="epi-dot" :style="{ '--epi': color(m) }" />{{ m }}</span>
+      </div>
+      <button class="ghost" @click="load" :disabled="loading" title="reload" aria-label="Reload catalog">↻</button>
+    </div>
+
+    <p v-if="err" class="msg err">{{ err }}</p>
+    <p v-else-if="loading" class="msg">Loading catalog…</p>
+    <p v-else-if="!shown.length" class="msg">No datasets{{ facet !== 'all' ? ' for ' + facet : '' }}.</p>
+
+    <div v-else class="ctbl" role="table" aria-label="Datasets">
+      <div class="chead" role="row">
+        <span role="columnheader">Dataset</span>
+        <span role="columnheader">Connector</span>
+        <span role="columnheader" class="num">Cols</span>
+        <span role="columnheader">Status</span>
+        <span role="columnheader" class="num">Ingest volume</span>
+      </div>
+      <div v-for="d in shown" :key="d.id" class="crow-wrap">
+        <div class="crow epi-stripe" role="row" :style="{ '--epi': color(d.epistemic_mode) }">
+          <span class="c-nm" role="cell">
+            <button class="nm-btn" @click="toggle(d.id)" :aria-expanded="expanded === d.id">
+              <b>{{ d.name }}</b>
+              <span class="labels"><i v-for="l in d.labels" :key="l" class="lbl">{{ l }}</i></span>
+            </button>
+          </span>
+          <span class="c-cn" role="cell"><span v-if="d.connector" class="pill">{{ d.connector }}</span><span v-else class="dash">—</span></span>
+          <span class="c-co num tnum" role="cell">{{ d.columns.length }}</span>
+          <span class="c-ep" role="cell"><span class="epi-chip" :style="{ '--epi': color(d.epistemic_mode), '--epi-wash': 'transparent' }">{{ d.epistemic_mode }}</span></span>
+          <span class="c-sp num" role="cell">
+            <Sparkline :series="series(d)" :w="72" :h="20" tone="accent" />
+            <span class="spv tnum" :title="isLive(d) ? 'live ingest volume' : 'demo series — backend volume_trend not yet supplied'">{{ isLive(d) ? '' : '~' }}{{ last(series(d)) }}</span>
+          </span>
+        </div>
+        <div v-if="expanded === d.id" class="schema" role="row">
+          <span class="sk-h">schema</span>
+          <code v-for="c in d.columns" :key="c" class="col">{{ c }}</code>
+        </div>
+      </div>
+    </div>
+
+    <p class="foot">Datasets are proof-carrying graph nodes — provenance + epistemic status are native fields, not a bolt-on catalog. The stripe on each row is its epistemic mode; the sparkline is ingest volume ({{ '~' }} = demo until the backend supplies <code>volume_trend</code>).</p>
+  </div>
+</template>
+
+<style scoped>
+.cat { font: 14px/1.5 var(--ui); color: var(--ink); }
+.cat :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+.cbar { display: flex; align-items: center; gap: var(--sp-3); margin-bottom: var(--sp-3); flex-wrap: wrap; }
+.facets { display: flex; gap: var(--sp-1); flex-wrap: wrap; }
+.facet { border: 1px solid var(--hairline); background: var(--surface); color: var(--muted); border-radius: var(--pill); padding: 3px 10px; font-size: 12px; cursor: pointer; }
+.facet:hover { color: var(--ink); border-color: var(--hairline-strong); }
+.facet.on { color: var(--accent-ink); background: var(--accent-wash); border-color: var(--accent); }
+.facet i { font-style: normal; color: var(--faint); margin-left: 4px; font-variant-numeric: tabular-nums; }
+.legend { display: flex; gap: var(--sp-3); margin-left: auto; flex-wrap: wrap; }
+.lg { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; color: var(--muted); text-transform: capitalize; }
+.ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); width: 30px; height: 30px; cursor: pointer; }
+
+.msg { color: var(--muted); } .msg.err { color: var(--fail); }
+
+.ctbl { border: 1px solid var(--hairline); border-radius: var(--r-3); overflow: hidden; }
+.chead, .crow { display: grid; grid-template-columns: minmax(200px, 2fr) 1fr 64px 1.1fr 1.3fr; align-items: center; gap: var(--sp-3); }
+.chead { padding: var(--sp-2) var(--sp-4); background: var(--sunken); border-bottom: 1px solid var(--hairline); }
+.chead span { font-size: 10.5px; text-transform: uppercase; letter-spacing: .07em; color: var(--faint); }
+.chead .num, .crow .num { text-align: right; justify-self: end; }
+.crow-wrap { border-bottom: 1px solid var(--hairline); }
+.crow-wrap:last-child { border-bottom: 0; }
+.crow { padding: var(--sp-2) var(--sp-4) var(--sp-2) calc(var(--sp-4) + 3px); min-height: 34px; } /* +3px clears the epi-stripe */
+.crow:hover { background: var(--surface-2); }
+.nm-btn { display: flex; align-items: baseline; gap: var(--sp-2); background: none; border: 0; padding: 0; color: inherit; cursor: pointer; text-align: left; min-width: 0; }
+.nm-btn b { font-size: 13px; font-weight: 600; }
+.labels { display: inline-flex; gap: 4px; flex-wrap: wrap; }
+.lbl { font-style: normal; font-size: 9.5px; text-transform: uppercase; letter-spacing: .04em; color: var(--faint); border: 1px solid var(--hairline); border-radius: var(--r-1); padding: 0 4px; }
+.pill { font-size: 10.5px; background: var(--hairline); border-radius: var(--r-2); padding: 1px 7px; color: var(--ink-2); }
+.dash { color: var(--faint); }
+.c-co { color: var(--ink-2); font-size: 12.5px; }
+.c-sp { display: inline-flex; align-items: center; gap: 6px; justify-content: flex-end; }
+.spv { font-size: 11.5px; color: var(--muted); min-width: 30px; text-align: right; }
+.schema { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; padding: 6px var(--sp-4) 10px calc(var(--sp-4) + 3px); background: var(--sunken); }
+.sk-h { font-size: 10px; text-transform: uppercase; letter-spacing: .06em; color: var(--faint); margin-right: 4px; }
+.col { font-family: var(--mono); font-size: 11px; color: var(--ink-2); background: var(--surface); border: 1px solid var(--hairline); border-radius: var(--r-1); padding: 1px 6px; }
+.foot { color: var(--muted); font-size: 12px; margin: var(--sp-3) 0 0; } .foot code { font-family: var(--mono); font-size: 11px; color: var(--ink-2); }
+</style>

--- a/apps/socioprophet-web/src/pages/studio/StudioOps.vue
+++ b/apps/socioprophet-web/src/pages/studio/StudioOps.vue
@@ -5,16 +5,15 @@
 // Foundry but sovereign + multi-backend.
 import { ref, onMounted, watch } from "vue";
 import {
-  loadPipelines, runPipeline, loadModels, promoteModel, loadCatalog, loadCompute, execute, loadCommunities,
+  loadPipelines, runPipeline, loadModels, promoteModel, loadCompute, execute, loadCommunities,
   EPISTEMIC_COLORS,
-  type Pipeline, type ModelEntry, type Dataset, type Compute, type Community, type ExecResult,
+  type Pipeline, type ModelEntry, type Compute, type Community, type ExecResult,
 } from "../../services/studioApi";
 
 const props = defineProps<{ project: string }>();
 
 const pipelines = ref<Pipeline[]>([]);
 const models = ref<ModelEntry[]>([]);
-const datasets = ref<Dataset[]>([]);
 const compute = ref<Compute | null>(null);
 const communities = ref<Community[]>([]);
 const loading = ref(true);
@@ -24,11 +23,11 @@ const token = ref("");
 async function load() {
   loading.value = true; err.value = "";
   try {
-    const [p, m, c, cp, cm] = await Promise.all([
-      loadPipelines(props.project), loadModels(props.project), loadCatalog(props.project),
+    const [p, m, cp, cm] = await Promise.all([
+      loadPipelines(props.project), loadModels(props.project),
       loadCompute(props.project), loadCommunities(props.project),
     ]);
-    pipelines.value = p.pipelines; models.value = m.models; datasets.value = c.datasets;
+    pipelines.value = p.pipelines; models.value = m.models;
     compute.value = cp; communities.value = cm.communities;
   } catch (e) { err.value = e instanceof Error ? e.message : "failed to load operations"; }
   finally { loading.value = false; }
@@ -150,21 +149,8 @@ function kv(o: Record<string, number>): string { return Object.entries(o).map(([
         <p class="sub">A proof-carrying DAG with a governed run ledger; lineage IS the graph — beats Databricks Workflows / Foundry Pipeline Builder.</p>
       </section>
 
-      <!-- Data catalog -->
-      <section class="card" v-if="datasets.length">
-        <header class="ch"><span class="ci">▤</span> Data catalog<span class="score">{{ datasets.length }}</span></header>
-        <table class="cat">
-          <tbody>
-            <tr v-for="d in datasets" :key="d.id">
-              <td class="nm">{{ d.name }}</td>
-              <td><span v-if="d.connector" class="pill">{{ d.connector }}</span></td>
-              <td class="mono cols">{{ d.columns.join(", ") }}</td>
-              <td><span class="epi" :style="{ borderColor: color(d.epistemic_mode), color: color(d.epistemic_mode) }">{{ d.epistemic_mode }}</span></td>
-            </tr>
-          </tbody>
-        </table>
-        <p class="sub">Datasets are proof-carrying graph nodes — provenance + epistemic status native, not a bolt-on catalog.</p>
-      </section>
+      <!-- Data catalog moved to its own Studio section (StudioCatalog.vue) — density + epistemic
+           stripe + inline ingest-volume sparklines. Operations stays focused on run-time surfaces. -->
 
       <!-- GraphRAG communities -->
       <section class="card wide" v-if="communities.length">
@@ -233,12 +219,6 @@ function kv(o: Record<string, number>): string { return Object.entries(o).map(([
 .pname { font-weight: 600; } .run { margin-left: auto; border: 1px solid var(--accent); background: var(--surface); color: var(--accent); border-radius: var(--r-2); padding: 3px 10px; font-size: 12px; cursor: pointer; }
 .dag { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; margin-top: 5px; }
 .step { font-size: 11.5px; background: var(--sunken); border-radius: var(--r-2); padding: 2px 9px; } .arrow { color: var(--faint); }
-
-/* catalog */
-.cat { width: 100%; border-collapse: collapse; font-size: 12.5px; }
-.cat td { padding: 5px 8px; border-bottom: 1px solid var(--sunken); } .cat tr:last-child td { border-bottom: 0; }
-.cat .nm { font-weight: 600; } .cat .cols { color: var(--muted); } .pill { font-size: 10px; background: var(--hairline); border-radius: var(--r-2); padding: 1px 7px; color: var(--muted); }
-.epi { font-size: 10px; border: 1px solid; border-radius: var(--r-1); padding: 1px 7px; }
 
 /* communities */
 .comms { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: var(--sp-3); }

--- a/apps/socioprophet-web/src/services/studioApi.ts
+++ b/apps/socioprophet-web/src/services/studioApi.ts
@@ -474,7 +474,10 @@ export interface PipelineStepDef { id: string; kind: string; inputs?: string[]; 
 export interface Pipeline { pipeline_id: string; name: string; steps: PipelineStepDef[]; step_count: number }
 export interface ModelVersion { model_id: string; version: string; stage: string; metrics: Record<string, number>; run?: string | null }
 export interface ModelEntry { name: string; versions: ModelVersion[] }
-export interface Dataset { id: string; name: string; labels: string[]; connector?: string | null; epistemic_mode: string; columns: string[] }
+// volume_trend: optional per-dataset ingest-volume series (row count over recent snapshots). When
+// the catalog backend supplies it the Catalog renders a live sparkline; otherwise the surface shows
+// a deterministic demo series (marked ~) — the same "shaped-like-real, live swaps in" seam as the rest.
+export interface Dataset { id: string; name: string; labels: string[]; connector?: string | null; epistemic_mode: string; columns: string[]; volume_trend?: number[] }
 export interface ComputeBackend { id: string; kind: string; note: string; entitled: boolean; default?: boolean }
 export interface Compute { backends: ComputeBackend[]; entitled_any: boolean; model: string }
 export interface Community { community: string; size: number; top_members: { id: string; label: string; degree: number }[]; epistemic_distribution: Record<string, number> }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -116,12 +116,9 @@ KNOWN_BROKEN = {
         "this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
     ),
     # portfolio-agent pinned to a sha- tag by gitops-promote after its first CI build (#925,
-    # sha-a6d8311383) → removed from the ratchet (it only shrinks).
-    "academy-board:moving-tag": (
-        "New service — the sovereign Academy board engine (apps/academy-board: server-authoritative mastery-check "
-        "grading + receipts on :8095, answer key never ships to the browser) added to CI this PR. Pin tag:latest -> "
-        "the sha- tag gitops-promote writes after the first CI build; no sha exists until merge."
-    ),
+    # sha-a6d8311383) → removed from the ratchet (it only shrinks). Same for academy-board:
+    # gitops-promote sha-pinned it after #926's first build (sha-f59cf2c9), so its moving-tag
+    # entry now passes and is removed.
     # sherlock-engine pinned to a sha- tag by gitops-promote after the 0.0.0.0 bind fix (#887) → removed
     # from the ratchet (it only shrinks). Same for synapse-bridge + holmes: gitops-promote sha-pinned both
     # after their first builds landed (#905/#906), so their moving-tag entries now pass and are removed.


### PR DESCRIPTION
First two passes of the **Studio design-language anneal** (the epistemic-ramp + Carbon program; Layer-0 tokens already shipped).

## 1 · Studio shell → Carbon UI-Shell
`Studio.vue` reskinned to Carbon UI-Shell conventions, driven **entirely by studio-tokens** (no `cds--` imports — the estate uses zero Carbon classes): a dark shell bar (`--bar`) for the SideNav + header, a 256px nav with the **signature Carbon active treatment** (accent-wash fill + 3px accent left indicator), a 48px header, token-based spacing, **real keyboard activation** (Enter/Space) and focus rings. Replaces the ad-hoc `#1b2740` hardcodes + rounded chrome.

## 2 · Data Catalog → its own surface
Promoted from a bare table buried in Operations to a first-class Studio section, `StudioCatalog.vue`:
- **Density** — compact tabular layout, tabular-nums, aligned columns.
- **Epistemic stripe** — each row carries its proof-status as a 3px stripe (`.epi-stripe`), *the moat made visible*.
- **Inline sparkline** — per-row ingest volume via `Sparkline`. Reads a new **optional** `Dataset.volume_trend` when the backend supplies it (live); otherwise a deterministic demo series **marked `~`** — honest, not a faked live line.
- Real **connector facet** + **epistemic legend** built from the data, expandable schema.
- Live via `loadCatalog`; removed the duplicate card + dead CSS from `StudioOps`.

## Verify
`vue-tsc` + `npm run build` + `preflight` clean. Headless boot render confirms the app boots, tokens load, no white-screen; the authenticated Studio pixels verify on the deployed surface (Studio sits behind auth, so headless preview can't reach them). Also cleared the `academy-board` ratchet entry (gitops sha-pinned it post-#926).

More passes to follow in order: Bostock graph/lineage DAG, governance small-multiples, ops gantt, factsheet drawer, sibling-surface alignment.