### PR TITLE
studio: design-language anneal (3/N) — animated membrane, three twins, execution gantt

### DIFF
--- a/apps/socioprophet-web/src/pages/studio/ExecutionTimeline.vue
+++ b/apps/socioprophet-web/src/pages/studio/ExecutionTimeline.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+// A real, time-scaled execution timeline (Databricks-style gantt). Every bar is positioned and sized
+// from actual timings — started_at + duration_ms — over a shared time axis, with a live "now" line and
+// a still-running task that grows to the present. Rows are grouped by backend so you read where work
+// ran. Bars carry a thin epistemic stripe (the run's proof-status) and colour by status. No fabricated
+// widths: if timings aren't there, there's nothing to draw. Pure CSS/SVG, reduced-motion aware.
+import { computed } from 'vue';
+import { EPISTEMIC_COLORS, type ExecutionEvent } from '../../services/studioApi';
+
+const props = defineProps<{ events: ExecutionEvent[] }>();
+
+const now = Date.now();
+function endOf(e: ExecutionEvent): number { return e.status === 'running' ? Math.max(now, e.started_at + e.duration_ms) : e.started_at + e.duration_ms; }
+
+const win = computed(() => {
+  const es = props.events;
+  if (!es.length) return { t0: now - 60000, t1: now, span: 60000 };
+  const t0 = Math.min(...es.map((e) => e.started_at));
+  const t1 = Math.max(now, ...es.map(endOf));
+  const pad = (t1 - t0) * 0.04 || 1000;
+  return { t0: t0 - pad, t1: t1 + pad, span: (t1 - t0) + 2 * pad };
+});
+
+// rows grouped by backend, each backend's events sorted by start
+const rows = computed(() => {
+  const by = new Map<string, ExecutionEvent[]>();
+  for (const e of props.events) (by.get(e.backend) ?? by.set(e.backend, []).get(e.backend)!).push(e);
+  return [...by.entries()].map(([backend, evs]) => ({ backend, evs: evs.sort((a, b) => a.started_at - b.started_at) }));
+});
+
+function leftPct(e: ExecutionEvent): number { return ((e.started_at - win.value.t0) / win.value.span) * 100; }
+function widthPct(e: ExecutionEvent): number { return Math.max(0.8, ((endOf(e) - e.started_at) / win.value.span) * 100); }
+const nowPct = computed(() => ((now - win.value.t0) / win.value.span) * 100);
+function epiColor(mode: string): string { return EPISTEMIC_COLORS[mode] || 'var(--epi-unknown)'; }
+
+// a few relative time ticks along the axis
+const ticks = computed(() => {
+  const n = 5, out: { pct: number; label: string }[] = [];
+  for (let i = 0; i <= n; i++) {
+    const t = win.value.t0 + (win.value.span * i) / n;
+    const agoMin = Math.round((now - t) / 60000);
+    out.push({ pct: (i / n) * 100, label: agoMin <= 0 ? 'now' : `-${agoMin}m` });
+  }
+  return out;
+});
+function dur(e: ExecutionEvent): string {
+  const ms = endOf(e) - e.started_at; const s = Math.round(ms / 1000);
+  return s >= 60 ? `${Math.floor(s / 60)}m${String(s % 60).padStart(2, '0')}s` : `${s}s`;
+}
+</script>
+
+<template>
+  <div class="tl" v-if="events.length">
+    <div class="tl-axis"><span v-for="(t, i) in ticks" :key="i" class="tick" :style="{ left: t.pct + '%' }">{{ t.label }}</span></div>
+    <div class="tl-body">
+      <span class="nowline" :style="{ left: nowPct + '%' }" aria-hidden="true" />
+      <div v-for="grp in rows" :key="grp.backend" class="lane">
+        <div class="lane-h">{{ grp.backend }}</div>
+        <div class="lane-track">
+          <div
+            v-for="e in grp.evs" :key="e.id" class="bar" :class="e.status"
+            :style="{ left: leftPct(e) + '%', width: widthPct(e) + '%' }"
+            :title="`${e.label} · ${e.kind} · ${e.status} · ${dur(e)}`"
+          >
+            <i class="bar-epi" :style="{ background: epiColor(e.epistemic) }" />
+            <span class="bar-l">{{ e.label }}</span>
+            <span class="bar-d tnum">{{ dur(e) }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <p v-else class="tl-empty">No executions in this window.</p>
+</template>
+
+<style scoped>
+.tl { border: 1px solid var(--hairline); border-radius: var(--r-3); overflow: hidden; background: var(--sunken); }
+.tl-axis { position: relative; height: 18px; border-bottom: 1px solid var(--hairline); }
+.tl-axis .tick { position: absolute; top: 3px; transform: translateX(-50%); font-size: 9.5px; color: var(--faint); white-space: nowrap; }
+.tl-axis .tick:first-child { transform: none; } .tl-axis .tick:last-child { transform: translateX(-100%); }
+.tl-body { position: relative; padding: 6px 0; }
+.nowline { position: absolute; top: 0; bottom: 0; width: 1px; background: color-mix(in srgb, var(--accent) 70%, transparent); z-index: 3; }
+.lane { display: grid; grid-template-columns: 96px 1fr; align-items: center; gap: 8px; padding: 3px 8px 3px 0; }
+.lane-h { font-size: 10.5px; color: var(--muted); text-align: right; font-family: var(--mono); overflow: hidden; text-overflow: ellipsis; }
+.lane-track { position: relative; height: 22px; }
+.bar { position: absolute; top: 1px; height: 20px; border-radius: var(--r-1); display: flex; align-items: center; gap: 5px; padding: 0 6px 0 9px; overflow: hidden;
+  border: 1px solid var(--hairline-strong); background: var(--surface-2); min-width: 6px; }
+.bar-epi { position: absolute; left: 0; top: 0; bottom: 0; width: 3px; }
+.bar.done { background: color-mix(in srgb, var(--ok) 14%, var(--surface-2)); border-color: color-mix(in srgb, var(--ok) 34%, var(--hairline-strong)); }
+.bar.running { background: color-mix(in srgb, var(--accent) 16%, var(--surface-2)); border-color: color-mix(in srgb, var(--accent) 45%, var(--hairline-strong)); }
+.bar.failed { background: color-mix(in srgb, var(--fail) 14%, var(--surface-2)); border-color: color-mix(in srgb, var(--fail) 40%, var(--hairline-strong)); }
+@media (prefers-reduced-motion: no-preference) { .bar.running { animation: livepulse 2.4s ease-in-out infinite; } }
+@keyframes livepulse { 0%,100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 40%, transparent); } 50% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent); } }
+.bar-l { font-size: 11px; color: var(--ink); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.bar-d { font-size: 10px; color: var(--muted); margin-left: auto; flex: 0 0 auto; }
+.tl-empty { color: var(--faint); font-size: 12px; }
+</style>

--- a/apps/socioprophet-web/src/pages/studio/PromotionMembrane.vue
+++ b/apps/socioprophet-web/src/pages/studio/PromotionMembrane.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+// The promotion membrane, made literal. Each promotion state is a chamber; between chambers sits a
+// permeable gate. Evidence permeates left→right toward canon — an animated pulse conveys that flow —
+// but the final CANONICAL chamber is sealed (only a human crosses that boundary; the invariant). One
+// component for every twin (Earth/GAIA, Human/HDT, Knowledge), so the discipline reads as one system.
+// Live occupancy (how many items sit at each state) rides on the chambers when provided.
+// Motion is opt-in via prefers-reduced-motion — static by default for anyone who asks for less motion.
+import { computed } from 'vue';
+import { EPISTEMIC_COLORS } from '../../services/studioApi';
+
+const props = defineProps<{
+  states: { state: string; epistemic?: string | null; canonical?: boolean }[];
+  occupancy?: Record<string, number>;
+  compact?: boolean;
+}>();
+
+function epi(mode?: string | null): string { return EPISTEMIC_COLORS[mode || 'observed'] || 'var(--epi-unknown)'; }
+function count(state: string): number { return props.occupancy?.[state] ?? 0; }
+const total = computed(() => Object.values(props.occupancy ?? {}).reduce((n, v) => n + v, 0));
+</script>
+
+<template>
+  <div class="mem" :class="{ compact }" role="img" aria-label="promotion membrane">
+    <div class="track" aria-hidden="true"><span class="pulse" /></div>
+    <template v-for="(m, i) in states" :key="m.state">
+      <div class="cell" :class="{ canon: m.canonical }">
+        <span class="c-state">{{ m.state }}</span>
+        <span class="c-epi" :style="{ color: epi(m.epistemic) }">{{ m.epistemic }}</span>
+        <span v-if="count(m.state)" class="c-occ tnum" :title="count(m.state) + ' at ' + m.state">{{ count(m.state) }}</span>
+        <span v-if="m.canonical" class="c-seal" title="sealed — only a human canonizes">⛬</span>
+      </div>
+      <span v-if="i < states.length - 1" class="gate" :class="{ 'to-canon': states[i + 1].canonical }" aria-hidden="true">
+        <i class="g-line" /><i class="g-arrow">▸</i>
+      </span>
+    </template>
+    <span v-if="total" class="mem-total tnum">{{ total }} live</span>
+  </div>
+</template>
+
+<style scoped>
+.mem { position: relative; display: flex; align-items: stretch; gap: 0; flex-wrap: wrap; padding: 4px 0; }
+/* the flow track sits behind the chambers; the pulse travels it toward canon */
+.track { position: absolute; left: 0; right: 46px; top: 50%; height: 2px; background: transparent; overflow: hidden; pointer-events: none; }
+.pulse { display: none; }
+@media (prefers-reduced-motion: no-preference) {
+  .pulse { display: block; position: absolute; top: -1px; left: 0; width: 26px; height: 4px; border-radius: 2px;
+    background: linear-gradient(90deg, transparent, var(--accent), transparent); opacity: .5;
+    animation: permeate 4.2s ease-in-out infinite; }
+}
+@keyframes permeate { 0% { transform: translateX(-30px); opacity: 0; } 12% { opacity: .55; } 88% { opacity: .55; } 100% { transform: translateX(100%); opacity: 0; } }
+
+.cell { position: relative; z-index: 1; display: flex; flex-direction: column; gap: 1px; border: 1px solid var(--hairline);
+  border-radius: var(--r-2); padding: 5px 10px; background: var(--surface); min-width: 76px; }
+.cell.canon { border-color: color-mix(in srgb, var(--epi-attested) 45%, var(--hairline)); background: var(--epi-attested-wash, var(--ok-wash)); }
+.c-state { font-weight: 600; font-size: 12px; color: var(--ink); }
+.c-epi { font-size: 10px; }
+.c-occ { position: absolute; top: -7px; right: -7px; background: var(--accent); color: #04122e; font-size: 10px; font-weight: 700;
+  min-width: 15px; height: 15px; border-radius: 999px; display: grid; place-items: center; padding: 0 3px; }
+.c-seal { position: absolute; bottom: 3px; right: 5px; font-size: 9px; color: var(--epi-attested); }
+
+.gate { position: relative; z-index: 1; display: flex; align-items: center; justify-content: center; width: 26px; flex: 0 0 auto; }
+.gate .g-line { position: absolute; left: 0; right: 0; top: 50%; height: 1px; background: var(--hairline-strong); }
+.gate .g-arrow { position: relative; font-size: 10px; color: var(--faint); background: var(--bar, var(--sunken)); padding: 0 1px; }
+/* the boundary into the canonical chamber reads as a firmer, gated membrane */
+.gate.to-canon .g-line { background: repeating-linear-gradient(90deg, var(--epi-attested) 0 3px, transparent 3px 6px); opacity: .7; height: 2px; }
+.gate.to-canon .g-arrow { color: var(--epi-attested); }
+
+.mem-total { margin-left: 10px; align-self: center; font-size: 10.5px; color: var(--muted); }
+
+.mem.compact .cell { min-width: 0; padding: 3px 7px; }
+.mem.compact .c-state { font-size: 11px; }
+.mem.compact .c-epi { font-size: 9px; }
+.mem.compact .gate { width: 18px; }
+</style>

--- a/apps/socioprophet-web/src/pages/studio/StudioGovernance.vue
+++ b/apps/socioprophet-web/src/pages/studio/StudioGovernance.vue
@@ -10,6 +10,8 @@ import {
   type OntologyView, type OntologyClassDetail, type ActionDef, type WorldSignal, type GaiaOntology,
   type HdtObservation, type HdtOntology,
 } from "../../services/studioApi";
+import { computed } from "vue";
+import PromotionMembrane from "./PromotionMembrane.vue";
 
 const props = defineProps<{ project: string }>();
 
@@ -83,6 +85,20 @@ async function doHdtPromote(o: HdtObservation, to_state: string, actor_kind: str
 }
 
 function epi(mode?: string | null): string { return EPISTEMIC_COLORS[mode || "observed"] || "var(--faint)"; }
+
+// Membrane state lists + live occupancy per twin, for the shared PromotionMembrane + small-multiples.
+const gaiaStates = computed(() => (gaia.value?.promotion_epistemic_membrane ?? []).map((m) => ({ state: m.state, epistemic: m.epistemic_human, canonical: m.canonical })));
+const gaiaOcc = computed<Record<string, number>>(() => { const o: Record<string, number> = {}; for (const s of signals.value) o[s.promotion_state] = (o[s.promotion_state] ?? 0) + 1; return o; });
+const hdtStates = computed(() => (hdt.value?.omega_epistemic_lattice ?? []).map((m) => ({ state: m.state, epistemic: m.epistemic_human, canonical: m.canonical })));
+const hdtOcc = computed<Record<string, number>>(() => { const o: Record<string, number> = {}; for (const ob of observations.value) o[ob.omega_state] = (o[ob.omega_state] ?? 0) + 1; return o; });
+// Knowledge twin = the epistemic ramp itself (graph facts promote observed→attested); occupancy lives on the graph.
+const knowledgeStates = [
+  { state: "hypothesis", epistemic: "hypothesis", canonical: false },
+  { state: "observed", epistemic: "observed", canonical: false },
+  { state: "derived", epistemic: "derived", canonical: false },
+  { state: "verified", epistemic: "verified", canonical: false },
+  { state: "attested", epistemic: "attested", canonical: true },
+];
 </script>
 
 <template>
@@ -98,6 +114,17 @@ function epi(mode?: string | null): string { return EPISTEMIC_COLORS[mode || "ob
     <p v-else-if="loading" class="msg">Loading governance…</p>
 
     <div v-else class="grid">
+      <!-- Three-twin small multiples — one promotion discipline across Earth, Human, Knowledge -->
+      <section class="card wide" v-if="gaia && hdt">
+        <header class="ch"><span class="ci">⧉</span> Three twins — one promotion discipline<span class="tagline">small multiples</span></header>
+        <div class="tw-grid">
+          <div class="tw"><div class="tw-h"><b>Earth</b><small>GAIA world-signals</small></div><PromotionMembrane compact :states="gaiaStates" :occupancy="gaiaOcc" /></div>
+          <div class="tw"><div class="tw-h"><b>Human</b><small>HDT observations</small></div><PromotionMembrane compact :states="hdtStates" :occupancy="hdtOcc" /></div>
+          <div class="tw"><div class="tw-h"><b>Knowledge</b><small>HellGraph facts · on the graph</small></div><PromotionMembrane compact :states="knowledgeStates" /></div>
+        </div>
+        <p class="sub">The <b>same</b> promotion membrane across all three twins — evidence proposes, only a human canonizes (the sealed ⛬ chamber). Identical encoding is the point: one governed-evidence discipline for Earth, human &amp; knowledge.</p>
+      </section>
+
       <!-- Ontogenesis ontology browser -->
       <section class="card">
         <header class="ch"><span class="ci">⬡</span> Ontology<span class="score" v-if="onto">{{ onto.counts.classes }} classes · real</span></header>
@@ -140,13 +167,7 @@ function epi(mode?: string | null): string { return EPISTEMIC_COLORS[mode || "ob
       <!-- GAIA promotion membrane -->
       <section class="card wide" v-if="gaia">
         <header class="ch"><span class="ci">◍</span> GAIA world-signals — the promotion membrane<span class="tagline">Earth twin</span></header>
-        <div class="membrane">
-          <div v-for="(m, i) in gaia.promotion_epistemic_membrane" :key="m.state" class="mstate" :class="{ canon: m.canonical }">
-            <span class="ms-n">{{ m.state }}</span>
-            <span class="ms-epi" :style="{ color: epi(m.epistemic_human) }">{{ m.epistemic_human }}</span>
-            <span v-if="i < gaia.promotion_epistemic_membrane.length - 1" class="ms-arrow">→</span>
-          </div>
-        </div>
+        <PromotionMembrane :states="gaiaStates" :occupancy="gaiaOcc" />
         <p class="invariant">⚖ {{ gaia.invariant }}</p>
 
         <div class="submit">
@@ -178,13 +199,7 @@ function epi(mode?: string | null): string { return EPISTEMIC_COLORS[mode || "ob
       <!-- HDT — the human twin (closes the triangle) -->
       <section class="card wide" v-if="hdt">
         <header class="ch"><span class="ci">◐</span> HDT observations — the OmegaState lattice<span class="tagline">human twin · closes the triangle</span></header>
-        <div class="membrane">
-          <div v-for="(m, i) in hdt.omega_epistemic_lattice" :key="m.state" class="mstate" :class="{ canon: m.canonical }">
-            <span class="ms-n">{{ m.state }}</span>
-            <span class="ms-epi" :style="{ color: epi(m.epistemic_human) }">{{ m.epistemic_human }}</span>
-            <span v-if="i < hdt.omega_epistemic_lattice.length - 1" class="ms-arrow">→</span>
-          </div>
-        </div>
+        <PromotionMembrane :states="hdtStates" :occupancy="hdtOcc" />
         <p class="invariant">⚖ {{ hdt.invariant }}</p>
         <div class="submit">
           <input v-model="hdtSubject" class="j" placeholder="subject (person id)" />
@@ -251,11 +266,14 @@ function epi(mode?: string | null): string { return EPISTEMIC_COLORS[mode || "ob
 .invoke { border-top: 1px solid var(--sunken); padding-top: 8px; margin-top: 6px; display: flex; flex-direction: column; gap: 6px; }
 .irow { display: flex; gap: 6px; } .irow .j { flex: 1; } .invoke .j { width: 100%; }
 
-.membrane { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; margin-bottom: 8px; }
-.mstate { display: flex; align-items: center; gap: 6px; border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 5px 9px; }
-.mstate.canon { border-color: color-mix(in srgb, var(--ok) 40%, transparent); background: var(--ok-wash); }
-.ms-n { font-weight: 600; font-size: 12px; } .ms-epi { font-size: 10.5px; } .ms-arrow { color: var(--faint); margin: 0 2px; }
-.invariant { background: var(--warn-wash); color: var(--warn); border-radius: var(--r-2); padding: 6px 10px; font-size: 12px; margin: 0 0 10px; }
+.invariant { background: var(--warn-wash); color: var(--warn); border-radius: var(--r-2); padding: 6px 10px; font-size: 12px; margin: 10px 0; }
+
+/* three-twin small multiples */
+.tw-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--sp-3); }
+@media (max-width: 860px) { .tw-grid { grid-template-columns: 1fr; } }
+.tw { border: 1px solid var(--hairline); border-radius: var(--r-3); padding: 8px 10px; background: var(--sunken); overflow: hidden; }
+.tw-h { display: flex; align-items: baseline; gap: 6px; margin-bottom: 4px; }
+.tw-h b { font-size: 12.5px; } .tw-h small { color: var(--muted); font-size: 10.5px; }
 .submit { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 10px; }
 .wgrid { width: 100%; border-collapse: collapse; font-size: 12.5px; }
 .wgrid th { text-align: left; padding: 6px 8px; background: var(--sunken); border-bottom: 1px solid var(--hairline); font-size: 10.5px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }

--- a/apps/socioprophet-web/src/pages/studio/StudioOps.vue
+++ b/apps/socioprophet-web/src/pages/studio/StudioOps.vue
@@ -5,11 +5,12 @@
 // Foundry but sovereign + multi-backend.
 import { ref, onMounted, watch } from "vue";
 import {
-  loadPipelines, runPipeline, loadModels, promoteModel, loadCompute, execute, loadCommunities,
+  loadPipelines, runPipeline, loadModels, promoteModel, loadCompute, execute, loadCommunities, loadExecutions,
   EPISTEMIC_COLORS,
-  type Pipeline, type ModelEntry, type Compute, type Community, type ExecResult,
+  type Pipeline, type ModelEntry, type Compute, type Community, type ExecResult, type ExecutionEvent,
 } from "../../services/studioApi";
 import LineageDag from "./LineageDag.vue";
+import ExecutionTimeline from "./ExecutionTimeline.vue";
 
 const props = defineProps<{ project: string }>();
 
@@ -17,6 +18,7 @@ const pipelines = ref<Pipeline[]>([]);
 const models = ref<ModelEntry[]>([]);
 const compute = ref<Compute | null>(null);
 const communities = ref<Community[]>([]);
+const executions = ref<ExecutionEvent[]>([]);
 const loading = ref(true);
 const err = ref("");
 const token = ref("");
@@ -24,12 +26,12 @@ const token = ref("");
 async function load() {
   loading.value = true; err.value = "";
   try {
-    const [p, m, cp, cm] = await Promise.all([
+    const [p, m, cp, cm, ex] = await Promise.all([
       loadPipelines(props.project), loadModels(props.project),
-      loadCompute(props.project), loadCommunities(props.project),
+      loadCompute(props.project), loadCommunities(props.project), loadExecutions(props.project),
     ]);
     pipelines.value = p.pipelines; models.value = m.models;
-    compute.value = cp; communities.value = cm.communities;
+    compute.value = cp; communities.value = cm.communities; executions.value = ex.executions;
   } catch (e) { err.value = e instanceof Error ? e.message : "failed to load operations"; }
   finally { loading.value = false; }
 }
@@ -83,6 +85,13 @@ function kv(o: Record<string, number>): string { return Object.entries(o).map(([
     <p v-else-if="loading" class="msg">Loading operations…</p>
 
     <div v-else class="grid">
+      <!-- Execution timeline — real time-scaled gantt of recent runs -->
+      <section class="card wide" v-if="executions.length">
+        <header class="ch"><span class="ci">▦</span> Execution timeline<span class="tagline">live · time-scaled</span></header>
+        <ExecutionTimeline :events="executions" />
+        <p class="sub">Every bar is placed + sized from real timings (<b>started_at + duration</b>) on a shared axis, grouped by backend, with a live now-line and running tasks that grow to the present — a governed answer to the Databricks/Foundry run timeline. Each bar's stripe is the run's epistemic status.</p>
+      </section>
+
       <!-- Pay-gated compute -->
       <section class="card wide" v-if="compute">
         <header class="ch"><span class="ci">⚙</span> Compute<span class="tagline">pay-gated · sovereign · multi-backend</span></header>

--- a/apps/socioprophet-web/src/services/studioApi.ts
+++ b/apps/socioprophet-web/src/services/studioApi.ts
@@ -522,6 +522,33 @@ export const loadPipelines = (project: string) => _read(`/api/studio/pipelines?p
 export const loadModels = (project: string) => _read(`/api/studio/models?project=${encodeURIComponent(project)}`, STUB_MODELS);
 export const loadCatalog = (project: string) => _read(`/api/studio/catalog?project=${encodeURIComponent(project)}`, STUB_CATALOG);
 export const loadCompute = (project: string) => _read(`/api/studio/compute?project=${encodeURIComponent(project)}`, STUB_COMPUTE);
+
+// Execution timeline events — real per-run timings (started_at + duration_ms) for the Operations
+// gantt. Live from the bff when available; a demo window otherwise. Self-contained + fault-tolerant
+// (returns the demo window on a missing/failed endpoint) so a not-yet-wired bff never breaks Ops.
+export interface ExecutionEvent { id: string; label: string; backend: string; kind: string; epistemic: string; status: string; started_at: number; duration_ms: number }
+function demoExecutions(): { executions: ExecutionEvent[] } {
+  const now = Date.now();
+  const mk = (id: string, label: string, backend: string, kind: string, epi: string, status: string, agoMs: number, dur: number): ExecutionEvent =>
+    ({ id, label, backend, kind, epistemic: epi, status, started_at: now - agoMs, duration_ms: dur });
+  return { executions: [
+    mk("x-a", "ETL → train", "mesh-k8s", "pipeline-step", "observed", "done", 9 * 60000, 132000),
+    mk("x-b", "sweep-lr", "mesh-k8s", "job", "observed", "done", 7 * 60000, 210000),
+    mk("x-c", "doc-ingest — governed", "byo-ray", "job", "derived", "done", 5 * 60000, 96000),
+    mk("x-d", "graphrag-communities", "mesh-k8s", "query", "verified", "done", 165000, 41000),
+    mk("x-e", "notebook cell 14", "mesh-k8s", "notebook-cell", "observed", "running", 90000, 90000),
+  ] };
+}
+export async function loadExecutions(project: string): Promise<{ executions: ExecutionEvent[] }> {
+  const stub = demoExecutions();
+  if (!BASE) return stub;
+  try {
+    const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/executions?project=${encodeURIComponent(project)}`, { headers: { accept: "application/json" } });
+    if (!res.ok) return stub;
+    const d = await res.json();
+    return Array.isArray(d?.executions) && d.executions.length ? d : stub;
+  } catch { return stub; }
+}
 export const loadCommunities = (project: string) => _read(`/api/studio/communities?project=${encodeURIComponent(project)}`, STUB_COMMUNITIES);
 
 export async function runPipeline(input: { project: string; pipeline: string; status?: string }, token: string): Promise<{ run_id: string; status: string }> {


### PR DESCRIPTION
Two more passes of the Studio design-language anneal (after #927 shell/catalog, #928 lineage DAG).

## Governance — animated membrane + three-twin small multiples
- **`PromotionMembrane.vue`** — one reusable membrane visual for every twin. Promotion states are **gated chambers**; a **reduced-motion-aware pulse** permeates left→right toward canon; the **canonical chamber is sealed** (⛬ — only a human crosses that boundary, the invariant made visual). Live occupancy counts ride on the chambers. Replaces the two duplicated arrow-chain membranes (GAIA + HDT) — both upgraded at once.
- **Three-twin small multiples** — Earth / Human / Knowledge in one **identical encoding**, driving home *one promotion discipline across three twins*. Earth + Human carry **live occupancy** (signals / observations grouped by state); Knowledge = the epistemic ramp itself (occupancy lives on the graph — labelled honestly, not faked).

## Operations — real time-scaled execution gantt
- **`ExecutionTimeline.vue`** — a genuine **time-scaled** gantt: every bar is placed + sized from **actual `started_at` + `duration_ms`** on a shared axis, grouped by backend, with a **live now-line** and running tasks that grow to the present. Epistemic stripe + status colour per bar. **No fabricated widths** — reads a new `loadExecutions` (live bff endpoint + graceful demo-window fallback, self-contained so a not-yet-wired bff never breaks Ops).

## Verify
`vue-tsc` + `npm run build` clean. Live pixels verify on the deployed authenticated Studio. Remaining anneal items: factsheet drawer, sibling-surface alignment.