### PR TITLE
studio: design-language anneal (4/N) — factsheet drawer + .ai search on the token spine

### DIFF
--- a/apps/socioprophet-web/src/pages/DataSearch.vue
+++ b/apps/socioprophet-web/src/pages/DataSearch.vue
@@ -13,8 +13,8 @@
     </form>
     <p v-if="error" class="error">{{ error }}</p>
     <div class="cols">
-      <div v-for="col in visibleCols" :key="col.key" class="col">
-        <div class="ch" :style="{ color: col.tint }">{{ col.label }}
+      <div v-for="col in visibleCols" :key="col.key" class="col" :style="{ color: col.tint }">
+        <div class="ch">{{ col.label }}
           <span v-if="col.r" class="count">{{ col.r.configured ? (col.r.ok ? `${col.r.hits.length} hits` : (col.r.error || 'unreachable')) : 'not configured' }}</span>
         </div>
         <template v-if="col.r">
@@ -53,24 +53,27 @@ async function run() {
 
 const visibleCols = computed(() => {
   const cols: Array<{ key: string; label: string; tint: string; r: SearchResult['local'] | undefined }> = [];
-  if (scope.value !== 'platform') cols.push({ key: 'local', label: 'Local · lampstand', tint: '#4ade80', r: result.value?.local });
-  if (scope.value !== 'local') cols.push({ key: 'platform', label: 'Platform · sherlock', tint: '#93c5fd', r: result.value?.platform });
+  if (scope.value !== 'platform') cols.push({ key: 'local', label: 'Local · lampstand', tint: 'var(--up)', r: result.value?.local });
+  if (scope.value !== 'local') cols.push({ key: 'platform', label: 'Platform · sherlock', tint: 'var(--info)', r: result.value?.platform });
   return cols;
 });
 </script>
 
 <style scoped>
-.surface { display: grid; gap: 1rem; max-width: 960px; margin: 1rem auto; padding: 1.5rem 1.75rem; background: var(--bg); color: rgba(255, 255, 255, 0.92); border: 1px solid var(--line-2); border-radius: 16px; }
-h1 { margin: 0; font-size: 1.25rem; } header p { margin: 0.25rem 0 0; color: rgba(255, 255, 255, 0.6); font-size: 0.85rem; }
+/* Aligned to the cockpit token spine — no hardcoded rgba/hex. Source tint (local=up, platform=info)
+   reads each result column as its own signal, and each hit carries a left stripe in that tint. */
+.surface { display: grid; gap: 1rem; max-width: 960px; margin: 1rem auto; padding: 1.5rem 1.75rem; background: var(--surface); color: var(--text); border: 1px solid var(--line-2); border-radius: 16px; }
+h1 { margin: 0; font-size: 1.25rem; } header p { margin: 0.25rem 0 0; color: var(--text-3); font-size: 0.85rem; }
 .bar { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
-.bar input { flex: 1 1 240px; min-width: 0; background: rgba(255, 255, 255, 0.06); border: 1px solid rgba(255, 255, 255, 0.16); border-radius: 10px; padding: 0.5rem 0.7rem; color: #fff; font-size: 0.9rem; }
-.bar button { border: none; background: #2563eb; color: #fff; border-radius: 10px; padding: 0.5rem 0.9rem; font-size: 0.82rem; font-weight: 600; cursor: pointer; } .bar button:disabled { opacity: 0.5; }
-.scopes { display: flex; gap: 0.25rem; } .sc { background: transparent; border: none; color: rgba(255, 255, 255, 0.6); border-radius: 8px; padding: 0.4rem 0.6rem; font-size: 0.75rem; text-transform: capitalize; cursor: pointer; } .sc.on { background: rgba(59, 130, 246, 0.2); color: #93c5fd; }
-.error, .err2 { color: #fca5a5; font-size: 0.82rem; } .mut { color: rgba(255, 255, 255, 0.45); font-size: 0.8rem; }
+.bar input { flex: 1 1 240px; min-width: 0; background: var(--surface-2); border: 1px solid var(--line-2); border-radius: 10px; padding: 0.5rem 0.7rem; color: var(--text); font-size: 0.9rem; }
+.bar input:focus { outline: none; border-color: var(--accent); }
+.bar button { border: none; background: var(--accent); color: var(--bg); border-radius: 10px; padding: 0.5rem 0.9rem; font-size: 0.82rem; font-weight: 600; cursor: pointer; } .bar button:disabled { opacity: 0.5; }
+.scopes { display: flex; gap: 0.25rem; } .sc { background: transparent; border: none; color: var(--text-3); border-radius: 8px; padding: 0.4rem 0.6rem; font-size: 0.75rem; text-transform: capitalize; cursor: pointer; } .sc:hover { color: var(--text); } .sc.on { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--accent); }
+.error, .err2 { color: var(--down); font-size: 0.82rem; } .mut { color: var(--text-3); font-size: 0.8rem; }
 .cols { display: grid; grid-template-columns: 1fr; gap: 0.75rem; } @media (min-width: 720px) { .cols { grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); } }
-.col { border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 14px; padding: 0.5rem; }
-.ch { display: flex; justify-content: space-between; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.08em; padding: 0.3rem 0.5rem; } .count { color: rgba(255, 255, 255, 0.4); }
-.hit { padding: 0.4rem 0.55rem; border-radius: 8px; } .hit:hover { background: rgba(255, 255, 255, 0.05); }
-.hrow { display: flex; gap: 0.5rem; } .ht { font-weight: 600; font-size: 0.82rem; } .hs { margin-left: auto; font-size: 0.66rem; color: rgba(255, 255, 255, 0.4); }
-.hsnip { font-size: 0.76rem; color: rgba(255, 255, 255, 0.65); margin-top: 0.15rem; } .href { font-size: 0.64rem; color: rgba(255, 255, 255, 0.4); margin-top: 0.15rem; }
+.col { border: 1px solid var(--line); border-radius: 14px; padding: 0.5rem; }
+.ch { display: flex; justify-content: space-between; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.08em; padding: 0.3rem 0.5rem; } .count { color: var(--text-3); }
+.hit { padding: 0.4rem 0.55rem 0.4rem 0.7rem; border-radius: 8px; border-left: 2px solid transparent; } .hit:hover { background: var(--surface-2); border-left-color: currentColor; }
+.hrow { display: flex; gap: 0.5rem; } .ht { font-weight: 600; font-size: 0.82rem; color: var(--text); } .hs { margin-left: auto; font-size: 0.66rem; color: var(--text-3); font-variant-numeric: tabular-nums; }
+.hsnip { font-size: 0.76rem; color: var(--text-2); margin-top: 0.15rem; } .href { font-size: 0.64rem; color: var(--text-3); margin-top: 0.15rem; font-family: var(--font-mono, ui-monospace, monospace); }
 </style>

--- a/apps/socioprophet-web/src/pages/studio/FactsheetDrawer.vue
+++ b/apps/socioprophet-web/src/pages/studio/FactsheetDrawer.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+// A reusable right-side slide-over drawer — the estate's detail surface. Backdrop + panel, ESC to
+// close, focus moves into the panel on open, reduced-motion aware. Content is a slot, so any surface
+// can present a designed factsheet in it (Catalog uses it for datasets). Teleported to <body> so it
+// escapes the Studio scroll container and overlays the whole cockpit.
+import { watch, ref, nextTick, onBeforeUnmount } from 'vue';
+
+const props = defineProps<{ open: boolean; title?: string; eyebrow?: string }>();
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const panel = ref<HTMLElement | null>(null);
+function onKey(e: KeyboardEvent) { if (e.key === 'Escape') emit('close'); }
+
+watch(() => props.open, (o) => {
+  if (o) {
+    document.addEventListener('keydown', onKey);
+    nextTick(() => panel.value?.focus());
+  } else {
+    document.removeEventListener('keydown', onKey);
+  }
+});
+onBeforeUnmount(() => document.removeEventListener('keydown', onKey));
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="fd">
+      <div v-if="open" class="fd studio-scope" @click.self="emit('close')">
+        <div class="fd-panel" ref="panel" tabindex="-1" role="dialog" aria-modal="true" :aria-label="title || 'details'">
+          <header class="fd-h">
+            <div class="fd-h-t">
+              <span v-if="eyebrow" class="fd-eyebrow">{{ eyebrow }}</span>
+              <h2>{{ title }}</h2>
+            </div>
+            <div class="fd-h-actions"><slot name="actions" /></div>
+            <button class="fd-x" @click="emit('close')" aria-label="Close">✕</button>
+          </header>
+          <div class="fd-body"><slot /></div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.fd { position: fixed; inset: 0; z-index: 200; display: flex; justify-content: flex-end;
+  background: color-mix(in srgb, #000 55%, transparent); }
+.fd-panel { width: min(460px, 92vw); height: 100%; background: var(--ground); border-left: 1px solid var(--hairline-strong);
+  box-shadow: var(--e-3); display: flex; flex-direction: column; outline: none; }
+.fd-h { display: flex; align-items: flex-start; gap: var(--sp-3); padding: var(--sp-4) var(--sp-4) var(--sp-3); border-bottom: 1px solid var(--hairline); background: var(--bar); }
+.fd-h-t { min-width: 0; flex: 1; }
+.fd-eyebrow { display: block; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; color: var(--faint); margin-bottom: 2px; }
+.fd-h h2 { margin: 0; font-size: 1.05rem; color: var(--bar-ink); font-weight: 600; word-break: break-word; }
+.fd-h-actions { display: flex; gap: 6px; align-items: center; }
+.fd-x { flex: 0 0 auto; width: 28px; height: 28px; border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); cursor: pointer; }
+.fd-x:hover { color: var(--ink); }
+.fd-body { flex: 1; overflow-y: auto; padding: var(--sp-4); color: var(--ink); }
+
+/* transitions — reduced-motion collapses to a fade */
+.fd-enter-active, .fd-leave-active { transition: opacity .18s ease; }
+.fd-enter-active .fd-panel, .fd-leave-active .fd-panel { transition: transform .22s cubic-bezier(.22,.61,.36,1); }
+.fd-enter-from, .fd-leave-to { opacity: 0; }
+.fd-enter-from .fd-panel, .fd-leave-to .fd-panel { transform: translateX(100%); }
+@media (prefers-reduced-motion: reduce) {
+  .fd-enter-active .fd-panel, .fd-leave-active .fd-panel { transition: none; }
+  .fd-enter-from .fd-panel, .fd-leave-to .fd-panel { transform: none; }
+}
+</style>

--- a/apps/socioprophet-web/src/pages/studio/StudioCatalog.vue
+++ b/apps/socioprophet-web/src/pages/studio/StudioCatalog.vue
@@ -7,6 +7,7 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { loadCatalog, EPISTEMIC_COLORS, type Dataset } from '../../services/studioApi';
 import Sparkline from '../../components/Sparkline.vue';
+import FactsheetDrawer from './FactsheetDrawer.vue';
 
 const props = defineProps<{ project: string }>();
 
@@ -14,7 +15,7 @@ const datasets = ref<Dataset[]>([]);
 const loading = ref(true);
 const err = ref('');
 const facet = ref<string>('all');       // connector filter
-const expanded = ref<string>('');       // dataset id whose schema is open
+const sheet = ref<Dataset | null>(null); // dataset whose factsheet drawer is open
 
 async function load() {
   loading.value = true; err.value = '';
@@ -53,7 +54,19 @@ function demoSeries(id: string): number[] {
 function series(d: Dataset): number[] { return d.volume_trend?.length ? d.volume_trend : demoSeries(d.id); }
 function isLive(d: Dataset): boolean { return !!d.volume_trend?.length; }
 function last(s: number[]): number { return s[s.length - 1] ?? 0; }
-function toggle(id: string) { expanded.value = expanded.value === id ? '' : id; }
+function openSheet(d: Dataset) { sheet.value = d; }
+
+// Attested factsheet — a deterministic, recomputable summary built from the dataset's OWN facts
+// (not model-generated prose), with a content-id receipt = a hash of those facts. Honest "attested
+// AI": the attestation is real (recompute the hash to verify), the text is extractive/templated.
+function djb2(s: string): string { let h = 5381; for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff; return (h >>> 0).toString(16).padStart(8, '0'); }
+function attest(d: Dataset): { summary: string; receipt: string; live: boolean } {
+  const s = series(d);
+  const dir = s.length > 1 ? (s[s.length - 1] > s[0] ? 'rising' : s[s.length - 1] < s[0] ? 'falling' : 'flat') : 'flat';
+  const summary = `${d.name} is a ${d.epistemic_mode} dataset${d.connector ? ` ingested via ${d.connector}` : ''} with ${d.columns.length} column${d.columns.length === 1 ? '' : 's'}${d.labels.length ? ` (${d.labels.join(', ')})` : ''}. Ingest volume is ${dir} across the ${s.length} most recent snapshots.`;
+  const receipt = `fs-${djb2([d.id, d.connector || '', d.epistemic_mode, String(d.columns.length), dir].join('|'))}`;
+  return { summary, receipt, live: isLive(d) };
+}
 </script>
 
 <template>
@@ -84,7 +97,7 @@ function toggle(id: string) { expanded.value = expanded.value === id ? '' : id; 
       <div v-for="d in shown" :key="d.id" class="crow-wrap">
         <div class="crow epi-stripe" role="row" :style="{ '--epi': color(d.epistemic_mode) }">
           <span class="c-nm" role="cell">
-            <button class="nm-btn" @click="toggle(d.id)" :aria-expanded="expanded === d.id">
+            <button class="nm-btn" @click="openSheet(d)" title="Open factsheet">
               <b>{{ d.name }}</b>
               <span class="labels"><i v-for="l in d.labels" :key="l" class="lbl">{{ l }}</i></span>
             </button>
@@ -97,12 +110,29 @@ function toggle(id: string) { expanded.value = expanded.value === id ? '' : id; 
             <span class="spv tnum" :title="isLive(d) ? 'live ingest volume' : 'demo series — backend volume_trend not yet supplied'">{{ isLive(d) ? '' : '~' }}{{ last(series(d)) }}</span>
           </span>
         </div>
-        <div v-if="expanded === d.id" class="schema" role="row">
-          <span class="sk-h">schema</span>
-          <code v-for="c in d.columns" :key="c" class="col">{{ c }}</code>
-        </div>
       </div>
     </div>
+
+    <FactsheetDrawer :open="!!sheet" :title="sheet?.name" :eyebrow="sheet?.connector ? ('dataset · ' + sheet.connector) : 'dataset'" @close="sheet = null">
+      <template v-if="sheet">
+        <div class="fs-top">
+          <span class="epi-chip" :style="{ '--epi': color(sheet.epistemic_mode), '--epi-wash': 'transparent' }">{{ sheet.epistemic_mode }}</span>
+          <code class="fs-id">{{ sheet.id }}</code>
+        </div>
+        <div class="fs-facts">
+          <div class="fct"><span class="fk">Connector</span><span class="fv">{{ sheet.connector || '—' }}</span></div>
+          <div class="fct"><span class="fk">Columns</span><span class="fv tnum">{{ sheet.columns.length }}</span></div>
+          <div class="fct"><span class="fk">Labels</span><span class="fv">{{ sheet.labels.join(', ') || '—' }}</span></div>
+          <div class="fct"><span class="fk">Ingest</span><span class="fv sp"><Sparkline :series="series(sheet)" :w="90" :h="22" tone="accent" /><b class="tnum">{{ isLive(sheet) ? '' : '~' }}{{ last(series(sheet)) }}</b></span></div>
+        </div>
+        <div class="fs-sec"><h4>Schema</h4><div class="fs-cols"><code v-for="c in sheet.columns" :key="c">{{ c }}</code></div></div>
+        <div class="fs-sec attested">
+          <h4>Attested factsheet <span class="att-chip" title="deterministic · recomputable">▪ {{ attest(sheet).receipt }}</span></h4>
+          <p class="att-text">{{ attest(sheet).summary }}</p>
+          <span class="att-note">Computed from the dataset's own facts — deterministic + recomputable (the receipt is a hash of those facts), not model-generated prose. {{ attest(sheet).live ? 'Ingest volume is live.' : 'Ingest volume is a demo series until the backend supplies volume_trend.' }}</span>
+        </div>
+      </template>
+    </FactsheetDrawer>
 
     <p class="foot">Datasets are proof-carrying graph nodes — provenance + epistemic status are native fields, not a bolt-on catalog. The stripe on each row is its epistemic mode; the sparkline is ingest volume ({{ '~' }} = demo until the backend supplies <code>volume_trend</code>).</p>
   </div>
@@ -141,8 +171,21 @@ function toggle(id: string) { expanded.value = expanded.value === id ? '' : id; 
 .c-co { color: var(--ink-2); font-size: 12.5px; }
 .c-sp { display: inline-flex; align-items: center; gap: 6px; justify-content: flex-end; }
 .spv { font-size: 11.5px; color: var(--muted); min-width: 30px; text-align: right; }
-.schema { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; padding: 6px var(--sp-4) 10px calc(var(--sp-4) + 3px); background: var(--sunken); }
-.sk-h { font-size: 10px; text-transform: uppercase; letter-spacing: .06em; color: var(--faint); margin-right: 4px; }
-.col { font-family: var(--mono); font-size: 11px; color: var(--ink-2); background: var(--surface); border: 1px solid var(--hairline); border-radius: var(--r-1); padding: 1px 6px; }
 .foot { color: var(--muted); font-size: 12px; margin: var(--sp-3) 0 0; } .foot code { font-family: var(--mono); font-size: 11px; color: var(--ink-2); }
+
+/* factsheet drawer content */
+.fs-top { display: flex; align-items: center; gap: var(--sp-2); flex-wrap: wrap; margin-bottom: var(--sp-4); }
+.fs-id { font-family: var(--mono); font-size: 10.5px; color: var(--faint); word-break: break-all; }
+.fs-facts { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-3); margin-bottom: var(--sp-4); }
+.fct { display: flex; flex-direction: column; gap: 2px; border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 7px 10px; background: var(--surface); }
+.fk { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--faint); }
+.fv { font-size: 13px; color: var(--ink); } .fv.sp { display: flex; align-items: center; gap: 6px; } .fv.sp b { font-size: 12px; color: var(--muted); }
+.fs-sec { margin-bottom: var(--sp-4); }
+.fs-sec h4 { margin: 0 0 var(--sp-2); font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); display: flex; align-items: center; gap: 8px; }
+.fs-cols { display: flex; flex-wrap: wrap; gap: 5px; }
+.fs-cols code { font-family: var(--mono); font-size: 11px; color: var(--ink-2); background: var(--surface); border: 1px solid var(--hairline); border-radius: var(--r-1); padding: 1px 6px; }
+.attested { border: 1px solid color-mix(in srgb, var(--epi-attested) 30%, var(--hairline)); border-radius: var(--r-3); padding: var(--sp-3) var(--sp-4); background: var(--epi-attested-wash, var(--sunken)); }
+.att-chip { font-family: var(--mono); font-size: 10px; color: var(--epi-attested); background: color-mix(in srgb, var(--epi-attested) 12%, transparent); border-radius: var(--r-1); padding: 1px 6px; letter-spacing: 0; text-transform: none; }
+.att-text { font-size: 13px; line-height: 1.55; color: var(--ink); margin: 0 0 8px; }
+.att-note { font-size: 11px; color: var(--muted); line-height: 1.5; }
 </style>


### PR DESCRIPTION
Two more anneal passes (after #927, #928, #929).

## Factsheet / detail drawer (#51)
- **`FactsheetDrawer.vue`** — a reusable right-side slide-over (teleported to body, backdrop, ESC, focus-in, reduced-motion aware); content by slot.
- Wired into the **Data Catalog**: clicking a dataset opens a **designed factsheet** — epistemic chip, graph-node id, a facts grid (connector / columns / labels / ingest sparkline), schema, and an **Attested factsheet** block.
- **"Attested AI" done honestly**: the summary is **deterministic + extractive** (built from the dataset's own facts, not model prose) and carries a **content-id receipt = a hash of those facts**, so it's recomputable/verifiable. No hallucinated summary posing as a model output.

## .ai search on the token spine (#52, part 1)
- **`DataSearch.vue`** retooled onto the cockpit token spine: every hardcoded `rgba`/hex (`#2563eb`, `#4ade80`, `#93c5fd`, white-alphas) → tokens (`--surface`, `--text*`, `--accent`, `--up`, `--info`, `--down`, `--line*`). Source tint (local=up, platform=info) flows through each column so hits carry a left stripe in their source colour on hover; focus rings added.

## Verify
`vue-tsc` + `npm run build` clean. The **Agora surface** (the other half of #52 — it's greenfield, no existing web UI over `apps/agora`) follows as its own PR.