### PR TITLE
health: Digital Health Twin — opt-in local-first walking skeleton

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -77,6 +77,7 @@ jobs:
           - { image: holmes,                context: apps/holmes,                dockerfile: Dockerfile }
           - { image: portfolio-agent,       context: apps/portfolio-agent,       dockerfile: Dockerfile }
           - { image: academy-board,         context: apps/academy-board,         dockerfile: Dockerfile }
+          - { image: health-twin,           context: apps/health-twin,           dockerfile: Dockerfile }
           - { image: memoryd,               context: apps/memoryd,               dockerfile: Dockerfile }
           - { image: node-commander,        context: apps/node-commander,        dockerfile: Dockerfile }
           - { image: liberty-stack-readout, context: apps/liberty-stack-readout, dockerfile: Dockerfile }

--- a/apps/health-twin/Dockerfile
+++ b/apps/health-twin/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.7
+# health-twin — the Digital Health Twin engine (walking skeleton) on :8097. FHIR-lite record bundle
+# keyed to organ systems + governed, receipted, revocable consent grants. In production this runs
+# LOCAL-FIRST on the person's own node (never a shared cloud); this image holds synthetic data only.
+# No native deps. Runs as uid 10001 under readOnlyRootFilesystem — tsx/esbuild writes only to /tmp
+# (values sets tmpDir.enabled). http.listen(PORT) binds 0.0.0.0 (no localhost-bind CrashLoop trap).
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --no-audit --no-fund && chown -R 10001:10001 /app
+COPY src ./src
+ENV PORT=8097
+EXPOSE 8097
+USER 10001
+CMD ["npx", "tsx", "src/server.ts"]

--- a/apps/health-twin/package.json
+++ b/apps/health-twin/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "health-twin",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Digital Health Twin engine (walking skeleton) — opt-in, local-first, sovereign FHIR-lite record store + governed consent grants. Synthetic data only; non-diagnostic.",
+  "dependencies": {
+    "tsx": "^4.19.2"
+  }
+}

--- a/apps/health-twin/src/data.ts
+++ b/apps/health-twin/src/data.ts
@@ -1,0 +1,64 @@
+// The Digital Health Twin engine's data model — FHIR-lite (a walking-skeleton subset of FHIR R4)
+// keyed to organ SYSTEMS so the anatomical body diagram can be the index. In production this store is
+// LOCAL-FIRST and SOVEREIGN (it runs on the person's own node / BearBrowser sidecar, encrypted, never
+// a shared cloud). Here it holds ONE clearly-SYNTHETIC subject so the surface renders — no real PHI.
+//
+// Trust rides the epistemic ramp: self-reported → lab-verified → clinician-attested. Nothing here is
+// diagnostic: the twin organises and retrieves records; a clinician diagnoses.
+
+export type EpistemicMode = 'observed' | 'derived' | 'verified' | 'attested' | 'hypothesis';
+
+// Organ systems = the anatomical index. `organs` are the diagram labels the poster shows.
+export interface System { id: string; label: string; organs: string[] }
+export const SYSTEMS: System[] = [
+  { id: 'nervous', label: 'Nervous', organs: ['Brain'] },
+  { id: 'cardiovascular', label: 'Cardiovascular', organs: ['Heart'] },
+  { id: 'respiratory', label: 'Respiratory', organs: ['Lungs'] },
+  { id: 'hepatic', label: 'Hepatic / Digestive', organs: ['Liver', 'Stomach', 'Pancreas', 'Intestines'] },
+  { id: 'urinary', label: 'Urinary', organs: ['Kidneys', 'Bladder'] },
+];
+
+export interface Observation {
+  id: string; system: string; code: string; codeSystem: 'LOINC'; display: string;
+  value: number; unit: string; refLow?: number; refHigh?: number;
+  effective: string; trend?: number[]; epistemic: EpistemicMode;
+}
+export interface Condition {
+  id: string; system: string; code: string; codeSystem: 'SNOMED'; display: string;
+  onset: string; clinicalStatus: string; epistemic: EpistemicMode;
+}
+export interface Encounter { id: string; system: string; type: string; date: string; provider: string; note: string }
+export interface ImagingStudy { id: string; system: string; modality: string; bodySite: string; date: string; description: string; epistemic: EpistemicMode }
+
+export interface Grant {
+  id: string; agent: string; scope: string; granted_at: string; expires_at: string;
+  revoked: boolean; reads: number; receipt: string;
+}
+
+// ── clearly-synthetic seed (NOT real PHI) ────────────────────────────────────────────────────────
+export const SUBJECT = { id: 'synthetic-subject-0', label: 'Demo Patient (synthetic)', note: 'Synthetic sample data — not a real person, not real medical records.' };
+
+export const OBSERVATIONS: Observation[] = [
+  { id: 'obs-ldl', system: 'cardiovascular', code: '13457-7', codeSystem: 'LOINC', display: 'LDL cholesterol', value: 148, unit: 'mg/dL', refLow: 0, refHigh: 100, effective: '2026-05-02', epistemic: 'verified', trend: [121, 126, 130, 129, 138, 142, 148] },
+  { id: 'obs-sbp', system: 'cardiovascular', code: '8480-6', codeSystem: 'LOINC', display: 'Systolic blood pressure', value: 138, unit: 'mmHg', refLow: 90, refHigh: 120, effective: '2026-05-02', epistemic: 'verified', trend: [128, 132, 130, 135, 134, 139, 138] },
+  { id: 'obs-a1c', system: 'hepatic', code: '4548-4', codeSystem: 'LOINC', display: 'Hemoglobin A1c', value: 5.9, unit: '%', refLow: 4, refHigh: 5.6, effective: '2026-04-18', epistemic: 'verified', trend: [5.4, 5.5, 5.6, 5.7, 5.8, 5.8, 5.9] },
+  { id: 'obs-alt', system: 'hepatic', code: '1742-6', codeSystem: 'LOINC', display: 'ALT (liver enzyme)', value: 31, unit: 'U/L', refLow: 7, refHigh: 56, effective: '2026-04-18', epistemic: 'verified', trend: [24, 26, 25, 28, 29, 30, 31] },
+  { id: 'obs-egfr', system: 'urinary', code: '33914-3', codeSystem: 'LOINC', display: 'eGFR (kidney function)', value: 92, unit: 'mL/min', refLow: 90, refHigh: 120, effective: '2026-04-18', epistemic: 'verified', trend: [99, 98, 97, 95, 94, 93, 92] },
+];
+
+export const CONDITIONS: Condition[] = [
+  { id: 'cond-htn', system: 'cardiovascular', code: '38341003', codeSystem: 'SNOMED', display: 'Essential hypertension', onset: '2024-11-10', clinicalStatus: 'active', epistemic: 'attested' },
+  { id: 'cond-pre', system: 'hepatic', code: '714628002', codeSystem: 'SNOMED', display: 'Prediabetes', onset: '2026-04-18', clinicalStatus: 'active', epistemic: 'verified' },
+];
+
+export const ENCOUNTERS: Encounter[] = [
+  { id: 'enc-mri', system: 'nervous', type: 'Imaging — Brain MRI', date: '2026-05-20', provider: 'Radiology', note: 'Routine surveillance; no acute findings noted in report.' },
+  { id: 'enc-card', system: 'cardiovascular', type: 'Cardiology consult', date: '2026-05-02', provider: 'Dr. A. Rivera', note: 'BP + lipids reviewed; lifestyle plan; recheck in 3 months.' },
+  { id: 'enc-lab', system: 'hepatic', type: 'Lab draw — metabolic panel', date: '2026-04-18', provider: 'LabCorp', note: 'A1c, ALT, eGFR, lipid panel.' },
+  { id: 'enc-pcp', system: 'cardiovascular', type: 'Primary care visit', date: '2024-11-10', provider: 'Dr. J. Okafor', note: 'Hypertension diagnosed; started monitoring.' },
+];
+
+export const IMAGING: ImagingStudy[] = [
+  { id: 'img-mri', system: 'nervous', modality: 'MRI', bodySite: 'Brain', date: '2026-05-20', description: 'MRI brain w/o contrast', epistemic: 'attested' },
+  { id: 'img-cxr', system: 'respiratory', modality: 'X-ray', bodySite: 'Chest', date: '2025-09-14', description: 'Chest radiograph, PA + lateral', epistemic: 'attested' },
+];

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -1,0 +1,112 @@
+// health-twin — the Digital Health Twin engine (walking skeleton). Serves the person's records as a
+// FHIR-lite bundle keyed to organ systems (so the anatomical diagram is the index), plus GOVERNED
+// consent grants: a designated agent gets a scoped, time-boxed, receipted, revocable read grant, and
+// every access is a receipt. In production this runs LOCAL-FIRST on the person's own node — never a
+// shared cloud. Here it holds one clearly-synthetic subject. Node http, binds 0.0.0.0.
+//
+// NOT a medical device. NOT diagnostic. Organises + retrieves + governs sharing of a person's own
+// records. Synthetic data only in this skeleton — no real PHI.
+import http from 'node:http';
+import { SUBJECT, SYSTEMS, OBSERVATIONS, CONDITIONS, ENCOUNTERS, IMAGING, type Grant } from './data.js';
+
+const PORT = Number(process.env.PORT ?? 8097);
+
+function djb2(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff;
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+function receipt(kind: string, parts: string[]): { id: string; verifier: 'health-twin'; at: string } {
+  return { id: `ht-${kind}-${djb2(parts.join('|'))}`, verifier: 'health-twin', at: new Date().toISOString() };
+}
+
+// In-memory grant ledger (skeleton). Local-first store in production.
+const grants: Grant[] = [];
+
+function bundle() {
+  // group records per system for the anatomical index
+  const bySystem = SYSTEMS.map((s) => ({
+    ...s,
+    observations: OBSERVATIONS.filter((o) => o.system === s.id),
+    conditions: CONDITIONS.filter((c) => c.system === s.id),
+    encounters: ENCOUNTERS.filter((e) => e.system === s.id),
+    imaging: IMAGING.filter((i) => i.system === s.id),
+  }));
+  return {
+    subject: SUBJECT,
+    systems: bySystem,
+    timeline: [...ENCOUNTERS].sort((a, b) => (a.date < b.date ? 1 : -1)),
+    counts: { observations: OBSERVATIONS.length, conditions: CONDITIONS.length, encounters: ENCOUNTERS.length, imaging: IMAGING.length },
+    grants: grants.map((g) => ({ ...g, active: !g.revoked && new Date(g.expires_at) > new Date() })),
+    disclaimer: 'Synthetic sample. Not a real person, not medical advice. This tool organises records; it does not diagnose.',
+  };
+}
+
+function send(res: http.ServerResponse, code: number, body: unknown) {
+  res.writeHead(code, { 'content-type': 'application/json', 'access-control-allow-origin': '*', 'access-control-allow-headers': 'content-type', 'access-control-allow-methods': 'POST, GET, OPTIONS' });
+  res.end(JSON.stringify(body));
+}
+function readJson(req: http.IncomingMessage): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let raw = ''; req.on('data', (c) => { raw += c; if (raw.length > 2_000_000) req.destroy(); });
+    req.on('end', () => { try { resolve(raw ? JSON.parse(raw) : {}); } catch (e) { reject(e); } });
+    req.on('error', reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+  if (req.method === 'OPTIONS') return send(res, 204, {});
+  if (req.method === 'GET' && url.pathname === '/healthz') return send(res, 200, { ok: true, service: 'health-twin' });
+
+  // The twin bundle (the surface's one read).
+  if (req.method === 'GET' && url.pathname === '/api/health/twin') return send(res, 200, bundle());
+
+  // Grant a designated agent a scoped, time-boxed read grant — receipted.
+  if (req.method === 'POST' && url.pathname === '/api/health/grant') {
+    try {
+      const b = await readJson(req);
+      const agent = String(b.agent ?? '').trim();
+      const scope = String(b.scope ?? 'all systems').trim() || 'all systems';
+      const ttlDays = Math.max(1, Math.min(365, Number(b.ttlDays ?? 30)));
+      if (!agent) return send(res, 422, { error: 'agent required' });
+      const now = new Date();
+      const g: Grant = {
+        id: `grant-${djb2([agent, scope, String(now.getTime())].join('|'))}`,
+        agent, scope, granted_at: now.toISOString(),
+        expires_at: new Date(now.getTime() + ttlDays * 86400000).toISOString(),
+        revoked: false, reads: 0, receipt: receipt('grant', [agent, scope, String(ttlDays)]).id,
+      };
+      grants.unshift(g);
+      return send(res, 200, { grant: g });
+    } catch { return send(res, 400, { error: 'bad json' }); }
+  }
+
+  // Revoke a grant — read-enforced: future reads by that agent are blocked.
+  if (req.method === 'POST' && url.pathname === '/api/health/revoke') {
+    try {
+      const b = await readJson(req);
+      const g = grants.find((x) => x.id === String(b.grant));
+      if (!g) return send(res, 404, { error: 'grant not found' });
+      g.revoked = true;
+      return send(res, 200, { grant: g, receipt: receipt('revoke', [g.id]) });
+    } catch { return send(res, 400, { error: 'bad json' }); }
+  }
+
+  // An agent exercises a grant to read a slice — the access itself is a receipt (or a block).
+  if (req.method === 'POST' && url.pathname === '/api/health/agent-read') {
+    try {
+      const b = await readJson(req);
+      const g = grants.find((x) => x.id === String(b.grant));
+      if (!g) return send(res, 404, { error: 'grant not found' });
+      if (g.revoked) return send(res, 403, { blocked: true, reason: 'grant revoked — read denied' });
+      if (new Date(g.expires_at) <= new Date()) return send(res, 403, { blocked: true, reason: 'grant expired — read denied' });
+      g.reads += 1;
+      return send(res, 200, { agent: g.agent, scope: g.scope, reads: g.reads, receipt: receipt('read', [g.id, String(g.reads)]) });
+    } catch { return send(res, 400, { error: 'bad json' }); }
+  }
+
+  send(res, 404, { error: 'not found' });
+});
+
+server.listen(PORT, () => { console.log(`health-twin listening on :${PORT}`); });

--- a/apps/socioprophet-web/nginx.conf
+++ b/apps/socioprophet-web/nginx.conf
@@ -87,6 +87,8 @@ http {
         location /svc/board/     { set $u academy-board.socioprophet.svc.cluster.local;      rewrite ^/svc/board/(.*)$     /$1 break; proxy_pass http://$u:8095; proxy_http_version 1.1; proxy_set_header Host $host; }
         # Agora — the work + knowledge plane (Jira/Confluence killer over HellGraph) on :8080.
         location /svc/agora/     { set $u agora.socioprophet.svc.cluster.local;               rewrite ^/svc/agora/(.*)$    /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
+        # Digital Health Twin engine (opt-in, local-first in prod; synthetic-demo here) → records/grants on :8097.
+        location /svc/health/    { set $u health-twin.socioprophet.svc.cluster.local;         rewrite ^/svc/health/(.*)$   /$1 break; proxy_pass http://$u:8097; proxy_http_version 1.1; proxy_set_header Host $host; }
         # Studio API → lattice-studio (Notebooks, Compute Plane, Governance, Commons, Experiments,
         # FAIR/cite/versions/receipts). The client sets VITE_STUDIO_API=/svc/studio (see .env.production),
         # so studioApi requests /svc/studio/api/studio/* — the rewrite strips /svc/studio and lattice-studio

--- a/apps/socioprophet-web/src/config/cockpitNav.ts
+++ b/apps/socioprophet-web/src/config/cockpitNav.ts
@@ -201,6 +201,7 @@ export const OPERATOR_SHORTCUTS: NavLeaf[] = [
   { label: 'Research Capture', to: '/research' },
   { label: 'Reader', to: '/reader' },
   { label: 'Journal', to: '/journal' },
+  { label: 'Health Self (opt-in)', to: '/health' },
 ];
 
 // Agent Machine cockpit — live on-device surfaces backed by the Noetica

--- a/apps/socioprophet-web/src/main.ts
+++ b/apps/socioprophet-web/src/main.ts
@@ -20,6 +20,7 @@ import Studio from './pages/Studio.vue';
 import Discovery from './pages/Discovery.vue';
 import DataSearch from './pages/DataSearch.vue';
 import AgoraSurface from './pages/AgoraSurface.vue';
+import HealthTwin from './pages/HealthTwin.vue';
 import KnowledgeGraph from './pages/KnowledgeGraph.vue';
 import ForgeImport from './pages/ForgeImport.vue';
 import NewsFeed from './pages/NewsFeed.vue';
@@ -137,6 +138,7 @@ const explicitRoutes = [
   { path: '/discovery', component: Discovery },
   { path: '/data/search', component: DataSearch },
   { path: '/agora', component: AgoraSurface },
+  { path: '/health', component: HealthTwin },
   { path: '/knowledge/graph', component: KnowledgeGraph },
   { path: '/forge/import', component: ForgeImport },
   { path: '/news', component: NewsFeed },

--- a/apps/socioprophet-web/src/pages/HealthTwin.vue
+++ b/apps/socioprophet-web/src/pages/HealthTwin.vue
@@ -1,0 +1,314 @@
+<script setup lang="ts">
+// Digital Health Twin — the "Digital Health Self" (walking skeleton). An OPT-IN, local-first,
+// sovereign view of a person's own records, indexed by organ system (the anatomical diagram as the
+// interface). Reuses the design-language components: Sparkline (lab trends), FactsheetDrawer (an
+// attested, NON-DIAGNOSTIC record factsheet), the epistemic stripe (record trust). Plus the sovereign
+// difference: a governed-sharing panel where a designated agent gets a scoped, revocable, RECEIPTED
+// read grant — revoke and the next read is blocked. Synthetic data only in this skeleton.
+//
+// Guardrails, enforced in the UI: opt-in gate before anything renders · non-diagnostic framing ·
+// nothing shared without an explicit grant · every access receipted.
+import { ref, computed, onMounted, watch, onBeforeUnmount } from 'vue';
+import { loadTwin, grantAccess, revokeAccess, agentRead, type TwinBundle, type SystemBundle, type Observation, type Condition } from '../services/healthTwinApi';
+import { EPISTEMIC_COLORS } from '../services/studioApi';
+import Sparkline from '../components/Sparkline.vue';
+import './studio/studio-tokens.css';
+
+const OPTIN_KEY = 'health-twin-optin-v1';
+const optedIn = ref(localStorage.getItem(OPTIN_KEY) === '1');
+function optIn() { localStorage.setItem(OPTIN_KEY, '1'); optedIn.value = true; load(); }
+function optOut() { localStorage.removeItem(OPTIN_KEY); optedIn.value = false; twin.value = null; }
+
+const twin = ref<TwinBundle | null>(null);
+const loading = ref(false);
+const err = ref('');
+const selected = ref<string>('cardiovascular');
+const flash = ref('');
+function say(m: string) { flash.value = m; setTimeout(() => (flash.value = ''), 2800); }
+
+async function load() {
+  loading.value = true; err.value = '';
+  try {
+    twin.value = await loadTwin();
+    if (!twin.value.systems.some((s) => s.id === selected.value)) selected.value = twin.value.systems[0]?.id ?? '';
+  } catch (e) { err.value = e instanceof Error ? e.message : 'failed to load health twin'; }
+  finally { loading.value = false; }
+}
+onMounted(() => { if (optedIn.value) load(); });
+
+function epi(mode: string): string { return EPISTEMIC_COLORS[mode] || 'var(--epi-unknown)'; }
+function recordCount(s: SystemBundle): number { return s.observations.length + s.conditions.length + s.encounters.length + s.imaging.length; }
+const sys = computed<SystemBundle | null>(() => twin.value?.systems.find((s) => s.id === selected.value) ?? null);
+function outOfRange(o: Observation): boolean { return (o.refHigh != null && o.value > o.refHigh) || (o.refLow != null && o.value < o.refLow); }
+
+// factsheet (attested, deterministic, non-diagnostic)
+function djb2(s: string): string { let h = 5381; for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff; return (h >>> 0).toString(16).padStart(8, '0'); }
+type Sheet = { title: string; eyebrow: string; epistemic: string; summary: string; receipt: string; facts: { k: string; v: string }[]; trend?: number[] };
+const sheet = ref<Sheet | null>(null);
+function obsSheet(o: Observation) {
+  const dir = o.trend && o.trend.length > 1 ? (o.trend[o.trend.length - 1] > o.trend[0] ? 'rising' : o.trend[o.trend.length - 1] < o.trend[0] ? 'falling' : 'stable') : 'stable';
+  const pos = o.refHigh != null && o.value > o.refHigh ? 'above' : o.refLow != null && o.value < o.refLow ? 'below' : 'within';
+  sheet.value = {
+    title: o.display, eyebrow: `lab · ${o.codeSystem} ${o.code}`, epistemic: o.epistemic,
+    summary: `${o.display} measured ${o.value} ${o.unit} on ${o.effective}, ${dir} over ${o.trend?.length ?? 1} results. Reference ${o.refLow ?? '—'}–${o.refHigh ?? '—'} ${o.unit}; this value is ${pos} range. Verified by lab. A record, not a diagnosis.`,
+    receipt: `ht-${djb2([o.id, String(o.value), o.effective, pos, dir].join('|'))}`,
+    facts: [{ k: 'Value', v: `${o.value} ${o.unit}` }, { k: 'Reference', v: `${o.refLow ?? '—'}–${o.refHigh ?? '—'} ${o.unit}` }, { k: 'Date', v: o.effective }, { k: 'Code', v: `${o.codeSystem} ${o.code}` }],
+    trend: o.trend,
+  };
+}
+function condSheet(c: Condition) {
+  sheet.value = {
+    title: c.display, eyebrow: `condition · ${c.codeSystem} ${c.code}`, epistemic: c.epistemic,
+    summary: `${c.display} (${c.codeSystem} ${c.code}), ${c.clinicalStatus}, onset ${c.onset}. Trust level: ${c.epistemic}. This is a stored record; it is not re-diagnosed here.`,
+    receipt: `ht-${djb2([c.id, c.clinicalStatus, c.onset].join('|'))}`,
+    facts: [{ k: 'Status', v: c.clinicalStatus }, { k: 'Onset', v: c.onset }, { k: 'Code', v: `${c.codeSystem} ${c.code}` }, { k: 'Trust', v: c.epistemic }],
+  };
+}
+// self-contained drawer: ESC closes (kept local so the health twin doesn't couple to Studio components)
+function onSheetKey(e: KeyboardEvent) { if (e.key === 'Escape') sheet.value = null; }
+watch(sheet, (s) => { if (s) document.addEventListener('keydown', onSheetKey); else document.removeEventListener('keydown', onSheetKey); });
+onBeforeUnmount(() => document.removeEventListener('keydown', onSheetKey));
+
+// governed sharing
+const ng = ref<{ agent: string; scope: string; ttl: number }>({ agent: '', scope: '', ttl: 30 });
+async function doGrant() {
+  if (!ng.value.agent.trim()) return;
+  try { await grantAccess(ng.value.agent.trim(), ng.value.scope.trim() || 'all systems', ng.value.ttl); say('Grant issued — receipted'); ng.value.agent = ''; ng.value.scope = ''; await load(); }
+  catch (e) { say(e instanceof Error ? e.message : 'grant failed'); }
+}
+async function doRevoke(id: string) { try { await revokeAccess(id); say('Revoked — future reads blocked'); await load(); } catch (e) { say(e instanceof Error ? e.message : 'revoke failed'); } }
+async function doAgentRead(id: string) {
+  const r = await agentRead(id);
+  if (r.blocked) say(`🔒 ${r.reason}`); else say(`Agent read ✓ receipt ${r.receipt?.id} (read #${r.reads})`);
+  await load();
+}
+</script>
+
+<template>
+  <div class="studio-scope htwin">
+    <!-- OPT-IN GATE — nothing renders until the person explicitly enables their twin -->
+    <div v-if="!optedIn" class="gate">
+      <div class="gate-card">
+        <span class="gate-mark">◈</span>
+        <h1>Your Digital Health Self</h1>
+        <p class="gate-lead">A private, <b>opt-in</b> place to gather a lifetime of your medical records — notes, labs, imaging — indexed by your body's systems, so you and the people you designate can make sense of it.</p>
+        <ul class="gate-points">
+          <li><b>Local-first &amp; sovereign.</b> Your records stay on your own node, encrypted. No vendor cloud; export and leave anytime.</li>
+          <li><b>You control access.</b> A designated person or agent can only read a slice you grant — scoped, time-boxed, revocable, and every access leaves a receipt.</li>
+          <li><b>Not a diagnosis.</b> This organises and retrieves your records. It never diagnoses or gives medical advice — that's your clinician.</li>
+          <li><b>This preview uses synthetic sample data</b> — not a real person, not real records.</li>
+        </ul>
+        <button class="btn big" @click="optIn">Enable my health twin</button>
+        <p class="gate-fine">Opt-in only. You can turn this off and clear it at any time.</p>
+      </div>
+    </div>
+
+    <!-- THE TWIN -->
+    <template v-else>
+      <header class="ht-top">
+        <div class="ht-h"><span class="ht-mark">◈</span><div><h1>Digital Health Self</h1><span class="ht-sub">{{ twin?.subject.label }} · organ-system index</span></div></div>
+        <button class="ghost" @click="load" :disabled="loading" aria-label="Reload">↻</button>
+        <button class="ghost txt" @click="optOut">Turn off</button>
+      </header>
+      <p class="disclaimer">⚕ Not medical advice · organises records, does not diagnose · <b>synthetic sample data</b>.</p>
+      <p v-if="flash" class="flash">{{ flash }}</p>
+      <p v-if="err" class="msg err">{{ err }}</p>
+      <p v-else-if="loading && !twin" class="msg">Loading your twin…</p>
+
+      <div v-else-if="twin" class="ht-body">
+        <!-- Anatomical system index -->
+        <aside class="ht-index" aria-label="Body systems">
+          <div class="idx-h">Body systems</div>
+          <button v-for="s in twin.systems" :key="s.id" class="idx-row" :class="{ on: selected === s.id }" @click="selected = s.id">
+            <span class="idx-label"><b>{{ s.label }}</b><small>{{ s.organs.join(' · ') }}</small></span>
+            <span class="idx-n tnum">{{ recordCount(s) }}</span>
+          </button>
+        </aside>
+
+        <!-- Selected system detail -->
+        <section class="ht-detail" v-if="sys">
+          <h2 class="det-h">{{ sys.label }} <span>{{ sys.organs.join(' · ') }}</span></h2>
+
+          <div v-if="sys.observations.length" class="det-sec">
+            <h3>Labs</h3>
+            <div v-for="o in sys.observations" :key="o.id" class="obs epi-stripe" :style="{ '--epi': epi(o.epistemic) }">
+              <button class="obs-nm" @click="obsSheet(o)">{{ o.display }}</button>
+              <span class="obs-v tnum" :class="{ oor: outOfRange(o) }">{{ o.value }} <i>{{ o.unit }}</i></span>
+              <Sparkline v-if="o.trend" :series="o.trend" :w="88" :h="22" :tone="outOfRange(o) ? 'down' : 'accent'" />
+              <span class="obs-ref">ref {{ o.refLow ?? '—' }}–{{ o.refHigh ?? '—' }}</span>
+              <span class="epi-chip" :style="{ '--epi': epi(o.epistemic), '--epi-wash': 'transparent' }">{{ o.epistemic }}</span>
+            </div>
+          </div>
+
+          <div v-if="sys.conditions.length" class="det-sec">
+            <h3>Conditions</h3>
+            <button v-for="c in sys.conditions" :key="c.id" class="cond epi-stripe" :style="{ '--epi': epi(c.epistemic) }" @click="condSheet(c)">
+              <b>{{ c.display }}</b><span class="cond-s">{{ c.clinicalStatus }}</span><span class="cond-o">onset {{ c.onset }}</span>
+              <span class="epi-chip" :style="{ '--epi': epi(c.epistemic), '--epi-wash': 'transparent' }">{{ c.epistemic }}</span>
+            </button>
+          </div>
+
+          <div v-if="sys.imaging.length" class="det-sec">
+            <h3>Imaging</h3>
+            <div v-for="im in sys.imaging" :key="im.id" class="img-row"><span class="mod">{{ im.modality }}</span><span>{{ im.description }}</span><span class="img-d">{{ im.date }}</span></div>
+          </div>
+
+          <div v-if="sys.encounters.length" class="det-sec">
+            <h3>History</h3>
+            <div class="tl">
+              <div v-for="e in sys.encounters" :key="e.id" class="tl-row"><span class="tl-d tnum">{{ e.date }}</span><span class="tl-dot" /><span class="tl-c"><b>{{ e.type }}</b><small>{{ e.provider }} — {{ e.note }}</small></span></div>
+            </div>
+          </div>
+
+          <p v-if="!recordCount(sys)" class="msg">No records for this system.</p>
+        </section>
+
+        <!-- Governed sharing -->
+        <aside class="ht-share" aria-label="Governed sharing">
+          <div class="sh-h">Who can read this</div>
+          <p class="sh-lead">Grant a designated person or agent a <b>scoped, time-boxed, revocable</b> read. Every access is a receipt.</p>
+          <div class="sh-form">
+            <input v-model="ng.agent" class="j" placeholder="agent / person id" />
+            <input v-model="ng.scope" class="j" placeholder="scope (e.g. cardiovascular 2024–2026)" />
+            <div class="sh-ttl"><label>expires in</label><input v-model.number="ng.ttl" type="number" min="1" max="365" class="j ttl" /><span>days</span></div>
+            <button class="btn" @click="doGrant" :disabled="!ng.agent.trim()">Grant read</button>
+          </div>
+          <div class="grants">
+            <div v-for="g in twin.grants" :key="g.id" class="grant" :class="{ revoked: g.revoked, expired: !g.active && !g.revoked }">
+              <div class="g-top"><b>{{ g.agent }}</b><span class="g-state">{{ g.revoked ? 'revoked' : g.active ? 'active' : 'expired' }}</span></div>
+              <div class="g-scope">{{ g.scope }}</div>
+              <div class="g-meta"><span>reads <b class="tnum">{{ g.reads }}</b></span><span class="g-exp">exp {{ g.expires_at.slice(0, 10) }}</span><span class="g-rcpt mono">{{ g.receipt }}</span></div>
+              <div class="g-actions">
+                <button class="mini" @click="doAgentRead(g.id)">simulate agent read</button>
+                <button v-if="!g.revoked" class="mini danger" @click="doRevoke(g.id)">revoke</button>
+              </div>
+            </div>
+            <p v-if="!twin.grants.length" class="sh-empty">No grants — your records are private.</p>
+          </div>
+        </aside>
+      </div>
+
+      <!-- self-contained record factsheet drawer (attested, non-diagnostic) -->
+      <Teleport to="body">
+        <Transition name="fd">
+          <div v-if="sheet" class="fd studio-scope" @click.self="sheet = null">
+            <div class="fd-panel" role="dialog" aria-modal="true" :aria-label="sheet.title">
+              <header class="fd-h">
+                <div class="fd-h-t"><span class="fd-eyebrow">{{ sheet.eyebrow }}</span><h2>{{ sheet.title }}</h2></div>
+                <button class="fd-x" @click="sheet = null" aria-label="Close">✕</button>
+              </header>
+              <div class="fd-body">
+                <div class="fs-top"><span class="epi-chip" :style="{ '--epi': epi(sheet.epistemic), '--epi-wash': 'transparent' }">{{ sheet.epistemic }}</span></div>
+                <Sparkline v-if="sheet.trend" :series="sheet.trend" :w="220" :h="40" tone="accent" />
+                <div class="fs-facts">
+                  <div v-for="f in sheet.facts" :key="f.k" class="fct"><span class="fk">{{ f.k }}</span><span class="fv">{{ f.v }}</span></div>
+                </div>
+                <div class="fs-att">
+                  <h4>Attested record <span class="att-chip">▪ {{ sheet.receipt }}</span></h4>
+                  <p>{{ sheet.summary }}</p>
+                  <span class="att-note">Deterministic summary of the record's own fields (recomputable via the receipt) — not model-generated prose, and not a diagnosis.</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </Transition>
+      </Teleport>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.htwin { font: 14px/1.5 var(--ui); color: var(--ink); background: var(--bg); min-height: 100%; padding: var(--sp-4) var(--sp-5); }
+.htwin :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+
+/* opt-in gate */
+.gate { display: grid; place-items: center; min-height: 70vh; }
+.gate-card { max-width: 560px; border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface); padding: var(--sp-6); text-align: center; }
+.gate-mark { font-size: 2rem; color: var(--accent); }
+.gate-card h1 { margin: var(--sp-2) 0; font-size: 1.5rem; }
+.gate-lead { color: var(--ink-2); font-size: .95rem; margin: 0 0 var(--sp-4); }
+.gate-points { list-style: none; margin: 0 0 var(--sp-4); padding: 0; text-align: left; display: flex; flex-direction: column; gap: var(--sp-2); }
+.gate-points li { font-size: .85rem; color: var(--ink-2); border-left: 2px solid var(--accent); padding-left: var(--sp-3); } .gate-points b { color: var(--ink); }
+.gate-fine { color: var(--faint); font-size: .72rem; margin: var(--sp-3) 0 0; }
+.btn { border: 1px solid var(--accent); background: var(--accent); color: #04122e; border-radius: var(--r-2); padding: 8px 16px; font-weight: 600; cursor: pointer; font-size: 13px; } .btn:disabled { opacity: .55; }
+.btn.big { font-size: 15px; padding: 10px 22px; }
+
+/* header */
+.ht-top { display: flex; align-items: center; gap: var(--sp-3); margin-bottom: var(--sp-2); }
+.ht-h { display: flex; align-items: center; gap: var(--sp-3); margin-right: auto; }
+.ht-mark { color: var(--accent); font-size: 1.2rem; } .ht-h h1 { margin: 0; font-size: 1.15rem; } .ht-sub { color: var(--muted); font-size: .78rem; }
+.ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); height: 30px; min-width: 30px; padding: 0 8px; cursor: pointer; } .ghost.txt { font-size: 12px; }
+.disclaimer { font-size: 11.5px; color: var(--warn); background: var(--warn-wash); border-radius: var(--r-2); padding: 5px 10px; margin: 0 0 var(--sp-3); } .disclaimer b { color: var(--ink); }
+.flash { background: var(--ok-wash); color: var(--ok); border-radius: var(--r-2); padding: 6px 11px; font-size: 12.5px; margin: 0 0 10px; }
+.msg { color: var(--muted); } .msg.err { color: var(--fail); }
+
+.ht-body { display: grid; grid-template-columns: 220px minmax(0, 1fr) 280px; gap: var(--sp-3); }
+@media (max-width: 1080px) { .ht-body { grid-template-columns: 1fr; } }
+
+/* index */
+.ht-index { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--sunken); padding: var(--sp-2); display: flex; flex-direction: column; gap: 3px; align-self: start; }
+.idx-h { font-size: 10.5px; text-transform: uppercase; letter-spacing: .07em; color: var(--faint); padding: 6px 8px; }
+.idx-row { display: flex; align-items: center; gap: 8px; background: transparent; border: 1px solid transparent; border-radius: var(--r-2); padding: 8px 10px; cursor: pointer; text-align: left; color: inherit; }
+.idx-row:hover { background: var(--surface); } .idx-row.on { background: var(--accent-wash); border-color: var(--accent); }
+.idx-label { display: flex; flex-direction: column; min-width: 0; } .idx-label b { font-size: 13px; } .idx-label small { color: var(--muted); font-size: 10.5px; }
+.idx-n { margin-left: auto; font-size: 11px; color: var(--ink-2); background: var(--surface); border-radius: var(--pill); padding: 0 7px; }
+
+/* detail */
+.ht-detail { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface); padding: var(--sp-4); min-width: 0; }
+.det-h { margin: 0 0 var(--sp-3); font-size: 1.05rem; } .det-h span { color: var(--muted); font-size: .8rem; font-weight: 400; }
+.det-sec { margin-bottom: var(--sp-4); } .det-sec h3 { margin: 0 0 var(--sp-2); font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); }
+.obs { display: flex; align-items: center; gap: var(--sp-3); padding: 7px 10px 7px 12px; border: 1px solid var(--hairline); border-radius: var(--r-2); margin-bottom: 6px; background: var(--sunken); flex-wrap: wrap; }
+.obs-nm { background: none; border: 0; color: var(--ink); font-weight: 600; font-size: 13px; cursor: pointer; padding: 0; text-align: left; }
+.obs-v { font-size: 14px; color: var(--ink); font-variant-numeric: tabular-nums; } .obs-v i { font-style: normal; font-size: 11px; color: var(--muted); } .obs-v.oor { color: var(--fail); }
+.obs-ref { font-size: 10.5px; color: var(--faint); } .obs .epi-chip { margin-left: auto; }
+.cond { display: flex; align-items: center; gap: var(--sp-3); padding: 8px 10px 8px 12px; border: 1px solid var(--hairline); border-radius: var(--r-2); margin-bottom: 6px; background: var(--sunken); width: 100%; text-align: left; color: inherit; cursor: pointer; }
+.cond b { font-size: 13px; } .cond-s { font-size: 10.5px; color: var(--warn); text-transform: uppercase; } .cond-o { font-size: 11px; color: var(--muted); } .cond .epi-chip { margin-left: auto; }
+.img-row { display: flex; align-items: center; gap: var(--sp-3); padding: 6px 10px; border-bottom: 1px solid var(--hairline); font-size: 12.5px; }
+.mod { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--epi-attested); border: 1px solid color-mix(in srgb, var(--epi-attested) 40%, var(--hairline)); border-radius: var(--r-1); padding: 0 6px; } .img-d { margin-left: auto; color: var(--faint); font-size: 11px; }
+.tl { display: flex; flex-direction: column; }
+.tl-row { display: grid; grid-template-columns: 84px 12px 1fr; align-items: start; gap: 8px; padding: 5px 0; }
+.tl-d { font-size: 11px; color: var(--muted); text-align: right; } .tl-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent); margin-top: 5px; }
+.tl-c { display: flex; flex-direction: column; } .tl-c b { font-size: 12.5px; } .tl-c small { color: var(--muted); font-size: 11px; }
+
+/* sharing */
+.ht-share { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--sunken); padding: var(--sp-3); align-self: start; }
+.sh-h { font-size: 12px; font-weight: 600; margin-bottom: 4px; } .sh-lead { font-size: 11.5px; color: var(--muted); margin: 0 0 var(--sp-3); } .sh-lead b { color: var(--ink-2); }
+.sh-form { display: flex; flex-direction: column; gap: 6px; margin-bottom: var(--sp-3); }
+.j { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 12.5px; background: var(--surface); color: var(--ink); width: 100%; }
+.sh-ttl { display: flex; align-items: center; gap: 6px; font-size: 11.5px; color: var(--muted); } .j.ttl { width: 64px; }
+.grants { display: flex; flex-direction: column; gap: 6px; }
+.grant { border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 7px 9px; background: var(--surface); }
+.grant.revoked { opacity: .6; } .grant.expired { opacity: .7; }
+.g-top { display: flex; align-items: center; justify-content: space-between; } .g-top b { font-size: 12.5px; }
+.g-state { font-size: 9.5px; text-transform: uppercase; letter-spacing: .04em; border-radius: var(--pill); padding: 1px 7px; background: var(--ok-wash); color: var(--ok); }
+.grant.revoked .g-state { background: var(--fail-wash); color: var(--fail); } .grant.expired .g-state { background: var(--sunken); color: var(--muted); }
+.g-scope { font-size: 11px; color: var(--ink-2); margin: 2px 0; }
+.g-meta { display: flex; gap: 8px; font-size: 10px; color: var(--muted); align-items: center; flex-wrap: wrap; } .g-rcpt { color: var(--faint); } .mono { font-family: var(--mono); }
+.g-actions { display: flex; gap: 5px; margin-top: 5px; }
+.mini { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); padding: 2px 8px; font-size: 11px; cursor: pointer; } .mini.danger { border-color: var(--fail); color: var(--fail); }
+.sh-empty { font-size: 11.5px; color: var(--faint); }
+
+/* factsheet content */
+.fs-top { margin-bottom: var(--sp-3); }
+.fs-facts { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-2); margin: var(--sp-3) 0; }
+.fct { display: flex; flex-direction: column; gap: 2px; border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 7px 10px; background: var(--surface); }
+.fk { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--faint); } .fv { font-size: 13px; color: var(--ink); }
+.fs-att { border: 1px solid color-mix(in srgb, var(--epi-attested) 30%, var(--hairline)); border-radius: var(--r-3); padding: var(--sp-3); background: var(--epi-attested-wash, var(--sunken)); }
+.fs-att h4 { margin: 0 0 6px; font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); display: flex; gap: 8px; align-items: center; }
+.att-chip { font-family: var(--mono); font-size: 10px; color: var(--epi-attested); text-transform: none; }
+.fs-att p { font-size: 13px; line-height: 1.55; color: var(--ink); margin: 0 0 8px; }
+.att-note { font-size: 11px; color: var(--muted); line-height: 1.5; }
+
+/* self-contained drawer chrome */
+.fd { position: fixed; inset: 0; z-index: 200; display: flex; justify-content: flex-end; background: color-mix(in srgb, #000 55%, transparent); }
+.fd-panel { width: min(440px, 92vw); height: 100%; background: var(--ground); border-left: 1px solid var(--hairline-strong); box-shadow: var(--e-3); display: flex; flex-direction: column; }
+.fd-h { display: flex; align-items: flex-start; gap: var(--sp-3); padding: var(--sp-4) var(--sp-4) var(--sp-3); border-bottom: 1px solid var(--hairline); background: var(--bar); }
+.fd-h-t { min-width: 0; flex: 1; } .fd-eyebrow { display: block; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; color: var(--faint); margin-bottom: 2px; }
+.fd-h h2 { margin: 0; font-size: 1.05rem; color: var(--bar-ink); font-weight: 600; word-break: break-word; }
+.fd-x { flex: 0 0 auto; width: 28px; height: 28px; border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); cursor: pointer; }
+.fd-body { flex: 1; overflow-y: auto; padding: var(--sp-4); color: var(--ink); }
+.fd-enter-active, .fd-leave-active { transition: opacity .18s ease; }
+.fd-enter-active .fd-panel, .fd-leave-active .fd-panel { transition: transform .22s cubic-bezier(.22,.61,.36,1); }
+.fd-enter-from, .fd-leave-to { opacity: 0; } .fd-enter-from .fd-panel, .fd-leave-to .fd-panel { transform: translateX(100%); }
+@media (prefers-reduced-motion: reduce) { .fd-enter-active .fd-panel, .fd-leave-active .fd-panel { transition: none; } .fd-enter-from .fd-panel, .fd-leave-to .fd-panel { transform: none; } }
+</style>

--- a/apps/socioprophet-web/src/services/healthTwinApi.ts
+++ b/apps/socioprophet-web/src/services/healthTwinApi.ts
@@ -1,0 +1,44 @@
+// Digital Health Twin client (walking skeleton) → the health-twin engine (/svc/health). Reads the
+// person's FHIR-lite record bundle (keyed to organ systems, so the anatomical diagram is the index)
+// and drives governed consent grants — a designated agent gets a scoped, time-boxed, receipted,
+// revocable read grant, and every access is a receipt or a block. In production the engine runs
+// LOCAL-FIRST on the person's own node; this skeleton reads a synthetic subject. Non-diagnostic.
+import { resolveBase } from '../config/cockpitRuntime';
+
+const BASE = resolveBase('health', 'VITE_HEALTH_BASE', '/svc/health');
+
+export type EpistemicMode = 'observed' | 'derived' | 'verified' | 'attested' | 'hypothesis';
+export interface Observation { id: string; system: string; code: string; codeSystem: string; display: string; value: number; unit: string; refLow?: number; refHigh?: number; effective: string; trend?: number[]; epistemic: EpistemicMode }
+export interface Condition { id: string; system: string; code: string; codeSystem: string; display: string; onset: string; clinicalStatus: string; epistemic: EpistemicMode }
+export interface Encounter { id: string; system: string; type: string; date: string; provider: string; note: string }
+export interface ImagingStudy { id: string; system: string; modality: string; bodySite: string; date: string; description: string; epistemic: EpistemicMode }
+export interface SystemBundle { id: string; label: string; organs: string[]; observations: Observation[]; conditions: Condition[]; encounters: Encounter[]; imaging: ImagingStudy[] }
+export interface Grant { id: string; agent: string; scope: string; granted_at: string; expires_at: string; revoked: boolean; reads: number; receipt: string; active?: boolean }
+export interface TwinBundle {
+  subject: { id: string; label: string; note: string };
+  systems: SystemBundle[];
+  timeline: Encounter[];
+  counts: { observations: number; conditions: number; encounters: number; imaging: number };
+  grants: Grant[];
+  disclaimer: string;
+}
+
+export async function loadTwin(): Promise<TwinBundle> {
+  const res = await fetch(`${BASE}/api/health/twin`, { headers: { accept: 'application/json' } });
+  if (!res.ok) throw new Error(`health twin unreachable (${res.status})`);
+  return (await res.json()) as TwinBundle;
+}
+export async function grantAccess(agent: string, scope: string, ttlDays: number): Promise<{ grant: Grant }> {
+  const res = await fetch(`${BASE}/api/health/grant`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ agent, scope, ttlDays }) });
+  if (!res.ok) throw new Error(`grant failed (${res.status})`);
+  return await res.json();
+}
+export async function revokeAccess(grant: string): Promise<unknown> {
+  const res = await fetch(`${BASE}/api/health/revoke`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ grant }) });
+  if (!res.ok) throw new Error(`revoke failed (${res.status})`);
+  return await res.json();
+}
+export async function agentRead(grant: string): Promise<{ blocked?: boolean; reason?: string; reads?: number; receipt?: { id: string } }> {
+  const res = await fetch(`${BASE}/api/health/agent-read`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ grant }) });
+  return await res.json();
+}

--- a/apps/socioprophet-web/vite.config.ts
+++ b/apps/socioprophet-web/vite.config.ts
@@ -101,6 +101,12 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/svc\/agora/, ''),
         },
+        // Digital Health Twin engine (opt-in local-first record bundle + governed consent grants).
+        '/svc/health': {
+          target: env.VITE_HEALTH_BASE || 'http://localhost:8097',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/health/, ''),
+        },
         // Same-origin proxy to the live Prophet Mesh (mesh.socioprophet.ai has no CORS).
         '/mesh': {
           target: env.VITE_MESH_BASE || 'https://mesh.socioprophet.ai',

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -38,6 +38,7 @@ spec:
           - { name: holmes }
           - { name: portfolio-agent }
           - { name: academy-board }
+          - { name: health-twin }
           - { name: memoryd }
           - { name: embeddings }
           - { name: regis-acr-api }

--- a/deploy/values/health-twin.yaml
+++ b/deploy/values/health-twin.yaml
@@ -1,0 +1,12 @@
+# health-twin — the Digital Health Twin engine (walking skeleton). FHIR-lite record bundle keyed to
+# organ systems + governed, receipted, revocable consent grants. The cockpit's /health surface →
+# nginx /svc/health → this on :8097. Node binds 0.0.0.0 (no localhost-bind CrashLoop trap).
+#
+# NOTE: in production this engine is LOCAL-FIRST on the person's own node (never a shared cloud); this
+# deployment is the walking-skeleton demo with SYNTHETIC data only — no real PHI.
+#
+# tag:latest → gitops-promote pins the sha- tag on the first successful build (new-service pattern).
+image: { repository: health-twin, tag: latest }
+service: { port: 8097, portName: http }
+# tsx/esbuild needs a writable /tmp under the chart's readOnlyRootFilesystem.
+tmpDir: { enabled: true }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -115,6 +115,11 @@ KNOWN_BROKEN = {
         "New service — first-party embeddings image (apps/embeddings, FastAPI + nomic-embed-text) added to CI "
         "this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
     ),
+    "health-twin:moving-tag": (
+        "New service — the Digital Health Twin engine (apps/health-twin: opt-in local-first FHIR-lite record "
+        "bundle + governed receipted consent grants on :8097, synthetic data only) added to CI this PR. Pin "
+        "tag:latest -> the sha- tag gitops-promote writes after the first CI build; no sha exists until merge."
+    ),
     # portfolio-agent pinned to a sha- tag by gitops-promote after its first CI build (#925,
     # sha-a6d8311383) → removed from the ratchet (it only shrinks). Same for academy-board:
     # gitops-promote sha-pinned it after #926's first build (sha-f59cf2c9), so its moving-tag


### PR DESCRIPTION
Walking skeleton for the **Digital Health Self** (design captured on branch `design/digital-health-twin`, doc: `docs/design/digital-health-twin.md`). **Opt-in, sovereign, non-diagnostic, SYNTHETIC data only.**

## What
- **`apps/health-twin`** (Node http :8097) — a FHIR-lite record bundle **keyed to organ systems** (the anatomical diagram as the index) + **governed consent grants**: a designated agent gets a **scoped, time-boxed, receipted, revocable** read; every access is a receipt or a block. **Verified e2e**: grant → agent-read (receipt, reads++) → revoke → agent-read **BLOCKED** (read-enforced revocation — the sovereign moat). Production = **local-first on the person's own node**; here one synthetic subject.
- **`HealthTwin.vue`** (route `/health`, **opt-in gated**): an anatomical **body-systems index** → per-system **labs** (Sparkline + out-of-range), **conditions** (epistemic stripe), **imaging**, a **history timeline**, an **attested non-diagnostic** record factsheet, and a **governed-sharing panel** (grant / revoke / simulate-read with live receipts + read counts). Self-contained (no cross-PR coupling).
- **Deploy**: Dockerfile · images.yml · values · ArgoCD · preflight · nginx/vite `/svc/health`.

## Guardrails (in the UI)
Opt-in gate before anything renders · non-diagnostic banner · synthetic-data banner · nothing shared without an explicit grant · every access receipted.

## Verify
`vue-tsc` + `build` + `preflight` clean; local grant→read→revoke→blocked verified. **Skeleton** — next: real FHIR/DICOM ingest, offline DICOM viewer, local-first storage substrate, full anatomical SVG.