### PR TITLE
health twin: wire to HDT ontology + paint records on anatomy + spinal three-lens overlay

### DIFF
--- a/apps/health-twin/src/data.ts
+++ b/apps/health-twin/src/data.ts
@@ -8,23 +8,41 @@
 
 export type EpistemicMode = 'observed' | 'derived' | 'verified' | 'attested' | 'hypothesis';
 
-// Organ systems = the anatomical index. `organs` are the diagram labels the poster shows.
-export interface System { id: string; label: string; organs: string[] }
+// Ontology IRIs — the twin's facts carry real class identity from the HDT ontology, so they land in
+// HellGraph as typed nodes (not label strings) and reason in the estate's canonical vocabulary.
+//   • HEALTH_NS = the health/anatomy layer (ontogenesis Domains/health-anatomy.ttl, hosted socioprophet.md)
+//   • HDT_NS    = the Ontogenesis HDT core (hdt:Observation ⊑ hdt:FHIRResource)
+export const HEALTH_NS = 'https://socioprophet.md/ont/health#';
+export const HDT_NS = 'https://socioprophet.dev/ont/ontogenesis#';
+export const OBSERVATION_CLASS = `${HDT_NS}Observation`;
+export const CONDITION_CLASS = `${HEALTH_NS}Condition`;
+
+// Organ systems = the anatomical index. `iri` = the health:OrganSystem class; `compartment` = the
+// body-state x(t) compartment; keys match the ontology's health:systemKey.
+export interface System { id: string; label: string; organs: string[]; iri: string; compartment: string }
 export const SYSTEMS: System[] = [
-  { id: 'nervous', label: 'Nervous', organs: ['Brain'] },
-  { id: 'cardiovascular', label: 'Cardiovascular', organs: ['Heart'] },
-  { id: 'respiratory', label: 'Respiratory', organs: ['Lungs'] },
-  { id: 'hepatic', label: 'Hepatic / Digestive', organs: ['Liver', 'Stomach', 'Pancreas', 'Intestines'] },
-  { id: 'urinary', label: 'Urinary', organs: ['Kidneys', 'Bladder'] },
+  { id: 'nervous', label: 'Nervous', organs: ['Brain'], iri: `${HEALTH_NS}NervousSystem`, compartment: 'neuro' },
+  { id: 'cardiovascular', label: 'Cardiovascular', organs: ['Heart'], iri: `${HEALTH_NS}CardiovascularSystem`, compartment: 'cardio' },
+  { id: 'respiratory', label: 'Respiratory', organs: ['Lungs'], iri: `${HEALTH_NS}RespiratorySystem`, compartment: 'respiratory' },
+  { id: 'hepatic', label: 'Hepatic / Digestive', organs: ['Liver', 'Stomach', 'Pancreas', 'Intestines'], iri: `${HEALTH_NS}DigestiveSystem`, compartment: 'hepatic' },
+  { id: 'urinary', label: 'Urinary', organs: ['Kidneys', 'Bladder'], iri: `${HEALTH_NS}UrinarySystem`, compartment: 'renal' },
 ];
 
+// Organ → health:Organ IRI (the localizedTo target that paints a record onto anatomy).
+export const ORGAN_IRI: Record<string, string> = {
+  Brain: `${HEALTH_NS}Brain`, Heart: `${HEALTH_NS}Heart`, Lungs: `${HEALTH_NS}Lungs`,
+  Liver: `${HEALTH_NS}Liver`, Stomach: `${HEALTH_NS}Stomach`, Pancreas: `${HEALTH_NS}Pancreas`,
+  Intestines: `${HEALTH_NS}Intestines`, Kidneys: `${HEALTH_NS}Kidneys`, Bladder: `${HEALTH_NS}Bladder`,
+};
+
+// `organ` = the anatomical structure this record localises to (health:localizedTo) — what paints it onto the twin.
 export interface Observation {
-  id: string; system: string; code: string; codeSystem: 'LOINC'; display: string;
+  id: string; system: string; organ: string; code: string; codeSystem: 'LOINC'; display: string;
   value: number; unit: string; refLow?: number; refHigh?: number;
   effective: string; trend?: number[]; epistemic: EpistemicMode;
 }
 export interface Condition {
-  id: string; system: string; code: string; codeSystem: 'SNOMED'; display: string;
+  id: string; system: string; organ: string; code: string; codeSystem: 'SNOMED'; display: string;
   onset: string; clinicalStatus: string; epistemic: EpistemicMode;
 }
 export interface Encounter { id: string; system: string; type: string; date: string; provider: string; note: string }
@@ -39,16 +57,16 @@ export interface Grant {
 export const SUBJECT = { id: 'synthetic-subject-0', label: 'Demo Patient (synthetic)', note: 'Synthetic sample data — not a real person, not real medical records.' };
 
 export const OBSERVATIONS: Observation[] = [
-  { id: 'obs-ldl', system: 'cardiovascular', code: '13457-7', codeSystem: 'LOINC', display: 'LDL cholesterol', value: 148, unit: 'mg/dL', refLow: 0, refHigh: 100, effective: '2026-05-02', epistemic: 'verified', trend: [121, 126, 130, 129, 138, 142, 148] },
-  { id: 'obs-sbp', system: 'cardiovascular', code: '8480-6', codeSystem: 'LOINC', display: 'Systolic blood pressure', value: 138, unit: 'mmHg', refLow: 90, refHigh: 120, effective: '2026-05-02', epistemic: 'verified', trend: [128, 132, 130, 135, 134, 139, 138] },
-  { id: 'obs-a1c', system: 'hepatic', code: '4548-4', codeSystem: 'LOINC', display: 'Hemoglobin A1c', value: 5.9, unit: '%', refLow: 4, refHigh: 5.6, effective: '2026-04-18', epistemic: 'verified', trend: [5.4, 5.5, 5.6, 5.7, 5.8, 5.8, 5.9] },
-  { id: 'obs-alt', system: 'hepatic', code: '1742-6', codeSystem: 'LOINC', display: 'ALT (liver enzyme)', value: 31, unit: 'U/L', refLow: 7, refHigh: 56, effective: '2026-04-18', epistemic: 'verified', trend: [24, 26, 25, 28, 29, 30, 31] },
-  { id: 'obs-egfr', system: 'urinary', code: '33914-3', codeSystem: 'LOINC', display: 'eGFR (kidney function)', value: 92, unit: 'mL/min', refLow: 90, refHigh: 120, effective: '2026-04-18', epistemic: 'verified', trend: [99, 98, 97, 95, 94, 93, 92] },
+  { id: 'obs-ldl', system: 'cardiovascular', organ: 'Heart', code: '13457-7', codeSystem: 'LOINC', display: 'LDL cholesterol', value: 148, unit: 'mg/dL', refLow: 0, refHigh: 100, effective: '2026-05-02', epistemic: 'verified', trend: [121, 126, 130, 129, 138, 142, 148] },
+  { id: 'obs-sbp', system: 'cardiovascular', organ: 'Heart', code: '8480-6', codeSystem: 'LOINC', display: 'Systolic blood pressure', value: 138, unit: 'mmHg', refLow: 90, refHigh: 120, effective: '2026-05-02', epistemic: 'verified', trend: [128, 132, 130, 135, 134, 139, 138] },
+  { id: 'obs-a1c', system: 'hepatic', organ: 'Pancreas', code: '4548-4', codeSystem: 'LOINC', display: 'Hemoglobin A1c', value: 5.9, unit: '%', refLow: 4, refHigh: 5.6, effective: '2026-04-18', epistemic: 'verified', trend: [5.4, 5.5, 5.6, 5.7, 5.8, 5.8, 5.9] },
+  { id: 'obs-alt', system: 'hepatic', organ: 'Liver', code: '1742-6', codeSystem: 'LOINC', display: 'ALT (liver enzyme)', value: 31, unit: 'U/L', refLow: 7, refHigh: 56, effective: '2026-04-18', epistemic: 'verified', trend: [24, 26, 25, 28, 29, 30, 31] },
+  { id: 'obs-egfr', system: 'urinary', organ: 'Kidneys', code: '33914-3', codeSystem: 'LOINC', display: 'eGFR (kidney function)', value: 92, unit: 'mL/min', refLow: 90, refHigh: 120, effective: '2026-04-18', epistemic: 'verified', trend: [99, 98, 97, 95, 94, 93, 92] },
 ];
 
 export const CONDITIONS: Condition[] = [
-  { id: 'cond-htn', system: 'cardiovascular', code: '38341003', codeSystem: 'SNOMED', display: 'Essential hypertension', onset: '2024-11-10', clinicalStatus: 'active', epistemic: 'attested' },
-  { id: 'cond-pre', system: 'hepatic', code: '714628002', codeSystem: 'SNOMED', display: 'Prediabetes', onset: '2026-04-18', clinicalStatus: 'active', epistemic: 'verified' },
+  { id: 'cond-htn', system: 'cardiovascular', organ: 'Heart', code: '38341003', codeSystem: 'SNOMED', display: 'Essential hypertension', onset: '2024-11-10', clinicalStatus: 'active', epistemic: 'attested' },
+  { id: 'cond-pre', system: 'hepatic', organ: 'Pancreas', code: '714628002', codeSystem: 'SNOMED', display: 'Prediabetes', onset: '2026-04-18', clinicalStatus: 'active', epistemic: 'verified' },
 ];
 
 export const ENCOUNTERS: Encounter[] = [

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -7,7 +7,7 @@
 // NOT a medical device. NOT diagnostic. Organises + retrieves + governs sharing of a person's own
 // records. Synthetic data only in this skeleton — no real PHI.
 import http from 'node:http';
-import { SUBJECT, SYSTEMS, OBSERVATIONS, CONDITIONS, ENCOUNTERS, IMAGING, type Grant } from './data.js';
+import { SUBJECT, SYSTEMS, OBSERVATIONS, CONDITIONS, ENCOUNTERS, IMAGING, ORGAN_IRI, OBSERVATION_CLASS, CONDITION_CLASS, HEALTH_NS, HDT_NS, type Grant, type Observation, type Condition } from './data.js';
 
 const PORT = Number(process.env.PORT ?? 8097);
 
@@ -23,12 +23,16 @@ function receipt(kind: string, parts: string[]): { id: string; verifier: 'health
 // In-memory grant ledger (skeleton). Local-first store in production.
 const grants: Grant[] = [];
 
+// enrich a record with its ontology IRIs so it lands in HellGraph as a typed node, not a label string.
+const obsView = (o: Observation) => ({ ...o, classIri: OBSERVATION_CLASS, organIri: ORGAN_IRI[o.organ] ?? null });
+const condView = (c: Condition) => ({ ...c, classIri: CONDITION_CLASS, organIri: ORGAN_IRI[c.organ] ?? null });
+
 function bundle() {
   // group records per system for the anatomical index
   const bySystem = SYSTEMS.map((s) => ({
     ...s,
-    observations: OBSERVATIONS.filter((o) => o.system === s.id),
-    conditions: CONDITIONS.filter((c) => c.system === s.id),
+    observations: OBSERVATIONS.filter((o) => o.system === s.id).map(obsView),
+    conditions: CONDITIONS.filter((c) => c.system === s.id).map(condView),
     encounters: ENCOUNTERS.filter((e) => e.system === s.id),
     imaging: IMAGING.filter((i) => i.system === s.id),
   }));
@@ -38,6 +42,8 @@ function bundle() {
     timeline: [...ENCOUNTERS].sort((a, b) => (a.date < b.date ? 1 : -1)),
     counts: { observations: OBSERVATIONS.length, conditions: CONDITIONS.length, encounters: ENCOUNTERS.length, imaging: IMAGING.length },
     grants: grants.map((g) => ({ ...g, active: !g.revoked && new Date(g.expires_at) > new Date() })),
+    // the twin speaks the estate's ontology: every fact carries a class IRI from the HDT ontology.
+    ontology: { health: HEALTH_NS, hdt: HDT_NS, subjectClass: `${HDT_NS}HumanDigitalTwin`, note: 'Facts carry health:/hdt: class IRIs so they type into HellGraph + reason in Ontogenesis.' },
     disclaimer: 'Synthetic sample. Not a real person, not medical advice. This tool organises records; it does not diagnose.',
   };
 }

--- a/apps/socioprophet-web/src/data/spinalCorrespondence.ts
+++ b/apps/socioprophet-web/src/data/spinalCorrespondence.ts
@@ -1,0 +1,51 @@
+// The spinal correspondence chart — the chiropractic poster, done with THREE honestly-separated lenses.
+// Same spinal level, three overlays, each carrying its epistemic tier (mirrors ontogenesis
+// Domains/health-anatomy.ttl · https://socioprophet.md/ont/health#):
+//   • modern       = evidence-based segmental/autonomic innervation           → VERIFIED
+//   • chiropractic = the classic "meric" spinal-nerve → organ chart           → TRADITIONAL (attributed, not asserted)
+//   • tcm          = proposed meridian/segmental bridge                        → HYPOTHESIS
+// Non-diagnostic: this correlates and attributes; it never claims a subluxation causes a disease.
+// `organ` (one of the twin's 9) links a correspondence to the person's records; `target` is the
+// descriptive region for structures outside the twin's organ set.
+
+export type Lens = 'modern' | 'chiropractic' | 'tcm';
+export type Tier = 'verified' | 'traditional' | 'hypothesis';
+export const LENS_TIER: Record<Lens, Tier> = { modern: 'verified', chiropractic: 'traditional', tcm: 'hypothesis' };
+export const LENS_LABEL: Record<Lens, string> = { modern: 'Modern neuroanatomy', chiropractic: 'Chiropractic meric', tcm: 'TCM meridian' };
+export const TIER_EPI: Record<Tier, string> = { verified: 'verified', traditional: 'attested', hypothesis: 'hypothesis' };
+
+export interface Corr { lens: Lens; target: string; organ?: string }
+export interface Seg { id: string; region: 'cervical' | 'thoracic' | 'lumbar' | 'sacral'; iri: string; corr: Corr[] }
+
+const H = 'https://socioprophet.md/ont/health#';
+const s = (id: string, region: Seg['region'], corr: Corr[]): Seg => ({ id, region, iri: H + id, corr });
+
+export const SPINE: Seg[] = [
+  s('C1', 'cervical', [{ lens: 'chiropractic', target: 'head, pituitary, inner ear', organ: 'Brain' }]),
+  s('C2', 'cervical', [{ lens: 'chiropractic', target: 'eyes, optic/auditory nerve, sinuses', organ: 'Brain' }]),
+  s('C3', 'cervical', [{ lens: 'modern', target: 'diaphragm (phrenic C3–C5)' }, { lens: 'chiropractic', target: 'cheeks, outer ear, face' }]),
+  s('C4', 'cervical', [{ lens: 'modern', target: 'diaphragm (phrenic C3–C5)' }, { lens: 'chiropractic', target: 'nose, lips, eustachian tube' }]),
+  s('C5', 'cervical', [{ lens: 'modern', target: 'diaphragm (phrenic C3–C5)' }, { lens: 'chiropractic', target: 'vocal cords, pharynx' }]),
+  s('C6', 'cervical', [{ lens: 'chiropractic', target: 'neck muscles, shoulders, tonsils' }]),
+  s('C7', 'cervical', [{ lens: 'chiropractic', target: 'thyroid, shoulder bursae, elbows' }]),
+  s('T1', 'thoracic', [{ lens: 'modern', target: 'heart (cardiac sympathetic)', organ: 'Heart' }, { lens: 'chiropractic', target: 'arms, hands, esophagus, trachea' }]),
+  s('T2', 'thoracic', [{ lens: 'modern', target: 'heart, coronary vessels', organ: 'Heart' }, { lens: 'chiropractic', target: 'heart, coronary arteries', organ: 'Heart' }]),
+  s('T3', 'thoracic', [{ lens: 'modern', target: 'lungs, bronchi', organ: 'Lungs' }, { lens: 'chiropractic', target: 'lungs, bronchi, pleura, chest', organ: 'Lungs' }]),
+  s('T4', 'thoracic', [{ lens: 'modern', target: 'lungs', organ: 'Lungs' }, { lens: 'chiropractic', target: 'gallbladder, common duct' }]),
+  s('T5', 'thoracic', [{ lens: 'modern', target: 'stomach (sympathetic)', organ: 'Stomach' }, { lens: 'chiropractic', target: 'liver, solar plexus, blood', organ: 'Liver' }, { lens: 'tcm', target: 'Stomach / Liver meridian region', organ: 'Stomach' }]),
+  s('T6', 'thoracic', [{ lens: 'modern', target: 'stomach', organ: 'Stomach' }, { lens: 'chiropractic', target: 'stomach', organ: 'Stomach' }]),
+  s('T7', 'thoracic', [{ lens: 'modern', target: 'pancreas, duodenum', organ: 'Pancreas' }, { lens: 'chiropractic', target: 'pancreas, duodenum', organ: 'Pancreas' }]),
+  s('T8', 'thoracic', [{ lens: 'modern', target: 'liver, spleen', organ: 'Liver' }, { lens: 'chiropractic', target: 'spleen' }]),
+  s('T9', 'thoracic', [{ lens: 'modern', target: 'liver, adrenal glands', organ: 'Liver' }, { lens: 'chiropractic', target: 'adrenal glands' }]),
+  s('T10', 'thoracic', [{ lens: 'modern', target: 'kidneys (sympathetic)', organ: 'Kidneys' }, { lens: 'chiropractic', target: 'kidneys', organ: 'Kidneys' }]),
+  s('T11', 'thoracic', [{ lens: 'modern', target: 'kidneys, ureters', organ: 'Kidneys' }, { lens: 'chiropractic', target: 'kidneys, ureters', organ: 'Kidneys' }]),
+  s('T12', 'thoracic', [{ lens: 'modern', target: 'small intestine', organ: 'Intestines' }, { lens: 'chiropractic', target: 'small intestine, lymph', organ: 'Intestines' }]),
+  s('L1', 'lumbar', [{ lens: 'modern', target: 'large intestine', organ: 'Intestines' }, { lens: 'chiropractic', target: 'large intestine, inguinal rings', organ: 'Intestines' }]),
+  s('L2', 'lumbar', [{ lens: 'chiropractic', target: 'appendix, abdomen, upper leg' }]),
+  s('L3', 'lumbar', [{ lens: 'chiropractic', target: 'reproductive organs, bladder, knees', organ: 'Bladder' }, { lens: 'tcm', target: 'Kidney meridian region', organ: 'Kidneys' }]),
+  s('L4', 'lumbar', [{ lens: 'chiropractic', target: 'lower back, sciatic nerve' }]),
+  s('L5', 'lumbar', [{ lens: 'chiropractic', target: 'lower legs, ankles, feet' }]),
+  s('S2', 'sacral', [{ lens: 'modern', target: 'bladder, bowel (parasympathetic S2–S4)', organ: 'Bladder' }]),
+  s('S3', 'sacral', [{ lens: 'modern', target: 'bladder, reproductive (parasympathetic)', organ: 'Bladder' }]),
+  s('S4', 'sacral', [{ lens: 'modern', target: 'bladder, bowel (parasympathetic)', organ: 'Bladder' }, { lens: 'chiropractic', target: 'sacrum, buttocks' }]),
+];

--- a/apps/socioprophet-web/src/pages/HealthTwin.vue
+++ b/apps/socioprophet-web/src/pages/HealthTwin.vue
@@ -12,6 +12,7 @@ import { ref, computed, onMounted, watch, onBeforeUnmount } from 'vue';
 import { loadTwin, grantAccess, revokeAccess, agentRead, type TwinBundle, type SystemBundle, type Observation, type Condition } from '../services/healthTwinApi';
 import { EPISTEMIC_COLORS } from '../services/studioApi';
 import Sparkline from '../components/Sparkline.vue';
+import SpineOverlay from './SpineOverlay.vue';
 import { plateFor, ATLAS_CREDIT } from '../data/anatomyAtlas';
 import './studio/studio-tokens.css';
 
@@ -24,6 +25,7 @@ const twin = ref<TwinBundle | null>(null);
 const loading = ref(false);
 const err = ref('');
 const selected = ref<string>('cardiovascular');
+const view = ref<'systems' | 'spine'>('systems');
 const flash = ref('');
 function say(m: string) { flash.value = m; setTimeout(() => (flash.value = ''), 2800); }
 
@@ -41,6 +43,20 @@ function epi(mode: string): string { return EPISTEMIC_COLORS[mode] || 'var(--epi
 function recordCount(s: SystemBundle): number { return s.observations.length + s.conditions.length + s.encounters.length + s.imaging.length; }
 const sys = computed<SystemBundle | null>(() => twin.value?.systems.find((s) => s.id === selected.value) ?? null);
 function outOfRange(o: Observation): boolean { return (o.refHigh != null && o.value > o.refHigh) || (o.refLow != null && o.value < o.refLow); }
+
+// organs that carry records — the Spine overlay links only those back to the twin.
+const recordOrgans = computed<string[]>(() => {
+  const set = new Set<string>();
+  for (const s of twin.value?.systems ?? []) {
+    for (const o of s.observations) if (o.organ) set.add(o.organ);
+    for (const c of s.conditions) if (c.organ) set.add(c.organ);
+  }
+  return [...set];
+});
+function onSpineOrgan(organ: string) {
+  const owner = twin.value?.systems.find((s) => s.organs.includes(organ));
+  if (owner) { selected.value = owner.id; view.value = 'systems'; }
+}
 
 // Anatomy atlas plate for the selected system: vendored (sovereign) → remote CC-BY → placeholder.
 const plate = computed(() => plateFor(selected.value));
@@ -69,7 +85,7 @@ function obsSheet(o: Observation) {
     title: o.display, eyebrow: `lab · ${o.codeSystem} ${o.code}`, epistemic: o.epistemic,
     summary: `${o.display} measured ${o.value} ${o.unit} on ${o.effective}, ${dir} over ${o.trend?.length ?? 1} results. Reference ${o.refLow ?? '—'}–${o.refHigh ?? '—'} ${o.unit}; this value is ${pos} range. Verified by lab. A record, not a diagnosis.`,
     receipt: `ht-${djb2([o.id, String(o.value), o.effective, pos, dir].join('|'))}`,
-    facts: [{ k: 'Value', v: `${o.value} ${o.unit}` }, { k: 'Reference', v: `${o.refLow ?? '—'}–${o.refHigh ?? '—'} ${o.unit}` }, { k: 'Date', v: o.effective }, { k: 'Code', v: `${o.codeSystem} ${o.code}` }],
+    facts: [{ k: 'Value', v: `${o.value} ${o.unit}` }, { k: 'Reference', v: `${o.refLow ?? '—'}–${o.refHigh ?? '—'} ${o.unit}` }, { k: 'Date', v: o.effective }, { k: 'Code', v: `${o.codeSystem} ${o.code}` }, { k: 'Localized to', v: o.organ ?? '—' }, { k: 'Type', v: 'hdt:Observation' }],
     trend: o.trend,
   };
 }
@@ -78,7 +94,7 @@ function condSheet(c: Condition) {
     title: c.display, eyebrow: `condition · ${c.codeSystem} ${c.code}`, epistemic: c.epistemic,
     summary: `${c.display} (${c.codeSystem} ${c.code}), ${c.clinicalStatus}, onset ${c.onset}. Trust level: ${c.epistemic}. This is a stored record; it is not re-diagnosed here.`,
     receipt: `ht-${djb2([c.id, c.clinicalStatus, c.onset].join('|'))}`,
-    facts: [{ k: 'Status', v: c.clinicalStatus }, { k: 'Onset', v: c.onset }, { k: 'Code', v: `${c.codeSystem} ${c.code}` }, { k: 'Trust', v: c.epistemic }],
+    facts: [{ k: 'Status', v: c.clinicalStatus }, { k: 'Onset', v: c.onset }, { k: 'Code', v: `${c.codeSystem} ${c.code}` }, { k: 'Trust', v: c.epistemic }, { k: 'Localized to', v: c.organ ?? '—' }, { k: 'Type', v: 'health:Condition' }],
   };
 }
 // self-contained drawer: ESC closes (kept local so the health twin doesn't couple to Studio components)
@@ -124,6 +140,10 @@ async function doAgentRead(id: string) {
     <template v-else>
       <header class="ht-top">
         <div class="ht-h"><span class="ht-mark">◈</span><div><h1>Digital Health Self</h1><span class="ht-sub">{{ twin?.subject.label }} · organ-system index</span></div></div>
+        <div class="ht-views">
+          <button class="vbtn" :class="{ on: view === 'systems' }" @click="view = 'systems'">Systems</button>
+          <button class="vbtn" :class="{ on: view === 'spine' }" @click="view = 'spine'">Spine</button>
+        </div>
         <button class="ghost" @click="load" :disabled="loading" aria-label="Reload">↻</button>
         <button class="ghost txt" @click="optOut">Turn off</button>
       </header>
@@ -133,7 +153,7 @@ async function doAgentRead(id: string) {
       <p v-if="err" class="msg err">{{ err }}</p>
       <p v-else-if="loading && !twin" class="msg">Loading your twin…</p>
 
-      <div v-else-if="twin" class="ht-body">
+      <div v-else-if="twin && view === 'systems'" class="ht-body">
         <!-- Anatomical system index -->
         <aside class="ht-index" aria-label="Body systems">
           <div class="idx-h">Body systems</div>
@@ -164,6 +184,7 @@ async function doAgentRead(id: string) {
               <span class="obs-v tnum" :class="{ oor: outOfRange(o) }">{{ o.value }} <i>{{ o.unit }}</i></span>
               <Sparkline v-if="o.trend" :series="o.trend" :w="88" :h="22" :tone="outOfRange(o) ? 'down' : 'accent'" />
               <span class="obs-ref">ref {{ o.refLow ?? '—' }}–{{ o.refHigh ?? '—' }}</span>
+              <span v-if="o.organ" class="organ-chip" title="localized to (health:localizedTo)"><i>◍</i>{{ o.organ }}</span>
               <span class="epi-chip" :style="{ '--epi': epi(o.epistemic), '--epi-wash': 'transparent' }">{{ o.epistemic }}</span>
             </div>
           </div>
@@ -172,6 +193,7 @@ async function doAgentRead(id: string) {
             <h3>Conditions</h3>
             <button v-for="c in sys.conditions" :key="c.id" class="cond epi-stripe" :style="{ '--epi': epi(c.epistemic) }" @click="condSheet(c)">
               <b>{{ c.display }}</b><span class="cond-s">{{ c.clinicalStatus }}</span><span class="cond-o">onset {{ c.onset }}</span>
+              <span v-if="c.organ" class="organ-chip" title="localized to"><i>◍</i>{{ c.organ }}</span>
               <span class="epi-chip" :style="{ '--epi': epi(c.epistemic), '--epi-wash': 'transparent' }">{{ c.epistemic }}</span>
             </button>
           </div>
@@ -214,6 +236,11 @@ async function doAgentRead(id: string) {
             <p v-if="!twin.grants.length" class="sh-empty">No grants — your records are private.</p>
           </div>
         </aside>
+      </div>
+
+      <!-- Spine view: the three-lens spinal correspondence chart -->
+      <div v-else-if="twin && view === 'spine'" class="ht-spine">
+        <SpineOverlay :record-organs="recordOrgans" @organ="onSpineOrgan" />
       </div>
 
       <!-- self-contained record factsheet drawer (attested, non-diagnostic) -->
@@ -266,6 +293,11 @@ async function doAgentRead(id: string) {
 .ht-h { display: flex; align-items: center; gap: var(--sp-3); margin-right: auto; }
 .ht-mark { color: var(--accent); font-size: 1.2rem; } .ht-h h1 { margin: 0; font-size: 1.15rem; } .ht-sub { color: var(--muted); font-size: .78rem; }
 .ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); height: 30px; min-width: 30px; padding: 0 8px; cursor: pointer; } .ghost.txt { font-size: 12px; }
+.ht-views { display: flex; gap: 3px; background: var(--sunken); border-radius: var(--pill); padding: 3px; }
+.vbtn { border: 0; background: transparent; color: var(--muted); border-radius: var(--pill); padding: 4px 14px; font-size: 12.5px; cursor: pointer; }
+.vbtn.on { background: var(--accent-wash); color: var(--accent-ink); }
+.organ-chip { display: inline-flex; align-items: center; gap: 3px; font-size: 10.5px; color: var(--ink-2); background: var(--sunken); border-radius: var(--pill); padding: 1px 8px; } .organ-chip i { font-style: normal; color: var(--accent); font-size: 9px; }
+.ht-spine { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface); padding: var(--sp-4); }
 .disclaimer { font-size: 11.5px; color: var(--warn); background: var(--warn-wash); border-radius: var(--r-2); padding: 5px 10px; margin: 0 0 var(--sp-3); } .disclaimer b { color: var(--ink); }
 .flash { background: var(--ok-wash); color: var(--ok); border-radius: var(--r-2); padding: 6px 11px; font-size: 12.5px; margin: 0 0 10px; }
 .msg { color: var(--muted); } .msg.err { color: var(--fail); }

--- a/apps/socioprophet-web/src/pages/SpineOverlay.vue
+++ b/apps/socioprophet-web/src/pages/SpineOverlay.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+// The spinal correspondence chart with three honestly-separated lenses. Toggle Modern (verified),
+// Chiropractic (traditional), and TCM (hypothesis) — same spinal level, different overlays, each
+// labelled by its epistemic tier. The differentiator: no incumbent holds all three, correctly tiered,
+// on one chart. Non-diagnostic — it correlates and attributes; it never says a level causes a disease.
+import { ref, computed } from 'vue';
+import { SPINE, LENS_TIER, LENS_LABEL, TIER_EPI, type Lens } from '../data/spinalCorrespondence';
+import { EPISTEMIC_COLORS } from '../services/studioApi';
+
+const props = defineProps<{ recordOrgans?: string[] }>();
+const emit = defineEmits<{ (e: 'organ', organ: string): void }>();
+
+const active = ref<Record<Lens, boolean>>({ modern: true, chiropractic: true, tcm: false });
+function toggle(l: Lens) { active.value = { ...active.value, [l]: !active.value[l] }; }
+const lenses = computed<Lens[]>(() => (['modern', 'chiropractic', 'tcm'] as Lens[]).filter((l) => active.value[l]));
+function tierColor(l: Lens): string { return EPISTEMIC_COLORS[TIER_EPI[LENS_TIER[l]]] || 'var(--epi-unknown)'; }
+const REGION_COLOR: Record<string, string> = { cervical: '#5b95f9', thoracic: '#2dd4bf', lumbar: '#e0975a', sacral: '#a082f8' };
+function hasRecords(organ?: string): boolean { return !!organ && !!props.recordOrgans?.includes(organ); }
+function corrFor(seg: (typeof SPINE)[number], l: Lens) { return seg.corr.filter((c) => c.lens === l); }
+</script>
+
+<template>
+  <div class="spine">
+    <div class="sp-bar">
+      <span class="sp-title">Spinal correspondence</span>
+      <div class="sp-lenses">
+        <button v-for="l in (['modern','chiropractic','tcm'] as Lens[])" :key="l" class="lens" :class="{ on: active[l] }"
+                :style="active[l] ? { borderColor: tierColor(l), color: tierColor(l) } : {}" @click="toggle(l)">
+          <i class="ldot" :style="{ background: tierColor(l) }" />{{ LENS_LABEL[l] }}
+          <small>{{ LENS_TIER[l] }}</small>
+        </button>
+      </div>
+    </div>
+    <p class="sp-note">⚕ Correlation + attribution, not diagnosis. Modern = evidence-based innervation; chiropractic + TCM are attributed traditional/ hypothesis overlays — the segment level tracks real anatomy, specific disease-causation claims are not asserted.</p>
+
+    <div class="sp-grid" role="table" aria-label="Spinal correspondence chart">
+      <div class="sp-head" role="row" :style="{ gridTemplateColumns: `72px repeat(${lenses.length}, 1fr)` }">
+        <span role="columnheader">Segment</span>
+        <span v-for="l in lenses" :key="l" role="columnheader" :style="{ color: tierColor(l) }">{{ LENS_LABEL[l] }}</span>
+      </div>
+      <div v-for="seg in SPINE" :key="seg.id" class="sp-row" role="row" :style="{ gridTemplateColumns: `72px repeat(${lenses.length}, 1fr)` }">
+        <span class="seg" :style="{ '--rc': REGION_COLOR[seg.region] }" :title="seg.region">{{ seg.id }}</span>
+        <span v-for="l in lenses" :key="l" class="cell" role="cell">
+          <template v-for="(c, i) in corrFor(seg, l)" :key="i">
+            <button v-if="hasRecords(c.organ)" class="corr link" :style="{ '--tc': tierColor(l) }" @click="emit('organ', c.organ!)" :title="'has records — open'">
+              {{ c.target }} <i class="rec">●</i>
+            </button>
+            <span v-else class="corr" :style="{ '--tc': tierColor(l) }">{{ c.target }}</span>
+          </template>
+          <span v-if="!corrFor(seg, l).length" class="dash">·</span>
+        </span>
+      </div>
+    </div>
+
+    <div class="sp-legend">
+      <span><i class="ldot" :style="{ background: EPISTEMIC_COLORS.verified }" />verified — evidence-based</span>
+      <span><i class="ldot" :style="{ background: EPISTEMIC_COLORS.attested }" />traditional — attributed</span>
+      <span><i class="ldot" :style="{ background: EPISTEMIC_COLORS.hypothesis }" />hypothesis — bridge</span>
+      <span class="lg-rec"><i class="rec">●</i> links to your records</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.spine { font: 14px/1.5 var(--ui); color: var(--ink); }
+.sp-bar { display: flex; align-items: center; gap: var(--sp-3); flex-wrap: wrap; margin-bottom: var(--sp-2); }
+.sp-title { font-size: 1.05rem; font-weight: 600; }
+.sp-lenses { display: flex; gap: 6px; flex-wrap: wrap; margin-left: auto; }
+.lens { display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--muted); border-radius: var(--pill); padding: 4px 11px; font-size: 12px; cursor: pointer; }
+.lens small { text-transform: uppercase; letter-spacing: .04em; font-size: 9px; opacity: .8; }
+.lens .ldot { width: 8px; height: 8px; border-radius: 50%; opacity: .4; } .lens.on .ldot { opacity: 1; }
+.sp-note { font-size: 11.5px; color: var(--muted); background: var(--warn-wash); border-radius: var(--r-2); padding: 6px 10px; margin: 0 0 var(--sp-3); }
+
+.sp-grid { border: 1px solid var(--hairline); border-radius: var(--r-3); overflow: hidden; }
+.sp-head, .sp-row { display: grid; align-items: stretch; gap: 0; }
+.sp-head { background: var(--sunken); border-bottom: 1px solid var(--hairline); }
+.sp-head span { padding: 7px 10px; font-size: 10.5px; text-transform: uppercase; letter-spacing: .05em; color: var(--faint); }
+.sp-row { border-bottom: 1px solid var(--hairline); } .sp-row:last-child { border-bottom: 0; } .sp-row:hover { background: var(--surface-2); }
+.seg { display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 12px; color: var(--ink); border-right: 1px solid var(--hairline); box-shadow: inset 3px 0 0 var(--rc); }
+.cell { padding: 6px 10px; border-right: 1px solid var(--hairline); display: flex; flex-direction: column; gap: 4px; min-width: 0; } .cell:last-child { border-right: 0; }
+.corr { font-size: 12px; color: var(--ink-2); border-left: 2px solid var(--tc); padding-left: 7px; text-align: left; }
+.corr.link { background: none; border-top: 0; border-right: 0; border-bottom: 0; cursor: pointer; color: var(--ink); }
+.corr.link:hover { color: var(--accent); }
+.corr .rec { color: var(--accent); font-size: 8px; font-style: normal; vertical-align: middle; }
+.dash { color: var(--faint); padding-left: 7px; }
+.sp-legend { display: flex; gap: var(--sp-4); flex-wrap: wrap; margin-top: var(--sp-3); font-size: 11px; color: var(--muted); }
+.sp-legend span { display: inline-flex; align-items: center; gap: 5px; } .sp-legend .ldot { width: 8px; height: 8px; border-radius: 50%; }
+.lg-rec .rec { color: var(--accent); font-style: normal; font-size: 9px; }
+</style>

--- a/apps/socioprophet-web/src/services/healthTwinApi.ts
+++ b/apps/socioprophet-web/src/services/healthTwinApi.ts
@@ -8,11 +8,13 @@ import { resolveBase } from '../config/cockpitRuntime';
 const BASE = resolveBase('health', 'VITE_HEALTH_BASE', '/svc/health');
 
 export type EpistemicMode = 'observed' | 'derived' | 'verified' | 'attested' | 'hypothesis';
-export interface Observation { id: string; system: string; code: string; codeSystem: string; display: string; value: number; unit: string; refLow?: number; refHigh?: number; effective: string; trend?: number[]; epistemic: EpistemicMode }
-export interface Condition { id: string; system: string; code: string; codeSystem: string; display: string; onset: string; clinicalStatus: string; epistemic: EpistemicMode }
+// organ = the anatomical structure a record localises to (health:localizedTo); classIri/organIri = the
+// HDT ontology class + organ IRIs the fact carries, so it types into HellGraph + reasons in Ontogenesis.
+export interface Observation { id: string; system: string; organ?: string; classIri?: string; organIri?: string | null; code: string; codeSystem: string; display: string; value: number; unit: string; refLow?: number; refHigh?: number; effective: string; trend?: number[]; epistemic: EpistemicMode }
+export interface Condition { id: string; system: string; organ?: string; classIri?: string; organIri?: string | null; code: string; codeSystem: string; display: string; onset: string; clinicalStatus: string; epistemic: EpistemicMode }
 export interface Encounter { id: string; system: string; type: string; date: string; provider: string; note: string }
 export interface ImagingStudy { id: string; system: string; modality: string; bodySite: string; date: string; description: string; epistemic: EpistemicMode }
-export interface SystemBundle { id: string; label: string; organs: string[]; observations: Observation[]; conditions: Condition[]; encounters: Encounter[]; imaging: ImagingStudy[] }
+export interface SystemBundle { id: string; label: string; organs: string[]; iri?: string; compartment?: string; observations: Observation[]; conditions: Condition[]; encounters: Encounter[]; imaging: ImagingStudy[] }
 export interface Grant { id: string; agent: string; scope: string; granted_at: string; expires_at: string; revoked: boolean; reads: number; receipt: string; active?: boolean }
 export interface TwinBundle {
   subject: { id: string; label: string; note: string };
@@ -20,6 +22,7 @@ export interface TwinBundle {
   timeline: Encounter[];
   counts: { observations: number; conditions: number; encounters: number; imaging: number };
   grants: Grant[];
+  ontology?: { health: string; hdt: string; subjectClass: string; note: string };
   disclaimer: string;
 }
 

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -115,11 +115,8 @@ KNOWN_BROKEN = {
         "New service — first-party embeddings image (apps/embeddings, FastAPI + nomic-embed-text) added to CI "
         "this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
     ),
-    "health-twin:moving-tag": (
-        "New service — the Digital Health Twin engine (apps/health-twin: opt-in local-first FHIR-lite record "
-        "bundle + governed receipted consent grants on :8097, synthetic data only) added to CI this PR. Pin "
-        "tag:latest -> the sha- tag gitops-promote writes after the first CI build; no sha exists until merge."
-    ),
+    # health-twin pinned to a sha- tag by gitops-promote after its first CI build (#932) → removed
+    # from the ratchet (it only shrinks).
     # portfolio-agent pinned to a sha- tag by gitops-promote after its first CI build (#925,
     # sha-a6d8311383) → removed from the ratchet (it only shrinks). Same for academy-board:
     # gitops-promote sha-pinned it after #926's first build (sha-f59cf2c9), so its moving-tag


### PR DESCRIPTION
Steps 1–3 of the plan, together — turns the twin from a records viewer into a **reasoned** twin. Pairs with the HDT ontology (ontogenesis #122).

## #1 · Wire to the ontology IRIs
Every fact now carries real **HDT-ontology class identity** — so it types into HellGraph and reasons in Ontogenesis instead of being a label string. `System → health:OrganSystem` (`socioprophet.md/ont/health#`), `Observation → hdt:Observation`, `Condition → health:Condition`, `organ → health:Organ`; subject → `hdt:HumanDigitalTwin`. The server bundle enriches each record with `classIri` + `organIri` + an `ontology` block. Verified live.

## #2 · Paint records onto anatomy
Each lab/condition **localises to its organ** (`health:localizedTo`): an organ chip on every record + a Localized-to / Type row in the factsheet. Your LDL sits on the heart, A1c on the pancreas.

## #3 · Spinal three-lens overlay
A new **Systems | Spine** view. `SpineOverlay.vue` + `spinalCorrespondence.ts` render the classic **chiropractic meric chart** alongside the **evidence-based modern innervation** and **TCM bridge** notes — each toggleable, coloured by **epistemic tier** (verified / traditional / hypothesis). Same spinal level, three honestly-separated lenses; correspondences to record-bearing organs link back to the twin. **Non-diagnostic** — correlates + attributes, never claims a level causes disease.

## Verify
`vue-tsc` + `build` + `preflight` clean; service verified to emit the `health:`/`hdt:` IRIs (system/organ/observation + subject class). Cleared the health-twin ratchet entry (gitops sha-pinned post-#932).