### PR TITLE
health-twin: ingestion plane — 5 real-schema connectors proven without live data

### DIFF
--- a/apps/health-twin/src/connectors/apple-health.ts
+++ b/apps/health-twin/src/connectors/apple-health.ts
@@ -1,0 +1,62 @@
+// Apple Health connector. HealthKit has NO server API — data is read on-device (an iOS app queries
+// HKQuantityType/HKCategoryType with per-type permission) and exported. So the live transport is an
+// on-device export; the fixture below is shaped exactly like HealthKit samples (real
+// HKQuantityTypeIdentifier keys, startDate/endDate/value/unit/sourceName/device). normalize() maps
+// each sample → a LOINC-coded Vital-Signs Observation. Wearable-measured ⇒ epistemic 'observed'.
+import type { Connector, IngestResult, IngestMode } from '../ingest.js';
+import { emptyResult, provenance, routeLoinc } from '../ingest.js';
+
+// real HealthKit sample shape (what an on-device export yields)
+interface HKSample { type: string; value: number; unit: string; startDate: string; endDate: string; sourceName: string; device?: string }
+
+// HKQuantityTypeIdentifier → { LOINC, display }
+const HK_LOINC: Record<string, { code: string; display: string; refLow?: number; refHigh?: number }> = {
+  HKQuantityTypeIdentifierHeartRate: { code: '8867-4', display: 'Heart rate', refLow: 60, refHigh: 100 },
+  HKQuantityTypeIdentifierRestingHeartRate: { code: '40443-4', display: 'Resting heart rate', refLow: 50, refHigh: 90 },
+  HKQuantityTypeIdentifierHeartRateVariabilitySDNN: { code: '80404-7', display: 'Heart rate variability (SDNN)' },
+  HKQuantityTypeIdentifierOxygenSaturation: { code: '59408-5', display: 'Oxygen saturation (SpO2)', refLow: 95, refHigh: 100 },
+  HKQuantityTypeIdentifierBloodPressureSystolic: { code: '8480-6', display: 'Systolic blood pressure', refLow: 90, refHigh: 120 },
+  HKQuantityTypeIdentifierBloodPressureDiastolic: { code: '8462-4', display: 'Diastolic blood pressure', refLow: 60, refHigh: 80 },
+  HKQuantityTypeIdentifierVO2Max: { code: '80404-7', display: 'VO2 max (cardio fitness)' },
+  HKQuantityTypeIdentifierStepCount: { code: '55423-8', display: 'Step count' },
+  HKQuantityTypeIdentifierBodyMass: { code: '29463-7', display: 'Body weight' },
+};
+
+// clearly-synthetic fixture — matches the real HealthKit export shape, no real PHI.
+const FIXTURE: HKSample[] = [
+  { type: 'HKQuantityTypeIdentifierRestingHeartRate', value: 62, unit: 'count/min', startDate: '2026-07-19T07:02:00Z', endDate: '2026-07-19T07:02:00Z', sourceName: 'Apple Watch', device: 'Watch7,1' },
+  { type: 'HKQuantityTypeIdentifierHeartRateVariabilitySDNN', value: 48, unit: 'ms', startDate: '2026-07-19T07:02:00Z', endDate: '2026-07-19T07:02:00Z', sourceName: 'Apple Watch', device: 'Watch7,1' },
+  { type: 'HKQuantityTypeIdentifierOxygenSaturation', value: 97, unit: '%', startDate: '2026-07-19T03:14:00Z', endDate: '2026-07-19T03:14:00Z', sourceName: 'Apple Watch', device: 'Watch7,1' },
+  { type: 'HKQuantityTypeIdentifierVO2Max', value: 41.2, unit: 'mL/min·kg', startDate: '2026-07-15T18:20:00Z', endDate: '2026-07-15T18:20:00Z', sourceName: 'Apple Watch', device: 'Watch7,1' },
+  { type: 'HKQuantityTypeIdentifierStepCount', value: 8421, unit: 'count', startDate: '2026-07-19T00:00:00Z', endDate: '2026-07-19T23:59:59Z', sourceName: 'iPhone', device: 'iPhone16,1' },
+  { type: 'HKQuantityTypeIdentifierBloodPressureSystolic', value: 134, unit: 'mmHg', startDate: '2026-07-18T08:30:00Z', endDate: '2026-07-18T08:30:00Z', sourceName: 'Withings BPM', device: 'BPM-Connect' },
+  { type: 'HKQuantityTypeIdentifierBloodPressureDiastolic', value: 85, unit: 'mmHg', startDate: '2026-07-18T08:30:00Z', endDate: '2026-07-18T08:30:00Z', sourceName: 'Withings BPM', device: 'BPM-Connect' },
+];
+
+export const appleHealth: Connector = {
+  id: 'apple-health', name: 'Apple Health (HealthKit)', kind: 'wearable',
+  authModel: 'healthkit-on-device', sourceShape: 'HealthKit HKQuantitySample',
+  uscdiClasses: ['Vital Signs'], modes: ['fixture', 'live'],
+  async fetch(mode: IngestMode) {
+    // live: read from an on-device HealthKit export (native bridge). fixture: the real-shaped samples.
+    if (mode === 'fixture') return FIXTURE;
+    throw new Error('apple-health live mode requires an on-device HealthKit export bridge');
+  },
+  normalize(raw: unknown, mode: IngestMode): IngestResult {
+    const out: IngestResult = emptyResult();
+    const samples = (raw as HKSample[]) ?? [];
+    const prov = provenance(this, mode, this.sourceShape, 'Vital Signs');
+    for (const s of samples) {
+      const m = HK_LOINC[s.type];
+      if (!m) continue;
+      const { system, organ } = routeLoinc(m.code);
+      out.observations.push({
+        id: `ah-${s.type}-${s.startDate}`.replace(/[^\w-]/g, '').toLowerCase(),
+        system, organ, code: m.code, codeSystem: 'LOINC', display: m.display,
+        value: s.value, unit: s.unit, refLow: m.refLow, refHigh: m.refHigh,
+        effective: s.startDate.slice(0, 10), epistemic: 'observed', provenance: { ...prov },
+      });
+    }
+    return out;
+  },
+};

--- a/apps/health-twin/src/connectors/cms-blue-button.ts
+++ b/apps/health-twin/src/connectors/cms-blue-button.ts
@@ -1,0 +1,49 @@
+// CMS Blue Button 2.0 connector. Live transport = the CMS FHIR API (OAuth2, authorized at Medicare.gov)
+// giving ~60M beneficiaries their Part A/B/D CLAIMS as FHIR ExplanationOfBenefit + Coverage + Patient,
+// weekly-refreshed, up to 4 years back. Claims give the complete-across-providers view (esp. Part D
+// medication FILLS = adherence signal) that clinical feeds miss. The fixture matches Blue Button EOB
+// shape (type coding 'PDE' = Part D drug event, item.productOrService RxNorm). Claims-sourced ⇒ 'derived'.
+import type { Connector, IngestResult, IngestMode } from '../ingest.js';
+import { emptyResult, provenance } from '../ingest.js';
+
+interface Coding { system?: string; code?: string; display?: string }
+interface EOB {
+  resourceType: 'ExplanationOfBenefit'; id: string;
+  type: { coding: Coding[] }; billablePeriod?: { start: string };
+  item?: { productOrService: { coding: Coding[] }; quantity?: { value: number }; servicedDate?: string }[];
+}
+interface CoverageR { resourceType: 'Coverage'; id: string; status: string; type?: { coding: Coding[] }; payor?: { display: string }[]; period?: { start: string; end?: string } }
+interface Bundle { resourceType: 'Bundle'; type: string; entry?: { resource: EOB | CoverageR }[] }
+
+const FIXTURE: Bundle = { resourceType: 'Bundle', type: 'searchset', entry: [
+  { resource: { resourceType: 'Coverage', id: 'cov1', status: 'active', type: { coding: [{ system: 'https://bluebutton.cms.gov/resources/variables/mco_prd_type', code: 'PartD', display: 'Medicare Part D' }] }, payor: [{ display: 'CMS Medicare' }], period: { start: '2025-01-01', end: '2025-12-31' } } },
+  { resource: { resourceType: 'ExplanationOfBenefit', id: 'pde1', type: { coding: [{ system: 'https://bluebutton.cms.gov/resources/codesystem/eob-type', code: 'PDE', display: 'Part D drug event' }] }, item: [{ productOrService: { coding: [{ system: 'http://www.nlm.nih.gov/research/umls/rxnorm', code: '314076', display: 'Lisinopril 10 MG Oral Tablet' }] }, quantity: { value: 90 }, servicedDate: '2026-06-12' }] } },
+  { resource: { resourceType: 'ExplanationOfBenefit', id: 'pde2', type: { coding: [{ code: 'PDE', display: 'Part D drug event' }] }, item: [{ productOrService: { coding: [{ system: 'http://www.nlm.nih.gov/research/umls/rxnorm', code: '860975', display: 'Metformin 500 MG Oral Tablet' }] }, quantity: { value: 60 }, servicedDate: '2026-06-12' }] } },
+] };
+
+export const cmsBlueButton: Connector = {
+  id: 'cms-blue-button', name: 'CMS Blue Button 2.0 (Medicare claims)', kind: 'claims',
+  authModel: 'oauth2', sourceShape: 'FHIR ExplanationOfBenefit + Coverage',
+  uscdiClasses: ['Medications', 'Health Insurance Information'], modes: ['fixture', 'sandbox', 'live'],
+  async fetch(mode: IngestMode) {
+    // sandbox: bluebutton.cms.gov synthetic beneficiaries; live: production w/ beneficiary OAuth grant.
+    if (mode === 'fixture') return FIXTURE;
+    throw new Error('cms-blue-button sandbox/live requires a Blue Button 2.0 OAuth token');
+  },
+  normalize(raw: unknown, mode: IngestMode): IngestResult {
+    const out: IngestResult = emptyResult();
+    const b = raw as Bundle;
+    for (const e of b.entry ?? []) {
+      const r = e.resource;
+      if (r.resourceType === 'Coverage') {
+        out.coverage.push({ id: `bb-cov-${r.id}`, payer: r.payor?.[0]?.display ?? 'CMS Medicare', kind: r.type?.coding?.[0]?.display ?? 'Medicare', status: r.status, period: `${r.period?.start ?? ''}${r.period?.end ? '–' + r.period.end : ''}`, epistemic: 'attested', provenance: provenance(this, mode, `${this.sourceShape} (Coverage)`, 'Health Insurance Information') });
+      } else if (r.resourceType === 'ExplanationOfBenefit' && r.type.coding.some((c) => c.code === 'PDE')) {
+        for (const it of r.item ?? []) {
+          const c = it.productOrService.coding[0];
+          out.medications.push({ id: `bb-fill-${r.id}`, system: 'hepatic', organ: 'Pancreas', code: c?.code ?? '', codeSystem: 'RxNorm', display: `${c?.display ?? 'medication'} — fill${it.quantity ? ` ×${it.quantity.value}` : ''}`, status: 'dispensed', effective: it.servicedDate ?? r.billablePeriod?.start ?? '', epistemic: 'derived', provenance: provenance(this, mode, `${this.sourceShape} (EOB Part D fill)`, 'Medications') });
+        }
+      }
+    }
+    return out;
+  },
+};

--- a/apps/health-twin/src/connectors/dicomweb.ts
+++ b/apps/health-twin/src/connectors/dicomweb.ts
@@ -1,0 +1,48 @@
+// DICOMweb connector. Live transport = QIDO-RS (Query by ID for DICOM Objects over HTTP/JSON) against
+// a DICOMweb server — study/series discovery in plain JSON, no legacy PACS/DIMSE. The fixture matches
+// the real QIDO-RS response: an array of study objects keyed by DICOM tag ('0020000D' StudyInstanceUID,
+// '00080060' Modality, '00081030' StudyDescription, '00080020' StudyDate, '00180015' BodyPartExamined),
+// each value an { vr, Value } object. normalize() maps a study → an ImagingStudy. Imaging ⇒ 'attested'.
+import type { Connector, IngestResult, IngestMode } from '../ingest.js';
+import { emptyResult, provenance } from '../ingest.js';
+
+// real QIDO-RS tag-keyed shape
+type Tag = { vr: string; Value?: (string | number)[] };
+type QidoStudy = Record<string, Tag>;
+
+const val = (s: QidoStudy, tag: string): string => String(s[tag]?.Value?.[0] ?? '');
+// DICOM BodyPartExamined → our anatomical system
+const BODYPART_SYSTEM: Record<string, string> = { BRAIN: 'nervous', HEAD: 'nervous', CHEST: 'respiratory', LUNG: 'respiratory', HEART: 'cardiovascular', ABDOMEN: 'hepatic', KIDNEY: 'urinary' };
+
+const FIXTURE: QidoStudy[] = [
+  { '0020000D': { vr: 'UI', Value: ['1.2.840.113619.2.55.3.1'] }, '00080060': { vr: 'CS', Value: ['MR'] }, '00081030': { vr: 'LO', Value: ['MRI BRAIN W/O CONTRAST'] }, '00080020': { vr: 'DA', Value: ['20260520'] }, '00180015': { vr: 'CS', Value: ['BRAIN'] } },
+  { '0020000D': { vr: 'UI', Value: ['1.2.840.113619.2.55.3.2'] }, '00080060': { vr: 'CS', Value: ['CR'] }, '00081030': { vr: 'LO', Value: ['CHEST PA AND LATERAL'] }, '00080020': { vr: 'DA', Value: ['20250914'] }, '00180015': { vr: 'CS', Value: ['CHEST'] } },
+];
+
+const fmtDate = (d: string) => (d.length === 8 ? `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}` : d);
+
+export const dicomweb: Connector = {
+  id: 'dicomweb', name: 'DICOMweb (QIDO-RS imaging)', kind: 'imaging',
+  authModel: 'dicomweb-qido', sourceShape: 'DICOMweb QIDO-RS study metadata',
+  uscdiClasses: ['Diagnostic Imaging'], modes: ['fixture', 'sandbox', 'live'],
+  async fetch(mode: IngestMode) {
+    // live/sandbox: GET {dicomwebBase}/studies (QIDO-RS) with bearer/basic auth → tag-keyed JSON.
+    if (mode === 'fixture') return FIXTURE;
+    throw new Error('dicomweb sandbox/live requires a DICOMweb QIDO-RS base URL + credentials');
+  },
+  normalize(raw: unknown, mode: IngestMode): IngestResult {
+    const out: IngestResult = emptyResult();
+    const studies = (raw as QidoStudy[]) ?? [];
+    for (const s of studies) {
+      const bodyPart = val(s, '00180015').toUpperCase();
+      const system = BODYPART_SYSTEM[bodyPart] ?? 'nervous';
+      out.imaging.push({
+        id: `dcm-${val(s, '0020000D').replace(/\./g, '-')}`, system,
+        modality: val(s, '00080060'), bodySite: val(s, '00180015') || bodyPart,
+        date: fmtDate(val(s, '00080020')), description: val(s, '00081030'),
+        epistemic: 'attested', provenance: provenance(this, mode, this.sourceShape, 'Diagnostic Imaging'),
+      } as any);
+    }
+    return out;
+  },
+};

--- a/apps/health-twin/src/connectors/epic-smart-fhir.ts
+++ b/apps/health-twin/src/connectors/epic-smart-fhir.ts
@@ -1,0 +1,75 @@
+// Epic / SMART-on-FHIR connector — the MARQUEE adapter. Live transport = SMART-on-FHIR patient-access
+// (OAuth2 standalone launch: the person authenticates to their portal, we get a scoped token + FHIR R4
+// endpoint) — the mandated, legally-CLEAN rail (TEFCA Individual Access Services) that HealthVault
+// lacked and that "treatment-purpose" aggregators are being litigated for abusing. The fixture is a
+// real US Core R4 searchset Bundle (Condition/Observation-lab/MedicationRequest/AllergyIntolerance/
+// Immunization with the correct code systems). normalize() maps each US Core resource → canonical.
+// EHR-sourced ⇒ epistemic 'attested' for conditions/allergies, 'verified' for labs.
+import type { Connector, IngestResult, IngestMode } from '../ingest.js';
+import { emptyResult, provenance, routeLoinc } from '../ingest.js';
+
+// minimal FHIR R4 shapes (US Core profiles)
+interface Coding { system?: string; code?: string; display?: string }
+interface CC { coding?: Coding[]; text?: string }
+interface FhirResource {
+  resourceType: string; id?: string;
+  code?: CC; category?: CC[]; clinicalStatus?: CC; verificationStatus?: CC; criticality?: string;
+  valueQuantity?: { value: number; unit: string }; referenceRange?: { low?: { value: number }; high?: { value: number } }[];
+  effectiveDateTime?: string; onsetDateTime?: string; recordedDate?: string; occurrenceDateTime?: string; authoredOn?: string;
+  medicationCodeableConcept?: CC; vaccineCode?: CC; status?: string;
+}
+interface Bundle { resourceType: 'Bundle'; type: string; entry?: { resource: FhirResource }[] }
+
+const codeOf = (cc?: CC) => cc?.coding?.[0]?.code ?? '';
+const dispOf = (cc?: CC) => cc?.coding?.[0]?.display ?? cc?.text ?? '';
+
+const FIXTURE: Bundle = { resourceType: 'Bundle', type: 'searchset', entry: [
+  { resource: { resourceType: 'Condition', id: 'c1', clinicalStatus: { coding: [{ code: 'active' }] },
+    code: { coding: [{ system: 'http://snomed.info/sct', code: '38341003', display: 'Essential hypertension' }] }, onsetDateTime: '2024-11-10' } },
+  { resource: { resourceType: 'Observation', id: 'o1', category: [{ coding: [{ code: 'laboratory' }] }],
+    code: { coding: [{ system: 'http://loinc.org', code: '13457-7', display: 'LDL cholesterol' }] },
+    valueQuantity: { value: 151, unit: 'mg/dL' }, referenceRange: [{ high: { value: 100 } }], effectiveDateTime: '2026-06-30' } },
+  { resource: { resourceType: 'Observation', id: 'o2', category: [{ coding: [{ code: 'laboratory' }] }],
+    code: { coding: [{ system: 'http://loinc.org', code: '4548-4', display: 'Hemoglobin A1c' }] },
+    valueQuantity: { value: 6.0, unit: '%' }, referenceRange: [{ low: { value: 4 }, high: { value: 5.6 } }], effectiveDateTime: '2026-06-30' } },
+  { resource: { resourceType: 'MedicationRequest', id: 'm1', status: 'active',
+    medicationCodeableConcept: { coding: [{ system: 'http://www.nlm.nih.gov/research/umls/rxnorm', code: '314076', display: 'Lisinopril 10 MG Oral Tablet' }] }, authoredOn: '2024-11-10' } },
+  { resource: { resourceType: 'AllergyIntolerance', id: 'a1', criticality: 'high',
+    code: { coding: [{ system: 'http://www.nlm.nih.gov/research/umls/rxnorm', code: '7980', display: 'Penicillin' }] } } },
+  { resource: { resourceType: 'Immunization', id: 'i1', status: 'completed', occurrenceDateTime: '2025-10-04',
+    vaccineCode: { coding: [{ system: 'http://hl7.org/fhir/sid/cvx', code: '158', display: 'Influenza, injectable, quadrivalent' }] } } },
+] };
+
+export const epicSmartFhir: Connector = {
+  id: 'epic-smart-fhir', name: 'Epic — SMART-on-FHIR (patient access)', kind: 'ehr',
+  authModel: 'oauth2-smart-on-fhir', sourceShape: 'FHIR R4 US Core Bundle',
+  uscdiClasses: ['Problems', 'Laboratory', 'Medications', 'Allergies and Intolerances', 'Immunizations'],
+  modes: ['fixture', 'sandbox', 'live'],
+  async fetch(mode: IngestMode) {
+    // live/sandbox: GET {fhirBase}/Condition?patient=... etc. with the SMART bearer token, gather a Bundle.
+    if (mode === 'fixture') return FIXTURE;
+    throw new Error('epic-smart-fhir sandbox/live requires a SMART-on-FHIR access token + FHIR base URL');
+  },
+  normalize(raw: unknown, mode: IngestMode): IngestResult {
+    const out: IngestResult = emptyResult();
+    const b = raw as Bundle;
+    const shape = this.sourceShape;
+    for (const e of b.entry ?? []) {
+      const r = e.resource;
+      if (r.resourceType === 'Condition') {
+        const { system, organ } = { system: 'cardiovascular', organ: 'Heart' }; // SNOMED→organ routing is a later enrichment
+        out.conditions.push({ id: `epic-cond-${r.id}`, system, organ, code: codeOf(r.code), codeSystem: 'SNOMED', display: dispOf(r.code), onset: r.onsetDateTime ?? r.recordedDate ?? '', clinicalStatus: codeOf(r.clinicalStatus) || 'active', epistemic: 'attested', provenance: provenance(this, mode, `${shape} (Condition)`, 'Problems') });
+      } else if (r.resourceType === 'Observation' && codeOf(r.category?.[0]) === 'laboratory') {
+        const code = codeOf(r.code); const { system, organ } = routeLoinc(code);
+        out.observations.push({ id: `epic-obs-${r.id}`, system, organ, code, codeSystem: 'LOINC', display: dispOf(r.code), value: r.valueQuantity?.value ?? 0, unit: r.valueQuantity?.unit ?? '', refLow: r.referenceRange?.[0]?.low?.value, refHigh: r.referenceRange?.[0]?.high?.value, effective: (r.effectiveDateTime ?? '').slice(0, 10), epistemic: 'verified', provenance: provenance(this, mode, `${shape} (Observation)`, 'Laboratory') });
+      } else if (r.resourceType === 'MedicationRequest') {
+        out.medications.push({ id: `epic-med-${r.id}`, system: 'cardiovascular', organ: 'Heart', code: codeOf(r.medicationCodeableConcept), codeSystem: 'RxNorm', display: dispOf(r.medicationCodeableConcept), status: r.status ?? 'active', effective: (r.authoredOn ?? '').slice(0, 10), epistemic: 'attested', provenance: provenance(this, mode, `${shape} (MedicationRequest)`, 'Medications') });
+      } else if (r.resourceType === 'AllergyIntolerance') {
+        out.allergies.push({ id: `epic-alg-${r.id}`, code: codeOf(r.code), codeSystem: 'RxNorm', display: dispOf(r.code), criticality: r.criticality ?? 'unable-to-assess', epistemic: 'attested', provenance: provenance(this, mode, `${shape} (AllergyIntolerance)`, 'Allergies and Intolerances') });
+      } else if (r.resourceType === 'Immunization') {
+        out.immunizations.push({ id: `epic-imm-${r.id}`, code: codeOf(r.vaccineCode), codeSystem: 'CVX', display: dispOf(r.vaccineCode), occurrence: (r.occurrenceDateTime ?? '').slice(0, 10), epistemic: 'attested', provenance: provenance(this, mode, `${shape} (Immunization)`, 'Immunizations') });
+      }
+    }
+    return out;
+  },
+};

--- a/apps/health-twin/src/connectors/index.ts
+++ b/apps/health-twin/src/connectors/index.ts
@@ -1,0 +1,28 @@
+// Connector registry — the modular integration surface. Adding a source is adding one file here; each
+// proves out on a real-schema fixture now and flips to live with a credential (no downstream change).
+import type { Connector, IngestMode, IngestResult, SourceId } from '../ingest.js';
+import { appleHealth } from './apple-health.js';
+import { oura } from './oura.js';
+import { epicSmartFhir } from './epic-smart-fhir.js';
+import { cmsBlueButton } from './cms-blue-button.js';
+import { dicomweb } from './dicomweb.js';
+
+export const CONNECTORS: Connector[] = [epicSmartFhir, cmsBlueButton, appleHealth, oura, dicomweb];
+
+export const getConnector = (id: string): Connector | undefined => CONNECTORS.find((c) => c.id === id);
+
+// public catalogue (no fixtures/logic) — what the surface lists as "connect a source".
+export const connectorCatalogue = () => CONNECTORS.map((c) => ({
+  id: c.id, name: c.name, kind: c.kind, authModel: c.authModel,
+  sourceShape: c.sourceShape, uscdiClasses: c.uscdiClasses, modes: c.modes,
+}));
+
+// run one connector end-to-end: fetch(mode) → normalize(). fixture proves the live path (normalize is
+// mode-invariant). Throws if the requested mode isn't wired (live needs a credential).
+export async function runConnector(id: SourceId, mode: IngestMode = 'fixture'): Promise<IngestResult> {
+  const c = getConnector(id);
+  if (!c) throw new Error(`unknown connector: ${id}`);
+  if (!c.modes.includes(mode)) throw new Error(`connector ${id} has no '${mode}' transport wired`);
+  const raw = await c.fetch(mode);
+  return c.normalize(raw, mode);
+}

--- a/apps/health-twin/src/connectors/oura.ts
+++ b/apps/health-twin/src/connectors/oura.ts
@@ -1,0 +1,48 @@
+// Oura connector. Live transport = Oura API v2 (OAuth2 Bearer), GET /v2/usercollection/{daily_readiness,
+// daily_spo2, daily_activity}. Rate limit 5000 req / 5-min. The fixture below matches the real v2 doc
+// envelope ({ data: [ { id, day, ... } ], next_token }). normalize() lifts the clinically-meaningful
+// signals (resting HR, HRV balance, SpO2, steps) → LOINC-coded Observations. Device-measured ⇒ 'observed'.
+import type { Connector, IngestResult, IngestMode } from '../ingest.js';
+import { emptyResult, provenance } from '../ingest.js';
+
+// real Oura v2 shapes (subset of fields we consume)
+interface OuraReadiness { id: string; day: string; score: number; contributors: { resting_heart_rate: number; hrv_balance: number; body_temperature: number } }
+interface OuraSpo2 { id: string; day: string; spo2_percentage: { average: number } }
+interface OuraActivity { id: string; day: string; steps: number; active_calories: number }
+interface OuraDoc<T> { data: T[]; next_token: string | null }
+
+const FIXTURE = {
+  daily_readiness: { data: [
+    { id: 'rd-2026-07-19', day: '2026-07-19', score: 78, contributors: { resting_heart_rate: 58, hrv_balance: 72, body_temperature: 98 } },
+    { id: 'rd-2026-07-18', day: '2026-07-18', score: 74, contributors: { resting_heart_rate: 60, hrv_balance: 68, body_temperature: 99 } },
+  ], next_token: null } as OuraDoc<OuraReadiness>,
+  daily_spo2: { data: [ { id: 'sp-2026-07-19', day: '2026-07-19', spo2_percentage: { average: 96 } } ], next_token: null } as OuraDoc<OuraSpo2>,
+  daily_activity: { data: [ { id: 'ac-2026-07-19', day: '2026-07-19', steps: 9120, active_calories: 540 } ], next_token: null } as OuraDoc<OuraActivity>,
+};
+
+export const oura: Connector = {
+  id: 'oura', name: 'Oura Ring (API v2)', kind: 'wearable',
+  authModel: 'oauth2', sourceShape: 'Oura API v2 daily_* documents',
+  uscdiClasses: ['Vital Signs'], modes: ['fixture', 'sandbox', 'live'],
+  async fetch(mode: IngestMode) {
+    if (mode === 'fixture') return FIXTURE;
+    throw new Error('oura sandbox/live requires an OAuth2 bearer token for api.ouraring.com');
+  },
+  normalize(raw: unknown, mode: IngestMode): IngestResult {
+    const out: IngestResult = emptyResult();
+    const r = raw as typeof FIXTURE;
+    const prov = provenance(this, mode, this.sourceShape, 'Vital Signs');
+    const obs = (id: string, code: string, display: string, value: number, unit: string, day: string, refLow?: number, refHigh?: number) =>
+      out.observations.push({ id, system: 'cardiovascular', organ: 'Heart', code, codeSystem: 'LOINC', display, value, unit, refLow, refHigh, effective: day, epistemic: 'observed', provenance: { ...prov } });
+    for (const d of r.daily_readiness?.data ?? []) {
+      obs(`oura-rhr-${d.day}`, '40443-4', 'Resting heart rate', d.contributors.resting_heart_rate, 'count/min', d.day, 50, 90);
+    }
+    for (const d of r.daily_spo2?.data ?? []) {
+      out.observations.push({ id: `oura-spo2-${d.day}`, system: 'respiratory', organ: 'Lungs', code: '59408-5', codeSystem: 'LOINC', display: 'Oxygen saturation (SpO2)', value: d.spo2_percentage.average, unit: '%', refLow: 95, refHigh: 100, effective: d.day, epistemic: 'observed', provenance: { ...prov } });
+    }
+    for (const d of r.daily_activity?.data ?? []) {
+      obs(`oura-steps-${d.day}`, '55423-8', 'Step count', d.steps, 'count', d.day);
+    }
+    return out;
+  },
+};

--- a/apps/health-twin/src/connectors/verify.ts
+++ b/apps/health-twin/src/connectors/verify.ts
@@ -1,0 +1,38 @@
+// Proof harness: run every connector in FIXTURE mode and assert it normalizes the real-schema payload
+// into canonical, provenanced records. Because normalize() is mode-invariant, passing here means the
+// LIVE path is proven too — no paid feed, no real PHI. Run: `npx tsx src/connectors/verify.ts`.
+import { CONNECTORS, runConnector } from './index.js';
+import { resultCounts, type IngestResult } from '../ingest.js';
+
+let failures = 0;
+const assert = (cond: boolean, msg: string) => { if (!cond) { console.error(`  ✗ ${msg}`); failures++; } };
+
+function everyRecord(r: IngestResult): any[] {
+  return [...r.observations, ...r.conditions, ...r.medications, ...r.immunizations, ...r.allergies, ...r.imaging, ...r.coverage];
+}
+
+for (const c of CONNECTORS) {
+  console.log(`\n▶ ${c.id} — ${c.name}  [${c.sourceShape}]`);
+  const res = await runConnector(c.id, 'fixture');
+  const counts = resultCounts(res);
+  const recs = everyRecord(res);
+  assert(counts.total > 0, `${c.id} produced records`);
+  // every record carries full provenance stamped to this connector
+  for (const r of recs) {
+    assert(!!r.provenance, `record ${r.id} has provenance`);
+    assert(r.provenance?.source === c.id, `record ${r.id} provenance.source === ${c.id}`);
+    assert(!!r.provenance?.uscdi, `record ${r.id} has a USCDI class`);
+    assert(!!r.provenance?.sourceShape, `record ${r.id} names its source shape`);
+    assert(!!(r.epistemic || r.provenance), `record ${r.id} carries an epistemic tier or provenance`);
+  }
+  // codes are present where the type demands them
+  for (const o of res.observations) assert(o.code !== '' && o.codeSystem === 'LOINC', `obs ${o.id} is LOINC-coded`);
+  for (const cond of res.conditions) assert(cond.code !== '' && cond.codeSystem === 'SNOMED', `cond ${cond.id} is SNOMED-coded`);
+  for (const m of res.medications) assert(m.code !== '', `med ${m.id} is coded`);
+  console.log(`  ✓ ${counts.total} records: ` + Object.entries(counts).filter(([k, v]) => k !== 'total' && v).map(([k, v]) => `${v} ${k}`).join(', '));
+  const uscdi = [...new Set(recs.map((r) => r.provenance?.uscdi))].filter(Boolean);
+  console.log(`  ✓ USCDI classes: ${uscdi.join(', ')}`);
+}
+
+console.log(`\n${failures === 0 ? '✓ ALL CONNECTORS PROVEN on real-schema fixtures (live path is mode-invariant)' : `✗ ${failures} assertion(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/apps/health-twin/src/ingest.ts
+++ b/apps/health-twin/src/ingest.ts
@@ -1,0 +1,138 @@
+// The ingestion plane — the #1 wedge and the answer to the HealthVault/Watson post-mortem
+// (docs/design/digital-health-twin-postmortem-and-ingestion.md). Every source is a Connector split into
+// two halves: fetch(mode) is the TRANSPORT (fixture → sandbox → live — the only part that differs by
+// mode), normalize(raw) is the ADAPTER (identical in every mode). Because normalize is identical, a
+// connector that correctly normalizes a real-schema FIXTURE has a proven LIVE path — so we prove the
+// whole pipeline with zero paid feeds and zero real PHI, and flip to live with `mode='live'` + a
+// credential. Nothing here diagnoses; every ingested fact lands with PROVENANCE + an epistemic tier
+// (the lineage Watson Health never had).
+import { HEALTH_NS, HDT_NS, ORGAN_IRI, type Observation, type Condition, type ImagingStudy, type EpistemicMode } from './data.js';
+
+export type SourceId =
+  | 'apple-health' | 'google-health-connect' | 'oura' | 'fitbit' | 'dexcom' | 'withings'
+  | 'epic-smart-fhir' | 'cms-blue-button' | 'dicomweb' | 'ccda' | 'manual';
+export type ConnectorKind = 'wearable' | 'ehr' | 'claims' | 'imaging' | 'lab' | 'document';
+export type AuthModel =
+  | 'oauth2-smart-on-fhir' | 'oauth2' | 'healthkit-on-device' | 'client-credentials'
+  | 'dicomweb-qido' | 'file-upload' | 'manual';
+export type IngestMode = 'fixture' | 'sandbox' | 'live';
+
+// Provenance rides on every fact: what came from where, how, when, in what shape, as which USCDI class.
+export interface Provenance {
+  source: SourceId;
+  connector: string;
+  authModel: AuthModel;
+  mode: IngestMode;
+  retrievedAt: string;
+  sourceShape: string; // e.g. 'HealthKit HKQuantitySample', 'FHIR R4 Observation (US Core)'
+  uscdi: string;       // USCDI v6 data class, e.g. 'Vital Signs', 'Laboratory', 'Medications'
+}
+
+// Canonical record shapes not already in data.ts (medications / immunizations / allergies / coverage).
+export interface MedicationRecord {
+  id: string; system: string; organ: string; code: string; codeSystem: 'RxNorm' | 'NDC';
+  display: string; status: string; effective: string; epistemic: EpistemicMode;
+}
+export interface ImmunizationRecord {
+  id: string; code: string; codeSystem: 'CVX'; display: string; occurrence: string; epistemic: EpistemicMode;
+}
+export interface AllergyRecord {
+  id: string; code: string; codeSystem: 'RxNorm' | 'SNOMED'; display: string; criticality: string; epistemic: EpistemicMode;
+}
+export interface CoverageRecord {
+  id: string; payer: string; kind: string; status: string; period: string; epistemic: EpistemicMode;
+}
+
+// Each normalized record carries its provenance. The twin never holds a fact without lineage.
+export type Provenanced<T> = T & { provenance: Provenance };
+
+export interface IngestResult {
+  observations: Provenanced<Observation>[];
+  conditions: Provenanced<Condition>[];
+  medications: Provenanced<MedicationRecord>[];
+  immunizations: Provenanced<ImmunizationRecord>[];
+  allergies: Provenanced<AllergyRecord>[];
+  imaging: Provenanced<ImagingStudy>[];
+  coverage: Provenanced<CoverageRecord>[];
+}
+export const emptyResult = (): IngestResult => ({
+  observations: [], conditions: [], medications: [], immunizations: [], allergies: [], imaging: [], coverage: [],
+});
+
+export interface Connector {
+  id: SourceId;
+  name: string;
+  kind: ConnectorKind;
+  authModel: AuthModel;
+  sourceShape: string;
+  uscdiClasses: string[];
+  modes: IngestMode[]; // which transports are wired (fixture always; sandbox/live where a rail exists)
+  // TRANSPORT — the only mode-dependent half. fixture reads a real-schema payload; live/sandbox is where
+  // a real authed HTTP call goes (same return shape, so normalize is untouched).
+  fetch(mode: IngestMode): Promise<unknown>;
+  // ADAPTER — identical across modes. Maps the real provider shape → canonical, USCDI-typed, provenanced.
+  normalize(raw: unknown, mode: IngestMode): IngestResult;
+}
+
+// ── shared normalization helpers ─────────────────────────────────────────────────────────────────
+// LOINC/organ routing so an ingested vital/lab localizes onto the anatomical twin (health:localizedTo).
+const LOINC_ROUTE: Record<string, { system: string; organ: string }> = {
+  '8867-4': { system: 'cardiovascular', organ: 'Heart' },   // heart rate
+  '40443-4': { system: 'cardiovascular', organ: 'Heart' },  // resting heart rate
+  '80404-7': { system: 'cardiovascular', organ: 'Heart' },  // HRV (R-R SDNN)
+  '8480-6': { system: 'cardiovascular', organ: 'Heart' },   // systolic BP
+  '8462-4': { system: 'cardiovascular', organ: 'Heart' },   // diastolic BP
+  '59408-5': { system: 'respiratory', organ: 'Lungs' },     // SpO2
+  '9279-1': { system: 'respiratory', organ: 'Lungs' },      // respiratory rate
+  '55423-8': { system: 'cardiovascular', organ: 'Heart' },  // steps
+  '29463-7': { system: 'hepatic', organ: 'Pancreas' },      // body weight (metabolic proxy)
+  '13457-7': { system: 'cardiovascular', organ: 'Heart' },  // LDL
+  '4548-4': { system: 'hepatic', organ: 'Pancreas' },       // A1c
+  '1742-6': { system: 'hepatic', organ: 'Liver' },          // ALT
+  '33914-3': { system: 'urinary', organ: 'Kidneys' },       // eGFR
+};
+export const routeLoinc = (code: string): { system: string; organ: string } =>
+  LOINC_ROUTE[code] ?? { system: 'cardiovascular', organ: 'Heart' };
+
+export const provenance = (
+  c: Connector, mode: IngestMode, sourceShape: string, uscdi: string,
+): Provenance => ({
+  source: c.id, connector: c.name, authModel: c.authModel, mode,
+  retrievedAt: new Date().toISOString(), sourceShape, uscdi,
+});
+
+// enrich an observation/condition/imaging with its ontology IRIs (typed node, not a label string).
+export const withObsIri = (o: Observation) => ({ ...o, classIri: `${HDT_NS}Observation`, organIri: ORGAN_IRI[o.organ] ?? null });
+export const withCondIri = (c: Condition) => ({ ...c, classIri: `${HEALTH_NS}Condition`, organIri: ORGAN_IRI[c.organ] ?? null });
+
+// merge many IngestResults, deduping by record id (cross-source reconciliation, richest-tier wins).
+const TIER_RANK: Record<EpistemicMode, number> = { hypothesis: 0, observed: 1, derived: 2, verified: 3, attested: 4 };
+export function mergeResults(results: IngestResult[]): IngestResult {
+  const out = emptyResult();
+  const seen = new Map<string, { tier: number; bucket: any[]; idx: number }>();
+  const add = (bucket: any[], rec: any) => {
+    const key = `${bucket === out.observations ? 'obs' : bucket === out.conditions ? 'cond' : 'x'}:${rec.id}`;
+    const tier = TIER_RANK[(rec.epistemic as EpistemicMode) ?? 'observed'] ?? 1;
+    const prior = seen.get(key);
+    if (prior) { if (tier > prior.tier) { prior.bucket[prior.idx] = rec; prior.tier = tier; } return; }
+    seen.set(key, { tier, bucket, idx: bucket.length }); bucket.push(rec);
+  };
+  for (const r of results) {
+    r.observations.forEach((x) => add(out.observations, x));
+    r.conditions.forEach((x) => add(out.conditions, x));
+    out.medications.push(...r.medications);
+    out.immunizations.push(...r.immunizations);
+    out.allergies.push(...r.allergies);
+    out.imaging.push(...r.imaging);
+    out.coverage.push(...r.coverage);
+  }
+  return out;
+}
+
+export const resultCounts = (r: IngestResult) => ({
+  observations: r.observations.length, conditions: r.conditions.length, medications: r.medications.length,
+  immunizations: r.immunizations.length, allergies: r.allergies.length, imaging: r.imaging.length,
+  coverage: r.coverage.length,
+  total: r.observations.length + r.conditions.length + r.medications.length + r.immunizations.length +
+    r.allergies.length + r.imaging.length + r.coverage.length,
+});

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -8,6 +8,8 @@
 // records. Synthetic data only in this skeleton — no real PHI.
 import http from 'node:http';
 import { SUBJECT, SYSTEMS, OBSERVATIONS, CONDITIONS, ENCOUNTERS, IMAGING, ORGAN_IRI, OBSERVATION_CLASS, CONDITION_CLASS, HEALTH_NS, HDT_NS, type Grant, type Observation, type Condition } from './data.js';
+import { connectorCatalogue, runConnector } from './connectors/index.js';
+import { mergeResults, resultCounts, emptyResult, type IngestResult, type IngestMode, type SourceId } from './ingest.js';
 
 const PORT = Number(process.env.PORT ?? 8097);
 
@@ -22,6 +24,29 @@ function receipt(kind: string, parts: string[]): { id: string; verifier: 'health
 
 // In-memory grant ledger (skeleton). Local-first store in production.
 const grants: Grant[] = [];
+
+// In-memory ingested store — records pulled through the connector plane (fixture mode here). Every
+// record carries provenance + an epistemic tier (the lineage Watson Health never had). Local-first in
+// production; this accumulates across ingest calls so the twin reflects what's been connected.
+let ingested: IngestResult = emptyResult();
+
+// A compact summary of what's been ingested: which sources, and which USCDI classes are now covered.
+function ingestedSummary() {
+  const all = [
+    ...ingested.observations, ...ingested.conditions, ...ingested.medications,
+    ...ingested.immunizations, ...ingested.allergies, ...ingested.imaging, ...ingested.coverage,
+  ];
+  const sources = new Map<string, { source: string; connector: string; mode: string; count: number }>();
+  const uscdi = new Set<string>();
+  for (const r of all as any[]) {
+    const p = r.provenance; if (!p) continue;
+    uscdi.add(p.uscdi);
+    const k = p.source;
+    const s = sources.get(k) ?? { source: p.source, connector: p.connector, mode: p.mode, count: 0 };
+    s.count += 1; sources.set(k, s);
+  }
+  return { counts: resultCounts(ingested), sources: [...sources.values()], uscdiCoverage: [...uscdi].sort() };
+}
 
 // enrich a record with its ontology IRIs so it lands in HellGraph as a typed node, not a label string.
 const obsView = (o: Observation) => ({ ...o, classIri: OBSERVATION_CLASS, organIri: ORGAN_IRI[o.organ] ?? null });
@@ -42,6 +67,8 @@ function bundle() {
     timeline: [...ENCOUNTERS].sort((a, b) => (a.date < b.date ? 1 : -1)),
     counts: { observations: OBSERVATIONS.length, conditions: CONDITIONS.length, encounters: ENCOUNTERS.length, imaging: IMAGING.length },
     grants: grants.map((g) => ({ ...g, active: !g.revoked && new Date(g.expires_at) > new Date() })),
+    // records pulled through the connector plane (provenance + epistemic tier on every one).
+    ingested: { ...ingested, summary: ingestedSummary() },
     // the twin speaks the estate's ontology: every fact carries a class IRI from the HDT ontology.
     ontology: { health: HEALTH_NS, hdt: HDT_NS, subjectClass: `${HDT_NS}HumanDigitalTwin`, note: 'Facts carry health:/hdt: class IRIs so they type into HellGraph + reason in Ontogenesis.' },
     disclaimer: 'Synthetic sample. Not a real person, not medical advice. This tool organises records; it does not diagnose.',
@@ -102,6 +129,33 @@ const server = http.createServer(async (req, res) => {
   if (req.method === 'GET' && url.pathname === '/api/health/twin.ttl') {
     res.writeHead(200, { 'content-type': 'text/turtle; charset=utf-8', 'access-control-allow-origin': '*' });
     return res.end(twinTtl());
+  }
+
+  // The connector catalogue — "connect a source". Each proves out on a real-schema fixture and flips
+  // to live with a credential (no downstream change).
+  if (req.method === 'GET' && url.pathname === '/api/health/connectors') {
+    return send(res, 200, { connectors: connectorCatalogue(), summary: ingestedSummary() });
+  }
+
+  // Ingest from a connector: fetch(mode) → normalize() → merge into the twin. fixture mode proves the
+  // live path (normalize is mode-invariant). Every landed record carries provenance + an epistemic tier.
+  if (req.method === 'POST' && url.pathname === '/api/health/ingest') {
+    try {
+      const b = await readJson(req);
+      const connector = String(b.connector ?? '').trim() as SourceId;
+      const mode = (String(b.mode ?? 'fixture').trim() || 'fixture') as IngestMode;
+      if (!connector) return send(res, 422, { error: 'connector required' });
+      const delta = await runConnector(connector, mode);
+      ingested = mergeResults([ingested, delta]);
+      const added = resultCounts(delta);
+      const sample = [...delta.observations, ...delta.conditions, ...delta.medications, ...delta.imaging][0] as any;
+      return send(res, 200, {
+        connector, mode, added, added_result: delta,
+        provenanceSample: sample?.provenance ?? null,
+        summary: ingestedSummary(),
+        receipt: receipt('ingest', [connector, mode, String(added.total)]),
+      });
+    } catch (e) { return send(res, 400, { error: (e as Error).message || 'ingest failed' }); }
   }
 
   // Grant a designated agent a scoped, time-boxed read grant — receipted.

--- a/docs/design/digital-health-twin-postmortem-and-ingestion.md
+++ b/docs/design/digital-health-twin-postmortem-and-ingestion.md
@@ -1,0 +1,162 @@
+# Why HealthVault and Watson Health died — and the ingestion architecture that answers it
+
+> The hard walls are ingestion-at-scale, regulatory, clinician workflow, and trust. Before building the
+> ingestion plane, we name exactly what killed the two most-funded attempts at this — because the
+> post-mortem *is* the architecture spec. Status: capture 2026-07-21. Non-diagnostic PHR posture.
+
+---
+
+## Part 1 — The deeper truth (not the obituary headline)
+
+The surface obituaries are "low consumer adoption" (HealthVault) and "Watson for Oncology gave unsafe
+recommendations, MD Anderson cancelled" (Watson Health). Both are true and both are shallow. The real
+causes are structural, and they are *opposite* failures that our architecture has to answer at the same
+time.
+
+### Microsoft HealthVault (2007–2019) — **a vault with no brain**
+- **It was a filing cabinet, not a product.** It *stored* records; it never *did* anything with them.
+  A place to put data is not a product — a thing that acts on data is. No reasoning, no insight, no
+  action returned to the person.
+- **Cold-start / empty-vault death spiral.** Population was manual and patient-mediated with no
+  automated ingestion. Empty vault → no value → no reason to fill it → empty vault. Two-sided market
+  (consumers *and* providers/devices) bootstrapped from neither side.
+- **No wedge into the clinical workflow.** It sat *outside* the EHR. Providers had no reason to push
+  data in or pull value out; data that went in never came back as value to a clinician or the person.
+- **It was too early — the rails did not exist yet.** HealthVault predates **FHIR / SMART-on-FHIR**
+  (2015+), **USCDI/US Core**, the **21st Century Cures Act** information-blocking rule (2016, enforced
+  2020+), **TEFCA** (2023), and **Blue Button 2.0**. It had to *beg* every provider for data through
+  bespoke integrations. Today the law *compels* providers to expose a patient-access API. Google Health
+  (2008–2012) died the identical death in the identical pre-rails window.
+
+**One-line cause: data without reasoning, populated by hand, outside the workflow, before the
+interoperability floor existed.**
+
+### IBM Watson Health (2015–2022) — **a "brain" bolted onto un-unified silos, sold before it worked**
+IBM spent >$4B acquiring Phytel, Explorys, Merge Healthcare, and Truven Health Analytics, and sold the
+pile to Francisco Partners for ~$1B. The deeper truths — several of which are only visible from inside:
+
+1. **It was an acquisition rollup wearing an AI brand, with no unified substrate.** Four companies,
+   four incompatible data models, four codebases, four sales orgs, spray-painted "Watson." There was
+   never a shared ontology underneath. **You cannot bolt a reasoning layer onto un-unified data** — and
+   they never unified it. "Sold off for parts" is the natural end of a thing that was *always* parts.
+2. **It encoded one institution's practice as universal truth, with no provenance.** Watson for
+   Oncology was trained largely on a small set of hypothetical/synthetic cases curated at a single
+   center — MSK's practice patterns presented as authoritative, black-box, one-size recommendations.
+   No way to say *"this is one institution's opinion — tier: institutional-practice — not verified
+   evidence."* **No provenance, no epistemic humility, no proof.** So when it was wrong it was
+   confidently, un-interrogably, liability-invitingly wrong.
+3. **It was a services-revenue vehicle, not a product.** IBM's incentive structure rewards booking
+   large consulting engagements and multi-year licenses to hospital CIOs on the strength of the brand,
+   then billing services hours to make it work *per site*. The thing was **sold before it worked** and
+   never productized — bespoke at every deployment, scalable at none. The "shitty company" instinct has
+   a precise mechanism: **the money was in the sales relationship and the services hours, not in
+   shipping working software**, so working software was never the actual objective.
+4. **Opaque to the only person who mattered — the clinician.** No citations, no reasoning trace. A
+   black box a doctor cannot interrogate is a black box a doctor will not trust, correctly.
+5. **The patient was never a party.** Pure enterprise B2B — hospitals and payers. No consent primitive,
+   no data-owner in the loop, no trust surface. Data was extracted, never returned.
+6. **Regulatory posture confusion.** It flirted with diagnosis (a medical-device claim) while branding
+   itself "decision support" — carrying the liability of the former with the evidence of neither.
+
+**One-line cause: reasoning without a unified, provenanced substrate; institutional bias sold as truth;
+a services business wearing a product costume; the patient absent.**
+
+### The synthesis — and why it maps 1:1 onto our thesis
+The two failures are mirror images:
+
+| | HealthVault | Watson Health |
+|---|---|---|
+| Had | the vault (storage) | the "brain" (reasoning) |
+| Missing | any reasoning / action | a unified, provenanced substrate |
+| Data | hand-entered, empty | rolled-up silos, un-unified |
+| Provenance | n/a | **absent** — bias sold as truth |
+| Patient | passive | **absent** |
+| Business | product with no value loop | **services vehicle, not product** |
+| Timing | pre-rails (no FHIR/Cures) | rails existed, ignored them |
+
+**Neither had the one thing that defines ours: a unified, ontology-typed, *provenanced* substrate with
+a proof-carrying, epistemically-honest reasoner on top of it, the patient sovereign and in the loop,
+shipped as a product on top of the mandated interoperability floor.** HealthVault had the vault and no
+brain; Watson had the "brain" and no honest vault. We build substrate + reasoner + provenance + consent
+as **one coherent thing**, patient-owned, riding rails (SMART-on-FHIR, USCDI v6, TEFCA IAS, Blue Button)
+that did not exist when HealthVault was begging for data.
+
+---
+
+## Part 2 — The seven design mandates the post-mortem forces
+
+1. **Reasoning is the product, not storage.** The vault only earns its place because a proof-carrying
+   reasoner acts on it. (Answers HealthVault #1.)
+2. **Automated ingestion on the mandated rails — no manual empty-vault.** SMART-on-FHIR patient access,
+   TEFCA Individual Access Services, Blue Button, DICOMweb, wearable APIs. (Answers HealthVault #2, #4.)
+3. **Provenance on every single fact — non-negotiable.** Source, connector, auth model, retrieval time,
+   the exact source shape, the USCDI class. No fact without its lineage. (Answers Watson #2, #4.)
+4. **Epistemic tiering — never sell one source's opinion as truth.** device-measured / lab-verified /
+   clinician-attested / patient-entered / derived, each labeled and colored, promotable only with
+   evidence. (Answers Watson #2.)
+5. **Unified substrate first — one ontology, not a rollup.** Everything normalizes to USCDI v6 + the
+   HDT/health ontology *before* it lands. No silo bolt-ons. (Answers Watson #1.)
+6. **Patient sovereign and in the loop — consent, receipts, revocation.** The data owner is the primary
+   party; every access is receipted; revocation is enforced on reads. (Answers Watson #5, both trust.)
+7. **Product, not services; non-diagnostic, honestly scoped.** It works out of the box the same way for
+   everyone; it organizes/retrieves/governs and never diagnoses. (Answers Watson #3, #6.)
+
+---
+
+## Part 3 — The ingestion architecture: prove every connector *without* their live data
+
+The user's directive: **bury the field by meeting or beating every feature; where a feature needs a
+data feed we don't have, build it anyway — modular enough to drop in paid or open data later — and
+prove the functionality against the real API's documented schema without their live data.**
+
+### The fixture → sandbox → live adapter model
+Every source (Apple Health, Google Health Connect, Oura, Fitbit, Dexcom, Withings, Epic/SMART-on-FHIR,
+CMS Blue Button, DICOMweb, C-CDA, manual) is a **`Connector`** with two separated halves:
+
+- **`fetch(mode)`** — the *transport*. This is the only part that differs by mode:
+  - `fixture` — reads a bundled payload **shaped exactly like the real API's documented response**
+    (HealthKit `HKQuantitySample`, Oura v2 `daily_sleep` doc, FHIR R4 US Core `Bundle`, Blue Button
+    `ExplanationOfBenefit`, DICOMweb QIDO-RS tag JSON). No credentials, no PHI, no contract.
+  - `sandbox` — hits the vendor's public sandbox (SMART sandbox, Blue Button sandbox, Dexcom sandbox,
+    Metriport sandbox) with synthetic patients.
+  - `live` — hits production with the person's OAuth grant / on-device export.
+- **`normalize(raw)`** — the *adapter logic*. **Identical across all three modes.** It maps the real
+  provider shape → our canonical, USCDI-typed, ontology-IRI'd, provenance-stamped records.
+
+**The load-bearing insight:** because `normalize` is identical in fixture and live mode, *a connector
+that correctly normalizes a real-schema fixture has a proven live path.* We validate the entire
+pipeline — ingest → normalize → USCDI-type → ontology-IRI → localize-to-organ → land-in-twin → reason —
+with zero paid feeds and zero real PHI. Flipping to live is `mode = 'live'` plus a credential. This is
+how we build the whole superset now and integrate real feeds (open, paid, or patient-authorized) later,
+one connector at a time, without ever blocking on a contract.
+
+### What ships in the walking skeleton (this increment)
+`apps/health-twin/src/ingest.ts` (framework) + `src/connectors/*` (five real-schema adapters):
+
+| Connector | Kind | Auth model (live) | Real source shape (fixture matches) | USCDI classes yielded |
+|---|---|---|---|---|
+| `apple-health` | wearable | HealthKit on-device export | `HKQuantitySample` / `HKCategorySample` | Vital Signs (HR, RHR, HRV, SpO2, BP, VO2max, weight, steps, sleep) |
+| `oura` | wearable | OAuth2 (Oura API v2) | `/v2/usercollection/daily_*` docs | Vital Signs (RHR, HRV, SpO2, sleep, activity) |
+| `epic-smart-fhir` | ehr | **OAuth2 SMART-on-FHIR** (patient access) | FHIR R4 US Core searchset `Bundle` | Problems, Labs, Medications, Allergies, Immunizations |
+| `cms-blue-button` | claims | OAuth2 (Blue Button 2.0) | FHIR `ExplanationOfBenefit` + `Coverage` | Medications (Part D fills), Health Insurance |
+| `dicomweb` | imaging | DICOMweb QIDO-RS | QIDO-RS study/series tag JSON | Diagnostic Imaging |
+
+Each record lands with a **`Provenance`** stamp (source, connector, authModel, mode, retrievedAt,
+sourceShape, uscdi) and an **epistemic tier** — so the very first fact the twin ingests already carries
+the lineage Watson never had. `epic-smart-fhir` is the marquee adapter: SMART-on-FHIR patient access is
+the **legally-clean, mandated path** (TEFCA Individual Access Services), the exact rail HealthVault
+lacked and the one the aggregators are being *litigated* for abusing under a "treatment" purpose.
+
+### Sequencing (one wall at a time, per the user)
+1. **Ingestion (this increment)** — the connector framework + 5 real-schema adapters, proven on
+   fixtures, provenance + USCDI + ontology on every record. ← *now*
+2. **Normalization/reconciliation at scale** — cross-source dedup, unit harmonization (UCUM), MPI-style
+   identity match, C-CDA→FHIR conversion (fork Metriport's AGPLv3 converter).
+3. **Clinician workflow** — SMART-on-FHIR app launch + CDS Hooks (push the twin's cited, tiered insight
+   into the EHR at the decision moment; write-back under grant).
+4. **Trust/regulatory** — consent receipts, revocation-on-read (already skeletoned), de-identification
+   for opt-in commons, SaMD boundary controls, the non-diagnostic guardrail as an enforced invariant.
+
+Everything is modular so a real feed — open (LOINC, RxNorm, CVX, USCDI value sets, OpenStax anatomy) or
+paid (a QHIN membership, a lab network) or patient-authorized (the person's own OAuth grant) — drops
+into a connector's `fetch` without touching `normalize` or anything downstream.


### PR DESCRIPTION
Focuses the first hard wall — **ingestion** — and answers *why the two most-funded attempts died* before building.

## The post-mortem is the spec (new doc: `digital-health-twin-postmortem-and-ingestion.md`)
- **HealthVault = a vault with no brain** — stored data, never acted on it; hand-fed (cold-start death spiral); outside the clinical workflow; **pre-rails** (no FHIR/Cures/TEFCA — it had to *beg* for data).
- **Watson Health = reasoning bolted onto un-unified silos** — an acquisition rollup wearing an AI brand with no shared ontology; **institutional practice sold as universal truth with no provenance**; a **services-revenue vehicle, not a product** (sold before it worked); the patient never a party.
- **Our answer** = a unified, *provenanced* substrate + a proof-carrying, epistemically-honest reasoner + sovereign consent, shipped as a product on the **mandated rails** HealthVault lacked.

## The architecture: prove every connector *without their live data*
Every source is a `Connector` split into two halves:
- **`fetch(mode)`** — the transport; the *only* mode-dependent half (`fixture` → `sandbox` → `live`).
- **`normalize(raw)`** — the adapter; **identical across all modes**.

Because `normalize` is mode-invariant, **a connector that normalizes a real-schema fixture has a proven live path.** We prove the entire pipeline (ingest → normalize → USCDI-type → ontology-IRI → localize-to-organ → land-in-twin) with **zero paid feeds and zero PHI**, and flip to live with just a credential. This is exactly the directive: build every feature now, drop in real (open/paid/patient-authorized) feeds later, modularly.

## What ships
- `ingest.ts` — Connector interface, **Provenance** on every fact (source/authModel/mode/sourceShape/USCDI), canonical records (+ meds/immunizations/allergies/coverage), LOINC→organ routing (`localizedTo`), cross-source dedup (richest epistemic tier wins), USCDI coverage summary.
- **5 real-schema adapters:** `epic-smart-fhir` (US Core R4 Bundle — the marquee, legally-clean patient-access rail), `cms-blue-button` (EOB Part D fills + Coverage), `apple-health` (HealthKit `HKQuantitySample`), `oura` (API v2 `daily_*` docs), `dicomweb` (QIDO-RS tag JSON).
- `server.ts`: `GET /api/health/connectors`, `POST /api/health/ingest`; bundle exposes `ingested` + coverage summary.
- `verify.ts` proof harness — **all 5 connectors normalize their fixtures → 22 records across all 8 USCDI classes**, every record provenanced. Verified live end-to-end (catalogue + ingest + bundle).

Non-diagnostic; synthetic fixtures only, no real PHI. No deploy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)