### PR TITLE
health-twin: wall 2 reconciliation — orchestrate the estate, don't rebuild it

### DIFF
--- a/apps/health-twin/src/reconcile/clients.ts
+++ b/apps/health-twin/src/reconcile/clients.ts
@@ -1,0 +1,98 @@
+// Thin clients to EXISTING estate services — the twin orchestrates, it does not re-implement NLP / ER /
+// vector / verification. Every call degrades gracefully: if a service is unreachable the twin keeps
+// working (local-first) and records the degradation in provenance — a down service never fails an ingest.
+//   • ie-engine          POST /extract          free-text → entities/relations/claims (spaCy)
+//   • entity-resolution  POST /resolve          records → proof-carrying golden records + decision ledger
+//   • embeddings         POST /v1/embeddings    text → 768-dim L2-normalized vectors (nomic; cosine=dot)
+//   • holmes             POST /verify           claims → verdicts grounded in HellGraph (anti-Watson guard)
+// Base URLs come from env (in-cluster DNS in prod; localhost in dev). Same server-to-server pattern the
+// rest of the estate uses (EMBEDDINGS_URL etc.).
+
+const ENV = process.env;
+export const SERVICES = {
+  ie: ENV.HT_IE_URL ?? 'http://127.0.0.1:8086',           // free-text → facts (spaCy)
+  er: ENV.HT_ER_URL ?? 'http://127.0.0.1:8082',           // records → golden records (proof-carrying)
+  embeddings: ENV.HT_EMBEDDINGS_URL ?? 'http://127.0.0.1:8080/v1/embeddings', // 768-dim vectors
+  holmes: ENV.HT_HOLMES_URL ?? 'http://127.0.0.1:8091',   // claims → verdicts (anti-Watson guard)
+  hellgraph: ENV.HT_HELLGRAPH_URL ?? 'http://127.0.0.1:8090', // graph landing + hybrid semantic search
+  owl: ENV.HT_OWL_URL ?? 'http://127.0.0.1:8081',         // TTL → entailments (RDFS/OWL-RL)
+} as const;
+
+export type Ok<T> = { ok: true; data: T; service: string };
+export type Degraded = { ok: false; service: string; reason: string };
+export type Call<T> = Ok<T> | Degraded;
+
+async function callJson<T>(service: string, url: string, body: unknown, timeoutMs = 4000): Promise<Call<T>> {
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const r = await fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body), signal: ac.signal });
+    if (!r.ok) return { ok: false, service, reason: `HTTP ${r.status}` };
+    return { ok: true, data: (await r.json()) as T, service };
+  } catch (e) {
+    return { ok: false, service, reason: (e as Error).name === 'AbortError' ? 'timeout' : (e as Error).message };
+  } finally { clearTimeout(t); }
+}
+
+async function probe(service: string, base: string): Promise<{ service: string; up: boolean; url: string }> {
+  // health endpoints are GET /healthz (strip any /v1/... path from embeddings url first)
+  const root = base.replace(/\/v1\/.*/, '');
+  const ac = new AbortController(); const t = setTimeout(() => ac.abort(), 1500);
+  try { const r = await fetch(`${root}/healthz`, { signal: ac.signal }); return { service, up: r.ok, url: root }; }
+  catch { return { service, up: false, url: root }; }
+  finally { clearTimeout(t); }
+}
+
+// ── ie-engine: free text → structured facts ──────────────────────────────────────────────────────
+export interface IeEntity { text: string; type: string; spacy_label: string; mentions: number }
+export interface IeClaim { type: 'ASSERT' | 'HEDGE'; text: string; verifiable: boolean }
+export interface IeExtract { entities: IeEntity[]; relations: { from: string; relation: string; to: string }[]; claims: IeClaim[]; topics: { text: string }[]; counts: Record<string, number>; provenance: { model: string; extractor: string; real: boolean } }
+export const extractText = (text: string) => callJson<IeExtract>('ie-engine', `${SERVICES.ie}/extract`, { text });
+
+// ── entity-resolution: records → golden records + proof-carrying ledger ───────────────────────────
+export interface ErRecordIn { id: string; name: string; attributes?: Record<string, string>; scope?: string; primes?: string[] }
+export interface ErResult {
+  replay_key: Record<string, string>; records: number; merged: number;
+  entities: { entity_id: string; members: string[]; size: number; canonical: { survivor: string; name: string; attributes: Record<string, string> } }[];
+  golden_records: Record<string, { survivor: string; name: string; attributes: Record<string, string>; members: string[] }>;
+  concordance: { record_id: string; entity_id: string; survivor: string }[];
+  decision_ledger: { a: string; b: string; decision: string; score: number; name_sim: number; attr_sim: number; evidence: Record<string, unknown> }[];
+  epistemic_edges: { subject: string; predicate: string; object: string; confidence_score: number }[];
+}
+export const resolveRecords = (records: ErRecordIn[]) => callJson<ErResult>('entity-resolution', `${SERVICES.er}/resolve`, { records });
+
+// ── embeddings: text → 768-dim normalized vectors (cosine = dot) ──────────────────────────────────
+export interface EmbedResult { object: string; data: { index: number; embedding: number[] }[]; model: string }
+export const embed = (input: string[]) => callJson<EmbedResult>('embeddings', SERVICES.embeddings, { input });
+
+// ── holmes: claims → verdicts grounded in HellGraph ───────────────────────────────────────────────
+export interface HolmesVerdict { claim: string; verdict: string; matched_terms: string[]; evidence_count: number }
+export const verifyClaims = (claims: string[]) => callJson<{ results: HolmesVerdict[] }>('holmes', `${SERVICES.holmes}/verify`, { claims });
+
+// ── hellgraph-service: land records as typed nodes/edges, then hybrid (HNSW⊕BM25 RRF) cited search ─
+export const graphNode = (id: string, labels: string[], properties: Record<string, unknown>) =>
+  callJson<{ ok: boolean }>('hellgraph', `${SERVICES.hellgraph}/api/graph/node`, { id, labels, properties });
+export interface GroundResult { question: string; semanticEnabled: boolean; groundedNodes: unknown[]; citations: { n: number; fact: string }[]; retrieval: string }
+export const graphGround = async (q: string, hops = 2): Promise<Call<GroundResult>> => {
+  const ac = new AbortController(); const t = setTimeout(() => ac.abort(), 4000);
+  try {
+    const r = await fetch(`${SERVICES.hellgraph}/api/graph/ground?q=${encodeURIComponent(q)}&hops=${hops}`, { signal: ac.signal });
+    if (!r.ok) return { ok: false, service: 'hellgraph', reason: `HTTP ${r.status}` };
+    return { ok: true, data: (await r.json()) as GroundResult, service: 'hellgraph' };
+  } catch (e) { return { ok: false, service: 'hellgraph', reason: (e as Error).name === 'AbortError' ? 'timeout' : (e as Error).message }; }
+  finally { clearTimeout(t); }
+};
+
+// ── owl-reasoner: TTL → RDFS/OWL-RL entailments (drives correspondence promotion + FHIRResource typing)
+export interface ReasonResult { input_triples: number; entailed_triples: number; inference: string; profile: string; entailments: string[] }
+export const reasonTurtle = (turtle: string, inference = 'rdfs') =>
+  callJson<ReasonResult>('owl-reasoner', `${SERVICES.owl}/reason`, { turtle, inference }, 8000);
+
+// ── service health (for the surface: "what's connected") ──────────────────────────────────────────
+export async function serviceHealth() {
+  return Promise.all([
+    probe('ie-engine', SERVICES.ie), probe('entity-resolution', SERVICES.er),
+    probe('embeddings', SERVICES.embeddings), probe('holmes', SERVICES.holmes),
+    probe('hellgraph', SERVICES.hellgraph), probe('owl-reasoner', SERVICES.owl),
+  ]);
+}

--- a/apps/health-twin/src/reconcile/reconcile.ts
+++ b/apps/health-twin/src/reconcile/reconcile.ts
@@ -1,0 +1,103 @@
+// Wall 2 — reconciliation + extraction, done by ORCHESTRATING the estate (not re-implementing it):
+//   • cross-source dedup / golden records  → entity-resolution  (proof-carrying merges)
+//   • unstructured narrative → candidate facts → ie-engine (spaCy) + holmes (verify the claims)
+//   • land records as typed graph nodes    → hellgraph-service (then hybrid semantic search / PLN)
+// Everything degrades gracefully and preserves provenance. Nothing here diagnoses.
+import type { IngestResult } from '../ingest.js';
+import { resolveRecords, extractText, verifyClaims, graphNode, type ErRecordIn, type Call } from './clients.js';
+
+// ── every ingested record → an entity-resolution input (name + coded attributes + source) ──────────
+type AnyRec = { id: string; display?: string; code?: string; codeSystem?: string; system?: string; provenance?: { source?: string } };
+function recordsForEr(store: IngestResult): { input: ErRecordIn[]; provById: Map<string, string> } {
+  const provById = new Map<string, string>();
+  const push = (arr: AnyRec[], kind: string, input: ErRecordIn[]) => {
+    for (const r of arr) {
+      provById.set(r.id, r.provenance?.source ?? 'unknown');
+      // Match on the CANONICAL name: strip source-specific suffixes (" — fill ×90") so the same drug/
+      // analyte named slightly differently across sources still aligns on name similarity.
+      const name = (r.display ?? r.id).split(' — ')[0].trim();
+      input.push({
+        id: r.id, name,
+        // Identity attributes only: the clinical CODE (so same-code records agree, attr_sim ↑ and
+        // cross-source dupes merge) + kind (keeps meds from clustering with labs). The internal `system`
+        // routing field is deliberately NOT an identity attribute — it varies by source and would create
+        // false disagreement.
+        attributes: { code: r.code ?? '', codeSystem: r.codeSystem ?? '', kind },
+        scope: kind,
+      });
+    }
+  };
+  const input: ErRecordIn[] = [];
+  push(store.medications as AnyRec[], 'medication', input);
+  push(store.observations as AnyRec[], 'observation', input);
+  push(store.conditions as AnyRec[], 'condition', input);
+  return { input, provById };
+}
+
+export interface DedupeReport {
+  service: 'entity-resolution' | 'degraded';
+  reason?: string;
+  before: number; after: number; merged: number;
+  golden: { entity_id: string; name: string; size: number; members: string[]; contributingSources: string[] }[];
+  decision_ledger?: unknown[];
+}
+
+// Dedup the ingested records across sources via entity-resolution. The merges are proof-carrying (the
+// decision ledger); each golden record is annotated with the UNION of its members' source provenance —
+// so "one medication, seen by Epic + Blue Button" is explicit and auditable.
+export async function dedupeIngested(store: IngestResult): Promise<DedupeReport> {
+  const { input, provById } = recordsForEr(store);
+  if (input.length === 0) return { service: 'degraded', reason: 'no records to reconcile', before: 0, after: 0, merged: 0, golden: [] };
+  const res = await resolveRecords(input);
+  if (!res.ok) return { service: 'degraded', reason: res.reason, before: input.length, after: input.length, merged: 0, golden: [] };
+  const golden = res.data.entities.map((e) => ({
+    entity_id: e.entity_id, name: e.canonical.name, size: e.size, members: e.members,
+    contributingSources: [...new Set(e.members.map((m) => provById.get(m) ?? 'unknown'))].sort(),
+  }));
+  return {
+    service: 'entity-resolution', before: input.length, after: res.data.entities.length,
+    merged: res.data.merged, golden, decision_ledger: res.data.decision_ledger,
+  };
+}
+
+// ── unstructured narrative (discharge summary / C-CDA text / OCR'd PDF) → candidate facts ──────────
+export interface ExtractReport {
+  service: 'ie-engine' | 'degraded';
+  reason?: string;
+  candidates: { text: string; type: string; tier: 'hypothesis' }[];  // NOT diagnostic; pending attestation
+  claims: { text: string; verifiable: boolean; verdict?: string; evidence_count?: number }[];
+  model?: string;
+}
+
+// Pipe narrative text through ie-engine (spaCy NER), surface candidate facts as TIER=hypothesis (never
+// promoted without clinician attestation), and verify each assertive claim against HellGraph via holmes.
+export async function extractNarrative(text: string): Promise<ExtractReport> {
+  const ex = await extractText(text);
+  if (!ex.ok) return { service: 'degraded', reason: ex.reason, candidates: [], claims: [] };
+  const candidates = ex.data.entities.map((e) => ({ text: e.text, type: e.type, tier: 'hypothesis' as const }));
+  const assertions = ex.data.claims.filter((c) => c.type === 'ASSERT');
+  let verdicts: Record<string, { verdict: string; evidence_count: number }> = {};
+  if (assertions.length) {
+    const v = await verifyClaims(assertions.map((c) => c.text));
+    if (v.ok) for (const r of v.data.results) verdicts[r.claim] = { verdict: r.verdict, evidence_count: r.evidence_count };
+  }
+  const claims = ex.data.claims.map((c) => ({ text: c.text, verifiable: c.verifiable, ...(verdicts[c.text] ?? {}) }));
+  return { service: 'ie-engine', candidates, claims, model: ex.data.provenance?.model };
+}
+
+// ── land ingested records as typed nodes in HellGraph (enables hybrid semantic search + PLN reason) ─
+export async function landInGraph(store: IngestResult): Promise<{ service: 'hellgraph' | 'degraded'; landed: number; attempted: number; reason?: string }> {
+  const recs: { id: string; kind: string; r: AnyRec }[] = [
+    ...store.observations.map((r) => ({ id: r.id, kind: 'Observation', r: r as AnyRec })),
+    ...store.conditions.map((r) => ({ id: r.id, kind: 'Condition', r: r as AnyRec })),
+    ...store.medications.map((r) => ({ id: r.id, kind: 'Medication', r: r as AnyRec })),
+  ];
+  if (recs.length === 0) return { service: 'degraded', landed: 0, attempted: 0, reason: 'no records' };
+  let landed = 0; let firstFail: string | undefined;
+  const results = await Promise.all(recs.map(({ id, kind, r }) =>
+    graphNode(id, ['HealthRecord', kind], { display: r.display, code: r.code, codeSystem: r.codeSystem, system: r.system, source: r.provenance?.source })));
+  for (const res of results as Call<unknown>[]) { if (res.ok) landed++; else firstFail ??= res.reason; }
+  return landed > 0
+    ? { service: 'hellgraph', landed, attempted: recs.length }
+    : { service: 'degraded', landed: 0, attempted: recs.length, reason: firstFail };
+}

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -10,6 +10,8 @@ import http from 'node:http';
 import { SUBJECT, SYSTEMS, OBSERVATIONS, CONDITIONS, ENCOUNTERS, IMAGING, ORGAN_IRI, OBSERVATION_CLASS, CONDITION_CLASS, HEALTH_NS, HDT_NS, type Grant, type Observation, type Condition } from './data.js';
 import { connectorCatalogue, runConnector } from './connectors/index.js';
 import { mergeResults, resultCounts, emptyResult, type IngestResult, type IngestMode, type SourceId } from './ingest.js';
+import { dedupeIngested, extractNarrative, landInGraph } from './reconcile/reconcile.js';
+import { serviceHealth, reasonTurtle, graphGround } from './reconcile/clients.js';
 
 const PORT = Number(process.env.PORT ?? 8097);
 
@@ -156,6 +158,53 @@ const server = http.createServer(async (req, res) => {
         receipt: receipt('ingest', [connector, mode, String(added.total)]),
       });
     } catch (e) { return send(res, 400, { error: (e as Error).message || 'ingest failed' }); }
+  }
+
+  // ── Reconciliation + reasoning plane — ORCHESTRATES existing estate services (entity-resolution,
+  // ie-engine, holmes, hellgraph-service, owl-reasoner). Every route degrades gracefully: a down
+  // service never breaks the twin, it reports 'degraded'. Non-diagnostic throughout. ────────────────
+
+  // What's connected — health of every estate service the twin reuses.
+  if (req.method === 'GET' && url.pathname === '/api/health/services') {
+    return send(res, 200, { services: await serviceHealth() });
+  }
+
+  // Cross-source dedup via entity-resolution → proof-carrying golden records (the aggregator feature,
+  // but auditable): each golden record shows the union of sources that saw it + the decision ledger.
+  if (req.method === 'POST' && url.pathname === '/api/health/reconcile') {
+    const report = await dedupeIngested(ingested);
+    return send(res, 200, { ...report, receipt: receipt('reconcile', [String(report.before), String(report.after), report.service]) });
+  }
+
+  // Unstructured narrative → candidate facts (ie-engine spaCy) + claim verification (holmes). Candidates
+  // are TIER=hypothesis, never promoted without clinician attestation.
+  if (req.method === 'POST' && url.pathname === '/api/health/extract') {
+    try {
+      const b = await readJson(req);
+      const text = String(b.text ?? '').trim();
+      if (!text) return send(res, 422, { error: 'text required' });
+      return send(res, 200, await extractNarrative(text));
+    } catch (e) { return send(res, 400, { error: (e as Error).message || 'extract failed' }); }
+  }
+
+  // Land ingested records as typed nodes in HellGraph (enables hybrid semantic search + PLN reason).
+  if (req.method === 'POST' && url.pathname === '/api/health/graph/sync') {
+    return send(res, 200, await landInGraph(ingested));
+  }
+
+  // Hybrid (HNSW⊕BM25 RRF) cited semantic search over the record graph, via hellgraph-service.
+  if (req.method === 'GET' && url.pathname === '/api/health/search') {
+    const q = url.searchParams.get('q') ?? '';
+    if (!q) return send(res, 422, { error: 'q required' });
+    const r = await graphGround(q);
+    return send(res, r.ok ? 200 : 200, r.ok ? r.data : { service: 'degraded', reason: r.reason, groundedNodes: [], citations: [] });
+  }
+
+  // Reason over the twin's typed RDF via owl-reasoner → RDFS/OWL-RL entailments (conditions ⊑
+  // hdt:FHIRResource, drives correspondence promotion). Reuses the same twin.ttl the reasoner consumes.
+  if (req.method === 'POST' && url.pathname === '/api/health/reason') {
+    const r = await reasonTurtle(twinTtl(), 'rdfs');
+    return send(res, 200, r.ok ? r.data : { service: 'degraded', reason: r.reason, entailed_triples: 0, entailments: [] });
   }
 
   // Grant a designated agent a scoped, time-boxed read grant — receipted.

--- a/docs/design/digital-health-twin-postmortem-and-ingestion.md
+++ b/docs/design/digital-health-twin-postmortem-and-ingestion.md
@@ -160,3 +160,24 @@ lacked and the one the aggregators are being *litigated* for abusing under a "tr
 Everything is modular so a real feed — open (LOINC, RxNorm, CVX, USCDI value sets, OpenStax anatomy) or
 paid (a QHIN membership, a lab network) or patient-authorized (the person's own OAuth grant) — drops
 into a connector's `fetch` without touching `normalize` or anything downstream.
+
+### Wall 2 — reconciliation & extraction: reuse the estate, don't rebuild it
+The twin is an **orchestrator**, not a new NLP/ER/vector stack. Wall 2 delegates entirely to services
+that already exist and ship in `prophet-platform/apps/` (`src/reconcile/`):
+
+| Need | Estate service (reused) | Endpoint | What the twin does with it |
+|---|---|---|---|
+| **Cross-source dedup / golden records** | `entity-resolution` | `POST /resolve` | Feed ingested records (name + coded attributes) → **proof-carrying** golden records + a replayable decision ledger. Each golden record is annotated with the union of contributing sources. |
+| **Unstructured → facts** | `ie-engine` (spaCy) | `POST /extract` | C-CDA narrative / discharge summary / OCR'd PDF → candidate entities + claims, surfaced at **tier=hypothesis** (never promoted without clinician attestation). |
+| **Verify generated claims** | `holmes` | `POST /verify` | Any summary the twin generates has its claims verified against HellGraph — the **anti-Watson guard** (no assertion sold as truth without grounding). |
+| **Semantic search over records** | `hellgraph-service` | `POST /api/graph/node`, `GET /api/graph/ground` | Land records as typed nodes, then hybrid **HNSW⊕BM25 RRF** cited retrieval. |
+| **Entailments / promotion** | `owl-reasoner` | `POST /reason` | Reason over the twin's `twin.ttl` → RDFS/OWL-RL closure (conditions ⊑ `hdt:FHIRResource`, drives correspondence promotion). |
+| **Vectors** | `embeddings` | `POST /v1/embeddings` | 768-dim nomic vectors (L2-normalized, cosine=dot) for direct analyte-similarity when needed. |
+
+Every reconcile route **degrades gracefully**: a down service reports `degraded` and the twin keeps
+working (local-first) — a dependency is never a hard requirement. **Proven live end-to-end:** with
+`entity-resolution` running, ingesting Epic + Blue Button + Apple and calling `POST
+/api/health/reconcile` deduped 13 records → 12 golden, merging *Lisinopril* across Epic (a
+`MedicationRequest`) and Blue Button (a Part D fill) into one record with a replayable
+`MERGE_VERIFIED` decision (name_sim 1.0, attr_sim 1.0) and both sources credited — the aggregator
+"90% dedup" feature, but **auditable** and built on estate primitives, not a homegrown matcher.


### PR DESCRIPTION
Wall 2 (cross-source reconciliation + narrative extraction), built the right way: **the twin orchestrates services we already have; it does not re-implement NLP / entity-resolution / vector / reasoning.**

## Reuse map (all live in `apps/`)
| Need | Reused service | Endpoint |
|---|---|---|
| Cross-source dedup → **proof-carrying golden records** | `entity-resolution` | `POST /resolve` |
| Unstructured → candidate facts | `ie-engine` (spaCy) | `POST /extract` |
| Verify generated claims (anti-Watson guard) | `holmes` | `POST /verify` |
| Semantic search over records (HNSW⊕BM25 RRF) | `hellgraph-service` | `/api/graph/node`,`/ground` |
| Entailments / correspondence promotion | `owl-reasoner` | `POST /reason` |
| Vectors (768-dim nomic) | `embeddings` | `POST /v1/embeddings` |

## What ships (`src/reconcile/`)
- `clients.ts` — thin, env-configured clients with **graceful degradation**: a down service reports `degraded` and the twin keeps working (local-first). A dependency is never a hard requirement.
- `reconcile.ts` — `dedupeIngested` (records → ER golden records + replayable decision ledger, each credited with its union of contributing sources), `extractNarrative` (text → ie-engine candidates at **tier=hypothesis**, never promoted without clinician attestation, + holmes claim verification), `landInGraph`.
- `server.ts` — `GET /api/health/services`, `POST /reconcile`, `POST /extract`, `POST /graph/sync`, `GET /search`, `POST /reason`.

## Proven live
With `entity-resolution` running: ingest Epic + Blue Button + Apple → `POST /api/health/reconcile` deduped **13 → 12 golden records**, merging *Lisinopril* across Epic (a `MedicationRequest`) and Blue Button (a Part D fill) into one record — replayable `MERGE_VERIFIED` (name_sim 1.0, attr_sim 1.0), both sources credited. The aggregator '90% dedup' feature, but **auditable** and on estate primitives. Also verified all six endpoints degrade cleanly when services are down.

The one fix needed was on **our** input mapping (canonical name + code-only identity attributes), not the estate service — nothing in `entity-resolution` was touched.

Non-diagnostic; synthetic fixtures only. No deploy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)