### PR TITLE
vendor: health-twin wall 4 (de-id + blinded n-ary consults) from prophet-health

### DIFF
--- a/apps/health-twin/package-lock.json
+++ b/apps/health-twin/package-lock.json
@@ -1,0 +1,504 @@
+{
+  "name": "health-twin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "health-twin",
+      "version": "0.1.0",
+      "dependencies": {
+        "tsx": "^4.19.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    }
+  }
+}

--- a/apps/health-twin/src/consult.ts
+++ b/apps/health-twin/src/consult.ts
@@ -1,0 +1,105 @@
+// Wall 4 — the blinded, n-ary opinion plane. The moat: because the twin is sovereign, consent-scoped,
+// and DE-IDENTIFIABLE, N clinicians each give an INDEPENDENT read on the same de-identified slice —
+// blind to the patient's identity, blind to each other, blind to prior labels. The aggregate is a
+// CONCORDANCE / DISSENT signal that removes anchoring, identity, and diagnostic-cascade bias.
+//
+// Each opinion attaches to the consult as a TIER=hypothesis claim (an opinion, never asserted truth —
+// the anti-Watson rule). The aggregate is a signal, NOT a diagnosis; a clinician still decides.
+import { deidentify, type DeidView, type DeidReceipt } from './deident.js';
+
+function djb2(s: string): string { let h = 5381; for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff; return (h >>> 0).toString(16).padStart(8, '0'); }
+const receipt = (kind: string, parts: string[]) => ({ id: `ht-${kind}-${djb2(parts.join('|'))}`, verifier: 'health-twin', at: new Date().toISOString() });
+
+export type Confidence = 'low' | 'moderate' | 'high';
+export interface Opinion {
+  id: string;
+  reviewer: string;       // pseudonymous reviewer handle (blinded to identity + to other reviewers at submit time)
+  assessment: string;     // the reviewer's read
+  confidence: Confidence;
+  tier: 'hypothesis';     // an opinion is a hypothesis, never verified/attested truth
+  at: string;
+  receipt: { id: string };
+}
+export interface Consult {
+  id: string;
+  createdAt: string;
+  scope: string;
+  slice: DeidView;        // the de-identified view every reviewer sees (no identity)
+  blind: true;
+  opinions: Opinion[];
+}
+
+// in-memory consult ledger (local-first store in production)
+const consults = new Map<string, Consult>();
+
+// Open a blinded consult over the twin (optionally scoped to a system). Returns the consult id + the
+// de-identified slice reviewers will see — identity is already gone before anyone reads it.
+export function openConsult(bundle: any, scope = 'whole twin'): { consult_id: string; slice: DeidView; receipt: { id: string } } {
+  const salt = `${Date.now()}-${scope}`;
+  const slice = deidentify(bundle, salt);
+  const id = `consult-${djb2([slice.receipt.pseudonym, scope, salt].join('|'))}`;
+  consults.set(id, { id, createdAt: new Date().toISOString(), scope, slice, blind: true, opinions: [] });
+  return { consult_id: id, slice, receipt: receipt('consult-open', [id, scope]) };
+}
+
+// The de-identified slice a reviewer opens (blind read — no identity, no other opinions shown here).
+export function reviewerView(consultId: string): { scope: string; slice: DeidView } | null {
+  const c = consults.get(consultId);
+  return c ? { scope: c.scope, slice: c.slice } : null;
+}
+
+// A reviewer submits an INDEPENDENT opinion — blind to identity and to other reviewers. Attaches as a
+// tier=hypothesis claim.
+export function submitOpinion(consultId: string, reviewer: string, assessment: string, confidence: Confidence): Opinion | { error: string } {
+  const c = consults.get(consultId);
+  if (!c) return { error: 'consult not found' };
+  const rv = reviewer.trim(); const a = assessment.trim();
+  if (!rv || !a) return { error: 'reviewer and assessment required' };
+  const op: Opinion = {
+    id: `op-${djb2([consultId, rv, a, String(Date.now())].join('|'))}`,
+    reviewer: rv, assessment: a, confidence, tier: 'hypothesis',
+    at: new Date().toISOString(), receipt: receipt('opinion', [consultId, rv]),
+  };
+  c.opinions.push(op);
+  return op;
+}
+
+const CONF_W: Record<Confidence, number> = { low: 1, moderate: 2, high: 3 };
+const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9 ]/g, '').replace(/\s+/g, ' ').trim();
+
+// Aggregate the independent opinions into a concordance/dissent signal. NOT a diagnosis — a signal that
+// concordance is reassurance and dissent is a flag worth more looking.
+export function aggregate(consultId: string) {
+  const c = consults.get(consultId);
+  if (!c) return { error: 'consult not found' };
+  const ops = c.opinions;
+  const n = ops.length;
+  // group by normalized assessment; weight by confidence
+  const groups = new Map<string, { assessment: string; reviewers: string[]; count: number; weight: number }>();
+  for (const o of ops) {
+    const k = norm(o.assessment);
+    const g = groups.get(k) ?? { assessment: o.assessment, reviewers: [], count: 0, weight: 0 };
+    g.reviewers.push(o.reviewer); g.count += 1; g.weight += CONF_W[o.confidence]; groups.set(k, g);
+  }
+  const ranked = [...groups.values()].sort((a, b) => b.weight - a.weight || b.count - a.count);
+  const top = ranked[0];
+  const agreement = n ? (top?.count ?? 0) / n : 0;
+  let verdict: 'insufficient' | 'unanimous' | 'majority' | 'split';
+  if (n < 2) verdict = 'insufficient';
+  else if (ranked.length === 1) verdict = 'unanimous';
+  else if ((top?.count ?? 0) > n / 2) verdict = 'majority';
+  else verdict = 'split';
+
+  return {
+    consult_id: consultId, scope: c.scope, blind: true,
+    opinions: ops.map((o) => ({ reviewer: o.reviewer, assessment: o.assessment, confidence: o.confidence, tier: o.tier, receipt: o.receipt.id })),
+    concordance: {
+      n, verdict, agreement: Math.round(agreement * 100) / 100,
+      groups: ranked.map((g) => ({ assessment: g.assessment, count: g.count, reviewers: g.reviewers })),
+      // dissent is the product's value: a split flags a case that deserves more looking
+      flag: verdict === 'split' ? 'discordant — warrants further review' : verdict === 'unanimous' ? 'concordant' : verdict === 'majority' ? 'mostly concordant' : 'need ≥2 independent opinions',
+    },
+    disclaimer: 'Independent, blinded opinions aggregated into a concordance signal. This is not a diagnosis; a clinician decides.',
+    receipt: receipt('consult-aggregate', [consultId, String(n)]),
+  };
+}

--- a/apps/health-twin/src/deident.ts
+++ b/apps/health-twin/src/deident.ts
@@ -1,0 +1,106 @@
+// Wall 4 — de-identification. Produces a de-identified view of the twin so a clinician can be granted a
+// BLINDED slice: they opine on the data, not the person. Approach = HIPAA Safe-Harbor-style identifier
+// removal + consistent date-SHIFTING (a per-view offset that breaks absolute dates while PRESERVING
+// intervals, which are clinically meaningful). Direct identifiers (name/label, provider names, free-text
+// notes) are stripped; the subject becomes a stable pseudonym; clinical codes/values/units/tiers are
+// preserved (that is exactly what the reviewer needs). Non-diagnostic; synthetic data only.
+
+// deterministic pseudonym so the same subject maps to the same token within a scope (unlinkable to identity)
+function djb2(s: string): string { let h = 5381; for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff; return (h >>> 0).toString(16).padStart(8, '0'); }
+
+const shiftDate = (iso: string, days: number): string => {
+  if (!iso || iso.length < 7) return iso;
+  const d = new Date(iso.length === 7 ? `${iso}-01` : iso);
+  if (isNaN(d.getTime())) return iso;
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+};
+
+export interface DeidReceipt {
+  method: 'safe-harbor+date-shift';
+  pseudonym: string;
+  identifiersRemoved: string[]; // categories handled
+  dateShiftDays: number;        // preserves intervals; absolute dates broken
+  at: string;
+}
+
+// The de-identified view a blinded reviewer sees. Note: NO name/label/provider, subject is a pseudonym.
+export interface DeidView {
+  subject: { pseudonym: string };
+  systems: {
+    id: string; label: string; organs: string[];
+    observations: { code: string; codeSystem: string; display: string; value: number; unit: string; refLow?: number; refHigh?: number; effective: string; trend?: number[]; epistemic: string; organ?: string }[];
+    conditions: { code: string; codeSystem: string; display: string; onset: string; clinicalStatus: string; epistemic: string; organ?: string }[];
+    encounters: { type: string; date: string }[]; // provider + free-text note REMOVED
+    imaging: { modality: string; bodySite: string; date: string; description: string; epistemic: string }[];
+  }[];
+  disclaimer: string;
+  receipt: DeidReceipt;
+}
+
+const NONDX = 'De-identified record for blinded review. Not a diagnosis; a clinician forms an opinion. Synthetic data.';
+
+// Build a de-identified view from the twin bundle. `salt` scopes the pseudonym + date-shift to a consult
+// so different consults are unlinkable. The bundle is the shape returned by the engine's bundle().
+export function deidentify(bundle: any, salt = 'default'): DeidView {
+  const subjectId = bundle?.subject?.id ?? 'subject';
+  const pseudonym = `anon:${djb2(`${subjectId}|${salt}`)}`;
+  // per-view deterministic date shift in [-183, +182] days — breaks absolute dates, preserves intervals
+  const dateShiftDays = (parseInt(djb2(`shift|${subjectId}|${salt}`), 16) % 366) - 183;
+  const removed = new Set<string>();
+
+  const systems = (bundle?.systems ?? []).map((s: any) => ({
+    id: s.id, label: s.label, organs: s.organs,
+    observations: (s.observations ?? []).map((o: any) => ({
+      code: o.code, codeSystem: o.codeSystem, display: o.display, value: o.value, unit: o.unit,
+      refLow: o.refLow, refHigh: o.refHigh, effective: shiftDate(o.effective, dateShiftDays), trend: o.trend,
+      epistemic: o.epistemic, organ: o.organ,
+    })),
+    conditions: (s.conditions ?? []).map((c: any) => ({
+      code: c.code, codeSystem: c.codeSystem, display: c.display, onset: shiftDate(c.onset, dateShiftDays),
+      clinicalStatus: c.clinicalStatus, epistemic: c.epistemic, organ: c.organ,
+    })),
+    encounters: (s.encounters ?? []).map((e: any) => {
+      if (e.provider) removed.add('provider-names');
+      if (e.note) removed.add('free-text-notes');
+      return { type: e.type, date: shiftDate(e.date, dateShiftDays) }; // provider + note dropped
+    }),
+    imaging: (s.imaging ?? []).map((im: any) => ({
+      modality: im.modality, bodySite: im.bodySite, date: shiftDate(im.date, dateShiftDays),
+      description: im.description, epistemic: im.epistemic,
+    })),
+  }));
+
+  if (bundle?.subject?.label) removed.add('names');
+  if (bundle?.subject?.note) removed.add('narrative');
+  removed.add('dates'); // shifted
+
+  return {
+    subject: { pseudonym },
+    systems,
+    disclaimer: NONDX,
+    receipt: {
+      method: 'safe-harbor+date-shift', pseudonym, identifiersRemoved: [...removed].sort(),
+      dateShiftDays, at: new Date().toISOString(),
+    },
+  };
+}
+
+// Invariant helper: does a de-identified view leak any known direct identifier field? Used by the
+// enforced non-diagnostic/de-id test. Returns the offending paths (empty = clean).
+export function identifierLeaks(view: any): string[] {
+  const leaks: string[] = [];
+  const scan = (obj: any, path: string) => {
+    if (obj == null || typeof obj !== 'object') return;
+    for (const [k, v] of Object.entries(obj)) {
+      const p = path ? `${path}.${k}` : k;
+      // direct identifiers forbidden ANYWHERE in a de-identified view
+      if (/^(name|note|provider|mrn|ssn|dob|email|phone|address|subjectLabel)$/i.test(k) && v) leaks.push(p);
+      // `label`/`id` are PHI only on the subject (a system's anatomical label like "Cardiovascular" is not)
+      if (/^(label|id)$/i.test(k) && v && /(^|\.)subject(\.|$)/i.test(p)) leaks.push(p);
+      if (typeof v === 'object') scan(v, p);
+    }
+  };
+  scan(view, '');
+  return leaks;
+}

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -1,0 +1,60 @@
+// Wall 4 — the non-diagnostic + de-identification guardrail, as an ENFORCED test. This runs in CI
+// (`npx tsx src/invariants.ts`) and exits non-zero if any invariant is violated — so the guardrail is a
+// property the build checks, not a promise in a comment. The failures that sank Watson (asserting as
+// truth, leaking what should be blinded) become impossible to merge.
+import { SUBJECT, SYSTEMS, OBSERVATIONS, CONDITIONS, ENCOUNTERS, IMAGING } from './data.js';
+import { deidentify, identifierLeaks } from './deident.js';
+import { openConsult, submitOpinion, aggregate } from './consult.js';
+import { patientSummaryCards, medReconciliationCards } from './cds/cds.js';
+import { emptyResult } from './ingest.js';
+
+let fails = 0;
+const ok = (cond: boolean, msg: string) => { console.log(`  ${cond ? '✓' : '✗'} ${msg}`); if (!cond) fails++; };
+
+// reconstruct the twin bundle shape (same grouping the server's bundle() uses)
+const sampleBundle = {
+  subject: SUBJECT,
+  systems: SYSTEMS.map((s) => ({
+    ...s,
+    observations: OBSERVATIONS.filter((o) => o.system === s.id),
+    conditions: CONDITIONS.filter((c) => c.system === s.id),
+    encounters: ENCOUNTERS.filter((e) => e.system === s.id),
+    imaging: IMAGING.filter((i) => i.system === s.id),
+  })),
+  disclaimer: 'Synthetic sample. Not a real person, not medical advice.',
+};
+
+console.log('\n▶ INVARIANT 1 — de-identification leaks no identity');
+const view = deidentify(sampleBundle, 'test');
+const leaks = identifierLeaks(view);
+ok(leaks.length === 0, `no identifier fields in the de-identified view (leaks: ${JSON.stringify(leaks)})`);
+ok(view.subject.pseudonym.startsWith('anon:') && !(view.subject as any).label && !(view.subject as any).id, 'subject reduced to a pseudonym (no id, no label)');
+ok(view.systems.every((s) => s.encounters.every((e) => !('provider' in e) && !('note' in e))), 'provider names + free-text notes removed from encounters');
+ok(view.receipt.identifiersRemoved.length > 0 && view.receipt.method === 'safe-harbor+date-shift', 'de-id receipt records method + identifiers removed');
+// dates broken but intervals preserved: an observation date must differ from the original
+const origDate = OBSERVATIONS[0]!.effective;
+const deidDate = view.systems.flatMap((s) => s.observations).find((o) => o.code === OBSERVATIONS[0]!.code)?.effective;
+ok(!!deidDate && deidDate !== origDate, 'absolute dates shifted (not equal to source)');
+
+console.log('\n▶ INVARIANT 2 — CDS cards are non-diagnostic + provenance-framed');
+const summary = await patientSummaryCards(emptyResult(), 'http://x');
+const meds = await medReconciliationCards(emptyResult(), 'http://x');
+const allCards = [...summary.cards, ...meds.cards];
+ok(allCards.length > 0, 'cards produced');
+ok(allCards.every((c) => /non-diagnostic|not a diagnosis|clinician decides/i.test(c.detail + c.source.label)), 'every card carries a non-diagnostic frame');
+ok(allCards.every((c) => !/\byou (have|are diagnosed)\b|\bdiagnosis:\s/i.test(c.detail)), 'no card asserts a diagnosis');
+
+console.log('\n▶ INVARIANT 3 — opinions are hypotheses, never asserted truth');
+const c = openConsult(sampleBundle, 'cardiovascular');
+ok(identifierLeaks(c.slice).length === 0, 'the consult slice reviewers see is de-identified');
+const op = submitOpinion(c.consult_id, 'reviewer-A', 'Consistent with early hypertension; monitor.', 'moderate');
+ok('tier' in op && (op as any).tier === 'hypothesis', 'a submitted opinion attaches as tier=hypothesis (not verified/attested)');
+submitOpinion(c.consult_id, 'reviewer-B', 'Consistent with early hypertension; monitor.', 'high');
+submitOpinion(c.consult_id, 'reviewer-C', 'Prefer secondary workup before labeling.', 'moderate');
+const agg = aggregate(c.consult_id) as any;
+ok(agg.blind === true && /not a diagnosis/i.test(agg.disclaimer), 'aggregate is blinded + framed as not a diagnosis');
+ok(['insufficient', 'unanimous', 'majority', 'split'].includes(agg.concordance.verdict), `concordance verdict computed (${agg.concordance.verdict}, agreement ${agg.concordance.agreement})`);
+ok(agg.opinions.every((o: any) => o.tier === 'hypothesis'), 'all aggregated opinions remain hypotheses');
+
+console.log(`\n${fails === 0 ? '✓ ALL GUARDRAIL INVARIANTS HOLD (non-diagnostic + de-identification enforced)' : `✗ ${fails} invariant(s) violated`}`);
+process.exit(fails === 0 ? 0 : 1);

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -13,6 +13,8 @@ import { mergeResults, resultCounts, emptyResult, type IngestResult, type Ingest
 import { dedupeIngested, extractNarrative, landInGraph } from './reconcile/reconcile.js';
 import { serviceHealth, reasonTurtle, graphGround } from './reconcile/clients.js';
 import { discovery, patientSummaryCards, medReconciliationCards } from './cds/cds.js';
+import { deidentify } from './deident.js';
+import { openConsult, reviewerView, submitOpinion, aggregate, type Confidence } from './consult.js';
 
 const PORT = Number(process.env.PORT ?? 8097);
 
@@ -220,6 +222,35 @@ const server = http.createServer(async (req, res) => {
       if (id === 'health-twin-medication-reconciliation') return send(res, 200, await medReconciliationCards(ingested, base));
       return send(res, 404, { error: `unknown cds-service: ${id}` });
     } catch (e) { return send(res, 400, { error: (e as Error).message || 'cds failed' }); }
+  }
+
+  // ── Wall 4: de-identification + blinded n-ary consults (the moat). Non-diagnostic; the aggregate is a
+  // concordance signal, a clinician decides. ────────────────────────────────────────────────────────
+
+  // A de-identified view of the twin (Safe-Harbor + date-shift) — proof identity is gone.
+  if (req.method === 'GET' && url.pathname === '/api/health/deident') return send(res, 200, deidentify(bundle()));
+
+  // Open a blinded consult: N clinicians will each read this de-identified slice independently.
+  if (req.method === 'POST' && url.pathname === '/api/health/consult') {
+    try { const b = await readJson(req); return send(res, 200, openConsult(bundle(), String(b.scope ?? 'whole twin').trim() || 'whole twin')); }
+    catch (e) { return send(res, 400, { error: (e as Error).message || 'consult failed' }); }
+  }
+
+  // Consult sub-routes: /api/health/consult/{id}[/review|/opinion]
+  if (url.pathname.startsWith('/api/health/consult/')) {
+    const rest = url.pathname.slice('/api/health/consult/'.length);
+    const [id, sub] = rest.split('/');
+    // A reviewer opens the blinded slice (no identity, no other opinions shown).
+    if (req.method === 'GET' && !sub) { const a = aggregate(id!); return send(res, (a as any).error ? 404 : 200, a); }
+    if (req.method === 'GET' && sub === 'review') { const v = reviewerView(id!); return send(res, v ? 200 : 404, v ?? { error: 'consult not found' }); }
+    // A reviewer submits an independent opinion (blind).
+    if (req.method === 'POST' && sub === 'opinion') {
+      try {
+        const b = await readJson(req);
+        const r = submitOpinion(id!, String(b.reviewer ?? ''), String(b.assessment ?? ''), (['low', 'moderate', 'high'].includes(b.confidence) ? b.confidence : 'moderate') as Confidence);
+        return send(res, (r as any).error ? 400 : 200, r);
+      } catch (e) { return send(res, 400, { error: (e as Error).message || 'opinion failed' }); }
+    }
   }
 
   // Grant a designated agent a scoped, time-boxed read grant — receipted.


### PR DESCRIPTION
Vendor-parity sync from the canonical repo **SocioProphet/prophet-health@2ffc7d9** so the platform CI builds + Argo CD deploys wall 4.

## Wall 4 — the moat (blinded, n-ary, anonymous)
- **De-identification** (`deident.ts`) — Safe-Harbor-style identifier removal + consistent **date-shift** (breaks absolute dates, **preserves intervals**). Subject → pseudonym; names/notes/providers stripped; clinical codes/values/tiers kept.
- **Blinded n-ary consults** (`consult.ts`) — open a consult over a de-identified slice; N clinicians submit **independent** opinions (blind to identity + to each other), each attaching as `tier=hypothesis` (never asserted truth); `aggregate()` → **concordance verdict** (unanimous/majority/split) + agreement ratio + **dissent flag**.
- **Enforced guardrail** (`invariants.ts`, wired into `ci.yml` upstream) — the non-diagnostic + de-identification invariants **fail the build** on violation. Watson's failure mode (asserting as truth, leaking what should be blinded) is now un-mergeable.

Endpoints: `GET /api/health/deident`, `POST /api/health/consult`, `GET /api/health/consult/{id}[/review]`, `POST /api/health/consult/{id}/opinion`.

**Proven live:** de-id (pseudonym, −154d shift, identifiers removed) → 3 blind opinions → majority/0.67 with the dissent surfaced, all `tier=hypothesis`, `blind=true`. Non-diagnostic; synthetic data only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)