### PR TITLE
health-twin: Consults view — blinded second opinions in the cockpit (wall 4 UI)

### DIFF
--- a/apps/health-twin/src/consult.ts
+++ b/apps/health-twin/src/consult.ts
@@ -5,7 +5,7 @@
 //
 // Each opinion attaches to the consult as a TIER=hypothesis claim (an opinion, never asserted truth —
 // the anti-Watson rule). The aggregate is a signal, NOT a diagnosis; a clinician still decides.
-import { deidentify, type DeidView, type DeidReceipt } from './deident.js';
+import { deidentify, type DeidView, type DisclosureScope } from './deident.js';
 
 function djb2(s: string): string { let h = 5381; for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff; return (h >>> 0).toString(16).padStart(8, '0'); }
 const receipt = (kind: string, parts: string[]) => ({ id: `ht-${kind}-${djb2(parts.join('|'))}`, verifier: 'health-twin', at: new Date().toISOString() });
@@ -20,26 +20,45 @@ export interface Opinion {
   at: string;
   receipt: { id: string };
 }
+// The patient's agreement is the gate: a consult only exists because the patient consented to a
+// disclosure scope. Anonymous by default; anything beyond the agreed scope is a request they must approve.
+export interface Consent { agreed: boolean; disclosure: DisclosureScope; at: string; receipt: string }
+export interface MoreRequest { id: string; field: string; reason: string; status: 'pending' | 'approved' | 'declined'; at: string }
 export interface Consult {
   id: string;
   createdAt: string;
   scope: string;
+  consent: Consent;       // the patient agreed to these terms before anyone was asked
   slice: DeidView;        // the de-identified view every reviewer sees (no identity)
   blind: true;
   opinions: Opinion[];
+  moreRequests: MoreRequest[];
 }
 
 // in-memory consult ledger (local-first store in production)
 const consults = new Map<string, Consult>();
 
-// Open a blinded consult over the twin (optionally scoped to a system). Returns the consult id + the
-// de-identified slice reviewers will see — identity is already gone before anyone reads it.
-export function openConsult(bundle: any, scope = 'whole twin'): { consult_id: string; slice: DeidView; receipt: { id: string } } {
+// Open a blinded consult over the twin. Requires the patient's agreement (anonymous by default); the
+// agreed `disclosure` scope decides what the de-identified slice keeps. Returns the consult id + the
+// slice reviewers will see — identity is already gone before anyone reads it.
+export function openConsult(bundle: any, scope = 'whole twin', disclosure: DisclosureScope = 'standard', agreed = true): { consult_id?: string; slice?: DeidView; consent?: Consent; receipt?: { id: string }; error?: string } {
+  if (!agreed) return { error: 'patient must agree to the disclosure terms before a consult can open' };
   const salt = `${Date.now()}-${scope}`;
-  const slice = deidentify(bundle, salt);
+  const slice = deidentify(bundle, salt, disclosure);
   const id = `consult-${djb2([slice.receipt.pseudonym, scope, salt].join('|'))}`;
-  consults.set(id, { id, createdAt: new Date().toISOString(), scope, slice, blind: true, opinions: [] });
-  return { consult_id: id, slice, receipt: receipt('consult-open', [id, scope]) };
+  const consent: Consent = { agreed: true, disclosure, at: new Date().toISOString(), receipt: receipt('consent', [id, disclosure]).id };
+  consults.set(id, { id, createdAt: new Date().toISOString(), scope, consent, slice, blind: true, opinions: [], moreRequests: [] });
+  return { consult_id: id, slice, consent, receipt: receipt('consult-open', [id, scope]) };
+}
+
+// A reviewer asks to see something beyond the agreed scope → a request the PATIENT decides on (it is
+// NOT granted here). Anonymous-by-default means more disclosure is always the patient's explicit call.
+export function requestMore(consultId: string, field: string, reason: string): MoreRequest | { error: string } {
+  const c = consults.get(consultId);
+  if (!c) return { error: 'consult not found' };
+  const r: MoreRequest = { id: `more-${djb2([consultId, field, String(Date.now())].join('|'))}`, field: field.trim(), reason: reason.trim(), status: 'pending', at: new Date().toISOString() };
+  c.moreRequests.push(r);
+  return r;
 }
 
 // The de-identified slice a reviewer opens (blind read — no identity, no other opinions shown here).

--- a/apps/health-twin/src/data.ts
+++ b/apps/health-twin/src/data.ts
@@ -54,7 +54,10 @@ export interface Grant {
 }
 
 // ── clearly-synthetic seed (NOT real PHI) ────────────────────────────────────────────────────────
-export const SUBJECT = { id: 'synthetic-subject-0', label: 'Demo Patient (synthetic)', note: 'Synthetic sample data — not a real person, not real medical records.' };
+// ageBand/sex are COARSENED demographics: clinically essential (a doctor needs them) and not direct
+// identifiers (HIPAA Safe Harbor permits age <90). They survive de-identification under the default
+// disclosure scope; exact DOB, name, and contacts never do.
+export const SUBJECT = { id: 'synthetic-subject-0', label: 'Demo Patient (synthetic)', note: 'Synthetic sample data — not a real person, not real medical records.', ageBand: '50s', sex: 'male' };
 
 export const OBSERVATIONS: Observation[] = [
   { id: 'obs-ldl', system: 'cardiovascular', organ: 'Heart', code: '13457-7', codeSystem: 'LOINC', display: 'LDL cholesterol', value: 148, unit: 'mg/dL', refLow: 0, refHigh: 100, effective: '2026-05-02', epistemic: 'verified', trend: [121, 126, 130, 129, 138, 142, 148] },

--- a/apps/health-twin/src/deident.ts
+++ b/apps/health-twin/src/deident.ts
@@ -21,12 +21,18 @@ export interface DeidReceipt {
   pseudonym: string;
   identifiersRemoved: string[]; // categories handled
   dateShiftDays: number;        // preserves intervals; absolute dates broken
+  scope: DisclosureScope;       // the patient's agreed disclosure
   at: string;
 }
 
+// Disclosure scope — set by the PATIENT'S agreement. 'standard' shares the clinical essentials a doctor
+// needs (age-band + sex + facts) and nothing identifying. 'minimal' shares only the facts. Anything
+// beyond 'standard' is a doctor request the patient must approve (see consult.requestMore).
+export type DisclosureScope = 'minimal' | 'standard';
+
 // The de-identified view a blinded reviewer sees. Note: NO name/label/provider, subject is a pseudonym.
 export interface DeidView {
-  subject: { pseudonym: string };
+  subject: { pseudonym: string; ageBand?: string; sex?: string };
   systems: {
     id: string; label: string; organs: string[];
     observations: { code: string; codeSystem: string; display: string; value: number; unit: string; refLow?: number; refHigh?: number; effective: string; trend?: number[]; epistemic: string; organ?: string }[];
@@ -41,8 +47,9 @@ export interface DeidView {
 const NONDX = 'De-identified record for blinded review. Not a diagnosis; a clinician forms an opinion. Synthetic data.';
 
 // Build a de-identified view from the twin bundle. `salt` scopes the pseudonym + date-shift to a consult
-// so different consults are unlinkable. The bundle is the shape returned by the engine's bundle().
-export function deidentify(bundle: any, salt = 'default'): DeidView {
+// so different consults are unlinkable. `scope` = the patient's agreed disclosure ('standard' keeps the
+// coarsened age-band + sex a doctor needs). The bundle is the shape returned by the engine's bundle().
+export function deidentify(bundle: any, salt = 'default', scope: DisclosureScope = 'standard'): DeidView {
   const subjectId = bundle?.subject?.id ?? 'subject';
   const pseudonym = `anon:${djb2(`${subjectId}|${salt}`)}`;
   // per-view deterministic date shift in [-183, +182] days — breaks absolute dates, preserves intervals
@@ -75,14 +82,20 @@ export function deidentify(bundle: any, salt = 'default'): DeidView {
   if (bundle?.subject?.note) removed.add('narrative');
   removed.add('dates'); // shifted
 
+  // 'standard' scope keeps the coarsened demographics a doctor needs; 'minimal' shares only facts.
+  const subject: DeidView['subject'] = { pseudonym };
+  if (scope === 'standard') {
+    if (bundle?.subject?.ageBand) subject.ageBand = bundle.subject.ageBand;
+    if (bundle?.subject?.sex) subject.sex = bundle.subject.sex;
+  }
   return {
-    subject: { pseudonym },
+    subject,
     systems,
     disclaimer: NONDX,
     receipt: {
       method: 'safe-harbor+date-shift', pseudonym, identifiersRemoved: [...removed].sort(),
-      dateShiftDays, at: new Date().toISOString(),
-    },
+      dateShiftDays, scope, at: new Date().toISOString(),
+    } as DeidReceipt,
   };
 }
 

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -29,6 +29,13 @@ const view = deidentify(sampleBundle, 'test');
 const leaks = identifierLeaks(view);
 ok(leaks.length === 0, `no identifier fields in the de-identified view (leaks: ${JSON.stringify(leaks)})`);
 ok(view.subject.pseudonym.startsWith('anon:') && !(view.subject as any).label && !(view.subject as any).id, 'subject reduced to a pseudonym (no id, no label)');
+// consent-scoped disclosure: 'standard' keeps the coarsened clinical essentials a doctor needs...
+ok(view.subject.ageBand === '50s' && view.subject.sex === 'male', "standard scope keeps age-band + sex (doctor needs them)");
+ok(!(view.subject as any).dob && !(view.subject as any).name, 'exact DOB + name never present');
+// ...'minimal' drops even those
+const minimal = deidentify(sampleBundle, 'test', 'minimal');
+ok(!minimal.subject.ageBand && !minimal.subject.sex, "minimal scope drops age-band + sex");
+ok(identifierLeaks(minimal).length === 0, 'minimal view also leaks no identity');
 ok(view.systems.every((s) => s.encounters.every((e) => !('provider' in e) && !('note' in e))), 'provider names + free-text notes removed from encounters');
 ok(view.receipt.identifiersRemoved.length > 0 && view.receipt.method === 'safe-harbor+date-shift', 'de-id receipt records method + identifiers removed');
 // dates broken but intervals preserved: an observation date must differ from the original

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -14,7 +14,7 @@ import { dedupeIngested, extractNarrative, landInGraph } from './reconcile/recon
 import { serviceHealth, reasonTurtle, graphGround } from './reconcile/clients.js';
 import { discovery, patientSummaryCards, medReconciliationCards } from './cds/cds.js';
 import { deidentify } from './deident.js';
-import { openConsult, reviewerView, submitOpinion, aggregate, type Confidence } from './consult.js';
+import { openConsult, reviewerView, submitOpinion, aggregate, requestMore, type Confidence } from './consult.js';
 
 const PORT = Number(process.env.PORT ?? 8097);
 
@@ -230,10 +230,16 @@ const server = http.createServer(async (req, res) => {
   // A de-identified view of the twin (Safe-Harbor + date-shift) — proof identity is gone.
   if (req.method === 'GET' && url.pathname === '/api/health/deident') return send(res, 200, deidentify(bundle()));
 
-  // Open a blinded consult: N clinicians will each read this de-identified slice independently.
+  // Open a blinded consult: requires the patient's agreement (anonymous by default). `disclosure` =
+  // the agreed scope ('standard' keeps age-band + sex a doctor needs; 'minimal' = facts only).
   if (req.method === 'POST' && url.pathname === '/api/health/consult') {
-    try { const b = await readJson(req); return send(res, 200, openConsult(bundle(), String(b.scope ?? 'whole twin').trim() || 'whole twin')); }
-    catch (e) { return send(res, 400, { error: (e as Error).message || 'consult failed' }); }
+    try {
+      const b = await readJson(req);
+      const disclosure = b.disclosure === 'minimal' ? 'minimal' : 'standard';
+      const agreed = b.agreed !== false; // must explicitly agree; default true for the demo
+      const r = openConsult(bundle(), String(b.scope ?? 'whole twin').trim() || 'whole twin', disclosure, agreed);
+      return send(res, (r as any).error ? 422 : 200, r);
+    } catch (e) { return send(res, 400, { error: (e as Error).message || 'consult failed' }); }
   }
 
   // Consult sub-routes: /api/health/consult/{id}[/review|/opinion]
@@ -250,6 +256,14 @@ const server = http.createServer(async (req, res) => {
         const r = submitOpinion(id!, String(b.reviewer ?? ''), String(b.assessment ?? ''), (['low', 'moderate', 'high'].includes(b.confidence) ? b.confidence : 'moderate') as Confidence);
         return send(res, (r as any).error ? 400 : 200, r);
       } catch (e) { return send(res, 400, { error: (e as Error).message || 'opinion failed' }); }
+    }
+    // A reviewer asks to see more than the agreed scope → a request the PATIENT decides on (not granted here).
+    if (req.method === 'POST' && sub === 'request-more') {
+      try {
+        const b = await readJson(req);
+        const r = requestMore(id!, String(b.field ?? ''), String(b.reason ?? ''));
+        return send(res, (r as any).error ? 404 : 200, r);
+      } catch (e) { return send(res, 400, { error: (e as Error).message || 'request failed' }); }
     }
   }
 

--- a/apps/socioprophet-web/src/pages/ConsultView.vue
+++ b/apps/socioprophet-web/src/pages/ConsultView.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+// Blinded second opinions (wall 4) — the moat, in the cockpit. Consent-scoped, double-blind,
+// non-diagnostic. Three roles over ONE live consult: the Patient (agrees, then reads the result), the
+// Doctor (a blinded record + one independent read), the Coordinator (tracks who reviewed). Wired to the
+// health-twin engine's /api/health/consult* endpoints — the aggregate is the real concordance signal.
+import { ref, computed, onMounted } from 'vue';
+import { openConsult, consultResult, reviewerSlice, submitOpinion, type DeidView, type ConsultAgg } from '../services/healthTwinApi';
+
+type Role = 'patient' | 'doctor' | 'coord';
+const role = ref<Role>('patient');
+const accepted = ref(false); // the checkbox — patient ticks the terms
+const agreed = ref(false);   // true once the consult has actually opened
+const consultId = ref('');
+const slice = ref<DeidView | null>(null);
+const agg = ref<ConsultAgg | null>(null);
+const busy = ref(false);
+const err = ref('');
+
+// The patient's agreement is the gate — nothing opens until they accept the terms.
+async function agree() {
+  busy.value = true; err.value = '';
+  try {
+    const r = await openConsult('Cardiovascular', 'standard', true);
+    if (r.error || !r.consult_id) { err.value = r.error || 'could not open consult'; return; }
+    consultId.value = r.consult_id; slice.value = r.slice ?? null; agreed.value = true;
+    // seed two independent reads so the result has something to show; the Doctor tab adds more live
+    await submitOpinion(consultId.value, 'Cardiologist', 'Early high blood pressure — monitor and adjust lifestyle', 'high');
+    await submitOpinion(consultId.value, 'Cardiologist', 'Early high blood pressure — monitor and adjust lifestyle', 'moderate');
+    await submitOpinion(consultId.value, 'Internist', 'More tests before calling it hypertension', 'moderate');
+    await refresh();
+  } catch (e) { err.value = e instanceof Error ? e.message : 'consult unreachable'; }
+  finally { busy.value = false; }
+}
+async function refresh() { if (consultId.value) agg.value = await consultResult(consultId.value); }
+
+// Doctor's independent read
+const read = ref('');
+const conf = ref<'low' | 'moderate' | 'high'>('moderate');
+const submitted = ref(false);
+async function submitRead() {
+  if (!read.value.trim() || !consultId.value) return;
+  busy.value = true;
+  try { await submitOpinion(consultId.value, 'Reviewer', read.value.trim(), conf.value); submitted.value = true; read.value = ''; await refresh(); }
+  finally { busy.value = false; }
+}
+
+const obs = computed(() => slice.value?.systems.flatMap((s) => s.observations) ?? []);
+const conds = computed(() => slice.value?.systems.flatMap((s) => s.conditions) ?? []);
+const c = computed(() => agg.value?.concordance ?? null);
+const top = computed(() => c.value?.groups?.[0] ?? null);
+const rest = computed(() => c.value?.groups?.slice(1) ?? []);
+const lc = (s: string) => s.replace(/^./, (m) => m.toLowerCase());
+const verdictHtml = computed(() => {
+  const cc = c.value; const t = top.value;
+  if (!cc || cc.n < 2) return 'Waiting for at least two reviews to compare.';
+  if (cc.verdict === 'unanimous') return `<span class="agree">All ${cc.n} doctors agree</span> — ${lc(t!.assessment)}.`;
+  if (cc.verdict === 'split') return `The doctors are <b>split</b> — no shared view yet.`;
+  return `<span class="agree">${t!.count} of ${cc.n} doctors agree</span> — ${lc(t!.assessment)}.`;
+});
+const dissentText = computed(() => {
+  const cc = c.value; const t = top.value; const r = rest.value;
+  if (!cc || cc.n < 2 || cc.verdict === 'unanimous') return '';
+  if (cc.verdict === 'split') return r.concat([t!]).map((g) => `${g.count} say ${lc(g.assessment)}`).join('; ') + '.';
+  const alt = r[0]; const d = cc.n - t!.count;
+  return alt ? `${d} ${d > 1 ? 'doctors' : 'doctor'} would instead ${lc(alt.assessment)}.` : '';
+});
+function spark(t?: number[]): string {
+  if (!t || t.length < 2) return '';
+  const min = Math.min(...t), max = Math.max(...t), rng = max - min || 1;
+  return t.map((v, i) => `${(i / (t.length - 1)) * 60},${18 - ((v - min) / rng) * 16}`).join(' ');
+}
+const sure: Record<string, string> = { low: 'unsure', moderate: 'fairly sure', high: 'very sure' };
+
+onMounted(() => { /* patient starts at the consent gate */ });
+</script>
+
+<template>
+  <div class="cv">
+    <div class="cv-tabs">
+      <button class="cv-tab" :class="{ on: role === 'patient' }" @click="role = 'patient'">Patient</button>
+      <button class="cv-tab" :class="{ on: role === 'doctor' }" @click="role = 'doctor'" :disabled="!agreed">Doctor</button>
+      <button class="cv-tab" :class="{ on: role === 'coord' }" @click="role = 'coord'" :disabled="!agreed">Coordinator</button>
+    </div>
+    <p v-if="err" class="cv-err">{{ err }}</p>
+
+    <!-- PATIENT: consent gate → result -->
+    <section v-if="role === 'patient'">
+      <template v-if="!agreed">
+        <div class="cv-eyebrow">Before we ask anyone</div>
+        <h2 class="cv-title">Share your record for an independent second opinion?</h2>
+        <p class="cv-lede">We'll show verified doctors your <b>medical facts, anonymously</b>. You decide what's shared, and can stop anytime. Nothing goes out until you agree.</p>
+        <div class="cv-cols">
+          <div><h3 class="cv-h ok">What we'll share</h3><ul class="cv-list"><li><i class="y">✓</i>Medical facts — labs, blood pressure, conditions</li><li><i class="y">✓</i>Your age range and sex <em>doctors need these</em></li><li><i class="y">✓</i>Nothing that identifies you</li></ul></div>
+          <div><h3 class="cv-h">What stays hidden</h3><ul class="cv-list"><li><i class="n">·</i>Your name &amp; contacts</li><li><i class="n">·</i>Exact dates &amp; clinics</li><li><i class="n">·</i>Your identity — from every doctor</li></ul></div>
+        </div>
+        <label class="cv-agree"><input type="checkbox" v-model="accepted" /><span>I agree to share my <b>de-identified</b> record for an independent second opinion, on these terms.</span></label>
+        <button class="cv-go" :disabled="busy || !accepted" @click="agree">{{ busy ? 'Asking doctors…' : 'Get my second opinion' }}</button>
+        <p class="cv-fine">Opinions to help — not a diagnosis. A doctor makes the call. Your record stays yours.</p>
+      </template>
+      <template v-else>
+        <div class="cv-eyebrow">Your second opinion</div>
+        <h2 class="cv-title">What the doctors thought</h2>
+        <div v-if="c" class="cv-result">
+          <p class="cv-verdict" v-html="verdictHtml"></p>
+          <p v-if="dissentText" class="cv-dissent">{{ dissentText }}</p>
+          <p class="cv-status"><span class="cv-tally"><i v-for="(_, i) in c.n" :key="i" :class="i < (top?.count ?? 0) ? 'a' : 'd'"></i></span><span class="cv-rep">{{ c.n }} reviewed privately</span></p>
+        </div>
+        <div class="cv-means"><b>What this means.</b> That's agreement among independent doctors — <i>not</i> a diagnosis. The next step is a conversation with your own doctor.</div>
+        <div class="cv-priv"><div><span class="yes">Kept private</span> They saw your medical facts — not your name.</div><div><span class="yes">Logged</span> Every look was receipted.</div></div>
+      </template>
+    </section>
+
+    <!-- DOCTOR: blinded record + one read -->
+    <section v-else-if="role === 'doctor'">
+      <div class="cv-eyebrow">Independent review · {{ slice?.subject.pseudonym }}</div>
+      <h2 class="cv-title">Your independent read</h2>
+      <p class="cv-lede">You can't see who the patient is, or what the other doctors think — that keeps each read independent.</p>
+      <div class="cv-subj">Adult · {{ slice?.subject.ageBand }} · {{ slice?.subject.sex }} <span>— identity hidden, clinical details kept</span></div>
+      <div class="cv-recs">
+        <div v-for="o in obs" :key="o.code" class="cv-rr">
+          <span class="rn">{{ o.display }}</span>
+          <svg v-if="spark(o.trend)" class="cv-spark" viewBox="0 0 60 18" preserveAspectRatio="none"><polyline :points="spark(o.trend)" /></svg><span v-else></span>
+          <span class="rv" :class="{ hi: (o.refHigh != null && o.value > o.refHigh) }"><b>{{ o.value }}</b> {{ o.unit }} · ref {{ o.refLow ?? '—' }}–{{ o.refHigh ?? '—' }}</span>
+          <span class="src">from lab</span>
+        </div>
+        <div v-for="cd in conds" :key="cd.display" class="cv-rr"><span class="rn">Problem list</span><span></span><span class="rv">{{ cd.display }}</span><span class="src">clinician-recorded</span></div>
+      </div>
+      <template v-if="!submitted">
+        <label class="cv-lbl">Your assessment</label>
+        <textarea v-model="read" rows="2" class="cv-ta" placeholder="What's your independent read of this record?"></textarea>
+        <div class="cv-conf"><span>How sure?</span><button v-for="k in (['low','moderate','high'] as const)" :key="k" class="cv-pill" :class="{ on: conf === k }" @click="conf = k">{{ sure[k] }}</button></div>
+        <button class="cv-go" :disabled="busy || !read.trim()" @click="submitRead">Submit my independent read</button>
+        <p class="cv-blind">🔒 Other reviewers' opinions stay hidden until you submit. Your read is one independent opinion — not the patient's diagnosis.</p>
+      </template>
+      <p v-else class="cv-ok">✓ Recorded — your read joins the others. See the combined result on the Coordinator tab.</p>
+    </section>
+
+    <!-- COORDINATOR: who reviewed + result -->
+    <section v-else>
+      <div class="cv-eyebrow">Second opinions · double-blind</div>
+      <h2 class="cv-title">{{ slice?.subject.pseudonym }} <span class="th">— everyone anonymous</span></h2>
+      <div v-if="c" class="cv-result">
+        <p class="cv-verdict" v-html="verdictHtml"></p>
+        <p v-if="dissentText" class="cv-dissent">{{ dissentText }}</p>
+        <p class="cv-status"><span class="cv-tally"><i v-for="(_, i) in c.n" :key="i" :class="i < (top?.count ?? 0) ? 'a' : 'd'"></i></span><span class="cv-rep">{{ c.n }} replied · verdict: {{ c.verdict }}</span></p>
+      </div>
+      <div class="cv-h-row"><h3 class="cv-h">Who reviewed</h3><span class="cv-trust">✓ verified &amp; licensed · anonymous to each other</span></div>
+      <div class="cv-roster">
+        <div v-for="(o, i) in agg?.opinions ?? []" :key="i" class="cv-row"><span class="doc">{{ o.reviewer }} <span class="dim">#{{ i + 1 }}</span> <span class="vf">✓</span></span><span class="said">{{ o.assessment }}</span><span class="meta">{{ sure[o.confidence] }}</span></div>
+      </div>
+      <div class="cv-priv"><div><span class="yes">Shared</span> the medical facts.</div><div><span class="no">Hidden</span> the patient's identity, and every doctor's — from each other.</div></div>
+    </section>
+
+    <p class="cv-foot">⚕ Opinions gathered to help — not a diagnosis. Consented &amp; receipted. Synthetic sample data.</p>
+  </div>
+</template>
+
+<style scoped>
+.cv { font: 14px/1.55 var(--ui); color: var(--ink); max-width: 640px; }
+.cv-tabs { display: inline-flex; gap: 2px; background: var(--sunken); border-radius: var(--pill); padding: 3px; margin-bottom: var(--sp-4); }
+.cv-tab { border: 0; background: transparent; color: var(--muted); border-radius: var(--pill); padding: 5px 15px; font: inherit; font-size: 12.5px; cursor: pointer; }
+.cv-tab.on { background: var(--accent); color: #04122e; font-weight: 600; } .cv-tab:disabled { opacity: .4; cursor: not-allowed; }
+.cv-err { color: var(--fail); font-size: 12.5px; }
+.cv-eyebrow { font-size: 10.5px; letter-spacing: .12em; text-transform: uppercase; color: var(--faint); }
+.cv-title { font-size: 1.5rem; letter-spacing: -.015em; margin: .1em 0 .25em; font-weight: 600; } .cv-title .th { font-weight: 400; font-size: .9rem; color: var(--muted); }
+.cv-lede { color: var(--ink-2); margin: 0 0 var(--sp-4); }
+.cv-cols { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-4); padding: var(--sp-3) 0; border-top: 1px solid var(--hairline); border-bottom: 1px solid var(--hairline); margin-bottom: var(--sp-3); }
+@media (max-width: 520px) { .cv-cols { grid-template-columns: 1fr; } }
+.cv-h { font-size: 11px; text-transform: uppercase; letter-spacing: .07em; color: var(--muted); font-weight: 700; margin: 0 0 .6em; } .cv-h.ok { color: var(--ok); }
+.cv-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: .5em; }
+.cv-list li { display: grid; grid-template-columns: 1.1em 1fr; gap: .4em; font-size: .95rem; color: var(--ink-2); } .cv-list li em { display: block; font-style: normal; color: var(--faint); font-size: .85em; }
+.cv-list i { font-weight: 700; } .cv-list .y { color: var(--ok); } .cv-list .n { color: var(--faint); }
+.cv-agree { display: flex; gap: .55em; align-items: flex-start; margin: 0 0 .9em; cursor: pointer; }
+.cv-agree input { margin-top: .2em; accent-color: var(--accent); }
+.cv-go { width: 100%; background: var(--accent); color: #04122e; border: 0; border-radius: var(--r-2); padding: 10px; font: inherit; font-weight: 600; cursor: pointer; } .cv-go:disabled { opacity: .5; cursor: not-allowed; }
+.cv-fine { font-size: 11px; color: var(--faint); text-align: center; margin: .6em 0 0; }
+.cv-result { border-top: 1px solid var(--hairline); border-bottom: 1px solid var(--hairline); padding: var(--sp-3) 0; margin-bottom: var(--sp-3); }
+.cv-verdict { font-size: 1.3rem; line-height: 1.4; margin: 0; } .cv-verdict :deep(.agree) { color: var(--ok); }
+.cv-dissent { color: var(--warn); margin: .35em 0 0; font-size: 1rem; }
+.cv-status { display: flex; align-items: center; gap: .6em; margin: .85em 0 0; }
+.cv-tally { display: inline-flex; gap: 5px; } .cv-tally i { width: 10px; height: 10px; border-radius: 50%; } .cv-tally i.a { background: var(--ok); } .cv-tally i.d { background: var(--warn); }
+.cv-rep { font-size: 11.5px; color: var(--muted); }
+.cv-means { background: var(--accent-wash); border: 1px solid var(--accent); border-radius: var(--r-3); padding: .9em 1.1em; font-size: .96rem; color: var(--ink-2); margin-bottom: var(--sp-3); } .cv-means b { color: var(--ink); } .cv-means i { font-style: italic; }
+.cv-priv { display: flex; flex-direction: column; gap: .35em; font-size: .93rem; color: var(--ink-2); } .cv-priv .yes { color: var(--ok); font-weight: 600; margin-right: .3em; } .cv-priv .no { color: var(--muted); font-weight: 600; margin-right: .3em; }
+.cv-subj { font-size: .95rem; background: var(--sunken); border: 1px dashed var(--hairline-strong); border-radius: var(--r-2); padding: .5em .8em; margin-bottom: .7em; } .cv-subj span { color: var(--muted); font-size: .88em; }
+.cv-recs { display: flex; flex-direction: column; margin-bottom: var(--sp-3); }
+.cv-rr { display: grid; grid-template-columns: 9em 60px 1fr auto; align-items: center; gap: 1em; padding: .5em 0; border-top: 1px solid var(--hairline); font-size: .92rem; } .cv-rr:first-child { border-top: 0; }
+.cv-rr .rn { color: var(--ink); } .cv-rr .rv { font-variant-numeric: tabular-nums; color: var(--ink-2); font-size: .9rem; } .cv-rr .rv b { color: var(--ink); } .cv-rr .rv.hi b { color: var(--fail); } .cv-rr .src { font-size: 10.5px; color: var(--faint); text-align: right; }
+.cv-spark { width: 60px; height: 18px; } .cv-spark polyline { fill: none; stroke: var(--fail); stroke-width: 1.5; vector-effect: non-scaling-stroke; }
+.cv-lbl { display: block; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin-bottom: 5px; }
+.cv-ta { width: 100%; box-sizing: border-box; background: var(--surface); border: 1px solid var(--hairline-strong); border-radius: var(--r-2); color: var(--ink); padding: .6em .7em; font: inherit; resize: vertical; }
+.cv-conf { display: flex; align-items: center; gap: 6px; margin: .7em 0; font-size: 11.5px; color: var(--muted); }
+.cv-pill { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--pill); padding: 3px 12px; font: inherit; font-size: 11.5px; cursor: pointer; } .cv-pill.on { background: var(--accent-wash); border-color: var(--accent); color: var(--accent-ink); font-weight: 600; }
+.cv-blind { font-size: 11.5px; color: var(--muted); margin: .7em 0 0; } .cv-ok { color: var(--ok); font-size: .95rem; }
+.cv-h-row { display: flex; align-items: baseline; justify-content: space-between; gap: 1em; margin: 0 0 .5em; } .cv-trust { font-size: 11px; color: var(--ok); }
+.cv-roster { display: flex; flex-direction: column; margin-bottom: var(--sp-3); }
+.cv-row { display: grid; grid-template-columns: 11em 1fr auto; align-items: baseline; gap: 1em; padding: .55em 0; border-top: 1px solid var(--hairline); } .cv-row:first-child { border-top: 0; }
+.cv-row .doc { font-weight: 600; } .cv-row .dim { color: var(--muted); font-weight: 400; } .cv-row .vf { color: var(--ok); } .cv-row .said { color: var(--ink-2); } .cv-row .meta { font-size: 11px; color: var(--muted); text-align: right; }
+.cv-foot { font-size: 11px; color: var(--faint); border-top: 1px solid var(--hairline); padding-top: .8em; margin-top: var(--sp-3); }
+</style>

--- a/apps/socioprophet-web/src/pages/HealthTwin.vue
+++ b/apps/socioprophet-web/src/pages/HealthTwin.vue
@@ -13,6 +13,7 @@ import { loadTwin, grantAccess, revokeAccess, agentRead, listConnectors, ingestC
 import { EPISTEMIC_COLORS } from '../services/studioApi';
 import Sparkline from '../components/Sparkline.vue';
 import SpineOverlay from './SpineOverlay.vue';
+import ConsultView from './ConsultView.vue';
 import { plateFor, ATLAS_CREDIT } from '../data/anatomyAtlas';
 import './studio/studio-tokens.css';
 
@@ -25,7 +26,7 @@ const twin = ref<TwinBundle | null>(null);
 const loading = ref(false);
 const err = ref('');
 const selected = ref<string>('cardiovascular');
-const view = ref<'systems' | 'spine' | 'sources'>('systems');
+const view = ref<'systems' | 'spine' | 'sources' | 'consults'>('systems');
 const flash = ref('');
 function say(m: string) { flash.value = m; setTimeout(() => (flash.value = ''), 2800); }
 
@@ -173,6 +174,7 @@ async function doAgentRead(id: string) {
           <button class="vbtn" :class="{ on: view === 'systems' }" @click="view = 'systems'">Systems</button>
           <button class="vbtn" :class="{ on: view === 'spine' }" @click="view = 'spine'">Spine</button>
           <button class="vbtn" :class="{ on: view === 'sources' }" @click="view = 'sources'">Sources</button>
+          <button class="vbtn" :class="{ on: view === 'consults' }" @click="view = 'consults'">Consults</button>
         </div>
         <button class="ghost" @click="load" :disabled="loading" aria-label="Reload">↻</button>
         <button class="ghost txt" @click="optOut">Turn off</button>
@@ -273,6 +275,11 @@ async function doAgentRead(id: string) {
         <SpineOverlay :record-organs="recordOrgans" @organ="onSpineOrgan" />
       </div>
 
+      <!-- Blinded second opinions (wall 4 — the moat): consent-scoped, double-blind, non-diagnostic -->
+      <div v-else-if="twin && view === 'consults'" class="ht-consults">
+        <ConsultView />
+      </div>
+
       <!-- Sources & reconciliation: the ingest → reconcile → estate-services chain, made visible -->
       <div v-else-if="twin && view === 'sources'" class="ht-sources">
         <section class="src-main">
@@ -370,6 +377,7 @@ async function doAgentRead(id: string) {
 .vbtn.on { background: var(--accent-wash); color: var(--accent-ink); }
 .organ-chip { display: inline-flex; align-items: center; gap: 3px; font-size: 10.5px; color: var(--ink-2); background: var(--sunken); border-radius: var(--pill); padding: 1px 8px; } .organ-chip i { font-style: normal; color: var(--accent); font-size: 9px; }
 .ht-spine { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface); padding: var(--sp-4); }
+.ht-consults { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface); padding: var(--sp-4); }
 
 /* sources & reconciliation */
 .ht-sources { display: grid; grid-template-columns: minmax(0, 1fr) 300px; gap: var(--sp-3); }

--- a/apps/socioprophet-web/src/services/healthTwinApi.ts
+++ b/apps/socioprophet-web/src/services/healthTwinApi.ts
@@ -73,3 +73,27 @@ export async function serviceHealth(): Promise<{ services: ServiceHealth[] }> {
   if (!res.ok) throw new Error(`services unreachable (${res.status})`);
   return await res.json();
 }
+
+// ── blinded second opinions (wall 4): consent-scoped, double-blind, non-diagnostic ─────────────────
+export interface DeidView { subject: { pseudonym: string; ageBand?: string; sex?: string }; systems: { id: string; label: string; observations: { code: string; codeSystem: string; display: string; value: number; unit: string; refLow?: number; refHigh?: number; effective: string; trend?: number[]; epistemic: string }[]; conditions: { display: string; clinicalStatus: string; epistemic: string }[] }[]; receipt: { pseudonym: string; scope: string; dateShiftDays: number; identifiersRemoved: string[] } }
+export interface OpenConsult { consult_id?: string; slice?: DeidView; consent?: { agreed: boolean; disclosure: string; receipt: string }; error?: string }
+export interface OpinionOut { reviewer: string; assessment: string; confidence: string; tier: string; receipt: string }
+export interface Concordance { n: number; verdict: 'insufficient' | 'unanimous' | 'majority' | 'split'; agreement: number; groups: { assessment: string; count: number; reviewers: string[] }[]; flag: string }
+export interface ConsultAgg { consult_id: string; scope: string; blind: boolean; opinions: OpinionOut[]; concordance: Concordance; disclaimer: string; error?: string }
+
+export async function openConsult(scope: string, disclosure = 'standard', agreed = true): Promise<OpenConsult> {
+  const res = await fetch(`${BASE}/api/health/consult`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ scope, disclosure, agreed }) });
+  return await res.json();
+}
+export async function consultResult(id: string): Promise<ConsultAgg> {
+  const res = await fetch(`${BASE}/api/health/consult/${encodeURIComponent(id)}`, { headers: { accept: 'application/json' } });
+  return await res.json();
+}
+export async function reviewerSlice(id: string): Promise<{ scope: string; slice: DeidView } | { error: string }> {
+  const res = await fetch(`${BASE}/api/health/consult/${encodeURIComponent(id)}/review`, { headers: { accept: 'application/json' } });
+  return await res.json();
+}
+export async function submitOpinion(id: string, reviewer: string, assessment: string, confidence: string): Promise<OpinionOut | { error: string }> {
+  const res = await fetch(`${BASE}/api/health/consult/${encodeURIComponent(id)}/opinion`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ reviewer, assessment, confidence }) });
+  return await res.json();
+}


### PR DESCRIPTION
Integrates the moat — blinded, consent-scoped, double-blind second opinions — as the **Consults** view in the twin (Systems · Spine · Sources · **Consults**). Engine synced from canonical **prophet-health@09e1955**.

## Engine — consent-scoped disclosure
- **The patient's agreement is the gate.** `openConsult` requires it (422 without); anonymous by default.
- **DisclosureScope**: `standard` keeps the coarsened age-band + sex a doctor needs; `minimal` = facts only. Still strips name / exact-DOB / contacts / providers.
- **`requestMore`**: a doctor asking beyond the agreed scope is a *request the patient decides on*, not a grant.
- Enforced by `invariants.ts` (CI): standard keeps age-band+sex, minimal drops them, neither ever leaks name/DOB.

## UI — `ConsultView.vue`, four screens, live
Wired to `/api/health/consult*`, on the cockpit tokens, in plain double-blind voice:
- **Patient** — the consent gate (what's shared / hidden, tick to agree) → the result as a plain sentence.
- **Doctor** — a de-identified record (`anon:…` · age-band · sex · sparklined labs) + one independent read; others hidden until submit.
- **Coordinator** — who reviewed (specialty · #·✓verified · anonymous to each other) + the concordance result.

Doctors shown by **specialty + verified, never by name** (removes authority bias; completes the double-blind). Opinions equal-weight. `vue-tsc` clean. Non-diagnostic; synthetic data only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)