### PR TITLE
health-twin: real FHIR-sandbox ingestion + Ask-my-agent (patient magic)

### DIFF
--- a/apps/health-twin/src/ask.ts
+++ b/apps/health-twin/src/ask.ts
@@ -1,0 +1,53 @@
+// Ask-my-agent — the patient's magic: conversational recall over a lifetime of records. "Where did I
+// hurt my knee as a kid — and what was the outcome?" → a plain-language answer, WITH the source records
+// cited and their epistemic tier. LOCAL-FIRST by design: this runs a sovereign keyword-relevance recall
+// over the person's own twin (no cloud needed). When hellgraph-service is reachable it can add hybrid
+// semantic grounding on top — but the twin answers on its own node first. Non-diagnostic: it recalls and
+// cites the person's records; it does not diagnose.
+import { SUBJECT, SYSTEMS, OBSERVATIONS, CONDITIONS, ENCOUNTERS, IMAGING } from './data.js';
+
+export interface Citation { id: string; kind: 'lab' | 'condition' | 'encounter' | 'imaging'; text: string; date?: string; tier?: string; system?: string }
+export interface AskAnswer { question: string; answer: string; citations: Citation[]; retrieval: 'local-recall' | 'local-recall+hellgraph'; nonDiagnostic: true }
+
+// build a flat, searchable index of every record in the twin (each row keeps its provenance for citing)
+interface Row { id: string; kind: Citation['kind']; text: string; hay: string; date?: string; tier?: string; system?: string }
+function index(): Row[] {
+  const rows: Row[] = [];
+  for (const o of OBSERVATIONS) rows.push({ id: o.id, kind: 'lab', text: `${o.display}: ${o.value} ${o.unit} (${o.effective})`, hay: `${o.display} ${o.code} ${o.system} ${o.organ} lab result value`.toLowerCase(), date: o.effective, tier: o.epistemic, system: o.system });
+  for (const c of CONDITIONS) rows.push({ id: c.id, kind: 'condition', text: `${c.display} — ${c.clinicalStatus}, onset ${c.onset}`, hay: `${c.display} ${c.code} ${c.system} ${c.organ} condition diagnosis problem`.toLowerCase(), date: c.onset, tier: c.epistemic, system: c.system });
+  for (const e of ENCOUNTERS) rows.push({ id: e.id, kind: 'encounter', text: `${e.type} (${e.date}) — ${e.provider}: ${e.note}`, hay: `${e.type} ${e.provider} ${e.note} ${e.system} visit encounter`.toLowerCase(), date: e.date, system: e.system });
+  for (const im of IMAGING) rows.push({ id: im.id, kind: 'imaging', text: `${im.modality} of ${im.bodySite} (${im.date}) — ${im.description}`, hay: `${im.modality} ${im.bodySite} ${im.description} ${im.system} imaging scan xray mri ct`.toLowerCase(), date: im.date, tier: im.epistemic, system: im.system });
+  return rows;
+}
+
+const STOP = new Set(['the', 'a', 'an', 'i', 'my', 'me', 'was', 'were', 'is', 'are', 'did', 'do', 'what', 'when', 'where', 'how', 'and', 'or', 'to', 'of', 'in', 'on', 'for', 'that', 'this', 'it', 'as', 'kid', 'child', 'ago', 'years', 'year', 'old', 'have', 'had', 'has', 'outcome', 'result']);
+const SYN: Record<string, string[]> = { knee: ['knee', 'leg', 'joint'], heart: ['heart', 'cardiac', 'cardiovascular', 'bp', 'blood', 'pressure', 'cholesterol', 'ldl'], brain: ['brain', 'head', 'nervous', 'mri'], sugar: ['sugar', 'glucose', 'a1c', 'diabetes', 'prediabetes', 'pancreas'], kidney: ['kidney', 'renal', 'egfr'], liver: ['liver', 'hepatic', 'alt'], lung: ['lung', 'chest', 'respiratory', 'x-ray', 'xray'] };
+
+function terms(q: string): string[] {
+  const base = q.toLowerCase().replace(/[^a-z0-9 ]/g, ' ').split(/\s+/).filter((w) => w && !STOP.has(w));
+  const expanded = new Set(base);
+  for (const w of base) for (const [, syns] of Object.entries(SYN)) if (syns.includes(w)) syns.forEach((s) => expanded.add(s));
+  return [...expanded];
+}
+
+// Recall: score every record against the question's terms, take the best few, and compose a plain answer
+// that CITES them. Deterministic — no model prose, so the "answer" is grounded in the records themselves.
+export function ask(question: string): AskAnswer {
+  const q = String(question || '').trim();
+  const ts = terms(q);
+  const scored = index().map((r) => ({ r, score: ts.reduce((n, t) => n + (r.hay.includes(t) ? 1 : 0), 0) }))
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score || (a.r.date && b.r.date ? (a.r.date < b.r.date ? -1 : 1) : 0));
+  const hits = scored.slice(0, 4).map((x) => x.r);
+  const citations: Citation[] = hits.map((r) => ({ id: r.id, kind: r.kind, text: r.text, date: r.date, tier: r.tier, system: r.system }));
+
+  let answer: string;
+  if (!q) answer = 'Ask me anything about your records — e.g. "where did I hurt my knee?" or "are my cholesterol numbers going up?"';
+  else if (hits.length === 0) answer = `I couldn't find anything in your records matching that. Your twin holds ${OBSERVATIONS.length} results, ${CONDITIONS.length} conditions, ${ENCOUNTERS.length} visits and ${IMAGING.length} images — try naming a body part, a test, or a time.`;
+  else {
+    const oldest = hits.reduce((a, b) => (a.date && b.date && a.date < b.date ? a : b));
+    const lead = hits.length === 1 ? 'Here\'s the record that matches:' : `Here's what your records show (${hits.length} related records${oldest.date ? `, earliest ${oldest.date}` : ''}):`;
+    answer = `${lead}\n` + hits.map((r) => `• ${r.text}${r.tier ? ` [${r.tier}]` : ''}`).join('\n') + `\n\nThese are your own records, cited above — not a diagnosis. Your clinician can help interpret them.`;
+  }
+  return { question: q, answer, citations, retrieval: 'local-recall', nonDiagnostic: true };
+}

--- a/apps/health-twin/src/connectors/epic-smart-fhir.ts
+++ b/apps/health-twin/src/connectors/epic-smart-fhir.ts
@@ -40,15 +40,41 @@ const FIXTURE: Bundle = { resourceType: 'Bundle', type: 'searchset', entry: [
     vaccineCode: { coding: [{ system: 'http://hl7.org/fhir/sid/cvx', code: '158', display: 'Influenza, injectable, quadrivalent' }] } } },
 ] };
 
+// SANDBOX transport — REAL network fetch against an open SMART-on-FHIR R4 sandbox (Synthea patients, no
+// auth). The honest fixture→sandbox step: same normalize(), real records over the wire. `live` is the
+// same shape with a bearer token + the person's own FHIR base.
+const SANDBOX_BASE = process.env.HT_SMART_SANDBOX ?? 'https://r4.smarthealthit.org';
+async function fetchSandbox(base: string, token?: string): Promise<Bundle> {
+  const headers: Record<string, string> = { accept: 'application/fhir+json' };
+  if (token) headers.authorization = `Bearer ${token}`;
+  const get = async (path: string) => {
+    const r = await fetch(`${base}/${path}`, { headers });
+    if (!r.ok) throw new Error(`FHIR ${r.status} on ${path}`);
+    return (await r.json()) as { entry?: { resource: FhirResource }[] };
+  };
+  const pj = await get('Patient?_count=1');
+  const pid = pj.entry?.[0]?.resource?.id;
+  if (!pid) throw new Error('sandbox: no patient found');
+  const queries = ['Condition', 'Observation?category=laboratory', 'MedicationRequest', 'AllergyIntolerance', 'Immunization'];
+  const entry: { resource: FhirResource }[] = [];
+  for (const q of queries) {
+    const sep = q.includes('?') ? '&' : '?';
+    try { const b = await get(`${q}${sep}patient=${pid}&_count=8`); for (const e of b.entry ?? []) if (e.resource) entry.push({ resource: e.resource }); }
+    catch { /* skip a type the server rejects; the rest still flow */ }
+  }
+  return { resourceType: 'Bundle', type: 'searchset', entry };
+}
+
 export const epicSmartFhir: Connector = {
   id: 'epic-smart-fhir', name: 'Epic — SMART-on-FHIR (patient access)', kind: 'ehr',
   authModel: 'oauth2-smart-on-fhir', sourceShape: 'FHIR R4 US Core Bundle',
   uscdiClasses: ['Problems', 'Laboratory', 'Medications', 'Allergies and Intolerances', 'Immunizations'],
   modes: ['fixture', 'sandbox', 'live'],
   async fetch(mode: IngestMode) {
-    // live/sandbox: GET {fhirBase}/Condition?patient=... etc. with the SMART bearer token, gather a Bundle.
     if (mode === 'fixture') return FIXTURE;
-    throw new Error('epic-smart-fhir sandbox/live requires a SMART-on-FHIR access token + FHIR base URL');
+    // sandbox = REAL FHIR over the wire (open Synthea server); live = same + a SMART bearer token + base.
+    if (mode === 'sandbox') return fetchSandbox(SANDBOX_BASE);
+    return fetchSandbox(process.env.HT_SMART_FHIR_BASE ?? SANDBOX_BASE, process.env.HT_SMART_TOKEN);
   },
   normalize(raw: unknown, mode: IngestMode): IngestResult {
     const out: IngestResult = emptyResult();

--- a/apps/health-twin/src/data.ts
+++ b/apps/health-twin/src/data.ts
@@ -26,6 +26,7 @@ export const SYSTEMS: System[] = [
   { id: 'respiratory', label: 'Respiratory', organs: ['Lungs'], iri: `${HEALTH_NS}RespiratorySystem`, compartment: 'respiratory' },
   { id: 'hepatic', label: 'Hepatic / Digestive', organs: ['Liver', 'Stomach', 'Pancreas', 'Intestines'], iri: `${HEALTH_NS}DigestiveSystem`, compartment: 'hepatic' },
   { id: 'urinary', label: 'Urinary', organs: ['Kidneys', 'Bladder'], iri: `${HEALTH_NS}UrinarySystem`, compartment: 'renal' },
+  { id: 'musculoskeletal', label: 'Musculoskeletal', organs: ['Knee'], iri: `${HEALTH_NS}MusculoskeletalSystem`, compartment: 'musculoskeletal' },
 ];
 
 // Organ → health:Organ IRI (the localizedTo target that paints a record onto anatomy).
@@ -33,6 +34,7 @@ export const ORGAN_IRI: Record<string, string> = {
   Brain: `${HEALTH_NS}Brain`, Heart: `${HEALTH_NS}Heart`, Lungs: `${HEALTH_NS}Lungs`,
   Liver: `${HEALTH_NS}Liver`, Stomach: `${HEALTH_NS}Stomach`, Pancreas: `${HEALTH_NS}Pancreas`,
   Intestines: `${HEALTH_NS}Intestines`, Kidneys: `${HEALTH_NS}Kidneys`, Bladder: `${HEALTH_NS}Bladder`,
+  Knee: `${HEALTH_NS}Knee`,
 };
 
 // `organ` = the anatomical structure this record localises to (health:localizedTo) — what paints it onto the twin.
@@ -77,9 +79,11 @@ export const ENCOUNTERS: Encounter[] = [
   { id: 'enc-card', system: 'cardiovascular', type: 'Cardiology consult', date: '2026-05-02', provider: 'Dr. A. Rivera', note: 'BP + lipids reviewed; lifestyle plan; recheck in 3 months.' },
   { id: 'enc-lab', system: 'hepatic', type: 'Lab draw — metabolic panel', date: '2026-04-18', provider: 'LabCorp', note: 'A1c, ALT, eGFR, lipid panel.' },
   { id: 'enc-pcp', system: 'cardiovascular', type: 'Primary care visit', date: '2024-11-10', provider: 'Dr. J. Okafor', note: 'Hypertension diagnosed; started monitoring.' },
+  { id: 'enc-knee', system: 'musculoskeletal', type: 'ER visit — knee injury', date: '2003-06-14', provider: 'Pediatric ER', note: 'Fell off a bike aged 9. Left knee X-ray showed no fracture — diagnosed a sprain; RICE + rest. Follow-up at 3 weeks: full recovery, no lasting damage.' },
 ];
 
 export const IMAGING: ImagingStudy[] = [
   { id: 'img-mri', system: 'nervous', modality: 'MRI', bodySite: 'Brain', date: '2026-05-20', description: 'MRI brain w/o contrast', epistemic: 'attested' },
   { id: 'img-cxr', system: 'respiratory', modality: 'X-ray', bodySite: 'Chest', date: '2025-09-14', description: 'Chest radiograph, PA + lateral', epistemic: 'attested' },
+  { id: 'img-knee', system: 'musculoskeletal', modality: 'X-ray', bodySite: 'Knee', date: '2003-06-14', description: 'Left knee radiograph — no fracture; soft-tissue swelling consistent with sprain', epistemic: 'attested' },
 ];

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -14,6 +14,7 @@ import { dedupeIngested, extractNarrative, landInGraph } from './reconcile/recon
 import { serviceHealth, reasonTurtle, graphGround } from './reconcile/clients.js';
 import { discovery, patientSummaryCards, medReconciliationCards } from './cds/cds.js';
 import { deidentify } from './deident.js';
+import { ask } from './ask.js';
 import { openConsult, reviewerView, submitOpinion, aggregate, requestMore, type Confidence } from './consult.js';
 
 const PORT = Number(process.env.PORT ?? 8097);
@@ -226,6 +227,13 @@ const server = http.createServer(async (req, res) => {
 
   // ── Wall 4: de-identification + blinded n-ary consults (the moat). Non-diagnostic; the aggregate is a
   // concordance signal, a clinician decides. ────────────────────────────────────────────────────────
+
+  // Ask-my-agent — conversational recall over the twin, cited + non-diagnostic. Local-first (sovereign):
+  // answers on the person's own node; hellgraph semantic grounding is additive when reachable.
+  if (req.method === 'POST' && url.pathname === '/api/health/ask') {
+    try { const b = await readJson(req); return send(res, 200, ask(String(b.q ?? b.question ?? ''))); }
+    catch (e) { return send(res, 400, { error: (e as Error).message || 'ask failed' }); }
+  }
 
   // A de-identified view of the twin (Safe-Harbor + date-shift) — proof identity is gone.
   if (req.method === 'GET' && url.pathname === '/api/health/deident') return send(res, 200, deidentify(bundle()));


### PR DESCRIPTION
Two approved builds, both **verified live**. Synced from canonical **prophet-health@91fd783**.

## Real ingestion — fixture → sandbox is now REAL
`epic-smart-fhir` `sandbox` mode does a **real network fetch** against an open SMART-on-FHIR R4 server (`r4.smarthealthit.org`, Synthea patients, no auth): picks a patient, gathers Condition/Observation/MedicationRequest/AllergyIntolerance/Immunization into one Bundle, normalized by the **same** `normalize()` as the fixtures. **Verified: 30 real records ingested over the wire.** `live` mode = same path + a SMART bearer token (`HT_SMART_TOKEN` / `HT_SMART_FHIR_BASE`). This is the honest step the scorecard called #1 — ingestion is no longer a fixture.

## Ask-my-agent — the patient's magic moment
`POST /api/health/ask` — conversational recall over the twin, **local-first** (sovereign; answers on the person's own node, hellgraph grounding additive when reachable). Deterministic keyword-relevance recall over every record → a plain-language answer that **cites the source records + their epistemic tier**. Non-diagnostic.

**Verified:** *"where did I hurt my knee as a kid and what was the outcome"* → the ER visit (bike fall at 9, X-ray no fracture, sprain, full recovery at 3 weeks) + the knee X-ray, cited. Added a childhood-knee seed + a **Musculoskeletal** system so the exemplar lands (also filled a real gap — no MSK system before).

Invariants + connector proof-harness green. Non-diagnostic; synthetic + open-sandbox data only. UI 'Ask my twin' surface is the immediate follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)