### PR TITLE
health-twin: guideline-grounded reasoning — cited, non-diagnostic guidance over your own numbers

### DIFF
--- a/apps/health-twin/src/guidelines.ts
+++ b/apps/health-twin/src/guidelines.ts
@@ -1,0 +1,80 @@
+// Guideline-grounded reasoning — the reasoning-column attack that meets OpenEvidence/Med-PaLM on their
+// turf, but sovereign + CITED + non-diagnostic. Reads the twin's own numbers (labs, vitals, conditions)
+// and surfaces recommendations grounded in REAL clinical guidelines (ACC/AHA, ADA, USPSTF, KDIGO), each
+// with its source, a strength, and a plain explanation. It NEVER diagnoses or prescribes — it says "here
+// is what the guidelines say about your numbers; discuss with your clinician." Deterministic, local-first.
+import { OBSERVATIONS, CONDITIONS, SUBJECT } from './data.js';
+
+export interface Guidance {
+  finding: string;         // the observation that triggered it (from the person's own record)
+  says: string;            // what the guideline says, in plain words
+  source: string;          // the real guideline it's grounded in
+  strength: 'screen' | 'discuss' | 'monitor' | 'confirm';
+  cites: string[];         // record ids this is grounded on
+}
+
+const obs = (code: string) => OBSERVATIONS.find((o) => o.code === code);
+const hasCond = (code: string) => CONDITIONS.some((c) => c.code === code);
+const ageNum = () => { const m = /(\d+)/.exec(String((SUBJECT as any).ageBand ?? '')); return m ? Number(m[1]) : undefined; };
+
+// Each rule is grounded in a named guideline; thresholds are the guideline's own. Non-diagnostic framing
+// is structural (strength = screen/discuss/monitor/confirm, never "diagnose").
+export function guidance(): { subject: string; items: Guidance[]; disclaimer: string } {
+  const items: Guidance[] = [];
+
+  const ldl = obs('13457-7');
+  if (ldl && ldl.value >= 100) {
+    const high = ldl.value >= 190;
+    items.push({
+      finding: `LDL cholesterol ${ldl.value} ${ldl.unit} (target <100)`,
+      says: high
+        ? 'LDL ≥190 is a statin-benefit group on its own. A high-intensity statin discussion is warranted.'
+        : `LDL is above target${hasCond('38341003') ? ', and with hypertension your 10-year cardiovascular risk is higher' : ''}. Guidelines suggest discussing lifestyle and statin candidacy (via an ASCVD risk estimate) with your clinician.`,
+      source: 'ACC/AHA 2018 Blood Cholesterol Guideline',
+      strength: 'discuss', cites: [ldl.id],
+    });
+  }
+
+  const a1c = obs('4548-4');
+  if (a1c) {
+    if (a1c.value >= 5.7 && a1c.value < 6.5) items.push({
+      finding: `HbA1c ${a1c.value}% (prediabetes range 5.7–6.4)`,
+      says: 'This is the prediabetes range. Intensive lifestyle change (7% weight loss + activity) cuts progression to diabetes by ~58%; annual A1c monitoring is recommended.',
+      source: 'ADA Standards of Care in Diabetes',
+      strength: 'monitor', cites: [a1c.id],
+    });
+    else if (a1c.value >= 6.5) items.push({
+      finding: `HbA1c ${a1c.value}% (≥6.5)`,
+      says: 'This value is in the diabetes range. A single value does not confirm a diagnosis — your clinician confirms with a repeat or second test.',
+      source: 'ADA Standards of Care in Diabetes',
+      strength: 'confirm', cites: [a1c.id],
+    });
+  }
+
+  const sbp = obs('8480-6');
+  if (sbp) {
+    if (sbp.value >= 140) items.push({ finding: `Systolic BP ${sbp.value} mmHg (stage 2, ≥140)`, says: 'This is stage-2 range. Guidelines recommend confirming with out-of-office readings and reviewing treatment with your clinician.', source: 'ACC/AHA 2017 High Blood Pressure Guideline', strength: 'confirm', cites: [sbp.id] });
+    else if (sbp.value >= 130) items.push({ finding: `Systolic BP ${sbp.value} mmHg (stage 1, 130–139)`, says: 'This is stage-1 range. Guidelines recommend confirming readings and lifestyle change; medication depends on your overall cardiovascular risk.', source: 'ACC/AHA 2017 High Blood Pressure Guideline', strength: 'monitor', cites: [sbp.id] });
+  }
+
+  const egfr = obs('33914-3');
+  if (egfr && egfr.value < 90) items.push({
+    finding: `eGFR ${egfr.value} mL/min`,
+    says: egfr.value < 60 ? 'Below 60 for ≥3 months would meet the CKD threshold. Confirm with a repeat eGFR + urine albumin.' : 'Mildly reduced. Worth periodic monitoring, especially alongside blood pressure.',
+    source: 'KDIGO CKD Guideline', strength: egfr.value < 60 ? 'confirm' : 'monitor', cites: [egfr.id],
+  });
+
+  // age-based preventive screening (USPSTF) — grounded on the person's own age band
+  const age = ageNum();
+  if (age != null && age >= 45 && age <= 75) items.push({
+    finding: `Age ${(SUBJECT as any).ageBand}`,
+    says: 'Colorectal cancer screening is recommended for adults 45–75 (colonoscopy every 10 years, or a stool-based test on its schedule).',
+    source: 'USPSTF Colorectal Cancer Screening', strength: 'screen', cites: [],
+  });
+
+  return {
+    subject: SUBJECT.id,
+    items,
+    disclaimer: 'What clinical guidelines say about your own recorded numbers — informational, cited, and NOT a diagnosis or a prescription. Bring it to your clinician to decide together.',
+  };
+}

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -16,6 +16,7 @@ import { discovery, patientSummaryCards, medReconciliationCards } from './cds/cd
 import { deidentify } from './deident.js';
 import { ask } from './ask.js';
 import { codeText, type CodedEntity } from './clinical.js';
+import { guidance } from './guidelines.js';
 import { openConsult, reviewerView, submitOpinion, aggregate, requestMore, type Confidence } from './consult.js';
 
 const PORT = Number(process.env.PORT ?? 8097);
@@ -236,6 +237,10 @@ const server = http.createServer(async (req, res) => {
 
   // ── Wall 4: de-identification + blinded n-ary consults (the moat). Non-diagnostic; the aggregate is a
   // concordance signal, a clinician decides. ────────────────────────────────────────────────────────
+
+  // Guideline-grounded guidance — the twin's own numbers → cited, non-diagnostic recommendations
+  // grounded in real clinical guidelines (ACC/AHA, ADA, USPSTF, KDIGO).
+  if (req.method === 'GET' && url.pathname === '/api/health/guidance') return send(res, 200, guidance());
 
   // Clinical coder — free text → coded facts (conditions→SNOMED, meds→RxNorm, labs→LOINC) + negation.
   // Clinical-terminology extraction for the cardiometabolic wedge; non-diagnostic (labels, not diagnoses).

--- a/apps/socioprophet-web/src/pages/AskTwin.vue
+++ b/apps/socioprophet-web/src/pages/AskTwin.vue
@@ -2,12 +2,20 @@
 // Ask-my-agent — the patient's magic. Ask in plain words; the twin recalls from a lifetime of records
 // and answers WITH the sources cited + their trust tier. Local-first (sovereign); non-diagnostic.
 import { ref } from 'vue';
-import { askTwin, type AskAnswer } from '../services/healthTwinApi';
+import { askTwin, guidance, type AskAnswer, type GuidanceItem } from '../services/healthTwinApi';
 
 const q = ref('');
 const ans = ref<AskAnswer | null>(null);
 const busy = ref(false);
 const err = ref('');
+const guide = ref<GuidanceItem[] | null>(null);
+const gBusy = ref(false);
+async function loadGuidance() {
+  gBusy.value = true; err.value = '';
+  try { guide.value = (await guidance()).items; }
+  catch (e) { err.value = e instanceof Error ? e.message : 'guidance failed'; }
+  finally { gBusy.value = false; }
+}
 const examples = [
   'where did I hurt my knee as a kid',
   'are my cholesterol numbers going up',
@@ -38,9 +46,21 @@ const kindIcon: Record<string, string> = { lab: '🧪', condition: '⚕', encoun
     </div>
     <div class="ask-ex">
       <button v-for="e in examples" :key="e" class="ex" @click="ask(e)">{{ e }}</button>
+      <button class="ex guide-btn" @click="loadGuidance">{{ gBusy ? 'checking…' : '⟢ what do the guidelines say about my numbers?' }}</button>
     </div>
 
     <p v-if="err" class="ask-err">{{ err }}</p>
+
+    <!-- guideline-grounded, cited, non-diagnostic guidance over the twin's own numbers -->
+    <div v-if="guide" class="guide">
+      <div class="guide-h">What the guidelines say about your numbers <span>cited · not a diagnosis</span></div>
+      <div v-for="(g, i) in guide" :key="i" class="g-item">
+        <div class="g-top"><span class="g-str" :data-s="g.strength">{{ g.strength }}</span><b>{{ g.finding }}</b></div>
+        <p class="g-says">{{ g.says }}</p>
+        <span class="g-src">⟢ {{ g.source }}</span>
+      </div>
+      <p v-if="!guide.length" class="ask-err" style="color:var(--muted)">Your numbers don't trigger any guideline flags right now.</p>
+    </div>
 
     <div v-if="ans" class="ans">
       <p class="ans-q">“{{ ans.question }}”</p>
@@ -77,4 +97,13 @@ const kindIcon: Record<string, string> = { lab: '🧪', condition: '⚕', encoun
 .cite { display: grid; grid-template-columns: 18px 1fr auto; align-items: baseline; gap: 8px; padding: 5px 0; border-top: 1px solid var(--hairline); font-size: 13px; } .cite:first-of-type { border-top: 0; }
 .c-ic { text-align: center; } .c-tx { color: var(--ink-2); } .c-tier { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; }
 .ans-foot { font-size: 11px; color: var(--faint); margin: var(--sp-3) 0 0; }
+.guide-btn { border-style: dashed; border-color: var(--accent); color: var(--accent-ink); }
+.guide { margin-top: var(--sp-4); border-top: 1px solid var(--hairline); padding-top: var(--sp-3); }
+.guide-h { font-size: 12px; font-weight: 600; margin-bottom: 10px; } .guide-h span { font-weight: 400; color: var(--muted); font-size: 10.5px; margin-left: 6px; }
+.g-item { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--sunken); padding: var(--sp-3); margin-bottom: 8px; }
+.g-top { display: flex; align-items: baseline; gap: 8px; margin-bottom: 4px; } .g-top b { font-size: 13px; }
+.g-str { font-size: 9.5px; text-transform: uppercase; letter-spacing: .05em; border-radius: var(--pill); padding: 1px 8px; background: var(--sunken); color: var(--muted); border: 1px solid var(--hairline-strong); }
+.g-str[data-s="confirm"] { color: var(--warn); border-color: var(--warn); } .g-str[data-s="discuss"] { color: var(--accent-ink); background: var(--accent-wash); border-color: var(--accent); } .g-str[data-s="screen"] { color: var(--ok); border-color: var(--ok); }
+.g-says { font-size: 13px; line-height: 1.55; color: var(--ink-2); margin: 0 0 6px; }
+.g-src { font-size: 11px; color: var(--faint); }
 </style>

--- a/apps/socioprophet-web/src/services/healthTwinApi.ts
+++ b/apps/socioprophet-web/src/services/healthTwinApi.ts
@@ -107,6 +107,14 @@ export async function askTwin(q: string): Promise<AskAnswer> {
   return await res.json();
 }
 
+// guideline-grounded, cited, non-diagnostic guidance over the twin's own numbers
+export interface GuidanceItem { finding: string; says: string; source: string; strength: 'screen' | 'discuss' | 'monitor' | 'confirm'; cites: string[] }
+export async function guidance(): Promise<{ items: GuidanceItem[]; disclaimer: string }> {
+  const res = await fetch(`${BASE}/api/health/guidance`, { headers: { accept: 'application/json' } });
+  if (!res.ok) throw new Error(`guidance failed (${res.status})`);
+  return await res.json();
+}
+
 // ── Capture surface: voice notes / photos / documents → the twin, hash-sealed + tier-tagged ────────
 export interface CodedEntity { text: string; category: string; code: string; codeSystem: string; display: string; negated: boolean }
 export interface Captured { id: string; kind: 'note' | 'photo' | 'document'; caption: string; text?: string; tier: string; by: string; contentHash: string; organ?: string; system?: string; capturedAt: string; receipt: string; coded?: CodedEntity[] }


### PR DESCRIPTION
The reasoning-column blow that meets OpenEvidence/Med-PaLM on grounded clinical reasoning — but **sovereign, cited, non-diagnostic, and over the person's OWN record**. Synced from prophet-health@70286aa.

## What it does
`guidelines.ts` reads the twin's own labs/vitals/conditions and surfaces recommendations grounded in **real clinical guidelines**, each with its **source** and a **strength** (screen/discuss/monitor/confirm):
- LDL vs target → **ACC/AHA 2018 Cholesterol** (cross-fact aware: LDL + hypertension → higher CV-risk framing)
- HbA1c → **ADA Standards of Care** (prediabetes vs diabetes-range, with the ~58% progression-reduction fact)
- Systolic BP → **ACC/AHA 2017 BP** (stage 1 vs 2)
- eGFR → **KDIGO CKD**; age band → **USPSTF** screening

It **never diagnoses or prescribes** — *"here's what the guidelines say about your numbers; discuss with your clinician."* `GET /api/health/guidance`.

## UI
'What do the guidelines say about my numbers?' in **Ask my twin** → cited recommendation cards, strength-tagged, non-diagnostic footer.

**Verified live** over the seed twin: LDL 148 → ACC/AHA lipid guidance; A1c 5.9 → ADA prediabetes; BP 138 → ACC/AHA stage-1; age 50s → USPSTF colorectal. `vue-tsc` + invariants green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)