### PR TITLE
health-twin: brain grounding + attested community aggregation (first TEE slice)

### DIFF
--- a/apps/health-twin/src/ask.ts
+++ b/apps/health-twin/src/ask.ts
@@ -5,9 +5,10 @@
 // semantic grounding on top — but the twin answers on its own node first. Non-diagnostic: it recalls and
 // cites the person's records; it does not diagnose.
 import { SUBJECT, SYSTEMS, OBSERVATIONS, CONDITIONS, ENCOUNTERS, IMAGING, MEDICATIONS, ALLERGIES, IMMUNIZATIONS } from './data.js';
+import { ground, type Grounded } from './knowledge.js';
 
 export interface Citation { id: string; kind: 'lab' | 'condition' | 'encounter' | 'imaging' | 'medication' | 'allergy' | 'immunization'; text: string; date?: string; tier?: string; system?: string }
-export interface AskAnswer { question: string; answer: string; citations: Citation[]; retrieval: 'local-recall' | 'local-recall+hellgraph'; nonDiagnostic: true }
+export interface AskAnswer { question: string; answer: string; citations: Citation[]; retrieval: 'local-recall' | 'local-recall+hellgraph'; grounded?: Grounded; nonDiagnostic: true }
 
 // build a flat, searchable index of every record in the twin (each row keeps its provenance for citing)
 interface Row { id: string; kind: Citation['kind']; text: string; hay: string; date?: string; tier?: string; system?: string }
@@ -57,5 +58,8 @@ export function ask(question: string): AskAnswer {
     const lead = hits.length === 1 ? 'Here\'s the record that matches:' : `Here's what your records show (${hits.length} related records${oldest.date ? `, earliest ${oldest.date}` : ''}):`;
     answer = `${lead}\n` + hits.map((r) => `• ${r.text}${r.tier ? ` [${r.tier}]` : ''}`).join('\n') + `\n\nThese are your own records, cited above — not a diagnosis. Your clinician can help interpret them.`;
   }
-  return { question: q, answer, citations, retrieval: 'local-recall', nonDiagnostic: true };
+  // ground the question in authoritative medical knowledge too (cited, evidence-tiered) — so the
+  // person gets their own records AND what the medicine says. Brain corpus plugs in behind ground().
+  const g = ground(q);
+  return { question: q, answer, citations, retrieval: 'local-recall', grounded: g.grounded ? g : undefined, nonDiagnostic: true };
 }

--- a/apps/health-twin/src/enclave.ts
+++ b/apps/health-twin/src/enclave.ts
@@ -1,0 +1,90 @@
+// First slice of the doctor community over confidential compute. Runs the blinded-consult aggregation
+// INSIDE an attested enclave over a SCOPED COMMUNITY POOL: de-identified case results from many providers
+// are pooled by scope (region / specialty / evidence tier / practice type), aggregated into a community
+// concordance signal, and returned with an ATTESTATION (which code ran, over which inputs, producing
+// which output — as digests, never the raw data) + a receipt.
+//
+// HONEST: this is a walking skeleton. The attestation here is a hash-based stand-in for a real TEE quote
+// (AWS Nitro Enclave / Intel TDX-SGX / AMD SEV-SNP measurement). The pool is synthetic. What's REAL is
+// the CONTRACT — the enclave sees de-identified inputs only and emits digests + a result, never raw data
+// — and the shape a real enclave will fill. Non-diagnostic: it aggregates blinded opinions; a clinician
+// decides.
+
+function djb2(s: string): string { let h = 5381; for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff; return (h >>> 0).toString(16).padStart(8, '0'); }
+
+export interface Scope { region?: string; specialty?: string; evidenceTier?: string; practiceType?: string }
+
+// A de-identified case result a provider's blinded panel contributed to the community pool. NO patient
+// data — only the panel's outcome. This is what crosses into the enclave.
+interface PoolCase { caseId: string; scope: Required<Scope>; verdict: 'unanimous' | 'majority' | 'split'; topRead: string; n: number }
+
+// synthetic community pool (stands in for federated, consented, de-identified panels across providers)
+const POOL: PoolCase[] = [
+  { caseId: 'c1', scope: { region: 'US', specialty: 'cardiology', evidenceTier: 'real-world', practiceType: 'academic' }, verdict: 'majority', topRead: 'Early hypertension — monitor + lifestyle', n: 3 },
+  { caseId: 'c2', scope: { region: 'US', specialty: 'cardiology', evidenceTier: 'real-world', practiceType: 'community' }, verdict: 'unanimous', topRead: 'Early hypertension — monitor + lifestyle', n: 4 },
+  { caseId: 'c3', scope: { region: 'EU', specialty: 'cardiology', evidenceTier: 'guideline', practiceType: 'academic' }, verdict: 'majority', topRead: 'Early hypertension — monitor + lifestyle', n: 5 },
+  { caseId: 'c4', scope: { region: 'EU', specialty: 'cardiology', evidenceTier: 'guideline', practiceType: 'community' }, verdict: 'split', topRead: 'More tests before labeling', n: 4 },
+  { caseId: 'c5', scope: { region: 'US', specialty: 'internal-medicine', evidenceTier: 'real-world', practiceType: 'community' }, verdict: 'majority', topRead: 'Confirm readings; recheck lipids', n: 3 },
+  { caseId: 'c6', scope: { region: 'AU', specialty: 'cardiology', evidenceTier: 'guideline', practiceType: 'community' }, verdict: 'unanimous', topRead: 'Early hypertension — monitor + lifestyle', n: 3 },
+  { caseId: 'c7', scope: { region: 'US', specialty: 'cardiology', evidenceTier: 'trial', practiceType: 'academic' }, verdict: 'majority', topRead: 'Statin discussion given LDL + risk', n: 6 },
+  { caseId: 'c8', scope: { region: 'EU', specialty: 'internal-medicine', evidenceTier: 'guideline', practiceType: 'academic' }, verdict: 'split', topRead: 'Secondary workup first', n: 4 },
+];
+
+export interface Attestation {
+  enclave: 'skeleton-tee';
+  measurement: string;   // hash of the code identity/version — a real TEE's PCR/MRENCLAVE analogue
+  inputsDigest: string;  // hash of the de-identified pooled inputs — proves what was computed on, not the data
+  outputDigest: string;  // hash of the result
+  scope: Scope;
+  note: string;
+  at: string;
+}
+
+const CODE_ID = 'blinded-community-aggregate@v1'; // what a real enclave would measure
+
+const matches = (c: PoolCase, s: Scope) =>
+  (!s.region || c.scope.region === s.region) && (!s.specialty || c.scope.specialty === s.specialty) &&
+  (!s.evidenceTier || c.scope.evidenceTier === s.evidenceTier) && (!s.practiceType || c.scope.practiceType === s.practiceType);
+
+// The attested computation. In a real enclave this body runs inside the TEE; here it runs in-process but
+// honours the contract: it reads only de-identified pool cases and returns a signal + digests.
+export function communityAggregate(scope: Scope) {
+  const cases = POOL.filter((c) => matches(c, scope));
+  const n = cases.length;
+  const inputsDigest = `sha-${djb2(JSON.stringify(cases.map((c) => c.caseId).sort()))}`;
+
+  // pool the blinded verdicts + reads into a community signal — no single case is identifiable
+  const verdicts = { unanimous: 0, majority: 0, split: 0 } as Record<PoolCase['verdict'], number>;
+  const reads = new Map<string, number>();
+  for (const c of cases) { verdicts[c.verdict]++; reads.set(c.topRead, (reads.get(c.topRead) ?? 0) + 1); }
+  const concordant = verdicts.unanimous + verdicts.majority;
+  const commonReads = [...reads.entries()].sort((a, b) => b[1] - a[1]).map(([read, count]) => ({ read, count }));
+
+  const signal = {
+    scope, cases: n, opinions: cases.reduce((t, c) => t + c.n, 0),
+    concordanceRate: n ? Math.round((concordant / n) * 100) / 100 : 0,
+    verdicts, commonReads,
+    reading: n === 0 ? 'no cases in this scope yet'
+      : concordant / n >= 0.7 ? `across ${n} blinded panels in this scope, most reached a concordant read — commonly: "${commonReads[0]?.read}"`
+      : `across ${n} blinded panels in this scope, reads are mixed — a case worth more independent review`,
+  };
+
+  const outputDigest = `sha-${djb2(JSON.stringify({ verdicts, commonReads, n }))}`;
+  const attestation: Attestation = {
+    enclave: 'skeleton-tee', measurement: `sha-${djb2(CODE_ID)}`, inputsDigest, outputDigest, scope,
+    note: 'Skeleton attestation (hash stand-in for a real TEE quote). The enclave sees de-identified pooled inputs only and emits digests + the result — never the raw data. Real deployment: AWS Nitro Enclave / Intel TDX-SGX / AMD SEV-SNP.',
+    at: new Date().toISOString(),
+  };
+  return {
+    signal, attestation,
+    receipt: { id: `ht-community-${djb2([inputsDigest, outputDigest].join('|'))}`, verifier: 'health-twin-enclave', at: new Date().toISOString() },
+    disclaimer: 'A community concordance signal from blinded, de-identified panels — computed under attestation, not a diagnosis. A clinician decides.',
+  };
+}
+
+// what scopes the pool actually spans (for the UI to offer real filters)
+export function communityScopes() {
+  const dims: Record<string, Set<string>> = { region: new Set(), specialty: new Set(), evidenceTier: new Set(), practiceType: new Set() };
+  for (const c of POOL) for (const k of Object.keys(dims)) dims[k]!.add((c.scope as any)[k]);
+  return { poolSize: POOL.length, region: [...dims.region!], specialty: [...dims.specialty!], evidenceTier: [...dims.evidenceTier!], practiceType: [...dims.practiceType!] };
+}

--- a/apps/health-twin/src/eval.ts
+++ b/apps/health-twin/src/eval.ts
@@ -8,6 +8,7 @@
 // Run: `npx tsx src/eval.ts`. Exits non-zero if any metric falls below its floor — so quality is gated.
 import { codeText } from './clinical.js';
 import { guidance } from './guidelines.js';
+import { ground } from './knowledge.js';
 
 interface Gold { code: string; negated: boolean; value?: string }
 interface Case { text: string; gold: Gold[] }
@@ -66,23 +67,39 @@ function evalGuidance() {
   return { want: want.length, hit: hit.length, acc: hit.length / want.length };
 }
 
+// grounding: does a clinical-knowledge question retrieve the right authoritative source?
+function evalGrounding() {
+  const cases: { q: string; source: string }[] = [
+    { q: 'what does prediabetes mean', source: 'ADA Standards of Care in Diabetes' },
+    { q: 'what does a statin do', source: 'Cholesterol Treatment Trialists’ meta-analyses' },
+    { q: 'what is my egfr and kidney function', source: 'KDIGO Chronic Kidney Disease Guideline' },
+    { q: 'what are blood pressure stages', source: 'ACC/AHA 2017 High Blood Pressure Guideline' },
+  ];
+  let hit = 0;
+  for (const c of cases) { const g = ground(c.q); if (g.grounded && g.citations.some((x) => x.source === c.source)) hit++; }
+  return { hit, total: cases.length, acc: hit / cases.length };
+}
+
 const pct = (x: number) => `${(x * 100).toFixed(1)}%`;
 const cod = evalCoding();
 const gud = evalGuidance();
+const grd = evalGrounding();
 
 console.log('\n═══ prophet-health clinical eval (honest — NOT MedQA) ═══');
 console.log(`  Clinical coding   precision ${pct(cod.precision)} · recall ${pct(cod.recall)} · F1 ${pct(cod.f1)}   (tp ${cod.tp} fp ${cod.fp} fn ${cod.fn})`);
 console.log(`  Negation          accuracy  ${pct(cod.negAcc)}`);
 console.log(`  Value extraction  accuracy  ${pct(cod.valAcc)}`);
 console.log(`  Guideline firing  ${gud.hit}/${gud.want}  ${pct(gud.acc)}`);
-console.log('  (measures OUR capabilities — coding/negation/values/guidance — not full clinical QA)');
+console.log(`  Grounding source  ${grd.hit}/${grd.total}  ${pct(grd.acc)}   (right authoritative source cited)`);
+console.log('  (measures OUR capabilities — coding/negation/values/guidance/grounding — not full clinical QA)');
 
 // quality floors — the build fails if we regress below these
-const floors = { f1: 0.85, negAcc: 0.9, valAcc: 0.9, guidance: 1.0 };
+const floors = { f1: 0.85, negAcc: 0.9, valAcc: 0.9, guidance: 1.0, grounding: 1.0 };
 const fails: string[] = [];
 if (cod.f1 < floors.f1) fails.push(`F1 ${pct(cod.f1)} < ${pct(floors.f1)}`);
 if (cod.negAcc < floors.negAcc) fails.push(`negation ${pct(cod.negAcc)} < ${pct(floors.negAcc)}`);
 if (cod.valAcc < floors.valAcc) fails.push(`values ${pct(cod.valAcc)} < ${pct(floors.valAcc)}`);
 if (gud.acc < floors.guidance) fails.push(`guidance ${pct(gud.acc)} < ${pct(floors.guidance)}`);
+if (grd.acc < floors.grounding) fails.push(`grounding ${pct(grd.acc)} < ${pct(floors.grounding)}`);
 console.log(fails.length ? `\n✗ below floor: ${fails.join(' · ')}` : '\n✓ all metrics above floor');
 process.exit(fails.length ? 1 : 0);

--- a/apps/health-twin/src/knowledge.ts
+++ b/apps/health-twin/src/knowledge.ts
@@ -1,0 +1,86 @@
+// Medical knowledge grounding — the "ground our answers in real medical texts" attack. A clinical
+// question gets a plain-language explanation CITED to an authoritative source, tagged with an evidence
+// tier. This is a starter CC/guideline-sourced knowledge base for the cardiometabolic wedge; the SAME
+// interface (`ground(question)`) is what the estate's BRAIN (board-exam corpus / medical texts) plugs
+// into behind — see groundFromBrain(). Non-diagnostic: it explains, it does not diagnose or prescribe.
+
+export type EvidenceTier = 'clinical-guideline' | 'systematic-review' | 'textbook-reference' | 'consensus';
+
+interface Topic { id: string; terms: string[]; explains: string; source: string; tier: EvidenceTier }
+
+// Curated, sourced facts. Each `explains` is plain-language; each carries its authoritative `source`.
+const KB: Topic[] = [
+  { id: 'prediabetes', terms: ['prediabetes', 'pre-diabetes', 'a1c', 'impaired glucose', 'blood sugar'], tier: 'clinical-guideline', source: 'ADA Standards of Care in Diabetes',
+    explains: 'Prediabetes means blood sugar is higher than normal but not yet diabetes — an A1c of 5.7–6.4%. It is a warning sign, not a diagnosis of diabetes, and it is often reversible: intensive lifestyle change (about 7% weight loss + regular activity) cuts progression to type-2 diabetes by roughly 58%.' },
+  { id: 'type2diabetes', terms: ['type 2 diabetes', 'diabetes', 't2dm', 'metformin'], tier: 'clinical-guideline', source: 'ADA Standards of Care in Diabetes',
+    explains: 'Type-2 diabetes is diagnosed at A1c ≥6.5% (confirmed). Metformin is usually the first-line medication; newer agents (SGLT2 inhibitors, GLP-1 agonists) are added based on heart and kidney factors.' },
+  { id: 'hypertension', terms: ['hypertension', 'high blood pressure', 'blood pressure', 'bp', 'systolic'], tier: 'clinical-guideline', source: 'ACC/AHA 2017 High Blood Pressure Guideline',
+    explains: 'Blood pressure is staged: normal <120/80, elevated 120–129 systolic, stage-1 130–139 (or 80–89 diastolic), stage-2 ≥140/90. A single reading does not diagnose it — it takes repeated, confirmed out-of-office readings.' },
+  { id: 'ldl', terms: ['ldl', 'cholesterol', 'bad cholesterol', 'lipids', 'hyperlipidemia'], tier: 'clinical-guideline', source: 'ACC/AHA 2018 Blood Cholesterol Guideline',
+    explains: 'LDL ("bad") cholesterol drives plaque in arteries; a common target is under 100 mg/dL, and lower for higher-risk people. Whether to treat depends on your overall 10-year cardiovascular risk (an ASCVD estimate), not the number alone.' },
+  { id: 'statins', terms: ['statin', 'atorvastatin', 'rosuvastatin', 'simvastatin', 'lipitor'], tier: 'systematic-review', source: 'Cholesterol Treatment Trialists’ meta-analyses',
+    explains: 'Statins lower LDL and, across large trials, reduce heart attacks and strokes roughly proportional to the LDL drop. Benefit is clearest in four groups: known cardiovascular disease, LDL ≥190, diabetes aged 40–75, or elevated 10-year risk.' },
+  { id: 'ascvd', terms: ['ascvd', 'cardiovascular risk', 'heart risk', '10-year risk'], tier: 'clinical-guideline', source: 'ACC/AHA Pooled Cohort Equations',
+    explains: 'The 10-year ASCVD risk estimate combines age, sex, blood pressure, cholesterol, diabetes, and smoking to gauge heart-attack/stroke risk — it is how clinicians decide whether cholesterol or blood-pressure treatment is worth it for you.' },
+  { id: 'egfr', terms: ['egfr', 'gfr', 'kidney', 'creatinine', 'ckd', 'renal'], tier: 'clinical-guideline', source: 'KDIGO Chronic Kidney Disease Guideline',
+    explains: 'eGFR estimates how well the kidneys filter. Below 60 for at least 3 months (or albumin in the urine) meets the threshold for chronic kidney disease. Mild reductions are common and are usually monitored, especially alongside blood pressure and diabetes.' },
+  { id: 'a1c-test', terms: ['hemoglobin a1c', 'hba1c', 'glycated'], tier: 'textbook-reference', source: 'MedlinePlus / clinical reference',
+    explains: 'HbA1c reflects average blood sugar over the past ~3 months. It is not affected by a single meal, which is why it is used to screen for and monitor diabetes.' },
+  { id: 'knee-sprain', terms: ['sprain', 'knee', 'knee injury', 'ligament'], tier: 'textbook-reference', source: 'StatPearls (knee sprain)',
+    explains: 'A sprain is a stretched or torn ligament. A normal X-ray rules out fracture but not soft-tissue injury. Most simple sprains heal with rest, ice, compression, and elevation (RICE) over a few weeks.' },
+  { id: 'lifestyle', terms: ['lifestyle', 'diet', 'exercise', 'weight loss', 'prevention'], tier: 'systematic-review', source: 'Diabetes Prevention Program (DPP)',
+    explains: 'For prediabetes and cardiovascular risk, structured lifestyle change — modest weight loss plus ~150 minutes of activity weekly — outperformed medication for preventing diabetes in the landmark DPP trial.' },
+];
+
+export interface Grounded {
+  question: string;
+  grounded: boolean;
+  answer: string;
+  citations: { topic: string; source: string; tier: EvidenceTier }[];
+  retrieval: 'local-kb' | 'brain';
+}
+
+const words = (s: string) => s.toLowerCase().replace(/[^a-z0-9 ]/g, ' ').split(/\s+/).filter(Boolean);
+
+// Ground a clinical question in the knowledge base: retrieve the best-matching sourced topics and
+// compose a cited explanation. Deterministic; every sentence traces to a named source.
+export function ground(question: string): Grounded {
+  const q = String(question || '').trim();
+  const ws = new Set(words(q));
+  const scored = KB.map((t) => ({ t, score: t.terms.reduce((n, term) => n + (term.split(' ').every((w) => ws.has(w)) ? 1 : 0), 0) }))
+    .filter((x) => x.score > 0).sort((a, b) => b.score - a.score);
+  const hits = scored.slice(0, 2).map((x) => x.t);
+  if (hits.length === 0) return { question: q, grounded: false, answer: '', citations: [], retrieval: 'local-kb' };
+  return {
+    question: q, grounded: true,
+    answer: hits.map((t) => t.explains).join(' '),
+    citations: hits.map((t) => ({ topic: t.id, source: t.source, tier: t.tier })),
+    retrieval: 'local-kb',
+  };
+}
+
+// The estate's BRAIN: the Noetica agent-machine serves 125k USMLE-textbook chunks (MedRAG) behind
+// POST /api/study/retrieve {query, fields:["medicine"], topK}. When NOETICA_AM_URL is set (and the
+// medicine field is vectorized + the server is up), this grounds answers in that real corpus with
+// citations; otherwise it returns null and the caller falls back to the local sourced KB. Same Grounded
+// shape either way, so nothing downstream changes. (Reuse-first: we ground in the brain we already test.)
+interface StudyHit { text: string; slug?: string; source?: string; material?: string; score?: number }
+export async function groundFromBrain(question: string): Promise<Grounded | null> {
+  const url = process.env.NOETICA_AM_URL;
+  if (!url) return null;
+  const ac = new AbortController(); const t = setTimeout(() => ac.abort(), 5000);
+  try {
+    const r = await fetch(`${url}/api/study/retrieve`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ query: question, fields: ['medicine'], topK: 6 }), signal: ac.signal });
+    if (!r.ok) return null;
+    const d = (await r.json()) as { hits?: StudyHit[] };
+    const hits = (d.hits ?? []).slice(0, 3);
+    if (hits.length === 0) return null;
+    return {
+      question, grounded: true,
+      answer: hits.map((h) => h.text.trim()).join(' '),
+      citations: hits.map((h) => ({ topic: h.slug ?? 'passage', source: h.source ?? h.material ?? 'USMLE textbook corpus (MedRAG)', tier: 'textbook-reference' as EvidenceTier })),
+      retrieval: 'brain',
+    };
+  } catch { return null; }
+  finally { clearTimeout(t); }
+}

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -15,6 +15,8 @@ import { serviceHealth, reasonTurtle, graphGround } from './reconcile/clients.js
 import { discovery, patientSummaryCards, medReconciliationCards } from './cds/cds.js';
 import { deidentify } from './deident.js';
 import { ask } from './ask.js';
+import { ground, groundFromBrain } from './knowledge.js';
+import { communityAggregate, communityScopes, type Scope } from './enclave.js';
 import { codeText, type CodedEntity } from './clinical.js';
 import { guidance } from './guidelines.js';
 import { openConsult, reviewerView, submitOpinion, aggregate, requestMore, type Confidence } from './consult.js';
@@ -254,8 +256,23 @@ const server = http.createServer(async (req, res) => {
   // Ask-my-agent — conversational recall over the twin, cited + non-diagnostic. Local-first (sovereign):
   // answers on the person's own node; hellgraph semantic grounding is additive when reachable.
   if (req.method === 'POST' && url.pathname === '/api/health/ask') {
-    try { const b = await readJson(req); return send(res, 200, ask(String(b.q ?? b.question ?? ''))); }
-    catch (e) { return send(res, 400, { error: (e as Error).message || 'ask failed' }); }
+    try {
+      const b = await readJson(req); const q = String(b.q ?? b.question ?? '');
+      const a = ask(q);
+      const brain = await groundFromBrain(q); // prefer the estate's brain corpus when wired; else local KB
+      if (brain && brain.grounded) a.grounded = brain;
+      return send(res, 200, a);
+    } catch (e) { return send(res, 400, { error: (e as Error).message || 'ask failed' }); }
+  }
+
+  // Explain — a clinical-knowledge question grounded in authoritative medical sources (cited, tiered).
+  // Uses the estate's brain corpus when wired (HT_BRAIN_URL), else the local sourced knowledge base.
+  if (req.method === 'POST' && url.pathname === '/api/health/explain') {
+    try {
+      const b = await readJson(req); const q = String(b.q ?? b.question ?? '');
+      const brain = await groundFromBrain(q);
+      return send(res, 200, brain && brain.grounded ? brain : ground(q));
+    } catch (e) { return send(res, 400, { error: (e as Error).message || 'explain failed' }); }
   }
 
   // Capture — a voice note / photo / document lands in the twin, hash-sealed + tier-tagged. The doctor's
@@ -279,6 +296,15 @@ const server = http.createServer(async (req, res) => {
       captured.unshift(rec);
       return send(res, 200, { captured: rec, count: captured.length });
     } catch (e) { return send(res, 400, { error: (e as Error).message || 'capture failed' }); }
+  }
+
+  // ── Doctor community over confidential compute (first slice): blinded-consult aggregation run INSIDE
+  // an attested enclave over a SCOPED community pool. The enclave sees de-identified inputs only and
+  // emits digests + a result — never raw data. Skeleton attestation; real deployment = Nitro/SGX/SEV. ──
+  if (req.method === 'GET' && url.pathname === '/api/health/community/scopes') return send(res, 200, communityScopes());
+  if (req.method === 'POST' && url.pathname === '/api/health/community/aggregate') {
+    try { const b = await readJson(req); return send(res, 200, communityAggregate((b.scope ?? {}) as Scope)); }
+    catch (e) { return send(res, 400, { error: (e as Error).message || 'aggregate failed' }); }
   }
 
   // A de-identified view of the twin (Safe-Harbor + date-shift) — proof identity is gone.

--- a/deploy/values/health-twin.yaml
+++ b/deploy/values/health-twin.yaml
@@ -20,5 +20,8 @@ config:
   HT_HELLGRAPH_URL: "http://hellgraph-service.socioprophet.svc.cluster.local:8090" # land + hybrid semantic search
   HT_OWL_URL: "http://owl-reasoner.socioprophet.svc.cluster.local:8080"            # TTL → entailments
   HT_EMBEDDINGS_URL: "http://embeddings.socioprophet.svc.cluster.local:8080/v1/embeddings"
+  # The estate's medical BRAIN (Noetica agent-machine, 125k USMLE-textbook chunks): grounds Ask/Explain
+  # in cited medical texts via /api/study/retrieve. Degrades to the local sourced KB if unreachable.
+  NOETICA_AM_URL: "http://agent-machine.socioprophet.svc.cluster.local:8080"
   # SMART launch link base for CDS Hooks cards (the cockpit's /health surface).
   SMART_APP_BASE: "https://socioprophet.md"


### PR DESCRIPTION
Two moves — grounding answers in the estate's real medical brain, and the first slice of the doctor community over confidential compute. Synced from prophet-health@88fb80a.

## Grounding — answers grounded in cited medical knowledge
- `knowledge.ts` — a starter CC/guideline-sourced KB; a clinical question → a plain, **cited, evidence-tiered** explanation.
- **Wired to the real brain:** `groundFromBrain()` calls the estate's **Noetica agent-machine** (`POST /api/study/retrieve`, the **125k USMLE-textbook MedRAG chunks** the estate already benchmarks) via `NOETICA_AM_URL` (added to deploy config, in-cluster DNS) — graceful fallback to the local KB when unreachable. Same `Grounded` shape either way.
- **Ask** now returns *your records* + *what the medicine says*, each cited; + `POST /api/health/explain`. Eval gains a grounding-source check (right authoritative source cited), floored + in CI. **Eval now: coding F1 98% · negation 96% · values 100% · guidance 3/3 · grounding 4/4.**

## Doctor community — first slice (confidential compute)
`enclave.ts` — the blinded-consult aggregation runs **inside an attested enclave** over a **scoped community pool** (region / specialty / evidence-tier / practice-type). The enclave sees de-identified case results only and emits an **attestation** (measurement + input-digest + output-digest — never raw data) + a receipt. Walking skeleton (hash stand-in for a real Nitro/SGX/SEV quote; synthetic pool) — but the **contract is real**. `GET /api/health/community/scopes`, `POST /api/health/community/aggregate {scope}`.

**Verified live:** EU-cardiology pool → mixed-read flag ('worth more review'); US-cardiology → concordant signal ('early hypertension — monitor'); each attested + receipted. Non-diagnostic; synthetic data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)