### PR TITLE
health-twin: patient + doctor charts (iPad clinician chart, care team, easy entry)

### DIFF
--- a/apps/health-twin/src/providers.ts
+++ b/apps/health-twin/src/providers.ts
@@ -1,0 +1,51 @@
+// Provider directory + care team. Two charts need this: the PATIENT chart shows who their doctors are —
+// specialty, years in practice, credentials, verified — with a profile they can review; the DOCTOR chart
+// shows the care team on a patient's record. Providers are derived from the encounters/records that
+// reference them. Verified = a real, licensed clinician (the trust primitive the community depends on).
+import { ENCOUNTERS } from './data.js';
+
+export interface Provider {
+  id: string; name: string; specialty: string; role: string;
+  since: number;          // year they began practising
+  credentials: string;    // e.g. "MD, FACC"
+  org: string; location: string;
+  npi?: string;           // National Provider Identifier (verification anchor)
+  verified: boolean;      // credential + license verified
+  match: string[];        // strings that appear in a record's provider field
+}
+
+export const PROVIDERS: Provider[] = [
+  { id: 'prov-rivera', name: 'Dr. Ana Rivera', specialty: 'Cardiology', role: 'Cardiologist', since: 2009, credentials: 'MD, FACC', org: 'Bay Cardiology Associates', location: 'San Francisco, CA', npi: '1063494177', verified: true, match: ['rivera'] },
+  { id: 'prov-okafor', name: 'Dr. James Okafor', specialty: 'Family Medicine', role: 'Primary care physician', since: 2014, credentials: 'MD', org: 'Mission Family Health', location: 'San Francisco, CA', npi: '1730346588', verified: true, match: ['okafor'] },
+  { id: 'prov-labcorp', name: 'LabCorp', specialty: 'Clinical Laboratory', role: 'Diagnostic lab', since: 1978, credentials: 'CLIA-certified', org: 'Laboratory Corporation of America', location: 'Burlington, NC', verified: true, match: ['labcorp'] },
+  { id: 'prov-radiology', name: 'Bay Imaging — Radiology', specialty: 'Radiology', role: 'Imaging center', since: 1996, credentials: 'ACR-accredited', org: 'Bay Imaging', location: 'San Francisco, CA', verified: true, match: ['radiology'] },
+  { id: 'prov-peds-er', name: 'Children’s Hospital ER', specialty: 'Emergency Medicine', role: 'Emergency department', since: 1985, credentials: 'ACS-verified', org: 'Children’s Hospital', location: 'Oakland, CA', verified: true, match: ['pediatric er', 'children'] },
+];
+
+export const yearsInPractice = (p: Provider): number => Math.max(0, new Date().getFullYear() - p.since);
+
+const find = (provider: string): Provider | undefined => {
+  const p = provider.toLowerCase();
+  return PROVIDERS.find((prov) => prov.match.some((m) => p.includes(m)));
+};
+
+// The care team on this record: which providers appear, when they were last seen, how many visits.
+export function careTeam() {
+  const seen = new Map<string, { provider: Provider; visits: number; lastSeen: string; firstSeen: string }>();
+  for (const e of ENCOUNTERS) {
+    const prov = find(e.provider);
+    if (!prov) continue;
+    const cur = seen.get(prov.id);
+    if (cur) { cur.visits++; if (e.date > cur.lastSeen) cur.lastSeen = e.date; if (e.date < cur.firstSeen) cur.firstSeen = e.date; }
+    else seen.set(prov.id, { provider: prov, visits: 1, lastSeen: e.date, firstSeen: e.date });
+  }
+  return [...seen.values()]
+    .sort((a, b) => (a.lastSeen < b.lastSeen ? 1 : -1))
+    .map((x) => ({ ...x.provider, yearsInPractice: yearsInPractice(x.provider), visits: x.visits, lastSeen: x.lastSeen, firstSeen: x.firstSeen }));
+}
+
+export const provider = (id: string) => {
+  const p = PROVIDERS.find((x) => x.id === id);
+  return p ? { ...p, yearsInPractice: yearsInPractice(p) } : null;
+};
+export const directory = () => PROVIDERS.map((p) => ({ ...p, yearsInPractice: yearsInPractice(p) }));

--- a/apps/health-twin/src/readings.ts
+++ b/apps/health-twin/src/readings.ts
@@ -1,0 +1,45 @@
+// Easy data entry — the key to the doctor chart. A device reading, a spoken phrase, or a typed line
+// ("BP 138/85, HR 72, glucose 110") becomes coded vital/lab observations, using the value-extracting
+// clinical coder. Same path whether it comes from a Bluetooth cuff, a voice note, or the keyboard.
+// tier = observed (device/self-entered); a clinician can later attest. Non-diagnostic.
+import { codeText } from './clinical.js';
+import { routeLoinc } from './ingest.js';
+
+export interface Reading {
+  id: string; system: string; organ: string; code: string; codeSystem: 'LOINC'; display: string;
+  value: number; unit: string; effective: string; epistemic: 'observed'; by: string; source: string;
+}
+
+// LOINC → { unit, display } for the codes the coder emits (vitals + common labs)
+const META: Record<string, { unit: string; display: string }> = {
+  '85354-9': { unit: 'mmHg', display: 'Blood pressure' }, '8480-6': { unit: 'mmHg', display: 'Systolic blood pressure' }, '8462-4': { unit: 'mmHg', display: 'Diastolic blood pressure' },
+  '8867-4': { unit: '/min', display: 'Heart rate' }, '59408-5': { unit: '%', display: 'Oxygen saturation' },
+  '29463-7': { unit: 'kg', display: 'Body weight' }, '39156-5': { unit: 'kg/m2', display: 'Body mass index' },
+  '2345-7': { unit: 'mg/dL', display: 'Glucose' }, '4548-4': { unit: '%', display: 'Hemoglobin A1c' },
+  '13457-7': { unit: 'mg/dL', display: 'LDL cholesterol' }, '2085-9': { unit: 'mg/dL', display: 'HDL cholesterol' },
+  '2571-8': { unit: 'mg/dL', display: 'Triglycerides' }, '2160-0': { unit: 'mg/dL', display: 'Creatinine' },
+  '33914-3': { unit: 'mL/min', display: 'eGFR' }, '1742-6': { unit: 'U/L', display: 'ALT' },
+};
+
+function mk(code: string, value: number, by: string, source: string): Reading {
+  const m = META[code] ?? { unit: '', display: code };
+  const { system, organ } = routeLoinc(code);
+  return { id: `rd-${code}-${Date.now()}-${Math.round(value)}`, system, organ, code, codeSystem: 'LOINC', display: m.display, value, unit: m.unit, effective: new Date().toISOString().slice(0, 10), epistemic: 'observed', by, source };
+}
+
+// Parse readings from free text/voice/device. Blood pressure "138/85" splits into systolic + diastolic.
+export function parseReadings(text: string, by = 'patient', source = 'manual'): Reading[] {
+  const out: Reading[] = [];
+  for (const e of codeText(text).entities) {
+    if ((e.category !== 'vital' && e.category !== 'lab') || !e.value || e.negated) continue;
+    if (e.code === '85354-9' && e.value.includes('/')) {
+      const [sys, dia] = e.value.split('/').map((n) => parseFloat(n));
+      if (!isNaN(sys!)) out.push(mk('8480-6', sys!, by, source));
+      if (!isNaN(dia!)) out.push(mk('8462-4', dia!, by, source));
+    } else {
+      const v = parseFloat(e.value);
+      if (!isNaN(v)) out.push(mk(e.code, v, by, source));
+    }
+  }
+  return out;
+}

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -17,6 +17,8 @@ import { deidentify } from './deident.js';
 import { ask } from './ask.js';
 import { ground, groundFromBrain } from './knowledge.js';
 import { communityAggregate, communityScopes, type Scope } from './enclave.js';
+import { directory, provider, careTeam } from './providers.js';
+import { parseReadings, type Reading } from './readings.js';
 import { codeText, type CodedEntity } from './clinical.js';
 import { guidance } from './guidelines.js';
 import { openConsult, reviewerView, submitOpinion, aggregate, requestMore, type Confidence } from './consult.js';
@@ -34,6 +36,9 @@ function receipt(kind: string, parts: string[]): { id: string; verifier: 'health
 
 // In-memory grant ledger (skeleton). Local-first store in production.
 const grants: Grant[] = [];
+
+// Entered readings — device / voice / keyboard vitals that became coded observations. Local-first store.
+const readings: Reading[] = [];
 
 // Capture surface — voice notes, photos, documents captured across devices land here, each hash-sealed
 // with provenance + an epistemic tier. A clinician's dictated note is 'attested'; a patient photo is
@@ -82,6 +87,7 @@ function bundle() {
     subject: SUBJECT,
     systems: bySystem,
     medications: MEDICATIONS, allergies: ALLERGIES, immunizations: IMMUNIZATIONS,
+    careTeam: careTeam(), readings,
     timeline: [...ENCOUNTERS].sort((a, b) => (a.date < b.date ? 1 : -1)),
     counts: { observations: OBSERVATIONS.length, conditions: CONDITIONS.length, encounters: ENCOUNTERS.length, imaging: IMAGING.length, medications: MEDICATIONS.length, allergies: ALLERGIES.length, immunizations: IMMUNIZATIONS.length },
     grants: grants.map((g) => ({ ...g, active: !g.revoked && new Date(g.expires_at) > new Date() })),
@@ -305,6 +311,23 @@ const server = http.createServer(async (req, res) => {
   if (req.method === 'POST' && url.pathname === '/api/health/community/aggregate') {
     try { const b = await readJson(req); return send(res, 200, communityAggregate((b.scope ?? {}) as Scope)); }
     catch (e) { return send(res, 400, { error: (e as Error).message || 'aggregate failed' }); }
+  }
+
+  // Provider directory + a provider's profile (the patient reviews who their doctors are).
+  if (req.method === 'GET' && url.pathname === '/api/health/providers') return send(res, 200, { providers: directory(), careTeam: careTeam() });
+  if (req.method === 'GET' && url.pathname.startsWith('/api/health/provider/')) {
+    const p = provider(url.pathname.slice('/api/health/provider/'.length));
+    return send(res, p ? 200 : 404, p ?? { error: 'provider not found' });
+  }
+
+  // Easy entry — a device reading / spoken phrase / typed line → coded vital+lab observations.
+  if (req.method === 'POST' && url.pathname === '/api/health/reading') {
+    try {
+      const b = await readJson(req);
+      const created = parseReadings(String(b.text ?? ''), b.by === 'clinician' ? 'clinician' : 'patient', String(b.source ?? 'manual'));
+      readings.unshift(...created);
+      return send(res, 200, { created, count: readings.length, receipt: receipt('reading', [String(created.length), String(Date.now())]) });
+    } catch (e) { return send(res, 400, { error: (e as Error).message || 'reading failed' }); }
   }
 
   // A de-identified view of the twin (Safe-Harbor + date-shift) — proof identity is gone.

--- a/apps/socioprophet-web/src/pages/DoctorChart.vue
+++ b/apps/socioprophet-web/src/pages/DoctorChart.vue
@@ -1,0 +1,167 @@
+<script setup lang="ts">
+// The physician's chart — built for an iPad at the bedside. The complete AUTHORIZED record (what the
+// patient granted), presented as a clinical chart: problems / meds / allergies up top, vitals with
+// one-tap voice/keyboard entry, labs with trends, and the full history as far back as it goes. Noetica's
+// intelligence, focused on the clinician. Non-diagnostic; a clinician decides.
+import { ref, computed, onMounted } from 'vue';
+import { loadTwin, addReading, type TwinBundle } from '../services/healthTwinApi';
+import Sparkline from '../components/Sparkline.vue';
+
+const twin = ref<TwinBundle | null>(null);
+const loading = ref(false);
+const err = ref('');
+const flash = ref('');
+async function load() {
+  loading.value = true; err.value = '';
+  try { twin.value = await loadTwin(); } catch (e) { err.value = e instanceof Error ? e.message : 'chart unreachable'; }
+  finally { loading.value = false; }
+}
+onMounted(load);
+
+const conditions = computed(() => twin.value?.systems.flatMap((s) => s.conditions) ?? []);
+const meds = computed(() => twin.value?.medications ?? []);
+const allergies = computed(() => twin.value?.allergies ?? []);
+const labs = computed(() => twin.value?.systems.flatMap((s) => s.observations) ?? []);
+const readings = computed(() => twin.value?.readings ?? []);
+const history = computed(() => [...(twin.value?.timeline ?? [])].sort((a, b) => (a.date < b.date ? 1 : -1)));
+const careTeam = computed(() => twin.value?.careTeam ?? []);
+const subj = computed(() => twin.value?.subject);
+function oor(o: { value: number; refHigh?: number; refLow?: number }) { return (o.refHigh != null && o.value > o.refHigh) || (o.refLow != null && o.value < o.refLow); }
+
+// quick reading entry — voice or keyboard
+const entry = ref('');
+const listening = ref(false);
+const busy = ref(false);
+const SR = typeof window !== 'undefined' ? ((window as any).SpeechRecognition || (window as any).webkitSpeechRecognition) : null;
+let rec: any = null;
+function toggleMic() {
+  if (!SR) return;
+  if (listening.value) { rec && rec.stop(); return; }
+  rec = new SR(); rec.continuous = true; rec.interimResults = true; rec.lang = 'en-US';
+  rec.onresult = (e: any) => { let f = ''; for (let i = e.resultIndex; i < e.results.length; i++) if (e.results[i].isFinal) f += e.results[i][0].transcript; if (f) entry.value = (entry.value + ' ' + f.trim()).trim(); };
+  rec.onend = () => { listening.value = false; };
+  rec.start(); listening.value = true;
+}
+async function submitReading() {
+  const t = entry.value.trim(); if (!t) return;
+  busy.value = true;
+  try { const r = await addReading(t, 'clinician', listening.value ? 'voice' : 'keyboard'); entry.value = ''; flash.value = `Recorded ${r.created.length} reading(s)`; setTimeout(() => (flash.value = ''), 2600); await load(); }
+  catch (e) { flash.value = e instanceof Error ? e.message : 'entry failed'; }
+  finally { busy.value = false; }
+}
+</script>
+
+<template>
+  <div class="dc">
+    <p class="dc-dx">⚕ Clinician chart — the patient's authorized record. Not a diagnosis; a clinician decides. Synthetic demo data.</p>
+    <p v-if="err" class="dc-err">{{ err }}</p>
+    <p v-else-if="loading && !twin" class="dc-msg">Loading chart…</p>
+
+    <template v-if="twin">
+      <!-- patient header + care team -->
+      <header class="dc-head">
+        <div class="dc-who">
+          <h1>{{ subj?.label }}</h1>
+          <span class="dc-demo">{{ subj?.ageBand }} · {{ subj?.sex }} · authorized record</span>
+        </div>
+        <div class="dc-team">
+          <span class="dc-team-h">Care team</span>
+          <div class="dc-team-list">
+            <span v-for="p in careTeam" :key="p.id" class="dc-doc" :title="`${p.credentials} · ${p.org} · ${p.location} · NPI ${p.npi || '—'}`">
+              <b>{{ p.name }}</b><i>{{ p.specialty }} · {{ p.yearsInPractice }}y</i><em v-if="p.verified" class="vf">✓</em>
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <!-- chart summary: what matters now -->
+      <section class="dc-grid3">
+        <div class="dc-card">
+          <div class="dc-card-h">Active problems</div>
+          <div v-for="c in conditions" :key="c.id" class="dc-line"><b>{{ c.display }}</b><span class="dc-sub">{{ c.codeSystem }} {{ c.code }} · {{ c.clinicalStatus }}</span></div>
+          <p v-if="!conditions.length" class="dc-empty">none recorded</p>
+        </div>
+        <div class="dc-card">
+          <div class="dc-card-h">Medications</div>
+          <div v-for="m in meds" :key="m.id" class="dc-line"><b>{{ m.display }}</b><span class="dc-sub">{{ m.dose }} · {{ m.status }}</span></div>
+          <p v-if="!meds.length" class="dc-empty">none recorded</p>
+        </div>
+        <div class="dc-card danger">
+          <div class="dc-card-h">Allergies</div>
+          <div v-for="a in allergies" :key="a.id" class="dc-line"><b>{{ a.display }}</b><span class="dc-sub">{{ a.reaction }} · {{ a.criticality }}</span></div>
+          <p v-if="!allergies.length" class="dc-empty">no known allergies</p>
+        </div>
+      </section>
+
+      <!-- vitals + one-tap entry -->
+      <section class="dc-card">
+        <div class="dc-card-h">Vitals &amp; readings <span class="dc-flash" v-if="flash">{{ flash }}</span></div>
+        <div class="dc-entry">
+          <input v-model="entry" class="dc-in" placeholder="Type or speak a reading — e.g. BP 138/85, HR 72, glucose 110" @keydown.enter="submitReading" />
+          <button v-if="SR" class="dc-mic" :class="{ on: listening }" @click="toggleMic">{{ listening ? '● stop' : '🎙' }}</button>
+          <button class="dc-add" :disabled="busy || !entry.trim()" @click="submitReading">Add</button>
+        </div>
+        <div v-if="readings.length" class="dc-vitals">
+          <span v-for="r in readings" :key="r.id" class="dc-vital"><b>{{ r.value }}</b> <i>{{ r.unit }}</i><small>{{ r.display }} · {{ r.source }}</small></span>
+        </div>
+      </section>
+
+      <!-- labs with trends -->
+      <section class="dc-card">
+        <div class="dc-card-h">Labs</div>
+        <div v-for="o in labs" :key="o.id" class="dc-lab">
+          <span class="dc-lab-nm">{{ o.display }}</span>
+          <span class="dc-lab-v" :class="{ oor: oor(o) }">{{ o.value }} <i>{{ o.unit }}</i></span>
+          <Sparkline v-if="o.trend" :series="o.trend" :w="120" :h="26" :tone="oor(o) ? 'down' : 'accent'" />
+          <span class="dc-lab-ref">ref {{ o.refLow ?? '—' }}–{{ o.refHigh ?? '—' }}</span>
+          <span class="dc-lab-d">{{ o.effective }}</span>
+        </div>
+      </section>
+
+      <!-- full history, as far back as it goes -->
+      <section class="dc-card">
+        <div class="dc-card-h">History <span class="dc-sub">longitudinal · earliest {{ history[history.length - 1]?.date }}</span></div>
+        <div v-for="e in history" :key="e.id" class="dc-hx">
+          <span class="dc-hx-d">{{ e.date }}</span>
+          <span class="dc-hx-dot" />
+          <span class="dc-hx-c"><b>{{ e.type }}</b><small>{{ e.provider }} — {{ e.note }}</small></span>
+        </div>
+      </section>
+
+      <p class="dc-foot">Intelligence for clinicians: coding, guideline guidance, grounded knowledge, and blinded community consults live on the Ask · Capture · Consults tabs — all over this same authorized record.</p>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.dc { font: 15px/1.55 var(--ui); color: var(--ink); max-width: 1100px; }
+.dc-dx { font-size: 12px; color: var(--warn); background: var(--warn-wash); border-radius: var(--r-2); padding: 6px 12px; margin: 0 0 var(--sp-3); }
+.dc-err { color: var(--fail); } .dc-msg { color: var(--muted); }
+.dc-head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--sp-4); flex-wrap: wrap; margin-bottom: var(--sp-4); }
+.dc-who h1 { margin: 0; font-size: 1.5rem; } .dc-demo { color: var(--muted); font-size: .85rem; }
+.dc-team { min-width: 260px; } .dc-team-h { font-size: 10.5px; text-transform: uppercase; letter-spacing: .06em; color: var(--faint); }
+.dc-team-list { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+.dc-doc { display: inline-flex; align-items: baseline; gap: 6px; background: var(--sunken); border: 1px solid var(--hairline); border-radius: var(--pill); padding: 4px 12px; font-size: 12.5px; } .dc-doc b { font-weight: 600; } .dc-doc i { font-style: normal; color: var(--muted); font-size: 11px; } .dc-doc .vf { color: var(--ok); font-style: normal; }
+.dc-grid3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--sp-3); margin-bottom: var(--sp-3); }
+@media (max-width: 820px) { .dc-grid3 { grid-template-columns: 1fr; } }
+.dc-card { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface); padding: var(--sp-3) var(--sp-4); margin-bottom: var(--sp-3); }
+.dc-card.danger { border-color: color-mix(in srgb, var(--fail) 30%, var(--hairline)); }
+.dc-card-h { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); font-weight: 700; margin-bottom: 10px; display: flex; align-items: center; gap: 10px; }
+.dc-flash { font-weight: 400; color: var(--ok); text-transform: none; letter-spacing: 0; }
+.dc-line { padding: 6px 0; border-top: 1px solid var(--hairline); } .dc-line:first-of-type { border-top: 0; } .dc-line b { font-size: 14px; } .dc-sub { display: block; color: var(--muted); font-size: 11.5px; }
+.dc-empty { color: var(--faint); font-size: 12.5px; }
+.dc-entry { display: flex; gap: 8px; margin-bottom: 10px; }
+.dc-in { flex: 1; min-height: 44px; border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 0 14px; font: inherit; font-size: 15px; background: var(--sunken); color: var(--ink); }
+.dc-in:focus { outline: 0; border-color: var(--accent); }
+.dc-mic { min-width: 52px; min-height: 44px; border: 1px solid var(--hairline-strong); background: var(--surface); border-radius: var(--r-2); font-size: 16px; cursor: pointer; } .dc-mic.on { border-color: var(--fail); color: var(--fail); }
+.dc-add { min-height: 44px; padding: 0 20px; background: var(--accent); color: #04122e; border: 0; border-radius: var(--r-2); font: inherit; font-weight: 600; font-size: 15px; cursor: pointer; } .dc-add:disabled { opacity: .5; }
+.dc-vitals { display: flex; flex-wrap: wrap; gap: 8px; }
+.dc-vital { display: flex; flex-direction: column; align-items: center; background: var(--sunken); border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 8px 14px; min-width: 96px; } .dc-vital b { font-size: 20px; font-variant-numeric: tabular-nums; } .dc-vital i { font-style: normal; font-size: 11px; color: var(--muted); } .dc-vital small { color: var(--faint); font-size: 10.5px; margin-top: 2px; text-align: center; }
+.dc-lab { display: grid; grid-template-columns: 1fr auto 120px auto auto; align-items: center; gap: var(--sp-3); padding: 8px 0; border-top: 1px solid var(--hairline); } .dc-lab:first-of-type { border-top: 0; }
+@media (max-width: 820px) { .dc-lab { grid-template-columns: 1fr auto; } .dc-lab :deep(svg), .dc-lab-ref, .dc-lab-d { display: none; } }
+.dc-lab-nm { font-weight: 600; font-size: 14px; } .dc-lab-v { font-variant-numeric: tabular-nums; font-size: 15px; } .dc-lab-v.oor { color: var(--fail); font-weight: 600; } .dc-lab-v i { font-style: normal; font-size: 11px; color: var(--muted); }
+.dc-lab-ref { font-size: 11px; color: var(--faint); } .dc-lab-d { font-size: 11px; color: var(--faint); }
+.dc-hx { display: grid; grid-template-columns: 96px 12px 1fr; align-items: start; gap: 10px; padding: 7px 0; }
+.dc-hx-d { font-size: 12px; color: var(--muted); text-align: right; } .dc-hx-dot { width: 9px; height: 9px; border-radius: 50%; background: var(--accent); margin-top: 5px; } .dc-hx-c b { font-size: 13.5px; } .dc-hx-c small { display: block; color: var(--muted); font-size: 12px; }
+.dc-foot { font-size: 12px; color: var(--faint); border-top: 1px solid var(--hairline); padding-top: 10px; margin-top: var(--sp-3); }
+</style>

--- a/apps/socioprophet-web/src/pages/HealthTwin.vue
+++ b/apps/socioprophet-web/src/pages/HealthTwin.vue
@@ -16,6 +16,7 @@ import SpineOverlay from './SpineOverlay.vue';
 import ConsultView from './ConsultView.vue';
 import AskTwin from './AskTwin.vue';
 import CaptureView from './CaptureView.vue';
+import DoctorChart from './DoctorChart.vue';
 import { plateFor, ATLAS_CREDIT } from '../data/anatomyAtlas';
 import './studio/studio-tokens.css';
 
@@ -28,7 +29,7 @@ const twin = ref<TwinBundle | null>(null);
 const loading = ref(false);
 const err = ref('');
 const selected = ref<string>('cardiovascular');
-const view = ref<'systems' | 'spine' | 'sources' | 'consults' | 'ask' | 'capture'>('systems');
+const view = ref<'systems' | 'spine' | 'sources' | 'consults' | 'ask' | 'capture' | 'chart'>('systems');
 const flash = ref('');
 function say(m: string) { flash.value = m; setTimeout(() => (flash.value = ''), 2800); }
 
@@ -179,12 +180,17 @@ async function doAgentRead(id: string) {
           <button class="vbtn" :class="{ on: view === 'ask' }" @click="view = 'ask'">Ask</button>
           <button class="vbtn" :class="{ on: view === 'capture' }" @click="view = 'capture'">Capture</button>
           <button class="vbtn" :class="{ on: view === 'consults' }" @click="view = 'consults'">Consults</button>
+          <button class="vbtn" :class="{ on: view === 'chart' }" @click="view = 'chart'">Chart</button>
         </div>
         <button class="ghost" @click="load" :disabled="loading" aria-label="Reload">↻</button>
         <button class="ghost txt" @click="optOut">Turn off</button>
       </header>
       <p class="disclaimer">⚕ Not medical advice · organises records, does not diagnose · <b>synthetic sample data</b>.</p>
       <p class="credit">{{ ATLAS_CREDIT }}</p>
+      <div v-if="view === 'systems' && twin?.careTeam?.length" class="ht-careteam">
+        <span class="ct-h">Your care team</span>
+        <span v-for="p in twin.careTeam" :key="p.id" class="ct-doc" :title="`${p.credentials} · ${p.org} · ${p.location}`"><b>{{ p.name }}</b> · {{ p.specialty }} · {{ p.yearsInPractice }}y<em v-if="p.verified" class="ct-vf">✓ verified</em></span>
+      </div>
       <p v-if="flash" class="flash">{{ flash }}</p>
       <p v-if="err" class="msg err">{{ err }}</p>
       <p v-else-if="loading && !twin" class="msg">Loading your twin…</p>
@@ -278,6 +284,9 @@ async function doAgentRead(id: string) {
       <div v-else-if="twin && view === 'spine'" class="ht-spine">
         <SpineOverlay :record-organs="recordOrgans" @organ="onSpineOrgan" />
       </div>
+
+      <!-- Doctor's chart (iPad): the authorized record as a clinical chart + Noetica intelligence -->
+      <div v-else-if="twin && view === 'chart'" class="ht-consults"><DoctorChart /></div>
 
       <!-- Ask-my-agent (patient magic): conversational recall over the twin, cited -->
       <div v-else-if="twin && view === 'ask'" class="ht-consults"><AskTwin /></div>
@@ -388,6 +397,9 @@ async function doAgentRead(id: string) {
 .organ-chip { display: inline-flex; align-items: center; gap: 3px; font-size: 10.5px; color: var(--ink-2); background: var(--sunken); border-radius: var(--pill); padding: 1px 8px; } .organ-chip i { font-style: normal; color: var(--accent); font-size: 9px; }
 .ht-spine { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface); padding: var(--sp-4); }
 .ht-consults { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface); padding: var(--sp-4); }
+.ht-careteam { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; margin: 0 0 var(--sp-3); }
+.ht-careteam .ct-h { font-size: 10.5px; text-transform: uppercase; letter-spacing: .06em; color: var(--faint); margin-right: 4px; }
+.ht-careteam .ct-doc { display: inline-flex; align-items: baseline; gap: 6px; font-size: 12px; color: var(--ink-2); background: var(--sunken); border: 1px solid var(--hairline); border-radius: var(--pill); padding: 3px 11px; } .ht-careteam .ct-doc b { color: var(--ink); } .ht-careteam .ct-vf { color: var(--ok); font-style: normal; font-size: 10px; }
 
 /* sources & reconciliation */
 .ht-sources { display: grid; grid-template-columns: minmax(0, 1fr) 300px; gap: var(--sp-3); }

--- a/apps/socioprophet-web/src/services/healthTwinApi.ts
+++ b/apps/socioprophet-web/src/services/healthTwinApi.ts
@@ -16,14 +16,26 @@ export interface Encounter { id: string; system: string; type: string; date: str
 export interface ImagingStudy { id: string; system: string; modality: string; bodySite: string; date: string; description: string; epistemic: EpistemicMode }
 export interface SystemBundle { id: string; label: string; organs: string[]; iri?: string; compartment?: string; observations: Observation[]; conditions: Condition[]; encounters: Encounter[]; imaging: ImagingStudy[] }
 export interface Grant { id: string; agent: string; scope: string; granted_at: string; expires_at: string; revoked: boolean; reads: number; receipt: string; active?: boolean }
+export interface Medication { id: string; system: string; organ: string; code: string; codeSystem: string; display: string; dose: string; status: string; started: string; epistemic: string }
+export interface Allergy { id: string; code: string; codeSystem: string; display: string; reaction: string; criticality: string; epistemic: string }
+export interface Immunization { id: string; code: string; codeSystem: string; display: string; date: string; epistemic: string }
+export interface CareTeamMember { id: string; name: string; specialty: string; role: string; credentials: string; org: string; location: string; npi?: string; verified: boolean; yearsInPractice: number; visits: number; lastSeen: string; firstSeen: string }
+export interface Reading { id: string; system: string; organ: string; code: string; codeSystem: string; display: string; value: number; unit: string; effective: string; epistemic: string; by: string; source: string }
 export interface TwinBundle {
-  subject: { id: string; label: string; note: string };
-  systems: SystemBundle[];
+  subject: { id: string; label: string; note: string; ageBand?: string; sex?: string };
+  systems: (SystemBundle & { medications?: Medication[] })[];
+  medications?: Medication[]; allergies?: Allergy[]; immunizations?: Immunization[];
+  careTeam?: CareTeamMember[]; readings?: Reading[];
   timeline: Encounter[];
   counts: { observations: number; conditions: number; encounters: number; imaging: number };
   grants: Grant[];
   ontology?: { health: string; hdt: string; subjectClass: string; note: string };
   disclaimer: string;
+}
+export async function addReading(text: string, by = 'clinician', source = 'keyboard'): Promise<{ created: Reading[]; count: number }> {
+  const res = await fetch(`${BASE}/api/health/reading`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ text, by, source }) });
+  if (!res.ok) throw new Error(`reading failed (${res.status})`);
+  return await res.json();
 }
 
 export async function loadTwin(): Promise<TwinBundle> {


### PR DESCRIPTION
Both charts + easy data entry, synced from prophet-health@b7b20c6.

## Patient chart — who your doctors are
`providers.ts`: a provider registry + `careTeam()` derived from the record's encounters — specialty, **years in practice**, credentials, **✓ verified**, NPI, org, location. A patient-facing **care-team strip** in the twin lets them see (and review) exactly who's on their care team. `GET /api/health/providers`, `GET /api/health/provider/{id}`.

## Doctor chart — the physician's iPad chart
`DoctorChart.vue` (new **Chart** view): the complete **authorized** record as a clinical chart, built for an iPad —
- **Chart summary**: active problems · medications · allergies (what matters now).
- **Vitals + one-tap entry** — type or **speak** a reading ("BP 138/85, HR 72, glucose 110") → coded LOINC observations (BP auto-splits systolic/diastolic). Same path for a Bluetooth cuff, voice, or keyboard.
- **Labs with trends** (sparklines), **full longitudinal history** as far back as it goes, **care team**.
- 44px touch targets, responsive columns that stack on narrow. Noetica's intelligence (coding, guidance, grounded knowledge, community consults) lives on the sibling tabs over this same record.

## Easy entry (engine)
`readings.ts` — device/voice/keyboard text → coded LOINC observations via the value-extracting clinical coder. **Verified:** "BP 138/85, HR 72, glucose 110" → systolic/diastolic/HR/glucose, coded. `POST /api/health/reading`.

`vue-tsc` + invariants + eval green. Non-diagnostic; synthetic data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)