### PR TITLE
health-twin: evidence grounded ON the twin (contextual + evidentiary) + doctor sees the anatomical twin

### DIFF
--- a/apps/health-twin/src/evidence.ts
+++ b/apps/health-twin/src/evidence.ts
@@ -1,0 +1,47 @@
+// Evidence grounded ON the twin — contextually and evidentiarily. For each notable finding on the
+// person's record (an out-of-range lab, an active condition), we build a CONTEXTUAL query — the finding
+// plus the patient's own context (age, sex, comorbidities) — retrieve grounding from the medical brain
+// (Noetica /api/study/retrieve, 125k USMLE chunks) or the local sourced KB, and attach it EVIDENTIARILY
+// to the specific record it backs. So the twin's findings become evidence-backed and patient-specific,
+// not generic. Non-diagnostic: it cites what the literature says about the person's own numbers.
+import { OBSERVATIONS, CONDITIONS, SUBJECT } from './data.js';
+import { ground, groundFromBrain, type EvidenceTier } from './knowledge.js';
+
+export interface TwinEvidence {
+  recordId: string;      // the twin record this evidence backs (evidentiary link)
+  finding: string;       // the person's own finding
+  query: string;         // the CONTEXTUAL query sent to the brain (finding + patient context)
+  evidence: string;      // what the literature says
+  citations: { source: string; tier: EvidenceTier }[];
+  retrieval: 'brain' | 'local-kb';
+}
+
+const outOfRange = (o: { value: number; refHigh?: number; refLow?: number }) =>
+  (o.refHigh != null && o.value > o.refHigh) || (o.refLow != null && o.value < o.refLow);
+
+export async function groundTwin(): Promise<{ context: string; items: TwinEvidence[]; disclaimer: string }> {
+  const s = SUBJECT as any;
+  const comorbid = CONDITIONS.map((c) => c.display.toLowerCase()).join(', ');
+  // the patient context that makes retrieval SPECIFIC to this person
+  const context = `${s.ageBand ?? ''} ${s.sex ?? ''}${comorbid ? `, history of ${comorbid}` : ''}`.trim();
+
+  const findings: { recordId: string; finding: string; term: string }[] = [
+    ...OBSERVATIONS.filter(outOfRange).map((o) => ({ recordId: o.id, finding: `${o.display} ${o.value} ${o.unit} (ref ${o.refLow ?? '–'}–${o.refHigh ?? '–'})`, term: o.display })),
+    ...CONDITIONS.map((c) => ({ recordId: c.id, finding: c.display, term: c.display })),
+  ];
+
+  const items: TwinEvidence[] = [];
+  for (const f of findings) {
+    const query = `${f.term} ${context}`.trim();          // CONTEXTUAL: finding + this patient's context
+    const g = (await groundFromBrain(query)) ?? ground(f.term); // brain (contextual) → else local KB
+    if (!g.grounded) continue;
+    items.push({
+      recordId: f.recordId, finding: f.finding, query,     // EVIDENTIARY: bound to the record
+      evidence: g.answer, citations: g.citations.map((c) => ({ source: c.source, tier: c.tier })), retrieval: g.retrieval,
+    });
+  }
+  return {
+    context, items,
+    disclaimer: 'Evidence from the medical literature about the patient\'s OWN findings, contextualized to their record and cited — informational, not a diagnosis. A clinician decides.',
+  };
+}

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -19,6 +19,7 @@ import { ground, groundFromBrain } from './knowledge.js';
 import { communityAggregate, communityScopes, type Scope } from './enclave.js';
 import { directory, provider, careTeam } from './providers.js';
 import { parseReadings, type Reading } from './readings.js';
+import { groundTwin } from './evidence.js';
 import { codeText, type CodedEntity } from './clinical.js';
 import { guidance } from './guidelines.js';
 import { openConsult, reviewerView, submitOpinion, aggregate, requestMore, type Confidence } from './consult.js';
@@ -312,6 +313,10 @@ const server = http.createServer(async (req, res) => {
     try { const b = await readJson(req); return send(res, 200, communityAggregate((b.scope ?? {}) as Scope)); }
     catch (e) { return send(res, 400, { error: (e as Error).message || 'aggregate failed' }); }
   }
+
+  // Evidence grounded ON the twin — the brain lookup contextualized by the patient's own record and
+  // bound evidentiarily to each finding. The clinician chart shows the literature behind each number.
+  if (req.method === 'GET' && url.pathname === '/api/health/evidence') return send(res, 200, await groundTwin());
 
   // Provider directory + a provider's profile (the patient reviews who their doctors are).
   if (req.method === 'GET' && url.pathname === '/api/health/providers') return send(res, 200, { providers: directory(), careTeam: careTeam() });

--- a/apps/socioprophet-web/src/pages/DoctorChart.vue
+++ b/apps/socioprophet-web/src/pages/DoctorChart.vue
@@ -4,16 +4,22 @@
 // one-tap voice/keyboard entry, labs with trends, and the full history as far back as it goes. Noetica's
 // intelligence, focused on the clinician. Non-diagnostic; a clinician decides.
 import { ref, computed, onMounted } from 'vue';
-import { loadTwin, addReading, type TwinBundle } from '../services/healthTwinApi';
+import { loadTwin, addReading, groundEvidence, type TwinBundle, type TwinEvidence } from '../services/healthTwinApi';
 import Sparkline from '../components/Sparkline.vue';
 
 const twin = ref<TwinBundle | null>(null);
 const loading = ref(false);
 const err = ref('');
 const flash = ref('');
+const evidence = ref<TwinEvidence[]>([]);
+const evContext = ref('');
+const evByRecord = computed(() => { const m: Record<string, TwinEvidence> = {}; for (const e of evidence.value) m[e.recordId] = e; return m; });
 async function load() {
   loading.value = true; err.value = '';
-  try { twin.value = await loadTwin(); } catch (e) { err.value = e instanceof Error ? e.message : 'chart unreachable'; }
+  try {
+    twin.value = await loadTwin();
+    try { const g = await groundEvidence(); evidence.value = g.items; evContext.value = g.context; } catch { /* evidence optional */ }
+  } catch (e) { err.value = e instanceof Error ? e.message : 'chart unreachable'; }
   finally { loading.value = false; }
 }
 onMounted(load);
@@ -78,7 +84,10 @@ async function submitReading() {
       <section class="dc-grid3">
         <div class="dc-card">
           <div class="dc-card-h">Active problems</div>
-          <div v-for="c in conditions" :key="c.id" class="dc-line"><b>{{ c.display }}</b><span class="dc-sub">{{ c.codeSystem }} {{ c.code }} · {{ c.clinicalStatus }}</span></div>
+          <div v-for="c in conditions" :key="c.id" class="dc-line">
+            <b>{{ c.display }}</b><span class="dc-sub">{{ c.codeSystem }} {{ c.code }} · {{ c.clinicalStatus }}</span>
+            <div v-if="evByRecord[c.id]" class="dc-ev">▸ {{ evByRecord[c.id].evidence }}<span class="dc-ev-src">⟢ {{ evByRecord[c.id].citations.map((x) => x.source).join('; ') }}</span></div>
+          </div>
           <p v-if="!conditions.length" class="dc-empty">none recorded</p>
         </div>
         <div class="dc-card">
@@ -106,15 +115,35 @@ async function submitReading() {
         </div>
       </section>
 
-      <!-- labs with trends -->
+      <!-- body systems: the anatomical twin for the clinician — full record where authorized -->
       <section class="dc-card">
-        <div class="dc-card-h">Labs</div>
-        <div v-for="o in labs" :key="o.id" class="dc-lab">
-          <span class="dc-lab-nm">{{ o.display }}</span>
-          <span class="dc-lab-v" :class="{ oor: oor(o) }">{{ o.value }} <i>{{ o.unit }}</i></span>
-          <Sparkline v-if="o.trend" :series="o.trend" :w="120" :h="26" :tone="oor(o) ? 'down' : 'accent'" />
-          <span class="dc-lab-ref">ref {{ o.refLow ?? '—' }}–{{ o.refHigh ?? '—' }}</span>
-          <span class="dc-lab-d">{{ o.effective }}</span>
+        <div class="dc-card-h">Body systems <span class="dc-sub">the anatomical twin · full record where the patient opted in</span></div>
+        <div class="dc-systems">
+          <div v-for="s in twin.systems" :key="s.id" class="dc-sys">
+            <div class="dc-sys-h"><b>{{ s.label }}</b><span>{{ s.organs.join(' · ') }}</span></div>
+            <div class="dc-sys-counts">
+              <span v-if="s.observations.length" class="dc-chip">{{ s.observations.length }} labs</span>
+              <span v-if="s.conditions.length" class="dc-chip warn">{{ s.conditions.length }} problems</span>
+              <span v-if="s.imaging.length" class="dc-chip">{{ s.imaging.length }} imaging</span>
+              <span v-if="s.encounters.length" class="dc-chip">{{ s.encounters.length }} visits</span>
+              <span v-if="!(s.observations.length || s.conditions.length || s.imaging.length || s.encounters.length)" class="dc-empty">—</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- labs with trends + evidence grounded on the twin -->
+      <section class="dc-card">
+        <div class="dc-card-h">Labs <span v-if="evContext" class="dc-sub">evidence contextualized to: {{ evContext }}</span></div>
+        <div v-for="o in labs" :key="o.id" class="dc-labwrap">
+          <div class="dc-lab">
+            <span class="dc-lab-nm">{{ o.display }}</span>
+            <span class="dc-lab-v" :class="{ oor: oor(o) }">{{ o.value }} <i>{{ o.unit }}</i></span>
+            <Sparkline v-if="o.trend" :series="o.trend" :w="120" :h="26" :tone="oor(o) ? 'down' : 'accent'" />
+            <span class="dc-lab-ref">ref {{ o.refLow ?? '—' }}–{{ o.refHigh ?? '—' }}</span>
+            <span class="dc-lab-d">{{ o.effective }}</span>
+          </div>
+          <div v-if="evByRecord[o.id]" class="dc-ev">▸ {{ evByRecord[o.id].evidence }}<span class="dc-ev-src">⟢ {{ evByRecord[o.id].citations.map((x) => x.source).join('; ') }} · {{ evByRecord[o.id].retrieval }}</span></div>
         </div>
       </section>
 
@@ -150,6 +179,14 @@ async function submitReading() {
 .dc-flash { font-weight: 400; color: var(--ok); text-transform: none; letter-spacing: 0; }
 .dc-line { padding: 6px 0; border-top: 1px solid var(--hairline); } .dc-line:first-of-type { border-top: 0; } .dc-line b { font-size: 14px; } .dc-sub { display: block; color: var(--muted); font-size: 11.5px; }
 .dc-empty { color: var(--faint); font-size: 12.5px; }
+.dc-ev { margin-top: 4px; font-size: 12px; line-height: 1.5; color: var(--ink-2); background: var(--accent-wash); border-left: 2px solid var(--accent); border-radius: 0 var(--r-1) var(--r-1) 0; padding: 5px 9px; }
+.dc-ev-src { display: block; color: var(--faint); font-size: 10.5px; margin-top: 2px; }
+.dc-systems { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 8px; }
+.dc-sys { border: 1px solid var(--hairline); border-radius: var(--r-2); background: var(--sunken); padding: 8px 10px; }
+.dc-sys-h b { font-size: 13px; } .dc-sys-h span { display: block; color: var(--muted); font-size: 10.5px; }
+.dc-sys-counts { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+.dc-chip { font-size: 10.5px; color: var(--ink-2); background: var(--surface); border: 1px solid var(--hairline); border-radius: var(--pill); padding: 1px 8px; } .dc-chip.warn { color: var(--warn); border-color: color-mix(in srgb, var(--warn) 40%, var(--hairline)); }
+.dc-labwrap { border-top: 1px solid var(--hairline); padding: 8px 0; } .dc-labwrap:first-of-type { border-top: 0; } .dc-labwrap .dc-lab { border-top: 0; padding: 0; }
 .dc-entry { display: flex; gap: 8px; margin-bottom: 10px; }
 .dc-in { flex: 1; min-height: 44px; border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 0 14px; font: inherit; font-size: 15px; background: var(--sunken); color: var(--ink); }
 .dc-in:focus { outline: 0; border-color: var(--accent); }

--- a/apps/socioprophet-web/src/services/healthTwinApi.ts
+++ b/apps/socioprophet-web/src/services/healthTwinApi.ts
@@ -37,6 +37,13 @@ export async function addReading(text: string, by = 'clinician', source = 'keybo
   if (!res.ok) throw new Error(`reading failed (${res.status})`);
   return await res.json();
 }
+// evidence grounded ON the twin — contextual (patient-specific query) + evidentiary (bound to a record)
+export interface TwinEvidence { recordId: string; finding: string; query: string; evidence: string; citations: { source: string; tier: string }[]; retrieval: string }
+export async function groundEvidence(): Promise<{ context: string; items: TwinEvidence[] }> {
+  const res = await fetch(`${BASE}/api/health/evidence`, { headers: { accept: 'application/json' } });
+  if (!res.ok) throw new Error(`evidence failed (${res.status})`);
+  return await res.json();
+}
 
 export async function loadTwin(): Promise<TwinBundle> {
   const res = await fetch(`${BASE}/api/health/twin`, { headers: { accept: 'application/json' } });


### PR DESCRIPTION
Both asks, synced from prophet-health@bd48a14.

## The doctor sees the anatomical twin (full history, where opted in)
`DoctorChart` now includes a **Body systems** panel — the organ-system index of the twin, showing the full record per system (labs · problems · imaging · visits), the same anatomical twin the patient has, surfaced for the clinician where the patient opted in.

## The brain lookup grounds evidence ON the twin — contextually + evidentiarily
`evidence.ts` (`GET /api/health/evidence`): for each notable finding (out-of-range lab, active condition) it —
- **Contextual:** builds a query = the finding **+ the patient's own context** (age, sex, comorbidities), so retrieval is patient-specific — not generic. Verified context: *"50s male, history of essential hypertension, prediabetes."*
- **Evidentiary:** retrieves from the medical **brain** (Noetica `/api/study/retrieve`, 125k USMLE chunks) or the local sourced KB, and **binds each passage to the record it backs** (LDL 148 → `obs-ldl` → ACC/AHA; A1c → `obs-a1c` → ADA; …).

The **DoctorChart** shows this evidence inline under each lab and condition — the literature behind the person's *own* numbers, cited and contextualized. Brain when reachable (`NOETICA_AM_URL`), local KB otherwise.

`vue-tsc` + invariants + eval green. Non-diagnostic; synthetic data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)