### PR TITLE
feat(health): doctor chart reads through the consent membrane

### DIFF
--- a/apps/health-twin/src/data.ts
+++ b/apps/health-twin/src/data.ts
@@ -53,6 +53,9 @@ export interface ImagingStudy { id: string; system: string; modality: string; bo
 export interface Grant {
   id: string; agent: string; scope: string; granted_at: string; expires_at: string;
   revoked: boolean; reads: number; receipt: string;
+  // structured consent scope (systems/kinds/lookback) — `scope` stays the human-readable label.
+  // Type-only import from grants.js: no runtime cycle.
+  scopeSpec?: import('./grants.js').GrantScope;
 }
 
 // ── clearly-synthetic seed (NOT real PHI) ────────────────────────────────────────────────────────

--- a/apps/health-twin/src/grants.ts
+++ b/apps/health-twin/src/grants.ts
@@ -1,0 +1,131 @@
+// Grant scoping — the consent membrane between the twin and an authorized clinician. The doctor
+// chart must render EXACTLY what the patient's grant covers: a structured scope (which body
+// systems, which record kinds, how far back), not a free-text label. applyScope() filters the
+// full bundle down to the granted slice and reports WITHHELD COUNTS — never content — so the
+// doctor can see that more history exists (and request it) without seeing it. Every successful
+// read is a receipt; every failure is an explicit block with a reason. This is the doctrine
+// ("every access is a receipt or a block") applied to the clinician surface, where the subject
+// stays IDENTIFIED (the doctor is authorized) — unlike deident.ts, which strips identity for
+// blinded reviewers. Two different membranes for two different trust relationships.
+import type { Grant } from './data.js';
+
+export type RecordKind =
+  | 'observations' | 'conditions' | 'encounters' | 'imaging'
+  | 'medications' | 'allergies' | 'immunizations' | 'readings';
+
+export interface GrantScope {
+  systems: string[] | 'all';   // body-system ids the grant covers
+  kinds: RecordKind[] | 'all'; // record kinds the grant covers
+  lookbackDays: number | null; // how far back; null = full history
+}
+
+// Named presets a patient picks when granting access. 'cardiometabolic' matches the wedge:
+// heart + metabolic (hepatic carries lipid/glucose panels) + renal.
+export const SCOPE_PRESETS: Record<string, GrantScope> = {
+  'full-history':    { systems: 'all', kinds: 'all', lookbackDays: null },
+  'cardiometabolic': { systems: ['cardiovascular', 'hepatic', 'urinary'], kinds: 'all', lookbackDays: null },
+  'meds-allergies':  { systems: 'all', kinds: ['medications', 'allergies'], lookbackDays: null },
+  'recent-90d':      { systems: 'all', kinds: 'all', lookbackDays: 90 },
+};
+
+export function resolveScope(preset?: string, spec?: Partial<GrantScope>): GrantScope {
+  const base = SCOPE_PRESETS[preset ?? ''] ?? SCOPE_PRESETS['full-history'];
+  return { ...base, ...(spec ?? {}) };
+}
+
+// A grant either opens (ok) or blocks with a stated reason — never a silent partial.
+export function resolveGrant(grants: Grant[], id: string):
+  | { ok: true; grant: Grant }
+  | { ok: false; reason: string } {
+  const g = grants.find((x) => x.id === id);
+  if (!g) return { ok: false, reason: 'grant not found' };
+  if (g.revoked) return { ok: false, reason: 'grant revoked — read denied' };
+  if (new Date(g.expires_at) <= new Date()) return { ok: false, reason: 'grant expired — read denied' };
+  return { ok: true, grant: g };
+}
+
+export const KINDS: RecordKind[] = ['observations', 'conditions', 'encounters', 'imaging', 'medications', 'allergies', 'immunizations', 'readings'];
+const inKinds = (scope: GrantScope, k: RecordKind) => scope.kinds === 'all' || scope.kinds.includes(k);
+const inSystems = (scope: GrantScope, sys?: string) => scope.systems === 'all' || (sys != null && scope.systems.includes(sys));
+
+// Each record kind dates differently; conditions use onset, meds use started, the rest are as named.
+const recordDate = (k: RecordKind, r: any): string | undefined =>
+  k === 'conditions' ? r.onset : k === 'medications' ? r.started : (r.effective ?? r.date);
+
+// Clinical-safety floor: a time-boxed grant must never hide what could kill the patient in the
+// room. Allergies (if the kind is granted) and ACTIVE conditions ignore lookbackDays.
+const safetyFloor = (k: RecordKind, r: any) =>
+  k === 'allergies' || (k === 'conditions' && r.clinicalStatus === 'active');
+
+function inWindow(scope: GrantScope, k: RecordKind, r: any): boolean {
+  if (scope.lookbackDays == null || safetyFloor(k, r)) return true;
+  const d = recordDate(k, r);
+  if (!d) return true; // undated records pass — withholding on a missing date hides silently
+  return new Date(d).getTime() >= Date.now() - scope.lookbackDays * 86_400_000;
+}
+
+// keep = kind granted AND (record's system in scope, where the record has one) AND inside the window
+const keeps = (scope: GrantScope, k: RecordKind, sys: string | undefined, r: any) =>
+  inKinds(scope, k) && (sys == null || inSystems(scope, sys)) && inWindow(scope, k, r);
+
+export type WithheldCounts = Partial<Record<RecordKind, number>> & { total: number };
+
+// Filter the full bundle() output down to the granted slice. Subject stays identified; grants
+// (the patient's control panel), ingest internals, and captured media are NOT in the clinician
+// view. Withheld = per-kind count deltas (full − kept) — counts leave, content never does.
+export function applyScope(full: any, scope: GrantScope): { view: any; withheld: WithheldCounts } {
+  const systems = (full.systems ?? [])
+    .filter((s: any) => inSystems(scope, s.id))
+    .map((s: any) => ({
+      ...s,
+      observations: (s.observations ?? []).filter((r: any) => keeps(scope, 'observations', s.id, r)),
+      conditions: (s.conditions ?? []).filter((r: any) => keeps(scope, 'conditions', s.id, r)),
+      encounters: (s.encounters ?? []).filter((r: any) => keeps(scope, 'encounters', s.id, r)),
+      imaging: (s.imaging ?? []).filter((r: any) => keeps(scope, 'imaging', s.id, r)),
+      medications: (s.medications ?? []).filter((r: any) => keeps(scope, 'medications', s.id, r)),
+    }));
+
+  const medications = (full.medications ?? []).filter((r: any) => keeps(scope, 'medications', r.system, r));
+  const allergies = (full.allergies ?? []).filter((r: any) => keeps(scope, 'allergies', undefined, r));
+  const immunizations = (full.immunizations ?? []).filter((r: any) => keeps(scope, 'immunizations', undefined, r));
+  const readings = (full.readings ?? []).filter((r: any) => keeps(scope, 'readings', r.system, r));
+  const timeline = systems.flatMap((s: any) => s.encounters).sort((a: any, b: any) => (a.date < b.date ? 1 : -1));
+
+  const sum = (k: string) => (full.systems ?? []).reduce((n: number, s: any) => n + ((s[k] ?? []).length), 0);
+  const kept = {
+    observations: systems.reduce((n: number, s: any) => n + s.observations.length, 0),
+    conditions: systems.reduce((n: number, s: any) => n + s.conditions.length, 0),
+    encounters: timeline.length,
+    imaging: systems.reduce((n: number, s: any) => n + s.imaging.length, 0),
+    medications: medications.length, allergies: allergies.length,
+    immunizations: immunizations.length, readings: readings.length,
+  };
+  const fullCounts: Record<RecordKind, number> = {
+    observations: sum('observations'), conditions: sum('conditions'), encounters: sum('encounters'),
+    imaging: sum('imaging'), medications: (full.medications ?? []).length,
+    allergies: (full.allergies ?? []).length, immunizations: (full.immunizations ?? []).length,
+    readings: (full.readings ?? []).length,
+  };
+  const withheld: WithheldCounts = { total: 0 };
+  for (const k of KINDS) {
+    const w = fullCounts[k] - (kept as any)[k];
+    if (w > 0) { withheld[k] = w; withheld.total += w; }
+  }
+
+  const view = {
+    subject: full.subject, // identified — the clinician is authorized, unlike a blinded reviewer
+    systems, medications, allergies, immunizations, readings,
+    careTeam: full.careTeam, timeline,
+    counts: kept,
+    ontology: full.ontology,
+    disclaimer: full.disclaimer,
+  };
+  return { view, withheld };
+}
+
+export const scopeSummary = (s: GrantScope): string =>
+  [
+    s.systems === 'all' ? 'all systems' : s.systems.join(' + '),
+    s.kinds === 'all' ? 'all record kinds' : s.kinds.join(', '),
+    s.lookbackDays == null ? 'full history' : `last ${s.lookbackDays} days`,
+  ].join(' · ');

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -63,5 +63,46 @@ ok(agg.blind === true && /not a diagnosis/i.test(agg.disclaimer), 'aggregate is 
 ok(['insufficient', 'unanimous', 'majority', 'split'].includes(agg.concordance.verdict), `concordance verdict computed (${agg.concordance.verdict}, agreement ${agg.concordance.agreement})`);
 ok(agg.opinions.every((o: any) => o.tier === 'hypothesis'), 'all aggregated opinions remain hypotheses');
 
-console.log(`\n${fails === 0 ? '✓ ALL GUARDRAIL INVARIANTS HOLD (non-diagnostic + de-identification enforced)' : `✗ ${fails} invariant(s) violated`}`);
+console.log('\n▶ INVARIANT 4 — grant scoping: the doctor sees exactly the granted slice');
+{
+  const { resolveScope, resolveGrant, applyScope } = await import('./grants.js');
+  const { MEDICATIONS, ALLERGIES, IMMUNIZATIONS } = await import('./data.js');
+  const fullBundle = {
+    ...sampleBundle,
+    systems: sampleBundle.systems.map((s) => ({ ...s, medications: MEDICATIONS.filter((m) => m.system === s.id) })),
+    medications: MEDICATIONS, allergies: ALLERGIES, immunizations: IMMUNIZATIONS, readings: [],
+  };
+
+  // cardiometabolic scope: nothing musculoskeletal crosses the membrane; withheld COUNTS do
+  const cardio = applyScope(fullBundle, resolveScope('cardiometabolic'));
+  ok(cardio.view.systems.every((s: any) => s.id !== 'musculoskeletal'), 'cardiometabolic view contains no musculoskeletal system');
+  ok(!JSON.stringify(cardio.view).toLowerCase().includes('knee'), 'the childhood knee history never leaves the twin');
+  ok(cardio.withheld.total > 0, `withheld COUNTS are reported (${cardio.withheld.total} records) — content never is`);
+
+  // conservation: kept + withheld = full (no record silently vanishes or double-counts)
+  const fullTotal = fullBundle.systems.reduce((n, s: any) => n + s.observations.length + s.conditions.length + s.encounters.length + s.imaging.length, 0)
+    + MEDICATIONS.length + ALLERGIES.length + IMMUNIZATIONS.length;
+  const keptTotal = Object.values(cardio.view.counts as Record<string, number>).reduce((a, b) => a + b, 0);
+  ok(keptTotal + cardio.withheld.total === fullTotal, `conservation: kept (${keptTotal}) + withheld (${cardio.withheld.total}) = full (${fullTotal})`);
+
+  // kinds scope: meds-allergies view carries no observations/conditions but still delivers its kinds
+  const medsOnly = applyScope(fullBundle, resolveScope('meds-allergies'));
+  ok(medsOnly.view.counts.observations === 0 && medsOnly.view.counts.conditions === 0, 'meds-allergies scope excludes observations + conditions');
+  ok(medsOnly.view.counts.medications > 0 && medsOnly.view.counts.allergies > 0, 'meds-allergies scope still delivers meds + allergies');
+
+  // clinical-safety floor: a time-boxed grant never hides allergies or ACTIVE conditions
+  const recent = applyScope(fullBundle, resolveScope('recent-90d'));
+  ok(recent.view.counts.allergies === ALLERGIES.length, 'lookback window never hides allergies (safety floor)');
+  const activeFull = fullBundle.systems.flatMap((s: any) => s.conditions).filter((c: any) => c.clinicalStatus === 'active').length;
+  ok(recent.view.counts.conditions >= activeFull, 'lookback window never hides ACTIVE conditions (safety floor)');
+
+  // enforcement: revoked / expired / unknown grants block with a stated reason
+  const now = Date.now();
+  const mk = (over: any) => ({ id: 'g', agent: 'a', scope: 'full-history', granted_at: new Date(now).toISOString(), expires_at: new Date(now + 864e5).toISOString(), revoked: false, reads: 0, receipt: 'r', ...over });
+  ok((resolveGrant([mk({ revoked: true })], 'g') as any).reason?.includes('revoked'), 'revoked grant blocks with reason');
+  ok((resolveGrant([mk({ expires_at: new Date(now - 1000).toISOString() })], 'g') as any).reason?.includes('expired'), 'expired grant blocks with reason');
+  ok((resolveGrant([], 'nope') as any).reason?.includes('not found'), 'unknown grant blocks with reason');
+}
+
+console.log(`\n${fails === 0 ? '✓ ALL GUARDRAIL INVARIANTS HOLD (non-diagnostic + de-identification + grant scoping enforced)' : `✗ ${fails} invariant(s) violated`}`);
 process.exit(fails === 0 ? 0 : 1);

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -23,6 +23,7 @@ import { groundTwin } from './evidence.js';
 import { codeText, type CodedEntity } from './clinical.js';
 import { guidance } from './guidelines.js';
 import { openConsult, reviewerView, submitOpinion, aggregate, requestMore, type Confidence } from './consult.js';
+import { resolveScope, resolveGrant, applyScope, scopeSummary, SCOPE_PRESETS } from './grants.js';
 
 const PORT = Number(process.env.PORT ?? 8097);
 
@@ -35,8 +36,18 @@ function receipt(kind: string, parts: string[]): { id: string; verifier: 'health
   return { id: `ht-${kind}-${djb2(parts.join('|'))}`, verifier: 'health-twin', at: new Date().toISOString() };
 }
 
-// In-memory grant ledger (skeleton). Local-first store in production.
-const grants: Grant[] = [];
+// In-memory grant ledger (skeleton). Local-first store in production. Seeded with one active
+// cardiometabolic grant for the care-team cardiologist so the doctor chart demos scoping on a
+// fresh boot (the childhood knee history is OUTSIDE this scope — it shows up as withheld counts).
+const grants: Grant[] = [{
+  id: 'grant-seed-rivera',
+  agent: 'Dr. A. Rivera (Cardiology)',
+  scope: 'cardiometabolic',
+  scopeSpec: resolveScope('cardiometabolic'),
+  granted_at: new Date().toISOString(),
+  expires_at: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+  revoked: false, reads: 0, receipt: 'ht-grant-seed',
+}];
 
 // Entered readings — device / voice / keyboard vitals that became coded observations. Local-first store.
 const readings: Reading[] = [];
@@ -316,7 +327,22 @@ const server = http.createServer(async (req, res) => {
 
   // Evidence grounded ON the twin — the brain lookup contextualized by the patient's own record and
   // bound evidentiarily to each finding. The clinician chart shows the literature behind each number.
-  if (req.method === 'GET' && url.pathname === '/api/health/evidence') return send(res, 200, await groundTwin());
+  // Grant-aware: with ?grant=<id> the evidence is scoped SERVER-SIDE to records inside the grant, so
+  // withheld findings can't leak to the clinician through the evidence side door. Enforced here, not
+  // in the client. A blocked grant blocks evidence too.
+  if (req.method === 'GET' && url.pathname === '/api/health/evidence') {
+    const gid = url.searchParams.get('grant');
+    const grounded = await groundTwin();
+    if (!gid) return send(res, 200, grounded);
+    const r = resolveGrant(grants, String(gid));
+    if (!r.ok) return send(res, 403, { blocked: true, reason: r.reason, receipt: receipt('evidence-blocked', [String(gid), r.reason]) });
+    const scope = r.grant.scopeSpec ?? resolveScope(r.grant.scope);
+    const { view } = applyScope(bundle(), scope);
+    const keptIds = new Set<string>([
+      ...view.systems.flatMap((s: any) => [...s.observations, ...s.conditions].map((x: any) => x.id)),
+    ]);
+    return send(res, 200, { ...grounded, items: grounded.items.filter((i) => keptIds.has(i.recordId)) });
+  }
 
   // Provider directory + a provider's profile (the patient reviews who their doctors are).
   if (req.method === 'GET' && url.pathname === '/api/health/providers') return send(res, 200, { providers: directory(), careTeam: careTeam() });
@@ -389,10 +415,44 @@ const server = http.createServer(async (req, res) => {
         agent, scope, granted_at: now.toISOString(),
         expires_at: new Date(now.getTime() + ttlDays * 86400000).toISOString(),
         revoked: false, reads: 0, receipt: receipt('grant', [agent, scope, String(ttlDays)]).id,
+        // structured scope: explicit spec > preset name > the scope label if it names a preset > full history
+        scopeSpec: resolveScope(String(b.preset ?? scope), b.scopeSpec),
       };
       grants.unshift(g);
-      return send(res, 200, { grant: g });
+      return send(res, 200, { grant: { ...g, scopeSummary: scopeSummary(g.scopeSpec!) } });
     } catch { return send(res, 400, { error: 'bad json' }); }
+  }
+
+  // Grant summaries for the clinician surface (id + label + active — never the record itself).
+  if (req.method === 'GET' && url.pathname === '/api/health/grants') {
+    return send(res, 200, {
+      grants: grants.map((g) => ({
+        id: g.id, agent: g.agent, scope: g.scope,
+        scopeSummary: scopeSummary(g.scopeSpec ?? resolveScope(g.scope)),
+        active: !g.revoked && new Date(g.expires_at) > new Date(),
+        expires_at: g.expires_at, reads: g.reads,
+      })),
+      presets: Object.fromEntries(Object.entries(SCOPE_PRESETS).map(([k, v]) => [k, scopeSummary(v)])),
+    });
+  }
+
+  // The doctor chart's data source: exercise a grant → the SCOPED bundle. The subject stays
+  // identified (the clinician is authorized); the slice is exactly what the consent covers, with
+  // withheld COUNTS (never content) so the doctor can see more history exists and request it.
+  // Every read is a receipt; revoked/expired/unknown grants get an explicit receipted block.
+  if (req.method === 'GET' && url.pathname === '/api/health/doctor-view') {
+    const id = String(url.searchParams.get('grant') ?? '');
+    const r = resolveGrant(grants, id);
+    if (!r.ok) return send(res, 403, { blocked: true, reason: r.reason, receipt: receipt('doctor-read-blocked', [id, r.reason]) });
+    const g = r.grant;
+    g.reads += 1;
+    const scope = g.scopeSpec ?? resolveScope(g.scope);
+    const { view, withheld } = applyScope(bundle(), scope);
+    return send(res, 200, {
+      grant: { id: g.id, agent: g.agent, scope: g.scope, scopeSummary: scopeSummary(scope), expires_at: g.expires_at, reads: g.reads },
+      view, withheld,
+      receipt: receipt('doctor-read', [g.id, String(g.reads)]),
+    });
   }
 
   // Revoke a grant — read-enforced: future reads by that agent are blocked.

--- a/apps/socioprophet-web/src/pages/DoctorChart.vue
+++ b/apps/socioprophet-web/src/pages/DoctorChart.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-// The physician's chart — built for an iPad at the bedside. The complete AUTHORIZED record (what the
-// patient granted), presented as a clinical chart: problems / meds / allergies up top, vitals with
-// one-tap voice/keyboard entry, labs with trends, and the full history as far back as it goes. Noetica's
-// intelligence, focused on the clinician. Non-diagnostic; a clinician decides.
+// The physician's chart — built for an iPad at the bedside. The chart reads THROUGH the patient's
+// consent grant: the engine returns exactly the granted slice (systems · record kinds · lookback),
+// withheld COUNTS (never content), and a receipt per read; a revoked or expired grant is an explicit
+// block. Problems / meds / allergies up top, vitals with one-tap voice/keyboard entry, labs with
+// trends, and history as far back as the grant reaches. Non-diagnostic; a clinician decides.
 import { ref, computed, onMounted } from 'vue';
-import { loadTwin, addReading, groundEvidence, type TwinBundle, type TwinEvidence } from '../services/healthTwinApi';
+import { listGrants, doctorView, addReading, groundEvidence, type GrantSummary, type WithheldCounts, type TwinBundle, type TwinEvidence } from '../services/healthTwinApi';
 import Sparkline from '../components/Sparkline.vue';
 
 const twin = ref<TwinBundle | null>(null);
@@ -14,11 +15,34 @@ const flash = ref('');
 const evidence = ref<TwinEvidence[]>([]);
 const evContext = ref('');
 const evByRecord = computed(() => { const m: Record<string, TwinEvidence> = {}; for (const e of evidence.value) m[e.recordId] = e; return m; });
+
+// consent membrane state — which grant this chart reads through
+const grants = ref<GrantSummary[]>([]);
+const grantId = ref('');
+const grantMeta = ref<{ agent: string; scope: string; scopeSummary: string; expires_at: string; reads: number } | null>(null);
+const withheld = ref<WithheldCounts | null>(null);
+const readReceipt = ref('');
+const blockedReason = ref('');
+const withheldDetail = computed(() =>
+  Object.entries(withheld.value ?? {}).filter(([k, v]) => k !== 'total' && v).map(([k, v]) => `${v} ${k}`).join(', '));
+
 async function load() {
   loading.value = true; err.value = '';
   try {
-    twin.value = await loadTwin();
-    try { const g = await groundEvidence(); evidence.value = g.items; evContext.value = g.context; } catch { /* evidence optional */ }
+    const gl = await listGrants();
+    grants.value = gl.grants;
+    if (!grantId.value) grantId.value = (gl.grants.find((g) => g.active) ?? gl.grants[0])?.id ?? '';
+    if (!grantId.value) { blockedReason.value = 'No consent grant on file — the patient has not authorized clinician access.'; twin.value = null; return; }
+    const dv = await doctorView(grantId.value);
+    if (dv.blocked || !dv.view) {
+      blockedReason.value = dv.reason ?? 'access blocked';
+      twin.value = null; grantMeta.value = null; withheld.value = null; evidence.value = [];
+      return;
+    }
+    blockedReason.value = '';
+    twin.value = dv.view as TwinBundle; // the SCOPED slice — grants panel stays with the patient
+    grantMeta.value = dv.grant ?? null; withheld.value = dv.withheld ?? null; readReceipt.value = dv.receipt?.id ?? '';
+    try { const g = await groundEvidence(grantId.value); evidence.value = g.items; evContext.value = g.context; } catch { /* evidence optional */ }
   } catch (e) { err.value = e instanceof Error ? e.message : 'chart unreachable'; }
   finally { loading.value = false; }
 }
@@ -61,7 +85,32 @@ async function submitReading() {
   <div class="dc">
     <p class="dc-dx">⚕ Clinician chart — the patient's authorized record. Not a diagnosis; a clinician decides. Synthetic demo data.</p>
     <p v-if="err" class="dc-err">{{ err }}</p>
-    <p v-else-if="loading && !twin" class="dc-msg">Loading chart…</p>
+    <p v-else-if="loading && !twin && !blockedReason" class="dc-msg">Loading chart…</p>
+
+    <!-- consent membrane: which grant this chart reads through — scope, receipt, and what's withheld -->
+    <section v-if="grants.length" class="dc-gate">
+      <div class="dc-gate-row">
+        <span class="dc-gate-h">Consent grant</span>
+        <select v-model="grantId" class="dc-gate-sel" @change="load()">
+          <option v-for="g in grants" :key="g.id" :value="g.id">{{ g.agent }} — {{ g.scope }}{{ g.active ? '' : ' (inactive)' }}</option>
+        </select>
+        <template v-if="grantMeta">
+          <span class="dc-gate-scope">{{ grantMeta.scopeSummary }}</span>
+          <span class="dc-gate-sub">expires {{ grantMeta.expires_at.slice(0, 10) }} · read #{{ grantMeta.reads }} · receipt {{ readReceipt }}</span>
+        </template>
+      </div>
+      <p v-if="withheld?.total" class="dc-withheld">
+        ⛉ {{ withheld.total }} record(s) withheld by the patient's consent scope <span class="dc-gate-sub">({{ withheldDetail }})</span>
+        — counts only; content stays with the patient. Expanded access is the patient's decision.
+      </p>
+    </section>
+
+    <!-- an explicit block IS the answer: revoked / expired / no grant -->
+    <div v-if="blockedReason" class="dc-blocked">
+      <b>⛔ Access blocked</b>
+      <span>{{ blockedReason }}</span>
+      <p>Every read is a receipt or a block. Ask the patient to grant (or re-grant) access from their twin.</p>
+    </div>
 
     <template v-if="twin">
       <!-- patient header + care team -->
@@ -166,6 +215,16 @@ async function submitReading() {
 .dc { font: 15px/1.55 var(--ui); color: var(--ink); max-width: 1100px; }
 .dc-dx { font-size: 12px; color: var(--warn); background: var(--warn-wash); border-radius: var(--r-2); padding: 6px 12px; margin: 0 0 var(--sp-3); }
 .dc-err { color: var(--fail); } .dc-msg { color: var(--muted); }
+/* consent membrane strip */
+.dc-gate { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--sunken); padding: 10px var(--sp-4); margin-bottom: var(--sp-3); }
+.dc-gate-row { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
+.dc-gate-h { font-size: 10.5px; text-transform: uppercase; letter-spacing: .06em; color: var(--faint); font-weight: 700; }
+.dc-gate-sel { font: 13px var(--ui); color: var(--ink); background: var(--surface); border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 4px 8px; max-width: 340px; }
+.dc-gate-scope { font-size: 12.5px; font-weight: 600; }
+.dc-gate-sub { font-size: 11.5px; color: var(--muted); }
+.dc-withheld { font-size: 12.5px; color: var(--warn); margin: 8px 0 0; }
+.dc-blocked { border: 1px solid color-mix(in srgb, var(--fail) 40%, var(--hairline)); border-radius: var(--r-3); background: color-mix(in srgb, var(--fail) 7%, var(--surface)); padding: var(--sp-3) var(--sp-4); margin-bottom: var(--sp-3); display: flex; flex-direction: column; gap: 4px; }
+.dc-blocked b { color: var(--fail); } .dc-blocked span { font-size: 14px; } .dc-blocked p { margin: 2px 0 0; font-size: 12.5px; color: var(--muted); }
 .dc-head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--sp-4); flex-wrap: wrap; margin-bottom: var(--sp-4); }
 .dc-who h1 { margin: 0; font-size: 1.5rem; } .dc-demo { color: var(--muted); font-size: .85rem; }
 .dc-team { min-width: 260px; } .dc-team-h { font-size: 10.5px; text-transform: uppercase; letter-spacing: .06em; color: var(--faint); }

--- a/apps/socioprophet-web/src/services/healthTwinApi.ts
+++ b/apps/socioprophet-web/src/services/healthTwinApi.ts
@@ -37,12 +37,36 @@ export async function addReading(text: string, by = 'clinician', source = 'keybo
   if (!res.ok) throw new Error(`reading failed (${res.status})`);
   return await res.json();
 }
-// evidence grounded ON the twin — contextual (patient-specific query) + evidentiary (bound to a record)
+// evidence grounded ON the twin — contextual (patient-specific query) + evidentiary (bound to a record).
+// Pass a grant id and the engine scopes evidence SERVER-SIDE to records inside the grant, so withheld
+// findings can't leak to a clinician through the evidence side door.
 export interface TwinEvidence { recordId: string; finding: string; query: string; evidence: string; citations: { source: string; tier: string }[]; retrieval: string }
-export async function groundEvidence(): Promise<{ context: string; items: TwinEvidence[] }> {
-  const res = await fetch(`${BASE}/api/health/evidence`, { headers: { accept: 'application/json' } });
+export async function groundEvidence(grant?: string): Promise<{ context: string; items: TwinEvidence[] }> {
+  const q = grant ? `?grant=${encodeURIComponent(grant)}` : '';
+  const res = await fetch(`${BASE}/api/health/evidence${q}`, { headers: { accept: 'application/json' } });
   if (!res.ok) throw new Error(`evidence failed (${res.status})`);
   return await res.json();
+}
+
+// ── grant-scoped clinician access: the doctor chart reads THROUGH a consent grant ─────────────────
+// The engine returns exactly the granted slice plus withheld COUNTS (never content); revoked/expired
+// grants return an explicit receipted block. Every read increments the grant's receipt trail.
+export interface GrantSummary { id: string; agent: string; scope: string; scopeSummary: string; active: boolean; expires_at: string; reads: number }
+export async function listGrants(): Promise<{ grants: GrantSummary[]; presets: Record<string, string> }> {
+  const res = await fetch(`${BASE}/api/health/grants`, { headers: { accept: 'application/json' } });
+  if (!res.ok) throw new Error(`grants unreachable (${res.status})`);
+  return await res.json();
+}
+export type WithheldCounts = { total: number } & Partial<Record<'observations' | 'conditions' | 'encounters' | 'imaging' | 'medications' | 'allergies' | 'immunizations' | 'readings', number>>;
+export interface DoctorView {
+  blocked?: boolean; reason?: string;
+  grant?: { id: string; agent: string; scope: string; scopeSummary: string; expires_at: string; reads: number };
+  view?: Omit<TwinBundle, 'grants'>; withheld?: WithheldCounts;
+  receipt?: { id: string };
+}
+export async function doctorView(grantId: string): Promise<DoctorView> {
+  const res = await fetch(`${BASE}/api/health/doctor-view?grant=${encodeURIComponent(grantId)}`, { headers: { accept: 'application/json' } });
+  return await res.json(); // a 403 carries the { blocked, reason, receipt } shape — the block IS the answer
 }
 
 export async function loadTwin(): Promise<TwinBundle> {


### PR DESCRIPTION
Companion to [prophet-health#1](https://github.com/SocioProphet/prophet-health/pull/1) — vendor-parity sync + the clinician-facing UI.

## health-twin (synced from prophet-health@bd48a14)
Structured `GrantScope` (systems · record kinds · lookback) + presets; `GET /doctor-view` returns exactly the granted slice with **withheld counts (never content)** and a receipt per read; revoked/expired grants are explicit receipted blocks; `/evidence?grant=` is scoped **server-side** so withheld findings can't leak through the evidence side door; clinical-safety floor (lookback never hides allergies or active conditions); INVARIANT 4 enforced in CI.

## socioprophet-web
**DoctorChart** now reads through the grant:
- consent-grant picker + scope summary strip (`cardiovascular + hepatic + urinary · all record kinds · full history`) with expiry, read count, and receipt id
- **withheld banner** — "5 record(s) withheld by the patient's consent scope (2 encounters, 3 imaging)" — counts only, expanded access is the patient's decision
- **blocked panel** for revoked/expired/no grant: every read is a receipt or a block
- evidence panel uses the same grant, so it can never show literature about withheld findings

Verified live against the engine (scoped view, revoke→403+receipt, preset grants, evidence filtered to 0 under meds-allergies). `vue-tsc` clean.