### PR TITLE
feat(lattice-studio): document→linked-knowledge ingestion pipeline (ST024)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -38,6 +38,9 @@ SERVICE_VERSION = "0.2.0"
 HELLGRAPH_URL = os.getenv("HELLGRAPH_URL", "http://hellgraph-service:8090")
 TRITFABRIC_URL = os.getenv("TRITFABRIC_URL", "http://tritfabric:8750")
 SEARCH_ORCH_URL = os.getenv("SEARCH_ORCH_URL", "http://search-orchestrator:8080")
+# Document-ingestion pipeline upstreams: real NER/relation extraction + entity resolution.
+IE_ENGINE_URL = os.getenv("IE_ENGINE_URL", "http://ie-engine:8080")
+ER_URL = os.getenv("ER_URL", "http://entity-resolution:8080")
 TIMEOUT = float(os.getenv("STUDIO_TIMEOUT", "5"))
 # Write gate for /api/studio/extract (mutates the graph). Fail-closed: unset → writes refused.
 STUDIO_WRITE_TOKEN = os.getenv("STUDIO_WRITE_TOKEN", "")
@@ -2497,6 +2500,186 @@ async def extract(req: ExtractRequest, authorization: str = Header(default="")) 
         "written": {"nodes": written_nodes, "edges": written_edges},
         "provenance": prov,
         "sample": entities[:10],
+        "errors": errors[:5] or None,
+    }
+
+
+def _chunk_text(text: str, max_chars: int = 4000) -> list[str]:
+    """Paragraph-preserving chunks for the IE hop (ie-engine caps entities/relations PER CALL, so chunking
+    is what lets a full document through, not just its first page). Oversized paragraphs split on sentence
+    boundaries; a pathological single sentence is hard-split rather than dropped."""
+    chunks: list[str] = []
+    buf = ""
+    for para in re.split(r"\n\s*\n", text):
+        para = para.strip()
+        if not para:
+            continue
+        if len(buf) + len(para) + 2 <= max_chars:
+            buf = f"{buf}\n\n{para}" if buf else para
+            continue
+        if buf:
+            chunks.append(buf); buf = ""
+        if len(para) <= max_chars:
+            buf = para
+            continue
+        for sent in re.split(r"(?<=[.!?])\s+", para):
+            while len(sent) > max_chars:                     # pathological unbroken run
+                chunks.append(sent[:max_chars]); sent = sent[max_chars:]
+            if len(buf) + len(sent) + 1 > max_chars:
+                chunks.append(buf); buf = sent
+            else:
+                buf = f"{buf} {sent}" if buf else sent
+    if buf:
+        chunks.append(buf)
+    return chunks
+
+
+class IngestDocumentRequest(BaseModel):
+    project: str = "default"
+    text: str
+    filename: str | None = None
+    source: str | None = None
+
+
+@app.post("/api/studio/ingest-document")
+async def ingest_document(req: IngestDocumentRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """The document→linked-knowledge pipeline (ST024): chunk → ie-engine (real spaCy NER + SVO relations)
+    → entity-resolution (proof-carrying golden records) → hellgraph upsert under ONE canonical id scheme.
+
+    Before this endpoint the estate had extraction, ER, and the graph as disconnected hops with two
+    incompatible id schemes (ie:<slug> vs <coll>:ent:<slug>) and NOBODY calling ER — the same real-world
+    entity landed as different nodes per path. Here every mention is resolved to a golden record first and
+    written as _ent_id(coll, canonical_name), the SAME scheme /extract and the workbench use, so document-
+    extracted, hand-authored, and regex-extracted facts about one entity converge on one node.
+
+    Fail-soft at each hop: IE unreachable → deterministic extract_facts fallback (tagged in provenance);
+    ER unreachable → identity resolution (each mention its own entity, error surfaced). Graph writes carry
+    the full studio provenance stamp + doc_sha so every fact traces back to the source document."""
+    _require_write_token(authorization)
+    text = req.text.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="empty document")
+    coll = proj_collection(req.project)
+    doc_sha = hashlib.sha256(text.encode()).hexdigest()
+    src = req.source or f"doc:{doc_sha[:16]}"
+    chunks = _chunk_text(text)
+
+    errors: list[str] = []
+    mentions: dict[str, str] = {}          # mention text → entity type ("" when unknown)
+    relations: list[dict[str, str]] = []   # {from, relation, to} in mention-text space
+    claims: list[dict[str, Any]] = []
+    extractor = "lattice-studio/ie-pipeline-v1"
+
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        # 1) EXTRACT — ie-engine per chunk, concurrently. Topics are ambience, not entities → skipped.
+        ie_results = await asyncio.gather(
+            *[_req(client, "POST", f"{IE_ENGINE_URL}/extract", json={"text": c}) for c in chunks]
+        )
+        ie_ok = False
+        for body, err in ie_results:
+            if err or not isinstance(body, dict):
+                if err:
+                    errors.append(f"ie-engine: {err}")
+                continue
+            ie_ok = True
+            for e in body.get("entities", []):
+                name, typ = str(e.get("text", "")).strip(), str(e.get("type", ""))
+                if name and typ != "Topic":
+                    mentions.setdefault(name, typ)
+            relations.extend(
+                {"from": str(r.get("from", "")), "relation": str(r.get("relation", "")), "to": str(r.get("to", ""))}
+                for r in body.get("relations", []) if r.get("from") and r.get("to")
+            )
+            claims.extend(body.get("claims", []))
+        if not ie_ok:
+            # Degraded but never dead: the deterministic extractor keeps ingestion working and the
+            # provenance tag makes the degradation visible instead of silent.
+            extractor = "lattice-studio/deterministic-v0-fallback"
+            ents, rels = extract_facts(text)
+            for n in ents:
+                mentions.setdefault(n, "")
+            relations.extend({"from": a, "relation": "co_occurs", "to": b} for a, b in rels)
+
+        # 2) RESOLVE — every unique mention through ER; golden records give the canonical name per entity.
+        mention_names = list(mentions)
+        canonical_of: dict[str, str] = {n: n for n in mention_names}    # identity fallback
+        aliases_of: dict[str, list[str]] = {}
+        er_meta: dict[str, Any] = {"resolved": False, "merged": 0, "review_queue": 0}
+        if mention_names:
+            records = [
+                {"id": f"m{i}", "name": n, "attributes": ({"type": mentions[n]} if mentions[n] else {}), "scope": coll}
+                for i, n in enumerate(mention_names)
+            ]
+            er_body, er_err = await _req(client, "POST", f"{ER_URL}/resolve", json={"records": records})
+            if er_err or not isinstance(er_body, dict):
+                if er_err:
+                    errors.append(f"entity-resolution: {er_err} (identity fallback)")
+            else:
+                by_rid = {r["id"]: r["name"] for r in records}
+                for ent in er_body.get("entities", []):
+                    canon = str(ent.get("canonical", {}).get("name", "")).strip()
+                    members = [by_rid[m] for m in ent.get("members", []) if m in by_rid]
+                    if not canon or not members:
+                        continue
+                    for m in members:
+                        canonical_of[m] = canon
+                    if len(members) > 1:
+                        aliases_of[canon] = sorted(m for m in members if m != canon)
+                er_meta = {"resolved": True, "merged": er_body.get("merged", 0),
+                           "review_queue": len(er_body.get("review_queue", [])),
+                           "replay_key": er_body.get("replay_key")}
+
+        # 3) WRITE — canonical nodes, then relations mapped through the canonical ids. A relation is written
+        # only when BOTH endpoints resolved to a known entity — dependency spans that matched nothing would
+        # otherwise mint junk nodes.
+        prov = {"epistemic_mode": "observed", "source": src, "extractor": extractor,
+                "project": coll, "kko_type": "Particulars", "doc_sha": doc_sha,
+                **({"filename": req.filename} if req.filename else {})}
+        canon_type: dict[str, str] = {}
+        for m, canon in canonical_of.items():
+            if mentions.get(m) and not canon_type.get(canon):
+                canon_type[canon] = mentions[m]
+        written_nodes = written_edges = 0
+        node_calls = [
+            _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                 json={"id": _ent_id(coll, canon),
+                       "labels": [coll, "Entity", *([canon_type[canon]] if canon_type.get(canon) else [])],
+                       "properties": {"name": canon, **({"aliases": aliases_of[canon]} if canon in aliases_of else {}), **prov}})
+            for canon in sorted(set(canonical_of.values()))
+        ]
+        for _, err in await asyncio.gather(*node_calls):
+            if err:
+                errors.append(err)
+            else:
+                written_nodes += 1
+        lookup = {n.lower(): c for n, c in canonical_of.items()}
+        resolved_rels = []
+        for r in relations:
+            fa, ta = lookup.get(r["from"].strip().lower()), lookup.get(r["to"].strip().lower())
+            if fa and ta and fa != ta:
+                label = re.sub(r"[^a-z0-9]+", "_", r["relation"].lower()).strip("_") or "relates_to"
+                resolved_rels.append((fa, label, ta))
+        skipped_relations = len(relations) - len(resolved_rels)
+        edge_calls = [
+            _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                 json={"label": label, "from": _ent_id(coll, fa), "to": _ent_id(coll, ta), "properties": prov})
+            for fa, label, ta in dict.fromkeys(resolved_rels)
+        ]
+        for _, err in await asyncio.gather(*edge_calls):
+            if err:
+                errors.append(err)
+            else:
+                written_edges += 1
+
+    return {
+        "project": req.project, "projectCollection": coll, "source": src, "doc_sha": doc_sha,
+        "chunks": len(chunks),
+        "extracted": {"mentions": len(mentions), "relations": len(relations), "claims": len(claims)},
+        "resolution": {**er_meta, "entities": len(set(canonical_of.values()))},
+        "written": {"nodes": written_nodes, "edges": written_edges, "skipped_relations": skipped_relations},
+        "claims": claims[:20],
+        "provenance": prov,
+        "sample": sorted(set(canonical_of.values()))[:10],
         "errors": errors[:5] or None,
     }
 

--- a/apps/lattice-studio/tests/test_document_ingestion.py
+++ b/apps/lattice-studio/tests/test_document_ingestion.py
@@ -1,0 +1,158 @@
+"""ST024 document→linked-knowledge pipeline: chunk → ie-engine → entity-resolution → hellgraph.
+
+The moat under test: every mention is resolved to a golden record BEFORE the graph write, and lands
+under the SAME canonical id scheme (_ent_id) the workbench and /extract use — so "Guzman & Gomez"
+and "GYG" become ONE node, not two, and every fact carries doc-level provenance (doc_sha + source).
+"""
+from fastapi.testclient import TestClient
+
+import lattice_studio.server as srv
+from lattice_studio.server import _chunk_text, app
+
+client = TestClient(app)
+
+
+def test_ingest_write_gate(monkeypatch):
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "")
+    r = client.post("/api/studio/ingest-document", json={"project": "team-x", "text": "GYG opened 12 stores."})
+    assert r.status_code == 503  # fail-closed: no token configured → writes refused
+
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    r = client.post("/api/studio/ingest-document", json={"project": "team-x", "text": "x"},
+                    headers={"authorization": "Bearer nope"})
+    assert r.status_code == 401
+
+
+def test_ingest_empty_document_rejected(monkeypatch):
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    r = client.post("/api/studio/ingest-document", json={"project": "team-x", "text": "   \n\n  "},
+                    headers={"authorization": "Bearer secret"})
+    assert r.status_code == 400
+
+
+def _fake_req_factory(calls, ie_payload=None, er_payload=None, ie_err=None, er_err=None):
+    async def fake_req(client, method, url, json=None):
+        calls.append((method, url, json))
+        if "/extract" in url and "ie-engine" in url:
+            return (None, ie_err) if ie_err else (ie_payload, None)
+        if "/resolve" in url:
+            return (None, er_err) if er_err else (er_payload, None)
+        if "/api/graph/node" in url or "/api/graph/edge" in url:
+            return {"ok": True}, None
+        return None, f"unexpected url {url}"
+    return fake_req
+
+
+IE_PAYLOAD = {
+    "entities": [
+        {"text": "Guzman & Gomez", "type": "Organization", "mentions": 2},
+        {"text": "GYG", "type": "Organization", "mentions": 3},
+        {"text": "Sydney", "type": "Location", "mentions": 1},
+        {"text": "the market", "type": "Topic", "count": 2},  # topics must NOT become entities
+    ],
+    "relations": [
+        {"from": "GYG", "relation": "open", "to": "Sydney"},
+        {"from": "Guzman & Gomez", "relation": "report", "to": "unmatched span"},  # endpoint unresolvable → skipped
+    ],
+    "claims": [{"type": "ASSERT", "text": "GYG opened 12 stores in Sydney.", "verifiable": True}],
+}
+
+# ER merges the two Organization mentions into one golden record with the long form canonical.
+ER_PAYLOAD = {
+    "replay_key": "er:2026-07-22",
+    "merged": 1,
+    "entities": [
+        {"entity_id": "ent:m0", "members": ["m0", "m1"], "size": 2,
+         "canonical": {"survivor": "m0", "name": "Guzman & Gomez", "attributes": {"type": "Organization"}}},
+        {"entity_id": "ent:m2", "members": ["m2"], "size": 1,
+         "canonical": {"survivor": "m2", "name": "Sydney", "attributes": {"type": "Location"}}},
+    ],
+    "review_queue": [],
+}
+
+
+def test_ingest_resolves_mentions_to_one_canonical_node(monkeypatch):
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    calls = []
+    monkeypatch.setattr(srv, "_req", _fake_req_factory(calls, IE_PAYLOAD, ER_PAYLOAD))
+    r = client.post("/api/studio/ingest-document",
+                    json={"project": "team-x", "text": "GYG opened 12 stores in Sydney.", "filename": "gyg.txt"},
+                    headers={"authorization": "Bearer secret"})
+    assert r.status_code == 200
+    b = r.json()
+    assert b["projectCollection"] == "proj-teamx"
+
+    # ER ran and merged GYG into Guzman & Gomez → 2 canonical entities from 3 mentions
+    assert b["resolution"] == {"resolved": True, "merged": 1, "review_queue": 0,
+                               "replay_key": "er:2026-07-22", "entities": 2}
+    assert b["extracted"]["mentions"] == 3  # topic filtered out
+
+    node_writes = [j for m, u, j in calls if "/api/graph/node" in u]
+    ids = {n["id"] for n in node_writes}
+    # ONE node for the merged org, under the workbench-compatible id scheme — the whole point
+    assert ids == {"proj-teamx:ent:guzman_&_gomez", "proj-teamx:ent:sydney"}
+    org = next(n for n in node_writes if "guzman" in n["id"])
+    assert org["properties"]["aliases"] == ["GYG"]
+    assert "Organization" in org["labels"]
+
+    # provenance: every fact traces to the document
+    assert org["properties"]["epistemic_mode"] == "observed"
+    assert org["properties"]["doc_sha"] == b["doc_sha"]
+    assert org["properties"]["filename"] == "gyg.txt"
+    assert org["properties"]["extractor"] == "lattice-studio/ie-pipeline-v1"
+
+    # edges: GYG→Sydney maps through canonicals; the unmatched-span relation is skipped, not minted
+    edge_writes = [j for m, u, j in calls if "/api/graph/edge" in u]
+    assert len(edge_writes) == 1
+    assert edge_writes[0]["from"] == "proj-teamx:ent:guzman_&_gomez"
+    assert edge_writes[0]["to"] == "proj-teamx:ent:sydney"
+    assert edge_writes[0]["label"] == "open"
+    assert b["written"] == {"nodes": 2, "edges": 1, "skipped_relations": 1}
+    assert b["claims"][0]["verifiable"] is True
+
+
+def test_ingest_ie_unreachable_falls_back_deterministic(monkeypatch):
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    calls = []
+    er_identity = {"replay_key": "er:x", "merged": 0, "entities": [], "review_queue": []}
+    monkeypatch.setattr(srv, "_req", _fake_req_factory(calls, er_payload=er_identity, ie_err="connect timeout"))
+    r = client.post("/api/studio/ingest-document",
+                    json={"project": "team-x", "text": "HellGraph beats Neo4j on provenance."},
+                    headers={"authorization": "Bearer secret"})
+    assert r.status_code == 200
+    b = r.json()
+    # degraded, visibly: fallback extractor tagged in provenance, error surfaced, but facts still written
+    assert b["provenance"]["extractor"] == "lattice-studio/deterministic-v0-fallback"
+    assert any("ie-engine" in e for e in b["errors"])
+    assert b["written"]["nodes"] >= 2
+
+
+def test_ingest_er_unreachable_identity_fallback(monkeypatch):
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    calls = []
+    monkeypatch.setattr(srv, "_req", _fake_req_factory(calls, IE_PAYLOAD, er_err="ER down"))
+    r = client.post("/api/studio/ingest-document",
+                    json={"project": "team-x", "text": "GYG opened 12 stores in Sydney."},
+                    headers={"authorization": "Bearer secret"})
+    assert r.status_code == 200
+    b = r.json()
+    # identity fallback: no merge, every mention its own node, error surfaced — never silent
+    assert b["resolution"]["resolved"] is False
+    assert b["written"]["nodes"] == 3
+    assert any("entity-resolution" in e for e in b["errors"])
+
+
+def test_chunker_preserves_paragraphs_and_splits_oversized():
+    text = "Para one.\n\nPara two."
+    assert _chunk_text(text) == ["Para one.\n\nPara two."]
+
+    many = "\n\n".join(f"Paragraph number {i} talks about entity {i}." for i in range(300))
+    chunks = _chunk_text(many)
+    assert len(chunks) > 1
+    assert all(len(c) <= 4000 for c in chunks)
+    assert "".join(chunks).count("Paragraph number") == 300  # nothing dropped
+
+    one_long_sentence = "word " * 2000  # no sentence boundaries at all
+    chunks = _chunk_text(one_long_sentence)
+    assert all(len(c) <= 4000 for c in chunks)
+    assert sum(c.count("word") for c in chunks) == 2000

--- a/deploy/values/lattice-studio.yaml
+++ b/deploy/values/lattice-studio.yaml
@@ -13,6 +13,10 @@ config:
   HELLGRAPH_URL: "http://hellgraph-service:8090"
   TRITFABRIC_URL: "http://tritfabric:8750"
   SEARCH_ORCH_URL: "http://search-orchestrator:8080"
+  # ST024 document-ingestion pipeline upstreams: /api/studio/ingest-document chains
+  # ie-engine (spaCy NER/relations) → entity-resolution (golden records) → hellgraph.
+  IE_ENGINE_URL: "http://ie-engine:8080"
+  ER_URL: "http://entity-resolution:8080"
   # The sovereign Spark backend. lattice-studio dispatches backend='spark' jobs to spark-runner (auth'd with the
   # shared SPARK_RUNNER_TOKEN secretEnv below). The loop is now closed end-to-end.
   SPARK_RUNNER_URL: "http://spark-runner.sovereign-runtime.svc.cluster.local:8080"


### PR DESCRIPTION
## What
`POST /api/studio/ingest-document` — the missing orchestrator for the knowledge-brain build (sprint ST024/P015): one call takes a document and produces linked, queryable knowledge.

```
chunk → ie-engine /extract (spaCy NER + SVO relations)
      → entity-resolution /resolve (proof-carrying golden records)
      → hellgraph node/edge upsert, ONE canonical id scheme
```

## Why
The estate had every pipeline stage deployed but disconnected: two incompatible node-id schemes (`ie:<slug>` vs `<coll>:ent:<slug>`) and **nothing calling entity-resolution** — the same real-world entity became different nodes depending on which path extracted it. Every mention now resolves to a golden record before the graph write and lands under `_ent_id(coll, canonical_name)` — the same scheme `/extract` and the workbench use — so "Guzman & Gomez" and "GYG" become one node with aliases, not two nodes.

## Design
- Same fail-closed `STUDIO_WRITE_TOKEN` gate as every graph-mutating route
- Full studio provenance stamp (epistemic_mode/source/extractor/project/kko_type) **+ doc_sha/filename** on every node and edge
- Fail-soft per hop, never silent: IE down → deterministic `extract_facts` fallback tagged in provenance; ER down → identity resolution with the error surfaced
- Relations written only when both endpoints resolve to known entities — unmatched dependency spans can't mint junk nodes
- Paragraph-preserving chunker so ie-engine's per-call entity/relation caps see the whole document
- `deploy/values`: `IE_ENGINE_URL` + `ER_URL` wired to the in-cluster services

## Verification
- 6 new tests: write gate, canonical merge + provenance + edge mapping, IE fallback, ER fallback, chunker invariants
- Full lattice-studio suite: **230 passed**; 2 pre-existing failures (`test_ontology_serves_real_classes_not_a_mock`, `test_action_invoke_shacl_rejects_nonconformant_writeback`) reproduce identically on unmodified main — local-env ontology/SHACL fixtures, untouched here

## Next (separate PRs)
- File front door (PDF/docx → text) feeding this endpoint
- GYG (ST028) + Berger Foods (ST027) corpora as first real ingestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)