### PR TITLE
feat(lattice-studio): file front door — PDF/DOCX/txt/md → ingestion pipeline (ST024)

### DIFF
--- a/apps/lattice-studio/requirements.txt
+++ b/apps/lattice-studio/requirements.txt
@@ -4,3 +4,5 @@ httpx==0.27.2
 rdflib==7.0.0
 PyJWT==2.9.0
 pyshacl>=0.26.0
+pypdf==5.1.0
+python-docx==1.1.2

--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -17,6 +17,7 @@ Upstreams (real, in-cluster):
 from __future__ import annotations
 
 import asyncio
+import base64
 import csv
 import hashlib
 import io
@@ -2559,9 +2560,16 @@ async def ingest_document(req: IngestDocumentRequest, authorization: str = Heade
     text = req.text.strip()
     if not text:
         raise HTTPException(status_code=400, detail="empty document")
-    coll = proj_collection(req.project)
+    return await _run_ingest_pipeline(req.project, text, req.filename, req.source)
+
+
+async def _run_ingest_pipeline(project: str, text: str, filename: str | None, source: str | None,
+                               extra_prov: dict[str, Any] | None = None) -> dict[str, Any]:
+    """The shared IE→ER→graph pipeline behind /ingest-document (raw text) and /ingest-file (converted files).
+    Caller is responsible for the write gate and for handing in non-empty text."""
+    coll = proj_collection(project)
     doc_sha = hashlib.sha256(text.encode()).hexdigest()
-    src = req.source or f"doc:{doc_sha[:16]}"
+    src = source or f"doc:{doc_sha[:16]}"
     chunks = _chunk_text(text)
 
     errors: list[str] = []
@@ -2634,7 +2642,7 @@ async def ingest_document(req: IngestDocumentRequest, authorization: str = Heade
         # otherwise mint junk nodes.
         prov = {"epistemic_mode": "observed", "source": src, "extractor": extractor,
                 "project": coll, "kko_type": "Particulars", "doc_sha": doc_sha,
-                **({"filename": req.filename} if req.filename else {})}
+                **({"filename": filename} if filename else {}), **(extra_prov or {})}
         canon_type: dict[str, str] = {}
         for m, canon in canonical_of.items():
             if mentions.get(m) and not canon_type.get(canon):
@@ -2672,7 +2680,7 @@ async def ingest_document(req: IngestDocumentRequest, authorization: str = Heade
                 written_edges += 1
 
     return {
-        "project": req.project, "projectCollection": coll, "source": src, "doc_sha": doc_sha,
+        "project": project, "projectCollection": coll, "source": src, "doc_sha": doc_sha,
         "chunks": len(chunks),
         "extracted": {"mentions": len(mentions), "relations": len(relations), "claims": len(claims)},
         "resolution": {**er_meta, "entities": len(set(canonical_of.values()))},
@@ -2682,6 +2690,73 @@ async def ingest_document(req: IngestDocumentRequest, authorization: str = Heade
         "sample": sorted(set(canonical_of.values()))[:10],
         "errors": errors[:5] or None,
     }
+
+
+# ---------------------------------------------------------------------------
+# File front door: PDF/DOCX/plain-text → text → the same IE→ER→graph pipeline.
+# Payload is base64 JSON (matching the estate's JSON-body convention) rather than
+# multipart, so callers — Noetica, app-vue, curl — need no special client handling.
+MAX_FILE_BYTES = int(os.getenv("STUDIO_MAX_FILE_BYTES", str(20 * 1024 * 1024)))
+
+
+def _doc_to_text(filename: str, data: bytes) -> str:
+    """Convert a supported document to plain text. Raises 415 for unsupported types; parser
+    failures are the caller's to wrap (422) so corrupt files never 500."""
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    if ext == "pdf":
+        from pypdf import PdfReader  # lazy: keeps cold-start light for the non-file routes
+        reader = PdfReader(io.BytesIO(data))
+        return "\n\n".join((page.extract_text() or "") for page in reader.pages)
+    if ext == "docx":
+        from docx import Document as DocxDocument  # lazy, same reason
+        d = DocxDocument(io.BytesIO(data))
+        parts = [p.text for p in d.paragraphs]
+        # Tables carry the numbers in business documents — flatten row-wise, cells pipe-joined.
+        for t in d.tables:
+            parts.extend(" | ".join(c.text.strip() for c in row.cells) for row in t.rows)
+        return "\n\n".join(x for x in parts if x.strip())
+    if ext in ("txt", "md", "markdown"):
+        return data.decode("utf-8", errors="replace")
+    raise HTTPException(
+        status_code=415,
+        detail=f"unsupported file type .{ext or '?'} — supported: pdf, docx, txt, md "
+               "(for tabular csv/json use /api/studio/ingest)")
+
+
+class IngestFileRequest(BaseModel):
+    project: str = "default"
+    filename: str
+    content_b64: str
+    source: str | None = None
+
+
+@app.post("/api/studio/ingest-file")
+async def ingest_file(req: IngestFileRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Drop a FILE in, get linked knowledge out — the literal ST024 outcome. Decodes + converts the
+    document, then runs the exact same governed pipeline as /ingest-document. Provenance additionally
+    carries file_sha (hash of the original bytes) next to doc_sha (hash of the extracted text), so a
+    fact is traceable both to the file that was dropped and to the text the extractor actually saw."""
+    _require_write_token(authorization)
+    try:
+        data = base64.b64decode(req.content_b64, validate=True)
+    except Exception:
+        raise HTTPException(status_code=400, detail="content_b64 is not valid base64") from None
+    if not data:
+        raise HTTPException(status_code=400, detail="empty file")
+    if len(data) > MAX_FILE_BYTES:
+        raise HTTPException(status_code=413, detail=f"file exceeds {MAX_FILE_BYTES} bytes")
+    try:
+        text = _doc_to_text(req.filename, data)
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001 — corrupt/unparseable document must 422, never 500
+        raise HTTPException(status_code=422, detail=f"could not parse {req.filename}: {exc}") from None
+    if not text.strip():
+        raise HTTPException(status_code=422,
+                            detail=f"no extractable text in {req.filename} (scanned/image-only PDFs need OCR first)")
+    return await _run_ingest_pipeline(
+        req.project, text.strip(), req.filename, req.source,
+        extra_prov={"file_sha": hashlib.sha256(data).hexdigest()})
 
 
 class NodeRequest(BaseModel):

--- a/apps/lattice-studio/tests/test_file_front_door.py
+++ b/apps/lattice-studio/tests/test_file_front_door.py
@@ -1,0 +1,107 @@
+"""File front door: /api/studio/ingest-file — PDF/DOCX/txt/md → text → the shared IE→ER→graph pipeline.
+
+Format handling is tested with REAL in-memory documents (python-docx builds a docx; pypdf builds a
+blank pdf), not fixtures — so a parser bump that changes behavior fails here, not in production.
+"""
+import base64
+import io
+
+from fastapi.testclient import TestClient
+
+import lattice_studio.server as srv
+from lattice_studio.server import _doc_to_text, app
+
+client = TestClient(app)
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode()
+
+
+async def _fake_req(client_, method, url, json=None):
+    # IE/ER/hellgraph all "reachable": IE returns one entity so the pipeline has something to write.
+    if "ie-engine" in url:
+        return {"entities": [{"text": "Guzman & Gomez", "type": "Organization"}], "relations": [], "claims": []}, None
+    if "/resolve" in url:
+        return {"replay_key": "er:x", "merged": 0, "review_queue": [],
+                "entities": [{"entity_id": "ent:m0", "members": ["m0"], "size": 1,
+                              "canonical": {"survivor": "m0", "name": "Guzman & Gomez"}}]}, None
+    return {"ok": True}, None
+
+
+def test_ingest_file_write_gate(monkeypatch):
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "")
+    r = client.post("/api/studio/ingest-file",
+                    json={"filename": "a.txt", "content_b64": _b64(b"hello")})
+    assert r.status_code == 503  # fail-closed
+
+
+def test_ingest_file_rejects_bad_b64_empty_and_oversize(monkeypatch):
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    hdr = {"authorization": "Bearer secret"}
+    assert client.post("/api/studio/ingest-file", headers=hdr,
+                       json={"filename": "a.txt", "content_b64": "not!!base64??"}).status_code == 400
+    assert client.post("/api/studio/ingest-file", headers=hdr,
+                       json={"filename": "a.txt", "content_b64": ""}).status_code == 400
+    monkeypatch.setattr("lattice_studio.server.MAX_FILE_BYTES", 4)
+    assert client.post("/api/studio/ingest-file", headers=hdr,
+                       json={"filename": "a.txt", "content_b64": _b64(b"12345")}).status_code == 413
+
+
+def test_ingest_file_unsupported_type_names_the_alternative(monkeypatch):
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    r = client.post("/api/studio/ingest-file", headers={"authorization": "Bearer secret"},
+                    json={"filename": "data.csv", "content_b64": _b64(b"a,b\n1,2")})
+    assert r.status_code == 415
+    assert "/api/studio/ingest" in r.json()["detail"]  # tabular data has its own door
+
+
+def test_ingest_file_txt_runs_pipeline_with_file_provenance(monkeypatch):
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    monkeypatch.setattr(srv, "_req", _fake_req)
+    raw = b"Guzman & Gomez opened 12 stores."
+    r = client.post("/api/studio/ingest-file", headers={"authorization": "Bearer secret"},
+                    json={"project": "team-x", "filename": "gyg.txt", "content_b64": _b64(raw)})
+    assert r.status_code == 200
+    b = r.json()
+    assert b["projectCollection"] == "proj-teamx"
+    assert b["written"]["nodes"] == 1
+    # double provenance: file_sha (dropped bytes) AND doc_sha (extracted text) — both traceable
+    import hashlib
+    assert b["provenance"]["file_sha"] == hashlib.sha256(raw).hexdigest()
+    assert b["provenance"]["doc_sha"] == hashlib.sha256(raw.decode().strip().encode()).hexdigest()
+    assert b["provenance"]["filename"] == "gyg.txt"
+
+
+def test_docx_conversion_includes_paragraphs_and_tables():
+    from docx import Document
+    d = Document()
+    d.add_paragraph("Guzman & Gomez quarterly report.")
+    t = d.add_table(rows=1, cols=2)
+    t.rows[0].cells[0].text = "Revenue"
+    t.rows[0].cells[1].text = "$12m"
+    buf = io.BytesIO()
+    d.save(buf)
+    text = _doc_to_text("report.docx", buf.getvalue())
+    assert "Guzman & Gomez quarterly report." in text
+    assert "Revenue | $12m" in text  # tables carry the numbers — must survive conversion
+
+
+def test_blank_pdf_yields_422_not_500(monkeypatch):
+    from pypdf import PdfWriter
+    w = PdfWriter()
+    w.add_blank_page(width=612, height=792)  # a page with no extractable text (scan-like)
+    buf = io.BytesIO()
+    w.write(buf)
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    r = client.post("/api/studio/ingest-file", headers={"authorization": "Bearer secret"},
+                    json={"filename": "scan.pdf", "content_b64": _b64(buf.getvalue())})
+    assert r.status_code == 422
+    assert "OCR" in r.json()["detail"]
+
+
+def test_corrupt_pdf_yields_422_not_500(monkeypatch):
+    monkeypatch.setattr("lattice_studio.server.STUDIO_WRITE_TOKEN", "secret")
+    r = client.post("/api/studio/ingest-file", headers={"authorization": "Bearer secret"},
+                    json={"filename": "broken.pdf", "content_b64": _b64(b"%PDF-1.4 garbage")})
+    assert r.status_code == 422


### PR DESCRIPTION
## What
`POST /api/studio/ingest-file` — completes the literal ST024 outcome on top of #953: **drop a file in, get linked knowledge out**. Decodes a base64 JSON payload, converts the document (pypdf / python-docx / utf-8), and runs the exact same governed IE→ER→graph pipeline as `/ingest-document` (shared core extracted as `_run_ingest_pipeline()`).

## Notes
- First document-format handling in the estate — the survey found zero PDF/docx support anywhere
- docx **tables flattened row-wise** (`Revenue | $12m`) — tables carry the numbers in business docs
- Double provenance: `file_sha` (dropped bytes) + `doc_sha` (extracted text) on every fact
- Guardrails: fail-closed write gate · 400 bad base64/empty · 413 size cap (`STUDIO_MAX_FILE_BYTES`, 20MB default) · 415 unsupported (csv/json redirected to `/api/studio/ingest`) · 422 corrupt/no-text (scanned PDFs told they need OCR) — parser failures can never 500
- Formats tested against **real in-memory documents** (python-docx/pypdf construct them in-test), not fixtures

## Verification
7 new tests; suite **237 passed**, same 2 pre-existing local-env failures as main (ontology/SHACL fixtures, untouched).

## Follow-up
GYG (ST028) + Berger (ST027) corpora through this door once source docs are staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)