### PR TITLE
fix(lattice-studio): SHACL writeback validation was vacuous — empty prefix map, pyshacl targeted nothing

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/ontology.py
+++ b/apps/lattice-studio/src/lattice_studio/ontology.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from functools import lru_cache
 from typing import Any
 
@@ -76,9 +77,30 @@ def _resolve_property(props: dict[str, dict[str, Any]], name: str) -> dict[str, 
     return next((p for p in props.values() if str(p.get("label", "")).lower() == low), None)
 
 
+_SHAPES_TTL_PATH = os.path.join(os.path.dirname(__file__), "data", "ontogenesis_shapes.ttl")
+
+
 @lru_cache(maxsize=1)
 def prefixes() -> dict[str, str]:
-    return _index().get("prefixes", {})
+    """Corpus prefix map, from the index when present, else recovered from the vendored shapes TTL.
+
+    The fallback is load-bearing: gen_ontogenesis_index.py historically emitted NO 'prefixes' key, so
+    expand() returned curies unexpanded — and pyshacl then targeted nothing (rdf:type <sp:Surface> never
+    matches the shapes' full IRIs), silently turning SHACL writeback validation into a vacuous pass.
+    The shapes TTL binds every corpus prefix in exactly the namespace world the validator resolves
+    against, so it is the authoritative recovery source."""
+    pf = dict(_index().get("prefixes", {}))
+    if pf:
+        return pf
+    try:
+        with open(_SHAPES_TTL_PATH, encoding="utf-8") as fh:
+            for line in fh:
+                m = re.match(r"\s*@prefix\s+([\w-]*):\s*<([^>]+)>", line)
+                if m and m.group(1):
+                    pf.setdefault(m.group(1), m.group(2))
+    except OSError:
+        pass
+    return pf
 
 
 def expand(curie: str) -> str:

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -1157,12 +1157,22 @@ def test_action_define_requires_token_and_effects(monkeypatch):
 
 def test_ontology_serves_real_classes_not_a_mock():
     b = client.get("/api/studio/ontology").json()
-    assert b["counts"]["classes"] == 817                                   # the real Ontogenesis corpus
+    assert b["counts"]["classes"] == 827                    # the real Ontogenesis corpus (+10 health classes, #936)
     assert b["base_iri"].endswith("ontogenesis#")
     assert any(c["iri"] == "upper:Entity" for c in b["classes"])           # upper ontology by default
     one = client.get("/api/studio/ontology?cls=ACSETAttr").json()
     props = {p["iri"] for p in one["class"]["inherited_properties"]}
     assert "acsetAttrName" in props and "attrType" in props                # real declared properties
+
+
+def test_ontology_prefixes_expand_to_full_iris():
+    """REGRESSION — the silent-wrong that disarmed SHACL: the generated index carried no prefix map, so
+    expand() returned curies unexpanded and pyshacl targeted nothing (every writeback vacuously conformed).
+    expand() must yield a real IRI for shape-constrained prefixes, whatever the index version."""
+    from lattice_studio import ontology
+    assert ontology.prefixes(), "prefix map must never be empty"
+    expanded = ontology.expand("sp:Surface")
+    assert expanded.startswith("http") and expanded.endswith("#Surface")
 
 
 def test_action_define_rejects_non_ontology_class(monkeypatch):

--- a/apps/lattice-studio/tools/gen_ontogenesis_index.py
+++ b/apps/lattice-studio/tools/gen_ontogenesis_index.py
@@ -63,6 +63,9 @@ def main() -> None:
     index = {
         "source": "ontogenesis", "commit": commit, "base_iri": "https://socioprophet.dev/ont/ontogenesis#",
         "parsed_files": parsed,
+        # The prefix map is LOAD-BEARING: ontology.expand() needs it to turn curies into full IRIs.
+        # Without it, SHACL writeback validation silently targets nothing (vacuous conforms=True).
+        "prefixes": {p: str(ns) for p, ns in g.namespaces() if p and not p.startswith(("xml", "rdf", "rdfs", "owl", "xsd"))},
         "counts": {"classes": len(classes),
                    "object_properties": sum(1 for v in props_by_domain.values() for e in v if e["kind"] == "object"),
                    "datatype_properties": sum(1 for v in props_by_domain.values() for e in v if e["kind"] == "datatype")},


### PR DESCRIPTION
## The bug (real, silent, live since #831)
`test_action_invoke_shacl_rejects_nonconformant_writeback` failed locally (200 where 422 expected) — and it was **not** env drift:

1. `gen_ontogenesis_index.py` never emitted a `prefixes` key → `ontology.expand()` returned curies unexpanded (`sp:Surface`, not the full IRI)
2. Candidate nodes were typed `rdf:type <sp:Surface>`, which matches **no** `sh:targetClass` in the shapes graph (turtle expands prefixes to full IRIs)
3. pyshacl vacuously reports `conforms=True` → **every nonconformant action writeback has passed the SHACL gate since it shipped** (#831)
4. Invisible because **no CI workflow runs lattice-studio's pytest suite** — the one test that catches this only ever ran on dev machines

## Fixes
- `ontology.prefixes()`: when the index has no prefix map, recover it from the vendored shapes TTL's `@prefix` bindings — the exact namespace world the validator resolves against; repairs every already-generated index
- Generator now emits the prefix map for future regens
- Regression test pinning `expand('sp:Surface')` → full IRI
- Class-count assertion 817 → 827 (corpus legitimately grew +10 health classes in #936 — the second, unrelated stale failure)

## Verification
lattice-studio suite: **240 passed, 0 failed** — fully green for the first time. The SHACL rejection test now passes because the gate actually rejects.

## Follow-up (separate)
Wire lattice-studio's pytest into CI so this class of silent failure can't hide again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)