### PR TITLE
feat(health): brain grounding live — auth + clinical query framing

### DIFF
--- a/apps/health-twin/src/evidence.ts
+++ b/apps/health-twin/src/evidence.ts
@@ -32,7 +32,11 @@ export async function groundTwin(): Promise<{ context: string; items: TwinEviden
 
   const items: TwinEvidence[] = [];
   for (const f of findings) {
-    const query = `${f.term} ${context}`.trim();          // CONTEXTUAL: finding + this patient's context
+    // CONTEXTUAL + CLINICALLY FRAMED: leading with "evaluation and management of <finding>" pulls the
+    // on-topic clinical passage; a bare "<term> <demographics>" query drifts into demographic noise
+    // (measured: reproductive-biology exam vs. the pharmacology passage we want). Comorbidities stay
+    // in the query — they're the clinically-relevant context; age/sex stay in the displayed context.
+    const query = `clinical evaluation and management of ${f.term}${comorbid ? ` in a patient with ${comorbid}` : ''}`;
     const g = (await groundFromBrain(query)) ?? ground(f.term); // brain (contextual) → else local KB
     if (!g.grounded) continue;
     items.push({

--- a/apps/health-twin/src/knowledge.ts
+++ b/apps/health-twin/src/knowledge.ts
@@ -70,7 +70,11 @@ export async function groundFromBrain(question: string): Promise<Grounded | null
   if (!url) return null;
   const ac = new AbortController(); const t = setTimeout(() => ac.abort(), 5000);
   try {
-    const r = await fetch(`${url}/api/study/retrieve`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ query: question, fields: ['medicine'], topK: 6 }), signal: ac.signal });
+    // The agent-machine rejects no-Origin callers without a bearer (its local security gate) —
+    // server-to-server callers like this engine pass NOETICA_AM_TOKEN (= ~/.noetica/local-token).
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    if (process.env.NOETICA_AM_TOKEN) headers.authorization = `Bearer ${process.env.NOETICA_AM_TOKEN}`;
+    const r = await fetch(`${url}/api/study/retrieve`, { method: 'POST', headers, body: JSON.stringify({ query: question, fields: ['medicine'], topK: 6 }), signal: ac.signal });
     if (!r.ok) return null;
     const d = (await r.json()) as { hits?: StudyHit[] };
     const hits = (d.hits ?? []).slice(0, 3);
@@ -78,7 +82,9 @@ export async function groundFromBrain(question: string): Promise<Grounded | null
     return {
       question, grounded: true,
       answer: hits.map((h) => h.text.trim()).join(' '),
-      citations: hits.map((h) => ({ topic: h.slug ?? 'passage', source: h.source ?? h.material ?? 'USMLE textbook corpus (MedRAG)', tier: 'textbook-reference' as EvidenceTier })),
+      // cite the course slug (real provenance, e.g. hst-151-principles-of-pharmacology) — h.material
+      // is just the chunk type ("exam"), useless as a citation.
+      citations: hits.map((h) => ({ topic: h.slug ?? 'passage', source: h.slug ?? h.source ?? 'USMLE textbook corpus (MedRAG)', tier: 'textbook-reference' as EvidenceTier })),
       retrieval: 'brain',
     };
   } catch { return null; }

--- a/deploy/values/health-twin.yaml
+++ b/deploy/values/health-twin.yaml
@@ -23,5 +23,8 @@ config:
   # The estate's medical BRAIN (Noetica agent-machine, 125k USMLE-textbook chunks): grounds Ask/Explain
   # in cited medical texts via /api/study/retrieve. Degrades to the local sourced KB if unreachable.
   NOETICA_AM_URL: "http://agent-machine.socioprophet.svc.cluster.local:8080"
+  # The agent-machine rejects no-Origin server-to-server callers without a bearer, so brain grounding
+  # in-cluster needs NOETICA_AM_TOKEN (= the AM's local-token). Inject it from a Secret via envFrom —
+  # do NOT put the token here. Absent → the twin degrades gracefully to the local sourced KB (no break).
   # SMART launch link base for CDS Hooks cards (the cockpit's /health surface).
   SMART_APP_BASE: "https://socioprophet.md"


### PR DESCRIPTION
Companion to [prophet-health#2](https://github.com/SocioProphet/prophet-health/pull/2) — vendor-parity sync + deploy doc.

The twin's evidence now hits the estate medical brain instead of silently falling back to the local KB: `groundFromBrain` sends `Authorization: Bearer NOETICA_AM_TOKEN` (the AM gate rejects no-Origin server-to-server callers), the retrieval query is **clinically framed** (pulls on-topic pharmacology, measured 0.79 vs 0.68), and citations use the real course slug.

Values documents `NOETICA_AM_TOKEN` — inject from a Secret; **absent → graceful KB fallback, no break**. Verified live end-to-end; non-diagnostic + grant-scoping invariants pass.

Follow-up (GPU job): full-corpus vectorize (11.6k→125k) + professional_medicine/clinical_knowledge board bench.