### PR TITLE
ci: push-to-main diagnostics runs + single diagnostics-gate check for rulesets

### DIFF
--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -3,6 +3,8 @@ name: validate-target-diagnostics
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -154,3 +156,18 @@ jobs:
           python-version: '3.11'
       - name: Run target
         run: make ${{ matrix.target }}
+
+  # Single stable check name for branch-protection rulesets: requiring this one
+  # job covers every matrix leg above (and any added later) without having to
+  # enumerate ~45 per-target check names in repo settings.
+  diagnostics-gate:
+    if: always()
+    needs: [validate-target-diagnostics, app-test-diagnostics, smoke-target-diagnostics]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any diagnostics job failed
+        run: |
+          echo "validate=${{ needs.validate-target-diagnostics.result }}"
+          echo "app-tests=${{ needs.app-test-diagnostics.result }}"
+          echo "smokes=${{ needs.smoke-target-diagnostics.result }}"
+          [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "false" ]


### PR DESCRIPTION
## Why

Investigation into "why did the vacuous SHACL writeback bug (#831, fixed by #955) sit invisible?" found the premise wrong: **lattice-studio's full pytest suite already runs on every PR** via `smoke-target-diagnostics (lattice-studio-smoke)` in this workflow — and it has been **failing red on every PR since Jul 17** (e.g. run 29922944480 on an unrelated branch: `test_action_invoke_shacl_rejects_nonconformant_writeback` + `test_ontology_serves_real_classes_not_a_mock`, `2 failed, 224 passed`).

The real gap is enforcement: `main` has no branch protection, so red checks never block a merge, and the failure was 1 of ~45 matrix jobs in 1 of 102 workflows.

## What

1. **`push: branches: [main]` trigger** — main itself now gets a post-merge diagnostics run (previously PR-only, so main never had a signal).
2. **`diagnostics-gate` job** — a single terminal job that `needs:` all three matrix jobs and fails if any leg failed or was cancelled. This gives branch-protection rulesets one stable check name to require; new matrix targets are covered automatically without touching repo settings.

A ruleset on `main` requiring `diagnostics-gate` (repo-admin bypass) is being added in repo settings alongside this PR.

## Merge order

**Merge #955 first.** This PR's own `diagnostics-gate` will stay red until the lattice-studio fix lands on main (the failing tests come from main, not this diff); after #955 merges, re-run or rebase and it goes green.

## Notes / follow-ups

- memoryd + entity-resolution pytest suites are already covered here (`memoryd-smoke`, `entity-resolution-smoke`) — no new workflow needed. commons-search is TypeScript with no test dir; nothing to add.
- Existing open PRs won't report `diagnostics-gate` until they pick up this workflow (rebase or close/reopen after merge); admins bypass in the meantime.
- Possible follow-up: also require `ci` workflow jobs (build-go / build-web) in the ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)