### PR TITLE
feat(compute-gateway): ingest + parse kinds — IFM 5-stage pipeline complete (ST028)

### DIFF
--- a/apps/compute-gateway/requirements.txt
+++ b/apps/compute-gateway/requirements.txt
@@ -4,3 +4,5 @@ pydantic>=2.6
 httpx>=0.27
 cryptography>=42.0
 jsonschema>=4.21
+pypdf>=5.1
+python-pptx>=1.0

--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -7,7 +7,11 @@ Adapters are injectable (`set_backend`) so tests never need a live forge/graph.
 """
 from __future__ import annotations
 
+import base64
+import hashlib
+import io
 import os
+import re
 import sqlite3
 import time
 from typing import Any, Awaitable, Callable
@@ -142,6 +146,124 @@ async def _inference(req_spec: dict, project: str, session: str | None) -> Adapt
     except Exception as e:  # noqa: BLE001
         return {"outputs": [], "runtime": "model-server", "status": "degraded",
                 "error": None, "degraded": f"model-server unreachable: {e}"}
+
+
+# ── IFM stages 01–02: land the pack, parse it to blocks ──
+_EMU_PER_PT = 12700  # PowerPoint positions are EMU; points are what humans cite
+
+
+def _sniff_media(filename: str, raw: bytes) -> str:
+    """Magic-bytes first (filenames lie), extension as tiebreak for zip containers."""
+    if raw[:5] == b"%PDF-":
+        return "application/pdf"
+    if raw[:4] == b"PK\x03\x04":  # OOXML container — pptx and docx share it
+        ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        if ext == "pptx":
+            return "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        if ext == "docx":
+            return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        return "application/zip"
+    return "text/plain"
+
+
+async def _ingest(req_spec: dict, project: str, session: str | None) -> AdapterResult:
+    """Stage 01 — land the pack by content hash. The sha256 is over the RAW bytes, so
+    identical packs hash identically whatever they're named, and a re-run of the same
+    request memoizes (the dedupe). Threads document_b64 + media_type to parse."""
+    try:
+        raw = base64.b64decode(req_spec.get("document_b64") or "", validate=True)
+    except Exception:  # noqa: BLE001
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": "ingest needs document_b64 (valid base64)", "degraded": None}
+    if not raw:
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": "ingest needs document_b64 (valid base64)", "degraded": None}
+    filename = str(req_spec.get("filename") or "")
+    media = str(req_spec.get("media_type") or _sniff_media(filename, raw))
+    return {"outputs": [ComputeOutput(type="artifact", data={
+                "sha256": hashlib.sha256(raw).hexdigest(), "size": len(raw),
+                "media_type": media, "filename": filename,
+                "document_b64": req_spec.get("document_b64")})],
+            "runtime": "gateway", "status": "ok", "error": None, "degraded": None,
+            "epistemic": "observed"}
+
+
+def _pdf_blocks(raw: bytes) -> tuple[list[dict], int]:
+    from pypdf import PdfReader  # lazy: parse is the only kind that needs it
+    reader = PdfReader(io.BytesIO(raw))
+    blocks: list[dict] = []
+    for pno, page in enumerate(reader.pages, 1):
+        text = (page.extract_text() or "").strip()
+        region = 0
+        for para in re.split(r"\n\s*\n", text):
+            para = para.strip()
+            if para:
+                blocks.append({"page": pno, "region": region, "kind": "text", "text": para})
+                region += 1
+    return blocks, len(reader.pages)
+
+
+def _pptx_blocks(raw: bytes) -> tuple[list[dict], int]:
+    from pptx import Presentation  # lazy, same reason
+    prs = Presentation(io.BytesIO(raw))
+    blocks: list[dict] = []
+    n = 0
+    for sno, slide in enumerate(prs.slides, 1):
+        n = sno
+        for shape in slide.shapes:
+            bbox = None
+            if shape.left is not None and shape.top is not None:
+                bbox = [round(shape.left / _EMU_PER_PT, 1), round(shape.top / _EMU_PER_PT, 1),
+                        round((shape.width or 0) / _EMU_PER_PT, 1), round((shape.height or 0) / _EMU_PER_PT, 1)]
+            if getattr(shape, "has_table", False):
+                # tables carry the numbers — cells pipe-joined row-wise, one block per table
+                rows = "\n".join(" | ".join(c.text.strip() for c in row.cells) for row in shape.table.rows)
+                if rows.strip():
+                    blocks.append({"page": sno, "kind": "table", "text": rows, "bbox": bbox})
+            elif getattr(shape, "has_text_frame", False) and shape.text_frame.text.strip():
+                blocks.append({"page": sno, "kind": "text", "text": shape.text_frame.text.strip(), "bbox": bbox})
+    return blocks, n
+
+
+async def _parse(req_spec: dict, project: str, session: str | None) -> AdapterResult:
+    """Stage 02 — document bytes → blocks[], each keeping its page (+ bbox in points for
+    PPTX shapes, tables pipe-joined; page/paragraph regions for PDF). Consumes the fields
+    ingest threads in; a corrupt or unsupported document is an ERROR, never a crash."""
+    try:
+        raw = base64.b64decode(req_spec.get("document_b64") or "", validate=True)
+    except Exception:  # noqa: BLE001
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": "parse needs document_b64 (thread it from an ingest step)", "degraded": None}
+    if not raw:
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": "parse needs document_b64 (thread it from an ingest step)", "degraded": None}
+    filename = str(req_spec.get("filename") or "")
+    media = str(req_spec.get("media_type") or _sniff_media(filename, raw))
+    try:
+        if media == "application/pdf":
+            blocks, pages = _pdf_blocks(raw)
+        elif media.endswith("presentationml.presentation"):
+            blocks, pages = _pptx_blocks(raw)
+        elif media.startswith("text/"):
+            text = raw.decode("utf-8", errors="replace").strip()
+            blocks = [{"page": 1, "region": i, "kind": "text", "text": p.strip()}
+                      for i, p in enumerate(re.split(r"\n\s*\n", text)) if p.strip()]
+            pages = 1
+        else:
+            return {"outputs": [], "runtime": "gateway", "status": "error",
+                    "error": f"parse: unsupported media type {media}", "degraded": None}
+    except Exception as e:  # noqa: BLE001 — corrupt document → honest error, not a 500
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": f"parse failed: {e}", "degraded": None}
+    if not blocks:
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": "parse: no extractable content (image-only/scanned documents need OCR)",
+                "degraded": None}
+    return {"outputs": [ComputeOutput(type="blocks", data={
+                "blocks": blocks, "pages": pages, "media_type": media,
+                "sha256": req_spec.get("sha256"), "filename": filename})],
+            "runtime": "gateway", "status": "ok", "error": None, "degraded": None,
+            "epistemic": "observed"}
 
 
 # ── IFM: document → structured facts (extraction) + reconcile vs open data ──
@@ -335,6 +457,8 @@ _BACKENDS: dict[str, Callable[..., Awaitable[AdapterResult]]] = {
     "hellgraph:graph-stats": lambda spec, project, session: _hellgraph_stats(spec, project),
     "spark-runner": lambda spec, project, session: _spark(spec, project, session),
     "model-server": lambda spec, project, session: _inference(spec, project, session),
+    "gateway:ingest": lambda spec, project, session: _ingest(spec, project, session),
+    "gateway:parse": lambda spec, project, session: _parse(spec, project, session),
     "holmes": lambda spec, project, session: _extraction(spec, project, session),
     "open-data": lambda spec, project, session: _reconcile(spec, project, session),
     "sql": lambda spec, project, session: _sql_load(spec, project, session),

--- a/apps/compute-gateway/src/compute_gateway/registry.py
+++ b/apps/compute-gateway/src/compute_gateway/registry.py
@@ -52,6 +52,20 @@ KINDS: dict[str, dict] = {
         "epistemic": "derived", "executes_user_code": False, "status": "live",
     },
     # ── IFM: document → SQL, proof-carrying ──
+    # Land the pack (stage 01): content-hash the raw bytes so identical packs are
+    # comparable and re-runs are free (request memoization = the dedupe). In-process.
+    "ingest": {
+        "backends": ["gateway"], "default": "gateway",
+        "capabilities": ["content-address", "pdf", "pptx", "dedupe"],
+        "epistemic": "observed", "executes_user_code": False, "status": "live",
+    },
+    # Layout-aware parse (stage 02): document bytes → blocks[], each keeping its page
+    # (+ shape bbox for PPTX, table cells pipe-joined; page/paragraph regions for PDF).
+    "parse": {
+        "backends": ["gateway"], "default": "gateway",
+        "capabilities": ["pdf", "pptx", "text-blocks", "tables", "page-regions"],
+        "epistemic": "observed", "executes_user_code": False, "status": "live",
+    },
     # Extract a (graphics-heavy) document into typed rows against a target schema;
     # each fact carries its lineage + warrant. Backend = Holmes/Sherlock (Studio).
     "extraction": {

--- a/apps/compute-gateway/tests/test_ingest_parse.py
+++ b/apps/compute-gateway/tests/test_ingest_parse.py
@@ -1,0 +1,160 @@
+"""IFM stages 01–02: ingest (content-address the pack) + parse (bytes → page-keeping blocks),
+completing the 5-stage governed pipeline: ingest → parse → extract → reconcile → load.
+
+Documents are built in-test (python-pptx / pypdf), not fixtures — a parser bump that changes
+behavior fails here first.
+"""
+import base64
+import hashlib
+import importlib
+import io
+import os
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import adapters, engine, receipts, server, zerotrust  # noqa: E402
+
+importlib.reload(zerotrust)
+importlib.reload(engine)
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+
+_ORIG_HOLMES = adapters._BACKENDS["holmes"]
+_ORIG_REFERENCE = adapters._REFERENCE
+
+
+def setup_function():
+    os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+    receipts._CHAINS.clear()
+    engine._MEMO.clear()
+
+
+def teardown_function():
+    # module-level injections must not leak into other test files (suite runs in one process)
+    adapters.set_backend("holmes", _ORIG_HOLMES)
+    adapters.set_reference_resolver(_ORIG_REFERENCE)
+
+
+def _compute(body):
+    return client.post("/v1/compute", json={"project": "demo", **body}, headers=AUTH).json()
+
+
+def _b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode()
+
+
+def _pptx_pack() -> bytes:
+    """A minimal graphics-heavy 'investor pack': title text + a financials table."""
+    from pptx import Presentation
+    from pptx.util import Inches
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[5])   # title-only layout
+    slide.shapes.title.text = "GYG FY26 Results"
+    tbl = slide.shapes.add_table(2, 2, Inches(1), Inches(2), Inches(6), Inches(1)).table
+    tbl.cell(0, 0).text = "Revenue"
+    tbl.cell(0, 1).text = "$1,204m"
+    tbl.cell(1, 0).text = "Net profit"
+    tbl.cell(1, 1).text = "$14m"
+    buf = io.BytesIO()
+    prs.save(buf)
+    return buf.getvalue()
+
+
+# ── ingest ──
+def test_ingest_content_addresses_the_raw_bytes():
+    raw = b"Quarterly trading update.\n\nRevenue rose."
+    r = _compute({"kind": "ingest", "spec": {"document_b64": _b64(raw), "filename": "update.txt"}})
+    assert r["status"] == "ok" and r["epistemic_status"] == "observed"
+    d = r["outputs"][0]["data"]
+    assert d["sha256"] == hashlib.sha256(raw).hexdigest()      # hash of the BYTES, not the name
+    assert d["size"] == len(raw) and d["media_type"] == "text/plain"
+    assert r["receipt"]["id"]                                  # sealed like any governed compute
+
+
+def test_ingest_rejects_missing_or_bad_b64():
+    assert _compute({"kind": "ingest", "spec": {}})["status"] == "error"
+    assert _compute({"kind": "ingest", "spec": {"document_b64": "!!not-b64!!"}})["status"] == "error"
+
+
+def test_ingest_media_sniff_prefers_magic_bytes():
+    pdfish = b"%PDF-1.7 minimal"
+    r = _compute({"kind": "ingest", "spec": {"document_b64": _b64(pdfish), "filename": "lying.txt"}})
+    assert r["outputs"][0]["data"]["media_type"] == "application/pdf"   # magic bytes beat the filename
+
+
+# ── parse ──
+def test_parse_pptx_keeps_pages_tables_and_bbox():
+    r = _compute({"kind": "parse", "spec": {"document_b64": _b64(_pptx_pack()), "filename": "pack.pptx"}})
+    assert r["status"] == "ok" and r["epistemic_status"] == "observed"
+    d = r["outputs"][0]["data"]
+    kinds = {b["kind"] for b in d["blocks"]}
+    assert "table" in kinds and "text" in kinds
+    table = next(b for b in d["blocks"] if b["kind"] == "table")
+    assert "Revenue | $1,204m" in table["text"]                # tables carry the numbers
+    assert table["page"] == 1 and table["bbox"] is not None    # page + region provenance
+    assert all(isinstance(v, (int, float)) for v in table["bbox"])
+
+
+def test_parse_text_and_error_paths():
+    r = _compute({"kind": "parse", "spec": {"document_b64": _b64(b"Para one.\n\nPara two."), "filename": "n.txt"}})
+    assert r["status"] == "ok" and len(r["outputs"][0]["data"]["blocks"]) == 2
+
+    # blank PDF (scan-like) → honest error naming OCR, never a crash
+    from pypdf import PdfWriter
+    w = PdfWriter(); w.add_blank_page(width=612, height=792)
+    buf = io.BytesIO(); w.write(buf)
+    r = _compute({"kind": "parse", "spec": {"document_b64": _b64(buf.getvalue()), "filename": "scan.pdf"}})
+    assert r["status"] == "error" and "OCR" in r["error"]
+
+    # corrupt PDF → error, not a 500
+    r = _compute({"kind": "parse", "spec": {"document_b64": _b64(b"%PDF-1.4 garbage"), "filename": "b.pdf"}})
+    assert r["status"] == "error"
+
+
+# ── the full 5-stage governed pipeline ──
+def test_five_stage_pipeline_document_to_sql(tmp_path, monkeypatch):
+    monkeypatch.setattr(adapters, "SQL_DSN", str(tmp_path / "ifm.db"), raising=False)
+
+    async def ref(entity, field, period):
+        return {"revenue": 1204.0}.get(field)                  # open-data stand-in agrees with the pack
+    adapters.set_reference_resolver(ref)
+
+    async def extract_from_blocks(spec, project, session):
+        # a deterministic extractor over the THREADED parse blocks — proves data flows
+        # ingest→parse→extract through `from`, not via hand-fed specs
+        table_txt = next(b["text"] for b in spec["blocks"] if b["kind"] == "table")
+        first = table_txt.splitlines()[0].split(" | ")
+        value = float(first[1].replace("$", "").replace(",", "").rstrip("m"))
+        return {"outputs": [adapters.ComputeOutput(type="table", data={
+                    "table": spec["target_schema"]["table"],
+                    "rows": [{"field": "revenue", "value": value, "unit": "AUD_m",
+                              "page": spec["blocks"][0]["page"], "source_span": "tbl1/r1",
+                              "warrant": "observed"}],
+                    "entity": spec.get("entity"), "period": spec.get("period")})],
+                "runtime": "holmes", "status": "ok", "error": None, "degraded": None,
+                "epistemic": "observed"}
+    adapters.set_backend("holmes", extract_from_blocks)
+
+    r = _compute({"kind": "workflow", "spec": {"steps": [
+        {"id": "ingest", "kind": "ingest", "spec": {"document_b64": _b64(_pptx_pack()), "filename": "pack.pptx"}},
+        {"id": "parse", "kind": "parse", "from": "ingest"},
+        {"id": "extract", "kind": "extraction", "from": "parse",
+         "spec": {"target_schema": {"table": "financials"}, "entity": {"cik": "0"}, "period": "FY26"}},
+        {"id": "reconcile", "kind": "reconcile", "from": "extract", "spec": {"tolerance": 0.01}},
+        {"id": "load", "kind": "load", "from": "reconcile", "spec": {"table": "financials"}},
+    ]}})
+    assert r["status"] == "ok" and r["kind"] == "workflow"
+    d = r["outputs"][0]["data"]
+    steps = {s["id"]: s for s in d["steps"]}
+    assert [*steps] == ["ingest", "parse", "extract", "reconcile", "load"]
+    assert steps["ingest"]["epistemic_status"] == "observed"
+    assert steps["reconcile"]["epistemic_status"] == "verified"   # pack agreed with the reference
+    assert all(s["receipt"] for s in d["steps"])                  # every stage sealed its own receipt
+    # 5 step receipts + 1 composite
+    assert client.get("/v1/receipts", params={"project": "demo"}, headers=AUTH).json()["count"] == 6


### PR DESCRIPTION
## What
The two missing stages of the IFM doc→SQL design. The full governed pipeline now runs end-to-end:

```
ingest (01) → parse (02) → extraction (03) → reconcile (04) → load (05)
```

- **ingest**: land the pack by content hash — sha256 over the raw bytes (identical packs hash identically whatever they're named); request memoization is the dedupe; magic-bytes media sniffing (filenames lie). Threads `document_b64` + media type to parse.
- **parse**: bytes → `blocks[]`, each keeping its page. PPTX per-shape with **real bbox** (EMU→points) and tables pipe-joined row-wise; PDF page+paragraph regions. Corrupt/image-only docs are honest errors naming the remedy (OCR) — never crashes.
- Both in-process (backend `gateway`), warrant `observed`, receipt-sealed and entitlement-gated like every governed compute.

## Proof
New end-to-end test builds a PPTX investor pack **in-test**, then: ingest → parse → extract revenue from the *threaded* table blocks → reconcile (promotes to `verified`) → SQL row landed — **5 step receipts + 1 composite**, weakest-link warrant intact.

6 new tests; compute-gateway suite **67 passed**.

## Next (separate PRs)
- Fact-mode extract endpoint (the `{blocks, target_schema} → {facts[]}` contract the extraction adapter already speaks)
- EDGAR `companyfacts` switch + wider concept map; `asx` reference backend (AU: reconcile pack vs statutory Appendix 4E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)