### PR TITLE
feat(lattice-studio): fact-mode extraction endpoint — gateway's extraction backend now real (ST028)

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -171,10 +171,13 @@ async def _extraction(req_spec: dict, project: str, session: str | None) -> Adap
     if facts is None:
         headers = {"Authorization": f"Bearer {EXTRACT_TOKEN}"} if EXTRACT_TOKEN else {}
         body = {"project": project, "document": req_spec.get("document"),
-                "blocks": req_spec.get("blocks"), "target_schema": schema}
+                "blocks": req_spec.get("blocks"), "target_schema": schema,
+                "period": req_spec.get("period")}
         try:
             async with httpx.AsyncClient(timeout=TIMEOUT, headers=headers) as c:
-                r = await c.post(f"{EXTRACT_URL}/api/studio/extract", json=body)
+                # fact-mode endpoint: {blocks, target_schema, period} → {facts[]} — NOT the
+                # graph-writing /api/studio/extract, whose contract is text→entities.
+                r = await c.post(f"{EXTRACT_URL}/api/studio/extract-facts", json=body)
                 if r.status_code != 200:
                     return {"outputs": [], "runtime": "holmes", "status": "error",
                             "error": f"extract HTTP {r.status_code}", "degraded": None}

--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -2759,6 +2759,131 @@ async def ingest_file(req: IngestFileRequest, authorization: str = Header(defaul
         extra_prov={"file_sha": hashlib.sha256(data).hexdigest()})
 
 
+# ---------------------------------------------------------------------------
+# Fact-mode extraction (IFM stage 03): parse blocks → typed facts against a target
+# SQL schema. This serves the contract the compute-gateway extraction adapter speaks
+# ({blocks, target_schema} → {facts[]}) — deterministic, span-preserving, and it
+# NEVER fabricates: a field the document doesn't state yields no fact at all.
+# left boundary blocks period/word-glued digits ('FY26', 'v1.5') from reading as values
+_FACT_NUM = re.compile(
+    r"(?<![\w.$])\(\s*\$?\s*\d[\d,]*(?:\.\d+)?\s*(?:%|bn|b|m|k)?\s*\)"     # accounting negative: (…)
+    r"|(?<![\w.$])\$?\s*-?\d[\d,]*(?:\.\d+)?\s*(?:%|bn|b|m|k)?(?=[\s|)]|$)", re.I)
+_FACT_SUFFIX_UNIT = {"%": "%", "m": "m", "b": "bn", "bn": "bn", "k": "k"}
+
+
+def _parse_fact_value(cell: str) -> tuple[float, str | None] | None:
+    """First numeric token in a cell → (value, detected_unit|None). Handles $, thousands
+    commas, m/bn/k magnitude suffixes, %, and accounting-style (parenthesised) negatives.
+    Values stay AS PRINTED (1204 for '$1,204m', unit 'm') — normalisation is validate's job."""
+    m = _FACT_NUM.search(cell)
+    if not m:
+        return None
+    tok = m.group(0).strip()
+    neg = tok.startswith("(")
+    t = tok.strip("()").replace("$", "").replace(",", "").strip()
+    m2 = re.match(r"(-?\d+(?:\.\d+)?)\s*(%|bn|b|m|k)?$", t, re.I)
+    if not m2:
+        return None
+    val = float(m2.group(1))
+    if neg:
+        val = -val
+    sfx = (m2.group(2) or "").lower()
+    return val, (_FACT_SUFFIX_UNIT.get(sfx) if sfx else None)
+
+
+def _fact_label_variants(field: dict[str, Any]) -> list[str]:
+    """Label strings that count as this field, all normalised: schema-author aliases
+    first (explicit intent wins), then the field name with underscores as spaces."""
+    out = [str(v).strip().lower() for v in field.get("labels", []) if str(v).strip()]
+    out.append(str(field.get("name", "")).replace("_", " ").strip().lower())
+    return [v for v in out if v]
+
+
+def _norm_label(s: str) -> str:
+    return re.sub(r"\s+", " ", s.strip().rstrip(":").lower())
+
+
+def _pick_period_cell(cells: list[str], header: list[str], period: str | None) -> tuple[float, str | None] | None:
+    """Which column is THE value? If the table header names the requested period ('FY26'),
+    that column wins. Otherwise the LAST parsable cell — results tables put the current
+    period rightmost by convention. (Wrong column = silently trading on last year's number.)"""
+    if period and header:
+        p = period.strip().lower()
+        for i, h in enumerate(header):
+            if p and p in h.strip().lower() and i < len(cells):
+                if (parsed := _parse_fact_value(cells[i])) is not None:
+                    return parsed
+    for c in reversed(cells[1:]):
+        if (parsed := _parse_fact_value(c)) is not None:
+            return parsed
+    return None
+
+
+def extract_facts_from_blocks(blocks: list[dict[str, Any]], target_schema: dict[str, Any],
+                              period: str | None = None) -> list[dict[str, Any]]:
+    """For each schema field, find the best-evidenced value in the blocks. Table rows beat
+    prose (a labelled cell IS the number; prose needs interpretation), exact label matches
+    beat 'Total X' prefixes, earlier pages beat later. One fact per field, or none."""
+    fields = [f for f in target_schema.get("fields", []) if f.get("name")]
+    facts: list[dict[str, Any]] = []
+    for field in fields:
+        variants = _fact_label_variants(field)
+        best: dict[str, Any] | None = None
+        for b in blocks:
+            page, kind = b.get("page"), b.get("kind", "text")
+            header: list[str] = []
+            for lno, line in enumerate(str(b.get("text", "")).splitlines()):
+                if kind == "table" and "|" in line:
+                    cells = [c.strip() for c in line.split("|")]
+                    if lno == 0 and _parse_fact_value(line) is None:
+                        header = cells          # a numberless first row is the period header
+                    lbl = _norm_label(cells[0])
+                    conf = 0.95 if lbl in variants else 0.9 if any(lbl == f"total {v}" for v in variants) else None
+                    if conf is None:
+                        continue
+                    parsed = _pick_period_cell(cells, header, period)
+                    span = f"p{page}/tbl: {cells[0]}"
+                else:
+                    low = line.lower()
+                    hit = next((v for v in variants if v in low), None)
+                    if hit is None:
+                        continue
+                    # the number must FOLLOW the label in the same line — 'revenue of $500m'
+                    parsed = _parse_fact_value(line[low.index(hit) + len(hit):])
+                    conf, span = 0.6, f"p{page}/txt: {line.strip()[:80]}"
+                if parsed is None:
+                    continue
+                value, detected_unit = parsed
+                cand = {"field": field["name"], "value": value,
+                        "unit": detected_unit or field.get("unit"),
+                        "page": page, "source_span": span, "confidence": conf, "verbatim": True}
+                if best is None or (cand["confidence"], -(cand["page"] or 0)) > (best["confidence"], -(best["page"] or 0)):
+                    best = cand
+        if best is not None:
+            facts.append(best)
+    return facts
+
+
+class ExtractFactsRequest(BaseModel):
+    project: str = "default"
+    blocks: list[dict[str, Any]]
+    target_schema: dict[str, Any] = {}
+    period: str | None = None
+    document: str | None = None
+
+
+@app.post("/api/studio/extract-facts")
+async def extract_facts_endpoint(req: ExtractFactsRequest) -> dict[str, Any]:
+    """The gateway extraction backend. Pure and side-effect-free — writes nothing, calls
+    nothing — so it carries no write gate; the compute plane's entitlement gate governs
+    who may run it as a compute. Every fact keeps page + source span; absent fields are
+    absent, not invented — the downstream warrant machinery depends on that honesty."""
+    facts = extract_facts_from_blocks(req.blocks, req.target_schema, req.period)
+    return {"facts": facts,
+            "fields_requested": len(req.target_schema.get("fields", [])),
+            "fields_found": len(facts)}
+
+
 class NodeRequest(BaseModel):
     project: str = "default"
     name: str

--- a/apps/lattice-studio/tests/test_fact_extraction.py
+++ b/apps/lattice-studio/tests/test_fact_extraction.py
@@ -1,0 +1,77 @@
+"""Fact-mode extraction (IFM stage 03): {blocks, target_schema} → {facts[]} — the contract
+the compute-gateway extraction adapter speaks. Deterministic, span-preserving, and it never
+fabricates: a field the document doesn't state yields NO fact (the warrant machinery depends
+on that honesty)."""
+from fastapi.testclient import TestClient
+
+from lattice_studio.server import _parse_fact_value, app, extract_facts_from_blocks
+
+client = TestClient(app)
+
+SCHEMA = {"table": "financials", "fields": [
+    {"name": "revenue", "type": "number", "unit": "AUD"},
+    {"name": "net_profit", "type": "number"},
+    {"name": "gross_margin", "type": "number"},
+    {"name": "npat", "type": "number", "labels": ["net profit after tax"]},
+    {"name": "ebitda", "type": "number"},          # deliberately absent from the pack
+]}
+
+PACK_BLOCKS = [
+    {"page": 1, "kind": "text", "text": "GYG FY26 Results"},
+    {"page": 2, "kind": "table", "text": "Metric | FY25 | FY26\nRevenue | $1,050m | $1,204m\n"
+                                         "Net profit | $9m | ($14m)\nGross margin | 61% | 63%"},
+    {"page": 3, "kind": "text", "text": "Net profit after tax of $12m reflects expansion costs.\n\n"
+                                        "Revenue rose strongly across all regions."},
+]
+
+
+def test_value_parser_handles_finance_notation():
+    assert _parse_fact_value("$1,204m") == (1204.0, "m")
+    assert _parse_fact_value("($14m)") == (-14.0, "m")          # accounting negative
+    assert _parse_fact_value("63%") == (63.0, "%")
+    assert _parse_fact_value("2.5bn") == (2.5, "bn")
+    assert _parse_fact_value("$500 ") == (500.0, None)
+    assert _parse_fact_value("FY26") is None                    # year token is not a value
+    assert _parse_fact_value("no numbers here") is None
+
+
+def test_period_column_selection_never_trades_on_last_years_number():
+    fy26 = {f["field"]: f for f in extract_facts_from_blocks(PACK_BLOCKS, SCHEMA, period="FY26")}
+    assert fy26["revenue"]["value"] == 1204.0                   # header-matched column
+    assert fy26["net_profit"]["value"] == -14.0                 # accounting negative, right period
+    fy25 = {f["field"]: f for f in extract_facts_from_blocks(PACK_BLOCKS, SCHEMA, period="FY25")}
+    assert fy25["revenue"]["value"] == 1050.0 and fy25["gross_margin"]["value"] == 61.0
+    # no period → rightmost (current-period convention)
+    noper = {f["field"]: f for f in extract_facts_from_blocks(PACK_BLOCKS, SCHEMA)}
+    assert noper["revenue"]["value"] == 1204.0
+
+
+def test_table_rows_beat_prose_and_spans_are_kept():
+    facts = {f["field"]: f for f in extract_facts_from_blocks(PACK_BLOCKS, SCHEMA, period="FY26")}
+    assert facts["revenue"]["confidence"] >= 0.9 and facts["revenue"]["page"] == 2
+    assert facts["revenue"]["source_span"].startswith("p2/tbl")
+    assert facts["revenue"]["verbatim"] is True
+    # percent field carries its detected unit
+    assert facts["gross_margin"]["unit"] == "%"
+
+
+def test_schema_aliases_reach_prose_facts():
+    facts = {f["field"]: f for f in extract_facts_from_blocks(PACK_BLOCKS, SCHEMA)}
+    # 'npat' has no table row — found via its alias in prose, at prose confidence
+    assert facts["npat"]["value"] == 12.0 and facts["npat"]["confidence"] == 0.6
+    assert facts["npat"]["source_span"].startswith("p3/txt")
+
+
+def test_absent_fields_are_never_fabricated():
+    facts = {f["field"]: f for f in extract_facts_from_blocks(PACK_BLOCKS, SCHEMA)}
+    assert "ebitda" not in facts                                # absent means absent
+    assert extract_facts_from_blocks([], SCHEMA) == []          # no blocks, no facts
+
+
+def test_extract_facts_endpoint_serves_gateway_contract():
+    r = client.post("/api/studio/extract-facts",
+                    json={"project": "demo", "blocks": PACK_BLOCKS, "target_schema": SCHEMA})
+    assert r.status_code == 200
+    b = r.json()
+    assert b["fields_requested"] == 5 and b["fields_found"] == 4
+    assert all({"field", "value", "page", "source_span", "confidence"} <= set(f) for f in b["facts"])


### PR DESCRIPTION
## What
`POST /api/studio/extract-facts` — serves the exact contract the compute-gateway extraction adapter has been speaking **into the void**: `{blocks, target_schema, period} → {facts[]}`. Until now the adapter POSTed to `/api/studio/extract` (a text→graph-entities contract) — real extraction only worked with pre-parsed facts. This closes the last missing hop in the IFM 5-stage pipeline: parse blocks now become typed, span-carrying facts.

## The extractor (deterministic, span-preserving)
- **Finance-notation parser**: $, thousands commas, m/bn/k suffixes, %, accounting-style `(…)` negatives; left-boundary guard so `FY26`/`v1.5` can never read as values
- **Period-aware column selection**: multi-period tables (`FY25 | FY26`) resolve against the requested period via the header row, fallback rightmost — *the wrong column = silently trading on last year's number*
- **Label matching**: schema aliases (`labels[]`) first, then field name; table 0.95 / "Total X" 0.9 / prose 0.6 — cells beat sentences
- **Never fabricates**: absent fields yield no fact — the warrant machinery depends on that honesty
- Pure and side-effect-free → no write gate; the compute plane's entitlement gate governs execution

## Gateway side
Extraction adapter → `/api/studio/extract-facts`, threads `period`. (No overlap with #958's hunks — merges cleanly in either order.)

## Verification
6 new tests incl. period-column and no-fabrication invariants; lattice-studio **246 passed**, compute-gateway **61 passed**.

## Remaining for the IFM demo
EDGAR `companyfacts` switch + wider concept map · `asx` reference backend (Appendix 4E cross-reconcile) · demo run on GYG FY26 + Chipotle packs

🤖 Generated with [Claude Code](https://claude.com/claude-code)