### PR TITLE
feat(compute-gateway): dual-jurisdiction reference backends — EDGAR company-facts (US) + statutory cross-document (AU)

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -196,35 +196,102 @@ async def _extraction(req_spec: dict, project: str, session: str | None) -> Adap
 _XBRL_CONCEPT = {
     "revenue": "RevenueFromContractWithCustomerExcludingAssessedTax",
     "revenues": "Revenues", "net_income": "NetIncomeLoss", "net_profit": "NetIncomeLoss",
-    "assets": "Assets", "liabilities": "Liabilities",
+    "npat": "NetIncomeLoss",
+    "gross_profit": "GrossProfit", "cost_of_revenue": "CostOfRevenue",
+    "operating_income": "OperatingIncomeLoss", "operating_profit": "OperatingIncomeLoss",
+    "eps_basic": "EarningsPerShareBasic", "eps_diluted": "EarningsPerShareDiluted",
+    "assets": "Assets", "liabilities": "Liabilities", "equity": "StockholdersEquity",
+    "cash": "CashAndCashEquivalentsAtCarryingValue",
+    "operating_cash_flow": "NetCashProvidedByUsedInOperatingActivities",
 }
+
+# companyfacts returns EVERY concept for an entity in one (large) payload — cached per
+# CIK so a multi-field reconcile is one EDGAR call, not one per field.
+_EDGAR_CACHE: dict[str, tuple[float, dict]] = {}
+_EDGAR_CACHE_TTL = float(os.getenv("SEC_EDGAR_CACHE_TTL", "900"))
+
+
+async def _edgar_companyfacts(cik: str) -> dict | None:
+    hit = _EDGAR_CACHE.get(cik)
+    if hit and (time.time() - hit[0]) < _EDGAR_CACHE_TTL:
+        return hit[1]
+    try:
+        async with httpx.AsyncClient(timeout=TIMEOUT, headers={"User-Agent": SEC_EDGAR_UA}) as c:
+            r = await c.get(f"{SEC_EDGAR_URL}/api/xbrl/companyfacts/CIK{cik}.json")
+            if r.status_code != 200:
+                return None
+            data = r.json()
+    except Exception:  # noqa: BLE001
+        return None
+    _EDGAR_CACHE[cik] = (time.time(), data)
+    return data
 
 
 async def _sec_edgar_reference(entity: dict, field: str, period: str) -> float | None:
-    """Reference value from SEC EDGAR XBRL company-facts (public, keyless). `entity`
-    carries a zero-padded 10-digit `cik`. Returns the value whose fiscal period matches,
-    else None (unresolved → the fact simply can't reach `verified`)."""
+    """US reference — SEC EDGAR XBRL via the company-facts endpoint the design names
+    (public, keyless; one call per entity, cached). `entity` carries a zero-padded 10-digit
+    `cik`. Returns the value whose fiscal period matches, else None (unresolved → the fact
+    simply can't reach `verified`)."""
     cik = str(entity.get("cik", "")).zfill(10)
     concept = _XBRL_CONCEPT.get(field.lower())
     if not cik.strip("0") or concept is None:
         return None
-    try:
-        async with httpx.AsyncClient(timeout=TIMEOUT, headers={"User-Agent": SEC_EDGAR_UA}) as c:
-            r = await c.get(f"{SEC_EDGAR_URL}/api/xbrl/companyconcept/CIK{cik}/us-gaap/{concept}.json")
-            if r.status_code != 200:
-                return None
-            for unit_rows in r.json().get("units", {}).values():
-                for row in unit_rows:
-                    if period and (row.get("fp") == period or row.get("frame", "").find(period) >= 0
-                                   or str(row.get("fy")) == period):
-                        return float(row["val"])
-    except Exception:  # noqa: BLE001
-        return None
+    data = await _edgar_companyfacts(cik)
+    fact = ((data or {}).get("facts", {}).get("us-gaap", {}) or {}).get(concept) or {}
+    for unit_rows in (fact.get("units") or {}).values():
+        for row in unit_rows:
+            if period and (row.get("fp") == period or str(row.get("frame", "")).find(period) >= 0
+                           or str(row.get("fy")) == period):
+                try:
+                    return float(row["val"])
+                except (KeyError, TypeError, ValueError):
+                    continue
     return None
 
 
-# the reference resolver is injectable (tests supply a deterministic source; prod = SEC EDGAR)
-_REFERENCE = _sec_edgar_reference
+async def _asx_prior_extraction_reference(entity: dict, field: str, period: str) -> float | None:
+    """AU reference — cross-document: Australia has no open-XBRL EDGAR twin (ASIC is paid),
+    but every ASX results release is lodged WITH a statutory Appendix 4E/4D. Run the
+    statutory form through this same pipeline FIRST (its rows land in the SQL sink,
+    receipts and all), then the glossy investor pack reconciles against those rows —
+    reference data that itself carries provenance. Reads (entity, period, field) from the
+    reference table in the load sink."""
+    ent_id = str(entity.get("cik") or entity.get("asx") or entity.get("name") or "")
+    table = str(entity.get("reference_table") or "reference_facts")
+    if not ent_id or not table.replace("_", "").isalnum():
+        return None
+    try:
+        con = sqlite3.connect(_sqlite_path(SQL_LOAD_DSN))
+        row = con.execute(f"SELECT value FROM {table} WHERE entity=? AND period=? AND field=?",
+                          (ent_id, period, field)).fetchone()
+        con.close()
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        return float(row[0]) if row is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+_REFERENCE_BACKENDS: dict[str, Callable[..., Awaitable[float | None]]] = {
+    "sec-edgar": _sec_edgar_reference,
+    "asx-appendix": _asx_prior_extraction_reference,
+}
+
+
+def _pick_reference(source: str | None, entity: dict) -> tuple[str, Callable[..., Awaitable[float | None]]]:
+    """Jurisdiction routing: an explicit source wins; else a CIK routes US (EDGAR) and an
+    ASX ticker routes AU (statutory cross-document). FactSet lands here as one more entry —
+    the reconcile logic never changes."""
+    if source in _REFERENCE_BACKENDS:
+        return source, _REFERENCE_BACKENDS[source]
+    if entity.get("asx") and not entity.get("cik"):
+        return "asx-appendix", _REFERENCE_BACKENDS["asx-appendix"]
+    return "sec-edgar", _REFERENCE_BACKENDS["sec-edgar"]
+
+
+# test override: when set, it beats jurisdiction routing (tests supply a deterministic source)
+_REFERENCE: Callable[..., Awaitable[float | None]] | None = None
 
 
 def set_reference_resolver(fn) -> None:
@@ -243,11 +310,13 @@ async def _reconcile(req_spec: dict, project: str, session: str | None) -> Adapt
     entity = req_spec.get("entity", {})
     period = req_spec.get("period", "")
     tol = float(req_spec.get("tolerance", 0.01))   # 1% default
-    source = req_spec.get("source", "sec-edgar")
+    source, resolver = _pick_reference(req_spec.get("source"), entity if isinstance(entity, dict) else {})
+    if _REFERENCE is not None:
+        resolver = _REFERENCE               # injected test resolver beats routing
     recs, all_ok = [], True
     for f in facts:
         field, val = f.get("field"), f.get("value")
-        ref = await _REFERENCE(entity, field, period)
+        ref = await resolver(entity, field, period)
         within = ref is not None and val is not None and abs(float(val) - ref) <= abs(ref) * tol
         delta = (float(val) - ref) if (ref is not None and val is not None) else None
         warrant = "verified" if within else (f.get("warrant") or "derived")
@@ -281,7 +350,8 @@ async def _sql_load(req_spec: dict, project: str, session: str | None) -> Adapte
         return {"outputs": [], "runtime": "sql", "status": "error",
                 "error": f"unsafe table name: {table!r}", "degraded": None}
     entity = req_spec.get("entity", {})
-    ent_id = str(entity.get("cik") or entity.get("name") or entity) if isinstance(entity, dict) else str(entity)
+    # keying must match what the reference resolvers use: cik (US) → asx (AU) → name
+    ent_id = str(entity.get("cik") or entity.get("asx") or entity.get("name") or entity) if isinstance(entity, dict) else str(entity)
     period, source = str(req_spec.get("period", "")), str(req_spec.get("source", "extraction"))
     if not rows:
         return {"outputs": [], "runtime": "sql", "status": "degraded", "error": None,

--- a/apps/compute-gateway/src/compute_gateway/registry.py
+++ b/apps/compute-gateway/src/compute_gateway/registry.py
@@ -59,11 +59,15 @@ KINDS: dict[str, dict] = {
         "capabilities": ["pdf", "pptx", "tables", "typed-rows", "source-spans"],
         "epistemic": "derived", "executes_user_code": False, "status": "live",
     },
-    # Reconcile extracted facts against a structured reference (SEC EDGAR open data
-    # now; FactSet on a key later). Agreement → verified; divergence → flagged edge.
+    # Reconcile extracted facts against a structured reference. Jurisdiction-routed:
+    # US = SEC EDGAR company-facts (open XBRL); AU = statutory Appendix 4E/4D previously
+    # extracted through this same pipeline (cross-document — AU has no open-XBRL twin).
+    # FactSet on a key later; the logic never changes. Agreement → verified; divergence
+    # → flagged edge (the tradable signal).
     "reconcile": {
         "backends": ["open-data"], "default": "open-data",
-        "capabilities": ["sec-edgar", "tolerance-check", "warrant-promotion", "divergence-flag"],
+        "capabilities": ["sec-edgar", "companyfacts", "asx-appendix", "jurisdiction-routing",
+                         "tolerance-check", "warrant-promotion", "divergence-flag"],
         "epistemic": "verified", "executes_user_code": False, "status": "live",
     },
     # Load reconciled facts into the structured SQL layer (the doc→SQL sink), keyed by

--- a/apps/compute-gateway/tests/test_reference_backends.py
+++ b/apps/compute-gateway/tests/test_reference_backends.py
@@ -1,0 +1,129 @@
+"""Dual-jurisdiction reference backends for reconcile (IFM stage 04).
+
+US: SEC EDGAR company-facts (one cached call per CIK). AU: cross-document — the statutory
+Appendix 4E, itself run through the governed pipeline, becomes the reference the glossy
+investor pack reconciles against. Routing is by entity: cik → EDGAR, asx → appendix.
+"""
+import asyncio
+import importlib
+import os
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import adapters, engine, receipts, server, zerotrust  # noqa: E402
+
+importlib.reload(zerotrust)
+importlib.reload(engine)
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+
+def setup_function():
+    os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+    receipts._CHAINS.clear()
+    engine._MEMO.clear()
+    adapters.set_reference_resolver(None)   # exercise REAL routing, not an injected stub
+    adapters._EDGAR_CACHE.clear()
+
+
+def teardown_function():
+    adapters.set_reference_resolver(None)
+
+
+def _compute(body):
+    return client.post("/v1/compute", json={"project": "demo", **body}, headers=AUTH).json()
+
+
+# ── jurisdiction routing ──
+def test_routing_by_entity_and_explicit_source():
+    assert adapters._pick_reference(None, {"cik": "320193"})[0] == "sec-edgar"
+    assert adapters._pick_reference(None, {"asx": "GYG"})[0] == "asx-appendix"
+    # explicit source always wins
+    assert adapters._pick_reference("asx-appendix", {"cik": "320193"})[0] == "asx-appendix"
+    # dual-listed (both ids) defaults to the structured feed
+    assert adapters._pick_reference(None, {"cik": "1", "asx": "X"})[0] == "sec-edgar"
+
+
+# ── US: EDGAR company-facts ──
+def test_edgar_companyfacts_parsing_and_concept_map(monkeypatch):
+    async def fake_companyfacts(cik):
+        return {"facts": {"us-gaap": {
+            "RevenueFromContractWithCustomerExcludingAssessedTax": {
+                "units": {"USD": [{"fy": 2026, "fp": "FY", "val": 9876000000}]}},
+            "NetIncomeLoss": {"units": {"USD": [{"fy": 2026, "fp": "FY", "val": 1234000000}]}},
+        }}}
+    monkeypatch.setattr(adapters, "_edgar_companyfacts", fake_companyfacts)
+
+    ent = {"cik": "1058090"}
+    assert asyncio.run(adapters._sec_edgar_reference(ent, "revenue", "FY")) == 9876000000.0
+    # npat maps onto the same GAAP concept as net_income (widened concept map)
+    assert asyncio.run(adapters._sec_edgar_reference(ent, "npat", "FY")) == 1234000000.0
+    # unmapped field resolves to None — never a guess
+    assert asyncio.run(adapters._sec_edgar_reference(ent, "same_store_sales", "FY")) is None
+
+
+def test_edgar_cache_one_call_per_cik(monkeypatch):
+    fetches = []
+
+    class FakeResp:
+        status_code = 200
+        def json(self):
+            return {"facts": {"us-gaap": {}}}
+
+    class FakeClient:
+        def __init__(self, **kw): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def get(self, url):
+            fetches.append(url)
+            return FakeResp()
+    monkeypatch.setattr(adapters.httpx, "AsyncClient", FakeClient)
+
+    asyncio.run(adapters._edgar_companyfacts("0001058090"))
+    asyncio.run(adapters._edgar_companyfacts("0001058090"))
+    assert len(fetches) == 1                     # second hit served from cache
+
+
+# ── AU: cross-document reconciliation against the statutory appendix ──
+def test_au_pack_reconciles_against_prior_appendix_extraction(tmp_path, monkeypatch):
+    monkeypatch.setattr(adapters, "SQL_LOAD_DSN", f"sqlite:///{tmp_path}/ifm.db")
+
+    # 1) the statutory Appendix 4E goes through the pipeline first → reference_facts table
+    r1 = _compute({"kind": "workflow", "spec": {"steps": [
+        {"id": "extract", "kind": "extraction", "spec": {
+            "target_schema": {"table": "reference_facts"},
+            "entity": {"asx": "GYG"}, "period": "FY26",
+            "facts": [{"field": "revenue", "value": 1204.0, "source_span": "4E/p2"},
+                      {"field": "net_profit", "value": -14.0, "source_span": "4E/p3"}]}},
+        {"id": "load", "kind": "load", "from": "extract",
+         "spec": {"table": "reference_facts", "source": "asx-appendix-4e"}},
+    ]}})
+    assert r1["status"] == "ok"
+
+    # 2) the glossy investor pack reconciles against those rows — agreement promotes
+    r2 = _compute({"kind": "reconcile", "spec": {
+        "entity": {"asx": "GYG"}, "period": "FY26", "tolerance": 0.01,
+        "facts": [{"field": "revenue", "value": 1204.0},        # agrees with the appendix
+                  {"field": "net_profit", "value": -20.0}]}})   # pack diverges — the signal
+    assert r2["status"] == "ok"
+    d = r2["outputs"][0]["data"]
+    assert d["source"] == "asx-appendix"                        # routed by the asx ticker
+    recs = {x["field"]: x for x in d["reconciliations"]}
+    assert recs["revenue"]["within_tol"] and recs["revenue"]["warrant"] == "verified"
+    assert recs["net_profit"]["flagged"] and recs["net_profit"]["delta"] == -6.0
+    assert d["all_verified"] is False                           # divergence surfaced, not buried
+
+
+def test_au_reference_missing_row_cannot_reach_verified(tmp_path, monkeypatch):
+    monkeypatch.setattr(adapters, "SQL_LOAD_DSN", f"sqlite:///{tmp_path}/empty.db")
+    r = _compute({"kind": "reconcile", "spec": {
+        "entity": {"asx": "GYG"}, "period": "FY26",
+        "facts": [{"field": "revenue", "value": 1204.0, "warrant": "observed"}]}})
+    rec = r["outputs"][0]["data"]["reconciliations"][0]
+    assert rec["reference"] is None and rec["within_tol"] is False
+    assert rec["warrant"] == "observed"                         # keeps its warrant, no promotion


### PR DESCRIPTION
## What
The design's 'pluggable reference' made real for both jurisdictions, per the US+AU-from-day-one decision.

**US** — EDGAR switched `companyconcept` → **`companyfacts`** (the endpoint the design names): one call returns every concept for an entity, cached per CIK (15-min TTL) — a multi-field reconcile is one EDGAR call, not one per field. Concept map widened 5 → 15 fields.

**AU** — Australia has no open-XBRL EDGAR twin (ASIC is pay-per-document). New `asx-appendix` backend does **cross-document reconciliation**: the statutory Appendix 4E/4D runs through this same pipeline *first* (its rows land in the SQL sink carrying receipts), then the glossy investor pack reconciles against those rows — *reference data that itself carries provenance*.

**Routing by entity**: `cik` → sec-edgar, `asx` → asx-appendix; explicit `source` wins; dual-listed defaults to the structured feed. FactSet lands as one more registry entry — the reconcile logic never changes.

## Verification
5 new tests: jurisdiction routing · companyfacts parsing + concept map · per-CIK cache (one fetch) · AU cross-document end-to-end (agreement promotes to `verified`, divergence flagged with Δ — the tradable signal) · missing reference can never reach `verified`. Suite **66 passed**.

## With #958 + #959
This completes the build-now scope of the IFM design note. Remaining: the actual demo run (GYG FY26 pack + Chipotle pack) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)