### PR TITLE
feat(reporting-watcher): the IFM cadence trigger — ASX reporting events auto-run the doc→SQL pipeline

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -52,6 +52,7 @@ jobs:
           - { image: eval-fabric-api,       context: apps/eval-fabric-api,      dockerfile: Dockerfile }
           - { image: agentic-os-api,        context: apps/agentic-os-api,       dockerfile: Dockerfile }
           - { image: hellgraph-service,     context: apps/hellgraph-service,    dockerfile: Dockerfile }
+          - { image: reporting-watcher,     context: apps/reporting-watcher,    dockerfile: Dockerfile }
           - { image: osm-map-api,           context: .,                         dockerfile: apps/osm-map-api/Dockerfile }
           - { image: dashboard-bff,         context: .,                         dockerfile: apps/dashboard-bff/Dockerfile }
           - { image: workspace-mail,        context: services/workspace-mail,   dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }

--- a/apps/reporting-watcher/Dockerfile
+++ b/apps/reporting-watcher/Dockerfile
@@ -1,0 +1,11 @@
+# reporting-watcher — the IFM cadence trigger: polls ASX reporting events, runs the
+# governed doc→SQL workflow on the compute gateway the moment a pack lands.
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+COPY main.py ./
+ENV PORT=8080
+EXPOSE 8080
+# 8080 + /healthz = the chart contract.
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/apps/reporting-watcher/main.py
+++ b/apps/reporting-watcher/main.py
@@ -1,0 +1,159 @@
+"""reporting-watcher — the IFM design's cadence trigger, running on the calendar.
+
+Polls the ASX announcements API for the watched tickers' reporting-event documents
+(results packs, statutory Appendix 4D/4E, annual reports). When a new one lands it
+downloads the PDF and runs the governed doc→SQL workflow on the compute gateway:
+ingest → parse → extract → reconcile → load, receipts and all.
+
+Deliberately STATELESS: the poller keeps only in-memory seen-keys, because safety
+lives downstream — packs are content-addressed and requests memoized at the gateway,
+so reprocessing after a restart re-seals nothing and costs nothing. Statutory forms
+are processed FIRST within a poll: the Appendix 4E lands in the reference table, so
+the glossy pack that follows reconciles against it (the AU cross-document design).
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import re
+import time
+from typing import Any
+
+import httpx
+from fastapi import FastAPI, Header, HTTPException
+
+app = FastAPI(title="reporting-watcher", version="0.1.0")
+
+ASX_API = os.getenv("ASX_API", "https://asx.api.markitdigital.com/asx-research/1.0").rstrip("/")
+ASX_FILE = os.getenv("ASX_FILE", "https://cdn-api.markitdigital.com/apiman-gateway/ASX/asx-research/1.0/file").rstrip("/")
+GATEWAY_URL = os.getenv("GATEWAY_URL", "http://compute-gateway:8080").rstrip("/")
+GATEWAY_TOKEN = os.getenv("GATEWAY_TOKEN", "")
+WATCH_TICKERS = [t.strip().lower() for t in os.getenv("WATCH_TICKERS", "gyg").split(",") if t.strip()]
+POLL_SECONDS = int(os.getenv("POLL_SECONDS", "1800"))
+PROJECT = os.getenv("WATCH_PROJECT", "gyg-reporting")
+REPORT_PERIOD = os.getenv("REPORT_PERIOD", "FY26")
+TIMEOUT = float(os.getenv("WATCHER_TIMEOUT", "120"))
+
+# What a results pack must yield. Override with TARGET_SCHEMA_JSON for other desks.
+_DEFAULT_SCHEMA = {
+    "table": "financials",
+    "fields": [
+        {"name": "revenue", "type": "number", "unit": "AUD_k", "labels": ["total revenue", "revenue"]},
+        {"name": "net_profit", "type": "number", "unit": "AUD_k",
+         "labels": ["net profit", "net profit after tax", "profit for the period", "npat"]},
+        {"name": "ebitda", "type": "number", "unit": "AUD_k", "labels": ["ebitda", "underlying ebitda"]},
+        {"name": "eps_diluted", "type": "number", "labels": ["diluted earnings per share", "diluted"]},
+    ],
+}
+TARGET_SCHEMA = json.loads(os.getenv("TARGET_SCHEMA_JSON", "null")) or _DEFAULT_SCHEMA
+
+_RELEVANT = re.compile(r"appendix 4[de]|full year|half year|results|annual report|trading update", re.I)
+
+STATE: dict[str, Any] = {"seen": set(), "runs": [], "last_poll": None, "polls": 0, "errors": 0}
+
+
+def relevant(item: dict) -> bool:
+    return item.get("announcementType") == "PERIODIC REPORTS" or bool(_RELEVANT.search(item.get("headline", "")))
+
+
+def statutory_first(items: list[dict]) -> list[dict]:
+    """Appendix 4D/4E before everything else: the statutory form is the AU reference —
+    it must be IN the reference table before the investor pack reconciles."""
+    return sorted(items, key=lambda i: 0 if re.search(r"appendix 4[de]", i.get("headline", ""), re.I) else 1)
+
+
+def _workflow_spec(ticker: str, item: dict, doc_b64: str) -> dict:
+    is_statutory = bool(re.search(r"appendix 4[de]", item.get("headline", ""), re.I))
+    table = "reference_facts" if is_statutory else TARGET_SCHEMA.get("table", "financials")
+    entity = {"asx": ticker.upper(), "name": item.get("displayName") or ticker.upper()}
+    return {"steps": [
+        {"id": "ingest", "kind": "ingest",
+         "spec": {"document_b64": doc_b64, "filename": f"{ticker}-{item.get('documentKey', 'doc')}.pdf"}},
+        {"id": "parse", "kind": "parse", "from": "ingest"},
+        {"id": "extract", "kind": "extraction", "from": "parse",
+         "spec": {"target_schema": {**TARGET_SCHEMA, "table": table}, "entity": entity,
+                  "period": REPORT_PERIOD, "column_convention": "current-last"}},
+        {"id": "reconcile", "kind": "reconcile", "from": "extract", "spec": {"tolerance": 0.01}},
+        {"id": "load", "kind": "load", "from": "reconcile",
+         "spec": {"table": table, "source": "asx-appendix-4e" if is_statutory else "investor-pack"}},
+    ]}
+
+
+async def process_item(client: httpx.AsyncClient, ticker: str, item: dict) -> dict:
+    key = item.get("documentKey", "")
+    r = await client.get(f"{ASX_FILE}/{key}")
+    r.raise_for_status()
+    doc_b64 = base64.b64encode(r.content).decode()
+    res = await client.post(
+        f"{GATEWAY_URL}/v1/compute",
+        headers={"Authorization": f"Bearer {GATEWAY_TOKEN}"},
+        json={"project": PROJECT, "kind": "workflow", "spec": _workflow_spec(ticker, item, doc_b64)})
+    body = res.json() if res.status_code == 200 else {"status": f"HTTP {res.status_code}"}
+    run = {
+        "ticker": ticker, "documentKey": key, "headline": item.get("headline"),
+        "date": item.get("date"), "status": body.get("status"),
+        "receipt": (body.get("receipt") or {}).get("id"),
+        "warrant": ((body.get("outputs") or [{}])[0].get("data") or {}).get("warrant"),
+        "at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    STATE["runs"] = (STATE["runs"] + [run])[-50:]
+    STATE["seen"].add(key)
+    return run
+
+
+async def poll_once() -> list[dict]:
+    """One pass over every watched ticker. Never raises — a dead API must not kill the loop."""
+    processed: list[dict] = []
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        for ticker in WATCH_TICKERS:
+            try:
+                r = await client.get(f"{ASX_API}/companies/{ticker}/announcements",
+                                     params={"page": 0, "itemsPerPage": 20})
+                items = (r.json().get("data") or {}).get("items") or []
+            except Exception:  # noqa: BLE001
+                STATE["errors"] += 1
+                continue
+            fresh = [i for i in items if relevant(i) and i.get("documentKey")
+                     and i["documentKey"] not in STATE["seen"]]
+            for item in statutory_first(fresh):
+                try:
+                    processed.append(await process_item(client, ticker, item))
+                except Exception:  # noqa: BLE001
+                    STATE["errors"] += 1
+    STATE["last_poll"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    STATE["polls"] += 1
+    return processed
+
+
+async def _loop() -> None:
+    while True:
+        await poll_once()
+        await asyncio.sleep(POLL_SECONDS)
+
+
+@app.on_event("startup")
+async def _start() -> None:
+    if os.getenv("WATCHER_DISABLE_LOOP") != "1":   # tests drive poll_once directly
+        asyncio.get_event_loop().create_task(_loop())
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    return {"ok": True, "service": "reporting-watcher", "tickers": WATCH_TICKERS}
+
+
+@app.get("/status")
+def status() -> dict[str, Any]:
+    return {"tickers": WATCH_TICKERS, "poll_seconds": POLL_SECONDS, "project": PROJECT,
+            "period": REPORT_PERIOD, "last_poll": STATE["last_poll"], "polls": STATE["polls"],
+            "errors": STATE["errors"], "seen": len(STATE["seen"]), "runs": STATE["runs"][-10:]}
+
+
+@app.post("/poke")
+async def poke(authorization: str = Header(default="")) -> dict[str, Any]:
+    """Manual trigger (the demo button). Same bearer the gateway takes — no second secret."""
+    if not GATEWAY_TOKEN or authorization.removeprefix("Bearer ").strip() != GATEWAY_TOKEN:
+        raise HTTPException(status_code=401, detail="bearer must match the gateway token")
+    return {"processed": await poll_once()}

--- a/apps/reporting-watcher/pytest.ini
+++ b/apps/reporting-watcher/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/apps/reporting-watcher/requirements.txt
+++ b/apps/reporting-watcher/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.110
+uvicorn[standard]>=0.29
+httpx>=0.27

--- a/apps/reporting-watcher/tests/test_watcher.py
+++ b/apps/reporting-watcher/tests/test_watcher.py
@@ -1,0 +1,98 @@
+"""The cadence trigger: relevance filter, statutory-first ordering, and one full poll
+against faked ASX + gateway — asserting the Appendix 4E hits the reference table BEFORE
+the investor pack reconciles (the AU cross-document contract)."""
+import asyncio
+import os
+
+os.environ["WATCHER_DISABLE_LOOP"] = "1"
+os.environ["GATEWAY_TOKEN"] = "t"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import main  # noqa: E402
+
+client = TestClient(main.app)
+
+
+def setup_function():
+    main.STATE["seen"] = set()
+    main.STATE["runs"] = []
+    main.STATE["errors"] = 0
+
+
+def test_relevance_filter():
+    assert main.relevant({"announcementType": "PERIODIC REPORTS", "headline": "x"})
+    assert main.relevant({"announcementType": "OTHER", "headline": "Appendix 4E and Annual Report"})
+    assert main.relevant({"announcementType": "OTHER", "headline": "2026 Full Year Results Briefing"})
+    assert not main.relevant({"announcementType": "SECURITY HOLDER DETAILS",
+                              "headline": "Ceasing to be a substantial holder"})
+
+
+def test_statutory_forms_process_first():
+    items = [{"headline": "FY26 Results Investor Presentation"},
+             {"headline": "Appendix 4E and Full Year Statutory Accounts"}]
+    assert "Appendix 4E" in main.statutory_first(items)[0]["headline"]
+
+
+def test_workflow_spec_routes_statutory_to_reference_table():
+    spec = main._workflow_spec("gyg", {"headline": "Appendix 4E", "documentKey": "k1"}, "QQ==")
+    load = next(s for s in spec["steps"] if s["id"] == "load")
+    assert load["spec"]["table"] == "reference_facts"
+    assert load["spec"]["source"] == "asx-appendix-4e"
+    spec2 = main._workflow_spec("gyg", {"headline": "FY26 Results Presentation", "documentKey": "k2"}, "QQ==")
+    load2 = next(s for s in spec2["steps"] if s["id"] == "load")
+    assert load2["spec"]["table"] == "financials"
+    ex = next(s for s in spec2["steps"] if s["id"] == "extract")
+    assert ex["spec"]["entity"] == {"asx": "GYG", "name": "GYG"}
+
+
+def test_poll_processes_new_docs_once_statutory_first(monkeypatch):
+    calls = {"gets": [], "computes": []}
+
+    class FakeResp:
+        def __init__(self, js=None, content=b"%PDF-fake"):
+            self.status_code, self._js, self.content = 200, js, content
+        def json(self):
+            return self._js
+        def raise_for_status(self):
+            return None
+
+    class FakeClient:
+        def __init__(self, **kw): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def get(self, url, params=None):
+            calls["gets"].append(url)
+            if "/announcements" in url:
+                return FakeResp(js={"data": {"items": [
+                    {"announcementType": "PERIODIC REPORTS", "documentKey": "pack-1",
+                     "headline": "FY26 Full Year Results Presentation", "date": "2026-08-28",
+                     "displayName": "GUZMAN Y GOMEZ"},
+                    {"announcementType": "PERIODIC REPORTS", "documentKey": "app4e-1",
+                     "headline": "Appendix 4E and Statutory Accounts", "date": "2026-08-28",
+                     "displayName": "GUZMAN Y GOMEZ"},
+                    {"announcementType": "SECURITY HOLDER DETAILS", "documentKey": "noise-1",
+                     "headline": "Ceasing to be a substantial holder"},
+                ]}})
+            return FakeResp()  # the PDF download
+        async def post(self, url, headers=None, json=None):
+            calls["computes"].append(json)
+            return FakeResp(js={"status": "ok", "receipt": {"id": f"sha256:{len(calls['computes'])}"},
+                                "outputs": [{"data": {"warrant": "verified"}}]})
+    monkeypatch.setattr(main.httpx, "AsyncClient", FakeClient)
+
+    processed = asyncio.run(main.poll_once())
+    assert [p["documentKey"] for p in processed] == ["app4e-1", "pack-1"]   # statutory FIRST, noise skipped
+    tables = [next(s for s in c["spec"]["steps"] if s["id"] == "load")["spec"]["table"]
+              for c in calls["computes"]]
+    assert tables == ["reference_facts", "financials"]
+
+    # second poll: nothing new → nothing reprocessed (and gateway memoization guards restarts anyway)
+    assert asyncio.run(main.poll_once()) == []
+
+
+def test_status_and_poke_auth():
+    r = client.get("/status")
+    assert r.status_code == 200 and r.json()["tickers"] == ["gyg"]
+    assert client.post("/poke").status_code == 401
+    assert client.post("/poke", headers={"Authorization": "Bearer wrong"}).status_code == 401

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -47,6 +47,8 @@ spec:
           - { name: tritfabric-consumption-api }
           - { name: agora }
           - { name: compute-gateway }
+          # the IFM cadence trigger: ASX reporting events → governed doc→SQL runs
+          - { name: reporting-watcher }
           # spark-runner MOVED to runtime-services → sovereign-runtime (executes user Spark jobs).
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —

--- a/deploy/values/compute-gateway.yaml
+++ b/deploy/values/compute-gateway.yaml
@@ -13,7 +13,7 @@ config:
   HELLGRAPH_URL: "http://hellgraph-service:8090"
   # THE uniform pay-gate across ALL compute kinds (generalizes STUDIO_COMPUTE_ENTITLEMENTS).
   # Tokens: "*" | "<kind>" | "<kind>:<backend>" | "<project>" | "<project>:<kind>" | "<project>:<kind>:<backend>".
-  COMPUTE_ENTITLEMENTS: "demo,default,graph-query,graph-stats"
+  COMPUTE_ENTITLEMENTS: "demo,default,graph-query,graph-stats,gyg-reporting"
   # every ok run writes its ComputeRun/Receipt subgraph to hellgraph (best-effort).
   GATEWAY_WRITE_PROVENANCE: "true"
 # GATEWAY_TOKEN provisioned out-of-band; FORGE_TOKEN is the SAME lattice-forge-token

--- a/deploy/values/reporting-watcher.yaml
+++ b/deploy/values/reporting-watcher.yaml
@@ -1,0 +1,20 @@
+# reporting-watcher — the IFM design's CADENCE trigger (apps/reporting-watcher).
+# Polls the ASX announcements API for the watched tickers' reporting events (results
+# packs, statutory Appendix 4D/4E) and runs the governed doc→SQL workflow on the
+# compute gateway the moment a pack lands. Statutory forms process FIRST so the
+# Appendix 4E is in the reference table before the investor pack reconciles (the AU
+# cross-document design). Stateless by design: packs are content-addressed and
+# requests memoized at the gateway, so restarts reprocess nothing.
+# tag:latest is a bootstrap; sha-pin after first build (gitops-promote only
+# MAINTAINS an existing sha- pin — a new latest service must be pinned once).
+image: { repository: reporting-watcher, tag: latest }
+service: { port: 8080, portName: http }
+config:
+  GATEWAY_URL: "http://compute-gateway:8080"
+  WATCH_TICKERS: "gyg"
+  WATCH_PROJECT: "gyg-reporting"
+  REPORT_PERIOD: "FY26"
+  POLL_SECONDS: "1800"
+# Same bearer the gateway accepts — the watcher is a gateway client, no second secret.
+secretEnv:
+  GATEWAY_TOKEN: { secretName: compute-gateway-token, key: token }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -99,6 +99,10 @@ KNOWN_BROKEN = {
         "New service — node-commander (node runtime control API) vendored into prophet-platform CI this PR. "
         "Pin tag:latest -> the sha- tag after the first build; none exists until merge."
     ),
+    "reporting-watcher:moving-tag": (
+        "New service — the IFM cadence trigger (ASX reporting events -> governed doc->SQL runs) added this "
+        "PR. Pin tag:latest -> the sha- tag after the first CI build; none exists until merge."
+    ),
     "regis-acr-api:moving-tag": (
         "Build-orphan fixed — regis-acr-api already BUILT in CI but was never in the ApplicationSet; this PR "
         "adds the deploy. Pin tag:latest -> the sha- tag after the next build; none exists for the deploy yet."


### PR DESCRIPTION
## What
The design note's last unbuilt sentence: *'a scheduled trigger per reporting event runs the workflow the moment a pack lands.'* New tiny service that polls the ASX announcements API for watched tickers' reporting events and runs the governed 5-stage doc→SQL workflow on the compute gateway when one lands.

**Why now:** GYG's FY26 annual drops in August. With this deployed, the IFM demo isn't a demo — it's the product running live on the exact event Ya Ying trades.

## Design
- **Statutory-first ordering**: Appendix 4D/4E processes before the glossy pack and loads to `reference_facts` — so the investor pack reconciles against the statutory numbers (the AU cross-document design, in operation)
- **Stateless on purpose**: packs are content-addressed and requests memoized at the gateway, so restarts reprocess nothing — safety lives downstream, not in poller state
- `/status` (last poll, recent runs + receipts) · token-gated `/poke` (the demo button) · same bearer as the gateway, no second secret
- Wired: values + ArgoCD row + images matrix + `gyg-reporting` entitlement on the gateway

## Verification
5 tests: relevance filter · statutory-first · reference-table routing · full faked poll (statutory ordering + noise skipped + second-poll dedupe) · poke auth.

## Post-merge operator note
`tag: latest` is the documented bootstrap for a new service — needs a **one-time sha-pin** after the first image build (gitops-promote only maintains existing sha- pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)