### PR TITLE
feat(lattice-studio): /api/studio/documents — cockpit document view (Noetica→platform loop, slice 1)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -3039,6 +3039,52 @@ async def _fetch_nodes(coll: str, limit: int = 200) -> tuple[list[dict[str, Any]
     return nodes, err
 
 
+@app.get("/api/studio/documents")
+async def documents(project: str = "default", limit: int = 500, doc_sha: str = "",
+                    _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """The DOCUMENT view of the project graph — what a Noetica user published, and how much
+    linked knowledge each document yielded. Groups nodes by the doc-level provenance the
+    ingestion pipeline stamps (doc_sha/filename/file_sha), so the cockpit shows documents,
+    not a node soup. Pass doc_sha to get one document's node ids (the explorer filter)."""
+    coll = proj_collection(project)
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit={limit}")
+    raw_nodes = res.get("nodes", []) if isinstance(res, dict) else []
+    raw_edges = res.get("edgeList", []) if isinstance(res, dict) else []
+    docs: dict[str, dict[str, Any]] = {}
+    node_doc: dict[str, str] = {}
+    undocumented = 0
+    for n in (raw_nodes if isinstance(raw_nodes, list) else []):
+        props = (n.get("properties") or {}) if isinstance(n, dict) else {}
+        sha = props.get("doc_sha")
+        if not sha:
+            undocumented += 1          # hand-authored / non-document facts — still real, just not doc-scoped
+            continue
+        d = docs.setdefault(sha, {"doc_sha": sha, "filename": props.get("filename"),
+                                  "file_sha": props.get("file_sha"), "source": props.get("source"),
+                                  "extractor": props.get("extractor"),
+                                  "entities": 0, "edges": 0, "sample": [], "node_ids": []})
+        d["entities"] += 1
+        if props.get("filename") and not d["filename"]:
+            d["filename"] = props["filename"]
+        if len(d["sample"]) < 5:
+            d["sample"].append(props.get("name", n.get("id")))
+        d["node_ids"].append(n.get("id", ""))
+        node_doc[n.get("id", "")] = sha
+    for e in (raw_edges if isinstance(raw_edges, list) else []):
+        sha = ((e.get("properties") or {}).get("doc_sha")) or node_doc.get(e.get("from", ""))
+        if sha in docs:
+            docs[sha]["edges"] += 1
+    if doc_sha:
+        docs = {k: v for k, v in docs.items() if k == doc_sha}
+    out = sorted(docs.values(), key=lambda d: -d["entities"])
+    for d in out:                       # node_ids only for a single-document query — list views stay light
+        if not doc_sha:
+            d.pop("node_ids", None)
+    return {"project": project, "projectCollection": coll, "documents": out, "count": len(out),
+            "undocumented_nodes": undocumented, "degraded": (err if err else None)}
+
+
 @app.get("/api/studio/graph")
 async def graph(project: str = "default", limit: int = 100, _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
     """KE-2: the project sub-graph with PROVENANCE PER NODE — the differentiator, read from the live kernel.

--- a/apps/lattice-studio/tests/test_document_ingestion.py
+++ b/apps/lattice-studio/tests/test_document_ingestion.py
@@ -156,3 +156,29 @@ def test_chunker_preserves_paragraphs_and_splits_oversized():
     chunks = _chunk_text(one_long_sentence)
     assert all(len(c) <= 4000 for c in chunks)
     assert sum(c.count("word") for c in chunks) == 2000
+
+
+def test_documents_view_groups_by_doc_provenance(monkeypatch):
+    """The cockpit's document view: nodes group by doc_sha, hand-authored facts counted
+    separately, single-doc query returns node ids for the explorer filter."""
+    async def fake_req(client, method, url, json=None):
+        return ({"nodes": [
+            {"id": "p:ent:a", "labels": ["p"], "properties": {"name": "GYG", "doc_sha": "d1", "filename": "gyg.pdf",
+                                                              "source": "doc:d1", "extractor": "lattice-studio/ie-pipeline-v1"}},
+            {"id": "p:ent:b", "labels": ["p"], "properties": {"name": "Sydney", "doc_sha": "d1"}},
+            {"id": "p:ent:c", "labels": ["p"], "properties": {"name": "Chipotle", "doc_sha": "d2", "filename": "cmg.htm"}},
+            {"id": "p:ent:h", "labels": ["p"], "properties": {"name": "Hand-authored"}},
+        ], "edgeList": [
+            {"id": "e1", "from": "p:ent:a", "to": "p:ent:b", "label": "open", "properties": {"doc_sha": "d1"}},
+        ]}, None)
+    import lattice_studio.server as srv2
+    monkeypatch.setattr(srv2, "_req", fake_req)
+
+    b = client.get("/api/studio/documents?project=team-x").json()
+    assert b["count"] == 2 and b["undocumented_nodes"] == 1
+    d1 = next(d for d in b["documents"] if d["doc_sha"] == "d1")
+    assert d1["entities"] == 2 and d1["edges"] == 1 and d1["filename"] == "gyg.pdf"
+    assert "GYG" in d1["sample"] and "node_ids" not in d1        # list view stays light
+
+    one = client.get("/api/studio/documents?project=team-x&doc_sha=d1").json()
+    assert one["count"] == 1 and set(one["documents"][0]["node_ids"]) == {"p:ent:a", "p:ent:b"}


### PR DESCRIPTION
## What
First slice of the **local Noetica user → platform → cockpit** loop Michael scoped: after a user publishes a document via `/api/studio/ingest-file`, the cockpit needs to show *documents*, not a node soup.

`GET /api/studio/documents?project=` groups the project subgraph by the doc-level provenance the ingestion pipeline stamps: per-document entity/edge counts, filename, extractor, `file_sha`/`doc_sha`, sample entities. Hand-authored facts count separately (`undocumented_nodes`). `?doc_sha=` returns one document's node ids — the explorer filter for 'show me this document's subgraph'. Same opt-in read gate as every studio read.

## Next slices (separate PRs)
- Noetica agent-machine `publish-document` action → this pipeline
- app-vue Studio 'Ingested documents' card consuming this endpoint

## Verification
1 new test (grouping, undocumented count, light list view, single-doc node ids); suite **251 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)