### PR TITLE
gitops: promote all three services → sha-15221040ff2d + credential-free promote flow

### DIFF
--- a/.github/workflows/gitops-promote.yml
+++ b/.github/workflows/gitops-promote.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write   # promote merges via auto-merged PR (see push step) — no direct-push bypass needed
 
 concurrency:
   group: gitops-promote
@@ -107,7 +108,16 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add deploy/values
           git commit -m "gitops: promote${bumped} → sha-${SHA:0:12}"
-          # main may have advanced while the build ran — rebase then push (values-only, no image re-trigger)
-          git pull --rebase --autostash origin main
-          git push origin main
-          echo "promoted:${bumped}"
+          # The main-required-checks ruleset (required diagnostics-gate) rejects direct
+          # GITHUB_TOKEN pushes — a required check can never pre-exist on a fresh commit,
+          # and the GitHub Actions app can't be a ruleset bypass actor. So promote merges
+          # the way everyone else does: a PR that PASSES the gate, auto-merged. Credential-
+          # free — no PAT in CI — and the gate stays meaningful for the bot too.
+          BRANCH="gitops/promote-${SHA:0:12}-$(date +%s)"
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "gitops: promote${bumped} → sha-${SHA:0:12}" \
+            --body "Automated image-pin promotion (values-only). Auto-merges when diagnostics-gate passes."
+          gh pr merge "$BRANCH" --squash --auto --delete-branch
+          echo "promoted via auto-merge PR:${bumped}"

--- a/deploy/values/compute-gateway.yaml
+++ b/deploy/values/compute-gateway.yaml
@@ -6,7 +6,7 @@
 # graph. Control-plane only (executes no user code) → platform namespace.
 # tag:latest is a bootstrap; sha-pin after first build (gitops-promote only
 # MAINTAINS an existing sha- pin — a new latest service must be pinned once).
-image: { repository: compute-gateway, tag: sha-ca861fc6623a1cdc494196b2806ceff8b1896eb7 }
+image: { repository: compute-gateway, tag: sha-15221040ff2d9780ec9f307c7f386db84f432e37 }
 service: { port: 8080, portName: http }
 config:
   FORGE_URL: "http://lattice-forge.sovereign-runtime.svc.cluster.local:8870"

--- a/deploy/values/lattice-studio.yaml
+++ b/deploy/values/lattice-studio.yaml
@@ -6,7 +6,7 @@
 # (#48), the pay-gated execution plane (#31), ontology-typed + SHACL-validated actions (#49/#830/#831), GAIA
 # stewardship + world-signals (#50/#51), the HDT twin (#52). NB there is NO gitops-promote workflow, so this pin
 # was never auto-bumped after those merges — hence a stale deploy. A promote job is the real fix (flagged).
-image: { repository: lattice-studio, tag: sha-c8892245661f0ec075704a6b8c501b541ce644df }
+image: { repository: lattice-studio, tag: sha-15221040ff2d9780ec9f307c7f386db84f432e37 }
 service: { port: 8080, portName: http }
 # server serves /healthz (chart default) — no probes.path override.
 config:

--- a/deploy/values/reporting-watcher.yaml
+++ b/deploy/values/reporting-watcher.yaml
@@ -7,7 +7,7 @@
 # requests memoized at the gateway, so restarts reprocess nothing.
 # tag:latest is a bootstrap; sha-pin after first build (gitops-promote only
 # MAINTAINS an existing sha- pin — a new latest service must be pinned once).
-image: { repository: reporting-watcher, tag: latest }
+image: { repository: reporting-watcher, tag: sha-15221040ff2d9780ec9f307c7f386db84f432e37 }
 service: { port: 8080, portName: http }
 config:
   GATEWAY_URL: "http://compute-gateway:8080"

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -99,10 +99,6 @@ KNOWN_BROKEN = {
         "New service — node-commander (node runtime control API) vendored into prophet-platform CI this PR. "
         "Pin tag:latest -> the sha- tag after the first build; none exists until merge."
     ),
-    "reporting-watcher:moving-tag": (
-        "New service — the IFM cadence trigger (ASX reporting events -> governed doc->SQL runs) added this "
-        "PR. Pin tag:latest -> the sha- tag after the first CI build; none exists until merge."
-    ),
     "regis-acr-api:moving-tag": (
         "Build-orphan fixed — regis-acr-api already BUILT in CI but was never in the ApplicationSet; this PR "
         "adds the deploy. Pin tag:latest -> the sha- tag after the next build; none exists for the deploy yet."


### PR DESCRIPTION
## Pins
lattice-studio · compute-gateway · reporting-watcher → `sha-15221040ff2d` — today's full build (ingestion pipeline, file front door, SHACL fix, fact extraction, dual reference backends, unit normalization, period-column fixes, and the watcher's **first** image, retiring its `tag:latest` bootstrap).

## Promote workflow — credential-free fix for the deploy freeze
The `main-required-checks` ruleset (required `diagnostics-gate`) rejects direct `GITHUB_TOKEN` pushes — a required check can never pre-exist on a fresh commit, and the GitHub Actions app can't be a ruleset bypass actor (422: not an org installation). PAT-in-CI was considered and **rejected**. Promote now merges the way everyone else does: commits pins to a `gitops/promote-*` branch, opens a PR, and auto-merges when the gate passes. No credential, and the gate stays meaningful for the bot. (Repo `allow_auto_merge` enabled to support this.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)