### PR TITLE
feat(hellgraph-service): org super-peer — opt-in-once federation for local Noetica users

### DIFF
--- a/apps/hellgraph-service/package.json
+++ b/apps/hellgraph-service/package.json
@@ -12,7 +12,10 @@
     "check:engine": "node scripts/check-engine-version.mjs"
   },
   "dependencies": {
-    "@socioprophet/hellgraph": "file:vendor/socioprophet-hellgraph-0.4.27.tgz"
+    "@socioprophet/hellgraph": "file:vendor/socioprophet-hellgraph-0.4.27.tgz",
+    "autobase": "7.28.1",
+    "corestore": "7.11.0",
+    "hyperswarm": "4.17.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/apps/hellgraph-service/src/federation.test.ts
+++ b/apps/hellgraph-service/src/federation.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The org super-peer membership loop (opt-in-once → percolate-forever), through the
+ * SERVICE surface: fail-closed governance, scoped admission, and a real participant
+ * whose local write replicates into the org index. Skips when autobase/corestore
+ * (engine optional deps) are absent — same convention as the engine's own tests.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import type * as http from 'node:http'
+import { FederatedAtomSpace, HmacTokenVerifier, nodeHandle, type AtomLogEntry } from '@socioprophet/hellgraph'
+import { startFederation, handleFederation, type Federation } from './federation.js'
+
+process.env['FEDERATION_SWARM'] = '0'   // no DHT in tests — direct replication streams only
+
+const tmp = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'hgs-fed-'))
+const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+async function federationAvailable(): Promise<boolean> {
+  // non-literal specifiers: these are the engine's OPTIONAL deps — no type declarations exist
+  try { await import('autobase' as string); await import('corestore' as string); return true } catch { return false }
+}
+
+/** Drive handleFederation with plain objects — the routes never touch the socket beyond
+ *  headers/writeHead/end, so a stub keeps the test at the unit seam the server uses. */
+function call(fed: Federation | null, method: string, pathName: string, body = '', authorization = ''):
+  Promise<{ code: number; body: Record<string, unknown> }> {
+  return new Promise((resolve) => {
+    const req = { method, headers: { authorization } } as unknown as http.IncomingMessage
+    let code = 0
+    const res = {
+      writeHead: (c: number) => { code = c },
+      end: (payload: string) => resolve({ code, body: JSON.parse(payload) as Record<string, unknown> }),
+    } as unknown as http.ServerResponse
+    const handled = handleFederation(fed, req, res, new URL(`http://x${pathName}`), body)
+    if (!handled) resolve({ code: -1, body: {} })
+  })
+}
+
+test('federation is fail-closed: no secret → stays off; disabled → honest status', async () => {
+  delete process.env['FEDERATION_ENABLED']
+  assert.equal(await startFederation(), null)
+
+  process.env['FEDERATION_ENABLED'] = '1'
+  delete process.env['FEDERATION_HMAC_SECRET']
+  assert.equal(await startFederation(), null)          // enabled but ungoverned → refuses
+
+  const status = await call(null, 'GET', '/api/federation/status')
+  assert.deepEqual(status.body, { enabled: false })
+  const admit = await call(null, 'POST', '/api/federation/admit', '{}')
+  assert.equal(admit.code, 503)
+})
+
+test('opt-in once: scoped admit → participant becomes writable → local write percolates to the org index', async (t) => {
+  if (!(await federationAvailable())) return t.skip('autobase/corestore not installed')
+
+  process.env['FEDERATION_ENABLED'] = '1'
+  process.env['FEDERATION_HMAC_SECRET'] = 'org-secret'
+  process.env['FEDERATION_DIR'] = tmp()
+  const fed = await startFederation()
+  assert.ok(fed, 'super-peer starts when governed')
+  assert.equal(fed.sp.authEnforced, true)
+
+  // status is open and carries what a cockpit needs
+  const status = await call(fed, 'GET', '/api/federation/status')
+  assert.equal(status.body['enabled'], true)
+  assert.match(String(status.body['baseKey']), /^[0-9a-f]{64}$/i)
+
+  // a sovereign participant joins from the base key — NOT writable until admitted
+  const participant = await FederatedAtomSpace.create(tmp(), { bootstrap: fed.sp.baseKey() })
+  const s1 = fed.sp.replicate(true) as { pipe: (x: unknown) => { pipe: (y: unknown) => void }; destroy?: () => void }
+  const s2 = participant.replicate(false) as { pipe: (x: unknown) => void }
+  ;(s1.pipe(s2) as { pipe: (y: unknown) => void }).pipe(s1)
+  await wait(200)
+
+  // governance: no token → 401; wrong scope → 401; bad key shape → 400
+  assert.equal((await call(fed, 'POST', '/api/federation/admit', '{"writerKey":"ab"}')).code, 401)
+  const readOnly = fed.verifier.mint({ id: 'reader', scopes: ['read'] })
+  assert.equal((await call(fed, 'POST', '/api/federation/admit', '{}', `Bearer ${readOnly}`)).code, 401)
+  const admin = fed.verifier.mint({ id: 'michael', scopes: ['admit'] })
+  assert.equal((await call(fed, 'POST', '/api/federation/admit', '{"writerKey":"zz"}', `Bearer ${admin}`)).code, 400)
+
+  // THE opt-in: admit the participant's writer key
+  const admitted = await call(fed, 'POST', '/api/federation/admit',
+    JSON.stringify({ writerKey: participant.localWriterKey() }), `Bearer ${admin}`)
+  assert.equal(admitted.code, 200)
+  assert.equal(admitted.body['by'], 'michael')
+
+  await wait(300)
+  await participant.update()
+  assert.equal(participant.isWritable(), true, 'participant becomes writable after admission syncs')
+
+  // seamless from here: a LOCAL write percolates into the ORG materialized view
+  const entry: AtomLogEntry = { seq: 1, ts: new Date().toISOString(), op: 'add_atom',
+    payload: { handle: nodeHandle('ConceptNode', 'YaYingLocalFact'), type: 'ConceptNode', name: 'YaYingLocalFact' } }
+  await participant.appendEntry(entry)
+
+  // replication + linearization are eventually-consistent — poll health (the engine's own
+  // truth signal: indexed node count + the causal cut over the participant's writer key)
+  let health = await fed.sp.health()
+  for (let i = 0; i < 30 && health.nodes < 1; i++) {
+    await wait(200)
+    health = await fed.sp.health()
+  }
+  assert.ok(health.nodes >= 1, 'the local fact percolates into the org index')
+  assert.equal((health.cut as Record<string, number>)[participant.localWriterKey()], 1,
+    'causal cut records the participant op — provenance of WHO contributed WHAT')
+
+  await fed.sp.close()
+})

--- a/apps/hellgraph-service/src/federation.ts
+++ b/apps/hellgraph-service/src/federation.ts
@@ -1,0 +1,107 @@
+/**
+ * federation — the ORG SUPER-PEER, hosted inside hellgraph-service (opt-in).
+ *
+ * The membership model Michael specified for the Noetica→platform loop: a user opts in
+ * ONCE (their writer key is admitted via a signed addWriter control op) and from then on
+ * their local graph changes percolate to the org graph automatically — no publish button,
+ * no per-document upload. Participants replicate over Hyperswarm (P2P, discovery by the
+ * federation base key — no ingress or cluster exposure needed); the super-peer is an
+ * INDEX, never a data owner, so its storage is reconstructible from participants' logs.
+ *
+ * Governance is fail-closed: no FEDERATION_HMAC_SECRET → federation refuses to start.
+ * /admit requires a bearer token minted from that secret carrying the 'admit' scope —
+ * admission IS the identity primitive until the login work lands (P007/P019).
+ *
+ * Env:
+ *   FEDERATION_ENABLED=1          opt in (default off — the graph service runs unchanged)
+ *   FEDERATION_HMAC_SECRET        token-mint/verify secret (required when enabled)
+ *   FEDERATION_DIR                corestore dir (default /data/federation; ephemeral OK —
+ *                                 the index re-materializes from participant replication)
+ */
+import * as os from 'node:os'
+import * as path from 'node:path'
+import type * as http from 'node:http'
+import { SuperPeer, HmacTokenVerifier, bearer, hasScope } from '@socioprophet/hellgraph'
+
+export interface Federation {
+  sp: SuperPeer
+  verifier: HmacTokenVerifier
+}
+
+export async function startFederation(): Promise<Federation | null> {
+  if (process.env['FEDERATION_ENABLED'] !== '1') return null
+  const secret = process.env['FEDERATION_HMAC_SECRET'] ?? ''
+  if (!secret) {
+    // fail-closed, but never take the graph service down with it
+    console.error('[federation] FEDERATION_ENABLED=1 but FEDERATION_HMAC_SECRET unset — refusing to start ungoverned; federation stays OFF')
+    return null
+  }
+  const dir = process.env['FEDERATION_DIR'] || path.join(os.tmpdir(), 'hellgraph-federation')
+  const verifier = HmacTokenVerifier.fromSecret(secret)
+  let sp: SuperPeer
+  try {
+    sp = await SuperPeer.create(dir, { auth: verifier })
+  } catch (e) {
+    // autobase/corestore are optional deps — an image built without them degrades honestly
+    console.error(`[federation] super-peer unavailable (autobase/corestore missing?): ${String((e as Error)?.message ?? e)}`)
+    return null
+  }
+  if (process.env['FEDERATION_SWARM'] !== '0') {   // '0' = direct-replication only (tests; air-gapped tiers)
+    try {
+      await sp.joinSwarm()
+      console.log('[federation] hyperswarm joined — participants can discover by base key')
+    } catch (e) {
+      console.error(`[federation] swarm unavailable (hyperswarm optional) — direct replication only: ${String((e as Error)?.message ?? e)}`)
+    }
+  }
+  console.log(`[federation] org super-peer LIVE — baseKey=${sp.baseKey()}`)
+  return { sp, verifier }
+}
+
+/** Routes on the MAIN service port (no second listener, nothing new exposed):
+ *    GET  /api/federation/status  → open: what a cockpit needs to render federation state
+ *    POST /api/federation/admit   → {writerKey}; bearer token with 'admit' scope (governance)
+ *  Returns true when the request was handled. */
+export function handleFederation(
+  fed: Federation | null,
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  url: URL,
+  body: string,
+): boolean {
+  const json = (code: number, obj: unknown): void => {
+    res.writeHead(code, { 'content-type': 'application/json' })
+    res.end(JSON.stringify(obj))
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/federation/status') {
+    if (!fed) { json(200, { enabled: false }); return true }
+    void fed.sp.health()
+      .then((h) => json(200, { enabled: true, authEnforced: fed.sp.authEnforced,
+                               baseKey: fed.sp.baseKey(), writerKey: fed.sp.writerKey(), health: h }))
+      .catch((e) => json(200, { enabled: true, baseKey: fed.sp.baseKey(),
+                                degraded: String((e as Error)?.message ?? e) }))
+    return true
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/federation/admit') {
+    if (!fed) { json(503, { error: 'federation disabled' }); return true }
+    const principal = fed.verifier.verify(bearer(req.headers['authorization']) ?? '')
+    if (!principal || !hasScope(principal, 'admit')) {
+      json(401, { error: 'admit requires a bearer token with the admit scope' })
+      return true
+    }
+    let writerKey = ''
+    try { writerKey = String((JSON.parse(body || '{}') as { writerKey?: string }).writerKey ?? '') } catch { /* fall through */ }
+    if (!/^[0-9a-f]{64}$/i.test(writerKey)) {
+      json(400, { error: 'writerKey must be a 64-hex-char participant key' })
+      return true
+    }
+    void fed.sp.admit(writerKey)
+      .then(() => json(200, { admitted: writerKey, by: principal.id }))
+      .catch((e) => json(500, { error: String((e as Error)?.message ?? e) }))
+    return true
+  }
+
+  return false
+}

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -35,6 +35,7 @@ import { fileURLToPath } from 'node:url'
 process.env['HELLGRAPH_STORE_DIR'] ||= path.join(os.homedir(), '.hellgraph-service')
 
 import * as engine from '@socioprophet/hellgraph'
+import { startFederation, handleFederation, type Federation } from './federation.js'
 import { getHellGraph, getAtomSpace, attachRocksDB, forwardChain, runSparql, runGremlin, runCypher, shaclValidate } from '@socioprophet/hellgraph'
 import { describeResource, toTurtle, toJsonLd, toHtml, negotiate } from './resource.js'
 import { askGraph, retrieveGrounding, retrieveGroundingAuto, synthesisEnabled, semanticEnabled } from './graphrag.js'
@@ -57,9 +58,20 @@ function readBody(req: http.IncomingMessage): Promise<string> {
   })
 }
 
+// The org super-peer (opt-in; see federation.ts). Initialized before listen() below.
+let federation: Federation | null = null
+
 const server = http.createServer((req, res) => {
   const url = new URL(req.url ?? '/', `http://localhost:${PORT}`)
   const g = getHellGraph()
+
+  // Federation governance surface (status open; admit scope-gated). Same port, nothing new exposed.
+  if (url.pathname.startsWith('/api/federation/')) {
+    if (req.method === 'POST') {
+      return void readBody(req).then((b) => { handleFederation(federation, req, res, url, b) })
+    }
+    if (handleFederation(federation, req, res, url, '')) return
+  }
 
   if (req.method === 'GET' && url.pathname === '/healthz') {
     return json(res, 200, { ok: true, service: 'hellgraph-service', engine_exports: Object.keys(engine).length })
@@ -307,6 +319,11 @@ function seedIfEmpty(): void {
 }
 
 function startLocalService(): void {
+  // Org super-peer first (opt-in, fail-closed, never fatal) — so /api/federation/status is
+  // truthful from the first request the service answers.
+  void startFederation().then((fed) => { federation = fed }).catch((e) => {
+    console.error('[federation] init failed (service continues without it):', e instanceof Error ? e.message : String(e))
+  })
   server.listen(PORT, () => {
     console.log(`[hellgraph-service] listening on :${PORT} (engine exports: ${Object.keys(engine).length})`)
     // Convergence backend: opt into RocksDB (same store model as Noetica, aligned to

--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -15,3 +15,17 @@ config:
   # to "" in the appset so a sovereign tier never reaches this socioprophet-namespace service.
   EMBEDDINGS_URL: "http://embeddings.socioprophet.svc.cluster.local:8080/v1/embeddings"
   EMBEDDINGS_MODEL: "nomic-embed-text"
+  # ── ORG SUPER-PEER (federation) — opt-in, OFF by default ──────────────────────────────────
+  # The membership loop for local Noetica users: admit a user's writer key ONCE (signed
+  # addWriter control op) and their local graph changes percolate to this org graph
+  # automatically over Hyperswarm (P2P discovery by base key — no ingress needed; the
+  # super-peer is an INDEX, never a data owner, so its storage re-materializes from
+  # participants' logs). Governance is fail-closed: enabling without the HMAC secret
+  # refuses to start. TO ACTIVATE:
+  #   kubectl -n socioprophet create secret generic hellgraph-federation-hmac --from-literal=secret=<random>
+  #   flip FEDERATION_ENABLED to "1", uncomment the secretEnv entry below, commit.
+  # Admit tokens are minted operator-side from the same secret (HmacTokenVerifier.mint,
+  # scope 'admit') — admission is the identity primitive until the login work lands.
+  FEDERATION_ENABLED: "0"
+# secretEnv addition when activating federation (see comment above):
+#   FEDERATION_HMAC_SECRET: { secretName: hellgraph-federation-hmac, key: secret }


### PR DESCRIPTION
## What
Federation slice 2 of the **local Noetica user → org graph** loop Michael specified: opt in ONCE (writer-key admission via signed addWriter control op), then local graph changes percolate to the org graph automatically — no publish button, no per-doc upload. Hosted **inside hellgraph-service** as an opt-in mode: one vendored engine, no second copy, engine consumed never modified.

## Design
- **P2P by construction**: participants replicate over Hyperswarm, discovering the super-peer by federation base key — no ingress, no cluster exposure. The super-peer is an *index, never a data owner* (storage re-materializes from participants' logs → ephemeral dir is fine).
- **Fail-closed governance**: enabled-without-secret refuses to start; `/api/federation/admit` requires a bearer token with the `admit` scope (engine's `HmacTokenVerifier`). **Admission is the identity primitive** until the login work lands (P007/P019).
- **Nothing new exposed**: status + admit ride the existing :8090 surface; `FEDERATION_SWARM=0` gives direct-replication-only for tests/air-gapped tiers.
- Deps pinned to the engine's own tested optional-dep versions (autobase 7.28.1 / corestore 7.11.0 / hyperswarm 4.17.0).

## Verification
Full-loop test (skip-if-unavailable, engine convention): join by baseKey → unadmitted stays read-only → 401/401/400 governance denials → scoped admit → participant writable → **local write percolates into the org index, causal cut recording who contributed what**. Suite 20/20.

## Next slices (separate PRs)
Noetica agent-machine participant (`FederatedAtomSpace` + the one-time opt-in setting) · cockpit federation card on `/api/federation/status` · Library surface (org/projects/user).

## Post-merge
OFF by default — activation runbook in the values file (create HMAC secret → flip `FEDERATION_ENABLED` → uncomment secretEnv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)