### PR TITLE
fix(reporting-watcher): don't fire the pipeline on advance notices

### DIFF
--- a/apps/reporting-watcher/main.py
+++ b/apps/reporting-watcher/main.py
@@ -51,11 +51,26 @@ TARGET_SCHEMA = json.loads(os.getenv("TARGET_SCHEMA_JSON", "null")) or _DEFAULT_
 
 _RELEVANT = re.compile(r"appendix 4[de]|full year|half year|results|annual report|trading update", re.I)
 
+# Scheduling / heads-up releases that NAME a reporting event but carry none of its
+# numbers. These lodge under announcementType "PERIODIC REPORTS" (so the type check
+# alone waves them through) and often echo the results wording ("...Full Year
+# Results..."), yet firing the pipeline on them yields an empty extraction — and the
+# real GYG "Advance Notice - 2026 Full Year Results and Briefing" is one, live in the
+# feed now. Excluded before anything else. (Verified against the live ASX feed
+# 2026-07-28; the keyless index also caps at the 5 most recent, itemsPerPage notwithstanding.)
+_EXCLUDE = re.compile(
+    r"advance notice|notice of (meeting|agm|annual general)"
+    r"|date (of|for) .*(results|release|report|announcement)"
+    r"|(results|investor) briefing details", re.I)
+
 STATE: dict[str, Any] = {"seen": set(), "runs": [], "last_poll": None, "polls": 0, "errors": 0}
 
 
 def relevant(item: dict) -> bool:
-    return item.get("announcementType") == "PERIODIC REPORTS" or bool(_RELEVANT.search(item.get("headline", "")))
+    headline = item.get("headline", "")
+    if _EXCLUDE.search(headline):           # scheduling notice — no numbers to extract
+        return False
+    return item.get("announcementType") == "PERIODIC REPORTS" or bool(_RELEVANT.search(headline))
 
 
 def statutory_first(items: list[dict]) -> list[dict]:

--- a/apps/reporting-watcher/tests/test_watcher.py
+++ b/apps/reporting-watcher/tests/test_watcher.py
@@ -28,6 +28,20 @@ def test_relevance_filter():
                               "headline": "Ceasing to be a substantial holder"})
 
 
+def test_advance_notice_is_not_relevant():
+    # regression: the advance notice lodges as PERIODIC REPORTS and echoes the results
+    # wording, so the bare type check waved it through and fired the pipeline on a
+    # document with no numbers. This is the exact live GYG headline (ASX feed 2026-07-28).
+    assert not main.relevant({"announcementType": "PERIODIC REPORTS",
+                              "headline": "Advance Notice - 2026 Full Year Results and Briefing"})
+    # sibling scheduling notices that also carry no financials
+    assert not main.relevant({"announcementType": "PERIODIC REPORTS", "headline": "Notice of Annual General Meeting"})
+    assert not main.relevant({"announcementType": "PERIODIC REPORTS", "headline": "Date of FY26 Results Release"})
+    # ...but the actual results pack that follows still fires
+    assert main.relevant({"announcementType": "PERIODIC REPORTS",
+                          "headline": "Appendix 4E and FY26 Full Year Results"})
+
+
 def test_statutory_forms_process_first():
     items = [{"headline": "FY26 Results Investor Presentation"},
              {"headline": "Appendix 4E and Full Year Statutory Accounts"}]


### PR DESCRIPTION
## What
Follow-up to #963. The reporting-watcher's relevance filter fired the governed doc→SQL pipeline on **advance notices** — scheduling releases that name the reporting event but carry no numbers.

## The bug (verified live)
`relevant()` treated any `announcementType == "PERIODIC REPORTS"` as a reporting event. The live GYG **"Advance Notice - 2026 Full Year Results and Briefing"** lodges under exactly that type and echoes the results wording, so it passed straight through and would have run ingest→parse→extract→reconcile→load on a document with nothing to extract — producing a junk run *before* the real FY26 pack even lands. It's in the live feed right now.

```
LIVE GYG feed — before fix: relevant(Advance Notice) = True   ← fires
                — after fix: relevant(Advance Notice) = False  ← excluded
simulated FY26 pack "Appendix 4E and 2026 Full Year Results" = True  ← still fires
```

## Fix
- Add an `_EXCLUDE` guard (advance notice / notice of meeting / date-of-results / briefing details), checked **before** the type/headline signals.
- Regression test using the exact live headline, plus sibling scheduling notices; asserts the real Appendix 4E / Full Year Results pack still fires.

## Verification
- `pytest` — 6 passed (5 existing + new regression).
- Re-ran the hardened `relevant()` against the **live ASX feed (2026-07-28)**: advance notice excluded, 0 false fires; simulated results pack fires.

Also confirmed while testing: the keyless ASX index caps at the 5 most recent items (itemsPerPage is ignored) — noted in a code comment; not changed here.