### PR TITLE
feat(compute-gateway): durable receipts + artifacts (survive a restart)

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -492,7 +492,13 @@ async def _reconcile(req_spec: dict, project: str, session: str | None) -> Adapt
 
 
 # ── IFM: load reconciled facts into the structured SQL layer (the doc→SQL sink) ──
-SQL_LOAD_DSN = os.getenv("SQL_LOAD_DSN", "sqlite:////tmp/ifm_extract.db")
+# The doc→SQL sink. An explicit DSN always wins; otherwise it follows GATEWAY_STORE_DIR
+# (the durable data dir) so the reconciled facts land beside the receipts on the same
+# PVC — not on /tmp, where a pod restart would silently drop the reference table the AU
+# cross-document reconcile reads back. /tmp stays the last-resort default for ephemeral dev.
+_STORE_DIR = os.getenv("GATEWAY_STORE_DIR", "").strip()
+SQL_LOAD_DSN = os.getenv("SQL_LOAD_DSN") or (
+    f"sqlite:///{_STORE_DIR}/ifm_extract.db" if _STORE_DIR else "sqlite:////tmp/ifm_extract.db")
 
 
 def _sqlite_path(dsn: str) -> str:

--- a/apps/compute-gateway/src/compute_gateway/artifacts.py
+++ b/apps/compute-gateway/src/compute_gateway/artifacts.py
@@ -17,6 +17,8 @@ import hashlib
 import json
 from typing import Any, Protocol
 
+from . import persistence
+
 
 def digest(obj: Any) -> str:
     """The content address — sha256 of the canonical JSON encoding."""
@@ -54,8 +56,27 @@ class MemoryBackend:
         return d in self._blobs
 
 
+class SqliteBackend:
+    """Durable content-addressed blob store — survives a restart. Same put/get/has
+    contract as MemoryBackend, but blobs live in the gateway SQLite file (unbounded:
+    durability is the whole point). zot/MinIO would be one more Backend behind this seam."""
+
+    def put(self, d: str, blob: Any) -> bool:
+        if persistence.has_blob(d):
+            return False
+        persistence.save_blob(d, blob)
+        return True
+
+    def get(self, d: str) -> Any | None:
+        return persistence.get_blob(d)
+
+    def has(self, d: str) -> bool:
+        return persistence.has_blob(d)
+
+
 _backend: Backend = MemoryBackend()
-# receipt id → the ordered artifact digests it produced (the data-lineage index)
+# receipt id → the ordered artifact digests it produced (the data-lineage index). A cache
+# hydrated from durable storage on boot and written through on store_outputs when enabled.
 _by_receipt: dict[str, list[str]] = {}
 _stats = {"puts": 0, "dedup_hits": 0}
 
@@ -63,6 +84,16 @@ _stats = {"puts": 0, "dedup_hits": 0}
 def set_backend(b: Backend) -> None:
     global _backend
     _backend = b
+
+
+def hydrate() -> None:
+    """Point at the durable backend and reload the data-lineage index. No-op when
+    persistence is disabled. Called at import so restarts keep full data lineage."""
+    if not persistence.enabled():
+        return
+    set_backend(SqliteBackend())
+    _by_receipt.clear()
+    _by_receipt.update(persistence.load_index())
 
 
 def store_outputs(receipt_id: str, outputs: list[Any]) -> list[str]:
@@ -77,6 +108,7 @@ def store_outputs(receipt_id: str, outputs: list[Any]) -> list[str]:
             _stats["dedup_hits"] += 1
         digests.append(d)
     _by_receipt[receipt_id] = digests
+    persistence.save_index(receipt_id, digests)   # write-through (no-op when disabled)
     return digests
 
 
@@ -113,3 +145,7 @@ def _reset() -> None:   # test hook
     _backend = MemoryBackend()
     _by_receipt.clear()
     _stats.update(puts=0, dedup_hits=0)
+
+
+# Boot onto durable storage if configured (no-op otherwise).
+hydrate()

--- a/apps/compute-gateway/src/compute_gateway/persistence.py
+++ b/apps/compute-gateway/src/compute_gateway/persistence.py
@@ -1,0 +1,143 @@
+"""Durable SQLite persistence for the compute plane's proof spine.
+
+In-memory is the walking skeleton; this is what makes receipts and content-addressed
+artifacts survive a restart, so a governed run stays replay-exact and auditable across
+pod bounces — not just within one process. Without it the reconciled SQL facts persist
+(the load sink) but the receipts, the signed chain, and the artifact blobs that back the
+`insufficient-evidence`/`verified` verdicts evaporate on restart — the audit story with
+them. Sovereign and no-bloat: one SQLite file, no external service; the zot/MinIO object
+store drops in behind these same call sites when the estate wants it.
+
+Enabled by GATEWAY_STORE_DIR. Unset ⇒ pure in-memory (tests, ephemeral dev) with ZERO
+behaviour change: every function below no-ops or returns empty, so callers fall back to
+their in-memory caches exactly as before. Each store hydrates its cache from here on boot
+and writes through on every mutation. The store dir is read dynamically (not captured at
+import) so a process can enable/point it before first use — which is what the tests do.
+
+CONCURRENCY: one SQLite file wants one writer. Enable this only where the gateway runs
+single-replica on a ReadWriteOnce volume — which is already the honest posture, since the
+in-memory store is per-pod today (a 2-replica gateway already returns different chains per
+pod). For a multi-writer HA gateway the same call sites take the zot/MinIO object backend
+instead; nothing above changes.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from typing import Any
+
+_LOCK = threading.Lock()
+_CONN: sqlite3.Connection | None = None
+_OPENED_FOR: str | None = None
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS receipts (
+  project TEXT NOT NULL, seq INTEGER NOT NULL, id TEXT NOT NULL, body TEXT NOT NULL,
+  PRIMARY KEY (project, seq));
+CREATE TABLE IF NOT EXISTS blobs (digest TEXT PRIMARY KEY, blob TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS artifact_index (
+  receipt_id TEXT NOT NULL, ord INTEGER NOT NULL, digest TEXT NOT NULL,
+  PRIMARY KEY (receipt_id, ord));
+"""
+
+
+def store_dir() -> str:
+    return os.getenv("GATEWAY_STORE_DIR", "").strip()
+
+
+def enabled() -> bool:
+    return bool(store_dir())
+
+
+def _conn() -> sqlite3.Connection:
+    """Lazily open (and, on a store-dir change, re-open) the WAL-mode SQLite file."""
+    global _CONN, _OPENED_FOR
+    d = store_dir()
+    if _CONN is not None and _OPENED_FOR == d:
+        return _CONN
+    if _CONN is not None:
+        _CONN.close()
+    os.makedirs(d, exist_ok=True)
+    _CONN = sqlite3.connect(os.path.join(d, "gateway.db"), check_same_thread=False)
+    _CONN.execute("PRAGMA journal_mode=WAL")
+    _CONN.executescript(_SCHEMA)
+    _CONN.commit()
+    _OPENED_FOR = d
+    return _CONN
+
+
+# ── receipts (the hash-chained proof spine) ──────────────────────────────────
+def load_receipts() -> dict[str, list[dict]]:
+    """Every project's chain in seal order — the caller rebuilds Receipt objects."""
+    if not enabled():
+        return {}
+    out: dict[str, list[dict]] = {}
+    for project, body in _conn().execute(
+            "SELECT project, body FROM receipts ORDER BY project, seq").fetchall():
+        out.setdefault(project, []).append(json.loads(body))
+    return out
+
+
+def save_receipt(project: str, seq: int, receipt_id: str, body_json: str) -> None:
+    if not enabled():
+        return
+    with _LOCK:
+        c = _conn()
+        c.execute("INSERT OR REPLACE INTO receipts (project, seq, id, body) VALUES (?,?,?,?)",
+                  (project, seq, receipt_id, body_json))
+        c.commit()
+
+
+# ── content-addressed artifact blobs + the receipt→digests index ─────────────
+def get_blob(d: str) -> Any | None:
+    if not enabled():
+        return None
+    row = _conn().execute("SELECT blob FROM blobs WHERE digest=?", (d,)).fetchone()
+    return json.loads(row[0]) if row else None
+
+
+def has_blob(d: str) -> bool:
+    if not enabled():
+        return False
+    return _conn().execute("SELECT 1 FROM blobs WHERE digest=?", (d,)).fetchone() is not None
+
+
+def save_blob(d: str, blob: Any) -> None:
+    if not enabled():
+        return
+    with _LOCK:
+        c = _conn()
+        c.execute("INSERT OR IGNORE INTO blobs (digest, blob) VALUES (?,?)",
+                  (d, json.dumps(blob, sort_keys=True, default=str, ensure_ascii=False)))
+        c.commit()
+
+
+def load_index() -> dict[str, list[str]]:
+    if not enabled():
+        return {}
+    out: dict[str, list[str]] = {}
+    for rid, digest in _conn().execute(
+            "SELECT receipt_id, digest FROM artifact_index ORDER BY receipt_id, ord").fetchall():
+        out.setdefault(rid, []).append(digest)
+    return out
+
+
+def save_index(receipt_id: str, digests: list[str]) -> None:
+    if not enabled():
+        return
+    with _LOCK:
+        c = _conn()
+        c.executemany("INSERT OR REPLACE INTO artifact_index (receipt_id, ord, digest) VALUES (?,?,?)",
+                      [(receipt_id, i, d) for i, d in enumerate(digests)])
+        c.commit()
+
+
+def _reset_connection() -> None:
+    """Test hook — drop the cached handle so the next call re-opens (simulates a restart)."""
+    global _CONN, _OPENED_FOR
+    if _CONN is not None:
+        _CONN.close()
+    _CONN = None
+    _OPENED_FOR = None

--- a/apps/compute-gateway/src/compute_gateway/receipts.py
+++ b/apps/compute-gateway/src/compute_gateway/receipts.py
@@ -12,11 +12,24 @@ import json
 import time
 from typing import Any
 
-from . import signing
+from . import persistence, signing
 from .contract import EpistemicStatus, Receipt
 
-# per-project hash chain
+# per-project hash chain — the in-memory index. When GATEWAY_STORE_DIR is set it is a
+# cache hydrated from durable storage on boot (see hydrate) and written through on seal,
+# so the chain survives a restart; unset, it is the whole store (ephemeral).
 _CHAINS: dict[str, list[Receipt]] = {}
+
+
+def hydrate() -> None:
+    """Rebuild the in-memory chains from durable storage. Idempotent; a no-op when
+    persistence is disabled. Called at import so a restarted process comes up with its
+    full, verifiable history already in hand."""
+    if not persistence.enabled():
+        return
+    _CHAINS.clear()
+    for project, bodies in persistence.load_receipts().items():
+        _CHAINS[project] = [Receipt(**b) for b in bodies]
 
 
 def sha(obj: Any) -> str:
@@ -39,6 +52,9 @@ def seal(project: str, *, kind: str, backend: str, runtime: str, inputs: Any,
     # in-toto Statement v1 + Ed25519 signature (unsigned if no key configured).
     signing.attest(receipt, signing.load_signing_key())
     chain.append(receipt)
+    # write-through AFTER attestation so the durable copy carries the signature/statement,
+    # and at the receipt's chain position so the ordered prev-links reload intact.
+    persistence.save_receipt(project, len(chain) - 1, receipt.id, receipt.model_dump_json())
     return receipt
 
 
@@ -77,3 +93,7 @@ def verify(project: str) -> dict:
         prev = r.id
     return {"valid": True, "count": len(ch), "signed": signed,
             "broken_at": None, "reason": None}
+
+
+# Boot with whatever durable history exists (no-op when persistence is disabled).
+hydrate()

--- a/apps/compute-gateway/tests/test_persistence.py
+++ b/apps/compute-gateway/tests/test_persistence.py
@@ -1,0 +1,121 @@
+"""Durability: receipts and content-addressed artifacts survive a restart.
+
+The whole point of the proof spine is that it outlives the process. These tests seal a
+chain and store blobs against a real SQLite file, then SIMULATE a restart (drop the
+in-memory caches + the db handle, re-hydrate) and assert the chain still verifies, the
+blobs still resolve, and the data-lineage index is intact. With GATEWAY_STORE_DIR unset
+the stores are pure in-memory, so the rest of the suite is unaffected."""
+import contextlib
+import importlib
+import os
+import tempfile
+
+from compute_gateway import artifacts, persistence, receipts
+from compute_gateway.contract import EpistemicStatus  # noqa: F401  (documents the seal contract)
+
+
+@contextlib.contextmanager
+def durable_store():
+    """Point the stores at a fresh SQLite dir and hydrate; restore in-memory-only after."""
+    prev = os.environ.get("GATEWAY_STORE_DIR")
+    with tempfile.TemporaryDirectory() as d:
+        os.environ["GATEWAY_STORE_DIR"] = d
+        persistence._reset_connection()
+        receipts._CHAINS.clear()
+        artifacts._reset()
+        receipts.hydrate()
+        artifacts.hydrate()
+        try:
+            yield d
+        finally:
+            if prev is None:
+                os.environ.pop("GATEWAY_STORE_DIR", None)
+            else:
+                os.environ["GATEWAY_STORE_DIR"] = prev
+            persistence._reset_connection()
+            receipts._CHAINS.clear()
+            artifacts._reset()
+
+
+def _restart() -> None:
+    """Everything a fresh process loses, then boots back with: caches + db handle dropped,
+    then re-hydrated from the durable file — exactly what import-time hydrate() does."""
+    receipts._CHAINS.clear()
+    artifacts._reset()
+    persistence._reset_connection()
+    receipts.hydrate()
+    artifacts.hydrate()
+
+
+def _seal(project: str, kind: str, out):
+    return receipts.seal(project, kind=kind, backend="gateway", runtime="test",
+                         inputs={"k": kind}, outputs=out, status="ok", actor="test",
+                         epistemic_status="verified")
+
+
+def test_receipt_chain_survives_restart_and_still_verifies():
+    with durable_store():
+        for i in range(3):
+            _seal("ifm", f"stage{i}", {"row": i})
+        before = receipts.verify("ifm")
+        assert before["valid"] and before["count"] == 3 and before["signed"] >= 0
+        ids = [r.id for r in receipts.chain("ifm")]
+
+        _restart()
+
+        after = receipts.verify("ifm")
+        assert after["valid"] and after["count"] == 3        # chain rebuilt from disk
+        assert [r.id for r in receipts.chain("ifm")] == ids  # same ids, same order
+        # prev-links reloaded intact: first has no prev, each subsequent points at the last
+        ch = receipts.chain("ifm")
+        assert ch[0].prev is None and ch[1].prev == ch[0].id and ch[2].prev == ch[1].id
+
+
+def test_artifacts_and_lineage_index_survive_restart():
+    with durable_store():
+        d0, d1 = artifacts.store_outputs("rcpt-1", [{"a": 1}, {"b": 2}])
+        assert artifacts.get(d0) == {"a": 1} and artifacts.get(d1) == {"b": 2}
+
+        _restart()
+
+        # blobs resolve from the durable backend, index rebuilt from disk
+        assert artifacts.get(d0) == {"a": 1} and artifacts.get(d1) == {"b": 2}
+        assert artifacts.for_receipt("rcpt-1") == [d0, d1]
+
+
+def test_dedup_holds_across_restart():
+    with durable_store():
+        artifacts.store_outputs("rcpt-1", [{"same": 1}])
+        _restart()
+        # identical content re-stored after restart is a dedup hit, not a second blob
+        newly = artifacts._backend.put(artifacts.digest({"same": 1}), {"same": 1})
+        assert newly is False
+
+
+def test_disabled_by_default_is_pure_memory():
+    # no GATEWAY_STORE_DIR ⇒ persistence is a no-op; the rest of the suite relies on this
+    os.environ.pop("GATEWAY_STORE_DIR", None)
+    persistence._reset_connection()
+    assert persistence.enabled() is False
+    assert persistence.load_receipts() == {} and persistence.load_index() == {}
+
+
+def test_sql_load_dsn_follows_store_dir():
+    from compute_gateway import adapters
+    prev_dir = os.environ.get("GATEWAY_STORE_DIR")
+    prev_dsn = os.environ.pop("SQL_LOAD_DSN", None)   # an explicit DSN wins by design; clear it here
+    try:
+        os.environ["GATEWAY_STORE_DIR"] = "/data/gw"
+        importlib.reload(adapters)
+        assert adapters.SQL_LOAD_DSN == "sqlite:////data/gw/ifm_extract.db"  # off /tmp, on the PVC
+        os.environ.pop("GATEWAY_STORE_DIR")
+        importlib.reload(adapters)
+        assert adapters.SQL_LOAD_DSN == "sqlite:////tmp/ifm_extract.db"      # ephemeral fallback
+    finally:
+        if prev_dir is not None:
+            os.environ["GATEWAY_STORE_DIR"] = prev_dir
+        else:
+            os.environ.pop("GATEWAY_STORE_DIR", None)
+        if prev_dsn is not None:
+            os.environ["SQL_LOAD_DSN"] = prev_dsn
+        importlib.reload(adapters)


### PR DESCRIPTION
## Why
ST028 Gap 1 of 2. The compute plane's proof spine was **RAM-only**: receipts (`_CHAINS`), content-addressed artifact blobs, and the data-lineage index all lived in dicts. A pod restart dropped the signed hash-chain and the blobs backing every `verified` / `insufficient-evidence` verdict — the audit and replay-exact guarantees with them. Only the SQL sink persisted, and it defaulted to `/tmp`.

For the IFM desk this is the line between "demo-proven" and "trade on it": when GYG's FY26 pack lands in August the watcher seals receipts — those must survive a bounce.

## What
An **opt-in** SQLite backend (`GATEWAY_STORE_DIR`) behind the stores' existing seams:
- **Receipts** — write-through in `seal()` (after attestation, at chain position), hydrate `_CHAINS` on boot. `chain()`/`verify()` untouched.
- **Artifacts** — new `SqliteBackend` behind the existing `Backend` protocol; the receipt→digests lineage index hydrates on boot and writes through in `store_outputs`.
- **SQL sink** — `SQL_LOAD_DSN` follows `GATEWAY_STORE_DIR` so reconciled facts land on the PVC beside the receipts, not `/tmp` (explicit `SQL_LOAD_DSN` still wins).

**Disabled by default.** With no `GATEWAY_STORE_DIR`, every persistence call no-ops and behaviour is byte-for-byte the in-memory path — the full suite proves it.

## Tests
`test_persistence.py` (5): seal → simulate restart → chain still verifies (ids, prev-links, Ed25519 signatures); artifacts + lineage index survive; dedup holds across restart; disabled-by-default is pure memory; DSN follows the store dir. **Full gateway suite green: 79 passed.**

## Deploy note (not flipped on here)
The gateway autoscales 1–2 replicas; one SQLite file wants one writer. Enabling durability in prod is a deliberate step: pin single-replica on a RWO PVC + set `GATEWAY_STORE_DIR`, **or** use the zot/MinIO object backend (drops in behind the same call sites) for a multi-writer HA gateway. Noted in `persistence.py`. The current in-memory store is already per-pod, so single-writer durable is strictly better, not a regression.

## Next
Gap 2 (follow-up PR): workflow-level RO-Crate aggregation — export a whole 5-stage run as one portable, self-verifying research object, built on these now-durable receipts.