### PR TITLE
feat(compute-gateway): workflow-level RO-Crate — a whole run as one research object

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/rocrate.py
+++ b/apps/compute-gateway/src/compute_gateway/rocrate.py
@@ -113,6 +113,107 @@ def build(receipt: Receipt, *, publisher: str = "SocioProphet compute-gateway") 
     return {"@context": RO_CRATE_CONTEXT, "@graph": graph}
 
 
+def _entities_for(receipt: Receipt, *, run_id: str, prefix: str,
+                  informed_by: list[str] | None = None,
+                  order: int | None = None) -> tuple[list[dict[str, Any]], list[str]]:
+    """The graph fragment for ONE run — action + content-addressed I/O + receipt + agent +
+    tool + (signed) attestation — under an id namespace so a composite and its steps coexist
+    in one crate without id collisions. Returns (entities, file @ids for the root hasPart)."""
+    in_id, out_id, rc_id = f"{prefix}input", f"{prefix}output", f"{prefix}receipt"
+    agent_id, tool_id = f"{prefix}actor", f"{prefix}kind"
+    props = [_pv("epistemic_status", receipt.epistemic_status), _pv("runtime", receipt.runtime),
+             _pv("status", receipt.status)]
+    if order is not None:
+        props.append(_pv("step_order", order))
+    action: dict[str, Any] = {
+        "@id": run_id, "@type": ["CreateAction", "prov:Activity"],
+        "name": f"compute:{receipt.kind}:{receipt.backend}",
+        "startTime": _iso(receipt.ts), "endTime": _iso(receipt.ts),
+        "agent": {"@id": agent_id}, "instrument": {"@id": tool_id},
+        "object": [{"@id": in_id}], "result": [{"@id": out_id}, {"@id": rc_id}],
+        "actionStatus": {"@id": "http://schema.org/CompletedActionStatus"
+                         if receipt.status == "ok" else "http://schema.org/FailedActionStatus"},
+        "additionalProperty": props,
+    }
+    if informed_by:
+        action["prov:wasInformedBy"] = [{"@id": x} for x in informed_by]
+    entities: list[dict[str, Any]] = [
+        action,
+        {"@id": in_id, "@type": ["File", "prov:Entity"], "name": "compute inputs",
+         "encodingFormat": "application/json", "sha256": _hex(receipt.inputs_sha)},
+        {"@id": out_id, "@type": ["File", "prov:Entity"], "name": "compute outputs",
+         "encodingFormat": "application/json", "sha256": _hex(receipt.outputs_sha),
+         "prov:wasGeneratedBy": {"@id": run_id}, "prov:wasDerivedFrom": {"@id": in_id}},
+        {"@id": rc_id, "@type": ["File", "prov:Entity"], "name": "proof-carrying receipt",
+         "identifier": receipt.id, "encodingFormat": "application/json",
+         "prov:wasGeneratedBy": {"@id": run_id},
+         "additionalProperty": [_pv("prev", receipt.prev or "genesis"), _pv("hash_chain", "sha256")]},
+        {"@id": agent_id, "@type": ["Person", "prov:Agent"], "name": receipt.actor},
+        {"@id": tool_id, "@type": "SoftwareApplication", "name": f"compute.{receipt.kind}",
+         "applicationCategory": "compute-kind", "operatingSystem": receipt.backend},
+    ]
+    parts = [in_id, out_id, rc_id]
+    if receipt.signature and receipt.statement is not None:
+        att_id = f"{prefix}attestation"
+        action["result"].append({"@id": att_id})
+        entities.append({
+            "@id": att_id, "@type": ["CreativeWork", "prov:Entity"],
+            "name": "in-toto attestation (Ed25519)", "encodingFormat": "application/vnd.in-toto+json",
+            "prov:wasGeneratedBy": {"@id": run_id},
+            "additionalProperty": [
+                _pv("predicateType", receipt.statement.get("predicateType", "")),
+                _pv("signature", receipt.signature),
+                _pv("public_key", receipt.public_key or ""),
+                _pv("algorithm", "Ed25519")],
+        })
+        parts.append(att_id)
+    return entities, parts
+
+
+def build_workflow(composite: Receipt, steps: list[Receipt], *,
+                   publisher: str = "SocioProphet compute-gateway") -> dict[str, Any]:
+    """Render a WHOLE governed workflow run as one RO-Crate: the composite run plus every
+    step as its own CreateAction / receipt / signed attestation, chained by
+    `prov:wasInformedBy` in pipeline order. This is the single portable, self-verifying
+    object an auditor (or a court) replays end to end — the composite's weakest-link warrant
+    on the outside, and inside it every step's inputs, outputs, and proof, down to the sha256s.
+    """
+    run_id = "#run"
+    step_ids = [f"#step{i}" for i in range(len(steps))]
+
+    comp_ents, comp_parts = _entities_for(composite, run_id=run_id, prefix="#",
+                                          informed_by=step_ids or None)
+    comp_ents[0]["step"] = [{"@id": sid} for sid in step_ids]        # ordered schema:step
+
+    step_ents: list[dict[str, Any]] = []
+    parts = list(comp_parts)
+    prev: str | None = None
+    for i, sr in enumerate(steps):
+        ents, sparts = _entities_for(sr, run_id=step_ids[i], prefix=f"#step{i}-",
+                                     informed_by=[prev] if prev else None, order=i)
+        step_ents += ents
+        parts += sparts
+        prev = step_ids[i]
+
+    root = {
+        "@id": "./", "@type": "Dataset",
+        "name": f"Governed workflow run · {len(steps)} steps · warrant {composite.epistemic_status}",
+        "description": (f"A {composite.epistemic_status} {len(steps)}-step workflow on the "
+                        f"SocioProphet Universal Compute Plane, sealed as composite receipt "
+                        f"{composite.id}; every step carries its own receipt and proof."),
+        "datePublished": _iso(composite.ts), "publisher": publisher,
+        "license": {"@id": "https://spdx.org/licenses/CC-BY-4.0"},
+        "mainEntity": {"@id": run_id},
+        "hasPart": [{"@id": p} for p in dict.fromkeys(parts)],   # dedup, order-preserving
+    }
+    graph: list[dict[str, Any]] = [
+        {"@type": "CreativeWork", "@id": "ro-crate-metadata.json",
+         "conformsTo": {"@id": RO_CRATE_SPEC}, "about": {"@id": "./"}},
+        root, *comp_ents, *step_ents,
+    ]
+    return {"@context": RO_CRATE_CONTEXT, "@graph": graph}
+
+
 def _pv(name: str, value: Any) -> dict[str, Any]:
     return {"@type": "PropertyValue", "name": name, "value": value}
 

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -191,6 +191,40 @@ def ro_crate_view(receipt_id: str, project: str = "default",
     return rocrate.build(match)
 
 
+def _workflow_step_receipts(composite_id: str, chain: list) -> list:
+    """Recover a workflow's ordered step receipts at export time. The composite's stored
+    output blob carries `steps[].receipt` (data lineage from artifacts), so no engine state
+    is needed — and with durable artifacts this survives a restart too."""
+    by_id = {r.id: r for r in chain}
+    for d in artifacts.for_receipt(composite_id):
+        blob = artifacts.get(d)
+        steps = blob.get("data", {}).get("steps") if isinstance(blob, dict) else None
+        if steps:
+            return [by_id[s["receipt"]] for s in steps
+                    if isinstance(s, dict) and s.get("receipt") in by_id]
+    return []
+
+
+@app.get("/v1/workflows/{receipt_id}/ro-crate")
+def workflow_ro_crate_view(receipt_id: str, project: str = "default",
+                           _: None = Depends(require_token)) -> dict:
+    """Export a WHOLE workflow run — the composite plus every step's receipt, I/O, and
+    signed attestation — as ONE RO-Crate 1.1 research object. The single portable,
+    self-verifying artifact that reconstructs the entire chain of custody; for a single
+    run use /v1/receipts/{id}/ro-crate instead."""
+    chain = receipts.chain(project)
+    composite = next((r for r in chain if r.id == receipt_id), None)
+    if composite is None:
+        raise HTTPException(status_code=404, detail=f"no receipt {receipt_id} in project {project}")
+    if composite.kind != "workflow":
+        raise HTTPException(
+            status_code=422,
+            detail=f"receipt {receipt_id} is kind '{composite.kind}', not a workflow — "
+                   f"use /v1/receipts/{receipt_id}/ro-crate")
+    steps = _workflow_step_receipts(composite.id, chain)
+    return rocrate.build_workflow(composite, steps)
+
+
 @app.get("/v1/receipts")
 def receipts_view(project: str = "default", _: None = Depends(require_token)) -> dict:
     ch = receipts.chain(project)

--- a/apps/compute-gateway/tests/test_rocrate.py
+++ b/apps/compute-gateway/tests/test_rocrate.py
@@ -87,6 +87,45 @@ def test_ro_crate_requires_auth():
     assert client.get("/v1/receipts/x/ro-crate").status_code == 401
 
 
+def _run_workflow():
+    return client.post("/v1/compute", json={"kind": "workflow", "project": "demo", "spec": {"steps": [
+        {"id": "a", "kind": "notebook", "spec": {"code": "1"}},
+        {"id": "b", "kind": "notebook", "spec": {"code": "2"}, "needs": ["a"]},
+    ]}}, headers=AUTH).json()
+
+
+def test_workflow_ro_crate_aggregates_every_step_with_proof():
+    rid = _run_workflow()["receipt"]["id"]
+    crate = client.get(f"/v1/workflows/{rid}/ro-crate", params={"project": "demo"}, headers=AUTH).json()
+    ids = _ids(crate)
+    assert crate["@context"] == "https://w3id.org/ro/crate/1.1/context"
+    # one research object, the composite run as its main entity, referencing both steps in order
+    assert ids["./"]["mainEntity"]["@id"] == "#run"
+    assert [s["@id"] for s in ids["#run"]["step"]] == ["#step0", "#step1"]
+    # each step is its own CreateAction, chained by prov:wasInformedBy (pipeline lineage)
+    assert "CreateAction" in ids["#step0"]["@type"] and "CreateAction" in ids["#step1"]["@type"]
+    assert ids["#step1"]["prov:wasInformedBy"][0]["@id"] == "#step0"
+    # every step carries its own content-addressed receipt + a signed attestation
+    for i in (0, 1):
+        assert len(ids[f"#step{i}-receipt"]["identifier"]) > 0
+        assert ids[f"#step{i}-output"]["prov:wasGeneratedBy"]["@id"] == f"#step{i}"
+        assert f"#step{i}-attestation" in ids
+    # ...and so does the composite
+    assert "#attestation" in ids and ids["#receipt"]["identifier"] == rid
+
+
+def test_workflow_ro_crate_422_on_a_plain_run():
+    rid = _run()["receipt"]["id"]   # a notebook, not a workflow
+    r = client.get(f"/v1/workflows/{rid}/ro-crate", params={"project": "demo"}, headers=AUTH)
+    assert r.status_code == 422 and "not a workflow" in r.json()["detail"]
+
+
+def test_workflow_ro_crate_404_for_unknown():
+    _run()
+    assert client.get("/v1/workflows/sha256:nope/ro-crate", params={"project": "demo"},
+                      headers=AUTH).status_code == 404
+
+
 def test_build_unsigned_has_no_attestation():
     # a receipt with no signature → crate omits the attestation node (never faked)
     from compute_gateway.contract import Receipt


### PR DESCRIPTION
## Why
ST028 Gap 2 of 2 (follows #968). Per-receipt RO-Crate export (`/v1/receipts/{id}/ro-crate`) renders a *single* run. But a 5-stage IFM workflow is a **composite receipt over five step receipts** — exporting the composite alone dropped each step's own inputs, outputs, and proof, i.e. the chain of custody an auditor or court actually needs.

## What
- `rocrate.build_workflow(composite, steps)` + `GET /v1/workflows/{id}/ro-crate`: the composite run **plus every step** as its own `CreateAction` / receipt / signed in-toto attestation, chained by `prov:wasInformedBy` in pipeline order — all in one RO-Crate 1.1 object. The composite's weakest-link warrant on the outside; inside, every step down to the sha256s.
- Step receipts are recovered **at export time** from the composite's stored output blob (`steps[].receipt`, the artifacts data-lineage) — **no engine change**, and durable now that #968 makes artifacts survive a restart.
- `422` on a non-workflow receipt (points you at the single-run endpoint), `404` on unknown. `build()` is untouched.

## Proof (live, real IFM shape)
Exporting a real `extract → reconcile` run:
```
composite warrant: observed          (weakest-link)
steps in order   : ['#step0', '#step1']
step0            : compute:extraction:holmes   + receipt
step1            : compute:reconcile:open-data  warrant=verified, prov:wasInformedBy #step0
23 @graph nodes | 12 content-addressed hasPart files
```

## Tests
`test_rocrate.py` +3: aggregated crate references both steps in order, `prov:wasInformedBy` chains them, each step **and** the composite carry a receipt + attestation; 422/404 paths. **Full gateway suite green: 82 passed.**

## Closes the ST028 productionization pair
With #968 (durable receipts/artifacts) + this, a governed IFM run now **survives a restart** and **exports as one portable, self-verifying object** — the audit deliverable.