### PR TITLE
feat(deploy): turn on durable proof store for compute-gateway

### DIFF
--- a/charts/socioprophet-service/templates/deployment.yaml
+++ b/charts/socioprophet-service/templates/deployment.yaml
@@ -82,8 +82,12 @@ spec:
           {{- end }}
           {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.tmpDir.enabled .Values.writableDirs .Values.extraFileMounts }}
+          {{- if or .Values.tmpDir.enabled .Values.writableDirs .Values.extraFileMounts .Values.persistence.enabled }}
           volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
             {{- if .Values.tmpDir.enabled }}
             - name: tmp
               mountPath: /tmp
@@ -102,8 +106,13 @@ spec:
               readOnly: true
             {{- end }}
           {{- end }}
-      {{- if or .Values.tmpDir.enabled .Values.writableDirs .Values.extraFileMounts }}
+      {{- if or .Values.tmpDir.enabled .Values.writableDirs .Values.extraFileMounts .Values.persistence.enabled }}
       volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "svc.fullname" . }}-data
+        {{- end }}
         {{- if .Values.tmpDir.enabled }}
         - name: tmp
           emptyDir:

--- a/charts/socioprophet-service/templates/pvc.yaml
+++ b/charts/socioprophet-service/templates/pvc.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.persistence.enabled }}
+# Durable volume for a single-writer service (see values.persistence). Rendered only when a
+# service opts in — stateless services get no PVC. The claim name is derived from the release
+# so it is stable across rollouts and the same PD re-binds; deletion policy follows the
+# StorageClass (GKE default: Delete), so treat this as service-owned durable state.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "svc.fullname" . }}-data
+  labels: {{- include "svc.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/charts/socioprophet-service/values.yaml
+++ b/charts/socioprophet-service/values.yaml
@@ -21,6 +21,18 @@ replicaCount: 1
 # for single-replica services on tight clusters to avoid a 2x-memory surge.
 strategy: {}
 
+# Optional durable volume (PVC). Default OFF — these services are stateless, so this is a
+# no-op for every service that doesn't opt in. Enable for a SINGLE-WRITER service (e.g.
+# compute-gateway's SQLite proof store): pair it with replicaCount: 1, autoscaling.enabled:
+# false, and strategy: { type: Recreate }, because a ReadWriteOnce PD binds to one pod and a
+# rolling update would deadlock on the mount.
+persistence:
+  enabled: false
+  storageClass: ""              # "" = cluster default; GKE PD single-writer = dynamic-rwo
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  mountPath: /data
+
 # Container port the app listens on (also the Service targetPort).
 service:
   type: ClusterIP

--- a/deploy/values/compute-gateway.yaml
+++ b/deploy/values/compute-gateway.yaml
@@ -16,9 +16,20 @@ config:
   COMPUTE_ENTITLEMENTS: "demo,default,graph-query,graph-stats,gyg-reporting"
   # every ok run writes its ComputeRun/Receipt subgraph to hellgraph (best-effort).
   GATEWAY_WRITE_PROVENANCE: "true"
+  # Durable proof store: receipts + content-addressed artifacts + the doc→SQL sink land on
+  # the PVC mounted here, so a governed run survives a restart (compute-gateway persistence).
+  GATEWAY_STORE_DIR: "/data"
 # GATEWAY_TOKEN provisioned out-of-band; FORGE_TOKEN is the SAME lattice-forge-token
 # already present in socioprophet (the gateway authenticates to the forge with it).
 secretEnv:
   GATEWAY_TOKEN: { secretName: compute-gateway-token, key: token }
   FORGE_TOKEN: { secretName: lattice-forge-token, key: token }
-autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
+# The proof store is one SQLite file ⇒ exactly one writer. Pin a single replica (no HPA) on a
+# ReadWriteOnce PD and Recreate on rollout so the PD is released before the new pod mounts it.
+# The gateway is control-plane and already ran effectively at 1 replica; the trade is a few
+# seconds of rollout downtime for durability — deliberate. Object-store backend removes this
+# constraint for a multi-writer HA gateway later.
+autoscaling: { enabled: false }
+replicaCount: 1
+strategy: { type: Recreate }
+persistence: { enabled: true, storageClass: dynamic-rwo, size: 2Gi, mountPath: /data }


### PR DESCRIPTION
## Why
The final ST028 step — actually **flip on** the durability #968 built. Until `GATEWAY_STORE_DIR` + a real volume are set in-cluster, the gateway's receipts/artifacts still live in RAM and vanish on a pod bounce. This makes a governed IFM run survive a restart, so when GYG's FY26 pack lands in August the sealed proof persists.

## What
**Chart (`socioprophet-service`) — additive, default OFF:**
- New gated `persistence` block → a `PersistentVolumeClaim` + volume/mount, rendered only when a service opts in. Every stateless consumer is untouched.

**compute-gateway values — opt in:**
- `persistence.enabled` on `dynamic-rwo` (GKE PD, ReadWriteOnce) 2Gi at `/data`; `GATEWAY_STORE_DIR=/data`.
- One SQLite file ⇒ one writer, so: `autoscaling.enabled: false`, `replicaCount: 1`, `strategy: { type: Recreate }` (a RWO PD must release before the new pod mounts). The gateway is control-plane and already sat at 1 replica (HPA min1/max2, cpu ~5%); the trade is a few seconds of rollout downtime for durability — deliberate. An object-store backend lifts the single-writer constraint for a multi-writer HA gateway later.

## Validation (grounded on the live cluster)
- `dynamic-rwo` confirmed present (GKE `pd.csi`, RWO, expandable).
- `helm template` on **compute-gateway** → PVC (RWO, dynamic-rwo, 2Gi) + `replicas: 1` + `strategy: Recreate` + `/data` mount + `GATEWAY_STORE_DIR` env + **no HPA**.
- `helm template` on a **default service** → **zero** persistence artifacts (blast radius nil across the ~40 shared consumers).
- `helm lint` clean.

## Rollout note
ArgoCD will prune the existing `compute-gateway` HPA (autoscaling now off) and do a `Recreate` swap to a single replica with the PD attached. First boot creates an empty `gateway.db`; the chain hydrates empty and grows from there.

## Closes ST028 productionization
#968 (durable code) + #969 (workflow RO-Crate) + this (enable in-cluster) = a governed IFM run that survives a restart and exports as one portable, self-verifying object.