### PR TITLE
fix(deploy): surge-free rolling update for compute-gateway (unblock durable rollout)

### DIFF
--- a/deploy/values/compute-gateway.yaml
+++ b/deploy/values/compute-gateway.yaml
@@ -25,11 +25,13 @@ secretEnv:
   GATEWAY_TOKEN: { secretName: compute-gateway-token, key: token }
   FORGE_TOKEN: { secretName: lattice-forge-token, key: token }
 # The proof store is one SQLite file ⇒ exactly one writer. Pin a single replica (no HPA) on a
-# ReadWriteOnce PD and Recreate on rollout so the PD is released before the new pod mounts it.
-# The gateway is control-plane and already ran effectively at 1 replica; the trade is a few
-# seconds of rollout downtime for durability — deliberate. Object-store backend removes this
-# constraint for a multi-writer HA gateway later.
+# ReadWriteOnce PD, and the new pod must not start until the old one releases the disk. We do
+# that with a surge-free rolling update (maxSurge 0, maxUnavailable 1) rather than type:Recreate:
+# for a single replica it behaves identically (old terminates before new starts), but it keeps
+# strategy.type == RollingUpdate, so switching an existing Deployment over doesn't hit the
+# apply-time conflict ("rollingUpdate may not be specified when type is Recreate"). Same few
+# seconds of rollout downtime — deliberate; the object-store backend lifts this later.
 autoscaling: { enabled: false }
 replicaCount: 1
-strategy: { type: Recreate }
+strategy: { type: RollingUpdate, rollingUpdate: { maxSurge: 0, maxUnavailable: 1 } }
 persistence: { enabled: true, storageClass: dynamic-rwo, size: 2Gi, mountPath: /data }


### PR DESCRIPTION
## Why
#970 set `strategy: Recreate` to make the single-replica gateway release its RWO PD before the new pod mounts it. But switching an **existing** RollingUpdate Deployment to Recreate fails at apply time:

```
Deployment "compute-gateway" is invalid: spec.strategy.rollingUpdate:
Forbidden: may not be specified when strategy type is 'Recreate'
```

The live object keeps its defaulted `spec.strategy.rollingUpdate`, and a strategic-merge apply won't drop it. Result on-cluster: ArgoCD created the PVC and pruned the HPA, but **could not apply the Deployment** — the old pod kept serving (no downtime) and the PVC sat `Pending` on `WaitForFirstConsumer`.

## Fix
Keep `type: RollingUpdate` with `maxSurge: 0, maxUnavailable: 1`. For a single replica this is **behaviorally identical to Recreate** — the old pod (and its RWO PD lock) terminates before the new pod starts — but there's **no strategy-type transition**, so ArgoCD applies it cleanly and the gateway rolls onto the durable PD.

## Verify after merge
ArgoCD applies the Deployment → surge-free swap → PVC binds (`WaitForFirstConsumer` releases once the new pod schedules) → pod `1/1` on `/data` with `GATEWAY_STORE_DIR` set. I'll confirm.