### PR TITLE
gitops: promote hellgraph-service → sha-3c9201d8 (KKO live)

### DIFF
--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -3,7 +3,7 @@
 # Pinned manually: the image built fine, but the images matrix run failed on an UNRELATED service
 # (sherlock-engine), and gitops-promote only fires on a fully-green images run — so one unrelated build
 # failure blocked the auto-promote. (Follow-up: promote per-service on partial success.)
-image: { repository: hellgraph-service, tag: sha-319b4abdf96673e2f4627c2b73b544f409835984 }
+image: { repository: hellgraph-service, tag: sha-3c9201d81d48692c26b450c123cf813d22267247 }
 service: { port: 8090, portName: http }
 config:
   # Estate sovereign embeddings contract (matches memoryd + prophet-platform #799): the engine


### PR DESCRIPTION
Manual open of the auto-promote PR the bot could not create (org setting blocks Actions from creating PRs). Values-only image pin for the KKO-live hellgraph-service (engine 0.4.28, PR #972).