### PR TITLE
owl-reasoner: load real KKO TBox for entailment (SP-ONTO-KKO-001 step 4)

### DIFF
--- a/apps/owl-reasoner/src/owl_reasoner/data/PROVENANCE.md
+++ b/apps/owl-reasoner/src/owl_reasoner/data/PROVENANCE.md
@@ -1,0 +1,15 @@
+# KKO — KBpedia Knowledge Ontology (vendored into owl-reasoner)
+
+**File:** `kko-2.10.n3` · **SHA-256:** `d907919fb40f20ed39a7fde0e8d114027449d9354a1976ce8248db5634cb7b07`
+**KKO version:** v2.00 · **Namespace:** `http://kbpedia.org/ontologies/kko#`
+
+Vendored as **package data** (under `src/`, so it ships in the image the Dockerfile builds from `COPY src`).
+It is the same byte-identical KKO TBox the HellGraph engine vendors (see
+`~/dev/hellgraph/ontology/kko/PROVENANCE.md`), loaded here by `reasoner.py::_kko_tbox()` so that
+`reason(..., with_kko=True)` computes RDFS/OWL-RL closure over the real KKO subClassOf hierarchy.
+
+**Source:** sovereign fork `SocioProphet/kbpedia` @ `master`, `versions/2.10/kko-demo.n3`
+(upstream `KBpedia/kbpedia`, formerly Cognonto).
+
+**License:** CC-BY-4.0 — © Michael K. Bergman & Fred Giasson (Cognonto / KBpedia). Attribution preserved;
+content unmodified. <https://kbpedia.org> · <https://creativecommons.org/licenses/by/4.0/>

--- a/apps/owl-reasoner/src/owl_reasoner/data/kko-2.10.n3
+++ b/apps/owl-reasoner/src/owl_reasoner/data/kko-2.10.n3
@@ -1,0 +1,4866 @@
+@prefix : <http://kbpedia.org/ontologies/kko#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@base <http://kbpedia.org/ontologies/kko#> .
+
+<http://kbpedia.org/ontologies/kko#> rdf:type owl:Ontology ;
+                                      owl:versionIRI <http://kbpedia.org/kbpedia/v200> ;
+                                      owl:imports <https://www.w3.org/2009/08/skos-reference/skos-owl1-dl.rdf> ;
+                                      skos:editorialNote "Version 1.30 of KKO is an internal release version only. This version is testing procedures for reverse mapping of sub-graph structures within a source knowledge base (B) to those of the target KBpedia knowledge structure (A). Most conventional mappings are of the B --> A form, where what is mapped from B requires a direct tie-in point in A. Reverse mapping, tentatively called reciprocal mapping, identifies and places new structure from B into A, resulting in the target now being (B+A)."@en ,
+                                                         """To our knowledge, this is the first knowledge representation usable by computers that attempts to embrace Peircean principles in all of its aspects. Being first also means little scrutinized. We hope other scholars of Charles Sanders Peirce (CSP, pronounced \"purse\") contribute with their understandings.
+
+The history of the KBpedia Knowledge Ontology (KKO) also shows periodic, big chunks of change. The ideas behind KKO are grand and encompassing. The writings of CSP are subtle and profound. Further, CSP's writings are still being transcribed and organized, and it is difficult to get what does exist in the literature in electronic form. The net result is sometimes new understandings and change in the upper KKO structure.
+
+Any attempt to capture the ideas of Charles Sanders Peirce or to be guided by an understanding of his teachings is fraught with many difficulties. His views shifted over the years; he was not always in a position to completely explicate his views; and much of his writing still remains untranscribed. Such is the nature of facts trying to lead to truth.
+
+We welcome input at any time about how best to capture Peircean ideas into a computable knowledge graph. Useful input will be readily acknowledged, including in future updates of the KBpedia Knowledge Ontolgy (KKO).
+
+Peircean scholars have been the first source of information here. A good starting point is the entire Peirce category on Wikipedia (https://en.wikipedia.org/wiki/Category:Charles_Sanders_Peirce). There are speciality Peircean online sources too numerous to list that are also useful from these starting links.
+
+Another resource is the Peirce online discussion list: http://www.iupui.edu/~arisbe/PEIRCE-L/PEIRCE-L.HTM."""@en ,
+                                                         "The initial KBpedia Knowledge Ontology (KKO, v 1.00) was a rather complete re-write and re-organization of the UMBEL (Upper Mapping and Binding Exchange Layer) ontology, significantly modified to accommodate its purpose for integrating knowledge bases (KBs)."@en ;
+                                      <http://purl.org/dc/elements/1.1/dateCopyrighted> "2016-06-01T20:00:00Z"^^xsd:dateTime ;
+                                      skos:prefLabel "KKO Demo"@en ;
+                                      <http://purl.org/dc/elements/1.1/date> "2019-01-23T20:00:00Z"^^xsd:dateTimeStamp ;
+                                      <http://purl.org/dc/elements/1.1/publisher> "Cognonto Corporation, via its agent, Semantics Press LLC"@en ;
+                                      skos:editorialNote """In KKO, 'CSP' is a shorthand for Charles Sanders Peirce (see https://en.wikipedia.org/wiki/Charles_Sanders_Peirce), whose writings have had a great influence on the design of this knowledge graph. 
+
+Also, some CSP quotes are derived from the following sources:
+
+CP x.y =Collected Papers of Charles Sanders Peirce, volume x, paragraph y. 
+
+See https://en.wikipedia.org/wiki/Charles_Sanders_Peirce_bibliography."""@en ;
+                                      <http://purl.org/dc/elements/1.1/description> """The KBpedia Knowledge Ontology (KKO) is a foundational ontology for capturing the essential components (or 'primitives') of knowledge bases. It is an amalgam of six of the largest public knowledge bases available -- Wikipedia, DBpedia, Wikidata, GeoNames, OpenCyc and UMBEL. It is designed for mapping and interoperating diverse ontologies to one another. The ultimate objective of KKO is to provide an ontology that surfaces and organizes the features within knowledge bases most useful to machine learning, artificial intelligence, data interoperability and mapping, and fact tagging and extraction.
+
+The design of the KBpedia Knowledge Ontology is informed by the semiotics (theory of signs) articulated by the 19th century American logician, Charles Sanders Peirce. The design is based on the triadic ideas of Firstness, Secondness and Thirdness that informed virtually all of Peirce's formulations in logic and philosophy. 
+
+Peirce's theory of signs reflects a continual process of the understanding of what a sign means evolving through truth-testing and community use and consensus. The ultimate basis of a sign resides in the idea or quality of something (a Firstness), which has a monadic relationship to itself; an object which is described or made evident in relation to these qualities through dyadic relationships (a Secondness); and then which is understood or perceived by an interpretant (a Thirdness), such as an intelligent human being. (Though in broadest terms, semiosis is not limited to human mediation, and may apply to other agents, such as artificial intelligence.) All signs embody all three of these triadic aspects.
+
+Signs build upon signs -- such is the case with human languages and the concepts conveyed by them -- and ultimately are subject to logic and questioning, the results of which may cause the nature of the relationships between these aspects of signs to undergo revision and refinement. Semiosis is thus intimately related to logic and is itself a continuous process.
+
+Words and language are themselves a Thirdness, which is the result of signmaking consensus. The semiotic or signmaking process builds from things as they are or may be to an ability to name and describe them though language -- and then ultimately to reason and argue over them leading to shared understandings, laws and complex notions of human concepts and worldviews. Each successive progression of signs involves this interplay of requisite Firstness, Secondness and Thirdness. This triadic nature of signs provides a coherent way to understand and organize the representation of knowledge at any level."""@en ;
+                                      skos:editorialNote "Version 1.50 marks a major update to KBpedia. KKO properties have been updated and organized according the three main property splits into Attributes, (external) Relations, and Representations (or Annotations) according to Peircean principles and the universal categories of Firstness, Secondness and Thirdness. Version 1.50 also uses this structure to introduce a comprehensive mapping against Wikidata properties."@en ;
+                                      <http://purl.org/vocab/vann/preferredNamespaceUri> "http://www.kbpedia.org/ontologies/kko#" ;
+                                      <http://purl.org/vocab/vann/preferredNamespacePrefix> "kko"@en ;
+                                      skos:editorialNote "Version 1.60 of KKO marked the first open-source version of KBpedia. It greatly expanded mappings to Wikidata and Wikipedia and moved to address gaps in the definitions of resource concepts (RCs). However, because of time pressures, not all open-source updates were completed for this release."@en ;
+                                      skos:altLabel "KBpedia"@en ;
+                                      skos:editorialNote "A fairly significant re-write of the KKO upper structure occurred with version 1.20. This update was driven by two factors: 1) a revisiting of some assignments due to the attention given actions and predicates (specifically, Actions, Events, Situations, Relations) as opposed to earlier efforts that focused on Entities and Classes (Generals); and 2) an attempt to both rely more directly on Peircean terminology where it made sense and to rely less directly on that terminology where it was obscure or dated."@en ,
+                                                         "Version 1.40 of the KBpedia Knowledge Ontology is the result of reciprocal mapping from Wikipedia to KBpedia. Reciprocal mapping adds sub-graph structure and new nodes to the target knowledge base. Nearly 40% more reference concepts were added to KBpedia in this v 1.40 release than in prior versions of KBpedia."@en ;
+                                      owl:versionInfo """Version 2.00, released Jan 23, 2019. Full mappings to Wikidata and Wikipedia have been completed, as well as complete definitions for all RCs (reference concepts).
+
+All duplicates have been checked and many minor typology corrections have been made.
+
+This version is understood to comprise the first, complete, open-source release of KBpedia. KKO is the upper ontology to KBpedia. We consider this the official open-source baseline for KBpedia.
+
+Note that KBpedia mappings are available in separate files."""@en ;
+                                      :prefURI "http://www.kbpedia.org/ontologies/kko.n3"^^xsd:anyURI ;
+                                      skos:definition "This is a NON-WORKING version of the KBpedia Knowledge Ontology (KKO). Each of the upper-level concepts in this ontology have been prefaced with the designator of Firstness (1-), Secondness (2-), or Thirdness (3-) according to Charles Sanders Peirce's universal categories. This demo version orders the primitives in the same manner across the ontology to overcome a display limitation if only using the Protege ontology browser."@en .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://kbpedia.org/ontologies/kko#associatives
+:associatives rdf:type owl:AnnotationProperty ;
+              skos:definition "These are a situational and contextual properties of proximity, affiliation or adjacency of the subject with regard to any contiguity."@en ;
+              skos:prefLabel "associatives"@en ;
+              skos:scopeNote "A Thirdness"@en ,
+                             "Some of the concepts associated with this set of properties are see also, lists, links (incoming + outgoing), associations, likenesses, resemblances."@en ;
+              rdfs:subPropertyOf :representations .
+
+
+###  http://kbpedia.org/ontologies/kko#augments
+:augments rdf:type owl:AnnotationProperty ;
+          skos:definition "An indicator to an external factor in relation to the object, which factor itself leads to still further explanations."@en ;
+          skos:prefLabel "augments"@en ;
+          skos:scopeNote "A Thirdness"@en ;
+          rdfs:subPropertyOf :associatives .
+
+
+###  http://kbpedia.org/ontologies/kko#codes
+:codes rdf:type owl:AnnotationProperty ;
+       skos:definition "An assignment of an object to a symbolic token or string that acts to group that object with similar items; the generation and interpretation of the token is (often) done in relation to an understood scheme or system."@en ;
+       skos:prefLabel "codes"@en ;
+       skos:scopeNote "A Thirdness"@en ;
+       rdfs:subPropertyOf :indexes .
+
+
+###  http://kbpedia.org/ontologies/kko#denotatives
+:denotatives rdf:type owl:AnnotationProperty ;
+             skos:definition "These ae icons or symbols that name or describe the subject."@en ;
+             skos:prefLabel "denotatives"@en ;
+             skos:scopeNote "A Firstness"@en ,
+                            "Some of the concepts associated with this set of properties are names, labels, images, descriptions, definitions, denotations, icons, designations, proper nouns."@en ;
+             rdfs:subPropertyOf :representations .
+
+
+###  http://kbpedia.org/ontologies/kko#descriptions
+:descriptions rdf:type owl:AnnotationProperty ;
+              skos:altLabel "abstracts"@en ,
+                            "definitions"@en ;
+              skos:definition "Symbol or text strings that are longer than labels and provide additional or contextual information about the object beyond simply drawing attention to it."@en ;
+              skos:prefLabel "descriptions"@en ;
+              skos:scopeNote "A Thirdness"@en ;
+              rdfs:subPropertyOf :denotatives .
+
+
+###  http://kbpedia.org/ontologies/kko#hasCharacteristic
+:hasCharacteristic rdf:type owl:AnnotationProperty ;
+                   skos:definition "The property kko:hasCharacteristic is used to assert the relation between a Reference Concept and external properties that may be used in external ontologies to characterize, describe, or provide attributes for data records associated with that concept. It is via this property or its inverse, kko:isCharacteristicOf, that external data characterizations may be incorporated and modeled within a domain ontology based on the KKO vocabulary."@en ;
+                   skos:prefLabel "has characteristic"@en ;
+                   rdfs:subPropertyOf :relateds .
+
+
+###  http://kbpedia.org/ontologies/kko#identifiers
+:identifiers rdf:type owl:AnnotationProperty ;
+             skos:altLabel "ID"@en ;
+             skos:definition "Generally (unique) symbols or strings that provide a key to the given subject, often within some conventional scheme for generating and recognizing the token assigned."@en ;
+             skos:prefLabel "identifiers"@en ;
+             skos:scopeNote "A Secondness"@en ;
+             rdfs:subPropertyOf :indexes .
+
+
+###  http://kbpedia.org/ontologies/kko#indexes
+:indexes rdf:type owl:AnnotationProperty ;
+         skos:definition "These ae indirect references or pointers that help situate or draw attention to the subject."@en ;
+         skos:prefLabel "indexes"@en ;
+         skos:scopeNote "A Secondness"@en ,
+                        "Some of the concepts associated with this set of properties are URIs, identifiers, keys, indices, references, semes, propositions (w/o objects), codes, selections, directional, citations, pronouns."@en ;
+         rdfs:subPropertyOf :representations .
+
+
+###  http://kbpedia.org/ontologies/kko#isCharacteristicOf
+:isCharacteristicOf rdf:type owl:AnnotationProperty ;
+                    skos:definition "The property kko:isCharacteristicOf is used to assert the relation between a property and a Reference Concept (or its punned individual) to which it applies. Such properties may be used in external ontologies to characterize, describe, or provide attributes for data records associated with that concept. It is via this property or its inverse, kko:hasCharacteristic, that external data characterizations may be incorporated and modeled within a domain ontology based on the KKO vocabulary."@en ;
+                    skos:prefLabel "is characteristic of"@en ;
+                    rdfs:subPropertyOf :relateds .
+
+
+###  http://kbpedia.org/ontologies/kko#labels
+:labels rdf:type owl:AnnotationProperty ;
+        skos:altLabel "names"@en ;
+        skos:definition "Symbolic text strings that help to name or draw attention to a particular object."@en ;
+        skos:prefLabel "labels"@en ;
+        skos:scopeNote "A Secondness"@en ,
+                       "Labels such as names, proper names, titles, aliases, synonyms, misspellings, honorifics and such that draw attention to a particular object are all part of the property category."@en ;
+        rdfs:subPropertyOf :denotatives .
+
+
+###  http://kbpedia.org/ontologies/kko#lists
+:lists rdf:type owl:AnnotationProperty ;
+       skos:definition "An aggregation, either ordered or unordered, of objects similar to one another with respect to given characters or types."@en ;
+       skos:prefLabel "lists"@en ;
+       skos:scopeNote "A Firstness"@en ;
+       rdfs:subPropertyOf :associatives .
+
+
+###  http://kbpedia.org/ontologies/kko#media
+:media rdf:type owl:AnnotationProperty ;
+       skos:altLabel "images"@en ;
+       skos:definition "Iconic images or sounds that invoke the identification with a given object or representation. Media in this sense draws attention to the object."@en ;
+       skos:prefLabel "media"@en ;
+       skos:scopeNote "A Firstness"@en ;
+       rdfs:subPropertyOf :denotatives .
+
+
+###  http://kbpedia.org/ontologies/kko#pointers
+:pointers rdf:type owl:AnnotationProperty ;
+          skos:altLabel "indicators"@en ;
+          skos:definition "Physical or symbolic indicators of a given thing and which draw attention to it."@en ;
+          skos:prefLabel "pointers"@en ;
+          skos:scopeNote "A Firstness"@en ;
+          rdfs:subPropertyOf :indexes .
+
+
+###  http://kbpedia.org/ontologies/kko#prefURI
+:prefURI rdf:type owl:AnnotationProperty ;
+         rdfs:subPropertyOf :pointers .
+
+
+###  http://kbpedia.org/ontologies/kko#relateds
+:relateds rdf:type owl:AnnotationProperty ;
+          skos:altLabel "see also"@en ;
+          skos:definition "An indicator of some nature to other objects similar or related to the given object; the criteria and degree or strength of relationship between the items are indeterminant."@en ;
+          skos:prefLabel "relateds"@en ;
+          skos:scopeNote "A Secondness"@en ;
+          rdfs:subPropertyOf :associatives .
+
+
+###  http://kbpedia.org/ontologies/kko#representations
+:representations rdf:type owl:AnnotationProperty ;
+                 skos:altLabel "annotations"@en ,
+                               "indexicals"@en ,
+                               "metadata"@en ;
+                 skos:definition "Pointers or indicators, including symbolic ones such as text or URLs, that draw attention to the actual or dynamic object."@en ;
+                 skos:prefLabel "representations"@en ;
+                 skos:scopeNote "A Thirdness"@en ,
+                                "Indexicals are of the form of re:A; that is, statements about or references to subject A."@en ,
+                                "Indexicals can not be inferred over because there are not class-subclass relations, nor natural relatedness, but may be analyzed in other ways."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#superPropertyOf
+:superPropertyOf rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/contributor
+<http://purl.org/dc/elements/1.1/contributor> rdf:type owl:AnnotationProperty ;
+                                              rdfs:subPropertyOf :augments .
+
+
+###  http://purl.org/dc/elements/1.1/creator
+<http://purl.org/dc/elements/1.1/creator> rdf:type owl:AnnotationProperty ;
+                                          rdfs:subPropertyOf :augments .
+
+
+###  http://purl.org/dc/elements/1.1/date
+<http://purl.org/dc/elements/1.1/date> rdf:type owl:AnnotationProperty ;
+                                       rdfs:subPropertyOf :augments .
+
+
+###  http://purl.org/dc/elements/1.1/dateCopyrighted
+<http://purl.org/dc/elements/1.1/dateCopyrighted> rdf:type owl:AnnotationProperty ;
+                                                  rdfs:subPropertyOf :augments .
+
+
+###  http://purl.org/dc/elements/1.1/description
+<http://purl.org/dc/elements/1.1/description> rdf:type owl:AnnotationProperty ;
+                                              rdfs:subPropertyOf :descriptions .
+
+
+###  http://purl.org/dc/elements/1.1/publisher
+<http://purl.org/dc/elements/1.1/publisher> rdf:type owl:AnnotationProperty ;
+                                            rdfs:subPropertyOf :augments .
+
+
+###  http://purl.org/vocab/vann/preferredNamespacePrefix
+<http://purl.org/vocab/vann/preferredNamespacePrefix> rdf:type owl:AnnotationProperty ;
+                                                      rdfs:subPropertyOf :identifiers .
+
+
+###  http://purl.org/vocab/vann/preferredNamespaceUri
+<http://purl.org/vocab/vann/preferredNamespaceUri> rdf:type owl:AnnotationProperty ;
+                                                   rdfs:subPropertyOf :identifiers .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#comment
+rdfs:comment rdf:type owl:AnnotationProperty ;
+             rdfs:subPropertyOf :augments .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#isDefinedBy
+rdfs:isDefinedBy rdfs:subPropertyOf :relateds .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#label
+rdfs:label rdfs:subPropertyOf :labels .
+
+
+###  http://www.w3.org/2000/01/rdf-schema#seeAlso
+rdfs:seeAlso rdfs:subPropertyOf :relateds .
+
+
+###  http://www.w3.org/2002/07/owl#backwardCompatibleWith
+owl:backwardCompatibleWith rdfs:subPropertyOf :relateds .
+
+
+###  http://www.w3.org/2002/07/owl#deprecated
+owl:deprecated rdfs:subPropertyOf :augments .
+
+
+###  http://www.w3.org/2002/07/owl#incompatibleWith
+owl:incompatibleWith rdfs:subPropertyOf :relateds .
+
+
+###  http://www.w3.org/2002/07/owl#priorVersion
+owl:priorVersion rdfs:subPropertyOf :relateds .
+
+
+###  http://www.w3.org/2002/07/owl#versionInfo
+owl:versionInfo rdfs:subPropertyOf :augments .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty ;
+              rdfs:subPropertyOf rdfs:label .
+
+
+###  http://www.w3.org/2004/02/skos/core#changeNote
+skos:changeNote rdf:type owl:AnnotationProperty ;
+                rdfs:subPropertyOf skos:note .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty ;
+                rdfs:subPropertyOf :descriptions .
+
+
+###  http://www.w3.org/2004/02/skos/core#editorialNote
+skos:editorialNote rdf:type owl:AnnotationProperty ;
+                   rdfs:subPropertyOf skos:note .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty ;
+             rdfs:subPropertyOf :augments .
+
+
+###  http://www.w3.org/2004/02/skos/core#hiddenLabel
+skos:hiddenLabel rdf:type owl:AnnotationProperty ;
+                 rdfs:subPropertyOf rdfs:label .
+
+
+###  http://www.w3.org/2004/02/skos/core#historyNote
+skos:historyNote rdf:type owl:AnnotationProperty ;
+                 rdfs:subPropertyOf skos:note .
+
+
+###  http://www.w3.org/2004/02/skos/core#note
+skos:note rdf:type owl:AnnotationProperty ;
+          rdfs:subPropertyOf :augments .
+
+
+###  http://www.w3.org/2004/02/skos/core#prefLabel
+skos:prefLabel rdf:type owl:AnnotationProperty ;
+               rdfs:subPropertyOf rdfs:label .
+
+
+###  http://www.w3.org/2004/02/skos/core#scopeNote
+skos:scopeNote rdf:type owl:AnnotationProperty ;
+               rdfs:subPropertyOf skos:note .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://kbpedia.org/ontologies/kko#HasOtherWritingsAspect
+:HasOtherWritingsAspect rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf :aspectProperties ;
+                        rdfs:domain owl:Thing ;
+                        rdfs:range :RefConcept ;
+                        skos:definition "This property provides links to articles in Wikipedia categories that have Writings aspects related to the main subject at hand; a separate grouping deals explicitly with Books." ;
+                        skos:prefLabel "Other Writings" .
+
+
+###  http://kbpedia.org/ontologies/kko#actions
+:actions rdf:type owl:ObjectProperty ;
+         rdfs:subPropertyOf :copulative ;
+         skos:altLabel "perception"@en ,
+                       "reaction"@en ;
+         skos:definition "Simple relations of energetics, perception or thought of subject (A) to some other object (B)."@en ;
+         skos:prefLabel "actions"@en ;
+         skos:scopeNote "A Secondness"@en ,
+                        "This category could be further split by energetic (1o), perceptual (2o) and thinking (3o)."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#adjunctual
+:adjunctual rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf :attributes ;
+            skos:altLabel "accidental"@en ,
+                          "happening"@en ;
+            skos:definition "These are events that may occur to a single entities or events (particulars) that help characterize it."@en ;
+            skos:prefLabel "adjunctual"@en ;
+            skos:scopeNote "A Secondness"@en ,
+                           "Some of the concepts associated with this set of properties are birth, death, marriage, events, accidents, surprises, happenings, extrinsic, adjunctual."@en ,
+                           "Though Peirce used ‘accidental’ much (Eventuals), he applied it in most cases to ‘accidental actuals’; thus, ‘adjunct’ better captures potentiality."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#aspectProperties
+:aspectProperties rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf :mappingProperties .
+
+
+###  http://kbpedia.org/ontologies/kko#attributes
+:attributes rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf :predicateProperties ;
+            skos:altLabel "attribute"@en ,
+                          "characteristic"@en ,
+                          "characteristics"@en ,
+                          "essenses"@en ,
+                          "inherences"@en ;
+            skos:definition "Attributes are the ways by which a subject (A) may be described, characterized, or situated. All relations are inward looking to the subject, A."@en ;
+            skos:prefLabel "attributes"@en ;
+            skos:scopeNote "A Firstness"@en ,
+                           "Attributes are of the form of A:A. All inherential and referential characteristics of and for subject A are included in this category."@en ,
+                           "Can also call Attributes ‘internal relations’."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#circumstances
+:circumstances rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf :mediative ;
+               skos:altLabel "contexts"@en ,
+                             "situations"@en ,
+                             "thoughts"@en ;
+               skos:definition "Relations of subject (A) to external circumstances, situations or contexts."@en ;
+               skos:prefLabel "circumstances"@en ;
+               skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#classifications
+:classifications rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :contextual ;
+                 skos:altLabel "classification"@en ,
+                               "classify"@en ;
+                 skos:definition "A characterization of subject (A) that involves evaluating subject (A) and providing a multi-factor typing, coding or value in relation to a given attribute or set of attributes."@en ;
+                 skos:prefLabel "classifications"@en ;
+                 skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#comparisons
+:comparisons rdf:type owl:ObjectProperty ;
+             rdfs:subPropertyOf :mediative ;
+             skos:altLabel "compared to"@en ,
+                           "similar"@en ;
+             skos:definition "Relations that compare, contrast or size up similarities or differences or overlaps between subject (A) and object (B)."@en ;
+             skos:prefLabel "comparisons"@en ;
+             skos:scopeNote "A Firstness"@en ,
+                            "Directly from Peirce; \"of the nature of logical possibilities” (CP 2.234)"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#conjoins
+:conjoins rdf:type owl:ObjectProperty ;
+          rdfs:subPropertyOf :copulative ;
+          skos:definition "Relations that involve the joining of a subject (A) to an object (B) via an intermediate object."@en ;
+          skos:prefLabel "conjoins"@en ;
+          skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#contextual
+:contextual rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf :attributes ;
+            skos:altLabel "context"@en ,
+                          "perspective"@en ;
+            skos:definition "These are circumstances or placements of single entities or events (particulars) that help characterize it."@en ;
+            skos:prefLabel "contextual"@en ;
+            skos:scopeNote "A Thirdness"@en ,
+                           "Some of the concepts associated with this set of properties include space, time, continuity, contiguous, smooth, otherness, ratings, situational (w/ respect to A), sensible, contiguous, all placements thereto, derivative, classificatory, rankings."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#copulative
+:copulative rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf :externalRelations ;
+            skos:definition "These are relatiionships of combination, membership, quantity, action, or identification."@en ;
+            skos:prefLabel "copulative"@en ;
+            skos:scopeNote "A Secondness"@en ,
+                           "Some of the concepts associated with this set of properties are accidental, real, place, time, situation, quantity, facets, aspects, conjunctive, lists, one-to-many, many-to-one, sum of, contextual, verbs."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#correspondsTo
+:correspondsTo rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf :mappingProperties ;
+               rdf:type owl:SymmetricProperty ,
+                        owl:TransitiveProperty ;
+               rdfs:domain owl:Thing ;
+               rdfs:range :RefConcept ;
+               rdfs:comment """The property kko:correspondsTo is used to assert a close correspondence between an external class, named entity, individual or instance with a Reference Concept class. kko:correspondsTo relates the external class, named entity, individual or instance to the class through the basis of both its subject matter and intended scope. This predicate should be used where the correspondence between the two entities is felt to be nearly equivalent to a sameAs assertion, and is reflexive, but without the full entailments of intensional class memberships. In these cases, both entities are understood to have the same type and intended scope, but without asserting a full class-level or sameAs individual relationship.
+
+This predicate is designed for the circumstance of aligning two different ontologies or knowledge bases based on node-level correspondences, but without entailing the actual ontological relationships and structure of the object source. For example, the kko:correspondsTo predicate is used to assert close correspondence between KKO Reference Concepts and Wikipedia categories or pages, yet without entailing the actual Wikipedia category structure.
+
+This property asserts a different and stronger relationship than kko:isAbout. One practical use is to guide specific instance member determinations when, say, the native structure of the external ontology or knowledge base is to be analyzed and replaced with an KKO-based structure.
+
+This property is therefore used to create a nearly equivalent assertion (however, with the degree of that equivalence being unknown or unknowable) between an external instance or class and a Reference Concept class"""@en .
+
+
+###  http://kbpedia.org/ontologies/kko#descendants
+:descendants rdf:type owl:ObjectProperty ;
+             rdfs:subPropertyOf :direct ;
+             skos:altLabel "hypernym"@en ,
+                           "hyponym"@en ,
+                           "subtype"@en ,
+                           "supertype"@en ;
+             skos:definition "A simple relationship where object (B) is a direct child or parent or subsumption (hyponym) or supersumption (hypernym) to subject (A)."@en ;
+             skos:prefLabel "descendants"@en ;
+             skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#direct
+:direct rdf:type owl:ObjectProperty ;
+        rdfs:subPropertyOf :externalRelations ;
+        skos:altLabel "simple relations"@en ;
+        skos:definition "These properties are in a simple (direct) relationship, meaning no intermediaries, between two different objects (entities, events, or their types, considered as instances)."@en ;
+        skos:prefLabel "direct relations"@en ;
+        skos:scopeNote "A Firstness"@en ,
+                       "Some of the concepts associated with this set of properties are is a, simple without parts, part of, members in types or classes, genealogical roles (parent, child, brother), identity, extensional."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#elementals
+:elementals rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf :intrinsics ;
+            skos:altLabel "components"@en ,
+                          "ingredients"@en ,
+                          "parts"@en ;
+            skos:definition "A contributing part of or integral input or aspect that adds to the understanding about the subject (A)."@en ;
+            skos:prefLabel "elementals"@en ;
+            skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#equivalences
+:equivalences rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :direct ;
+              skos:altLabel "equal"@en ,
+                            "identical to"@en ,
+                            "same as"@en ;
+              skos:definition "A simple relatiionship between a subject (A) and an object (B) that asserts equalness or sameness."@en ;
+              skos:prefLabel "equivalences"@en ;
+              skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#eventuals
+:eventuals rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf :adjunctual ;
+           skos:altLabel "accidentals"@en ,
+                         "dates"@en ,
+                         "events"@en ,
+                         "eventuals"@en ;
+           skos:definition "Chance, accidental or planned occurrences that directly involve subject (A)."@en ;
+           skos:prefLabel "eventuals"@en ;
+           skos:scopeNote "A Secondness"@en ,
+                          "Attributes of time are often candidates for this property category. \"Thus, space does for different subjects of one predicate precisely what time does for different predicates of the same subject.\" (CP 1.501)"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#externalRelations
+:externalRelations rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :predicateProperties ;
+                   skos:definition "All external facing relations of a subject (A) to outside objects or data."@en ;
+                   skos:prefLabel "external relations"@en ;
+                   skos:scopeNote "A Secondness"@en ,
+                                  "Direct relations + Copulative properties are intended to inclusively conform to what Peirce called \"simple relations\"."@en ,
+                                  "External relations are of the form A:B. These are all of the external facing relations for subject A, be they actions or perceptions or situations with respect to the external world."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#extrinsics
+:extrinsics rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf :adjunctual ;
+            skos:altLabel "external events"@en ,
+                          "external factors"@en ;
+            skos:definition "External events or circumstances that directly involve subject (A) or help define the nature or reality of subject (A)."@en ;
+            skos:prefLabel "extrinsics"@en ;
+            skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#forms
+:forms rdf:type owl:ObjectProperty ;
+       rdfs:subPropertyOf :intrinsics ;
+       skos:altLabel "arrangements"@en ,
+                     "configurations"@en ,
+                     "forms"@en ,
+                     "shapes"@en ;
+       skos:definition "Configurations or arrangements that are of the nature or perceivable of the subject (A)."@en ;
+       skos:prefLabel "forms"@en ;
+       skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#hasAcademicsAspect
+:hasAcademicsAspect rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :aspectProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :RefConcept ;
+                    skos:definition "This property provides links to articles in Wikipedia categories that have Academics aspects related to the main subject at hand. Academics are understood to exclude other notable persons, artists, athletes, businesspersons, entertainers, leaders, professionals, religious persons and shady characters, which each have their own aspects." ;
+                    skos:prefLabel "Academics" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasActionsAspect
+:hasActionsAspect rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf :aspectProperties ;
+                  rdfs:domain owl:Thing ;
+                  rdfs:range :RefConcept ;
+                  skos:definition "This property provides links to articles in Wikipedia categories that have Actions aspects related to the main subject at hand. Recreation, Sports and War actions are specifically excluded, since these have their own properties." ;
+                  skos:prefLabel "Actions" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasAnalysisOrganizingAspect
+:hasAnalysisOrganizingAspect rdf:type owl:ObjectProperty ;
+                             rdfs:subPropertyOf :aspectProperties ;
+                             rdfs:domain owl:Thing ;
+                             rdfs:range :RefConcept ;
+                             skos:definition "This property provides links to articles in Wikipedia categories that have Analysis and Organizing aspects related to the main subject at hand." ;
+                             skos:prefLabel "Analysis & Organizing" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasAnimalsAspect
+:hasAnimalsAspect rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf :aspectProperties ;
+                  rdfs:domain owl:Thing ;
+                  rdfs:range :RefConcept ;
+                  skos:definition "This property provides links to articles in Wikipedia categories that have Animals aspects related to the main subject at hand." ;
+                  skos:prefLabel "Animals" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasArtistsAspect
+:hasArtistsAspect rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf :aspectProperties ;
+                  rdfs:domain owl:Thing ;
+                  rdfs:range :RefConcept ;
+                  skos:definition "This property provides links to articles in Wikipedia categories that have Artists aspects related to the main subject at hand. Artists are understood to exclude academics, other notable persons, athletes, businesspersons, entertainers, leaders, professionals, religious persons and shady characters, which each have their own aspects." ;
+                  skos:prefLabel "Artists" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasAthletesAspect
+:hasAthletesAspect rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :aspectProperties ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range :RefConcept ;
+                   skos:definition "This property provides links to articles in Wikipedia categories that have Athletes aspects related to the main subject at hand." ;
+                   skos:prefLabel "Athletes" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasAttributesAspect
+:hasAttributesAspect rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf :aspectProperties ;
+                     rdfs:domain owl:Thing ;
+                     rdfs:range :RefConcept ;
+                     skos:definition "This property provides links to articles in Wikipedia categories that have Attributes aspects related to the main subject at hand." ;
+                     skos:prefLabel "Attributes" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasAudioAspect
+:hasAudioAspect rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :aspectProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :RefConcept ;
+                skos:definition "This property provides links to articles in Wikipedia categories that have Audio aspects related to the main subject at hand. Music recordings, including singles, albums, long-playing and extended-play records are specifically included." ;
+                skos:prefLabel "Audio" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasBooksAspect
+:hasBooksAspect rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :aspectProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :RefConcept ;
+                skos:definition "This property provides links to articles in Wikipedia categories that have Books aspects related to the main subject at hand." ;
+                skos:prefLabel "Books" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasBusinesspersonsAspect
+:hasBusinesspersonsAspect rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf :aspectProperties ;
+                          rdfs:domain owl:Thing ;
+                          rdfs:range :RefConcept ;
+                          skos:definition "This property provides links to articles in Wikipedia categories that have Businesspersons aspects related to the main subject at hand. Businesspersons are understood to exclude academics, artists, athletes, other notable persons, entertainers, leaders, professionals, religious persons and shady characters, which each have their own aspects." ;
+                          skos:prefLabel "Businesspersons" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasCartoonsAspect
+:hasCartoonsAspect rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :aspectProperties ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range :RefConcept ;
+                   skos:definition "This property provides links to articles in Wikipedia categories that have Cartoons aspects related to the main subject at hand. General animation-related topics are also specifically included." ;
+                   skos:prefLabel "Cartoons" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasChemistryAspect
+:hasChemistryAspect rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :aspectProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :RefConcept ;
+                    skos:definition "This property provides links to articles in Wikipedia categories that have Chemistry aspects related to the main subject at hand. Inorganic chemistry, organic chemistry, and biochemistry are specifically included." ;
+                    skos:prefLabel "Chemistry" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasCommercialEstablishmentsAspect
+:hasCommercialEstablishmentsAspect rdf:type owl:ObjectProperty ;
+                                   rdfs:subPropertyOf :aspectProperties ;
+                                   rdfs:domain owl:Thing ;
+                                   rdfs:range :RefConcept ;
+                                   skos:definition "This property provides links to articles in Wikipedia categories that have Commercial Establishments aspects related to the main subject at hand. Commercial Establishments are a subset of facilities, which have some separate aspects." ;
+                                   skos:prefLabel "Commercial Establishments" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasCompaniesAspect
+:hasCompaniesAspect rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :aspectProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :RefConcept ;
+                    skos:definition "This property provides links to articles in Wikipedia categories that have Companies aspects related to the main subject at hand. Companies are a subset of organizations, which have some separate aspects." ;
+                    skos:prefLabel "Companies" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasComputingAspect
+:hasComputingAspect rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :aspectProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :RefConcept ;
+                    skos:definition "This property provides links to articles in Wikipedia categories that have Computing aspects related to the main subject at hand. This aspect is specifically separate from Software." ;
+                    skos:prefLabel "Computing" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasCountriesNationalitiesAspect
+:hasCountriesNationalitiesAspect rdf:type owl:ObjectProperty ;
+                                 rdfs:subPropertyOf :aspectProperties ;
+                                 rdfs:domain owl:Thing ;
+                                 rdfs:range :RefConcept ;
+                                 skos:definition "This property provides links to articles in Wikipedia categories that have Country or Nationality aspects related to the main subject at hand." ;
+                                 skos:prefLabel "Countries & Nationalities" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasCrimeWarAspect
+:hasCrimeWarAspect rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :aspectProperties ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range :RefConcept ;
+                   skos:definition "This property provides links to articles in Wikipedia categories that have Crime & War (strife) aspects related to the main subject at hand." ;
+                   skos:prefLabel "Crime & War" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasDatesAspect
+:hasDatesAspect rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :aspectProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :RefConcept ;
+                skos:definition "This property provides links to articles in Wikipedia categories that have Dates aspects related to the main subject at hand. Individual years and centuries are specifically included." ;
+                skos:prefLabel "Dates" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasDisastersAspect
+:hasDisastersAspect rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :aspectProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :RefConcept ;
+                    skos:definition "This property provides links to articles in Wikipedia categories that have Disasters aspects related to the main subject at hand. Disasters are a subset of events, which have some other aspects." ;
+                    skos:prefLabel "Disasters" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasDrinkAspect
+:hasDrinkAspect rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :aspectProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :RefConcept ;
+                skos:definition "This property provides links to articles in Wikipedia categories that have Drink aspects related to the main subject at hand." ;
+                skos:prefLabel "Drink" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasDrugsAspect
+:hasDrugsAspect rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :aspectProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :RefConcept ;
+                skos:definition "This property provides links to articles in Wikipedia categories that have Drugs aspects related to the main subject at hand." ;
+                skos:prefLabel "Drugs" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasEntertainersAspect
+:hasEntertainersAspect rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf :aspectProperties ;
+                       rdfs:domain owl:Thing ;
+                       rdfs:range :RefConcept ;
+                       skos:definition "This property provides links to articles in Wikipedia categories that have Entertainers aspects related to the main subject at hand. Entertainers (or performers) are understood to exclude academics, artists, athletes, businesspersons, other notable persons, leaders, professionals, religious persons and shady characters, which each have their own aspects." ;
+                       skos:prefLabel "Entertainers" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasErasAspect
+:hasErasAspect rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf :aspectProperties ;
+               rdfs:domain owl:Thing ;
+               rdfs:range :RefConcept ;
+               skos:definition "This property provides links to articles in Wikipedia categories that have Eras aspects related to the main subject at hand. Eras refer to nameable, large durations of time." ;
+               skos:prefLabel "Eras" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasEventsAspect
+:hasEventsAspect rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :aspectProperties ;
+                 rdfs:domain owl:Thing ;
+                 rdfs:range :RefConcept ;
+                 skos:definition "This property provides links to articles in Wikipedia categories that have Events aspects related to the main subject at hand." ;
+                 skos:prefLabel "Events" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasExtraterrestrialAspect
+:hasExtraterrestrialAspect rdf:type owl:ObjectProperty ;
+                           rdfs:subPropertyOf :aspectProperties ;
+                           rdfs:domain owl:Thing ;
+                           rdfs:range :RefConcept ;
+                           skos:definition "This property provides links to articles in Wikipedia categories that have Extraterrestrial aspects related to the main subject at hand." ;
+                           skos:prefLabel "Extraterrestrial" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasFictionalAspect
+:hasFictionalAspect rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :aspectProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :RefConcept ;
+                    skos:definition "This property provides links to articles in Wikipedia categories that have Fictional aspects related to the main subject at hand." ;
+                    skos:prefLabel "Fictional" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasFieldsOfStudyAspect
+:hasFieldsOfStudyAspect rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf :aspectProperties ;
+                        rdfs:domain owl:Thing ;
+                        rdfs:range :RefConcept ;
+                        skos:definition "This property provides links to articles in Wikipedia categories that have Fields Of Study aspects related to the main subject at hand. Academic disciplines and department names and emphases are specifically included." ;
+                        skos:prefLabel "Fields Of Study" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasFilmsAspect
+:hasFilmsAspect rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :aspectProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :RefConcept ;
+                skos:definition "This property provides links to articles in Wikipedia categories that have Films aspects related to the main subject at hand. All film and movie forms are specifically included." ;
+                skos:prefLabel "Films" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasFinancialAspect
+:hasFinancialAspect rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :aspectProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :RefConcept ;
+                    skos:definition "This property provides links to articles in Wikipedia categories that have Financial aspects related to the main subject at hand. General economic topics are also specifically included." ;
+                    skos:prefLabel "Financial" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasFoodAspect
+:hasFoodAspect rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf :aspectProperties ;
+               rdfs:domain owl:Thing ;
+               rdfs:range :RefConcept ;
+               skos:definition "This property provides links to articles in Wikipedia categories that have Food aspects related to the main subject at hand." ;
+               skos:prefLabel "Food" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasGamesAspect
+:hasGamesAspect rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :aspectProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :RefConcept ;
+                skos:definition "This property provides links to articles in Wikipedia categories that have Games aspects related to the main subject at hand." ;
+                skos:prefLabel "Games" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasGenresAspect
+:hasGenresAspect rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :aspectProperties ;
+                 rdfs:domain owl:Thing ;
+                 rdfs:range :RefConcept ;
+                 skos:definition "This property provides links to articles in Wikipedia categories that have Genres aspects related to the main subject at hand." ;
+                 skos:prefLabel "Genres" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasGovernmentalAspect
+:hasGovernmentalAspect rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf :aspectProperties ;
+                       rdfs:domain owl:Thing ;
+                       rdfs:range :RefConcept ;
+                       skos:definition "This property provides links to articles in Wikipedia categories that have Governmental aspects related to the main subject at hand. Government is a subset of organizations, which have some separate aspects." ;
+                       skos:prefLabel "Governmental" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasHabitedAreasAspect
+:hasHabitedAreasAspect rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf :aspectProperties ;
+                       rdfs:domain owl:Thing ;
+                       rdfs:range :RefConcept ;
+                       skos:definition "This property provides links to articles in Wikipedia categories that have Habited Areas aspects related to the main subject at hand. Habited Areas may span from single rooms to larger complexes and communities in which individuals live. Animal habitations are specifically included in this aspect." ;
+                       skos:prefLabel "Habited Areas" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasHealthDiseaseAspect
+:hasHealthDiseaseAspect rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf :aspectProperties ;
+                        rdfs:domain owl:Thing ;
+                        rdfs:range :RefConcept ;
+                        skos:definition "This property provides links to articles in Wikipedia categories that have Health or Disease aspects related to the main subject at hand." ;
+                        skos:prefLabel "Health & Disease" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasHonorsCelebrationsAspect
+:hasHonorsCelebrationsAspect rdf:type owl:ObjectProperty ;
+                             rdfs:subPropertyOf :aspectProperties ;
+                             rdfs:domain owl:Thing ;
+                             rdfs:range :RefConcept ;
+                             skos:definition "This property provides links to articles in Wikipedia categories that have Honors & Celebrations aspects related to the main subject at hand." ;
+                             skos:prefLabel "Honors & Celebrations" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasImagesAspect
+:hasImagesAspect rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :aspectProperties ;
+                 rdfs:domain owl:Thing ;
+                 rdfs:range :RefConcept ;
+                 skos:definition "This property provides links to articles in Wikipedia categories that have Images aspects related to the main subject at hand." ;
+                 skos:prefLabel "Images" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasInYearAspect
+:hasInYearAspect rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :aspectProperties ;
+                 rdfs:domain owl:Thing ;
+                 rdfs:range :RefConcept ;
+                 skos:definition "This property provides links to articles in Wikipedia categories that have In Year aspects related to the main subject at hand. In Year is a reference to a specific calendar year." ;
+                 skos:prefLabel "In Year" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasIndustrialFacilitiesAspect
+:hasIndustrialFacilitiesAspect rdf:type owl:ObjectProperty ;
+                               rdfs:subPropertyOf :aspectProperties ;
+                               rdfs:domain owl:Thing ;
+                               rdfs:range :RefConcept ;
+                               skos:definition "This property provides links to articles in Wikipedia categories that have Industrial Facilities aspects related to the main subject at hand. Industrial Facilities are a subset of facilities, which have some separate aspects." ;
+                               skos:prefLabel "Industrial Facilities" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasJobTypesAspect
+:hasJobTypesAspect rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :aspectProperties ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range :RefConcept ;
+                   skos:definition "This property provides links to articles in Wikipedia categories that have Job Types aspects related to the main subject at hand. Job Types is one subset of overall Person aspects." ;
+                   skos:prefLabel "Job Types" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasLandformsAspect
+:hasLandformsAspect rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :aspectProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :RefConcept ;
+                    skos:definition "This property provides links to articles in Wikipedia categories that have Landforms aspects related to the main subject at hand." ;
+                    skos:prefLabel "Landforms" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasLanguagesAspect
+:hasLanguagesAspect rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :aspectProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :RefConcept ;
+                    skos:definition "This property provides links to articles in Wikipedia categories that have Languages aspects related to the main subject at hand. Both human and artificial languages are specifically included." ;
+                    skos:prefLabel "Languages" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasLeadersAspect
+:hasLeadersAspect rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf :aspectProperties ;
+                  rdfs:domain owl:Thing ;
+                  rdfs:range :RefConcept ;
+                  skos:definition "This property provides links to articles in Wikipedia categories that have Leaders aspects related to the main subject at hand. Leaders are understood to exclude academics, artists, athletes, businesspersons, entertainers, other notable persons, professionals, religious persons and shady characters, which each have their own aspects." ;
+                  skos:prefLabel "Leaders" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasListsAspect
+:hasListsAspect rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :aspectProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :RefConcept ;
+                skos:definition "This property provides links to articles in Wikipedia categories that have Lists aspects related to the main subject at hand." ;
+                skos:prefLabel "Lists" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasLivingThingsAspect
+:hasLivingThingsAspect rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf :aspectProperties ;
+                       rdfs:domain owl:Thing ;
+                       rdfs:range :RefConcept ;
+                       skos:definition "This property provides links to articles in Wikipedia categories that have Living Things aspects related to the main subject at hand. Living Things are understood to include all life forms and concepts apart from Animals and Plants." ;
+                       skos:prefLabel "Living Things" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasLocationsOtherAspect
+:hasLocationsOtherAspect rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf :aspectProperties ;
+                         rdfs:domain owl:Thing ;
+                         rdfs:range :RefConcept ;
+                         skos:definition "This property provides links to articles in Wikipedia categories that have Locations (other) aspects related to the main subject at hand. This grouping complements the Habited Areas or Countries & Nationalities properties." ;
+                         skos:prefLabel "Locations (other)" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasMathNumbersAspect
+:hasMathNumbersAspect rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf :aspectProperties ;
+                      rdfs:domain owl:Thing ;
+                      rdfs:range :RefConcept ;
+                      skos:definition "This property provides links to articles in Wikipedia categories that have Math & Numbers aspects related to the main subject at hand." ;
+                      skos:prefLabel "Math & Numbers" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasMilitaryAspect
+:hasMilitaryAspect rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :aspectProperties ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range :RefConcept ;
+                   skos:definition "This property provides links to articles in Wikipedia categories that have Military aspects related to the main subject at hand." ;
+                   skos:prefLabel "Military" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasMonumentsAspect
+:hasMonumentsAspect rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :aspectProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :RefConcept ;
+                    skos:definition "This property provides links to articles in Wikipedia categories that have Monuments aspects related to the main subject at hand. Monuments are a subset of facilities." ;
+                    skos:prefLabel "Monuments" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasMusicAspect
+:hasMusicAspect rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :aspectProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :RefConcept ;
+                skos:definition "This property provides links to articles in Wikipedia categories that have Music aspects related to the main subject at hand. Music recordings, shown under the Audio property, are specifically excluded." ;
+                skos:prefLabel "Music" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasNaturalAreasAspect
+:hasNaturalAreasAspect rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf :aspectProperties ;
+                       rdfs:domain owl:Thing ;
+                       rdfs:range :RefConcept ;
+                       skos:definition "This property provides links to articles in Wikipedia categories that have Natural Areas aspects related to the main subject at hand." ;
+                       skos:prefLabel "Natural Areas" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasNaturalPhenomenaAspect
+:hasNaturalPhenomenaAspect rdf:type owl:ObjectProperty ;
+                           rdfs:subPropertyOf :aspectProperties ;
+                           rdfs:domain owl:Thing ;
+                           rdfs:range :RefConcept ;
+                           skos:definition "This property provides links to articles in Wikipedia categories that have Natural Phenomena aspects related to the main subject at hand." ;
+                           skos:prefLabel "Natural Phenomena" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasNaturalSubstanceAspect
+:hasNaturalSubstanceAspect rdf:type owl:ObjectProperty ;
+                           rdfs:subPropertyOf :aspectProperties ;
+                           rdfs:domain owl:Thing ;
+                           rdfs:range :RefConcept ;
+                           skos:definition "This property provides links to articles in Wikipedia categories that have Natural Substance aspects related to the main subject at hand." ;
+                           skos:prefLabel "Natural Substance" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasNotablePersonsAspect
+:hasNotablePersonsAspect rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf :aspectProperties ;
+                         rdfs:domain owl:Thing ;
+                         rdfs:range :RefConcept ;
+                         skos:definition "This property provides links to articles in Wikipedia categories that have Notable Persons aspects related to the main subject at hand. Notable Persons are understood to exclude academics, artists, athletes, businesspersons, entertainers, leaders, professionals, religious persons and shady characters, which each have their own aspects." ;
+                         skos:prefLabel "Notable Persons" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasOtherFacilitiesAspect
+:hasOtherFacilitiesAspect rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf :aspectProperties ;
+                          rdfs:domain owl:Thing ;
+                          rdfs:range :RefConcept ;
+                          skos:definition "This property provides links to articles in Wikipedia categories that have Other Facilities aspects related to the main subject at hand." ;
+                          skos:prefLabel "Other Facilities" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasOtherOrganizationsAspect
+:hasOtherOrganizationsAspect rdf:type owl:ObjectProperty ;
+                             rdfs:subPropertyOf :aspectProperties ;
+                             rdfs:domain owl:Thing ;
+                             rdfs:range :RefConcept ;
+                             skos:definition "This property provides links to articles in Wikipedia categories that have Other Organizations aspects related to the main subject at hand. Sports teams, companies, and colleges and universities, are explicitly excluded since they have their own separate groupings." ;
+                             skos:prefLabel "Other Organizations" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasPerformingArtsAspect
+:hasPerformingArtsAspect rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf :aspectProperties ;
+                         rdfs:domain owl:Thing ;
+                         rdfs:range :RefConcept ;
+                         skos:definition "This property provides links to articles in Wikipedia categories that have Performing Arts aspects related to the main subject at hand." ;
+                         skos:prefLabel "Performing Arts" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasPlantsAspect
+:hasPlantsAspect rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :aspectProperties ;
+                 rdfs:domain owl:Thing ;
+                 rdfs:range :RefConcept ;
+                 skos:definition "This property provides links to articles in Wikipedia categories that have Plants aspects related to the main subject at hand." ;
+                 skos:prefLabel "Plants" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasPoliticsAspect
+:hasPoliticsAspect rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :aspectProperties ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range :RefConcept ;
+                   skos:definition "This property provides links to articles in Wikipedia categories that have Politics aspects related to the main subject at hand." ;
+                   skos:prefLabel "Politics" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasProductsAspect
+:hasProductsAspect rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :aspectProperties ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range :RefConcept ;
+                   skos:definition "This property provides links to articles in Wikipedia categories that have Products aspects related to the main subject at hand." ;
+                   skos:prefLabel "Products" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasProfessionalsAspect
+:hasProfessionalsAspect rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf :aspectProperties ;
+                        rdfs:domain owl:Thing ;
+                        rdfs:range :RefConcept ;
+                        skos:definition "This property provides links to articles in Wikipedia categories that have Professionals aspects related to the main subject at hand. Professionals are understood to exclude academics, artists, athletes, businesspersons, entertainers, leaders, other notable persons, religious persons and shady characters, which each have their own aspects." ;
+                        skos:prefLabel "Professionals" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasRecreationAspect
+:hasRecreationAspect rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf :aspectProperties ;
+                     rdfs:domain owl:Thing ;
+                     rdfs:range :RefConcept ;
+                     skos:definition "This property provides links to articles in Wikipedia categories that have Recreation aspects related to the main subject at hand." ;
+                     skos:prefLabel "Recreation" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasReligiousAspect
+:hasReligiousAspect rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :aspectProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :RefConcept ;
+                    skos:definition "This property provides links to articles in Wikipedia categories that have Religious aspects related to the main subject at hand." ;
+                    skos:prefLabel "Religious" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasReligiousPersonsAspect
+:hasReligiousPersonsAspect rdf:type owl:ObjectProperty ;
+                           rdfs:subPropertyOf :aspectProperties ;
+                           rdfs:domain owl:Thing ;
+                           rdfs:range :RefConcept ;
+                           skos:definition "This property provides links to articles in Wikipedia categories that have Religious Persons aspects related to the main subject at hand. Religions Persons are understood to exclude academics, artists, athletes, businesspersons, entertainers, leaders, professionals, other notable persons and shady characters, which each have their own aspects." ;
+                           skos:prefLabel "Religious Persons" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasSchoolsAspect
+:hasSchoolsAspect rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf :aspectProperties ;
+                  rdfs:domain owl:Thing ;
+                  rdfs:range :RefConcept ;
+                  skos:definition "This property provides links to articles in Wikipedia categories that have Schools aspects related to the main subject at hand. Education topics and colleges and universities are explicitly included in this grouping." ;
+                  skos:prefLabel "Schools" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasShadyCharactersAspect
+:hasShadyCharactersAspect rdf:type owl:ObjectProperty ;
+                          rdfs:subPropertyOf :aspectProperties ;
+                          rdfs:domain owl:Thing ;
+                          rdfs:range :RefConcept ;
+                          skos:definition "This property provides links to articles in Wikipedia categories that have Shady Characters aspects related to the main subject at hand. Shady characters, including criminals and persons of possibly poor reputation, are understood to exclude academics, artists, athletes, businesspersons, entertainers, leaders, professionals, religious persons and other notable persons, which each have their own aspects." ;
+                          skos:prefLabel "Shady Characters" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasSocietyAspect
+:hasSocietyAspect rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf :aspectProperties ;
+                  rdfs:domain owl:Thing ;
+                  rdfs:range :RefConcept ;
+                  skos:definition "This property provides links to articles in Wikipedia categories that have Society aspects related to the main subject at hand." ;
+                  skos:prefLabel "Society" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasSoftwareAspect
+:hasSoftwareAspect rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :aspectProperties ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range :RefConcept ;
+                   skos:definition "This property provides links to articles in Wikipedia categories that have Software aspects related to the main subject at hand." ;
+                   skos:prefLabel "Software" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasSportsAspect
+:hasSportsAspect rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :aspectProperties ;
+                 rdfs:domain owl:Thing ;
+                 rdfs:range :RefConcept ;
+                 skos:definition "This property provides links to articles in Wikipedia categories that have Sports aspects related to the main subject at hand." ;
+                 skos:prefLabel "Sports" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasStandardsAspect
+:hasStandardsAspect rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :aspectProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :RefConcept ;
+                    skos:definition "This property provides links to articles in Wikipedia categories that have Standards aspects related to the main subject at hand." ;
+                    skos:prefLabel "Standards" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasStructuredDataAspect
+:hasStructuredDataAspect rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf :aspectProperties ;
+                         rdfs:domain owl:Thing ;
+                         rdfs:range :RefConcept ;
+                         skos:definition "This property provides links to articles in Wikipedia categories that have Structured Data aspects related to the main subject at hand. Databases, structured forms of information such as spreadsheets and markup, and structured notations are specifically included in this grouping." ;
+                         skos:prefLabel "Structured Data" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasStructuredInfoAspect
+:hasStructuredInfoAspect rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf :aspectProperties ;
+                         rdfs:domain owl:Thing ;
+                         rdfs:range :RefConcept ;
+                         skos:definition "This property provides links to articles in Wikipedia categories that have Structured Info aspects related to the main subject at hand. Structured Info is a less organized (structured) format than Structured Data, which has its own aspect, or is a notation reflecting the same." ;
+                         skos:prefLabel "Structured Info" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasTVAspect
+:hasTVAspect rdf:type owl:ObjectProperty ;
+             rdfs:subPropertyOf :aspectProperties ;
+             rdfs:domain owl:Thing ;
+             rdfs:range :RefConcept ;
+             skos:definition "This property provides links to articles in Wikipedia categories that have TV aspects related to the main subject at hand." ;
+             skos:prefLabel "TV" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasTeamsAspect
+:hasTeamsAspect rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :aspectProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :RefConcept ;
+                skos:definition "This property provides links to articles in Wikipedia categories that have Teams aspects related to the main subject at hand. Most teams are sports in nature." ;
+                skos:prefLabel "Teams" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasTimeAspect
+:hasTimeAspect rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf :aspectProperties ;
+               rdfs:domain owl:Thing ;
+               rdfs:range :RefConcept ;
+               skos:definition "This property provides links to articles in Wikipedia categories that have Time aspects related to the main subject at hand. Specific Dates are excluded since they have their own separate grouping." ;
+               skos:prefLabel "Time" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasTopicsAspect
+:hasTopicsAspect rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :aspectProperties ;
+                 rdfs:domain owl:Thing ;
+                 rdfs:range :RefConcept ;
+                 skos:definition "This property provides links to articles in Wikipedia categories that have Topics aspects related to the main subject at hand." ;
+                 skos:prefLabel "Topics" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasTransportFacilitiesAspect
+:hasTransportFacilitiesAspect rdf:type owl:ObjectProperty ;
+                              rdfs:subPropertyOf :aspectProperties ;
+                              rdfs:domain owl:Thing ;
+                              rdfs:range :RefConcept ;
+                              skos:definition "This property provides links to articles in Wikipedia categories that have Transport Facilities aspects related to the main subject at hand. Transport Facilities are a subset of facilioties, which have some separate aspects." ;
+                              skos:prefLabel "Transport Facilities" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasVisualArtsAspect
+:hasVisualArtsAspect rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf :aspectProperties ;
+                     rdfs:domain owl:Thing ;
+                     rdfs:range :RefConcept ;
+                     skos:definition "This property provides links to articles in Wikipedia categories that have Visual Arts aspects related to the main subject at hand. Films and TV are specifically excluded since they have their own separate groupings." ;
+                     skos:prefLabel "Visual Arts" .
+
+
+###  http://kbpedia.org/ontologies/kko#hasWebStuffAspect
+:hasWebStuffAspect rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :aspectProperties ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range :RefConcept ;
+                   skos:definition "This property provides links to articles in Wikipedia categories that have Web Stuff aspects related to the main subject at hand." ;
+                   skos:prefLabel "Web Stuff" .
+
+
+###  http://kbpedia.org/ontologies/kko#intrinsics
+:intrinsics rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf :attributes ;
+            skos:definition "Innate characteristics or essences of single entities or events (particulars)."@en ;
+            skos:prefLabel "intrinsics"@en ;
+            skos:scopeNote "A Firstness"@en ,
+                           "Some of the concepts associated with this set of properties are oneness, qualities, feelings, inherent, negation, is, has, intensional, naturalness, internal, innateness."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#isAbout
+:isAbout rdf:type owl:ObjectProperty ;
+         rdfs:subPropertyOf :mappingProperties ;
+         owl:inverseOf :isRelatedTo ;
+         rdfs:domain owl:Thing ;
+         rdfs:range :RefConcept ;
+         skos:definition """The property kko:isAbout is used to assert the relation between a named entity (individual) and a Reference Concept class. kko:isAbout relates the named entity (individual) to the class through the basis of its subject matter. The relation acknowledges that the scope of the class can not be determined solely by the aggregation or extent of its associated individual entity members, and that the nature of the Reference Concept class may not alone bound or define the individual entity.
+
+This property is therefore used to create a topical assertion between an individual and a Reference Concept."""@en ;
+         skos:prefLabel "is about"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#isLike
+:isLike rdf:type owl:ObjectProperty ;
+        rdfs:subPropertyOf :mappingProperties ;
+        rdf:type owl:SymmetricProperty ;
+        rdfs:domain owl:Thing ;
+        rdfs:range owl:Thing ;
+        skos:definition """The property kko:isLike is used to assert an associative link between similar individuals who may or may not be identical, but are believed to be so. This property is not intended as a general expression of similarity, but rather the likely but uncertain same identity of the two resources being related.
+
+This property can and should be changed if the certainty of the sameness of identity is subsequently determined.
+
+In general, we may not be able to assert that two individuals are the same based solely on current information on hand. However, there may be quite reasonable bases or methods that the two individuals are likely the same without being one hundred percent sure.
+
+kko:isLike has the semantics of likely identity, but where there is some uncertainty that the two resources indeed refer to the exact same individual with the same identity. Such uncertainty can arise when, for example, common names may be used for different individuals (e.g., John Smith).
+
+It is appropriate to use this property when there is strong belief the two resources refer to the same individual with the same identity, but that association can not be asserted at the present time with certitude. """@en ;
+        skos:prefLabel "is like"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#isRelatedTo
+:isRelatedTo rdf:type owl:ObjectProperty ;
+             rdfs:subPropertyOf :mappingProperties ;
+             rdfs:domain :RefConcept ;
+             rdfs:range owl:Thing ;
+             skos:definition "Check the definition of kko:isAbout for the definition of this property; isRelatedTo is the inverse property of isAbout. "@en ;
+             skos:prefLabel "links entity"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#mappingProperties
+:mappingProperties rdf:type owl:ObjectProperty ;
+                   skos:definition "A category of convenience for aggregating all of the mapping properties."@en ;
+                   skos:prefLabel "mapping properties"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#mediative
+:mediative rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf :externalRelations ;
+           skos:definition "These are relationships of relevance, meaning or explanation – namely, thirdness – about subjects and types."@en ;
+           skos:prefLabel "mediative"@en ;
+           skos:scopeNote "A Thirdness"@en ,
+                          "Some of the concepts associated with this set of properties are concepts, generalities, similarity, genres, aspects, comparison, performance, thought, triadic, agreement/ difference, placement in space/time (contiguity), conditional, reasoning, classification."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#partsOf
+:partsOf rdf:type owl:ObjectProperty ;
+         rdfs:subPropertyOf :direct ;
+         skos:altLabel "part"@en ;
+         skos:definition "A simple relationship where the object (B) is a part of or component of subjext (A)."@en ;
+         skos:prefLabel "parts of"@en ;
+         skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#performances
+:performances rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :mediative ;
+              skos:altLabel "performance"@en ;
+              skos:definition "Relations of quantity or rank for how subject (A) performed in relation to object (B)."@en ;
+              skos:prefLabel "performances"@en ;
+              skos:scopeNote "A Secondness"@en ,
+                             "Directly from Peirce;  “of the nature of actual facts” (CP 2.234)"@en ,
+                             "Other concepts associated with this set of properties are sequences; processes; combinations."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#predicateProperties
+:predicateProperties rdf:type owl:ObjectProperty ;
+                     skos:editorialNote "From Peirce “every fact is a relation”; all facts are assertions."@en ,
+                                        "The predicate object properties in KKO are organized into a three-level schema based on the Peircean universal categories of Firstness, Secondness and Thirdness, resulting in 27 predicate types (3 * 3 * 3)  in the hierarchy. Either data or object properties may relate to nearly all levels in this schema."@en ,
+                                        "The same organizatonal schema (3 * 3 * 3) for these object properties is duplicated for data properties, since sources do not uniformly (nor correctly!) determine their appropriate format. In the paralellism the object property categoreis have the most direct names; those for data properties are appended with the 'xxx data' term. Efforts to be comprehensive across external property mappings should best consult both property types."@en ;
+                     skos:prefLabel "predicate properties"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#qualities
+:qualities rdf:type owl:ObjectProperty ;
+           rdfs:subPropertyOf :intrinsics ;
+           skos:altLabel "inherent"@en ,
+                         "intrinsic"@en ,
+                         "quality"@en ;
+           skos:definition "An internal characteristic or aspect of an object; collectively these internal relations define intensionally what kind of thing to which the object belongs, though that relationship is not intrinsic."@en ;
+           skos:prefLabel "qualities"@en ;
+           skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#quantities
+:quantities rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf :adjunctual ;
+            skos:altLabel "amount"@en ,
+                          "number of"@en ,
+                          "population"@en ,
+                          "quantifiable"@en ,
+                          "quantity"@en ;
+            skos:definition "A characteristic of a subject (A) that is expressed as a number quantity."@en ;
+            skos:prefLabel "quantities"@en ;
+            skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#ratings
+:ratings rdf:type owl:ObjectProperty ;
+         rdfs:subPropertyOf :contextual ;
+         skos:altLabel "orderings"@en ,
+                       "rankings"@en ;
+         skos:definition "An assigned value or characterization that orders subject (A) in relation to other subjects for a given attribute."@en ;
+         skos:prefLabel "ratings"@en ;
+         skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToAbstraction
+:relatesToAbstraction rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf :relatesToProperties ;
+                      rdfs:domain owl:Thing ;
+                      skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+                      skos:prefLabel "has abstraction"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToActivity
+:relatesToActivity rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :relatesToProperties ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range :ActionTypes ;
+                   skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+                   skos:prefLabel "has activity"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToAnimal
+:relatesToAnimal rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :relatesToProperties ;
+                 rdfs:domain owl:Thing ;
+                 rdfs:range :Animals ;
+                 skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+                 skos:prefLabel "relates to animal"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToArea
+:relatesToArea rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf :relatesToProperties ;
+               rdfs:domain owl:Thing ;
+               skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+               skos:prefLabel "relates to area or region"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToAttribute
+:relatesToAttribute rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :relatesToProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :AttributeTypes ;
+                    skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+                    skos:prefLabel "has attribute"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToAudioInfo
+:relatesToAudioInfo rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :relatesToProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :AudioInfo ;
+                    skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+                    skos:prefLabel "relates to audio information"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToBioProcess
+:relatesToBioProcess rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf :relatesToProperties ;
+                     rdfs:domain owl:Thing ;
+                     rdfs:range :AreaRegion ;
+                     skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                     skos:prefLabel "relates to a biological process"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToChemistry
+:relatesToChemistry rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :relatesToProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :Chemistry ;
+                    skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                    skos:prefLabel "relates to chemistry"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToDisease
+:relatesToDisease rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf :relatesToProperties ;
+                  rdfs:domain owl:Thing ;
+                  rdfs:range :Diseases ;
+                  skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                  skos:prefLabel "relates to disease"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToDrug
+:relatesToDrug rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf :relatesToProperties ;
+               rdfs:domain owl:Thing ;
+               rdfs:range :Drugs ;
+               skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+               skos:prefLabel "relates to drug"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToElement
+:relatesToElement rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf :relatesToProperties ;
+                  rdfs:domain owl:Thing ;
+                  skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                  skos:prefLabel "relates to atom or element"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToEntity
+:relatesToEntity rdf:type owl:ObjectProperty ;
+                 rdfs:subPropertyOf :relatesToProperties ;
+                 rdfs:domain owl:Thing ;
+                 skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                 skos:prefLabel "relates to entity"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToEvent
+:relatesToEvent rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :relatesToProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :EventTypes ;
+                skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+                skos:prefLabel "has event"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToFacility
+:relatesToFacility rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :relatesToProperties ;
+                   rdfs:domain owl:Thing ;
+                   rdfs:range :Facilities ;
+                   skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                   skos:prefLabel "relates to facility"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToFinanceEconomy
+:relatesToFinanceEconomy rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf :relatesToProperties ;
+                         rdfs:domain owl:Thing ;
+                         rdfs:range :EconomicSystems ;
+                         skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                         skos:prefLabel "relates to finance or economy"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToFoodDrink
+:relatesToFoodDrink rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :relatesToProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :FoodDrink ;
+                    skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+                    skos:prefLabel "has food drink"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToForm
+:relatesToForm rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf :relatesToProperties ;
+               rdfs:domain owl:Thing ;
+               skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+               skos:prefLabel "has form"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToGeoEntity
+:relatesToGeoEntity rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :relatesToProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :Geopolitical ;
+                    skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                    skos:prefLabel "relates to geopolitical entity"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToLocation
+:relatesToLocation rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :relatesToProperties ;
+                   rdfs:domain owl:Thing ;
+                   skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                   skos:prefLabel "relates to a location or place"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToOrgChemistry
+:relatesToOrgChemistry rdf:type owl:ObjectProperty ;
+                       rdfs:subPropertyOf :relatesToProperties ;
+                       rdfs:domain owl:Thing ;
+                       rdfs:range :OrganicChemistry ;
+                       skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                       skos:prefLabel "relates to organic chemistry"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToOrganizationType
+:relatesToOrganizationType rdf:type owl:ObjectProperty ;
+                           rdfs:subPropertyOf :relatesToProperties ;
+                           rdfs:domain owl:Thing ;
+                           rdfs:range :Organizations ;
+                           skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+                           skos:prefLabel "has organization type"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToOtherOrganism
+:relatesToOtherOrganism rdf:type owl:ObjectProperty ;
+                        rdfs:subPropertyOf :relatesToProperties ;
+                        rdfs:domain owl:Thing ;
+                        rdfs:range [ rdf:type owl:Class ;
+                                     owl:unionOf ( :Prokaryotes
+                                                   :ProtistsFungus
+                                                 )
+                                   ] ;
+                        skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                        skos:prefLabel "relates to other organism"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToPersonType
+:relatesToPersonType rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf :relatesToProperties ;
+                     rdfs:domain owl:Thing ;
+                     rdfs:range :Persons ;
+                     skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+                     skos:prefLabel "has person type"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToPhenomenon
+:relatesToPhenomenon rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf :relatesToProperties ;
+                     rdfs:domain owl:Thing ;
+                     rdfs:range :NaturalPhenomena ;
+                     skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                     skos:prefLabel "relates to natural phenomenon"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToPlant
+:relatesToPlant rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :relatesToProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :Plants ;
+                skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                skos:prefLabel "relates to plant"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToProductType
+:relatesToProductType rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf :relatesToProperties ;
+                      rdfs:domain owl:Thing ;
+                      rdfs:range :Products ;
+                      skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+                      skos:prefLabel "has product type"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToProperties
+:relatesToProperties rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf :mappingProperties ;
+                     skos:definition "A parental category of convenience for aggregating all of the relatesTo properties."@en ;
+                     skos:prefLabel "relatesTo properties"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToSituation
+:relatesToSituation rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :relatesToProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :SituationTypes ;
+                    skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                    skos:prefLabel "relates to situation"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToSociety
+:relatesToSociety rdf:type owl:ObjectProperty ;
+                  rdfs:subPropertyOf :relatesToProperties ;
+                  rdfs:domain owl:Thing ;
+                  rdfs:range :Society ;
+                  skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                  skos:prefLabel "relates to society"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToStructuredInfo
+:relatesToStructuredInfo rdf:type owl:ObjectProperty ;
+                         rdfs:subPropertyOf :relatesToProperties ;
+                         rdfs:domain owl:Thing ;
+                         rdfs:range :StructuredInfo ;
+                         skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                         skos:prefLabel "relates to structured information"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToSubstance
+:relatesToSubstance rdf:type owl:ObjectProperty ;
+                    rdfs:subPropertyOf :relatesToProperties ;
+                    rdfs:domain owl:Thing ;
+                    rdfs:range :NaturalSubstances ;
+                    skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                    skos:prefLabel "relates to natural substance"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToTime
+:relatesToTime rdf:type owl:ObjectProperty ;
+               rdfs:subPropertyOf :relatesToProperties ;
+               rdfs:domain owl:Thing ;
+               rdfs:range :Times ;
+               skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+               skos:prefLabel "has time"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToTopic
+:relatesToTopic rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :relatesToProperties ;
+                rdfs:domain owl:Thing ;
+                rdfs:range :TopicsCategories ;
+                skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship "@en ;
+                skos:prefLabel "has topic"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToVisualInfo
+:relatesToVisualInfo rdf:type owl:ObjectProperty ;
+                     rdfs:subPropertyOf :relatesToProperties ;
+                     rdfs:domain owl:Thing ;
+                     rdfs:range :VisualInfo ;
+                     skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                     skos:prefLabel "relates to visual information"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#relatesToWrittenInfo
+:relatesToWrittenInfo rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf :relatesToProperties ;
+                      rdfs:domain owl:Thing ;
+                      skos:definition "This predicate relates an external entity to the SuperType (ST) shown. It indicates there is a relationship to the ST of a verifiable nature, but which is undetermined as to strength or a full rdf:type relationship."@en ;
+                      skos:prefLabel "relates to written information"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#situants
+:situants rdf:type owl:ObjectProperty ;
+          rdfs:subPropertyOf :contextual ;
+          skos:altLabel "placements"@en ;
+          skos:definition "Attributes or characteristics that help situate, or place in a locational context, the subject (A)."@en ;
+          skos:prefLabel "situants"@en ;
+          skos:scopeNote "A Firstness"@en ,
+                         "Attributes of space are often a part of this property category. \"Thus, space does for different subjects of one predicate precisely what time does for different predicates of the same subject.\" (CP 1.501)"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#skosProperties
+:skosProperties rdf:type owl:ObjectProperty ;
+                skos:definition "A category of convenience for aggregating all of the SKOS properties."@en ;
+                skos:prefLabel "SKOS properties"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#typings
+:typings rdf:type owl:ObjectProperty ;
+         rdfs:subPropertyOf :copulative ;
+         skos:altLabel "identities"@en ,
+                       "is a"@en ;
+         skos:definition "This simple relation is for all of the is-a relations to types (B) for subject (A)."@en ;
+         skos:prefLabel "typings"@en ;
+         skos:scopeNote "A Firstness"@en ,
+                        "Open question: do 'circumstances' belong here as well?"@en .
+
+
+###  http://www.w3.org/2002/07/owl#topObjectProperty
+owl:topObjectProperty rdf:type owl:ObjectProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#hasTopConcept
+skos:hasTopConcept rdf:type owl:ObjectProperty ;
+                   rdfs:subPropertyOf :skosProperties .
+
+
+###  http://www.w3.org/2004/02/skos/core#inScheme
+skos:inScheme rdf:type owl:ObjectProperty ;
+              rdfs:subPropertyOf :skosProperties .
+
+
+###  http://www.w3.org/2004/02/skos/core#member
+skos:member rdf:type owl:ObjectProperty ;
+            rdfs:subPropertyOf :skosProperties .
+
+
+###  http://www.w3.org/2004/02/skos/core#memberList
+skos:memberList rdf:type owl:ObjectProperty ;
+                rdfs:subPropertyOf :skosProperties .
+
+
+###  http://www.w3.org/2004/02/skos/core#semanticRelation
+skos:semanticRelation rdf:type owl:ObjectProperty ;
+                      rdfs:subPropertyOf :skosProperties .
+
+
+#################################################################
+#    Data properties
+#################################################################
+
+###  http://kbpedia.org/ontologies/kko#actionsData
+:actionsData rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf :copulativeData ;
+             skos:altLabel "actions"@en ,
+                           "perceptions"@en ,
+                           "reactions"@en ;
+             skos:definition "Simple relations of energetics, perception or thought of subject (A) to some other object (B)."@en ;
+             skos:prefLabel "actions data properties"@en ;
+             skos:scopeNote "A Secondness"@en ,
+                            "This category could be further split by energetic (1o), perceptual (2o) and thinking (3o)."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#adjunctualData
+:adjunctualData rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf :attributesData ;
+                skos:altLabel "accidental"@en ,
+                              "happening"@en ;
+                skos:definition "These are events that may occur to a single entities or events (particulars) that help characterize it."@en ;
+                skos:prefLabel "adjunctual data properties"@en ;
+                skos:scopeNote "A Secondness"@en ,
+                               "Some of the concepts associated with this set of properties are birth, death, marriage, events, accidents, surprises, happenings, extrinsic, adjunctual."@en ,
+                               "Though Peirce used ‘accidental’ much (Eventuals), he applied it in most cases to ‘accidental actuals’; thus, ‘adjunct’ better captures potentiality."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#attributesData
+:attributesData rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf :predicateDataProperties ;
+                skos:altLabel "attribute"@en ,
+                              "characteristic"@en ,
+                              "characteristics"@en ,
+                              "inherences"@en ;
+                skos:definition "Attributes are the ways by which a subject (A) may be described, characterized, or situated. All relations are inward looking to the subject, A."@en ;
+                skos:prefLabel "attributes data properties"@en ;
+                skos:scopeNote "A Firstness"@en ,
+                               "Attributes are of the form of A:A. All inherential and referential characteristics of and for subject A are included in this category."@en ,
+                               "Can also call Attributes ‘internal relations’."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#circumstancesData
+:circumstancesData rdf:type owl:DatatypeProperty ;
+                   rdfs:subPropertyOf :mediativeData ;
+                   skos:altLabel "contextual data properties"@en ,
+                                 "situations"@en ,
+                                 "thoughts"@en ;
+                   skos:definition "Relations of subject (A) to external circumstances, situations or contexts."@en ;
+                   skos:prefLabel "circumstances data properties"@en ;
+                   skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#classificationsData
+:classificationsData rdf:type owl:DatatypeProperty ;
+                     rdfs:subPropertyOf :contextualData ;
+                     skos:altLabel "classification"@en ,
+                                   "classify"@en ;
+                     skos:definition "A characterization of subject (A) that involves evaluating subject (A) and providing a multi-factor typing, coding or value in relation to a given attribute or set of attributes."@en ;
+                     skos:prefLabel "classifications data properties"@en ;
+                     skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#comparisonsData
+:comparisonsData rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf :mediativeData ;
+                 skos:altLabel "compared to"@en ,
+                               "comparisons"@en ,
+                               "similar"@en ;
+                 skos:definition "Relations that compare, contrast or size up similarities or differences or overlaps between subject (A) and object (B)."@en ;
+                 skos:prefLabel "comparisons data properties"@en ;
+                 skos:scopeNote "A Firstness"@en ,
+                                "Directly from Peirce; \"of the nature of logical possibilities” (CP 2.234)"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#conjoinsData
+:conjoinsData rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf :copulativeData ;
+              skos:altLabel "conjoins"@en ;
+              skos:definition "Relations that involve the joining of a subject (A) to an object (B) via an intermediate object."@en ;
+              skos:prefLabel "conjoins data properties"@en ;
+              skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#contextualData
+:contextualData rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf :attributesData ;
+                skos:altLabel "context"@en ,
+                              "perspective"@en ;
+                skos:definition "These are circumstances or placements of single entities or events (particulars) that help characterize it."@en ;
+                skos:prefLabel "contextual data properties"@en ;
+                skos:scopeNote "A Thirdness"@en ,
+                               "Some of the concepts associated with this set of properties include space, time, continuity, contiguous, smooth, otherness, ratings, situational (w/ respect to A), sensible, contiguous, all placements thereto, derivative, classificatory, rankings."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#copulativeData
+:copulativeData rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf :externalRelationsData ;
+                skos:definition "These are relatiionships of combination, membership, quantity, action, or identification."@en ;
+                skos:prefLabel "copulative data properties"@en ;
+                skos:scopeNote "A Secondness"@en ,
+                               "Some of the concepts associated with this set of properties are accidental, real, place, time, situation, quantity, facets, aspects, conjunctive, lists, one-to-many, many-to-one, sum of, contextual, verbs."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#descendantsData
+:descendantsData rdf:type owl:DatatypeProperty ;
+                 rdfs:subPropertyOf :directData ;
+                 skos:altLabel "hypernym"@en ,
+                               "hyponym"@en ,
+                               "subtype"@en ,
+                               "supertype"@en ;
+                 skos:definition "A simple relationship where object (B) is a direct child or parent or subsumption (hyponym) or supersumption (hypernym) to subject (A)."@en ;
+                 skos:prefLabel "descendants data properties"@en ;
+                 skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#directData
+:directData rdf:type owl:DatatypeProperty ;
+            rdfs:subPropertyOf :externalRelationsData ;
+            skos:altLabel "simple relations data properties"@en ;
+            skos:definition "These properties are a direct relationship (no intermediaries) between two different objects (entities, events, or their types, considered as instances)."@en ;
+            skos:prefLabel "direct relations data properties"@en ;
+            skos:scopeNote "A Firstness"@en ,
+                           "Some of the concepts associated with this set of properties are is a, simple without parts, part of, members in types or classes, genealogical roles (parent, child, brother), identity, extensional."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#elementalsData
+:elementalsData rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf :intrinsicsData ;
+                skos:altLabel "components"@en ,
+                              "ingredients"@en ,
+                              "parts"@en ;
+                skos:definition "A contributing part of or integral input or aspect that adds to the understanding about the subject (A)."@en ;
+                skos:prefLabel "elementals data properties"@en ;
+                skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#equivalencesData
+:equivalencesData rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf :directData ;
+                  skos:altLabel "equal"@en ,
+                                "identical to"@en ,
+                                "same as"@en ;
+                  skos:definition "A simple relatiionship between a subject (A) and an object (B) that asserts equalness or sameness."@en ;
+                  skos:prefLabel "equivalences data properties"@en ;
+                  skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#eventualsData
+:eventualsData rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf :adjunctualData ;
+               skos:altLabel "accidentals"@en ,
+                             "dates"@en ,
+                             "events"@en ,
+                             "eventuals data properties"@en ,
+                             "happenings"@en ;
+               skos:definition "Chance, accidental or planned occurrences that directly involve subject (A)."@en ;
+               skos:prefLabel "eventuals data properties"@en ;
+               skos:scopeNote "A Secondness"@en ,
+                              "Attributes of time are often candidates for this property category. \"Thus, space does for different subjects of one predicate precisely what time does for different predicates of the same subject.\" (CP 1.501)"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#externalRelationsData
+:externalRelationsData rdf:type owl:DatatypeProperty ;
+                       rdfs:subPropertyOf :predicateDataProperties ;
+                       skos:definition "All external facing relations of a subject (A) to outside objects or data."@en ;
+                       skos:prefLabel "external relations data properties"@en ;
+                       skos:scopeNote "A Secondness"@en ,
+                                      "Direct relations + Copulative properties are intended to inclusively conform to what Peirce called \"simple relations\"."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#extrinsicsData
+:extrinsicsData rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf :adjunctualData ;
+                skos:altLabel "external events"@en ,
+                              "external factors"@en ;
+                skos:definition "External events or circumstances that directly involve subject (A) or help define the nature or reality of subject (A)."@en ;
+                skos:prefLabel "extrinsics data properties"@en ;
+                skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#formsData
+:formsData rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf :intrinsicsData ;
+           skos:altLabel "arrangements"@en ,
+                         "configurations"@en ,
+                         "shapes"@en ;
+           skos:definition "Forms or arrangements that are of the nature or perceivable of the subject (A)."@en ;
+           skos:prefLabel "forms data properties"@en ;
+           skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#intrinsicsData
+:intrinsicsData rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf :attributesData ;
+                skos:definition "Innate characteristics or essences of single entities or events (particulars)."@en ;
+                skos:prefLabel "intrinsics data properties"@en ;
+                skos:scopeNote "A Firstness"@en ,
+                               "Some of the concepts associated with this set of properties are oneness, qualities, feelings, inherent, negation, is, has, intensional, naturalness, internal, innateness."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#mediativeData
+:mediativeData rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf :externalRelationsData ;
+               skos:definition "These are relationships of relevance, meaning or explanation – namely, thirdness – about subjects and types."@en ;
+               skos:prefLabel "mediative data properties"@en ;
+               skos:scopeNote "A Thirdness"@en ,
+                              "Some of the concepts associated with this set of properties are concepts, generalities, similarity, genres, aspects, comparison, performance, thought, triadic, agreement/ difference, placement in space/time (contiguity), conditional, reasoning, classification."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#partsData
+:partsData rdf:type owl:DatatypeProperty ;
+           rdfs:subPropertyOf :directData ;
+           skos:altLabel "part"@en ,
+                         "parts of"@en ;
+           skos:definition "A simple relationship where the object (B) is a part of or component of subjext (A)."@en ;
+           skos:prefLabel "parts data properties"@en ;
+           skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#performancesData
+:performancesData rdf:type owl:DatatypeProperty ;
+                  rdfs:subPropertyOf :mediativeData ;
+                  skos:altLabel "performance"@en ,
+                                "performances"@en ;
+                  skos:definition "Relations of quantity or rank for how subject (A) performed in relation to object (B)."@en ;
+                  skos:prefLabel "performances data properties"@en ;
+                  skos:scopeNote "A Secondness"@en ,
+                                 "Directly from Peirce;  “of the nature of actual facts” (CP 2.234)"@en ,
+                                 "Other concepts associated with this set of properties are sequences; processes; combinations."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#predicateDataProperties
+:predicateDataProperties rdf:type owl:DatatypeProperty ;
+                         skos:definition "A category of convenience for aggregating all of the predicate data properties."@en ;
+                         skos:editorialNote "From Peirce “every fact is a relation”; all facts are assertions."@en ,
+                                            "The predicate data properties in KKO are organized into a three-level schema based on the Peircean universal categories of Firstness, Secondness and Thirdness, resulting in 27 predicate types (3 * 3 * 3)  in the hierarchy. Either data or object properties may relate to nearly all levels in this schema."@en ,
+                                            "The same organizatonal schema (3 * 3 * 3) for these data properties is duplicated for object properties, since sources do not uniformly (nor correctly!) determine their appropriate format. In the paralellism the object property categoreis have the most direct names; those for data properties are appended with the 'xxx data' term. Efforts to be comprehensive across external property mappings should best consult both property types."@en ;
+                         skos:prefLabel "predicate data properties"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#qualitiesData
+:qualitiesData rdf:type owl:DatatypeProperty ;
+               rdfs:subPropertyOf :intrinsicsData ;
+               skos:altLabel "inherent"@en ,
+                             "intrinsic"@en ,
+                             "quality"@en ;
+               skos:definition "An internal characteristic or aspect of an object; collectively these internal relations define intensionally what kind of thing to which the object belongs, though that relationship is not intrinsic."@en ;
+               skos:prefLabel "data properties"@en ;
+               skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#quantitiesData
+:quantitiesData rdf:type owl:DatatypeProperty ;
+                rdfs:subPropertyOf :adjunctualData ;
+                skos:altLabel "amount"@en ,
+                              "number of"@en ,
+                              "population"@en ,
+                              "quantifiable"@en ,
+                              "quantity"@en ;
+                skos:definition "A characteristic of a subject (A) that is expressed as a number quantity."@en ;
+                skos:prefLabel "quantities data properties"@en ;
+                skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#ratingsData
+:ratingsData rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf :contextualData ;
+             skos:altLabel "orderings"@en ,
+                           "rankings"@en ;
+             skos:definition "An assigned value or characterization that orders subject (A) in relation to other subjects for a given attribute."@en ;
+             skos:prefLabel "ratings data properties"@en ;
+             skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#situantsData
+:situantsData rdf:type owl:DatatypeProperty ;
+              rdfs:subPropertyOf :contextualData ;
+              skos:altLabel "placements"@en ,
+                            "situants data properties"@en ;
+              skos:definition "Attributes or characteristics that help situate, or place in a locational context, the subject (A)."@en ;
+              skos:prefLabel "situants data properties"@en ;
+              skos:scopeNote "A Firstness"@en ,
+                             "Attributes of space are often a part of this property category. \"Thus, space does for different subjects of one predicate precisely what time does for different predicates of the same subject.\" (CP 1.501)"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#typingsData
+:typingsData rdf:type owl:DatatypeProperty ;
+             rdfs:subPropertyOf :copulativeData ;
+             skos:altLabel "identities"@en ,
+                           "is a"@en ;
+             skos:definition "This simple relation is for all of the is-a relations to types (B) for subject (A)."@en ;
+             skos:prefLabel "typings data properties"@en ;
+             skos:scopeNote "A Firstness"@en .
+
+
+###  http://www.w3.org/2002/07/owl#topDataProperty
+owl:topDataProperty rdf:type owl:DatatypeProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://kbpedia.org/ontologies/kko#ActionTypes
+:ActionTypes rdf:type owl:Class ;
+             rdfs:subClassOf :CopulativeRelations ;
+             skos:altLabel "activity type"@en ,
+                           "activity types"@en ;
+             skos:definition """Acts or actions, organized by types, that result (mostly) from human effort, often conducted by organizations to assist other organizations or individuals (in which case they are known as services, such as medicine, law, printing, consulting or teaching) or individual or group efforts for leisure, fun, sports, games or personal interests (activities).
+
+Generic, broad grouping of actions that apply to generic objects are also included in this SuperType."""@en ;
+             skos:editorialNote "This is the tie-in point for the ActionTypes SuperType (ST); it connects to a relatively major typology with a comparatively large number of action or activity Types."@en ;
+             skos:prefLabel "action types"@en ;
+             skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#AreaRegion
+:AreaRegion rdf:type owl:Class ;
+            rdfs:subClassOf :Places ;
+            skos:altLabel "area"@en ,
+                          "areas"@en ,
+                          "region"@en ,
+                          "regions"@en ;
+            skos:definition "The AreaRegion SuperType includes all nameable or definable areas or regions that may be found within \"space\". Though the distinction is not sharp, this SuperType is meant to be distinct from specific points of interest (POIs) that may be mapped (often displayed as a thumbtack). Areas or regions are best displayed on a map as a polygon (area) or path (polyline)."@en ;
+            skos:editorialNote "This is the tie-in point for the AreaRegion SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+            skos:prefLabel "area or region"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#Areas
+:Areas rdf:type owl:Class ;
+       rdfs:subClassOf :Space ;
+       skos:altLabel "area"@en ,
+                     "region"@en ;
+       skos:definition "Any 2D or defined area that may change over time or scope."@en ;
+       skos:prefLabel "areas"@en ;
+       skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#AudioInfo
+:AudioInfo rdf:type owl:Class ;
+           rdfs:subClassOf :AVInfo ;
+           owl:disjointWith [ rdf:type owl:Class ;
+                              owl:unionOf ( :AreaRegion
+                                            :BiologicalProcesses
+                                            :Drugs
+                                            :EconomicSystems
+                                            :Facilities
+                                            :FoodDrink
+                                            :LocationPlace
+                                            :Society
+                                            :Times
+                                            :AtomsElements
+                                            :NaturalMatter
+                                            :OrganicChemistry
+                                            :Persons
+                                            :Prokaryotes
+                                            :ProtistsFungus
+                                            :Eukaryotes
+                                            :LivingThings
+                                            :NaturalSubstances
+                                            :OrganicMatter
+                                            :Organizations
+                                            :Places
+                                            :Plants
+                                            :SocialSystems
+                                            :Agents
+                                            :Animals
+                                            :Chemistry
+                                            :Diseases
+                                            :Geopolitical
+                                            :StructuredInfo
+                                          )
+                            ] ;
+           skos:definition "This SuperType is for any audio-only human work. Examples include live music performances, record albums, or radio shows or individual radio broadcasts"@en ;
+           skos:editorialNote "This is the tie-in point for the AudioInfo SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+           skos:prefLabel "audio information"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#BiologicalProcesses
+:BiologicalProcesses rdf:type owl:Class ;
+                     rdfs:subClassOf :OrganicChemistry ;
+                     skos:altLabel "biochemical pathways"@en ,
+                                   "biological process"@en ;
+                     skos:definition "The Biochemical Processes SuperType is for all sequences of reactions and chemical pathways associated with living things. Includes decompositional processes."@en ;
+                     skos:editorialNote "This is the tie-in point for the BiologicalProcesses SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+                     skos:prefLabel "biological processes"@en ;
+                     skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#Drugs
+:Drugs rdf:type owl:Class ;
+       rdfs:subClassOf :Artifacts ;
+       owl:disjointWith [ rdf:type owl:Class ;
+                          owl:unionOf ( :AreaRegion
+                                        :AudioInfo
+                                        :BiologicalProcesses
+                                        :EconomicSystems
+                                        :EventTypes
+                                        :Facilities
+                                        :LocationPlace
+                                        :SituationTypes
+                                        :Society
+                                        :Times
+                                        :VisualInfo
+                                        :AVInfo
+                                        :AtomsElements
+                                        :NaturalPhenomena
+                                        :Persons
+                                        :Prokaryotes
+                                        :KnowledgeDomains
+                                        :NaturalSubstances
+                                        :Organizations
+                                        :Places
+                                        :SocialSystems
+                                        :WrittenInfo
+                                        :Agents
+                                        :Animals
+                                        :Diseases
+                                        :Geopolitical
+                                        :StructuredInfo
+                                      )
+                        ] ;
+       skos:altLabel "drug"@en ,
+                     "pharmaceutical"@en ;
+       skos:definition "This SuperType is a drug, medication or addictive substance, or a toxin or a poison."@en ;
+       skos:editorialNote "This is the tie-in point for the Drugs SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+       skos:prefLabel "drugs"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#EconomicSystems
+:EconomicSystems rdf:type owl:Class ;
+                 rdfs:subClassOf :SocialSystems ;
+                 owl:disjointWith [ rdf:type owl:Class ;
+                                    owl:unionOf ( :AudioInfo
+                                                  :BiologicalProcesses
+                                                  :Drugs
+                                                  :FoodDrink
+                                                  :Times
+                                                  :AtomsElements
+                                                  :NaturalPhenomena
+                                                  :OrganicChemistry
+                                                  :Prokaryotes
+                                                  :ProtistsFungus
+                                                  :Eukaryotes
+                                                  :Plants
+                                                  :Animals
+                                                  :Diseases
+                                                  :Geopolitical
+                                                )
+                                  ] ;
+                 skos:altLabel "economic system"@en ,
+                               "economy"@en ,
+                               "finance"@en ,
+                               "finance and economy"@en ;
+                 skos:definition """An economic system is a system of production, resource allocation, and distribution of goods and services within a society or a given geographic area. It includes the combination of the various institutions, agencies, entities, decision-making processes, and patterns of consumption and financing that comprise the economic structure of a given community. As such, an economic system is a type of social system.
+
+This SuperType pertains to all things financial and with respect to the economy, including chartable company performance, stock index entities, money, local currencies, taxes, incomes, accounts and accounting, mortgages and property."""@en ;
+                 skos:editorialNote "This is the tie-in point for the EconomicSystems SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+                 skos:prefLabel "economic systems"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#EventTypes
+:EventTypes rdf:type owl:Class ;
+            rdfs:subClassOf :TimeTypes ;
+            owl:disjointWith [ rdf:type owl:Class ;
+                               owl:unionOf ( :AreaRegion
+                                             :Drugs
+                                             :Facilities
+                                             :LocationPlace
+                                             :Persons
+                                             :Prokaryotes
+                                             :ProtistsFungus
+                                             :Eukaryotes
+                                             :Places
+                                             :Plants
+                                             :Agents
+                                             :Animals
+                                             :Geopolitical
+                                           )
+                             ] ;
+            skos:altLabel "event"@en ,
+                          "event types"@en ;
+            skos:definition "These are nameable occasions, games, sports events, conferences, natural phenomena, natural disasters, wars, incidents, anniversaries, holidays, or notable moments or periods in time  Events have a finite duration, with a beginning and end. Individual events (such as wars, disasters, newsworthy occasions) may also have their own names."@en ;
+            skos:editorialNote "This is the tie-in point for the EventTypes SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+            skos:prefLabel "event types"@en ;
+            skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#Facilities
+:Facilities rdf:type owl:Class ;
+            rdfs:subClassOf :Artifacts ;
+            owl:disjointWith [ rdf:type owl:Class ;
+                               owl:unionOf ( :AudioInfo
+                                             :BiologicalProcesses
+                                             :Drugs
+                                             :EventTypes
+                                             :FoodDrink
+                                             :SituationTypes
+                                             :Society
+                                             :Times
+                                             :AtomsElements
+                                             :OrganicChemistry
+                                             :Persons
+                                             :Prokaryotes
+                                             :ProtistsFungus
+                                             :LivingThings
+                                             :Plants
+                                             :WrittenInfo
+                                             :Animals
+                                             :Diseases
+                                             :Geopolitical
+                                             :StructuredInfo
+                                           )
+                             ] ;
+            skos:altLabel "facility"@en ;
+            skos:definition """Facilities are physical places or buildings constructed by humans, such as schools, public institutions, markets, museums, amusement parks, worship places, stations, airports, ports, carstops, lines, railroads, roads, waterways, tunnels, bridges, parks, sport facilities, monuments. All can be geospatially located.
+
+Facilities also include animal pens and enclosures and general human \"activity\" areas (golf course, archeology sites, etc.). Iportantly Facilities include infrastructure systems such as roadways and physical networks.
+
+Facilities also include the component parts that go into making them (such as foundations, doors, windows, roofs, etc.) 
+
+Facilities can also include natural structures that have been converted or used for human activities, such as occupied caves or agricultural facilities.
+
+Finally, facilities also include workplaces. Workplaces are areas of human activities, ranging from single person workstations to large aggregations of people (but which are not formal political entities)"""@en ;
+            skos:editorialNote "This is the tie-in point for the Facilities SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+            skos:prefLabel "facilities"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#FoodDrink
+:FoodDrink rdf:type owl:Class ;
+           rdfs:subClassOf :Artifacts ;
+           owl:disjointWith [ rdf:type owl:Class ;
+                              owl:unionOf ( :AreaRegion
+                                            :AudioInfo
+                                            :BiologicalProcesses
+                                            :EconomicSystems
+                                            :Facilities
+                                            :LocationPlace
+                                            :SituationTypes
+                                            :Society
+                                            :Times
+                                            :VisualInfo
+                                            :AVInfo
+                                            :AtomsElements
+                                            :Information
+                                            :NaturalPhenomena
+                                            :Persons
+                                            :Organizations
+                                            :Places
+                                            :SocialSystems
+                                            :WrittenInfo
+                                            :Agents
+                                            :Diseases
+                                            :Geopolitical
+                                            :StructuredInfo
+                                          )
+                            ] ;
+           skos:definition "This SuperType is any edible substance grown, made or harvested by humans. The category also specifically includes the concept of cuisines "@en ;
+           skos:editorialNote "This is the tie-in point for the FoodDrink SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+           skos:prefLabel "food or drink"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#Generals
+:Generals rdf:type owl:Class ;
+          owl:equivalentClass :SuperTypes ;
+          skos:altLabel "class"@en ,
+                        "classes"@en ,
+                        "super type"@en ,
+                        "super types"@en ,
+                        "supertype"@en ,
+                        "universals"@en ;
+          skos:definition """Generals are classes, types or kinds (natural kinds or classes) whose members are instances that share intensional or extensional aspects with other instance members.
+
+In Peircean terms, 'generals' are collections of individuals or predicates that have the same properties or characteristics (are intensional). Generals may be organized into a hierarchy of sub-types, with children inheriting the properties or characteristics of the parent(s). It is thus possible to infer across sub-type lineages. Generals are also sometimes referred to as either types or kinds."""@en ;
+          skos:editorialNote "Generals include all of the types in the KBpedia Knowledge Ontology (KKO). The types themselves are organized into typologies, segregated by the SuperTypes noted under this branch. Most of the typologies (especially those marked as 'major' ones) are disjoint (non-overlapping) with one another. This disjointedness is a key structural aspect in being able to reason and slice-and-dice the entire KBpedia knowledge space."@en ,
+                             "Note there is a degree of structural similarity between the main Particulars branch in KKO and the main Generals branch. This structural similarity is because Particulars deal with the nature and classification of individuals or instances, while Generals deal with the quite similar classification of classes or types. Fundamentally, all instances are characterized according to the Particulars branch; all types are characterized according to the Generals branch."@en ;
+          skos:prefLabel "generals"@en ;
+          skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#LocationPlace
+:LocationPlace rdf:type owl:Class ;
+               rdfs:subClassOf :Places ;
+               skos:altLabel "location"@en ,
+                             "locations"@en ,
+                             "place"@en ,
+                             "places"@en ;
+               skos:definition "The LocationPlace SuperType is for bounded and defined points in \"space\", which can be positiioned via some form of coordinate system and can often be shown as points of interest (POIs) on a map. This SuperType is distinguished by areas or locations, which are often best displayed as polygons or polylines on a map."@en ;
+               skos:editorialNote "This is the tie-in point for the LocationPlace SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+               skos:prefLabel "location or place"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#Points
+:Points rdf:type owl:Class ;
+        rdfs:subClassOf :Space ;
+        skos:altLabel "POI"@en ,
+                      "coordinate"@en ,
+                      "point"@en ;
+        skos:definition "A point is a primitive notion upon which geometry is built. Being a primitive notion means that a point cannot be defined in terms of previously defined objects. A point is defined only by some properties, called axioms, that it must satisfy.  In two-dimensional Euclidean space, a point is represented by an ordered pair (x, y) of numbers, where the first number conventionally represents the horizontal and is often denoted by x, and the second number conventionally represents the vertical and is often denoted by y."@en ;
+        skos:prefLabel "points"@en ;
+        skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#Products
+:Products rdf:type owl:Class ;
+          rdfs:subClassOf :Artifacts ;
+          owl:disjointWith [ rdf:type owl:Class ;
+                             owl:unionOf ( :BiologicalProcesses
+                                           :Times
+                                           :Persons
+                                           :Geopolitical
+                                         )
+                           ] ;
+          skos:altLabel "good"@en ,
+                        "product"@en ;
+          skos:definition "This is SuperType includes any instance offered for sale or performed as a commercial service. A Product is often a physical object made by humans that is not a conceptual work or a facility, such as vehicles, cars, trains, aircraft, spaceships, ships, foods, beverages, clothes, drugs, weapons."@en ;
+          skos:editorialNote "This is the tie-in point for the Products SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+          skos:prefLabel "products"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#RefConcept
+:RefConcept rdf:type owl:Class ;
+            rdfs:subClassOf skos:Concept ,
+                            [ rdf:type owl:Restriction ;
+                              owl:onProperty :isRelatedTo ;
+                              owl:allValuesFrom owl:Thing
+                            ] ;
+            skos:altLabel "RC"@en ,
+                          "ref concept" ,
+                          "refconcept" ;
+            skos:definition """Reference Concepts are a distinct subset of the more broadly understood concept such as used in the SKOS RDFS controlled vocabulary or formal concept analysis or the very general or abstract concepts common to some upper ontologies.
+
+Reference Concepts are selected for their use as concrete, subject-related or commonly used notions for describing tangible ideas and referents in human experience and language. Reference Concepts are classes, the members of which are nameable instances or named entities, which by definition are held as distinct from these concepts. The KKO ontology is a coherently organized structure (or reference \"backbone\") of these Reference Concepts. """@en ;
+            skos:editorialNote """It is not unusual to want to treat things either as a class or an instance in an ontology, depending on context. Among other aspects, this is known as metamodeling and it can be accomplished in a number of ways. One of the reasons KKO is modeled using the Web Ontology Language (OWL2) is its ability to provide a neat trick for doing this called “punning“.
+
+Let's take the example of 'trucks' for why we may want to pun.  We may have a category called 'trucks', which may further be split into truck types, brands of trucks, type of engine, and so forth. Yet, when talking about the idea of 'truck', we may want to characterize that a truck is designed primarily for the transport of cargo (as opposed to automobiles for people transport), or that trucks may have different drivers license requirements or different license fees than autos, or certain sizes or weights. These descriptive properties refer to trucks as an instance.
+
+These mixed cases combine both the organization of concepts in relation to one another and with respect to their set members, and with the description and characterization of these concepts as things unto themselves. This is a natural and common way to express most any domain of interest. Where we have different contexts for describing or discussing 'trucks', punning gives us the abiity to model both contexts.
+
+The punning technique works because the IRI for the object ends up being treated as both a concept (class) and an instance (individual). Thus, while the object shares the same IRI, depending on its context, it is evaluated by an OWL reasoner as a different thing (class or individual). The OWL API achieves this by actually writing out the object in both its class view and individual view.
+
+Because of the KKO's role (among others) as a reference structure for mapping and interoperating external data, it is helpful to think of all of the Reference Concepts (RCs) in the system as classes. This can apply to things which are seemingly individuals, such as specific persons or events, because they may be referred to in multiple ways and in multiple contexts. On the other hand, we want to describe and provide characteristics for these RCs, a view best accomplished when the RC is treated as an instance. Thus, all RCs in the KKO are punned.
+
+To learn more about punning and metamodeling, see further http://www.mkbergman.com/913/metamodeling-in-domain-ontologies/."""@en ;
+            skos:prefLabel "reference concept"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#SituationTypes
+:SituationTypes rdf:type owl:Class ;
+                rdfs:subClassOf :MediativeRelations ;
+                owl:disjointWith [ rdf:type owl:Class ;
+                                   owl:unionOf ( :AreaRegion
+                                                 :Drugs
+                                                 :Facilities
+                                                 :FoodDrink
+                                                 :Times
+                                                 :AtomsElements
+                                                 :Persons
+                                                 :Prokaryotes
+                                                 :ProtistsFungus
+                                                 :WrittenInfo
+                                                 :Geopolitical
+                                               )
+                                 ] ;
+                skos:altLabel "situation"@en ,
+                              "situation types"@en ;
+                skos:definition "The Situations SuperType is a state or context consisting of one or more objects having certain properties or bearing certain relations to each other. Situations capture the conditions or circumstances for something. Situations can often be a complex combination of contextual conditions."@en ;
+                skos:editorialNote "This is the tie-in point for the SituationTypes SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+                skos:prefLabel "situation types"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#Situations
+:Situations rdf:type owl:Class ;
+            rdfs:subClassOf :States ;
+            skos:altLabel "circumstance"@en ,
+                          "situation"@en ;
+            skos:definition "A situation is a particular set of circumstances or state of affairs or that set the context for how particular actions or events may unfold. Situations influence outcomes and potential outcomes for given occurrences."@en ;
+            skos:prefLabel "situations"@en ;
+            skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#Society
+:Society rdf:type owl:Class ;
+         rdfs:subClassOf :SocialSystems ;
+         owl:disjointWith [ rdf:type owl:Class ;
+                            owl:unionOf ( :AreaRegion
+                                          :AudioInfo
+                                          :BiologicalProcesses
+                                          :Drugs
+                                          :Facilities
+                                          :FoodDrink
+                                          :LocationPlace
+                                          :Times
+                                          :VisualInfo
+                                          :AVInfo
+                                          :AtomsElements
+                                          :NaturalMatter
+                                          :NaturalPhenomena
+                                          :OrganicChemistry
+                                          :Persons
+                                          :Prokaryotes
+                                          :ProtistsFungus
+                                          :Shapes
+                                          :Eukaryotes
+                                          :LivingThings
+                                          :NaturalSubstances
+                                          :OrganicMatter
+                                          :Places
+                                          :Plants
+                                          :TopicsCategories
+                                          :Animals
+                                          :Chemistry
+                                          :Diseases
+                                          :Forms
+                                          :Geopolitical
+                                        )
+                          ] ;
+         skos:definition "This SuperType category includes concepts related to political systems, laws, rules or cultural mores governing societal or community behavior, or doctrinal, faith or religious bases or entities (such as gods, angels, totems) governing spiritual human matters. Culture, Issues, beliefs and various activisms (most -isms) are included."@en ;
+         skos:editorialNote "This is the tie-in point for the Society SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+         skos:prefLabel "society"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#Space
+:Space rdf:type owl:Class ;
+       rdfs:subClassOf :Continuants ;
+       skos:definition "Space entities relate to the idea of \"space\" and locations and positions within that \"space\". Specific sub-groupings under the category include the definition and specification of 1D, 2D and 3D shapes; places, regions and locations within space; and forms that objects may take within \"space\"."@en ;
+       skos:editorialNote "Space is different subjects of one predicate (from CP 1.501)."@en ;
+       skos:prefLabel "space"@en ;
+       skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#SpaceRegions
+:SpaceRegions rdf:type owl:Class ;
+              rdfs:subClassOf :Space ;
+              skos:altLabel "region"@en ,
+                            "space"@en ;
+              skos:definition "Any 3D region that may change over time or scope."@en ;
+              skos:prefLabel "space regions"@en ;
+              skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#Time
+:Time rdf:type owl:Class ;
+      rdfs:subClassOf :Continuants ;
+      skos:definition "A time particular is an entity that represents the indefinite continued progression of existence and events that occur in apparently irreversible succession from the past through the present to the future."@en ;
+      skos:editorialNote "Time is different predicates of one subject (from CP 1.501)."@en ;
+      skos:prefLabel "time"@en ;
+      skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#Times
+:Times rdf:type owl:Class ;
+       rdfs:subClassOf :TimeTypes ;
+       skos:definition "This SuperType is for specific time or date or period (such as eras, or days, weeks, months type intervals) references in various formats "@en ;
+       skos:editorialNote "This is the tie-in point for the Times SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+       skos:prefLabel "times"@en ;
+       skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#VisualInfo
+:VisualInfo rdf:type owl:Class ;
+            rdfs:subClassOf :AVInfo ;
+            owl:disjointWith [ rdf:type owl:Class ;
+                               owl:unionOf ( :AreaRegion
+                                             :BiologicalProcesses
+                                             :Drugs
+                                             :FoodDrink
+                                             :LocationPlace
+                                             :Society
+                                             :Times
+                                             :AtomsElements
+                                             :OrganicChemistry
+                                             :Persons
+                                             :Prokaryotes
+                                             :ProtistsFungus
+                                             :Eukaryotes
+                                             :LivingThings
+                                             :NaturalSubstances
+                                             :Organizations
+                                             :Plants
+                                             :Agents
+                                             :Animals
+                                             :Diseases
+                                             :Geopolitical
+                                           )
+                             ] ;
+            skos:definition "The Visual Info SuperType is for any still image or picture or streaming video human work, with or without audio. Examples include graphics, pictures, movies, TV shows, individual shows from a TV show, etc."@en ;
+            skos:editorialNote "This is the tie-in point for the VisualInfo SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+            skos:prefLabel "visual information"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-AVInfo
+:AVInfo rdf:type owl:Class ;
+        rdfs:subClassOf :Information ;
+        owl:disjointWith [ rdf:type owl:Class ;
+                           owl:unionOf ( :AreaRegion
+                                         :BiologicalProcesses
+                                         :Drugs
+                                         :FoodDrink
+                                         :LocationPlace
+                                         :Society
+                                         :Times
+                                         :AtomsElements
+                                         :OrganicChemistry
+                                         :Persons
+                                         :Prokaryotes
+                                         :ProtistsFungus
+                                         :Eukaryotes
+                                         :LivingThings
+                                         :NaturalSubstances
+                                         :Organizations
+                                         :Plants
+                                         :Agents
+                                         :Animals
+                                         :Diseases
+                                         :Geopolitical
+                                       )
+                         ] ;
+        skos:altLabel "The AV Info SuperType is for information that contains BOTH audio and visual information, such as talking movies, TV commercials, etc."@en ;
+        skos:prefLabel "AV info"@en ;
+        skos:scopeNote "A Firstness"@en ,
+                       "This is the tie-in point for the AVInfo SuperType (ST); it connects to a relatively minor typology."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Absolute
+:Absolute rdf:type owl:Class ;
+          rdfs:subClassOf :Pluralness ;
+          skos:altLabel "completeness"@en ,
+                        "ipso facto"@en ,
+                        "perfection"@en ;
+          skos:definition "An absolute is something that is existing, able to be thought of, or able to be viewed without relation to other things. An absolute is something that is complete in and of itself."@en ;
+          skos:editorialNote """Could possibly expand this branch with the following structure:
+
+   Inclusive [1ns]	
+        Equivalence [1ns]
+        Member [2ns]
+        Set [3ns]
+   Exclusive [2ns]	
+   Difference [3ns]"""@en ;
+          skos:prefLabel "absolute"@en ;
+          skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Accidental
+:Accidental rdf:type owl:Class ;
+            rdfs:subClassOf :Suchness ;
+            skos:altLabel "occurrence"@en ;
+            skos:definition "Accidentals are those occurrences that bring things into actuality. As used here, accidental is an \"indecomposable\" that represents the potentiality of such an occurrence. Per CS 1.430, an accidental \"is something that can only happen by having a subject with an independent mode of being not dependent upon this nor upon any determination whatsoever. It is something which happens.\""@en ;
+            skos:editorialNote "See CP 2.377, but also a common qualifier used by CSP."@en ;
+            skos:prefLabel "accidental"@en ;
+            skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-AtomsElements
+:AtomsElements rdf:type owl:Class ;
+               rdfs:subClassOf :NaturalMatter ;
+               skos:altLabel "atoms"@en ,
+                             "chemical element"@en ;
+               skos:definition "The Atoms and Elements SuperType contains all known chemical elements and the constituents of atoms."@en ;
+               skos:editorialNote "This is the tie-in point for the AtomElements SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+               skos:prefLabel "atoms or elements"@en ;
+               skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-AttributeTypes
+:AttributeTypes rdf:type owl:Class ;
+                rdfs:subClassOf :Predications ;
+                skos:altLabel "attribute"@en ,
+                              "attribute types"@en ;
+                skos:definition """Attributes are the intensional characteristics of an object, event, entity, type (when viewed as an instance), or concept. The relationship is between the individual instance (or Particular) and its own attributes and characteristics, in the form of A:A. Attributes may be intrinsic characteristics or essences of single particulars, such as colors, shapes, sizes, or other descriptive characteristics. Attributes may be adjunctual or accidental happenings to the particular, such as birth or death. Or, attributes may be contextual in terms of placing the particular within time or space or in relation to external circumstances.
+
+These attributes have been categorized according to these distinctions and grouped and organized into types."""@en ;
+                skos:editorialNote "This is the tie-in point for the AttributeTypes SuperType (ST). By design and convention, AttributeTypes are NOT EntityTypes. AttributeTypes connects to a relatively major typology with a comparatively large number of Attributes."@en ;
+                skos:prefLabel "attribute types"@en ;
+                skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Attributives
+:Attributives rdf:type owl:Class ;
+              rdfs:subClassOf :DyadicMonads ;
+              skos:altLabel "attributes"@en ,
+                            "attributive"@en ;
+              skos:definition """Attributives are dyadic monads that capture the attributes or characteristics of subjects. Attributives provide the characteristics for self-identity ('Oneness'), characteristics and individuals that are external ('Otherness'), and those essences that make things what they are ('Inherence'). 
+
+As \"indecomposables\", attributives are the potential or possibility of such a dyad, rather than being the actual dyad."""@en ;
+              skos:prefLabel "attributives"@en ;
+              skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Chance
+:Chance rdf:type owl:Class ;
+        rdfs:subClassOf :Thisness ;
+        skos:altLabel "random"@en ;
+        skos:definition "A chance is a random occurrence with an indeterminate outcome. As an \"indecomposable\", this monad is merely a potential or possibility, and not an actual occurrence."@en ;
+        skos:prefLabel "chance"@en ;
+        skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-CollectiveStuff
+:CollectiveStuff rdf:type owl:Class ;
+                 rdfs:subClassOf :ComplexEntities ;
+                 skos:altLabel "collective entities"@en ,
+                               "collective entity"@en ,
+                               "mob"@en ;
+                 skos:definition "A grouping of similar stuff, which may or may not have its own identity, such as a \"lump\" or \"mob\" or \"cloud\", but also including \"buckets of water\" and \"lumps of clay\", and which are not a type or class of like entities"@en ;
+                 skos:prefLabel "collective stuff"@en ;
+                 skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Concepts
+:Concepts rdf:type owl:Class ;
+          rdfs:subClassOf :ConceptualSystems ;
+          skos:altLabel "concept"@en ;
+          skos:definition """Concepts are ideas and mediated combinations of ideas that reflect more abstract or generalized thoughts than the typing or natural classing of objects, the focus of most other supertypes. 
+
+Concepts are non-disjoint with all other supertypes."""@en ;
+          skos:editorialNote """As defined in KKO, concepts are NOT entities, but may be entity types. Concepts are the most abstract treatment of particulars and types, and are organized not by logically determinable semiosis, but by \"worldviews\" that provide a coherent, but not necessarily decomposable, organization of ideas.
+
+Concepts are organized into schema, which have a kind of hierarchical or taxonomic backbone of sorts, but are ultimately graphs. (Not sure here, but the typologies used for organizing entities are strictly taxonomic, I think.)
+
+Concept structures are most often what is seen in current ontologies, both those of the upper and domain variety.
+
+How we go about constructing the concept schema, let alone whether there will only be a single one or perhaps 2-3, remains to be determined. The basic ideas at present for the first schema are all based on \"bridging from\" or leveraging an existing schema. Possible source schema include:
+
+1) the upper structure of OpenCyc, absent many abstract concepts, entities and entity types
+2) an existing organizational structure from Wikipedia. Individual candidates include:
+-- https://en.wikipedia.org/wiki/Category:Main_topic_classifications
+-- https://en.wikipedia.org/wiki/Category:Fundamental_categories
+3) another existing upper ontology, though all I have inspected seemed flawed (as does now OpenCyc to me)
+4) an existing KOS system in widespread use, such as UDC, or LCSH (Library of Congress) (see https://en.wikipedia.org/wiki/Library_of_Congress_Classification)
+5) some other internal means based on residual RCs with some unknown method.
+
+This general topic should also address the questions of Rules, Domains, Schema, and Worldviews."""@en ,
+                             "This is the tie-in point for the Concepts SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+          skos:prefLabel "concepts"@en ;
+          skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-ConceptualSystems
+:ConceptualSystems rdf:type owl:Class ;
+                   rdfs:subClassOf :Systems ;
+                   skos:altLabel "conceptual system"@en ,
+                                 "mental process"@en ,
+                                 "mental processes"@en ,
+                                 "thinking"@en ;
+                   skos:definition """A conceptual system is a system that is composed of non-physical objects, i.e. ideas or concepts. In this context a system is taken to mean \"an interrelated, interworking set of objects\". Such systems may be related to any topic from formal science to individual imagination. Conceptual systems may be found within the human mind, as works of art and fiction, and within the academic world.
+
+The Conceptual Systems SuperType is for human and cognitive constructs not otherwise related to natural classes. Concepts, topics and categories and category systems are specifically included in this SuperType.
+
+All conceptual systems and processes are inherently non-disjoint."""@en ;
+                   skos:prefLabel "conceptual systems"@en ;
+                   skos:scopeNote "A Firstness"@en ,
+                                  "This is the tie-in point for the ConceptualSystems SuperType (ST); it connects to a relatively minor typology."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Concurrents
+:Concurrents rdf:type owl:Class ;
+             rdfs:subClassOf :Relatives ;
+             skos:altLabel "concurrent"@en ,
+                           "self-relative"@en ;
+             skos:definition """A concurrent is a simple relative whose elements are of the form A:A. The character signified by a concurrent is an absolute character. Concurrents express a mere agreement among objects. All concurrents are copulative and continuous.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+             skos:editorialNote "See CP 3.136; CP 3.226."@en ;
+             skos:prefLabel "concurrents"@en ;
+             skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Constituents
+:Constituents rdf:type owl:Class ;
+              rdfs:subClassOf :SuperTypes ;
+              skos:altLabel "constituent"@en ,
+                            "constituent types"@en ;
+              skos:definition "This grouping of SuperTypes represents building blocks, or components, commonly used by other SuperTypes. The basic building block areas are Space, Time and fundamental Natural Phenomena or processes. Because of their role as constituents in orther SuperTypes, there are few disjoint assertions within this grouping."@en ;
+              skos:editorialNote "This is the tie-in point for the Constituents SuperType (ST); it connects to a relatively minor typology."@en ;
+              skos:prefLabel "constituents"@en ;
+              skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Denotative
+:Denotative rdf:type owl:Class ;
+            rdfs:subClassOf :Associative ;
+            skos:altLabel "denominative"@en ,
+                          "designation"@en ,
+                          "designative"@en ,
+                          "proper name"@en ;
+            skos:definition """A denotative is the purest means to draw attention to something, such as a proper name or definitive symbol.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+            skos:prefLabel "denotative"@en ;
+            skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Denotatives
+:Denotatives rdf:type owl:Class ;
+             rdfs:subClassOf :RepresentationTypes ;
+             skos:altLabel "denotative"@en ,
+                           "denotive"@en ,
+                           "denotives"@en ,
+                           "labels"@en ,
+                           "names"@en ;
+             skos:definition "Icons or symbols that name or describe the subject."@en ;
+             skos:editorialNote "Concepts in this type include names, labels, images, descriptions, definitions, denotations, icons, designations, proper nouns."@en ;
+             skos:prefLabel "denotatives"@en ;
+             skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-DirectRelations
+:DirectRelations rdf:type owl:Class ;
+                 rdfs:subClassOf :RelationTypes ;
+                 skos:altLabel "direct relation"@en ,
+                               "identity"@en ,
+                               "simple relations"@en ;
+                 skos:definition "A direct relationship (no intermediaries) between two different objects (entities, events, or their types, considered as instances)."@en ;
+                 skos:editorialNote "Concepts in this type include is a, simple without parts, part of, members in types or classes, genealogical roles (parent, child, brother), identity, extensional."@en ,
+                                    "This is the tie-in point for the DirectRelationTypes SuperType (ST). By design and convention, DirectRelationTypes are NOT EntityTypes. DirectRelationTypes connects to a relatively major typology with a comparatively large number of direct relations."@en ;
+                 skos:prefLabel "direct relations"@en ;
+                 skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Exertion
+:Exertion rdf:type owl:Class ;
+          rdfs:subClassOf :Action ;
+          skos:altLabel "effort"@en ,
+                        "work"@en ;
+          skos:definition "Exertion is the application of force, including thought."@en ;
+          skos:prefLabel "exertion"@en ;
+          skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-FirstMonads
+:FirstMonads rdf:type owl:Class ;
+             rdfs:subClassOf :Monads ;
+             skos:altLabel "ontic"@en ,
+                           "qualia"@en ;
+             skos:definition """First monads are \"indecomposable\" elements that capture the quality (suchness), haecceity (thisness) or pluralness of things. Like all monads, they are possibles or potentials, and not actually realized in any way. They are the possible ways that particulars and generals might be understood in and of themselves, in isolation without respect to any other or contrast.
+
+Like its alternate label, first monads are similar to ontic (from the Greek ὄν, genitive ὄντος: \"of that which is\"), relating to the physical, real, or factual existence. Ontic describes what is there, as opposed to the nature or properties of that being."""@en ;
+             skos:editorialNote """Category name could also be 'Ontic'; see https://en.wikipedia.org/wiki/Ontic.
+
+Could also be called 'Qualia'; see https://en.wikipedia.org/wiki/Qualia. See also http://cogprints.org/254/1/quinqual.htm for whether Qualia are a descriptor we want to use"""@en ,
+                                "From CP 1.303: \"The pure idea of a monad is not that of an object. For an object is over against me. But it is much nearer an object than it is to a conception of self, which is still more complex. There must be some determination, or suchness, otherwise we shall think nothing at all. But it must not be an abstract suchness, for that has reference to a special suchness. It must be a special suchness with some degree of determination, not, however, thought as more or less. There is to be no comparison. So that it is a suchness Imagine me to make and in a slumberous condition to have a vague, unobjectified, still less unsubjectified, sense of redness, or of salt taste, or of an ache, or of grief or joy, or of a prolonged musical note. That would be, as nearly as possible, a purely monadic state of feeling. Now in order to convert that psychological or logical conception into a metaphysical one, we must think of a metaphysical monad as a pure nature, or quality, in itself without parts or features, and without embodiment. Such is a pure monad. The meanings of names of \"secondary\" qualities are as good approximations to examples of monads as can be given.\""@en ;
+             skos:prefLabel "first monads"@en ;
+             skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Icon
+:Icon rdf:type owl:Class ;
+      rdfs:subClassOf :Representation ;
+      skos:altLabel "icons"@en ,
+                    "replica"@en ;
+      skos:definition """An Icon is a sign which refers to the Object that it denotes merely by virtue of characters of its own, and which it possesses, just the same, whether any such Object actually exists or not. (from CP 2.247)
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+      skos:prefLabel "icon"@en ;
+      skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Iconic
+:Iconic rdf:type owl:Class ;
+        rdfs:subClassOf :Indicatives ;
+        skos:altLabel "likeness"@en ;
+        skos:definition """Iconic monads are where the representation of something has an analogous relationship to that thing. They are of the form of an image or diagram or perceptual analog.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+        skos:prefLabel "iconic"@en ;
+        skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Identity
+:Identity rdf:type owl:Class ;
+          rdfs:subClassOf :Oneness ;
+          skos:definition """Identity is the relation each thing bears just to itself, or sameness. Identity is a relation that x and y stand in if, and only if, they are one and the same thing, or identical to each other (i.e. if, and only if x = y). As an \"indecomposable\", identity is the potential or possibility of such a dyadic relationship, rather than the dyad itself.
+
+Nature is the essential properties and causes of things to be what they are. Nature defines what the essence, or hypokeimenon, is of the given thing."""@en ;
+          skos:prefLabel "identity"@en ;
+          skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Information
+:Information rdf:type owl:Class ;
+             rdfs:subClassOf :Symbolic ;
+             owl:disjointWith [ rdf:type owl:Class ;
+                                owl:unionOf ( :BiologicalProcesses
+                                              :FoodDrink
+                                              :Times
+                                              :AtomsElements
+                                              :Persons
+                                              :Prokaryotes
+                                              :ProtistsFungus
+                                              :NaturalSubstances
+                                              :Organizations
+                                              :Plants
+                                              :Agents
+                                              :Diseases
+                                              :Geopolitical
+                                            )
+                              ] ;
+             skos:definition "The Information SuperType is a grouping of SuperTypes dealing with any aspect of human or computer information, including written, audio, visual or structural forms. All instances in this SuperType are conceptual works."@en ;
+             skos:editorialNote "This is the tie-in point for the Information SuperType (ST); it connects to a relatively minor typology."@en ;
+             skos:prefLabel "information"@en ;
+             skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-InquiryMethods
+:InquiryMethods rdf:type owl:Class ;
+                rdfs:subClassOf :Methodeutic ;
+                skos:altLabel "inquiry"@en ,
+                              "inquiry methods"@en ,
+                              "knowledge discovery"@en ;
+                skos:definition "These are the methods and techniques for testing facts and assumptions, organizing inquiry and research, and all other methodologies associated with the quest to gain new knowledge. The methods of inquiry and the information base to which they are applied differ by knowledge domain."@en ;
+                skos:editorialNote "This is the tie-in point for the InquiryMethods SuperType (ST); it connects to a relatively minor typology."@en ;
+                skos:prefLabel "methods of inquiry"@en ;
+                skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Instants
+:Instants rdf:type owl:Class ;
+          rdfs:subClassOf :Time ;
+          skos:altLabel "moments"@en ;
+          skos:definition "An instant is an infinitesimal moment in time, a moment whose passage is instantaneous."@en ;
+          skos:prefLabel "instants"@en ;
+          skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-IntrinsicAttributes
+:IntrinsicAttributes rdf:type owl:Class ;
+                     rdfs:subClassOf :AttributeTypes ;
+                     skos:altLabel "inherent"@en ,
+                                   "innate"@en ,
+                                   "intensional"@en ,
+                                   "intrinsic"@en ,
+                                   "intrinsic attribute"@en ,
+                                   "qualities"@en ;
+                     skos:definition "Innate characteristics or essences of single entities or events (particulars)."@en ;
+                     skos:editorialNote "Concepts in this type include oneness, qualities, feelings, inherent, negation, is, has, intensional, naturalness, internal, innateness."@en ,
+                                        "This is the tie-in point for the IntrinsicAttributeTypes SuperType (ST). By design and convention, IntrinsicAttributeTypes are NOT EntityTypes. IntrinsicAttributeTypes connects to a relatively major typology with a comparatively large number of intrinsic attributes."@en ;
+                     skos:prefLabel "intrinsic attributes"@en ;
+                     skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Matter
+:Matter rdf:type owl:Class ;
+        rdfs:subClassOf :Real ;
+        skos:altLabel "ordinary matter"@en ,
+                      "substance"@en ;
+        skos:definition """Matter includes ordinary matter composed of atoms, and in the 20th centry also has come to be understood as including other energy phenomena such as light or sound. Most matter is understood to have mass even when at rest, but this is ill-defined because an object's mass can arise from its (possibly massless) constituents' motion and interaction energies. Matter is also used loosely as a general term for the substances that make up all observable physical or real objects.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+        skos:prefLabel "matter"@en ;
+        skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Members
+:Members rdf:type owl:Class ;
+         rdfs:subClassOf :PartOfEntities ;
+         skos:altLabel "individual"@en ,
+                       "instance"@en ,
+                       "member"@en ;
+         skos:definition "A member is any one of the distinct objects that make up that set. Members are normally understood as the instances or individuals that comprise a class, kind or type."@en ;
+         skos:prefLabel "members"@en ;
+         skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-MonadicDyads
+:MonadicDyads rdf:type owl:Class ;
+              rdfs:subClassOf :Particulars ;
+              skos:altLabel "existence" ,
+                            "monadic dyad"@en ;
+              skos:definition """A monadic dyad has at least one monad as part of the pair in a dyad. It can be formed from monads alone (applicable to all under the Monads branch), or an inherential dyad of a subject and a monad, because it is an intrinsic quality of an object. A monadic dyad is the realization of these dyads, making real the possibility by conceptualizing or discussing them.
+
+A monadic dyad is a realized thing, but it is not clear if it is an individual or instance. If it could be so grasped, it would be an entity."""@en ;
+              skos:editorialNote "From CP 1.532: \"We may say with some approach to accuracy that the general Firstness of all true Secondness is existence, though this term more particularly applies to Secondness in so far as it is an element of the reacting first and second.\"" ;
+              skos:prefLabel "monadic dyads"@en ;
+              skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Monads
+:Monads rdf:type owl:Class ;
+        rdfs:subClassOf owl:Thing ;
+        skos:altLabel "element"@en ,
+                      "elements"@en ,
+                      "indecomposable"@en ,
+                      "indecomposables"@en ,
+                      "monad"@en ,
+                      "primitive"@en ,
+                      "primitives"@en ;
+        skos:definition "Monads are what CSP called \"indecomposables\", that is fundamental concepts and ideas that are integral to themselves and can not be \"decomposed\" into smaller units or concepts. The purest form (a First) of monads is what CSP called Quality or Feeling. it is the unrealized possiblity or potential of a sensation. (If realized, it becomes Secondness.) CSP maintained (proved) that all complex structures and concepts can be \"decomposed\" to no more than two (Secondenss, or Relations or Facts) or three (Thirdness, or Mediation or Thought) of these monads. The concept of these monads together and in themselves constitutes a monad in that the idea or concept of them stands on its own, and can not be \"decomposed\" to smaller units."@en ;
+        skos:editorialNote "CSP considered the term 'elements' but rejected it as not sufficiently precise. 'Primitives' are also a possible term, but is not used because CSP reserved that term for some kinds of relations."@en ,
+                           """Concepts that are Firstness and at the appropriate level of generality, but NOT yet included in this Monads branch are:
+
+    Beauty
+    Ethics
+    State
+    Truth"""@en ,
+                           "From CP 1.328: \"The being of a monadic quality is a mere potentiality, without existence. Existence is purely dyadic.\""@en ,
+                           """We can have first, second, and third monads because the idea of the things can be seen as a possibility in itself. As CSP states in CP 1.450: \"The first of these is that any unit (or units) whatsoever contemplated in itself without conscious regard to its parts would, were our sense to respond to it, be seen to embody a monad.\"
+
+Peirce goes on to say (in CP 1.451): \"What has been here affirmed of collections of units is equally true of collections of monads. Namely, any monads may be contemplated together, and in their monadic aspect without regard to the single monads are seen to be one monad. There is thus a relation between monads similar to the relation of a unit to a monad. But there is this difference in the two cases: a monad thus embraced under another monad is so embraced in its very mode of being, while that a unit should be embraced under a monad has no concern with the mode of existence of the unit, which lies in its brute self-identity and otherness from all the rest.\"
+
+What this means is that a *type*, a natural class or natural kind, can itself be represented as a monad when considered in its entirety (as the idea or concept, not as its collection of members). We can thus apply the same idea of dyadic relations as applied to monads as being applicable to the type ideal. This formulation is somewhat akin to the idea of \"punning\" in the OWL 2 language."""@en ;
+        skos:prefLabel "monads"@en ;
+        skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-MonoidalDyad
+:MonoidalDyad rdf:type owl:Class ;
+              rdfs:subClassOf :MonadicDyads ;
+              skos:altLabel "secondary quality"@en ;
+              skos:definition "A monoidal dyad is a dyad formed by realizing (conceptualizing or denoting) a single monad; it is self-referential. A monoidal dyad is a realized monad, making real the possibility by conceptualizing or discussing it. Any of the possibles or potentials provided under the Monads branch may be realized as a monoidal dyad."@en ;
+              skos:editorialNote "Every possible or potential monad provided under the Monads branch may be made real or conceptualized as a monoidal dyad (particular)."@en ,
+                                 "See CP 1.303: \"The meanings of names of \"secondary\" qualities are as good approximations to examples of monads as can be given.\""@en ;
+              skos:prefLabel "monoidal dyad"@en ;
+              skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-NaturalMatter
+:NaturalMatter rdf:type owl:Class ;
+               rdfs:subClassOf :Manifestations ;
+               owl:disjointWith [ rdf:type owl:Class ;
+                                  owl:unionOf ( :AudioInfo
+                                                :Society
+                                                :Times
+                                                :Persons
+                                                :Prokaryotes
+                                                :ProtistsFungus
+                                                :Organizations
+                                                :WrittenInfo
+                                                :Agents
+                                                :Animals
+                                                :Diseases
+                                                :Geopolitical
+                                                :StructuredInfo
+                                              )
+                                ] ;
+               skos:altLabel "natural things"@en ;
+               skos:definition "The Natural Matter SuperType captures all non-living, non-artifactual actual things found in nature, and not a result of human or cognitive activity."@en ;
+               skos:editorialNote "This is the tie-in point for the NaturalMatter SuperType (ST); it connects to a relatively minor typology."@en ;
+               skos:prefLabel "natural matter"@en ;
+               skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-NaturalPhenomena
+:NaturalPhenomena rdf:type owl:Class ;
+                  rdfs:subClassOf :Constituents ;
+                  skos:altLabel "natural phenomenon"@en ,
+                                "natural processes"@en ;
+                  skos:definition "This SuperType includes natural phenomena and natural processes such as weather, weathering, erosion, fires, lightning, earthquakes, tectonics, etc. Clouds and weather processes are specifically included. Also includes climate cycles, general natural events (such as hurricanes) that are not specifically named."@en ;
+                  skos:editorialNote "This is the tie-in point for the NaturalPhenomona SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+                  skos:prefLabel "natural phenomena"@en ;
+                  skos:scopeNote "A Firstness"@en ,
+                                 "Were this to be split, possible categories are Energy (Firstness), Light (Secondness) and Matter (Thirdness) as constituent concepts"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Numbers
+:Numbers rdf:type owl:Class ;
+         rdfs:subClassOf :Values ;
+         skos:altLabel "number"@en ;
+         skos:definition "A number is a mathematical object used to count, measure, and label values."@en ;
+         skos:prefLabel "numbers"@en ;
+         skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Oneness
+:Oneness rdf:type owl:Class ;
+         rdfs:subClassOf :Attributives ;
+         skos:altLabel "essence"@en ,
+                       "hypokeimenon"@en ,
+                       "identical"@en ,
+                       "sameness"@en ;
+         skos:definition """Oneness is the identity and nature of the attributive in relation to its subject.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+         skos:editorialNote "See https://en.wikipedia.org/wiki/Hypokeimenon and https://en.wikipedia.org/wiki/Essence."@en ;
+         skos:prefLabel "oneness"@en ;
+         skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-OrganicChemistry
+:OrganicChemistry rdf:type owl:Class ;
+                  rdfs:subClassOf :OrganicMatter ;
+                  owl:disjointWith [ rdf:type owl:Class ;
+                                     owl:unionOf ( :AreaRegion
+                                                   :AudioInfo
+                                                   :EconomicSystems
+                                                   :Facilities
+                                                   :LocationPlace
+                                                   :Society
+                                                   :Times
+                                                   :VisualInfo
+                                                   :AVInfo
+                                                   :NaturalPhenomena
+                                                   :Persons
+                                                   :Prokaryotes
+                                                   :ProtistsFungus
+                                                   :Organizations
+                                                   :Places
+                                                   :SocialSystems
+                                                   :WrittenInfo
+                                                   :Agents
+                                                   :Animals
+                                                   :Geopolitical
+                                                   :StructuredInfo
+                                                 )
+                                   ] ;
+                  skos:altLabel "biochemistry"@en ;
+                  skos:definition "The Organic Chemistry SuperType is for all chemistry involving carbon, including the biochemistry of living organisms and the materials chemistry (including polymers) of organic compounds such as fossil fuels."@en ;
+                  skos:editorialNote "This is the tie-in point for the OrganicChemistry SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+                  skos:prefLabel "organic chemistry"@en ;
+                  skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Persons
+:Persons rdf:type owl:Class ;
+         rdfs:subClassOf :Agents ;
+         owl:disjointWith [ rdf:type owl:Class ;
+                            owl:unionOf ( :AreaRegion
+                                          :AudioInfo
+                                          :BiologicalProcesses
+                                          :Drugs
+                                          :EventTypes
+                                          :Facilities
+                                          :FoodDrink
+                                          :LocationPlace
+                                          :Products
+                                          :SituationTypes
+                                          :Society
+                                          :Times
+                                          :VisualInfo
+                                          :AVInfo
+                                          :AtomsElements
+                                          :Information
+                                          :NaturalMatter
+                                          :NaturalPhenomena
+                                          :OrganicChemistry
+                                          :Prokaryotes
+                                          :ProtistsFungus
+                                          :Artifacts
+                                          :NaturalSubstances
+                                          :Organizations
+                                          :Places
+                                          :Plants
+                                          :TopicsCategories
+                                          :WrittenInfo
+                                          :Chemistry
+                                          :Diseases
+                                          :Geopolitical
+                                          :StructuredInfo
+                                        )
+                          ] ;
+         skos:altLabel "person types"@en ;
+         skos:definition """The appropriate SuperType for all named, individual human beings. This SuperType also includes the assignment of formal, honorific or cultural titles given to specific human individuals. It further includes names given to humans who conduct specific jobs or activities (the latter case is known as an avocation). Examples include steelworker, waitress, lawyer, plumber, artisan. Ethnic groups are specifically included.
+
+Persons as living animals are included under the Animals SuperType."""@en ;
+         skos:editorialNote "This is the tie-in point for the Persons SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+         skos:prefLabel "persons"@en ;
+         skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Phenomenal
+:Phenomenal rdf:type owl:Class ;
+            rdfs:subClassOf :SingleEntities ;
+            skos:altLabel "An object is anything that we can perceive, think or talk about."@en ,
+                          "entity"@en ,
+                          "material"@en ,
+                          "object"@en ;
+            skos:definition "A phenomenal entity is an object that is manifest in some way and form; it is material or can be experienced."@en ;
+            skos:prefLabel "phenomenal"@en ;
+            skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Prokaryotes
+:Prokaryotes rdf:type owl:Class ;
+             rdfs:subClassOf :LivingThings ;
+             skos:altLabel "prokaryote"@en ;
+             skos:definition "The Prokaryotes include all prokaryotic organisms, including the Monera, Archaebacteria, Bacteria, and Blue-green algas. Prokaryotes lack a cell membrane and cell nucleus. By convention, also included in this SuperType are viruses and prions."@en ;
+             skos:editorialNote "This is the tie-in point for the Prokaryotes SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+             skos:prefLabel "prokaryotes"@en ;
+             skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-ProtistsFungus
+:ProtistsFungus rdf:type owl:Class ;
+                rdfs:subClassOf :Eukaryotes ;
+                owl:disjointWith [ rdf:type owl:Class ;
+                                   owl:unionOf ( :AreaRegion
+                                                 :AudioInfo
+                                                 :BiologicalProcesses
+                                                 :EconomicSystems
+                                                 :EventTypes
+                                                 :Facilities
+                                                 :LocationPlace
+                                                 :SituationTypes
+                                                 :Society
+                                                 :Times
+                                                 :VisualInfo
+                                                 :AVInfo
+                                                 :AtomsElements
+                                                 :Information
+                                                 :NaturalMatter
+                                                 :NaturalPhenomena
+                                                 :OrganicChemistry
+                                                 :Persons
+                                                 :Prokaryotes
+                                                 :KnowledgeDomains
+                                                 :NaturalSubstances
+                                                 :Organizations
+                                                 :Places
+                                                 :SocialSystems
+                                                 :WrittenInfo
+                                                 :Agents
+                                                 :Animals
+                                                 :Chemistry
+                                                 :Diseases
+                                                 :Geopolitical
+                                                 :StructuredInfo
+                                               )
+                                 ] ;
+                skos:altLabel "fungi"@en ,
+                              "fungus"@en ,
+                              "protista"@en ,
+                              "protists"@en ;
+                skos:definition "This is the remaining cluster of eukaryotic organisms, specifically including the fungus and the protista (protozoans and slime molds)."@en ;
+                skos:editorialNote "This is the tie-in point for the ProtistsFungus SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+                skos:prefLabel "protists fungus"@en ;
+                skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Quality
+:Quality rdf:type owl:Class ;
+         rdfs:subClassOf :Inherence ;
+         skos:definition """A Quality in the dyadic monad sense is any of the singular monads under Suchness.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+         skos:editorialNote "See CP 1.563, wherein it is described as a “quality in degree a contingent inherence” or \"qualitative unity”."@en ;
+         skos:prefLabel "quality"@en ;
+         skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Quantity
+:Quantity rdf:type owl:Class ;
+          rdfs:subClassOf :Conjunctives ;
+          skos:definition """Quantity is a predicate that can exist as a magnitude or multitude. Quantities can be compared in terms of \"more,\" \"less,\" or \"equal,\" or by assigning a numerical value in terms of a unit of measurement. Some quantities are such by their inner nature (as number), while others are functioning as states (properties, dimensions, attributes) of things such as heavy and light, long and short, broad and narrow, small and great, or much and little.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+          skos:editorialNote "From CP 4.664: \"A quantity is in one sense or another an object of almost any category; but most appropriately the word is used to denote a dyadic relation, which is considered as having conceivable exact determinations differing from one another only in a linear respect, that is, so that there is a dyadic relation of \"being r to\" such that, of any two of the determinations in the same linear respect, one is r to whatever the other is r to, and is r to something the other is not r to; and to know all the possible determinations to which any determination was in that linear relation would be to know the determination exactly, the determinations being defined as such as to satisfy (especially so as just to satisfy) some general condition. If there is but a single linear respect such that, whatever two conceivable determinations of a quantity be taken, they can differ in that respect alone, it is called a simple quantity; but a quantity whose determinations can differ from others in different linear respects is called a complex quantity. The expressed determination of a quantity in all its linear respects of determination (especially if the expression be such that the determination is exact, that is, is a single one and is not any other), is called the value of the quantity.\""@en ,
+                             "See also CP 3.252 and CP 4.152."@en ;
+          skos:prefLabel "quantity"@en ;
+          skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Representation
+:Representation rdf:type owl:Class ;
+                rdfs:subClassOf :TriadicMonads ;
+                skos:altLabel "representations"@en ,
+                              "sign"@en ;
+                skos:definition """A representation is any icon, index, or symbol referring to another specific thing, be it an event, entity, type, predicate, or any other particular that might be used to refer to another particular or general.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+                skos:prefLabel "representation"@en ;
+                skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Shapes
+:Shapes rdf:type owl:Class ;
+        rdfs:subClassOf :SpaceTypes ;
+        owl:disjointWith [ rdf:type owl:Class ;
+                           owl:unionOf ( :BiologicalProcesses
+                                         :Society
+                                         :Organizations
+                                         :Geopolitical
+                                       )
+                         ] ;
+        skos:altLabel "shape"@en ,
+                      "shape types"@en ;
+        skos:definition "The Shapes SuperType captures all 1D, 2D and 3D shapes, regular or irregular. Most shapes are geometrically describable things."@en ;
+        skos:editorialNote """This is the tie-in point for the Shapes SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types.
+
+Most entities are characterized by a shape. Thus, the Shapes ST is not very useful in disjointedness assertions."""@en ;
+        skos:prefLabel "shapes"@en ;
+        skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-SingleEntities
+:SingleEntities rdf:type owl:Class ;
+                rdfs:subClassOf :Entities ;
+                skos:altLabel "identities"@en ,
+                              "identity"@en ,
+                              "single entity"@en ;
+                skos:definition "A single entity is an individual that has Identity unique to it without needing to be part of a collective or whole, Identify is the difference or character that marks off an individual from the rest of the same kind; also known by selfhood or sameness."@en ;
+                skos:prefLabel "single entities"@en ;
+                skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Spontaneous
+:Spontaneous rdf:type owl:Class ;
+             rdfs:subClassOf :Events ;
+             skos:altLabel "chance"@en ,
+                           "randomness"@en ;
+             skos:definition "An unpredictable event occurring without apparent cause; a \"surprise\""@en ;
+             skos:prefLabel "spontaneous"@en ;
+             skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Suchness
+:Suchness rdf:type owl:Class ;
+          rdfs:subClassOf :FirstMonads ;
+          skos:altLabel "ens"@en ,
+                        "primen"@en ,
+                        "protoidal"@en ,
+                        "qualia"@en ,
+                        "quality"@en ;
+          skos:definition """Suchness, also known as qualities, or qualia, are the perceived attributes of entities. These perceived properties are an interpretation of the underlying, intrinsic characteristics of the object.
+
+Suchness is not realized, but a possibility or potential, and is an \"indecomposable\" element."""@en ;
+          skos:editorialNote "In a triples concept, a suchness could represent either the S – P – 0 individually"@en ,
+                             "See CP 1.295 (related to the components of the Phaneron): \"These things being premised we may say in primo, there is no a priori reason why there should not be indecomposable elements of the phaneron which are what they are regardless of anything else, each complete in itself; provided, of course, that they be capable of composition. We will call these and all that particularly relates to them Priman. Indeed, it is almost inevitable that there should be such, since there will be compound concepts which do not refer to anything, and it will generally be possible to abstract from the internal.\""@en ;
+          skos:prefLabel "suchness"@en ;
+          skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-TriadicAction
+:TriadicAction rdf:type owl:Class ;
+               rdfs:subClassOf :Continuous ;
+               skos:altLabel "semiosis"@en ;
+               skos:definition "Triadic action is when one event, A, produces a second event, B, that is a means to the production of a third event, C. An example of this action is 'A gives B to C'."@en ;
+               skos:editorialNote "Peirce's object-representamen-interpretant sign is an example of triadic action."@en ;
+               skos:prefLabel "triadic action"@en ;
+               skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Unary
+:Unary rdf:type owl:Class ;
+       rdfs:subClassOf :Connective ;
+       skos:altLabel "Alogical refers to any relation that is not based upon a form of logic."@en ,
+                     "unary logic"@en ,
+                     "unary relation"@en ;
+       skos:definition """There are 4 unary operations: 1) always true; 2) never true (unary falsum); 3) unary Identity; and 4) unary negation.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+       skos:prefLabel "unary"@en ;
+       skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#1-Values
+:Values rdf:type owl:Class ;
+        rdfs:subClassOf :Quantity ;
+        skos:altLabel "amount"@en ,
+                      "value"@en ,
+                      "worth"@en ;
+        skos:definition "The value of an attribute is any number, amount or other mathematical object assigned to it, computed for it, or implied by a function as a result of a particular number being assigned to its argument. Values may be strings or numbers, with magnitudes or multitudes possible for the numbers."@en ;
+        skos:editorialNote "See CP 4.664."@en ;
+        skos:prefLabel "values"@en ;
+        skos:scopeNote "A Firstness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2D-Dimensions
+:D-Dimensions rdf:type owl:Class ;
+              rdfs:subClassOf :Areas ;
+              skos:altLabel "2d dimension"@en ,
+                            "dimension"@en ,
+                            "dimensional"@en ;
+              skos:definition "Dimensions represent any of the bounded conditions related to the 2D aspects (height, width, length) of the area."@en ;
+              skos:prefLabel "2D Dimensions"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Action
+:Action rdf:type owl:Class ;
+        rdfs:subClassOf :Events ;
+        skos:altLabel "brute force"@en ,
+                      "reaction"@en ;
+        skos:definition "Action is where the modification of things is more prominent than reaction to it (or the perception of it). Action always occurs in combination with reaction. It is what gives rise to events and entities."@en ;
+        skos:editorialNote "From CP 1.324: \"The waking state is a consciousness of reaction; and as the consciousness itself is two-sided, so it has also two varieties; namely, action, where our modification of other things is more prominent than their reaction on us, and perception, where their effect on us is overwhelmingly greater than our effect on them.\""@en ,
+                           "See CP 1.324."@en ,
+                           "Struggle is the equal combination of action and reaction (CP 5.45)."@en ,
+                           "Struggle is the equal combination of action and reaction (CP 5.45.)."@en ;
+        skos:prefLabel "action"@en ;
+        skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Activities
+:Activities rdf:type owl:Class ;
+            rdfs:subClassOf :Continuous ;
+            skos:altLabel "action"@en ,
+                          "activity"@en ;
+            skos:definition "Activities are particulars that are ongoing or occur over a period of time and result (often) from human effort or other agents. Human activities are often conducted by organizations to assist other organizations or individuals (in which case they are known as services, such as medicine, law, printing, consulting or teaching) or individual or group efforts for leisure, fun, sports, games or personal interests (activities)."@en ;
+            skos:prefLabel "activities"@en ;
+            skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-AdjunctualAttributes
+:AdjunctualAttributes rdf:type owl:Class ;
+                      rdfs:subClassOf :AttributeTypes ;
+                      skos:altLabel "accidents"@en ,
+                                    "adjunctual attribute"@en ,
+                                    "life events"@en ;
+                      skos:definition "Events that may occur to a single entities or events (particulars) that help characterize it."@en ;
+                      skos:editorialNote "Concepts in this type include birth, death, marriage, events, accidents, surprises, happenings, extrinsic, adjunctual."@en ,
+                                         "This is the tie-in point for the AdjunctualAttributeTypes SuperType (ST). By design and convention, AdjunctualAttributeTypes are NOT EntityTypes. AdjunctualAttributeTypes connects to a relatively major typology with a comparatively large number of adjunctual attributes."@en ;
+                      skos:prefLabel "adjunctual attributes"@en ;
+                      skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Artifacts
+:Artifacts rdf:type owl:Class ;
+           rdfs:subClassOf :Symbolic ;
+           owl:disjointWith [ rdf:type owl:Class ;
+                              owl:unionOf ( :BiologicalProcesses
+                                            :Times
+                                            :Persons
+                                            :Geopolitical
+                                          )
+                            ] ;
+           skos:altLabel "artifact"@en ;
+           skos:definition "The Artifacts SuperType is a major grouping of SuperTypes and is for all material expressions of human works, except for those strictly related to information or data."@en ;
+           skos:editorialNote "This is the tie-in point for the Artifacts SuperType (ST); it connects to a relatively minor typology."@en ;
+           skos:prefLabel "artifacts"@en ;
+           skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Being
+:Being rdf:type owl:Class ;
+       rdfs:subClassOf :Thisness ;
+       skos:altLabel "existence"@en ,
+                     "ousia"@en ;
+       skos:definition "Being, or existence, is that which exists independent of perception or thought. As an \"indecomposable\", this is the possibility or potential of existence rather than actual existence."@en ;
+       skos:editorialNote "See https://en.wikipedia.org/wiki/Ousia"@en ;
+       skos:prefLabel "being"@en ;
+       skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Binary
+:Binary rdf:type owl:Class ;
+        rdfs:subClassOf :Connective ;
+        skos:altLabel "binary logic"@en ,
+                      "binary relation"@en ,
+                      "dyadic"@en ,
+                      "dyadic logic"@en ,
+                      "propositional logic"@en ;
+        skos:definition """A logical relation is part of a formal system (together with defined semantics) in the form of model-theoretic interpretation that assigns truth values to sentences of the formal language; that is, formulae that contain no free variables. A logic is sound if all sentences that can be derived are true in the interpretation, and complete if, conversely, all true sentences can be derived.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+        skos:prefLabel "binary"@en ;
+        skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-CopulativeRelations
+:CopulativeRelations rdf:type owl:Class ;
+                     rdfs:subClassOf :RelationTypes ;
+                     skos:altLabel "combinations"@en ,
+                                   "copulative relation"@en ,
+                                   "quantities"@en ;
+                     skos:definition "Relatiionships of combination, membership, quantity, action, or circumstance."@en ;
+                     skos:editorialNote "Concepts in this type include accidental, real, place, time, situation, quantity, facets, aspects, conjunctive, lists, one-to-many, many-to-one, sum of, contextual, verbs."@en ,
+                                        "The three main branches of this SuperType (ST) are Typings (a Firstness), ActionTypes (a Secondness) and Conjoins (a Thirdness). Only the ActionTypes ST is listed formally with the KKO. See the CopulativeRelations typology for the entire presentation of reference concepts (RCs)."@en ,
+                                        "This is the tie-in point for the CopulativeRelationTypes SuperType (ST). By design and convention, CopulativeRelationTypes are NOT EntityTypes. CopulativeRelationTypes connects to a relatively major typology with a comparatively large number of copulative relations, including the major ActionTypes."@en ;
+                     skos:prefLabel "copulative relations"@en ;
+                     skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Discrete
+:Discrete rdf:type owl:Class ;
+          rdfs:subClassOf :Quantity ;
+          skos:altLabel "quanta"@en ,
+                        "quantized"@en ;
+          skos:definition """A discrete quantity is one that is separate or discontinuous from other values. The distribution of discrete quantities is lumpy or ordinal across multiple entities in the same class or type.
+
+By definition, discrete quantities are not continuous."""@en ;
+          skos:prefLabel "discrete"@en ;
+          skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-DyadicMonads
+:DyadicMonads rdf:type owl:Class ;
+              rdfs:subClassOf :Monads ;
+              skos:altLabel "assertion"@en ,
+                            "attribute"@en ,
+                            "characteristic"@en ,
+                            "relation"@en ,
+                            "simple sentence"@en ,
+                            "statement"@en ;
+              skos:definition "Dyadic monads are \"indecomposable\" elements that capture the ideas of relation, fact and reaction characteristic of Secondness. Like all monads, they are possibles or potentials, and not actually realized in any way. They are the possible ways that particulars might be understood in and of themselves, in isolation without respect to any other or contrast."@en ;
+              skos:prefLabel "dyadic monads"@en ;
+              skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-EssentialDyad
+:EssentialDyad rdf:type owl:Class ;
+               rdfs:subClassOf :MonadicDyads ;
+               skos:definition "An essential dyad is where both the subject and the object of the dyad are monads. This realization takes the form of a subsumptive realization (as scarlet is to red, for example)."@en ;
+               skos:editorialNote "From CP 1.462: \"The only primary essential dyadism is that between a containing monadic quality and a contained monadic quality. For qualities cannot resemble one another nor contrast with one another unless in respect to a third quality; so that the resemblance of qualities is triadic.\""@en ;
+               skos:prefLabel "essential dyad"@en ;
+               skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Eukaryotes
+:Eukaryotes rdf:type owl:Class ;
+            rdfs:subClassOf :LivingThings ;
+            owl:disjointWith [ rdf:type owl:Class ;
+                               owl:unionOf ( :AreaRegion
+                                             :AudioInfo
+                                             :BiologicalProcesses
+                                             :EconomicSystems
+                                             :EventTypes
+                                             :Facilities
+                                             :LocationPlace
+                                             :Society
+                                             :Times
+                                             :VisualInfo
+                                             :AVInfo
+                                             :AtomsElements
+                                             :NaturalPhenomena
+                                             :Prokaryotes
+                                             :NaturalSubstances
+                                             :Organizations
+                                             :Places
+                                             :SocialSystems
+                                             :WrittenInfo
+                                             :Geopolitical
+                                             :StructuredInfo
+                                           )
+                             ] ;
+            skos:altLabel "eukaryote"@en ;
+            skos:definition "Eukaryotes are living things that have a cell nucleus and cell membrane, and are one of the three major kingdoms of life."@en ;
+            skos:editorialNote "This is the tie-in point for the Eukaryotes SuperType (ST); it connects to a relatively minor typology."@en ;
+            skos:prefLabel "eukaryotes"@en ;
+            skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Events
+:Events rdf:type owl:Class ;
+        rdfs:subClassOf :Particulars ;
+        skos:altLabel "actuality"@en ,
+                      "event"@en ,
+                      "occurrence"@en ;
+        skos:definition """Events are occurrences resulting from the dual effects of an action and a countervailing reaction, that result in an existence.  Events begin in an instant and may be no longer than that, or may continue through many instants and still retain an event identity. Thus, events may have duration. Also, thoughts are events. Without events, there are no entities.
+
+Events may have a finite duration, with a beginning and end. Individual events (such as wars, disasters, newsworthy occasions) may also have their own names.
+
+Events are demarcated by a change, or a difference in state (that is, qualities). A change may occur by chance, by exertion, by perception, or any other action."""@en ;
+        skos:editorialNote "From 5.284: \". . . there is no intuition or cognition not determined by previous cognitions, it follows that the striking in of a new experience is never an instantaneous affair, but is an event occupying time, and coming to pass by a continuous process.\""@en ,
+                           "From CP 1.132: \". . . every event is precisely determined by general laws, which evidently never can be rendered probable by observation, and which, if admitted, must, therefore, stand as self-evident.\""@en ,
+                           "From CP 1.24: \"Let us begin with considering actuality, and try to make out just what it consists in. If I ask you what the actuality of an event consists in, you will tell me that it consists in its happening then and there. The specifications then and there involve all its relations to other existents. The actuality of the event seems to lie in its relations to the universe of existents. . . . Actuality is something brute. There is no reason in it. I instance putting your shoulder against a door and trying to force it open against an unseen, silent, and unknown resistance. We have a two-sided consciousness of effort and resistance, which seems to me to come tolerably near to a pure sense of actuality. On the whole, I think we have here a mode of being of one thing which consists in how a second object is. I call that Secondness.\""@en ,
+                           "From CP 1.336: \"We perceive objects brought before us; but that which we especially experience -- the kind of thing to which the word \"experience\" is more particularly applied -- is an event. We cannot accurately be said to perceive events; for this requires what Kant called the \"synthesis of apprehension,\" not however, by any means, making the needful discriminations. A whistling locomotive passes at high speed close beside me. As it passes the note of the whistle is suddenly lowered from a well-understood cause. I perceive the whistle, if you will. I have, at any rate, a sensation of it. But I cannot be said to have a sensation of the change of note. I have a sensation of the lower note. But the cognition of the change is of a more intellectual kind. That I experience rather than perceive. It is [the] special field of experience to acquaint us with events, with changes of perception. Now that which particularly characterizes sudden changes of perception is a shock. A shock is a volitional phenomenon.\""@en ,
+                           """From CP 1.492: \"It is, in the first place, only real events that \"take place,\" or have dates, in real time. Imaginary events, the course of a romance, are represented as having relations like those of time among one another, but they have no real places in time. . . . What, then, is a real event? It is an existential junction of incompossible facts.\"
+
+See further CP 1.492 - 1.494."""@en ,
+                           "From CP 1.493: \"In general, however, we may say that for an event there is requisite: first, a contradiction; second, existential embodiments of these contradictory states; [third,] an immediate existential junction of these two contradictory existential embodiments or facts, so that the subjects are existentially identical; and fourth, in this existential junction a definite one of the two facts must be existentially first in the order of evolution and existentially second in the order of involution. We say the former is earlier, the latter later in time. That is, the past can in some measure work upon and influence (or flow into) the future, but the future cannot in the least work upon the past. On the other hand, the future can remember and know the past, but the past can only know the future so far as it can imagine the process by which the future is to be influenced.\""@en ,
+                           "From CP 5.472: \"An event, A, may, by brute force, produce an event, B; and then the event, B, may in its turn produce a third event, C. The fact that the event, C, is about to be produced by B has no influence at all upon the production of B by A. It is impossible that it should, since the action of B in producing C is a contingent future event at the time B is produced. Such is dyadic action, which is so called because each step of it concerns a pair of objects.\""@en ,
+                           "In CP 2.245, CSP defines a Sinsign as either an existent thing or an event."@en ,
+                           "See CP 1.492-494."@en ;
+        skos:prefLabel "events"@en ;
+        skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Index
+:Index rdf:type owl:Class ;
+       rdfs:subClassOf :Representation ;
+       skos:altLabel "indexes"@en ,
+                     "indice"@en ;
+       skos:definition """An Index is a sign which refers to the Object that it denotes by virtue of being really affected by that Object. (from CP 2.248)
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+       skos:prefLabel "index"@en ;
+       skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Indexes
+:Indexes rdf:type owl:Class ;
+         rdfs:subClassOf :RepresentationTypes ;
+         skos:altLabel "IDs"@en ,
+                       "identifiers"@en ,
+                       "index"@en ,
+                       "indices"@en ;
+         skos:definition "Indirect references or pointers that help situate or draw attention to the subject."@en ;
+         skos:editorialNote "Concepts in this type include URIs, identifiers, keys, indices, references, semes, propositions (w/o objects), codes, selections, directional, citations, contextual (?), pronouns."@en ;
+         skos:prefLabel "indexes"@en ;
+         skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Indexical
+:Indexical rdf:type owl:Class ;
+           rdfs:subClassOf :Indicatives ;
+           skos:altLabel "index"@en ,
+                         "indicator"@en ,
+                         "indices"@en ;
+           skos:definition """An indexical monad is anything that directs attention. An indexical does not assert anything.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+           skos:prefLabel "indexical"@en ;
+           skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Inherent
+:Inherent rdf:type owl:Class ;
+          rdfs:subClassOf :Suchness ;
+          skos:altLabel "quiddity"@en ;
+          skos:definition """Inherent is a quality \"possessed\" by something. As an \"indecomposable\", inherent is a potential character or characteristic of something that helps define what it is. In scholastic philosophy, quiddity is another term for the essence of an object, literally its \"whatness\" or \"what it is\".
+
+Quiddity describes properties that a particular entity (e.g., an automobile) shares with others of its kind. It is not exactly equivalent to essence, since some shared properties may not be central to a thing's essence. For example, an automobile may share with another automobile the property of tinted windows, but that character is not central to the automobile's essence."""@en ;
+          skos:editorialNote "See https://en.wikipedia.org/wiki/Quiddity."@en ;
+          skos:prefLabel "inherent"@en ;
+          skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Intervals
+:Intervals rdf:type owl:Class ;
+           rdfs:subClassOf :Time ;
+           skos:altLabel "interval"@en ,
+                         "segments"@en ,
+                         "time span"@en ;
+           skos:definition "Any duration of time from the shortest of moments to eons."@en ;
+           skos:prefLabel "intervals"@en ;
+           skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-KnowledgeDomains
+:KnowledgeDomains rdf:type owl:Class ;
+                  rdfs:subClassOf :Methodeutic ;
+                  skos:altLabel "academic disciplines"@en ,
+                                "fields of study"@en ;
+                  skos:definition """Knowledge domains are the topics for study and discovery. The boundaries of the domains are somewhat arbitrary, but describe common fields of inquiry and study. It is through the intense knowledge gained by studying these domains that can produce the insights for new knowledge. 
+
+Knowledge domains are often the focus of academic studies and disciplines, what OpenCyc calls FieldsOfStudy. Systematic human activity in these domains creates, builds and organizes knowledge in the form of testable explanations and predictions about the domain at hand (which may result in the expansion into new domains)."""@en ;
+                  skos:editorialNote "This is the tie-in point for the KnowledgeDomains SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types. KnowledgeDomain is nearly synonymous with FieldsOfStudy."@en ,
+                                     "This node traces out all of the major sub-branches of the OpenCyc FieldsOfStudy. The upper portions may be aligned with Peirce's natural science classification (see https://en.wikipedia.org/wiki/Classification_of_the_sciences_%28Peirce%29)"@en ;
+                  skos:prefLabel "knowledge domains"@en ;
+                  skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-LivingThings
+:LivingThings rdf:type owl:Class ;
+              rdfs:subClassOf :OrganicMatter ;
+              owl:disjointWith [ rdf:type owl:Class ;
+                                 owl:unionOf ( :AreaRegion
+                                               :AudioInfo
+                                               :Facilities
+                                               :LocationPlace
+                                               :Society
+                                               :Times
+                                               :VisualInfo
+                                               :AVInfo
+                                               :AtomsElements
+                                               :NaturalPhenomena
+                                               :NaturalSubstances
+                                               :Organizations
+                                               :Places
+                                               :WrittenInfo
+                                               :Geopolitical
+                                               :StructuredInfo
+                                             )
+                               ] ;
+              skos:altLabel "animate thing"@en ,
+                            "animate things"@en ,
+                            "life form"@en ,
+                            "life forms"@en ,
+                            "living thing"@en ,
+                            "organism"@en ,
+                            "organisms"@en ;
+              skos:definition "The Living Things SuperType is for all living organisms, including humans (as animals). Also included in the definition are the diseases that may affect living things."@en ;
+              skos:editorialNote "This is the tie-in point for the LivingThings SuperType (ST); it connects to an intermediate typology."@en ;
+              skos:prefLabel "living things"@en ;
+              skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Mediation
+:Mediation rdf:type owl:Class ;
+           rdfs:subClassOf :TriadicMonads ;
+           skos:altLabel "betweenness"@en ,
+                         "conciliation"@en ,
+                         "intermediation"@en ,
+                         "representation"@en ,
+                         "satisficing"@en ,
+                         "synthesis"@en ;
+           skos:definition """Mediation is the representation of \"something of\" to \"something to\". Mediation is the bringing together of a Firstness and a Secondness.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+           skos:editorialNote "Mediation is perhaps the most common term used by CSP for Thirdness."@en ,
+                              "See CP 6.32."@en ;
+           skos:prefLabel "mediation"@en ;
+           skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-MixedStuff
+:MixedStuff rdf:type owl:Class ;
+            rdfs:subClassOf :Predications ;
+            skos:altLabel "mixture"@en ;
+            skos:definition "Mixed stuff is the combination of two or more individuals that has no identity beyond its mixture. For example, dry cement mix or baking ingredients fits into this category. However, if by virtue of the mixture or some process applied to it, such as adding water to make concrete or baking in an oven, a new identity gets created, then the thing should be more properly categorized as a compound entity."@en ;
+            skos:prefLabel "mixed stuff"@en ;
+            skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Multitudes
+:Multitudes rdf:type owl:Class ;
+            rdfs:subClassOf :Values ;
+            skos:altLabel "count"@en ,
+                          "multitude"@en ;
+            skos:definition "Multitude, or count, is the number of elements of a finite set of objects."@en ;
+            skos:prefLabel "multitudes"@en ;
+            skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-NaturalSubstances
+:NaturalSubstances rdf:type owl:Class ;
+                   rdfs:subClassOf :NaturalMatter ;
+                   owl:disjointWith [ rdf:type owl:Class ;
+                                      owl:unionOf ( :ActionTypes
+                                                    :AudioInfo
+                                                    :BiologicalProcesses
+                                                    :Drugs
+                                                    :Society
+                                                    :Times
+                                                    :VisualInfo
+                                                    :AVInfo
+                                                    :Information
+                                                    :Persons
+                                                    :Prokaryotes
+                                                    :ProtistsFungus
+                                                    :Eukaryotes
+                                                    :LivingThings
+                                                    :Organizations
+                                                    :Plants
+                                                    :WrittenInfo
+                                                    :Agents
+                                                    :Animals
+                                                    :Diseases
+                                                    :Geopolitical
+                                                    :StructuredInfo
+                                                  )
+                                    ] ;
+                   skos:altLabel "natural materials"@en ,
+                                 "natural substance"@en ;
+                   skos:definition "The Natural Substances SuperType are minerals, compounds, chemicals, or physical objects that are not the outcome of purposeful human effort, but are found naturally occurring. Other natural objects (such as rock, fossil, etc.) are also found under this SuperType. Chemicals can be Natural Substances, but only if they are naturally occurring, such as limestone or salt."@en ;
+                   skos:editorialNote "This is the tie-in point for the NaturalSubstances SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+                   skos:prefLabel "natural substances"@en ;
+                   skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Negation
+:Negation rdf:type owl:Class ;
+          rdfs:subClassOf :Inherence ;
+          skos:definition """Negation is the complementary selection of all other characters when a given character (monad) is selected. That is, when something is selected, all other characters of a similar nature are not selected. Negation can also be indicated as an active exclusion.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+          skos:editorialNote """From CP 2.379: \"The conception of negation, objectively considered, is one of the most
+important of logical relations; but subjectively considered, it is not a term of logic at all, but is prelogical. That is to say, it is one of those ideas which must have been fully developed and mastered before the idea of investigating the legitimacy of reasonings could have been carried to any extent.\""""@en ,
+                             "See CP 1.450: \"Those objects of the universe which do not possess a given character possess another character which, in reference to that universe, is in the relation of negation to the first. Hence, it is impossible to form a single class of dyads; two classes of dyads must be formed at once. Hence, considering all the monads which can appear on the contemplation of sets of units of the universe in their monadic aspect, every single unit is determined to be one subject of a dyad which has any one of those monads as its second subject, namely it is either such a dyad as determines it to have the character of being one of the units which made up the object of the contemplation in which that monad appeared, or it is such a dyad as determines the unit to have the character belonging to all the other units of the universe.\""@en ,
+                             "See CP 1.563, where it is also called a “possible inherence” or “negative unity”."@en ;
+          skos:prefLabel "negation"@en ;
+          skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Opponents
+:Opponents rdf:type owl:Class ;
+           rdfs:subClassOf :Relatives ;
+           skos:altLabel "alio-relative"@en ,
+                         "opponent"@en ;
+           skos:definition """An opponent is a simple relative whose elements are of the form A:B. The character signified by an opponent is a relative character (that is, one that cannot be prescinded from reference to a correlate). An opponent contains no pair of elements with itself.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+           skos:editorialNote "See CP 3.136; CP 3.226."@en ;
+           skos:prefLabel "opponents"@en ;
+           skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-OrganicMatter
+:OrganicMatter rdf:type owl:Class ;
+               rdfs:subClassOf :Manifestations ;
+               owl:disjointWith [ rdf:type owl:Class ;
+                                  owl:unionOf ( :AudioInfo
+                                                :Society
+                                                :Times
+                                                :NaturalPhenomena
+                                              )
+                                ] ;
+               skos:definition "This umbrella SuperType represents all living things, dead things, decompositions from dead things, and fluids or excretions from living things. All agents related to living things or organizations are included. The organic chemistry underlying life is also included, as are diseases associated with living things."@en ;
+               skos:editorialNote "This is the tie-in point for the OrganicMatter SuperType (ST); it connects to a relatively minor typology."@en ;
+               skos:prefLabel "organic matter"@en ;
+               skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Organizations
+:Organizations rdf:type owl:Class ;
+               rdfs:subClassOf :Agents ;
+               owl:disjointWith [ rdf:type owl:Class ;
+                                  owl:unionOf ( :AudioInfo
+                                                :BiologicalProcesses
+                                                :Drugs
+                                                :FoodDrink
+                                                :LocationPlace
+                                                :Times
+                                                :VisualInfo
+                                                :AVInfo
+                                                :AtomsElements
+                                                :Information
+                                                :NaturalMatter
+                                                :NaturalPhenomena
+                                                :OrganicChemistry
+                                                :Persons
+                                                :Prokaryotes
+                                                :ProtistsFungus
+                                                :Shapes
+                                                :Eukaryotes
+                                                :LivingThings
+                                                :NaturalSubstances
+                                                :Plants
+                                                :WrittenInfo
+                                                :Animals
+                                                :Chemistry
+                                                :Diseases
+                                                :Forms
+                                                :StructuredInfo
+                                              )
+                                ] ;
+               skos:altLabel "groups"@en ,
+                             "organization"@en ;
+               skos:definition """Organization is a broad SuperType and includes formal collections of humans, sometimes by legal means, charter, agreement or some mode of formal understanding. Examples include geoplotical entities such as nations, municipalities or countries (though these have also been segregated into their own supertype); or companies, institutes, governments, universities, militaries, political parties, game groups, international organizations, trade associations, etc. All institutions, for example, are organizations.
+
+Also included are informal collections of humans. Informal or less defined groupings of humans may result from ethnicity or tribes or nationality or from shared interests (such as social networks or mailing lists) or expertise (\"communities of practice\"). This dimension also includes the notion of identifiable human groups with set members at any given point in time. Examples include music groups, cast members of a play, directors on a corporate Board, TV show members, gangs, mobs, juries, generations, minorities, etc.
+
+Finally, Organizations contain the concepts of Industries and Programs and Communities."""@en ;
+               skos:editorialNote "This is the tie-in point for the Organizations SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+               skos:prefLabel "organizations"@en ;
+               skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Otherness
+:Otherness rdf:type owl:Class ;
+           rdfs:subClassOf :Attributives ;
+           skos:altLabel "other"@en ,
+                         "secundo"@en ;
+           skos:editorialNote "In CP 1.296:  \"In secundo, there is no reason why there should not be indecomposable elements which are what they are relatively to a second but independently of any third. Such, for example, is the idea of otherness. We will call such ideas and all that is marked by them (i.e., dependent on a second).\""@en ,
+                              "In CP 1.566: \"Otherness . . . is the inseparable spouse of identity: wherever there is identity there is necessarily otherness; and in whatever field there is true otherness there is necessarily identity. Since identity belongs exclusively to that which is hic et nunc, so likewise must otherness. It is, therefore, in a sense a dynamical relation, though only a relation of reason.\""@en ;
+           skos:prefLabel """Otherness is that which comes into focus upon the realization of the one, as its contrast or exclusion from the middle.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ,
+                          "otherness"@en ;
+           skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-PartOfEntities
+:PartOfEntities rdf:type owl:Class ;
+                rdfs:subClassOf :Entities ;
+                skos:definition """An entity that, while discrete, is understood to be part of a larger whole. An entity that is part of a larger whole may exist independently or not from the whole of which it is a part, but in either case is unable to fulfill its essence or complete nature if apart from the whole.
+
+A part of entity may be seen as having an identity of its own, and is often nameable."""@en ;
+                skos:prefLabel "part of"@en ;
+                skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Particulars
+:Particulars rdf:type owl:Class ;
+             rdfs:subClassOf owl:Thing ;
+             skos:altLabel "individual"@en ,
+                           "individuals"@en ,
+                           "specifics"@en ;
+             skos:definition """Particulars, often referred to as Individuals (but that is not absolutely so because of the uncertain status of monadic dyads), are discrete, separate things that have their own identity. Particulars arise from a head-butting duality of action and reaction, and exist totally in the present. Both events and entities are kinds of particulars.
+
+Particulars may be understood in an intensional sense, wherein they are defined through a set of characteristics or attributes, the necessary and sufficient properties for belonging to that set. Or, particulars may be understood in an extensional sense, wherein they are defined as one of the members within the set or concept at hand, which is a more relational or contextual view. Particulars may also be a part of something broader so long as they have their own discrete identity. For examples, a specific tire or engine may be an individual or particular part of a car; a baton pass may be a moment within a relay race."""@en ;
+             skos:editorialNote "Note there is a degree of structural similarity between the main Particulars branch in KKO and the main Generals branch. This structural similarity is because Particulars deal with the nature and classification of individuals or instances, while Generals deal with the quite similar classification of classes or types. Fundamentally, all instances are characterized according to the Particulars branch; all types are characterized according to the Generals branch."@en ;
+             skos:prefLabel "particulars"@en ;
+             skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Parts
+:Parts rdf:type owl:Class ;
+       rdfs:subClassOf :PartOfEntities ;
+       skos:altLabel "meronym"@en ,
+                     "part"@en ,
+                     "part-of"@en ;
+       skos:definition """A part, or meronym, denotes a constituent part of, or a member of something.  A meronym refers to a part of a whole. For example, 'finger' is a meronym of 'hand' because a finger is part of a hand. Similarly, 'wheel' is a meronym of 'automobile'.
+
+In knowledge representation languages, meronymy is often expressed as \"part-of\"."""@en ;
+       skos:prefLabel "parts"@en ;
+       skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Perception
+:Perception rdf:type owl:Class ;
+            rdfs:subClassOf :Action ;
+            skos:altLabel "sensation"@en ;
+            skos:definition "Perception is the sensation of feelings. It is also the awareness of qualities (Firstness)."@en ;
+            skos:prefLabel "perception"@en ;
+            skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Places
+:Places rdf:type owl:Class ;
+        rdfs:subClassOf :SpaceTypes ;
+        owl:disjointWith [ rdf:type owl:Class ;
+                           owl:unionOf ( :ActionTypes
+                                         :AudioInfo
+                                         :BiologicalProcesses
+                                         :Drugs
+                                         :EventTypes
+                                         :FoodDrink
+                                         :Society
+                                         :Times
+                                         :AtomsElements
+                                         :OrganicChemistry
+                                         :Persons
+                                         :Prokaryotes
+                                         :ProtistsFungus
+                                         :Eukaryotes
+                                         :LivingThings
+                                         :Plants
+                                         :WrittenInfo
+                                         :Animals
+                                         :Chemistry
+                                         :Diseases
+                                         :StructuredInfo
+                                       )
+                         ] ;
+        skos:altLabel "place"@en ,
+                      "place types"@en ;
+        skos:definition "The Places SuperType is for any area within a space. Areas within Places may be either areas or regions or specific locations or places."@en ;
+        skos:editorialNote "This is the tie-in point for the Places SuperType (ST); it connects to a relatively minor typology."@en ;
+        skos:prefLabel "places"@en ;
+        skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Plants
+:Plants rdf:type owl:Class ;
+        rdfs:subClassOf :Eukaryotes ;
+        owl:disjointWith [ rdf:type owl:Class ;
+                           owl:unionOf ( :AreaRegion
+                                         :AudioInfo
+                                         :BiologicalProcesses
+                                         :EconomicSystems
+                                         :EventTypes
+                                         :Facilities
+                                         :LocationPlace
+                                         :Society
+                                         :Times
+                                         :VisualInfo
+                                         :AVInfo
+                                         :AtomsElements
+                                         :Information
+                                         :NaturalPhenomena
+                                         :Persons
+                                         :Prokaryotes
+                                         :NaturalSubstances
+                                         :Organizations
+                                         :Places
+                                         :SocialSystems
+                                         :WrittenInfo
+                                         :Agents
+                                         :Animals
+                                         :Diseases
+                                         :Geopolitical
+                                         :StructuredInfo
+                                       )
+                         ] ;
+        skos:altLabel "plant"@en ;
+        skos:definition "This SuperType includes all plant types and flora, including flowering plants, algae, non-flowering plants, gymnosperms, cycads, and plant parts and body types. Note that all Plant Parts are also included."@en ;
+        skos:editorialNote "This is the tie-in point for the Plants SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+        skos:prefLabel "plants"@en ;
+        skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Predications
+:Predications rdf:type owl:Class ;
+              rdfs:subClassOf :SuperTypes ;
+              skos:altLabel "predication"@en ,
+                            "relations"@en ;
+              skos:definition "Predications are the various ways that statements may be made about a subject, including attributes (internal relations), external relations, indexicals and annotations. Collectively, all of these may be deemed as \"relations\", but it is better to maintain the more distinct typings."@en ;
+              skos:editorialNote "This is the tie-in point for the Predications SuperType (ST); it connects to a relatively minor typology."@en ;
+              skos:prefLabel "predications"@en ;
+              skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Real
+:Real rdf:type owl:Class ;
+      rdfs:subClassOf :Oneness ;
+      skos:altLabel "reality"@en ;
+      skos:definition """Real are things or concepts that have existed, do exist, or will exist. The truth refers to what is real, while falsity refers to what is not. Fictions are considered not real.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+      skos:prefLabel "real"@en ;
+      skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-RelationTypes
+:RelationTypes rdf:type owl:Class ;
+               rdfs:subClassOf :Predications ;
+               skos:altLabel "external relation"@en ,
+                             "relation"@en ,
+                             "relation types"@en ;
+               skos:definition """By definition, RelationTypes are external relations. External relations are assertions between an object, event, entity, type, or concept and another particular or general. An external relationship has the form of A:B. External relations may be simple ones of a direct relationship between two different instances. External relations may be copulative by combining objects or asserting membership, quantity, action or circumstance. Or, external relations may be mediative to provide meaning, context, relevance, generalizations, or other explanations of the subject with respect to the external world. External relations are extensional.
+
+These external relations have been categorized according to these distinctions and grouped and organized into types."""@en ;
+               skos:editorialNote """This General could be split as follows:
+
+    DyadicRelations [1ns]
+    ExistentialRelations [2ns] (needs to include Creation [3ns] and Destruction [3ns]; separate from CSP definition in 3.571)
+    SituationTypes [3ns]"""@en ,
+                                  "This is the tie-in point for the ExternalRelationTypes SuperType (ST). By design and convention, ExternalRelationTypes are NOT EntityTypes. ExternalRelationTypes connects to a relatively major typology with a comparatively large number of Relations."@en ;
+               skos:prefLabel "relation types"@en ;
+               skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Relatives
+:Relatives rdf:type owl:Class ;
+           rdfs:subClassOf :DyadicMonads ;
+           skos:altLabel "relation"@en ,
+                         "relative"@en ;
+           skos:definition """Relatives are the manner in which two different or similar things may be connected or related. All of these relationships are dyadic.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+           skos:editorialNote "From CP 3.136: \"The first division of relatives is, of course, into simple relatives and conjugatives. The most fundamental divisions of simple relatives are based on the distinction between elementary relatives of the form (A:A), and those of the form (A:B). These are divisions in regard to the amount of opposition between relative and correlative.\""@en ,
+                              """This entire branch likely requires further attention and refinement. A key source for this possible change is CSP's lengthy discussion on 'dyadic relations' (see further CP 3.571).
+
+Under that dichotomous scheme, all of the dyadic relations are presented in a dichotomous manner. Further, Concurrents and Opponents are further down the dyadic relation change, all being 'Existential Relations'. 
+
+This possible review will require extensive study."""@en ;
+           skos:prefLabel "relatives"@en ;
+           skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Similarity
+:Similarity rdf:type owl:Class ;
+            rdfs:subClassOf :Associative ;
+            skos:altLabel "resemblance"@en ,
+                          "similar"@en ;
+            skos:definition """Similarity is that which resembles something else, as in quality, form, etc. Similarity is often qualified by the nature, traits or characteristics in common between the two compared entities.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+            skos:editorialNote "From CP 1.567: \"Similarity, on the other hand, is of quite a different nature. The forms of the words similarity and dissimilarity suggest that one is the negative of the other, which is absurd, since everything is both similar and dissimilar to everything else. Two characters, being of the nature of ideas, are, in a measure, the same. Their mere existence constitutes a unity of the two, or, in other words, pairs them. Things are similar and dissimilar so far as their characters are so. We see, then, that the first category of relations embraces only similarities; while the second, embracing all other relations, may be termed dynamical relations.\""@en ;
+            skos:prefLabel "similarity"@en ;
+            skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-SimpleRelative
+:SimpleRelative rdf:type owl:Class ;
+                rdfs:subClassOf :Pluralness ;
+                skos:altLabel "A simple relative is a binary relationship where a pair of things stands in a particular relation. Simple relatives may be equivalent relationships or partially equivalent relationships, with various kinds of order."@en ,
+                              "binary relationship"@en ,
+                              "correspondence"@en ,
+                              "dyadic relationship"@en ;
+                skos:prefLabel "simple relative"@en ;
+                skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-SocialSystems
+:SocialSystems rdf:type owl:Class ;
+               rdfs:subClassOf :Systems ;
+               owl:disjointWith [ rdf:type owl:Class ;
+                                  owl:unionOf ( :AudioInfo
+                                                :BiologicalProcesses
+                                                :Drugs
+                                                :FoodDrink
+                                                :Times
+                                                :AtomsElements
+                                                :NaturalPhenomena
+                                                :OrganicChemistry
+                                                :Prokaryotes
+                                                :ProtistsFungus
+                                                :Eukaryotes
+                                                :Plants
+                                                :Animals
+                                                :Geopolitical
+                                              )
+                                ] ;
+               skos:altLabel "social process"@en ,
+                             "social processes"@en ,
+                             "social system"@en ;
+               skos:definition """A social system is a network of relationships constituting a coherent whole that exist between individuals, groups, and institutions. The term refers to the formal structure of role and status that can form in a small, stable group. An individual may belong to multiple social systems at once; examples of social systems include nuclear family units, communities, cities, nations, college campuses, corporations, and industries. The organization and definition of groups within a social system depend on various shared characteristics such as location, socioeconomic status, race, religion, societal function, or other distinguishable features, and may cover perspectives on issues held by different groups.
+
+Social systems attempt to capture the complex systems and processes pursued by humans as social groups."""@en ;
+               skos:editorialNote "This is the tie-in point for the SocialSystems SuperType (ST); it connects to a relatively minor typology."@en ;
+               skos:prefLabel "social systems"@en ;
+               skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-States
+:States rdf:type owl:Class ;
+        rdfs:subClassOf :SingleEntities ;
+        skos:altLabel "condition"@en ,
+                      "state"@en ;
+        skos:definition """A state is a condition or of circumstances applying at any given time. States are possible characteristics of entities, components, compound entities, or kinds. Often states are one of multiple possible conditions potentially applicable to the object at hand.
+
+For examples, on-off are two possible states for electrical circuits. Life stages are possible states for living things. Or, gas, liquid or solid states may characterize matter."""@en ;
+        skos:prefLabel "states"@en ;
+        skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-SubstantialForm
+:SubstantialForm rdf:type owl:Class ;
+                 rdfs:subClassOf :Real ;
+                 skos:altLabel "essential character"@en ;
+                 skos:definition """Substantial forms are the forms or ideas that organize matter and make it intelligible. Substantial forms are the source of properties, order, unity, identity, and information about objects.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+                 skos:editorialNote "From Aristotle"@en ;
+                 skos:prefLabel "substantial form"@en ;
+                 skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Subsumptive
+:Subsumptive rdf:type owl:Class ;
+             rdfs:subClassOf :Conjunctives ;
+             skos:altLabel "hiearchical"@en ,
+                           "is-a"@en ,
+                           "subsumption"@en ,
+                           "types"@en ,
+                           "typical"@en ;
+             skos:definition """Subsumption is a 'is-a' relationship between two things where one thing is a sub-class or instance of the other thing, which is its super-class or type, respectively. Anything that satisfies the sub-class or instance specification also satisfies the super-class or type specification. In this way, things become specifics of the general.
+
+When referring to a parent thing, the synonym is typical, which relates to types, wherein multiple, shared attributes comprise the types. The shared characteristics of an individual to other individuals in its class constitutes its typicality."""@en ;
+             skos:prefLabel "subsumptive"@en ;
+             skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-Thisness
+:Thisness rdf:type owl:Class ;
+          rdfs:subClassOf :FirstMonads ;
+          skos:altLabel "haecceity"@en ,
+                        "hecceity"@en ,
+                        "manifestation"@en ,
+                        "secundan"@en ,
+                        "thatness"@en ;
+          skos:definition "Thisness (or thatness) is what kind of thing something is. Thisness, which applies to an undifferentiated individual, is the discrete qualities, properties or characteristics of a thing that make it a particular thing. Haecceity is a person's or object's \"thisness,\" the individualising difference. Haecceity denotes the discrete qualities, properties or characteristics of a thing which make it a particular thing."@en ;
+          skos:editorialNote "From CP 3.434: \"A sign which denotes a thing by forcing it upon the attention is called an index. An index does not describe the qualities of its object. An object, in so far as it is denoted by an index, having thisness, and distinguishing itself from other things by its continuous identity and forcefulness, but not by any distinguishing characters, may be called a hecceity. A hecceity in its relation to the assertion is a subject thereof.\""@en ,
+                             "See https://en.wikipedia.org/wiki/Haecceity. Hecceity is the term used by CSP."@en ,
+                             "Thisness comes about in contrast to otherness, which is why it is secundan."@en ;
+          skos:prefLabel "thisness"@en ;
+          skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-TimeTypes
+:TimeTypes rdf:type owl:Class ;
+           rdfs:subClassOf :Constituents ;
+           skos:altLabel "time types"@en ;
+           skos:definition "This grouping of SuperTypes is for all concepts with a time-related component, such as an activity that spans over time, an event which has a beginning and an end, or general time-related concepts."@en ;
+           skos:editorialNote "This is the tie-in point for the TimeTypes SuperType (ST); it connects to a relatively minor typology."@en ;
+           skos:prefLabel "time types"@en ;
+           skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-TopicsCategories
+:TopicsCategories rdf:type owl:Class ;
+                  rdfs:subClassOf :ConceptualSystems ;
+                  owl:disjointWith [ rdf:type owl:Class ;
+                                     owl:unionOf ( :BiologicalProcesses
+                                                   :LocationPlace
+                                                   :Society
+                                                   :Persons
+                                                   :Prokaryotes
+                                                   :Geopolitical
+                                                 )
+                                   ] ;
+                  skos:altLabel "categories"@en ,
+                                "category"@en ,
+                                "topic"@en ,
+                                "topics"@en ;
+                  skos:definition "This largely subject-oriented SuperType is a means for using controlled vocabularies and classification schemes for characterizing what content \"is about\". The key constituents of this category are Types, Classifications, Concepts, CCC, and controlled vocabularies "@en ;
+                  skos:editorialNote "The OpenCyc topics goe here, starting with CycVocabularyTopLevelTopic (http://localhost:3602/cgi-bin/cg?cb-cf&c89438)."@en ,
+                                     "This is the tie-in point for the TopicsCategories SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+                  skos:prefLabel "topics categories"@en ;
+                  skos:scopeNote "A Secondness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#2-WrittenInfo
+:WrittenInfo rdf:type owl:Class ;
+             rdfs:subClassOf :Information ;
+             owl:disjointWith [ rdf:type owl:Class ;
+                                owl:unionOf ( :AreaRegion
+                                              :BiologicalProcesses
+                                              :Drugs
+                                              :Facilities
+                                              :FoodDrink
+                                              :LocationPlace
+                                              :SituationTypes
+                                              :Times
+                                              :AtomsElements
+                                              :NaturalMatter
+                                              :OrganicChemistry
+                                              :Persons
+                                              :Prokaryotes
+                                              :ProtistsFungus
+                                              :Eukaryotes
+                                              :LivingThings
+                                              :NaturalSubstances
+                                              :Organizations
+                                              :Places
+                                              :Plants
+                                              :Agents
+                                              :Animals
+                                              :Chemistry
+                                              :Diseases
+                                              :Geopolitical
+                                            )
+                              ] ;
+             skos:definition "This SuperType includes any general material written by humans including books, blogs, articles, manuscripts, but any written information conveyed via text."@en ;
+             skos:prefLabel "written information"@en ;
+             skos:scopeNote "A Secondness"@en ,
+                            "This is the tie-in point for the WrittenInfo SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3D-Dimensions
+:D-Dimensions rdf:type owl:Class ;
+              rdfs:subClassOf :SpaceRegions ;
+              skos:altLabel "3D"@en ,
+                            "3d dimension"@en ;
+              skos:definition "Dimensions represent any of the bounded conditions related to combinations of 3D space and time dimensions."@en ;
+              skos:prefLabel "3D Dimensions"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-AccidentalForm
+:AccidentalForm rdf:type owl:Class ;
+                rdfs:subClassOf :Real ;
+                skos:altLabel "non-essential"@en ;
+                skos:definition """Accidental forms are the non-essential properties of things; that is, properties that the thing could lose or gain without changing its essential nature. For example, the red color of a ball is an accidental form of a ball in that the ball could be changed to green or blue without losing its essential character.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+                skos:editorialNote "From Aristotle"@en ;
+                skos:prefLabel "accidental form"@en ;
+                skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Agents
+:Agents rdf:type owl:Class ;
+        rdfs:subClassOf :OrganicMatter ;
+        owl:disjointWith [ rdf:type owl:Class ;
+                           owl:unionOf ( :AudioInfo
+                                         :BiologicalProcesses
+                                         :Drugs
+                                         :FoodDrink
+                                         :Times
+                                         :VisualInfo
+                                         :AVInfo
+                                         :AtomsElements
+                                         :Information
+                                         :NaturalMatter
+                                         :NaturalPhenomena
+                                         :OrganicChemistry
+                                         :Prokaryotes
+                                         :ProtistsFungus
+                                         :NaturalSubstances
+                                         :Plants
+                                         :WrittenInfo
+                                         :Chemistry
+                                         :Diseases
+                                         :StructuredInfo
+                                       )
+                         ] ;
+        skos:altLabel "agent"@en ,
+                      "animate agent"@en ;
+        skos:definition "The Agents SuperType is for all beings, single or acting as groups, that can express and act upon desires or beliefs. Agents may be individual Persons, general Organizations, or Geopolitical entities."@en ;
+        skos:editorialNote "This is the tie-in point for the Agents SuperType (ST); it connects to a relatively minor typology."@en ;
+        skos:prefLabel "agents"@en ;
+        skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Animals
+:Animals rdf:type owl:Class ;
+         rdfs:subClassOf :Eukaryotes ;
+         owl:disjointWith [ rdf:type owl:Class ;
+                            owl:unionOf ( :AreaRegion
+                                          :AudioInfo
+                                          :BiologicalProcesses
+                                          :Drugs
+                                          :EconomicSystems
+                                          :EventTypes
+                                          :Facilities
+                                          :LocationPlace
+                                          :Society
+                                          :Times
+                                          :VisualInfo
+                                          :AVInfo
+                                          :AtomsElements
+                                          :NaturalMatter
+                                          :NaturalPhenomena
+                                          :OrganicChemistry
+                                          :Prokaryotes
+                                          :ProtistsFungus
+                                          :NaturalSubstances
+                                          :Organizations
+                                          :Places
+                                          :Plants
+                                          :SocialSystems
+                                          :WrittenInfo
+                                          :Chemistry
+                                          :Geopolitical
+                                          :StructuredInfo
+                                        )
+                          ] ;
+         skos:altLabel "aniimal"@en ;
+         skos:definition "This large SuperType includes all animal types, including specific animal types and vertebrates, invertebrates, insects, crustaceans, fish, reptiles, amphibia, birds, mammals, and animal body parts. Animal parts are specifically included. Also, groupings of such animals are included. Humans, as an animal, are included (versus as an individual Person). Diseases are specifically excluded. Animals have many of the similar overlaps to Plants. However, in addition, there are more terms for animal groups, animal parts, animal secretions, etc. Also Animals can include some human traits (posture, dead animal, etc)"@en ;
+         skos:editorialNote "This is the tie-in point for the Animals SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+         skos:prefLabel "animals"@en ;
+         skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Associative
+:Associative rdf:type owl:Class ;
+             rdfs:subClassOf :Indicatives ;
+             skos:definition """Associative, or association, is when two or more ideas or things exhibit an \"attraction\" between them due to likeness or similarity or some other correspondence. An associative monad is not amenable to a logical assertion.
+
+Associatives are the juxtaposition of a different thing to a given thing to indicate a relationship of some nature. Associatives must be between two or more objects. Since the degree of association can not be defined, no inference can be made about associations. Sameness or being a member of the same type is specifically excluded from this definition
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+             skos:editorialNote "Addition and multiplication are associative operations."@en ,
+                                "In CP 1.270, CSP calls 'association' \"an attraction between ideas,\" analogous to gravitation."@en ;
+             skos:prefLabel "associative"@en ;
+             skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Associatives
+:Associatives rdf:type owl:Class ;
+              rdfs:subClassOf :RepresentationTypes ;
+              skos:altLabel "adjacency"@en ,
+                            "associations"@en ,
+                            "associative"@en ,
+                            "proximity"@en ;
+              skos:definition "A situational or contextual assertion of proximity, affiliation or adjacency of the subject with regard to any contiguity."@en ;
+              skos:editorialNote "Concepts in this type include see also, lists, links (incoming + outgoing), associations, likenesses, resemblances."@en ;
+              skos:prefLabel "associatives"@en ;
+              skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Chemistry
+:Chemistry rdf:type owl:Class ;
+           rdfs:subClassOf :NaturalMatter ;
+           owl:disjointWith [ rdf:type owl:Class ;
+                              owl:unionOf ( :AreaRegion
+                                            :AudioInfo
+                                            :LocationPlace
+                                            :Society
+                                            :Times
+                                            :Persons
+                                            :Prokaryotes
+                                            :ProtistsFungus
+                                            :KnowledgeDomains
+                                            :Organizations
+                                            :Places
+                                            :WrittenInfo
+                                            :Agents
+                                            :Animals
+                                            :Diseases
+                                            :Geopolitical
+                                            :StructuredInfo
+                                          )
+                            ] ;
+           skos:definition "This SuperType is the category for chemical bonds, chemical composition groupings, and the like. It is formed by what is not a natural substance or living thing (organic) substance. Organic Chemistry and Biological Processes are, by definition, separate SuperTypes. This Chemistry SuperType thus includes inorganic chemistry, physical chemistry, analytical chemistry, materials chemistry, nuclear chemistry, and theoretical chemistry."@en ;
+           skos:editorialNote "This is the tie-in point for the Chemistry SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+           skos:prefLabel "chemistry"@en ;
+           skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Complex
+:Complex rdf:type owl:Class ;
+         rdfs:subClassOf :Quantity ;
+         skos:definition "A complex quantity is one whose determinations can differ from others in different linear respects."@en ;
+         skos:editorialNote "See CP 4.664."@en ;
+         skos:prefLabel "complex quantity"@en ;
+         skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-ComplexEntities
+:ComplexEntities rdf:type owl:Class ;
+                 rdfs:subClassOf :Entities ;
+                 skos:altLabel "complex entity"@en ,
+                               "whole"@en ;
+                 skos:definition """A complex entity is a nameable, discrete thing, comprised itself of more than one individual. These individual parts are not all of the same kind, which are better known as classes or types.
+
+Many organizations and products, as examples, may be complex entities."""@en ;
+                 skos:prefLabel "complex entities"@en ;
+                 skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-CompoundEntities
+:CompoundEntities rdf:type owl:Class ;
+                  rdfs:subClassOf :ComplexEntities ;
+                  skos:altLabel "compound entity"@en ,
+                                "unit"@en ,
+                                "units"@en ;
+                  skos:prefLabel "A compound entity is an integral individual made up of multiple parts or individuals of different kinds working together as a unit. Machines and living bodies are two examples of a compound entity."@en ,
+                                 "compound entities"@en ;
+                  skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Conditional
+:Conditional rdf:type owl:Class ;
+             rdfs:subClassOf :Connective ;
+             skos:altLabel "conditional operation"@en ;
+             skos:definition """A conditional, or ternary, operation is an n-ary operation with n = 3. A ternary operation on a set A takes any given three elements of A and combines them to form a single element of A.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+             skos:prefLabel "conditional"@en ;
+             skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Conjugative
+:Conjugative rdf:type owl:Class ;
+             rdfs:subClassOf :Pluralness ;
+             skos:altLabel "join"@en ;
+             skos:definition "Any entity formed by joining two or more smaller entities together; to join together."@en ;
+             skos:prefLabel "conjugative"@en ;
+             skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Conjunctives
+:Conjunctives rdf:type owl:Class ;
+              rdfs:subClassOf :Relatives ;
+              skos:altLabel "and"@en ,
+                            "conjunction"@en ,
+                            "conjunctive"@en ;
+              skos:definition """'And' is the truth-functional operator of logical conjunction, and acts to assign (assert) an attribute to an entity.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+              skos:prefLabel "conjunctives"@en ;
+              skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Connective
+:Connective rdf:type owl:Class ;
+            rdfs:subClassOf :Conjunctives ;
+            skos:altLabel "dynamical"@en ,
+                          "logic function"@en ,
+                          "operator"@en ,
+                          "operators"@en ,
+                          "propositional logic"@en ;
+            skos:definition """A logical connective (also called a logical operator) is a symbol or word used to connect two or more sentences (of either a formal or a natural language) in a grammatically valid way, such that the sense of the compound sentence produced depends only on the original sentences.
+
+The most common logical connectives are binary connectives (also called dyadic connectives) which join two sentences which can be thought of as the function's operands. Also commonly, negation is considered to be a unary connective.
+
+Logical connectives along with quantifiers are the two main types of logical constants used in formal systems such as propositional logic and predicate logic. Semantics of a logical connective is often, but not always, presented as a truth function.
+
+A logical relation is part of a formal system (together with defined semantics) in the form of model-theoretic interpretation that assigns truth values to sentences of the formal language; that is, formulae that contain no free variables. A logic is sound if all sentences that can be derived are true in the interpretation, and complete if, conversely, all true sentences can be derived.
+
+A logical connective is similar to but not equivalent to a conditional operator.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+            skos:editorialNote "For additional background, see https://en.wikipedia.org/wiki/Logical_connective and https://en.wikipedia.org/wiki/Truth_function."@en ;
+            skos:prefLabel "logical connective"@en ;
+            skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-ContextualAttributes
+:ContextualAttributes rdf:type owl:Class ;
+                      rdfs:subClassOf :AttributeTypes ;
+                      skos:altLabel "contextual"@en ,
+                                    "contextual attribute"@en ,
+                                    "situational"@en ;
+                      skos:definition "Circumstances or placements of single entities or events (particulars) that help characterize it."@en ;
+                      skos:editorialNote "Concepts in this type include space, time, continuity, contiguous, smooth, otherness, ratings, situational (w/ respect to A), sensible, contiguous, all placements thereto, derivative, classificatory, rankings."@en ,
+                                         "This is the tie-in point for the ContextualAttributeTypes SuperType (ST). By design and convention, ContextualAttributeTypes are NOT EntityTypes. ContextualAttributeTypes connects to a relatively major typology with a comparatively large number of contextual attributes."@en ;
+                      skos:prefLabel "contextual attributes"@en ;
+                      skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Contiguity
+:Contiguity rdf:type owl:Class ;
+            rdfs:subClassOf :Associative ;
+            skos:altLabel "proximity"@en ;
+            skos:definition """Association by contiguity means proximity of things in either time or space.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+            skos:editorialNote "From CP 4.87: \"Phenomena that inward force puts together appear similar; phenomena that outward force puts together appear contiguous.\""@en ;
+            skos:prefLabel "contiguity"@en ;
+            skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Continuants
+:Continuants rdf:type owl:Class ;
+             rdfs:subClassOf :SingleEntities ;
+             skos:altLabel "continuant"@en ;
+             skos:definition "A thing of a continuous nature that retains its identity even though its states and relations may change."@en ;
+             skos:editorialNote """SpaceTime is a likely included here. SpaceTime combines the three dimensions of space and the dimension of time into an interwoven continuum.
+
+See http://www.textlog.de/4279-5.html for triadic discussion of space-time."""@en ;
+             skos:prefLabel "continuants"@en ;
+             skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Continuous
+:Continuous rdf:type owl:Class ;
+            rdfs:subClassOf :Events ;
+            skos:altLabel "continua"@en ,
+                          "continuum"@en ,
+                          "durative"@en ,
+                          "dynamics"@en ,
+                          "inconstant"@en ,
+                          "inconstants" ,
+                          "occurants"@en ,
+                          "perdurants"@en ;
+            skos:definition """A continuous event or thing is one that varies over time or space, respectively, and which may be approximated by a function. Though different individuals may have different continuous quantities at any given moment, across all instances the distribution can be modeled as continuous.
+
+By definition, continuous quantities are not discrete."""@en ;
+            skos:editorialNote """SpaceTime is a likely sub-category here. SpaceTime combines the three dimensions of space and the dimension of time into an interwoven continuum.
+
+See http://www.textlog.de/4279-5.html for triadic discussion of space-time."""@en ;
+            skos:prefLabel "continuous"@en ;
+            skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Diseases
+:Diseases rdf:type owl:Class ;
+          rdfs:subClassOf :LivingThings ;
+          skos:altLabel "disease"@en ,
+                        "pathology"@en ;
+          skos:definition "Diseases are atypical or unusual or unhealthy conditions for (mostly human) living things, generally known as conditions, disorders, infections, diseases or syndromes. Diseases only affect living things and sometimes are caused by living things. This SuperType also includes impairments, disease vectors, wounds and injuries, and poisoning."@en ;
+          skos:editorialNote "This is the tie-in point for the Diseases SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+          skos:prefLabel "diseases"@en ;
+          skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-EmergentKnowledge
+:EmergentKnowledge rdf:type owl:Class ;
+                   rdfs:subClassOf :Methodeutic ;
+                   skos:altLabel "emergence"@en ,
+                                 "new knowledge"@en ;
+                   skos:definition """Knowledge emergence is the result of a process (the methodeutic) whereby new complex entities, principals of the real world, or discovery of new insights are made. The new knowledge so discovered then requires inspection for how it fits and interacts with the world, oft resulting in the emergence of new domains for inquiry. 
+
+Knowledge may also emerge when existing assumptions are tested and found to be incorrect. Thus, knowledge is always emerging and our understanding of the world is always fallible. But the discovery and the emergence of new knowledge is always available to any domain of inquiry.
+
+Emergence is central in theories of integrative levels and of complex systems. For instance, the phenomenon of life as studied in biology is an emergent property of chemistry and psychological phenomena emerge from the neurobiological phenomena of living things. Likewise, economic and legal phenomena emerge from psychology.
+
+In philosophy, emergence typically refers to emergentism. Almost all accounts of emergentism include a form of epistemic or ontological irreducibility to the lower levels. In the Peircean sense, the basis for emergence rests in the logic of semiosis and the triadic categories of Firstness, Secondness and Thirdness."""@en ;
+                   skos:editorialNote "This is the tie-in point for the EmergentKnowledge SuperType (ST); it connects to a relatively minor typology."@en ;
+                   skos:prefLabel "emergent knowledge"@en ;
+                   skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Entities
+:Entities rdf:type owl:Class ;
+          rdfs:subClassOf :Particulars ;
+          skos:altLabel "entity"@en ,
+                        "instance"@en ,
+                        "instances"@en ;
+          skos:definition "Entities are the various ways that individuals (or particulars) may be expressed and understood. Entities may be qualitative, actual, or conceptual. The awareness of entities begins in an instant. The awareness of entities is an event, as is the cognition about them."@en ;
+          skos:prefLabel "entities"@en ;
+          skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Eternal
+:Eternal rdf:type owl:Class ;
+         rdfs:subClassOf :Time ;
+         skos:altLabel "always"@en ,
+                       "permanent"@en ;
+         skos:definition "Eternal is lasting forever, unending."@en ;
+         skos:editorialNote "See CP 1.427."@en ;
+         skos:prefLabel "eternal"@en ;
+         skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Fictional
+:Fictional rdf:type owl:Class ;
+           rdfs:subClassOf :Oneness ;
+           skos:altLabel "fiction"@en ,
+                         "imaginary"@en ,
+                         "not real"@en ;
+           skos:definition """Fictional is invented, imaginary or not real. Fictions exist in the mind or in concept, but are not real things in the world.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+           skos:prefLabel "fictional"@en ;
+           skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Form
+:Form rdf:type owl:Class ;
+      rdfs:subClassOf :Thisness ;
+      skos:altLabel "appearance"@en ,
+                    "congfiguration"@en ,
+                    "forms"@en ,
+                    "shape"@en ;
+      skos:definition "Form is the material transformation or appearance of matter; it is what is perceived about an object including shape, material, color and other perceptual properties. As an \"indecomposable\" this is the possibility or potential of form rather than actual form."@en ;
+      skos:prefLabel "form"@en ;
+      skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Forms
+:Forms rdf:type owl:Class ;
+       rdfs:subClassOf :SpaceTypes ;
+       skos:altLabel "form"@en ,
+                     "form types"@en ;
+       skos:definition "This SuperType category includes all aspects of the shapes that objects take in space; Forms is thus closely related to Shapes. The Forms SuperType is also the collection of natural cartographic features that occur on the surface of the Earth or other planetary bodies, as well as the form shapes that naturally occurring matter may assume. Positive examples include Mountain, Ocean, and Mesa. Artificial features such as canals are excluded. Most instances of these natural features have a fixed location in space."@en ;
+       skos:editorialNote "This is the tie-in point for the Forms SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+       skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-FunctionalComponents
+:FunctionalComponents rdf:type owl:Class ;
+                      rdfs:subClassOf :PartOfEntities ;
+                      skos:altLabel "functional component"@en ,
+                                    "sub-system"@en ;
+                      skos:definition "A functional component is a system of interacting or interdependent component parts forming a complex/intricate unit, but which still fulfills its essence as a part of a whole. For example, a heart is a functional component of many animals, or a transmission or engine are functional components of automobiles."@en ;
+                      skos:prefLabel "functional components"@en ;
+                      skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Geopolitical
+:Geopolitical rdf:type owl:Class ;
+              rdfs:subClassOf :Agents ;
+              skos:definition "The Geopolitical SuperType is for named places that have some informal or formal political (authorized) component. Important subcollections include Country, IndependentCountry, State_Geopolitical, City, and Province."@en ;
+              skos:editorialNote "This is the tie-in point for the Geopolitical SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en ;
+              skos:prefLabel "geopolitical"@en ;
+              skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Indicatives
+:Indicatives rdf:type owl:Class ;
+             rdfs:subClassOf :DyadicMonads ;
+             skos:altLabel "about"@en ,
+                           "indication"@en ,
+                           "indicative"@en ;
+             skos:definition """Indicatives are dyadic monads that relate two items together but do not enable or support logical assertions. Indicatives act as iconic or referential indexes or provide associations such as denotation or similarity. An indicative, like a pointing finger or an iconic image, directs attention to an object.
+
+Indicatives are any indicator, pointer, connecter, or reference between individuals that stands apart from the referent. Indicatives are not assertions, they are more like associations and indicators, and can not be reasoned over, but provide an alternative means to indicate a given thing.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+             skos:editorialNote "Pronouns are indicative words, such as: this, that, something, anything."@en ;
+             skos:prefLabel "indicatives"@en ;
+             skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Inherence
+:Inherence rdf:type owl:Class ;
+           rdfs:subClassOf :Attributives ;
+           skos:definition "An inherence dyad is one in which a quality (single monad) is matched with a subject."@en ;
+           skos:prefLabel "inherence"@en ;
+           skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-InherentialDyad
+:InherentialDyad rdf:type owl:Class ;
+                 rdfs:subClassOf :MonadicDyads ;
+                 skos:altLabel "attribute"@en ;
+                 skos:definition "An inherential dyad is one where a monad is matched with a non-monadic subject. An inherential dyad is also known as an intrinsic attribute."@en ;
+                 skos:editorialNote "Though an inherential dyad strongly resembles an essential dyad, \"It is, after all, however, radically different from the essential dyad, because the quality of the subject of inherence is a mere accident of that individual. Inherence may be regarded from another point of view. Namely, the individual subject may be conceived as brought into relation to itself by the possession of the attribute.\" (from CP 1.464)"@en ;
+                 skos:prefLabel "inherential dyad"@en ;
+                 skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Intrinsic
+:Intrinsic rdf:type owl:Class ;
+           rdfs:subClassOf :Inherence ;
+           skos:definition """An intrinsic attribute is shown by reaction; it is a quality that arises from the thing as a result of an action (perception or exertion). It is a character that is embodied or integral to the thing at hand. An intrinsic attribute is of the nature of a given thing; it is a necessary inherence.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+           skos:editorialNote "See CP 1.563."@en ;
+           skos:prefLabel "intrinsic"@en ;
+           skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-LearningProcesses
+:LearningProcesses rdf:type owl:Class ;
+                   rdfs:subClassOf :ConceptualSystems ;
+                   skos:altLabel "learning"@en ,
+                                 "learning process"@en ;
+                   skos:definition "Learning processes are the ways to acquire new, or to modify or reinforce, existing knowledge, behaviors, skills, values, or preferences and may involve synthesizing different types of information."@en ;
+                   skos:editorialNote "This is the tie-in point for the LearningProcesses SuperType (ST); it connects to a relatively minor typology."@en ;
+                   skos:prefLabel "learning processes"@en ;
+                   skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Magnitudes
+:Magnitudes rdf:type owl:Class ;
+            rdfs:subClassOf :Values ;
+            skos:altLabel "amount"@en ,
+                          "magnitude"@en ;
+            skos:definition "Magnitude is the size of a mathematical object, a property by which the object can be compared as larger or smaller than other objects of the same kind. More formally, an object's magnitude is an ordering (or ranking) of the class of objects to which it belongs."@en ;
+            skos:prefLabel "magnitudes"@en ;
+            skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Manifestations
+:Manifestations rdf:type owl:Class ;
+                rdfs:subClassOf :SuperTypes ;
+                skos:altLabel "manifestation"@en ;
+                skos:definition """This grouping of SuperTypes includes what might be termed perceived \"reality\", including substances and ideas and concepts. Manifestations are the various ways that substances or ideas and concepts may be expressed or perceived. 
+
+The three major subdivisions of Manifestation are Natural (inanimate) Matter, Organic (living and decomposed) Matter, and Symbolic (which are human works, ideas or information). Fictional things may also be manifestations of a symbolic type."""@en ;
+                skos:editorialNote "This is the tie-in point for the Manifestions SuperType (ST); it connects to a relatively minor typology."@en ;
+                skos:prefLabel "manifestations"@en ;
+                skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-MediativeRelations
+:MediativeRelations rdf:type owl:Class ;
+                    rdfs:subClassOf :RelationTypes ;
+                    skos:altLabel "genres"@en ,
+                                  "mediative relation"@en ,
+                                  "similarities"@en ;
+                    skos:definition "Relationships of relevance, meaning or explanation – namely, thirdness – about subjects and types."@en ;
+                    skos:editorialNote "Concepts in this type include concepts, generalities, similarity, genres, aspects, comparison, performance, thought, triadic, agreement/difference, placement in space/time (contiguity), conditional, reasoning, classification."@en ,
+                                       "This is the tie-in point for the MediativelRelationTypes SuperType (ST). By design and convention, MediativeRelationTypes are NOT EntityTypes. MediativeRelationTypes connects to a relatively major typology with a comparatively large number of mediative relations."@en ;
+                    skos:prefLabel "mediative relations"@en ;
+                    skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Mentation
+:Mentation rdf:type owl:Class ;
+           rdfs:subClassOf :TriadicMonads ;
+           skos:altLabel "considering"@en ,
+                         "mentality"@en ,
+                         "thinking"@en ;
+           skos:definition """Mentation is the formation of concepts, ideas, thinking and any symbol formation or modification in the mind. Cognition is not an exact synomym or analog because mentation is not necessarily as structured or knowledge-oriented. Mentation is thought of any kind or nature.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+           skos:prefLabel "mentation"@en ;
+           skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Methodeutic
+:Methodeutic rdf:type owl:Class ;
+             rdfs:subClassOf :Systems ;
+             <http://purl.org/dc/elements/1.1/description> ""@en ,
+                                                           """The methodeutic, so coined by Charles S. Peirce to distinguish from common methods, is nonetheless the methodology and techniques for inquiry and knowledge development, expressed as the scientific method in its fullest form. Abductive reasoning and hypothesis generation are key aspects of the method, which involves, for any given domain, observing and questioning the facts and generalities of the domain in order to discover new knowledge. That new knowledge results from posing and testing hypotheses about the possible explanations for the observations and potentials.
+
+The methodeutic is the penultimate and last step in logical inquiry. The new knowledge generated as a result of the methodeutic then becomes the object of subsequent inspection and inquiry, with new hypotheses generated and new tests conducted. In this manner knowledge is discovered, confirmed or denied, which forms the basis for extensions and revisions to the current knowledge base."""@en ;
+             skos:altLabel "methods"@en ,
+                           "speculative rhetoric"@en ;
+             skos:definition "The methodeutic is the methodology and techniques for inquiry and knowledge development. Abductive reasoning and hypothesis generation are key aspects of the methodeutic."@en ;
+             skos:editorialNote """No. 27 of Methodeutic. The first business of this memoir is to show the precise nature of methodeutic; how it differs from critic; how, although it considers not what is admissable but what is advantageous, it is nevertheless a purely theoretical study, and not an art; how it is from the most strictly theoretical point of view, an absolutely essential and distinct department of logical inquiry; and how upon the other hand, it is readily made useful to a researcher into any science, even mathematics. It strongly resembles the purely mathematical part of political economy, which is also a theoretical study of advantages. Of the different classes of arguments, abductions are the only ones in which after they have been admitted to be just, it still remains to inquire whether they are advantageous. But since the whole business of heuretic, so far as its theory goes, falls under methodeutic, there is no kind of argumentation that methodeutic can pass over without notice. Nor is methodeutic confined to the consideration of arguments. On the contrary, its special subjects have always been understood to be the definition and division of terms. The formation of systems of propositions, although it has been neglected, should also evidently be included in methodeutic. In its method, methodeutic is less strict than critic.
+
+CSP 1902 | Carnegie Institution Correspondence | HP 2:1035; NEM 4:26"""@en ,
+                                "This is the tie-in point for the Methodeutic SuperType (ST); it connects to a relatively minor typology."@en ,
+                                "This node traces out all of the major sub-branches of the OpenCyc FieldsOfStudy. It should be reviewed to see if the upper portions can be aligned with Peirce's natural science classification (see https://en.wikipedia.org/wiki/Classification_of_the_sciences_%28Peirce%29)"@en ,
+                                """…Methodeutic, which is the last goal of logical study[,] is the theory of the advancement of knowledge of all kinds.
+
+CSP 1903 | Lecture I [R] | MS [R] 449:56"""@en ,
+                                """…one branch of logic is methodeutic, which should investigate the general principles upon which scientific studies should be carried on.
+
+CSP 1905 | Adirondack Summer School Lectures | MS [R] 1334:28"""@en ;
+             skos:prefLabel "methodeutic"@en ;
+             skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Pluralness
+:Pluralness rdf:type owl:Class ;
+            rdfs:subClassOf :FirstMonads ;
+            skos:altLabel "combination"@en ,
+                          "composition"@en ,
+                          "conceptual"@en ,
+                          "plurality"@en ,
+                          "tertian"@en ;
+            skos:definition "Pluralness is the idea of more than one, and is more than the idea of one in relation to another. As an \"indecomposable\", pluralness is the potential or possibility of a group or collection more than one or two, but is not an actual collection."@en ;
+            skos:editorialNote "From CP 1.297: \"In tertio there is no a priori reason why there should not be indecomposable elements which are what they are relatively to a second and a third, regardless of any fourth. Such, for example, is the idea of composition. We will call everything marked by being a third or medium of connection, between a first and second anything, tertian.\""@en ,
+                               "From CP 4.332: \"The general idea of plurality is involved in the fundamental concept of Thirdness, a concept without which there can be no suggestion of such a thing as logic, or such a character as truth. Plurality, therefore, is an idea much more fundamental than that of the ordinal place of a member of a linear series.\""@en ;
+            skos:prefLabel "pluralness"@en ;
+            skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Processes
+:Processes rdf:type owl:Class ;
+           rdfs:subClassOf :Continuous ;
+           skos:altLabel "process"@en ;
+           skos:definition "Processes are a series of activities or events that when combined can lead to particular outcomes. Often the activities or events need to occur in a set order or through set proportions in order for the outcome to occur. Processes may be natural (such as erosion or weathering or sunlight) or biological (such as growth, reproduction or death) or agentivie (such as industrial production, creating works or transporting goods)."@en ;
+           skos:prefLabel "processes"@en ;
+           skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Relational
+:Relational rdf:type owl:Class ;
+            rdfs:subClassOf :Suchness ;
+            skos:altLabel "connection"@en ;
+            skos:definition "A relational is something that brings two monads together. In this \"indecomposable\" sense, a relational is a possible or potential something to bring or connect or relate two items together; no actual relationship is realized."@en ;
+            skos:prefLabel "relational"@en ;
+            skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-RepresentationTypes
+:RepresentationTypes rdf:type owl:Class ;
+                     rdfs:subClassOf :Predications ;
+                     skos:altLabel "annotation"@en ,
+                                   "annotations"@en ,
+                                   "indexical"@en ,
+                                   "indexical type"@en ,
+                                   "indexicals"@en ,
+                                   "metadata"@en ,
+                                   "representations" ,
+                                   "signifiers" ;
+                     skos:definition """Representations are signs, and the means by which we point to, draw or direct attention to, or designate, denote or describe a particular object, entity, event, type or general.  A representational relationship has the form of re:A. Representations can be designative of the subject, that is, be icons or symbols (including labels, definitions, and descriptions). Representations may be indexes that more-or-less help situate or provide traceable reference to the subject. Or, representations may be associations, resemblances and likelihoods in relation to the subject, more often of indeterminate character.
+
+These representations have been categorized according to these distinctions and grouped and organized into types."""@en ;
+                     skos:editorialNote "Signifier is also a good preferred label, but is not used to avoid confusion with Saussure's semiotic terminology, which has a different grounding than CSP's version."@en ,
+                                        "This is the tie-in point for the RepresentationTypes SuperType (ST). By design and convention, RepresentationTypes are NOT EntityTypes."@en ;
+                     skos:prefLabel "representation types"@en ;
+                     skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-SpaceTypes
+:SpaceTypes rdf:type owl:Class ;
+            rdfs:subClassOf :Constituents ;
+            skos:altLabel "space types"@en ;
+            skos:definition "This category is a grouping of concepts related to the idea of \"space\" and locations and positions within that \"space\". Specific sub-groupings under the category include the definition and specification of 1D, 2D and 3D shapes; places, regions and locations within space; and forms that objects may take within \"space\"."@en ;
+            skos:editorialNote "This is the tie-in point for the SpaceTypes SuperType (ST); it connects to a relatively minor typology."@en ;
+            skos:prefLabel "space types"@en ;
+            skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-StructuredInfo
+:StructuredInfo rdf:type owl:Class ;
+                rdfs:subClassOf :Information ;
+                owl:disjointWith [ rdf:type owl:Class ;
+                                   owl:unionOf ( :AreaRegion
+                                                 :AudioInfo
+                                                 :BiologicalProcesses
+                                                 :Drugs
+                                                 :Facilities
+                                                 :FoodDrink
+                                                 :LocationPlace
+                                                 :Times
+                                                 :AtomsElements
+                                                 :NaturalMatter
+                                                 :OrganicChemistry
+                                                 :Persons
+                                                 :Prokaryotes
+                                                 :ProtistsFungus
+                                                 :Eukaryotes
+                                                 :LivingThings
+                                                 :NaturalSubstances
+                                                 :Organizations
+                                                 :Places
+                                                 :Plants
+                                                 :Agents
+                                                 :Animals
+                                                 :Chemistry
+                                                 :Diseases
+                                                 :Geopolitical
+                                               )
+                                 ] ;
+                skos:definition "This information SuperType is for all kinds of structured information and datasets, including computer programs, databases, files, Web pages and structured data that can be presented in tabular form."@en ;
+                skos:prefLabel "structured information"@en ;
+                skos:scopeNote "A Thirdness"@en ,
+                               "This is the tie-in point for the StructuredInfo SuperType (ST); it connects to a relatively major typology with a comparatively large number of Entity Types."@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-SuperTypes
+:SuperTypes rdf:type owl:Class ;
+            skos:altLabel "class"@en ,
+                          "classes"@en ,
+                          "general"@en ,
+                          "generals" ,
+                          "kind"@en ,
+                          "kinds"@en ,
+                          "type"@en ,
+                          "types"@en ;
+            skos:definition "SuperTypes are a collection of (mostly) similar Reference Concepts. Most of the SuperType classes have been designed to be (mostly) disjoint from the other SuperType classes. SuperTypes thus provide a higher-level of clustering and organization of Reference Concepts for use in user interfaces and for reasoning purposes."@en ;
+            skos:editorialNote "In Peircean (Charles Sanders Peirce) terms, these are 'Generals'"@en ,
+                               "SuperTypes include all of the types in the KBpedia Knowledge Ontology (KKO). The types themselves are organized into typologies, segregated by these SuperTypes as placed under this branch. Most of the typologies (especially those marked as 'major' ones) are disjoint (non-overlapping) with one another. This disjointedness is a key structural aspect in being able to reason and slice-and-dice the entire KBpedia knowledge space."@en ,
+                               """Two concepts at sufficient level of generality and seemingly appropriate to this Generals branch, but which are NOT presently listed are:
+
+    Logic
+    Belief"""@en ;
+            skos:prefLabel "SuperTypes"@en ;
+            skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Symbol
+:Symbol rdf:type owl:Class ;
+        rdfs:subClassOf :Representation ;
+        skos:altLabel "symbols"@en ;
+        skos:definition """A Symbol is a sign which refers to the Object that it denotes by virtue of a law, usually an association of general ideas, which operates to cause the Symbol to be interpreted as referring to that Object. (from CP 2.249)
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+        skos:prefLabel "symbol"@en ;
+        skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Symbolic
+:Symbolic rdf:type owl:Class ;
+          rdfs:subClassOf :Manifestations ;
+          skos:definition "This grouping of SuperTypes is for all works, ideas, information and concepts resulting from symbolic human (and artificial agent) cognition."@en ;
+          skos:editorialNote "This is the tie-in point for the Symbolic SuperType (ST); it connects to a relatively minor typology."@en ;
+          skos:prefLabel "symbolic"@en ;
+          skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Systems
+:Systems rdf:type owl:Class ;
+         rdfs:subClassOf :Symbolic ;
+         skos:altLabel "system"@en ;
+         skos:definition "Systems are ongoing processes of human- or cognitive-related effort. This SuperType is a grouping of such individual supertypes."@en ;
+         skos:editorialNote "This is the tie-in point for the Systems SuperType (ST); it connects to a relatively minor typology."@en ;
+         skos:prefLabel "systems"@en ;
+         skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-Thought
+:Thought rdf:type owl:Class ;
+         rdfs:subClassOf :Action ;
+         skos:definition "Thought is a sign created in the mind."@en ;
+         skos:prefLabel "thought"@en ;
+         skos:scopeNote "A Thirdness"@en .
+
+
+###  http://kbpedia.org/ontologies/kko#3-TriadicMonads
+:TriadicMonads rdf:type owl:Class ;
+               rdfs:subClassOf :Monads ;
+               skos:altLabel "combination"@en ,
+                             "thought"@en ,
+                             "triadic monad"@en ;
+               skos:definition """Triadic monads are \"indecomposable\" elements that capture the ideas of combination, thought, mediation, and signs characteristic of Thirdness. Like all monads, they are possibles or potentials, and not actually realized in any way. They are the possible ways that such three-way relationships, or generals, might be understood in and of themselves, in isolation without respect to any other or contrast.
+
+As an \"indecomposable,\" this category should be understood as the potential or possibility of this monad and not representative of the actual thing."""@en ;
+               skos:prefLabel "triadic monads"@en ;
+               skos:scopeNote "A Thirdness"@en .
+
+
+###  http://www.w3.org/2004/02/skos/core#Concept
+skos:Concept rdf:type owl:Class .
+
+
+###  Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi

--- a/apps/owl-reasoner/src/owl_reasoner/reasoner.py
+++ b/apps/owl-reasoner/src/owl_reasoner/reasoner.py
@@ -10,6 +10,8 @@ Pure (no HTTP) so it is trivially testable; the service wrapper + graph pull liv
 """
 from __future__ import annotations
 
+from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 from rdflib import OWL, RDF, RDFS, Graph
@@ -31,19 +33,44 @@ except Exception:  # pragma: no cover
 # OWL2-RL is the profile owlrl's OWLRL_Semantics implements — expose the standard profile name as an alias.
 _PROFILE_ALIASES = {"owl2rl": "owlrl", "owl2-rl": "owlrl", "owl": "owlrl"}
 
+# The KKO upper ontology (KBpedia Knowledge Ontology), vendored as package data so it ships in the image.
+_KKO_PATH = Path(__file__).resolve().parent / "data" / "kko-2.10.n3"
+
+
+@lru_cache(maxsize=1)
+def _kko_tbox() -> Graph:
+    """The KKO TBox (168 classes / 167 rdfs:subClassOf), parsed once and cached. Returns an empty graph
+    if the vendored file is missing, so ``with_kko`` degrades to a no-op rather than failing."""
+    g = Graph()
+    try:
+        # the .n3 is Turtle-compatible; parse as turtle to avoid rdflib's noisy N3-parser deprecations.
+        g.parse(_KKO_PATH.as_posix(), format="turtle")
+    except Exception:  # pragma: no cover — missing/parse issue must never take reasoning down
+        pass
+    return g
+
 
 def reason(turtle: str, shapes: str | None = None, inference: str = "rdfs",
-           limit: int = 100, explain: bool = False) -> dict[str, Any]:
+           limit: int = 100, explain: bool = False, with_kko: bool = False) -> dict[str, Any]:
     """Compute entailments (+ optional SHACL validation) over a Turtle graph.
 
     inference: 'rdfs' | 'owlrl'/'owl2rl' | 'both' | 'none'. Returns input/entailed counts, a sample of the
     NEW (derived) triples, optional per-triple JUSTIFICATIONS (SOUND proof trees grounded in asserted facts,
     plus honest coverage — not the "why" incumbents' opaque reasoners hide), and, with shapes, the SHACL report.
+
+    with_kko: merge the full KKO upper ontology (the vendored TBox) before closure, so data typed with
+    kko: classes gets subClassOf transitivity + type propagation WITHOUT the caller inlining the axioms.
     """
     inference = _PROFILE_ALIASES.get(inference, inference)
     g = Graph()
     g.parse(data=turtle, format="turtle")
-    baseline = set(g)  # to diff out the entailments
+    kko_tbox_triples = 0
+    if with_kko:
+        tbox = _kko_tbox()
+        for t in tbox:
+            g.add(t)
+        kko_tbox_triples = len(tbox)
+    baseline = set(g)  # to diff out the entailments (the KKO TBox is baseline — never counted as entailed)
     n_in = len(baseline)
 
     mode = inference if _HAVE_OWLRL else "unavailable"
@@ -60,6 +87,7 @@ def reason(turtle: str, shapes: str | None = None, inference: str = "rdfs",
         "input_triples": n_in,
         "entailed_triples": len(entailed),
         "inference": mode,
+        "kko_tbox": {"loaded": with_kko, "triples": kko_tbox_triples},
         "profile": {"rdfs": "RDFS", "owlrl": "OWL 2 RL", "both": "OWL 2 RL + RDFS", "none": "none"}.get(mode, mode),
         # proof-carrying: each entailed triple is a derivation over stated facts + the ontology
         "entailments": [f"{_c(s)} {_c(p)} {_c(o)}" for (s, p, o) in entailed[:limit]],

--- a/apps/owl-reasoner/src/owl_reasoner/server.py
+++ b/apps/owl-reasoner/src/owl_reasoner/server.py
@@ -33,6 +33,7 @@ class ReasonRequest(BaseModel):
     shapes: str | None = None
     inference: str = "rdfs"        # 'rdfs' | 'owlrl'/'owl2rl' | 'both' | 'none'
     explain: bool = False          # emit per-entailment justifications (rule + premises)
+    with_kko: bool = False         # merge the KKO upper-ontology TBox before closure (entail over KKO)
 
 
 @app.get("/healthz")
@@ -42,7 +43,7 @@ def healthz() -> dict[str, Any]:
 
 @app.post("/reason")
 def reason_endpoint(req: ReasonRequest) -> dict[str, Any]:
-    return reason(req.turtle, req.shapes, req.inference, explain=req.explain)
+    return reason(req.turtle, req.shapes, req.inference, explain=req.explain, with_kko=req.with_kko)
 
 
 @app.post("/reason/project")

--- a/apps/owl-reasoner/tests/test_reasoner.py
+++ b/apps/owl-reasoner/tests/test_reasoner.py
@@ -158,6 +158,35 @@ def test_reason_endpoint_explain():
     assert isinstance(r.json()["justifications"], list) and len(r.json()["justifications"]) >= 1
 
 
+# ─── KKO TBox auto-load (with_kko) — entail over the real ontology, no inline axioms ─────────────
+KKO_LEAF_TTL = """@prefix kko: <http://kbpedia.org/ontologies/kko#> .
+@prefix ex: <http://ex/> .
+ex:x a kko:Suchness ."""   # asserts ONLY the leaf type — the subClassOf chain lives in the vendored TBox
+
+
+def test_with_kko_entails_ancestor_type_without_inline_axioms():
+    # Suchness ⊑ FirstMonads ⊑ Monads is in the KKO TBox, not the input, so these are DERIVATIONS.
+    out = reason(KKO_LEAF_TTL, inference="rdfs", with_kko=True, limit=20000)
+    assert out["kko_tbox"]["loaded"] is True
+    assert out["kko_tbox"]["triples"] > 3000            # the full KKO n3 (~3978 triples)
+    assert "x type Monads" in out["entailments"]        # ex:x a kko:Monads, via the KKO subClassOf chain
+    assert "x type FirstMonads" in out["entailments"]   # the intermediate ancestor too
+
+
+def test_without_kko_no_ancestor_entailment():
+    out = reason(KKO_LEAF_TTL, inference="rdfs")         # TBox NOT loaded
+    assert out["kko_tbox"] == {"loaded": False, "triples": 0}
+    assert not any("Monads" in e for e in out["entailments"])  # can't derive an ancestor with no axioms
+
+
+def test_with_kko_endpoint():
+    r = client.post("/reason", json={"turtle": KKO_LEAF_TTL, "inference": "rdfs", "with_kko": True})
+    assert r.status_code == 200
+    j = r.json()
+    assert j["kko_tbox"]["loaded"] is True and j["kko_tbox"]["triples"] > 3000
+    assert j["entailed_triples"] > 1000                 # RDFS closure over data + the KKO TBox
+
+
 def test_tabular_rdf_maps_rows_with_class_and_predicates():
     from owl_reasoner.tabular_rdf import map_rows
     rows = [


### PR DESCRIPTION
The reasoner reasoned over an **empty KKO TBox**. This vendors the real KKO (168 classes, CC-BY-4.0, package data) and merges it before closure on `with_kko=true`, so `ex:x a kko:Suchness ⊢ ex:x a kko:Monads` (via `Suchness ⊑ FirstMonads ⊑ Monads`) — no inline axioms. 21/21 tests (3 new). Completes the reasoning half of KKO wiring.