### PR TITLE
feat(web): serve the socioprophet.ai apex from the cockpit ingress (store identity)

### DIFF
--- a/charts/socioprophet-service/templates/managed-certificate.yaml
+++ b/charts/socioprophet-service/templates/managed-certificate.yaml
@@ -11,4 +11,18 @@ metadata:
   labels: {{- include "svc.labels" . | nindent 4 }}
 spec:
   domains: {{- toYaml .Values.ingress.managedCertificate.domains | nindent 4 }}
+{{- range .Values.ingress.additionalManagedCertificates }}
+---
+# Additional cert as its OWN object (never appended to an existing one): a ManagedCertificate's
+# domain list is immutable and fail-closed — one unresolvable domain stalls the WHOLE cert. A
+# separate object lets a new domain (e.g. the apex, pre-DNS-cutover) provision independently
+# without risking the live cert. List it alongside in the managed-certificates annotation.
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: {{ .name | quote }}
+  labels: {{- include "svc.labels" $ | nindent 4 }}
+spec:
+  domains: {{- toYaml .domains | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/deploy/values/socioprophet-web.yaml
+++ b/deploy/values/socioprophet-web.yaml
@@ -21,18 +21,27 @@ ingress:
   # stay stable across ingress re-creates. Reserved as `socioprophet-web-app-ip` (IN_USE).
   annotations:
     kubernetes.io/ingress.global-static-ip-name: socioprophet-web-app-ip
-    # HTTPS for the public prod domain. The GKE-managed cert (below) provisions once
-    # app.socioprophet.com's A record points at 8.233.245.238 — decoupled from .ai (which
-    # has no public A record yet), so it's its OWN single-domain cert, not a shared one.
-    networking.gke.io/managed-certificates: socioprophet-web-com-cert
+    # HTTPS for the public prod domain + the .ai APEX. Each domain gets its OWN
+    # ManagedCertificate object (a cert's domain list is immutable and fail-closed — one
+    # unresolvable domain stalls the whole cert), so the live .com cert is never at risk
+    # while the apex cert sits Provisioning until socioprophet.ai's A record (Namecheap)
+    # points at 8.233.245.238.
+    networking.gke.io/managed-certificates: socioprophet-web-com-cert,socioprophet-ai-apex-cert
   # GKE ManagedCertificate rendered by the chart (templates/managed-certificate.yaml) —
   # only socioprophet-web sets this, so no other chart consumer emits a cert.
   managedCertificate:
     name: socioprophet-web-com-cert
     domains: [app.socioprophet.com]
+  # The .ai apex as a SEPARATE, independently-provisioning cert. The apex serves the
+  # store-identity statics: Flathub domain verification (/.well-known/org.flathub.VerifiedApps.txt
+  # — token file mounts via extraFileMounts once Flathub issues it) and /screenshots/.
+  additionalManagedCertificates:
+    - { name: socioprophet-ai-apex-cert, domains: [socioprophet.ai] }
   # app.socioprophet.com = the prod login URL (marketing "Sign in" button → here). app.socioprophet.ai
-  # stays as the .ai alias (HTTP for now; no public A record). Same backend/cockpit for both.
+  # stays as the .ai alias (HTTP for now; no public A record). socioprophet.ai (apex) = the
+  # store/canonical identity domain. Same backend/cockpit for all three.
   hosts:
+    - { host: socioprophet.ai,      paths: [{ path: /, pathType: Prefix }] }
     - { host: app.socioprophet.ai,  paths: [{ path: /, pathType: Prefix }] }
     - { host: app.socioprophet.com, paths: [{ path: /, pathType: Prefix }] }
 autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 6 }


### PR DESCRIPTION
## Why
The Noetica store identity (`ai.socioprophet.Noetica`) requires `https://socioprophet.ai` to serve `/.well-known/org.flathub.VerifiedApps.txt` (Flathub domain verification) + `/screenshots/`. Today the apex has **no HTTPS at all** (Namecheap URL-forward IP, 443 dead). Per Michael's call: host it on **our own cluster**, not Firebase/hyperscaler hosting.

## What
- **Chart:** `ingress.additionalManagedCertificates` — extra GKE certs render as their **own objects**, never appended to an existing one (ManagedCertificate domain lists are immutable and fail-closed — one unresolvable domain stalls the whole cert). Opt-in; helm-verified a default consumer renders **0** certs.
- **socioprophet-web:** add `socioprophet.ai` host + `socioprophet-ai-apex-cert` (independent cert), both certs in the `managed-certificates` annotation. The live `.com` cert is never touched.

## Rollout
Safe pre-DNS: the new cert sits `Provisioning` until the apex A record points at `8.233.245.238`; existing hosts/certs unaffected. After merge+ArgoCD sync, Michael flips the Namecheap A record and the cert goes Active in ~15–60 min. The Flathub token file mounts later via the existing `extraFileMounts` pattern (out-of-git ConfigMap, same as firebase-config.js).