### PR TITLE
fix(noetica-impair): pin the image to the stack its tests run against

### DIFF
--- a/apps/noetica-impair/requirements.txt
+++ b/apps/noetica-impair/requirements.txt
@@ -1,7 +1,24 @@
-# Pinned for the container image. torch/CUDA come from the base image, not from here.
+# Pinned to the versions the test suite actually runs against, not to whatever is
+# newest. torch/CUDA come from the base image, never from here.
+#
+# The first build of this image failed because the pins were assembled by checking
+# that each version EXISTS on PyPI, which is not the same as checking they RESOLVE
+# together: transformers 5.14.1 requires safetensors>=0.8.0 and the pin said 0.5.3.
+# Worse, a pin that resolves but differs from the tested stack is the quieter bug --
+# the rig's hooks reach into transformers internals (decoder layer structure, and the
+# MoE gate return signature changed in transformers>=5), so a container running a
+# different version than the suite is validating nothing.
 transformers==5.14.1
-numpy==2.1.3
+safetensors==0.8.0
+tokenizers==0.22.2
+huggingface-hub==1.24.0
+numpy==2.5.1
 pyyaml==6.0.2
+
+# device_map="auto" in models/loaders.py needs accelerate. It is NOT installed in the
+# local dev env, so this pin is the one thing here the suite does not exercise -- the
+# CPU toy path never takes the device_map branch. Flagged rather than silently trusted.
 accelerate==1.10.1
-safetensors==0.5.3
+
+# Loading a SentencePiece-tokenizer model (Gemma, Llama) needs this at load time.
 sentencepiece==0.2.0


### PR DESCRIPTION
The first build of this image failed on pip resolution:

```
ERROR: Cannot install -r requirements.txt (line 2) and safetensors==0.5.3
because these package versions have conflicting dependencies.
```

`transformers==5.14.1` requires `safetensors>=0.8.0`. I had verified each pin **exists** on PyPI, which is not the same as verifying they **resolve together**.

## The quieter problem

The pins had also drifted from the environment the rig's 287 tests actually run in — `numpy` 2.1.3 vs 2.5.1, with `tokenizers` and `huggingface-hub` unpinned entirely. A container running a different stack than the suite validates is validating nothing, and this rig is unusually exposed to that: its hooks reach into `transformers` internals, and the MoE gate return signature changed in `transformers>=5`.

This now mirrors the canonical repo's `requirements.txt` — the tested stack, verified to resolve as a set.

`accelerate` is called out in the file as the one pin the suite does **not** exercise (`loaders.py` uses `device_map='auto'`, but the CPU toy path never takes that branch), flagged rather than silently trusted.

## Prevention

Upstream CI gained two gates so this cannot recur: pins must resolve together (`pip install --dry-run`), and pins must equal the versions the suite imports.