### PR TITLE
fix(noetica-impair): COPY LICENSE — pyproject declares it, so the install needs it

### DIFF
--- a/apps/noetica-impair/Dockerfile
+++ b/apps/noetica-impair/Dockerfile
@@ -20,7 +20,9 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY pyproject.toml ./
+# LICENSE comes along because pyproject declares license = { file = "LICENSE" };
+# without it the editable install fails with "License file does not exist".
+COPY pyproject.toml LICENSE ./
 COPY src ./src
 RUN pip install --no-cache-dir --no-deps -e .
 

--- a/apps/noetica-impair/tests/test_packaging.py
+++ b/apps/noetica-impair/tests/test_packaging.py
@@ -1,0 +1,45 @@
+"""The build context must contain everything the package metadata references.
+
+Regression: pyproject declared license = { file = "LICENSE" } while the Dockerfile
+copied only requirements/pyproject/src, so the image build failed at
+`pip install -e .` with "License file does not exist" — after a five-minute CUDA
+layer pull, three attempts in.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def copied_paths() -> set[str]:
+    df = (ROOT / "Dockerfile").read_text()
+    out: set[str] = set()
+    for m in re.finditer(r"^COPY\s+(.+?)\s+\S+\s*$", df, re.M):
+        for tok in m.group(1).split():
+            out.add(tok.strip("./"))
+    return out
+
+
+def test_every_file_pyproject_references_is_copied_into_the_image():
+    pp = (ROOT / "pyproject.toml").read_text()
+    copied = copied_paths()
+    needed = {m.group(2) for m in
+              re.finditer(r'(readme|license)\s*=\s*\{?\s*(?:file\s*=\s*)?"([^"]+)"', pp)}
+    missing = sorted(f for f in needed if f not in copied)
+    assert not missing, (
+        f"pyproject references {missing} but the Dockerfile never COPYs them; "
+        "`pip install -e .` will fail inside the image"
+    )
+
+
+def test_the_package_source_dir_is_copied():
+    assert "src" in copied_paths()
+
+
+def test_referenced_files_actually_exist_in_the_repo():
+    pp = (ROOT / "pyproject.toml").read_text()
+    for m in re.finditer(r'(readme|license)\s*=\s*\{?\s*(?:file\s*=\s*)?"([^"]+)"', pp):
+        assert (ROOT / m.group(2)).is_file(), f"{m.group(2)} referenced but absent"


### PR DESCRIPTION
Third build failure on this image:

```
OSError: License file does not exist: LICENSE
error: metadata-generation-failed
ERROR: process "pip install --no-cache-dir --no-deps -e ." did not complete successfully
```

`pyproject.toml` declares `license = { file = "LICENSE" }`, but the Dockerfile copied only `requirements.txt`, `pyproject.toml` and `src/`. The metadata referenced a file that was never in the image.

Progress note: the dependency install now succeeds — this is a later stage than the previous two failures.

## Prevention

Upstream added a packaging test that parses both files and asserts every path `pyproject` references is `COPY`ed by the Dockerfile **and** exists in the repo.

All three failures so far have been the same shape: a mismatch between what the build context contained and what something inside it expected, each discovered only after a multi-minute CUDA layer pull. That class of check belongs in the fast suite, not in a GPU image build.