### PR TITLE
gitops: promote hellgraph-service → /api/graph/explore (engine 0.4.35)

### DIFF
--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -3,7 +3,7 @@
 # Pinned manually: the image built fine, but the images matrix run failed on an UNRELATED service
 # (sherlock-engine), and gitops-promote only fires on a fully-green images run — so one unrelated build
 # failure blocked the auto-promote. (Follow-up: promote per-service on partial success.)
-image: { repository: hellgraph-service, tag: sha-f30efd7885622cec0b963c3c184f0ffcedcc595f }
+image: { repository: hellgraph-service, tag: sha-67c7512b7b6819d41e051bde90994afdbbbc7f6c }
 service: { port: 8090, portName: http }
 config:
   # Estate sovereign embeddings contract (matches memoryd + prophet-platform #799): the engine


### PR DESCRIPTION
Manual open of the blocked auto-promote (org setting). Values-only pin for the explore-endpoint build (PR #982).