### PR TITLE
hellgraph-service: ontology-scoped analytics (scope=data default)

### DIFF
--- a/apps/hellgraph-service/src/analytics.ts
+++ b/apps/hellgraph-service/src/analytics.ts
@@ -13,6 +13,30 @@ export interface NodeLite { id: string }
 export interface EdgeLite { from: string; to: string }
 export interface GraphSource { allNodes(): NodeLite[]; allEdges(): EdgeLite[] }
 
+/** Node shape needed for label-scoping (the store's GraphNode satisfies it). */
+export interface LabeledNodeLite extends NodeLite { labels?: string[] }
+export interface LabeledGraphSource { allNodes(): LabeledNodeLite[]; allEdges(): EdgeLite[] }
+
+/** Labels that carry the ONTOLOGY (KKO upper classes + KBpedia reference concepts), not domain data. */
+export const ONTOLOGY_LABELS = ['KkoClass', 'KkoReferenceConcept'] as const
+
+/**
+ * A GraphSource view with ontology nodes (and their incident edges) filtered out — so analytics and
+ * exploration rank DOMAIN data, not the type system. The ontology stays fully queryable (SPARQL/Cypher/
+ * kko endpoints are unaffected); this only scopes the analytics projection. Lazily materialized per call.
+ */
+export function dataScope(g: LabeledGraphSource): GraphSource {
+  const isOntology = (n: LabeledNodeLite): boolean =>
+    (n.labels ?? []).some((l) => (ONTOLOGY_LABELS as readonly string[]).includes(l))
+  return {
+    allNodes(): NodeLite[] { return g.allNodes().filter((n) => !isOntology(n)) },
+    allEdges(): EdgeLite[] {
+      const keep = new Set(this.allNodes().map((n) => n.id))
+      return g.allEdges().filter((e) => keep.has(e.from) && keep.has(e.to))
+    },
+  }
+}
+
 interface NativeKernel {
   pagerank(n: number, from: number[], to: number[], damping: number, iters: number, tol: number): number[]
   connectedComponents(n: number, from: number[], to: number[]): number[]

--- a/apps/hellgraph-service/src/server.test.ts
+++ b/apps/hellgraph-service/src/server.test.ts
@@ -87,6 +87,17 @@ test('explore suggests graph-proximal nodes via /api/graph/explore', async () =>
   assert.equal((await req('GET', '/api/graph/explore')).status, 400)          // no-seeds guard
 })
 
+test('analytics scope=data hides the ontology; scope=all includes it', async () => {
+  // KKO is loaded at startup (168 KkoClass nodes). Under the default data scope they must not appear.
+  const d = await req('GET', '/api/graph/analytics?metric=pagerank&limit=1000')
+  assert.equal(d.json.scope, 'data')
+  assert.ok(!d.json.top.some((t: any) => String(t.id).includes('kbpedia.org')), 'no KKO nodes under scope=data')
+  const a = await req('GET', '/api/graph/analytics?metric=pagerank&limit=1000&scope=all')
+  assert.equal(a.json.scope, 'all')
+  assert.ok(a.json.top.some((t: any) => String(t.id).includes('kbpedia.org')), 'KKO visible under scope=all')
+  assert.ok(a.json.nodes > d.json.nodes, 'scope=all sees more nodes than scope=data')
+})
+
 test('subgraph returns nodes + only internal edges (induced, no dangling)', async () => {
   const L = `proj-test${process.pid}`
   await req('POST', '/api/graph/node', { id: `${L}:a`, labels: [L, 'Entity'], properties: { name: 'A' } })

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -39,7 +39,7 @@ import { startFederation, handleFederation, type Federation } from './federation
 import { getHellGraph, getAtomSpace, attachRocksDB, forwardChain, runSparql, runGremlin, runCypher, shaclValidate } from '@socioprophet/hellgraph'
 import { describeResource, toTurtle, toJsonLd, toHtml, negotiate } from './resource.js'
 import { askGraph, retrieveGrounding, retrieveGroundingAuto, synthesisEnabled, semanticEnabled } from './graphrag.js'
-import { pagerank, connectedComponents, bfs, sssp, cdlp, lcc, analyticsBackend } from './analytics.js'
+import { pagerank, connectedComponents, bfs, sssp, cdlp, lcc, analyticsBackend, dataScope } from './analytics.js'
 
 const PORT = Number(process.env.PORT ?? 8090)
 
@@ -145,15 +145,19 @@ const server = http.createServer((req, res) => {
   if (req.method === 'GET' && url.pathname === '/api/graph/analytics') {
     const metric = url.searchParams.get('metric') ?? 'pagerank'
     const limit = Math.min(Number(url.searchParams.get('limit') ?? 20), 500)
-    if (metric === 'components') return json(res, 200, connectedComponents(g))
-    if (metric === 'pagerank') return json(res, 200, { metric, ...pagerank(g, limit) })
+    // scope=data (default) filters ontology nodes (KkoClass / KkoReferenceConcept) out of the analytics
+    // projection so metrics rank DOMAIN data, not the type system. scope=all analyzes everything.
+    const scope = url.searchParams.get('scope') ?? 'data'
+    const ga = scope === 'all' ? g : dataScope(g)
+    if (metric === 'components') return json(res, 200, { scope, ...connectedComponents(ga) })
+    if (metric === 'pagerank') return json(res, 200, { metric, scope, ...pagerank(ga, limit) })
     try {
-      if (metric === 'cdlp') return json(res, 200, { metric, ...cdlp(g, Math.min(Number(url.searchParams.get('iters') ?? 10), 100)) })
-      if (metric === 'lcc') return json(res, 200, { metric, ...lcc(g) })
+      if (metric === 'cdlp') return json(res, 200, { metric, scope, ...cdlp(ga, Math.min(Number(url.searchParams.get('iters') ?? 10), 100)) })
+      if (metric === 'lcc') return json(res, 200, { metric, scope, ...lcc(ga) })
       if (metric === 'bfs' || metric === 'sssp') {
         const source = url.searchParams.get('source')
         if (!source) return json(res, 400, { error: `metric '${metric}' needs ?source=<nodeId>` })
-        return json(res, 200, { metric, ...(metric === 'bfs' ? bfs(g, source) : sssp(g, source)) })
+        return json(res, 200, { metric, scope, ...(metric === 'bfs' ? bfs(ga, source) : sssp(ga, source)) })
       }
     } catch (e) { return json(res, 500, { error: String(e) }) }
     return json(res, 400, { error: `unknown metric '${metric}' (use pagerank | components | bfs | sssp | cdlp | lcc)` })


### PR DESCRIPTION
Filters ontology nodes (`KkoClass`/`KkoReferenceConcept`) out of the analytics projection by default so metrics rank domain data, not the type system; `?scope=all` opts in. Ontology stays fully queryable. 24/24 tests. Critical before the 55k-RC load (improvement #6).