### PR TITLE
deploy: pin owl-reasoner → sha-01faed59 (KKO TBox live, off tag:latest)

### DIFF
--- a/deploy/values/owl-reasoner.yaml
+++ b/deploy/values/owl-reasoner.yaml
@@ -1,8 +1,8 @@
 # owl-reasoner — RDFS/OWL-RL reasoning + SHACL validation over HellGraph (apps/owl-reasoner). Bridges
 # Ontogenesis-class inference (rdflib/owlrl/pyshacl) onto the graph: entails knowledge derivable but not
 # stated, over the KKO upper ontology — Protégé/Stardog reasoner parity, proof-carrying. Reasons over raw
-# Turtle or pulls a project's KKO-typed graph from lattice-studio. tag:latest → sha-pinned after first build.
-image: { repository: owl-reasoner, tag: latest }
+# Turtle or pulls a project's KKO-typed graph from lattice-studio. sha-pinned (KKO-TBox build, PR #974); auto-promoted on subsequent builds.
+image: { repository: owl-reasoner, tag: sha-01faed593ae18e1497161e5934bb1199b9f58a7a }
 service: { port: 8080, portName: http }
 config:
   LATTICE_STUDIO_URL: "http://lattice-studio:8080"


### PR DESCRIPTION
Values-only pin: the KKO-TBox owl-reasoner build (#974) succeeded but never got pinned (promote was broken); still on `tag:latest` (the moving-tag trap). Pins to the verified build sha → ArgoCD rolls the KKO-entailment reasoner. Improvement #3.