### PR TITLE
deploy: PHT timeseries stack — QuestDB + ClickHouse + ArcticDB gateway (tritfabric spec)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -90,6 +90,9 @@ jobs:
           - { image: tritfabric-consumption-api, context: ., dockerfile: apps/tritfabric-consumption-api/Dockerfile }
           - { image: agora,                 context: apps/agora,                 dockerfile: Dockerfile }
           - { image: spark-runner,          context: apps/spark-runner,          dockerfile: Dockerfile }
+          # PHT-5 dataset/version store (embedded ArcticDB gateway). QuestDB + ClickHouse are
+          # upstream images digest-pinned in deploy/values — no build entry for them.
+          - { image: arcticdb-gateway,      context: apps/arcticdb-gateway,      dockerfile: Dockerfile }
     uses: SocioProphet/.github/.github/workflows/build-image.yml@main
     with:
       image: ${{ matrix.image }}

--- a/apps/arcticdb-gateway/Dockerfile
+++ b/apps/arcticdb-gateway/Dockerfile
@@ -1,0 +1,12 @@
+# arcticdb-gateway — versioned DataFrame artifacts over embedded ArcticDB/LMDB (tritfabric PHT-5
+# dataset/version store, atoms-catalog section 3.3: "gateway Deployment wrapping embedded ArcticDB").
+# python:3.11 (not 3.12): arcticdb 4.4.3 — the newest Apache-2.0-converted release (license audit in
+# requirements.txt) — publishes wheels up to cp311.
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+ENV PORT=8080
+EXPOSE 8080
+CMD ["uvicorn", "arcticdb_gateway.server:app", "--host", "0.0.0.0", "--port", "8080", "--app-dir", "src"]

--- a/apps/arcticdb-gateway/pyproject.toml
+++ b/apps/arcticdb-gateway/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "arcticdb-gateway"
+version = "0.1.0"
+description = "PHT-5 dataset/version store: HTTP gateway over embedded ArcticDB (LMDB)"
+# arcticdb 4.4.3 (the newest Apache-2.0-converted release) ships cp311 wheels at most.
+requires-python = ">=3.11,<3.12"
+dependencies = [
+  "arcticdb==4.4.3",
+  "fastapi==0.115.0",
+  "uvicorn==0.30.6",
+  "pandas==2.2.2",
+  "numpy==1.26.4",
+  "pytz==2024.1",
+]
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/apps/arcticdb-gateway/requirements-test.txt
+++ b/apps/arcticdb-gateway/requirements-test.txt
@@ -1,0 +1,3 @@
+# Test-only dependencies (fastapi.testclient needs httpx). Runtime pins live in requirements.txt.
+pytest==8.3.2
+httpx==0.27.2

--- a/apps/arcticdb-gateway/requirements.txt
+++ b/apps/arcticdb-gateway/requirements.txt
@@ -1,0 +1,37 @@
+# Exact runtime closure (pip freeze of python:3.11-slim linux/amd64 — the image environment).
+#
+# ── ArcticDB LICENSE AUDIT (verified 2026-07-28) ─────────────────────────────────────────────
+# arcticdb is published under BSL 1.1 with, per LICENSE.txt at tag v4.4.3: "Change Date: ...
+# two years as of the release date of the respective version" and "Change License: Apache
+# License, version 2.0". arcticdb 4.4.3 was released to PyPI on 2024-06-19 (upload_time from
+# https://pypi.org/pypi/arcticdb/4.4.3/json). 2024-06-19 + 2 years = 2026-06-19 < today, so
+# THIS PINNED VERSION IS APACHE 2.0. It is the newest non-rc release inside the converted
+# window. DO NOT bump past a version younger than two years without a licensing decision.
+#
+# pandas is pinned to 2.2.2 (not 3.x): arcticdb 4.4.3 imports pytz transitively-by-era and
+# targets the pandas 2.x API; pandas 3 dropped the pytz dependency and broke `import arcticdb`
+# (verified empirically). numpy<2 and protobuf<5 are arcticdb 4.4.3's own declared bounds.
+arcticdb==4.4.3
+fastapi==0.115.0
+uvicorn==0.30.6
+pandas==2.2.2
+numpy==1.26.4
+pytz==2024.1
+annotated-types==0.8.0
+anyio==4.14.2
+attrs==26.1.0
+click==8.4.2
+h11==0.16.0
+idna==3.18
+msgpack==1.2.1
+packaging==26.2
+protobuf==4.25.9
+pydantic==2.13.4
+pydantic_core==2.46.4
+python-dateutil==2.9.0.post0
+PyYAML==6.0.3
+six==1.17.0
+starlette==0.38.6
+typing-inspection==0.4.2
+typing_extensions==4.16.0
+tzdata==2026.3

--- a/apps/arcticdb-gateway/src/arcticdb_gateway/__init__.py
+++ b/apps/arcticdb-gateway/src/arcticdb_gateway/__init__.py
@@ -1,0 +1,1 @@
+"""arcticdb-gateway — PHT-5 dataset/version store: a thin HTTP contract over embedded ArcticDB (LMDB)."""

--- a/apps/arcticdb-gateway/src/arcticdb_gateway/server.py
+++ b/apps/arcticdb-gateway/src/arcticdb_gateway/server.py
@@ -1,0 +1,85 @@
+"""arcticdb-gateway service — versioned DataFrame artifacts over embedded ArcticDB (LMDB).
+
+PHT-5 "ArcticDB gateway (dataset/version artifacts)" from the tritfabric spec
+(fabric/docs/pht.md PHT-5; fabric/docs/atoms-catalog.md section 3.3): a gateway Deployment
+wrapping the embedded library, so model training/backtesting artifacts get durable,
+versioned, time-travelable storage behind a plain HTTP contract.
+
+  GET  /healthz                                     liveness/readiness (opens LMDB on first call)
+  POST /v1/write                                    { library, symbol, data, index?, metadata?, prune_previous? }
+  GET  /v1/read?library=&symbol=&as_of=             latest, or time-travel to an integer version
+  GET  /v1/versions?library=&symbol=                version catalog (newest first per symbol)
+
+Storage: embedded ArcticDB over LMDB at ARCTIC_URI (default lmdb:///data/arcticdb — the PVC
+mount in deploy/values/arcticdb-gateway.yaml). LMDB is single-writer: one replica, Recreate.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from .store import BadRequest, GatewayStore, SymbolNotFound
+
+DEFAULT_URI = "lmdb:///data/arcticdb?map_size=8GB"
+
+
+class WriteRequest(BaseModel):
+    library: str = Field(min_length=1)
+    symbol: str = Field(min_length=1)
+    # Columns-oriented payload: { "price": [1.0, 2.0], "qty": [10, 20] }
+    data: dict[str, list[Any]]
+    # Optional row index; ISO-8601 strings become a DatetimeIndex (the time-series canonical form).
+    index: list[Any] | None = None
+    metadata: dict[str, Any] | None = None
+    prune_previous: bool = False
+
+
+def create_app(uri: str | None = None) -> FastAPI:
+    store = GatewayStore(uri or os.getenv("ARCTIC_URI", DEFAULT_URI))
+    app = FastAPI(title="arcticdb-gateway", version="0.1.0")
+
+    @app.get("/healthz")
+    def healthz() -> dict[str, Any]:
+        try:
+            info = store.ping()
+        except Exception as e:  # noqa: BLE001 — a broken store must fail the probe, not hide
+            raise HTTPException(status_code=503, detail=f"arcticdb backend unavailable: {e}") from e
+        return {"ok": True, "service": "arcticdb-gateway", "backend": store.uri.split("?")[0], **info}
+
+    @app.post("/v1/write")
+    def write(req: WriteRequest) -> dict[str, Any]:
+        try:
+            return store.write(
+                req.library, req.symbol, req.data, req.index, req.metadata, req.prune_previous
+            )
+        except BadRequest as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
+    @app.get("/v1/read")
+    def read(
+        library: str = Query(min_length=1),
+        symbol: str = Query(min_length=1),
+        as_of: int | None = Query(default=None, description="integer version for time-travel"),
+    ) -> dict[str, Any]:
+        try:
+            return store.read(library, symbol, as_of)
+        except SymbolNotFound as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
+
+    @app.get("/v1/versions")
+    def versions(
+        library: str = Query(min_length=1),
+        symbol: str | None = Query(default=None),
+    ) -> dict[str, Any]:
+        try:
+            return {"library": library, "versions": store.versions(library, symbol)}
+        except SymbolNotFound as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
+
+    return app
+
+
+app = create_app()

--- a/apps/arcticdb-gateway/src/arcticdb_gateway/store.py
+++ b/apps/arcticdb-gateway/src/arcticdb_gateway/store.py
@@ -1,0 +1,139 @@
+"""Embedded ArcticDB (LMDB) behind a small, deterministic gateway surface.
+
+Why a gateway at all: ArcticDB is an embedded library, not a server. The tritfabric atoms
+catalog (fabric/docs/atoms-catalog.md section 3.3) deploys it as "gateway Deployment wrapping
+embedded ArcticDB" so the rest of the platform talks HTTP contracts, never links the library.
+LMDB is strictly single-writer — the Deployment must run with one replica (values file pairs
+persistence with replicaCount: 1 + Recreate).
+
+LICENSE (verified 2026-07-28, PyPI + LICENSE.txt at tag v4.4.3):
+  arcticdb 4.4.3 was released 2024-06-19 under BSL 1.1 whose Change Date is "two years as of
+  the release date of the respective version" with Change License = Apache License 2.0.
+  2024-06-19 + 2 years = 2026-06-19, which has passed — this pinned version is Apache 2.0 today.
+  Do NOT bump this pin to a version less than two years old without a licensing decision.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+
+class SymbolNotFound(KeyError):
+    """Library or symbol (or requested version) does not exist."""
+
+
+class BadRequest(ValueError):
+    """Payload is structurally invalid (mismatched column lengths, empty data...)."""
+
+
+class GatewayStore:
+    """Lazily-initialised Arctic handle + the three gateway operations (write/read/versions)."""
+
+    def __init__(self, uri: str) -> None:
+        self.uri = uri
+        self._arctic: Any = None
+
+    # -- lifecycle -----------------------------------------------------------------
+    @property
+    def arctic(self) -> Any:
+        """Open LMDB on first use, not at import — the module stays importable without /data."""
+        if self._arctic is None:
+            from arcticdb import Arctic  # deferred: keeps import cheap for tooling/tests
+
+            self._arctic = Arctic(self.uri)
+        return self._arctic
+
+    def ping(self) -> dict[str, Any]:
+        """Force backend init so the readiness probe proves LMDB actually opens (a green
+        /healthz over a broken store would be a silent failure)."""
+        return {"libraries": len(self.arctic.list_libraries())}
+
+    # -- helpers -------------------------------------------------------------------
+    def _library(self, name: str, create: bool) -> Any:
+        if create:
+            return self.arctic.get_library(name, create_if_missing=True)
+        if name not in self.arctic.list_libraries():
+            raise SymbolNotFound(f"library {name!r} does not exist")
+        return self.arctic.get_library(name)
+
+    @staticmethod
+    def _frame(data: dict[str, list[Any]], index: list[Any] | None) -> pd.DataFrame:
+        if not data:
+            raise BadRequest("data must contain at least one column")
+        lengths = {len(v) for v in data.values()}
+        if len(lengths) != 1:
+            raise BadRequest(f"columns have mismatched lengths: { {k: len(v) for k, v in data.items()} }")
+        (n,) = lengths
+        if index is not None:
+            if len(index) != n:
+                raise BadRequest(f"index length {len(index)} != column length {n}")
+            try:
+                idx = pd.to_datetime(index)
+            except (ValueError, TypeError) as e:
+                raise BadRequest(f"index is not parseable as timestamps: {e}") from e
+            return pd.DataFrame(data, index=idx)
+        return pd.DataFrame(data)
+
+    @staticmethod
+    def _index_out(df: pd.DataFrame) -> list[Any]:
+        if isinstance(df.index, pd.DatetimeIndex):
+            return [ts.isoformat() for ts in df.index]
+        return [i.item() if hasattr(i, "item") else i for i in df.index]
+
+    # -- operations ----------------------------------------------------------------
+    def write(
+        self,
+        library: str,
+        symbol: str,
+        data: dict[str, list[Any]],
+        index: list[Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+        prune_previous: bool = False,
+    ) -> dict[str, Any]:
+        df = self._frame(data, index)
+        lib = self._library(library, create=True)
+        item = lib.write(symbol, df, metadata=metadata, prune_previous_versions=prune_previous)
+        return {
+            "library": library,
+            "symbol": symbol,
+            "version": int(item.version),
+            "rows": int(df.shape[0]),
+            "columns": list(df.columns),
+        }
+
+    def read(self, library: str, symbol: str, as_of: int | None = None) -> dict[str, Any]:
+        lib = self._library(library, create=False)
+        if not lib.has_symbol(symbol):
+            raise SymbolNotFound(f"symbol {symbol!r} not found in library {library!r}")
+        try:
+            item = lib.read(symbol, as_of=as_of)
+        except Exception as e:  # arcticdb raises NoSuchVersionException for a bad as_of
+            if "NoSuchVersion" in type(e).__name__ or "NoDataFound" in type(e).__name__:
+                raise SymbolNotFound(f"version {as_of!r} of {symbol!r} not found: {e}") from e
+            raise
+        df = item.data
+        return {
+            "library": library,
+            "symbol": symbol,
+            "version": int(item.version),
+            "index": self._index_out(df),
+            "data": {c: [v.item() if hasattr(v, "item") else v for v in df[c].tolist()] for c in df.columns},
+            "metadata": item.metadata,
+        }
+
+    def versions(self, library: str, symbol: str | None = None) -> list[dict[str, Any]]:
+        lib = self._library(library, create=False)
+        out = []
+        for key, info in lib.list_versions(symbol).items():
+            out.append(
+                {
+                    "symbol": key.symbol,
+                    "version": int(key.version),
+                    "date": info.date.isoformat() if getattr(info, "date", None) is not None else None,
+                    "deleted": bool(getattr(info, "deleted", False)),
+                    "snapshots": list(getattr(info, "snapshots", []) or []),
+                }
+            )
+        out.sort(key=lambda r: (r["symbol"], -r["version"]))
+        return out

--- a/apps/arcticdb-gateway/tests/test_gateway.py
+++ b/apps/arcticdb-gateway/tests/test_gateway.py
@@ -1,0 +1,123 @@
+"""arcticdb-gateway tests — real embedded ArcticDB over a tmpdir LMDB (no mocks).
+
+Each test gets a fresh LMDB under pytest's tmp_path, exercising the exact storage engine the
+image ships (arcticdb==4.4.3): write/version semantics, time-travel reads, and the version
+catalog are all asserted against the real library, not a fake.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from arcticdb_gateway.server import create_app
+
+
+@pytest.fixture()
+def client(tmp_path):
+    app = create_app(f"lmdb://{tmp_path}/arctic?map_size=256MB")  # small map for tests
+    with TestClient(app) as c:
+        yield c
+
+
+def test_healthz_reports_backend(client):
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["service"] == "arcticdb-gateway"
+    assert body["backend"].startswith("lmdb://")
+    assert body["libraries"] == 0
+
+
+def test_write_read_roundtrip_with_datetime_index(client):
+    payload = {
+        "library": "prices",
+        "symbol": "ASX.GYG",
+        "data": {"close": [10.5, 11.25, 10.9], "volume": [100, 250, 175]},
+        "index": ["2026-07-01T00:00:00", "2026-07-02T00:00:00", "2026-07-03T00:00:00"],
+        "metadata": {"source": "test-fixture"},
+    }
+    w = client.post("/v1/write", json=payload)
+    assert w.status_code == 200, w.text
+    assert w.json() == {
+        "library": "prices",
+        "symbol": "ASX.GYG",
+        "version": 0,
+        "rows": 3,
+        "columns": ["close", "volume"],
+    }
+
+    r = client.get("/v1/read", params={"library": "prices", "symbol": "ASX.GYG"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["version"] == 0
+    assert body["data"]["close"] == [10.5, 11.25, 10.9]
+    assert body["data"]["volume"] == [100, 250, 175]
+    assert body["index"] == ["2026-07-01T00:00:00", "2026-07-02T00:00:00", "2026-07-03T00:00:00"]
+    assert body["metadata"] == {"source": "test-fixture"}
+
+
+def test_versioning_and_time_travel(client):
+    base = {"library": "ts", "symbol": "series"}
+    v0 = client.post("/v1/write", json={**base, "data": {"x": [1, 2]}})
+    v1 = client.post("/v1/write", json={**base, "data": {"x": [3, 4, 5]}})
+    assert (v0.json()["version"], v1.json()["version"]) == (0, 1)
+
+    latest = client.get("/v1/read", params={"library": "ts", "symbol": "series"}).json()
+    assert latest["version"] == 1
+    assert latest["data"]["x"] == [3, 4, 5]
+
+    time_travel = client.get(
+        "/v1/read", params={"library": "ts", "symbol": "series", "as_of": 0}
+    ).json()
+    assert time_travel["version"] == 0
+    assert time_travel["data"]["x"] == [1, 2]
+
+    vs = client.get("/v1/versions", params={"library": "ts"})
+    assert vs.status_code == 200
+    versions = vs.json()["versions"]
+    assert [(v["symbol"], v["version"]) for v in versions] == [("series", 1), ("series", 0)]
+    assert all(v["deleted"] is False and v["date"] is not None for v in versions)
+
+
+def test_versions_filtered_by_symbol(client):
+    client.post("/v1/write", json={"library": "lib", "symbol": "a", "data": {"x": [1]}})
+    client.post("/v1/write", json={"library": "lib", "symbol": "b", "data": {"x": [2]}})
+    only_a = client.get("/v1/versions", params={"library": "lib", "symbol": "a"}).json()["versions"]
+    assert [(v["symbol"], v["version"]) for v in only_a] == [("a", 0)]
+
+
+def test_missing_symbol_and_library_are_404(client):
+    client.post("/v1/write", json={"library": "exists", "symbol": "s", "data": {"x": [1]}})
+    assert client.get("/v1/read", params={"library": "exists", "symbol": "nope"}).status_code == 404
+    assert client.get("/v1/read", params={"library": "ghost", "symbol": "s"}).status_code == 404
+    assert client.get("/v1/versions", params={"library": "ghost"}).status_code == 404
+    # a version that never existed time-travels to a 404, not a 500
+    assert (
+        client.get(
+            "/v1/read", params={"library": "exists", "symbol": "s", "as_of": 99}
+        ).status_code
+        == 404
+    )
+
+
+def test_write_validation_is_400(client):
+    mismatched = {"library": "l", "symbol": "s", "data": {"a": [1, 2], "b": [1]}}
+    assert client.post("/v1/write", json=mismatched).status_code == 400
+    empty = {"library": "l", "symbol": "s", "data": {}}
+    assert client.post("/v1/write", json=empty).status_code == 400
+    bad_index = {"library": "l", "symbol": "s", "data": {"a": [1]}, "index": ["not-a-time"]}
+    assert client.post("/v1/write", json=bad_index).status_code == 400
+    wrong_index_len = {"library": "l", "symbol": "s", "data": {"a": [1]}, "index": []}
+    assert client.post("/v1/write", json=wrong_index_len).status_code == 400
+
+
+def test_writes_persist_across_store_handles(tmp_path):
+    """Durability: a second app instance over the same LMDB path sees the first one's writes."""
+    uri = f"lmdb://{tmp_path}/arctic?map_size=256MB"
+    with TestClient(create_app(uri)) as c1:
+        c1.post("/v1/write", json={"library": "dur", "symbol": "s", "data": {"x": [7]}})
+    with TestClient(create_app(uri)) as c2:
+        got = c2.get("/v1/read", params={"library": "dur", "symbol": "s"})
+        assert got.status_code == 200
+        assert got.json()["data"]["x"] == [7]

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -49,6 +49,14 @@ spec:
           - { name: compute-gateway }
           # the IFM cadence trigger: ASX reporting events → governed doc→SQL runs
           - { name: reporting-watcher }
+          # PHT-5 timeseries substrate (tritfabric fabric/docs/pht.md + atoms-catalog section 3):
+          # questdb + clickhouse are third-party upstream images DIGEST-pinned in their values
+          # files (like socbase-* below — never touched by the build-image/gitops-promote SHA
+          # pipeline); arcticdb-gateway is first-party (images.yml matrix, sha-promoted).
+          # clickhouse requires the clickhouse-admin Secret first — see deploy/values/clickhouse.yaml.
+          - { name: questdb }
+          - { name: clickhouse }
+          - { name: arcticdb-gateway }
           # spark-runner MOVED to runtime-services → sovereign-runtime (executes user Spark jobs).
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —

--- a/deploy/values/arcticdb-gateway.yaml
+++ b/deploy/values/arcticdb-gateway.yaml
@@ -1,0 +1,45 @@
+# arcticdb-gateway — PHT-5 dataset/version store (tritfabric fabric/docs/pht.md PHT-5;
+# atoms-catalog section 3.3: "gateway Deployment wrapping embedded ArcticDB"). First-party
+# service (apps/arcticdb-gateway): FastAPI over the embedded ArcticDB library on LMDB, so
+# training/backtesting artifacts get versioned, time-travelable storage behind an HTTP
+# contract instead of every consumer linking the library. Spec namespace is `data`; v0
+# co-locates in `socioprophet` (see questdb.yaml).
+#
+# LICENSE (audit in apps/arcticdb-gateway/requirements.txt): arcticdb pinned to 4.4.3,
+# released 2024-06-19 — its BSL 1.1 Change Date (2 years) passed 2026-06-19, so the pinned
+# version is Apache 2.0 today. Never bump past a release younger than two years without a
+# licensing decision.
+nameOverride: arcticdb-gateway
+
+image:
+  repository: arcticdb-gateway
+  # sha-pinned by gitops-promote after the first CI build (embeddings.yaml precedent).
+  tag: latest
+  # Guard against the moving-tag+IfNotPresent trap while the tag is still `latest`; harmless
+  # once promotion pins an immutable sha- tag (kubelet re-checks, digests match, no-op).
+  pullPolicy: Always
+
+service: { port: 8080, portName: http }
+
+config:
+  # LMDB inside the PVC; map_size caps the LMDB memory map and must stay under the PVC size.
+  ARCTIC_URI: "lmdb:///data/arcticdb?map_size=8GB"
+
+# LMDB is strictly single-writer: one replica, no HPA, Recreate (RWO PD would deadlock a
+# rolling update) — the exact pairing the chart's persistence comment prescribes.
+persistence:
+  enabled: true
+  size: 10Gi
+  mountPath: /data
+replicaCount: 1
+autoscaling: { enabled: false }
+strategy: { type: Recreate }
+
+# /healthz opens LMDB on first call (fast, local) so readiness proves the store, not just uvicorn.
+probes:
+  path: /healthz
+
+# Honest floor: pandas/numpy runtime + LMDB page cache; artifact writes are bursty, not resident.
+resources:
+  requests: { cpu: 100m, memory: 512Mi }
+  limits:   { cpu: "1",  memory: 1Gi }

--- a/deploy/values/clickhouse.yaml
+++ b/deploy/values/clickhouse.yaml
@@ -1,0 +1,66 @@
+# ClickHouse — PHT-5 heavy-analytics engine (tritfabric fabric/docs/pht.md PHT-5; atoms-catalog
+# section 3.2: "long retention, big scans, joins, multi-tenant analytics serving"). Upstream
+# image, Apache 2.0. Spec namespace is `data`; v0 co-locates in `socioprophet` (see questdb.yaml).
+#
+# ── v0 vs the spec's deployment shape ────────────────────────────────────────────────────────
+# atoms-catalog 3.2 prescribes "Altinity operator + ClickHouseInstallation (CHI)". That route
+# installs cluster-wide CRDs + an operator, which this PR deliberately does NOT do (no
+# cluster-wide operators/CRDs ride along in a services PR). v0 is a plain single-node
+# clickhouse-server behind the shared chart — enough to land the contract and start
+# materializing. UPGRADE PATH: install the Altinity clickhouse-operator (its own ApplicationSet
+# entry + namespace, CRDs reviewed on their own), express this node as a ClickHouseInstallation
+# CR (replicas/shards/zookeeper-keeper managed there), migrate data, retire this values file.
+#
+# Digest-pinned (moving-tag+IfNotPresent trap — see questdb.yaml). 26.3 is the current LTS
+# line; tag = newest 26.3 patch. NOT touched by build-image/gitops-promote.
+#
+# Boot-verified under the chart's hardened defaults (runAsNonRoot 10001, readOnlyRootFilesystem):
+# needs the two writableDirs below + DO_NOT_CHOWN + an admin password, then /ping returns 200
+# and queries run. Without a password the entrypoint locks user `default` to localhost —
+# useless in-cluster — so the password Secret is REQUIRED (fail-closed, not optional).
+# PREREQ (out of band — never commit secrets):
+#   kubectl -n socioprophet create secret generic clickhouse-admin --from-literal=password="$(openssl rand -base64 24)"
+nameOverride: clickhouse
+
+image:
+  registry: docker.io          # third-party upstream image, not this platform's GAR
+  repository: clickhouse/clickhouse-server
+  # 26.3.17.56 = newest patch of the 26.3 LTS line (2026-07-20), manifest-list digest.
+  tag: "26.3.17.56@sha256:422be85ae7344058369cdd366ac0efea9daa8428b55c9cf50258e83a7d12fcb3"
+
+service:
+  port: 8123                   # HTTP interface (queries + /ping health)
+  portName: http
+  extraPorts:
+    - { name: native, port: 9000 }   # native TCP protocol (clickhouse-client, drivers)
+
+persistence:
+  enabled: true
+  size: 20Gi                   # long-retention store — first to grow; resize before Altinity move
+  mountPath: /var/lib/clickhouse
+
+# The entrypoint writes the generated user config into users.d, and the server logs to
+# /var/log/clickhouse-server — both must be writable under readOnlyRootFilesystem.
+writableDirs:
+  - /var/log/clickhouse-server
+  - /etc/clickhouse-server/users.d
+
+config:
+  CLICKHOUSE_DO_NOT_CHOWN: "1"   # running non-root; the entrypoint must not attempt chown
+  CLICKHOUSE_USER: "default"
+secretEnv:
+  # With a password set, the entrypoint grants user `default` network access (::/0) + this
+  # password instead of localhost-only. Missing Secret = pod won't start = loud, by design.
+  CLICKHOUSE_PASSWORD: { secretName: clickhouse-admin, key: password }
+
+replicaCount: 1
+autoscaling: { enabled: false }
+strategy: { type: Recreate }
+
+probes:
+  path: /ping                  # built-in health endpoint on the HTTP port
+
+# Honest floor for a scan-heavy columnar engine (spec: big scans + joins — memory-bound).
+resources:
+  requests: { cpu: 500m, memory: 2Gi }
+  limits:   { cpu: "2",  memory: 4Gi }

--- a/deploy/values/questdb.yaml
+++ b/deploy/values/questdb.yaml
@@ -1,0 +1,48 @@
+# QuestDB — PHT-5 hot time-series engine (tritfabric fabric/docs/pht.md PHT-5; atoms-catalog
+# section 3.1: "hot ingest + short retention + edge-local queries"). Upstream image, Apache 2.0.
+# The spec's target namespace is `data`; v0 co-locates in `socioprophet` beside the estate's
+# self-hosted postgres (deploy/datastores) until a data-namespace split is worth its cost.
+#
+# Digest-pinned (estate rule: a moving tag + IfNotPresent means a fix never rolls out). The tag
+# is documentation; the digest is what deploys. IfNotPresent is SAFE here because the digest is
+# immutable. Bumping = update tag AND digest together (docker buildx imagetools inspect, or the
+# Hub API). NOT touched by build-image/gitops-promote — we don't build this image.
+#
+# QuestDB OSS has no native replication/failover — the platform owns HA/DR (atoms-catalog 3.1
+# note) — so: single writer on a PVC, Recreate (a rolling update would deadlock on the RWO PD),
+# no autoscaling. Everything QuestDB owns (conf/ db/ log/) lives under /var/lib/questdb = the PVC.
+# Boot-verified under the chart's hardened defaults (runAsNonRoot 10001 + readOnlyRootFilesystem
+# + writable /tmp emptyDir): 9.4.3 starts clean and serves HTTP with only the PVC writable.
+nameOverride: questdb
+
+image:
+  registry: docker.io          # third-party upstream image, not this platform's GAR
+  repository: questdb/questdb
+  # 9.4.3 = latest stable (2026-06-15), multi-arch manifest-list digest (amd64+arm64).
+  tag: "9.4.3@sha256:3fd139f9f16015afc1b064fe4591b271be26cdec10315415e5511e9d80a5919e"
+
+service:
+  port: 9000                   # HTTP: REST query + web console + ILP-over-HTTP ingest
+  portName: http
+  extraPorts:
+    - { name: pgwire, port: 8812 }   # Postgres wire protocol (SELECT surface)
+    - { name: ilp,    port: 9009 }   # InfluxDB line protocol (TCP ingest)
+
+persistence:
+  enabled: true
+  size: 10Gi
+  mountPath: /var/lib/questdb  # QuestDB root: conf/ db/ log/ all live here
+
+replicaCount: 1
+autoscaling: { enabled: false }
+strategy: { type: Recreate }
+
+probes:
+  # The main HTTP port serves the console at / (200). QuestDB's dedicated health endpoint
+  # lives on the separate min-server port (9003) — not exposed in v0 to keep the surface small.
+  path: /
+
+# Honest floor for a hot-ingest JVM store (spec: short-retention hot windows, not bulk scans).
+resources:
+  requests: { cpu: 250m, memory: 1Gi }
+  limits:   { cpu: "2",  memory: 2Gi }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -84,9 +84,12 @@ KNOWN_BROKEN = {
     # reasoning-failure-runner:moving-tag is RESOLVED — deploy/values/reasoning-failure-runner.yaml is now pinned
     # to a sha- tag (the Chaos & Resilience Fabric orchestrator, CHAOS_RESILIENCE_FABRIC_V0.md). The ratchet only
     # shrinks: fixed → removed from KNOWN_BROKEN so it can never silently regress to `:latest` again.
-    "owl-reasoner:moving-tag": (
-        "New service — Dockerfile + images.yml entry added this PR, so it BUILDS. Pin `tag: latest` → the sha- "
-        "tag after the first CI build (same chicken-and-egg as grlplus-service/grl-mesh): no sha exists until merge."
+    # owl-reasoner:moving-tag is RESOLVED — deploy/values/owl-reasoner.yaml was manually sha-pinned
+    # (KKO-TBox build, #974). The ratchet only shrinks: fixed → removed so it can't regress silently.
+    "arcticdb-gateway:moving-tag": (
+        "New service — PHT-5 dataset/version store (apps/arcticdb-gateway) added to images.yml this PR. Pin "
+        "tag:latest -> the sha- tag after the first CI build; no sha exists until merge. Its values set "
+        "pullPolicy: Always as the interim guard against the moving-tag+IfNotPresent trap."
     ),
     "entity-resolution:moving-tag": (
         "New service — Dockerfile + images.yml entry added this PR. Pin tag:latest -> sha- after first CI build."


### PR DESCRIPTION
Implements the PHT-5 timeseries storage substrate from the tritfabric spec (`fabric/docs/pht.md` PHT-5 "Query Engines" + `fabric/docs/atoms-catalog.md` section 3) as deployable values on the shared `socioprophet-service` chart plus one first-party app. Spec namespace is `data`; v0 co-locates in `socioprophet` beside the estate postgres (`deploy/datastores`), noted in each values file.

## Images (upstream, digest-pinned — moving-tag+IfNotPresent trap avoided)

| Engine | Image | Digest |
|---|---|---|
| QuestDB (hot TS, atoms 3.1) | `docker.io/questdb/questdb:9.4.3` (latest stable, 2026-06-15) | `sha256:3fd139f9f16015afc1b064fe4591b271be26cdec10315415e5511e9d80a5919e` |
| ClickHouse (analytics, atoms 3.2) | `docker.io/clickhouse/clickhouse-server:26.3.17.56` (26.3 LTS line, 2026-07-20) | `sha256:422be85ae7344058369cdd366ac0efea9daa8428b55c9cf50258e83a7d12fcb3` |
| arcticdb-gateway (atoms 3.3) | first-party — built by `images.yml` (new matrix entry), `tag: latest` until the first gitops-promote sha-pin; `pullPolicy: Always` guards the interim | n/a |

Digest pinning uses the chart's existing `image.tag` slot in `name:tag@digest` form (valid OCI reference; the digest is what deploys, the tag is documentation) — no chart changes needed.

Both third-party images were **boot-verified under the chart's hardened defaults** (runAsNonRoot 10001, readOnlyRootFilesystem) in a container run before writing the values:
- QuestDB 9.4.3 starts clean with only the PVC (`/var/lib/questdb`) + `/tmp` writable; HTTP up on 9000.
- ClickHouse needs `writableDirs: [/var/log/clickhouse-server, /etc/clickhouse-server/users.d]`, `CLICKHOUSE_DO_NOT_CHOWN=1`, and a password — without one its entrypoint locks user `default` to localhost (useless in-cluster). With them: `/ping` → 200, `SELECT 42` → 42. **Deploy prereq (out of band, never committed):** `kubectl -n socioprophet create secret generic clickhouse-admin --from-literal=password=...` — fail-closed by design (pod won't start without it).

## ClickHouse: v0 vs the spec's Altinity route

atoms-catalog 3.2 prescribes **Altinity operator + ClickHouseInstallation (CHI)**. That means cluster-wide CRDs + an operator, which this PR deliberately does **not** install (no cluster-wide operators riding along in a services PR). v0 is a plain single-node `clickhouse-server` behind the shared chart. Upgrade path (documented in `deploy/values/clickhouse.yaml`): install the Altinity clickhouse-operator as its own ApplicationSet entry + namespace with its CRDs reviewed on their own, express this node as a CHI resource, migrate data, retire the values file.

## ArcticDB license verification (the reason for the 4.4.3 pin)

- ArcticDB is **BSL 1.1** with, per `LICENSE.txt` at tag `v4.4.3`: *"Change Date: … two years as of the release date of the respective version"*, *"Change License: Apache License, version 2.0"*.
- **arcticdb 4.4.3 was released 2024-06-19** (PyPI `upload_time`, `https://pypi.org/pypi/arcticdb/4.4.3/json`).
- 2024-06-19 + 2 years = **2026-06-19 < today (2026-07-28) → the pinned version is Apache 2.0 now.** It is the newest non-rc release inside the converted window (4.4.4/4.5.0 only ever shipped as rcX in that window).
- Consequences, all pinned exactly in `apps/arcticdb-gateway/requirements.txt` (full frozen closure, with the audit as a header comment): python 3.11 image (4.4.3 ships wheels up to cp311), `pandas==2.2.2` + `pytz==2024.1` (pandas 3 dropped pytz and empirically breaks `import arcticdb`), `numpy==1.26.4` (<2), `protobuf==4.25.9` (<5). **Do not bump arcticdb past a release younger than two years without a licensing decision.**

## arcticdb-gateway service

`apps/arcticdb-gateway` (mirrors `apps/owl-reasoner` layout): FastAPI over the embedded library on LMDB at the PVC (`ARCTIC_URI=lmdb:///data/arcticdb?map_size=8GB`). LMDB is single-writer → `replicaCount: 1` + `Recreate` + no HPA, exactly the chart's persistence pairing. `/healthz` opens LMDB on first call so readiness proves the store, not just uvicorn.

- `GET /healthz`
- `POST /v1/write` `{library, symbol, data, index?, metadata?, prune_previous?}` → version
- `GET /v1/read?library&symbol&as_of=` (integer-version time-travel)
- `GET /v1/versions?library&symbol=`

## Tests (real arcticdb over tmpdir LMDB, run in the prod-equivalent linux/amd64 py3.11 container against the exact pinned requirements)

```
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-8.3.2, pluggy-1.6.0 -- /usr/local/bin/python
rootdir: /w
configfile: pyproject.toml
plugins: anyio-4.14.2
collecting ... collected 7 items

tests/test_gateway.py::test_healthz_reports_backend PASSED               [ 14%]
tests/test_gateway.py::test_write_read_roundtrip_with_datetime_index PASSED [ 28%]
tests/test_gateway.py::test_versioning_and_time_travel PASSED            [ 42%]
tests/test_gateway.py::test_versions_filtered_by_symbol PASSED           [ 57%]
tests/test_gateway.py::test_missing_symbol_and_library_are_404 PASSED    [ 71%]
tests/test_gateway.py::test_write_validation_is_400 PASSED               [ 85%]
tests/test_gateway.py::test_writes_persist_across_store_handles PASSED   [100%]

======================== 7 passed, 4 warnings in 5.63s =========================
```

(`pip check`: "No broken requirements found." The 4 warnings are a pandas-2.2.2 DeprecationWarning raised from arcticdb internals — era-consistent, benign.)

## Validation

- `deploy-tests` helm-render gate run locally: **all 42 values files render** (39 existing + 3 new).
- Rendered manifests inspected: digest image refs, extraPorts (pgwire/ilp, native), PVC claims, writableDirs, secretEnv, Recreate strategy all correct.

## Resources (honest floors, per directive)

- QuestDB: requests 250m/1Gi, limits 2/2Gi, PVC 10Gi
- ClickHouse: requests 500m/2Gi, limits 2/4Gi, PVC 20Gi
- arcticdb-gateway: requests 100m/512Mi, limits 1/1Gi, PVC 10Gi

**DO NOT MERGE without review** — opened for review only. Deploy order note: create the `clickhouse-admin` Secret before (or right after) sync; QuestDB and the gateway have no prereqs.


## Preflight ratchet maintenance (second commit)

The `preflight` gate failed on the first push for a pre-existing reason: `owl-reasoner:moving-tag` was still in `KNOWN_BROKEN` although #974 sha-pinned it, and the ratchet fails until stale entries are deleted. This PR deletes it (the gate's own demanded remedy) and adds `arcticdb-gateway:moving-tag` with the standard new-service chicken-and-egg reason (embeddings/memoryd precedent) — no sha- tag exists until the first build on main; `pullPolicy: Always` guards the interim. QuestDB/ClickHouse need no entries (digest-pinned third-party). Verified locally: preflight exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
