### PR TITLE
feat: prophet-materializer-clickhouse — proof-carrying log→ClickHouse materializer (W1.1)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -93,6 +93,8 @@ jobs:
           # PHT-5 dataset/version store (embedded ArcticDB gateway). QuestDB + ClickHouse are
           # upstream images digest-pinned in deploy/values — no build entry for them.
           - { image: arcticdb-gateway,      context: apps/arcticdb-gateway,      dockerfile: Dockerfile }
+          # Seal-the-Walls W1.1: proof-carrying HellGraph-log → ClickHouse materializer.
+          - { image: prophet-materializer-clickhouse, context: apps/prophet-materializer-clickhouse, dockerfile: Dockerfile }
     uses: SocioProphet/.github/.github/workflows/build-image.yml@main
     with:
       image: ${{ matrix.image }}

--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -578,6 +578,43 @@ async def _sql_load(req_spec: dict, project: str, session: str | None) -> Adapte
             "runtime": "sql", "status": "ok", "error": None, "degraded": None, "epistemic": weakest}
 
 
+async def _materialize(req_spec: dict, project: str, session: str | None) -> AdapterResult:
+    """Seal-the-Walls W1.1 — attest one materializer batch on THE receipt spine.
+
+    A materializer (log → derived view, e.g. prophet-materializer-clickhouse) calls this
+    after inserting a batch and BEFORE writing its checkpoint: the sealed receipt is the
+    proof "materialized through cut [from_cursor, to_cursor]" (pht.md Design commitment 3).
+    In-process — the batch itself already ran in the materializer; the gateway's job is the
+    governed, hash-chained, Ed25519-attested evidence. The spec IS the receipt's inputs, so
+    inputs_sha binds {from_cursor, to_cursor, row_count, batch_hash} into the chain.
+
+    `_no_provenance`: a materialize receipt must NOT write its provenance subgraph back into
+    hellgraph — the graph is the very log being materialized, so the write-back would emit
+    new log events, which the materializer would materialize, which would mint a receipt,
+    which would write provenance… an unbounded self-feeding loop (~4 nodes + 5 edges per
+    poll interval, forever). Its provenance lives where it proves something: on the receipt
+    chain and in the sink's checkpoint row.
+    """
+    missing = [k for k in ("sink", "table", "to_cursor", "row_count", "batch_hash")
+               if req_spec.get(k) in (None, "")]
+    if missing:
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": f"materialize spec missing {missing} "
+                         f"(need sink, table, to_cursor, row_count, batch_hash)",
+                "degraded": None, "_no_provenance": True}
+    data = {
+        "source": req_spec.get("source", "hellgraph"),
+        "sink": req_spec["sink"], "table": req_spec["table"],
+        "from_cursor": int(req_spec.get("from_cursor", 0)),
+        "to_cursor": int(req_spec["to_cursor"]),
+        "row_count": int(req_spec["row_count"]),
+        "batch_hash": str(req_spec["batch_hash"]),
+    }
+    return {"outputs": [ComputeOutput(type="result", data=data)],
+            "runtime": "gateway", "status": "ok", "error": None, "degraded": None,
+            "_no_provenance": True}
+
+
 # kind → adapter coroutine. Overridable in tests.
 _BACKENDS: dict[str, Callable[..., Awaitable[AdapterResult]]] = {
     "forge": lambda spec, project, session: _forge(spec, project, session),
@@ -587,6 +624,7 @@ _BACKENDS: dict[str, Callable[..., Awaitable[AdapterResult]]] = {
     "model-server": lambda spec, project, session: _inference(spec, project, session),
     "gateway:ingest": lambda spec, project, session: _ingest(spec, project, session),
     "gateway:parse": lambda spec, project, session: _parse(spec, project, session),
+    "gateway:materialize": lambda spec, project, session: _materialize(spec, project, session),
     "holmes": lambda spec, project, session: _extraction(spec, project, session),
     "open-data": lambda spec, project, session: _reconcile(spec, project, session),
     "sql": lambda spec, project, session: _sql_load(spec, project, session),

--- a/apps/compute-gateway/src/compute_gateway/engine.py
+++ b/apps/compute-gateway/src/compute_gateway/engine.py
@@ -201,7 +201,11 @@ async def execute(req: ComputeRequest, _depth: int = 0) -> ComputeResult:
             step_run = f"proj-{req.project}:compute:{short}"
             delta.edges.append(GraphEdge.model_validate({"label": "HAS_STEP", "from": run_id, "to": step_run}))
             delta.edges.append(GraphEdge.model_validate({"label": "prov:wasInformedBy", "from": step_run, "to": run_id}))
-    if WRITE_PROVENANCE and status == "ok":
+    # an adapter may veto the provenance write-back (`_no_provenance`): a materialize run's
+    # provenance subgraph would land in the very graph whose log the materializer tails —
+    # each receipt would emit new log events and feed itself forever. The receipt chain
+    # still carries the run; only the graph write-back is suppressed.
+    if WRITE_PROVENANCE and status == "ok" and not raw.get("_no_provenance"):
         delta.written = await adapters.write_provenance(delta)
 
     attestation = zerotrust.attestation_bundle(receipt)

--- a/apps/compute-gateway/src/compute_gateway/registry.py
+++ b/apps/compute-gateway/src/compute_gateway/registry.py
@@ -91,6 +91,17 @@ KINDS: dict[str, dict] = {
         "capabilities": ["upsert", "sqlite", "keyed-by-entity-period", "warrant-tagged"],
         "epistemic": "derived", "executes_user_code": False, "status": "live",
     },
+    # ── Seal-the-Walls W1.1: proof-carrying materializers ──
+    # A materializer (prophet-materializer-clickhouse et al.) tails the HellGraph log and
+    # writes a derived view; after each batch it attests "materialized through cut X" HERE,
+    # so the receipt lands on THE estate receipt spine (pht.md Design commitment 3 — never a
+    # parallel receipt lineage). In-process: the gateway seals over the batch coordinates
+    # {sink, table, from_cursor, to_cursor, row_count, batch_hash}; it runs no user code.
+    "materialize": {
+        "backends": ["gateway"], "default": "gateway",
+        "capabilities": ["log-tail", "checkpoint-cut", "idempotent-batch", "clickhouse"],
+        "epistemic": "derived", "executes_user_code": False, "status": "live",
+    },
 }
 
 

--- a/apps/compute-gateway/tests/test_materialize.py
+++ b/apps/compute-gateway/tests/test_materialize.py
@@ -1,0 +1,112 @@
+"""Seal-the-Walls W1.1 — the `materialize` kind: a materializer batch attested on THE
+estate receipt spine (pht.md Design commitment 3: materializers are proof-carrying and
+NEVER grow a parallel receipt lineage).
+
+Covers: sealing (inputs_sha binds the batch coordinates), spec validation (fail loud),
+the provenance write-back veto (a materialize receipt must not feed the very log being
+materialized), and memo idempotency (a retried batch returns the SAME receipt).
+"""
+import importlib
+import os
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import adapters, engine, receipts, server  # noqa: E402
+
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+BATCH = {
+    "source": "hellgraph", "sink": "clickhouse", "table": "hellgraph.events",
+    "from_cursor": 100, "to_cursor": 158, "row_count": 42,
+    "batch_hash": "sha256:" + "ab" * 32,
+}
+
+_ORIG_WRITE_PROVENANCE_FLAG = engine.WRITE_PROVENANCE
+_ORIG_WRITE_PROVENANCE_FN = adapters.write_provenance
+
+
+def setup_function():
+    os.environ["COMPUTE_ENTITLEMENTS"] = "demo"   # pin: sibling modules mutate the shared env
+    receipts._CHAINS.clear()
+    engine._MEMO.clear()
+
+
+def teardown_function():
+    engine.WRITE_PROVENANCE = _ORIG_WRITE_PROVENANCE_FLAG
+    adapters.write_provenance = _ORIG_WRITE_PROVENANCE_FN
+
+
+def _compute(spec):
+    return client.post("/v1/compute", json={"kind": "materialize", "project": "demo", "spec": spec},
+                       headers=AUTH).json()
+
+
+def test_materialize_seals_batch_coordinates_on_the_chain():
+    r = _compute(BATCH)
+    assert r["status"] == "ok" and r["kind"] == "materialize" and r["backend"] == "gateway"
+    assert r["epistemic_status"] == "derived"                     # a materialized view is derived
+    out = r["outputs"][0]["data"]
+    assert out["from_cursor"] == 100 and out["to_cursor"] == 158
+    assert out["row_count"] == 42 and out["batch_hash"] == BATCH["batch_hash"]
+    # the receipt landed on the project's ONE hash chain, inputs bound over the spec
+    rc = r["receipt"]
+    assert rc is not None and rc["inputs_sha"] == receipts.sha(BATCH)
+    chain = receipts.chain("demo")
+    assert [c.id for c in chain] == [rc["id"]]
+    assert receipts.verify("demo")["valid"] is True
+
+
+def test_materialize_missing_coordinates_fails_loud():
+    r = _compute({"sink": "clickhouse", "table": "hellgraph.events"})  # no cut, no hash
+    assert r["status"] == "error"
+    assert "to_cursor" in r["error"] and "batch_hash" in r["error"]
+
+
+def test_materialize_never_writes_provenance_back_into_the_log():
+    # force the provenance path ON, and record any write-back attempt
+    engine.WRITE_PROVENANCE = True
+    calls = []
+
+    async def recording_write(delta):
+        calls.append(delta)
+        return True
+
+    adapters.write_provenance = recording_write
+
+    r = _compute(BATCH)
+    assert r["status"] == "ok"
+    assert calls == []                                            # the veto held: no graph write-back
+    assert r["graph_delta"]["written"] is False
+
+    # control: a non-materialize kind DOES write provenance under the same flag,
+    # proving the veto is per-adapter, not a dead code path.
+    async def fake_graph(spec, project, session):
+        from compute_gateway.contract import ComputeOutput
+        return {"outputs": [ComputeOutput(type="graph", data={"count": 1})],
+                "runtime": "hellgraph", "status": "ok", "error": None, "degraded": None}
+
+    orig = adapters._BACKENDS["hellgraph:graph-stats"]
+    adapters.set_backend("hellgraph:graph-stats", fake_graph)
+    try:
+        os.environ["COMPUTE_ENTITLEMENTS"] = "demo,graph-stats"
+        c = client.post("/v1/compute", json={"kind": "graph-stats", "project": "demo", "spec": {}},
+                        headers=AUTH).json()
+        assert c["status"] == "ok" and len(calls) == 1
+    finally:
+        adapters.set_backend("hellgraph:graph-stats", orig)
+
+
+def test_materialize_retry_returns_the_same_receipt():
+    # a materializer that crashed after sealing but before checkpointing re-runs the
+    # IDENTICAL batch → the memo returns the same receipt, not a duplicate on the chain
+    first = _compute(BATCH)
+    again = _compute(BATCH)
+    assert again["memoized"] is True
+    assert again["receipt"]["id"] == first["receipt"]["id"]
+    assert len(receipts.chain("demo")) == 1

--- a/apps/hellgraph-service/README.md
+++ b/apps/hellgraph-service/README.md
@@ -17,6 +17,7 @@ npm run typecheck
 |---|---|---|
 | GET | `/healthz` | liveness + engine export count |
 | GET | `/api/graph/stats` | node / edge counts |
+| GET | `/api/graph/log?since=&limit=` | log-tail for materializers: creation events after `since` (seq asc, ≤1000) + `cursor` + `version` |
 | POST | `/api/graph/node` | `{ id, labels[], properties? }` → upsert node |
 | POST | `/api/graph/edge` | `{ label, from, to, properties? }` → add edge |
 | GET | `/api/graph/query?label=X` | nodes carrying a label |

--- a/apps/hellgraph-service/src/server.test.ts
+++ b/apps/hellgraph-service/src/server.test.ts
@@ -305,6 +305,62 @@ test('graphrag: HYBRID retrieval (HNSW+BM25 RRF) seeds by embedding, not substri
   } finally { delete process.env.EMBEDDINGS_URL }
 })
 
+test('log-tail: /api/graph/log streams creation events since a cursor (materializer contract)', async () => {
+  const L = `logtail-${process.pid}`
+  // the shared test graph already carries KKO + earlier tests' writes — anchor on the
+  // CURRENT version (logical clock) so only THIS test's events are after the cursor.
+  const v0 = (await req('GET', '/api/graph/log?limit=1')).json.version as number
+  await req('POST', '/api/graph/node', { id: `${L}:a`, labels: [L], properties: { name: 'A', n: 1 } })
+  await req('POST', '/api/graph/node', { id: `${L}:b`, labels: [L] })
+  await req('POST', '/api/graph/edge', { label: 'links', from: `${L}:a`, to: `${L}:b`, properties: { w: 2 } })
+
+  const r = await req('GET', `/api/graph/log?since=${v0}&limit=1000`)
+  assert.equal(r.status, 200)
+  // exactly this test's graph events (PredicateNode/ListLink encoding atoms are NOT events)
+  assert.equal(r.json.events.length, 3)
+  assert.deepEqual(r.json.events.map((e: any) => e.kind), ['node', 'node', 'edge'])
+  // ordered by seq ascending, strictly monotonic
+  const seqs = r.json.events.map((e: any) => e.seq)
+  assert.ok(seqs[0] > v0 && seqs[0] < seqs[1] && seqs[1] < seqs[2], 'seq ascending, since-exclusive')
+  const [na, nb, ed] = r.json.events
+  assert.equal(na.id, `${L}:a`)
+  assert.deepEqual(na.labels, [L])
+  assert.deepEqual(na.properties, { name: 'A', n: 1 })            // float decode keeps the number
+  assert.ok(typeof na.wallTime === 'string' && na.wallTime.length > 0)
+  assert.equal(nb.id, `${L}:b`)
+  assert.equal(ed.label, 'links')
+  assert.equal(ed.from, `${L}:a`)
+  assert.equal(ed.to, `${L}:b`)
+  assert.deepEqual(ed.properties, { w: 2 })
+  assert.ok(typeof ed.id === 'string' && ed.id.length > 0)        // edge id = link handle (stable)
+  // cursor = seq of the last returned event; version = the store's logical clock
+  assert.equal(r.json.cursor, seqs[2])
+  assert.ok(r.json.version >= r.json.cursor)
+})
+
+test('log-tail: since is exclusive and an empty page keeps the cursor', async () => {
+  const tip = (await req('GET', '/api/graph/log?limit=1')).json.version as number
+  const r = await req('GET', `/api/graph/log?since=${tip}`)
+  assert.equal(r.status, 200)
+  assert.deepEqual(r.json.events, [])
+  assert.equal(r.json.cursor, tip)                                 // unchanged — safe to re-poll
+})
+
+test('log-tail: limit pages the stream and the cursor resumes it losslessly', async () => {
+  const L = `logpage-${process.pid}`
+  const v0 = (await req('GET', '/api/graph/log?limit=1')).json.version as number
+  for (const x of ['p', 'q', 'r']) await req('POST', '/api/graph/node', { id: `${L}:${x}`, labels: [L] })
+
+  const p1 = await req('GET', `/api/graph/log?since=${v0}&limit=2`)
+  assert.equal(p1.json.events.length, 2)
+  assert.deepEqual(p1.json.events.map((e: any) => e.id), [`${L}:p`, `${L}:q`])
+  const p2 = await req('GET', `/api/graph/log?since=${p1.json.cursor}&limit=2`)
+  assert.equal(p2.json.events.length, 1)                           // resume exactly after page 1
+  assert.equal(p2.json.events[0].id, `${L}:r`)
+  const p3 = await req('GET', `/api/graph/log?since=${p2.json.cursor}&limit=2`)
+  assert.deepEqual(p3.json.events, [])                             // caught up
+})
+
 test('graphrag: multi-hop grounding reaches beyond 1 hop (?hops=2)', async () => {
   const S = `hop-${process.pid}`
   await req('POST', '/api/graph/node', { id: `${S}:a`, labels: ['N'], properties: { name: 'Alpha' } })

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -7,6 +7,7 @@
  * Routes:
  *   GET  /healthz                  liveness + engine export count
  *   GET  /api/graph/stats          node / edge counts
+ *   GET  /api/graph/log?since=&limit=  log-tail for materializers: creation events > since (seq asc) + cursor
  *   GET  /api/graph/analytics?metric=pagerank|components  the BENCHMARKED Rust CSR kernel (native, TS fallback)
  *   POST /api/graph/node           { id, labels[], properties? } → upsert node
  *   POST /api/graph/edge           { label, from, to, properties? } → add edge
@@ -136,6 +137,74 @@ const server = http.createServer((req, res) => {
 
   if (req.method === 'GET' && url.pathname === '/api/graph/stats') {
     return json(res, 200, { nodes: g.allNodes().length, edges: g.allEdges().length })
+  }
+
+  // Log-tail surface — the materializer contract (Seal-the-Walls W1.1). HellGraph IS the platform
+  // log (tritfabric fabric/docs/pht.md, "Design commitments 2026-07-29"): derived stores (ClickHouse,
+  // ArcticDB, QuestDB) tail THIS endpoint and materialize, checkpointing by `cursor`.
+  //   GET /api/graph/log?since=<seq>&limit=N → { events: [{seq, kind, …}], cursor, version }
+  // since-EXCLUSIVE, ordered by seq ascending, bounded by limit (max 1000). `cursor` = seq of the
+  // last returned event (== since when the page is empty) — feed it back as the next `since`.
+  //
+  // WHY atoms, not AtomSpace.logTail(): the engine's public logTail() reads the IN-MEMORY op log,
+  // which the JSONL restore path does NOT rebuild (applyLogEntry re-indexes atoms but never
+  // re-pushes log entries) — after a pod restart it only covers the current process, so a
+  // materializer resuming an older checkpoint would silently miss history. atom.createdAtSeq IS
+  // rehydrated from the persisted log on restore, so deriving events from atoms stays correct
+  // across restarts. Consequence (the documented contract): this surface emits CREATION events
+  // ordered by the logical clock, each carrying the atom's CURRENT labels/properties
+  // (materialized-view semantics — the ReplacingMergeTree row downstream is latest-wins anyway);
+  // a later property write on an already-emitted atom does not re-emit it.
+  if (req.method === 'GET' && url.pathname === '/api/graph/log') {
+    const since = Math.max(0, Number(url.searchParams.get('since') ?? 0) || 0)
+    const limit = Math.max(1, Math.min(1000, Number(url.searchParams.get('limit') ?? 500) || 500))
+    const as = getAtomSpace()
+    // decode a stored Value the way the store facade does (float | 'true'/'false' | string)
+    const decode = (v: { kind: string; value: (string | number)[] } | undefined): unknown => {
+      if (!v) return null
+      if (v.kind === 'float') return v.value[0] ?? null
+      const s = String(v.value[0] ?? '')
+      return s === 'true' ? true : s === 'false' ? false : s
+    }
+    const props = (values: Record<string, { kind: string; value: (string | number)[] }>): Record<string, unknown> => {
+      const out: Record<string, unknown> = {}
+      for (const [k, v] of Object.entries(values)) if (k.startsWith('prop:')) out[k.slice(5)] = decode(v)
+      return out
+    }
+    type LogEvent =
+      | { seq: number; kind: 'node'; id: string; labels: string[]; properties: Record<string, unknown>; wallTime: string }
+      | { seq: number; kind: 'edge'; id: string; label: string; from: string; to: string; properties: Record<string, unknown>; wallTime: string }
+    const events: LogEvent[] = []
+    // graph nodes = ConceptNode atoms (the store's ENTITY type; labels under the graph:labels value)
+    for (const a of as.getByType('ConceptNode', false)) {
+      if (a.createdAtSeq <= since) continue
+      const labelsVal = a.values['graph:labels']
+      events.push({
+        seq: a.createdAtSeq, kind: 'node', id: a.name ?? a.handle,
+        labels: labelsVal?.kind === 'string' ? labelsVal.value : [],
+        properties: props(a.values), wallTime: a.createdAt,
+      })
+    }
+    // graph edges = EvaluationLink(PredicateNode(label), ListLink(from, to)) — mirror the store's
+    // projectEdge: skip malformed links rather than emitting a partial event.
+    for (const a of as.getByType('EvaluationLink', false)) {
+      if (a.createdAtSeq <= since) continue
+      const [predH, listH] = a.outgoing ?? []
+      const pred = predH ? as.getAtom(predH) : undefined
+      const list = listH ? as.getAtom(listH) : undefined
+      const [fromH, toH] = list?.outgoing ?? []
+      const from = fromH ? as.getAtom(fromH) : undefined
+      const to = toH ? as.getAtom(toH) : undefined
+      if (!pred?.name || !from?.name || !to?.name) continue
+      events.push({
+        seq: a.createdAtSeq, kind: 'edge', id: a.handle, label: pred.name,
+        from: from.name, to: to.name, properties: props(a.values), wallTime: a.createdAt,
+      })
+    }
+    events.sort((x, y) => x.seq - y.seq)
+    const page = events.slice(0, limit)
+    const cursor = page.length > 0 ? page[page.length - 1]!.seq : since
+    return json(res, 200, { events: page, cursor, version: g.version() })
   }
 
   // Graph analytics over the BENCHMARKED Rust CSR kernel (hg_analytics via N-API) — the same code

--- a/apps/prophet-materializer-clickhouse/Dockerfile
+++ b/apps/prophet-materializer-clickhouse/Dockerfile
@@ -1,0 +1,14 @@
+# prophet-materializer-clickhouse — Seal-the-Walls W1.1: the first proof-carrying
+# materializer. Tails the HellGraph log surface (GET /api/graph/log), writes the
+# hellgraph.events derived view into ClickHouse idempotently (ReplacingMergeTree keyed
+# by event_id, versioned by seq), checkpoints by the log's logical clock, and seals a
+# receipt per batch on the estate spine via compute-gateway (never a new lineage).
+# python:3.11-slim mirrors apps/arcticdb-gateway (the PHT-5 sibling).
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+ENV PORT=8080
+EXPOSE 8080
+CMD ["uvicorn", "prophet_materializer_clickhouse.server:app", "--host", "0.0.0.0", "--port", "8080", "--app-dir", "src"]

--- a/apps/prophet-materializer-clickhouse/pyproject.toml
+++ b/apps/prophet-materializer-clickhouse/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "prophet-materializer-clickhouse"
+version = "0.1.0"
+description = "Seal-the-Walls W1.1: proof-carrying HellGraph log -> ClickHouse materializer (checkpoint by logical clock, idempotent by event_id, receipts on the compute-gateway spine)"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi==0.115.0",
+  "uvicorn==0.30.6",
+  "httpx==0.27.2",
+]
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/apps/prophet-materializer-clickhouse/requirements-test.txt
+++ b/apps/prophet-materializer-clickhouse/requirements-test.txt
@@ -1,0 +1,3 @@
+# Test-only dependencies (fastapi.testclient needs httpx, already a runtime pin).
+# Runtime pins live in requirements.txt.
+pytest==8.3.2

--- a/apps/prophet-materializer-clickhouse/requirements.txt
+++ b/apps/prophet-materializer-clickhouse/requirements.txt
@@ -1,0 +1,22 @@
+# Exact runtime closure (pip freeze of the three top-level pins in pyproject.toml).
+# Shared pins line up with apps/arcticdb-gateway/requirements.txt (same base image, same
+# fastapi/uvicorn line); httpx==0.27.2 is the same version the estate already uses for
+# fastapi TestClients. httpcore 1.0.9 + h11 0.16.0 are the post-CVE-2025-43859 pairing.
+# No ClickHouse driver on purpose: the materializer speaks ClickHouse's plain HTTP
+# interface (:8123) via httpx — sovereign, decoupled, no bloat.
+fastapi==0.115.0
+uvicorn==0.30.6
+httpx==0.27.2
+annotated-types==0.8.0
+anyio==4.14.2
+certifi==2026.7.22
+click==8.4.2
+h11==0.16.0
+httpcore==1.0.9
+idna==3.18
+pydantic==2.13.4
+pydantic_core==2.46.4
+sniffio==1.3.1
+starlette==0.38.6
+typing-inspection==0.4.2
+typing_extensions==4.16.0

--- a/apps/prophet-materializer-clickhouse/src/prophet_materializer_clickhouse/__init__.py
+++ b/apps/prophet-materializer-clickhouse/src/prophet_materializer_clickhouse/__init__.py
@@ -1,0 +1,1 @@
+"""prophet-materializer-clickhouse — proof-carrying HellGraph log → ClickHouse materializer."""

--- a/apps/prophet-materializer-clickhouse/src/prophet_materializer_clickhouse/clients.py
+++ b/apps/prophet-materializer-clickhouse/src/prophet_materializer_clickhouse/clients.py
@@ -1,0 +1,164 @@
+"""The three doors the materializer talks through — all injectable, so unit tests run on
+fakes and the loop's correctness (checkpoint ordering, idempotency, fail-closed receipts)
+is proven without a cluster.
+
+- HellGraphClient    → hellgraph-service GET /api/graph/log (THE log; pht.md commitment 1)
+- ClickHouseClient   → ClickHouse's plain HTTP interface (:8123). No driver dependency:
+                       INSERT ... FORMAT JSONEachRow over httpx is the whole protocol.
+- GatewayClient      → compute-gateway POST /v1/compute kind=materialize (THE receipt
+                       spine; pht.md commitment 3 — never a parallel receipt lineage).
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import httpx
+
+TIMEOUT = float(os.getenv("HTTP_TIMEOUT_SECONDS", "30"))
+
+
+class HellGraphClient:
+    """Log-tail reader. `poll` is since-EXCLUSIVE and returns the endpoint's contract
+    verbatim: {events: [...], cursor: <max seq in page | since>, version: <logical clock>}."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    def poll(self, since: int, limit: int) -> dict[str, Any]:
+        r = httpx.get(f"{self.base_url}/api/graph/log",
+                      params={"since": since, "limit": limit}, timeout=TIMEOUT)
+        r.raise_for_status()
+        return r.json()
+
+
+class ClickHouseError(RuntimeError):
+    pass
+
+
+# ── the derived view + its checkpoint, exactly as the design commits them ──
+# events: ReplacingMergeTree versioned by seq, ORDER BY event_id → re-inserting the same
+#   event (a batch retried after a crash) collapses to ONE row at merge/FINAL — the
+#   idempotency bar. Dual timestamps (wall_time = the log's clock, ingest_time = ours)
+#   per pht.md commitment 3.
+# materializer_checkpoint: one row per materializer name, versioned by cursor. The cursor
+#   is monotonic, so max(cursor) is correct even before parts merge (no FINAL needed).
+DDL = [
+    "CREATE DATABASE IF NOT EXISTS hellgraph",
+    """
+    CREATE TABLE IF NOT EXISTS hellgraph.events (
+      event_id    String,
+      seq         UInt64,
+      kind        LowCardinality(String),
+      label       String,
+      from_id     String,
+      to_id       String,
+      properties  String,
+      wall_time   DateTime64(3, 'UTC'),
+      ingest_time DateTime64(3, 'UTC') DEFAULT now64(3)
+    ) ENGINE = ReplacingMergeTree(seq) ORDER BY event_id
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS hellgraph.materializer_checkpoint (
+      materializer String,
+      cursor       UInt64,
+      updated_at   DateTime64(3, 'UTC') DEFAULT now64(3)
+    ) ENGINE = ReplacingMergeTree(cursor) ORDER BY materializer
+    """,
+]
+
+EVENT_COLUMNS = ("event_id", "seq", "kind", "label", "from_id", "to_id",
+                 "properties", "wall_time")
+
+
+class ClickHouseClient:
+    """ClickHouse over its HTTP interface. Reads that must see deduped rows go through
+    FINAL (SELECT ... FROM hellgraph.events FINAL) — ReplacingMergeTree dedups at merge
+    time, so a plain SELECT may still see a retried batch twice; FINAL (or GROUP BY
+    event_id + argMax) is the read-side half of the idempotency contract."""
+
+    def __init__(self, url: str, user: str = "default", password: str = "") -> None:
+        self.url = url.rstrip("/")
+        self.user = user
+        self.password = password
+
+    def _headers(self) -> dict[str, str]:
+        return {"X-ClickHouse-User": self.user, "X-ClickHouse-Key": self.password}
+
+    def execute(self, sql: str, body: str | None = None) -> str:
+        """Run one statement. When `body` is given, `sql` is passed as the query param and
+        the body carries the data (the INSERT ... FORMAT JSONEachRow shape)."""
+        if body is None:
+            r = httpx.post(self.url, content=sql, headers=self._headers(), timeout=TIMEOUT)
+        else:
+            r = httpx.post(self.url, params={"query": sql}, content=body,
+                           headers=self._headers(), timeout=TIMEOUT)
+        if r.status_code != 200:
+            raise ClickHouseError(f"clickhouse {r.status_code}: {r.text[:500]}")
+        return r.text
+
+    def ensure_schema(self) -> None:
+        for stmt in DDL:
+            self.execute(stmt.strip())
+
+    def insert_events(self, rows: list[dict[str, Any]]) -> None:
+        if not rows:
+            return
+        cols = ", ".join(EVENT_COLUMNS)
+        body = "\n".join(json.dumps({c: row[c] for c in EVENT_COLUMNS}, ensure_ascii=False)
+                         for row in rows)
+        self.execute(f"INSERT INTO hellgraph.events ({cols}) FORMAT JSONEachRow", body)
+
+    def read_checkpoint(self, materializer: str) -> int:
+        out = self.execute(
+            "SELECT max(cursor) FROM hellgraph.materializer_checkpoint "
+            f"WHERE materializer = '{materializer}'").strip()
+        return int(out) if out else 0
+
+    def write_checkpoint(self, materializer: str, cursor: int) -> None:
+        body = json.dumps({"materializer": materializer, "cursor": cursor})
+        self.execute(
+            "INSERT INTO hellgraph.materializer_checkpoint (materializer, cursor) "
+            "FORMAT JSONEachRow", body)
+
+
+class GatewayError(RuntimeError):
+    """Receipt minting failed — the batch MUST NOT be checkpointed (fail-closed)."""
+
+
+class GatewayClient:
+    """Seals one receipt per batch on the estate spine: POST /v1/compute with the
+    `materialize` kind. The gateway hash-chains + Ed25519-attests it; the spec binds
+    {from_cursor, to_cursor, row_count, batch_hash} into inputs_sha. Any failure —
+    transport, auth, non-ok status — raises GatewayError so the caller cannot
+    checkpoint an unattested batch."""
+
+    def __init__(self, base_url: str, token: str, project: str = "default") -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.project = project
+
+    def mint(self, *, from_cursor: int, to_cursor: int, row_count: int,
+             batch_hash: str, table: str = "hellgraph.events") -> dict[str, Any]:
+        req = {
+            "kind": "materialize",
+            "project": self.project,
+            "actor": "prophet-materializer-clickhouse",
+            "spec": {
+                "source": "hellgraph", "sink": "clickhouse", "table": table,
+                "from_cursor": from_cursor, "to_cursor": to_cursor,
+                "row_count": row_count, "batch_hash": batch_hash,
+            },
+        }
+        try:
+            r = httpx.post(f"{self.base_url}/v1/compute", json=req,
+                           headers={"Authorization": f"Bearer {self.token}"}, timeout=TIMEOUT)
+        except httpx.HTTPError as e:
+            raise GatewayError(f"compute-gateway unreachable: {e}") from e
+        if r.status_code != 200:
+            raise GatewayError(f"compute-gateway {r.status_code}: {r.text[:500]}")
+        result = r.json()
+        if result.get("status") != "ok" or not result.get("receipt"):
+            raise GatewayError(f"materialize receipt refused: {json.dumps(result)[:500]}")
+        return result["receipt"]

--- a/apps/prophet-materializer-clickhouse/src/prophet_materializer_clickhouse/materializer.py
+++ b/apps/prophet-materializer-clickhouse/src/prophet_materializer_clickhouse/materializer.py
@@ -1,0 +1,138 @@
+"""The materializer core — one governed batch per call, restart-safe by construction.
+
+Order inside a logical batch (the WHOLE correctness argument):
+
+    read checkpoint → poll log(since=checkpoint) → INSERT rows → mint receipt → INSERT checkpoint
+
+- The checkpoint INSERT is the COMMIT POINT. Everything before it is idempotently
+  repeatable: rows re-inserted after a crash collapse in ReplacingMergeTree (keyed by
+  event_id, versioned by seq), and a re-minted identical batch memoizes to the SAME
+  receipt on the gateway. Crash anywhere before the checkpoint ⇒ the next run replays
+  the same cut and converges to the same state — zero duplicate rows at FINAL.
+- The receipt comes BEFORE the checkpoint (fail-closed): if the estate spine cannot
+  attest "materialized through cut X", the cut is not committed and the batch is
+  retried. A view that cannot prove its currency does not advance.
+- Empty poll ⇒ no receipt, no checkpoint — receipts attest work, not heartbeats.
+
+Events arrive from hellgraph-service GET /api/graph/log (creation events, seq-ascending,
+since-exclusive) and map 1:1 onto hellgraph.events rows:
+
+    event_id   "node:<id>" | "edge:<link-handle>"   (the idempotency key)
+    seq        the log's logical clock at creation   (the ReplacingMergeTree version)
+    label      edge label, or the node's labels joined with ','
+    properties the event's properties as canonical JSON (sorted keys)
+    wall_time  the log's wall-clock timestamp; ingest_time is stamped by ClickHouse
+               (dual timestamps — pht.md Design commitment 3)
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from .clients import GatewayError
+
+MATERIALIZER_NAME = "clickhouse"
+
+
+def to_row(event: dict[str, Any]) -> dict[str, Any]:
+    kind = event["kind"]
+    if kind == "node":
+        label = ",".join(event.get("labels") or [])
+        from_id, to_id = "", ""
+    else:
+        label = event.get("label") or ""
+        from_id, to_id = event.get("from") or "", event.get("to") or ""
+    return {
+        "event_id": f"{kind}:{event['id']}",
+        "seq": int(event["seq"]),
+        "kind": kind,
+        "label": label,
+        "from_id": from_id,
+        "to_id": to_id,
+        "properties": json.dumps(event.get("properties") or {}, sort_keys=True,
+                                 ensure_ascii=False, default=str),
+        "wall_time": _clickhouse_ts(event.get("wallTime")),
+    }
+
+
+def _clickhouse_ts(iso: str | None) -> str:
+    """ISO-8601 → 'YYYY-MM-DD HH:MM:SS.mmm' UTC — the one DateTime64 text form ClickHouse
+    parses without best-effort settings. Unparseable/missing falls back to epoch zero
+    (never dropped: the row's ordering truth is seq, not the wall clock)."""
+    if iso:
+        try:
+            dt = datetime.fromisoformat(iso.replace("Z", "+00:00")).astimezone(timezone.utc)
+            return dt.strftime("%Y-%m-%d %H:%M:%S.") + f"{dt.microsecond // 1000:03d}"
+        except ValueError:
+            pass
+    return "1970-01-01 00:00:00.000"
+
+
+def batch_hash(rows: list[dict[str, Any]]) -> str:
+    """sha256 over the SORTED event_ids — order-independent, so the same cut always
+    hashes the same and the gateway's memo can collapse a retried batch."""
+    joined = "\n".join(sorted(r["event_id"] for r in rows))
+    return "sha256:" + hashlib.sha256(joined.encode()).hexdigest()
+
+
+@dataclass
+class BatchResult:
+    events: int = 0
+    from_cursor: int = 0
+    to_cursor: int = 0
+    version: int = 0
+    receipt_id: str | None = None
+    batch_hash: str | None = None
+    checkpointed: bool = False
+
+    @property
+    def lag(self) -> int:
+        return max(0, self.version - self.to_cursor)
+
+
+@dataclass
+class Materializer:
+    hellgraph: Any
+    clickhouse: Any
+    gateway: Any
+    batch_limit: int = 500
+    _schema_ready: bool = field(default=False, repr=False)
+
+    def run_once(self) -> BatchResult:
+        """One logical batch. Raises on ClickHouse/gateway failure — the caller's loop
+        logs and retries; nothing is ever checkpointed past a failure (fail-closed)."""
+        if not self._schema_ready:
+            self.clickhouse.ensure_schema()
+            self._schema_ready = True
+
+        since = self.clickhouse.read_checkpoint(MATERIALIZER_NAME)
+        page = self.hellgraph.poll(since=since, limit=self.batch_limit)
+        events = page.get("events") or []
+        version = int(page.get("version") or 0)
+        if not events:
+            # nothing to materialize — no receipt (attest work, not heartbeats), no checkpoint
+            return BatchResult(events=0, from_cursor=since, to_cursor=since, version=version)
+
+        rows = [to_row(e) for e in events]
+        cut = int(page["cursor"])
+        digest = batch_hash(rows)
+
+        # 1) rows first — idempotent by construction (event_id key + seq version)
+        self.clickhouse.insert_events(rows)
+        # 2) receipt on the estate spine — a GatewayError aborts HERE, before the
+        #    checkpoint, so the unattested cut is retried in full (fail-closed)
+        receipt = self.gateway.mint(from_cursor=since, to_cursor=cut,
+                                    row_count=len(rows), batch_hash=digest)
+        # 3) the commit point
+        self.clickhouse.write_checkpoint(MATERIALIZER_NAME, cut)
+
+        return BatchResult(events=len(rows), from_cursor=since, to_cursor=cut,
+                           version=version, receipt_id=receipt.get("id"),
+                           batch_hash=digest, checkpointed=True)
+
+
+__all__ = ["Materializer", "BatchResult", "GatewayError", "to_row", "batch_hash",
+           "MATERIALIZER_NAME"]

--- a/apps/prophet-materializer-clickhouse/src/prophet_materializer_clickhouse/server.py
+++ b/apps/prophet-materializer-clickhouse/src/prophet_materializer_clickhouse/server.py
@@ -1,0 +1,113 @@
+"""HTTP shell: /healthz (last cursor + lag, honest) + the poll loop on a daemon thread.
+
+The loop never dies: any batch error is recorded in state and retried after the poll
+interval (a batch that failed was, by construction, not checkpointed — see
+materializer.run_once). /healthz always answers 200 with the truth; liveness is "the
+process and loop are up", not "every dependency is green" — a poller has no traffic to
+gate, and restarting it cannot fix a down ClickHouse.
+
+Config (env):
+  HELLGRAPH_URL           the log surface                (default http://hellgraph-service:8090)
+  CLICKHOUSE_URL          ClickHouse HTTP interface      (default http://clickhouse:8123)
+  CLICKHOUSE_USER         (default "default")
+  CLICKHOUSE_PASSWORD     via secretEnv — never in values/config
+  COMPUTE_GATEWAY_URL     the receipt spine              (default http://compute-gateway:8080)
+  GATEWAY_TOKEN           via secretEnv (compute-gateway-token)
+  MATERIALIZER_PROJECT    receipt chain/project          (default "default")
+  POLL_INTERVAL_SECONDS   (default 5)
+  BATCH_LIMIT             (default 500, server caps at 1000)
+  MATERIALIZER_LOOP=off   disables the background loop (tests / one-shot debugging)
+"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from .clients import ClickHouseClient, GatewayClient, HellGraphClient
+from .materializer import MATERIALIZER_NAME, Materializer
+
+
+@asynccontextmanager
+async def _lifespan(_app: FastAPI):
+    if os.getenv("MATERIALIZER_LOOP", "on").lower() != "off":
+        threading.Thread(target=_loop, name="materializer-loop", daemon=True).start()
+    yield
+
+
+app = FastAPI(title="prophet-materializer-clickhouse", version="0.1.0", lifespan=_lifespan)
+
+POLL_INTERVAL = float(os.getenv("POLL_INTERVAL_SECONDS", "5"))
+BATCH_LIMIT = int(os.getenv("BATCH_LIMIT", "500"))
+
+STATE: dict = {
+    "last_cursor": 0, "version": 0, "lag": 0,
+    "batches_ok": 0, "events_written": 0, "receipts": 0,
+    "last_receipt_id": None, "last_batch_at": None,
+    "last_error": None, "last_error_at": None,
+    "loop_running": False,
+}
+_STATE_LOCK = threading.Lock()
+
+
+def build_materializer() -> Materializer:
+    return Materializer(
+        hellgraph=HellGraphClient(os.getenv("HELLGRAPH_URL", "http://hellgraph-service:8090")),
+        clickhouse=ClickHouseClient(
+            os.getenv("CLICKHOUSE_URL", "http://clickhouse:8123"),
+            user=os.getenv("CLICKHOUSE_USER", "default"),
+            password=os.getenv("CLICKHOUSE_PASSWORD", "")),
+        gateway=GatewayClient(
+            os.getenv("COMPUTE_GATEWAY_URL", "http://compute-gateway:8080"),
+            token=os.getenv("GATEWAY_TOKEN", ""),
+            project=os.getenv("MATERIALIZER_PROJECT", "default")),
+        batch_limit=BATCH_LIMIT,
+    )
+
+
+def run_step(m: Materializer) -> bool:
+    """One loop step: run a batch, fold the outcome into STATE. Returns True when a
+    non-empty batch landed (the loop then polls again immediately to drain a backlog
+    faster than one batch per interval)."""
+    try:
+        result = m.run_once()
+        with _STATE_LOCK:
+            STATE["version"] = result.version
+            STATE["lag"] = result.lag
+            STATE["last_error"] = None
+            if result.checkpointed:
+                STATE["last_cursor"] = result.to_cursor
+                STATE["batches_ok"] += 1
+                STATE["events_written"] += result.events
+                STATE["receipts"] += 1
+                STATE["last_receipt_id"] = result.receipt_id
+                STATE["last_batch_at"] = time.time()
+            else:
+                STATE["last_cursor"] = result.from_cursor
+        return result.checkpointed
+    except Exception as e:  # noqa: BLE001 — the loop must survive any dependency outage
+        with _STATE_LOCK:
+            STATE["last_error"] = f"{type(e).__name__}: {e}"
+            STATE["last_error_at"] = time.time()
+        return False
+
+
+def _loop() -> None:
+    m = build_materializer()
+    with _STATE_LOCK:
+        STATE["loop_running"] = True
+    while True:
+        drained_more = run_step(m)
+        if not drained_more:
+            time.sleep(POLL_INTERVAL)
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    with _STATE_LOCK:
+        snapshot = dict(STATE)
+    return {"ok": True, "service": "prophet-materializer-clickhouse",
+            "materializer": MATERIALIZER_NAME, **snapshot}

--- a/apps/prophet-materializer-clickhouse/tests/test_clickhouse_integration.py
+++ b/apps/prophet-materializer-clickhouse/tests/test_clickhouse_integration.py
@@ -1,0 +1,97 @@
+"""Best-effort integration: the REAL clickhouse-server (the exact digest deploy/values
+pins) proving the ReplacingMergeTree idempotency contract end-to-end — a replayed batch
+leaves ZERO duplicate rows at FINAL. Unit fakes are the merge gate; this runs when
+podman is available and the image can be pulled, and skips loudly otherwise.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from prophet_materializer_clickhouse.clients import ClickHouseClient  # noqa: E402
+from prophet_materializer_clickhouse.materializer import (  # noqa: E402
+    MATERIALIZER_NAME, Materializer,
+)
+from test_materializer import FakeGateway, FakeHellGraph, THREE_EVENTS  # noqa: E402
+
+VALUES = Path(__file__).resolve().parents[3] / "deploy" / "values" / "clickhouse.yaml"
+
+
+def _image_ref() -> str | None:
+    """The digest-pinned image FROM the deployed values file — the test can't drift
+    from what prod runs."""
+    if not VALUES.exists():
+        return None
+    m = re.search(r'repository:\s*(\S+)\s*\n.*?tag:\s*"([^"]+)"', VALUES.read_text(), re.S)
+    return f"docker.io/{m.group(1)}:{m.group(2)}" if m else None
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+pytestmark = pytest.mark.skipif(shutil.which("podman") is None, reason="podman not available")
+
+
+@pytest.fixture(scope="module")
+def clickhouse_url():
+    image = _image_ref()
+    if image is None:
+        pytest.skip("deploy/values/clickhouse.yaml not found (image context?)")
+    port = _free_port()
+    name = f"materializer-it-{uuid.uuid4().hex[:8]}"
+    run = subprocess.run(
+        ["podman", "run", "-d", "--rm", "--name", name, "-p", f"127.0.0.1:{port}:8123",
+         "-e", "CLICKHOUSE_PASSWORD=it-test", image],
+        capture_output=True, text=True, timeout=600)
+    if run.returncode != 0:
+        pytest.skip(f"could not start clickhouse container (best-effort): {run.stderr[-300:]}")
+    try:
+        import httpx
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            try:
+                if httpx.get(f"http://127.0.0.1:{port}/ping", timeout=2).status_code == 200:
+                    break
+            except Exception:  # noqa: BLE001
+                time.sleep(1)
+        else:
+            pytest.skip("clickhouse container never became healthy (best-effort)")
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        subprocess.run(["podman", "rm", "-f", name], capture_output=True, timeout=60)
+
+
+def test_replayed_batch_deduplicates_in_real_replacingmergetree(clickhouse_url):
+    ch = ClickHouseClient(clickhouse_url, user="default", password="it-test")
+    m = Materializer(hellgraph=FakeHellGraph(THREE_EVENTS), clickhouse=ch,
+                     gateway=FakeGateway(), batch_limit=500)
+
+    m.run_once()                                                   # batch lands + checkpoints
+    assert ch.read_checkpoint(MATERIALIZER_NAME) == 12
+
+    # simulate a restart from an OLDER checkpoint: rewind for real, replay the same cut
+    ch.execute("TRUNCATE TABLE hellgraph.materializer_checkpoint")
+    ch.write_checkpoint(MATERIALIZER_NAME, 5)
+    m.run_once()                                                   # replays seq 9 + 12
+
+    raw = int(ch.execute("SELECT count() FROM hellgraph.events").strip())
+    final = int(ch.execute("SELECT count() FROM hellgraph.events FINAL").strip())
+    distinct = int(ch.execute("SELECT uniqExact(event_id) FROM hellgraph.events").strip())
+    assert raw >= 3                                                # replay really re-inserted
+    assert final == 3 == distinct                                  # ZERO duplicates at FINAL
+    ids = ch.execute("SELECT event_id FROM hellgraph.events FINAL ORDER BY event_id").split()
+    assert ids == sorted(["node:n:a", "node:n:b", "edge:EvaluationLink(...)"])
+    assert ch.read_checkpoint(MATERIALIZER_NAME) == 12

--- a/apps/prophet-materializer-clickhouse/tests/test_materializer.py
+++ b/apps/prophet-materializer-clickhouse/tests/test_materializer.py
@@ -1,0 +1,245 @@
+"""Unit gate for the materializer core: IDEMPOTENCY IS THE ACCEPTANCE BAR.
+
+All three doors are faked. FakeClickHouse mimics the ReplacingMergeTree contract
+honestly: raw inserts KEEP duplicates (parts before a merge), `final_rows()` dedups by
+event_id keeping the max-seq version (what SELECT ... FINAL / argMax returns) — so the
+no-duplicates assertions test the same semantics the real table provides, not a fake's
+convenience.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from prophet_materializer_clickhouse.clients import GatewayError  # noqa: E402
+from prophet_materializer_clickhouse.materializer import (  # noqa: E402
+    MATERIALIZER_NAME, Materializer, batch_hash, to_row,
+)
+
+# ── fakes ────────────────────────────────────────────────────────────────────
+
+
+def ev_node(seq: int, nid: str, labels=None, props=None):
+    return {"seq": seq, "kind": "node", "id": nid, "labels": labels or ["T"],
+            "properties": props or {}, "wallTime": "2026-07-29T12:00:00.000Z"}
+
+
+def ev_edge(seq: int, eid: str, label: str, frm: str, to: str, props=None):
+    return {"seq": seq, "kind": "edge", "id": eid, "label": label, "from": frm,
+            "to": to, "properties": props or {}, "wallTime": "2026-07-29T12:00:01.500Z"}
+
+
+class FakeHellGraph:
+    """Implements the /api/graph/log contract: since-exclusive, seq-ascending, limited,
+    cursor = last returned seq (or since when empty), version = top of the log."""
+
+    def __init__(self, events):
+        self.events = sorted(events, key=lambda e: e["seq"])
+
+    @property
+    def version(self):
+        return self.events[-1]["seq"] if self.events else 0
+
+    def poll(self, since: int, limit: int):
+        page = [e for e in self.events if e["seq"] > since][:limit]
+        return {"events": page,
+                "cursor": page[-1]["seq"] if page else since,
+                "version": self.version}
+
+
+class FakeClickHouse:
+    def __init__(self):
+        self.raw_rows = []          # parts as inserted — duplicates SURVIVE here
+        self.checkpoints = []       # (materializer, cursor) appends
+        self.schema_created = 0
+        self.fail_next_checkpoint = False
+
+    def ensure_schema(self):
+        self.schema_created += 1
+
+    def insert_events(self, rows):
+        self.raw_rows.extend(rows)
+
+    def read_checkpoint(self, materializer):
+        cs = [c for m, c in self.checkpoints if m == materializer]
+        return max(cs) if cs else 0
+
+    def write_checkpoint(self, materializer, cursor):
+        if self.fail_next_checkpoint:
+            self.fail_next_checkpoint = False
+            raise RuntimeError("simulated crash between insert and checkpoint")
+        self.checkpoints.append((materializer, cursor))
+
+    def final_rows(self):
+        """ReplacingMergeTree(seq) ORDER BY event_id at FINAL: one row per event_id,
+        the max-seq version wins."""
+        best = {}
+        for r in self.raw_rows:
+            k = r["event_id"]
+            if k not in best or r["seq"] >= best[k]["seq"]:
+                best[k] = r
+        return list(best.values())
+
+
+class FakeGateway:
+    def __init__(self):
+        self.mints = []
+        self.down = False
+
+    def mint(self, *, from_cursor, to_cursor, row_count, batch_hash, table="hellgraph.events"):
+        if self.down:
+            raise GatewayError("compute-gateway unreachable: connection refused")
+        receipt = {"id": f"sha256:receipt-{from_cursor}-{to_cursor}",
+                   "inputs_sha": batch_hash, "prev": self.mints[-1]["receipt"]["id"] if self.mints else None}
+        self.mints.append({"from_cursor": from_cursor, "to_cursor": to_cursor,
+                           "row_count": row_count, "batch_hash": batch_hash,
+                           "table": table, "receipt": receipt})
+        return receipt
+
+
+THREE_EVENTS = [
+    ev_node(5, "n:a", labels=["Person", "T"], props={"name": "Ada", "n": 1}),
+    ev_node(9, "n:b"),
+    ev_edge(12, "EvaluationLink(...)", "KNOWS", "n:a", "n:b", props={"w": 2}),
+]
+
+
+def make(events=None, batch_limit=500):
+    hg, ch, gw = FakeHellGraph(events or THREE_EVENTS), FakeClickHouse(), FakeGateway()
+    return Materializer(hellgraph=hg, clickhouse=ch, gateway=gw, batch_limit=batch_limit), hg, ch, gw
+
+
+# ── (1) happy path: rows + checkpoint + receipt, all coherent ────────────────
+
+
+def test_happy_path_batch_writes_rows_checkpoint_and_receipt():
+    m, hg, ch, gw = make()
+    r = m.run_once()
+
+    assert r.checkpointed and r.events == 3
+    assert (r.from_cursor, r.to_cursor) == (0, 12)
+    # rows landed, mapped per the contract
+    assert {row["event_id"] for row in ch.raw_rows} == {"node:n:a", "node:n:b", "edge:EvaluationLink(...)"}
+    node_a = next(row for row in ch.raw_rows if row["event_id"] == "node:n:a")
+    assert node_a["label"] == "Person,T" and node_a["seq"] == 5
+    assert node_a["properties"] == '{"n": 1, "name": "Ada"}'          # canonical (sorted) JSON
+    assert node_a["wall_time"] == "2026-07-29 12:00:00.000"
+    edge = next(row for row in ch.raw_rows if row["kind"] == "edge")
+    assert (edge["label"], edge["from_id"], edge["to_id"]) == ("KNOWS", "n:a", "n:b")
+    # checkpoint = the page cursor, written ONCE, AFTER the receipt
+    assert ch.checkpoints == [(MATERIALIZER_NAME, 12)]
+    # exactly one receipt, binding the cut + the batch hash over sorted event_ids
+    assert len(gw.mints) == 1
+    mint = gw.mints[0]
+    assert (mint["from_cursor"], mint["to_cursor"], mint["row_count"]) == (0, 12, 3)
+    assert mint["batch_hash"] == batch_hash([to_row(e) for e in THREE_EVENTS])
+    assert r.receipt_id == mint["receipt"]["id"]
+
+
+# ── (2) crash after insert, before checkpoint → rerun → ZERO duplicates ─────
+
+
+def test_crash_between_insert_and_checkpoint_then_rerun_no_duplicates():
+    m, hg, ch, gw = make()
+    ch.fail_next_checkpoint = True
+
+    with pytest.raises(RuntimeError):
+        m.run_once()                                  # rows inserted, receipt minted, then "crash"
+    assert ch.checkpoints == []                       # nothing committed
+    assert len(ch.raw_rows) == 3                      # the orphaned insert is real
+
+    r = m.run_once()                                  # restart: re-reads checkpoint 0, replays the cut
+    assert r.checkpointed and ch.checkpoints == [(MATERIALIZER_NAME, 12)]
+
+    # raw parts DO carry the duplicates (6 rows) — proving dedup does the work…
+    assert len(ch.raw_rows) == 6
+    # …and the FINAL view has ZERO duplicate rows: one per event_id, exact set match
+    final_ids = [row["event_id"] for row in ch.final_rows()]
+    assert sorted(final_ids) == sorted(set(final_ids))
+    assert set(final_ids) == {"node:n:a", "node:n:b", "edge:EvaluationLink(...)"}
+    # the replayed batch is the SAME cut with the SAME hash (gateway memo collapses it)
+    assert [x["batch_hash"] for x in gw.mints] == [gw.mints[0]["batch_hash"]] * len(gw.mints)
+
+
+def test_restart_from_older_checkpoint_is_idempotent():
+    # a checkpoint REGRESSION (restored older checkpoint row) replays events already
+    # materialized — the acceptance bar says the view must not grow duplicates
+    m, hg, ch, gw = make()
+    m.run_once()
+    assert ch.read_checkpoint(MATERIALIZER_NAME) == 12
+
+    ch.checkpoints = [(MATERIALIZER_NAME, 5)]         # rewind: an older checkpoint survives a restore
+    r = m.run_once()                                  # replays seq 9, 12
+    assert r.checkpointed and r.to_cursor == 12
+    final_ids = [row["event_id"] for row in ch.final_rows()]
+    assert sorted(final_ids) == sorted(set(final_ids))
+    assert set(final_ids) == {"node:n:a", "node:n:b", "edge:EvaluationLink(...)"}
+
+
+# ── (3) empty poll → no receipt, no checkpoint, no insert ───────────────────
+
+
+def test_empty_poll_mints_no_receipt():
+    m, hg, ch, gw = make()
+    m.run_once()
+    assert len(gw.mints) == 1
+
+    r = m.run_once()                                  # caught up — nothing new
+    assert not r.checkpointed and r.events == 0
+    assert len(gw.mints) == 1                         # STILL one — no heartbeat receipts
+    assert ch.checkpoints == [(MATERIALIZER_NAME, 12)]
+    assert len(ch.raw_rows) == 3
+    assert r.lag == 0
+
+
+# ── (4) gateway unreachable → NOT checkpointed (fail-closed), then retried ──
+
+
+def test_gateway_down_fails_closed_and_batch_retries():
+    m, hg, ch, gw = make()
+    gw.down = True
+
+    with pytest.raises(GatewayError):
+        m.run_once()
+    assert ch.checkpoints == []                       # the unattested cut was NOT committed
+
+    gw.down = False
+    r = m.run_once()                                  # same cut, retried in full
+    assert r.checkpointed and r.to_cursor == 12
+    assert len(gw.mints) == 1 and gw.mints[0]["from_cursor"] == 0
+    final_ids = [row["event_id"] for row in ch.final_rows()]
+    assert sorted(final_ids) == sorted(set(final_ids))  # and still no duplicates
+
+
+# ── batching + mapping details ──────────────────────────────────────────────
+
+
+def test_batch_limit_pages_the_backlog_one_receipt_per_batch():
+    m, hg, ch, gw = make(batch_limit=2)
+    r1 = m.run_once()
+    assert (r1.from_cursor, r1.to_cursor, r1.events) == (0, 9, 2)
+    assert r1.lag == 12 - 9
+    r2 = m.run_once()
+    assert (r2.from_cursor, r2.to_cursor, r2.events) == (9, 12, 1)
+    assert ch.checkpoints == [(MATERIALIZER_NAME, 9), (MATERIALIZER_NAME, 12)]
+    assert [x["to_cursor"] for x in gw.mints] == [9, 12]
+    assert len(ch.final_rows()) == 3
+
+
+def test_batch_hash_is_order_independent_and_content_bound():
+    rows_a = [to_row(e) for e in THREE_EVENTS]
+    rows_b = [to_row(e) for e in reversed(THREE_EVENTS)]
+    assert batch_hash(rows_a) == batch_hash(rows_b)
+    assert batch_hash(rows_a) != batch_hash(rows_a[:2])
+    assert batch_hash(rows_a).startswith("sha256:")
+
+
+def test_to_row_handles_malformed_walltime_without_dropping_the_event():
+    row = to_row({"seq": 3, "kind": "node", "id": "x", "labels": [], "properties": {},
+                  "wallTime": "not-a-timestamp"})
+    assert row["wall_time"] == "1970-01-01 00:00:00.000"
+    assert row["event_id"] == "node:x" and row["label"] == ""

--- a/apps/prophet-materializer-clickhouse/tests/test_server.py
+++ b/apps/prophet-materializer-clickhouse/tests/test_server.py
@@ -1,0 +1,55 @@
+"""/healthz truthfulness + run_step state folding (loop disabled — units drive steps)."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+os.environ["MATERIALIZER_LOOP"] = "off"   # no background thread under test
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from prophet_materializer_clickhouse import server  # noqa: E402
+from prophet_materializer_clickhouse.materializer import Materializer  # noqa: E402
+from test_materializer import FakeClickHouse, FakeGateway, FakeHellGraph, THREE_EVENTS  # noqa: E402
+
+client = TestClient(server.app)
+
+
+def setup_function():
+    server.STATE.update({
+        "last_cursor": 0, "version": 0, "lag": 0, "batches_ok": 0, "events_written": 0,
+        "receipts": 0, "last_receipt_id": None, "last_batch_at": None,
+        "last_error": None, "last_error_at": None, "loop_running": False,
+    })
+
+
+def test_healthz_reports_cursor_and_lag_after_a_batch():
+    m = Materializer(hellgraph=FakeHellGraph(THREE_EVENTS), clickhouse=FakeClickHouse(),
+                     gateway=FakeGateway(), batch_limit=2)
+    assert server.run_step(m) is True                  # first page (2 events) landed
+
+    h = client.get("/healthz").json()
+    assert h["ok"] is True and h["service"] == "prophet-materializer-clickhouse"
+    assert h["last_cursor"] == 9 and h["version"] == 12 and h["lag"] == 3
+    assert h["batches_ok"] == 1 and h["events_written"] == 2 and h["receipts"] == 1
+    assert h["last_receipt_id"] and h["last_error"] is None
+
+    assert server.run_step(m) is True                  # drain the rest
+    assert server.run_step(m) is False                 # caught up → empty step
+    h = client.get("/healthz").json()
+    assert h["last_cursor"] == 12 and h["lag"] == 0 and h["receipts"] == 2
+
+
+def test_healthz_reports_failure_without_advancing_the_cursor():
+    gw = FakeGateway()
+    gw.down = True
+    m = Materializer(hellgraph=FakeHellGraph(THREE_EVENTS), clickhouse=FakeClickHouse(),
+                     gateway=gw, batch_limit=500)
+    assert server.run_step(m) is False                 # swallowed, recorded, not checkpointed
+
+    h = client.get("/healthz").json()
+    assert h["ok"] is True                             # liveness stays truthful-200
+    assert "GatewayError" in h["last_error"]
+    assert h["last_cursor"] == 0 and h["receipts"] == 0 and h["batches_ok"] == 0

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -60,6 +60,9 @@ spec:
           # - { name: questdb }
           - { name: clickhouse }
           - { name: arcticdb-gateway }
+          # Seal-the-Walls W1.1: proof-carrying log→ClickHouse materializer (first-party;
+          # tails hellgraph-service /api/graph/log, receipts via compute-gateway kind=materialize).
+          - { name: prophet-materializer-clickhouse }
           # spark-runner MOVED to runtime-services → sovereign-runtime (executes user Spark jobs).
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —

--- a/deploy/values/compute-gateway.yaml
+++ b/deploy/values/compute-gateway.yaml
@@ -13,7 +13,9 @@ config:
   HELLGRAPH_URL: "http://hellgraph-service:8090"
   # THE uniform pay-gate across ALL compute kinds (generalizes STUDIO_COMPUTE_ENTITLEMENTS).
   # Tokens: "*" | "<kind>" | "<kind>:<backend>" | "<project>" | "<project>:<kind>" | "<project>:<kind>:<backend>".
-  COMPUTE_ENTITLEMENTS: "demo,default,graph-query,graph-stats,gyg-reporting"
+  # `materialize` = the Seal-the-Walls W1.1 receipt door for materializer batches
+  # (prophet-materializer-clickhouse) — explicit kind token, not reliant on project naming.
+  COMPUTE_ENTITLEMENTS: "demo,default,graph-query,graph-stats,gyg-reporting,materialize"
   # every ok run writes its ComputeRun/Receipt subgraph to hellgraph (best-effort).
   GATEWAY_WRITE_PROVENANCE: "true"
   # Durable proof store: receipts + content-addressed artifacts + the doc→SQL sink land on

--- a/deploy/values/prophet-materializer-clickhouse.yaml
+++ b/deploy/values/prophet-materializer-clickhouse.yaml
@@ -1,0 +1,51 @@
+# prophet-materializer-clickhouse — Seal-the-Walls W1.1: the first proof-carrying
+# materializer (tritfabric fabric/docs/pht.md, "Design commitments 2026-07-29" #3).
+# Tails hellgraph-service GET /api/graph/log (HellGraph IS the log — commitment 1),
+# INSERTs the hellgraph.events derived view into ClickHouse (ReplacingMergeTree keyed
+# by event_id, versioned by seq → idempotent replay), checkpoints by the log's logical
+# clock in hellgraph.materializer_checkpoint, and seals ONE receipt per batch on the
+# estate spine via compute-gateway POST /v1/compute kind=materialize (never a parallel
+# receipt lineage). Fail-closed: no receipt ⇒ no checkpoint ⇒ the batch retries.
+nameOverride: prophet-materializer-clickhouse
+
+image:
+  repository: prophet-materializer-clickhouse
+  # sha-pinned by gitops-promote after the first CI build (arcticdb-gateway precedent).
+  tag: latest
+  # Guard against the moving-tag+IfNotPresent trap while the tag is still `latest`; harmless
+  # once promotion pins an immutable sha- tag (kubelet re-checks, digests match, no-op).
+  pullPolicy: Always
+
+service: { port: 8080, portName: http }
+
+config:
+  HELLGRAPH_URL: "http://hellgraph-service:8090"
+  # the shared chart names the Service after the release/nameOverride → `clickhouse`
+  # (deploy/values/clickhouse.yaml nameOverride), HTTP interface port 8123.
+  CLICKHOUSE_URL: "http://clickhouse:8123"
+  CLICKHOUSE_USER: "default"
+  COMPUTE_GATEWAY_URL: "http://compute-gateway:8080"
+  MATERIALIZER_PROJECT: "default"
+  POLL_INTERVAL_SECONDS: "5"
+  BATCH_LIMIT: "500"
+secretEnv:
+  # the same Secrets the source services already require in this namespace — nothing new
+  # is provisioned for the materializer (see clickhouse.yaml PREREQ + provision-secrets).
+  CLICKHOUSE_PASSWORD: { secretName: clickhouse-admin, key: password }
+  GATEWAY_TOKEN: { secretName: compute-gateway-token, key: token }
+
+# One materializer per sink: the checkpoint row is a single-writer cursor. No HPA; a
+# brief gap during Recreate just means the next poll drains a slightly larger batch —
+# the whole design is restart-safe (idempotent replay from the last committed cut).
+replicaCount: 1
+autoscaling: { enabled: false }
+strategy: { type: Recreate }
+
+probes:
+  path: /healthz   # reports last committed cursor + lag vs the log's clock (honest liveness)
+
+# Honest floor for a poll→map→INSERT loop: httpx + fastapi resident, batches are small
+# (BATCH_LIMIT 500 events) and stream straight through.
+resources:
+  requests: { cpu: 50m,  memory: 256Mi }
+  limits:   { cpu: 500m, memory: 512Mi }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -91,6 +91,12 @@ KNOWN_BROKEN = {
         "tag:latest -> the sha- tag after the first CI build; no sha exists until merge. Its values set "
         "pullPolicy: Always as the interim guard against the moving-tag+IfNotPresent trap."
     ),
+    "prophet-materializer-clickhouse:moving-tag": (
+        "New service — Seal-the-Walls W1.1 proof-carrying log→ClickHouse materializer "
+        "(apps/prophet-materializer-clickhouse) added to images.yml this PR. Pin tag:latest -> the sha- tag "
+        "after the first CI build; no sha exists until merge. Its values set pullPolicy: Always as the "
+        "interim guard against the moving-tag+IfNotPresent trap."
+    ),
     "entity-resolution:moving-tag": (
         "New service — Dockerfile + images.yml entry added this PR. Pin tag:latest -> sha- after first CI build."
     ),


### PR DESCRIPTION
Wave 1.1 of the **Seal-the-Walls** program: the log-tail surface + the first proof-carrying materializer, per the spec in tritfabric `fabric/docs/pht.md` "Design commitments (2026-07-29)" — HellGraph IS the log; derived stores are rebuildable views; materializers checkpoint by the logical clock, write idempotently by `event_id`, and seal receipts on the estate spine, never a new lineage.

## Design

```
hellgraph-service                prophet-materializer-clickhouse            ClickHouse (26.3 LTS, digest-pinned)
GET /api/graph/log  ──poll──▶  read checkpoint → map events → INSERT ──▶  hellgraph.events        (ReplacingMergeTree(seq) ORDER BY event_id)
      ▲                              │ mint receipt (fail-closed)          hellgraph.materializer_checkpoint
      │                              ▼                                     (cursor = the committed cut)
   THE log            compute-gateway POST /v1/compute kind=materialize
                      → hash-chained + Ed25519-attested on THE receipt spine
```

Batch order **is** the correctness argument: `read checkpoint → poll(since) → INSERT rows → mint receipt → INSERT checkpoint`. The checkpoint INSERT is the commit point; everything before it is idempotently repeatable (event_id dedup + gateway memo), and the receipt precedes it — an unattested cut is never committed, it is retried. Empty poll ⇒ no receipt (receipts attest work, not heartbeats). Restarting from an **older** checkpoint produces **zero duplicate rows** at `FINAL` — the acceptance bar, proven on fakes that honestly emulate ReplacingMergeTree parts-vs-FINAL *and* against the real server.

## Log-endpoint contract (Part A)

`GET /api/graph/log?since=<seq>&limit=N` on hellgraph-service → since-**exclusive**, `seq`-ascending, limit-bounded (max 1000):

```json
{ "events": [
    { "seq": 5,  "kind": "node", "id": "n:a", "labels": ["Person"], "properties": {"name": "Ada", "n": 1}, "wallTime": "2026-07-29T12:00:00.000Z" },
    { "seq": 12, "kind": "edge", "id": "<link-handle>", "label": "KNOWS", "from": "n:a", "to": "n:b", "properties": {"w": 2}, "wallTime": "…" }
  ],
  "cursor": 12,     // seq of the last returned event; == since when the page is empty
  "version": 12 }   // the store's logical clock (lag = version - cursor)
```

**Approach chosen: events derived from atoms (`atom.createdAtSeq`), not the engine's `logTail()`.** The vendored engine (0.4.40) *does* expose a public log accessor — `HellGraphStore.logTail(n)` — but it reads the in-memory op log, which the JSONL **restore path does not rebuild** (`applyLogEntry` re-indexes atoms without re-pushing entries): after a pod restart it only covers the current process, so a materializer resuming an older checkpoint would silently miss history. `createdAtSeq`/`createdAt` **are** rehydrated on restore, so the atom-derived surface stays correct across restarts. Documented consequence: the surface emits **creation** events carrying the atom's *current* labels/properties (materialized-view semantics — the ReplacingMergeTree row downstream is latest-wins anyway); later property writes on an already-emitted atom don't re-emit it. Engine consumed strictly via its public API (`getByType`, `getAtom`) — no engine edits.

## Receipt-path decision (Part B)

`/v1/attestation` is a read view and the artifact routes are GETs — the gateway's one minting path is the engine behind `POST /v1/compute`. So the batch receipt goes through a new **`materialize` kind** (in-process `gateway` backend, executes no user code, epistemic `derived`): the request `spec` carries `{source, sink, table, from_cursor, to_cursor, row_count, batch_hash=sha256 over sorted event_ids}` and the spec **is** the receipt's inputs, so `inputs_sha` binds the cut into the hash chain, with the standard in-toto Statement + Ed25519 signature on top. Same chain, same verify, same attestation bundle as every other compute — no parallel lineage.

Two deliberate mechanics:
- **Provenance write-back veto** (`_no_provenance`, honored by the engine): a materialize receipt must not write its provenance subgraph into hellgraph — that graph is the very log being materialized, so each receipt would emit new log events and feed itself forever (~4 nodes + 5 edges per poll interval, unbounded). Its provenance lives on the receipt chain and in the sink's checkpoint row. A regression test proves the veto is per-adapter (a control kind still writes provenance under the same flag).
- **Memo = retry idempotency**: an identical replayed batch (crash after seal, before checkpoint) returns the *same* receipt instead of double-minting.

`COMPUTE_ENTITLEMENTS` gains the explicit `materialize` kind token (not reliant on project naming).

## Wiring (Part C)

- `images.yml`: `prophet-materializer-clickhouse` matrix entry (context `apps/prophet-materializer-clickhouse`).
- `deploy/values/prophet-materializer-clickhouse.yaml`: 256Mi/512Mi, `HELLGRAPH_URL=http://hellgraph-service:8090`, `CLICKHOUSE_URL=http://clickhouse:8123` (the shared chart names the Service after `nameOverride` → `clickhouse`), `COMPUTE_GATEWAY_URL=http://compute-gateway:8080`; secretEnv from the **existing** `clickhouse-admin` + `compute-gateway-token` Secrets in `socioprophet` — nothing new to provision. One replica, Recreate (single-writer checkpoint cursor), `pullPolicy: Always` while the tag is `latest`.
- Appset entry next to `clickhouse`/`arcticdb-gateway`; preflight ratchet entry `prophet-materializer-clickhouse:moving-tag` (arcticdb-gateway precedent) — pin the sha- tag after the first CI build.

## Acceptance evidence (verbatim)

**hellgraph-service** — `node --import tsx --test src/*.test.ts`:
```
✔ log-tail: /api/graph/log streams creation events since a cursor (materializer contract) (4.043625ms)
✔ log-tail: since is exclusive and an empty page keeps the cursor (1.904541ms)
✔ log-tail: limit pages the stream and the cursor resumes it losslessly (3.031542ms)
✔ graphrag: multi-hop grounding reaches beyond 1 hop (?hops=2) (4.992625ms)
ℹ tests 27
ℹ pass 27
ℹ fail 0
```

**compute-gateway** — `PYTHONPATH=src pytest -q tests` (includes the 4 new `test_materialize.py` tests):
```
86 passed, 1 warning in 0.79s
```

**prophet-materializer-clickhouse** — `pytest -q tests` (10 unit on fakes + 1 podman integration against the exact values digest, image ref parsed from `deploy/values/clickhouse.yaml` so it cannot drift):
```
...........                                                              [100%]
11 passed in 8.19s
```
The four required scenarios are individually covered: (1) happy-path → rows+checkpoint+receipt coherent; (2) crash-after-insert-before-checkpoint → rerun → raw parts hold 6 rows, FINAL holds exactly the 3 event_ids (zero duplicates, asserted by event_id set) — plus an explicit restart-from-older-checkpoint variant; (3) empty poll → no receipt, no checkpoint; (4) gateway unreachable → GatewayError, cut NOT committed, retried cleanly. The integration test replays a rewound cut against real ClickHouse `26.3.17.56` and asserts `count() FINAL == uniqExact(event_id) == 3` with `raw >= 3`.

**Repo validation**:
```
helm-render: 43/43 values files ok (incl. prophet-materializer-clickhouse.yaml)
preflight:   OK: every deployed first-party service is built by CI and pulls from a registry we publish to
             (new service ratcheted: prophet-materializer-clickhouse:moving-tag — pin sha- after first build)
```

Pre-existing, untouched: the two `tsc --noEmit` `import.meta` diagnostics in hellgraph-service (`seedIfEmpty`/`loadRcIfEnabled`) exist identically on `main`; tests and the tsx runtime are unaffected.

## Post-merge

1. gitops-promote pins the first `sha-` tag → remove the ratchet entry.
2. The `clickhouse-admin` Secret must exist before the pod goes Ready (already a clickhouse.yaml PREREQ; the materializer reuses it).
3. First run materializes the full existing log from cursor 0 in 500-event pages — by design (views are rebuildable from the log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
