### PR TITLE
feat: market-replay — first sourceos-spec MarketDataEvent emitter (W1.2)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -95,6 +95,9 @@ jobs:
           - { image: arcticdb-gateway,      context: apps/arcticdb-gateway,      dockerfile: Dockerfile }
           # Seal-the-Walls W1.1: proof-carrying HellGraph-log → ClickHouse materializer.
           - { image: prophet-materializer-clickhouse, context: apps/prophet-materializer-clickhouse, dockerfile: Dockerfile }
+          # Seal-the-Walls W1.2: deterministic synthetic MarketDataEvent replay emitter —
+          # the first sourceos-spec-conformant events INTO the log the materializer tails.
+          - { image: market-replay,         context: apps/market-replay,         dockerfile: Dockerfile }
     uses: SocioProphet/.github/.github/workflows/build-image.yml@main
     with:
       image: ${{ matrix.image }}

--- a/apps/market-replay/Dockerfile
+++ b/apps/market-replay/Dockerfile
@@ -1,0 +1,14 @@
+# market-replay — Seal-the-Walls W1.2: the first sourceos-spec-conformant event
+# producer. A deterministic seeded random walk emits SYNTHETIC MarketDataEvent objects
+# (validated per event against the vendored sourceos-spec schema, fail-closed) into the
+# platform log as hellgraph-service graph writes (POST /api/graph/node|edge); the W1.1
+# materializer tails the log and lands them in ClickHouse. No real market data.
+# python:3.11-slim mirrors apps/arcticdb-gateway + apps/prophet-materializer-clickhouse.
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+ENV PORT=8080
+EXPOSE 8080
+CMD ["uvicorn", "market_replay.server:app", "--host", "0.0.0.0", "--port", "8080", "--app-dir", "src"]

--- a/apps/market-replay/pyproject.toml
+++ b/apps/market-replay/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "market-replay"
+version = "0.1.0"
+description = "Seal-the-Walls W1.2: deterministic synthetic MarketDataEvent replay emitter — first sourceos-spec-conformant events into the HellGraph platform log (schema-validated per event, fail-closed)"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi==0.115.0",
+  "uvicorn==0.30.6",
+  "httpx==0.27.2",
+  "jsonschema==4.26.0",
+]
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/apps/market-replay/requirements-test.txt
+++ b/apps/market-replay/requirements-test.txt
@@ -1,0 +1,3 @@
+# Test-only dependencies (fastapi.testclient needs httpx, already a runtime pin).
+# Runtime pins live in requirements.txt.
+pytest==8.3.2

--- a/apps/market-replay/requirements.txt
+++ b/apps/market-replay/requirements.txt
@@ -1,0 +1,29 @@
+# Exact runtime closure (pip freeze of the four top-level pins in pyproject.toml).
+# Shared pins line up with apps/prophet-materializer-clickhouse/requirements.txt (same
+# base image, same fastapi/uvicorn/httpx line; httpcore 1.0.9 + h11 0.16.0 are the
+# post-CVE-2025-43859 pairing). jsonschema==4.26.0 brings attrs (already 26.1.0 in the
+# arcticdb-gateway closure), jsonschema-specifications, referencing and rpds-py — the
+# per-event Draft 2020-12 validation gate against the VENDORED sourceos-spec
+# MarketDataEvent.json (hermetic: no network, no spec checkout; provenance + sha256
+# pinned in src/market_replay/contract.py).
+fastapi==0.115.0
+uvicorn==0.30.6
+httpx==0.27.2
+jsonschema==4.26.0
+annotated-types==0.8.0
+anyio==4.14.2
+attrs==26.1.0
+certifi==2026.7.22
+click==8.4.2
+h11==0.16.0
+httpcore==1.0.9
+idna==3.18
+jsonschema-specifications==2025.9.1
+pydantic==2.13.4
+pydantic_core==2.46.4
+referencing==0.37.0
+rpds-py==2026.6.3
+sniffio==1.3.1
+starlette==0.38.6
+typing-inspection==0.4.2
+typing_extensions==4.16.0

--- a/apps/market-replay/src/market_replay/__init__.py
+++ b/apps/market-replay/src/market_replay/__init__.py
@@ -1,0 +1,1 @@
+"""market-replay — Seal-the-Walls W1.2: first sourceos-spec MarketDataEvent emitter (synthetic replay → HellGraph log)."""

--- a/apps/market-replay/src/market_replay/contract.py
+++ b/apps/market-replay/src/market_replay/contract.py
@@ -1,0 +1,139 @@
+"""The vendored MarketDataEvent contract: tick → event constructor + hermetic validation.
+
+Schema provenance (vendored so validation needs no network and no spec checkout):
+    repo    SourceOS-Linux/sourceos-spec  (merged PR #204)
+    path    schemas/MarketDataEvent.json
+    commit  487e4b614b79e556af3aea2c70471eca13281377
+            (2026-07-28, "schemas: MPCC event contract v0.1 — conversation + trading
+            event family")
+    sha256  7d18865d1a435f8a2e78977ef51f865b842c810f4648faa8755b506fe8b13d55
+Re-vendor by copying the file from sourceos-spec and updating this block. The sha256 is
+asserted at import: a drifted or hand-edited copy fails LOUDLY at startup, never
+silently at emit time — the emitter's whole claim is "what enters the log conforms to
+the estate contract", so the contract itself must be tamper-evident.
+
+MarketDataEvent is a profile of the ConversationEvent envelope (same identity /
+causality / governance vocabulary: id URN, type, specVersion, actorRef, workspaceRef,
+branchRef, wallTime, logicalTime, provenanceLinks, policyLabels, riskLabels). Required
+here: id, type, specVersion, wallTime, instrumentRef, venueRef, eventKind, rawPayload,
+canonicalPayload — with additionalProperties: false, so the validator rejects both
+missing fields AND invented ones.
+
+Fail-closed startup: startup_check() re-hashes the vendored bytes, checks the schema is
+itself a valid Draft 2020-12 schema, and validates one probe event built from a probe
+tick — so a generator↔contract drift kills the process at boot, before a single
+non-conformant object can reach the log.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from importlib import resources
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from .generator import Tick
+
+SCHEMA_SHA256 = "7d18865d1a435f8a2e78977ef51f865b842c810f4648faa8755b506fe8b13d55"
+SPEC_VERSION = "0.1.0"                       # const in the schema — pinned, not guessed
+URN_PREFIX = "urn:srcos:market-data-event:"
+
+# Fixed envelope identity for this producer (free-form refs are permitted in v0.1).
+ACTOR_REF = "urn:srcos:agent:market-replay"
+WORKSPACE_REF = "socioprophet"
+BRANCH_REF = "main"
+VENUE_REF = "SYNTH"                          # synthetic venue — clearly not a real MIC
+FEED_REF = "market-replay/synthetic-walk"
+NORMALIZATION_REGIME = "market-replay/synthetic-walk@v1"
+
+_SCHEMA_BYTES = (resources.files("market_replay") / "schemas" / "MarketDataEvent.json").read_bytes()
+_actual = hashlib.sha256(_SCHEMA_BYTES).hexdigest()
+if _actual != SCHEMA_SHA256:  # tamper-evident vendoring — see module docstring
+    raise RuntimeError(
+        f"vendored MarketDataEvent.json drifted: sha256 {_actual} != pinned {SCHEMA_SHA256}; "
+        "re-vendor from sourceos-spec and update contract.py provenance")
+
+SCHEMA: dict[str, Any] = json.loads(_SCHEMA_BYTES)
+VALIDATOR = Draft202012Validator(SCHEMA)
+
+# URN local-id charset per the schema's id pattern: [A-Za-z0-9._~-]. Symbols like
+# "SP:AAA" carry a colon, so the local id sanitizes it ("SP-AAA") while the event's
+# instrumentRef keeps the raw symbol. One local id serves BOTH the URN and the graph
+# node id, so node ↔ event identity is 1:1 by construction.
+_URN_UNSAFE = re.compile(r"[^A-Za-z0-9._~-]")
+
+
+def local_id(symbol: str, seq: int) -> str:
+    return f"mde-{_URN_UNSAFE.sub('-', symbol)}-{seq:06d}"
+
+
+def build_event(tick: Tick, wall_time: str) -> dict[str, Any]:
+    """One synthetic trade tick → one MarketDataEvent-conformant object.
+
+    rawPayload is the generator's output verbatim ("as received, before any
+    normalization"); canonicalPayload declares its normalization regime, as the
+    schema's invariant demands. qualityFlags carries "synthetic" — the schema's own
+    example flag — so no consumer can mistake replay data for a real feed.
+    """
+    return {
+        "id": URN_PREFIX + local_id(tick.symbol, tick.seq),
+        "type": "MarketDataEvent",
+        "specVersion": SPEC_VERSION,
+        "actorRef": ACTOR_REF,
+        "workspaceRef": WORKSPACE_REF,
+        "branchRef": BRANCH_REF,
+        "wallTime": wall_time,
+        "logicalTime": tick.seq,
+        "instrumentRef": tick.symbol,
+        "venueRef": VENUE_REF,
+        "eventKind": "trade",
+        "sequenceRef": tick.seq,
+        "feedRef": FEED_REF,
+        "rawPayload": {"symbol": tick.symbol, "seq": tick.seq,
+                       "price": tick.price, "volume": tick.volume},
+        "canonicalPayload": {"normalizationRegime": NORMALIZATION_REGIME,
+                             "instrument": tick.symbol, "price": tick.price,
+                             "size": tick.volume, "side": "synthetic"},
+        "qualityFlags": ["synthetic"],
+        "policyLabels": ["synthetic-data"],
+    }
+
+
+def validate_event(event: dict[str, Any]) -> None:
+    """Raises jsonschema.ValidationError on any non-conformance (fail-closed gate)."""
+    VALIDATOR.validate(event)
+
+
+def flatten(event: dict[str, Any], ingest_time: str) -> dict[str, Any]:
+    """The graph-node property projection the materializer carries to ClickHouse:
+    flat scalars for querying, PLUS the full validated event as canonical JSON — so
+    the log carries the spec-conformant OBJECT, not just a lossy projection."""
+    return {
+        "eventId": event["id"],
+        "schemaVersion": event["specVersion"],
+        "eventKind": event["eventKind"],
+        "symbol": event["instrumentRef"],
+        "venue": event["venueRef"],
+        "price": event["canonicalPayload"]["price"],
+        "volume": event["canonicalPayload"]["size"],
+        "seq": event["sequenceRef"],
+        "eventTime": event["wallTime"],
+        "ingestTime": ingest_time,
+        "feed": event["feedRef"],
+        "actor": event["actorRef"],
+        "synthetic": True,
+        "event": json.dumps(event, sort_keys=True, ensure_ascii=False),
+    }
+
+
+def startup_check(probe_tick: Tick, wall_time: str) -> None:
+    """Boot-time fail-closed gate: schema is valid 2020-12 AND a probe event built by
+    THIS code validates against it. Any drift dies here, before the first emit."""
+    Draft202012Validator.check_schema(SCHEMA)
+    validate_event(build_event(probe_tick, wall_time))
+
+
+__all__ = ["SCHEMA", "SCHEMA_SHA256", "SPEC_VERSION", "build_event", "validate_event",
+           "flatten", "local_id", "startup_check"]

--- a/apps/market-replay/src/market_replay/emitter.py
+++ b/apps/market-replay/src/market_replay/emitter.py
@@ -1,0 +1,178 @@
+"""The emitter core — validate-then-write, one governed batch per call, restart-safe.
+
+Write path (the whole point of W1.2 — events enter the platform log as graph writes):
+
+    tick → build_event → VALIDATE (jsonschema, fail-closed) →
+        POST /api/graph/node  {id: mde-<sym>-<seq>, labels: [MarketDataEvent, <symbol>],
+                               properties: flattened event + full event JSON}
+        POST /api/graph/edge  {label: aboutSymbol, from: <event node>, to: <symbol node>}
+
+hellgraph-service appends both writes to its log; prophet-materializer-clickhouse (W1.1)
+tails GET /api/graph/log and lands them in ClickHouse. This service never talks to
+ClickHouse — the log is the only door (pht.md commitment 1).
+
+Fail-closed rules, in order of severity:
+- VALIDATION failure ⇒ the event is NOT emitted, counted, and logged loudly. The tick
+  is dropped (a deterministically-invalid tick would wedge the stream forever); the
+  count on /healthz is the alarm — its steady-state MUST be 0.
+- HELLGRAPH failure ⇒ the batch stays PENDING and is retried next interval; no new
+  ticks are generated while a batch is pending (bounded memory, gapless seq stream).
+  Each pending item tracks node/edge completion separately: node re-POSTs are safe
+  (upsert + ReplacingMergeTree dedup by event_id) but a re-added edge would mint a NEW
+  log event and a duplicate ClickHouse row — so a half-emitted item never re-sends the
+  half that landed.
+- The loop never dies: any error is recorded in state and retried after the interval.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+import httpx
+import jsonschema
+
+from .contract import build_event, flatten, local_id, startup_check, validate_event
+from .generator import Tick, TickGenerator
+
+log = logging.getLogger("market-replay")
+
+TIMEOUT = 10.0
+EVENT_LABEL = "MarketDataEvent"
+SYMBOL_LABEL = "Symbol"
+EDGE_LABEL = "aboutSymbol"
+
+
+class EmitError(RuntimeError):
+    """hellgraph-service unreachable or refused a write — retry, never crash-loop."""
+
+
+class HellGraphWriter:
+    """The one door out: POST /api/graph/node|edge on hellgraph-service. Injectable so
+    unit tests prove batch semantics (shapes, retry, no duplicate edges) on a fake."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    def _post(self, path: str, payload: dict[str, Any]) -> None:
+        try:
+            r = httpx.post(f"{self.base_url}{path}", json=payload, timeout=TIMEOUT)
+        except httpx.HTTPError as e:
+            raise EmitError(f"hellgraph unreachable: {e}") from e
+        if r.status_code != 200:
+            raise EmitError(f"hellgraph {r.status_code} on {path}: {r.text[:300]}")
+
+    def post_node(self, node_id: str, labels: list[str], properties: dict[str, Any]) -> None:
+        self._post("/api/graph/node", {"id": node_id, "labels": labels, "properties": properties})
+
+    def post_edge(self, label: str, from_id: str, to_id: str) -> None:
+        self._post("/api/graph/edge", {"label": label, "from": from_id, "to": to_id})
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+@dataclass
+class _Pending:
+    """One validated event's remaining writes. node_done flips before the edge POST so
+    a mid-item failure resumes exactly where it stopped."""
+    event: dict[str, Any]
+    node_id: str
+    symbol: str
+    seq: int
+    node_done: bool = False
+
+
+@dataclass
+class BatchResult:
+    generated: int = 0
+    emitted: int = 0              # events whose node AND edge both landed this call
+    validation_failures: int = 0
+    pending: int = 0              # events still awaiting hellgraph after this call
+    last_seq: int = 0
+    hellgraph_ok: bool = True
+
+
+@dataclass
+class ReplayEmitter:
+    generator: TickGenerator
+    writer: Any                   # HellGraphWriter | test fake
+    clock: Callable[[], str] = field(default=_utc_now_iso)
+    _symbols_ensured: bool = field(default=False, repr=False)
+    _pending: list[_Pending] = field(default_factory=list, repr=False)
+    _last_seq: int = field(default=0, repr=False)
+
+    def startup_check(self) -> None:
+        """Boot gate: vendored-schema hash already asserted at import; here a probe
+        event from a THROWAWAY generator (same seed) must validate. Raises on drift —
+        the process must not come up able to emit non-conformant objects."""
+        probe = TickGenerator(self.generator.symbols, self.generator.seed).next_tick(
+            self.generator.symbols[0])
+        startup_check(probe, self.clock())
+
+    def ensure_symbols(self) -> None:
+        """Upsert one Symbol node per configured symbol (id = the raw symbol string).
+        Runs once per process; addNode is an upsert, so restarts are harmless."""
+        for s in self.generator.symbols:
+            self.writer.post_node(s, [SYMBOL_LABEL], {"symbol": s, "synthetic": True})
+        self._symbols_ensured = True
+
+    def run_once(self) -> BatchResult:
+        """One interval: (re)try symbol nodes, drain any pending half-batch, and only
+        when nothing is pending generate + validate + emit a fresh batch."""
+        result = BatchResult(last_seq=self._last_seq)
+
+        if not self._symbols_ensured:
+            try:
+                self.ensure_symbols()
+            except EmitError as e:
+                log.warning("symbol-node upsert failed, will retry: %s", e)
+                result.hellgraph_ok = False
+                result.pending = len(self._pending)
+                return result
+
+        if not self._pending:
+            for tick in self.generator.next_batch():
+                result.generated += 1
+                event = build_event(tick, self.clock())
+                try:
+                    # THE fail-closed gate: nothing non-conformant may reach the log.
+                    validate_event(event)
+                except jsonschema.ValidationError as e:
+                    result.validation_failures += 1
+                    log.error("VALIDATION FAILURE — event NOT emitted (symbol=%s seq=%s): %s",
+                              tick.symbol, tick.seq, e.message)
+                    continue
+                self._pending.append(_Pending(event=event, symbol=tick.symbol, seq=tick.seq,
+                                              node_id=local_id(tick.symbol, tick.seq)))
+
+        result.emitted, result.hellgraph_ok = self._drain()
+        result.pending = len(self._pending)
+        result.last_seq = self._last_seq
+        return result
+
+    def _drain(self) -> tuple[int, bool]:
+        emitted = 0
+        while self._pending:
+            item = self._pending[0]
+            try:
+                if not item.node_done:
+                    self.writer.post_node(
+                        item.node_id, [EVENT_LABEL, item.symbol],
+                        flatten(item.event, ingest_time=self.clock()))
+                    item.node_done = True
+                self.writer.post_edge(EDGE_LABEL, item.node_id, item.symbol)
+            except EmitError as e:
+                log.warning("hellgraph write failed at %s (seq=%s), batch stays pending: %s",
+                            "edge" if item.node_done else "node", item.seq, e)
+                return emitted, False
+            self._pending.pop(0)
+            emitted += 1
+            self._last_seq = max(self._last_seq, item.seq)
+        return emitted, True
+
+
+__all__ = ["ReplayEmitter", "HellGraphWriter", "BatchResult", "EmitError",
+           "EVENT_LABEL", "SYMBOL_LABEL", "EDGE_LABEL"]

--- a/apps/market-replay/src/market_replay/generator.py
+++ b/apps/market-replay/src/market_replay/generator.py
@@ -1,0 +1,70 @@
+"""Deterministic synthetic tick source — a seeded random walk per symbol.
+
+SYNTHETIC BY CONSTRUCTION: no real market data enters this service. Prices start at a
+base derived from sha256(symbol) (never Python's salted hash — PYTHONHASHSEED would
+break replay), step by a seeded Gaussian return, and every downstream event carries
+qualityFlags=["synthetic"]. The point of W1.2 is the CONTRACT — the first
+sourceos-spec-conformant MarketDataEvent objects flowing through the platform log —
+not the data.
+
+Determinism is the acceptance bar: each symbol owns a private random.Random seeded
+with "<seed>:<symbol>", so a symbol's price path depends only on (seed, symbol, seq) —
+not on the symbol list's order, the interval, or the wall clock. Two generators with
+the same seed produce byte-identical tick streams (the unit-test gate), which makes
+every row the materializer lands in ClickHouse replayable from first principles.
+"""
+from __future__ import annotations
+
+import hashlib
+import random
+from dataclasses import dataclass
+
+# Walk parameters — small per-tick moves so long runs stay in a plausible band.
+STEP_SIGMA = 0.005          # stddev of the per-tick fractional return
+PRICE_FLOOR = 0.01          # a random walk must never emit a non-positive price
+VOLUME_RANGE = (1, 1_000)   # inclusive bounds for the synthetic trade size
+
+
+def base_price(symbol: str) -> float:
+    """Stable starting price in [50, 150) derived from sha256(symbol) — identical on
+    every host and run, independent of process hash randomization."""
+    digest = hashlib.sha256(symbol.encode("utf-8")).digest()
+    return 50.0 + (int.from_bytes(digest[:8], "big") % 10_000) / 100.0
+
+
+@dataclass(frozen=True)
+class Tick:
+    symbol: str
+    seq: int          # per-symbol, monotonically increasing from 1 — the replay clock
+    price: float
+    volume: int
+
+
+class TickGenerator:
+    """Per-symbol seeded random walk. `next_batch()` yields one Tick per symbol in the
+    configured order; per-symbol state is independent, so adding or reordering symbols
+    never perturbs another symbol's path."""
+
+    def __init__(self, symbols: list[str], seed: int) -> None:
+        if not symbols:
+            raise ValueError("TickGenerator needs at least one symbol")
+        self.symbols = list(symbols)
+        self.seed = seed
+        self._rng = {s: random.Random(f"{seed}:{s}") for s in self.symbols}
+        self._price = {s: base_price(s) for s in self.symbols}
+        self._seq = {s: 0 for s in self.symbols}
+
+    def next_tick(self, symbol: str) -> Tick:
+        rng = self._rng[symbol]
+        step = rng.gauss(0.0, STEP_SIGMA)
+        price = max(PRICE_FLOOR, round(self._price[symbol] * (1.0 + step), 4))
+        self._price[symbol] = price
+        self._seq[symbol] += 1
+        return Tick(symbol=symbol, seq=self._seq[symbol], price=price,
+                    volume=rng.randint(*VOLUME_RANGE))
+
+    def next_batch(self) -> list[Tick]:
+        return [self.next_tick(s) for s in self.symbols]
+
+
+__all__ = ["Tick", "TickGenerator", "base_price"]

--- a/apps/market-replay/src/market_replay/schemas/MarketDataEvent.json
+++ b/apps/market-replay/src/market_replay/schemas/MarketDataEvent.json
@@ -1,0 +1,240 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/MarketDataEvent.json",
+  "title": "MarketDataEvent",
+  "description": "A venue-originating or feed-originating market-data state change (quote, trade, book delta/snapshot, bar, venue status, heartbeat, or gap marker). Profile of the ConversationEvent envelope: shares the single MPCC identity/causality/governance vocabulary (specVersion, actorRef, workspaceRef, branchRef, visibilityScope, wallTime, logicalTime, causalParents, traceContext, provenanceLinks, policyLabels, riskLabels) — envelope parity is enforced by tools/validate_mpcc_event_examples.py. Provenance: SocioProphet/profit-mpcc schemas/market-data-event.schema.json and docs/trading-event-families.md, hardened to the policy-integrity tranche-0001 strictness bar.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "wallTime",
+    "instrumentRef",
+    "venueRef",
+    "eventKind",
+    "rawPayload",
+    "canonicalPayload"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:market-data-event:[A-Za-z0-9._~-]+$",
+      "description": "Stable URN identifier. Pattern: urn:srcos:market-data-event:<local-id>. Invariant: event identity is stable and never reused."
+    },
+    "type": {
+      "const": "MarketDataEvent",
+      "description": "Discriminator constant — always \"MarketDataEvent\"."
+    },
+    "specVersion": {
+      "const": "0.1.0",
+      "description": "MPCC event-contract version, pinned per the profit-mpcc policy-integrity tranche-0001 discipline. This family is versioned independently of the v2 metadata-plane schemas; changing this const is a contract change."
+    },
+    "actorRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Authority reference of the actor that emitted this event (human subject, agent, service, or system). Subject or Agent Registry URNs are recommended; free-form identifiers are permitted in v0.1."
+    },
+    "workspaceRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Workspace scope this event belongs to. Free-form stable reference in v0.1; a typed workspace URN may narrow this in a later minor version."
+    },
+    "branchRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Conversation-fabric branch this event was appended to. Free-form stable reference in v0.1, pending adoption of the profit-mpcc branch-id contract."
+    },
+    "visibilityScope": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A visibility scope label such as private, shared, public, or an audience URN."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Visibility scopes governing who may observe this event (e.g. private, shared, public, or audience URNs)."
+    },
+    "wallTime": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 wall-clock time of the event as observed by the producer. Family profiles map their primary domain timestamp onto this field."
+    },
+    "logicalTime": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "minimum": 0,
+      "minLength": 1,
+      "description": "Producer-scoped logical clock: a non-negative integer for scalar (Lamport-style) clocks, or a non-empty string for encoded vector/hybrid clocks. Invariant: causalParents must never point forward in logical time."
+    },
+    "causalParents": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^urn:srcos:[a-z0-9-]+:[A-Za-z0-9._~-]+$",
+        "description": "URN of a causally preceding event in any MPCC event family."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Event URNs this event causally depends on. Cross-family parents are permitted (e.g. an OrderIntent caused by a MarketDataEvent). Invariant: parents must never point forward in logical time."
+    },
+    "traceContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "traceId"
+      ],
+      "properties": {
+        "traceId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Distributed trace identifier."
+        },
+        "spanId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Span identifier within the trace."
+        },
+        "baggage": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "String-valued trace baggage entries."
+        }
+      },
+      "description": "Optional distributed-tracing correlation context."
+    },
+    "provenanceLinks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "rel",
+          "ref"
+        ],
+        "properties": {
+          "rel": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Relation of the linked artifact to this event (e.g. derived_from, quotes, source_feed)."
+          },
+          "ref": {
+            "type": "string",
+            "minLength": 1,
+            "description": "URN or stable reference of the linked artifact."
+          }
+        },
+        "description": "A single provenance link (relation + reference)."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Typed provenance links from this event to upstream artifacts, sources, or records."
+    },
+    "policyLabels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A policy label."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Policy labels attached to this event by producers or the policy fabric."
+    },
+    "riskLabels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A risk label."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Risk labels attached to this event by producers or risk controls."
+    },
+    "instrumentRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Instrument identifier (symbology per the venue/feed contract, e.g. ACME.XNAS)."
+    },
+    "venueRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Venue identifier the event originates from or refers to (e.g. a MIC such as XNAS)."
+    },
+    "eventKind": {
+      "type": "string",
+      "enum": [
+        "quote",
+        "trade",
+        "book_delta",
+        "book_snapshot",
+        "bar",
+        "venue_status",
+        "heartbeat",
+        "gap_marker"
+      ],
+      "description": "Kind of market-data event: quote, trade, book delta, book snapshot, bar, venue status, heartbeat, or gap marker."
+    },
+    "sequenceRef": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "minimum": 0,
+      "minLength": 1,
+      "description": "Feed or venue sequence number (non-negative integer) or sequence token (non-empty string) used for ordering and gap detection."
+    },
+    "feedRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the concrete feed or subscription that delivered this event."
+    },
+    "rawPayload": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ],
+      "description": "The venue/feed payload exactly as received, before any normalization."
+    },
+    "canonicalPayload": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ],
+      "description": "The normalized payload. Invariant: the canonical form must declare the normalization regime used."
+    },
+    "nullAbsenceRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:null-absence:[A-Za-z0-9._~-]+$",
+      "description": "NullAbsenceRecord URN when this event marks a typed absence (heartbeat, gap_marker). Typed reference replacing the loose inline null_absence object of the source draft."
+    },
+    "qualityFlags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A data-quality flag."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Data-quality flags attached by the feed handler (e.g. stale, out_of_order, synthetic)."
+    }
+  }
+}

--- a/apps/market-replay/src/market_replay/server.py
+++ b/apps/market-replay/src/market_replay/server.py
@@ -1,0 +1,101 @@
+"""HTTP shell: /healthz (emitted count, last seq, validation failures, hellgraph
+reachability — the truth) + the replay loop on a daemon thread.
+
+The loop never dies: hellgraph outages leave the batch pending and retried next
+interval (see emitter.run_once — no crash-loop, no gap in the seq stream); validation
+failures are counted and surfaced, never emitted. /healthz always answers 200 with the
+truth; liveness is "the process and loop are up", not "every dependency is green" — a
+producer has no traffic to gate, and restarting it cannot fix a down hellgraph.
+
+Config (env):
+  HELLGRAPH_URL             the graph/log surface       (default http://hellgraph-service:8090)
+  REPLAY_ENABLED            "on"/"off" — the loop gate  (default on; off = serve /healthz only)
+  REPLAY_INTERVAL_SECONDS   seconds between batches     (default 5)
+  REPLAY_SYMBOLS            comma-separated symbol set  (default SP:AAA,SP:BBB,SP:CCC)
+  REPLAY_SEED               random-walk seed            (default 42 — deterministic by default)
+"""
+from __future__ import annotations
+
+import os
+import threading
+import time
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from .emitter import HellGraphWriter, ReplayEmitter
+from .generator import TickGenerator
+
+REPLAY_ENABLED = os.getenv("REPLAY_ENABLED", "on").lower() != "off"
+REPLAY_INTERVAL = float(os.getenv("REPLAY_INTERVAL_SECONDS", "5"))
+SYMBOLS = [s.strip() for s in
+           os.getenv("REPLAY_SYMBOLS", "SP:AAA,SP:BBB,SP:CCC").split(",") if s.strip()]
+SEED = int(os.getenv("REPLAY_SEED", "42"))
+
+
+@asynccontextmanager
+async def _lifespan(_app: FastAPI):
+    if REPLAY_ENABLED:
+        em = build_emitter()
+        # Fail-closed boot gate IN THE MAIN THREAD: contract drift (schema hash is
+        # already asserted at import; this validates a probe event) aborts uvicorn
+        # startup — a visible crash, never a silently dead loop behind a green pod.
+        em.startup_check()
+        threading.Thread(target=_loop, args=(em,), name="replay-loop", daemon=True).start()
+    yield
+
+
+app = FastAPI(title="market-replay", version="0.1.0", lifespan=_lifespan)
+
+STATE: dict = {
+    "enabled": REPLAY_ENABLED, "symbols": SYMBOLS, "seed": SEED,
+    "interval_seconds": REPLAY_INTERVAL,
+    "ticks_generated": 0, "emitted": 0, "last_seq": 0,
+    "validation_failures": 0,          # steady-state MUST be 0 — nonzero is the alarm
+    "pending": 0, "hellgraph_ok": None,
+    "last_emit_at": None, "last_error": None, "last_error_at": None,
+    "loop_running": False,
+}
+_STATE_LOCK = threading.Lock()
+
+
+def build_emitter() -> ReplayEmitter:
+    return ReplayEmitter(
+        generator=TickGenerator(SYMBOLS, seed=SEED),
+        writer=HellGraphWriter(os.getenv("HELLGRAPH_URL", "http://hellgraph-service:8090")))
+
+
+def run_step(em: ReplayEmitter) -> None:
+    """One loop step: run a batch, fold the outcome into STATE."""
+    try:
+        result = em.run_once()
+        with _STATE_LOCK:
+            STATE["ticks_generated"] += result.generated
+            STATE["emitted"] += result.emitted
+            STATE["validation_failures"] += result.validation_failures
+            STATE["pending"] = result.pending
+            STATE["last_seq"] = result.last_seq
+            STATE["hellgraph_ok"] = result.hellgraph_ok
+            STATE["last_error"] = None
+            if result.emitted:
+                STATE["last_emit_at"] = time.time()
+    except Exception as e:  # noqa: BLE001 — the loop must survive any dependency outage
+        with _STATE_LOCK:
+            STATE["hellgraph_ok"] = False
+            STATE["last_error"] = f"{type(e).__name__}: {e}"
+            STATE["last_error_at"] = time.time()
+
+
+def _loop(em: ReplayEmitter) -> None:
+    with _STATE_LOCK:
+        STATE["loop_running"] = True
+    while True:
+        run_step(em)
+        time.sleep(REPLAY_INTERVAL)
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    with _STATE_LOCK:
+        snapshot = dict(STATE)
+    return {"ok": True, "service": "market-replay", **snapshot}

--- a/apps/market-replay/tests/test_emitter.py
+++ b/apps/market-replay/tests/test_emitter.py
@@ -1,0 +1,205 @@
+"""Unit gate for the contract + emitter core: NOTHING NON-CONFORMANT REACHES THE LOG.
+
+The hellgraph door is faked. The fake records every write verbatim, so the assertions
+pin the exact node/edge shapes the platform log (and, via the W1.1 materializer,
+ClickHouse) will carry — and the failure tests prove fail-closed validation and
+retry-without-duplicates under an outage.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from market_replay import contract, emitter as emitter_mod  # noqa: E402
+from market_replay.contract import build_event, flatten, local_id, validate_event  # noqa: E402
+from market_replay.emitter import (  # noqa: E402
+    EDGE_LABEL, EVENT_LABEL, SYMBOL_LABEL, EmitError, ReplayEmitter,
+)
+from market_replay.generator import Tick, TickGenerator  # noqa: E402
+
+SYMBOLS = ["SP:AAA", "SP:BBB", "SP:CCC"]
+WALL = "2026-07-29T12:00:00.000Z"
+
+
+class FakeWriter:
+    """Records post_node/post_edge verbatim; `down` fails everything, `fail_edges`
+    fails only edges (the half-emitted-item case)."""
+
+    def __init__(self):
+        self.nodes: list[tuple] = []
+        self.edges: list[tuple] = []
+        self.down = False
+        self.fail_edges = False
+
+    def post_node(self, node_id, labels, properties):
+        if self.down:
+            raise EmitError("hellgraph down")
+        self.nodes.append((node_id, list(labels), dict(properties)))
+
+    def post_edge(self, label, from_id, to_id):
+        if self.down or self.fail_edges:
+            raise EmitError("hellgraph down")
+        self.edges.append((label, from_id, to_id))
+
+
+def make(writer=None) -> tuple[ReplayEmitter, FakeWriter]:
+    w = writer or FakeWriter()
+    em = ReplayEmitter(generator=TickGenerator(SYMBOLS, seed=42), writer=w,
+                       clock=lambda: WALL)
+    return em, w
+
+
+# ── the contract itself ──────────────────────────────────────────────────────
+
+
+def test_generated_events_validate_against_the_vendored_schema():
+    gen = TickGenerator(SYMBOLS, seed=42)
+    for _ in range(10):
+        for tick in gen.next_batch():
+            validate_event(build_event(tick, WALL))     # raises on any drift
+
+
+def test_event_shape_is_the_spec_envelope():
+    ev = build_event(Tick(symbol="SP:AAA", seq=7, price=101.25, volume=42), WALL)
+    assert ev["id"] == "urn:srcos:market-data-event:mde-SP-AAA-000007"
+    assert ev["type"] == "MarketDataEvent" and ev["specVersion"] == "0.1.0"
+    assert ev["instrumentRef"] == "SP:AAA" and ev["eventKind"] == "trade"
+    assert ev["logicalTime"] == 7 and ev["sequenceRef"] == 7
+    assert ev["qualityFlags"] == ["synthetic"]          # unmistakably not a real feed
+    assert ev["canonicalPayload"]["normalizationRegime"]  # schema invariant: declared
+    validate_event(ev)
+
+
+@pytest.mark.parametrize("mutate", [
+    lambda e: e.pop("instrumentRef"),                       # missing required
+    lambda e: e.pop("canonicalPayload"),                    # missing required
+    lambda e: e.update(eventKind="vibes"),                  # outside the enum
+    lambda e: e.update(id="urn:srcos:market-data-event:mde-SP:AAA-7"),  # ':' breaks the URN charset
+    lambda e: e.update(specVersion="9.9.9"),                # const violation
+    lambda e: e.update(bonusField=True),                    # additionalProperties: false
+])
+def test_malformed_events_are_rejected(mutate):
+    ev = build_event(Tick(symbol="SP:AAA", seq=1, price=100.0, volume=1), WALL)
+    mutate(ev)
+    with pytest.raises(jsonschema.ValidationError):
+        validate_event(ev)
+
+
+def test_startup_check_passes_for_this_producer():
+    em, _ = make()
+    em.startup_check()                                  # must not raise
+
+
+# ── emission shapes ──────────────────────────────────────────────────────────
+
+
+def test_run_once_posts_symbol_nodes_event_nodes_and_aboutSymbol_edges():
+    em, w = make()
+    result = em.run_once()
+
+    assert result.generated == 3 and result.emitted == 3
+    assert result.validation_failures == 0 and result.pending == 0
+    assert result.hellgraph_ok is True and result.last_seq == 1
+
+    symbol_nodes = [n for n in w.nodes if SYMBOL_LABEL in n[1]]
+    event_nodes = [n for n in w.nodes if EVENT_LABEL in n[1]]
+    assert [n[0] for n in symbol_nodes] == SYMBOLS       # once each, id = raw symbol
+    assert [n[0] for n in event_nodes] == [local_id(s, 1) for s in SYMBOLS]
+
+    nid, labels, props = event_nodes[0]
+    assert nid == "mde-SP-AAA-000001"
+    assert labels == [EVENT_LABEL, "SP:AAA"]
+    assert props["eventId"] == "urn:srcos:market-data-event:mde-SP-AAA-000001"
+    assert props["schemaVersion"] == "0.1.0" and props["symbol"] == "SP:AAA"
+    assert isinstance(props["price"], float) and isinstance(props["volume"], int)
+    assert props["eventTime"] == WALL and props["ingestTime"] == WALL
+    assert props["synthetic"] is True
+    embedded = json.loads(props["event"])               # the log carries the OBJECT
+    validate_event(embedded)
+    assert embedded["id"] == props["eventId"]
+
+    assert w.edges == [(EDGE_LABEL, local_id(s, 1), s) for s in SYMBOLS]
+
+
+def test_symbol_nodes_are_created_once_not_per_batch():
+    em, w = make()
+    em.run_once()
+    em.run_once()
+    assert len([n for n in w.nodes if SYMBOL_LABEL in n[1]]) == 3
+    assert len([n for n in w.nodes if EVENT_LABEL in n[1]]) == 6   # 2 batches × 3
+
+
+# ── fail-closed validation ───────────────────────────────────────────────────
+
+
+def test_invalid_event_is_counted_and_never_emitted(monkeypatch):
+    """Corrupt ONE symbol's event at the source: it must be dropped loudly while the
+    rest of the batch still lands — fail-closed, not fail-everything."""
+    real = contract.build_event
+
+    def corrupting(tick, wall_time):
+        ev = real(tick, wall_time)
+        if tick.symbol == "SP:BBB":
+            del ev["instrumentRef"]                    # now schema-invalid
+        return ev
+
+    monkeypatch.setattr(emitter_mod, "build_event", corrupting)
+    em, w = make()
+    result = em.run_once()
+
+    assert result.validation_failures == 1
+    assert result.emitted == 2 and result.pending == 0
+    event_nodes = [n[0] for n in w.nodes if EVENT_LABEL in n[1]]
+    assert event_nodes == ["mde-SP-AAA-000001", "mde-SP-CCC-000001"]   # SP:BBB absent
+    assert all(frm != local_id("SP:BBB", 1) for _, frm, _to in w.edges)
+
+
+# ── hellgraph outage: retry, no crash, no duplicates, no gaps ────────────────
+
+
+def test_outage_keeps_batch_pending_then_drains_without_gaps():
+    em, w = make()
+    w.down = True
+    r1 = em.run_once()                                  # symbols can't even be ensured
+    assert r1.hellgraph_ok is False and r1.emitted == 0
+
+    w.down = False
+    r2 = em.run_once()                                  # heals: symbols + batch 1
+    assert r2.hellgraph_ok is True and r2.emitted == 3 and r2.last_seq == 1
+
+    w.down = True
+    r3 = em.run_once()                                  # batch 2 generated, all pending
+    assert r3.generated == 3 and r3.emitted == 0 and r3.pending == 3
+
+    r4 = em.run_once()                                  # still down: NOTHING new generated
+    assert r4.generated == 0 and r4.pending == 3        # bounded memory, gapless stream
+
+    w.down = False
+    r5 = em.run_once()                                  # drains the pending batch
+    assert r5.emitted == 3 and r5.pending == 0 and r5.last_seq == 2
+
+    seqs = sorted(int(n[0].rsplit("-", 1)[1]) for n in w.nodes if EVENT_LABEL in n[1])
+    assert seqs == [1, 1, 1, 2, 2, 2]                   # no seq skipped, none duplicated
+
+
+def test_half_emitted_item_never_resends_the_landed_node():
+    em, w = make()
+    w.fail_edges = True
+    r1 = em.run_once()
+    assert r1.emitted == 0 and r1.pending == 3          # first node landed, edge didn't
+    nodes_before = len(w.nodes)
+
+    w.fail_edges = False
+    r2 = em.run_once()
+    assert r2.emitted == 3 and r2.pending == 0
+
+    first = local_id("SP:AAA", 1)
+    assert len([n for n in w.nodes if n[0] == first]) == 1     # node POSTed exactly once
+    assert len([e for e in w.edges if e[1] == first]) == 1     # edge exactly once
+    assert len(w.nodes) == nodes_before + 2             # only the two unlanded nodes followed

--- a/apps/market-replay/tests/test_generator.py
+++ b/apps/market-replay/tests/test_generator.py
@@ -1,0 +1,62 @@
+"""Determinism is the acceptance bar: the whole replay stream must be a pure function
+of (seed, symbol, seq) — never of wall clock, host, process hash seed, or list order."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from market_replay.generator import Tick, TickGenerator, base_price  # noqa: E402
+
+SYMBOLS = ["SP:AAA", "SP:BBB", "SP:CCC"]
+
+
+def stream(gen: TickGenerator, batches: int) -> list[Tick]:
+    out: list[Tick] = []
+    for _ in range(batches):
+        out.extend(gen.next_batch())
+    return out
+
+
+def test_same_seed_produces_identical_streams():
+    a = stream(TickGenerator(SYMBOLS, seed=42), 20)
+    b = stream(TickGenerator(SYMBOLS, seed=42), 20)
+    assert a == b                                   # Tick is frozen → value equality
+    assert len(a) == 60
+
+
+def test_different_seed_diverges():
+    a = stream(TickGenerator(SYMBOLS, seed=42), 5)
+    b = stream(TickGenerator(SYMBOLS, seed=43), 5)
+    assert a != b
+
+
+def test_symbol_paths_independent_of_list_order():
+    fwd = stream(TickGenerator(SYMBOLS, seed=42), 10)
+    rev = stream(TickGenerator(list(reversed(SYMBOLS)), seed=42), 10)
+    by_symbol = lambda ticks, s: [t for t in ticks if t.symbol == s]  # noqa: E731
+    for s in SYMBOLS:
+        assert by_symbol(fwd, s) == by_symbol(rev, s)
+
+
+def test_seq_is_per_symbol_monotonic_from_one_and_prices_stay_positive():
+    ticks = stream(TickGenerator(SYMBOLS, seed=7), 50)
+    for s in SYMBOLS:
+        seqs = [t.seq for t in ticks if t.symbol == s]
+        assert seqs == list(range(1, 51))
+    assert all(t.price > 0 for t in ticks)
+    assert all(1 <= t.volume <= 1_000 for t in ticks)
+
+
+def test_base_price_is_stable_and_in_band():
+    assert base_price("SP:AAA") == base_price("SP:AAA")
+    for s in SYMBOLS:
+        assert 50.0 <= base_price(s) < 150.0
+
+
+def test_empty_symbol_set_is_refused():
+    with pytest.raises(ValueError):
+        TickGenerator([], seed=1)

--- a/apps/market-replay/tests/test_server.py
+++ b/apps/market-replay/tests/test_server.py
@@ -1,0 +1,84 @@
+"""/healthz truthfulness + run_step state folding (loop disabled — units drive steps)."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+os.environ["REPLAY_ENABLED"] = "off"   # no background thread under test
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from market_replay import server  # noqa: E402
+from market_replay.emitter import ReplayEmitter  # noqa: E402
+from market_replay.generator import TickGenerator  # noqa: E402
+from test_emitter import WALL, FakeWriter  # noqa: E402
+
+client = TestClient(server.app)
+
+
+def make(writer: FakeWriter) -> ReplayEmitter:
+    return ReplayEmitter(generator=TickGenerator(["SP:AAA", "SP:BBB", "SP:CCC"], seed=42),
+                         writer=writer, clock=lambda: WALL)
+
+
+def setup_function():
+    server.STATE.update({
+        "ticks_generated": 0, "emitted": 0, "last_seq": 0, "validation_failures": 0,
+        "pending": 0, "hellgraph_ok": None, "last_emit_at": None,
+        "last_error": None, "last_error_at": None, "loop_running": False,
+    })
+
+
+def test_healthz_reports_emission_truth_after_batches():
+    em = make(FakeWriter())
+    server.run_step(em)
+
+    h = client.get("/healthz").json()
+    assert h["ok"] is True and h["service"] == "market-replay"
+    assert h["enabled"] is False                       # REPLAY_ENABLED=off — the truth
+    assert h["emitted"] == 3 and h["ticks_generated"] == 3 and h["last_seq"] == 1
+    assert h["validation_failures"] == 0               # the steady-state MUST-be-0 gauge
+    assert h["hellgraph_ok"] is True and h["pending"] == 0
+    assert h["last_emit_at"] and h["last_error"] is None
+
+    server.run_step(em)
+    h = client.get("/healthz").json()
+    assert h["emitted"] == 6 and h["last_seq"] == 2
+
+
+def test_healthz_reports_outage_without_lying_or_crashing():
+    w = FakeWriter()
+    w.down = True
+    em = make(w)
+    server.run_step(em)                                # swallowed, recorded, no crash
+
+    h = client.get("/healthz").json()
+    assert h["ok"] is True                             # liveness stays truthful-200
+    assert h["hellgraph_ok"] is False and h["emitted"] == 0
+    assert h["last_emit_at"] is None
+
+    w.down = False                                     # heal → the SAME emitter drains
+    server.run_step(em)
+    h = client.get("/healthz").json()
+    assert h["hellgraph_ok"] is True and h["emitted"] == 3 and h["pending"] == 0
+
+
+def test_healthz_surfaces_validation_failures(monkeypatch):
+    from market_replay import contract, emitter as emitter_mod
+
+    real = contract.build_event
+
+    def corrupting(tick, wall_time):
+        ev = real(tick, wall_time)
+        ev["eventKind"] = "vibes"                      # schema-invalid for every tick
+        return ev
+
+    monkeypatch.setattr(emitter_mod, "build_event", corrupting)
+    em = make(FakeWriter())
+    server.run_step(em)
+
+    h = client.get("/healthz").json()
+    assert h["validation_failures"] == 3               # counted loudly...
+    assert h["emitted"] == 0 and h["pending"] == 0     # ...and NOTHING was emitted

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -63,6 +63,9 @@ spec:
           # Seal-the-Walls W1.1: proof-carrying log→ClickHouse materializer (first-party;
           # tails hellgraph-service /api/graph/log, receipts via compute-gateway kind=materialize).
           - { name: prophet-materializer-clickhouse }
+          # Seal-the-Walls W1.2: synthetic MarketDataEvent replay emitter (first-party;
+          # schema-validated sourceos-spec events → hellgraph graph writes → the log above).
+          - { name: market-replay }
           # spark-runner MOVED to runtime-services → sovereign-runtime (executes user Spark jobs).
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —

--- a/deploy/values/market-replay.yaml
+++ b/deploy/values/market-replay.yaml
@@ -1,0 +1,47 @@
+# market-replay — Seal-the-Walls W1.2: the first sourceos-spec-conformant event
+# producer on the platform log. A deterministic seeded random walk emits SYNTHETIC
+# MarketDataEvent objects (SourceOS-Linux/sourceos-spec schemas/MarketDataEvent.json,
+# vendored + sha256-pinned in apps/market-replay/src/market_replay/contract.py;
+# validated per event, fail-closed — an invalid event is counted on /healthz and NEVER
+# emitted). Events enter the log as hellgraph-service graph writes (POST
+# /api/graph/node + an aboutSymbol edge per event); prophet-materializer-clickhouse
+# (W1.1) tails GET /api/graph/log and lands them in ClickHouse. No real market data:
+# every event carries qualityFlags=["synthetic"] and venueRef=SYNTH.
+nameOverride: market-replay
+
+image:
+  repository: market-replay
+  # sha-pinned by gitops-promote after the first CI build (prophet-materializer-clickhouse
+  # precedent).
+  tag: latest
+  # Guard against the moving-tag+IfNotPresent trap while the tag is still `latest`; harmless
+  # once promotion pins an immutable sha- tag (kubelet re-checks, digests match, no-op).
+  pullPolicy: Always
+
+service: { port: 8080, portName: http }
+
+config:
+  HELLGRAPH_URL: "http://hellgraph-service:8090"
+  REPLAY_ENABLED: "on"
+  REPLAY_INTERVAL_SECONDS: "5"
+  REPLAY_SYMBOLS: "SP:AAA,SP:BBB,SP:CCC"
+  # The walk is a pure function of (seed, symbol, seq): same seed ⇒ the same replayable
+  # stream on every restart. Event URNs embed the per-symbol seq, so ClickHouse
+  # (ReplacingMergeTree keyed by event_id) collapses restart re-emissions to one row.
+  REPLAY_SEED: "42"
+
+# ONE writer for the seq stream: a second replica would race the same deterministic
+# URNs and interleave duplicate graph writes. No HPA; Recreate over RollingUpdate so
+# two emitters never overlap even during a rollout.
+replicaCount: 1
+autoscaling: { enabled: false }
+strategy: { type: Recreate }
+
+probes:
+  path: /healthz   # emitted count, last seq, validation failures (MUST be 0), hellgraph reachability
+
+# Honest floor for a 3-symbol/5s validate→POST loop: fastapi + jsonschema resident,
+# events are ~1KB and stream straight through.
+resources:
+  requests: { cpu: 25m,  memory: 128Mi }
+  limits:   { cpu: 200m, memory: 256Mi }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -86,14 +86,13 @@ KNOWN_BROKEN = {
     # shrinks: fixed → removed from KNOWN_BROKEN so it can never silently regress to `:latest` again.
     # owl-reasoner:moving-tag is RESOLVED — deploy/values/owl-reasoner.yaml was manually sha-pinned
     # (KKO-TBox build, #974). The ratchet only shrinks: fixed → removed so it can't regress silently.
-    "arcticdb-gateway:moving-tag": (
-        "New service — PHT-5 dataset/version store (apps/arcticdb-gateway) added to images.yml this PR. Pin "
-        "tag:latest -> the sha- tag after the first CI build; no sha exists until merge. Its values set "
-        "pullPolicy: Always as the interim guard against the moving-tag+IfNotPresent trap."
-    ),
-    "prophet-materializer-clickhouse:moving-tag": (
-        "New service — Seal-the-Walls W1.1 proof-carrying log→ClickHouse materializer "
-        "(apps/prophet-materializer-clickhouse) added to images.yml this PR. Pin tag:latest -> the sha- tag "
+    # arcticdb-gateway:moving-tag + prophet-materializer-clickhouse:moving-tag are RESOLVED —
+    # gitops-promote sha-pinned both values files after their first CI builds (arcticdb-gateway →
+    # sha-8fbda01e…, prophet-materializer-clickhouse → sha-4df9dcbd…). The ratchet only shrinks:
+    # fixed → removed so neither can silently regress to `:latest` again.
+    "market-replay:moving-tag": (
+        "New service — Seal-the-Walls W1.2 synthetic MarketDataEvent replay emitter "
+        "(apps/market-replay) added to images.yml this PR. Pin tag:latest -> the sha- tag "
         "after the first CI build; no sha exists until merge. Its values set pullPolicy: Always as the "
         "interim guard against the moving-tag+IfNotPresent trap."
     ),


### PR DESCRIPTION
Seal-the-Walls **W1.2**: `apps/market-replay` — the first REAL sourceos-spec-conformant events flowing into the platform log. W1.1 built the log→ClickHouse materializer; this puts governed, schema-validated events INTO the log it tails.

## End-to-end path

```
market-replay (seeded synthetic walk, 3 symbols / 5s)
  └─ build MarketDataEvent → jsonschema-VALIDATE against the VENDORED spec (fail-closed)
       └─ POST /api/graph/node   hellgraph-service:8090   (event node, upsert)
       └─ POST /api/graph/edge   aboutSymbol → Symbol node (created once)
            └─ hellgraph log (GET /api/graph/log — HellGraph IS the log)
                 └─ prophet-materializer-clickhouse (W1.1) tails, INSERTs
                      └─ ClickHouse hellgraph.events (ReplacingMergeTree by event_id)
                           + one sealed receipt per batch on the compute-gateway spine
```

No new receipt lineage, no ClickHouse coupling: the emitter's only door is the graph write surface; W1.1 carries everything downstream. Event URNs embed the deterministic per-symbol seq, so restart re-emissions collapse to one row in ClickHouse (`event_id` key) — replay-idempotent end to end.

## Schema provenance (vendored, hermetic, tamper-evident)

- **Contract**: `SourceOS-Linux/sourceos-spec` `schemas/MarketDataEvent.json` — merged PR #204, commit `487e4b614b79e556af3aea2c70471eca13281377` (2026-07-28, "schemas: MPCC event contract v0.1"), a profile of the ConversationEvent MPCC envelope.
- **Vendored** byte-identical at `apps/market-replay/src/market_replay/schemas/MarketDataEvent.json`; sha256 `7d18865d1a435f8a2e78977ef51f865b842c810f4648faa8755b506fe8b13d55` pinned in `contract.py` and **asserted at import** — a drifted copy kills boot, never silently emits.
- Fail-closed gates: (1) import-time hash check, (2) boot-time `Draft202012Validator.check_schema` + probe-event validation in uvicorn lifespan (drift aborts startup visibly), (3) **per-event validation before every emit** — invalid ⇒ counted on `/healthz` (`validation_failures`, steady-state MUST be 0) and never emitted.

## Event shape (deterministic sample — seed 42, `SP:AAA` seq 1, validated)

```json
{
  "id": "urn:srcos:market-data-event:mde-SP-AAA-000001",
  "type": "MarketDataEvent",
  "specVersion": "0.1.0",
  "actorRef": "urn:srcos:agent:market-replay",
  "workspaceRef": "socioprophet",
  "branchRef": "main",
  "wallTime": "2026-07-29T12:00:00.000Z",
  "logicalTime": 1,
  "instrumentRef": "SP:AAA",
  "venueRef": "SYNTH",
  "eventKind": "trade",
  "sequenceRef": 1,
  "feedRef": "market-replay/synthetic-walk",
  "rawPayload": { "symbol": "SP:AAA", "seq": 1, "price": 74.2649, "volume": 546 },
  "canonicalPayload": {
    "normalizationRegime": "market-replay/synthetic-walk@v1",
    "instrument": "SP:AAA", "price": 74.2649, "size": 546, "side": "synthetic"
  },
  "qualityFlags": ["synthetic"],
  "policyLabels": ["synthetic-data"]
}
```

**Clearly synthetic by construction**: seeded per-symbol random walk (base price from `sha256(symbol)`, never the salted process hash), `venueRef: SYNTH`, `qualityFlags: ["synthetic"]`, `policyLabels: ["synthetic-data"]`. No real market data anywhere. The graph node carries the flattened fields (`eventId`, `symbol`, `price`, `volume`, `eventTime`, `ingestTime`, `schemaVersion`, …) **plus the full validated event as canonical JSON** — the log carries the spec-conformant object, not a lossy projection. One local id (`mde-SP-AAA-000001`) serves both the URN and the graph node id, so node ↔ event identity is 1:1.

## Resilience semantics

- **Validation failure** ⇒ NOT emitted, counted, logged loudly (the tick is dropped — a deterministically-invalid tick would wedge the stream; the healthz counter is the alarm).
- **hellgraph outage** ⇒ batch stays pending, retried each interval; no new ticks generated while pending (bounded memory, gapless seq stream); half-emitted items track node/edge separately so a landed node is never re-sent (a re-added edge would mint a duplicate log event — a re-upserted node is collapsed by ReplacingMergeTree anyway).
- `/healthz` always answers 200 with the truth: `emitted`, `last_seq`, `validation_failures`, `hellgraph_ok`, `pending`, `last_error`.

## Tests (23 passed — determinism, conformance, shapes, fail-closed, outage retry)

```
$ python -m pytest -q tests
.......................                                                  [100%]
23 passed in 0.37s
```

- `test_generator.py` (6): same seed ⇒ identical streams; divergence under a different seed; symbol paths independent of list order; per-symbol monotonic seq from 1; price/volume bounds; empty set refused.
- `test_emitter.py` (14): 10 batches of generated events all validate; exact envelope shape; **6 malformed mutations rejected** (missing required, enum violation, URN charset, const violation, `additionalProperties: false`); startup probe; exact node/edge shapes incl. embedded event revalidation; Symbol nodes once; invalid event counted + never emitted while the rest of the batch lands; outage ⇒ pending ⇒ heal ⇒ drain with **no seq gaps and no duplicates**; half-emitted item never re-sends the landed node.
- `test_server.py` (3): `/healthz` truth after batches, through an outage (still 200, `hellgraph_ok: false`), and under forced validation failures (counted, nothing emitted).

## Wiring (arcticdb-gateway / W1.1 precedent, mirrored exactly)

- `apps/market-replay/`: python:3.11-slim, pyproject + exact-pin `requirements.txt` (shared pins line up with the materializer; `jsonschema==4.26.0` closure added), `src/`, `tests/`.
- `.github/workflows/images.yml`: matrix entry.
- `deploy/values/market-replay.yaml`: 128Mi/256Mi, `HELLGRAPH_URL=http://hellgraph-service:8090`, `REPLAY_ENABLED "on"`, interval 5s, seed 42; single writer (`replicaCount: 1`, Recreate — a second replica would race the same deterministic URNs); `pullPolicy: Always` as the interim moving-tag guard.
- `deploy/argocd/platform-services.yaml`: ApplicationSet entry next to `prophet-materializer-clickhouse`.
- `tools/preflight_deploy_contract.py`: `market-replay:moving-tag` ratchet entry until gitops-promote pins the first `sha-` tag. **Also removes the two stale entries the gate now demands gone**: `arcticdb-gateway:moving-tag` + `prophet-materializer-clickhouse:moving-tag` were sha-pinned by gitops-promote (`sha-8fbda01e…` / `sha-4df9dcbd…`), so preflight currently FAILS on origin/main ("now passes — delete it; the ratchet only shrinks"). Verified on a pristine origin/main worktree; with this PR preflight exits 0.

## Validation

- `helm template x charts/socioprophet-service -f deploy/values/market-replay.yaml` → renders clean (ServiceAccount/ConfigMap/Service/Deployment, all env keys present).
- `python3 tools/preflight_deploy_contract.py` → exit 0; `51 deployed, 40 first-party checked against 45 built images`; market-replay tracked in the ratchet.
- After merge: gitops-promote pins the first `sha-` tag → remove `market-replay:moving-tag` from the ratchet in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
