### PR TITLE
feat(w6.1): exhaust accounting — bytes on every receipt, discard ledger bound by hash

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/artifacts.py
+++ b/apps/compute-gateway/src/compute_gateway/artifacts.py
@@ -112,6 +112,18 @@ def store_outputs(receipt_id: str, outputs: list[Any]) -> list[str]:
     return digests
 
 
+def put(obj: Any) -> str:
+    """Content-address a single blob (dedup'd; durable when persistence is enabled) and
+    return its digest. W6.1 uses this for ExhaustRecords so the receipt's exhaust_sha IS
+    the retrieval address (/v1/artifacts/{digest})."""
+    d = digest(obj)
+    newly = _backend.put(d, obj)
+    _stats["puts"] += 1
+    if not newly:
+        _stats["dedup_hits"] += 1
+    return d
+
+
 def get(d: str) -> Any | None:
     return _backend.get(d)
 

--- a/apps/compute-gateway/src/compute_gateway/contract.py
+++ b/apps/compute-gateway/src/compute_gateway/contract.py
@@ -46,6 +46,11 @@ class Receipt(BaseModel):
     statement: dict[str, Any] | None = None     # in-toto Statement v1
     signature: str | None = None                # base64 Ed25519 sig over canonical statement bytes
     public_key: str | None = None               # base64 raw Ed25519 public key (None → unsigned)
+    # ── exhaust accounting (W6.1; observability, NOT part of the id-hash — receipts
+    #    persisted before these fields existed must keep verifying) ──
+    bytes_in: int | None = None                 # canonical-serialized size of the inputs
+    bytes_out: int | None = None                # canonical-serialized size of the outputs
+    exhaust_sha: str | None = None              # sha of the ExhaustRecord (sourceos-spec), when emitted
 
 
 class GraphNode(BaseModel):

--- a/apps/compute-gateway/src/compute_gateway/engine.py
+++ b/apps/compute-gateway/src/compute_gateway/engine.py
@@ -186,10 +186,23 @@ async def execute(req: ComputeRequest, _depth: int = 0) -> ComputeResult:
     # reconcile → verified only when every fact reconciled). Falls back to the kind default.
     epistemic = raw.get("epistemic", epistemic)
 
+    # ── exhaust accounting (W6.1) ──────────────────────────────────────────────
+    # Every receipt carries what the stage consumed vs produced (bytes_out/bytes_in
+    # is the v1 entropy proxy). An adapter that DISCARDS things reports them via
+    # `_exhaust` (an ExhaustRecord, sourceos-spec: counts + hash-only item refs) —
+    # content-addressed into the artifact store so the discard ledger is retrievable
+    # at /v1/artifacts/{exhaust_sha}, and bound to the receipt via exhaust_sha.
+    outputs_dump = [o.model_dump() for o in raw["outputs"]]
+    exhaust = raw.get("_exhaust")
+    exhaust_sha = artifacts.put(exhaust) if isinstance(exhaust, dict) else None
+
     receipt = receipts.seal(
         req.project, kind=kind, backend=backend, runtime=raw["runtime"],
-        inputs=req.spec, outputs=[o.model_dump() for o in raw["outputs"]],
-        status=status, actor=req.actor, epistemic_status=epistemic)
+        inputs=req.spec, outputs=outputs_dump,
+        status=status, actor=req.actor, epistemic_status=epistemic,
+        bytes_in=receipts.canonical_size(req.spec),
+        bytes_out=receipts.canonical_size(outputs_dump),
+        exhaust_sha=exhaust_sha)
 
     delta = adapters.build_delta(req.project, kind, backend, receipt.id, epistemic,
                                  inputs_sha=receipt.inputs_sha, outputs_sha=receipt.outputs_sha)

--- a/apps/compute-gateway/src/compute_gateway/receipts.py
+++ b/apps/compute-gateway/src/compute_gateway/receipts.py
@@ -38,8 +38,16 @@ def sha(obj: Any) -> str:
     ).hexdigest()
 
 
+def canonical_size(obj: Any) -> int:
+    """Byte size of the SAME canonical serialization sha() hashes — so bytes_in/bytes_out
+    (W6.1 exhaust accounting) measure exactly what the content hashes bind."""
+    return len(json.dumps(obj, sort_keys=True, default=str, ensure_ascii=False).encode())
+
+
 def seal(project: str, *, kind: str, backend: str, runtime: str, inputs: Any,
-         outputs: Any, status: str, actor: str, epistemic_status: EpistemicStatus) -> Receipt:
+         outputs: Any, status: str, actor: str, epistemic_status: EpistemicStatus,
+         bytes_in: int | None = None, bytes_out: int | None = None,
+         exhaust_sha: str | None = None) -> Receipt:
     chain = _CHAINS.setdefault(project, [])
     prev = chain[-1].id if chain else None
     body = {
@@ -47,7 +55,10 @@ def seal(project: str, *, kind: str, backend: str, runtime: str, inputs: Any,
         "inputs_sha": sha(inputs), "outputs_sha": sha(outputs), "status": status,
         "actor": actor, "epistemic_status": epistemic_status, "prev": prev, "ts": time.time(),
     }
-    receipt = Receipt(id=sha(body), **body)
+    # exhaust accounting (W6.1) rides OUTSIDE the id-hash body, like the attestation —
+    # pre-existing persisted receipts (no such fields) must keep verifying unchanged.
+    receipt = Receipt(id=sha(body), **body,
+                      bytes_in=bytes_in, bytes_out=bytes_out, exhaust_sha=exhaust_sha)
     # standards-based authenticity, layered on top of the chain's integrity:
     # in-toto Statement v1 + Ed25519 signature (unsigned if no key configured).
     signing.attest(receipt, signing.load_signing_key())

--- a/apps/compute-gateway/tests/test_exhaust_accounting.py
+++ b/apps/compute-gateway/tests/test_exhaust_accounting.py
@@ -1,0 +1,125 @@
+"""W6.1 exhaust accounting (design-register: exhaust-accounting).
+
+Every receipt now carries bytes_in/bytes_out (v1 entropy proxy = compression ratio),
+and an adapter that discards things reports them as an `_exhaust` ExhaustRecord —
+content-addressed into the artifact store and bound to the receipt via exhaust_sha.
+Back-compat is a law, not a hope: receipts persisted BEFORE these fields existed
+must keep verifying (the fields ride outside the id-hash body, like the attestation)."""
+import contextlib
+import importlib
+import os
+import tempfile
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import adapters, artifacts, engine, persistence, receipts, server, zerotrust  # noqa: E402
+from compute_gateway.contract import ComputeOutput  # noqa: E402
+
+importlib.reload(zerotrust)
+importlib.reload(engine)
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+EXHAUST = {
+    "type": "ExhaustRecord", "specVersion": "2.0", "source": "compute",
+    "counts": {"candidatesRejected": 2},
+    "bytesIn": 100, "bytesOut": 10,
+    "items": [{"kind": "candidate", "sha256": "a" * 64, "size": 90}],
+}
+
+
+def setup_function():
+    os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+    receipts._CHAINS.clear()
+    engine._MEMO.clear()
+    artifacts._reset()
+
+    async def plain(spec, project, session):
+        return {"outputs": [ComputeOutput(type="result", text="ok")],
+                "runtime": "python3", "status": "ok", "error": None, "degraded": None}
+
+    async def discarding(spec, project, session):
+        return {"outputs": [ComputeOutput(type="result", text="kept")],
+                "runtime": "hellgraph", "status": "ok", "error": None, "degraded": None,
+                "_exhaust": EXHAUST}
+
+    adapters.set_backend("forge", plain)
+    adapters.set_backend("hellgraph:graph-query", discarding)
+
+
+def _run(kind, spec):
+    return client.post("/v1/compute", json={"kind": kind, "project": "demo", "spec": spec},
+                       headers=AUTH).json()
+
+
+def test_every_receipt_carries_bytes_accounting():
+    r = _run("notebook", {"code": "1+1"})
+    rc = r["receipt"]
+    assert rc["bytes_in"] == receipts.canonical_size({"code": "1+1"})
+    assert rc["bytes_out"] == receipts.canonical_size(r["outputs"])
+    assert rc["exhaust_sha"] is None      # nothing was discarded → no ledger, never faked
+
+
+def test_exhaust_record_is_bound_and_retrievable():
+    r = _run("graph-query", {"label": "demo"})
+    sha = r["receipt"]["exhaust_sha"]
+    assert sha == artifacts.digest(EXHAUST)   # the binding IS the retrieval address
+    blob = client.get(f"/v1/artifacts/{sha}", headers=AUTH).json()["blob"]
+    assert blob == EXHAUST                     # discard ledger retrievable, hash-addressed
+    # and the chain (with the new fields riding along) still verifies
+    assert client.get("/v1/receipts/verify", params={"project": "demo"}, headers=AUTH).json()["valid"]
+
+
+def test_workflow_composite_carries_bytes_too():
+    r = client.post("/v1/compute", json={"kind": "workflow", "project": "demo", "spec": {"steps": [
+        {"id": "a", "kind": "notebook", "spec": {"code": "1"}},
+        {"id": "b", "kind": "graph-query", "spec": {"label": "demo"}, "needs": ["a"]},
+    ]}, "no_cache": True}, headers=AUTH).json()
+    assert r["receipt"]["bytes_in"] is not None and r["receipt"]["bytes_out"] is not None
+    # the discarding STEP carries its exhaust on its own receipt
+    step_ids = [s["receipt"] for s in r["outputs"][0]["data"]["steps"]]
+    chain = {c["id"]: c for c in client.get("/v1/receipts", params={"project": "demo"},
+                                            headers=AUTH).json()["receipts"]}
+    assert chain[step_ids[1]]["exhaust_sha"] == artifacts.digest(EXHAUST)
+
+
+def test_pre_fields_persisted_receipts_still_verify():
+    """The back-compat law: a receipt persisted BEFORE W6.1 (no exhaust fields in its
+    stored JSON) must rehydrate and verify unchanged — the fields are outside the id-hash."""
+    prev_env = os.environ.get("GATEWAY_STORE_DIR")
+    with tempfile.TemporaryDirectory() as d:
+        os.environ["GATEWAY_STORE_DIR"] = d
+        persistence._reset_connection()
+        try:
+            receipts._CHAINS.clear()
+            r = receipts.seal("compat", kind="notebook", backend="forge", runtime="py",
+                              inputs={"x": 1}, outputs=[{"y": 2}], status="ok",
+                              actor="t", epistemic_status="derived")
+            # simulate a pre-W6.1 stored row: strip the new fields from the persisted JSON
+            import json as _json
+            con = persistence._conn()
+            (body_json,) = con.execute("SELECT body FROM receipts WHERE id=?", (r.id,)).fetchone()
+            body = _json.loads(body_json)
+            for k in ("bytes_in", "bytes_out", "exhaust_sha"):
+                body.pop(k, None)
+            con.execute("UPDATE receipts SET body=? WHERE id=?", (_json.dumps(body), r.id))
+            con.commit()
+            # restart: rehydrate from the stripped (old-format) row
+            receipts._CHAINS.clear()
+            persistence._reset_connection()
+            receipts.hydrate()
+            v = receipts.verify("compat")
+            assert v["valid"] and v["count"] == 1          # old-format receipt verifies
+            assert receipts.chain("compat")[0].bytes_in is None   # honestly absent, not faked
+        finally:
+            if prev_env is None:
+                os.environ.pop("GATEWAY_STORE_DIR", None)
+            else:
+                os.environ["GATEWAY_STORE_DIR"] = prev_env
+            persistence._reset_connection()
+            receipts._CHAINS.clear()

--- a/docs/design-register.yaml
+++ b/docs/design-register.yaml
@@ -32,7 +32,13 @@ register:
       compression ratio. Exhaust->intake loop: trace-dream job mines
       discarded-but-later-needed to tune retrieval + SRS.
     owner: agent-machine + compute-gateway (+ sourceos-spec fields)
-    status: absent
+    status: declared
+    # declared 2026-07-29: ExhaustRecord schema MERGED (sourceos-spec #208); gateway emission
+    # code-complete + tested (bytes on every receipt; _exhaust bound via content-addressed
+    # exhaust_sha; pre-W6.1 persisted receipts still verify — fields ride outside the id-hash).
+    # `wired` requires: merged + gateway image rolled + live /v1/compute probe.
+    # `measured` still needs: agent-machine compaction/retrieval sources + trace-dream
+    # discard-mining + compression-ratio on the Govern Proof act.
     probe: "sample /v1/compute receipt carries exhaust_sha and bytes_in/bytes_out"
     wave: W6.1
 


### PR DESCRIPTION
Second lane of Metaphor→Mechanism (program #1003, gate #1004; ExhaustRecord spec = sourceos-spec#208).

**What ships:** every receipt now carries `bytes_in`/`bytes_out` (canonical-serialized, measuring exactly what the content shas bind; ratio = v1 entropy proxy). Adapters that discard content report an `_exhaust` ExhaustRecord — counts + hash-only refs, never payloads (EX-I2) — content-addressed so the receipt's `exhaust_sha` IS its retrieval address (`/v1/artifacts/{sha}`).

**Back-compat as law:** the fields ride OUTSIDE the id-hash body (same pattern as the attestation). Tested by stripping the fields from a persisted row, restarting, and re-verifying the chain — receipts sealed before W6.1 keep verifying on the durable PD.

**Register:** `exhaust-accounting` promoted `absent→declared` (spec merged + code tested). Per the ladder rule it does NOT claim `wired` until this is deployed and the live probe passes — that promotion comes as a follow-up with the probe receipt.

4 new tests; full gateway suite 94 green; register gate passes.