### PR TITLE
feat(w1.3): receipt unification — engine sealed() receipts chained on THE spine, ONE verify walk

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -18,6 +18,7 @@ from typing import Any, Awaitable, Callable
 
 import httpx
 
+from . import engine_receipts
 from .contract import ComputeOutput, GraphDelta, GraphEdge, GraphNode
 
 FORGE_URL = os.getenv("FORGE_URL", "http://lattice-forge.sovereign-runtime.svc.cluster.local:8870").rstrip("/")
@@ -657,6 +658,66 @@ async def _governance(req_spec: dict, project: str, session: str | None) -> Adap
             "runtime": "gateway", "status": "ok", "error": None, "degraded": None,
             "_no_provenance": True}
 
+async def _engine_seal(req_spec: dict, project: str, session: str | None) -> AdapterResult:
+    """Seal-the-Walls W1.3 — receipt unification: chain an ENGINE sealed() receipt
+    into THE receipt spine.
+
+    hellgraph-service calls this after each /api/graph/enrich | /api/graph/explore
+    with {kind, engineReceipt, subject}. The engine receipt is already proof-carrying
+    (sealed sha256 over the ranked output + snapshot {seq,nodes,edges}); what it lacks
+    is the estate spine: hash-chain position, in-toto statement, Ed25519 signature.
+    The gateway VERIFIES before it attests — shape pinned to the engine's sealed()
+    output and the sealed hash RECOMPUTED byte-exactly (JS JSON.stringify semantics,
+    see engine_receipts.py). A receipt that does not recompute is refused loudly:
+    never claim sealed when it isn't. The sealed output binds {engine_hash, snapshot}
+    beside the full engine receipt, so verify_walk can later re-check signature →
+    engine hash → snapshot.seq binding end-to-end.
+
+    `_no_provenance`: like materialize, the receipt's provenance subgraph must NOT be
+    written back into hellgraph — the graph is the very substrate whose state (seq)
+    this receipt attests, so the write-back would bump the clock on every read and
+    feed the materializer log an event per enrich call. The proof lives on the chain.
+    """
+    kind = req_spec.get("kind")
+    if kind not in engine_receipts.ENGINE_KINDS:
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": f"engine-seal spec.kind must be one of {list(engine_receipts.ENGINE_KINDS)}, "
+                         f"got {kind!r}",
+                "degraded": None, "_no_provenance": True, "epistemic": "unknown"}
+    subject = req_spec.get("subject") or {}
+    if not isinstance(subject, dict):
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": "engine-seal subject must be a JSON object",
+                "degraded": None, "_no_provenance": True, "epistemic": "unknown"}
+    er = req_spec.get("engineReceipt")
+    errors = engine_receipts.validate(kind, er)
+    if errors:
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": f"engine receipt shape invalid: {'; '.join(errors)}",
+                "degraded": None, "_no_provenance": True, "epistemic": "unknown"}
+    try:
+        recomputed = engine_receipts.sealed_hash(kind, er)
+    except engine_receipts.EngineReceiptError as e:
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": f"engine receipt not canonicalizable: {e}",
+                "degraded": None, "_no_provenance": True, "epistemic": "unknown"}
+    if recomputed != er["hash"]:
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": f"engine sealed hash does not recompute: sealed {er['hash']}, "
+                         f"recomputed {recomputed} — refusing to attest",
+                "degraded": None, "_no_provenance": True, "epistemic": "unknown"}
+    snap = er["snapshot"]
+    data = {
+        "kind": kind, "subject": subject, "engine_hash": er["hash"],
+        # the seal-time binding verify_walk step 3 checks the receipt against —
+        # covered by outputs_sha, which the SIGNED in-toto statement carries.
+        "snapshot": {"seq": int(snap["seq"]), "nodes": int(snap["nodes"]), "edges": int(snap["edges"])},
+        "engine_receipt": er,
+    }
+    return {"outputs": [ComputeOutput(type="result", data=data)],
+            "runtime": "gateway", "status": "ok", "error": None, "degraded": None,
+            "_no_provenance": True, "epistemic": "verified"}
+
 
 # kind → adapter coroutine. Overridable in tests.
 _BACKENDS: dict[str, Callable[..., Awaitable[AdapterResult]]] = {
@@ -669,6 +730,8 @@ _BACKENDS: dict[str, Callable[..., Awaitable[AdapterResult]]] = {
     "gateway:parse": lambda spec, project, session: _parse(spec, project, session),
     "gateway:materialize": lambda spec, project, session: _materialize(spec, project, session),
     "gateway:governance": lambda spec, project, session: _governance(spec, project, session),
+
+    "gateway:engine-seal": lambda spec, project, session: _engine_seal(spec, project, session),
     "holmes": lambda spec, project, session: _extraction(spec, project, session),
     "open-data": lambda spec, project, session: _reconcile(spec, project, session),
     "sql": lambda spec, project, session: _sql_load(spec, project, session),

--- a/apps/compute-gateway/src/compute_gateway/engine_receipts.py
+++ b/apps/compute-gateway/src/compute_gateway/engine_receipts.py
@@ -1,0 +1,337 @@
+"""Seal-the-Walls W1.3 — receipt unification: the HellGraph ENGINE's sealed()
+receipts on THE estate receipt spine, verifiable end-to-end by ONE walk.
+
+The engine (vendored @socioprophet/hellgraph) seals every enrich/explore result:
+`hash = "sha256:" + sha256(JSON.stringify(rec))` over the receipt WITHOUT its
+`hash` field, where `rec` is built with a fixed key order and serialized by V8's
+JSON.stringify (insertion order, no whitespace, ECMAScript number formatting).
+For the gateway to attest that seal it must RECOMPUTE it byte-exactly — so this
+module carries a JS-faithful serializer (`js_stringify`) plus the engine's exact
+receipt shapes (key order pinned from the vendored dist, engine 0.4.40):
+
+  enrich  (AttributeRecommendation): {label, method, peers, snapshot, recommendations}
+      recommendation item: {key, kind, fusedScore, rank, peerCoverage, ownCoverage, signals}
+      signals: {consistency, trust, probabilistic[, coherence]}   (coherence LAST when present)
+  explore (Exploration):             {seeds, method, snapshot, suggestions}
+      suggestion item: {id, labels, score, rank}
+  snapshot (both): {seq, nodes, edges} — seq = the store's monotonic logical
+      clock, THE receipt binding to graph state (counts alone collide).
+
+Canonicalization is SCHEMA-DRIVEN, not trust-the-wire: key order is rebuilt from
+the pinned shapes, so recomputation survives any transport that reorders keys
+(the durable blob store re-serializes with sort_keys). Unknown keys are REFUSED
+loudly — a receipt this module can't order byte-exactly is a receipt it must not
+attest (an engine shape change lands here as a fail-loud diff, never a silent
+mis-hash).
+
+The verify walk (`verify_walk`) is the ONE end-to-end check the wall demands:
+  1. gateway-signature    — the receipt is on the project chain, its id-hash
+                            recomputes, and the Ed25519 signature over the
+                            in-toto statement verifies (spine authenticity).
+  2. engine-seal-hash     — the stored engine receipt's sealed sha256 recomputes
+                            byte-exactly (engine-output integrity).
+  3. snapshot-seq-binding — the stored envelope matches the SIGNED outputs_sha
+                            and the engine receipt's snapshot.seq equals the seq
+                            the gateway bound at seal time (graph-state binding;
+                            catches tamper-and-reseal, which step 2 cannot).
+Each step is typed in the returned trace; a failure stops the walk and marks the
+remaining steps skipped — so tampering fails at the step that OWNS the guarantee.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from decimal import Decimal
+from typing import Any
+
+from . import artifacts, receipts, signing
+
+ENGINE_KINDS = ("enrich", "explore")
+
+# ── the engine's receipt shapes, key order pinned from the vendored dist ──
+_SNAPSHOT_KEYS = ("seq", "nodes", "edges")
+_SIGNAL_KEYS = ("consistency", "trust", "probabilistic", "coherence")   # coherence optional, LAST
+_RECOMMENDATION_KEYS = ("key", "kind", "fusedScore", "rank", "peerCoverage", "ownCoverage", "signals")
+_SUGGESTION_KEYS = ("id", "labels", "score", "rank")
+_TOP_KEYS = {
+    "enrich": ("label", "method", "peers", "snapshot", "recommendations"),
+    "explore": ("seeds", "method", "snapshot", "suggestions"),
+}
+_OUTPUT_FIELD = {"enrich": "recommendations", "explore": "suggestions"}
+
+
+class EngineReceiptError(ValueError):
+    """A receipt this module cannot canonicalize byte-exactly (never attest it)."""
+
+
+# ── JS-faithful serialization: byte-identical to V8 JSON.stringify ──
+def _js_number(x: float) -> str:
+    """ECMAScript Number::toString(x, 10) for a finite double — V8's shortest
+    round-trip digits (Python's repr produces the same digit string) re-rendered
+    with JS placement rules: plain decimal for 1e-6 ≤ |x| < 1e21, exponent form
+    (`e+21`, `e-7` — sign always, no zero-pad) outside, integral doubles without
+    a trailing `.0`."""
+    if math.isnan(x) or math.isinf(x):
+        raise EngineReceiptError("non-finite number in engine receipt")
+    if x == 0:
+        return "0"                                   # JSON.stringify(-0) === "0"
+    sign, digits, exponent = Decimal(repr(x)).as_tuple()
+    ds = "".join(map(str, digits)).rstrip("0") or "0"
+    exponent += len(digits) - len(ds)                # shortest digits, adjusted exponent
+    k = len(ds)
+    n = k + int(exponent)                            # value = 0.<ds> × 10^n
+    if k <= n <= 21:
+        body = ds + "0" * (n - k)
+    elif 0 < n <= 21:
+        body = ds[:n] + "." + ds[n:]
+    elif -6 < n <= 0:
+        body = "0." + "0" * (-n) + ds
+    else:
+        e = n - 1
+        mantissa = ds if k == 1 else ds[0] + "." + ds[1:]
+        body = f"{mantissa}e{'+' if e >= 0 else '-'}{abs(e)}"
+    return ("-" if sign else "") + body
+
+
+def js_stringify(value: Any) -> str:
+    """V8 JSON.stringify for the JSON value domain (dict insertion order kept).
+    Python's json string escaping already matches V8 (`\\b \\t \\n \\f \\r`,
+    `\\u00xx` control chars, raw non-ASCII); numbers need `_js_number`."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):                      # before int — bool subclasses int
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return _js_number(value)
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, list):
+        return "[" + ",".join(js_stringify(v) for v in value) + "]"
+    if isinstance(value, dict):
+        parts = []
+        for k, v in value.items():
+            if not isinstance(k, str):
+                raise EngineReceiptError(f"non-string object key: {k!r}")
+            parts.append(json.dumps(k, ensure_ascii=False) + ":" + js_stringify(v))
+        return "{" + ",".join(parts) + "}"
+    raise EngineReceiptError(f"unserializable value of type {type(value).__name__}")
+
+
+# ── shape validation + schema-driven canonical ordering ──
+def _is_count(v: Any) -> bool:
+    return isinstance(v, int) and not isinstance(v, bool) and v >= 0
+
+
+def _is_num(v: Any) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
+def _check_exact_keys(obj: dict, allowed: tuple[str, ...], required: tuple[str, ...],
+                      where: str, errors: list[str]) -> None:
+    unknown = [k for k in obj if k not in allowed]
+    missing = [k for k in required if k not in obj]
+    if unknown:
+        errors.append(f"{where} has unknown key(s) {unknown} (engine 0.4.x shape pinned — refuse, never mis-hash)")
+    if missing:
+        errors.append(f"{where} missing {missing}")
+
+
+def validate(kind: str, receipt: Any) -> list[str]:
+    """Errors making `receipt` NOT a sealable engine receipt of `kind`. Empty ⇒
+    the shape is exactly the engine's sealed() output: hash + snapshot
+    {seq,nodes,edges} + the ranked output — everything sealed_hash() can order."""
+    if kind not in ENGINE_KINDS:
+        return [f"kind must be one of {list(ENGINE_KINDS)}, got {kind!r}"]
+    if not isinstance(receipt, dict):
+        return ["engineReceipt must be a JSON object"]
+    errors: list[str] = []
+    top = _TOP_KEYS[kind]
+    _check_exact_keys(receipt, top + ("hash",), top + ("hash",), "engineReceipt", errors)
+    if errors:
+        return errors
+
+    h = receipt["hash"]
+    if not (isinstance(h, str) and h.startswith("sha256:") and len(h) == 71):
+        errors.append("hash must be 'sha256:<64 hex>'")
+    if not isinstance(receipt["method"], str):
+        errors.append("method must be a string")
+
+    snap = receipt["snapshot"]
+    if not isinstance(snap, dict):
+        errors.append("snapshot must be an object {seq, nodes, edges}")
+    else:
+        _check_exact_keys(snap, _SNAPSHOT_KEYS, _SNAPSHOT_KEYS, "snapshot", errors)
+        for k in _SNAPSHOT_KEYS:
+            if k in snap and not _is_count(snap[k]):
+                errors.append(f"snapshot.{k} must be a non-negative integer")
+
+    if kind == "enrich":
+        if not isinstance(receipt["label"], str):
+            errors.append("label must be a string")
+        if not _is_count(receipt["peers"]):
+            errors.append("peers must be a non-negative integer")
+        recs = receipt["recommendations"]
+        if not isinstance(recs, list):
+            errors.append("recommendations must be a list")
+        else:
+            for i, item in enumerate(recs):
+                where = f"recommendations[{i}]"
+                if not isinstance(item, dict):
+                    errors.append(f"{where} must be an object")
+                    continue
+                _check_exact_keys(item, _RECOMMENDATION_KEYS, _RECOMMENDATION_KEYS, where, errors)
+                for k in ("key", "kind"):
+                    if not isinstance(item.get(k, ""), str):
+                        errors.append(f"{where}.{k} must be a string")
+                for k in ("fusedScore", "peerCoverage", "ownCoverage"):
+                    if k in item and not _is_num(item[k]):
+                        errors.append(f"{where}.{k} must be a number")
+                if "rank" in item and not _is_count(item["rank"]):
+                    errors.append(f"{where}.rank must be a non-negative integer")
+                sig = item.get("signals")
+                if not isinstance(sig, dict):
+                    errors.append(f"{where}.signals must be an object")
+                else:
+                    _check_exact_keys(sig, _SIGNAL_KEYS, _SIGNAL_KEYS[:3], f"{where}.signals", errors)
+                    for k in _SIGNAL_KEYS:
+                        if k in sig and not _is_num(sig[k]):
+                            errors.append(f"{where}.signals.{k} must be a number")
+    else:
+        seeds = receipt["seeds"]
+        if not (isinstance(seeds, list) and all(isinstance(s, str) for s in seeds)):
+            errors.append("seeds must be a list of strings")
+        sugs = receipt["suggestions"]
+        if not isinstance(sugs, list):
+            errors.append("suggestions must be a list")
+        else:
+            for i, item in enumerate(sugs):
+                where = f"suggestions[{i}]"
+                if not isinstance(item, dict):
+                    errors.append(f"{where} must be an object")
+                    continue
+                _check_exact_keys(item, _SUGGESTION_KEYS, _SUGGESTION_KEYS, where, errors)
+                if not isinstance(item.get("id", ""), str):
+                    errors.append(f"{where}.id must be a string")
+                labels = item.get("labels", [])
+                if not (isinstance(labels, list) and all(isinstance(x, str) for x in labels)):
+                    errors.append(f"{where}.labels must be a list of strings")
+                if "score" in item and not _is_num(item["score"]):
+                    errors.append(f"{where}.score must be a number")
+                if "rank" in item and not _is_count(item["rank"]):
+                    errors.append(f"{where}.rank must be a non-negative integer")
+    return errors
+
+
+def _ordered(obj: dict, keys: tuple[str, ...]) -> dict:
+    """The object with its keys in the ENGINE's construction order (optional keys
+    — signals.coherence — simply absent). Validation already refused unknowns."""
+    return {k: obj[k] for k in keys if k in obj}
+
+
+def canonicalize(kind: str, rec: dict) -> dict:
+    """Rebuild the exact object the engine hashed (receipt WITHOUT `hash`), key
+    order restored from the pinned shapes — trust the schema, not the wire."""
+    out = _ordered(rec, _TOP_KEYS[kind])
+    out["snapshot"] = _ordered(rec["snapshot"], _SNAPSHOT_KEYS)
+    if kind == "enrich":
+        out["recommendations"] = [
+            {**_ordered(r, _RECOMMENDATION_KEYS), "signals": _ordered(r["signals"], _SIGNAL_KEYS)}
+            for r in rec["recommendations"]]
+    else:
+        out["suggestions"] = [_ordered(s, _SUGGESTION_KEYS) for s in rec["suggestions"]]
+    return out
+
+
+def sealed_hash(kind: str, receipt: dict) -> str:
+    """Recompute the engine's sealed sha256 byte-exactly: canonical key order,
+    V8 serialization, hash field excluded."""
+    rec = canonicalize(kind, {k: v for k, v in receipt.items() if k != "hash"})
+    return "sha256:" + hashlib.sha256(js_stringify(rec).encode()).hexdigest()
+
+
+# ── the ONE verify walk ──
+_WALK = ("gateway-signature", "engine-seal-hash", "snapshot-seq-binding")
+
+
+def _receipt_body_hash_ok(r: Any) -> bool:
+    body = {k: getattr(r, k) for k in (
+        "project", "kind", "backend", "runtime", "inputs_sha", "outputs_sha",
+        "status", "actor", "epistemic_status", "prev", "ts")}
+    return receipts.sha(body) == r.id
+
+
+def verify_walk(project: str, receipt_id: str) -> dict[str, Any]:
+    """Walk an engine-seal receipt end-to-end: gateway signature → engine sealed
+    hash recomputation → snapshot.seq binding. Returns {valid, receipt_id,
+    project, steps:[{step, status: ok|fail|skipped, detail}]}; the walk stops at
+    the first failure so tampering is attributed to the step that owns it."""
+    steps: list[dict[str, Any]] = []
+
+    def fail(step: str, detail: str) -> dict[str, Any]:
+        steps.append({"step": step, "status": "fail", "detail": detail})
+        for later in _WALK[len(steps):]:
+            steps.append({"step": later, "status": "skipped", "detail": "prior step failed"})
+        return {"valid": False, "receipt_id": receipt_id, "project": project, "steps": steps}
+
+    def ok(step: str, detail: str | None = None) -> None:
+        steps.append({"step": step, "status": "ok", "detail": detail})
+
+    # 1 — gateway-signature: on the chain, id-hash intact, Ed25519 verifies.
+    r = next((x for x in receipts.chain(project) if x.id == receipt_id), None)
+    if r is None:
+        return fail("gateway-signature", f"no receipt {receipt_id} in project {project}")
+    if r.kind != "engine-seal":
+        return fail("gateway-signature", f"receipt kind {r.kind!r} is not engine-seal")
+    if not _receipt_body_hash_ok(r):
+        return fail("gateway-signature", "receipt id-hash does not recompute (chain tampered)")
+    if r.signature is None:
+        return fail("gateway-signature",
+                    "receipt is unsigned (no GATEWAY_SIGNING_KEY at seal time) — spine authenticity unprovable")
+    if r.statement is None or not signing.verify_signature(r.statement, r.signature, r.public_key):
+        return fail("gateway-signature", "gateway Ed25519 signature does not verify over the in-toto statement")
+    ok("gateway-signature", "chained + Ed25519 over in-toto statement verified")
+
+    # 2 — engine-seal-hash: the stored engine receipt's sealed sha256 recomputes.
+    digests = artifacts.for_receipt(receipt_id)
+    blob = next((b for b in (artifacts.get(d) for d in digests)
+                 if isinstance(b, dict) and isinstance(b.get("data"), dict)
+                 and "engine_receipt" in b["data"]), None)
+    if blob is None:
+        return fail("engine-seal-hash", "stored engine receipt not found in the artifact store")
+    ekind = blob["data"].get("kind")
+    er = blob["data"]["engine_receipt"]
+    errors = validate(ekind, er)
+    if errors:
+        return fail("engine-seal-hash", f"stored engine receipt shape invalid: {'; '.join(errors)}")
+    try:
+        recomputed = sealed_hash(ekind, er)
+    except EngineReceiptError as e:
+        return fail("engine-seal-hash", f"engine receipt not canonicalizable: {e}")
+    if recomputed != er["hash"]:
+        return fail("engine-seal-hash",
+                    f"engine sealed hash does not recompute: sealed {er['hash']}, recomputed {recomputed}")
+    ok("engine-seal-hash", f"sealed sha256 recomputed byte-exactly ({recomputed})")
+
+    # 3 — snapshot-seq-binding: the receipt's snapshot.seq equals the seq bound at
+    # seal time, AND the SIGNED outputs_sha still covers the stored envelope. This
+    # is what catches tamper-AND-reseal: a self-consistently re-hashed engine
+    # receipt passes step 2, but it cannot move the signed binding. The seq
+    # comparison runs first so a seq divergence is named as such; the outputs_sha
+    # pin then closes the remaining move (rewriting the binding copy itself).
+    bound = blob["data"].get("snapshot")
+    claimed = er["snapshot"]
+    if not (isinstance(bound, dict) and _is_count(bound.get("seq")) and _is_count(claimed.get("seq"))):
+        return fail("snapshot-seq-binding", "snapshot.seq missing or not a non-negative integer")
+    if bound["seq"] != claimed["seq"]:
+        return fail("snapshot-seq-binding",
+                    f"engine receipt snapshot.seq {claimed['seq']} does not match the sealed binding seq {bound['seq']}")
+    stored_outputs = [artifacts.get(d) for d in digests]
+    if receipts.sha(stored_outputs) != r.outputs_sha:
+        return fail("snapshot-seq-binding",
+                    "stored envelope does not match the signed outputs_sha (binding broken)")
+    ok("snapshot-seq-binding", f"graph-state binding intact (seq {bound['seq']})")
+
+    return {"valid": True, "receipt_id": receipt_id, "project": project, "steps": steps}

--- a/apps/compute-gateway/src/compute_gateway/registry.py
+++ b/apps/compute-gateway/src/compute_gateway/registry.py
@@ -115,6 +115,20 @@ KINDS: dict[str, dict] = {
                         "hash-chained-audit", "dry-run"],
         "epistemic": "observed", "executes_user_code": False, "status": "live",
     },
+
+    # ── Seal-the-Walls W1.3: receipt unification — engine sealed() receipts on THE spine ──
+    # hellgraph-service POSTs each enrich/explore ENGINE receipt (sealed sha256 over the
+    # ranked output + snapshot {seq,nodes,edges}) here; the gateway recomputes that seal
+    # byte-exactly (V8 JSON.stringify semantics — engine_receipts.py), wraps it in the
+    # signed in-toto envelope, and chains it on the ONE spine — so a single verify walk
+    # covers gateway signature → engine hash → snapshot.seq binding end-to-end. In-process,
+    # runs no user code. Warrant `verified`: the seal is independently RECOMPUTED, not
+    # trusted (error receipts carry `unknown` — the adapter types them explicitly).
+    "engine-seal": {
+        "backends": ["gateway"], "default": "gateway",
+        "capabilities": ["enrich", "explore", "sealed-hash-recompute", "snapshot-seq-binding"],
+        "epistemic": "verified", "executes_user_code": False, "status": "live",
+    },
 }
 
 

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -9,12 +9,13 @@ the walking skeleton of "any compute, one contract".
 from __future__ import annotations
 
 import os
+from typing import Any, Literal
 
 from fastapi import Depends, FastAPI, Header, HTTPException
 
 from pydantic import BaseModel
 
-from . import artifacts, engine, grants, planner, receipts, registry, rocrate, zerotrust
+from . import artifacts, engine, engine_receipts, grants, planner, receipts, registry, rocrate, zerotrust
 from .contract import ComputeRequest, ComputeResult
 
 app = FastAPI(title="compute-gateway", version="0.1.0")
@@ -223,6 +224,51 @@ def workflow_ro_crate_view(receipt_id: str, project: str = "default",
                    f"use /v1/receipts/{receipt_id}/ro-crate")
     steps = _workflow_step_receipts(composite.id, chain)
     return rocrate.build_workflow(composite, steps)
+
+
+class EngineSealBody(BaseModel):
+    """W1.3 receipt unification — an ENGINE sealed() receipt presented for chaining."""
+    kind: Literal["enrich", "explore"]
+    engineReceipt: dict[str, Any]
+    subject: dict[str, Any] = {}
+    project: str = "default"
+    actor: str = "hellgraph-service"
+    entitlement: str | None = None
+
+
+@app.post("/v1/engine-receipts")
+async def engine_receipt_seal(body: EngineSealBody, _: None = Depends(require_token)) -> dict:
+    """Chain a HellGraph ENGINE sealed() receipt (enrich | explore) into THE receipt
+    spine. Runs through the exact same governed path as every compute (the
+    `engine-seal` kind): entitle → memo → validate + RECOMPUTE the engine's sealed
+    sha256 byte-exactly → seal → Ed25519-attest. Identical receipt re-presented ⇒
+    the memo returns the SAME receipt (idempotent retry, materialize precedent).
+    A receipt whose seal does not recompute is refused (422) — the spine never
+    attests what it cannot verify."""
+    req = ComputeRequest(
+        kind="engine-seal", project=body.project, actor=body.actor,
+        entitlement=body.entitlement,
+        spec={"kind": body.kind, "engineReceipt": body.engineReceipt, "subject": body.subject})
+    result = await engine.execute(req)
+    if result.status in ("entitlement_required", "grant_required"):
+        raise HTTPException(status_code=403, detail=result.message or result.status)
+    if result.status != "ok" or result.receipt is None:
+        raise HTTPException(status_code=422, detail=result.error or result.message or "engine-seal refused")
+    return {
+        "receiptId": result.receipt.id,
+        "envelope": {"receipt": result.receipt.model_dump(), "attestation": result.attestation},
+        "memoized": result.memoized,
+    }
+
+
+@app.get("/v1/engine-receipts/{receipt_id}/verify")
+def engine_receipt_verify(receipt_id: str, project: str = "default",
+                          _: None = Depends(require_token)) -> dict:
+    """ONE verify() that walks an engine receipt end-to-end: gateway Ed25519
+    signature → engine sealed-hash recomputation → snapshot.seq binding. Always
+    200 with {valid, steps:[{step, status, detail}]} — the typed trace IS the
+    result; a missing receipt is simply valid:false at the first step."""
+    return engine_receipts.verify_walk(project, receipt_id)
 
 
 @app.get("/v1/receipts")

--- a/apps/compute-gateway/tests/test_engine_seal.py
+++ b/apps/compute-gateway/tests/test_engine_seal.py
@@ -1,0 +1,278 @@
+"""Seal-the-Walls W1.3 — receipt unification: engine sealed() receipts chained on THE
+spine, ONE verify walk end-to-end, tampering attributed to the step that owns it.
+
+Golden fixtures are REAL engine output: captured from the vendored
+@socioprophet/hellgraph 0.4.40 dist (node), hashes minted by V8's JSON.stringify —
+so the Python recomputation is anchored against actual engine bytes, not against
+itself. The number battery likewise carries V8 ground truth (`JSON.stringify(v)`
+outputs generated in node), covering every formatting divergence between Python
+repr and ECMAScript Number::toString (integral floats, 1e-5/1e-6 plain forms,
+e-7/e+21 exponent forms, unpadded exponents, subnormals).
+"""
+import base64
+import importlib
+import json
+import os
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo,engine-seal"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+# deterministic Ed25519 key: the signature step must be REAL in these tests
+os.environ["GATEWAY_SIGNING_KEY"] = base64.b64encode(bytes(range(32))).decode()
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import artifacts, engine, engine_receipts, receipts, server  # noqa: E402
+
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+# ── golden fixtures: REAL sealed receipts from the vendored engine (0.4.40) ──
+ENRICH_JSON = (
+    '{"label":"FxClass","method":"rrf(consistency,trust,probabilistic)","peers":7,'
+    '"snapshot":{"seq":58,"nodes":10,"edges":8},"recommendations":[{"key":"extraA","kind":"property",'
+    '"fusedScore":0.04918032786885246,"rank":1,"peerCoverage":1,"ownCoverage":0,'
+    '"signals":{"consistency":1,"trust":1,"probabilistic":0.875}},'
+    '{"key":"fx_rel","kind":"relation-out","fusedScore":0.04838709677419355,"rank":2,'
+    '"peerCoverage":0.8571428571428571,"ownCoverage":0,"signals":{"consistency":0.8571428571428571,'
+    '"trust":0.8571428571428572,"probabilistic":0.7346938775510203}},'
+    '{"key":"extraB","kind":"property","fusedScore":0.047619047619047616,"rank":3,'
+    '"peerCoverage":0.42857142857142855,"ownCoverage":0,"signals":{"consistency":0.42857142857142855,'
+    '"trust":0.42857142857142866,"probabilistic":0.3214285714285714}}],'
+    '"hash":"sha256:018f2febf0c76f91752ba9726c9a32a4a8d3ca03895a5d877b780c312d34cc71"}'
+)
+EXPLORE_JSON = (
+    '{"seeds":["fx:c0"],"method":"rrf(personalized-pagerank,seed-adjacency)",'
+    '"snapshot":{"seq":58,"nodes":10,"edges":8},"suggestions":[{"id":"fx:c1","labels":["FxClass"],'
+    '"score":0.03278688524590164,"rank":1},{"id":"fx:c2","labels":["FxClass"],'
+    '"score":0.03225806451612903,"rank":2}],'
+    '"hash":"sha256:35a9df2dd74a25fcbb966a41d2949cd7646912d743aeec730a36fa1a1d3a00af"}'
+)
+
+# (value-as-parsed-from-JS, V8 JSON.stringify output) — generated in node
+V8_NUMBERS = [
+    (0, "0"), (1, "1"), (-1, "-1"), (0.5, "0.5"), (1.5, "1.5"), (2, "2"),
+    (1e-5, "0.00001"), (1e-6, "0.000001"), (1e-7, "1e-7"), (1.5e-7, "1.5e-7"),
+    (0.0001, "0.0001"), (1e21, "1e+21"), (1e20, "100000000000000000000"),
+    (1.2345678901234567e20, "123456789012345670000"),
+    (0.30000000000000004, "0.30000000000000004"), (0.3333333333333333, "0.3333333333333333"),
+    (0.03278688524590164, "0.03278688524590164"), (0.8571428571428572, "0.8571428571428572"),
+    (1e-323, "1e-323"), (5e-324, "5e-324"),
+    (1.7976931348623157e308, "1.7976931348623157e+308"),
+    (123456789.12345679, "123456789.12345679"), (-2.5e-9, "-2.5e-9"),
+    (3.0, "3"), (100.0, "100"), (2e64, "2e+64"), (6.02e23, "6.02e+23"),
+    (-0.000015, "-0.000015"), (7.006492321624085e-46, "7.006492321624085e-46"),
+]
+
+
+def setup_function():
+    os.environ["COMPUTE_ENTITLEMENTS"] = "demo,engine-seal"   # pin: sibling modules mutate the shared env
+    receipts._CHAINS.clear()
+    engine._MEMO.clear()
+    artifacts._reset()
+
+
+def _enrich_receipt():
+    return json.loads(ENRICH_JSON)
+
+
+def _explore_receipt():
+    return json.loads(EXPLORE_JSON)
+
+
+def _seal(kind, er, subject=None, project="demo"):
+    return client.post("/v1/engine-receipts", headers=AUTH, json={
+        "kind": kind, "engineReceipt": er,
+        "subject": subject or {"service": "hellgraph-service", "endpoint": f"/api/graph/{kind}"},
+        "project": project})
+
+
+def _verify(receipt_id, project="demo"):
+    return client.get(f"/v1/engine-receipts/{receipt_id}/verify",
+                      params={"project": project}, headers=AUTH).json()
+
+
+def _statuses(walk):
+    return [(s["step"], s["status"]) for s in walk["steps"]]
+
+
+# ── the byte-exact recomputation, anchored on REAL V8 output ──
+def test_js_stringify_matches_v8_number_formatting():
+    for v, expected in V8_NUMBERS:
+        assert engine_receipts.js_stringify(v) == expected, f"{v!r} → {expected}"
+    # strings, escapes, nesting, key order (V8 ground truth from node)
+    assert engine_receipts.js_stringify("quote\"q") == '"quote\\"q"'
+    assert engine_receipts.js_stringify("ctrl\x01\x1f") == '"ctrl\\u0001\\u001f"'
+    assert engine_receipts.js_stringify("unicodé ☃") == '"unicodé ☃"'
+    assert engine_receipts.js_stringify({"b": 1, "a": [True, False, None, {"z": 0.875, "y": "x"}]}) \
+        == '{"b":1,"a":[true,false,null,{"z":0.875,"y":"x"}]}'
+
+
+def test_sealed_hash_recomputes_real_engine_receipts():
+    er, xr = _enrich_receipt(), _explore_receipt()
+    assert engine_receipts.sealed_hash("enrich", er) == er["hash"]
+    assert engine_receipts.sealed_hash("explore", xr) == xr["hash"]
+    # and the recomputation is over CANONICAL order, not wire order: scrambling
+    # the received key order (what the durable blob store's sort_keys does) must
+    # not change the recomputed seal.
+    scrambled = {k: er[k] for k in sorted(er)}
+    scrambled["snapshot"] = {k: er["snapshot"][k] for k in sorted(er["snapshot"])}
+    assert engine_receipts.sealed_hash("enrich", scrambled) == er["hash"]
+
+
+# ── sealing onto the spine ──
+def test_engine_seal_chains_a_signed_envelope_and_one_verify_walks_it():
+    r = _seal("enrich", _enrich_receipt())
+    assert r.status_code == 200
+    body = r.json()
+    rc = body["envelope"]["receipt"]
+    assert body["receiptId"] == rc["id"]
+    assert rc["kind"] == "engine-seal" and rc["backend"] == "gateway"
+    assert rc["epistemic_status"] == "verified"       # the seal was RECOMPUTED, not trusted
+    assert rc["signature"] and rc["public_key"] and rc["statement"]
+    assert body["envelope"]["attestation"]["results"]["cosign_valid"] is True
+    # on THE one chain
+    chain = receipts.chain("demo")
+    assert [c.id for c in chain] == [body["receiptId"]]
+    assert receipts.verify("demo")["valid"] is True
+    # ONE verify() walks it end-to-end, every step typed and ok, in walk order
+    walk = _verify(body["receiptId"])
+    assert walk["valid"] is True
+    assert _statuses(walk) == [("gateway-signature", "ok"), ("engine-seal-hash", "ok"),
+                               ("snapshot-seq-binding", "ok")]
+
+
+def test_engine_seal_explore_receipt_verifies_too():
+    r = _seal("explore", _explore_receipt())
+    assert r.status_code == 200
+    walk = _verify(r.json()["receiptId"])
+    assert walk["valid"] is True and len(walk["steps"]) == 3
+
+
+def test_engine_seal_retry_returns_the_same_receipt():
+    # hellgraph-service retrying the identical POST (timeout, restart) must not
+    # grow the chain — the memo returns the SAME receipt (materialize precedent).
+    first = _seal("enrich", _enrich_receipt()).json()
+    again = _seal("enrich", _enrich_receipt()).json()
+    assert again["receiptId"] == first["receiptId"] and again["memoized"] is True
+    assert len(receipts.chain("demo")) == 1
+
+
+def test_engine_seal_shape_validation_fails_loud():
+    er = _enrich_receipt()
+    del er["snapshot"]
+    r = _seal("enrich", er)
+    assert r.status_code == 422 and "snapshot" in r.json()["detail"]
+    # unknown keys are refused, never silently mis-hashed
+    er2 = _enrich_receipt()
+    er2["surprise"] = 1
+    r2 = _seal("enrich", er2)
+    assert r2.status_code == 422 and "surprise" in r2.json()["detail"]
+    # wrong kind literal is a 422 at the contract edge
+    assert client.post("/v1/engine-receipts", headers=AUTH, json={
+        "kind": "bogus", "engineReceipt": _enrich_receipt()}).status_code == 422
+
+
+def test_engine_seal_refuses_a_hash_that_does_not_recompute():
+    er = _enrich_receipt()
+    er["hash"] = "sha256:" + "0" * 64
+    r = _seal("enrich", er)
+    assert r.status_code == 422
+    assert "does not recompute" in r.json()["detail"]
+    # the refusal is an honest error receipt on the chain, typed unknown — the
+    # spine records the refusal without claiming verification.
+    chain = receipts.chain("demo")
+    assert len(chain) == 1 and chain[0].status == "error"
+    assert chain[0].epistemic_status == "unknown"
+
+
+# ── the three tamper cases: each fails at the RIGHT step ──
+def test_tamper_output_byte_fails_at_engine_seal_hash():
+    rid = _seal("explore", _explore_receipt()).json()["receiptId"]
+    # flip a byte in the STORED engine output (a suggestion id) — seal untouched
+    blob = artifacts.get(artifacts.for_receipt(rid)[0])
+    blob["data"]["engine_receipt"]["suggestions"][0]["id"] = "fx:cX"
+    walk = _verify(rid)
+    assert walk["valid"] is False
+    assert _statuses(walk) == [("gateway-signature", "ok"), ("engine-seal-hash", "fail"),
+                               ("snapshot-seq-binding", "skipped")]
+    assert "does not recompute" in walk["steps"][1]["detail"]
+
+
+def test_tamper_seq_and_reseal_fails_at_snapshot_seq_binding():
+    rid = _seal("enrich", _enrich_receipt()).json()["receiptId"]
+    # a SELF-CONSISTENT forgery: bump seq inside the engine receipt AND re-seal its
+    # hash. Step 2 must pass (the forged receipt recomputes) — only the signed
+    # seal-time binding can catch that the graph state moved.
+    blob = artifacts.get(artifacts.for_receipt(rid)[0])
+    er = blob["data"]["engine_receipt"]
+    er["snapshot"]["seq"] += 1
+    er["hash"] = engine_receipts.sealed_hash("enrich", er)
+    walk = _verify(rid)
+    assert walk["valid"] is False
+    assert _statuses(walk) == [("gateway-signature", "ok"), ("engine-seal-hash", "ok"),
+                               ("snapshot-seq-binding", "fail")]
+    assert "snapshot.seq" in walk["steps"][2]["detail"]
+
+
+def test_tamper_signature_fails_at_gateway_signature():
+    rid = _seal("enrich", _enrich_receipt()).json()["receiptId"]
+    r = receipts.chain("demo")[0]
+    sig = bytearray(base64.b64decode(r.signature))
+    sig[0] ^= 0xFF                                     # flip a byte in the Ed25519 signature
+    r.signature = base64.b64encode(bytes(sig)).decode()
+    walk = _verify(rid)
+    assert walk["valid"] is False
+    assert _statuses(walk) == [("gateway-signature", "fail"), ("engine-seal-hash", "skipped"),
+                               ("snapshot-seq-binding", "skipped")]
+    assert "signature" in walk["steps"][0]["detail"]
+
+
+def test_tamper_whole_envelope_cannot_outrun_the_signed_outputs_sha():
+    # the strongest forgery: rewrite the stored binding AND the engine receipt,
+    # both self-consistent. The signed outputs_sha still pins the envelope.
+    rid = _seal("explore", _explore_receipt()).json()["receiptId"]
+    blob = artifacts.get(artifacts.for_receipt(rid)[0])
+    er = blob["data"]["engine_receipt"]
+    er["snapshot"]["seq"] += 7
+    er["hash"] = engine_receipts.sealed_hash("explore", er)
+    blob["data"]["snapshot"]["seq"] += 7               # binding rewritten to match
+    walk = _verify(rid)
+    assert walk["valid"] is False
+    assert walk["steps"][2]["step"] == "snapshot-seq-binding"
+    assert walk["steps"][2]["status"] == "fail"
+    assert "outputs_sha" in walk["steps"][2]["detail"]
+
+
+def test_verify_walk_missing_receipt_is_invalid_at_step_one():
+    walk = _verify("sha256:" + "ee" * 32)
+    assert walk["valid"] is False
+    assert walk["steps"][0]["step"] == "gateway-signature"
+    assert walk["steps"][0]["status"] == "fail"
+
+
+def test_verify_walk_refuses_non_engine_seal_kinds():
+    # seal a materialize receipt, then ask the engine walk to verify it — the walk
+    # must refuse at step 1 rather than "verify" a receipt with no engine seal.
+    os.environ["COMPUTE_ENTITLEMENTS"] = "demo,engine-seal,materialize"
+    m = client.post("/v1/compute", headers=AUTH, json={
+        "kind": "materialize", "project": "demo",
+        "spec": {"sink": "clickhouse", "table": "hellgraph.events", "to_cursor": 9,
+                 "row_count": 1, "batch_hash": "sha256:" + "ab" * 32}}).json()
+    walk = _verify(m["receipt"]["id"])
+    assert walk["valid"] is False and "not engine-seal" in walk["steps"][0]["detail"]
+
+
+def test_unsigned_seal_is_honestly_unverifiable():
+    # without a signing key the envelope is sealed UNSIGNED (never faked) — and the
+    # verify walk must then refuse step 1: no claimed authenticity without a signature.
+    key = os.environ.pop("GATEWAY_SIGNING_KEY")
+    try:
+        rid = _seal("enrich", _enrich_receipt()).json()["receiptId"]
+        walk = _verify(rid)
+        assert walk["valid"] is False
+        assert walk["steps"][0]["step"] == "gateway-signature"
+        assert "unsigned" in walk["steps"][0]["detail"]
+    finally:
+        os.environ["GATEWAY_SIGNING_KEY"] = key

--- a/apps/hellgraph-service/src/auth.integration.test.ts
+++ b/apps/hellgraph-service/src/auth.integration.test.ts
@@ -124,7 +124,7 @@ test('fail-closed startup: AUTH_ENFORCE=on without AUTH_HMAC_SECRET refuses to b
       ...process.env,
       AUTH_ENFORCE: 'on',
       AUTH_HMAC_SECRET: '',
-      PORT: '19099',
+      PORT: '19096',
       HELLGRAPH_SEED: 'off',
       HELLGRAPH_LOAD_KKO: 'off',
       HELLGRAPH_STORE_DIR: `${process.env.TMPDIR ?? '/tmp'}/hgsvc-failclosed-${process.pid}`,

--- a/apps/hellgraph-service/src/membrane.test.ts
+++ b/apps/hellgraph-service/src/membrane.test.ts
@@ -267,7 +267,7 @@ test('seal degradation is honest: gateway down/erroring ⇒ decision lands with 
   } finally { gatewayMode = 'ok' }
   // gateway unreachable
   const prev = process.env.COMPUTE_GATEWAY_URL
-  process.env.COMPUTE_GATEWAY_URL = 'http://127.0.0.1:19099' // nothing listens here
+  process.env.COMPUTE_GATEWAY_URL = 'http://127.0.0.1:19108' // nothing listens here
   try {
     const d = await post('/api/membrane/decide', effectRequest('seal-down'))
     assert.equal(d.status, 200)

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -50,6 +50,7 @@ import { askGraph, retrieveGrounding, retrieveGroundingAuto, synthesisEnabled, s
 import { pagerank, connectedComponents, bfs, sssp, cdlp, lcc, analyticsBackend, dataScope } from './analytics.js'
 import { initAuth, authorize, type AuthState } from './auth.js'
 import { initMembrane, handleMembrane, membraneCheckNodeWrite, type MembraneState } from './membrane.js'
+import { sealToSpine, spineEnabled, unsealedReceipts } from './spine.js'
 
 const PORT = Number(process.env.PORT ?? 8090)
 
@@ -141,15 +142,21 @@ const server = http.createServer((req, res) => {
   }
 
   // Enrichment surface — profile a class's schema-in-use + rank useful new attributes (proof-carrying).
-  //   GET /api/graph/enrich?label=X[&topK=N]  → { profile, recommendation, kkoCoherence }
+  //   GET /api/graph/enrich?label=X[&topK=N]  → { profile, recommendation, kkoCoherence[, spine] }
   // Runs the enrichClass orchestrator: profile (coverage+cardinality) + the RRF-fused recommender
   // (consistency, PageRank-trust, PLN-probabilistic — and the KKO coherence ranker AUTO-ACTIVATES when
   // KBpedia reference concepts are loaded in this graph). Each result is sealed over the graph snapshot.
+  // W1.3: with GATEWAY_RECEIPTS=on the sealed engine receipt is chained onto the compute-gateway
+  // spine and the response carries spine:{ok,receiptId} — honest degradation on failure (spine.ts).
   if (req.method === 'GET' && url.pathname === '/api/graph/enrich') {
     const label = url.searchParams.get('label')
     if (!label) return void json(res, 400, { ok: false, error: 'enrich requires ?label=' })
     const topK = Math.max(1, Math.min(100, Number(url.searchParams.get('topK') ?? 10) || 10))
-    return void json(res, 200, { ok: true, ...engine.enrichClass(g, label, { topK }) })
+    const result = engine.enrichClass(g, label, { topK })
+    if (!spineEnabled()) return void json(res, 200, { ok: true, ...result })
+    return void sealToSpine('enrich', result.recommendation,
+      { service: 'hellgraph-service', endpoint: '/api/graph/enrich', label, topK })
+      .then((spine) => json(res, 200, { ok: true, ...result, spine }))
   }
 
   // Guided exploration — from seed node id(s), rank what to explore next (proof-carrying).
@@ -162,11 +169,19 @@ const server = http.createServer((req, res) => {
     const seeds = seedsParam.split(',').map((s) => s.trim()).filter(Boolean)
     if (seeds.length === 0) return void json(res, 400, { ok: false, error: 'explore requires at least one seed id' })
     const topK = Math.max(1, Math.min(100, Number(url.searchParams.get('topK') ?? 10) || 10))
-    return void json(res, 200, { ok: true, exploration: engine.exploreFrom(g, seeds, { topK }) })
+    const exploration = engine.exploreFrom(g, seeds, { topK })
+    if (!spineEnabled()) return void json(res, 200, { ok: true, exploration })
+    return void sealToSpine('explore', exploration,
+      { service: 'hellgraph-service', endpoint: '/api/graph/explore', seeds, topK })
+      .then((spine) => json(res, 200, { ok: true, exploration, spine }))
   }
 
   if (req.method === 'GET' && url.pathname === '/healthz') {
-    return json(res, 200, { ok: true, service: 'hellgraph-service', engine_exports: Object.keys(engine).length })
+    return json(res, 200, {
+      ok: true, service: 'hellgraph-service', engine_exports: Object.keys(engine).length,
+      // W1.3 honest-degradation counter: enrich/explore results served WITHOUT a spine receipt
+      unsealedReceipts: unsealedReceipts(),
+    })
   }
 
   if (req.method === 'GET' && url.pathname === '/api/graph/stats') {

--- a/apps/hellgraph-service/src/spine.test.ts
+++ b/apps/hellgraph-service/src/spine.test.ts
@@ -1,0 +1,163 @@
+/**
+ * W1.3 receipt unification — hellgraph-service side: the sealed engine receipt is
+ * chained onto the compute-gateway spine and the enrich/explore response carries
+ * spine:{ok, receiptId}; failure degrades HONESTLY (result still serves,
+ * spine:{ok:false, reason}, /healthz unsealedReceipts counts it, warn log) —
+ * never fail the read because sealing failed, never claim sealed when it isn't.
+ *
+ * The gateway here is a local mock: these tests pin OUR side of the contract
+ * (what we POST, how we attach, how we degrade). The gateway's own recomputation
+ * and verify walk are covered by apps/compute-gateway/tests/test_engine_seal.py
+ * against REAL engine fixtures.
+ */
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import * as http from 'node:http'
+
+process.env.PORT = String(19093) // free test port, read at module import
+process.env.HELLGRAPH_STORE_DIR = `${process.env.TMPDIR ?? '/tmp'}/hgsvc-spine-test-${process.pid}`
+process.env.HELLGRAPH_SEED = 'off' // tests build their own graphs — don't auto-seed the boot corpus
+process.env.GATEWAY_RECEIPTS = 'on'
+process.env.GATEWAY_URL = 'http://127.0.0.1:19094'
+process.env.GATEWAY_TOKEN = 'spine-test-token'
+process.env.GATEWAY_TIMEOUT_MS = '900'
+
+const BASE = `http://127.0.0.1:${process.env.PORT}`
+
+// ── mock compute-gateway: records requests; behavior switched per test ──
+type Seen = { path: string; auth: string | undefined; body: any }
+const seen: Seen[] = []
+let mode: 'ok' | 'http401' = 'ok'
+const MOCK_RECEIPT_ID = 'sha256:' + 'ab'.repeat(32)
+
+const mockGateway = http.createServer((req, res) => {
+  let d = ''
+  req.on('data', (c: Buffer) => { d += c.toString() })
+  req.on('end', () => {
+    seen.push({ path: req.url ?? '', auth: req.headers.authorization, body: d ? JSON.parse(d) : undefined })
+    if (mode === 'http401') {
+      res.writeHead(401, { 'content-type': 'application/json' })
+      return void res.end(JSON.stringify({ detail: 'unauthorized' }))
+    }
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ receiptId: MOCK_RECEIPT_ID, envelope: { receipt: { id: MOCK_RECEIPT_ID } } }))
+  })
+})
+
+let srv: { close: (cb?: () => void) => void }
+
+before(async () => {
+  await new Promise<void>((r) => mockGateway.listen(19094, r))
+  const mod = await import('./server')
+  srv = mod.server as unknown as typeof srv
+  await new Promise((r) => setTimeout(r, 150)) // give the listener a tick
+})
+after(() => { srv?.close(); mockGateway.close() })
+
+async function req(method: string, path: string, body?: unknown) {
+  const r = await fetch(BASE + path, {
+    method,
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  return { status: r.status, json: (await r.json()) as any }
+}
+
+async function unsealedCount(): Promise<number> {
+  return (await req('GET', '/healthz')).json.unsealedReceipts as number
+}
+
+test('enrich attaches spine:{ok,receiptId} and POSTs the sealed engine receipt to the gateway', async () => {
+  const L = `sp-enr-${process.pid}`
+  await req('POST', '/api/graph/node', { id: `${L}:c1`, labels: [L], properties: { spKey: 'a' } })
+  await req('POST', '/api/graph/node', { id: `${L}:c2`, labels: [L], properties: { spKey: 'b' } })
+  await req('POST', '/api/graph/node', { id: `${L}:p1`, labels: [`${L}-peer`], properties: { spKey: 'c', spExtra: 'x' } })
+
+  seen.length = 0
+  const r = await req('GET', `/api/graph/enrich?label=${encodeURIComponent(L)}&topK=5`)
+  assert.equal(r.status, 200)
+  assert.equal(r.json.ok, true)
+  assert.match(r.json.recommendation.hash, /^sha256:/)              // result unchanged: still proof-carrying
+  assert.deepEqual(r.json.spine, { ok: true, receiptId: MOCK_RECEIPT_ID })
+
+  // what crossed the wire is the CONTRACT: kind + the sealed receipt + subject, bearer-authed
+  assert.equal(seen.length, 1)
+  assert.equal(seen[0].path, '/v1/engine-receipts')
+  assert.equal(seen[0].auth, 'Bearer spine-test-token')
+  assert.equal(seen[0].body.kind, 'enrich')
+  assert.equal(seen[0].body.actor, 'hellgraph-service')
+  assert.equal(seen[0].body.engineReceipt.hash, r.json.recommendation.hash)   // the EXACT sealed receipt
+  assert.deepEqual(seen[0].body.engineReceipt.snapshot, r.json.recommendation.snapshot)
+  assert.equal(seen[0].body.subject.endpoint, '/api/graph/enrich')
+  assert.equal(seen[0].body.subject.label, L)
+})
+
+test('explore attaches spine too, POSTing the exploration receipt', async () => {
+  const L = `sp-exp-${process.pid}`
+  await req('POST', '/api/graph/node', { id: `${L}:s`, labels: [L] })
+  await req('POST', '/api/graph/node', { id: `${L}:n1`, labels: [L] })
+  await req('POST', '/api/graph/edge', { label: 'rel', from: `${L}:s`, to: `${L}:n1` })
+
+  seen.length = 0
+  const r = await req('GET', `/api/graph/explore?seeds=${encodeURIComponent(`${L}:s`)}&topK=5`)
+  assert.equal(r.status, 200)
+  assert.deepEqual(r.json.spine, { ok: true, receiptId: MOCK_RECEIPT_ID })
+  assert.equal(seen[0].body.kind, 'explore')
+  assert.equal(seen[0].body.engineReceipt.hash, r.json.exploration.hash)
+  assert.deepEqual(seen[0].body.subject.seeds, [`${L}:s`])
+})
+
+test('gateway unreachable ⇒ honest degradation: result serves, spine:{ok:false}, counter + warn', async () => {
+  const L = `sp-deg-${process.pid}`
+  await req('POST', '/api/graph/node', { id: `${L}:s`, labels: [L] })
+  const before = await unsealedCount()
+  process.env.GATEWAY_URL = 'http://127.0.0.1:19099' // nothing listens here (read per call)
+  try {
+    const r = await req('GET', `/api/graph/explore?seeds=${encodeURIComponent(`${L}:s`)}`)
+    assert.equal(r.status, 200)                                     // availability: the read never fails
+    assert.ok(r.json.exploration && Array.isArray(r.json.exploration.suggestions))
+    assert.equal(r.json.spine.ok, false)                            // …but we never claim sealed
+    assert.match(r.json.spine.reason, /unreachable/)
+    assert.equal(await unsealedCount(), before + 1)                  // /healthz counts every unsealed serve
+  } finally {
+    process.env.GATEWAY_URL = 'http://127.0.0.1:19094'
+  }
+})
+
+test('gateway refusal (HTTP 401) degrades honestly with the status in the reason', async () => {
+  const L = `sp-401-${process.pid}`
+  await req('POST', '/api/graph/node', { id: `${L}:s`, labels: [L] })
+  const before = await unsealedCount()
+  mode = 'http401'
+  try {
+    const r = await req('GET', `/api/graph/explore?seeds=${encodeURIComponent(`${L}:s`)}`)
+    assert.equal(r.status, 200)
+    assert.equal(r.json.spine.ok, false)
+    assert.match(r.json.spine.reason, /gateway HTTP 401/)
+    assert.equal(await unsealedCount(), before + 1)
+  } finally {
+    mode = 'ok'
+  }
+})
+
+test('GATEWAY_RECEIPTS off ⇒ no spine field at all (exact pre-W1.3 response shape)', async () => {
+  const L = `sp-off-${process.pid}`
+  await req('POST', '/api/graph/node', { id: `${L}:s`, labels: [L] })
+  process.env.GATEWAY_RECEIPTS = 'off'
+  try {
+    seen.length = 0
+    const r = await req('GET', `/api/graph/explore?seeds=${encodeURIComponent(`${L}:s`)}`)
+    assert.equal(r.status, 200)
+    assert.ok(!('spine' in r.json), 'no spine field when disabled')
+    assert.equal(seen.length, 0, 'no gateway call when disabled')
+  } finally {
+    process.env.GATEWAY_RECEIPTS = 'on'
+  }
+})
+
+test('healthz reports the unsealedReceipts counter', async () => {
+  const h = await req('GET', '/healthz')
+  assert.equal(h.status, 200)
+  assert.equal(typeof h.json.unsealedReceipts, 'number')
+  assert.ok(h.json.unsealedReceipts >= 2, 'the two degradation tests above were counted')
+})

--- a/apps/hellgraph-service/src/spine.test.ts
+++ b/apps/hellgraph-service/src/spine.test.ts
@@ -1,3 +1,10 @@
+// PORT ALLOCATION (node:test runs test FILES in parallel — every bound port must be
+// unique across this directory, or files race and the loser gets EADDRINUSE + undefined
+// responses; found exactly that way when W1.3 and W2 were reconciled):
+//   19091 server.test  ·  19093 membrane.test  ·  19094 membrane-off.test
+//   19095 auth.integration  ·  19096 auth.integration spawn  ·  19097 membrane stub gateway
+//   19101 spine.test  ·  19102 spine.test mock gateway
+//   dead ports (nothing may ever bind these): 19108 membrane, 19109 spine
 /**
  * W1.3 receipt unification — hellgraph-service side: the sealed engine receipt is
  * chained onto the compute-gateway spine and the enrich/explore response carries
@@ -14,11 +21,11 @@ import { test, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import * as http from 'node:http'
 
-process.env.PORT = String(19093) // free test port, read at module import
+process.env.PORT = String(19101) // free test port (see PORT ALLOCATION below), read at module import
 process.env.HELLGRAPH_STORE_DIR = `${process.env.TMPDIR ?? '/tmp'}/hgsvc-spine-test-${process.pid}`
 process.env.HELLGRAPH_SEED = 'off' // tests build their own graphs — don't auto-seed the boot corpus
 process.env.GATEWAY_RECEIPTS = 'on'
-process.env.GATEWAY_URL = 'http://127.0.0.1:19094'
+process.env.GATEWAY_URL = 'http://127.0.0.1:19102'
 process.env.GATEWAY_TOKEN = 'spine-test-token'
 process.env.GATEWAY_TIMEOUT_MS = '900'
 
@@ -47,7 +54,7 @@ const mockGateway = http.createServer((req, res) => {
 let srv: { close: (cb?: () => void) => void }
 
 before(async () => {
-  await new Promise<void>((r) => mockGateway.listen(19094, r))
+  await new Promise<void>((r) => mockGateway.listen(19102, r))
   const mod = await import('./server')
   srv = mod.server as unknown as typeof srv
   await new Promise((r) => setTimeout(r, 150)) // give the listener a tick
@@ -111,7 +118,7 @@ test('gateway unreachable ⇒ honest degradation: result serves, spine:{ok:false
   const L = `sp-deg-${process.pid}`
   await req('POST', '/api/graph/node', { id: `${L}:s`, labels: [L] })
   const before = await unsealedCount()
-  process.env.GATEWAY_URL = 'http://127.0.0.1:19099' // nothing listens here (read per call)
+  process.env.GATEWAY_URL = 'http://127.0.0.1:19109' // nothing listens here (read per call)
   try {
     const r = await req('GET', `/api/graph/explore?seeds=${encodeURIComponent(`${L}:s`)}`)
     assert.equal(r.status, 200)                                     // availability: the read never fails
@@ -120,7 +127,7 @@ test('gateway unreachable ⇒ honest degradation: result serves, spine:{ok:false
     assert.match(r.json.spine.reason, /unreachable/)
     assert.equal(await unsealedCount(), before + 1)                  // /healthz counts every unsealed serve
   } finally {
-    process.env.GATEWAY_URL = 'http://127.0.0.1:19094'
+    process.env.GATEWAY_URL = 'http://127.0.0.1:19102'
   }
 })
 

--- a/apps/hellgraph-service/src/spine.ts
+++ b/apps/hellgraph-service/src/spine.ts
@@ -1,0 +1,76 @@
+/**
+ * Seal-the-Walls W1.3 — receipt unification: chain the engine's sealed() receipts
+ * into the compute-gateway receipt spine (THE estate's one hash-chained,
+ * Ed25519/in-toto-attested evidence line — never a parallel receipt lineage).
+ *
+ * After /api/graph/enrich | /api/graph/explore computes its proof-carrying result
+ * (sealed sha256 over the ranked output + snapshot {seq,nodes,edges}), the engine
+ * receipt is POSTed to compute-gateway POST /v1/engine-receipts (kind=engine-seal),
+ * which RECOMPUTES the seal byte-exactly, wraps it in the signed envelope, and
+ * chains it — so ONE gateway verify() walks signature → engine hash → snapshot.seq
+ * binding end-to-end. The HTTP response then carries spine:{ok:true, receiptId}.
+ *
+ * HONEST DEGRADATION (availability over ceremony, but never a false claim): a
+ * sealing failure NEVER fails the graph read. The result still serves, with
+ * spine:{ok:false, reason}, the /healthz `unsealedReceipts` counter incremented,
+ * and a warn log — sealed is a verifiable statement here, not a vibe.
+ *
+ * Env (deploy/values/hellgraph-service.yaml): GATEWAY_RECEIPTS=on enables the
+ * attach; GATEWAY_URL (in-cluster: http://compute-gateway:8080); GATEWAY_TOKEN
+ * (same compute-gateway-token Secret the materializer uses; optional — absent
+ * just degrades honestly); GATEWAY_TIMEOUT_MS (default 3000 — a slow spine must
+ * not stall a graph read); GATEWAY_PROJECT (chain namespace, default 'default').
+ * All read per call, so ops/tests can flip them without a restart.
+ */
+
+export type SpineResult = { ok: true; receiptId: string } | { ok: false; reason: string }
+
+let unsealed = 0
+
+/** How many enrich/explore results served WITHOUT a spine receipt (reported in /healthz). */
+export const unsealedReceipts = (): number => unsealed
+
+/** The values default is "on"; anything else disables the attach entirely (no spine field). */
+export const spineEnabled = (): boolean => (process.env['GATEWAY_RECEIPTS'] ?? '').toLowerCase() === 'on'
+
+function degrade(kind: string, reason: string): SpineResult {
+  unsealed++
+  console.warn(`[hellgraph-service] engine ${kind} receipt NOT sealed to spine (unsealed total ${unsealed}): ${reason}`)
+  return { ok: false, reason }
+}
+
+/** POST one engine sealed() receipt to the gateway spine. Resolves, never rejects. */
+export async function sealToSpine(
+  kind: 'enrich' | 'explore',
+  engineReceipt: unknown,
+  subject: Record<string, unknown>,
+): Promise<SpineResult> {
+  const base = (process.env['GATEWAY_URL'] ?? 'http://compute-gateway:8080').replace(/\/+$/, '')
+  const token = process.env['GATEWAY_TOKEN'] ?? ''
+  const timeoutMs = Number(process.env['GATEWAY_TIMEOUT_MS'] ?? 3000) || 3000
+  const project = process.env['GATEWAY_PROJECT'] ?? 'default'
+  try {
+    const r = await fetch(`${base}/v1/engine-receipts`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+      // the receipt object serializes here with the SAME V8 JSON.stringify that
+      // minted its hash — the gateway recomputes over exactly these semantics.
+      body: JSON.stringify({ kind, engineReceipt, subject, project, actor: 'hellgraph-service' }),
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+    if (!r.ok) {
+      const text = await r.text().catch(() => '')
+      return degrade(kind, `gateway HTTP ${r.status}: ${text.slice(0, 300)}`)
+    }
+    const body = (await r.json()) as { receiptId?: unknown }
+    if (typeof body.receiptId !== 'string' || body.receiptId.length === 0) {
+      return degrade(kind, 'gateway response missing receiptId')
+    }
+    return { ok: true, receiptId: body.receiptId }
+  } catch (e) {
+    return degrade(kind, `gateway unreachable: ${e instanceof Error ? e.message : String(e)}`)
+  }
+}

--- a/deploy/values/compute-gateway.yaml
+++ b/deploy/values/compute-gateway.yaml
@@ -16,7 +16,9 @@ config:
   # `materialize` = the Seal-the-Walls W1.1 receipt door for materializer batches
   # (prophet-materializer-clickhouse) — explicit kind token, not reliant on project naming.
   # `governance` = the L5 lifecycle-warden run-attestation door — same reasoning.
-  COMPUTE_ENTITLEMENTS: "demo,default,graph-query,graph-stats,gyg-reporting,materialize,governance"
+  # `engine-seal` = the W1.3 receipt-unification door: hellgraph-service chains its engine
+  # sealed() enrich/explore receipts onto THE spine — explicit kind token, same rationale.
+  COMPUTE_ENTITLEMENTS: "demo,default,graph-query,graph-stats,gyg-reporting,materialize,governance,engine-seal"
   # every ok run writes its ComputeRun/Receipt subgraph to hellgraph (best-effort).
   GATEWAY_WRITE_PROVENANCE: "true"
   # Durable proof store: receipts + content-addressed artifacts + the doc→SQL sink land on

--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -23,6 +23,16 @@ config:
   # the image). Activates the KKO coherence ranker in /api/graph/enrich and gives semantic entity
   # typing its target vocabulary. Idempotent (content-addressed atoms).
   HELLGRAPH_LOAD_RC: "on"  # 0.4.40 batched loader: measured 560MB peak @55k under a 400MB heap cap
+  # ── W1.3 receipt unification: engine sealed() receipts → THE estate spine ──
+  # After each /api/graph/enrich|explore, the sealed engine receipt (sha256 over the ranked
+  # output + snapshot {seq,nodes,edges}) is POSTed to compute-gateway POST /v1/engine-receipts
+  # (kind=engine-seal, same namespace — materializer precedent) and the response carries
+  # spine:{ok, receiptId}; ONE gateway verify then walks signature → engine hash → snapshot.seq
+  # binding end-to-end. Honest degradation by design: gateway unreachable ⇒ the result still
+  # serves with spine:{ok:false, reason} and /healthz unsealedReceipts increments — the read
+  # NEVER fails because sealing failed, and we never claim sealed when it isn't.
+  GATEWAY_RECEIPTS: "on"
+  GATEWAY_URL: "http://compute-gateway:8080"
   # ── ORG SUPER-PEER (federation) — opt-in, OFF by default ──────────────────────────────────
   # The membership loop for local Noetica users: admit a user's writer key ONCE (signed
   # addWriter control op) and their local graph changes percolate to this org graph
@@ -55,9 +65,14 @@ config:
   MEMBRANE_ENFORCE: "on"
   COMPUTE_GATEWAY_URL: "http://compute-gateway:8080"
 secretEnv:
-  # Same Secret compute-gateway + prophet-materializer-clickhouse already require in this
-  # namespace — nothing new is provisioned for the membrane's seal calls.
-  GATEWAY_TOKEN: { secretName: compute-gateway-token, key: token }
+  # The SAME compute-gateway-token Secret compute-gateway + prophet-materializer-clickhouse
+  # already require in this namespace — nothing new is provisioned, for either the membrane's
+  # seal calls (W2.2) or the engine-receipt spine (W1.3).
+  # optional: true — THE graph service must never block on the receipts secret. Absent token
+  # ⇒ gateway 401 ⇒ spine:{ok:false} + unsealedReceipts, and membrane decisions land with
+  # sealed:false + sealError. Both degrade the ATTESTATION honestly; neither degrades the
+  # GATE, which is structural and needs no seal to refuse a write.
+  GATEWAY_TOKEN: { secretName: compute-gateway-token, key: token, optional: true }
 # secretEnv additions when activating federation / auth enforcement (see comments above):
 #   FEDERATION_HMAC_SECRET: { secretName: hellgraph-federation-hmac, key: secret }
 #   AUTH_HMAC_SECRET: { secretName: hellgraph-auth-hmac, key: secret }


### PR DESCRIPTION
## Seal-the-Walls W1.3 — receipt unification

The HellGraph engine already seals every `/api/graph/enrich` and `/api/graph/explore` result — `hash = sha256(JSON.stringify(rec))` over the ranked output + snapshot `{seq, nodes, edges}` — but that proof lived **beside** the estate receipt spine, not on it. This PR chains it in, so **one** gateway `verify()` walks an enrich receipt end-to-end:

```
gateway-signature  →  engine-seal-hash  →  snapshot-seq-binding
(Ed25519/in-toto)     (byte-exact seal      (seal-time seq bound by the
 on THE chain          recomputation)        SIGNED outputs_sha)
```

### compute-gateway — new `engine-seal` kind (materialize conventions)
- **`engine_receipts.py`** — the core: a JS-faithful serializer (V8 `JSON.stringify` semantics: ECMAScript number placement `0.00001`/`1e-7`/`1e+21`, integral doubles without `.0`, insertion-order keys) + the engine's receipt shapes pinned from the vendored 0.4.40 dist, so the engine's sealed sha256 **recomputes byte-exactly in Python**. Canonicalization is schema-driven, not trust-the-wire (survives the durable blob store's `sort_keys` round-trip); unknown keys are refused loudly — the gateway never attests bytes it cannot re-order exactly.
- **`POST /v1/engine-receipts`** `{kind: enrich|explore, engineReceipt, subject}` → shape validation → seal recomputation (**mismatch = 422 refusal**, honest error receipt typed `unknown`) → sealed + Ed25519/in-toto attested on the ONE hash chain → `{receiptId, envelope}`. Identical retry ⇒ memo returns the **same** receipt. `_no_provenance` like materialize: an enrich read must not bump the very clock (`seq`) its receipt attests.
- **`GET /v1/engine-receipts/{id}/verify`** → `{valid, steps: [{step, status: ok|fail|skipped, detail}]}` — fail-fast, remaining steps marked skipped, so tampering fails **at the step that owns the guarantee**:
  - flip a byte in the output → `engine-seal-hash`
  - tamper `seq` — even self-consistently **re-sealed** → `snapshot-seq-binding`
  - flip a byte in the signature → `gateway-signature`
  - rewrite the whole stored envelope → still caught: the SIGNED `outputs_sha` pins it

### hellgraph-service — surgical `server.ts` diff + new `src/spine.ts`
- `GATEWAY_RECEIPTS=on` (values default): after enrich/explore, the engine receipt POSTs to the gateway; response carries `spine:{ok:true, receiptId}`.
- **Honest degradation**: gateway unreachable/refusing ⇒ the result **still serves** with `spine:{ok:false, reason}`, `/healthz` gains an `unsealedReceipts` counter, warn log. The read never fails because sealing failed; sealed is never claimed when it isn't. Flag off ⇒ byte-identical pre-W1.3 responses.

### Values
- `hellgraph-service`: `GATEWAY_URL: http://compute-gateway:8080` (same-namespace DNS, materializer precedent), `GATEWAY_RECEIPTS: "on"`, optional `compute-gateway-token` secretEnv — nothing new provisioned.
- `compute-gateway`: `COMPUTE_ENTITLEMENTS` += `engine-seal` (explicit kind token, materialize precedent).

### Evidence
- **compute-gateway pytest: 94 → 108 passed** (+14; golden fixtures captured from the REAL vendored engine in node, a V8 number-format battery with node-generated ground truth, 3+1 tamper cases, retry idempotency, unsigned-is-honestly-unverifiable).
- **hellgraph-service node:test: 27 → 33 pass, 0 fail** (+6; attach contract for both kinds, unreachable + HTTP-refusal degradation, healthz counter, flag-off shape).
- **Real end-to-end** (no mocks, local): live service with the KKO backbone loaded (seq 1021) against the live gateway — real V8-minted seals recomputed byte-exactly in Python, verify walk all-green for enrich AND explore.
- `helm template` clean for both services; `tools/preflight_deploy_contract.py` exit 0.
- Rebased onto `origin/main` after W6.0/W6.1 landed (exhaust accounting) — full suite green on the new base, zero drift at push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)