### PR TITLE
fix(workspace-mail): the daily mail backup has never run — pin a real image + the pull secret it always needed

### DIFF
--- a/infra/k8s/workspace-mail/base/backup-cronjob.yaml
+++ b/infra/k8s/workspace-mail/base/backup-cronjob.yaml
@@ -12,6 +12,13 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
+          # REQUIRED for the zot ref above: zot refuses anonymous pulls (401 UNAUTHORIZED).
+          # The workspace-mail + workspace-smtp Deployments in this namespace already pull
+          # through this same secret; the CronJob never had one because its ghcr ref was
+          # never pullable in the first place. Without this line the image fix alone is
+          # cosmetic — the job keeps ImagePullBackOff'ing.
+          imagePullSecrets:
+            - name: zot-pull
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -19,7 +26,18 @@ spec:
               type: RuntimeDefault
           containers:
             - name: mail-backup
-              image: ghcr.io/socioprophet/prophet-platform/workspace-backup:dev
+              # Stock alpine, mirrored in our sovereign zot and pinned BY DIGEST.
+              # Was ghcr.io/socioprophet/prophet-platform/workspace-backup:dev — an image
+              # NOTHING in this repo builds (no images.yml entry, no Dockerfile), so this
+              # CronJob has ImagePullBackOff'd every night since it was authored: the daily
+              # mail backup has never once run. The payload is a /bin/sh + date + tar
+              # one-liner, so it needs no first-party image at all — only a shell and tar.
+              # Digest, not tag: zot carries library/alpine as :latest only, and a moving
+              # tag on a backup job means the backup silently changes underfoot.
+              # Probe-verified in-cluster before this change (socioprophet namespace, this
+              # exact digest, uid 1000, caps dropped, seccomp RuntimeDefault): the pull
+              # succeeds and the one-liner produces a real, listable .tar.gz.
+              image: registry.socioprophet.ai/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
               command:
                 - /bin/sh
                 - -c

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -105,16 +105,12 @@ OUR_REGISTRIES = ("us-central1-docker.pkg.dev/socioprophet-platform/", "registry
 # Entries must carry a reason. The list only ever shrinks: if an entry starts passing,
 # the gate FAILS and demands its removal, so it cannot rot into a permanent excuse.
 KNOWN_BROKEN = {
-    "workspace-mail:wrong-registry": (
-        "CAUGHT by the check-6 ghcr.io/socioprophet closure the moment it landed: the mail-backup "
-        "CronJob (infra/k8s/workspace-mail/base/backup-cronjob.yaml) pulls "
-        "ghcr.io/socioprophet/prophet-platform/workspace-backup:dev — an image never built by "
-        "anything, so the DAILY MAIL BACKUP HAS SILENTLY NEVER RUN (ImagePullBackOff since it was "
-        "authored). The job is a /bin/sh tar one-liner; the fix is choosing + pinning a real image "
-        "(stock busybox via zot, or a first-party backup image in images.yml) and VERIFYING a backup "
-        "artifact lands — a deliberate rollout in its own PR, not a drive-by edit inside the tier-"
-        "doctrine PR that found it. Ratchet demands removal once fixed."
-    ),
+    # workspace-mail:wrong-registry is RESOLVED — the mail-backup CronJob now pulls stock
+    # alpine from our own zot, pinned by digest, with the zot-pull secret it always needed
+    # (infra/k8s/workspace-mail/base/backup-cronjob.yaml). The daily backup had never run
+    # once: the old ghcr.io/socioprophet/prophet-platform/workspace-backup:dev is built by
+    # nothing. The ratchet only shrinks: fixed → removed, so a backup job can never again
+    # sit in ImagePullBackOff behind a permanent excuse.
     # reasoning-failure-runner:moving-tag is RESOLVED — deploy/values/reasoning-failure-runner.yaml is now pinned
     # to a sha- tag (the Chaos & Resilience Fabric orchestrator, CHAOS_RESILIENCE_FABRIC_V0.md). The ratchet only
     # shrinks: fixed → removed from KNOWN_BROKEN so it can never silently regress to `:latest` again.


### PR DESCRIPTION
## What was broken

`infra/k8s/workspace-mail/base/backup-cronjob.yaml` pulled `ghcr.io/socioprophet/prophet-platform/workspace-backup:dev` — **an image nothing in this repo builds**: no `images.yml` entry, no Dockerfile, no source. The CronJob has ImagePullBackOff'd at 03:00 UTC every night since it was authored, so **the mail data has no backups at all** — not stale ones, none.

Found by the tier-doctrine preflight (#1009) the moment its check-6 `ghcr.io/socioprophet` closure landed, and ratcheted as `workspace-mail:wrong-registry` rather than drive-by-fixed inside that PR. This is the deliberate rollout it was deferred to.

## The fix

The payload is a `/bin/sh` + `date` + `tar` one-liner. It doesn't need a first-party image — it needs a shell and tar. So: **stock alpine, already mirrored in our sovereign zot, pinned BY DIGEST**:

```
registry.socioprophet.ai/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
```

Digest rather than tag because zot carries `library/alpine` as `:latest` only, and a moving tag underneath a backup job means the backup changes underfoot without anyone deciding to.

**A second hole, found while fixing the first:** swapping the image alone would have been cosmetic. **zot refuses anonymous pulls** (verified: `401 UNAUTHORIZED` from `/v2/_catalog`), and this CronJob carried **no `imagePullSecrets`** — it never needed one, because its ghcr reference was never pullable in the first place. The `workspace-mail` and `workspace-smtp` Deployments beside it already pull through `zot-pull`; the CronJob now does too. Without that line the job keeps failing, just with a different message.

## Evidence

**Image capability, probe-verified in-cluster before committing** — a throwaway pod in `socioprophet`, this exact digest, the real command shape, under the CronJob's own hardening (`runAsUser: 1000`, `runAsNonRoot`, `capabilities: drop [ALL]`, `seccompProfile: RuntimeDefault`):

```
ARTIFACT: -rw-r--r--  1 1000  root  151 Jul 29 13:27 mail-20260729T132704Z.tar.gz
tmp/maildata/
tmp/maildata/f.txt
PROBE-OK uid=1000
```

The pull succeeded with `zot-pull` and the one-liner produced a real, listable `.tar.gz`. Pod deleted after.

**Ratchet, verified in three states** — proving the gate tracks this fix rather than being blind to it:

| state | exit | meaning |
|---|---|---|
| old manifest + entry present | 0 | the entry was excusing a real failure |
| **fixed manifest + entry present** | **1** | `workspace-mail:wrong-registry: now passes — delete it from KNOWN_BROKEN` |
| fixed manifest + entry removed | 0 | `OK: every deployed first-party service is built by CI and pulls from a registry we publish to` |

Final: `preflight: 52 deployed (17 foundation / 35 reference), 41 first-party checked against 46 built images` — **exit 0**, self-test teeth verified on every run.

## How the rollout gets verified

The probe proves the image can do the job; it does not prove *this* job did it. After merge and Argo sync, verification is a backup artifact actually landing on the `workspace-mail-backup` PVC:

1. **Force one run rather than waiting for 03:00 UTC:** `kubectl -n socioprophet create job --from=cronjob/mail-backup mail-backup-verify`
2. **The pod reaches `Succeeded`** (not `ImagePullBackOff`, not `Error`) and its log ends with `Mail backup complete: mail-<STAMP>.tar.gz`.
3. **The artifact exists and is non-trivial on the backup volume** — a reader pod mounting `workspace-mail-backup` shows `mail-<STAMP>.tar.gz` with a size consistent with the maildir (not a ~45-byte empty archive), and `tar tzf` lists real maildir entries. *This is the acceptance test: the log line alone is not proof, since `tar` can exit 0 having archived nothing.*
4. **The next natural 03:00 UTC run also succeeds**, confirming the schedule path and not just the manual trigger.
5. Delete the verification Job.

Two follow-ups deliberately **not** bundled here, so this stays a single reviewable change: the job keeps no retention policy (backups accumulate until the 20Gi PVC fills — that needs a real policy decision, and `lifecycle-warden` is now the natural executor for it), and the archives are unencrypted at rest on the volume.