### PR TITLE
feat(w6.4): declared organs — the mesh's functional groups, typed and observable

### DIFF
--- a/apps/hellgraph-service/src/organs.test.ts
+++ b/apps/hellgraph-service/src/organs.test.ts
@@ -1,0 +1,109 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  declaredOrgans, foldHealth, assembleOrgan, assembleOrgans, httpProber,
+  type Health, type OrganMember, type Prober, type OrganSpec,
+} from './organs.js'
+
+const member = (health: Health): OrganMember => ({ service: 's', health })
+
+const SPEC: OrganSpec = {
+  kind: 'memory', name: 'Memory organ',
+  members: [
+    { service: 'a', endpoint: 'http://a', capabilities: ['recall', 'ground'] },
+    { service: 'b', endpoint: 'http://b', capabilities: ['recall'] },
+  ],
+}
+
+const proberFor = (byUrl: Record<string, Health>): Prober =>
+  async (endpoint) => ({ health: byUrl[endpoint] ?? 'unknown' })
+
+// ── OR-I2: health is DERIVED, never asserted ────────────────────────────────────
+test('all healthy members ⇒ healthy organ', () => {
+  assert.equal(foldHealth([member('healthy'), member('healthy')]), 'healthy')
+})
+
+test('all down ⇒ down', () => {
+  assert.equal(foldHealth([member('down'), member('down')]), 'down')
+})
+
+test('an UNKNOWN member blocks a healthy verdict — an organ we cannot see is not one we can call well', () => {
+  assert.equal(foldHealth([member('healthy'), member('unknown')]), 'degraded')
+})
+
+test('nothing knowable ⇒ unknown, never a guess', () => {
+  assert.equal(foldHealth([member('unknown'), member('unknown')]), 'unknown')
+  assert.equal(foldHealth([]), 'unknown')
+})
+
+test('a mix of healthy and down is degraded', () => {
+  assert.equal(foldHealth([member('healthy'), member('down')]), 'degraded')
+})
+
+// ── OR-I1: never invent a member, never assume health ───────────────────────────
+test('assembled members correspond exactly to the declared services', async () => {
+  const organ = await assembleOrgan(SPEC, proberFor({ 'http://a': 'healthy', 'http://b': 'healthy' }))
+  assert.deepEqual(organ.members.map((m) => m.service), ['a', 'b'])
+  assert.equal(organ.members.length, SPEC.members.length, 'no phantom members')
+})
+
+test('a failed probe yields unknown, NOT healthy', async () => {
+  const organ = await assembleOrgan(SPEC, async () => { throw new Error('boom') })
+  assert.ok(organ.members.every((m) => m.health === 'unknown'))
+  assert.equal(organ.health, 'unknown')
+  assert.ok(organ.members[0]!.detail, 'and the reason is recorded')
+})
+
+test('assembleOrgan never throws — a probe failure is data, not an outage', async () => {
+  const organ = await assembleOrgan(SPEC, async () => { throw new Error('nope') })
+  assert.equal(organ.type, 'Organ')
+})
+
+// ── shape conforms to the spec ──────────────────────────────────────────────────
+test('organ carries a urn id, capability union, and observation time', async () => {
+  const organ = await assembleOrgan(SPEC, proberFor({ 'http://a': 'healthy', 'http://b': 'down' }))
+  assert.equal(organ.id, 'urn:srcos:organ:memory')
+  assert.deepEqual(organ.capabilities, ['ground', 'recall'], 'deduped + sorted union of member capabilities')
+  assert.equal(organ.health, 'degraded')
+  assert.ok(Date.parse(organ.observedAt) > 0)
+  assert.equal(organ.specVersion, '2.0')
+})
+
+// ── the declared anatomy ────────────────────────────────────────────────────────
+test('four organs are declared over real estate services', () => {
+  const specs = declaredOrgans({})
+  assert.deepEqual(specs.map((s) => s.kind).sort(), ['memory', 'perception', 'policy', 'routing'])
+  const services = specs.flatMap((s) => s.members.map((m) => m.service))
+  for (const expected of ['memory-mesh', 'zone-router', 'compute-gateway', 'ie-engine', 'identity-policy']) {
+    assert.ok(services.includes(expected), `${expected} should be a declared member`)
+  }
+  assert.ok(specs.every((s) => s.members.length > 0), 'no empty organs')
+})
+
+test('endpoints are env-overridable so another topology declares the same organs over its own addresses', () => {
+  const specs = declaredOrgans({ MEMORY_MESH_URL: 'http://edge-mesh:9999' })
+  const mesh = specs.find((s) => s.kind === 'memory')!.members.find((m) => m.service === 'memory-mesh')!
+  assert.equal(mesh.endpoint, 'http://edge-mesh:9999')
+})
+
+test('assembleOrgans probes the whole anatomy in one pass', async () => {
+  const organs = await assembleOrgans(declaredOrgans({}), async () => ({ health: 'healthy' }))
+  assert.equal(organs.length, 4)
+  assert.ok(organs.every((o) => o.health === 'healthy'))
+})
+
+// ── the prober distinguishes "answered badly" from "did not answer" ─────────────
+test('httpProber: non-2xx is down, unreachable is unknown', async () => {
+  const originalFetch = globalThis.fetch
+  try {
+    globalThis.fetch = (async () => ({ ok: false, status: 503 })) as unknown as typeof fetch
+    assert.deepEqual(await httpProber(50)('http://x'), { health: 'down', detail: 'HTTP 503' })
+
+    globalThis.fetch = (async () => { throw new Error('ECONNREFUSED') }) as unknown as typeof fetch
+    const unreachable = await httpProber(50)('http://x')
+    assert.equal(unreachable.health, 'unknown', 'no answer is NOT evidence of death — it is absence of evidence')
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})

--- a/apps/hellgraph-service/src/organs.ts
+++ b/apps/hellgraph-service/src/organs.ts
@@ -1,0 +1,157 @@
+/**
+ * organs — the mesh's functional groups, typed and observable.
+ *
+ * The organogenesis design's first mechanical form, and deliberately its least ambitious:
+ * v1 organs are DECLARED over services that already exist, not grown. Four kinds —
+ * memory retains, routing directs, perception ingests, policy governs — each a named group
+ * of real services with live health. That turns "the mesh has capabilities" from an
+ * implicit property of a deployment into something you can GET and audit.
+ *
+ * Two invariants (sourceos-spec Organ.json), and they are the whole point:
+ *   OR-I1 — an organ never invents a member. Every member is a real addressable service, and
+ *           a member whose health cannot be determined is `unknown`. Never optimistically
+ *           "healthy": a probe that failed is not evidence of health.
+ *   OR-I2 — organ health is DERIVED from members. An organ cannot claim to be healthier than
+ *           what it is made of.
+ *
+ * Membership dynamics (v2, join/leave by capability + load over the admit/writer-key
+ * machinery) and true differentiation (v3) stay out of scope until v1 proves useful — the
+ * same membrane-before-organs ordering the twin program used.
+ */
+
+export type OrganKind = 'memory' | 'routing' | 'perception' | 'policy'
+export type Health = 'healthy' | 'degraded' | 'down' | 'unknown'
+
+export interface OrganMember {
+  service: string
+  endpoint?: string
+  health: Health
+  checkedAt?: string
+  detail?: string
+}
+
+export interface Organ {
+  type: 'Organ'
+  specVersion: string
+  id: string
+  kind: OrganKind
+  name: string
+  members: OrganMember[]
+  capabilities: string[]
+  health: Health
+  observedAt: string
+}
+
+export const SPEC_VERSION = '2.0'
+
+/** A member declaration: which real service, where, and what it contributes. */
+export interface MemberSpec { service: string; endpoint: string; capabilities: string[] }
+
+export interface OrganSpec { kind: OrganKind; name: string; members: MemberSpec[] }
+
+/**
+ * The declared anatomy. Every entry names a service that actually exists in the estate;
+ * endpoints are env-overridable so a different topology (edge, one-box, air-gapped) declares
+ * the same organs over its own addresses rather than pretending the cluster's are present.
+ */
+export function declaredOrgans(env: Record<string, string | undefined> = process.env): OrganSpec[] {
+  const url = (name: string, fallback: string): string => env[name] || fallback
+  return [
+    {
+      kind: 'memory', name: 'Memory organ',
+      members: [
+        { service: 'memory-mesh', endpoint: url('MEMORY_MESH_URL', 'http://memory-mesh:8080'), capabilities: ['recall', 'append'] },
+        { service: 'hellgraph-service', endpoint: url('HELLGRAPH_SELF_URL', 'http://hellgraph-service:8090'), capabilities: ['ground', 'graph-query'] },
+      ],
+    },
+    {
+      kind: 'routing', name: 'Routing organ',
+      members: [
+        { service: 'zone-router', endpoint: url('ZONE_ROUTER_URL', 'http://zone-router:8080'), capabilities: ['zone-route', 'retry', 'dead-letter'] },
+        { service: 'compute-gateway', endpoint: url('COMPUTE_GATEWAY_URL', 'http://compute-gateway:8080'), capabilities: ['compute-route', 'entitlement-gate'] },
+      ],
+    },
+    {
+      kind: 'perception', name: 'Perception organ',
+      members: [
+        { service: 'ie-engine', endpoint: url('IE_ENGINE_URL', 'http://ie-engine:8080'), capabilities: ['extract'] },
+        { service: 'entity-resolution', endpoint: url('ENTITY_RESOLUTION_URL', 'http://entity-resolution:8080'), capabilities: ['resolve'] },
+        { service: 'embeddings', endpoint: url('EMBEDDINGS_URL', 'http://embeddings:8080'), capabilities: ['embed'] },
+      ],
+    },
+    {
+      kind: 'policy', name: 'Policy organ',
+      members: [
+        { service: 'identity-policy', endpoint: url('IDENTITY_POLICY_URL', 'http://identity-policy:8080'), capabilities: ['policy-decision'] },
+        { service: 'evidence-receipts', endpoint: url('EVIDENCE_RECEIPTS_URL', 'http://evidence-receipts:8080'), capabilities: ['receipt', 'attest'] },
+      ],
+    },
+  ]
+}
+
+/**
+ * Fold member health into organ health (OR-I2).
+ *   healthy   — every member whose health is KNOWN is healthy, and at least one is known
+ *   down      — every known member is down
+ *   unknown   — nothing is known (no member could be probed)
+ *   degraded  — anything else, including a healthy member sitting beside an unknown one
+ *
+ * `unknown` members deliberately prevent a `healthy` verdict: an organ we cannot fully see
+ * is not an organ we can call well.
+ */
+export function foldHealth(members: OrganMember[]): Health {
+  if (!members.length) return 'unknown'
+  const known = members.filter((m) => m.health !== 'unknown')
+  if (!known.length) return 'unknown'
+  const allHealthy = known.every((m) => m.health === 'healthy')
+  const allDown = known.every((m) => m.health === 'down')
+  if (allDown) return 'down'
+  if (allHealthy && known.length === members.length) return 'healthy'
+  return 'degraded'
+}
+
+export type Prober = (endpoint: string) => Promise<{ health: Health; detail?: string }>
+
+/**
+ * Default prober: GET {endpoint}/healthz with a hard timeout. Any non-2xx is `down`; a
+ * network error or timeout is `unknown` — we distinguish "answered badly" from "did not
+ * answer", because conflating them is how a dead service gets reported as merely degraded.
+ */
+export function httpProber(timeoutMs = 2000): Prober {
+  return async (endpoint: string) => {
+    const ctl = new AbortController()
+    const timer = setTimeout(() => ctl.abort(), timeoutMs)
+    try {
+      const res = await fetch(`${endpoint}/healthz`, { signal: ctl.signal })
+      return res.ok ? { health: 'healthy' } : { health: 'down', detail: `HTTP ${res.status}` }
+    } catch (e) {
+      return { health: 'unknown', detail: (e as Error).name === 'AbortError' ? 'probe timed out' : 'unreachable' }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}
+
+/** Assemble one organ by probing its declared members. Never throws — a probe failure is data. */
+export async function assembleOrgan(spec: OrganSpec, probe: Prober, now = new Date()): Promise<Organ> {
+  const checkedAt = now.toISOString()
+  const members: OrganMember[] = await Promise.all(spec.members.map(async (m) => {
+    const r = await probe(m.endpoint).catch(() => ({ health: 'unknown' as Health, detail: 'prober threw' }))
+    return { service: m.service, endpoint: m.endpoint, health: r.health, checkedAt, ...(r.detail ? { detail: r.detail } : {}) }
+  }))
+  return {
+    type: 'Organ', specVersion: SPEC_VERSION,
+    id: `urn:srcos:organ:${spec.kind}`,
+    kind: spec.kind, name: spec.name, members,
+    capabilities: [...new Set(spec.members.flatMap((m) => m.capabilities))].sort(),
+    health: foldHealth(members),
+    observedAt: checkedAt,
+  }
+}
+
+/** The whole anatomy, probed in parallel. */
+export async function assembleOrgans(
+  specs: OrganSpec[] = declaredOrgans(), probe: Prober = httpProber(), now = new Date(),
+): Promise<Organ[]> {
+  return Promise.all(specs.map((s) => assembleOrgan(s, probe, now)))
+}

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -49,6 +49,7 @@ import { describeResource, toTurtle, toJsonLd, toHtml, negotiate } from './resou
 import { askGraph, retrieveGrounding, retrieveGroundingAuto, synthesisEnabled, semanticEnabled } from './graphrag.js'
 import { pagerank, connectedComponents, bfs, sssp, cdlp, lcc, analyticsBackend, dataScope } from './analytics.js'
 import { initAuth, authorize, type AuthState } from './auth.js'
+import { assembleOrgans } from './organs.js'
 import { initMembrane, handleMembrane, membraneCheckNodeWrite, type MembraneState } from './membrane.js'
 import { sealToSpine, spineEnabled, unsealedReceipts } from './spine.js'
 
@@ -182,6 +183,23 @@ const server = http.createServer((req, res) => {
       // W1.3 honest-degradation counter: enrich/explore results served WITHOUT a spine receipt
       unsealedReceipts: unsealedReceipts(),
     })
+  }
+
+  // GET /api/organs — the mesh's functional groups (memory/routing/perception/policy) as
+  // typed Organs with LIVE member health, per sourceos-spec Organ.json. v1 organs are
+  // DECLARED over services that already exist, not grown: this makes the mesh's capabilities
+  // inspectable instead of implicit. Health is derived from members only (OR-I2), and an
+  // unprobeable member reports `unknown` rather than an optimistic `healthy` (OR-I1).
+  if (req.method === 'GET' && url.pathname === '/api/organs') {
+    return void assembleOrgans()
+      .then((organs) => json(res, 200, {
+        organs,
+        counts: organs.reduce<Record<string, number>>((acc, o) => {
+          acc[o.health] = (acc[o.health] ?? 0) + 1
+          return acc
+        }, {}),
+      }))
+      .catch((e: Error) => json(res, 500, { error: e.message }))
   }
 
   if (req.method === 'GET' && url.pathname === '/api/graph/stats') {


### PR DESCRIPTION
Final design lane of Metaphor→Mechanism (program #1003). Spec: sourceos-spec#211 (merged).

**v1 organs are DECLARED, not grown** — asserted over services that already exist (memory / routing / perception / policy), each reporting live member health. The mesh's capabilities stop being an implicit property of a deployment and become something you can `GET` and audit.

**The two invariants are the point:**
- **OR-I1** — never invents a member; a member whose health can't be determined is `unknown`, **never optimistically healthy**. A probe that failed is not evidence of health.
- **OR-I2** — organ health is **derived** from members. An unknown member **blocks** a healthy verdict: an organ we cannot fully see is not one we can call well.

The prober distinguishes **"answered badly"** (non-2xx → `down`) from **"did not answer"** (timeout → `unknown`) — conflating those is how a dead service gets reported as merely degraded. `assembleOrgan` never throws: a probe failure is data, not an outage.

Endpoints are env-overridable, so an edge / one-box / air-gapped topology declares the same organs over **its own** addresses rather than pretending the cluster's are present.

**Wired:** `GET /api/organs` on the federation plane → organs + health census. 13 tests; service suite **73 pass / 0 fail**.

v2 membership dynamics and v3 differentiation stay out of scope until v1 earns them — the same membrane-before-organs ordering the twin program used.