### PR TITLE
ci(secrets): mint clickhouse-admin in CI — the third class of secret

### DIFF
--- a/.github/workflows/provision-secrets.yml
+++ b/.github/workflows/provision-secrets.yml
@@ -14,12 +14,25 @@ name: provision-secrets
 #
 # Run: Actions → provision-secrets → Run workflow (optionally scope with `only`).
 # Rotate a token = update the GitHub secret, re-run. A missing value is skipped, not errored.
+#
+# THREE CLASSES OF SECRET LIVE HERE:
+#   1. SYNCED  — the value is a human/vendor-issued token held in GitHub secrets (the `sync` calls).
+#   2. DERIVED — the value already exists in-cluster and is copied so it cannot drift
+#                (postgres-credentials ← postgres-admin).
+#   3. MINTED  — nobody should ever know the value: CI generates it. No GitHub secret, no human
+#                handling, no value in a chat log or a terminal history. `clickhouse-admin` is the
+#                first of these. Minted secrets are CREATE-IF-ABSENT: see the mint step for why
+#                re-running must never silently regenerate them.
 
 on:
   workflow_dispatch:
     inputs:
       only:
         description: "Comma-separated secret names to provision (blank = all)"
+        required: false
+        default: ""
+      rotate:
+        description: "Comma-separated MINTED secrets to force-regenerate (DANGEROUS — see the mint step)"
         required: false
         default: ""
 
@@ -97,3 +110,54 @@ jobs:
             --from-literal=username=postgres --from-literal=password="$PW" \
             --dry-run=client -o yaml | kubectl apply -f -
           echo "✔ postgres-credentials → namespace/socioprophet (derived from postgres-admin)"
+
+      # ── MINTED secrets: generated in CI, known to nobody ────────────────────────────────────
+      # clickhouse-admin gates BOTH the ClickHouse server (which sets its admin password from this
+      # value on first init) and prophet-materializer-clickhouse (which authenticates with it).
+      # Until it exists both pods sit in CreateContainerConfigError — `secret "clickhouse-admin"
+      # not found` — which is exactly where they have been.
+      #
+      # CREATE-IF-ABSENT, deliberately. ClickHouse PERSISTS the admin password into its data
+      # volume on first initialization, so regenerating this Secret on a later run would leave the
+      # stored server password and the client credential disagreeing — the materializer would then
+      # fail to authenticate against a database that is otherwise perfectly healthy, which is a
+      # miserable failure to diagnose. Rotation is therefore opt-in via the `rotate` input AND
+      # requires the coordinated procedure in deploy/values/clickhouse.yaml (rotate the server's
+      # own password, then this Secret, then restart consumers) — a workflow input alone cannot
+      # make that safe, so it warns loudly and still refuses to touch an initialized volume.
+      #
+      # Charset is alphanumeric on purpose: base64 emits '/', '+' and '=', which are hazardous
+      # inside connection strings and URL-encoded config. 32 chars of [A-Za-z0-9] is ~190 bits.
+      - name: Mint clickhouse-admin (create-if-absent)
+        env:
+          ONLY: ${{ inputs.only }}
+          ROTATE: ${{ inputs.rotate }}
+        run: |
+          set -euo pipefail
+          NAME=clickhouse-admin NS=socioprophet
+          if [ -n "$ONLY" ] && ! printf ',%s,' "$ONLY" | grep -q ",$NAME,"; then
+            echo "· skip $NAME (not in 'only' filter)"; exit 0
+          fi
+
+          EXISTS=$(kubectl get secret "$NAME" -n "$NS" --ignore-not-found -o name || true)
+          FORCE=false
+          if printf ',%s,' "$ROTATE" | grep -q ",$NAME,"; then FORCE=true; fi
+
+          if [ -n "$EXISTS" ] && [ "$FORCE" != true ]; then
+            echo "✔ $NAME already present in $NS — left untouched (minted secrets are never silently regenerated)"
+            exit 0
+          fi
+
+          if [ -n "$EXISTS" ] && [ "$FORCE" = true ]; then
+            echo "⚠ ROTATING $NAME. ClickHouse stores its admin password on the data volume: unless"
+            echo "⚠ the SERVER password was rotated in the same maintenance window, consumers will"
+            echo "⚠ now fail to authenticate. Restart clickhouse AND prophet-materializer-clickhouse."
+          fi
+
+          PW=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32)
+          [ ${#PW} -eq 32 ] || { echo "✗ generator produced ${#PW} chars, refusing"; exit 1; }
+          echo "::add-mask::$PW"
+
+          kubectl create secret generic "$NAME" -n "$NS" \
+            --from-literal=password="$PW" --dry-run=client -o yaml | kubectl apply -f -
+          echo "✔ $NAME → namespace/$NS (minted in CI; the value exists nowhere else)"

--- a/deploy/values/clickhouse.yaml
+++ b/deploy/values/clickhouse.yaml
@@ -19,6 +19,13 @@
 # and queries run. Without a password the entrypoint locks user `default` to localhost —
 # useless in-cluster — so the password Secret is REQUIRED (fail-closed, not optional).
 # PREREQ (out of band — never commit secrets):
+#   Actions → provision-secrets → Run workflow   (mints it; nobody ever handles the value)
+# The password is MINTED IN CI, not typed by a human: the provision-secrets workflow generates 32
+# alphanumeric chars and applies the Secret over WIF. It is CREATE-IF-ABSENT — ClickHouse persists
+# its admin password into the data volume on first init, so silently regenerating the Secret later
+# would leave the server and its clients disagreeing. Deliberate rotation = the `rotate` input PLUS
+# rotating the server's own password in the same window, then restarting clickhouse and
+# prophet-materializer-clickhouse. Break-glass equivalent (avoid — the value lands in shell history):
 #   kubectl -n socioprophet create secret generic clickhouse-admin --from-literal=password="$(openssl rand -base64 24)"
 nameOverride: clickhouse
 


### PR DESCRIPTION
## Why

`clickhouse` and `prophet-materializer-clickhouse` have both been in `CreateContainerConfigError` since they were deployed. The live reason, verbatim:

```
secret "clickhouse-admin" not found
```

The documented fix was for a human to run an `openssl rand` one-liner into a terminal. That is the wrong shape for a password **nobody needs to know**: it should be generated by the pipeline that provisions it, not carried by a person through a shell history and a chat window.

## What this adds

`provision-secrets.yml` already had two classes of secret. This names and adds the third:

| class | value comes from | example |
|---|---|---|
| **SYNCED** | a human/vendor-issued token in GitHub secrets | `compute-gateway-token` |
| **DERIVED** | in-cluster state, copied so it cannot drift | `postgres-credentials` ← `postgres-admin` |
| **MINTED** | **generated in CI — no GitHub secret, no human handling** | **`clickhouse-admin`** |

The mint step generates 32 alphanumeric characters, `::add-mask::`s the value, and applies the Secret over the WIF path the workflow already uses. Nothing is echoed; the value exists nowhere but the cluster.

## Two decisions worth reviewing

**Create-if-absent, not regenerate.** ClickHouse persists its admin password into the data volume on first initialization. If a later run of this workflow silently minted a new value, the stored server password and the client credential would disagree — and the materializer would fail to authenticate against a database that is otherwise perfectly healthy. That is a miserable failure to diagnose, so re-running is a no-op with a clear message. Deliberate rotation is opt-in through a new `rotate` input, which warns that the server's own password must be rotated in the same maintenance window and both consumers restarted. A workflow input cannot make that safe by itself, so it says so rather than pretending.

**Alphanumeric rather than base64.** `openssl rand -base64` emits `/`, `+` and `=`, which are hazardous inside connection strings and URL-encoded config. 32 characters of `[A-Za-z0-9]` is roughly 190 bits — more than enough, and it cannot break a DSN.

## How to run it, and how it gets verified

```
Actions → provision-secrets → Run workflow
```

Optionally scope with `only: clickhouse-admin`. Acceptance is not "the workflow was green" — it is the two pods actually recovering:

1. The step prints `✔ clickhouse-admin → namespace/socioprophet (minted in CI; the value exists nowhere else)`.
2. `clickhouse` leaves `CreateContainerConfigError` and reaches `Running`/ready.
3. `prophet-materializer-clickhouse` reaches `Running` **and authenticates** — its log shows a successful connection rather than an auth failure, which is the part that proves the server and client agree on the minted value.
4. The materializer then drains the backlog the live emitter has been accumulating, and rows land in `hellgraph.events`. *That* is the end-to-end proof: spec-validated event → graph log → CausalCut → ClickHouse → sealed receipt.

`deploy/values/clickhouse.yaml` is updated so its instructions point at the workflow, with the manual `kubectl` line retained only as documented break-glass — and labelled as such, since it puts the value in shell history.