### PR TITLE
ci(gitops-promote): dispatch the required check onto the promote branch (premise CONFIRMED, not obsolete)

### DIFF
--- a/.github/workflows/gitops-promote.yml
+++ b/.github/workflows/gitops-promote.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: write
   pull-requests: write   # promote merges via auto-merged PR (see push step) — no direct-push bypass needed
+  actions: write         # REQUIRED to `gh workflow run` the required-check workflow onto the promote
+                         # branch (see the long note in the push step). The repo default workflow
+                         # permission is read-only, so without this the dispatch 403s and every
+                         # promote PR sits BLOCKED forever waiting for diagnostics-gate.
 
 concurrency:
   group: gitops-promote
@@ -119,5 +123,46 @@ jobs:
           gh pr create --base main --head "$BRANCH" \
             --title "gitops: promote${bumped} → sha-${SHA:0:12}" \
             --body "Automated image-pin promotion (values-only). Auto-merges when diagnostics-gate passes."
+
+          # ── Why the explicit dispatch below is REQUIRED (measured 2026-07-29) ──────────
+          # A PR opened by this job never gets its required check on its own. Two distinct
+          # failure modes were observed on real promote PRs, both ending in BLOCKED:
+          #   • #1007/#1013 — ZERO pull_request runs created. The GITHUB_TOKEN no-recursion
+          #     rule: events caused by GITHUB_TOKEN do not start workflow runs.
+          #   • #1017/#1018 — 18 pull_request runs ARE created, but every one lands at
+          #     conclusion=action_required (parked awaiting approval), and a run parked at
+          #     action_required publishes NO check-runs. Measured alongside it:
+          #     GET /repos/:r/actions/permissions/fork-pr-contributor-approval reports
+          #     approval_policy=first_time_contributors, and these runs' triggering_actor
+          #     is github-actions[bot] (on runs that DID work — #981/#983 — it was a human).
+          #     The policy is the likeliest cause; the parked state is the measured fact.
+          # Either way `diagnostics-gate` — the ONE context required by the
+          # `main-required-checks` ruleset — is absent, so the PR can never merge.
+          # The 7-8 checks that DO appear on these PRs (CodeQL `Analyze (*)`, `CodeQL`,
+          # `GitGuardian Security Checks`) are GitHub-App/`dynamic`-event products, exempt
+          # from the GITHUB_TOKEN rule — none of them is required, so a green rollup of
+          # those alone is a mirage. Do NOT read "7 checks passing" as "ready to merge".
+          #
+          # workflow_dispatch is the documented exception to the no-recursion rule: an
+          # EXPLICIT dispatch does create a run even under GITHUB_TOKEN, and because it is
+          # not a pull_request event it is not subject to the contributor-approval gate.
+          # The run attaches its check-runs to the branch-head SHA, which is the PR head,
+          # so `diagnostics-gate` lands on the PR rollup and the ruleset is satisfied.
+          # This is the CI-native fix: no PAT, no GitHub App token, no new secrets.
+          # NOTE: this needs `actions: write` (see the permissions block at the top) —
+          # the repo default workflow permission is read-only.
+          #
+          # validate-target-diagnostics.yml is safe to dispatch: it already declares
+          # workflow_dispatch, it has NO paths: filter (so a values-only diff still runs
+          # it — verified on #1008, which changed only deploy/values/compute-gateway.yaml
+          # and still produced diagnostics-gate=success), and it contains no
+          # github.event.pull_request.* expressions, so the job graph and every check NAME
+          # are byte-identical under pull_request and workflow_dispatch.
+          # If you are tempted to "just push an empty commit to kick CI" — that is the
+          # manual workaround this dispatch replaces. Don't re-add it.
+          if ! gh workflow run validate-target-diagnostics.yml --ref "$BRANCH"; then
+            echo "::warning::could not dispatch validate-target-diagnostics for $BRANCH; the PR will stay BLOCKED until diagnostics-gate is produced some other way"
+          fi
+
           gh pr merge "$BRANCH" --squash --auto --delete-branch
           echo "promoted via auto-merge PR:${bumped}"

--- a/.github/workflows/gitops-promote.yml
+++ b/.github/workflows/gitops-promote.yml
@@ -160,8 +160,18 @@ jobs:
           # are byte-identical under pull_request and workflow_dispatch.
           # If you are tempted to "just push an empty commit to kick CI" — that is the
           # manual workaround this dispatch replaces. Don't re-add it.
-          if ! gh workflow run validate-target-diagnostics.yml --ref "$BRANCH"; then
-            echo "::warning::could not dispatch validate-target-diagnostics for $BRANCH; the PR will stay BLOCKED until diagnostics-gate is produced some other way"
+          # Retry: this job is unattended, and a dispatch that silently fails leaves the PR
+          # BLOCKED until a human happens to notice. A freshly-pushed ref can also take a
+          # moment to become dispatchable.
+          dispatched=""
+          for attempt in 1 2 3; do
+            if gh workflow run validate-target-diagnostics.yml --ref "$BRANCH"; then
+              dispatched=1; echo "dispatched diagnostics onto $BRANCH (attempt $attempt)"; break
+            fi
+            echo "dispatch attempt $attempt failed; retrying in 10s"; sleep 10
+          done
+          if [ -z "$dispatched" ]; then
+            echo "::warning::could not dispatch validate-target-diagnostics for $BRANCH after 3 attempts; the PR will stay BLOCKED until diagnostics-gate is produced some other way"
           fi
 
           gh pr merge "$BRANCH" --squash --auto --delete-branch


### PR DESCRIPTION
## Verdict: the premise is **still true**. A promote PR cannot merge on its own today.

The recent observation that promote PRs "show 7 checks, all passing" is real — but those 7 checks
are a mirage. **None of them is the required one.**

`gh api repos/SocioProphet/prophet-platform/rulesets` → ruleset `main-required-checks` (active, on
`~DEFAULT_BRANCH`) requires exactly **one** status check context:

```
diagnostics-gate
```

That is the whole required set. There is no classic branch protection (`/branches/main/protection`
→ 404 "Branch not protected"), and org-level rulesets are unavailable on this plan. So the single
question is: does a bot-opened promote PR produce `diagnostics-gate`? Measured answer: **no.**

## Evidence table — consecutive promote PRs

`human` = commits on the PR whose author is not `github-actions[bot]`.

| PR | state | commits | human commit | total checks | `diagnostics-gate` |
|----|-------|---------|--------------|--------------|--------------------|
| #981 | MERGED | 1 | **0** | 78 | ✅ success |
| #983 | MERGED | 1 | **0** | 78 | ✅ success |
| #988 | closed | 1 | 0 | 2 runs only | ❌ ABSENT |
| #989 | closed | 1 | 0 | 2 runs only | ❌ ABSENT |
| #993 | closed | 1 | 0 | 2 runs only | ❌ ABSENT |
| #990 | MERGED | 2 | 1 (`ci: trigger required checks (GITHUB_TO…`) | 79 | ✅ success |
| #996 | MERGED | 2 | 1 (`ci: trigger required checks (GITHUB_TO…`) | 79 | ✅ success |
| #998 | MERGED | 2 | 1 (`ci: trigger required checks (GITHUB_TO…`) | 79 | ✅ success |
| #1000 | MERGED | 2 | 1 (`ci: retrigger checks (bot-push workflo…`) | 79 | ✅ success |
| #1005 | MERGED | 2 | 1 (`ci: retrigger checks (bot-push workflo…`) | 80 | ✅ success |
| #1007 | closed | 1 | **0** | 8 | ❌ ABSENT |
| #1008 | MERGED | 2 | 1 (`ci: retrigger checks (bot-push workflo…`) | 80 | ✅ success |
| #1013 | closed | 1 | **0** | 8 | ❌ ABSENT |
| #1017 | open | 1 | **0** | 8 | ❌ ABSENT → `mergeable_state: blocked` |
| #1018 | open | 1 | **0** | 8 | ❌ ABSENT → `mergeable_state: blocked` |

**Every promote PR that merged did so either after a human empty commit, or (#981/#983) in a window
where the `pull_request` runs were attributed to a human `triggering_actor`. Not one bot-only
promote PR has satisfied the required check on its own.**

(#1017/#1018 were kicked by hand after these snapshots were taken, to get the doors/receipts code
to prod. The rows above are their pre-kick state at head `5d5897ac` / `aaad93ee`.)

## What the 7-8 "passing" checks actually are

On #1013 (bot-only), mapping each check-run to its producing app:

```
CodeQL                          ← app=github-advanced-security
Analyze (actions)               ← app=github-actions   (CodeQL default setup)
Analyze (javascript-typescript) ← app=github-actions
Analyze (rust)                  ← app=github-actions
Analyze (javascript-typescript) ← app=github-actions
Analyze (go)                    ← app=github-actions
Analyze (python)                ← app=github-actions
GitGuardian Security Checks     ← app=gitguardian
```

The only workflow runs on that SHA were `[dynamic] PR #1013` and `[dynamic] Code Quality: PR #1013`
— CodeQL default setup and Copilot review, which fire on the `dynamic` event and are **exempt** from
the GITHUB_TOKEN rule. GitGuardian is a GitHub App, likewise exempt. **Zero of these is required**, so
an all-green rollup of them means nothing. That is exactly why the contradiction looked like the
premise had gone obsolete.

## Two distinct failure modes (both end in BLOCKED)

Measured, and they are *not* the same mechanism:

1. **#1007 / #1013 — no runs at all.** `GET /actions/runs?head_sha=…` returns `total_count: 2`, both
   `dynamic`. Zero `pull_request` runs. This is the classic GITHUB_TOKEN no-recursion rule.
2. **#1017 / #1018 — 18 `pull_request` runs created, all parked.** Every one has
   `event=pull_request`, `triggering_actor=github-actions[bot]`, and
   **`conclusion=action_required`** — queued awaiting approval. A run parked at `action_required`
   publishes no check-runs, which is why the PR still showed only 8. Measured alongside:
   `GET /actions/permissions/fork-pr-contributor-approval` → `{"approval_policy":"first_time_contributors"}`.
   On the two runs that *did* work (#981/#983) the `triggering_actor` was `mdheller`, not the bot.
   The policy is the likeliest cause; the parked state is the measured fact.

Either way `diagnostics-gate` never appears, and `mergeable_state` stays `blocked`.

## The fix (CI-native, no PAT / no App token / no new secrets)

After opening the promote PR, explicitly dispatch the workflow that produces the required check onto
the promote branch:

```sh
gh workflow run validate-target-diagnostics.yml --ref "$BRANCH"
```

`workflow_dispatch` is the documented exception to the no-recursion rule — an explicit dispatch does
create a run even under GITHUB_TOKEN — and because it is not a `pull_request` event it also escapes
the contributor-approval gate that parked #1017/#1018. The run's check-runs attach to the branch-head
SHA, which is the PR head, so `diagnostics-gate` lands on the PR rollup and the ruleset is satisfied.

This also adds `actions: write` to the job's `permissions` block. The repo's
`default_workflow_permissions` is `read`, so without it the dispatch would 403 and every promote PR
would sit blocked forever.

### Why `validate-target-diagnostics.yml` is safe to dispatch (all checked programmatically)

```
triggers:             {'pull_request': {'branches': ['main']}, 'push': {'branches': ['main']}, 'workflow_dispatch': None}
has paths filter:     False
diagnostics-gate job: no `name:` override → check name == job id, identical under every trigger
grep 'github.event.pull_request' → no matches in the file body
```

- It **already** declares `workflow_dispatch` — this PR adds no new trigger surface.
- **No `paths:` filter**, so a values-only diff still runs it. Verified end-to-end on #1008, whose
  only changed file was `deploy/values/compute-gateway.yaml` and which still produced
  `diagnostics-gate=success`. A skipped-and-therefore-never-reported required check is not a risk here.
- **No `github.event.pull_request.*` expressions**, so the job graph and every check NAME are
  byte-identical under `pull_request` and `workflow_dispatch`. Nothing to guard or degrade.

### Protections for human PRs are unchanged

No ruleset is modified, no required check is removed or scoped away, and no branch-pattern exemption
is added. `diagnostics-gate` still has to genuinely pass on the promote branch — the bot now merely
causes it to *run*; it cannot cause it to *pass*. This deliberately avoids the alternative of scoping
a weaker ruleset to `gitops/promote-*`, which would have made the gate meaningless for exactly the
commits that reach production.

## What this replaces

The manual workaround — `git commit --allow-empty -m "ci: retrigger checks"` — appears on 6 of the
merged PRs above. A repo-wide grep for `allow-empty|empty commit|retrigger check|kick ci` found **no
documentation** encoding it (it lived only in habits and commit messages), so the durable place to
record the finding is the promote workflow itself. The added comment block explains both failure
modes, names the mirage explicitly ("Do NOT read '7 checks passing' as 'ready to merge'"), and ends
with "If you are tempted to 'just push an empty commit to kick CI' — that is the manual workaround
this dispatch replaces. Don't re-add it."
