### PR TITLE
fix(review): close the Copilot-found defects on #1009-#1015 (policy bypass, races, overclaims)

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/engine_receipts.py
+++ b/apps/compute-gateway/src/compute_gateway/engine_receipts.py
@@ -25,9 +25,15 @@ attest (an engine shape change lands here as a fail-loud diff, never a silent
 mis-hash).
 
 The verify walk (`verify_walk`) is the ONE end-to-end check the wall demands:
-  1. gateway-signature    — the receipt is on the project chain, its id-hash
-                            recomputes, and the Ed25519 signature over the
-                            in-toto statement verifies (spine authenticity).
+  1. gateway-signature    — the receipt is genuinely ON the project chain: every
+                            predecessor's id-hash recomputes and every prev-link
+                            from genesis up to this receipt holds, so its POSITION
+                            is proved rather than assumed; then the Ed25519
+                            signature over the in-toto statement verifies (spine
+                            authenticity). Membership alone was the old, weaker
+                            claim — it passed a reordered chain and a broken
+                            earlier prev-link, which is precisely what "chained"
+                            is supposed to exclude.
   2. engine-seal-hash     — the stored engine receipt's sealed sha256 recomputes
                             byte-exactly (engine-output integrity).
   3. snapshot-seq-binding — the stored envelope matches the SIGNED outputs_sha
@@ -263,6 +269,30 @@ def _receipt_body_hash_ok(r: Any) -> bool:
     return receipts.sha(body) == r.id
 
 
+def _chain_prefix_problem(chain: list, index: int) -> str | None:
+    """Verify the hash chain from GENESIS up to and including `index`.
+
+    "On the chain" is a claim about ORDER, not about membership. Checking only that
+    the target receipt exists in the list and that its own body re-hashes proved
+    neither: a reordered chain, or a broken prev-link in an earlier receipt, left the
+    target intact and the step still said ok. Since the receipt's position is the
+    whole point of a hash chain, the walk now re-derives it — every predecessor's
+    id-hash recomputed and every prev-link followed — before claiming the target is
+    chained at all. Returns None when the prefix is intact, else the reason.
+    """
+    prev: str | None = None
+    for i, x in enumerate(chain[: index + 1]):
+        if not _receipt_body_hash_ok(x):
+            where = "this receipt" if i == index else f"predecessor #{i}"
+            return f"{where} ({x.id}) id-hash does not recompute (chain tampered)"
+        if x.prev != prev:
+            where = "this receipt" if i == index else f"predecessor #{i}"
+            return (f"prev-link broken at {where} ({x.id}): prev={x.prev!r}, "
+                    f"expected {prev!r} — the chain order does not hold up to this receipt")
+        prev = x.id
+    return None
+
+
 def verify_walk(project: str, receipt_id: str) -> dict[str, Any]:
     """Walk an engine-seal receipt end-to-end: gateway signature → engine sealed
     hash recomputation → snapshot.seq binding. Returns {valid, receipt_id,
@@ -279,20 +309,26 @@ def verify_walk(project: str, receipt_id: str) -> dict[str, Any]:
     def ok(step: str, detail: str | None = None) -> None:
         steps.append({"step": step, "status": "ok", "detail": detail})
 
-    # 1 — gateway-signature: on the chain, id-hash intact, Ed25519 verifies.
-    r = next((x for x in receipts.chain(project) if x.id == receipt_id), None)
-    if r is None:
+    # 1 — gateway-signature: genuinely ON the chain (every prev-link from genesis to
+    #     here re-derived), id-hash intact, Ed25519 verifies.
+    ch = receipts.chain(project)
+    index = next((i for i, x in enumerate(ch) if x.id == receipt_id), None)
+    if index is None:
         return fail("gateway-signature", f"no receipt {receipt_id} in project {project}")
+    r = ch[index]
     if r.kind != "engine-seal":
         return fail("gateway-signature", f"receipt kind {r.kind!r} is not engine-seal")
-    if not _receipt_body_hash_ok(r):
-        return fail("gateway-signature", "receipt id-hash does not recompute (chain tampered)")
+    broken = _chain_prefix_problem(ch, index)
+    if broken:
+        return fail("gateway-signature", broken)
     if r.signature is None:
         return fail("gateway-signature",
                     "receipt is unsigned (no GATEWAY_SIGNING_KEY at seal time) — spine authenticity unprovable")
     if r.statement is None or not signing.verify_signature(r.statement, r.signature, r.public_key):
         return fail("gateway-signature", "gateway Ed25519 signature does not verify over the in-toto statement")
-    ok("gateway-signature", "chained + Ed25519 over in-toto statement verified")
+    ok("gateway-signature",
+       f"chain position {index} re-derived: every id-hash and prev-link from genesis to this "
+       f"receipt verified, + Ed25519 over the in-toto statement")
 
     # 2 — engine-seal-hash: the stored engine receipt's sealed sha256 recomputes.
     digests = artifacts.for_receipt(receipt_id)

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -264,10 +264,15 @@ async def engine_receipt_seal(body: EngineSealBody, _: None = Depends(require_to
 @app.get("/v1/engine-receipts/{receipt_id}/verify")
 def engine_receipt_verify(receipt_id: str, project: str = "default",
                           _: None = Depends(require_token)) -> dict:
-    """ONE verify() that walks an engine receipt end-to-end: gateway Ed25519
-    signature → engine sealed-hash recomputation → snapshot.seq binding. Always
-    200 with {valid, steps:[{step, status, detail}]} — the typed trace IS the
-    result; a missing receipt is simply valid:false at the first step."""
+    """ONE verify() that walks an engine receipt end-to-end: chain position (every
+    id-hash + prev-link from genesis) and gateway Ed25519 signature → engine
+    sealed-hash recomputation → snapshot.seq binding.
+
+    Once past auth this ALWAYS answers 200 with {valid, steps:[{step, status,
+    detail}]} — the typed trace IS the result, so a missing receipt, a tampered
+    chain and a broken seal are all valid:false at the step that owns the failure,
+    never an HTTP error. Auth itself still refuses first: require_token raises 401
+    (bad/absent token) or 503 (no GATEWAY_TOKEN configured — fail-closed)."""
     return engine_receipts.verify_walk(project, receipt_id)
 
 

--- a/apps/compute-gateway/tests/test_engine_seal.py
+++ b/apps/compute-gateway/tests/test_engine_seal.py
@@ -245,6 +245,48 @@ def test_tamper_whole_envelope_cannot_outrun_the_signed_outputs_sha():
     assert "outputs_sha" in walk["steps"][2]["detail"]
 
 
+def test_reordered_chain_fails_at_gateway_signature():
+    # "on the chain" is a claim about ORDER. Membership + own-hash said ok even when
+    # the chain had been shuffled underneath the receipt — so a receipt could be
+    # moved to a different position in history and still verify. It cannot now.
+    first = _seal("enrich", _enrich_receipt()).json()["receiptId"]
+    second = _seal("explore", _explore_receipt()).json()["receiptId"]
+    chain = receipts._CHAINS["demo"]
+    assert [c.id for c in chain] == [first, second]
+
+    chain.reverse()                                    # same receipts, forged order
+    walk = _verify(second)                             # now sitting at position 0
+    assert walk["valid"] is False
+    assert _statuses(walk) == [("gateway-signature", "fail"), ("engine-seal-hash", "skipped"),
+                               ("snapshot-seq-binding", "skipped")]
+    assert "prev-link" in walk["steps"][0]["detail"]
+
+
+def test_broken_earlier_prev_link_fails_the_receipt_that_depends_on_it():
+    # Tamper with a PREDECESSOR, not the target. The target's own body still
+    # re-hashes perfectly — the old step 1 passed it and attested a receipt whose
+    # history had been rewritten beneath it.
+    first = _seal("enrich", _enrich_receipt()).json()["receiptId"]
+    second = _seal("explore", _explore_receipt()).json()["receiptId"]
+    chain = receipts._CHAINS["demo"]
+
+    chain[0].actor = "someone-else"                    # predecessor body altered
+    assert engine_receipts._receipt_body_hash_ok(chain[1]) is True   # target itself intact
+    walk = _verify(second)
+    assert walk["valid"] is False
+    assert walk["steps"][0]["step"] == "gateway-signature"
+    assert walk["steps"][0]["status"] == "fail"
+    detail = walk["steps"][0]["detail"]
+    assert "predecessor #0" in detail and first in detail
+    assert "id-hash does not recompute" in detail
+
+    # a receipt EARLIER than the tampering is unaffected — the walk verifies the
+    # prefix each receipt actually depends on, not the whole chain indiscriminately.
+    receipts._CHAINS["demo"] = [chain[0]]
+    chain[0].actor = "hellgraph-service"               # restore: genesis is sound again
+    assert _verify(first)["steps"][0]["status"] == "ok"
+
+
 def test_verify_walk_missing_receipt_is_invalid_at_step_one():
     walk = _verify("sha256:" + "ee" * 32)
     assert walk["valid"] is False

--- a/apps/hellgraph-service/src/contract.test.ts
+++ b/apps/hellgraph-service/src/contract.test.ts
@@ -1,0 +1,80 @@
+/**
+ * contract — the vendored-schema validator's own gates.
+ *
+ * The membrane's whole claim is "what enters the graph conforms to the estate
+ * contract", so the validator is load-bearing: a keyword it implements loosely is
+ * a hole in every downstream guarantee. These tests pin the sharp edges.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { validateAgainst, canonicalJson, SPEC_VERSION, SCHEMAS } from './contract.js'
+
+function report(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'urn:srcos:execution-report:contract-test-1',
+    type: 'ExecutionReport',
+    specVersion: SPEC_VERSION,
+    wallTime: '2026-07-29T12:00:00Z',
+    orderIntentRef: 'urn:srcos:order-intent:contract-test-1',
+    reportKind: 'fill',
+    ...over,
+  }
+}
+
+test('the baseline fixture is valid — so a failure below means the KEYWORD fired', () => {
+  assert.deepEqual(validateAgainst('ExecutionReport', report()), [])
+})
+
+test('uniqueItems is order-INSENSITIVE for objects: {rel,ref} and {ref,rel} are ONE item', () => {
+  // These two schemas really do apply uniqueItems to arrays of objects, which is
+  // what makes this more than theory.
+  for (const name of ['ExecutionReport', 'OrderIntent'] as const) {
+    const links = (SCHEMAS[name]['properties'] as Record<string, Record<string, unknown>>)['provenanceLinks']!
+    assert.equal(links['uniqueItems'], true, `${name}.provenanceLinks must still be uniqueItems`)
+    assert.equal((links['items'] as Record<string, unknown>)['type'], 'object',
+      `${name}.provenanceLinks must still be an array OF OBJECTS (else this test is moot)`)
+  }
+
+  // Same content, keys typed in the other order. JSON.stringify called these two
+  // different values, so the duplicate slipped through.
+  const reordered = validateAgainst('ExecutionReport', report({
+    provenanceLinks: [
+      { rel: 'derived_from', ref: 'urn:srcos:order-intent:x' },
+      { ref: 'urn:srcos:order-intent:x', rel: 'derived_from' },
+    ],
+  }))
+  assert.ok(reordered.some((e) => e.includes('items must be unique')),
+    `reordered-key duplicate must be rejected, got: ${JSON.stringify(reordered)}`)
+
+  // literal duplicates still rejected (the case that always worked)
+  const literal = validateAgainst('ExecutionReport', report({
+    provenanceLinks: [
+      { rel: 'derived_from', ref: 'urn:srcos:order-intent:x' },
+      { rel: 'derived_from', ref: 'urn:srcos:order-intent:x' },
+    ],
+  }))
+  assert.ok(literal.some((e) => e.includes('items must be unique')))
+
+  // genuinely DIFFERENT links still pass — the fix must not over-reject
+  assert.deepEqual(validateAgainst('ExecutionReport', report({
+    provenanceLinks: [
+      { rel: 'derived_from', ref: 'urn:srcos:order-intent:x' },
+      { rel: 'quotes', ref: 'urn:srcos:order-intent:x' },
+      { rel: 'derived_from', ref: 'urn:srcos:order-intent:y' },
+    ],
+  })), [])
+
+  // and string arrays (the common case) are unaffected
+  assert.ok(validateAgainst('ExecutionReport', report({ policyLabels: ['a', 'a'] }))
+    .some((e) => e.includes('items must be unique')))
+  assert.deepEqual(validateAgainst('ExecutionReport', report({ policyLabels: ['a', 'b'] })), [])
+})
+
+test('canonicalJson is key-order independent at every depth (the identity uniqueness uses)', () => {
+  assert.equal(
+    canonicalJson({ b: 1, a: { d: [{ z: 1, y: 2 }], c: 3 } }),
+    canonicalJson({ a: { c: 3, d: [{ y: 2, z: 1 }] }, b: 1 }),
+  )
+  // …but NOT array-order independent: [1,2] and [2,1] are different values
+  assert.notEqual(canonicalJson([1, 2]), canonicalJson([2, 1]))
+})

--- a/apps/hellgraph-service/src/contract.ts
+++ b/apps/hellgraph-service/src/contract.ts
@@ -135,7 +135,16 @@ function check(schema: SchemaObj, v: unknown, at: string, errors: string[]): voi
     const items = schema['items']
     if (items && typeof items === 'object') v.forEach((x, i) => check(items as SchemaObj, x, `${at}[${i}]`, errors))
     if (schema['uniqueItems'] === true) {
-      const seen = new Set(v.map((x) => JSON.stringify(x)))
+      // JSON Schema uniqueness is by VALUE, and object equality is key-order
+      // independent. Comparing raw JSON.stringify output made {rel,ref} and
+      // {ref,rel} two different items, so a duplicate provenance link passed
+      // merely by being typed in the other order — and the schemas that need
+      // this are real: ExecutionReport.provenanceLinks and
+      // OrderIntent.provenanceLinks are both uniqueItems arrays OF OBJECTS.
+      // canonicalJson sorts keys at every depth, which is exactly the identity
+      // decisionHash already seals over — one notion of "the same value" in
+      // this file, not two.
+      const seen = new Set(v.map((x) => canonicalJson(x as Json)))
       if (seen.size !== v.length) errors.push(`${at}: items must be unique`)
     }
   }

--- a/apps/hellgraph-service/src/membrane.test.ts
+++ b/apps/hellgraph-service/src/membrane.test.ts
@@ -24,15 +24,23 @@ let srv: { close: (cb?: () => void) => void }
 interface SealCall { path: string; authorization: string; body: any }
 const sealCalls: SealCall[] = []
 let gatewayMode: 'ok' | 'error' = 'ok'
+// Widens the seal window on demand so the single-flight test exercises a REAL
+// concurrent overlap rather than hoping the event loop interleaves.
+let gatewayDelayMs = 0
 const stubGateway = http.createServer((req, res) => {
   let d = ''
   req.on('data', (c) => { d += c })
   req.on('end', () => {
     sealCalls.push({ path: req.url ?? '', authorization: String(req.headers['authorization'] ?? ''), body: JSON.parse(d || '{}') })
-    res.writeHead(gatewayMode === 'ok' ? 200 : 500, { 'content-type': 'application/json' })
-    res.end(JSON.stringify(gatewayMode === 'ok'
-      ? { status: 'ok', kind: 'materialize', backend: 'gateway', receipt: { id: `sha256:stub-receipt-${sealCalls.length}` } }
-      : { status: 'error', error: 'stub-induced failure' }))
+    const n = sealCalls.length
+    const reply = (): void => {
+      res.writeHead(gatewayMode === 'ok' ? 200 : 500, { 'content-type': 'application/json' })
+      res.end(JSON.stringify(gatewayMode === 'ok'
+        ? { status: 'ok', kind: 'materialize', backend: 'gateway', receipt: { id: `sha256:stub-receipt-${n}` } }
+        : { status: 'error', error: 'stub-induced failure' }))
+    }
+    if (gatewayDelayMs > 0) setTimeout(reply, gatewayDelayMs).unref()
+    else reply()
   })
 })
 
@@ -167,6 +175,47 @@ test('policy kernel v0 denies over-limit + human-approval requests; B on a denie
   assert.ok(k.json.reasons.includes('intent_kind_not_allowed:pause'))
 })
 
+test('SIGN IS A GATE: non-positive price/quantity is denied and cannot buy its way under maxNotional', async () => {
+  // The bypass this closes: OrderIntent.price is spec-valid as a NEGATIVE number
+  // (type number|string|null, no `minimum`), so qty × price went negative and sailed
+  // under MEMBRANE_MAX_NOTIONAL — an approval on a trade with no size limit at all.
+  const neg = await post('/api/membrane/decide', effectRequest('price-neg', { price: -10 }))
+  assert.equal(neg.status, 200)
+  assert.equal(neg.json.decision, 'denied')
+  assert.ok(neg.json.reasons.includes('price_not_positive'), `reasons: ${JSON.stringify(neg.json.reasons)}`)
+
+  // zero price: a "free" limit order is not a limit order
+  const zero = await post('/api/membrane/decide', effectRequest('price-zero', { price: 0 }))
+  assert.equal(zero.json.decision, 'denied')
+  assert.ok(zero.json.reasons.includes('price_not_positive'))
+
+  // negative quantity (already covered by quantity_not_positive — asserted so it stays covered)
+  const negQty = await post('/api/membrane/decide', effectRequest('qty-neg', { quantity: -100 }))
+  assert.equal(negQty.json.decision, 'denied')
+  assert.ok(negQty.json.reasons.includes('quantity_not_positive'))
+
+  // THE bypass, exactly: 9,999 × -1,000,000 = -9.999e9 notional. Under the old
+  // signed comparison this was "below" the 1,000,000 cap and APPROVED. It must now
+  // be denied for the sign AND for the magnitude — belt and suspenders, both named.
+  const huge = await post('/api/membrane/decide', effectRequest('notional-neg', { quantity: 9_999, price: -1_000_000 }))
+  assert.equal(huge.json.decision, 'denied')
+  assert.ok(huge.json.reasons.includes('price_not_positive'))
+  assert.ok(huge.json.reasons.includes('notional_exceeds_limit:1000000'),
+    `magnitude must still bind: ${JSON.stringify(huge.json.reasons)}`)
+
+  // and B cannot land on any of them
+  const b = await post('/api/graph/node', {
+    id: 'urn:srcos:execution-report:t-notional-neg', labels: ['ExecutionReport'],
+    properties: { decisionRef: huge.json.decisionRef, intentRef: 'urn:srcos:order-intent:t-notional-neg', reportKind: 'fill' },
+  })
+  assert.equal(b.status, 403)
+  assert.equal(b.json.reason, 'decision_not_approved')
+
+  // a market order (price null) is still legal — the gate is on DECLARED prices
+  const mkt = await post('/api/membrane/decide', effectRequest('price-null', { orderType: 'market', price: null }))
+  assert.equal(mkt.json.decision, 'approved', `reasons: ${JSON.stringify(mkt.json.reasons)}`)
+})
+
 test('intentRef mismatch is a typed 403 — the approval is FOR an intent, not a bearer chip', async () => {
   const d = await post('/api/membrane/decide', effectRequest('match-a'))
   assert.equal(d.json.decision, 'approved')
@@ -200,6 +249,48 @@ test('decide is idempotent by key: same key twice = the SAME decision, sealed on
   // exactly one EffectDecision node exists for the key
   const q = await get('/api/graph/query?label=EffectDecision')
   assert.equal(q.json.nodes.filter((n: any) => n.id === first.json.decisionRef).length, 1)
+})
+
+test('CONCURRENT decides with one key single-flight: one node, one seal, IDENTICAL responses', async () => {
+  // The pre-fix hole: the existence check saw the node written before the seal
+  // await, so a caller arriving inside the seal window got idempotent:true with
+  // sealed:false/receiptRef:null — the SAME decision, but NOT the same answer.
+  // "same key twice = the SAME decision, sealed once" is a statement about the
+  // RESPONSE too, so concurrent callers now await the one in-flight decision.
+  const sealsBefore = sealCalls.length
+  gatewayDelayMs = 120 // hold the seal open so all N genuinely overlap
+  let responses: any[]
+  try {
+    responses = await Promise.all(
+      Array.from({ length: 8 }, () => post('/api/membrane/decide', effectRequest('race'))),
+    )
+  } finally { gatewayDelayMs = 0 }
+
+  assert.equal(sealCalls.length, sealsBefore + 1, 'exactly ONE seal for 8 concurrent decides on one key')
+  const q = await get('/api/graph/query?label=EffectDecision')
+  const ref = responses[0]!.json.decisionRef
+  assert.equal(q.json.nodes.filter((n: any) => n.id === ref).length, 1, 'exactly ONE EffectDecision node')
+
+  for (const r of responses) {
+    assert.equal(r.status, 200)
+    assert.equal(r.json.decision, 'approved')
+    assert.equal(r.json.decisionRef, ref)
+    // every concurrent caller sees the SEALED decision — none observes the
+    // mid-flight sealed:false snapshot.
+    assert.equal(r.json.sealed, true, `concurrent response reported sealed:${r.json.sealed}`)
+    assert.equal(r.json.receiptRef, responses[0]!.json.receiptRef)
+    assert.equal(r.json.decisionHash, responses[0]!.json.decisionHash)
+  }
+  // The winner announces the fresh decision; the followers are marked idempotent.
+  assert.equal(responses.filter((r) => r.json.idempotent === false).length, 1,
+    'exactly one caller is credited with MAKING the decision')
+
+  // A later replay still returns the same sealed decision, unchanged.
+  const replay = await post('/api/membrane/decide', effectRequest('race'))
+  assert.equal(replay.json.idempotent, true)
+  assert.equal(replay.json.decisionRef, ref)
+  assert.equal(replay.json.sealed, true)
+  assert.equal(sealCalls.length, sealsBefore + 1)
 })
 
 test('spec-validation rejects malformed requests (vendored schemas, loud errors)', async () => {

--- a/apps/hellgraph-service/src/membrane.ts
+++ b/apps/hellgraph-service/src/membrane.ts
@@ -116,8 +116,20 @@ export function evaluatePolicy(kernel: PolicyKernelV0, request: Dict, intent: Di
   const qty = asNumber(intent['quantity'])
   if (qty === null || qty <= 0) reasons.push('quantity_not_positive')
   else if (qty > kernel.maxQuantity) reasons.push(`quantity_exceeds_limit:${kernel.maxQuantity}`)
+  // SIGN IS A GATE, NOT A DETAIL. The vendored OrderIntent schema types price as
+  // number | signed-decimal-string | null (null = market order) with no `minimum`,
+  // so a NEGATIVE or ZERO price is spec-valid and arrives here. Unchecked, it made
+  // notional = qty × price negative, which trivially slipped under maxNotional —
+  // an approval bypass on the whole B-after-A gate (qty × -20000 "costs" nothing).
+  // A declared price must therefore be strictly positive; absent/null stays legal
+  // for market orders and is caught for limit orders by limit_price_required above.
+  const priceDeclared = intent['price'] !== undefined && intent['price'] !== null
   const price = asNumber(intent['price'])
-  if (qty !== null && price !== null && qty * price > kernel.maxNotional) {
+  if (priceDeclared && (price === null || price <= 0)) reasons.push('price_not_positive')
+  // Defence in depth: cap the MAGNITUDE. Even if a sign check were ever removed or
+  // a future intent kind carried a signed price legitimately, the notional limit
+  // must still bound exposure rather than be satisfied by a minus sign.
+  if (qty !== null && price !== null && Math.abs(qty * price) > kernel.maxNotional) {
     reasons.push(`notional_exceeds_limit:${kernel.maxNotional}`)
   }
   return reasons.length === 0 ? { decision: 'approved', reasons: [] } : { decision: 'denied', reasons }
@@ -239,6 +251,17 @@ function decisionResponse(node: GraphNode, idempotent: boolean): Dict {
   }
 }
 
+// ── single-flight: one decision per idempotencyKey, even under concurrency ─────────────
+// The decision node is written BEFORE the seal is awaited, so a second request for the
+// same key arriving inside the seal window used to find the node and answer from it —
+// same decision, but sealed:false/receiptRef:null while the seal was still in flight.
+// "same key twice = the SAME decision, sealed once" is a claim about the ANSWER, not
+// only about node and receipt counts, so concurrent callers now await the ONE decision
+// already being made. Checked BEFORE the stored-node lookup, which is what closes the
+// window: the entry outlives the node write and is cleared only once sealing settles.
+type DecideOutcome = { ok: true; node: GraphNode } | { ok: false; code: number; body: Dict }
+const inFlightDecisions = new Map<string, Promise<DecideOutcome>>()
+
 /** Handle /api/membrane/* on the main port. Returns true when the request was handled. */
 export function handleMembrane(g: MembraneGraph, req: http.IncomingMessage, res: http.ServerResponse, url: URL, body: string): boolean {
   if (!(req.method === 'POST' && url.pathname === '/api/membrane/decide')) return false
@@ -268,6 +291,16 @@ export function handleMembrane(g: MembraneGraph, req: http.IncomingMessage, res:
     // 4) Idempotency by key: same key twice = the SAME decision, never re-evaluated.
     const idempotencyKey = String(request['idempotencyKey'])
     const decisionId = decisionIdFor(idempotencyKey)
+    // 4a) A decision for this key is being made RIGHT NOW: await that one and answer
+    //     from its settled result — never race it, never observe it mid-seal.
+    const pending = inFlightDecisions.get(idempotencyKey)
+    if (pending) {
+      const outcome = await pending
+      return outcome.ok
+        ? respond(res, 200, decisionResponse(outcome.node, true))
+        : respond(res, outcome.code, outcome.body)
+    }
+    // 4b) Already decided and settled: return the stored decision verbatim.
     const existing = g.getNode(decisionId)
     if (existing) {
       if (existing.properties['idempotencyKey'] !== idempotencyKey) {
@@ -275,46 +308,67 @@ export function handleMembrane(g: MembraneGraph, req: http.IncomingMessage, res:
       }
       return respond(res, 200, decisionResponse(existing, true))
     }
-    // 5) Policy kernel v0 (deny-by-default). A deny IS a decision: recorded + sealed like an approve.
-    const verdict = evaluatePolicy(policyKernelV0(), request, intent)
-    const decidedAt = new Date().toISOString()
-    const decision = buildDecision(request, intent, verdict, decidedAt)
-    const selfCheck = validateAgainst('EffectDecision', decision)
-    if (selfCheck.length > 0) { // unreachable if the boot probe passed; belt-and-suspenders
-      return respond(res, 500, { ok: false, error: 'decision_nonconformant', errors: selfCheck })
+    // 4c) We are the single flight for this key. Everything from policy evaluation to
+    //     the sealed write happens inside ONE registered promise.
+    const work = (async (): Promise<DecideOutcome> => {
+      // 5) Policy kernel v0 (deny-by-default). A deny IS a decision: recorded + sealed like an approve.
+      const verdict = evaluatePolicy(policyKernelV0(), request, intent)
+      const decidedAt = new Date().toISOString()
+      const decision = buildDecision(request, intent, verdict, decidedAt)
+      const selfCheck = validateAgainst('EffectDecision', decision)
+      if (selfCheck.length > 0) { // unreachable if the boot probe passed; belt-and-suspenders
+        return { ok: false, code: 500, body: { ok: false, error: 'decision_nonconformant', errors: selfCheck } }
+      }
+      // 6) Structural write: the EffectDecision node (scalar projection + the full
+      //    spec-conformant object as canonical JSON — the log carries the OBJECT, not
+      //    just a lossy projection; market-replay flatten() discipline).
+      const props: Record<string, PropertyValue> = {
+        decision: verdict.decision,
+        effectRequestRef: String(request['id']),
+        intentRef: String(intent['id']),
+        idempotencyKey,
+        decidedAt,
+        decidedByActorRef: MEMBRANE_ACTOR,
+        capability: String(request['capability']),
+        effectKind: String(request['effectKind']),
+        specVersion: SPEC_VERSION,
+        decisionHash: String(decision['decisionHash']),
+        rationale: String(decision['rationale']),
+        reasons: JSON.stringify(verdict.reasons),
+        decisionEvent: canonicalJson(decision as Json),
+        sealed: false,
+        receiptRef: null,
+        sealError: null,
+      }
+      const vBefore = g.version()
+      g.addNode(decisionId, ['EffectDecision'], props)
+      const vAfter = g.version()
+      // 7) Seal on the estate receipt spine; record the outcome HONESTLY either way.
+      const seal = await sealDecision(String(decision['decisionHash']), vBefore, vAfter, process.env)
+      const sealedProps: Record<string, PropertyValue> = {
+        ...props, sealed: seal.sealed, receiptRef: seal.receiptRef, sealError: seal.sealError,
+      }
+      return { ok: true, node: g.addNode(decisionId, ['EffectDecision'], sealedProps) }
+    })()
+    inFlightDecisions.set(idempotencyKey, work)
+    try {
+      const outcome = await work
+      return outcome.ok
+        ? respond(res, 200, decisionResponse(outcome.node, false))
+        : respond(res, outcome.code, outcome.body)
+    } catch (e) {
+      // The flight itself blew up. Followers awaiting `work` see the same rejection
+      // and answer identically — one failure, one story.
+      return respond(res, 500, { ok: false, error: 'decision_failed', errors: [e instanceof Error ? e.message : String(e)] })
+    } finally {
+      // Cleared only after sealing settled, so the NEXT caller either joins a live
+      // flight or reads a fully sealed node — never the mid-flight snapshot.
+      inFlightDecisions.delete(idempotencyKey)
     }
-    // 6) Structural write: the EffectDecision node (scalar projection + the full
-    //    spec-conformant object as canonical JSON — the log carries the OBJECT, not
-    //    just a lossy projection; market-replay flatten() discipline).
-    const props: Record<string, PropertyValue> = {
-      decision: verdict.decision,
-      effectRequestRef: String(request['id']),
-      intentRef: String(intent['id']),
-      idempotencyKey,
-      decidedAt,
-      decidedByActorRef: MEMBRANE_ACTOR,
-      capability: String(request['capability']),
-      effectKind: String(request['effectKind']),
-      specVersion: SPEC_VERSION,
-      decisionHash: String(decision['decisionHash']),
-      rationale: String(decision['rationale']),
-      reasons: JSON.stringify(verdict.reasons),
-      decisionEvent: canonicalJson(decision as Json),
-      sealed: false,
-      receiptRef: null,
-      sealError: null,
-    }
-    const vBefore = g.version()
-    g.addNode(decisionId, ['EffectDecision'], props)
-    const vAfter = g.version()
-    // 7) Seal on the estate receipt spine; record the outcome HONESTLY either way.
-    const seal = await sealDecision(String(decision['decisionHash']), vBefore, vAfter, process.env)
-    const sealedProps: Record<string, PropertyValue> = {
-      ...props, sealed: seal.sealed, receiptRef: seal.receiptRef, sealError: seal.sealError,
-    }
-    const node = g.addNode(decisionId, ['EffectDecision'], sealedProps)
-    return respond(res, 200, decisionResponse(node, false))
-  })()
+  })().catch((e: unknown) => {
+    // Never leave an awaiting client hanging on an unexpected throw.
+    if (!res.writableEnded) respond(res, 500, { ok: false, error: 'decision_failed', errors: [e instanceof Error ? e.message : String(e)] })
+  })
   return true
 }
 

--- a/apps/hellgraph-service/src/spine.test.ts
+++ b/apps/hellgraph-service/src/spine.test.ts
@@ -20,6 +20,7 @@
 import { test, before, after } from 'node:test'
 import assert from 'node:assert/strict'
 import * as http from 'node:http'
+import { sealToSpine, unsealedReceipts, suppressedSpineWarns } from './spine.js'
 
 process.env.PORT = String(19101) // free test port (see PORT ALLOCATION below), read at module import
 process.env.HELLGRAPH_STORE_DIR = `${process.env.TMPDIR ?? '/tmp'}/hgsvc-spine-test-${process.pid}`
@@ -160,6 +161,49 @@ test('GATEWAY_RECEIPTS off ⇒ no spine field at all (exact pre-W1.3 response sh
   } finally {
     process.env.GATEWAY_RECEIPTS = 'on'
   }
+})
+
+test('degrade warnings are THROTTLED, the unsealed COUNTER is not (outage stays visible)', async () => {
+  // A gateway outage under load warned once per enrich/explore, burying the incident
+  // it was reporting. Only the log line is rate-limited; the counter — which is what
+  // /healthz surfaces and what an alert fires on — still moves on every degradation.
+  const prevUrl = process.env.GATEWAY_URL
+  const prevInterval = process.env.SPINE_WARN_INTERVAL_MS
+  const realWarn = console.warn
+  const lines: string[] = []
+  console.warn = (...a: unknown[]): void => { lines.push(a.map(String).join(' ')) }
+  const before = unsealedReceipts()
+  try {
+    process.env.GATEWAY_URL = 'http://127.0.0.1:19109' // dead port (see PORT ALLOCATION)
+
+    // interval 0 = no throttle: every degradation speaks. Establishes the baseline
+    // AND pins lastWarnAt so the throttled phase below is deterministic.
+    process.env.SPINE_WARN_INTERVAL_MS = '0'
+    for (let i = 0; i < 3; i++) await sealToSpine('explore', { hash: `sha256:${i}` }, {})
+    assert.equal(lines.length, 3, 'unthrottled: one line per degradation')
+
+    // now throttle hard: 25 more failures, not one extra line
+    process.env.SPINE_WARN_INTERVAL_MS = '60000'
+    lines.length = 0
+    for (let i = 0; i < 25; i++) await sealToSpine('enrich', { hash: `sha256:x${i}` }, {})
+    assert.equal(lines.length, 0, `throttled window must stay quiet, got: ${JSON.stringify(lines)}`)
+    assert.equal(suppressedSpineWarns(), 25, 'every suppressed line is still counted')
+
+    // …and the next line that DOES get emitted admits how many it swallowed, so the
+    // log never implies the outage was smaller than it was.
+    process.env.SPINE_WARN_INTERVAL_MS = '0'
+    await sealToSpine('enrich', { hash: 'sha256:last' }, {})
+    assert.equal(lines.length, 1)
+    assert.match(lines[0]!, /\+25 similar warning\(s\) suppressed/)
+    assert.equal(suppressedSpineWarns(), 0, 'the suppressed tally resets once reported')
+  } finally {
+    console.warn = realWarn
+    process.env.GATEWAY_URL = prevUrl
+    if (prevInterval === undefined) delete process.env.SPINE_WARN_INTERVAL_MS
+    else process.env.SPINE_WARN_INTERVAL_MS = prevInterval
+  }
+  // 3 + 25 + 1 degradations, every single one counted
+  assert.equal(unsealedReceipts(), before + 29, 'the counter is never sampled')
 })
 
 test('healthz reports the unsealedReceipts counter', async () => {

--- a/apps/hellgraph-service/src/spine.ts
+++ b/apps/hellgraph-service/src/spine.ts
@@ -5,37 +5,79 @@
  *
  * After /api/graph/enrich | /api/graph/explore computes its proof-carrying result
  * (sealed sha256 over the ranked output + snapshot {seq,nodes,edges}), the engine
- * receipt is POSTed to compute-gateway POST /v1/engine-receipts (kind=engine-seal),
- * which RECOMPUTES the seal byte-exactly, wraps it in the signed envelope, and
+ * receipt is POSTed to compute-gateway POST /v1/engine-receipts with body
+ * kind=enrich|explore (WHICH engine receipt this is — engine-seal is the gateway's
+ * own COMPUTE kind, minted on its side, never sent by us). The gateway then
+ * RECOMPUTES the seal byte-exactly, wraps it in the signed envelope, and
  * chains it — so ONE gateway verify() walks signature → engine hash → snapshot.seq
  * binding end-to-end. The HTTP response then carries spine:{ok:true, receiptId}.
  *
  * HONEST DEGRADATION (availability over ceremony, but never a false claim): a
  * sealing failure NEVER fails the graph read. The result still serves, with
  * spine:{ok:false, reason}, the /healthz `unsealedReceipts` counter incremented,
- * and a warn log — sealed is a verifiable statement here, not a vibe.
+ * and a warn log — sealed is a verifiable statement here, not a vibe. The COUNTER
+ * is exact and unsampled; only the log line is rate-limited (an outage under load
+ * warned once per request and buried its own incident), and each emitted line
+ * reports how many it suppressed.
  *
  * Env (deploy/values/hellgraph-service.yaml): GATEWAY_RECEIPTS=on enables the
  * attach; GATEWAY_URL (in-cluster: http://compute-gateway:8080); GATEWAY_TOKEN
  * (same compute-gateway-token Secret the materializer uses; optional — absent
  * just degrades honestly); GATEWAY_TIMEOUT_MS (default 3000 — a slow spine must
- * not stall a graph read); GATEWAY_PROJECT (chain namespace, default 'default').
- * All read per call, so ops/tests can flip them without a restart.
+ * not stall a graph read); GATEWAY_PROJECT (chain namespace, default 'default');
+ * SPINE_WARN_INTERVAL_MS (minimum gap between degrade warnings, default 60000;
+ * 0 = never throttle). All read per call, so ops/tests can flip them without a
+ * restart.
  */
 
 export type SpineResult = { ok: true; receiptId: string } | { ok: false; reason: string }
 
 let unsealed = 0
+let lastWarnAt = 0
+let suppressedWarns = 0
 
 /** How many enrich/explore results served WITHOUT a spine receipt (reported in /healthz). */
 export const unsealedReceipts = (): number => unsealed
 
+/** How many degrade warnings the throttle swallowed since the last emitted line. */
+export const suppressedSpineWarns = (): number => suppressedWarns
+
 /** The values default is "on"; anything else disables the attach entirely (no spine field). */
 export const spineEnabled = (): boolean => (process.env['GATEWAY_RECEIPTS'] ?? '').toLowerCase() === 'on'
 
+/** Minimum gap between degrade warnings. 0 disables throttling (tests). */
+const warnIntervalMs = (): number => {
+  const raw = process.env['SPINE_WARN_INTERVAL_MS']
+  if (raw === undefined || raw.trim() === '') return 60_000
+  const n = Number(raw)
+  return Number.isFinite(n) && n >= 0 ? n : 60_000
+}
+
+/**
+ * Degrade honestly, but do not SHOUT once per request: a gateway outage under load
+ * emitted one warn line per enrich/explore, which buries the incident it is meant to
+ * report (and, on a busy node, everything else in the log with it).
+ *
+ * The counter is NOT sampled — `unsealed` moves on every single degradation, so
+ * /healthz `unsealedReceipts` remains the exact, unthrottled truth an outage is
+ * detected by. Only the LOG LINE is rate-limited, and each emitted line carries the
+ * number of lines suppressed since the last one, so the log never implies the
+ * problem happened fewer times than it did.
+ */
 function degrade(kind: string, reason: string): SpineResult {
-  unsealed++
-  console.warn(`[hellgraph-service] engine ${kind} receipt NOT sealed to spine (unsealed total ${unsealed}): ${reason}`)
+  unsealed++ // always: the metric is the alarm, and an alarm may not be sampled
+  const interval = warnIntervalMs()
+  const now = Date.now()
+  if (lastWarnAt === 0 || interval === 0 || now - lastWarnAt >= interval) {
+    const alsoSuppressed = suppressedWarns > 0
+      ? ` [+${suppressedWarns} similar warning(s) suppressed in the last ${Math.round(interval / 1000)}s]`
+      : ''
+    console.warn(`[hellgraph-service] engine ${kind} receipt NOT sealed to spine (unsealed total ${unsealed})${alsoSuppressed}: ${reason}`)
+    lastWarnAt = now
+    suppressedWarns = 0
+  } else {
+    suppressedWarns++
+  }
   return { ok: false, reason }
 }
 

--- a/apps/lifecycle-warden/src/server.test.ts
+++ b/apps/lifecycle-warden/src/server.test.ts
@@ -5,7 +5,7 @@
  */
 import { test, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { resolveBootConfig, start, type WardenService } from './server.js'
+import { resolveBootConfig, start, MAX_BODY_BYTES, type WardenService } from './server.js'
 
 const PORT = 19095
 const BASE = `http://127.0.0.1:${PORT}`
@@ -31,7 +31,7 @@ async function req(method: string, path: string, body?: unknown) {
   return { status: r.status, json: (await r.json()) as any }
 }
 
-test('fail-closed: WARDEN_ENFORCE=on with missing MinIO creds refuses to boot', () => {
+test('fail-closed: ENFORCING with missing MinIO creds refuses to boot', () => {
   assert.throws(
     () => resolveBootConfig({ WARDEN_ENFORCE: 'on', WARDEN_DRY_RUN: 'off' } as NodeJS.ProcessEnv),
     /fail-closed/,
@@ -41,6 +41,39 @@ test('fail-closed: WARDEN_ENFORCE=on with missing MinIO creds refuses to boot', 
     () => resolveBootConfig({ MINIO_ENDPOINT: 'minio:9000' } as NodeJS.ProcessEnv),
     /partial MinIO config/,
   )
+})
+
+test('ENFORCE=on while dry-run wins BOOTS and warns loudly — the refusal tracks real enforcement', () => {
+  // The two-lever contract, honoured: nothing is applied in dry-run, so there is no
+  // delete to be amnesiac about and no reason to refuse. What there IS reason for is
+  // saying out loud that the operator asked to enforce and is not getting it.
+  const warnings: string[] = []
+  const cfg = resolveBootConfig(
+    { WARDEN_ENFORCE: 'on' } as NodeJS.ProcessEnv, // DRY_RUN unset ⇒ defaults to on
+    (m) => warnings.push(m),
+  )
+  assert.equal(cfg.enforce, false)
+  assert.equal(cfg.dryRun, true)
+  assert.equal(cfg.minio, null)
+  assert.equal(warnings.length, 1, `expected exactly one warning, got ${JSON.stringify(warnings)}`)
+  assert.match(warnings[0]!, /DRY-RUN WINS/)
+  assert.match(warnings[0]!, /MinIO credentials/) // credential-less is named too
+
+  // same lever combination WITH creds: still boots, still warns (it always could —
+  // this is the case the old code handled, kept here so the two stay consistent)
+  const warned2: string[] = []
+  const withCreds = resolveBootConfig(
+    { WARDEN_ENFORCE: 'on', MINIO_ENDPOINT: 'm:9000', MINIO_ACCESS_KEY: 'a', MINIO_SECRET_KEY: 's' } as NodeJS.ProcessEnv,
+    (m) => warned2.push(m),
+  )
+  assert.equal(withCreds.enforce, false)
+  assert.equal(warned2.length, 1)
+  assert.match(warned2[0]!, /DRY-RUN WINS/)
+
+  // and the quiet, correct default says nothing at all
+  const silent: string[] = []
+  resolveBootConfig({} as NodeJS.ProcessEnv, (m) => silent.push(m))
+  assert.deepEqual(silent, [])
 })
 
 test('both levers required: ENFORCE=on alone stays dry-run; +DRY_RUN=off enforces', () => {
@@ -113,6 +146,35 @@ test('vendor materialize without a configured client is refused (egress default-
   const r = await req('POST', '/v1/objects/h-3/materialize', { vendor: 'gemini', optIn: true, ttlMs: 1000 })
   assert.equal(r.status, 403) // no vendor client configured → structurally impossible
   assert.equal(r.json.ok, false)
+})
+
+test('an oversized body is ANSWERED (413), never left hanging', async () => {
+  // The bug: over the cap the read called req.destroy(), which emits neither 'end'
+  // nor necessarily 'error', so the promise never settled and the handler awaited a
+  // body that would never arrive — the client hung until its own timeout, forever on
+  // a keep-alive connection. The guarantee under test is simply: it SETTLES, fast.
+  const oversized = 'x'.repeat(MAX_BODY_BYTES + 1024)
+  const answered = fetch(`${BASE}/v1/objects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ id: 'too-big', content: oversized }),
+  }).then(async (r) => ({ hung: false as const, status: r.status, body: await r.text() }))
+  const verdict = await Promise.race([
+    answered,
+    new Promise<{ hung: true }>((r) => setTimeout(() => r({ hung: true }), 5_000).unref()),
+  ])
+  assert.equal(verdict.hung, false, 'readBody HUNG: no response within 5s for an oversized body')
+  assert.equal((verdict as { status: number }).status, 413)
+  assert.match((verdict as { body: string }).body, /exceeds 5000000 bytes/)
+
+  // and the server is still healthy afterwards — refusing one body did not wound it
+  const h = await req('GET', '/healthz')
+  assert.equal(h.status, 200)
+  assert.equal(h.json.ok, true)
+
+  // a normal body on the same route still works
+  const ok = await req('POST', '/v1/objects', { id: 'not-too-big', content: 'small' })
+  assert.equal(ok.status, 201)
 })
 
 test('unknown object and bad routes answer honestly', async () => {

--- a/apps/lifecycle-warden/src/server.ts
+++ b/apps/lifecycle-warden/src/server.ts
@@ -23,8 +23,10 @@
  *   GET  /v1/audit/verify            walk + re-hash every persisted chunk; reports tamper seq
  *
  * Mode: DRY-RUN by default. Enforcement requires BOTH levers — WARDEN_ENFORCE=on AND
- * WARDEN_DRY_RUN=off — and refuses to boot without MinIO credentials (fail-closed:
- * an enforcing warden with amnesia would re-plan deletes it can't account for).
+ * WARDEN_DRY_RUN=off — and an ENFORCING warden refuses to boot without MinIO
+ * credentials (fail-closed: an enforcing warden with amnesia would re-plan deletes it
+ * can't account for). WARDEN_ENFORCE=on while dry-run still wins is NOT a refusal:
+ * it boots, applies nothing, and warns loudly that it is declared-but-unenforced.
  */
 import * as http from 'node:http'
 import { Warden } from './warden.js'
@@ -35,6 +37,13 @@ import { S3ObjectBackend, type ObjectBackend, type Trigger } from '@socioprophet
 
 const PORT = Number(process.env.PORT ?? 8095)
 const INTERVAL_S = Number(process.env.WARDEN_INTERVAL_SECONDS ?? 300)
+/** Hard cap on a request body. Over it the read is refused with 413, not hung. */
+export const MAX_BODY_BYTES = 5_000_000
+
+/** Typed so the request handler answers 413 rather than a generic 500. */
+export class PayloadTooLarge extends Error {
+  readonly statusCode = 413
+}
 
 export interface BootConfig {
   dryRun: boolean
@@ -47,8 +56,19 @@ export interface BootConfig {
 /**
  * Resolve + validate boot config. Throws on the fail-closed cases so both the process
  * (exit 1) and the tests can assert refusal without spawning.
+ *
+ * The refusal tracks ACTUAL enforcement, not the intent to enforce. Refusing whenever
+ * WARDEN_ENFORCE=on — dry-run or not — contradicted the two-lever contract this service
+ * documents: with dry-run still winning, nothing is ever applied, so there is no delete
+ * to be amnesiac about, and the "dry-run wins" warning could never be reached in the
+ * credential-less case. Worse, it was inconsistent: the same ENFORCE=on + DRY_RUN=on
+ * combination booted happily the moment creds happened to be present. So:
+ *   both levers thrown + no creds  → REFUSE (the real fail-closed case, unchanged)
+ *   ENFORCE=on but dry-run wins    → boot, and WARN loudly that nothing is enforced
+ * `warn` is injectable so the declared-but-unenforced warning is TESTABLE rather than
+ * stranded in the process entrypoint (the membrane's initMembrane pattern).
  */
-export function resolveBootConfig(env: NodeJS.ProcessEnv): BootConfig {
+export function resolveBootConfig(env: NodeJS.ProcessEnv, warn: (msg: string) => void = console.warn): BootConfig {
   const enforceFlag = (env.WARDEN_ENFORCE ?? 'off').toLowerCase() === 'on'
   const dryRunFlag = (env.WARDEN_DRY_RUN ?? 'on').toLowerCase() !== 'off'
   const enforce = enforceFlag && !dryRunFlag
@@ -62,9 +82,17 @@ export function resolveBootConfig(env: NodeJS.ProcessEnv): BootConfig {
     }
     minio = { ...parseEndpoint(endpoint), accessKey, secretKey, bucket: (env.MINIO_BUCKET ?? 'lifecycle-warden').trim() }
   }
-  if (enforceFlag && !minio) {
-    // FAIL-CLOSED: enforcement without durable storage/credentials is refused outright.
-    throw new Error('WARDEN_ENFORCE=on but MinIO credentials are missing — refusing to start (fail-closed). Provide MINIO_ENDPOINT + MINIO_ACCESS_KEY/MINIO_SECRET_KEY via secretEnv.')
+  if (enforce && !minio) {
+    // FAIL-CLOSED: ENFORCING without durable storage/credentials is refused outright —
+    // an enforcing warden with amnesia would re-plan deletes it cannot account for.
+    throw new Error('WARDEN_ENFORCE=on and WARDEN_DRY_RUN=off but MinIO credentials are missing — refusing to start (fail-closed). Provide MINIO_ENDPOINT + MINIO_ACCESS_KEY/MINIO_SECRET_KEY via secretEnv.')
+  }
+  if (enforceFlag && !enforce) {
+    // Declared-but-unenforced, said out loud: the operator asked for enforcement and
+    // is NOT getting it. Silence here is how a governance service ends up believed.
+    warn('[lifecycle-warden] WARN WARDEN_ENFORCE=on but WARDEN_DRY_RUN is not "off" — DRY-RUN WINS: ' +
+      'retention transitions are PLANNED and audited, never applied. Throw BOTH levers to enforce' +
+      (minio ? '' : ' (and provide MinIO credentials — enforcement is refused without them)'))
   }
   return {
     dryRun: !enforce,
@@ -175,12 +203,49 @@ export async function start(cfg: BootConfig, port = PORT, intervalSeconds = INTE
     res.end(s)
   }
 
+  /**
+   * Read a request body, bounded, and ALWAYS settle.
+   *
+   * The bug this replaces: over the cap it called req.destroy(), which emits neither
+   * 'end' nor (necessarily) 'error' — so the promise never settled, the awaiting
+   * handler hung forever, and the client waited on a response that would never come.
+   * Meanwhile 'data' kept concatenating, so the process went on buying memory for a
+   * request it had already given up on. A client abort hung identically.
+   *
+   * Now: settle EXACTLY once, stop accumulating the instant we give up, and treat
+   * 'close'/'aborted' as terminal — a socket that closed without 'end' is a failed
+   * read, not a pending one. Chunks are concatenated as Buffers and decoded once, so
+   * a multi-byte UTF-8 character split across two chunks survives (per-chunk
+   * toString() silently mangled it).
+   */
   function readBody(req: http.IncomingMessage): Promise<string> {
     return new Promise((resolve, reject) => {
-      let d = ''
-      req.on('data', (c: Buffer) => { d += c.toString(); if (d.length > 5_000_000) req.destroy() })
-      req.on('end', () => resolve(d))
-      req.on('error', reject)
+      const chunks: Buffer[] = []
+      let size = 0
+      let settled = false
+      const finish = (fn: () => void): void => { if (settled) return; settled = true; fn() }
+      const fail = (err: Error): void => finish(() => reject(err))
+
+      req.on('data', (c: Buffer) => {
+        if (settled) return // already given up — do not keep buying memory
+        size += c.length
+        if (size > MAX_BODY_BYTES) {
+          // Stop reading and stop buffering, but do NOT destroy here: the handler
+          // still has to put a 413 on the wire, and a destroyed socket cannot carry
+          // one. The catch below answers, then closes.
+          chunks.length = 0
+          req.pause()
+          fail(new PayloadTooLarge(`request body exceeds ${MAX_BODY_BYTES} bytes`))
+          return
+        }
+        chunks.push(c)
+      })
+      req.on('end', () => finish(() => resolve(Buffer.concat(chunks).toString('utf8'))))
+      req.on('error', fail)
+      req.on('aborted', () => fail(new Error('request aborted before the body completed')))
+      // Terminal backstop: after a normal 'end' this is a no-op (already settled);
+      // after destroy() or an abort it is the ONLY event that still fires.
+      req.on('close', () => fail(new Error('request closed before the body completed')))
     })
   }
 
@@ -276,8 +341,20 @@ export async function start(cfg: BootConfig, port = PORT, intervalSeconds = INTE
 
       return json(res, 404, { ok: false, error: `no route: ${req.method} ${p}` })
     })().catch((err: Error) => {
-      res.writeHead(500, { 'content-type': 'application/json' })
-      res.end(JSON.stringify({ ok: false, error: err.message }))
+      // An oversized body is the client's error (413), not the server's. And if the
+      // socket is already gone — the abort/close path — there is nothing to answer to:
+      // writing would throw and mask the original failure.
+      if (res.writableEnded || res.headersSent || !res.socket) return
+      const tooLarge = err instanceof PayloadTooLarge
+      res.writeHead(tooLarge ? err.statusCode : 500, {
+        'content-type': 'application/json',
+        // the client is mid-upload of a body we refuse to read; keeping the
+        // connection alive would only invite the rest of it
+        ...(tooLarge ? { connection: 'close' } : {}),
+      })
+      res.end(JSON.stringify({ ok: false, error: err.message }), () => {
+        if (tooLarge) req.destroy() // answered first, THEN hang up
+      })
     })
   })
 
@@ -316,9 +393,8 @@ if (require.main === module) {
   start(cfg)
     .then((svc) => {
       console.log(`[lifecycle-warden] listening on :${PORT} — mode=${cfg.enforce ? 'ENFORCE' : 'dry-run'} storage=${cfg.minio ? 'minio' : 'memory'} interval=${INTERVAL_S}s`)
-      if ((process.env.WARDEN_ENFORCE ?? 'off').toLowerCase() === 'on' && !cfg.enforce) {
-        console.warn('[lifecycle-warden] WARDEN_ENFORCE=on but WARDEN_DRY_RUN is not "off" — dry-run wins; throw BOTH levers to enforce')
-      }
+      // (the declared-but-unenforced warning is emitted by resolveBootConfig, where
+      //  it is reachable in every configuration and covered by a test)
       // First pass shortly after boot, so healthz shows real lastRun/dueCounts quickly.
       setTimeout(() => { void svc.runNow() }, 3_000).unref()
     })

--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -26,7 +26,9 @@ config:
   # ── W1.3 receipt unification: engine sealed() receipts → THE estate spine ──
   # After each /api/graph/enrich|explore, the sealed engine receipt (sha256 over the ranked
   # output + snapshot {seq,nodes,edges}) is POSTed to compute-gateway POST /v1/engine-receipts
-  # (kind=engine-seal, same namespace — materializer precedent) and the response carries
+  # (body kind=enrich|explore — which of the two engine receipts this is; the gateway then runs
+  # it through its own COMPUTE kind engine-seal, same namespace — materializer precedent)
+  # and the response carries
   # spine:{ok, receiptId}; ONE gateway verify then walks signature → engine hash → snapshot.seq
   # binding end-to-end. Honest degradation by design: gateway unreachable ⇒ the result still
   # serves with spine:{ok:false, reason} and /healthz unsealedReceipts increments — the read

--- a/infra/k8s/workspace-mail/base/backup-cronjob.yaml
+++ b/infra/k8s/workspace-mail/base/backup-cronjob.yaml
@@ -12,7 +12,7 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
-          # REQUIRED for the zot ref above: zot refuses anonymous pulls (401 UNAUTHORIZED).
+          # REQUIRED for the zot image ref below: zot refuses anonymous pulls (401 UNAUTHORIZED).
           # The workspace-mail + workspace-smtp Deployments in this namespace already pull
           # through this same secret; the CronJob never had one because its ghcr ref was
           # never pullable in the first place. Without this line the image fix alone is

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -39,10 +39,19 @@ Six checks, all static (no registry credentials, runs anywhere):
      declaring an explicit foreign image.registry pin: that is the deliberate
      "upstream builds this" statement, and checks 3/4 still govern its tags.
 
-  The tier gate proves its own teeth before checking the repo: a hermetic self-test
-  rebuilds both failure modes (an unannotated Application; a foundation service
-  nothing builds) in a temp fixture on every run and requires them to FAIL. A gate
-  that cannot fail is a comment with a green checkmark.
+SCOPE: every check walks deploy/argocd RECURSIVELY. The root app-of-apps recurses,
+so an ApplicationSet in a subdirectory (deploy/argocd/fogstack/) is exactly as
+deployed as a top-level one. Service discovery used to glob only the top level while
+the tier gate walked the whole tree — so a subdirectory-only service was counted and
+tiered by check 5 but silently exempt from checks 1-4 and 6, and the printed tier
+line described a population the value checks never ran over. A hole in the very gate
+that exists to prove there are no phantom deploys.
+
+  The gate proves its own teeth before checking the repo: a hermetic self-test
+  rebuilds all three failure modes (an unannotated Application; a foundation service
+  nothing builds; a service declared only in a subdirectory) in a temp fixture on
+  every run and requires them to FAIL. A gate that cannot fail is a comment with a
+  green checkmark.
 
 First-party vs third-party is decided by image.registry: third-party values pin a
 foreign registry explicitly (socbase-auth -> docker.io/supabase/gotrue), while
@@ -123,11 +132,10 @@ KNOWN_BROKEN = {
     # RESOLVED 2026-07-29: market-replay likewise — gitops-promote pinned it to
     # sha-6fd49d94… on merge of #1005 (first light: the emitter is live and sha-pinned),
     # so its moving-tag entry now passes and the ratchet requires its deletion.
-        "lifecycle-warden:moving-tag": (
-        "New service — L5 governance executor (apps/lifecycle-warden) added to images.yml this PR. "
-        "Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge. Its "
-        "values set pullPolicy: Always as the interim guard against the moving-tag+IfNotPresent trap."
-    ),
+    # RESOLVED 2026-07-29: lifecycle-warden — gitops-promote sha-pinned it to
+    # sha-9fd245401789 (#1017) after its first CI build, exactly as this entry predicted.
+    # The ratchet only shrinks, and it had already begun FAILING the gate on main for
+    # this reason: fixed → removed, so the warden can never silently regress to `:latest`.
     "entity-resolution:moving-tag": (
         "New service — Dockerfile + images.yml entry added this PR. Pin tag:latest -> sha- after first CI build."
     ),
@@ -227,7 +235,10 @@ def tier_contract(argocd_dir: Path) -> tuple[list[tuple[str, str]], dict[str, st
     problems: list[tuple[str, str]] = []
     tiers: dict[str, str] = {}
     for path in sorted(argocd_dir.rglob("*.yaml")):
-        rel = path.name
+        # Path RELATIVE to deploy/argocd, not just the basename: the walk is
+        # recursive, so "fogstack-appset.yaml" alone cannot tell you which
+        # directory the offending element lives in.
+        rel = path.relative_to(argocd_dir).as_posix()
         text = _live_lines(path.read_text(encoding="utf-8"))
         for doc in re.split(r"^---\s*$", text, flags=re.M):
             kind_m = re.search(r"^kind:\s*(ApplicationSet|Application)\s*$", doc, re.M)
@@ -315,12 +326,26 @@ def check_empty_tag(name: str, image: dict) -> str | None:
     return None
 
 
-def deployed_services() -> set[str]:
-    """Service names from every ApplicationSet list generator under deploy/argocd."""
+def deployed_services(argocd_dir: Path | None = None) -> set[str]:
+    """Service names from every ApplicationSet list generator under deploy/argocd.
+
+    RECURSIVE, and that is the point. Check 5 (tier_contract) has always walked
+    rglob, but this — the set checks 1-4 and 6 actually run over — globbed only the
+    top level, so an ApplicationSet in a subdirectory (deploy/argocd/fogstack/) was
+    silently exempt from the values, build, moving-tag, empty-tag and foundation
+    checks while still being counted and tiered. The root app-of-apps recurses, so
+    a subdirectory ApplicationSet is exactly as deployed as a top-level one: a hole
+    in the very gate that exists to prove there are no phantom deploys.
+
+    Comment-stripped for the same reason tier_contract is: a commented-out element
+    is a breadcrumb, not a deployment, and the two discovery paths must agree on
+    the set — otherwise the printed tier counts describe a different population
+    from the one that was checked.
+    """
     names: set[str] = set()
-    for path in sorted(ARGOCD_DIR.glob("*.yaml")):
-        text = path.read_text(encoding="utf-8")
+    for path in sorted((argocd_dir or ARGOCD_DIR).rglob("*.yaml")):
         # Parse loosely: these files are Go-templated, so yaml.safe_load can choke.
+        text = _live_lines(path.read_text(encoding="utf-8"))
         names |= set(re.findall(r"^\s*-\s*\{\s*name:\s*([a-z0-9][a-z0-9-]*)", text, re.M))
     return names
 
@@ -499,7 +524,44 @@ def run_self_test() -> None:
             )
             raise SystemExit(1)
 
-    print("self-test: both doctrine failure modes still FAIL (untiered app; foundation without build) — teeth verified")
+        # Failure mode C — SCOPE. A service declared only in a SUBDIRECTORY
+        # ApplicationSet must be discovered, or checks 1-4 and 6 silently skip it
+        # while check 5 still counts and tiers it. That was the live hole: the tier
+        # line printed a population the value checks never ran over. A commented-out
+        # element must NOT be discovered — a breadcrumb is not a deployment.
+        (argocd / "sub").mkdir()
+        (argocd / "sub" / "nested-appset.yaml").write_text(
+            "apiVersion: argoproj.io/v1alpha1\n"
+            "kind: ApplicationSet\n"
+            "metadata:\n"
+            "  name: selftest-nested\n"
+            "spec:\n"
+            "  generators:\n"
+            "    - list:\n"
+            "        elements:\n"
+            "          - { name: nested-svc, tier: reference }\n"
+            "          # - { name: retired-svc, tier: reference }\n",
+            encoding="utf-8",
+        )
+        found = deployed_services(argocd)
+        if "nested-svc" not in found:
+            print(
+                "preflight SELF-TEST FAIL: a service declared only in a deploy/argocd "
+                f"SUBDIRECTORY is not discovered (got {sorted(found) or 'nothing'}) — checks 1-4/6 "
+                "would skip it while check 5 still tiers it (the scope hole is back).",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        if "retired-svc" in found:
+            print(
+                "preflight SELF-TEST FAIL: a COMMENTED-OUT element counts as deployed — "
+                "a breadcrumb is not a deployment (_live_lines regression).",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+    print("self-test: all three doctrine failure modes still FAIL (untiered app; foundation "
+          "without build; subdirectory service out of scope) — teeth verified")
 
 
 def main() -> int:


### PR DESCRIPTION
Twelve findings from the Copilot reviews on today's merges (#1009 #1010 #1011 #1012 #1015). Each was **verified against the code before being acted on** — the estate rule is evaluate Copilot, never obey it. Two verdicts came back narrower than reported; both are stated plainly rather than quietly implemented.

Every new test was confirmed to **FAIL against the unfixed code first**.

## MUST FIX

### 1. Policy-kernel bypass via negative price — `apps/hellgraph-service/src/membrane.ts`
**Confirmed, and worse than a rounding concern.** The vendored `OrderIntent` schema types `price` as `number | signed-decimal-string | null` with **no `minimum`**, so a negative price is *spec-valid* and reaches the kernel. `qty × price` then went negative and sailed under `MEMBRANE_MAX_NOTIONAL`: `9999 × -1000000` = -9.999e9, "below" the 1e6 cap, **approved**. That is an approval bypass on the B-after-A gate itself.

- A declared price must now be strictly positive → typed reason `price_not_positive` (absent/`null` stays legal for market orders; limit orders keep `limit_price_required`).
- The notional limit binds `Math.abs(qty × price)` as defence in depth — a minus sign must never satisfy a size cap.
- **Correction to the brief:** non-positive *quantity* was **already** denied by `quantity_not_positive`. No change was needed; a test now pins that it stays covered.

Tests: negative price, zero price, negative quantity, the huge-negative-notional bypass (asserting *both* reasons fire), B refused on the resulting decision, and a market order still approved.

### 2. Idempotency race — `membrane.ts`
**The defect is real; the stated mechanism is not.** Copilot's account — both callers observe "no decision", both evaluate, both write, both seal — is **not reachable**: nothing awaits between the existence check and `addNode`, so no interleaving can occur there even in principle.

What *is* real, reproduced with a test before touching the code: the decision node is written **before** the seal is awaited, so a caller arriving inside the seal window found the node and answered from it — `idempotent: true`, `sealed: false`, `receiptRef: null`. One node and one seal, but **not the same answer**, and "same key twice = the SAME decision, sealed once" is a claim about the *answer*. The pre-fix probe failed exactly there (`concurrent response reported sealed:false`).

Fixed with a single-flight promise map keyed by `idempotencyKey`, checked **before** the stored-node lookup — that ordering is what closes the window, since the map entry outlives the node write and clears only once sealing settles. Test: 8 concurrent decides on one key → one node, one seal, byte-identical responses, exactly one caller credited with making the decision.

### 3. Preflight blind spot — `tools/preflight_deploy_contract.py`
**Confirmed structurally.** Check 5 walked `rglob`; `deployed_services()` globbed only the top level, so a subdirectory ApplicationSet was counted and tiered but never checked by 1–4 or 6 — a hole in the gate that exists to prove there are no phantom deploys. Discovery is now recursive and comment-stripped, so both discovery paths agree on the population.

**Honest scope report — before/after are IDENTICAL:**

| | before | after |
|---|---|---|
| deployed services | 52 | 52 |
| foundation / reference | 17 / 35 | 17 / 35 |
| first-party checked | 41 | 41 |

`deploy/argocd/fogstack/` declares four services (`search-orchestrator`, `eval-fabric-api`, `hellgraph-service`, `reasoning-failure-runner`) and **all four are also declared in top-level ApplicationSets**, so they were already being checked. Nothing newly came into scope, nothing newly failed, and **nothing was ratcheted to hide a failure**. The hole was latent, not live — reported as such rather than dressed up as a save.

A **third self-test failure mode** now proves the recursion can't silently regress (verified: reverting `rglob`→`glob` makes the gate fail loudly), and that a commented-out element is still not a deployment.

### 4. `readBody()` could hang forever — `apps/lifecycle-warden/src/server.ts`
**Confirmed.** Over the 5MB cap it called `req.destroy()`, which emits neither `'end'` nor necessarily `'error'` — the promise never settled, the handler awaited a body that would never arrive, and `'data'` kept concatenating for a request already abandoned. A client abort hung identically. Now: settle **exactly once**, stop accumulating on give-up, treat `close`/`aborted`/`error` as terminal, and answer **413** before hanging up. Chunks are concatenated as Buffers and decoded once, so a multi-byte UTF-8 character split across chunks survives (per-chunk `toString()` silently mangled it). Test asserts a real 413 arrives within 5s and the server stays healthy after.

### 5. Warden fail-closed vs. its two-lever contract — `lifecycle-warden/src/server.ts`
**Agreed with the verdict, with one factual correction.** The refusal now tracks *actual* enforcement (`ENFORCE=on` AND `DRY_RUN=off`); dry-run boots and warns loudly. The old behaviour was **inconsistent**, which is the sharper argument for the change: `ENFORCE=on` + `DRY_RUN=on` booted happily whenever creds happened to be present, and refused only when they weren't.

**Correction:** the "dry-run wins" warning was not globally unreachable — only in the credential-less case. It is now emitted from `resolveBootConfig` with an injectable `warn`, so it is reachable in **every** configuration and covered by a test, instead of stranded in the `require.main` entrypoint. The true fail-closed path is intact and still tested. Module docstring updated to match.

### 6. `uniqueItems` key-order dependence — `apps/hellgraph-service/src/contract.ts`
**Verified first, as asked — and it does apply.** `ExecutionReport.provenanceLinks` and `OrderIntent.provenanceLinks` are both `uniqueItems` arrays of **objects** (`{rel, ref}`). So `[{rel,ref},{ref,rel}]` — one duplicate typed two ways — passed. Comparison now canonicalizes via the existing `canonicalJson` (recursive key sort), keeping one notion of "the same value" in a file whose whole job is canonical bytes. New `contract.test.ts` asserts the schemas still have that shape (so the test can't quietly become moot), rejects reordered-key and literal duplicates, and confirms genuinely different links still pass.

### 7. `verify_walk()` overclaim — `apps/compute-gateway/.../engine_receipts.py`
**Confirmed.** Step 1 reported `gateway-signature: ok` on mere *membership* plus its own id-hash. "On the chain" is a claim about **order**, and neither a reordered chain nor a broken earlier prev-link was excluded. Took the preferred fix: the walk now re-derives the receipt's **position** — every predecessor's id-hash recomputed and every prev-link followed from genesis — before attesting anything. Docstring states the exact guarantee; step name kept for consumer compatibility.

Two tamper tests, both confirmed to fail against the old code: a **reordered chain**, and a **tampered predecessor** whose target receipt still re-hashes perfectly (the case the old step waved through). A receipt earlier than the tampering still verifies — the walk checks the prefix each receipt actually depends on.

## ALSO FIX (inaccurate docs are real defects here)

8. **`server.py`** — "Always 200" ignored `require_token`'s 401/503. Now states that auth refuses first, and that *past auth* the typed trace is always the result.
9. **`spine.ts`** — `degrade()` warned once per request, so a gateway outage under load buried the incident it was reporting. The **log** is throttled (`SPINE_WARN_INTERVAL_MS`, default 60s) and each emitted line reports how many it suppressed; the `unsealedReceipts` **counter is never sampled** — the metric is the alarm, and an alarm may not be sampled. Test: 25 failures in a throttled window produce 0 lines, the counter still moves 25, and the next line admits `+25 suppressed`.
10. **`deploy/values/hellgraph-service.yaml`** — the POST body kind is `enrich|explore`; `engine-seal` is the gateway's own COMPUTE kind. **`spine.ts` carried the same error** beyond the reported file; both corrected.
11. **preflight** — `tier_contract()` reports paths relative to `deploy/argocd` instead of bare basenames, now that the walk is recursive.
12. **`backup-cronjob.yaml`** — the zot ref is *below* the comment, not above.

## Unasked-for but blocking: the ratchet had already broken main

`origin/main` **fails preflight (exit 1)** independently of this PR: gitops-promote sha-pinned `lifecycle-warden` in #1017 without shrinking `KNOWN_BROKEN`, so its entry now passes and the ratchet correctly demands deletion. Verified on a clean `origin/main` checkout. Entry removed with a RESOLVED breadcrumb, per the gate's own protocol.

## Gates (rebased on `947cf5f5`)

| suite | before | after |
|---|---|---|
| `apps/hellgraph-service` (npm test) | 73 | **79** |
| `apps/compute-gateway` (pytest) | 112 | **114** |
| `apps/lifecycle-warden` (npm test) | 25 | **27** |

All green. `python3 tools/preflight_deploy_contract.py` → **exit 0** (was exit 1 on main). `helm template` clean for the touched values file; `kubectl kustomize infra/k8s/workspace-mail/base` clean. `lifecycle-warden` typecheck clean.

**Honest deviation:** `apps/hellgraph-service` `npm run typecheck` reports 2 pre-existing `TS1343 import.meta` errors in `src/server.ts` — **present on `origin/main`, in a file this PR does not touch**, and not introduced here. Left alone: fixing them means changing the tsconfig module mode, which is its own blast radius and its own PR.