### PR TITLE
fix(ci): mint generator died of SIGPIPE — use openssl, no pipeline

### DIFF
--- a/.github/workflows/provision-secrets.yml
+++ b/.github/workflows/provision-secrets.yml
@@ -126,8 +126,9 @@ jobs:
       # own password, then this Secret, then restart consumers) — a workflow input alone cannot
       # make that safe, so it warns loudly and still refuses to touch an initialized volume.
       #
-      # Charset is alphanumeric on purpose: base64 emits '/', '+' and '=', which are hazardous
-      # inside connection strings and URL-encoded config. 32 chars of [A-Za-z0-9] is ~190 bits.
+      # Charset is hex on purpose: base64 emits '/', '+' and '=', which are hazardous inside
+      # connection strings and URL-encoded config. 48 hex chars is 192 bits — more than enough,
+      # and it cannot break a DSN.
       - name: Mint clickhouse-admin (create-if-absent)
         env:
           ONLY: ${{ inputs.only }}
@@ -154,8 +155,13 @@ jobs:
             echo "⚠ now fail to authenticate. Restart clickhouse AND prophet-materializer-clickhouse."
           fi
 
-          PW=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32)
-          [ ${#PW} -eq 32 ] || { echo "✗ generator produced ${#PW} chars, refusing"; exit 1; }
+          # openssl, not `tr -dc … | head -c N`: when head closes the pipe after N bytes, tr dies
+          # of SIGPIPE and the pipeline returns non-zero, so under `bash -e` the step fails AFTER
+          # having possibly applied nothing — which is exactly how the first run of this step died
+          # ("tr: write error: Broken pipe"). openssl needs no pipeline at all.
+          PW=$(openssl rand -hex 24)
+          [ ${#PW} -eq 48 ] || { echo "✗ generator produced ${#PW} chars, refusing"; exit 1; }
+          case "$PW" in *[!0-9a-f]*) echo "✗ generator produced non-hex output, refusing"; exit 1;; esac
           echo "::add-mask::$PW"
 
           kubectl create secret generic "$NAME" -n "$NS" \

--- a/deploy/values/clickhouse.yaml
+++ b/deploy/values/clickhouse.yaml
@@ -20,8 +20,8 @@
 # useless in-cluster — so the password Secret is REQUIRED (fail-closed, not optional).
 # PREREQ (out of band — never commit secrets):
 #   Actions → provision-secrets → Run workflow   (mints it; nobody ever handles the value)
-# The password is MINTED IN CI, not typed by a human: the provision-secrets workflow generates 32
-# alphanumeric chars and applies the Secret over WIF. It is CREATE-IF-ABSENT — ClickHouse persists
+# The password is MINTED IN CI, not typed by a human: the provision-secrets workflow generates 48
+# hex chars (192 bits) and applies the Secret over WIF. It is CREATE-IF-ABSENT — ClickHouse persists
 # its admin password into the data volume on first init, so silently regenerating the Secret later
 # would leave the server and its clients disagreeing. Deliberate rotation = the `rotate` input PLUS
 # rotating the server's own password in the same window, then restarting clickhouse and


### PR DESCRIPTION
## What happened

The first real run of the new mint step (added in #1022) **failed**:

```
tr: write error: Broken pipe
##[error]Process completed with exit code 1
```

`tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32` is a trap I walked into: `head` closes the pipe once it has its 32 bytes, `tr` then dies of `SIGPIPE`, the pipeline returns non-zero, and under the runner's `bash -e` the step fails — **after having applied nothing**. So `clickhouse-admin` was never created and both pods stayed in `CreateContainerConfigError`. My bug.

## The fix

`openssl rand -hex 24` — no pipeline, so there is no pipe to break. 48 hex characters, 192 bits, and still free of the `/`, `+` and `=` that make base64 hazardous inside a DSN or URL-encoded config.

Both properties are now **asserted before the Secret is applied** — length and charset — so a malformed generator refuses to mint rather than quietly producing something surprising:

```bash
PW=$(openssl rand -hex 24)
[ ${#PW} -eq 48 ] || { echo "✗ generator produced ${#PW} chars, refusing"; exit 1; }
case "$PW" in *[!0-9a-f]*) echo "✗ generator produced non-hex output, refusing"; exit 1;; esac
```

## Verification

I extracted the exact step body from the workflow and ran it under `bash -e` before pushing — `generated len=48 ok`. I also reproduced the original form failing locally, so the diagnosis is the cause and not a guess.

Everything else about the mint step stands as reviewed in #1022: create-if-absent, masked, applied over the existing WIF path, rotation opt-in with the coordination warning. `deploy/values/clickhouse.yaml` updated so its description matches (48 hex, not 32 alphanumeric).

## After merge

Re-run `Actions → provision-secrets` with `only: clickhouse-admin`. Acceptance is unchanged and is **not** "the workflow went green": `clickhouse` and `prophet-materializer-clickhouse` must both leave `CreateContainerConfigError`, the materializer must *authenticate* (proving server and client agree on the minted value), and rows must land in `hellgraph.events` from the backlog the live emitter has been accumulating.