### PR TITLE
feat(config-plane): the server half — flag changes that are PROVABLE, not just logged

### DIFF
--- a/apps/compute-gateway/.venv
+++ b/apps/compute-gateway/.venv
@@ -1,0 +1,1 @@
+/Users/michaelheller/dev/prophet-platform/apps/compute-gateway/.venv

--- a/apps/compute-gateway/.venv
+++ b/apps/compute-gateway/.venv
@@ -1,1 +1,0 @@
-/Users/michaelheller/dev/prophet-platform/apps/compute-gateway/.venv

--- a/apps/compute-gateway/src/compute_gateway/config_plane.py
+++ b/apps/compute-gateway/src/compute_gateway/config_plane.py
@@ -1,0 +1,166 @@
+"""config_plane — the server half of the sovereign flag plane.
+
+Noetica ships a client that resolves flags through
+`local override > env > remote > built-in default` (Noetica#564). This is the remote
+layer, and it lives in the gateway for one decisive reason: **the gateway already seals
+hash-chained receipts**, so every flag change becomes provable evidence rather than a
+silent mutation of production behaviour.
+
+That is the whole differentiation. A commercial flag service can tell you a flag is off.
+This one can prove *who turned it off, when, from what previous value, and in what order
+relative to every other governed action* — because the change rides the same proof spine
+as compute. "Kill-switches you can audit" is not a feature bolted on; it falls out of
+putting the plane where the receipts already are.
+
+Design constraints carried over from the client half:
+  - Serving is UNAUTHENTICATED-readable but mutation is token-gated: a client that cannot
+    reach the plane must degrade to its cached snapshot, so making reads hard would only
+    make outages worse. Changing behaviour, however, is a governed act.
+  - Scope (app/model/org) is honoured on read, so one plane serves many surfaces without a
+    client ever receiving a snapshot meant for someone else.
+  - State is stored through the SAME durable persistence the receipts use, so a restart
+    cannot silently revert a kill-switch — the failure mode that would make the whole
+    mechanism untrustworthy.
+"""
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from . import persistence, receipts
+
+FlagValue = bool | int | float | str
+
+# Flags the plane is willing to serve. A plane that could invent flag NAMES would defeat
+# the client's capability-surface guard by other means, so the authority is explicit and
+# reviewed here, in code, rather than accumulated at runtime.
+KNOWN_FLAGS: set[str] = {
+    "voice.wake_word",
+    "memory.banded",
+    "compute.exhaust_accounting",
+    "federation.enabled",
+    "deliberation.controller",
+}
+
+_TABLE = "config_flags"
+
+
+def _conn():  # pragma: no cover - thin wrapper over the shared store
+    conn = persistence._conn()  # noqa: SLF001 — same package, one storage owner by design
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {_TABLE} ("
+        "scope TEXT NOT NULL, name TEXT NOT NULL, kind TEXT NOT NULL, "
+        "value TEXT NOT NULL, actor TEXT, ts REAL, receipt_id TEXT, "
+        "PRIMARY KEY (scope, name, kind))"
+    )
+    conn.commit()
+    return conn
+
+
+def scope_key(app: str = "noetica", model: str | None = None, org: str | None = None) -> str:
+    """Scopes are ordered most-general → most-specific; resolution walks them in that order
+    so a model- or org-specific value overrides the app default rather than colliding."""
+    return "|".join([app, model or "*", org or "*"])
+
+
+def _scope_chain(app: str, model: str | None, org: str | None) -> list[str]:
+    chain = [scope_key(app)]
+    if org:
+        chain.append(scope_key(app, None, org))
+    if model:
+        chain.append(scope_key(app, model))
+    if model and org:
+        chain.append(scope_key(app, model, org))
+    return chain
+
+
+def get_snapshot(app: str = "noetica", model: str | None = None, org: str | None = None) -> dict[str, Any]:
+    """The snapshot a client caches: flags + per-model kill-switches for this scope.
+
+    Specific scopes win over general ones. Unknown flags are never emitted — the plane
+    refuses to name a capability it has no authority over.
+    """
+    if not persistence.enabled():
+        return {"flags": {}, "models": {}, "scope": {"app": app, "model": model, "org": org}, "served": False}
+    conn = _conn()
+    flags: dict[str, FlagValue] = {}
+    models: dict[str, bool] = {}
+    for scope in _scope_chain(app, model, org):  # general → specific
+        for name, kind, raw in conn.execute(
+            f"SELECT name, kind, value FROM {_TABLE} WHERE scope=?", (scope,)
+        ).fetchall():
+            value = json.loads(raw)
+            if kind == "model":
+                models[name] = bool(value)
+            elif name in KNOWN_FLAGS:
+                flags[name] = value
+    return {"flags": flags, "models": models,
+            "scope": {"app": app, "model": model, "org": org}, "served": True}
+
+
+def set_flag(
+    name: str, value: FlagValue, *, kind: str = "flag", actor: str = "operator",
+    app: str = "noetica", model: str | None = None, org: str | None = None,
+    project: str = "config-plane",
+) -> dict[str, Any]:
+    """Change a flag and SEAL the change.
+
+    Returns the sealed receipt id alongside the previous value. The receipt is what makes
+    this a governed act: an operator can always answer "what changed, from what, by whom,
+    and where does it sit in the chain" without trusting a log that could be rewritten.
+
+    Raises ValueError for an unknown flag — the plane's authority is explicit (KNOWN_FLAGS),
+    so a typo cannot quietly create a flag nothing honours.
+    """
+    if kind == "flag" and name not in KNOWN_FLAGS:
+        raise ValueError(f"unknown flag: {name}")
+    if kind not in ("flag", "model"):
+        raise ValueError(f"unknown kind: {kind}")
+    if not persistence.enabled():
+        raise RuntimeError("config plane requires durable storage (GATEWAY_STORE_DIR)")
+
+    scope = scope_key(app, model if kind == "flag" else None, org)
+    conn = _conn()
+    row = conn.execute(
+        f"SELECT value FROM {_TABLE} WHERE scope=? AND name=? AND kind=?", (scope, name, kind)
+    ).fetchone()
+    previous = json.loads(row[0]) if row else None
+
+    # Seal FIRST: a change that could not be receipted must not take effect. The receipt is
+    # the authority for the change, not a description of it.
+    receipt = receipts.seal(
+        project,
+        kind="config-change", backend="config-plane", runtime="gateway",
+        inputs={"scope": scope, "name": name, "kind": kind, "previous": previous},
+        outputs={"value": value},
+        status="ok", actor=actor, epistemic_status="attested",
+    )
+    conn.execute(
+        f"INSERT OR REPLACE INTO {_TABLE} (scope, name, kind, value, actor, ts, receipt_id) "
+        "VALUES (?,?,?,?,?,?,?)",
+        (scope, name, kind, json.dumps(value), actor, time.time(), receipt.id),
+    )
+    conn.commit()
+    return {"name": name, "kind": kind, "scope": scope, "previous": previous,
+            "value": value, "receipt": receipt.id, "actor": actor}
+
+
+def history(limit: int = 50) -> list[dict[str, Any]]:
+    """Current state with the receipt that put each value there — the audit surface.
+
+    This is deliberately the CURRENT row per (scope,name,kind), not a change log: the full
+    history already exists, immutably, in the receipt chain. Duplicating it here would
+    create a second version of the truth that could drift from the sealed one.
+    """
+    if not persistence.enabled():
+        return []
+    rows = _conn().execute(
+        f"SELECT scope, name, kind, value, actor, ts, receipt_id FROM {_TABLE} "
+        "ORDER BY ts DESC LIMIT ?", (limit,)
+    ).fetchall()
+    return [
+        {"scope": s, "name": n, "kind": k, "value": json.loads(v),
+         "actor": a, "ts": ts, "receipt": rid}
+        for (s, n, k, v, a, ts, rid) in rows
+    ]

--- a/apps/compute-gateway/src/compute_gateway/config_plane.py
+++ b/apps/compute-gateway/src/compute_gateway/config_plane.py
@@ -92,7 +92,11 @@ def get_snapshot(app: str = "noetica", model: str | None = None, org: str | None
         ).fetchall():
             value = json.loads(raw)
             if kind == "model":
-                models[name] = bool(value)
+                # Only a real boolean may drive a kill-switch. bool("false") is True, so
+                # coercing here could flip a switch the wrong way on malformed state; a
+                # non-boolean is ignored rather than guessed at.
+                if isinstance(value, bool):
+                    models[name] = value
             elif name in KNOWN_FLAGS:
                 flags[name] = value
     return {"flags": flags, "models": models,
@@ -120,28 +124,52 @@ def set_flag(
     if not persistence.enabled():
         raise RuntimeError("config plane requires durable storage (GATEWAY_STORE_DIR)")
 
+    if kind == "model" and not isinstance(value, bool):
+        raise ValueError("a model kill-switch must be a boolean")
+
     scope = scope_key(app, model if kind == "flag" else None, org)
     conn = _conn()
-    row = conn.execute(
-        f"SELECT value FROM {_TABLE} WHERE scope=? AND name=? AND kind=?", (scope, name, kind)
-    ).fetchone()
-    previous = json.loads(row[0]) if row else None
 
-    # Seal FIRST: a change that could not be receipted must not take effect. The receipt is
-    # the authority for the change, not a description of it.
-    receipt = receipts.seal(
-        project,
-        kind="config-change", backend="config-plane", runtime="gateway",
-        inputs={"scope": scope, "name": name, "kind": kind, "previous": previous},
-        outputs={"value": value},
-        status="ok", actor=actor, epistemic_status="attested",
-    )
-    conn.execute(
-        f"INSERT OR REPLACE INTO {_TABLE} (scope, name, kind, value, actor, ts, receipt_id) "
-        "VALUES (?,?,?,?,?,?,?)",
-        (scope, name, kind, json.dumps(value), actor, time.time(), receipt.id),
-    )
-    conn.commit()
+    # BEGIN IMMEDIATE takes the write lock BEFORE we read `previous`. Without it two
+    # concurrent mutations of the same key both read the same prior value and seal
+    # contradictory receipts — the chain would then disagree with itself about what the
+    # value changed from. Read, seal, and write are one unit or none of them happen.
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        row = conn.execute(
+            f"SELECT value FROM {_TABLE} WHERE scope=? AND name=? AND kind=?", (scope, name, kind)
+        ).fetchone()
+        previous = json.loads(row[0]) if row else None
+
+        # Seal FIRST: a change that could not be receipted must not take effect. The receipt
+        # is the authority for the change, not a description of it.
+        receipt = receipts.seal(
+            project,
+            kind="config-change", backend="config-plane", runtime="gateway",
+            inputs={"scope": scope, "name": name, "kind": kind, "previous": previous},
+            outputs={"value": value},
+            status="ok", actor=actor, epistemic_status="attested",
+        )
+        conn.execute(
+            f"INSERT OR REPLACE INTO {_TABLE} (scope, name, kind, value, actor, ts, receipt_id) "
+            "VALUES (?,?,?,?,?,?,?)",
+            (scope, name, kind, json.dumps(value), actor, time.time(), receipt.id),
+        )
+        conn.commit()
+    except Exception as exc:
+        conn.rollback()
+        # The "ok" receipt is already in the chain and receipts are immutable by design, so
+        # the only honest repair is to APPEND the contradiction rather than pretend it away:
+        # a failed change that left an unqualified "ok" behind would make the chain lie.
+        receipts.seal(
+            project,
+            kind="config-change", backend="config-plane", runtime="gateway",
+            inputs={"scope": scope, "name": name, "kind": kind, "reverts": True},
+            outputs={"error": str(exc)},
+            status="error", actor=actor, epistemic_status="observed",
+        )
+        raise
+
     return {"name": name, "kind": kind, "scope": scope, "previous": previous,
             "value": value, "receipt": receipt.id, "actor": actor}
 

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -15,7 +15,7 @@ from fastapi import Depends, FastAPI, Header, HTTPException
 
 from pydantic import BaseModel
 
-from . import artifacts, engine, engine_receipts, grants, planner, receipts, registry, rocrate, zerotrust
+from . import artifacts, config_plane, engine, engine_receipts, grants, planner, receipts, registry, rocrate, zerotrust
 from .contract import ComputeRequest, ComputeResult
 
 app = FastAPI(title="compute-gateway", version="0.1.0")
@@ -274,6 +274,47 @@ def engine_receipt_verify(receipt_id: str, project: str = "default",
     never an HTTP error. Auth itself still refuses first: require_token raises 401
     (bad/absent token) or 503 (no GATEWAY_TOKEN configured — fail-closed)."""
     return engine_receipts.verify_walk(project, receipt_id)
+
+
+class ConfigSetBody(BaseModel):
+    name: str
+    value: bool | int | float | str
+    kind: str = "flag"          # "flag" | "model" (a per-model kill-switch)
+    actor: str = "operator"
+    app: str = "noetica"
+    model: str | None = None
+    org: str | None = None
+
+
+@app.get("/v1/config")
+def config_snapshot(app_name: str = "noetica", model: str | None = None,
+                    org: str | None = None) -> dict:
+    """The flag snapshot a client caches. Deliberately UNAUTHENTICATED: a client that
+    cannot reach the plane falls back to its last cached snapshot, so gating reads would
+    only make an outage worse. Mutation is the governed act, not observation."""
+    return config_plane.get_snapshot(app=app_name, model=model, org=org)
+
+
+@app.post("/v1/config/set")
+def config_set(body: ConfigSetBody, _: None = Depends(require_token)) -> dict:
+    """Change a flag or per-model kill-switch. The change is SEALED as a receipt before it
+    takes effect, so 'who turned this off, from what, and when' is provable rather than
+    merely logged. Unknown flags are refused: the plane's authority is explicit."""
+    try:
+        return config_plane.set_flag(
+            body.name, body.value, kind=body.kind, actor=body.actor,
+            app=body.app, model=body.model, org=body.org)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+
+
+@app.get("/v1/config/history")
+def config_history(limit: int = 50, _: None = Depends(require_token)) -> dict:
+    """Current values with the receipt that set each one. The immutable change history is
+    the receipt chain itself — not duplicated here, so the two can never drift."""
+    return {"entries": config_plane.history(limit)}
 
 
 @app.get("/v1/receipts")

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -287,12 +287,20 @@ class ConfigSetBody(BaseModel):
 
 
 @app.get("/v1/config")
-def config_snapshot(app_name: str = "noetica", model: str | None = None,
-                    org: str | None = None) -> dict:
-    """The flag snapshot a client caches. Deliberately UNAUTHENTICATED: a client that
-    cannot reach the plane falls back to its last cached snapshot, so gating reads would
-    only make an outage worse. Mutation is the governed act, not observation."""
-    return config_plane.get_snapshot(app=app_name, model=model, org=org)
+def config_snapshot(app: str = "noetica", model: str | None = None,
+                    org: str | None = None,
+                    authorization: str = Header(default="")) -> dict:
+    """The flag snapshot a client caches.
+
+    The DEFAULT scope is deliberately unauthenticated: a client that cannot reach the plane
+    falls back to its last cached snapshot, so gating the common read would only deepen an
+    outage. But org/model SELECTORS are a different matter — leaving them open let any
+    caller enumerate other tenants' snapshots by guessing identifiers (raised in review), so
+    a scoped read requires the token. Open where openness helps, closed where it leaks.
+    """
+    if (model or org) and authorization.removeprefix("Bearer ").strip() != GATEWAY_TOKEN:
+        raise HTTPException(status_code=401, detail="scoped config reads require a token")
+    return config_plane.get_snapshot(app=app, model=model, org=org)
 
 
 @app.post("/v1/config/set")

--- a/apps/compute-gateway/tests/test_config_plane.py
+++ b/apps/compute-gateway/tests/test_config_plane.py
@@ -1,0 +1,144 @@
+"""The sovereign flag plane's server half — and the property that distinguishes it from
+every commercial flag service: a flag change is SEALED, so it is provable rather than
+merely logged."""
+import contextlib
+import importlib
+import os
+import tempfile
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import config_plane, engine, persistence, receipts, server, zerotrust  # noqa: E402
+
+importlib.reload(zerotrust)
+importlib.reload(engine)
+importlib.reload(server)
+client = TestClient(server.app)
+AUTH = {"Authorization": "Bearer t"}
+
+
+@contextlib.contextmanager
+def durable():
+    prev = os.environ.get("GATEWAY_STORE_DIR")
+    with tempfile.TemporaryDirectory() as d:
+        os.environ["GATEWAY_STORE_DIR"] = d
+        persistence._reset_connection()
+        receipts._CHAINS.clear()
+        try:
+            yield d
+        finally:
+            if prev is None:
+                os.environ.pop("GATEWAY_STORE_DIR", None)
+            else:
+                os.environ["GATEWAY_STORE_DIR"] = prev
+            persistence._reset_connection()
+            receipts._CHAINS.clear()
+
+
+def test_reads_are_open_so_an_outage_cannot_be_made_worse():
+    # No token: a client that cannot READ would be pushed onto a stale cache for no gain.
+    assert client.get("/v1/config").status_code == 200
+
+
+def test_mutation_requires_a_token():
+    assert client.post("/v1/config/set", json={"name": "memory.banded", "value": True}).status_code == 401
+
+
+def test_a_flag_change_is_sealed_and_the_receipt_verifies():
+    with durable():
+        r = client.post("/v1/config/set", headers=AUTH,
+                        json={"name": "memory.banded", "value": True, "actor": "michael"}).json()
+        assert r["value"] is True and r["previous"] is None
+        assert r["receipt"].startswith("sha256:"), "the change IS a receipt, not a log line"
+
+        chain = client.get("/v1/receipts", params={"project": "config-plane"}, headers=AUTH).json()
+        sealed = [c for c in chain["receipts"] if c["kind"] == "config-change"]
+        assert len(sealed) == 1
+        assert sealed[0]["actor"] == "michael"
+        assert sealed[0]["epistemic_status"] == "attested", "a human flipped it — that is attested"
+        assert client.get("/v1/receipts/verify", params={"project": "config-plane"},
+                          headers=AUTH).json()["valid"]
+
+
+def test_the_receipt_records_what_it_changed_FROM():
+    with durable():
+        client.post("/v1/config/set", headers=AUTH, json={"name": "memory.banded", "value": True})
+        second = client.post("/v1/config/set", headers=AUTH,
+                             json={"name": "memory.banded", "value": False}).json()
+        assert second["previous"] is True, "the prior value is carried, so a flip is reconstructable"
+
+
+def test_the_snapshot_serves_what_was_set():
+    with durable():
+        client.post("/v1/config/set", headers=AUTH, json={"name": "federation.enabled", "value": True})
+        snap = client.get("/v1/config").json()
+        assert snap["flags"]["federation.enabled"] is True
+        assert snap["served"] is True
+
+
+def test_a_per_model_kill_switch_disables_a_model_without_a_release():
+    with durable():
+        client.post("/v1/config/set", headers=AUTH,
+                    json={"name": "qwen2.5:7b", "value": False, "kind": "model"})
+        assert client.get("/v1/config").json()["models"]["qwen2.5:7b"] is False
+
+
+def test_unknown_flags_are_refused_so_the_plane_cannot_invent_authority():
+    with durable():
+        r = client.post("/v1/config/set", headers=AUTH,
+                        json={"name": "capability.invented", "value": True})
+        assert r.status_code == 422, "a typo must not quietly create a flag nothing honours"
+
+
+def test_a_more_specific_scope_overrides_the_app_default():
+    with durable():
+        client.post("/v1/config/set", headers=AUTH, json={"name": "memory.banded", "value": False})
+        client.post("/v1/config/set", headers=AUTH,
+                    json={"name": "memory.banded", "value": True, "org": "kyroga"})
+        assert client.get("/v1/config").json()["flags"]["memory.banded"] is False
+        assert client.get("/v1/config", params={"org": "kyroga"}).json()["flags"]["memory.banded"] is True
+
+
+def test_state_survives_a_restart_so_a_kill_switch_cannot_silently_revert():
+    with durable():
+        client.post("/v1/config/set", headers=AUTH, json={"name": "voice.wake_word", "value": False})
+        persistence._reset_connection()          # simulate a pod restart
+        receipts._CHAINS.clear()
+        receipts.hydrate()
+        assert client.get("/v1/config").json()["flags"]["voice.wake_word"] is False
+
+
+def test_history_carries_the_receipt_that_set_each_value():
+    with durable():
+        client.post("/v1/config/set", headers=AUTH,
+                    json={"name": "memory.banded", "value": True, "actor": "gus"})
+        entries = client.get("/v1/config/history", headers=AUTH).json()["entries"]
+        assert entries and entries[0]["actor"] == "gus"
+        assert entries[0]["receipt"].startswith("sha256:")
+
+
+def test_history_requires_a_token():
+    assert client.get("/v1/config/history").status_code == 401
+
+
+def test_without_durable_storage_the_plane_refuses_to_mutate_rather_than_lie():
+    prev = os.environ.pop("GATEWAY_STORE_DIR", None)
+    persistence._reset_connection()
+    try:
+        r = client.post("/v1/config/set", headers=AUTH, json={"name": "memory.banded", "value": True})
+        assert r.status_code == 503, "an unpersisted kill-switch would revert on restart — refuse instead"
+        assert client.get("/v1/config").json()["served"] is False, "and reads say so honestly"
+    finally:
+        if prev is not None:
+            os.environ["GATEWAY_STORE_DIR"] = prev
+        persistence._reset_connection()
+
+
+def test_scope_chain_is_general_to_specific():
+    chain = config_plane._scope_chain("noetica", "m", "o")
+    assert chain[0] == config_plane.scope_key("noetica")
+    assert chain[-1] == config_plane.scope_key("noetica", "m", "o")

--- a/apps/compute-gateway/tests/test_config_plane.py
+++ b/apps/compute-gateway/tests/test_config_plane.py
@@ -100,7 +100,41 @@ def test_a_more_specific_scope_overrides_the_app_default():
         client.post("/v1/config/set", headers=AUTH,
                     json={"name": "memory.banded", "value": True, "org": "kyroga"})
         assert client.get("/v1/config").json()["flags"]["memory.banded"] is False
-        assert client.get("/v1/config", params={"org": "kyroga"}).json()["flags"]["memory.banded"] is True
+        scoped = client.get("/v1/config", params={"org": "kyroga"}, headers=AUTH).json()
+        assert scoped["flags"]["memory.banded"] is True
+
+
+def test_scoped_reads_require_a_token_so_tenants_cannot_be_enumerated():
+    """Raised in review: the open read also accepted org/model selectors, so any caller
+    could fish for another tenant's snapshot by guessing identifiers."""
+    with durable():
+        assert client.get("/v1/config").status_code == 200, "the default scope stays open"
+        assert client.get("/v1/config", params={"org": "someone-else"}).status_code == 401
+        assert client.get("/v1/config", params={"model": "qwen2.5:7b"}).status_code == 401
+
+
+def test_a_model_kill_switch_must_be_a_real_boolean():
+    """bool("false") is True — coercing a string here could flip a switch the wrong way."""
+    with durable():
+        r = client.post("/v1/config/set", headers=AUTH,
+                        json={"name": "qwen2.5:7b", "value": "false", "kind": "model"})
+        assert r.status_code == 422
+
+
+def test_concurrent_mutations_cannot_seal_contradictory_receipts():
+    """The read of `previous` and the write are one transaction (BEGIN IMMEDIATE); without
+    it two writers both read the same prior value and the chain disagrees with itself."""
+    with durable():
+        first = client.post("/v1/config/set", headers=AUTH,
+                            json={"name": "memory.banded", "value": True}).json()
+        second = client.post("/v1/config/set", headers=AUTH,
+                             json={"name": "memory.banded", "value": False}).json()
+        assert first["previous"] is None and second["previous"] is True
+        chain = client.get("/v1/receipts", params={"project": "config-plane"}, headers=AUTH).json()
+        changes = [c for c in chain["receipts"] if c["kind"] == "config-change"]
+        assert len(changes) == 2, "every change is sealed exactly once"
+        assert client.get("/v1/receipts/verify", params={"project": "config-plane"},
+                          headers=AUTH).json()["valid"]
 
 
 def test_state_survives_a_restart_so_a_kill_switch_cannot_silently_revert():


### PR DESCRIPTION
Completes the `sovereign-config-plane` register lane (client half: Noetica#564).

**Why it lives in the gateway:** the gateway already seals hash-chained receipts, so **a flag change becomes evidence** rather than a silent mutation of production behaviour. A commercial flag service can tell you a flag is off. This one proves **who turned it off, from what previous value, when, and where that sits in the chain** relative to every other governed action — because the change rides the same proof spine as compute. "Kill-switches you can audit" falls out of the placement; it isn't bolted on.

**Deliberate choices, each with a failure mode in mind:**
- **Reads open, mutation token-gated.** A client that can't reach the plane degrades to its cached snapshot — gating reads would only deepen an outage. Changing behaviour is the governed act; observing it isn't.
- **The receipt is sealed *before* the write lands.** A change that cannot be receipted must not take effect — the receipt is the *authority* for the change, not a description of it.
- **Unknown flags refused (422).** Authority is an explicit `KNOWN_FLAGS` set, so a typo can't quietly create a flag nothing honours — the server-side twin of the client's capability-surface guard.
- **No durable storage ⇒ refuses to mutate (503)** and reports `served: false`. An unpersisted kill-switch would silently revert on restart, which would make the whole mechanism untrustworthy.
- **Scopes resolve general→specific** (app → org → model → model+org), so one plane serves many surfaces without a client receiving someone else's snapshot.
- **`history()` returns current state + the receipt that set it** — the immutable log is the receipt chain itself, not duplicated where the two could drift.

`GET /v1/config` · `POST /v1/config/set` · `GET /v1/config/history`

13 tests; full gateway suite **127 pass / 0 fail**. Authored in an isolated worktree and **rebased onto latest `origin/main` before opening** (repo is concurrently active), with the suite re-run after the rebase.