### PR TITLE
fix(hellgraph-service): use __dirname, not import.meta — typecheck green again

### DIFF
--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -35,7 +35,6 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import * as fs from 'node:fs'
 import * as zlib from 'node:zlib'
-import { fileURLToPath } from 'node:url'
 
 // Storage isolation: this service must NOT share Noetica's single-writer JSONL
 // store. Set a service-local store dir BEFORE the engine's lazy getAtomSpace()
@@ -494,7 +493,7 @@ function seedIfEmpty(): void {
     const g = getHellGraph()
     if (g.allNodes().length > 0) return
     const seedDir = process.env['HELLGRAPH_SEED_DIR'] ||
-      path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'seeds')
+      path.join(__dirname, '..', 'seeds')
     if (!fs.existsSync(seedDir)) return
     const files = fs.readdirSync(seedDir).filter((f) => f.endsWith('.json')).sort()
     let nodes = 0, edges = 0
@@ -540,7 +539,7 @@ function loadRcIfEnabled(): void {
   if (process.env['HELLGRAPH_LOAD_RC'] !== 'on') return
   try {
     const gzPath = process.env['HELLGRAPH_RC_PATH'] ||
-      path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'ontology', 'kbpedia-rc-2.10.n3.gz')
+      path.join(__dirname, '..', 'ontology', 'kbpedia-rc-2.10.n3.gz')
     if (!fs.existsSync(gzPath)) { console.error(`[hellgraph-service] RC load skipped: ${gzPath} not found`); return }
     const t0 = Date.now()
     const text = zlib.gunzipSync(fs.readFileSync(gzPath)).toString('utf8')


### PR DESCRIPTION
## The failure

`tsc --noEmit` has been red on `origin/main`:

```
src/server.ts(497,44): error TS1343: The 'import.meta' meta-property is only allowed when the '--module' option is 'es2020' | ... | 'nodenext'.
src/server.ts(543,44): error TS1343: (same)
```

`npm test` stayed green the whole time because **tsx transpiles without typechecking** — so this only ever bit `tsc`, which is exactly the kind of gap that lets a type error live in `main` indefinitely.

## The decision

**The tsconfig was not the mistake — the `import.meta` was.** Both call sites do the same thing: derive server.ts's own directory to reach `<app>/seeds` and `<app>/ontology`. Under CommonJS that is spelled `__dirname`.

Everything about this service already says CommonJS, and one file had simply drifted to the ESM idiom:

| signal | value |
|---|---|
| `package.json` | `"type": "commonjs"` |
| start script / image `CMD` | `tsx src/server.ts` (CJS) |
| `tsconfig.json` | `module: commonjs`, deliberately |
| sibling `contract.ts` | already uses `__dirname`, with a comment stating it is correct here |

So: two derivations become `__dirname`, and the now-unused `node:url` import is dropped. **Three lines, no behaviour change.**

**Rejected — moving to `node16`/`nodenext`:** it would force converting `contract.ts`'s `__dirname` schema loading, and the Dockerfile's `COPY src ./src` plus the CommonJS `tsx` entrypoint rest on the same assumption. That is a large blast radius across a live service to buy nothing that a two-token change already gets.

## Verification

**Typecheck** — 2 errors → **0**.
**Suite** — **79/79**, unchanged.

**Path resolution under the image's own layout** (the Dockerfile copies `src`, `seeds` and `ontology` as siblings under `/app`), simulated exactly and probed with `__dirname`:

```
__dirname      = /app/src
seeds    -> /app/seeds                                  EXISTS (1 json)
ontology -> /app/ontology/kbpedia-rc-2.10.n3.gz         EXISTS
schemas  -> /app/src/schemas                            EXISTS (4 files)
```

The third line is `contract.ts`'s lookup — untouched by this change, checked because the task asked whether the Docker build still resolves `src/schemas/`. It does, and it is copied by the same `COPY src ./src`.

**A real boot**, not just a static check — the changed code path actually running under tsx:

```
[hellgraph-service] listening on :19311 (engine exports: 266)
[hellgraph-service] auto-seeded 20 nodes / 26 edges from 1 seed file(s)
```

Analytics then reported a populated graph (22 nodes / 26 edges), so `seedIfEmpty()` found its directory through the new resolution. The RC path is derived identically one function below.

## Note

This clears the two pre-existing errors flagged as out-of-scope on #1025 and #1030, so `apps/hellgraph-service` now typechecks clean — worth keeping that way, since a red `tsc` teaches everyone to ignore it.