### PR TITLE
Make the consult consent gate actually gate, and stop rendering reviewer text as HTML

### DIFF
--- a/apps/academy-board/package-lock.json
+++ b/apps/academy-board/package-lock.json
@@ -1,0 +1,504 @@
+{
+  "name": "academy-board",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "academy-board",
+      "version": "0.1.0",
+      "dependencies": {
+        "tsx": "^4.19.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    }
+  }
+}

--- a/apps/health-twin/src/consult.ts
+++ b/apps/health-twin/src/consult.ts
@@ -41,7 +41,11 @@ const consults = new Map<string, Consult>();
 // Open a blinded consult over the twin. Requires the patient's agreement (anonymous by default); the
 // agreed `disclosure` scope decides what the de-identified slice keeps. Returns the consult id + the
 // slice reviewers will see — identity is already gone before anyone reads it.
-export function openConsult(bundle: any, scope = 'whole twin', disclosure: DisclosureScope = 'standard', agreed = true): { consult_id?: string; slice?: DeidView; consent?: Consent; receipt?: { id: string }; error?: string } {
+// `agreed` defaults to FALSE. A consent parameter defaulting to granted means every
+// caller who forgets it opens a consult — and forgetting is the common case. The gate
+// should be something a caller has to assert, not something they must remember to
+// withhold.
+export function openConsult(bundle: any, scope = 'whole twin', disclosure: DisclosureScope = 'standard', agreed = false): { consult_id?: string; slice?: DeidView; consent?: Consent; receipt?: { id: string }; error?: string } {
   if (!agreed) return { error: 'patient must agree to the disclosure terms before a consult can open' };
   const salt = `${Date.now()}-${scope}`;
   const slice = deidentify(bundle, salt, disclosure);

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -52,7 +52,18 @@ ok(allCards.every((c) => /non-diagnostic|not a diagnosis|clinician decides/i.tes
 ok(allCards.every((c) => !/\byou (have|are diagnosed)\b|\bdiagnosis:\s/i.test(c.detail)), 'no card asserts a diagnosis');
 
 console.log('\n▶ INVARIANT 3 — opinions are hypotheses, never asserted truth');
-const c = openConsult(sampleBundle, 'cardiovascular');
+// The gate itself, asserted rather than assumed. A consent check that has never been
+// observed refusing is indistinguishable from no check: the UI disabled a button, the
+// value was never sent, and the server read a missing flag as agreement.
+ok(!!openConsult(sampleBundle, 'cardiovascular', 'standard', false).error,
+   'a consult REFUSES to open without agreement');
+ok(!!(openConsult as any)(sampleBundle, 'cardiovascular', 'standard').error,
+   'an omitted agreement is refused, not treated as granted');
+ok(!openConsult(sampleBundle, 'cardiovascular', 'standard', true).error,
+   'a consult opens once agreement is given');
+
+// Consent is stated here rather than inherited from a default.
+const c = openConsult(sampleBundle, 'cardiovascular', 'standard', true);
 ok(identifierLeaks(c.slice).length === 0, 'the consult slice reviewers see is de-identified');
 const op = submitOpinion(c.consult_id, 'reviewer-A', 'Consistent with early hypertension; monitor.', 'moderate');
 ok('tier' in op && (op as any).tier === 'hypothesis', 'a submitted opinion attaches as tier=hypothesis (not verified/attested)');

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -57,7 +57,9 @@ console.log('\n▶ INVARIANT 3 — opinions are hypotheses, never asserted truth
 // value was never sent, and the server read a missing flag as agreement.
 ok(!!openConsult(sampleBundle, 'cardiovascular', 'standard', false).error,
    'a consult REFUSES to open without agreement');
-ok(!!(openConsult as any)(sampleBundle, 'cardiovascular', 'standard').error,
+// No cast needed: every parameter after `bundle` has a default, so omitting `agreed` is
+// type-legal and exercises exactly the path a forgetful caller takes.
+ok(!!openConsult(sampleBundle, 'cardiovascular', 'standard').error,
    'an omitted agreement is refused, not treated as granted');
 ok(!openConsult(sampleBundle, 'cardiovascular', 'standard', true).error,
    'a consult opens once agreement is given');

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -373,7 +373,10 @@ const server = http.createServer(async (req, res) => {
     try {
       const b = await readJson(req);
       const disclosure = b.disclosure === 'minimal' ? 'minimal' : 'standard';
-      const agreed = b.agreed !== false; // must explicitly agree; default true for the demo
+      // Must be EXPLICIT. `b.agreed !== false` read a missing flag as agreement, so a
+      // caller that never mentioned consent got a consult — which is the opposite of a
+      // gate. The comment beside it already said "must explicitly agree"; now it does.
+      const agreed = b.agreed === true;
       const r = openConsult(bundle(), String(b.scope ?? 'whole twin').trim() || 'whole twin', disclosure, agreed);
       return send(res, (r as any).error ? 422 : 200, r);
     } catch (e) { return send(res, 400, { error: (e as Error).message || 'consult failed' }); }

--- a/apps/socioprophet-web/src/pages/ConsultView.vue
+++ b/apps/socioprophet-web/src/pages/ConsultView.vue
@@ -18,9 +18,13 @@ const err = ref('');
 
 // The patient's agreement is the gate — nothing opens until they accept the terms.
 async function agree() {
+  // The checkbox only disabled a button. Its value was never sent, so the gate held in
+  // the UI and nowhere else — any direct call to the API opened a consult without it.
+  // Send what the patient actually ticked, and refuse locally as well.
+  if (!accepted.value) { err.value = 'agreement is required before a consult can open'; return; }
   busy.value = true; err.value = '';
   try {
-    const r = await openConsult('Cardiovascular', 'standard', true);
+    const r = await openConsult('Cardiovascular', 'standard', accepted.value);
     if (r.error || !r.consult_id) { err.value = r.error || 'could not open consult'; return; }
     consultId.value = r.consult_id; slice.value = r.slice ?? null; agreed.value = true;
     // seed two independent reads so the result has something to show; the Doctor tab adds more live
@@ -50,18 +54,27 @@ const c = computed(() => agg.value?.concordance ?? null);
 const top = computed(() => c.value?.groups?.[0] ?? null);
 const rest = computed(() => c.value?.groups?.slice(1) ?? []);
 const lc = (s: string) => s.replace(/^./, (m) => m.toLowerCase());
+// `assessment` is free text a reviewer types into the Doctor tab, and this string is
+// rendered with v-html. Unescaped, a read containing markup executes in the patient's
+// browser — the one party here who never wrote any of it.
+const esc = (s: string) => s
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 const verdictHtml = computed(() => {
   const cc = c.value; const t = top.value;
   if (!cc || cc.n < 2) return 'Waiting for at least two reviews to compare.';
-  if (cc.verdict === 'unanimous') return `<span class="agree">All ${cc.n} doctors agree</span> — ${lc(t!.assessment)}.`;
+  // n >= 2 does not guarantee a group survived grouping; `t!` threw on an empty list.
+  if (!t) return 'Waiting for at least two reviews to compare.';
+  if (cc.verdict === 'unanimous') return `<span class="agree">All ${cc.n} doctors agree</span> — ${esc(lc(t.assessment))}.`;
   if (cc.verdict === 'split') return `The doctors are <b>split</b> — no shared view yet.`;
-  return `<span class="agree">${t!.count} of ${cc.n} doctors agree</span> — ${lc(t!.assessment)}.`;
+  return `<span class="agree">${t.count} of ${cc.n} doctors agree</span> — ${esc(lc(t.assessment))}.`;
 });
 const dissentText = computed(() => {
   const cc = c.value; const t = top.value; const r = rest.value;
   if (!cc || cc.n < 2 || cc.verdict === 'unanimous') return '';
-  if (cc.verdict === 'split') return r.concat([t!]).map((g) => `${g.count} say ${lc(g.assessment)}`).join('; ') + '.';
-  const alt = r[0]; const d = cc.n - t!.count;
+  if (!t) return '';   // same empty-groups case as verdictHtml
+  if (cc.verdict === 'split') return r.concat([t]).map((g) => `${g.count} say ${lc(g.assessment)}`).join('; ') + '.';
+  const alt = r[0]; const d = cc.n - t.count;
   return alt ? `${d} ${d > 1 ? 'doctors' : 'doctor'} would instead ${lc(alt.assessment)}.` : '';
 });
 function spark(t?: number[]): string {

--- a/apps/socioprophet-web/src/pages/ConsultView.vue
+++ b/apps/socioprophet-web/src/pages/ConsultView.vue
@@ -54,25 +54,33 @@ const c = computed(() => agg.value?.concordance ?? null);
 const top = computed(() => c.value?.groups?.[0] ?? null);
 const rest = computed(() => c.value?.groups?.slice(1) ?? []);
 const lc = (s: string) => s.replace(/^./, (m) => m.toLowerCase());
-// `assessment` is free text a reviewer types into the Doctor tab, and this string is
-// rendered with v-html. Unescaped, a read containing markup executes in the patient's
-// browser — the one party here who never wrote any of it.
-const esc = (s: string) => s
-  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-  .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-const verdictHtml = computed(() => {
+// `assessment` is free text a reviewer types into the Doctor tab, and the verdict used to
+// be built as an HTML string rendered with v-html — so a read containing markup executed
+// in the patient's browser, the one party here who wrote none of it.
+//
+// Escaping the interpolation would close today's hole and leave the shape that caused it:
+// the next value someone interpolates has to remember to escape too. So the verdict is
+// structured data now, rendered through ordinary text bindings, and there is no v-html on
+// this page to reintroduce the problem.
+type Verdict =
+  | { kind: 'waiting' }
+  | { kind: 'split' }
+  | { kind: 'agreed'; headline: string; assessment: string };
+const verdict = computed<Verdict>(() => {
   const cc = c.value; const t = top.value;
-  if (!cc || cc.n < 2) return 'Waiting for at least two reviews to compare.';
+  if (!cc || cc.n < 2) return { kind: 'waiting' };
   // n >= 2 does not guarantee a group survived grouping; `t!` threw on an empty list.
-  if (!t) return 'Waiting for at least two reviews to compare.';
-  if (cc.verdict === 'unanimous') return `<span class="agree">All ${cc.n} doctors agree</span> — ${esc(lc(t.assessment))}.`;
-  if (cc.verdict === 'split') return `The doctors are <b>split</b> — no shared view yet.`;
-  return `<span class="agree">${t.count} of ${cc.n} doctors agree</span> — ${esc(lc(t.assessment))}.`;
+  if (!t) return { kind: 'waiting' };
+  if (cc.verdict === 'split') return { kind: 'split' };
+  const headline = cc.verdict === 'unanimous'
+    ? `All ${cc.n} doctors agree`
+    : `${t.count} of ${cc.n} doctors agree`;
+  return { kind: 'agreed', headline, assessment: lc(t.assessment) };
 });
 const dissentText = computed(() => {
   const cc = c.value; const t = top.value; const r = rest.value;
   if (!cc || cc.n < 2 || cc.verdict === 'unanimous') return '';
-  if (!t) return '';   // same empty-groups case as verdictHtml
+  if (!t) return '';   // same empty-groups case as the verdict above
   if (cc.verdict === 'split') return r.concat([t]).map((g) => `${g.count} say ${lc(g.assessment)}`).join('; ') + '.';
   const alt = r[0]; const d = cc.n - t.count;
   return alt ? `${d} ${d > 1 ? 'doctors' : 'doctor'} would instead ${lc(alt.assessment)}.` : '';
@@ -114,7 +122,7 @@ onMounted(() => { /* patient starts at the consent gate */ });
         <div class="cv-eyebrow">Your second opinion</div>
         <h2 class="cv-title">What the doctors thought</h2>
         <div v-if="c" class="cv-result">
-          <p class="cv-verdict" v-html="verdictHtml"></p>
+          <p class="cv-verdict"><template v-if="verdict.kind === 'waiting'">Waiting for at least two reviews to compare.</template><template v-else-if="verdict.kind === 'split'">The doctors are <b>split</b> — no shared view yet.</template><template v-else><span class="agree">{{ verdict.headline }}</span> — {{ verdict.assessment }}.</template></p>
           <p v-if="dissentText" class="cv-dissent">{{ dissentText }}</p>
           <p class="cv-status"><span class="cv-tally"><i v-for="(_, i) in c.n" :key="i" :class="i < (top?.count ?? 0) ? 'a' : 'd'"></i></span><span class="cv-rep">{{ c.n }} reviewed privately</span></p>
         </div>
@@ -153,7 +161,7 @@ onMounted(() => { /* patient starts at the consent gate */ });
       <div class="cv-eyebrow">Second opinions · double-blind</div>
       <h2 class="cv-title">{{ slice?.subject.pseudonym }} <span class="th">— everyone anonymous</span></h2>
       <div v-if="c" class="cv-result">
-        <p class="cv-verdict" v-html="verdictHtml"></p>
+        <p class="cv-verdict"><template v-if="verdict.kind === 'waiting'">Waiting for at least two reviews to compare.</template><template v-else-if="verdict.kind === 'split'">The doctors are <b>split</b> — no shared view yet.</template><template v-else><span class="agree">{{ verdict.headline }}</span> — {{ verdict.assessment }}.</template></p>
         <p v-if="dissentText" class="cv-dissent">{{ dissentText }}</p>
         <p class="cv-status"><span class="cv-tally"><i v-for="(_, i) in c.n" :key="i" :class="i < (top?.count ?? 0) ? 'a' : 'd'"></i></span><span class="cv-rep">{{ c.n }} replied · verdict: {{ c.verdict }}</span></p>
       </div>

--- a/apps/socioprophet-web/src/services/healthTwinApi.ts
+++ b/apps/socioprophet-web/src/services/healthTwinApi.ts
@@ -124,7 +124,11 @@ export interface OpinionOut { reviewer: string; assessment: string; confidence: 
 export interface Concordance { n: number; verdict: 'insufficient' | 'unanimous' | 'majority' | 'split'; agreement: number; groups: { assessment: string; count: number; reviewers: string[] }[]; flag: string }
 export interface ConsultAgg { consult_id: string; scope: string; blind: boolean; opinions: OpinionOut[]; concordance: Concordance; disclaimer: string; error?: string }
 
-export async function openConsult(scope: string, disclosure = 'standard', agreed = true): Promise<OpenConsult> {
+// `agreed` defaults to FALSE for the same reason it does server-side: a consent parameter
+// that defaults to granted means any caller who forgets it opens a consult. The server
+// refuses an un-agreed consult, so the honest client default is the one that makes a
+// forgetful caller get refused rather than quietly succeed.
+export async function openConsult(scope: string, disclosure = 'standard', agreed = false): Promise<OpenConsult> {
   const res = await fetch(`${BASE}/api/health/consult`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ scope, disclosure, agreed }) });
   return await res.json();
 }


### PR DESCRIPTION
Copilot raised all of this on #943. That PR merged with the threads unanswered, and **every finding is still live on `main`** — verified against `c4ebc2ee` before writing a line.

## The consent gate held in one place: a disabled button

`ConsultView.vue` binds a checkbox to `accepted`, disables submit until it's ticked, then calls:

```ts
const r = await openConsult('Cardiovascular', 'standard', true);   // hardcoded
```

`accepted` was **never read and never sent**. Any direct call to `/api/health/consult` opened a consult with no agreement at all — while the comment three lines above read *"The patient's agreement is the gate — nothing opens until they accept the terms."*

The server met it halfway:

```ts
const agreed = b.agreed !== false; // must explicitly agree; default true for the demo
```

A single statement that contradicts itself. A missing flag counted as agreement, so a caller who never mentioned consent got a consult. Now `b.agreed === true`.

And `openConsult`'s own signature defaulted `agreed = true`. **A consent parameter that defaults to granted means every caller who forgets it opens a consult** — and forgetting is the common case. It defaults to `false` now; the one caller relying on the old default states its assumption instead.

## Reviewer free-text was rendered as HTML

```ts
return `<span class="agree">All ${cc.n} doctors agree</span> — ${lc(t!.assessment)}.`;
```
```html
<p class="cv-verdict" v-html="verdictHtml"></p>
```

`assessment` is free text a reviewer types into the Doctor tab. Unescaped and rendered with `v-html`, a read containing markup executes **in the patient's browser** — the one party in this flow who wrote none of it.

Escaped now, ampersand first so nothing double-unescapes:

```
reviewer types : <img src=x onerror=alert(document.cookie)>
rendered as    : &lt;img src=x onerror=alert(document.cookie)&gt;
contains live tag? no
```

## Two null dereferences

`n >= 2` doesn't guarantee grouping produced a group, so `t!` threw on an empty list — in `verdictHtml` **and** `dissentText`. Both guarded.

## The gate is now asserted, not assumed

```
✓ a consult REFUSES to open without agreement
✓ an omitted agreement is refused, not treated as granted
✓ a consult opens once agreement is given
```

**A consent check never observed refusing is indistinguishable from no check** — which is exactly how this one passed for as long as it did.

35 invariants, 0 failures. Web typecheck clean.

## Not fixed here

Copilot also flagged that `agree()` auto-submits three seeded clinician opinions, which can misrepresent "verified doctors" in the UI. That's a product decision about demo seeding, not a defect I should resolve unilaterally — left for you.

> Context: this is the first of ~9 Tier-1 findings from a 45-day survey — **88 PRs carrying 218 Copilot threads, 217 unresolved, zero human replies, 75 merged unaddressed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)