### PR TITLE
Gate /api/organs, and close the anonymous write path on arcticdb-gateway

### DIFF
--- a/.github/workflows/provision-secrets.yml
+++ b/.github/workflows/provision-secrets.yml
@@ -10,7 +10,7 @@ name: provision-secrets
 #   • Variables:  GKE_CLUSTER, GKE_LOCATION  (the prophet-platform GKE Autopilot cluster)
 #   • Secrets:    GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT  (already set),
 #                 plus the token values: SPARK_RUNNER_TOKEN, LATTICE_FORGE_TOKEN,
-#                 COMPUTE_GATEWAY_TOKEN, STUDIO_WRITE_TOKEN
+#                 COMPUTE_GATEWAY_TOKEN, STUDIO_WRITE_TOKEN, ARCTICDB_GATEWAY_TOKEN
 #
 # Run: Actions → provision-secrets → Run workflow (optionally scope with `only`).
 # Rotate a token = update the GitHub secret, re-run. A missing value is skipped, not errored.
@@ -65,6 +65,7 @@ jobs:
           LATTICE_FORGE_TOKEN: ${{ secrets.LATTICE_FORGE_TOKEN }}
           COMPUTE_GATEWAY_TOKEN: ${{ secrets.COMPUTE_GATEWAY_TOKEN }}
           STUDIO_WRITE_TOKEN: ${{ secrets.STUDIO_WRITE_TOKEN }}
+          ARCTICDB_GATEWAY_TOKEN: ${{ secrets.ARCTICDB_GATEWAY_TOKEN }}
           ONLY: ${{ inputs.only }}
         run: |
           set -euo pipefail
@@ -88,6 +89,7 @@ jobs:
           sync lattice-forge-token   token "$LATTICE_FORGE_TOKEN"   sovereign-runtime socioprophet
           sync compute-gateway-token token "$COMPUTE_GATEWAY_TOKEN" socioprophet
           sync studio-write-token    token "$STUDIO_WRITE_TOKEN"    socioprophet
+          sync arcticdb-gateway-token token "$ARCTICDB_GATEWAY_TOKEN" socioprophet
 
           echo "done."
 

--- a/apps/arcticdb-gateway/src/arcticdb_gateway/server.py
+++ b/apps/arcticdb-gateway/src/arcticdb_gateway/server.py
@@ -18,12 +18,28 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, Header, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from .store import BadRequest, GatewayStore, SymbolNotFound
 
 DEFAULT_URI = "lmdb:///data/arcticdb?map_size=8GB"
+
+
+def require_token(authorization: str = Header(default="")) -> None:
+    """Fail-closed write auth, matching compute-gateway.
+
+    /v1/write mutated the LMDB-backed store with no authentication at all, so anything
+    that could reach the pod could write versioned artifacts into it. The estate's
+    convention for a mutating endpoint is 503 when no token is configured — an
+    unconfigured gateway refuses rather than serving open — and 401 when one is wrong.
+    Reads stay open: this closes the mutation path, which is the asymmetry that matters.
+    """
+    token = os.getenv("GATEWAY_TOKEN", "")
+    if not token:
+        raise HTTPException(status_code=503, detail="gateway token not configured (fail-closed)")
+    if authorization.removeprefix("Bearer ").strip() != token:
+        raise HTTPException(status_code=401, detail="unauthorized")
 
 
 class WriteRequest(BaseModel):
@@ -50,7 +66,7 @@ def create_app(uri: str | None = None) -> FastAPI:
         return {"ok": True, "service": "arcticdb-gateway", "backend": store.uri.split("?")[0], **info}
 
     @app.post("/v1/write")
-    def write(req: WriteRequest) -> dict[str, Any]:
+    def write(req: WriteRequest, _: None = Depends(require_token)) -> dict[str, Any]:
         try:
             return store.write(
                 req.library, req.symbol, req.data, req.index, req.metadata, req.prune_previous

--- a/apps/arcticdb-gateway/tests/test_gateway.py
+++ b/apps/arcticdb-gateway/tests/test_gateway.py
@@ -12,9 +12,24 @@ from fastapi.testclient import TestClient
 from arcticdb_gateway.server import create_app
 
 
+TEST_TOKEN = "test-write-token"
+
+
 @pytest.fixture()
-def client(tmp_path):
+def client(tmp_path, monkeypatch):
+    # /v1/write is fail-closed: configure a token and present it, so these tests
+    # exercise the AUTHORIZED path. The refusals get their own tests below.
+    monkeypatch.setenv("GATEWAY_TOKEN", TEST_TOKEN)
     app = create_app(f"lmdb://{tmp_path}/arctic?map_size=256MB")  # small map for tests
+    with TestClient(app, headers={"Authorization": f"Bearer {TEST_TOKEN}"}) as c:
+        yield c
+
+
+@pytest.fixture()
+def unauthed_client(tmp_path, monkeypatch):
+    """Same app, no token configured and none presented."""
+    monkeypatch.delenv("GATEWAY_TOKEN", raising=False)
+    app = create_app(f"lmdb://{tmp_path}/arctic?map_size=256MB")
     with TestClient(app) as c:
         yield c
 
@@ -121,3 +136,57 @@ def test_writes_persist_across_store_handles(tmp_path):
         got = c2.get("/v1/read", params={"library": "dur", "symbol": "s"})
         assert got.status_code == 200
         assert got.json()["data"]["x"] == [7]
+
+
+# /v1/write mutated the LMDB-backed store with no authentication at all — anything that
+# could reach the pod could write versioned artifacts into it. These are the refusals;
+# a write gate never observed refusing is indistinguishable from no gate.
+
+
+def test_write_refuses_when_no_token_is_configured(unauthed_client):
+    # Fail-closed: an unconfigured gateway refuses rather than serving open.
+    r = unauthed_client.post("/v1/write", json={"library": "l", "symbol": "s", "data": {"x": [1]}})
+    assert r.status_code == 503
+    assert "fail-closed" in r.json()["detail"]
+
+
+def test_write_refuses_a_wrong_token(client):
+    r = client.post(
+        "/v1/write",
+        json={"library": "l", "symbol": "s", "data": {"x": [1]}},
+        headers={"Authorization": "Bearer not-the-token"},
+    )
+    assert r.status_code == 401
+
+
+def test_write_refuses_a_missing_header_when_a_token_is_configured(client):
+    r = client.post(
+        "/v1/write",
+        json={"library": "l", "symbol": "s", "data": {"x": [1]}},
+        headers={"Authorization": ""},
+    )
+    assert r.status_code == 401
+
+
+def test_write_accepts_the_configured_token(client):
+    r = client.post("/v1/write", json={"library": "l", "symbol": "s", "data": {"x": [1]}})
+    assert r.status_code == 200
+
+
+def test_only_the_write_route_is_token_gated(tmp_path):
+    """Structural: the auth dependency is attached to /v1/write and to nothing else.
+
+    Asserted against the route table rather than by issuing requests, so it holds
+    regardless of whether the storage backend can be opened in this environment.
+    The asymmetry is deliberate — this closes the MUTATION path. A read that cannot
+    cite a token is still a read; a write that cannot is an anonymous mutation.
+    """
+    from arcticdb_gateway.server import require_token
+
+    app = create_app(f"lmdb://{tmp_path}/arctic?map_size=256MB")
+    gated = {
+        r.path
+        for r in app.routes
+        if any(d.call is require_token for d in getattr(getattr(r, "dependant", None), "dependencies", []))
+    }
+    assert gated == {"/v1/write"}, f"expected only /v1/write to be gated, got {gated}"

--- a/apps/hellgraph-service/src/auth.test.ts
+++ b/apps/hellgraph-service/src/auth.test.ts
@@ -121,3 +121,31 @@ test('authorize: multi-scope tokens work; ungated paths never challenge', () => 
   assert.equal(authorize(s, req('GET'), at('/healthz')), null)
   assert.equal(authorize(s, req('GET'), at('/api/federation/status')), null)
 })
+
+test('requiredScope: /api/organs is gated — it discloses topology and triggers probing', () => {
+  // It sat outside /api/graph/ and /api/membrane/, so it answered unauthenticated even
+  // with AUTH_ENFORCE=on. The endpoint returns internal service endpoints with live
+  // health AND makes the server probe those members, so an anonymous caller both reads
+  // the mesh's shape and gets the service to emit outbound requests for them.
+  assert.equal(requiredScope('GET', '/api/organs'), 'graph:read')
+  assert.equal(requiredScope('HEAD', '/api/organs'), 'graph:read')
+  assert.equal(requiredScope('POST', '/api/organs'), 'graph:write')
+  // a genuine subpath is gated too
+  assert.equal(requiredScope('GET', '/api/organs/memory'), 'graph:read')
+  // ...but a sibling that merely shares the prefix string is NOT silently captured
+  assert.equal(requiredScope('GET', '/api/organs-public'), null)
+  assert.equal(requiredScope('GET', '/api/organsomething'), null)
+})
+
+test('authorize: /api/organs refuses without a token under enforcement', () => {
+  const s = enforcing()
+  const denied = authorize(s, req('GET'), at('/api/organs'))
+  assert.ok(denied, 'unauthenticated /api/organs must be refused when enforcing')
+  assert.equal(denied!.code, 401)
+  assert.equal((denied!.body as any).requiredScope, 'graph:read')
+  // and proceeds with a scoped token
+  assert.equal(authorize(s, req('GET', tok(['graph:read'])), at('/api/organs')), null)
+  // a token without the scope is forbidden, not merely unauthorized
+  const wrong = authorize(s, req('GET', tok(['graph:enrich'])), at('/api/organs'))
+  assert.equal(wrong!.code, 403)
+})

--- a/apps/hellgraph-service/src/auth.ts
+++ b/apps/hellgraph-service/src/auth.ts
@@ -108,9 +108,24 @@ const ROUTE_SCOPES: Record<string, GraphScope> = {
   'GET /api/graph/enrich': 'graph:enrich',
 }
 
+// Prefixes this module gates. /api/organs is here because it discloses the mesh's
+// internal service endpoints with live health AND makes the server probe those members
+// on demand — so an unauthenticated caller both reads the topology and gets the service
+// to generate outbound requests on their behalf. It was reachable with AUTH_ENFORCE=on
+// purely because it sits outside /api/graph/ and /api/membrane/.
+const GATED_PREFIXES = ['/api/graph/', '/api/membrane/', '/api/organs'] as const
+
+/** Exact match, or a genuine subpath. A bare `startsWith` would also gate a sibling
+ *  like `/api/organs-public`, quietly capturing routes this list never named. */
+function underGatedPrefix(pathname: string): boolean {
+  return GATED_PREFIXES.some((p) =>
+    p.endsWith('/') ? pathname.startsWith(p) : pathname === p || pathname.startsWith(`${p}/`),
+  )
+}
+
 /** The scope a request needs, or null when the path is not gated by this module. */
 export function requiredScope(method: string, pathname: string): GraphScope | null {
-  if (!pathname.startsWith('/api/graph/') && !pathname.startsWith('/api/membrane/')) return null
+  if (!underGatedPrefix(pathname)) return null
   const mapped = ROUTE_SCOPES[`${method} ${pathname}`]
   if (mapped) return mapped
   // Fail-closed default for unmapped paths under the gated prefixes.

--- a/deploy/values/arcticdb-gateway.yaml
+++ b/deploy/values/arcticdb-gateway.yaml
@@ -25,6 +25,14 @@ config:
   # LMDB inside the PVC; map_size caps the LMDB memory map and must stay under the PVC size.
   ARCTIC_URI: "lmdb:///data/arcticdb?map_size=8GB"
 
+# POST /v1/write is fail-closed: with no token configured it returns 503 rather than
+# accepting anonymous mutations. This secret is therefore a DEPLOY PREREQUISITE — without
+# it every write is refused (which is the correct failure, but it is a failure).
+# Provisioned by .github/workflows/provision-secrets.yml from the ARCTICDB_GATEWAY_TOKEN
+# repo secret. Reads are unaffected.
+secretEnv:
+  GATEWAY_TOKEN: { secretName: arcticdb-gateway-token, key: token }
+
 # LMDB is strictly single-writer: one replica, no HPA, Recreate (RWO PD would deadlock a
 # rolling update) — the exact pairing the chart's persistence comment prescribes.
 persistence:


### PR DESCRIPTION
Two authorization holes Copilot raised on **#1021** and **#994**. Both PRs merged with the threads unanswered; **both are still live on `main`**, verified against `c4ebc2ee`.

## `/api/organs` answered unauthenticated with `AUTH_ENFORCE=on`

```ts
export function requiredScope(method: string, pathname: string): GraphScope | null {
  if (!pathname.startsWith('/api/graph/') && !pathname.startsWith('/api/membrane/')) return null
```

`/api/organs` is neither, so it returned `null` — no scope, no challenge, no token. The endpoint discloses the mesh's internal service endpoints with live health **and** makes the server probe those members on demand, so an anonymous caller both reads the topology and gets the service to emit outbound requests on their behalf.

The gated set is now a named list. Membership is **exact match or a genuine subpath**, not a bare `startsWith` — that would also have captured a sibling like `/api/organs-public`, quietly gating routes the list never named. There's a test for that, because a fix that silently over-gates is its own defect:

```
✓ requiredScope('GET', '/api/organs')         → 'graph:read'
✓ requiredScope('GET', '/api/organs/memory')  → 'graph:read'
✓ requiredScope('GET', '/api/organs-public')  → null      ← not silently captured
✓ unauthenticated /api/organs                 → 401
✓ token without the scope                     → 403 (forbidden, not merely unauthorized)
```

## `POST /v1/write` had no authentication at all

arcticdb-gateway mutated the LMDB-backed store anonymously: **anything able to reach the pod could write versioned artifacts into it.** The only `503` in the whole file was a backend-unavailable error.

`compute-gateway`, in this same repo, already has the convention — `503` when no token is configured so an unconfigured gateway refuses rather than serving open, `401` when one is wrong. arcticdb-gateway now follows it.

The token is read **at call time** rather than captured at import (compute-gateway captures at import). That keeps the dependency testable and stops a stale capture surviving a config change.

**Reads stay open deliberately.** This closes the mutation path — a read that cannot cite a token is still a read; a write that cannot is an anonymous mutation. That asymmetry is asserted **structurally against the route table**, so it holds without a working storage backend and would fail if the dependency were ever attached to a read or dropped from the write.

## Verification

- hellgraph-service: **81 tests, 0 failures**
- arcticdb-gateway: the three refusal tests and the structural test pass locally. The accept-path test needs a real arcticdb store — as do **six pre-existing tests** — and that library isn't installed on this machine. `origin/main` fails the same six identically, so the failures are environmental, not introduced here.

> Second batch from the 45-day Copilot survey. First was #1033 (consent gate + XSS). Remaining Tier-1: #932 unauthenticated twin bundle, #940 Host-header injection, #942 djb2 consult IDs.
>
> Side-finding worth a follow-up: `health-twin/src/server.ts` already replaced djb2 with real SHA-256, but `consult.ts` still uses djb2 for consult IDs — the remediation was partial. And both still hash `parts.join('|')`, so #999's ambiguous-serialization finding survives the SHA-256 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)