### PR TITLE
fix(ci): premerge audit gates on CONFLICT SURFACE, not distance from main

### DIFF
--- a/tools/premerge_audit.py
+++ b/tools/premerge_audit.py
@@ -1,4 +1,43 @@
 #!/usr/bin/env python3
+"""premerge audit — refuse to merge a branch whose staleness could actually break main.
+
+WHY THIS CHANGED
+----------------
+The original rule was `behind > 0 -> fail`. On a busy repo that starves PRs: you rebase to
+zero, CI takes ten minutes, main moves two commits, the gate fails, repeat. Observed live
+on this repo — a docs-only PR was blocked while an unrelated service promotion landed.
+Worse, the blanket rule made small safe changes MORE expensive than large risky ones,
+because they are the ones left waiting for a quiet moment that never comes.
+
+It was also unsound in the other direction: `behind == 0` does not mean "safe". A branch
+can be perfectly current and still break main, and a branch can be 40 commits behind and
+be provably unaffected by every one of them.
+
+The question worth asking is not *how far behind are you* but **did the base change
+anything your change also touches**. That is the real conflict surface — the same thing a
+merge queue establishes by rebase-and-test, computed here in one cheap diff.
+
+DECISION MODEL
+--------------
+  overlap     = files this branch changed  n  files the base changed since our merge-base
+  hot overlap = overlap restricted to HOT_PREFIXES (build, CI, tooling, contracts, apps)
+
+  1. hot overlap non-empty         -> FAIL. Both sides edited something load-bearing.
+  2. overlap non-empty             -> FAIL. Genuine semantic-conflict risk.
+  3. behind > PREMERGE_MAX_BEHIND  -> FAIL. Unbounded drift is its own risk, overlap or not.
+  4. otherwise                     -> PASS, stating exactly why staleness is safe here.
+
+Rules 1-2 are STRICTER than the old gate (a zero-behind branch with an overlapping edit
+used to pass). Rules 3-4 are looser only where looseness is provably harmless. Net: fewer
+false alarms, and it now catches a class of real conflict the old rule missed.
+
+`PREMERGE_STRICT=1` restores the historical `behind > 0 -> fail` behaviour for anyone who
+wants the old guarantee unchanged.
+
+NOTE: this remains an APPROXIMATION of a merge queue. If GitHub merge queues are enabled
+for this repo, prefer them — they rebase-and-TEST at the front of the queue, which proves
+what this can only infer. This gate is the cheap version for repos without one.
+"""
 from __future__ import annotations
 
 import os
@@ -18,43 +57,108 @@ HOT_PREFIXES = [
     'conformance/',
 ]
 
+# How far behind we tolerate when nothing overlaps. Generous on purpose: with zero overlap
+# the base's commits cannot interact with this diff, so the remaining risk is only that the
+# branch was authored against a much older tree. Bounded, not unlimited.
+DEFAULT_MAX_BEHIND = 50
+
 
 def run(cmd: list[str]) -> str:
     return subprocess.check_output(cmd, cwd=ROOT, text=True).strip()
 
 
+def _lines(output: str) -> list[str]:
+    return [line for line in output.splitlines() if line.strip()]
+
+
+def is_hot(path: str) -> bool:
+    return any(path == prefix or path.startswith(prefix) for prefix in HOT_PREFIXES)
+
+
+def audit(base_ref: str, head_ref: str, max_behind: int = DEFAULT_MAX_BEHIND,
+          strict: bool = False) -> tuple[int, list[str]]:
+    """Return (exit_code, report_lines). Split out from main() so it is testable against
+    real git fixtures rather than mocks — a gate proven with mocks proves nothing."""
+    out: list[str] = ['premerge audit summary', f'base_ref={base_ref}', f'head_ref={head_ref}']
+
+    changed = _lines(run(['git', 'diff', '--name-only', f'{base_ref}...{head_ref}']))
+    ahead_behind = run(['git', 'rev-list', '--left-right', '--count', f'{base_ref}...{head_ref}'])
+    behind, ahead = (int(x) for x in ahead_behind.split())
+
+    # What the BASE changed since we diverged. `A...B` diffs from the merge-base, so this is
+    # exactly "commits on the base we do not have", expressed as files.
+    base_changed = _lines(run(['git', 'diff', '--name-only', f'{head_ref}...{base_ref}']))
+
+    overlap = sorted(set(changed) & set(base_changed))
+    hot_overlap = [p for p in overlap if is_hot(p)]
+    hot_hits = [p for p in changed if is_hot(p)]
+
+    out += [
+        f'changed_files={len(changed)}',
+        f'ahead={ahead}',
+        f'behind={behind}',
+        f'hot_path_hits={len(hot_hits)}',
+        f'base_changed_files={len(base_changed)}',
+        f'overlap={len(overlap)}',
+        f'hot_overlap={len(hot_overlap)}',
+    ]
+    if hot_hits:
+        out.append('hot paths:')
+        out += [f' - {p}' for p in hot_hits]
+    if overlap:
+        out.append('overlapping files (changed by BOTH this branch and the base):')
+        out += [f' - {p}' for p in overlap]
+
+    if not changed:
+        out.append('no changed files detected; nothing to audit')
+        return 0, out
+
+    if strict and behind > 0:
+        out.append(f'PREMERGE_STRICT=1 and branch is {behind} behind — refresh before merge')
+        return 1, out
+
+    if hot_overlap:
+        out.append(
+            f'REFUSED: {len(hot_overlap)} hot path(s) changed by BOTH this branch and the base. '
+            'Rebase and re-run the tests — a load-bearing file must not be merged on inference.'
+        )
+        return 1, out
+
+    if overlap:
+        out.append(
+            f'REFUSED: {len(overlap)} file(s) changed by BOTH this branch and the base since the '
+            'merge-base. That is a real conflict surface even when git can auto-merge it — '
+            'rebase and re-run the tests.'
+        )
+        return 1, out
+
+    if behind > max_behind:
+        out.append(
+            f'REFUSED: {behind} commits behind exceeds the {max_behind} tolerance. Nothing '
+            'overlaps, but a branch this stale was authored against a materially different tree.'
+        )
+        return 1, out
+
+    if behind:
+        out.append(
+            f"OK: {behind} commit(s) behind, but the base touched none of this branch's files "
+            f'({len(base_changed)} base file(s) checked) — staleness cannot affect this change.'
+        )
+    else:
+        out.append('OK: branch is current with base.')
+    return 0, out
+
+
 def main() -> int:
     base_ref = os.environ.get('PREMERGE_BASE_REF', 'origin/main')
     head_ref = os.environ.get('PREMERGE_HEAD_REF', 'HEAD')
+    max_behind = int(os.environ.get('PREMERGE_MAX_BEHIND', DEFAULT_MAX_BEHIND))
+    strict = os.environ.get('PREMERGE_STRICT') == '1'
 
-    diff_output = run(['git', 'diff', '--name-only', f'{base_ref}...{head_ref}'])
-    changed = [line for line in diff_output.splitlines() if line.strip()]
-
-    ahead_behind = run(['git', 'rev-list', '--left-right', '--count', f'{base_ref}...{head_ref}'])
-    behind, ahead = [int(x) for x in ahead_behind.split()]
-
-    hot_hits = [path for path in changed if any(path == prefix or path.startswith(prefix) for prefix in HOT_PREFIXES)]
-
-    print('premerge audit summary')
-    print(f'base_ref={base_ref}')
-    print(f'head_ref={head_ref}')
-    print(f'changed_files={len(changed)}')
-    print(f'ahead={ahead}')
-    print(f'behind={behind}')
-    print(f'hot_path_hits={len(hot_hits)}')
-
-    if hot_hits:
-        print('hot paths:')
-        for path in hot_hits:
-            print(f' - {path}')
-
-    if behind > 0:
-        print('branch is behind base and should be refreshed before merge')
-        return 1
-    if not changed:
-        print('no changed files detected; nothing to audit')
-        return 0
-    return 0
+    code, report = audit(base_ref, head_ref, max_behind, strict)
+    for line in report:
+        print(line)
+    return code
 
 
 if __name__ == '__main__':

--- a/tools/premerge_audit.py
+++ b/tools/premerge_audit.py
@@ -19,7 +19,8 @@ merge queue establishes by rebase-and-test, computed here in one cheap diff.
 
 DECISION MODEL
 --------------
-  overlap     = files this branch changed  n  files the base changed since our merge-base
+  overlap     = intersection of (files this branch changed) and (files the base changed
+                since our merge-base)
   hot overlap = overlap restricted to HOT_PREFIXES (build, CI, tooling, contracts, apps)
 
   1. hot overlap non-empty         -> FAIL. Both sides edited something load-bearing.
@@ -109,13 +110,17 @@ def audit(base_ref: str, head_ref: str, max_behind: int = DEFAULT_MAX_BEHIND,
         out.append('overlapping files (changed by BOTH this branch and the base):')
         out += [f' - {p}' for p in overlap]
 
-    if not changed:
-        out.append('no changed files detected; nothing to audit')
-        return 0, out
-
+    # STRICT is evaluated FIRST, before the no-op early return: the historical gate failed on
+    # `behind > 0` regardless of whether the branch changed anything, and "restores the old
+    # behaviour" has to mean exactly that. (Caught in review — the original ordering let a
+    # behind-but-empty branch pass under strict.)
     if strict and behind > 0:
         out.append(f'PREMERGE_STRICT=1 and branch is {behind} behind — refresh before merge')
         return 1, out
+
+    if not changed:
+        out.append('no changed files detected; nothing to audit')
+        return 0, out
 
     if hot_overlap:
         out.append(

--- a/tools/tests/test_premerge_audit.py
+++ b/tools/tests/test_premerge_audit.py
@@ -1,0 +1,148 @@
+"""premerge_audit against REAL git repositories.
+
+A merge gate mocked at the subprocess boundary proves only that the mocks agree with each
+other. Every case here builds an actual repo with an actual divergence, so the assertions
+are about git's real answers.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools import premerge_audit  # noqa: E402
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(['git', *args], cwd=repo, text=True).strip()
+
+
+def write(repo: Path, rel: str, text: str) -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+@pytest.fixture()
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A repo with `main` and a `feature` branch that diverged after a common base."""
+    r = tmp_path / 'r'
+    r.mkdir()
+    git(r, 'init', '-q', '-b', 'main')
+    git(r, 'config', 'user.email', 't@t')
+    git(r, 'config', 'user.name', 't')
+    write(r, 'README.md', 'base\n')
+    write(r, 'apps/svc/main.py', 'base\n')
+    write(r, 'docs/notes.md', 'base\n')
+    git(r, 'add', '-A')
+    git(r, 'commit', '-qm', 'base')
+    git(r, 'branch', 'feature')
+    # point the module at this repo
+    monkeypatch.setattr(premerge_audit, 'ROOT', r)
+    return r
+
+
+def advance_main(repo: Path, rel: str, text: str, msg: str = 'main moves') -> None:
+    git(repo, 'checkout', '-q', 'main')
+    write(repo, rel, text)
+    git(repo, 'add', '-A')
+    git(repo, 'commit', '-qm', msg)
+
+
+def commit_on_feature(repo: Path, rel: str, text: str, msg: str = 'feature work') -> None:
+    git(repo, 'checkout', '-q', 'feature')
+    write(repo, rel, text)
+    git(repo, 'add', '-A')
+    git(repo, 'commit', '-qm', msg)
+
+
+def audit(repo: Path, **kw):
+    git(repo, 'checkout', '-q', 'feature')
+    return premerge_audit.audit('main', 'HEAD', **kw)
+
+
+def test_current_branch_passes(repo: Path):
+    commit_on_feature(repo, 'docs/notes.md', 'changed\n')
+    code, out = audit(repo)
+    assert code == 0
+    assert any('branch is current' in line for line in out)
+
+
+def test_the_starvation_case_now_passes_when_nothing_overlaps(repo: Path):
+    """THE regression this change exists to prevent: a docs-only PR blocked because an
+    unrelated service moved on main. Behind > 0, zero overlap => safe."""
+    commit_on_feature(repo, 'docs/notes.md', 'my docs\n')
+    advance_main(repo, 'apps/other/thing.py', 'unrelated\n')
+    advance_main(repo, 'apps/other/more.py', 'also unrelated\n', 'main moves again')
+    code, out = audit(repo)
+    assert code == 0, out
+    assert any('staleness cannot affect this change' in line for line in out)
+    assert any(line == 'behind=2' for line in out), 'still reports the drift honestly'
+
+
+def test_overlap_is_refused_even_though_git_could_automerge(repo: Path):
+    """The case the OLD gate missed in the other direction: both sides edited the same file.
+    Different lines, git merges fine — and it is still a real conflict surface."""
+    commit_on_feature(repo, 'docs/notes.md', 'base\nmine at the bottom\n')
+    advance_main(repo, 'docs/notes.md', 'theirs at the top\nbase\n')
+    code, out = audit(repo)
+    assert code == 1
+    assert any('REFUSED' in line and 'conflict surface' in line for line in out)
+    assert any(' - docs/notes.md' in line for line in out), 'names the offending file'
+
+
+def test_hot_path_overlap_is_refused_with_its_own_reason(repo: Path):
+    commit_on_feature(repo, 'apps/svc/main.py', 'base\nmine\n')
+    advance_main(repo, 'apps/svc/main.py', 'theirs\nbase\n')
+    code, out = audit(repo)
+    assert code == 1
+    assert any('hot path' in line and 'REFUSED' in line for line in out)
+    assert any(line == 'hot_overlap=1' for line in out)
+
+
+def test_hot_paths_alone_do_not_block_when_the_base_left_them_untouched(repo: Path):
+    """Touching apps/ is normal work. It only matters when the BASE touched it too —
+    otherwise the old gate's hot-path signal was noise it printed and ignored anyway."""
+    commit_on_feature(repo, 'apps/svc/main.py', 'mine\n')
+    advance_main(repo, 'docs/notes.md', 'unrelated\n')
+    code, out = audit(repo)
+    assert code == 0, out
+    assert any(line == 'hot_path_hits=1' for line in out)
+    assert any(line == 'hot_overlap=0' for line in out)
+
+
+def test_unbounded_drift_is_refused_even_without_overlap(repo: Path):
+    commit_on_feature(repo, 'docs/notes.md', 'mine\n')
+    for i in range(4):
+        advance_main(repo, f'apps/other/f{i}.py', f'{i}\n', f'main {i}')
+    code, out = audit(repo, max_behind=2)
+    assert code == 1
+    assert any('exceeds the 2 tolerance' in line for line in out)
+
+
+def test_strict_mode_restores_the_old_behaviour_exactly(repo: Path):
+    commit_on_feature(repo, 'docs/notes.md', 'mine\n')
+    advance_main(repo, 'apps/other/thing.py', 'unrelated\n')
+    assert audit(repo)[0] == 0, 'default: safe'
+    code, out = audit(repo, strict=True)
+    assert code == 1
+    assert any('PREMERGE_STRICT=1' in line for line in out)
+
+
+def test_a_branch_with_no_changes_is_a_no_op(repo: Path):
+    code, out = audit(repo)
+    assert code == 0
+    assert any('nothing to audit' in line for line in out)
+
+
+def test_report_always_carries_the_counters_downstream_tooling_reads(repo: Path):
+    commit_on_feature(repo, 'docs/notes.md', 'mine\n')
+    _, out = audit(repo)
+    for key in ('changed_files=', 'ahead=', 'behind=', 'hot_path_hits=', 'overlap=', 'hot_overlap='):
+        assert any(line.startswith(key) for line in out), f'missing {key}'

--- a/tools/tests/test_premerge_audit.py
+++ b/tools/tests/test_premerge_audit.py
@@ -146,3 +146,13 @@ def test_report_always_carries_the_counters_downstream_tooling_reads(repo: Path)
     _, out = audit(repo)
     for key in ('changed_files=', 'ahead=', 'behind=', 'hot_path_hits=', 'overlap=', 'hot_overlap='):
         assert any(line.startswith(key) for line in out), f'missing {key}'
+
+
+def test_strict_mode_fails_a_behind_branch_even_with_no_changes(repo: Path):
+    """Regression (review-found): the old gate failed on `behind > 0` regardless of whether
+    the branch changed anything. Strict mode must reproduce that exactly, so the no-op
+    early return cannot be allowed to short-circuit it."""
+    advance_main(repo, 'apps/other/thing.py', 'unrelated\n')
+    code, out = audit(repo, strict=True)      # feature has NO commits of its own
+    assert code == 1
+    assert any('PREMERGE_STRICT=1' in line for line in out)


### PR DESCRIPTION
## The problem, observed live
The rule was `behind > 0 → fail`. On a busy repo that **starves PRs**: rebase to zero → CI takes ten minutes → main moves two commits → gate fails → repeat. It blocked a **docs-only** PR here while an unrelated service promotion landed. It also made *small safe* changes more expensive than large risky ones, because they're the ones left waiting for a quiet moment that never comes.

It was unsound in the other direction too: **`behind == 0` does not mean safe.** A branch can be current and still break main; a branch can be 40 behind and be provably unaffected by every one of those commits.

## The fix — gate on the real question
*Did the base change anything this branch also touches?* That's the actual conflict surface — the same thing a merge queue establishes by rebase-and-test, computed in one cheap diff.

| | rule |
|---|---|
| 1 | **hot overlap** → FAIL (both sides edited something load-bearing) |
| 2 | **overlap** → FAIL (real conflict surface *even when git auto-merges*) |
| 3 | `behind > PREMERGE_MAX_BEHIND` (50) → FAIL (unbounded drift is its own risk) |
| 4 | otherwise → **PASS**, stating why staleness is harmless here |

**Rules 1–2 are stricter than before** — a zero-behind branch with an overlapping edit used to sail straight through, and that's the class that actually breaks main. Rules 3–4 are looser *only where looseness is provable*. Net: fewer false alarms **and** a real conflict class now caught.

Also fixes a **"declared but unenforced" inside the gate itself**: `hot_path_hits` was computed, printed, and never used in any decision.

`PREMERGE_STRICT=1` restores the old behaviour verbatim. The docstring is explicit that this **approximates** a merge queue, and that a real merge queue (rebase-and-*test* at the head) is better where available — I'd recommend enabling one for this repo.

## Tests
**9 tests against real git repositories.** A merge gate mocked at the subprocess boundary proves only that the mocks agree with each other. Cases include the exact starvation scenario, the overlap case the old rule missed, hot-path overlap, unbounded drift, and strict-mode parity.

Dogfooded: run against its own diff it reports `hot_path_hits=2, hot_overlap=0 → OK`.