### PR TITLE
Stop the Host header choosing SMART links; make consult receipts real and unambiguous

### DIFF
--- a/apps/health-twin/src/consult.ts
+++ b/apps/health-twin/src/consult.ts
@@ -5,10 +5,20 @@
 //
 // Each opinion attaches to the consult as a TIER=hypothesis claim (an opinion, never asserted truth —
 // the anti-Watson rule). The aggregate is a signal, NOT a diagnosis; a clinician still decides.
+import { createHash } from 'node:crypto';
 import { deidentify, type DeidView, type DisclosureScope } from './deident.js';
 
-function djb2(s: string): string { let h = 5381; for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff; return (h >>> 0).toString(16).padStart(8, '0'); }
-const receipt = (kind: string, parts: string[]) => ({ id: `ht-${kind}-${djb2(parts.join('|'))}`, verifier: 'health-twin', at: new Date().toISOString() });
+// server.ts replaced djb2 with real SHA-256 and said so; this file was missed, so consult
+// ids and consult receipts stayed 32-bit djb2 — trivially collidable, and guessable enough
+// that an id which can be fetched and posted to is an enumeration surface.
+//
+// Parts are JSON-encoded rather than joined on '|'. A separator that can occur inside a part
+// is not a separator: ['a|b','c'] and ['a','b|c'] joined that way produce the same string and
+// therefore the same digest, so a stronger hash over an ambiguous encoding still collides.
+function sha256(parts: string[]): string {
+  return createHash('sha256').update(JSON.stringify(parts)).digest('hex');
+}
+const receipt = (kind: string, parts: string[]) => ({ id: `ht-${kind}-${sha256(parts)}`, verifier: 'health-twin', at: new Date().toISOString() });
 
 export type Confidence = 'low' | 'moderate' | 'high';
 export interface Opinion {
@@ -45,7 +55,7 @@ export function openConsult(bundle: any, scope = 'whole twin', disclosure: Discl
   if (!agreed) return { error: 'patient must agree to the disclosure terms before a consult can open' };
   const salt = `${Date.now()}-${scope}`;
   const slice = deidentify(bundle, salt, disclosure);
-  const id = `consult-${djb2([slice.receipt.pseudonym, scope, salt].join('|'))}`;
+  const id = `consult-${sha256([slice.receipt.pseudonym, scope, salt])}`;
   const consent: Consent = { agreed: true, disclosure, at: new Date().toISOString(), receipt: receipt('consent', [id, disclosure]).id };
   consults.set(id, { id, createdAt: new Date().toISOString(), scope, consent, slice, blind: true, opinions: [], moreRequests: [] });
   return { consult_id: id, slice, consent, receipt: receipt('consult-open', [id, scope]) };
@@ -56,7 +66,7 @@ export function openConsult(bundle: any, scope = 'whole twin', disclosure: Discl
 export function requestMore(consultId: string, field: string, reason: string): MoreRequest | { error: string } {
   const c = consults.get(consultId);
   if (!c) return { error: 'consult not found' };
-  const r: MoreRequest = { id: `more-${djb2([consultId, field, String(Date.now())].join('|'))}`, field: field.trim(), reason: reason.trim(), status: 'pending', at: new Date().toISOString() };
+  const r: MoreRequest = { id: `more-${sha256([consultId, field, String(Date.now())])}`, field: field.trim(), reason: reason.trim(), status: 'pending', at: new Date().toISOString() };
   c.moreRequests.push(r);
   return r;
 }
@@ -75,7 +85,7 @@ export function submitOpinion(consultId: string, reviewer: string, assessment: s
   const rv = reviewer.trim(); const a = assessment.trim();
   if (!rv || !a) return { error: 'reviewer and assessment required' };
   const op: Opinion = {
-    id: `op-${djb2([consultId, rv, a, String(Date.now())].join('|'))}`,
+    id: `op-${sha256([consultId, rv, a, String(Date.now())])}`,
     reviewer: rv, assessment: a, confidence, tier: 'hypothesis',
     at: new Date().toISOString(), receipt: receipt('opinion', [consultId, rv]),
   };

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -106,14 +106,31 @@ console.log('\n▶ INVARIANT 4 — grant scoping: the doctor sees exactly the gr
 
 
 // cryptographic receipts: receipt ids + content addresses must be REAL sha256 (64 hex), never a
-// short non-cryptographic hash wearing a sha label (the djb2-as-"sha-" regression, fixed 2026-07-29)
+// short non-cryptographic hash wearing a sha label.
+//
+// The previous version of this block computed its OWN sha256, built its OWN string, and
+// asserted that the string it had just built matched a regex. It proved that node can hash,
+// and touched not one receipt this service emits — which is why it passed for the whole
+// period consult.ts was still minting 8-hex djb2 ids under the same comment claiming the
+// regression was fixed. An invariant that constructs its own subject cannot fail.
+//
+// These read the ids the code actually produces.
 {
-  const { createHash } = await import("node:crypto");
-  const h = createHash("sha256").update("probe").digest("hex");
-  ok(/^[0-9a-f]{64}$/.test(h), "sha256 available and 64-hex");
-  const rid = `ht-probe-${h}`;
-  ok(/^ht-[a-z-]+-[0-9a-f]{64}$/.test(rid), "receipt id shape is ht-<kind>-<sha256 64-hex>");
-  ok(/^sha256-[0-9a-f]{64}$/.test(`sha256-${h}`), "content addresses are sha256-<64-hex> — label matches the math");
+  const consult = openConsult(sampleBundle, 'receipt-probe', 'standard', true);
+  ok(/^consult-[0-9a-f]{64}$/.test(consult.consult_id ?? ''),
+     `consult id is a real sha256 (${(consult.consult_id ?? '').slice(0, 24)}…)`);
+  ok(/^ht-[a-z-]+-[0-9a-f]{64}$/.test(consult.receipt?.id ?? ''),
+     'consult-open receipt id is ht-<kind>-<sha256 64-hex>');
+  ok(/^ht-[a-z-]+-[0-9a-f]{64}$/.test(consult.consent?.receipt ?? ''),
+     'consent receipt id is ht-<kind>-<sha256 64-hex>');
+
+  const opinion = submitOpinion(consult.consult_id!, 'reviewer-probe', 'a read', 'moderate') as any;
+  ok(/^op-[0-9a-f]{64}$/.test(opinion.id ?? ''), 'opinion id is a real sha256');
+  ok(/^ht-[a-z-]+-[0-9a-f]{64}$/.test(opinion.receipt?.id ?? ''), 'opinion receipt id is a real sha256');
+
+  // No id anywhere may be the old 8-hex djb2 shape.
+  const ids = [consult.consult_id, consult.receipt?.id, consult.consent?.receipt, opinion.id, opinion.receipt?.id];
+  ok(ids.every((i) => !/-[0-9a-f]{8}$/.test(String(i))), 'no id ends in an 8-hex (djb2) digest');
 }
 
 console.log(`\n${fails === 0 ? '✓ ALL GUARDRAIL INVARIANTS HOLD (non-diagnostic + de-identification + grant scoping enforced)' : `✗ ${fails} invariant(s) violated`}`);

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -34,8 +34,12 @@ const PORT = Number(process.env.PORT ?? 8097);
 function sha256(s: string): string {
   return createHash('sha256').update(s).digest('hex');
 }
+// Parts are JSON-encoded, not joined on '|'. A separator that can appear inside a part is
+// not a separator: ['a|b','c'] and ['a','b|c'] join to the same string and so hash to the
+// same digest. A stronger hash over an ambiguous encoding is still ambiguous — two
+// different fact-sets producing one receipt id is exactly what tamper-evidence must exclude.
 function receipt(kind: string, parts: string[]): { id: string; verifier: 'health-twin'; at: string } {
-  return { id: `ht-${kind}-${sha256(parts.join('|'))}`, verifier: 'health-twin', at: new Date().toISOString() };
+  return { id: `ht-${kind}-${sha256(JSON.stringify(parts))}`, verifier: 'health-twin', at: new Date().toISOString() };
 }
 
 // In-memory grant ledger (skeleton). Local-first store in production. Seeded with one active
@@ -252,7 +256,13 @@ const server = http.createServer(async (req, res) => {
     try {
       await readJson(req); // hook context (patientId, prefetch) — skeleton reads the local twin
       const id = url.pathname.slice('/cds-services/'.length);
-      const base = process.env.SMART_APP_BASE ?? `http://${req.headers.host}`;
+      // SMART launch links go into CDS cards a clinician clicks. Falling back to
+      // req.headers.host let a caller choose that destination: Host is attacker-supplied
+      // on most deployments, so a crafted header pointed the "launch the twin" link at a
+      // domain of their choosing, inside a card the EHR presents as ours.
+      // Configured value only — no configuration means relative links, which resolve
+      // against whatever origin actually served the card rather than a claimed one.
+      const base = process.env.SMART_APP_BASE ?? '';
       if (id === 'health-twin-patient-summary') return send(res, 200, await patientSummaryCards(ingested, base));
       if (id === 'health-twin-medication-reconciliation') return send(res, 200, await medReconciliationCards(ingested, base));
       return send(res, 404, { error: `unknown cds-service: ${id}` });


### PR DESCRIPTION
Three Copilot findings — **#940**, **#942**, **#999** — all still live on `main`, verified against `c4ebc2ee`.

## #940 — the Host header chose where a clinical link pointed

```ts
const base = process.env.SMART_APP_BASE ?? `http://${req.headers.host}`;
```

SMART launch links go into CDS cards a clinician clicks. `Host` is attacker-supplied on most deployments, so a crafted header decided where *"Open Health Twin in context"* pointed — inside a card the EHR presents as ours.

Configured value only. With none configured the link is **relative**, resolving against the origin that actually served the card rather than one a caller claimed.

## #942 — the djb2 remediation was only half done

`server.ts` moved to real SHA-256 and left a comment saying so. `consult.ts` was missed and still minted **32-bit djb2** ids for consults, opinions, more-requests and their receipts. Consult ids are fetchable and postable, so a guessable one is an enumeration surface.

## #999 — a stronger hash over an ambiguous encoding is still ambiguous

Both files hashed `parts.join('|')`. A separator that can occur inside a part is not a separator:

```
['a|b', 'c']  →  "a|b|c"
['a', 'b|c']  →  "a|b|c"      same string, same digest
```

Two different fact-sets producing one receipt id is exactly what tamper-evidence must exclude — and the SHA-256 upgrade did nothing about it. Parts are JSON-encoded now, in both files.

## The invariant that was supposed to catch all this

```js
const h = createHash("sha256").update("probe").digest("hex");
const rid = `ht-probe-${h}`;
ok(/^ht-[a-z-]+-[0-9a-f]{64}$/.test(rid), "receipt id shape is ht-<kind>-<sha256 64-hex>");
```

It computes its **own** hash, builds its **own** string, and asserts that the string it just built matches a regex. It proves node can hash. **It touches no receipt this service emits** — which is how it passed for the entire period `consult.ts` was minting 8-hex ids, directly beneath a comment declaring the djb2 regression *"fixed 2026-07-29"*.

An invariant that constructs its own subject cannot fail. Copilot said this almost word for word on #999 and it was right.

It now reads the ids the code actually produces — consult id, consult-open receipt, consent receipt, opinion id, opinion receipt — and asserts none ends in an 8-hex digest:

```
✓ consult id is a real sha256 (consult-58aa5aac75e1a6b2…)
✓ consult-open receipt id is ht-<kind>-<sha256 64-hex>
✓ consent receipt id is ht-<kind>-<sha256 64-hex>
✓ opinion id is a real sha256
✓ opinion receipt id is a real sha256
✓ no id ends in an 8-hex (djb2) digest
```

**Mutation-tested:** reintroducing djb2 fails four of them. Restoring passes. That is the difference between this version and the one it replaces.

35 invariants, 0 failures. `tsc` clean.

> Third batch from the 45-day Copilot survey, after #1033 and #1034.
>
> **#932 assessed, not fixed here.** `GET /api/health/twin` returns the full bundle with no authorization, and health-twin has *no* auth machinery at all — zero matches for Authorization/Bearer/401. Its header says it runs "LOCAL-FIRST on the person's own node", but `deploy/values/health-twin.yaml` routes it through nginx at `/svc/health`, so it is reachable. Data is synthetic today; the connector plane can land real records. Adding an auth model to a service that has none, and updating every cockpit call to carry a token, is a design decision rather than a defect fix — flagging it for you rather than inventing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)