### PR TITLE
Stop serving the record bundle openly once real records exist

### DIFF
--- a/apps/health-twin/src/exposure.ts
+++ b/apps/health-twin/src/exposure.ts
@@ -1,0 +1,77 @@
+// Who may read the record bundle, and on what grounds.
+//
+// GET /api/health/twin returned the whole bundle with no authorization. The service header
+// says it runs LOCAL-FIRST on the person's own node — but deploy/values routes it through
+// the cockpit's nginx at /svc/health, so it is reachable, and the cockpit calls it from the
+// BROWSER. A bearer token would therefore live in JavaScript, which is not authentication;
+// it is authentication-shaped decoration.
+//
+// What actually makes the endpoint safe today is that the data is synthetic. So that is the
+// thing enforced: in the default mode the twin serves freely and REFUSES the moment real
+// records exist. The connector plane can land real records at any time, and when it does the
+// open endpoint has to stop on its own — not when someone remembers to change a setting.
+//
+// 'authenticated' is for a deployment that genuinely serves a person's records: a token is
+// required and its absence fails closed, so the permissive mode is something an operator
+// asserts rather than something they inherit by forgetting.
+//
+// Pure and parameterised so it is testable without standing up a server; server.ts binds a
+// port at import time, which would otherwise make the gate provable only by running it.
+
+export type Exposure = 'synthetic-only' | 'authenticated';
+
+export interface ExposureDenial {
+  code: 401 | 403 | 503;
+  body: Record<string, unknown>;
+}
+
+export interface ExposureInputs {
+  mode: Exposure;
+  /** Configured shared secret. Empty means none configured. */
+  token: string;
+  /** Raw Authorization header as presented, if any. */
+  authorization: string;
+  /** How many records the connector plane has actually landed. */
+  ingestedRecords: number;
+}
+
+/** Read the mode from the environment. Anything but the explicit opt-in is synthetic-only. */
+export function exposureFromEnv(env: NodeJS.ProcessEnv = process.env): Exposure {
+  return env['HEALTH_TWIN_EXPOSURE'] === 'authenticated' ? 'authenticated' : 'synthetic-only';
+}
+
+/** Null = serve it. Otherwise the refusal, with the reason stated rather than implied. */
+export function exposureDenial(input: ExposureInputs): ExposureDenial | null {
+  if (input.mode === 'authenticated') {
+    if (!input.token) {
+      return {
+        code: 503,
+        body: {
+          error: 'HEALTH_TWIN_EXPOSURE=authenticated but HEALTH_TWIN_TOKEN is unset — ' +
+            'refusing to serve records ungoverned (fail-closed)',
+        },
+      };
+    }
+    const presented = input.authorization.replace(/^Bearer\s+/i, '').trim();
+    // Length-independent compare is not the concern here (the token is a deployment secret,
+    // not a per-user credential); an empty presented value must simply never match.
+    if (!presented || presented !== input.token) {
+      return { code: 401, body: { error: 'unauthorized' } };
+    }
+    return null;
+  }
+
+  if (input.ingestedRecords > 0) {
+    return {
+      code: 403,
+      body: {
+        error: 'refusing to serve the record bundle: this instance holds ingested records ' +
+          'and is running in synthetic-only exposure',
+        ingestedRecords: input.ingestedRecords,
+        remedy: 'set HEALTH_TWIN_EXPOSURE=authenticated and provision HEALTH_TWIN_TOKEN, or ' +
+          'run this twin local-first and stop routing it publicly',
+      },
+    };
+  }
+  return null;
+}

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -116,5 +116,45 @@ console.log('\n▶ INVARIANT 4 — grant scoping: the doctor sees exactly the gr
   ok(/^sha256-[0-9a-f]{64}$/.test(`sha256-${h}`), "content addresses are sha256-<64-hex> — label matches the math");
 }
 
+
+console.log('\n▶ INVARIANT 6 — the record bundle is not served open once real records exist');
+{
+  const { exposureDenial, exposureFromEnv } = await import('./exposure.js');
+  const open = { mode: 'synthetic-only' as const, token: '', authorization: '' };
+
+  // The safety of the open endpoint rests entirely on the data being synthetic, so that is
+  // the condition enforced. A twin holding real records must stop serving them openly on its
+  // own, not when someone remembers to change a setting.
+  ok(exposureDenial({ ...open, ingestedRecords: 0 }) === null,
+     'synthetic twin (0 ingested records) serves the bundle');
+  const withRecords = exposureDenial({ ...open, ingestedRecords: 1 });
+  ok(withRecords?.code === 403,
+     'ONE real ingested record stops the open bundle (403)');
+  ok(String(JSON.stringify(withRecords?.body)).includes('remedy'),
+     'the refusal states how to serve records legitimately, not just that it refused');
+
+  // authenticated mode: the permissive state must be asserted, and asserting it without a
+  // secret must fail closed rather than silently serving.
+  const auth = { mode: 'authenticated' as const, ingestedRecords: 0 };
+  ok(exposureDenial({ ...auth, token: '', authorization: 'Bearer anything' })?.code === 503,
+     'authenticated mode with no token configured fails CLOSED (503), it does not serve');
+  ok(exposureDenial({ ...auth, token: 's3cret', authorization: '' })?.code === 401,
+     'no Authorization header is refused');
+  ok(exposureDenial({ ...auth, token: 's3cret', authorization: 'Bearer wrong' })?.code === 401,
+     'a wrong token is refused');
+  ok(exposureDenial({ ...auth, token: 's3cret', authorization: 'Bearer s3cret' }) === null,
+     'the configured token is accepted');
+  ok(exposureDenial({ ...auth, token: 's3cret', authorization: 'Bearer  s3cret  ' }) === null,
+     'surrounding whitespace does not defeat a correct token');
+  // and a real deployment still serves records under a token, which synthetic-only would refuse
+  ok(exposureDenial({ mode: 'authenticated', token: 's3cret', authorization: 'Bearer s3cret', ingestedRecords: 500 }) === null,
+     'authenticated mode serves real records — the gate is about governance, not about refusing work');
+
+  // default is the safe one: anything but the explicit opt-in is synthetic-only
+  ok(exposureFromEnv({} as NodeJS.ProcessEnv) === 'synthetic-only', 'default exposure is synthetic-only');
+  ok(exposureFromEnv({ HEALTH_TWIN_EXPOSURE: 'yes' } as any) === 'synthetic-only', 'an unrecognised value is NOT treated as authenticated');
+  ok(exposureFromEnv({ HEALTH_TWIN_EXPOSURE: 'authenticated' } as any) === 'authenticated', 'the explicit opt-in is honoured');
+}
+
 console.log(`\n${fails === 0 ? '✓ ALL GUARDRAIL INVARIANTS HOLD (non-diagnostic + de-identification + grant scoping enforced)' : `✗ ${fails} invariant(s) violated`}`);
 process.exit(fails === 0 ? 0 : 1);

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -25,6 +25,7 @@ import { codeText, type CodedEntity } from './clinical.js';
 import { guidance } from './guidelines.js';
 import { openConsult, reviewerView, submitOpinion, aggregate, requestMore, type Confidence } from './consult.js';
 import { resolveScope, resolveGrant, applyScope, scopeSummary, SCOPE_PRESETS } from './grants.js';
+import { exposureDenial, exposureFromEnv } from './exposure.js';
 
 const PORT = Number(process.env.PORT ?? 8097);
 
@@ -36,6 +37,19 @@ function sha256(s: string): string {
 }
 function receipt(kind: string, parts: string[]): { id: string; verifier: 'health-twin'; at: string } {
   return { id: `ht-${kind}-${sha256(parts.join('|'))}`, verifier: 'health-twin', at: new Date().toISOString() };
+}
+
+// Exposure gate — see exposure.ts for why the condition is "is the data synthetic" rather
+// than a bearer token the browser would have to hold.
+const EXPOSURE = exposureFromEnv();
+
+function denyExposure(req: http.IncomingMessage) {
+  return exposureDenial({
+    mode: EXPOSURE,
+    token: process.env.HEALTH_TWIN_TOKEN ?? '',
+    authorization: String(req.headers['authorization'] ?? ''),
+    ingestedRecords: resultCounts(ingested).total,
+  });
 }
 
 // In-memory grant ledger (skeleton). Local-first store in production. Seeded with one active
@@ -163,7 +177,10 @@ const server = http.createServer(async (req, res) => {
   if (req.method === 'GET' && url.pathname === '/healthz') return send(res, 200, { ok: true, service: 'health-twin' });
 
   // The twin bundle (the surface's one read).
-  if (req.method === 'GET' && url.pathname === '/api/health/twin') return send(res, 200, bundle());
+  if (req.method === 'GET' && url.pathname === '/api/health/twin') {
+    const denied = denyExposure(req);
+    return denied ? send(res, denied.code, denied.body) : send(res, 200, bundle());
+  }
 
   // the twin as reasoner-ready RDF (Turtle) — typed with the HDT ontology, imports the TBox.
   if (req.method === 'GET' && url.pathname === '/api/health/twin.ttl') {
@@ -365,7 +382,11 @@ const server = http.createServer(async (req, res) => {
   }
 
   // A de-identified view of the twin (Safe-Harbor + date-shift) — proof identity is gone.
-  if (req.method === 'GET' && url.pathname === '/api/health/deident') return send(res, 200, deidentify(bundle()));
+  if (req.method === 'GET' && url.pathname === '/api/health/deident') {
+    // De-identified, but still derived from the same records — gated on the same condition.
+    const denied = denyExposure(req);
+    return denied ? send(res, denied.code, denied.body) : send(res, 200, deidentify(bundle()));
+  }
 
   // Open a blinded consult: requires the patient's agreement (anonymous by default). `disclosure` =
   // the agreed scope ('standard' keeps age-band + sex a doctor needs; 'minimal' = facts only).


### PR DESCRIPTION
The last Tier-1 finding from the 45-day Copilot survey (**#932**). `GET /api/health/twin` returned the whole record bundle with no authorization, and health-twin has **no auth machinery at all** — zero matches for Authorization, Bearer or 401 anywhere in the service.

## Why a bearer token would have been theatre

The service header says it runs LOCAL-FIRST on the person's own node, never a shared cloud. But `deploy/values/health-twin.yaml` routes it through the cockpit's nginx at `/svc/health`, and the cockpit calls it **from the browser**:

```
apps/socioprophet-web/nginx.conf:91
  location /svc/health/ { proxy_pass http://health-twin.socioprophet.svc.cluster.local:8097; }
```

A token would therefore live in JavaScript where anyone can read it. That closes the finding on paper and changes nothing in fact.

## What is enforced instead

**The thing that actually makes this endpoint safe today is that the data is synthetic.** So that is the condition:

- **`synthetic-only` (default)** — serves freely, and **refuses the moment the connector plane has landed one real record.** The endpoint stops on its own when the risk materialises, rather than when someone remembers to change a setting. The 403 states the remedy, not just the refusal.
- **`authenticated`** — for a deployment that genuinely serves a person's records. A token is required; setting the mode *without* providing one fails closed at 503 rather than serving.

Anything other than the explicit opt-in reads as `synthetic-only`, so the permissive state must be **asserted**, never inherited by typo.

## Testability was a design constraint, not an afterthought

The logic lives in `exposure.ts` as a pure function rather than inside the request handler. `server.ts` binds a port at import, which would have made this gate provable only by standing up a server — and a gate that is awkward to test is a gate that ends up untested. That is the failure mode this whole line of work exists to remove.

## Twelve invariants, mostly refusals

```
✓ synthetic twin (0 ingested records) serves the bundle
✓ ONE real ingested record stops the open bundle (403)
✓ the refusal states how to serve records legitimately, not just that it refused
✓ authenticated mode with no token configured fails CLOSED (503), it does not serve
✓ no Authorization header is refused
✓ a wrong token is refused
✓ the configured token is accepted
✓ surrounding whitespace does not defeat a correct token
✓ authenticated mode serves real records — the gate is about governance, not refusing work
✓ default exposure is synthetic-only
✓ an unrecognised value is NOT treated as authenticated
✓ the explicit opt-in is honoured
```

The ninth is deliberate: a gate satisfied by refusing everything is not a gate, so authenticated mode is asserted to serve 500 real records under a valid token.

**Mutation-tested** — removing the condition fails two invariants; restoring passes.

44 invariants, 0 failures. `tsc` clean.

> Completes Tier-1: #1033 (consent + XSS), #1034 (organs + arcticdb authz), #1036 (Host header + receipts), this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)