### PR TITLE
Ship the KKO TBox in the wheel, and stop reporting a request as an outcome

### DIFF
--- a/apps/owl-reasoner/pyproject.toml
+++ b/apps/owl-reasoner/pyproject.toml
@@ -6,3 +6,9 @@ requires-python = ">=3.11"
 dependencies = ["fastapi==0.115.0","uvicorn==0.30.6","httpx==0.27.2","rdflib==7.0.0","owlrl==6.0.2","pyshacl==0.26.0"]
 [tool.setuptools.packages.find]
 where = ["src"]
+
+# The KKO TBox is DATA the reasoner loads at runtime, not code. Without this it is absent
+# from any built wheel/sdist, _kko_tbox() silently returns an empty graph, and `with_kko`
+# becomes a no-op in every installed deployment while passing from a source checkout.
+[tool.setuptools.package-data]
+owl_reasoner = ["data/*.n3", "data/*.md"]

--- a/apps/owl-reasoner/src/owl_reasoner/reasoner.py
+++ b/apps/owl-reasoner/src/owl_reasoner/reasoner.py
@@ -50,6 +50,25 @@ def _kko_tbox() -> Graph:
     return g
 
 
+def kko_tbox_status(requested: bool, triples: int) -> dict[str, Any]:
+    """What the KKO TBox actually did on this call, as opposed to what was asked for.
+
+    Requested and loaded are separate facts. _kko_tbox() deliberately degrades rather than
+    raising — a missing or unparseable vendored file must not take reasoning down — but that
+    degradation has to be visible in the response, or `with_kko=true` reports success on a
+    deployment where the ontology contributed nothing. `unavailable_reason` is present only
+    when the two disagree, so a client never has to infer the difference from a zero.
+    """
+    loaded = requested and triples > 0
+    status: dict[str, Any] = {"requested": requested, "loaded": loaded, "triples": triples}
+    if requested and not loaded:
+        status["unavailable_reason"] = (
+            f"KKO TBox requested but no triples were parsed from {_KKO_PATH.name}; "
+            "with_kko had no effect on this result"
+        )
+    return status
+
+
 def reason(turtle: str, shapes: str | None = None, inference: str = "rdfs",
            limit: int = 100, explain: bool = False, with_kko: bool = False) -> dict[str, Any]:
     """Compute entailments (+ optional SHACL validation) over a Turtle graph.
@@ -87,7 +106,11 @@ def reason(turtle: str, shapes: str | None = None, inference: str = "rdfs",
         "input_triples": n_in,
         "entailed_triples": len(entailed),
         "inference": mode,
-        "kko_tbox": {"loaded": with_kko, "triples": kko_tbox_triples},
+        # `loaded` used to be `with_kko` — the caller's REQUEST, not the outcome. _kko_tbox()
+        # swallows a missing or unparseable file and returns an empty graph, so a deployment
+        # without the TBox answered {"loaded": true, "triples": 0}: the response asserted the
+        # ontology was in play while with_kko was silently a no-op.
+        "kko_tbox": kko_tbox_status(with_kko, kko_tbox_triples),
         "profile": {"rdfs": "RDFS", "owlrl": "OWL 2 RL", "both": "OWL 2 RL + RDFS", "none": "none"}.get(mode, mode),
         # proof-carrying: each entailed triple is a derivation over stated facts + the ontology
         "entailments": [f"{_c(s)} {_c(p)} {_c(o)}" for (s, p, o) in entailed[:limit]],

--- a/apps/owl-reasoner/tests/test_reasoner.py
+++ b/apps/owl-reasoner/tests/test_reasoner.py
@@ -175,7 +175,14 @@ def test_with_kko_entails_ancestor_type_without_inline_axioms():
 
 def test_without_kko_no_ancestor_entailment():
     out = reason(KKO_LEAF_TTL, inference="rdfs")         # TBox NOT loaded
-    assert out["kko_tbox"] == {"loaded": False, "triples": 0}
+    # Asserted by property rather than exact dict equality: the status gained a `requested`
+    # field so a request can no longer be reported as an outcome, and a frozen literal here
+    # would fail on any future addition without saying anything about behaviour.
+    assert out["kko_tbox"]["requested"] is False
+    assert out["kko_tbox"]["loaded"] is False
+    assert out["kko_tbox"]["triples"] == 0
+    # not requested is not a failure, so no reason is attached
+    assert "unavailable_reason" not in out["kko_tbox"]
     assert not any("Monads" in e for e in out["entailments"])  # can't derive an ancestor with no axioms
 
 
@@ -225,3 +232,69 @@ def test_virtualize_endpoint_json_and_turtle():
 def test_virtualize_400_without_subject_template():
     r = client.post("/virtualize", json={"rows": [{"id": "1"}], "mapping": {"base": "http://ex/"}})
     assert r.status_code == 400
+
+
+# `kko_tbox.loaded` used to be the caller's REQUEST flag. _kko_tbox() degrades to an empty
+# graph when the vendored .n3 is missing or unparseable — correct, so a bad file cannot take
+# reasoning down — but with `loaded: with_kko` the response then claimed the ontology was in
+# play while `with_kko` was silently a no-op. pyproject declared no package-data, so that was
+# the state of every installed wheel while a source checkout passed.
+
+
+def test_kko_status_separates_requested_from_loaded():
+    from owl_reasoner.reasoner import kko_tbox_status
+
+    assert kko_tbox_status(False, 0) == {"requested": False, "loaded": False, "triples": 0}
+    assert kko_tbox_status(True, 335) == {"requested": True, "loaded": True, "triples": 335}
+
+
+def test_kko_status_refuses_to_claim_loaded_with_no_triples():
+    from owl_reasoner.reasoner import kko_tbox_status
+
+    s = kko_tbox_status(True, 0)
+    assert s["requested"] is True
+    assert s["loaded"] is False, "a request must never be reported as an outcome"
+    assert "unavailable_reason" in s, "the response must say why, not leave a client to infer it from a zero"
+
+
+def test_kko_reports_not_loaded_when_the_tbox_file_is_absent(monkeypatch):
+    """The wheel scenario, exercised rather than assumed.
+
+    Point _KKO_PATH at a file that does not exist, clear the lru_cache, and confirm the
+    reasoner reports loaded=False instead of echoing the request.
+    """
+    from owl_reasoner import reasoner as R
+    from pathlib import Path
+
+    R._kko_tbox.cache_clear()
+    monkeypatch.setattr(R, "_KKO_PATH", Path("/nonexistent/kko-missing.n3"))
+    try:
+        out = R.reason("<urn:a> a <urn:B> .", with_kko=True)
+        assert out["kko_tbox"]["requested"] is True
+        assert out["kko_tbox"]["loaded"] is False
+        assert out["kko_tbox"]["triples"] == 0
+        assert "unavailable_reason" in out["kko_tbox"]
+    finally:
+        R._kko_tbox.cache_clear()
+
+
+def test_kko_actually_loads_from_the_repo_checkout():
+    from owl_reasoner import reasoner as R
+
+    R._kko_tbox.cache_clear()
+    out = R.reason("<urn:a> a <urn:B> .", with_kko=True)
+    assert out["kko_tbox"]["loaded"] is True
+    assert out["kko_tbox"]["triples"] > 0, "the vendored TBox must actually parse"
+    assert "unavailable_reason" not in out["kko_tbox"]
+
+
+def test_kko_tbox_is_declared_as_package_data():
+    """Without this the .n3 is absent from a built wheel and with_kko is a no-op in every
+    installed deployment — the condition that made the reporting bug invisible."""
+    import tomllib
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    cfg = tomllib.loads((root / "pyproject.toml").read_text())
+    patterns = cfg["tool"]["setuptools"]["package-data"]["owl_reasoner"]
+    assert any(p.endswith(".n3") for p in patterns), f"the TBox must ship in the wheel; got {patterns}"


### PR DESCRIPTION
Copilot raised both halves on **#974**. Both are still live, and **they compound**.

## The TBox never shipped

`pyproject.toml` declared no `package-data`, so the vendored `kko-2.10.n3` was absent from every built wheel. Verified rather than argued:

```
origin/main wheel .n3: NONE          ← confirms the finding
this branch wheel .n3: ['owl_reasoner/data/kko-2.10.n3']
```

## And the response claimed it had

```python
"kko_tbox": {"loaded": with_kko, "triples": kko_tbox_triples}
```

`_kko_tbox()` deliberately swallows a missing or unparseable file and returns an empty graph — correct, a bad vendored file must not take reasoning down. But `loaded` was the caller's **request**, not the outcome.

Together those two mean **every installed deployment answered `{"loaded": true, "triples": 0}`** while `with_kko` was silently a no-op. The service asserted the ontology was in play, and the only evidence to the contrary was a zero the client had to notice and interpret.

`requested` and `loaded` are separate now, and when they disagree the response carries `unavailable_reason` naming the file and stating that `with_kko` had no effect:

```json
{"requested": true, "loaded": false, "triples": 0,
 "unavailable_reason": "KKO TBox requested but no triples were parsed from kko-2.10.n3; with_kko had no effect on this result"}
```

Adding a key is backward-compatible for anything reading `.loaded` — the endpoint test, which checks keys individually, passed unchanged.

## One existing test broke, and it deserved to

`test_without_kko_no_ancestor_entailment` asserted the status by **exact dict equality** and failed on the new field. I rewrote it to assert properties instead: a frozen literal fails on any future addition while saying nothing about behaviour, and the field it was frozen against is precisely the one that let a request masquerade as an outcome.

## Tests

Five added, including **the wheel scenario exercised rather than assumed** — `_KKO_PATH` pointed at a nonexistent file with the `lru_cache` cleared, asserting `loaded=False`; its converse that the real checkout parses >0 triples; and a check that `pyproject` still declares the `.n3` as package-data, since that declaration is what keeps the whole thing non-vacuous.

**26 passed, 0 failed** (main: 21 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)