### PR TITLE
Actually enforce date-time, and refuse to start if the checker is a no-op

### DIFF
--- a/apps/market-replay/pyproject.toml
+++ b/apps/market-replay/pyproject.toml
@@ -8,6 +8,10 @@ dependencies = [
   "uvicorn==0.30.6",
   "httpx==0.27.2",
   "jsonschema==4.26.0",
+  # jsonschema treats `format` as an annotation unless a checker is supplied, and its
+  # date-time checker is a NO-OP without this package. Without it the "schema-validated,
+  # fail-closed" claim above silently excludes every timestamp in the schema.
+  "rfc3339-validator==0.1.4",
 ]
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/apps/market-replay/requirements.txt
+++ b/apps/market-replay/requirements.txt
@@ -27,3 +27,4 @@ sniffio==1.3.1
 starlette==0.38.6
 typing-inspection==0.4.2
 typing_extensions==4.16.0
+rfc3339-validator==0.1.4

--- a/apps/market-replay/src/market_replay/contract.py
+++ b/apps/market-replay/src/market_replay/contract.py
@@ -56,7 +56,24 @@ if _actual != SCHEMA_SHA256:  # tamper-evident vendoring — see module docstrin
         "re-vendor from sourceos-spec and update contract.py provenance")
 
 SCHEMA: dict[str, Any] = json.loads(_SCHEMA_BYTES)
-VALIDATOR = Draft202012Validator(SCHEMA)
+
+# jsonschema treats `format` as an ANNOTATION unless a checker is supplied, so
+# Draft202012Validator(SCHEMA) never validated the schema's "format": "date-time" —
+# a structurally-valid event carrying "not-a-timestamp" passed the gate this module
+# describes as "schema-validated per event, fail-closed".
+#
+# Passing the checker is not sufficient on its own: its date-time entry only exists when
+# rfc3339-validator is installed, so a missing dependency would turn the fix back into the
+# no-op it replaces — silently, and only in whichever environment lacked the package. The
+# assertion below makes that impossible: no timestamp checking means no import.
+_FORMAT_CHECKER = Draft202012Validator.FORMAT_CHECKER
+if "date-time" not in _FORMAT_CHECKER.checkers:  # pragma: no cover - guarded by test
+    raise RuntimeError(
+        "jsonschema's date-time format checker is unavailable (install rfc3339-validator). "
+        "Refusing to start: this module claims per-event schema validation, and without it "
+        "every `format: date-time` in MarketDataEvent.json would go unchecked."
+    )
+VALIDATOR = Draft202012Validator(SCHEMA, format_checker=_FORMAT_CHECKER)
 
 # URN local-id charset per the schema's id pattern: [A-Za-z0-9._~-]. Symbols like
 # "SP:AAA" carry a colon, so the local id sanitizes it ("SP-AAA") while the event's

--- a/apps/market-replay/tests/test_contract.py
+++ b/apps/market-replay/tests/test_contract.py
@@ -1,0 +1,36 @@
+
+
+# jsonschema treats `format` as an ANNOTATION unless a checker is supplied, so the
+# validator never enforced the schema's "format": "date-time". A structurally-valid event
+# carrying "not-a-timestamp" passed the gate this module calls "schema-validated per
+# event, fail-closed".
+
+
+def test_date_time_format_is_actually_enforced():
+    from market_replay.contract import VALIDATOR, build_event
+    from market_replay.generator import Tick
+
+    ev = build_event(Tick(symbol="SP:AAA", seq=1, price=1.0, volume=1), "2026-07-29T00:00:00Z")
+    assert not list(VALIDATOR.iter_errors(ev)), "a well-formed event must still validate"
+
+    broken = dict(ev)
+    broken["wallTime"] = "not-a-timestamp"
+    errs = list(VALIDATOR.iter_errors(broken))
+    assert errs, "a malformed date-time must be REJECTED, not annotated"
+    assert any("date-time" in str(e.message) or "format" in str(e.message) for e in errs), \
+        f"the rejection must cite the format, got: {[e.message for e in errs]}"
+
+
+def test_the_format_checker_is_not_silently_a_noop():
+    """The trap this fix had to avoid.
+
+    Draft202012Validator.FORMAT_CHECKER only carries a date-time entry when
+    rfc3339-validator is installed. Passing the checker without the dependency turns the
+    fix back into the no-op it replaces — silently, and only in whichever environment
+    lacks the package. contract.py refuses to import in that state; this asserts the
+    condition directly so the reason is visible rather than inferred from an ImportError.
+    """
+    from market_replay.contract import _FORMAT_CHECKER
+
+    assert "date-time" in _FORMAT_CHECKER.checkers, \
+        "date-time checking unavailable — install rfc3339-validator; format would be unenforced"


### PR DESCRIPTION
Copilot raised this on **#1002**; still live on main.

## The finding

```python
VALIDATOR = Draft202012Validator(SCHEMA)   # no format_checker
```

jsonschema treats `format` as an **annotation** unless a checker is supplied, so `MarketDataEvent.json`'s `"format": "date-time"` was never validated. A structurally valid event carrying `wallTime: "not-a-timestamp"` passed the gate this module's own description calls *"schema-validated per event, fail-closed"*.

## The trap in the obvious fix

Passing the checker alone would **not** have fixed it. `Draft202012Validator.FORMAT_CHECKER` carries a `date-time` entry only when `rfc3339-validator` is installed — and it was not:

```
date-time in FORMAT_CHECKER.checkers: False
rejects "not-a-date":                 False
```

Adding `format_checker=` without the dependency turns the fix back into the no-op it replaces — silently, and only in whichever environment lacks the package. That is the same defect wearing the fix's clothes, and **it would have looked closed in the diff**.

## What landed

- `rfc3339-validator==0.1.4` pinned in `pyproject.toml` **and** the `requirements.txt` closure.
- `contract.py` **refuses to import** when date-time checking is unavailable. No timestamp validation means no start, rather than a service that runs and quietly checks less than it claims.

```python
if "date-time" not in _FORMAT_CHECKER.checkers:
    raise RuntimeError("... Refusing to start: this module claims per-event schema validation ...")
```

## Tests

- a malformed `wallTime` is **rejected**, and the rejection cites the format
- the checker actually carries a `date-time` entry — asserted directly, so the reason is visible rather than inferred from an `ImportError`

**25 passed, 0 failed.**

> The design-register probe findings (#1016/#1004) are on this branch's todo but not in this commit — they need a different treatment and shouldn't hold up an enforcement fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)