### PR TITLE
perf(ci): skip app-test + smoke legs on provably-inert docs diffs

### DIFF
--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -8,6 +8,50 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Cheap gatekeeper: decide whether this PR can possibly affect application code or service
+  # behaviour. Runs in seconds, no toolchain, so it costs far less than the legs it can save.
+  #
+  # SAFETY PROPERTIES (each one deliberate — see the PR for the adversarial review):
+  #   * FAIL-SAFE. Any doubt -> docs_only=false -> everything runs. An empty diff, a detection
+  #     error, or a push to main all fall through to "run everything". Skipping requires
+  #     positive proof of inertness, never absence of evidence.
+  #   * NARROW. Only docs/** and root *.md count as inert. Everything else (apps, tools, infra,
+  #     .github, contracts) forces the full matrix.
+  #   * COVERAGE-PRESERVING. validate-target-diagnostics is NEVER skipped, because its
+  #     `validate-repo` leg runs tools/validate_repo.py, which asserts REQUIRED_FILES like
+  #     docs/ARCHITECTURE.md exist and scans for TODO/PLACEHOLDER. Docs are NOT inert to that
+  #     check, so it keeps running on docs-only PRs. Only the app-test and smoke legs — which
+  #     exercise application code and service behaviour — are skipped.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.detect.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: detect
+        name: Is this diff provably inert for app/service tests?
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "not a pull_request (${{ github.event_name }}) — main is never validated by inference"
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          BASE="${{ github.base_ref }}"
+          git fetch --no-tags --quiet origin "$BASE"
+          CHANGED="$(git diff --name-only "origin/$BASE...HEAD" || true)"
+          if [ -z "$CHANGED" ]; then
+            echo "empty diff — running everything"
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "changed files:"; echo "$CHANGED" | sed 's/^/  /'
+          # The rule lives in tools/ci_docs_only.py so it is unit-tested; a skip rule that
+          # only exists in YAML is a skip rule nobody can test.
+          RESULT="$(echo "$CHANGED" | python3 tools/ci_docs_only.py)"
+          echo "docs_only=$RESULT" >> "$GITHUB_OUTPUT"
+          echo "decision: docs_only=$RESULT (false => full matrix)"
+
   validate-target-diagnostics:
     runs-on: ubuntu-latest
     strategy:
@@ -59,6 +103,8 @@ jobs:
         run: make ${{ matrix.target }}
 
   app-test-diagnostics:
+    needs: changes
+    if: always() && needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -147,6 +193,8 @@ jobs:
           path: diagnostic-logs/${{ matrix.name }}.log
 
   smoke-target-diagnostics:
+    needs: changes
+    if: always() && needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -45,10 +45,26 @@ jobs:
             echo "empty diff — running everything"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          echo "changed files:"; echo "$CHANGED" | sed 's/^/  /'
+          # printf, not echo: a filename beginning with -n/-e is legal in git and
+          # echo would eat it as a flag.
+          echo "changed files:"; printf '%s\n' "$CHANGED" | sed 's/^/  /'
           # The rule lives in tools/ci_docs_only.py so it is unit-tested; a skip rule that
           # only exists in YAML is a skip rule nobody can test.
-          RESULT="$(echo "$CHANGED" | python3 tools/ci_docs_only.py)"
+          #
+          # The detector is NOT allowed to fail this job. Skipping tests must require a
+          # positive "true"; anything else — a crash, a missing interpreter, an
+          # unrecognised answer — falls back to running the full matrix. Letting the job
+          # fail instead would still be safe for coverage (the dependents run on an empty
+          # output), but it paints the workflow red while the required gate stays green,
+          # which teaches people to ignore red.
+          if ! RESULT="$(printf '%s\n' "$CHANGED" | python3 tools/ci_docs_only.py 2>&1)"; then
+            echo "detector failed, running everything. output: $RESULT"
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ "$RESULT" != "true" ] && [ "$RESULT" != "false" ]; then
+            echo "detector said '$RESULT', which is neither true nor false — running everything"
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
           echo "docs_only=$RESULT" >> "$GITHUB_OUTPUT"
           echo "decision: docs_only=$RESULT (false => full matrix)"
 

--- a/tools/ci_docs_only.py
+++ b/tools/ci_docs_only.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Decide whether a diff is provably inert for app-code and service-behaviour tests.
+
+Extracted from the workflow on purpose: a skip rule embedded in YAML is a skip rule nobody
+can test, and a CI optimisation that silently stops running tests is worse than no
+optimisation at all. This is the code the workflow calls, so tools/tests exercises exactly
+what production executes — no second copy to drift.
+
+CONTRACT
+  stdin  : newline-separated changed paths (as `git diff --name-only` emits them)
+  stdout : "true" if the app-test/smoke legs may skip, else "false"
+
+SAFETY: the answer is "false" (run everything) unless every single path is on the inert
+allowlist. Empty input, unrecognised paths, mixed diffs — all run everything. Skipping
+requires positive proof of inertness, never absence of evidence.
+
+SCOPE: "inert" here means inert *to application and service tests*. It does NOT mean
+unvalidated — the validate-target-diagnostics legs (including validate-repo, which asserts
+REQUIRED_FILES such as docs/ARCHITECTURE.md and scans for TODO/PLACEHOLDER) are never
+skipped, so documentation keeps its own coverage.
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+# A path is inert only if it is inside docs/ or is a top-level markdown file.
+# Anchored and slash-explicit so `docsomething/x.py` and `apps/svc/README.md` do NOT match.
+INERT = re.compile(r'^(docs/|[^/]+\.md$)')
+
+
+def docs_only(paths: list[str]) -> bool:
+    cleaned = [p.strip() for p in paths if p.strip()]
+    if not cleaned:
+        return False  # an empty diff tells us nothing; run everything
+    return all(INERT.match(p) for p in cleaned)
+
+
+def main() -> int:
+    print('true' if docs_only(sys.stdin.read().splitlines()) else 'false')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/tests/test_ci_docs_only.py
+++ b/tools/tests/test_ci_docs_only.py
@@ -1,0 +1,67 @@
+"""The skip rule that decides whether app-test/smoke legs may be skipped.
+
+A CI optimisation that silently stops running tests is worse than no optimisation, so this
+suite is adversarial: most cases assert that we DO run everything.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci_docs_only import docs_only  # noqa: E402
+
+
+@pytest.mark.parametrize('paths', [
+    ['docs/design-register.yaml'],
+    ['README.md'],
+    ['docs/a.md', 'CHANGELOG.md'],
+    ['docs/nested/deep/thing.md'],
+    ['docs/ARCHITECTURE.md'],          # safe: validate-repo still runs and asserts it exists
+])
+def test_inert_diffs_may_skip_the_app_and_smoke_legs(paths):
+    assert docs_only(paths) is True
+
+
+@pytest.mark.parametrize('paths', [
+    ['apps/compute-gateway/src/x.py'],
+    ['tools/premerge_audit.py'],
+    ['.github/workflows/ci.yml'],
+    ['infra/k8s/overlays/x.yaml'],
+    ['contracts/platform/thing.yaml'],
+    ['Makefile'],
+    ['go.work'],
+])
+def test_code_and_infra_always_run_everything(paths):
+    assert docs_only(paths) is False
+
+
+def test_one_code_file_among_many_docs_forces_a_full_run():
+    """The failure mode that matters: a big docs PR hiding a single code edit."""
+    paths = [f'docs/note{i}.md' for i in range(50)] + ['apps/api/main.go']
+    assert docs_only(paths) is False
+
+
+def test_an_empty_diff_proves_nothing_and_runs_everything():
+    assert docs_only([]) is False
+    assert docs_only(['', '  ']) is False
+
+
+@pytest.mark.parametrize('path', [
+    'docsomething/x.py',      # prefix collision — must not be read as docs/
+    'apps/svc/README.md',     # markdown, but NOT top-level, and it sits beside code
+    'infra/docs/x.py',        # 'docs' appears, but not at the root
+])
+def test_near_misses_do_not_earn_a_skip(path):
+    assert docs_only([path]) is False
+
+
+def test_the_rule_is_all_or_nothing():
+    """Skipping requires EVERY path to be inert — proof of inertness, not a majority vote."""
+    assert docs_only(['docs/a.md', 'docs/b.md']) is True
+    assert docs_only(['docs/a.md', 'apps/x.py']) is False


### PR DESCRIPTION
Closes #1043.

## The measurement
A docs-only PR (**one file**, `docs/design-register.yaml`) triggered **70 checks** including the full **44-leg** diagnostics matrix, with **30 runs queued** repo-wide. Three zero-behind, zero-failure PRs waited over an hour on runners alone. **86 of 103 workflows already use path filters** — this one is the outlier, because it carries the only required check.

## Adversarial review changed the design
**The naive fix would have opened a coverage hole.** `tools/validate_repo.py` (the `validate-repo` leg) asserts `REQUIRED_FILES` like `docs/ARCHITECTURE.md` exist and scans for TODO/PLACEHOLDER. **Docs are not inert to it.** So `validate-target-diagnostics` (27 legs) is **never skipped** — documentation keeps its own coverage exactly. Only `app-test` (7) and `smoke` (10), which exercise application code and service behaviour a markdown edit cannot reach, are skipped.

**Adding `paths:` would deadlock the repo.** `diagnostics-gate` is the sole required check; if the workflow doesn't trigger, the gate never reports and the PR blocks **forever** — the exact failure `gitops-promote.yml` already documents. The trigger is untouched; skipping is at the **job level**, so skipped legs consume **no runner** while the gate still reports.

**Fail-safe, not fail-open.** `if: always() && …` is load-bearing: without `always()`, a *failed* detector would skip the tests by default and the gate would go green on nothing. With it, a broken detector yields empty output and everything runs. Empty diffs, pushes to `main`, and unrecognised paths all fall through to "run everything".

**The gate is unchanged and still correct** — `if: always()`, fails only on `failure`/`cancelled`, so a skipped leg passes. Verified structurally, not assumed.

## Testability
The rule lives in `tools/ci_docs_only.py`, **not inline YAML** — a skip rule that only exists in a workflow is a skip rule nobody can test, and a CI optimisation that silently stops running tests is worse than no optimisation.

**18 tests, deliberately adversarial** (most assert we *do* run everything): prefix collisions (`docsomething/`), non-root markdown beside code (`apps/svc/README.md`), `infra/docs/x.py`, empty diffs, and the one that matters — **a single code file hidden among fifty docs edits still forces a full run**.

> This PR touches `.github/` and `tools/`, so by its own rule it runs the **full** matrix.
