### PR TITLE
perf(ci): path-filter 7 always-on validators, with an auditor that proves the filters

### DIFF
--- a/.github/workflows/brokerage-validation.yml
+++ b/.github/workflows/brokerage-validation.yml
@@ -1,8 +1,11 @@
 name: brokerage-validation
 on:
-  push:
-    branches: [ main ]
   pull_request:
+    paths:
+      - 'tools/validate_examples.py'
+      - 'specs/brokerage/**'
+      - '.github/workflows/brokerage-validation.yml'
+  push:
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/ci-path-filter-audit.yml
+++ b/.github/workflows/ci-path-filter-audit.yml
@@ -1,0 +1,34 @@
+name: ci-path-filter-audit
+
+# A `paths:` filter is a promise that nothing outside those globs can affect the
+# check.  This job re-derives each vouched workflow's real inputs from the
+# scripts it runs and fails if the promise no longer holds.  It is filtered to
+# workflow/tool edits because nothing else can falsify it.
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'tools/check_workflow_path_filters.py'
+      - 'tools/tests/test_check_workflow_path_filters.py'
+      - 'Makefile'
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  path-filter-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install test deps
+        run: python -m pip install --upgrade pip pytest
+      - name: Auditor can still detect a broken filter
+        run: pytest -q tools/tests/test_check_workflow_path_filters.py
+      - name: Vouched path filters still cover their inputs
+        run: python3 tools/check_workflow_path_filters.py

--- a/.github/workflows/cloudshell-fog-structural-conformance-v2.yml
+++ b/.github/workflows/cloudshell-fog-structural-conformance-v2.yml
@@ -1,7 +1,19 @@
 name: cloudshell-fog structural conformance v2
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - 'tools/validate-cloudshell-fog-*.sh'
+      - 'tools/attach_fogstack_manifest_signature.py'
+      - 'apps/cloudshell-fog/**'
+      - 'contracts/cloudshell-fog/**'
+      - 'infra/argocd/**'
+      - 'infra/k8s/**'
+      - 'infra/policy/**'
+      - 'releases/manifests/**'
+      - 'docs/CLOUDSHELL_FOG_*.md'
+      - 'docs/FOGSTACK_SIGNED_MANIFESTS.md'
+      - '.github/workflows/cloudshell-fog-structural-conformance-v2.yml'
   push:
     branches: [main]
   workflow_dispatch: {}

--- a/.github/workflows/cloudshell-fog-structural-conformance-v3.yml
+++ b/.github/workflows/cloudshell-fog-structural-conformance-v3.yml
@@ -1,7 +1,19 @@
 name: cloudshell-fog structural conformance v3
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - 'tools/validate-cloudshell-fog-*.sh'
+      - 'tools/attach_fogstack_manifest_signature.py'
+      - 'apps/cloudshell-fog/**'
+      - 'contracts/cloudshell-fog/**'
+      - 'infra/argocd/**'
+      - 'infra/k8s/**'
+      - 'infra/policy/**'
+      - 'releases/manifests/**'
+      - 'docs/CLOUDSHELL_FOG_*.md'
+      - 'docs/FOGSTACK_SIGNED_MANIFESTS.md'
+      - '.github/workflows/cloudshell-fog-structural-conformance-v3.yml'
   push:
     branches: [main]
   workflow_dispatch: {}

--- a/.github/workflows/scope-d-hardening-fixtures.yml
+++ b/.github/workflows/scope-d-hardening-fixtures.yml
@@ -2,6 +2,10 @@ name: proposal-safety-fixtures
 
 on:
   pull_request:
+    paths:
+      - 'tools/validate_scope_d_hardening_fixtures.py'
+      - 'fixtures/ops-fabric/**'
+      - '.github/workflows/scope-d-hardening-fixtures.yml'
   push:
     branches:
       - main

--- a/.github/workflows/semantic-projection-contracts.yml
+++ b/.github/workflows/semantic-projection-contracts.yml
@@ -1,6 +1,13 @@
 name: semantic-projection-contracts
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths:
+      - 'tools/validate_semantic_projection.py'
+      - 'contracts/semantic-projection/**'
+      - '.github/workflows/semantic-projection-contracts.yml'
+  push:
+    branches: [ main ]
 
 jobs:
   validate:

--- a/.github/workflows/svf-validation.yml
+++ b/.github/workflows/svf-validation.yml
@@ -1,9 +1,14 @@
 name: SVF Validation
 
 on:
+  pull_request:
+    paths:
+      - 'tools/validate_svf_agent_contract.py'
+      - 'contracts/svf/**'
+      - 'Makefile'
+      - '.github/workflows/svf-validation.yml'
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/workspace-operation-runtime.yml
+++ b/.github/workflows/workspace-operation-runtime.yml
@@ -2,6 +2,13 @@ name: workspace-operation-runtime
 
 on:
   pull_request:
+    paths:
+      - 'tests/workspace_operations/**'
+      - 'src/**'
+      - 'infra/datastores/postgres/**'
+      - 'infra/k8s/**'
+      - 'infra/local/**'
+      - '.github/workflows/workspace-operation-runtime.yml'
   push:
     branches:
       - main

--- a/docs/CI_PATH_FILTER_DEBT.md
+++ b/docs/CI_PATH_FILTER_DEBT.md
@@ -1,0 +1,161 @@
+# CI path-filter debt
+
+`tools/check_workflow_path_filters.py` re-derives what each path-filtered
+workflow actually reads and checks that the filter still covers it. Workflows
+in its `VOUCHED` set are enforced and must stay clean; everything below is
+**pre-existing** and reported as advisory, so the audit could ship without a
+90-workflow rewrite. The list is meant to shrink.
+
+Regenerate with `python3 tools/check_workflow_path_filters.py`.
+
+## Uncovered inputs (10 workflows)
+
+A change to these paths does **not** trigger the validator that reads them —
+the check stays green because it is never asked.
+
+- **cloudshell-fog-structural-conformance.yml**
+  - tools/validate-cloudshell-fog-structural-conformance.sh reads docs/FOGSTACK_SIGNED_MANIFESTS.md, not matched by paths: filter
+  - tools/validate-cloudshell-fog-structural-conformance.sh reads tools/attach_fogstack_manifest_signature.py, not matched by paths: filter
+- **deploy-tests.yml**
+  - apps/eval-fabric-api/app/tracing.py reads docs/OBSERVABILITY_OTEL_OPENINFERENCE.md, not matched by paths: filter
+  - apps/eval-fabric-api/app/tracing_example.py reads infra/local/docker-compose.otel-collector.yml, not matched by paths: filter
+  - apps/eval-fabric-api/tests/test_schemas.py reads schemas/eval, not matched by paths: filter
+  - runs tests/test_head_to_head.py, which its paths: filter does not match
+- **devsecops-investigation-run.yml**
+  - tools/validate_devsecops_investigation_run.py reads tests/fixtures/workroom/devsecops-investigation-run.missing-topology-evidence.invalid.json, not matched by paths: filter
+  - tools/validate_devsecops_investigation_run.py reads tests/fixtures/workroom/devsecops-investigation-run.projection-evidence-mismatch.invalid.json, not matched by paths: filter
+  - tools/validate_devsecops_investigation_run.py reads tests/fixtures/workroom/devsecops-investigation-run.ready-for-rca-without-collected-evidence.invalid.json, not matched by paths: filter
+- **devsecops-scope-d-adversarial.yml**
+  - tools/validate_devsecops_scope_d_adversarial.py reads tests/fixtures/workroom/devsecops-workroom.post-merge-incident.valid.json, not matched by paths: filter
+  - tools/validate_devsecops_scope_d_adversarial.py reads tests/fixtures/workroom/devsecops-workroom.pre-merge-validation-failure.valid.json, not matched by paths: filter
+- **mount-intent.yml**
+  - libs/python/mount-intent/src/mount_intent/intents.py reads apps/regis-acr-api, not matched by paths: filter
+- **personal-intelligence-cell.yml**
+  - runs tools/validate_repo.py, which its paths: filter does not match
+  - tools/validate_cell_gateway_api.py reads docs/EVENT_BUS_TOPICS.md, not matched by paths: filter
+  - tools/validate_cell_lampstand_live_fixture.py reads tools/run_cell_lampstand_live_fixture.py, not matched by paths: filter
+  - tools/validate_repo.py reads apps/api/go.mod, not matched by paths: filter
+  - tools/validate_repo.py reads apps/gateway/go.mod, not matched by paths: filter
+  - tools/validate_repo.py reads contracts/imported/IMPORT_MANIFEST.yaml, not matched by paths: filter
+  - tools/validate_repo.py reads contracts/imported/memory-mesh/SOURCE_MANIFEST.yaml, not matched by paths: filter
+  - tools/validate_repo.py reads contracts/imported/new-hope/SOURCE_MANIFEST.yaml, not matched by paths: filter
+  - tools/validate_repo.py reads contracts/imported/semantic-serdes/SOURCE_MANIFEST.yaml, not matched by paths: filter
+  - tools/validate_repo.py reads docs/ARCHITECTURE.md, not matched by paths: filter
+  - tools/validate_repo.py reads docs/DROPZONE_MEMBRANES.md, not matched by paths: filter
+  - tools/validate_repo.py reads docs/EVENT_BUS_TOPICS.md, not matched by paths: filter
+  - tools/validate_repo.py reads docs/MEMORY_MESH_INTEGRATION.md, not matched by paths: filter
+  - tools/validate_repo.py reads docs/TRITRPC_PLATFORM_BINDING.md, not matched by paths: filter
+  - tools/validate_repo.py reads docs/TRITRPC_SPEC.md, not matched by paths: filter
+  - tools/validate_repo.py reads docs/ZONE_MODEL.md, not matched by paths: filter
+  - tools/validate_repo.py reads infra/k8s/argo-cd/appsets/socioprophet-appset.yaml, not matched by paths: filter
+  - tools/validate_repo.py reads tools/run_prophet_understand_vertical_slice.py, not matched by paths: filter
+  - tools/validate_repo.py reads tools/validate_professional_intelligence.py, not matched by paths: filter
+  - tools/validate_repo.py reads tools/validate_prophet_understand.py, not matched by paths: filter
+- **preflight-deploy-contract.yml**
+  - tools/preflight_deploy_contract.py reads apps/embeddings, not matched by paths: filter
+- **professional-intelligence-gate4.yml**
+  - tools/validate_professional_intelligence.py reads contracts/evidence/adoption-event.schema.json, not matched by paths: filter
+  - tools/validate_professional_intelligence.py reads contracts/evidence/adoption-event.v0.1.example.json, not matched by paths: filter
+  - tools/validate_professional_intelligence.py reads contracts/institution/institution-entity.schema.json, not matched by paths: filter
+  - tools/validate_professional_intelligence.py reads contracts/institution/institution-entity.v0.1.example.json, not matched by paths: filter
+  - tools/validate_professional_intelligence.py reads contracts/policy/obligation.schema.json, not matched by paths: filter
+  - tools/validate_professional_intelligence.py reads contracts/policy/obligation.v0.1.example.json, not matched by paths: filter
+  - tools/validate_professional_intelligence.py reads contracts/risk/conflict-check.schema.json, not matched by paths: filter
+  - tools/validate_professional_intelligence.py reads contracts/risk/conflict-check.v0.1.example.json, not matched by paths: filter
+- **sourceos-contracts.yml**
+  - tools/smoke_sourceos_synthetic_boot_fingerprint.py reads tools/check_sourceos_boot_fingerprint_compliance.py, not matched by paths: filter
+- **tofu-plan.yml**
+  - runs tools/validate_no_provider_leakage.py, which its paths: filter does not match
+  - tools/validate_no_provider_leakage.py reads infra/argocd, not matched by paths: filter
+  - tools/validate_no_provider_leakage.py reads infra/k8s, not matched by paths: filter
+  - tools/validate_no_provider_leakage.py reads infra/local, not matched by paths: filter
+
+## No unfiltered push-on-main trigger (82 workflows)
+
+Filtered on `pull_request` with no unfiltered push-on-main run, so a wrong
+filter means the check never runs at all rather than running at merge time.
+Adding the safety net is cheap and should come first.
+
+- agent-action-trace-contracts.yml
+- cloudshell-fog-structural-conformance.yml
+- cross-repo-orchestration-interop.yml
+- deploy-tests.yml
+- devsecops-action-grant.yml
+- devsecops-agentplane-handoff.yml
+- devsecops-gaia-topology.yml
+- devsecops-investigation-run.yml
+- devsecops-postmortem-lesson.yml
+- devsecops-regression-promotion.yml
+- devsecops-scope-d-adversarial.yml
+- devsecops-workroom-demo-readiness.yml
+- devsecops-workroom-rca-guards.yml
+- devsecops-workroom-report.yml
+- fogstack-agent-core-plan.yml
+- fogstack-agent-machine-node-profile.yml
+- fogstack-apply-plan-index.yml
+- fogstack-apply-plan-parity.yml
+- fogstack-approval-intent.yml
+- fogstack-deploy-plan.yml
+- fogstack-filesystem-registry-root.yml
+- fogstack-filesystem-registry.yml
+- fogstack-gitops-bundle.yml
+- fogstack-kubernetes-manifests.yml
+- fogstack-live-apply-plan.yml
+- fogstack-local-cluster-runtime.yml
+- fogstack-local-demo.yml
+- fogstack-manifest-promotion.yml
+- fogstack-manifest-publication.yml
+- fogstack-registry-lifecycle.yml
+- fogstack-registry-metadata-signatures.yml
+- fogstack-registry-publication.yml
+- fogstack-registry-root.yml
+- fogstack-release-proof-canonical-refs.yml
+- fogstack-release-proof.yml
+- fogstack-runtime-contract.yml
+- fogstack-validation.yml
+- fogstack-wider-release-graph.yml
+- ghost-event-v3-validate.yml
+- ghost-governance-fracture.yml
+- ghost-v3-combined-control-plane.yml
+- mount-intent.yml
+- multidomain-geospatial-program-state.yml
+- openai-research-mcp-smoke.yml
+- ops-fabric-api.yml
+- osm-map-api.yml
+- personal-intelligence-cell.yml
+- preflight-deploy-contract.yml
+- probe-contract.yml
+- professional-intelligence-gate4.yml
+- prometheus-agentplane-policy-provenance.yml
+- prometheus-agentplane-schema-pin.yml
+- prometheus-jsonld.yml
+- prometheus-local-demo.yml
+- prometheus-neurosymbolic-contracts.yml
+- prometheus-ontogenesis-compat.yml
+- prometheus-optional-pysr.yml
+- prometheus-pysr-mvp.yml
+- prometheus-sindy-fast-path.yml
+- prometheus-sindy-run-artifact-emission.yml
+- prometheus-sr-run-artifact-emission.yml
+- provider-binding-evidence.yml
+- provider-binding-validation.yml
+- reasoning-failure-runner.yml
+- regis-acr-service.yml
+- search-orchestrator-image.yml
+- search-orchestrator-multicloud-rollout.yml
+- search-orchestrator.yml
+- socioprophet-api-image.yml
+- sourceos-contracts.yml
+- telemetry-runtime-slice.yml
+- tofu-plan.yml
+- tritfabric-consumption-api-stubs.yml
+- tritrpc-gateway-image.yml
+- validate-change-v2-agentplane-run-link.yml
+- validate-forensic-genesis-edge-tightening.yml
+- validate-forensic-genesis-edge.yml
+- validate-telemetry.yml
+- wopi-host-validation.yml
+- workspace-context.yml
+- workspace-services-image.yml
+- workspace-terraform-validate.yml
+

--- a/tools/check_workflow_path_filters.py
+++ b/tools/check_workflow_path_filters.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Prove that a path-filtered workflow still runs when its real inputs change.
+
+A `paths:` filter on a validation workflow is a promise: "nothing outside these
+globs can affect this check."  A wrong promise is worse than no filter, because
+the validator stops running pre-merge and nobody notices — the check is still
+green, it is simply never asked.  That is the "declared but unenforced" failure
+mode this repo already hunts elsewhere.
+
+So we do not take the promise on trust.  For every workflow that declares
+`pull_request.paths`, we read the scripts it actually runs, statically extract
+the repository paths those scripts open, and assert each one is matched by the
+declared globs.  Add an input directory to a validator without widening its
+filter and this check fails.
+
+Deliberately conservative: we only *add* required coverage.  Unparseable
+constructs are reported, never silently ignored.
+"""
+from __future__ import annotations
+
+import fnmatch
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+# `ROOT / "contracts" / "svf"` and friends.
+PY_JOIN = re.compile(r'ROOT\s*/\s*((?:["\'][^"\']+["\']\s*/\s*)*["\'][^"\']+["\'])')
+# `$ROOT/tools/validate-x.sh`
+SH_JOIN = re.compile(r'\$(?:\{)?ROOT(?:\})?/([A-Za-z0-9_./*-]+)')
+# bare repo-relative paths in a workflow `run:` line or a python literal
+BARE = re.compile(r'(?<![\w/.-])((?:tools|tests|specs|contracts|fixtures|apps|infra|libs|releases|src|docs)/[A-Za-z0-9_./*-]+)')
+
+
+def declared_paths(text: str) -> list[str]:
+    """Globs under `pull_request: paths:` — parsed positionally, no yaml dep."""
+    m = re.search(r'^on:.*?(?=^\w)', text, re.M | re.S)
+    if not m:
+        return []
+    on = m.group(0)
+    pr = re.search(r'^  pull_request:\s*$(.*?)(?=^  \w|\Z)', on, re.M | re.S)
+    if not pr:
+        return []
+    blk = re.search(r'^    paths:\s*$(.*?)(?=^    \w|\Z)', pr.group(1), re.M | re.S)
+    if not blk:
+        return []
+    return [x.strip().strip("'\"") for x in re.findall(r"^\s*-\s*(.+)$", blk.group(1), re.M)]
+
+
+def has_main_push(text: str) -> bool:
+    """An unfiltered push-on-main trigger is the safety net that makes a wrong
+    filter degrade to merge-time detection instead of never running at all."""
+    m = re.search(r'^on:.*?(?=^\w)', text, re.M | re.S)
+    if not m:
+        return False
+    push = re.search(r'^  push:\s*$(.*?)(?=^  \w|\Z)', m.group(0), re.M | re.S)
+    return bool(push and "main" in push.group(1) and "paths:" not in push.group(1))
+
+
+def make_target_scripts(target: str) -> set[str]:
+    """`run: make foo` hides the real script in the Makefile recipe.  A checker
+    that cannot see through this silently vouches for a filter it never
+    examined — so resolve the target rather than skip it."""
+    mk = ROOT / "Makefile"
+    if not mk.exists():
+        return set()
+    body = re.search(rf'^{re.escape(target)}:.*?$(.*?)(?=^\S|\Z)',
+                     mk.read_text(encoding="utf-8", errors="replace"), re.M | re.S)
+    return set(BARE.findall(body.group(1))) if body else set()
+
+
+def scripts_invoked(text: str) -> set[str]:
+    out: set[str] = set()
+    for line in re.findall(r'run:\s*(?:\|)?(.*)', text):
+        out.update(BARE.findall(line))
+        for target in re.findall(r'\bmake\s+([A-Za-z0-9_.-]+)', line):
+            out.update(make_target_scripts(target))
+    resolved: set[str] = set()
+    for item in out:
+        if Path(item).suffix in {".py", ".sh"}:
+            resolved.add(item)
+            continue
+        # `pytest tests/some_dir/` names a directory, not a script — analyse the
+        # test modules inside it, or the workflow looks unanalysable and gets
+        # wrongly vouched.
+        d = ROOT / item.rstrip("/")
+        if d.is_dir():
+            resolved.update(str(f.relative_to(ROOT)) for f in d.rglob("*.py"))
+    return resolved
+
+
+def inputs_of(script: Path, seen: set[Path] | None = None) -> set[str]:
+    """Repo paths a script reads, following shell scripts that call siblings."""
+    seen = seen if seen is not None else set()
+    if script in seen or not script.exists():
+        return set()
+    seen.add(script)
+    src = script.read_text(encoding="utf-8", errors="replace")
+    found: set[str] = set()
+    for joined in PY_JOIN.findall(src):
+        parts = re.findall(r'["\']([^"\']+)["\']', joined)
+        if parts:
+            found.add("/".join(parts))
+    found.update(SH_JOIN.findall(src))
+    found.update(BARE.findall(src))
+    for nested in {f for f in found if f.endswith(".sh")}:
+        found |= inputs_of(ROOT / nested, seen)
+    out = set()
+    for f in found:
+        if f.startswith(".github") or "/" not in f:
+            continue          # bare dir mentions in prose/help text
+        if f.split("/")[0] == "build":
+            continue          # generated artifact, produced by the job, not an input
+        if not (ROOT / f).exists():
+            continue          # only vouch for inputs that actually exist today
+        out.add(f)
+    return out
+
+
+def covered(path: str, globs: list[str]) -> bool:
+    for g in globs:
+        g = g.rstrip("/")
+        if fnmatch.fnmatch(path, g) or fnmatch.fnmatch(path, g + "/*"):
+            return True
+        # `a/**` must cover `a/b/c` — fnmatch's * does not cross separators
+        if g.endswith("/**") and (path == g[:-3] or path.startswith(g[:-2])):
+            return True
+    return False
+
+
+# Workflows whose filter this repo has actually verified against its inputs.
+# Enforced hard.  Everything else is reported as advisory debt — see
+# `docs/CI_PATH_FILTER_DEBT.md`.  The list is meant to grow; nothing is meant
+# to leave it.
+VOUCHED = {
+    "brokerage-validation.yml",
+    "semantic-projection-contracts.yml",
+    "svf-validation.yml",
+    "scope-d-hardening-fixtures.yml",
+    "workspace-operation-runtime.yml",
+    "cloudshell-fog-structural-conformance-v2.yml",
+    "cloudshell-fog-structural-conformance-v3.yml",
+}
+
+
+def main() -> int:
+    failures: list[str] = []
+    advisory: list[str] = []
+    checked = 0
+    for wf in sorted(WORKFLOWS.glob("*.yml")):
+        text = wf.read_text(encoding="utf-8", errors="replace")
+        globs = declared_paths(text)
+        if not globs:
+            continue
+        if wf.name == "ci-path-filter-audit.yml":
+            # The auditor's own tool and tests mention repo paths as DATA
+            # (fixtures, examples in docstrings), not as inputs it reads.
+            # Scanning it would report those literals as uncovered forever.
+            continue
+        checked += 1
+        sink = failures if wf.name in VOUCHED else advisory
+        if not has_main_push(text):
+            sink.append(
+                f"{wf.name}: filtered on pull_request but has no unfiltered "
+                f"push-on-main trigger — a wrong filter would mean it NEVER runs")
+        found_scripts = scripts_invoked(text)
+        if wf.name in VOUCHED and not found_scripts:
+            failures.append(
+                f"{wf.name}: vouched, but no analysable script was found in its "
+                f"run: steps — the filter cannot be proven, so it is not vouched")
+        for script in found_scripts:
+            if not covered(script, globs):
+                sink.append(f"{wf.name}: runs {script}, which its paths: filter does not match")
+            for dep in inputs_of(ROOT / script):
+                if not covered(dep, globs):
+                    sink.append(f"{wf.name}: {script} reads {dep}, not matched by paths: filter")
+
+    for f in sorted(set(failures)):
+        print(f"FAIL {f}")
+    for a in sorted(set(advisory)):
+        print(f"debt {a}")
+    print(f"\nchecked {checked} path-filtered workflow(s): "
+          f"{len(VOUCHED)} vouched, {len(set(failures))} failure(s), "
+          f"{len(set(advisory))} pre-existing gap(s) not yet vouched")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_check_workflow_path_filters.py
+++ b/tools/tests/test_check_workflow_path_filters.py
@@ -1,0 +1,108 @@
+"""Adversarial tests for the path-filter auditor.
+
+The auditor's whole value is that it FAILS when a filter stops covering its
+inputs.  A checker that cannot fail is worse than no checker — it converts an
+unverified assumption into a green tick.  So most of these tests deliberately
+break something and assert the auditor notices.
+
+Two of them exist because the auditor really did pass a broken filter during
+development: `make <target>` hid the script in the Makefile, and
+`pytest <dir>/` named a directory rather than a module, so in both cases the
+auditor found nothing to analyse and vouched for a filter it had never read.
+"""
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOL = ROOT / "tools" / "check_workflow_path_filters.py"
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+_spec = importlib.util.spec_from_file_location("cwpf", TOOL)
+cwpf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cwpf)
+
+
+def run_auditor() -> int:
+    return subprocess.run([sys.executable, str(TOOL)], capture_output=True).returncode
+
+
+@pytest.fixture
+def mutate(tmp_path):
+    """Edit a workflow in place, then restore it no matter how the test ends."""
+    backups: list[tuple[Path, Path]] = []
+
+    def _mutate(name: str, old: str, new: str = "") -> None:
+        target = WORKFLOWS / name
+        backup = tmp_path / name
+        shutil.copy(target, backup)
+        backups.append((target, backup))
+        text = target.read_text(encoding="utf-8")
+        assert old in text, f"fixture is stale: {old!r} not present in {name}"
+        target.write_text(text.replace(old, new), encoding="utf-8")
+
+    yield _mutate
+    for target, backup in backups:
+        shutil.copy(backup, target)
+
+
+def test_repo_is_currently_clean():
+    assert run_auditor() == 0, "vouched workflows must cover their inputs on main"
+
+
+def test_narrowing_a_filter_is_caught(mutate):
+    """Drop a validator's input dir from its filter -> the check would silently
+    stop running on changes to that dir.  Must fail."""
+    mutate("svf-validation.yml", "      - 'contracts/svf/**'\n")
+    assert run_auditor() == 1
+
+
+def test_narrowing_an_infra_filter_is_caught(mutate):
+    """The defect this auditor found in its own author's work."""
+    mutate("workspace-operation-runtime.yml", "      - 'infra/k8s/**'\n")
+    assert run_auditor() == 1
+
+
+def test_removing_the_push_on_main_safety_net_is_caught(mutate):
+    """Without an unfiltered push-on-main trigger, a wrong filter means the
+    validator never runs at all, rather than running late."""
+    mutate("brokerage-validation.yml", "  push:\n    branches: [ main ]\n")
+    assert run_auditor() == 1
+
+
+def test_make_targets_are_resolved():
+    """`run: make validate-svf-agent-contract` must resolve to the script the
+    recipe actually invokes, or the workflow looks unanalysable."""
+    assert "tools/validate_svf_agent_contract.py" in cwpf.make_target_scripts(
+        "validate-svf-agent-contract")
+
+
+def test_pytest_directories_are_resolved():
+    """`pytest tests/workspace_operations/` names a directory, not a module."""
+    found = cwpf.scripts_invoked("run: pytest tests/workspace_operations/ -q")
+    assert any(f.startswith("tests/workspace_operations/") and f.endswith(".py")
+               for f in found)
+
+
+def test_unanalysable_vouched_workflow_fails(monkeypatch):
+    """If we cannot see any script, we must not claim the filter is proven."""
+    monkeypatch.setattr(cwpf, "scripts_invoked", lambda _text: set())
+    assert cwpf.main() == 1
+
+
+def test_double_star_glob_crosses_separators():
+    """fnmatch's `*` stops at `/`; `a/**` must still match `a/b/c`."""
+    assert cwpf.covered("infra/k8s/base/deploy.yaml", ["infra/k8s/**"])
+    assert not cwpf.covered("infra/argocd/app.yaml", ["infra/k8s/**"])
+
+
+def test_generated_artifacts_are_not_required_inputs():
+    """A path the job itself writes under build/ is an output, not an input."""
+    assert not any(p.startswith("build/") for p in cwpf.inputs_of(
+        ROOT / "tools" / "check_workflow_path_filters.py"))


### PR DESCRIPTION
## What

Adds `paths:` filters to 7 validators that previously ran on **every** PR, and ships an auditor that proves those filters are honest.

**Measured before:** 15 of 103 workflows had no path filter → every PR started ~17 workflow runs. A one-file docs PR (#1027) triggered 70 checks. With ~5 concurrent runners and 200+ runs queued, PRs waited hours on checks their diff could not possibly affect.

## What is deliberately NOT filtered

| Workflow | Why it must stay unfiltered |
|---|---|
| `validate-target-diagnostics` | Contains `diagnostics-gate`, the **sole required check**. Filtering its trigger means the gate never reports → every PR blocks forever. |
| `premerge-audit`, `design-register` | Gates whose job is to see every PR. |
| `ci`, `validate` | Generic; inputs not provably bounded. |

## The risk, and the two countermeasures

A wrong path filter is worse than none: the validator silently stops running pre-merge and the check stays green **because nobody asks it**.

1. **Safety net.** Every filtered workflow keeps an *unfiltered* `push: branches: [main]` trigger. A mis-mapped filter degrades to merge-time detection — never to never.
2. **An auditor, not an assertion.** `tools/check_workflow_path_filters.py` re-derives each vouched workflow's real inputs from the scripts it runs (resolving `make` targets and `pytest <dir>`) and fails if the filter stops covering them.

## The auditor earned its place — twice

It first **passed a deliberately-broken filter.** `make validate-svf-agent-contract` hid the script in the Makefile and `pytest tests/workspace_operations/` named a directory, so the auditor found nothing to analyse and vouched for filters it had never read. A checker that cannot fail is worse than no checker — it converts an unverified assumption into a green tick. Both are now resolved, and an unanalysable vouched workflow is a hard failure.

Once fixed, it immediately caught **a real defect in this PR's own work**: `workspace-operation-runtime` reads `infra/k8s`, `infra/local` and `infra/datastores/postgres`, which my first draft of its filter omitted. Shipping that would have stopped infra changes from being validated pre-merge.

**9 adversarial tests** assert the auditor still fails on a narrowed filter, a narrowed infra filter, and a removed safety net.

## Pre-existing debt — reported, not silently inherited

The auditor also scanned the 82 workflows that were *already* filtered, and recorded what it found in `docs/CI_PATH_FILTER_DEBT.md` (advisory, not enforced, so this could ship without a 90-workflow rewrite):

- **10 workflows have inputs outside their own filter.** The one worth acting on: `tofu-plan` runs `validate_no_provider_leakage.py`, which reads `infra/argocd`, `infra/k8s` and `infra/local` — none of which trigger it. Provider-leakage validation does not run when those change.
- **82 lack the push-on-main safety net.**

Also found: `cloudshell-fog-structural-conformance-v2` and `-v3` are **byte-identical apart from their name** and run the same script twice on every PR, alongside a third base workflow. Filtered here rather than deleted — collapsing them is a separate call.

Refs #1043
