### PR TITLE
fix(warrant): the proof surface could render a false green — three integrity defects

### DIFF
--- a/apps/socioprophet-web/src/__tests__/VariantRail.smoke.test.ts
+++ b/apps/socioprophet-web/src/__tests__/VariantRail.smoke.test.ts
@@ -71,3 +71,42 @@ describe('<VariantRail> (ranked alternatives)', () => {
     expect(w.findAll('.vr-item').length).toBe(0);
   });
 });
+
+/**
+ * A deficit is one comparison, so it has to be run under one rubric. Scoring the gap in the
+ * LOSER's weights lets a variant carrying a different weighting name an axis that played no
+ * part in the ranking that actually happened — the ordering is by composite, and only the
+ * winner's weighting produced it.
+ */
+describe('<VariantRail> — the deficit is measured in the winner\'s weights', () => {
+  /** Same scores as the fixture's #1/#3 pair, but the loser carries an inverted rubric. */
+  function skewed() {
+    const winner = structuredClone(variants[0]);
+    const loser = structuredClone(variants[2]);
+    winner.senseMetric.weights = { coverage: 0.5, groundedness: 0.3, similarity: 0.2 };
+    // Under the LOSER's own weights, coverage (0.2 × 0.9 = 0.18) would outrank groundedness
+    // (0.75 × 0.05 = 0.0375) and the rail would say "lost on coverage".
+    loser.senseMetric.weights = { coverage: 0.9, groundedness: 0.05, similarity: 0.05 };
+    return [winner, loser];
+  }
+
+  it('names the axis the WINNER\'s weighting blames, not the loser\'s', () => {
+    const w = mount(VariantRail, { props: { variants: skewed() } });
+    const why = w.find('.vr-why').text();
+    // winner's rubric: groundedness 0.75 × 0.3 = 0.225 > coverage 0.2 × 0.5 = 0.10
+    expect(why).toContain('groundedness');
+    expect(why).not.toContain('lost on coverage');
+    // and the weight printed is the winner's, not the loser's 0.05
+    expect(why).toContain('w0.30');
+  });
+
+  it('says out loud that the two were scored under different rubrics', () => {
+    const w = mount(VariantRail, { props: { variants: skewed() } });
+    expect(w.find('.vr-wmismatch').text()).toContain('different weights than the winner');
+  });
+
+  it('stays quiet when every variant shares the winner\'s weights', () => {
+    const w = mount(VariantRail, { props: { variants } });
+    expect(w.find('.vr-wmismatch').exists()).toBe(false);
+  });
+});

--- a/apps/socioprophet-web/src/__tests__/warrantApiParse.test.ts
+++ b/apps/socioprophet-web/src/__tests__/warrantApiParse.test.ts
@@ -1,0 +1,209 @@
+/**
+ * W11 — `parseWalk()` strictness (the gateway door).
+ *
+ * The distinction under test is the whole reason <Warrant> exists:
+ *
+ *   "we could not understand the response"   ≠   "the proof is bad"
+ *
+ * A payload-SHAPE error is NOT a verification failure. Coercing an unrecognized step name
+ * to `unknown-step` or an unrecognized status to `fail` turns the first fact into the
+ * second, and the surface then renders UNSEALED — an accusation the gateway never made.
+ * Malformed ⇒ `unavailable`, surfaced as such.
+ *
+ * The module also pins the walk's shape: `steps` is "always length 3", in the order
+ * gateway-signature → engine-seal-hash → snapshot-seq-binding. That claim is enforced here
+ * rather than merely asserted in a comment.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RECEIPT_WALK_STEPS } from '../features/warrant/types';
+
+const GW = 'http://gateway.test';
+
+/**
+ * `GATEWAY` is resolved once at module load, so each case re-imports the module with the
+ * host runtime config already in place. Without a base the door short-circuits to
+ * `unavailable` and never reaches the parser.
+ */
+async function loadApi(base: string | null = GW) {
+  vi.resetModules();
+  const w = window as unknown as { __COCKPIT_CONFIG__?: unknown };
+  if (base) w.__COCKPIT_CONFIG__ = { bases: { gateway: base } };
+  else delete w.__COCKPIT_CONFIG__;
+  return import('../services/warrantApi');
+}
+
+function respondWith(body: unknown, ok = true, status = 200) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok, status, json: async () => body })),
+  );
+}
+
+/**
+ * A well-formed walk, used as the base every malformed case mutates away from. Typed loosely
+ * on purpose: these cases are about payloads the compiler would never let us construct, which
+ * is exactly the class of input the parser has to survive at runtime.
+ */
+interface LooseStep {
+  step: unknown;
+  status: unknown;
+  detail: unknown;
+}
+interface LooseWalk {
+  valid: unknown;
+  receipt_id: unknown;
+  project: unknown;
+  steps: LooseStep[];
+}
+
+function goodWalk(): LooseWalk {
+  return {
+    valid: true,
+    receipt_id: 'rcpt-1',
+    project: 'default',
+    steps: RECEIPT_WALK_STEPS.map((step): LooseStep => ({ step, status: 'ok', detail: null })),
+  };
+}
+
+beforeEach(() => {
+  const w = window as unknown as { __COCKPIT_CONFIG__?: unknown };
+  delete w.__COCKPIT_CONFIG__;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('parseWalk — a shape error is not a verification failure', () => {
+  it('accepts the real gateway shape', async () => {
+    const api = await loadApi();
+    respondWith(goodWalk());
+    const r = await api.verifyReceipt('rcpt-1');
+    expect(r.mode).toBe('live');
+    expect(r.data?.valid).toBe(true);
+    expect(r.data?.steps.map((s) => s.step)).toEqual([...RECEIPT_WALK_STEPS]);
+  });
+
+  it('rejects an unrecognized STATUS instead of coercing it to "fail"', async () => {
+    const api = await loadApi();
+    const body = goodWalk();
+    // A gateway that grows a fourth status must not be read as an accusation.
+    body.steps[1] = { step: 'engine-seal-hash', status: 'indeterminate', detail: null };
+    respondWith(body);
+
+    const r = await api.verifyReceipt('rcpt-1');
+    expect(r.mode).toBe('unavailable');
+    expect(r.data).toBeNull();
+    expect(r.error).toMatch(/unrecognized/i);
+  });
+
+  it('rejects a non-string STEP NAME instead of coercing it to "unknown-step"', async () => {
+    const api = await loadApi();
+    const body = goodWalk();
+    body.steps[0] = { step: 42, status: 'ok', detail: null };
+    respondWith(body);
+
+    const r = await api.verifyReceipt('rcpt-1');
+    expect(r.mode).toBe('unavailable');
+    expect(r.data).toBeNull();
+  });
+
+  it('rejects a step whose `detail` is neither string nor null', async () => {
+    const api = await loadApi();
+    const body = goodWalk();
+    body.steps[2] = { step: 'snapshot-seq-binding', status: 'ok', detail: { oops: true } };
+    respondWith(body);
+
+    const r = await api.verifyReceipt('rcpt-1');
+    expect(r.mode).toBe('unavailable');
+    expect(r.data).toBeNull();
+  });
+
+  it('rejects a null / non-object step entry', async () => {
+    const api = await loadApi();
+    const body = goodWalk();
+    body.steps[1] = null as unknown as LooseStep;
+    respondWith(body);
+
+    const r = await api.verifyReceipt('rcpt-1');
+    expect(r.mode).toBe('unavailable');
+    expect(r.data).toBeNull();
+  });
+});
+
+describe('parseWalk — the "always length 3, pinned order" claim is enforced, not just asserted', () => {
+  it('rejects a walk with too few steps', async () => {
+    const api = await loadApi();
+    const body = goodWalk();
+    body.steps = body.steps.slice(0, 2);
+    respondWith(body);
+
+    const r = await api.verifyReceipt('rcpt-1');
+    expect(r.mode).toBe('unavailable');
+    expect(r.data).toBeNull();
+  });
+
+  it('rejects a walk with an extra step', async () => {
+    const api = await loadApi();
+    const body = goodWalk();
+    body.steps = [...body.steps, { step: 'bonus-step', status: 'ok', detail: null }];
+    respondWith(body);
+
+    const r = await api.verifyReceipt('rcpt-1');
+    expect(r.mode).toBe('unavailable');
+    expect(r.data).toBeNull();
+  });
+
+  it('rejects the three steps in the wrong ORDER', async () => {
+    const api = await loadApi();
+    const body = goodWalk();
+    body.steps = [body.steps[1], body.steps[0], body.steps[2]];
+    respondWith(body);
+
+    const r = await api.verifyReceipt('rcpt-1');
+    expect(r.mode).toBe('unavailable');
+    expect(r.data).toBeNull();
+  });
+
+  it('rejects an unexpected step NAME', async () => {
+    const api = await loadApi();
+    const body = goodWalk();
+    body.steps[2] = { step: 'snapshot-seq-bindings', status: 'ok', detail: null };
+    respondWith(body);
+
+    const r = await api.verifyReceipt('rcpt-1');
+    expect(r.mode).toBe('unavailable');
+    expect(r.data).toBeNull();
+  });
+
+  it('still keeps `skipped` — the status that must never read as passed', async () => {
+    const api = await loadApi();
+    const body = goodWalk();
+    body.valid = false;
+    body.steps[1] = { step: 'engine-seal-hash', status: 'fail', detail: 'hash mismatch' };
+    body.steps[2] = { step: 'snapshot-seq-binding', status: 'skipped', detail: 'prior step failed' };
+    respondWith(body);
+
+    const r = await api.verifyReceipt('rcpt-1');
+    expect(r.mode).toBe('live');
+    expect(r.data?.steps[2].status).toBe('skipped');
+  });
+});
+
+describe('parseWalk — the envelope', () => {
+  it('rejects a payload that is not an object', async () => {
+    const api = await loadApi();
+    respondWith('nope');
+    const r = await api.verifyReceipt('rcpt-1');
+    expect(r.mode).toBe('unavailable');
+  });
+
+  it('reports an unconfigured gateway as unavailable, never as a pass', async () => {
+    const api = await loadApi(null);
+    const r = await api.verifyReceipt('rcpt-1');
+    expect(r.mode).toBe('unavailable');
+    expect(r.data).toBeNull();
+    expect(r.error).toMatch(/no compute-gateway base configured/);
+  });
+});

--- a/apps/socioprophet-web/src/__tests__/warrantProofIntegrity.test.ts
+++ b/apps/socioprophet-web/src/__tests__/warrantProofIntegrity.test.ts
@@ -1,0 +1,220 @@
+/**
+ * W11 — the two integrity properties that outrank every other behaviour of this surface.
+ *
+ *  1. FIXTURE DATA MAY NEVER BACK A PROOF RESULT.
+ *     Fixture plans are fine — the surface says so in a banner. A fixture *seal* or a
+ *     fixture *walk* standing in for a live check that did not succeed is not: it renders a
+ *     real verification that failed as a green "sealed". A live check that failed must read
+ *     as unavailable/unknown.
+ *
+ *  2. COLOUR MAY NEVER OUTRANK PROOF.
+ *     `unknown` ("could not check") must not keep a confident epistemic ramp colour, and
+ *     must stay visually distinct from `unsealed` ("checked, and it failed").
+ */
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import StudioWarrant from '../pages/studio/StudioWarrant.vue';
+import Warrant from '../components/warrant/Warrant.vue';
+import { warrantView, type PlanGrounding } from '../features/warrant/types';
+import { FIXTURE_RECEIPT_ID, FIXTURE_SEAL_DEGRADED, FIXTURE_WALK_VALID } from '../data/warrantFixture';
+
+/** Swappable live-verify outcome; defaults to the real (unconfigured ⇒ unavailable) door. */
+const h = vi.hoisted(() => ({
+  verify: null as null | ((id: string, project?: string) => Promise<unknown>),
+}));
+
+vi.mock('../services/warrantApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../services/warrantApi')>();
+  return {
+    ...actual,
+    verifyReceipt: (id: string, project?: string) =>
+      h.verify ? h.verify(id, project) : actual.verifyReceipt(id, project),
+  };
+});
+
+afterEach(() => {
+  h.verify = null;
+});
+
+async function mountSurface() {
+  const w = mount(StudioWarrant);
+  await flushPromises();
+  return w;
+}
+
+const runBadge = (w: ReturnType<typeof mount>) => w.find('.wsurf-runhead .wr');
+const liveButton = (w: ReturnType<typeof mount>) => w.find('.wsurf-live');
+const stateButtons = (w: ReturnType<typeof mount>) => w.findAll('.wsurf-state');
+
+const GROUNDED: PlanGrounding = {
+  kind: 'token-span',
+  tokenSpan: { start: 9, end: 18, text: 'suppliers', tokenIndices: [2] },
+  conceptRef: 'urn:srcos:type:Supplier',
+  source: 'lexicon',
+  confidence: 0.97,
+};
+
+// ─── 1. a failed live walk must not fall back to fixture proof ─────────────────
+
+describe('StudioWarrant — a live check that failed is never backfilled with fixture proof', () => {
+  it('offers an explicit live-verify door', async () => {
+    const w = await mountSurface();
+    expect(liveButton(w).exists()).toBe(true);
+  });
+
+  it('drops the fixture SEAL and the fixture WALK when the live walk is unavailable', async () => {
+    const w = await mountSurface();
+    // Baseline: the sealed fixture state reads sealed, off fixture data, and says it is fixture.
+    expect(runBadge(w).classes()).toContain('wr-sealed');
+
+    // Ask the gateway for real. Nothing is configured, so the attempt fails.
+    await liveButton(w).trigger('click');
+    await flushPromises();
+
+    // The badge must NOT still read sealed off the fixture.
+    expect(runBadge(w).classes()).not.toContain('wr-sealed');
+    expect(runBadge(w).classes()).toContain('wr-unknown');
+    expect(w.find('.err').text()).toMatch(/no compute-gateway base configured/);
+
+    // …and the fixture's three green steps must be gone from the receipt walk.
+    await runBadge(w).find('.wr-badge').trigger('click');
+    expect(w.find('.wr-steps').exists()).toBe(false);
+  });
+
+  it('does the same from the tampered fixture state — no fixture verdict either way', async () => {
+    const w = await mountSurface();
+    await stateButtons(w)[1].trigger('click');
+    expect(runBadge(w).classes()).toContain('wr-unsealed');
+
+    await liveButton(w).trigger('click');
+    await flushPromises();
+
+    // "could not check" — not the fixture's INVALID verdict, which is also a claim about proof.
+    expect(runBadge(w).classes()).toContain('wr-unknown');
+    expect(runBadge(w).classes()).not.toContain('wr-unsealed');
+  });
+
+  it('renders a live walk that SUCCEEDS, and marks the surface live', async () => {
+    h.verify = async () => ({ data: FIXTURE_WALK_VALID, mode: 'live' as const });
+    const w = await mountSurface();
+    await liveButton(w).trigger('click');
+    await flushPromises();
+
+    expect(runBadge(w).classes()).toContain('wr-sealed');
+    expect(w.find('.err').exists()).toBe(false);
+  });
+
+  it('lets a live walk that FAILS its verification read as unsealed — a real check, a real verdict', async () => {
+    h.verify = async () => ({
+      data: {
+        valid: false,
+        receipt_id: FIXTURE_RECEIPT_ID,
+        project: 'default',
+        steps: [
+          { step: 'gateway-signature', status: 'ok', detail: null },
+          { step: 'engine-seal-hash', status: 'fail', detail: 'hash mismatch' },
+          { step: 'snapshot-seq-binding', status: 'skipped', detail: 'prior step failed' },
+        ],
+      },
+      mode: 'live' as const,
+    });
+    const w = await mountSurface();
+    await liveButton(w).trigger('click');
+    await flushPromises();
+
+    expect(runBadge(w).classes()).toContain('wr-unsealed');
+    expect(runBadge(w).find('.wr-why').text()).toContain('engine-seal-hash');
+  });
+
+  it('never shows a live-failure error next to a sealed badge', async () => {
+    const w = await mountSurface();
+    await liveButton(w).trigger('click');
+    await flushPromises();
+
+    // Whatever the surface chooses to do next, these two may never be on screen together.
+    const erroring = w.find('.err').exists();
+    expect(erroring && runBadge(w).classes().includes('wr-sealed')).toBe(false);
+  });
+
+  it('lets the user go back to the fixture demo explicitly, and clears the live failure with it', async () => {
+    const w = await mountSurface();
+    await liveButton(w).trigger('click');
+    await flushPromises();
+    expect(w.find('.err').exists()).toBe(true);
+
+    // Switching the fixture proof-state is a deliberate "show me the fixture story" action.
+    await stateButtons(w)[0].trigger('click');
+    expect(w.find('.err').exists()).toBe(false);
+    expect(runBadge(w).classes()).toContain('wr-sealed');
+  });
+});
+
+// ─── 4. the degraded state has nothing to walk, and the code must agree ────────
+
+describe('StudioWarrant — "nothing to walk" means the code offers nothing to walk', () => {
+  it('carries no receiptRef in the degraded state, so the badge cannot ask for a walk', async () => {
+    const w = await mountSurface();
+    await stateButtons(w)[2].trigger('click');
+
+    await runBadge(w).find('.wr-badge').trigger('click');
+    await flushPromises();
+
+    // The copy says the claim was never sealed, so there is nothing to walk …
+    expect(w.find('.wr-nowalk').text()).toContain('never sealed');
+    // … and no walk was requested behind the user's back.
+    expect(w.find('.wr-hash').exists()).toBe(false);
+  });
+
+  it('carries the receiptRef the SEAL actually reports in the sealed state', async () => {
+    const w = await mountSurface();
+    await runBadge(w).find('.wr-badge').trigger('click');
+    expect(w.find('.wr-walk-head .wr-hash').text()).toBe(FIXTURE_RECEIPT_ID);
+  });
+});
+
+// ─── 3. colour may never outrank proof ─────────────────────────────────────────
+
+describe('warrantView — the epistemic ramp degrades for unknown as well as unsealed', () => {
+  it('refuses an unknown claim a confident ramp mode', () => {
+    const v = warrantView({ claim: 'c', grounding: GROUNDED });
+    expect(v.seal).toBe('unknown');
+    // 'observed' is the confident mode for a token-span grounding. Not while unproven.
+    expect(v.epistemic).toBe('unknown');
+  });
+
+  it('degrades every warrant kind that is not sealed', () => {
+    for (const kind of ['token-span', 'registry-default', 'ungrounded'] as const) {
+      const g = { ...GROUNDED, kind } as PlanGrounding;
+      expect(warrantView({ claim: 'c', grounding: g }).epistemic).toBe('unknown');
+    }
+  });
+
+  it('still lets a SEALED claim keep its confident ramp mode', () => {
+    const v = warrantView({ claim: 'c', grounding: GROUNDED, walk: FIXTURE_WALK_VALID });
+    expect(v.seal).toBe('sealed');
+    expect(v.epistemic).toBe('observed');
+  });
+});
+
+describe('<Warrant> — unknown and unsealed are both unconfident, and still distinguishable', () => {
+  const styleOf = (w: ReturnType<typeof mount>) => w.find('.wr').attributes('style') ?? '';
+
+  it('gives an unknown claim no confident colour', () => {
+    const unknown = mount(Warrant, { props: { w: { claim: 'c', grounding: GROUNDED } } });
+    expect(styleOf(unknown)).not.toContain('--epi-observed');
+    expect(styleOf(unknown)).toContain('--epi-unknown');
+  });
+
+  it('keeps "could not check" visually distinct from "checked, and it failed"', () => {
+    const unknown = mount(Warrant, { props: { w: { claim: 'c', grounding: GROUNDED } } });
+    const unsealed = mount(Warrant, {
+      props: { w: { claim: 'c', grounding: GROUNDED, seal: FIXTURE_SEAL_DEGRADED } },
+    });
+    expect(styleOf(unsealed)).toContain('--fail');
+    expect(styleOf(unknown)).not.toContain('--fail');
+    expect(styleOf(unknown)).not.toBe(styleOf(unsealed));
+    // and the labels stay different too
+    expect(unknown.find('.wr-seal').text()).toBe('unknown');
+    expect(unsealed.find('.wr-seal').text()).toBe('UNSEALED');
+  });
+});

--- a/apps/socioprophet-web/src/components/warrant/VariantRail.vue
+++ b/apps/socioprophet-web/src/components/warrant/VariantRail.vue
@@ -54,6 +54,12 @@
           </span>
         </p>
 
+        <!-- An invalid comparison is named, not quietly rendered as a valid one. -->
+        <p v-if="weightsDiffer(v)" class="vr-wmismatch">
+          scored under different weights than the winner — this gap is not a like-for-like
+          comparison, and the axis above is computed in the winner's weighting
+        </p>
+
         <div class="vr-actions">
           <button class="vr-rerun" type="button" @click="emit('rerun', v)">
             Re-run on #{{ v.rank }}
@@ -97,18 +103,45 @@ const weightsLabel = computed(() => {
  * The axis that cost this variant the most, in COMPOSITE POINTS — deficit × weight. A big
  * raw gap on a 0.2-weighted axis matters less than a small gap on a 0.5-weighted one, and
  * saying "lost on coverage" when similarity did the damage would be a nicer-sounding lie.
+ *
+ * The weights come from the WINNER, deliberately. A deficit is a statement about one
+ * comparison — "how many composite points behind the winner is this variant" — and a
+ * comparison has to be run under a single rubric or it is not a comparison at all. Scoring
+ * the loser's gap in the loser's own weights is apples-to-oranges: it can name an axis that
+ * contributed nothing to the ranking that actually happened, since the ranking is by
+ * composite and only one weighting produced that ordering. The winner's weighting is the one
+ * the field was ranked under, so it is the honest denominator.
+ *
+ * If the weights ever DO diverge across variants, the number is unsound however it is
+ * computed — so that case is surfaced rather than silently averaged over (`weightsDiffer`).
  */
 function lossOf(v: PlanVariant): { axis: string; delta: number; weight: number; cost: number } | null {
   const w = winnerMetric.value;
   if (!w || v.rank === 1) return null;
   const m = v.senseMetric;
+  const wt = w.weights;
   const rows = [
-    { axis: 'coverage', delta: m.coverage - w.coverage, weight: m.weights.coverage },
-    { axis: 'groundedness', delta: m.groundedness - w.groundedness, weight: m.weights.groundedness },
-    { axis: 'similarity', delta: m.similarity - w.similarity, weight: m.weights.similarity },
+    { axis: 'coverage', delta: m.coverage - w.coverage, weight: wt.coverage },
+    { axis: 'groundedness', delta: m.groundedness - w.groundedness, weight: wt.groundedness },
+    { axis: 'similarity', delta: m.similarity - w.similarity, weight: wt.similarity },
   ].map((r) => ({ ...r, cost: r.delta * r.weight }));
   const worst = rows.reduce((a, b) => (b.cost < a.cost ? b : a));
   return worst.cost < 0 ? worst : null;
+}
+
+/**
+ * Did this variant get scored under a different rubric than the winner? Then the "lost on X"
+ * line is comparing two things that were never on the same scale, and the rail says so
+ * instead of printing a confident number over an invalid comparison.
+ */
+function weightsDiffer(v: PlanVariant): boolean {
+  const w = winnerMetric.value;
+  if (!w || v.rank === 1) return false;
+  const a = v.senseMetric.weights;
+  const b = w.weights;
+  return (
+    a.coverage !== b.coverage || a.groundedness !== b.groundedness || a.similarity !== b.similarity
+  );
 }
 </script>
 
@@ -238,6 +271,12 @@ function lossOf(v: PlanVariant): { axis: string; delta: number; weight: number; 
   margin: 0;
   color: var(--warn, #d29922);
   font-size: 0.64rem;
+}
+.vr-wmismatch {
+  margin: 0;
+  color: var(--fail, #e5534b);
+  font-size: 0.62rem;
+  line-height: 1.45;
 }
 .vr-why b {
   font-weight: 700;

--- a/apps/socioprophet-web/src/features/warrant/types.ts
+++ b/apps/socioprophet-web/src/features/warrant/types.ts
@@ -267,7 +267,12 @@ export interface ReceiptVerifyWalk {
   valid: boolean;
   receipt_id: string;
   project: string;
-  /** Always length 3. */
+  /**
+   * Always length 3, in `RECEIPT_WALK_STEPS` order — and that is ENFORCED, not merely
+   * claimed: `warrantApi.ts::parseWalk` refuses any payload of another length, order or
+   * naming as an unrecognized shape rather than coercing it into a walk. A value of this
+   * type therefore only ever reaches a surface having satisfied the contract above.
+   */
   steps: ReceiptWalkStep[];
 }
 
@@ -429,9 +434,18 @@ export function warrantView(input: WarrantInput): WarrantView {
     seal: state,
     sealLabel: SEAL_LABEL[state],
     sealDetail: detail,
-    // An unsealed claim never gets to keep an attested/observed ramp colour — the ramp
-    // must degrade with the seal, or the colour lies about the proof.
-    epistemic: state === 'unsealed' ? 'unknown' : state === 'sealed' && kind === 'receipt' ? 'attested' : meta.epistemic,
+    // Colour can never outrank proof. ONLY a sealed claim keeps a confident ramp mode;
+    // everything else — `unsealed` (checked, failed) and `unknown` (could not check alike) —
+    // degrades to the `unknown` ramp. An unproven claim wearing "observed" blue is the exact
+    // dishonesty this component exists to prevent, and "we could not check" is not a licence
+    // to look confident.
+    //
+    // The two non-sealed states stay DISTINGUISHABLE, just not by borrowing confidence:
+    // `seal`/`sealLabel` separate them in text ("unknown" vs "UNSEALED"), and <Warrant>
+    // paints `unsealed` in --fail while `unknown` takes the desaturated --epi-unknown. So
+    // "could not check" reads as absence, "checked and failed" reads as alarm, and neither
+    // reads as proof.
+    epistemic: state === 'sealed' ? (kind === 'receipt' ? 'attested' : meta.epistemic) : 'unknown',
     span: g?.tokenSpan ?? null,
     receiptRef: input.receiptRef ?? input.walk?.receipt_id ?? input.seal?.receiptRef ?? null,
     walk: input.walk ?? null,

--- a/apps/socioprophet-web/src/pages/studio/StudioWarrant.vue
+++ b/apps/socioprophet-web/src/pages/studio/StudioWarrant.vue
@@ -16,7 +16,6 @@ import Warrant from '../../components/warrant/Warrant.vue';
 import { compileQuestion, verifyReceipt, type WarrantLoadMode } from '../../services/warrantApi';
 import {
   FIXTURE_QUESTION,
-  FIXTURE_RECEIPT_ID,
   FIXTURE_SEAL_DEGRADED,
   FIXTURE_SEAL_OK,
   FIXTURE_WALK_TAMPERED,
@@ -27,6 +26,7 @@ import type {
   PlanVariant,
   ReceiptVerifyWalk,
   SealOutcome,
+  WarrantInput,
 } from '../../features/warrant/types';
 
 const question = ref(FIXTURE_QUESTION);
@@ -46,11 +46,39 @@ const proofState = ref<ProofState>('sealed');
 const liveWalk = ref<ReceiptVerifyWalk | null>(null);
 const walkError = ref<string | null>(null);
 
-const seal = computed<SealOutcome>(() =>
-  proofState.value === 'degraded' ? FIXTURE_SEAL_DEGRADED : FIXTURE_SEAL_OK,
+/**
+ * Whether a LIVE verification has been asked for, and how it went. This is the line between
+ * the two lanes: fixture data may back the PLAN surfaces all day — it is labelled, and a plan
+ * is not a proof — but it may never back a proof RESULT. Once a live check has been attempted
+ * and did not succeed, falling back to the fixture walk would render a verification that
+ * failed as a green "sealed", which is the one thing this surface exists to make impossible.
+ */
+type LiveStatus = 'idle' | 'pending' | 'ok' | 'failed';
+const liveStatus = ref<LiveStatus>('idle');
+const liveFailed = computed(() => liveStatus.value === 'failed');
+
+/**
+ * The receipt id, which is a fact we hold independently of whether we could verify it. The
+ * degraded fixture was never sealed, so it genuinely has none — and the code has to agree
+ * with the copy that says "nothing to walk" rather than handing out a receipt anyway.
+ */
+const receiptRef = computed<string | null>(
+  () =>
+    liveWalk.value?.receipt_id ??
+    (proofState.value === 'degraded' ? FIXTURE_SEAL_DEGRADED.receiptRef : FIXTURE_SEAL_OK.receiptRef),
 );
+
+/** A seal is a CLAIM about proof, so a failed live check retracts it rather than restating it. */
+const seal = computed<SealOutcome | null>(() => {
+  if (liveFailed.value) return null;
+  return proofState.value === 'degraded' ? FIXTURE_SEAL_DEGRADED : FIXTURE_SEAL_OK;
+});
+
 const walk = computed<ReceiptVerifyWalk | null>(() => {
   if (liveWalk.value) return liveWalk.value;
+  // A live walk that failed or was unavailable leaves NOTHING behind — not the fixture's
+  // valid walk, and not its INVALID one either, since a fixture verdict is still a verdict.
+  if (liveFailed.value) return null;
   if (proofState.value === 'sealed') return FIXTURE_WALK_VALID;
   if (proofState.value === 'tampered') return FIXTURE_WALK_TAMPERED;
   return null; // degraded — never sealed, so there is nothing to walk
@@ -65,13 +93,16 @@ const winnerMetric = computed(
 );
 
 /** The compilation-level warrant: the whole run's claim, and whether it is sealed. */
-const runWarrant = computed(() => ({
+const runWarrant = computed<WarrantInput>(() => ({
   claim: compilation.value
     ? `Compiled “${compilation.value.question}” into ${compilation.value.variants.length} typed plan variant(s) against snapshot seq ${compilation.value.snapshot.seq}`
     : 'No compilation',
-  seal: seal.value,
+  seal: seal.value ?? undefined,
   walk: walk.value ?? undefined,
-  receiptRef: FIXTURE_RECEIPT_ID,
+  // Sourced from the seal that actually reports one, never stamped on unconditionally: the
+  // degraded fixture has `receiptRef: null` and says "nothing to walk", so it must not hand
+  // <Warrant> a receipt that would make the badge offer a walk anyway.
+  receiptRef: receiptRef.value ?? undefined,
 }));
 
 async function run() {
@@ -87,12 +118,42 @@ async function run() {
   }
 }
 
-/** Ask the gateway to walk the receipt for real. Reports unavailability as unavailability. */
-async function walkReceipt(receiptRef: string) {
+/**
+ * Ask the gateway to walk the receipt for real. Reports unavailability as unavailability —
+ * which means recording the FAILURE, not just the error string, because `liveFailed` is what
+ * stops the fixture walk from quietly taking the answer's place.
+ */
+async function walkReceipt(id: string) {
   walkError.value = null;
-  const r = await verifyReceipt(receiptRef);
-  if (r.data) liveWalk.value = r.data;
-  else walkError.value = r.error ?? 'verify walk unavailable';
+  liveStatus.value = 'pending';
+  const r = await verifyReceipt(id);
+  if (r.data) {
+    liveWalk.value = r.data;
+    liveStatus.value = 'ok';
+  } else {
+    liveWalk.value = null;
+    liveStatus.value = 'failed';
+    walkError.value = r.error ?? 'verify walk unavailable';
+  }
+}
+
+/** The explicit live door. Disabled when there is no receipt to walk. */
+function verifyLive() {
+  const id = receiptRef.value;
+  if (!id) return;
+  void walkReceipt(id);
+}
+
+/**
+ * Switching the fixture proof-state is a deliberate "show me the fixture story" action, so it
+ * resets the live lane — leaving a stale live failure on screen next to a fresh fixture badge
+ * would be its own kind of lie.
+ */
+function selectState(s: ProofState) {
+  proofState.value = s;
+  liveWalk.value = null;
+  liveStatus.value = 'idle';
+  walkError.value = null;
 }
 
 function rerun(v: PlanVariant) {
@@ -153,9 +214,9 @@ onMounted(run);
           :key="s"
           class="wsurf-state"
           type="button"
-          :class="{ on: proofState === s }"
-          :aria-pressed="proofState === s"
-          @click="proofState = s; liveWalk = null"
+          :class="{ on: proofState === s && liveStatus === 'idle' }"
+          :aria-pressed="proofState === s && liveStatus === 'idle'"
+          @click="selectState(s)"
         >
           {{ s }}
         </button>
@@ -169,7 +230,37 @@ onMounted(run);
           }}
         </span>
       </div>
-      <p v-if="walkError" class="err">{{ walkError }}</p>
+
+      <!-- The live door, stated separately from the fixture switch, because the two lanes
+           must never be mistaken for one another. -->
+      <div class="wsurf-states">
+        <span class="wsurf-states-l">live proof</span>
+        <button
+          class="wsurf-live"
+          type="button"
+          :disabled="!receiptRef || liveStatus === 'pending'"
+          @click="verifyLive"
+        >
+          {{ liveStatus === 'pending' ? 'Verifying…' : 'Verify live' }}
+        </button>
+        <span class="wsurf-states-hint">
+          {{
+            !receiptRef
+              ? 'no receipt on this claim — there is nothing to walk'
+              : liveStatus === 'ok'
+                ? 'walked against the gateway for real'
+                : liveStatus === 'failed'
+                  ? 'the live walk did not run — the fixture walk is NOT shown in its place'
+                  : 'walks this receipt against GET /v1/engine-receipts/{id}/verify'
+          }}
+        </span>
+      </div>
+
+      <p v-if="walkError" class="err">
+        Live receipt walk unavailable — {{ walkError }}. Nothing is standing in for it: a check
+        that did not run cannot be rendered as proof, so the warrant above reads
+        <b>unknown</b> until it does.
+      </p>
     </div>
 
     <div v-if="compilation && selected" class="grid cols-2 wsurf-body">
@@ -296,6 +387,25 @@ onMounted(run);
   background: var(--accent-wash);
 }
 .wsurf-state:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.wsurf-live {
+  background: transparent;
+  color: var(--accent-ink);
+  border: 1px solid var(--accent);
+  border-radius: var(--r-1);
+  padding: 1px 8px;
+  font-size: 0.66rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+.wsurf-live:disabled {
+  color: var(--faint);
+  border-color: var(--border-2);
+  cursor: default;
+}
+.wsurf-live:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }

--- a/apps/socioprophet-web/src/services/warrantApi.ts
+++ b/apps/socioprophet-web/src/services/warrantApi.ts
@@ -23,10 +23,13 @@ import {
   FIXTURE_SEAL_DEGRADED,
   FIXTURE_WALK_VALID,
 } from '../data/warrantFixture';
+import { RECEIPT_WALK_STEPS } from '../features/warrant/types';
 import type {
   NlqCompilation,
   ReceiptVerifyWalk,
   ReceiptWalkStatus,
+  ReceiptWalkStep,
+  ReceiptWalkStepName,
   SealOutcome,
 } from '../features/warrant/types';
 
@@ -56,9 +59,38 @@ export interface VerifyResult {
 const WALK_STATUSES: ReceiptWalkStatus[] = ['ok', 'fail', 'skipped'];
 
 /**
+ * Parse one step, against the name the pinned walk expects in that position.
+ *
+ * Strict on purpose. Every earlier version of this coerced — an unrecognized status became
+ * `fail`, a missing name became `unknown-step` — and that quietly converts one fact into a
+ * very different one: "we could not understand the gateway" turned into "the proof is bad".
+ * The surface downstream renders the second as UNSEALED, an accusation the gateway never
+ * made. Anything unrecognized returns null and the whole payload is refused.
+ */
+function parseStep(raw: unknown, expected: ReceiptWalkStepName): ReceiptWalkStep | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const st = raw as Record<string, unknown>;
+  if (st['step'] !== expected) return null;
+  const status = st['status'];
+  if (!WALK_STATUSES.includes(status as ReceiptWalkStatus)) return null;
+  const detail = st['detail'];
+  if (detail !== null && detail !== undefined && typeof detail !== 'string') return null;
+  return {
+    step: expected,
+    status: status as ReceiptWalkStatus,
+    detail: typeof detail === 'string' ? detail : null,
+  };
+}
+
+/**
  * Validate the gateway's payload before trusting it. A verify walk that does not parse is
- * NOT a pass — it is an error, and gets reported as one. This is the same posture the
- * server takes: never let an unverifiable thing read as verified.
+ * NOT a pass — and it is NOT a failure either. It is an unrecognized shape, reported as
+ * `unavailable`, because "we could not check" and "we checked and it failed" are different
+ * facts and this whole module exists to keep them apart.
+ *
+ * This is also where the `steps` contract stops being a comment: `_WALK` is exactly three
+ * steps in a pinned order (engine_receipts.py :262), so a payload of any other length, order
+ * or naming is a contract change we have not been taught to read — refused, not guessed at.
  */
 function parseWalk(raw: unknown): ReceiptVerifyWalk | null {
   if (!raw || typeof raw !== 'object') return null;
@@ -66,17 +98,15 @@ function parseWalk(raw: unknown): ReceiptVerifyWalk | null {
   if (typeof o['valid'] !== 'boolean') return null;
   if (typeof o['receipt_id'] !== 'string' || typeof o['project'] !== 'string') return null;
   if (!Array.isArray(o['steps'])) return null;
-  const steps = o['steps'].map((s) => {
-    const st = (s ?? {}) as Record<string, unknown>;
-    const status = st['status'];
-    return {
-      step: typeof st['step'] === 'string' ? st['step'] : 'unknown-step',
-      status: WALK_STATUSES.includes(status as ReceiptWalkStatus)
-        ? (status as ReceiptWalkStatus)
-        : 'fail',
-      detail: typeof st['detail'] === 'string' ? st['detail'] : null,
-    };
-  });
+  if (o['steps'].length !== RECEIPT_WALK_STEPS.length) return null;
+
+  const steps: ReceiptWalkStep[] = [];
+  for (let i = 0; i < RECEIPT_WALK_STEPS.length; i += 1) {
+    const step = parseStep(o['steps'][i], RECEIPT_WALK_STEPS[i]);
+    if (!step) return null;
+    steps.push(step);
+  }
+
   return {
     valid: o['valid'] as boolean,
     receipt_id: o['receipt_id'] as string,


### PR DESCRIPTION
## Why this is a follow-up and not part of #1040

#1040 merged (commit `53b4ac4`) while these fixes were being written. GitHub will not attach commits to a merged PR, so they land here. The branch is based on current `main` and contains only these fixes.

**This matters more than a normal follow-up:** `<Warrant>` exists so the cockpit can never overstate proof. Its own contract says a failing walk overrides a `sealed:true` claim, `unknown` stays distinct from `unsealed`, and colour can never outrank proof. Three paths violated that, and they are on `main` today. A proof surface that can render a false green is worse than no proof surface.

## The three defects

**1 — a failed LIVE verify walk fell back to FIXTURE proof.** A real check that did not succeed could display as sealed.

This turned out to be **worse than the review described**. Suppressing the fixture *walk* alone does not fix it: with `FIXTURE_SEAL_OK.sealed === true` still in hand, `resolveSeal()` reads a missing walk as `sealed` and the badge stays green regardless. **Copilot's own recommendation — suppress the fixture fallback for `walk` — would have left the false green in place.** A failed live check must retract the fixture **seal and walk** together.

Fixing this collided with defect 4: removing `receiptRef` from the degraded state removed the *only* path that could ever trigger a live walk, which would have made the live-verify code dead. So the live door is now an explicit **Verify live** control — a stated affordance rather than a side effect of opening a badge.

**2 — `parseWalk()` collapsed "malformed" into "failed".** Unknown step names became `'unknown-step'` and unknown statuses became `'fail'`, so a payload-*shape* error rendered as a verification *failure*. Those are different facts, and this component insists on that distinction everywhere else. Malformed is now `unknown`, and the documented "always length 3, pinned order" contract is enforced rather than merely claimed.

**3 — `epistemic` degraded for `unsealed` but not `unknown`.** An unchecked claim kept a confident ramp colour, directly breaking "colour can never outrank proof". Now degrades for both, visually distinct — *could not check* is not *is not sealed*.

## One review item rejected, because the premise was factually wrong

Copilot flagged `--epi-simulated` as a newly introduced ramp token, and I passed that on. **Both are wrong.** `--epi-simulated` and `--epi-verified` are pre-existing `.studio-scope` tokens at `studio-tokens.css:13`, verified against pre-PR main (`f3d10515`) — and **#1040 never touched that file**. All 8 `--epi-*` tokens the warrant code uses resolve against the 12 defined; nothing falls back to a hardcoded colour. The stated risk does not exist.

My follow-on instruction to "add it with both themes" rested on a second wrong premise: that file has no both-theme structure — it is dark-only by design and says so in its header. Adding a light block would have invented a convention the file deliberately does not have.

The real residue was the **PR body** of #1040, which listed 5 of the 7 ramp tokens. That claim/code disagreement is corrected there.

## Item 6 — weighted deficit

`lossOf()` now uses the **winner's** weights. A deficit is one comparison and must run under one rubric: the ordering is by composite, and only the winner's weighting produced it, so a loser's own weights can name an axis that played no part in the ranking that actually happened. Where weights genuinely diverge the number is unsound however computed, so the UI says so rather than printing a confident figure over an invalid comparison.

## Evidence — every fix teeth-checked before it was trusted

| defect | before fix | after |
|---|---|---|
| 2 · `parseWalk` (12 tests) | **8 failed** — precisely the coercion and count/order/name cases | 12/12 |
| 3 · `epistemic` (5 tests) | **3 failed** — e.g. `expected 'observed' to be 'unknown'` | 5/5 |
| 1 · fixture fallback (7 tests) | reverting **only the suppression logic** fails exactly the 3 fallback tests | 7/7 |

That last row is the important one: with the new button present but the logic reverted, the fallback tests still fail — so the **logic**, not the affordance, carries the fix.

Across both new files pre-fix: **19 failed / 7 passed**. Item 6 was teeth-checked the same way.

**Suite: 513 passed / 5 failed** (484 baseline + 29 new). Those 5 reproduce identically on pristine `origin/main` — verified in a separate worktree, unrelated to this change. `vue-tsc` exit 0, `vite build` exit 0, `preflight_deploy_contract.py` exit 0.