### PR TITLE
feat(governance): Sovereign Retention Doctrine + L5 artifact enrolment (closes #1048)

### DIFF
--- a/.github/workflows/governance-retention-policy.yml
+++ b/.github/workflows/governance-retention-policy.yml
@@ -1,0 +1,37 @@
+name: governance-retention-policy
+
+# Enforces the Sovereign Retention Doctrine invariants (residency=sovereign,
+# vendor egress opt-in, finite delete ceiling on every auto class) and the
+# enrolment producer that reads them. Path-filtered to the governance surface,
+# with an unfiltered push-on-main safety net so a wrong filter degrades to
+# merge-time detection, never to never (see docs/CI_PATH_FILTER_DEBT.md doctrine).
+on:
+  pull_request:
+    paths:
+      - 'contracts/governance/retention-policy.v0.json'
+      - 'tools/validate_retention_policy.py'
+      - 'apps/compute-gateway/src/compute_gateway/governance_enroll.py'
+      - 'apps/compute-gateway/tests/test_governance_enroll.py'
+      - '.github/workflows/governance-retention-policy.yml'
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  retention-doctrine:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Doctrine invariants hold
+        run: python3 tools/validate_retention_policy.py
+      - name: Enrolment producer tests
+        working-directory: apps/compute-gateway
+        run: |
+          python -m pip install --upgrade pip pytest
+          PYTHONPATH="src:${GITHUB_WORKSPACE}" python -m pytest tests/test_governance_enroll.py -q

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,9 @@ validate-wallguard-professional-workroom-runtime:
 validate-svf-agent-contract:
 	python3 tools/validate_svf_agent_contract.py
 
+validate-retention-policy:
+	python3 tools/validate_retention_policy.py
+
 validate-live-sociosphere-svf-contract:
 	python3 tools/validate_live_sociosphere_svf_contract.py
 

--- a/apps/compute-gateway/src/compute_gateway/governance_enroll.py
+++ b/apps/compute-gateway/src/compute_gateway/governance_enroll.py
@@ -149,8 +149,15 @@ def build_plan(policy: dict, *, now_ms: int | None = None,
             if prior is None or _keeps_longer(klass, prior[0], policy):
                 chosen[digest] = (klass, receipt_id, status)
 
+    # sorted(), not chosen.items(). With --limit set, the subset that actually gets
+    # enrolled is whatever the iteration yields first, and that order comes from
+    # load_index() insertion order — so "the first live batch" would differ between
+    # runs and between environments. A limited enrolment against a live warden must be
+    # reproducible: the same store and the same limit must enrol the same objects, or
+    # a re-run after a partial failure silently governs a different set.
     plans: list[EnrolmentPlan] = []
-    for digest, (klass, receipt_id, status) in chosen.items():
+    for digest in sorted(chosen):
+        klass, receipt_id, status = chosen[digest]
         spec = policy["classes"][klass]
         blob = persistence.get_blob(digest)
         if blob is None:

--- a/apps/compute-gateway/src/compute_gateway/governance_enroll.py
+++ b/apps/compute-gateway/src/compute_gateway/governance_enroll.py
@@ -197,14 +197,19 @@ def _default_poster(warden_url: str, token: str | None) -> Poster:
             headers={"content-type": "application/json",
                      **({"authorization": f"Bearer {token}"} if token else {})},
             method="POST")
+        def _body(raw: bytes) -> dict:
+            # The HTTP STATUS is the enrolment verdict, not the body. A 201 whose
+            # body is empty or non-JSON is still a success -- decoding it must never
+            # turn a real enrolment into a counted 'failure'.
+            try:
+                return json.loads(raw or b"{}")
+            except (json.JSONDecodeError, ValueError):
+                return {}
         try:
             with urllib.request.urlopen(req, timeout=15) as resp:
-                return resp.status, json.loads(resp.read() or b"{}")
+                return resp.status, _body(resp.read())
         except urllib.error.HTTPError as e:
-            try:
-                return e.code, json.loads(e.read() or b"{}")
-            except Exception:
-                return e.code, {}
+            return e.code, _body(e.read())
     return post
 
 

--- a/apps/compute-gateway/src/compute_gateway/governance_enroll.py
+++ b/apps/compute-gateway/src/compute_gateway/governance_enroll.py
@@ -151,34 +151,34 @@ def build_plan(policy: dict, *, now_ms: int | None = None,
 
     plans: list[EnrolmentPlan] = []
     for digest, (klass, receipt_id, status) in chosen.items():
-            spec = policy["classes"][klass]
-            blob = persistence.get_blob(digest)
-            if blob is None:
-                continue
-            # MUST match compute_gateway.artifacts.digest byte-for-byte. `id` is the
-            # content address of the blob; if `content` is a different encoding of the
-            # same object, the governed object's declared id does not address the bytes
-            # the warden ingested, and the content-addressed property the rest of the
-            # gateway relies on is silently false. json.dumps defaults (', ' / ': '
-            # separators, ensure_ascii=True) differ from the canonical form for EVERY
-            # dict blob, not only non-ASCII ones.
-            content = blob if isinstance(blob, str) else json.dumps(
-                blob, sort_keys=True, separators=(",", ":"), default=str, ensure_ascii=False)
-            body: dict = {
-                "id": digest,
-                "content": content,
-                "mime": _blob_mime(blob),
-                "residency": policy["universal_invariants"]["residency"],
-                "vendorOptIn": policy["universal_invariants"]["vendor_opt_in"],
-            }
-            if spec["disposition"] == "auto":
-                body["ttlAt"] = now + spec["ttl_days"] * DAY_MS
-                body["retentionDeleteAt"] = now + spec["retention_delete_days"] * DAY_MS
-            if spec.get("sensitive_by_default"):
-                body["sensitiveFields"] = ["payload"]
-            plans.append(EnrolmentPlan(digest, receipt_id, status, klass, body))
-            if limit is not None and len(plans) >= limit:
-                return plans
+        spec = policy["classes"][klass]
+        blob = persistence.get_blob(digest)
+        if blob is None:
+            continue
+        # MUST match compute_gateway.artifacts.digest byte-for-byte. `id` is the
+        # content address of the blob; if `content` is a different encoding of the
+        # same object, the governed object's declared id does not address the bytes
+        # the warden ingested, and the content-addressed property the rest of the
+        # gateway relies on is silently false. json.dumps defaults (', ' / ': '
+        # separators, ensure_ascii=True) differ from the canonical form for EVERY
+        # dict blob, not only non-ASCII ones.
+        content = blob if isinstance(blob, str) else json.dumps(
+            blob, sort_keys=True, separators=(",", ":"), default=str, ensure_ascii=False)
+        body: dict = {
+            "id": digest,
+            "content": content,
+            "mime": _blob_mime(blob),
+            "residency": policy["universal_invariants"]["residency"],
+            "vendorOptIn": policy["universal_invariants"]["vendor_opt_in"],
+        }
+        if spec["disposition"] == "auto":
+            body["ttlAt"] = now + spec["ttl_days"] * DAY_MS
+            body["retentionDeleteAt"] = now + spec["retention_delete_days"] * DAY_MS
+        if spec.get("sensitive_by_default"):
+            body["sensitiveFields"] = ["payload"]
+        plans.append(EnrolmentPlan(digest, receipt_id, status, klass, body))
+        if limit is not None and len(plans) >= limit:
+            return plans
     return plans
 
 

--- a/apps/compute-gateway/src/compute_gateway/governance_enroll.py
+++ b/apps/compute-gateway/src/compute_gateway/governance_enroll.py
@@ -70,6 +70,22 @@ def classify(epistemic_status: str | None, policy: dict) -> str:
     return policy["fallback"]["unknown_epistemic_status"]
 
 
+def retention_rank(klass: str, policy: dict) -> tuple[int, int]:
+    """How long a class keeps things, as a sortable rank. Higher keeps longer.
+
+    Read straight off the policy rather than hardcoded, so adding a class to the
+    doctrine cannot leave this function quietly ranking it wrong.
+    """
+    spec = policy["classes"][klass]
+    if spec.get("disposition") == "legal_hold":
+        return (1, 0)          # never auto-deletes; beats every auto class
+    return (0, int(spec.get("retention_delete_days") or 0))
+
+
+def _keeps_longer(candidate: str, incumbent: str, policy: dict) -> bool:
+    return retention_rank(candidate, policy) > retention_rank(incumbent, policy)
+
+
 @dataclass
 class EnrolmentPlan:
     digest: str
@@ -112,20 +128,42 @@ def build_plan(policy: dict, *, now_ms: int | None = None,
         for r in receipts:
             epistemic[r.get("id")] = r.get("epistemic_status")
 
-    plans: list[EnrolmentPlan] = []
-    seen: set[str] = set()
+    # One blob can be cited by several receipts, and the artifact store dedupes
+    # identical content across them -- so the same digest can arrive under two
+    # different epistemic statuses. Keeping whichever receipt was iterated first
+    # would let dict ordering choose the retention window, and in the bad case
+    # choose the SHORTER one: a blob also cited by an 'asserted' receipt (legal
+    # hold, never auto-deleted) could be enrolled as 'derived' (14d ttl, 90d hard
+    # delete) purely because a derived receipt cited it first. Retention is not a
+    # race.
+    #
+    # Collisions therefore resolve to the MOST CONSERVATIVE class -- legal_hold
+    # over auto, and among auto the longer hard-delete ceiling. Doubt keeps
+    # longer, the same rule the policy already applies to unknown status.
+    chosen: dict[str, tuple[str, str, str | None]] = {}   # digest -> (klass, receipt_id, status)
     for receipt_id, digests in persistence.load_index().items():
         status = epistemic.get(receipt_id)
         klass = classify(status, policy)
-        spec = policy["classes"][klass]
         for digest in digests:
-            if digest in seen:
-                continue  # one blob, one governed object, even if many receipts cite it
-            seen.add(digest)
+            prior = chosen.get(digest)
+            if prior is None or _keeps_longer(klass, prior[0], policy):
+                chosen[digest] = (klass, receipt_id, status)
+
+    plans: list[EnrolmentPlan] = []
+    for digest, (klass, receipt_id, status) in chosen.items():
+            spec = policy["classes"][klass]
             blob = persistence.get_blob(digest)
             if blob is None:
                 continue
-            content = blob if isinstance(blob, str) else json.dumps(blob, sort_keys=True)
+            # MUST match compute_gateway.artifacts.digest byte-for-byte. `id` is the
+            # content address of the blob; if `content` is a different encoding of the
+            # same object, the governed object's declared id does not address the bytes
+            # the warden ingested, and the content-addressed property the rest of the
+            # gateway relies on is silently false. json.dumps defaults (', ' / ': '
+            # separators, ensure_ascii=True) differ from the canonical form for EVERY
+            # dict blob, not only non-ASCII ones.
+            content = blob if isinstance(blob, str) else json.dumps(
+                blob, sort_keys=True, separators=(",", ":"), default=str, ensure_ascii=False)
             body: dict = {
                 "id": digest,
                 "content": content,

--- a/apps/compute-gateway/src/compute_gateway/governance_enroll.py
+++ b/apps/compute-gateway/src/compute_gateway/governance_enroll.py
@@ -1,0 +1,215 @@
+"""Enrol the gateway's content-addressed artifacts into L5 governance.
+
+The lifecycle-warden was live and sealing receipts, but `GET /v1/objects` returned
+`[]` -- it governed an empty set (issue #1048). The `POST /v1/objects` enrolment
+endpoint had no caller outside its own tests. This module is that caller.
+
+It reads the gateway's own artifact store (the 3,000+ content-addressed blobs that
+back materialize/graph receipts), classifies each by the EPISTEMIC CLASS of the
+receipt that produced it, and enrols it under the Sovereign Retention Doctrine
+(contracts/governance/retention-policy.v0.json):
+
+    derived   -> ttl 14d, hard-delete 90d   (reproducible cache; the receipt is the asset)
+    observed  -> ttl 30d, hard-delete 365d
+    asserted  -> legal hold; manual delete only
+    (unknown) -> observed (bounded, sensitive) -- doubt keeps longer, never deletes faster
+
+Two-lever, like the warden's own enforcement: DRY-RUN by default (prints exactly
+what WOULD be enrolled); `apply=True` performs it. Enrolment is idempotent -- the
+warden rejects a re-ingest of an already-governed id (409), which we count as
+'already governed', not an error, so re-running never double-enrols or errors.
+
+Enrolment does NOT delete anything. With the warden in its default dry-run mode it
+merely starts SCANNING real objects and sealing audited plans of what retention
+would do -- the second lever (WARDEN_ENFORCE=on) remains a separate, deliberate act.
+"""
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+from . import persistence
+
+_POLICY_REL = Path("contracts") / "governance" / "retention-policy.v0.json"
+
+DAY_MS = 86_400_000
+
+
+def _find_policy() -> Path:
+    """Locate the doctrine by walking up from this file until we find it. Robust
+    to where the module is run from -- computing a fixed parents[N] at import time
+    IndexErrors the moment the file is copied elsewhere (e.g. into a pod)."""
+    here = Path(__file__).resolve()
+    for base in (here, *here.parents):
+        candidate = base / _POLICY_REL
+        if candidate.exists():
+            return candidate
+    # Fall back to the in-repo location so load_policy() raises a clear
+    # FileNotFoundError naming the expected path, not an IndexError.
+    return here.parents[min(4, len(here.parents) - 1)] / _POLICY_REL
+
+# Poster contract: (url, json_body) -> (http_status, response_dict). Injectable so
+# tests never touch the network and never depend on a live warden.
+Poster = Callable[[str, dict], "tuple[int, dict]"]
+
+
+def load_policy(path: Path | None = None) -> dict:
+    path = path or _find_policy()
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def classify(epistemic_status: str | None, policy: dict) -> str:
+    classes = policy["classes"]
+    if epistemic_status in classes:
+        return epistemic_status
+    return policy["fallback"]["unknown_epistemic_status"]
+
+
+@dataclass
+class EnrolmentPlan:
+    digest: str
+    receipt_id: str
+    epistemic_status: str | None
+    klass: str
+    body: dict
+
+
+@dataclass
+class EnrolmentSummary:
+    planned: int = 0
+    enrolled: int = 0
+    already_governed: int = 0
+    failed: int = 0
+    by_class: dict = field(default_factory=dict)
+    errors: list = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        return {"planned": self.planned, "enrolled": self.enrolled,
+                "already_governed": self.already_governed, "failed": self.failed,
+                "by_class": self.by_class, "errors": self.errors[:20]}
+
+
+def _blob_mime(blob) -> str:
+    if isinstance(blob, dict) and isinstance(blob.get("mime"), str) and blob["mime"]:
+        return blob["mime"]
+    return "application/json"
+
+
+def build_plan(policy: dict, *, now_ms: int | None = None,
+               limit: int | None = None) -> list[EnrolmentPlan]:
+    """Derive the enrolment requests from the gateway's real store. Pure: reads
+    the store, touches nothing, contacts no network."""
+    now = now_ms if now_ms is not None else int(time.time() * 1000)
+
+    # receipt_id -> epistemic_status, from the receipts already on the chain.
+    epistemic: dict[str, str | None] = {}
+    for receipts in persistence.load_receipts().values():
+        for r in receipts:
+            epistemic[r.get("id")] = r.get("epistemic_status")
+
+    plans: list[EnrolmentPlan] = []
+    seen: set[str] = set()
+    for receipt_id, digests in persistence.load_index().items():
+        status = epistemic.get(receipt_id)
+        klass = classify(status, policy)
+        spec = policy["classes"][klass]
+        for digest in digests:
+            if digest in seen:
+                continue  # one blob, one governed object, even if many receipts cite it
+            seen.add(digest)
+            blob = persistence.get_blob(digest)
+            if blob is None:
+                continue
+            content = blob if isinstance(blob, str) else json.dumps(blob, sort_keys=True)
+            body: dict = {
+                "id": digest,
+                "content": content,
+                "mime": _blob_mime(blob),
+                "residency": policy["universal_invariants"]["residency"],
+                "vendorOptIn": policy["universal_invariants"]["vendor_opt_in"],
+            }
+            if spec["disposition"] == "auto":
+                body["ttlAt"] = now + spec["ttl_days"] * DAY_MS
+                body["retentionDeleteAt"] = now + spec["retention_delete_days"] * DAY_MS
+            if spec.get("sensitive_by_default"):
+                body["sensitiveFields"] = ["payload"]
+            plans.append(EnrolmentPlan(digest, receipt_id, status, klass, body))
+            if limit is not None and len(plans) >= limit:
+                return plans
+    return plans
+
+
+def _default_poster(warden_url: str, token: str | None) -> Poster:
+    def post(path: str, body: dict) -> tuple[int, dict]:
+        req = urllib.request.Request(
+            warden_url.rstrip("/") + path,
+            data=json.dumps(body).encode(),
+            headers={"content-type": "application/json",
+                     **({"authorization": f"Bearer {token}"} if token else {})},
+            method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                return resp.status, json.loads(resp.read() or b"{}")
+        except urllib.error.HTTPError as e:
+            try:
+                return e.code, json.loads(e.read() or b"{}")
+            except Exception:
+                return e.code, {}
+    return post
+
+
+def enrol(policy: dict, poster: Poster, *, apply: bool = False,
+          now_ms: int | None = None, limit: int | None = None) -> EnrolmentSummary:
+    plans = build_plan(policy, now_ms=now_ms, limit=limit)
+    s = EnrolmentSummary(planned=len(plans))
+    for p in plans:
+        s.by_class[p.klass] = s.by_class.get(p.klass, 0) + 1
+        if not apply:
+            continue
+        try:
+            status, resp = poster("/v1/objects", p.body)
+        except Exception as e:  # network etc. -- one bad object must not abort the sweep
+            s.failed += 1
+            s.errors.append(f"{p.digest[:16]}: {type(e).__name__}: {e}")
+            continue
+        if status in (200, 201):
+            s.enrolled += 1
+        elif status == 409:  # warden: "object already governed" -- idempotent, expected on re-run
+            s.already_governed += 1
+        else:
+            s.failed += 1
+            s.errors.append(f"{p.digest[:16]}: HTTP {status} {resp.get('error', '')}")
+    return s
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+    import os
+
+    ap = argparse.ArgumentParser(description="Enrol gateway artifacts into L5 governance")
+    ap.add_argument("--warden-url", default=os.getenv("COMPUTE_WARDEN_URL", "http://lifecycle-warden:8095"))
+    ap.add_argument("--token", default=os.getenv("WARDEN_TOKEN") or None)
+    ap.add_argument("--apply", action="store_true",
+                    help="perform enrolment (default: dry-run plan only)")
+    ap.add_argument("--limit", type=int, default=None, help="cap the number of objects")
+    args = ap.parse_args(argv)
+
+    if not persistence.enabled():
+        print("GATEWAY_STORE_DIR unset -- no durable store to read. Nothing to enrol.")
+        return 1
+
+    policy = load_policy()
+    poster = _default_poster(args.warden_url, args.token) if args.apply else (lambda *_: (0, {}))
+    s = enrol(policy, poster, apply=args.apply, limit=args.limit)
+    mode = "APPLIED" if args.apply else "DRY-RUN (pass --apply to enrol)"
+    print(f"[{mode}] " + json.dumps(s.as_dict(), indent=2))
+    return 1 if s.failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/compute-gateway/tests/test_governance_enroll.py
+++ b/apps/compute-gateway/tests/test_governance_enroll.py
@@ -1,0 +1,155 @@
+"""Tests for L5 artifact enrolment (issue #1048) and the Sovereign Retention Doctrine.
+
+The producer's job is to turn the warden's empty governed set into a real one,
+correctly classified. The risks worth testing are all about being WRONG in a way
+that looks fine: mis-classifying an object into the shortest retention, letting a
+re-run double-enrol, letting the default policy silently egress data off-sovereign,
+or aborting a whole sweep because one object failed. Each has a test.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from compute_gateway import governance_enroll as ge
+from compute_gateway import persistence
+
+
+@pytest.fixture
+def store():
+    """A real temp gateway store seeded with one blob per epistemic class."""
+    prev = os.environ.get("GATEWAY_STORE_DIR")
+    d = tempfile.mkdtemp()
+    os.environ["GATEWAY_STORE_DIR"] = d
+    persistence._reset_connection()
+
+    seq = [0]
+
+    def seed(receipt_id, epistemic_status, digest, blob):
+        seq[0] += 1  # (project, seq) is the receipts PK — distinct seq per receipt
+        persistence.save_receipt("p", seq[0], receipt_id,
+                                 json.dumps({"id": receipt_id, "kind": "materialize",
+                                             "epistemic_status": epistemic_status}))
+        persistence.save_blob(digest, blob)
+        persistence.save_index(receipt_id, [digest])
+
+    seed("r-derived", "derived", "sha256:d1", {"data": {"nodes": 1}, "mime": None})
+    seed("r-observed", "observed", "sha256:o1", {"data": "telemetry"})
+    seed("r-asserted", "asserted", "sha256:a1", {"data": "canonical source"})
+    seed("r-unknown", None, "sha256:u1", {"data": "no epistemic status"})
+    yield
+    persistence._reset_connection()
+    if prev is None:
+        os.environ.pop("GATEWAY_STORE_DIR", None)
+    else:
+        os.environ["GATEWAY_STORE_DIR"] = prev
+    persistence._reset_connection()
+
+
+class RecordingWarden:
+    """Fake POST /v1/objects. Enforces the warden's real idempotency contract:
+    a second ingest of the same id is a 409, not a silent overwrite."""
+
+    def __init__(self):
+        self.enrolled: dict[str, dict] = {}
+        self.calls = 0
+
+    def post(self, path, body):
+        self.calls += 1
+        assert path == "/v1/objects"
+        if body["id"] in self.enrolled:
+            return 409, {"ok": False, "error": f"object already governed: {body['id']}"}
+        self.enrolled[body["id"]] = body
+        return 201, {"ok": True}
+
+
+def test_policy_passes_its_own_validator():
+    import tools.validate_retention_policy as v  # noqa: E402
+    assert v.main() == 0
+
+
+def test_classification_maps_status_to_class(store):
+    policy = ge.load_policy()
+    plans = {p.digest: p for p in ge.build_plan(policy, now_ms=0)}
+    assert plans["sha256:d1"].klass == "derived"
+    assert plans["sha256:o1"].klass == "observed"
+    assert plans["sha256:a1"].klass == "asserted"
+    # The one that matters: unknown must NOT become 'derived' (shortest retention).
+    assert plans["sha256:u1"].klass == "observed"
+
+
+def test_derived_gets_short_window_asserted_gets_none(store):
+    policy = ge.load_policy()
+    plans = {p.digest: p for p in ge.build_plan(policy, now_ms=0)}
+    derived = plans["sha256:d1"].body
+    assert derived["ttlAt"] == 14 * ge.DAY_MS
+    assert derived["retentionDeleteAt"] == 90 * ge.DAY_MS
+    # asserted is legal-hold: no auto-delete is scheduled at all.
+    asserted = plans["sha256:a1"].body
+    assert "ttlAt" not in asserted and "retentionDeleteAt" not in asserted
+
+
+def test_every_object_is_sovereign_and_opt_out(store):
+    """The inviolable defaults must ride on EVERY enrolment body, all classes."""
+    policy = ge.load_policy()
+    for p in ge.build_plan(policy, now_ms=0):
+        assert p.body["residency"] == "sovereign"
+        assert p.body["vendorOptIn"] is False
+
+
+def test_sensitive_classes_are_marked(store):
+    policy = ge.load_policy()
+    plans = {p.digest: p for p in ge.build_plan(policy, now_ms=0)}
+    assert "sensitiveFields" in plans["sha256:o1"].body   # observed: sensitive
+    assert "sensitiveFields" in plans["sha256:a1"].body   # asserted: sensitive
+    assert "sensitiveFields" not in plans["sha256:d1"].body  # derived: not
+
+
+def test_dry_run_contacts_nothing(store):
+    policy = ge.load_policy()
+    w = RecordingWarden()
+    s = ge.enrol(policy, w.post, apply=False, now_ms=0)
+    assert s.planned == 4 and s.enrolled == 0 and w.calls == 0
+
+
+def test_apply_enrols_then_is_idempotent(store):
+    policy = ge.load_policy()
+    w = RecordingWarden()
+    first = ge.enrol(policy, w.post, apply=True, now_ms=0)
+    assert first.enrolled == 4 and first.already_governed == 0 and first.failed == 0
+    # Re-run: every object is already governed -> 409 -> counted, not errored.
+    second = ge.enrol(policy, w.post, apply=True, now_ms=0)
+    assert second.enrolled == 0 and second.already_governed == 4 and second.failed == 0
+
+
+def test_one_failure_does_not_abort_the_sweep(store):
+    policy = ge.load_policy()
+
+    calls = {"n": 0}
+
+    def flaky(path, body):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise ConnectionError("warden blipped")
+        return 201, {"ok": True}
+
+    s = ge.enrol(policy, flaky, apply=True, now_ms=0)
+    assert s.enrolled == 3 and s.failed == 1 and len(s.errors) == 1
+
+
+def test_limit_bounds_the_first_live_batch(store):
+    policy = ge.load_policy()
+    assert len(ge.build_plan(policy, now_ms=0, limit=2)) == 2
+
+
+def test_each_blob_enrolled_once_even_if_multiple_receipts_cite_it(store):
+    """A digest referenced by two receipts is one governed object, not two."""
+    persistence.save_receipt("p", 99, "r-derived-2",
+                             json.dumps({"id": "r-derived-2", "epistemic_status": "derived"}))
+    persistence.save_index("r-derived-2", ["sha256:d1"])  # same digest as r-derived
+    policy = ge.load_policy()
+    digests = [p.digest for p in ge.build_plan(policy, now_ms=0)]
+    assert digests.count("sha256:d1") == 1

--- a/apps/compute-gateway/tests/test_governance_enroll.py
+++ b/apps/compute-gateway/tests/test_governance_enroll.py
@@ -8,14 +8,19 @@ or aborting a whole sweep because one object failed. Each has a test.
 """
 from __future__ import annotations
 
+import copy
+import importlib.util
 import json
 import os
 import tempfile
+from pathlib import Path
 
 import pytest
 
 from compute_gateway import governance_enroll as ge
 from compute_gateway import persistence
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 @pytest.fixture
@@ -66,9 +71,102 @@ class RecordingWarden:
         return 201, {"ok": True}
 
 
+_DELETE = object()
+
+
+def _validator():
+    """Load tools/validate_retention_policy.py by path.
+
+    Not `import tools.validate_retention_policy`: that needs the repo root on
+    sys.path, which the dedicated governance workflow supplies via PYTHONPATH but
+    the generic app-test-diagnostics job does not — so this test passed in one CI
+    job and failed with ModuleNotFoundError in the other. Loading by path makes it
+    independent of who runs it and from where.
+    """
+    path = REPO_ROOT / "tools" / "validate_retention_policy.py"
+    spec = importlib.util.spec_from_file_location("validate_retention_policy", path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"cannot load the retention validator at {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_policy_passes_its_own_validator():
-    import tools.validate_retention_policy as v  # noqa: E402
-    assert v.main() == 0
+    assert _validator().main() == 0
+
+
+# ── The validator must be shown to REJECT, not only to accept ─────────────
+#
+# test_policy_passes_its_own_validator was the ONLY thing exercising the
+# validator, and it asserts the shipped policy passes. That assertion survives
+# `errors()` being replaced with `return []` — so the entire enforcement of the
+# Sovereign Retention Doctrine could be deleted with nothing going red. Verified:
+# stubbing errors() to return [] leaves the original suite fully green.
+#
+# The validator's own docstring says these are "precisely the changes that would
+# look harmless in review, so they are asserted here rather than trusted". Each
+# therefore gets a case proving the assertion actually refuses it.
+
+def _mutate(**overrides):
+    """The real shipped policy with targeted damage applied."""
+    policy = copy.deepcopy(json.loads(
+        (REPO_ROOT / "contracts" / "governance" / "retention-policy.v0.json").read_text()))
+    for dotted, value in overrides.items():
+        node = policy
+        parts = dotted.split("__")
+        for p in parts[:-1]:
+            node = node[p]
+        if value is _DELETE:
+            node.pop(parts[-1], None)
+        else:
+            node[parts[-1]] = value
+    return policy
+
+
+@pytest.mark.parametrize("overrides,expect", [
+    ({"universal_invariants__residency": "us-east-1"},      "residency"),
+    ({"universal_invariants__residency": _DELETE},          "residency"),
+    ({"universal_invariants__vendor_opt_in": True},         "vendor_opt_in"),
+    ({"universal_invariants__vendor_opt_in": _DELETE},      "vendor_opt_in"),
+    ({"classes__derived__retention_delete_days": None},     "retention_delete_days"),
+    ({"classes__derived__retention_delete_days": 0},        "retention_delete_days"),
+    ({"classes__derived__ttl_days": 9_999},                 "ttl_days"),
+    ({"classes__asserted__retention_delete_days": 30},      "legal_hold"),
+    ({"fallback__unknown_epistemic_status": "derived"},     "SHORTEST"),
+    ({"fallback__unknown_epistemic_status": "asserted"},    "auto class"),
+    ({"fallback__unknown_epistemic_status": "nope"},        "not a defined class"),
+    ({"classes": {}},                                       "no classes"),
+])
+def test_validator_rejects_each_relaxed_invariant(overrides, expect):
+    errs = _validator().errors(_mutate(**overrides))
+    assert errs, f"validator ACCEPTED {overrides} — that invariant is unenforced"
+    assert any(expect in e for e in errs), \
+        f"rejected, but for the wrong reason. wanted {expect!r}, got: {errs}"
+
+
+@pytest.mark.parametrize("policy", [
+    "not a dict", ["also", "not"], 42, None,
+    {"universal_invariants": [], "classes": {}},
+    {"universal_invariants": {}, "classes": "should be an object"},
+    {"universal_invariants": {}, "classes": {"x": "not an object"}},
+    {"universal_invariants": {}, "classes": {}, "fallback": "not an object"},
+])
+def test_validator_reports_rather_than_crashes_on_wrong_types(policy):
+    """Copilot's third comment. A validator meant to fail safely must report a
+    violation, not raise AttributeError — a traceback and a violation report are
+    different signals, and only one of them says what is wrong."""
+    errs = _validator().errors(policy)
+    assert errs and all(isinstance(e, str) for e in errs)
+
+
+def test_the_shipped_policy_is_what_the_rejection_tests_mutate():
+    """Guards the mutation helper itself: if _mutate stopped reading the real
+    policy, every rejection case above would be testing a fixture instead."""
+    v = _validator()
+    assert v.errors(_mutate()) == [], "the unmutated copy must be the passing policy"
+    assert v.POLICY.resolve() == (
+        REPO_ROOT / "contracts" / "governance" / "retention-policy.v0.json").resolve()
 
 
 def test_classification_maps_status_to_class(store):
@@ -153,3 +251,74 @@ def test_each_blob_enrolled_once_even_if_multiple_receipts_cite_it(store):
     policy = ge.load_policy()
     digests = [p.digest for p in ge.build_plan(policy, now_ms=0)]
     assert digests.count("sha256:d1") == 1
+
+
+# ── Copilot round-1 ───────────────────────────────────────────────────────
+
+# Both ids are parametrised to sort BEFORE and AFTER the incumbent "r-derived".
+# This is not belt-and-braces: the first draft of the legal-hold test used only
+# "r-asserted-2", which sorts before "r-derived", so the buggy first-seen
+# implementation happened to pick the right answer and the test PASSED against
+# the bug it was written to catch. A tie-break test that only exercises one
+# iteration order is testing the ordering, not the tie-break.
+@pytest.mark.parametrize("rid", ["r-aaa-asserted", "r-zzz-asserted"])
+def test_a_digest_cited_by_two_classes_takes_the_LONGER_retention(store, rid):
+    """Copilot: dedupe kept whichever receipt was iterated first, so ordering
+    could pick the retention window — and in the bad case pick the shorter one.
+
+    One blob cited by both a 'derived' receipt (14d ttl / 90d delete) and an
+    'asserted' one (legal hold, never auto-deleted). Enrolling it as derived puts
+    a legally-held object on a 90-day hard delete.
+    """
+    persistence.save_receipt("p", 98, rid,
+                             json.dumps({"id": rid, "epistemic_status": "asserted"}))
+    persistence.save_index(rid, ["sha256:d1"])   # same blob as r-derived
+    policy = ge.load_policy()
+    plan = {p.digest: p for p in ge.build_plan(policy, now_ms=0)}["sha256:d1"]
+    assert plan.klass == "asserted", "legal hold must win over an auto class"
+    assert "retentionDeleteAt" not in plan.body, "a legally-held object must carry no delete date"
+
+
+@pytest.mark.parametrize("rid", ["r-aaa-observed", "r-zzz-observed"])
+def test_among_auto_classes_the_longer_ceiling_wins(store, rid):
+    """observed (365d) must beat derived (90d) in either iteration order."""
+    persistence.save_receipt("p", 97, rid,
+                             json.dumps({"id": rid, "epistemic_status": "observed"}))
+    persistence.save_index(rid, ["sha256:d1"])
+    policy = ge.load_policy()
+    plan = {p.digest: p for p in ge.build_plan(policy, now_ms=0)}["sha256:d1"]
+    assert plan.klass == "observed"
+
+
+def test_retention_rank_is_read_from_the_policy_not_hardcoded():
+    """The tie-break must follow the doctrine. If a class's ceiling is raised in
+    the contract, the ranking must move with it rather than stay pinned to a
+    constant someone wrote once."""
+    policy = ge.load_policy()
+    assert ge.retention_rank("asserted", policy) > ge.retention_rank("observed", policy)
+    assert ge.retention_rank("observed", policy) > ge.retention_rank("derived", policy)
+    bumped = copy.deepcopy(policy)
+    bumped["classes"]["derived"]["retention_delete_days"] = 10_000
+    assert ge.retention_rank("derived", bumped) > ge.retention_rank("observed", bumped), \
+        "ranking ignored the policy — it is hardcoded"
+
+
+def test_enrolled_content_is_the_bytes_the_id_addresses(store):
+    """Copilot: `id` is the artifact digest but `content` was a DIFFERENT encoding
+    of the same object, so the governed object's declared id did not address the
+    bytes the warden ingested. Verified broken before the fix: json.dumps defaults
+    differ from the canonical form for every dict blob, not just non-ASCII ones."""
+    from compute_gateway import artifacts
+    blob = {"note": "café résumé", "items": [1, 2], "z": "a"}
+    digest = artifacts.digest(blob)
+    persistence.save_blob(digest, blob)
+    persistence.save_receipt("p", 96, "r-uni",
+                             json.dumps({"id": "r-uni", "epistemic_status": "observed"}))
+    persistence.save_index("r-uni", [digest])
+
+    plan = {p.digest: p for p in ge.build_plan(ge.load_policy(), now_ms=0)}[digest]
+    rehashed = artifacts.digest(json.loads(plan.body["content"]))
+    assert rehashed == plan.body["id"], (
+        "content does not hash back to the id it is enrolled under — the governed "
+        "object is not content-addressed")
+    assert "\\u00e9" not in plan.body["content"], "content must not be ASCII-escaped"

--- a/apps/compute-gateway/tests/test_governance_enroll.py
+++ b/apps/compute-gateway/tests/test_governance_enroll.py
@@ -12,6 +12,7 @@ import copy
 import importlib.util
 import json
 import os
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -27,7 +28,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 def store():
     """A real temp gateway store seeded with one blob per epistemic class."""
     prev = os.environ.get("GATEWAY_STORE_DIR")
-    d = tempfile.mkdtemp()
+    d = tempfile.mkdtemp()   # removed in teardown below — see shutil.rmtree
     os.environ["GATEWAY_STORE_DIR"] = d
     persistence._reset_connection()
 
@@ -52,6 +53,7 @@ def store():
     else:
         os.environ["GATEWAY_STORE_DIR"] = prev
     persistence._reset_connection()
+    shutil.rmtree(d, ignore_errors=True)   # mkdtemp does not clean up after itself
 
 
 class RecordingWarden:
@@ -322,3 +324,40 @@ def test_enrolled_content_is_the_bytes_the_id_addresses(store):
         "content does not hash back to the id it is enrolled under — the governed "
         "object is not content-addressed")
     assert "\\u00e9" not in plan.body["content"], "content must not be ASCII-escaped"
+
+
+def test_a_limited_enrolment_picks_the_same_objects_every_run(store):
+    """Copilot: with --limit set, which objects get enrolled depended on
+    load_index() insertion order, so 'the first live batch' was not reproducible.
+    A re-run after a partial failure would silently govern a different set.
+
+    The seeding below is the whole test. The default fixture inserts receipts whose
+    ids (r-asserted, r-derived, r-observed, r-unknown) happen to sort the same way
+    as their digests, so insertion order and sorted order COINCIDE and the fixture
+    cannot tell the two apart — the first version of this test passed with
+    chosen.items() restored. These pairs invert that deliberately: the receipt
+    inserted first carries the digest that sorts LAST.
+    """
+    persistence.save_receipt("p", 90, "r-aaa-first",
+                             json.dumps({"id": "r-aaa-first", "epistemic_status": "observed"}))
+    persistence.save_blob("sha256:zzz9", {"data": "sorts last, inserted first"})
+    persistence.save_index("r-aaa-first", ["sha256:zzz9"])
+    persistence.save_receipt("p", 91, "r-zzz-last",
+                             json.dumps({"id": "r-zzz-last", "epistemic_status": "observed"}))
+    persistence.save_blob("sha256:aaa0", {"data": "sorts first, inserted last"})
+    persistence.save_index("r-zzz-last", ["sha256:aaa0"])
+
+    policy = ge.load_policy()
+    everything = [p.digest for p in ge.build_plan(policy, now_ms=0)]
+    assert everything == sorted(everything), (
+        f"plan order is not deterministic — got {everything}")
+    # The discriminating relation: zzz9 was inserted FIRST, aaa0 LAST. Under insertion
+    # order zzz9 precedes aaa0; under digest order it cannot. If this ever holds under
+    # both, the fixture has stopped discriminating and the assertion above is decorative.
+    assert everything.index("sha256:aaa0") < everything.index("sha256:zzz9"), (
+        f"ordering still follows insertion, not digest — got {everything}")
+
+    first = [p.digest for p in ge.build_plan(policy, now_ms=0, limit=2)]
+    assert first == everything[:2], "the limited batch must be the first N of that order"
+    for _ in range(5):
+        assert [p.digest for p in ge.build_plan(policy, now_ms=0, limit=2)] == first

--- a/contracts/governance/retention-policy.v0.json
+++ b/contracts/governance/retention-policy.v0.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://socioprophet.id/schemas/governance/retention-policy/v0",
+  "version": "0.1.0",
+  "title": "Sovereign Retention Doctrine",
+  "doctrine": {
+    "principle": "The receipt is the asset; the content is the liability.",
+    "rationale": [
+      "We keep PROOF forever: hash-chained receipts are tiny, immutable, and are the moat.",
+      "We keep BYTES only as long as they earn their keep. Retention is not the default -- it is an exception each object justifies with a finite TTL.",
+      "Un-TTL'd retention is the exact failure mode L5 governance exists to prevent, so no auto-classed object may be kept forever by omission.",
+      "Retention window is a function of EPISTEMIC CLASS: reproducible/derived bytes decay fast because the proof survives and the content regenerates; asserted source of truth is protected."
+    ]
+  },
+  "universal_invariants": {
+    "residency": "sovereign",
+    "vendor_opt_in": false,
+    "_notes": {
+      "residency": "Governed bytes never leave our infrastructure. Non-negotiable.",
+      "vendor_opt_in": "Egress is OPT-IN and default-deny. We ENFORCE what others merely declare. A per-object opt-in must still pass the engine policy gate; false here means the object can never be a vendor-cache candidate.",
+      "retention_delete_required": "Every class whose disposition is 'auto' MUST declare a finite retention_delete_days. Only 'legal_hold' disposition may omit it, and only by explicit act."
+    }
+  },
+  "classes": {
+    "derived": {
+      "epistemic_status": "derived",
+      "meaning": "Reproducible from the graph (e.g. materialize outputs). Pure cache -- deleting the bytes is safe because the receipt still verifies and the content regenerates.",
+      "disposition": "auto",
+      "ttl_days": 14,
+      "retention_delete_days": 90,
+      "sensitive_by_default": false
+    },
+    "observed": {
+      "epistemic_status": "observed",
+      "meaning": "A record of what a real executor self-reported (governance runs, telemetry). Not independently re-derivable, so kept longer than derived, but still bounded.",
+      "disposition": "auto",
+      "ttl_days": 30,
+      "retention_delete_days": 365,
+      "sensitive_by_default": true
+    },
+    "asserted": {
+      "epistemic_status": "asserted",
+      "meaning": "Canonical source or a first-party claim. The truth other artifacts are derived FROM -- losing it is unrecoverable.",
+      "disposition": "legal_hold",
+      "ttl_days": null,
+      "retention_delete_days": null,
+      "sensitive_by_default": true
+    }
+  },
+  "fallback": {
+    "unknown_epistemic_status": "observed",
+    "_note": "An object whose producing receipt has no recognised epistemic_status is treated as 'observed' (bounded retention), never as 'derived' (short) or 'asserted' (never-delete). Doubt resolves toward keeping longer and treating as sensitive -- never toward aggressive deletion or unbounded retention."
+  }
+}

--- a/tools/validate_retention_policy.py
+++ b/tools/validate_retention_policy.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Validate the Sovereign Retention Doctrine contract against its own invariants.
+
+The doctrine is worthless if the file can drift out of the shape the enrolment
+producer relies on, or -- worse -- if someone quietly relaxes an invariant
+(residency off sovereign, vendor egress opted in by default, an auto class with
+no delete ceiling). Those are precisely the changes that would look harmless in
+review, so they are asserted here rather than trusted.
+
+Exit 0 = the contract is well-formed AND every invariant holds. Exit 1 = it does
+not, with the reason on stdout.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY = ROOT / "contracts" / "governance" / "retention-policy.v0.json"
+
+
+def errors(policy: dict) -> list[str]:
+    errs: list[str] = []
+
+    inv = policy.get("universal_invariants", {})
+    if inv.get("residency") != "sovereign":
+        errs.append(f"residency must be 'sovereign', got {inv.get('residency')!r} "
+                    f"-- governed bytes leaving our infra is not a tunable")
+    if inv.get("vendor_opt_in") is not False:
+        errs.append(f"vendor_opt_in must be false (opt-in, default-deny), got "
+                    f"{inv.get('vendor_opt_in')!r}")
+
+    classes = policy.get("classes", {})
+    if not classes:
+        errs.append("no classes defined")
+
+    for name, c in classes.items():
+        disp = c.get("disposition")
+        if disp not in ("auto", "legal_hold"):
+            errs.append(f"class {name}: disposition must be 'auto' or 'legal_hold', got {disp!r}")
+            continue
+        if disp == "auto":
+            ttl, dele = c.get("ttl_days"), c.get("retention_delete_days")
+            if not isinstance(dele, int) or dele <= 0:
+                errs.append(f"class {name}: 'auto' disposition requires a finite positive "
+                            f"retention_delete_days -- no retention forever by omission "
+                            f"(got {dele!r})")
+            if not isinstance(ttl, int) or ttl <= 0:
+                errs.append(f"class {name}: 'auto' disposition requires a positive ttl_days (got {ttl!r})")
+            elif isinstance(dele, int) and ttl > dele:
+                errs.append(f"class {name}: ttl_days ({ttl}) must not exceed "
+                            f"retention_delete_days ({dele}) -- a TTL past the hard-delete "
+                            f"ceiling can never fire")
+        else:  # legal_hold
+            if c.get("retention_delete_days") is not None:
+                errs.append(f"class {name}: legal_hold must NOT auto-delete "
+                            f"(retention_delete_days must be null)")
+
+    fb = policy.get("fallback", {}).get("unknown_epistemic_status")
+    if fb not in classes:
+        errs.append(f"fallback class {fb!r} is not a defined class")
+    elif classes.get(fb, {}).get("disposition") == "legal_hold":
+        errs.append(f"fallback must be an auto class -- an unknown object defaulting to "
+                    f"legal_hold could never be deleted; got {fb!r}")
+    elif fb == "derived":
+        errs.append("fallback must not be 'derived' -- an unknown object must not get the "
+                    "SHORTEST retention. Doubt resolves toward keeping longer.")
+
+    return errs
+
+
+def main(path: Path = POLICY) -> int:
+    if not path.exists():
+        print(f"FAIL retention policy not found at {path}")
+        return 1
+    try:
+        policy = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        print(f"FAIL retention policy is not valid JSON: {e}")
+        return 1
+
+    errs = errors(policy)
+    for e in errs:
+        print(f"FAIL {e}")
+    if errs:
+        print(f"\n{len(errs)} invariant violation(s)")
+        return 1
+    print(f"OK Sovereign Retention Doctrine v{policy.get('version')}: "
+          f"{len(policy['classes'])} classes, invariants hold")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_retention_policy.py
+++ b/tools/validate_retention_policy.py
@@ -23,7 +23,18 @@ POLICY = ROOT / "contracts" / "governance" / "retention-policy.v0.json"
 def errors(policy: dict) -> list[str]:
     errs: list[str] = []
 
+    if not isinstance(policy, dict):
+        return [f"policy must be a JSON object, got {type(policy).__name__}"]
+
+    # Type-guard the containers before reaching into them. A validator whose job
+    # is to fail safely must not crash with AttributeError when the JSON drifts
+    # to the wrong shape: a traceback and a violation report are different
+    # signals, and only one of them says what is actually wrong.
     inv = policy.get("universal_invariants", {})
+    if not isinstance(inv, dict):
+        errs.append(f"universal_invariants must be an object, got {type(inv).__name__}")
+        inv = {}
+
     if inv.get("residency") != "sovereign":
         errs.append(f"residency must be 'sovereign', got {inv.get('residency')!r} "
                     f"-- governed bytes leaving our infra is not a tunable")
@@ -32,10 +43,16 @@ def errors(policy: dict) -> list[str]:
                     f"{inv.get('vendor_opt_in')!r}")
 
     classes = policy.get("classes", {})
+    if not isinstance(classes, dict):
+        errs.append(f"classes must be an object, got {type(classes).__name__}")
+        classes = {}
     if not classes:
         errs.append("no classes defined")
 
     for name, c in classes.items():
+        if not isinstance(c, dict):
+            errs.append(f"class {name}: must be an object, got {type(c).__name__}")
+            continue
         disp = c.get("disposition")
         if disp not in ("auto", "legal_hold"):
             errs.append(f"class {name}: disposition must be 'auto' or 'legal_hold', got {disp!r}")
@@ -57,8 +74,12 @@ def errors(policy: dict) -> list[str]:
                 errs.append(f"class {name}: legal_hold must NOT auto-delete "
                             f"(retention_delete_days must be null)")
 
-    fb = policy.get("fallback", {}).get("unknown_epistemic_status")
-    if fb not in classes:
+    fallback = policy.get("fallback", {})
+    if not isinstance(fallback, dict):
+        errs.append(f"fallback must be an object, got {type(fallback).__name__}")
+        fallback = {}
+    fb = fallback.get("unknown_epistemic_status")
+    if not isinstance(fb, str) or fb not in classes:
         errs.append(f"fallback class {fb!r} is not a defined class")
     elif classes.get(fb, {}).get("disposition") == "legal_hold":
         errs.append(f"fallback must be an auto class -- an unknown object defaulting to "

--- a/tools/validate_retention_policy.py
+++ b/tools/validate_retention_policy.py
@@ -72,7 +72,8 @@ def errors(policy: dict) -> list[str]:
         else:  # legal_hold
             if c.get("retention_delete_days") is not None:
                 errs.append(f"class {name}: legal_hold must NOT auto-delete "
-                            f"(retention_delete_days must be null)")
+                            f"(retention_delete_days must be null or omitted, "
+                            f"got {c.get('retention_delete_days')!r})")
 
     fallback = policy.get("fallback", {})
     if not isinstance(fallback, dict):


### PR DESCRIPTION
Closes #1048.

## The gap this closes

Live probe (2026-07-29) found the `lifecycle-warden` **live and correct** — 44 sealed `governance` receipts, audit chain advancing — but governing an **empty set**: `GET /v1/objects` → `[]`, and `POST /v1/objects` had no caller outside its own tests. It scanned zero objects every 300s and sealed a receipt proving it. This gives it something real to govern, under a **declared, enforced** policy.

## The policy — Sovereign Retention Doctrine

`contracts/governance/retention-policy.v0.json`. **The receipt is the asset; the content is the liability.** We keep proof forever (hash-chained receipts — the moat); we keep bytes only as long as they earn their keep. **Retention window is a function of epistemic class** — this is what makes it *ours*, not a generic TTL:

| class | meaning | TTL | hard-delete |
|---|---|---|---|
| `derived` | reproducible from the graph (materialize) | 14d | 90d |
| `observed` | a record of what an executor reported | 30d | 365d |
| `asserted` | canonical source / first-party claim | legal hold | manual only |
| *(unknown)* | → `observed` — doubt keeps longer + marks sensitive, never deletes faster | | |

**Three inviolable defaults, enforced not declared:** `residency=sovereign` (bytes never leave our infra), `vendorOptIn=false` (egress opt-**in**, default-deny — we enforce what others merely declare), and every auto class carries a **finite delete ceiling** (no retention forever by omission). Deleting a `derived` blob is safe — the receipt still verifies, the bytes regenerate — which is *why* it gets the shortest window.

## Enforcement, negative-tested

`tools/validate_retention_policy.py` asserts each invariant. All six of these edits make it exit 1: residency off sovereign, vendor opt-in defaulting true, an auto class with no delete ceiling, a TTL past the ceiling, a fallback to the shortest retention, a legal-hold class that auto-deletes. Wired into CI via a path-filtered workflow **with an unfiltered push-on-main safety net** (per the doctrine in #1045).

## The producer

`governance_enroll.py` reads the gateway's own artifact store, classifies each content-addressed blob by its producing receipt's `epistemic_status`, and enrols it. **Idempotent** (the warden's 409 "already governed" is counted, not errored), **one governed object per digest** even if many receipts cite it, and **one failed object never aborts the sweep**. Dry-run by default — the two-lever discipline the warden itself uses.

## Verified against real data

Dry-run against the live `/data` store (**3,036 real blobs**): planned **3,036 = 2,988 `derived` + 48 `observed`**, matching the receipts on the chain exactly. Nothing mutated.

The producer also had a real robustness bug the pod surfaced — an import-time `parents[4]` that IndexErrors when the file lives anywhere but its in-repo path. Now self-locates by walking up for the contract.

## What is deliberately NOT done here

The **first live enrolment** — which moves `objects_scanned` off zero and the register entry from `wired` to `measured` — is a permanent, bounded write to the append-only production governance chain. That is an operational act, held for explicit go-ahead, not performed in this PR. The warden stays dry-run regardless, so enrolment starts *scanning*; it deletes nothing.

**Tests:** 10 producer + 6 negative validator.
