### PR TITLE
docs(register): l5-governance-lifecycle declared→wired (live probe)

### DIFF
--- a/docs/design-register.yaml
+++ b/docs/design-register.yaml
@@ -112,10 +112,29 @@ register:
   # ── Pre-existing convictions imported so the register is honest from birth ──
   - id: l5-governance-lifecycle
     source: blueprint audit 2026-07 ("libraries nobody calls")
-    mechanism: "lifecycle.ts FSM actually invoked on the governed path"
+    mechanism: >-
+      The engine lifecycle FSM + Governor + object store are invoked on the governed
+      path by apps/lifecycle-warden, which runs dueTransitions → runRetention → gc every
+      WARDEN_INTERVAL_SECONDS and seals each pass on THE receipt spine via compute-gateway
+      kind=governance (adapters._governance). No longer a library with zero callers.
     owner: prophet-platform
-    status: declared      # library complete, ZERO callers — the canonical RC2 case
-    probe: "callers-grep of lifecycle FSM entrypoints > 0 outside tests"
+    status: wired
+    # declared→wired 2026-07-29 on LIVE PROBE (not inference): deployment lifecycle-warden
+    # 1/1 in ns socioprophet; GET /healthz 200; GET /v1/audit/head seq 59; and 44 kind=governance
+    # receipts on the gateway chain (/data/gateway.db) — the warden IS the caller and the
+    # evidence is on the spine. CI has no cluster access, so probe_cmd below is the static
+    # wiring proxy; the runtime probe is re-run by hand on each roll.
+    # 🔴 CANNOT reach `measured` until objects_scanned > 0: the warden governs an EMPTY set
+    # (POST /v1/objects had no caller — issue #1048). PR #1054 adds the enrolment producer +
+    # Sovereign Retention Doctrine; the first LIVE enrolment is a deliberate bounded write to
+    # the append-only prod chain, held for go-ahead. Until then: it runs, it is receipted, it
+    # governs nothing — do not describe above `wired`.
+    probe: "warden is the live caller: healthz 200 + 44 kind=governance receipts on the spine"
+    probe_cmd: >-
+      grep -q "_governance" apps/compute-gateway/src/compute_gateway/adapters.py
+      && grep -q '"governance"' apps/compute-gateway/src/compute_gateway/registry.py
+      && test -f deploy/values/lifecycle-warden.yaml
+      && grep -rq "lifecycle-warden" deploy/argocd/
     wave: unassigned
 
   - id: swarm-holography-gate


### PR DESCRIPTION
Promotes `l5-governance-lifecycle` from `declared` to `wired`, unblocked now that #1027 landed (both touch `docs/design-register.yaml`).

## Why the old status was stale

The entry read: *"the canonical RC2 case — library complete, ZERO callers."* Live probe (2026-07-29) says otherwise:

- deployment `lifecycle-warden` **1/1** in ns `socioprophet`
- `GET /healthz` → **200**, `GET /v1/audit/head` → **seq 59**
- **44 `kind=governance` receipts** on the gateway chain (`/data/gateway.db`)

The warden runs the engine's lifecycle FSM + Governor on the governed path and seals each pass on the receipt spine via `adapters._governance`. It **is** a caller.

## Probe

CI has no cluster access, so `probe_cmd` is the static wiring proxy — gateway `_governance` adapter + registry backend + warden values + argocd reference. **The register gate executed it: PASS.** The runtime probe (healthz + receipts) is re-run by hand on each roll.

## Held at `wired`, not `measured` — deliberately

The warden governs an **empty set** (#1048). It runs, it's receipted, it governs nothing. #1054 adds the enrolment producer + Sovereign Retention Doctrine; the first live enrolment moves `objects_scanned` off zero and reaches `measured`, and is a bounded write to the append-only prod chain held for go-ahead. Nothing is described above its probe-verified status.