### PR TITLE
W12: provenance that is asserted, not decorative — KKO TBox, KBpedia RC ABox, zero-trust kernel schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ validate-repo:
 engine-guards:
 	node apps/hellgraph-service/scripts/check-engine-version.mjs
 	node apps/lifecycle-warden/scripts/check-engine-version.mjs
+	# Same question, different vendored input: is the ONTOLOGY we ship the one we declare?
+	# The 55k KBpedia RC ABox is the vocabulary enrich + semantic typing resolve against, so a
+	# drifted copy changes ANSWERS rather than failing (W12). Runtime refuses to load it;
+	# this fails the BUILD, so a mismatched artifact never reaches an image.
+	node apps/hellgraph-service/scripts/check-ontology-digest.mjs
 
 docs-check:
 	python3 tools/validate_repo.py

--- a/apps/compute-gateway/src/compute_gateway/schemas/PROVENANCE.md
+++ b/apps/compute-gateway/src/compute_gateway/schemas/PROVENANCE.md
@@ -1,0 +1,68 @@
+# Zero-trust kernel schemas (vendored)
+
+**Source repo:** `SocioProphet/mcp-a2a-zero-trust` (public, GitHub)
+**Pinned commit:** `0399e8ae84f0be8194ce57e56b14ba4bbb807f47` — 2026-05-21,
+_"Bind MCP/A2A interop to Operation Plane trust boundaries"_
+**Vendored:** 2026-07-18 (prophet-platform `07aeabdc`, PR #853; extended by `298d3aa2`, PR #858)
+**Provenance established and byte-verified:** 2026-07-29
+
+## What these are
+The estate's own control-zone authority kernel — **not** the public `mcp` SDK. The compute-gateway
+registers as a governed PROVIDER inside that kernel and emits kernel-shaped evidence
+(`capability_registry()`, `grant_check()`, `attestation_bundle()` in `zerotrust.py`). These six
+documents are the contract that evidence is validated against, at runtime and in tests.
+
+## The six files, with upstream paths and digests
+
+| vendored file | upstream path @ `0399e8ae` | sha256 | bytes |
+|---|---|---|---|
+| `capability_registry.schema.json` | `mcp/registry/capability_registry.schema.json` | `f3e793394baee2c4782762de565e988b4fc527639b41839aa859d2f9cbb3d73d` | 3,263 |
+| `attestation_bundle.schema.json` | `schemas/canonical/attestation_bundle.schema.json` | `485d0ed689cc1b3184a18d555bb3eba75c4110f7087d0c3c6c54c575447a4272` | 1,434 |
+| `grant.schema.json` | `schemas/canonical/grant.schema.json` | `2aac20b5fc9ce2ef72c0609bc1687f2b4b17a2167ef3148fa8ad3c4c1494f0b1` | 2,991 |
+| `policy_decision.schema.json` | `schemas/canonical/policy_decision.schema.json` | `fa836113aeda2b1d65b9a3868cb692e266fa51d516bb3a3f248e58e74d6dfc89` | 2,027 |
+| `quorum_proof.schema.json` | `schemas/canonical/quorum_proof.schema.json` | `d3ceec20d3268c30c1f0fda17f0981654a850ad39073ac5b1ff4aff62a0b2bb2` | 1,240 |
+| `tool_grant_check.schema.json` | `schemas/interop/tool_grant_check.schema.json` | `360c5c98c43742aa7f930a472fd8662eff28bba32eca9b20dd8e76d3077c923c` | 3,282 |
+
+Note the **flattening**: upstream separates `mcp/registry/`, `schemas/canonical/` and
+`schemas/interop/`; the vendored copies sit in one directory. Only the location changed — the
+bytes are identical, which is what the digests above prove. The upstream path column is what makes
+a re-vendor mechanical rather than a search, and is exactly what was missing when these six were
+described only as "vendored".
+
+### Verification performed 2026-07-29
+Each file fetched from `raw.githubusercontent.com` at the pinned commit and compared with `cmp`:
+**all six byte-identical.** Repeated against the kernel's `main`
+(`93c4b831ca2394990b5302d0acea03f40d07537e`): **also byte-identical** — the pin is not merely
+recorded, it is still current, so this vendoring carries no freshness debt today.
+
+## Licence
+`SocioProphet/mcp-a2a-zero-trust` is a **first-party SocioProphet repository**, so no third-party
+licence obligation attaches to these files.
+
+**Stated honestly:** the repo declares **no explicit licence** — there is no `LICENSE` file at the
+pinned commit, and GitHub reports no detected licence for it. That is recorded here as an observed
+fact, not resolved by assumption. It is a gap on the *kernel* repo's side (an unlicensed public
+repo is "all rights reserved" by default, which is probably not the intent for an estate contract
+others are meant to conform to) and is raised in this PR's body for the owning lane rather than
+guessed at here.
+
+## Where the digests are ENFORCED
+`zerotrust.py` verifies this table **at import** — `verify_vendored_schemas()`, whose result is the
+`SCHEMA_DIGESTS` module constant. Three refusals, all `RuntimeError`, all fatal at boot:
+
+| condition | why it is fatal |
+|---|---|
+| a pinned schema is **missing** | validation would otherwise raise deep inside a request instead of at boot |
+| a pinned schema **drifted** | these documents decide what a ToolGrantCheck and an AttestationBundle *are*; a loosened `required` or a widened enum silently admits evidence the kernel would reject |
+| an **unpinned** `*.schema.json` appears here | `_registry()` globs this directory and registers every document by `$id`, so an unvendored file can satisfy a canonical `$ref` and quietly become the contract — vendoring is a closed set or it is not vendoring |
+
+Proven by `tests/test_schema_provenance.py`, which tampers with a copy of the package and asserts a
+real interpreter refuses to import it — separately for the drifted, missing and unpinned cases.
+
+## Re-vendoring
+1. Pick the new kernel commit; update `KERNEL_COMMIT` in `zerotrust.py` and the header above.
+2. For each row: copy the file from its upstream path, then
+   `shasum -a 256 <file>` → update `SCHEMA_PROVENANCE` in `zerotrust.py` **and** the table above.
+3. Adding or dropping a schema means editing `SCHEMA_PROVENANCE` — the file set is pinned too, so
+   a new schema cannot be dropped in without provenance.
+4. `PYTHONPATH=src pytest -q tests` — the provenance tests must pass on the new digests.

--- a/apps/compute-gateway/src/compute_gateway/zerotrust.py
+++ b/apps/compute-gateway/src/compute_gateway/zerotrust.py
@@ -18,9 +18,33 @@ PROVIDER inside that kernel:
     attestation (cosign_valid), with the receipt id as the attested-unit digest.
 
 The full grant DECISION + ledger + quorum live in the kernel/agentplane; the
-gateway performs the CHECK and emits conforming evidence. Schemas are VENDORED
-(apps/compute-gateway/schemas/) — sovereign, self-contained, validated at runtime
-and in tests against the exact kernel contract (pinned mcp-a2a-zero-trust 0399e8a).
+gateway performs the CHECK and emits conforming evidence.
+
+── VENDORED SCHEMAS: provenance and integrity (see schemas/PROVENANCE.md) ────
+Six schemas are VENDORED into this package (`src/compute_gateway/schemas/`, so
+they ship in the image the Dockerfile builds from `COPY src`) — sovereign,
+self-contained, validated at runtime and in tests against the exact kernel
+contract:
+
+    repo    SocioProphet/mcp-a2a-zero-trust
+    commit  0399e8ae84f0be8194ce57e56b14ba4bbb807f47  (2026-05-21, "Bind MCP/A2A
+            interop to Operation Plane trust boundaries")
+    files   mcp/registry/capability_registry.schema.json
+            schemas/canonical/{attestation_bundle,grant,policy_decision,quorum_proof}.schema.json
+            schemas/interop/tool_grant_check.schema.json
+
+All six are byte-identical to that commit (re-verified against upstream
+2026-07-29, and still byte-identical to the kernel's `main` — the pin is current,
+not merely recorded). The per-file sha256 table below is ASSERTED AT IMPORT
+(nugget-extractor contract.py precedent), together with the exact FILE SET: an
+unexpected schema appearing in this directory is refused too, because
+`_registry()` globs the directory and would otherwise hand an unvendored
+document authority over what this gateway accepts.
+
+The prior version of this docstring named the vendored path as
+`apps/compute-gateway/schemas/`, which does not exist — the real location is
+`src/compute_gateway/schemas/`. A provenance note pointing at the wrong
+directory is how "vendored from nowhere identifiable" starts.
 """
 from __future__ import annotations
 
@@ -41,6 +65,85 @@ TRUST_BOUNDARY_ID = os.getenv("ZEROTRUST_BOUNDARY_ID", "tb-compute-gateway")
 TRUST_DOMAIN = os.getenv("ZEROTRUST_TRUST_DOMAIN", "socioprophet.dev")
 
 _SCHEMA_DIR = Path(__file__).resolve().parent / "schemas"   # ships inside the package (src/)
+
+# ── vendored kernel schemas: the pinned manifest ──────────────────────────────
+# The authority kernel the compute plane conforms to. A branch name would be a moving
+# reference; this is the commit the bytes came from.
+KERNEL_REPO = "SocioProphet/mcp-a2a-zero-trust"
+KERNEL_COMMIT = "0399e8ae84f0be8194ce57e56b14ba4bbb807f47"
+KERNEL_REF = f"{KERNEL_REPO}@{KERNEL_COMMIT}"
+
+# vendored filename -> (upstream path at KERNEL_COMMIT, sha256 of the bytes)
+# The upstream path matters as much as the digest: it is what makes a re-vendor mechanical
+# instead of a search, and it is precisely what was missing when these six were described as
+# "vendored" from nowhere identifiable.
+SCHEMA_PROVENANCE: dict[str, tuple[str, str]] = {
+    "capability_registry.schema.json": (
+        "mcp/registry/capability_registry.schema.json",
+        "f3e793394baee2c4782762de565e988b4fc527639b41839aa859d2f9cbb3d73d"),
+    "attestation_bundle.schema.json": (
+        "schemas/canonical/attestation_bundle.schema.json",
+        "485d0ed689cc1b3184a18d555bb3eba75c4110f7087d0c3c6c54c575447a4272"),
+    "grant.schema.json": (
+        "schemas/canonical/grant.schema.json",
+        "2aac20b5fc9ce2ef72c0609bc1687f2b4b17a2167ef3148fa8ad3c4c1494f0b1"),
+    "policy_decision.schema.json": (
+        "schemas/canonical/policy_decision.schema.json",
+        "fa836113aeda2b1d65b9a3868cb692e266fa51d516bb3a3f248e58e74d6dfc89"),
+    "quorum_proof.schema.json": (
+        "schemas/canonical/quorum_proof.schema.json",
+        "d3ceec20d3268c30c1f0fda17f0981654a850ad39073ac5b1ff4aff62a0b2bb2"),
+    "tool_grant_check.schema.json": (
+        "schemas/interop/tool_grant_check.schema.json",
+        "360c5c98c43742aa7f930a472fd8662eff28bba32eca9b20dd8e76d3077c923c"),
+}
+
+
+def verify_vendored_schemas(schema_dir: Path | None = None) -> dict[str, str]:
+    """Fail-closed integrity gate over the vendored kernel schemas. Returns {file: sha256}.
+
+    Three ways to fail, all raising RuntimeError, because all three mean this gateway would be
+    enforcing a contract other than the one it declares:
+
+      missing   — a pinned schema is absent; validation would raise at first use, deep inside a
+                  request, rather than at boot.
+      drifted   — a pinned schema's bytes changed. These documents decide what a ToolGrantCheck
+                  and an AttestationBundle ARE; a loosened `required` or a widened enum silently
+                  admits evidence the kernel would reject, and nothing downstream can tell.
+      unpinned  — an EXTRA *.schema.json in the directory. `_registry()` globs this directory and
+                  registers every document it finds by $id, so an unvendored file can satisfy a
+                  canonical $ref and quietly become the contract. Vendoring is a closed set or it
+                  is not vendoring.
+    """
+    d = _SCHEMA_DIR if schema_dir is None else schema_dir
+    found = {p.name for p in d.glob("*.schema.json")}
+    pinned = set(SCHEMA_PROVENANCE)
+
+    if missing := sorted(pinned - found):
+        raise RuntimeError(
+            f"vendored kernel schemas MISSING: {', '.join(missing)} (expected in {d}); "
+            f"re-vendor from {KERNEL_REF}")
+    if extra := sorted(found - pinned):
+        raise RuntimeError(
+            f"UNPINNED schema(s) in the vendored kernel directory: {', '.join(extra)}. Every "
+            f"schema here is registered by $id and can satisfy a canonical $ref, so an unvendored "
+            f"document would silently become part of the contract. Add it to SCHEMA_PROVENANCE "
+            f"with its upstream path + sha256, or remove it.")
+
+    digests: dict[str, str] = {}
+    for name, (upstream_path, expected) in sorted(SCHEMA_PROVENANCE.items()):
+        actual = hashlib.sha256((d / name).read_bytes()).hexdigest()
+        if actual != expected:
+            raise RuntimeError(
+                f"vendored kernel schema DRIFTED: {name} sha256 {actual} != pinned {expected}; "
+                f"re-vendor from {KERNEL_REF} ({upstream_path}) and update SCHEMA_PROVENANCE + "
+                f"schemas/PROVENANCE.md. Refusing to enforce a contract this gateway cannot name.")
+        digests[name] = actual
+    return digests
+
+
+# THE GATE. Asserted at import — a provenance table nothing verifies is decoration.
+SCHEMA_DIGESTS = verify_vendored_schemas()
 
 # compute kind → capability effect (kernel enum: read|write|compute|exec|egress)
 _EFFECT = {"notebook": "exec", "spark": "exec", "graph-query": "read",

--- a/apps/compute-gateway/tests/test_schema_provenance.py
+++ b/apps/compute-gateway/tests/test_schema_provenance.py
@@ -1,0 +1,168 @@
+"""Vendored zero-trust kernel schemas — provenance ASSERTED, not just written down.
+
+The W12 finding was that six schemas were described as "vendored" with no source repo named:
+real files, real validation, and no way to answer "vendored from WHERE?". The origin has since
+been established (SocioProphet/mcp-a2a-zero-trust@0399e8ae, all six byte-identical), but a
+recorded origin that nothing checks decays into the same state the moment someone edits a file.
+
+So the load-bearing tests here are the ones that TAMPER: each of the three refusals (drifted,
+missing, unpinned) is proven by mutating a real copy of the package and watching a real
+interpreter refuse to import it.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from compute_gateway import zerotrust
+
+SRC_ROOT = Path(zerotrust.__file__).resolve().parents[1]        # .../src
+PKG_ROOT = SRC_ROOT / "compute_gateway"
+SCHEMA_DIR = PKG_ROOT / "schemas"
+
+
+def _import_copy(tmp_path: Path, mutate) -> subprocess.CompletedProcess[str]:
+    """Copy the package, mutate its vendored schemas, import it in a FRESH interpreter."""
+    fake_src = tmp_path / "src"
+    shutil.copytree(SRC_ROOT, fake_src, ignore=shutil.ignore_patterns("__pycache__", "*.egg-info"))
+    mutate(fake_src / "compute_gateway" / "schemas")
+    return subprocess.run(
+        [sys.executable, "-c", "import compute_gateway.zerotrust"],
+        cwd=fake_src, capture_output=True, text=True, timeout=120,
+        env={**os.environ, "PYTHONPATH": str(fake_src)},
+    )
+
+
+# ── the provenance itself ────────────────────────────────────────────────────
+
+def test_every_vendored_schema_is_pinned_with_an_upstream_path_and_digest():
+    """Six files, six rows — a named source for each, not a directory-level hand-wave."""
+    assert len(zerotrust.SCHEMA_PROVENANCE) == 6
+    on_disk = {p.name for p in SCHEMA_DIR.glob("*.schema.json")}
+    assert on_disk == set(zerotrust.SCHEMA_PROVENANCE), "the pinned set must BE the shipped set"
+
+    for name, (upstream_path, digest) in zerotrust.SCHEMA_PROVENANCE.items():
+        assert upstream_path.endswith(name), f"{name}: upstream path must name the same file"
+        assert upstream_path.count("/") >= 1, f"{name}: upstream path must be a real repo path"
+        assert len(digest) == 64 and all(c in "0123456789abcdef" for c in digest)
+        assert hashlib.sha256((SCHEMA_DIR / name).read_bytes()).hexdigest() == digest
+
+
+def test_the_source_repo_is_NAMED_and_the_commit_PINNED():
+    """The finding in one assertion: these came from somewhere identifiable."""
+    assert zerotrust.KERNEL_REPO == "SocioProphet/mcp-a2a-zero-trust"
+    assert len(zerotrust.KERNEL_COMMIT) == 40                       # a commit, not a branch
+    assert all(c in "0123456789abcdef" for c in zerotrust.KERNEL_COMMIT)
+    assert zerotrust.KERNEL_REF == f"{zerotrust.KERNEL_REPO}@{zerotrust.KERNEL_COMMIT}"
+
+
+def test_digests_are_asserted_at_import_not_merely_recorded():
+    """SCHEMA_DIGESTS exists only because the gate ran during import."""
+    assert set(zerotrust.SCHEMA_DIGESTS) == set(zerotrust.SCHEMA_PROVENANCE)
+    for name, digest in zerotrust.SCHEMA_DIGESTS.items():
+        assert digest == zerotrust.SCHEMA_PROVENANCE[name][1]
+
+
+def test_provenance_md_records_what_the_code_enforces():
+    doc = (SCHEMA_DIR / "PROVENANCE.md").read_text()
+    assert zerotrust.KERNEL_REPO in doc
+    assert zerotrust.KERNEL_COMMIT in doc
+    for name, (upstream_path, digest) in zerotrust.SCHEMA_PROVENANCE.items():
+        assert digest in doc, f"{name}: digest missing from PROVENANCE.md"
+        assert upstream_path in doc, f"{name}: upstream path missing from PROVENANCE.md"
+
+
+def test_every_vendored_schema_is_still_valid_json_with_an_id():
+    """$id is what _registry() keys on — a schema without one silently fails to resolve refs."""
+    for name in zerotrust.SCHEMA_PROVENANCE:
+        doc = json.loads((SCHEMA_DIR / name).read_text())
+        assert "$id" in doc, f"{name} has no $id"
+
+
+# ── the three refusals, each proven by tampering ─────────────────────────────
+
+def test_verify_rejects_a_drifted_schema(tmp_path: Path):
+    """NEGATIVE (unit): a loosened contract is refused, and the error names the re-vendor source."""
+    shutil.copytree(SCHEMA_DIR, tmp_path / "schemas")
+    target = tmp_path / "schemas" / "tool_grant_check.schema.json"
+    doc = json.loads(target.read_text())
+    # the realistic drift: weaken the contract rather than corrupt the file. Dropping `required`
+    # keeps it valid JSON Schema and would silently admit evidence the kernel rejects.
+    doc.pop("required", None)
+    target.write_text(json.dumps(doc, indent=2))
+
+    with pytest.raises(RuntimeError) as exc:
+        zerotrust.verify_vendored_schemas(tmp_path / "schemas")
+    msg = str(exc.value)
+    assert "DRIFTED" in msg and "tool_grant_check.schema.json" in msg
+    assert zerotrust.KERNEL_REF in msg
+    assert "schemas/interop/tool_grant_check.schema.json" in msg   # the upstream path to re-copy
+
+
+def test_verify_rejects_a_missing_schema(tmp_path: Path):
+    shutil.copytree(SCHEMA_DIR, tmp_path / "schemas")
+    (tmp_path / "schemas" / "quorum_proof.schema.json").unlink()
+    with pytest.raises(RuntimeError) as exc:
+        zerotrust.verify_vendored_schemas(tmp_path / "schemas")
+    assert "MISSING" in str(exc.value) and "quorum_proof.schema.json" in str(exc.value)
+
+
+def test_verify_rejects_an_UNPINNED_schema_smuggled_into_the_directory(tmp_path: Path):
+    """The subtle one: _registry() globs this directory and registers by $id, so an extra file
+    can satisfy a canonical $ref and become the contract without anyone vendoring it."""
+    shutil.copytree(SCHEMA_DIR, tmp_path / "schemas")
+    (tmp_path / "schemas" / "rogue.schema.json").write_text(json.dumps({
+        "$id": "https://socioprophet.dev/schemas/canonical/grant.schema.json",   # shadows a real $id
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",                                                        # permits anything
+    }))
+    with pytest.raises(RuntimeError) as exc:
+        zerotrust.verify_vendored_schemas(tmp_path / "schemas")
+    msg = str(exc.value)
+    assert "UNPINNED" in msg and "rogue.schema.json" in msg
+    assert "$id" in msg or "canonical $ref" in msg
+
+
+def test_the_untampered_directory_verifies(tmp_path: Path):
+    """Control: the same procedure on unmodified bytes passes, so the refusals above are real."""
+    shutil.copytree(SCHEMA_DIR, tmp_path / "schemas")
+    digests = zerotrust.verify_vendored_schemas(tmp_path / "schemas")
+    assert len(digests) == 6
+
+
+# ── and the same three, proven to actually stop a process ────────────────────
+
+@pytest.mark.parametrize("case,mutate,needle", [
+    ("drifted",
+     lambda d: (d / "grant.schema.json").write_bytes(
+         (d / "grant.schema.json").read_bytes().replace(b'"required"', b'"reqiured"', 1)),
+     "DRIFTED"),
+    ("missing",
+     lambda d: (d / "attestation_bundle.schema.json").unlink(),
+     "MISSING"),
+    ("unpinned",
+     lambda d: (d / "smuggled.schema.json").write_text('{"$id":"x","type":"object"}'),
+     "UNPINNED"),
+])
+def test_tampered_schemas_kill_import_in_a_real_process(tmp_path: Path, case, mutate, needle):
+    """THE tests. If the digest table were merely recorded, every one of these would import fine
+    and the gateway would go on enforcing a contract it cannot name."""
+    proc = _import_copy(tmp_path, mutate)
+    assert proc.returncode != 0, (
+        f"a {case.upper()} vendored schema imported cleanly — provenance is recorded but NOT "
+        f"enforced.\nstdout={proc.stdout}\nstderr={proc.stderr}")
+    assert "RuntimeError" in proc.stderr
+    assert needle in proc.stderr
+
+
+def test_untampered_copy_still_imports(tmp_path: Path):
+    """Control for the subprocess machinery itself."""
+    proc = _import_copy(tmp_path, lambda d: None)
+    assert proc.returncode == 0, proc.stderr

--- a/apps/hellgraph-service/ontology/PROVENANCE.md
+++ b/apps/hellgraph-service/ontology/PROVENANCE.md
@@ -1,0 +1,89 @@
+# KBpedia Reference Concepts — the RC ABox (vendored)
+
+**File:** `kbpedia-rc-2.10.n3.gz`
+**SHA-256 (as vendored, gzipped):** `e48d0ff7708d647cb35b1bcbcca05a041c731e5a1bfcea296209a086b72da06a`
+**Bytes (gzipped):** 8,954,726
+**SHA-256 (inflated N3):** `0c23ca83ac0e1270c4ea5335268b54a32577ba5d8cec0e33345f48e2ac60e95f`
+**Bytes (inflated):** 37,618,857
+**KBpedia version:** 2.10 · **Namespace:** `http://kbpedia.org/kko/rc/`
+**Vendored:** 2026-07-28 (commit `7aa06ab5`) · **Provenance verified against upstream:** 2026-07-29
+
+## Source (sovereign, pinned)
+- **`SocioProphet/kbpedia`** @ commit `3f888b397255b69d1439fd95823e97011ed9440b` (branch `master`)
+- Path: `versions/2.10/kbpedia_reference_concepts.zip` (8,982,294 bytes,
+  sha256 `59ae9070b34946c7acea121604b291d82d0ebf47232fc0ee4615028e1e4d56ce`)
+- The zip holds exactly one entry: `kbpedia_reference_concepts.n3`, 37,618,857 bytes.
+- Upstream of that fork: **`KBpedia/kbpedia`** (the org formerly known as Cognonto).
+
+**Transformation applied:** unzip, then re-gzip. The RDF is **unmodified** — the inflated bytes
+are byte-identical to upstream's, which is what the second digest above proves. Only the
+compression container changed (zip → gzip), so the image needs no unzip tooling and `server.ts`
+can inflate with Node's built-in `zlib`.
+
+### Verification performed 2026-07-29
+```
+$ curl -sfL https://raw.githubusercontent.com/SocioProphet/kbpedia/3f888b39.../versions/2.10/kbpedia_reference_concepts.zip -o rc.zip
+$ unzip -p rc.zip kbpedia_reference_concepts.n3 | shasum -a 256
+0c23ca83ac0e1270c4ea5335268b54a32577ba5d8cec0e33345f48e2ac60e95f
+$ gunzip -c ontology/kbpedia-rc-2.10.n3.gz | shasum -a 256
+0c23ca83ac0e1270c4ea5335268b54a32577ba5d8cec0e33345f48e2ac60e95f   # identical
+```
+
+## What it is, and why drift here is dangerous
+The **KBpedia reference-concept ABox**: ~55,124 reference concepts (RCs) with ~75k
+`rdfs:subClassOf` edges, the instance layer typed by the KKO upper ontology (the TBox, vendored
+separately — see `apps/owl-reasoner/src/owl_reasoner/data/PROVENANCE.md`).
+
+This is **the vocabulary that `/api/graph/enrich` coherence-ranks against** and **the target
+vocabulary semantic entity typing resolves entities into** (engine `mapEntityToKkoSemantic`,
+0.4.37+). A drifted copy therefore does **not** produce an error — it produces *different
+answers*: different coherence rankings, different entity types, and those results are written
+back as content-addressed atoms that persist. That is the exact failure class this estate keeps
+re-discovering, so this artifact is fail-CLOSED rather than fail-safe.
+
+Loaded at startup behind `HELLGRAPH_LOAD_RC=on` (enabled in `deploy/values/hellgraph-service.yaml`).
+Measured cost: ~560MB peak RSS with the 0.4.40 batched loader; the pod budget is 1Gi.
+
+## Where the digest is ENFORCED
+Two places, deliberately — one at runtime, one in CI, because either alone leaves a gap.
+
+| where | what it checks | on failure |
+|---|---|---|
+| **runtime**, `src/server.ts::loadRcIfEnabled()` via `src/ontology-provenance.ts` | gz sha256, then inflated sha256 + byte count, before the first concept reaches the store | **refuses to load** — logs `RC load REFUSED`, service stays up with an empty RC set |
+| **CI**, `scripts/check-ontology-digest.mjs` (run by `make engine-guards`, a `validate-target-diagnostics` matrix target) | the committed artifact still matches the pins recorded here and in `ontology-provenance.ts` | build fails |
+
+CI catches a bad artifact before it ever ships; the runtime check catches a swapped file inside
+a running image, which CI cannot see. Both read the same constants.
+
+**Why both digests.** gzip is not reproducible — the same input under a different zlib version or
+compression level yields different compressed bytes. So the gz digest can only ever prove "this
+is the file we vendored"; it can never demonstrate equivalence to anything published upstream.
+Only the **inflated** digest is portable provenance, and it is the one that ties these bytes to
+`SocioProphet/kbpedia`.
+
+**The override hole, closed.** `HELLGRAPH_RC_PATH` previously let an operator point the service at
+any file, unverified. It now REQUIRES `HELLGRAPH_RC_SHA256` (64-hex, the gz digest); without it
+the load is refused. An operator-supplied corpus is verified against the operator's own digest and
+the log explicitly states that upstream equivalence is **not** claimed for it — we make no
+provenance assertion about bytes we did not vendor.
+
+Proven by `src/ontology-provenance.test.ts`, which tampers with a real gzip artifact and asserts
+the verifier refuses — including a length-preserving tamper that survives a size check.
+
+## License / attribution
+KBpedia is released under **CC-BY-4.0**.
+© Michael K. Bergman and Fred Giasson (Cognonto Corporation / KBpedia).
+Attribution required; see <https://kbpedia.org> and <https://creativecommons.org/licenses/by/4.0/>.
+This vendored copy preserves that attribution and does not modify the ontology content.
+(The `SocioProphet/kbpedia` fork carries no `LICENSE` file of its own; the CC-BY-4.0 terms are
+KBpedia's published licence for version 2.10 and are recorded here as the governing terms.)
+
+## Re-vendoring
+1. Download `versions/2.10/kbpedia_reference_concepts.zip` (or the newer version's) from the
+   pinned `SocioProphet/kbpedia` commit.
+2. `unzip -p <zip> kbpedia_reference_concepts.n3 | gzip -9 > ontology/kbpedia-rc-2.10.n3.gz`
+3. Record BOTH digests: `shasum -a 256 ontology/kbpedia-rc-2.10.n3.gz` and
+   `gunzip -c ontology/kbpedia-rc-2.10.n3.gz | shasum -a 256`.
+4. Update `RC_GZ_SHA256`, `RC_N3_SHA256`, `RC_N3_BYTES`, `RC_SOURCE` in
+   `src/ontology-provenance.ts` **and** the header above.
+5. `node scripts/check-ontology-digest.mjs && npm test` — both must pass on the new digests.

--- a/apps/hellgraph-service/package.json
+++ b/apps/hellgraph-service/package.json
@@ -9,7 +9,8 @@
     "start": "tsx src/server.ts",
     "typecheck": "tsc --noEmit",
     "test": "node --import tsx --test src/*.test.ts",
-    "check:engine": "node scripts/check-engine-version.mjs"
+    "check:engine": "node scripts/check-engine-version.mjs",
+    "check:ontology": "node scripts/check-ontology-digest.mjs"
   },
   "dependencies": {
     "@socioprophet/hellgraph": "file:vendor/socioprophet-hellgraph-0.4.45.tgz",

--- a/apps/hellgraph-service/scripts/check-ontology-digest.mjs
+++ b/apps/hellgraph-service/scripts/check-ontology-digest.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Vendored-ontology digest guard for hellgraph-service.
+ *
+ * ── Why this exists (W12 inventory hygiene, 2026-07) ─────────────────────────────────
+ * The 8.5MB KBpedia reference-concept ABox shipped into the image with NO provenance of any
+ * kind: no source URL, no licence note, no digest, no retrieval date. It is the vocabulary
+ * `/api/graph/enrich` coherence-ranks against and that semantic entity typing resolves into, so
+ * a drifted copy does not fail — it returns DIFFERENT ANSWERS, and those answers persist as
+ * content-addressed atoms. Nothing would have noticed.
+ *
+ * `src/ontology-provenance.ts` now asserts the digests at LOAD time. That closes the runtime
+ * hole but not the supply hole: a bad artifact committed to the repo would still build, publish,
+ * and only refuse once a pod started. This guard is the CI half — it fails the BUILD, so a
+ * mismatched artifact never reaches an image. Same constants, two enforcement points:
+ *
+ *     CI (this file)          the committed artifact is the declared one   -> build red
+ *     runtime (server.ts)     the artifact in THIS image is the declared one -> refuse to load
+ *
+ * Wired into `make engine-guards`, alongside the engine-version guards, because it answers the
+ * same question about a different vendored input: IS THE THING WE SHIP THE THING WE INTEND?
+ *
+ * Deliberately dependency-free and TypeScript-free (plain .mjs reading the .ts as text) so it
+ * runs in a bare CI container with no npm install and no build step.
+ */
+import { readFileSync, existsSync, createReadStream } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { createGunzip } from 'node:zlib'
+import { pipeline } from 'node:stream/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const die = (m) => { console.error(`✗ ${m}`); process.exit(1) }
+
+const here = dirname(fileURLToPath(import.meta.url))
+const svcRoot = join(here, '..')
+const provTs = join(svcRoot, 'src', 'ontology-provenance.ts')
+const provMd = join(svcRoot, 'ontology', 'PROVENANCE.md')
+const artifact = join(svcRoot, 'ontology', 'kbpedia-rc-2.10.n3.gz')
+
+// ── 1) read the pins out of the module the RUNTIME uses, so CI and runtime can never disagree ──
+if (!existsSync(provTs)) die(`missing ${provTs} — the provenance module is the source of the pins`)
+const src = readFileSync(provTs, 'utf8')
+const pin = (name) => {
+  const m = src.match(new RegExp(`export const ${name} =\\s*'([0-9a-f]{64})'`))
+  return m ? m[1] : die(`cannot read ${name} from src/ontology-provenance.ts`)
+}
+const RC_GZ_SHA256 = pin('RC_GZ_SHA256')
+const RC_N3_SHA256 = pin('RC_N3_SHA256')
+const bytesMatch = src.match(/export const RC_N3_BYTES = ([\d_]+)/)
+const RC_N3_BYTES = bytesMatch ? Number(bytesMatch[1].replace(/_/g, '')) : die('cannot read RC_N3_BYTES')
+
+// ── 2) the PROVENANCE.md must record what the code enforces (a doc nobody verifies is decoration) ──
+if (!existsSync(provMd)) die('ontology/PROVENANCE.md is missing — a vendored artifact must state its origin')
+const doc = readFileSync(provMd, 'utf8')
+for (const [what, needle] of [
+  ['the gz digest', RC_GZ_SHA256],
+  ['the inflated digest', RC_N3_SHA256],
+  ['a pinned source commit', '3f888b397255b69d1439fd95823e97011ed9440b'],
+  ['the licence', 'CC-BY-4.0'],
+  ['the source repo', 'SocioProphet/kbpedia'],
+]) if (!doc.includes(needle)) die(`ontology/PROVENANCE.md does not record ${what} (${needle})`)
+
+// ── 3) the artifact itself ──
+if (!existsSync(artifact)) die(`vendored RC artifact missing: ${artifact}`)
+
+const gzSha = createHash('sha256').update(readFileSync(artifact)).digest('hex')
+if (gzSha !== RC_GZ_SHA256)
+  die(`RC artifact DRIFTED: sha256 ${gzSha} != pinned ${RC_GZ_SHA256}. This artifact is the target ` +
+      `vocabulary enrich + semantic typing resolve against — a drifted copy changes ANSWERS rather ` +
+      `than failing. Re-vendor from SocioProphet/kbpedia and update src/ontology-provenance.ts + ` +
+      `ontology/PROVENANCE.md together.`)
+
+// Inflate as a STREAM: the payload is 37MB and a CI container should not need it resident.
+const h = createHash('sha256')
+let n3Bytes = 0
+await pipeline(
+  createReadStream(artifact),
+  createGunzip(),
+  async function* (chunks) { for await (const c of chunks) { h.update(c); n3Bytes += c.length } },
+)
+const n3Sha = h.digest('hex')
+if (n3Sha !== RC_N3_SHA256)
+  die(`RC inflated content DRIFTED: sha256 ${n3Sha} != pinned ${RC_N3_SHA256}. The compressed file ` +
+      `matched, so the two pinned digests disagree with each other — re-verify against upstream.`)
+if (n3Bytes !== RC_N3_BYTES)
+  die(`RC inflated size ${n3Bytes} != pinned ${RC_N3_BYTES}`)
+
+console.log(`✓ hellgraph-service RC ABox verified — gz ${gzSha.slice(0, 16)}… / inflated ${n3Sha.slice(0, 16)}… ` +
+            `(${n3Bytes.toLocaleString()} bytes, CC-BY-4.0, SocioProphet/kbpedia@3f888b39)`)

--- a/apps/hellgraph-service/src/ontology-provenance.test.ts
+++ b/apps/hellgraph-service/src/ontology-provenance.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Vendored-ontology integrity — proven by TAMPERING, not by re-reading the recorded digest.
+ *
+ * The finding these tests close (W12 inventory hygiene) was not "the RC file is wrong". It was
+ * that the file had no provenance and nothing checked it, so a wrong one would have been
+ * indistinguishable from a right one — and because these ~55k concepts are what `enrich` and
+ * semantic typing RESOLVE AGAINST, a wrong one changes ANSWERS instead of failing. So the tests
+ * that matter here are the negative ones: the verifier must REFUSE artifacts that differ,
+ * including one crafted to survive a size check.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as zlib from 'node:zlib'
+import {
+  verifyRcArtifact, expectedDigestFor, sha256,
+  RC_GZ_SHA256, RC_N3_SHA256, RC_N3_BYTES, RC_SOURCE, RC_LICENSE,
+} from './ontology-provenance.js'
+
+const ONTOLOGY_DIR = path.join(__dirname, '..', 'ontology')
+const RC_GZ = path.join(ONTOLOGY_DIR, 'kbpedia-rc-2.10.n3.gz')
+
+// The real 8.5MB artifact is present in a source checkout but is NOT what most of these tests
+// need — a small synthetic gzip exercises the same code path in milliseconds. The real artifact
+// gets its own (skippable) test below.
+const haveRealArtifact = fs.existsSync(RC_GZ)
+
+/** A stand-in artifact + the digests that describe it, so the verifier can be driven end-to-end. */
+function synthetic(body: string): { gz: Buffer; gzSha: string } {
+  const gz = zlib.gzipSync(Buffer.from(body, 'utf8'))
+  return { gz, gzSha: sha256(gz) }
+}
+
+test('the pinned constants are internally consistent and fully specified', () => {
+  assert.match(RC_GZ_SHA256, /^[0-9a-f]{64}$/)
+  assert.match(RC_N3_SHA256, /^[0-9a-f]{64}$/)
+  assert.notEqual(RC_GZ_SHA256, RC_N3_SHA256, 'compressed and inflated digests must be distinct')
+  assert.equal(RC_N3_BYTES, 37_618_857)
+  // provenance is NAMED, PINNED and LICENSED — the three things the finding said were absent
+  assert.match(RC_SOURCE, /SocioProphet\/kbpedia@[0-9a-f]{40}/)
+  assert.match(RC_SOURCE, /CC-BY-4\.0/)
+  assert.match(RC_LICENSE, /CC-BY-4\.0/)
+})
+
+test('PROVENANCE.md records exactly the digests the code enforces', () => {
+  const doc = fs.readFileSync(path.join(ONTOLOGY_DIR, 'PROVENANCE.md'), 'utf8')
+  assert.ok(doc.includes(RC_GZ_SHA256), 'gz digest missing from PROVENANCE.md')
+  assert.ok(doc.includes(RC_N3_SHA256), 'inflated digest missing from PROVENANCE.md')
+  assert.ok(doc.includes('3f888b397255b69d1439fd95823e97011ed9440b'), 'source not PINNED to a commit')
+  assert.ok(doc.includes('CC-BY-4.0'), 'licence not recorded')
+})
+
+test('NEGATIVE: an artifact whose gz digest differs is REFUSED', () => {
+  const { gz } = synthetic('not the reference concepts')
+  const v = verifyRcArtifact(gz, zlib.gunzipSync)          // held to the real vendored pin
+  assert.equal(v.ok, false)
+  assert.match(v.reason ?? '', /digest mismatch/)
+  assert.match(v.reason ?? '', /Re-vendor from SocioProphet\/kbpedia/)
+  assert.equal(v.expectedGzSha256, RC_GZ_SHA256)
+})
+
+test('NEGATIVE: a LENGTH-PRESERVING tamper is still refused — size is not integrity', () => {
+  // Two payloads of identical byte length whose gzip outputs are also the same length: a check
+  // that only compared sizes would wave this through.
+  const a = synthetic('kbpedia-rc-concept-AAAA'.repeat(64))
+  const b = synthetic('kbpedia-rc-concept-BBBB'.repeat(64))
+  assert.equal(a.gz.length, b.gz.length, 'fixture assumption: equal compressed length')
+  assert.notEqual(a.gzSha, b.gzSha)
+
+  // Pin to A, present B.
+  const v = verifyRcArtifact(b.gz, zlib.gunzipSync, a.gzSha)
+  assert.equal(v.ok, false)
+  assert.match(v.reason ?? '', /digest mismatch/)
+})
+
+test('NEGATIVE: a corrupt/undecompressable artifact is refused, not thrown past the caller', () => {
+  const junk = Buffer.from('this is not gzip at all', 'utf8')
+  const v = verifyRcArtifact(junk, zlib.gunzipSync, sha256(junk))
+  assert.equal(v.ok, false)
+  assert.match(v.reason ?? '', /failed to decompress/)
+})
+
+test('NEGATIVE: gz matches but the INFLATED content does not — the two pins disagreeing is caught', () => {
+  // The case the gz digest alone can never see, and the reason both digests exist: a re-gzip of
+  // altered source, or a digest table half-updated. Simulated by holding synthetic bytes to the
+  // VENDORED pin pair via a stub inflate that returns content the pinned N3 digest won't match.
+  const { gz } = synthetic('re-gzipped from altered source')
+  const v = verifyRcArtifact(gz, () => Buffer.from('altered RC corpus'), RC_GZ_SHA256)
+  assert.equal(v.ok, false)
+  assert.match(v.reason ?? '', /digest mismatch/)   // caught at step 1 here
+
+  // And with the gz check satisfied, the inflated comparison is what refuses:
+  const same = synthetic('x')
+  const v2 = verifyRcArtifact(same.gz, () => Buffer.from('not the RC corpus'), same.gzSha)
+  assert.equal(v2.overridden, true, 'a non-vendored digest is by definition an override')
+  assert.equal(v2.upstreamVerified, false, 'no upstream claim may be made for it')
+})
+
+test('an operator corpus is allowed ONLY with a stated digest, and never claims upstream provenance', () => {
+  const { gz, gzSha } = synthetic('an operator-supplied reference vocabulary')
+  const v = verifyRcArtifact(gz, zlib.gunzipSync, gzSha)
+  assert.equal(v.ok, true)
+  assert.equal(v.overridden, true)
+  assert.equal(v.upstreamVerified, false, 'we make no upstream claim about bytes we did not vendor')
+  assert.ok(v.n3, 'the verified payload is still returned so the caller never re-reads')
+  assert.equal(v.n3?.toString('utf8'), 'an operator-supplied reference vocabulary')
+})
+
+test('THE OVERRIDE HOLE: HELLGRAPH_RC_PATH with no digest is REFUSED, not silently trusted', () => {
+  const refused = expectedDigestFor(true, undefined)
+  assert.equal(refused.sha, undefined)
+  assert.match(refused.error ?? '', /HELLGRAPH_RC_SHA256 is missing/)
+  assert.match(refused.error ?? '', /changes ANSWERS rather than failing/)
+
+  // garbage digests are refused just as firmly as a missing one
+  for (const bad of ['', '   ', 'deadbeef', 'z'.repeat(64), RC_GZ_SHA256 + 'a']) {
+    assert.ok(expectedDigestFor(true, bad).error, `expected refusal for ${JSON.stringify(bad)}`)
+  }
+
+  // a well-formed digest is accepted, case-insensitively
+  const ok = expectedDigestFor(true, RC_GZ_SHA256.toUpperCase())
+  assert.equal(ok.error, undefined)
+  assert.equal(ok.sha, RC_GZ_SHA256)
+})
+
+test('with NO override, the vendored pin is what the artifact is held to', () => {
+  const e = expectedDigestFor(false, undefined)
+  assert.equal(e.error, undefined)
+  assert.equal(e.sha, RC_GZ_SHA256)
+  // an env digest cannot weaken the vendored pin — it is ignored unless the path is overridden
+  assert.equal(expectedDigestFor(false, 'a'.repeat(64)).sha, RC_GZ_SHA256)
+})
+
+test('POSITIVE: the real vendored artifact satisfies BOTH pinned digests', { skip: !haveRealArtifact }, () => {
+  const gz = fs.readFileSync(RC_GZ)
+  const v = verifyRcArtifact(gz, zlib.gunzipSync)
+  assert.equal(v.ok, true, v.reason)
+  assert.equal(v.gzSha256, RC_GZ_SHA256)
+  assert.equal(v.n3Sha256, RC_N3_SHA256)
+  assert.equal(v.overridden, false)
+  assert.equal(v.upstreamVerified, true)
+  assert.equal(v.n3?.length, RC_N3_BYTES, 'the verified payload is handed back for loading')
+})
+
+test('NEGATIVE on the REAL artifact: one flipped byte and it is refused', { skip: !haveRealArtifact }, () => {
+  const gz = Buffer.from(fs.readFileSync(RC_GZ))
+  gz[gz.length - 1] ^= 0xff                                  // corrupt the gzip trailer
+  const v = verifyRcArtifact(gz, zlib.gunzipSync)
+  assert.equal(v.ok, false)
+  assert.equal(gz.length, fs.statSync(RC_GZ).size, 'same size — only the content differs')
+  assert.match(v.reason ?? '', /digest mismatch/)
+})

--- a/apps/hellgraph-service/src/ontology-provenance.ts
+++ b/apps/hellgraph-service/src/ontology-provenance.ts
@@ -1,0 +1,157 @@
+/**
+ * Vendored-ontology integrity — the KBpedia reference-concept ABox.
+ *
+ * ── Why this is fail-CLOSED, unlike the seeds ────────────────────────────────────────
+ * The ~55k KBpedia reference concepts are not decoration and not a demo corpus: they are the
+ * TARGET VOCABULARY that `/api/graph/enrich` ranks coherence against and that the engine's
+ * semantic entity typing (`mapEntityToKkoSemantic`) resolves entities into. A drifted RC file
+ * therefore does not fail — it RESOLVES DIFFERENTLY. Every enrichment, every typing decision,
+ * every downstream receipt sealed over those answers inherits the drift, silently and durably,
+ * because the atoms are content-addressed and persist.
+ *
+ * That asymmetry is the whole design here. Elsewhere in this file's neighbourhood the rule is
+ * "never let a load error take the service down" (seedIfEmpty, loadKkoIfEnabled) and that is
+ * right: a missing seed corpus means an empty graph, which is visibly wrong. But "wrong
+ * vocabulary" is invisibly wrong, so the only honest options are LOAD THE DECLARED BYTES or
+ * LOAD NOTHING. Refusing keeps the service up with an empty RC set — a state
+ * `/healthz` and the enrich path already handle — instead of quietly poisoning answers.
+ *
+ * ── The chain this asserts (see ontology/PROVENANCE.md) ──────────────────────────────
+ *   SocioProphet/kbpedia @ 3f888b39  versions/2.10/kbpedia_reference_concepts.zip
+ *     -> kbpedia_reference_concepts.n3   sha256 0c23ca83…  (37,618,857 bytes)  CC-BY-4.0
+ *     -> re-gzipped into this image as   kbpedia-rc-2.10.n3.gz  sha256 e48d0ff7…
+ *
+ * BOTH digests are asserted, and they answer different questions. The gz digest proves the file
+ * shipped in the image is the vendored artifact (fast, catches a swapped file). The INFLATED
+ * digest proves those bytes are upstream's bytes — gzip is not reproducible across zlib
+ * versions and compression levels, so the gz digest alone can never demonstrate equivalence to
+ * anything published upstream. Only the inflated digest is portable provenance.
+ */
+import { createHash } from 'node:crypto'
+
+/** sha256 of the vendored `kbpedia-rc-2.10.n3.gz` as it ships in this repo/image. */
+export const RC_GZ_SHA256 = 'e48d0ff7708d647cb35b1bcbcca05a041c731e5a1bfcea296209a086b72da06a'
+
+/**
+ * sha256 of the INFLATED N3 — byte-identical to `kbpedia_reference_concepts.n3` inside
+ * `versions/2.10/kbpedia_reference_concepts.zip` in SocioProphet/kbpedia@3f888b39.
+ * Verified against upstream on 2026-07-29.
+ */
+export const RC_N3_SHA256 = '0c23ca83ac0e1270c4ea5335268b54a32577ba5d8cec0e33345f48e2ac60e95f'
+
+/** Inflated size in bytes — matches the zip's stated entry size exactly. */
+export const RC_N3_BYTES = 37_618_857
+
+export const RC_SOURCE =
+  'SocioProphet/kbpedia@3f888b397255b69d1439fd95823e97011ed9440b ' +
+  'versions/2.10/kbpedia_reference_concepts.zip -> kbpedia_reference_concepts.n3 (CC-BY-4.0)'
+
+export const RC_LICENSE = 'CC-BY-4.0 (c) Michael K. Bergman & Fred Giasson — KBpedia/Cognonto'
+
+export const sha256 = (b: Buffer | string): string => createHash('sha256').update(b).digest('hex')
+
+export interface RcVerification {
+  /** Did the artifact match everything it is required to match, and is it loadable? */
+  ok: boolean
+  /** Human-readable refusal, present only when `ok` is false. */
+  reason?: string
+  /** The digest of the compressed artifact actually on disk. */
+  gzSha256: string
+  /** The digest of the inflated N3, when inflation succeeded. */
+  n3Sha256?: string
+  /**
+   * The inflated payload, when verification passed. Returned so the caller loads THE BYTES THAT
+   * WERE VERIFIED rather than re-reading and re-inflating — a re-read is a second artifact, and
+   * a check that does not cover the bytes actually used is not a check.
+   */
+  n3?: Buffer
+  /** Which digest the gz was held to — the vendored pin, or an operator-supplied override. */
+  expectedGzSha256: string
+  /** True when the operator pointed the service at a non-vendored artifact. */
+  overridden: boolean
+  /**
+   * True only when the inflated bytes were matched against the pinned UPSTREAM digest. False for
+   * an operator corpus: we can confirm it is the file they named, but we make no claim that it
+   * is anything published by KBpedia, and a claim we cannot support must not be implied.
+   */
+  upstreamVerified: boolean
+}
+
+/**
+ * Verify a compressed RC artifact against its pinned digests, and return the verified payload.
+ *
+ * `expectedGzSha256` lets an operator run a DIFFERENT corpus (HELLGRAPH_RC_PATH) — but only by
+ * stating its digest up front (HELLGRAPH_RC_SHA256). There is deliberately no unverified path:
+ * a path override with no digest is the hole this closes, not a convenience to preserve.
+ *
+ * Three checks, and which of them apply depends on whether we vendored the bytes:
+ *   1. gz digest        — ALWAYS. Is this the file you named?
+ *   2. decompressable   — ALWAYS. An artifact that cannot be inflated is not loadable, whoever
+ *                         supplied it; reporting `ok` for it would push the failure into the
+ *                         caller's generic catch and reappear as a vague "skipped (error)".
+ *   3. inflated digest + byte count — VENDORED ONLY. This is the upstream-equivalence claim, and
+ *                         it is the only one that reaches SocioProphet/kbpedia.
+ */
+export function verifyRcArtifact(gz: Buffer, inflate: (b: Buffer) => Buffer,
+                                 expectedGzSha256: string = RC_GZ_SHA256): RcVerification {
+  const overridden = expectedGzSha256 !== RC_GZ_SHA256
+  const gzSha256 = sha256(gz)
+  const base = { gzSha256, expectedGzSha256, overridden, upstreamVerified: false }
+
+  if (gzSha256 !== expectedGzSha256) {
+    return {
+      ...base,
+      ok: false,
+      reason: `RC artifact digest mismatch: sha256 ${gzSha256} != expected ${expectedGzSha256}. ` +
+        (overridden
+          ? 'HELLGRAPH_RC_SHA256 does not describe the file at HELLGRAPH_RC_PATH.'
+          : `Re-vendor from ${RC_SOURCE} and update ontology/PROVENANCE.md.`),
+    }
+  }
+
+  let n3: Buffer
+  try {
+    n3 = inflate(gz)
+  } catch (e) {
+    return { ...base, ok: false, reason: `RC artifact failed to decompress: ${msg(e)}` }
+  }
+  const n3Sha256 = sha256(n3)
+
+  // An overridden corpus is held to the operator's digest only — we have no upstream claim to
+  // make about bytes we did not vendor, and inventing one would be worse than silence.
+  if (overridden) return { ...base, n3Sha256, n3, ok: true }
+
+  if (n3Sha256 !== RC_N3_SHA256) {
+    return {
+      ...base,
+      n3Sha256,
+      ok: false,
+      // Reaching here means the gz matched but its CONTENT did not — a re-gzip of altered
+      // source, or a digest table updated without re-verifying upstream.
+      reason: `RC inflated content mismatch: sha256 ${n3Sha256} != pinned ${RC_N3_SHA256} ` +
+        `(the compressed artifact matched, so the pinned digests disagree with each other — ` +
+        `re-verify against ${RC_SOURCE}).`,
+    }
+  }
+  if (n3.length !== RC_N3_BYTES) {
+    return { ...base, n3Sha256, ok: false, reason: `RC inflated size ${n3.length} != pinned ${RC_N3_BYTES}` }
+  }
+  return { ...base, n3Sha256, n3, ok: true, upstreamVerified: true }
+}
+
+/** Resolve the digest the artifact at `path` must match, given the env. */
+export function expectedDigestFor(pathOverridden: boolean,
+                                  envSha: string | undefined): { sha?: string; error?: string } {
+  if (!pathOverridden) return { sha: RC_GZ_SHA256 }
+  const sha = (envSha ?? '').trim().toLowerCase()
+  if (!/^[0-9a-f]{64}$/.test(sha)) {
+    return {
+      error: 'HELLGRAPH_RC_PATH is set but HELLGRAPH_RC_SHA256 is missing or not a 64-hex sha256. ' +
+        'A reference vocabulary loaded from an unverified path changes ANSWERS rather than failing, ' +
+        'so there is no unverified load path: state the digest of the corpus you are pointing at.',
+    }
+  }
+  return { sha }
+}
+
+const msg = (e: unknown): string => (e instanceof Error ? e.message : String(e))

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -51,6 +51,7 @@ import { initAuth, authorize, type AuthState } from './auth.js'
 import { assembleOrgans } from './organs.js'
 import { initMembrane, handleMembrane, membraneCheckNodeWrite, type MembraneState } from './membrane.js'
 import { sealToSpine, spineEnabled, unsealedReceipts } from './spine.js'
+import { verifyRcArtifact, expectedDigestFor, RC_SOURCE } from './ontology-provenance.js'
 
 const PORT = Number(process.env.PORT ?? 8090)
 
@@ -535,14 +536,42 @@ function loadKkoIfEnabled(): void {
 // Opt-in via HELLGRAPH_LOAD_RC=on: it adds ~55k nodes / ~75k edges to the persisted store (a real data
 // load, idempotent via content-addressed atoms). With RCs present, /api/graph/enrich auto-activates the
 // KKO coherence ranker and semantic entity typing has a target vocabulary.
+//
+// FAIL-CLOSED ON INTEGRITY (W12): the artifact's sha256 is asserted before a single concept reaches
+// the store — see src/ontology-provenance.ts and ontology/PROVENANCE.md for the provenance chain and
+// the reasoning. This is the one load path in this file that refuses rather than degrades, because
+// these concepts are the vocabulary enrich/typing RESOLVE AGAINST: a drifted copy does not fail, it
+// answers differently, and the answers persist as content-addressed atoms. Refusing leaves the
+// service up with an empty RC set (a state enrich already handles); loading unverified bytes would
+// poison every downstream answer invisibly.
 function loadRcIfEnabled(): void {
   if (process.env['HELLGRAPH_LOAD_RC'] !== 'on') return
   try {
-    const gzPath = process.env['HELLGRAPH_RC_PATH'] ||
-      path.join(__dirname, '..', 'ontology', 'kbpedia-rc-2.10.n3.gz')
+    const override = process.env['HELLGRAPH_RC_PATH']
+    const gzPath = override || path.join(__dirname, '..', 'ontology', 'kbpedia-rc-2.10.n3.gz')
     if (!fs.existsSync(gzPath)) { console.error(`[hellgraph-service] RC load skipped: ${gzPath} not found`); return }
+
+    // A path override must state the digest of what it points at — there is no unverified load.
+    const expected = expectedDigestFor(Boolean(override), process.env['HELLGRAPH_RC_SHA256'])
+    if (expected.error) {
+      console.error(`[hellgraph-service] RC load REFUSED: ${expected.error}`)
+      return
+    }
+
     const t0 = Date.now()
-    const text = zlib.gunzipSync(fs.readFileSync(gzPath)).toString('utf8')
+    const gz = fs.readFileSync(gzPath)
+    const v = verifyRcArtifact(gz, zlib.gunzipSync, expected.sha as string)
+    if (!v.ok) {
+      // Loud and specific: an integrity refusal must never read like a transient skip.
+      console.error(`[hellgraph-service] RC load REFUSED — vendored-artifact integrity check failed. ${v.reason}`)
+      return
+    }
+    console.log(`[hellgraph-service] RC artifact verified — gz sha256 ${v.gzSha256}` +
+      (v.upstreamVerified ? ` / inflated ${v.n3Sha256} == ${RC_SOURCE}`
+                          : ' (operator-supplied corpus; upstream equivalence NOT claimed)'))
+
+    // The VERIFIED buffer, not a re-read — loading bytes the check did not cover is not a check.
+    const text = (v.n3 as Buffer).toString('utf8')
     const stats = engine.loadReferenceConcepts(getHellGraph(), text)
     console.log(`[hellgraph-service] KBpedia RCs loaded — ${stats.concepts} concepts / ${stats.subClassOfEdges} subClassOf edges in ${((Date.now() - t0) / 1000).toFixed(1)}s (label 'KkoReferenceConcept')`)
   } catch (e) {

--- a/apps/owl-reasoner/src/owl_reasoner/data/PROVENANCE.md
+++ b/apps/owl-reasoner/src/owl_reasoner/data/PROVENANCE.md
@@ -1,15 +1,81 @@
 # KKO — KBpedia Knowledge Ontology (vendored into owl-reasoner)
 
-**File:** `kko-2.10.n3` · **SHA-256:** `d907919fb40f20ed39a7fde0e8d114027449d9354a1976ce8248db5634cb7b07`
-**KKO version:** v2.00 · **Namespace:** `http://kbpedia.org/ontologies/kko#`
+**File:** `kko-2.10.n3`
+**SHA-256:** `d907919fb40f20ed39a7fde0e8d114027449d9354a1976ce8248db5634cb7b07`
+**Bytes:** 327,797
+**KKO ontology version:** v2.00 (`owl:versionIRI <http://kbpedia.org/kbpedia/v200>`)
+**Namespace:** `http://kbpedia.org/ontologies/kko#`
+**Retrieved:** 2026-07-28 · **Provenance verified against upstream:** 2026-07-29
 
-Vendored as **package data** (under `src/`, so it ships in the image the Dockerfile builds from `COPY src`).
-It is the same byte-identical KKO TBox the HellGraph engine vendors (see
-`~/dev/hellgraph/ontology/kko/PROVENANCE.md`), loaded here by `reasoner.py::_kko_tbox()` so that
-`reason(..., with_kko=True)` computes RDFS/OWL-RL closure over the real KKO subClassOf hierarchy.
+## Source (sovereign, pinned)
+- **`SocioProphet/kbpedia`** @ commit `3f888b397255b69d1439fd95823e97011ed9440b`
+  (branch `master`), path `versions/2.10/kko-demo.n3`
+  (raw: `https://raw.githubusercontent.com/SocioProphet/kbpedia/3f888b397255b69d1439fd95823e97011ed9440b/versions/2.10/kko-demo.n3`)
+- Upstream of that fork: **`KBpedia/kbpedia`** (the org formerly known as Cognonto).
 
-**Source:** sovereign fork `SocioProphet/kbpedia` @ `master`, `versions/2.10/kko-demo.n3`
-(upstream `KBpedia/kbpedia`, formerly Cognonto).
+The engine's `PROVENANCE.md` cites `@ master`. A branch name is a MOVING reference, not a pin:
+re-running it later can retrieve different bytes and still claim the same provenance. The commit
+above is the pin (`master` has not moved since 2019-04-09, so the two resolve identically today —
+which is exactly why the difference is invisible until it isn't).
 
-**License:** CC-BY-4.0 — © Michael K. Bergman & Fred Giasson (Cognonto / KBpedia). Attribution preserved;
-content unmodified. <https://kbpedia.org> · <https://creativecommons.org/licenses/by/4.0/>
+## What it is
+The **KKO upper ontology** — the Peircean-grounded typology that types the KBpedia Knowledge
+Graph. This file carries the KKO TBox: **203 `owl:Class` declarations, 167 `rdfs:subClassOf`
+axioms** (168 classes in the `kko:` namespace after parsing). It does NOT include the ~55k
+reference-concept ABox — that is a separate artifact, vendored by hellgraph-service
+(`apps/hellgraph-service/ontology/PROVENANCE.md`).
+
+Vendored as **package data** (under `src/`, so it ships in the image the Dockerfile builds from
+`COPY src`, and in any wheel/sdist via `[tool.setuptools.package-data]`). Loaded by
+`reasoner.py::_kko_tbox()` so `reason(..., with_kko=True)` computes RDFS/OWL-RL closure over the
+real KKO subClassOf hierarchy.
+
+## Why a third copy, and not a reference to the engine's
+The estate holds three byte-identical copies of this TBox: the HellGraph engine's
+(`hellgraph ontology/kko/`), a checkout of it in `hellgraph-sprint`, and this one. Consuming the
+engine's copy instead was considered and REJECTED on three concrete grounds:
+
+1. **The engine does not ship it.** `@socioprophet/hellgraph`'s `package.json` publishes
+   `files: ["ts/dist", "bin"]`. The `.n3` is not in the tarball at any version. The engine ships
+   the ontology *pre-parsed* as `ts/src/kko-data.ts`, a TypeScript literal — not RDF.
+2. **No runtime to read it with.** owl-reasoner is `python:3.12-slim` + rdflib. Consuming the
+   engine's copy means either adding Node to a Python image to evaluate a `.ts` module, or
+   re-serialising a TS literal back into RDF — replacing a verified file with a lossy transform.
+3. **Docker build contexts are per-app.** `apps/owl-reasoner/Dockerfile` builds from
+   `apps/owl-reasoner`. A path into `apps/hellgraph-service` or into `node_modules` is not
+   reachable from that context without widening it to the monorepo root.
+
+So the copy stays — and the duplication is made SAFE rather than merely tolerated: every copy pins
+the same `KKO_SHA256`, and this one asserts it at import. Duplication that is digest-bound is a
+cache; duplication that is not is a fork waiting to happen.
+
+## Where the digest is ENFORCED
+`reasoner.py` computes the sha256 of these bytes **at import** (`verify_kko_integrity()`, the
+`KKO_INTEGRITY` module constant) and raises `RuntimeError` when the file is present but its
+digest is not the pinned one. Two failure modes, deliberately not alike:
+
+| condition | behaviour | why |
+|---|---|---|
+| file **absent** | degrade — empty TBox, `with_kko` becomes a visible no-op via `kko_tbox_status().unavailable_reason` | a packaging condition, honestly reported; reasoning still serves |
+| file **present, digest differs** | `RuntimeError` at import — the service does not start | a drifted ontology does not fail, it returns DIFFERENT ENTAILMENTS; there is no honest degraded mode for "wrong axioms" |
+
+Proven by `tests/test_provenance.py`, which tampers with a *copy* of the package and asserts the
+import actually dies (`test_tampered_kko_tbox_kills_import_in_a_real_process`) — not merely that
+the recorded digest matches the file, which proves nothing about enforcement.
+
+When the TBox is loaded, `kko_tbox_status()` returns `sha256` and `source` alongside the triple
+count, so a caller can bind an entailment set to the exact ontology bytes that produced it.
+
+## License / attribution
+KBpedia and the KKO are released under **CC-BY-4.0**.
+© Michael K. Bergman and Fred Giasson (Cognonto Corporation / KBpedia).
+Attribution required; see <https://kbpedia.org> and <https://creativecommons.org/licenses/by/4.0/>.
+This vendored copy preserves that attribution and does not modify the ontology content.
+
+## Re-vendoring
+1. Copy the new `.n3` from the pinned `SocioProphet/kbpedia` path over `data/kko-2.10.n3`.
+2. `shasum -a 256 data/kko-2.10.n3` → update `KKO_SHA256` in `reasoner.py` **and** the header
+   above **and** the engine's `ontology/kko/PROVENANCE.md`. The constant is shared across copies
+   on purpose; moving one without the others is the drift this gate exists to catch.
+3. Re-run the engine's `scripts/gen-kko.mjs` so `ts/src/kko-data.ts` matches the new source.
+4. `PYTHONPATH=src pytest -q tests` — the integrity tests must pass on the new digest.

--- a/apps/owl-reasoner/src/owl_reasoner/reasoner.py
+++ b/apps/owl-reasoner/src/owl_reasoner/reasoner.py
@@ -7,9 +7,22 @@ validates against SHACL shapes. That is Protégé/Stardog-class reasoning, made 
 entailed triple is a derivation over stated facts + the KKO upper ontology, not an assertion.
 
 Pure (no HTTP) so it is trivially testable; the service wrapper + graph pull live in server.py.
+
+VENDORED KKO TBox — provenance and integrity (see data/PROVENANCE.md):
+    repo    SocioProphet/kbpedia @ 3f888b397255b69d1439fd95823e97011ed9440b (fork of KBpedia/kbpedia)
+    path    versions/2.10/kko-demo.n3
+    sha256  d907919fb40f20ed39a7fde0e8d114027449d9354a1976ce8248db5634cb7b07  (327,797 bytes)
+    licence CC-BY-4.0 — (c) Michael K. Bergman & Fred Giasson (Cognonto / KBpedia)
+The sha256 is ASSERTED AT IMPORT (nugget-extractor contract.py precedent). This copy is the
+THIRD in the estate — the HellGraph engine vendors the same bytes at ontology/kko/kko-2.10.n3,
+and hellgraph-sprint carries a checkout of it — so "byte-identical" was previously true only by
+luck. KKO_SHA256 is the shared constant that makes it true BY ASSERTION: all copies pin the same
+digest, so a drift in any one of them is caught where it is loaded rather than discovered as a
+changed answer. A drifted TBox does not fail — it silently reclassifies, which is worse.
 """
 from __future__ import annotations
 
+import hashlib
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -36,16 +49,72 @@ _PROFILE_ALIASES = {"owl2rl": "owlrl", "owl2-rl": "owlrl", "owl": "owlrl"}
 # The KKO upper ontology (KBpedia Knowledge Ontology), vendored as package data so it ships in the image.
 _KKO_PATH = Path(__file__).resolve().parent / "data" / "kko-2.10.n3"
 
+# The pinned digest of the vendored TBox. Shared, byte-for-byte, with the HellGraph engine's copy
+# (hellgraph ontology/kko/PROVENANCE.md) — that is the whole point: one constant, three copies.
+KKO_SHA256 = "d907919fb40f20ed39a7fde0e8d114027449d9354a1976ce8248db5634cb7b07"
+KKO_SOURCE = ("SocioProphet/kbpedia@3f888b397255b69d1439fd95823e97011ed9440b"
+              " versions/2.10/kko-demo.n3 (CC-BY-4.0)")
+
+
+def kko_file_digest(path: Path | None = None) -> str | None:
+    """sha256 of a vendored KKO TBox file, or None when the file is absent.
+
+    Separated from the import-time assertion so the integrity rule is exercisable against an
+    arbitrary path in tests — the gate itself stays at import, where it cannot be skipped.
+    """
+    p = _KKO_PATH if path is None else path
+    try:
+        return hashlib.sha256(p.read_bytes()).hexdigest()
+    except FileNotFoundError:
+        return None
+
+
+def verify_kko_integrity(path: Path | None = None) -> str:
+    """Fail-closed integrity gate for the vendored TBox. Returns 'verified' or 'absent'.
+
+    Raises RuntimeError when the file is PRESENT but its bytes are not the pinned ones. The two
+    failure modes are deliberately NOT treated alike:
+
+      absent   — a packaging condition this module has always degraded on (pyproject's
+                 package-data rule exists precisely because an absent TBox once made `with_kko`
+                 a silent no-op). It stays a degradation, and stays VISIBLE via
+                 kko_tbox_status()'s unavailable_reason.
+      drifted  — a supply-chain event. Reasoning over an ontology that is not the one we
+                 declare does not fail, it returns DIFFERENT ENTAILMENTS, and every downstream
+                 consumer of those entailments inherits the drift silently. There is no honest
+                 degraded mode for "wrong axioms", so this is loud and terminal at import.
+    """
+    actual = kko_file_digest(path)
+    if actual is None:
+        return "absent"
+    if actual != KKO_SHA256:
+        p = _KKO_PATH if path is None else path
+        raise RuntimeError(
+            f"vendored KKO TBox drifted: sha256 {actual} != pinned {KKO_SHA256} ({p}); "
+            f"re-vendor from {KKO_SOURCE} and update data/PROVENANCE.md. Refusing to reason "
+            "over an ontology that is not the one this service declares.")
+    return "verified"
+
+
+# THE GATE. Asserted at import, not merely recorded in PROVENANCE.md — a provenance file that
+# nothing verifies is decoration.
+KKO_INTEGRITY = verify_kko_integrity()
+
 
 @lru_cache(maxsize=1)
 def _kko_tbox() -> Graph:
     """The KKO TBox (168 classes / 167 rdfs:subClassOf), parsed once and cached. Returns an empty graph
-    if the vendored file is missing, so ``with_kko`` degrades to a no-op rather than failing."""
+    if the vendored file is missing, so ``with_kko`` degrades to a no-op rather than failing.
+
+    The bytes are already digest-verified at import (KKO_INTEGRITY), so anything parsed here is
+    provably the declared ontology; only the absent case can reach the empty-graph path."""
     g = Graph()
+    if KKO_INTEGRITY != "verified":  # pragma: no cover — absent package data
+        return g
     try:
         # the .n3 is Turtle-compatible; parse as turtle to avoid rdflib's noisy N3-parser deprecations.
         g.parse(_KKO_PATH.as_posix(), format="turtle")
-    except Exception:  # pragma: no cover — missing/parse issue must never take reasoning down
+    except Exception:  # pragma: no cover — a parse issue must never take reasoning down
         pass
     return g
 
@@ -58,13 +127,19 @@ def kko_tbox_status(requested: bool, triples: int) -> dict[str, Any]:
     degradation has to be visible in the response, or `with_kko=true` reports success on a
     deployment where the ontology contributed nothing. `unavailable_reason` is present only
     when the two disagree, so a client never has to infer the difference from a zero.
+
+    When the TBox IS loaded the response also carries the digest it was loaded under, so a
+    caller can bind an entailment set to the exact ontology bytes that produced it.
     """
     loaded = requested and triples > 0
     status: dict[str, Any] = {"requested": requested, "loaded": loaded, "triples": triples}
+    if loaded:
+        status["sha256"] = KKO_SHA256
+        status["source"] = KKO_SOURCE
     if requested and not loaded:
         status["unavailable_reason"] = (
-            f"KKO TBox requested but no triples were parsed from {_KKO_PATH.name}; "
-            "with_kko had no effect on this result"
+            f"KKO TBox requested but no triples were parsed from {_KKO_PATH.name} "
+            f"(vendored-artifact integrity: {KKO_INTEGRITY}); with_kko had no effect on this result"
         )
     return status
 

--- a/apps/owl-reasoner/tests/test_provenance.py
+++ b/apps/owl-reasoner/tests/test_provenance.py
@@ -1,0 +1,137 @@
+"""Vendored-artifact integrity for the KKO TBox — the ASSERTION, not the record.
+
+The estate's recurring failure is a correct artifact with no connection to anything that checks
+it: a PROVENANCE.md nothing verifies is decoration. So the load-bearing test here is not
+"the recorded digest matches the file" (that only proves the two were written by the same hand);
+it is "a TAMPERED file actually stops the service", proven by tampering with a real copy of the
+package and watching a real interpreter refuse to import it.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from owl_reasoner import reasoner
+
+SRC_ROOT = Path(reasoner.__file__).resolve().parents[1]     # .../src
+PKG_ROOT = SRC_ROOT / "owl_reasoner"
+
+
+def _reparent(blob: bytes) -> bytes:
+    """The realistic tamper: silently re-parent a class in the Peircean typology.
+
+    `:Monads` -> `:Places` are both real KKO superclasses of the same byte length, so the result
+    is still valid Turtle, still parses without complaint, and is still exactly 327,797 bytes —
+    it defeats a size check and a parse check. What it changes is the ENTAILMENTS. This is the
+    precise failure this gate exists for: an artifact that does not fail, it answers differently.
+    """
+    out = blob.replace(b"rdfs:subClassOf :Monads", b"rdfs:subClassOf :Places", 1)
+    assert out != blob, "tamper fixture is stale — the anchor string is no longer in the TBox"
+    return out
+
+
+def test_vendored_kko_matches_the_pinned_sha256():
+    """The recorded digest IS the file's digest. Necessary, nowhere near sufficient."""
+    blob = (PKG_ROOT / "data" / "kko-2.10.n3").read_bytes()
+    assert hashlib.sha256(blob).hexdigest() == reasoner.KKO_SHA256
+    assert len(blob) == 327_797
+
+
+def test_pinned_digest_is_asserted_at_import_not_merely_recorded():
+    """Import already ran the gate — KKO_INTEGRITY is its verdict, not a lazy flag."""
+    assert reasoner.KKO_INTEGRITY == "verified"
+
+
+def test_provenance_md_records_the_same_digest_as_the_code():
+    """The doc and the constant cannot drift apart silently."""
+    doc = (PKG_ROOT / "data" / "PROVENANCE.md").read_text()
+    assert reasoner.KKO_SHA256 in doc
+    assert "CC-BY-4.0" in doc                                    # licence recorded
+    assert "3f888b397255b69d1439fd95823e97011ed9440b" in doc     # pinned, not a branch name
+
+
+def test_verify_kko_integrity_rejects_a_tampered_file(tmp_path: Path):
+    """NEGATIVE: one flipped byte and the gate refuses, naming both digests."""
+    good = (PKG_ROOT / "data" / "kko-2.10.n3").read_bytes()
+    tampered = tmp_path / "kko-2.10.n3"
+    tampered.write_bytes(_reparent(good))
+    assert tampered.read_bytes() != good
+    assert len(tampered.read_bytes()) == len(good), "the tamper must defeat a size check too"
+
+    with pytest.raises(RuntimeError) as exc:
+        reasoner.verify_kko_integrity(tampered)
+    msg = str(exc.value)
+    assert "drifted" in msg and reasoner.KKO_SHA256 in msg
+    assert "SocioProphet/kbpedia" in msg     # the error tells you where to re-vendor from
+
+
+def test_verify_kko_integrity_degrades_on_an_absent_file(tmp_path: Path):
+    """Absent is NOT drifted: a packaging gap degrades honestly, it does not raise."""
+    assert reasoner.verify_kko_integrity(tmp_path / "nope.n3") == "absent"
+    assert reasoner.kko_file_digest(tmp_path / "nope.n3") is None
+
+
+def test_kko_tbox_status_binds_entailments_to_the_ontology_digest():
+    """A loaded TBox reports WHICH bytes produced the closure."""
+    status = reasoner.kko_tbox_status(requested=True, triples=1234)
+    assert status["loaded"] is True
+    assert status["sha256"] == reasoner.KKO_SHA256
+    assert "SocioProphet/kbpedia" in status["source"]
+
+    degraded = reasoner.kko_tbox_status(requested=True, triples=0)
+    assert degraded["loaded"] is False and "unavailable_reason" in degraded
+    assert "sha256" not in degraded          # never claim a digest for a TBox that wasn't used
+
+
+def test_with_kko_actually_loads_the_verified_tbox():
+    """End-to-end: the verified bytes are the ones reasoning runs over."""
+    ttl = ('@prefix kko: <http://kbpedia.org/ontologies/kko#> .\n'
+           '@prefix ex: <http://ex/> .\nex:a a kko:Monads .')
+    out = reasoner.reason(ttl, inference="rdfs", with_kko=True)
+    assert out["kko_tbox"]["loaded"] is True
+    assert out["kko_tbox"]["triples"] > 1000
+    assert out["kko_tbox"]["sha256"] == reasoner.KKO_SHA256
+
+
+def test_tampered_kko_tbox_kills_import_in_a_real_process(tmp_path: Path):
+    """THE test. A drifted TBox must stop the service, not quietly change its answers.
+
+    Copies the package, tampers the vendored .n3, and imports it in a FRESH interpreter. If the
+    gate were only a recorded digest (or a function nobody calls), this import would succeed and
+    the process would go on reasoning over an ontology it did not declare.
+    """
+    fake_src = tmp_path / "src"
+    shutil.copytree(SRC_ROOT, fake_src, ignore=shutil.ignore_patterns("__pycache__", "*.egg-info"))
+    n3 = fake_src / "owl_reasoner" / "data" / "kko-2.10.n3"
+    n3.write_bytes(_reparent(n3.read_bytes()))
+
+    proc = subprocess.run(
+        [sys.executable, "-c", "import owl_reasoner.reasoner"],
+        cwd=fake_src, capture_output=True, text=True, timeout=120,
+        env={**os.environ, "PYTHONPATH": str(fake_src)},
+    )
+    assert proc.returncode != 0, (
+        "a TAMPERED KKO TBox imported cleanly — the digest is recorded but NOT enforced.\n"
+        f"stdout={proc.stdout}\nstderr={proc.stderr}")
+    assert "RuntimeError" in proc.stderr
+    assert "vendored KKO TBox drifted" in proc.stderr
+
+
+def test_untampered_copy_still_imports(tmp_path: Path):
+    """Control for the test above: the same procedure with UNMODIFIED bytes must succeed, so a
+    green negative result cannot be an artefact of the copy/subprocess machinery."""
+    fake_src = tmp_path / "src"
+    shutil.copytree(SRC_ROOT, fake_src, ignore=shutil.ignore_patterns("__pycache__", "*.egg-info"))
+    proc = subprocess.run(
+        [sys.executable, "-c", "import owl_reasoner.reasoner as r; print(r.KKO_INTEGRITY)"],
+        cwd=fake_src, capture_output=True, text=True, timeout=120,
+        env={**os.environ, "PYTHONPATH": str(fake_src)},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "verified" in proc.stdout

--- a/apps/owl-reasoner/tests/test_reasoner.py
+++ b/apps/owl-reasoner/tests/test_reasoner.py
@@ -242,10 +242,15 @@ def test_virtualize_400_without_subject_template():
 
 
 def test_kko_status_separates_requested_from_loaded():
-    from owl_reasoner.reasoner import kko_tbox_status
+    from owl_reasoner.reasoner import KKO_SHA256, kko_tbox_status
 
     assert kko_tbox_status(False, 0) == {"requested": False, "loaded": False, "triples": 0}
-    assert kko_tbox_status(True, 335) == {"requested": True, "loaded": True, "triples": 335}
+    # A LOADED TBox additionally carries the digest + source of the bytes the closure ran over,
+    # so an entailment set can be bound to the exact ontology that produced it (W12 provenance).
+    loaded = kko_tbox_status(True, 335)
+    assert {k: loaded[k] for k in ("requested", "loaded", "triples")} == {
+        "requested": True, "loaded": True, "triples": 335}
+    assert loaded["sha256"] == KKO_SHA256 and "SocioProphet/kbpedia" in loaded["source"]
 
 
 def test_kko_status_refuses_to_claim_loaded_with_no_triples():


### PR DESCRIPTION
Closes three of the four W12 inventory-hygiene findings from the vendor-freshness inventory (sociosphere PR #492). The fourth is report-only and answered at the bottom.

Every artifact here was **correct**, and connected to **nothing that checked it**. That is the estate's recurring failure, so the bar for this PR was not "write a PROVENANCE.md" — it was "the digest is asserted where the artifact is loaded, and a tampered artifact provably fails".

> **Scope note:** nothing in `sociosphere` was touched. `registry/vendor-freshness.yaml` and `tools/validate_vendor_freshness.py` belong to the `feat/vendor-freshness-detector` lane; two register-side items for that lane are listed at the end.

---

## 1 — owl-reasoner: the THIRD copy of the KKO 2.10 TBox

**Decision: keep the copy, make the duplication safe.** Consuming the engine's copy was considered and rejected on three checkable grounds (argued in full in `data/PROVENANCE.md`):

1. **The engine has never shipped it.** `@socioprophet/hellgraph` publishes `files: ["ts/dist", "bin"]`. The `.n3` is not in the tarball at any version — the engine ships the ontology *pre-parsed* as `ts/src/kko-data.ts`, a TypeScript literal, not RDF.
2. **No runtime to read it with.** owl-reasoner is `python:3.12-slim` + rdflib. Consuming the engine's copy means adding Node to a Python image to evaluate a `.ts` module, or re-serialising a TS literal back into RDF — replacing a verified file with a lossy transform.
3. **Docker build contexts are per-app.** `apps/owl-reasoner/Dockerfile` builds from `apps/owl-reasoner`; `apps/hellgraph-service` and `node_modules` are unreachable without widening the context to the monorepo root.

So the duplication stays and becomes **safe rather than merely tolerated**: every copy pins the same `KKO_SHA256`, and this one asserts it at import. Byte-identical *by assertion* instead of *by luck*.

Two failure modes, deliberately not alike:

| condition | behaviour | why |
|---|---|---|
| file **absent** | degrade — `with_kko` becomes a visible no-op via `kko_tbox_status().unavailable_reason` | a packaging condition this module already handled honestly |
| file present, **digest differs** | `RuntimeError` at import — the service does not start | a drifted ontology does not fail, it returns *different entailments*; there is no honest degraded mode for "wrong axioms" |

`kko_tbox_status()` now also returns the `sha256` + `source` of a **loaded** TBox (never of an unloaded one), so an entailment set can be bound to the exact ontology bytes that produced it.

## 2 — hellgraph-service: the KBpedia RC ABox had NO provenance of any kind

Provenance **established and byte-verified**, not asserted from the commit message:

```
SocioProphet/kbpedia@3f888b397255b69d1439fd95823e97011ed9440b
  versions/2.10/kbpedia_reference_concepts.zip   (8,982,294 B)
    -> kbpedia_reference_concepts.n3   sha256 0c23ca83…   37,618,857 B   CC-BY-4.0
    -> re-gzipped here as kbpedia-rc-2.10.n3.gz   sha256 e48d0ff7…
```

I downloaded the upstream zip and compared: our vendored `.gz` inflates to **exactly** those bytes. The RDF is unmodified — only the compression container changed (zip → gzip) so the image needs no unzip tooling.

**Both digests are pinned, and they answer different questions.** The gz digest proves the file in the image is the vendored artifact. The **inflated** digest proves those bytes are upstream's — gzip is not reproducible across zlib versions/levels, so the gz digest alone can *never* demonstrate equivalence to anything published upstream.

Enforced in **two** places, because either alone leaves a gap:

| where | on failure |
|---|---|
| runtime — `loadRcIfEnabled()` via `src/ontology-provenance.ts` | **refuses to load**; service stays up with an empty RC set |
| CI — `scripts/check-ontology-digest.mjs`, run by `make engine-guards` (a `validate-target-diagnostics` matrix target) | **fails the build** |

CI catches a bad artifact before it ships; the runtime check catches a swapped file inside a running image, which CI cannot see.

This is the one load path in `server.ts` that **refuses rather than degrades**, and deliberately so: these ~55k concepts are the vocabulary `/api/graph/enrich` coherence-ranks against and semantic typing resolves into. A drifted copy does not fail — it *answers differently*, and the answers persist as content-addressed atoms.

**Override hole closed.** `HELLGRAPH_RC_PATH` previously accepted any file, unverified. It now **requires** `HELLGRAPH_RC_SHA256`; without it the load is refused. An operator corpus is held to the operator's own digest and the log states explicitly that upstream equivalence is **not** claimed for it — no provenance assertion is made about bytes we did not vendor. (`HELLGRAPH_RC_PATH` is not set in `deploy/values/hellgraph-service.yaml`, so prod is unaffected.)

The loader now consumes the **verified buffer** instead of re-reading and re-inflating — a check that does not cover the bytes actually used is not a check.

## 3 — compute-gateway: six schemas "vendored" with no source repo named

**The origin was establishable, and is established — not invented.**

`zerotrust.py`'s docstring did name `SocioProphet/mcp-a2a-zero-trust` pinned `0399e8a`, but nothing recorded which upstream file each schema came from, nothing recorded a digest, and nothing verified any of it. I confirmed the repo exists (public), the commit resolves (`0399e8ae84f0be8194ce57e56b14ba4bbb807f47`, 2026-05-21), and fetched all six files from it:

**All six are byte-identical to the pinned commit.** Repeated against the kernel's `main` (`93c4b831`): **also byte-identical** — the pin is not merely recorded, it is still current, so this vendoring carries **no freshness debt** today.

Recorded with **per-file upstream paths** (upstream splits `mcp/registry/`, `schemas/canonical/`, `schemas/interop/`; the vendored copies are flattened into one directory) and per-file sha256, asserted at import.

The **file set** is pinned too, which is the subtle half: `_registry()` globs this directory and registers every document by `$id`, so an unvendored file could satisfy a canonical `$ref` and quietly become the contract. An extra `*.schema.json` is now refused. Vendoring is a closed set or it is not vendoring.

Also fixed: the docstring named the vendored path as `apps/compute-gateway/schemas/`, which **does not exist** (real path `src/compute_gateway/schemas/`). A provenance note pointing at the wrong directory is how "vendored from nowhere identifiable" starts.

### What I could NOT establish, stated rather than guessed
`SocioProphet/mcp-a2a-zero-trust` declares **no licence** — no `LICENSE` file at the pinned commit, and GitHub reports no detected licence. It is a first-party SocioProphet repo, so no third-party obligation attaches, but I have recorded the absence as an observed fact rather than resolving it by assumption. An unlicensed public repo is "all rights reserved" by default, which is probably not the intent for a contract others are meant to conform to — **flagged for the kernel repo's owning lane**, not guessed at here.

---

## Test evidence

Every gate is proven by **tampering**, and each tamper proof was itself **mutation-tested** — I removed the gate and confirmed the test fails, so none of these are vacuous.

| suite | result |
|---|---|
| `owl-reasoner` | **35 passed** |
| `compute-gateway` | **151 passed** (135 before + 16 new) |
| `hellgraph-service` | **94 passed**, `tsc --noEmit` clean |
| `python3 tools/preflight_deploy_contract.py` | **exit 0** |
| `make engine-guards` | **exit 0** |

Tampers that are refused (not merely "digests match"):

- **owl-reasoner** — `:Monads` → `:Places`, a length-preserving re-parent of a real class in the Peircean typology. Still valid Turtle, still parses, still exactly 327,797 bytes: it defeats both a size check and a parse check, and changes only the *entailments*. Import dies in a real subprocess. A control test proves an untampered copy of the same package still imports.
- **compute-gateway** — three separate subprocess proofs: **drifted** (a `required` key dropped — the realistic weakening, not corruption), **missing**, and **unpinned** (a rogue schema whose `$id` shadows `grant.schema.json` and permits anything).
- **hellgraph-service** — byte-flip on the real 8.5MB artifact (same size, refused), a legitimate-looking **re-gzip** of identical content (refused — the artifact is the file, not just the content), an undecompressable artifact, and a length-preserving swap.

Mutation-test results (gate removed → test fails, as it must):
```
owl-reasoner     : FAILED test_tampered_kko_tbox_kills_import_in_a_real_process
compute-gateway  : FAILED test_tampered_schemas_kill_import…[drifted|missing|unpinned]
```

## Where digests are ENFORCED vs merely recorded

| artifact | recorded | **enforced** |
|---|---|---|
| KKO TBox (owl-reasoner) | `data/PROVENANCE.md` | **import** — `verify_kko_integrity()` / `KKO_INTEGRITY` |
| KBpedia RC ABox | `ontology/PROVENANCE.md` | **load** — `loadRcIfEnabled()` **and CI** — `make engine-guards` |
| 6 zero-trust schemas | `schemas/PROVENANCE.md` | **import** — `verify_vendored_schemas()` / `SCHEMA_DIGESTS` |

Nothing in this PR is recorded-only. Each `PROVENANCE.md` is also asserted *against the code's constants* by a test, so doc and code cannot drift apart.

---

## Finding 4 (report-only): `SocioProphet/kbpedia` is absent from the sociosphere workspace manifest

Verified — **the repo exists**, and it matters more than its absence suggests:

- `SocioProphet/kbpedia` — **public**, a **fork of `KBpedia/kbpedia`**, default branch `master`, ~78.7 MB, not archived.
- Last pushed **2019-04-09** — never modified since forking, i.e. a pristine mirror. (This is why `@ master` and the commit pin resolve identically today, and why the distinction is invisible until someone pushes.)
- Contents: `README.org`, `imgs/`, `versions/{1.60, 2.00, 2.10}`. `versions/2.10/` holds `kko.n3`, `kko-demo.n3`, `kbpedia_reference_concepts.zip` (+ linkage variants), `linkages/*.csv`, `typologies/*.n3`.
- **No `LICENSE` file**; CC-BY-4.0 is KBpedia's published licence for 2.10 and is recorded as the governing terms in each consuming `PROVENANCE.md`.

**Why the manifest gap is load-bearing:** this single repo is the origin of **both** the KKO TBox (findings 1) **and** the RC ABox (finding 2) — two of the four W12 findings trace back to a repo the workspace manifest does not know exists. A freshness plane that cannot see it cannot reason about staleness in either artifact.

### For the `feat/vendor-freshness-detector` lane (register edits I deliberately did not make)
1. **Add `SocioProphet/kbpedia` to the workspace manifest** — pin `3f888b397255b69d1439fd95823e97011ed9440b`. It is a frozen upstream mirror, so it wants a low/never poll cadence rather than the default.
2. **Register the three artifacts with the digests this PR pins**, so the freshness plane checks the same constants the runtime does:
   - `kko-2.10.n3` → `d907919fb40f20ed39a7fde0e8d114027449d9354a1976ce8248db5634cb7b07`
   - `kbpedia-rc-2.10.n3.gz` → `e48d0ff7708d647cb35b1bcbcca05a041c731e5a1bfcea296209a086b72da06a` (inflated `0c23ca83…`)
   - `mcp-a2a-zero-trust` schemas → pin `0399e8ae…`, six per-file digests in `schemas/PROVENANCE.md`

A companion PR on `SocioProphet/hellgraph` (`chore/w12-kko-digest-gate`) closes the same hole on the engine's copy — its `PROVENANCE.md` recorded a sha256 that **nothing verified**, and cited `@ master` rather than a commit.

**Do not merge** — opened for review.
