### PR TITLE
feat(cockpit): W11.4 annotation overlay, W11.5 nugget feed, W11.6 expertise-adaptive depth

### DIFF
--- a/apps/socioprophet-web/src/__tests__/annotationOverlay.test.ts
+++ b/apps/socioprophet-web/src/__tests__/annotationOverlay.test.ts
@@ -1,0 +1,183 @@
+/**
+ * W11.4 — the annotation overlay. Ambiguity is data, not noise.
+ *
+ * The contract under test is that NOTHING the compiler saw gets silently deleted:
+ *   1. every competing concept for a span survives to the model;
+ *   2. "used" comes from the PLAN, never from confidence rank — which is the only way the
+ *      override case (plan took the lower-confidence reading) can be detected at all;
+ *   3. a span consumed only by a BINDING still counts as consumed, because the engine's own
+ *      coverage arithmetic counts it;
+ *   4. overlapping spans are surfaced, not dropped;
+ *   5. depth may fold competitors away, but must say how many it folded.
+ */
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import AnnotationOverlay from '../components/warrant/AnnotationOverlay.vue';
+import { buildAnnotationOverlay, conceptLabel } from '../features/warrant/annotations';
+import { FIXTURE_COMPILATION, FIXTURE_QUESTION } from '../data/warrantFixture';
+
+const V1 = FIXTURE_COMPILATION.variants[0]!;
+const V2 = FIXTURE_COMPILATION.variants[1]!;
+const ANN = FIXTURE_COMPILATION.annotations;
+
+const build = (v = V1) => buildAnnotationOverlay(FIXTURE_QUESTION, ANN, v.provenance, v.plan);
+const spanAt = (start: number, o = build()) => o.spans.find((s) => s.span.start === start)!;
+
+describe('annotation overlay — the model', () => {
+  it('keeps every competing concept for a span', () => {
+    const delayed = spanAt(34);
+    expect(delayed.candidates.map((c) => c.conceptRef).sort()).toEqual([
+      'urn:srcos:concept:DelayedStatus',
+      'urn:srcos:concept:LateShipment',
+    ]);
+    expect(delayed.ambiguous).toBe(true);
+  });
+
+  it('reads "used" from the plan, NOT from confidence order', () => {
+    const delayed = spanAt(34);
+    // LateShipment scores higher (0.91 vs 0.88) but the plan bound DelayedStatus.
+    expect(delayed.topConfidenceConceptRef).toBe('urn:srcos:concept:LateShipment');
+    expect(delayed.usedConceptRef).toBe('urn:srcos:concept:DelayedStatus');
+    expect(delayed.overrodeTopConfidence).toBe(true);
+
+    const used = delayed.candidates.find((c) => c.used)!;
+    const lost = delayed.candidates.find((c) => !c.used)!;
+    expect(used.conceptRef).toBe('urn:srcos:concept:DelayedStatus');
+    expect(lost.confidence).toBeGreaterThan(used.confidence);
+  });
+
+  it('does not flag an override when the plan took the top candidate', () => {
+    const suppliers = spanAt(9);
+    expect(suppliers.ambiguous).toBe(true);
+    expect(suppliers.usedConceptRef).toBe('urn:srcos:type:Supplier');
+    expect(suppliers.topConfidenceConceptRef).toBe('urn:srcos:type:Supplier');
+    expect(suppliers.overrodeTopConfidence).toBe(false);
+  });
+
+  it('counts a span consumed only by a BINDING as consumed', () => {
+    // "Germany" fills the `region` input; it never appears in node-level provenance.
+    const inProvenance = V1.provenance.some((p) => p.tokenSpan?.start === 22);
+    expect(inProvenance).toBe(false);
+
+    const germany = spanAt(22);
+    expect(germany.consumed).toBe(true);
+    expect(germany.usedConceptRef).toBe('urn:srcos:concept:Germany');
+    const via = germany.candidates.find((c) => c.used)!.usedBy[0]!;
+    expect(via.via).toBe('binding');
+    expect(via.input).toBe('region');
+  });
+
+  it('agrees with the engine: consumed spans reconcile with the variant coverage', () => {
+    // V1 reports 5/5 content tokens consumed, so no CONTENT span may read as unconsumed.
+    expect(V1.senseMetric.consumedContentTokens).toBe(5);
+    const o = build();
+    const unconsumedContent = o.spans
+      .filter((s) => !s.consumed)
+      // "many" is a sub-span of the already-consumed "how many"; its tokens are covered.
+      .filter((s) => s.span.text !== 'many');
+    expect(unconsumedContent).toEqual([]);
+  });
+
+  it('reports an unconsumed span when the selected variant ignores it', () => {
+    // V2 never consumes "delayed" — that is exactly why it lost on coverage.
+    const o = build(V2);
+    const delayed = o.spans.find((s) => s.span.start === 34)!;
+    expect(delayed.consumed).toBe(false);
+    expect(delayed.usedConceptRef).toBeNull();
+    // An unconsumed span cannot have "overridden" anything.
+    expect(delayed.overrodeTopConfidence).toBe(false);
+  });
+
+  it('keeps overlapping spans instead of dropping them', () => {
+    const o = build();
+    expect(o.overlapped.map((s) => s.span.text)).toEqual(['many']);
+    // …and it is still counted in the totals, not quietly excluded.
+    expect(o.spans.some((s) => s.span.text === 'many')).toBe(true);
+    expect(o.unconsumedCount).toBe(1);
+  });
+
+  it('lays the question out losslessly', () => {
+    const o = build();
+    expect(o.segments.map((s) => s.text).join('')).toBe(FIXTURE_QUESTION);
+    for (const s of o.segments) expect(FIXTURE_QUESTION.slice(s.start, s.end)).toBe(s.text);
+  });
+
+  it('summarizes the ambiguity', () => {
+    const o = build();
+    expect(o.spans.length).toBe(5);
+    expect(o.ambiguousCount).toBe(3); // suppliers, Germany, delayed
+    expect(o.overriddenCount).toBe(1); // delayed
+  });
+
+  it('shortens concept URNs to their readable tail', () => {
+    expect(conceptLabel('urn:srcos:concept:DelayedStatus')).toBe('DelayedStatus');
+    expect(conceptLabel('http://kbpedia.org/ontologies/kko#Quantity')).toBe('Quantity');
+  });
+});
+
+describe('annotation overlay — the surface', () => {
+  const mountAt = (level: 'novice' | 'journeyman' | 'expert', variant = V1) =>
+    mount(AnnotationOverlay, {
+      props: {
+        question: FIXTURE_QUESTION,
+        annotations: ANN,
+        provenance: variant.provenance,
+        plan: variant.plan,
+        level,
+      },
+    });
+
+  it('lights consumed spans and marks unconsumed ones differently', () => {
+    const w = mountAt('expert');
+    const consumed = w.findAll('.ao-span.sp-consumed');
+    expect(consumed.length).toBeGreaterThan(0);
+    // The override span wears the loud class.
+    expect(w.find('.ao-span.sp-overridden').exists()).toBe(true);
+  });
+
+  it('names the override in plain words, with both concepts', () => {
+    const w = mountAt('expert');
+    const warn = w.find('.ao-span.sp-overridden .ao-warn');
+    expect(warn.exists()).toBe(true);
+    expect(warn.text()).toContain('DelayedStatus');
+    expect(warn.text()).toContain('LateShipment');
+    expect(warn.text()).toContain('NOT the highest-confidence');
+  });
+
+  it('shows every competing candidate at journeyman and above', () => {
+    const w = mountAt('journeyman');
+    const delayed = w.findAll('.ao-span').find((s) => s.text().includes('delayed'))!;
+    expect(delayed.findAll('.ao-cand').length).toBe(2);
+    expect(delayed.text()).toContain('used by the plan');
+    expect(delayed.text()).toContain('not used');
+  });
+
+  it('folds competitors away at novice depth — but DISCLOSES how many', () => {
+    const w = mountAt('novice');
+    const delayed = w.findAll('.ao-span').find((s) => s.text().includes('delayed'))!;
+    expect(delayed.findAll('.ao-cand').length).toBe(1);
+    expect(delayed.find('.ao-hidden').text()).toContain('1 competing reading');
+  });
+
+  it('still warns about the override at NOVICE depth — ambiguity is warrant-bearing', () => {
+    const w = mountAt('novice');
+    const warn = w.find('.ao-span.sp-overridden .ao-warn');
+    expect(warn.exists()).toBe(true);
+    expect(warn.text()).toContain('NOT the highest-confidence');
+  });
+
+  it('renders overlapping spans in their own strip rather than hiding them', () => {
+    const w = mountAt('expert');
+    const strip = w.find('.ao-overlap');
+    expect(strip.exists()).toBe(true);
+    expect(strip.text()).toContain('many');
+    expect(strip.text()).toContain('Quantity');
+  });
+
+  it('says a span was annotated and left unconsumed', () => {
+    const w = mountAt('expert', V2);
+    const delayed = w.findAll('.ao-span').find((s) => s.text().includes('delayed'))!;
+    expect(delayed.classes()).toContain('sp-unconsumed');
+    expect(delayed.find('.ao-warn').text()).toContain('No plan node consumed this span');
+  });
+});

--- a/apps/socioprophet-web/src/__tests__/expertiseDepth.test.ts
+++ b/apps/socioprophet-web/src/__tests__/expertiseDepth.test.ts
@@ -1,0 +1,220 @@
+/**
+ * W11.6 — expertise-adaptive depth.
+ *
+ * THE RULE: depth changes what is SHOWN, never what is CLAIMED.
+ *
+ * The centrepiece is `no gloss ever overstates its warrant` below. Every plain-language
+ * reading declares the epistemic strength it conveys, and this suite asserts that equals the
+ * strength the warrant actually has — for every warrant kind at every depth. A future edit
+ * that softened the novice wording for `model-generated` would fail here rather than ship.
+ *
+ * The rest pins the floor: the warrant badge, the model-generated banner and the seal state
+ * render at EVERY depth, and the stored preference actually persists.
+ */
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import NuggetCard from '../components/nuggets/NuggetCard.vue';
+import DepthControl from '../components/depth/DepthControl.vue';
+import {
+  EXPERTISE_LEVELS,
+  WARRANT_STRENGTH,
+  clampText,
+  depthPolicy,
+  isExpertise,
+  warrantGloss,
+  type Expertise,
+} from '../features/depth/expertise';
+import { FIXTURE_NUGGETS } from '../data/nuggetFixture';
+import { useSettings } from '../stores/settings';
+import type { WarrantKind } from '../features/warrant/types';
+
+const KINDS = Object.keys(WARRANT_STRENGTH) as WarrantKind[];
+const MODEL = FIXTURE_NUGGETS.find((n) => n.warrant.type === 'model-generated')!;
+const QUOTE = FIXTURE_NUGGETS.find((n) => n.warrant.type === 'direct-quote')!;
+
+describe('depth — no gloss ever overstates its warrant', () => {
+  it('every (kind × level) gloss conveys exactly the strength the warrant has', () => {
+    for (const kind of KINDS) {
+      for (const level of EXPERTISE_LEVELS) {
+        const g = warrantGloss(kind, level);
+        expect(g.text.length).toBeGreaterThan(0);
+        // The whole point: the wording may change with depth, the strength may not.
+        expect(g.conveys).toBe(WARRANT_STRENGTH[kind]);
+      }
+    }
+  });
+
+  it('a model-generated gloss is never as strong as a direct-quote gloss, at any depth', () => {
+    for (const level of EXPERTISE_LEVELS) {
+      expect(warrantGloss('model-generated', level).conveys).toBeLessThan(
+        warrantGloss('direct-quote', level).conveys,
+      );
+    }
+  });
+
+  it('warns at least as hard for a novice as for an expert', () => {
+    // The novice wording for invented content must not be the gentle one.
+    expect(warrantGloss('model-generated', 'novice').text).toContain('NOT in the source');
+    expect(warrantGloss('ungrounded', 'novice').text).toContain('Invented');
+  });
+
+  it('gives an unrecognized warrant the weakest reading rather than a confident one', () => {
+    const g = warrantGloss('not-a-real-kind' as WarrantKind, 'expert');
+    expect(g.conveys).toBe(0);
+    expect(g.text).toContain('unproven');
+  });
+});
+
+describe('depth — policy gates supporting detail only', () => {
+  it('is ordered shallow → deep', () => {
+    expect(EXPERTISE_LEVELS.map((l) => depthPolicy(l).rank)).toEqual([0, 1, 2]);
+  });
+
+  it('reveals monotonically more as depth increases', () => {
+    const flags = [
+      'showRawRefs',
+      'showSpanOffsets',
+      'showEvidenceList',
+      'showProvenanceChain',
+      'showPolicyLabels',
+      'showCanonicalPayload',
+      'showLosingCandidates',
+      'showConfidence',
+    ] as const;
+    for (const f of flags) {
+      const seq = EXPERTISE_LEVELS.map((l) => Number(depthPolicy(l)[f]));
+      // never turns something back OFF as you go deeper
+      for (let i = 1; i < seq.length; i++) expect(seq[i]!).toBeGreaterThanOrEqual(seq[i - 1]!);
+    }
+  });
+
+  it('exposes no flag capable of hiding a warrant, a seal, or the model-generated marker', () => {
+    const keys = Object.keys(depthPolicy('novice'));
+    for (const forbidden of ['showWarrant', 'showSeal', 'showModelGenerated', 'showWarrantType']) {
+      expect(keys).not.toContain(forbidden);
+    }
+  });
+
+  it('falls back to the shallow policy for an unknown level', () => {
+    expect(depthPolicy('wizard' as Expertise).level).toBe('novice');
+    expect(isExpertise('wizard')).toBe(false);
+    expect(isExpertise('expert')).toBe(true);
+  });
+
+  it('clamps text on a word boundary and marks it truncated', () => {
+    const long = 'word '.repeat(200).trim();
+    const r = clampText(long, depthPolicy('novice'));
+    expect(r.truncated).toBe(true);
+    expect(r.text.endsWith('…')).toBe(true);
+    expect(clampText('short', depthPolicy('novice')).truncated).toBe(false);
+    // Expert has no budget at all.
+    expect(clampText(long, depthPolicy('expert')).truncated).toBe(false);
+  });
+});
+
+describe('depth — the honesty floor holds at every level', () => {
+  const card = (n = MODEL, level: Expertise = 'novice') =>
+    mount(NuggetCard, { props: { nugget: n, level } });
+
+  it('shows the warrant badge and its type at every depth', () => {
+    for (const level of EXPERTISE_LEVELS) {
+      for (const n of FIXTURE_NUGGETS) {
+        const w = card(n, level);
+        expect(w.find('.wr').exists()).toBe(true);
+        expect(w.find('.ng-kind').text()).toBe(n.warrant.type);
+      }
+    }
+  });
+
+  it('shows the model-generated banner at every depth — novice included', () => {
+    for (const level of EXPERTISE_LEVELS) {
+      const w = card(MODEL, level);
+      expect(w.find('.ng-banner').exists()).toBe(true);
+      expect(w.find('.ng').classes()).toContain('ng-model');
+    }
+  });
+
+  it('shows the unknown seal state at every depth', () => {
+    for (const level of EXPERTISE_LEVELS) {
+      expect(card(QUOTE, level).find('.ng-seal').text()).toContain('unknown');
+    }
+  });
+
+  it('never labels a model-generated nugget with a source-warranted word', () => {
+    for (const level of EXPERTISE_LEVELS) {
+      const t = card(MODEL, level).text();
+      expect(t).not.toContain('direct quote');
+      expect(t).toContain('model-generated');
+    }
+  });
+});
+
+describe('depth — it genuinely changes what is shown', () => {
+  const card = (level: Expertise) =>
+    mount(NuggetCard, { props: { nugget: FIXTURE_NUGGETS.find((n) => n.warrant.type === 'computed')!, level } });
+
+  it('hides evidence, payload, provenance and URNs from a novice', () => {
+    const w = card('novice');
+    expect(w.text()).not.toContain('Evidence');
+    expect(w.text()).not.toContain('Canonical');
+    expect(w.text()).not.toContain('Provenance');
+    expect(w.text()).not.toContain('Content hash');
+  });
+
+  it('adds evidence at journeyman and the full record at expert', () => {
+    expect(card('journeyman').text()).toContain('Evidence');
+    expect(card('journeyman').text()).not.toContain('Canonical');
+
+    const x = card('expert').text();
+    expect(x).toContain('Evidence');
+    expect(x).toContain('Canonical');
+    expect(x).toContain('Provenance');
+    expect(x).toContain('nugget-extractor/quantity@v1');
+  });
+
+  it('discloses that novice text was shortened rather than silently cutting it', () => {
+    const long = { ...QUOTE, text: 'x '.repeat(400).trim() };
+    const w = mount(NuggetCard, { props: { nugget: long, level: 'novice' as Expertise } });
+    expect(w.find('.ng-trunc').text()).toContain('full text is unchanged');
+  });
+});
+
+describe('depth — the preference is stored, not per-page', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    try {
+      localStorage.clear();
+    } catch { /* storage disabled */ }
+  });
+
+  it('defaults to novice — the shallow, safe default', () => {
+    expect(useSettings().expertise).toBe('novice');
+  });
+
+  it('persists a change to localStorage under the shared settings key', async () => {
+    const s = useSettings();
+    s.setExpertise('expert');
+    await new Promise((r) => setTimeout(r, 0));
+    const raw = JSON.parse(localStorage.getItem('sp.settings.v1') ?? '{}');
+    expect(raw.expertise).toBe('expert');
+  });
+
+  it('ignores a corrupt stored value instead of trusting it', () => {
+    localStorage.setItem('sp.settings.v1', JSON.stringify({ expertise: 'god-mode' }));
+    setActivePinia(createPinia());
+    expect(useSettings().expertise).toBe('novice');
+  });
+
+  it('the control writes the stored preference', async () => {
+    const w = mount(DepthControl);
+    const expert = w.findAll('.dc-opt').find((b) => b.text() === 'Expert')!;
+    await expert.trigger('click');
+    expect(useSettings().expertise).toBe('expert');
+    expect(w.find('.dc-opt.on').text()).toBe('Expert');
+  });
+
+  it('states the guarantee next to the control', () => {
+    expect(mount(DepthControl).find('.dc-vow').text()).toContain('never what is claimed');
+  });
+});

--- a/apps/socioprophet-web/src/__tests__/nuggetFeed.test.ts
+++ b/apps/socioprophet-web/src/__tests__/nuggetFeed.test.ts
@@ -1,0 +1,344 @@
+/**
+ * W11.5 — the KnowledgeNugget feed.
+ *
+ * The contract under test is the schema's own normative rule: model-generated content stays
+ * VISIBLY distinguishable, and no path may launder it into something source-warranted. Plus
+ * the estate's fixture-honesty rule: a failed live read never quietly becomes fixture proof.
+ *
+ *   1. Fixture integrity — direct-quote spans really do slice out of the hashed source.
+ *   2. parseNugget is fail-closed, and unreadable is UNKNOWN, not a failure verdict.
+ *   3. The span is passed to <Warrant> only when it genuinely warrants the text.
+ *   4. A nugget's seal is `unknown` — never sealed, never unsealed.
+ *   5. The card makes direct-quote and model-generated read differently.
+ *   6. The service: live / live-but-empty / unreachable are three different outcomes.
+ */
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import NuggetCard from '../components/nuggets/NuggetCard.vue';
+import StudioNuggets from '../pages/studio/StudioNuggets.vue';
+import {
+  FIXTURE_CONTENT_HASH,
+  FIXTURE_MALFORMED,
+  FIXTURE_NUGGETS,
+  FIXTURE_SOURCE_TEXT,
+} from '../data/nuggetFixture';
+import { nuggetWarrantInput, parseNugget, type KnowledgeNugget } from '../features/nuggets/types';
+import { fetchNuggets } from '../services/nuggetApi';
+import { isModelGenerated, isSourceWarranted, warrantView } from '../features/warrant/types';
+
+const byType = (t: string) => FIXTURE_NUGGETS.find((n) => n.warrant.type === t)!;
+const QUOTE = byType('direct-quote');
+const COMPUTED = byType('computed');
+const MODEL = byType('model-generated');
+const INFERRED = byType('inferred');
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('nugget fixture — faithful to the producer', () => {
+  it('every direct-quote span slices back out of the hashed source, exactly', () => {
+    const quotes = FIXTURE_NUGGETS.filter((n) => n.warrant.type === 'direct-quote');
+    expect(quotes.length).toBeGreaterThan(0);
+    for (const n of quotes) {
+      const { start, end } = n.sourceRef.span;
+      expect(FIXTURE_SOURCE_TEXT.slice(start, end)).toBe(n.text);
+      // The family validator's invariant for direct-quote.
+      expect(end - start).toBe(n.text.length);
+    }
+  });
+
+  it('every span lies inside the source and is well-ordered', () => {
+    for (const n of FIXTURE_NUGGETS) {
+      const { start, end } = n.sourceRef.span;
+      expect(end).toBeGreaterThanOrEqual(start);
+      expect(end).toBeLessThanOrEqual(FIXTURE_SOURCE_TEXT.length);
+      expect(n.sourceRef.contentHash).toBe(FIXTURE_CONTENT_HASH);
+    }
+  });
+
+  it('derived warrants cite evidence; model-generated need not', () => {
+    for (const n of FIXTURE_NUGGETS) {
+      if (n.warrant.type === 'computed' || n.warrant.type === 'inferred') {
+        expect(n.warrant.evidence.length).toBeGreaterThan(0);
+      }
+    }
+    expect(MODEL.warrant.evidence).toEqual([]);
+  });
+
+  it('every cited evidence ref resolves to a nugget in the feed', () => {
+    const ids = new Set(FIXTURE_NUGGETS.map((n) => n.id));
+    const derived = FIXTURE_NUGGETS.filter(
+      (n) => n.warrant.type === 'computed' || n.warrant.type === 'inferred',
+    );
+    expect(derived.length).toBeGreaterThan(0);
+    for (const n of derived) {
+      for (const ref of n.warrant.evidence) expect(ids.has(ref)).toBe(true);
+    }
+  });
+
+  it('a computed nugget is warranted by a direct quote, not by another derivation', () => {
+    const quoteIds = new Set(
+      FIXTURE_NUGGETS.filter((n) => n.warrant.type === 'direct-quote').map((n) => n.id),
+    );
+    for (const n of FIXTURE_NUGGETS.filter((x) => x.warrant.type === 'computed')) {
+      expect(n.warrant.evidence.every((e) => quoteIds.has(e))).toBe(true);
+    }
+  });
+});
+
+describe('parseNugget — fail-closed', () => {
+  it('accepts every fixture nugget', () => {
+    for (const n of FIXTURE_NUGGETS) expect(parseNugget(n).ok).toBe(true);
+  });
+
+  it('rejects a computed warrant that cites no evidence, and says why', () => {
+    const r = parseNugget(FIXTURE_MALFORMED, 'node-1');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain('cites no evidence');
+      expect(r.nodeId).toBe('node-1');
+    }
+  });
+
+  it('refuses an unrecognized warrant type instead of downgrading it to a known one', () => {
+    const r = parseNugget({ ...QUOTE, warrant: { ...QUOTE.warrant, type: 'vibes' } });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain('unrecognized warrant.type');
+  });
+
+  it('names the missing field rather than defaulting it', () => {
+    const { text: _drop, ...noText } = QUOTE;
+    const r = parseNugget(noText);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('missing text');
+  });
+});
+
+describe('nuggetWarrantInput — no laundering', () => {
+  it('gives <Warrant> a source span ONLY for a direct quote', () => {
+    expect(nuggetWarrantInput(QUOTE).span).toBeDefined();
+    // For these the span is a conditioning/source window; it does not warrant the text.
+    expect(nuggetWarrantInput(MODEL).span).toBeUndefined();
+    expect(nuggetWarrantInput(COMPUTED).span).toBeUndefined();
+    expect(nuggetWarrantInput(INFERRED).span).toBeUndefined();
+  });
+
+  it('carries the warrant type through unchanged', () => {
+    for (const n of FIXTURE_NUGGETS) {
+      expect(warrantView(nuggetWarrantInput(n)).kind).toBe(n.warrant.type);
+    }
+  });
+
+  it('resolves every nugget to seal UNKNOWN — not sealed, not unsealed', () => {
+    for (const n of FIXTURE_NUGGETS) {
+      const v = warrantView(nuggetWarrantInput(n));
+      expect(v.seal).toBe('unknown');
+      expect(v.sealLabel).toBe('unknown');
+    }
+  });
+
+  it('gives NO nugget a confident ramp mode, however strong its warrant', () => {
+    // #1052's rule: only a SEALED claim keeps a confident ramp. A nugget carries no receipt,
+    // so its seal is unknown — and a direct quote gets exactly the same desaturated ramp as a
+    // model guess. Warrant kind and seal state are different axes; the ramp answers the seal
+    // one, and the card separates the warrant one by hue and by the label.
+    for (const n of FIXTURE_NUGGETS) {
+      expect(warrantView(nuggetWarrantInput(n)).epistemic).toBe('unknown');
+    }
+    // …while the warrant KIND still comes through untouched.
+    expect(warrantView(nuggetWarrantInput(QUOTE)).kindLabel).toBe('direct quote');
+    expect(warrantView(nuggetWarrantInput(MODEL)).kindLabel).toBe('model-generated');
+  });
+
+  it('classifies source-warranted exactly as contract.py SOURCE_WARRANTED does', () => {
+    // contract.py :61 — SOURCE_WARRANTED = ("direct-quote", "computed", "inferred")
+    expect(isSourceWarranted('direct-quote')).toBe(true);
+    expect(isSourceWarranted('computed')).toBe(true);
+    expect(isSourceWarranted('inferred')).toBe(true);
+    expect(isSourceWarranted('model-generated')).toBe(false);
+    // …and the plan-side invented kind is never source-warranted either.
+    expect(isSourceWarranted('ungrounded')).toBe(false);
+    expect(isModelGenerated('model-generated')).toBe(true);
+    expect(isModelGenerated('ungrounded')).toBe(true);
+    expect(isModelGenerated('direct-quote')).toBe(false);
+  });
+});
+
+describe('<NuggetCard> — the difference is visible at a glance', () => {
+  const card = (n: KnowledgeNugget, level: 'novice' | 'journeyman' | 'expert' = 'expert') =>
+    mount(NuggetCard, { props: { nugget: n, level } });
+
+  it('brands a model-generated nugget three ways at once', () => {
+    const w = card(MODEL);
+    expect(w.find('.ng').classes()).toContain('ng-model'); // dashed container
+    expect(w.find('.ng-banner').exists()).toBe(true); // standing banner
+    expect(w.find('.ng-banner').text()).toContain('Not warranted by the source');
+    expect(w.find('.ng-kind').text()).toBe('model-generated'); // the label
+  });
+
+  it('does not brand a direct quote as model-generated, and styles it as a quotation', () => {
+    const w = card(QUOTE);
+    expect(w.find('.ng').classes()).not.toContain('ng-model');
+    expect(w.find('.ng-banner').exists()).toBe(false);
+    expect(w.find('.ng-text').classes()).toContain('quote');
+  });
+
+  it('calls the span a conditioning window for model-generated, and a span otherwise', () => {
+    expect(card(MODEL).text()).toContain('conditioning window');
+    expect(card(QUOTE).text()).not.toContain('conditioning window');
+  });
+
+  it('never paints the stripe at full ramp strength, since no nugget is sealed', () => {
+    for (const n of FIXTURE_NUGGETS) {
+      const style = card(n).find('.ng').attributes('style') ?? '';
+      // Hue is present (so a quote still reads differently from a guess)…
+      expect(style).toContain('--epi-');
+      // …but always mixed down, never the raw token that a SEALED surface would use.
+      expect(style).toContain('color-mix');
+    }
+  });
+
+  it('states the seal as unknown, and explains why there is no receipt', () => {
+    const w = card(QUOTE);
+    expect(w.find('.ng-seal').text()).toContain('unknown');
+    expect(w.find('.ng-seal').text()).toContain('seals the emitted BATCH');
+  });
+
+  it('shows a direct quote has no cited evidence WITHOUT implying a defect', () => {
+    const w = card(QUOTE);
+    expect(w.text()).toContain('grounded by its source span itself');
+  });
+});
+
+describe('nugget feed service — live, empty and unreachable are three facts', () => {
+  const node = (n: KnowledgeNugget) => ({
+    id: n.id,
+    labels: ['KnowledgeNugget', `warrant:${n.warrant.type}`],
+    properties: { nuggetId: n.id, warrantType: n.warrant.type, nugget: JSON.stringify(n) },
+  });
+
+  it('parses nuggets out of the graph node property when the read succeeds', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ count: 2, nodes: [node(QUOTE), node(MODEL)] }),
+      }),
+    );
+    const r = await fetchNuggets();
+    expect(r.mode).toBe('live');
+    expect(r.error).toBeNull();
+    expect(r.items.filter((i) => i.ok).length).toBe(2);
+  });
+
+  it('reports a reachable-but-empty graph as LIVE and empty — never as fixtures', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ count: 0, nodes: [] }) }));
+    const r = await fetchNuggets();
+    expect(r.mode).toBe('live');
+    expect(r.emptyLive).toBe(true);
+    expect(r.items).toEqual([]);
+  });
+
+  it('falls back to FIXTURE — labelled, with the reason — when the graph is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    const r = await fetchNuggets();
+    expect(r.mode).toBe('fixture');
+    expect(r.error).toContain('ECONNREFUSED');
+    expect(r.items.filter((i) => i.ok).length).toBe(FIXTURE_NUGGETS.length);
+  });
+
+  it('treats a non-ok HTTP status as unavailable, not as an empty graph', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) }));
+    const r = await fetchNuggets();
+    expect(r.mode).toBe('fixture');
+    expect(r.error).toContain('503');
+    expect(r.emptyLive).toBe(false);
+  });
+
+  it('keeps a node whose canonical JSON will not parse, as unreadable with a reason', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ count: 1, nodes: [{ id: 'n1', properties: { nugget: '{not json' } }] }),
+      }),
+    );
+    const r = await fetchNuggets();
+    expect(r.mode).toBe('live');
+    const bad = r.items.find((i) => !i.ok)!;
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.reason).toContain('did not parse');
+  });
+});
+
+describe('Studio nugget feed surface', () => {
+  it('declares the fixture fallback above everything it renders', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    const w = mount(StudioNuggets);
+    await flushPromises();
+    const banner = w.find('.nf-mode');
+    expect(banner.classes()).toContain('m-fixture');
+    expect(banner.text()).toContain('FIXTURE');
+    expect(banner.text()).toContain('nothing below came off a graph');
+  });
+
+  it('says plainly that delivery is pull, not push', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    const w = mount(StudioNuggets);
+    await flushPromises();
+    expect(w.find('.nf-pull').text()).toContain('Pull, not push');
+  });
+
+  it('does not pass its filters off as access control', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    const w = mount(StudioNuggets);
+    await flushPromises();
+    const grant = w.find('.nf-grant').text();
+    expect(grant).toContain('not grant scoping and not access control');
+    expect(grant).toContain('follow-on');
+  });
+
+  it('subscribes to every warrant class by default, and discloses what a filter hides', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    const w = mount(StudioNuggets);
+    await flushPromises();
+    expect(w.findAll('.ng').length).toBe(FIXTURE_NUGGETS.length);
+
+    const modelPill = w.findAll('.nf-sub').find((b) => b.text().startsWith('model-generated'))!;
+    await modelPill.trigger('click');
+    expect(w.findAll('.ng').length).toBe(FIXTURE_NUGGETS.length - 1);
+    expect(w.find('.nf-hidden').text()).toContain('1 readable nugget');
+  });
+
+  it('never folds model-generated into a single headline total', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    const w = mount(StudioNuggets);
+    await flushPromises();
+    const split = w.find('.nf-split');
+    expect(split.text()).toContain('source-warranted');
+    expect(split.text()).toContain('model-generated');
+    const src = FIXTURE_NUGGETS.filter((n) => isSourceWarranted(n.warrant.type)).length;
+    expect(w.find('.nf-split-src').text()).toContain(String(src));
+    expect(w.find('.nf-split-mod').text()).toContain(String(FIXTURE_NUGGETS.length - src));
+  });
+
+  it('lists unreadable payloads rather than dropping them, and calls them unknown', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    const w = mount(StudioNuggets);
+    await flushPromises();
+    const bad = w.find('.nf-bad');
+    expect(bad.exists()).toBe(true);
+    expect(bad.text()).toContain('Unreadable is');
+    expect(bad.text()).toContain('cites no evidence');
+  });
+
+  it('shows a real empty state on a reachable graph, with no fixtures substituted', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ count: 0, nodes: [] }) }));
+    const w = mount(StudioNuggets);
+    await flushPromises();
+    expect(w.find('.nf-empty').exists()).toBe(true);
+    expect(w.find('.nf-empty').text()).toContain('not a reason to show you fixtures');
+    expect(w.findAll('.ng').length).toBe(0);
+  });
+});

--- a/apps/socioprophet-web/src/components/depth/DepthControl.vue
+++ b/apps/socioprophet-web/src/components/depth/DepthControl.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+// W11.6 — the depth control. Writes the STORED preference (stores/settings.ts → localStorage),
+// so setting it once changes every proof surface, on this visit and the next.
+//
+// It is a segmented control rather than a hidden "advanced" switch on purpose: TA-E's premise
+// is that depth is a property of the CONSUMER, so it has to be as visible and as durable as a
+// theme setting. What it does NOT do is change any claim — see features/depth/expertise.ts.
+import { computed } from 'vue';
+import { useSettings } from '../../stores/settings';
+import { EXPERTISE_LEVELS, depthPolicy, type Expertise } from '../../features/depth/expertise';
+
+withDefaults(defineProps<{ compact?: boolean }>(), { compact: false });
+
+const settings = useSettings();
+const level = computed<Expertise>(() => settings.expertise as Expertise);
+const policy = computed(() => depthPolicy(level.value));
+</script>
+
+<template>
+  <div class="dc" role="group" aria-label="Detail depth">
+    <span class="dc-l">depth</span>
+    <div class="dc-seg">
+      <button
+        v-for="l in EXPERTISE_LEVELS"
+        :key="l"
+        class="dc-opt"
+        type="button"
+        :class="{ on: level === l }"
+        :aria-pressed="level === l"
+        @click="settings.setExpertise(l)"
+      >
+        {{ depthPolicy(l).label }}
+      </button>
+    </div>
+    <span v-if="!compact" class="dc-blurb">{{ policy.blurb }}</span>
+    <!-- The guarantee, stated where the control is, because a depth control is exactly the
+         affordance a reader would suspect of hiding bad news. -->
+    <span v-if="!compact" class="dc-vow">
+      Depth changes what is shown, never what is claimed — warrant type, seal state and
+      model-generated markers show at every depth.
+    </span>
+  </div>
+</template>
+
+<style scoped>
+.dc {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.dc-l {
+  color: var(--faint);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.dc-seg {
+  display: inline-flex;
+  border: 1px solid var(--border-2);
+  border-radius: var(--r-1);
+  overflow: hidden;
+}
+.dc-opt {
+  background: transparent;
+  color: var(--muted);
+  border: 0;
+  border-right: 1px solid var(--border-2);
+  padding: 2px 10px;
+  font-size: 0.68rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+.dc-opt:last-child {
+  border-right: 0;
+}
+.dc-opt:hover {
+  color: var(--ink);
+  background: var(--surface);
+}
+.dc-opt.on {
+  color: var(--accent-ink);
+  background: var(--accent-wash);
+}
+.dc-opt:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.dc-blurb {
+  color: var(--faint);
+  font-size: 0.64rem;
+}
+.dc-vow {
+  flex-basis: 100%;
+  color: var(--faint);
+  font-size: 0.6rem;
+  line-height: 1.45;
+  border-left: 2px solid var(--hairline-strong);
+  padding-left: 0.45rem;
+}
+</style>

--- a/apps/socioprophet-web/src/components/nuggets/NuggetCard.vue
+++ b/apps/socioprophet-web/src/components/nuggets/NuggetCard.vue
@@ -1,0 +1,352 @@
+<script setup lang="ts">
+// W11.5 — one KnowledgeNugget, with its warrant on the front.
+//
+// The schema's normative rule is that model-generated content stays VISIBLY distinguishable on
+// every downstream surface. So the difference is carried three ways at once, not buried in a
+// tooltip: the epistemic stripe down the left edge, the <Warrant> badge, and — for
+// model-generated only — a standing banner. Any one of them could be missed; all three cannot.
+//
+// Depth (W11.6) folds away evidence lists, provenance chains, URNs, hashes and payloads.
+// It never folds away the warrant badge, the stripe, the model-generated banner, or the
+// unsealed/unknown seal state. Those render at every level, by construction — there is no
+// depth flag capable of hiding them.
+import { computed } from 'vue';
+import Warrant from '../warrant/Warrant.vue';
+import {
+  nuggetWarrantInput,
+  refLabel,
+  type KnowledgeNugget,
+} from '../../features/nuggets/types';
+import { clampText, depthPolicy, warrantGloss, type Expertise } from '../../features/depth/expertise';
+import { isModelGenerated, pct } from '../../features/warrant/types';
+
+const props = defineProps<{ nugget: KnowledgeNugget; level: Expertise }>();
+
+const policy = computed(() => depthPolicy(props.level));
+const kind = computed(() => props.nugget.warrant.type);
+const modelGenerated = computed(() => isModelGenerated(kind.value));
+const gloss = computed(() => warrantGloss(kind.value, props.level));
+const w = computed(() => nuggetWarrantInput(props.nugget));
+const body = computed(() => clampText(props.nugget.text, policy.value));
+const span = computed(() => props.nugget.sourceRef.span);
+
+/**
+ * The stripe hue, by WARRANT KIND — a different axis from seal state.
+ *
+ * Deliberately mixed down to 62% rather than using the raw `--epi-*` token. A nugget's seal is
+ * always `unknown` (no receipt exists for it), so `warrantView().epistemic` is `unknown` and
+ * the <Warrant> badge beside this stripe renders desaturated. A full-strength `--epi-observed`
+ * stripe next to an `unknown` badge would be a surface arguing with itself, and would re-open
+ * the "colour outranks proof" hole that #1052 closed on the plan surfaces.
+ *
+ * So: hue still separates a quote from a model guess at a glance (which W11.5 requires), but
+ * the intensity never claims proof the nugget does not carry.
+ */
+const KIND_HUE: Record<string, string> = {
+  'direct-quote': 'var(--epi-observed)',
+  computed: 'var(--epi-derived)',
+  inferred: 'var(--epi-derived)',
+  'model-generated': 'var(--epi-hypothesis)',
+};
+const stripe = computed(
+  () => `color-mix(in srgb, ${KIND_HUE[kind.value] ?? 'var(--epi-unknown)'} 62%, var(--panel))`,
+);
+
+const payload = computed(() => {
+  const p = props.nugget.canonicalPayload;
+  return p && typeof p === 'object' ? (p as Record<string, unknown>) : null;
+});
+</script>
+
+<template>
+  <article class="ng" :class="{ 'ng-model': modelGenerated }" :style="{ '--epi': stripe }">
+    <!-- Warrant row. Always first, always present, at every depth. -->
+    <header class="ng-head">
+      <Warrant :w="w" />
+      <span class="ng-kind">{{ kind }}</span>
+      <span v-if="policy.showConfidence" class="ng-conf tnum" :title="'Producer-stated confidence'">
+        {{ pct(nugget.warrant.confidence) }}
+      </span>
+      <time class="ng-time" :datetime="nugget.wallTime">{{ nugget.wallTime.slice(0, 16).replace('T', ' ') }}</time>
+    </header>
+
+    <!--
+      The banner is unconditional for model-generated. Not depth-gated, not collapsible:
+      the schema says "MUST remain visibly distinguishable on every downstream surface".
+    -->
+    <p v-if="modelGenerated" class="ng-banner">
+      <b>Model-generated.</b> Not warranted by the source. The span below is the window the model
+      was conditioned on — it is not evidence for this statement.
+    </p>
+
+    <p class="ng-text" :class="{ quote: kind === 'direct-quote' }">{{ body.text }}</p>
+    <p v-if="body.truncated" class="ng-trunc">
+      Shortened for {{ policy.label.toLowerCase() }} depth — the full text is unchanged, raise depth to read it.
+    </p>
+
+    <!-- Plain-language reading of the warrant, at this depth. Never stronger than the warrant. -->
+    <p class="ng-gloss">{{ gloss.text }}</p>
+
+    <dl class="ng-meta">
+      <div class="ng-row">
+        <dt>Source</dt>
+        <dd>
+          <span v-if="policy.showRawRefs" class="mono">{{ nugget.sourceRef.docRef }}</span>
+          <span v-else>{{ refLabel(nugget.sourceRef.docRef) }}</span>
+          <span v-if="policy.showSpanOffsets" class="ng-span tnum">
+            {{ modelGenerated ? 'conditioning window' : 'span' }} [{{ span.start }},{{ span.end }})
+            <template v-if="span.page">· p{{ span.page }}</template>
+          </span>
+        </dd>
+      </div>
+
+      <div v-if="policy.showRawRefs" class="ng-row">
+        <dt>Content hash</dt>
+        <dd><code class="mono ng-hash">{{ nugget.sourceRef.contentHash }}</code></dd>
+      </div>
+
+      <!-- Evidence. For computed/inferred the schema guarantees >= 1; for model-generated the
+           absence is itself the point, so it is stated rather than left blank. -->
+      <div v-if="policy.showEvidenceList" class="ng-row">
+        <dt>Evidence</dt>
+        <dd>
+          <template v-if="nugget.warrant.evidence.length">
+            <span v-for="e in nugget.warrant.evidence" :key="e" class="ng-chip mono">
+              {{ policy.showRawRefs ? e : refLabel(e) }}
+            </span>
+          </template>
+          <span v-else-if="kind === 'direct-quote'" class="ng-none">
+            none cited — a direct quote is grounded by its source span itself
+          </span>
+          <span v-else class="ng-none warn">none cited</span>
+        </dd>
+      </div>
+
+      <div v-if="policy.showPolicyLabels && nugget.policyLabels.length" class="ng-row">
+        <dt>Policy</dt>
+        <dd><span v-for="p in nugget.policyLabels" :key="p" class="ng-chip">{{ p }}</span></dd>
+      </div>
+
+      <div v-if="policy.showCanonicalPayload && payload" class="ng-row">
+        <dt>Canonical</dt>
+        <dd>
+          <span v-if="payload['normalizationRegime']" class="ng-regime mono">
+            regime {{ payload['normalizationRegime'] }}
+          </span>
+          <code class="ng-payload mono">{{ JSON.stringify(payload) }}</code>
+        </dd>
+      </div>
+
+      <div v-if="policy.showProvenanceChain && nugget.provenance?.length" class="ng-row">
+        <dt>Provenance</dt>
+        <dd>
+          <span v-for="p in nugget.provenance" :key="`${p.rel}|${p.ref}`" class="ng-prov">
+            <span class="ng-rel">{{ p.rel }}</span>
+            <span class="mono">{{ policy.showRawRefs ? p.ref : refLabel(p.ref) }}</span>
+          </span>
+        </dd>
+      </div>
+
+      <div v-if="policy.showRawRefs" class="ng-row">
+        <dt>Nugget</dt>
+        <dd>
+          <code class="mono ng-hash">{{ nugget.id }}</code>
+          <span class="ng-by">by <span class="mono">{{ nugget.createdBy }}</span></span>
+          <span class="ng-by">logical {{ nugget.logicalTime }}</span>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- Seal state, stated once per card. `unknown` is not `unsealed`, and neither is `sealed`. -->
+    <p class="ng-seal">
+      Seal: <b>unknown</b> — KnowledgeNugget 0.1.0 carries no receipt reference. The extractor
+      seals the emitted BATCH, not the individual nugget, so nothing here proves this one is on
+      the chain.
+    </p>
+  </article>
+</template>
+
+<style scoped>
+.ng {
+  position: relative;
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.7rem 0.85rem 0.7rem 1rem;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-3);
+}
+/* The epistemic stripe — the at-a-glance signal. */
+.ng::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  border-radius: var(--r-3) 0 0 var(--r-3);
+  background: var(--epi);
+}
+/* Model-generated is dimmer and dashed: it must not read like the quotes around it. */
+.ng-model {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--epi-hypothesis) 46%, transparent);
+  background: color-mix(in srgb, var(--epi-hypothesis) 7%, var(--panel));
+}
+
+.ng-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.ng-kind {
+  color: var(--epi);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 700;
+}
+.ng-conf {
+  color: var(--muted);
+  font-size: 0.64rem;
+}
+.ng-time {
+  margin-left: auto;
+  color: var(--faint);
+  font-size: 0.62rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.ng-banner {
+  margin: 0;
+  padding: 0.35rem 0.5rem;
+  border-radius: var(--r-1);
+  background: color-mix(in srgb, var(--epi-hypothesis) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--epi-hypothesis) 44%, transparent);
+  color: var(--ink-2);
+  font-size: 0.66rem;
+  line-height: 1.45;
+}
+.ng-banner b {
+  color: var(--epi-hypothesis);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ng-text {
+  margin: 0;
+  color: var(--ink);
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+/* A verbatim cut looks like a quotation. Nothing else does. */
+.ng-text.quote {
+  border-left: 2px solid color-mix(in srgb, var(--epi-observed) 55%, transparent);
+  padding-left: 0.55rem;
+  font-style: italic;
+}
+.ng-trunc,
+.ng-gloss {
+  margin: 0;
+  color: var(--faint);
+  font-size: 0.66rem;
+  line-height: 1.45;
+}
+
+.ng-meta {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0.1rem 0 0;
+}
+.ng-row {
+  display: grid;
+  grid-template-columns: 6rem 1fr;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+.ng-row dt {
+  color: var(--faint);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.ng-row dd {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 0.68rem;
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  align-items: baseline;
+}
+.ng-span {
+  color: var(--faint);
+  font-size: 0.62rem;
+}
+.ng-hash {
+  color: var(--muted);
+  font-size: 0.6rem;
+  overflow-wrap: anywhere;
+}
+.ng-chip {
+  border: 1px solid var(--border-2);
+  border-radius: var(--pill);
+  padding: 0 7px;
+  font-size: 0.62rem;
+  color: var(--muted);
+}
+.ng-none {
+  color: var(--faint);
+  font-style: italic;
+  font-size: 0.64rem;
+}
+.ng-none.warn {
+  color: var(--epi-hypothesis);
+  font-style: normal;
+}
+.ng-regime {
+  color: var(--epi-derived);
+  font-size: 0.62rem;
+}
+.ng-payload {
+  color: var(--muted);
+  font-size: 0.6rem;
+  overflow-wrap: anywhere;
+}
+.ng-prov {
+  display: inline-flex;
+  gap: 0.3rem;
+  align-items: baseline;
+  font-size: 0.62rem;
+}
+.ng-rel {
+  color: var(--faint);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.56rem;
+}
+.ng-by {
+  color: var(--faint);
+  font-size: 0.6rem;
+}
+.ng-seal {
+  margin: 0;
+  padding-top: 0.35rem;
+  border-top: 1px solid var(--hairline);
+  color: var(--faint);
+  font-size: 0.62rem;
+  line-height: 1.45;
+}
+.ng-seal b {
+  color: var(--epi-unknown);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.mono {
+  font-family: var(--mono);
+}
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/apps/socioprophet-web/src/components/warrant/AnnotationOverlay.vue
+++ b/apps/socioprophet-web/src/components/warrant/AnnotationOverlay.vue
@@ -1,0 +1,463 @@
+<script setup lang="ts">
+// W11.4 — the annotation overlay. The question, with every competing reading kept.
+//
+// Consumed spans are lit; hover or keyboard-focus a span to see EVERY ontology concept that
+// competed for those characters, each with its annotator and confidence, and which one the plan
+// actually bound. The interesting cases get their own marks:
+//
+//   • ambiguous          more than one distinct concept claimed the span
+//   • overridden         the plan did NOT take the highest-confidence candidate  ← the EBA lesson
+//   • unconsumed         annotated, but no plan node bound anything here
+//
+// "Used" is read from the selected variant's provenance, never guessed from confidence order —
+// which is the only reason `overridden` can be detected at all.
+//
+// Depth (W11.6) folds the losing candidates and the numbers away for a novice. It never folds
+// away the fact that a span was ambiguous or that the plan overrode the ranking: those are
+// warrant-bearing, so they render at every depth.
+import { computed } from 'vue';
+import {
+  buildAnnotationOverlay,
+  conceptLabel,
+  type AnnotatedSpan,
+} from '../../features/warrant/annotations';
+import { depthPolicy, type Expertise } from '../../features/depth/expertise';
+import { pct, type NodeProvenance, type PlanNode, type TokenAnnotation } from '../../features/warrant/types';
+
+const props = withDefaults(
+  defineProps<{
+    question: string;
+    annotations: readonly TokenAnnotation[];
+    /** The SELECTED variant's provenance — node-level grounding. */
+    provenance: readonly NodeProvenance[];
+    /** The SELECTED variant's plan, so binding-level consumption is counted too. */
+    plan?: PlanNode | null;
+    level: Expertise;
+  }>(),
+  { plan: null },
+);
+
+const overlay = computed(() =>
+  buildAnnotationOverlay(props.question, props.annotations, props.provenance, props.plan),
+);
+const policy = computed(() => depthPolicy(props.level));
+
+/** Candidates to render: at novice depth, only the one the plan used (if any). */
+function shown(s: AnnotatedSpan) {
+  if (policy.value.showLosingCandidates) return s.candidates;
+  const used = s.candidates.filter((c) => c.used);
+  return used.length > 0 ? used : s.candidates.slice(0, 1);
+}
+function hiddenCount(s: AnnotatedSpan) {
+  return s.candidates.length - shown(s).length;
+}
+function spanClass(s: AnnotatedSpan) {
+  return {
+    'sp-consumed': s.consumed,
+    'sp-unconsumed': !s.consumed,
+    'sp-ambiguous': s.ambiguous,
+    'sp-overridden': s.overrodeTopConfidence,
+  };
+}
+</script>
+
+<template>
+  <div class="ao">
+    <!-- Counts first: the shape of the ambiguity, before the detail. -->
+    <div class="ao-summary">
+      <span class="ao-stat"
+        ><b class="tnum">{{ overlay.spans.length }}</b> annotated span{{ overlay.spans.length === 1 ? '' : 's' }}</span
+      >
+      <span v-if="overlay.ambiguousCount" class="ao-stat s-amb"
+        ><b class="tnum">{{ overlay.ambiguousCount }}</b> ambiguous</span
+      >
+      <span v-if="overlay.overriddenCount" class="ao-stat s-ovr"
+        ><b class="tnum">{{ overlay.overriddenCount }}</b> plan overrode top confidence</span
+      >
+      <span v-if="overlay.unconsumedCount" class="ao-stat s-unc"
+        ><b class="tnum">{{ overlay.unconsumedCount }}</b> annotated but unconsumed</span
+      >
+    </div>
+
+    <!-- The question itself. -->
+    <p class="ao-text">
+      <template v-for="(seg, i) in overlay.segments" :key="i">
+        <span v-if="!seg.annotated" class="ao-plain">{{ seg.text }}</span>
+        <span v-else class="ao-span" :class="spanClass(seg.annotated)" tabindex="0" role="button"
+          :aria-label="`${seg.text}: ${seg.annotated.candidates.length} candidate concept(s), ${seg.annotated.consumed ? 'consumed by the plan' : 'not consumed'}`"
+        >
+          <span class="ao-span-t">{{ seg.text }}</span>
+          <span v-if="seg.annotated.ambiguous" class="ao-mark" aria-hidden="true">⑂</span>
+
+          <!-- the competing-concepts popover -->
+          <span class="ao-pop" role="tooltip">
+            <span class="ao-pop-head">
+              <b>“{{ seg.text }}”</b>
+              <span v-if="policy.showSpanOffsets" class="ao-off tnum"
+                >[{{ seg.annotated.span.start }},{{ seg.annotated.span.end }})</span
+              >
+              <span class="ao-pop-n"
+                >{{ seg.annotated.candidates.length }} candidate{{ seg.annotated.candidates.length === 1 ? '' : 's' }}</span
+              >
+            </span>
+
+            <!-- Warrant-bearing notices. Rendered at EVERY depth. -->
+            <span v-if="seg.annotated.overrodeTopConfidence" class="ao-warn">
+              The plan bound <b>{{ conceptLabel(seg.annotated.usedConceptRef ?? '') }}</b
+              >, which is NOT the highest-confidence candidate
+              (<b>{{ conceptLabel(seg.annotated.topConfidenceConceptRef ?? '') }}</b
+              >). Ranking and choice disagree here.
+            </span>
+            <span v-else-if="!seg.annotated.consumed" class="ao-warn">
+              No plan node consumed this span. It was annotated and then left on the floor —
+              this is a coverage gap, not a resolved reading.
+            </span>
+            <span v-else-if="seg.annotated.ambiguous" class="ao-note">
+              {{ seg.annotated.candidates.length }} readings competed; the plan took one.
+            </span>
+
+            <ul class="ao-cands">
+              <li
+                v-for="c in shown(seg.annotated)"
+                :key="`${c.conceptRef}|${c.source}`"
+                class="ao-cand"
+                :class="{ used: c.used }"
+              >
+                <span class="ao-cand-top">
+                  <span class="ao-cand-mark" aria-hidden="true">{{ c.used ? '●' : '○' }}</span>
+                  <span class="ao-cand-c mono">{{ conceptLabel(c.conceptRef) }}</span>
+                  <span v-if="c.used" class="ao-cand-used">used by the plan</span>
+                  <span v-else class="ao-cand-lost">not used</span>
+                </span>
+                <span v-if="policy.showConfidence" class="ao-cand-meta">
+                  <span class="tnum">{{ pct(c.confidence) }}</span> confidence · annotator
+                  <span class="mono">{{ c.source }}</span>
+                </span>
+                <span v-if="policy.showRawRefs" class="ao-cand-ref mono">{{ c.conceptRef }}</span>
+                <span v-if="c.used && c.usedBy.length" class="ao-cand-by">
+                  bound by
+                  <span v-for="(u, j) in c.usedBy" :key="`${u.nodeId}|${u.via}|${u.input ?? ''}`" class="mono"
+                    >{{ u.actionName }}<span class="ao-nid">
+                      ({{ u.nodeId }}<template v-if="u.via === 'binding'"> · {{ u.input }}</template
+                      >)</span
+                    ><span v-if="j < c.usedBy.length - 1">, </span></span
+                  >
+                </span>
+              </li>
+            </ul>
+
+            <!-- Never let depth silently swallow competitors: say how many are folded. -->
+            <span v-if="hiddenCount(seg.annotated) > 0" class="ao-hidden">
+              {{ hiddenCount(seg.annotated) }} competing reading{{ hiddenCount(seg.annotated) === 1 ? '' : 's' }}
+              hidden at this depth — raise depth to see {{ hiddenCount(seg.annotated) === 1 ? 'it' : 'them' }}.
+            </span>
+          </span>
+        </span>
+      </template>
+    </p>
+
+    <!-- Spans that could not be laid out inline because they overlap one that was. Shown, not
+         dropped: a hidden competitor is the bug this surface exists to fix. -->
+    <div v-if="overlay.overlapped.length" class="ao-overlap">
+      <span class="ao-overlap-l">overlapping spans (not shown inline)</span>
+      <span v-for="s in overlay.overlapped" :key="`${s.span.start}:${s.span.end}`" class="ao-overlap-i">
+        “{{ s.span.text }}”
+        <span v-if="policy.showSpanOffsets" class="ao-off tnum">[{{ s.span.start }},{{ s.span.end }})</span>
+        →
+        <span v-for="(c, j) in s.candidates" :key="c.conceptRef + c.source" class="mono">
+          {{ conceptLabel(c.conceptRef) }}<span v-if="c.used" class="ao-cand-used"> ·used</span
+          ><span v-if="j < s.candidates.length - 1">, </span>
+        </span>
+      </span>
+    </div>
+
+    <div class="ao-legend">
+      <span><i class="lg lg-consumed" />consumed by the plan</span>
+      <span><i class="lg lg-unconsumed" />annotated, unconsumed</span>
+      <span><i class="lg lg-overridden" />plan overrode top confidence</span>
+      <span>⑂ more than one concept competed</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ao {
+  display: grid;
+  gap: 0.7rem;
+}
+.ao-summary {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.ao-stat {
+  font-size: 0.66rem;
+  color: var(--muted);
+  border: 1px solid var(--border-2);
+  border-radius: var(--pill);
+  padding: 1px 9px;
+}
+.ao-stat b {
+  color: var(--ink);
+}
+.ao-stat.s-amb {
+  color: var(--epi-derived);
+  border-color: color-mix(in srgb, var(--epi-derived) 40%, transparent);
+}
+.ao-stat.s-amb b {
+  color: var(--epi-derived);
+}
+.ao-stat.s-ovr {
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 44%, transparent);
+  background: var(--warn-wash);
+}
+.ao-stat.s-ovr b {
+  color: var(--warn);
+}
+.ao-stat.s-unc {
+  color: var(--epi-hypothesis);
+  border-color: color-mix(in srgb, var(--epi-hypothesis) 40%, transparent);
+}
+.ao-stat.s-unc b {
+  color: var(--epi-hypothesis);
+}
+
+.ao-text {
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 2.1;
+  color: var(--ink-2);
+  background: var(--sunken);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-2);
+  padding: 0.7rem 0.8rem;
+}
+.ao-plain {
+  color: var(--faint);
+}
+
+.ao-span {
+  position: relative;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 2px;
+  cursor: help;
+  border-radius: var(--r-1);
+  padding: 1px 4px;
+  border-bottom: 2px solid var(--idle);
+  color: var(--ink);
+}
+.ao-span:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+/* Consumed = lit on the observed rung; unconsumed stays grey and dashed. */
+.ao-span.sp-consumed {
+  background: color-mix(in srgb, var(--epi-observed) 16%, transparent);
+  border-bottom-color: var(--epi-observed);
+}
+.ao-span.sp-unconsumed {
+  color: var(--muted);
+  border-bottom-style: dashed;
+  border-bottom-color: var(--epi-hypothesis);
+}
+.ao-span.sp-ambiguous {
+  border-bottom-color: var(--epi-derived);
+}
+/* Override is the loudest state — warn, because ranking and choice disagreed. */
+.ao-span.sp-overridden {
+  background: var(--warn-wash);
+  border-bottom-color: var(--warn);
+}
+.ao-mark {
+  font-size: 0.7rem;
+  color: var(--epi-derived);
+  line-height: 1;
+}
+.sp-overridden .ao-mark {
+  color: var(--warn);
+}
+
+.ao-pop {
+  position: absolute;
+  z-index: 60;
+  bottom: calc(100% + 8px);
+  left: 0;
+  display: grid;
+  gap: 0.35rem;
+  width: max-content;
+  max-width: 27rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: var(--r-3);
+  background: var(--surface);
+  border: 1px solid var(--hairline-strong);
+  box-shadow: var(--e-3);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(4px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+  font-size: 0.72rem;
+  line-height: 1.45;
+  text-align: left;
+  white-space: normal;
+  color: var(--ink-2);
+}
+.ao-span:hover .ao-pop,
+.ao-span:focus-visible .ao-pop {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+.ao-pop-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  color: var(--ink);
+  font-size: 0.74rem;
+}
+.ao-pop-n {
+  margin-left: auto;
+  color: var(--faint);
+  font-size: 0.62rem;
+}
+.ao-off {
+  color: var(--faint);
+  font-size: 0.62rem;
+}
+
+.ao-warn {
+  color: var(--warn);
+  background: var(--warn-wash);
+  border: 1px solid color-mix(in srgb, var(--warn) 34%, transparent);
+  border-radius: var(--r-1);
+  padding: 0.3rem 0.4rem;
+  font-size: 0.66rem;
+}
+.ao-note {
+  color: var(--epi-derived);
+  font-size: 0.66rem;
+}
+
+.ao-cands {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.3rem;
+}
+.ao-cand {
+  display: grid;
+  gap: 1px;
+  padding: 0.3rem 0.4rem;
+  border-radius: var(--r-1);
+  background: var(--sunken);
+  border-left: 3px solid var(--idle);
+}
+.ao-cand.used {
+  border-left-color: var(--epi-observed);
+  background: var(--epi-observed-wash);
+}
+.ao-cand-top {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+.ao-cand-mark {
+  color: var(--idle);
+  font-size: 0.6rem;
+}
+.ao-cand.used .ao-cand-mark {
+  color: var(--epi-observed);
+}
+.ao-cand-c {
+  color: var(--ink);
+  font-size: 0.7rem;
+}
+.ao-cand-used {
+  margin-left: auto;
+  color: var(--epi-observed);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+}
+.ao-cand-lost {
+  margin-left: auto;
+  color: var(--faint);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.ao-cand-meta,
+.ao-cand-by {
+  color: var(--faint);
+  font-size: 0.62rem;
+}
+.ao-cand-ref {
+  color: var(--muted);
+  font-size: 0.6rem;
+  overflow-wrap: anywhere;
+}
+.ao-nid {
+  color: var(--faint);
+}
+.ao-hidden {
+  color: var(--faint);
+  font-size: 0.62rem;
+  border-top: 1px solid var(--hairline);
+  padding-top: 0.3rem;
+}
+
+.ao-overlap {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.5rem 0.6rem;
+  border: 1px dashed var(--border-2);
+  border-radius: var(--r-2);
+}
+.ao-overlap-l {
+  color: var(--faint);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+.ao-overlap-i {
+  color: var(--ink-2);
+  font-size: 0.68rem;
+}
+
+.ao-legend {
+  display: flex;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+  color: var(--faint);
+  font-size: 0.62rem;
+  align-items: center;
+}
+.lg {
+  display: inline-block;
+  width: 10px;
+  height: 3px;
+  border-radius: 2px;
+  margin-right: 5px;
+  vertical-align: middle;
+}
+.lg-consumed {
+  background: var(--epi-observed);
+}
+.lg-unconsumed {
+  background: var(--epi-hypothesis);
+}
+.lg-overridden {
+  background: var(--warn);
+}
+.mono {
+  font-family: var(--mono);
+}
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/apps/socioprophet-web/src/components/warrant/Warrant.vue
+++ b/apps/socioprophet-web/src/components/warrant/Warrant.vue
@@ -41,7 +41,11 @@
       </span>
       <span v-else class="wr-row">
         <b>Source span</b>
-        <span class="wr-nospan">none — model-generated</span>
+        <!-- Derived from the KIND, never assumed: a `computed` nugget with no span is missing
+             its span, which is a different fact from being model-generated. -->
+        <span class="wr-nospan">
+          none — {{ isModelGenerated(view.kind) ? view.kindLabel : 'no source span recorded' }}
+        </span>
       </span>
 
       <span v-if="view.admissibility" class="wr-row">
@@ -105,7 +109,12 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { WALK_STEP_MEANING, warrantView, type WarrantInput } from '../../features/warrant/types';
+import {
+  WALK_STEP_MEANING,
+  isModelGenerated,
+  warrantView,
+  type WarrantInput,
+} from '../../features/warrant/types';
 
 const props = withDefaults(defineProps<{ w: WarrantInput; compact?: boolean; defaultOpen?: boolean }>(), {
   compact: false,

--- a/apps/socioprophet-web/src/data/nuggetFixture.ts
+++ b/apps/socioprophet-web/src/data/nuggetFixture.ts
@@ -1,0 +1,219 @@
+/**
+ * Deterministic, offline-safe fixture for the W11.5 nugget feed.
+ *
+ * WHY A FIXTURE: a live door DOES exist (see `services/nuggetApi.ts` — nuggets land in
+ * hellgraph-service as nodes labelled `KnowledgeNugget`, readable via
+ * `GET /api/graph/query?label=KnowledgeNugget`), but it only returns anything once
+ * `apps/nugget-extractor` has actually ingested a document into the graph the cockpit is
+ * pointed at. In dev, in tests, and on any environment that has not run an extraction, the
+ * feed falls back to THIS — and says so on screen, loudly, the way StudioWarrant does.
+ *
+ * The values are faithful to the producer, not decorative:
+ *   • ids are content-addressed exactly as `contract.local_id` computes them —
+ *     sha256(`${docRef}|${contentHash}`)[:12] + a 6-digit ordinal.
+ *   • `contentHash` is the real sha256 of SOURCE_TEXT below, in the schema's
+ *     `sha256-<64hex>` form.
+ *   • every direct-quote's span satisfies the family validator's invariant
+ *     `end - start === text.length`, and slices back out of SOURCE_TEXT byte-for-byte.
+ *     `src/__tests__/nuggetFeed.test.ts` re-derives all of it.
+ *   • `createdBy`, `specVersion` and the KKO type URIs are the producer's own constants.
+ *
+ * PRODUCER NOTE (deliberate, not an oversight): `apps/nugget-extractor` mints only
+ * `direct-quote` and `computed` — its module docstring is explicit that it runs no inference
+ * engine and calls no model. The `inferred` and `model-generated` entries below therefore
+ * carry a DIFFERENT `createdBy`, because in the real system they would come from a producer
+ * that does. Attributing them to the extractor would be a small lie in a fixture whose whole
+ * job is to demonstrate honest attribution.
+ */
+import type { KnowledgeNugget } from '../features/nuggets/types';
+
+/** The hashed source state every span below indexes into. */
+export const FIXTURE_SOURCE_TEXT = [
+  'Northwind Logistics Group — FY24 Annual Report (extract)',
+  '',
+  'Network revenue for FY24 was AUD 1,138.9m, up 22.6% on the prior corresponding period.',
+  'Supply chain disruption in Germany delayed 14 shipments in the second half.',
+  'The Group expects trading conditions to normalise during FY25.',
+].join('\n');
+
+export const FIXTURE_DOC_REF = 'urn:srcos:document:northwind-fy24-annual-report';
+
+/** Real sha256 of FIXTURE_SOURCE_TEXT, in the schema's `sha256-<64hex>` form. */
+export const FIXTURE_CONTENT_HASH =
+  'sha256-cbc77923930d0aec9104ca4c8a7c2baf16926cb46b7f7c9aed9892ac112cb459';
+
+const NUG = 'urn:srcos:knowledge-nugget:nug-9c70031e47ab-';
+const EXTRACTOR = 'urn:srcos:agent:nugget-extractor';
+const KKO_WRITTEN_INFO = 'http://kbpedia.org/ontologies/kko#WrittenInfo';
+const KKO_QUANTITY = 'http://kbpedia.org/ontologies/kko#Quantity';
+const RUN_REF = 'urn:srcos:run:nugget-extract-20260728T2214Z';
+const REGIME = 'nugget-extractor/quantity@v1';
+
+const src = (start: number, end: number) => ({
+  docRef: FIXTURE_DOC_REF,
+  span: { start, end },
+  contentHash: FIXTURE_CONTENT_HASH,
+});
+
+/** N0 — a verbatim cut. confidence 1.0: a direct quote is not a guess. */
+const N0: KnowledgeNugget = {
+  id: `${NUG}000000`,
+  type: 'KnowledgeNugget',
+  specVersion: '0.1.0',
+  sourceRef: src(58, 144),
+  warrant: { type: 'direct-quote', evidence: [], confidence: 1 },
+  text: 'Network revenue for FY24 was AUD 1,138.9m, up 22.6% on the prior corresponding period.',
+  kkoTypeRefs: [KKO_WRITTEN_INFO],
+  policyLabels: ['public-filing'],
+  provenance: [{ rel: 'extracted_by', ref: RUN_REF }],
+  createdBy: EXTRACTOR,
+  wallTime: '2026-07-28T22:14:03.114Z',
+  logicalTime: 1,
+};
+
+/**
+ * N1 — a currency quantity, normalized. CITES N0: the value's warrant names the span it was
+ * computed from. This is the production IFM lineage (document → typed value) the contract
+ * generalizes.
+ */
+const N1: KnowledgeNugget = {
+  id: `${NUG}000001`,
+  type: 'KnowledgeNugget',
+  specVersion: '0.1.0',
+  sourceRef: src(87, 99),
+  warrant: { type: 'computed', evidence: [N0.id], confidence: 1 },
+  text: 'Normalized quantity: 1.1389e+09 AUD (from "AUD 1,138.9m").',
+  kkoTypeRefs: [KKO_QUANTITY],
+  canonicalPayload: {
+    normalizationRegime: REGIME,
+    kind: 'currency',
+    value: 1138900000,
+    unit: 'AUD',
+    currencySymbol: null,
+    scale: 'million',
+    surface: 'AUD 1,138.9m',
+  },
+  policyLabels: ['public-filing'],
+  provenance: [
+    { rel: 'derived_from', ref: N0.id },
+    { rel: 'extracted_by', ref: RUN_REF },
+  ],
+  createdBy: EXTRACTOR,
+  wallTime: '2026-07-28T22:14:03.118Z',
+  logicalTime: 2,
+};
+
+/** N2 — a percentage, same regime, also citing N0. */
+const N2: KnowledgeNugget = {
+  id: `${NUG}000002`,
+  type: 'KnowledgeNugget',
+  specVersion: '0.1.0',
+  sourceRef: src(104, 109),
+  warrant: { type: 'computed', evidence: [N0.id], confidence: 1 },
+  text: 'Normalized quantity: 22.6 percent (from "22.6%").',
+  kkoTypeRefs: [KKO_QUANTITY],
+  canonicalPayload: {
+    normalizationRegime: REGIME,
+    kind: 'percentage',
+    value: 22.6,
+    unit: 'percent',
+    currencySymbol: null,
+    scale: null,
+    surface: '22.6%',
+  },
+  policyLabels: ['public-filing'],
+  provenance: [
+    { rel: 'derived_from', ref: N0.id },
+    { rel: 'extracted_by', ref: RUN_REF },
+  ],
+  createdBy: EXTRACTOR,
+  wallTime: '2026-07-28T22:14:03.121Z',
+  logicalTime: 3,
+};
+
+/** N3 — the second quote. */
+const N3: KnowledgeNugget = {
+  id: `${NUG}000003`,
+  type: 'KnowledgeNugget',
+  specVersion: '0.1.0',
+  sourceRef: src(145, 220),
+  warrant: { type: 'direct-quote', evidence: [], confidence: 1 },
+  text: 'Supply chain disruption in Germany delayed 14 shipments in the second half.',
+  kkoTypeRefs: [KKO_WRITTEN_INFO],
+  policyLabels: ['public-filing'],
+  provenance: [{ rel: 'extracted_by', ref: RUN_REF }],
+  createdBy: EXTRACTOR,
+  wallTime: '2026-07-28T22:14:03.124Z',
+  logicalTime: 4,
+};
+
+/**
+ * N4 — an INFERENCE from two cited quotes. Note the different producer: the extractor runs no
+ * inference engine, so this could not have come from it.
+ */
+const N4: KnowledgeNugget = {
+  id: `${NUG}000004`,
+  type: 'KnowledgeNugget',
+  specVersion: '0.1.0',
+  sourceRef: src(145, 220),
+  warrant: { type: 'inferred', evidence: [N0.id, N3.id], confidence: 0.71 },
+  text: 'European distribution was a material drag on FY24 network revenue.',
+  kkoTypeRefs: [KKO_WRITTEN_INFO],
+  policyLabels: ['public-filing', 'analyst-derived'],
+  provenance: [
+    { rel: 'derived_from', ref: N0.id },
+    { rel: 'derived_from', ref: N3.id },
+    { rel: 'extracted_by', ref: 'urn:srcos:run:reasoning-council-20260728T2231Z' },
+  ],
+  createdBy: 'urn:srcos:agent:reasoning-council',
+  wallTime: '2026-07-28T22:31:47.002Z',
+  logicalTime: 5,
+};
+
+/**
+ * N5 — MODEL-GENERATED. Evidence-free, which the schema permits precisely because this class
+ * is admissibility-discounted regardless. Its `sourceRef.span` is the CONDITIONING WINDOW the
+ * generation was given — it does not warrant the text, and the surface must not render it as
+ * though it did.
+ *
+ * Its stated confidence (0.62) sits in the same range as the inferred nugget's (0.71), which
+ * is the point: the two numbers are NOT comparable across warrant types. The schema is explicit
+ * that admissibility keys on warrant.type first and confidence second, so no amount of stated
+ * confidence promotes this out of the model-generated class.
+ */
+const N5: KnowledgeNugget = {
+  id: `${NUG}000005`,
+  type: 'KnowledgeNugget',
+  specVersion: '0.1.0',
+  sourceRef: src(221, 283),
+  warrant: { type: 'model-generated', evidence: [], confidence: 0.62 },
+  text: 'Management will likely consolidate European distribution into a single hub during FY25.',
+  kkoTypeRefs: [KKO_WRITTEN_INFO],
+  policyLabels: ['model-output'],
+  provenance: [{ rel: 'extracted_by', ref: 'urn:srcos:run:summarizer-20260728T2240Z' }],
+  createdBy: 'urn:srcos:agent:summarizer',
+  wallTime: '2026-07-28T22:40:12.880Z',
+  logicalTime: 6,
+};
+
+/** Newest first, the order the feed renders. */
+export const FIXTURE_NUGGETS: KnowledgeNugget[] = [N5, N4, N3, N2, N1, N0];
+
+/**
+ * A payload that will NOT parse — carried so the feed's fail-closed path is demonstrable
+ * rather than merely asserted. It is a `computed` warrant citing no evidence, which the
+ * schema's if/then forbids. The feed shows it as unreadable, with the reason, and does not
+ * render it as a nugget.
+ */
+export const FIXTURE_MALFORMED = {
+  id: `${NUG}000009`,
+  type: 'KnowledgeNugget',
+  specVersion: '0.1.0',
+  sourceRef: src(0, 56),
+  warrant: { type: 'computed', evidence: [], confidence: 0.9 },
+  text: 'Northwind Logistics Group — FY24 Annual Report (extract)',
+  policyLabels: [],
+  createdBy: EXTRACTOR,
+  wallTime: '2026-07-28T22:14:03.130Z',
+  logicalTime: 9,
+};

--- a/apps/socioprophet-web/src/data/warrantFixture.ts
+++ b/apps/socioprophet-web/src/data/warrantFixture.ts
@@ -31,6 +31,9 @@ export const FIXTURE_QUESTION = 'how many suppliers in Germany are delayed';
 /** Character offsets are real offsets into FIXTURE_QUESTION — every span slices back exactly. */
 const SPAN = {
   howMany: { start: 0, end: 8, text: 'how many', tokenIndices: [0, 1] },
+  /** Sub-span of `howMany` — an OVERLAPPING annotation, kept to exercise the overlay's
+   *  overlap path. The engine emits these; a surface that drops them is the W11.4 bug. */
+  many: { start: 4, end: 8, text: 'many', tokenIndices: [1] },
   suppliers: { start: 9, end: 18, text: 'suppliers', tokenIndices: [2] },
   germany: { start: 22, end: 29, text: 'Germany', tokenIndices: [4] },
   delayed: { start: 34, end: 41, text: 'delayed', tokenIndices: [6] },
@@ -456,11 +459,33 @@ export const FIXTURE_COMPILATION: NlqCompilation = {
     sha256: 'sha256:4f1b9c2e8a7d6543210fedcba9876543210abcdef0123456789abcdef01234567',
   },
   tokens: FIXTURE_TOKENS,
+  /**
+   * The FULL annotation list — every competitor, exactly as the engine keeps it.
+   *
+   * `compileQuestion` (nlq.ts @ v0.4.45 :1160-1174) sorts the raw annotations by
+   * (start, end, conceptRef, source) and puts THAT list on the compilation, while handing the
+   * search a separate view deduped to one entry per (span, concept). This list is faithful to
+   * the first: sorted the same way, and carrying the competitors the search view collapses.
+   *
+   * Four kinds of ambiguity are represented, because W11.4 exists to render them:
+   *   • howMany   one concept, TWO annotators agreeing at different confidences.
+   *   • many      an OVERLAPPING sub-span of howMany that no plan node binds.
+   *   • suppliers two rival types (the entity vs. its contract).
+   *   • Germany   country vs. football team — consumed by a BINDING, not a node grounding.
+   *   • delayed   THE case: the plan binds DelayedStatus (0.88) while LateShipment (0.91)
+   *               scored higher and lost. Confidence order and the plan's choice disagree,
+   *               and before this surface existed nothing on screen said so.
+   */
   annotations: [
+    { tokenSpan: SPAN.howMany, conceptRef: 'urn:srcos:action:Count', source: 'kko-semantic', confidence: 0.9 },
     { tokenSpan: SPAN.howMany, conceptRef: 'urn:srcos:action:Count', source: 'lexicon', confidence: 0.94 },
+    { tokenSpan: SPAN.many, conceptRef: 'urn:srcos:concept:Quantity', source: 'kko-semantic', confidence: 0.55 },
     { tokenSpan: SPAN.suppliers, conceptRef: 'urn:srcos:type:Supplier', source: 'lexicon', confidence: 0.97 },
+    { tokenSpan: SPAN.suppliers, conceptRef: 'urn:srcos:type:SupplierContract', source: 'kko-semantic', confidence: 0.62 },
     { tokenSpan: SPAN.germany, conceptRef: 'urn:srcos:concept:Germany', source: 'kko-semantic', confidence: 0.81 },
+    { tokenSpan: SPAN.germany, conceptRef: 'urn:srcos:concept:GermanyNationalTeam', source: 'lexicon', confidence: 0.44 },
     { tokenSpan: SPAN.delayed, conceptRef: 'urn:srcos:concept:DelayedStatus', source: 'lexicon', confidence: 0.88 },
+    { tokenSpan: SPAN.delayed, conceptRef: 'urn:srcos:concept:LateShipment', source: 'kko-semantic', confidence: 0.91 },
   ],
   snapshot: { seq: 41207, nodes: 128_940, edges: 411_663 },
   weights: DEFAULT_SENSE_WEIGHTS,

--- a/apps/socioprophet-web/src/features/depth/expertise.ts
+++ b/apps/socioprophet-web/src/features/depth/expertise.ts
@@ -1,0 +1,218 @@
+/**
+ * W11.6 — expertise-adaptive depth (DARPA TA-E).
+ *
+ * The same answer, rendered at the depth its consumer can use: novice / journeyman / expert.
+ * Progressive disclosure bound to a STORED preference (see `stores/settings.ts`), not a
+ * per-page toggle that nobody ever flips.
+ *
+ * ── THE ONE RULE ───────────────────────────────────────────────────────────────────────────
+ * Depth changes what is SHOWN. It never changes what is CLAIMED.
+ *
+ * A novice view may hide the evidence URNs, the span arithmetic and the normalization regime.
+ * It may NOT make a weak warrant look strong. That is not a style guideline here — it is
+ * enforced two ways, both testable:
+ *
+ *   1. `DepthPolicy` only ever gates SUPPORTING detail. There is deliberately no flag capable
+ *      of hiding a warrant type, a seal state, or a model-generated marker, so no future edit
+ *      can turn one off by flipping a boolean. What is not expressible cannot regress.
+ *
+ *   2. Every plain-language gloss declares the strength it CONVEYS, and `WARRANT_STRENGTH`
+ *      declares the strength the warrant actually HAS. `src/__tests__/expertiseDepth.test.ts`
+ *      asserts they are equal for every (kind × level) pair. A gloss that flattered its
+ *      warrant would fail the suite rather than ship.
+ *
+ * Note the asymmetry that follows from the rule: glossing DOWN is safe, glossing UP is not.
+ * The novice text for `model-generated` is blunter than the expert text, not softer.
+ */
+import type { WarrantKind } from '../warrant/types';
+
+export type Expertise = 'novice' | 'journeyman' | 'expert';
+
+/** Ordered shallow → deep. The stored preference is one of these. */
+export const EXPERTISE_LEVELS: readonly Expertise[] = ['novice', 'journeyman', 'expert'] as const;
+
+export function isExpertise(v: unknown): v is Expertise {
+  return typeof v === 'string' && (EXPERTISE_LEVELS as readonly string[]).includes(v);
+}
+
+/**
+ * Ordinal epistemic strength of a warrant kind. Higher = a stronger claim on truth.
+ *
+ * This is the yardstick the gloss test measures against, so it is deliberately coarse and
+ * explicit rather than derived from the ramp colour — colour must follow proof, not define it.
+ *
+ *   3  the source (or the chain) vouches for it directly
+ *   2  derived from things that are vouched for
+ *   0  produced by a model; the source does not support it
+ */
+export const WARRANT_STRENGTH: Record<WarrantKind, number> = {
+  // source- or chain-warranted
+  'direct-quote': 3,
+  'token-span': 3,
+  receipt: 3,
+  // derived from warranted inputs
+  computed: 2,
+  inferred: 2,
+  'registry-default': 2,
+  // invented
+  'model-generated': 0,
+  ungrounded: 0,
+};
+
+/**
+ * What a given depth reveals. EVERY field here is supporting detail.
+ *
+ * Warrant type, seal state, the unsealed reason and the model-generated marker are absent by
+ * design: they are unconditional, so there is no switch to get wrong.
+ */
+export interface DepthPolicy {
+  level: Expertise;
+  /** 0 novice … 2 expert. */
+  rank: number;
+  label: string;
+  /** What this level is for, shown next to the control. */
+  blurb: string;
+  /** Raw URNs, content hashes, receipt ids. */
+  showRawRefs: boolean;
+  /** `[start,end)` character arithmetic. */
+  showSpanOffsets: boolean;
+  /** The warrant's cited evidence refs, itemized. */
+  showEvidenceList: boolean;
+  /** Typed provenance chain links (derived_from, extracted_by, supersedes). */
+  showProvenanceChain: boolean;
+  /** Policy labels attached by producers or the policy fabric. */
+  showPolicyLabels: boolean;
+  /** The normalized machine-readable payload + its normalization regime. */
+  showCanonicalPayload: boolean;
+  /** W11.4: the competing concepts a span carried beyond the one the plan bound. */
+  showLosingCandidates: boolean;
+  /** Numeric confidences and annotator names. */
+  showConfidence: boolean;
+  /** Truncate long nugget text to this many characters; null = never truncate. */
+  maxTextChars: number | null;
+}
+
+const POLICIES: Record<Expertise, DepthPolicy> = {
+  novice: {
+    level: 'novice',
+    rank: 0,
+    label: 'Novice',
+    blurb: 'The claim and how far to trust it. Supporting detail stays folded away.',
+    showRawRefs: false,
+    showSpanOffsets: false,
+    showEvidenceList: false,
+    showProvenanceChain: false,
+    showPolicyLabels: false,
+    showCanonicalPayload: false,
+    showLosingCandidates: false,
+    showConfidence: false,
+    maxTextChars: 240,
+  },
+  journeyman: {
+    level: 'journeyman',
+    rank: 1,
+    label: 'Journeyman',
+    blurb: 'Adds the evidence, the competing readings, and stated confidence.',
+    showRawRefs: false,
+    showSpanOffsets: true,
+    showEvidenceList: true,
+    showProvenanceChain: false,
+    showPolicyLabels: true,
+    showCanonicalPayload: false,
+    showLosingCandidates: true,
+    showConfidence: true,
+    maxTextChars: 600,
+  },
+  expert: {
+    level: 'expert',
+    rank: 2,
+    label: 'Expert',
+    blurb: 'Everything on the record: URNs, hashes, provenance chain, normalization regime.',
+    showRawRefs: true,
+    showSpanOffsets: true,
+    showEvidenceList: true,
+    showProvenanceChain: true,
+    showPolicyLabels: true,
+    showCanonicalPayload: true,
+    showLosingCandidates: true,
+    showConfidence: true,
+    maxTextChars: null,
+  },
+};
+
+export function depthPolicy(level: Expertise): DepthPolicy {
+  return POLICIES[level] ?? POLICIES.novice;
+}
+
+/** A depth-appropriate wording, plus the epistemic strength it claims to convey. */
+export interface WarrantGloss {
+  text: string;
+  /** MUST equal WARRANT_STRENGTH[kind]. Proven by test, for every kind × level. */
+  conveys: number;
+}
+
+/**
+ * Plain-language readings of each warrant kind, per depth.
+ *
+ * Read the `model-generated` row: the novice wording is the bluntest of the three. That is the
+ * asymmetry the rule demands — when in doubt, a shallower view must warn harder, not softer.
+ */
+const GLOSSES: Record<WarrantKind, Record<Expertise, string>> = {
+  'direct-quote': {
+    novice: 'Quoted word-for-word from the source.',
+    journeyman: 'The exact source span, cut from the document — the source itself warrants it.',
+    expert: 'direct-quote: text is byte-identical to sourceRef.span over the hashed source state.',
+  },
+  'token-span': {
+    novice: 'Taken straight from the words you asked.',
+    journeyman: 'Grounded in the question text — it points back at the characters that evoked it.',
+    expert: 'token-span grounding: conceptRef bound from an annotated span of the question.',
+  },
+  receipt: {
+    novice: 'Backed by a tamper-evident record.',
+    journeyman: 'Warranted by a receipt on the gateway chain rather than by a plan node.',
+    expert: 'receipt warrant: in-toto statement on the gateway chain, Ed25519-signed, seq-bound.',
+  },
+  computed: {
+    novice: 'Worked out from numbers stated in the source.',
+    journeyman: 'Calculated from cited source values under a declared normalization regime.',
+    expert: 'computed: deterministic normalization over cited values; regime declared in canonicalPayload.',
+  },
+  inferred: {
+    novice: 'Reasoned from things the source says — a step beyond quoting.',
+    journeyman: 'Follows by stated inference from cited premises. The premises are warranted; this step is reasoning.',
+    expert: 'inferred: entailment from cited premises; schema requires ≥1 evidence ref.',
+  },
+  'registry-default': {
+    novice: 'Filled in from a standard setting, not from your question.',
+    journeyman: 'Supplied by an ambient typed value the registry vouches for, not by the question text.',
+    expert: 'registry-default grounding: slot filled from a registered default; no token span.',
+  },
+  'model-generated': {
+    novice: 'Written by the AI. It is NOT in the source — treat it as a suggestion.',
+    journeyman: 'Produced by a model from the source window, and not warranted by it. Discounted wherever used.',
+    expert: 'model-generated: unwarranted by sourceRef; admissibility-discounted, never launderable.',
+  },
+  ungrounded: {
+    novice: 'Invented by the planner. Nothing in your question asked for it.',
+    journeyman: 'Not grounded in the question. Filed as a model-generated claim and discounted by the admissibility gate.',
+    expert: 'ungrounded grounding: no token span; admissibility ruling carries the discount.',
+  },
+};
+
+/** The gloss for a warrant kind at a depth, tagged with the strength it conveys. */
+export function warrantGloss(kind: WarrantKind, level: Expertise): WarrantGloss {
+  const byLevel = GLOSSES[kind];
+  // An unknown kind must never borrow a confident gloss. Strength 0, and it says so.
+  if (!byLevel) return { text: 'Unrecognized warrant — treated as unproven.', conveys: 0 };
+  return { text: byLevel[level] ?? byLevel.novice, conveys: WARRANT_STRENGTH[kind] ?? 0 };
+}
+
+/** Truncate to the depth's budget, on a word boundary, with an explicit ellipsis. */
+export function clampText(text: string, policy: DepthPolicy): { text: string; truncated: boolean } {
+  const max = policy.maxTextChars;
+  if (max === null || text.length <= max) return { text, truncated: false };
+  const cut = text.slice(0, max);
+  const sp = cut.lastIndexOf(' ');
+  return { text: (sp > max * 0.6 ? cut.slice(0, sp) : cut).trimEnd() + '…', truncated: true };
+}

--- a/apps/socioprophet-web/src/features/nuggets/types.ts
+++ b/apps/socioprophet-web/src/features/nuggets/types.ts
@@ -1,0 +1,226 @@
+/**
+ * KnowledgeNugget — the estate's L2 content grain, made renderable.
+ *
+ * STRUCTURAL MIRROR of `KnowledgeNugget.json` @ specVersion 0.1.0 (sourceos-spec #210, vendored
+ * into `apps/nugget-extractor/src/nugget_extractor/schemas/`). Copied field-for-field, not
+ * invented. The producer is `apps/nugget-extractor` (#1042).
+ *
+ * ── THE NORMATIVE RULE THIS FILE EXISTS TO KEEP ────────────────────────────────────────────
+ * From the schema's own description:
+ *
+ *   "warrant.type = model-generated MUST remain visibly distinguishable on every downstream
+ *    surface — retrieval, ranking, rendering, and admissibility weighting all discount
+ *    model-generated nuggets relative to source-warranted ones, and no downstream transform
+ *    may launder a model-generated nugget into a source-warranted one."
+ *
+ * So: no mapping in this file ever widens a warrant. Unparseable input becomes `unreadable`,
+ * which is UNKNOWN — deliberately not "model-generated" (we did not establish that) and
+ * deliberately not a failure verdict (we did not check anything). It is simply not readable,
+ * and it says so.
+ */
+import type { NuggetWarrantType, TokenSpan, WarrantInput } from '../warrant/types';
+
+export type { NuggetWarrantType };
+
+/** KnowledgeNugget.json → sourceRef.span */
+export interface NuggetSpan {
+  /** 0-based inclusive character offset into the hashed source text. */
+  start: number;
+  /** 0-based exclusive offset. For direct-quote, `end - start === text.length` (validator-enforced). */
+  end: number;
+  /** 1-based page, for paginated sources. */
+  page?: number;
+}
+
+/** KnowledgeNugget.json → sourceRef */
+export interface NuggetSourceRef {
+  /** URN of the governed source document. `urn:srcos:<kind>:<local-id>`. */
+  docRef: string;
+  /**
+   * The span within the hashed source text. For `model-generated` this is the CONDITIONING
+   * WINDOW the generation was given — per the schema, it does NOT warrant the text.
+   */
+  span: NuggetSpan;
+  /** `sha256-<64 hex>`. Pins the nugget to an immutable source state so offsets cannot drift. */
+  contentHash: string;
+}
+
+/** KnowledgeNugget.json → warrant */
+export interface NuggetWarrant {
+  type: NuggetWarrantType;
+  /**
+   * Evidence refs grounding the warrant. Schema invariant: `computed` and `inferred` MUST cite
+   * at least one — a derivation with no cited inputs is not a derivation. `direct-quote` is
+   * grounded by sourceRef itself; `model-generated` may be evidence-free, which is exactly why
+   * it is admissibility-discounted.
+   */
+  evidence: string[];
+  /**
+   * Producer-stated confidence, 0..1. NOT admissibility: the schema is explicit that
+   * admissibility is a function of warrant.type FIRST (model-generated is discounted whatever
+   * its confidence) and confidence second. The UI must never let this number outrank the type.
+   */
+  confidence: number;
+}
+
+export interface NuggetProvenanceLink {
+  /** e.g. derived_from, extracted_by, supersedes. */
+  rel: string;
+  ref: string;
+}
+
+/** KnowledgeNugget.json @ 0.1.0 */
+export interface KnowledgeNugget {
+  id: string;
+  type: 'KnowledgeNugget';
+  specVersion: string;
+  sourceRef: NuggetSourceRef;
+  warrant: NuggetWarrant;
+  text: string;
+  kkoTypeRefs?: string[];
+  canonicalPayload?: unknown;
+  provenance?: NuggetProvenanceLink[];
+  policyLabels: string[];
+  createdBy: string;
+  wallTime: string;
+  /** Non-negative integer, or an encoded vector/hybrid clock string. */
+  logicalTime: number | string;
+}
+
+/**
+ * A feed entry. A payload that will not parse is KEPT as `ok: false` with the reason, never
+ * dropped and never coerced into a nugget with default fields.
+ *
+ * Why keep it at all: a silently discarded item makes the feed look cleaner than the data is.
+ * The count of unreadable items is itself a signal, and the surface shows it.
+ */
+export type FeedItem =
+  | { ok: true; nugget: KnowledgeNugget; nodeId: string }
+  | { ok: false; nodeId: string; reason: string };
+
+const WARRANT_TYPES: readonly NuggetWarrantType[] = [
+  'direct-quote',
+  'computed',
+  'inferred',
+  'model-generated',
+];
+
+export function isNuggetWarrantType(v: unknown): v is NuggetWarrantType {
+  return typeof v === 'string' && (WARRANT_TYPES as readonly string[]).includes(v);
+}
+
+const str = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
+const num = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
+
+/**
+ * Parse one nugget, fail-closed.
+ *
+ * Every required field of the schema is checked. A nugget missing or mistyping ANY of them is
+ * returned as unreadable with the field named — because the alternative (filling a default) is
+ * how a `model-generated` nugget would eventually get read as something better.
+ *
+ * `warrant.type` is checked against the CLOSED v0.1 enum. An unrecognized value is unreadable,
+ * not silently downgraded to a known member: inventing a type is how a contract bump upstream
+ * turns into a wrong colour downstream.
+ */
+export function parseNugget(raw: unknown, nodeId = ''): FeedItem {
+  const bad = (reason: string): FeedItem => ({ ok: false, nodeId, reason });
+  if (!raw || typeof raw !== 'object') return bad('payload is not an object');
+  const o = raw as Record<string, unknown>;
+
+  if (!str(o['id'])) return bad('missing id');
+  const id = o['id'];
+  if (o['type'] !== 'KnowledgeNugget') return bad(`type is not KnowledgeNugget (got ${String(o['type'])})`);
+  if (!str(o['specVersion'])) return bad('missing specVersion');
+  if (!str(o['text'])) return bad('missing text');
+  if (!str(o['createdBy'])) return bad('missing createdBy');
+  if (!str(o['wallTime'])) return bad('missing wallTime');
+  const logical = o['logicalTime'];
+  if (!num(logical) && !str(logical)) return bad('missing logicalTime');
+
+  const srcRaw = o['sourceRef'];
+  if (!srcRaw || typeof srcRaw !== 'object') return bad('missing sourceRef');
+  const src = srcRaw as Record<string, unknown>;
+  const spanRaw = src['span'];
+  if (!spanRaw || typeof spanRaw !== 'object') return bad('missing sourceRef.span');
+  const sp = spanRaw as Record<string, unknown>;
+  if (!num(sp['start']) || !num(sp['end'])) return bad('sourceRef.span offsets are not numbers');
+  if (!str(src['docRef'])) return bad('missing sourceRef.docRef');
+  if (!str(src['contentHash'])) return bad('missing sourceRef.contentHash');
+
+  const wRaw = o['warrant'];
+  if (!wRaw || typeof wRaw !== 'object') return bad('missing warrant');
+  const w = wRaw as Record<string, unknown>;
+  if (!isNuggetWarrantType(w['type'])) {
+    return bad(`unrecognized warrant.type: ${String(w['type'])}`);
+  }
+  if (!num(w['confidence'])) return bad('missing warrant.confidence');
+  const evidence = Array.isArray(w['evidence']) ? w['evidence'].filter(str) : [];
+  // Schema invariant, re-checked here: a derivation that cites nothing is not a derivation.
+  if ((w['type'] === 'computed' || w['type'] === 'inferred') && evidence.length === 0) {
+    return bad(`${w['type']} warrant cites no evidence (schema requires >= 1)`);
+  }
+
+  const span: NuggetSpan = { start: sp['start'], end: sp['end'] };
+  if (num(sp['page'])) span.page = sp['page'];
+
+  const nugget: KnowledgeNugget = {
+    id,
+    type: 'KnowledgeNugget',
+    specVersion: o['specVersion'],
+    sourceRef: { docRef: src['docRef'], span, contentHash: src['contentHash'] },
+    warrant: { type: w['type'], evidence, confidence: w['confidence'] },
+    text: o['text'],
+    kkoTypeRefs: Array.isArray(o['kkoTypeRefs']) ? o['kkoTypeRefs'].filter(str) : [],
+    policyLabels: Array.isArray(o['policyLabels']) ? o['policyLabels'].filter(str) : [],
+    createdBy: o['createdBy'],
+    wallTime: o['wallTime'],
+    logicalTime: logical,
+  };
+  if ('canonicalPayload' in o) nugget.canonicalPayload = o['canonicalPayload'];
+  if (Array.isArray(o['provenance'])) {
+    nugget.provenance = o['provenance']
+      .filter((p): p is Record<string, unknown> => !!p && typeof p === 'object')
+      .filter((p) => str(p['rel']) && str(p['ref']))
+      .map((p) => ({ rel: p['rel'] as string, ref: p['ref'] as string }));
+  }
+  return { ok: true, nugget, nodeId: nodeId || id };
+}
+
+/**
+ * The nugget's warrant, as the `<Warrant>` primitive's input.
+ *
+ * TWO decisions here are load-bearing:
+ *
+ * 1. `span` is supplied ONLY for `direct-quote`. `<Warrant>` renders `span` as "Source span" —
+ *    the characters the claim points back at — and for a direct quote that is exactly true
+ *    (the schema forces `end - start === text.length`). For computed / inferred /
+ *    model-generated the span is the CONDITIONING WINDOW, and the schema says outright that it
+ *    does not warrant the text. Passing it anyway would render an unwarranted claim as though
+ *    it pointed at proof. The window is still shown on the card — labelled as what it is.
+ *
+ * 2. No `seal` and no `walk` are supplied, so every nugget resolves to `unknown`.
+ *    KnowledgeNugget@0.1.0 has no receipt field: `apps/nugget-extractor`'s emitter seals the
+ *    BATCH (one `POST /v1/compute kind=nugget-emit` receipt per document), not the nugget. So
+ *    per-nugget seal state is genuinely unknown — which is not "unsealed", and is very much
+ *    not "sealed". Fabricating a seal here is the exact failure #1052 closed.
+ */
+export function nuggetWarrantInput(n: KnowledgeNugget): WarrantInput {
+  const input: WarrantInput = { claim: n.text, kind: n.warrant.type };
+  if (n.warrant.type === 'direct-quote') {
+    const span: TokenSpan = {
+      start: n.sourceRef.span.start,
+      end: n.sourceRef.span.end,
+      text: n.text,
+      tokenIndices: [],
+    };
+    input.span = span;
+  }
+  return input;
+}
+
+/** Short display form of a URN or URI: the last meaningful segment. */
+export function refLabel(ref: string): string {
+  const tail = ref.split(/[:/#]/).filter(Boolean).pop();
+  return tail && tail.length > 0 ? tail : ref;
+}

--- a/apps/socioprophet-web/src/features/warrant/annotations.ts
+++ b/apps/socioprophet-web/src/features/warrant/annotations.ts
@@ -1,0 +1,275 @@
+/**
+ * W11.4 — the annotation overlay model. Ambiguity is data, not noise.
+ *
+ * THE LESSON (EBA): one token routinely carries SEVERAL competing ontology annotations, and a
+ * surface that renders only the one the plan bound has quietly deleted the most interesting
+ * fact on the screen — that there was a choice, and that something chose.
+ *
+ * The engine does not hide this. `compileQuestion` (hellgraph `ts/src/nlq.ts` @ v0.4.45, line
+ * ~1160) keeps the FULL annotation list on the compilation and hands the search a separate,
+ * deduped view:
+ *
+ *     const annotations = raw.sort(…)                    // ← everything, kept for provenance
+ *     const bySpanConcept = new Map<string, TokenAnnotation>()
+ *     …                                                   // one per (span, concept), best confidence
+ *     const searchAnnotations = [...bySpanConcept.values()]
+ *
+ * So `NlqCompilation.annotations` already carries every competitor, including several distinct
+ * `conceptRef`s over the same characters and the same concept proposed by several annotators.
+ * The cockpit's job is only to stop throwing that away.
+ *
+ * This module is PURE and framework-free so the honesty rules below are unit-testable:
+ *
+ *   1. Every candidate for a span is kept. Nothing is filtered by confidence.
+ *   2. "Used" is read from the PLAN's provenance, never inferred from confidence rank. When the
+ *      plan bound a lower-confidence concept, `overrodeTopConfidence` records exactly that.
+ *   3. A span nothing consumed is `consumed: false` — reported as unconsumed, never as
+ *      implicitly fine, and never silently omitted.
+ *   4. Overlapping spans cannot be laid out in one linear run, so the ones that do not fit are
+ *      surfaced in `overlapped` rather than dropped. Dropping them would re-commit the exact
+ *      sin this surface exists to fix.
+ */
+import { planNodes, type NodeProvenance, type PlanNode, type TokenAnnotation, type TokenSpan } from './types';
+
+/** How a plan took hold of a span. Both count as consumption — see `gatherConsumption`. */
+export type ConsumptionVia = 'grounding' | 'binding';
+
+export interface ConsumingNode {
+  nodeId: string;
+  actionName: string;
+  via: ConsumptionVia;
+  /** The declared input name, for `via: 'binding'`. */
+  input?: string;
+}
+
+/** One ontology concept proposed for a span, and whether the plan actually took it. */
+export interface ConceptCandidate {
+  conceptRef: string;
+  /** Which annotator proposed it (`lexicon`, `kko-semantic`, or a caller's own). */
+  source: string;
+  /** Annotator confidence in [0,1]. Carried through from the engine; does NOT gate the search. */
+  confidence: number;
+  /** True when the selected plan bound THIS concept for THIS span. Read from the plan, not guessed. */
+  used: boolean;
+  /** Plan nodes that consumed it, when used. */
+  usedBy: ConsumingNode[];
+}
+
+/** A span of the question, with every concept that competed for it. */
+export interface AnnotatedSpan {
+  span: TokenSpan;
+  /** Used first, then confidence descending, then conceptRef for determinism. */
+  candidates: ConceptCandidate[];
+  /** True when the plan consumed any candidate on this span. */
+  consumed: boolean;
+  /** The conceptRef the plan bound, when consumed. */
+  usedConceptRef: string | null;
+  /** True when more than one DISTINCT conceptRef competed here — the ambiguity flag. */
+  ambiguous: boolean;
+  /** The highest-confidence candidate, regardless of what the plan did. */
+  topConfidenceConceptRef: string | null;
+  /**
+   * True when the plan bound a concept that was NOT the highest-confidence candidate. The single
+   * most valuable thing this overlay can tell an operator: the ranking and the choice disagreed.
+   */
+  overrodeTopConfidence: boolean;
+}
+
+/** A run of question text: either plain, or an annotated span. */
+export interface OverlaySegment {
+  text: string;
+  start: number;
+  end: number;
+  /** Null for the plain text between annotated spans. */
+  annotated: AnnotatedSpan | null;
+}
+
+export interface AnnotationOverlay {
+  question: string;
+  segments: OverlaySegment[];
+  /**
+   * Annotated spans that overlap an already-laid-out span and so have no place in the linear
+   * run. Kept and rendered separately — never discarded.
+   */
+  overlapped: AnnotatedSpan[];
+  /** Every annotated span, laid out or overlapped, in document order. */
+  spans: AnnotatedSpan[];
+  /** Spans carrying more than one distinct concept. */
+  ambiguousCount: number;
+  /** Spans where the plan did not take the top-confidence candidate. */
+  overriddenCount: number;
+  /** Annotated spans the plan consumed nothing from. */
+  unconsumedCount: number;
+}
+
+const spanKey = (s: TokenSpan) => `${s.start}:${s.end}`;
+
+/**
+ * (span, concept) → the plan nodes that took it.
+ *
+ * BOTH consumption routes are gathered, because the engine counts both. `scoreVariant`
+ * (nlq.ts @ v0.4.45 :1065-1071) adds a node's grounding span AND every binding span to the
+ * `consumed` set before computing coverage:
+ *
+ *     if (g.tokenSpan) { for (const i of g.tokenSpan.tokenIndices) consumed.add(i); … }
+ *     for (const b of node.bindings) {
+ *       if (b.tokenSpan) for (const i of b.tokenSpan.tokenIndices) consumed.add(i)
+ *     }
+ *
+ * …but `provenance` only ever gets a row PER NODE. So a span consumed solely by a binding —
+ * "Germany" filling a `region` input is the canonical case — is invisible in provenance while
+ * still counting toward coverage. An overlay reading provenance alone would print "annotated
+ * but unconsumed" next to a coverage figure of 100%, and one of the two would be lying.
+ */
+function gatherConsumption(
+  provenance: readonly NodeProvenance[],
+  plan: PlanNode | null,
+): Map<string, ConsumingNode[]> {
+  const consumedBy = new Map<string, ConsumingNode[]>();
+  const add = (span: TokenSpan, conceptRef: string, entry: ConsumingNode) => {
+    const k = `${spanKey(span)}|${conceptRef}`;
+    const list = consumedBy.get(k) ?? [];
+    // A node can appear once per route; don't double-count the same (node, route, input).
+    if (!list.some((e) => e.nodeId === entry.nodeId && e.via === entry.via && e.input === entry.input)) {
+      list.push(entry);
+    }
+    consumedBy.set(k, list);
+  };
+
+  for (const p of provenance) {
+    if (p.tokenSpan && p.conceptRef) {
+      add(p.tokenSpan, p.conceptRef, { nodeId: p.nodeId, actionName: p.actionName, via: 'grounding' });
+    }
+  }
+  if (plan) {
+    for (const node of planNodes(plan)) {
+      for (const b of node.bindings) {
+        if (b.tokenSpan && b.conceptRef) {
+          add(b.tokenSpan, b.conceptRef, {
+            nodeId: node.nodeId,
+            actionName: node.actionName,
+            via: 'binding',
+            input: b.input,
+          });
+        }
+      }
+    }
+  }
+  return consumedBy;
+}
+
+/**
+ * Build the overlay for one question + one plan variant.
+ *
+ * @param question    the compiled question — spans are character offsets into THIS string.
+ * @param annotations `NlqCompilation.annotations` — the full, undeduped competitor list.
+ * @param provenance  the SELECTED variant's `provenance` (node-level grounding).
+ * @param plan        the SELECTED variant's plan, so binding-level consumption is seen too.
+ */
+export function buildAnnotationOverlay(
+  question: string,
+  annotations: readonly TokenAnnotation[],
+  provenance: readonly NodeProvenance[],
+  plan: PlanNode | null = null,
+): AnnotationOverlay {
+  const consumedBy = gatherConsumption(provenance, plan);
+
+  // Group every annotation by the exact characters it covers.
+  const groups = new Map<string, { span: TokenSpan; anns: TokenAnnotation[] }>();
+  for (const a of annotations) {
+    const k = spanKey(a.tokenSpan);
+    const g = groups.get(k);
+    if (g) g.anns.push(a);
+    else groups.set(k, { span: a.tokenSpan, anns: [a] });
+  }
+
+  const spans: AnnotatedSpan[] = [...groups.values()]
+    .map(({ span, anns }) => {
+      const candidates: ConceptCandidate[] = anns.map((a) => {
+        const usedBy = consumedBy.get(`${spanKey(span)}|${a.conceptRef}`) ?? [];
+        return {
+          conceptRef: a.conceptRef,
+          source: a.source,
+          confidence: a.confidence,
+          used: usedBy.length > 0,
+          usedBy,
+        };
+      });
+
+      // Top confidence is computed over the candidates as proposed — deliberately NOT
+      // influenced by what the plan did, so the two can be compared.
+      const byConfidence = [...candidates].sort(
+        (x, y) => y.confidence - x.confidence || x.conceptRef.localeCompare(y.conceptRef),
+      );
+      const top = byConfidence[0] ?? null;
+      const used = candidates.find((c) => c.used) ?? null;
+      const distinctConcepts = new Set(candidates.map((c) => c.conceptRef));
+
+      candidates.sort(
+        (x, y) =>
+          Number(y.used) - Number(x.used) ||
+          y.confidence - x.confidence ||
+          x.conceptRef.localeCompare(y.conceptRef) ||
+          x.source.localeCompare(y.source),
+      );
+
+      return {
+        span,
+        candidates,
+        consumed: used !== null,
+        usedConceptRef: used?.conceptRef ?? null,
+        ambiguous: distinctConcepts.size > 1,
+        topConfidenceConceptRef: top?.conceptRef ?? null,
+        // Only meaningful when something WAS used: an unconsumed span did not override anything.
+        overrodeTopConfidence:
+          used !== null && top !== null && used.conceptRef !== top.conceptRef,
+      } satisfies AnnotatedSpan;
+    })
+    // Document order; longer spans first so a container is laid out before anything inside it.
+    .sort((a, b) => a.span.start - b.span.start || b.span.end - a.span.end);
+
+  // Lay out the linear run. Anything that would overlap is set aside, not dropped.
+  const segments: OverlaySegment[] = [];
+  const overlapped: AnnotatedSpan[] = [];
+  let cursor = 0;
+  for (const s of spans) {
+    if (s.span.start < cursor) {
+      overlapped.push(s);
+      continue;
+    }
+    if (s.span.start > cursor) {
+      segments.push({
+        text: question.slice(cursor, s.span.start),
+        start: cursor,
+        end: s.span.start,
+        annotated: null,
+      });
+    }
+    segments.push({
+      text: question.slice(s.span.start, s.span.end),
+      start: s.span.start,
+      end: s.span.end,
+      annotated: s,
+    });
+    cursor = s.span.end;
+  }
+  if (cursor < question.length) {
+    segments.push({ text: question.slice(cursor), start: cursor, end: question.length, annotated: null });
+  }
+
+  return {
+    question,
+    segments,
+    overlapped,
+    spans,
+    ambiguousCount: spans.filter((s) => s.ambiguous).length,
+    overriddenCount: spans.filter((s) => s.overrodeTopConfidence).length,
+    unconsumedCount: spans.filter((s) => !s.consumed).length,
+  };
+}
+
+/** Short display form of a concept URN: the last segment, which is the readable part. */
+export function conceptLabel(ref: string): string {
+  const tail = ref.split(/[:/#]/).filter(Boolean).pop();
+  return tail && tail.length > 0 ? tail : ref;
+}

--- a/apps/socioprophet-web/src/features/warrant/types.ts
+++ b/apps/socioprophet-web/src/features/warrant/types.ts
@@ -323,8 +323,20 @@ export function sealFromSpine(spine: SpineResult): SealOutcome {
  */
 export type WarrantSealState = 'sealed' | 'unsealed' | 'unknown';
 
+/**
+ * KnowledgeNugget warrant taxonomy — sourceos-spec `KnowledgeNugget.json` @ 0.1.0, the
+ * `warrant.type` enum, closed at v0.1 (widening it is a contract bump).
+ *
+ * This is a SECOND, independent warrant vocabulary. It is kept separate from `GroundingKind`
+ * on purpose: a nugget's `computed` is not a plan node's `registry-default`, and folding one
+ * into the other to save a union member would be precisely the laundering the schema's
+ * normative rule forbids ("no downstream transform may launder a model-generated nugget into
+ * a source-warranted one"). Two vocabularies, both rendered natively, neither translated.
+ */
+export type NuggetWarrantType = 'direct-quote' | 'computed' | 'inferred' | 'model-generated';
+
 /** How a claim earned its place — the warrant TYPE, distinct from whether it is sealed. */
-export type WarrantKind = GroundingKind | 'receipt';
+export type WarrantKind = GroundingKind | 'receipt' | NuggetWarrantType;
 
 export interface WarrantInput {
   /** What is being asserted. */
@@ -337,6 +349,13 @@ export interface WarrantInput {
   walk?: ReceiptVerifyWalk;
   /** Receipt id, when known but not yet walked. */
   receiptRef?: string;
+  /**
+   * Explicit warrant kind, for claims that are not NLQ plan nodes (a KnowledgeNugget's
+   * `warrant.type`). When set it WINS over the grounding-derived kind. Omit for plan nodes.
+   */
+  kind?: WarrantKind;
+  /** Source span, for claims that carry one without a `PlanGrounding` (nuggets). */
+  span?: TokenSpan;
 }
 
 export interface WarrantView {
@@ -381,7 +400,58 @@ const KIND_META: Record<WarrantKind, { label: string; blurb: string; epistemic: 
     blurb: 'Warranted by a receipt on the gateway chain rather than by a plan node.',
     epistemic: 'attested',
   },
+
+  // ── KnowledgeNugget warrants (sourceos-spec KnowledgeNugget.json @ 0.1.0) ──
+  // The ramp descends with the warrant: you can SEE a direct quote in the source; a computed
+  // value is derived from cited ones; an inference is derived from stated premises; a
+  // model-generated statement is a hypothesis the source does not support. `model-generated`
+  // shares the `hypothesis` rung with `ungrounded` because they are the same epistemic fact.
+  'direct-quote': {
+    label: 'direct quote',
+    blurb: 'The exact source span, cut from the document — warranted by the source itself.',
+    epistemic: 'observed',
+  },
+  computed: {
+    label: 'computed',
+    blurb: 'Derived by deterministic computation over cited source values, under a declared normalization regime.',
+    epistemic: 'derived',
+  },
+  inferred: {
+    label: 'inferred',
+    blurb: 'Follows by stated inference from cited premises. The premises are warranted; this step is reasoning.',
+    epistemic: 'derived',
+  },
+  'model-generated': {
+    label: 'model-generated',
+    blurb:
+      'Produced by a model conditioned on the source window, and NOT warranted by it. Admissibility-discounted wherever it is used.',
+    epistemic: 'hypothesis',
+  },
 };
+
+/** Warrant kinds the source itself vouches for — mirrors contract.py SOURCE_WARRANTED. */
+const SOURCE_WARRANTED: ReadonlySet<WarrantKind> = new Set<WarrantKind>([
+  'direct-quote',
+  'computed',
+  'inferred',
+  'token-span',
+]);
+
+/**
+ * True when a warrant is model-produced rather than source-warranted.
+ *
+ * The KnowledgeNugget schema makes this NORMATIVE: "model-generated MUST remain visibly
+ * distinguishable on every downstream surface". Surfaces call this rather than string-matching
+ * a label, so the rule has exactly one implementation to audit.
+ */
+export function isModelGenerated(kind: WarrantKind): boolean {
+  return kind === 'model-generated' || kind === 'ungrounded';
+}
+
+/** True when the source vouches for the content. `unknown`/invented kinds are never included. */
+export function isSourceWarranted(kind: WarrantKind): boolean {
+  return SOURCE_WARRANTED.has(kind);
+}
 
 const SEAL_LABEL: Record<WarrantSealState, string> = {
   sealed: 'sealed',
@@ -422,8 +492,15 @@ export function resolveSeal(input: WarrantInput): {
 
 /** Build the full renderable view. The one normalization every W11 surface goes through. */
 export function warrantView(input: WarrantInput): WarrantView {
-  const kind: WarrantKind = input.grounding ? input.grounding.kind : 'receipt';
-  const meta = KIND_META[kind];
+  // An explicit kind wins (nuggets); otherwise the plan node's grounding decides; a claim with
+  // neither is riding a receipt. Unknown kinds fall back to the `unknown` ramp rather than
+  // crashing or, worse, borrowing a confident label they did not earn.
+  const kind: WarrantKind = input.kind ?? (input.grounding ? input.grounding.kind : 'receipt');
+  const meta = KIND_META[kind] ?? {
+    label: String(kind),
+    blurb: 'Unrecognized warrant kind — treated as unproven.',
+    epistemic: 'unknown' as const,
+  };
   const { state, detail } = resolveSeal(input);
   const g = input.grounding;
   return {
@@ -445,8 +522,14 @@ export function warrantView(input: WarrantInput): WarrantView {
     // paints `unsealed` in --fail while `unknown` takes the desaturated --epi-unknown. So
     // "could not check" reads as absence, "checked and failed" reads as alarm, and neither
     // reads as proof.
+    //
+    // W11.5 note: this is why NO KnowledgeNugget reaches a confident ramp mode. A nugget
+    // carries no receipt, so its seal is `unknown`, so its ramp is `unknown` — regardless of
+    // how strong its WARRANT is. Warrant kind and seal state are different axes, and the ramp
+    // answers the seal one. NuggetCard distinguishes the warrant axis by hue at reduced
+    // strength, deliberately never at full ramp intensity.
     epistemic: state === 'sealed' ? (kind === 'receipt' ? 'attested' : meta.epistemic) : 'unknown',
-    span: g?.tokenSpan ?? null,
+    span: g?.tokenSpan ?? input.span ?? null,
     receiptRef: input.receiptRef ?? input.walk?.receipt_id ?? input.seal?.receiptRef ?? null,
     walk: input.walk ?? null,
     admissibility: g?.admissibility ?? null,

--- a/apps/socioprophet-web/src/pages/Studio.vue
+++ b/apps/socioprophet-web/src/pages/Studio.vue
@@ -23,6 +23,7 @@ import StudioOps from './studio/StudioOps.vue';
 import StudioGovernance from './studio/StudioGovernance.vue';
 import StudioCommons from './studio/StudioCommons.vue';
 import StudioWarrant from './studio/StudioWarrant.vue';
+import StudioNuggets from './studio/StudioNuggets.vue';
 
 type Sec = { id: string; label: string; ic: string; comp: any; sub: string; project?: boolean };
 const GROUPS: { group: string; items: Sec[] }[] = [
@@ -37,6 +38,7 @@ const GROUPS: { group: string; items: Sec[] }[] = [
     { id: 'analytics', label: 'Analytics', ic: '📈', comp: markRaw(Analytics), sub: 'PageRank / components on the Rust kernel' },
     { id: 'graphrag', label: 'GraphRAG', ic: '✦', comp: markRaw(GraphRAG), sub: 'Ask the graph, cited answers' },
     { id: 'warrant', label: 'Warrant', ic: '⊨', comp: markRaw(StudioWarrant), sub: 'The plan, the alternatives, and the receipt walk — proof made visible' },
+    { id: 'nuggets', label: 'Nugget Feed', ic: '◇', comp: markRaw(StudioNuggets), sub: 'Warrant-typed knowledge grains — a direct quote never reads like a model guess' },
     { id: 'resource', label: 'Resource Browser', ic: '◈', comp: markRaw(ResourceBrowser), sub: 'Dereferenceable Linked Data' },
   ]},
   { group: 'Reason & Resolve', items: [

--- a/apps/socioprophet-web/src/pages/studio/StudioNuggets.vue
+++ b/apps/socioprophet-web/src/pages/studio/StudioNuggets.vue
@@ -1,0 +1,401 @@
+<script setup lang="ts">
+// W11.5 — the nugget feed. JustIN delivery (DARPA TA-D) against the cockpit's pull-only reality.
+//
+// The three JustIN axes, and exactly how far each one actually gets today:
+//   just-in-time   PARTIAL. The graph read is real, but it is a POLL. There is no nugget
+//                  stream to subscribe to, so "push" is not claimed anywhere on this surface.
+//   just-enough    YES. W11.6 depth drives how much of each nugget renders.
+//   just-for-me    CLIENT-SIDE ONLY. The filters below are a view, not access control —
+//                  there is no grant plumbing to scope this feed. Said on screen, not hidden.
+//
+// Every nugget shows its warrant through the existing <Warrant> primitive, and a direct-quote
+// is built to read differently from a model-generated one at a glance — stripe, badge, and a
+// standing banner, none of which depth can switch off.
+import { computed, onMounted, ref } from 'vue';
+import NuggetCard from '../../components/nuggets/NuggetCard.vue';
+import DepthControl from '../../components/depth/DepthControl.vue';
+import { fetchNuggets, type NuggetFeedResult } from '../../services/nuggetApi';
+import { refLabel, type FeedItem, type NuggetWarrantType } from '../../features/nuggets/types';
+import { isSourceWarranted } from '../../features/warrant/types';
+import { useSettings } from '../../stores/settings';
+import type { Expertise } from '../../features/depth/expertise';
+
+const settings = useSettings();
+const level = computed<Expertise>(() => settings.expertise as Expertise);
+
+const feed = ref<NuggetFeedResult | null>(null);
+const busy = ref(false);
+const lastPolled = ref<string | null>(null);
+
+const WARRANT_TYPES: NuggetWarrantType[] = ['direct-quote', 'computed', 'inferred', 'model-generated'];
+/** Subscription: which warrant classes this reader wants. All on by default — hiding by
+ *  default would be a filter that quietly suppresses the weakest evidence. */
+const subscribed = ref<Set<NuggetWarrantType>>(new Set(WARRANT_TYPES));
+const query = ref('');
+
+async function load() {
+  busy.value = true;
+  try {
+    feed.value = await fetchNuggets();
+    lastPolled.value = new Date().toISOString().slice(11, 19);
+  } finally {
+    busy.value = false;
+  }
+}
+onMounted(load);
+
+function toggle(t: NuggetWarrantType) {
+  const next = new Set(subscribed.value);
+  if (next.has(t)) next.delete(t);
+  else next.add(t);
+  subscribed.value = next;
+}
+
+const ok = computed<FeedItem[]>(() => (feed.value?.items ?? []).filter((i) => i.ok));
+const unreadable = computed(() => (feed.value?.items ?? []).filter((i) => !i.ok));
+
+const visible = computed(() =>
+  ok.value.flatMap((i) => {
+    if (!i.ok) return [];
+    if (!subscribed.value.has(i.nugget.warrant.type)) return [];
+    const q = query.value.trim().toLowerCase();
+    if (q && !i.nugget.text.toLowerCase().includes(q) && !i.nugget.sourceRef.docRef.toLowerCase().includes(q)) {
+      return [];
+    }
+    return [i.nugget];
+  }),
+);
+
+/** How many readable nuggets the subscription is currently hiding. Always disclosed. */
+const filteredOut = computed(() => ok.value.length - visible.value.length);
+
+const counts = computed(() => {
+  const c: Record<string, number> = {};
+  for (const i of ok.value) if (i.ok) c[i.nugget.warrant.type] = (c[i.nugget.warrant.type] ?? 0) + 1;
+  return c;
+});
+
+/**
+ * The split that actually matters, over what is CURRENTLY VISIBLE — so the headline number
+ * tracks the filters instead of quietly describing a larger set the reader cannot see.
+ */
+const split = computed(() => {
+  const source = visible.value.filter((n) => isSourceWarranted(n.warrant.type)).length;
+  return { source, model: visible.value.length - source };
+});
+</script>
+
+<template>
+  <div class="nf">
+    <!-- Provenance of the surface itself, first, above everything it renders. -->
+    <div v-if="feed" class="nf-mode" :class="`m-${feed.mode}`">
+      <span class="nf-mode-tag">{{ feed.mode }}</span>
+      <span v-if="feed.mode === 'live'">
+        Read from the graph:
+        <code class="mono">GET /api/graph/query?label=KnowledgeNugget</code> on hellgraph-service,
+        where <code class="mono">apps/nugget-extractor</code> writes each nugget with its full
+        canonical JSON on the node.
+      </span>
+      <span v-else>
+        These nuggets are a FIXTURE, not live data. The live read failed and fixtures were shown
+        rather than an empty page — nothing below came off a graph.
+        <b class="nf-why">{{ feed.error }}</b>
+      </span>
+    </div>
+
+    <div class="card">
+      <div class="nf-head">
+        <div>
+          <h3>Nugget feed</h3>
+          <p class="desc">
+            The L2 content grain — warrant-typed fragments lifted from governed sources. Each one
+            states where it came from and how it is warranted.
+          </p>
+        </div>
+        <button class="btn ghost" type="button" :disabled="busy" @click="load">
+          {{ busy ? 'Polling…' : 'Poll' }}
+        </button>
+      </div>
+
+      <!-- Honest about the delivery model. -->
+      <p class="nf-pull">
+        <b>Pull, not push.</b> hellgraph-service exposes no nugget stream, so this is a manual
+        poll<span v-if="lastPolled"> — last read {{ lastPolled }}</span
+        >. Just-in-time delivery is not wired; calling this a live feed would overstate it.
+      </p>
+
+      <div class="nf-controls">
+        <div class="nf-subs">
+          <span class="nf-l">subscription</span>
+          <button
+            v-for="t in WARRANT_TYPES"
+            :key="t"
+            class="nf-sub"
+            type="button"
+            :class="[{ on: subscribed.has(t) }, `w-${t}`]"
+            :aria-pressed="subscribed.has(t)"
+            @click="toggle(t)"
+          >
+            {{ t }}<span class="nf-n tnum">{{ counts[t] ?? 0 }}</span>
+          </button>
+        </div>
+        <input v-model="query" type="text" class="nf-q" aria-label="Filter nuggets" placeholder="filter text or source…" />
+      </div>
+
+      <DepthControl />
+
+      <!-- Not access control. Stated where the filters are, so it cannot be mistaken. -->
+      <p class="nf-grant">
+        <b>Scope:</b> these filters are a client-side VIEW over everything the graph returned —
+        not grant scoping and not access control. Per-reader grant scoping (the Memory
+        Distribution Grant plane) is not reachable from this app: no grant service base is
+        configured, nuggets carry no grant claim, and hellgraph-service does not filter by one.
+        Wiring it is a follow-on.
+      </p>
+    </div>
+
+    <!-- The split, over what is on screen. Model-generated is never folded into a total. -->
+    <p v-if="visible.length" class="nf-split">
+      <span class="nf-split-src"
+        ><b class="tnum">{{ split.source }}</b> source-warranted</span
+      >
+      <span class="nf-split-mod"
+        ><b class="tnum">{{ split.model }}</b> model-generated</span
+      >
+      <span v-if="filteredOut > 0" class="nf-hidden">
+        · {{ filteredOut }} readable nugget{{ filteredOut === 1 ? '' : 's' }} hidden by your
+        subscription or filter
+      </span>
+    </p>
+    <p v-else-if="filteredOut > 0" class="nf-hidden">
+      All {{ filteredOut }} readable nugget{{ filteredOut === 1 ? '' : 's' }} hidden by your
+      subscription or filter.
+    </p>
+
+    <!-- Reachable and genuinely empty. Fixtures are NOT substituted here. -->
+    <div v-if="feed && feed.mode === 'live' && feed.emptyLive" class="card nf-empty">
+      <h3>No nuggets on this graph</h3>
+      <p class="desc">
+        The graph answered and holds no <code class="mono">KnowledgeNugget</code> nodes. That is a
+        real, empty result — not a loading state, and not a reason to show you fixtures. Run
+        <code class="mono">apps/nugget-extractor</code> against a document to populate it.
+      </p>
+    </div>
+
+    <div class="nf-list">
+      <NuggetCard v-for="n in visible" :key="n.id" :nugget="n" :level="level" />
+    </div>
+
+    <!-- Unreadable payloads: kept and counted, never dropped. -->
+    <div v-if="unreadable.length" class="card nf-bad">
+      <h3>{{ unreadable.length }} unreadable payload{{ unreadable.length === 1 ? '' : 's' }}</h3>
+      <p class="desc">
+        These did not parse against KnowledgeNugget 0.1.0, so they are not rendered as nuggets.
+        Unreadable is <b>unknown</b>, not invalid — nothing here was checked and found wanting;
+        it could not be read at all. They are listed because a silently dropped item would make
+        this feed look cleaner than the data is.
+      </p>
+      <ul class="nf-badlist">
+        <li v-for="(u, i) in unreadable" :key="i">
+          <code class="mono">{{ u.nodeId ? refLabel(u.nodeId) : '(no node id)' }}</code>
+          <span class="nf-badwhy">{{ u.ok ? '' : u.reason }}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.nf {
+  display: grid;
+  gap: 1rem;
+}
+.nf-mode {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 0.7rem;
+  border-radius: var(--r-2);
+  font-size: 0.72rem;
+  line-height: 1.5;
+  color: var(--ink-2);
+  background: var(--warn-wash);
+  border: 1px solid color-mix(in srgb, var(--warn) 34%, transparent);
+}
+.nf-mode.m-live {
+  background: var(--ok-wash);
+  border-color: color-mix(in srgb, var(--ok) 34%, transparent);
+}
+.nf-mode-tag {
+  color: var(--warn);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  font-size: 0.62rem;
+  font-weight: 700;
+  flex: 0 0 auto;
+}
+.m-live .nf-mode-tag {
+  color: var(--ok);
+}
+.nf-why {
+  display: block;
+  margin-top: 0.2rem;
+  color: var(--warn);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  font-weight: 400;
+  overflow-wrap: anywhere;
+}
+.nf-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.nf-head h3 {
+  margin: 0 0 0.3rem;
+}
+.nf-pull,
+.nf-grant {
+  margin: 0 0 0.7rem;
+  padding: 0.4rem 0.55rem;
+  border-radius: var(--r-1);
+  background: var(--sunken);
+  border: 1px solid var(--hairline);
+  color: var(--faint);
+  font-size: 0.66rem;
+  line-height: 1.5;
+}
+.nf-grant {
+  margin: 0.7rem 0 0;
+}
+.nf-pull b,
+.nf-grant b {
+  color: var(--ink-2);
+}
+.nf-controls {
+  display: flex;
+  gap: 0.7rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 0.7rem;
+}
+.nf-subs {
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.nf-l {
+  color: var(--faint);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.nf-sub {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid var(--border-2);
+  border-radius: var(--pill);
+  padding: 1px 9px;
+  font-size: 0.66rem;
+  cursor: pointer;
+  font-family: inherit;
+  opacity: 0.55;
+}
+.nf-sub.on {
+  opacity: 1;
+  color: var(--ink);
+  border-color: var(--hairline-strong);
+  background: var(--surface);
+}
+.nf-sub:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+/* Each subscription pill wears its own rung of the ramp. */
+.nf-sub.w-direct-quote.on {
+  color: var(--epi-observed);
+  border-color: color-mix(in srgb, var(--epi-observed) 50%, transparent);
+}
+.nf-sub.w-computed.on,
+.nf-sub.w-inferred.on {
+  color: var(--epi-derived);
+  border-color: color-mix(in srgb, var(--epi-derived) 50%, transparent);
+}
+.nf-sub.w-model-generated.on {
+  color: var(--epi-hypothesis);
+  border-color: color-mix(in srgb, var(--epi-hypothesis) 50%, transparent);
+}
+.nf-n {
+  color: var(--faint);
+  font-size: 0.6rem;
+}
+.nf-q {
+  flex: 1 1 14rem;
+  max-width: 22rem;
+}
+.nf-hidden {
+  margin: 0;
+  color: var(--faint);
+  font-size: 0.66rem;
+}
+.nf-split {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  align-items: baseline;
+  margin: 0;
+  font-size: 0.66rem;
+  color: var(--muted);
+}
+.nf-split-src b {
+  color: var(--epi-observed);
+}
+.nf-split-mod b {
+  color: var(--epi-hypothesis);
+}
+.nf-list {
+  display: grid;
+  gap: 0.7rem;
+}
+.nf-empty h3,
+.nf-bad h3 {
+  margin: 0 0 0.3rem;
+}
+.nf-bad {
+  border-color: color-mix(in srgb, var(--epi-hypothesis) 40%, transparent);
+}
+.nf-badlist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.3rem;
+}
+.nf-badlist li {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: baseline;
+  font-size: 0.66rem;
+  padding: 0.3rem 0.4rem;
+  border-radius: var(--r-1);
+  background: var(--sunken);
+  border-left: 3px solid var(--epi-unknown);
+}
+.nf-badwhy {
+  color: var(--epi-hypothesis);
+}
+.mono {
+  font-family: var(--mono);
+}
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/apps/socioprophet-web/src/pages/studio/StudioWarrant.vue
+++ b/apps/socioprophet-web/src/pages/studio/StudioWarrant.vue
@@ -13,6 +13,10 @@ import PlanTree from '../../components/warrant/PlanTree.vue';
 import VariantRail from '../../components/warrant/VariantRail.vue';
 import SenseMetricBadge from '../../components/warrant/SenseMetricBadge.vue';
 import Warrant from '../../components/warrant/Warrant.vue';
+import AnnotationOverlay from '../../components/warrant/AnnotationOverlay.vue';
+import DepthControl from '../../components/depth/DepthControl.vue';
+import { useSettings } from '../../stores/settings';
+import type { Expertise } from '../../features/depth/expertise';
 import { compileQuestion, verifyReceipt, type WarrantLoadMode } from '../../services/warrantApi';
 import {
   FIXTURE_QUESTION,
@@ -28,6 +32,9 @@ import type {
   SealOutcome,
   WarrantInput,
 } from '../../features/warrant/types';
+
+const settings = useSettings();
+const level = computed<Expertise>(() => settings.expertise as Expertise);
 
 const question = ref(FIXTURE_QUESTION);
 const compilation = ref<NlqCompilation | null>(null);
@@ -261,6 +268,28 @@ onMounted(run);
         that did not run cannot be rendered as proof, so the warrant above reads
         <b>unknown</b> until it does.
       </p>
+    </div>
+
+    <!-- W11.4 — the annotation overlay. Ambiguity is data, not noise. -->
+    <div v-if="compilation && selected" class="card">
+      <div class="wsurf-runhead">
+        <div>
+          <h3>Annotations · what each token could have meant</h3>
+          <p class="desc">
+            The compiler keeps every competing reading; the plan takes one. Hover or focus a lit
+            span to see the concepts that competed for it, and which one variant #{{ selected.rank }}
+            actually bound.
+          </p>
+        </div>
+        <DepthControl compact />
+      </div>
+      <AnnotationOverlay
+        :question="compilation.question"
+        :annotations="compilation.annotations"
+        :provenance="selected.provenance"
+        :plan="selected.plan"
+        :level="level"
+      />
     </div>
 
     <div v-if="compilation && selected" class="grid cols-2 wsurf-body">

--- a/apps/socioprophet-web/src/services/nuggetApi.ts
+++ b/apps/socioprophet-web/src/services/nuggetApi.ts
@@ -1,0 +1,122 @@
+/**
+ * KnowledgeNugget feed API (W11.5).
+ *
+ * ── THE LIVE DOOR IS REAL, AND IT IS THIS ONE ──────────────────────────────────────────────
+ * `apps/nugget-extractor` (#1042) writes each nugget into hellgraph-service as a graph node:
+ *
+ *     POST /api/graph/node  {id: <nuggetId>, labels: ["KnowledgeNugget", "warrant:<type>"],
+ *                            properties: contract.flatten(nugget, ingest_time)}
+ *
+ * and `contract.flatten` (contract.py :321) puts the FULL validated nugget on the node as
+ * canonical JSON under the `nugget` property — deliberately, so "the graph carries the
+ * spec-conformant OBJECT, not just a lossy projection".
+ *
+ * hellgraph-service serves label-scoped node reads at `GET /api/graph/query?label=…`
+ * (server.ts :328), returning `{count, nodes}` with full properties. Composing the two gives a
+ * genuine live feed with no new endpoint required — which is exactly what the emitter's design
+ * note anticipated: "`warrant:<type>` is a LABEL, so 'give me everything that is not
+ * model-generated' is a label query rather than a JSON scan".
+ *
+ * ── WHAT IS NOT WIRED, STATED PLAINLY ──────────────────────────────────────────────────────
+ *   • No push. `/api/graph/query` is pull-only; there is no SSE/WS nugget stream, so "JustIN
+ *     delivery" is currently a poll. The surface says so rather than implying a live push.
+ *   • No grant scoping. The Memory Distribution Grant plane is not reachable from this app —
+ *     there is no grant service base, no grant claim on the node, and nothing in
+ *     hellgraph-service filters by grant. Subscription below is therefore a CLIENT-SIDE view
+ *     filter and is labelled as one. It is not access control and must not be read as any.
+ *
+ * ── FALLBACK POSTURE (the #1052 lesson) ────────────────────────────────────────────────────
+ * A failed live read must never quietly become fixture proof. So:
+ *   • reachable + nuggets  → mode 'live'
+ *   • reachable + zero     → mode 'live', an EMPTY feed, and an explicit empty state. Fixtures
+ *                            are NOT substituted; an empty graph is a fact, not a gap to fill.
+ *   • unreachable / error  → mode 'fixture', fixtures shown, and `error` carries the reason so
+ *                            the surface can print it. Never 'live'.
+ */
+import { resolveBase } from '../config/cockpitRuntime';
+import { FIXTURE_MALFORMED, FIXTURE_NUGGETS } from '../data/nuggetFixture';
+import { parseNugget, type FeedItem } from '../features/nuggets/types';
+
+const HELLGRAPH = resolveBase('hellgraph', 'VITE_HELLGRAPH_BASE', '/svc/hellgraph');
+
+/** The node label the emitter writes. `apps/nugget-extractor/emitter.py` NUGGET_LABEL. */
+export const NUGGET_LABEL = 'KnowledgeNugget';
+
+export type NuggetLoadMode = 'live' | 'fixture';
+
+export interface NuggetFeedResult {
+  items: FeedItem[];
+  mode: NuggetLoadMode;
+  /** Why the live read did not produce the feed. Null when it did. */
+  error: string | null;
+  /** True when the graph answered and simply held no nuggets. Only meaningful when mode==='live'. */
+  emptyLive: boolean;
+}
+
+interface GraphNode {
+  id?: unknown;
+  labels?: unknown;
+  properties?: unknown;
+}
+
+/**
+ * Pull nuggets from the graph.
+ *
+ * `warrantType` maps onto the emitter's `warrant:<type>` label so the filter runs server-side
+ * where possible; with no filter it reads the `KnowledgeNugget` label.
+ */
+export async function fetchNuggets(warrantType?: string): Promise<NuggetFeedResult> {
+  const label = warrantType ? `warrant:${warrantType}` : NUGGET_LABEL;
+  const url = `${HELLGRAPH.replace(/\/$/, '')}/api/graph/query?label=${encodeURIComponent(label)}`;
+  try {
+    const res = await fetch(url, { headers: { accept: 'application/json' } });
+    if (!res.ok) return fixture(`hellgraph ${res.status} on /api/graph/query?label=${label}`);
+    const body = (await res.json()) as { count?: unknown; nodes?: unknown };
+    if (!Array.isArray(body.nodes)) {
+      return fixture('hellgraph returned an unrecognized /api/graph/query shape');
+    }
+
+    const items: FeedItem[] = [];
+    for (const raw of body.nodes as GraphNode[]) {
+      const nodeId = typeof raw?.id === 'string' ? raw.id : '';
+      const props = (raw?.properties ?? {}) as Record<string, unknown>;
+      const blob = props['nugget'];
+      if (typeof blob !== 'string') {
+        // The node exists but carries no canonical nugget JSON. That is unreadable, which is
+        // NOT the same as invalid — we never checked the nugget, we just cannot see it.
+        items.push({ ok: false, nodeId, reason: 'node has no canonical `nugget` property' });
+        continue;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(blob);
+      } catch (e) {
+        items.push({
+          ok: false,
+          nodeId,
+          reason: `canonical nugget JSON did not parse: ${e instanceof Error ? e.message : String(e)}`,
+        });
+        continue;
+      }
+      items.push(parseNugget(parsed, nodeId));
+    }
+
+    // Reachable and empty is a LIVE fact. Do not paper over it with fixtures.
+    return { items, mode: 'live', error: null, emptyLive: items.length === 0 };
+  } catch (e) {
+    return fixture(`hellgraph unreachable: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+/** The labelled fallback. Always stamped 'fixture', always carrying why. */
+function fixture(error: string): NuggetFeedResult {
+  const items: FeedItem[] = FIXTURE_NUGGETS.map((n) => parseNugget(n, n.id));
+  // Carried on purpose: the fail-closed path should be visible in the fixture feed too.
+  items.push(parseNugget(FIXTURE_MALFORMED, FIXTURE_MALFORMED.id));
+  return { items, mode: 'fixture', error, emptyLive: false };
+}
+
+/** The fixture feed on its own, for tests and for the surface's explicit "show fixture" path. */
+export function fixtureFeed(): NuggetFeedResult {
+  return fixture('fixture requested explicitly');
+}

--- a/apps/socioprophet-web/src/stores/settings.ts
+++ b/apps/socioprophet-web/src/stores/settings.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref, watch } from 'vue';
+import { isExpertise, type Expertise } from '../features/depth/expertise';
 
 // User settings + nav personalization, all persisted to localStorage:
 //   operatorMode  when on, the operator/SourceOS drawer sections default to expanded
@@ -7,6 +8,11 @@ import { ref, watch } from 'vue';
 //   theme         'dark' | 'light' — applied as data-theme on <html>.
 //   pinned        surface routes the user pinned to the top of the drawer.
 //   openSections  per-section accordion open/closed state (id -> bool).
+//   expertise     W11.6 — novice | journeyman | expert. Drives progressive disclosure on the
+//                 proof surfaces. Lives HERE, next to the other durable preferences, rather
+//                 than as per-page state: the point of TA-E is that a consumer sets their
+//                 depth once and every surface honours it. Depth gates supporting detail
+//                 only — never a warrant type, a seal state, or a model-generated marker.
 
 type Theme = 'dark' | 'light';
 const LS_KEY = 'sp.settings.v1';
@@ -17,6 +23,7 @@ interface Persisted {
   pinned: string[];
   openSections: Record<string, boolean>;
   meshChat: boolean;
+  expertise: Expertise;
 }
 
 function load(): Persisted {
@@ -30,10 +37,16 @@ function load(): Persisted {
         pinned: Array.isArray(p.pinned) ? p.pinned : [],
         openSections: p.openSections && typeof p.openSections === 'object' ? p.openSections : {},
         meshChat: !!p.meshChat,
+        // Unrecognized/absent → novice. The shallow default is the safe one: it shows less,
+        // and depth can never weaken a warrant, so a wrong guess here cannot mislead.
+        expertise: isExpertise(p.expertise) ? p.expertise : 'novice',
       };
     }
   } catch { /* ignore */ }
-  return { operatorMode: false, theme: 'dark', pinned: [], openSections: {}, meshChat: false };
+  return {
+    operatorMode: false, theme: 'dark', pinned: [], openSections: {}, meshChat: false,
+    expertise: 'novice',
+  };
 }
 
 function applyTheme(theme: Theme) {
@@ -47,18 +60,22 @@ export const useSettings = defineStore('settings', () => {
   const pinned = ref<string[]>(initial.pinned);
   const openSections = ref<Record<string, boolean>>(initial.openSections);
   const meshChat = ref<boolean>(initial.meshChat);
+  const expertise = ref<Expertise>(initial.expertise);
 
   applyTheme(theme.value);
 
-  watch([operatorMode, theme, pinned, openSections, meshChat], () => {
+  watch([operatorMode, theme, pinned, openSections, meshChat, expertise], () => {
     applyTheme(theme.value);
     try {
       localStorage.setItem(LS_KEY, JSON.stringify({
         operatorMode: operatorMode.value, theme: theme.value,
         pinned: pinned.value, openSections: openSections.value, meshChat: meshChat.value,
+        expertise: expertise.value,
       }));
     } catch { /* ignore */ }
   }, { deep: true });
+
+  const setExpertise = (e: Expertise) => { expertise.value = e; };
 
   const toggleMeshChat = () => { meshChat.value = !meshChat.value; };
 
@@ -82,8 +99,8 @@ export const useSettings = defineStore('settings', () => {
   };
 
   return {
-    operatorMode, theme, pinned, openSections, meshChat,
-    toggleOperatorMode, setTheme, toggleTheme, toggleMeshChat,
+    operatorMode, theme, pinned, openSections, meshChat, expertise,
+    toggleOperatorMode, setTheme, toggleTheme, toggleMeshChat, setExpertise,
     isPinned, togglePin, isSectionOpen, toggleSection,
   };
 });


### PR DESCRIPTION
Three surfaces on the W11 proof spine, built on the `<Warrant>` primitive from #1040/#1052 and the `.studio-scope` tokens. Vue 3 `<script setup>`, scoped plain CSS, epistemic ramp, dark-only. No React, no `@carbon` import.

## W11.4 — annotation overlay

`components/warrant/AnnotationOverlay.vue` + `features/warrant/annotations.ts` (pure, unit-tested).

The EBA lesson is that one token carries several competing ontology annotations and the mapping picks a winner too early. **The engine never hid this** — `compileQuestion` (nlq.ts @ v0.4.45 :1160) keeps the full annotation list on the compilation and hands the *search* a separate view deduped by `(span, concept)`. The overlay just stops throwing the rest away.

Consumed spans are lit; hover/focus shows every candidate concept with its annotator and confidence, and which one the plan bound.

Three things worth review:

- **"Used" is read from the plan, never from confidence rank.** That is the only reason the interesting case is detectable: the fixture's `delayed` span binds `DelayedStatus` (0.88) while `LateShipment` (0.91) ranked higher and lost. The overlay says so in words rather than silently showing the winner.
- **Consumption counts bindings, not just node grounding.** `scoreVariant` adds both to its `consumed` set, but `provenance` only ever gets a row per *node*. Reading provenance alone would have rendered "annotated but unconsumed" on the `Germany` span next to a coverage figure of 100% — two numbers on one screen, one of them lying.
- **Overlapping spans are surfaced, not dropped.** Dropping them would re-commit the exact sin the surface exists to fix.

## W11.5 — nugget feed

`pages/studio/StudioNuggets.vue`, `components/nuggets/NuggetCard.vue`, `features/nuggets/types.ts`, `services/nuggetApi.ts`.

**The live door is real and used.** `nugget-extractor` (#1042) writes each nugget to hellgraph-service with the full canonical JSON on the node (`contract.flatten`), and hellgraph-service serves label-scoped reads — so `GET /api/graph/query?label=KnowledgeNugget` is a genuine feed with no new endpoint. This is what the emitter's own design note anticipated when it made `warrant:<type>` a label.

Honest about the gaps, on screen:

- **Pull, not push.** No nugget stream exists, so JustIN delivery is a poll. Not described as live push.
- **Not grant-scoped.** The filters are a client-side view — explicitly *not* access control. The Memory Distribution Grant plane is unreachable from this app (no base configured, no grant claim on the node, no server-side filter). Called out as a follow-on rather than faked.
- **Three outcomes, not two.** Reachable-with-nuggets → live. Reachable-and-empty → live + an empty state, **fixtures are not substituted**. Unreachable → fixtures, labelled, with the reason printed.
- **Unparseable payloads are kept and counted as UNREADABLE** — unknown, not a failure verdict. Nothing was checked and found wanting; it could not be read at all.

Per the schema's normative rule, `model-generated` is distinguishable three ways at once (stripe, badge, standing banner). The `sourceRef.span` is passed to `<Warrant>` **only** for `direct-quote` — for the others it is a conditioning window that, per the schema, does not warrant the text.

## W11.6 — expertise-adaptive depth

`features/depth/expertise.ts`, `components/depth/DepthControl.vue`, `stores/settings.ts`.

novice / journeyman / expert, bound to a **stored** preference in the existing settings store (`sp.settings.v1`), so depth is set once and every proof surface honours it — not a per-page toggle nobody flips.

*Depth changes what is shown, never what is claimed*, enforced two ways rather than asserted:

1. `DepthPolicy` can only gate **supporting** detail. There is deliberately no flag capable of hiding a warrant type, a seal state, or a model-generated marker — what is not expressible cannot regress.
2. Every gloss declares the strength it **conveys**; `WARRANT_STRENGTH` declares the strength the warrant **has**. The suite asserts they are equal for every kind × level pair. Glossing down is safe; glossing up fails the build. The novice wording for `model-generated` is the bluntest of the three, not the softest.

## Interaction with #1052

Rebased onto it, and its rule propagates: **only a SEALED claim keeps a confident ramp mode.** No nugget carries a receipt (the extractor seals the *batch*, not the nugget), so every nugget resolves to the `unknown` ramp however strong its warrant.

That caught a real problem in my first pass: the card's stripe used raw `--epi-observed`, which would have sat at full proof-intensity next to a desaturated `unknown` badge — a surface arguing with itself, and the same "colour outranks proof" hole #1052 closed on the plan surfaces. The stripe now separates warrant kind by *hue* at reduced intensity, never at full ramp strength. Pinned by test.

## Verification

| | before | after |
|---|---|---|
| tests | 518 | **588** (+70) |
| failures | 5 | **5** (unchanged) |

The 5 failures are the pre-existing `OperatorDashboard`, `capabilityScreens` ×2, `newsDepth` ×2 — verified reproducing on pristine main, in files this PR does not touch (only 3 new test files added, no existing one modified).

- `vue-tsc --noEmit` clean
- `vite build` clean
- `python3 tools/preflight_deploy_contract.py` exit 0

## Fixture vs live

| surface | data |
|---|---|
| W11.4 overlay | **fixture** — rides the existing `warrantFixture` compilation; no NLQ compile endpoint exists (unchanged from #1040, banner already says so). Competing annotations added to the fixture, faithful to the engine's sort order. |
| W11.5 feed | **live door wired** (`/api/graph/query?label=KnowledgeNugget`), fixture fallback labelled with the failure reason |
| W11.6 depth | preference is **real** and persisted; renders over whatever the surface holds |