### PR TITLE
feat(device-service): the southbound device plane — one interface, N drivers (W8.7)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -104,6 +104,9 @@ jobs:
           # L5 governance executor: runs the engine's lifecycle FSM + retention scheduler +
           # vendor-cache gc (blueprint-audit: complete machinery, zero callers — until this).
           - { image: lifecycle-warden,      context: apps/lifecycle-warden,      dockerfile: Dockerfile }
+          # FOG & CITIZEN PLANE W8.7: the southbound device plane — the estate's first.
+          # ONE southbound interface (DeviceProfile/DeviceReading), N protocol drivers.
+          - { image: device-service,        context: apps/device-service,        dockerfile: Dockerfile }
     uses: SocioProphet/.github/.github/workflows/build-image.yml@main
     with:
       image: ${{ matrix.image }}

--- a/.github/workflows/probe-contract.yml
+++ b/.github/workflows/probe-contract.yml
@@ -46,6 +46,12 @@ jobs:
           # in-process (vendored schema + probe nuggets), and the drain loop is a no-op
           # with nothing pending — so /healthz answers unaided on the values file's port.
           - { service: nugget-extractor, context: apps/nugget-extractor, dockerfile: Dockerfile }
+          # boots with no dependencies at all: the profiles are packaged in the image and
+          # the boot gate (vendored schemas + recomputed profile digests + a probe reading)
+          # is entirely in-process. The poll loop finds no hellgraph and keeps the batch
+          # pending, which is exactly what /healthz is there to report — so it answers
+          # unaided on the values file's port.
+          - { service: device-service, context: apps/device-service, dockerfile: Dockerfile }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -163,6 +163,18 @@ jobs:
             working-directory: apps/nugget-extractor
             install: pip install -r requirements.txt -r requirements-test.txt
             test: PYTHONPATH=src pytest -q tests
+          # device-service (W8.7 southbound device plane). This leg gates the attribution
+          # invariant — a reading must resolve to its device, its profile, the exact
+          # profile REVISION (digest) and the declared physical channel, or it is refused
+          # and counted. It also covers the gapless-retry and seal-then-count semantics,
+          # the BLE GATT decoders (including the sint16 signedness trap that silently
+          # turns -5 degC into +650 degC), and the refusal to start on a protocol with no
+          # driver. The sourceos-spec schemas are VENDORED and sha256-asserted at import,
+          # so this leg also catches contract drift the moment a vendored copy is edited.
+          - name: device-service
+            working-directory: apps/device-service
+            install: pip install -r requirements.txt -r requirements-test.txt
+            test: PYTHONPATH=src pytest -q tests
           - name: tools-tests
             working-directory: .
             install: pip install pytest pyyaml jsonschema

--- a/apps/device-service/Dockerfile
+++ b/apps/device-service/Dockerfile
@@ -1,0 +1,27 @@
+# device-service — FOG & CITIZEN PLANE W8.7: the estate's southbound device plane.
+# ONE southbound interface, N protocol drivers (EdgeX Foundry's lesson). Devices are
+# declared by DeviceProfile and observed as DeviceReading (SourceOS-Linux/sourceos-spec
+# v0.1.0, VENDORED and sha256-asserted at import), validated fail-closed against BOTH the
+# schema and the profile the reading cites, written to the platform log as
+# hellgraph-service graph writes (KKO-typed, quality-labelled), and sealed one receipt
+# per batch on the estate spine via compute-gateway POST /v1/compute kind=materialize.
+# Never a fifth receipt lineage.
+#
+# NO RADIO IN THIS IMAGE, deliberately. One driver ships — `virtual` — and its readings
+# are SIMULATED, marked as such on the profile, on every reading's policy/risk labels, on
+# the graph node, and on /healthz (`simulated_devices`). The real-BLE seam is
+# src/device_service/ble.py: the GATT characteristic decoders are real and unit-tested
+# against the Bluetooth SIG formats, BleGattDriver is complete against an injected
+# transport, and no transport implementation ships. build_driver() REFUSES a ble-gatt
+# profile rather than starting a service that polls nothing behind a green /healthz.
+#
+# python:3.11-slim mirrors apps/market-replay + apps/nugget-extractor. The dependency
+# closure is market-replay's exactly — no apt layer, no native toolchain, no radio stack.
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+ENV PORT=8080
+EXPOSE 8080
+CMD ["uvicorn", "device_service.server:app", "--host", "0.0.0.0", "--port", "8080", "--app-dir", "src"]

--- a/apps/device-service/pyproject.toml
+++ b/apps/device-service/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "device-service"
+version = "0.1.0"
+description = "FOG & CITIZEN PLANE W8.7: the southbound device plane — one interface, N protocol drivers. DeviceProfile/DeviceReading (sourceos-spec v0.1.0, vendored + sha256-pinned), validated fail-closed against schema AND profile, written to the HellGraph log KKO-typed, and sealed on the compute-gateway receipt spine"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi==0.115.0",
+  "uvicorn==0.30.6",
+  "httpx==0.27.2",
+  "jsonschema==4.26.0",
+  # jsonschema treats `format` as an annotation unless a checker is supplied, and its
+  # date-time checker is a NO-OP without this package. Without it the "schema-validated,
+  # fail-closed" claim above silently excludes every timestamp in the schema — and this
+  # family carries three (observedAt, receivedAt, wallTime), one of which is the
+  # southbound latency measurement. contract.py refuses to import without it.
+  "rfc3339-validator==0.1.4",
+]
+[tool.setuptools.packages.find]
+where = ["src"]
+[tool.setuptools.package-data]
+device_service = ["schemas/*.json", "profiles/*.json"]

--- a/apps/device-service/requirements-test.txt
+++ b/apps/device-service/requirements-test.txt
@@ -1,0 +1,3 @@
+# Test-only dependencies (fastapi.testclient needs httpx, already a runtime pin).
+# Runtime pins live in requirements.txt.
+pytest==8.3.2

--- a/apps/device-service/requirements.txt
+++ b/apps/device-service/requirements.txt
@@ -1,0 +1,35 @@
+# Exact runtime closure (pip freeze of the five top-level pins in pyproject.toml).
+# Identical to apps/market-replay/requirements.txt — same base image, same
+# fastapi/uvicorn/httpx line, same jsonschema Draft 2020-12 validation gate against the
+# VENDORED sourceos-spec schemas (hermetic: no network, no spec checkout; provenance +
+# sha256 pinned in src/device_service/contract.py). httpcore 1.0.9 + h11 0.16.0 are the
+# post-CVE-2025-43859 pairing.
+#
+# There is deliberately NO BLE/radio dependency (no bleak, no dbus). See
+# src/device_service/ble.py: the GATT decoders are real and tested, the transport is the
+# one missing class, and build_driver() REFUSES a ble-gatt profile rather than letting
+# the service pretend. Adding a radio is a deliberate change with a security review
+# attached, not a quiet pip line.
+fastapi==0.115.0
+uvicorn==0.30.6
+httpx==0.27.2
+jsonschema==4.26.0
+annotated-types==0.8.0
+anyio==4.14.2
+attrs==26.1.0
+certifi==2026.7.22
+click==8.4.2
+h11==0.16.0
+httpcore==1.0.9
+idna==3.18
+jsonschema-specifications==2025.9.1
+pydantic==2.13.4
+pydantic_core==2.46.4
+referencing==0.37.0
+rpds-py==2026.6.3
+sniffio==1.3.1
+starlette==0.38.6
+typing-inspection==0.4.2
+typing_extensions==4.16.0
+rfc3339-validator==0.1.4
+six==1.17.0

--- a/apps/device-service/src/device_service/__init__.py
+++ b/apps/device-service/src/device_service/__init__.py
@@ -1,0 +1,1 @@
+"""device-service — the southbound device plane (W8.7)."""

--- a/apps/device-service/src/device_service/ble.py
+++ b/apps/device-service/src/device_service/ble.py
@@ -1,0 +1,179 @@
+"""The real-BLE seam — typed, and honest about exactly what is missing.
+
+WHAT IS REAL HERE: the GATT characteristic decoders. They implement the Bluetooth SIG
+formats byte-for-byte and are unit-tested against vectors taken from the specifications,
+because decoding is where the interesting bugs live — a sint16 read as uint16 turns
+-5.00 degC into +650.31 degC, and nothing downstream can tell. `BleGattDriver` is a
+complete DeviceDriver against an injected transport.
+
+WHAT IS MISSING: `BleTransport` has no implementation in this build. There is no radio,
+no `bleak`, no pairing, no bonding. One class implementing three methods, plus one line
+in drivers.DRIVERS, is the entire remaining distance — and `build_driver()` refuses a
+ble-gatt profile until that line exists, so nothing can quietly pretend otherwise.
+
+WHY IT IS NOT SHIPPED: a BLE transport needs a radio on the node, host DBus/Bluetooth
+access from a container that currently runs unprivileged with a read-only rootfs, and a
+pairing/bonding story that is a security review of its own (securityMode is a declared
+field on the profile precisely so that review has something to bite on). Shipping a
+transport stub that returned plausible bytes would be worse than shipping none: it would
+make simulated data indistinguishable from measured data at the one layer where the
+distinction is still recoverable.
+
+Characteristic formats implemented (Bluetooth SIG, Environmental Sensing + Battery):
+  0x2A6E Temperature        sint16, little-endian, 0.01 degC        -> Cel
+  0x2A6F Humidity           uint16, little-endian, 0.01 %           -> %
+  0x2A19 Battery Level      uint8, 0..100 %                         -> %
+"""
+from __future__ import annotations
+
+import struct
+from typing import Any, Protocol
+
+TEMPERATURE_UUID = "00002a6e-0000-1000-8000-00805f9b34fb"
+HUMIDITY_UUID = "00002a6f-0000-1000-8000-00805f9b34fb"
+BATTERY_LEVEL_UUID = "00002a19-0000-1000-8000-00805f9b34fb"
+
+ENVIRONMENTAL_SENSING_SERVICE = "0000181a-0000-1000-8000-00805f9b34fb"
+BATTERY_SERVICE = "0000180f-0000-1000-8000-00805f9b34fb"
+
+
+class DecodeError(ValueError):
+    """The characteristic payload is not the shape the format requires."""
+
+
+def decode_temperature(payload: bytes) -> float:
+    """0x2A6E: sint16 little-endian, unit 0.01 degC.
+
+    SIGNEDNESS IS THE BUG THAT MATTERS. Read as uint16, -5.00 degC (0xFE0C) decodes to
+    +650.36 degC — a plausible-looking number that no range check on a -40..85 profile
+    would ever pass, which is the only reason it would be caught at all. Explicit '<h'.
+    """
+    if len(payload) != 2:
+        raise DecodeError(f"temperature (0x2A6E) needs exactly 2 bytes, got {len(payload)}")
+    (raw,) = struct.unpack("<h", payload)
+    return round(raw * 0.01, 2)
+
+
+def decode_humidity(payload: bytes) -> float:
+    """0x2A6F: uint16 little-endian, unit 0.01 %. Unsigned — humidity has no negatives."""
+    if len(payload) != 2:
+        raise DecodeError(f"humidity (0x2A6F) needs exactly 2 bytes, got {len(payload)}")
+    (raw,) = struct.unpack("<H", payload)
+    return round(raw * 0.01, 2)
+
+
+def decode_battery_level(payload: bytes) -> int:
+    """0x2A19: uint8 percent. The spec bounds it 0..100; a device reporting 255 is
+    faulty, and passing that through as 'the battery is at 255%' is precisely the kind of
+    quiet nonsense the range declaration exists to stop. Rejected at the decoder."""
+    if len(payload) != 1:
+        raise DecodeError(f"battery level (0x2A19) needs exactly 1 byte, got {len(payload)}")
+    value = payload[0]
+    if value > 100:
+        raise DecodeError(f"battery level {value} is outside the spec's 0..100 percent")
+    return value
+
+
+#: characteristic UUID -> decoder. A profile's metrics[].sourceAddress ends in the UUID.
+DECODERS = {
+    TEMPERATURE_UUID: decode_temperature,
+    HUMIDITY_UUID: decode_humidity,
+    BATTERY_LEVEL_UUID: decode_battery_level,
+}
+
+
+def characteristic_of(source_address: str) -> str:
+    """Extract the characteristic UUID from a profile sourceAddress of the form
+    gatt://<service-uuid>/<characteristic-uuid>."""
+    if not source_address.startswith("gatt://"):
+        raise DecodeError(f"not a GATT source address: {source_address!r}")
+    parts = source_address[len("gatt://"):].split("/")
+    if len(parts) != 2 or not parts[1]:
+        raise DecodeError(
+            f"GATT source address must be gatt://<service>/<characteristic>: {source_address!r}"
+        )
+    return parts[1].lower()
+
+
+class BleTransport(Protocol):
+    """The one thing this build does not have. Implement it and BLE is live.
+
+    An implementation owns connection, pairing/bonding per the profile's securityMode,
+    and notification handling. It hands back raw characteristic bytes and nothing else —
+    decoding stays here so it is testable without a radio.
+    """
+
+    def connect(self) -> None: ...
+
+    def read_characteristic(self, uuid: str) -> bytes:
+        """Raise TimeoutError if the peripheral did not answer within the window."""
+        ...
+
+    def disconnect(self) -> None: ...
+
+
+class BleGattDriver:
+    """A complete DeviceDriver for BLE GATT devices, against an injected transport.
+
+    Nothing here is a placeholder: given a BleTransport, this polls a real Acme TH-100 (or
+    any Environmental-Sensing peripheral whose profile names the right characteristics).
+    A per-metric timeout becomes a typed absence rather than a re-reported stale value —
+    the distinction the contract's `stale` vs `unavailable` split exists to preserve.
+    """
+
+    def __init__(self, profile: dict[str, Any], device_ref: str, transport: BleTransport) -> None:
+        self.profile = profile
+        self.device_ref = device_ref
+        self.transport = transport
+        self.metrics = [m["metric"] for m in profile["metrics"]]
+        self._declared = {m["metric"]: m for m in profile["metrics"]}
+        self._connected = False
+
+    def poll(self) -> list[Any]:
+        from .drivers import DriverError, Sample  # local import: keeps drivers.py the entry point
+
+        if not self._connected:
+            try:
+                self.transport.connect()
+                self._connected = True
+            except Exception as exc:  # noqa: BLE001 - any transport failure is one failure
+                raise DriverError(f"BLE connect failed for {self.device_ref}: {exc}") from exc
+
+        samples: list[Any] = []
+        for metric in self.metrics:
+            declared = self._declared[metric]
+            uuid = characteristic_of(declared["sourceAddress"])
+            decoder = DECODERS.get(uuid)
+            if decoder is None:
+                raise DriverError(
+                    f"no decoder for characteristic {uuid} ({metric}) — a profile may not "
+                    f"declare a channel this driver cannot actually read"
+                )
+            try:
+                payload = self.transport.read_characteristic(uuid)
+            except TimeoutError:
+                samples.append(
+                    Sample(metric=metric, value=None, quality="unavailable",
+                           absence_kind="timeout", raw=None, flags=["notify_window_missed"])
+                )
+                continue
+            except Exception as exc:  # noqa: BLE001
+                samples.append(
+                    Sample(metric=metric, value=None, quality="unavailable",
+                           absence_kind="transport_failure", raw=None,
+                           flags=[f"transport:{type(exc).__name__}"])
+                )
+                continue
+            try:
+                value = decoder(payload)
+            except DecodeError:
+                # A payload that does not decode is NOT an absence — the device answered.
+                # It is a fault, and re-reporting it as "no data" would hide a broken
+                # device behind the same counter as a quiet one.
+                raise DriverError(
+                    f"{self.device_ref}/{metric}: undecodable payload {payload.hex()}"
+                ) from None
+            samples.append(
+                Sample(metric=metric, value=value, quality="ok", raw={"hex": payload.hex()})
+            )
+        return samples

--- a/apps/device-service/src/device_service/clients.py
+++ b/apps/device-service/src/device_service/clients.py
@@ -1,0 +1,145 @@
+"""The two doors out — both injectable, so the emitter's semantics are proven on fakes.
+
+- HellGraphWriter -> hellgraph-service POST /api/graph/node|edge. THE log; device
+  readings enter the platform exactly the way MarketDataEvents and KnowledgeNuggets do
+  (market-replay / nugget-extractor precedent), and the same materializer tails it.
+- GatewayClient   -> compute-gateway POST /v1/compute kind=materialize. THE receipt
+  spine. NOT a fifth lineage: the same door, the same hash chain and the same Ed25519
+  attestation the materializer, the lifecycle warden and the extraction spine use.
+
+WHY kind=materialize AND NOT A NEW KIND. The four spine kinds are materialize,
+governance, engine-seal and nugget-emit. `governance` requires an audit_head this
+service does not have; `engine-seal` hard-refuses anything that is not a HellGraph
+enrich/explore receipt (it RECOMPUTES the seal); `nugget-emit` refuses warrant_counts
+outside the KnowledgeNugget taxonomy, so using it would mean lying about warrants.
+`materialize` is the one whose spec is domain-neutral, and there is already an in-repo
+precedent for reusing it across domains: hellgraph-service's membrane seals EffectDecision
+rows with kind=materialize under the comment "reuse its shape, no new kind". A device
+batch fills the fields honestly — source is the device, sink is the log, table is the
+node label, the cursors are the device's own reading sequence, and batch_hash binds the
+exact bytes emitted.
+
+The one honest caveat: the registry stamps `materialize` with the epistemic warrant
+`derived`, while a raw sensor value would want `observed`. That is defensible here
+because the receipt is not about the measurement — it attests that N readings with this
+batch hash were materialized onto the log through this cut. It is a claim about the
+materialization, which is derived. If a future device family needs `observed` at the
+receipt level, that is an argument for a fifth kind made deliberately, not a reason to
+mint one in passing.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+TIMEOUT = 10.0
+
+#: The graph node label readings land under. Also the `table` on the sealed receipt.
+READING_LABEL = "DeviceReading"
+DEVICE_LABEL = "Device"
+PROFILE_LABEL = "DeviceProfile"
+ABSENCE_LABEL = "NullAbsenceRecord"
+KKO_TYPE_LABEL = "KkoType"
+
+EDGE_FROM_DEVICE = "fromDevice"
+EDGE_DECLARED_BY = "declaredBy"
+EDGE_CONFORMS_TO = "conformsTo"
+EDGE_KKO_TYPE = "kkoType"
+EDGE_ABSENCE = "absenceTypedBy"
+
+
+class EmitError(RuntimeError):
+    """A graph write did not land. The batch stays pending and resumes at the same op."""
+
+
+class GatewayError(RuntimeError):
+    """The receipt was refused. Nothing is counted as emitted without one."""
+
+
+class HellGraphWriter:
+    """The one door onto the log: POST /api/graph/node|edge on hellgraph-service.
+
+    addNode is an UPSERT and is safe to repeat. addEdge is NOT — a re-added edge mints a
+    second log event and a duplicate downstream row — which is why the emitter tracks a
+    per-write cursor and never re-sends the half of a batch that already landed.
+    """
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    def _post(self, path: str, payload: dict[str, Any]) -> None:
+        try:
+            r = httpx.post(f"{self.base_url}{path}", json=payload, timeout=TIMEOUT)
+        except httpx.HTTPError as e:
+            raise EmitError(f"hellgraph unreachable: {e}") from e
+        if r.status_code != 200:
+            raise EmitError(f"hellgraph {r.status_code} on {path}: {r.text[:300]}")
+
+    def post_node(self, node_id: str, labels: list[str], properties: dict[str, Any]) -> None:
+        self._post("/api/graph/node", {"id": node_id, "labels": labels, "properties": properties})
+
+    def post_edge(self, label: str, from_id: str, to_id: str) -> None:
+        self._post("/api/graph/edge", {"label": label, "from": from_id, "to": to_id})
+
+
+class GatewayClient:
+    """Seals one receipt per emitted batch on the estate spine.
+
+    The spec IS the receipt's inputs, so inputs_sha binds {source, sink, table,
+    from_cursor, to_cursor, row_count, batch_hash} into the chain — the seal covers the
+    exact readings that went onto the graph, in order. Any failure (transport, auth,
+    non-ok status, missing receipt) raises, so the caller cannot count an unattested
+    batch as emitted.
+
+    Idempotent by construction: an identical spec re-POSTed after a crash hits the
+    gateway's content-addressed memo and returns the SAME receipt id with memoized=true,
+    rather than minting a duplicate on the chain.
+    """
+
+    def __init__(self, base_url: str, token: str, project: str = "default") -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.project = project
+
+    def mint(
+        self,
+        *,
+        device_ref: str,
+        from_cursor: int,
+        to_cursor: int,
+        row_count: int,
+        batch_hash: str,
+    ) -> dict[str, Any]:
+        req = {
+            "kind": "materialize",
+            "project": self.project,
+            "actor": "device-service",
+            "spec": {
+                "source": device_ref,
+                "sink": "hellgraph",
+                "table": READING_LABEL,
+                "from_cursor": from_cursor,
+                "to_cursor": to_cursor,
+                "row_count": row_count,
+                "batch_hash": batch_hash,
+            },
+        }
+        try:
+            r = httpx.post(
+                f"{self.base_url}/v1/compute",
+                json=req,
+                headers={"Authorization": f"Bearer {self.token}"},
+                timeout=TIMEOUT,
+            )
+        except httpx.HTTPError as e:
+            raise GatewayError(f"compute-gateway unreachable: {e}") from e
+        if r.status_code != 200:
+            raise GatewayError(f"compute-gateway {r.status_code}: {r.text[:500]}")
+        result = r.json()
+        # An adapter-level refusal is HTTP 200 with status="error" in the body, so the
+        # status code alone is not the check.
+        if result.get("status") != "ok" or not result.get("receipt"):
+            raise GatewayError(f"materialize receipt refused: {json.dumps(result)[:500]}")
+        return result["receipt"]

--- a/apps/device-service/src/device_service/contract.py
+++ b/apps/device-service/src/device_service/contract.py
@@ -1,0 +1,446 @@
+"""The vendored DeviceService contract: profile digesting, reading construction, and the
+hermetic fail-closed validation gate.
+
+Schema provenance (vendored so validation needs no network and no spec checkout):
+    repo    SourceOS-Linux/sourceos-spec  (PR #215, feat/device-service-contract)
+    paths   schemas/DeviceProfile.json, schemas/DeviceReading.json,
+            schemas/NullAbsenceRecord.json
+    commit  ba84bed8d7826d9c52ed55dd0d176bf853e43631
+            (2026-07-29, "schemas: DeviceService contract v0.1 — the southbound
+            device plane (W8.7)"; NullAbsenceRecord is unchanged from 487e4b6, the
+            MPCC event contract — it is REUSED, not re-invented)
+    sha256  DeviceProfile.json     2d68700fe5f33b7955bd086125f384b27000aeeafd866504dd5bf7b46d51ff28
+            DeviceReading.json     261f1972cb16e3468e2b2eb6204748005f1c10c4dd9fb35e5dcba3a3cc6119df
+            NullAbsenceRecord.json 9e51c264acec89efc8021e62e54e2e513e9890e85126f46f11ecf93a9936f84d
+Re-vendor by copying the files from sourceos-spec and updating this block. The sha256s
+are asserted at import: a drifted or hand-edited copy fails LOUDLY at startup, never
+silently at emit time — this service's whole claim is "what enters the log conforms to
+the estate contract", so the contract itself must be tamper-evident.
+(apps/market-replay/src/market_replay/contract.py and apps/nugget-extractor precedent.)
+
+THE NORMATIVE INVARIANT this module enforces: a reading is ATTRIBUTABLE OR IT IS
+NOTHING. Beyond schema conformance, every reading is checked against the profile it
+cites — metric declared, unit and source address equal to the declaration, value of the
+declared type and inside the declared range, digest equal to the RECOMPUTED digest of
+the profile as loaded. An unattributable reading is not emitted, it is counted.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from importlib import resources
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+SPEC_VERSION = "0.1.0"
+
+PROFILE_SCHEMA_SHA256 = "2d68700fe5f33b7955bd086125f384b27000aeeafd866504dd5bf7b46d51ff28"
+READING_SCHEMA_SHA256 = "261f1972cb16e3468e2b2eb6204748005f1c10c4dd9fb35e5dcba3a3cc6119df"
+ABSENCE_SCHEMA_SHA256 = "9e51c264acec89efc8021e62e54e2e513e9890e85126f46f11ecf93a9936f84d"
+
+# KKO reference concepts, taken from the TBox this estate actually vendors
+# (apps/owl-reasoner/src/owl_reasoner/data/kko-2.10.n3, namespace
+# http://kbpedia.org/ontologies/kko#). BOTH terms were verified present in that file —
+# they are not invented URIs, and tests/test_kko.py re-verifies it against the vendored
+# TBox so an invented URI cannot survive CI.
+#
+# They are deliberately COARSE. KKO is the 169-term upper ontology; the ~58k KBpedia
+# reference-concept layer that would carry a concept as specific as "temperature" is NOT
+# vendored anywhere in this estate. Citing kbpedia.org/kko/rc/Temperature would look more
+# precise and resolve to nothing — the same silent-wrong this service exists to prevent.
+# The metric name and unit carry the specificity the ontology cannot. As in
+# nugget-extractor: these are DECLARED type refs; nothing here resolves them against a
+# loaded KKO (the platform-wide TBox binding is a separate, tracked gap).
+KKO = "http://kbpedia.org/ontologies/kko#"
+KKO_QUANTITY = KKO + "Quantity"  # a magnitude-with-unit (number/integer metrics)
+KKO_STATES = KKO + "States"      # a state of a thing (boolean metrics)
+
+
+def _load(name: str, pinned: str) -> tuple[dict[str, Any], bytes]:
+    raw = (resources.files("device_service") / "schemas" / name).read_bytes()
+    actual = hashlib.sha256(raw).hexdigest()
+    if actual != pinned:  # tamper-evident vendoring — see module docstring
+        raise RuntimeError(
+            f"vendored {name} drifted: sha256 {actual} != pinned {pinned}; "
+            "re-vendor from sourceos-spec and update contract.py provenance"
+        )
+    return json.loads(raw), raw
+
+
+PROFILE_SCHEMA, _PROFILE_BYTES = _load("DeviceProfile.json", PROFILE_SCHEMA_SHA256)
+READING_SCHEMA, _READING_BYTES = _load("DeviceReading.json", READING_SCHEMA_SHA256)
+ABSENCE_SCHEMA, _ABSENCE_BYTES = _load("NullAbsenceRecord.json", ABSENCE_SCHEMA_SHA256)
+
+# jsonschema treats `format` as an ANNOTATION unless a checker is supplied, so a plain
+# Draft202012Validator(SCHEMA) never validates the schema's "format": "date-time" — a
+# structurally-valid reading carrying "not-a-timestamp" would pass the gate this module
+# describes as fail-closed. Passing the checker is not sufficient on its own: its
+# date-time entry only exists when rfc3339-validator is installed, so a missing
+# dependency would turn the fix back into the no-op it replaces, silently, and only in
+# whichever environment lacked the package. The assertion makes that impossible: no
+# timestamp checking means no import. (market-replay found this the hard way.)
+_FORMAT_CHECKER = Draft202012Validator.FORMAT_CHECKER
+if "date-time" not in _FORMAT_CHECKER.checkers:  # pragma: no cover - guarded by test
+    raise RuntimeError(
+        "jsonschema's date-time format checker is unavailable (install rfc3339-validator). "
+        "Refusing to start: this module claims per-reading schema validation, and without "
+        "it every `format: date-time` in DeviceReading.json would go unchecked."
+    )
+
+PROFILE_VALIDATOR = Draft202012Validator(PROFILE_SCHEMA, format_checker=_FORMAT_CHECKER)
+READING_VALIDATOR = Draft202012Validator(READING_SCHEMA, format_checker=_FORMAT_CHECKER)
+ABSENCE_VALIDATOR = Draft202012Validator(ABSENCE_SCHEMA, format_checker=_FORMAT_CHECKER)
+
+# The absence kinds a southbound driver can honestly attribute. A driver knows the
+# device did not answer (timeout), that the link broke (transport_failure), or that it
+# has no basis to say which (no_event_observed). It does NOT know that a device chose
+# silence, refused, or was redacted — those are claims about intent, and a driver
+# asserting them would be inventing a cause. The full 12-kind taxonomy stays available
+# to producers that can actually attribute; this service restricts itself to what it
+# can know.
+DRIVER_ABSENCE_KINDS = ("timeout", "transport_failure", "no_event_observed")
+
+# Normative digest projection — MUST stay byte-identical to
+# sourceos-spec tools/validate_device_service_examples.py DIGEST_FIELDS. Exactly the
+# fields that decide which readings are admissible; prose, labels and timestamps are
+# excluded so a documentation edit does not orphan live readings.
+DIGEST_FIELDS = ["deviceClass", "protocol", "metrics"]
+
+SIMULATED_LABEL = "synthetic:simulated-device"
+SIMULATED_RISK = "not-a-measurement"
+
+
+class ContractError(ValueError):
+    """A reading (or profile) is not admissible. Never swallowed: counted and logged."""
+
+
+def definition_digest(profile: dict[str, Any]) -> str:
+    """Recompute DeviceProfile.definitionDigest. Normative: sha256 over the canonical
+    JSON (sorted keys, no whitespace, UTF-8) of the DIGEST_FIELDS projection of the
+    document AS WRITTEN — schema defaults are not materialised, so an omitted field and
+    an explicitly-defaulted one are different declarations and hash differently."""
+    core = {field: profile[field] for field in DIGEST_FIELDS}
+    canonical = json.dumps(core, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def load_profile(raw: dict[str, Any]) -> dict[str, Any]:
+    """Validate a profile and RECOMPUTE its digest. A profile whose stored digest is not
+    the digest of its own declared capability is refused at load: every reading pins that
+    value, so admitting a lying digest would make every downstream pin meaningless."""
+    errors = sorted(PROFILE_VALIDATOR.iter_errors(raw), key=str)
+    if errors:
+        raise ContractError(f"profile does not conform: {errors[0].message}")
+    recomputed = definition_digest(raw)
+    if raw["definitionDigest"] != recomputed:
+        raise ContractError(
+            f"profile {raw['id']}: definitionDigest {raw['definitionDigest']} is not the "
+            f"digest of its own declared capability (recomputed {recomputed})"
+        )
+    names = [m["metric"] for m in raw["metrics"]]
+    if len(names) != len(set(names)):
+        raise ContractError(f"profile {raw['id']}: duplicate metric names {names}")
+    return raw
+
+
+def metric_of(profile: dict[str, Any], metric: str) -> dict[str, Any]:
+    for declared in profile["metrics"]:
+        if declared["metric"] == metric:
+            return declared
+    raise ContractError(f"metric {metric!r} is not declared by {profile['id']}")
+
+
+def is_simulated(profile: dict[str, Any]) -> bool:
+    return profile["protocol"] == "virtual"
+
+
+def build_reading(
+    *,
+    profile: dict[str, Any],
+    device_ref: str,
+    metric: str,
+    value: Any,
+    quality: str,
+    observed_at: str,
+    received_at: str,
+    wall_time: str,
+    logical_time: int,
+    sequence_ref: int,
+    workspace_ref: str,
+    branch_ref: str,
+    actor_ref: str,
+    raw_payload: Any = None,
+    quality_flags: list[str] | None = None,
+    null_absence_ref: str | None = None,
+    causal_parents: list[str] | None = None,
+) -> dict[str, Any]:
+    """Construct one DeviceReading from a driver sample and its profile.
+
+    Everything that makes the reading attributable is copied FROM THE PROFILE — unit,
+    source address, ontology type, digest — so a driver cannot supply them and cannot
+    get them wrong. A driver reports a value; the contract layer says what it means.
+    """
+    declared = metric_of(profile, metric)
+    simulated = is_simulated(profile)
+    reading: dict[str, Any] = {
+        "id": f"urn:srcos:device-reading:{reading_local_id(device_ref, metric, sequence_ref)}",
+        "type": "DeviceReading",
+        "specVersion": SPEC_VERSION,
+        "actorRef": actor_ref,
+        "workspaceRef": workspace_ref,
+        "branchRef": branch_ref,
+        "visibilityScope": ["private"],
+        "wallTime": wall_time,
+        "logicalTime": logical_time,
+        "causalParents": causal_parents or [],
+        "provenanceLinks": [
+            # Stated, not merely checkable: the attribution must survive being read by
+            # something that never loads the profile.
+            {"rel": "declared_by", "ref": profile["id"]},
+            {"rel": "produced_by", "ref": device_ref},
+            {"rel": "ingested_by", "ref": "prophet-platform:apps/device-service"},
+        ],
+        # A simulated reading carries the not-a-measurement labels its profile carries.
+        # This is the KnowledgeNugget model-generated rule applied to sensors: generated
+        # data that is indistinguishable downstream is worse than no data, because it is
+        # believed. The labels ride on the reading itself, not only on the profile a
+        # consumer might not fetch.
+        "policyLabels": [SIMULATED_LABEL] if simulated else list(profile.get("policyLabels", [])),
+        "riskLabels": [SIMULATED_RISK] if simulated else list(profile.get("riskLabels", [])),
+        "deviceRef": device_ref,
+        "deviceProfileRef": profile["id"],
+        "profileDigest": profile["definitionDigest"],
+        "metric": metric,
+        "sourceAddress": declared["sourceAddress"],
+        "value": value,
+        "unit": declared["unit"],
+        "quality": quality,
+        "observedAt": observed_at,
+        "receivedAt": received_at,
+        "sequenceRef": sequence_ref,
+        "nullAbsenceRef": null_absence_ref,
+        "qualityFlags": quality_flags or [],
+        "rawPayload": raw_payload,
+    }
+    if declared.get("kkoTypeRef"):
+        reading["kkoTypeRef"] = declared["kkoTypeRef"]
+    return reading
+
+
+def reading_local_id(device_ref: str, metric: str, sequence_ref: int) -> str:
+    """Deterministic local id: the same (device, metric, seq) always yields the same URN,
+    so a restart re-emitting a batch upserts the same node instead of minting a duplicate.
+    The URN charset is [A-Za-z0-9._~-]; device slugs and dotted metric names are safe, the
+    urn: prefix and its colons are not, so only the device's local part is used."""
+    device_slug = device_ref.rsplit(":", 1)[-1]
+    return f"{device_slug}-{metric}-{sequence_ref:012d}"
+
+
+def validate_reading(reading: dict[str, Any], profile: dict[str, Any]) -> None:
+    """THE fail-closed gate. Two layers, both mandatory:
+
+    1. schema conformance against the vendored DeviceReading.json;
+    2. ATTRIBUTION against the profile the reading cites — the layer a schema cannot
+       express, because it is a claim about two documents agreeing.
+
+    Raises ContractError on any non-conformance. The caller does not emit and does not
+    count the reading as emitted; it counts the failure.
+    """
+    errors = sorted(READING_VALIDATOR.iter_errors(reading), key=str)
+    if errors:
+        raise ContractError(f"schema: {errors[0].message}")
+
+    if reading["deviceProfileRef"] != profile["id"]:
+        raise ContractError(
+            f"reading cites {reading['deviceProfileRef']} but was validated against {profile['id']}"
+        )
+    recomputed = definition_digest(profile)
+    if reading["profileDigest"] != recomputed:
+        raise ContractError(
+            f"profileDigest {reading['profileDigest']} != the recomputed digest of "
+            f"{profile['id']} ({recomputed}) — the reading names a revision it was not "
+            f"admitted against"
+        )
+
+    declared = metric_of(profile, reading["metric"])
+    if reading["unit"] != declared["unit"]:
+        raise ContractError(
+            f"unit {reading['unit']!r} contradicts the declared {declared['unit']!r} "
+            f"for {reading['metric']}"
+        )
+    if reading["sourceAddress"] != declared["sourceAddress"]:
+        raise ContractError(
+            f"sourceAddress {reading['sourceAddress']!r} is not the channel declared for "
+            f"{reading['metric']} ({declared['sourceAddress']!r})"
+        )
+    if declared.get("kkoTypeRef") and reading.get("kkoTypeRef") != declared["kkoTypeRef"]:
+        raise ContractError(f"kkoTypeRef disagrees with the declaration for {reading['metric']}")
+
+    if reading["receivedAt"] and reading["receivedAt"] < reading["observedAt"]:
+        raise ContractError("receivedAt precedes observedAt")
+
+    simulated = is_simulated(profile)
+    labelled = SIMULATED_LABEL in reading["policyLabels"]
+    if simulated and not labelled:
+        raise ContractError(
+            f"produced under a virtual profile but carries no {SIMULATED_LABEL!r} label — "
+            "simulated data must stay visibly distinguishable downstream"
+        )
+    if labelled and not simulated:
+        raise ContractError("a physically-measured reading must not be labelled simulated")
+
+    if reading["quality"] == "unavailable":
+        # The schema already binds value:null + a present nullAbsenceRef; this is the
+        # non-null check the schema's `not` covers, restated where the error is legible.
+        if not reading.get("nullAbsenceRef"):
+            raise ContractError("unavailable reading carries no nullAbsenceRef")
+        return
+
+    expected = declared["valueType"]
+    value = reading["value"]
+    ok = {
+        "number": isinstance(value, (int, float)) and not isinstance(value, bool),
+        "integer": isinstance(value, int) and not isinstance(value, bool),
+        "boolean": isinstance(value, bool),
+        "string": isinstance(value, str),
+    }[expected]
+    if not ok:
+        raise ContractError(
+            f"value {value!r} is not the declared {expected} for {reading['metric']}"
+        )
+    if expected in ("number", "integer"):
+        lo, hi = declared["minimum"], declared["maximum"]
+        if not (lo <= value <= hi):
+            raise ContractError(
+                f"value {value!r} is outside the declared operating range [{lo}, {hi}] for "
+                f"{reading['metric']} — a device disagreeing with its own profile is a "
+                f"fault or a wrong profile, never a datum to pass through quietly"
+            )
+
+
+def flatten(reading: dict[str, Any], ingest_time: str) -> dict[str, Any]:
+    """The graph-node property projection: flat scalars for querying, PLUS the full
+    validated reading as canonical JSON — so the log carries the spec-conformant OBJECT,
+    not just a lossy projection. (market-replay / nugget-extractor precedent.)"""
+    return {
+        "readingId": reading["id"],
+        "deviceRef": reading["deviceRef"],
+        "deviceProfileRef": reading["deviceProfileRef"],
+        "profileDigest": reading["profileDigest"],
+        "metric": reading["metric"],
+        "sourceAddress": reading["sourceAddress"],
+        "unit": reading["unit"],
+        "quality": reading["quality"],
+        "valueNum": reading["value"] if isinstance(reading["value"], (int, float))
+        and not isinstance(reading["value"], bool) else None,
+        "valueBool": reading["value"] if isinstance(reading["value"], bool) else None,
+        "valueStr": reading["value"] if isinstance(reading["value"], str) else None,
+        "observedAt": reading["observedAt"],
+        "receivedAt": reading["receivedAt"],
+        "wallTime": reading["wallTime"],
+        "logicalTime": reading["logicalTime"],
+        "sequenceRef": reading["sequenceRef"],
+        "simulated": SIMULATED_LABEL in reading["policyLabels"],
+        "specVersion": reading["specVersion"],
+        "ingestTime": ingest_time,
+        "reading": json.dumps(reading, sort_keys=True, separators=(",", ":"), ensure_ascii=False),
+    }
+
+
+def batch_hash(readings: list[dict[str, Any]]) -> str:
+    """sha256 over the canonical JSON of the batch, in emission order. This is what the
+    sealed receipt binds: change any byte of any reading and the receipt no longer
+    matches the batch it claims to cover."""
+    canonical = json.dumps(readings, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def startup_check(profiles: list[dict[str, Any]]) -> None:
+    """Boot-time fail-closed gate: both schemas are valid 2020-12 documents, every
+    commissioned profile conforms AND carries its own recomputed digest, and a probe
+    reading built by THIS code against each profile's first metric validates. Any drift
+    dies here, before the first poll — a visible crash, never a silently dead loop
+    behind a green pod."""
+    Draft202012Validator.check_schema(PROFILE_SCHEMA)
+    Draft202012Validator.check_schema(READING_SCHEMA)
+    for profile in profiles:
+        load_profile(profile)
+        declared = profile["metrics"][0]
+        probe_value = {
+            "number": float(declared.get("minimum") or 0),
+            "integer": int(declared.get("minimum") or 0),
+            "boolean": False,
+            "string": "probe",
+        }[declared["valueType"]]
+        reading = build_reading(
+            profile=profile,
+            device_ref="urn:srcos:device:startup_probe",
+            metric=declared["metric"],
+            value=probe_value,
+            quality="ok",
+            observed_at="2026-01-01T00:00:00.000Z",
+            received_at="2026-01-01T00:00:00.000Z",
+            wall_time="2026-01-01T00:00:00.000Z",
+            logical_time=0,
+            sequence_ref=0,
+            workspace_ref="urn:srcos:workspace:startup_probe",
+            branch_ref="urn:srcos:branch:startup_probe",
+            actor_ref="urn:srcos:agent:device_service",
+            raw_payload={"probe": True},
+        )
+        validate_reading(reading, profile)
+
+
+def build_absence_record(
+    *,
+    reading_id: str,
+    kind: str,
+    observed_at: str,
+    workspace_ref: str,
+    branch_ref: str,
+    device_ref: str,
+    metric: str,
+    expected_next_sequence: int,
+    causal_notes: str,
+) -> dict[str, Any]:
+    """Type the absence, rather than re-reporting a stale value as if it were measured.
+
+    The record reuses the existing 12-kind MPCC taxonomy — the device plane does not get
+    its own vocabulary — and this service restricts itself to the three kinds a driver
+    can honestly attribute (DRIVER_ABSENCE_KINDS).
+    """
+    if kind not in DRIVER_ABSENCE_KINDS:
+        raise ContractError(
+            f"absence kind {kind!r} is not one a southbound driver can attribute "
+            f"{list(DRIVER_ABSENCE_KINDS)} — asserting intent the driver cannot observe"
+        )
+    return {
+        "id": f"urn:srcos:null-absence:{reading_id.rsplit(':', 1)[-1]}",
+        "type": "NullAbsenceRecord",
+        "specVersion": SPEC_VERSION,
+        "kind": kind,
+        "observedAt": observed_at,
+        "relatedEventRef": reading_id,
+        "relatedBranchRef": branch_ref,
+        "relatedWorkspaceRef": workspace_ref,
+        "causalNotes": causal_notes,
+        "policyLabels": [],
+        "provenanceLinks": [
+            {"rel": "detected_by", "ref": "prophet-platform:apps/device-service"},
+            {"rel": "produced_by", "ref": device_ref},
+        ],
+        "details": {"metric": metric, "expectedNextSequence": expected_next_sequence},
+    }
+
+
+def validate_absence_record(record: dict[str, Any], reading: dict[str, Any]) -> None:
+    """Schema conformance plus the back-reference: an absence record that does not point
+    at the reading it explains leaves the reading's nullAbsenceRef dangling."""
+    errors = sorted(ABSENCE_VALIDATOR.iter_errors(record), key=str)
+    if errors:
+        raise ContractError(f"absence schema: {errors[0].message}")
+    if record["relatedEventRef"] != reading["id"]:
+        raise ContractError("absence record does not point back at the reading it explains")
+    if reading.get("nullAbsenceRef") != record["id"]:
+        raise ContractError("reading's nullAbsenceRef does not name this absence record")

--- a/apps/device-service/src/device_service/drivers.py
+++ b/apps/device-service/src/device_service/drivers.py
@@ -1,0 +1,206 @@
+"""The southbound driver interface — ONE interface, N protocol drivers (EdgeX's lesson).
+
+A driver's entire job is to speak a protocol and hand back `Sample`s. It does NOT build
+readings, does not know about URNs, units, ranges, provenance, the graph or the receipt
+spine, and cannot supply any of the fields that make a reading attributable — those are
+copied from the profile by contract.build_reading(). That asymmetry is the whole point:
+adding a Zigbee driver must not be able to introduce a second event vocabulary, because
+a driver has no way to express one.
+
+REGISTRY, AND WHY IT FAILS CLOSED: build_driver() refuses a profile whose protocol has
+no registered driver. A service that started anyway and quietly polled nothing would
+present a green pod, a green /healthz and zero readings — the exact "declared but
+unenforced" shape the estate keeps finding. Refusing to start is louder and cheaper.
+
+WHAT ACTUALLY SHIPS HERE, PLAINLY: one real driver, `virtual` — a deterministic
+simulator with no physical counterpart. Its readings are SIMULATED, and they are marked
+as such at every layer that can carry a mark (profile protocol, profile labels, reading
+policy/risk labels, a `simulated` property on the graph node, a `simulated_devices`
+counter on /healthz). Nothing in this service pretends to have touched a sensor.
+
+The real-BLE seam is `ble.py`: the GATT characteristic DECODERS are real, correct and
+unit-tested against the Bluetooth SIG formats, and `BleGattDriver` is complete against
+an injected `BleTransport`. No `BleTransport` implementation ships — that one class,
+plus a registry line, is the entire distance to a real BLE device.
+"""
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass, field
+from typing import Any, Callable, Protocol
+
+
+class DriverError(RuntimeError):
+    """The driver could not talk to the device. The caller types this as an absence."""
+
+
+class DriverUnavailable(RuntimeError):
+    """No driver is registered (or buildable) for this protocol. Fail closed at boot."""
+
+
+@dataclass(frozen=True)
+class Sample:
+    """One raw observation as the driver saw it.
+
+    A driver reports what it observed and how much it believes it. It does not report
+    units, ranges, ontology types or provenance — the profile declares those, and
+    contract.build_reading() is the only thing that may put them on a reading.
+    """
+
+    metric: str
+    value: Any
+    quality: str = "ok"
+    #: Set only when quality == "unavailable"; must be one of contract.DRIVER_ABSENCE_KINDS.
+    absence_kind: str | None = None
+    #: The pre-decode payload, kept so a decode bug is provable after the fact.
+    raw: Any = None
+    flags: list[str] = field(default_factory=list)
+
+
+class DeviceDriver(Protocol):
+    """The one southbound interface. Implement this and a protocol is supported."""
+
+    #: Metric names this driver can produce; must be a subset of the profile's.
+    metrics: list[str]
+
+    def poll(self) -> list[Sample]:
+        """Read the device once. Raise DriverError if the device could not be reached at
+        all; return Samples with quality="unavailable" for per-metric absences."""
+        ...
+
+
+# --------------------------------------------------------------------------- virtual
+
+
+class VirtualRoomSensorDriver:
+    """A deterministic simulated room sensor. NOT a measurement of anything.
+
+    Values are a pure function of (seed, device, metric, tick): the same seed replays the
+    same stream on every restart, so a re-emitted batch upserts identical nodes rather
+    than minting drifted duplicates. Each metric walks a smooth band strictly INSIDE the
+    profile's declared operating range — a simulator that emitted out-of-range values
+    would make the must-be-zero `validation_failures` counter nonzero in steady state and
+    train everyone to ignore it.
+
+    `drop_every_n` (default 0 = never) makes the driver report a typed absence instead of
+    a value on every Nth tick, so the unavailable → NullAbsenceRecord path can be
+    exercised end-to-end on a running deployment rather than only in tests.
+    """
+
+    def __init__(
+        self,
+        profile: dict[str, Any],
+        device_ref: str,
+        seed: int = 42,
+        drop_every_n: int = 0,
+    ) -> None:
+        self.profile = profile
+        self.device_ref = device_ref
+        self.seed = seed
+        self.drop_every_n = max(0, drop_every_n)
+        self.metrics = [m["metric"] for m in profile["metrics"]]
+        self._declared = {m["metric"]: m for m in profile["metrics"]}
+        self._tick = 0
+
+    def _phase(self, metric: str) -> float:
+        """A stable per-(seed, device, metric) phase offset, so metrics do not move in
+        lockstep. Derived by hash rather than by RNG state so it survives a restart."""
+        key = f"{self.seed}:{self.device_ref}:{metric}".encode()
+        return int.from_bytes(hashlib.sha256(key).digest()[:4], "big") / 0xFFFFFFFF
+
+    def _value(self, metric: str, tick: int) -> Any:
+        declared = self._declared[metric]
+        phase = self._phase(metric)
+        wave = math.sin(2 * math.pi * (tick / 720.0 + phase))  # ~12 min period at 1 Hz
+        if declared["valueType"] == "boolean":
+            return wave > 0.5
+        lo, hi = float(declared["minimum"]), float(declared["maximum"])
+        # Walk the middle 40% of the declared range. Deliberately conservative: a
+        # simulator has no business exercising the range boundary, and one that did would
+        # make a genuine out-of-range fault indistinguishable from normal synthetic drift.
+        centre = (lo + hi) / 2.0
+        amplitude = (hi - lo) * 0.20
+        value = centre + amplitude * wave
+        if declared["valueType"] == "integer":
+            return int(round(value))
+        resolution = declared.get("resolution") or 0.01
+        return round(round(value / resolution) * resolution, 6)
+
+    def poll(self) -> list[Sample]:
+        self._tick += 1
+        tick = self._tick
+        dropping = self.drop_every_n and tick % self.drop_every_n == 0
+        samples: list[Sample] = []
+        for metric in self.metrics:
+            if dropping:
+                samples.append(
+                    Sample(
+                        metric=metric,
+                        value=None,
+                        quality="unavailable",
+                        absence_kind="timeout",
+                        raw=None,
+                        flags=["simulated_drop"],
+                    )
+                )
+                continue
+            samples.append(
+                Sample(
+                    metric=metric,
+                    value=self._value(metric, tick),
+                    quality="ok",
+                    raw={"driver": "virtual", "tick": tick, "seed": self.seed},
+                )
+            )
+        return samples
+
+
+# -------------------------------------------------------------------------- registry
+
+DriverFactory = Callable[[dict[str, Any], str, dict[str, Any]], DeviceDriver]
+
+
+def _virtual_factory(profile: dict[str, Any], device_ref: str, options: dict[str, Any]) -> DeviceDriver:
+    return VirtualRoomSensorDriver(
+        profile,
+        device_ref,
+        seed=int(options.get("seed", 42)),
+        drop_every_n=int(options.get("drop_every_n", 0)),
+    )
+
+
+#: protocol -> factory. Adding a protocol is adding a line here and a module beside
+#: ble.py. Nothing else in the service changes — that is the interface holding.
+DRIVERS: dict[str, DriverFactory] = {
+    "virtual": _virtual_factory,
+}
+
+
+def build_driver(
+    profile: dict[str, Any], device_ref: str, options: dict[str, Any] | None = None
+) -> DeviceDriver:
+    """Build the driver for a commissioned device, or refuse.
+
+    Refusing is the point. A profile declaring `ble-gatt` on a build with no BLE
+    transport must not start a service that silently polls nothing: the operator would
+    see a green pod and an empty graph and have no way to tell that from a quiet house.
+    """
+    protocol = profile["protocol"]
+    factory = DRIVERS.get(protocol)
+    if factory is None:
+        raise DriverUnavailable(
+            f"no driver registered for protocol {protocol!r} (device {device_ref}, "
+            f"profile {profile['id']}). Registered: {sorted(DRIVERS)}. Refusing to start "
+            f"rather than run a service that polls nothing behind a green /healthz — see "
+            f"ble.py for the shape a protocol driver takes."
+        )
+    driver = factory(profile, device_ref, options or {})
+    declared = {m["metric"] for m in profile["metrics"]}
+    unknown = sorted(set(driver.metrics) - declared)
+    if unknown:
+        raise DriverUnavailable(
+            f"driver for {device_ref} produces metrics the profile does not declare: "
+            f"{unknown} — a reading nothing declares is unattributable by construction"
+        )
+    return driver

--- a/apps/device-service/src/device_service/emitter.py
+++ b/apps/device-service/src/device_service/emitter.py
@@ -1,0 +1,417 @@
+"""The emitter core — poll, validate-then-write, seal, and only then count.
+
+Write path (W8.7 — the estate's first southbound sensor stream on the platform log):
+
+    driver.poll() -> Samples -> build_reading() from the PROFILE -> VALIDATE EVERY ONE
+    (fail-closed, schema + attribution) ->
+        POST /api/graph/node  {id: <profileUrn>,  labels: [DeviceProfile]}
+        POST /api/graph/node  {id: <deviceUrn>,   labels: [Device]}
+        POST /api/graph/edge  {label: conformsTo,    from: device,  to: profile}
+        POST /api/graph/node  {id: <kkoTypeUri>,  labels: [KkoType]}          (per type)
+        POST /api/graph/node  {id: <absenceUrn>,  labels: [NullAbsenceRecord]} (per absence)
+        POST /api/graph/node  {id: <readingUrn>,  labels: [DeviceReading, quality:<q>]}
+        POST /api/graph/edge  {label: fromDevice,    from: reading, to: device}
+        POST /api/graph/edge  {label: declaredBy,    from: reading, to: profile}
+        POST /api/graph/edge  {label: kkoType,       from: reading, to: <kkoTypeUri>}
+        POST /api/graph/edge  {label: absenceTypedBy, from: reading, to: <absenceUrn>}
+    -> POST /v1/compute kind=materialize (compute-gateway)  ⇒ sealed receipt
+    -> only THEN is the batch counted as emitted.
+
+The graph shape is the contract made walkable: `quality:<q>` is a LABEL, so "give me
+everything that is not a measurement" is a label query rather than a JSON scan, and the
+normative stale/substituted/unavailable distinction survives into every downstream
+surface. `kkoType` edges are what make readings KKO-typed IN THE GRAPH rather than only
+in a JSON field, and `declaredBy` makes the attribution chain traversable from a value
+back to the declaration that gave it meaning.
+
+FAIL-CLOSED RULES, in order of severity:
+- VALIDATION failure ⇒ that reading is NOT emitted, counted, and logged loudly. The rest
+  of the poll still emits (one bad metric must not cost the whole device), and the count
+  on /healthz is the alarm — its steady state MUST be 0. The sealed receipt covers the
+  batch that DID emit, so the graph and the chain never disagree.
+- DRIVER failure ⇒ the device is skipped this interval and recorded; no partial batch is
+  queued. A device that cannot be reached produces nothing, not a stale value wearing an
+  ok quality.
+- HELLGRAPH failure ⇒ the batch stays PENDING with a per-WRITE cursor and resumes exactly
+  where it stopped. No new polling happens for a device with a pending batch, so the
+  reading sequence never skips and memory is bounded. Node writes are upserts and safe to
+  repeat; an edge write is not, so a half-written batch never re-sends the half that
+  landed.
+- GATEWAY failure ⇒ the graph writes have already landed (they cannot be un-written), so
+  the batch stays pending AT THE RECEIPT STEP and retries the receipt only. Nothing is
+  counted as emitted until it is both on the graph and attested — the materializer's
+  "no receipt ⇒ no checkpoint" rule.
+- The loop never dies: any error is recorded in state and retried after the interval.
+
+CONCURRENCY: the drain loop and the /healthz reader both touch this object, so every
+mutation of the pending queue, the write cursor and the logical clock is under one
+reentrant lock (nugget-extractor observed the two-thread double-drain bug for real).
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from . import contract
+from .clients import (
+    ABSENCE_LABEL,
+    DEVICE_LABEL,
+    EDGE_ABSENCE,
+    EDGE_CONFORMS_TO,
+    EDGE_DECLARED_BY,
+    EDGE_FROM_DEVICE,
+    EDGE_KKO_TYPE,
+    KKO_TYPE_LABEL,
+    PROFILE_LABEL,
+    READING_LABEL,
+    EmitError,
+    GatewayError,
+)
+from .drivers import DeviceDriver, DriverError, Sample
+
+log = logging.getLogger("device_service.emitter")
+
+
+def utcnow() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+@dataclass
+class CommissionedDevice:
+    """One physical (or virtual) thing, bound to the profile it conforms to.
+
+    In v0.1 this binding lives here, in the service's commissioned-device table. Every
+    reading carries both refs plus the profile digest, so the binding is auditable from
+    the graph even though a typed `Device` registry contract does not exist yet (named as
+    the first follow-on in specs/device-service-contract.md §11).
+    """
+
+    device_ref: str
+    profile: dict[str, Any]
+    driver: DeviceDriver
+    seq: int = 0
+
+
+@dataclass
+class _Op:
+    kind: str  # "node" | "edge"
+    args: tuple
+
+
+@dataclass
+class _Batch:
+    device_ref: str
+    readings: list[dict[str, Any]]
+    ops: list[_Op]
+    from_cursor: int
+    to_cursor: int
+    cursor: int = 0  # index into ops; advanced ONLY after a write lands
+    receipt_pending: bool = True
+
+
+@dataclass
+class PollResult:
+    polled: int = 0
+    emitted: int = 0
+    validation_failures: int = 0
+    driver_failures: int = 0
+    receipts: int = 0
+    pending: int = 0
+    last_receipt_id: str | None = None
+    quality_counts: dict[str, int] = field(default_factory=dict)
+    # False means "no evidence either way" — a drain with nothing pending contacts
+    # NOTHING, so folding default-true flags into /healthz would report both dependencies
+    # green without ever having asked.
+    attempted: bool = False
+    hellgraph_ok: bool = True
+    gateway_ok: bool = True
+
+
+class Emitter:
+    def __init__(
+        self,
+        devices: list[CommissionedDevice],
+        writer: Any,
+        gateway: Any,
+        *,
+        workspace_ref: str,
+        branch_ref: str,
+        actor_ref: str = "urn:srcos:agent:device_service",
+        clock: Callable[[], str] = utcnow,
+    ) -> None:
+        self.devices = devices
+        self.writer = writer
+        self.gateway = gateway
+        self.workspace_ref = workspace_ref
+        self.branch_ref = branch_ref
+        self.actor_ref = actor_ref
+        self.clock = clock
+        self._lock = threading.RLock()
+        self._pending: list[_Batch] = []
+        self._logical_time = 0
+        self._types_ensured: set[str] = set()
+        self._devices_ensured: set[str] = set()
+
+    # ------------------------------------------------------------------ properties
+    @property
+    def pending_readings(self) -> int:
+        with self._lock:
+            return sum(len(b.readings) for b in self._pending)
+
+    @property
+    def simulated_devices(self) -> int:
+        return sum(1 for d in self.devices if contract.is_simulated(d.profile))
+
+    @property
+    def protocols(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for d in self.devices:
+            counts[d.profile["protocol"]] = counts.get(d.profile["protocol"], 0) + 1
+        return counts
+
+    def startup_check(self) -> None:
+        contract.startup_check([d.profile for d in self.devices])
+
+    # ------------------------------------------------------------------- the loop
+    @staticmethod
+    def _merge(into: PollResult, other: PollResult) -> None:
+        into.emitted += other.emitted
+        into.receipts += other.receipts
+        into.last_receipt_id = other.last_receipt_id or into.last_receipt_id
+        for k, v in other.quality_counts.items():
+            into.quality_counts[k] = into.quality_counts.get(k, 0) + v
+        if other.attempted:
+            into.attempted = True
+            into.hellgraph_ok = other.hellgraph_ok
+            into.gateway_ok = other.gateway_ok
+
+    def run_once(self) -> PollResult:
+        """One interval: resume anything outstanding first, then poll only the devices
+        that have nothing pending, then drain what was just built."""
+        with self._lock:
+            result = PollResult()
+            self._merge(result, self._drain())
+            pending_devices = {b.device_ref for b in self._pending}
+
+            for device in self.devices:
+                if device.device_ref in pending_devices:
+                    # Gapless: no new samples for a device whose last batch has not
+                    # fully landed. Bounded memory, and the seq stream never skips.
+                    continue
+                result.polled += 1
+                try:
+                    samples = device.driver.poll()
+                except DriverError as e:
+                    result.driver_failures += 1
+                    log.warning("driver failure for %s, skipping this interval: %s",
+                                device.device_ref, e)
+                    continue
+                batch = self._build_batch(device, samples, result)
+                if batch is not None:
+                    self._pending.append(batch)
+
+            self._merge(result, self._drain())
+            result.pending = sum(len(b.readings) for b in self._pending)
+            return result
+
+    # ------------------------------------------------------------------- building
+    def _build_batch(
+        self, device: CommissionedDevice, samples: list[Sample], result: PollResult
+    ) -> _Batch | None:
+        profile = device.profile
+        from_cursor = device.seq
+        readings: list[dict[str, Any]] = []
+        absences: list[dict[str, Any]] = []
+
+        for sample in samples:
+            device.seq += 1
+            self._logical_time += 1
+            now = self.clock()
+            reading_id = (
+                "urn:srcos:device-reading:"
+                + contract.reading_local_id(device.device_ref, sample.metric, device.seq)
+            )
+            absence = None
+            if sample.quality == "unavailable":
+                try:
+                    absence = contract.build_absence_record(
+                        reading_id=reading_id,
+                        kind=sample.absence_kind or "no_event_observed",
+                        observed_at=now,
+                        workspace_ref=self.workspace_ref,
+                        branch_ref=self.branch_ref,
+                        device_ref=device.device_ref,
+                        metric=sample.metric,
+                        expected_next_sequence=device.seq + 1,
+                        causal_notes=(
+                            f"{device.device_ref}/{sample.metric} produced no value at "
+                            f"sequence {device.seq}. Typed as an absence rather than "
+                            f"re-reporting the prior value, which would have been "
+                            f"substituted data wearing an ok quality."
+                        ),
+                    )
+                except contract.ContractError as e:
+                    result.validation_failures += 1
+                    log.error("VALIDATION FAILURE — absence NOT emitted (%s/%s seq=%s): %s",
+                              device.device_ref, sample.metric, device.seq, e)
+                    continue
+
+            try:
+                reading = contract.build_reading(
+                    profile=profile,
+                    device_ref=device.device_ref,
+                    metric=sample.metric,
+                    value=sample.value,
+                    quality=sample.quality,
+                    observed_at=now,
+                    received_at=now,
+                    wall_time=now,
+                    logical_time=self._logical_time,
+                    sequence_ref=device.seq,
+                    workspace_ref=self.workspace_ref,
+                    branch_ref=self.branch_ref,
+                    actor_ref=self.actor_ref,
+                    raw_payload=sample.raw,
+                    quality_flags=list(sample.flags),
+                    null_absence_ref=absence["id"] if absence else None,
+                )
+                # THE fail-closed gate: nothing non-conformant, and nothing
+                # unattributable, may reach the log.
+                contract.validate_reading(reading, profile)
+                if absence is not None:
+                    contract.validate_absence_record(absence, reading)
+            except contract.ContractError as e:
+                result.validation_failures += 1
+                log.error("VALIDATION FAILURE — reading NOT emitted (%s/%s seq=%s): %s",
+                          device.device_ref, sample.metric, device.seq, e)
+                continue
+
+            readings.append(reading)
+            if absence is not None:
+                absences.append(absence)
+
+        if not readings:
+            return None
+        return _Batch(
+            device_ref=device.device_ref,
+            readings=readings,
+            ops=self._plan(device, readings, absences),
+            from_cursor=from_cursor,
+            to_cursor=device.seq,
+        )
+
+    def _plan(
+        self,
+        device: CommissionedDevice,
+        readings: list[dict[str, Any]],
+        absences: list[dict[str, Any]],
+    ) -> list[_Op]:
+        """The ordered write plan. Nodes before the edges that reference them, so an edge
+        never points at a node the log has not seen yet."""
+        profile = device.profile
+        ops: list[_Op] = []
+        ingest = self.clock()
+
+        if device.device_ref not in self._devices_ensured:
+            ops.append(_Op("node", (profile["id"], [PROFILE_LABEL], {
+                "profileRef": profile["id"],
+                "deviceClass": profile["deviceClass"],
+                "protocol": profile["protocol"],
+                "definitionDigest": profile["definitionDigest"],
+                "metricCount": len(profile["metrics"]),
+                "simulated": contract.is_simulated(profile),
+                "declaredAt": profile["declaredAt"],
+                "specVersion": profile["specVersion"],
+            })))
+            ops.append(_Op("node", (device.device_ref, [DEVICE_LABEL], {
+                "deviceRef": device.device_ref,
+                "deviceProfileRef": profile["id"],
+                "protocol": profile["protocol"],
+                "simulated": contract.is_simulated(profile),
+                "commissionedAt": ingest,
+            })))
+            ops.append(_Op("edge", (EDGE_CONFORMS_TO, device.device_ref, profile["id"])))
+
+        types = sorted({r["kkoTypeRef"] for r in readings if r.get("kkoTypeRef")})
+        for uri in types:
+            if uri not in self._types_ensured:
+                ops.append(_Op("node", (uri, [KKO_TYPE_LABEL], {"uri": uri, "vocab": "kko"})))
+
+        by_reading = {a["relatedEventRef"]: a for a in absences}
+        for reading in readings:
+            absence = by_reading.get(reading["id"])
+            if absence is not None:
+                ops.append(_Op("node", (absence["id"], [ABSENCE_LABEL], {
+                    "absenceId": absence["id"],
+                    "kind": absence["kind"],
+                    "observedAt": absence["observedAt"],
+                    "relatedEventRef": absence["relatedEventRef"],
+                    "causalNotes": absence["causalNotes"],
+                    "specVersion": absence["specVersion"],
+                })))
+            ops.append(_Op("node", (
+                reading["id"],
+                [READING_LABEL, f"quality:{reading['quality']}"],
+                contract.flatten(reading, ingest_time=ingest),
+            )))
+            ops.append(_Op("edge", (EDGE_FROM_DEVICE, reading["id"], device.device_ref)))
+            ops.append(_Op("edge", (EDGE_DECLARED_BY, reading["id"], profile["id"])))
+            if reading.get("kkoTypeRef"):
+                ops.append(_Op("edge", (EDGE_KKO_TYPE, reading["id"], reading["kkoTypeRef"])))
+            if absence is not None:
+                ops.append(_Op("edge", (EDGE_ABSENCE, reading["id"], absence["id"])))
+        return ops
+
+    # -------------------------------------------------------------------- draining
+    def _drain(self) -> PollResult:
+        result = PollResult()
+        while self._pending:
+            batch = self._pending[0]
+            result.attempted = True
+            try:
+                while batch.cursor < len(batch.ops):
+                    op = batch.ops[batch.cursor]
+                    if op.kind == "node":
+                        self.writer.post_node(*op.args)
+                    else:
+                        self.writer.post_edge(*op.args)
+                    batch.cursor += 1  # advance ONLY after the write lands
+            except EmitError as e:
+                log.warning("hellgraph write failed at op %d/%d (device=%s), batch stays "
+                            "pending: %s", batch.cursor, len(batch.ops), batch.device_ref, e)
+                result.hellgraph_ok = False
+                break
+
+            try:
+                receipt = self.gateway.mint(
+                    device_ref=batch.device_ref,
+                    from_cursor=batch.from_cursor,
+                    to_cursor=batch.to_cursor,
+                    row_count=len(batch.readings),
+                    batch_hash=contract.batch_hash(batch.readings),
+                )
+            except GatewayError as e:
+                log.warning("receipt refused for device=%s — graph writes landed, batch stays "
+                            "pending at the receipt step: %s", batch.device_ref, e)
+                result.gateway_ok = False
+                break
+
+            batch.receipt_pending = False
+            result.emitted += len(batch.readings)
+            result.receipts += 1
+            result.last_receipt_id = receipt.get("id") or receipt.get("receipt_id")
+            for reading in batch.readings:
+                result.quality_counts[reading["quality"]] = (
+                    result.quality_counts.get(reading["quality"], 0) + 1
+                )
+            self._devices_ensured.add(batch.device_ref)
+            self._types_ensured.update(
+                r["kkoTypeRef"] for r in batch.readings if r.get("kkoTypeRef")
+            )
+            self._pending.pop(0)
+
+        result.pending = sum(len(b.readings) for b in self._pending)
+        return result

--- a/apps/device-service/src/device_service/profiles/acme-th100-ble.json
+++ b/apps/device-service/src/device_service/profiles/acme-th100-ble.json
@@ -1,0 +1,81 @@
+{
+  "id": "urn:srcos:device-profile:acme_th100_room_sensor_v1",
+  "type": "DeviceProfile",
+  "specVersion": "0.1.0",
+  "actorRef": "urn:srcos:agent:device_service",
+  "workspaceRef": "urn:srcos:workspace:citizen_home_demo",
+  "visibilityScope": [
+    "private"
+  ],
+  "provenanceLinks": [
+    {
+      "rel": "declared_from",
+      "ref": "datasheet:acme-th-100-rev-c"
+    },
+    {
+      "rel": "conforms_to",
+      "ref": "org.bluetooth.service.environmental_sensing"
+    }
+  ],
+  "policyLabels": [
+    "residence:interior",
+    "pii:none"
+  ],
+  "riskLabels": [],
+  "deviceClass": "acme-th-100-room-sensor",
+  "manufacturer": "Acme Instruments",
+  "model": "TH-100",
+  "protocol": "ble-gatt",
+  "protocolBinding": {
+    "endpoint": "ble://C4:2F:90:11:8A:3D",
+    "securityMode": "pairing-bonded",
+    "parameters": {
+      "connectionIntervalMs": 1000,
+      "notifyOnly": true,
+      "gattService": "0000181a-0000-1000-8000-00805f9b34fb"
+    }
+  },
+  "metrics": [
+    {
+      "metric": "temperature",
+      "kkoTypeRef": "http://kbpedia.org/ontologies/kko#Quantity",
+      "valueType": "number",
+      "unit": "Cel",
+      "minimum": -40.0,
+      "maximum": 85.0,
+      "resolution": 0.01,
+      "samplePeriodMs": 1000,
+      "sourceAddress": "gatt://0000181a-0000-1000-8000-00805f9b34fb/00002a6e-0000-1000-8000-00805f9b34fb",
+      "access": "read"
+    },
+    {
+      "metric": "humidity.relative",
+      "kkoTypeRef": "http://kbpedia.org/ontologies/kko#Quantity",
+      "valueType": "number",
+      "unit": "%",
+      "minimum": 0.0,
+      "maximum": 100.0,
+      "resolution": 0.01,
+      "samplePeriodMs": 1000,
+      "sourceAddress": "gatt://0000181a-0000-1000-8000-00805f9b34fb/00002a6f-0000-1000-8000-00805f9b34fb",
+      "access": "read"
+    },
+    {
+      "metric": "battery.level",
+      "kkoTypeRef": "http://kbpedia.org/ontologies/kko#Quantity",
+      "valueType": "integer",
+      "unit": "%",
+      "minimum": 0,
+      "maximum": 100,
+      "resolution": 1,
+      "samplePeriodMs": 300000,
+      "sourceAddress": "gatt://0000180f-0000-1000-8000-00805f9b34fb/00002a19-0000-1000-8000-00805f9b34fb",
+      "access": "read"
+    }
+  ],
+  "declaredAt": "2026-07-29T08:00:00.000Z",
+  "identityRef": "urn:srcos:device-identity:home_edge_node_01",
+  "adminState": "enabled",
+  "supersedesRef": null,
+  "definitionDigest": "sha256:24dfe44e340bc684c2c5618cfad534717c6b1f218b6bf7e94aa809afecab2813"
+}

--- a/apps/device-service/src/device_service/profiles/virtual-room-sensor.json
+++ b/apps/device-service/src/device_service/profiles/virtual-room-sensor.json
@@ -1,0 +1,77 @@
+{
+  "id": "urn:srcos:device-profile:srcos_virtual_room_sensor_v1",
+  "type": "DeviceProfile",
+  "specVersion": "0.1.0",
+  "actorRef": "urn:srcos:agent:device_service",
+  "workspaceRef": "urn:srcos:workspace:citizen_home_demo",
+  "visibilityScope": [
+    "private"
+  ],
+  "provenanceLinks": [
+    {
+      "rel": "declared_from",
+      "ref": "prophet-platform:apps/device-service/profiles/virtual-room-sensor.json"
+    }
+  ],
+  "policyLabels": [
+    "synthetic:simulated-device"
+  ],
+  "riskLabels": [
+    "not-a-measurement"
+  ],
+  "deviceClass": "srcos-virtual-room-sensor",
+  "manufacturer": "SourceOS",
+  "model": "virtual-room-sensor",
+  "protocol": "virtual",
+  "protocolBinding": {
+    "endpoint": "virtual://room-sensor",
+    "securityMode": "none",
+    "parameters": {
+      "seed": 20260729,
+      "samplePeriodMs": 1000
+    }
+  },
+  "metrics": [
+    {
+      "metric": "temperature",
+      "kkoTypeRef": "http://kbpedia.org/ontologies/kko#Quantity",
+      "valueType": "number",
+      "unit": "Cel",
+      "minimum": 5.0,
+      "maximum": 40.0,
+      "resolution": 0.01,
+      "samplePeriodMs": 1000,
+      "sourceAddress": "virtual://room-sensor/temperature",
+      "access": "read"
+    },
+    {
+      "metric": "humidity.relative",
+      "kkoTypeRef": "http://kbpedia.org/ontologies/kko#Quantity",
+      "valueType": "number",
+      "unit": "%",
+      "minimum": 10.0,
+      "maximum": 90.0,
+      "resolution": 0.01,
+      "samplePeriodMs": 1000,
+      "sourceAddress": "virtual://room-sensor/humidity.relative",
+      "access": "read"
+    },
+    {
+      "metric": "occupancy.detected",
+      "kkoTypeRef": "http://kbpedia.org/ontologies/kko#States",
+      "valueType": "boolean",
+      "unit": "{bool}",
+      "minimum": null,
+      "maximum": null,
+      "resolution": null,
+      "samplePeriodMs": 1000,
+      "sourceAddress": "virtual://room-sensor/occupancy.detected",
+      "access": "read"
+    }
+  ],
+  "declaredAt": "2026-07-29T08:00:00.000Z",
+  "identityRef": "urn:srcos:device-identity:home_edge_node_01",
+  "adminState": "enabled",
+  "supersedesRef": null,
+  "definitionDigest": "sha256:55d51880fb7d938c7d87f0a8190b6d1499ba2c00291dbe55b710be5fc93e6666"
+}

--- a/apps/device-service/src/device_service/schemas/DeviceProfile.json
+++ b/apps/device-service/src/device_service/schemas/DeviceProfile.json
@@ -1,0 +1,328 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/DeviceProfile.json",
+  "title": "DeviceProfile",
+  "description": "What a southbound device IS: the typed, digest-pinned declaration of one class of physical device — its protocol, its protocol binding, and the exact set of readings it produces with units, value types, specified ranges, and protocol-native source addresses. This is the single southbound abstraction the fog-and-citizen plane reads devices through (EdgeX Foundry's lesson: ONE southbound interface, N protocol drivers); a driver implements a protocol, it does not invent a vocabulary. A DeviceReading is admissible only against a profile, and definitionDigest pins the exact revision it was admitted against so a range cannot be widened after the fact to legalise a reading that already failed. Distinct from DeviceIdentity, which governs admission and trust for a SourceOS operator workstation, not the metrology of a sensor; the two bind via identityRef rather than competing.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "deviceClass",
+    "protocol",
+    "protocolBinding",
+    "metrics",
+    "definitionDigest",
+    "declaredAt"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:device-profile:[A-Za-z0-9._~-]+$",
+      "description": "Stable URN identifier. Pattern: urn:srcos:device-profile:<local-id>. Invariant: profile identity is stable and never reused; a changed declaration is a new profile that names its predecessor via supersedesRef."
+    },
+    "type": {
+      "const": "DeviceProfile",
+      "description": "Discriminator constant — always \"DeviceProfile\"."
+    },
+    "specVersion": {
+      "const": "0.1.0",
+      "description": "DeviceService contract version, pinned per the policy-integrity tranche-0001 discipline. This family is versioned independently of the v2 metadata-plane schemas; changing this const is a contract change."
+    },
+    "actorRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Authority reference of the actor that emitted this event (human subject, agent, service, or system). Subject or Agent Registry URNs are recommended; free-form identifiers are permitted in v0.1."
+    },
+    "workspaceRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Workspace scope this event belongs to. Free-form stable reference in v0.1; a typed workspace URN may narrow this in a later minor version."
+    },
+    "visibilityScope": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A visibility scope label such as private, shared, public, or an audience URN."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Visibility scopes governing who may observe this event (e.g. private, shared, public, or audience URNs)."
+    },
+    "provenanceLinks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "rel",
+          "ref"
+        ],
+        "properties": {
+          "rel": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Relation of the linked artifact to this event (e.g. derived_from, quotes, source_feed)."
+          },
+          "ref": {
+            "type": "string",
+            "minLength": 1,
+            "description": "URN or stable reference of the linked artifact."
+          }
+        },
+        "description": "A single provenance link (relation + reference)."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Typed provenance links from this event to upstream artifacts, sources, or records."
+    },
+    "policyLabels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A policy label."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Policy labels attached to this event by producers or the policy fabric."
+    },
+    "riskLabels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A risk label."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Risk labels attached to this event by producers or risk controls."
+    },
+    "deviceClass": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable slug for the class of device this profile describes (e.g. acme-th-100-thermostat). Profiles describe a device MODEL; instances cite the profile by URN in every reading."
+    },
+    "manufacturer": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Device manufacturer, as printed on the device or its datasheet."
+    },
+    "model": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Manufacturer's model designation."
+    },
+    "protocol": {
+      "type": "string",
+      "enum": [
+        "ble-gatt",
+        "zigbee",
+        "z-wave",
+        "matter",
+        "modbus-tcp",
+        "mqtt",
+        "coap",
+        "snmp",
+        "http-poll",
+        "virtual"
+      ],
+      "description": "Southbound protocol a driver must speak to reach this device. \"virtual\" denotes a simulated device with no physical counterpart — it is a first-class, visibly distinguishable member of the taxonomy precisely so that simulated readings can never be mistaken for measured ones downstream."
+    },
+    "protocolBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "endpoint",
+        "securityMode"
+      ],
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Protocol-native endpoint of the device as a whole: BLE peripheral address, Modbus host:port, MQTT broker URL, or virtual:// authority. Per-metric addressing lives in metrics[].sourceAddress."
+        },
+        "securityMode": {
+          "type": "string",
+          "enum": [
+            "none",
+            "psk",
+            "certificate",
+            "pairing-bonded",
+            "token"
+          ],
+          "description": "Transport security posture of the southbound link. \"none\" is legal and must stay visible: an unauthenticated sensor link is a stated risk, not an omission."
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": [
+              "string",
+              "number",
+              "integer",
+              "boolean"
+            ],
+            "description": "A scalar binding parameter value."
+          },
+          "description": "Scalar protocol parameters the driver needs (e.g. unitId for Modbus, connectionIntervalMs for BLE). Scalars only: a nested blob here would be an untyped escape hatch."
+        }
+      },
+      "description": "How a driver reaches this device: endpoint, transport security posture, and scalar protocol parameters."
+    },
+    "metrics": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "metric",
+          "valueType",
+          "unit",
+          "sourceAddress"
+        ],
+        "properties": {
+          "metric": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$",
+            "description": "Metric name, unique within this profile. Lowercase dot-separated segments (e.g. temperature, air.pm2_5). This is the name a DeviceReading cites."
+          },
+          "kkoTypeRef": {
+            "type": "string",
+            "format": "uri",
+            "description": "Ontology class URI of the observed quantity. Shares the URI vocabulary of KnowledgeNugget.kkoTypeRefs and SemanticAction slot types, so a reading binds as a typed graph value without a second ontology mapping. Producers SHOULD cite a class they can verify exists in the ontology the estate actually vendors: the KKO upper ontology (http://kbpedia.org/ontologies/kko#, 169 terms) is vendored; the ~58k KBpedia reference-concept layer that would carry a concept as specific as \"temperature\" is NOT, and citing an unvendored URI is an unresolvable type ref wearing the appearance of one."
+          },
+          "valueType": {
+            "type": "string",
+            "enum": [
+              "number",
+              "integer",
+              "boolean",
+              "string"
+            ],
+            "description": "JSON type of DeviceReading.value for this metric. A reading whose value type disagrees with this declaration is inadmissible."
+          },
+          "unit": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Unit symbol of the reading value (UCUM symbol recommended, e.g. Cel, %, ug/m3). Use \"1\" for a dimensionless ratio and \"{bool}\" for a boolean state. A reading MUST repeat this unit verbatim so it is self-describing at the point of consumption."
+          },
+          "minimum": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Inclusive lower bound of the device's specified operating range for this metric. Required for number/integer metrics: a numeric metric with no declared range cannot distinguish a real excursion from a decode error."
+          },
+          "maximum": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "description": "Inclusive upper bound of the device's specified operating range for this metric. Required for number/integer metrics."
+          },
+          "resolution": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "exclusiveMinimum": 0,
+            "description": "Smallest reportable increment of this metric in declared units, when the device specifies one."
+          },
+          "samplePeriodMs": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 1,
+            "description": "Nominal sampling period in milliseconds. Consumers use it to distinguish an overdue reading from an absent device; it is a declaration, not a guarantee."
+          },
+          "sourceAddress": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Protocol-native address this metric is read from — the BLE GATT characteristic UUID, Modbus register, MQTT topic, or virtual:// path. A DeviceReading MUST repeat it verbatim, which is what proves the value came from the declared physical channel of the declared metric rather than from somewhere else."
+          },
+          "access": {
+            "type": "string",
+            "enum": [
+              "read"
+            ],
+            "default": "read",
+            "description": "Access mode. Closed to \"read\" at v0.1: this contract is a southbound READ abstraction. Commanding a device is a world-changing effect and must travel the MPCC EffectRequest -> EffectDecision lifecycle, not a widened enum here."
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "valueType": {
+                  "enum": [
+                    "number",
+                    "integer"
+                  ]
+                }
+              },
+              "required": [
+                "valueType"
+              ]
+            },
+            "then": {
+              "required": [
+                "minimum",
+                "maximum"
+              ],
+              "properties": {
+                "minimum": {
+                  "type": "number"
+                },
+                "maximum": {
+                  "type": "number"
+                }
+              },
+              "description": "A numeric metric MUST declare a real (non-null) operating range. Without one there is no way to tell a genuine excursion from a decode error, and every out-of-range value becomes admissible by default."
+            }
+          }
+        ],
+        "description": "One metric this device produces: its name, ontology type, value type, unit, specified range, and the protocol-native address it is read from."
+      },
+      "description": "The complete set of readings this device produces. A profile that declares no metric describes nothing; a reading citing a metric absent from this set is inadmissible."
+    },
+    "definitionDigest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "description": "sha256 over the canonical JSON (sorted keys, no whitespace) of the declared-capability projection {deviceClass, protocol, metrics}. Recomputed — never merely read back — by tools/validate_device_service_examples.py. Every DeviceReading pins this value, so widening a range after the fact produces a new digest and orphans the readings it was meant to legalise instead of silently admitting them."
+    },
+    "declaredAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 time this profile revision was declared."
+    },
+    "identityRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:device-identity:[A-Za-z0-9._~-]+$",
+      "description": "DeviceIdentity URN of the SourceOS host that owns the southbound link to this device (the gateway workstation or edge node), when one is registered. Binds sensor metrology to the existing admission/attestation family instead of duplicating trust vocabulary."
+    },
+    "adminState": {
+      "type": "string",
+      "enum": [
+        "enabled",
+        "disabled"
+      ],
+      "default": "enabled",
+      "description": "Operator intent for devices of this class. \"disabled\" means readings are not to be ingested; it is an authorisation state, not a liveness observation."
+    },
+    "supersedesRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:device-profile:[A-Za-z0-9._~-]+$",
+      "description": "DeviceProfile URN this revision supersedes, so a declaration change is an auditable chain rather than an in-place edit."
+    }
+  }
+}

--- a/apps/device-service/src/device_service/schemas/DeviceReading.json
+++ b/apps/device-service/src/device_service/schemas/DeviceReading.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/DeviceReading.json",
+  "title": "DeviceReading",
+  "description": "One observation from one southbound device: a single metric's value, in a declared unit, at a declared instant, with a declared quality. Profile of the ConversationEvent envelope: shares the single MPCC identity/causality/governance vocabulary (actorRef, workspaceRef, branchRef, visibilityScope, wallTime, logicalTime, causalParents, traceContext, provenanceLinks, policyLabels, riskLabels) with byte-identical sub-schemas — parity is enforced by tools/validate_device_service_examples.py. Normative: a reading is ATTRIBUTABLE OR IT IS NOTHING. deviceRef, deviceProfileRef, profileDigest, metric, sourceAddress and unit are all required, so every value resolves to the physical thing that produced it, the exact declared-capability revision it was admitted against, and the protocol-native channel it came off. An unattributable reading is the silent-wrong this contract exists to make impossible.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "deviceRef",
+    "deviceProfileRef",
+    "profileDigest",
+    "metric",
+    "sourceAddress",
+    "value",
+    "unit",
+    "quality",
+    "observedAt",
+    "wallTime"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:device-reading:[A-Za-z0-9._~-]+$",
+      "description": "Stable URN identifier. Pattern: urn:srcos:device-reading:<local-id>. Invariant: reading identity is stable and never reused."
+    },
+    "type": {
+      "const": "DeviceReading",
+      "description": "Discriminator constant — always \"DeviceReading\"."
+    },
+    "specVersion": {
+      "const": "0.1.0",
+      "description": "DeviceService contract version, pinned per the policy-integrity tranche-0001 discipline. This family is versioned independently of the v2 metadata-plane schemas; changing this const is a contract change."
+    },
+    "actorRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Authority reference of the actor that emitted this event (human subject, agent, service, or system). Subject or Agent Registry URNs are recommended; free-form identifiers are permitted in v0.1."
+    },
+    "workspaceRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Workspace scope this event belongs to. Free-form stable reference in v0.1; a typed workspace URN may narrow this in a later minor version."
+    },
+    "branchRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Conversation-fabric branch this event was appended to. Free-form stable reference in v0.1, pending adoption of the profit-mpcc branch-id contract."
+    },
+    "visibilityScope": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A visibility scope label such as private, shared, public, or an audience URN."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Visibility scopes governing who may observe this event (e.g. private, shared, public, or audience URNs)."
+    },
+    "wallTime": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 wall-clock time of the event as observed by the producer. Family profiles map their primary domain timestamp onto this field."
+    },
+    "logicalTime": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "minimum": 0,
+      "minLength": 1,
+      "description": "Producer-scoped logical clock: a non-negative integer for scalar (Lamport-style) clocks, or a non-empty string for encoded vector/hybrid clocks. Invariant: causalParents must never point forward in logical time."
+    },
+    "causalParents": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^urn:srcos:[a-z0-9-]+:[A-Za-z0-9._~-]+$",
+        "description": "URN of a causally preceding event in any MPCC event family."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Event URNs this event causally depends on. Cross-family parents are permitted (e.g. an OrderIntent caused by a MarketDataEvent). Invariant: parents must never point forward in logical time."
+    },
+    "traceContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "traceId"
+      ],
+      "properties": {
+        "traceId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Distributed trace identifier."
+        },
+        "spanId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Span identifier within the trace."
+        },
+        "baggage": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "String-valued trace baggage entries."
+        }
+      },
+      "description": "Optional distributed-tracing correlation context."
+    },
+    "provenanceLinks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "rel",
+          "ref"
+        ],
+        "properties": {
+          "rel": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Relation of the linked artifact to this event (e.g. derived_from, quotes, source_feed)."
+          },
+          "ref": {
+            "type": "string",
+            "minLength": 1,
+            "description": "URN or stable reference of the linked artifact."
+          }
+        },
+        "description": "A single provenance link (relation + reference)."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Typed provenance links from this event to upstream artifacts, sources, or records."
+    },
+    "policyLabels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A policy label."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Policy labels attached to this event by producers or the policy fabric."
+    },
+    "riskLabels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A risk label."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Risk labels attached to this event by producers or risk controls."
+    },
+    "deviceRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:device:[A-Za-z0-9._~-]+$",
+      "description": "URN of the device INSTANCE that produced this reading — the individual physical thing, stable across profile revisions and across its own re-commissioning. Required: a reading that cannot name its device is unattributable."
+    },
+    "deviceProfileRef": {
+      "type": "string",
+      "pattern": "^urn:srcos:device-profile:[A-Za-z0-9._~-]+$",
+      "description": "DeviceProfile URN this reading is admissible against. Required: the profile is what makes a bare number mean something."
+    },
+    "profileDigest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$",
+      "description": "The referenced profile's definitionDigest at the instant this reading was admitted. Pins the exact declared-capability revision: if the profile is later widened, this reading still records which contract it actually passed, and a mismatch is detectable rather than silently forgiven."
+    },
+    "metric": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$",
+      "description": "Name of the metric observed. Must be declared in the referenced profile's metrics set."
+    },
+    "sourceAddress": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Protocol-native address this value was actually read from. Must equal the sourceAddress the profile declares for this metric — that equality is what proves the value came off the declared physical channel and not from an adjacent characteristic, register, or topic."
+    },
+    "value": {
+      "type": [
+        "number",
+        "boolean",
+        "string",
+        "null"
+      ],
+      "description": "The observed value, in the declared unit, of the type the profile declares for this metric. null is legal ONLY for quality \"unavailable\", where it must be accompanied by nullAbsenceRef — a typed absence, never an untyped hole."
+    },
+    "unit": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unit symbol of value, repeated verbatim from the profile's declaration for this metric. Deliberately redundant: consumers read readings, not profiles, and a value whose unit must be looked up elsewhere is a unit-confusion incident waiting to happen. The validator enforces the equality."
+    },
+    "quality": {
+      "type": "string",
+      "enum": [
+        "ok",
+        "degraded",
+        "stale",
+        "substituted",
+        "unavailable"
+      ],
+      "description": "Observation quality, closed at v0.1: ok (measured, within specification); degraded (measured, but the driver has cause to doubt it); stale (a cached prior value re-reported because the device did not answer in time); substituted (a value supplied by something other than the device, e.g. a default or an interpolation); unavailable (no value — the device produced nothing). Invariant: stale and substituted are NOT ok, and substituted is NOT measured. Conflating them is how a smart-home twin comes to believe a default is a measurement."
+    },
+    "observedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 instant the device observed the value, as close to the sensor as the protocol permits. Distinct from wallTime (the producer's event time) and receivedAt (arrival at the DeviceService): observedAt -> receivedAt is the southbound latency a twin's sync budget is actually spent on, and collapsing them hides it."
+    },
+    "receivedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 instant the DeviceService received this value from the driver. Invariant: never earlier than observedAt."
+    },
+    "sequenceRef": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "minimum": 0,
+      "minLength": 1,
+      "description": "Driver-scoped monotonic sequence number (non-negative integer) or sequence token (non-empty string) for this device+metric stream, used for gap detection. A gap is reported as a typed absence, not inferred from silence."
+    },
+    "nullAbsenceRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:null-absence:[A-Za-z0-9._~-]+$",
+      "description": "NullAbsenceRecord URN typing the absence when quality is \"unavailable\". Reuses the existing 12-kind MPCC absence taxonomy rather than inventing a device-local one, so a transport failure is never conflated with a device that intentionally reported nothing."
+    },
+    "qualityFlags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A data-quality flag."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Driver-attached data-quality flags (e.g. out_of_order, recovered_after_gap, low_battery). Advisory detail beneath the closed quality enum, never a substitute for it."
+    },
+    "kkoTypeRef": {
+      "type": "string",
+      "format": "uri",
+      "description": "Ontology class URI of the observed quantity, carried verbatim from the profile's metric declaration so a reading is graph-typed on arrival without a profile lookup. Kept at the granularity the estate can actually resolve (see DeviceProfile.metrics[].kkoTypeRef); the metric name and unit carry the specificity the vendored ontology does not."
+    },
+    "rawPayload": {
+      "type": [
+        "object",
+        "array",
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ],
+      "description": "The driver payload exactly as received from the device, before decoding or normalization (e.g. the BLE characteristic notification as a hex string). Keeping the pre-decode form is what makes a decode bug provable after the fact."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "quality": {
+            "const": "unavailable"
+          }
+        },
+        "required": [
+          "quality"
+        ]
+      },
+      "then": {
+        "properties": {
+          "value": {
+            "type": "null"
+          }
+        },
+        "required": [
+          "nullAbsenceRef"
+        ],
+        "not": {
+          "properties": {
+            "nullAbsenceRef": {
+              "type": "null"
+            }
+          },
+          "required": [
+            "nullAbsenceRef"
+          ]
+        }
+      },
+      "else": {
+        "properties": {
+          "value": {
+            "not": {
+              "type": "null"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/apps/device-service/src/device_service/schemas/NullAbsenceRecord.json
+++ b/apps/device-service/src/device_service/schemas/NullAbsenceRecord.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/NullAbsenceRecord.json",
+  "title": "NullAbsenceRecord",
+  "description": "A first-class record of an observed absence, typed by the 12-kind MPCC null/absence taxonomy so that event semantics, merge logic, provenance, policy, and effect handling never silently conflate materially different kinds of \"nothing\". Working invariants: no_event_observed is not empty_payload; transport_failure is not intentional_silence; refusal is not abstention. Provenance: SocioProphet/profit-mpcc schemas/null-absence.schema.json and docs/null-absence-taxonomy.md, hardened to the policy-integrity tranche-0001 strictness bar.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "kind",
+    "observedAt"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:null-absence:[A-Za-z0-9._~-]+$",
+      "description": "Stable URN identifier. Pattern: urn:srcos:null-absence:<local-id>"
+    },
+    "type": {
+      "const": "NullAbsenceRecord",
+      "description": "Discriminator constant — always \"NullAbsenceRecord\"."
+    },
+    "specVersion": {
+      "const": "0.1.0",
+      "description": "MPCC event-contract version, pinned per the profit-mpcc policy-integrity tranche-0001 discipline. Changing this const is a contract change."
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "no_event_observed",
+        "empty_payload",
+        "heartbeat",
+        "acknowledgment",
+        "timeout",
+        "transport_failure",
+        "intentional_silence",
+        "abstention",
+        "refusal",
+        "withheld_redacted",
+        "tombstone",
+        "explicit_noop"
+      ],
+      "description": "The kind of absence observed. no_event_observed: no event is known to exist for the interval or scope. empty_payload: an event exists but its payload is intentionally or structurally empty. heartbeat: a liveness signal with minimal semantic content. acknowledgment: a bounded acknowledgment referencing prior state or receipt. timeout: an expected response did not arrive within the governing temporal boundary. transport_failure: the absence arises from channel failure rather than communicative intent. intentional_silence: an actor intentionally emits nothing within scope. abstention: an actor declines to decide or endorse while remaining inside the protocol. refusal: an actor explicitly declines a request, command, delegation, or effect. withheld_redacted: content exists but is withheld or masked under policy or privacy constraints. tombstone: a deletion marker preserving identity and history while negating payload visibility. explicit_noop: a first-class no-op event recording deliberate non-action."
+    },
+    "observedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 date-time when the absence was observed or established."
+    },
+    "relatedEventRef": {
+      "type": ["string", "null"],
+      "pattern": "^urn:srcos:[a-z0-9-]+:[A-Za-z0-9._~-]+$",
+      "description": "URN of the MPCC event this absence relates to (e.g. the last event before a gap, or the event whose reply never arrived)."
+    },
+    "relatedBranchRef": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "description": "Conversation-fabric branch scope of the absence, when applicable."
+    },
+    "relatedWorkspaceRef": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "description": "Workspace scope of the absence, when applicable."
+    },
+    "causalNotes": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable note on the causal interpretation of the absence."
+    },
+    "policyLabels": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A policy label."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Policy labels attached to this absence record."
+    },
+    "provenanceLinks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["rel", "ref"],
+        "properties": {
+          "rel": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Relation of the linked artifact to this event (e.g. derived_from, quotes, source_feed)."
+          },
+          "ref": {
+            "type": "string",
+            "minLength": 1,
+            "description": "URN or stable reference of the linked artifact."
+          }
+        },
+        "description": "A single provenance link (relation + reference)."
+      },
+      "uniqueItems": true,
+      "default": [],
+      "description": "Typed provenance links from this event to upstream artifacts, sources, or records."
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Bounded kind-specific detail payload (e.g. expected sequence numbers for a gap). Keep minimal; recurring keys should be promoted to typed fields in a later minor version."
+    }
+  }
+}

--- a/apps/device-service/src/device_service/server.py
+++ b/apps/device-service/src/device_service/server.py
@@ -1,0 +1,241 @@
+"""device-service — FOG & CITIZEN PLANE W8.7: the estate's southbound device plane.
+
+ONE southbound interface (sourceos-spec DeviceProfile/DeviceReading v0.1.0, VENDORED and
+sha256-asserted at import), N protocol drivers. Readings are validated fail-closed
+against BOTH the schema and the profile they cite, written to the platform log as
+hellgraph-service graph writes (KKO-typed, quality-labelled), and sealed one receipt per
+batch on the estate spine via compute-gateway POST /v1/compute kind=materialize. Never a
+fifth receipt lineage.
+
+/healthz always answers 200 with the truth. Failures are counted and surfaced, never
+emitted. Liveness is "the process and loop are up", not "every dependency is green" — a
+producer has no traffic to gate, and restarting it cannot fix a down hellgraph.
+
+`validation_failures` MUST be 0 in steady state. It counts readings that failed the
+schema OR failed attribution against their profile; nonzero means a device disagrees
+with its own declaration, which is a fault or a wrong profile, and either way is the
+alarm this service exists to raise.
+
+`simulated_devices` is reported next to `devices` on purpose. This deployment ships ONE
+driver, `virtual`, and its readings are simulated. Anything that reads /healthz can tell
+at a glance how much of this stream is a measurement and how much is not.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from contextlib import asynccontextmanager
+from importlib import resources
+from typing import Any
+
+from fastapi import FastAPI
+
+from . import contract
+from .clients import GatewayClient, HellGraphWriter
+from .drivers import DriverUnavailable, build_driver
+from .emitter import CommissionedDevice, Emitter
+
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+log = logging.getLogger("device_service")
+
+HELLGRAPH_URL = os.getenv("HELLGRAPH_URL", "http://hellgraph-service:8090")
+COMPUTE_GATEWAY_URL = os.getenv("COMPUTE_GATEWAY_URL", "http://compute-gateway:8080")
+GATEWAY_TOKEN = os.getenv("GATEWAY_TOKEN", "")
+DEVICE_PROJECT = os.getenv("DEVICE_PROJECT", "default")
+
+POLL_ENABLED = os.getenv("DEVICE_POLL_ENABLED", "on").lower() in ("on", "true", "1", "yes")
+POLL_INTERVAL = float(os.getenv("DEVICE_POLL_INTERVAL_SECONDS", "5"))
+WORKSPACE_REF = os.getenv("DEVICE_WORKSPACE_REF", "urn:srcos:workspace:citizen_home_demo")
+BRANCH_REF = os.getenv("DEVICE_BRANCH_REF", "urn:srcos:branch:home_main")
+
+#: Commissioned devices: "<deviceRef>=<profile-name>" pairs, comma-separated. The profile
+#: name resolves to src/device_service/profiles/<name>.json. In v0.1 the instance ->
+#: profile binding lives here; every reading carries both refs plus the profile digest so
+#: the binding is auditable from the graph (see specs/device-service-contract.md §11).
+DEVICES = os.getenv(
+    "DEVICE_COMMISSIONED",
+    "urn:srcos:device:room_sensor_01=virtual-room-sensor,"
+    "urn:srcos:device:room_sensor_02=virtual-room-sensor",
+)
+VIRTUAL_SEED = int(os.getenv("DEVICE_VIRTUAL_SEED", "42"))
+#: 0 = never. Non-zero makes the virtual driver report a TYPED absence every Nth tick, so
+#: the unavailable -> NullAbsenceRecord path is exercisable on a live deployment.
+VIRTUAL_DROP_EVERY_N = int(os.getenv("DEVICE_VIRTUAL_DROP_EVERY_N", "0"))
+
+STATE: dict[str, Any] = {
+    "enabled": POLL_ENABLED,
+    "poll_interval_seconds": POLL_INTERVAL,
+    "devices": 0,
+    "simulated_devices": 0,
+    "protocols": {},
+    "polled": 0,
+    "emitted": 0,
+    "validation_failures": 0,   # steady-state MUST be 0 — nonzero is the alarm
+    "driver_failures": 0,
+    "pending": 0,
+    "receipts": 0,
+    "last_receipt_id": None,
+    "quality_counts": {},
+    "hellgraph_ok": None,       # None = never asked, not "green"
+    "gateway_ok": None,
+    "last_emit_at": None,
+    "last_error": None,
+    "last_error_at": None,
+    "loop_running": False,
+}
+_STATE_LOCK = threading.Lock()
+_EMITTER: Emitter | None = None
+
+
+def load_profile_file(name: str) -> dict[str, Any]:
+    raw = (resources.files("device_service") / "profiles" / f"{name}.json").read_text("utf-8")
+    return contract.load_profile(json.loads(raw))
+
+
+def build_emitter() -> Emitter:
+    devices: list[CommissionedDevice] = []
+    for spec in (s.strip() for s in DEVICES.split(",") if s.strip()):
+        if "=" not in spec:
+            raise ValueError(
+                f"DEVICE_COMMISSIONED entry {spec!r} is not <deviceRef>=<profile-name>"
+            )
+        device_ref, profile_name = (part.strip() for part in spec.split("=", 1))
+        profile = load_profile_file(profile_name)
+        driver = build_driver(
+            profile,
+            device_ref,
+            {"seed": VIRTUAL_SEED, "drop_every_n": VIRTUAL_DROP_EVERY_N},
+        )
+        devices.append(CommissionedDevice(device_ref=device_ref, profile=profile, driver=driver))
+    if not devices:
+        raise ValueError("no devices commissioned — refusing to run a device plane with no devices")
+    return Emitter(
+        devices,
+        HellGraphWriter(HELLGRAPH_URL),
+        GatewayClient(COMPUTE_GATEWAY_URL, GATEWAY_TOKEN, project=DEVICE_PROJECT),
+        workspace_ref=WORKSPACE_REF,
+        branch_ref=BRANCH_REF,
+    )
+
+
+def _apply(result: Any) -> None:
+    with _STATE_LOCK:
+        STATE["polled"] += result.polled
+        STATE["emitted"] += result.emitted
+        STATE["validation_failures"] += result.validation_failures
+        STATE["driver_failures"] += result.driver_failures
+        STATE["receipts"] += result.receipts
+        STATE["pending"] = result.pending
+        if result.last_receipt_id:
+            STATE["last_receipt_id"] = result.last_receipt_id
+        for quality, count in result.quality_counts.items():
+            STATE["quality_counts"][quality] = STATE["quality_counts"].get(quality, 0) + count
+        # An unchecked dependency is never reported up: only a drain that actually
+        # contacted something may move these flags off None.
+        if result.attempted:
+            STATE["hellgraph_ok"] = result.hellgraph_ok
+            STATE["gateway_ok"] = result.gateway_ok
+        if result.emitted:
+            STATE["last_emit_at"] = time.time()
+
+
+def _loop(emitter: Emitter) -> None:
+    with _STATE_LOCK:
+        STATE["loop_running"] = True
+    while True:
+        try:
+            _apply(emitter.run_once())
+        except Exception as e:  # noqa: BLE001 — the loop must survive any dependency outage
+            with _STATE_LOCK:
+                STATE["hellgraph_ok"] = False
+                STATE["last_error"] = f"{type(e).__name__}: {e}"
+                STATE["last_error_at"] = time.time()
+            log.exception("poll interval failed, retrying after the interval")
+        time.sleep(POLL_INTERVAL)
+
+
+@asynccontextmanager
+async def _lifespan(_app: FastAPI):
+    global _EMITTER
+    if POLL_ENABLED:
+        _EMITTER = build_emitter()
+        # Fail-closed boot gate IN THE MAIN THREAD: schema drift (the vendored sha256 is
+        # already asserted at import), a profile whose digest is not its own, or a probe
+        # reading that does not validate aborts uvicorn startup — a visible crash, never
+        # a silently dead loop behind a green pod. build_emitter() has already refused
+        # any profile whose protocol has no registered driver.
+        _EMITTER.startup_check()
+        with _STATE_LOCK:
+            STATE["devices"] = len(_EMITTER.devices)
+            STATE["simulated_devices"] = _EMITTER.simulated_devices
+            STATE["protocols"] = _EMITTER.protocols
+        threading.Thread(target=_loop, args=(_EMITTER,), name="device-poll-loop",
+                         daemon=True).start()
+    yield
+
+
+app = FastAPI(
+    title="device-service",
+    version="0.1.0",
+    description="W8.7 southbound device plane: one interface, N protocol drivers",
+    lifespan=_lifespan,
+)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    with _STATE_LOCK:
+        snapshot = dict(STATE)
+        snapshot["quality_counts"] = dict(STATE["quality_counts"])
+    if _EMITTER is not None:
+        snapshot["pending"] = _EMITTER.pending_readings
+    return {
+        "ok": True,
+        "service": "device-service",
+        "spec_version": contract.SPEC_VERSION,
+        "profile_schema_sha256": contract.PROFILE_SCHEMA_SHA256,
+        "reading_schema_sha256": contract.READING_SCHEMA_SHA256,
+        "receipt_kind": "materialize",
+        **snapshot,
+    }
+
+
+@app.get("/v1/profiles")
+def profiles() -> dict[str, Any]:
+    """The declared capability of every commissioned device, with its RECOMPUTED digest.
+
+    Exposed because a reading's whole meaning is the profile it pins: a consumer holding
+    a reading must be able to fetch the declaration it names and check the digest itself,
+    rather than taking this service's word for it.
+    """
+    if _EMITTER is None:
+        return {"devices": []}
+    return {
+        "devices": [
+            {
+                "deviceRef": d.device_ref,
+                "deviceProfileRef": d.profile["id"],
+                "protocol": d.profile["protocol"],
+                "simulated": contract.is_simulated(d.profile),
+                "definitionDigest": d.profile["definitionDigest"],
+                "recomputedDigest": contract.definition_digest(d.profile),
+                "metrics": [
+                    {
+                        "metric": m["metric"],
+                        "unit": m["unit"],
+                        "valueType": m["valueType"],
+                        "minimum": m.get("minimum"),
+                        "maximum": m.get("maximum"),
+                        "sourceAddress": m["sourceAddress"],
+                        "kkoTypeRef": m.get("kkoTypeRef"),
+                    }
+                    for m in d.profile["metrics"]
+                ],
+                "sequence": d.seq,
+            }
+            for d in _EMITTER.devices
+        ]
+    }

--- a/apps/device-service/tests/conftest.py
+++ b/apps/device-service/tests/conftest.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import copy
+import json
+from importlib import resources
+from typing import Any
+
+import pytest
+
+from device_service import contract
+
+
+def _profile(name: str) -> dict[str, Any]:
+    raw = (resources.files("device_service") / "profiles" / f"{name}.json").read_text("utf-8")
+    return json.loads(raw)
+
+
+@pytest.fixture
+def virtual_profile() -> dict[str, Any]:
+    return contract.load_profile(_profile("virtual-room-sensor"))
+
+
+@pytest.fixture
+def ble_profile() -> dict[str, Any]:
+    return contract.load_profile(_profile("acme-th100-ble"))
+
+
+@pytest.fixture
+def reading(virtual_profile) -> dict[str, Any]:
+    return contract.build_reading(
+        profile=virtual_profile,
+        device_ref="urn:srcos:device:room_sensor_01",
+        metric="temperature",
+        value=21.5,
+        quality="ok",
+        observed_at="2026-07-29T09:15:00.000Z",
+        received_at="2026-07-29T09:15:00.042Z",
+        wall_time="2026-07-29T09:15:00.042Z",
+        logical_time=117,
+        sequence_ref=117,
+        workspace_ref="urn:srcos:workspace:citizen_home_demo",
+        branch_ref="urn:srcos:branch:home_main",
+        actor_ref="urn:srcos:agent:device_service",
+        raw_payload={"driver": "virtual", "tick": 117},
+    )
+
+
+class FakeWriter:
+    """Records graph writes; can be told to fail after N successful ops."""
+
+    def __init__(self, fail_after: int | None = None) -> None:
+        self.nodes: list[tuple] = []
+        self.edges: list[tuple] = []
+        self.fail_after = fail_after
+        self.ops = 0
+
+    def _maybe_fail(self) -> None:
+        from device_service.clients import EmitError
+
+        if self.fail_after is not None and self.ops >= self.fail_after:
+            raise EmitError("fake hellgraph outage")
+        self.ops += 1
+
+    def post_node(self, node_id, labels, properties) -> None:
+        self._maybe_fail()
+        self.nodes.append((node_id, list(labels), properties))
+
+    def post_edge(self, label, from_id, to_id) -> None:
+        self._maybe_fail()
+        self.edges.append((label, from_id, to_id))
+
+
+class FakeGateway:
+    """Records seals; can refuse. Memoizes by spec, like the real gateway."""
+
+    def __init__(self, refuse: bool = False) -> None:
+        self.calls: list[dict] = []
+        self.refuse = refuse
+        self._memo: dict[str, dict] = {}
+
+    def mint(self, *, device_ref, from_cursor, to_cursor, row_count, batch_hash) -> dict:
+        from device_service.clients import GatewayError
+
+        if self.refuse:
+            raise GatewayError("fake gateway refusal")
+        spec = {
+            "device_ref": device_ref, "from_cursor": from_cursor, "to_cursor": to_cursor,
+            "row_count": row_count, "batch_hash": batch_hash,
+        }
+        self.calls.append(spec)
+        key = json.dumps(spec, sort_keys=True)
+        if key in self._memo:
+            return self._memo[key]
+        receipt = {"id": f"sha256:receipt{len(self._memo):04d}", "kind": "materialize"}
+        self._memo[key] = receipt
+        return receipt
+
+
+@pytest.fixture
+def fake_writer() -> FakeWriter:
+    return FakeWriter()
+
+
+@pytest.fixture
+def fake_gateway() -> FakeGateway:
+    return FakeGateway()
+
+
+@pytest.fixture
+def mutate():
+    def _mutate(doc: dict, **changes: Any) -> dict:
+        out = copy.deepcopy(doc)
+        out.update(changes)
+        return out
+
+    return _mutate

--- a/apps/device-service/tests/test_ble.py
+++ b/apps/device-service/tests/test_ble.py
@@ -1,0 +1,193 @@
+"""The BLE GATT layer — decoders against the Bluetooth SIG formats, and the driver.
+
+This is the part of the real-BLE seam that is REAL. The decoders are where the
+interesting bugs live, and they are testable without a radio, so they are tested here
+rather than deferred along with the transport.
+"""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from device_service import ble
+from device_service.drivers import DriverError
+
+
+# ---------------------------------------------------------------- 0x2A6E temperature
+def test_temperature_decodes_sint16_at_hundredths():
+    assert ble.decode_temperature(b"\x59\x08") == 21.37   # 2137 * 0.01
+    assert ble.decode_temperature(b"\x00\x00") == 0.0
+
+
+def test_temperature_is_SIGNED_and_that_is_the_whole_point():
+    """0x2A6E is sint16. Read as uint16, -5.00 degC decodes to +650.36 — a plausible
+    number that a -40..85 profile range would reject only by luck. The explicit '<h' is
+    the fix; this test is what stops it silently becoming '<H' again."""
+    payload = struct.pack("<h", -500)
+    assert ble.decode_temperature(payload) == -5.0
+    misread = struct.unpack("<H", payload)[0] * 0.01
+    assert misread == pytest.approx(650.36)
+    assert ble.decode_temperature(payload) != misread
+
+
+def test_temperature_rejects_a_wrong_length_payload():
+    for bad in (b"", b"\x59", b"\x59\x08\x00"):
+        with pytest.raises(ble.DecodeError, match="exactly 2 bytes"):
+            ble.decode_temperature(bad)
+
+
+# ------------------------------------------------------------------- 0x2A6F humidity
+def test_humidity_decodes_uint16_at_hundredths():
+    assert ble.decode_humidity(b"\x7c\x15") == 55.0       # 5500 * 0.01
+    assert ble.decode_humidity(b"\x10\x27") == 100.0      # 10000 * 0.01
+
+
+def test_humidity_rejects_a_wrong_length_payload():
+    with pytest.raises(ble.DecodeError, match="exactly 2 bytes"):
+        ble.decode_humidity(b"\x7c")
+
+
+# --------------------------------------------------------------------- 0x2A19 battery
+def test_battery_decodes_uint8_percent():
+    assert ble.decode_battery_level(b"\x57") == 87
+    assert ble.decode_battery_level(b"\x00") == 0
+    assert ble.decode_battery_level(b"\x64") == 100
+
+
+def test_battery_rejects_out_of_spec_values():
+    """A device reporting 255% is faulty. Passing it through would put nonsense in the
+    graph with an `ok` quality attached."""
+    with pytest.raises(ble.DecodeError, match="0..100 percent"):
+        ble.decode_battery_level(b"\xff")
+
+
+# ------------------------------------------------------------------ source addressing
+def test_characteristic_is_extracted_from_the_profile_source_address(ble_profile):
+    declared = {m["metric"]: m for m in ble_profile["metrics"]}
+    assert ble.characteristic_of(declared["temperature"]["sourceAddress"]) == ble.TEMPERATURE_UUID
+    assert ble.characteristic_of(declared["humidity.relative"]["sourceAddress"]) == ble.HUMIDITY_UUID
+    assert ble.characteristic_of(declared["battery.level"]["sourceAddress"]) == ble.BATTERY_LEVEL_UUID
+
+
+def test_a_non_gatt_source_address_is_rejected():
+    with pytest.raises(ble.DecodeError, match="not a GATT source address"):
+        ble.characteristic_of("virtual://room-sensor/temperature")
+    with pytest.raises(ble.DecodeError, match="must be gatt://"):
+        ble.characteristic_of("gatt://only-a-service")
+
+
+def test_every_shipped_ble_profile_metric_has_a_decoder(ble_profile):
+    """A profile may not declare a channel this driver cannot actually read."""
+    for metric in ble_profile["metrics"]:
+        uuid = ble.characteristic_of(metric["sourceAddress"])
+        assert uuid in ble.DECODERS, f"{metric['metric']} declares an undecodable channel"
+
+
+# ------------------------------------------------------------------------ the driver
+class FakeTransport:
+    """A test double for the ONE class that does not ship. Its existence here is the
+    measure of the remaining distance: everything else is already written."""
+
+    def __init__(self, payloads: dict[str, object]) -> None:
+        self.payloads = payloads
+        self.connected = False
+
+    def connect(self) -> None:
+        self.connected = True
+
+    def read_characteristic(self, uuid: str) -> bytes:
+        value = self.payloads[uuid]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def disconnect(self) -> None:
+        self.connected = False
+
+
+def test_the_driver_reads_and_decodes_a_whole_device(ble_profile):
+    transport = FakeTransport({
+        ble.TEMPERATURE_UUID: struct.pack("<h", 2137),
+        ble.HUMIDITY_UUID: struct.pack("<H", 5500),
+        ble.BATTERY_LEVEL_UUID: b"\x57",
+    })
+    driver = ble.BleGattDriver(ble_profile, "urn:srcos:device:th100_bed2", transport)
+    samples = {s.metric: s for s in driver.poll()}
+    assert transport.connected
+    assert samples["temperature"].value == 21.37
+    assert samples["humidity.relative"].value == 55.0
+    assert samples["battery.level"].value == 87
+    assert all(s.quality == "ok" for s in samples.values())
+    # The pre-decode bytes are kept, so a decode bug stays provable after the fact.
+    assert samples["temperature"].raw == {"hex": "5908"}
+
+
+def test_a_timeout_becomes_a_typed_absence_not_a_stale_value(ble_profile):
+    transport = FakeTransport({
+        ble.TEMPERATURE_UUID: struct.pack("<h", 2137),
+        ble.HUMIDITY_UUID: TimeoutError("notify window elapsed"),
+        ble.BATTERY_LEVEL_UUID: b"\x57",
+    })
+    driver = ble.BleGattDriver(ble_profile, "urn:srcos:device:th100_bed2", transport)
+    samples = {s.metric: s for s in driver.poll()}
+    absent = samples["humidity.relative"]
+    assert absent.quality == "unavailable"
+    assert absent.absence_kind == "timeout"
+    assert absent.value is None
+    # The other metrics still report: one silent characteristic is not a dead device.
+    assert samples["temperature"].value == 21.37
+
+
+def test_a_transport_error_is_typed_distinctly_from_a_timeout(ble_profile):
+    transport = FakeTransport({
+        ble.TEMPERATURE_UUID: ConnectionResetError("link dropped"),
+        ble.HUMIDITY_UUID: struct.pack("<H", 5500),
+        ble.BATTERY_LEVEL_UUID: b"\x57",
+    })
+    driver = ble.BleGattDriver(ble_profile, "urn:srcos:device:th100_bed2", transport)
+    samples = {s.metric: s for s in driver.poll()}
+    assert samples["temperature"].absence_kind == "transport_failure"
+
+
+def test_an_undecodable_payload_is_a_FAULT_not_an_absence(ble_profile):
+    """The device answered. Reporting that as 'no data' would hide a broken device behind
+    the same counter as a quiet one."""
+    transport = FakeTransport({
+        ble.TEMPERATURE_UUID: b"\x01\x02\x03",
+        ble.HUMIDITY_UUID: struct.pack("<H", 5500),
+        ble.BATTERY_LEVEL_UUID: b"\x57",
+    })
+    driver = ble.BleGattDriver(ble_profile, "urn:srcos:device:th100_bed2", transport)
+    with pytest.raises(DriverError, match="undecodable payload"):
+        driver.poll()
+
+
+def test_a_failed_connect_is_a_driver_error(ble_profile):
+    class Dead:
+        def connect(self):
+            raise OSError("no adapter")
+
+        def read_characteristic(self, uuid):  # pragma: no cover - never reached
+            raise AssertionError
+
+        def disconnect(self):  # pragma: no cover
+            pass
+
+    driver = ble.BleGattDriver(ble_profile, "urn:srcos:device:th100_bed2", Dead())
+    with pytest.raises(DriverError, match="BLE connect failed"):
+        driver.poll()
+
+
+def test_decoded_values_land_inside_the_profile_declared_ranges(ble_profile):
+    """The decoders and the profile must agree, or every real reading fails the gate."""
+    transport = FakeTransport({
+        ble.TEMPERATURE_UUID: struct.pack("<h", 2137),
+        ble.HUMIDITY_UUID: struct.pack("<H", 5500),
+        ble.BATTERY_LEVEL_UUID: b"\x57",
+    })
+    driver = ble.BleGattDriver(ble_profile, "urn:srcos:device:th100_bed2", transport)
+    declared = {m["metric"]: m for m in ble_profile["metrics"]}
+    for sample in driver.poll():
+        spec = declared[sample.metric]
+        assert spec["minimum"] <= sample.value <= spec["maximum"]

--- a/apps/device-service/tests/test_contract.py
+++ b/apps/device-service/tests/test_contract.py
@@ -1,0 +1,307 @@
+"""The contract layer: vendoring integrity, digest pinning, and the attribution gate.
+
+The negative cases here are the point. A gate that only ever sees conforming input has
+not been tested; it has been visited.
+"""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from importlib import resources
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from device_service import contract
+
+
+# ------------------------------------------------------------------ vendoring
+def test_vendored_schema_hashes_match_the_pins():
+    for name, pinned in (
+        ("DeviceProfile.json", contract.PROFILE_SCHEMA_SHA256),
+        ("DeviceReading.json", contract.READING_SCHEMA_SHA256),
+        ("NullAbsenceRecord.json", contract.ABSENCE_SCHEMA_SHA256),
+    ):
+        raw = (resources.files("device_service") / "schemas" / name).read_bytes()
+        assert hashlib.sha256(raw).hexdigest() == pinned, f"{name} drifted from its pin"
+
+
+def test_schemas_are_valid_2020_12_documents():
+    for schema in (contract.PROFILE_SCHEMA, contract.READING_SCHEMA, contract.ABSENCE_SCHEMA):
+        Draft202012Validator.check_schema(schema)
+
+
+def test_date_time_format_checking_is_actually_wired():
+    """Without rfc3339-validator the date-time checker is a silent no-op, and every
+    timestamp in the family goes unvalidated. contract.py refuses to import in that
+    state; this proves the checker is live rather than merely passed."""
+    assert "date-time" in Draft202012Validator.FORMAT_CHECKER.checkers
+    bad = {"observedAt": "not-a-timestamp"}
+    errors = list(contract.READING_VALIDATOR.iter_errors({**bad}))
+    assert any("not-a-timestamp" in e.message or "date-time" in e.message for e in errors)
+
+
+# --------------------------------------------------------------------- digest
+def test_definition_digest_matches_the_profile_as_written(virtual_profile):
+    assert virtual_profile["definitionDigest"] == contract.definition_digest(virtual_profile)
+
+
+def test_digest_algorithm_is_the_normative_one(virtual_profile):
+    core = {f: virtual_profile[f] for f in ["deviceClass", "protocol", "metrics"]}
+    canonical = json.dumps(core, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    expected = "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    assert contract.definition_digest(virtual_profile) == expected
+
+
+def test_widening_a_range_changes_the_digest(virtual_profile):
+    """THE attack this construct exists to stop: a reading fails the declared range, so
+    somebody widens the range. The digest must move, orphaning the readings that pinned
+    the old one instead of retroactively legalising them."""
+    before = contract.definition_digest(virtual_profile)
+    widened = copy.deepcopy(virtual_profile)
+    widened["metrics"][0]["maximum"] = 200.0
+    assert contract.definition_digest(widened) != before
+
+
+def test_prose_edits_do_not_change_the_digest(virtual_profile):
+    """The converse: a documentation change must NOT orphan live readings."""
+    before = contract.definition_digest(virtual_profile)
+    edited = copy.deepcopy(virtual_profile)
+    edited["manufacturer"] = "Someone Else"
+    edited["declaredAt"] = "2027-01-01T00:00:00.000Z"
+    edited["policyLabels"] = edited["policyLabels"] + ["extra:label"]
+    assert contract.definition_digest(edited) == before
+
+
+def test_load_profile_refuses_a_lying_digest(virtual_profile):
+    lying = copy.deepcopy(virtual_profile)
+    lying["definitionDigest"] = "sha256:" + "0" * 64
+    with pytest.raises(contract.ContractError, match="not the digest of its own"):
+        contract.load_profile(lying)
+
+
+def test_load_profile_refuses_duplicate_metric_names(virtual_profile):
+    dupe = copy.deepcopy(virtual_profile)
+    dupe["metrics"].append(copy.deepcopy(dupe["metrics"][0]))
+    dupe["definitionDigest"] = contract.definition_digest(dupe)
+    with pytest.raises(contract.ContractError, match="duplicate metric"):
+        contract.load_profile(dupe)
+
+
+# ---------------------------------------------------------------- attribution
+def test_a_built_reading_is_attributable(reading, virtual_profile):
+    contract.validate_reading(reading, virtual_profile)
+    for key in ("deviceRef", "deviceProfileRef", "profileDigest", "metric",
+                "sourceAddress", "unit", "quality", "observedAt"):
+        assert reading[key], f"{key} must be present and non-empty"
+
+
+def test_the_builder_copies_attribution_from_the_profile_not_the_caller(reading, virtual_profile):
+    """A driver reports a value; it cannot supply the fields that give it meaning."""
+    declared = contract.metric_of(virtual_profile, "temperature")
+    assert reading["unit"] == declared["unit"]
+    assert reading["sourceAddress"] == declared["sourceAddress"]
+    assert reading["kkoTypeRef"] == declared["kkoTypeRef"]
+    assert reading["profileDigest"] == virtual_profile["definitionDigest"]
+
+
+def test_provenance_links_name_both_the_device_and_the_profile(reading):
+    refs = {link["ref"] for link in reading["provenanceLinks"]}
+    assert reading["deviceRef"] in refs
+    assert reading["deviceProfileRef"] in refs
+
+
+@pytest.mark.parametrize(
+    "field,value,match",
+    [
+        ("unit", "[degF]", "contradicts the declared"),
+        ("sourceAddress", "virtual://room-sensor/humidity.relative", "not the channel declared"),
+        ("profileDigest", "sha256:" + "1" * 64, "recomputed digest"),
+        ("deviceProfileRef", "urn:srcos:device-profile:someone_else", "validated against"),
+        ("kkoTypeRef", "http://example.org/Nope", "kkoTypeRef disagrees"),
+    ],
+)
+def test_attribution_drift_is_refused(reading, virtual_profile, mutate, field, value, match):
+    with pytest.raises(contract.ContractError, match=match):
+        contract.validate_reading(mutate(reading, **{field: value}), virtual_profile)
+
+
+def test_value_outside_the_declared_range_is_refused(reading, virtual_profile, mutate):
+    with pytest.raises(contract.ContractError, match="outside the declared operating range"):
+        contract.validate_reading(mutate(reading, value=900.0), virtual_profile)
+
+
+def test_value_of_the_wrong_declared_type_is_refused(reading, virtual_profile, mutate):
+    with pytest.raises(contract.ContractError, match="not the declared number"):
+        contract.validate_reading(mutate(reading, value="21.5"), virtual_profile)
+
+
+def test_undeclared_metric_is_refused(reading, virtual_profile, mutate):
+    with pytest.raises(contract.ContractError, match="not declared by"):
+        contract.validate_reading(mutate(reading, metric="pressure"), virtual_profile)
+
+
+def test_received_before_observed_is_refused(reading, virtual_profile, mutate):
+    with pytest.raises(contract.ContractError, match="receivedAt precedes observedAt"):
+        contract.validate_reading(
+            mutate(reading, receivedAt="2026-07-29T09:14:00.000Z"), virtual_profile
+        )
+
+
+def test_schema_violations_are_refused(reading, virtual_profile, mutate):
+    with pytest.raises(contract.ContractError, match="schema"):
+        contract.validate_reading(mutate(reading, specVersion="0.2.0"), virtual_profile)
+    with pytest.raises(contract.ContractError, match="schema"):
+        contract.validate_reading(mutate(reading, quality="estimated"), virtual_profile)
+    with pytest.raises(contract.ContractError, match="schema"):
+        contract.validate_reading(mutate(reading, observedAt="yesterday"), virtual_profile)
+
+
+# ------------------------------------------------------- simulated visibility
+def test_a_simulated_reading_carries_its_labels(reading):
+    assert contract.SIMULATED_LABEL in reading["policyLabels"]
+    assert contract.SIMULATED_RISK in reading["riskLabels"]
+
+
+def test_stripping_the_simulated_label_is_refused(reading, virtual_profile, mutate):
+    with pytest.raises(contract.ContractError, match="visibly distinguishable"):
+        contract.validate_reading(mutate(reading, policyLabels=[]), virtual_profile)
+
+
+def test_a_physical_reading_may_not_claim_to_be_simulated(ble_profile):
+    physical = contract.build_reading(
+        profile=ble_profile,
+        device_ref="urn:srcos:device:th100_bed2",
+        metric="temperature",
+        value=21.0,
+        quality="ok",
+        observed_at="2026-07-29T09:15:00.000Z",
+        received_at="2026-07-29T09:15:00.100Z",
+        wall_time="2026-07-29T09:15:00.100Z",
+        logical_time=1,
+        sequence_ref=1,
+        workspace_ref="urn:srcos:workspace:citizen_home_demo",
+        branch_ref="urn:srcos:branch:home_main",
+        actor_ref="urn:srcos:agent:device_service",
+    )
+    assert contract.SIMULATED_LABEL not in physical["policyLabels"]
+    contract.validate_reading(physical, ble_profile)
+    physical["policyLabels"] = [contract.SIMULATED_LABEL]
+    with pytest.raises(contract.ContractError, match="must not be labelled simulated"):
+        contract.validate_reading(physical, ble_profile)
+
+
+# ------------------------------------------------------------- typed absence
+def _absent(profile, **over):
+    base = dict(
+        profile=profile,
+        device_ref="urn:srcos:device:room_sensor_01",
+        metric="temperature",
+        value=None,
+        quality="unavailable",
+        observed_at="2026-07-29T09:15:00.000Z",
+        received_at="2026-07-29T09:15:00.042Z",
+        wall_time="2026-07-29T09:15:00.042Z",
+        logical_time=200,
+        sequence_ref=200,
+        workspace_ref="urn:srcos:workspace:citizen_home_demo",
+        branch_ref="urn:srcos:branch:home_main",
+        actor_ref="urn:srcos:agent:device_service",
+    )
+    base.update(over)
+    return contract.build_reading(**base)
+
+
+def test_an_absence_is_typed_end_to_end(virtual_profile):
+    reading_id = "urn:srcos:device-reading:" + contract.reading_local_id(
+        "urn:srcos:device:room_sensor_01", "temperature", 200
+    )
+    record = contract.build_absence_record(
+        reading_id=reading_id, kind="timeout", observed_at="2026-07-29T09:15:00.000Z",
+        workspace_ref="urn:srcos:workspace:citizen_home_demo",
+        branch_ref="urn:srcos:branch:home_main",
+        device_ref="urn:srcos:device:room_sensor_01", metric="temperature",
+        expected_next_sequence=201, causal_notes="no notification in the window",
+    )
+    reading = _absent(virtual_profile, null_absence_ref=record["id"])
+    contract.validate_reading(reading, virtual_profile)
+    contract.validate_absence_record(record, reading)
+    assert reading["value"] is None
+    assert record["kind"] == "timeout"
+
+
+def test_an_untyped_absence_is_refused_by_the_schema(virtual_profile):
+    with pytest.raises(contract.ContractError, match="schema"):
+        contract.validate_reading(_absent(virtual_profile), virtual_profile)
+
+
+def test_an_absence_carrying_a_value_is_refused(virtual_profile):
+    reading = _absent(virtual_profile, null_absence_ref="urn:srcos:null-absence:x")
+    reading["value"] = 21.0
+    with pytest.raises(contract.ContractError, match="schema"):
+        contract.validate_reading(reading, virtual_profile)
+
+
+def test_a_driver_may_not_assert_intent_it_cannot_observe():
+    """`intentional_silence` and `refusal` are claims about a device's intent. A
+    southbound driver has no basis for either; asserting one would be inventing a cause."""
+    for kind in ("intentional_silence", "refusal", "withheld_redacted"):
+        with pytest.raises(contract.ContractError, match="not one a southbound driver"):
+            contract.build_absence_record(
+                reading_id="urn:srcos:device-reading:x", kind=kind,
+                observed_at="2026-07-29T09:15:00.000Z", workspace_ref="w", branch_ref="b",
+                device_ref="urn:srcos:device:d", metric="temperature",
+                expected_next_sequence=1, causal_notes="n",
+            )
+
+
+def test_a_dangling_absence_reference_is_refused(virtual_profile):
+    reading = _absent(virtual_profile, null_absence_ref="urn:srcos:null-absence:wrong_one")
+    record = contract.build_absence_record(
+        reading_id=reading["id"], kind="timeout", observed_at="2026-07-29T09:15:00.000Z",
+        workspace_ref="w", branch_ref="b", device_ref="urn:srcos:device:room_sensor_01",
+        metric="temperature", expected_next_sequence=201, causal_notes="n",
+    )
+    with pytest.raises(contract.ContractError, match="does not name this absence record"):
+        contract.validate_absence_record(record, reading)
+
+
+# ------------------------------------------------------------- misc contract
+def test_reading_ids_are_deterministic():
+    a = contract.reading_local_id("urn:srcos:device:room_sensor_01", "humidity.relative", 7)
+    b = contract.reading_local_id("urn:srcos:device:room_sensor_01", "humidity.relative", 7)
+    assert a == b
+    assert a != contract.reading_local_id("urn:srcos:device:room_sensor_02", "humidity.relative", 7)
+
+
+def test_reading_ids_satisfy_the_urn_pattern(virtual_profile, reading):
+    import re
+
+    pattern = contract.READING_SCHEMA["properties"]["id"]["pattern"]
+    assert re.match(pattern, reading["id"])
+
+
+def test_flatten_carries_the_whole_validated_object(reading):
+    flat = contract.flatten(reading, ingest_time="2026-07-29T09:15:01.000Z")
+    assert json.loads(flat["reading"]) == reading
+    assert flat["valueNum"] == reading["value"]
+    assert flat["simulated"] is True
+
+
+def test_batch_hash_binds_every_byte(reading, mutate):
+    a = contract.batch_hash([reading])
+    assert a == contract.batch_hash([reading])
+    assert a != contract.batch_hash([mutate(reading, value=21.51)])
+    assert a != contract.batch_hash([reading, reading])
+
+
+def test_startup_check_passes_for_shipped_profiles(virtual_profile, ble_profile):
+    contract.startup_check([virtual_profile, ble_profile])
+
+
+def test_startup_check_fails_on_a_tampered_profile(virtual_profile):
+    tampered = copy.deepcopy(virtual_profile)
+    tampered["metrics"][0]["unit"] = "[degF]"  # digest no longer matches
+    with pytest.raises(contract.ContractError):
+        contract.startup_check([tampered])

--- a/apps/device-service/tests/test_drivers.py
+++ b/apps/device-service/tests/test_drivers.py
@@ -1,0 +1,154 @@
+"""The driver layer: the virtual simulator, and the registry that refuses to pretend."""
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from device_service import contract
+from device_service.drivers import (
+    DRIVERS,
+    DriverUnavailable,
+    VirtualRoomSensorDriver,
+    build_driver,
+)
+
+
+def test_only_the_virtual_driver_ships():
+    """Stated plainly rather than implied: this build has ONE driver, and it simulates.
+    If a real protocol driver is ever added, this test is what makes that a deliberate,
+    reviewed change instead of a quiet one."""
+    assert sorted(DRIVERS) == ["virtual"]
+
+
+def test_a_profile_with_no_registered_driver_is_refused(ble_profile):
+    """A ble-gatt profile on a build with no BLE transport must not start a service that
+    polls nothing behind a green /healthz."""
+    with pytest.raises(DriverUnavailable, match="no driver registered for protocol 'ble-gatt'"):
+        build_driver(ble_profile, "urn:srcos:device:th100_bed2")
+
+
+def test_the_refusal_names_the_seam(ble_profile):
+    with pytest.raises(DriverUnavailable, match="ble.py"):
+        build_driver(ble_profile, "urn:srcos:device:th100_bed2")
+
+
+def test_a_driver_producing_undeclared_metrics_is_refused(virtual_profile):
+    class Rogue:
+        metrics = ["temperature", "smugness"]
+
+        def poll(self):  # pragma: no cover - never reached
+            return []
+
+    DRIVERS["rogue-test"] = lambda profile, device_ref, options: Rogue()
+    rogue_profile = copy.deepcopy(virtual_profile)
+    rogue_profile["protocol"] = "virtual"
+    try:
+        DRIVERS["virtual-rogue"] = lambda profile, device_ref, options: Rogue()
+        with pytest.raises(DriverUnavailable, match="unattributable by construction"):
+            build_driver({**rogue_profile, "protocol": "virtual-rogue"}, "urn:srcos:device:x")
+    finally:
+        DRIVERS.pop("rogue-test", None)
+        DRIVERS.pop("virtual-rogue", None)
+
+
+# ------------------------------------------------------------------ the simulator
+def test_the_virtual_driver_is_deterministic(virtual_profile):
+    a = VirtualRoomSensorDriver(virtual_profile, "urn:srcos:device:room_sensor_01", seed=42)
+    b = VirtualRoomSensorDriver(virtual_profile, "urn:srcos:device:room_sensor_01", seed=42)
+    for _ in range(10):
+        assert [(s.metric, s.value) for s in a.poll()] == [(s.metric, s.value) for s in b.poll()]
+
+
+def test_a_different_seed_gives_a_different_stream(virtual_profile):
+    a = VirtualRoomSensorDriver(virtual_profile, "urn:srcos:device:room_sensor_01", seed=42)
+    b = VirtualRoomSensorDriver(virtual_profile, "urn:srcos:device:room_sensor_01", seed=99)
+    assert [s.value for s in a.poll()] != [s.value for s in b.poll()]
+
+
+def test_two_devices_on_one_profile_do_not_move_in_lockstep(virtual_profile):
+    a = VirtualRoomSensorDriver(virtual_profile, "urn:srcos:device:room_sensor_01", seed=42)
+    b = VirtualRoomSensorDriver(virtual_profile, "urn:srcos:device:room_sensor_02", seed=42)
+    assert [s.value for s in a.poll()] != [s.value for s in b.poll()]
+
+
+def test_simulated_values_stay_well_inside_the_declared_range(virtual_profile):
+    """A simulator that touched the range boundary would make the must-be-zero
+    validation_failures counter flap and train everyone to ignore it."""
+    driver = VirtualRoomSensorDriver(virtual_profile, "urn:srcos:device:room_sensor_01", seed=42)
+    declared = {m["metric"]: m for m in virtual_profile["metrics"]}
+    for _ in range(2000):
+        for sample in driver.poll():
+            spec = declared[sample.metric]
+            if spec["valueType"] == "boolean":
+                assert isinstance(sample.value, bool)
+                continue
+            assert spec["minimum"] < sample.value < spec["maximum"]
+
+
+def test_simulated_values_are_of_the_declared_type(virtual_profile):
+    driver = VirtualRoomSensorDriver(virtual_profile, "urn:srcos:device:room_sensor_01", seed=42)
+    declared = {m["metric"]: m for m in virtual_profile["metrics"]}
+    for sample in driver.poll():
+        expected = declared[sample.metric]["valueType"]
+        if expected == "boolean":
+            assert isinstance(sample.value, bool)
+        elif expected == "integer":
+            assert isinstance(sample.value, int) and not isinstance(sample.value, bool)
+        else:
+            assert isinstance(sample.value, float)
+
+
+def test_every_simulated_sample_survives_the_contract_gate(virtual_profile):
+    """The end-to-end claim: what this driver produces is admissible. 3000 samples, and
+    validation_failures must be exactly zero — the same bar /healthz reports."""
+    driver = VirtualRoomSensorDriver(virtual_profile, "urn:srcos:device:room_sensor_01", seed=42)
+    failures = 0
+    checked = 0
+    for tick in range(1, 1001):
+        for sample in driver.poll():
+            reading = contract.build_reading(
+                profile=virtual_profile,
+                device_ref="urn:srcos:device:room_sensor_01",
+                metric=sample.metric,
+                value=sample.value,
+                quality=sample.quality,
+                observed_at="2026-07-29T09:15:00.000Z",
+                received_at="2026-07-29T09:15:00.042Z",
+                wall_time="2026-07-29T09:15:00.042Z",
+                logical_time=tick,
+                sequence_ref=tick,
+                workspace_ref="urn:srcos:workspace:citizen_home_demo",
+                branch_ref="urn:srcos:branch:home_main",
+                actor_ref="urn:srcos:agent:device_service",
+                raw_payload=sample.raw,
+            )
+            try:
+                contract.validate_reading(reading, virtual_profile)
+                checked += 1
+            except contract.ContractError:
+                failures += 1
+    assert checked == 3000
+    assert failures == 0
+
+
+def test_drop_every_n_produces_typed_absences(virtual_profile):
+    driver = VirtualRoomSensorDriver(
+        virtual_profile, "urn:srcos:device:room_sensor_01", seed=42, drop_every_n=3
+    )
+    qualities = []
+    for _ in range(6):
+        qualities.append({s.quality for s in driver.poll()})
+    assert qualities[2] == {"unavailable"}
+    assert qualities[5] == {"unavailable"}
+    assert qualities[0] == {"ok"}
+    dropped = [s for _ in range(1) for s in driver.poll()]  # tick 7 — not a drop
+    assert all(s.quality == "ok" for s in dropped)
+
+
+def test_absences_carry_a_kind_a_driver_can_actually_attribute(virtual_profile):
+    driver = VirtualRoomSensorDriver(
+        virtual_profile, "urn:srcos:device:room_sensor_01", seed=42, drop_every_n=1
+    )
+    for sample in driver.poll():
+        assert sample.absence_kind in contract.DRIVER_ABSENCE_KINDS

--- a/apps/device-service/tests/test_emitter.py
+++ b/apps/device-service/tests/test_emitter.py
@@ -1,0 +1,357 @@
+"""The emitter: validate-then-write, fail-closed, gapless retry, seal-then-count.
+
+These are the semantics that make the difference between a service that streams and a
+service that appears to. Each is proven on fakes, so the failure modes are reachable.
+"""
+from __future__ import annotations
+
+import pytest
+
+from device_service import contract
+from device_service.clients import EmitError, GatewayError, READING_LABEL
+from device_service.drivers import DriverError, Sample, VirtualRoomSensorDriver
+from device_service.emitter import CommissionedDevice, Emitter
+
+from conftest import FakeGateway, FakeWriter
+
+DEVICE = "urn:srcos:device:room_sensor_01"
+
+
+def make_emitter(virtual_profile, writer=None, gateway=None, driver=None, devices=None):
+    writer = writer or FakeWriter()
+    gateway = gateway or FakeGateway()
+    if devices is None:
+        devices = [
+            CommissionedDevice(
+                device_ref=DEVICE,
+                profile=virtual_profile,
+                driver=driver or VirtualRoomSensorDriver(virtual_profile, DEVICE, seed=42),
+            )
+        ]
+    return Emitter(
+        devices, writer, gateway,
+        workspace_ref="urn:srcos:workspace:citizen_home_demo",
+        branch_ref="urn:srcos:branch:home_main",
+    ), writer, gateway
+
+
+class ScriptedDriver:
+    def __init__(self, profile, script):
+        self.metrics = [m["metric"] for m in profile["metrics"]]
+        self.script = list(script)
+        self.calls = 0
+
+    def poll(self):
+        self.calls += 1
+        if not self.script:
+            return []
+        step = self.script.pop(0)
+        if isinstance(step, Exception):
+            raise step
+        return step
+
+
+# ---------------------------------------------------------------------- happy path
+def test_a_clean_interval_emits_seals_and_counts(virtual_profile):
+    em, writer, gateway = make_emitter(virtual_profile)
+    result = em.run_once()
+    assert result.polled == 1
+    assert result.emitted == 3          # three metrics on the virtual profile
+    assert result.validation_failures == 0
+    assert result.receipts == 1
+    assert result.pending == 0
+    assert result.hellgraph_ok and result.gateway_ok
+    assert len(gateway.calls) == 1
+    assert gateway.calls[0]["row_count"] == 3
+    assert gateway.calls[0]["batch_hash"].startswith("sha256:")
+
+
+def test_the_graph_shape_is_the_contract_made_walkable(virtual_profile):
+    em, writer, _ = make_emitter(virtual_profile)
+    em.run_once()
+    labels = {node[0]: node[1] for node in writer.nodes}
+    # profile, device and kko type nodes exist
+    assert virtual_profile["id"] in labels
+    assert DEVICE in labels
+    assert any("KkoType" in v for v in labels.values())
+    # readings carry a quality LABEL, so "not a measurement" is a label query
+    reading_nodes = [n for n in writer.nodes if READING_LABEL in n[1]]
+    assert len(reading_nodes) == 3
+    assert all(any(lbl.startswith("quality:") for lbl in n[1]) for n in reading_nodes)
+    edges = {(e[0], e[2]) for e in writer.edges}
+    assert ("conformsTo", virtual_profile["id"]) in edges
+    assert ("fromDevice", DEVICE) in edges
+    assert ("declaredBy", virtual_profile["id"]) in edges
+    assert any(label == "kkoType" for label, _ in edges)
+
+
+def test_nodes_precede_the_edges_that_reference_them(virtual_profile):
+    em, writer, _ = make_emitter(virtual_profile)
+    em.run_once()
+    seen: set[str] = set()
+    order = []
+    for node in writer.nodes:
+        order.append(("node", node[0]))
+    # Reconstruct true interleaving by replaying the plan through a recording writer.
+    class Recorder:
+        def __init__(self):
+            self.seq = []
+
+        def post_node(self, node_id, labels, properties):
+            self.seq.append(("node", node_id))
+
+        def post_edge(self, label, from_id, to_id):
+            self.seq.append(("edge", from_id, to_id))
+
+    rec = Recorder()
+    em2, _, _ = make_emitter(virtual_profile, writer=rec)
+    em2.run_once()
+    for entry in rec.seq:
+        if entry[0] == "node":
+            seen.add(entry[1])
+        else:
+            assert entry[1] in seen, f"edge from {entry[1]} before its node"
+            assert entry[2] in seen, f"edge to {entry[2]} before its node"
+
+
+def test_the_full_validated_reading_lands_on_the_node(virtual_profile):
+    import json
+
+    em, writer, _ = make_emitter(virtual_profile)
+    em.run_once()
+    node = next(n for n in writer.nodes if READING_LABEL in n[1])
+    payload = json.loads(node[2]["reading"])
+    contract.validate_reading(payload, virtual_profile)
+    assert node[2]["simulated"] is True
+
+
+# ------------------------------------------------------------------- fail-closed
+def test_a_nonconformant_reading_is_counted_and_NOT_emitted(virtual_profile):
+    """A driver reporting a value outside the declared range must not reach the log."""
+    bad = ScriptedDriver(virtual_profile, [[
+        Sample(metric="temperature", value=999.0),
+        Sample(metric="humidity.relative", value=50.0),
+    ]])
+    em, writer, gateway = make_emitter(virtual_profile, driver=bad)
+    result = em.run_once()
+    assert result.validation_failures == 1
+    assert result.emitted == 1                      # the good one still emits
+    emitted_metrics = {
+        n[2]["metric"] for n in writer.nodes if READING_LABEL in n[1]
+    }
+    assert emitted_metrics == {"humidity.relative"}
+    # the seal covers exactly what landed
+    assert gateway.calls[0]["row_count"] == 1
+
+
+def test_a_whole_bad_poll_seals_nothing(virtual_profile):
+    bad = ScriptedDriver(virtual_profile, [[Sample(metric="temperature", value=999.0)]])
+    em, writer, gateway = make_emitter(virtual_profile, driver=bad)
+    result = em.run_once()
+    assert result.validation_failures == 1
+    assert result.emitted == 0
+    assert gateway.calls == []
+    assert writer.nodes == []
+
+
+def test_a_driver_failure_skips_the_device_without_a_partial_batch(virtual_profile):
+    dead = ScriptedDriver(virtual_profile, [DriverError("radio gone")])
+    em, writer, gateway = make_emitter(virtual_profile, driver=dead)
+    result = em.run_once()
+    assert result.driver_failures == 1
+    assert result.emitted == 0
+    assert result.pending == 0
+    assert writer.nodes == [] and gateway.calls == []
+
+
+# --------------------------------------------------------------- gapless retry
+def _one_shot(profile):
+    """A driver that yields exactly one poll, so a retry test observes the retry and not
+    a fresh batch arriving behind it."""
+    return ScriptedDriver(profile, [[
+        Sample(metric="temperature", value=21.5),
+        Sample(metric="humidity.relative", value=48.0),
+    ]])
+
+
+def test_a_hellgraph_outage_keeps_the_batch_pending_and_resumes_at_the_same_op(virtual_profile):
+    writer = FakeWriter(fail_after=4)
+    em, _, gateway = make_emitter(virtual_profile, writer=writer, driver=_one_shot(virtual_profile))
+    result = em.run_once()
+    assert result.hellgraph_ok is False
+    assert result.emitted == 0
+    assert result.pending == 2
+    assert gateway.calls == []          # nothing sealed: nothing fully landed
+    landed = writer.ops
+    assert landed == 4
+
+    writer.fail_after = None
+    result2 = em.run_once()
+    assert result2.emitted == 2
+    assert result2.pending == 0
+    assert len(gateway.calls) == 1
+    # The half that landed was NOT re-sent: every recorded write is a distinct op, so the
+    # totals match exactly rather than double-counting the four that already landed.
+    assert writer.ops > landed
+    assert len(writer.nodes) + len(writer.edges) == writer.ops
+
+
+def test_no_new_polling_while_a_batch_is_pending(virtual_profile):
+    """Gapless: the sequence never skips, and memory stays bounded."""
+    driver = VirtualRoomSensorDriver(virtual_profile, DEVICE, seed=42)
+    writer = FakeWriter(fail_after=2)
+    em, _, _ = make_emitter(virtual_profile, writer=writer, driver=driver)
+    em.run_once()
+    assert em.devices[0].seq == 3
+    for _ in range(5):
+        em.run_once()
+    assert em.devices[0].seq == 3, "polled again while a batch was outstanding"
+    assert em.pending_readings == 3
+
+
+def test_the_sequence_is_gapless_across_an_outage(virtual_profile):
+    """No sequence number is skipped and none is emitted twice, across a failure and a
+    recovery. This is the property that lets a consumer detect a genuine gap."""
+    writer = FakeWriter(fail_after=5)
+    em, _, _ = make_emitter(virtual_profile, writer=writer)
+    em.run_once()
+    writer.fail_after = None
+    em.run_once()
+    em.run_once()
+    seqs = sorted(n[2]["sequenceRef"] for n in writer.nodes if READING_LABEL in n[1])
+    assert seqs == sorted(set(seqs)), f"a sequence number was emitted twice: {seqs}"
+    assert seqs == list(range(1, len(seqs) + 1)), f"sequence skipped: {seqs}"
+    assert len(seqs) == em.devices[0].seq
+
+
+def test_a_gateway_refusal_keeps_the_batch_pending_at_the_receipt_step(virtual_profile):
+    """Graph writes cannot be un-written, so only the receipt is retried — and nothing is
+    counted as emitted until it is both on the graph and attested."""
+    gateway = FakeGateway(refuse=True)
+    em, writer, _ = make_emitter(
+        virtual_profile, gateway=gateway, driver=_one_shot(virtual_profile)
+    )
+    result = em.run_once()
+    assert result.gateway_ok is False
+    assert result.emitted == 0
+    assert result.pending == 2
+    writes_after_first = writer.ops
+    assert writes_after_first > 0            # the graph writes DID land
+
+    gateway.refuse = False
+    result2 = em.run_once()
+    assert result2.emitted == 2
+    assert result2.receipts == 1
+    # the graph writes were not replayed — only the receipt was retried
+    assert writer.ops == writes_after_first
+
+
+def test_a_retried_receipt_is_idempotent(virtual_profile):
+    """An identical spec re-POSTed after a crash hits the gateway memo and returns the
+    same receipt id rather than minting a duplicate on the chain."""
+    gateway = FakeGateway()
+    em, _, _ = make_emitter(virtual_profile, gateway=gateway)
+    em.run_once()
+    first = gateway.calls[0]
+    assert gateway.mint(**{
+        "device_ref": first["device_ref"], "from_cursor": first["from_cursor"],
+        "to_cursor": first["to_cursor"], "row_count": first["row_count"],
+        "batch_hash": first["batch_hash"],
+    })["id"] == "sha256:receipt0000"
+
+
+def test_the_loop_survives_and_recovers(virtual_profile):
+    writer = FakeWriter(fail_after=0)
+    em, _, gateway = make_emitter(virtual_profile, writer=writer, driver=_one_shot(virtual_profile))
+    for _ in range(3):
+        result = em.run_once()
+        assert result.hellgraph_ok is False
+        assert result.emitted == 0
+    writer.fail_after = None
+    result = em.run_once()
+    assert result.emitted == 2 and result.hellgraph_ok
+
+
+def test_recovery_catches_up_within_one_interval(virtual_profile):
+    """Deliberate, not accidental: an interval drains what is outstanding, then polls the
+    devices that are now clear, then drains again. A recovered device therefore lands its
+    stuck batch AND a fresh one in the same tick, instead of staying one interval behind
+    forever after a single outage."""
+    writer = FakeWriter(fail_after=0)
+    em, _, gateway = make_emitter(virtual_profile, writer=writer)
+    em.run_once()
+    assert em.pending_readings == 3
+    writer.fail_after = None
+    result = em.run_once()
+    assert result.emitted == 6
+    assert result.receipts == 2
+    assert em.pending_readings == 0
+
+
+# ------------------------------------------------------------------ typed absence
+def test_an_absence_lands_as_a_typed_record_wired_to_its_reading(virtual_profile):
+    driver = VirtualRoomSensorDriver(virtual_profile, DEVICE, seed=42, drop_every_n=1)
+    em, writer, _ = make_emitter(virtual_profile, driver=driver)
+    result = em.run_once()
+    assert result.emitted == 3
+    assert result.quality_counts == {"unavailable": 3}
+    absence_nodes = [n for n in writer.nodes if "NullAbsenceRecord" in n[1]]
+    assert len(absence_nodes) == 3
+    assert all(n[2]["kind"] == "timeout" for n in absence_nodes)
+    absence_edges = [e for e in writer.edges if e[0] == "absenceTypedBy"]
+    assert len(absence_edges) == 3
+    reading_nodes = [n for n in writer.nodes if READING_LABEL in n[1]]
+    assert all("quality:unavailable" in n[1] for n in reading_nodes)
+    assert all(n[2]["valueNum"] is None for n in reading_nodes)
+
+
+# --------------------------------------------------------------- multiple devices
+def test_devices_are_independent(virtual_profile):
+    d1 = CommissionedDevice(
+        device_ref="urn:srcos:device:room_sensor_01", profile=virtual_profile,
+        driver=VirtualRoomSensorDriver(virtual_profile, "urn:srcos:device:room_sensor_01", seed=42),
+    )
+    d2 = CommissionedDevice(
+        device_ref="urn:srcos:device:room_sensor_02", profile=virtual_profile,
+        driver=VirtualRoomSensorDriver(virtual_profile, "urn:srcos:device:room_sensor_02", seed=42),
+    )
+    em, writer, gateway = make_emitter(virtual_profile, devices=[d1, d2])
+    result = em.run_once()
+    assert result.polled == 2
+    assert result.emitted == 6
+    assert result.receipts == 2, "one receipt per device batch"
+    assert {c["device_ref"] for c in gateway.calls} == {d1.device_ref, d2.device_ref}
+
+
+def test_a_stuck_device_does_not_block_a_healthy_one(virtual_profile):
+    stuck = CommissionedDevice(
+        device_ref="urn:srcos:device:stuck", profile=virtual_profile,
+        driver=ScriptedDriver(virtual_profile, [DriverError("gone")] * 5),
+    )
+    healthy = CommissionedDevice(
+        device_ref="urn:srcos:device:healthy", profile=virtual_profile,
+        driver=VirtualRoomSensorDriver(virtual_profile, "urn:srcos:device:healthy", seed=7),
+    )
+    em, _, gateway = make_emitter(virtual_profile, devices=[stuck, healthy])
+    result = em.run_once()
+    assert result.driver_failures == 1
+    assert result.emitted == 3
+    assert {c["device_ref"] for c in gateway.calls} == {"urn:srcos:device:healthy"}
+
+
+# --------------------------------------------------------------- honest liveness
+def test_an_idle_drain_reports_no_evidence_rather_than_green(virtual_profile):
+    """A drain with nothing pending contacts NOTHING. Reporting both dependencies green
+    without having asked is exactly the lie /healthz must not tell."""
+    em, _, _ = make_emitter(virtual_profile, devices=[])
+    result = em.run_once()
+    assert result.attempted is False
+    assert result.polled == 0
+
+
+def test_startup_check_runs_the_real_gate(virtual_profile):
+    em, _, _ = make_emitter(virtual_profile)
+    em.startup_check()
+    em.devices[0].profile = {**virtual_profile, "definitionDigest": "sha256:" + "0" * 64}
+    with pytest.raises(contract.ContractError):
+        em.startup_check()

--- a/apps/device-service/tests/test_kko.py
+++ b/apps/device-service/tests/test_kko.py
@@ -1,0 +1,76 @@
+"""The ontology URIs must EXIST in the TBox this estate actually vendors.
+
+An invented type ref is worse than no type ref: it looks resolvable, so nothing
+downstream questions it, and the failure surfaces only when a reasoner is finally
+pointed at it. This test reads the vendored KKO TBox from apps/owl-reasoner and asserts
+every URI this service declares is really in it.
+
+It is skipped, loudly, when the TBox is not reachable (an image build that copies only
+this app's directory), because a check that silently passes when it cannot look is the
+same failure in different clothing.
+"""
+from __future__ import annotations
+
+import json
+import re
+from importlib import resources
+from pathlib import Path
+
+import pytest
+
+from device_service import contract
+
+#: apps/device-service/tests/test_kko.py -> apps/owl-reasoner/.../kko-2.10.n3
+TBOX = (
+    Path(__file__).resolve().parents[2]
+    / "owl-reasoner" / "src" / "owl_reasoner" / "data" / "kko-2.10.n3"
+)
+
+pytestmark = pytest.mark.skipif(
+    not TBOX.exists(), reason=f"vendored KKO TBox not reachable at {TBOX}"
+)
+
+
+def _terms() -> set[str]:
+    text = TBOX.read_text(encoding="utf-8")
+    return set(re.findall(r"(?:^|\s):([A-Za-z][A-Za-z0-9_-]*)", text))
+
+
+def test_the_declared_kko_uris_exist_in_the_vendored_tbox():
+    terms = _terms()
+    for uri in (contract.KKO_QUANTITY, contract.KKO_STATES):
+        assert uri.startswith(contract.KKO), f"{uri} is not in the KKO namespace"
+        local = uri[len(contract.KKO):]
+        assert local in terms, (
+            f"{uri} is NOT in the vendored KKO TBox ({TBOX.name}). An unresolvable type "
+            f"ref that looks resolvable is the silent-wrong this service exists to stop."
+        )
+
+
+def test_every_shipped_profile_cites_only_verified_uris():
+    terms = _terms()
+    for name in ("virtual-room-sensor", "acme-th100-ble"):
+        raw = (resources.files("device_service") / "profiles" / f"{name}.json").read_text("utf-8")
+        profile = json.loads(raw)
+        for metric in profile["metrics"]:
+            uri = metric.get("kkoTypeRef")
+            if not uri:
+                continue
+            assert uri.startswith(contract.KKO), (
+                f"{name}/{metric['metric']} cites {uri}, which is outside the vendored "
+                f"KKO namespace — the ~58k KBpedia reference-concept layer is NOT "
+                f"vendored anywhere in this estate."
+            )
+            assert uri[len(contract.KKO):] in terms, f"{name}/{metric['metric']}: {uri} not in TBox"
+
+
+def test_the_specific_reference_concepts_are_confirmed_absent():
+    """Documents WHY the typing is coarse, and fails if that ever changes silently: if
+    KBpedia reference concepts are vendored later, this test goes red and the profiles
+    should be re-typed to the more precise URIs rather than left at Quantity."""
+    terms = _terms()
+    for tempting in ("Temperature", "RelativeHumidity", "Occupancy"):
+        assert tempting not in terms, (
+            f"'{tempting}' is now in the vendored TBox — re-type the profiles to the "
+            f"precise reference concept instead of the coarse upper-ontology class."
+        )

--- a/apps/device-service/tests/test_server.py
+++ b/apps/device-service/tests/test_server.py
@@ -1,0 +1,174 @@
+"""The HTTP surface: an honest /healthz, and the profile endpoint that lets a consumer
+check the digest itself instead of trusting this service."""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from device_service import contract
+
+
+@pytest.fixture
+def server(monkeypatch):
+    monkeypatch.setenv("DEVICE_POLL_ENABLED", "off")
+    import device_service.server as mod
+
+    importlib.reload(mod)
+    return mod
+
+
+def test_healthz_answers_200_with_the_counters(server):
+    with TestClient(server.app) as client:
+        body = client.get("/healthz").json()
+    assert body["ok"] is True
+    assert body["service"] == "device-service"
+    for key in (
+        "polled", "emitted", "validation_failures", "driver_failures", "pending",
+        "receipts", "last_receipt_id", "quality_counts", "hellgraph_ok", "gateway_ok",
+        "loop_running", "last_error", "last_error_at", "last_emit_at",
+        "devices", "simulated_devices", "protocols", "poll_interval_seconds",
+    ):
+        assert key in body, f"/healthz omits {key}"
+
+
+def test_validation_failures_is_present_and_zero(server):
+    """The must-be-0 counter. Its presence is not decoration: it is the alarm for a
+    device disagreeing with its own declaration."""
+    with TestClient(server.app) as client:
+        body = client.get("/healthz").json()
+    assert body["validation_failures"] == 0
+
+
+def test_healthz_publishes_the_contract_pins(server):
+    """Contract drift is visible from a probe, without exec'ing into the pod."""
+    with TestClient(server.app) as client:
+        body = client.get("/healthz").json()
+    assert body["spec_version"] == contract.SPEC_VERSION
+    assert body["profile_schema_sha256"] == contract.PROFILE_SCHEMA_SHA256
+    assert body["reading_schema_sha256"] == contract.READING_SCHEMA_SHA256
+
+
+def test_healthz_declares_which_receipt_lineage_is_reused(server):
+    """Not a fifth lineage — stated where an operator can see it."""
+    with TestClient(server.app) as client:
+        body = client.get("/healthz").json()
+    assert body["receipt_kind"] == "materialize"
+
+
+def test_unasked_dependencies_report_none_not_green(server):
+    """None means 'never asked'. Reporting True before contacting anything is the exact
+    lie a health endpoint must not tell."""
+    with TestClient(server.app) as client:
+        body = client.get("/healthz").json()
+    assert body["hellgraph_ok"] is None
+    assert body["gateway_ok"] is None
+
+
+def test_healthz_answers_even_with_polling_disabled(server):
+    with TestClient(server.app) as client:
+        assert client.get("/healthz").status_code == 200
+
+
+# ------------------------------------------------------------------ commissioning
+def test_the_default_commissioning_builds_and_passes_its_own_boot_gate(monkeypatch):
+    monkeypatch.setenv("DEVICE_POLL_ENABLED", "off")
+    import device_service.server as mod
+
+    importlib.reload(mod)
+    emitter = mod.build_emitter()
+    emitter.startup_check()
+    assert len(emitter.devices) == 2
+    assert emitter.simulated_devices == 2
+    assert emitter.protocols == {"virtual": 2}
+
+
+def test_commissioning_a_ble_device_refuses_to_start(monkeypatch):
+    """The fail-closed boot gate: a profile whose protocol has no driver must crash the
+    service, not produce a green pod polling nothing."""
+    from device_service.drivers import DriverUnavailable
+
+    monkeypatch.setenv("DEVICE_POLL_ENABLED", "off")
+    monkeypatch.setenv(
+        "DEVICE_COMMISSIONED", "urn:srcos:device:th100_bed2=acme-th100-ble"
+    )
+    import device_service.server as mod
+
+    importlib.reload(mod)
+    with pytest.raises(DriverUnavailable, match="no driver registered for protocol 'ble-gatt'"):
+        mod.build_emitter()
+
+
+def test_an_empty_commissioning_is_refused(monkeypatch):
+    monkeypatch.setenv("DEVICE_POLL_ENABLED", "off")
+    monkeypatch.setenv("DEVICE_COMMISSIONED", "")
+    import device_service.server as mod
+
+    importlib.reload(mod)
+    with pytest.raises(ValueError, match="no devices commissioned"):
+        mod.build_emitter()
+
+
+def test_a_malformed_commissioning_entry_is_refused(monkeypatch):
+    monkeypatch.setenv("DEVICE_POLL_ENABLED", "off")
+    monkeypatch.setenv("DEVICE_COMMISSIONED", "urn:srcos:device:oops")
+    import device_service.server as mod
+
+    importlib.reload(mod)
+    with pytest.raises(ValueError, match="not <deviceRef>=<profile-name>"):
+        mod.build_emitter()
+
+
+# ---------------------------------------------------------------- /v1/profiles
+def test_profiles_endpoint_exposes_the_recomputed_digest(monkeypatch):
+    """A consumer holding a reading must be able to fetch the declaration it pins and
+    recompute the digest, rather than taking this service's word for it."""
+    monkeypatch.setenv("DEVICE_POLL_ENABLED", "off")
+    import device_service.server as mod
+
+    importlib.reload(mod)
+    mod._EMITTER = mod.build_emitter()
+    with TestClient(mod.app) as client:
+        body = client.get("/v1/profiles").json()
+    assert len(body["devices"]) == 2
+    for entry in body["devices"]:
+        assert entry["definitionDigest"] == entry["recomputedDigest"]
+        assert entry["simulated"] is True
+        assert entry["protocol"] == "virtual"
+        assert entry["metrics"]
+        for metric in entry["metrics"]:
+            assert metric["unit"] and metric["sourceAddress"] and metric["valueType"]
+
+
+# ------------------------------------------------------------------ state plumbing
+def test_healthz_reflects_a_real_poll(monkeypatch, virtual_profile):
+    from device_service.drivers import VirtualRoomSensorDriver
+    from device_service.emitter import CommissionedDevice, Emitter
+
+    from conftest import FakeGateway, FakeWriter
+
+    monkeypatch.setenv("DEVICE_POLL_ENABLED", "off")
+    import device_service.server as mod
+
+    importlib.reload(mod)
+    device_ref = "urn:srcos:device:room_sensor_01"
+    emitter = Emitter(
+        [CommissionedDevice(
+            device_ref=device_ref, profile=virtual_profile,
+            driver=VirtualRoomSensorDriver(virtual_profile, device_ref, seed=42),
+        )],
+        FakeWriter(), FakeGateway(),
+        workspace_ref="urn:srcos:workspace:citizen_home_demo",
+        branch_ref="urn:srcos:branch:home_main",
+    )
+    mod._EMITTER = emitter
+    mod._apply(emitter.run_once())
+    with TestClient(mod.app) as client:
+        body = client.get("/healthz").json()
+    assert body["emitted"] == 3
+    assert body["receipts"] == 1
+    assert body["validation_failures"] == 0
+    assert body["quality_counts"] == {"ok": 3}
+    assert body["hellgraph_ok"] is True and body["gateway_ok"] is True
+    assert body["last_receipt_id"]

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -95,6 +95,18 @@ spec:
           # warden is absent, declared L5 governance silently stops running (the exact
           # failure mode the blueprint audit found). Built from source in images.yml.
           - { name: lifecycle-warden, tier: foundation }
+          # FOG & CITIZEN PLANE W8.7: the southbound device plane (first-party; the estate
+          # had NO device abstraction anywhere). Devices declared by DeviceProfile,
+          # observed as DeviceReading, validated fail-closed against BOTH the schema and
+          # the profile the reading cites → hellgraph graph writes, KKO-typed and
+          # quality-labelled → one receipt per batch via compute-gateway kind=materialize.
+          # tier: foundation — DeviceReading IS the estate's southbound CONTRACT: it is
+          # the single interface every protocol driver and every twin/consumer exchanges,
+          # and the normative rule that a reading is attributable-or-nothing is enforced
+          # at this producer. A driver is swappable (only `virtual` ships today, and it
+          # SIMULATES — see the values file); the contract is not. Built from source in
+          # images.yml.
+          - { name: device-service, tier: foundation }
           # spark-runner MOVED to runtime-services → sovereign-runtime (executes user Spark jobs).
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —

--- a/deploy/values/device-service.yaml
+++ b/deploy/values/device-service.yaml
@@ -1,0 +1,74 @@
+# device-service — FOG & CITIZEN PLANE W8.7: the estate's southbound device plane.
+# ONE southbound interface, N protocol drivers (EdgeX Foundry's lesson). Devices are
+# declared by DeviceProfile and observed as DeviceReading (SourceOS-Linux/sourceos-spec
+# v0.1.0, vendored + sha256-pinned in apps/device-service/src/device_service/contract.py;
+# validated per reading, fail-closed, against BOTH the schema and the profile the reading
+# cites — an inadmissible reading is counted on /healthz and NEVER emitted). Readings
+# enter the log as hellgraph-service graph writes (KKO-typed, quality-labelled), and each
+# batch is sealed on the estate spine via compute-gateway POST /v1/compute
+# kind=materialize (the membrane precedent — reuse the door, never a fifth lineage).
+#
+# EVERY READING THIS DEPLOYMENT PRODUCES IS SIMULATED. One driver ships (`virtual`), and
+# the simulation is marked at every layer: protocol=virtual on the profile,
+# synthetic:simulated-device + not-a-measurement on every reading, simulated=true on the
+# graph node, and simulated_devices on /healthz. The real-BLE seam is
+# apps/device-service/src/device_service/ble.py — the GATT decoders are real and tested,
+# the transport is the one missing class, and the service REFUSES to start on a ble-gatt
+# profile rather than polling nothing behind a green pod.
+nameOverride: device-service
+
+image:
+  repository: device-service
+  # sha-pinned by gitops-promote after the first CI build (nugget-extractor precedent).
+  tag: latest
+  # Guard against the moving-tag+IfNotPresent trap while the tag is still `latest`; harmless
+  # once promotion pins an immutable sha- tag (kubelet re-checks, digests match, no-op).
+  pullPolicy: Always
+
+service: { port: 8080, portName: http }
+
+config:
+  HELLGRAPH_URL: "http://hellgraph-service:8090"
+  COMPUTE_GATEWAY_URL: "http://compute-gateway:8080"
+  # `default` is an entitled project token on compute-gateway (COMPUTE_ENTITLEMENTS), and
+  # `materialize` is entitled by kind as well — nothing new is provisioned for this service.
+  DEVICE_PROJECT: "default"
+  DEVICE_POLL_ENABLED: "on"
+  DEVICE_POLL_INTERVAL_SECONDS: "5"
+  DEVICE_WORKSPACE_REF: "urn:srcos:workspace:citizen_home_demo"
+  DEVICE_BRANCH_REF: "urn:srcos:branch:home_main"
+  # The commissioned-device table: <deviceRef>=<profile-name>, resolving to
+  # src/device_service/profiles/<name>.json. In v0.1 the instance -> profile binding lives
+  # here; every reading carries both refs plus the profile digest, so the binding stays
+  # auditable from the graph until the typed Device registry contract lands.
+  DEVICE_COMMISSIONED: "urn:srcos:device:room_sensor_01=virtual-room-sensor,urn:srcos:device:room_sensor_02=virtual-room-sensor"
+  # The walk is a pure function of (seed, device, metric, tick): same seed ⇒ the same
+  # replayable stream on every restart. Reading URNs embed the per-device seq, so a
+  # re-emitted batch upserts the same nodes instead of minting drifted duplicates.
+  DEVICE_VIRTUAL_SEED: "42"
+  # 0 = never. Non-zero makes the virtual driver report a TYPED absence (a
+  # NullAbsenceRecord, not a re-reported stale value) every Nth tick, so the unavailable
+  # path is exercisable on a live deployment and not only in tests.
+  DEVICE_VIRTUAL_DROP_EVERY_N: "0"
+secretEnv:
+  # the same Secret every proof-carrying producer on this spine already presents
+  # (materializer / lifecycle-warden / nugget-extractor precedent) — already provisioned
+  # in this namespace, nothing new is minted for the device plane.
+  GATEWAY_TOKEN: { secretName: compute-gateway-token, key: token }
+
+# ONE poller per device set: a second replica would race the same deterministic reading
+# URNs and interleave duplicate graph writes on the same seq stream. No HPA; Recreate over
+# RollingUpdate so two pollers never overlap even during a rollout.
+replicaCount: 1
+autoscaling: { enabled: false }
+strategy: { type: Recreate }
+
+probes:
+  path: /healthz   # emitted, per-quality counts, pending, receipts, hellgraph/gateway reachability, contract sha256s, simulated_devices, and validation_failures (MUST be 0)
+
+# Honest floor for a 2-device/3-metric/5s poll→validate→POST→seal loop: fastapi +
+# jsonschema resident, readings are ~1KB and stream straight through. No radio stack, no
+# model weights, no native toolchain.
+resources:
+  requests: { cpu: 25m,  memory: 128Mi }
+  limits:   { cpu: 200m, memory: 256Mi }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -168,6 +168,11 @@ KNOWN_BROKEN = {
         "KnowledgeNuggets) added to CI this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha "
         "exists until merge."
     ),
+    "device-service:moving-tag": (
+        "New service — FOG & CITIZEN PLANE W8.7 southbound device plane (apps/device-service: DeviceProfile "
+        "declarations -> fail-closed-validated DeviceReadings) added to CI this PR. Pin tag:latest -> the sha- "
+        "tag after the first CI build; no sha exists until merge."
+    ),
     # health-twin pinned to a sha- tag by gitops-promote after its first CI build (#932) → removed
     # from the ratchet (it only shrinks).
     # portfolio-agent pinned to a sha- tag by gitops-promote after its first CI build (#925,


### PR DESCRIPTION
Depends on the contract: **SourceOS-Linux/sourceos-spec#215** (`DeviceProfile` + `DeviceReading` v0.1.0), vendored here and sha256-asserted at import.

## The gap

The estate had **no southbound device abstraction anywhere**. The health twin ingests batch corpora; the smart home has nothing; a Δt<50ms twin sync is aspirational for the simple reason that no sensor stream exists to be late.

This is the **load-bearing half of W8**: one southbound interface and one driver that actually runs, rather than four sketches. The broker, the OCTAVE pipeline and the home ontology are **deliberately not here** — see Follow-ons.

## What it does

```
driver.poll() -> Samples -> build_reading() FROM THE PROFILE -> validate fail-closed
  (schema AND attribution) -> hellgraph graph writes (KKO-typed, quality-labelled)
  -> compute-gateway kind=materialize -> only THEN counted as emitted
```

A driver's whole job is to speak a protocol and hand back samples. It **cannot** supply unit, source address, ontology type or digest — those are copied from the profile — so adding a Zigbee driver cannot introduce a second event vocabulary, because a driver has no way to express one. That asymmetry is the entire EdgeX lesson made structural.

## Attributable or nothing

Beyond schema conformance, the gate checks each reading **against the profile it cites**: metric declared, `unit` and `sourceAddress` equal to the declaration, value of the declared type and inside the declared range, `profileDigest` equal to the **recomputed** digest. A reading that fails is counted, logged loudly and NOT emitted — and the seal covers exactly what did land, so the graph and the chain never disagree.

## What is real and what is simulated — plainly

**One driver ships: `virtual`. Its readings are SIMULATED.** Marked at every layer that can carry a mark: `protocol: virtual` on the profile, `synthetic:simulated-device` + `not-a-measurement` on every reading (the contract layer **refuses** a simulated reading that lost them), `simulated: true` on the graph node, and `simulated_devices` on `/healthz`. Nothing pretends to have touched a sensor.

**The real-BLE seam is typed and mostly written.** `src/device_service/ble.py`:
- the GATT characteristic decoders are **real, correct and unit-tested** against the Bluetooth SIG formats (0x2A6E / 0x2A6F / 0x2A19) — including the sint16 signedness trap that turns `-5.00 degC` into `+650.36 degC` if read unsigned;
- `BleGattDriver` is **complete** against an injected `BleTransport`, including timeout → typed absence and undecodable-payload → fault;
- **no `BleTransport` implementation ships.** That one class plus one registry line is the entire remaining distance, and `build_driver()` **refuses** a `ble-gatt` profile rather than starting a service that polls nothing behind a green pod.

Why no transport: it needs a radio on the node, host DBus/Bluetooth from a container that runs unprivileged with a read-only rootfs, and a pairing/bonding story that is a security review of its own. A stub returning plausible bytes would be **worse** than none — it would make simulated data indistinguishable from measured at the one layer where the distinction is still recoverable.

## Not a fifth receipt lineage

Batches seal via `kind=materialize`, following `hellgraph-service/src/membrane.ts`, which already reuses that kind cross-domain (*"reuse its shape, no new kind"*). `governance` needs an `audit_head` this service does not have; `engine-seal` recomputes and refuses anything that is not an engine receipt; `nugget-emit` would require lying about warrant taxonomy. `materialize` is already entitled **by kind**, so no gateway change is needed.

**Honest caveat**, stated in `clients.py`: the registry stamps `materialize` with warrant `derived` where a raw sensor value would want `observed`. Defensible because the receipt attests *the materialization of a batch through a cut*, not the measurement. If a device family ever needs `observed` at the receipt level, that is an argument for a fifth kind made deliberately — not one minted in passing.

## Absence is typed, ontology is verified

- `quality: unavailable` is schema-bound to a null value **plus** a `NullAbsenceRecord`, reusing the existing 12-kind MPCC taxonomy. This service restricts itself to the three kinds a driver can honestly attribute (`timeout`, `transport_failure`, `no_event_observed`) — `intentional_silence` and `refusal` are claims about intent no southbound driver can observe.
- `kkoTypeRef` cites `kko#Quantity` and `kko#States`, **both confirmed present** in the vendored TBox by `tests/test_kko.py`. The ~58k KBpedia reference-concept layer that would carry "temperature" is not vendored anywhere in this estate, so citing `kko/rc/Temperature` would look more precise and resolve to nothing. The test also fails if those concepts are ever vendored, so the coarse typing gets revisited rather than forgotten.

## Verification — run, not asserted

**98 tests** (`PYTHONPATH=src pytest -q tests`): contract 36, emitter 19, ble 16, server 12, drivers 12, kko 3.

Run for real against stub hellgraph/compute-gateway endpoints:
```
emitted 144   receipts 48 (hash-chained)   validation_failures 0
quality_counts {ok: 126, unavailable: 18}   pending 0
node labels  [Device, DeviceProfile, DeviceReading, KkoType, NullAbsenceRecord,
              quality:ok, quality:unavailable]
edge labels  [absenceTypedBy, conformsTo, declaredBy, fromDevice, kkoType]
```
A reading pulled **back off the graph** re-validates against the vendored contract.

Then the dependency was killed mid-flight and restarted:
```
during outage    emitted froze at 372, pending 6, hellgraph_ok false, loop_running true
after recovery   emitted 414, pending 0, validation_failures 0
sealed cursor cuts  186 -> 246, discontinuities: NONE   (both devices)
```

Gates:
```
python3 tools/preflight_deploy_contract.py       exit 0  (54 deployed, 19 foundation)
helm template (all deploy/values/*.yaml)         OK
tools/check_workflow_path_filters.py             0 failures
```

## Wiring

`images.yml` · `deploy/values/device-service.yaml` · appset **`tier: foundation`** · moving-tag ratchet entry · the **GATED** `app-test-diagnostics` matrix (not `deploy-tests`, per commit `0f55ec02`) · `probe-contract` (boots unaided).

`tier: foundation` because `DeviceReading` **is** the estate's southbound contract — the single interface every protocol driver and every twin/consumer exchanges. A driver is swappable; the contract is not. Same argument as `nugget-extractor`.

## Deviations, stated

1. **The only driver simulates.** Called out above and in the Dockerfile, values file, appset comment and `/healthz`.
2. **No container runtime on this machine**, so the image was not built locally — the app was run from source with the Dockerfile's exact entrypoint (`uvicorn device_service.server:app --app-dir src`). CI builds it; `probe-contract` will assert the image honours the values file.
3. **`materialize` warrant is `derived`, not `observed`** — reasoned above rather than papered over.
4. **Ontology typing is coarse** (`Quantity`/`States`) because that is what the estate vendors.
5. **No `Device` instance registry.** `deviceRef` names an instance by a URN with no schema yet; the binding lives in `DEVICE_COMMISSIONED` and every reading carries both refs plus the digest so it stays auditable. First follow-on.

## Follow-ons (deliberately not in this PR)

- **W8.8 `Device` instance registry** — typed instance→profile binding, admin/operating state, commissioning receipt, checkable outside the producing service.
- **A real BLE transport** — the one class in `ble.py`, plus the security review its `securityMode` field exists to bite on.
- **The device broker / fan-in** — this service polls; a broker for push protocols (MQTT/CoAP) is a separate shape.
- **The OCTAVE pipeline and the home ontology** — both need the reading stream to exist first. It does now.
- **Command/actuation** — must travel `EffectRequest` → `EffectDecision`; `access` is closed to `read` so it cannot arrive by enum-widening.
- **Aggregate/derived readings** — downsampling and unit conversion produce new observations whose provenance rules are not stated; emitting them as `DeviceReading`s would launder a computation into a measurement.