### PR TITLE
feat(revendor): disciplined, receipt-sealed engine re-vendor executor

### DIFF
--- a/tools/assert_vendored_engine_marker.py
+++ b/tools/assert_vendored_engine_marker.py
@@ -13,11 +13,23 @@ so there is no second opinion of "what distinguishes this release."
 
 Two things worth stating because both have already gone wrong:
 
-* It searches the extracted bytes with Python string containment, NEVER grep. grep
-  false-negatives on the bundled dist (it treats the minified single-line bundle as
-  binary and silently skips it), which would turn this evidence check into a rubber
-  stamp. Verified: grep reports zero `PROP_NS` in the real 0.4.45 bundle that plainly
-  contains it.
+* It searches the extracted bytes with Python string containment, NEVER grep. The
+  packed dist trips binary heuristics — 0.4.45's index.js is a 395 KB minified
+  single-line bundle carrying a NUL byte at offset 5985 — and what a grep does when
+  it decides a file is binary is not fixed: it varies across GNU/BSD builds, `-a`,
+  locale, and any wrapper on PATH. In the dev shell this repo is usually driven
+  from, `grep PROP_NS` on that bundle exits 1 while `/usr/bin/grep` finds all three
+  occurrences.
+
+  The point is not that grep is always wrong — it is that the answer depends on
+  which grep ran, and an evidence check whose result depends on the searcher's
+  binary-detection heuristic is not evidence. Python containment is deterministic
+  over the bytes and has no such mode.
+
+  (An earlier draft of this docstring asserted flatly that "grep reports zero
+  PROP_NS in the real 0.4.45 bundle". That is false of /usr/bin/grep and was
+  measured through the broken shell shim. Corrected here rather than deleted,
+  because the wrong version was load-bearing justification.)
 * A substring is not a marker. `"prop:"` appears in BOTH 0.4.40 and 0.4.45; only the
   full assignment `PROP_NS = "prop:"` distinguishes them. Pass the whole discriminating
   token as --expect, and pass known-decoy substrings as --forbid to prove the point.
@@ -39,15 +51,47 @@ from pathlib import Path
 DEFAULT_MEMBER = "package/ts/dist/index.js"
 
 
+# A packed engine dist is a few hundred KB (0.4.45's index.js is 395 KB). 64 MiB
+# is ~150x that — generous for any real release, and small enough that a
+# decompression bomb cannot exhaust the runner. This matters because the tool is
+# pointed at registry-pulled artifacts: the thing being inspected is exactly the
+# thing not yet trusted, so it must not be read unbounded into memory.
+MAX_MEMBER_BYTES = 64 * 1024 * 1024
+
+
 def read_member(tarball: Path, member: str) -> str:
     with tarfile.open(tarball, "r:gz") as tar:
         try:
-            handle = tar.extractfile(member)
+            info = tar.getmember(member)
         except KeyError:
-            handle = None
-        if handle is None:
             raise SystemExit(f"ERR: {tarball.name} has no member {member!r} — cannot assert the dist")
-        return handle.read().decode("utf-8", errors="replace")
+        # Only a regular file can carry a marker. A symlink/hardlink member would
+        # make extractfile follow a link inside the archive, and a directory or
+        # device yields None; refuse all of them by name rather than by accident.
+        if not info.isfile():
+            raise SystemExit(
+                f"ERR: {tarball.name} member {member!r} is not a regular file "
+                f"(type {info.type!r}) — refusing to treat it as the dist")
+        if info.size > MAX_MEMBER_BYTES:
+            raise SystemExit(
+                f"ERR: {tarball.name} member {member!r} declares {info.size} bytes "
+                f"> {MAX_MEMBER_BYTES} — refusing to read; this is not a packed dist")
+        handle = tar.extractfile(info)
+        if handle is None:
+            raise SystemExit(f"ERR: {tarball.name} has no readable member {member!r} — cannot assert the dist")
+        with handle:
+            # Read one byte past the cap so a member whose declared size lies
+            # about the compressed payload is still caught.
+            raw = handle.read(MAX_MEMBER_BYTES + 1)
+        if len(raw) > MAX_MEMBER_BYTES:
+            raise SystemExit(
+                f"ERR: {tarball.name} member {member!r} expands beyond {MAX_MEMBER_BYTES} bytes "
+                "despite its declared size — refusing to read (decompression bomb)")
+        # Python string containment, NEVER grep — see the module docstring. Verified
+        # on the real 0.4.45 bundle: `grep PROP_NS` reports zero matches (the file is
+        # classified as `data`) while `grep -a` reports three. grep here would make
+        # this evidence check a rubber stamp.
+        return raw.decode("utf-8", errors="replace")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tools/assert_vendored_engine_marker.py
+++ b/tools/assert_vendored_engine_marker.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Assert a vendored engine tarball is really the release it claims to be.
+
+The load-bearing step of the re-vendor discipline (vendor-freshness-plane.md § Re-vendor
+discipline, step 2): a `version` field is NOT evidence. `package.json` says whatever it
+says regardless of what the bundle contains — a previous release shipped a stale `dist`
+with a fresh version string in exactly this way. The only evidence is a discriminating
+marker INSIDE the packed dist.
+
+This tool is the generic mechanism; the marker VALUES come from the caller (the
+vendor-freshness register's `version_marker`, carried into the re-vendor EffectRequest),
+so there is no second opinion of "what distinguishes this release."
+
+Two things worth stating because both have already gone wrong:
+
+* It searches the extracted bytes with Python string containment, NEVER grep. grep
+  false-negatives on the bundled dist (it treats the minified single-line bundle as
+  binary and silently skips it), which would turn this evidence check into a rubber
+  stamp. Verified: grep reports zero `PROP_NS` in the real 0.4.45 bundle that plainly
+  contains it.
+* A substring is not a marker. `"prop:"` appears in BOTH 0.4.40 and 0.4.45; only the
+  full assignment `PROP_NS = "prop:"` distinguishes them. Pass the whole discriminating
+  token as --expect, and pass known-decoy substrings as --forbid to prove the point.
+
+Usage:
+  assert_vendored_engine_marker.py <tarball> --expect 'PROP_NS = "prop:"' [--forbid ...]
+                                   [--member package/ts/dist/index.js]
+Exit 0 and print a receipt on success; exit 1 with the reason on failure.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import tarfile
+from pathlib import Path
+
+DEFAULT_MEMBER = "package/ts/dist/index.js"
+
+
+def read_member(tarball: Path, member: str) -> str:
+    with tarfile.open(tarball, "r:gz") as tar:
+        try:
+            handle = tar.extractfile(member)
+        except KeyError:
+            handle = None
+        if handle is None:
+            raise SystemExit(f"ERR: {tarball.name} has no member {member!r} — cannot assert the dist")
+        return handle.read().decode("utf-8", errors="replace")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Assert a discriminating marker inside a vendored engine tarball's packed dist.")
+    ap.add_argument("tarball", type=Path)
+    ap.add_argument("--expect", action="append", default=[], metavar="MARKER",
+                    help="marker string that MUST be present in the packed dist (repeatable)")
+    ap.add_argument("--forbid", action="append", default=[], metavar="MARKER",
+                    help="marker string that must be ABSENT — e.g. a decoy substring (repeatable)")
+    ap.add_argument("--member", default=DEFAULT_MEMBER, help=f"tarball member to inspect (default {DEFAULT_MEMBER})")
+    args = ap.parse_args(argv)
+
+    if not args.tarball.exists():
+        print(f"ERR: tarball not found: {args.tarball}", file=sys.stderr)
+        return 1
+    if not args.expect:
+        print("ERR: at least one --expect marker is required (a version field is not evidence)", file=sys.stderr)
+        return 1
+
+    dist = read_member(args.tarball, args.member)
+    digest = hashlib.sha256(args.tarball.read_bytes()).hexdigest()
+
+    missing = [m for m in args.expect if m not in dist]
+    present_forbidden = [m for m in args.forbid if m in dist]
+
+    problems = []
+    if missing:
+        problems.append(f"expected markers absent from {args.member}: {missing}")
+    if present_forbidden:
+        problems.append(f"forbidden markers present in {args.member}: {present_forbidden}")
+
+    receipt = {
+        "tool": "prophet-platform.assert_vendored_engine_marker.v1",
+        "tarball": str(args.tarball),
+        "tarball_digest": f"sha256:{digest}",
+        "member": args.member,
+        "expected_present": args.expect,
+        "forbidden_absent": args.forbid,
+        "passed": not problems,
+        "problems": problems,
+        "non_claims": [
+            "Asserts the packed dist carries the discriminating marker; does NOT rebuild or run the engine.",
+            "Marker values are supplied by the caller (the register's version_marker); this tool holds no opinion of what a release is.",
+        ],
+    }
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    if problems:
+        for p in problems:
+            print(f"ERR: {p}", file=sys.stderr)
+        return 1
+    print(f"OK: {args.tarball.name} dist carries {len(args.expect)} expected marker(s), {len(args.forbid)} decoy(s) absent")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/assert_vendored_engine_marker.py
+++ b/tools/assert_vendored_engine_marker.py
@@ -59,8 +59,28 @@ DEFAULT_MEMBER = "package/ts/dist/index.js"
 MAX_MEMBER_BYTES = 64 * 1024 * 1024
 
 
+def sha256_file(path: Path) -> str:
+    """Digest by streaming. The receipt covers a registry-pulled artifact of unknown
+    size, so reading it whole to hash it would reintroduce the unbounded read that
+    read_member() takes care to avoid — the same defect one line apart."""
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
 def read_member(tarball: Path, member: str) -> str:
-    with tarfile.open(tarball, "r:gz") as tar:
+    # A corrupt, truncated, non-gzip or unreadable tarball must produce the same clean
+    # "ERR: ... / exit 1" as every other failure here. Letting tarfile.ReadError or OSError
+    # escape would give automation a stack trace and a different exit code for what is,
+    # from the caller's side, the ordinary case of "this artifact is not what it claims".
+    try:
+        tar = tarfile.open(tarball, "r:gz")
+    except (tarfile.TarError, OSError) as exc:
+        raise SystemExit(f"ERR: {tarball.name} is not a readable gzip tarball — "
+                         f"{type(exc).__name__}: {exc}")
+    with tar:
         try:
             info = tar.getmember(member)
         except KeyError:
@@ -80,17 +100,17 @@ def read_member(tarball: Path, member: str) -> str:
         if handle is None:
             raise SystemExit(f"ERR: {tarball.name} has no readable member {member!r} — cannot assert the dist")
         with handle:
-            # Read one byte past the cap so a member whose declared size lies
-            # about the compressed payload is still caught.
+            # Read one byte past the cap so a member whose ACTUAL expanded bytes exceed
+            # its DECLARED header size is still caught. (The tar header's `size` field is
+            # the uncompressed member size, so it can disagree with what the member
+            # actually expands to — the header is part of the untrusted input.)
             raw = handle.read(MAX_MEMBER_BYTES + 1)
         if len(raw) > MAX_MEMBER_BYTES:
             raise SystemExit(
-                f"ERR: {tarball.name} member {member!r} expands beyond {MAX_MEMBER_BYTES} bytes "
-                "despite its declared size — refusing to read (decompression bomb)")
-        # Python string containment, NEVER grep — see the module docstring. Verified
-        # on the real 0.4.45 bundle: `grep PROP_NS` reports zero matches (the file is
-        # classified as `data`) while `grep -a` reports three. grep here would make
-        # this evidence check a rubber stamp.
+                f"ERR: {tarball.name} member {member!r} expands past {MAX_MEMBER_BYTES} bytes "
+                f"despite a declared size of {info.size} — refusing to read (decompression bomb)")
+        # Python string containment, NEVER grep — see the module docstring for why
+        # (binary heuristics are searcher-dependent; containment is not).
         return raw.decode("utf-8", errors="replace")
 
 
@@ -112,7 +132,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     dist = read_member(args.tarball, args.member)
-    digest = hashlib.sha256(args.tarball.read_bytes()).hexdigest()
+    digest = sha256_file(args.tarball)
 
     missing = [m for m in args.expect if m not in dist]
     present_forbidden = [m for m in args.forbid if m in dist]

--- a/tools/assert_vendored_engine_marker.py
+++ b/tools/assert_vendored_engine_marker.py
@@ -70,7 +70,7 @@ def sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
-def read_member(tarball: Path, member: str) -> str:
+def read_member(tarball: Path, member: str) -> bytes:
     # A corrupt, truncated, non-gzip or unreadable tarball must produce the same clean
     # "ERR: ... / exit 1" as every other failure here. Letting tarfile.ReadError or OSError
     # escape would give automation a stack trace and a different exit code for what is,
@@ -109,9 +109,13 @@ def read_member(tarball: Path, member: str) -> str:
             raise SystemExit(
                 f"ERR: {tarball.name} member {member!r} expands past {MAX_MEMBER_BYTES} bytes "
                 f"despite a declared size of {info.size} — refusing to read (decompression bomb)")
-        # Python string containment, NEVER grep — see the module docstring for why
-        # (binary heuristics are searcher-dependent; containment is not).
-        return raw.decode("utf-8", errors="replace")
+        # Returned as BYTES, deliberately. Decoding with errors="replace" substitutes
+        # U+FFFD for anything that is not valid UTF-8 — which, in an evidence tool, means
+        # the thing being searched is no longer the thing that was shipped. A marker
+        # sitting next to a bad byte could be altered, and the search would then answer a
+        # question about a repaired copy. Markers are exact byte sequences; compare bytes.
+        # (Containment, never grep — see the module docstring for why.)
+        return raw
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -131,11 +135,18 @@ def main(argv: list[str] | None = None) -> int:
         print("ERR: at least one --expect marker is required (a version field is not evidence)", file=sys.stderr)
         return 1
 
-    dist = read_member(args.tarball, args.member)
+    try:
+        dist = read_member(args.tarball, args.member)
+    except SystemExit as exc:
+        # read_member raises SystemExit for the artifact-is-not-what-it-claims cases.
+        # main() is called programmatically (tests, other tools), so it must have ONE
+        # exit convention: return 0/1. Convert rather than leak mixed control flow.
+        print(str(exc), file=sys.stderr)
+        return 1
     digest = sha256_file(args.tarball)
 
-    missing = [m for m in args.expect if m not in dist]
-    present_forbidden = [m for m in args.forbid if m in dist]
+    missing = [m for m in args.expect if m.encode("utf-8") not in dist]
+    present_forbidden = [m for m in args.forbid if m.encode("utf-8") in dist]
 
     problems = []
     if missing:
@@ -157,12 +168,16 @@ def main(argv: list[str] | None = None) -> int:
             "Marker values are supplied by the caller (the register's version_marker); this tool holds no opinion of what a release is.",
         ],
     }
+    # stdout carries the receipt and NOTHING else, so a consumer can pipe this straight
+    # into jq. Human status goes to stderr — a receipt that has to be grepped out of
+    # prose is not machine-readable evidence.
     print(json.dumps(receipt, indent=2, sort_keys=True))
     if problems:
         for p in problems:
             print(f"ERR: {p}", file=sys.stderr)
         return 1
-    print(f"OK: {args.tarball.name} dist carries {len(args.expect)} expected marker(s), {len(args.forbid)} decoy(s) absent")
+    print(f"OK: {args.tarball.name} dist carries {len(args.expect)} expected marker(s), "
+          f"{len(args.forbid)} decoy(s) absent", file=sys.stderr)
     return 0
 
 

--- a/tools/revendor_engine.py
+++ b/tools/revendor_engine.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Execute a disciplined engine re-vendor and seal each step into a receipt.
+
+The consumer-side executor of the vendor-freshness plane. sociosphere's detector emits an
+EffectRequest; the membrane approves it; THIS acts on the approval — and it treats every
+step of the re-vendor discipline (vendor-freshness-plane.md § Re-vendor discipline) as a
+claim it must PROVE, not a command it may assume worked. The deliverable is a re-vendor PR
+whose body *is* the receipt: which tarball (by digest), which marker proved it is that
+release, which files moved, the floor it raised, and the guard's own verdict. A re-vendor
+that cannot show its work is the stale-dist-under-a-fresh-version-string regression this
+plane exists to stop.
+
+Three properties it holds because each has a failure mode that has actually happened here:
+
+* Fail-closed. Any step whose proof does not hold aborts the whole operation, leaving a
+  receipt that records exactly where it stopped. Nothing half-applied; no PR on a broken
+  proof. (The opposite — a guard that fails and is ignored — is VFP-0001.)
+* Atomic across consumers. hellgraph-service and lifecycle-warden MUST track the same
+  engine release; lifecycle-warden once drifted five releases behind unnoticed because a
+  re-vendor moved one and not the other. The tarball and the floor move for ALL consumers
+  in one change or not at all.
+* Idempotent. Keyed on to_version. If every consumer already ships it (tarball present,
+  marker proven, floor at or above it) the run is a no-op that says so — a re-emitted
+  finding must never open a second PR.
+
+Default is dry-run: it computes the plan and the receipt and mutates nothing. --apply
+performs the file changes; --open-pr additionally opens the (idempotent) re-vendor PR.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+
+
+def _load_marker_tool():
+    """Reuse the verified marker assertion rather than reimplement byte-containment."""
+    spec = importlib.util.spec_from_file_location(
+        "assert_vendored_engine_marker", _HERE / "assert_vendored_engine_marker.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+marker_tool = _load_marker_tool()
+
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+class RevendorAbort(Exception):
+    """A discipline step could not be proven. Carries the failed step's evidence so the
+    receipt records precisely where and why the re-vendor stopped."""
+
+    def __init__(self, step: str, reason: str, evidence: dict | None = None):
+        super().__init__(f"{step}: {reason}")
+        self.step = step
+        self.reason = reason
+        self.evidence = evidence or {}
+
+
+def _semver_key(v: str) -> tuple[int, int, int]:
+    return tuple(int(p) for p in v.split("."))  # type: ignore[return-value]
+
+
+@dataclass
+class RevendorPlan:
+    """What to re-vendor to, and how to prove it. Derived from an approved EffectRequest,
+    or given directly for a manual/tested run."""
+    to_version: str
+    tarball: Path
+    expect_markers: list[str]
+    consumers: list[str] = field(default_factory=lambda: ["hellgraph-service", "lifecycle-warden"])
+    forbid_markers: list[str] = field(default_factory=list)
+    member: str = marker_tool.DEFAULT_MEMBER
+    requested_by_event_ref: str | None = None
+
+    @property
+    def idempotency_key(self) -> str:
+        return f"engine@{self.to_version}"
+
+    def __post_init__(self):
+        if not SEMVER.match(self.to_version):
+            raise ValueError(f"to_version must be X.Y.Z, got {self.to_version!r}")
+        self.tarball = Path(self.tarball)
+        if not self.expect_markers:
+            raise ValueError("at least one expect marker is required — a version field is not evidence")
+
+    @classmethod
+    def from_effect_request(cls, doc: dict) -> "RevendorPlan":
+        """Build from the EffectRequest the plane emits (schema specVersion 0.1.0):
+        capability vendor.revendor, parameters carry from/to versions, the register's
+        version_marker rides in parameters.expectMarkers."""
+        if doc.get("capability") != "vendor.revendor":
+            raise ValueError(f"not a vendor.revendor EffectRequest (capability={doc.get('capability')!r})")
+        p = doc.get("parameters", {})
+        markers = p.get("expectMarkers") or ([p["versionMarker"]] if p.get("versionMarker") else [])
+        return cls(
+            to_version=p["toVersion"],
+            tarball=Path(p["tarball"]),
+            expect_markers=list(markers),
+            forbid_markers=list(p.get("forbidMarkers", [])),
+            consumers=list(p.get("consumers", ["hellgraph-service", "lifecycle-warden"])),
+            requested_by_event_ref=doc.get("requestedByEventRef"),
+        )
+
+
+# ── the artifacts the executor reads and rewrites ────────────────────────────────────
+
+def _pkg_path(root: Path, consumer: str) -> Path:
+    return root / "apps" / consumer / "package.json"
+
+
+def _guard_path(root: Path, consumer: str) -> Path:
+    return root / "apps" / consumer / "scripts" / "check-engine-version.mjs"
+
+
+def _vendored_ref(root: Path, consumer: str) -> tuple[str | None, str | None]:
+    """Return (dependency spec, pinned version) for the engine dep, or (None, None)."""
+    pkg = json.loads(_pkg_path(root, consumer).read_text())
+    spec = pkg.get("dependencies", {}).get("@socioprophet/hellgraph")
+    if not spec:
+        return None, None
+    m = re.search(r"socioprophet-hellgraph-(\d+\.\d+\.\d+)\.tgz", spec) or re.search(r"#v?(\d+\.\d+\.\d+)$", spec)
+    return spec, (m.group(1) if m else None)
+
+
+def _current_floor(root: Path, consumer: str) -> str | None:
+    m = re.search(r"const MIN_ENGINE = '(\d+\.\d+\.\d+)'", _guard_path(root, consumer).read_text())
+    return m.group(1) if m else None
+
+
+# ── the disciplined steps, each returning evidence or raising RevendorAbort ───────────
+
+def step_assert_marker(plan: RevendorPlan) -> dict:
+    """Discipline step 2: prove the tarball's packed dist carries the discriminating
+    marker. A version field is not evidence; the bundle is."""
+    if not plan.tarball.exists():
+        raise RevendorAbort("assert_marker", f"tarball not found: {plan.tarball}")
+    raw = marker_tool.read_member(plan.tarball, plan.member)  # bounded, typed read
+    missing = [m for m in plan.expect_markers if m.encode("utf-8") not in raw]
+    present_forbidden = [m for m in plan.forbid_markers if m.encode("utf-8") in raw]
+    digest = marker_tool.sha256_file(plan.tarball)
+    evidence = {
+        "tarball_digest": f"sha256:{digest}", "member": plan.member,
+        "expected_present": plan.expect_markers, "forbidden_absent": plan.forbid_markers,
+    }
+    if missing or present_forbidden:
+        raise RevendorAbort("assert_marker",
+                            f"marker proof failed (missing={missing}, forbidden_present={present_forbidden})",
+                            evidence)
+    return evidence
+
+
+def step_precheck(plan: RevendorPlan, root: Path) -> dict:
+    """Read-only validation of every consumer BEFORE any file is touched, so a violation
+    (a missing dep, a floor that would move backwards) aborts with nothing half-applied.
+    place_tarball and bump_floor keep their own checks as defense-in-depth, but this is
+    where fail-closed is actually enforced across the atomic set."""
+    per_consumer = {}
+    for consumer in plan.consumers:
+        spec, ver = _vendored_ref(root, consumer)
+        if spec is None:
+            raise RevendorAbort("precheck", f"{consumer} has no @socioprophet/hellgraph dependency")
+        floor = _current_floor(root, consumer)
+        if floor is None:
+            raise RevendorAbort("precheck", f"{consumer} guard has no MIN_ENGINE constant")
+        if _semver_key(plan.to_version) < _semver_key(floor):
+            raise RevendorAbort("precheck",
+                                f"{consumer} floor {floor} is already above target {plan.to_version} — "
+                                f"a re-vendor moves forward or aborts; refusing to lower a floor")
+        per_consumer[consumer] = {"current_version": ver, "current_floor": floor}
+    return {"consumers": per_consumer}
+
+
+def step_place_tarball(plan: RevendorPlan, root: Path, apply: bool) -> dict:
+    """Discipline step: place the tarball and repoint the dep, for every consumer, so the
+    ref, filename and internal version all agree (what check-engine-version.mjs enforces)."""
+    new_name = f"socioprophet-hellgraph-{plan.to_version}.tgz"
+    per_consumer = {}
+    for consumer in plan.consumers:
+        old_spec, old_ver = _vendored_ref(root, consumer)
+        if old_spec is None:
+            raise RevendorAbort("place_tarball", f"{consumer} has no @socioprophet/hellgraph dependency")
+        vendor_dir = root / "apps" / consumer / "vendor"
+        new_ref = f"file:vendor/{new_name}"
+        removed = []
+        if apply:
+            vendor_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(plan.tarball, vendor_dir / new_name)
+            for old in vendor_dir.glob("socioprophet-hellgraph-*.tgz"):
+                if old.name != new_name:
+                    old.unlink()
+                    removed.append(old.name)
+            pkg_file = _pkg_path(root, consumer)
+            pkg = json.loads(pkg_file.read_text())
+            pkg["dependencies"]["@socioprophet/hellgraph"] = new_ref
+            pkg_file.write_text(json.dumps(pkg, indent=2) + "\n")
+        per_consumer[consumer] = {"old_ref": old_spec, "new_ref": new_ref,
+                                  "old_version": old_ver, "removed": removed}
+    return {"new_tarball": new_name, "consumers": per_consumer}
+
+
+def step_bump_floor(plan: RevendorPlan, root: Path, apply: bool) -> dict:
+    """Discipline step 3: raise MIN_ENGINE for every consumer so the floor moves with the
+    tarball. Never LOWERS a floor — a re-vendor is a move forward or an abort."""
+    per_consumer = {}
+    for consumer in plan.consumers:
+        old = _current_floor(root, consumer)
+        if old is None:
+            raise RevendorAbort("bump_floor", f"{consumer} guard has no MIN_ENGINE constant")
+        if _semver_key(plan.to_version) < _semver_key(old):
+            raise RevendorAbort("bump_floor",
+                                f"{consumer} floor {old} is already above target {plan.to_version} — "
+                                f"refusing to lower it")
+        if apply and old != plan.to_version:
+            gp = _guard_path(root, consumer)
+            gp.write_text(re.sub(r"const MIN_ENGINE = '\d+\.\d+\.\d+'",
+                                 f"const MIN_ENGINE = '{plan.to_version}'", gp.read_text(), count=1))
+        per_consumer[consumer] = {"old_floor": old, "new_floor": plan.to_version}
+    return {"consumers": per_consumer}
+
+
+def step_verify_guard(plan: RevendorPlan, root: Path) -> dict:
+    """Run each consumer's own guard against the applied state. The guard re-checks the
+    ref/filename/internal-version agreement and the floor from scratch — the executor does
+    not get to grade its own work."""
+    per_consumer = {}
+    for consumer in plan.consumers:
+        gp = _guard_path(root, consumer)
+        proc = subprocess.run(["node", str(gp)], capture_output=True, text=True, timeout=60)
+        per_consumer[consumer] = {"exit": proc.returncode,
+                                  "stdout": proc.stdout.strip(), "stderr": proc.stderr.strip()}
+        if proc.returncode != 0:
+            raise RevendorAbort("verify_guard", f"{consumer} guard rejected the re-vendor",
+                                per_consumer[consumer])
+    return {"consumers": per_consumer}
+
+
+def _already_current(plan: RevendorPlan, root: Path) -> bool:
+    """True only if EVERY consumer already ships to_version with the marker proven and the
+    floor at or above it — the idempotency guard."""
+    for consumer in plan.consumers:
+        _, ver = _vendored_ref(root, consumer)
+        floor = _current_floor(root, consumer)
+        if ver != plan.to_version or floor is None or _semver_key(floor) < _semver_key(plan.to_version):
+            return False
+        tgz = root / "apps" / consumer / "vendor" / f"socioprophet-hellgraph-{plan.to_version}.tgz"
+        if not tgz.exists():
+            return False
+        try:
+            raw = marker_tool.read_member(tgz, plan.member)
+        except SystemExit:
+            return False
+        if any(m.encode("utf-8") not in raw for m in plan.expect_markers):
+            return False
+    return True
+
+
+def _seal(receipt: dict) -> dict:
+    """Tamper-evident seal: a digest over the canonical receipt body. Any later edit to a
+    step or its evidence changes the digest."""
+    body = {k: v for k, v in receipt.items() if k != "receipt_digest"}
+    receipt["receipt_digest"] = "sha256:" + hashlib.sha256(
+        json.dumps(body, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    return receipt
+
+
+def execute(plan: RevendorPlan, root: Path, apply: bool = False) -> dict:
+    """Run the disciplined re-vendor. Returns a sealed receipt. Fail-closed: the first
+    step that cannot be proven stops the run with status=failed and nothing half-applied
+    beyond what already succeeded (steps are ordered so a failed proof precedes mutation
+    of that concern). In dry-run (apply=False) no file is touched."""
+    receipt: dict = {
+        "tool": "prophet-platform.revendor_engine.v1",
+        "idempotency_key": plan.idempotency_key,
+        "to_version": plan.to_version,
+        "consumers": plan.consumers,
+        "requested_by_event_ref": plan.requested_by_event_ref,
+        "mode": "apply" if apply else "dry-run",
+        "steps": [],
+    }
+
+    def record(step: str, ok: bool, evidence: dict):
+        receipt["steps"].append({"step": step, "ok": ok, "evidence": evidence})
+
+    # Marker proof first: it never mutates and it is the gate on everything after it.
+    try:
+        record("assert_marker", True, step_assert_marker(plan))
+    except RevendorAbort as abort:
+        record(abort.step, False, {"reason": abort.reason, **abort.evidence})
+        receipt["status"] = "failed"
+        return _seal(receipt)
+
+    if _already_current(plan, root):
+        receipt["status"] = "noop"
+        receipt["note"] = "every consumer already ships this release with the marker proven and the floor raised"
+        return _seal(receipt)
+
+    # All read-only proofs must hold before the first mutation (fail-closed across the set).
+    try:
+        record("precheck", True, step_precheck(plan, root))
+    except RevendorAbort as abort:
+        record(abort.step, False, {"reason": abort.reason, **abort.evidence})
+        receipt["status"] = "failed"
+        return _seal(receipt)
+
+    for step_fn, name in ((step_place_tarball, "place_tarball"), (step_bump_floor, "bump_floor")):
+        try:
+            record(name, True, step_fn(plan, root, apply))
+        except RevendorAbort as abort:
+            record(abort.step, False, {"reason": abort.reason, **abort.evidence})
+            receipt["status"] = "failed"
+            return _seal(receipt)
+
+    # The guard only means something against applied files.
+    if apply:
+        try:
+            record("verify_guard", True, step_verify_guard(plan, root))
+        except RevendorAbort as abort:
+            record(abort.step, False, {"reason": abort.reason, **abort.evidence})
+            receipt["status"] = "failed"
+            return _seal(receipt)
+
+    receipt["status"] = "applied" if apply else "planned"
+    return _seal(receipt)
+
+
+# ── PR emission (idempotent) ─────────────────────────────────────────────────────────
+
+def open_pr(plan: RevendorPlan, receipt: dict, root: Path) -> dict:
+    """Open the re-vendor PR whose body is the receipt. Idempotent on the branch name
+    (derived from the idempotency key): if the branch already exists, do not open a second
+    PR. Requires an applied receipt."""
+    if receipt.get("status") != "applied":
+        raise RevendorAbort("open_pr", f"refusing to open a PR for a {receipt.get('status')} receipt")
+    branch = f"revendor/engine-{plan.to_version}"
+    existing = subprocess.run(["git", "-C", str(root), "ls-remote", "--heads", "origin", branch],
+                              capture_output=True, text=True).stdout.strip()
+    if existing:
+        return {"opened": False, "reason": "branch already exists — idempotent no-op", "branch": branch}
+    body = "```json\n" + json.dumps(receipt, indent=2) + "\n```"
+    subprocess.run(["git", "-C", str(root), "switch", "-c", branch], check=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-aqm",
+                    f"chore(revendor): engine → {plan.to_version} (marker-proven, guard-verified)"], check=True)
+    subprocess.run(["git", "-C", str(root), "push", "-u", "origin", branch], check=True)
+    subprocess.run(["gh", "pr", "create", "--fill-first", "--body", body, "--head", branch], check=True, cwd=root)
+    return {"opened": True, "branch": branch}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Execute a disciplined, receipt-sealed engine re-vendor.")
+    ap.add_argument("--from-effect-request", type=Path, help="an approved vendor.revendor EffectRequest JSON")
+    ap.add_argument("--to-version")
+    ap.add_argument("--tarball", type=Path)
+    ap.add_argument("--expect", action="append", default=[], metavar="MARKER")
+    ap.add_argument("--forbid", action="append", default=[], metavar="MARKER")
+    ap.add_argument("--consumer", action="append", default=[], help="repeatable; default both engine consumers")
+    ap.add_argument("--root", type=Path, default=_HERE.parent, help="repo root (default: this repo)")
+    ap.add_argument("--apply", action="store_true", help="perform the file changes (default: dry-run)")
+    ap.add_argument("--open-pr", action="store_true", help="open the idempotent re-vendor PR (implies --apply)")
+    args = ap.parse_args(argv)
+
+    if args.from_effect_request:
+        plan = RevendorPlan.from_effect_request(json.loads(args.from_effect_request.read_text()))
+    elif args.to_version and args.tarball:
+        plan = RevendorPlan(to_version=args.to_version, tarball=args.tarball, expect_markers=args.expect,
+                            forbid_markers=args.forbid,
+                            consumers=args.consumer or ["hellgraph-service", "lifecycle-warden"])
+    else:
+        ap.error("provide --from-effect-request, or both --to-version and --tarball")
+
+    apply = args.apply or args.open_pr
+    receipt = execute(plan, args.root, apply=apply)
+    if receipt["status"] == "applied" and args.open_pr:
+        receipt["pr"] = open_pr(plan, receipt, args.root)
+        _seal(receipt)
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+    return 0 if receipt["status"] in ("applied", "planned", "noop") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/revendor_engine.py
+++ b/tools/revendor_engine.py
@@ -290,11 +290,55 @@ def _seal(receipt: dict) -> dict:
     return receipt
 
 
+def _capture_pre_state(plan: RevendorPlan, root: Path) -> dict:
+    """Snapshot every file the mutation steps (place_tarball, bump_floor) can touch, so a
+    failure AFTER a mutation — including verify_guard, which runs against applied files —
+    can be rolled back to leave nothing half-applied. Copilot #1062: verify_guard failing
+    used to leave the copied tarball, the unlinked old tarball, the bumped package.json and
+    the bumped guard on disk while reporting status=failed."""
+    files: dict[str, bytes] = {}
+    vendor_dirs: list[Path] = []
+    pre_vendor: dict[str, set[str]] = {}
+    for consumer in plan.consumers:
+        vendor_dir = root / "apps" / consumer / "vendor"
+        vendor_dirs.append(vendor_dir)
+        present = set()
+        if vendor_dir.is_dir():
+            for f in vendor_dir.iterdir():
+                if f.is_file():
+                    files[str(f)] = f.read_bytes()
+                    present.add(f.name)
+        pre_vendor[str(vendor_dir)] = present
+        for p in (_pkg_path(root, consumer), _guard_path(root, consumer)):
+            if p.exists():
+                files[str(p)] = p.read_bytes()
+    return {"files": files, "vendor_dirs": [str(d) for d in vendor_dirs], "pre_vendor": pre_vendor}
+
+
+def _rollback(state: dict) -> None:
+    """Restore the captured pre-mutation state: rewrite every snapshotted file (reverting
+    package.json/guard and recreating any unlinked old tarball) and delete any vendor file
+    the run created (the new tarball). Idempotent."""
+    for path_str, data in state["files"].items():
+        p = Path(path_str)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(data)
+    for d_str in state["vendor_dirs"]:
+        d = Path(d_str)
+        if not d.is_dir():
+            continue
+        keep = state["pre_vendor"].get(d_str, set())
+        for f in d.iterdir():
+            if f.is_file() and f.name not in keep:
+                f.unlink()
+
+
 def execute(plan: RevendorPlan, root: Path, apply: bool = False) -> dict:
-    """Run the disciplined re-vendor. Returns a sealed receipt. Fail-closed: the first
-    step that cannot be proven stops the run with status=failed and nothing half-applied
-    beyond what already succeeded (steps are ordered so a failed proof precedes mutation
-    of that concern). In dry-run (apply=False) no file is touched."""
+    """Run the disciplined re-vendor. Returns a sealed receipt. Fail-closed AND atomic under
+    apply: read-only proofs (marker, precheck) run before any mutation, and if a later step
+    fails — including verify_guard, which necessarily runs against the mutated files — every
+    mutation is rolled back, so a failed run leaves NOTHING half-applied. In dry-run
+    (apply=False) no file is touched."""
     receipt: dict = {
         "tool": "prophet-platform.revendor_engine.v1",
         "idempotency_key": plan.idempotency_key,
@@ -329,20 +373,27 @@ def execute(plan: RevendorPlan, root: Path, apply: bool = False) -> dict:
         receipt["status"] = "failed"
         return _seal(receipt)
 
+    # Capture the pre-mutation state so any failure below rolls back to it (apply only).
+    pre_state = _capture_pre_state(plan, root) if apply else None
     for step_fn, name in ((step_place_tarball, "place_tarball"), (step_bump_floor, "bump_floor")):
         try:
             record(name, True, step_fn(plan, root, apply))
         except RevendorAbort as abort:
-            record(abort.step, False, {"reason": abort.reason, **abort.evidence})
+            if apply:
+                _rollback(pre_state)
+            record(abort.step, False,
+                   {"reason": abort.reason, "rolled_back": bool(apply), **abort.evidence})
             receipt["status"] = "failed"
             return _seal(receipt)
 
-    # The guard only means something against applied files.
+    # The guard only means something against applied files — and it runs AFTER the
+    # mutations, so its failure must undo them too, or the tree is left half-applied.
     if apply:
         try:
             record("verify_guard", True, step_verify_guard(plan, root))
         except RevendorAbort as abort:
-            record(abort.step, False, {"reason": abort.reason, **abort.evidence})
+            _rollback(pre_state)
+            record(abort.step, False, {"reason": abort.reason, "rolled_back": True, **abort.evidence})
             receipt["status"] = "failed"
             return _seal(receipt)
 

--- a/tools/revendor_engine.py
+++ b/tools/revendor_engine.py
@@ -145,7 +145,23 @@ def step_assert_marker(plan: RevendorPlan) -> dict:
     marker. A version field is not evidence; the bundle is."""
     if not plan.tarball.exists():
         raise RevendorAbort("assert_marker", f"tarball not found: {plan.tarball}")
-    raw = marker_tool.read_member(plan.tarball, plan.member)  # bounded, typed read
+    # Copilot #1062 round 2: marker_tool.read_member raises SystemExit for the
+    # artifact-is-not-what-it-claims cases (unreadable gzip, missing member,
+    # non-file member, declared-size-over-cap, expanded-past-cap). SystemExit
+    # inherits from BaseException, so execute()'s `except RevendorAbort` lets it
+    # tear the whole run down WITHOUT a sealed receipt — the exact opposite of
+    # this executor's fail-closed-AND-receipt-producing contract. Convert to a
+    # RevendorAbort here so a corrupt tarball becomes a receipt saying
+    # assert_marker.ok=false with the reader's own error text as evidence.
+    try:
+        raw = marker_tool.read_member(plan.tarball, plan.member)  # bounded, typed read
+    except SystemExit as exc:
+        raise RevendorAbort(
+            "assert_marker",
+            f"tarball could not be read as a packed dist: {exc}",
+            {"tarball": str(plan.tarball), "member": plan.member,
+             "reader_error": str(exc)},
+        )
     missing = [m for m in plan.expect_markers if m.encode("utf-8") not in raw]
     present_forbidden = [m for m in plan.forbid_markers if m.encode("utf-8") in raw]
     digest = marker_tool.sha256_file(plan.tarball)
@@ -405,7 +421,25 @@ def main(argv: list[str] | None = None) -> int:
     apply = args.apply or args.open_pr
     receipt = execute(plan, args.root, apply=apply)
     if receipt["status"] == "applied" and args.open_pr:
-        receipt["pr"] = open_pr(plan, receipt, args.root)
+        # Copilot #1062 round 2: the receipt IS the deliverable. If open_pr raises
+        # (RevendorAbort for a non-applied state, subprocess.CalledProcessError from
+        # any of git switch/add/commit/push or gh pr create, or OSError on a broken
+        # git tree) and we let it propagate, main() exits before printing — and
+        # automation loses the final JSON status entirely. Record the failure as a
+        # regular step, demote to failed, re-seal, print. Exit 1 still signals the
+        # operation failed, but a downstream `jq` on stdout has the whole story.
+        try:
+            receipt["pr"] = open_pr(plan, receipt, args.root)
+        except (RevendorAbort, subprocess.CalledProcessError, OSError) as exc:
+            step = getattr(exc, "step", "open_pr")
+            reason = getattr(exc, "reason", None) or str(exc)
+            evidence: dict = dict(getattr(exc, "evidence", {}) or {})
+            if isinstance(exc, subprocess.CalledProcessError):
+                evidence.update({"argv": list(exc.cmd) if exc.cmd else [],
+                                 "returncode": exc.returncode})
+            receipt["steps"].append({"step": step, "ok": False,
+                                     "evidence": {"reason": reason, **evidence}})
+            receipt["status"] = "failed"
         _seal(receipt)
     print(json.dumps(receipt, indent=2, sort_keys=True))
     return 0 if receipt["status"] in ("applied", "planned", "noop") else 1

--- a/tools/revendor_engine.py
+++ b/tools/revendor_engine.py
@@ -336,6 +336,25 @@ def execute(plan: RevendorPlan, root: Path, apply: bool = False) -> dict:
 
 # ── PR emission (idempotent) ─────────────────────────────────────────────────────────
 
+def _paths_this_revendor_mutates(plan: RevendorPlan, root: Path) -> list[Path]:
+    """The EXACT files a successful re-vendor of `plan` touches — the new tgz (untracked),
+    any old tgz(s) unlinked, package.json and the guard for each consumer. Enumerating them
+    is what lets us `git add` them explicitly rather than `git commit -a` (Copilot #1062:
+    -a misses the untracked new tgz entirely — the PR would delete the old tgz + bump
+    package.json but never carry the new bytes it points at — and risks sweeping in
+    unrelated tracked changes)."""
+    paths: list[Path] = []
+    for consumer in plan.consumers:
+        vendor_dir = root / "apps" / consumer / "vendor"
+        paths.append(vendor_dir / f"socioprophet-hellgraph-{plan.to_version}.tgz")
+        # Any other tgz in vendor/ was unlinked by step_place_tarball; adding the whole
+        # directory (post-mutation state) captures both the new file and the deletions.
+        paths.append(vendor_dir)
+        paths.append(_pkg_path(root, consumer))
+        paths.append(_guard_path(root, consumer))
+    return paths
+
+
 def open_pr(plan: RevendorPlan, receipt: dict, root: Path) -> dict:
     """Open the re-vendor PR whose body is the receipt. Idempotent on the branch name
     (derived from the idempotency key): if the branch already exists, do not open a second
@@ -349,11 +368,16 @@ def open_pr(plan: RevendorPlan, receipt: dict, root: Path) -> dict:
         return {"opened": False, "reason": "branch already exists — idempotent no-op", "branch": branch}
     body = "```json\n" + json.dumps(receipt, indent=2) + "\n```"
     subprocess.run(["git", "-C", str(root), "switch", "-c", branch], check=True)
-    subprocess.run(["git", "-C", str(root), "commit", "-aqm",
+    # Copilot #1062: `git commit -a` (a) does NOT stage new files, so the freshly-copied
+    # tarball would be committed-around, and (b) sweeps in any unrelated tracked change
+    # in the working tree. Stage the exact paths this run mutated, then commit without -a.
+    mutated = [str(p.relative_to(root)) for p in _paths_this_revendor_mutates(plan, root)]
+    subprocess.run(["git", "-C", str(root), "add", "--", *mutated], check=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm",
                     f"chore(revendor): engine → {plan.to_version} (marker-proven, guard-verified)"], check=True)
     subprocess.run(["git", "-C", str(root), "push", "-u", "origin", branch], check=True)
     subprocess.run(["gh", "pr", "create", "--fill-first", "--body", body, "--head", branch], check=True, cwd=root)
-    return {"opened": True, "branch": branch}
+    return {"opened": True, "branch": branch, "staged_paths": mutated}
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tools/test_assert_vendored_engine_marker.py
+++ b/tools/test_assert_vendored_engine_marker.py
@@ -9,6 +9,7 @@ whole reason a substring proves nothing.
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import io
 import tarfile
 from pathlib import Path
@@ -183,3 +184,34 @@ def test_non_regular_member_is_refused(tmp_path):
     with pytest.raises(SystemExit) as e:
         tool.main([str(linky), "--expect", MARKER])
     assert "not a regular file" in str(e.value)
+
+
+# ── Copilot round-2 ───────────────────────────────────────────────────────
+
+def test_a_corrupt_tarball_fails_cleanly_not_with_a_stack_trace(tmp_path):
+    """Automation reads the exit code. A ReadError escaping as a traceback is a
+    different failure mode from every other error path in this tool."""
+    junk = tmp_path / "corrupt.tgz"
+    junk.write_bytes(b"this is definitely not a gzip stream")
+    with pytest.raises(SystemExit) as e:
+        tool.main([str(junk), "--expect", MARKER])
+    assert "not a readable gzip tarball" in str(e.value)
+
+
+def test_a_directory_passed_as_a_tarball_fails_cleanly(tmp_path):
+    d = tmp_path / "adir.tgz"
+    d.mkdir()
+    with pytest.raises(SystemExit) as e:
+        tool.main([str(d), "--expect", MARKER])
+    assert "not a readable gzip tarball" in str(e.value)
+
+
+def test_the_tarball_digest_is_streamed_not_slurped():
+    """The receipt digest must not undo read_member's bounded read one line later.
+    Same digest as a whole-file hash, without holding the file in memory."""
+    import hashlib
+    assert tool.sha256_file(REAL_045) == hashlib.sha256(REAL_045.read_bytes()).hexdigest()
+    src = inspect.getsource(tool.main)
+    assert "read_bytes()" not in src, (
+        "main() slurps the whole tarball to hash it — this tool runs on registry-pulled "
+        "artifacts of unknown size, which is the exact case read_member() bounds")

--- a/tools/test_assert_vendored_engine_marker.py
+++ b/tools/test_assert_vendored_engine_marker.py
@@ -8,6 +8,7 @@ whole reason a substring proves nothing.
 """
 from __future__ import annotations
 
+import json
 import importlib.util
 import inspect
 import io
@@ -60,8 +61,7 @@ def test_missing_dist_member_fails_loudly(tmp_path):
     empty = tmp_path / "empty.tgz"
     with tarfile.open(empty, "w:gz"):
         pass
-    with pytest.raises(SystemExit):
-        tool.main([str(empty), "--expect", MARKER])
+    assert tool.main([str(empty), "--expect", MARKER]) == 1
 
 
 def test_forbidden_marker_present_fails(tmp_path):
@@ -153,7 +153,8 @@ def test_the_dist_trips_binary_heuristics_but_containment_is_unaffected():
         "trigger, so the docstring's justification needs revisiting")
     assert raw.count(b"PROP_NS") == 3, "fixture changed; update the expected count"
     dist = tool.read_member(REAL_045, MEMBER)
-    assert MARKER in dist, "Python containment must find the marker regardless"
+    assert isinstance(dist, bytes), "the member must be searched as bytes, not repaired text"
+    assert MARKER.encode() in dist, "byte containment must find the marker regardless"
 
 
 # ── Copilot round-1: bounded, typed member reads ──────────────────────────
@@ -168,9 +169,7 @@ def test_oversized_member_is_refused_rather_than_read(tmp_path):
         info.size = len(payload)
         tar.addfile(info, io.BytesIO(payload))
     assert bomb.stat().st_size < 200_000, "fixture must be small on disk to be a bomb"
-    with pytest.raises(SystemExit) as e:
-        tool.main([str(bomb), "--expect", MARKER])
-    assert "refusing to read" in str(e.value)
+    assert tool.main([str(bomb), "--expect", MARKER]) == 1
 
 
 def test_non_regular_member_is_refused(tmp_path):
@@ -181,9 +180,7 @@ def test_non_regular_member_is_refused(tmp_path):
         info.type = tarfile.SYMTYPE
         info.linkname = "../../../../etc/passwd"
         tar.addfile(info)
-    with pytest.raises(SystemExit) as e:
-        tool.main([str(linky), "--expect", MARKER])
-    assert "not a regular file" in str(e.value)
+    assert tool.main([str(linky), "--expect", MARKER]) == 1
 
 
 # ── Copilot round-2 ───────────────────────────────────────────────────────
@@ -193,17 +190,13 @@ def test_a_corrupt_tarball_fails_cleanly_not_with_a_stack_trace(tmp_path):
     different failure mode from every other error path in this tool."""
     junk = tmp_path / "corrupt.tgz"
     junk.write_bytes(b"this is definitely not a gzip stream")
-    with pytest.raises(SystemExit) as e:
-        tool.main([str(junk), "--expect", MARKER])
-    assert "not a readable gzip tarball" in str(e.value)
+    assert tool.main([str(junk), "--expect", MARKER]) == 1
 
 
 def test_a_directory_passed_as_a_tarball_fails_cleanly(tmp_path):
     d = tmp_path / "adir.tgz"
     d.mkdir()
-    with pytest.raises(SystemExit) as e:
-        tool.main([str(d), "--expect", MARKER])
-    assert "not a readable gzip tarball" in str(e.value)
+    assert tool.main([str(d), "--expect", MARKER]) == 1
 
 
 def test_the_tarball_digest_is_streamed_not_slurped():
@@ -215,3 +208,45 @@ def test_the_tarball_digest_is_streamed_not_slurped():
     assert "read_bytes()" not in src, (
         "main() slurps the whole tarball to hash it — this tool runs on registry-pulled "
         "artifacts of unknown size, which is the exact case read_member() bounds")
+
+
+def test_main_has_one_exit_convention(tmp_path, capsys):
+    """Copilot round-3: main() returned 0/1 for some failures and raised SystemExit
+    for others, so a programmatic caller had to handle both. Every failure path now
+    returns 1 and explains itself on stderr."""
+    junk = tmp_path / "corrupt.tgz"; junk.write_bytes(b"not gzip")
+    empty = tmp_path / "empty.tgz"
+    with tarfile.open(empty, "w:gz"):
+        pass
+    for argv in ([str(junk), "--expect", MARKER],           # unreadable
+                 [str(empty), "--expect", MARKER],          # member absent
+                 [str(REAL_045)],                           # no --expect
+                 [str(tmp_path / "nope.tgz"), "--expect", MARKER]):  # missing file
+        assert tool.main(argv) == 1, f"{argv} must RETURN 1, not raise"
+        assert capsys.readouterr().err, f"{argv} must say why on stderr"
+
+
+def test_stdout_is_pure_json_so_a_consumer_can_pipe_it(capsys):
+    """The receipt is the machine-readable output. A human 'OK:' line on stdout made
+    it unparseable; status now goes to stderr."""
+    assert tool.main([str(REAL_045), "--expect", MARKER]) == 0
+    cap = capsys.readouterr()
+    receipt = json.loads(cap.out)          # must not raise
+    assert receipt["passed"] is True
+    assert receipt["tarball_digest"].startswith("sha256:")
+    assert "OK:" in cap.err, "human status belongs on stderr"
+    assert "OK:" not in cap.out, "stdout must be JSON only"
+
+
+def test_markers_are_matched_as_exact_bytes(tmp_path):
+    """errors='replace' would substitute U+FFFD for invalid UTF-8, so the search would
+    answer a question about a repaired copy rather than the shipped bytes. A marker
+    adjacent to a bad byte must still be found exactly."""
+    payload = b'\xff\xfe' + MARKER.encode() + b'\x80trailing'
+    t = tmp_path / "badbytes.tgz"
+    with tarfile.open(t, "w:gz") as tar:
+        info = tarfile.TarInfo("package/ts/dist/index.js"); info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    assert tool.main([str(t), "--expect", MARKER]) == 0
+    assert b"\xef\xbf\xbd" not in tool.read_member(t, "package/ts/dist/index.js"), \
+        "no U+FFFD substitution — the bytes must be untouched"

--- a/tools/test_assert_vendored_engine_marker.py
+++ b/tools/test_assert_vendored_engine_marker.py
@@ -23,6 +23,10 @@ MARKER = 'PROP_NS = "prop:"'
 
 def _load():
     spec = importlib.util.spec_from_file_location("assert_vendored_engine_marker", TOOL)
+    if spec is None or spec.loader is None:
+        raise AssertionError(
+            f"cannot build an import spec for {TOOL} — the tool is missing or unreadable. "
+            "Failing here rather than on a downstream AttributeError so the cause is the message.")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -67,3 +71,115 @@ def test_forbidden_marker_present_fails(tmp_path):
 def test_expect_required():
     # A version field is not evidence — refuse to "pass" with nothing asserted.
     assert tool.main([str(REAL_045)]) == 1
+
+
+# ── The assertion must be shown to FIRE, not merely to exist ──────────────
+#
+# Everything above this line proves the tool passes on the real tarball and
+# fails on hand-built toys. That is not the same claim. An assertion whose only
+# negative cases are synthetic can still be blind to the real artifact — the
+# toys are 60-byte files, the real dist is 395 KB of minified bundle that the OS
+# classifies as `data`. So the negative case is built by mutating the REAL
+# 0.4.45 tarball and re-running the tool against it.
+#
+# This is the whole point of the tool. A re-vendor check that cannot go red is
+# a rubber stamp with a receipt attached.
+
+MEMBER = "package/ts/dist/index.js"
+
+
+def _mutate_real(dst: Path, old: bytes, new: bytes) -> Path:
+    """Rebuild the real 0.4.45 tarball with one substitution in the packed dist."""
+    with tarfile.open(REAL_045, "r:gz") as src, tarfile.open(dst, "w:gz") as out:
+        for m in src.getmembers():
+            data = src.extractfile(m).read() if m.isfile() else None
+            if m.name == MEMBER:
+                assert old in data, "mutation target absent — the fixture, not the tool, is wrong"
+                data = data.replace(old, new)
+                m.size = len(data)
+            out.addfile(m, io.BytesIO(data) if data is not None else None)
+    return dst
+
+
+def test_real_tarball_with_the_marker_removed_goes_RED(tmp_path):
+    """Break the marker in the real bundle; the decoy substring `prop:` is left
+    in place, so only the full assignment distinguishes pass from fail."""
+    broken = _mutate_real(tmp_path / "broken.tgz",
+                          b'PROP_NS = "prop:"', b'PROP_NS_RENAMED = "prop:"')
+    assert tool.main([str(broken), "--expect", MARKER]) == 1
+    # And the tool is not merely rejecting any rebuilt tarball: an untouched
+    # rebuild of the same bytes still passes.
+    same = _mutate_real(tmp_path / "same.tgz", b'PROP_NS = "prop:"', b'PROP_NS = "prop:"')
+    assert tool.main([str(same), "--expect", MARKER]) == 0
+
+
+def test_real_tarball_with_one_character_changed_goes_RED(tmp_path):
+    """Single-character mutation: PROP_NS -> PROP_N5. The check must be exact."""
+    broken = _mutate_real(tmp_path / "onechar.tgz",
+                          b'PROP_NS = "prop:"', b'PROP_N5 = "prop:"')
+    assert tool.main([str(broken), "--expect", MARKER]) == 1
+
+
+def test_a_substring_marker_would_NOT_have_caught_it(tmp_path):
+    """The reason --expect must carry the whole assignment. Against the same
+    broken bundle, the substring `prop:` passes — it is present in 0.4.40 too,
+    so it discriminates nothing. This test exists to keep the marker strong:
+    it fails if someone weakens --expect and assumes the tool still works."""
+    broken = _mutate_real(tmp_path / "weak.tgz",
+                          b'PROP_NS = "prop:"', b'PROP_NS_RENAMED = "prop:"')
+    assert tool.main([str(broken), "--expect", "prop:"]) == 0
+    assert tool.main([str(broken), "--expect", MARKER]) == 1
+
+
+def test_the_dist_trips_binary_heuristics_but_containment_is_unaffected():
+    """Pins the docstring's justification as an actual property of the artifact
+    rather than a claim about some particular grep build.
+
+    Deliberately does NOT assert what `grep` returns. Writing this test first
+    with `assert grep_returncode == 1` made it fail: /usr/bin/grep finds all
+    three occurrences, and the docstring's original "grep reports zero" claim
+    turned out to have been measured through a broken shell shim. Asserting a
+    tool-specific exit code here would either encode that false claim or make CI
+    depend on which grep the runner ships.
+
+    What IS stably true, and is what the tool relies on: the bundle carries a NUL
+    byte, so it is a legitimate binary-heuristic trigger for any searcher, while
+    Python containment has no such mode and answers over the bytes."""
+    with tarfile.open(REAL_045, "r:gz") as t:
+        raw = t.extractfile(MEMBER).read()
+    assert b"\x00" in raw, (
+        "the dist no longer contains a NUL byte — binary heuristics may no longer "
+        "trigger, so the docstring's justification needs revisiting")
+    assert raw.count(b"PROP_NS") == 3, "fixture changed; update the expected count"
+    dist = tool.read_member(REAL_045, MEMBER)
+    assert MARKER in dist, "Python containment must find the marker regardless"
+
+
+# ── Copilot round-1: bounded, typed member reads ──────────────────────────
+
+def test_oversized_member_is_refused_rather_than_read(tmp_path):
+    """A decompression bomb must not be read into memory. Highly compressible
+    zeros: tiny on disk, enormous expanded."""
+    bomb = tmp_path / "bomb.tgz"
+    payload = b"\0" * (tool.MAX_MEMBER_BYTES + 4096)
+    with tarfile.open(bomb, "w:gz") as tar:
+        info = tarfile.TarInfo(MEMBER)
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    assert bomb.stat().st_size < 200_000, "fixture must be small on disk to be a bomb"
+    with pytest.raises(SystemExit) as e:
+        tool.main([str(bomb), "--expect", MARKER])
+    assert "refusing to read" in str(e.value)
+
+
+def test_non_regular_member_is_refused(tmp_path):
+    """A symlink named like the dist must not be followed."""
+    linky = tmp_path / "linky.tgz"
+    with tarfile.open(linky, "w:gz") as tar:
+        info = tarfile.TarInfo(MEMBER)
+        info.type = tarfile.SYMTYPE
+        info.linkname = "../../../../etc/passwd"
+        tar.addfile(info)
+    with pytest.raises(SystemExit) as e:
+        tool.main([str(linky), "--expect", MARKER])
+    assert "not a regular file" in str(e.value)

--- a/tools/test_assert_vendored_engine_marker.py
+++ b/tools/test_assert_vendored_engine_marker.py
@@ -1,0 +1,69 @@
+"""Coverage for tools/assert_vendored_engine_marker.py.
+
+Pins the load-bearing property of the re-vendor discipline: the assertion reads the
+packed dist (not package.json) and a substring is not a marker. The real vendored
+0.4.45 tarball must pass on the full PROP_NS assignment; a bundle that carries only the
+decoy substring `prop:` must fail — that decoy is present in 0.4.40 too, which is the
+whole reason a substring proves nothing.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "tools" / "assert_vendored_engine_marker.py"
+REAL_045 = ROOT / "apps" / "hellgraph-service" / "vendor" / "socioprophet-hellgraph-0.4.45.tgz"
+MARKER = 'PROP_NS = "prop:"'
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("assert_vendored_engine_marker", TOOL)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+tool = _load()
+
+
+def _tarball(path: Path, index_js: str) -> Path:
+    with tarfile.open(path, "w:gz") as tar:
+        data = index_js.encode("utf-8")
+        info = tarfile.TarInfo("package/ts/dist/index.js")
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+    return path
+
+
+def test_real_045_passes_on_full_marker():
+    # The committed production tarball genuinely carries the marker.
+    assert tool.main([str(REAL_045), "--expect", MARKER]) == 0
+
+
+def test_decoy_substring_is_not_a_marker(tmp_path):
+    # Carries 'prop:' (present in BOTH 0.4.40 and 0.4.45) but not the full assignment.
+    t = _tarball(tmp_path / "decoy.tgz", 'const x = "prop:"; // no PROP_NS assignment here')
+    assert tool.main([str(t), "--expect", MARKER]) == 1
+
+
+def test_missing_dist_member_fails_loudly(tmp_path):
+    empty = tmp_path / "empty.tgz"
+    with tarfile.open(empty, "w:gz"):
+        pass
+    with pytest.raises(SystemExit):
+        tool.main([str(empty), "--expect", MARKER])
+
+
+def test_forbidden_marker_present_fails(tmp_path):
+    t = _tarball(tmp_path / "has-old.tgz", f'{MARKER}\nconst legacyGraphLabels = true;')
+    assert tool.main([str(t), "--expect", MARKER, "--forbid", "legacyGraphLabels"]) == 1
+
+
+def test_expect_required():
+    # A version field is not evidence — refuse to "pass" with nothing asserted.
+    assert tool.main([str(REAL_045)]) == 1

--- a/tools/test_revendor_engine.py
+++ b/tools/test_revendor_engine.py
@@ -1,0 +1,164 @@
+"""Coverage for tools/revendor_engine.py.
+
+The re-vendor is exercised end-to-end on a temp copy of the two consumers: a synthesized
+0.4.40 is re-vendored to the REAL 0.4.45 tarball, and success is judged by the consumers'
+OWN check-engine-version.mjs guard — the executor does not grade its own work. Idempotency,
+fail-closed (bad marker; refusing to lower a floor), and the tamper-evident seal are pinned
+because each corresponds to a way this has gone wrong before.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOL = ROOT / "tools" / "revendor_engine.py"
+REAL_045 = ROOT / "apps" / "hellgraph-service" / "vendor" / "socioprophet-hellgraph-0.4.45.tgz"
+REAL_GUARD = ROOT / "apps" / "hellgraph-service" / "scripts" / "check-engine-version.mjs"
+MARKER = 'PROP_NS = "prop:"'
+CONSUMERS = ["hellgraph-service", "lifecycle-warden"]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("revendor_engine", TOOL)
+    mod = importlib.util.module_from_spec(spec)
+    # @dataclass resolves its own module via sys.modules during class creation; register
+    # before exec so the importlib-loaded module is findable.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+eng = _load()
+
+
+def _engine_tarball(path: Path, version: str, with_marker: bool) -> Path:
+    """A minimal engine tarball: internal package.json version + a packed dist. The decoy
+    'prop:' is always present, so only the full PROP_NS assignment discriminates."""
+    with tarfile.open(path, "w:gz") as tar:
+        for name, data in (
+            ("package/package.json", json.dumps({"name": "@socioprophet/hellgraph", "version": version}).encode()),
+            ("package/ts/dist/index.js",
+             ((MARKER + "\n") if with_marker else "").encode() + b'const decoy = "prop:";\n'),
+        ):
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return path
+
+
+def _fixture(root: Path, start_version: str = "0.4.40", floor: str = "0.4.40") -> Path:
+    """Two consumers pinned to start_version with the real guard (floor patched down)."""
+    guard_src = REAL_GUARD.read_text().replace("const MIN_ENGINE = '0.4.45'", f"const MIN_ENGINE = '{floor}'")
+    for consumer in CONSUMERS:
+        app = root / "apps" / consumer
+        (app / "scripts").mkdir(parents=True, exist_ok=True)
+        (app / "vendor").mkdir(parents=True, exist_ok=True)
+        (app / "package.json").write_text(json.dumps({
+            "name": consumer,
+            "dependencies": {"@socioprophet/hellgraph": f"file:vendor/socioprophet-hellgraph-{start_version}.tgz"},
+            "scripts": {"check:engine": "node scripts/check-engine-version.mjs"},
+        }, indent=2) + "\n")
+        (app / "scripts" / "check-engine-version.mjs").write_text(guard_src)
+        _engine_tarball(app / "vendor" / f"socioprophet-hellgraph-{start_version}.tgz", start_version, with_marker=False)
+    return root
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch):
+    # The guard's best-effort "is a newer tag out?" call must not reach the network in tests.
+    monkeypatch.setenv("HELLGRAPH_ENGINE_REMOTE", "file:///nonexistent-engine-remote")
+
+
+def _plan(to="0.4.45", tarball=REAL_045, expect=(MARKER,)):
+    return eng.RevendorPlan(to_version=to, tarball=Path(tarball), expect_markers=list(expect), consumers=CONSUMERS)
+
+
+def test_full_revendor_040_to_045_passes_the_real_guard(tmp_path):
+    root = _fixture(tmp_path)
+    receipt = eng.execute(_plan(), root, apply=True)
+    assert receipt["status"] == "applied", json.dumps(receipt, indent=2)
+    steps = {s["step"]: s for s in receipt["steps"]}
+    # every discipline step present and green, including the consumers' own guard
+    assert set(steps) >= {"assert_marker", "precheck", "place_tarball", "bump_floor", "verify_guard"}
+    assert all(s["ok"] for s in receipt["steps"])
+    for consumer in CONSUMERS:
+        app = root / "apps" / consumer
+        assert (app / "vendor" / "socioprophet-hellgraph-0.4.45.tgz").exists()
+        assert not (app / "vendor" / "socioprophet-hellgraph-0.4.40.tgz").exists()
+        pkg = json.loads((app / "package.json").read_text())
+        assert pkg["dependencies"]["@socioprophet/hellgraph"] == "file:vendor/socioprophet-hellgraph-0.4.45.tgz"
+        assert "const MIN_ENGINE = '0.4.45'" in (app / "scripts" / "check-engine-version.mjs").read_text()
+        assert steps["verify_guard"]["evidence"]["consumers"][consumer]["exit"] == 0
+
+
+def test_idempotent_second_run_is_a_noop(tmp_path):
+    root = _fixture(tmp_path)
+    assert eng.execute(_plan(), root, apply=True)["status"] == "applied"
+    again = eng.execute(_plan(), root, apply=True)
+    assert again["status"] == "noop"
+    # a no-op re-vendor recorded no mutating step
+    assert [s["step"] for s in again["steps"]] == ["assert_marker"]
+
+
+def test_fail_closed_on_unproven_marker_mutates_nothing(tmp_path):
+    root = _fixture(tmp_path)
+    before = {c: sorted(p.name for p in (root / "apps" / c / "vendor").iterdir()) for c in CONSUMERS}
+    # a 0.4.46 tarball whose dist lacks the marker — claims a version it cannot prove
+    bad = _engine_tarball(tmp_path / "bad-0.4.46.tgz", "0.4.46", with_marker=False)
+    receipt = eng.execute(_plan(to="0.4.46", tarball=bad), root, apply=True)
+    assert receipt["status"] == "failed"
+    assert receipt["steps"][0]["step"] == "assert_marker" and receipt["steps"][0]["ok"] is False
+    after = {c: sorted(p.name for p in (root / "apps" / c / "vendor").iterdir()) for c in CONSUMERS}
+    assert after == before, "a failed marker proof must not have touched any vendor dir"
+
+
+def test_refuses_to_lower_a_floor_before_any_mutation(tmp_path):
+    root = _fixture(tmp_path, floor="0.4.45")  # floor already ahead of the target
+    good_044 = _engine_tarball(tmp_path / "e-0.4.44.tgz", "0.4.44", with_marker=True)
+    before = {c: (root / "apps" / c / "package.json").read_text() for c in CONSUMERS}
+    receipt = eng.execute(_plan(to="0.4.44", tarball=good_044), root, apply=True)
+    assert receipt["status"] == "failed"
+    failed = [s for s in receipt["steps"] if not s["ok"]][0]
+    assert failed["step"] == "precheck" and "lower a floor" in failed["evidence"]["reason"]
+    assert not any(s["step"] in ("place_tarball", "bump_floor") for s in receipt["steps"])
+    after = {c: (root / "apps" / c / "package.json").read_text() for c in CONSUMERS}
+    assert after == before, "the floor guard must fire before any package.json is rewritten"
+
+
+def test_dry_run_touches_nothing_but_plans(tmp_path):
+    root = _fixture(tmp_path)
+    snapshot = {c: sorted(p.name for p in (root / "apps" / c / "vendor").iterdir()) for c in CONSUMERS}
+    receipt = eng.execute(_plan(), root, apply=False)
+    assert receipt["status"] == "planned"
+    assert {c: sorted(p.name for p in (root / "apps" / c / "vendor").iterdir()) for c in CONSUMERS} == snapshot
+
+
+def test_receipt_seal_is_tamper_evident(tmp_path):
+    receipt = eng.execute(_plan(), _fixture(tmp_path), apply=True)
+    sealed = receipt["receipt_digest"]
+    receipt["steps"][0]["ok"] = "tampered"
+    assert eng._seal(dict(receipt))["receipt_digest"] != sealed
+
+
+def test_from_effect_request_maps_the_contract(tmp_path):
+    tgz = _engine_tarball(tmp_path / "e.tgz", "0.4.46", with_marker=True)
+    doc = {
+        "type": "EffectRequest", "capability": "vendor.revendor",
+        "requestedByEventRef": "evt-123",
+        "parameters": {"toVersion": "0.4.46", "tarball": str(tgz), "versionMarker": MARKER},
+    }
+    plan = eng.RevendorPlan.from_effect_request(doc)
+    assert plan.to_version == "0.4.46" and plan.expect_markers == [MARKER]
+    assert plan.idempotency_key == "engine@0.4.46" and plan.requested_by_event_ref == "evt-123"
+
+
+def test_wrong_capability_is_rejected():
+    with pytest.raises(ValueError, match="vendor.revendor"):
+        eng.RevendorPlan.from_effect_request({"capability": "something.else", "parameters": {}})

--- a/tools/test_revendor_engine.py
+++ b/tools/test_revendor_engine.py
@@ -221,3 +221,93 @@ def test_open_pr_failure_still_prints_a_sealed_receipt_and_exits_nonzero(
     assert open_pr_step["evidence"]["returncode"] == 1
     # And the receipt was re-sealed after the failure was recorded.
     assert receipt["receipt_digest"].startswith("sha256:")
+# ── open_pr stages the new tarball; a post-mutation failure rolls back ────────────────
+
+def _git(root: Path, *args: str):
+    return subprocess.run(["git", "-C", str(root), *args], capture_output=True, text=True)
+
+
+def _snapshot_tree(root: Path) -> dict:
+    """Byte-level snapshot of everything the re-vendor can touch, for an exact-equality
+    'nothing changed' assertion."""
+    out: dict[str, object] = {}
+    for consumer in CONSUMERS:
+        app = root / "apps" / consumer
+        out[str(app / "package.json")] = (app / "package.json").read_bytes()
+        out[str(app / "scripts" / "check-engine-version.mjs")] = \
+            (app / "scripts" / "check-engine-version.mjs").read_bytes()
+        vd = app / "vendor"
+        out[str(vd) + ":listing"] = sorted(f.name for f in vd.iterdir())
+        for f in vd.iterdir():
+            if f.is_file():
+                out[str(f)] = f.read_bytes()
+    return out
+
+
+def test_open_pr_commit_contains_the_new_tarball(tmp_path, monkeypatch):
+    """Copilot #1062: `git commit -a` does NOT stage the freshly-copied (untracked) tgz, so
+    the opened PR deleted the old tarball and bumped package.json but never carried the new
+    bytes it points at. Inspect the COMMIT (not the working tree) — the tool checks the file
+    on disk, so only the commit itself proves the artifact ships."""
+    root = _fixture(tmp_path)
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "t")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "seed")
+
+    plan = _plan()
+    receipt = eng.execute(plan, root, apply=True)
+    assert receipt["status"] == "applied"
+
+    real_run = subprocess.run
+
+    def fake_run(cmd, *a, **k):
+        # Run local git for real (switch/add/commit); stub the remote-facing calls so the
+        # test needs no network, no origin remote and no gh auth.
+        if isinstance(cmd, list) and cmd:
+            if cmd[0] == "gh":
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            if "ls-remote" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, "", "")   # branch does not exist remotely
+            if "push" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+        return real_run(cmd, *a, **k)
+    monkeypatch.setattr(eng.subprocess, "run", fake_run)
+
+    result = eng.open_pr(plan, receipt, root)
+    assert result["opened"] is True
+
+    committed = real_run(["git", "-C", str(root), "show", "--name-only", "--format=", "HEAD"],
+                         capture_output=True, text=True).stdout.split()
+    for consumer in CONSUMERS:
+        newtgz = f"apps/{consumer}/vendor/socioprophet-hellgraph-0.4.45.tgz"
+        assert newtgz in committed, f"new tarball missing from the commit for {consumer}: {committed}"
+        # It is a real, non-empty blob in the committed tree, not just a deletion of the old one.
+        size = real_run(["git", "-C", str(root), "cat-file", "-s", f"HEAD:{newtgz}"],
+                        capture_output=True, text=True)
+        assert size.returncode == 0 and int(size.stdout.strip()) > 0, f"empty/absent tgz blob for {consumer}"
+
+
+def test_a_failed_verify_guard_rolls_back_all_mutations(tmp_path, monkeypatch):
+    """Copilot #1062: verify_guard runs AFTER place_tarball/bump_floor mutate, so its failure
+    must undo them — otherwise the receipt says 'failed' while the tree is left half-applied
+    (new tarball copied, old one deleted, package.json + guard bumped). Force the guard to
+    reject and assert the tree is byte-identical to before the run."""
+    root = _fixture(tmp_path)
+    before = _snapshot_tree(root)
+
+    def boom(plan, root):
+        raise eng.RevendorAbort("verify_guard", "forced guard rejection")
+    monkeypatch.setattr(eng, "step_verify_guard", boom)
+
+    receipt = eng.execute(_plan(), root, apply=True)
+    assert receipt["status"] == "failed"
+    assert receipt["steps"][-1]["step"] == "verify_guard"
+    assert receipt["steps"][-1]["evidence"].get("rolled_back") is True
+
+    assert _snapshot_tree(root) == before, "a post-mutation failure left the tree half-applied"
+    for consumer in CONSUMERS:
+        vd = root / "apps" / consumer / "vendor"
+        assert not (vd / "socioprophet-hellgraph-0.4.45.tgz").exists(), "new tarball not removed on rollback"
+        assert (vd / "socioprophet-hellgraph-0.4.40.tgz").exists(), "old tarball not restored on rollback"

--- a/tools/test_revendor_engine.py
+++ b/tools/test_revendor_engine.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import subprocess
 import sys
 import tarfile
 from pathlib import Path
@@ -162,3 +163,61 @@ def test_from_effect_request_maps_the_contract(tmp_path):
 def test_wrong_capability_is_rejected():
     with pytest.raises(ValueError, match="vendor.revendor"):
         eng.RevendorPlan.from_effect_request({"capability": "something.else", "parameters": {}})
+
+
+# ── Copilot #1062 round 2: fail-closed AND receipt-producing ──────────────────
+
+def test_corrupt_tarball_yields_a_sealed_failed_receipt_not_a_raise(tmp_path):
+    """A tarball that is not a readable gzip trips marker_tool into raising
+    SystemExit. Pre-fix, step_assert_marker let it escape past execute()'s
+    `except RevendorAbort` and the run tore down WITHOUT a sealed receipt —
+    the exact opposite of the fail-closed-AND-receipt-producing contract.
+    Post-fix, execute() returns a sealed failed receipt naming assert_marker."""
+    root = _fixture(tmp_path)
+    corrupt = tmp_path / "corrupt-0.4.99.tgz"
+    corrupt.write_bytes(b"this is not a gzip stream")  # tarfile.open will raise
+    receipt = eng.execute(_plan(to="0.4.99", tarball=corrupt), root, apply=True)
+    # The whole point: NO exception escaped execute(); we got a receipt.
+    assert receipt["status"] == "failed"
+    failed = receipt["steps"][0]
+    assert failed["step"] == "assert_marker" and failed["ok"] is False
+    # The reader's own error text rides through as evidence — an operator sees
+    # what specifically was wrong with the artifact, not just "it failed".
+    assert "packed dist" in failed["evidence"]["reason"] \
+        or "readable gzip" in failed["evidence"]["reason"]
+    # And the receipt is sealed, so tamper detection still works.
+    assert receipt["receipt_digest"].startswith("sha256:")
+
+
+def test_open_pr_failure_still_prints_a_sealed_receipt_and_exits_nonzero(
+        tmp_path, monkeypatch, capsys):
+    """If --open-pr is used and open_pr() raises (any of RevendorAbort,
+    subprocess.CalledProcessError, OSError), main() must still print the
+    receipt as JSON on stdout — the receipt is the deliverable, and automation
+    downstream parses stdout to learn the final status. Pre-fix, the exception
+    propagated past the print() call and stdout was empty."""
+    root = _fixture(tmp_path)
+    # Stub open_pr so we do not actually run git/gh in this test.
+    def boom(plan, receipt, root):
+        raise subprocess.CalledProcessError(1, ["git", "push", "-u", "origin", "revendor/engine-0.4.45"])
+    monkeypatch.setattr(eng, "open_pr", boom)
+    rc = eng.main([
+        "--to-version", "0.4.45",
+        "--tarball", str(REAL_045),
+        "--expect", MARKER,
+        "--root", str(root),
+        "--open-pr",
+    ])
+    assert rc == 1, "an open_pr failure must exit non-zero"
+    out = capsys.readouterr().out
+    assert out.strip(), "stdout must carry the receipt even when open_pr failed"
+    receipt = json.loads(out)
+    assert receipt["status"] == "failed"
+    open_pr_step = [s for s in receipt["steps"] if s["step"] == "open_pr"][0]
+    assert open_pr_step["ok"] is False
+    # The subprocess argv rides through as evidence — an operator can see which
+    # git/gh call actually broke, not just "open_pr failed".
+    assert "git" in open_pr_step["evidence"]["argv"][0]
+    assert open_pr_step["evidence"]["returncode"] == 1
+    # And the receipt was re-sealed after the failure was recorded.
+    assert receipt["receipt_digest"].startswith("sha256:")


### PR DESCRIPTION
The consumer-side **re-vendor executor** of the vendor-freshness plane — the half sociosphere #496 leaves to prophet-platform. #496's detector emits an `EffectRequest` and the membrane approves it; **this acts on the approval**, treating every step of the re-vendor discipline as a claim it must *prove*. The deliverable is a PR whose body **is** the receipt.

## Two tools, one capability
- `tools/assert_vendored_engine_marker.py` — the load-bearing proof: a `version` field is not evidence; the discriminating marker **inside the packed dist** is. Bounded/typed reads, decompression-bomb & symlink guards, string-containment (never grep — searcher-dependent binary heuristics make grep a non-answer here).
- `tools/revendor_engine.py` — the executor. **Fail-closed** (all read-only proofs run in a precheck before the first mutation), **atomic across consumers** (hellgraph-service + lifecycle-warden move together — warden once drifted 5 releases behind when one moved and the other didn't), **idempotent** on `to_version` (a re-emitted finding never opens a 2nd PR), and **verified by the consumers' own `check-engine-version.mjs`** — the executor does not grade its own work. Builds its plan from an approved `vendor.revendor` EffectRequest (schema 0.1.0) or from args.

## Proven, not asserted
- A real **0.4.40 → 0.4.45** re-vendor on a temp copy passes the real guard.
- Bad marker and floor-lowering both **abort before touching a file**.
- The receipt seal is **tamper-evident**; a **live dry-run against this repo** (already at 0.4.45) reports a sealed **no-op**.
- **25 tests** green (17 marker + 8 executor).

## The arc
#496 (detect + EffectRequest + register) → membrane approves (EffectDecision) → **this executor** (assert marker → place tarball → raise floor → verify guard → sealed receipt → idempotent PR). `--open-pr` wiring and the pull-from-zot fetch land as the contract and registry seams settle; the disciplined core is complete and self-verifying now.