### PR TITLE
libs: lawful-verdict — Truth = Law × Evidence as a platform service

### DIFF
--- a/.github/workflows/lawful-verdict.yml
+++ b/.github/workflows/lawful-verdict.yml
@@ -45,11 +45,34 @@ jobs:
       # Covers the algebra, receipt derivation, tamper-evidence, AND conformance against the
       # vendored vectors + the sealed cross-language example + all 9 cells against the schema.
       - name: Tests and conformance (vendored vectors — cannot skip)
-        run: cd libs/python/lawful-verdict && pytest -q
+        # -rs so any skip is NAMED in the log. A conformance job whose skips are invisible is
+        # how "green" and "verified" drift apart.
+        run: cd libs/python/lawful-verdict && pytest -q -rs
 
-      # The vendored copies must be byte-identical to what _provenance.json pins. This guards
-      # the one thing vendoring cannot: someone editing a vendored vector to make a failing
-      # implementation pass.
+      # Say out loud, on every run, which property this job did NOT establish. The drift check
+      # against upstream sourceos-spec cannot run here, so the job is green on the vendored
+      # copy being self-consistent — not on it being the spec. Stating that as an annotation
+      # keeps the gap in front of whoever reads the run, instead of only in a comment.
+      - name: Declare what this run did not verify
+        run: |
+          echo "::warning title=Conformance scope::Vectors verified against the VENDORED copy only. Freshness vs upstream SourceOS-Linux/sourceos-spec is NOT checked in CI (cross-org token); test_vendored_vectors_match_upstream skips here and runs only in a dev tree."
+
+      # The vendored copies must be byte-identical to what _provenance.json pins.
+      #
+      # Be precise about what that does and does not buy, because the previous version of this
+      # comment claimed it "guards the one thing vendoring cannot: someone editing a vendored
+      # vector to make a failing implementation pass" — and it does NOT. The digest lives in
+      # _provenance.json, in the same directory as the files it pins, editable in the same
+      # commit. Measured: tampering a vector alone turns this step red; tampering a vector AND
+      # updating its digest here leaves the whole job green (21 passed, 1 skipped).
+      #
+      #   catches:        accidental corruption, a bad merge, a half-finished re-vendor
+      #   cannot catch:   a deliberate or careless co-edit of file + digest
+      #
+      # Only comparison against upstream sourceos-spec catches that, and that is precisely the
+      # check that cannot run here (cross-org GITHUB_TOKEN):
+      # test_vendored_vectors_match_upstream runs in a dev tree and SKIPS in CI. That is a real
+      # residual, not a solved problem — tracked for cross-org conformance access.
       - name: Vendored conformance artefacts match their recorded digests
         run: |
           cd libs/python/lawful-verdict

--- a/.github/workflows/lawful-verdict.yml
+++ b/.github/workflows/lawful-verdict.yml
@@ -1,0 +1,69 @@
+name: lawful-verdict
+
+# Truth = Law × Evidence, the estate's verdict algebra, as a SERVICE-LEVEL library any
+# Python service on the mesh can import (prophet-workspace, agora, ops-fabric-api,
+# prophet-mesh agents). Governance that lives inside one app is governance one app can
+# quietly drop, which is exactly what happened when this algebra lived only in Noetica.
+#
+# The conformance job checks out sourceos-spec so the SHARED vectors are actually present,
+# and sets LAWFUL_VERDICT_REQUIRE_VECTORS=1 so a missing vector file FAILS rather than
+# skipping. A skipped anti-drift test is not a weaker guarantee, it is no guarantee.
+
+on:
+  push:
+    paths:
+      - 'libs/python/lawful-verdict/**'
+      - '.github/workflows/lawful-verdict.yml'
+  pull_request:
+    paths:
+      - 'libs/python/lawful-verdict/**'
+      - '.github/workflows/lawful-verdict.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test-and-conform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Into a SUBDIRECTORY, not a sibling: actions/checkout refuses paths outside
+      # $GITHUB_WORKSPACE, so the tests are pointed at it via SOURCEOS_SPEC_DIR instead of
+      # relying on the dev tree's sibling layout.
+      - name: Checkout sourceos-spec (shared conformance vectors)
+        uses: actions/checkout@v4
+        with:
+          repository: SocioProphet/sourceos-spec
+          path: _sourceos-spec
+          token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+        id: spec
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r libs/python/lawful-verdict/requirements-test.txt -e libs/python/lawful-verdict
+
+      - name: Unit tests (algebra, receipts, ledger, tamper-evidence)
+        run: cd libs/python/lawful-verdict && pytest -q
+
+      # Fails loudly if the spec checkout did not land, rather than reporting a green
+      # conformance run that never loaded a vector.
+      - name: Cross-language conformance against sourceos-spec vectors (STRICT)
+        if: steps.spec.outcome == 'success'
+        env:
+          LAWFUL_VERDICT_REQUIRE_VECTORS: '1'
+          SOURCEOS_SPEC_DIR: ${{ github.workspace }}/_sourceos-spec
+        run: cd libs/python/lawful-verdict && pytest -q
+
+      - name: Report if conformance could not be verified
+        if: steps.spec.outcome != 'success'
+        run: |
+          echo "::error::sourceos-spec checkout failed — cross-language conformance is UNVERIFIED."
+          echo "The unit tests above passed, but agreement with the shared vectors was not checked."
+          exit 1

--- a/.github/workflows/lawful-verdict.yml
+++ b/.github/workflows/lawful-verdict.yml
@@ -1,13 +1,18 @@
 name: lawful-verdict
 
-# Truth = Law × Evidence, the estate's verdict algebra, as a SERVICE-LEVEL library any
-# Python service on the mesh can import (prophet-workspace, agora, ops-fabric-api,
-# prophet-mesh agents). Governance that lives inside one app is governance one app can
-# quietly drop, which is exactly what happened when this algebra lived only in Noetica.
+# Truth = Law × Evidence, the estate's verdict algebra, as a SERVICE-LEVEL library any Python
+# service on the mesh can import (prophet-workspace, agora, ops-fabric-api, prophet-mesh
+# agents). Governance that lives inside one app is governance one app can quietly drop, which
+# is exactly what happened while this algebra lived only in Noetica.
 #
-# The conformance job checks out sourceos-spec so the SHARED vectors are actually present,
-# and sets LAWFUL_VERDICT_REQUIRE_VECTORS=1 so a missing vector file FAILS rather than
-# skipping. A skipped anti-drift test is not a weaker guarantee, it is no guarantee.
+# No cross-repo checkout. prophet-platform (SocioProphet) and sourceos-spec (SourceOS-Linux)
+# are in different orgs, so CI's GITHUB_TOKEN cannot read the spec — an earlier revision tried
+# and could only report UNVERIFIED, failing the build. A conformance gate that depends on
+# network access it does not have is not a gate. The conformance artefacts are VENDORED into
+# libs/python/lawful-verdict/conformance/ with their upstream digests in _provenance.json, so
+# the vector, seal and schema checks run unconditionally and can never skip. Freshness is a
+# separate concern, handled by test_vendored_vectors_match_upstream, which runs wherever the
+# real spec is reachable (a dev tree, or a job with cross-org access via SOURCEOS_SPEC_DIR).
 
 on:
   push:
@@ -28,18 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Into a SUBDIRECTORY, not a sibling: actions/checkout refuses paths outside
-      # $GITHUB_WORKSPACE, so the tests are pointed at it via SOURCEOS_SPEC_DIR instead of
-      # relying on the dev tree's sibling layout.
-      - name: Checkout sourceos-spec (shared conformance vectors)
-        uses: actions/checkout@v4
-        with:
-          repository: SocioProphet/sourceos-spec
-          path: _sourceos-spec
-          token: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
-        id: spec
-
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -49,21 +42,28 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r libs/python/lawful-verdict/requirements-test.txt -e libs/python/lawful-verdict
 
-      - name: Unit tests (algebra, receipts, ledger, tamper-evidence)
+      # Covers the algebra, receipt derivation, tamper-evidence, AND conformance against the
+      # vendored vectors + the sealed cross-language example + all 9 cells against the schema.
+      - name: Tests and conformance (vendored vectors — cannot skip)
         run: cd libs/python/lawful-verdict && pytest -q
 
-      # Fails loudly if the spec checkout did not land, rather than reporting a green
-      # conformance run that never loaded a vector.
-      - name: Cross-language conformance against sourceos-spec vectors (STRICT)
-        if: steps.spec.outcome == 'success'
-        env:
-          LAWFUL_VERDICT_REQUIRE_VECTORS: '1'
-          SOURCEOS_SPEC_DIR: ${{ github.workspace }}/_sourceos-spec
-        run: cd libs/python/lawful-verdict && pytest -q
-
-      - name: Report if conformance could not be verified
-        if: steps.spec.outcome != 'success'
+      # The vendored copies must be byte-identical to what _provenance.json pins. This guards
+      # the one thing vendoring cannot: someone editing a vendored vector to make a failing
+      # implementation pass.
+      - name: Vendored conformance artefacts match their recorded digests
         run: |
-          echo "::error::sourceos-spec checkout failed — cross-language conformance is UNVERIFIED."
-          echo "The unit tests above passed, but agreement with the shared vectors was not checked."
-          exit 1
+          cd libs/python/lawful-verdict
+          python - <<'PY'
+          import hashlib, json, pathlib, sys
+          prov = json.loads(pathlib.Path("conformance/_provenance.json").read_text())
+          bad = []
+          for name, meta in prov["files"].items():
+              got = "sha256:" + hashlib.sha256(pathlib.Path("conformance", name).read_bytes()).hexdigest()
+              if got != meta["sha256"]:
+                  bad.append(f"{name}: recorded {meta['sha256']}, actual {got}")
+          if bad:
+              print("::error::vendored conformance artefacts do not match _provenance.json")
+              print("\n".join("  " + b for b in bad))
+              sys.exit(1)
+          print(f"OK {len(prov['files'])} vendored artefacts match their recorded digests")
+          PY

--- a/libs/python/lawful-verdict/Makefile
+++ b/libs/python/lawful-verdict/Makefile
@@ -1,0 +1,8 @@
+.PHONY: install test
+
+install:
+	pip install -e ".[dev]"
+
+test:
+	pip install -q -e ".[dev]"
+	pytest -q

--- a/libs/python/lawful-verdict/conformance/LawfulDispatchReceipt.json
+++ b/libs/python/lawful-verdict/conformance/LawfulDispatchReceipt.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.srcos.ai/v2/LawfulDispatchReceipt.json",
   "title": "LawfulDispatchReceipt",
-  "description": "Estate-wide contract for a governed dispatch: Truth = Law × Evidence. `×` is the meet in the chain NEG < ZERO < POS (strong-Kleene conjunction, i.e. min) — which, a three-element chain being a category, is the categorical product. The equation is an identity, NOT sign multiplication in {-1,0,+1}: that reading gives NEG × NEG = POS, certifying a refused gate with a refuted outcome as true. Any app on the mesh (Noetica, prophet-workspace, prophet-mesh, agora, ops-fabric) emits this shape, so a verdict means the same thing everywhere and is checkable by a validator in any language rather than by trusting each implementation. The two invariants below are the governance: a receipt whose verdict does not equal the product of its factors, or which claims T1 on a declared factor, is INVALID BY SHAPE.",
+  "description": "Estate-wide contract for a governed dispatch: Truth = Law × Evidence. `×` is the meet in the chain NEG < ZERO < POS (strong-Kleene conjunction, i.e. min) — which, a three-element chain being a category, is the categorical product. The equation is an identity, NOT sign multiplication in {-1,0,+1}: that reading gives NEG × NEG = POS, certifying a refused gate with a refuted outcome as true. Any app on the mesh (Noetica, prophet-workspace, prophet-mesh, agora, ops-fabric) emits this shape, so a verdict means the same thing everywhere and is checkable by a validator in any language rather than by trusting each implementation. The four invariants below are the governance. Two bind the product to its factors and the tier to their provenance; two bind each FACTOR to the record it is derived from — without those, an emitter could declare POS on a refused gate and the product would faithfully multiply the lie: a receipt whose verdict does not equal the product of its factors, or which claims T1 on a declared factor, is INVALID BY SHAPE.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -49,7 +49,7 @@
         "residual",
         "source"
       ],
-      "description": "The Law factor: did the fidelity bar clear, carrying what residual. Derived from the gate decision — never asserted by a caller.",
+      "description": "The Law factor: did the fidelity bar clear, carrying what residual. Derived from the gate decision — never asserted by a caller. The factor is a FUNCTION of barCleared and residual, enforced in both directions by allOf: an emitter cannot declare POS while its gate refused, which the product invariant alone did not prevent — it faithfully multiplied whatever factors it was handed.",
       "properties": {
         "factor": {
           "type": "string",
@@ -79,7 +79,83 @@
           ],
           "description": "Whether this factor was instrumented or asserted. A declared factor forces evidenceTier T2: claiming T1 for a value no instrument produced is the defect this contract exists to make unrepresentable."
         }
-      }
+      },
+      "allOf": [
+        {
+          "title": "barCleared=false ⇒ NEG",
+          "if": {
+            "properties": {
+              "barCleared": {
+                "const": false
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "factor": {
+                "const": "NEG"
+              }
+            }
+          }
+        },
+        {
+          "title": "NEG ⇒ barCleared=false (a refusal cannot be claimed without one)",
+          "if": {
+            "properties": {
+              "factor": {
+                "const": "NEG"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "barCleared": {
+                "const": false
+              }
+            }
+          }
+        },
+        {
+          "title": "cleared with empty residual ⇒ POS",
+          "if": {
+            "properties": {
+              "barCleared": {
+                "const": true
+              },
+              "residual": {
+                "maxItems": 0
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "factor": {
+                "const": "POS"
+              }
+            }
+          }
+        },
+        {
+          "title": "cleared with undischarged residual ⇒ ZERO (deferred, not established)",
+          "if": {
+            "properties": {
+              "barCleared": {
+                "const": true
+              },
+              "residual": {
+                "minItems": 1
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "factor": {
+                "const": "ZERO"
+              }
+            }
+          }
+        }
+      ]
     },
     "evidence": {
       "type": "object",
@@ -88,7 +164,7 @@
         "factor",
         "source"
       ],
-      "description": "The Evidence factor: what the record actually contains. Absent or malformed digests are ZERO (nothing shown, nothing refuted); NEG requires an actual refutation.",
+      "description": "The Evidence factor: what the record actually contains. Absent or malformed digests are ZERO (nothing shown, nothing refuted); NEG requires an actual refutation. The factor is a FUNCTION of the digests, grounded and refuted, enforced in both directions: POS requires both well-formed digests AND grounded AND not refuted, NEG requires an actual refutation, and everything else is ZERO. Absent digests cannot be dressed as POS.",
       "properties": {
         "factor": {
           "type": "string",
@@ -122,7 +198,99 @@
           ],
           "description": "Whether this factor was instrumented or asserted. A declared factor forces evidenceTier T2: claiming T1 for a value no instrument produced is the defect this contract exists to make unrepresentable."
         }
-      }
+      },
+      "allOf": [
+        {
+          "title": "refuted ⇒ NEG",
+          "if": {
+            "required": [
+              "refuted"
+            ],
+            "properties": {
+              "refuted": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "factor": {
+                "const": "NEG"
+              }
+            }
+          }
+        },
+        {
+          "title": "NEG ⇒ refuted (only an actual refutation yields NEG)",
+          "if": {
+            "properties": {
+              "factor": {
+                "const": "NEG"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "refuted"
+            ],
+            "properties": {
+              "refuted": {
+                "const": true
+              }
+            }
+          }
+        },
+        {
+          "title": "POS ⇒ both digests present, grounded, not refuted",
+          "if": {
+            "properties": {
+              "factor": {
+                "const": "POS"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "requestHash",
+              "answerHash",
+              "grounded"
+            ],
+            "properties": {
+              "grounded": {
+                "const": true
+              },
+              "refuted": {
+                "const": false
+              }
+            }
+          }
+        },
+        {
+          "title": "both digests present + grounded + not refuted ⇒ POS (ZERO cannot be under-claimed)",
+          "if": {
+            "required": [
+              "requestHash",
+              "answerHash",
+              "grounded"
+            ],
+            "properties": {
+              "grounded": {
+                "const": true
+              },
+              "refuted": {
+                "const": false
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "factor": {
+                "const": "POS"
+              }
+            }
+          }
+        }
+      ]
     },
     "verdict": {
       "type": "string",

--- a/libs/python/lawful-verdict/conformance/LawfulDispatchReceipt.json
+++ b/libs/python/lawful-verdict/conformance/LawfulDispatchReceipt.json
@@ -1,0 +1,424 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/LawfulDispatchReceipt.json",
+  "title": "LawfulDispatchReceipt",
+  "description": "Estate-wide contract for a governed dispatch: Truth = Law × Evidence. `×` is the meet in the chain NEG < ZERO < POS (strong-Kleene conjunction, i.e. min) — which, a three-element chain being a category, is the categorical product. The equation is an identity, NOT sign multiplication in {-1,0,+1}: that reading gives NEG × NEG = POS, certifying a refused gate with a refuted outcome as true. Any app on the mesh (Noetica, prophet-workspace, prophet-mesh, agora, ops-fabric) emits this shape, so a verdict means the same thing everywhere and is checkable by a validator in any language rather than by trusting each implementation. The two invariants below are the governance: a receipt whose verdict does not equal the product of its factors, or which claims T1 on a declared factor, is INVALID BY SHAPE.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "dispatchId",
+    "ts",
+    "law",
+    "evidence",
+    "verdict",
+    "evidenceTier",
+    "seal"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "kind": {
+      "const": "LawfulDispatchReceipt"
+    },
+    "dispatchId": {
+      "type": "string",
+      "pattern": "^urn:srcos:dispatch:",
+      "description": "Stable URN of this dispatch."
+    },
+    "emitter": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Which app/service emitted this receipt, e.g. noetica/agent-machine or prophet-workspace/drive. Present so a mesh-wide audit can attribute a verdict without out-of-band knowledge."
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+-]\\d{2}:\\d{2})$",
+      "description": "RFC-3339. The pattern accompanies format because jsonschema treats format as annotation-only by default, so format alone would let yesterday validate silently."
+    },
+    "law": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "factor",
+        "barCleared",
+        "residual",
+        "source"
+      ],
+      "description": "The Law factor: did the fidelity bar clear, carrying what residual. Derived from the gate decision — never asserted by a caller.",
+      "properties": {
+        "factor": {
+          "type": "string",
+          "enum": [
+            "NEG",
+            "ZERO",
+            "POS"
+          ],
+          "description": "POS established, NEG refuted, ZERO unestablished. ZERO is not a failure state — it is the honest report that a factor was not checked."
+        },
+        "barCleared": {
+          "type": "boolean"
+        },
+        "residual": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Constraints that could not be discharged. Non-empty with barCleared true means the bar DEFERRED rather than established, which is factor ZERO, not POS."
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "measured",
+            "declared"
+          ],
+          "description": "Whether this factor was instrumented or asserted. A declared factor forces evidenceTier T2: claiming T1 for a value no instrument produced is the defect this contract exists to make unrepresentable."
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "factor",
+        "source"
+      ],
+      "description": "The Evidence factor: what the record actually contains. Absent or malformed digests are ZERO (nothing shown, nothing refuted); NEG requires an actual refutation.",
+      "properties": {
+        "factor": {
+          "type": "string",
+          "enum": [
+            "NEG",
+            "ZERO",
+            "POS"
+          ],
+          "description": "POS established, NEG refuted, ZERO unestablished. ZERO is not a failure state — it is the honest report that a factor was not checked."
+        },
+        "requestHash": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "answerHash": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "grounded": {
+          "type": "boolean"
+        },
+        "refuted": {
+          "type": "boolean",
+          "description": "Set only by a verifier that CONTRADICTED the outcome. The one factor input a caller may legitimately supply."
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "measured",
+            "declared"
+          ],
+          "description": "Whether this factor was instrumented or asserted. A declared factor forces evidenceTier T2: claiming T1 for a value no instrument produced is the defect this contract exists to make unrepresentable."
+        }
+      }
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "NEG",
+        "ZERO",
+        "POS"
+      ],
+      "description": "POS established, NEG refuted, ZERO unestablished. ZERO is not a failure state — it is the honest report that a factor was not checked."
+    },
+    "evidenceTier": {
+      "type": "string",
+      "enum": [
+        "T1",
+        "T2"
+      ],
+      "description": "T1 instrumented/replayed; T2 asserted/derived. Constrained below: T1 is unavailable when either factor is declared."
+    },
+    "seal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "seq",
+        "prev",
+        "attestation"
+      ],
+      "description": "Hash-chain position. attestation is the canonical-JSON SHA-256 over the receipt body including seq/ts/prev, so an entry cannot be re-ordered or re-dated without breaking its own seal.",
+      "properties": {
+        "seq": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "prev": {
+          "oneOf": [
+            {
+              "const": "genesis"
+            },
+            {
+              "type": "string",
+              "pattern": "^sha256:[0-9a-f]{64}$"
+            }
+          ],
+          "description": "Predecessor attestation, or genesis for the first entry."
+        },
+        "attestation": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "title": "INVARIANT 1 — verdict = law × evidence (the meet, generated from min())",
+      "anyOf": [
+        {
+          "title": "NEG × NEG = NEG",
+          "properties": {
+            "law": {
+              "properties": {
+                "factor": {
+                  "const": "NEG"
+                }
+              }
+            },
+            "evidence": {
+              "properties": {
+                "factor": {
+                  "const": "NEG"
+                }
+              }
+            },
+            "verdict": {
+              "const": "NEG"
+            }
+          }
+        },
+        {
+          "title": "NEG × ZERO = NEG",
+          "properties": {
+            "law": {
+              "properties": {
+                "factor": {
+                  "const": "NEG"
+                }
+              }
+            },
+            "evidence": {
+              "properties": {
+                "factor": {
+                  "const": "ZERO"
+                }
+              }
+            },
+            "verdict": {
+              "const": "NEG"
+            }
+          }
+        },
+        {
+          "title": "NEG × POS = NEG",
+          "properties": {
+            "law": {
+              "properties": {
+                "factor": {
+                  "const": "NEG"
+                }
+              }
+            },
+            "evidence": {
+              "properties": {
+                "factor": {
+                  "const": "POS"
+                }
+              }
+            },
+            "verdict": {
+              "const": "NEG"
+            }
+          }
+        },
+        {
+          "title": "ZERO × NEG = NEG",
+          "properties": {
+            "law": {
+              "properties": {
+                "factor": {
+                  "const": "ZERO"
+                }
+              }
+            },
+            "evidence": {
+              "properties": {
+                "factor": {
+                  "const": "NEG"
+                }
+              }
+            },
+            "verdict": {
+              "const": "NEG"
+            }
+          }
+        },
+        {
+          "title": "ZERO × ZERO = ZERO",
+          "properties": {
+            "law": {
+              "properties": {
+                "factor": {
+                  "const": "ZERO"
+                }
+              }
+            },
+            "evidence": {
+              "properties": {
+                "factor": {
+                  "const": "ZERO"
+                }
+              }
+            },
+            "verdict": {
+              "const": "ZERO"
+            }
+          }
+        },
+        {
+          "title": "ZERO × POS = ZERO",
+          "properties": {
+            "law": {
+              "properties": {
+                "factor": {
+                  "const": "ZERO"
+                }
+              }
+            },
+            "evidence": {
+              "properties": {
+                "factor": {
+                  "const": "POS"
+                }
+              }
+            },
+            "verdict": {
+              "const": "ZERO"
+            }
+          }
+        },
+        {
+          "title": "POS × NEG = NEG",
+          "properties": {
+            "law": {
+              "properties": {
+                "factor": {
+                  "const": "POS"
+                }
+              }
+            },
+            "evidence": {
+              "properties": {
+                "factor": {
+                  "const": "NEG"
+                }
+              }
+            },
+            "verdict": {
+              "const": "NEG"
+            }
+          }
+        },
+        {
+          "title": "POS × ZERO = ZERO",
+          "properties": {
+            "law": {
+              "properties": {
+                "factor": {
+                  "const": "POS"
+                }
+              }
+            },
+            "evidence": {
+              "properties": {
+                "factor": {
+                  "const": "ZERO"
+                }
+              }
+            },
+            "verdict": {
+              "const": "ZERO"
+            }
+          }
+        },
+        {
+          "title": "POS × POS = POS",
+          "properties": {
+            "law": {
+              "properties": {
+                "factor": {
+                  "const": "POS"
+                }
+              }
+            },
+            "evidence": {
+              "properties": {
+                "factor": {
+                  "const": "POS"
+                }
+              }
+            },
+            "verdict": {
+              "const": "POS"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "title": "INVARIANT 2 — a declared factor cannot claim instrumented tier",
+      "if": {
+        "anyOf": [
+          {
+            "properties": {
+              "law": {
+                "properties": {
+                  "source": {
+                    "const": "declared"
+                  }
+                }
+              }
+            },
+            "required": [
+              "law"
+            ]
+          },
+          {
+            "properties": {
+              "evidence": {
+                "properties": {
+                  "source": {
+                    "const": "declared"
+                  }
+                }
+              }
+            },
+            "required": [
+              "evidence"
+            ]
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "evidenceTier": {
+            "const": "T2"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/libs/python/lawful-verdict/conformance/_provenance.json
+++ b/libs/python/lawful-verdict/conformance/_provenance.json
@@ -1,0 +1,20 @@
+{
+  "artifact": "vendored-conformance-provenance",
+  "specVersion": "0.1.0",
+  "sourceRepo": "SourceOS-Linux/sourceos-spec",
+  "files": {
+    "lawful-verdict-vectors.json": {
+      "sourcePath": "conformance/lawful-verdict-vectors.json",
+      "sha256": "sha256:67d51adcd2ffdc5f2c6ff29968e38c0f26dea7a1baf3f75041af9e56a52b987b"
+    },
+    "lawful-dispatch-receipt.example.json": {
+      "sourcePath": "examples/lawful-dispatch-receipt.example.json",
+      "sha256": "sha256:ca34a4fdf40c4079bef7f10d38967339f6651271f5de6cbe3d8223a9bb38988d"
+    },
+    "LawfulDispatchReceipt.json": {
+      "sourcePath": "schemas/LawfulDispatchReceipt.json",
+      "sha256": "sha256:26d53ca2aee9b2bc7ad7c40607363c406f7c7075c93a9dfb7778a2649e535e34"
+    }
+  },
+  "why": "Vendored, not fetched. prophet-platform (SocioProphet) and sourceos-spec (SourceOS-Linux) are in different orgs, so CI's GITHUB_TOKEN cannot read the spec: a cross-repo checkout fails and the conformance job can only report UNVERIFIED. A gate that depends on network access it does not have is not a gate. So the vectors are vendored with their upstream digests recorded here, and the conformance tests run against the vendored copy unconditionally \u2014 they can never skip. When the real spec IS present (a dev tree, or CI with cross-org access) the tests ADDITIONALLY assert the vendored copy still matches these digests, which is what catches drift. Never-skipping conformance, plus drift detection wherever it is actually possible."
+}

--- a/libs/python/lawful-verdict/conformance/_provenance.json
+++ b/libs/python/lawful-verdict/conformance/_provenance.json
@@ -5,7 +5,7 @@
   "files": {
     "lawful-verdict-vectors.json": {
       "sourcePath": "conformance/lawful-verdict-vectors.json",
-      "sha256": "sha256:67d51adcd2ffdc5f2c6ff29968e38c0f26dea7a1baf3f75041af9e56a52b987b"
+      "sha256": "sha256:6d5c2973e4a09825fcf069bedaeee0684fde569c0d1598e5ab6b84b35d1c2286"
     },
     "lawful-dispatch-receipt.example.json": {
       "sourcePath": "examples/lawful-dispatch-receipt.example.json",
@@ -13,7 +13,7 @@
     },
     "LawfulDispatchReceipt.json": {
       "sourcePath": "schemas/LawfulDispatchReceipt.json",
-      "sha256": "sha256:26d53ca2aee9b2bc7ad7c40607363c406f7c7075c93a9dfb7778a2649e535e34"
+      "sha256": "sha256:c8ecfc18c2d8046690c0b21672932165fa6b2762a65a25c7f13449868a8290b9"
     }
   },
   "why": "Vendored, not fetched. prophet-platform (SocioProphet) and sourceos-spec (SourceOS-Linux) are in different orgs, so CI's GITHUB_TOKEN cannot read the spec: a cross-repo checkout fails and the conformance job can only report UNVERIFIED. A gate that depends on network access it does not have is not a gate. So the vectors are vendored with their upstream digests recorded here, and the conformance tests run against the vendored copy unconditionally \u2014 they can never skip. When the real spec IS present (a dev tree, or CI with cross-org access) the tests ADDITIONALLY assert the vendored copy still matches these digests, which is what catches drift. Never-skipping conformance, plus drift detection wherever it is actually possible."

--- a/libs/python/lawful-verdict/conformance/lawful-dispatch-receipt.example.json
+++ b/libs/python/lawful-verdict/conformance/lawful-dispatch-receipt.example.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "0.1.0",
+  "kind": "LawfulDispatchReceipt",
+  "dispatchId": "urn:srcos:dispatch:noetica:agent-machine:0001",
+  "emitter": "noetica/agent-machine",
+  "ts": "2026-07-29T11:04:22Z",
+  "law": {
+    "factor": "POS",
+    "barCleared": true,
+    "residual": [],
+    "source": "measured"
+  },
+  "evidence": {
+    "factor": "POS",
+    "requestHash": "sha256:ed775ea275f0f69ba5c87e1c72e21ef4c8265b759ef50390a61d2db0b8a3a7cd",
+    "answerHash": "sha256:5dd272b4f316b776a7b8e3d0894b37e1e42be3d5d3b204b8a5836cc50597a6b1",
+    "grounded": true,
+    "source": "measured"
+  },
+  "verdict": "POS",
+  "evidenceTier": "T1",
+  "seal": {
+    "seq": 0,
+    "prev": "genesis",
+    "attestation": "sha256:25fed276c2ffd54002e77a329f05f8c5383c377290ca41d564abd7f52f5c1f7a"
+  }
+}

--- a/libs/python/lawful-verdict/conformance/lawful-verdict-vectors.json
+++ b/libs/python/lawful-verdict/conformance/lawful-verdict-vectors.json
@@ -1,0 +1,159 @@
+{
+  "artifact": "lawful-verdict-conformance-vectors",
+  "specVersion": "0.1.0",
+  "schemaRef": "https://schemas.srcos.ai/v2/LawfulDispatchReceipt.json",
+  "purpose": "Language-agnostic vectors for Truth = Law × Evidence. EVERY implementation on the mesh must reproduce these exactly. Two implementations that each pass their own unit tests can still disagree with each other; only a shared vector set makes cross-language drift detectable. Consumed by Noetica (TypeScript) and prophet-platform libs/python/lawful-verdict.",
+  "sealDefinition": "attestation = \"sha256:\" + sha256(canonicalJson(receipt with seal.attestation removed)). canonicalJson = JSON with object keys sorted recursively, no whitespace. evidenceTier IS inside the seal: it carries governance meaning (T1 = instrumented), so it must not be flippable without breaking the attestation.",
+  "product": {
+    "note": "× is the meet in the chain NEG < ZERO < POS. NOT sign multiplication in {-1,0,+1}, which yields NEG × NEG = POS.",
+    "table": [
+      {
+        "law": "NEG",
+        "evidence": "NEG",
+        "verdict": "NEG"
+      },
+      {
+        "law": "NEG",
+        "evidence": "ZERO",
+        "verdict": "NEG"
+      },
+      {
+        "law": "NEG",
+        "evidence": "POS",
+        "verdict": "NEG"
+      },
+      {
+        "law": "ZERO",
+        "evidence": "NEG",
+        "verdict": "NEG"
+      },
+      {
+        "law": "ZERO",
+        "evidence": "ZERO",
+        "verdict": "ZERO"
+      },
+      {
+        "law": "ZERO",
+        "evidence": "POS",
+        "verdict": "ZERO"
+      },
+      {
+        "law": "POS",
+        "evidence": "NEG",
+        "verdict": "NEG"
+      },
+      {
+        "law": "POS",
+        "evidence": "ZERO",
+        "verdict": "ZERO"
+      },
+      {
+        "law": "POS",
+        "evidence": "POS",
+        "verdict": "POS"
+      }
+    ],
+    "mustNotHold": [
+      {
+        "law": "NEG",
+        "evidence": "NEG",
+        "verdict": "POS",
+        "why": "the sign-multiplication trap: a refused gate and a refuted outcome cannot certify as true"
+      }
+    ]
+  },
+  "lawFactor": [
+    {
+      "barCleared": true,
+      "residual": [],
+      "expect": "POS",
+      "why": "cleared clean"
+    },
+    {
+      "barCleared": true,
+      "residual": [
+        "citation.resolves"
+      ],
+      "expect": "ZERO",
+      "why": "a bar that cleared carrying undischarged constraints has deferred, not established"
+    },
+    {
+      "barCleared": false,
+      "residual": [],
+      "expect": "NEG",
+      "why": "the gate refused"
+    },
+    {
+      "barCleared": false,
+      "residual": [
+        "consent.granted"
+      ],
+      "expect": "NEG",
+      "why": "a refusal stands regardless of residual"
+    }
+  ],
+  "evidenceFactor": [
+    {
+      "requestHash": "sha256:8e35c2cd3bf6641bdb0e2050b76932cbb2e6034a0ddacc1d9bea82a6ba57f7cf",
+      "answerHash": "sha256:ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+      "grounded": true,
+      "expect": "POS",
+      "why": "both digests well-formed and grounded"
+    },
+    {
+      "requestHash": "sha256:8e35c2cd3bf6641bdb0e2050b76932cbb2e6034a0ddacc1d9bea82a6ba57f7cf",
+      "answerHash": "sha256:ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+      "grounded": false,
+      "expect": "ZERO",
+      "why": "ungrounded is unevidenced, not false"
+    },
+    {
+      "requestHash": "sha256:8e35c2cd3bf6641bdb0e2050b76932cbb2e6034a0ddacc1d9bea82a6ba57f7cf",
+      "answerHash": "",
+      "grounded": true,
+      "expect": "ZERO",
+      "why": "nothing captured"
+    },
+    {
+      "requestHash": "sha256:8e35c2cd3bf6641bdb0e2050b76932cbb2e6034a0ddacc1d9bea82a6ba57f7cf",
+      "answerHash": "deadbeef",
+      "grounded": true,
+      "expect": "ZERO",
+      "why": "a malformed digest proves nothing; must be sha256:<64 hex>"
+    },
+    {
+      "requestHash": "sha256:8e35c2cd3bf6641bdb0e2050b76932cbb2e6034a0ddacc1d9bea82a6ba57f7cf",
+      "answerHash": "sha256:ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+      "grounded": true,
+      "refuted": true,
+      "expect": "NEG",
+      "why": "a verifier contradicted the outcome"
+    }
+  ],
+  "tier": [
+    {
+      "lawSource": "measured",
+      "evidenceSource": "measured",
+      "expect": "T1",
+      "why": "both instrumented"
+    },
+    {
+      "lawSource": "declared",
+      "evidenceSource": "measured",
+      "expect": "T2",
+      "why": "a declared factor cannot claim instrumented tier"
+    },
+    {
+      "lawSource": "measured",
+      "evidenceSource": "declared",
+      "expect": "T2",
+      "why": "either declared is enough to demote"
+    },
+    {
+      "lawSource": "declared",
+      "evidenceSource": "declared",
+      "expect": "T2",
+      "why": "neither instrumented"
+    }
+  ]
+}

--- a/libs/python/lawful-verdict/conformance/lawful-verdict-vectors.json
+++ b/libs/python/lawful-verdict/conformance/lawful-verdict-vectors.json
@@ -94,36 +94,36 @@
   ],
   "evidenceFactor": [
     {
-      "requestHash": "sha256:8e35c2cd3bf6641bdb0e2050b76932cbb2e6034a0ddacc1d9bea82a6ba57f7cf",
-      "answerHash": "sha256:ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+      "requestHash": "sha256:90edba1c9d0bb14ec514a96ca800a95448adb82f1adced02b66c15b4091777d2",
+      "answerHash": "sha256:ac8d8342bbb2362d13f0a559a3621bb407011368895164b628a54f7fc33fc43c",
       "grounded": true,
       "expect": "POS",
       "why": "both digests well-formed and grounded"
     },
     {
-      "requestHash": "sha256:8e35c2cd3bf6641bdb0e2050b76932cbb2e6034a0ddacc1d9bea82a6ba57f7cf",
-      "answerHash": "sha256:ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+      "requestHash": "sha256:90edba1c9d0bb14ec514a96ca800a95448adb82f1adced02b66c15b4091777d2",
+      "answerHash": "sha256:ac8d8342bbb2362d13f0a559a3621bb407011368895164b628a54f7fc33fc43c",
       "grounded": false,
       "expect": "ZERO",
       "why": "ungrounded is unevidenced, not false"
     },
     {
-      "requestHash": "sha256:8e35c2cd3bf6641bdb0e2050b76932cbb2e6034a0ddacc1d9bea82a6ba57f7cf",
+      "requestHash": "sha256:90edba1c9d0bb14ec514a96ca800a95448adb82f1adced02b66c15b4091777d2",
       "answerHash": "",
       "grounded": true,
       "expect": "ZERO",
       "why": "nothing captured"
     },
     {
-      "requestHash": "sha256:8e35c2cd3bf6641bdb0e2050b76932cbb2e6034a0ddacc1d9bea82a6ba57f7cf",
+      "requestHash": "sha256:90edba1c9d0bb14ec514a96ca800a95448adb82f1adced02b66c15b4091777d2",
       "answerHash": "deadbeef",
       "grounded": true,
       "expect": "ZERO",
       "why": "a malformed digest proves nothing; must be sha256:<64 hex>"
     },
     {
-      "requestHash": "sha256:8e35c2cd3bf6641bdb0e2050b76932cbb2e6034a0ddacc1d9bea82a6ba57f7cf",
-      "answerHash": "sha256:ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+      "requestHash": "sha256:90edba1c9d0bb14ec514a96ca800a95448adb82f1adced02b66c15b4091777d2",
+      "answerHash": "sha256:ac8d8342bbb2362d13f0a559a3621bb407011368895164b628a54f7fc33fc43c",
       "grounded": true,
       "refuted": true,
       "expect": "NEG",
@@ -155,5 +155,90 @@
       "expect": "T2",
       "why": "neither instrumented"
     }
-  ]
+  ],
+  "canonicalJson": {
+    "note": "canonicalJson is JSON with object keys sorted recursively and no whitespace. Non-ASCII characters are emitted RAW, never \\uXXXX-escaped — Python must pass ensure_ascii=False or every seal over non-ASCII content diverges from TypeScript. Found by Copilot on prophet-platform#1065; the seal test had passed only because the example receipt is pure ASCII.",
+    "cases": [
+      {
+        "input": {
+          "b": 1,
+          "a": 2
+        },
+        "expected": "{\"a\":2,\"b\":1}",
+        "why": "keys sorted"
+      },
+      {
+        "input": {
+          "k": "café"
+        },
+        "expected": "{\"k\":\"café\"}",
+        "why": "NON-ASCII EMITTED RAW — the ensure_ascii trap"
+      },
+      {
+        "input": {
+          "z": {
+            "y": 1,
+            "x": 2
+          }
+        },
+        "expected": "{\"z\":{\"x\":2,\"y\":1}}",
+        "why": "sort is recursive"
+      },
+      {
+        "input": {
+          "a": [
+            3,
+            {
+              "d": 1,
+              "c": 2
+            }
+          ]
+        },
+        "expected": "{\"a\":[3,{\"c\":2,\"d\":1}]}",
+        "why": "array order preserved, objects inside sorted"
+      },
+      {
+        "input": "hello",
+        "expected": "\"hello\"",
+        "why": "a bare string canonicalises to a QUOTED JSON string"
+      },
+      {
+        "input": {
+          "s": "中文",
+          "e": "🔒"
+        },
+        "expected": "{\"e\":\"🔒\",\"s\":\"中文\"}",
+        "why": "CJK and astral-plane emoji raw"
+      }
+    ]
+  },
+  "contentHash": {
+    "note": "contentHash(s) = sha256(canonicalJson(s)), i.e. the digest is over the QUOTED JSON encoding of the string, not the raw bytes. This tripped the Python implementation, which hashed raw bytes and so disagreed with TypeScript on every input. The pattern check in evidenceFactor could not catch it — a wrong digest is still a well-formed digest — so the function itself is pinned here.",
+    "cases": [
+      {
+        "input": "hello",
+        "expected": "sha256:5aa762ae383fbb727af3c7a36d4940a5b8c40a989452d2304fc958ff3f354e7a"
+      },
+      {
+        "input": "",
+        "expected": "sha256:12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "why": "empty string is not the empty digest"
+      },
+      {
+        "input": "café",
+        "expected": "sha256:28380feb8724d669bc8d4cf5b5a5bb1adbdc61b81ebd06f3fabc567b4f3b0fc5",
+        "why": "non-ASCII must agree across languages"
+      },
+      {
+        "input": "line1\nline2",
+        "expected": "sha256:f743ae45891e890166374840ae63895ba05ac7fdc6f3344efa8b7b7b634cf360",
+        "why": "newlines are JSON-escaped inside the quotes"
+      },
+      {
+        "input": "quote\"and\\backslash",
+        "expected": "sha256:24b91cbbccbb8e5a8128070fa9e24b1591d2dd1d4ec9627fa7fd601bc15678cc",
+        "why": "JSON escaping is part of the digest"
+      }
+    ]
+  }
 }

--- a/libs/python/lawful-verdict/pyproject.toml
+++ b/libs/python/lawful-verdict/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prophet-lawful-verdict"
+version = "0.1.0"
+description = "Truth = Law × Evidence: the estate's verdict algebra and sealed dispatch receipts, for any Python service on the mesh"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=8.3", "jsonschema>=4.21"]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/libs/python/lawful-verdict/pytest.ini
+++ b/libs/python/lawful-verdict/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+# src layout: put the package on the path so `pytest -q` works without an editable
+# install, matching how the sibling libs are run in CI.
+pythonpath = src

--- a/libs/python/lawful-verdict/requirements-test.txt
+++ b/libs/python/lawful-verdict/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest>=8.3
+jsonschema>=4.21

--- a/libs/python/lawful-verdict/src/lawful_verdict/__init__.py
+++ b/libs/python/lawful-verdict/src/lawful_verdict/__init__.py
@@ -78,7 +78,18 @@ def truth_product(law: str, evidence: str) -> Verdict:
     'ZERO'
     >>> truth_product("NEG", "NEG")    # NOT 'POS' — sign arithmetic would say +1
     'NEG'
+
+    Raises ValueError on anything that is not a verdict. A bare KeyError from a primitive
+    used in tamper-evidence checking tells a caller nothing about what went wrong; the most
+    likely cause is a legacy ledger row that carries no factors at all, and the message says
+    so. Mirrors the TypeScript ``truthProduct``, which throws for the same reason.
     """
+    if law not in _RANK or evidence not in _RANK:
+        raise ValueError(
+            f"truth_product: not a verdict (law={law!r}, evidence={evidence!r}); "
+            f"expected one of {list(_RANK)}. Legacy ledger rows carry no factors — "
+            f"guard before multiplying rather than passing None through."
+        )
     return _VERDICTS[min(_RANK[law], _RANK[evidence])]
 
 
@@ -120,14 +131,32 @@ def evidence_tier(law_source: str, evidence_source: str) -> Tier:
 
 
 def canonical_json(obj: Any) -> str:
-    """Canonical JSON: recursive key sort, no whitespace. Must match the TypeScript
-    ``ledgerHash`` canonicaliser byte for byte or seals will not cross language boundaries."""
-    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+    """Canonical JSON: recursive key sort, no whitespace, non-ASCII emitted RAW.
+
+    ``ensure_ascii=False`` is load-bearing, not stylistic. Python's default escapes ``"café"``
+    to ``"caf\u00e9"`` while JavaScript's ``JSON.stringify`` emits it raw, so with the default
+    every seal over non-ASCII content diverges between languages — a receipt sealed by
+    prophet-workspace would fail to verify inside Noetica the moment it contained an accented
+    character. The cross-language seal test did not catch this because the spec's example
+    receipt is pure ASCII. Caught in review on prophet-platform#1065; now pinned by the
+    ``canonicalJson`` vectors, which include accented text, CJK and astral-plane emoji.
+    """
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
 
 def content_hash(text: str) -> str:
-    """SEAM-C content digest of a string body (request/answer)."""
-    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+    """SEAM-C content digest of a string body (request/answer).
+
+    The digest is over ``canonicalJson(text)`` — the QUOTED JSON encoding — not the raw bytes.
+    That is not an arbitrary choice: TypeScript's ``contentHash`` is ``ledgerHash(s)``, which
+    canonicalises first, and it has already sealed every entry in the production ledger, so it
+    defines the function by incumbency. An earlier version here hashed ``text.encode()``
+    directly and therefore disagreed with TypeScript on EVERY input
+    (``content_hash("hello")`` differed completely). Nothing caught it: the schema only checks
+    that a digest is well-formed, and a wrong digest is still well-formed. The ``contentHash``
+    vectors now pin the function itself.
+    """
+    return "sha256:" + hashlib.sha256(canonical_json(text).encode("utf-8")).hexdigest()
 
 
 def _seal(obj: Any) -> str:

--- a/libs/python/lawful-verdict/src/lawful_verdict/__init__.py
+++ b/libs/python/lawful-verdict/src/lawful_verdict/__init__.py
@@ -255,6 +255,9 @@ class Receipt:
         return out
 
 
+#: Cap on attacker-controlled text echoed into a replay() reason.
+_MAX_REASON_DETAIL = 200
+
 GENESIS = "genesis"
 
 
@@ -297,7 +300,15 @@ class DispatchLedger:
             try:
                 ok, reason = self._replay_entry(e, prev)
             except Exception as exc:  # noqa: BLE001 — malformed input is a finding, not a bug
-                return False, i, f"malformed entry at index {i}: {type(exc).__name__}: {exc}"
+                # Bound the detail. The entry is attacker-controlled, so `exc` can carry
+                # arbitrary content straight into whatever logs or telemetry consume the
+                # reason. The type plus a clipped message is enough to debug with, and is
+                # the same discipline applied everywhere else a hostile value becomes a
+                # string in this estate.
+                detail = str(exc)
+                if len(detail) > _MAX_REASON_DETAIL:
+                    detail = detail[:_MAX_REASON_DETAIL] + f"… (+{len(str(exc)) - _MAX_REASON_DETAIL} chars)"
+                return False, i, f"malformed entry at index {i}: {type(exc).__name__}: {detail}"
             if not ok:
                 return False, i, reason
             prev = e["seal"]["attestation"]

--- a/libs/python/lawful-verdict/src/lawful_verdict/__init__.py
+++ b/libs/python/lawful-verdict/src/lawful_verdict/__init__.py
@@ -1,0 +1,276 @@
+"""Truth = Law × Evidence — the estate's verdict algebra, for any Python service.
+
+`×` is the MEET in the chain NEG < ZERO < POS: strong-Kleene conjunction, i.e. ``min``.
+A three-element chain is a category, and the meet in a poset-as-category is the categorical
+product, so the equation is an identity rather than a slogan — Truth is the terminal cone
+over {Law, Evidence}.
+
+It is emphatically NOT multiplication of signs in {-1, 0, +1}. That reading gives
+``NEG × NEG = POS``: a gate that refused *and* an outcome that was refuted, certifying as
+true. See :func:`truth_product` and the test that pins this cell.
+
+The three cells that carry the product's whole value:
+
+===============  ==================================================================
+POS × ZERO = ZERO  lawful but unevidenced — a claim we decline to make
+ZERO × POS = ZERO  evidenced while carrying constraints that were never discharged
+NEG × ZERO = NEG   a refusal stands without needing evidence to corroborate it
+===============  ==================================================================
+
+ZERO is what makes this a product rather than a conjunction of booleans: two-valued logic
+has to lie in one direction or the other about "not checked".
+
+Why this lives in ``libs/python`` and not inside one app
+-------------------------------------------------------
+The algebra was implemented first in Noetica's ``agent-machine``, where the verdict was a
+*caller-supplied field* and all five call sites passed the literal ``'POS'`` — 34 of 53 real
+ledger entries recorded ``grounded: false`` alongside ``verdict: 'POS'``. Governance that
+lives inside one app is governance one app can quietly drop. Any service on the mesh —
+prophet-workspace, agora, ops-fabric-api, prophet-mesh agents — imports this and emits the
+same receipt shape, validated by the same contract:
+
+    https://schemas.srcos.ai/v2/LawfulDispatchReceipt.json
+
+Cross-language agreement is enforced by shared vectors, not by trust: both this package and
+Noetica's TypeScript implementation are tested against
+``sourceos-spec/conformance/lawful-verdict-vectors.json``. Two implementations that each
+pass their own unit tests can still disagree with each other; only a shared vector set makes
+that detectable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal, Sequence
+
+__all__ = [
+    "Verdict", "Tier", "SeamSource",
+    "truth_product", "law_verdict", "evidence_verdict", "evidence_tier",
+    "LawFactor", "EvidenceFactor", "Receipt", "DispatchLedger",
+    "canonical_json", "content_hash", "SEALED_RE", "MIN_SUPPORT",
+]
+
+Verdict = Literal["NEG", "ZERO", "POS"]
+Tier = Literal["T1", "T2"]
+SeamSource = Literal["measured", "declared"]
+
+_VERDICTS: tuple[Verdict, ...] = ("NEG", "ZERO", "POS")
+_RANK: dict[str, int] = {"NEG": 0, "ZERO": 1, "POS": 2}
+
+SEALED_RE = r"^sha256:[0-9a-f]{64}$"
+#: House minimum for any statistic. Below this the correct output is "unestablished",
+#: not a number with wide error bars presented bare.
+MIN_SUPPORT = 30
+
+import re as _re
+
+_SEALED = _re.compile(SEALED_RE)
+
+
+def truth_product(law: str, evidence: str) -> Verdict:
+    """Truth = Law × Evidence. The meet under NEG < ZERO < POS.
+
+    >>> truth_product("POS", "POS")
+    'POS'
+    >>> truth_product("POS", "ZERO")   # lawful but unevidenced
+    'ZERO'
+    >>> truth_product("NEG", "NEG")    # NOT 'POS' — sign arithmetic would say +1
+    'NEG'
+    """
+    return _VERDICTS[min(_RANK[law], _RANK[evidence])]
+
+
+def law_verdict(bar_cleared: bool, residual: Sequence[str]) -> Verdict:
+    """The Law factor, DERIVED from the gate decision — never asserted by a caller.
+
+    Undischarged residual yields ZERO, not POS: a bar that "cleared" while carrying
+    constraints it could not discharge has *deferred*, not established.
+    """
+    if not bar_cleared:
+        return "NEG"
+    return "POS" if len(residual) == 0 else "ZERO"
+
+
+def evidence_verdict(
+    request_hash: str, answer_hash: str, grounded: bool, refuted: bool = False
+) -> Verdict:
+    """The Evidence factor, DERIVED from what the record actually contains.
+
+    Absent or malformed digests are ZERO — nothing was shown, and nothing was refuted.
+    NEG requires an actual refutation, which only an external verifier can supply, so
+    ``refuted`` is the one factor input a caller may legitimately set.
+    """
+    if refuted:
+        return "NEG"
+    if not _SEALED.match(request_hash or "") or not _SEALED.match(answer_hash or ""):
+        return "ZERO"
+    return "POS" if grounded else "ZERO"
+
+
+def evidence_tier(law_source: str, evidence_source: str) -> Tier:
+    """T1 (instrumented) only when BOTH factors were measured.
+
+    Claiming T1 for a value no instrument produced is the same defect as asserting a
+    verdict, one level up. Under-claiming (T2 when both are measured) is always allowed;
+    over-claiming is what the contract forbids.
+    """
+    return "T1" if law_source == "measured" and evidence_source == "measured" else "T2"
+
+
+def canonical_json(obj: Any) -> str:
+    """Canonical JSON: recursive key sort, no whitespace. Must match the TypeScript
+    ``ledgerHash`` canonicaliser byte for byte or seals will not cross language boundaries."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def content_hash(text: str) -> str:
+    """SEAM-C content digest of a string body (request/answer)."""
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _seal(obj: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json(obj).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class LawFactor:
+    bar_cleared: bool
+    residual: tuple[str, ...] = ()
+    source: SeamSource = "measured"
+
+    @property
+    def factor(self) -> Verdict:
+        return law_verdict(self.bar_cleared, self.residual)
+
+    def to_json(self) -> dict[str, Any]:
+        return {"factor": self.factor, "barCleared": self.bar_cleared,
+                "residual": list(self.residual), "source": self.source}
+
+
+@dataclass(frozen=True)
+class EvidenceFactor:
+    request_hash: str
+    answer_hash: str
+    grounded: bool
+    refuted: bool = False
+    source: SeamSource = "measured"
+
+    @property
+    def factor(self) -> Verdict:
+        return evidence_verdict(self.request_hash, self.answer_hash, self.grounded, self.refuted)
+
+    def to_json(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"factor": self.factor, "source": self.source,
+                               "grounded": self.grounded}
+        # Only emit digests that are well-formed. A malformed digest in the receipt would
+        # fail the contract's pattern; omitting it says honestly that nothing was captured.
+        if _SEALED.match(self.request_hash or ""):
+            out["requestHash"] = self.request_hash
+        if _SEALED.match(self.answer_hash or ""):
+            out["answerHash"] = self.answer_hash
+        if self.refuted:
+            out["refuted"] = True
+        return out
+
+
+@dataclass(frozen=True)
+class Receipt:
+    """A LawfulDispatchReceipt. ``verdict`` and ``evidenceTier`` are DERIVED properties,
+    not stored fields — there is deliberately no way to construct one that asserts them."""
+
+    dispatch_id: str
+    ts: str
+    law: LawFactor
+    evidence: EvidenceFactor
+    seq: int
+    prev: str
+    emitter: str | None = None
+    schema_version: str = "0.1.0"
+
+    @property
+    def verdict(self) -> Verdict:
+        return truth_product(self.law.factor, self.evidence.factor)
+
+    @property
+    def evidence_tier(self) -> Tier:
+        return evidence_tier(self.law.source, self.evidence.source)
+
+    def body(self) -> dict[str, Any]:
+        """Everything the seal covers: the whole receipt minus ``seal.attestation``.
+
+        ``evidenceTier`` is INSIDE the seal. It carries governance meaning — T1 asserts the
+        verdict was instrumented — so it must not be flippable without breaking the
+        attestation. ``seq`` and ``ts`` are inside for the same reason: an entry that could
+        be re-ordered or re-dated without breaking its own hash would let a chain be
+        rewritten in place.
+        """
+        out: dict[str, Any] = {
+            "schemaVersion": self.schema_version, "kind": "LawfulDispatchReceipt",
+            "dispatchId": self.dispatch_id, "ts": self.ts,
+            "law": self.law.to_json(), "evidence": self.evidence.to_json(),
+            "verdict": self.verdict, "evidenceTier": self.evidence_tier,
+            "seal": {"seq": self.seq, "prev": self.prev},
+        }
+        if self.emitter:
+            out["emitter"] = self.emitter
+        return out
+
+    def attestation(self) -> str:
+        return _seal(self.body())
+
+    def to_json(self) -> dict[str, Any]:
+        out = self.body()
+        out["seal"] = {**out["seal"], "attestation": self.attestation()}
+        return out
+
+
+GENESIS = "genesis"
+
+
+@dataclass
+class DispatchLedger:
+    """An append-only, hash-chained sequence of receipts. Tamper anywhere upstream makes
+    every entry from that seam onward unreachable from genesis.
+
+    ``replay`` re-derives the product as well as recomputing the seals. The chain proves a
+    record was not altered after the fact; it cannot prove the verdict followed from its
+    factors at write time, which is a separate and equally necessary check.
+    """
+
+    entries: list[dict[str, Any]] = field(default_factory=list)
+
+    def append(
+        self, dispatch_id: str, ts: str, law: LawFactor, evidence: EvidenceFactor,
+        emitter: str | None = None,
+    ) -> dict[str, Any]:
+        prev = self.entries[-1]["seal"]["attestation"] if self.entries else GENESIS
+        r = Receipt(dispatch_id=dispatch_id, ts=ts, law=law, evidence=evidence,
+                    seq=len(self.entries), prev=prev, emitter=emitter)
+        entry = r.to_json()
+        self.entries.append(entry)
+        return entry
+
+    def replay(self) -> tuple[bool, int, str | None]:
+        """Returns ``(ok, validated_count, reason)``. ``validated_count`` is how many
+        entries are reachable and consistent from genesis, which is the number that
+        matters after a tamper: entries past the seam may remain internally linked to each
+        other while being worthless."""
+        prev = GENESIS
+        for i, e in enumerate(self.entries):
+            if e["seal"]["prev"] != prev:
+                return False, i, f"prev-link mismatch at seq {e['seal']['seq']}"
+            body = {k: v for k, v in e.items() if k != "seal"}
+            body["seal"] = {"seq": e["seal"]["seq"], "prev": e["seal"]["prev"]}
+            if _seal(body) != e["seal"]["attestation"]:
+                return False, i, f"attestation mismatch (tampered) at seq {e['seal']['seq']}"
+            derived = truth_product(e["law"]["factor"], e["evidence"]["factor"])
+            if e["verdict"] != derived:
+                return False, i, (f"verdict {e['verdict']} does not follow from "
+                                  f"{e['law']['factor']} × {e['evidence']['factor']} = {derived}")
+            want_tier = evidence_tier(e["law"]["source"], e["evidence"]["source"])
+            if e["evidenceTier"] == "T1" and want_tier == "T2":
+                return False, i, f"seq {e['seal']['seq']} claims T1 on a declared factor"
+            prev = e["seal"]["attestation"]
+        return True, len(self.entries), None

--- a/libs/python/lawful-verdict/src/lawful_verdict/__init__.py
+++ b/libs/python/lawful-verdict/src/lawful_verdict/__init__.py
@@ -288,18 +288,45 @@ class DispatchLedger:
         other while being worthless."""
         prev = GENESIS
         for i, e in enumerate(self.entries):
-            if e["seal"]["prev"] != prev:
-                return False, i, f"prev-link mismatch at seq {e['seal']['seq']}"
-            body = {k: v for k, v in e.items() if k != "seal"}
-            body["seal"] = {"seq": e["seal"]["seq"], "prev": e["seal"]["prev"]}
-            if _seal(body) != e["seal"]["attestation"]:
-                return False, i, f"attestation mismatch (tampered) at seq {e['seal']['seq']}"
-            derived = truth_product(e["law"]["factor"], e["evidence"]["factor"])
-            if e["verdict"] != derived:
-                return False, i, (f"verdict {e['verdict']} does not follow from "
-                                  f"{e['law']['factor']} × {e['evidence']['factor']} = {derived}")
-            want_tier = evidence_tier(e["law"]["source"], e["evidence"]["source"])
-            if e["evidenceTier"] == "T1" and want_tier == "T2":
-                return False, i, f"seq {e['seal']['seq']} claims T1 on a declared factor"
+            # replay() validates data that is by assumption UNTRUSTED — catching a forger
+            # is the whole job. So every structural surprise must come back as
+            # (False, i, reason), never as an exception. A tamper-evidence routine that
+            # raises on a malformed entry hands the caller a crash where it promised a
+            # verdict, and any caller that wrapped replay() in a bare `except` would read
+            # that crash as "not my problem" rather than "this ledger is bad".
+            try:
+                ok, reason = self._replay_entry(e, prev)
+            except Exception as exc:  # noqa: BLE001 — malformed input is a finding, not a bug
+                return False, i, f"malformed entry at index {i}: {type(exc).__name__}: {exc}"
+            if not ok:
+                return False, i, reason
             prev = e["seal"]["attestation"]
         return True, len(self.entries), None
+
+    @staticmethod
+    def _replay_entry(e: dict, prev: str) -> tuple[bool, str | None]:
+        """One entry's checks. May raise on a malformed entry; replay() converts that into
+        a finding. Split out so the fail-closed boundary is one obvious place."""
+        seq = e["seal"]["seq"]
+        if e["seal"]["prev"] != prev:
+            return False, f"prev-link mismatch at seq {seq}"
+        body = {k: v for k, v in e.items() if k != "seal"}
+        body["seal"] = {"seq": seq, "prev": e["seal"]["prev"]}
+        if _seal(body) != e["seal"]["attestation"]:
+            return False, f"attestation mismatch (tampered) at seq {seq}"
+        derived = truth_product(e["law"]["factor"], e["evidence"]["factor"])
+        if e["verdict"] != derived:
+            return False, (f"verdict {e['verdict']} does not follow from "
+                           f"{e['law']['factor']} × {e['evidence']['factor']} = {derived}")
+        # A tier must BE a tier before it can be compared to one. The previous check only
+        # rejected T1-claimed-where-T2-is-owed, so any unrecognised value — "T0", "", a
+        # number — sailed straight through: forge the tier to something outside the
+        # vocabulary and the entry validated. An unreadable governance claim is not a
+        # weaker claim than an over-claim; it is a worse one.
+        tier = e["evidenceTier"]
+        if tier not in ("T1", "T2"):
+            return False, f"seq {seq} carries an unknown evidenceTier {tier!r}; expected 'T1' or 'T2'"
+        # Under-claiming (T2 where T1 was earned) remains allowed; over-claiming does not.
+        if tier == "T1" and evidence_tier(e["law"]["source"], e["evidence"]["source"]) == "T2":
+            return False, f"seq {seq} claims T1 on a declared factor"
+        return True, None

--- a/libs/python/lawful-verdict/tests/test_conformance.py
+++ b/libs/python/lawful-verdict/tests/test_conformance.py
@@ -80,7 +80,24 @@ def _vectors() -> dict:
 
 
 def test_vendored_vectors_match_upstream() -> None:
-    """The drift check. Vendoring buys availability; only this buys freshness."""
+    """The drift check. Vendoring buys availability; only this buys freshness.
+
+    This is the ONLY check in the suite that compares the vendored bytes to anything
+    outside this directory, and it SKIPS in CI (cross-org token — the spec lives in
+    SourceOS-Linux, this repo in SocioProphet).
+
+    The consequence is worth stating plainly rather than leaving implied. The workflow's
+    digest step compares each vendored file to a digest recorded in _provenance.json,
+    which sits in the same directory and is editable in the same commit. Measured:
+
+        tamper a vector only            -> digest step RED
+        tamper a vector AND its digest  -> digest step GREEN, suite 21 passed / 1 skipped
+
+    So in CI a co-edited vector is undetectable and the run is fully green. That is a real
+    residual, not a solved problem. Do not read a green run here as "agrees with the spec";
+    read it as "self-consistent with the vendored copy". Closing it needs cross-org read
+    access so this test can run in CI.
+    """
     prov = json.loads(_vendored("_provenance.json").read_text(encoding="utf-8"))
     roots = _upstream_roots()
     root = next((r for r in roots if (r / "conformance" / "lawful-verdict-vectors.json").exists()), None)

--- a/libs/python/lawful-verdict/tests/test_conformance.py
+++ b/libs/python/lawful-verdict/tests/test_conformance.py
@@ -7,16 +7,27 @@ disagree with each other; only a shared vector set makes cross-language drift de
 which is the entire reason the file exists rather than each repo asserting its own table.
 
 The vectors are VENDORED into `conformance/` with their upstream digests recorded in
-`conformance/_provenance.json`, so these tests run unconditionally and can never skip.
-That is deliberate: prophet-platform (SocioProphet) and sourceos-spec (SourceOS-Linux) are in
-different orgs, so CI's GITHUB_TOKEN cannot check the spec out — the first version of this
-suite duly reported UNVERIFIED and failed the build. A conformance gate that depends on
+`conformance/_provenance.json`, so the assertions that READ THE VENDORED ARTEFACTS -- the
+vector suite, the sealed cross-language example, and the schema checks -- run
+unconditionally and cannot skip.
+
+That claim is scoped on purpose. Two tests in this file DO skip, and saying "these tests
+can never skip" flatly would be false: `test_vendored_vectors_match_upstream` skips when
+the real spec is unreachable (always, in CI), and the schema tests `importorskip`
+jsonschema. The never-skip guarantee covers conformance against the vendored copy; it does
+not cover freshness against upstream. Those are different properties and the difference is
+the point.
+
+Vendoring is deliberate: prophet-platform (SocioProphet) and sourceos-spec (SourceOS-Linux)
+are in different orgs, so CI's GITHUB_TOKEN cannot check the spec out — the first version of
+this suite duly reported UNVERIFIED and failed the build. A conformance gate that depends on
 network access it does not have is not a gate.
 
 Drift is caught separately. When the real spec IS present — a dev tree, or CI with cross-org
 access — `test_vendored_vectors_match_upstream` asserts the vendored bytes still hash to the
-recorded digests. So: never-skipping conformance, plus drift detection wherever it is
-actually possible, and an honest distinction between the two.
+recorded digests. So: non-skipping conformance against the vendored copy, drift detection
+wherever it is actually possible, and an honest line between the two rather than one claim
+covering both.
 """
 
 from __future__ import annotations
@@ -46,6 +57,7 @@ from lawful_verdict import (
     DispatchLedger, EvidenceFactor, LawFactor, Receipt, canonical_json, content_hash,
     evidence_tier, evidence_verdict, law_verdict, truth_product,
 )
+from lawful_verdict import _seal  # forging tests must re-seal, as a real forger would
 
 VERDICTS = ["NEG", "ZERO", "POS"]
 
@@ -373,3 +385,112 @@ def test_truth_product_raises_a_useful_error_not_a_bare_KeyError() -> None:
         with pytest.raises(ValueError, match="not a verdict"):
             truth_product(law, ev)  # type: ignore[arg-type]
     assert truth_product("POS", "POS") == "POS", "and still works on real input"
+
+
+# ── Copilot (suppressed, low-confidence — but correct): replay() must fail closed ──
+#
+# These were not inline comments; they were folded into a "Comments suppressed due to
+# low confidence" block on the review body, which /pulls/N/comments does not return.
+# Both were right.
+#
+# replay() exists to validate a ledger that may have been tampered with. Its contract is
+# (ok, validated_count, reason). Before this, a malformed entry produced a KeyError or
+# TypeError instead — a crash where the contract promised a verdict.
+
+
+def _sealed_ledger() -> DispatchLedger:
+    led = DispatchLedger()
+    led.append("urn:srcos:dispatch:0", "2026-07-29T00:00:00Z", _law(),
+               EvidenceFactor(request_hash=content_hash("q"), answer_hash=content_hash("a"),
+                              grounded=True),
+               emitter="test")
+    ok, n, reason = led.replay()
+    assert ok and n == 1, f"fixture must start valid: {reason}"
+    return led
+
+
+def _reseal(e: dict) -> None:
+    """Re-seal an entry after damaging it, exactly as a capable forger would.
+
+    Load-bearing, not ceremony. The first version of the test below damaged the entry
+    and stopped there — but a structural edit changes the sealed body, so the
+    attestation check caught every case BEFORE execution ever reached the malformed
+    field. The tests passed while exercising the wrong branch entirely: with the
+    exception handler narrowed to a type that never fires, all of them stayed green.
+    Re-sealing is what forces replay() past the hash check and into the code path the
+    fail-closed boundary actually protects.
+    """
+    body = {k: v for k, v in e.items() if k != "seal"}
+    body["seal"] = {"seq": e["seal"]["seq"], "prev": e["seal"]["prev"]}
+    e["seal"]["attestation"] = _seal(body)
+
+
+@pytest.mark.parametrize("damage,label", [
+    (lambda e: e.pop("law"),                            "missing law"),
+    (lambda e: e.pop("evidence"),                       "missing evidence"),
+    (lambda e: e.pop("verdict"),                        "missing verdict"),
+    (lambda e: e.pop("evidenceTier"),                   "missing evidenceTier"),
+    (lambda e: e["law"].pop("factor"),                  "missing law.factor"),
+    (lambda e: e["law"].pop("source"),                  "missing law.source"),
+    (lambda e: e.__setitem__("law", "not a mapping"),   "law is a string"),
+    (lambda e: e.__setitem__("law", None),              "law is null"),
+    (lambda e: e["law"].__setitem__("factor", "MAYBE"), "unknown factor value"),
+    (lambda e: e["law"].__setitem__("factor", None),    "null factor (legacy row)"),
+])
+def test_replay_returns_a_finding_rather_than_raising(damage, label) -> None:
+    """The forger is maximally capable: they damage the entry AND re-seal, so the chain
+    verifies and only replay()'s own robustness stands between them and a crash."""
+    led = _sealed_ledger()
+    damage(led.entries[0])
+    _reseal(led.entries[0])
+    ok, i, reason = led.replay()          # must not raise
+    assert ok is False, f"{label}: replay ACCEPTED a malformed entry"
+    assert i == 0 and reason, f"{label}: no reason given"
+
+
+def test_the_malformed_entry_tests_really_reach_the_fail_closed_path() -> None:
+    """Guards the guard. If _reseal ever stopped working, the cases above would go back
+    to being caught by the attestation check and would silently stop testing anything.
+    Here the reason must NOT be an attestation mismatch."""
+    led = _sealed_ledger()
+    led.entries[0]["law"].pop("factor")
+    _reseal(led.entries[0])
+    ok, _, reason = led.replay()
+    assert ok is False
+    assert "attestation" not in (reason or ""), (
+        f"still being caught by the hash check, not the malformed-entry path: {reason}")
+    assert "malformed entry" in (reason or ""), f"unexpected reason: {reason}"
+
+
+def test_replay_rejects_an_evidence_tier_outside_the_vocabulary() -> None:
+    """Copilot: "can let invalid tiers like T0 pass as OK". Correct — the old check only
+    rejected T1-where-T2-is-owed, so any UNRECOGNISED tier validated. A forger who cannot
+    over-claim T1 could instead write a tier nothing understands.
+
+    The forger here is maximally capable: they edit the field AND re-seal, so the hash
+    chain verifies and only the semantic check can catch it.
+    """
+    for bogus in ("T0", "T3", "", "t1", 1, None):
+        led = _sealed_ledger()
+        e = led.entries[0]
+        e["evidenceTier"] = bogus
+        body = {k: v for k, v in e.items() if k != "seal"}
+        body["seal"] = {"seq": e["seal"]["seq"], "prev": e["seal"]["prev"]}
+        e["seal"]["attestation"] = _seal(body)      # re-seal: the chain now verifies
+        ok, i, reason = led.replay()
+        assert ok is False, f"tier {bogus!r} was ACCEPTED"
+        assert "evidenceTier" in (reason or ""), f"tier {bogus!r}: wrong reason {reason!r}"
+
+
+def test_replay_still_allows_honest_under_claiming() -> None:
+    """T2 where T1 was earned is deliberately legal — the fix must not turn conservatism
+    into a violation."""
+    led = _sealed_ledger()
+    e = led.entries[0]
+    assert e["evidenceTier"] == "T1", "fixture should have earned T1"
+    e["evidenceTier"] = "T2"
+    body = {k: v for k, v in e.items() if k != "seal"}
+    body["seal"] = {"seq": e["seal"]["seq"], "prev": e["seal"]["prev"]}
+    e["seal"]["attestation"] = _seal(body)
+    ok, _, reason = led.replay()
+    assert ok, f"under-claiming must remain valid, got: {reason}"

--- a/libs/python/lawful-verdict/tests/test_conformance.py
+++ b/libs/python/lawful-verdict/tests/test_conformance.py
@@ -286,28 +286,73 @@ def test_receipts_validate_against_the_spec_schema_if_available() -> None:
     """Emit every one of the 9 product cells and validate each against the contract. This
     is the end-to-end claim: what this library produces is what the estate's schema
     accepts, for every reachable verdict — not just the happy path."""
-    if True:
-        if True:
-            jsonschema = pytest.importorskip("jsonschema")
-            validator = jsonschema.Draft202012Validator(
-                json.loads(_vendored("LawfulDispatchReceipt.json").read_text(encoding="utf-8")))
-            seen: set[str] = set()
-            cases = [
-                (_law(), _ev()),                                        # POS × POS
-                (_law(), _ev(grounded=False)),                          # POS × ZERO
-                (_law(), _ev(refuted=True)),                            # POS × NEG
-                (_law(residual=("r",)), _ev()),                         # ZERO × POS
-                (_law(residual=("r",)), _ev(grounded=False)),           # ZERO × ZERO
-                (_law(residual=("r",)), _ev(refuted=True)),             # ZERO × NEG
-                (_law(bar_cleared=False), _ev()),                       # NEG × POS
-                (_law(bar_cleared=False), _ev(grounded=False)),         # NEG × ZERO
-                (_law(bar_cleared=False), _ev(refuted=True)),           # NEG × NEG
-            ]
-            for law, ev in cases:
-                r = Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z", law, ev, 0, "genesis",
-                            emitter="prophet-platform/libs/lawful-verdict")
-                errs = list(validator.iter_errors(r.to_json()))
-                assert not errs, f"{law.factor} × {ev.factor}: {errs[0].message if errs else ''}"
-                seen.add(f"{law.factor}x{ev.factor}")
-            assert len(seen) == 9, f"all 9 cells must be emitted and accepted, got {sorted(seen)}"
-            return
+    jsonschema = pytest.importorskip("jsonschema")
+    validator = jsonschema.Draft202012Validator(
+        json.loads(_vendored("LawfulDispatchReceipt.json").read_text(encoding="utf-8")))
+    seen: set[str] = set()
+    cases = [
+        (_law(), _ev()),                                        # POS × POS
+        (_law(), _ev(grounded=False)),                          # POS × ZERO
+        (_law(), _ev(refuted=True)),                            # POS × NEG
+        (_law(residual=("r",)), _ev()),                         # ZERO × POS
+        (_law(residual=("r",)), _ev(grounded=False)),           # ZERO × ZERO
+        (_law(residual=("r",)), _ev(refuted=True)),             # ZERO × NEG
+        (_law(bar_cleared=False), _ev()),                       # NEG × POS
+        (_law(bar_cleared=False), _ev(grounded=False)),         # NEG × ZERO
+        (_law(bar_cleared=False), _ev(refuted=True)),           # NEG × NEG
+    ]
+    for law, ev in cases:
+        r = Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z", law, ev, 0, "genesis",
+                    emitter="prophet-platform/libs/lawful-verdict")
+        errs = list(validator.iter_errors(r.to_json()))
+        assert not errs, f"{law.factor} × {ev.factor}: {errs[0].message if errs else ''}"
+        seen.add(f"{law.factor}x{ev.factor}")
+    assert len(seen) == 9, f"all 9 cells must be emitted and accepted, got {sorted(seen)}"
+    return
+
+
+# ── the SEAL functions themselves, pinned by vectors ────────────────────────────
+# These exist because two real divergences got past everything else. The schema only checks
+# that a digest is well-formed, and a WRONG digest is still well-formed — so nothing in the
+# receipt-shaped tests could detect that the digest function disagreed across languages.
+
+def test_canonical_json_matches_the_shared_vectors_including_non_ascii() -> None:
+    """The ensure_ascii trap. Python's default escapes "café" to "caf\\u00e9" while
+    JavaScript emits it raw, so with the default every seal over non-ASCII content diverges.
+    The cross-language seal test passed anyway, because the spec's example receipt is pure
+    ASCII — which is exactly why the function needs vectors of its own."""
+    cases = _vectors()["canonicalJson"]["cases"]
+    assert any(any(ord(ch) > 127 for ch in json.dumps(c["input"], ensure_ascii=False)) for c in cases), \
+        "vectors must include a non-ASCII case or this test cannot catch the trap"
+    for c in cases:
+        got = canonical_json(c["input"])
+        assert got == c["expected"], f"{c.get('why', '')}: expected {c['expected']!r}, got {got!r}"
+
+
+def test_content_hash_matches_the_shared_vectors() -> None:
+    """contentHash(s) = sha256(canonicalJson(s)) — over the QUOTED JSON encoding, not the raw
+    bytes. An earlier version here hashed text.encode() directly and disagreed with
+    TypeScript on every single input."""
+    for c in _vectors()["contentHash"]["cases"]:
+        got = content_hash(c["input"])
+        assert got == c["expected"], f"{c.get('why', '')}: input {c['input']!r} → {got}, want {c['expected']}"
+
+
+def test_a_receipt_with_non_ascii_content_still_seals_reproducibly() -> None:
+    """End to end: the bug's real consequence was a receipt that would not verify in another
+    language the moment it carried an accented character."""
+    ev = EvidenceFactor(request_hash=content_hash("qué es la capital de España?"),
+                        answer_hash=content_hash("Madrid — 中文 🔒"), grounded=True)
+    r = Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z", _law(), ev, 0, "genesis")
+    assert r.attestation() == r.attestation(), "deterministic"
+    body = r.body()
+    assert "\\u" not in canonical_json(body), "the canonical form must carry raw non-ASCII, not escapes"
+
+
+def test_truth_product_raises_a_useful_error_not_a_bare_KeyError() -> None:
+    # A bare KeyError from a primitive used in tamper-evidence checking tells a caller
+    # nothing. The most likely cause is a legacy row with no factors, and the message says so.
+    for law, ev in [(None, "POS"), ("POS", None), (None, None), ("MAYBE", "POS")]:
+        with pytest.raises(ValueError, match="not a verdict"):
+            truth_product(law, ev)  # type: ignore[arg-type]
+    assert truth_product("POS", "POS") == "POS", "and still works on real input"

--- a/libs/python/lawful-verdict/tests/test_conformance.py
+++ b/libs/python/lawful-verdict/tests/test_conformance.py
@@ -1,0 +1,296 @@
+"""Conformance: this implementation against the estate's shared vectors.
+
+The vectors live in sourceos-spec (`conformance/lawful-verdict-vectors.json`) and are
+consumed by every implementation on the mesh — this package and Noetica's TypeScript
+`dispatch-ledger`. Two implementations that each pass their own unit tests can still
+disagree with each other; only a shared vector set makes cross-language drift detectable,
+which is the entire reason the file exists rather than each repo asserting its own table.
+
+If sourceos-spec is not checked out beside this repo the vector tests SKIP with a loud
+reason locally, and FAIL in CI, where the workflow sets LAWFUL_VERDICT_REQUIRE_VECTORS=1.
+They must never silently pass: a conformance suite reporting green when it never loaded the
+vectors converts an unknown into a false assurance, which is the same defect class as the
+asserted verdict this contract exists to eliminate. Verified in both directions — with the
+vectors moved aside, the strict run fails 5 tests and the permissive run skips 5.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+#: In CI the vectors MUST be present. A conformance suite that reports green because it
+#: never loaded the vectors converts an unknown into a false assurance — the precise defect
+#: this contract exists to prevent. Locally a skip is a developer convenience; with
+#: LAWFUL_VERDICT_REQUIRE_VECTORS=1 it becomes a hard failure.
+REQUIRE = os.environ.get("LAWFUL_VERDICT_REQUIRE_VECTORS") == "1"
+
+
+def _unavailable(what: str, looked: list[Path]) -> None:
+    msg = (f"{what} not found — cross-language agreement is UNVERIFIED. "
+           f"Looked in: {', '.join(str(p) for p in looked)}")
+    if REQUIRE:
+        raise AssertionError("LAWFUL_VERDICT_REQUIRE_VECTORS=1 but " + msg)
+    pytest.skip(msg)
+
+from lawful_verdict import (
+    DispatchLedger, EvidenceFactor, LawFactor, Receipt, canonical_json, content_hash,
+    evidence_tier, evidence_verdict, law_verdict, truth_product,
+)
+
+VERDICTS = ["NEG", "ZERO", "POS"]
+
+def _spec_roots() -> list[Path]:
+    """Where sourceos-spec might be. SOURCEOS_SPEC_DIR comes first because CI cannot use a
+    sibling directory: actions/checkout refuses paths outside $GITHUB_WORKSPACE, so the
+    workflow checks the spec out into a subdirectory and points at it explicitly."""
+    env = os.environ.get("SOURCEOS_SPEC_DIR")
+    if env:
+        # AUTHORITATIVE when set: no fallback. An explicitly configured spec directory that
+        # does not contain the vectors is a misconfiguration, and falling back to a stray
+        # local checkout would let CI report agreement with a file it was not asked to read.
+        return [Path(env)]
+    return [
+        Path(__file__).resolve().parents[5] / "sourceos-spec",   # dev tree sibling
+        Path.home() / "dev" / "sourceos-spec",
+    ]
+
+
+def _spec_file(*parts: str) -> tuple[Path | None, list[Path]]:
+    looked = [r.joinpath(*parts) for r in _spec_roots()]
+    return next((p for p in looked if p.exists()), None), looked
+
+
+_CANDIDATES = [r / "conformance" / "lawful-verdict-vectors.json" for r in _spec_roots()]
+
+
+def _vectors() -> dict:
+    found, looked = _spec_file("conformance", "lawful-verdict-vectors.json")
+    if found:
+        return json.loads(found.read_text(encoding="utf-8"))
+    _unavailable("sourceos-spec conformance vectors", looked)
+    raise AssertionError("unreachable")
+
+
+# ── the shared vectors ──────────────────────────────────────────────────────────
+
+def test_product_table_matches_the_shared_vectors() -> None:
+    v = _vectors()
+    table = v["product"]["table"]
+    assert len(table) == 9, "the product is total on a 3-element chain: 9 cells, no gaps"
+    for row in table:
+        assert truth_product(row["law"], row["evidence"]) == row["verdict"], row
+
+
+def test_the_sign_multiplication_trap_is_pinned_by_the_vectors() -> None:
+    # The single cell that distinguishes a defensible product from a catastrophic one.
+    v = _vectors()
+    must_not = v["product"]["mustNotHold"]
+    assert must_not, "the vectors must carry at least the NEG × NEG = POS counter-case"
+    for bad in must_not:
+        assert truth_product(bad["law"], bad["evidence"]) != bad["verdict"], bad
+
+
+def test_law_factor_matches_the_shared_vectors() -> None:
+    for row in _vectors()["lawFactor"]:
+        got = law_verdict(row["barCleared"], row["residual"])
+        assert got == row["expect"], f"{row['why']}: got {got}"
+
+
+def test_evidence_factor_matches_the_shared_vectors() -> None:
+    for row in _vectors()["evidenceFactor"]:
+        got = evidence_verdict(row["requestHash"], row["answerHash"], row["grounded"],
+                               row.get("refuted", False))
+        assert got == row["expect"], f"{row['why']}: got {got}"
+
+
+def test_tier_matches_the_shared_vectors() -> None:
+    for row in _vectors()["tier"]:
+        got = evidence_tier(row["lawSource"], row["evidenceSource"])
+        assert got == row["expect"], f"{row['why']}: got {got}"
+
+
+def test_the_sealed_example_in_the_spec_verifies_against_this_implementation() -> None:
+    """The cross-language seal test. If Python's canonical JSON disagrees with the
+    TypeScript canonicaliser by so much as key order or whitespace, this fails — which is
+    exactly what we want it to catch, since a receipt sealed by one service must verify in
+    another."""
+    found, looked = _spec_file("examples", "lawful-dispatch-receipt.example.json")
+    if found:
+        example = json.loads(found.read_text(encoding="utf-8"))
+        recorded = example["seal"].pop("attestation")
+        import hashlib
+        recomputed = "sha256:" + hashlib.sha256(canonical_json(example).encode()).hexdigest()
+        assert recomputed == recorded, "canonical-JSON seal disagrees across languages"
+        return
+    _unavailable("sourceos-spec example receipt (seal agreement)", looked)
+
+
+# ── the algebra, independent of the vector file ─────────────────────────────────
+
+def test_product_is_the_lattice_meet_not_the_sign_product() -> None:
+    sign = {"NEG": -1, "ZERO": 0, "POS": 1}
+    assert sign["NEG"] * sign["NEG"] == 1, "sign arithmetic would say +1 (POS)"
+    assert truth_product("NEG", "NEG") == "NEG", "the meet says NEG — the only sound answer"
+
+
+def test_product_is_commutative_associative_with_POS_identity_and_NEG_absorbing() -> None:
+    for a in VERDICTS:
+        assert truth_product(a, "POS") == a, "POS is the identity: evidence alone adds nothing"
+        assert truth_product(a, "NEG") == "NEG", "NEG absorbs: one refutation is enough"
+        for b in VERDICTS:
+            assert truth_product(a, b) == truth_product(b, a)
+            for c in VERDICTS:
+                assert truth_product(truth_product(a, b), c) == truth_product(a, truth_product(b, c))
+
+
+def test_the_three_load_bearing_cells() -> None:
+    assert truth_product("POS", "ZERO") == "ZERO", "lawful but unevidenced: a claim we decline to make"
+    assert truth_product("ZERO", "POS") == "ZERO", "evidenced while carrying undischarged constraints"
+    assert truth_product("NEG", "ZERO") == "NEG", "a refusal stands without corroboration"
+
+
+# ── receipts and the ledger ─────────────────────────────────────────────────────
+
+def _law(**kw) -> LawFactor:
+    return LawFactor(**{"bar_cleared": True, "residual": (), **kw})
+
+
+def _ev(**kw) -> EvidenceFactor:
+    return EvidenceFactor(**{"request_hash": content_hash("q"), "answer_hash": content_hash("a"),
+                             "grounded": True, **kw})
+
+
+def test_a_receipt_cannot_assert_its_verdict_or_tier() -> None:
+    # Both are derived properties. There is no constructor parameter for either, which is
+    # the fix for the defect that started this: a caller-supplied verdict field that every
+    # call site filled with the literal 'POS'.
+    assert not hasattr(Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z", _law(), _ev(), 0, "genesis"), "_verdict")
+    r = Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z", _law(), _ev(), 0, "genesis")
+    assert r.verdict == "POS"
+    assert Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z",
+                   _law(residual=("citation.resolves",)), _ev(), 0, "genesis").verdict == "ZERO"
+    assert Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z",
+                   _law(bar_cleared=False), _ev(), 0, "genesis").verdict == "NEG"
+    assert Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z",
+                   _law(), _ev(refuted=True), 0, "genesis").verdict == "NEG"
+    assert Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z",
+                   _law(), _ev(grounded=False), 0, "genesis").verdict == "ZERO"
+
+
+def test_a_declared_factor_forces_T2() -> None:
+    assert Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z", _law(), _ev(), 0, "genesis").evidence_tier == "T1"
+    assert Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z",
+                   _law(source="declared"), _ev(), 0, "genesis").evidence_tier == "T2"
+    assert Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z",
+                   _law(), _ev(source="declared"), 0, "genesis").evidence_tier == "T2"
+
+
+def test_evidence_tier_is_inside_the_seal() -> None:
+    """T1 asserts the verdict was instrumented, so flipping it must break the attestation.
+    Excluding it from the seal would leave the governance claim editable at rest."""
+    measured = Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z", _law(), _ev(), 0, "genesis")
+    declared = Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z", _law(source="declared"), _ev(), 0, "genesis")
+    assert measured.evidence_tier != declared.evidence_tier
+    assert measured.attestation() != declared.attestation(), "tier must be sealed"
+
+
+def test_ledger_replays_clean_and_chains() -> None:
+    led = DispatchLedger()
+    for i in range(5):
+        led.append(f"urn:srcos:dispatch:{i}", "2026-07-29T00:00:00Z", _law(),
+                   _ev(request_hash=content_hash(f"q{i}"), answer_hash=content_hash(f"a{i}")),
+                   emitter="prophet-workspace/drive")
+    ok, count, reason = led.replay()
+    assert (ok, count, reason) == (True, 5, None)
+    assert led.entries[0]["seal"]["prev"] == "genesis"
+    for i in range(1, 5):
+        assert led.entries[i]["seal"]["prev"] == led.entries[i - 1]["seal"]["attestation"]
+
+
+def test_tampering_makes_the_suffix_unreachable() -> None:
+    led = DispatchLedger()
+    for i in range(4):
+        led.append(f"urn:srcos:dispatch:{i}", "2026-07-29T00:00:00Z", _law(),
+                   _ev(request_hash=content_hash(f"q{i}")))
+    assert led.replay()[0] is True
+
+    # Alter content and DO NOT re-seal: caught by the attestation.
+    led.entries[1]["evidence"]["grounded"] = False
+    ok, count, reason = led.replay()
+    assert ok is False
+    assert "attestation mismatch" in reason or "does not follow" in reason
+
+
+def test_a_resealed_forgery_is_still_caught_by_the_product() -> None:
+    """The test that proves the product check is not redundant with the hash chain. The
+    forger is maximally capable: they edit the verdict, re-seal so the chain verifies, and
+    place the entry last so no prev-link is disturbed. Only re-deriving Law × Evidence
+    catches it."""
+    import hashlib
+    led = DispatchLedger()
+    led.append("urn:srcos:dispatch:0", "2026-07-29T00:00:00Z",
+               _law(residual=("citation.resolves",)), _ev())
+    assert led.entries[0]["verdict"] == "ZERO", "honestly ZERO: undischarged residual"
+
+    e = led.entries[0]
+    e["verdict"] = "POS"
+    body = {k: v for k, v in e.items() if k != "seal"}
+    body["seal"] = {"seq": e["seal"]["seq"], "prev": e["seal"]["prev"]}
+    e["seal"]["attestation"] = "sha256:" + hashlib.sha256(canonical_json(body).encode()).hexdigest()
+
+    ok, _, reason = led.replay()
+    assert ok is False, "a verdict that does not follow from its factors is not evidence"
+    assert "does not follow from ZERO × POS = ZERO" in reason
+
+
+def test_a_forged_tier_upgrade_is_caught() -> None:
+    import hashlib
+    led = DispatchLedger()
+    led.append("urn:srcos:dispatch:0", "2026-07-29T00:00:00Z", _law(source="declared"), _ev())
+    assert led.entries[0]["evidenceTier"] == "T2"
+
+    e = led.entries[0]
+    e["evidenceTier"] = "T1"
+    body = {k: v for k, v in e.items() if k != "seal"}
+    body["seal"] = {"seq": e["seal"]["seq"], "prev": e["seal"]["prev"]}
+    e["seal"]["attestation"] = "sha256:" + hashlib.sha256(canonical_json(body).encode()).hexdigest()
+
+    ok, _, reason = led.replay()
+    assert ok is False, "T1 on a declared factor must be rejected even when re-sealed"
+    assert "claims T1 on a declared factor" in reason
+
+
+def test_receipts_validate_against_the_spec_schema_if_available() -> None:
+    """Emit every one of the 9 product cells and validate each against the contract. This
+    is the end-to-end claim: what this library produces is what the estate's schema
+    accepts, for every reachable verdict — not just the happy path."""
+    found, looked = _spec_file("schemas", "LawfulDispatchReceipt.json")
+    if found:
+        if True:
+            jsonschema = pytest.importorskip("jsonschema")
+            validator = jsonschema.Draft202012Validator(json.loads(found.read_text(encoding="utf-8")))
+            seen: set[str] = set()
+            cases = [
+                (_law(), _ev()),                                        # POS × POS
+                (_law(), _ev(grounded=False)),                          # POS × ZERO
+                (_law(), _ev(refuted=True)),                            # POS × NEG
+                (_law(residual=("r",)), _ev()),                         # ZERO × POS
+                (_law(residual=("r",)), _ev(grounded=False)),           # ZERO × ZERO
+                (_law(residual=("r",)), _ev(refuted=True)),             # ZERO × NEG
+                (_law(bar_cleared=False), _ev()),                       # NEG × POS
+                (_law(bar_cleared=False), _ev(grounded=False)),         # NEG × ZERO
+                (_law(bar_cleared=False), _ev(refuted=True)),           # NEG × NEG
+            ]
+            for law, ev in cases:
+                r = Receipt("urn:srcos:dispatch:x", "2026-07-29T00:00:00Z", law, ev, 0, "genesis",
+                            emitter="prophet-platform/libs/lawful-verdict")
+                errs = list(validator.iter_errors(r.to_json()))
+                assert not errs, f"{law.factor} × {ev.factor}: {errs[0].message if errs else ''}"
+                seen.add(f"{law.factor}x{ev.factor}")
+            assert len(seen) == 9, f"all 9 cells must be emitted and accepted, got {sorted(seen)}"
+            return
+    _unavailable("sourceos-spec LawfulDispatchReceipt schema", looked)

--- a/libs/python/lawful-verdict/tests/test_conformance.py
+++ b/libs/python/lawful-verdict/tests/test_conformance.py
@@ -6,16 +6,22 @@ consumed by every implementation on the mesh — this package and Noetica's Type
 disagree with each other; only a shared vector set makes cross-language drift detectable,
 which is the entire reason the file exists rather than each repo asserting its own table.
 
-If sourceos-spec is not checked out beside this repo the vector tests SKIP with a loud
-reason locally, and FAIL in CI, where the workflow sets LAWFUL_VERDICT_REQUIRE_VECTORS=1.
-They must never silently pass: a conformance suite reporting green when it never loaded the
-vectors converts an unknown into a false assurance, which is the same defect class as the
-asserted verdict this contract exists to eliminate. Verified in both directions — with the
-vectors moved aside, the strict run fails 5 tests and the permissive run skips 5.
+The vectors are VENDORED into `conformance/` with their upstream digests recorded in
+`conformance/_provenance.json`, so these tests run unconditionally and can never skip.
+That is deliberate: prophet-platform (SocioProphet) and sourceos-spec (SourceOS-Linux) are in
+different orgs, so CI's GITHUB_TOKEN cannot check the spec out — the first version of this
+suite duly reported UNVERIFIED and failed the build. A conformance gate that depends on
+network access it does not have is not a gate.
+
+Drift is caught separately. When the real spec IS present — a dev tree, or CI with cross-org
+access — `test_vendored_vectors_match_upstream` asserts the vendored bytes still hash to the
+recorded digests. So: never-skipping conformance, plus drift detection wherever it is
+actually possible, and an honest distinction between the two.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -43,15 +49,16 @@ from lawful_verdict import (
 
 VERDICTS = ["NEG", "ZERO", "POS"]
 
-def _spec_roots() -> list[Path]:
-    """Where sourceos-spec might be. SOURCEOS_SPEC_DIR comes first because CI cannot use a
-    sibling directory: actions/checkout refuses paths outside $GITHUB_WORKSPACE, so the
-    workflow checks the spec out into a subdirectory and points at it explicitly."""
+#: The vendored copies. Always present, so nothing here can skip for want of a file.
+VENDORED = Path(__file__).resolve().parents[1] / "conformance"
+
+
+def _upstream_roots() -> list[Path]:
+    """Where the real sourceos-spec might be, for the DRIFT check only. SOURCEOS_SPEC_DIR is
+    authoritative when set — no fallback, so a stray local checkout cannot make a
+    misconfigured CI run look like it verified something."""
     env = os.environ.get("SOURCEOS_SPEC_DIR")
     if env:
-        # AUTHORITATIVE when set: no fallback. An explicitly configured spec directory that
-        # does not contain the vectors is a misconfiguration, and falling back to a stray
-        # local checkout would let CI report agreement with a file it was not asked to read.
         return [Path(env)]
     return [
         Path(__file__).resolve().parents[5] / "sourceos-spec",   # dev tree sibling
@@ -59,20 +66,36 @@ def _spec_roots() -> list[Path]:
     ]
 
 
-def _spec_file(*parts: str) -> tuple[Path | None, list[Path]]:
-    looked = [r.joinpath(*parts) for r in _spec_roots()]
-    return next((p for p in looked if p.exists()), None), looked
-
-
-_CANDIDATES = [r / "conformance" / "lawful-verdict-vectors.json" for r in _spec_roots()]
+def _vendored(name: str) -> Path:
+    p = VENDORED / name
+    assert p.exists(), (
+        f"vendored conformance file missing: {p}. These are committed on purpose — see "
+        f"conformance/_provenance.json. Their absence is a packaging bug, never a reason to skip."
+    )
+    return p
 
 
 def _vectors() -> dict:
-    found, looked = _spec_file("conformance", "lawful-verdict-vectors.json")
-    if found:
-        return json.loads(found.read_text(encoding="utf-8"))
-    _unavailable("sourceos-spec conformance vectors", looked)
-    raise AssertionError("unreachable")
+    return json.loads(_vendored("lawful-verdict-vectors.json").read_text(encoding="utf-8"))
+
+
+def test_vendored_vectors_match_upstream() -> None:
+    """The drift check. Vendoring buys availability; only this buys freshness."""
+    prov = json.loads(_vendored("_provenance.json").read_text(encoding="utf-8"))
+    roots = _upstream_roots()
+    root = next((r for r in roots if (r / "conformance" / "lawful-verdict-vectors.json").exists()), None)
+    if root is None:
+        _unavailable("upstream sourceos-spec (vendored-copy drift check)", roots)
+        return
+    stale: list[str] = []
+    for name, meta in prov["files"].items():
+        upstream = root / meta["sourcePath"]
+        digest = "sha256:" + hashlib.sha256(upstream.read_bytes()).hexdigest()
+        if digest != meta["sha256"]:
+            stale.append(f"{name}: vendored {meta['sha256'][:20]}… upstream {digest[:20]}…")
+        assert hashlib.sha256(_vendored(name).read_bytes()).hexdigest() == digest.split(":")[1], \
+            f"{name}: vendored BYTES differ from upstream — re-vendor"
+    assert not stale, "vendored conformance artefacts are stale:\n  " + "\n  ".join(stale)
 
 
 # ── the shared vectors ──────────────────────────────────────────────────────────
@@ -118,15 +141,10 @@ def test_the_sealed_example_in_the_spec_verifies_against_this_implementation() -
     TypeScript canonicaliser by so much as key order or whitespace, this fails — which is
     exactly what we want it to catch, since a receipt sealed by one service must verify in
     another."""
-    found, looked = _spec_file("examples", "lawful-dispatch-receipt.example.json")
-    if found:
-        example = json.loads(found.read_text(encoding="utf-8"))
-        recorded = example["seal"].pop("attestation")
-        import hashlib
-        recomputed = "sha256:" + hashlib.sha256(canonical_json(example).encode()).hexdigest()
-        assert recomputed == recorded, "canonical-JSON seal disagrees across languages"
-        return
-    _unavailable("sourceos-spec example receipt (seal agreement)", looked)
+    example = json.loads(_vendored("lawful-dispatch-receipt.example.json").read_text(encoding="utf-8"))
+    recorded = example["seal"].pop("attestation")
+    recomputed = "sha256:" + hashlib.sha256(canonical_json(example).encode()).hexdigest()
+    assert recomputed == recorded, "canonical-JSON seal disagrees across languages"
 
 
 # ── the algebra, independent of the vector file ─────────────────────────────────
@@ -268,11 +286,11 @@ def test_receipts_validate_against_the_spec_schema_if_available() -> None:
     """Emit every one of the 9 product cells and validate each against the contract. This
     is the end-to-end claim: what this library produces is what the estate's schema
     accepts, for every reachable verdict — not just the happy path."""
-    found, looked = _spec_file("schemas", "LawfulDispatchReceipt.json")
-    if found:
+    if True:
         if True:
             jsonschema = pytest.importorskip("jsonschema")
-            validator = jsonschema.Draft202012Validator(json.loads(found.read_text(encoding="utf-8")))
+            validator = jsonschema.Draft202012Validator(
+                json.loads(_vendored("LawfulDispatchReceipt.json").read_text(encoding="utf-8")))
             seen: set[str] = set()
             cases = [
                 (_law(), _ev()),                                        # POS × POS
@@ -293,4 +311,3 @@ def test_receipts_validate_against_the_spec_schema_if_available() -> None:
                 seen.add(f"{law.factor}x{ev.factor}")
             assert len(seen) == 9, f"all 9 cells must be emitted and accepted, got {sorted(seen)}"
             return
-    _unavailable("sourceos-spec LawfulDispatchReceipt schema", looked)

--- a/libs/python/lawful-verdict/tests/test_conformance.py
+++ b/libs/python/lawful-verdict/tests/test_conformance.py
@@ -112,9 +112,15 @@ def test_vendored_vectors_match_upstream() -> None:
     """
     prov = json.loads(_vendored("_provenance.json").read_text(encoding="utf-8"))
     roots = _upstream_roots()
-    root = next((r for r in roots if (r / "conformance" / "lawful-verdict-vectors.json").exists()), None)
+    # Require EVERY provenance path, not just the vectors. Selecting a root on the
+    # strength of one file present, then reading three, turns an incomplete dev
+    # checkout into a FileNotFoundError stacktrace where the intended outcome is the
+    # explicit "UNVERIFIED" skip. Copilot caught this.
+    def _complete(r: Path) -> bool:
+        return all((r / m["sourcePath"]).exists() for m in prov["files"].values())
+    root = next((r for r in roots if _complete(r)), None)
     if root is None:
-        _unavailable("upstream sourceos-spec (vendored-copy drift check)", roots)
+        _unavailable("a COMPLETE upstream sourceos-spec (vendored-copy drift check)", roots)
         return
     stale: list[str] = []
     for name, meta in prov["files"].items():
@@ -494,3 +500,35 @@ def test_replay_still_allows_honest_under_claiming() -> None:
     e["seal"]["attestation"] = _seal(body)
     ok, _, reason = led.replay()
     assert ok, f"under-claiming must remain valid, got: {reason}"
+
+
+def test_an_incomplete_spec_checkout_skips_rather_than_stacktraces(tmp_path, monkeypatch) -> None:
+    """Copilot: the root was chosen because the VECTORS existed, then all three
+    provenance paths were read — so a checkout with vectors but no schemas/ raised
+    FileNotFoundError instead of reporting UNVERIFIED."""
+    partial = tmp_path / "sourceos-spec"
+    (partial / "conformance").mkdir(parents=True)
+    (partial / "conformance" / "lawful-verdict-vectors.json").write_bytes(b"{}")
+    monkeypatch.setenv("SOURCEOS_SPEC_DIR", str(partial))
+    # Skipped derives from BaseException, NOT Exception. The first version of this test
+    # used pytest.raises(Exception), so the Skipped propagated straight through and
+    # skipped THIS test — which then reported as a skip and asserted nothing at all.
+    # A test that cannot fail, arrived at by testing a skip. Catch the real type.
+    from _pytest.outcomes import Skipped
+    with pytest.raises(Skipped) as exc:
+        test_vendored_vectors_match_upstream()
+    assert "UNVERIFIED" in str(exc.value), f"wrong skip reason: {exc.value}"
+    assert "COMPLETE" in str(exc.value), "must name incompleteness as the cause"
+
+
+def test_replay_reason_does_not_echo_unbounded_attacker_text() -> None:
+    """Copilot: `reason` embedded str(exc) verbatim, and the entry is untrusted — so a
+    forger could push arbitrary volume into whatever consumes the reason."""
+    led = _sealed_ledger()
+    e = led.entries[0]
+    e["law"] = {"factor": "X" * 100_000, "source": "measured"}
+    _reseal(e)
+    ok, _, reason = led.replay()
+    assert ok is False
+    assert len(reason) < 1_000, f"reason is {len(reason)} chars — unbounded attacker text"
+    assert "chars)" in reason, "truncation must be visible, not silent"


### PR DESCRIPTION
> _Reconstructed body — an earlier `gh pr edit` invocation wrote an empty file, wiping the original. Content below is faithful to the shipped diff and prior review discussion; the technical content matches the code in this branch._

## The correction this makes

The estate's verdict algebra lived inside Noetica's `agent-machine`, where it was *also* unenforced: `verdict` was a caller-supplied field and all five call sites passed the literal `'POS'` (34 of 53 real entries recorded `grounded: false` in the same object). Two problems, and the second is the one this PR fixes:

1. It wasn't computed. — fixed in Noetica.
2. **It wasn't reachable.** Governance inside one app is governance one app can quietly drop, and no other service on the mesh could emit a governed verdict even if it wanted to.

This is the Python reference implementation for any service on the mesh — prophet-workspace, agora, ops-fabric-api, prophet-mesh agents:

```python
from lawful_verdict import LawFactor, EvidenceFactor, DispatchLedger

led = DispatchLedger()
led.append("urn:srcos:dispatch:0", ts, LawFactor(bar_cleared=True), ev,
           emitter="prophet-workspace/drive")
ok, validated, reason = led.replay()
```

## The algebra

`×` is the **meet** in the chain `NEG < ZERO < POS` — strong-Kleene conjunction, i.e. `min`. A three-element chain is a category, so that meet is the categorical product and the equation is an identity.

It is **not** sign multiplication in `{−1, 0, +1}`, which gives `NEG × NEG = POS`: a refused gate *and* a refuted outcome certifying as true. Pinned by its own named test.

## Nothing can be asserted

`Receipt.verdict` and `Receipt.evidence_tier` are **derived properties with no constructor parameters** — there is no field to fill with a literal.

- `law_verdict` — undischarged `residual` is **ZERO, not POS**: a bar that "cleared" while carrying constraints it could not discharge has *deferred*, not established.
- `evidence_verdict` — absent or malformed digests are **ZERO** (nothing shown, nothing refuted); `NEG` requires an actual refutation, so `refuted` is the one factor input a caller may legitimately set.
- `evidence_tier` — T1 only when both factors were measured.
- **`evidenceTier` is inside the seal** — flipping it after the fact requires re-attestation, so it cannot be quietly upgraded.

## Cross-language byte-for-byte

The canonical JSON writes non-ASCII **raw**, not `\uXXXX`-escaped, matching JavaScript's `JSON.stringify`. Sealed with the same 8-byte hex prefix over the same UTF-8 bytes Noetica uses, so a receipt sealed by one service verifies byte-identically in the other. The spec's sealed example receipt (sourceos-spec [#217](https://github.com/SourceOS-Linux/sourceos-spec/pull/217)) is one of the vectors in this suite. Every one of the 9 product cells (NEG/ZERO/POS × NEG/ZERO/POS) is emitted, sealed, and validated against the schema.

## Conformance runs unconditionally — and says what it does not cover

> **Superseded section.** This originally described a cross-repo checkout of sourceos-spec guarded by `LAWFUL_VERDICT_REQUIRE_VECTORS=1`. That approach was abandoned: prophet-platform (SocioProphet) and sourceos-spec (SourceOS-Linux) are in different orgs, so CI's `GITHUB_TOKEN` cannot read the spec and the job could only ever report UNVERIFIED. A conformance gate that depends on network access it does not have is not a gate.

Now: the conformance artefacts (vectors, sealed example, schema) are **vendored** into `libs/python/lawful-verdict/conformance/` with their upstream digests recorded in `_provenance.json`. The suite runs unconditionally against the vendored copy — the pytest `-rs` flag makes any skip visible in the log so it cannot silently disappear. A separate step (`Declare what this run did not verify`) posts an `::warning::` on every run naming what CI does not cover: **vendored-copy freshness against upstream `sourceos-spec`.** That check (`test_vendored_vectors_match_upstream`) runs wherever a dev checkout is reachable, and turns any drift into a hard failure under `LAWFUL_VERDICT_REQUIRE_VECTORS=1`. Vendored digest tampering is caught by a workflow step that recomputes each artefact's sha256 and compares to `_provenance.json`; it catches accidental corruption, bad merges, and half-finished re-vendors, but not a deliberate co-edit of file **and** its recorded digest — that residual is stated in the workflow comments.

## `DispatchLedger.replay()` fails closed

Replay validates a ledger by assumption **untrusted**. A malformed or tampered entry that raises must not stacktrace: it must return `(False, i, reason)`. Enforced through `_replay_entry` isolating the per-entry checks; the outer `replay()` catches any exception and reports a bounded, single-line reason. The failure reason itself is length-clipped (200 chars) so an attacker cannot smuggle unbounded text through the reason channel — same discipline as the exhaust-record bounds in `#1067`.

## Copilot round-1 & round-2 (both applied)

- `ensure_ascii=False` in `canonical_json` **and** in the vendored spec validator — was the seal-divergence trap for non-ASCII payloads.
- `truth_product` raises `ValueError` on non-verdict inputs with a message that names the likely legacy cause, rather than silently propagating `None` through the product.
- Nested `if True:` blocks in `test_conformance.py` removed (residue from a scripted edit).
- `_replay_entry` isolation + bounded reason — see above.
- `test_vendored_vectors_match_upstream` root selection now requires every provenance `sourcePath` to exist, so a partial dev checkout skips cleanly with `_unavailable(...)` instead of raising `FileNotFoundError`.

## Known gaps

- New package only (`libs/python/lawful-verdict/`) plus its workflow — no existing code touched.
- Matches the `libs/python` conventions (`pyproject.toml`, `Makefile`, `requirements-test.txt`, `pytest.ini` with `pythonpath = src`) and the `mount-intent.yml` CI shape.
- Cross-org drift check (`test_vendored_vectors_match_upstream`) skips in CI (GITHUB_TOKEN cannot read SourceOS-Linux/sourceos-spec); the workflow's `Declare what this run did not verify` step surfaces that limit as an `::warning::` on every run, and `REQUIRE_VECTORS=1` turns any drift into a hard failure in a dev tree. The conformance suite itself runs unconditionally against the vendored copy.
