### PR TITLE
health-twin: the de-identification boundary was still a 32-bit hash

### DIFF
--- a/apps/health-twin/src/deident.ts
+++ b/apps/health-twin/src/deident.ts
@@ -5,8 +5,76 @@
 // notes) are stripped; the subject becomes a stable pseudonym; clinical codes/values/units/tiers are
 // preserved (that is exactly what the reviewer needs). Non-diagnostic; synthetic data only.
 
-// deterministic pseudonym so the same subject maps to the same token within a scope (unlinkable to identity)
-function djb2(s: string): string { let h = 5381; for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff; return (h >>> 0).toString(16).padStart(8, '0'); }
+import { createHash, createHmac } from 'node:crypto';
+
+// ── PSEUDONYM DERIVATION ────────────────────────────────────────────────────────────────────────
+// The pseudonym was a 32-bit djb2 digest. Over PHI that is not a de-identification boundary: the
+// entire 2^32 output space enumerates in seconds, and distinct subjects start colliding by the
+// birthday bound at ~77k subjects — two people silently becoming one "anonymous" record.
+//
+// WHAT A WIDER DIGEST FIXES, AND WHAT IT DOES NOT — read this before trusting `anon:`.
+// SHA-256 truncated to 128 bits closes the OUTPUT space: you cannot find a second input that maps
+// to a given pseudonym, and you cannot enumerate the outputs. It does NOT close the INPUT space.
+// `salt` defaults to the literal 'default', and server.ts calls deidentify(bundle()) with no salt
+// at all, so on the default path the pseudonym is a pure function of a subject id. Subject ids are
+// low-entropy and guessable, and an attacker re-identifying by guessing never needed to invert the
+// hash — only to run it FORWARDS over candidate ids and compare. Against that attack a 256-bit
+// digest is worth exactly as much as a 32-bit one.
+//
+// A KEY is the only thing that closes the input space, so the derivation is HMAC-SHA256 whenever
+// HEALTH_TWIN_DEID_KEY is set: without the key the forward function cannot be computed at all, and
+// guessing the subject id stops being enough.
+//
+// THE FALLBACK IS REAL AND IT IS NOT PROTECTED. There is no key management in this service to
+// source a key from, so when the variable is unset the derivation falls back to unkeyed SHA-256,
+// warns once on stderr, and — the part that matters — RECORDS THE FACT in the de-id receipt
+// (`keyed: false`, `derivation: 'sha256'`). An unkeyed view is honestly labelled as unkeyed rather
+// than presented as protected. Treat unkeyed pseudonyms as pseudonymous-but-guessable, never as
+// anonymised, and do not release them outside a trust boundary that would also accept the raw ids.
+const DEID_KEY_VAR = 'HEALTH_TWIN_DEID_KEY';
+// read per call, not at import: a process may configure the key after this module loads, and the
+// invariants exercise both the keyed and unkeyed branches in one run.
+const deidKey = (): string => process.env[DEID_KEY_VAR] ?? '';
+
+let warnedUnkeyed = false;
+function warnIfUnkeyed(): void {
+  if (deidKey() || warnedUnkeyed) return;
+  warnedUnkeyed = true;
+  console.warn(
+    `[deident] ${DEID_KEY_VAR} is not set — pseudonyms are UNKEYED sha256. They are stable and ` +
+    'collision-resistant, but anyone who can GUESS a subject id can recompute the pseudonym and ' +
+    'confirm the guess. Receipts are marked keyed:false. Do not treat these views as anonymised.',
+  );
+}
+
+// Domain-separated derivation. The pseudonym and the date shift come from the SAME subject id and
+// salt, so they must not come from the same digest: sharing one would let anybody holding a
+// pseudonym solve for that view's date shift and undo the shifting (and vice-versa). The domain
+// tag is part of the hashed message, and the message is JSON-encoded so a '|' inside a subject id
+// cannot be re-parsed as a field boundary.
+function derive(domain: 'pseudonym' | 'dateshift', subjectId: string, salt: string): string {
+  const msg = JSON.stringify([domain, subjectId, salt]);
+  const key = deidKey();
+  warnIfUnkeyed();
+  return key
+    ? createHmac('sha256', key).update(msg).digest('hex')
+    : createHash('sha256').update(msg).digest('hex');
+}
+
+// 32 hex = 128 bits. The truncation is DELIBERATE, not an oversight: 128 bits is past any
+// collision or enumeration concern for a subject population, while keeping the token short enough
+// to appear in a UI, a URL and a reviewer's notes. The security limit on this value is the input
+// space described above, not these 128 bits — lengthening it would buy nothing.
+const PSEUDONYM_HEX = 32;
+
+// Date shift in [-183, +182] days, from 64 bits of the dateshift-domain digest.
+// BigInt, not parseInt: parseInt over a hex string longer than 13 digits silently exceeds 2^53 and
+// returns a rounded float, so the low bits — the ones the modulus actually consumes — are lost and
+// the "shift" degenerates toward a handful of values. BigInt is exact. Modulo bias over 2^64 into
+// 366 buckets is ~1e-17 and irrelevant here.
+function dateShiftFrom(digest: string): number {
+  return Number(BigInt(`0x${digest.slice(0, 16)}`) % 366n) - 183;
+}
 
 const shiftDate = (iso: string, days: number): string => {
   if (!iso || iso.length < 7) return iso;
@@ -22,6 +90,11 @@ export interface DeidReceipt {
   identifiersRemoved: string[]; // categories handled
   dateShiftDays: number;        // preserves intervals; absolute dates broken
   scope: DisclosureScope;       // the patient's agreed disclosure
+  // How the pseudonym was actually derived on THIS view. A receipt that reported a protection the
+  // run did not have would be worse than no receipt, so these are recorded from the live key state
+  // rather than from intent: `keyed: false` means a guessable subject id yields this pseudonym.
+  derivation: 'hmac-sha256' | 'sha256';
+  keyed: boolean;
   at: string;
 }
 
@@ -51,9 +124,13 @@ const NONDX = 'De-identified record for blinded review. Not a diagnosis; a clini
 // coarsened age-band + sex a doctor needs). The bundle is the shape returned by the engine's bundle().
 export function deidentify(bundle: any, salt = 'default', scope: DisclosureScope = 'standard'): DeidView {
   const subjectId = bundle?.subject?.id ?? 'subject';
-  const pseudonym = `anon:${djb2(`${subjectId}|${salt}`)}`;
-  // per-view deterministic date shift in [-183, +182] days — breaks absolute dates, preserves intervals
-  const dateShiftDays = (parseInt(djb2(`shift|${subjectId}|${salt}`), 16) % 366) - 183;
+  // `anon:` prefix is load-bearing — INVARIANT 1 asserts the subject was reduced to a pseudonym by
+  // testing for it. 32 hex of a domain-separated digest follows (see PSEUDONYM_HEX).
+  const pseudonym = `anon:${derive('pseudonym', subjectId, salt).slice(0, PSEUDONYM_HEX)}`;
+  // per-view deterministic date shift in [-183, +182] days — breaks absolute dates, preserves
+  // intervals. Separate domain, so holding the pseudonym does not reveal the shift.
+  const dateShiftDays = dateShiftFrom(derive('dateshift', subjectId, salt));
+  const keyed = deidKey().length > 0;
   const removed = new Set<string>();
 
   const systems = (bundle?.systems ?? []).map((s: any) => ({
@@ -94,7 +171,9 @@ export function deidentify(bundle: any, salt = 'default', scope: DisclosureScope
     disclaimer: NONDX,
     receipt: {
       method: 'safe-harbor+date-shift', pseudonym, identifiersRemoved: [...removed].sort(),
-      dateShiftDays, scope, at: new Date().toISOString(),
+      dateShiftDays, scope,
+      derivation: keyed ? 'hmac-sha256' : 'sha256', keyed,
+      at: new Date().toISOString(),
     } as DeidReceipt,
   };
 }

--- a/apps/health-twin/src/deident.ts
+++ b/apps/health-twin/src/deident.ts
@@ -32,13 +32,55 @@ import { createHash, createHmac } from 'node:crypto';
 // than presented as protected. Treat unkeyed pseudonyms as pseudonymous-but-guessable, never as
 // anonymised, and do not release them outside a trust boundary that would also accept the raw ids.
 const DEID_KEY_VAR = 'HEALTH_TWIN_DEID_KEY';
+
+// A key shorter than this is NOT a key for this purpose, and is refused rather than used.
+// The key exists to close the INPUT space — to make the forward function incomputable to someone
+// guessing subject ids. A one-character or whitespace key does not do that: it is enumerated as
+// fast as the subject ids are. Accepting it would still stamp `keyed: true` / `hmac-sha256` on the
+// receipt, and a reader who trusts that flag would be told the view is protected when it is not.
+// The receipt's single job is to never overstate, so a degenerate key is rejected and the run falls
+// back to the honest unkeyed path — labelled unkeyed, exactly like a missing key.
+// 16 bytes = 128 bits, matching the pseudonym width; below that the flag would outrun the fact.
+const MIN_DEID_KEY_BYTES = 16;
+
 // read per call, not at import: a process may configure the key after this module loads, and the
 // invariants exercise both the keyed and unkeyed branches in one run.
-const deidKey = (): string => process.env[DEID_KEY_VAR] ?? '';
+const rawDeidKey = (): string => process.env[DEID_KEY_VAR] ?? '';
+
+/**
+ * The EFFECTIVE key state for this call — one source of truth for both the derivation and the
+ * receipt. These were two independent reads of the environment, which meant the receipt reported
+ * what the environment said rather than what the derivation did; they agree today only because
+ * nothing can interleave between them. Deriving both from one value makes the receipt structurally
+ * unable to describe a derivation that did not happen.
+ */
+function keyState(): { key: string; keyed: boolean; rejected: boolean } {
+  const raw = rawDeidKey();
+  if (!raw) return { key: '', keyed: false, rejected: false };
+  if (Buffer.byteLength(raw, 'utf8') < MIN_DEID_KEY_BYTES) return { key: '', keyed: false, rejected: true };
+  return { key: raw, keyed: true, rejected: false };
+}
 
 let warnedUnkeyed = false;
+let warnedRejected = false;
 function warnIfUnkeyed(): void {
-  if (deidKey() || warnedUnkeyed) return;
+  const st = keyState();
+  if (st.keyed) return;
+  // A configured-but-refused key is a DIFFERENT operator situation from an unset one: somebody
+  // intended protection and did not get it, so it must not be reported with the same message an
+  // untouched deployment gets.
+  if (st.rejected) {
+    if (warnedRejected) return;
+    warnedRejected = true;
+    console.warn(
+      `[deident] ${DEID_KEY_VAR} is set but is shorter than the ${MIN_DEID_KEY_BYTES}-byte minimum — ` +
+      'it has been REFUSED, not used. A key this short does not close the guessing attack the key ' +
+      'exists to close, and using it would let the receipt claim keyed:true for a protection you do ' +
+      'not have. Falling back to UNKEYED sha256; receipts are marked keyed:false.',
+    );
+    return;
+  }
+  if (warnedUnkeyed) return;
   warnedUnkeyed = true;
   console.warn(
     `[deident] ${DEID_KEY_VAR} is not set — pseudonyms are UNKEYED sha256. They are stable and ` +
@@ -54,9 +96,9 @@ function warnIfUnkeyed(): void {
 // cannot be re-parsed as a field boundary.
 function derive(domain: 'pseudonym' | 'dateshift', subjectId: string, salt: string): string {
   const msg = JSON.stringify([domain, subjectId, salt]);
-  const key = deidKey();
+  const { key, keyed } = keyState();
   warnIfUnkeyed();
-  return key
+  return keyed
     ? createHmac('sha256', key).update(msg).digest('hex')
     : createHash('sha256').update(msg).digest('hex');
 }
@@ -130,7 +172,8 @@ export function deidentify(bundle: any, salt = 'default', scope: DisclosureScope
   // per-view deterministic date shift in [-183, +182] days — breaks absolute dates, preserves
   // intervals. Separate domain, so holding the pseudonym does not reveal the shift.
   const dateShiftDays = dateShiftFrom(derive('dateshift', subjectId, salt));
-  const keyed = deidKey().length > 0;
+  // the SAME predicate derive() just used — not a second look at the environment
+  const keyed = keyState().keyed;
   const removed = new Set<string>();
 
   const systems = (bundle?.systems ?? []).map((s: any) => ({

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -4,7 +4,7 @@
 // truth, leaking what should be blinded) become impossible to merge.
 import { SUBJECT, SYSTEMS, OBSERVATIONS, CONDITIONS, ENCOUNTERS, IMAGING } from './data.js';
 import { deidentify, identifierLeaks } from './deident.js';
-import { openConsult, submitOpinion, aggregate } from './consult.js';
+import { openConsult, submitOpinion, aggregate, requestMore } from './consult.js';
 import { patientSummaryCards, medReconciliationCards } from './cds/cds.js';
 import { emptyResult } from './ingest.js';
 
@@ -128,6 +128,7 @@ console.log('\n▶ INVARIANT 4 — grant scoping: the doctor sees exactly the gr
 // regression was fixed. An invariant that constructs its own subject cannot fail.
 //
 // These read the ids the code actually produces.
+console.log('\n▶ INVARIANT 5 — receipts EMITTED by the real code paths are cryptographic');
 {
   const consult = openConsult(sampleBundle, 'receipt-probe', 'standard', true);
   ok(/^consult-[0-9a-f]{64}$/.test(consult.consult_id ?? ''),
@@ -141,9 +142,74 @@ console.log('\n▶ INVARIANT 4 — grant scoping: the doctor sees exactly the gr
   ok(/^op-[0-9a-f]{64}$/.test(opinion.id ?? ''), 'opinion id is a real sha256');
   ok(/^ht-[a-z-]+-[0-9a-f]{64}$/.test(opinion.receipt?.id ?? ''), 'opinion receipt id is a real sha256');
 
-  // No id anywhere may be the old 8-hex djb2 shape.
-  const ids = [consult.consult_id, consult.receipt?.id, consult.consent?.receipt, opinion.id, opinion.receipt?.id];
-  ok(ids.every((i) => !/-[0-9a-f]{8}$/.test(String(i))), 'no id ends in an 8-hex (djb2) digest');
+  const more = requestMore(consult.consult_id!, 'medication list', 'need the full list') as any;
+  ok(/^more-[0-9a-f]{64}$/.test(more.id ?? ''), 'more-request id is a real sha256');
+
+  // aggregate() mints its own receipt and re-publishes every opinion's receipt id; both are checked
+  // on the value the function returns, not on a reconstruction of it.
+  const probeAgg = aggregate(consult.consult_id!) as any;
+  ok(/^ht-[a-z-]+-[0-9a-f]{64}$/.test(probeAgg.receipt?.id ?? ''),
+     'consult-aggregate receipt id is a real sha256');
+  ok(probeAgg.opinions.length > 0 && probeAgg.opinions.every((o: any) => /^ht-[a-z-]+-[0-9a-f]{64}$/.test(o.receipt)),
+     'every opinion receipt republished by aggregate is a real sha256');
+
+  // No id anywhere may be the old 8-hex djb2 shape. This is the check that would have caught
+  // the miss: it runs over EMITTED ids, so a djb2 call site cannot hide behind a passing suite.
+  const ids = [
+    consult.consult_id, consult.receipt?.id, consult.consent?.receipt,
+    opinion.id, opinion.receipt?.id, more.id, probeAgg.receipt?.id,
+    ...probeAgg.opinions.map((o: any) => o.receipt),
+  ];
+  ok(ids.every((i) => !/-[0-9a-f]{8}$/.test(String(i))), 'no emitted id ends in an 8-hex (djb2) digest');
+  ok(ids.every((i) => /-[0-9a-f]{64}$/.test(String(i))), `all ${ids.length} emitted ids carry a full 64-hex digest`);
+}
+
+console.log('\n▶ INVARIANT 8 — the de-identification boundary is cryptographic AND honestly labelled');
+// deident.ts derived the pseudonym over PHI with 32-bit djb2 — the same regression as the consult
+// receipts, but a re-identification risk rather than a receipt-integrity one, and it survived the
+// sweep because this file never wore a "sha-" label. Asserted on real deidentify() output.
+{
+  const v = deidentify(sampleBundle, 'deid-probe');
+  ok(/^anon:[0-9a-f]{32}$/.test(v.receipt.pseudonym),
+     `pseudonym is anon: + 32 hex / 128 bits (${v.receipt.pseudonym})`);
+  ok(!/^anon:[0-9a-f]{8}$/.test(v.receipt.pseudonym), 'pseudonym is NOT the old 8-hex djb2 token');
+  ok(v.subject.pseudonym === v.receipt.pseudonym, 'the view and its receipt carry the same pseudonym');
+
+  ok(deidentify(sampleBundle, 'deid-probe').receipt.pseudonym === v.receipt.pseudonym,
+     'same subject + same salt → same pseudonym (stable within a consult)');
+  ok(deidentify(sampleBundle, 'other-scope').receipt.pseudonym !== v.receipt.pseudonym,
+     'a different salt → a different pseudonym (consults stay unlinkable)');
+
+  // parseInt over >13 hex digits silently rounds past 2^53 and collapses the low bits the modulus
+  // consumes, so a broken derivation reaches only a few distinct values instead of the window.
+  const shifts = Array.from({ length: 400 }, (_, i) => deidentify(sampleBundle, `s${i}`).receipt.dateShiftDays);
+  ok(shifts.every((d) => Number.isInteger(d) && d >= -183 && d <= 182), 'every date shift is an integer in [-183, +182]');
+  ok(new Set(shifts).size > 200, `date shift spreads across the window (${new Set(shifts).size} distinct over 400 salts — a parseInt precision loss collapses this)`);
+
+  // domain separation: if both derivations shared one digest, deriving the shift FROM the pseudonym
+  // would reproduce it every time; with separation, all 8 agreeing is a (1/366)^8 event.
+  const allMatch = Array.from({ length: 8 }, (_, i) => `sep${i}`).every((salt) => {
+    const view = deidentify(sampleBundle, salt);
+    const fromPseudonym = Number(BigInt(`0x${view.receipt.pseudonym.slice(5, 21)}`) % 366n) - 183;
+    return fromPseudonym === view.receipt.dateShiftDays;
+  });
+  ok(!allMatch, 'date shift is domain-separated from the pseudonym (not derivable from it)');
+
+  // The receipt must not claim a protection the run did not have. Both branches are exercised so a
+  // receipt hard-coded to keyed:true — the failure mode that matters — cannot pass.
+  const KEY = 'HEALTH_TWIN_DEID_KEY';
+  const saved = process.env[KEY];
+  delete process.env[KEY];
+  const unkeyed = deidentify(sampleBundle, 'deid-probe');
+  ok(unkeyed.receipt.keyed === false && unkeyed.receipt.derivation === 'sha256',
+     'with no key configured the receipt declares keyed:false / sha256 — it does not overstate');
+  process.env[KEY] = 'invariant-test-key';
+  const keyed = deidentify(sampleBundle, 'deid-probe');
+  ok(keyed.receipt.keyed === true && keyed.receipt.derivation === 'hmac-sha256',
+     'with a key configured the receipt declares keyed:true / hmac-sha256');
+  ok(keyed.receipt.pseudonym !== unkeyed.receipt.pseudonym,
+     'the key actually enters the derivation (keyed pseudonym ≠ unkeyed pseudonym)');
+  if (saved === undefined) delete process.env[KEY]; else process.env[KEY] = saved;
 }
 
 

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -199,17 +199,42 @@ console.log('\n▶ INVARIANT 8 — the de-identification boundary is cryptograph
   // receipt hard-coded to keyed:true — the failure mode that matters — cannot pass.
   const KEY = 'HEALTH_TWIN_DEID_KEY';
   const saved = process.env[KEY];
-  delete process.env[KEY];
-  const unkeyed = deidentify(sampleBundle, 'deid-probe');
-  ok(unkeyed.receipt.keyed === false && unkeyed.receipt.derivation === 'sha256',
-     'with no key configured the receipt declares keyed:false / sha256 — it does not overstate');
-  process.env[KEY] = 'invariant-test-key';
-  const keyed = deidentify(sampleBundle, 'deid-probe');
-  ok(keyed.receipt.keyed === true && keyed.receipt.derivation === 'hmac-sha256',
-     'with a key configured the receipt declares keyed:true / hmac-sha256');
-  ok(keyed.receipt.pseudonym !== unkeyed.receipt.pseudonym,
-     'the key actually enters the derivation (keyed pseudonym ≠ unkeyed pseudonym)');
-  if (saved === undefined) delete process.env[KEY]; else process.env[KEY] = saved;
+  // try/finally: this block mutates a process-wide variable that changes how PHI is de-identified.
+  // Restoring it only on the happy path would leave every later invariant running under a key state
+  // it did not choose, and a de-id failure would then be attributed to the wrong cause.
+  try {
+    delete process.env[KEY];
+    const unkeyed = deidentify(sampleBundle, 'deid-probe');
+    ok(unkeyed.receipt.keyed === false && unkeyed.receipt.derivation === 'sha256',
+       'with no key configured the receipt declares keyed:false / sha256 — it does not overstate');
+    process.env[KEY] = 'invariant-test-key-32-bytes-long';
+    const keyed = deidentify(sampleBundle, 'deid-probe');
+    ok(keyed.receipt.keyed === true && keyed.receipt.derivation === 'hmac-sha256',
+       'with a key configured the receipt declares keyed:true / hmac-sha256');
+    ok(keyed.receipt.pseudonym !== unkeyed.receipt.pseudonym,
+       'the key actually enters the derivation (keyed pseudonym ≠ unkeyed pseudonym)');
+
+    // A DEGENERATE KEY MUST NOT BUY THE keyed:true LABEL.
+    // The receipt's only job is to never overstate protection. The key is there to close the
+    // guessing attack; a one-character or whitespace key does not close it, so stamping
+    // keyed:true / hmac-sha256 for one would tell a reader the view is protected when it is not.
+    // Such a key is refused and the run falls back to the honest unkeyed path.
+    for (const weak of [' ', 'x', 'short', '\t\n', 'fifteen-bytes!']) {
+      process.env[KEY] = weak;
+      const r = deidentify(sampleBundle, 'deid-probe').receipt;
+      ok(r.keyed === false && r.derivation === 'sha256',
+         `a ${Buffer.byteLength(weak)}-byte key is refused, not reported as protection (${JSON.stringify(weak)} → keyed:${r.keyed})`);
+      ok(r.pseudonym === unkeyed.receipt.pseudonym,
+         `a refused key really is unused — the pseudonym is the unkeyed one (${JSON.stringify(weak)})`);
+    }
+    // and the boundary is where it says it is: 16 bytes is accepted
+    process.env[KEY] = 'sixteen-bytes-16';
+    const atMin = deidentify(sampleBundle, 'deid-probe').receipt;
+    ok(Buffer.byteLength('sixteen-bytes-16') === 16 && atMin.keyed === true && atMin.derivation === 'hmac-sha256',
+       'a key at the 16-byte minimum IS accepted (the floor is a floor, not a moving refusal)');
+  } finally {
+    if (saved === undefined) delete process.env[KEY]; else process.env[KEY] = saved;
+  }
 }
 
 


### PR DESCRIPTION
Mirror half of SocioProphet/prophet-health#5. **Do not merge before it** — prophet-health is the source of truth.

## What was still broken here

#1036 fixed the consult receipts in this repo. `deident.ts` was never fixed, **in either repo** — it never wore the `sha-` label the original sweep matched on, so it kept deriving the patient pseudonym with djb2:

```
anon:${djb2(`${subjectId}|${salt}`)}                          // 32 bits over PHI
const dateShiftDays = (parseInt(djb2(...), 16) % 366) - 183;
```

Over PHI that is a re-identification risk rather than a receipt-integrity one: the whole 2^32 output space enumerates in seconds, and distinct subjects start colliding by the birthday bound around 77k — two people silently becoming one "anonymous" record.

## Changes

`deident.ts` is ported **byte-for-byte** from prophet-health:

- domain-separated derivation (`pseudonym` vs `dateshift`), so holding a pseudonym cannot be solved for that view's date shift or the reverse
- pseudonym = **32 hex / 128 bits**, a deliberate documented truncation
- date shift over 64 bits via **BigInt** — `parseInt` on more than 13 hex digits silently rounds past 2^53 and drops the low bits the modulus consumes
- `anon:` prefix kept (INVARIANT 1 asserts it)

**HMAC-SHA256 when `HEALTH_TWIN_DEID_KEY` is set; honest unkeyed fallback when it is not.** Widening the digest closes the output space, not the input space: `salt` defaults to the literal `'default'` and `server.ts` calls `deidentify(bundle())` with no salt, so anyone who can guess a subject id recomputes the pseudonym by running the function **forwards**. No digest width prevents that; only a key does. There is no key management here to source one from, so unkeyed stays the default path — it warns once on stderr and records `keyed: false` / `derivation: 'sha256'` in the de-id receipt. An unkeyed view is labelled unkeyed, not presented as protected.

`invariants.ts`:
- **INVARIANT 8** (new) asserts the above on real `deidentify()` output, exercising **both** key branches so a receipt hard-coded to `keyed:true` cannot pass
- **INVARIANT 5** gains the `aggregate()` and `requestMore()` emissions the earlier pass did not cover, and is now labelled

## Not synced — hand-applied

`prophet-health/scripts/sync-to-platform.sh` was **not** run. It does `rsync -a --delete`, and against the current trees it would have:

- **deleted** `exposure.ts` and all seven `dynamics/` files (they exist only here)
- **reverted** #1033, #1036 and #1038
- clobbered the `image:` tag `gitops-promote[bot]` owns, via `deploy/values/health-twin.yaml`

Worth noting for anyone auditing that drift: `diff -rq` **under-reports** it — it missed `dynamics/` and `eval.ts` entirely. The comparison above was done with a node walker over sha256 of every file.

Remaining intentional drift after this PR: `exposure.ts`, `dynamics/*`, and the `eval.ts` / `server.ts` / `invariants.ts` sections that carry them. Those are platform-only features, out of scope here, and must survive any future sync.

## Verification

`npx tsx src/invariants.ts` → **exit 0** (INVARIANTS 1–8, including exposure and twin-dynamics). `npx tsx src/eval.ts` → **exit 0**.

The pseudonym produced here is byte-identical to the one prophet-health produces for the same input (`anon:63338a9fdad34ef786f20a89946a7e6c`), confirming the two derivations have not drifted.