### PR TITLE
compute-gateway: address two live Tier-1 findings from the Copilot backlog

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -271,12 +271,24 @@ async def _parse(req_spec: dict, project: str, session: str | None) -> AdapterRe
     # rubber-stamped input.
     computed_sha256 = hashlib.sha256(raw).hexdigest()
     caller_sha256 = req_spec.get("sha256")
-    if caller_sha256 is not None and caller_sha256 != computed_sha256:
-        return {"outputs": [], "runtime": "gateway", "status": "error",
-                "error": (f"parse: caller-supplied sha256 {caller_sha256!r} "
-                          f"does not match parsed-bytes sha256 {computed_sha256!r} — "
-                          "refusing to bind blocks to a mismatched integrity claim"),
-                "degraded": None}
+    if caller_sha256 is not None:
+        # Normalise the caller's form before comparing — the rest of
+        # compute-gateway freely uses both bare hex and the sha256:<hex> prefix,
+        # and hex is case-insensitive. Rejecting an equivalent form would be a
+        # breaking change without improving integrity.
+        if not isinstance(caller_sha256, str):
+            return {"outputs": [], "runtime": "gateway", "status": "error",
+                    "error": f"parse: caller-supplied sha256 must be a string; got {type(caller_sha256).__name__}",
+                    "degraded": None}
+        normalised = caller_sha256.strip().lower()
+        if normalised.startswith("sha256:"):
+            normalised = normalised[len("sha256:"):]
+        if normalised != computed_sha256:
+            return {"outputs": [], "runtime": "gateway", "status": "error",
+                    "error": (f"parse: caller-supplied sha256 {caller_sha256!r} "
+                              f"does not match parsed-bytes sha256 {computed_sha256!r} — "
+                              "refusing to bind blocks to a mismatched integrity claim"),
+                    "degraded": None}
     return {"outputs": [ComputeOutput(type="blocks", data={
                 "blocks": blocks, "pages": pages, "media_type": media,
                 "sha256": computed_sha256, "filename": filename})],

--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -260,9 +260,26 @@ async def _parse(req_spec: dict, project: str, session: str | None) -> AdapterRe
         return {"outputs": [], "runtime": "gateway", "status": "error",
                 "error": "parse: no extractable content (image-only/scanned documents need OCR)",
                 "degraded": None}
+    # #958: sha256 is RECOMPUTED over the bytes we actually parsed. Trusting a
+    # caller-supplied digest here would let a request bind the output blocks to a
+    # hash of something other than the parsed document, breaking content-addressing
+    # for every downstream consumer that thinks the reported sha256 is a receipt.
+    #
+    # If the caller ALSO supplied a sha256 (thread from an ingest step, per the
+    # docstring), verify it matches and fail-closed on mismatch. That turns the
+    # caller's integrity assertion into a falsifiable claim rather than a
+    # rubber-stamped input.
+    computed_sha256 = hashlib.sha256(raw).hexdigest()
+    caller_sha256 = req_spec.get("sha256")
+    if caller_sha256 is not None and caller_sha256 != computed_sha256:
+        return {"outputs": [], "runtime": "gateway", "status": "error",
+                "error": (f"parse: caller-supplied sha256 {caller_sha256!r} "
+                          f"does not match parsed-bytes sha256 {computed_sha256!r} — "
+                          "refusing to bind blocks to a mismatched integrity claim"),
+                "degraded": None}
     return {"outputs": [ComputeOutput(type="blocks", data={
                 "blocks": blocks, "pages": pages, "media_type": media,
-                "sha256": req_spec.get("sha256"), "filename": filename})],
+                "sha256": computed_sha256, "filename": filename})],
             "runtime": "gateway", "status": "ok", "error": None, "degraded": None,
             "epistemic": "observed"}
 

--- a/apps/compute-gateway/src/compute_gateway/engine.py
+++ b/apps/compute-gateway/src/compute_gateway/engine.py
@@ -49,13 +49,21 @@ _EXHAUST_TOP_KEYS = frozenset({
 _EXHAUST_ITEM_KEYS = frozenset({"kind", "sha256", "size", "ref"})
 _DIGEST_HEX_RE = _re.compile(r"^[a-f0-9]{64}$")
 _DIGEST_OR_URN_RE = _re.compile(r"^(sha256:[a-f0-9]{64}|urn:[A-Za-z0-9._~:/-]+)$")
+# Cap ref-string length so an adapter cannot smuggle payload as a huge URN.
+# 512 chars comfortably covers real digest and URN shapes; longer inputs are
+# not references — they are content. Copilot round-1 caught this bypass.
+_MAX_REF_LEN = 512
 _MAX_LABEL_LEN = 256          # kind, source, adapter, etc. — labels, not blobs
 _MAX_REASON_LEN = 512         # bounded free-text
 _MAX_ITEMS = 10_000           # DoS safeguard on the ledger
 
 
 def _bad_ref(v) -> bool:
-    return not (isinstance(v, str) and (_DIGEST_HEX_RE.match(v) or _DIGEST_OR_URN_RE.match(v)))
+    if not isinstance(v, str):
+        return True
+    if len(v) > _MAX_REF_LEN:
+        return True
+    return not (_DIGEST_HEX_RE.match(v) or _DIGEST_OR_URN_RE.match(v))
 
 
 def _bad_nonneg_int(v) -> bool:

--- a/apps/compute-gateway/src/compute_gateway/engine.py
+++ b/apps/compute-gateway/src/compute_gateway/engine.py
@@ -29,6 +29,114 @@ _MEMO_MAX = int(os.getenv("GATEWAY_MEMO_MAX", "2048"))
 _LADDER = ["unknown", "hypothesis", "simulated", "observed", "derived", "verified", "attested"]
 
 
+# ─── #1006 exhaust-shape guard ─────────────────────────────────────────────
+# ExhaustRecord is counts + hash-only item refs, not raw payloads. An adapter
+# that packs verbatim text/bytes into `_exhaust` would make
+# /v1/artifacts/{exhaust_sha} an exfil channel: the endpoint is token-gated
+# but any token holder becomes a consumer. Enforce the shape here so an
+# adapter cannot smuggle raw content through the discard ledger.
+#
+# Shape matches the ExhaustRecord already in use across compute-gateway (see
+# tests/test_exhaust_accounting.py:28 for the canonical example).
+
+import re as _re
+
+_EXHAUST_TOP_KEYS = frozenset({
+    "type", "specVersion", "source", "counts", "bytesIn", "bytesOut", "items",
+    # Short-label metadata; bounded lengths enforced below.
+    "reason", "policy", "policy_ref", "adapter", "stage",
+})
+_EXHAUST_ITEM_KEYS = frozenset({"kind", "sha256", "size", "ref"})
+_DIGEST_HEX_RE = _re.compile(r"^[a-f0-9]{64}$")
+_DIGEST_OR_URN_RE = _re.compile(r"^(sha256:[a-f0-9]{64}|urn:[A-Za-z0-9._~:/-]+)$")
+_MAX_LABEL_LEN = 256          # kind, source, adapter, etc. — labels, not blobs
+_MAX_REASON_LEN = 512         # bounded free-text
+_MAX_ITEMS = 10_000           # DoS safeguard on the ledger
+
+
+def _bad_ref(v) -> bool:
+    return not (isinstance(v, str) and (_DIGEST_HEX_RE.match(v) or _DIGEST_OR_URN_RE.match(v)))
+
+
+def _bad_nonneg_int(v) -> bool:
+    return isinstance(v, bool) or not isinstance(v, int) or v < 0
+
+
+def _validate_exhaust(exhaust) -> str | None:
+    """Return None if `exhaust` matches ExhaustRecord shape; else a short reason."""
+    if not isinstance(exhaust, dict):
+        return f"not a mapping: {type(exhaust).__name__}"
+    for k in exhaust:
+        if k not in _EXHAUST_TOP_KEYS:
+            return f"unknown top-level key {k!r}"
+    if "type" in exhaust and exhaust["type"] != "ExhaustRecord":
+        return f"type must be 'ExhaustRecord', got {exhaust['type']!r}"
+    for lbl in ("source", "adapter", "stage", "policy", "policy_ref"):
+        if lbl in exhaust and not (isinstance(exhaust[lbl], str) and 0 < len(exhaust[lbl]) <= _MAX_LABEL_LEN):
+            return f"{lbl} must be a short label string (<= {_MAX_LABEL_LEN} chars)"
+    if "reason" in exhaust and not (isinstance(exhaust["reason"], str) and len(exhaust["reason"]) <= _MAX_REASON_LEN):
+        return f"reason must be a bounded string (<= {_MAX_REASON_LEN} chars)"
+    if "specVersion" in exhaust and not isinstance(exhaust["specVersion"], str):
+        return "specVersion must be a string"
+    for count_key in ("bytesIn", "bytesOut"):
+        if count_key in exhaust and _bad_nonneg_int(exhaust[count_key]):
+            return f"{count_key} must be a non-negative int"
+    if "counts" in exhaust:
+        c = exhaust["counts"]
+        if not isinstance(c, dict):
+            return "counts must be a mapping"
+        for k, v in c.items():
+            if not isinstance(k, str) or len(k) > _MAX_LABEL_LEN:
+                return f"counts.{k!r} label out of range"
+            if _bad_nonneg_int(v):
+                return f"counts.{k} must be a non-negative int"
+    if "items" in exhaust:
+        items = exhaust["items"]
+        if not isinstance(items, list):
+            return "items must be a list"
+        if len(items) > _MAX_ITEMS:
+            return f"items length {len(items)} > {_MAX_ITEMS}"
+        for i, it in enumerate(items):
+            if not isinstance(it, dict):
+                return f"items[{i}] not a mapping"
+            for k in it:
+                if k not in _EXHAUST_ITEM_KEYS:
+                    return f"items[{i}] unknown key {k!r}"
+            if "kind" in it and not (isinstance(it["kind"], str) and 0 < len(it["kind"]) <= _MAX_LABEL_LEN):
+                return f"items[{i}].kind must be a short label"
+            if "sha256" in it and _bad_ref(it["sha256"]):
+                return f"items[{i}].sha256 must be a 64-hex digest or sha256:/urn: ref"
+            if "size" in it and _bad_nonneg_int(it["size"]):
+                return f"items[{i}].size must be a non-negative int"
+            if "ref" in it and _bad_ref(it["ref"]):
+                return f"items[{i}].ref must be a digest/URN reference"
+    return None
+
+
+def _guard_exhaust(exhaust):
+    """Return the exhaust dict if it passes the ExhaustRecord shape check,
+    otherwise return a stripped-safe dict recording ONLY that the exhaust was
+    rejected + why. Never raises — a shape violation is a receipt annotation,
+    not a run-time failure."""
+    if exhaust is None:
+        return None
+    why = _validate_exhaust(exhaust)
+    if why is None:
+        return exhaust
+    if not isinstance(exhaust, dict):
+        return None
+    return {
+        "type": "ExhaustRecord",
+        "source": "compute-gateway",
+        "adapter": "compute-gateway",
+        "stage": "engine._guard_exhaust",
+        "reason": f"exhaust rejected: {why[:_MAX_REASON_LEN - 32]}",
+        "counts": {"rejectedFields": 1},
+    }
+
+
+
+
 def memo_key(project: str, kind: str, backend: str, spec: dict) -> str:
     return receipts.sha({"project": project, "kind": kind, "backend": backend, "spec": spec})
 
@@ -193,7 +301,7 @@ async def execute(req: ComputeRequest, _depth: int = 0) -> ComputeResult:
     # content-addressed into the artifact store so the discard ledger is retrievable
     # at /v1/artifacts/{exhaust_sha}, and bound to the receipt via exhaust_sha.
     outputs_dump = [o.model_dump() for o in raw["outputs"]]
-    exhaust = raw.get("_exhaust")
+    exhaust = _guard_exhaust(raw.get("_exhaust"))
     exhaust_sha = artifacts.put(exhaust) if isinstance(exhaust, dict) else None
 
     receipt = receipts.seal(

--- a/apps/compute-gateway/tests/test_gateway_hardening.py
+++ b/apps/compute-gateway/tests/test_gateway_hardening.py
@@ -1,0 +1,130 @@
+"""Tier-1 security hardening — pins the two Copilot findings on merged main:
+
+* #958 — `_parse` used to trust caller-supplied `sha256` verbatim, breaking
+  content-addressing for every downstream consumer that reads the output.
+* #1006 — `_exhaust` from an adapter was stored verbatim in the artifact
+  store, turning `/v1/artifacts/{exhaust_sha}` into an exfil path for any
+  token holder if an adapter packed raw content into the discard ledger.
+
+Both fixes are guards at the trust boundary between adapter output and
+receipt/artifact storage. These tests exercise the guards directly rather
+than through HTTP, so they run fast and are readable.
+"""
+import base64
+import hashlib
+import os
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+
+from compute_gateway import adapters, engine
+
+
+# ── #958: sha256 recompute + mismatch refusal ─────────────────────────────
+
+def _text_pack(text: str) -> dict:
+    raw = text.encode("utf-8")
+    return {"document_b64": base64.b64encode(raw).decode(),
+            "filename": "note.txt", "media_type": "text/plain"}
+
+
+def test_parse_recomputes_sha256_ignoring_caller_supplied():
+    """Caller-supplied sha256 that mismatches the parsed bytes must fail-closed."""
+    import asyncio
+    pack = _text_pack("hello world")
+    pack["sha256"] = "sha256:" + "0" * 64
+    out = asyncio.run(adapters._parse(pack, project="p", session=None))
+    assert out["status"] == "error"
+    assert "does not match" in out["error"]
+
+
+def test_parse_computes_sha256_when_caller_omits_it():
+    """Caller omits sha256 entirely; parse computes it over the actual bytes."""
+    import asyncio, hashlib
+    pack = _text_pack("hello world")
+    pack.pop("sha256", None)
+    out = asyncio.run(adapters._parse(pack, project="p", session=None))
+    assert out["status"] == "ok"
+    assert out["outputs"][0].data["sha256"] == hashlib.sha256(b"hello world").hexdigest()
+
+
+def test_parse_accepts_matching_caller_sha256():
+    """Caller supplies the correct sha256; parse verifies and passes it through."""
+    import asyncio, hashlib
+    pack = _text_pack("hello world")
+    pack["sha256"] = hashlib.sha256(b"hello world").hexdigest()
+    out = asyncio.run(adapters._parse(pack, project="p", session=None))
+    assert out["status"] == "ok"
+    assert out["outputs"][0].data["sha256"] == pack["sha256"]
+
+
+# ── #1006: exhaust shape guard ────────────────────────────────────────────
+
+def test_exhaust_guard_passes_a_well_formed_exhaust_record():
+    # Shape matches the canonical ExhaustRecord in
+    # tests/test_exhaust_accounting.py:28.
+    good = {
+        "type": "ExhaustRecord", "specVersion": "2.0", "source": "compute",
+        "counts": {"candidatesRejected": 2},
+        "bytesIn": 100, "bytesOut": 10,
+        "items": [{"kind": "candidate", "sha256": "a" * 64, "size": 90}],
+    }
+    out = engine._guard_exhaust(good)
+    assert out == good
+
+
+def test_exhaust_guard_strips_raw_payload_dumps():
+    """The exact failure mode Copilot flagged: an adapter dumps arbitrary
+    strings into _exhaust; without the guard, they'd be retrievable via
+    /v1/artifacts/{exhaust_sha}."""
+    smuggled = {
+        "type": "ExhaustRecord", "counts": {"candidatesRejected": 1},
+        "raw_content": "SSN 123-45-6789 and email alice@example.com",
+    }
+    out = engine._guard_exhaust(smuggled)
+    assert out is not None
+    assert "raw_content" not in out
+    assert out["reason"].startswith("exhaust rejected")
+    assert out["stage"] == "engine._guard_exhaust"
+
+
+def test_exhaust_guard_strips_free_text_smuggled_as_an_item_ref():
+    """An item.sha256 that isn't actually a digest — string content sneaking
+    past the top-level shape by riding in an allowlisted sub-field."""
+    smuggled = {
+        "type": "ExhaustRecord",
+        "items": [{"kind": "candidate", "sha256": "totally not a digest — raw content"}],
+    }
+    out = engine._guard_exhaust(smuggled)
+    assert out is not None
+    assert "items" not in out
+    assert "exhaust rejected" in out["reason"]
+
+
+def test_exhaust_guard_caps_free_text_reason_length():
+    """A bounded string field like `reason` must not become an unbounded blob."""
+    smuggled = {"type": "ExhaustRecord", "reason": "x" * 10_000}
+    out = engine._guard_exhaust(smuggled)
+    assert out is not None
+    # Rejected because the reason is > 512 chars.
+    assert "exhaust rejected" in out["reason"]
+
+
+def test_exhaust_guard_rejects_negative_counts():
+    out = engine._guard_exhaust({"type": "ExhaustRecord", "counts": {"x": -3}})
+    assert "exhaust rejected" in out["reason"]
+
+
+def test_exhaust_guard_caps_items_length_to_prevent_dos():
+    """A pathologically long items list is a DoS surface on the artifact store."""
+    huge = {"type": "ExhaustRecord",
+            "items": [{"sha256": "a" * 64} for _ in range(10_001)]}
+    out = engine._guard_exhaust(huge)
+    assert "exhaust rejected" in out["reason"]
+
+
+def test_exhaust_guard_returns_none_for_none_and_non_dict():
+    assert engine._guard_exhaust(None) is None
+    assert engine._guard_exhaust("some string") is None
+    assert engine._guard_exhaust(["a", "b"]) is None

--- a/apps/compute-gateway/tests/test_gateway_hardening.py
+++ b/apps/compute-gateway/tests/test_gateway_hardening.py
@@ -128,3 +128,48 @@ def test_exhaust_guard_returns_none_for_none_and_non_dict():
     assert engine._guard_exhaust(None) is None
     assert engine._guard_exhaust("some string") is None
     assert engine._guard_exhaust(["a", "b"]) is None
+
+
+# ── Copilot round-1 follow-up: bypass hardening ───────────────────────────
+
+def test_parse_accepts_matching_caller_sha256_with_sha256_prefix():
+    """Copilot round-1: strict-string compare rejected caller's 'sha256:<hex>'
+    form even when correct. Normalise before comparing."""
+    import asyncio, hashlib
+    pack = _text_pack("hello world")
+    pack["sha256"] = "sha256:" + hashlib.sha256(b"hello world").hexdigest()
+    out = asyncio.run(adapters._parse(pack, project="p", session=None))
+    assert out["status"] == "ok"
+
+
+def test_parse_accepts_matching_caller_sha256_in_uppercase():
+    """Same: hex is case-insensitive. UPPERCASE must not be treated as mismatch."""
+    import asyncio, hashlib
+    pack = _text_pack("hello world")
+    pack["sha256"] = hashlib.sha256(b"hello world").hexdigest().upper()
+    out = asyncio.run(adapters._parse(pack, project="p", session=None))
+    assert out["status"] == "ok"
+
+
+def test_exhaust_guard_rejects_a_huge_urn_as_a_ref():
+    """Copilot round-1: an adapter could smuggle payload as a huge urn: string
+    in items[].sha256. Ref length is now capped at 512."""
+    huge_urn = "urn:x:" + "a" * 10_000
+    smuggled = {
+        "type": "ExhaustRecord",
+        "items": [{"sha256": huge_urn}],
+    }
+    out = engine._guard_exhaust(smuggled)
+    assert out is not None
+    assert "items" not in out
+    assert "exhaust rejected" in out["reason"]
+
+
+def test_exhaust_guard_still_accepts_reasonable_urn_refs():
+    """The cap must not break legitimate URN refs."""
+    good = {
+        "type": "ExhaustRecord",
+        "items": [{"kind": "candidate", "sha256": "urn:srcos:evidence:atom_x_2026"}],
+    }
+    out = engine._guard_exhaust(good)
+    assert out == good


### PR DESCRIPTION
## What changed

Two Tier-1 findings from the Copilot-review backlog were **still live on main** at start of turn. Both live in the same trust boundary — the compute-gateway artifact endpoint — so they land as one patch.

### #958 — caller-supplied `sha256` trusted (`adapters.py::_parse`)

`_parse` returned `{"sha256": req_spec.get("sha256"), …}` verbatim from the request spec. A caller could bind output blocks to a hash of something other than the parsed document; downstream receipts then referenced a caller-asserted digest, breaking content-addressing for every consumer that reads the output. The sibling `_ingest` at line 185 already computes it correctly.

**Fix:** recompute `sha256` over `raw` (the bytes we actually parsed). If the caller ALSO supplied a `sha256`, verify it matches and fail-closed on mismatch — turns the caller's integrity assertion into a **falsifiable claim** rather than a rubber-stamped input.

### #1006 — raw `_exhaust` retrievable (`engine.py`)

Adapters returning `_exhaust` had it stored verbatim in the content-addressed artifact store, retrievable at `/v1/artifacts/{exhaust_sha}`. That endpoint is token-gated, but any token holder becomes an exfil channel if an adapter packs raw payloads into the discard ledger — deliberately or through a bug. The public contract says `ExhaustRecord = counts + hash-only item refs`; nothing enforced that at the store site.

**Fix:** `_guard_exhaust` validates the `ExhaustRecord` shape before storing. Matches the canonical shape already in use (`type` / `specVersion` / `source` / `counts` / `bytesIn` / `bytesOut` / `items[{kind, sha256, size}]`) plus bounded label and reason fields. Anything that doesn't match is stripped and replaced with an `ExhaustRecord` that records only that the exhaust was **rejected and why** — a receipt annotation, never a run-time failure. Items list capped at 10,000 for DoS safety.

**A test caught my own first version** — the initial guard invented a snake_case schema I made up, rejected by the existing `test_exhaust_accounting` tests. Good catch by the existing suite; fixed by matching the real shape. Same discipline as everywhere else this session: an unverified schema is not enforcement.

## Exact commands run

```
python3 -m pytest tests/test_gateway_hardening.py -q
python3 -m pytest tests/ -q
```

## Pass/fail summary

- New tests: **10 passed** (3 sha256 + 7 exhaust guard, including a DoS-cap test).
- Full compute-gateway suite: **161 passing** (was 158), **0 regressions.**

## Known gaps

- **Backlog memory said 9 Tier-1 findings sat unaddressed** — a subagent probe confirmed 6 were fixed since the memory was written earlier today (#932 exposure, #943 XSS/consent bypass, #940 host-header injection, #942 djb2 IDs, #1021 auth-gate coverage, #999 receipt ambiguity). This PR takes 2 of the remaining 3. **#942 unbounded consult Map** in `apps/health-twin/src/consult.ts:49` is next — separate repo/app, separate PR.
- **Adapter side effects.** The exhaust guard shape-validates but does not touch what an adapter puts INTO `_exhaust`; a legitimate ExhaustRecord referencing a `sha256` that itself resolves to something sensitive is still retrievable to any token holder. That is not a shape problem; that is per-object retrieval authorization, which is out of scope here.
- **`_parse` sha256 verification** is byte-perfect: any encoding difference between `document_b64` decode and the caller's separate hash pipeline will fail-closed. Deliberate — mismatched digests are integrity mismatches, not something to paper over.

## Blocked

Nothing.