### PR TITLE
health-twin: bound the in-memory consult ledger + closeConsult() (closes #942)

### DIFF
--- a/apps/health-twin/package-lock.json
+++ b/apps/health-twin/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "tsx": "^4.19.2"
-      }
+      },
+      "devDependencies": {}
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",

--- a/apps/health-twin/package.json
+++ b/apps/health-twin/package.json
@@ -3,8 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Digital Health Twin engine (walking skeleton) — opt-in, local-first, sovereign FHIR-lite record store + governed consent grants. Synthetic data only; non-diagnostic.",
+  "description": "Digital Health Twin engine (walking skeleton) \u2014 opt-in, local-first, sovereign FHIR-lite record store + governed consent grants. Synthetic data only; non-diagnostic.",
   "dependencies": {
     "tsx": "^4.19.2"
-  }
+  },
+  "scripts": {
+    "test": "node --import tsx --test src/*.test.ts"
+  },
+  "devDependencies": {}
 }

--- a/apps/health-twin/src/consult.test.ts
+++ b/apps/health-twin/src/consult.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the bounded consult ledger (#942).
+ *
+ * The failure this pins: openConsult() had no size cap. An attacker (or a
+ * benign integration that spins up consults in a loop) grew the in-memory
+ * Map without ceiling — a slow-burn DoS that a running twin cannot recover
+ * from without a restart. Fix caps the store and fails-closed on overflow
+ * so the failure mode is a visible refusal rather than an OOM crash.
+ *
+ * We reload the module per test so CONSULT_MAX can be overridden via env
+ * without racing other tests; the ledger is module-scoped state.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+async function freshModule(env: Record<string, string> = {}) {
+  for (const [k, v] of Object.entries(env)) process.env[k] = v;
+  // Bust the ESM cache by appending a unique query to the specifier.
+  const suffix = Math.random().toString(36).slice(2);
+  return await import(`./consult.js?fresh=${suffix}`);
+}
+
+function agree(m: typeof import('./consult.js'), n: number) {
+  // NB: openConsult mints id from sha256([pseudonym, scope, `${Date.now()}-${scope}`]).
+  // Two calls in the same millisecond with the same scope collide on id and one
+  // silently overwrites the other in the Map. That is a preexisting bug in the
+  // codebase (see PR body — separate follow-up). We pass a unique scope per call
+  // here so the cap test measures the cap and not the collision.
+  const opened: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const r = m.openConsult({ patient: `p${i}` }, `scope-${i}`, 'standard', true);
+    if (r.consult_id) opened.push(r.consult_id);
+  }
+  return opened;
+}
+
+test('openConsult opens up to the cap then fails-closed with an explicit reason', async () => {
+  const m = await freshModule({ HEALTH_TWIN_CONSULT_MAX: '3' });
+  assert.equal(m.CONSULT_MAX, 3);
+
+  const ok = agree(m, 3);
+  assert.equal(ok.length, 3);
+  assert.equal(m.consultCount(), 3);
+
+  const overflow = m.openConsult({ patient: 'p3' }, 'cardiometabolic', 'standard', true);
+  assert.ok(!overflow.consult_id, 'must not admit a 4th consult');
+  assert.match(overflow.error!, /consult ledger full/);
+  assert.match(overflow.error!, /HEALTH_TWIN_CONSULT_MAX/);
+});
+
+test('closeConsult frees a slot so a new consult can open', async () => {
+  const m = await freshModule({ HEALTH_TWIN_CONSULT_MAX: '2' });
+  const ids = agree(m, 2);
+  assert.equal(m.consultCount(), 2);
+  assert.equal(m.openConsult({}, 'x', 'standard', true).error?.includes('full'), true);
+
+  assert.equal(m.closeConsult(ids[0]!), true);
+  assert.equal(m.consultCount(), 1);
+
+  const r = m.openConsult({ patient: 'new' }, 'x', 'standard', true);
+  assert.ok(r.consult_id, 'must accept after slot freed');
+});
+
+test('closeConsult on an unknown id returns false without touching the ledger', async () => {
+  const m = await freshModule({ HEALTH_TWIN_CONSULT_MAX: '10' });
+  const [id] = agree(m, 1);
+  assert.equal(m.consultCount(), 1);
+  assert.equal(m.closeConsult('nope'), false);
+  assert.equal(m.consultCount(), 1, 'ledger untouched');
+  assert.equal(m.closeConsult(id!), true);
+});
+
+test('a non-consenting request never counts against the cap', async () => {
+  const m = await freshModule({ HEALTH_TWIN_CONSULT_MAX: '2' });
+  // 3 non-consenting opens must not fill the ledger.
+  for (let i = 0; i < 3; i++) {
+    const r = m.openConsult({}, 'x', 'standard' /* agreed defaults false */);
+    assert.match(r.error!, /must agree/);
+  }
+  assert.equal(m.consultCount(), 0);
+  // Room for two legitimate consults still available.
+  assert.equal(agree(m, 2).length, 2);
+});
+
+test('default cap is 10_000 when env is unset or malformed', async () => {
+  delete process.env.HEALTH_TWIN_CONSULT_MAX;
+  const m1 = await freshModule();
+  assert.equal(m1.CONSULT_MAX, 10_000);
+
+  const m2 = await freshModule({ HEALTH_TWIN_CONSULT_MAX: 'not a number' });
+  assert.equal(m2.CONSULT_MAX, 10_000);
+
+  const m3 = await freshModule({ HEALTH_TWIN_CONSULT_MAX: '-5' });
+  assert.equal(m3.CONSULT_MAX, 10_000, 'negatives fall back to default');
+});

--- a/apps/health-twin/src/consult.ts
+++ b/apps/health-twin/src/consult.ts
@@ -45,8 +45,27 @@ export interface Consult {
   moreRequests: MoreRequest[];
 }
 
-// in-memory consult ledger (local-first store in production)
+// in-memory consult ledger (local-first store in production).
+//
+// #942: bounded to HEALTH_TWIN_CONSULT_MAX (default 10 000) — an unbounded
+// Map is a slow-burn DoS surface (memory grows without ceiling) and a live
+// operational risk on long-lived deployments. openConsult FAIL-CLOSES at the
+// cap: it returns an explicit error rather than silently evicting the oldest
+// consult. Silent LRU eviction of a consult with attached medical opinions
+// would destroy real work, and 'lost state' is the class of failure this
+// codebase removes as a matter of doctrine. Explicit pruning is closeConsult.
+const _envMax = Number.parseInt(process.env.HEALTH_TWIN_CONSULT_MAX ?? '', 10);
+export const CONSULT_MAX = Number.isFinite(_envMax) && _envMax > 0 ? _envMax : 10_000;
 const consults = new Map<string, Consult>();
+
+/** Explicit pruning — the caller decides what to drop. Returns true when a
+ *  consult was removed, false when the id wasn\'t known. */
+export function closeConsult(consultId: string): boolean {
+  return consults.delete(consultId);
+}
+
+/** Introspection for operators and tests. */
+export function consultCount(): number { return consults.size; }
 
 // Open a blinded consult over the twin. Requires the patient's agreement (anonymous by default); the
 // agreed `disclosure` scope decides what the de-identified slice keeps. Returns the consult id + the
@@ -57,6 +76,9 @@ const consults = new Map<string, Consult>();
 // withhold.
 export function openConsult(bundle: any, scope = 'whole twin', disclosure: DisclosureScope = 'standard', agreed = false): { consult_id?: string; slice?: DeidView; consent?: Consent; receipt?: { id: string }; error?: string } {
   if (!agreed) return { error: 'patient must agree to the disclosure terms before a consult can open' };
+  if (consults.size >= CONSULT_MAX) {
+    return { error: `consult ledger full (${consults.size}/${CONSULT_MAX}) — close finished consults with closeConsult() or raise HEALTH_TWIN_CONSULT_MAX; refusing to silently evict a consult with attached opinions` };
+  }
   const salt = `${Date.now()}-${scope}`;
   const slice = deidentify(bundle, salt, disclosure);
   const id = `consult-${sha256([slice.receipt.pseudonym, scope, salt])}`;


### PR DESCRIPTION
## What changed

Third of the three Tier-1 findings from the Copilot review backlog that were still live on merged main (after this session's earlier probe found 6 of 9 had been fixed since the memory was written earlier today). Fixes the last one.

`apps/health-twin/src/consult.ts:49` — `const consults = new Map<string, Consult>();` — had **no cap, no TTL, no eviction, no `.delete` anywhere** in 138 lines. A slow-burn DoS surface: memory grows without ceiling on a long-lived deployment. An attacker or a benign loop could exhaust the process.

### The fix

- **`CONSULT_MAX`** — env `HEALTH_TWIN_CONSULT_MAX`, default `10_000`. Value validated (positive int required; malformed input falls back to the default rather than silently disabling the cap).
- **`openConsult` fail-closes at the cap** with an explicit reason. LRU eviction of a consult with attached medical opinions would **destroy real work** — "lost state" is the failure mode this codebase removes as a matter of doctrine. Explicit pruning goes through `closeConsult()`.
- **`closeConsult(id)`** — returns `true` on removal, `false` on unknown id.
- **`consultCount()`** — introspection for operators and tests.

Test infrastructure added: `apps/health-twin` had no test script and no tests. Now `npm test` runs `node --import tsx --test src/*.test.ts`.

## Exact commands run

```
npm test
```

## Pass/fail summary

**5/5 pass.** Coverage: cap enforcement + fail-closed error string; slot freeing via `closeConsult`; `closeConsult` on unknown id is a no-op; non-consenting requests never count against the cap; default `10_000` with unset / malformed / negative env values.

## Separate preexisting bug surfaced by these tests (flagging, not sweeping)

`openConsult` mints `id = sha256([pseudonym, scope, salt])` where `salt = ${Date.now()}-${scope}`. **Two calls in the same millisecond with the same scope collide on id**, silently overwriting each other in the Map. My test hit this by opening N consults with a shared scope in a tight loop. Test corrected to use a unique scope per call so the cap test measures the cap, not the collision.

This is a real correctness issue — someone integrating this API in a way that opens multiple consults with the same scope per millisecond (a batch import, for example) will lose data silently. Belongs in its own PR. Sketch fix: include `randomUUID()` in the id inputs, or move to `crypto.randomUUID()` directly.

## Known gaps

- **No TTL / grace period** — a caller must call `closeConsult` explicitly or accept that the ledger fills. A follow-up could add "consults older than N days evict on next open" but that risks silent data loss again; a "warn at 80% full" heartbeat is probably the better next step.
- **Not distributed** — the ledger is module-scoped, so the cap is per-process. A multi-replica health-twin deployment has N × cap. The README already notes production is local-first (one process per user), so this is fine for the intended shape; noting it here so it isn't discovered later.
- **No test of the id-collision bug** — deliberately. That would either force the fix into this PR (scope creep) or ship a red test (worse). Follow-up PR files a failing test and a fix together.

## Blocked

Nothing.