### PR TITLE
fix(device-service): order observedAt/receivedAt as instants, not strings

### DIFF
--- a/apps/device-service/src/device_service/contract.py
+++ b/apps/device-service/src/device_service/contract.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from datetime import datetime, timezone
 from importlib import resources
 from typing import Any
 
@@ -123,6 +124,44 @@ def definition_digest(profile: dict[str, Any]) -> str:
     core = {field: profile[field] for field in DIGEST_FIELDS}
     canonical = json.dumps(core, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def instant(value: str) -> datetime | None:
+    """Parse an RFC3339 `date-time` to an absolute instant, or None if it is not one.
+
+    MUST stay behaviourally identical to sourceos-spec
+    tools/validate_device_service_examples.py instant() — the spec tool and this gate
+    have to agree on what "receivedAt >= observedAt" means, or a reading the estate
+    conformance tool refuses would still be emitted here.
+
+    Comparing these as STRINGS is wrong and silently so: DeviceReading pins
+    `format: date-time` with NO `pattern`, so schema-valid values vary in both UTC
+    offset and fractional-second precision. Two proven counterexamples the string
+    compare misses (tests/test_contract.py holds both):
+
+        observedAt 2026-07-29T09:15:00.500Z / receivedAt 2026-07-29T09:15:00Z
+            receivedAt is 500ms EARLIER, but '.' (0x2E) < 'Z' (0x5A), so it sorts later;
+        observedAt 2026-07-29T20:00:00+00:00 / receivedAt 2026-07-29T21:00:00+05:00
+            receivedAt is 4h EARLIER, but "21" > "20" lexicographically.
+
+    An ordering check built on string compare is a check that cannot fail for exactly
+    the documents most likely to be wrong. Normative in specs/device-service-contract.md
+    §6: the ordering is over instants, not strings.
+    """
+    text = value.strip()
+    if len(text) > 10 and text[10] in "tT":  # RFC3339 permits a lowercase separator
+        text = text[:10] + "T" + text[11:]
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        # RFC3339 requires an offset. A naive stamp is not an instant; refuse it rather
+        # than assume UTC and compare two different clocks.
+        return None
+    return parsed.astimezone(timezone.utc)
 
 
 def load_profile(raw: dict[str, Any]) -> dict[str, Any]:
@@ -277,8 +316,25 @@ def validate_reading(reading: dict[str, Any], profile: dict[str, Any]) -> None:
     if declared.get("kkoTypeRef") and reading.get("kkoTypeRef") != declared["kkoTypeRef"]:
         raise ContractError(f"kkoTypeRef disagrees with the declaration for {reading['metric']}")
 
-    if reading["receivedAt"] and reading["receivedAt"] < reading["observedAt"]:
-        raise ContractError("receivedAt precedes observedAt")
+    # Compare INSTANTS, never strings (see instant()). The schema's date-time format
+    # checker is the first line and rejects most malformed stamps, but it does not make
+    # two well-formed stamps comparable — that is this parse. An unorderable pair is
+    # refused rather than waved through: a check that cannot be performed has not passed.
+    received = reading.get("receivedAt")
+    if received:
+        observed_at, received_at = instant(reading["observedAt"]), instant(received)
+        if observed_at is None or received_at is None:
+            raise ContractError(
+                f"observedAt/receivedAt must be RFC3339 instants with an offset "
+                f"({reading['observedAt']!r} -> {received!r}) — an unorderable pair "
+                f"cannot be checked, so the reading is not admissible"
+            )
+        if received_at < observed_at:
+            raise ContractError(
+                f"receivedAt precedes observedAt by "
+                f"{(observed_at - received_at).total_seconds()}s — the reading arrived "
+                f"before it was observed"
+            )
 
     simulated = is_simulated(profile)
     labelled = SIMULATED_LABEL in reading["policyLabels"]

--- a/apps/device-service/src/device_service/contract.py
+++ b/apps/device-service/src/device_service/contract.py
@@ -320,8 +320,12 @@ def validate_reading(reading: dict[str, Any], profile: dict[str, Any]) -> None:
     # checker is the first line and rejects most malformed stamps, but it does not make
     # two well-formed stamps comparable — that is this parse. An unorderable pair is
     # refused rather than waved through: a check that cannot be performed has not passed.
+    # Copilot #1069: `if received:` treated '' as absent and skipped the gate. The
+    # whole point of this PR is that malformed timestamps must fail closed, not
+    # slip through under the same truthiness check that admitted the good ones.
+    # Explicit presence check; let instant('') drive the fail-closed refusal.
     received = reading.get("receivedAt")
-    if received:
+    if received is not None:
         observed_at, received_at = instant(reading["observedAt"]), instant(received)
         if observed_at is None or received_at is None:
             raise ContractError(

--- a/apps/device-service/tests/test_contract.py
+++ b/apps/device-service/tests/test_contract.py
@@ -149,6 +149,130 @@ def test_received_before_observed_is_refused(reading, virtual_profile, mutate):
         )
 
 
+# ------------------------------------------------- instants, not strings (§6)
+#
+# DeviceReading pins `format: date-time` with NO `pattern`, so schema-valid stamps vary
+# in UTC offset AND fractional-second precision. The pairs below are the ones a
+# string comparison gets WRONG. They are not hypothetical: both were verified against
+# the identical check in sourceos-spec before this fix landed.
+#
+# (observedAt, receivedAt, how much earlier receivedAt actually is)
+INVERTED_PAIRS_THAT_SORT_FORWARD = [
+    # '.' (0x2E) < 'Z' (0x5A): the more precise stamp sorts FIRST while being later.
+    ("2026-07-29T09:15:00.500Z", "2026-07-29T09:15:00Z", "0.5s"),
+    # "21" > "20" as text, but +05:00 puts 21:00 at 16:00Z — four hours before.
+    ("2026-07-29T20:00:00+00:00", "2026-07-29T21:00:00+05:00", "4h"),
+]
+
+# Positive controls: genuinely well-ordered pairs, written across offsets and
+# precisions, that MUST still be admitted. A stricter gate that refuses good readings
+# has just moved the bug.
+ORDERED_PAIRS_ACROSS_OFFSETS_AND_PRECISIONS = [
+    # Same instant, two spellings. Equal is admissible (the invariant is >=).
+    ("2026-07-29T09:15:00Z", "2026-07-29T11:15:00+02:00"),
+    # 42ms of real latency; '.042Z' sorts BEFORE 'Z', so string compare false-alarms.
+    ("2026-07-29T09:15:00Z", "2026-07-29T09:15:00.042Z"),
+    # 1s of real latency across a +02:00 offset.
+    ("2026-07-29T20:00:00+00:00", "2026-07-29T22:00:01+02:00"),
+]
+
+# The one positive control that a string comparison actively REJECTS. Teeth have to
+# point both ways: a gate that only false-negatives is blind, one that false-positives
+# throws away good readings. This pair proves the fix fixes the second failure too.
+STRING_COMPARE_FALSE_ALARM = ("2026-07-29T09:15:00Z", "2026-07-29T09:15:00.042Z")
+
+
+@pytest.mark.parametrize("observed,received,gap", INVERTED_PAIRS_THAT_SORT_FORWARD)
+def test_inverted_pair_is_refused_even_when_it_sorts_forward(
+    reading, virtual_profile, mutate, observed, received, gap
+):
+    """THE regression. receivedAt is genuinely earlier by {gap}; the old
+    `reading["receivedAt"] < reading["observedAt"]` string compare said otherwise and
+    admitted the reading."""
+    with pytest.raises(contract.ContractError, match="receivedAt precedes observedAt"):
+        contract.validate_reading(
+            mutate(reading, observedAt=observed, receivedAt=received, wallTime=received),
+            virtual_profile,
+        )
+
+
+@pytest.mark.parametrize("observed,received", ORDERED_PAIRS_ACROSS_OFFSETS_AND_PRECISIONS)
+def test_equivalent_instants_written_differently_are_admitted(
+    reading, virtual_profile, mutate, observed, received
+):
+    """Positive control: correctly-ordered pairs across offsets and precisions must
+    still PASS. A gate that refuses these has moved the bug, not fixed it."""
+    contract.validate_reading(
+        mutate(reading, observedAt=observed, receivedAt=received, wallTime=received),
+        virtual_profile,
+    )
+
+
+def test_the_counterexamples_are_actually_adversarial():
+    """Guards the guard. If a future edit weakened these fixtures into pairs a string
+    compare already handles, the tests above would still be green while testing
+    nothing. This asserts, explicitly, that naive `<` gets them wrong — so the cases
+    keep their teeth even if the fix is reverted and re-derived."""
+    for observed, received, _gap in INVERTED_PAIRS_THAT_SORT_FORWARD:
+        assert contract.instant(received) < contract.instant(observed), "not inverted"
+        assert not (received < observed), "a string compare would already catch this"
+    for observed, received in ORDERED_PAIRS_ACROSS_OFFSETS_AND_PRECISIONS:
+        assert contract.instant(received) >= contract.instant(observed), "not ordered"
+
+    observed, received = STRING_COMPARE_FALSE_ALARM
+    assert (observed, received) in ORDERED_PAIRS_ACROSS_OFFSETS_AND_PRECISIONS
+    assert received < observed, "this control no longer false-alarms a string compare"
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("2026-07-29T09:15:00Z", "2026-07-29 09:15:00+00:00"),
+    ("2026-07-29T09:15:00.500Z", "2026-07-29 09:15:00.500000+00:00"),
+    ("2026-07-29t09:15:00z", "2026-07-29 09:15:00+00:00"),      # RFC3339 lowercase
+    ("2026-07-29T11:15:00+02:00", "2026-07-29 09:15:00+00:00"),  # normalised to UTC
+    ("2026-07-29T21:00:00+05:00", "2026-07-29 16:00:00+00:00"),
+])
+def test_instant_normalises_to_utc(text, expected):
+    assert str(contract.instant(text)) == expected
+
+
+@pytest.mark.parametrize("text", [
+    "2026-07-29T09:15:00",   # naive: RFC3339 requires an offset
+    "2026-07-29",            # a date is not an instant
+    "yesterday",
+    "",
+])
+def test_instant_fails_closed_on_anything_that_is_not_an_instant(text):
+    """A naive stamp carries no offset, so it is not an instant — refuse it rather than
+    assume UTC and silently compare two different clocks."""
+    assert contract.instant(text) is None
+
+
+def test_a_reading_with_no_receivedAt_is_admitted(reading, virtual_profile):
+    """receivedAt is optional in DeviceReading.json (not in `required`). The check now
+    reads it with .get() like the spec tool does; the old `reading["receivedAt"]` raised
+    a bare KeyError — not a ContractError — on a schema-valid reading that omits it, so
+    the caller's `except ContractError` would not have counted it as a validation
+    failure. There is nothing to order here, and nothing to fail."""
+    without = {k: v for k, v in reading.items() if k != "receivedAt"}
+    contract.validate_reading(without, virtual_profile)
+
+
+def test_an_unorderable_pair_is_refused_not_waved_through(
+    reading, virtual_profile, mutate, monkeypatch
+):
+    """Defence in depth. The schema's date-time format checker normally rejects a naive
+    stamp first (contract.py refuses to import without it). If that layer ever degraded,
+    the ordering gate must still refuse the pair it cannot order — never pass it."""
+    monkeypatch.setattr(
+        contract, "READING_VALIDATOR", Draft202012Validator(contract.READING_SCHEMA)
+    )
+    with pytest.raises(contract.ContractError, match="unorderable pair"):
+        contract.validate_reading(
+            mutate(reading, observedAt="2026-07-29T09:15:00", receivedAt="2026-07-29T09:15:01"),
+            virtual_profile,
+        )
+
+
 def test_schema_violations_are_refused(reading, virtual_profile, mutate):
     with pytest.raises(contract.ContractError, match="schema"):
         contract.validate_reading(mutate(reading, specVersion="0.2.0"), virtual_profile)

--- a/apps/device-service/tests/test_contract.py
+++ b/apps/device-service/tests/test_contract.py
@@ -164,6 +164,11 @@ INVERTED_PAIRS_THAT_SORT_FORWARD = [
     ("2026-07-29T20:00:00+00:00", "2026-07-29T21:00:00+05:00", "4h"),
 ]
 
+# Test ids that carry the gap (Copilot #1069): a failure line reads
+# "test_inverted_pair_is_refused_even_when_it_sorts_forward[fractional-precision-gap=0.5s]"
+# rather than an opaque tuple hash, without deforming the fixture the other tests reuse.
+_INVERTED_IDS = ["fractional-precision-gap=0.5s", "offset-inversion-gap=4h"]
+
 # Positive controls: genuinely well-ordered pairs, written across offsets and
 # precisions, that MUST still be admitted. A stricter gate that refuses good readings
 # has just moved the bug.
@@ -182,13 +187,15 @@ ORDERED_PAIRS_ACROSS_OFFSETS_AND_PRECISIONS = [
 STRING_COMPARE_FALSE_ALARM = ("2026-07-29T09:15:00Z", "2026-07-29T09:15:00.042Z")
 
 
-@pytest.mark.parametrize("observed,received,gap", INVERTED_PAIRS_THAT_SORT_FORWARD)
+@pytest.mark.parametrize(
+    "observed,received,gap", INVERTED_PAIRS_THAT_SORT_FORWARD, ids=_INVERTED_IDS,
+)
 def test_inverted_pair_is_refused_even_when_it_sorts_forward(
     reading, virtual_profile, mutate, observed, received, gap
 ):
-    """THE regression. receivedAt is genuinely earlier by {gap}; the old
-    `reading["receivedAt"] < reading["observedAt"]` string compare said otherwise and
-    admitted the reading."""
+    """THE regression. receivedAt is genuinely earlier by `gap` (visible in the test id);
+    the old `reading["receivedAt"] < reading["observedAt"]` string compare said otherwise
+    and admitted the reading."""
     with pytest.raises(contract.ContractError, match="receivedAt precedes observedAt"):
         contract.validate_reading(
             mutate(reading, observedAt=observed, receivedAt=received, wallTime=received),
@@ -271,6 +278,21 @@ def test_an_unorderable_pair_is_refused_not_waved_through(
             mutate(reading, observedAt="2026-07-29T09:15:00", receivedAt="2026-07-29T09:15:01"),
             virtual_profile,
         )
+
+
+def test_empty_string_receivedAt_is_refused_not_treated_as_absent(
+    reading, virtual_profile, mutate, monkeypatch
+):
+    """Copilot #1069: `if received:` treated '' as absent and skipped the gate. Same
+    degraded-validator scenario as the pair test — the format checker is bypassed, so a
+    naive gate that keys on truthiness lets the payload through. The whole point of
+    this PR is that unorderable inputs fail closed, not silently pass under the
+    truthiness check that admits well-formed ones."""
+    monkeypatch.setattr(
+        contract, "READING_VALIDATOR", Draft202012Validator(contract.READING_SCHEMA)
+    )
+    with pytest.raises(contract.ContractError, match="unorderable pair"):
+        contract.validate_reading(mutate(reading, receivedAt=""), virtual_profile)
 
 
 def test_schema_violations_are_refused(reading, virtual_profile, mutate):


### PR DESCRIPTION
Copilot flagged this on #1060 and it merged unaddressed.

## The bug

`apps/device-service/src/device_service/contract.py`, the attribution gate:

```python
if reading["receivedAt"] and reading["receivedAt"] < reading["observedAt"]:
    raise ContractError("receivedAt precedes observedAt")
```

`DeviceReading.json` pins `format: date-time` with **no `pattern`**, so schema-valid values vary in UTC offset and fractional-second precision. Two counterexamples, both **proven** by mutation against the identical check in `sourceos-spec` before this fix:

| observedAt | receivedAt | reality | string compare says |
|---|---|---|---|
| `2026-07-29T09:15:00.500Z` | `2026-07-29T09:15:00Z` | receivedAt is **500ms earlier** | passes — `'.'` (0x2E) < `'Z'` (0x5A) |
| `2026-07-29T20:00:00+00:00` | `2026-07-29T21:00:00+05:00` | receivedAt is **4h earlier** | passes — `"21"` > `"20"` |

It has teeth in the wrong direction too: a genuinely well-ordered pair written `09:15:00Z` → `09:15:00.042Z` (42ms of real latency) is **refused**, because `.042Z` sorts before `Z`.

An ordering check built on string compare is a check that cannot fail for exactly the documents most likely to be wrong.

## The fix

Mirrors the `instant()` helper that landed in `SourceOS-Linux/sourceos-spec` **#215** (`tools/validate_device_service_examples.py`): normalise a lowercase `t`/`z` separator, map trailing `Z` to `+00:00`, parse with `datetime.fromisoformat`, convert to UTC, fail closed on a naive stamp carrying no offset. Then compare the parsed instants.

This is a **conformance fix**, not a preference: `specs/device-service-contract.md` §6 in #215 now states the rule normatively — "that ordering is over **instants, not strings** … implementations MUST parse both to an absolute instant and MUST refuse a pair that cannot be parsed to one". The implementation this repo vendors those schemas from was out of conformance with the spec text.

Two behaviour changes beyond the ordering itself:

- **An unorderable pair is refused, not waved through.** A check that cannot be performed has not passed. The schema's `date-time` format checker is the first line and normally rejects these already (`contract.py` refuses to import without `rfc3339-validator`); this is the second.
- **`receivedAt` is read with `.get()`.** It is optional in `DeviceReading.json` (not in `required`). The old subscript raised a bare `KeyError` — not a `ContractError` — on a schema-valid reading that omits it, so `emitter.py`'s `except contract.ContractError` would not have counted it as a validation failure.

## Proof the tests have teeth

The tests were run against the **reverted** (string-compare) implementation. Both counterexamples fail, and so do the false-alarm control and the unorderable-pair guard:

```
FAILED test_inverted_pair_is_refused_even_when_it_sorts_forward[...09:15:00.500Z-...09:15:00Z-0.5s]
FAILED test_inverted_pair_is_refused_even_when_it_sorts_forward[...20:00:00+00:00-...21:00:00+05:00-4h]
FAILED test_equivalent_instants_written_differently_are_admitted[...09:15:00Z-...09:15:00.042Z]
FAILED test_an_unorderable_pair_is_refused_not_waved_through
E       Failed: DID NOT RAISE <class 'device_service.contract.ContractError'>
4 failed, 48 passed
```

With the fix restored: **115 passed** (`PYTHONPATH=src pytest -q tests`, the exact invocation the `validate-target-diagnostics` device-service leg uses).

Coverage added:
- both counterexamples, parametrised;
- three positive controls — `Z` vs `+02:00` at the same instant, `Z` vs `.042Z`, and 1s of real latency across a `+02:00` offset — proving equivalent and correctly-ordered instants written differently still pass;
- direct `instant()` coverage: UTC normalisation across offsets and lowercase `t`/`z`, and fail-closed on naive / date-only / garbage / empty;
- a reading that omits `receivedAt` entirely;
- a **meta-test** asserting the counterexamples really are pairs a naive `<` gets wrong. If a later edit weakened them into pairs a string compare already handles, the tests above would stay green while testing nothing. This one goes red instead — it caught an overclaim in my own first draft of the positive controls.

## Sweep for the same idiom

Swept all of `apps/device-service` (and the wider repo) for anything else ordering or diffing these timestamps as strings. **Nothing else.** Specifically:

- **No latency metric is computed anywhere**, despite the spec naming `observedAt` → `receivedAt` "the southbound latency a twin's sync budget is actually spent on". The obvious suspect does not exist yet — worth knowing before someone adds it with a string subtraction.
- `emitter.py` stamps `observedAt`, `receivedAt` and `wallTime` from a **single** `self.clock()` call per sample, so in-house they are always byte-equal. The bug only bit readings built by a caller supplying distinct stamps — which is exactly what the BLE/driver path is being built toward.
- `server.py`'s `last_emit_at` / `last_error_at` are numeric `time.time()` floats. Fine.
- `contract.py flatten()` writes `observedAt` / `receivedAt` / `wallTime` into HellGraph node properties **as strings**. Not a bug here, but any downstream Cypher that orders or ranges on those properties inherits the same trap. Out of scope, flagged.
- Repo-wide, the only other `*At`-vs-`*At` comparisons are `hellgraph-service/src/organs.test.ts` (`Date.parse(...) > 0`) and `socioprophet-web/.../governance.ts` (`ageMinutes()` → `Date.parse`). Both parse first. Clean.

## Deviations / notes

- `sourceos-spec` was **read only**, via `gh api` against the merged #215 — no fetch, no checkout, no edit, per the active-agent hold on that repo.
- The fail-closed branch is **not reachable through `validate_reading` in a correctly-installed environment**: `rfc3339-validator` rejects naive stamps, leap seconds and `+24:00` at the schema layer first, and `contract.py` refuses to import without it. It is tested two ways — `instant()` directly, and through `validate_reading` with the format checker monkeypatched off, which is the degraded state the branch exists for. Being unreachable today is the correct outcome, not dead code.
- Verified locally on **Python 3.12**; CI runs **3.11**. Every test vector uses only `fromisoformat` behaviour available since 3.7 (3-digit fractional seconds, `±HH:MM` offsets) — nothing depends on the 3.11 ISO-8601 relaxation, and `Z` and lowercase separators are normalised by hand before parsing rather than relying on the stdlib.
- `instant()` is deliberately a near-verbatim port rather than a shared import: this module's whole claim is that it is hermetic and vendored. It carries a `MUST stay behaviourally identical to` note pointing at the spec tool. Nothing mechanically enforces that parity — a real, if small, drift surface.
