### PR TITLE
compute-gateway: the exhaust guard from #1067 has two open doors

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/engine.py
+++ b/apps/compute-gateway/src/compute_gateway/engine.py
@@ -39,6 +39,7 @@ _LADDER = ["unknown", "hypothesis", "simulated", "observed", "derived", "verifie
 # Shape matches the ExhaustRecord already in use across compute-gateway (see
 # tests/test_exhaust_accounting.py:28 for the canonical example).
 
+import json as _json
 import re as _re
 
 _EXHAUST_TOP_KEYS = frozenset({
@@ -56,6 +57,25 @@ _MAX_REF_LEN = 512
 _MAX_LABEL_LEN = 256          # kind, source, adapter, etc. — labels, not blobs
 _MAX_REASON_LEN = 512         # bounded free-text
 _MAX_ITEMS = 10_000           # DoS safeguard on the ledger
+_MAX_SPEC_VERSION_LEN = 64    # a version string ("2.0", "2026-07-29"), not a field
+_MAX_COUNT_KEYS = 256         # a counts map is a tally, not a key-value store
+
+# Aggregate backstop. Every bound above is per-field, and per-field bounds only
+# close the dimensions someone remembered to enumerate — `specVersion` and the
+# *number* of `counts` keys were both unbounded on earlier passes of this very
+# guard, each good for >10 MB of verbatim smuggled text. A total-size cap is the
+# one check that also closes the dimensions nobody thought of, so it is
+# deliberately consulted last and deliberately NOT derived from the per-field
+# limits (deriving it would make it re-state the same assumptions it exists to
+# catch).
+#
+# Sized by measurement, not guess: the largest LEGITIMATE record the per-field
+# bounds permit is a full 10 000-entry bare-digest discard ledger, which
+# serialises to 0.93 MiB. The largest record that is legal in every individual
+# field but is plainly payload — 10 000 items x two 512-char URN refs — is
+# 10.05 MiB. 2 MiB sits between them: ~2x headroom over the real ceiling, and
+# still refuses the per-field-legal blob.
+_MAX_EXHAUST_BYTES = 2 * 1024 * 1024
 
 
 def _bad_ref(v) -> bool:
@@ -84,8 +104,10 @@ def _validate_exhaust(exhaust) -> str | None:
             return f"{lbl} must be a short label string (<= {_MAX_LABEL_LEN} chars)"
     if "reason" in exhaust and not (isinstance(exhaust["reason"], str) and len(exhaust["reason"]) <= _MAX_REASON_LEN):
         return f"reason must be a bounded string (<= {_MAX_REASON_LEN} chars)"
-    if "specVersion" in exhaust and not isinstance(exhaust["specVersion"], str):
-        return "specVersion must be a string"
+    if "specVersion" in exhaust and not (
+        isinstance(exhaust["specVersion"], str) and len(exhaust["specVersion"]) <= _MAX_SPEC_VERSION_LEN
+    ):
+        return f"specVersion must be a version string (<= {_MAX_SPEC_VERSION_LEN} chars)"
     for count_key in ("bytesIn", "bytesOut"):
         if count_key in exhaust and _bad_nonneg_int(exhaust[count_key]):
             return f"{count_key} must be a non-negative int"
@@ -93,6 +115,8 @@ def _validate_exhaust(exhaust) -> str | None:
         c = exhaust["counts"]
         if not isinstance(c, dict):
             return "counts must be a mapping"
+        if len(c) > _MAX_COUNT_KEYS:
+            return f"counts has {len(c)} keys > {_MAX_COUNT_KEYS} — a tally, not a payload"
         for k, v in c.items():
             if not isinstance(k, str) or len(k) > _MAX_LABEL_LEN:
                 return f"counts.{k!r} label out of range"
@@ -118,6 +142,15 @@ def _validate_exhaust(exhaust) -> str | None:
                 return f"items[{i}].size must be a non-negative int"
             if "ref" in it and _bad_ref(it["ref"]):
                 return f"items[{i}].ref must be a digest/URN reference"
+    # Aggregate backstop — last, so it catches whatever the per-field checks
+    # above did not think to bound. Everything reaching here is JSON-safe
+    # (str/int/dict/list only), but fail closed if serialisation surprises us.
+    try:
+        total = len(_json.dumps(exhaust, separators=(",", ":"), ensure_ascii=False, default=str).encode("utf-8"))
+    except Exception as exc:  # pragma: no cover - defensive
+        return f"exhaust is not serialisable: {type(exc).__name__}"
+    if total > _MAX_EXHAUST_BYTES:
+        return f"exhaust serialises to {total} bytes > {_MAX_EXHAUST_BYTES} — a ledger, not a payload"
     return None
 
 

--- a/apps/compute-gateway/src/compute_gateway/engine.py
+++ b/apps/compute-gateway/src/compute_gateway/engine.py
@@ -155,10 +155,23 @@ def _validate_exhaust(exhaust) -> str | None:
 
 
 def _guard_exhaust(exhaust):
-    """Return the exhaust dict if it passes the ExhaustRecord shape check,
-    otherwise return a stripped-safe dict recording ONLY that the exhaust was
-    rejected + why. Never raises — a shape violation is a receipt annotation,
-    not a run-time failure."""
+    """Return the exhaust dict if it passes the ExhaustRecord shape check.
+
+    Three outcomes, because callers branch on them:
+
+    * passes            -> the dict itself, unchanged
+    * a dict that fails -> a stripped-safe dict recording ONLY that the exhaust
+                           was rejected and why. The offending content never
+                           reaches the artifact store.
+    * None, or anything  -> ``None``. There is nothing to annotate: the caller
+      that is not a dict     stores exhaust only ``if isinstance(exhaust, dict)``,
+                             so a string or list simply produces no exhaust
+                             record rather than an empty one.
+
+    Never raises — a shape violation is a receipt annotation, not a run-time
+    failure. Copilot flagged the earlier docstring for promising the second
+    outcome in all failing cases; the third was already the behaviour and is the
+    right one, so the docstring moved rather than the code."""
     if exhaust is None:
         return None
     why = _validate_exhaust(exhaust)

--- a/apps/compute-gateway/src/compute_gateway/engine.py
+++ b/apps/compute-gateway/src/compute_gateway/engine.py
@@ -116,7 +116,7 @@ def _validate_exhaust(exhaust) -> str | None:
         if not isinstance(c, dict):
             return "counts must be a mapping"
         if len(c) > _MAX_COUNT_KEYS:
-            return f"counts has {len(c)} keys > {_MAX_COUNT_KEYS} — a tally, not a payload"
+            return f"counts has {len(c)} entries (max {_MAX_COUNT_KEYS}) — a tally, not a payload"
         for k, v in c.items():
             if not isinstance(k, str) or len(k) > _MAX_LABEL_LEN:
                 return f"counts.{k!r} label out of range"
@@ -145,10 +145,18 @@ def _validate_exhaust(exhaust) -> str | None:
     # Aggregate backstop — last, so it catches whatever the per-field checks
     # above did not think to bound. Everything reaching here is JSON-safe
     # (str/int/dict/list only), but fail closed if serialisation surprises us.
+    #
+    # Deliberately WITHOUT default=str, even though artifacts.digest uses it. A
+    # default= handler is the opposite of failing closed: it stops json.dumps
+    # raising on an unknown type by silently stringifying it, so the except branch
+    # below could never fire and an object the per-field checks never anticipated
+    # would be measured, accepted, and stored. Since nothing that reaches here
+    # should be anything but str/int/dict/list, a TypeError is exactly the signal
+    # wanted — it means the validation above regressed.
     try:
-        total = len(_json.dumps(exhaust, separators=(",", ":"), ensure_ascii=False, default=str).encode("utf-8"))
-    except Exception as exc:  # pragma: no cover - defensive
-        return f"exhaust is not serialisable: {type(exc).__name__}"
+        total = len(_json.dumps(exhaust, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+    except (TypeError, ValueError) as exc:
+        return f"exhaust is not serialisable ({type(exc).__name__}: {exc}) — refusing to store it"
     if total > _MAX_EXHAUST_BYTES:
         return f"exhaust serialises to {total} bytes > {_MAX_EXHAUST_BYTES} — a ledger, not a payload"
     return None

--- a/apps/compute-gateway/tests/test_gateway_hardening.py
+++ b/apps/compute-gateway/tests/test_gateway_hardening.py
@@ -10,6 +10,7 @@ Both fixes are guards at the trust boundary between adapter output and
 receipt/artifact storage. These tests exercise the guards directly rather
 than through HTTP, so they run fast and are readable.
 """
+import asyncio
 import base64
 import hashlib
 import os
@@ -31,7 +32,6 @@ def _text_pack(text: str) -> dict:
 
 def test_parse_recomputes_sha256_ignoring_caller_supplied():
     """Caller-supplied sha256 that mismatches the parsed bytes must fail-closed."""
-    import asyncio
     pack = _text_pack("hello world")
     pack["sha256"] = "sha256:" + "0" * 64
     out = asyncio.run(adapters._parse(pack, project="p", session=None))
@@ -41,7 +41,6 @@ def test_parse_recomputes_sha256_ignoring_caller_supplied():
 
 def test_parse_computes_sha256_when_caller_omits_it():
     """Caller omits sha256 entirely; parse computes it over the actual bytes."""
-    import asyncio, hashlib
     pack = _text_pack("hello world")
     pack.pop("sha256", None)
     out = asyncio.run(adapters._parse(pack, project="p", session=None))
@@ -51,7 +50,6 @@ def test_parse_computes_sha256_when_caller_omits_it():
 
 def test_parse_accepts_matching_caller_sha256():
     """Caller supplies the correct sha256; parse verifies and passes it through."""
-    import asyncio, hashlib
     pack = _text_pack("hello world")
     pack["sha256"] = hashlib.sha256(b"hello world").hexdigest()
     out = asyncio.run(adapters._parse(pack, project="p", session=None))
@@ -135,7 +133,6 @@ def test_exhaust_guard_returns_none_for_none_and_non_dict():
 def test_parse_accepts_matching_caller_sha256_with_sha256_prefix():
     """Copilot round-1: strict-string compare rejected caller's 'sha256:<hex>'
     form even when correct. Normalise before comparing."""
-    import asyncio, hashlib
     pack = _text_pack("hello world")
     pack["sha256"] = "sha256:" + hashlib.sha256(b"hello world").hexdigest()
     out = asyncio.run(adapters._parse(pack, project="p", session=None))
@@ -144,7 +141,6 @@ def test_parse_accepts_matching_caller_sha256_with_sha256_prefix():
 
 def test_parse_accepts_matching_caller_sha256_in_uppercase():
     """Same: hex is case-insensitive. UPPERCASE must not be treated as mismatch."""
-    import asyncio, hashlib
     pack = _text_pack("hello world")
     pack["sha256"] = hashlib.sha256(b"hello world").hexdigest().upper()
     out = asyncio.run(adapters._parse(pack, project="p", session=None))
@@ -173,3 +169,103 @@ def test_exhaust_guard_still_accepts_reasonable_urn_refs():
     }
     out = engine._guard_exhaust(good)
     assert out == good
+
+
+# ── Copilot round-2 follow-up: the two dimensions still unbounded ─────────
+#
+# These were verified as LIVE bypasses against the round-1 guard before the
+# fix: each smuggled >10 MB of verbatim text through `_guard_exhaust` intact
+# and into the artifact store, retrievable at /v1/artifacts/{exhaust_sha} —
+# the exact exfil path this guard exists to close. Literal sizes below are
+# written out rather than derived from engine._MAX_* on purpose: a test that
+# reads the same constant as the implementation cannot detect the constant
+# being widened.
+#
+# Each test also pins WHICH check rejected the record, via the reason string.
+# That is not decoration. First draft of these tests asserted only "rejected",
+# and stayed green with the per-field bound deleted — because the aggregate
+# backstop caught the same payload. Two guards where the test cannot tell them
+# apart is one guard that can be removed without any test going red.
+
+
+def test_exhaust_guard_rejects_payload_smuggled_as_specversion():
+    """`specVersion` was type-checked but not length-bounded — a string field
+    on the top-level allowlist with no ceiling is an open exfil door."""
+    payload = "SSN 123-45-6789 alice@example.com " * 300_000  # ~10 MB
+    smuggled = {"type": "ExhaustRecord", "specVersion": payload, "counts": {"x": 1}}
+    out = engine._guard_exhaust(smuggled)
+    assert out is not None
+    assert "specVersion" not in out, "raw payload survived the guard via specVersion"
+    assert "exhaust rejected" in out["reason"]
+    assert "specVersion must be a version string" in out["reason"], (
+        "must be rejected BY THE specVersion BOUND, not incidentally by the "
+        f"aggregate backstop; got: {out['reason']}")
+
+
+def test_specversion_bound_fires_below_the_aggregate_backstop():
+    """The discriminating case: a specVersion too long to be a version but far
+    too small to trip the 2 MiB backstop. Only the per-field bound can catch
+    this, so it proves the bound exists rather than being shadowed."""
+    smuggled = {"type": "ExhaustRecord", "specVersion": "v" * 5_000}
+    out = engine._guard_exhaust(smuggled)
+    assert out is not None
+    assert "specVersion" not in out
+    assert "specVersion must be a version string" in out["reason"]
+
+
+def test_exhaust_guard_accepts_a_real_spec_version_string():
+    """The bound must not break the actual field it is bounding."""
+    good = {"type": "ExhaustRecord", "specVersion": "2.0", "counts": {"dropped": 3}}
+    assert engine._guard_exhaust(good) == good
+
+
+def test_exhaust_guard_rejects_payload_smuggled_as_counts_keys():
+    """`counts` bounded each key to 256 chars but never bounded how MANY keys.
+    50 000 x 246-char keys = ~12 MB of attacker-chosen text, all label."""
+    smuggled = {"type": "ExhaustRecord",
+                "counts": {f"k{i:06d}" + "x" * 240: 1 for i in range(50_000)}}
+    out = engine._guard_exhaust(smuggled)
+    assert out is not None
+    assert len(out.get("counts", {})) <= 1, "counts payload survived the guard"
+    assert "exhaust rejected" in out["reason"]
+    assert "counts has" in out["reason"], (
+        "must be rejected BY THE counts-key bound, not incidentally by the "
+        f"aggregate backstop; got: {out['reason']}")
+
+
+def test_counts_key_bound_fires_below_the_aggregate_backstop():
+    """Discriminating case: 2 000 short count keys is only ~26 KB — nowhere
+    near the 2 MiB backstop — but is still a key-value store, not a tally."""
+    smuggled = {"type": "ExhaustRecord", "counts": {f"k{i}": 1 for i in range(2_000)}}
+    out = engine._guard_exhaust(smuggled)
+    assert out is not None
+    assert len(out.get("counts", {})) <= 1
+    assert "counts has" in out["reason"]
+
+
+def test_exhaust_guard_accepts_an_ordinary_counts_tally():
+    good = {"type": "ExhaustRecord",
+            "counts": {f"bucket{i}": i for i in range(64)}}
+    assert engine._guard_exhaust(good) == good
+
+
+def test_exhaust_guard_total_size_backstop_catches_unenumerated_dimensions():
+    """The aggregate cap is the check that closes dimensions nobody enumerated.
+    Every field here is individually legal — 10 000 items each carrying a
+    512-char URN ref clears every per-field bound, yet totals ~5 MB."""
+    ref = "urn:x:" + "a" * 500
+    assert not engine._bad_ref(ref), "each ref must be individually LEGAL for this test to mean anything"
+    smuggled = {"type": "ExhaustRecord",
+                "items": [{"kind": "candidate", "sha256": ref, "ref": ref} for _ in range(10_000)]}
+    out = engine._guard_exhaust(smuggled)
+    assert out is not None
+    assert "items" not in out, "per-field-legal payload still totalling megabytes survived"
+    assert "exhaust rejected" in out["reason"]
+
+
+def test_exhaust_guard_accepts_a_large_but_legitimate_ref_ledger():
+    """A real 10 000-entry discard ledger of bare digests must still pass —
+    the backstop bounds bytes, not usefulness."""
+    good = {"type": "ExhaustRecord", "source": "compute",
+            "items": [{"kind": "candidate", "sha256": "a" * 64} for _ in range(10_000)]}
+    assert engine._guard_exhaust(good) == good

--- a/apps/compute-gateway/tests/test_gateway_hardening.py
+++ b/apps/compute-gateway/tests/test_gateway_hardening.py
@@ -191,7 +191,11 @@ def test_exhaust_guard_still_accepts_reasonable_urn_refs():
 def test_exhaust_guard_rejects_payload_smuggled_as_specversion():
     """`specVersion` was type-checked but not length-bounded — a string field
     on the top-level allowlist with no ceiling is an open exfil door."""
-    payload = "SSN 123-45-6789 alice@example.com " * 300_000  # ~10 MB
+    # 96 KB is ample: it is 1500x the 64-char specVersion bound and still well under
+    # the 2 MiB backstop, so the reason assertion below proves the per-field bound
+    # fired. The live bypass measured 10.2 MB; reproducing that volume in CI buys no
+    # extra coverage, only allocation.
+    payload = "SSN 123-45-6789 alice@example.com " * 3_000  # ~96 KB
     smuggled = {"type": "ExhaustRecord", "specVersion": payload, "counts": {"x": 1}}
     out = engine._guard_exhaust(smuggled)
     assert out is not None
@@ -222,8 +226,9 @@ def test_exhaust_guard_accepts_a_real_spec_version_string():
 def test_exhaust_guard_rejects_payload_smuggled_as_counts_keys():
     """`counts` bounded each key to 256 chars but never bounded how MANY keys.
     50 000 x 246-char keys = ~12 MB of attacker-chosen text, all label."""
+    # 400 keys clears the 256-key bound; the live bypass used 50 000 (~12.7 MB).
     smuggled = {"type": "ExhaustRecord",
-                "counts": {f"k{i:06d}" + "x" * 240: 1 for i in range(50_000)}}
+                "counts": {f"k{i:06d}" + "x" * 240: 1 for i in range(400)}}
     out = engine._guard_exhaust(smuggled)
     assert out is not None
     assert len(out.get("counts", {})) <= 1, "counts payload survived the guard"
@@ -255,8 +260,11 @@ def test_exhaust_guard_total_size_backstop_catches_unenumerated_dimensions():
     512-char URN ref clears every per-field bound, yet totals ~5 MB."""
     ref = "urn:x:" + "a" * 500
     assert not engine._bad_ref(ref), "each ref must be individually LEGAL for this test to mean anything"
+    # 2 600 items x two 512-char URNs is ~2.7 MiB — over the 2 MiB backstop, under
+    # the 10 000-item cap, every field individually legal. The smallest construction
+    # that can only be caught by the aggregate check.
     smuggled = {"type": "ExhaustRecord",
-                "items": [{"kind": "candidate", "sha256": ref, "ref": ref} for _ in range(10_000)]}
+                "items": [{"kind": "candidate", "sha256": ref, "ref": ref} for _ in range(2_600)]}
     out = engine._guard_exhaust(smuggled)
     assert out is not None
     assert "items" not in out, "per-field-legal payload still totalling megabytes survived"


### PR DESCRIPTION
Follow-up to #1067, which merged while this review was in flight. Copilot left
three comments on that PR; two were addressed before merge, **the third was not**,
and it is correct.

## The finding Copilot made and #1067 shipped without

`_guard_exhaust` exists to stop an adapter smuggling raw content into the discard
ledger, because the ledger is content-addressed into the artifact store and served
at `/v1/artifacts/{exhaust_sha}` — token-gated, but any token holder is a consumer.

`specVersion` is on the top-level allowlist and was type-checked but never
length-bounded. Verified live against merged main before fixing:

```
PROBE specVersion  bytes=10,200,000  SURVIVED_GUARD=True
```

10.2 MB of verbatim text through the guard, intact, into the artifact store. That
is the exact exfil path the guard was written to close.

## A second one, found by probing for siblings

`counts` bounded each key to 256 chars but never bounded **how many** keys:

```
PROBE counts keys   bytes=12,700,037  SURVIVED_GUARD=True
```

## Fix

Both bounded per-field, plus an aggregate 2 MiB cap as a backstop. Per-field
bounds only close the dimensions someone remembered to enumerate, and this guard
has now missed two. The backstop is deliberately consulted last and deliberately
not derived from the per-field limits.

Sized by measurement, not guess:

| record | serialises to |
|---|---|
| largest *legitimate* record the per-field bounds permit (full 10k-entry bare-digest ledger) | 0.93 MiB |
| smallest per-field-legal record that is plainly payload (10k items x two 512-char URNs) | 10.05 MiB |
| cap | 2 MiB |

## Proof each bound fires

Mutation, not assertion-by-inspection. Widening any single bound turns its own
tests red and leaves the rest green:

| mutation | result |
|---|---|
| `_MAX_SPEC_VERSION_LEN` 64 → 100M | 2 failed, 20 passed |
| `_MAX_COUNT_KEYS` 256 → 100M | 2 failed, 20 passed |
| aggregate backstop deleted | 1 failed, 21 passed |
| backstop tightened to 128 KiB | legit-ledger test fails (bound is not merely permissive) |
| restored | 22 passed |

**The first draft of these tests did not have that property.** They asserted only
"was rejected", and stayed green with the per-field bound deleted — because the
aggregate backstop caught the same payload. Two guards the tests cannot tell apart
is one guard that can be deleted with nothing going red. They now assert *which*
check rejected the record, and each per-field bound has a discriminating case
sized deliberately below the backstop so the two cannot shadow each other.

Full compute-gateway suite: 173 passed.

## Non-claims

- Does not change what adapters legitimately emit; a real ExhaustRecord is ~242 bytes.
- Does not re-audit the `_parse` sha256 recompute from #1067 beyond confirming
  `raw` is the decoded document bytes actually parsed (it is).
- Residual, deliberately not closed here: within the 2 MiB cap, well-formed URN
  refs remain an attacker-chosen channel at ~6 bits/char. Bounding refs harder
  than 512 chars is a separate judgement about what a legitimate URN looks like.