### PR TITLE
health-twin: read HEALTH_TWIN_CONSULT_MAX strictly (Copilot on #1068)

### DIFF
--- a/apps/health-twin/src/consult.test.ts
+++ b/apps/health-twin/src/consult.test.ts
@@ -93,3 +93,42 @@ test('default cap is 10_000 when env is unset or malformed', async () => {
   const m3 = await freshModule({ HEALTH_TWIN_CONSULT_MAX: '-5' });
   assert.equal(m3.CONSULT_MAX, 10_000, 'negatives fall back to default');
 });
+
+/**
+ * The test above claimed "or malformed" but only exercised the two malformed
+ * inputs that Number.parseInt happens to reject outright. The dangerous class
+ * is the one parseInt ACCEPTS by reading a prefix and discarding the rest, and
+ * none of those were covered.
+ *
+ * Note the trap in the original test's own notation: it writes the default as
+ * the JS numeric literal `10_000`, which is 10000. The *string* '10_000' — the
+ * same thing an operator types into a ConfigMap — parses to 10. The test
+ * spelled the failing input on every line and could never hit it, because a
+ * literal is not a string.
+ *
+ * Each case below FAILED against the parseInt implementation merged in #1068.
+ */
+test('a partially-numeric cap is refused, not silently truncated', async () => {
+  const cases: Array<[string, string]> = [
+    ['10_000', 'underscore separator: parseInt stops at "_" and yields 10'],
+    ['1e5', 'scientific notation: parseInt stops at "e" and yields 1'],
+    ['10000oops', 'trailing garbage: parseInt reads the prefix and reports success'],
+    ['0x10', 'hex: parseInt(radix 10) stops at "x" and yields 0'],
+    ['12.9', 'decimal: parseInt truncates silently'],
+    ['', 'empty'],
+    ['   ', 'whitespace only'],
+    ['+5', 'signed'],
+    ['99999999999999999999', 'beyond Number.MAX_SAFE_INTEGER'],
+  ];
+  for (const [value, why] of cases) {
+    const m = await freshModule({ HEALTH_TWIN_CONSULT_MAX: value });
+    assert.equal(m.CONSULT_MAX, 10_000, `${JSON.stringify(value)} must fall back to the default — ${why}`);
+  }
+});
+
+test('a well-formed cap is still honoured', async () => {
+  for (const [value, expected] of [['1', 1], ['42', 42], ['10000', 10_000], [' 250 ', 250]] as const) {
+    const m = await freshModule({ HEALTH_TWIN_CONSULT_MAX: value });
+    assert.equal(m.CONSULT_MAX, expected, `${JSON.stringify(value)} must be honoured`);
+  }
+});

--- a/apps/health-twin/src/consult.test.ts
+++ b/apps/health-twin/src/consult.test.ts
@@ -118,7 +118,13 @@ test('a partially-numeric cap is refused, not silently truncated', async () => {
     ['', 'empty'],
     ['   ', 'whitespace only'],
     ['+5', 'signed'],
-    ['99999999999999999999', 'beyond Number.MAX_SAFE_INTEGER'],
+    ['99999999999999999999', 'far beyond Number.MAX_SAFE_INTEGER'],
+    // The sharp one: all digits, and Number() does NOT fail on it — it rounds to
+    // 9007199254740992, which IS a safe integer, so an isSafeInteger() guard
+    // accepts a value one less than what the operator wrote. Silently altering
+    // the config is the same defect as parseInt's partial read.
+    ['9007199254740993', 'one past MAX_SAFE_INTEGER — Number() rounds it to a *different* safe integer'],
+    ['9007199254740992', 'MAX_SAFE_INTEGER + 1 — the first value that cannot round-trip'],
   ];
   for (const [value, why] of cases) {
     const m = await freshModule({ HEALTH_TWIN_CONSULT_MAX: value });
@@ -127,7 +133,12 @@ test('a partially-numeric cap is refused, not silently truncated', async () => {
 });
 
 test('a well-formed cap is still honoured', async () => {
-  for (const [value, expected] of [['1', 1], ['42', 42], ['10000', 10_000], [' 250 ', 250]] as const) {
+  for (const [value, expected] of [
+    ['1', 1], ['42', 42], ['10000', 10_000], [' 250 ', 250],
+    // The boundary itself must remain acceptable — the rejection above must be
+    // "cannot round-trip", not "large numbers are suspicious".
+    ['9007199254740991', Number.MAX_SAFE_INTEGER],
+  ] as const) {
     const m = await freshModule({ HEALTH_TWIN_CONSULT_MAX: value });
     assert.equal(m.CONSULT_MAX, expected, `${JSON.stringify(value)} must be honoured`);
   }

--- a/apps/health-twin/src/consult.ts
+++ b/apps/health-twin/src/consult.ts
@@ -68,6 +68,18 @@ export interface Consult {
 // A cap of 1 or 10 wedges the consult API almost immediately, and (until an
 // operator surface for closeConsult exists — see #1072) that wedge lasts until
 // the process restarts. Refusing to guess is the only safe reading.
+// All digits, then a safe-integer range check. The two together are sufficient,
+// including at the precision boundary — Number() rounds a digit string past
+// MAX_SAFE_INTEGER, but every such rounded value is itself unsafe, so
+// isSafeInteger still rejects it. Measured, because it is not obvious:
+//
+//     "9007199254740993" -> Number() 9007199254740992, isSafeInteger FALSE  -> rejected
+//     "9007199254740992" -> Number() 9007199254740992, isSafeInteger FALSE  -> rejected
+//     "9007199254740991" -> Number() 9007199254740991, isSafeInteger TRUE   -> accepted
+//
+// (A review suggested BigInt here on the premise that isSafeInteger returns true
+// for the rounded value. It does not — see the table. BigInt would be equivalent,
+// so the simpler form stays. The boundary cases are pinned in the tests.)
 const DEFAULT_CONSULT_MAX = 10_000;
 const _envRaw = (process.env.HEALTH_TWIN_CONSULT_MAX ?? '').trim();
 const _envMax = /^\d+$/.test(_envRaw) ? Number(_envRaw) : Number.NaN;

--- a/apps/health-twin/src/consult.ts
+++ b/apps/health-twin/src/consult.ts
@@ -54,12 +54,29 @@ export interface Consult {
 // consult. Silent LRU eviction of a consult with attached medical opinions
 // would destroy real work, and 'lost state' is the class of failure this
 // codebase removes as a matter of doctrine. Explicit pruning is closeConsult.
-const _envMax = Number.parseInt(process.env.HEALTH_TWIN_CONSULT_MAX ?? '', 10);
-export const CONSULT_MAX = Number.isFinite(_envMax) && _envMax > 0 ? _envMax : 10_000;
+// The cap is parsed STRICTLY: the whole value must be digits, or we fall back
+// to the default. Number.parseInt() is the wrong tool for reading config,
+// because it stops at the first character it does not understand and reports
+// success on the prefix it managed to read. Three of those partial reads are
+// things an operator would plausibly write, and every one of them silently
+// yields a cap far smaller than intended rather than an error:
+//
+//     HEALTH_TWIN_CONSULT_MAX="10_000"  ->  parseInt 10     ->  cap of 10
+//     HEALTH_TWIN_CONSULT_MAX="1e5"     ->  parseInt 1      ->  cap of 1
+//     HEALTH_TWIN_CONSULT_MAX="10000oops" -> parseInt 10000 ->  wrong-but-plausible
+//
+// A cap of 1 or 10 wedges the consult API almost immediately, and (until an
+// operator surface for closeConsult exists — see #1072) that wedge lasts until
+// the process restarts. Refusing to guess is the only safe reading.
+const DEFAULT_CONSULT_MAX = 10_000;
+const _envRaw = (process.env.HEALTH_TWIN_CONSULT_MAX ?? '').trim();
+const _envMax = /^\d+$/.test(_envRaw) ? Number(_envRaw) : Number.NaN;
+export const CONSULT_MAX =
+  Number.isSafeInteger(_envMax) && _envMax > 0 ? _envMax : DEFAULT_CONSULT_MAX;
 const consults = new Map<string, Consult>();
 
 /** Explicit pruning — the caller decides what to drop. Returns true when a
- *  consult was removed, false when the id wasn\'t known. */
+ *  consult was removed, false when the id wasn't known. */
 export function closeConsult(consultId: string): boolean {
   return consults.delete(consultId);
 }


### PR DESCRIPTION
> **Path note for the health-twin lane:** this touches `apps/health-twin/src/consult.ts`
> and its test. I was asked to stay off `server.ts`/`deident.ts`/`invariants.ts` and have;
> no open PR touches `consult.ts`. Reassign or take over if it collides with live work.

Follow-up to #1068, which merged while this review was in flight with three
Copilot comments unaddressed. This closes two of them; the third needs
`server.ts` and is filed separately.

## The one with a live consequence

`Number.parseInt()` is the wrong tool for reading config: it stops at the first
character it does not understand and reports success on the prefix it read.
Three of those partial reads are things an operator would plausibly write into
a ConfigMap, and each silently yields a cap far smaller than intended:

| env value | parseInt | resulting cap |
|---|---|---|
| `10_000` | 10 | **10** |
| `1e5` | 1 | **1** |
| `10000oops` | 10000 | 10000 (wrong but plausible) |
| `0x10` | 0 | falls back |
| `12.9` | 12 | 12 |

A cap of 1 or 10 wedges the consult API almost immediately. And because **no
HTTP surface can reach `closeConsult()`**, that wedge lasts until the process
restarts — so a single typo in a ConfigMap turns the DoS fix into a DoS.

The whole value must now be digits, or the default stands.

## Why the existing test did not catch it

Worth recording, because the trap is subtle. The test is named *"default cap is
10_000 when env is unset or malformed"* and covers exactly the two malformed
inputs `parseInt` rejects outright (`'not a number'`, `'-5'`). The dangerous
class is the one `parseInt` **accepts**, and none of those were covered.

And the test writes the default as the JS numeric literal `10_000` — which is
`10000`. The *string* `'10_000'`, which is what an operator actually types,
parses to `10`. The test spelled the failing input on every single line and
could never hit it, because a literal is not a string.

New cases verified **red** against the implementation merged in #1068
(`actual: 10, expected: 10000`), green after the fix. 7 tests pass.

## Also fixed

The stray backslash in the `closeConsult` JSDoc (`wasn\'t`), which rendered
literally in IDE hovers — Copilot's second comment.

## Verified separately, no change needed

The cap **does** bound memory as the PR claimed. 60 000 open attempts:

| cap | ledger after 60k attempts | heap |
|---|---|---|
| 1 000 | exactly 1 000 | flat at 8.2 MiB |
| 20 000 | exactly 20 000 | flat at 25.2 MiB |

Refusals are counted and the ledger never exceeds the cap.

## Not fixed here — needs the health-twin lane

`closeConsult()` is exported and tested but **called by nothing outside its own
test file**. `server.ts` imports `openConsult, reviewerView, submitOpinion,
aggregate, requestMore` — not `closeConsult`, not `consultCount`. So the
overflow error tells operators to "close finished consults with
`closeConsult()`" via a function no deployed caller can invoke. Filed as an
issue; the fix is a `DELETE /api/health/consult/:id` in `server.ts`, which is
another lane's file.