### PR TITLE
health-twin: make the de-identification date shift fail closed

### DIFF
--- a/apps/health-twin/src/deident.ts
+++ b/apps/health-twin/src/deident.ts
@@ -118,13 +118,99 @@ function dateShiftFrom(digest: string): number {
   return Number(BigInt(`0x${digest.slice(0, 16)}`) % 366n) - 183;
 }
 
-const shiftDate = (iso: string, days: number): string => {
-  if (!iso || iso.length < 7) return iso;
-  const d = new Date(iso.length === 7 ? `${iso}-01` : iso);
-  if (isNaN(d.getTime())) return iso;
-  d.setDate(d.getDate() + days);
-  return d.toISOString().slice(0, 10);
-};
+// ── DATE SHIFTING ───────────────────────────────────────────────────────────────────────────────
+// shiftDate used to FAIL OPEN. Anything it could not parse — a bare '2024', an empty string,
+// 'not-a-date', a malformed-but-meaningful '2024-13-45' — was returned UNCHANGED, so an UNSHIFTED
+// date survived into a view whose receipt claims 'safe-harbor+date-shift'. Today's synthetic data
+// is all well-formed ISO, so nothing reaches those paths; the connector plane (Epic / CMS Blue
+// Button / DICOMweb) lands date fields with no such guarantee. The failure is silent by
+// construction: a passed-through date is byte-indistinguishable from a shifted one.
+//
+// Every date field now lands in exactly ONE of four outcomes, each explicit and each COUNTED on the
+// receipt (see DeidReceipt.dates). The four are separated deliberately, because the old code got
+// the bare-year case RIGHT — but by accident, through the very same `length < 7` short-circuit that
+// waved the garbage through. Correct-by-accident and wrong are the same line of code until you
+// split them apart.
+//
+// WHY A SENTINEL AND NOT A DROP. Dropping an unparseable date fails closed on the DATA but fails
+// OPEN on the READER: an absent field is indistinguishable from "this subject had no such date", so
+// the suppression becomes invisible at the point of use. That is the same silent-gap failure being
+// fixed here, merely relocated from the writer to the reader. The sentinel makes the gap legible
+// where it is READ; the receipt count makes it legible in the AUDIT RECORD.
+export const DATE_UNSHIFTABLE = 'date-unshiftable';
+
+// What a single date field became. Exactly one per field, and all four are counted.
+export type DateOutcome = 'shifted' | 'yearOnly' | 'absent' | 'unshiftable';
+
+export interface DateShiftCounts {
+  shifted: number;      // parsed and moved by dateShiftDays
+  yearOnly: number;     // bare 'YYYY' — deliberately passed through, see below
+  absent: number;       // no date to shift ('' / null / undefined)
+  unshiftable: number;  // replaced with DATE_UNSHIFTABLE — the receipt must not hide these
+}
+
+const BARE_YEAR = /^\d{4}$/;
+// The leading calendar date of an ISO-8601 value: 'YYYY-MM', 'YYYY-MM-DD', or 'YYYY-MM-DD' followed
+// by a time. Matching the DATE and ignoring any time-of-day is what keeps this timezone-stable for
+// offset-bearing and offset-less datetimes alike (see the UTC note below).
+const ISO_LEAD = /^(\d{4})-(\d{2})(?:-(\d{2}))?(?:[T ].*)?$/;
+const MS_PER_DAY = 86_400_000;
+const SHIFTED_FORM = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Shift one date field, reporting WHICH of the four branches it took so the caller can count it.
+ *
+ * The arithmetic is UTC-only, and that is load-bearing. The previous implementation parsed with
+ * `new Date(iso)` — which reads a date-only ISO string as UTC MIDNIGHT — then advanced it with
+ * LOCAL-time `getDate`/`setDate`. Those two cancel only while the local UTC offset is identical on
+ * both sides of the shift. Across a DST transition they do not, and the shipped code was measurably
+ * NOT timezone-stable: under America/Los_Angeles, '2024-01-15' shifted +88d produced 2024-04-11,
+ * where UTC, Asia/Kolkata and Pacific/Kiritimati (neither of the latter observes DST) all produced
+ * 2024-04-12. The error is per-DATE, not per-view, so it also broke the one property this module
+ * exists to preserve: the real 152-day interval 2024-01-15 → 2024-06-15 came back as 153 days under
+ * LA, because only the earlier endpoint crossed the March transition. Whole days added to a UTC
+ * instant cannot drift — there is no local offset left to fail to cancel.
+ */
+function shiftDateField(value: unknown, days: number): { value: string; outcome: DateOutcome } {
+  // (3) ABSENT — there was no date. Not an error, and not something to stamp a sentinel onto.
+  // The original value is returned so an undefined field stays undefined rather than becoming ''.
+  if (value === null || value === undefined || value === '') {
+    return { value: value as string, outcome: 'absent' };
+  }
+  // A non-string in a date field is not a date. Fail closed rather than coerce it.
+  if (typeof value !== 'string') return { value: DATE_UNSHIFTABLE, outcome: 'unshiftable' };
+
+  // (2) BARE YEAR — an EXPLICIT ALLOW, not a fallthrough. HIPAA Safe Harbor permits year
+  // granularity for dates (it is dates more precise than a year that must go), so 'YYYY' is already
+  // de-identified and passing it through unshifted is correct. It is counted separately so that
+  // "we allowed this" is never confused with "we failed to parse this".
+  if (BARE_YEAR.test(value)) return { value, outcome: 'yearOnly' };
+
+  // (1) WELL-FORMED — 'YYYY-MM' (treated as the 1st), 'YYYY-MM-DD', or either followed by a time.
+  const m = ISO_LEAD.exec(value);
+  if (m) {
+    const year = Number(m[1]);
+    const month = Number(m[2]);
+    const day = m[3] === undefined ? 1 : Number(m[3]);
+    // setUTCFullYear rather than Date.UTC(): Date.UTC maps a 2-digit year onto 19xx, which would
+    // silently relocate a year like '0024'.
+    const base = new Date(0);
+    base.setUTCFullYear(year, month - 1, day);
+    // Date normalises out-of-range parts instead of rejecting them — '2024-13-45' would quietly
+    // become 2025-02-14. Round-tripping the components is what actually rejects a malformed date.
+    if (
+      base.getUTCFullYear() === year && base.getUTCMonth() === month - 1 && base.getUTCDate() === day
+    ) {
+      const shifted = new Date(base.getTime() + days * MS_PER_DAY).toISOString().slice(0, 10);
+      // A year outside the 4-digit range formats as '+010000-…' and would emit a truncated string;
+      // anything that is not a plain YYYY-MM-DD is treated as unshiftable rather than shipped.
+      if (SHIFTED_FORM.test(shifted)) return { value: shifted, outcome: 'shifted' };
+    }
+  }
+
+  // (4) EVERYTHING ELSE — unparseable. Replaced with the sentinel, never returned as itself.
+  return { value: DATE_UNSHIFTABLE, outcome: 'unshiftable' };
+}
 
 export interface DeidReceipt {
   method: 'safe-harbor+date-shift';
@@ -137,6 +223,12 @@ export interface DeidReceipt {
   // rather than from intent: `keyed: false` means a guessable subject id yields this pseudonym.
   derivation: 'hmac-sha256' | 'sha256';
   keyed: boolean;
+  // What actually happened to every date field in THIS view, by branch. `method` says
+  // 'safe-harbor+date-shift'; a receipt that made that claim while N dates went through unshifted
+  // would be a receipt that lies, in exactly the way `keyed:false` above exists to prevent. A
+  // non-zero `unshiftable` is the receipt declining to overstate: those fields carry
+  // DATE_UNSHIFTABLE, not a date. `yearOnly` is a permitted pass-through, not a failure.
+  dates: DateShiftCounts;
   at: string;
 }
 
@@ -175,32 +267,40 @@ export function deidentify(bundle: any, salt = 'default', scope: DisclosureScope
   // the SAME predicate derive() just used — not a second look at the environment
   const keyed = keyState().keyed;
   const removed = new Set<string>();
+  // Per-view tally. Every shiftDate() call below lands in exactly one bucket, and the whole tally
+  // goes on the receipt, so the count cannot drift from what was actually emitted.
+  const dates: DateShiftCounts = { shifted: 0, yearOnly: 0, absent: 0, unshiftable: 0 };
+  const shiftDate = (value: unknown): string => {
+    const r = shiftDateField(value, dateShiftDays);
+    dates[r.outcome]++;
+    return r.value;
+  };
 
   const systems = (bundle?.systems ?? []).map((s: any) => ({
     id: s.id, label: s.label, organs: s.organs,
     observations: (s.observations ?? []).map((o: any) => ({
       code: o.code, codeSystem: o.codeSystem, display: o.display, value: o.value, unit: o.unit,
-      refLow: o.refLow, refHigh: o.refHigh, effective: shiftDate(o.effective, dateShiftDays), trend: o.trend,
+      refLow: o.refLow, refHigh: o.refHigh, effective: shiftDate(o.effective), trend: o.trend,
       epistemic: o.epistemic, organ: o.organ,
     })),
     conditions: (s.conditions ?? []).map((c: any) => ({
-      code: c.code, codeSystem: c.codeSystem, display: c.display, onset: shiftDate(c.onset, dateShiftDays),
+      code: c.code, codeSystem: c.codeSystem, display: c.display, onset: shiftDate(c.onset),
       clinicalStatus: c.clinicalStatus, epistemic: c.epistemic, organ: c.organ,
     })),
     encounters: (s.encounters ?? []).map((e: any) => {
       if (e.provider) removed.add('provider-names');
       if (e.note) removed.add('free-text-notes');
-      return { type: e.type, date: shiftDate(e.date, dateShiftDays) }; // provider + note dropped
+      return { type: e.type, date: shiftDate(e.date) }; // provider + note dropped
     }),
     imaging: (s.imaging ?? []).map((im: any) => ({
-      modality: im.modality, bodySite: im.bodySite, date: shiftDate(im.date, dateShiftDays),
+      modality: im.modality, bodySite: im.bodySite, date: shiftDate(im.date),
       description: im.description, epistemic: im.epistemic,
     })),
   }));
 
   if (bundle?.subject?.label) removed.add('names');
   if (bundle?.subject?.note) removed.add('narrative');
-  removed.add('dates'); // shifted
+  removed.add('dates'); // shifted — per-branch outcome is on receipt.dates, which does not round up
 
   // 'standard' scope keeps the coarsened demographics a doctor needs; 'minimal' shares only facts.
   const subject: DeidView['subject'] = { pseudonym };
@@ -216,6 +316,7 @@ export function deidentify(bundle: any, salt = 'default', scope: DisclosureScope
       method: 'safe-harbor+date-shift', pseudonym, identifiersRemoved: [...removed].sort(),
       dateShiftDays, scope,
       derivation: keyed ? 'hmac-sha256' : 'sha256', keyed,
+      dates,
       at: new Date().toISOString(),
     } as DeidReceipt,
   };

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -235,6 +235,97 @@ console.log('\n▶ INVARIANT 8 — the de-identification boundary is cryptograph
   } finally {
     if (saved === undefined) delete process.env[KEY]; else process.env[KEY] = saved;
   }
+
+  // ── THE DATE SHIFT FAILS CLOSED ───────────────────────────────────────────────────────────────
+  // shiftDate() returned anything it could not parse UNCHANGED, so a malformed-but-meaningful date
+  // ('2024-13-45') survived UNSHIFTED into a view whose receipt claims 'safe-harbor+date-shift'.
+  // Asserted on real deidentify() OUTPUT: calling the helper directly, or checking a hand-built
+  // string, would leave the actual data path unproven — which is exactly how consult.ts went on
+  // shipping 8-hex ids underneath a passing invariant.
+  const WELL_FORMED = ['2024-01-15', '2024-01', '2024-01-15T10:30:00Z'];
+  const YEAR_ONLY = ['2024'];
+  const ABSENT: (string | undefined)[] = ['', undefined];
+  // malformed, and none of it a date: month 13 / day 45, a real-looking impossible day, a
+  // non-ISO ordering, prose, whitespace, and all-zeroes.
+  const GARBAGE = ['not-a-date', '2024-13-45', '2024-02-30', '15/01/2024', 'yesterday', '   ', '0000-00-00'];
+  const ALL = [...WELL_FORMED, ...YEAR_ONLY, ...ABSENT, ...GARBAGE];
+  const dateBundle = {
+    subject: { id: 'date-probe' },
+    systems: [{
+      id: 'sys', label: 'Sys', organs: [],
+      observations: ALL.map((d, i) => ({
+        code: `C${i}`, codeSystem: 'LOINC', display: `case ${i}`, value: 1, unit: 'x',
+        effective: d, epistemic: 'measured',
+      })),
+      conditions: [], encounters: [], imaging: [],
+    }],
+  };
+  const dv = deidentify(dateBundle, 'date-probe');
+  const emitted = dv.systems[0].observations.map((o: any) => o.effective);
+
+  // THE INVARIANT: no unparseable input survives as itself.
+  const survivors = GARBAGE.filter((g) => emitted.includes(g));
+  ok(survivors.length === 0,
+     `no unparseable date survives as itself through deidentify() (survivors: ${JSON.stringify(survivors)})`);
+  // and what replaced it is the sentinel. The LITERAL, not the imported constant: this string is a
+  // wire contract a reader matches on, so a change to the constant's VALUE must fail here.
+  const garbageOut = emitted.slice(WELL_FORMED.length + YEAR_ONLY.length + ABSENT.length);
+  ok(garbageOut.every((v: unknown) => v === 'date-unshiftable'),
+     `every unparseable date is replaced by the sentinel (${JSON.stringify(garbageOut)})`);
+
+  // A bare year is an EXPLICIT ALLOW — Safe Harbor permits year granularity — not a parse failure.
+  ok(emitted[WELL_FORMED.length] === '2024', 'a bare year passes through unshifted (Safe Harbor permits it)');
+  ok(WELL_FORMED.every((_, i) => /^\d{4}-\d{2}-\d{2}$/.test(emitted[i]) && emitted[i] !== WELL_FORMED[i]),
+     `every well-formed date was actually shifted (${JSON.stringify(emitted.slice(0, WELL_FORMED.length))})`);
+
+  // The receipt must not overstate what was de-identified: every date field is counted in exactly
+  // one branch, and the branches sum to the number of fields that went in.
+  const dc = dv.receipt.dates;
+  ok(dc.shifted === WELL_FORMED.length && dc.yearOnly === YEAR_ONLY.length
+     && dc.absent === ABSENT.length && dc.unshiftable === GARBAGE.length,
+     `receipt counts each branch exactly (${JSON.stringify(dc)})`);
+  ok(dc.shifted + dc.yearOnly + dc.absent + dc.unshiftable === ALL.length,
+     `receipt accounts for all ${ALL.length} date fields — none silently uncounted`);
+  ok(dc.unshiftable > 0,
+     'a view containing unshiftable dates says so on its receipt rather than claiming a clean shift');
+
+  // TIMEZONE STABILITY. The shift is whole days on a UTC instant, so the same input must give the
+  // same output in every zone. The previous implementation parsed date-only strings as UTC midnight
+  // and then advanced them with LOCAL-time setDate: the two offsets cancel only when none of the
+  // shift crosses a DST transition, so under America/Los_Angeles '2024-01-15' +88d came out a day
+  // early. Several salts are exercised precisely so that some shifts DO cross a transition.
+  const ZONES = ['UTC', 'America/Los_Angeles', 'Pacific/Kiritimati', 'Asia/Kolkata'];
+  const savedTZ = process.env.TZ;
+  // try/finally for the same reason the key block uses one: TZ is process-wide, and leaving it set
+  // would silently re-time every invariant that runs after this.
+  try {
+    const perZone = ZONES.map((tz) => {
+      process.env.TZ = tz;
+      return JSON.stringify(Array.from({ length: 12 }, (_, i) => {
+        const v = deidentify(dateBundle, `tz-salt-${i}`);
+        return [v.receipt.dateShiftDays, v.systems[0].observations.map((o: any) => o.effective)];
+      }));
+    });
+    ok(new Set(perZone).size === 1,
+       `the de-identified dates are identical in ${ZONES.join(', ')} (a local-time shift diverges across a DST edge)`);
+  } finally {
+    if (savedTZ === undefined) delete process.env.TZ; else process.env.TZ = savedTZ;
+  }
+
+  // INTERVALS SURVIVE — the property the whole date-shift exists to preserve. The local-time bug
+  // broke this too: only the endpoint on the far side of a DST edge moved, so a real 152-day gap
+  // came back as 153 under LA.
+  const gapBundle = (id: string) => ({
+    subject: { id }, systems: [{ id: 'sys', label: 'Sys', organs: [],
+      observations: ['2024-01-15', '2024-06-15'].map((d, i) => ({
+        code: `G${i}`, codeSystem: 'LOINC', display: `g${i}`, value: 1, unit: 'x', effective: d, epistemic: 'measured' })),
+      conditions: [], encounters: [], imaging: [] }],
+  });
+  const gapsHold = Array.from({ length: 12 }, (_, i) => {
+    const o = deidentify(gapBundle('gap'), `gap-${i}`).systems[0].observations;
+    return Math.round((Date.parse(o[1].effective) - Date.parse(o[0].effective)) / 86_400_000);
+  }).every((g) => g === 152);
+  ok(gapsHold, 'a 152-day interval is still 152 days after shifting (intervals are what the shift must preserve)');
 }
 
 


### PR DESCRIPTION
> **Stacked on #1066.** Base is `fix/djb2-sweep-deident`, not `main`. `deident.ts` on platform `main` still carries the pre-sha256 djb2 derivation, so branching from `main` would either revert #1066 or break the deliberate byte-parity with prophet-health. Merge #1066 first; this retargets to `main` on its own.
> Twin PR: SocioProphet/prophet-health#7.

`shiftDate()` failed open. Anything it could not parse was returned **unchanged** — a bare `2024`, an empty string, `not-a-date`, a malformed-but-meaningful `2024-13-45` — so an **unshifted** date could land in a view whose receipt claims `safe-harbor+date-shift`. Nothing in today's synthetic data reaches those paths, but the connector plane (Epic / CMS Blue Button / DICOMweb) lands date fields with no well-formedness guarantee, and the failure is silent by construction: a passed-through date is byte-indistinguishable from a shifted one.

## The four branches

Every date field now takes exactly one, each explicit and separately counted:

| input | branch | result |
|---|---|---|
| `2024-01-15`, `2024-01`, `2024-01-15T10:30:00Z` | `shifted` | moved by `dateShiftDays` |
| `2024` (`/^\d{4}$/`) | `yearOnly` | **explicit allow** — passed through |
| `''`, `null`, `undefined` | `absent` | passed through; there was no date |
| anything else | `unshiftable` | replaced with `date-unshiftable` |

The bare-year case was *already* correct — Safe Harbor permits year granularity — but correct **by accident**, via the same `length < 7` short-circuit that waved the garbage through. Correct-by-accident and wrong are the same line of code until you split them, so it is now a deliberate branch with the reason written down.

## Why a sentinel and not a drop

Dropping an unparseable date fails closed on the **data** but fails **open on the reader**: an absent field is indistinguishable from *"this subject had no such date"*, so the suppression goes invisible at the point of use. That is the same silent-gap failure being fixed, merely relocated from writer to reader. The sentinel makes the gap legible where it is **read**; the receipt count makes it legible in the **audit record**.

## The receipt

`DeidReceipt` gains `dates: { shifted, yearOnly, absent, unshiftable }`. A receipt claiming `safe-harbor+date-shift` while N dates went through unshifted is a receipt that lies — the same failure `keyed: false` / `derivation: 'sha256'` already exists to prevent. The branches sum to the number of fields that went in, so nothing is silently uncounted, and a non-zero `unshiftable` is the receipt declining to overstate.

## Also: the shift was NOT timezone-stable

Found while verifying that it was. The old code parsed date-only strings as UTC midnight and then advanced them with **local-time** `getDate`/`setDate`. Those offsets cancel only while none of the shift crosses a DST transition:

| input | shift | UTC | America/Los_Angeles | Pacific/Kiritimati | Asia/Kolkata |
|---|---|---|---|---|---|
| `2024-01-15` | −3d | 2024-01-12 | 2024-01-12 | 2024-01-12 | 2024-01-12 |
| `2024-01-15` | +88d | 2024-04-12 | **2024-04-11** | 2024-04-12 | 2024-04-12 |

A −3d shift does not cross the March transition, which is why the property looked true. Because the error is **per-date**, not per-view, it also broke the one thing the shift exists to preserve: the real 152-day interval `2024-01-15 → 2024-06-15` came back as **153 days** under LA, since only the earlier endpoint crossed the transition.

The arithmetic is now whole days added to a UTC instant — there is no local offset left to fail to cancel. **Well-formed inputs keep their previous UTC-zone output exactly**; only the DST-drifted zones change, and they change to agree.

## Verification

- `npx tsx src/invariants.ts` → exit 0, `npx tsx src/eval.ts` → exit 0, in **both** repos.
- Four-zone re-verification (`UTC`, `America/Los_Angeles`, `Pacific/Kiritimati`, `Asia/Kolkata`) through real `deidentify()` output: byte-identical in all four.
- **Teeth**, both repos: reverting the sentinel to a passthrough fails with all 7 malformed inputs named as survivors; reverting to local-time `setDate` fails the TZ-stability *and* interval-preservation assertions. Restored, green again.
- The invariant reads **real `deidentify()` output**, not a hand-built string — checking a synthetic probe is how `consult.ts` kept shipping 8-hex ids under a green gate.
- `deident.ts` re-verified **byte-identical** across both repos (`sha256 d4b5d1b3cd7d4ad53e5a8e0a818cdedca97e9acf4f9a1f88d2a2ad8ac2b15660`) via a node walker over per-file sha256. `scripts/sync-to-platform.sh` was **not** run — hand-applied, per the standing warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
