### PR TITLE
PROBE (do not merge): documented docs-only skip, NEW gate

### DIFF
--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -34,6 +34,10 @@ jobs:
         name: Is this diff provably inert for app/service tests?
         run: |
           set -euo pipefail
+          # PROBE ONLY - not for merge. Forces the docs-only verdict so the
+          # skip path is exercised even though this diff touches .github/.
+          echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          echo "PROBE: forcing docs_only=true"; exit 0
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "not a pull_request (${{ github.event_name }}) — main is never validated by inference"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"; exit 0

--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -250,14 +250,41 @@ jobs:
   # Single stable check name for branch-protection rulesets: requiring this one
   # job covers every matrix leg above (and any added later) without having to
   # enumerate ~45 per-target check names in repo settings.
+  #
+  # DO NOT RENAME THIS JOB. `diagnostics-gate` is the only context in the
+  # `main-required-checks` ruleset, and gitops-promote.yml dispatches this
+  # workflow specifically to produce this check name on promote branches.
+  #
+  # This gate used to read:
+  #   [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "false" ]
+  # which tested `failure` and `cancelled` and nothing else. A skipped job
+  # reports `skipped`, so both contains() calls were false and the gate went
+  # GREEN — the sole required check for the repository passing having verified
+  # that nothing ran. `changes` was not even in `needs:`, so the job that
+  # authorises the skips was outside the gate it authorises.
+  #
+  # The verdict now lives in tools/ci_diagnostics_gate.py, under unit test, for
+  # the same reason the skip rule lives in tools/ci_docs_only.py: a rule that
+  # only exists as a YAML expression is a rule nobody can test — and this one
+  # decides whether anything may merge at all. It is fail-CLOSED. Every needed
+  # job must have SUCCEEDED, with exactly one documented exception: app-test-
+  # diagnostics and smoke-target-diagnostics may report `skipped` when the
+  # `changes` job proved the diff docs-only (docs/** and root *.md, per
+  # tools/ci_docs_only.py), which is the filter declared on those two jobs
+  # above. Any other skip — a new path filter, a mistyped condition, a leg
+  # dropped from `needs:` — is RED until someone argues the case in that file.
   diagnostics-gate:
     if: always()
-    needs: [validate-target-diagnostics, app-test-diagnostics, smoke-target-diagnostics]
+    needs: [changes, validate-target-diagnostics, app-test-diagnostics, smoke-target-diagnostics]
     runs-on: ubuntu-latest
     steps:
-      - name: Fail if any diagnostics job failed
+      - uses: actions/checkout@v4
+      - name: Fail unless every diagnostics job ran and passed
+        # `needs` reaches the rule through the environment rather than string
+        # interpolation, so the verdict is computed from data and never from
+        # shell text assembled at template-expansion time.
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          echo "validate=${{ needs.validate-target-diagnostics.result }}"
-          echo "app-tests=${{ needs.app-test-diagnostics.result }}"
-          echo "smokes=${{ needs.smoke-target-diagnostics.result }}"
-          [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "false" ]
+          set -euo pipefail
+          printf '%s' "$NEEDS_JSON" | python3 tools/ci_diagnostics_gate.py

--- a/tools/ci_diagnostics_gate.py
+++ b/tools/ci_diagnostics_gate.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""The verdict rule behind `diagnostics-gate` — the ONE status check the
+`main-required-checks` ruleset requires for merging to main.
+
+WHY THIS FILE EXISTS
+  The gate used to be a single YAML expression:
+
+      [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "false" ]
+
+  It tested `failure` and `cancelled` and nothing else. A GitHub job that is
+  *skipped* reports `skipped` — neither of those — so both `contains()` calls
+  returned false and the gate went GREEN. When a path filter skipped the
+  upstream legs, every needed job reported `skipped` and the sole required
+  check for the whole repository passed having verified that nothing ran.
+
+  That is the defect this module closes, and the reason the rule now lives in
+  Python: a merge gate that only exists as a YAML expression is a merge gate
+  nobody can test. Same argument as tools/ci_docs_only.py, applied to the thing
+  that actually decides whether code may land.
+
+FAIL-CLOSED
+  ci_docs_only.py fails OPEN (any doubt runs the full matrix) because the worst
+  case there is wasted minutes. This module is its mirror image and fails
+  CLOSED: an unrecognised result, an unknown job, a missing job, or malformed
+  input is a RED gate. The worst case here is unreviewed code reaching main, so
+  doubt must block.
+
+CONTRACT
+  stdin  : the workflow's `toJSON(needs)` payload
+  stdout : one line per needed job, then the verdict
+  exit   : 0 = gate passes, 1 = gate fails
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+# Jobs that must have genuinely run and passed. No skip is ever acceptable for
+# these, so a path filter added to either one turns the gate RED until someone
+# comes here and argues the case in code.
+#
+#   changes                      — the job that AUTHORISES every skip below. If the
+#                                  authoriser did not run, no skip downstream can be
+#                                  trusted, whatever it claims.
+#   validate-target-diagnostics  — documented COVERAGE-PRESERVING in the workflow: its
+#                                  validate-repo leg asserts REQUIRED_FILES exist and
+#                                  scans for suspect markers, so documentation is NOT
+#                                  inert to it and it runs on every diff.
+MUST_SUCCEED = ('changes', 'validate-target-diagnostics')
+
+# Jobs allowed to report `skipped`, and ONLY under the one documented filter:
+# `if: always() && needs.changes.outputs.docs_only != 'true'`, whose rule is
+# tools/ci_docs_only.py (docs/** and root *.md are inert to application and
+# service tests). Skipped for any other reason — an upstream failure, a new
+# filter, a mistyped condition — is RED.
+DOCS_ONLY_SKIPPABLE = ('app-test-diagnostics', 'smoke-target-diagnostics')
+
+KNOWN_JOBS = MUST_SUCCEED + DOCS_ONLY_SKIPPABLE
+
+AUTHORISING_JOB = 'changes'
+AUTHORISING_OUTPUT = 'docs_only'
+
+
+def verdict(needs: dict) -> tuple[bool, list[str]]:
+    """Return (gate_passes, human-readable findings).
+
+    `needs` is the decoded `toJSON(needs)` payload: a mapping of job id to
+    {"result": str, "outputs": {...}}.
+    """
+    findings: list[str] = []
+    ok = True
+
+    if not isinstance(needs, dict):
+        return False, [f'needs payload is {type(needs).__name__}, not an object']
+
+    # A job wired into `needs:` that this rule has never heard of is unverified
+    # coverage: the gate would pass on it by silence. Fail until it is classified.
+    for job in sorted(set(needs) - set(KNOWN_JOBS)):
+        ok = False
+        findings.append(
+            f'{job}: wired into the gate but not classified here — add it to '
+            f'MUST_SUCCEED or DOCS_ONLY_SKIPPABLE in tools/ci_diagnostics_gate.py'
+        )
+
+    # A job this rule expects but that is absent from the payload means someone
+    # removed it from `needs:`, silently dropping it from the merge gate.
+    for job in KNOWN_JOBS:
+        if job not in needs:
+            ok = False
+            findings.append(
+                f'{job}: expected in the gate\'s `needs:` and absent — the gate '
+                f'no longer covers it'
+            )
+
+    entry = needs.get(AUTHORISING_JOB)
+    outputs = entry.get('outputs') if isinstance(entry, dict) else None
+    docs_only = (outputs or {}).get(AUTHORISING_OUTPUT) if isinstance(outputs, dict) else None
+    skips_authorised = docs_only == 'true'
+
+    for job in KNOWN_JOBS:
+        if job not in needs:
+            continue
+        entry = needs[job]
+        result = entry.get('result') if isinstance(entry, dict) else None
+
+        if result == 'success':
+            findings.append(f'{job}: success')
+            continue
+
+        if result == 'skipped' and job in DOCS_ONLY_SKIPPABLE and skips_authorised:
+            findings.append(
+                f'{job}: skipped — authorised by {AUTHORISING_JOB}.outputs.'
+                f'{AUTHORISING_OUTPUT}=true (tools/ci_docs_only.py: the diff is '
+                f'docs/** and root *.md only, which is inert to app and service tests)'
+            )
+            continue
+
+        ok = False
+        if result == 'skipped' and job in DOCS_ONLY_SKIPPABLE:
+            findings.append(
+                f'{job}: skipped but NOT authorised — {AUTHORISING_JOB}.outputs.'
+                f'{AUTHORISING_OUTPUT}={docs_only!r}, so this diff is not inert and '
+                f'these tests were owed'
+            )
+        elif result == 'skipped':
+            findings.append(
+                f'{job}: skipped, and it is never allowed to skip — it is the '
+                f'coverage this gate exists to guarantee'
+            )
+        else:
+            findings.append(f'{job}: {result!r}')
+
+    return ok, findings
+
+
+def main() -> int:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        print('FAIL: no needs payload on stdin', file=sys.stderr)
+        return 1
+    try:
+        needs = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f'FAIL: needs payload is not valid JSON: {exc}', file=sys.stderr)
+        return 1
+
+    ok, findings = verdict(needs)
+    for line in findings:
+        print(f'  {line}')
+    if ok:
+        print('diagnostics-gate: PASS — every leg ran, or skipped under a documented filter')
+        return 0
+    # Verdict on stdout, not stderr. Python block-buffers stdout when it is not a
+    # TTY, so a verdict written to stderr reaches the Actions log BEFORE the
+    # findings that justify it — exactly backwards for whoever is reading a red
+    # merge gate. The ::error:: annotation puts the headline in the run summary.
+    print('diagnostics-gate: FAIL — an unexplained skip is a red gate, not a green one')
+    print('::error::diagnostics-gate: a needed job did not succeed, or skipped without '
+          'authorisation. The per-job verdict is immediately above this line in the log.')
+    return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/tests/test_ci_diagnostics_gate.py
+++ b/tools/tests/test_ci_diagnostics_gate.py
@@ -1,0 +1,225 @@
+"""The verdict rule behind `diagnostics-gate`, the ONE required check for merging to main.
+
+The bug this suite exists to prevent recurring: the gate tested `failure` and
+`cancelled` but not `skipped`, so a skipped job sailed through and the gate went
+green having verified nothing. Most cases below therefore assert the gate is RED —
+a merge gate is worth exactly what its negative vectors prove.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci_diagnostics_gate import (  # noqa: E402
+    DOCS_ONLY_SKIPPABLE,
+    KNOWN_JOBS,
+    MUST_SUCCEED,
+    verdict,
+)
+
+ALL_RESULTS = ('success', 'failure', 'cancelled', 'skipped')
+
+
+def needs(*, changes='success', validate='success', app='success', smoke='success',
+          docs_only='false'):
+    """A `toJSON(needs)` payload shaped exactly as GitHub emits it."""
+    return {
+        'changes': {'result': changes, 'outputs': {'docs_only': docs_only}},
+        'validate-target-diagnostics': {'result': validate, 'outputs': {}},
+        'app-test-diagnostics': {'result': app, 'outputs': {}},
+        'smoke-target-diagnostics': {'result': smoke, 'outputs': {}},
+    }
+
+
+# ── the happy paths ───────────────────────────────────────────────────────────
+
+def test_every_leg_green_passes():
+    ok, _ = verdict(needs())
+    assert ok is True
+
+
+def test_docs_only_skip_of_app_and_smoke_is_authorised():
+    """The one documented filter: docs/** and root *.md are inert to app/service tests."""
+    ok, findings = verdict(needs(app='skipped', smoke='skipped', docs_only='true'))
+    assert ok is True
+    assert any('authorised' in f for f in findings)
+
+
+def test_docs_only_true_does_not_require_the_skip():
+    """A docs-only diff that runs the legs anyway is still perfectly green."""
+    ok, _ = verdict(needs(docs_only='true'))
+    assert ok is True
+
+
+# ── the regression this module was written for ────────────────────────────────
+
+@pytest.mark.parametrize('job', KNOWN_JOBS)
+def test_a_skipped_job_without_authorisation_is_red(job):
+    """THE BUG. `skipped` is neither 'failure' nor 'cancelled'; the old gate passed it."""
+    payload = needs()
+    payload[job]['result'] = 'skipped'
+    ok, _ = verdict(payload)
+    assert ok is False, f'{job} skipped with docs_only=false must fail the gate'
+
+
+def test_everything_skipped_is_red():
+    """The live scenario: a path filter skips every leg and the gate verifies nothing."""
+    ok, _ = verdict(needs(changes='skipped', validate='skipped', app='skipped',
+                          smoke='skipped'))
+    assert ok is False
+
+
+def test_everything_skipped_is_red_even_when_docs_only_claims_true():
+    """docs_only only ever authorises the app and smoke legs — never the validators."""
+    ok, _ = verdict(needs(changes='skipped', validate='skipped', app='skipped',
+                          smoke='skipped', docs_only='true'))
+    assert ok is False
+
+
+@pytest.mark.parametrize('job', MUST_SUCCEED)
+def test_the_always_on_jobs_may_never_skip(job):
+    payload = needs(docs_only='true')
+    payload[job]['result'] = 'skipped'
+    ok, _ = verdict(payload)
+    assert ok is False, f'{job} must run on every diff, docs-only included'
+
+
+def test_a_skipped_authoriser_cannot_authorise_its_own_skip():
+    """If `changes` did not run, its outputs are empty and prove nothing."""
+    payload = needs(changes='skipped', app='skipped', smoke='skipped')
+    payload['changes']['outputs'] = {}
+    ok, _ = verdict(payload)
+    assert ok is False
+
+
+# ── the behaviour the old gate did get right, which must not regress ──────────
+
+@pytest.mark.parametrize('job', KNOWN_JOBS)
+@pytest.mark.parametrize('bad', ['failure', 'cancelled'])
+def test_failure_and_cancellation_stay_red(job, bad):
+    payload = needs()
+    payload[job]['result'] = bad
+    ok, _ = verdict(payload)
+    assert ok is False
+
+
+@pytest.mark.parametrize('bad', ['failure', 'cancelled'])
+def test_a_failing_leg_is_red_even_on_a_docs_only_diff(bad):
+    payload = needs(docs_only='true')
+    payload['app-test-diagnostics']['result'] = bad
+    ok, _ = verdict(payload)
+    assert ok is False
+
+
+# ── fail-closed on anything unrecognised ──────────────────────────────────────
+
+@pytest.mark.parametrize('result', ['', None, 'neutral', 'timed_out', 'SUCCESS', 'sucess'])
+def test_an_unrecognised_result_is_red(result):
+    """Only the literal string 'success' is success. Case included."""
+    payload = needs()
+    payload['app-test-diagnostics']['result'] = result
+    ok, _ = verdict(payload)
+    assert ok is False
+
+
+def test_a_job_removed_from_needs_is_red():
+    """Dropping a job from `needs:` silently removes it from the merge gate."""
+    payload = needs()
+    del payload['smoke-target-diagnostics']
+    ok, _ = verdict(payload)
+    assert ok is False
+
+
+def test_an_unclassified_job_added_to_needs_is_red():
+    """A new leg must be classified here, or the gate would pass on it by silence."""
+    payload = needs()
+    payload['brand-new-diagnostics'] = {'result': 'success', 'outputs': {}}
+    ok, _ = verdict(payload)
+    assert ok is False
+
+
+def test_an_empty_payload_is_red():
+    ok, _ = verdict({})
+    assert ok is False
+
+
+@pytest.mark.parametrize('payload', [[], 'success', None, 42])
+def test_a_malformed_payload_is_red(payload):
+    ok, _ = verdict(payload)
+    assert ok is False
+
+
+@pytest.mark.parametrize('docs_only', ['True', 'TRUE', '1', 'yes', '', None, True])
+def test_only_the_literal_string_true_authorises_a_skip(docs_only):
+    """GitHub outputs are strings; anything but 'true' leaves the skip unauthorised."""
+    payload = needs(app='skipped', smoke='skipped', docs_only=docs_only)
+    ok, _ = verdict(payload)
+    assert ok is False
+
+
+def test_missing_outputs_block_do_not_authorise_a_skip():
+    payload = needs(app='skipped', smoke='skipped')
+    del payload['changes']['outputs']
+    ok, _ = verdict(payload)
+    assert ok is False
+
+
+# ── exhaustive truth table, so no combination is left to inference ────────────
+
+@pytest.mark.parametrize('app', ALL_RESULTS)
+@pytest.mark.parametrize('smoke', ALL_RESULTS)
+@pytest.mark.parametrize('docs_only', ['true', 'false'])
+def test_truth_table_for_the_skippable_legs(app, smoke, docs_only):
+    def leg_ok(result):
+        return result == 'success' or (result == 'skipped' and docs_only == 'true')
+
+    expected = leg_ok(app) and leg_ok(smoke)
+    ok, _ = verdict(needs(app=app, smoke=smoke, docs_only=docs_only))
+    assert ok is expected
+
+
+@pytest.mark.parametrize('result', ALL_RESULTS)
+@pytest.mark.parametrize('job', MUST_SUCCEED)
+@pytest.mark.parametrize('docs_only', ['true', 'false'])
+def test_truth_table_for_the_always_on_jobs(job, result, docs_only):
+    payload = needs(docs_only=docs_only)
+    payload[job]['result'] = result
+    ok, _ = verdict(payload)
+    assert ok is (result == 'success')
+
+
+# ── the module is invoked as a process by the workflow, so test it that way ───
+
+def run_cli(stdin: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / 'tools' / 'ci_diagnostics_gate.py')],
+        input=stdin, capture_output=True, text=True, check=False,
+    )
+
+
+def test_cli_exits_zero_when_green():
+    assert run_cli(json.dumps(needs())).returncode == 0
+
+
+def test_cli_exits_nonzero_on_an_unauthorised_skip():
+    proc = run_cli(json.dumps(needs(app='skipped', smoke='skipped')))
+    assert proc.returncode != 0
+
+
+@pytest.mark.parametrize('stdin', ['', '   ', 'not json', '{"changes":'])
+def test_cli_fails_closed_on_unusable_input(stdin):
+    """A gate that cannot read its inputs must block, never wave the merge through."""
+    assert run_cli(stdin).returncode != 0
+
+
+def test_the_classification_lists_are_disjoint_and_complete():
+    assert set(MUST_SUCCEED) & set(DOCS_ONLY_SKIPPABLE) == set()
+    assert set(KNOWN_JOBS) == set(MUST_SUCCEED) | set(DOCS_ONLY_SKIPPABLE)


### PR DESCRIPTION
Throwaway probe. **Do not merge — will be closed.**

`changes` reports `docs_only=true`, so app-tests and smokes skip under the filter they already declare, while the always-on validators still run.

Expected: **diagnostics-gate GREEN** — the fix must not break the intended docs-only optimisation. This is the teeth-the-other-way case.