### PR TITLE
health-twin: a grant id is not a credential — authenticate the holder on the PHI consent path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,47 @@ jobs:
           test "$(curl -s -o /dev/null -w '%{http_code}' localhost:8097/api/health/twin)" = 403
           test "$(curl -s -o /dev/null -w '%{http_code}' -X POST localhost:8097/api/health/grant -H 'content-type: application/json' -d '{"agent":"attacker"}')" = 403
 
+      # ── The configuration that will actually serve real records ────────────────────────────────
+      # Everything above runs the synthetic-only twin. `authenticated` is the mode a deployment holding
+      # a person's records must be in, and it had NO live coverage — the two membranes were each proved
+      # alone and never together. They answer different questions and neither substitutes for the
+      # other: exposure = may THIS DEPLOYMENT serve records at all; the grant = WHO may read how much.
+      # A request carrying one and not the other must fail, or one of them is decoration.
+      - name: boot smoke (authenticated mode) — both membranes, and neither alone
+        env:
+          HEALTH_TWIN_EXPOSURE: authenticated
+          HEALTH_TWIN_TOKEN: ci-deployment-secret-not-a-production-value
+        run: |
+          # the demo seed CANNOT exist here — asking for it is fatal at boot, not a warning
+          if HEALTH_TWIN_SEED_GRANT=1 PORT=8098 npx tsx src/server.ts > /tmp/seed-refusal.log 2>&1; then
+            echo "FAIL: the server booted with a demo consent grant in an authenticated deployment" >&2; exit 1
+          fi
+          grep -q 'Refusing to boot' /tmp/seed-refusal.log
+          # nor can the query-string form be switched back on here
+          if HEALTH_TWIN_LEGACY_GRANT_QUERY=1 PORT=8098 npx tsx src/server.ts > /tmp/legacy-refusal.log 2>&1; then
+            echo "FAIL: the server booted with grant ids accepted in the query string, in an authenticated deployment" >&2; exit 1
+          fi
+          grep -q 'Refusing to boot' /tmp/legacy-refusal.log
+
+          PORT=8098 npx tsx src/server.ts & sleep 3
+          curl -fsS localhost:8098/healthz
+          # minting consent needs the deployment credential
+          test "$(curl -s -o /dev/null -w '%{http_code}' -X POST localhost:8098/api/health/grant -H 'content-type: application/json' -d '{"agent":"Dr. X","scope":"cardiometabolic"}')" = 401
+          TOKEN=$(curl -fsS -X POST localhost:8098/api/health/grant \
+            -H "authorization: Bearer $HEALTH_TWIN_TOKEN" -H 'content-type: application/json' \
+            -d '{"agent":"Dr. X","scope":"cardiometabolic"}' | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+          test -n "$TOKEN"
+          # holder credential without the deployment credential → refused
+          test "$(curl -s -o /dev/null -w '%{http_code}' -H "x-health-grant: $TOKEN" localhost:8098/api/health/agent-read -X POST -d '{}' -H 'content-type: application/json')" = 401
+          # BOTH → the read goes through, receipted. This is the path that serves a real chart.
+          curl -fsS -H "authorization: Bearer $HEALTH_TWIN_TOKEN" -H "x-health-grant: $TOKEN" \
+            -X POST localhost:8098/api/health/agent-read -H 'content-type: application/json' -d '{}' | grep -q '"presentedBy":"sha256-'
+          # /doctor-view is not exposure-gated in this mirror (prophet-health is ahead there), so the
+          # holder credential alone is what stands between a caller and the chart. Assert exactly that
+          # rather than an exposure refusal this code does not make.
+          test "$(curl -s -o /dev/null -w '%{http_code}' localhost:8098/api/health/doctor-view)" = 401
+          curl -fsS -H "x-health-grant: $TOKEN" localhost:8098/api/health/doctor-view | grep -q '"presentedBy":"sha256-'
+
   orchestration-fixtures:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
           # refuses to boot.
           HEALTH_TWIN_SEED_GRANT: '1'
           HEALTH_TWIN_SEED_GRANT_SECRET: ci-holder-secret-not-a-production-value
+          # An explicit allowlist, because the default on a synthetic-only deployment is the loopback
+          # dev origins and this proves the configured path too. `*` is not expressible — asking for
+          # it is fatal at boot, asserted below.
+          HEALTH_TWIN_ALLOWED_ORIGINS: http://localhost:5174
         run: |
           SEED_GRANT=grant-dev-seed-cardiology
           SEED_TOKEN="$SEED_GRANT.$HEALTH_TWIN_SEED_GRANT_SECRET"
@@ -70,19 +74,96 @@ jobs:
           # holds what used to be sufficient to open a chart. It is refused before any lookup happens.
           test "$(curl -s -o /dev/null -w '%{http_code}' "localhost:8097/api/health/doctor-view?grant=$SEED_GRANT")" = 401
           curl -s "localhost:8097/api/health/doctor-view?grant=$SEED_GRANT" | grep -q 'not accepted in the query string'
+          # 🔴 NEGATIVE: …and refused WITH a valid holder credential too. The guard used to be
+          # `bareId !== null && !presented`, so a request carrying both was served 200: the id still
+          # went into the access log, the proxy log, the history and the `Referer`, and the
+          # deprecation Warning was suppressed on exactly those requests. What leaks the id is the
+          # URL, not the absence of a better credential.
+          test "$(curl -s -o /dev/null -w '%{http_code}' -H "x-health-grant: $SEED_TOKEN" "localhost:8097/api/health/doctor-view?grant=$SEED_GRANT")" = 401
+          curl -sD - -o /dev/null -H "x-health-grant: $SEED_TOKEN" "localhost:8097/api/health/doctor-view?grant=$SEED_GRANT" | grep -qi '^warning:'
+          # …and the same for a bare id in the JSON body, which is the same capability by a channel
+          # that merely happens not to be logged.
+          test "$(curl -s -o /dev/null -w '%{http_code}' -X POST localhost:8097/api/health/agent-read -H 'content-type: application/json' -H "x-health-grant: $SEED_TOKEN" -d "{\"grant\":\"$SEED_GRANT\"}")" = 401
           # NEGATIVE: the id in the header with no secret; a guessed secret; no credential at all.
           test "$(curl -s -o /dev/null -w '%{http_code}' -H "x-health-grant: $SEED_GRANT" localhost:8097/api/health/doctor-view)" = 401
           test "$(curl -s -o /dev/null -w '%{http_code}' -H "x-health-grant: $SEED_GRANT.wrong-secret" localhost:8097/api/health/doctor-view)" = 401
           test "$(curl -s -o /dev/null -w '%{http_code}' localhost:8097/api/health/doctor-view)" = 401
           # NEGATIVE: no enumeration oracle — an unknown id and a wrong secret are indistinguishable.
-          diff <(curl -s -H "x-health-grant: grant-nope.wrong-secret" localhost:8097/api/health/doctor-view | grep -o '"reason":"[^"]*"') \
-               <(curl -s -H "x-health-grant: $SEED_GRANT.also-wrong" localhost:8097/api/health/doctor-view | grep -o '"reason":"[^"]*"')
+          #
+          # 🔴 The previous form of this check COULD NOT FAIL. It was:
+          #     diff <(curl … | grep -o '"reason":"[^"]*"') <(curl … | grep -o '"reason":"[^"]*"')
+          # which compares one grepped substring and ignores every other field in the body — an
+          # oracle hiding in `detail`, in the receipt, or in the shape sails straight through
+          # (demonstrated). And `grep -o` prints NOTHING when it does not match, so two empty
+          # responses — server down, route renamed, body reshaped — diff clean and the step goes
+          # green having compared nothing at all. A check that passes on two empty strings is not a
+          # check. Whole body, non-emptiness asserted, and only the receipt's clock normalised.
+          norm() {
+            node -e '
+              let s=""; process.stdin.on("data",d=>s+=d).on("end",()=>{
+                if(!s.trim()){console.error("EMPTY refusal body — nothing was compared");process.exit(9);}
+                let o; try{o=JSON.parse(s);}catch{console.error("NON-JSON refusal body: "+s.slice(0,200));process.exit(9);}
+                if(o&&o.receipt&&o.receipt.at)o.receipt.at="<clock>";
+                process.stdout.write(JSON.stringify(o));});'
+          }
+          # assert_identical_refusals <label> <bodyA> <bodyB> <expected-substring>
+          assert_identical_refusals() {
+            local label="$1" na nb
+            na="$(printf '%s' "$2" | norm)" || { echo "FAIL [$label]: first refusal body unusable" >&2; return 1; }
+            nb="$(printf '%s' "$3" | norm)" || { echo "FAIL [$label]: second refusal body unusable" >&2; return 1; }
+            # positive control: this must be the refusal we think it is, not two matching non-refusals
+            printf '%s' "$na" | grep -q -- "$4" || { echo "FAIL [$label]: body is not the refusal under test (want: $4)" >&2; printf '  got: %s\n' "$na" >&2; return 1; }
+            [ "$na" = "$nb" ] || { echo "FAIL [$label]: id-enumeration oracle — unknown id and wrong secret give DIFFERENT refusals" >&2; diff <(printf '%s\n' "$na") <(printf '%s\n' "$nb") >&2 || true; return 1; }
+            echo "ok [$label]: refusals byte-identical"
+          }
+          # PROVE THE CHECK HAS TEETH, in CI, before trusting its verdict. A scanner that has never
+          # been seen to fail is a scanner nobody has tested.
+          UNIFORM='grant holder authentication failed'
+          if assert_identical_refusals self-test/differ '{"reason":"grant holder authentication failed","x":1}' '{"reason":"grant holder authentication failed","x":2}' "$UNIFORM" 2>/dev/null; then
+            echo "FAIL: the enumeration check passed two DIFFERENT bodies — it cannot fail" >&2; exit 1; fi
+          if assert_identical_refusals self-test/empty '' '' "$UNIFORM" 2>/dev/null; then
+            echo "FAIL: the enumeration check passed two EMPTY bodies — the old bug is back" >&2; exit 1; fi
+          if assert_identical_refusals self-test/not-a-refusal '{"ok":true}' '{"ok":true}' "$UNIFORM" 2>/dev/null; then
+            echo "FAIL: the enumeration check passed two matching NON-refusals" >&2; exit 1; fi
+          # …and only now, the real thing.
+          assert_identical_refusals unknown-id-vs-wrong-secret \
+            "$(curl -s -H "x-health-grant: grant-nope.wrong-secret" localhost:8097/api/health/doctor-view)" \
+            "$(curl -s -H "x-health-grant: $SEED_GRANT.also-wrong"  localhost:8097/api/health/doctor-view)" \
+            "$UNIFORM"
           # NEGATIVE: nothing in the refusal leaks the chart, the agent or the scope.
           if curl -s -H "x-health-grant: $SEED_GRANT.wrong-secret" localhost:8097/api/health/doctor-view | grep -qE 'Rivera|cardiometabolic|withheld|observations'; then
             echo "FAIL: a refused grant read leaked chart, agent or scope detail" >&2; exit 1
           fi
+          # 🔴 NEGATIVE: the CREDENTIAL IS NOT USABLE FROM ANYWHERE. `send()` put
+          # `access-control-allow-origin: *` on every response, and this change added
+          # `x-health-grant` to the allowed request headers — together, an invitation for any page in
+          # any tab to mint a grant and read the chart cross-origin. Verified end to end in a real
+          # browser before the fix. Proved both ways here, on the routes that take the credential.
+          for R in /api/health/doctor-view /api/health/evidence /api/health/grant /api/health/twin /api/health/twin.ttl; do
+            if curl -sD - -o /dev/null -H 'Origin: https://evil.example' "localhost:8097$R" | grep -qi 'access-control-allow-origin'; then
+              echo "FAIL: $R handed an allowance to an origin that is not on the list" >&2; exit 1; fi
+            curl -sD - -o /dev/null -H 'Origin: https://evil.example' "localhost:8097$R" | grep -qi '^vary: origin'
+          done
+          if curl -sD - -o /dev/null localhost:8097/api/health/doctor-view -H "x-health-grant: $SEED_TOKEN" | grep -qi 'access-control-allow-origin: \*'; then
+            echo "FAIL: a wildcard origin is still being emitted" >&2; exit 1; fi
+          # …and the legitimate cockpit origin still works, header for header.
+          curl -sD - -o /dev/null -H 'Origin: http://localhost:5174' localhost:8097/api/health/doctor-view | grep -qi 'access-control-allow-origin: http://localhost:5174'
+          curl -sD - -o /dev/null -H 'Origin: http://localhost:5174' localhost:8097/api/health/doctor-view | grep -qi 'access-control-allow-headers:.*x-health-grant'
+          # the preflight — where a browser asks whether it may send the credential from this origin
+          test "$(curl -s -o /dev/null -w '%{http_code}' -X OPTIONS -H 'Origin: https://evil.example' -H 'Access-Control-Request-Method: POST' -H 'Access-Control-Request-Headers: x-health-grant' localhost:8097/api/health/grant)" = 403
+          test "$(curl -s -o /dev/null -w '%{http_code}' -X OPTIONS -H 'Origin: http://localhost:5174' -H 'Access-Control-Request-Method: POST' -H 'Access-Control-Request-Headers: x-health-grant' localhost:8097/api/health/grant)" = 204
+          # 🔴 NEGATIVE: /evidence carried NO credential requirement — `required:false` meant "no
+          # grant, no narrowing", i.e. the widest read the service can do, for free. groundTwin()
+          # returns every out-of-range observation and every condition with its value, unit and
+          # reference range, plus the patient's age band, sex and comorbidity list as retrieval
+          # context: the content of the records a scope withholds. That is the side door the route's
+          # own comment claims to close, and prophet-platform#1083's tests already assert the 401.
+          test "$(curl -s -o /dev/null -w '%{http_code}' localhost:8097/api/health/evidence)" = 401
+          if curl -s localhost:8097/api/health/evidence | grep -qE '"finding"|"context"'; then
+            echo "FAIL: unauthenticated /evidence returned findings or patient context" >&2; exit 1; fi
           # POSITIVE: the actual holder still reads. A gate that refuses everyone is equally broken.
           curl -fsS -H "x-health-grant: $SEED_TOKEN" localhost:8097/api/health/doctor-view | grep -q '"withheld"'
+          curl -fsS -H "x-health-grant: $SEED_TOKEN" localhost:8097/api/health/evidence | grep -q '"presentedBy":"sha256-'
           # the read is receipted with WHO presented WHAT against WHICH subject, and does not overstate
           curl -fsS -H "x-health-grant: $SEED_TOKEN" localhost:8097/api/health/doctor-view | grep -q '"presentedBy":"sha256-'
           curl -fsS -H "x-health-grant: $SEED_TOKEN" localhost:8097/api/health/doctor-view | grep -q '"subject":"synthetic-subject-0"'
@@ -95,6 +176,23 @@ jobs:
           # a freshly issued grant hands back its secret ONCE, and that secret works
           NEW=$(curl -fsS -X POST localhost:8097/api/health/grant -H 'content-type: application/json' -d '{"agent":"Dr. CI","scope":"cardiometabolic"}')
           echo "$NEW" | grep -q '"shownOnce":true'
+          # 🔴 NEGATIVE: grant ids are MINTED, not derived. `grant-<sha256(agent|scope|ms)>` collided
+          # on 79% of 200 concurrent issues to the same agent and scope — two rows under one identity,
+          # one holder silently unable to authenticate, revocation hitting one of them, and every
+          # receipt naming that id ambiguous. And `granted_at` is published at millisecond precision
+          # beside the agent and the scope, so the id was recomputable offline from a grant listing.
+          node --input-type=module -e '
+            const N=300, body=JSON.stringify({agent:"Dr. Concurrent",scope:"cardiometabolic"});
+            const rs=await Promise.all(Array.from({length:N},()=>fetch("http://localhost:8097/api/health/grant",
+              {method:"POST",headers:{"content-type":"application/json"},body}).then(r=>r.json())));
+            const ids=rs.map(r=>r.grant.id), u=new Set(ids);
+            if(u.size!==N){console.error(`FAIL: ${N-u.size}/${N} grant ids collided under concurrency`);process.exit(1);}
+            const {createHash}=await import("node:crypto"); const g=rs[0].grant, ms=new Date(g.granted_at).getTime();
+            for(const j of [["Dr. Concurrent","cardiometabolic",String(ms)].join("|"), JSON.stringify(["Dr. Concurrent","cardiometabolic",String(ms)])])
+              if("grant-"+createHash("sha256").update(j).digest("hex")===g.id){console.error("FAIL: the id is recomputable from its published inputs");process.exit(1);}
+            if(!/^grant-[0-9a-f]{64}$/.test(g.id)){console.error("FAIL: id is not 256 minted bits: "+g.id);process.exit(1);}
+            console.log(`ok: ${N} concurrent grants, ${u.size} distinct ids, none derivable from (agent, scope, granted_at)`);
+          '
           NEW_TOKEN=$(echo "$NEW" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
           curl -fsS -H "x-health-grant: $NEW_TOKEN" localhost:8097/api/health/doctor-view | grep -q '"withheld"'
           # revoke it, and the SAME authenticated holder is now refused on grant STATE (403, not 401)
@@ -128,6 +226,12 @@ jobs:
             echo "FAIL: the server booted with grant ids accepted in the query string, in an authenticated deployment" >&2; exit 1
           fi
           grep -q 'Refusing to boot' /tmp/legacy-refusal.log
+          # nor can a wildcard origin be configured — on a service that accepts the credential header,
+          # `*` is the difference between "a clinician may read this chart" and "any page may".
+          if HEALTH_TWIN_ALLOWED_ORIGINS='*' PORT=8098 npx tsx src/server.ts > /tmp/cors-refusal.log 2>&1; then
+            echo "FAIL: the server booted with a wildcard CORS origin on a credential-bearing service" >&2; exit 1
+          fi
+          grep -q 'Refusing to boot' /tmp/cors-refusal.log
 
           PORT=8098 npx tsx src/server.ts & sleep 3
           curl -fsS localhost:8098/healthz
@@ -147,6 +251,11 @@ jobs:
           # rather than an exposure refusal this code does not make.
           test "$(curl -s -o /dev/null -w '%{http_code}' localhost:8098/api/health/doctor-view)" = 401
           curl -fsS -H "x-health-grant: $TOKEN" localhost:8098/api/health/doctor-view | grep -q '"presentedBy":"sha256-'
+          # An authenticated deployment allows NO browser origin unless one is named. The cockpit
+          # reaches this service same-origin through the nginx /svc/health proxy and never needs one;
+          # a deployment that does need one says so, rather than inheriting a wildcard by default.
+          if curl -sD - -o /dev/null -H 'Origin: http://localhost:5174' localhost:8098/api/health/doctor-view | grep -qi 'access-control-allow-origin'; then
+            echo "FAIL: an authenticated deployment handed out a CORS allowance it was never configured with" >&2; exit 1; fi
 
   orchestration-fixtures:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,77 @@ jobs:
           pnpm install
           pnpm build
 
+  # The health-twin engine had NO CI in this repo — only an image build in images.yml. Its guardrail
+  # invariants (de-identification, non-diagnostic framing, grant scoping, consent) existed and ran
+  # nowhere, so the mirror could drift out of conformance silently while prophet-health stayed green.
+  health-twin:
+    runs-on: ubuntu-latest
+    defaults: { run: { working-directory: apps/health-twin } }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm install --no-audit --no-fund
+      - name: guardrail invariants — non-diagnostic + de-identification + grant holder auth
+        run: npx tsx src/invariants.ts
+      - name: clinical eval — coding F1 / negation / values / guidance / residual fit (floors gated)
+        run: npx tsx src/eval.ts
+      - name: unit tests
+        run: npm test
+      - name: boot smoke — a grant id is not a credential, proved both ways
+        env:
+          # The demo consent grant is no longer a literal in server.ts. It exists only when asked for,
+          # its secret is supplied out of band, and asking for it on an `authenticated` deployment
+          # refuses to boot.
+          HEALTH_TWIN_SEED_GRANT: '1'
+          HEALTH_TWIN_SEED_GRANT_SECRET: ci-holder-secret-not-a-production-value
+        run: |
+          SEED_GRANT=grant-dev-seed-cardiology
+          SEED_TOKEN="$SEED_GRANT.$HEALTH_TWIN_SEED_GRANT_SECRET"
+          PORT=8097 npx tsx src/server.ts & sleep 3
+          curl -fsS localhost:8097/healthz
+          # NEGATIVE: the id alone, on the channel it used to arrive on. A query string is written to
+          # access logs, proxy logs, browser history and `Referer`, so anyone who reads one of those
+          # holds what used to be sufficient to open a chart. It is refused before any lookup happens.
+          test "$(curl -s -o /dev/null -w '%{http_code}' "localhost:8097/api/health/doctor-view?grant=$SEED_GRANT")" = 401
+          curl -s "localhost:8097/api/health/doctor-view?grant=$SEED_GRANT" | grep -q 'not accepted in the query string'
+          # NEGATIVE: the id in the header with no secret; a guessed secret; no credential at all.
+          test "$(curl -s -o /dev/null -w '%{http_code}' -H "x-health-grant: $SEED_GRANT" localhost:8097/api/health/doctor-view)" = 401
+          test "$(curl -s -o /dev/null -w '%{http_code}' -H "x-health-grant: $SEED_GRANT.wrong-secret" localhost:8097/api/health/doctor-view)" = 401
+          test "$(curl -s -o /dev/null -w '%{http_code}' localhost:8097/api/health/doctor-view)" = 401
+          # NEGATIVE: no enumeration oracle — an unknown id and a wrong secret are indistinguishable.
+          diff <(curl -s -H "x-health-grant: grant-nope.wrong-secret" localhost:8097/api/health/doctor-view | grep -o '"reason":"[^"]*"') \
+               <(curl -s -H "x-health-grant: $SEED_GRANT.also-wrong" localhost:8097/api/health/doctor-view | grep -o '"reason":"[^"]*"')
+          # NEGATIVE: nothing in the refusal leaks the chart, the agent or the scope.
+          if curl -s -H "x-health-grant: $SEED_GRANT.wrong-secret" localhost:8097/api/health/doctor-view | grep -qE 'Rivera|cardiometabolic|withheld|observations'; then
+            echo "FAIL: a refused grant read leaked chart, agent or scope detail" >&2; exit 1
+          fi
+          # POSITIVE: the actual holder still reads. A gate that refuses everyone is equally broken.
+          curl -fsS -H "x-health-grant: $SEED_TOKEN" localhost:8097/api/health/doctor-view | grep -q '"withheld"'
+          # the read is receipted with WHO presented WHAT against WHICH subject, and does not overstate
+          curl -fsS -H "x-health-grant: $SEED_TOKEN" localhost:8097/api/health/doctor-view | grep -q '"presentedBy":"sha256-'
+          curl -fsS -H "x-health-grant: $SEED_TOKEN" localhost:8097/api/health/doctor-view | grep -q '"subject":"synthetic-subject-0"'
+          curl -fsS -H "x-health-grant: $SEED_TOKEN" localhost:8097/api/health/doctor-view | grep -q '"identityVerified":false'
+          # the patient's control panel lists grants but never the holder verifier
+          curl -fsS localhost:8097/api/health/grants | grep -q '"holderBound":true'
+          if curl -s localhost:8097/api/health/grants | grep -q 'holderDigest'; then
+            echo "FAIL: /api/health/grants published the holder verifier" >&2; exit 1
+          fi
+          # a freshly issued grant hands back its secret ONCE, and that secret works
+          NEW=$(curl -fsS -X POST localhost:8097/api/health/grant -H 'content-type: application/json' -d '{"agent":"Dr. CI","scope":"cardiometabolic"}')
+          echo "$NEW" | grep -q '"shownOnce":true'
+          NEW_TOKEN=$(echo "$NEW" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+          curl -fsS -H "x-health-grant: $NEW_TOKEN" localhost:8097/api/health/doctor-view | grep -q '"withheld"'
+          # revoke it, and the SAME authenticated holder is now refused on grant STATE (403, not 401)
+          NEW_ID=${NEW_TOKEN%.*}
+          curl -fsS -X POST localhost:8097/api/health/revoke -H 'content-type: application/json' -d "{\"grant\":\"$NEW_ID\"}" | grep -q '"revoked":true'
+          test "$(curl -s -o /dev/null -w '%{http_code}' -H "x-health-grant: $NEW_TOKEN" localhost:8097/api/health/doctor-view)" = 403
+          # once a real record lands, the exposure membrane closes minting too — an open mint endpoint
+          # would make holder authentication theatre (issue yourself a grant, read with your own secret)
+          curl -fsS -X POST localhost:8097/api/health/ingest -H 'content-type: application/json' -d '{"connector":"epic-smart-fhir"}'
+          test "$(curl -s -o /dev/null -w '%{http_code}' localhost:8097/api/health/twin)" = 403
+          test "$(curl -s -o /dev/null -w '%{http_code}' -X POST localhost:8097/api/health/grant -H 'content-type: application/json' -d '{"agent":"attacker"}')" = 403
+
   orchestration-fixtures:
     runs-on: ubuntu-latest
     steps:

--- a/apps/health-twin/src/cors.ts
+++ b/apps/health-twin/src/cors.ts
@@ -1,0 +1,141 @@
+// WHICH ORIGINS may drive this engine from a browser.
+//
+// `send()` set `access-control-allow-origin: *` on every response, and the holder-credential change
+// added `x-health-grant` to `access-control-allow-headers`. Read those two lines together and they
+// say: ANY web page on the internet may call this engine, set the credential header, and READ THE
+// REPLY. On a synthetic-only deployment minting is ungated, so a page the patient merely visits could
+// POST /api/health/grant, take the one-shot secret out of a response it is allowed to read, and pull
+// the chart cross-origin — without a single leaked id. Introducing a credential and simultaneously
+// making it usable from anywhere hands back exactly what the credential was for. `*` was survivable
+// while `content-type` was the only allowed header; it stopped being survivable in the same commit
+// that made a credential presentable.
+//
+// THE POLICY. `*` is not a value this service will emit, and not a value an operator can configure.
+// A browser origin is allowed only if it is named, exactly, in the allowlist; anything else gets NO
+// `access-control-allow-origin` at all and the browser refuses to hand the response to the page.
+//
+// WHAT THIS DOES AND DOES NOT BUY. CORS is enforced by the browser, not by us: `curl` and any
+// server-side client ignore all of this, and always could. What it stops is the DRIVE-BY — a page in
+// a tab the patient already has open using the patient's own network position. It is not a substitute
+// for the exposure membrane or for holder authentication, and it is not claimed as one.
+//
+// NO CREDENTIALS MODE. `access-control-allow-credentials` is deliberately never sent. The holder
+// credential is an explicit header the caller has to set, not ambient authority the browser attaches;
+// keeping cookies out of the picture is the same reasoning that put the credential in a header
+// instead of the query string.
+//
+// Pure and parameterised — no http, no process state — so the policy is provable without binding a
+// port, exactly as exposure.ts and grantauth.ts are.
+import { HOLDER_HEADER } from './grantauth.js';
+
+export type Exposure = 'synthetic-only' | 'authenticated';
+
+/** Never `*`, and never the two credential-bearing verbs without an origin match. */
+export const CORS_ALLOW_HEADERS = `content-type, authorization, ${HOLDER_HEADER}`;
+export const CORS_ALLOW_METHODS = 'POST, GET, OPTIONS';
+
+/**
+ * Local development and the BearBrowser sovereign embedding are the only browser callers that are
+ * genuinely cross-origin. The DEPLOYED cockpit is not: nginx proxies `/svc/health/` to this service,
+ * so those requests are same-origin and never consult CORS at all (see apps/socioprophet-web/
+ * nginx.conf and vite.config.ts). That is why this list is short, and why an empty list breaks
+ * nothing in the cluster.
+ *
+ * 5174 is the cockpit's vite dev server; 8080 is its nginx container port when run locally.
+ * Anything else — including a BearBrowser sovereign host on some other loopback port — has to be
+ * named in HEALTH_TWIN_ALLOWED_ORIGINS. Guessing a wider default is how `*` happened.
+ */
+export const DEV_ORIGINS: readonly string[] = [
+  'http://localhost:5174', 'http://127.0.0.1:5174',
+  'http://localhost:8080', 'http://127.0.0.1:8080',
+];
+
+export interface OriginPolicy {
+  origins: string[];
+  /** Non-empty = refuse to boot, with this stated. */
+  fatal?: string;
+  why: string;
+}
+
+/**
+ * `HEALTH_TWIN_ALLOWED_ORIGINS` — comma-separated EXACT origins (`scheme://host[:port]`), and it is
+ * authoritative whenever the variable is PRESENT, including when it is empty: `""` means "no browser
+ * origin at all", which an operator must be able to say out loud. (Treating empty as unset would
+ * silently reinstate the dev defaults on the deployment that had just asked for none.) Absent:
+ *
+ *   • `synthetic-only` → the loopback dev origins above, because the data is synthetic and a
+ *     developer should not have to configure CORS to run the thing;
+ *   • `authenticated`  → NOTHING. A deployment that has declared it serves real records names the
+ *     browsers that may drive it, or serves none of them. The default cockpit path does not need it.
+ *
+ * `*` is FATAL AT BOOT in either mode. This whole module exists because that value was reachable;
+ * leaving it configurable would move the defect from a line of code to a line of YAML. A
+ * configuration that cannot exist cannot be forgotten about — the same rule seedGrantDecision() and
+ * legacyQueryDecision() already apply.
+ */
+export function corsPolicyFromEnv(env: NodeJS.ProcessEnv, exposure: Exposure): OriginPolicy {
+  const declared = env['HEALTH_TWIN_ALLOWED_ORIGINS'];
+  if (declared !== undefined) {
+    const listed = String(declared).split(',').map((s) => s.trim()).filter(Boolean);
+    if (listed.length === 0) return { origins: [], why: 'HEALTH_TWIN_ALLOWED_ORIGINS is empty — no browser origin is allowed' };
+    if (listed.includes('*')) {
+      return {
+        origins: [],
+        fatal: 'HEALTH_TWIN_ALLOWED_ORIGINS contains "*": a wildcard origin on a service that accepts ' +
+          `the \`${HOLDER_HEADER}\` credential lets any page on the internet mint a grant and read the ` +
+          'chart from the visitor\'s own browser. Name the cockpit origins explicitly. Refusing to boot.',
+        why: 'wildcard origin requested',
+      };
+    }
+    const bad = listed.filter((o) => !isOrigin(o));
+    if (bad.length) {
+      return {
+        origins: [],
+        fatal: `HEALTH_TWIN_ALLOWED_ORIGINS holds ${bad.length} value(s) that are not an origin ` +
+          `(${bad.join(', ')}). An origin is \`scheme://host[:port]\` with no path, no trailing slash ` +
+          'and no wildcard — a value that never matches is a silent outage. Refusing to boot.',
+        why: 'malformed origin in the allowlist',
+      };
+    }
+    return { origins: [...new Set(listed)], why: `${listed.length} origin(s) allowed from HEALTH_TWIN_ALLOWED_ORIGINS` };
+  }
+  if (exposure === 'authenticated') {
+    return {
+      origins: [],
+      why: 'no browser origin is allowed (authenticated deployment, HEALTH_TWIN_ALLOWED_ORIGINS unset) — ' +
+        'the cockpit reaches this service same-origin through the nginx /svc/health proxy',
+    };
+  }
+  return { origins: [...DEV_ORIGINS], why: 'loopback development origins (synthetic-only default)' };
+}
+
+/** `scheme://host[:port]`, nothing else. Rejects `*`, paths, trailing slashes and bare hostnames. */
+export function isOrigin(value: string): boolean {
+  if (!/^https?:\/\/[^/?#*\s]+$/.test(value)) return false;
+  try { return new URL(value).origin === value; } catch { return false; }
+}
+
+/**
+ * The CORS headers for one response. `origin` is the request's `Origin` header, absent for
+ * same-origin and non-browser callers — who get no CORS headers, because they never look at them.
+ *
+ * `vary: origin` goes on EVERY response, allowed or not: the reply now depends on the request's
+ * origin, and a cache that does not know that will hand one origin's allowance to another.
+ */
+export function corsHeaders(origin: string | undefined, allowed: ReadonlySet<string>): Record<string, string> {
+  const o = (origin ?? '').trim();
+  if (!o) return { vary: 'origin' };
+  if (!allowed.has(o)) return { vary: 'origin' }; // no ACAO — the browser refuses to expose the reply
+  return {
+    vary: 'origin',
+    'access-control-allow-origin': o,
+    'access-control-allow-headers': CORS_ALLOW_HEADERS,
+    'access-control-allow-methods': CORS_ALLOW_METHODS,
+  };
+}
+
+/** True only for an origin that was named. An absent Origin is not a browser and is not "allowed". */
+export function originAllowed(origin: string | undefined, allowed: ReadonlySet<string>): boolean {
+  const o = (origin ?? '').trim();
+  return !!o && allowed.has(o);
+}

--- a/apps/health-twin/src/data.ts
+++ b/apps/health-twin/src/data.ts
@@ -53,6 +53,10 @@ export interface ImagingStudy { id: string; system: string; modality: string; bo
 export interface Grant {
   id: string; agent: string; scope: string; granted_at: string; expires_at: string;
   revoked: boolean; reads: number; receipt: string;
+  // `sha256-<hex>` of the holder secret minted when the grant was issued. The secret itself is shown
+  // ONCE, in the issue response, and is never stored — so a stolen ledger yields no readable grant.
+  // Absent = the grant binds no holder and authenticates nobody (see grantauth.ts; it fails closed).
+  holderDigest?: string;
   // structured consent scope (systems/kinds/lookback) — `scope` stays the human-readable label.
   // Type-only import from grants.js: no runtime cycle.
   scopeSpec?: import('./grants.js').GrantScope;

--- a/apps/health-twin/src/grantauth.ts
+++ b/apps/health-twin/src/grantauth.ts
@@ -113,7 +113,25 @@ export interface HolderAuthInput {
   onUnbound?: (grantId: string) => void;
 }
 
-/** Fails closed: every path that is not a proven digest match is a refusal. */
+/**
+ * A digest that matches nothing, minted once per process from the CSPRNG. The refusal path compares
+ * against THIS when the grant is unknown or unbound, so that an unknown id costs the same sha256 and
+ * the same timingSafeEqual as a real one. See authenticateHolder(): the body of a refusal was already
+ * uniform, and the CLOCK was the remaining oracle.
+ */
+const NO_SUCH_GRANT_DIGEST = holderDigest(mintHolderSecret());
+
+/**
+ * Fails closed: every path that is not a proven digest match is a refusal.
+ *
+ * CONSTANT WORK ON THE REFUSAL PATH. Every reachable outcome below computes the presented secret's
+ * digest and runs exactly one timingSafeEqual, whether or not the grant exists and whether or not it
+ * is bound. Returning early on `!g` made the RESPONSE TIME an id-enumeration oracle even though the
+ * response BODY was uniform — the caller learns "this id exists" from the clock instead of the JSON.
+ * (Measured against `grants.find()` over a 2,000-grant ledger: an unknown id cost 37× a known one,
+ * because the miss also paid for a full scan. server.ts now indexes the ledger by id, which removes
+ * the scan; this removes what is left.)
+ */
 export function authenticateHolder(input: HolderAuthInput): HolderAuth {
   if (!input.presented) {
     return {
@@ -129,6 +147,9 @@ export function authenticateHolder(input: HolderAuthInput): HolderAuth {
     };
   }
   const g = input.find(parsed.grantId);
+  // Computed BEFORE any branch on whether the grant was found, and compared unconditionally.
+  const expected = g?.holderDigest ?? NO_SUCH_GRANT_DIGEST;
+  const matches = constantTimeEqual(expected, holderDigest(parsed.secret));
   if (!g) return { ok: false, code: 401, reason: HOLDER_FAILED };
   if (!g.holderDigest) {
     // A grant minted before holder binding existed authenticates nobody. It does not get a pass for
@@ -136,9 +157,7 @@ export function authenticateHolder(input: HolderAuthInput): HolderAuth {
     input.onUnbound?.(parsed.grantId);
     return { ok: false, code: 401, reason: HOLDER_FAILED };
   }
-  if (!constantTimeEqual(g.holderDigest, holderDigest(parsed.secret))) {
-    return { ok: false, code: 401, reason: HOLDER_FAILED };
-  }
+  if (!matches) return { ok: false, code: 401, reason: HOLDER_FAILED };
   return { ok: true, grantId: parsed.grantId, holderDigest: g.holderDigest };
 }
 
@@ -230,3 +249,53 @@ export const LEGACY_QUERY_DETAIL =
 export const LEGACY_QUERY_WARNING =
   `299 - "deprecated: grant id in query string; use the ${HOLDER_HEADER} header. This form is unauthenticated ` +
   `and is refused unless HEALTH_TWIN_LEGACY_GRANT_QUERY=1 on a synthetic-only deployment."`;
+
+export const BODY_ID_REFUSAL = 'a bare grant id in the request body is not a credential';
+export const BODY_ID_DETAIL =
+  `a JSON body is not written to the access log, but possession of the id is still the whole ` +
+  `authorization — present the grant as \`${HOLDER_HEADER}: <grant-id>.<secret>\` instead`;
+export const BOTH_FORMS_REFUSAL = 'a bare grant id was presented alongside a holder credential';
+export const BOTH_FORMS_DETAIL =
+  `two different answers to "which grant is this" on one request is how a service ends up checking ` +
+  `one and believing it checked the other — send only \`${HOLDER_HEADER}\``;
+
+/**
+ * WHAT TO DO WITH A BARE GRANT ID, wherever it arrived.
+ *
+ * 🔴 THE BUG THIS REPLACES. The refusal was guarded by `bareId !== null && !presented`: a request
+ * carrying BOTH a `?grant=<id>` and a valid `x-health-grant` header skipped the refusal entirely and
+ * was served 200. So the id still went into the access log, the proxy log, the browser history and
+ * the `Referer` of every outbound link — and the deprecation `Warning` was suppressed on exactly the
+ * requests that were normalising the channel. The leak is not caused by the id being the credential;
+ * it is caused by the id being IN THE URL. Adding a second, better credential does not un-log it.
+ *
+ * So the query form is refused WHENEVER IT IS PRESENT, whatever else the request carries. The one
+ * exception is the explicit synthetic-only opt-in, and even then only when the caller presents
+ * nothing better: a request that has a real credential has no business also naming a grant in the URL.
+ *
+ * Pure, so the rule is provable without a socket, and shared by both channels so they cannot drift.
+ */
+export interface BareIdDecision {
+  refuse: boolean;
+  /** Present when refusing. */
+  reason?: string;
+  detail?: string;
+  /** Present when NOT refusing: the legacy path is live and must be loud on every single use. */
+  warn?: boolean;
+}
+
+export function bareIdPolicy(input: {
+  channel: 'query' | 'body';
+  /** Did the request also present a holder credential? */
+  presented: boolean;
+  /** HEALTH_TWIN_LEGACY_GRANT_QUERY=1 on a synthetic-only deployment. */
+  legacyAllowed: boolean;
+}): BareIdDecision {
+  if (!input.legacyAllowed) {
+    return input.channel === 'query'
+      ? { refuse: true, reason: LEGACY_QUERY_REFUSAL, detail: LEGACY_QUERY_DETAIL }
+      : { refuse: true, reason: BODY_ID_REFUSAL, detail: BODY_ID_DETAIL };
+  }
+  if (input.presented) return { refuse: true, reason: BOTH_FORMS_REFUSAL, detail: BOTH_FORMS_DETAIL };
+  return { refuse: false, warn: true };
+}

--- a/apps/health-twin/src/grantauth.ts
+++ b/apps/health-twin/src/grantauth.ts
@@ -1,0 +1,232 @@
+// WHO is holding this grant — the difference between a capability and a credential.
+//
+// resolveGrant() answers three questions: does this id exist, is it unrevoked, is it unexpired.
+// It never asks who is presenting it. That makes a grant id a BEARER CAPABILITY: possession is
+// authorization. And the id travelled in a query string, which is the one place a secret cannot
+// survive — it lands in access logs, proxy logs, browser history and the `Referer` header of every
+// outbound link from the page that used it. One of them (the demo seed) was additionally hard-coded
+// in server.ts, so "read the source" was a valid way to obtain a chart.
+//
+// So the grant now BINDS to a holder. At issue time the server mints a 256-bit secret, stores only
+// its sha256 digest on the grant, and returns the secret ONCE. Reading through the grant means
+// presenting `<grant-id>.<secret>` in a request header; the server hashes what was presented and
+// compares digests in constant time. The id alone stops being sufficient — which is the whole defect.
+//
+// WHAT THIS IS NOT. This authenticates the HOLDER OF A SECRET. It does not authenticate a person, an
+// organisation or a clinician licence: there is no identity provider, no key directory and no PKI in
+// this estate, and inventing one here would be authentication-shaped decoration of exactly the kind
+// exposure.ts refuses to ship. If the secret is forwarded, the forwardee is the holder. That is
+// stated in HOLDER_AUTH_DISCLOSURE and returned on every authenticated read, in the same spirit as
+// deident.ts recording `keyed:false` rather than implying a protection it does not have.
+//
+// WHY A DEDICATED HEADER AND NOT `Authorization`. `Authorization` is already spoken for: exposure.ts
+// reads it for the DEPLOYMENT token that decides whether this instance may serve records at all.
+// Those are two different questions with two different lifetimes and two different holders (an
+// operator; a clinician), and an `authenticated`-mode deployment needs BOTH presented on the same
+// request. Stacking them on one header is how a service ends up checking one and believing it
+// checked the other. A request header is equally safe from the leak channels that motivated this
+// change: unlike a query string it is not in the request line, so it is not in access logs, not in
+// `Referer`, and not in browser history.
+//
+// Pure and parameterised — no http, no process state — so the gate is provable without binding a
+// port. server.ts binds at import time, which would otherwise make this testable only by running it.
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+
+/** Lower-case, because node lower-cases incoming header names. */
+export const HOLDER_HEADER = 'x-health-grant';
+
+/** What this module needs of a grant. The secret itself is never stored, so it is not in this shape. */
+export interface HolderBound {
+  id: string;
+  /** `sha256-<64 hex>` of the holder secret. Absent = the grant binds nobody and can authenticate nobody. */
+  holderDigest?: string;
+}
+
+export type HolderAuth =
+  | { ok: true; grantId: string; holderDigest: string }
+  | { ok: false; code: 401; reason: string; detail?: string };
+
+/**
+ * What the caller is told about the authentication they just passed. Returned on the read itself:
+ * a surface that shows a chart should be able to show what stands behind it without reading this file.
+ */
+export const HOLDER_AUTH_DISCLOSURE = {
+  mechanism: 'grant-holder-secret',
+  binds: 'the holder of a per-grant secret minted at issue time and shown once',
+  verifier: 'sha256 digest, constant-time compare; the secret itself is never stored',
+  /** No identity provider, no key directory, no PKI. A forwarded secret makes the forwardee the holder. */
+  identityVerified: false,
+  /** The credential is presented in a header, so it is not in the request line, logs or `Referer`. */
+  channel: `request header ${HOLDER_HEADER}`,
+} as const;
+
+/** 256 bits from the CSPRNG. base64url so it survives a header, a shell and a URL unescaped. */
+export function mintHolderSecret(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/** The only form of the secret that is ever written down. */
+export function holderDigest(secret: string): string {
+  return `sha256-${createHash('sha256').update(secret, 'utf8').digest('hex')}`;
+}
+
+/** What the holder presents: the id (so the server can find the grant) joined to the secret. */
+export function holderToken(grantId: string, secret: string): string {
+  return `${grantId}.${secret}`;
+}
+
+/**
+ * Split on the LAST dot: grant ids contain dashes and hex, never a dot, while base64url secrets
+ * contain `-` and `_` but also never a dot. Splitting on the first dot would break the moment an id
+ * scheme grows one.
+ */
+export function parseHolderToken(raw: string): { grantId: string; secret: string } | null {
+  const t = (raw ?? '').trim();
+  if (!t) return null;
+  const i = t.lastIndexOf('.');
+  if (i <= 0 || i === t.length - 1) return null;
+  return { grantId: t.slice(0, i), secret: t.slice(i + 1) };
+}
+
+/** Pull the presented token out of a node headers object (array-valued headers take the first). */
+export function presentedHolderToken(headers: Record<string, string | string[] | undefined>): string {
+  const h = headers?.[HOLDER_HEADER];
+  return String((Array.isArray(h) ? h[0] : h) ?? '').trim();
+}
+
+export const HOLDER_REQUIRED = 'grant holder credential required';
+/**
+ * ONE reason for every authentication failure that involves a real credential attempt: unknown id,
+ * unbound grant, wrong secret. Distinguishing them would turn this endpoint into an oracle that
+ * confirms which grant ids exist and are bound — to a caller who has, by definition, just failed to
+ * authenticate. Grant STATE (revoked / expired) is reported with its reason, but only to a holder who
+ * has already proved they hold the grant.
+ */
+export const HOLDER_FAILED = 'grant holder authentication failed';
+
+export interface HolderAuthInput {
+  /** Raw header value as presented. */
+  presented: string;
+  /** Grant lookup by id. Returns undefined for unknown ids. */
+  find: (id: string) => HolderBound | undefined;
+  /** Optional sink for the operator-facing detail that must not go on the wire. */
+  onUnbound?: (grantId: string) => void;
+}
+
+/** Fails closed: every path that is not a proven digest match is a refusal. */
+export function authenticateHolder(input: HolderAuthInput): HolderAuth {
+  if (!input.presented) {
+    return {
+      ok: false, code: 401, reason: HOLDER_REQUIRED,
+      detail: `present the grant as \`${HOLDER_HEADER}: <grant-id>.<secret>\` — the id on its own is not a credential`,
+    };
+  }
+  const parsed = parseHolderToken(input.presented);
+  if (!parsed) {
+    return {
+      ok: false, code: 401, reason: 'malformed grant holder credential',
+      detail: `expected \`${HOLDER_HEADER}: <grant-id>.<secret>\``,
+    };
+  }
+  const g = input.find(parsed.grantId);
+  if (!g) return { ok: false, code: 401, reason: HOLDER_FAILED };
+  if (!g.holderDigest) {
+    // A grant minted before holder binding existed authenticates nobody. It does not get a pass for
+    // being old. The operator-facing reason goes to the log, not to the caller who just failed.
+    input.onUnbound?.(parsed.grantId);
+    return { ok: false, code: 401, reason: HOLDER_FAILED };
+  }
+  if (!constantTimeEqual(g.holderDigest, holderDigest(parsed.secret))) {
+    return { ok: false, code: 401, reason: HOLDER_FAILED };
+  }
+  return { ok: true, grantId: parsed.grantId, holderDigest: g.holderDigest };
+}
+
+/**
+ * Both sides are `sha256-<64 hex>`, so they are the same length whenever the stored value is
+ * well-formed; the length guard exists for a malformed record, not for a secret, and returning early
+ * on it leaks nothing about the secret.
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+// ── boot-time policy: the demo seed, and the legacy query form ──────────────────────────────────
+// Both of these are conveniences that are safe only while the data is synthetic. Neither is allowed
+// to be a comment: the server REFUSES TO BOOT if either is asked for in a deployment that has
+// declared it serves real records. A configuration that cannot exist cannot be forgotten about.
+
+export type Exposure = 'synthetic-only' | 'authenticated';
+
+export interface SeedDecision {
+  seed: boolean;
+  /** Non-empty = refuse to boot, with this stated. */
+  fatal?: string;
+  /** Present only when seeding. Never a literal in source. */
+  secret?: string;
+  /** true = freshly minted this boot (so it must be printed once); false = supplied by the operator. */
+  minted?: boolean;
+  why: string;
+}
+
+/**
+ * The demo cardiologist grant. It used to be an unconditional array literal in server.ts with a
+ * well-known id, which meant every deployment shipped a live grant whose "credential" was a string
+ * printed in a public repository. Now: absent unless explicitly asked for, never valid in an
+ * `authenticated` deployment, and its secret is either supplied by the operator or minted at boot.
+ */
+export function seedGrantDecision(env: NodeJS.ProcessEnv, exposure: Exposure): SeedDecision {
+  if (env['HEALTH_TWIN_SEED_GRANT'] !== '1') {
+    return { seed: false, why: 'HEALTH_TWIN_SEED_GRANT is not "1" — no demo grant is seeded (default)' };
+  }
+  if (exposure === 'authenticated') {
+    return {
+      seed: false,
+      fatal: 'HEALTH_TWIN_SEED_GRANT=1 with HEALTH_TWIN_EXPOSURE=authenticated: a demo consent grant ' +
+        'cannot exist on a deployment that serves real records. Refusing to boot.',
+      why: 'demo seed requested in an authenticated deployment',
+    };
+  }
+  const supplied = String(env['HEALTH_TWIN_SEED_GRANT_SECRET'] ?? '').trim();
+  return supplied
+    ? { seed: true, secret: supplied, minted: false, why: 'demo seed with an operator-supplied holder secret' }
+    : { seed: true, secret: mintHolderSecret(), minted: true, why: 'demo seed with a holder secret minted this boot' };
+}
+
+export interface LegacyQueryDecision {
+  allowed: boolean;
+  fatal?: string;
+  why: string;
+}
+
+/**
+ * `?grant=<id>` — the leak channel itself. Refused by default. An operator running the synthetic
+ * demo can re-enable it for compatibility with the cockpit's current fetch calls, and gets a
+ * `Warning` header and a deprecation block on every use; a deployment that has declared it serves
+ * real records cannot enable it at all.
+ */
+export function legacyQueryDecision(env: NodeJS.ProcessEnv, exposure: Exposure): LegacyQueryDecision {
+  if (env['HEALTH_TWIN_LEGACY_GRANT_QUERY'] !== '1') {
+    return { allowed: false, why: 'grant ids are not accepted in the query string (default)' };
+  }
+  if (exposure === 'authenticated') {
+    return {
+      allowed: false,
+      fatal: 'HEALTH_TWIN_LEGACY_GRANT_QUERY=1 with HEALTH_TWIN_EXPOSURE=authenticated: a grant id in a ' +
+        'query string is logged by every proxy in the path and leaks in `Referer`. Refusing to boot.',
+      why: 'legacy query form requested in an authenticated deployment',
+    };
+  }
+  return { allowed: true, why: 'DEPRECATED legacy query form enabled for the synthetic demo' };
+}
+
+export const LEGACY_QUERY_REFUSAL = 'grant ids are not accepted in the query string';
+export const LEGACY_QUERY_DETAIL =
+  `a query string is written to access logs, proxy logs, browser history and \`Referer\` — present the ` +
+  `grant as \`${HOLDER_HEADER}: <grant-id>.<secret>\` instead`;
+export const LEGACY_QUERY_WARNING =
+  `299 - "deprecated: grant id in query string; use the ${HOLDER_HEADER} header. This form is unauthenticated ` +
+  `and is refused unless HEALTH_TWIN_LEGACY_GRANT_QUERY=1 on a synthetic-only deployment."`;

--- a/apps/health-twin/src/grants.ts
+++ b/apps/health-twin/src/grants.ts
@@ -34,10 +34,14 @@ export function resolveScope(preset?: string, spec?: Partial<GrantScope>): Grant
 }
 
 // A grant either opens (ok) or blocks with a stated reason — never a silent partial.
-export function resolveGrant(grants: Grant[], id: string):
+//
+// Takes the ledger either as the array or as an id-keyed index. server.ts passes the index: a linear
+// `.find()` makes the time to refuse an answer to "does this id exist?", which is the enumeration
+// oracle the uniform refusal body exists to close. The array form stays for callers that hold one.
+export function resolveGrant(grants: Grant[] | ReadonlyMap<string, Grant>, id: string):
   | { ok: true; grant: Grant }
   | { ok: false; reason: string } {
-  const g = grants.find((x) => x.id === id);
+  const g = Array.isArray(grants) ? grants.find((x) => x.id === id) : grants.get(id);
   if (!g) return { ok: false, reason: 'grant not found' };
   if (g.revoked) return { ok: false, reason: 'grant revoked — read denied' };
   if (new Date(g.expires_at) <= new Date()) return { ok: false, reason: 'grant expired — read denied' };

--- a/apps/health-twin/src/ids.ts
+++ b/apps/health-twin/src/ids.ts
@@ -19,7 +19,7 @@
 //      grantauth.ts fixed), but an id that a stranger can derive is still an offline guessing target
 //      handed out for free, and it is the input to revocation, which is id-only by design.
 //
-// THE DECISION: an identifier is MINTED, not DERIVED. 128 bits from the CSPRNG, hex. Nothing about
+// THE DECISION: an identifier is MINTED, not DERIVED. 256 bits from the CSPRNG, hex. Nothing about
 // the record is recoverable from it, nothing about it is predictable from the record, and the
 // collision probability over any ledger this service could hold is not a number worth writing down.
 //

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -424,5 +424,90 @@ console.log('\n▶ INVARIANT 7 — twin dynamics: physics disposes, and a refusa
     'a cardiovascular-only grant admits exactly the cardio compartment (hepatic + renal stay outside)');
 }
 
+console.log('\n▶ INVARIANT 8 — a grant id is not a credential: the holder is authenticated, both ways');
+{
+  const {
+    authenticateHolder, holderDigest, holderToken, mintHolderSecret, parseHolderToken,
+    presentedHolderToken, seedGrantDecision, legacyQueryDecision,
+    HOLDER_AUTH_DISCLOSURE, HOLDER_FAILED, HOLDER_HEADER,
+  } = await import('./grantauth.js');
+
+  const secret = mintHolderSecret();
+  const bound = { id: 'grant-bound', holderDigest: holderDigest(secret) };
+  const unbound = { id: 'grant-legacy' }; // minted before holder binding existed
+  const find = (id: string) => [bound, unbound].find((g) => g.id === id);
+
+  // ── THE DEFECT: possession of the id must not be enough ────────────────────────────────────────
+  const leakedIdOnly = authenticateHolder({ presented: bound.id, find });
+  ok(leakedIdOnly.ok === false, 'a leaked grant id ALONE does not authenticate (the id is not a credential)');
+  const wrongSecret = authenticateHolder({ presented: holderToken(bound.id, mintHolderSecret()), find });
+  ok(wrongSecret.ok === false, 'the right id with the wrong secret is refused');
+  const noCredential = authenticateHolder({ presented: '', find });
+  ok(noCredential.ok === false && (noCredential as any).reason !== HOLDER_FAILED,
+     'presenting nothing at all is refused, and told how to present (a usage error, not a failed attempt)');
+  ok(authenticateHolder({ presented: holderToken(unbound.id, secret), find }).ok === false,
+     'a grant carrying NO holder binding authenticates nobody — it fails closed, it does not get a legacy pass');
+
+  // ── AND THE OTHER WAY: the real holder still gets in ───────────────────────────────────────────
+  const good = authenticateHolder({ presented: holderToken(bound.id, secret), find });
+  ok(good.ok === true && good.holderDigest === bound.holderDigest,
+     'the holder of the minted secret IS authenticated (a gate that refuses everyone is equally broken)');
+
+  // no enumeration oracle: "wrong secret" and "no such grant" are indistinguishable to a caller who
+  // has just failed to authenticate. Otherwise this endpoint answers "which grant ids are real?".
+  const unknownId = authenticateHolder({ presented: holderToken('grant-does-not-exist', secret), find });
+  ok(unknownId.ok === false && (unknownId as any).reason === (wrongSecret as any).reason
+     && (unknownId as any).detail === undefined && (wrongSecret as any).detail === undefined,
+     `unknown id and wrong secret give the identical refusal ("${(unknownId as any).reason}") — no id-enumeration oracle`);
+
+  // the secret is never written down, and the digest is not the secret
+  ok(!Object.values(bound).includes(secret) && bound.holderDigest !== secret, 'the grant stores a digest, never the secret');
+  ok(/^sha256-[0-9a-f]{64}$/.test(bound.holderDigest), 'the holder verifier is sha256-<64 hex> — the label matches the math');
+  ok(mintHolderSecret() !== mintHolderSecret() && Buffer.from(mintHolderSecret(), 'base64url').length === 32,
+     'each minted secret is 256 fresh CSPRNG bits (not derived from the id, not guessable from another grant)');
+
+  // token plumbing: ids contain dashes, secrets contain base64url — the split must survive both
+  const parsed = parseHolderToken(holderToken('grant-abc-123', secret));
+  ok(parsed?.grantId === 'grant-abc-123' && parsed?.secret === secret, 'a token round-trips through parse (split on the LAST dot)');
+  ok(parseHolderToken('no-separator') === null && parseHolderToken('') === null && parseHolderToken('.x') === null,
+     'a malformed token parses to null rather than to a half-credential');
+  ok(presentedHolderToken({ [HOLDER_HEADER]: `  ${holderToken(bound.id, secret)}  ` }) === holderToken(bound.id, secret),
+     'the header is read and trimmed');
+
+  // the disclosure never overstates: this binds a secret-holder, NOT a verified identity
+  ok(HOLDER_AUTH_DISCLOSURE.identityVerified === false,
+     'the disclosure states identityVerified:false — it authenticates the holder of a secret, not a person');
+  ok(!/\bverified (clinician|identity|person)\b/i.test(JSON.stringify(HOLDER_AUTH_DISCLOSURE)),
+     'nothing in the disclosure claims a verified person');
+
+  // ── the seed grant cannot exist in a production configuration ──────────────────────────────────
+  ok(seedGrantDecision({} as NodeJS.ProcessEnv, 'synthetic-only').seed === false,
+     'no demo grant is seeded by default (the hard-coded grant-seed-rivera is gone)');
+  const fatal = seedGrantDecision({ HEALTH_TWIN_SEED_GRANT: '1' } as any, 'authenticated');
+  ok(fatal.seed === false && !!fatal.fatal,
+     'asking for the demo grant on an authenticated deployment is FATAL — the server refuses to boot, it does not warn');
+  const seeded = seedGrantDecision({ HEALTH_TWIN_SEED_GRANT: '1' } as any, 'synthetic-only');
+  ok(seeded.seed === true && !!seeded.secret && seeded.minted === true && !fatal.secret,
+     'the demo grant on a synthetic deployment gets a secret MINTED at boot (never a literal in source)');
+  ok(seedGrantDecision({ HEALTH_TWIN_SEED_GRANT: '1', HEALTH_TWIN_SEED_GRANT_SECRET: 'operator-supplied' } as any, 'synthetic-only').secret === 'operator-supplied',
+     'an operator may supply the seed secret out of band (so CI can prove the positive case without scraping stdout)');
+
+  // ── and the leak channel itself is off unless someone turns it on, and cannot be turned on in prod
+  ok(legacyQueryDecision({} as NodeJS.ProcessEnv, 'synthetic-only').allowed === false,
+     '?grant=<id> is refused by default — the credential does not travel in the request line');
+  const legacyFatal = legacyQueryDecision({ HEALTH_TWIN_LEGACY_GRANT_QUERY: '1' } as any, 'authenticated');
+  ok(legacyFatal.allowed === false && !!legacyFatal.fatal,
+     'the legacy query form cannot be enabled on an authenticated deployment — that is also FATAL at boot');
+  ok(legacyQueryDecision({ HEALTH_TWIN_LEGACY_GRANT_QUERY: '1' } as any, 'synthetic-only').allowed === true,
+     'the synthetic demo may opt back in (deprecated, warned on every use)');
+
+  // ── the source itself no longer carries a usable grant ─────────────────────────────────────────
+  const { readFileSync } = await import('node:fs');
+  const serverSrc = readFileSync(new URL('./server.ts', import.meta.url), 'utf8');
+  ok(!serverSrc.includes('grant-seed-rivera'), 'the hard-coded grant-seed-rivera id is gone from server.ts');
+  ok(!/holderDigest:\s*['"`]/.test(serverSrc) && !/HEALTH_TWIN_SEED_GRANT_SECRET\s*=\s*['"`][^'"`]/.test(serverSrc),
+     'no holder secret or digest is a literal in server.ts');
+}
+
 console.log(`\n${fails === 0 ? '✓ ALL GUARDRAIL INVARIANTS HOLD (non-diagnostic + de-identification + grant scoping enforced)' : `✗ ${fails} invariant(s) violated`}`);
 process.exit(fails === 0 ? 0 : 1);

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -424,7 +424,7 @@ console.log('\n▶ INVARIANT 7 — twin dynamics: physics disposes, and a refusa
     'a cardiovascular-only grant admits exactly the cardio compartment (hepatic + renal stay outside)');
 }
 
-console.log('\n▶ INVARIANT 8 — a grant id is not a credential: the holder is authenticated, both ways');
+console.log('\n▶ INVARIANT 9 — a grant id is not a credential: the holder is authenticated, both ways');
 {
   const {
     authenticateHolder, holderDigest, holderToken, mintHolderSecret, parseHolderToken,
@@ -507,6 +507,142 @@ console.log('\n▶ INVARIANT 8 — a grant id is not a credential: the holder is
   ok(!serverSrc.includes('grant-seed-rivera'), 'the hard-coded grant-seed-rivera id is gone from server.ts');
   ok(!/holderDigest:\s*['"`]/.test(serverSrc) && !/HEALTH_TWIN_SEED_GRANT_SECRET\s*=\s*['"`][^'"`]/.test(serverSrc),
      'no holder secret or digest is a literal in server.ts');
+}
+
+console.log('\n▶ INVARIANT 10 — the credential is not usable from anywhere: origins, ids, and the bare-id rule');
+{
+  const { corsHeaders, corsPolicyFromEnv, isOrigin, originAllowed, DEV_ORIGINS } = await import('./cors.js');
+  const { mintId, ID_PATTERN } = await import('./ids.js');
+  const {
+    bareIdPolicy, authenticateHolder, holderDigest, holderToken, mintHolderSecret,
+    LEGACY_QUERY_REFUSAL, BODY_ID_REFUSAL, BOTH_FORMS_REFUSAL,
+  } = await import('./grantauth.js');
+
+  // ── CORS: `*` is not a value this service emits, and not one an operator can ask for ────────────
+  // `access-control-allow-origin: *` alongside an allowed `x-health-grant` header let ANY page mint a
+  // grant and read the chart cross-origin — the PR that introduced the credential also made it
+  // usable by an attacker page. The allowlist is the fix; these prove it BOTH ways.
+  const allowed = new Set(['https://cockpit.example']);
+  const hit = corsHeaders('https://cockpit.example', allowed);
+  const miss = corsHeaders('https://evil.example', allowed);
+  const none = corsHeaders(undefined, allowed);
+  ok(hit['access-control-allow-origin'] === 'https://cockpit.example',
+     'an allowlisted origin is echoed EXACTLY (a gate that refuses everyone is equally broken)');
+  ok(miss['access-control-allow-origin'] === undefined && none['access-control-allow-origin'] === undefined,
+     'a foreign origin — and a caller with no Origin at all — gets no access-control-allow-origin');
+  ok(!Object.values({ ...hit, ...miss, ...none }).includes('*'),
+     'no response carries a wildcard origin, on a hit or a miss');
+  ok(hit['vary'] === 'origin' && miss['vary'] === 'origin' && none['vary'] === 'origin',
+     'every response varies on Origin — the reply depends on it, and a cache that does not know that leaks one origin’s allowance to another');
+  ok(hit['access-control-allow-credentials'] === undefined,
+     'credentials mode is never enabled: the holder credential is an explicit header, never ambient browser authority');
+  ok(miss['access-control-allow-headers'] === undefined,
+     `a refused origin is not even told it could have set the credential header`);
+  ok(originAllowed('https://cockpit.example', allowed) && !originAllowed('', allowed) && !originAllowed('https://evil.example', allowed),
+     'originAllowed() is true only for a named origin — an absent Origin is not a browser and is not "allowed"');
+
+  const wildcard = corsPolicyFromEnv({ HEALTH_TWIN_ALLOWED_ORIGINS: 'https://ok.example,*' } as any, 'synthetic-only');
+  ok(wildcard.origins.length === 0 && !!wildcard.fatal,
+     'asking for `*` in HEALTH_TWIN_ALLOWED_ORIGINS is FATAL at boot — the defect cannot move from a line of code to a line of YAML');
+  ok(!!corsPolicyFromEnv({ HEALTH_TWIN_ALLOWED_ORIGINS: 'https://ok.example/path' } as any, 'synthetic-only').fatal,
+     'a value that is not an origin is fatal too — an allowlist entry that can never match is a silent outage');
+  ok(corsPolicyFromEnv({} as NodeJS.ProcessEnv, 'authenticated').origins.length === 0,
+     'an authenticated deployment allows NO browser origin unless one is named (the cockpit reaches it same-origin through nginx)');
+  ok(corsPolicyFromEnv({} as NodeJS.ProcessEnv, 'synthetic-only').origins.every((o) => DEV_ORIGINS.includes(o)),
+     'the synthetic-only default is the loopback dev origins and nothing wider');
+  ok(corsPolicyFromEnv({ HEALTH_TWIN_ALLOWED_ORIGINS: 'https://a.example, https://b.example' } as any, 'authenticated').origins.length === 2,
+     'a named allowlist is authoritative, in either mode');
+  ok(corsPolicyFromEnv({ HEALTH_TWIN_ALLOWED_ORIGINS: '' } as any, 'synthetic-only').origins.length === 0,
+     'an EMPTY HEALTH_TWIN_ALLOWED_ORIGINS means none — "no browser at all" has to be sayable, or the dev defaults come back on the deployment that just asked for none');
+  ok(isOrigin('https://a.example') && isOrigin('http://127.0.0.1:5174')
+     && !isOrigin('*') && !isOrigin('https://a.example/') && !isOrigin('a.example') && !isOrigin('https://*.example'),
+     'an origin is `scheme://host[:port]` — no wildcard, no path, no trailing slash, no bare hostname');
+
+  // ── ids are MINTED, not derived from their own published inputs ────────────────────────────────
+  const ids = Array.from({ length: 5_000 }, () => mintId('grant'));
+  ok(new Set(ids).size === ids.length,
+     '5,000 ids minted in one tight loop are all distinct — the old sha256(agent|scope|ms) collided on 79% of 200 concurrent issues');
+  ok(ids.every((i) => ID_PATTERN.test(i)) && ids[0]!.length === 'grant-'.length + 64,
+     'every id is <prefix>-<64 hex> — 256 CSPRNG bits, the width the estate’s no-djb2 id ratchet already demands');
+  {
+    // The whole point: the published fields no longer determine the id.
+    const { createHash } = await import('node:crypto');
+    // Every millisecond a mint could plausibly have happened in, derived both ways the old code
+    // might have joined its parts. None of them may hit a minted id. (The widths now match — a
+    // 256-bit mint is 64 hex, same as a sha256 — so this compares VALUES, which is the actual claim.)
+    const now = Date.now();
+    const derived = new Set<string>();
+    for (let t = now - 5_000; t <= now + 5_000; t++) {
+      const parts = ['Dr. X', 'cardiometabolic', String(t)];
+      derived.add(`grant-${createHash('sha256').update(parts.join('|')).digest('hex')}`);
+      derived.add(`grant-${createHash('sha256').update(JSON.stringify(parts)).digest('hex')}`);
+    }
+    ok(ids.every((i) => !derived.has(i)),
+       `an id is not recomputable from (agent, scope, granted_at) — ${derived.size.toLocaleString()} candidate derivations over a 10s window hit none of ${ids.length.toLocaleString()} minted ids; a grant listing is no longer a way to derive every id in it`);
+  }
+
+  // ── a bare id is refused wherever it arrives, and whatever else the request carries ────────────
+  ok(bareIdPolicy({ channel: 'query', presented: false, legacyAllowed: false }).reason === LEGACY_QUERY_REFUSAL,
+     '?grant=<id> alone is refused');
+  ok(bareIdPolicy({ channel: 'query', presented: true, legacyAllowed: false }).refuse === true,
+     '🔴 ?grant=<id> is refused EVEN WITH a valid holder credential — `bareId !== null && !presented` served those 200, left the id in the URL, and suppressed the deprecation warning');
+  ok(bareIdPolicy({ channel: 'body', presented: false, legacyAllowed: false }).reason === BODY_ID_REFUSAL,
+     'a bare id in the JSON body is refused too, and told why in its own words (a body is not logged; possession is still the whole authorization)');
+  ok(bareIdPolicy({ channel: 'body', presented: true, legacyAllowed: false }).refuse === true,
+     'a bare body id plus a credential is refused as well — one request, one answer to "which grant is this"');
+  ok(bareIdPolicy({ channel: 'query', presented: false, legacyAllowed: true }).refuse === false
+     && bareIdPolicy({ channel: 'query', presented: false, legacyAllowed: true }).warn === true,
+     'the synthetic-only opt-in still works, and is warned on every use (a gate that refuses everyone is equally broken)');
+  ok(bareIdPolicy({ channel: 'query', presented: true, legacyAllowed: true }).reason === BOTH_FORMS_REFUSAL,
+     'even with the opt-in on, presenting BOTH forms is refused rather than silently preferring one');
+
+  // ── the refusal costs the same whether or not the id exists ────────────────────────────────────
+  // The body was already uniform; the CLOCK was the remaining oracle. Both halves are asserted: the
+  // ledger is indexed (no scan) and the compare runs on every path (no early return on a miss).
+  {
+    // The two ids are the SAME LENGTH on purpose: an attacker picks the id, so a length difference
+    // measures strlen on their own input and tells them nothing about the ledger. What must not vary
+    // is the cost of the LOOKUP and the COMPARE. Interleaved runs, minimum taken — the minimum is the
+    // run least disturbed by the scheduler, and a real oracle survives it.
+    const KNOWN = 'grant-known-000000000000000000000000';
+    const UNKNOWN = 'grant-nope--000000000000000000000000';
+    const index = new Map([[KNOWN, { id: KNOWN, holderDigest: holderDigest(mintHolderSecret()) }]]);
+    const find = (id: string) => index.get(id);
+    const bench = (id: string, iters: number) => {
+      for (let i = 0; i < 5_000; i++) authenticateHolder({ presented: `${id}.wrong-secret`, find });
+      const t0 = process.hrtime.bigint();
+      for (let i = 0; i < iters; i++) authenticateHolder({ presented: `${id}.wrong-secret`, find });
+      return Number(process.hrtime.bigint() - t0);
+    };
+    //
+    // SELF-CALIBRATING, because a shared CI runner's noise floor is not knowable in advance and a
+    // fixed threshold is either flaky or meaningless. The same workload is benched twice to measure
+    // what this machine's repeat-measurement error IS, and the known-vs-unknown difference then has
+    // to sit inside that. This detects an ORDER-OF-MAGNITUDE tell — the array scan was 3,682% — and
+    // is not claimed as a formal constant-time proof, which a JIT and a shared runner cannot give.
+    const a: number[] = [], b: number[] = [], c: number[] = [];
+    for (let r = 0; r < 5; r++) {
+      a.push(bench(KNOWN, 20_000)); b.push(bench(UNKNOWN, 20_000)); c.push(bench(KNOWN, 20_000));
+    }
+    const exists = Math.min(...a), unknown = Math.min(...b), again = Math.min(...c);
+    const rel = (x: number, y: number) => Math.abs(x - y) / Math.max(x, y);
+    const noise = rel(exists, again);           // the same work, twice — pure measurement error
+    const skew = rel(exists, unknown);          // the signal an attacker would be reading
+    const budget = Math.max(0.25, noise * 2);
+    ok(skew <= budget,
+       `refusing a KNOWN id and an UNKNOWN id cost the same to within this machine's own noise ` +
+       `(skew ${(skew * 100).toFixed(1)}%, noise floor ${(noise * 100).toFixed(1)}%, budget ${(budget * 100).toFixed(1)}%) — ` +
+       `the response time is not an id-enumeration oracle (the ledger scan it replaced measured 3,682%)`);
+
+    // Both halves of that, asserted in the source so a refactor cannot quietly reinstate either.
+    // Comments are stripped first: this file's own prose names the thing it is forbidding.
+    const src = (await import('node:fs')).readFileSync(new URL('./server.ts', import.meta.url), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    ok(!/grants\.find\(/.test(src) && /grantIndex\.get\(/.test(src),
+       'server.ts looks a grant up by index, not by walking the ledger (a scan costs a full pass on a miss and one comparison on a head hit: 54µs vs 1.4µs over 2,000 grants)');
+    ok(!/['"`]access-control-allow-origin['"`]/.test(src),
+       'server.ts sets no access-control-allow-origin of its own — cors.ts holds the only copy of the policy');
+  }
 }
 
 console.log(`\n${fails === 0 ? '✓ ALL GUARDRAIL INVARIANTS HOLD (non-diagnostic + de-identification + grant scoping enforced)' : `✗ ${fails} invariant(s) violated`}`);

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -429,7 +429,7 @@ console.log('\n▶ INVARIANT 8 — a grant id is not a credential: the holder is
   const {
     authenticateHolder, holderDigest, holderToken, mintHolderSecret, parseHolderToken,
     presentedHolderToken, seedGrantDecision, legacyQueryDecision,
-    HOLDER_AUTH_DISCLOSURE, HOLDER_FAILED, HOLDER_HEADER,
+    HOLDER_AUTH_DISCLOSURE, HOLDER_FAILED, HOLDER_HEADER, HOLDER_REQUIRED,
   } = await import('./grantauth.js');
 
   const secret = mintHolderSecret();
@@ -443,7 +443,7 @@ console.log('\n▶ INVARIANT 8 — a grant id is not a credential: the holder is
   const wrongSecret = authenticateHolder({ presented: holderToken(bound.id, mintHolderSecret()), find });
   ok(wrongSecret.ok === false, 'the right id with the wrong secret is refused');
   const noCredential = authenticateHolder({ presented: '', find });
-  ok(noCredential.ok === false && (noCredential as any).reason !== HOLDER_FAILED,
+  ok(noCredential.ok === false && (noCredential as any).reason === HOLDER_REQUIRED && (noCredential as any).reason !== HOLDER_FAILED,
      'presenting nothing at all is refused, and told how to present (a usage error, not a failed attempt)');
   ok(authenticateHolder({ presented: holderToken(unbound.id, secret), find }).ok === false,
      'a grant carrying NO holder binding authenticates nobody — it fails closed, it does not get a legacy pass');

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -348,7 +348,7 @@ function authorizeGrant(req: http.IncomingMessage, url: URL, who: string, requir
   const auth = authenticateHolder({
     presented,
     find: findGrant,
-    onUnbound: (id) => console.warn(`health-twin: grant ${id} carries no holder binding — refused (fail-closed)`),
+    onUnbound: (id) => console.warn(`health-twin: grant ${String(id).replace(/[\r\n]/g, ' ')} carries no holder binding — refused (fail-closed)`),
   });
   if (!auth.ok) {
     return {

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -27,10 +27,12 @@ import { openConsult, reviewerView, submitOpinion, aggregate, requestMore, type 
 import { resolveScope, resolveGrant, applyScope, scopeSummary, SCOPE_PRESETS } from './grants.js';
 import { exposureDenial, exposureFromEnv } from './exposure.js';
 import {
-  HOLDER_HEADER, HOLDER_AUTH_DISCLOSURE, LEGACY_QUERY_REFUSAL, LEGACY_QUERY_DETAIL, LEGACY_QUERY_WARNING,
-  authenticateHolder, holderDigest, holderToken, legacyQueryDecision, mintHolderSecret,
+  HOLDER_HEADER, HOLDER_AUTH_DISCLOSURE, LEGACY_QUERY_WARNING,
+  authenticateHolder, bareIdPolicy, holderDigest, holderToken, legacyQueryDecision, mintHolderSecret,
   presentedHolderToken, seedGrantDecision,
 } from './grantauth.js';
+import { corsHeaders, corsPolicyFromEnv, originAllowed } from './cors.js';
+import { mintId } from './ids.js';
 import { predict, COMPARTMENTS, COMPARTMENT_SYSTEM, currentObservations, type Covariates } from './dynamics/predict.js';
 import { gatePolicy, rejectionLedger } from './dynamics/gate.js';
 import { fitSurrogate } from './dynamics/surrogate.js';
@@ -66,8 +68,23 @@ function denyExposure(req: http.IncomingMessage) {
 }
 
 // In-memory grant ledger (skeleton). Local-first store in production.
+//
+// Indexed by id, and the index is not a micro-optimisation. `grants.find((g) => g.id === id)` walks
+// the ledger, so a MISS costs a full scan and a HIT near the head costs one comparison — which makes
+// the response time an answer to "does this grant id exist?" for a caller who has, by definition,
+// just failed to authenticate. Measured over a 2,000-grant ledger: an unknown id took 54µs against
+// 1.4µs for a known one, a 37× tell through a refusal body that is otherwise byte-identical.
+// grantauth.ts closes the rest of the gap by doing the same digest work on every refusal.
+//
+// The array stays: it is the ORDER the patient's control panel is listed in. The two are written
+// together in addGrant(), which is the only way a grant enters the ledger.
 const grants: Grant[] = [];
-const findGrant = (id: string) => grants.find((g) => g.id === id);
+const grantIndex = new Map<string, Grant>();
+const findGrant = (id: string) => grantIndex.get(id);
+function addGrant(g: Grant, where: 'head' | 'tail' = 'head') {
+  if (where === 'head') grants.unshift(g); else grants.push(g);
+  grantIndex.set(g.id, g);
+}
 
 // ── the demo cardiologist grant, and the two boot-time policies around it ───────────────────────
 //
@@ -82,13 +99,18 @@ const findGrant = (id: string) => grants.find((g) => g.id === id);
 // be the thing nobody remembered to turn off.
 const SEED = seedGrantDecision(process.env, EXPOSURE);
 const LEGACY_QUERY = legacyQueryDecision(process.env, EXPOSURE);
-for (const fatal of [SEED.fatal, LEGACY_QUERY.fatal]) {
+// Which browser origins may drive this engine. `*` is neither emitted nor configurable — see cors.ts
+// for why a wildcard stopped being survivable in the same change that made a credential presentable.
+const CORS = corsPolicyFromEnv(process.env, EXPOSURE);
+const ALLOWED_ORIGINS: ReadonlySet<string> = new Set(CORS.origins);
+for (const fatal of [SEED.fatal, LEGACY_QUERY.fatal, CORS.fatal]) {
   if (fatal) { console.error(`health-twin: ${fatal}`); process.exit(1); }
 }
+console.log(`health-twin: CORS — ${CORS.why}${CORS.origins.length ? ` [${CORS.origins.join(' ')}]` : ''}`);
 if (SEED.seed) {
   // The scope is the cardiometabolic wedge, so the doctor chart still demos scoping on a fresh boot
   // (the childhood knee history is OUTSIDE it — it shows up as withheld counts).
-  grants.push({
+  addGrant({
     id: 'grant-dev-seed-cardiology',
     agent: 'Dr. A. Rivera (Cardiology) — DEV SEED, synthetic subject only',
     scope: 'cardiometabolic',
@@ -97,7 +119,7 @@ if (SEED.seed) {
     expires_at: new Date(Date.now() + 30 * 86_400_000).toISOString(),
     revoked: false, reads: 0, receipt: 'ht-grant-dev-seed',
     holderDigest: holderDigest(SEED.secret!),
-  });
+  }, 'tail');
   console.log(`health-twin: DEV SEED GRANT active (${SEED.why}). Synthetic subject only.`);
   // Printed once, to the operator who asked for it, because the alternative is a literal in source.
   if (SEED.minted) {
@@ -209,13 +231,26 @@ function twinTtl(): string {
   return head.concat(out).join('\n') + '\n';
 }
 
+/**
+ * 🔴 THIS IS THE SHARED CORS SURFACE. Every route answers through here, so the wildcard that used to
+ * sit on this line was on every response the service made — including the ones that accept and act
+ * on the holder credential. `access-control-allow-origin: *` plus `access-control-allow-headers:
+ * … x-health-grant` is an invitation: any page in any tab may call this engine, set the credential,
+ * and read the reply. Minting is ungated on a synthetic-only deployment, so a page could issue itself
+ * a grant, take the one-shot secret from a response it was allowed to read, and pull the chart —
+ * cross-origin, with no leaked id at all. The credential this PR introduced was usable by an attacker
+ * page the moment it existed.
+ *
+ * Now the origin is matched against an explicit allowlist (cors.ts) and echoed only on a hit; a
+ * caller with no `Origin` — same-origin browser requests through the nginx /svc/health proxy, curl,
+ * every server-to-server client — gets no CORS headers, because it never looks at them. `res.req` is
+ * the request this response belongs to, so no call site had to change: a per-route flag would have
+ * been the thing someone forgets on the one route that matters.
+ */
 function send(res: http.ServerResponse, code: number, body: unknown, extra: Record<string, string> = {}) {
   res.writeHead(code, {
     'content-type': 'application/json',
-    'access-control-allow-origin': '*',
-    // the holder credential rides a request header, so a cross-origin caller has to be allowed to set it
-    'access-control-allow-headers': `content-type, authorization, ${HOLDER_HEADER}`,
-    'access-control-allow-methods': 'POST, GET, OPTIONS',
+    ...corsHeaders(res.req?.headers?.origin as string | undefined, ALLOWED_ORIGINS),
     ...extra,
   });
   res.end(JSON.stringify(body));
@@ -261,27 +296,37 @@ type GrantAuthz =
 function authorizeGrant(req: http.IncomingMessage, url: URL, who: string, required: boolean, legacyBodyId?: string): GrantAuthz | null {
   // The two channels a bare id used to arrive on: `?grant=` (logged everywhere) and a JSON body
   // field (not logged, but still possession-is-authorization). Neither is a credential.
-  const bareId = url.searchParams.get('grant') ?? (legacyBodyId ? String(legacyBodyId) : null);
+  const queryId = url.searchParams.get('grant');
+  const bodyId = legacyBodyId != null && String(legacyBodyId).trim() ? String(legacyBodyId) : null;
+  const channel: 'query' | 'body' | null = queryId !== null ? 'query' : bodyId !== null ? 'body' : null;
+  const bareId = queryId ?? bodyId;
   const presented = presentedHolderToken(req.headers as Record<string, string | string[] | undefined>);
 
-  if (bareId !== null && !presented) {
-    if (!LEGACY_QUERY.allowed) {
+  // 🔴 THE GUARD USED TO BE `bareId !== null && !presented`, which meant a request carrying BOTH a
+  // `?grant=<id>` and a valid header skipped the refusal and was served 200: the id still landed in
+  // the access log, the proxy log, the history and the `Referer`, and the deprecation `Warning` was
+  // suppressed on precisely the requests that were teaching callers the channel still works. What
+  // leaks the id is the URL, not the absence of a better credential. So the bare form is refused
+  // WHENEVER IT IS PRESENT — see bareIdPolicy(), which is pure and covered by the invariants.
+  if (channel !== null) {
+    const policy = bareIdPolicy({ channel, presented: !!presented, legacyAllowed: LEGACY_QUERY.allowed });
+    if (policy.refuse) {
       return {
         ok: false, code: 401,
         body: {
           blocked: true, authenticated: false,
-          reason: LEGACY_QUERY_REFUSAL, detail: LEGACY_QUERY_DETAIL,
-          receipt: grantUseReceipt('grant-auth-denied', [who, LEGACY_QUERY_REFUSAL], { route: who, authenticated: false }),
+          reason: policy.reason, detail: policy.detail,
+          receipt: grantUseReceipt('grant-auth-denied', [who, policy.reason!], { route: who, authenticated: false }),
         },
         headers: { warning: LEGACY_QUERY_WARNING },
       };
     }
     // Enabled only on a synthetic-only deployment, and loud on every single use.
-    const r = resolveGrant(grants, bareId);
+    const r = resolveGrant(grantIndex, bareId!);
     if (!r.ok) {
       return {
         ok: false, code: 403,
-        body: { blocked: true, authenticated: false, reason: r.reason, receipt: grantUseReceipt(`${who}-blocked`, [bareId, r.reason], { route: who, authenticated: false }) },
+        body: { blocked: true, authenticated: false, reason: r.reason, receipt: grantUseReceipt(`${who}-blocked`, [bareId!, r.reason], { route: who, authenticated: false }) },
         headers: { warning: LEGACY_QUERY_WARNING },
       };
     }
@@ -303,7 +348,7 @@ function authorizeGrant(req: http.IncomingMessage, url: URL, who: string, requir
     };
   }
   // The holder is proved. Now, and only now, the grant's own state answers.
-  const r = resolveGrant(grants, auth.grantId);
+  const r = resolveGrant(grantIndex, auth.grantId);
   if (!r.ok) {
     return {
       ok: false, code: 403,
@@ -329,7 +374,15 @@ const authenticatedAs = (a: Extract<GrantAuthz, { ok: true }>) => (a.legacy
 
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
-  if (req.method === 'OPTIONS') return send(res, 204, {});
+  // The preflight is where a browser asks whether it may send `x-health-grant` from this origin. An
+  // origin that is not on the list is told no, out loud, rather than being handed a 204 with no
+  // allowance in it — the browser blocks either way, but only one of them is debuggable.
+  if (req.method === 'OPTIONS') {
+    const o = String(req.headers.origin ?? '');
+    return o && !originAllowed(o, ALLOWED_ORIGINS)
+      ? send(res, 403, { error: 'origin not allowed', detail: 'name it in HEALTH_TWIN_ALLOWED_ORIGINS' })
+      : send(res, 204, {});
+  }
   if (req.method === 'GET' && url.pathname === '/healthz') return send(res, 200, { ok: true, service: 'health-twin' });
 
   // The twin bundle (the surface's one read).
@@ -340,7 +393,12 @@ const server = http.createServer(async (req, res) => {
 
   // the twin as reasoner-ready RDF (Turtle) — typed with the HDT ontology, imports the TBox.
   if (req.method === 'GET' && url.pathname === '/api/health/twin.ttl') {
-    res.writeHead(200, { 'content-type': 'text/turtle; charset=utf-8', 'access-control-allow-origin': '*' });
+    // Turtle, so it does not go through send() — and so it had its own hand-rolled `*`. Same policy,
+    // written once: a second CORS surface is a second thing to forget.
+    res.writeHead(200, {
+      'content-type': 'text/turtle; charset=utf-8',
+      ...corsHeaders(req.headers.origin, ALLOWED_ORIGINS),
+    });
     return res.end(twinTtl());
   }
 
@@ -509,14 +567,26 @@ const server = http.createServer(async (req, res) => {
 
   // Evidence grounded ON the twin — the brain lookup contextualized by the patient's own record and
   // bound evidentiarily to each finding. The clinician chart shows the literature behind each number.
-  // Grant-aware: with ?grant=<id> the evidence is scoped SERVER-SIDE to records inside the grant, so
-  // withheld findings can't leak to the clinician through the evidence side door. Enforced here, not
-  // in the client. A blocked grant blocks evidence too.
+  // The evidence is scoped SERVER-SIDE to records inside the grant, so withheld findings can't leak
+  // to the clinician through the evidence side door. Enforced here, not in the client. A blocked
+  // grant blocks evidence too.
+  //
+  // 🔴 THE GRANT IS REQUIRED HERE, and it was not. `required: false` means "no grant = no narrowing",
+  // which on this route is "no credential = the WIDEST read the service can perform": groundTwin()
+  // walks every out-of-range observation and every condition and returns each one's display, value,
+  // unit and reference range, plus the patient's age band, sex and full comorbidity list as the
+  // retrieval context. That is the content of the records a scope withholds, reachable with nothing
+  // presented at all — the exact side door the sentence above says this route closes.
+  //
+  // "No narrowing" is the right default on a route where a grant only trims an otherwise-permitted
+  // read (predict, which is exposure-gated, so an unauthenticated caller is stopped by the deployment
+  // membrane first). /evidence is not exposure-gated in this mirror, so nothing else stands in front
+  // of it. The cockpit agrees: prophet-platform#1083 calls this only from the clinician chart and
+  // only after a token is entered, and its tests assert the 401. Nothing reads it unauthenticated.
   if (req.method === 'GET' && url.pathname === '/api/health/evidence') {
-    const a = authorizeGrant(req, url, 'evidence', false);
-    const grounded = await groundTwin();
-    if (a === null) return send(res, 200, grounded); // no grant offered → no narrowing
+    const a = authorizeGrant(req, url, 'evidence', true)!;
     if (!a.ok) return send(res, a.code, a.body, a.headers);
+    const grounded = await groundTwin();
     const scope = a.grant.scopeSpec ?? resolveScope(a.grant.scope);
     const { view } = applyScope(bundle(), scope);
     const keptIds = new Set<string>([
@@ -685,7 +755,14 @@ const server = http.createServer(async (req, res) => {
       // Minted here, hashed immediately, returned once, never stored and never logged.
       const secret = mintHolderSecret();
       const g: Grant = {
-        id: `grant-${sha256([agent, scope, String(now.getTime())].join('|'))}`,
+        // 🔴 WAS `grant-<sha256(agent|scope|ms)>` — a hash of its own published inputs. Two grants to
+        // the same agent with the same scope in the same millisecond collided (measured: 79% over 200
+        // concurrent issues), which puts two rows in the ledger under one identity: one holder stops
+        // authenticating with no error, revoking the id revokes one of them, and every receipt naming
+        // it is ambiguous about which grant it recorded. And `granted_at` is published at millisecond
+        // precision beside the agent and the scope, so anyone with a grant listing could recompute
+        // every id in it offline. Minted from the CSPRNG now — see ids.ts for why not a salted hash.
+        id: mintId('grant'),
         agent, scope, granted_at: now.toISOString(),
         expires_at: new Date(now.getTime() + ttlDays * 86400000).toISOString(),
         revoked: false, reads: 0, receipt: receipt('grant', [agent, scope, String(ttlDays)]).id,
@@ -693,7 +770,7 @@ const server = http.createServer(async (req, res) => {
         scopeSpec: resolveScope(String(b.preset ?? scope), b.scopeSpec),
         holderDigest: holderDigest(secret),
       };
-      grants.unshift(g);
+      addGrant(g);
       return send(res, 200, {
         grant: { ...publicGrant(g), scopeSummary: scopeSummary(g.scopeSpec!) },
         holder: {

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -121,9 +121,16 @@ if (SEED.seed) {
     holderDigest: holderDigest(SEED.secret!),
   }, 'tail');
   console.log(`health-twin: DEV SEED GRANT active (${SEED.why}). Synthetic subject only.`);
-  // Printed once, to the operator who asked for it, because the alternative is a literal in source.
+  // The seed grant's holder SECRET is never written to a log. A credential in a log is precisely the
+  // leak channel this PR exists to close (access logs, proxy logs, browser history, `Referer`), so the
+  // seed is no exception: printing `grant-dev-seed-cardiology.<secret>` here would re-open it on the
+  // operator's stdout. CI proves the positive path by supplying the secret out of band
+  // (HEALTH_TWIN_SEED_GRANT_SECRET), never by scraping this line — see the invariant on seedGrantDecision.
   if (SEED.minted) {
-    console.log(`health-twin: seed holder token (shown once) — ${HOLDER_HEADER}: ${holderToken('grant-dev-seed-cardiology', SEED.secret!)}`);
+    console.log(
+      `health-twin: DEV SEED GRANT holder secret was minted this boot and is NOT logged (a credential in a ` +
+      `log is the defect this service refuses). It is unrecoverable; to drive the seed grant set ` +
+      `HEALTH_TWIN_SEED_GRANT_SECRET to a holder secret you choose and reboot — the id alone is not a credential.`);
   } else {
     console.log(`health-twin: seed holder secret taken from HEALTH_TWIN_SEED_GRANT_SECRET (not printed)`);
   }
@@ -330,7 +337,9 @@ function authorizeGrant(req: http.IncomingMessage, url: URL, who: string, requir
         headers: { warning: LEGACY_QUERY_WARNING },
       };
     }
-    console.warn(`health-twin: DEPRECATED unauthenticated bare-id read on ${who} (${bareId})`);
+    // `bareId` is caller-supplied; strip CR/LF before it reaches the log so a crafted id cannot forge
+    // or split log lines (log-injection). `who` is a fixed route name, not user input.
+    console.warn(`health-twin: DEPRECATED unauthenticated bare-id read on ${who} (${String(bareId).replace(/[\r\n]/g, ' ')})`);
     return { ok: true, grant: r.grant, holder: 'unauthenticated:legacy-bare-id', legacy: true };
   }
 
@@ -784,7 +793,12 @@ const server = http.createServer(async (req, res) => {
         grantorAuth: EXPOSURE === 'authenticated'
           ? { authenticatedAs: 'deployment operator (HEALTH_TWIN_TOKEN)', isThePatient: false, note: 'no patient identity plane exists here — consent is issued by whoever operates the node' }
           : { authenticatedAs: null, isThePatient: false, note: 'synthetic-only deployment: minting is ungated because the data is synthetic, and refuses the moment real records land' },
-        receipt: grantUseReceipt('grant-issued', [g.id, g.holderDigest!, agent, scope], { grant: g.id, boundTo: g.holderDigest }),
+        // `boundTo: true`, not the digest itself. The holder verifier binds the receipt (it is in the
+        // hashed parts above, so a changed digest changes the receipt id), but it must not appear
+        // verbatim in the response: this file strips it everywhere else (publicGrant, bundle), and
+        // publishing a verifier is how an offline guessing target is handed out for free. A boolean says
+        // "this grant is holder-bound" without leaking what it is bound to.
+        receipt: grantUseReceipt('grant-issued', [g.id, g.holderDigest!, agent, scope], { grant: g.id, boundTo: true }),
       });
     } catch { return send(res, 400, { error: 'bad json' }); }
   }

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -26,6 +26,11 @@ import { guidance } from './guidelines.js';
 import { openConsult, reviewerView, submitOpinion, aggregate, requestMore, type Confidence } from './consult.js';
 import { resolveScope, resolveGrant, applyScope, scopeSummary, SCOPE_PRESETS } from './grants.js';
 import { exposureDenial, exposureFromEnv } from './exposure.js';
+import {
+  HOLDER_HEADER, HOLDER_AUTH_DISCLOSURE, LEGACY_QUERY_REFUSAL, LEGACY_QUERY_DETAIL, LEGACY_QUERY_WARNING,
+  authenticateHolder, holderDigest, holderToken, legacyQueryDecision, mintHolderSecret,
+  presentedHolderToken, seedGrantDecision,
+} from './grantauth.js';
 import { predict, COMPARTMENTS, COMPARTMENT_SYSTEM, currentObservations, type Covariates } from './dynamics/predict.js';
 import { gatePolicy, rejectionLedger } from './dynamics/gate.js';
 import { fitSurrogate } from './dynamics/surrogate.js';
@@ -60,18 +65,52 @@ function denyExposure(req: http.IncomingMessage) {
   });
 }
 
-// In-memory grant ledger (skeleton). Local-first store in production. Seeded with one active
-// cardiometabolic grant for the care-team cardiologist so the doctor chart demos scoping on a
-// fresh boot (the childhood knee history is OUTSIDE this scope — it shows up as withheld counts).
-const grants: Grant[] = [{
-  id: 'grant-seed-rivera',
-  agent: 'Dr. A. Rivera (Cardiology)',
-  scope: 'cardiometabolic',
-  scopeSpec: resolveScope('cardiometabolic'),
-  granted_at: new Date().toISOString(),
-  expires_at: new Date(Date.now() + 30 * 86_400_000).toISOString(),
-  revoked: false, reads: 0, receipt: 'ht-grant-seed',
-}];
+// In-memory grant ledger (skeleton). Local-first store in production.
+const grants: Grant[] = [];
+const findGrant = (id: string) => grants.find((g) => g.id === id);
+
+// ── the demo cardiologist grant, and the two boot-time policies around it ───────────────────────
+//
+// This used to be an unconditional array literal right here: a fixed, well-known id (the invariants
+// assert that string is gone, so it is not repeated even in this comment), active for 30 days, on
+// every boot of every deployment. Since a grant id was the whole credential, that made a live consent
+// grant whose secret was a string committed to a public repository — presentable by anyone who read
+// the source, a log line or a `Referer`. It is now: absent by default, refused outright in a
+// deployment that serves real records, and bound to a secret that is never in source.
+//
+// Both policies REFUSE TO BOOT rather than warn. A production configuration that cannot exist cannot
+// be the thing nobody remembered to turn off.
+const SEED = seedGrantDecision(process.env, EXPOSURE);
+const LEGACY_QUERY = legacyQueryDecision(process.env, EXPOSURE);
+for (const fatal of [SEED.fatal, LEGACY_QUERY.fatal]) {
+  if (fatal) { console.error(`health-twin: ${fatal}`); process.exit(1); }
+}
+if (SEED.seed) {
+  // The scope is the cardiometabolic wedge, so the doctor chart still demos scoping on a fresh boot
+  // (the childhood knee history is OUTSIDE it — it shows up as withheld counts).
+  grants.push({
+    id: 'grant-dev-seed-cardiology',
+    agent: 'Dr. A. Rivera (Cardiology) — DEV SEED, synthetic subject only',
+    scope: 'cardiometabolic',
+    scopeSpec: resolveScope('cardiometabolic'),
+    granted_at: new Date().toISOString(),
+    expires_at: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+    revoked: false, reads: 0, receipt: 'ht-grant-dev-seed',
+    holderDigest: holderDigest(SEED.secret!),
+  });
+  console.log(`health-twin: DEV SEED GRANT active (${SEED.why}). Synthetic subject only.`);
+  // Printed once, to the operator who asked for it, because the alternative is a literal in source.
+  if (SEED.minted) {
+    console.log(`health-twin: seed holder token (shown once) — ${HOLDER_HEADER}: ${holderToken('grant-dev-seed-cardiology', SEED.secret!)}`);
+  } else {
+    console.log(`health-twin: seed holder secret taken from HEALTH_TWIN_SEED_GRANT_SECRET (not printed)`);
+  }
+} else if (SEED.why) {
+  console.log(`health-twin: no demo grant — ${SEED.why}`);
+}
+if (LEGACY_QUERY.allowed) {
+  console.warn(`health-twin: DEPRECATED — ${LEGACY_QUERY.why}. ?grant=<id> authenticates nobody and leaks the id into every log in the path.`);
+}
 
 // Entered readings — device / voice / keyboard vitals that became coded observations. Local-first store.
 const readings: Reading[] = [];
@@ -126,7 +165,10 @@ function bundle() {
     careTeam: careTeam(), readings,
     timeline: [...ENCOUNTERS].sort((a, b) => (a.date < b.date ? 1 : -1)),
     counts: { observations: OBSERVATIONS.length, conditions: CONDITIONS.length, encounters: ENCOUNTERS.length, imaging: IMAGING.length, medications: MEDICATIONS.length, allergies: ALLERGIES.length, immunizations: IMMUNIZATIONS.length },
-    grants: grants.map((g) => ({ ...g, active: !g.revoked && new Date(g.expires_at) > new Date() })),
+    // `holderDigest` is the verifier for a live credential. It is not secret-equivalent (sha256 of
+    // 256 random bits), but there is no reason for it to be readable, and publishing verifiers is how
+    // an offline guessing target gets handed out for free.
+    grants: grants.map((g) => publicGrant(g)),
     // records pulled through the connector plane (provenance + epistemic tier on every one).
     ingested: { ...ingested, summary: ingestedSummary() },
     // captured media (voice notes, photos, documents) — hash-sealed, tier-tagged.
@@ -167,10 +209,23 @@ function twinTtl(): string {
   return head.concat(out).join('\n') + '\n';
 }
 
-function send(res: http.ServerResponse, code: number, body: unknown) {
-  res.writeHead(code, { 'content-type': 'application/json', 'access-control-allow-origin': '*', 'access-control-allow-headers': 'content-type', 'access-control-allow-methods': 'POST, GET, OPTIONS' });
+function send(res: http.ServerResponse, code: number, body: unknown, extra: Record<string, string> = {}) {
+  res.writeHead(code, {
+    'content-type': 'application/json',
+    'access-control-allow-origin': '*',
+    // the holder credential rides a request header, so a cross-origin caller has to be allowed to set it
+    'access-control-allow-headers': `content-type, authorization, ${HOLDER_HEADER}`,
+    'access-control-allow-methods': 'POST, GET, OPTIONS',
+    ...extra,
+  });
   res.end(JSON.stringify(body));
 }
+
+// The grant as anyone but the ledger may see it: never the holder verifier.
+const publicGrant = (g: Grant) => {
+  const { holderDigest: _verifier, ...rest } = g;
+  return { ...rest, active: !g.revoked && new Date(g.expires_at) > new Date() };
+};
 function readJson(req: http.IncomingMessage): Promise<any> {
   return new Promise((resolve, reject) => {
     let raw = ''; req.on('data', (c) => { raw += c; if (raw.length > 2_000_000) req.destroy(); });
@@ -178,6 +233,99 @@ function readJson(req: http.IncomingMessage): Promise<any> {
     req.on('error', reject);
   });
 }
+
+// ── the consent membrane's front door ───────────────────────────────────────────────────────────
+//
+// Every route that reads THROUGH a grant comes through here, so there is one answer to "who may
+// exercise this consent" rather than five copies that drift. The order is deliberate:
+//
+//   1. the query-string form is refused before anything is looked up — accepting a credential on a
+//      channel that logs it is the defect, and answering it at all normalises the channel;
+//   2. the HOLDER is authenticated (constant-time digest compare) with ONE uniform failure, so a
+//      caller who cannot authenticate cannot use the endpoint to discover which grant ids exist;
+//   3. only then is grant STATE consulted, so revoked/expired keep their stated reasons — reported
+//      to someone who has proved they hold the grant.
+//
+// Every refusal carries a receipt, for the same reason every read does: a block nobody can point at
+// afterwards is indistinguishable from a block that never happened.
+type GrantAuthz =
+  | { ok: true; grant: Grant; holder: string; legacy: boolean }
+  | { ok: false; code: number; body: Record<string, unknown>; headers?: Record<string, string> };
+
+/**
+ * `who` names the surface being read, so the receipt says WHAT was presented against WHICH subject
+ * on WHICH route. `required` is false for routes where a grant narrows an otherwise-permitted read
+ * (evidence, predict, the rejection ledger): no grant at all means "no narrowing", a presented grant
+ * means "authenticate it".
+ */
+function authorizeGrant(req: http.IncomingMessage, url: URL, who: string, required: boolean, legacyBodyId?: string): GrantAuthz | null {
+  // The two channels a bare id used to arrive on: `?grant=` (logged everywhere) and a JSON body
+  // field (not logged, but still possession-is-authorization). Neither is a credential.
+  const bareId = url.searchParams.get('grant') ?? (legacyBodyId ? String(legacyBodyId) : null);
+  const presented = presentedHolderToken(req.headers as Record<string, string | string[] | undefined>);
+
+  if (bareId !== null && !presented) {
+    if (!LEGACY_QUERY.allowed) {
+      return {
+        ok: false, code: 401,
+        body: {
+          blocked: true, authenticated: false,
+          reason: LEGACY_QUERY_REFUSAL, detail: LEGACY_QUERY_DETAIL,
+          receipt: grantUseReceipt('grant-auth-denied', [who, LEGACY_QUERY_REFUSAL], { route: who, authenticated: false }),
+        },
+        headers: { warning: LEGACY_QUERY_WARNING },
+      };
+    }
+    // Enabled only on a synthetic-only deployment, and loud on every single use.
+    const r = resolveGrant(grants, bareId);
+    if (!r.ok) {
+      return {
+        ok: false, code: 403,
+        body: { blocked: true, authenticated: false, reason: r.reason, receipt: grantUseReceipt(`${who}-blocked`, [bareId, r.reason], { route: who, authenticated: false }) },
+        headers: { warning: LEGACY_QUERY_WARNING },
+      };
+    }
+    console.warn(`health-twin: DEPRECATED unauthenticated bare-id read on ${who} (${bareId})`);
+    return { ok: true, grant: r.grant, holder: 'unauthenticated:legacy-bare-id', legacy: true };
+  }
+
+  if (!presented && !required) return null; // no grant offered, and this route does not demand one
+
+  const auth = authenticateHolder({
+    presented,
+    find: findGrant,
+    onUnbound: (id) => console.warn(`health-twin: grant ${id} carries no holder binding — refused (fail-closed)`),
+  });
+  if (!auth.ok) {
+    return {
+      ok: false, code: auth.code,
+      body: { blocked: true, authenticated: false, reason: auth.reason, detail: auth.detail, receipt: grantUseReceipt('grant-auth-denied', [who, auth.reason], { route: who, authenticated: false }) },
+    };
+  }
+  // The holder is proved. Now, and only now, the grant's own state answers.
+  const r = resolveGrant(grants, auth.grantId);
+  if (!r.ok) {
+    return {
+      ok: false, code: 403,
+      body: { blocked: true, authenticated: true, reason: r.reason, receipt: grantUseReceipt(`${who}-blocked`, [auth.grantId, auth.holderDigest, r.reason], { route: who, grant: auth.grantId, presentedBy: auth.holderDigest }) },
+    };
+  }
+  return { ok: true, grant: r.grant, holder: auth.holderDigest, legacy: false };
+}
+
+/**
+ * A grant-use receipt names WHO presented WHAT against WHICH subject — the three things an audit
+ * after the fact has to answer. Same `ht-<kind>-<sha256>` shape and same `verifier`/`at` fields as
+ * every other receipt this service emits; the holder appears as the stored digest, never the secret.
+ */
+function grantUseReceipt(kind: string, parts: string[], extra: Record<string, unknown> = {}) {
+  return { ...receipt(kind, [...parts, SUBJECT.id]), subject: SUBJECT.id, ...extra };
+}
+
+/** What an authenticated read says about the authentication behind it. Claims nothing more. */
+const authenticatedAs = (a: Extract<GrantAuthz, { ok: true }>) => (a.legacy
+  ? { ...HOLDER_AUTH_DISCLOSURE, mechanism: 'none (deprecated ?grant= query form)', binds: 'nobody — possession of an id that travels in logs', channel: 'query string', deprecated: true }
+  : HOLDER_AUTH_DISCLOSURE);
 
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
@@ -365,17 +513,21 @@ const server = http.createServer(async (req, res) => {
   // withheld findings can't leak to the clinician through the evidence side door. Enforced here, not
   // in the client. A blocked grant blocks evidence too.
   if (req.method === 'GET' && url.pathname === '/api/health/evidence') {
-    const gid = url.searchParams.get('grant');
+    const a = authorizeGrant(req, url, 'evidence', false);
     const grounded = await groundTwin();
-    if (!gid) return send(res, 200, grounded);
-    const r = resolveGrant(grants, String(gid));
-    if (!r.ok) return send(res, 403, { blocked: true, reason: r.reason, receipt: receipt('evidence-blocked', [String(gid), r.reason]) });
-    const scope = r.grant.scopeSpec ?? resolveScope(r.grant.scope);
+    if (a === null) return send(res, 200, grounded); // no grant offered → no narrowing
+    if (!a.ok) return send(res, a.code, a.body, a.headers);
+    const scope = a.grant.scopeSpec ?? resolveScope(a.grant.scope);
     const { view } = applyScope(bundle(), scope);
     const keptIds = new Set<string>([
       ...view.systems.flatMap((s: any) => [...s.observations, ...s.conditions].map((x: any) => x.id)),
     ]);
-    return send(res, 200, { ...grounded, items: grounded.items.filter((i) => keptIds.has(i.recordId)) });
+    return send(res, 200, {
+      ...grounded,
+      items: grounded.items.filter((i) => keptIds.has(i.recordId)),
+      authentication: authenticatedAs(a),
+      receipt: grantUseReceipt('evidence-read', [a.grant.id, a.holder], { grant: a.grant.id, presentedBy: a.holder }),
+    }, a.legacy ? { warning: LEGACY_QUERY_WARNING } : {});
   }
 
   // ── W10 TWIN DYNAMICS — the twin PREDICTS, under a gate. "Learned proposes, physics disposes."
@@ -419,12 +571,11 @@ const server = http.createServer(async (req, res) => {
         : COMPARTMENTS;
       const covariates = b.covariates && typeof b.covariates === 'object' ? (b.covariates as Covariates) : undefined;
 
-      const gid = url.searchParams.get('grant');
+      const a = authorizeGrant(req, url, 'predict', false);
+      if (a && !a.ok) return send(res, a.code, a.body, a.headers);
       let withheldSystems: string[] = [];
-      if (gid) {
-        const r = resolveGrant(grants, String(gid));
-        if (!r.ok) return send(res, 403, { blocked: true, reason: r.reason, receipt: receipt('predict-blocked', [String(gid), r.reason]) });
-        const scope = r.grant.scopeSpec ?? resolveScope(r.grant.scope);
+      if (a) {
+        const scope = a.grant.scopeSpec ?? resolveScope(a.grant.scope);
         const allowed = compartments.filter((k) => scope.systems === 'all' || scope.systems.includes(COMPARTMENT_SYSTEM[k]));
         withheldSystems = compartments.filter((k) => !allowed.includes(k)).map((k) => COMPARTMENT_SYSTEM[k]);
         compartments = allowed;
@@ -432,7 +583,9 @@ const server = http.createServer(async (req, res) => {
       if (compartments.length === 0) return send(res, 403, { blocked: true, reason: 'no compartment is inside this grant\u2019s scope' });
 
       const p = predict({ horizonDays, stepDays, compartments, covariates });
-      return send(res, 200, gid ? { ...p, grant: { id: gid, withheldSystems } } : p);
+      return send(res, 200, a
+        ? { ...p, grant: { id: a.grant.id, withheldSystems }, authentication: authenticatedAs(a), grantReceipt: grantUseReceipt('predict-read', [a.grant.id, a.holder], { grant: a.grant.id, presentedBy: a.holder }) }
+        : p, a?.legacy ? { warning: LEGACY_QUERY_WARNING } : {});
     } catch (e) { return send(res, 400, { error: (e as Error).message || 'predict failed' }); }
   }
 
@@ -507,15 +660,30 @@ const server = http.createServer(async (req, res) => {
     }
   }
 
-  // Grant a designated agent a scoped, time-boxed read grant — receipted.
+  // Grant a designated agent a scoped, time-boxed read grant — receipted, and now HOLDER-BOUND.
+  //
+  // 🔴 Minting is exposure-gated, and that is not decoration: an OPEN mint endpoint makes holder
+  // authentication theatre, because anyone refused at /doctor-view could simply issue themselves a
+  // full-history grant and read with a credential of their own choosing. Whether this deployment may
+  // hand out consent at all is the same question exposure.ts already answers for serving records.
+  //
+  // Be plain about what the grantor authentication IS: on a synthetic-only deployment, none — the
+  // data being synthetic is the whole protection, exactly as exposure.ts says. On an `authenticated`
+  // deployment it is the DEPLOYMENT secret, i.e. "whoever operates this node", NOT the patient. There
+  // is no patient identity plane in this skeleton, so consent cannot be attributed to the person
+  // whose records it discloses. That is recorded in the response rather than implied away.
   if (req.method === 'POST' && url.pathname === '/api/health/grant') {
     try {
+      const denied = denyExposure(req);
+      if (denied) return send(res, denied.code, denied.body);
       const b = await readJson(req);
       const agent = String(b.agent ?? '').trim();
       const scope = String(b.scope ?? 'all systems').trim() || 'all systems';
       const ttlDays = Math.max(1, Math.min(365, Number(b.ttlDays ?? 30)));
       if (!agent) return send(res, 422, { error: 'agent required' });
       const now = new Date();
+      // Minted here, hashed immediately, returned once, never stored and never logged.
+      const secret = mintHolderSecret();
       const g: Grant = {
         id: `grant-${sha256([agent, scope, String(now.getTime())].join('|'))}`,
         agent, scope, granted_at: now.toISOString(),
@@ -523,22 +691,42 @@ const server = http.createServer(async (req, res) => {
         revoked: false, reads: 0, receipt: receipt('grant', [agent, scope, String(ttlDays)]).id,
         // structured scope: explicit spec > preset name > the scope label if it names a preset > full history
         scopeSpec: resolveScope(String(b.preset ?? scope), b.scopeSpec),
+        holderDigest: holderDigest(secret),
       };
       grants.unshift(g);
-      return send(res, 200, { grant: { ...g, scopeSummary: scopeSummary(g.scopeSpec!) } });
+      return send(res, 200, {
+        grant: { ...publicGrant(g), scopeSummary: scopeSummary(g.scopeSpec!) },
+        holder: {
+          token: holderToken(g.id, secret),
+          shownOnce: true,
+          present: `${HOLDER_HEADER}: ${holderToken(g.id, secret)}`,
+          note: 'This is the only time the secret exists outside the holder. It is not recoverable — ' +
+            'only its sha256 digest is stored. Lost means re-issue, never look up.',
+        },
+        authentication: HOLDER_AUTH_DISCLOSURE,
+        grantorAuth: EXPOSURE === 'authenticated'
+          ? { authenticatedAs: 'deployment operator (HEALTH_TWIN_TOKEN)', isThePatient: false, note: 'no patient identity plane exists here — consent is issued by whoever operates the node' }
+          : { authenticatedAs: null, isThePatient: false, note: 'synthetic-only deployment: minting is ungated because the data is synthetic, and refuses the moment real records land' },
+        receipt: grantUseReceipt('grant-issued', [g.id, g.holderDigest!, agent, scope], { grant: g.id, boundTo: g.holderDigest }),
+      });
     } catch { return send(res, 400, { error: 'bad json' }); }
   }
 
-  // Grant summaries for the clinician surface (id + label + active — never the record itself).
+  // Grant summaries for the clinician surface (id + label + active — never the record itself, and
+  // never the holder verifier: this list is the patient's control panel, not a credential store.
+  // `holderBound` says whether the grant can authenticate anyone at all, so an unbound legacy grant
+  // is visible as such rather than looking active and silently refusing.)
   if (req.method === 'GET' && url.pathname === '/api/health/grants') {
     return send(res, 200, {
       grants: grants.map((g) => ({
         id: g.id, agent: g.agent, scope: g.scope,
         scopeSummary: scopeSummary(g.scopeSpec ?? resolveScope(g.scope)),
         active: !g.revoked && new Date(g.expires_at) > new Date(),
+        holderBound: !!g.holderDigest,
         expires_at: g.expires_at, reads: g.reads,
       })),
       presets: Object.fromEntries(Object.entries(SCOPE_PRESETS).map(([k, v]) => [k, scopeSummary(v)])),
+      authentication: HOLDER_AUTH_DISCLOSURE,
     });
   }
 
@@ -546,42 +734,80 @@ const server = http.createServer(async (req, res) => {
   // identified (the clinician is authorized); the slice is exactly what the consent covers, with
   // withheld COUNTS (never content) so the doctor can see more history exists and request it.
   // Every read is a receipt; revoked/expired/unknown grants get an explicit receipted block.
+  //
+  // 🔴 `resolveGrant` checks that the id exists, is unrevoked and is unexpired — nothing else — and
+  // the id arrived in a QUERY STRING, so it was a bearer capability with no holder authentication,
+  // logged by every proxy in the path and leaked in `Referer`; one of them was hard-coded in this
+  // file. Anyone who read the source, a log, or a referrer could present it.
+  //
+  // Now the grant BINDS A HOLDER: `x-health-grant: <grant-id>.<secret>`, verified against a sha256
+  // digest stored at issue time. A leaked id is no longer a chart. See grantauth.ts — including what
+  // this deliberately does NOT claim: it authenticates the holder of a secret, not a person.
   if (req.method === 'GET' && url.pathname === '/api/health/doctor-view') {
-    const id = String(url.searchParams.get('grant') ?? '');
-    const r = resolveGrant(grants, id);
-    if (!r.ok) return send(res, 403, { blocked: true, reason: r.reason, receipt: receipt('doctor-read-blocked', [id, r.reason]) });
-    const g = r.grant;
+    const a = authorizeGrant(req, url, 'doctor-read', true)!;
+    if (!a.ok) return send(res, a.code, a.body, a.headers);
+    const g = a.grant;
     g.reads += 1;
     const scope = g.scopeSpec ?? resolveScope(g.scope);
     const { view, withheld } = applyScope(bundle(), scope);
     return send(res, 200, {
       grant: { id: g.id, agent: g.agent, scope: g.scope, scopeSummary: scopeSummary(scope), expires_at: g.expires_at, reads: g.reads },
       view, withheld,
-      receipt: receipt('doctor-read', [g.id, String(g.reads)]),
-    });
+      authentication: authenticatedAs(a),
+      receipt: grantUseReceipt('doctor-read', [g.id, a.holder, String(g.reads)], { grant: g.id, presentedBy: a.holder }),
+    }, a.legacy ? { warning: LEGACY_QUERY_WARNING } : {});
   }
 
   // Revoke a grant — read-enforced: future reads by that agent are blocked.
+  //
+  // DELIBERATELY still id-only, and the honest reason is written into the response. Revocation is the
+  // PATIENT shutting a door on someone else's grant; the patient does not hold the clinician's secret,
+  // so requiring the holder credential here would mean only the person being revoked could revoke
+  // themselves. Slamming the door must never be harder than opening it.
+  //
+  // What that leaves unprotected, stated rather than implied: on a synthetic-only deployment anyone
+  // who learns a grant id can revoke it. That is a denial-of-ACCESS, not a disclosure — the failure
+  // direction is a clinician locked out, not a stranger reading a chart — but it is real, and it is
+  // unfixable here without a patient identity plane this estate does not have. On an `authenticated`
+  // deployment the exposure membrane at least requires the deployment secret.
   if (req.method === 'POST' && url.pathname === '/api/health/revoke') {
     try {
+      const denied = denyExposure(req);
+      if (denied) return send(res, denied.code, denied.body);
       const b = await readJson(req);
-      const g = grants.find((x) => x.id === String(b.grant));
+      const g = findGrant(String(b.grant));
       if (!g) return send(res, 404, { error: 'grant not found' });
       g.revoked = true;
-      return send(res, 200, { grant: g, receipt: receipt('revoke', [g.id]) });
+      return send(res, 200, {
+        grant: publicGrant(g),
+        revokerAuth: {
+          authenticatedAs: EXPOSURE === 'authenticated' ? 'deployment operator (HEALTH_TWIN_TOKEN)' : null,
+          isThePatient: false,
+          note: 'revocation is id-only by design (the patient does not hold the clinician secret); ' +
+            'no patient identity plane exists here, so the revoker is not authenticated as the subject',
+        },
+        receipt: grantUseReceipt('revoke', [g.id], { grant: g.id }),
+      });
     } catch { return send(res, 400, { error: 'bad json' }); }
   }
 
   // An agent exercises a grant to read a slice — the access itself is a receipt (or a block).
+  // Same holder credential as /doctor-view: this route counted a read and named the agent on the
+  // strength of an id in a JSON body, which is the same bearer capability by another channel.
   if (req.method === 'POST' && url.pathname === '/api/health/agent-read') {
     try {
+      const denied = denyExposure(req);
+      if (denied) return send(res, denied.code, denied.body);
       const b = await readJson(req);
-      const g = grants.find((x) => x.id === String(b.grant));
-      if (!g) return send(res, 404, { error: 'grant not found' });
-      if (g.revoked) return send(res, 403, { blocked: true, reason: 'grant revoked — read denied' });
-      if (new Date(g.expires_at) <= new Date()) return send(res, 403, { blocked: true, reason: 'grant expired — read denied' });
+      const a = authorizeGrant(req, url, 'agent-read', true, b.grant ? String(b.grant) : undefined)!;
+      if (!a.ok) return send(res, a.code, a.body, a.headers);
+      const g = a.grant;
       g.reads += 1;
-      return send(res, 200, { agent: g.agent, scope: g.scope, reads: g.reads, receipt: receipt('read', [g.id, String(g.reads)]) });
+      return send(res, 200, {
+        agent: g.agent, scope: g.scope, reads: g.reads,
+        authentication: authenticatedAs(a),
+        receipt: grantUseReceipt('read', [g.id, a.holder, String(g.reads)], { grant: g.id, presentedBy: a.holder }),
+      });
     } catch { return send(res, 400, { error: 'bad json' }); }
   }
 

--- a/deploy/values/health-twin.yaml
+++ b/deploy/values/health-twin.yaml
@@ -28,3 +28,13 @@ config:
   # do NOT put the token here. Absent → the twin degrades gracefully to the local sourced KB (no break).
   # SMART launch link base for CDS Hooks cards (the cockpit's /health surface).
   SMART_APP_BASE: "https://socioprophet.md"
+  # CORS. Deliberately NOT set, and that is the whole point: the cockpit reaches this service
+  # SAME-ORIGIN through nginx (`/svc/health/` → health-twin:8097, see apps/socioprophet-web/
+  # nginx.conf), so no browser here ever performs a cross-origin request and no allowance is needed.
+  # The service no longer emits `access-control-allow-origin: *` — on a surface that accepts the
+  # `x-health-grant` credential, a wildcard let any page in any tab mint a grant and read the chart.
+  # Unset on a synthetic-only deployment, the default allowlist is the loopback developer origins
+  # (nothing in-cluster can be at one of those). To allow a browser origin that is genuinely
+  # cross-origin — a BearBrowser sovereign host on a loopback sidecar, say — name it exactly:
+  #   HEALTH_TWIN_ALLOWED_ORIGINS: "http://127.0.0.1:7654"
+  # `""` means none at all. `"*"` is refused AT BOOT, in either exposure mode.


### PR DESCRIPTION
Hand-applied mirror of **prophet-health#8**. **Not** produced by `scripts/sync-to-platform.sh` — that script would delete 8 platform-only files and revert #1033/#1036/#1038, including re-opening a consent gate that defaults to granted.

## The defect

`resolveGrant()` verified three things: the grant id **exists**, is **unrevoked**, is **unexpired**. Nothing else. Possession of the id was authorization.

And the id travelled in a **query string** — the one channel a secret cannot survive. It lands in access logs, proxy logs, browser history, and the `Referer` of every outbound link from the page that used it. One grant (`grant-seed-rivera`) was additionally **hard-coded in `server.ts`**, so *reading the source* was a way to obtain a chart.

Harmless against today's synthetic data. A stranger reading a real patient record the day the connector plane lands actual ones.

## The design

The grant now **binds a holder**. At issue time the server mints 256 CSPRNG bits, stores only the `sha256` digest, returns the secret **once**, and a read means presenting `x-health-grant: <grant-id>.<secret>` — hashed and compared in constant time.

- **Per-grant secret, not a new auth system.** No identity provider, key directory or PKI exists in this estate; inventing one here would be the authentication-shaped decoration `exposure.ts` already refuses to ship. This reuses that module's shape: pure, parameterised, fail-closed, provable without binding a port.
- **A dedicated header, not `Authorization`.** `Authorization` already carries the *deployment* token that `exposure.ts` checks. Two questions, two lifetimes, two holders — and an `authenticated` deployment needs both on one request. A request header is equally out of logs, `Referer` and history.

## What changed

- `apps/health-twin/src/grantauth.ts` (new, byte-identical to prophet-health's).
- **One uniform refusal** for unknown id / unbound grant / wrong secret — no id-enumeration oracle. Grant **state** (revoked / expired) keeps its reason, for a proven holder only.
- **`?grant=` refused by default** (401 + `Warning` header). Opt-in `HEALTH_TWIN_LEGACY_GRANT_QUERY=1` for the synthetic demo, warned on every use; **fatal at boot** on an `authenticated` deployment.
- **Hard-coded seed grant gone.** Exists only under `HEALTH_TWIN_SEED_GRANT=1`, secret minted at boot or supplied out of band, **fatal at boot** in an `authenticated` deployment. Enforced — an invariant asserts the old id string is absent from `server.ts`.
- **Minting is exposure-gated** (`POST /grant`, `/revoke`, `/agent-read`). An open mint endpoint makes holder authentication theatre.
- **Receipts** on every grant use: who presented, what, against which subject — same `ht-<kind>-<sha256>` shape. Refusals receipted too. `holderDigest` never leaves the ledger.

## What is authenticated vs merely asserted

Recorded in the responses, in the spirit of `deident.ts` writing `keyed:false`:

- **holder** → real (secret + digest, constant-time). Every read returns `authentication.identityVerified: false`: this binds *the holder of a secret*, not a person. A forwarded secret makes the forwardee the holder.
- **grantor** → the deployment secret in `authenticated` mode, nothing in `synthetic-only`. `POST /grant` returns `grantorAuth.isThePatient: false`.
- **revoker** → id only, **deliberately**: the patient does not hold the clinician's secret, so requiring it would mean only the person being revoked could revoke themselves. `revokerAuth` says so. Residual: anyone who learns an id can revoke it on a synthetic deployment — denial-of-*access*, not disclosure, unfixable without a patient identity plane this estate lacks.

## Also: this repo had no CI for health-twin at all

The engine's guardrail invariants — de-identification, non-diagnostic framing, grant scoping, consent — **ran nowhere in prophet-platform.** Only `images.yml` touched `apps/health-twin`, and it only builds an image. The mirror could drift out of conformance indefinitely while prophet-health stayed green.

This PR adds a `health-twin` job to `ci.yml`: invariants, eval, the unit tests, and the both-ways grant proof against a live server.

## Proved both ways

**Refused** — leaked id in the query string; id in the header with no secret; right id + guessed secret; no credential; an unbound grant. Unknown-id and wrong-secret refusals are byte-identical (`diff`ed in CI). Nothing in a refusal leaks chart, agent or scope.

**Allowed** — the real holder reads: `200` with the scoped view, withheld counts and a receipt carrying `presentedBy: sha256-…` / `subject: synthetic-subject-0`. A freshly issued grant's one-shot token works. After revocation the *same authenticated holder* gets `403` on **state**, not `401` on authentication. Once a real record lands, exposure closes minting (403) — a holder credential is not a way around the deployment membrane.

`npx tsx src/invariants.ts` → 0 · `npx tsx src/eval.ts` → 0 · `npm test` → 5/5 · boot smoke → 0.

## Known consequence — the cockpit

`apps/socioprophet-web/src/services/healthTwinApi.ts` still calls `/api/health/doctor-view?grant=…` from the browser and will now get a 401. Intended direction, but it needs a follow-up: the cockpit cannot hold a per-grant secret today, and the honest fix is a clinician-supplied token, not a secret shipped in JavaScript. Until then `HEALTH_TWIN_LEGACY_GRANT_QUERY=1` restores the synthetic demo.

## Mirror asymmetries deliberately NOT ported

prophet-health's `server.ts` is ahead of this one in ways unrelated to this fix (exposure gates on `/twin.ttl`, `/evidence`, `/guidance`, `/reason` + its egress receipt; grant scoping on `/dynamics/rejections`; the exposure gate on `/doctor-view`). Those are separate changes and are **not** in this PR — only the grant-holder fix is.
