### PR TITLE
DO NOT MERGE BEFORE #1080: fail diagnostics-gate on a job declared in the workflow but never wired into needs:

### DIFF
--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -254,6 +254,17 @@ jobs:
   # DO NOT RENAME THIS JOB. `diagnostics-gate` is the only context in the
   # `main-required-checks` ruleset, and gitops-promote.yml dispatches this
   # workflow specifically to produce this check name on promote branches.
+  # That instruction is now ENFORCED, not merely written down: the rule below
+  # excludes this exact job id from its wiring check (a job cannot need itself)
+  # and asserts the name is present, so a rename turns the gate RED instead of
+  # silently disabling it.
+  #
+  # ADDING A JOB TO THIS FILE? It must also go in `needs:` below and be
+  # classified in tools/ci_diagnostics_gate.py. A job that is declared here but
+  # left out of `needs:` still runs and can still fail, and this — the only
+  # required check in the repository — would never look at it. The rule checks
+  # for that too, from the file rather than from the `needs:` payload, because
+  # the payload cannot report a job that was never wired in.
   #
   # This gate used to read:
   #   [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "false" ]

--- a/tools/ci_diagnostics_gate.py
+++ b/tools/ci_diagnostics_gate.py
@@ -18,6 +18,19 @@ WHY THIS FILE EXISTS
   nobody can test. Same argument as tools/ci_docs_only.py, applied to the thing
   that actually decides whether code may land.
 
+TWO PROPERTIES, NOT ONE
+  1. Every job wired into the gate's `needs:` genuinely ran and passed, or
+     skipped under the one documented filter.               -> verdict()
+  2. Every job DECLARED in the workflow file is wired into the gate's `needs:`
+     in the first place.                                    -> wiring_verdict()
+
+  (2) is not implied by (1), and that is the whole point of it. `verdict()` can
+  only see the jobs GitHub hands it, which is exactly the `needs:` list. A job
+  added to validate-target-diagnostics.yml and never added to `needs:` runs, can
+  fail, and the one required check for the repository never looks at it. The job
+  is correct, the gate is correct, and there is no edge between them — so the
+  gate is green while a failing job sits beside it.
+
 FAIL-CLOSED
   ci_docs_only.py fails OPEN (any doubt runs the full matrix) because the worst
   case there is wasted minutes. This module is its mirror image and fails
@@ -27,13 +40,17 @@ FAIL-CLOSED
 
 CONTRACT
   stdin  : the workflow's `toJSON(needs)` payload
-  stdout : one line per needed job, then the verdict
+  reads  : .github/workflows/validate-target-diagnostics.yml, for property (2)
+  stdout : one line per needed job, then one line per wiring finding, then the
+           verdict
   exit   : 0 = gate passes, 1 = gate fails
 """
 from __future__ import annotations
 
 import json
+import re
 import sys
+from pathlib import Path
 
 # Jobs that must have genuinely run and passed. No skip is ever acceptable for
 # these, so a path filter added to either one turns the gate RED until someone
@@ -56,6 +73,28 @@ MUST_SUCCEED = ('changes', 'validate-target-diagnostics')
 DOCS_ONLY_SKIPPABLE = ('app-test-diagnostics', 'smoke-target-diagnostics')
 
 KNOWN_JOBS = MUST_SUCCEED + DOCS_ONLY_SKIPPABLE
+
+# The gate job itself: the ONE job in this workflow legitimately absent from
+# `diagnostics-gate`'s `needs:`, because a job cannot depend on itself.
+#
+# This single literal is the entire self-exclusion, and it is a literal rather
+# than a pattern on purpose. The estate has already been burned by the broad
+# kind — a ratchet that excluded "its own" entries by pattern ended up counting
+# its own allowlist, and only went green AFTER the commit that should have
+# failed it. A prefix, suffix or substring rule here would swallow real misses:
+# `diagnostics-gate-v2`, `pre-diagnostics-gate` and `diagnostics-gates` are
+# different jobs and every one of them must still be caught.
+#
+# The name is also asserted PRESENT (see wiring_verdict), so the exclusion
+# cannot quietly decay into a no-op. That assertion is the first automated
+# enforcement of the "DO NOT RENAME THIS JOB" comment in the workflow: this is
+# the only context in the `main-required-checks` ruleset and the exact check
+# name gitops-promote.yml dispatches this workflow to produce, so a rename
+# disables the merge gate estate-wide — silently, until now.
+GATE_JOB = 'diagnostics-gate'
+
+WORKFLOW = (Path(__file__).resolve().parents[1]
+            / '.github' / 'workflows' / 'validate-target-diagnostics.yml')
 
 AUTHORISING_JOB = 'changes'
 AUTHORISING_OUTPUT = 'docs_only'
@@ -142,6 +181,106 @@ def verdict(needs: dict) -> tuple[bool, list[str]]:
     return ok, findings
 
 
+def declared_jobs(text: str) -> list[str]:
+    """Top-level job ids in the workflow — parsed positionally, no yaml dep.
+
+    Same idiom, and the same reason, as tools/check_workflow_path_filters.py:
+    this rule executes inside the gate job, which has `python3` and no
+    `pip install` step, so it reads YAML with the standard library or not at all.
+
+    Scoped to the `jobs:` block deliberately. The trigger keys under `on:`
+    (`pull_request`, `push`, `workflow_dispatch`) sit at the same two-space
+    indent as job ids, so an unscoped scan reports three phantom "unwired jobs"
+    and pins the only required check in the repository red forever.
+    """
+    block = re.search(r'^jobs:[ \t]*(?:#.*)?$(.*?)(?=^\w|\Z)', text, re.M | re.S)
+    if not block:
+        return []
+    return re.findall(r'^  ([A-Za-z0-9_-]+):[ \t]*(?:#.*)?$', block.group(1), re.M)
+
+
+def wiring_verdict(text: str | None) -> tuple[bool, list[str]]:
+    """Property (2): is every job in the workflow FILE covered by this gate?
+
+    `text` is the workflow source, or None when it could not be read.
+
+    The rule is an equality against KNOWN_JOBS rather than a subset test, and
+    that is what makes the two halves of this module compose:
+
+        wiring_verdict : jobs declared in the file, less the gate == KNOWN_JOBS
+        verdict        : jobs present in the `needs:` payload     == KNOWN_JOBS
+        GitHub         : the `needs:` payload IS the gate's `needs:` list
+
+    Chain them and you get "every job declared in the workflow is in the gate's
+    `needs:`" — enforced at runtime, inside the required check itself, without
+    this module having to parse the `needs:` list as a third source of truth
+    that could drift from the other two.
+    """
+    if text is None:
+        return False, [
+            f'{WORKFLOW.name}: could not be read at {WORKFLOW} — the wiring '
+            f'property cannot be checked, and an unverifiable gate blocks'
+        ]
+
+    declared = set(declared_jobs(text))
+    if not declared:
+        return False, [
+            f'{WORKFLOW.name}: no top-level jobs parsed out of it. Either the '
+            f'file moved or its layout changed and this parser has gone blind. '
+            f'Blind is RED: it will not vouch for a file it could not read.'
+        ]
+
+    findings: list[str] = []
+    ok = True
+
+    if GATE_JOB not in declared:
+        ok = False
+        findings.append(
+            f'{GATE_JOB}: not declared in {WORKFLOW.name}. This rule excludes '
+            f'exactly that one job id from the wiring check (a job cannot need '
+            f'itself), so a rename leaves the exclusion matching nothing while '
+            f'the renamed job goes unchecked. It is also the only context in the '
+            f'main-required-checks ruleset and the check name gitops-promote.yml '
+            f'dispatches for, so renaming it disables the merge gate '
+            f'estate-wide. Restore the name.'
+        )
+
+    for job in sorted(declared - {GATE_JOB} - set(KNOWN_JOBS)):
+        ok = False
+        findings.append(
+            f'{job}: declared in {WORKFLOW.name} but NOT wired into '
+            f'{GATE_JOB}\'s `needs:`. It runs, it can fail, and the one required '
+            f'check for this repository never looks at it. Add it to the gate\'s '
+            f'`needs:` and classify it in MUST_SUCCEED or DOCS_ONLY_SKIPPABLE.'
+        )
+
+    for job in KNOWN_JOBS:
+        if job not in declared:
+            ok = False
+            findings.append(
+                f'{job}: classified in tools/ci_diagnostics_gate.py but no longer '
+                f'declared in {WORKFLOW.name} — this rule is guarding coverage '
+                f'that does not exist. Remove the classification, or restore the '
+                f'job.'
+            )
+
+    if ok:
+        findings.append(
+            f'workflow wiring: all {len(declared)} job(s) declared in '
+            f'{WORKFLOW.name} are covered by {GATE_JOB} (itself excepted)'
+        )
+    return ok, findings
+
+
+def workflow_wiring() -> tuple[bool, list[str]]:
+    """`wiring_verdict` against the real file on disk, failing closed if absent."""
+    try:
+        text = WORKFLOW.read_text(encoding='utf-8', errors='replace')
+    except OSError:
+        text = None
+    return wiring_verdict(text)
+
+
 def main() -> int:
     raw = sys.stdin.read().strip()
     if not raw:
@@ -156,16 +295,29 @@ def main() -> int:
     ok, findings = verdict(needs)
     for line in findings:
         print(f'  {line}')
+
+    # Property (2), checked from the file rather than the payload — the payload
+    # cannot report a job that was never wired in. Evaluated unconditionally and
+    # printed even when the payload verdict has already failed, so one red run
+    # shows every reason it is red instead of one reason per push.
+    wiring_ok, wiring_findings = workflow_wiring()
+    for line in wiring_findings:
+        print(f'  {line}')
+    ok = ok and wiring_ok
+
     if ok:
-        print('diagnostics-gate: PASS — every leg ran, or skipped under a documented filter')
+        print('diagnostics-gate: PASS — every job in the workflow is wired into this '
+              'gate, and every leg ran or skipped under a documented filter')
         return 0
     # Verdict on stdout, not stderr. Python block-buffers stdout when it is not a
     # TTY, so a verdict written to stderr reaches the Actions log BEFORE the
     # findings that justify it — exactly backwards for whoever is reading a red
     # merge gate. The ::error:: annotation puts the headline in the run summary.
-    print('diagnostics-gate: FAIL — an unexplained skip is a red gate, not a green one')
-    print('::error::diagnostics-gate: a needed job did not succeed, or skipped without '
-          'authorisation. The per-job verdict is immediately above this line in the log.')
+    print('diagnostics-gate: FAIL — an unexplained skip, or a job this gate does not '
+          'cover, is a red gate and not a green one')
+    print('::error::diagnostics-gate: a needed job did not succeed, skipped without '
+          'authorisation, or is declared in the workflow without being wired into this '
+          'gate. The per-job verdict is immediately above this line in the log.')
     return 1
 
 

--- a/tools/tests/test_ci_diagnostics_gate.py
+++ b/tools/tests/test_ci_diagnostics_gate.py
@@ -8,6 +8,7 @@ a merge gate is worth exactly what its negative vectors prove.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -20,9 +21,14 @@ if str(REPO_ROOT) not in sys.path:
 
 from tools.ci_diagnostics_gate import (  # noqa: E402
     DOCS_ONLY_SKIPPABLE,
+    GATE_JOB,
     KNOWN_JOBS,
     MUST_SUCCEED,
+    WORKFLOW,
+    declared_jobs,
     verdict,
+    wiring_verdict,
+    workflow_wiring,
 )
 
 ALL_RESULTS = ('success', 'failure', 'cancelled', 'skipped')
@@ -245,3 +251,239 @@ def test_cli_fails_closed_on_unusable_input(stdin):
 def test_the_classification_lists_are_disjoint_and_complete():
     assert set(MUST_SUCCEED) & set(DOCS_ONLY_SKIPPABLE) == set()
     assert set(KNOWN_JOBS) == set(MUST_SUCCEED) | set(DOCS_ONLY_SKIPPABLE)
+
+
+# ══ property 2: every job DECLARED in the workflow is wired into the gate ═════
+#
+# Everything above validates the jobs the gate was handed — that is, the ones in
+# its `needs:`. None of it can see a job added to the workflow file and never
+# wired into `needs:` at all. That job runs, it can fail, and the only required
+# check for the repository never looks at it: the job is correct, the gate is
+# correct, and there is no edge between them.
+
+WORKFLOW_TEXT = WORKFLOW.read_text(encoding='utf-8')
+
+# Every job id the workflow is expected to declare: the four the gate needs,
+# plus the gate itself.
+ALL_DECLARED = KNOWN_JOBS + (GATE_JOB,)
+
+
+def workflow_text(*jobs: str) -> str:
+    """A synthetic workflow with the same top-level shape as the real one —
+    including the `on:` triggers, because their two-space indent is precisely
+    what the parser has to not mistake for a job."""
+    body = ''.join(
+        f'  {job}:\n'
+        f'    runs-on: ubuntu-latest\n'
+        f'    steps:\n'
+        f'      - run: echo {job}\n'
+        for job in jobs
+    )
+    return (
+        'name: validate-target-diagnostics\n\n'
+        'on:\n'
+        '  pull_request:\n'
+        '    branches: [ main ]\n'
+        '  push:\n'
+        '    branches: [ main ]\n'
+        '  workflow_dispatch:\n\n'
+        'jobs:\n' + body
+    )
+
+
+# ── the ratchet: the real file, not a fixture copy ────────────────────────────
+
+def test_every_job_in_the_real_workflow_is_wired_into_the_gate():
+    """THE RATCHET, and the reason this reads the REAL file rather than a
+    fixture: add a job to validate-target-diagnostics.yml and this test fails
+    until the job is wired into the gate's `needs:` and classified in
+    tools/ci_diagnostics_gate.py. A fixture copy would go stale on exactly the
+    commit where it mattered."""
+    assert set(declared_jobs(WORKFLOW_TEXT)) == set(KNOWN_JOBS) | {GATE_JOB}
+
+
+def test_the_real_workflow_passes_the_wiring_check_today():
+    """The mirror of every red case below. A checker that always fails is as
+    broken as one that never does."""
+    ok, findings = workflow_wiring()
+    assert ok is True, findings
+
+
+def test_the_module_points_at_the_workflow_it_claims_to():
+    """`WORKFLOW` is resolved from __file__; if tools/ ever moves, the gate must
+    not end up silently checking a path that does not exist."""
+    assert WORKFLOW.exists(), WORKFLOW
+    assert WORKFLOW.name == 'validate-target-diagnostics.yml'
+    assert WORKFLOW.read_text(encoding='utf-8').startswith('name: validate-target-diagnostics')
+
+
+# ── the parser, which has no yaml dep and must still be right ─────────────────
+
+def test_the_parser_does_not_mistake_on_triggers_for_jobs():
+    """`pull_request`, `push` and `workflow_dispatch` are indented exactly like
+    job ids. An unscoped scan reports three phantom unwired jobs and pins the
+    repository's only required check red forever."""
+    found = declared_jobs(WORKFLOW_TEXT)
+    for trigger in ('pull_request', 'push', 'workflow_dispatch'):
+        assert trigger not in found
+
+
+def test_the_parser_ignores_comments_and_nested_keys():
+    """Only column-2 keys inside `jobs:` are jobs. Comments at that indent, and
+    the deeper keys of a job body, are not."""
+    text = (
+        'on:\n  push:\n    branches: [ main ]\n\n'
+        'jobs:\n'
+        '  # commented-out-job:\n'
+        '  real-job:  # trailing comment\n'
+        '    runs-on: ubuntu-latest\n'
+        '    needs: [other]\n'
+        '    steps:\n'
+        '      - run: |\n'
+        '          echo not-a-job:\n'
+    )
+    assert declared_jobs(text) == ['real-job']
+
+
+def test_the_regex_parser_agrees_with_a_real_yaml_parser():
+    """The gate job runs `python3` with no `pip install`, so the rule parses the
+    workflow with a regex. That trade is only safe while the regex agrees with a
+    real parser on the real file — so check it here, where pyyaml IS installed
+    (the `tools-tests` leg installs it). Imported lazily: an optional dependency
+    must never make the merge gate's own test module unimportable."""
+    yaml = pytest.importorskip('yaml')
+    parsed = yaml.safe_load(WORKFLOW_TEXT)
+    assert declared_jobs(WORKFLOW_TEXT) == list(parsed['jobs'])
+    # And, while a real parser is to hand, close the loop the runtime rule
+    # deduces transitively: the gate's `needs:` list in the file is exactly the
+    # classified set.
+    assert set(parsed['jobs'][GATE_JOB]['needs']) == set(KNOWN_JOBS)
+
+
+def test_the_synthetic_fixture_declares_what_the_real_workflow_declares():
+    """If the fixture drifted from the real file, every red case below would be
+    proving something about a workflow this repo does not have."""
+    assert set(declared_jobs(workflow_text(*ALL_DECLARED))) == set(declared_jobs(WORKFLOW_TEXT))
+
+
+# ── THE GAP ───────────────────────────────────────────────────────────────────
+
+def test_a_fully_wired_workflow_is_green():
+    ok, _ = wiring_verdict(workflow_text(*ALL_DECLARED))
+    assert ok is True
+
+
+def test_a_job_added_to_the_file_but_never_wired_into_the_gate_is_red():
+    """THE GAP THIS CLOSES. The job runs and can fail; the required check never
+    looks at it."""
+    ok, findings = wiring_verdict(workflow_text(*ALL_DECLARED, 'orphan-diagnostics'))
+    assert ok is False
+    assert any(f.startswith('orphan-diagnostics:') for f in findings)
+
+
+@pytest.mark.parametrize('job', KNOWN_JOBS)
+def test_a_classified_job_deleted_from_the_file_is_red(job):
+    """The other direction: a classification guarding coverage that no longer
+    exists is a stale promise, not a passing gate."""
+    remaining = [j for j in ALL_DECLARED if j != job]
+    ok, findings = wiring_verdict(workflow_text(*remaining))
+    assert ok is False
+    assert any(f.startswith(f'{job}:') for f in findings)
+
+
+# ── the self-exclusion, which is the part most likely to rot ──────────────────
+
+def test_the_gate_job_does_not_trip_its_own_check():
+    """`diagnostics-gate` cannot appear in its own `needs:` — a job cannot
+    depend on itself — so its absence is legitimate and must not be reported."""
+    ok, findings = wiring_verdict(workflow_text(*ALL_DECLARED))
+    assert ok is True
+    assert not any(f.startswith(f'{GATE_JOB}:') for f in findings)
+
+
+@pytest.mark.parametrize('lookalike', [
+    'diagnostics-gate-v2',
+    'diagnostics-gates',
+    'pre-diagnostics-gate',
+    'diagnostics_gate',
+    'Diagnostics-Gate',
+    'diagnostics-gate2',
+    'gate',
+])
+def test_the_self_exclusion_is_one_exact_name_and_not_a_pattern(lookalike):
+    """The estate has been burned by the broad kind of self-exclusion: a ratchet
+    that skipped its own entries by pattern counted its own allowlist and only
+    went green AFTER the commit that should have failed it. Every name here is a
+    different job from the gate and every one must still be caught."""
+    ok, findings = wiring_verdict(workflow_text(*ALL_DECLARED, lookalike))
+    assert ok is False
+    assert any(f.startswith(f'{lookalike}:') for f in findings)
+
+
+def test_renaming_the_gate_job_is_red():
+    """DO NOT RENAME THIS JOB. `diagnostics-gate` is the only context in the
+    main-required-checks ruleset and the exact check name gitops-promote.yml
+    dispatches this workflow to produce, so a rename disables the merge gate
+    estate-wide. It also leaves the self-exclusion above matching nothing. This
+    is the first automated enforcement of that comment."""
+    renamed = [j for j in ALL_DECLARED if j != GATE_JOB] + ['merge-gate']
+    ok, findings = wiring_verdict(workflow_text(*renamed))
+    assert ok is False
+    assert any(f.startswith(f'{GATE_JOB}:') and 'not declared' in f for f in findings)
+
+
+# ── fail-closed when the parser cannot see ────────────────────────────────────
+
+def test_an_unreadable_workflow_is_red():
+    """If the file cannot be read the property is unverifiable, and an
+    unverifiable merge gate blocks."""
+    ok, _ = wiring_verdict(None)
+    assert ok is False
+
+
+@pytest.mark.parametrize('text', [
+    '',
+    'name: x\non:\n  push:\n    branches: [ main ]\n',   # no jobs: block at all
+    'jobs:\n',                                            # jobs: block, no jobs
+    'not yaml at all',
+    'jobs:\n    over-indented:\n      runs-on: ubuntu-latest\n',
+])
+def test_a_workflow_with_no_parsable_jobs_is_red(text):
+    """A parser that has gone blind must block, never vouch for a file it could
+    not read."""
+    ok, _ = wiring_verdict(text)
+    assert ok is False
+
+
+# ── end to end, through the entrypoint the gate step actually runs ────────────
+
+def test_cli_goes_red_on_an_unwired_job_and_green_again_when_it_is_removed(tmp_path):
+    """Red then green, against the REAL workflow file, through the same
+    `python3 tools/ci_diagnostics_gate.py` the gate step invokes.
+
+    The payload is fully green throughout: every needed leg reports success. The
+    gate must still fail while an unwired job sits in the file, which is exactly
+    the state that used to be invisible. Mutate-and-restore is the idiom
+    tools/tests/test_check_workflow_path_filters.py already uses for the same
+    reason — a checker only ever run against a passing file is not proven."""
+    backup = tmp_path / WORKFLOW.name
+    shutil.copy(WORKFLOW, backup)
+    original = WORKFLOW.read_text(encoding='utf-8')
+    try:
+        assert run_cli(json.dumps(needs())).returncode == 0, 'baseline must be green'
+
+        WORKFLOW.write_text(
+            original.rstrip('\n')
+            + '\n\n  orphan-diagnostics:\n'
+              '    runs-on: ubuntu-latest\n'
+              '    steps:\n'
+              '      - run: exit 1\n',
+            encoding='utf-8')
+        proc = run_cli(json.dumps(needs()))
+        assert proc.returncode != 0, 'a job outside the gate must turn the gate red'
+        assert 'orphan-diagnostics' in proc.stdout
+    finally:
+        shutil.copy(backup, WORKFLOW)
+
+    assert WORKFLOW.read_text(encoding='utf-8') == original
+    assert run_cli(json.dumps(needs())).returncode == 0, 'must be green once restored'


### PR DESCRIPTION
## ⛔ DO NOT MERGE UNTIL #1080 LANDS

**This PR is stacked on #1080** (`fix/diagnostics-gate-fail-closed-on-skip`), and its base branch is set to that branch rather than `main` so the ordering is enforced by GitHub and not only by this sentence.

Two reasons it must not land first:

1. **It would invalidate #1080's proof runs.** #1080's red-then-green evidence was produced against a gate that does not yet contain this check.
2. **It cannot land first.** `tools/ci_diagnostics_gate.py` does not exist on `main`; it is created by #1080. This PR only edits it.

As of opening, #1080 is **OPEN / BLOCKED**. Once it merges, GitHub will retarget this PR to `main` automatically. Please merge #1080 first, then this.

---

## The gap

#1080 made `diagnostics-gate` fail-closed on unexplained `skipped` results and moved the verdict into `tools/ci_diagnostics_gate.py`. That rule validates **the jobs in the gate's `needs:` list** — it already goes red if a job is dropped from `needs:`, or if an unclassified job is added to it.

What it cannot see is a job added to `validate-target-diagnostics.yml` and **never wired into `needs:` at all**. `verdict()` is only ever handed the `needs:` payload, and a job outside `needs:` is simply not in it. Such a job runs, it can fail, and the **only required status check in the repository** never looks at it.

The job is correct. The gate is correct. There is no edge between them. Last "correct artifact, missing connection" left in this gate.

## The check

`tools/ci_diagnostics_gate.py` gains a second property, read from the workflow **file** rather than the payload — because the payload cannot report a job that was never wired in:

```
wiring_verdict : jobs declared in the file, less the gate == KNOWN_JOBS
verdict        : jobs present in the `needs:` payload     == KNOWN_JOBS   (already there)
GitHub         : the `needs:` payload IS the gate's `needs:` list
```

Chained, those pin *every job declared in the workflow is in the gate's `needs:`* — without this module parsing the `needs:` list as a third source of truth that could itself drift.

**No new dependency.** A regex over top-level job keys, scoped to the `jobs:` block — the same *"parsed positionally, no yaml dep"* idiom as `tools/check_workflow_path_filters.py`, because the gate job runs `python3` with no `pip install`. Scoping is load-bearing: `pull_request`, `push` and `workflow_dispatch` sit at the same two-space indent as job ids, so an unscoped scan reports three phantom unwired jobs and pins the required check red forever. A test cross-checks the regex against **pyyaml on the real file** (lazily imported; the `tools-tests` leg installs it) so the no-dep trade stays honest.

**Enforced twice**, as asked:
- a **runtime assertion** inside the gate — which is what carries the load on docs-only diffs, where the `tools-tests` leg is legitimately skipped;
- a **unit test reading the REAL workflow** asserting `declared_jobs(...) == set(KNOWN_JOBS) | {'diagnostics-gate'}`, so it **ratchets** the moment anyone adds a job. Deliberately not a fixture copy: a copy goes stale on exactly the commit where it matters.

Fails closed throughout — unreadable file, moved file, or a layout the parser cannot read is RED, never a silent pass.

## The self-exclusion is one literal, not a pattern

`diagnostics-gate` is legitimately absent from its own `needs:` (a job cannot depend on itself). That exclusion is **exactly one literal job id**.

This is narrow on purpose. The estate has been burned the other way: a ratchet that excluded "its own" entries by pattern ended up counting its own allowlist and only went green *after* the commit that should have failed it. So every lookalike is still caught, each with a test:

| added job | result |
|---|---|
| `diagnostics-gate-v2` | RED (caught) |
| `diagnostics-gates` | RED (caught) |
| `pre-diagnostics-gate` | RED (caught) |
| `diagnostics_gate` | RED (caught) |
| `Diagnostics-Gate` | RED (caught) |
| `gate` | RED (caught) |

The name is also asserted **present**, so the exclusion cannot quietly decay into a no-op.

### Which means: renaming the gate job is now RED

**The `diagnostics-gate` job is NOT renamed by this PR.** The opposite — this is the first *automated* enforcement of the `DO NOT RENAME THIS JOB` comment. It is the only context in ruleset `main-required-checks` and the exact check name `gitops-promote.yml` dispatches this workflow to produce, so a rename disables the merge gate estate-wide. Until now that was protected by prose. Now:

```
diagnostics-gate: not declared in validate-target-diagnostics.yml. This rule excludes
exactly that one job id from the wiring check (a job cannot need itself), so a rename
leaves the exclusion matching nothing while the renamed job goes unchecked. ...
merge-gate: declared in validate-target-diagnostics.yml but NOT wired into
diagnostics-gate's `needs:`. ...
```

## Proof — red, then green

Run locally against the **real** workflow file, through the same entrypoint the gate step invokes. **The `needs:` payload is fully green in every run below** — every needed leg reports `success`. That is the point: the old gate had nothing to complain about.

**1. Baseline — untouched workflow:**
```
  changes: success
  validate-target-diagnostics: success
  app-test-diagnostics: success
  smoke-target-diagnostics: success
  workflow wiring: all 5 job(s) declared in validate-target-diagnostics.yml are covered by diagnostics-gate (itself excepted)
diagnostics-gate: PASS — every job in the workflow is wired into this gate, and every leg ran or skipped under a documented filter
exit=0
```

**2. RED — `audit-diagnostics` appended to the file, not to `needs:`:**
```
  changes: success
  validate-target-diagnostics: success
  app-test-diagnostics: success
  smoke-target-diagnostics: success
  audit-diagnostics: declared in validate-target-diagnostics.yml but NOT wired into diagnostics-gate's `needs:`. It runs, it can fail, and the one required check for this repository never looks at it. Add it to the gate's `needs:` and classify it in MUST_SUCCEED or DOCS_ONLY_SKIPPABLE.
diagnostics-gate: FAIL — an unexplained skip, or a job this gate does not cover, is a red gate and not a green one
::error::diagnostics-gate: a needed job did not succeed, skipped without authorisation, or is declared in the workflow without being wired into this gate.
exit=1
```

The unit-test ratchet fires on the same mutated file — `5 failed, 122 passed`, including `test_every_job_in_the_real_workflow_is_wired_into_the_gate`.

**3. GREEN again — file restored:** identical to the baseline, `exit=0`. A checker that always fails is as broken as one that never does, so both directions are proven, and the red-then-green pair is committed as a test (`test_cli_goes_red_on_an_unwired_job_and_green_again_when_it_is_removed`) using the same mutate-and-restore idiom `test_check_workflow_path_filters.py` already uses.

**`diagnostics-gate` does not trip its own check:** the baseline is green and emits no finding naming it.

## Suite

`pytest -q tools/tests`, the same command the `tools-tests` leg runs:

| | before (base = #1080 head) | after |
|---|---|---|
| collected | 388 | 417 |
| result | 376 passed, 12 skipped | **405 passed, 12 skipped** |

+29 tests, all passing; no pre-existing test changed outcome. `ruff check` clean.

## Scope

Touches `tools/ci_diagnostics_gate.py`, `tools/tests/test_ci_diagnostics_gate.py`, and a comment block in `.github/workflows/validate-target-diagnostics.yml`. **`gitops-promote.yml` is not touched** (#1076's lane); neither are `apps/health-twin/**` or `apps/device-service/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
