### PR TITLE
cockpit: read the health twin through a grant holder credential, not a grant id

### DIFF
--- a/apps/socioprophet-web/src/__tests__/healthGrantIssue.test.ts
+++ b/apps/socioprophet-web/src/__tests__/healthGrantIssue.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The PATIENT half of grant holder authentication (prophet-platform#1081) — the sharing panel.
+ *
+ * Issuing a grant now mints a secret and returns it ONCE as `holder.token`; only its sha256 digest
+ * is stored, so it can never be looked up again. Three things have to be true on this surface:
+ *
+ *   1. the token is shown once, plainly labelled as unrecoverable, and is not written anywhere;
+ *   2. `holderBound` is a visible difference — a grant that authenticates nobody is not rendered
+ *      identically to one that does;
+ *   3. "exercise this grant" is DISABLED for any grant whose token this session does not hold. The
+ *      patient does not hold the clinician's secret, and the button must say so rather than fail.
+ */
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import HealthTwin from '../pages/HealthTwin.vue';
+import { clearHolderToken } from '../services/healthHolderToken';
+
+const MINTED = 'grant-fresh999.mInTeD-s3cr3t-value';
+
+const TWIN = {
+  subject: { id: 'subj-1', label: 'Synthetic Subject', note: '', ageBand: '45-54', sex: 'F' },
+  systems: [{ id: 'cardiovascular', label: 'Cardiovascular', organs: ['heart'], observations: [], conditions: [], encounters: [], imaging: [] }],
+  timeline: [], counts: { observations: 0, conditions: 0, encounters: 0, imaging: 0 },
+  medications: [], allergies: [], immunizations: [], careTeam: [], readings: [],
+  grants: [
+    { id: 'grant-bound1', agent: 'Dr. Bound', scope: 'cardiometabolic', granted_at: '2026-01-01T00:00:00.000Z', expires_at: '2026-12-01T00:00:00.000Z', revoked: false, reads: 1, receipt: 'ht-g1', active: true },
+    { id: 'grant-legacy', agent: 'Dr. Legacy', scope: 'all systems', granted_at: '2026-01-01T00:00:00.000Z', expires_at: '2026-12-01T00:00:00.000Z', revoked: false, reads: 0, receipt: 'ht-g2', active: true },
+  ],
+  disclaimer: 'non-diagnostic',
+};
+
+const GRANTS = {
+  grants: [
+    { id: 'grant-bound1', agent: 'Dr. Bound', scope: 'cardiometabolic', scopeSummary: 'cardiometabolic', active: true, holderBound: true, expires_at: '2026-12-01T00:00:00.000Z', reads: 1 },
+    { id: 'grant-legacy', agent: 'Dr. Legacy', scope: 'all systems', scopeSummary: 'full history', active: true, holderBound: false, expires_at: '2026-12-01T00:00:00.000Z', reads: 0 },
+  ],
+  presets: {},
+};
+
+const json = (status: number, b: unknown) => new Response(JSON.stringify(b), { status, headers: { 'content-type': 'application/json' } });
+const flush = async () => { for (let i = 0; i < 8; i++) await new Promise((r) => setTimeout(r, 0)); };
+
+let calls: { url: string; token?: string }[] = [];
+
+beforeEach(() => {
+  clearHolderToken();
+  localStorage.setItem('health-twin-optin-v1', '1'); // past the opt-in gate
+  calls = [];
+  vi.stubGlobal('fetch', vi.fn(async (input: any, init: any = {}) => {
+    const url = String(input);
+    calls.push({ url, token: ((init.headers ?? {}) as Record<string, string>)['x-health-grant'] });
+    if (url.includes('/api/health/twin')) return json(200, TWIN);
+    if (url.includes('/api/health/grants')) return json(200, GRANTS);
+    if (url.includes('/api/health/grant')) {
+      return json(200, {
+        grant: { ...TWIN.grants[0], id: 'grant-fresh999', agent: 'Dr. New' },
+        holder: { token: MINTED, shownOnce: true, present: `x-health-grant: ${MINTED}`, note: 'This is the only time the secret exists outside the holder.' },
+      });
+    }
+    return json(200, {});
+  }));
+});
+afterEach(() => { clearHolderToken(); localStorage.clear(); vi.unstubAllGlobals(); });
+
+describe('health twin · sharing panel under holder binding', () => {
+  it('renders holderBound as a visible difference between the two grants', async () => {
+    const w = mount(HealthTwin);
+    await flush();
+
+    const marks = w.findAll('.g-bound');
+    expect(marks.length).toBe(2);
+    expect(marks[0].classes()).toContain('bound');
+    expect(marks[0].text()).toContain('holder-bound');
+    expect(marks[1].classes()).toContain('unbound');
+    expect(marks[1].text()).toContain('authenticates nobody');
+    expect(marks[0].text()).not.toBe(marks[1].text());
+  });
+
+  it('disables "exercise this grant" for grants whose token this session does not hold', async () => {
+    const w = mount(HealthTwin);
+    await flush();
+
+    const buttons = w.findAll('.g-actions button').filter((b) => b.text().includes('exercise'));
+    expect(buttons.length).toBe(2);
+    for (const b of buttons) expect(b.attributes('disabled')).toBeDefined();
+    expect(buttons[0].attributes('title')).toContain('do not hold');
+  });
+
+  it('shows the minted token once, labels it unrecoverable, and never persists it', async () => {
+    const w = mount(HealthTwin);
+    await flush();
+
+    await w.find('.sh-form input').setValue('Dr. New');
+    await w.findAll('.sh-form button').find((b) => b.text().includes('Grant read'))!.trigger('click');
+    await flush();
+
+    const panel = w.find('.sh-issued');
+    expect(panel.exists()).toBe(true);
+    expect(panel.find('.iss-tok').text()).toBe(MINTED);
+    expect(panel.text()).toContain('shown once');
+    expect(panel.text()).toMatch(/not recoverable/);
+
+    // it exists on screen, and nowhere else
+    expect(JSON.stringify(localStorage)).not.toContain('mInTeD');
+    expect(JSON.stringify(sessionStorage)).not.toContain('mInTeD');
+    expect(document.cookie).not.toContain('mInTeD');
+    // and no request ever carried it in a URL
+    for (const c of calls) expect(c.url).not.toContain('mInTeD');
+  });
+
+  it('dismissing the minted token clears it from the surface', async () => {
+    const w = mount(HealthTwin);
+    await flush();
+    await w.find('.sh-form input').setValue('Dr. New');
+    await w.findAll('.sh-form button').find((b) => b.text().includes('Grant read'))!.trigger('click');
+    await flush();
+
+    expect(w.find('.sh-issued').exists()).toBe(true);
+    await w.findAll('.iss-actions button').find((b) => b.text().includes('done'))!.trigger('click');
+    await flush();
+    expect(w.find('.sh-issued').exists()).toBe(false);
+    expect(w.html()).not.toContain('mInTeD');
+  });
+});

--- a/apps/socioprophet-web/src/__tests__/healthHolderAuth.test.ts
+++ b/apps/socioprophet-web/src/__tests__/healthHolderAuth.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Grant HOLDER AUTHENTICATION in the cockpit — the client half of prophet-platform#1081.
+ *
+ * The engine stopped accepting a grant id as a credential: `?grant=<id>` is refused with 401 because
+ * a query string lands in access logs, proxy logs, browser history and `Referer`. Reads now present
+ * `x-health-grant: <grant-id>.<secret>`, verified against a stored sha256 digest.
+ *
+ * These are the three proofs that the cockpit half is honest, plus the two that keep it honest:
+ *
+ *   1. NO TOKEN  → the empty state renders and NOT ONE request goes out that the engine would 401.
+ *                  (The old chart fired doctor-view at mount with whatever grant id came first.)
+ *   2. GOOD TOKEN→ doctor-view, evidence and agent-read all succeed, all three on the header, and
+ *                  no request URL anywhere carries `grant=`.
+ *   3. BAD TOKEN → the 401 surfaces as the recoverable "enter your token" state — not a crash, not a
+ *                  generic error toast, and not a silently blank chart.
+ *   4. The credential never reaches localStorage, sessionStorage or document.cookie.
+ *   5. `holderBound` is rendered as a visible difference, so a grant that can authenticate someone
+ *      does not look identical to one that cannot.
+ */
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import DoctorChart from '../pages/DoctorChart.vue';
+import { clearHolderToken } from '../services/healthHolderToken';
+
+const GOOD = 'grant-abc123.s3cr3t-token-value';
+const BAD = 'grant-abc123.wrong-secret';
+
+const GRANTS = {
+  grants: [
+    { id: 'grant-abc123', agent: 'Dr. A. Rivera (Cardiology)', scope: 'cardiometabolic', scopeSummary: 'cardiometabolic · 2y', active: true, holderBound: true, expires_at: '2026-12-01T00:00:00.000Z', reads: 2 },
+    { id: 'grant-legacy', agent: 'Dr. Old Grant', scope: 'all systems', scopeSummary: 'full history', active: true, holderBound: false, expires_at: '2026-12-01T00:00:00.000Z', reads: 0 },
+  ],
+  presets: {},
+};
+
+const VIEW = {
+  grant: { id: 'grant-abc123', agent: 'Dr. A. Rivera (Cardiology)', scope: 'cardiometabolic', scopeSummary: 'cardiometabolic · 2y', expires_at: '2026-12-01T00:00:00.000Z', reads: 3 },
+  view: {
+    subject: { id: 'subj-1', label: 'Synthetic Subject', note: '', ageBand: '45-54', sex: 'F' },
+    systems: [{ id: 'cardiovascular', label: 'Cardiovascular', organs: ['heart'], observations: [], conditions: [], encounters: [], imaging: [] }],
+    timeline: [], counts: { observations: 0, conditions: 0, encounters: 0, imaging: 0 },
+    medications: [], allergies: [], immunizations: [], careTeam: [], readings: [],
+    disclaimer: 'non-diagnostic',
+  },
+  withheld: { total: 4, conditions: 4 },
+  receipt: { id: 'ht-doctor-read-abcdef' },
+};
+
+const REFUSAL = { blocked: true, authenticated: false, reason: 'grant holder authentication failed' };
+
+/** Every request the component made: url + the credential header, if any. */
+let calls: { url: string; token?: string }[] = [];
+
+function installFetch(token: string | null) {
+  calls = [];
+  const fetchMock = vi.fn(async (input: any, init: any = {}) => {
+    const url = String(input);
+    const headers = (init.headers ?? {}) as Record<string, string>;
+    const presented = headers['x-health-grant'];
+    calls.push({ url, token: presented });
+
+    if (url.includes('/api/health/grants')) return json(200, GRANTS);
+
+    // The engine's rule, reproduced: these routes require a valid holder credential.
+    if (url.includes('/api/health/doctor-view') || url.includes('/api/health/evidence') || url.includes('/api/health/agent-read')) {
+      if (!presented) return json(401, { blocked: true, reason: 'grant holder credential required' });
+      if (presented !== GOOD) return json(401, REFUSAL);
+      if (url.includes('/api/health/doctor-view')) return json(200, VIEW);
+      if (url.includes('/api/health/evidence')) return json(200, { context: 'cardiometabolic', items: [] });
+      return json(200, { agent: 'Dr. A. Rivera (Cardiology)', reads: 4, receipt: { id: 'ht-read-1' } });
+    }
+    return json(200, {});
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  if (token) {
+    // Enter it the way a clinician does — through the component's own input.
+    return token;
+  }
+  return null;
+}
+
+const json = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+/** Type a token into the chart's credential field and submit it. */
+async function enterToken(w: any, token: string) {
+  await w.find('.dc-auth-in').setValue(token);
+  await w.find('.dc-auth-go').trigger('click');
+  await flush();
+}
+
+const flush = async () => { for (let i = 0; i < 6; i++) await new Promise((r) => setTimeout(r, 0)); };
+
+beforeEach(() => { clearHolderToken(); });
+afterEach(() => { clearHolderToken(); vi.unstubAllGlobals(); });
+
+describe('doctor chart · grant holder authentication', () => {
+  it('1. with NO token: shows the enter-token empty state and makes no request that would 401', async () => {
+    installFetch(null);
+    const w = mount(DoctorChart);
+    await flush();
+
+    // the recoverable state, not an error and not a chart
+    expect(w.find('.dc-auth').exists()).toBe(true);
+    expect(w.find('.dc-auth-h').text()).toContain('Enter your grant token');
+    expect(w.find('.dc-err').exists()).toBe(false);
+    expect(w.find('.dc-head').exists()).toBe(false);
+
+    // the ONLY call is the unauthenticated grants list, which the engine serves to anyone
+    expect(calls.map((c) => c.url.replace(/^.*\/api/, '/api'))).toEqual(['/api/health/grants']);
+    expect(calls.some((c) => c.url.includes('doctor-view'))).toBe(false);
+    expect(calls.some((c) => c.url.includes('/api/health/evidence'))).toBe(false);
+  });
+
+  it('1b. the empty state says the token is session-only and that losing it on refresh is intended', async () => {
+    installFetch(null);
+    const w = mount(DoctorChart);
+    await flush();
+    const copy = w.find('.dc-auth').text();
+    expect(copy).toContain('in memory for this session only');
+    expect(copy).toMatch(/Refreshing the page loses it, and that is deliberate/);
+  });
+
+  it('2. with a VALID token: doctor-view, evidence and agent-read all go through on the header', async () => {
+    installFetch(null);
+    const w = mount(DoctorChart);
+    await flush();
+    await enterToken(w, GOOD);
+
+    // the chart rendered
+    expect(w.find('.dc-auth').exists()).toBe(false);
+    expect(w.find('.dc-head').exists()).toBe(true);
+    expect(w.find('.dc-gate').text()).toContain('Dr. A. Rivera (Cardiology)');
+
+    const dv = calls.find((c) => c.url.includes('doctor-view'));
+    const ev = calls.find((c) => c.url.includes('/api/health/evidence'));
+    expect(dv?.token).toBe(GOOD);
+    expect(ev?.token).toBe(GOOD);
+
+    // agent-read is exercised directly against the same credential
+    const { agentRead } = await import('../services/healthTwinApi');
+    const r = await agentRead();
+    expect(r.receipt?.id).toBe('ht-read-1');
+    expect(calls.find((c) => c.url.includes('agent-read'))?.token).toBe(GOOD);
+  });
+
+  it('2b. NO request ever carries the grant in the URL — the `?grant=` form is gone', async () => {
+    installFetch(null);
+    const w = mount(DoctorChart);
+    await flush();
+    await enterToken(w, GOOD);
+
+    const { agentRead } = await import('../services/healthTwinApi');
+    await agentRead();
+
+    expect(calls.length).toBeGreaterThan(2);
+    for (const c of calls) {
+      expect(c.url).not.toContain('grant=');
+      expect(c.url).not.toContain('s3cr3t');
+    }
+  });
+
+  it('3. with a BAD token: the 401 is the recoverable enter-token state, not a crash or a blank chart', async () => {
+    installFetch(null);
+    const w = mount(DoctorChart);
+    await flush();
+    await enterToken(w, BAD);
+
+    // back to the credential prompt, flagged as a refusal, with the engine's reason shown
+    expect(w.find('.dc-auth').exists()).toBe(true);
+    expect(w.find('.dc-auth').classes()).toContain('refused');
+    expect(w.find('.dc-auth-h').text()).toContain('refused');
+    expect(w.find('.dc-auth-why').text()).toContain('grant holder authentication failed');
+
+    // NOT a generic error, and NOT the 403 "access blocked" panel (that means a proven holder)
+    expect(w.find('.dc-err').exists()).toBe(false);
+    expect(w.find('.dc-blocked').exists()).toBe(false);
+    // the input is offered again, so it is recoverable in place
+    expect(w.find('.dc-auth-in').exists()).toBe(true);
+
+    // and the refused credential was dropped rather than kept to re-fail
+    const { hasHolderToken } = await import('../services/healthHolderToken');
+    expect(hasHolderToken.value).toBe(false);
+
+    // recovery actually works: entering the right one from that same state opens the chart
+    await enterToken(w, GOOD);
+    expect(w.find('.dc-head').exists()).toBe(true);
+  });
+
+  it('3b. a bare grant id is rejected client-side, without spending a failed authentication', async () => {
+    installFetch(null);
+    const w = mount(DoctorChart);
+    await flush();
+    const before = calls.length;
+    await enterToken(w, 'grant-abc123'); // no `.secret` — not a credential
+    expect(w.find('.dc-auth').classes()).toContain('refused');
+    expect(calls.length).toBe(before); // nothing was sent
+  });
+
+  it('4. the credential never lands in localStorage, sessionStorage or a cookie', async () => {
+    installFetch(null);
+    const w = mount(DoctorChart);
+    await flush();
+    await enterToken(w, GOOD);
+
+    expect(JSON.stringify(localStorage)).not.toContain('s3cr3t');
+    expect(JSON.stringify(sessionStorage)).not.toContain('s3cr3t');
+    expect(document.cookie).not.toContain('s3cr3t');
+    // and it is not left sitting in the DOM input either
+    expect(w.html()).not.toContain('s3cr3t');
+  });
+
+  it('5. holderBound is a visible difference: a grant that authenticates nobody is marked as such', async () => {
+    installFetch(null);
+    const w = mount(DoctorChart);
+    await flush();
+
+    const badges = w.findAll('.dc-gr-badge');
+    expect(badges.length).toBe(2);
+    expect(badges[0].classes()).toContain('bound');
+    expect(badges[0].text()).toContain('holder-bound');
+    expect(badges[1].classes()).toContain('unbound');
+    expect(badges[1].text()).toContain('authenticates nobody');
+    // the two are not presented identically
+    expect(badges[0].text()).not.toBe(badges[1].text());
+    expect(w.find('.dc-gr-note').exists()).toBe(true);
+  });
+});

--- a/apps/socioprophet-web/src/pages/DoctorChart.vue
+++ b/apps/socioprophet-web/src/pages/DoctorChart.vue
@@ -4,8 +4,15 @@
 // withheld COUNTS (never content), and a receipt per read; a revoked or expired grant is an explicit
 // block. Problems / meds / allergies up top, vitals with one-tap voice/keyboard entry, labs with
 // trends, and history as far back as the grant reaches. Non-diagnostic; a clinician decides.
+//
+// The chart reads through a HOLDER CREDENTIAL, not a grant id. The clinician pastes the token the
+// patient's twin showed once at issue time; it is held in memory for this session and nowhere else
+// (healthHolderToken.ts explains why not localStorage / sessionStorage / a cookie). No token means
+// no request — the empty state below is reached without ever asking the engine a question it would
+// have to refuse.
 import { ref, computed, onMounted } from 'vue';
-import { listGrants, doctorView, addReading, groundEvidence, type GrantSummary, type WithheldCounts, type TwinBundle, type TwinEvidence } from '../services/healthTwinApi';
+import { listGrants, doctorView, addReading, groundEvidence, HolderAuthError, type GrantSummary, type WithheldCounts, type TwinBundle, type TwinEvidence } from '../services/healthTwinApi';
+import { setHolderToken, clearHolderToken, hasHolderToken, holderGrantId } from '../services/healthHolderToken';
 import Sparkline from '../components/Sparkline.vue';
 
 const twin = ref<TwinBundle | null>(null);
@@ -18,7 +25,6 @@ const evByRecord = computed(() => { const m: Record<string, TwinEvidence> = {}; 
 
 // consent membrane state — which grant this chart reads through
 const grants = ref<GrantSummary[]>([]);
-const grantId = ref('');
 const grantMeta = ref<{ agent: string; scope: string; scopeSummary: string; expires_at: string; reads: number } | null>(null);
 const withheld = ref<WithheldCounts | null>(null);
 const readReceipt = ref('');
@@ -26,25 +32,81 @@ const blockedReason = ref('');
 const withheldDetail = computed(() =>
   Object.entries(withheld.value ?? {}).filter(([k, v]) => k !== 'total' && v).map(([k, v]) => `${v} ${k}`).join(', '));
 
+// The credential, and the one state that is NOT a failure: a recoverable "enter your token".
+// `refused` distinguishes "the engine rejected what you presented" from "you haven't presented one".
+const tokenEntry = ref('');
+const authNeeded = ref<{ reason: string; detail?: string; refused: boolean } | null>(null);
+const held = hasHolderToken;
+// The id half of the held token. Safe to render — the id was never the secret; that was the bug.
+const heldGrant = computed(() => grants.value.find((g) => g.id === holderGrantId.value) ?? null);
+
+function clearChart() {
+  twin.value = null; grantMeta.value = null; withheld.value = null; evidence.value = [];
+  evContext.value = ''; readReceipt.value = '';
+}
+
+/**
+ * Mount, and every refresh of the grant list. Reads ONLY the unauthenticated grants list — the
+ * patient's control panel, which needs no credential — and stops there when nothing is held. The
+ * old version fired doctor-view at mount with whichever grant id happened to be first, which under
+ * holder auth is a guaranteed 401 and a receipted failed read on every page load.
+ */
 async function load() {
   loading.value = true; err.value = '';
   try {
-    const gl = await listGrants();
-    grants.value = gl.grants;
-    if (!grantId.value) grantId.value = (gl.grants.find((g) => g.active) ?? gl.grants[0])?.id ?? '';
-    if (!grantId.value) { blockedReason.value = 'No consent grant on file — the patient has not authorized clinician access.'; twin.value = null; return; }
-    const dv = await doctorView(grantId.value);
+    grants.value = (await listGrants()).grants;
+  } catch (e) {
+    err.value = e instanceof Error ? e.message : 'grants unreachable';
+    loading.value = false; return;
+  }
+  loading.value = false;
+  if (held.value) await readChart();
+}
+
+async function readChart() {
+  loading.value = true; err.value = ''; authNeeded.value = null;
+  try {
+    const dv = await doctorView();
     if (dv.blocked || !dv.view) {
+      // 403: the holder is proven, the GRANT is revoked or expired. A block is an answer, not a fault.
       blockedReason.value = dv.reason ?? 'access blocked';
-      twin.value = null; grantMeta.value = null; withheld.value = null; evidence.value = [];
+      clearChart();
       return;
     }
     blockedReason.value = '';
     twin.value = dv.view as TwinBundle; // the SCOPED slice — grants panel stays with the patient
     grantMeta.value = dv.grant ?? null; withheld.value = dv.withheld ?? null; readReceipt.value = dv.receipt?.id ?? '';
-    try { const g = await groundEvidence(grantId.value); evidence.value = g.items; evContext.value = g.context; } catch { /* evidence optional */ }
-  } catch (e) { err.value = e instanceof Error ? e.message : 'chart unreachable'; }
-  finally { loading.value = false; }
+    // Evidence stays optional: the chart is already rendering under a proven credential, and blanking
+    // it because a secondary read failed would be a worse answer than showing it without annotations.
+    try { const g = await groundEvidence(); evidence.value = g.items; evContext.value = g.context; } catch { /* evidence optional */ }
+  } catch (e) {
+    if (e instanceof HolderAuthError) {
+      // Recoverable. The credential is what failed — say so, and let the clinician enter another.
+      authNeeded.value = { reason: e.reason, detail: e.detail, refused: !e.missing };
+      if (!e.missing) clearHolderToken(); // a refused token is not worth keeping around to re-fail
+      blockedReason.value = ''; clearChart();
+    } else {
+      err.value = e instanceof Error ? e.message : 'chart unreachable';
+    }
+  } finally { loading.value = false; }
+}
+
+function submitToken() {
+  if (!setHolderToken(tokenEntry.value)) {
+    authNeeded.value = {
+      reason: 'That is not a grant token.',
+      detail: 'Expected `<grant-id>.<secret>` — a grant id on its own is not a credential.',
+      refused: true,
+    };
+    return;
+  }
+  tokenEntry.value = ''; // the raw credential does not linger in a DOM input once it is held
+  readChart();
+}
+
+function forgetToken() {
+  clearHolderToken();
+  clearChart(); blockedReason.value = ''; authNeeded.value = null; tokenEntry.value = '';
 }
 onMounted(load);
 
@@ -85,20 +147,72 @@ async function submitReading() {
   <div class="dc">
     <p class="dc-dx">⚕ Clinician chart — the patient's authorized record. Not a diagnosis; a clinician decides. Synthetic demo data.</p>
     <p v-if="err" class="dc-err">{{ err }}</p>
-    <p v-else-if="loading && !twin && !blockedReason" class="dc-msg">Loading chart…</p>
+    <p v-else-if="loading && held && !twin && !blockedReason" class="dc-msg">Loading chart…</p>
 
-    <!-- consent membrane: which grant this chart reads through — scope, receipt, and what's withheld -->
-    <section v-if="grants.length" class="dc-gate">
+    <!-- ── no credential held: the recoverable state, reached WITHOUT an unauthenticated read ──── -->
+    <section v-if="!held" class="dc-auth" :class="{ refused: authNeeded?.refused }">
+      <b class="dc-auth-h">{{ authNeeded?.refused ? '⛔ That token was refused' : '🔑 Enter your grant token' }}</b>
+      <p v-if="authNeeded?.refused" class="dc-auth-why">
+        {{ authNeeded.reason }}<span v-if="authNeeded.detail"> — {{ authNeeded.detail }}</span>
+      </p>
+      <p class="dc-auth-lead">
+        This chart reads through the patient's consent grant. The grant's access token is shown
+        <b>once</b>, to whoever issued it — paste it here. A grant id on its own is not a credential.
+      </p>
+      <div class="dc-auth-form">
+        <input
+          v-model="tokenEntry" type="password" class="dc-auth-in" placeholder="grant-id.secret"
+          autocomplete="off" spellcheck="false" aria-label="Grant access token"
+          @keydown.enter="submitToken" />
+        <button class="dc-auth-go" :disabled="!tokenEntry.trim()" @click="submitToken">Open chart</button>
+      </div>
+      <p class="dc-auth-fine">
+        Held <b>in memory for this session only</b> — never written to this device, this browser, or a
+        cookie. <b>Refreshing the page loses it, and that is deliberate:</b> a credential that survives
+        a refresh is a credential left behind on a shared bedside screen. Re-entering costs you
+        seconds; persisting it costs the patient their chart.
+      </p>
+      <p class="dc-auth-fine">
+        No token? It cannot be looked up — only its digest is stored, so a lost token means the grant
+        has to be re-issued. Ask the patient, or the operator of this node, for one.
+      </p>
+
+      <!-- grants on file: which of them can actually authenticate anyone -->
+      <div v-if="grants.length" class="dc-auth-grants">
+        <span class="dc-auth-grants-h">Grants on file</span>
+        <div v-for="g in grants" :key="g.id" class="dc-gr" :class="{ off: !g.active }">
+          <b class="dc-gr-agent">{{ g.agent }}</b>
+          <span class="dc-gr-scope">{{ g.scopeSummary || g.scope }}</span>
+          <span class="dc-gr-badge" :class="g.holderBound ? 'bound' : 'unbound'">
+            {{ g.holderBound ? '🔑 holder-bound' : '⚠ authenticates nobody' }}
+          </span>
+          <span class="dc-gr-state">{{ g.active ? 'active' : 'inactive' }}</span>
+        </div>
+        <p v-if="grants.some((g) => !g.holderBound)" class="dc-gr-note">
+          A grant marked <b>authenticates nobody</b> was issued before grants bound a holder. It still
+          reads as active, but every read through it is refused — it has to be re-issued to be usable.
+        </p>
+      </div>
+      <p v-else class="dc-auth-fine">
+        No consent grant on file — the patient has not authorized clinician access.
+      </p>
+    </section>
+
+    <!-- consent membrane: the credential this chart reads through — scope, receipt, and what's withheld -->
+    <section v-else class="dc-gate">
       <div class="dc-gate-row">
-        <span class="dc-gate-h">Consent grant</span>
-        <select v-model="grantId" class="dc-gate-sel" @change="load()">
-          <option v-for="g in grants" :key="g.id" :value="g.id">{{ g.agent }} — {{ g.scope }}{{ g.active ? '' : ' (inactive)' }}</option>
-        </select>
+        <span class="dc-gate-h">Reading through</span>
+        <span class="dc-gate-scope">{{ heldGrant?.agent || grantMeta?.agent || holderGrantId }}</span>
         <template v-if="grantMeta">
           <span class="dc-gate-scope">{{ grantMeta.scopeSummary }}</span>
           <span class="dc-gate-sub">expires {{ grantMeta.expires_at.slice(0, 10) }} · read #{{ grantMeta.reads }} · receipt {{ readReceipt }}</span>
         </template>
+        <button class="dc-gate-forget" @click="forgetToken">Forget token</button>
       </div>
+      <p class="dc-gate-fine">
+        Holder-authenticated — this proves possession of the grant's secret. It does not verify an
+        identity, an organisation or a clinical licence; there is no identity provider behind it.
+      </p>
       <p v-if="withheld?.total" class="dc-withheld">
         ⛉ {{ withheld.total }} record(s) withheld by the patient's consent scope <span class="dc-gate-sub">({{ withheldDetail }})</span>
         — counts only; content stays with the patient. Expanded access is the patient's decision.
@@ -219,9 +333,34 @@ async function submitReading() {
 .dc-gate { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--sunken); padding: 10px var(--sp-4); margin-bottom: var(--sp-3); }
 .dc-gate-row { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
 .dc-gate-h { font-size: 10.5px; text-transform: uppercase; letter-spacing: .06em; color: var(--faint); font-weight: 700; }
-.dc-gate-sel { font: 13px var(--ui); color: var(--ink); background: var(--surface); border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 4px 8px; max-width: 340px; }
 .dc-gate-scope { font-size: 12.5px; font-weight: 600; }
 .dc-gate-sub { font-size: 11.5px; color: var(--muted); }
+.dc-gate-fine { font-size: 11px; color: var(--faint); margin: 6px 0 0; }
+.dc-gate-forget { margin-left: auto; font: 11.5px var(--ui); color: var(--muted); background: var(--surface); border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 3px 10px; cursor: pointer; }
+.dc-gate-forget:hover { color: var(--fail); border-color: color-mix(in srgb, var(--fail) 40%, var(--hairline)); }
+/* the recoverable "enter your token" state — a credential prompt, not a failure toast */
+.dc-auth { border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--hairline)); border-radius: var(--r-3); background: var(--sunken); padding: var(--sp-3) var(--sp-4); margin-bottom: var(--sp-3); max-width: 680px; }
+.dc-auth.refused { border-color: color-mix(in srgb, var(--fail) 40%, var(--hairline)); background: color-mix(in srgb, var(--fail) 5%, var(--surface)); }
+.dc-auth-h { display: block; font-size: 14px; margin-bottom: 6px; }
+.dc-auth.refused .dc-auth-h { color: var(--fail); }
+.dc-auth-why { font-size: 12.5px; color: var(--fail); margin: 0 0 8px; }
+.dc-auth-lead { font-size: 13px; color: var(--ink-2); margin: 0 0 10px; }
+.dc-auth-form { display: flex; gap: 8px; flex-wrap: wrap; }
+.dc-auth-in { flex: 1; min-width: 220px; min-height: 40px; border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 0 12px; font: inherit; font-size: 14px; background: var(--surface); color: var(--ink); }
+.dc-auth-in:focus { outline: 0; border-color: var(--accent); }
+.dc-auth-go { min-height: 40px; padding: 0 18px; background: var(--accent); color: #04122e; border: 0; border-radius: var(--r-2); font: inherit; font-weight: 600; cursor: pointer; }
+.dc-auth-go:disabled { opacity: .5; cursor: default; }
+.dc-auth-fine { font-size: 11.5px; line-height: 1.5; color: var(--muted); margin: 10px 0 0; }
+.dc-auth-grants { margin-top: var(--sp-3); border-top: 1px solid var(--hairline); padding-top: 10px; }
+.dc-auth-grants-h { font-size: 10.5px; text-transform: uppercase; letter-spacing: .06em; color: var(--faint); font-weight: 700; }
+.dc-gr { display: flex; align-items: baseline; flex-wrap: wrap; gap: 8px; padding: 6px 0; border-top: 1px solid var(--hairline); font-size: 12.5px; }
+.dc-gr:first-of-type { border-top: 0; } .dc-gr.off { opacity: .6; }
+.dc-gr-agent { font-weight: 600; } .dc-gr-scope { color: var(--muted); font-size: 11.5px; }
+.dc-gr-state { margin-left: auto; font-size: 11px; color: var(--faint); }
+.dc-gr-badge { font-size: 10.5px; border-radius: var(--pill); padding: 1px 9px; border: 1px solid var(--hairline); }
+.dc-gr-badge.bound { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 40%, var(--hairline)); background: color-mix(in srgb, var(--ok) 8%, transparent); }
+.dc-gr-badge.unbound { color: var(--warn); border-color: color-mix(in srgb, var(--warn) 45%, var(--hairline)); background: var(--warn-wash); }
+.dc-gr-note { font-size: 11.5px; line-height: 1.5; color: var(--warn); margin: 8px 0 0; }
 .dc-withheld { font-size: 12.5px; color: var(--warn); margin: 8px 0 0; }
 .dc-blocked { border: 1px solid color-mix(in srgb, var(--fail) 40%, var(--hairline)); border-radius: var(--r-3); background: color-mix(in srgb, var(--fail) 7%, var(--surface)); padding: var(--sp-3) var(--sp-4); margin-bottom: var(--sp-3); display: flex; flex-direction: column; gap: 4px; }
 .dc-blocked b { color: var(--fail); } .dc-blocked span { font-size: 14px; } .dc-blocked p { margin: 2px 0 0; font-size: 12.5px; color: var(--muted); }

--- a/apps/socioprophet-web/src/pages/HealthTwin.vue
+++ b/apps/socioprophet-web/src/pages/HealthTwin.vue
@@ -9,7 +9,8 @@
 // Guardrails, enforced in the UI: opt-in gate before anything renders · non-diagnostic framing ·
 // nothing shared without an explicit grant · every access receipted.
 import { ref, computed, onMounted, watch, onBeforeUnmount } from 'vue';
-import { loadTwin, grantAccess, revokeAccess, agentRead, listConnectors, ingestConnector, reconcile, serviceHealth, type TwinBundle, type SystemBundle, type Observation, type Condition, type ConnectorMeta, type IngestSummary, type ServiceHealth, type ReconcileReport } from '../services/healthTwinApi';
+import { loadTwin, grantAccess, revokeAccess, agentRead, listGrants, listConnectors, ingestConnector, reconcile, serviceHealth, HolderAuthError, type TwinBundle, type SystemBundle, type Observation, type Condition, type ConnectorMeta, type IngestSummary, type ServiceHealth, type ReconcileReport } from '../services/healthTwinApi';
+import { setHolderToken, clearHolderToken, holderGrantId } from '../services/healthHolderToken';
 import { EPISTEMIC_COLORS } from '../services/studioApi';
 import Sparkline from '../components/Sparkline.vue';
 import SpineOverlay from './SpineOverlay.vue';
@@ -33,6 +34,12 @@ const view = ref<'systems' | 'spine' | 'sources' | 'consults' | 'ask' | 'capture
 const flash = ref('');
 function say(m: string) { flash.value = m; setTimeout(() => (flash.value = ''), 2800); }
 
+// Whether each grant can authenticate anyone. `/api/health/twin` does not carry it (that shape
+// deliberately strips the holder verifier), so it is merged in from the grants endpoint, which does.
+// undefined = we could not find out — reported as "unknown" rather than guessed either way.
+const holderBound = ref<Record<string, boolean>>({});
+const anyUnbound = computed(() => (twin.value?.grants ?? []).some((g) => holderBound.value[g.id] === false));
+
 async function load() {
   loading.value = true; err.value = '';
   try {
@@ -40,6 +47,9 @@ async function load() {
     if (!twin.value.systems.some((s) => s.id === selected.value)) selected.value = twin.value.systems[0]?.id ?? '';
   } catch (e) { err.value = e instanceof Error ? e.message : 'failed to load health twin'; }
   finally { loading.value = false; }
+  try {
+    holderBound.value = Object.fromEntries((await listGrants()).grants.map((g) => [g.id, g.holderBound]));
+  } catch { holderBound.value = {}; /* unknown beats a guess */ }
 }
 onMounted(() => { if (optedIn.value) load(); });
 
@@ -135,17 +145,61 @@ function onSheetKey(e: KeyboardEvent) { if (e.key === 'Escape') sheet.value = nu
 watch(sheet, (s) => { if (s) document.addEventListener('keydown', onSheetKey); else document.removeEventListener('keydown', onSheetKey); });
 onBeforeUnmount(() => document.removeEventListener('keydown', onSheetKey));
 
-// governed sharing
+// ── governed sharing ────────────────────────────────────────────────────────────────────────────
+// Issuing a grant now mints a HOLDER SECRET, returned exactly once. Only its sha256 digest is kept,
+// so this screen is the only moment the token exists outside the holder: it is shown here to be
+// handed to the clinician, and it is never written anywhere by this app.
 const ng = ref<{ agent: string; scope: string; ttl: number }>({ agent: '', scope: '', ttl: 30 });
+/** The freshly-minted token, held in component state ONLY until dismissed. Never persisted. */
+const issued = ref<{ agent: string; token: string; note: string } | null>(null);
+const copied = ref(false);
+
 async function doGrant() {
   if (!ng.value.agent.trim()) return;
-  try { await grantAccess(ng.value.agent.trim(), ng.value.scope.trim() || 'all systems', ng.value.ttl); say('Grant issued — receipted'); ng.value.agent = ''; ng.value.scope = ''; await load(); }
-  catch (e) { say(e instanceof Error ? e.message : 'grant failed'); }
+  const agent = ng.value.agent.trim();
+  try {
+    const r = await grantAccess(agent, ng.value.scope.trim() || 'all systems', ng.value.ttl);
+    ng.value.agent = ''; ng.value.scope = ''; copied.value = false;
+    if (r.holder?.token) {
+      issued.value = { agent, token: r.holder.token, note: r.holder.note };
+      // Also hold it in this session's credential slot, so "exercise this grant" below can
+      // demonstrate the read the clinician would make. Dropped on dismiss, and on refresh.
+      setHolderToken(r.holder.token);
+    }
+    say('Grant issued — receipted. Hand the token over now; it is not recoverable.');
+    await load();
+  } catch (e) { say(e instanceof Error ? e.message : 'grant failed'); }
 }
-async function doRevoke(id: string) { try { await revokeAccess(id); say('Revoked — future reads blocked'); await load(); } catch (e) { say(e instanceof Error ? e.message : 'revoke failed'); } }
+/** Wipe the token from component state. The engine cannot re-show it, and neither can we. */
+function dismissIssued() { issued.value = null; copied.value = false; }
+async function copyIssued() {
+  if (!issued.value) return;
+  try { await navigator.clipboard.writeText(issued.value.token); copied.value = true; }
+  catch { say('Copy failed — select the token and copy it manually.'); }
+}
+
+async function doRevoke(id: string) {
+  try {
+    await revokeAccess(id);
+    if (holderGrantId.value === id) clearHolderToken(); // the credential we hold is now worthless
+    say('Revoked — future reads blocked'); await load();
+  } catch (e) { say(e instanceof Error ? e.message : 'revoke failed'); }
+}
+/**
+ * Exercising a grant needs the grant's own credential, which the PATIENT does not hold — that is the
+ * whole point of holder binding, and the button is disabled rather than quietly failing for any
+ * grant whose token is not the one in this session. No grant id is sent; the credential names it.
+ */
+const canExercise = (id: string) => holderGrantId.value === id;
 async function doAgentRead(id: string) {
-  const r = await agentRead(id);
-  if (r.blocked) say(`🔒 ${r.reason}`); else say(`Agent read ✓ receipt ${r.receipt?.id} (read #${r.reads})`);
+  if (!canExercise(id)) { say('You do not hold this grant’s token — only its holder can exercise it.'); return; }
+  try {
+    const r = await agentRead();
+    if (r.blocked) say(`🔒 ${r.reason}`); else say(`Agent read ✓ receipt ${r.receipt?.id} (read #${r.reads})`);
+  } catch (e) {
+    if (e instanceof HolderAuthError) { clearHolderToken(); say(`🔒 ${e.reason}`); }
+    else say(e instanceof Error ? e.message : 'read failed');
+  }
   await load();
 }
 </script>
@@ -265,17 +319,51 @@ async function doAgentRead(id: string) {
             <div class="sh-ttl"><label>expires in</label><input v-model.number="ng.ttl" type="number" min="1" max="365" class="j ttl" /><span>days</span></div>
             <button class="btn" @click="doGrant" :disabled="!ng.agent.trim()">Grant read</button>
           </div>
+          <!-- the token, shown ONCE: the only moment it exists outside its holder -->
+          <div v-if="issued" class="sh-issued">
+            <b class="iss-h">🔑 Access token for {{ issued.agent }} — shown once</b>
+            <code class="iss-tok">{{ issued.token }}</code>
+            <div class="iss-actions">
+              <button class="mini" @click="copyIssued">{{ copied ? 'copied ✓' : 'copy' }}</button>
+              <button class="mini" @click="dismissIssued">done — hide it</button>
+            </div>
+            <p class="iss-note">{{ issued.note }}</p>
+            <p class="iss-note">
+              Give this to {{ issued.agent }} over a channel you trust. It is not saved here, and it is
+              not recoverable — only its digest is stored, so a lost token means re-issuing the grant.
+            </p>
+          </div>
+
           <div class="grants">
             <div v-for="g in twin.grants" :key="g.id" class="grant" :class="{ revoked: g.revoked, expired: !g.active && !g.revoked }">
-              <div class="g-top"><b>{{ g.agent }}</b><span class="g-state">{{ g.revoked ? 'revoked' : g.active ? 'active' : 'expired' }}</span></div>
+              <div class="g-top">
+                <b>{{ g.agent }}</b>
+                <span class="g-state">{{ g.revoked ? 'revoked' : g.active ? 'active' : 'expired' }}</span>
+              </div>
               <div class="g-scope">{{ g.scope }}</div>
               <div class="g-meta"><span>reads <b class="tnum">{{ g.reads }}</b></span><span class="g-exp">exp {{ g.expires_at.slice(0, 10) }}</span><span class="g-rcpt mono">{{ g.receipt }}</span></div>
+              <!-- can this grant authenticate anyone at all? -->
+              <div class="g-bound" :class="holderBound[g.id] === false ? 'unbound' : holderBound[g.id] ? 'bound' : 'unknown'">
+                <template v-if="holderBound[g.id]">🔑 holder-bound — only whoever holds its token can read</template>
+                <template v-else-if="holderBound[g.id] === false">⚠ authenticates nobody — issued before tokens; every read is refused until re-issued</template>
+                <template v-else>· holder binding unknown — the grants list did not answer</template>
+              </div>
               <div class="g-actions">
-                <button class="mini" @click="doAgentRead(g.id)">simulate agent read</button>
+                <button class="mini" :disabled="!canExercise(g.id)"
+                  :title="canExercise(g.id) ? 'Read as the holder, using the token issued in this session' : 'You do not hold this grant’s token — only its holder can exercise it'"
+                  @click="doAgentRead(g.id)">exercise this grant</button>
                 <button v-if="!g.revoked" class="mini danger" @click="doRevoke(g.id)">revoke</button>
               </div>
             </div>
             <p v-if="!twin.grants.length" class="sh-empty">No grants — your records are private.</p>
+            <p v-if="anyUnbound" class="sh-warn">
+              A grant that <b>authenticates nobody</b> predates holder binding. It reads as active but
+              cannot be used — revoke it and issue a new one to replace it.
+            </p>
+            <p class="sh-fine">
+              “Exercise” is enabled only for a grant whose token was issued in this session. You are the
+              patient — you do not hold a clinician's token, and that is the protection working.
+            </p>
           </div>
         </aside>
       </div>
@@ -477,7 +565,19 @@ async function doAgentRead(id: string) {
 .g-meta { display: flex; gap: 8px; font-size: 10px; color: var(--muted); align-items: center; flex-wrap: wrap; } .g-rcpt { color: var(--faint); } .mono { font-family: var(--mono); }
 .g-actions { display: flex; gap: 5px; margin-top: 5px; }
 .mini { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); padding: 2px 8px; font-size: 11px; cursor: pointer; } .mini.danger { border-color: var(--fail); color: var(--fail); }
+.mini:disabled { opacity: .45; cursor: default; }
 .sh-empty { font-size: 11.5px; color: var(--faint); }
+/* can this grant authenticate anyone — the difference between a capability and a credential */
+.g-bound { font-size: 10px; line-height: 1.45; margin-top: 4px; }
+.g-bound.bound { color: var(--ok); } .g-bound.unbound { color: var(--warn); } .g-bound.unknown { color: var(--faint); }
+.sh-warn { font-size: 11px; line-height: 1.5; color: var(--warn); margin: 6px 0 0; }
+.sh-fine { font-size: 10.5px; line-height: 1.5; color: var(--faint); margin: 6px 0 0; }
+/* the minted token, shown once */
+.sh-issued { border: 1px solid color-mix(in srgb, var(--ok) 45%, var(--hairline)); background: color-mix(in srgb, var(--ok) 7%, var(--surface)); border-radius: var(--r-2); padding: 9px 10px; margin-bottom: 8px; }
+.iss-h { display: block; font-size: 12px; color: var(--ok); margin-bottom: 6px; }
+.iss-tok { display: block; font-family: var(--mono); font-size: 11px; word-break: break-all; user-select: all; background: var(--sunken); border: 1px solid var(--hairline); border-radius: var(--r-1); padding: 6px 8px; color: var(--ink); }
+.iss-actions { display: flex; gap: 5px; margin-top: 6px; }
+.iss-note { font-size: 10.5px; line-height: 1.5; color: var(--muted); margin: 6px 0 0; }
 
 /* factsheet content */
 .fs-top { margin-bottom: var(--sp-3); }

--- a/apps/socioprophet-web/src/services/healthHolderToken.ts
+++ b/apps/socioprophet-web/src/services/healthHolderToken.ts
@@ -1,0 +1,84 @@
+// The grant HOLDER CREDENTIAL — `<grant-id>.<secret>` — and the only place this app is allowed to
+// keep one: a module-scoped ref, i.e. the JavaScript heap of this tab, for as long as this tab lives.
+//
+// WHY THE CREDENTIAL EXISTS AT ALL. A grant id used to be the whole credential, presented as
+// `?grant=<id>`. Possession was authorization, and the channel wrote the id into access logs, proxy
+// logs, browser history and the `Referer` of every outbound link. The engine now binds each grant to
+// a 256-bit secret minted at issue time, stores only its sha256 digest, and reads it from the
+// `x-health-grant` request header. See apps/health-twin/src/grantauth.ts.
+//
+// WHY NOT localStorage / sessionStorage / a cookie — the three obvious places, all refused:
+//   • localStorage survives the browser being closed, so the credential outlives the clinician's
+//     shift and stays on a shared bedside iPad for the next person who opens the cockpit. It is also
+//     readable by any script that ever runs on this origin, which turns one XSS into a chart.
+//   • sessionStorage is narrower (per tab, cleared on close) but has the same XSS reachability and
+//     still survives a reload — so "I walked away and the tab was still open" still reads the chart.
+//   • a cookie is worse than both: it is attached to requests automatically, which is precisely the
+//     ambient-authority property that made the query-string form dangerous, and it would ride along
+//     on requests this app never intended to authenticate.
+// The heap is not immune to XSS either — nothing in a browser is — but it is the smallest window we
+// can offer: no persistence, no automatic attachment, and gone the moment the tab goes.
+//
+// WHY LOSING IT ON REFRESH IS CORRECT. A credential that survives a refresh is a credential left
+// behind on a shared machine. Re-entry is a two-second cost paid by the clinician; persistence is an
+// open chart paid for by the patient. The UI says so in as many words rather than treating it as a
+// papercut to engineer around.
+//
+// A browser also cannot safely hold a long-lived per-grant secret that WE choose — which is why
+// there is no build-time token here, no `VITE_HEALTH_GRANT_TOKEN`, and nothing to commit. The secret
+// is the clinician's, supplied per session. apps/health-twin/src/exposure.ts is the standing refusal
+// of the alternative.
+import { computed, ref } from 'vue';
+
+/** The header the engine reads the credential from (grantauth.ts: HOLDER_HEADER). */
+export const HOLDER_HEADER = 'x-health-grant';
+
+/**
+ * Module scope, deliberately: it outlives any single component (the doctor chart is a tab that
+ * unmounts every time the clinician looks at something else) and dies with the tab. Not exported —
+ * `holderHeader()` is the only reader, so there is exactly one call site to audit.
+ */
+const token = ref('');
+
+/** Whether a credential is held for this session. */
+export const hasHolderToken = computed(() => token.value.length > 0);
+
+/**
+ * The grant-id half of the held token: everything before the LAST dot, mirroring the server's
+ * `parseHolderToken()` (ids carry dashes and hex, secrets are base64url — neither contains a dot).
+ * The id is not the secret; it is safe to render, and naming the grant being read is the whole point
+ * of showing it. The half after the dot is never returned by anything in this module.
+ */
+export const holderGrantId = computed(() => {
+  const i = token.value.lastIndexOf('.');
+  return i > 0 ? token.value.slice(0, i) : '';
+});
+
+/**
+ * Accept a pasted credential. Shape-checks it the same way the server does, so an obviously wrong
+ * paste (a bare grant id, most likely) is caught here instead of being spent as a failed
+ * authentication attempt against the engine.
+ *
+ * @returns false when the input is not `<id>.<secret>`; the held token is left untouched.
+ */
+export function setHolderToken(raw: string): boolean {
+  const t = (raw ?? '').trim();
+  const i = t.lastIndexOf('.');
+  if (i <= 0 || i === t.length - 1) return false;
+  token.value = t;
+  return true;
+}
+
+/** Drop the credential. Called on sign-off, on a refusal, and by the explicit "forget" control. */
+export function clearHolderToken(): void {
+  token.value = '';
+}
+
+/**
+ * The ONE reader. Returns the header to merge into a fetch, or null when nothing is held — callers
+ * that get null must not make the request at all, rather than sending an unauthenticated one that
+ * would 401 and write a failed read into the engine's receipt trail for no reason.
+ */
+export function holderHeader(): Record<string, string> | null {
+  return token.value ? { [HOLDER_HEADER]: token.value } : null;
+}

--- a/apps/socioprophet-web/src/services/healthTwinApi.ts
+++ b/apps/socioprophet-web/src/services/healthTwinApi.ts
@@ -4,8 +4,80 @@
 // revocable read grant, and every access is a receipt or a block. In production the engine runs
 // LOCAL-FIRST on the person's own node; this skeleton reads a synthetic subject. Non-diagnostic.
 import { resolveBase } from '../config/cockpitRuntime';
+import { HOLDER_HEADER, holderHeader } from './healthHolderToken';
 
 const BASE = resolveBase('health', 'VITE_HEALTH_BASE', '/svc/health');
+
+// ── reading THROUGH a consent grant: the holder credential ─────────────────────────────────────
+// A grant id is no longer a credential. Every route that reads through a grant wants
+// `x-health-grant: <grant-id>.<secret>`; the `?grant=<id>` form is refused with 401 by default
+// because a query string is written to access logs, proxy logs, browser history and `Referer`.
+// It is NOT kept here as a fallback — a fallback becomes the path of least resistance, and the leak
+// it causes is silent. (`HEALTH_TWIN_LEGACY_GRANT_QUERY=1` exists server-side for synthetic-only
+// deployments, warns on every use and refuses to boot in an authenticated one. It is a migration
+// escape hatch, not something this cockpit is allowed to depend on.)
+// The credential itself lives in healthHolderToken.ts — in memory, never persisted.
+
+/**
+ * What an authenticated read says about the authentication behind it (grantauth.ts:
+ * HOLDER_AUTH_DISCLOSURE). Note `identityVerified: false` — this proves possession of a secret, not
+ * that anyone is a clinician.
+ */
+export interface HolderAuthDisclosure {
+  mechanism: string; binds: string; verifier?: string;
+  identityVerified: boolean; channel: string; deprecated?: boolean;
+}
+
+/**
+ * A 401 from the consent membrane — the CREDENTIAL failed, not the chart. Distinct from a generic
+ * Error precisely so the UI can offer "enter your token" instead of a failure toast: one is
+ * recoverable by the person looking at the screen, the other is not.
+ *
+ * `missing: true` = we never held one, so nothing was sent — no request, no failed read in the
+ * engine's receipt trail. `missing: false` = the engine refused what we presented.
+ *
+ * Nothing derived from the token is ever put in this error. The server's `reason`/`detail` are fixed
+ * strings that never echo the presented value, and its single uniform failure reason is deliberate:
+ * a caller who has just failed to authenticate must not be able to use the response as an oracle for
+ * which grant ids exist.
+ */
+export class HolderAuthError extends Error {
+  readonly status = 401;
+  constructor(readonly reason: string, readonly missing: boolean, readonly detail?: string) {
+    super(reason);
+    this.name = 'HolderAuthError';
+  }
+}
+
+/**
+ * Headers for a read that REQUIRES the grant credential. Throws before touching the network when
+ * nothing is held, so "no token" costs zero unauthenticated requests.
+ */
+function holderHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  const h = holderHeader();
+  if (!h) {
+    throw new HolderAuthError(
+      'grant holder credential required', true,
+      `present the grant as \`${HOLDER_HEADER}: <grant-id>.<secret>\` — the id on its own is not a credential`,
+    );
+  }
+  return { ...extra, ...h };
+}
+
+/** Turn a 401 body into the recoverable error. Shared, so every grant-scoped route refuses alike. */
+function refusal(payload: unknown): HolderAuthError {
+  const b = (payload ?? {}) as { reason?: unknown; detail?: unknown };
+  return new HolderAuthError(
+    typeof b.reason === 'string' ? b.reason : 'grant holder authentication failed',
+    false,
+    typeof b.detail === 'string' ? b.detail : undefined,
+  );
+}
+
+/** Parse defensively: a proxy can answer a 401 with html, and `.json()` would throw over the refusal. */
+async function readBody(res: Response): Promise<any> {
+  return await res.json().catch(() => ({}));
+}
 
 export type EpistemicMode = 'observed' | 'derived' | 'verified' | 'attested' | 'hypothesis';
 // organ = the anatomical structure a record localises to (health:localizedTo); classIri/organIri = the
@@ -38,35 +110,63 @@ export async function addReading(text: string, by = 'clinician', source = 'keybo
   return await res.json();
 }
 // evidence grounded ON the twin — contextual (patient-specific query) + evidentiary (bound to a record).
-// Pass a grant id and the engine scopes evidence SERVER-SIDE to records inside the grant, so withheld
-// findings can't leak to a clinician through the evidence side door.
+// Present the grant credential and the engine scopes evidence SERVER-SIDE to records inside the
+// grant, so withheld findings can't leak to a clinician through the evidence side door.
 export interface TwinEvidence { recordId: string; finding: string; query: string; evidence: string; citations: { source: string; tier: string }[]; retrieval: string }
-export async function groundEvidence(grant?: string): Promise<{ context: string; items: TwinEvidence[] }> {
-  const q = grant ? `?grant=${encodeURIComponent(grant)}` : '';
-  const res = await fetch(`${BASE}/api/health/evidence${q}`, { headers: { accept: 'application/json' } });
+/**
+ * Requires the holder credential even though the ENGINE treats the grant as optional here (no grant
+ * offered = evidence is not narrowed at all). That default is right for the engine and wrong for a
+ * clinician surface: an unauthenticated call would quietly return evidence over records the consent
+ * scope withholds, which is the side door this scoping exists to close. So the chart either reads
+ * evidence through the grant or does not read it.
+ */
+export async function groundEvidence(): Promise<{ context: string; items: TwinEvidence[]; authentication?: HolderAuthDisclosure }> {
+  const res = await fetch(`${BASE}/api/health/evidence`, { headers: holderHeaders({ accept: 'application/json' }) });
+  const b = await readBody(res);
+  if (res.status === 401) throw refusal(b);
   if (!res.ok) throw new Error(`evidence failed (${res.status})`);
-  return await res.json();
+  return b;
 }
 
 // ── grant-scoped clinician access: the doctor chart reads THROUGH a consent grant ─────────────────
 // The engine returns exactly the granted slice plus withheld COUNTS (never content); revoked/expired
 // grants return an explicit receipted block. Every read increments the grant's receipt trail.
-export interface GrantSummary { id: string; agent: string; scope: string; scopeSummary: string; active: boolean; expires_at: string; reads: number }
-export async function listGrants(): Promise<{ grants: GrantSummary[]; presets: Record<string, string> }> {
+/**
+ * `holderBound` = this grant carries a holder digest, so it can authenticate someone. A grant issued
+ * before holder binding existed is `false`: it still looks active and unexpired, but it authenticates
+ * nobody and every read through it is refused. Rendering the two identically would mean showing an
+ * "active" grant that cannot be used, and leaving the patient to discover it from a clinician's
+ * failed login — so the UI has to tell them apart.
+ */
+export interface GrantSummary { id: string; agent: string; scope: string; scopeSummary: string; active: boolean; holderBound: boolean; expires_at: string; reads: number }
+/** Unauthenticated by design: this is the patient's control panel, not a credential store. */
+export async function listGrants(): Promise<{ grants: GrantSummary[]; presets: Record<string, string>; authentication?: HolderAuthDisclosure }> {
   const res = await fetch(`${BASE}/api/health/grants`, { headers: { accept: 'application/json' } });
   if (!res.ok) throw new Error(`grants unreachable (${res.status})`);
   return await res.json();
 }
 export type WithheldCounts = { total: number } & Partial<Record<'observations' | 'conditions' | 'encounters' | 'imaging' | 'medications' | 'allergies' | 'immunizations' | 'readings', number>>;
 export interface DoctorView {
-  blocked?: boolean; reason?: string;
+  blocked?: boolean; reason?: string; authenticated?: boolean;
   grant?: { id: string; agent: string; scope: string; scopeSummary: string; expires_at: string; reads: number };
   view?: Omit<TwinBundle, 'grants'>; withheld?: WithheldCounts;
+  authentication?: HolderAuthDisclosure;
   receipt?: { id: string };
 }
-export async function doctorView(grantId: string): Promise<DoctorView> {
-  const res = await fetch(`${BASE}/api/health/doctor-view?grant=${encodeURIComponent(grantId)}`, { headers: { accept: 'application/json' } });
-  return await res.json(); // a 403 carries the { blocked, reason, receipt } shape — the block IS the answer
+/**
+ * No grant-id argument any more, and that is the point rather than a tidy-up: WHICH grant is read is
+ * now decided by the credential presented, not by a parameter the caller picks. Asking for a grant
+ * you cannot authenticate is not a thing that can be expressed.
+ *
+ * A 401 throws (the credential is wrong — recoverable by entering the right one). A 403 returns
+ * normally carrying `{ blocked, reason, receipt }`: the grant is revoked or expired, the holder is
+ * proven, and the block IS the answer.
+ */
+export async function doctorView(): Promise<DoctorView> {
+  const res = await fetch(`${BASE}/api/health/doctor-view`, { headers: holderHeaders({ accept: 'application/json' }) });
+  const b = await readBody(res);
+  if (res.status === 401) throw refusal(b);
+  return b;
 }
 
 export async function loadTwin(): Promise<TwinBundle> {
@@ -74,19 +174,50 @@ export async function loadTwin(): Promise<TwinBundle> {
   if (!res.ok) throw new Error(`health twin unreachable (${res.status})`);
   return (await res.json()) as TwinBundle;
 }
-export async function grantAccess(agent: string, scope: string, ttlDays: number): Promise<{ grant: Grant }> {
+/**
+ * Issuing a grant now mints a holder secret, and `holder.token` is the ONE time it exists outside
+ * the holder — only its sha256 digest is stored, so lost means re-issue, never look up. The caller
+ * has to hand it to the clinician there and then; nothing in this app writes it down.
+ */
+export interface IssuedGrant {
+  grant: Grant & { scopeSummary?: string };
+  holder: { token: string; shownOnce: boolean; present: string; note: string };
+  authentication?: HolderAuthDisclosure;
+  grantorAuth?: { authenticatedAs: string | null; isThePatient: boolean; note: string };
+  receipt?: { id: string };
+}
+export async function grantAccess(agent: string, scope: string, ttlDays: number): Promise<IssuedGrant> {
   const res = await fetch(`${BASE}/api/health/grant`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ agent, scope, ttlDays }) });
   if (!res.ok) throw new Error(`grant failed (${res.status})`);
   return await res.json();
 }
+/**
+ * Still id-only, and deliberately NOT converted to the holder credential. Revocation is the patient
+ * shutting a door on someone else's grant, and the patient does not hold the clinician's secret —
+ * requiring it here would mean only the person being revoked could revoke themselves. Slamming the
+ * door must never be harder than opening it. (Server-side reasoning: server.ts, /api/health/revoke.)
+ */
 export async function revokeAccess(grant: string): Promise<unknown> {
   const res = await fetch(`${BASE}/api/health/revoke`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ grant }) });
   if (!res.ok) throw new Error(`revoke failed (${res.status})`);
   return await res.json();
 }
-export async function agentRead(grant: string): Promise<{ blocked?: boolean; reason?: string; reads?: number; receipt?: { id: string } }> {
-  const res = await fetch(`${BASE}/api/health/agent-read`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ grant }) });
-  return await res.json();
+/**
+ * Exercising a grant, on the holder credential — the id is NOT sent in the body. It used to be, and
+ * a bare id in a JSON body is the same bearer capability as one in a query string, just on a channel
+ * that happens not to be logged; the engine refuses it for that reason. The grant being exercised is
+ * whichever one the presented credential authenticates.
+ */
+export interface AgentRead {
+  agent?: string; scope?: string; reads?: number;
+  blocked?: boolean; reason?: string; authenticated?: boolean;
+  authentication?: HolderAuthDisclosure; receipt?: { id: string };
+}
+export async function agentRead(): Promise<AgentRead> {
+  const res = await fetch(`${BASE}/api/health/agent-read`, { method: 'POST', headers: holderHeaders({ 'content-type': 'application/json' }), body: '{}' });
+  const b = await readBody(res);
+  if (res.status === 401) throw refusal(b);
+  return b;
 }
 
 // ── ingestion + reconciliation surface (the connector plane + the estate services it orchestrates) ──


### PR DESCRIPTION
Client half of **prophet-platform#1081 / prophet-health#8**. Those PRs made the engine stop accepting a grant id as a credential; this makes the cockpit stop sending one.

## What was broken

`apps/socioprophet-web/src/services/healthTwinApi.ts` called the old way on three routes, all of which now 401:

| call | old form |
|---|---|
| `doctorView(grantId)` | `GET /api/health/doctor-view?grant=<id>` |
| `groundEvidence(grant)` | `GET /api/health/evidence?grant=<id>` |
| `agentRead(grant)` | `POST /api/health/agent-read` with the bare id in the JSON body |

A query string is written to access logs, proxy logs, browser history and `Referer`. A bare id in a JSON body is the same bearer capability on a channel that merely happens not to be logged. The engine refuses both.

## Which surface — resolved before writing code

The brief flagged the standing "client-vue is canonical" rule. **That rule was inverted on 2026-07-20 and does not apply here**, and independently the question is moot:

- `client-vue` lives in a **different repo** (`~/dev/socioprophet/socioprophet-web/client-vue`), is **not deployed**, and is on the BearBrowser sovereign-local lane.
- It contains **zero** health-twin code — no `DoctorChart`, no `healthTwinApi`, no `doctor-view`, no `grant` handling. Nothing to fix.
- `apps/socioprophet-web` is the ArgoCD-deployed cockpit (`deploy/argocd/`, `infra/k8s/argo-cd/appsets/`) and holds the only doctor-chart surface. It is **Vue**, so the "Vue not React" requirement is already satisfied.

Fixed **one** surface because only one exists. I did not touch the other shell.

Within `apps/socioprophet-web` there were **two** affected pages, not the one handed over: `DoctorChart.vue` (clinician: doctor-view + evidence) and `HealthTwin.vue` (patient: mint + agent-read).

## The design

**No secret is shipped and none is committed.** A browser cannot safely hold a long-lived per-grant secret — there is no build-time token, no `VITE_*` var, nothing in source. The clinician supplies the token per session.

**Where it lives:** a module-scoped `ref` in the new `src/services/healthHolderToken.ts` — the JS heap of the tab. Not `localStorage` (survives the browser closing, so the credential outlives the shift on a shared bedside iPad, and one XSS becomes a chart), not `sessionStorage` (same XSS reach, still survives a reload), not a cookie (attached automatically — the ambient authority that made the query form dangerous in the first place). The token is not exported; `holderHeader()` is the only reader, so there is exactly one call site to audit. `holderGrantId` exposes only the id half.

**Losing it on refresh is correct**, and the UI says so in as many words rather than engineering around it.

**`?grant=` is removed outright**, not kept as a fallback — a fallback becomes the path of least resistance and the leak it causes is silent. `doctorView()` and `agentRead()` also **lose their grant-id argument**: which grant is read is now decided by the credential presented, so asking for a grant you cannot authenticate is no longer expressible.

**401 is distinct.** New `HolderAuthError` separates "your credential failed" (recoverable — enter another) from a generic failure. A **403 stays the existing receipted block**, because a 403 means the holder *is* proven and the grant is revoked or expired. Nothing token-derived ever enters an error, a URL, a log or a telemetry payload; there are no `console.*` calls in the token path at all.

**`holderBound` is surfaced on both surfaces.** A grant issued before holder binding reads as active but authenticates nobody and refuses every read. The clinician view badges it `authenticates nobody` vs `holder-bound`; the patient panel says it in full and prompts a re-issue. Where the grants list cannot be reached it renders "unknown" rather than guessing either way.

**Patient side:** `holder.token` is shown once at issue, labelled unrecoverable, copyable, and wiped on dismiss. "Exercise this grant" is **disabled** unless this session holds that grant's token — the patient does not hold a clinician's secret, and that is the protection working rather than a bug to route around. Revocation stays id-only, matching the server's reasoning (slamming the door must never be harder than opening it).

`HEALTH_TWIN_LEGACY_GRANT_QUERY=1` is **not** depended on anywhere.

## Proof

12 new tests in `healthHolderAuth.test.ts` + `healthGrantIssue.test.ts`, mounting the real components against a mocked engine that reproduces the 401 rule:

1. **No token** -> empty state renders; the *only* request is the unauthenticated grants list. No doctor-view, no evidence. Zero 401s in the logs.
2. **Valid token** -> doctor-view, evidence and agent-read all succeed, all three carrying `x-health-grant`; no request URL contains `grant=`.
3. **Bad token** -> 401 renders as the recoverable enter-token state (not a crash, not a generic toast, not a blank chart), the refused credential is dropped, and entering a good one from that same state opens the chart. A bare id is rejected client-side without spending a failed authentication.
4. Credential never reaches `localStorage` / `sessionStorage` / `document.cookie`, and is not left in the DOM input.
5. `holderBound` renders as a genuinely different badge.

**Each load-bearing assertion was verified to FAIL against a deliberately broken build** — restoring `?grant=` fails proof 2; defeating the pre-flight guard so an unauthenticated request goes out fails proof 1; making `canExercise` always true fails the gating test.

**Built output grepped:** `0` occurrences of `grant=`, `0` secret literals, `1` occurrence of `x-health-grant` (positive control — the header path did ship).

`vue-tsc --noEmit` clean · `vite build` clean · suite **595 passed** (was 583; +12 mine). The **5 pre-existing failures** (AlgoTradingBoard, NlpExtractionBench, NewsFeed x2, OperatorDashboard) were confirmed identical on a clean `origin/main` with this work stashed — untouched by and unrelated to this change.

## Honest deviations

- **`groundEvidence()` now requires the credential**, though the engine treats the grant as optional there (no grant = no narrowing). That default is right for the engine and wrong for a clinician surface: an unauthenticated call would quietly return evidence over records the consent scope withholds — the exact side door the scoping exists to close.
- **`holderBound` is merged client-side on the patient panel.** `/api/health/twin` deliberately strips the holder verifier and does not carry `holderBound`; only `/api/health/grants` does. Rather than edit `apps/health-twin/**` (another lane is live there), `HealthTwin.vue` joins the two by id and renders "unknown" if the grants call fails. A one-line server-side addition of `holderBound` to `publicGrant()` would remove the extra fetch — worth doing in the engine lane.
- **Evidence failures after a successful doctor-view are still swallowed**, as before. The chart is already rendering under a proven credential; blanking it because a secondary annotation read failed is a worse answer than showing it unannotated.
- Not exercised against a live engine — no health-twin instance was running. The 401/403 contract is reproduced from `grantauth.ts` and `authorizeGrant()` in the #1081 branch, which is **open, not merged**; if that contract shifts before it lands, the mocked rule in these tests is the thing to re-check.
