### PR TITLE
fix(shape-c): assertions that evaporate under -O, and one enforcement key that fails open

### DIFF
--- a/tools/check_fogstack_registry_root_metadata.py
+++ b/tools/check_fogstack_registry_root_metadata.py
@@ -51,7 +51,22 @@ def main() -> int:
 
     ref = root.get("revocation_index_ref")
     expected = root.get("revocation_index_digest")
-    if isinstance(ref, str):
+    # `revocation_index_ref` is optional (schema: ["string", "null"], not in
+    # `required`), so absent/null legitimately skips. Anything ELSE must fail,
+    # not skip. This tool never applies the JSON schema -- it is hand-rolled --
+    # so nothing else rejects a mistyped ref. Under the previous
+    # `if isinstance(ref, str)` a numeric, list or object ref fell straight
+    # through: existence AND digest verification of the revocation index were
+    # both skipped and the tool printed "FogStack registry root metadata
+    # passed." One mistyped key silently switched off revocation checking.
+    # The releases loop above already fails closed on a non-string ref; this
+    # branch was the odd one out.
+    if ref is not None and not isinstance(ref, str):
+        errors.append(
+            f"revocation_index_ref must be a string or null, got {type(ref).__name__} "
+            f"({ref!r}) -- a mistyped ref skips revocation-index verification entirely"
+        )
+    elif isinstance(ref, str):
         if not Path(ref).exists():
             errors.append(f"missing index: {ref}")
         elif sha256_file(Path(ref)) != expected:

--- a/tools/smoke_regis_acr_service.py
+++ b/tools/smoke_regis_acr_service.py
@@ -25,25 +25,44 @@ except Exception as exc:  # pragma: no cover
     sys.exit(2)
 
 
+class SmokeFailure(RuntimeError):
+    """A Regis ACR service smoke obligation failed."""
+
+
+def require(condition: object, context: object) -> None:
+    """Smoke check that survives `python -O`.
+
+    All 30 checks in this tool were bare `assert`. `python -O` strips every one
+    of them, so main() walked the whole service path -- health, ingest,
+    proposal, promotion margin, relationship hook -- inspected none of the
+    responses, and still returned 0. It would have reported a clean smoke run
+    against a service answering 500s, or one that had quietly started
+    performing canonical mutations (`canonical_mutation: true`), which is the
+    exact safety posture these checks exist to hold.
+    """
+    if not condition:
+        raise SmokeFailure(str(context)[:2000])
+
+
 def assert_receipt(payload: Dict[str, Any], action: str) -> None:
     receipt = payload.get("receipt")
-    assert isinstance(receipt, dict), payload
-    assert receipt.get("service") == "regis-acr-api", receipt
-    assert receipt.get("action") == action, receipt
-    assert receipt.get("status") == "succeeded", receipt
+    require(isinstance(receipt, dict), payload)
+    require(receipt.get("service") == "regis-acr-api", receipt)
+    require(receipt.get("action") == action, receipt)
+    require(receipt.get("status") == "succeeded", receipt)
     for key in ("correlation_id", "subject_ref", "payload_ref", "event_ref", "receipt_ref", "created_at"):
-        assert receipt.get(key), receipt
+        require(receipt.get(key), receipt)
 
 
 def main() -> int:
     client = TestClient(app)
 
     health = client.get("/healthz")
-    assert health.status_code == 200, health.text
+    require(health.status_code == 200, health.text)
     health_json = health.json()
-    assert health_json["ok"] is True, health_json
-    assert health_json["service"] == "regis-acr-api", health_json
-    assert "DecisionLedgerEntry" in health_json["contracts"], health_json
+    require(health_json["ok"] is True, health_json)
+    require(health_json["service"] == "regis-acr-api", health_json)
+    require("DecisionLedgerEntry" in health_json["contracts"], health_json)
 
     source_record = {
         "source_record_id": "src:tesco:supplier:0001",
@@ -62,19 +81,22 @@ def main() -> int:
     }
 
     ingest = client.post("/v1/source-records", json=source_record)
-    assert ingest.status_code == 200, ingest.text
+    require(ingest.status_code == 200, ingest.text)
     ingest_json = ingest.json()
-    assert ingest_json["ok"] is True, ingest_json
-    assert ingest_json["decision_ledger_entry"]["canonical_mutation"] is False, ingest_json
-    assert ingest_json["decision_ledger_entry"]["outcome"] == "accepted_as_evidence_only", ingest_json
+    require(ingest_json["ok"] is True, ingest_json)
+    require(ingest_json["decision_ledger_entry"]["canonical_mutation"] is False, ingest_json)
+    require(
+        ingest_json["decision_ledger_entry"]["outcome"] == "accepted_as_evidence_only",
+        ingest_json,
+    )
     assert_receipt(ingest_json, "SourceRecordIngest")
 
     proposal = client.post("/v1/concordance/proposals", json=source_record)
-    assert proposal.status_code == 200, proposal.text
+    require(proposal.status_code == 200, proposal.text)
     proposal_json = proposal.json()
-    assert proposal_json["concordance_links"][0]["status"] == "pending_review", proposal_json
-    assert proposal_json["concordance_links"][0]["canonical_mutation"] is False, proposal_json
-    assert proposal_json["decision_ledger_entry"]["canonical_mutation"] is False, proposal_json
+    require(proposal_json["concordance_links"][0]["status"] == "pending_review", proposal_json)
+    require(proposal_json["concordance_links"][0]["canonical_mutation"] is False, proposal_json)
+    require(proposal_json["decision_ledger_entry"]["canonical_mutation"] is False, proposal_json)
     assert_receipt(proposal_json, "ConcordanceProposal")
 
     low_margin = client.post("/v1/promotion/evaluate", json={
@@ -83,11 +105,14 @@ def main() -> int:
         "runnerup_score": 0.82,
         "winner_flip_rate": 0.2,
     })
-    assert low_margin.status_code == 200, low_margin.text
+    require(low_margin.status_code == 200, low_margin.text)
     low_json = low_margin.json()
-    assert low_json["energy_ledger_entry"]["promotion_allowed"] is False, low_json
-    assert low_json["energy_ledger_entry"]["promotion_decision"] == "blocked_or_review_required", low_json
-    assert low_json["energy_ledger_entry"]["canonical_mutation"] is False, low_json
+    require(low_json["energy_ledger_entry"]["promotion_allowed"] is False, low_json)
+    require(
+        low_json["energy_ledger_entry"]["promotion_decision"] == "blocked_or_review_required",
+        low_json,
+    )
+    require(low_json["energy_ledger_entry"]["canonical_mutation"] is False, low_json)
     assert_receipt(low_json, "PromotionEvaluation")
 
     eligible = client.post("/v1/promotion/evaluate", json={
@@ -96,11 +121,14 @@ def main() -> int:
         "runnerup_score": 0.80,
         "winner_flip_rate": 0.0,
     })
-    assert eligible.status_code == 200, eligible.text
+    require(eligible.status_code == 200, eligible.text)
     eligible_json = eligible.json()
-    assert eligible_json["energy_ledger_entry"]["promotion_allowed"] is True, eligible_json
-    assert eligible_json["energy_ledger_entry"]["promotion_decision"] == "eligible_for_evidence_only_insert", eligible_json
-    assert eligible_json["energy_ledger_entry"]["canonical_mutation"] is False, eligible_json
+    require(eligible_json["energy_ledger_entry"]["promotion_allowed"] is True, eligible_json)
+    require(
+        eligible_json["energy_ledger_entry"]["promotion_decision"] == "eligible_for_evidence_only_insert",
+        eligible_json,
+    )
+    require(eligible_json["energy_ledger_entry"]["canonical_mutation"] is False, eligible_json)
     assert_receipt(eligible_json, "PromotionEvaluation")
 
     hook = client.post("/v1/relationships/formation-hooks", json={
@@ -108,13 +136,13 @@ def main() -> int:
         "subject_entity_ref": "canonical:acme-cooperative-foods-ltd",
         "object_entity_ref": "canonical:tesco-plc",
     })
-    assert hook.status_code == 200, hook.text
+    require(hook.status_code == 200, hook.text)
     hook_json = hook.json()
     bindings = hook_json["relationship_formation_hook"]["ontogenesis_bindings"]
-    assert bindings["genesis_event_required"] is True, hook_json
-    assert bindings["validity_interval_required"] is True, hook_json
-    assert bindings["derivation_path_required"] is True, hook_json
-    assert hook_json["relationship_formation_hook"]["canonical_mutation"] is False, hook_json
+    require(bindings["genesis_event_required"] is True, hook_json)
+    require(bindings["validity_interval_required"] is True, hook_json)
+    require(bindings["derivation_path_required"] is True, hook_json)
+    require(hook_json["relationship_formation_hook"]["canonical_mutation"] is False, hook_json)
     assert_receipt(hook_json, "RelationshipFormationHook")
 
     summary = {

--- a/tools/smoke_sourceos_m2_filesystem_registry.py
+++ b/tools/smoke_sourceos_m2_filesystem_registry.py
@@ -12,7 +12,13 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def load(path: Path) -> dict:
     data = json.loads(path.read_text(encoding="utf-8"))
-    assert isinstance(data, dict)
+    if not isinstance(data, dict):
+        # Was `assert isinstance(data, dict)`. Under `python -O` that check is
+        # stripped, so a JSON file that is a list (or a bare string/number)
+        # flowed on as if it were the expected object and every later
+        # `.get(...)` silently reported the field as absent rather than the
+        # file as malformed.
+        raise TypeError(f"{path}: expected a JSON object, got {type(data).__name__}")
     return data
 
 

--- a/tools/smoke_sourceos_m2_lifecycle_proof.py
+++ b/tools/smoke_sourceos_m2_lifecycle_proof.py
@@ -12,7 +12,13 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def load(path: Path) -> dict:
     data = json.loads(path.read_text(encoding="utf-8"))
-    assert isinstance(data, dict)
+    if not isinstance(data, dict):
+        # Was `assert isinstance(data, dict)`. Under `python -O` that check is
+        # stripped, so a JSON file that is a list (or a bare string/number)
+        # flowed on as if it were the expected object and every later
+        # `.get(...)` silently reported the field as absent rather than the
+        # file as malformed.
+        raise TypeError(f"{path}: expected a JSON object, got {type(data).__name__}")
     return data
 
 

--- a/tools/validate_workspace_context_record.py
+++ b/tools/validate_workspace_context_record.py
@@ -10,17 +10,41 @@ SCHEMA = ROOT / "contracts/workspace-context/workspace-context-record.v0.1.json"
 EXAMPLE = ROOT / "contracts/workspace-context/workspace-context-record.v0.1.example.json"
 
 
+class RecordInvalid(Exception):
+    """The Workspace Context record fixture failed a validation obligation."""
+
+
+def require(condition: object, message: str) -> None:
+    """Validation check that survives `python -O`.
+
+    Every check in this tool was a bare `assert`. `python -O` strips all of
+    them, leaving main() with nothing to do but fall through to
+    `print("OK: Workspace Context record validation passed")` and return 0 --
+    a validator reporting a pass for a fixture it never read. There is no
+    partial failure mode here: under -O the entire tool was a no-op that
+    printed OK.
+    """
+    if not condition:
+        raise RecordInvalid(message)
+
+
 def main():
     try:
         schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
         example = json.loads(EXAMPLE.read_text(encoding="utf-8"))
         for key in schema["required"]:
-            assert key in example, f"missing {key}"
-        assert example["version"] == "0.1"
-        assert example["platform_refs"]["event_envelope_ref"]
-        assert example["platform_refs"]["evidence_receipt_ref"]
-        assert example["workroom_ref"]
-        assert example["workspace_object_ref"]
+            require(key in example, f"missing {key}")
+        require(example["version"] == "0.1", "version must be '0.1'")
+        require(
+            example["platform_refs"]["event_envelope_ref"],
+            "platform_refs.event_envelope_ref must be non-empty",
+        )
+        require(
+            example["platform_refs"]["evidence_receipt_ref"],
+            "platform_refs.evidence_receipt_ref must be non-empty",
+        )
+        require(example["workroom_ref"], "workroom_ref must be non-empty")
+        require(example["workspace_object_ref"], "workspace_object_ref must be non-empty")
     except Exception as exc:
         print(f"ERR: {exc}", file=sys.stderr)
         return 2


### PR DESCRIPTION
Two Shape-C sub-patterns in `tools/`. Every fix below has a revert-proof.

---

## C1 — assertions that evaporate

Four CI-invoked tools did real verification with bare `assert`. `python -O` strips every `assert`, and each tool still reported success.

### `tools/validate_workspace_context_record.py` (6) — whole tool evaporates
Every check in this tool was an `assert`. Under `-O`, `main()` had nothing left to do but fall through to `print("OK: Workspace Context record validation passed")` and return 0. There is no partial failure mode: the entire validator was a no-op that printed OK. Invoked by `.github/workflows/workspace-context.yml:33`.

**Proof** — example set to `version: 9.9` with `workroom_ref` and `evidence_receipt_ref` blanked, under `python -O`:
before rc 0 `OK: ... validation passed` → after rc 2 `ERR: version must be '0.1'`.

### `tools/smoke_regis_acr_service.py` (30)
Health, ingest, proposal, promotion-margin and relationship-hook responses all went uninspected under `-O` while `main()` returned 0. Invoked by `.github/workflows/regis-acr-service.yml:37`.

**Proof** — service patched to answer `canonical_mutation: true` and receipt `status: "failed"`, the exact evidence-only safety posture these checks defend, under `python -O`: before `main()` returned 0 against a mutating service → after `SmokeFailure`.

### `tools/smoke_sourceos_m2_lifecycle_proof.py` / `..._filesystem_registry.py` (1 each)
`load()`'s `assert isinstance(data, dict)` is the only shape check on parsed JSON. Under `-O` a file containing a list flowed on as the expected object, so every later `.get()` reported fields *absent* rather than the file *malformed*. Invoked by `.github/workflows/sourceos-contracts.yml:50,52`.

**Proof** — list-valued JSON under `python -O`: before `load()` returned a `list` → after `TypeError` naming the file.

Clean inputs still pass under both `python3` and `python3 -O`.

---

## C3 — an enforcement key that fails open

### `tools/check_fogstack_registry_root_metadata.py`
The revocation index was guarded by `if isinstance(ref, str):`. `revocation_index_ref` is legitimately optional (schema `["string","null"]`, not in `required`), so absent/null should skip — but **any other type also fell through**, skipping both the existence check and the digest comparison, after which the tool printed `FogStack registry root metadata passed.` with exit 0. One mistyped key silently switched off revocation-index verification.

Nothing else catches it: this checker is hand-rolled and **never applies** `fogstack-registry-root-metadata-v0.1.schema.json`, so the clause that would reject a non-string ref is never evaluated. The releases loop eight lines above already fails closed on a non-string ref — this branch was the odd one out.

**Proof**, against a synthetic root that passes cleanly:

| `revocation_index_ref` | before | after |
|---|---|---|
| `123` / `["a"]` / `{"k":1}` | rc 0, *"metadata passed."* | rc 1, typed diagnostic |
| `null` (legitimately optional) | rc 0 | rc 0 |
| valid path | rc 0 | rc 0 |

Existing suites still green: `test_fogstack_registry_root_metadata.py` + `test_fogstack_registry_schema_tightening.py` → 7 passed.

---

## Lane notes
- Touches only `tools/*.py`. Does **not** touch compute-gateway, arcticdb-gateway, `ci_docs_only.py`, `validate-target-diagnostics.yml`, `gitops-promote.yml`, `apps/health-twin/**` or `apps/device-service/**`.
- **Registered, not fixed:** `tools/validate_professional_intelligence_manifest.py` has 3 evaporating asserts (L97, L119, L125), but its Makefile target is referenced from `validate-target-diagnostics.yml:96`, live in another lane (#1080/#1082). Left for that lane to avoid a mid-flight collision.
- Scanned from a materialized `main` tree at pinned SHA `00090bd`, not a worktree.