### PR TITLE
compute-gateway: gate the app selector on /v1/config and stop failing open

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -35,11 +35,15 @@ def _bearer(authorization: str) -> str:
     `Bearer x`; `removeprefix("Bearer ")` matched one casing and silently treated the
     whole header as the token for every other input. Returning "" for a malformed
     header keeps the "no credential" and "wrong credential" paths identical.
+
+    Split on any run of whitespace rather than a literal space: RFC 7235 spells the
+    separator `1*SP`, so HTAB is not strictly conformant, but rejecting `Bearer<TAB>token`
+    buys no safety and costs a confusing 401.
     """
-    scheme, _, credential = authorization.strip().partition(" ")
-    if scheme.lower() != "bearer":
+    parts = authorization.strip().split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
         return ""
-    return credential.strip()
+    return parts[1].strip()
 
 
 def require_token(authorization: str = Header(default="")) -> None:
@@ -325,8 +329,13 @@ def config_snapshot(app: str = DEFAULT_APP, model: str | None = None,
     fail-OPEN when GATEWAY_TOKEN was unset (`"" != ""` is False, so an absent header
     authenticated against an unconfigured service) — the exact inverse of the 503 every
     other route answers. One parsing path, one failure mode.
+
+    The test is `is not None`, not truthiness: `?model=` arrives as "", which is falsy.
+    Today that collapses to the default scope anyway (scope_key does `model or "*"`), so
+    it discloses nothing — but the gate would be relying on a falsiness convention in a
+    different module to stay closed. Gate on presence and the two stay independent.
     """
-    if model or org or app != DEFAULT_APP:
+    if model is not None or org is not None or app != DEFAULT_APP:
         require_token(authorization)
     return config_plane.get_snapshot(app=app, model=model, org=org)
 

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -9,6 +9,7 @@ the walking skeleton of "any compute, one contract".
 from __future__ import annotations
 
 import os
+import secrets
 from typing import Any, Literal
 
 from fastapi import Depends, FastAPI, Header, HTTPException
@@ -22,11 +23,29 @@ app = FastAPI(title="compute-gateway", version="0.1.0")
 
 GATEWAY_TOKEN = os.getenv("GATEWAY_TOKEN", "")
 
+# The one app scope served without a token. Anything else is a SELECTOR, and a selector
+# that needs no credential is an enumeration primitive — see config_snapshot().
+DEFAULT_APP = "noetica"
+
+
+def _bearer(authorization: str) -> str:
+    """The presented credential, or "" if this is not a well-formed Bearer header.
+
+    RFC 7235 makes the auth scheme case-insensitive, so `bearer x` is as valid as
+    `Bearer x`; `removeprefix("Bearer ")` matched one casing and silently treated the
+    whole header as the token for every other input. Returning "" for a malformed
+    header keeps the "no credential" and "wrong credential" paths identical.
+    """
+    scheme, _, credential = authorization.strip().partition(" ")
+    if scheme.lower() != "bearer":
+        return ""
+    return credential.strip()
+
 
 def require_token(authorization: str = Header(default="")) -> None:
     if not GATEWAY_TOKEN:
         raise HTTPException(status_code=503, detail="gateway token not configured (fail-closed)")
-    if authorization.removeprefix("Bearer ").strip() != GATEWAY_TOKEN:
+    if not secrets.compare_digest(_bearer(authorization), GATEWAY_TOKEN):
         raise HTTPException(status_code=401, detail="unauthorized")
 
 
@@ -287,19 +306,28 @@ class ConfigSetBody(BaseModel):
 
 
 @app.get("/v1/config")
-def config_snapshot(app: str = "noetica", model: str | None = None,
+def config_snapshot(app: str = DEFAULT_APP, model: str | None = None,
                     org: str | None = None,
                     authorization: str = Header(default="")) -> dict:
     """The flag snapshot a client caches.
 
     The DEFAULT scope is deliberately unauthenticated: a client that cannot reach the plane
     falls back to its last cached snapshot, so gating the common read would only deepen an
-    outage. But org/model SELECTORS are a different matter — leaving them open let any
-    caller enumerate other tenants' snapshots by guessing identifiers (raised in review), so
-    a scoped read requires the token. Open where openness helps, closed where it leaks.
+    outage. But a SELECTOR is a different matter — leaving one open lets any caller
+    enumerate other tenants' snapshots by guessing identifiers, so a scoped read requires
+    the token. Open where openness helps, closed where it leaks.
+
+    `app` is a selector too. The first pass at this gated `model`/`org` and left `app`
+    open, which still allowed enumerating every other app's snapshot by guessing the
+    name — `scope_key(app, ...)` proves the scope is real. All three are gated now.
+
+    And the gate is require_token, not a second hand-rolled comparison. The local copy
+    fail-OPEN when GATEWAY_TOKEN was unset (`"" != ""` is False, so an absent header
+    authenticated against an unconfigured service) — the exact inverse of the 503 every
+    other route answers. One parsing path, one failure mode.
     """
-    if (model or org) and authorization.removeprefix("Bearer ").strip() != GATEWAY_TOKEN:
-        raise HTTPException(status_code=401, detail="scoped config reads require a token")
+    if model or org or app != DEFAULT_APP:
+        require_token(authorization)
     return config_plane.get_snapshot(app=app, model=model, org=org)
 
 

--- a/apps/compute-gateway/tests/test_config_plane.py
+++ b/apps/compute-gateway/tests/test_config_plane.py
@@ -151,6 +151,22 @@ def test_the_bearer_scheme_is_matched_case_insensitively():
         assert client.get("/v1/config", params={"org": "kyroga"},
                           headers={"Authorization": "Basic t"}).status_code == 401, \
             "a non-Bearer scheme is not a credential"
+        assert client.get("/v1/config", params={"org": "kyroga"},
+                          headers={"Authorization": "t"}).status_code == 401, \
+            "a raw token with no scheme is not a credential — removeprefix() accepted this"
+        assert client.get("/v1/config", params={"org": "kyroga"},
+                          headers={"Authorization": "Bearer\tt"}).status_code == 200, \
+            "HTAB between scheme and credential is tolerated, not a confusing 401"
+
+
+def test_an_empty_selector_is_still_a_selector():
+    """`?model=` arrives as "" and is falsy. It collapses to the default scope today, so
+    nothing leaks — but gating on truthiness would make this endpoint's security depend on
+    a falsiness convention in config_plane. Gate on presence instead (Copilot on #1085)."""
+    with durable():
+        assert client.get("/v1/config", params={"model": ""}).status_code == 401
+        assert client.get("/v1/config", params={"org": ""}).status_code == 401
+        assert client.get("/v1/config", params={"model": ""}, headers=AUTH).status_code == 200
 
 
 def test_a_model_kill_switch_must_be_a_real_boolean():

--- a/apps/compute-gateway/tests/test_config_plane.py
+++ b/apps/compute-gateway/tests/test_config_plane.py
@@ -113,6 +113,46 @@ def test_scoped_reads_require_a_token_so_tenants_cannot_be_enumerated():
         assert client.get("/v1/config", params={"model": "qwen2.5:7b"}).status_code == 401
 
 
+def test_the_app_selector_is_gated_too():
+    """The org/model half of this was fixed and `app` was left open, which still allowed
+    enumerating any other app's snapshot by guessing the name (Copilot #1029, :292/:303)."""
+    # Literal, not server.DEFAULT_APP: this must fail on the RESPONSE when the gate is
+    # reverted, not on a missing attribute.
+    with durable():
+        assert client.get("/v1/config", params={"app": "noetica"}).status_code == 200, \
+            "the default app is the open scope"
+        assert client.get("/v1/config", params={"app": "someone-elses-app"}).status_code == 401
+        assert client.get("/v1/config", params={"app": "someone-elses-app"},
+                          headers=AUTH).status_code == 200, "a token still reads any scope"
+
+
+def test_a_scoped_read_fails_closed_when_no_token_is_configured():
+    """The hand-rolled check compared against GATEWAY_TOKEN directly, so an UNCONFIGURED
+    gateway ("" != "" is False) authenticated an anonymous scoped read — fail-open, the
+    inverse of the 503 every require_token route answers."""
+    with durable():
+        prev = server.GATEWAY_TOKEN
+        server.GATEWAY_TOKEN = ""
+        try:
+            r = client.get("/v1/config", params={"org": "someone-else"})
+            assert r.status_code == 503, f"unconfigured gateway must refuse, got {r.status_code}"
+        finally:
+            server.GATEWAY_TOKEN = prev
+
+
+def test_the_bearer_scheme_is_matched_case_insensitively():
+    """RFC 7235 makes the scheme case-insensitive; removeprefix("Bearer ") matched exactly
+    one casing and fed the whole header through as the token for every other input."""
+    with durable():
+        assert client.get("/v1/config", params={"org": "kyroga"},
+                          headers={"Authorization": "bearer t"}).status_code == 200
+        assert client.get("/v1/config", params={"org": "kyroga"},
+                          headers={"Authorization": "BEARER t"}).status_code == 200
+        assert client.get("/v1/config", params={"org": "kyroga"},
+                          headers={"Authorization": "Basic t"}).status_code == 401, \
+            "a non-Bearer scheme is not a credential"
+
+
 def test_a_model_kill_switch_must_be_a_real_boolean():
     """bool("false") is True — coercing a string here could flip a switch the wrong way."""
     with durable():


### PR DESCRIPTION
Closes two live Tier-1 findings from the Copilot review backlog, both on `GET /v1/config` in `apps/compute-gateway/src/compute_gateway/server.py`.

## 1. `app` is a scope selector and was not gated

Copilot raised the scoped-read exposure three times on #1029 ([:292](https://github.com/SocioProphet/prophet-platform/pull/1029#discussion_r3678007013), [:303](https://github.com/SocioProphet/prophet-platform/pull/1029#discussion_r3678007040), and [the original](https://github.com/SocioProphet/prophet-platform/pull/1029#discussion_r3675673929)). The `org`/`model` half was fixed. `app` was not — and `app` selects a scope exactly like the other two (`scope_key(app, ...)` proves the scope is real), so any unauthenticated caller could still enumerate another app's flag snapshot by guessing the name.

## 2. The gate failed OPEN when no token was configured

The more serious defect was in the check itself. It was a second, hand-rolled copy of `require_token`'s comparison:

```python
if (model or org) and authorization.removeprefix("Bearer ").strip() != GATEWAY_TOKEN:
```

With `GATEWAY_TOKEN` unset that reads `"" != ""` → `False`, so an **unconfigured gateway authenticated an anonymous scoped read**. Every other route on this service answers 503 in that state. The one endpoint with a hand-rolled check was the one that failed open.

Scoped reads now call `require_token`, so there is one parsing path and one failure mode.

## 3. Bearer parsing, hardened once in the shared path

From the same review's suppressed-comments block (`:292`, `:302`): the scoped check re-implemented token parsing and accepted a raw token with no scheme. `removeprefix("Bearer ")` also matched exactly one casing, so a conformant `bearer <token>` was rejected while the entire header of any other scheme was passed through and compared as if it were the credential. Now: scheme matched case-insensitively per RFC 7235, comparison via `secrets.compare_digest`.

## Revert-proof

Four new tests in `apps/compute-gateway/tests/test_config_plane.py`. With `server.py` fully reverted to `origin/main` and the tests kept, all four fail **on the response**, not on a missing symbol:

```
FAILED test_the_app_selector_is_gated_too - AssertionError
FAILED test_a_scoped_read_fails_closed_when_no_token_is_configured
FAILED test_the_bearer_scheme_is_matched_case_insensitively
FAILED test_an_empty_selector_is_still_a_selector
4 failed, 16 passed
```

With the fix: `20 passed`. Full suite `168 passed`; the only remaining failure is a missing `pypdf` in the local env, unrelated.

## Follow-up commit addressing this PR's own Copilot review

`?model=` arrives as `""` and is falsy, so the gate did not fire. I checked whether it leaks — it does not: `scope_key()` does `model or "*"`, so an empty selector collapses to the default scope, which is already open. Changed anyway, because gating on truthiness made this endpoint's security depend on a falsiness convention in a *different module*. Now `is not None`. Also: split on any whitespace so `Bearer<TAB>token` is not a confusing 401, and added the missing assertion that a bare schemeless token is refused — the claim this PR makes about the old behaviour was previously unpinned.

## Scope

Touches `compute_gateway/server.py` and its test only. Does not touch `validate-target-diagnostics.yml`, `gitops-promote.yml`, `health-twin/src/{server,deident,invariants,grantauth}.ts`, or `apps/device-service/**`.

Do not merge on my account — flagging for review.
