### PR TITLE
auth primitives: parse the Bearer scheme, then compare in constant time

### DIFF
--- a/apps/arcticdb-gateway/src/arcticdb_gateway/server.py
+++ b/apps/arcticdb-gateway/src/arcticdb_gateway/server.py
@@ -34,11 +34,15 @@ def _bearer(authorization: str) -> str:
     `Bearer x`; `removeprefix("Bearer ")` matched one casing and silently passed the
     whole header through as the token for every other input, which meant a header
     carrying a different scheme was compared as though it were a credential.
+
+    Split on any run of whitespace rather than a literal space: RFC 7235 spells the
+    separator `1*SP`, so HTAB is not strictly conformant, but rejecting `Bearer<TAB>token`
+    buys no safety and costs a confusing 401.
     """
-    scheme, _, credential = authorization.strip().partition(" ")
-    if scheme.lower() != "bearer":
+    parts = authorization.strip().split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
         return ""
-    return credential.strip()
+    return parts[1].strip()
 
 
 def require_token(authorization: str = Header(default="")) -> None:

--- a/apps/arcticdb-gateway/src/arcticdb_gateway/server.py
+++ b/apps/arcticdb-gateway/src/arcticdb_gateway/server.py
@@ -16,6 +16,7 @@ mount in deploy/values/arcticdb-gateway.yaml). LMDB is single-writer: one replic
 from __future__ import annotations
 
 import os
+import secrets
 from typing import Any
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Query
@@ -26,6 +27,20 @@ from .store import BadRequest, GatewayStore, SymbolNotFound
 DEFAULT_URI = "lmdb:///data/arcticdb?map_size=8GB"
 
 
+def _bearer(authorization: str) -> str:
+    """The presented credential, or "" if this is not a well-formed Bearer header.
+
+    RFC 7235 makes the auth scheme case-insensitive, so `bearer x` is as valid as
+    `Bearer x`; `removeprefix("Bearer ")` matched one casing and silently passed the
+    whole header through as the token for every other input, which meant a header
+    carrying a different scheme was compared as though it were a credential.
+    """
+    scheme, _, credential = authorization.strip().partition(" ")
+    if scheme.lower() != "bearer":
+        return ""
+    return credential.strip()
+
+
 def require_token(authorization: str = Header(default="")) -> None:
     """Fail-closed write auth, matching compute-gateway.
 
@@ -34,11 +49,15 @@ def require_token(authorization: str = Header(default="")) -> None:
     convention for a mutating endpoint is 503 when no token is configured — an
     unconfigured gateway refuses rather than serving open — and 401 when one is wrong.
     Reads stay open: this closes the mutation path, which is the asymmetry that matters.
+
+    The comparison is constant-time. `!=` on a secret returns as soon as it finds a
+    differing byte, which makes the response time a function of how much of the token
+    the caller already has — enough, over many requests, to recover it a byte at a time.
     """
     token = os.getenv("GATEWAY_TOKEN", "")
     if not token:
         raise HTTPException(status_code=503, detail="gateway token not configured (fail-closed)")
-    if authorization.removeprefix("Bearer ").strip() != token:
+    if not secrets.compare_digest(_bearer(authorization), token):
         raise HTTPException(status_code=401, detail="unauthorized")
 
 

--- a/apps/arcticdb-gateway/tests/test_gateway.py
+++ b/apps/arcticdb-gateway/tests/test_gateway.py
@@ -215,8 +215,10 @@ def test_a_valid_credential_is_still_accepted(monkeypatch):
     monkeypatch.setenv("GATEWAY_TOKEN", TEST_TOKEN)
     assert _refusal(f"Bearer {TEST_TOKEN}") is None
     assert _refusal(f"Bearer  {TEST_TOKEN} ") is None, "surrounding whitespace is not part of it"
+    assert _refusal(f"Bearer\t{TEST_TOKEN}") is None, "HTAB separator is tolerated, not a 401"
     assert _refusal("Bearer wrong") == 401
     assert _refusal("") == 401
+    assert _refusal("Bearer") == 401, "a scheme with no credential is not a credential"
 
 
 def test_an_unconfigured_gateway_still_fails_closed(monkeypatch):
@@ -225,17 +227,37 @@ def test_an_unconfigured_gateway_still_fails_closed(monkeypatch):
     assert _refusal("") == 503, "no token configured must never authenticate an empty header"
 
 
-def test_the_token_comparison_is_constant_time():
-    """Structural: `!=` on a secret short-circuits at the first differing byte, which makes
-    latency a function of how much of the token the caller already holds. Asserted on the
-    source because a timing difference is not reliably observable in a unit test."""
-    import inspect
+def test_the_token_comparison_is_constant_time(monkeypatch):
+    """`!=` on a secret short-circuits at the first differing byte, which makes latency a
+    function of how much of the token the caller already holds.
+
+    Asserted by observing that the comparison actually runs through
+    secrets.compare_digest — not by grepping the source, which a harmless rename or
+    helper extraction would break without changing behaviour, and not by measuring time,
+    which is not reliably observable in a unit test.
+    """
+    import secrets as secrets_mod
 
     from arcticdb_gateway import server
 
-    src = inspect.getsource(server.require_token)
-    assert "compare_digest" in src, "the token comparison must be constant-time"
-    assert "!= token" not in src, "a short-circuiting comparison leaks the token byte by byte"
+    monkeypatch.setenv("GATEWAY_TOKEN", TEST_TOKEN)
+    seen: list[tuple[str, str]] = []
+    real = secrets_mod.compare_digest
+
+    def spy(a, b):
+        seen.append((a, b))
+        return real(a, b)
+
+    monkeypatch.setattr(server.secrets, "compare_digest", spy)
+
+    assert _refusal(f"Bearer {TEST_TOKEN}") is None
+    assert seen == [(TEST_TOKEN, TEST_TOKEN)], \
+        f"the presented token must be compared via compare_digest, saw {seen}"
+
+    seen.clear()
+    assert _refusal("Bearer wrong") == 401
+    assert seen == [("wrong", TEST_TOKEN)], \
+        f"a wrong token must ALSO go through compare_digest, saw {seen}"
 
 
 def test_only_the_write_route_is_token_gated(tmp_path):

--- a/apps/arcticdb-gateway/tests/test_gateway.py
+++ b/apps/arcticdb-gateway/tests/test_gateway.py
@@ -173,6 +173,71 @@ def test_write_accepts_the_configured_token(client):
     assert r.status_code == 200
 
 
+# The header-parsing tests below call require_token directly rather than issuing requests,
+# for the same reason test_only_the_write_route_is_token_gated asserts on the route table:
+# the auth decision is independent of whether the LMDB backend can be opened here, and
+# binding these to a live store would make the security property unprovable wherever the
+# arcticdb native extension will not load.
+
+
+def _refusal(authorization: str) -> int | None:
+    """The status require_token raises for a header, or None if it allows the call."""
+    from fastapi import HTTPException
+
+    from arcticdb_gateway.server import require_token
+
+    try:
+        require_token(authorization)
+    except HTTPException as e:
+        return e.status_code
+    return None
+
+
+def test_the_bearer_scheme_is_case_insensitive(monkeypatch):
+    """RFC 7235: the auth scheme is case-insensitive. `removeprefix("Bearer ")` matched
+    exactly one casing, so a conformant client sending `bearer` got a 401 (Copilot #1034)."""
+    monkeypatch.setenv("GATEWAY_TOKEN", TEST_TOKEN)
+    for header in (f"bearer {TEST_TOKEN}", f"BEARER {TEST_TOKEN}", f"BeArEr {TEST_TOKEN}"):
+        assert _refusal(header) is None, f"{header!r} is a valid bearer credential"
+
+
+def test_a_non_bearer_scheme_is_not_a_credential(monkeypatch):
+    """The old parse was a no-op on any other scheme, so the ENTIRE header value was then
+    compared as though it were the token. It never matched — but an auth path should refuse
+    what it cannot parse, not compare it and hope. A bare secret is not a bearer credential
+    either, and that one DID authenticate."""
+    monkeypatch.setenv("GATEWAY_TOKEN", TEST_TOKEN)
+    for header in (f"Basic {TEST_TOKEN}", f"Token {TEST_TOKEN}", TEST_TOKEN):
+        assert _refusal(header) == 401, f"{header!r} is not a bearer credential"
+
+
+def test_a_valid_credential_is_still_accepted(monkeypatch):
+    monkeypatch.setenv("GATEWAY_TOKEN", TEST_TOKEN)
+    assert _refusal(f"Bearer {TEST_TOKEN}") is None
+    assert _refusal(f"Bearer  {TEST_TOKEN} ") is None, "surrounding whitespace is not part of it"
+    assert _refusal("Bearer wrong") == 401
+    assert _refusal("") == 401
+
+
+def test_an_unconfigured_gateway_still_fails_closed(monkeypatch):
+    monkeypatch.delenv("GATEWAY_TOKEN", raising=False)
+    assert _refusal("Bearer anything") == 503
+    assert _refusal("") == 503, "no token configured must never authenticate an empty header"
+
+
+def test_the_token_comparison_is_constant_time():
+    """Structural: `!=` on a secret short-circuits at the first differing byte, which makes
+    latency a function of how much of the token the caller already holds. Asserted on the
+    source because a timing difference is not reliably observable in a unit test."""
+    import inspect
+
+    from arcticdb_gateway import server
+
+    src = inspect.getsource(server.require_token)
+    assert "compare_digest" in src, "the token comparison must be constant-time"
+    assert "!= token" not in src, "a short-circuiting comparison leaks the token byte by byte"
+
+
 def test_only_the_write_route_is_token_gated(tmp_path):
     """Structural: the auth dependency is attached to /v1/write and to nothing else.
 

--- a/apps/health-twin/src/exposure.test.ts
+++ b/apps/health-twin/src/exposure.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The Authorization header parse on the PHI read path.
+ *
+ * Raised by Copilot on #1038 (exposure.ts:60) and never answered: the gate
+ * stripped a Bearer prefix *if it happened to be there* rather than requiring
+ * the scheme, so `replace(/^Bearer\s+/i, '')` was a no-op on any other input and
+ * the whole header value was then compared as though it were the credential.
+ *
+ * The consequence worth pinning is the bare one: `Authorization: <secret>`, with
+ * no scheme at all, authenticated. That is not a bearer credential, and a gate
+ * that accepts inputs it never meant to accept is one refactor away from
+ * accepting the wrong one.
+ *
+ * These live in their own file rather than in invariants.ts because that module
+ * is owned by another lane (#1081) while this landed.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { exposureDenial, type ExposureInputs } from './exposure.js';
+
+const authed = (authorization: string): ExposureInputs => ({
+  mode: 'authenticated',
+  token: 's3cret',
+  authorization,
+  ingestedRecords: 0,
+});
+
+test('a well-formed Bearer credential is accepted', () => {
+  assert.equal(exposureDenial(authed('Bearer s3cret')), null);
+});
+
+test('the Bearer scheme is case-insensitive per RFC 7235', () => {
+  assert.equal(exposureDenial(authed('bearer s3cret')), null);
+  assert.equal(exposureDenial(authed('BEARER s3cret')), null);
+});
+
+test('surrounding whitespace does not change the credential', () => {
+  assert.equal(exposureDenial(authed('  Bearer   s3cret  ')), null);
+});
+
+test('a schemeless credential is NOT a bearer credential', () => {
+  // The defect: replace() left this untouched, so `presented === token` held.
+  assert.equal(exposureDenial(authed('s3cret'))?.code, 401);
+});
+
+test('a non-Bearer scheme carrying the secret is refused', () => {
+  assert.equal(exposureDenial(authed('Basic s3cret'))?.code, 401);
+  assert.equal(exposureDenial(authed('Token s3cret'))?.code, 401);
+});
+
+test('a scheme with no credential is refused', () => {
+  assert.equal(exposureDenial(authed('Bearer'))?.code, 401);
+  assert.equal(exposureDenial(authed('Bearer   '))?.code, 401);
+});
+
+test('the wrong credential is still refused', () => {
+  assert.equal(exposureDenial(authed('Bearer wrong'))?.code, 401);
+  assert.equal(exposureDenial(authed(''))?.code, 401);
+});
+
+test('an unset token fails closed with 503, not open', () => {
+  assert.equal(
+    exposureDenial({ ...authed('Bearer anything'), token: '' })?.code,
+    503,
+  );
+});

--- a/apps/health-twin/src/exposure.ts
+++ b/apps/health-twin/src/exposure.ts
@@ -18,7 +18,22 @@
 // Pure and parameterised so it is testable without standing up a server; server.ts binds a
 // port at import time, which would otherwise make the gate provable only by running it.
 
+import { timingSafeEqual } from 'node:crypto';
+
 export type Exposure = 'synthetic-only' | 'authenticated';
+
+/** Constant-time string compare. timingSafeEqual throws on a length mismatch, which would
+ *  itself leak the length, so unequal lengths are compared against a same-length decoy and
+ *  always answer false. */
+function timingSafeEquals(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) {
+    timingSafeEqual(ab, ab);
+    return false;
+  }
+  return timingSafeEqual(ab, bb);
+}
 
 export interface ExposureDenial {
   code: 401 | 403 | 503;
@@ -61,9 +76,13 @@ export function exposureDenial(input: ExposureInputs): ExposureDenial | null {
     // from accepting the wrong one. Match the scheme, then take the rest as the token.
     const match = /^Bearer[ \t]+(.+)$/i.exec(input.authorization.trim());
     const presented = match ? match[1].trim() : '';
-    // Length-independent compare is not the concern here (the token is a deployment secret,
-    // not a per-user credential); an empty presented value must simply never match.
-    if (!presented || presented !== input.token) {
+    // Constant-time. The previous note here argued a length-independent compare was not the
+    // concern because the token is a deployment secret rather than a per-user credential.
+    // That reasoning is weaker than it looks on THIS endpoint: it is externally reachable
+    // (deploy/values routes it through the cockpit's nginx at /svc/health) and it guards
+    // PHI, so an attacker gets unlimited free attempts against a single long-lived secret —
+    // exactly the case where a byte-at-a-time oracle is worth having. Cheap to remove.
+    if (!presented || !timingSafeEquals(presented, input.token)) {
       return { code: 401, body: { error: 'unauthorized' } };
     }
     return null;

--- a/apps/health-twin/src/exposure.ts
+++ b/apps/health-twin/src/exposure.ts
@@ -74,7 +74,13 @@ export function exposureDenial(input: ExposureInputs): ExposureDenial | null {
     // was compared as the string `Basic <secret>`. Neither is a bearer credential, and an
     // auth path that accepts things it never meant to accept is one bad refactor away
     // from accepting the wrong one. Match the scheme, then take the rest as the token.
-    const match = /^Bearer[ \t]+(.+)$/i.exec(input.authorization.trim());
+    // The token group is `\S.*`, not `.+`: `[ \t]+` and `.+` both match a space/tab, so on a header
+    // like `Bearer \t\t\t…` the two quantifiers share the boundary and matching is worst-case quadratic
+    // — a polynomial-ReDoS on the PHI auth path (CodeQL js/polynomial-redos, high). Requiring the token
+    // to START non-whitespace makes the split unique (`\S` and `[ \t]` are disjoint), so there is nothing
+    // to backtrack over. `.trim()` already stripped the outer spaces and a bearer token never begins with
+    // whitespace, so nothing legitimate is lost; a whitespace-only tail still fails to match and 401s.
+    const match = /^Bearer[ \t]+(\S.*)$/is.exec(input.authorization.trim());
     const presented = match ? match[1].trim() : '';
     // Constant-time. The previous note here argued a length-independent compare was not the
     // concern because the token is a deployment secret rather than a per-user credential.

--- a/apps/health-twin/src/exposure.ts
+++ b/apps/health-twin/src/exposure.ts
@@ -52,7 +52,15 @@ export function exposureDenial(input: ExposureInputs): ExposureDenial | null {
         },
       };
     }
-    const presented = input.authorization.replace(/^Bearer\s+/i, '').trim();
+    // REQUIRE the Bearer scheme rather than stripping it when it happens to be there.
+    // `replace(/^Bearer\s+/i, '')` is a no-op on a header that carries any other scheme,
+    // so the entire header value was then compared as though it were the credential: a
+    // bare `Authorization: <secret>` authenticated, and `Authorization: Basic <secret>`
+    // was compared as the string `Basic <secret>`. Neither is a bearer credential, and an
+    // auth path that accepts things it never meant to accept is one bad refactor away
+    // from accepting the wrong one. Match the scheme, then take the rest as the token.
+    const match = /^Bearer[ \t]+(.+)$/i.exec(input.authorization.trim());
+    const presented = match ? match[1].trim() : '';
     // Length-independent compare is not the concern here (the token is a deployment secret,
     // not a per-user credential); an empty presented value must simply never match.
     if (!presented || presented !== input.token) {


### PR DESCRIPTION
Two unanswered Copilot findings, both the same shape of bug: a token check that **strips `Bearer` if it happens to be there** rather than requiring the scheme. The parse is then a no-op on anything else, and the whole header value gets compared as though it were the credential.

## arcticdb-gateway — [#1034 :42](https://github.com/SocioProphet/prophet-platform/pull/1034#discussion_r3675985454)

- `removeprefix("Bearer ")` matched exactly one casing. RFC 7235 makes the scheme case-insensitive, so a conformant client sending `bearer <token>` got a 401, while a header carrying no scheme at all was accepted.
- `!=` on a secret returns at the first differing byte, making response latency a function of how much of the token the caller already holds. Now `secrets.compare_digest`.

## health-twin `exposure.ts` — [#1038 :60](https://github.com/SocioProphet/prophet-platform/pull/1038#discussion_r3676419994), the PHI read path

`replace(/^Bearer\s+/i, '')` left a schemeless `Authorization: <secret>` untouched, so it compared equal and **authenticated**. Now the scheme is matched and the remainder taken as the credential.

**Correction to the finding as written.** Copilot's example was `Authorization: Basic <secret>`, and that one did *not* authenticate — it was compared as the literal string `"Basic <secret>"` and failed. I verified this directly rather than assume. The real hole was the bare no-scheme form. The finding is valid; its illustration overstated it.

## Revert-proof

**arcticdb** — 3 of 5 new tests fail on the old parse; the 2 covering unchanged behaviour keep passing:
```
FAILED test_the_bearer_scheme_is_case_insensitive
FAILED test_a_non_bearer_scheme_is_not_a_credential
FAILED test_the_token_comparison_is_constant_time
3 failed, 2 passed
```
These call `require_token` directly rather than issuing requests, following the precedent already set by `test_only_the_write_route_is_token_gated` — the auth decision is independent of whether the LMDB backend can be opened, and binding it to a live store makes the security property unprovable wherever the `arcticdb` native extension will not load (it does not load on macOS).

**exposure** — new `apps/health-twin/src/exposure.test.ts`, 8 cases. On the old code:
```
✖ a schemeless credential is NOT a bearer credential
✖ surrounding whitespace does not change the credential
6 pass / 2 fail
```
New file rather than an edit to `invariants.ts`, because that module is owned by #1081 while this lands. `src/*.test.ts` is already the `npm test` glob, so #1081's new health-twin CI job picks it up. I ran `npx tsx src/invariants.ts` against the changed `exposure.ts` — all guardrail invariants still hold, so this does not disturb that lane.

## One honest caveat

`apps/arcticdb-gateway` has **no test leg in CI today** — `images.yml` builds the image and nothing runs `tests/`. Until that is wired, the arcticdb half of this PR is correct and locally revert-proof but not CI-enforced. #1086 adds the leg.

Do not merge on my account — flagging for review.

---

## Follow-up commit addressing this PR's own Copilot review

**Copilot was right and I was wrong on one point.** `exposure.ts` still compared with `!==`, and my comment there argued a length-independent compare was not the concern because the token is a deployment secret rather than a per-user credential. That reasoning is weaker than it looks *on this endpoint*: `deploy/values` routes health-twin through the cockpit's nginx at `/svc/health`, so it is externally reachable, and it guards PHI — unlimited free attempts against one long-lived secret is exactly where a timing oracle pays off. Now `timingSafeEqual`, with the length-mismatch path compared against a same-length decoy so the length does not leak through the early return.

Also: both gateways now split on any whitespace run (`Bearer<TAB>token` was a needless 401 — though note RFC 7235 spells the separator `1*SP`, so the strict behaviour was defensible), and the constant-time test no longer greps `inspect.getsource()`. It spies on `secrets.compare_digest` and asserts **both** the accept and the reject path go through it with the exact arguments — semantic rather than textual, survives refactors, still fails if the comparison reverts to `!=`.
