### PR TITLE
ci: the docs-only detector must not be able to certify its own modification

### DIFF
--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -51,13 +51,28 @@ jobs:
           # The rule lives in tools/ci_docs_only.py so it is unit-tested; a skip rule that
           # only exists in YAML is a skip rule nobody can test.
           #
+          # It is read from the BASE REF, never from the PR checkout. `python3
+          # tools/ci_docs_only.py` ran the pull request's OWN copy of the detector, and the
+          # detector is not on its own inert allowlist — so a PR could edit it to print
+          # "true" unconditionally and thereby skip app-test and smoke for its entire diff.
+          # The detector would be certifying its own modification. origin/$BASE is the copy
+          # that has already been reviewed and merged.
+          #
+          # Consequence worth stating: a PR that improves the detector does not get the
+          # improvement applied to itself. That is the correct direction — the change takes
+          # effect once merged, and until then the PR runs the full matrix anyway.
+          DETECTOR="$(mktemp)"
+          if ! git show "origin/$BASE:tools/ci_docs_only.py" > "$DETECTOR" 2>/dev/null; then
+            echo "cannot read the detector from origin/$BASE — running everything"
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
           # The detector is NOT allowed to fail this job. Skipping tests must require a
           # positive "true"; anything else — a crash, a missing interpreter, an
           # unrecognised answer — falls back to running the full matrix. Letting the job
           # fail instead would still be safe for coverage (the dependents run on an empty
           # output), but it paints the workflow red while the required gate stays green,
           # which teaches people to ignore red.
-          if ! RESULT="$(printf '%s\n' "$CHANGED" | python3 tools/ci_docs_only.py 2>&1)"; then
+          if ! RESULT="$(printf '%s\n' "$CHANGED" | python3 "$DETECTOR" 2>&1)"; then
             echo "detector failed, running everything. output: $RESULT"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
@@ -173,6 +188,15 @@ jobs:
           # so this leg also catches contract drift the moment a vendored copy is edited.
           - name: device-service
             working-directory: apps/device-service
+            install: pip install -r requirements.txt -r requirements-test.txt
+            test: PYTHONPATH=src pytest -q tests
+          # arcticdb-gateway had tests but NO leg: images.yml built the image and nothing
+          # ran tests/. Its /v1/write auth is the whole reason the service is safe to expose
+          # in-cluster, and an auth test that never executes is decoration. requirements.txt
+          # is a pip freeze of the python:3.11-slim image, which is what this matrix pins,
+          # so the leg runs the same closure the image ships.
+          - name: arcticdb-gateway
+            working-directory: apps/arcticdb-gateway
             install: pip install -r requirements.txt -r requirements-test.txt
             test: PYTHONPATH=src pytest -q tests
           - name: tools-tests

--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -62,6 +62,7 @@ jobs:
           # improvement applied to itself. That is the correct direction — the change takes
           # effect once merged, and until then the PR runs the full matrix anyway.
           DETECTOR="$(mktemp)"
+          trap 'rm -f "$DETECTOR"' EXIT
           if ! git show "origin/$BASE:tools/ci_docs_only.py" > "$DETECTOR" 2>/dev/null; then
             echo "cannot read the detector from origin/$BASE — running everything"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"; exit 0

--- a/tools/ci_docs_only.py
+++ b/tools/ci_docs_only.py
@@ -18,22 +18,51 @@ SCOPE: "inert" here means inert *to application and service tests*. It does NOT 
 unvalidated — the validate-target-diagnostics legs (including validate-repo, which asserts
 REQUIRED_FILES such as docs/ARCHITECTURE.md and scans for TODO/PLACEHOLDER) are never
 skipped, so documentation keeps its own coverage.
+
+TRUST: the workflow reads THIS FILE FROM THE BASE REF, not from the PR checkout. Running
+the PR's own copy would let a pull request edit this detector to answer "true"
+unconditionally and thereby skip app-test and smoke for its entire diff — a detector
+certifying its own modification. See the `changes` job in
+.github/workflows/validate-target-diagnostics.yml and the structural test that pins it.
 """
 from __future__ import annotations
 
+import posixpath
 import re
 import sys
 
-# A path is inert only if it is inside docs/ or is a top-level markdown file.
-# Anchored and slash-explicit so `docsomething/x.py` and `apps/svc/README.md` do NOT match.
-INERT = re.compile(r'^(docs/|[^/]+\.md$)')
+# Extensions that are genuinely inert to application and service tests: prose and images.
+# NOT "anything under docs/" — a docs directory can legally hold executable and
+# machine-consumed files (docs/conf.py, docs/scripts/gen.ts), and this repo already carries
+# docs/design-register.yaml, which a workflow reads, plus docs/generated/**/*.json schema
+# examples. Treating those as inert is a coverage hole that opens itself the day someone
+# adds the file. An allowlist fails in the safe direction: an extension not named here
+# runs everything.
+DOC_SUFFIXES = frozenset({
+    '.md', '.rst', '.txt',
+    '.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.ico', '.pdf',
+})
+
+# A top-level markdown file (README.md, CHANGELOG.md). Anchored and slash-explicit so
+# `apps/svc/README.md`, which sits beside code, does NOT match.
+TOP_LEVEL_MD = re.compile(r'^[^/]+\.md$')
+
+
+def _inert(path: str) -> bool:
+    """One path's verdict. An unrecognised shape is never inert."""
+    if TOP_LEVEL_MD.match(path):
+        return True
+    # Slash-explicit so `docsomething/x.py` is not read as a docs path.
+    if not path.startswith('docs/'):
+        return False
+    return posixpath.splitext(path)[1].lower() in DOC_SUFFIXES
 
 
 def docs_only(paths: list[str]) -> bool:
     cleaned = [p.strip() for p in paths if p.strip()]
     if not cleaned:
         return False  # an empty diff tells us nothing; run everything
-    return all(INERT.match(p) for p in cleaned)
+    return all(_inert(p) for p in cleaned)
 
 
 def main() -> int:

--- a/tools/tests/test_ci_docs_only.py
+++ b/tools/tests/test_ci_docs_only.py
@@ -139,7 +139,20 @@ def test_an_unreadable_base_detector_runs_everything():
     """Fail-safe, not fail-open: if the base copy cannot be read, the full matrix runs."""
     script = _changes_job_script()
     marker = 'git show "origin/$BASE:tools/ci_docs_only.py"'
+    # Assert the landmarks before slicing on them, so a moved marker reports what is wrong
+    # instead of an IndexError with an unhelpful traceback.
+    assert marker in script, f'expected the base-ref read {marker!r} in the detect step'
     tail = script.split(marker, 1)[1]
+    assert 'fi' in tail, 'expected the base-ref read to be inside a guarded if-block'
     guard = tail.split('fi', 1)[0]
     assert 'docs_only=false' in guard, \
         'a detector that cannot be read from the base ref must fall back to running everything'
+
+
+def test_the_detector_temp_file_is_cleaned_up():
+    """Runners are ephemeral, but a step that leaks a temp file per run is still the kind of
+    hygiene that turns into a full disk on a self-hosted runner."""
+    script = _changes_job_script()
+    assert 'DETECTOR="$(mktemp)"' in script
+    assert "trap 'rm -f \"$DETECTOR\"' EXIT" in script, \
+        'the detector temp file must be removed when the step exits'

--- a/tools/tests/test_ci_docs_only.py
+++ b/tools/tests/test_ci_docs_only.py
@@ -18,11 +18,13 @@ from tools.ci_docs_only import docs_only  # noqa: E402
 
 
 @pytest.mark.parametrize('paths', [
-    ['docs/design-register.yaml'],
     ['README.md'],
     ['docs/a.md', 'CHANGELOG.md'],
     ['docs/nested/deep/thing.md'],
     ['docs/ARCHITECTURE.md'],          # safe: validate-repo still runs and asserts it exists
+    ['docs/img/diagram.png'],
+    ['docs/notes.rst', 'docs/notes.txt'],
+    ['docs/A.MD'],                     # extension match is case-insensitive
 ])
 def test_inert_diffs_may_skip_the_app_and_smoke_legs(paths):
     assert docs_only(paths) is True
@@ -65,3 +67,79 @@ def test_the_rule_is_all_or_nothing():
     """Skipping requires EVERY path to be inert — proof of inertness, not a majority vote."""
     assert docs_only(['docs/a.md', 'docs/b.md']) is True
     assert docs_only(['docs/a.md', 'apps/x.py']) is False
+
+
+# ---------------------------------------------------------------------------
+# Copilot #1044 (ci_docs_only.py:36 and :29): "anything under docs/ is inert" is a
+# coverage hole that opens itself. docs/ can hold executable and machine-consumed
+# files, and the moment one appears it is silently exempted from app-test and smoke.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('path', [
+    'docs/conf.py',                       # Sphinx config — executable
+    'docs/scripts/gen.ts',
+    'docs/scripts/build.sh',
+    'docs/tooling/helper.js',
+    'docs/design-register.yaml',          # this repo HAS this, and a workflow reads it
+    'docs/generated/identity/examples/identity_session_context.example.v0.1.json',
+    'docs/Makefile',                      # no extension at all
+    'docs/.env',
+])
+def test_an_executable_or_machine_consumed_file_under_docs_is_not_inert(path):
+    assert docs_only([path]) is False, f'{path} must not earn a skip'
+
+
+def test_a_code_file_hidden_in_a_docs_only_diff_forces_a_full_run():
+    """The exploit shape: a large, plausibly docs-only PR carrying one executable path."""
+    paths = [f'docs/note{i}.md' for i in range(30)] + ['docs/scripts/postinstall.py']
+    assert docs_only(paths) is False
+
+
+def test_the_detector_is_not_inert_to_itself():
+    """A PR editing the skip rule must run the full matrix. Together with reading the
+    detector from the base ref, this is what stops it certifying its own modification."""
+    assert docs_only(['tools/ci_docs_only.py']) is False
+    assert docs_only(['tools/tests/test_ci_docs_only.py']) is False
+    assert docs_only(['.github/workflows/validate-target-diagnostics.yml']) is False
+
+
+# ---------------------------------------------------------------------------
+# The trust boundary itself. Structural, because the property lives in YAML: the
+# workflow must execute the BASE ref's detector, not the PR checkout's copy.
+# ---------------------------------------------------------------------------
+
+WORKFLOW = REPO_ROOT / '.github' / 'workflows' / 'validate-target-diagnostics.yml'
+
+
+def _changes_job_script() -> str:
+    """The `changes` job's detect step, as text. Deliberately not a YAML-schema
+    assertion — what matters is the shell that actually runs."""
+    import yaml
+
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    steps = wf['jobs']['changes']['steps']
+    detect = [s for s in steps if s.get('id') == 'detect']
+    assert len(detect) == 1, 'expected exactly one detect step in the changes job'
+    return detect[0]['run']
+
+
+def test_the_detector_is_read_from_the_base_ref_not_the_pr_checkout():
+    """Copilot #1044 (:66), unanswered: running `python3 tools/ci_docs_only.py` executes
+    the PR's own copy. A PR could edit it to print "true" unconditionally and skip
+    app-test and smoke for its whole diff — self-certification."""
+    script = _changes_job_script()
+    assert 'git show "origin/$BASE:tools/ci_docs_only.py"' in script, \
+        'the detector must be read from the base ref'
+    assert 'python3 tools/ci_docs_only.py' not in script, \
+        'executing the PR checkout of the detector lets a PR certify its own skip'
+
+
+def test_an_unreadable_base_detector_runs_everything():
+    """Fail-safe, not fail-open: if the base copy cannot be read, the full matrix runs."""
+    script = _changes_job_script()
+    marker = 'git show "origin/$BASE:tools/ci_docs_only.py"'
+    tail = script.split(marker, 1)[1]
+    guard = tail.split('fi', 1)[0]
+    assert 'docs_only=false' in guard, \
+        'a detector that cannot be read from the base ref must fall back to running everything'


### PR DESCRIPTION
Three findings, one theme: **the CI does not enforce what it claims to.**

## 1. Self-certification — [#1044 :66](https://github.com/SocioProphet/prophet-platform/pull/1044#discussion_r3677243248), unanswered

The `changes` job ran `python3 tools/ci_docs_only.py` — the **pull request's own copy** of the detector. The detector is not on its own inert allowlist, so a PR could edit it to print `true` unconditionally and the workflow would believe it, skipping `app-test` and `smoke` for that PR's entire diff.

Demonstrated end to end before fixing, in a throwaway repo:

```
PR diff: apps/service.py + tools/ci_docs_only.py (edited to always return True)

  detector from PR checkout  -> docs_only=true   app-test + smoke SKIPPED
  detector from the base ref -> docs_only=false  full matrix RUNS
```

Now read via `git show "origin/$BASE:tools/ci_docs_only.py"`. A base copy that cannot be read falls back to running everything.

Consequence worth stating: a PR that *improves* the detector does not get the improvement applied to itself. That is the correct direction, and such a PR runs the full matrix anyway.

## 2. `docs/` is not uniformly inert — [#1044 :36](https://github.com/SocioProphet/prophet-platform/pull/1044#discussion_r3677128250) plus the suppressed block at `:29`

`INERT = ^(docs/|[^/]+\.md$)` treated **any** path under `docs/` as inert. `docs/` can hold executable and machine-consumed files, and this repo already carries `docs/design-register.yaml` (a workflow reads it) and `docs/generated/**/*.json` schema examples.

Now an extension allowlist — prose and images. `docs/conf.py`, `docs/scripts/gen.ts`, `docs/Makefile`, and the yaml/json now run the full matrix. **This only ever runs more tests, never fewer.** One existing test asserted `docs/design-register.yaml` was inert; it is updated, deliberately, and that is the behaviour change to look at.

## 3. arcticdb-gateway had tests and no leg

`images.yml` built the image; nothing ran `tests/`. Added to the app-test matrix — this is what makes the auth fix in #1086 enforced rather than decorative. Its `requirements.txt` is a pip freeze of `python:3.11-slim`, which is what the matrix pins, so the leg runs the closure the image ships.

## Revert-proof

11 of the 32 tests in `tools/tests/test_ci_docs_only.py` fail when the two source changes are reverted — including the two **structural** tests that pin the base-ref read in the YAML, since a shell-level property cannot be pinned by a unit test alone:

```
FAILED test_the_detector_is_read_from_the_base_ref_not_the_pr_checkout
FAILED test_an_unreadable_base_detector_runs_everything
FAILED test_an_executable_or_machine_consumed_file_under_docs_is_not_inert[docs/conf.py]
... 8 more
11 failed, 21 passed
```

`tools/tests` is already an app-test leg, so these run.

## Scope / coordination

Touches only the `changes` job and the app-test matrix. **Does not touch `diagnostics-gate`**, which #1080 and #1082 own. Rebased on `origin/main` at time of push; if those land first this should rebase cleanly, as the hunks are far apart in the file.

Do not merge on my account — flagging for review.

---

## Follow-up commit addressing this PR's own Copilot review

Two fair points, both taken: the detector temp file is now removed via `trap 'rm -f "$DETECTOR"' EXIT` (hygiene on ephemeral runners, but this estate has self-hosted runners and disk has been a live constraint), and `test_an_unreadable_base_detector_runs_everything` now asserts each landmark exists before slicing on it, so a moved marker reports what changed instead of an `IndexError` in the test's own string surgery.

Revert-proof updated: with both source files fully reverted to `origin/main`, **12 fail, 21 pass**. With the fix: **33 pass**.
