### PR TITLE
fix(compute-gateway): ZEROTRUST_ENFORCE=1 meant OFF, and OFF was silent

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/zerotrust.py
+++ b/apps/compute-gateway/src/compute_gateway/zerotrust.py
@@ -51,18 +51,76 @@ from __future__ import annotations
 import functools
 import hashlib
 import json
+import logging
 import os
 import time
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 from . import registry, signing
 from .contract import Receipt
 
-ZEROTRUST_ENFORCE = os.getenv("ZEROTRUST_ENFORCE", "false").lower() == "true"
+log = logging.getLogger("compute_gateway.zerotrust")
+
+# ── env flags: one spelling convention, and "off" is never silent ─────────────
+# The estate spells truthy at least three ways: "1" is dominant (NOETICA_SHACL_ENFORCE,
+# BROKER_REQUIRE_KEY, SERVICE_REGISTER_STRICT, PREMERGE_STRICT), memoryd/main.py accepts
+# {'1','true','yes'}, and hellgraph-service uses 'on'. This module used to accept the literal
+# "true" and nothing else, so ZEROTRUST_ENFORCE=1 — the estate's OWN dominant spelling — parsed
+# as False. An operator who set it believed the gate was on; grant_check silently skipped every
+# grant-store validation. A flag with three spellings, one of which quietly means "off", is a
+# worse failure than no flag at all.
+TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def env_flag(name: str, default: str = "false") -> bool:
+    """Parse a boolean env var — THE one way this package parses them.
+
+    Other apps in the estate still carry their own variants (memoryd, hellgraph-service,
+    device-service, openai-research-mcp, osm-map-api). Consolidating those is a separate
+    change; this at least stops the gateway from adding a fourth convention. Note that
+    engine.py's GATEWAY_MEMOIZE / GATEWAY_WRITE_PROVENANCE still use `== "true"` — they
+    default to ON, so the same bug there turns a feature off rather than a gate, but they
+    should adopt this helper too.
+    """
+    return os.getenv(name, default).strip().lower() in TRUTHY
+
+
+ZEROTRUST_ENFORCE = env_flag("ZEROTRUST_ENFORCE")
 TRUST_BOUNDARY_ID = os.getenv("ZEROTRUST_BOUNDARY_ID", "tb-compute-gateway")
 TRUST_DOMAIN = os.getenv("ZEROTRUST_TRUST_DOMAIN", "socioprophet.dev")
+
+
+def warn_if_unenforced(warn: Callable[[str], None] | None = None) -> bool:
+    """Announce a DISABLED zero-trust gate loudly at startup. Returns True if it warned.
+
+    Matches the discipline hellgraph-service already applies in auth.ts (`initAuth`) and
+    membrane.ts (`initMembrane`): off is a legitimate rollout state, but it is a passthrough,
+    and a passthrough must be stated out loud exactly once rather than inferred from silence.
+
+    The default is deliberately NOT flipped to on here. `deploy/values/compute-gateway.yaml`
+    does not set ZEROTRUST_ENFORCE at all, so the deployed default is off, and turning it on
+    is a deployment decision with a live blast radius — not something to slip in under a
+    parsing fix. Making "off" audible is the fix; choosing "on" is Michael's call.
+    """
+    if ZEROTRUST_ENFORCE:
+        return False
+    (warn or log.warning)(
+        "[zerotrust] WARN ZEROTRUST_ENFORCE is OFF — grant validation is a PASSTHROUGH. "
+        "grant_check() never checks a presented grant_id against the grant store, so a "
+        "REVOKED or EXPIRED grant returns valid=True on entitlement alone, and a user-code "
+        "kind dispatches with no capability grant at all. Set ZEROTRUST_ENFORCE to one of "
+        f"{sorted(TRUTHY)} to fail closed."
+    )
+    return True
+
+
+# Import IS startup for this module (the vendored-schema provenance assertion below already
+# relies on that), and the gateway's entrypoint is `uvicorn compute_gateway.server:app`, which
+# imports this module rather than calling an init hook we could hang the warning off.
+warn_if_unenforced()
 
 _SCHEMA_DIR = Path(__file__).resolve().parent / "schemas"   # ships inside the package (src/)
 
@@ -208,6 +266,11 @@ def grant_check(*, project: str, kind: str, backend: str, actor: str,
     kernel-shaped evidence AND, under ZEROTRUST_ENFORCE, tightens the decision:
     a user-code kind presented with no grant_id fails closed regardless of
     entitlement (defence in depth — a paid entitlement is not a capability grant).
+
+    With enforcement OFF this function validates NOTHING against the grant store: a
+    presented grant_id is echoed into the evidence and `valid` tracks `entitled` alone,
+    so a REVOKED or EXPIRED grant still reads valid=True. That is the passthrough
+    warn_if_unenforced() announces at startup — it is a real state, not a theoretical one.
     """
     needs_grant = registry.KINDS.get(kind, {}).get("executes_user_code", False)
     gid = grant_id or f"grant-implicit-{project}-{kind}"

--- a/apps/compute-gateway/tests/test_zerotrust.py
+++ b/apps/compute-gateway/tests/test_zerotrust.py
@@ -176,3 +176,115 @@ def test_spark_routes_live_with_receipt_and_warrant():
     assert r["epistemic_status"] == "derived"
     assert r["outputs"][0]["type"] == "table"
     assert r["receipt"]["kind"] == "spark"               # same universal receipt
+
+
+# ── ZEROTRUST_ENFORCE: the flag must MEAN what the estate spells ──
+# Regression: the flag was `os.getenv(...).lower() == "true"`, so ZEROTRUST_ENFORCE=1 — the
+# estate's dominant spelling (NOETICA_SHACL_ENFORCE, BROKER_REQUIRE_KEY, SERVICE_REGISTER_STRICT,
+# PREMERGE_STRICT) — parsed as False and the gate was silently OFF. With it off, grant_check()
+# validates nothing against the store: a revoked grant returns valid=True on entitlement alone.
+
+def _reimport_with(value: str | None):
+    """Re-import zerotrust with ZEROTRUST_ENFORCE set (or unset) — it is read at import."""
+    prev = os.environ.get("ZEROTRUST_ENFORCE")
+    if value is None:
+        os.environ.pop("ZEROTRUST_ENFORCE", None)
+    else:
+        os.environ["ZEROTRUST_ENFORCE"] = value
+    try:
+        return importlib.reload(zerotrust).ZEROTRUST_ENFORCE
+    finally:
+        if prev is None:
+            os.environ.pop("ZEROTRUST_ENFORCE", None)
+        else:
+            os.environ["ZEROTRUST_ENFORCE"] = prev
+        importlib.reload(zerotrust)
+        zerotrust.ZEROTRUST_ENFORCE = False
+
+
+def test_enforce_flag_accepts_the_conventional_truthy_set():
+    for spelling in ("1", "true", "TRUE", "True", "yes", "YES", "on", "ON", " true ", " 1 "):
+        assert _reimport_with(spelling) is True, f"{spelling!r} must enable enforcement"
+    for spelling in ("0", "false", "no", "off", "", "  ", "maybe"):
+        assert _reimport_with(spelling) is False, f"{spelling!r} must NOT enable enforcement"
+    assert _reimport_with(None) is False, "absent stays off — the default is not being flipped here"
+
+
+def test_enforce_via_numeric_one_actually_refuses_a_revoked_grant():
+    """The whole point: `=1` must not just parse True, it must reach the enforcement block."""
+    gr = client.post("/v1/grants", json={"kind": "graph-query", "project": "demo"},
+                     headers=AUTH).json()
+    gid = gr["grant"]["grant_id"]
+    client.post(f"/v1/grants/{gid}/revoke", headers=AUTH)
+
+    prev = os.environ.get("ZEROTRUST_ENFORCE")
+    os.environ["ZEROTRUST_ENFORCE"] = "1"
+    try:
+        importlib.reload(zerotrust)
+        assert zerotrust.ZEROTRUST_ENFORCE is True
+        check, permitted = zerotrust.grant_check(project="demo", kind="graph-query",
+                                                 backend="hellgraph", actor="a",
+                                                 grant_id=gid, entitled=True)
+        assert permitted is False, "a revoked grant must be refused when ZEROTRUST_ENFORCE=1"
+        assert check["result"]["revoked"] is True
+        assert check["result"]["valid"] is False
+
+        # ...and a VALID grant still passes: this is a gate, not a wall.
+        ok = client.post("/v1/grants", json={"kind": "graph-query", "project": "demo"},
+                         headers=AUTH).json()["grant"]["grant_id"]
+        _c2, permitted2 = zerotrust.grant_check(project="demo", kind="graph-query",
+                                                backend="hellgraph", actor="a",
+                                                grant_id=ok, entitled=True)
+        assert permitted2 is True, "a live grant must still be admitted"
+    finally:
+        if prev is None:
+            os.environ.pop("ZEROTRUST_ENFORCE", None)
+        else:
+            os.environ["ZEROTRUST_ENFORCE"] = prev
+        importlib.reload(zerotrust)
+        zerotrust.ZEROTRUST_ENFORCE = False
+
+
+def test_disabled_enforcement_leaks_a_revoked_grant_and_says_so_out_loud():
+    """Pin BOTH halves of the silent-wrong: the leak is real, and it is now announced."""
+    gr = client.post("/v1/grants", json={"kind": "graph-query", "project": "demo"},
+                     headers=AUTH).json()
+    gid = gr["grant"]["grant_id"]
+    client.post(f"/v1/grants/{gid}/revoke", headers=AUTH)
+
+    zerotrust.ZEROTRUST_ENFORCE = False
+    _check, permitted = zerotrust.grant_check(project="demo", kind="graph-query",
+                                              backend="hellgraph", actor="a",
+                                              grant_id=gid, entitled=True)
+    assert permitted is True, "documents the cost of off: a revoked grant passes on entitlement"
+
+    said: list[str] = []
+    assert zerotrust.warn_if_unenforced(said.append) is True
+    assert len(said) == 1, "exactly one WARN (auth.ts / membrane.ts discipline)"
+    msg = said[0]
+    assert "ZEROTRUST_ENFORCE" in msg and "OFF" in msg
+    assert "REVOKED" in msg, "the warning must name what it costs, not just that a flag is off"
+
+    zerotrust.ZEROTRUST_ENFORCE = True
+    said2: list[str] = []
+    assert zerotrust.warn_if_unenforced(said2.append) is False
+    assert said2 == [], "enforced startup is quiet"
+    zerotrust.ZEROTRUST_ENFORCE = False
+
+
+def test_env_flag_helper_is_the_one_convention():
+    prev = os.environ.get("_ZT_PROBE")
+    try:
+        for v, want in (("1", True), ("true", True), ("yes", True), ("on", True),
+                        ("ON", True), (" 1 ", True), ("0", False), ("off", False),
+                        ("", False), ("nope", False)):
+            os.environ["_ZT_PROBE"] = v
+            assert zerotrust.env_flag("_ZT_PROBE") is want, f"{v!r}"
+        os.environ.pop("_ZT_PROBE", None)
+        assert zerotrust.env_flag("_ZT_PROBE") is False
+        assert zerotrust.env_flag("_ZT_PROBE", "on") is True, "callers may default to on"
+    finally:
+        if prev is None:
+            os.environ.pop("_ZT_PROBE", None)
+        else:
+            os.environ["_ZT_PROBE"] = prev

--- a/deploy/values/compute-gateway.yaml
+++ b/deploy/values/compute-gateway.yaml
@@ -24,6 +24,14 @@ config:
   # Durable proof store: receipts + content-addressed artifacts + the doc→SQL sink land on
   # the PVC mounted here, so a governed run survives a restart (compute-gateway persistence).
   GATEWAY_STORE_DIR: "/data"
+  # ZEROTRUST_ENFORCE is DELIBERATELY UNSET, and that means the zero-trust gate is OFF in
+  # production: grant_check() records kernel-shaped evidence but validates no presented
+  # grant_id against the store, so a REVOKED or EXPIRED grant reads valid=True on entitlement
+  # alone. The gateway now says so out loud in its startup log rather than leaving it to be
+  # inferred from an absent key. Turning it on is a deployment decision with a live blast
+  # radius (every user-code kind starts requiring an explicit capability grant), so it is
+  # left to an explicit call, not flipped as a side effect of the parsing fix:
+  #   ZEROTRUST_ENFORCE: "1"      # accepted: 1 | true | yes | on
 # GATEWAY_TOKEN provisioned out-of-band; FORGE_TOKEN is the SAME lattice-forge-token
 # already present in socioprophet (the gateway authenticates to the forge with it).
 secretEnv:


### PR DESCRIPTION
Two separate failures stacked on one flag.

## 1. The flag accepted only the literal `"true"`

```python
ZEROTRUST_ENFORCE = os.getenv("ZEROTRUST_ENFORCE", "false").lower() == "true"
```

So `1`, `yes` and `on` all parsed `False`. **`1` is the estate's dominant spelling** (`NOETICA_SHACL_ENFORCE`, `BROKER_REQUIRE_KEY`, `SERVICE_REGISTER_STRICT`, `PREMERGE_STRICT`), and this same repo already disagrees with itself — `memoryd/main.py` takes `{'1','true','yes'}`, `hellgraph-service` takes `'on'`. Three conventions, one of which quietly means "off" on the security gate. An operator who set `ZEROTRUST_ENFORCE=1` got an unenforced gateway.

Measured by re-importing the module per spelling, then presenting a **revoked** grant to `grant_check()`:

| `ZEROTRUST_ENFORCE` | before | after |
|---|---|---|
| `"true"` / `"TRUE"` / `"True"` | refused | refused |
| `"1"` | **`valid=True` LEAK** | refused |
| `"yes"` / `"YES"` | **`valid=True` LEAK** | refused |
| `"on"` / `"ON"` | **`valid=True` LEAK** | refused |
| `" true "` (padded) | **`valid=True` LEAK** | refused |
| `"0"` / `"no"` / `"off"` | `valid=True` | `valid=True` (correctly off) |
| unset | `valid=True` | `valid=True` (correctly off) |

`valid=True` on a revoked grant is the whole cost: with enforcement off, `grant_check()` never consults the grant store, so **revoked and expired grants pass on entitlement alone**.

## 2. "Off" was inferred from silence

`deploy/values/compute-gateway.yaml` never sets the variable, so the deployed default is off and nothing said so. It now warns at startup, naming what the passthrough costs — matching `hellgraph-service` `auth.ts:initAuth()` and `membrane.ts:initMembrane()`, including their "exactly one WARN" discipline:

```
[zerotrust] WARN ZEROTRUST_ENFORCE is OFF — grant validation is a PASSTHROUGH. grant_check()
never checks a presented grant_id against the grant store, so a REVOKED or EXPIRED grant returns
valid=True on entitlement alone, and a user-code kind dispatches with no capability grant at all.
Set ZEROTRUST_ENFORCE to one of ['1', 'on', 'true', 'yes'] to fail closed.
```

Enforced startup stays quiet.

## The default is deliberately NOT flipped

Turning enforcement on is a deployment decision with a live blast radius — every user-code kind starts requiring an explicit capability grant — and it should not ride in on a parsing fix.

**Recommendation: turn it on** (`ZEROTRUST_ENFORCE: "1"`). The gate is otherwise decorative and revoked grants are honoured in production today. The values file now carries that as a documented, commented-out line so the choice is *visible* rather than absent. Your call, not mine.

## Scope

`env_flag()` is introduced as this package's one parser, but **only `ZEROTRUST_ENFORCE` is migrated**. `engine.py`'s `GATEWAY_MEMOIZE` / `GATEWAY_WRITE_PROVENANCE` still use `== "true"`; they default to ON, so the same bug turns a feature off rather than a gate — noted in the helper's docstring rather than refactored here. The estate-wide consolidation (memoryd, hellgraph-service, device-service, openai-research-mcp, osm-map-api) is a separate change; a shared lib cannot be reached from this image anyway, since the Dockerfile only `COPY src`.

## Verification

- 4 new tests, all **failing on the pre-fix module** and passing after.
- Full compute-gateway suite **169/169**. `ruff` clean. Values YAML re-parsed to confirm `ZEROTRUST_ENFORCE` is still absent from `config` (comment only).
- Rebased on `origin/main` immediately before push; no overlap with the `compute_gateway/server.py` lane.