### PR TITLE
health-twin: consult the reconciliation verdict on the request path, seal the anti-clamp audit, and give the app CI at all

### DIFF
--- a/apps/health-twin/src/dynamics/predict.ts
+++ b/apps/health-twin/src/dynamics/predict.ts
@@ -17,7 +17,8 @@ import {
 import { fitSurrogate, proposeDelta, SEED_COVARIATES, SURROGATE_ID, SURROGATE_VERSION } from './surrogate.js';
 import {
   reconcile, recordRejections, auditEmission, gatePolicy, reconciliationVerdict, GATE_ID, GATE_POLICY_VERSION,
-  ADMISSIBILITY_DIGEST, type GateDecision, type RejectionRecord, type RejectionReason, type Reconciliation,
+  ADMISSIBILITY_DIGEST, EMISSION_LAW,
+  type GateDecision, type RejectionRecord, type RejectionReason, type Reconciliation,
 } from './gate.js';
 import { seal, verifySeal, q, type Seal } from './seal.js';
 import { OBSERVATIONS } from '../data.js';
@@ -45,6 +46,14 @@ export interface PredictOptions {
    * argument only — it is never reachable from HTTP input, so no caller can steer the gate.
    */
   overrideDelta?: (k: Compartment, day: number, mechanistic: number) => number;
+  /**
+   * TEST-ONLY injection point, same discipline as `overrideDelta`: rewrite a compartment's decisions
+   * AFTER adjudication, so the harness can simulate a BROKEN GATE — one that clamps. There is no other
+   * way to exercise the anti-clamp response: `reconcile()` cannot produce a clamp, which is the point,
+   * so a gate that clamps has to be forged to prove the audit acts on it. Function argument only, never
+   * read from HTTP input.
+   */
+  overrideDecisions?: (k: Compartment, decisions: GateDecision[]) => GateDecision[];
 }
 
 export interface OrganPrediction {
@@ -101,6 +110,52 @@ const DISCLAIMER =
   'Projection of this record’s own numbers under the current regimen, from a mechanistic organ model with a '
   + 'gated learned correction. Synthetic data. Not a diagnosis, not a prognosis, not a medical device — a clinician decides.';
 
+// ── the sealed projection ────────────────────────────────────────────────────────────────────────
+//
+// 🔴 ONE function, called by both `predict()` (which computes the seal) and `verifyPrediction()`
+// (which re-derives it). It used to be written out twice, by hand, and the two copies had already
+// drifted: neither included `emissionAudit`, so a clamp violation did not perturb the digest and was
+// UNPROVABLE from the receipt afterwards — the receipt said "this run is fine" whether or not it was.
+// A seal that omits the audit of its own emission is a seal over the part nobody doubts.
+//
+// What the projection must therefore bind, and why each is load-bearing:
+//   • emitted / mechanistic / decisions — the numbers and the adjudication that produced them;
+//   • emissionAudit — the ANTI-CLAMP verdict. Without it a clamped run and an honest run seal alike;
+//   • reconciliation (per organ AND for the run) — the safety verdict the request path acts on. It is
+//     derivable from the decisions today, but "derivable" is not "bound": a future change to
+//     reconciliationVerdict() could flip deny→allow without moving a single digest.
+function sealedProjection(organs: OrganPrediction[], reconciliation: Reconciliation) {
+  return {
+    reconciliation,
+    organs: organs.map((o) => ({
+      compartment: o.compartment, days: o.days, mechanistic: o.mechanistic, emitted: o.emitted,
+      decisions: o.decisions.map((d) => ({ day: d.day, verdict: d.verdict, reason: d.reason ?? null, proposed: d.proposed, emitted: d.emitted })),
+      emissionAudit: o.emissionAudit,
+      reconciliation: o.reconciliation,
+    })),
+  };
+}
+
+/**
+ * Raised when the gate's own anti-clamp audit fails — i.e. the engine emitted a value that is neither
+ * the physics nor the whole proposal. This is NOT a caller error and it is not a rejected proposal: it
+ * means the GATE ITSELF is broken, and the number it produced is the silent-wrong class in the flesh.
+ *
+ * The audit result used to only choose which literal to write into a field nobody read. Now it fails
+ * CLOSED: the prediction is sealed first (so the violation is bound into a receipt and provable after
+ * the fact) and then refused, so a clamped clinical number never reaches a caller at all.
+ */
+export class EmissionLawViolation extends Error {
+  readonly name = 'EmissionLawViolation';
+  constructor(
+    readonly law: string,
+    readonly violations: { compartment: Compartment; violations: unknown[] }[],
+    readonly receipt: Seal,
+  ) {
+    super(`the gate emitted a value that is neither the physics nor the whole proposal (${violations.map((v) => v.compartment).join(', ')}) — refusing to serve a clamped prediction; receipt ${receipt.id}`);
+  }
+}
+
 /** The twin's latest recorded value for each compartment's observable. */
 export function currentObservations(): { sbp?: number; a1c?: number; egfr?: number } {
   const byCode = (c: string) => OBSERVATIONS.find((o) => o.code === c)?.value;
@@ -134,8 +189,9 @@ export function predict(opts: PredictOptions = {}): TwinPrediction {
   const allDecisions: GateDecision[] = [];
 
   for (const k of compartments) {
-    const mechanistic: number[] = [], proposed: (number | null)[] = [], emitted: number[] = [];
-    const decisions: GateDecision[] = [];
+    const mechanistic: number[] = [], proposed: (number | null)[] = [];
+    let emitted: number[] = [];
+    let decisions: GateDecision[] = [];
     let previousEmitted = observableOf(run.steps[0]!, k);
 
     days.forEach((day, i) => {
@@ -163,6 +219,14 @@ export function predict(opts: PredictOptions = {}): TwinPrediction {
       previousEmitted = decision.emitted;
     });
 
+    // TEST-ONLY: simulate a gate that clamps, so the anti-clamp response can be proven to have teeth.
+    // The emitted trajectory is re-read from the (possibly rewritten) decisions, because a forged clamp
+    // that did not move `emitted` would not be a clamp — it would be a mislabelled record.
+    if (opts.overrideDecisions) {
+      decisions = opts.overrideDecisions(k, decisions);
+      emitted = [emitted[0]!, ...decisions.map((d) => d.emitted)];
+    }
+
     const byReason: Partial<Record<RejectionReason, number>> = {};
     for (const d of decisions) if (d.verdict === 'rejected' && d.reason) byReason[d.reason] = (byReason[d.reason] ?? 0) + 1;
     const audit = auditEmission(decisions);
@@ -183,14 +247,13 @@ export function predict(opts: PredictOptions = {}): TwinPrediction {
   const byReason: Partial<Record<RejectionReason, number>> = {};
   for (const d of allDecisions) if (d.verdict === 'rejected' && d.reason) byReason[d.reason] = (byReason[d.reason] ?? 0) + 1;
 
+  const reconciliation = reconciliationVerdict(allDecisions);
+
   // ── seal ───────────────────────────────────────────────────────────────────────────────────────
   // Inputs, output and provenance are digested separately and bound into one snapshot, so a surface
   // can prove after the fact WHICH model, WHICH surrogate weights and WHICH gate policy produced this.
   const inputs = { horizonDays, stepDays, compartments, observed, covariates };
-  const output = organs.map((o) => ({
-    compartment: o.compartment, days: o.days, mechanistic: o.mechanistic, emitted: o.emitted,
-    decisions: o.decisions.map((d) => ({ day: d.day, verdict: d.verdict, reason: d.reason ?? null, proposed: d.proposed, emitted: d.emitted })),
-  }));
+  const output = sealedProjection(organs, reconciliation);
   const provenance = {
     mechanistic: { model: MODEL_ID, version: MODEL_VERSION, params: digestParams(params) },
     surrogate: { id: SURROGATE_ID, version: SURROGATE_VERSION, coefficientsDigest: sur.coefficientsDigest, fittedOn: sur.fittedOn, residualOnly: true as const },
@@ -199,9 +262,18 @@ export function predict(opts: PredictOptions = {}): TwinPrediction {
   const receipt = seal('prediction', inputs, output, provenance);
   const rejections = recordRejections(receipt.id, allDecisions);
 
+  // ── the anti-clamp law, ENFORCED ───────────────────────────────────────────────────────────────
+  // Sealed FIRST, refused SECOND, and the order is the whole point: the receipt exists and binds the
+  // violation, so the failure is provable after the fact — and then nothing is served. A clamped value
+  // that is merely LABELLED as clamped is still a clamped clinical number on a surface.
+  const clamped = organs
+    .filter((o) => o.emissionAudit !== 'ok')
+    .map((o) => ({ compartment: o.compartment, violations: (o.emissionAudit as { violations: unknown[] }).violations }));
+  if (clamped.length > 0) throw new EmissionLawViolation(EMISSION_LAW, clamped, receipt);
+
   return {
     horizonDays, stepDays, anchoredTo: observed, covariates, organs,
-    reconciliation: reconciliationVerdict(allDecisions),
+    reconciliation,
     gate: {
       policyVersion: GATE_POLICY_VERSION, admissibilityDigest: ADMISSIBILITY_DIGEST,
       accepted: allDecisions.filter((d) => d.verdict === 'accepted').length,
@@ -219,12 +291,12 @@ function digestParams(p: unknown): string {
   return seal('params', p, null, null).inputsDigest;
 }
 
-/** Re-derive a prediction's seal from its own contents — the verification side of the receipt. */
+/**
+ * Re-derive a prediction's seal from its own contents — the verification side of the receipt.
+ * Uses the SAME `sealedProjection` the seal was computed over, so the two can no longer drift apart.
+ */
 export function verifyPrediction(p: TwinPrediction): boolean {
   const inputs = { horizonDays: p.horizonDays, stepDays: p.stepDays, compartments: p.organs.map((o) => o.compartment), observed: p.anchoredTo, covariates: p.covariates };
-  const output = p.organs.map((o) => ({
-    compartment: o.compartment, days: o.days, mechanistic: o.mechanistic, emitted: o.emitted,
-    decisions: o.decisions.map((d) => ({ day: d.day, verdict: d.verdict, reason: d.reason ?? null, proposed: d.proposed, emitted: d.emitted })),
-  }));
+  const output = sealedProjection(p.organs, p.reconciliation);
   return verifySeal(p.receipt, 'prediction', inputs, output, p.provenance);
 }

--- a/apps/health-twin/src/dynamics/verify.ts
+++ b/apps/health-twin/src/dynamics/verify.ts
@@ -17,7 +17,7 @@ import {
   reconcile, auditEmission, rejectionLedger, _clearLedger, gatePolicy, EMISSION_LAW,
   RANGE, MAX_RATE_PER_DAY, ENVELOPE_K, REJECTION_REASONS, type RejectionReason, type ReconciliationVerdict,
 } from './gate.js';
-import { predict, verifyPrediction, currentObservations } from './predict.js';
+import { predict, verifyPrediction, currentObservations, EmissionLawViolation } from './predict.js';
 import { seal, canonical, digest } from './seal.js';
 
 let failures = 0;
@@ -199,6 +199,66 @@ console.log('\n▶ E3 — THE VERDICT USES THE VOCABULARY THE BODY-STATE SCHEMA 
   // 'learned_only' is unreachable BY CONSTRUCTION and that is the point: physics always runs first.
   const anyLearnedOnly = [applied, untouched, refused].some((p) => p.reconciliation.verdict === 'learned_only');
   ok(!anyLearnedOnly, "'learned_only' is unreachable — the mechanistic model always runs and the surrogate cannot express an absolute value");
+}
+
+console.log('\n▶ E4 — THE ANTI-CLAMP AUDIT IS INSIDE THE SEAL, AND IT FAILS CLOSED');
+{
+  // The audit used to only pick which literal went into a field, and the sealed projection EXCLUDED
+  // that field — so a clamped run and an honest run produced the same digest and the violation was
+  // unprovable from the receipt afterwards. Both halves are asserted here: bound, and acted on.
+  const p = predict();
+  ok(verifyPrediction(p), 'a clean prediction verifies against its own receipt');
+
+  const tampered = structuredClone(p) as typeof p;
+  (tampered.organs[0] as { emissionAudit: unknown }).emissionAudit = {
+    violated: 'clamp', law: EMISSION_LAW,
+    violations: [{ compartment: 'cardio', day: 7, emitted: RANGE.cardio.lo, mechanistic: 138, proposed: 38 }],
+  };
+  ok(!verifyPrediction(tampered),
+    'flipping emissionAudit from ok to a clamp violation BREAKS the seal — the violation is provable from the receipt');
+
+  const flipped = structuredClone(p) as typeof p;
+  flipped.reconciliation = { ...flipped.reconciliation, executionDecision: 'allow', humanActuation: 'permitted', verdict: 'physics_verified' };
+  ok(!verifyPrediction(flipped),
+    'flipping the reconciliation verdict deny→allow BREAKS the seal — the safety verdict is BOUND, not merely derivable');
+
+  // now a gate that genuinely clamps: it emits the BOUNDARY instead of the physics. predict() must
+  // seal it (so it is provable) and then REFUSE it (so the clamped number never reaches a caller).
+  let thrown: EmissionLawViolation | null = null;
+  try {
+    predict({
+      compartments: ['cardio'], overrideDelta: () => -100,
+      overrideDecisions: (_k, ds) => ds.map((d) => ({ ...d, emitted: RANGE.cardio.lo })),
+    });
+  } catch (e) { thrown = e instanceof EmissionLawViolation ? e : null; }
+  ok(thrown !== null, 'a gate that clamps makes predict() THROW — a clamped prediction is never returned');
+  if (thrown) {
+    ok(thrown.law === EMISSION_LAW, 'the refusal cites the anti-clamp law');
+    ok(thrown.violations.some((v) => v.compartment === 'cardio'), 'the refusal names the compartment that clamped');
+    ok(/^ht-prediction-[0-9a-f]{64}$/.test(thrown.receipt.id),
+      'the prediction was SEALED BEFORE it was refused — the receipt exists, so the violation is provable after the fact');
+    const honest = predict({ compartments: ['cardio'], overrideDelta: () => -100 });
+    ok(thrown.receipt.snapshotDigest !== honest.receipt.snapshotDigest,
+      'the clamped run and the honest run seal DIFFERENTLY (before this fix they were identical)');
+  }
+}
+
+console.log('\n▶ E5 — THE DENY VERDICT IS REACHABLE FROM CALLER INPUT ALONE (no test hook)');
+{
+  // This is why the unwired verdict mattered. `covariates` is read straight off the POST body in
+  // server.ts, and the surrogate consumes it — so an ordinary caller can drive the proposal across the
+  // admissibility bounds and make the run divergent. No overrideDelta, no privileged access.
+  const live = predict({ covariates: { adherencePdc: 50, reninIndex: 50, bmi: 28.4, uacr: 0.18 } });
+  ok(live.reconciliation.verdict === 'divergent',
+    `caller-supplied covariates alone drive the run divergent (got '${live.reconciliation.verdict}', ${live.gate.rejected} refusals)`);
+  ok(live.reconciliation.executionDecision === 'deny' && live.reconciliation.humanActuation === 'blocked' && live.reconciliation.omegaCeiling === 'TRUSTED',
+    'that run carries deny / blocked / TRUSTED — the verdict the request path must act on');
+  ok(live.organs.every((o) => o.emitted.every((v, i) => Number.isFinite(v) && Number.isFinite(o.mechanistic[i]!))),
+    'the divergent run still carries a readable mechanistic trajectory (the refusal is about actuation, not about reading)');
+
+  const ordinary = predict();
+  ok(ordinary.reconciliation.executionDecision === 'allow',
+    'TEETH THE OTHER WAY — the default covariates still produce an ALLOWED prediction, so the gate is not simply refusing everything');
 }
 
 // ── F. the seal ──────────────────────────────────────────────────────────────────────────────────

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -403,6 +403,36 @@ console.log('\n▶ INVARIANT 7 — twin dynamics: physics disposes, and a refusa
   ok(forced.reconciliation.executionDecision === 'deny' && forced.reconciliation.humanActuation === 'blocked' && forced.reconciliation.omegaCeiling === 'TRUSTED',
     'divergent denies actuation and caps omega at TRUSTED (body-state schema safety invariant)');
 
+  // 7b-ter. THE VERDICT IS ONLY WORTH COMPUTING IF SOMETHING CONSULTS IT.
+  // It was computed correctly, proven correctly, and never read on the request path: /api/health/predict
+  // sent a 'deny' with 200 OK in a body shaped exactly like an allowed prediction. Two things are
+  // invariants now — that the deny is reachable from ORDINARY CALLER INPUT (so this is a live path, not
+  // a hypothetical), and that the verdict is BOUND INTO THE SEAL (so it cannot be flipped after the
+  // fact). The HTTP status/shape half is asserted in the ci.yml boot smoke, against a real server.
+  const { verifyPrediction } = await import('./dynamics/predict.js');
+  const viaCovariates = predict({ covariates: { adherencePdc: 50, reninIndex: 50, bmi: 28.4, uacr: 0.18 } });
+  ok(viaCovariates.reconciliation.executionDecision === 'deny',
+    'caller-supplied covariates alone can drive the run to deny — the divergent path is reachable over HTTP, not just from the harness');
+  ok(predict().reconciliation.executionDecision === 'allow',
+    'teeth the other way: default covariates still produce an allowed prediction');
+  const flipped = structuredClone(viaCovariates);
+  flipped.reconciliation = { ...flipped.reconciliation, executionDecision: 'allow', humanActuation: 'permitted' };
+  ok(!verifyPrediction(flipped), 'flipping deny→allow breaks the receipt — the safety verdict is sealed, not decorative');
+
+  // 7b-quater. the anti-clamp audit is INSIDE the seal and predict() refuses rather than serving a clamp
+  const clean = predict();
+  ok(verifyPrediction(clean), 'a clean prediction verifies against its own receipt');
+  const clampTampered = structuredClone(clean);
+  (clampTampered.organs[0] as { emissionAudit: unknown }).emissionAudit = { violated: 'clamp', law: 'x', violations: [] };
+  ok(!verifyPrediction(clampTampered),
+    'a clamp violation perturbs the seal — "never clamps" is provable from the receipt, not just asserted in a comment');
+  const { EmissionLawViolation } = await import('./dynamics/predict.js');
+  let refusedClamp = false;
+  try {
+    predict({ compartments: ['cardio'], overrideDelta: () => -100, overrideDecisions: (_k, ds) => ds.map((d) => ({ ...d, emitted: RANGE.cardio.lo })) });
+  } catch (e) { refusedClamp = e instanceof EmissionLawViolation; }
+  ok(refusedClamp, 'a gate that clamps makes predict() fail CLOSED — the clamped number is never returned to a caller');
+
   // 7c. a prediction that can reach a patient-facing surface is PROVABLE and framed non-diagnostically
   const pred = predict();
   ok(/^ht-prediction-[0-9a-f]{64}$/.test(pred.receipt.id), 'a prediction carries a sha256 receipt id of the estate shape');

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -33,7 +33,7 @@ import {
 } from './grantauth.js';
 import { corsHeaders, corsPolicyFromEnv, originAllowed } from './cors.js';
 import { mintId } from './ids.js';
-import { predict, COMPARTMENTS, COMPARTMENT_SYSTEM, currentObservations, type Covariates } from './dynamics/predict.js';
+import { predict, EmissionLawViolation, COMPARTMENTS, COMPARTMENT_SYSTEM, currentObservations, type Covariates } from './dynamics/predict.js';
 import { gatePolicy, rejectionLedger } from './dynamics/gate.js';
 import { fitSurrogate } from './dynamics/surrogate.js';
 import { OBSERVABLE, type Compartment } from './dynamics/mechanistic.js';
@@ -662,10 +662,69 @@ const server = http.createServer(async (req, res) => {
       if (compartments.length === 0) return send(res, 403, { blocked: true, reason: 'no compartment is inside this grant\u2019s scope' });
 
       const p = predict({ horizonDays, stepDays, compartments, covariates });
-      return send(res, 200, a
+      // #1081 holder-auth: the success body carries the authenticated grant + use-receipt; #1089's
+      // verdict gate below is applied to exactly this body (auth first, then the physics verdict).
+      const body = a
         ? { ...p, grant: { id: a.grant.id, withheldSystems }, authentication: authenticatedAs(a), grantReceipt: grantUseReceipt('predict-read', [a.grant.id, a.holder], { grant: a.grant.id, presentedBy: a.holder }) }
-        : p, a?.legacy ? { warning: LEGACY_QUERY_WARNING } : {});
-    } catch (e) { return send(res, 400, { error: (e as Error).message || 'predict failed' }); }
+        : p;
+      const extra = a?.legacy ? { warning: LEGACY_QUERY_WARNING } : {};
+      const rec = p.reconciliation;
+
+      // ── THE GATE VERDICT IS CONSULTED HERE, NOT JUST COMPUTED ────────────────────────────────
+      // The body-state schema's safety invariant is that a 'divergent' forward model MUST NOT drive
+      // human actuation. gate.ts emits exactly that — executionDecision 'deny', humanActuation
+      // 'blocked', omegaCeiling 'TRUSTED' — and this endpoint used to send it with `200 OK` in a body
+      // shaped identically to an allowed prediction. The verdict was serialised and inert: a caller
+      // doing the ordinary `if (res.ok) render(body.organs)` could not tell a denied forward model
+      // from a permitted one. And this is NOT a theoretical path — `covariates` is caller-supplied,
+      // so an unprivileged POST can drive the surrogate across the admissibility bounds and make the
+      // run divergent. It was reachable, it was live, and it read as success.
+      //
+      // Why 409 and not 200: a naive client keys off `res.ok`, so the refusal has to be non-2xx or it
+      // is not a refusal. Why 409 and not 403: in this engine 403 means "you may not SEE this" — the
+      // exposure membrane and the grant scope both use it — and that is a different thing. Here the
+      // caller may see the trajectory in full; what is withdrawn is its standing to drive an action.
+      // Conflating the two would render "access denied" over data the caller is entitled to read, and
+      // would make a consent refusal and a physics refusal indistinguishable in any log or dashboard.
+      // 409 Conflict is the accurate one: the learned proposal conflicts with the mechanistic law.
+      //
+      // Why the prediction moves under `prediction`: the SHAPE has to differ too. A denied response
+      // that still answers `body.organs[i].emitted` is one careless `res.ok` away from being rendered
+      // as an ordinary forecast. Nested, a client that never considered divergence gets `undefined`
+      // and fails loudly instead of quietly. The trajectory itself is still served in full and is
+      // still the mechanistic one, exactly as the gate's own reason text promises.
+      if (rec.executionDecision === 'deny') {
+        return send(res, 409, {
+          blocked: true,
+          reason: rec.reason,
+          // hoisted, not merely nested: these three ARE the safety invariant, and a reader that has to
+          // walk into `.reconciliation` to find them is a reader that can miss them
+          executionDecision: rec.executionDecision,
+          humanActuation: rec.humanActuation,
+          omegaCeiling: rec.omegaCeiling,
+          verdict: rec.verdict,
+          schema: rec.schema,
+          reconciliation: rec,
+          // the trajectory is READABLE — it is the physics — but it is advisory, never actuation-grade
+          advisory: true,
+          prediction: body,
+          receipt: p.receipt,
+        }, extra);
+      }
+      return send(res, 200, body, extra);
+    } catch (e) {
+      // The anti-clamp law failing is NOT a bad request — it means the gate itself emitted a value
+      // that is neither the physics nor the whole proposal. Nothing is served, and the receipt that
+      // binds the violation is returned so the failure is provable rather than merely logged.
+      if (e instanceof EmissionLawViolation) {
+        return send(res, 500, {
+          error: 'emission-law-violation',
+          law: e.law, violations: e.violations, receipt: e.receipt,
+          detail: 'the reconciliation gate emitted a clamped value; the prediction was sealed and then refused rather than served',
+        });
+      }
+      return send(res, 400, { error: (e as Error).message || 'predict failed' });
+    }
   }
 
   // The rejection ledger. A refusal nobody can see may as well have been a silent clamp, so the refusals


### PR DESCRIPTION
Vendor-parity mirror of **SocioProphet/prophet-health#9**, **hand-applied** — `scripts/sync-to-platform.sh` was not run; it would delete platform-only files (`consult.test.ts`) and revert merged PRs.

## The gate computed the right answer and nothing read it

`reconciliationVerdict()` classifies a run whose learned proposals were refused as `divergent` and emits the body-state schema's safety invariant with it — `executionDecision: 'deny'`, `humanActuation: 'blocked'`, `omegaCeiling: 'TRUSTED'`. Every read of those three lived in the CI harnesses; `server.ts` contained none of them, and `/api/health/predict` answered **`200 OK`** in a body shaped exactly like an allowed prediction.

`covariates` is read straight off the POST body and feeds the surrogate, so the divergent path is reachable by any caller. Measured before the change: `{"adherencePdc":50,"reninIndex":50}` refuses 13 of 39 proposals, produces `deny` / `blocked` / `TRUSTED`, and was served as `200 OK`.

A denied run now answers **`409 Conflict`** with the three safety fields hoisted to the top level and the prediction nested under `prediction`, so the shape differs too and a client that never considered divergence fails loudly rather than rendering a refused forecast. The mechanistic trajectory is still served in full.

`403` is deliberately **not** reused: in this engine it means *"you may not see this"* (exposure membrane, grant scope). Here the caller may see the trajectory — what is withdrawn is its standing to drive an action. Conflating the two would make a consent refusal and a physics refusal indistinguishable to any surface or log.

## `emissionAudit` was outside its own seal

`audit.ok` only chose which literal to embed, and the sealed projection excluded the field — so a clamped run and an honest run produced identical digests. The projection was hand-written twice, in `predict()` and `verifyPrediction()`, which is how it drifted.

One `sealedProjection()` is now called by both. It binds `emissionAudit` and the reconciliation verdict; flipping either breaks the receipt. `predict()` seals first and then throws `EmissionLawViolation`, so the violation is provable from the receipt and the clamped number is never served. `server.ts` maps it to `500` with the receipt, not the generic `400`.

## 🔴 This app had NO CI in this repo

`src/dynamics/verify.ts:2` states, in its own file header, that it is *"wired into ci.yml"*. **No such step existed.** The only reference to `health-twin` in any workflow was a Docker build line in `images.yml`. So none of it had ever run here: not the connector fixtures, not the twin-dynamics proofs, not the guardrail invariants, not the clinical eval, not the unit tests.

A `health-twin` job now runs all of them, plus a both-ways boot smoke asserting `allow=200` / `deny=409` with `blocked` + `TRUSTED` surfaced and the trajectory still readable. The harnesses' own claim is now true rather than deleted.

## Verified locally

`connectors/verify.ts` 11 ✓ · `dynamics/verify.ts` 81 ✓ · `invariants.ts` 73 ✓ · `eval.ts` ✓ · `npm test` 5/5 · boot smoke ✓ — all exit 0.

## ⚠️ Pre-existing mirror drift — NOT touched by this PR

A per-file sha256 walk shows this mirror is **behind** `prophet-health` on six files, and this PR deliberately does not widen or narrow that set:

| file | platform mirror is missing |
|---|---|
| `dynamics/gate.ts` | the grant-scoped `rejectionLedger(limit, only)` — the ledger here is **unscoped**, so a cardiovascular grant holder can read renal refusals |
| `eval.ts` | the correction that scores through `reconcile()`; this copy still scores the **ungated** surrogate |
| `invariants.ts` | several emitted-receipt invariants |
| `consult.ts`, `deident.ts`, `server.ts` | other merged fixes |

The unscoped rejection ledger is the consequential one and wants its own PR. The `eval.ts` gap is cosmetic *on this cohort* — the old ungated code reports the same 34.0% / 23.5%, because the gate refuses nothing here — but it is right by coincidence, which is the exact reason the gated version was written.

Do not merge without a maintainer read of the 409 choice.