### PR TITLE
fix(infra): stop drift detection reporting "could not look" as "no drift"

### DIFF
--- a/.github/workflows/infra-drift-detect.yml
+++ b/.github/workflows/infra-drift-detect.yml
@@ -5,6 +5,14 @@ on:
     # Runs at 06:00 UTC daily.
     - cron: "0 6 * * *"
   workflow_dispatch:
+  pull_request:
+    # So a change to the drift machinery itself is exercised before it merges.
+    # Only the self-test runs on a PR; the cloud lanes are gated on the event.
+    paths:
+      - ".github/workflows/infra-drift-detect.yml"
+      - "scripts/ci/tofu-drift-plan.sh"
+      - "scripts/ci/install-opentofu.sh"
+      - "scripts/ci/test-tofu-drift-plan.sh"
 
 permissions:
   contents: read
@@ -21,33 +29,50 @@ permissions:
 #   AZURE_TENANT_ID        — your Azure tenant GUID
 #   AZURE_SUBSCRIPTION_ID  — your Azure subscription GUID
 #   IBM_TRUSTED_PROFILE_ID — tofu output github_ci_trusted_profile_id (infra/tofu/environments/ibm-iks)
+#
+# Every lane runs scripts/ci/tofu-drift-plan.sh, which maps OpenTofu's exit codes
+# onto three distinct outcomes: 0 = clean, 2 = drift (issue opened, job green),
+# anything else = the check could not run (job RED). Previously the plan ran under
+# `continue-on-error: true` and an issue was opened only on exit 2, so a failed
+# init or bad credentials — exit 1 — gave a green job and no issue, which is the
+# same signal as "no drift".
+#
+# OpenTofu is installed by scripts/ci/install-opentofu.sh rather than
+# opentofu/setup-opentofu, which this repo's Actions allowlist blocks; see that
+# script for why, and for the checksum pinning that replaces it.
 
 jobs:
+  # Guards the exit-code mapping itself. Runs everywhere, needs no cloud access,
+  # and is the reason the four lanes below can be trusted to tell drift from error.
+  self-test:
+    name: self-test / exit-code mapping
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify drift, error and clean are distinguishable
+        run: scripts/ci/test-tofu-drift-plan.sh
+
   gcp-landing:
     name: plan / gcp-landing
     runs-on: ubuntu-latest
-    environment: gcp-prod
+    needs: self-test
+    if: github.event_name != 'pull_request'
+    # Was `gcp-prod`, which does not exist in this repo; `gcp-plan` is the
+    # plan-only environment tofu-plan.yml already uses.
+    environment: gcp-plan
     steps:
       - uses: actions/checkout@v4
-      - uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
+      - name: Install OpenTofu
+        run: scripts/ci/install-opentofu.sh
       - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: ${{ vars.GCP_TOFU_SA }}
       - name: plan
         id: plan
-        working-directory: infra/tofu/envs/gcp-landing
-        run: |
-          tofu init -reconfigure
-          # -detailed-exitcode returns 2 on drift; capture it before set -e/pipefail aborts the step.
-          set +e
-          tofu plan -detailed-exitcode -out=plan.tfplan 2>&1 | tee plan.txt
-          ec=${PIPESTATUS[0]}
-          set -e
-          echo "exitcode=${ec}" >> "$GITHUB_OUTPUT"
-        continue-on-error: true
+        run: scripts/ci/tofu-drift-plan.sh gcp-landing infra/tofu/envs/gcp-landing
       - name: open drift issue
-        if: steps.plan.outputs.exitcode == '2'
+        if: steps.plan.outputs.drift == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -63,27 +88,21 @@ jobs:
   aws-eks:
     name: plan / aws-eks
     runs-on: ubuntu-latest
+    needs: self-test
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
+      - name: Install OpenTofu
+        run: scripts/ci/install-opentofu.sh
       - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ vars.AWS_TOFU_ROLE_ARN }}
           aws-region: us-east-1
       - name: plan
         id: plan
-        working-directory: infra/tofu/environments/aws-eks
-        run: |
-          tofu init -reconfigure
-          # -detailed-exitcode returns 2 on drift; capture it before set -e/pipefail aborts the step.
-          set +e
-          tofu plan -detailed-exitcode -out=plan.tfplan 2>&1 | tee plan.txt
-          ec=${PIPESTATUS[0]}
-          set -e
-          echo "exitcode=${ec}" >> "$GITHUB_OUTPUT"
-        continue-on-error: true
+        run: scripts/ci/tofu-drift-plan.sh aws-eks infra/tofu/environments/aws-eks
       - name: open drift issue
-        if: steps.plan.outputs.exitcode == '2'
+        if: steps.plan.outputs.drift == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -99,9 +118,12 @@ jobs:
   azure-aks:
     name: plan / azure-aks
     runs-on: ubuntu-latest
+    needs: self-test
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
+      - name: Install OpenTofu
+        run: scripts/ci/install-opentofu.sh
       - uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
@@ -109,18 +131,9 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - name: plan
         id: plan
-        working-directory: infra/tofu/environments/azure-aks
-        run: |
-          tofu init -reconfigure
-          # -detailed-exitcode returns 2 on drift; capture it before set -e/pipefail aborts the step.
-          set +e
-          tofu plan -detailed-exitcode -out=plan.tfplan 2>&1 | tee plan.txt
-          ec=${PIPESTATUS[0]}
-          set -e
-          echo "exitcode=${ec}" >> "$GITHUB_OUTPUT"
-        continue-on-error: true
+        run: scripts/ci/tofu-drift-plan.sh azure-aks infra/tofu/environments/azure-aks
       - name: open drift issue
-        if: steps.plan.outputs.exitcode == '2'
+        if: steps.plan.outputs.drift == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -136,9 +149,12 @@ jobs:
   ibm-iks:
     name: plan / ibm-iks
     runs-on: ubuntu-latest
+    needs: self-test
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
+      - name: Install OpenTofu
+        run: scripts/ci/install-opentofu.sh
       - name: Authenticate via IBM Trusted Profile (OIDC)
         run: |
           # Exchange the GitHub OIDC token for an IBM IAM access token.
@@ -152,20 +168,11 @@ jobs:
           echo "IC_IAM_TOKEN=$IBM_TOKEN" >> "$GITHUB_ENV"
       - name: plan
         id: plan
-        working-directory: infra/tofu/environments/ibm-iks
         env:
           IC_IAM_TOKEN: ${{ env.IC_IAM_TOKEN }}
-        run: |
-          tofu init -reconfigure
-          # -detailed-exitcode returns 2 on drift; capture it before set -e/pipefail aborts the step.
-          set +e
-          tofu plan -detailed-exitcode -out=plan.tfplan 2>&1 | tee plan.txt
-          ec=${PIPESTATUS[0]}
-          set -e
-          echo "exitcode=${ec}" >> "$GITHUB_OUTPUT"
-        continue-on-error: true
+        run: scripts/ci/tofu-drift-plan.sh ibm-iks infra/tofu/environments/ibm-iks
       - name: open drift issue
-        if: steps.plan.outputs.exitcode == '2'
+        if: steps.plan.outputs.drift == 'true'
         uses: actions/github-script@v7
         with:
           script: |

--- a/scripts/ci/install-opentofu.sh
+++ b/scripts/ci/install-opentofu.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Install a pinned, checksum-verified OpenTofu without using a third-party action.
+#
+# `opentofu/setup-opentofu` cannot run in this repo. Actions here are restricted
+# to `allowed_actions: selected` -- github-owned plus verified-Marketplace plus
+# an explicit pattern allowlist (dtolnay/*, Swatinem/*, oven-sh/*, tauri-apps/*).
+# setup-opentofu is not on the Marketplace at all
+# (https://github.com/marketplace/actions/setup-opentofu returns 404), so it is
+# none of those. Every scheduled run of infra-drift-detect.yml since it was
+# created on 2026-07-03 is a `startup_failure` (26/26), and tofu-plan.yml went
+# the same way from 2026-06-23 onward after succeeding earlier in June.
+#
+# Downloading the release archive and checking it against a committed sha256 is
+# strictly stronger than the action was: the checksum is reviewed in-tree, and
+# no third-party code runs with access to the workflow token.
+#
+# Bumping TOFU_VERSION requires adding its checksum below. An unknown version is
+# a hard error rather than an unverified download.
+
+set -euo pipefail
+
+TOFU_VERSION="${TOFU_VERSION:-1.8.3}"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) GOARCH=amd64 ;;
+  aarch64|arm64) GOARCH=arm64 ;;
+  *) echo "::error::unsupported architecture ${ARCH}" >&2; exit 1 ;;
+esac
+
+# sha256 of tofu_<version>_linux_<arch>.zip, from the upstream SHA256SUMS.
+case "${TOFU_VERSION}_${GOARCH}" in
+  1.8.3_amd64) SHA256=dc44b452a407648a40900eea5ceca2dd586dd084ae085863dba997331dcf8225 ;;
+  1.8.3_arm64) SHA256=c3ea55a86aaf22729be63371176fdefa40ae9632a6b620c64b98d7fb3a13205e ;;
+  *)
+    echo "::error title=unpinned OpenTofu::no committed sha256 for OpenTofu ${TOFU_VERSION} ${GOARCH}." >&2
+    echo "Add it from https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_SHA256SUMS before bumping." >&2
+    exit 1
+    ;;
+esac
+
+ZIP="tofu_${TOFU_VERSION}_linux_${GOARCH}.zip"
+URL="https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/${ZIP}"
+DEST="${TOFU_INSTALL_DIR:-/usr/local/bin}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Downloading ${URL}"
+curl -fsSL --retry 3 --retry-delay 2 -o "${TMP}/${ZIP}" "$URL"
+
+echo "${SHA256}  ${TMP}/${ZIP}" | sha256sum -c -
+
+unzip -q -o "${TMP}/${ZIP}" tofu -d "$TMP"
+install -m 0755 "${TMP}/tofu" "${DEST}/tofu"
+
+# Invoke by path, not via PATH, so this reports the binary just installed rather
+# than some other tofu that happens to be earlier in PATH.
+"${DEST}/tofu" version

--- a/scripts/ci/test-tofu-drift-plan.sh
+++ b/scripts/ci/test-tofu-drift-plan.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Counter-test for scripts/ci/tofu-drift-plan.sh.
+#
+# Asserts that the three OpenTofu outcomes stay distinguishable, and — the part
+# that matters — re-runs the *previous* inline logic against the same stubs to
+# show it could not tell them apart. If someone reverts the mapping, the second
+# half of this test is what goes red.
+#
+# `tofu` is stubbed, so this needs no cloud credentials and runs on every PR.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNDER_TEST="${HERE}/tofu-drift-plan.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fails=0
+check() { # check <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    printf '  ok    %-52s %s\n' "$1" "$3"
+  else
+    printf '  FAIL  %-52s expected %s, got %s\n' "$1" "$2" "$3"
+    fails=$((fails + 1))
+  fi
+}
+
+# A stub `tofu`: INIT_EC controls `tofu init`, PLAN_EC controls `tofu plan`.
+mkdir -p "${WORK}/bin"
+cat > "${WORK}/bin/tofu" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  init) echo "stub: tofu init (exit ${INIT_EC:-0})"; exit "${INIT_EC:-0}" ;;
+  plan) echo "stub: tofu plan (exit ${PLAN_EC:-0})"; exit "${PLAN_EC:-0}" ;;
+  *)    exit 0 ;;
+esac
+STUB
+chmod +x "${WORK}/bin/tofu"
+export PATH="${WORK}/bin:${PATH}"
+
+mkdir -p "${WORK}/lane"
+
+run_new() { # run_new <init_ec> <plan_ec>  -> prints "<script_exit> <drift_output>"
+  local out="${WORK}/out.txt"
+  : > "$out"
+  ( INIT_EC="$1" PLAN_EC="$2" GITHUB_OUTPUT="$out" "$UNDER_TEST" testlane "${WORK}/lane" ) >/dev/null 2>&1
+  local ec=$?
+  local drift
+  drift="$(sed -n 's/^drift=//p' "$out" | tail -1)"
+  echo "${ec} ${drift:-<unset>}"
+}
+
+# The logic exactly as it stood before this change: plan under
+# `continue-on-error: true`, issue opened only when exitcode == '2'.
+run_old() { # run_old <init_ec> <plan_ec> -> prints "<job_result> <issue_opened>"
+  local out="${WORK}/old.txt"
+  : > "$out"
+  (
+    cd "${WORK}/lane" || exit 1
+    set +e
+    INIT_EC="$1" tofu init -reconfigure >/dev/null 2>&1
+    INIT_EC="$1" PLAN_EC="$2" tofu plan -detailed-exitcode -out=plan.tfplan 2>&1 | tee plan.txt >/dev/null
+    ec=${PIPESTATUS[0]}
+    set -e
+    echo "exitcode=${ec}" >> "$out"
+  )
+  local step_ec=$?
+  # continue-on-error: true meant the job was green whatever the step did.
+  local job="green"
+  [ "$step_ec" -eq 0 ] || job="green(masked)"
+  local captured
+  captured="$(sed -n 's/^exitcode=//p' "$out" | tail -1)"
+  local issue="no"
+  [ "${captured:-}" = "2" ] && issue="yes"
+  echo "${job} ${issue}"
+}
+
+echo "tofu-drift-plan.sh — exit-code mapping"
+check "clean      (init 0, plan 0) -> exit 0, drift=false" "0 false"    "$(run_new 0 0)"
+check "drift      (init 0, plan 2) -> exit 0, drift=true"  "0 true"     "$(run_new 0 2)"
+check "plan error (init 0, plan 1) -> exit 1, drift=unknown" "1 unknown" "$(run_new 0 1)"
+check "init error (init 1)         -> exit 1, drift=unknown" "1 unknown" "$(run_new 1 0)"
+check "odd code   (init 0, plan 9) -> exit 1, drift=unknown" "1 unknown" "$(run_new 0 9)"
+
+echo
+echo "previous logic on the same stubs — what this change fixes"
+check "OLD clean      -> green, no issue"        "green no"  "$(run_old 0 0)"
+check "OLD drift      -> green, issue opened"    "green yes" "$(run_old 0 2)"
+check "OLD plan error -> green, NO issue"        "green no"  "$(run_old 0 1)"
+check "OLD init error -> green, NO issue"        "green no"  "$(run_old 1 0)"
+
+echo
+if [ "$fails" -ne 0 ]; then
+  echo "FAILED: ${fails} assertion(s)." >&2
+  echo "The last two OLD rows are the defect: an error and a clean run produced" >&2
+  echo "an identical signal. The first block is what must keep them apart." >&2
+  exit 1
+fi
+echo "PASS: drift, error and clean are distinguishable; the previous logic conflated error with clean."

--- a/scripts/ci/tofu-drift-plan.sh
+++ b/scripts/ci/tofu-drift-plan.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Run `tofu plan -detailed-exitcode` for one cloud lane and map OpenTofu's three
+# outcomes onto three DISTINCT CI outcomes.
+#
+#   tofu exit 0  -> no drift                    -> exit 0, drift=false
+#   tofu exit 2  -> drift                       -> exit 0, drift=true   (issue opened)
+#   anything else, including a failed `tofu init`
+#                -> WE COULD NOT LOOK           -> exit 1, drift=unknown
+#
+# The third case is the whole point. infra-drift-detect.yml previously ran the
+# plan under `continue-on-error: true` and then opened an issue only when
+# `exitcode == '2'`. Exit 2 is drift, but exit 1 is *error* -- a failed init,
+# expired credentials, an unreachable provider. All of those produced a green
+# job and no issue, which is byte-for-byte the same signal as "no drift". The
+# estate's only multi-cloud drift detection reported "could not look" as
+# "nothing found".
+#
+# Usage: tofu-drift-plan.sh <lane-name> <working-directory>
+
+set -uo pipefail
+
+LANE="${1:?lane name required}"
+DIR="${2:?working directory required}"
+OUT="${GITHUB_OUTPUT:-/dev/stdout}"
+
+emit() { printf '%s=%s\n' "$1" "$2" >> "$OUT"; }
+
+fail() {
+  echo "::error title=drift check could not run::${LANE}: $1 Drift status is UNKNOWN, not clean." >&2
+  emit drift unknown
+  exit 1
+}
+
+cd "$DIR" || fail "working directory '${DIR}' does not exist."
+
+tofu init -reconfigure 2>&1 | tee init.txt
+init_ec="${PIPESTATUS[0]}"
+[ "$init_ec" -eq 0 ] || fail "tofu init exited ${init_ec}."
+
+tofu plan -detailed-exitcode -out=plan.tfplan 2>&1 | tee plan.txt
+ec="${PIPESTATUS[0]}"
+emit exitcode "$ec"
+
+case "$ec" in
+  0)
+    echo "${LANE}: no drift."
+    emit drift false
+    ;;
+  2)
+    echo "::warning title=infrastructure drift::${LANE} has diverged from live state."
+    emit drift true
+    ;;
+  *)
+    fail "tofu plan exited ${ec}."
+    ;;
+esac


### PR DESCRIPTION
All four cloud lanes ran the plan under `continue-on-error: true` and then opened an issue only `if: steps.plan.outputs.exitcode == '2'`. **Exit 2 is drift; exit 1 is error.** A failed init, expired credentials or a provider error gave a green job and no issue — the same signal as a clean plan — across `gcp-landing`, `aws-eks`, `azure-aks` and `ibm-iks`.

The plan logic moves into `scripts/ci/tofu-drift-plan.sh`, one implementation for all four lanes:

| `tofu` exit | meaning | result |
|---|---|---|
| 0 | clean | exit 0, `drift=false` |
| 2 | drift | exit 0, `drift=true`, issue opened |
| anything else | **could not look** | **exit 1**, `drift=unknown`, job RED |

`tofu init` is checked too. It previously ran *before* the `set +e`, so its failure left `steps.plan.outputs.exitcode` unset, the issue condition false, and `continue-on-error` kept the job green.

## Two further defects, without which none of the above would be observable

**This workflow has never executed a single step.** All 26 scheduled runs since it was created on 2026-07-03 are `startup_failure`:

```
$ gh api .../workflows/infra-drift-detect.yml/runs --jq '[.workflow_runs[].conclusion]|group_by(.)|map({(.[0]):length})|add'
{"startup_failure":26}
```

1. **`opentofu/setup-opentofu` is blocked by this repo's Actions allowlist.** `actions/permissions` is `allowed_actions: selected` with `github_owned_allowed`, `verified_allowed`, and `patterns_allowed: ["dtolnay/*","Swatinem/*","oven-sh/*","tauri-apps/*"]`. setup-opentofu is not github-owned, not in the patterns, and **not on the Marketplace at all** (`https://github.com/marketplace/actions/setup-opentofu` -> 404), so `verified_allowed` cannot cover it. The corroboration is `tofu-plan.yml`, which uses the same action: `{"success":2,"failure":6,"startup_failure":25}`, with the transition to `startup_failure` on **2026-06-23** and never a green run since. `infra-drift-detect.yml` was created after that date, which is why it is 26/26.

   All four pinned SHAs were checked and do resolve, and `opentofu/setup-opentofu@v1` points at exactly the pinned SHA — the pin was not the problem.

   Replaced by `scripts/ci/install-opentofu.sh`: downloads the pinned release and verifies it against a **committed sha256**, and refuses to install a version whose checksum is not in the file. Stronger than the action was — the checksum is reviewed in-tree and no third-party code runs with the workflow token.

2. **`environment: gcp-prod` does not exist.** The repo has exactly two environments, `copilot` and `gcp-plan`. `tofu-plan.yml` uses `gcp-plan`; this lane now does too.

## Red-then-green

`scripts/ci/test-tofu-drift-plan.sh` stubs `tofu`, needs no cloud access, and runs on every PR touching this machinery. It asserts the new mapping **and re-runs the previous inline logic against the same stubs**, so the conflation is recorded as a test rather than a claim:

```
tofu-drift-plan.sh — exit-code mapping
  ok    clean      (init 0, plan 0) -> exit 0, drift=false   0 false
  ok    drift      (init 0, plan 2) -> exit 0, drift=true    0 true
  ok    plan error (init 0, plan 1) -> exit 1, drift=unknown 1 unknown
  ok    init error (init 1)         -> exit 1, drift=unknown 1 unknown
  ok    odd code   (init 0, plan 9) -> exit 1, drift=unknown 1 unknown

previous logic on the same stubs — what this change fixes
  ok    OLD clean      -> green, no issue                    green no
  ok    OLD drift      -> green, issue opened                green yes
  ok    OLD plan error -> green, NO issue                    green no      <-- the defect
  ok    OLD init error -> green, NO issue                    green no      <-- the defect
```

Revert the `case` statement to the old "only 2 matters" behaviour:
```
  FAIL  plan error (init 0, plan 1) -> ... expected 1 unknown, got 0 false
  FAIL  odd code   (init 0, plan 9) -> ... expected 1 unknown, got 0 false
  EXIT=1
```
Remove the init guard:
```
  FAIL  init error (init 1)         -> ... expected 1 unknown, got 0 false
  EXIT=1
```
Restored: `EXIT=0`.

Installer, exercised for real (arm64 host, `sha256sum` shimmed to `shasum -a 256`):
- pinned download + verify -> `tofu_1.8.3_linux_arm64.zip: OK`
- committed checksum corrupted -> `FAILED / WARNING: 1 computed checksum did NOT match`, aborts
- `TOFU_VERSION=1.12.5` -> `::error title=unpinned OpenTofu::no committed sha256 …`, refuses

`actionlint` is clean on the rewritten workflow; `bash -n` clean on all three scripts.

## Deviation worth flagging

`tofu-plan.yml` has the identical `opentofu/setup-opentofu` blocker and is still fully inert. It is left alone here to keep this PR to the drift lane.