### PR TITLE
lattice-studio: the project name is a value, not query syntax

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -26,6 +26,7 @@ import os
 import re
 import uuid
 from datetime import datetime, timezone
+from urllib.parse import quote
 from typing import Any
 
 import httpx
@@ -138,7 +139,7 @@ async def studio(project: str = "default", _auth: dict[str, Any] | None = Depend
             _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/stats"),
             _req(client, "GET", f"{TRITFABRIC_URL}/v1/registry"),
             _req(client, "POST", f"{SEARCH_ORCH_URL}/v0/search/query", json=_sherlock_request(project)),
-            _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit=300"),
+            _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit=300"),
             _req(client, "GET", f"{EVIDENCE_RECEIPTS_URL}/v1/receipts/recent?service=hellgraph-service&limit=10"),
         )
     degraded = {k: v for k, v in {"graph": gerr, "models": rerr, "extraction": serr}.items() if v}
@@ -333,7 +334,7 @@ async def query(req: QueryRequest, _auth: dict[str, Any] | None = Depends(requir
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
         (res, err), (subg, _s) = await asyncio.gather(
             _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/{lang}", json=body),
-            _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit=500"),
+            _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit=500"),
         )
     if not isinstance(res, dict):
         raise HTTPException(status_code=400, detail=f"query failed: {err or 'no result from kernel'}")
@@ -370,7 +371,7 @@ def _safe_json(s: Any) -> Any:
 async def _fetch_raw_nodes(coll: str, limit: int = 500) -> tuple[list[dict[str, Any]], str | None]:
     """Raw project nodes (properties preserved — unlike _map_node, which projects to a fixed field set)."""
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit={limit}")
+        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}")
     raw = (res.get("nodes") if isinstance(res, dict) else None) or []
     return (raw if isinstance(raw, list) else []), err
 
@@ -1129,7 +1130,7 @@ async def perspectives(project: str = "default",
 async def _fetch_graph(coll: str, limit: int = 2000) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str | None]:
     """Project subgraph as (nodes, edges, err). Edges carry {from, to, label} — used for lineage walks."""
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit={limit}")
+        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}")
     nodes = (res.get("nodes") if isinstance(res, dict) else None) or []
     edges = (res.get("edgeList") if isinstance(res, dict) else None) or []
     return (nodes if isinstance(nodes, list) else []), (edges if isinstance(edges, list) else []), err
@@ -3020,7 +3021,7 @@ async def _fetch_subgraph(coll: str, limit: int = 200) -> tuple[list[dict[str, A
     explorer draws real topology — not a chip-cloud — and every node still carries its provenance.
     """
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit={limit}")
+        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}")
     raw_nodes = res.get("nodes", []) if isinstance(res, dict) else []
     raw_edges = res.get("edgeList", []) if isinstance(res, dict) else []
     nodes = [_map_node(n) for n in (raw_nodes if isinstance(raw_nodes, list) else [])[:limit]]
@@ -3048,7 +3049,7 @@ async def documents(project: str = "default", limit: int = 500, doc_sha: str = "
     not a node soup. Pass doc_sha to get one document's node ids (the explorer filter)."""
     coll = proj_collection(project)
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit={limit}")
+        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}")
     raw_nodes = res.get("nodes", []) if isinstance(res, dict) else []
     raw_edges = res.get("edgeList", []) if isinstance(res, dict) else []
     docs: dict[str, dict[str, Any]] = {}

--- a/apps/lattice-studio/tests/test_upstream_url_encoding.py
+++ b/apps/lattice-studio/tests/test_upstream_url_encoding.py
@@ -1,0 +1,81 @@
+"""The project name reaches hellgraph as a VALUE, never as query syntax.
+
+Copilot #964 (server.py:3052), unanswered: `coll` is derived from the caller-controlled
+`project` and interpolated straight into the upstream query string. proj_collection()
+strips dashes and truncates to 12 characters but does not restrict the character set, so
+`&`, `=` and `#` survive into the URL:
+
+    project="&limit=99999"
+      -> coll="proj-&limit=99999"
+      -> GET /api/graph/subgraph?label=proj-&limit=99999&limit=500
+
+which hands the caller control of an upstream parameter the endpoint never meant to
+expose. Percent-encoding at the boundary fixes it without touching proj_collection() —
+that mapping mirrors Noetica's projectCollectionId, and changing it would silently query
+a different collection than Noetica writes to.
+"""
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+import lattice_studio.server as srv
+
+
+CAPTURED: list[str] = []
+
+
+@pytest.fixture(autouse=True)
+def capture_upstream(monkeypatch):
+    """Record every upstream URL and answer nothing, so only URL construction is under test."""
+    CAPTURED.clear()
+
+    async def fake_req(client, method, url, json=None):
+        CAPTURED.append(url)
+        return None, "stubbed"
+
+    monkeypatch.setattr(srv, "_req", fake_req)
+    yield
+
+
+def _subgraph_urls() -> list[str]:
+    return [u for u in CAPTURED if "/api/graph/subgraph" in u]
+
+
+@pytest.mark.parametrize("project", [
+    "&limit=99999",
+    "x&debug=1",
+    "#frag",
+    "a=b&c=d",
+    "?x=1",
+])
+def test_a_hostile_project_name_cannot_inject_an_upstream_parameter(project):
+    from fastapi.testclient import TestClient
+
+    client = TestClient(srv.app)
+    client.get("/api/studio/documents", params={"project": project})
+
+    urls = _subgraph_urls()
+    assert urls, "expected the documents view to call /api/graph/subgraph"
+    for url in urls:
+        q = parse_qs(urlparse(url).query, keep_blank_values=True)
+        # The caller's text must appear as the VALUE of label and nowhere else.
+        assert set(q) <= {"label", "limit"}, f"injected parameter(s) {set(q) - {'label', 'limit'}} in {url}"
+        assert q.get("limit") == ["500"], f"limit was overridden: {q.get('limit')} in {url}"
+        assert len(q.get("label", [])) == 1, f"label split into multiple values in {url}"
+        assert urlparse(url).fragment == "", f"a fragment truncated the query: {url}"
+
+
+def test_the_ordinary_project_name_is_unchanged_on_the_wire():
+    """Encoding must not alter the collection actually queried — proj_collection() mirrors
+    Noetica's projectCollectionId, and a changed value would query the wrong collection."""
+    from fastapi.testclient import TestClient
+
+    client = TestClient(srv.app)
+    client.get("/api/studio/documents", params={"project": "default"})
+
+    urls = _subgraph_urls()
+    assert urls
+    q = parse_qs(urlparse(urls[0]).query)
+    assert q["label"] == [srv.proj_collection("default")] == ["proj-default"]


### PR DESCRIPTION
[Copilot #964, `server.py:3052`](https://github.com/SocioProphet/prophet-platform/pull/964#discussion_r3631541367) — unanswered, and still live on `main`.

`coll` is derived from the caller-controlled `project` and interpolated straight into the upstream query string. `proj_collection()` strips dashes and truncates to 12 characters but does not restrict the character set, so `&`, `=` and `#` survive into the URL:

```
project="&limit=99999"
  -> coll="proj-&limit=99999"
  -> GET /api/graph/subgraph?label=proj-&limit=99999&limit=500
```

The caller controls an upstream parameter the endpoint never meant to expose, and a `#` truncates the query at a fragment. Six call sites, all the same shape.

## Why the fix is at the boundary, not in `proj_collection()`

Sanitising `proj_collection()` looks tidier and is the wrong move: that mapping mirrors Noetica's `projectCollectionId`, so changing it would make lattice-studio query a *different collection* than Noetica writes to — trading a bounded injection for a silent join break. `quote(coll, safe='')` changes only the wire encoding; the collection actually queried is byte-identical, which one of the tests asserts.

## Severity, stated honestly

`/api/studio/documents` is behind `require_read`, the injected span is capped at 12 characters, and the target is an internal service. This is a real parameter injection, not a critical one. Worth fixing because it is cheap and unambiguous, not because it is an emergency.

## One thing worth a reviewer's eye

Single quotes inside the f-string are deliberate — nested double quotes are PEP 701 (Python 3.12+), and this package declares `requires-python = ">=3.11"`, which is also what the CI matrix pins. I verified it compiles under 3.11.15; the double-quoted form would have been a syntax error in CI.

## Revert-proof

`apps/lattice-studio/tests/test_upstream_url_encoding.py`, 6 cases. Against the old interpolation:

```
FAILED ...[&limit=99999]
FAILED ...[x&debug=1]
FAILED ...[#frag]
FAILED ...[a=b&c=d]
4 failed, 2 passed
```

The 2 that pass are the ones asserting unchanged behaviour (`?x=1`, which is not a separator inside a query, and the ordinary-name case).

Full suite: `253 passed, 4 failed` — all four are missing local deps (`pypdf`, `docx`, `pyshacl`) and fail identically on unmodified `main`.

## Note

`apps/lattice-studio` is **not in the app-test matrix**, so this suite does not run in CI. I did not add it here: unlike arcticdb-gateway (added in #1087), lattice-studio has pre-existing failures that would land a red leg. That wiring needs its own pass.

Do not merge on my account — flagging for review.
