### PR TITLE
health-twin: the rejection ledger was a side door around the grant scope

### DIFF
--- a/apps/health-twin/package.json
+++ b/apps/health-twin/package.json
@@ -8,7 +8,10 @@
     "tsx": "^4.19.2"
   },
   "scripts": {
-    "test": "node --import tsx --test src/*.test.ts"
+    "test": "node --import tsx --test src/*.test.ts",
+    "invariants": "tsx src/invariants.ts",
+    "eval": "tsx src/eval.ts",
+    "smoke:ledger-scope": "tsx src/dynamics/ledger-scope.smoke.ts"
   },
   "devDependencies": {}
 }

--- a/apps/health-twin/src/dynamics/gate.ts
+++ b/apps/health-twin/src/dynamics/gate.ts
@@ -85,7 +85,13 @@ export const RULES: AdmissibilityRule[] = [
     bound: 'proposed ≤ sbpUntreated(t) + tol' },
   { reason: 'monotonicity', compartments: ['renal'],
     law: 'Functioning nephron mass does not regenerate on this horizon, so eGFR is non-increasing under the model.',
-    bound: 'proposed ≤ previousAccepted + tol' },
+    // `previousEmitted`, NOT `previousAccepted` — and the difference is load-bearing, not pedantic.
+    // The bound is the last value the twin actually EMITTED, which after a refusal is the mechanistic
+    // fallback. Bounding against the last ACCEPTED value would leave the rule undefined for a run whose
+    // proposals were all refused, and would compare the trajectory against a point the twin never
+    // published. RULES is served verbatim at GET /api/health/dynamics as inspectable policy, so the
+    // text has to name the quantity the code actually reads.
+    bound: 'proposed ≤ previousEmitted + tol' },
   { reason: 'rate', compartments: ['cardio', 'hepatic', 'renal'],
     law: 'The observable cannot move faster over a step than a chronic trajectory permits.',
     bound: `|Δ|/Δt ≤ ${MAX_RATE_PER_DAY.cardio} mmHg/d · ${MAX_RATE_PER_DAY.hepatic} %/d · ${MAX_RATE_PER_DAY.renal} mL/min/d` },
@@ -288,10 +294,21 @@ export function recordRejections(predictionId: string, decisions: GateDecision[]
   return recs;
 }
 
-export function rejectionLedger(limit = 100): { count: number; rejections: RejectionRecord[]; byReason: Record<string, number> } {
+/**
+ * Read the ledger, optionally restricted to a set of compartments.
+ *
+ * 🔴 A ledger entry is NOT policy. It carries `mechanistic`, `proposed`, `delta`, `emitted` and the
+ * measured violation — real physiological values for the person the prediction was anchored to. So a
+ * caller holding a cardiovascular grant must not read renal entries, or the ledger becomes the side
+ * door around the consent scope that /predict is careful to close. `only` is that scope, and the
+ * count and the reason histogram are recomputed OVER THE SCOPED SET: a total taken across the whole
+ * ledger would itself disclose that out-of-scope refusals happened.
+ */
+export function rejectionLedger(limit = 100, only?: readonly Compartment[]): { count: number; rejections: RejectionRecord[]; byReason: Record<string, number> } {
+  const scoped = only ? LEDGER.filter((r) => only.includes(r.compartment)) : LEDGER;
   const byReason: Record<string, number> = {};
-  for (const r of LEDGER) byReason[r.reason!] = (byReason[r.reason!] ?? 0) + 1;
-  return { count: LEDGER.length, rejections: LEDGER.slice(0, limit), byReason };
+  for (const r of scoped) byReason[r.reason!] = (byReason[r.reason!] ?? 0) + 1;
+  return { count: scoped.length, rejections: scoped.slice(0, limit), byReason };
 }
 
 /** Test-only: reset the ledger between harness scenarios. */

--- a/apps/health-twin/src/dynamics/ledger-scope.smoke.ts
+++ b/apps/health-twin/src/dynamics/ledger-scope.smoke.ts
@@ -1,0 +1,139 @@
+/**
+ * BOOT SMOKE — the rejection ledger is scoped by the grant, at the HTTP surface.
+ *
+ * invariants.ts proves `rejectionLedger(limit, only)` filters correctly as a FUNCTION. That is not
+ * the same claim as "the endpoint scopes". The leak this closes lived in the handler, not in the
+ * ledger: `GET /api/health/dynamics/rejections` called `rejectionLedger(limit)` with no `only`, so a
+ * clinician holding a cardiovascular-only grant — refused the renal forecast at /predict — could
+ * read the renal trajectory out of the refusals instead. A port that moved the filter into gate.ts
+ * but left the handler calling it unscoped would pass every unit invariant and still leak. So this
+ * boots the real server and asks the real endpoint.
+ *
+ * The refusals are driven through the ORDINARY PUBLIC PATH: `covariates` is caller-supplied on
+ * POST /predict, so an unprivileged request drives the surrogate across the admissibility bounds
+ * and fills the ledger across all three compartments. Nothing test-only is reachable here — the
+ * overrideDelta hook is deliberately not wired to the network — which is precisely why the ledger
+ * is a real disclosure surface and not a debug artefact.
+ *
+ * TEETH BOTH WAYS. A scoping test that only asserts refusals is indistinguishable from an endpoint
+ * that is simply broken, so the full-scope and no-grant reads must still return everything.
+ *
+ * Run: npx tsx src/dynamics/ledger-scope.smoke.ts
+ */
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const PORT = Number(process.env.SMOKE_PORT ?? 8231);
+const BASE = `http://127.0.0.1:${PORT}`;
+const here = dirname(fileURLToPath(import.meta.url));
+const serverEntry = resolve(here, '../server.ts');
+
+let fails = 0;
+const ok = (cond: boolean, label: string) => {
+  console.log(`  ${cond ? '✓' : '✗'} ${label}`);
+  if (!cond) fails++;
+};
+
+const j = async (path: string, init?: RequestInit) => {
+  const res = await fetch(`${BASE}${path}`, init);
+  let body: any = null;
+  try { body = await res.json(); } catch { /* non-JSON is a body of null, status still asserted */ }
+  return { status: res.status, body };
+};
+
+const grant = async (agent: string, scopeSpec: unknown) =>
+  (await j('/api/health/grant', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ agent, scope: 'custom', scopeSpec }),
+  })).body?.grant?.id as string;
+
+const child = spawn('npx', ['tsx', serverEntry], {
+  env: { ...process.env, PORT: String(PORT) },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+let serverLog = '';
+child.stdout.on('data', (d) => { serverLog += d; });
+child.stderr.on('data', (d) => { serverLog += d; });
+
+const shutdown = () => { try { child.kill('SIGKILL'); } catch { /* already gone */ } };
+process.on('exit', shutdown);
+
+try {
+  // wait for listen
+  let up = false;
+  for (let i = 0; i < 120 && !up; i++) {
+    try { up = (await fetch(`${BASE}/healthz`)).ok; } catch { await new Promise((r) => setTimeout(r, 250)); }
+  }
+  if (!up) { console.error('server never came up:\n' + serverLog); shutdown(); process.exit(1); }
+
+  console.log('\n▶ BOOT SMOKE — the rejection ledger is scoped by grant at the HTTP surface');
+
+  // Fill the ledger across all three compartments through the public predict path.
+  await j('/api/health/predict', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      horizonDays: 365, stepDays: 30,
+      covariates: { adherencePdc: 0, reninIndex: 50, bmi: 90, uacr: 9000 },
+    }),
+  });
+
+  // ── UNSCOPED (no grant): the operator view. Everything, as before. ────────────────────────────
+  const all = await j('/api/health/dynamics/rejections');
+  const organs = new Set<string>((all.body?.rejections ?? []).map((r: any) => r.compartment));
+  ok(all.status === 200 && all.body.count > 0, `an ungranted read still returns the ledger (${all.body?.count} refusals)`);
+  ok(organs.has('cardio') && organs.has('hepatic') && organs.has('renal'),
+     `the unscoped ledger spans every compartment (${[...organs].sort().join(', ')})`);
+
+  // ── CARDIOVASCULAR-ONLY GRANT: cardio entries only, totals recomputed. ────────────────────────
+  const cardioGrant = await grant('dr-cardio', { systems: ['cardiovascular'], kinds: 'all', lookbackDays: null });
+  const scoped = await j(`/api/health/dynamics/rejections?grant=${cardioGrant}`);
+  const sBody = scoped.body ?? {};
+  const sOrgans = new Set<string>((sBody.rejections ?? []).map((r: any) => r.compartment));
+  ok(scoped.status === 200, 'a cardiovascular grant may read the ledger');
+  ok(sOrgans.size === 1 && sOrgans.has('cardio'),
+     `a cardiovascular-only grant sees ONLY cardiovascular refusals (${[...sOrgans].join(', ') || 'none'})`);
+  ok(sBody.count === (sBody.rejections ?? []).length && sBody.count < all.body.count,
+     `count is recomputed over the scoped set (${sBody.count}, not the whole-ledger ${all.body.count})`);
+  ok(Object.values(sBody.byReason ?? {}).reduce((a: number, b: any) => a + b, 0) === sBody.count,
+     'byReason sums to the scoped count — the histogram discloses no out-of-scope refusal');
+  // the renal trajectory must not be reconstructable from anything in the response
+  ok(!JSON.stringify(sBody.rejections ?? []).includes('renal') && !('renal' in (sBody.byReason ?? {})),
+     'no renal value appears anywhere in the scoped response — the /predict refusal cannot be walked around');
+  ok(Array.isArray(sBody.grant?.withheldSystems) && sBody.grant.withheldSystems.length > 0,
+     `the response NAMES what was withheld rather than silently omitting it (${JSON.stringify(sBody.grant?.withheldSystems)})`);
+
+  // ── A GRANT WITH NO COMPARTMENT IN SCOPE: 403, not an empty 200. ──────────────────────────────
+  // An empty ledger and a refused read are different facts, and a 200 with count:0 would assert the
+  // first while meaning the second — the caller would conclude the twin had refused nothing.
+  const outOfScope = await grant('dr-derm', { systems: ['integumentary'], kinds: 'all', lookbackDays: null });
+  const denied = await j(`/api/health/dynamics/rejections?grant=${outOfScope}`);
+  ok(denied.status === 403, `a grant with no compartment in scope is refused 403 (got ${denied.status})`);
+  ok(denied.body?.blocked === true && typeof denied.body?.reason === 'string',
+     'the refusal is explicit and states a reason');
+  ok(denied.body?.rejections === undefined && denied.body?.count === undefined,
+     'the 403 carries no ledger content and no whole-ledger total');
+
+  // ── AN UNKNOWN / REVOKED GRANT: 403 with a receipt. ───────────────────────────────────────────
+  const bogus = await j('/api/health/dynamics/rejections?grant=grant-does-not-exist');
+  ok(bogus.status === 403 && bogus.body?.receipt, 'an unknown grant is refused 403 and the refusal is receipted');
+
+  // ── TEETH THE OTHER WAY — a full-scope grant still sees everything. ───────────────────────────
+  const fullGrant = await grant('dr-full', { systems: 'all', kinds: 'all', lookbackDays: null });
+  const fullRead = await j(`/api/health/dynamics/rejections?grant=${fullGrant}`);
+  const fOrgans = new Set<string>((fullRead.body?.rejections ?? []).map((r: any) => r.compartment));
+  ok(fullRead.status === 200 && fullRead.body.count === all.body.count,
+     `a full-scope grant still sees the whole ledger (${fullRead.body?.count} of ${all.body.count})`);
+  ok(fOrgans.has('cardio') && fOrgans.has('hepatic') && fOrgans.has('renal'),
+     'a full-scope grant sees every compartment — the gate is scoping, not just refusing');
+
+  console.log(`\n${fails === 0 ? '✓ THE REJECTION LEDGER IS GRANT-SCOPED AT THE ENDPOINT' : `✗ ${fails} scoped-ledger assertion(s) failed`}`);
+} catch (e) {
+  console.error('smoke failed:', e, '\n--- server log ---\n' + serverLog);
+  fails++;
+} finally {
+  shutdown();
+}
+process.exit(fails === 0 ? 0 : 1);

--- a/apps/health-twin/src/eval.ts
+++ b/apps/health-twin/src/eval.ts
@@ -12,7 +12,8 @@ import { guidance } from './guidelines.js';
 import { ground } from './knowledge.js';
 import { buildCohort, mechanisticFor, SAMPLE_DAYS, HORIZON_DAYS } from './dynamics/cohort.js';
 import { fitSurrogate, proposeDelta } from './dynamics/surrogate.js';
-import { OBSERVABLE, type Compartment } from './dynamics/mechanistic.js';
+import { OBSERVABLE, anchorTo, simulate, observableOf, DEFAULT_PARAMS, type Compartment } from './dynamics/mechanistic.js';
+import { reconcile } from './dynamics/gate.js';
 
 interface Gold { code: string; negated: boolean; value?: string }
 interface Case { text: string; gold: Gold[] }
@@ -84,27 +85,56 @@ function evalGrounding() {
   return { hit, total: cases.length, acc: hit / cases.length };
 }
 
-// twin dynamics: mechanistic-alone vs mechanistic + gated learned residual, on HELD-OUT synthetic
+// twin dynamics: mechanistic-alone vs mechanistic + GATED learned residual, on HELD-OUT synthetic
 // subjects the surrogate was never fitted on. 🔴 The cohort is SYNTHETIC and its ground truth is a
 // superset of the mechanistic model, so this measures that the residual machinery extracts real signal
 // from covariates the ODE does not consume. It is NOT clinical validation and must never be quoted as
 // such. Renal is expected NOT to improve — see the note by its floor.
-function evalDynamics() {
+//
+// 🔴 THE RESIDUAL IS SCORED THROUGH THE REAL GATE. This previously computed `m + proposeDelta(...)`
+// while reporting "gated", which measured a path predict() never takes. It happened to agree — the
+// gate refuses nothing on this cohort — but "the number was right by coincidence" is not the same
+// claim as "the number is right", and the gate is the entire safety argument for shipping a learned
+// term at all. A floor that scores the ungated surrogate would keep passing through exactly the
+// regression the gate exists to catch: a surrogate that drifts into inadmissible proposals would score
+// on its raw output while the twin emitted the physics.
+//
+// So `reconcile()` — the same function predict() calls — adjudicates every step, `previousEmitted`
+// chains across the horizon exactly as it does in a real run, and the reported RMSE is over what the
+// twin WOULD ACTUALLY EMIT. The ungated figure is reported alongside it, and any divergence between
+// the two is printed rather than left for a reader to assume away.
+function evalDynamics(amplify = 1) {
   const sur = fitSurrogate();
   const test = buildCohort().filter((s) => s.split === 'test');
-  const out: Record<string, { rmseM: number; rmseR: number; gain: number; n: number }> = {};
+  const out: Record<string, { rmseM: number; rmseR: number; rmseUngated: number; gain: number; n: number; accepted: number; rejected: number; byReason: Record<string, number> }> = {};
   for (const k of ['cardio', 'hepatic', 'renal'] as Compartment[]) {
-    let seM = 0, seR = 0, n = 0;
+    let seM = 0, seR = 0, seU = 0, n = 0, accepted = 0, rejected = 0;
+    const byReason: Record<string, number> = {};
     for (const s of test) {
       const mech = mechanisticFor(s)[k];
+      // the gate reads the full mechanistic state (untreated path, τ_rbc, …), not just the observable
+      const params = anchorTo(s.baseline, DEFAULT_PARAMS);
+      const run = simulate(HORIZON_DAYS, params);
+      let previousEmitted = observableOf(run.steps[0]!, k);
       SAMPLE_DAYS.forEach((d, i) => {
         const y = s.truth[k][i]!, m = mech[i]!;
-        const r = m + proposeDelta(sur, k, s.covariates, d / HORIZON_DAYS);
-        seM += (y - m) ** 2; seR += (y - r) ** 2; n++;
+        const delta = proposeDelta(sur, k, s.covariates, d / HORIZON_DAYS) * amplify;
+        const decision = reconcile({
+          compartment: k, day: d, dtDays: d - (i === 0 ? 0 : SAMPLE_DAYS[i - 1]!),
+          mechanistic: m, previousEmitted, proposed: m + delta, delta,
+          step: run.steps[d]!, params,
+        });
+        if (decision.verdict === 'rejected') { rejected++; byReason[decision.reason!] = (byReason[decision.reason!] ?? 0) + 1; }
+        else accepted++;
+        seM += (y - m) ** 2;
+        seR += (y - decision.emitted) ** 2;   // what the twin would actually emit
+        seU += (y - (m + delta)) ** 2;        // what the surrogate wanted, ungoverned
+        previousEmitted = decision.emitted;
+        n++;
       });
     }
-    const rmseM = Math.sqrt(seM / n), rmseR = Math.sqrt(seR / n);
-    out[k] = { rmseM, rmseR, gain: 1 - rmseR / rmseM, n };
+    const rmseM = Math.sqrt(seM / n), rmseR = Math.sqrt(seR / n), rmseUngated = Math.sqrt(seU / n);
+    out[k] = { rmseM, rmseR, rmseUngated, gain: 1 - rmseR / rmseM, n, accepted, rejected, byReason };
   }
   return out;
 }
@@ -122,12 +152,43 @@ console.log(`  Value extraction  accuracy  ${pct(cod.valAcc)}`);
 console.log(`  Guideline firing  ${gud.hit}/${gud.want}  ${pct(gud.acc)}`);
 console.log(`  Grounding source  ${grd.hit}/${grd.total}  ${pct(grd.acc)}   (right authoritative source cited)`);
 console.log('  (measures OUR capabilities — coding/negation/values/guidance/grounding — not full clinical QA)');
-console.log('\n  Twin dynamics — held-out RMSE, mechanistic alone → mechanistic + gated learned residual');
+console.log('\n  Twin dynamics — held-out RMSE, mechanistic alone → mechanistic + GATED learned residual');
+console.log('    (scored through reconcile() — the same gate predict() runs, so this is what the twin would emit)');
 for (const k of ['cardio', 'hepatic', 'renal'] as Compartment[]) {
   const d = dyn[k]!;
-  console.log(`    ${k.padEnd(8)} ${d.rmseM.toFixed(4)} → ${d.rmseR.toFixed(4)} ${OBSERVABLE[k].unit.padEnd(7)} ${d.gain >= 0 ? pct(d.gain) + ' better' : pct(-d.gain) + ' WORSE'}   (n=${d.n} held-out points)`);
+  console.log(`    ${k.padEnd(8)} ${d.rmseM.toFixed(4)} → ${d.rmseR.toFixed(4)} ${OBSERVABLE[k].unit.padEnd(7)} ${d.gain >= 0 ? pct(d.gain) + ' better' : pct(-d.gain) + ' WORSE'}   (n=${d.n} held-out points · gate accepted ${d.accepted}/${d.n}${d.rejected ? ` · refused ${JSON.stringify(d.byReason)}` : ''})`);
+}
+// State the gate's effect out loud. If it refused nothing, the gated and ungated numbers coincide and
+// the reader is entitled to know that this figure is the gate's BEST case rather than a test of it —
+// the teeth are proven separately, by verify.ts and INVARIANT 7. If it ever starts refusing, the
+// divergence prints here instead of hiding inside a single RMSE.
+const totalRejected = (['cardio', 'hepatic', 'renal'] as Compartment[]).reduce((a, k) => a + dyn[k]!.rejected, 0);
+if (totalRejected === 0) {
+  console.log('    gate refused 0/'
+    + (['cardio', 'hepatic', 'renal'] as Compartment[]).reduce((a, k) => a + dyn[k]!.n, 0)
+    + ' proposals on this cohort — every proposal was admissible, so the gated and ungated residuals coincide here.');
+} else {
+  for (const k of ['cardio', 'hepatic', 'renal'] as Compartment[]) {
+    const d = dyn[k]!;
+    if (d.rejected) console.log(`    ${k}: gate refused ${d.rejected}/${d.n} — ungated RMSE would read ${d.rmseUngated.toFixed(4)} (${pct(1 - d.rmseUngated / d.rmseM)}), gated reads ${d.rmseR.toFixed(4)} (${pct(d.gain)}).`);
+  }
 }
 console.log('    🔴 SYNTHETIC cohort — measures that the residual extracts signal the ODE ignores, NOT clinical validity.');
+
+// GATE-WIRING SELF-CHECK. The gate refuses nothing on this cohort, so "scored through the gate" and
+// "scored without one" print the same number — which means a future edit could unwire reconcile()
+// here and every floor would stay green. That is precisely the silent-wrong shape this estate keeps
+// finding, so the wiring is PROVEN rather than trusted: re-score with a deliberately inadmissible
+// residual and require the gate to refuse it and to hold the emitted trajectory at the physics. If
+// this check ever passes trivially, the eval is no longer measuring what it says it measures.
+const probe = evalDynamics(40);
+const probeRejected = (['cardio', 'hepatic', 'renal'] as Compartment[]).reduce((a, k) => a + probe[k]!.rejected, 0);
+const gateBites = probeRejected > 0
+  && probe.cardio!.rmseR < probe.cardio!.rmseUngated
+  && probe.cardio!.rmseR <= probe.cardio!.rmseM * 1.0001;   // all-refused ⇒ the emitted path IS the physics
+console.log(`\n  Gate wiring self-check — amplified (×40) residual: gate refused ${probeRejected}/${probe.cardio!.n * 3}`);
+console.log(`    cardio ungated RMSE would be ${probe.cardio!.rmseUngated.toFixed(4)}; through the gate it is ${probe.cardio!.rmseR.toFixed(4)} (physics = ${probe.cardio!.rmseM.toFixed(4)}).`);
+console.log(`    ${gateBites ? '✓ the gate is live in this eval — an inadmissible residual is refused and the physics is emitted' : '✗ THE GATE IS NOT WIRED INTO THIS EVAL — the reported numbers do not measure what they claim'}`);
 
 // quality floors — the build fails if we regress below these
 const floors = { f1: 0.85, negAcc: 0.9, valAcc: 0.9, guidance: 1.0, grounding: 1.0, cardioGain: 0.20, hepaticGain: 0.15, renalNoHarm: -0.02 };
@@ -144,5 +205,8 @@ if (dyn.hepatic!.gain < floors.hepaticGain) fails.push(`hepatic residual gain ${
 // learn. That is a property of the observable, and the honest response is to say so in the floor rather
 // than to lengthen the horizon or shrink the noise until the number flatters us.
 if (dyn.renal!.gain < floors.renalNoHarm) fails.push(`renal residual DEGRADED fit by ${pct(-dyn.renal!.gain)}`);
+// The gate is the whole safety argument for shipping a learned term, so an eval that has stopped
+// exercising it is a failed eval, not a passing one.
+if (!gateBites) fails.push('the reconciliation gate is not wired into the dynamics eval (it refused nothing even for a ×40 inadmissible residual)');
 console.log(fails.length ? `\n✗ below floor: ${fails.join(' · ')}` : '\n✓ all metrics above floor');
 process.exit(fails.length ? 1 : 0);

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -452,6 +452,39 @@ console.log('\n▶ INVARIANT 7 — twin dynamics: physics disposes, and a refusa
   const allowedDyn = (['cardio', 'hepatic', 'renal'] as const).filter((k) => cardioOnly.systems.includes(COMPARTMENT_SYSTEM[k]));
   ok(resolvedDyn.ok === true && allowedDyn.length === 1 && allowedDyn[0] === 'cardio',
     'a cardiovascular-only grant admits exactly the cardio compartment (hepatic + renal stay outside)');
+
+  // 7e. THE REJECTION LEDGER IS RECORD CONTENT, AND IT IS SCOPED LIKE ONE.
+  // Every entry carries mechanistic / proposed / delta / emitted — the person's own trajectory in
+  // mmHg, % and mL/min. The endpoint shipped ungated and unscoped, so a clinician refused the renal
+  // forecast at /predict could have reconstructed it by reading the refusals instead. Scoping the
+  // ledger closes that side door, and the count and histogram are recomputed over the scoped set —
+  // a total taken across the whole ledger would itself disclose that out-of-scope refusals happened.
+  _clearLedger();
+  predict({ overrideDelta: () => -100 });               // force refusals in ALL THREE compartments
+  const full = rejectionLedger(500);
+  const scoped = rejectionLedger(500, ['cardio']);
+  ok(full.rejections.some((r) => r.compartment === 'renal') && full.rejections.some((r) => r.compartment === 'hepatic'),
+    `the unscoped ledger holds every compartment (${full.count} refusals across ${new Set(full.rejections.map((r) => r.compartment)).size} organs)`);
+  ok(scoped.rejections.every((r) => r.compartment === 'cardio'),
+    'a cardio-scoped ledger read returns cardio entries ONLY — the renal trajectory is not readable through the refusals');
+  ok(scoped.count === scoped.rejections.length && scoped.count < full.count,
+    `the scoped count is recomputed over the scoped set (${scoped.count} of ${full.count}), not leaked as a whole-ledger total`);
+  ok(Object.values(scoped.byReason).reduce((a, b) => a + b, 0) === scoped.count,
+    'the scoped reason histogram sums to the scoped count — no out-of-scope refusal is counted');
+  // and the values really are record content, so the scoping is load-bearing rather than tidy
+  ok(full.rejections.every((r) => typeof r.mechanistic === 'number' && typeof r.emitted === 'number'),
+    'a ledger entry does carry physiological values (which is WHY it is gated and scoped)');
+  _clearLedger();
+
+  // 7f. DECLARED == ENFORCED. RULES is served verbatim at GET /api/health/dynamics as inspectable
+  // policy, so a rule whose text names a different quantity than the code reads is a documented lie
+  // on a PHI surface. The renal bound said `previousAccepted` while the gate read `previousEmitted`.
+  const { RULES } = await import('./dynamics/gate.js');
+  const renalMono = RULES.find((r) => r.reason === 'monotonicity' && r.compartments.includes('renal'))!;
+  ok(/previousEmitted/.test(renalMono.bound) && !/previousAccepted/.test(renalMono.bound),
+    `the renal monotonicity bound names the quantity the gate actually reads (${renalMono.bound})`);
+  ok(RULES.every((r) => !/previousAccepted/.test(r.bound)),
+    'no published rule bound names a quantity the gate does not read');
 }
 
 console.log('\n▶ INVARIANT 9 — a grant id is not a credential: the holder is authenticated, both ways');

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -728,10 +728,38 @@ const server = http.createServer(async (req, res) => {
   }
 
   // The rejection ledger. A refusal nobody can see may as well have been a silent clamp, so the refusals
-  // are a first-class readable surface — not a log line. Decisions and bounds only, never record content.
+  // are a first-class readable surface — not a log line.
+  //
+  // 🔴 A ledger entry IS record content. An earlier comment here claimed "decisions and bounds only,
+  // never record content" and that was simply false: every entry carries the mechanistic value, the
+  // proposal, the delta and the emitted value — the person's own trajectory in mmHg, % and mL/min. So
+  // the SAME TWO MEMBRANES that guard /predict guard this, for the same two reasons:
+  //   • EXPOSURE, because these are record-derived numbers and this endpoint is reachable cross-origin;
+  //   • the GRANT scope, because a clinician holding a cardiovascular grant must not learn the renal
+  //     trajectory — and would have, by reading the refusals instead of asking for the prediction.
+  // Without both, a caller refused at /predict could reconstruct what it was refused, one rejection at
+  // a time, which is exactly the bypass the grant scope exists to prevent.
   if (req.method === 'GET' && url.pathname === '/api/health/dynamics/rejections') {
+    const denied = denyExposure(req);
+    if (denied) return send(res, denied.code, denied.body);
     const limit = Math.max(1, Math.min(500, Number(url.searchParams.get('limit') ?? 100)));
-    return send(res, 200, { ...rejectionLedger(limit), law: gatePolicy().doctrine });
+
+    const gid = url.searchParams.get('grant');
+    let only: Compartment[] | undefined;
+    let withheldSystems: string[] = [];
+    if (gid) {
+      const r = resolveGrant(grants, String(gid));
+      if (!r.ok) return send(res, 403, { blocked: true, reason: r.reason, receipt: receipt('rejections-blocked', [String(gid), r.reason]) });
+      const scope = r.grant.scopeSpec ?? resolveScope(r.grant.scope);
+      only = COMPARTMENTS.filter((k) => scope.systems === 'all' || scope.systems.includes(COMPARTMENT_SYSTEM[k]));
+      withheldSystems = COMPARTMENTS.filter((k) => !only!.includes(k)).map((k) => COMPARTMENT_SYSTEM[k]);
+      if (only.length === 0) return send(res, 403, { blocked: true, reason: 'no compartment is inside this grant’s scope' });
+    }
+    return send(res, 200, {
+      ...rejectionLedger(limit, only),
+      law: gatePolicy().doctrine,
+      ...(gid ? { grant: { id: gid, withheldSystems } } : {}),
+    });
   }
 
   // Provider directory + a provider's profile (the patient reviews who their doctors are).


### PR DESCRIPTION
## The leak

`GET /api/health/dynamics/rejections` called `rejectionLedger(limit)` with no scope and served the result to anyone.

Every ledger entry carries `mechanistic` / `proposed` / `delta` / `emitted` — the person's own trajectory in **mmHg, % and mL/min**. So a clinician holding a cardiovascular-only grant, *refused* the renal forecast at `/predict`, could reconstruct it by reading the refusals instead. The refusals **were** the disclosure. That is precisely the side door grant scope exists to close.

Ported from prophet-health `origin/main` (`6ee637c`), where it is already closed.

## What changed

| file | change |
|---|---|
| `dynamics/gate.ts` | `rejectionLedger(limit, only?)` filters by compartment **and recomputes `count` + the `byReason` histogram over the scoped set**. Porting the filter but leaving a whole-ledger total would leave the leak half-open — the total itself discloses that out-of-scope refusals happened. Now **byte-identical** to prophet-health. |
| `dynamics/gate.ts` (RULES) | the renal monotonicity bound said `previousAccepted` while the gate reads `previousEmitted`. `RULES` is served verbatim at `GET /api/health/dynamics` as inspectable policy — that was a documented lie on a PHI surface. |
| `server.ts` | the handler resolves the grant, derives `only` from its scope spec, **403s when no compartment is in scope**, names `withheldSystems` instead of silently omitting them, and is exposure-gated like `/predict`. |
| `eval.ts` | scored the **ungated** surrogate while reporting "gated" — right by coincidence on this cohort, but blind to a surrogate drifting into inadmissible proposals. Every step is now adjudicated by `reconcile()`, the same function `predict()` calls. Now **byte-identical** to prophet-health. |
| `invariants.ts` | +7e (scoped ledger) and +7f (declared == enforced). |
| `dynamics/ledger-scope.smoke.ts` | **new** — end-to-end boot smoke. |

## Proof — teeth both ways, at the endpoint

The unit invariant proves the *function* filters. The leak lived in the *handler*, so the smoke boots the real server and asks the real endpoint. Refusals are driven through the **ordinary public path** — `covariates` is caller-supplied on `POST /predict`, so an unprivileged request fills the ledger across all three compartments.

```
▶ BOOT SMOKE — the rejection ledger is scoped by grant at the HTTP surface
  ✓ an ungranted read still returns the ledger (35 refusals)
  ✓ the unscoped ledger spans every compartment (cardio, hepatic, renal)
  ✓ a cardiovascular-only grant sees ONLY cardiovascular refusals (cardio)
  ✓ count is recomputed over the scoped set (13, not the whole-ledger 35)
  ✓ byReason sums to the scoped count — the histogram discloses no out-of-scope refusal
  ✓ no renal value appears anywhere in the scoped response
  ✓ the response NAMES what was withheld (["hepatic","urinary"])
  ✓ a grant with no compartment in scope is refused 403
  ✓ the 403 carries no ledger content and no whole-ledger total
  ✓ an unknown grant is refused 403 and the refusal is receipted
  ✓ a full-scope grant still sees the whole ledger (35 of 35)
  ✓ a full-scope grant sees every compartment — the gate is scoping, not just refusing
```

**The smoke was verified to fail.** Reverting the handler to `rejectionLedger(limit)` breaks 3 assertions (`EXIT=1`); restoring passes again. It cannot silently un-port.

`eval.ts` gate self-check: ×40 amplified residual → gate refused 295/360; cardio RMSE **120.0005 ungated → 4.8084 through the gate**.

## Deliberately NOT ported — these would have reverted live work

- **`consult.ts`** — prophet-platform is **ahead**, not behind. It holds #1068's bounded consult ledger (`CONSULT_MAX`, `closeConsult`, `consultCount`, fail-closed at the cap); prophet-health does not have it. A wholesale port would have **deleted** it. #1070 and #1072 are also in flight on that file.
- **`deident.ts`** + its 9 date-shift invariants — **#1074 is already porting exactly this.** Left to that lane rather than resolved blind.
- **the rest of `server.ts`'s exposure pass** (`/twin.ttl`, `/reason` egress receipt, `/guidance`, `/evidence`, `/dynamics` `anchoredTo`, `/doctor-view`) — **#1081** is rewriting grant handling on those same routes.

`consult.test.ts` (platform-only) is untouched and still passes 5/5.

## ⚠️ For #1081

This handler uses the bare `?grant=` + `resolveGrant` pattern, matching `/predict` as main has it today. #1081 replaces that with `authorizeGrant()` to authenticate the **holder**. `/api/health/dynamics/rejections` must be converted along with the others, or it becomes a fresh instance of the bypass #1081 closes.

## ⚠️ CI: this runs nowhere in this repo yet

**#1089 is still OPEN**, so prophet-platform still has **no health-twin CI job at all** — `grep -c health-twin .github/workflows/ci.yml` = **0**. Until #1089 lands, neither the ported invariants nor the new smoke execute in this repo's CI. I did not add a job here because #1089 and #1081 both modify `ci.yml`.

Add to #1089's job when it lands:

```yaml
- name: scoped rejection ledger — the refusals are not a side door around the grant
  run: npx tsx src/dynamics/ledger-scope.smoke.ts
```

Verified locally in **both** repos: `invariants.ts` → 0, `eval.ts` → 0, `dynamics/verify.ts` → 0, `connectors/verify.ts` → 0, `consult.test.ts` 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
