### PR TITLE
tools: close the last Shape-C1 item — the PI manifest asserts were not the check

### DIFF
--- a/tools/tests/test_professional_intelligence_manifest_shape.py
+++ b/tools/tests/test_professional_intelligence_manifest_shape.py
@@ -1,0 +1,113 @@
+"""The manifest shape guards must reject malformed input under `python -O` too.
+
+`python -O` strips every `assert`, so a validator whose shape checks are bare
+asserts reports success on input it never validated. This tool used to carry
+three such asserts (on the manifest, on `capabilities`, and on
+`capabilities.workspaceOS`). They were removable rather than convertible: each
+sat immediately after an `expect_mapping()` guard that already rejects a
+non-mapping, prints ERR and drives a non-zero exit -- a plain isinstance test,
+not an assert, so -O leaves it intact.
+
+These tests pin that. They run the validator under BOTH interpreters and
+require identical, failing behaviour on each malformed shape, so the guards
+cannot silently regress into assert-based checking -- which would still look
+correct under a default `python3` test run and fail open under -O.
+"""
+
+from __future__ import annotations
+
+import copy
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "tools" / "validate_professional_intelligence_manifest.py"
+MANIFEST_NAME = "professional-intelligence.manifest.yaml"
+
+# Both interpreters must agree. Under -O the tool is what CI would run if
+# PYTHONOPTIMIZE were ever set in the environment; the point of the pair is
+# that the two columns never diverge.
+INTERPRETERS = [
+    pytest.param([sys.executable], id="python3"),
+    pytest.param([sys.executable, "-O"], id="python3-O"),
+]
+
+
+def real_manifest() -> dict:
+    return yaml.safe_load((REPO_ROOT / MANIFEST_NAME).read_text(encoding="utf-8"))
+
+
+def run_against(tmp_path: Path, manifest_obj: object, argv_prefix: list[str]):
+    """Run the validator against a synthetic repo root holding `manifest_obj`.
+
+    The tool resolves its own location (`Path(__file__).resolve().parents[1]`)
+    to find the manifest, so the tool is copied -- a symlink would resolve back
+    to the real repo and quietly validate the real manifest instead.
+    """
+    root = tmp_path / "root"
+    (root / "tools").mkdir(parents=True)
+    shutil.copy2(TOOL, root / "tools" / TOOL.name)
+    (root / MANIFEST_NAME).write_text(
+        yaml.safe_dump(manifest_obj, sort_keys=False), encoding="utf-8"
+    )
+    return subprocess.run(
+        argv_prefix + [str(root / "tools" / TOOL.name)],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("argv_prefix", INTERPRETERS)
+def test_real_manifest_still_validates(tmp_path: Path, argv_prefix: list[str]) -> None:
+    """A checker that rejects valid input is worse than the bug it fixed."""
+    proc = run_against(tmp_path, real_manifest(), argv_prefix)
+    assert proc.returncode == 0, proc.stderr
+    assert "structure valid" in proc.stdout
+
+
+@pytest.mark.parametrize("argv_prefix", INTERPRETERS)
+def test_non_mapping_manifest_is_rejected(tmp_path: Path, argv_prefix: list[str]) -> None:
+    proc = run_against(tmp_path, [{"apiVersion": "x"}, {"kind": "y"}], argv_prefix)
+    assert proc.returncode == 2, proc.stdout
+    assert "manifest must be a mapping/object" in proc.stderr
+    # Must not have reached the success banner.
+    assert "structure valid" not in proc.stdout
+
+
+@pytest.mark.parametrize("argv_prefix", INTERPRETERS)
+def test_non_mapping_capabilities_is_rejected(tmp_path: Path, argv_prefix: list[str]) -> None:
+    manifest = real_manifest()
+    manifest["capabilities"] = ["workspaceOS", "institutionGraph"]
+    proc = run_against(tmp_path, manifest, argv_prefix)
+    assert proc.returncode == 2, proc.stdout
+    assert "capabilities must be a mapping/object" in proc.stderr
+    assert "structure valid" not in proc.stdout
+
+
+@pytest.mark.parametrize("argv_prefix", INTERPRETERS)
+def test_non_mapping_workspace_os_is_rejected(tmp_path: Path, argv_prefix: list[str]) -> None:
+    manifest = real_manifest()
+    manifest["capabilities"] = copy.deepcopy(manifest["capabilities"])
+    manifest["capabilities"]["workspaceOS"] = ["status", "ownerRepos"]
+    proc = run_against(tmp_path, manifest, argv_prefix)
+    assert proc.returncode == 2, proc.stdout
+    assert "capabilities.workspaceOS must be a mapping/object" in proc.stderr
+    assert "structure valid" not in proc.stdout
+
+
+def test_validator_carries_no_bare_asserts() -> None:
+    """Guard the guard: no shape check in this tool may be a bare `assert`.
+
+    Catches a regression at the source rather than only through behaviour --
+    if someone reintroduces `assert isinstance(...)` here, -O would strip it.
+    """
+    import ast
+
+    tree = ast.parse(TOOL.read_text(encoding="utf-8"))
+    asserts = [n.lineno for n in ast.walk(tree) if isinstance(n, ast.Assert)]
+    assert not asserts, f"{TOOL.name} regained bare assert(s) at line(s) {asserts}"

--- a/tools/tests/test_professional_intelligence_manifest_shape.py
+++ b/tools/tests/test_professional_intelligence_manifest_shape.py
@@ -29,6 +29,22 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL = REPO_ROOT / "tools" / "validate_professional_intelligence_manifest.py"
 MANIFEST_NAME = "professional-intelligence.manifest.yaml"
 
+# The in-repo evidence the real manifest declares under
+# capabilities.workspaceOS.{contractPaths,controlRefs}. The validator now stats
+# these (require_declared_paths_exist), so a synthetic root that copies only the
+# tool makes the tool reject the real manifest for a path that is absent only
+# because the fixture never carried it. Copied into the synthetic root exactly as
+# build_root() does in test_professional_intelligence_manifest_evidence_paths.py.
+# Cross-repo refs (SocioProphet/<repo>:<path>) are not present in any checkout and
+# stay skipped by the tool, so they are deliberately NOT listed here.
+LOCAL_EVIDENCE = [
+    "contracts/workspace/workroom-update-request.example.json",
+    "contracts/workspace/workroom-update-response.accepted.example.json",
+    "contracts/workspace/workroom-update-response.invalid-runtime-mutation.example.json",
+    "docs/WORKROOM_UPDATE_RUNTIME_BOUNDARY.md",
+    "tools/validate_workroom_update_contract.py",
+]
+
 # Both interpreters must agree. Under -O the tool is what CI would run if
 # PYTHONOPTIMIZE were ever set in the environment; the point of the pair is
 # that the two columns never diverge.
@@ -55,6 +71,13 @@ def run_against(tmp_path: Path, manifest_obj: object, argv_prefix: list[str]):
     (root / MANIFEST_NAME).write_text(
         yaml.safe_dump(manifest_obj, sort_keys=False), encoding="utf-8"
     )
+    # The validator stats the manifest's in-repo evidence; carry it into the
+    # synthetic root so a valid manifest is not rejected for a fixture omission.
+    # Same copy-loop as build_root() in the evidence-paths suite.
+    for rel in LOCAL_EVIDENCE:
+        dest = root / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / rel, dest)
     return subprocess.run(
         argv_prefix + [str(root / "tools" / TOOL.name)],
         capture_output=True,

--- a/tools/validate_professional_intelligence_manifest.py
+++ b/tools/validate_professional_intelligence_manifest.py
@@ -94,7 +94,16 @@ def main() -> int:
     data = yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
     if not expect_mapping(data, "manifest"):
         return 2
-    assert isinstance(data, dict)
+    # `data` is a mapping from here on, and that is enforced above rather than
+    # asserted. expect_mapping() is a plain isinstance test that prints ERR and
+    # returns False, so `python -O` cannot strip it -- unlike the bare
+    # `assert isinstance(data, dict)` that used to sit on this line. That assert
+    # was a narrowing hint for a type checker this repo does not run, and it
+    # could never fire: a non-mapping manifest has already returned 2 one line
+    # up. Removing it closes the "assert evaporates under -O" finding here
+    # without changing behaviour on any input. The -O behaviour of all three
+    # shape guards in this function is now pinned by
+    # tools/tests/test_professional_intelligence_manifest_shape.py.
 
     bad = 0
     for key in REQUIRED_TOP_LEVEL:
@@ -116,13 +125,19 @@ def main() -> int:
     if not expect_mapping(capabilities, "capabilities"):
         bad += 1
         capabilities = {}
-    assert isinstance(capabilities, dict)
+    # Both branches leave a dict behind -- expect_mapping() proved one, the
+    # fallback assigned the other -- so the removed `assert isinstance(...)`
+    # here was unreachable-with-a-false-condition, not a check. The real
+    # rejection is the `bad += 1` above, which survives -O. Normalising to {}
+    # rather than returning is deliberate: it lets the run keep accumulating
+    # every downstream error instead of stopping at the first one.
 
     workspace_os = capabilities.get("workspaceOS")
     if not expect_mapping(workspace_os, "capabilities.workspaceOS"):
         bad += 1
         workspace_os = {}
-    assert isinstance(workspace_os, dict)
+    # Same shape as the capabilities guard above: enforced by expect_mapping()
+    # plus the {} fallback, so the removed assert added nothing at runtime.
 
     for key in REQUIRED_WORKSPACE_OS_KEYS:
         if key not in workspace_os:


### PR DESCRIPTION
Closes the last deferred **Shape-C1** item, registered in #1084:
`tools/validate_professional_intelligence_manifest.py` L97/L119/L125 used bare
`assert` for shape checks, which `python -O` strips.

**Probing it first changed the verdict.** These three asserts are not
load-bearing, so #1084's remedy (`require()` / `raise TypeError`) does not apply
here — and applying it would have been a regression. Reporting that rather than
shipping a fix whose teeth I could not demonstrate.

## Why they were never the check

Each assert sits immediately after an `expect_mapping()` guard that already
rejects a non-mapping. `expect_mapping()` is a plain `isinstance` test that
prints `ERR:` and returns `False` — **not** an assert, so `-O` leaves it intact.

| line | guard that actually enforces it |
|---|---|
| L97 | `if not expect_mapping(data, "manifest"): return 2` |
| L119 | `expect_mapping(...)` → `bad += 1; capabilities = {}` |
| L125 | `expect_mapping(...)` → `bad += 1; workspace_os = {}` |

Each assert was therefore unreachable-with-a-false-condition: a narrowing hint
for a type checker **this repo does not run** (no mypy/pyright config, no CI
type-check step anywhere).

## Proof, measured on `origin/main` before any edit

Malformed manifests (top level a list; `capabilities` a list;
`capabilities.workspaceOS` a list), run under **`python3 -O`** against the
unmodified `main` tool:

```
rc=2  -O  A: top-level is a LIST      ERR: manifest must be a mapping/object
rc=2  -O  B: capabilities is a LIST   ERR: capabilities must be a mapping/object
rc=2  -O  C: workspaceOS is a LIST    ERR: capabilities.workspaceOS must be a mapping/object
```

All three already fail closed under `-O`. There was no evaporating check.

Converting them to `raise` would additionally have broken deliberate behaviour:
L119/L125 normalise to `{}` specifically so a run keeps accumulating **every**
downstream error instead of stopping at the first.

## What this PR does instead

1. **Removes the three vestigial asserts**, recording at each site which guard
   establishes the invariant — so the next Shape-C sweep does not re-flag this
   file for a fourth time.
2. **Adds `tools/tests/test_professional_intelligence_manifest_shape.py`**,
   turning "the guard happens to survive `-O`" into an enforced property. It
   runs the validator under `python3` **and** `python3 -O` against each
   malformed shape, plus an AST check that fails if any bare `assert` returns.
   No other test in `tools/tests` exercises `-O`.

**Behaviour is unchanged on every input.** Pre- vs post-change output across
4 manifests x {`python3`, `python3 -O`} is byte-identical (diff: empty). The
real manifest still validates `rc=0` under both interpreters and via
`make validate-professional-intelligence-manifest`.

## The new test has teeth — verified both ways

| mutation | result |
|---|---|
| restore the three asserts | AST test fails, naming `[97, 119, 125]` |
| make `expect_mapping` assert-based (the real fail-open) | **7 of 9 fail**, incl. all six `-O`/plain shape tests |
| restored | 9 passed, file byte-identical to pre-mutation |

`tools/tests`: **298 passed** (289 + 9 new).

## Also found in the file — reported, not changed

- **`demoAcceptance` misdiagnoses a bad shape** (L164). If `demoAcceptance` is
  present but not a mapping, the ternary yields `None` and the tool reports
  *"demoAcceptance.required must be a non-empty list"* — pointing at the wrong
  field. It still **fails closed** (`rc=2`); this is message quality, not teeth.
  Every other field in the file uses `expect_mapping` for this.
- **`metadata.name` check is skipped when `metadata` is not a mapping** (L117
  `elif`) — `bad` is already incremented so it fails closed, but the specific
  diagnostic is lost.
- **Declared-but-never-stat'd evidence.** The validator enforces that
  `contractPaths` / `controlRefs` *list* certain paths, but never checks they
  exist. The manifest could claim contract alignment against deleted files and
  still print *"OK: workspaceOS contract-aligned evidence present"*. Cross-repo
  refs can't be checked locally, but five in-repo ones could be. I verified all
  five currently exist, so this is latent, not currently broken.

No other bare asserts remain in the file (AST-verified, and now CI-enforced).

## Lane

`tools/` only — two files. **Does not touch `validate-target-diagnostics.yml`**
(#1080 and #1082 were both still open when this was written, which is why this
item was deferred in the first place; the tool change is independent of them).