### PR TITLE
ci(helm-release): revive a workflow that has never once started (17/17 startup_failure)

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -13,10 +13,57 @@ on:
     paths:
       - 'charts/**'
       - '.github/workflows/helm-release.yml'
+      - 'scripts/ci/install-chart-releaser.sh'
+      - 'scripts/ci/release-charts.sh'
+  pull_request:
+    branches: [main]
+    paths:
+      # A change to this workflow, or to the scripts it now depends on, has to be
+      # exercised before it merges. Every run from 2026-06-23 to 2026-07-29 was a
+      # startup_failure (17/17), and nothing triggered on the workflow file
+      # itself, so no PR could ever have revealed that. The pull_request path
+      # runs the package job only — it never publishes.
+      - 'charts/**'
+      - '.github/workflows/helm-release.yml'
+      - 'scripts/ci/install-chart-releaser.sh'
+      - 'scripts/ci/release-charts.sh'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
+  # Runs on every event, including pull_request. Read-only: it proves the pinned
+  # toolchain installs and the charts package, without cutting a release.
+  package:
+    name: Package charts (no publish)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      # helm/chart-releaser-action cannot run here: this repo restricts actions
+      # to github-owned + verified-Marketplace + an explicit pattern allowlist
+      # (dtolnay/*, Swatinem/*, oven-sh/*, tauri-apps/*). The action *is*
+      # Marketplace-listed, which makes it look allowed, but its publisher `helm`
+      # carries no verified-creator badge and it matches no pattern. The run was
+      # rejected before any job started, which is why every run was a
+      # startup_failure with nothing in the logs.
+      # See scripts/ci/install-chart-releaser.sh for the checksum pinning that
+      # replaces it.
+      - name: Install chart-releaser
+        run: scripts/ci/install-chart-releaser.sh
+
+      - name: Package every chart
+        run: scripts/ci/release-charts.sh --package-only
+
   release:
+    name: Publish charts
+    needs: package
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write    # chart-releaser: create releases + push gh-pages
@@ -33,11 +80,12 @@ jobs:
 
       - uses: azure/setup-helm@v4
 
+      - name: Install chart-releaser
+        run: scripts/ci/install-chart-releaser.sh
+
       # 1. Public chart repo on GitHub Pages (helm repo add).
       - name: Release charts to GitHub Pages
-        uses: helm/chart-releaser-action@v1.6.0
-        with:
-          charts_dir: charts
+        run: scripts/ci/release-charts.sh
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/scripts/ci/install-chart-releaser.sh
+++ b/scripts/ci/install-chart-releaser.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Install a pinned, checksum-verified chart-releaser (`cr`) without using a
+# third-party action.
+#
+# `helm/chart-releaser-action` cannot run in this repo. Actions here are
+# restricted to `allowed_actions: selected` -- github-owned plus
+# verified-Marketplace plus an explicit pattern allowlist (dtolnay/*,
+# Swatinem/*, oven-sh/*, tauri-apps/*). chart-releaser-action *is* on the
+# Marketplace (https://github.com/marketplace/actions/helm-chart-releaser
+# returns 200), which makes this one easy to misdiagnose -- but its publisher
+# `helm` carries no verified-creator badge, so `verified_allowed` does not
+# cover it and it matches no pattern. Every run of helm-release.yml since the
+# workflow was created is a `startup_failure` (17/17, 2026-06-23 -> 2026-07-29):
+# the run is rejected before any job starts, so there are no logs to read.
+#
+# Downloading the release archive and checking it against a committed sha256 is
+# strictly stronger than the action was: the checksum is reviewed in-tree, and
+# no third-party code runs with access to the workflow token.
+#
+# Bumping CR_VERSION requires adding its checksum below. An unknown version is a
+# hard error rather than an unverified download.
+
+set -euo pipefail
+
+CR_VERSION="${CR_VERSION:-1.8.1}"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) GOARCH=amd64 ;;
+  aarch64|arm64) GOARCH=arm64 ;;
+  *) echo "::error::unsupported architecture ${ARCH}" >&2; exit 1 ;;
+esac
+
+# sha256 of chart-releaser_<version>_linux_<arch>.tar.gz, from the upstream
+# checksums.txt attached to the release.
+case "${CR_VERSION}_${GOARCH}" in
+  1.8.1_amd64) SHA256=834046b27b00cd6ba451326875c1937d4f2b671063c2053e031434ade73002b5 ;;
+  1.8.1_arm64) SHA256=03811896f65f73faffa63aa24f54ac4fed73e088418d0582723917b69c2a280b ;;
+  *)
+    echo "::error title=unpinned chart-releaser::no committed sha256 for chart-releaser ${CR_VERSION} ${GOARCH}." >&2
+    echo "Add it from https://github.com/helm/chart-releaser/releases/download/v${CR_VERSION}/checksums.txt before bumping." >&2
+    exit 1
+    ;;
+esac
+
+TGZ="chart-releaser_${CR_VERSION}_linux_${GOARCH}.tar.gz"
+URL="https://github.com/helm/chart-releaser/releases/download/v${CR_VERSION}/${TGZ}"
+DEST="${CR_INSTALL_DIR:-/usr/local/bin}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Downloading ${URL}"
+curl -fsSL --retry 3 --retry-delay 2 -o "${TMP}/${TGZ}" "$URL"
+
+echo "${SHA256}  ${TMP}/${TGZ}" | sha256sum -c -
+
+tar -xzf "${TMP}/${TGZ}" -C "$TMP" cr
+install -m 0755 "${TMP}/cr" "${DEST}/cr"
+
+# Invoke by path, not via PATH, so this reports the binary just installed rather
+# than some other cr that happens to be earlier in PATH.
+"${DEST}/cr" version

--- a/scripts/ci/release-charts.sh
+++ b/scripts/ci/release-charts.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# Publish charts/* as a Helm repo on the gh-pages branch, using the `cr` binary
+# installed by scripts/ci/install-chart-releaser.sh.
+#
+# This is the orchestration that `helm/chart-releaser-action` used to do. That
+# action cannot run here (see install-chart-releaser.sh for why), so the same
+# three `cr` calls are made directly.
+#
+#   --package-only   package the charts and stop. No token, no writes, no
+#                    releases. This is what runs on a pull request, so a change
+#                    to this script or to the workflow is exercised before it
+#                    merges instead of only being discovered on main.
+#
+# Deliberate difference from the action: the action diffed charts against the
+# latest tag and uploaded only what changed. Here every chart is packaged and
+# `cr upload --skip-existing` drops the ones already released. Same outcome,
+# but it does not depend on tag history being intact, and re-running is a no-op
+# rather than a failure.
+
+set -euo pipefail
+
+PACKAGE_ONLY=0
+case "${1:-}" in
+  --package-only) PACKAGE_ONLY=1 ;;
+  "") ;;
+  *) echo "::error::unknown argument '$1' (expected --package-only or nothing)" >&2; exit 1 ;;
+esac
+
+PKG_DIR=".cr-release-packages"
+rm -rf "$PKG_DIR" && mkdir -p "$PKG_DIR"
+
+found=0
+for chart in charts/*/; do
+  [ -f "${chart}Chart.yaml" ] || continue
+  echo "Packaging ${chart}"
+  cr package "$chart" --package-path "$PKG_DIR"
+  found=1
+done
+
+if [ "$found" -eq 0 ]; then
+  echo "::error::no chart found under charts/ -- refusing to report success for publishing nothing" >&2
+  exit 1
+fi
+
+ls -l "$PKG_DIR"
+
+if [ "$PACKAGE_ONLY" -eq 1 ]; then
+  echo "--package-only: packaged $(find "$PKG_DIR" -name '*.tgz' | wc -l | tr -d ' ') chart(s), not publishing."
+  exit 0
+fi
+
+: "${CR_TOKEN:?CR_TOKEN must be set to publish}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+: "${GITHUB_SHA:?GITHUB_SHA must be set}"
+OWNER="${GITHUB_REPOSITORY%%/*}"
+REPO="${GITHUB_REPOSITORY##*/}"
+PAGES_BRANCH="${CR_PAGES_BRANCH:-gh-pages}"
+
+# `cr index --push` publishes by running `git worktree add --detach <dir>
+# origin/<pages-branch>`, so the branch has to already exist -- otherwise the
+# push fails on an unresolvable ref. Creating it empty is the one-time manual
+# setup step chart-releaser documents; do it here so the first run works rather
+# than failing on a prerequisite nobody is watching for.
+if ! git ls-remote --exit-code --heads origin "$PAGES_BRANCH" >/dev/null 2>&1; then
+  echo "Branch '${PAGES_BRANCH}' does not exist yet; creating it with an empty index."
+  wt="$(mktemp -d)/${PAGES_BRANCH}"
+  git worktree add --detach "$wt"
+  git -C "$wt" checkout --orphan "$PAGES_BRANCH"
+  git -C "$wt" rm -rq --cached . || true
+  find "$wt" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+  : > "$wt/index.yaml"
+  git -C "$wt" add index.yaml
+  git -C "$wt" commit -m "chore(charts): initialise Helm chart repository index"
+  git -C "$wt" push origin "$PAGES_BRANCH"
+  git worktree remove --force "$wt"
+  git fetch origin "${PAGES_BRANCH}:refs/remotes/origin/${PAGES_BRANCH}"
+fi
+
+cr upload \
+  --owner "$OWNER" \
+  --git-repo "$REPO" \
+  --package-path "$PKG_DIR" \
+  --pages-branch "$PAGES_BRANCH" \
+  --commit "$GITHUB_SHA" \
+  --token "$CR_TOKEN" \
+  --skip-existing
+
+cr index \
+  --owner "$OWNER" \
+  --git-repo "$REPO" \
+  --package-path "$PKG_DIR" \
+  --pages-branch "$PAGES_BRANCH" \
+  --index-path .cr-index/index.yaml \
+  --token "$CR_TOKEN" \
+  --push


### PR DESCRIPTION
All 17 runs of `helm-release.yml` (2026-06-23 → 2026-07-29) are `startup_failure`. It has never once succeeded — never once *started*. The run is rejected at creation, before any job exists, so there are no logs to point at the cause.

```
$ gh api .../workflows/helm-release.yml/runs --jq '.total_count, (…group_by(.conclusion))'
17
{"startup_failure":17}
```

## Root cause

`helm/chart-releaser-action@v1.6.0`.

The repo sets `allowed_actions: selected`:

```json
{"github_owned_allowed":true,"verified_allowed":true,
 "patterns_allowed":["dtolnay/*","Swatinem/*","oven-sh/*","tauri-apps/*"]}
```

The action **is on the Marketplace** — `https://github.com/marketplace/actions/helm-chart-releaser` returns 200 — which is what makes this one easy to get wrong. But `verified_allowed` gates on the *publisher's verified-creator badge*, not on Marketplace presence, and the publisher `helm` has none. Fetching the listing finds **zero** `Verified<` markers, against **2** for `azure/login`. It is not github-owned and matches no pattern.

Isolated by elimination — every other action in the file demonstrably runs today:

| action in `helm-release.yml` | status | evidence |
|---|---|---|
| `actions/checkout@v4` | allowed | github-owned |
| `azure/setup-helm@v4` | allowed | verified; `deploy-tests.yml` = 88 successes |
| `google-github-actions/auth@v2` | allowed | verified; `provision-secrets.yml` succeeds |
| **`helm/chart-releaser-action@v1.6.0`** | **blocked** | Marketplace 200, **0 Verified markers** |

## The fix — option 1, for consistency

Replaced with a pinned, checksum-verified install of the `cr` binary (`scripts/ci/install-chart-releaser.sh`) plus the three `cr` calls the action wrapped (`scripts/ci/release-charts.sh`). This matches `scripts/ci/install-opentofu.sh` from **#1090** / **#1097** — same shape: committed sha256, hard refusal on an unpinned version, hard failure on checksum mismatch.

The committed checksums were verified by downloading both linux artifacts and recomputing:

```
834046b27b00cd6ba451326875c1937d4f2b671063c2053e031434ade73002b5  linux_amd64
03811896f65f73faffa63aa24f54ac4fed73e088418d0582723917b69c2a280b  linux_arm64
```

`cr` is pinned at **v1.8.1** rather than the v1.6.0 the action defaulted to. There is no behaviour to preserve — the step has never executed once.

**Option 2 — an admin adds `helm/*` to `patterns_allowed`** — would also work. Not done deliberately: it is a settings change with no diff to review, and it was rejected for the OpenTofu case for that reason. Noting it so the choice reads as deliberate rather than overlooked.

### Deliberate behaviour differences from the action

- **Every chart is packaged; `cr upload --skip-existing` drops the already-released ones.** The action diffed charts against the latest tag. Same outcome, no dependence on tag history being intact, and re-running is a no-op rather than a failure.
- **`gh-pages` is bootstrapped if absent.** `cr index --push` publishes via `git worktree add --detach <dir> origin/gh-pages`, so the branch must already exist. **`gh-pages` does not exist in this repo** (`git ls-remote --heads origin gh-pages` is empty), so even with the policy fixed the first run would have died on a prerequisite nobody is watching for. Creating it empty is the one-time manual setup chart-releaser documents; it is guarded by `ls-remote`, so it happens at most once.

## Making the fix verifiable pre-merge

The workflow had **no `pull_request` trigger at all** — only `push: branches:[main]` and `workflow_dispatch`. A PR touching it could not run it. That is the same blind spot #1097 closed for `tofu-plan.yml`, and it is a large part of why 17 consecutive failures went unnoticed.

It now triggers on itself and on the two scripts, and splits into two jobs:

- **`package`** — runs on `pull_request`, `permissions: contents: read`. Installs the pinned `cr`, packages every chart, publishes nothing.
- **`release`** — `if: github.event_name != 'pull_request'`. Cuts releases, pushes `gh-pages`, pushes OCI.

The policy check is **whole-file at run creation**, so a PR-time run that reaches its steps proves *every* `uses:` in the file is permitted — including `google-github-actions/auth@v2`, which only the skipped `release` job uses.

Verified locally before pushing:

| behaviour | result |
|---|---|
| valid version, real tarball | downloads, checksum `OK`, installs |
| tampered committed sha256 | `FAILED` / `did NOT match`, exit 1, **nothing installed** |
| `CR_VERSION=9.9.9` | refuses, prints the checksums.txt URL, exit 1 |
| `release-charts.sh --package-only` | packages all 4 charts, exit 0 |
| missing `CR_TOKEN` | refuses to publish |

---

## This is the third instance — and there is a fourth

`infra-drift-detect` (26 `startup_failure`), `tofu-plan.yml` (25), `helm-release.yml` (17). I enumerated **every** `uses:` across the repo — all 104 files in `.github/workflows/`, plus a whole-tree sweep confirming there are no composite actions (`.github/actions/` is empty, no `action.yml` exists anywhere) — and checked each against the policy — github-owned, publisher verified-creator badge (fetched and counted, not assumed from Marketplace presence, which is exactly what fooled this case), or pattern match.

### Blocked

| action | why | workflows | observed |
|---|---|---|---|
| `helm/chart-releaser-action@v1.6.0` | Marketplace 200, **0 Verified** | `helm-release.yml` | 17/17 `startup_failure` |
| `opentofu/setup-opentofu@v1`, `@9d84900f` | **not Marketplace-listed** (404) | `tofu-plan.yml`, `infra-drift-detect.yml` | 25 + 26 `startup_failure` |
| **`peter-evans/create-pull-request@v6`** | Marketplace 200, **0 Verified** | **`search-orchestrator-image-pin.yml`** | **9/9 `startup_failure` since 2026-07-03** |

**The fourth is `search-orchestrator-image-pin.yml`.** It last succeeded 2026-04-26; every run from 2026-07-03 onward is a `startup_failure`. It is `workflow_run`-triggered off the image build, so it fires rarely and fails invisibly — the automated image-digest pinning it exists to do has not happened in nearly four months. Same root cause, same failure mode. **Not fixed here** — it needs its own PR, since `create-pull-request` has no one-line `run:` equivalent (likely `gh pr create`).

### Allowed — verified, no action needed

`azure/setup-helm@v4`, `azure/login`, `azure/setup-kubectl@v3`, `docker/login-action@v3`, `docker/setup-buildx-action@v3`, `docker/build-push-action@v5,v6`, `hashicorp/setup-terraform@v3`, `aws-actions/configure-aws-credentials`, `google-github-actions/auth@v2`, `google-github-actions/get-gke-credentials@v2` — all show 2 `Verified<` markers, and all but `azure/login` and `aws-actions/*` are independently confirmed by live successful runs. `SocioProphet/.github/.github/workflows/build-image.yml@main` is a same-org reusable workflow (`images.yml`, 68 successes). All `actions/*` are github-owned.

Worth noting: **none of the four allowlisted patterns is used by any workflow in this repo.** `dtolnay/*`, `Swatinem/*`, `oven-sh/*`, `tauri-apps/*` are Rust/Tauri patterns belonging to Noetica and BearBrowser. The pattern allowlist is dead weight here.

## Recommendation: make this mechanical

Four workflows have now been silently dead for weeks to months on the same policy, and the failure mode is *specifically* one that produces nothing to read — no logs, no annotation, and a `paths:` filter that often means no PR can surface it either. Manual discovery does not scale.

A check should fail a PR when a workflow references an action the policy cannot run. Sketch:

1. Read the live policy from `GET /repos/{owner}/{repo}/actions/permissions/selected-actions`.
2. Parse every `uses:` under `.github/workflows/`.
3. Allow: `actions/*` and `github/*` when `github_owned_allowed`; same-repo / same-org reusable workflows; anything matching `patterns_allowed`.
4. Otherwise, when `verified_allowed`, resolve the action's Marketplace listing and require the **verified-creator badge** — not merely a 200. Fetching the listing and getting 200 is precisely what makes this bug look fine.
5. Fail with the action, the workflow, and which of the three gates it missed.

**Natural home: `tools/check_workflow_path_filters.py`,** run by `ci-path-filter-audit.yml`. That workflow already triggers on `.github/workflows/**`, already parses every workflow file, and is already framed around exactly this doctrine — *"a wrong promise is worse than no filter, because the validator stops running pre-merge and nobody notices."* A policy-blocked action is the same failure with a harsher edge: the validator does not merely stop being asked, it is rejected outright. (The sibling `scripts/verify_workflow_branches.py` in socioprophet is the other candidate, but it is in the wrong repo and does not already read this repo's workflows.)

Step 4 needs a network call, which that tool deliberately does not make today — so it wants either a committed, reviewed allowlist of verified publishers or an `--offline` mode. That is a real design question, which is why **it is not built in this PR.** Proposing it here rather than bundling it.

## Not touched

`.cr-release-packages/` and `.cr-index/` are runner-local build output and are not in `.gitignore`. Nothing commits from the main worktree — `cr index --push` operates in its own temp worktree — so this is cosmetic. Left alone to keep the diff inside `helm-release.yml` + `scripts/ci/`.

## Verification status

See the first comment below for whether the `package` job actually reached its steps. A workflow that merely parses proves nothing here — the entire defect is rejection before startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
