### PR TITLE
tools: the PI manifest declared contract evidence it never stat'd

### DIFF
--- a/tools/tests/test_professional_intelligence_manifest_evidence_paths.py
+++ b/tools/tests/test_professional_intelligence_manifest_evidence_paths.py
@@ -1,0 +1,226 @@
+"""The manifest's declared evidence must exist on disk, not merely be listed.
+
+`require_set_contains()` proves the manifest *lists* a contract path. That is a
+declaration about the world. Before this was pinned, every in-repo path named by
+`workspaceOS.contractPaths` / `workspaceOS.controlRefs` could be deleted and the
+validator would still print `OK: workspaceOS contract-aligned evidence present`
+and exit 0 -- verified against the pre-fix tool.
+
+These tests delete each declared path in turn and require a non-zero exit that
+names it, under `python3` AND `python3 -O`. A check that has only ever been run
+against a fully-present set has never been observed failing and proves nothing.
+
+The expected paths below are written out literally rather than imported from the
+tool. A test that derives its expectations from the code under test validates
+nothing -- it agrees with whatever that code currently says.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL = REPO_ROOT / "tools" / "validate_professional_intelligence_manifest.py"
+MANIFEST_NAME = "professional-intelligence.manifest.yaml"
+
+# The in-repo evidence the manifest claims contract alignment against. Held
+# independently of the tool's own constants on purpose (see module docstring).
+LOCAL_EVIDENCE = [
+    "contracts/workspace/workroom-update-request.example.json",
+    "contracts/workspace/workroom-update-response.accepted.example.json",
+    "contracts/workspace/workroom-update-response.invalid-runtime-mutation.example.json",
+    "docs/WORKROOM_UPDATE_RUNTIME_BOUNDARY.md",
+    "tools/validate_workroom_update_contract.py",
+]
+
+# Refs into peer estate repos. These are not present in this checkout and so
+# cannot be stat'd here; the tool must say so out loud rather than skip quietly.
+CROSS_REPO_EVIDENCE = [
+    "SocioProphet/prophet-workspace:contracts/workspace/workroom.schema.json",
+    "SocioProphet/prophet-workspace:contracts/workspace/professional-workroom.schema.json",
+    "SocioProphet/prophet-workspace:contracts/workspace/professional-workroom.v0.1.example.json",
+    "SocioProphet/prophet-workspace:docs/workroom-substrate-alignment-v0.md",
+    "SocioProphet/prophet-workspace:tools/validate_professional_workrooms.py",
+    "SocioProphet/workspace-inventory:inventory/estate-overlays/prophet-workspace-workroom-substrate.yaml",
+    "SocioProphet/systems-learning-loops:kb/receipts/prophet-workspace-workroom-substrate.receipt.yaml",
+]
+
+# Both interpreters must agree. `-O` strips asserts, so a check written as one
+# evaporates there while still looking correct under a default test run.
+INTERPRETERS = [
+    pytest.param([sys.executable], id="python3"),
+    pytest.param([sys.executable, "-O"], id="python3-O"),
+]
+
+
+def load_tool_module():
+    spec = importlib.util.spec_from_file_location("_pi_manifest_tool", TOOL)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_root(tmp_path: Path) -> Path:
+    """Materialise a synthetic repo root the tool will accept.
+
+    The tool derives its ROOT from `Path(__file__).resolve().parents[1]`, so the
+    tool is copied rather than symlinked -- a symlink resolves back to the real
+    repo and would quietly validate the real tree instead of the fixture.
+    """
+    root = tmp_path / "root"
+    (root / "tools").mkdir(parents=True)
+    shutil.copy2(TOOL, root / "tools" / TOOL.name)
+    shutil.copy2(REPO_ROOT / MANIFEST_NAME, root / MANIFEST_NAME)
+    for rel in LOCAL_EVIDENCE:
+        dest = root / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / rel, dest)
+    return root
+
+
+def run(root: Path, argv_prefix: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv_prefix + [str(root / "tools" / TOOL.name)],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("argv_prefix", INTERPRETERS)
+def test_fixture_root_validates_and_the_existence_check_actually_ran(
+    tmp_path: Path, argv_prefix: list[str]
+) -> None:
+    """Baseline: a complete tree passes, and the new check is observably live.
+
+    Asserting rc==0 alone would also pass if the existence check were deleted,
+    so this pins the evidence line too -- a checker must show it did the work,
+    not merely print a success banner.
+    """
+    proc = run(build_root(tmp_path), argv_prefix)
+    assert proc.returncode == 0, proc.stderr
+    assert "workspaceOS.contractPaths: 3 in-repo evidence path(s) exist on disk" in proc.stdout
+    assert "workspaceOS.controlRefs: 2 in-repo evidence path(s) exist on disk" in proc.stdout
+
+
+@pytest.mark.parametrize("missing", LOCAL_EVIDENCE)
+@pytest.mark.parametrize("argv_prefix", INTERPRETERS)
+def test_deleting_a_declared_path_fails_and_names_it(
+    tmp_path: Path, argv_prefix: list[str], missing: str
+) -> None:
+    """The teeth. Each declared path, deleted one at a time, must be caught."""
+    root = build_root(tmp_path)
+    (root / missing).unlink()
+
+    proc = run(root, argv_prefix)
+    assert proc.returncode == 2, f"deleting {missing} did not fail the validator: {proc.stdout}"
+    assert missing in proc.stderr, proc.stderr
+    assert "does not exist in this repo" in proc.stderr
+    # The banner this gap used to reach must not be printed.
+    assert "contract-aligned evidence present" not in proc.stdout
+
+
+@pytest.mark.parametrize("argv_prefix", INTERPRETERS)
+def test_all_declared_paths_missing_is_reported_per_path(
+    tmp_path: Path, argv_prefix: list[str]
+) -> None:
+    root = build_root(tmp_path)
+    for rel in LOCAL_EVIDENCE:
+        (root / rel).unlink()
+
+    proc = run(root, argv_prefix)
+    assert proc.returncode == 2, proc.stdout
+    for rel in LOCAL_EVIDENCE:
+        assert rel in proc.stderr, f"{rel} was not named in the failure output"
+
+
+@pytest.mark.parametrize("argv_prefix", INTERPRETERS)
+def test_cross_repo_refs_are_skipped_out_loud(tmp_path: Path, argv_prefix: list[str]) -> None:
+    """A silently-skipped ref is how declared-but-unverified evidence returns.
+
+    Cross-repo refs genuinely cannot be stat'd from this checkout, so the tool
+    must neither fail on them nor pass over them in silence.
+    """
+    proc = run(build_root(tmp_path), argv_prefix)
+    assert proc.returncode == 0, proc.stderr
+    assert "SKIP: workspaceOS.contractPaths: 3 cross-repo ref(s)" in proc.stdout
+    assert "SKIP: workspaceOS.controlRefs: 4 cross-repo ref(s)" in proc.stdout
+    for ref in CROSS_REPO_EVIDENCE:
+        assert ref in proc.stdout, f"cross-repo ref {ref} was skipped without being named"
+        # Skipped, not treated as a missing local file.
+        assert ref not in proc.stderr
+
+
+def test_cross_repo_classification_is_not_a_bare_colon_test() -> None:
+    """Guard the partition itself: the skip list must not be able to grow silently.
+
+    If a local path were misclassified as cross-repo it would be skipped rather
+    than stat'd, quietly reopening the gap this file exists to close.
+    """
+    module = load_tool_module()
+    for ref in CROSS_REPO_EVIDENCE:
+        assert module.is_cross_repo_ref(ref), f"{ref} should be cross-repo"
+    for ref in LOCAL_EVIDENCE:
+        assert not module.is_cross_repo_ref(ref), f"{ref} should be checked locally"
+    # A colon inside an ordinary in-repo path is not an estate ref.
+    assert not module.is_cross_repo_ref("docs/notes:draft.md")
+    # An unrecognised org must fall through to the LOCAL side, where it is
+    # stat'd and fails loudly, rather than joining the silently-skipped column.
+    # This is the safe direction for a misclassification and must stay that way.
+    assert not module.is_cross_repo_ref("SomeOtherOrg/repo:contracts/thing.json")
+    assert "SocioProphet" in module.ESTATE_ORGS
+
+    declared = module.REQUIRED_WORKSPACE_OS_CONTRACTS | module.REQUIRED_WORKSPACE_OS_CONTROLS
+    locally_checked = {r for r in declared if not module.is_cross_repo_ref(r)}
+    assert locally_checked == set(LOCAL_EVIDENCE), (
+        "the set of locally-verifiable evidence paths changed; update this test "
+        "deliberately rather than letting a path drift into the skipped column"
+    )
+
+
+@pytest.mark.parametrize("argv_prefix", INTERPRETERS)
+def test_non_mapping_demo_acceptance_names_demo_acceptance(
+    tmp_path: Path, argv_prefix: list[str]
+) -> None:
+    """A wrongly-shaped `demoAcceptance` must not be reported as `.required`.
+
+    Diagnostics only -- both the old and new code fail closed with rc=2 -- but
+    the old message pointed the reader at a field that was not the problem.
+    """
+    root = build_root(tmp_path)
+    manifest = yaml.safe_load((root / MANIFEST_NAME).read_text(encoding="utf-8"))
+    manifest["demoAcceptance"] = ["workroom update contract validated"]
+    (root / MANIFEST_NAME).write_text(
+        yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8"
+    )
+
+    proc = run(root, argv_prefix)
+    assert proc.returncode == 2, proc.stdout
+    assert "ERR: demoAcceptance must be a mapping/object" in proc.stderr
+    assert "demoAcceptance.required" not in proc.stderr, (
+        "the wrong field is still being named: " + proc.stderr
+    )
+
+
+@pytest.mark.parametrize("argv_prefix", INTERPRETERS)
+def test_empty_demo_acceptance_required_still_names_required(
+    tmp_path: Path, argv_prefix: list[str]
+) -> None:
+    """The correct diagnosis for the correct fault is unchanged."""
+    root = build_root(tmp_path)
+    manifest = yaml.safe_load((root / MANIFEST_NAME).read_text(encoding="utf-8"))
+    manifest["demoAcceptance"] = {"required": []}
+    (root / MANIFEST_NAME).write_text(
+        yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8"
+    )
+
+    proc = run(root, argv_prefix)
+    assert proc.returncode == 2, proc.stdout
+    assert "ERR: demoAcceptance.required must be a non-empty list" in proc.stderr

--- a/tools/validate_professional_intelligence_manifest.py
+++ b/tools/validate_professional_intelligence_manifest.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import sys
 
 try:
@@ -87,6 +88,63 @@ def require_set_contains(values: object, required: set[str], label: str) -> int:
     return 0
 
 
+# Estate refs are written `<org>/<repo>:<path>`. The org is matched against a
+# known set rather than any `<a>/<b>:` shape so that an unrecognised prefix
+# falls through to the LOCAL side, where it gets stat'd and fails loudly if it
+# is not there. The costly direction of a misclassification is the other one:
+# anything routed to the cross-repo side is skipped, and a wrongly-skipped ref
+# is precisely the unverified-declaration gap this check exists to close. If a
+# new estate org appears, adding it here is a deliberate act.
+ESTATE_ORGS = frozenset({"SocioProphet"})
+CROSS_REPO_REF = re.compile(r"^(?P<org>[A-Za-z0-9._-]+)/[A-Za-z0-9._-]+:.+$")
+
+
+def is_cross_repo_ref(ref: str) -> bool:
+    """True for refs that name another estate repo, e.g. `SocioProphet/x:path`.
+
+    Cross-repo refs point outside this checkout, so their target cannot be
+    stat'd from here -- see require_declared_paths_exist().
+    """
+    match = CROSS_REPO_REF.match(ref)
+    return match is not None and match.group("org") in ESTATE_ORGS
+
+
+def require_declared_paths_exist(required: set[str], label: str) -> int:
+    """Stat the in-repo evidence this manifest claims alignment against.
+
+    require_set_contains() only proves the manifest *lists* a path. Listing is
+    a declaration about the world; this function checks the world. Without it
+    the manifest can claim contract alignment against files that were deleted
+    or never existed, and the tool still prints its OK banner and exits 0.
+
+    Cross-repo refs (`SocioProphet/<repo>:<path>`) resolve into peer repos that
+    are not present in this checkout, so they CANNOT be verified here and are
+    skipped deliberately. The skip is printed rather than silent: an unreported
+    skip is how a declared-but-unverified ref creeps back in. Verifying those
+    belongs to the owning repo's own validator.
+    """
+    local_refs = sorted(r for r in required if not is_cross_repo_ref(r))
+    skipped = sorted(r for r in required if is_cross_repo_ref(r))
+
+    if skipped:
+        print(
+            f"SKIP: {label}: {len(skipped)} cross-repo ref(s) not stat-able from this "
+            f"checkout, not verified here: {skipped}"
+        )
+
+    missing = [ref for ref in local_refs if not (ROOT / ref).exists()]
+    if missing:
+        for ref in missing:
+            print(
+                f"ERR: {label} declares {ref!r} but that path does not exist in this repo",
+                file=sys.stderr,
+            )
+        return 1
+
+    print(f"OK: {label}: {len(local_refs)} in-repo evidence path(s) exist on disk")
+    return 0
+
+
 def main() -> int:
     if not MANIFEST.exists():
         return fail(f"missing {MANIFEST.relative_to(ROOT)}")
@@ -141,13 +199,26 @@ def main() -> int:
     bad += require_set_contains(owner_repos, {"SocioProphet/prophet-workspace"}, "workspaceOS.ownerRepos")
     bad += require_set_contains(workspace_os.get("contractPaths", []), REQUIRED_WORKSPACE_OS_CONTRACTS, "workspaceOS.contractPaths")
     bad += require_set_contains(workspace_os.get("controlRefs", []), REQUIRED_WORKSPACE_OS_CONTROLS, "workspaceOS.controlRefs")
+
+    # The two require_set_contains() calls above only prove the manifest LISTS
+    # these refs. Stat the in-repo ones so "contract-aligned" cannot be claimed
+    # against files that are no longer there. Driven off the same constants the
+    # listing checks use, so the two can never drift apart.
+    bad += require_declared_paths_exist(REQUIRED_WORKSPACE_OS_CONTRACTS, "workspaceOS.contractPaths")
+    bad += require_declared_paths_exist(REQUIRED_WORKSPACE_OS_CONTROLS, "workspaceOS.controlRefs")
     bad += require_set_contains(workspace_os.get("recoveredSubstrateRefs", []), REQUIRED_RECOVERED_REFS, "workspaceOS.recoveredSubstrateRefs")
 
     claim_boundary = data.get("claimBoundary", [])
     bad += require_set_contains(claim_boundary, set(CLAIM_BOUNDARY_REQUIREMENTS), "claimBoundary")
 
-    demo_required = data.get("demoAcceptance", {}).get("required") if isinstance(data.get("demoAcceptance"), dict) else None
-    if not expect_nonempty_list(demo_required, "demoAcceptance.required"):
+    # Route the shape check through expect_mapping() like every other field.
+    # The old inline ternary collapsed a non-mapping demoAcceptance to None and
+    # then blamed "demoAcceptance.required", naming a field that is not the
+    # problem. Same fail-closed outcome, correct diagnosis.
+    demo_acceptance = data.get("demoAcceptance")
+    if not expect_mapping(demo_acceptance, "demoAcceptance"):
+        bad += 1
+    elif not expect_nonempty_list(demo_acceptance.get("required"), "demoAcceptance.required"):
         bad += 1
 
     if bad:


### PR DESCRIPTION
Closes the **declared-but-never-stat'd** gap in
`tools/validate_professional_intelligence_manifest.py`, reported but not fixed
in #1096.

`require_set_contains()` proves the manifest *lists* a contract path. Nothing
ever checked the path was **there**. Deleting all five in-repo evidence files
and re-running the tool on unmodified `origin/main`, in a temp copy of the repo:

```
OK: professional-intelligence.manifest.yaml structure valid
OK: workspaceOS contract-aligned evidence present
OK: workroom update runtime boundary refs present
OK: workroom update invalid fixture is registered
OK: claim boundaries present
rc=0
```

A check that verifies a *declaration about the world* rather than the world.

## What changed

`require_declared_paths_exist()` stats the in-repo members of
`REQUIRED_WORKSPACE_OS_CONTRACTS` / `REQUIRED_WORKSPACE_OS_CONTROLS`. It is
driven off **the same constants the listing checks use**, so the two cannot
drift, and the manifest cannot weaken the check by editing itself.

### Cross-repo refs are skipped out loud

`SocioProphet/<repo>:<path>` refs resolve into peer repos absent from this
checkout and genuinely cannot be stat'd here. They are skipped deliberately and
the skip is **printed**, on every run, including green ones:

```
SKIP: workspaceOS.contractPaths: 3 cross-repo ref(s) not stat-able from this checkout, not verified here: [...]
OK: workspaceOS.contractPaths: 3 in-repo evidence path(s) exist on disk
SKIP: workspaceOS.controlRefs: 4 cross-repo ref(s) not stat-able from this checkout, not verified here: [...]
OK: workspaceOS.controlRefs: 2 in-repo evidence path(s) exist on disk
```

A silently-skipped ref is how this class comes back. 7 skipped, 5 verified,
both counts visible.

Classification matches `<org>/<repo>:` against a **known-org set**, not any
`<a>/<b>:` shape, so an unrecognised prefix falls through to the LOCAL side and
fails loudly. Skipping is the costly direction of a misclassification. This is
not theoretical: the first draft of the regex sent `docs/notes:draft.md` to the
skipped column and the new test caught it before commit.

## Teeth — the mandatory proof

Each of the five deleted in turn in a temp copy of the repo:

| tool | rc | behaviour |
|---|---|---|
| `origin/main` | **0** | prints `OK: workspaceOS contract-aligned evidence present` |
| this branch | **2** | `ERR: workspaceOS.controlRefs declares 'docs/WORKROOM_UPDATE_RUNTIME_BOUNDARY.md' but that path does not exist in this repo` |

Restored → rc=0 again. All five caught, **identical under `python3` and
`python3 -O`**. Every one of the 21 new tests runs under both interpreters,
extending the `-O` discipline #1096 introduced rather than regressing it.

The baseline test asserts the **evidence line is present**, not merely rc=0 —
rc=0 alone would still pass if the check were deleted.

## 2. `demoAcceptance` named the wrong field

A non-mapping `demoAcceptance` collapsed to `None` through an inline ternary and
was then reported as *"demoAcceptance.required must be a non-empty list"*. It
fails closed either way (rc=2), so this is **diagnostics only**. It now routes
through `expect_mapping()` like every other field in the file:

| manifest | before | after |
|---|---|---|
| `demoAcceptance: [...]` | `ERR: demoAcceptance.required must be a non-empty list` | `ERR: demoAcceptance must be a mapping/object` |
| `demoAcceptance: {required: []}` | `ERR: demoAcceptance.required ...` | unchanged |

## Verification

- `tools/tests`: **310 passed** (289 on this base + 21 new). No regressions.
- Real manifest still validates **rc=0** under `python3`, `python3 -O`, and
  `make validate-professional-intelligence-manifest`.

## ⚠️ Merge-order note — interacts with #1096

#1096 is **not merged**, so this branch is cut from `main` and its 289-test
baseline excludes #1096's 9 tests. The two merge **cleanly textually**, but the
combination is **not green**, and that is worth catching before it lands:

#1096's `run_against()` builds a fixture root holding only the tool and the
manifest. Under this branch's tool that root is no longer a valid repo — the
five declared evidence paths are absent — so
`test_real_manifest_still_validates` fails (2 tests; the malformed-shape tests
still pass). The tool is behaving correctly; the fixture is under-specified.

Verified fix, 7 lines in **#1096's** file — whichever PR merges second applies it:

```python
DECLARED_EVIDENCE = [
    "contracts/workspace/workroom-update-request.example.json",
    "contracts/workspace/workroom-update-response.accepted.example.json",
    "contracts/workspace/workroom-update-response.invalid-runtime-mutation.example.json",
    "docs/WORKROOM_UPDATE_RUNTIME_BOUNDARY.md",
    "tools/validate_workroom_update_contract.py",
]
# ...in run_against(), after copying the tool:
for rel in DECLARED_EVIDENCE:
    dest = root / rel
    dest.parent.mkdir(parents=True, exist_ok=True)
    shutil.copy2(REPO_ROOT / rel, dest)
```

Measured on the actual merge tree: **30 passed** across both files with that
patch applied. Not applied here — the file does not exist on this branch's base.

## Lane

`tools/` only — two files. Does **not** touch
`.github/workflows/validate-target-diagnostics.yml`.
