### PR TITLE
ci(search): revive an image-pin workflow rejected before startup since 2026-06-23

### DIFF
--- a/.github/workflows/search-orchestrator-image-pin.yml
+++ b/.github/workflows/search-orchestrator-image-pin.yml
@@ -6,26 +6,99 @@ on:
       - search-orchestrator-image
     types:
       - completed
+  # Until now nothing could fire this workflow from its own source file. It
+  # succeeded once (2026-04-26) and was then rejected at run creation nine times
+  # (2026-07-03 .. 2026-07-20) without one character of it changing, because the
+  # repo's Actions allowlist moved underneath it on 2026-06-23. No review could
+  # have caught that: no pull request ever ran this file. These two triggers close
+  # the hole — a change to the workflow, or to the script it now depends on, has
+  # to prove itself before it merges.
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/search-orchestrator-image-pin.yml"
+      - "scripts/ci/open-image-pin-pr.sh"
+      - "scripts/ci/test-open-image-pin-pr.sh"
+  # Also the operator handle for re-pinning after a missed or failed build,
+  # without re-running the image build to get there.
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "search-orchestrator-image run to pin from (blank = latest successful run on main)"
+        required: false
 
 permissions:
   contents: write
   pull-requests: write
-  actions: read
+  # `write`, not `read`. The pin PR is opened with GITHUB_TOKEN, and a PR opened
+  # that way never starts a `pull_request` run, so the required `diagnostics-gate`
+  # check never appears and the PR can never merge. scripts/ci/open-image-pin-pr.sh
+  # dispatches the gate explicitly to fix that, and `gh workflow run` needs
+  # actions: write. The script and gitops-promote.yml carry the measurements.
+  actions: write
 
 jobs:
+  # No network, no secrets, seconds to run — and the only reason a pull_request
+  # event reaches this file at all. This is the leg that would have caught the
+  # 2026-06-23 breakage.
+  self-test:
+    name: self-test / pin PR logic
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify no-op, scoping, create, refresh and dispatch-failure behaviour
+        run: scripts/ci/test-open-image-pin-pr.sh
+
   pin:
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
+    needs: self-test
+    # Deliberately never on pull_request: a PR must not force-push automation
+    # branches or open pull requests of its own.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           ref: main
 
+      - name: Resolve the image build to pin from
+        id: source
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Via env, not `${{ }}` inside the script: inputs.run_id is operator-supplied
+          # and direct interpolation would splice it into the shell before bash sees it.
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          INPUT_RUN_ID: ${{ inputs.run_id }}
+        run: |
+          set -euo pipefail
+          run_id="${WORKFLOW_RUN_ID:-}"
+          [ -n "$run_id" ] || run_id="${INPUT_RUN_ID:-}"
+          # It is about to become part of an API path; digits only.
+          if [ -n "$run_id" ] && ! [[ "$run_id" =~ ^[0-9]+$ ]]; then
+            echo "::error::run_id must be numeric, got: $run_id"
+            exit 1
+          fi
+          if [ -z "$run_id" ]; then
+            run_id="$(gh run list --workflow=search-orchestrator-image.yml --branch main \
+                        --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
+            [ -n "$run_id" ] || {
+              echo "::error::no successful search-orchestrator-image run on main to pin from"
+              exit 1
+            }
+            echo "no run id supplied; using the latest successful build on main: $run_id"
+          fi
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
       - uses: actions/download-artifact@v4
         with:
           name: search-orchestrator-image-evidence
           path: image-evidence
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.source.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Apply image lock
@@ -39,32 +112,12 @@ jobs:
         run: |
           python3 tools/validate_search_orchestrator_image_release.py
 
-      - name: Create pinning pull request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          branch: automation/search-orchestrator-image-pin
-          delete-branch: true
-          title: "release(search): pin search orchestrator image digest"
-          commit-message: "release(search): pin search orchestrator image digest"
-          body: |
-            ## Summary
-
-            Pins the Search Orchestrator image digest from the successful `search-orchestrator-image` workflow run.
-
-            ## Scope
-
-            - Updates `releases/images/search-orchestrator.image-lock.json`
-            - Updates the digest-pinned Kustomize image patch
-            - Keeps the example lock unchanged
-
-            ## Safety posture
-
-            - Digest pin only
-            - No runtime route behavior change
-            - No learner action execution
-            - No Canon promotion
-            - No policy grant creation
-            - No memory writeback
-          add-paths: |
-            releases/images/search-orchestrator.image-lock.json
-            infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml
+      # Was `peter-evans/create-pull-request@v6`. That action is Marketplace-listed
+      # but its creator carries no verified badge, so this repo's
+      # `allowed_actions: selected` policy blocks it and every run was rejected
+      # before any job started. See the script for the full account, the rejected
+      # settings-change alternative, and why it dispatches the diagnostics gate.
+      - name: Open the pinning pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: scripts/ci/open-image-pin-pr.sh

--- a/scripts/ci/open-image-pin-pr.sh
+++ b/scripts/ci/open-image-pin-pr.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# Open (or refresh) the search-orchestrator image-pin pull request, without a
+# third-party action.
+#
+# WHY THIS EXISTS INSTEAD OF `peter-evans/create-pull-request`
+# ------------------------------------------------------------
+# This repo restricts Actions to `allowed_actions: selected` — github-owned, plus
+# verified-creator Marketplace actions, plus an explicit pattern allowlist
+# (dtolnay/*, Swatinem/*, oven-sh/*, tauri-apps/*). `peter-evans/create-pull-request`
+# is Marketplace-listed, but its creator is an individual with no verified-creator
+# badge, so `verified_allowed` does not cover it, and it matches no pattern.
+#
+# A workflow that references a blocked action is rejected at run creation, before
+# any job starts: conclusion `startup_failure`, no logs, no annotation, no alert.
+# search-orchestrator-image-pin.yml succeeded once (2026-04-26) and then failed
+# that way nine times in a row (2026-07-03 .. 2026-07-20) without one character of
+# the file changing — the policy moved underneath it on 2026-06-23. The other two
+# actions it uses, actions/checkout and actions/download-artifact, are
+# github-owned and were never affected.
+#
+# The alternative fix — an admin adding `peter-evans/*` to patterns_allowed — is a
+# repository settings change: invisible in a diff, unreviewable in a PR, and it
+# re-grants a third party code execution against the workflow token. It was
+# rejected for exactly that reason in the OpenTofu case (PRs #1090 and #1097, see
+# scripts/ci/install-opentofu.sh). This follows that precedent.
+#
+# BEHAVIOUR (matching what the action did, minus the third party)
+# ---------------------------------------------------------------
+#   * Commits ONLY the two pin paths — the action's `add-paths`. The evidence
+#     artifact downloaded into image-evidence/ never enters the commit.
+#   * No digest change is the normal case, and is a silent success, not a failure.
+#   * The automation branch is reused and reset, so repeated builds refresh one
+#     pull request instead of opening a pile of them.
+#
+# THE GITHUB_TOKEN CONSEQUENCE — read before changing the dispatch below
+# ----------------------------------------------------------------------
+# A pull request opened with GITHUB_TOKEN does not start `pull_request` workflow
+# runs. That is GitHub's no-recursion rule, and it is deliberate. In this repo the
+# `main-required-checks` ruleset requires exactly one context, `diagnostics-gate`,
+# so a PR opened here gets no gate, and cannot merge — permanently BLOCKED, with a
+# handful of green GitHub-App checks (CodeQL, GitGuardian) making it look ready.
+# Measured on real PRs: #1007/#1013 (zero runs) and #1017/#1018 (runs parked at
+# action_required, which publish no check-runs). gitops-promote.yml carries the
+# full write-up.
+#
+# workflow_dispatch is the documented exception: an explicit dispatch does create
+# a run under GITHUB_TOKEN, and is not a pull_request event, so it is not subject
+# to the contributor-approval gate either. Its check-runs attach to the branch
+# head, which is the PR head, so `diagnostics-gate` lands on the PR rollup.
+# That is why this script dispatches, and why the workflow needs `actions: write`.
+# Removing the dispatch does not make the PR "slightly worse" — it makes every PR
+# this workflow opens unmergeable.
+
+set -euo pipefail
+
+BASE="${PIN_PR_BASE:-main}"
+BRANCH="${PIN_PR_BRANCH:-automation/search-orchestrator-image-pin}"
+TITLE="release(search): pin search orchestrator image digest"
+DIAGNOSTICS_WORKFLOW="${PIN_PR_DIAGNOSTICS_WORKFLOW:-validate-target-diagnostics.yml}"
+# Overridable so the self-test does not spend 20 real seconds proving the retry.
+RETRY_SLEEP="${PIN_PR_RETRY_SLEEP:-10}"
+
+PIN_PATHS=(
+  "releases/images/search-orchestrator.image-lock.json"
+  "infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml"
+)
+
+# ── Nothing to pin ───────────────────────────────────────────────────────────
+# The digest already matches. This is the common outcome for a rebuild of an
+# unchanged tree, and it must not look like a failure.
+if [ -z "$(git status --porcelain -- "${PIN_PATHS[@]}")" ]; then
+  echo "no digest change: the lock and the Kustomize patch already match this build"
+  echo "nothing to open"
+  exit 0
+fi
+
+echo "digest change detected in:"
+git status --porcelain -- "${PIN_PATHS[@]}" | sed 's/^/  /'
+
+# ── Commit, on a reset automation branch ─────────────────────────────────────
+git config user.name "search-orchestrator-image-pin"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+git checkout -b "$BRANCH"
+# Explicit pathspec, never `git commit -a`: image-evidence/ and anything else the
+# job leaves in the tree stays out. This is the `add-paths` guarantee.
+git add -- "${PIN_PATHS[@]}"
+git commit -m "$TITLE"
+
+# --force: this is a reusable automation ref that may still hold a now-stale
+# digest from an earlier build. The action reset it the same way. Nothing but
+# this job writes under automation/.
+git push --force origin "HEAD:refs/heads/$BRANCH"
+
+# ── Open the PR, or reuse the one that is already open ───────────────────────
+open_pr() {
+  gh pr list --head "$BRANCH" --base "$BASE" --state open \
+    --json number --jq '.[0].number // empty'
+}
+
+pr="$(open_pr)"
+if [ -n "$pr" ]; then
+  echo "PR #$pr is already open for $BRANCH; the refreshed pin was pushed onto it"
+else
+  gh pr create --base "$BASE" --head "$BRANCH" --title "$TITLE" --body "$(
+    cat <<'BODY'
+## Summary
+
+Pins the Search Orchestrator image digest from the successful `search-orchestrator-image`
+workflow run.
+
+## Scope
+
+- Updates `releases/images/search-orchestrator.image-lock.json`
+- Updates the digest-pinned Kustomize image patch
+- Keeps the example lock unchanged
+
+## Safety posture
+
+- Digest pin only
+- No runtime route behavior change
+- No learner action execution
+- No Canon promotion
+- No policy grant creation
+- No memory writeback
+
+## How this PR gets its required check
+
+This PR was opened by CI with `GITHUB_TOKEN`. **A pull request opened that way does
+not start `pull_request` workflow runs** — GitHub's no-recursion rule. The
+`main-required-checks` ruleset requires `diagnostics-gate`, so left alone this PR
+would sit BLOCKED forever, while unrelated GitHub-App checks (CodeQL, GitGuardian)
+go green and make it look mergeable. It is not: a green rollup of those alone is a
+mirage.
+
+So the job that opened this PR also dispatches `validate-target-diagnostics.yml`
+onto this branch explicitly. `workflow_dispatch` is the documented exception to
+the no-recursion rule, and its check-runs attach to this branch head, which is
+this PR's head — so `diagnostics-gate` appears here and the ruleset is satisfied.
+
+**If `diagnostics-gate` is missing below**, the dispatch failed (the job logs a
+warning when it does). Produce it with:
+
+```
+gh workflow run validate-target-diagnostics.yml --ref automation/search-orchestrator-image-pin
+```
+
+Do not "push an empty commit to kick CI" — that is the manual workaround the
+dispatch replaces.
+BODY
+  )"
+  pr="$(open_pr)"
+  echo "opened PR #${pr:-<unknown>} for $BRANCH"
+fi
+
+# ── Give the PR the one check that is actually required ──────────────────────
+# Unattended job: a dispatch that quietly fails leaves the PR BLOCKED until a
+# human happens to look. A freshly pushed ref can also take a moment to become
+# dispatchable, hence the retry.
+dispatched=""
+for attempt in 1 2 3; do
+  if gh workflow run "$DIAGNOSTICS_WORKFLOW" --ref "$BRANCH"; then
+    dispatched=1
+    echo "dispatched $DIAGNOSTICS_WORKFLOW onto $BRANCH (attempt $attempt)"
+    break
+  fi
+  echo "dispatch attempt $attempt failed; retrying in ${RETRY_SLEEP}s"
+  sleep "$RETRY_SLEEP"
+done
+
+if [ -z "$dispatched" ]; then
+  echo "::warning::could not dispatch $DIAGNOSTICS_WORKFLOW onto $BRANCH after 3 attempts. PR #${pr:-<unknown>} will stay BLOCKED, because diagnostics-gate is required and a GITHUB_TOKEN pull request does not produce it on its own. Recover with: gh workflow run $DIAGNOSTICS_WORKFLOW --ref $BRANCH"
+fi

--- a/scripts/ci/test-open-image-pin-pr.sh
+++ b/scripts/ci/test-open-image-pin-pr.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Self-test for scripts/ci/open-image-pin-pr.sh.
+#
+# The script it guards runs unattended, on a trigger no pull request fires, and it
+# force-pushes a branch and opens a PR. That combination is exactly how
+# search-orchestrator-image-pin.yml managed to be broken from 2026-06-23 to
+# 2026-07-20 without anyone noticing. So the logic gets a test that needs no
+# network, no secrets and no GitHub: a throwaway git repo, and a `gh` stub on PATH
+# that records what it was asked to do.
+#
+# What is genuinely covered: the no-op exit, commit path-scoping, branch reset,
+# create-vs-refresh, and the diagnostics dispatch including its failure warning.
+# What is NOT covered: that the real `gh` accepts these arguments, and that the
+# real API behaves as expected. Those need a live run.
+
+set -euo pipefail
+
+SCRIPT_UNDER_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/open-image-pin-pr.sh"
+[ -x "$SCRIPT_UNDER_TEST" ] || { echo "FAIL: $SCRIPT_UNDER_TEST is not executable"; exit 1; }
+
+LOCK="releases/images/search-orchestrator.image-lock.json"
+PATCH="infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml"
+
+WORKROOT="$(mktemp -d)"
+trap 'rm -rf "$WORKROOT"' EXIT
+
+failures=0
+pass() { echo "  ok   — $1"; }
+fail() { echo "  FAIL — $1"; failures=$((failures + 1)); }
+
+# A `gh` that logs its arguments and answers `pr list` from the environment.
+make_gh_stub() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/gh" <<'STUB'
+#!/usr/bin/env bash
+# One line per invocation. `gh pr create --body` carries a multi-line body, and
+# logging it verbatim put lines like "workflow run." — wrapped prose from the body
+# — at the start of a log line, where a `^workflow run` assertion counted it as a
+# fourth dispatch. Flatten first, then assertions mean what they look like.
+printf '%s\n' "$(printf '%s' "$*" | tr '\n' ' ')" >>"$GH_LOG"
+case "$1 ${2:-}" in
+  "pr list")     printf '%s' "${STUB_OPEN_PR:-}" ;;
+  "pr create")   echo "https://github.com/SocioProphet/prophet-platform/pull/9999" ;;
+  "workflow run") exit "${STUB_DISPATCH_RC:-0}" ;;
+esac
+exit 0
+STUB
+  chmod +x "$dir/gh"
+}
+
+# A repo with an origin to push to, the two pin paths committed, and the script
+# available at the path the workflow calls it by.
+new_case() {
+  local name="$1"
+  CASE_DIR="$WORKROOT/$name"
+  mkdir -p "$CASE_DIR"
+  git init --quiet --bare "$CASE_DIR/origin.git"
+  git clone --quiet "$CASE_DIR/origin.git" "$CASE_DIR/work"
+  cd "$CASE_DIR/work"
+  git config user.email seed@example.invalid
+  git config user.name seed
+  git config init.defaultBranch main >/dev/null 2>&1 || true
+  git checkout --quiet -b main 2>/dev/null || true
+  mkdir -p "$(dirname "$LOCK")" "$(dirname "$PATCH")"
+  echo '{"digest":"sha256:old"}' >"$LOCK"
+  echo 'image: old' >"$PATCH"
+  git add -A && git commit --quiet -m "seed"
+  git push --quiet -u origin main >/dev/null 2>&1
+
+  GH_LOG="$CASE_DIR/gh.log"
+  : >"$GH_LOG"
+  make_gh_stub "$CASE_DIR/bin"
+  export GH_LOG
+  export PATH="$CASE_DIR/bin:$PATH"
+  export PIN_PR_RETRY_SLEEP=0
+  unset STUB_OPEN_PR STUB_DISPATCH_RC || true
+}
+
+run_script() {
+  set +e
+  OUT="$("$SCRIPT_UNDER_TEST" 2>&1)"
+  RC=$?
+  set -e
+}
+
+echo "case 1: no digest change is a silent success"
+new_case nochange
+run_script
+[ "$RC" -eq 0 ] || fail "expected exit 0, got $RC"
+grep -q "no digest change" <<<"$OUT" || fail "expected the no-op message; got: $OUT"
+[ ! -s "$GH_LOG" ] || fail "gh must not be called when there is nothing to pin; got: $(cat "$GH_LOG")"
+git -C "$CASE_DIR/origin.git" show-ref --quiet refs/heads/automation/search-orchestrator-image-pin \
+  && fail "no automation branch should have been pushed" \
+  || pass "no-op: exits 0, touches nothing"
+
+echo "case 2: a digest change opens a PR and dispatches the gate"
+new_case create
+echo '{"digest":"sha256:new"}' >"$LOCK"
+echo 'image: new' >"$PATCH"
+run_script
+[ "$RC" -eq 0 ] || fail "expected exit 0, got $RC — $OUT"
+git -C "$CASE_DIR/origin.git" show-ref --quiet refs/heads/automation/search-orchestrator-image-pin \
+  || fail "the automation branch was not pushed"
+grep -q "^pr create" "$GH_LOG" || fail "gh pr create was not called"
+grep -q "^workflow run validate-target-diagnostics.yml" "$GH_LOG" \
+  || fail "the diagnostics gate was not dispatched"
+grep -q -- "--ref automation/search-orchestrator-image-pin" "$GH_LOG" \
+  || fail "the dispatch did not target the automation branch"
+[ "$failures" -eq 0 ] && pass "create: branch pushed, PR opened, gate dispatched"
+
+echo "case 3: only the pin paths are committed"
+new_case scoped
+echo '{"digest":"sha256:new"}' >"$LOCK"
+echo 'image: new' >"$PATCH"
+mkdir -p image-evidence && echo 'downloaded artifact' >image-evidence/search-orchestrator-image.json
+echo 'unrelated dirty file' >NOTES.txt
+run_script
+[ "$RC" -eq 0 ] || fail "expected exit 0, got $RC — $OUT"
+committed="$(git -C "$CASE_DIR/work" show --name-only --format= HEAD | sort | tr '\n' ' ')"
+case "$committed" in
+  *image-evidence*) fail "the evidence artifact was committed: $committed" ;;
+  *NOTES.txt*)      fail "an unrelated file was committed: $committed" ;;
+  *)                pass "scoping: committed only [$committed]" ;;
+esac
+
+echo "case 4: an already-open PR is refreshed, not duplicated"
+new_case refresh
+echo '{"digest":"sha256:new"}' >"$LOCK"
+echo 'image: new' >"$PATCH"
+export STUB_OPEN_PR=4242
+run_script
+[ "$RC" -eq 0 ] || fail "expected exit 0, got $RC — $OUT"
+grep -q "^pr create" "$GH_LOG" && fail "a second PR was opened over an existing one"
+grep -q "#4242 is already open" <<<"$OUT" || fail "the existing PR was not reported; got: $OUT"
+grep -q "^workflow run" "$GH_LOG" || fail "the gate must still be dispatched on a refresh"
+unset STUB_OPEN_PR
+[ "$failures" -eq 0 ] && pass "refresh: reuses PR #4242, still dispatches"
+
+echo "case 5: a failed dispatch warns loudly instead of passing quietly"
+new_case dispatchfail
+echo '{"digest":"sha256:new"}' >"$LOCK"
+echo 'image: new' >"$PATCH"
+export STUB_DISPATCH_RC=1
+run_script
+[ "$RC" -eq 0 ] || fail "a failed dispatch should not fail the job, got $RC"
+grep -q "::warning::" <<<"$OUT" || fail "no warning annotation on dispatch failure; got: $OUT"
+grep -q "BLOCKED" <<<"$OUT" || fail "the warning must say the PR will be BLOCKED"
+[ "$(grep -c '^workflow run' "$GH_LOG")" -eq 3 ] || fail "expected 3 dispatch attempts, got $(grep -c '^workflow run' "$GH_LOG")"
+unset STUB_DISPATCH_RC
+[ "$failures" -eq 0 ] && pass "dispatch failure: 3 attempts, warns, does not fail the job"
+
+echo
+if [ "$failures" -ne 0 ]; then
+  echo "$failures check(s) FAILED"
+  exit 1
+fi
+echo "all pin-PR checks passed"


### PR DESCRIPTION
## The defect

`search-orchestrator-image-pin.yml` succeeded once, on **2026-04-26**, and has been a
`startup_failure` every time it has fired since — **nine consecutive**, 2026-07-03
through 2026-07-20.

The file is not at fault, and the proof is that it never changed: the commit that
created it (`7580a53a`, 2026-04-26) is still the only commit that touches it. The
version failing nine times is byte-identical to the version that succeeded. The
repository's Actions allowlist moved underneath it on **2026-06-23**.

Policy today:

```
allowed_actions: selected
{"github_owned_allowed":true,"verified_allowed":true,
 "patterns_allowed":["dtolnay/*","Swatinem/*","oven-sh/*","tauri-apps/*"]}
```

`peter-evans/create-pull-request@v6` is Marketplace-listed, but its creator is an
individual with **no verified-creator badge**, so `verified_allowed` does not reach
it, and it matches no pattern. A workflow naming a blocked action is rejected **at
run creation** — before any job starts. No logs, no annotation, no failing step, and
a conclusion that reads as infrastructure noise. The other two actions it uses,
`actions/checkout@v4` and `actions/download-artifact@v4`, are github-owned and were
never affected.

The April→July gap is trigger absence, not a later regression: `workflow_run` only,
and the upstream image build did not land on `main` between those dates.

## The fix

`peter-evans/create-pull-request` → `scripts/ci/open-image-pin-pr.sh`, opening the PR
with `gh` and the workflow token. Same direction as the OpenTofu case in #1090/#1097
(`scripts/ci/install-opentofu.sh`). It preserves what the action did — `add-paths`
scoping, branch reuse, no-op on an unchanged digest — with no third party holding the
workflow token.

**The alternative was considered and not taken.** An admin could add `peter-evans/*`
to `patterns_allowed`. That is a repository *settings* change: invisible in a diff,
unreviewable in a PR, and it re-grants a third party execution against `GITHUB_TOKEN`.
It was rejected for exactly that reason in the OpenTofu case, and this follows the
precedent rather than quietly diverging from it.

## ⚠️ The `GITHUB_TOKEN` consequence, stated plainly

**A pull request opened with `GITHUB_TOKEN` does not start `pull_request` workflow
runs.** That is GitHub's no-recursion rule.

`main-required-checks` requires exactly one context: `diagnostics-gate`. So a PR
opened by this workflow gets no gate and **cannot merge** — while CodeQL and
GitGuardian (GitHub-App checks, exempt from the rule) go green and make it look
ready. It is not. Three `gitops/promote` PRs are sitting `BLOCKED` in exactly this
state right now: **#1093, #1064, #1063**.

Shipping the naive `gh pr create` would have reproduced that trap, so this does not:
the script **dispatches `validate-target-diagnostics.yml` onto the branch
explicitly**. `workflow_dispatch` is the documented exception — it does create a run
under `GITHUB_TOKEN`, it is not a `pull_request` event so the contributor-approval
gate does not park it, and its check-runs attach to the branch head, which is the PR
head. `diagnostics-gate` therefore lands on the PR rollup. This is why `permissions`
moves from `actions: read` to `actions: write`.

If the dispatch fails, the job emits a `::warning::` naming the PR and the recovery
command rather than exiting green in silence. The PR body it writes explains all of
this to whoever opens it, including what to do if the gate is missing. The mechanism
and its measurements are `gitops-promote.yml`'s; this reuses them rather than
inventing a second answer.

## Why it could rot for four months, and what changes

Nothing could fire this workflow from its own source file — `workflow_run` only. **No
pull request has ever run it**, so no review could have caught the breakage, and
`startup_failure` raises no alert. That is the real defect; the blocked action is just
what it happened to be.

So the workflow now also triggers on `pull_request` limited to itself and its script,
and runs a `self-test` job — no network, no secrets, seconds — that exercises the
PR-opening logic against a throwaway git repo and a stubbed `gh`:

| case | asserts |
|---|---|
| no digest change | exits 0 silently, pushes nothing, never calls `gh` |
| digest change | branch pushed, PR opened, gate dispatched |
| path scoping | commits **only** the two pin paths — not `image-evidence/`, not stray files |
| PR already open | refreshes it, does not open a second |
| dispatch fails | 3 attempts, `::warning::`, says BLOCKED, does not fail the job |

The test was mutation-checked, because a green test that cannot fail is worse than
none: breaking path scoping, the no-op guard, and the dispatch each produce the
specific failure written for them. It also earned its keep immediately — it caught a
real bug in its own harness, where the multi-line PR body logged prose starting
"workflow run." and inflated a dispatch count from 3 to 4.

A `workflow_dispatch` trigger is also added, permanently: it is the operator handle
for re-pinning after a missed build without re-running the image build, and it is the
only way to exercise the `pin` job by hand. `inputs.run_id` is passed through `env`
and validated numeric rather than interpolated into the shell.

## The general problem

This is the **fourth** workflow found dead from one policy change: `tofu-drift-detect`
(26 `startup_failure`s), `tofu-plan.yml` (25), `helm-release.yml` (17 — never once
succeeded), and this (9). **77 rejected runs, over a month, no alert.**

A policy change that silently kills workflows produces `startup_failure`, which reads
as flakiness and pages nobody. The per-workflow fixes do not address that. Whatever
mechanical check comes out of this should catch a **newly-blocked** action — an
allowlist that shrinks, or a `uses:` that is added and does not match it — not just
re-detect today's four. A check that only knows these four names will miss the fifth
exactly as thoroughly as we missed these.

## Verification — what was and was not proven

**Verified locally:**
- Self-test passes 5/5; mutation-tested with 3 mutants, each caught.
- `python3 tools/check_workflow_path_filters.py` → `0 failure(s)` with this change.
  The workflow joins the advisory list ("no unfiltered push-on-main trigger"); it is
  not vouched, nothing regresses. `docs/CI_PATH_FILTER_DEBT.md` is another lane's file
  and is deliberately untouched — it is advisory and asserted by nothing.
- YAML parses; the `pin` job's `if` excludes `pull_request`, so a PR can never
  force-push an automation branch or open a PR of its own.
- Empirically confirmed the policy reading rather than assuming it: `hashicorp/*`,
  `azure/*`, `docker/*` and `google-github-actions/*` all have **successful** runs
  *after* 2026-06-23, so `verified_allowed` demonstrably works for verified creators —
  which is what isolates `peter-evans` as unverified.

**Verified in CI:** this PR triggers the workflow via the new `pull_request` filter.
**A run being created at all is the proof** — `startup_failure` is instant and happens
before queueing, so a run that reaches `queued` has already cleared the defect. See
the checks below for the live state.

**NOT verified:** the `pin` job end-to-end against live GitHub. It is `workflow_run`/
dispatch-gated, and dispatching it would force-push `automation/search-orchestrator-image-pin`
and open a real pin PR — avoidable side effects while CI is saturated. So the real
`gh pr create` / `gh workflow run` calls are covered by a stub, not by the live API.
The first genuine end-to-end exercise will be the next successful
`search-orchestrator-image` build on `main`. Called out rather than glossed.

Note for whoever picks that up: the digest has been unpinned since April while at
least six image builds succeeded, so the first real run will produce a substantive pin.

## Scope

Three files. No other lane's workflows, no settings change, no new secret.

- `.github/workflows/search-orchestrator-image-pin.yml`
- `scripts/ci/open-image-pin-pr.sh` (new)
- `scripts/ci/test-open-image-pin-pr.sh` (new)

CI is saturated (~400 queued, 0 self-hosted runners). **Pending is not green** — please
read the checks before merging, and do not merge on a green rollup that is missing
`diagnostics-gate`.
