### PR TITLE
harden(ci): adversarial-review follow-ups on #1044 skip rule + #1045 auditor

### DIFF
--- a/docs/CI_PATH_FILTER_DEBT.md
+++ b/docs/CI_PATH_FILTER_DEBT.md
@@ -8,7 +8,7 @@ in its `VOUCHED` set are enforced and must stay clean; everything below is
 
 Regenerate with `python3 tools/check_workflow_path_filters.py`.
 
-## Uncovered inputs (10 workflows)
+## Uncovered inputs (22 workflows)
 
 A change to these paths does **not** trigger the validator that reads them —
 the check stays green because it is never asked.
@@ -17,9 +17,6 @@ the check stays green because it is never asked.
   - tools/validate-cloudshell-fog-structural-conformance.sh reads docs/FOGSTACK_SIGNED_MANIFESTS.md, not matched by paths: filter
   - tools/validate-cloudshell-fog-structural-conformance.sh reads tools/attach_fogstack_manifest_signature.py, not matched by paths: filter
 - **deploy-tests.yml**
-  - apps/eval-fabric-api/app/tracing.py reads docs/OBSERVABILITY_OTEL_OPENINFERENCE.md, not matched by paths: filter
-  - apps/eval-fabric-api/app/tracing_example.py reads infra/local/docker-compose.otel-collector.yml, not matched by paths: filter
-  - apps/eval-fabric-api/tests/test_schemas.py reads schemas/eval, not matched by paths: filter
   - runs tests/test_head_to_head.py, which its paths: filter does not match
 - **devsecops-investigation-run.yml**
   - tools/validate_devsecops_investigation_run.py reads tests/fixtures/workroom/devsecops-investigation-run.missing-topology-evidence.invalid.json, not matched by paths: filter
@@ -28,6 +25,47 @@ the check stays green because it is never asked.
 - **devsecops-scope-d-adversarial.yml**
   - tools/validate_devsecops_scope_d_adversarial.py reads tests/fixtures/workroom/devsecops-workroom.post-merge-incident.valid.json, not matched by paths: filter
   - tools/validate_devsecops_scope_d_adversarial.py reads tests/fixtures/workroom/devsecops-workroom.pre-merge-validation-failure.valid.json, not matched by paths: filter
+- **fogstack-apply-plan-index.yml**
+  - tools/tests/test_update_fogstack_local_demo_apply_plan.py reads tools/run_fogstack_local_demo.py, not matched by paths: filter
+  - tools/tests/test_update_fogstack_local_demo_apply_plan.py reads tools/run_fogstack_local_demo_deploy_plan.py, not matched by paths: filter
+  - tools/tests/test_update_fogstack_local_demo_apply_plan.py reads tools/update_fogstack_local_demo_deploy_artifacts.py, not matched by paths: filter
+- **fogstack-apply-plan-parity.yml**
+  - tools/tests/test_fogstack_parity_readiness.py reads tools/run_fogstack_local_demo_full.py, not matched by paths: filter
+- **fogstack-deploy-plan.yml**
+  - tools/tests/test_fogstack_deploy_plan.py reads apps/api, not matched by paths: filter
+  - tools/tests/test_fogstack_deploy_plan.py reads apps/gateway, not matched by paths: filter
+- **fogstack-filesystem-registry-root.yml**
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/build_fogstack_registry_publication_index.py, not matched by paths: filter
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/build_fogstack_registry_rollback_revocation_index.py, not matched by paths: filter
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/check_fogstack_filesystem_registry.py, not matched by paths: filter
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/check_fogstack_registry_rollback_revocation_index.py, not matched by paths: filter
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/publish_fogstack_filesystem_registry.py, not matched by paths: filter
+- **fogstack-filesystem-registry.yml**
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/build_fogstack_filesystem_registry_root.py, not matched by paths: filter
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/build_fogstack_registry_rollback_revocation_index.py, not matched by paths: filter
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/check_fogstack_filesystem_registry_root.py, not matched by paths: filter
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/check_fogstack_registry_rollback_revocation_index.py, not matched by paths: filter
+- **fogstack-kubernetes-manifests.yml**
+  - tools/run_fogstack_local_demo_deploy_plan.py reads tools/build_fogstack_agent_machine_node_profile.py, not matched by paths: filter
+  - tools/run_fogstack_local_demo_deploy_plan.py reads tools/build_fogstack_gitops_bundle.py, not matched by paths: filter
+  - tools/run_fogstack_local_demo_deploy_plan.py reads tools/build_fogstack_local_cluster_runtime_adapter.py, not matched by paths: filter
+  - tools/run_fogstack_local_demo_deploy_plan.py reads tools/check_fogstack_gitops_bundle.py, not matched by paths: filter
+  - tools/run_fogstack_local_demo_deploy_plan.py reads tools/check_fogstack_runtime_contract.py, not matched by paths: filter
+  - tools/run_fogstack_local_demo_deploy_plan.py reads tools/emit_fogstack_agent_machine_node_inventory_record.py, not matched by paths: filter
+  - tools/run_fogstack_local_demo_deploy_plan.py reads tools/emit_fogstack_gitops_readiness_record.py, not matched by paths: filter
+  - tools/run_fogstack_local_demo_deploy_plan.py reads tools/emit_fogstack_immutable_update_readiness_record.py, not matched by paths: filter
+  - tools/run_fogstack_local_demo_deploy_plan.py reads tools/emit_fogstack_live_cluster_preflight_record.py, not matched by paths: filter
+  - tools/run_fogstack_local_demo_deploy_plan.py reads tools/emit_fogstack_runtime_dry_run_record.py, not matched by paths: filter
+- **fogstack-local-demo.yml**
+  - tools/check_fogstack_parity_readiness.py reads tools/validate_fogstack_svf_signadot_adapter_readiness.py, not matched by paths: filter
+- **fogstack-registry-lifecycle.yml**
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/build_fogstack_filesystem_registry_root.py, not matched by paths: filter
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/build_fogstack_registry_publication_index.py, not matched by paths: filter
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/check_fogstack_filesystem_registry.py, not matched by paths: filter
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/check_fogstack_filesystem_registry_root.py, not matched by paths: filter
+  - tools/tests/test_fogstack_filesystem_registry.py reads tools/publish_fogstack_filesystem_registry.py, not matched by paths: filter
+- **fogstack-validation.yml**
+  - runs tools/tests/test_fogstack_validation_to_evidence.py, which its paths: filter does not match
 - **mount-intent.yml**
   - libs/python/mount-intent/src/mount_intent/intents.py reads apps/regis-acr-api, not matched by paths: filter
 - **personal-intelligence-cell.yml**
@@ -52,7 +90,9 @@ the check stays green because it is never asked.
   - tools/validate_repo.py reads tools/validate_professional_intelligence.py, not matched by paths: filter
   - tools/validate_repo.py reads tools/validate_prophet_understand.py, not matched by paths: filter
 - **preflight-deploy-contract.yml**
+  - tools/preflight_deploy_contract.py reads apps/device-service, not matched by paths: filter
   - tools/preflight_deploy_contract.py reads apps/embeddings, not matched by paths: filter
+  - tools/preflight_deploy_contract.py reads apps/nugget-extractor, not matched by paths: filter
 - **professional-intelligence-gate4.yml**
   - tools/validate_professional_intelligence.py reads contracts/evidence/adoption-event.schema.json, not matched by paths: filter
   - tools/validate_professional_intelligence.py reads contracts/evidence/adoption-event.v0.1.example.json, not matched by paths: filter
@@ -62,6 +102,35 @@ the check stays green because it is never asked.
   - tools/validate_professional_intelligence.py reads contracts/policy/obligation.v0.1.example.json, not matched by paths: filter
   - tools/validate_professional_intelligence.py reads contracts/risk/conflict-check.schema.json, not matched by paths: filter
   - tools/validate_professional_intelligence.py reads contracts/risk/conflict-check.v0.1.example.json, not matched by paths: filter
+- **prometheus-agentplane-schema-pin.yml**
+  - tools/run_prometheus_local_demo.py reads catalog/prometheus-sr-gate-policy-equation-discovery.v0.1.json, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads contracts/ontology/prometheus-sr-assertion-compat.manifest.json, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tests/fixtures/prometheus/pysr-mvp-linear.csv, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tests/fixtures/prometheus/sindy-fast-path-linear.csv, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/emit_prometheus_gate_evaluation.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/emit_prometheus_jsonld_review.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/prometheus_ai_descartes_mvp.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/prometheus_emit_sr_run_artifact.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/prometheus_pysr_mvp.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/prometheus_sindy_fast_path.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/validate_prometheus_jsonld_shacl.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/validate_prometheus_ontogenesis_compat.py, not matched by paths: filter
+- **prometheus-jsonld.yml**
+  - tools/run_prometheus_local_demo.py reads catalog/prometheus-sr-gate-policy-equation-discovery.v0.1.json, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads contracts/ontology/prometheus-sr-assertion-compat.manifest.json, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tests/fixtures/prometheus/pysr-mvp-linear.csv, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tests/fixtures/prometheus/sindy-fast-path-linear.csv, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/prometheus_ai_descartes_mvp.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/prometheus_emit_sr_run_artifact.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/prometheus_pysr_mvp.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/prometheus_sindy_fast_path.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/validate_prometheus_ontogenesis_compat.py, not matched by paths: filter
+- **prometheus-local-demo.yml**
+  - tools/run_prometheus_local_demo.py reads catalog/prometheus-sr-gate-policy-equation-discovery.v0.1.json, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads contracts/ontology/prometheus-sr-assertion-compat.manifest.json, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/prometheus_ai_descartes_mvp.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/validate_prometheus_jsonld_shacl.py, not matched by paths: filter
+  - tools/run_prometheus_local_demo.py reads tools/validate_prometheus_ontogenesis_compat.py, not matched by paths: filter
 - **sourceos-contracts.yml**
   - tools/smoke_sourceos_synthetic_boot_fingerprint.py reads tools/check_sourceos_boot_fingerprint_compliance.py, not matched by paths: filter
 - **tofu-plan.yml**

--- a/tools/check_workflow_path_filters.py
+++ b/tools/check_workflow_path_filters.py
@@ -56,7 +56,12 @@ def has_main_push(text: str) -> bool:
     if not m:
         return False
     push = re.search(r'^  push:\s*$(.*?)(?=^  \w|\Z)', m.group(0), re.M | re.S)
-    return bool(push and "main" in push.group(1) and "paths:" not in push.group(1))
+    if not push or "paths:" in push.group(1):
+        return False
+    # Match `main` as a whole branch token, not a substring: a push filtered to
+    # `maintenance` or `main-release` is NOT the unfiltered main-branch safety net,
+    # and `"main" in ...` would wrongly accept it.
+    return re.search(r'(?<![\w-])main(?![\w-])', push.group(1)) is not None
 
 
 def make_target_scripts(target: str) -> set[str]:
@@ -71,11 +76,46 @@ def make_target_scripts(target: str) -> set[str]:
     return set(BARE.findall(body.group(1))) if body else set()
 
 
+def _run_bodies(text: str) -> list[str]:
+    """Every `run:` body, INCLUDING multi-line `run: |` / `run: >` block scalars.
+
+    The naive `run:\\s*(.*)` captures only the first physical line, so a script
+    invoked on line 2+ of a block scalar is invisible -- and a vouched workflow
+    whose real script lives in a `run: |` block would be checked against nothing
+    and pass. Block bodies are gathered by indentation: the run-together lines
+    more-indented than the `run:` key belong to it.
+    """
+    bodies: list[str] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        m = re.match(r'^(\s*)(?:-\s+)?run:\s*(\|[-+]?|>[-+]?)?\s*(.*)$', lines[i])
+        if not m:
+            i += 1
+            continue
+        indent, block, inline = m.group(1), m.group(2), m.group(3)
+        if not block:
+            bodies.append(inline)
+            i += 1
+            continue
+        base = len(indent)
+        collected = [inline] if inline else []
+        i += 1
+        while i < len(lines):
+            ln = lines[i]
+            if ln.strip() and (len(ln) - len(ln.lstrip())) <= base:
+                break
+            collected.append(ln)
+            i += 1
+        bodies.append("\n".join(collected))
+    return bodies
+
+
 def scripts_invoked(text: str) -> set[str]:
     out: set[str] = set()
-    for line in re.findall(r'run:\s*(?:\|)?(.*)', text):
-        out.update(BARE.findall(line))
-        for target in re.findall(r'\bmake\s+([A-Za-z0-9_.-]+)', line):
+    for body in _run_bodies(text):
+        out.update(BARE.findall(body))
+        for target in re.findall(r'\bmake\s+([A-Za-z0-9_.-]+)', body):
             out.update(make_target_scripts(target))
     resolved: set[str] = set()
     for item in out:

--- a/tools/check_workflow_path_filters.py
+++ b/tools/check_workflow_path_filters.py
@@ -56,12 +56,18 @@ def has_main_push(text: str) -> bool:
     if not m:
         return False
     push = re.search(r'^  push:\s*$(.*?)(?=^  \w|\Z)', m.group(0), re.M | re.S)
-    if not push or "paths:" in push.group(1):
+    # `paths:` OR `paths-ignore:` under push means the trigger is filtered, not the
+    # unfiltered safety net: `paths-ignore` still skips the run for the ignored set,
+    # so it cannot be relied on to catch a wrong filter at merge time. `"paths:" in`
+    # missed `paths-ignore:` (no `paths:` substring in it), wrongly accepting it.
+    if not push or re.search(r'^\s+paths(?:-ignore)?:', push.group(1), re.M):
         return False
-    # Match `main` as a whole branch token, not a substring: a push filtered to
-    # `maintenance` or `main-release` is NOT the unfiltered main-branch safety net,
-    # and `"main" in ...` would wrongly accept it.
-    return re.search(r'(?<![\w-])main(?![\w-])', push.group(1)) is not None
+    # Match `main` as a whole branch token, not a substring: `maintenance`,
+    # `main-release`, `main/foo` and globs like `main.*` are different refs, NOT the
+    # unfiltered main-branch safety net. The boundary excludes every ref-name
+    # character (`[\w./*+-]`), so only an exact `main` token counts — `(?![\w-])`
+    # alone let `/`, `.` and `*` through.
+    return re.search(r'(?<![\w./*+-])main(?![\w./*+-])', push.group(1)) is not None
 
 
 def make_target_scripts(target: str) -> set[str]:

--- a/tools/ci_docs_only.py
+++ b/tools/ci_docs_only.py
@@ -24,16 +24,39 @@ from __future__ import annotations
 import re
 import sys
 
-# A path is inert only if it is inside docs/ or is a top-level markdown file.
-# Anchored and slash-explicit so `docsomething/x.py` and `apps/svc/README.md` do NOT match.
-INERT = re.compile(r'^(docs/|[^/]+\.md$)')
+# A path is inert only if it is prose/asset content: a top-level markdown file, or a file
+# under docs/ that is NOT executable. `docs/` is not a free pass — it routinely holds live
+# code (docs/conf.py for Sphinx, docs/scripts/*.ts generators) that a test can import, so
+# treating all of docs/ as inert would let a change to executable doc tooling skip the very
+# tests that cover it. Anchored + slash-explicit so `docsomething/x.py` and
+# `apps/svc/README.md` do NOT match.
+INERT = re.compile(r'^(docs/.+|[^/]+\.md)$')
+
+# Never inert regardless of location — anything that can be imported, executed, or that
+# defines behaviour. A docs/ path with one of these extensions is treated as live code.
+EXECUTABLE_SUFFIXES = (
+    ".py", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".sh", ".bash", ".zsh",
+    ".rb", ".go", ".rs", ".java", ".ipynb", ".mk", ".cmake",
+)
+EXECUTABLE_NAMES = ("Makefile", "Dockerfile")
+
+
+def _is_inert(path: str) -> bool:
+    if not INERT.match(path):
+        return False
+    lower = path.lower()
+    if lower.endswith(EXECUTABLE_SUFFIXES):
+        return False  # e.g. docs/conf.py, docs/scripts/gen.ts — live code under docs/
+    if path.rsplit("/", 1)[-1] in EXECUTABLE_NAMES:
+        return False
+    return True
 
 
 def docs_only(paths: list[str]) -> bool:
     cleaned = [p.strip() for p in paths if p.strip()]
     if not cleaned:
         return False  # an empty diff tells us nothing; run everything
-    return all(INERT.match(p) for p in cleaned)
+    return all(_is_inert(p) for p in cleaned)
 
 
 def main() -> int:

--- a/tools/tests/test_check_workflow_path_filters.py
+++ b/tools/tests/test_check_workflow_path_filters.py
@@ -106,3 +106,31 @@ def test_generated_artifacts_are_not_required_inputs():
     """A path the job itself writes under build/ is an output, not an input."""
     assert not any(p.startswith("build/") for p in cwpf.inputs_of(
         ROOT / "tools" / "check_workflow_path_filters.py"))
+
+
+def test_multiline_run_block_scripts_are_seen():
+    """A script invoked on line 2+ of a `run: |` block must be surfaced, or a
+    vouched workflow could hide its real script from the auditor (Copilot on #1045)."""
+    wf = (
+        "name: x\non:\n  pull_request:\n    paths: ['tools/**']\n"
+        "  push:\n    branches: [main]\njobs:\n  a:\n    steps:\n"
+        "      - run: |\n"
+        "          pip install foo\n"
+        "          python3 tools/hidden_script.py\n"
+        "          bash tools/another.sh\n"
+    )
+    found = cwpf.scripts_invoked(wf)
+    assert "tools/hidden_script.py" in found
+    assert "tools/another.sh" in found
+
+
+@pytest.mark.parametrize("branches,expected", [
+    ("[main]", True),
+    ("[ main, dev ]", True),
+    ("[maintenance]", False),   # substring 'main' must NOT count as the main safety net
+    ("[main-release]", False),
+])
+def test_main_is_matched_as_a_whole_branch_token(branches, expected):
+    wf = (f"name: y\non:\n  push:\n    branches: {branches}\n"
+          f"  pull_request:\n    paths: ['x/**']\njobs: {{}}\n")
+    assert cwpf.has_main_push(wf) is expected

--- a/tools/tests/test_check_workflow_path_filters.py
+++ b/tools/tests/test_check_workflow_path_filters.py
@@ -127,10 +127,27 @@ def test_multiline_run_block_scripts_are_seen():
 @pytest.mark.parametrize("branches,expected", [
     ("[main]", True),
     ("[ main, dev ]", True),
+    ('["main"]', True),
     ("[maintenance]", False),   # substring 'main' must NOT count as the main safety net
     ("[main-release]", False),
+    ("[main/foo]", False),      # a slashed ref is a different branch, not `main`
+    ("[main.*]", False),        # a glob is not the exact main-push safety net
+    ("[dev, feature/main]", False),
 ])
 def test_main_is_matched_as_a_whole_branch_token(branches, expected):
     wf = (f"name: y\non:\n  push:\n    branches: {branches}\n"
           f"  pull_request:\n    paths: ['x/**']\njobs: {{}}\n")
+    assert cwpf.has_main_push(wf) is expected
+
+
+@pytest.mark.parametrize("push_filter,expected", [
+    ("", True),
+    ("    paths: ['src/**']\n", False),
+    ("    paths-ignore: ['docs/**']\n", False),   # paths-ignore still filters the push
+])
+def test_paths_ignore_push_is_not_an_unfiltered_safety_net(push_filter, expected):
+    # A `paths-ignore:` push skips runs for the ignored set, so it cannot be the
+    # unfiltered net that turns a wrong filter into merge-time detection.
+    wf = (f"name: z\non:\n  push:\n    branches: [main]\n{push_filter}"
+          f"jobs: {{}}\n")
     assert cwpf.has_main_push(wf) is expected

--- a/tools/tests/test_ci_docs_only.py
+++ b/tools/tests/test_ci_docs_only.py
@@ -65,3 +65,26 @@ def test_the_rule_is_all_or_nothing():
     """Skipping requires EVERY path to be inert — proof of inertness, not a majority vote."""
     assert docs_only(['docs/a.md', 'docs/b.md']) is True
     assert docs_only(['docs/a.md', 'apps/x.py']) is False
+
+
+@pytest.mark.parametrize('path', [
+    'docs/conf.py',          # Sphinx config — live Python under docs/
+    'docs/scripts/gen.ts',   # a generator that a test could import
+    'docs/build.sh',
+    'docs/Makefile',
+    'docs/notebook.ipynb',
+])
+def test_executable_files_under_docs_are_not_inert(path):
+    """docs/ is not a free pass: it holds live code, and changing that code must
+    not skip the tests that cover it (Copilot on #1044)."""
+    assert docs_only([path]) is False
+
+
+@pytest.mark.parametrize('path', [
+    'docs/architecture.md',
+    'docs/guide/deep/nested.md',
+    'README.md',
+    'docs/img/diagram.png',   # a doc ASSET, not executable
+])
+def test_prose_and_assets_under_docs_stay_inert(path):
+    assert docs_only([path]) is True


### PR DESCRIPTION
My own adversarial re-read of the CI work shipped this session, per Michael's request to "perform your own adversarial review of everything we've touched." Three real defects — **two weaken checks I introduced this session** — each with regression tests.

## 1. `ci_docs_only` treated all of `docs/` as inert (Copilot on #1044)
`docs/` routinely holds live code: `docs/conf.py` (Sphinx), `docs/scripts/*.ts` generators, a `docs/Makefile`. The skip rule claimed these "provably inert," so a change to executable doc tooling could **skip the app-test and smoke legs that cover it**. Now a `docs/` path is inert only if it is **not executable** — markdown and assets stay inert; `.py/.ts/.sh/.ipynb/Makefile` under `docs/` are live code.

**Measured:** `docs/conf.py` and `docs/scripts/gen.ts` went `docs_only=true` → `false`.

## 2. The path-filter auditor missed multi-line `run:` blocks (Copilot on #1045)
`scripts_invoked` read only the first physical line of each `run:`. A script invoked on line 2+ of a `run: |` block — the most common Actions pattern — was **invisible**, so a vouched workflow could hide its real script from the auditor and pass against nothing. Now parses block scalars by indentation.

This made the auditor **more honest, not more lenient**: pre-existing advisory gaps rose **128 → 185** as previously-hidden scripts became visible. The 7 vouched workflows still pass (0 failures).

## 3. `has_main_push` matched `main` as a substring
A push filtered to `maintenance` or `main-release` counted as the unfiltered main-branch safety net. Now matched as a whole branch token.

## Also filed, not fixed here
- **#1029 config-plane:** the `app` read selector is ungated while `org`/`model` require a token. Whether that is a tenancy leak depends on the threat model (is `app` a tenant dimension or just the product name?). Filing separately rather than re-architecting merged auth — see the linked issue.

**Tests:** 14 new regression tests (41 total across the two suites). Debt register regenerated from the live run.