### PR TITLE
fix(iac): repair invalid HCL on main since 2026-07-03 + fix what the tofu-plan blackout hid

### DIFF
--- a/infra/tofu/environments/aws-eks/main.tf
+++ b/infra/tofu/environments/aws-eks/main.tf
@@ -104,11 +104,11 @@ module "github_ci" {
 
 # Budget alert — hard cap at $5k/month; alerts at 80% + 100% forecasted spend.
 resource "aws_budgets_budget" "prophet_platform" {
-  name              = "prophet-platform-monthly"
-  budget_type       = "COST"
-  limit_amount      = "5000"
-  limit_unit        = "USD"
-  time_unit         = "MONTHLY"
+  name         = "prophet-platform-monthly"
+  budget_type  = "COST"
+  limit_amount = "5000"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
 
   notification {
     comparison_operator        = "GREATER_THAN"

--- a/infra/tofu/envs/gcp-landing/main.tf
+++ b/infra/tofu/envs/gcp-landing/main.tf
@@ -212,14 +212,21 @@ resource "google_billing_budget" "platform" {
     }
   }
 
-  threshold_rules { threshold_percent = 0.8  spend_basis = "FORECASTED_SPEND" }
-  threshold_rules { threshold_percent = 1.0  spend_basis = "FORECASTED_SPEND" }
+  threshold_rules {
+    threshold_percent = 0.8
+    spend_basis       = "FORECASTED_SPEND"
+  }
 
-  notifications_rule {
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "FORECASTED_SPEND"
+  }
+
+  all_updates_rule {
     monitoring_notification_channels = []
-    pubsub_topic                      = google_pubsub_topic.budget_alerts.id
-    schema_version                    = "1.0"
-    enable_project_level_recipients   = true
+    pubsub_topic                     = google_pubsub_topic.budget_alerts.id
+    schema_version                   = "1.0"
+    enable_project_level_recipients  = true
   }
 }
 

--- a/infra/tofu/modules/github-oidc-aws/main.tf
+++ b/infra/tofu/modules/github-oidc-aws/main.tf
@@ -47,8 +47,8 @@ resource "aws_iam_role_policy" "github_ci_state" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"]
+        Effect = "Allow"
+        Action = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"]
         Resource = [
           "arn:aws:s3:::${var.state_bucket_name}",
           "arn:aws:s3:::${var.state_bucket_name}/*",

--- a/infra/tofu/modules/ibm-trusted-profile/main.tf
+++ b/infra/tofu/modules/ibm-trusted-profile/main.tf
@@ -6,6 +6,17 @@
 # After apply, store the profile CRN as a GitHub Actions variable (not a secret):
 #   IBM_TRUSTED_PROFILE_ID → trusted_profile_id output
 
+# The IBM provider is the only non-hashicorp/ namespace provider in this repo,
+# so the source address must be declared here as well as in the root module —
+# otherwise OpenTofu infers "hashicorp/ibm", which does not exist, and init
+# fails before it can resolve the real provider. Version stays pinned in the
+# root (envs/.../versions.tf) to keep a single constraint.
+terraform {
+  required_providers {
+    ibm = { source = "IBM-Cloud/ibm" }
+  }
+}
+
 resource "ibm_iam_trusted_profile" "github_ci" {
   name        = "github-ci-${var.profile_name_suffix}"
   description = "GitHub Actions OIDC federation — no static API keys"

--- a/infra/tofu/modules/ibm-trusted-profile/variables.tf
+++ b/infra/tofu/modules/ibm-trusted-profile/variables.tf
@@ -15,6 +15,6 @@ variable "cos_instance_crn" {
   description = "CRN of the IBM COS instance holding the Tofu state bucket"
 }
 variable "state_bucket_name" {
-  type        = string
-  default     = "prophet-tofu-state-ibm"
+  type    = string
+  default = "prophet-tofu-state-ibm"
 }


### PR DESCRIPTION
## Why

`.github/workflows/tofu-plan.yml` has returned `startup_failure` since **2026-06-23** and has never actually run. Its first step is `tofu fmt -check`, so when that step began failing, the four `tofu init -backend=false && tofu validate` steps behind it never executed either. This PR fixes the HCL and then fixes what the silence was hiding.

All work verified with **OpenTofu 1.8.3** — the pinned `TOFU_VERSION` in `tofu-plan.yml`, not whatever is on a laptop.

## Blocking relationship with #1097

⚠️ **#1097 revives `tofu-plan.yml` and is red until this lands** — this breakage is exactly what it catches. **Either this merges first, or the two merge together.** This PR deliberately does not touch `tofu-plan.yml`; that file is #1097's lane.

Same 2026-06-23 root cause, also in flight: **#1090** (drift lanes), `helm-release.yml`, `search-orchestrator-image-pin.yml` — four workflows killed by the `allowed_actions: selected` policy.

## 1. The parse error (formatting)

`envs/gcp-landing/main.tf` had two `threshold_rules` single-line blocks each carrying two arguments, which HCL forbids. Arrived in `c5bc4cfe` (#674, 2026-07-03).

**There were two bad lines, not one.** The parser only ever reports the first (215); 216 was identical and would have failed the very next run. Both are fixed.

`tofu fmt` also realigned three more files. **`environments/aws-eks/main.tf` was not in the original report** — the parse error aborted the recursive walk before `fmt` ever reached it.

## 2. What the blackout hid — `tofu validate`

| env | before | after |
|---|---|---|
| `envs/local` | clean | ✅ `Success!` |
| `envs/gcp-landing` | ❌ **`Unsupported block type: notifications_rule`** | ✅ `Success!` |
| `envs/shared` | clean | ✅ `Success!` |
| `envs/prod` | clean | ✅ `Success!` |

`local`, `shared` and `prod` were genuinely clean — a useful negative, and they were actually run, not assumed.

### ⚠️ Semantic change to gcp-landing — flagged, not folded in

Renamed block `notifications_rule` → **`all_updates_rule`** on `google_billing_budget.platform`.

`notifications_rule` **is not a valid block on this resource in any provider version.** Verified against the real provider schema (`tofu providers schema -json`) for both google **6.50.0** and **7.42.0** — in both, the notification block is `all_updates_rule`, and all four attributes already inside the block (`monitoring_notification_channels`, `pubsub_topic`, `schema_version`, `enable_project_level_recipients`) are valid members of it. So this is a pure rename with no change to intended behaviour.

**Consequence worth noting:** `gcp-landing` could never have been applied in this state, so the $5k/month budget cap has never been able to deliver a notification.

## 3. Beyond the four envs (second commit, droppable)

I validated the **ten other config roots CI never looks at**. Nine were clean. `environments/ibm-iks` **could not even `init`**: `modules/ibm-trusted-profile` uses `ibm_*` resources but declared no provider source, so OpenTofu inferred `hashicorp/ibm`, which does not exist. A root-level declaration does not propagate to child modules.

`fab2d02b` adds the source declaration. It is **isolated in its own commit so it can be dropped** without affecting the four envs CI validates.

**This does not make `ibm-iks` valid.** It unblocks `init`, which then surfaces two further pre-existing errors that were previously unreachable, left for follow-up as they need IBM domain decisions:
- `ibm_is_vpc.this` — tag `repo:SocioProphet/prophet-platform` violates IBM's tag regex `^[A-Za-z0-9:_ .-]+$` (the `/` is rejected).
- `ibm_iam_trusted_profile_claim_rule.github` — `type = "Profile-OIDC"` is not permitted; the provider accepts only `Profile-SAML` or `Profile-CR`.

## 4. Findings reported, deliberately NOT fixed here

**Providers are completely unpinned in all four CI envs.** None of `envs/{local,gcp-landing,shared,prod}` declares `required_providers`. `infra/tofu/shared/versions.tf` pins google to `~> 6.0` and its comment claims it is "used only in envs/gcp-*", but `shared/` is a standalone directory that **no env ever loads** — envs only reference `../../modules/*`. `gcp-landing` therefore resolved **google 7.42.0**, a full major version above the stated intent. Combined with `.terraform.lock.hcl` being gitignored, every CI run re-resolves to whatever is newest that day. **"Validates clean today" is not reproducible tomorrow.** Pinning would change the resolved provider and is a real semantic decision, so it belongs in its own PR.

**CI validates 4 of 14 config roots.** `bootstrap/{aws,azure,gcp}`, `environments/*` (6 dirs) and `shared/` are never validated — which is why the `ibm-iks` break survived indefinitely. `fmt -check -recursive` covers all of them; `validate` does not. Flagging for #1097's owner rather than editing that workflow.

## Proof

```
$ tofu version
OpenTofu v1.8.3

$ tofu fmt -check -recursive infra/tofu/
FMT_CHECK_EXIT=0

envs/local        init exit=0  validate exit=0  Success! The configuration is valid.
envs/gcp-landing  init exit=0  validate exit=0  Success! The configuration is valid.
envs/shared       init exit=0  validate exit=0  Success! The configuration is valid.
envs/prod         init exit=0  validate exit=0  Success! The configuration is valid.
```
Clean-room run: all `.terraform/` and lock files deleted first. `gcp-landing` used `TF_VAR_billing_account="000000-000000-000000"`, matching CI.

Every change is inside `infra/tofu/**`.
