### PR TITLE
fix(ci): SHA-pin actions in gitops-promote/images/provision-secrets/ci-path-filter-audit

### DIFF
--- a/.github/workflows/ci-path-filter-audit.yml
+++ b/.github/workflows/ci-path-filter-audit.yml
@@ -22,8 +22,8 @@ jobs:
   path-filter-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: '3.11'
       - name: Install test deps

--- a/.github/workflows/gitops-promote.yml
+++ b/.github/workflows/gitops-promote.yml
@@ -40,7 +40,7 @@ jobs:
       (github.event.workflow_run.head_branch == 'main' && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -107,7 +107,7 @@ jobs:
           # FOG & CITIZEN PLANE W8.7: the southbound device plane — the estate's first.
           # ONE southbound interface (DeviceProfile/DeviceReading), N protocol drivers.
           - { image: device-service,        context: apps/device-service,        dockerfile: Dockerfile }
-    uses: SocioProphet/.github/.github/workflows/build-image.yml@main
+    uses: SocioProphet/.github/.github/workflows/build-image.yml@ab2d7063cb27802e4b7b875b8330e8129eb03ac5 # main @ 2026-07-30
     with:
       image: ${{ matrix.image }}
       context: ${{ matrix.context }}

--- a/.github/workflows/provision-secrets.yml
+++ b/.github/workflows/provision-secrets.yml
@@ -45,12 +45,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - uses: google-github-actions/get-gke-credentials@v2
+      - uses: google-github-actions/get-gke-credentials@64bc7249bbcf78056bb92f14d3cedc2da193946c # v2.3.5
         with:
           # Default to the known prophet-platform coordinates so the workflow is self-sufficient
           # even when the repo Variables were never set (they weren't — this is why the first run


### PR DESCRIPTION
## Why

Adversarial review flagged four workflows as defense-in-depth gaps: each holds `contents: write`, WIF, secret-provisioning, or write-to-`main` authority while resolving actions through moving tags. A compromised or hijacked action tag could exercise that authority. Pin the action refs (and one reusable-workflow ref) to full commit SHAs, with trailing version comments so renovate/dependabot can still bump them.

Only these four workflows are touched. A broader sweep can follow.

## Pins

### `.github/workflows/gitops-promote.yml` (`contents:write`, `pull-requests:write`, `actions:write`; auto-merges PRs to `main`; workflow_dispatches other refs)
- L43 `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  (matches the existing pin in `design-register.yml` for repo-wide consistency)

### `.github/workflows/images.yml` (image build + push authority)
- L110 reusable workflow `SocioProphet/.github/.github/workflows/build-image.yml@main` -> `@ab2d7063cb27802e4b7b875b8330e8129eb03ac5 # main @ 2026-07-30`
  Closes the moving-`@main` reusable-workflow bootstrap gap.

### `.github/workflows/provision-secrets.yml` (WIF; provisions cluster Secrets)
- L48 `google-github-actions/auth@v2` -> `@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13`
- L53 `google-github-actions/get-gke-credentials@v2` -> `@64bc7249bbcf78056bb92f14d3cedc2da193946c # v2.3.5`

### `.github/workflows/ci-path-filter-audit.yml` (path-filter auditor)
- L25 `actions/checkout@v4` -> `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
- L26 `actions/setup-python@v5` -> `@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0`
  (both match the existing `design-register.yml` pins)

## Notes

- All source refs verified as `commit`-type (not annotated tags) — no dereference required.
- Every replacement carries a trailing `# vX.Y.Z` (or `# main @ YYYY-MM-DD` for the reusable-workflow @main pin) so renovate/dependabot can still open bump PRs.
- Deliberately did NOT touch any workflow beyond the four flagged; scope-creep would blur the review.
