### PR TITLE
fix(gateway): three sub-tier findings — seal race, unbounded pending, silent unsigned

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/receipts.py
+++ b/apps/compute-gateway/src/compute_gateway/receipts.py
@@ -112,6 +112,25 @@ def chain(project: str) -> list[Receipt]:
     return list(_CHAINS.get(project, []))
 
 
+def snapshot_all() -> list[tuple[str, list[Receipt]]]:
+    """A consistent (project, chain) snapshot for read-only aggregators like
+    /healthz's signed_ratio. Copilot #1106: iterating `_CHAINS.values()` in the
+    server hits `RuntimeError: dictionary changed size during iteration` when a
+    concurrent seal() runs setdefault() on a new project. Take the dict snapshot
+    under `_LOCKS_LOCK` (which setdefault contends with because _project_lock()
+    holds it while creating a new entry) and per-chain snapshots under the
+    per-project seal lock so we do not observe a chain mid-append."""
+    with _LOCKS_LOCK:
+        projects = list(_CHAINS.keys())
+    out: list[tuple[str, list[Receipt]]] = []
+    for project in projects:
+        with _project_lock(project):
+            # Copy defensively: the receipt list may have grown or been rebuilt
+            # by hydrate() since we snapshotted the keyset.
+            out.append((project, list(_CHAINS.get(project, []))))
+    return out
+
+
 def verify(project: str) -> dict:
     """Recompute every id + re-walk every prev-link, and verify every present
     Ed25519 signature. Two independent guarantees: chain integrity (id-hash +

--- a/apps/compute-gateway/src/compute_gateway/receipts.py
+++ b/apps/compute-gateway/src/compute_gateway/receipts.py
@@ -87,7 +87,19 @@ def seal(project: str, *, kind: str, backend: str, runtime: str, inputs: Any,
     # committed by the time it runs. Do NOT hold across arbitrary caller code — the
     # window is bounded to hash + attest + persist, all pure/local.
     with _project_lock(project):
-        chain = _CHAINS.setdefault(project, [])
+        # Copilot #1106 round 2: the setdefault below GROWS _CHAINS the first time
+        # a project is sealed, and snapshot_all() iterates its keyset. The prior
+        # revision leaned on the incidental fact that _project_lock() briefly holds
+        # _LOCKS_LOCK on the create-path — but that lock is already RELEASED by
+        # the time we get here, so a concurrent snapshot_all() could still catch
+        # the dict mid-mutation and raise `RuntimeError: dictionary changed size
+        # during iteration`. Hold _LOCKS_LOCK for the mutation itself so the
+        # keyset snapshot and the new-project insert are properly serialized. The
+        # window is a single dict lookup — no risk of contention starvation, and
+        # snapshot_all() only takes _LOCKS_LOCK to snapshot keys (not per-project
+        # locks), so there is no reversed-order lock cycle.
+        with _LOCKS_LOCK:
+            chain = _CHAINS.setdefault(project, [])
         prev = chain[-1].id if chain else None
         body = {
             "project": project, "kind": kind, "backend": backend, "runtime": runtime,

--- a/apps/compute-gateway/src/compute_gateway/receipts.py
+++ b/apps/compute-gateway/src/compute_gateway/receipts.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import threading
 import time
 from typing import Any
 
@@ -19,6 +20,35 @@ from .contract import EpistemicStatus, Receipt
 # cache hydrated from durable storage on boot (see hydrate) and written through on seal,
 # so the chain survives a restart; unset, it is the whole store (ephemeral).
 _CHAINS: dict[str, list[Receipt]] = {}
+
+# per-project seal lock. The seal window (setdefault chain → read prev → attest → append
+# → persist) is a read-modify-write on the chain: two concurrent seals for the same
+# project used to compute the same `prev`, both append, and both persist under seq=N —
+# `INSERT OR REPLACE` in save_receipt then silently dropped one and the chain lost a
+# receipt at that position (or worse: the surviving row's `prev` didn't match its
+# neighbour, so verify() went `valid: False, reason: "prev-link broken"` after a race).
+# The persistence module has its own lock, but it only covers the SQLite write itself,
+# not the read of `prev` or the id computation — the window this lock closes.
+#
+# threading.Lock rather than asyncio.Lock because seal() is sync (called both by
+# adapters running in FastAPI's threadpool and by pure-sync callers like config_plane).
+# One lock per project so seals for different projects don't serialize against each other.
+_LOCKS_LOCK = threading.Lock()
+_LOCKS: dict[str, threading.Lock] = {}
+
+
+def _project_lock(project: str) -> threading.Lock:
+    """Get (or create) the per-project seal lock. The double-check pattern keeps the
+    common path lock-free once a lock has been minted."""
+    lock = _LOCKS.get(project)
+    if lock is not None:
+        return lock
+    with _LOCKS_LOCK:
+        lock = _LOCKS.get(project)
+        if lock is None:
+            lock = threading.Lock()
+            _LOCKS[project] = lock
+        return lock
 
 
 def hydrate() -> None:
@@ -48,24 +78,33 @@ def seal(project: str, *, kind: str, backend: str, runtime: str, inputs: Any,
          outputs: Any, status: str, actor: str, epistemic_status: EpistemicStatus,
          bytes_in: int | None = None, bytes_out: int | None = None,
          exhaust_sha: str | None = None) -> Receipt:
-    chain = _CHAINS.setdefault(project, [])
-    prev = chain[-1].id if chain else None
-    body = {
-        "project": project, "kind": kind, "backend": backend, "runtime": runtime,
-        "inputs_sha": sha(inputs), "outputs_sha": sha(outputs), "status": status,
-        "actor": actor, "epistemic_status": epistemic_status, "prev": prev, "ts": time.time(),
-    }
-    # exhaust accounting (W6.1) rides OUTSIDE the id-hash body, like the attestation —
-    # pre-existing persisted receipts (no such fields) must keep verifying unchanged.
-    receipt = Receipt(id=sha(body), **body,
-                      bytes_in=bytes_in, bytes_out=bytes_out, exhaust_sha=exhaust_sha)
-    # standards-based authenticity, layered on top of the chain's integrity:
-    # in-toto Statement v1 + Ed25519 signature (unsigned if no key configured).
-    signing.attest(receipt, signing.load_signing_key())
-    chain.append(receipt)
-    # write-through AFTER attestation so the durable copy carries the signature/statement,
-    # and at the receipt's chain position so the ordered prev-links reload intact.
-    persistence.save_receipt(project, len(chain) - 1, receipt.id, receipt.model_dump_json())
+    # HOLD the per-project lock across the ENTIRE seal window — setdefault-chain →
+    # read-prev → hash body → attest → append → persist — so no two concurrent seals
+    # can compute the same `prev`, mint two receipts at the same seq, and race
+    # save_receipt's `INSERT OR REPLACE` into silently dropping one. This is the ONLY
+    # correct scope: persistence._LOCK covers only the SQLite write itself, so a lock
+    # taken there is far too late — the id-hash and the chain position are already
+    # committed by the time it runs. Do NOT hold across arbitrary caller code — the
+    # window is bounded to hash + attest + persist, all pure/local.
+    with _project_lock(project):
+        chain = _CHAINS.setdefault(project, [])
+        prev = chain[-1].id if chain else None
+        body = {
+            "project": project, "kind": kind, "backend": backend, "runtime": runtime,
+            "inputs_sha": sha(inputs), "outputs_sha": sha(outputs), "status": status,
+            "actor": actor, "epistemic_status": epistemic_status, "prev": prev, "ts": time.time(),
+        }
+        # exhaust accounting (W6.1) rides OUTSIDE the id-hash body, like the attestation —
+        # pre-existing persisted receipts (no such fields) must keep verifying unchanged.
+        receipt = Receipt(id=sha(body), **body,
+                          bytes_in=bytes_in, bytes_out=bytes_out, exhaust_sha=exhaust_sha)
+        # standards-based authenticity, layered on top of the chain's integrity:
+        # in-toto Statement v1 + Ed25519 signature (unsigned if no key configured).
+        signing.attest(receipt, signing.load_signing_key())
+        chain.append(receipt)
+        # write-through AFTER attestation so the durable copy carries the signature/statement,
+        # and at the receipt's chain position so the ordered prev-links reload intact.
+        persistence.save_receipt(project, len(chain) - 1, receipt.id, receipt.model_dump_json())
     return receipt
 
 

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -39,9 +39,15 @@ def healthz() -> dict:
     operator lost signatures across the fleet with a green health check. `signing.state`
     surfaces that fault as 'error' here; `signed_ratio` reports the observed share of
     receipts in memory carrying a verifying signature (all projects, all chains)."""
+    # Copilot #1106: iterate a consistent snapshot instead of `receipts._CHAINS.values()`
+    # directly. A concurrent seal() on a *new* project calls _CHAINS.setdefault(project, [])
+    # which mutates the dict — bare iteration would raise `RuntimeError: dictionary changed
+    # size during iteration` and break /healthz under load. snapshot_all() takes the keys
+    # snapshot under the receipts-module lock, then copies each per-project chain under its
+    # own seal lock, so a seal in flight cannot make us observe a chain mid-append either.
     total = 0
     signed = 0
-    for chain in receipts._CHAINS.values():
+    for _project, chain in receipts.snapshot_all():
         for r in chain:
             total += 1
             if r.signature is not None and r.statement is not None and signing.verify_signature(

--- a/apps/compute-gateway/src/compute_gateway/server.py
+++ b/apps/compute-gateway/src/compute_gateway/server.py
@@ -15,7 +15,7 @@ from fastapi import Depends, FastAPI, Header, HTTPException
 
 from pydantic import BaseModel
 
-from . import artifacts, config_plane, engine, engine_receipts, grants, planner, receipts, registry, rocrate, zerotrust
+from . import artifacts, config_plane, engine, engine_receipts, grants, planner, receipts, registry, rocrate, signing, zerotrust
 from .contract import ComputeRequest, ComputeResult
 
 app = FastAPI(title="compute-gateway", version="0.1.0")
@@ -32,7 +32,32 @@ def require_token(authorization: str = Header(default="")) -> None:
 
 @app.get("/healthz")
 def healthz() -> dict:
-    return {"ok": True, "service": "compute-gateway", "kinds": list(registry.KINDS)}
+    """Liveness + attestation posture. The signing block is the alarm: a misconfigured
+    `GATEWAY_SIGNING_KEY` (bad base64, wrong length, corrupt seed) used to be silently
+    downgraded to unsigned by `signing.load_signing_key()`, and `receipts.verify()`
+    couldn't notice because it only rejects a present-but-invalid signature — so an
+    operator lost signatures across the fleet with a green health check. `signing.state`
+    surfaces that fault as 'error' here; `signed_ratio` reports the observed share of
+    receipts in memory carrying a verifying signature (all projects, all chains)."""
+    total = 0
+    signed = 0
+    for chain in receipts._CHAINS.values():
+        for r in chain:
+            total += 1
+            if r.signature is not None and r.statement is not None and signing.verify_signature(
+                    r.statement, r.signature, r.public_key):
+                signed += 1
+    return {
+        "ok": True,
+        "service": "compute-gateway",
+        "kinds": list(registry.KINDS),
+        "signing": {
+            "state": signing.signing_state(),
+            "signed": signed,
+            "count": total,
+            "signed_ratio": (signed / total) if total else None,
+        },
+    }
 
 
 @app.get("/v1/contract")

--- a/apps/compute-gateway/src/compute_gateway/signing.py
+++ b/apps/compute-gateway/src/compute_gateway/signing.py
@@ -42,7 +42,11 @@ def load_signing_key() -> Ed25519PrivateKey | None:
     """Ed25519 private key from `GATEWAY_SIGNING_KEY` (base64 32-byte seed).
 
     Absent or malformed → None (the caller emits an *unsigned* receipt; we never
-    fabricate a signature).
+    fabricate a signature). Callers who need to distinguish "no key configured"
+    from "key present but bad" should use `signing_state()` — quietly downgrading a
+    misconfigured key to unsigned was masking a real operational fault (Copilot #TBD:
+    a bad key silently produced unsigned receipts whose `verify()` reported
+    `valid: True` because verify only fails on a *present-but-invalid* signature).
     """
     raw = os.getenv("GATEWAY_SIGNING_KEY", "").strip()
     if not raw:
@@ -54,6 +58,35 @@ def load_signing_key() -> Ed25519PrivateKey | None:
         return Ed25519PrivateKey.from_private_bytes(seed)
     except Exception:  # noqa: BLE001 — a bad key is treated as "no key", never faked
         return None
+
+
+def signing_state() -> str:
+    """Report the observable state of the signing config, from the same env var
+    `load_signing_key()` inspects, without mutating anything:
+
+      * 'signed'   — a valid Ed25519 seed is configured; new receipts get signatures.
+      * 'unsigned' — no key is configured (env unset or blank); receipts are unsigned
+                     by design (dev/tests). This is deliberate, not a fault.
+      * 'error'    — `GATEWAY_SIGNING_KEY` IS set, but decoding fails (bad base64,
+                     wrong length, corrupt seed). Receipts silently ride as unsigned,
+                     and `verify()` cannot notice because it only rejects a
+                     present-but-invalid signature — the failure mode this state
+                     exists to make loud on `/healthz` (see server.py).
+    """
+    raw = os.getenv("GATEWAY_SIGNING_KEY", "").strip()
+    if not raw:
+        return "unsigned"
+    try:
+        seed = base64.b64decode(raw)
+    except Exception:  # noqa: BLE001
+        return "error"
+    if len(seed) != 32:
+        return "error"
+    try:
+        Ed25519PrivateKey.from_private_bytes(seed)
+    except Exception:  # noqa: BLE001
+        return "error"
+    return "signed"
 
 
 def _pub_b64(pub: Ed25519PublicKey) -> str:

--- a/apps/compute-gateway/tests/test_sub_tier_hardening.py
+++ b/apps/compute-gateway/tests/test_sub_tier_hardening.py
@@ -1,0 +1,207 @@
+"""Sub-tier hardening — the three findings from adversarial review at
+main@55fb4c5a. Each test exercises the discriminating case: the ONE outcome
+that could only be produced by the missing guard, so a regression to the
+pre-fix behaviour would flip the assertion.
+
+  1) receipts.seal race window — concurrent seals for the same project
+     could compute the same `prev`, both persist under seq=N, and one
+     receipt was silently dropped by INSERT OR REPLACE. Threaded stress
+     test asserts chain length == threads and every prev-link is intact.
+  2) signing state / /healthz visibility — a MALFORMED
+     GATEWAY_SIGNING_KEY used to silently downgrade to unsigned; verify()
+     couldn't notice (it only fails on a present-but-invalid signature),
+     so an operator lost signatures with a green health check.
+"""
+from __future__ import annotations
+
+import base64
+import importlib
+import os
+import threading
+
+os.environ["GATEWAY_TOKEN"] = "t"
+os.environ["COMPUTE_ENTITLEMENTS"] = "demo"
+os.environ["GATEWAY_WRITE_PROVENANCE"] = "false"
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from compute_gateway import receipts, server, signing  # noqa: E402
+
+AUTH = {"Authorization": "Bearer t"}
+
+
+# ── #1: receipts.seal race window ────────────────────────────────────────
+
+def _reset_receipts() -> None:
+    receipts._CHAINS.clear()
+    # NB: don't clear _LOCKS — the whole point is that per-project locks are stable.
+
+
+def test_concurrent_seals_for_same_project_never_lose_a_receipt():
+    """N threads racing seal() on ONE project must produce N receipts, all
+    chained (each `prev` is the previous receipt's id). Pre-fix, two threads
+    could read the same `prev`, both append, both persist under the same
+    seq — INSERT OR REPLACE dropped one, verify() reported valid:False with
+    'prev-link broken', OR the two duplicate rows agreed on prev but the
+    chain silently lost a receipt (count < threads)."""
+    _reset_receipts()
+    N = 32
+    barrier = threading.Barrier(N)
+    errors: list[BaseException] = []
+
+    def seal_one(i: int) -> None:
+        try:
+            barrier.wait()                # maximise race window
+            receipts.seal(
+                "race-project", kind="notebook", backend="forge", runtime="python3",
+                inputs={"i": i}, outputs=[{"i": i}], status="ok", actor="tester",
+                epistemic_status="derived")
+        except BaseException as e:  # noqa: BLE001 — surface racy exceptions
+            errors.append(e)
+
+    threads = [threading.Thread(target=seal_one, args=(i,)) for i in range(N)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+    assert not errors, f"seal() raised under contention: {errors[:3]}"
+    chain = receipts.chain("race-project")
+    assert len(chain) == N, f"lost a receipt: {len(chain)}/{N} (race dropped one)"
+    # Every prev-link resolves to the previous receipt's id — the chain integrity
+    # check that verify() runs, expressed directly so a failure names the bug.
+    prev = None
+    for r in chain:
+        assert r.prev == prev, f"prev-link broken at {r.id[:16]}: got {r.prev!r} want {prev!r}"
+        prev = r.id
+    # Full contract: verify() must still pass end-to-end.
+    v = receipts.verify("race-project")
+    assert v["valid"] is True, v
+    assert v["count"] == N
+
+
+def test_concurrent_seals_across_projects_do_not_serialize_on_each_other():
+    """Per-project locks — seals for DIFFERENT projects must not block each
+    other, so a slow project cannot starve the rest. This is a shape assert:
+    both chains end up complete, independent of interleaving."""
+    _reset_receipts()
+    N = 8
+    barrier = threading.Barrier(2 * N)
+
+    def seal_into(project: str, i: int) -> None:
+        barrier.wait()
+        receipts.seal(project, kind="notebook", backend="forge", runtime="python3",
+                      inputs={"i": i}, outputs=[{"i": i}], status="ok", actor="tester",
+                      epistemic_status="derived")
+
+    threads = ([threading.Thread(target=seal_into, args=("a", i)) for i in range(N)]
+               + [threading.Thread(target=seal_into, args=("b", i)) for i in range(N)])
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+    assert len(receipts.chain("a")) == N
+    assert len(receipts.chain("b")) == N
+    assert receipts.verify("a")["valid"] is True
+    assert receipts.verify("b")["valid"] is True
+
+
+# ── #3: signing state + /healthz visibility ──────────────────────────────
+
+def test_signing_state_reports_signed_when_valid_key_configured():
+    prev = os.environ.get("GATEWAY_SIGNING_KEY")
+    try:
+        os.environ["GATEWAY_SIGNING_KEY"] = base64.b64encode(b"0" * 32).decode()
+        assert signing.signing_state() == "signed"
+    finally:
+        if prev is None: os.environ.pop("GATEWAY_SIGNING_KEY", None)
+        else: os.environ["GATEWAY_SIGNING_KEY"] = prev
+
+
+def test_signing_state_reports_unsigned_when_no_key():
+    prev = os.environ.get("GATEWAY_SIGNING_KEY")
+    try:
+        os.environ.pop("GATEWAY_SIGNING_KEY", None)
+        assert signing.signing_state() == "unsigned"
+    finally:
+        if prev is not None: os.environ["GATEWAY_SIGNING_KEY"] = prev
+
+
+def test_signing_state_reports_error_for_malformed_key():
+    """The bug this whole story exists to make loud: a bad key used to be
+    silently swallowed to None, receipts rode unsigned, and verify() couldn't
+    tell. Now signing_state() returns 'error' — a distinct third value that
+    /healthz surfaces so an operator sees the fault."""
+    prev = os.environ.get("GATEWAY_SIGNING_KEY")
+    try:
+        # Set to wrong-length base64 — decodes cleanly, but seed is not 32 bytes.
+        os.environ["GATEWAY_SIGNING_KEY"] = base64.b64encode(b"too-short").decode()
+        assert signing.signing_state() == "error"
+        # Set to invalid base64 — decode raises.
+        os.environ["GATEWAY_SIGNING_KEY"] = "not-valid-base64!!!!"
+        assert signing.signing_state() == "error"
+    finally:
+        if prev is None: os.environ.pop("GATEWAY_SIGNING_KEY", None)
+        else: os.environ["GATEWAY_SIGNING_KEY"] = prev
+
+
+def test_healthz_reports_signing_error_and_signed_ratio():
+    """Integration: with a MALFORMED key, /healthz reports signing.state=='error'
+    AND — crucially — receipts sealed under this configuration are NOT
+    signature-verified (signed==0). Pre-fix, /healthz reported no signing state
+    at all, and verify() cheerfully reported valid:True because it only flags
+    a present-but-invalid signature. This test would have caught that failure
+    mode: the whole gateway would report signing='error' + zero signed receipts,
+    turning a silent misconfiguration into a loud one."""
+    prev = os.environ.get("GATEWAY_SIGNING_KEY")
+    _reset_receipts()
+    try:
+        os.environ["GATEWAY_SIGNING_KEY"] = base64.b64encode(b"too-short").decode()
+        # Re-import server so the signing-state read is fresh (it reads env at
+        # call time, but seal captures the key at seal time — mint receipts here).
+        importlib.reload(server)
+        client = TestClient(server.app)
+
+        # Seal a receipt under the bad-key regime.
+        receipts.seal("hp", kind="notebook", backend="forge", runtime="python3",
+                      inputs={"x": 1}, outputs=[{"x": 1}], status="ok", actor="op",
+                      epistemic_status="derived")
+
+        health = client.get("/healthz").json()
+        assert health["signing"]["state"] == "error"
+        assert health["signing"]["count"] >= 1
+        # The whole point: the receipt is NOT signature-verified. Pre-fix, a caller
+        # reading verify() saw valid:True and no signal that signatures were absent.
+        assert health["signing"]["signed"] == 0
+        assert health["signing"]["signed_ratio"] == 0.0
+
+        # verify() ALSO stays valid:True — chain integrity is unaffected — so /healthz
+        # is the ONLY loud surface for the misconfiguration. That's why it matters here.
+        v = receipts.verify("hp")
+        assert v["valid"] is True and v["signed"] == 0
+    finally:
+        if prev is None: os.environ.pop("GATEWAY_SIGNING_KEY", None)
+        else: os.environ["GATEWAY_SIGNING_KEY"] = prev
+        importlib.reload(server)
+
+
+def test_healthz_reports_signed_ratio_when_key_is_valid():
+    """Complement to the error case: with a valid key, /healthz shows the healthy
+    signed / count ratio so an operator distinguishes 'no receipts yet' (ratio
+    None) from 'receipts sealed and all signed' (ratio 1.0)."""
+    prev = os.environ.get("GATEWAY_SIGNING_KEY")
+    _reset_receipts()
+    try:
+        os.environ["GATEWAY_SIGNING_KEY"] = base64.b64encode(b"1" * 32).decode()
+        importlib.reload(server)
+        client = TestClient(server.app)
+
+        receipts.seal("hp2", kind="notebook", backend="forge", runtime="python3",
+                      inputs={"x": 1}, outputs=[{"x": 1}], status="ok", actor="op",
+                      epistemic_status="derived")
+
+        health = client.get("/healthz").json()
+        assert health["signing"]["state"] == "signed"
+        assert health["signing"]["signed"] == health["signing"]["count"] >= 1
+        assert health["signing"]["signed_ratio"] == 1.0
+    finally:
+        if prev is None: os.environ.pop("GATEWAY_SIGNING_KEY", None)
+        else: os.environ["GATEWAY_SIGNING_KEY"] = prev
+        importlib.reload(server)

--- a/apps/nugget-extractor/src/nugget_extractor/emitter.py
+++ b/apps/nugget-extractor/src/nugget_extractor/emitter.py
@@ -55,6 +55,7 @@ is stated rather than papered over with a queue this service has no store for.
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -67,6 +68,15 @@ from .clients import EmitError, GatewayError
 from .extract import Extraction
 
 log = logging.getLogger("nugget-extractor")
+
+# Ceiling on _pending batches. A hellgraph outage stalls drain() at the FIRST failing
+# op (batch.cursor never advances past it) while /v1/extract keeps admitting new
+# documents — every call adds one batch to _pending and NUGGET_EXTRACTOR_MAX_PENDING
+# batches later the pod is OOM'd. The cap makes that surface as a 503-shaped result
+# (see BatchResult.status == 'degraded') that the caller can back-pressure on,
+# instead of a pod bounce. Match the device-service `run_once` skip-with-reason
+# pattern: no partial batch, no counted work, an explicit reason string.
+MAX_PENDING = int(os.environ.get("NUGGET_EXTRACTOR_MAX_PENDING", "1000"))
 
 NUGGET_LABEL = "KnowledgeNugget"
 DOCUMENT_LABEL = "SourceDocument"
@@ -119,6 +129,12 @@ class BatchResult:
     attempted: bool = False
     hellgraph_ok: bool = True
     gateway_ok: bool = True
+    # Back-pressure signal: 'ok' | 'degraded'. Set when submit() refused to admit the
+    # batch (because _pending is at MAX_PENDING) so the HTTP layer can translate to 503
+    # instead of letting the pod balloon toward OOM. A `reason` explains which
+    # dependency is stalled — the caller sees WHY it's being back-pressured.
+    status: str = "ok"
+    reason: str | None = None
 
 
 @dataclass
@@ -163,6 +179,25 @@ class NuggetEmitter:
     def _submit(self, extraction: Extraction, *, doc_ref: str, run_ref: str,
                 policy_labels: list[str] | None = None,
                 extra_kko_type_refs: list[str] | None = None) -> BatchResult:
+        # BACK-PRESSURE gate — enforced BEFORE we build nuggets or advance the logical
+        # clock, so a refused submit is a pure no-op the caller can safely retry. The
+        # pending queue only fills when drain() is stalled (hellgraph or gateway is
+        # down); admitting more work while both sides are wedged is what turns an
+        # upstream outage into an OOM crash. Match device-service's skip-with-reason
+        # posture — no partial batch, no counted work, an explicit reason string.
+        if len(self._pending) >= MAX_PENDING:
+            reason = (
+                "nugget-extractor pending queue full "
+                f"({len(self._pending)}/{MAX_PENDING}) — hellgraph downstream may be "
+                "unavailable; retry after drain")
+            log.warning("submit REFUSED — %s (doc=%s)", reason, doc_ref)
+            return BatchResult(
+                documents=0, extracted=0, emitted=0, validation_failures=0,
+                pending=sum(len(b.nuggets) for b in self._pending),
+                status="degraded", reason=reason,
+                hellgraph_ok=False,   # the cap only trips when drain is stalled
+                gateway_ok=False,
+            )
         built = nugget_builder.build(
             extraction, doc_ref=doc_ref, run_ref=run_ref, clock=self.clock,
             logical_start=self._logical, policy_labels=policy_labels or [],

--- a/apps/nugget-extractor/src/nugget_extractor/emitter.py
+++ b/apps/nugget-extractor/src/nugget_extractor/emitter.py
@@ -76,7 +76,34 @@ log = logging.getLogger("nugget-extractor")
 # (see BatchResult.status == 'degraded') that the caller can back-pressure on,
 # instead of a pod bounce. Match the device-service `run_once` skip-with-reason
 # pattern: no partial batch, no counted work, an explicit reason string.
-MAX_PENDING = int(os.environ.get("NUGGET_EXTRACTOR_MAX_PENDING", "1000"))
+#
+# Copilot #1106: a bare `int(os.environ.get(...))` on a misconfigured value
+# (e.g. NUGGET_EXTRACTOR_MAX_PENDING="off") would raise ValueError at IMPORT
+# time and crash the pod on boot — an OOM guard that itself becomes a boot-
+# time outage. Parse defensively: fall back to the 1000 default and log at
+# WARN so the misconfiguration is loud rather than silent, and clamp to a
+# non-negative floor (a negative cap would silently disable admission
+# forever, which is the same shape defect).
+def _parse_max_pending(raw: str | None, default: int = 1000) -> int:
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        log.warning(
+            "NUGGET_EXTRACTOR_MAX_PENDING=%r is not an int; falling back to %d",
+            raw, default,
+        )
+        return default
+    if value < 0:
+        log.warning(
+            "NUGGET_EXTRACTOR_MAX_PENDING=%d is negative; clamping to 0", value,
+        )
+        return 0
+    return value
+
+
+MAX_PENDING = _parse_max_pending(os.environ.get("NUGGET_EXTRACTOR_MAX_PENDING"))
 
 NUGGET_LABEL = "KnowledgeNugget"
 DOCUMENT_LABEL = "SourceDocument"

--- a/apps/nugget-extractor/src/nugget_extractor/server.py
+++ b/apps/nugget-extractor/src/nugget_extractor/server.py
@@ -232,6 +232,23 @@ def extract_endpoint(req: ExtractRequest, _: None = Depends(require_token)) -> d
             STATE["last_error_at"] = time.time()
         raise HTTPException(status_code=500, detail=f"{type(e).__name__}: {e}")
 
+    # Back-pressure: submit() refused to admit because _pending is at the cap. Surface
+    # as 503 so the caller retries rather than the pod balloons to OOM. Nothing was
+    # counted, nothing was extracted, no state was mutated below this point.
+    if result.status == "degraded":
+        with _LOCK:
+            STATE["hellgraph_ok"] = result.hellgraph_ok
+            STATE["gateway_ok"] = result.gateway_ok
+            STATE["last_error"] = result.reason or "pending queue full"
+            STATE["last_error_at"] = time.time()
+        raise HTTPException(status_code=503, detail={
+            "status": "degraded",
+            "reason": result.reason,
+            "pending": result.pending,
+            "hellgraph_ok": result.hellgraph_ok,
+            "gateway_ok": result.gateway_ok,
+        })
+
     with _LOCK:
         STATE["documents"] += result.documents
         STATE["extracted"] += result.extracted

--- a/apps/nugget-extractor/tests/test_pending_cap.py
+++ b/apps/nugget-extractor/tests/test_pending_cap.py
@@ -1,0 +1,132 @@
+"""Back-pressure — the pending-queue ceiling that turns a hellgraph outage
+from an OOM crash into a 503.
+
+Pre-fix: `self._pending.append(_PendingBatch(...))` had no ceiling. Once
+hellgraph stopped answering, drain() stalled at the first failing op
+(batch.cursor never advanced) while POST /v1/extract kept admitting new
+documents — MAX_PENDING batches later the pod was OOM'd. The cap makes
+that surface as status='degraded' at the API and a 503 at the HTTP layer,
+matching the device-service run_once skip-with-reason posture.
+"""
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+from nugget_extractor import emitter as em, extract as ex
+from nugget_extractor.clients import EmitError
+
+TEXT = b"Network sales grew 22.6% to AUD 1,138.9 million.\n\nStore rollout continued."
+DOC = "urn:srcos:document:cap-test"
+RUN = "urn:srcos:run:cap-test"
+
+
+class WedgedGraph:
+    """hellgraph is down — every write raises EmitError, cursor never advances."""
+    def post_node(self, *_a, **_kw): raise EmitError("hellgraph down")
+    def post_edge(self, *_a, **_kw): raise EmitError("hellgraph down")
+
+
+class UnusedGateway:
+    """The gateway is never reached when the graph writes fail first."""
+    def mint(self, **_kw): raise AssertionError("gateway must not be called when hellgraph is down")
+
+
+def _extraction() -> ex.Extraction:
+    return ex.extract(TEXT, filename="a.txt")
+
+
+def test_submit_refuses_with_degraded_status_when_pending_at_ceiling():
+    """Discriminating case: with a tiny MAX_PENDING (2) and a wedged hellgraph,
+    the FIRST two submits fill _pending (drain fails, batch stays), and the
+    THIRD submit is refused with status='degraded' and an explanatory reason.
+    Pre-fix, the third submit appended anyway — _pending would grow unbounded."""
+    with mock.patch.object(em, "MAX_PENDING", 2):
+        e = em.NuggetEmitter(writer=WedgedGraph(), gateway=UnusedGateway(),
+                             clock=lambda: "2026-07-29T00:00:00.000Z")
+        # First 2 admitted (drain fails, batch stays pending).
+        r1 = e.submit(_extraction(), doc_ref=DOC + "-1", run_ref=RUN)
+        r2 = e.submit(_extraction(), doc_ref=DOC + "-2", run_ref=RUN)
+        assert r1.status == "ok" and r2.status == "ok"
+        assert r1.hellgraph_ok is False  # drain saw the outage
+        assert len(e._pending) == 2
+
+        # Third submit — cap engaged. This is the load-bearing assertion.
+        r3 = e.submit(_extraction(), doc_ref=DOC + "-3", run_ref=RUN)
+        assert r3.status == "degraded"
+        assert r3.reason is not None
+        assert "pending queue full" in r3.reason
+        assert "hellgraph downstream may be unavailable" in r3.reason
+        # No work was counted — a degraded submit is a pure no-op.
+        assert r3.documents == 0 and r3.extracted == 0 and r3.emitted == 0
+        assert r3.hellgraph_ok is False and r3.gateway_ok is False
+        # _pending did NOT grow past the cap.
+        assert len(e._pending) == 2
+
+
+def test_submit_admits_again_after_drain_frees_the_queue():
+    """After the queue drains (e.g. hellgraph recovers), submits succeed again —
+    the cap is a back-pressure signal, not a permanent kill-switch."""
+    with mock.patch.object(em, "MAX_PENDING", 1):
+        # Start wedged: fill the one slot.
+        e = em.NuggetEmitter(writer=WedgedGraph(), gateway=UnusedGateway(),
+                             clock=lambda: "2026-07-29T00:00:00.000Z")
+        r1 = e.submit(_extraction(), doc_ref=DOC + "-a", run_ref=RUN)
+        assert r1.status == "ok"
+        # Next one is refused.
+        r2 = e.submit(_extraction(), doc_ref=DOC + "-b", run_ref=RUN)
+        assert r2.status == "degraded"
+
+        # Simulate hellgraph recovery: swap in a healthy graph + gateway and drain.
+        class HealthyGraph:
+            def post_node(self, *_a, **_kw): pass
+            def post_edge(self, *_a, **_kw): pass
+
+        class HealthyGateway:
+            def __init__(self): self.calls = 0
+            def mint(self, **_kw):
+                self.calls += 1
+                return {"receipt_id": f"rcpt-{self.calls:04d}"}
+
+        e.writer = HealthyGraph()
+        e.gateway = HealthyGateway()
+        drained = e.drain()
+        assert drained.emitted > 0
+        assert len(e._pending) == 0
+
+        # Now new work is admitted again.
+        r3 = e.submit(_extraction(), doc_ref=DOC + "-c", run_ref=RUN)
+        assert r3.status == "ok"
+        assert r3.emitted > 0
+
+
+def test_max_pending_default_is_1000():
+    """Guard against silent tuning drift — the default is contracted."""
+    # Read the current module value, but also verify the env-driven default.
+    from importlib import reload
+    prev = os.environ.pop("NUGGET_EXTRACTOR_MAX_PENDING", None)
+    try:
+        reload(em)
+        assert em.MAX_PENDING == 1000
+    finally:
+        if prev is not None:
+            os.environ["NUGGET_EXTRACTOR_MAX_PENDING"] = prev
+        reload(em)
+
+
+def test_max_pending_env_override_is_respected():
+    prev = os.environ.get("NUGGET_EXTRACTOR_MAX_PENDING")
+    try:
+        os.environ["NUGGET_EXTRACTOR_MAX_PENDING"] = "5"
+        from importlib import reload
+        reload(em)
+        assert em.MAX_PENDING == 5
+    finally:
+        if prev is None:
+            os.environ.pop("NUGGET_EXTRACTOR_MAX_PENDING", None)
+        else:
+            os.environ["NUGGET_EXTRACTOR_MAX_PENDING"] = prev
+        from importlib import reload
+        reload(em)


### PR DESCRIPTION
Three sub-tier findings verified real at `main@55fb4c5a`, each with a
discriminating test that would flip on regression.

## 1. Seal-window race in `receipts.py`

**File:** `apps/compute-gateway/src/compute_gateway/receipts.py:47-79`

**Failure:** The `seal()` window (`_CHAINS.setdefault` → read `prev` → hash body
→ `attest` → append → `persistence.save_receipt`) had **no lock at all**.
`persistence._LOCK` only covers the SQLite write itself, not the read of `prev`
or the id computation. Two concurrent seals for the same project could compute
the **same `prev`**, both append, and both persist under `seq=N` — `INSERT OR
REPLACE` in `save_receipt` silently dropped one, or the surviving pair had a
broken prev-link and `verify()` reported `valid: False, reason: "prev-link
broken"` after the race.

**Fix:** Per-project `threading.Lock` held across the entire window — bounded
to hash + attest + persist, all pure/local (no arbitrary caller code inside).
Concurrent seals across **different** projects still run in parallel; the
lock is minted lazily per project (double-check for the common path). Chose
`threading.Lock` rather than `asyncio.Lock` because seal is sync and callers
include FastAPI's threadpool as well as pure-sync `config_plane`.

**Test:** `test_concurrent_seals_for_same_project_never_lose_a_receipt` fires
32 threads at one project through a barrier; asserts `len(chain) == 32` and
every `prev`-link resolves. A second test confirms different-project seals
don't serialize on each other.

## 2. Unbounded pending queue in `nugget_extractor/emitter.py`

**File:** `apps/nugget-extractor/src/nugget_extractor/emitter.py:145-208`
**Pod-crash surface:** `submit()` did `self._pending.append(_PendingBatch(...))`
with no ceiling.

**Failure:** hellgraph outage stalled `drain()` at the first failing op
(`batch.cursor` never advanced past it) while `POST /v1/extract` kept
admitting new documents — every call added a batch to `_pending` and the pod
was OOM'd downstream.

**Fix:** `MAX_PENDING = int(os.environ.get('NUGGET_EXTRACTOR_MAX_PENDING',
'1000'))`. `submit()` gate-checks before building nuggets or advancing the
logical clock; over-cap returns `BatchResult(status='degraded', reason=...)`
as a pure no-op the caller can safely retry. `server.py` translates
`status='degraded'` into HTTP `503`. Matches the `device-service.run_once`
skip-with-reason pattern.

**Test:** `test_submit_refuses_with_degraded_status_when_pending_at_ceiling`
patches `MAX_PENDING=2` with a wedged graph and asserts the third submit
returns `degraded` with a `pending queue full` reason, and `_pending` did
not grow. Recovery test confirms admissions resume after drain frees the
queue.

## 3. Silent-unsigned regime in `signing.py` + `/healthz`

**File:** `apps/compute-gateway/src/compute_gateway/signing.py:41-88`,
`apps/compute-gateway/src/compute_gateway/server.py:33-64`

**Failure:** Any exception decoding `GATEWAY_SIGNING_KEY` returned `None`, the
seal proceeded unsigned, and `verify()` reported `valid: True` because it only
fails on a **present-but-invalid** signature. An operator with a bad key lost
signatures across the fleet with a green health check.

**Fix:** Keep the fail-to-`None` behaviour (the "we never fabricate a
signature" contract is correct) but expose the state:
- New `signing.signing_state()` → `'signed' | 'unsigned' | 'error'`.
- `/healthz` now emits `signing.{state, signed, count, signed_ratio}` — the
  live signed / total across all in-memory chains, plus the state so a
  configured-but-broken key surfaces as `error` distinct from an unconfigured
  key's `unsigned`.

**Test:** `test_healthz_reports_signing_error_and_signed_ratio` stubs a
malformed key, seals a receipt, and asserts `/healthz` reports
`signing.state == 'error'` AND `signed == 0`. Also asserts `verify()` still
reports `valid: True` (chain integrity is unaffected) — so `/healthz` is
the **only** loud surface for this misconfiguration. That's the whole point.

---

## Test results

- `apps/compute-gateway`: 172 passed (7 new, all pre-existing pass)
- `apps/nugget-extractor`: 84 passed (4 new, all pre-existing pass)