### PR TITLE
fix(iac): make ibm-iks pass tofu validate — and stop it claiming OIDC federation IBM cannot do

### DIFF
--- a/infra/tofu/environments/ibm-iks/README.md
+++ b/infra/tofu/environments/ibm-iks/README.md
@@ -10,5 +10,25 @@ unchanged.
 tofu init && tofu apply
 $(tofu output -raw get_credentials)
 ```
-> Validate-clean; not apply-tested (no IBM keys here). Confirm flavor names
-> (`bx2.4x16`, `gx2-8x64x1v100`) + kube_version against `ibmcloud ks` before applying.
+> Validate-clean as of the PR that added this line — and **not before**. This
+> root had never once passed `tofu validate`: it failed at `tofu init` until the
+> IBM provider source was declared, and the two errors that unblocking exposed
+> had been unreachable the whole time. Not apply-tested (no IBM keys here).
+> Confirm flavor names (`bx2.4x16`, `gx2-8x64x1v100`) + kube_version against
+> `ibmcloud ks` before applying.
+
+## ⚠️ CI authentication does not work
+
+`module.github_ci` creates an IBM Trusted Profile, but **it has no claim rule and
+cannot be assumed by GitHub Actions.** IBM IAM accepts only `Profile-SAML`
+(human SSO from a registered SAML realm) and `Profile-CR` (IBM Cloud compute:
+`VSI`, `PVS`, `BMS`, `IKS_SA`, `ROKS_SA`, `CE`). A GitHub-hosted runner is
+neither, and IBM's IAM identity-provider API has no OIDC type at all — only
+`saml`, `appid`, `ldap`. There is no IBM equivalent of GCP/Azure workload
+identity federation for CI.
+
+Consequently the `cr-token` exchange in
+`.github/workflows/infra-drift-detect.yml` cannot succeed, and applying this
+root requires a real credential (`IC_API_KEY`). See the header of
+`../../modules/ibm-trusted-profile/main.tf` for the three supported options and
+the recommendation.

--- a/infra/tofu/environments/ibm-iks/main.tf
+++ b/infra/tofu/environments/ibm-iks/main.tf
@@ -3,12 +3,18 @@
 # + Argo CD + the identical root app. App layer (charts/ + deploy/argocd)
 # unchanged.
 
+# IBM user tags must match ^[A-Za-z0-9:_ .-]+$ — no "/". So the repo is carried
+# as two tags (org + name) rather than one "owner/name" tag. This matches how
+# every other root already labels: aws-eks/azure-aks and shared/labels.tf both
+# use a separate "org" = "socioprophet" key and never embed the owner in the
+# repo name. Values are lowercase because IBM lowercases user tags on write.
 locals {
   prophet_tags = [
     "managed-by:opentofu",
     "environment:production",
     "team:platform",
-    "repo:SocioProphet/prophet-platform",
+    "org:socioprophet",
+    "repo:prophet-platform",
   ]
 }
 
@@ -67,8 +73,10 @@ resource "ibm_cr_namespace" "images" {
   tags              = local.prophet_tags
 }
 
-# GitHub Actions OIDC federation via IBM Trusted Profile (no static API keys).
-# After apply, set IBM_TRUSTED_PROFILE_ID as a GitHub Actions *variable*.
+# IBM Trusted Profile for CI. ⚠️ NOT currently federated to GitHub Actions —
+# IBM IAM has no claim rule type that accepts a GitHub OIDC token. The profile
+# and its policies are created, but nothing can assume them yet. Read the header
+# of modules/ibm-trusted-profile/main.tf before wiring anything to this.
 module "github_ci" {
   source            = "../../modules/ibm-trusted-profile"
   github_repo       = "SocioProphet/prophet-platform"
@@ -79,5 +87,5 @@ module "github_ci" {
 
 output "github_ci_trusted_profile_id" {
   value       = module.github_ci.trusted_profile_id
-  description = "Set as GitHub Actions variable IBM_TRUSTED_PROFILE_ID (not a secret)."
+  description = "IBM Trusted Profile ID. WARNING: setting this as IBM_TRUSTED_PROFILE_ID will NOT make CI auth work — the profile has no claim rule, because IBM cannot federate GitHub Actions OIDC."
 }

--- a/infra/tofu/modules/ibm-trusted-profile/main.tf
+++ b/infra/tofu/modules/ibm-trusted-profile/main.tf
@@ -1,10 +1,54 @@
-# IBM IAM Trusted Profile — GitHub Actions OIDC federation.
-# IBM's equivalent of AWS IRSA / Azure WIF / GCP WIF.
-# GitHub Actions gets a short-lived OIDC token; IBM IAM validates the claim
-# and issues a temporary session token. No static API keys in CI.
+# IBM IAM Trusted Profile.
 #
-# After apply, store the profile CRN as a GitHub Actions variable (not a secret):
-#   IBM_TRUSTED_PROFILE_ID → trusted_profile_id output
+# ⚠️  THIS MODULE DOES NOT FEDERATE GITHUB ACTIONS. IT CANNOT.
+#
+# It used to claim to be "IBM's equivalent of AWS IRSA / Azure WIF / GCP WIF"
+# and carried a claim rule with type = "Profile-OIDC". No such type exists.
+# IBM IAM accepts exactly two claim rule types, and neither one can consume a
+# GitHub Actions OIDC token:
+#
+#   Profile-SAML — federated *human* users from a SAML IdP registered in the
+#                  account. Requires realm_name naming that registered realm.
+#   Profile-CR   — IBM Cloud *compute resources*. cr_type must be one of
+#                  VSI, PVS, BMS, IKS_SA, ROKS_SA, CE — every one of which is a
+#                  workload running inside IBM Cloud, identified by a compute
+#                  resource token it reads from its own instance metadata
+#                  service or projected service account file.
+#
+# A GitHub-hosted runner is neither. It cannot mint a cr_token, so there is no
+# value of `type` that makes this work. IBM's own docs enumerate the ways a
+# trusted profile can be assumed — federated users, compute resources, service
+# IDs, cloud service instances — and external OIDC providers are not among them.
+#
+# Refs:
+#   https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/iam_trusted_profile_claim_rule
+#   https://cloud.ibm.com/docs/account?topic=account-create-trusted-profile
+#   https://cloud.ibm.com/docs/account?topic=account-trusted-profile-iam-token
+#
+# The invalid claim rule is therefore removed rather than swapped for one that
+# would pass `tofu validate` while federating nothing. CONSEQUENCE: the profile
+# below is created but is NOT ASSUMABLE BY CI. The policies attached to it grant
+# nothing to anyone until one of these identity bindings is chosen:
+#
+#   1. Run the job on IBM compute. Move the drift plan to Code Engine (cr_type
+#      "CE") or an IKS workload (cr_type "IKS_SA") and reduce GitHub Actions to
+#      a trigger. This is the only option that is genuinely keyless, and it is
+#      the true analogue of AWS IRSA — note IRSA is *pod* identity, which IBM
+#      does support; it is Azure/GCP-style *CI* federation that IBM lacks.
+#   2. Service ID + API key held in GitHub secrets. Supported, works today,
+#      but reintroduces the long-lived credential this module set out to avoid.
+#      Rotation then has to be owned somewhere.
+#   3. Service ID + API key in IBM Secrets Manager, fetched at job start. Still
+#      needs a bootstrap credential in GitHub, so it narrows the blast radius
+#      rather than removing it.
+#
+# 1 is the recommendation. 2 and 3 should be treated as interim.
+#
+# Known-broken dependent (outside this module's lane, not fixed here):
+#   .github/workflows/infra-drift-detect.yml posts a GitHub OIDC token to
+#   grant_type=urn:ibm:params:oauth:grant-type:cr-token. That exchange expects a
+#   compute resource token and will reject a GitHub token. That workflow needs
+#   reworking alongside whichever option is chosen.
 
 # The IBM provider is the only non-hashicorp/ namespace provider in this repo,
 # so the source address must be declared here as well as in the root module —
@@ -18,22 +62,15 @@ terraform {
 }
 
 resource "ibm_iam_trusted_profile" "github_ci" {
-  name        = "github-ci-${var.profile_name_suffix}"
-  description = "GitHub Actions OIDC federation — no static API keys"
+  name = "github-ci-${var.profile_name_suffix}"
+  # Description states the actual state of the profile, not the intent. Anyone
+  # reading this in the IBM console should learn that it grants nothing yet.
+  description = "NOT FEDERATED — no claim rule. Intended consumer ${var.github_repo}; IBM has no GitHub Actions OIDC path. See infra/tofu/modules/ibm-trusted-profile/main.tf"
 }
 
-# Claim rule binding GitHub's OIDC token to this profile.
-resource "ibm_iam_trusted_profile_claim_rule" "github" {
-  profile_id = ibm_iam_trusted_profile.github_ci.id
-  type       = "Profile-OIDC"
-  realm_name = "https://token.actions.githubusercontent.com"
-
-  conditions {
-    claim    = "repository"
-    operator = "EQUALS"
-    value    = "\"${var.github_repo}\""
-  }
-}
+# NO CLAIM RULE. See the header. `ibm_iam_trusted_profile_claim_rule` cannot
+# express "trust GitHub Actions", and a rule that validated but matched nothing
+# would be worse than its absence: it would look like federation was configured.
 
 # Policy: read-only viewer on the resource group + IKS cluster.
 resource "ibm_iam_trusted_profile_policy" "viewer" {


### PR DESCRIPTION
Stacked on #1103 (`fix/tofu-fmt-validate-blackout`) — that PR's provider-source declaration is what makes `tofu init` work here at all. Retarget to `main` once #1103 merges.

`infra/tofu/environments/ibm-iks` **has never passed `tofu validate`.** It failed at `tofu init` because `modules/ibm-trusted-profile` used `ibm_*` resources without a declared provider source, so OpenTofu inferred the nonexistent `hashicorp/ibm`. #1103 fixed that, which unblocked init and exposed two errors that had been unreachable the entire time.

## Before / after

Both with **OpenTofu 1.8.3** (the `TOFU_VERSION` in `tofu-plan.yml`), `tofu init -backend=false && tofu validate`:

**Before** — 2 errors:
```
Error: "tags.2" ("repo:SocioProphet/prophet-platform") should match regexp ^[A-Za-z0-9:_ .-]+$
  with ibm_is_vpc.this, on main.tf line 21

Error: "type" must contain a value from []string{"Profile-SAML", "Profile-CR"}, got "Profile-OIDC"
  with module.github_ci.ibm_iam_trusted_profile_claim_rule.github,
  on ../../modules/ibm-trusted-profile/main.tf line 28
```

**After** — from a clean `.terraform`:
```
Success! The configuration is valid.
```
`tofu fmt -check -recursive infra/tofu/` also clean.

> ⚠️ **Local evidence only.** Actions is at a spend cap (456 queued, 0 running), so CI could not verify this. Everything above was run on a local 1.8.3 binary.

---

## Error 1 — the tag convention, and where it applies

IBM user tags must match `^[A-Za-z0-9:_ .-]+$`. No `/`. So `repo:SocioProphet/prophet-platform` is rejected.

**Convention chosen: split the owner out into its own tag.**
```diff
-    "repo:SocioProphet/prophet-platform",
+    "org:socioprophet",
+    "repo:prophet-platform",
```

This is not a new invention — it is what the rest of the estate already does. `environments/aws-eks`, `environments/azure-aks` and `shared/labels.tf` all carry a separate `"org" = "socioprophet"` key and never embed the owner in the repo name. ibm-iks was the only place in the tree that tried to put `owner/name` in a single tag. Values are lowercase because IBM lowercases user tags on write.

**Where else it applies: nowhere.** I checked before changing it, as asked. `local.prophet_tags` is *not* shared — every root declares its own, and the shapes are not even compatible:

| Root | `prophet_tags` type |
|---|---|
| `environments/ibm-iks` | list of `"key:value"` strings (IBM tag format) |
| `environments/aws-eks` | map |
| `environments/azure-aks` | map |

So this change is scoped to ibm-iks. Within ibm-iks it is applied consistently by construction: all four tagged resources (`ibm_is_vpc`, `ibm_is_subnet`, `ibm_container_vpc_cluster`, `ibm_cr_namespace`) reference `local.prophet_tags`. Only the VPC errored because only `ibm_is_vpc` attaches a `ValidateFunc` to `tags`, but all four were carrying the malformed value.

---

## Error 2 — this is a redesign, not a fix

**`Profile-CR` is not the answer. There is no answer.** IBM Cloud cannot federate GitHub Actions OIDC at all, so the module's premise — *"IBM's equivalent of AWS IRSA / Azure WIF / GCP WIF"* — was never achievable.

**The claim rule enum is closed at two values**, hard-coded in the provider ([`resource_ibm_iam_trusted_profile_claim_rule.go`](https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/ibm/service/iamidentity/resource_ibm_iam_trusted_profile_claim_rule.go)):
```go
ValidateFunc: validate.ValidateAllowedStringValues([]string{"Profile-SAML", "Profile-CR"}),
```

**`Profile-CR` is compute-resource-only.** From the [provider docs](https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/website/docs/r/iam_trusted_profile_claim_rule.html.markdown):

> `cr_type` — The compute resource type the rule applies to, required only if type is specified as `'Profile-CR'`. Supported values are **VSI, PVS, BMS, IKS_SA, ROKS_SA, CE**.

Every one of those six is a workload running *inside* IBM Cloud — VPC virtual server, Power VS, bare metal, IKS service account, OpenShift service account, Code Engine. The CR token is not an arbitrary JWT; it is platform-injected, read from the instance metadata service or a projected service account file (`/var/run/secrets/tokens/sa-token`, `/var/run/secrets/codeengine.cloud.ibm.com/compute-resource-token/token`). A GitHub-hosted runner cannot mint one.

**`Profile-SAML` is for human SSO.** Same docs: `realm_name` is *"The realm name of the Idp this claim rule applies to. This field is required only if the type is specified as `'Profile-SAML'`"*, and the type carries an `expiration` ("session expiration in seconds"). It maps a federated user arriving via browser SSO from a registered SAML realm onto a profile. GitHub Actions issues OIDC JWTs, not SAML assertions.

**And there is no IdP route either.** [`resource_ibm_iam_idp.go`](https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/ibm/service/iamidentity/resource_ibm_iam_idp.go) allows exactly `saml`, `appid`, `ldap` — no OIDC type, and no `issuer` / `jwks` / `client_id` fields anywhere in the IAM Identity surface to point at `https://token.actions.githubusercontent.com`.

Corroborating: IBM's own [`IBM/actions-ibmcloud-cli`](https://github.com/IBM/actions-ibmcloud-cli) action accepts exactly one auth input — `api_key`. No OIDC, no trusted profile, no `id-token` permission. And the upstream [`terraform-ibm-modules/terraform-ibm-trusted-profile`](https://github.com/terraform-ibm-modules/terraform-ibm-trusted-profile) makes no IRSA/WIF claim; its example uses `Profile-CR` with `cr_type = "VSI"`. The IRSA-equivalence claim was added locally.

IBM's own docs enumerate how a trusted profile can be assumed — federated (SAML) users, compute resources, service IDs, cloud service instances ([create-trusted-profile](https://cloud.ibm.com/docs/account?topic=account-create-trusted-profile), [trusted-profile-iam-token](https://cloud.ibm.com/docs/account?topic=account-trusted-profile-iam-token)). External OIDC providers are not on the list.

> Honest caveat on the negative: I found no IBM statement that says *"we do not support OIDC federation."* The conclusion rests on closed enums in two independent IBM-authored codebases, the total absence of OIDC primitives in the IAM Identity API, and IBM's own action shipping API-key-only auth. Strong, but it is negative evidence.

### What this PR does instead

Removes the invalid claim rule rather than swapping it for one that passes the validator and federates nothing — that is precisely the "control that passes and does nothing" defect class. **Consequence, stated plainly rather than hidden: the trusted profile is created but is NOT assumable by CI, and its policies grant nothing to anyone.** That is now documented in four places — module header, the calling comment in `ibm-iks/main.tf`, the output `description`, and the env README — plus the IBM console description string itself reads `NOT FEDERATED — no claim rule`.

### Recommended shape (needs a decision, not mine to make unilaterally)

1. **Run the job on IBM compute.** Move the drift plan to Code Engine (`cr_type = "CE"`) or an IKS workload (`IKS_SA`), reduce GitHub Actions to a trigger. Only genuinely keyless option. Worth noting AWS IRSA is *pod* identity, which IBM **does** support via `Profile-CR`; it is Azure/GCP-style *CI* federation that IBM lacks — the module conflated the two.
2. **Service ID + API key in GitHub secrets.** Supported, works today, reintroduces the long-lived credential. Rotation needs an owner.
3. **Service ID + API key in IBM Secrets Manager**, fetched at job start. Narrows blast radius; still needs a bootstrap secret.

**1 is the recommendation; 2 and 3 are interim.**

### 🔴 Also broken, flagged not fixed (out of lane)

`.github/workflows/infra-drift-detect.yml` (~line 149) posts a **GitHub OIDC token** to `grant_type=urn:ibm:params:oauth:grant-type:cr-token`. That grant expects a compute resource token and will reject it, for exactly the reason above. The two halves of this design never agreed with each other — the module declared `Profile-OIDC` while the workflow assumed CR. Neither has ever run. That workflow is outside `environments/ibm-iks/` + `modules/ibm-trusted-profile/`, so it is untouched here and needs reworking alongside whichever option is chosen.

---

## CI coverage — this rotted because nothing watched it

`tofu-plan.yml` runs `fmt -check -recursive` across all of `infra/tofu/`, but `validate` on only **four** roots, all under `envs/`: `local`, `gcp-landing`, `shared`, `prod`. The entire `environments/` tree and all of `bootstrap/` are unvalidated. That is why a root that had *never* validated survived indefinitely.

⚠️ **I have not edited `tofu-plan.yml` — PR #1097 owns it.** Recommendation for whoever lands #1097:

**Add these nine roots to the `fmt-and-validate` job** (`tofu init -backend=false && tofu validate` each):

```
infra/tofu/environments/ibm-iks
infra/tofu/environments/aws-eks
infra/tofu/environments/azure-aks
infra/tofu/environments/gcp-ephemeral
infra/tofu/environments/gcp-gke
infra/tofu/environments/gcp-persistent
infra/tofu/bootstrap/aws
infra/tofu/bootstrap/azure
infra/tofu/bootstrap/gcp
```

**All nine are safe to add now.** I validated each locally on 1.8.3: **eight already pass clean**, and the ninth (`ibm-iks`) passes as of this PR. So this widening goes green immediately — there is no cleanup backlog gating it.

Two notes for whoever implements it:
- `bootstrap/aws` emits a non-fatal provider deprecation warning (`aws_s3_bucket_lifecycle_configuration` missing `rule[0].filter`) — pre-existing, warns only, does not fail `validate`. Worth a separate ticket before it becomes an error in a future provider.
- A matrix over the root list would be tidier than nine copy-pasted steps, and would make the next added root a one-line change rather than an omission.

Given the tree is 13 roots and CI watches 4, a cheap follow-up guard would be a check that every directory containing a `versions.tf`/`backend` block appears in the validate matrix — otherwise root #14 lands unwatched the same way this one did.

## Test plan

- [x] `tofu init -backend=false && tofu validate` in `environments/ibm-iks` on 1.8.3 — clean `.terraform`, passes
- [x] `tofu fmt -check -recursive infra/tofu/` — clean
- [x] All 8 other uncovered roots validated locally on 1.8.3 — all pass
- [ ] CI — **blocked, spend cap**. Not verified in Actions.
- [ ] `tofu apply` — not attempted; no IBM credentials, and per the above CI cannot obtain any.
