### PR TITLE
iac(tofu): pin providers where OpenTofu actually reads them + commit locks

### DIFF
--- a/infra/tofu/.gitignore
+++ b/infra/tofu/.gitignore
@@ -9,4 +9,11 @@ dns-records.txt
 crash.log
 override.tf
 *_override.tf
-.terraform.lock.hcl
+
+# .terraform.lock.hcl is deliberately NOT ignored. Ignoring it meant every CI run
+# re-resolved providers against the registry, so a green `tofu validate` said
+# nothing about the next run. Commit the lock for any root you want reproducible.
+# Regenerate with the TOFU_VERSION in .github/workflows/tofu-plan.yml:
+#   tofu providers lock \
+#     -platform=linux_amd64 -platform=darwin_arm64 -platform=darwin_amd64
+# linux_amd64 is what CI runs on; the darwin entries keep local init working.

--- a/infra/tofu/envs/gcp-landing/.terraform.lock.hcl
+++ b/infra/tofu/envs/gcp-landing/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "h1:O5jnIJXJcM6QWNYDPJAeR/yD01GfvrX4q4X6yLg9Afg=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:+hUxBwXLP3XadzrFEtVYM7qZ/0wChqJHQbtacAWw76s=",
+    "h1:MklYYZlCefCzM5jrAUYHdY+4nOsyCDIvygcL1u79e94=",
+    "h1:t5b8qSJkvi4QALUqqDf17y9e7OBXd1liUyOebVst0YM=",
+    "zh:29d310cfbc3ff8c5c7b3c18d713ced4b4fa66efaffeefc948702771f3723b90d",
+    "zh:41dcd4804b25e396970ba93f898835d2044cde4afc3d3fb4f727d48be5f6df7c",
+    "zh:41f8082aacd9cc6b3d0f3b9f9c9c8ce3337d3d55060c50e92a0ccc695047c494",
+    "zh:552daf0e06d5ab4f7ebc4fb4783d2f408ed9d077cd1ee051edcbeda5f5da65cf",
+    "zh:6de2ba0d713bdc02e13e261cc71cd083cdc7532135749e53595b7b709f668125",
+    "zh:6fdfdeabcdaa7f8edb7311f4edf50ba67904628117567957c17a3cc68a78b113",
+    "zh:753fab77e80f24f066e0a1f8c9a00f6a85c9e428f7c45c27ca91d6d8240f357c",
+    "zh:813905d3b03839fdc11218e3e384cb80e7de753549ed7857e32007a20fbca4c5",
+    "zh:8e75bf1b6b8e48be515c27248f7e70f9c833456b6bf6acd89613d7ef98d48e19",
+    "zh:e723909015b30d930a8ebf7242c463af332aa09b11c6892aedbe79e2f8b2647c",
+  ]
+}

--- a/infra/tofu/envs/gcp-landing/versions.tf
+++ b/infra/tofu/envs/gcp-landing/versions.tf
@@ -1,0 +1,20 @@
+# Provider pins for the `envs/gcp-landing` root.
+#
+# OpenTofu has no include mechanism for root modules: `required_providers` is
+# only read from the root it lives in. Every root under infra/tofu/ therefore
+# carries its own versions.tf. infra/tofu/shared/ is NOT included by anything —
+# see the note in infra/tofu/shared/versions.tf.
+#
+# google is held at 6.x to match environments/gcp-* (gcp-gke, gcp-ephemeral,
+# gcp-persistent). Before this file existed the root was unconstrained and
+# resolved whatever was newest that day — 7.42.0 as of 2026-07-29, a full major
+# above the intent recorded in shared/versions.tf.
+
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    google      = { source = "hashicorp/google", version = "~> 6.0" }
+    google-beta = { source = "hashicorp/google-beta", version = "~> 6.0" }
+  }
+}

--- a/infra/tofu/envs/local/.terraform.lock.hcl
+++ b/infra/tofu/envs/local/.terraform.lock.hcl
@@ -1,0 +1,77 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/local" {
+  version     = "2.9.0"
+  constraints = "~> 2.5"
+  hashes = [
+    "h1:dPIAf8oUAz+vW2E0iZunMvpuPddRZIztRsPSY1u+VnY=",
+    "h1:rxomJjDwOo+YZ+WIPc25FqEgsz9orh/2MCyUcZmFjvw=",
+    "h1:t0CMn/Rkwquw8l2yQ+O4ApzbMZfY2UazbsDnZygzACA=",
+    "zh:13ef7ecd1e397ec5b20ea588508dd3e3b8d6c50d809ae76b079abf9dd8d02e4b",
+    "zh:2190c9325980076489ce02b0f5dd2c0b91fc8711cefa99e714d8619a32827ad1",
+    "zh:2a0cfc5600730093705071707e4a4e4e953e7d9091859e0f66b46daa1060dd5d",
+    "zh:2ff53eac1af43ab9a2248a0e53c963d46e19cf04bc4c3f323591cfcebb218252",
+    "zh:4ebc3dee700f60af9da29970052fd02fa947813162b224716862dc9d7f1f7542",
+    "zh:5fe6dab84ceeaa8eb3f1567c5f05578333370c472240ca5c5bfc25e92d4d5586",
+    "zh:66bbec16367bbf440045502c9779b11f4ac5b022c8d8d17afe12d431950838b5",
+    "zh:7641e5c2e4b529e869cde29ab5b1de2fd1091489eb745b19ac2709bd7f4dfd84",
+    "zh:855bfba0756d17ce07595ff57d7cf664443d1495127cb88fb063362734b8b22a",
+    "zh:aaec10f237921d60c581d1b7a66f0a8a8019d9802dc04af11b5b981f6682e01d",
+    "zh:e460835a38ffa1e74f6929904bfd14ef473d217fd537b7ce834abe5ce5e2ce07",
+    "zh:ecc4295215db0e4aea3c9329611c31e09a853e1ae207d56742403bd4f5516703",
+    "zh:ee6d9fae63a612072e00402894e14826af7a3351c235b9c5b423b7629a77ca29",
+    "zh:f2b5c8db74aa7ebcf7cd423672358437d42401675069ef67b01ff910054e49d5",
+    "zh:f5aff74d3eb96d4592c7bca5cd3ea89b469e84efbf382944bd0f844a57059c09",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = "~> 3.2"
+  hashes = [
+    "h1:0r7+t8CqzjfBgHgEiJGBCw+McEUdRXliMdF+Hk29d8o=",
+    "h1:eODLdk/pARc4yxChAFtwseVmBr+r5fF9yGOvUhwGEyM=",
+    "h1:mdu+qpyVmjDDLMrcL1JFy+cSyF58I3TFJwB5NssCZ58=",
+    "zh:083dcc0bec53f8abfa3f2aa2ce9d732a9675338fd60ae7d61162e25db7cb08bf",
+    "zh:19f7456b5a2ad16595860974714bfdb25b87bc16356ea9d5c7453892aaa27864",
+    "zh:222c0ed1fed4e4c677ebe626104dbfdba66763e264de0d9c27c58ce60104ee69",
+    "zh:271711d6caa7dd5a4e9b79fe8c679fab61a840bcf80040a0f5ebb425d1b27d97",
+    "zh:5adcf35f30baaea13f80c2a2c774deb9369892719493049687e23476c9dff40f",
+    "zh:5bcfd19df16e73d7f0ad75bd09e2b3b86cf6700d09822d585d68304b71de1d97",
+    "zh:604edecf263e38674decb35bb4e0e048fdc951f26fa103c33065ff9728f0313b",
+    "zh:782acbfb4fa4807e273e588fe45b4aaea9dd0fd1136f76ec3200f6f4db3af8d6",
+    "zh:84411a596d528fe67294e5c1cfd0c2036b08802497bcc4215ce518924f3c9a4a",
+    "zh:85e79eecf3f5348975cffec3016b0eba3baf605646102d4348796ccd2df2e5f6",
+    "zh:95669535ca17aeefef307ebfd59ce6930953173baae5637e8cbbf0297ec7ad58",
+    "zh:d04d9b177747bfd66b4a45b5d911a2a7822aa8451f5e35621971fb7a4206b530",
+    "zh:e6d9c924475283e90833450a14a732f4deb6d9bb131db8f86ab856e894270836",
+    "zh:ebcab0c8a1334c86ed7cfa53f571a17ad6d27e9901f27a8854ea622a74b54bb6",
+    "zh:ef9c757bb2c83d2103811a3d86b6ec5be06b0ffc337b84db1582d023bce7cdcd",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:8EQU5KSxezcjo/phRSe69rDOI0lk4pSaggj7FsskYp8=",
+    "h1:U8KXqGCoNI9/guYbTvzgdtVk3fRthoG0UXwm1JoEpIs=",
+    "h1:j3lS+ZEERFnoab8t1ppDrScGVP/cgWbzlCrEYKTCXYw=",
+    "zh:03f1114cc20b8913523735ab76e0f0a2b16ce13c92923a53304bf85f07fc0dbc",
+    "zh:105b678ee72322a3067f105d7e05e940f6143238f377f6e87ff4ec909246ac2a",
+    "zh:55f3bbf13ea18cbace61a706566a80f25f33fe2b1780b6f3d7b582af2a05b6d2",
+    "zh:63adf996db48f082f7a6351eb485e219cd88795fc71e6ec60a837263ab0d2cb1",
+    "zh:7e99550738a4e3cc68b8a467714b0d69371025fe95e3326d5323d026d55653e9",
+    "zh:8342b54af3a18a37e075eeae61be57f4de2ba71b35d95c5075d402dd2c1f289d",
+    "zh:83ee18e32ac9dd5fc91298554b7c4cfa4c3a1db50f4c797945637cc93c0844ae",
+    "zh:993ecc0adbf6bd535a59fbc9b735d8c33950e6f6eb5e621d750da9b71d65d80a",
+    "zh:ad722bc59d4edbf1415e827fc007c0efe6e0e9462d5568bae20b34be1058a261",
+    "zh:ae9448e1f87b2f9a6c5197a0e9862162ec6b137cb3a3835e11522995d8939e7c",
+    "zh:bc9cdd3aac784f759125c6627f6f6416e8726a1c184eb9cf3e55b9edbc94c627",
+    "zh:c8e35b89572ba1c40a9b20022e033a3395fb8d42e7604d50c900f193ba10382e",
+    "zh:e2deaa8a9975ef81d9f62baed12c41286918b0a10908e0e031f13f69a3b730a1",
+    "zh:ee39707557210a0ab1098aa357d2cdfe502e5a312d0dbdffb09d08facc4d3fc5",
+    "zh:f81afe4eb63e8aa9e0ea71be6c990f0dc69cb360e7191c0742a991f4a5081b64",
+  ]
+}

--- a/infra/tofu/envs/local/versions.tf
+++ b/infra/tofu/envs/local/versions.tf
@@ -1,0 +1,20 @@
+# Provider pins for the `envs/local` root.
+#
+# OpenTofu has no include mechanism for root modules: `required_providers` is
+# only read from the root it lives in. Every root under infra/tofu/ therefore
+# carries its own versions.tf. infra/tofu/shared/ is NOT included by anything —
+# see the note in infra/tofu/shared/versions.tf.
+#
+# This env is deliberately cloud-free (k3d only). Do not add google/aws/azurerm
+# here: a required_providers entry is installed and locked even when no resource
+# uses it, so listing a cloud provider would make the local dev loop depend on it.
+
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    local  = { source = "hashicorp/local", version = "~> 2.5" }
+    null   = { source = "hashicorp/null", version = "~> 3.2" }
+    random = { source = "hashicorp/random", version = "~> 3.6" }
+  }
+}

--- a/infra/tofu/envs/prod/.terraform.lock.hcl
+++ b/infra/tofu/envs/prod/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "h1:O5jnIJXJcM6QWNYDPJAeR/yD01GfvrX4q4X6yLg9Afg=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:+hUxBwXLP3XadzrFEtVYM7qZ/0wChqJHQbtacAWw76s=",
+    "h1:MklYYZlCefCzM5jrAUYHdY+4nOsyCDIvygcL1u79e94=",
+    "h1:t5b8qSJkvi4QALUqqDf17y9e7OBXd1liUyOebVst0YM=",
+    "zh:29d310cfbc3ff8c5c7b3c18d713ced4b4fa66efaffeefc948702771f3723b90d",
+    "zh:41dcd4804b25e396970ba93f898835d2044cde4afc3d3fb4f727d48be5f6df7c",
+    "zh:41f8082aacd9cc6b3d0f3b9f9c9c8ce3337d3d55060c50e92a0ccc695047c494",
+    "zh:552daf0e06d5ab4f7ebc4fb4783d2f408ed9d077cd1ee051edcbeda5f5da65cf",
+    "zh:6de2ba0d713bdc02e13e261cc71cd083cdc7532135749e53595b7b709f668125",
+    "zh:6fdfdeabcdaa7f8edb7311f4edf50ba67904628117567957c17a3cc68a78b113",
+    "zh:753fab77e80f24f066e0a1f8c9a00f6a85c9e428f7c45c27ca91d6d8240f357c",
+    "zh:813905d3b03839fdc11218e3e384cb80e7de753549ed7857e32007a20fbca4c5",
+    "zh:8e75bf1b6b8e48be515c27248f7e70f9c833456b6bf6acd89613d7ef98d48e19",
+    "zh:e723909015b30d930a8ebf7242c463af332aa09b11c6892aedbe79e2f8b2647c",
+  ]
+}

--- a/infra/tofu/envs/prod/versions.tf
+++ b/infra/tofu/envs/prod/versions.tf
@@ -1,0 +1,21 @@
+# Provider pins for the `envs/prod` root.
+#
+# OpenTofu has no include mechanism for root modules: `required_providers` is
+# only read from the root it lives in. Every root under infra/tofu/ therefore
+# carries its own versions.tf. infra/tofu/shared/ is NOT included by anything —
+# see the note in infra/tofu/shared/versions.tf.
+#
+# google is held at 6.x to match environments/gcp-* (gcp-gke, gcp-ephemeral,
+# gcp-persistent). Before this file existed the root was unconstrained and
+# resolved whatever was newest that day — 7.42.0 as of 2026-07-29, a full major
+# above the intent recorded in shared/versions.tf. This is the production root;
+# floating across provider majors here was the sharpest edge of that gap.
+
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    google      = { source = "hashicorp/google", version = "~> 6.0" }
+    google-beta = { source = "hashicorp/google-beta", version = "~> 6.0" }
+  }
+}

--- a/infra/tofu/envs/shared/.terraform.lock.hcl
+++ b/infra/tofu/envs/shared/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "h1:O5jnIJXJcM6QWNYDPJAeR/yD01GfvrX4q4X6yLg9Afg=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:+hUxBwXLP3XadzrFEtVYM7qZ/0wChqJHQbtacAWw76s=",
+    "h1:MklYYZlCefCzM5jrAUYHdY+4nOsyCDIvygcL1u79e94=",
+    "h1:t5b8qSJkvi4QALUqqDf17y9e7OBXd1liUyOebVst0YM=",
+    "zh:29d310cfbc3ff8c5c7b3c18d713ced4b4fa66efaffeefc948702771f3723b90d",
+    "zh:41dcd4804b25e396970ba93f898835d2044cde4afc3d3fb4f727d48be5f6df7c",
+    "zh:41f8082aacd9cc6b3d0f3b9f9c9c8ce3337d3d55060c50e92a0ccc695047c494",
+    "zh:552daf0e06d5ab4f7ebc4fb4783d2f408ed9d077cd1ee051edcbeda5f5da65cf",
+    "zh:6de2ba0d713bdc02e13e261cc71cd083cdc7532135749e53595b7b709f668125",
+    "zh:6fdfdeabcdaa7f8edb7311f4edf50ba67904628117567957c17a3cc68a78b113",
+    "zh:753fab77e80f24f066e0a1f8c9a00f6a85c9e428f7c45c27ca91d6d8240f357c",
+    "zh:813905d3b03839fdc11218e3e384cb80e7de753549ed7857e32007a20fbca4c5",
+    "zh:8e75bf1b6b8e48be515c27248f7e70f9c833456b6bf6acd89613d7ef98d48e19",
+    "zh:e723909015b30d930a8ebf7242c463af332aa09b11c6892aedbe79e2f8b2647c",
+  ]
+}

--- a/infra/tofu/envs/shared/versions.tf
+++ b/infra/tofu/envs/shared/versions.tf
@@ -1,0 +1,21 @@
+# Provider pins for the `envs/shared` root.
+#
+# OpenTofu has no include mechanism for root modules: `required_providers` is
+# only read from the root it lives in. Every root under infra/tofu/ therefore
+# carries its own versions.tf. infra/tofu/shared/ is NOT included by anything —
+# see the note in infra/tofu/shared/versions.tf. (That directory and this env
+# share a name and nothing else.)
+#
+# google is held at 6.x to match environments/gcp-* (gcp-gke, gcp-ephemeral,
+# gcp-persistent). Before this file existed the root was unconstrained and
+# resolved whatever was newest that day — 7.42.0 as of 2026-07-29, a full major
+# above the intent recorded in shared/versions.tf.
+
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    google      = { source = "hashicorp/google", version = "~> 6.0" }
+    google-beta = { source = "hashicorp/google-beta", version = "~> 6.0" }
+  }
+}

--- a/infra/tofu/shared/versions.tf
+++ b/infra/tofu/shared/versions.tf
@@ -1,20 +1,30 @@
+# infra/tofu/shared/ is NOT a shared include. OpenTofu has no include mechanism
+# for root modules — a `terraform { required_providers }` block is only read from
+# the root directory `tofu init` is run in. This directory is a sibling root that
+# declares no backend and no resources; the envs reference ../../modules/*, never
+# this path. Nothing here reaches any env.
+#
+# This file used to pin google/google-beta at ~> 6.0 with the comment "used only
+# in envs/gcp-* and modules that explicitly declare provider". That was false in
+# both directions: no env loaded this file, and no env pinned anything, so
+# envs/{gcp-landing,shared,prod} resolved google 7.42.0 — one major above the
+# intent stated right here. The pins now live where they are actually read:
+#
+#   infra/tofu/envs/local/versions.tf
+#   infra/tofu/envs/gcp-landing/versions.tf
+#   infra/tofu/envs/shared/versions.tf
+#   infra/tofu/envs/prod/versions.tf
+#   infra/tofu/environments/*/versions.tf   (already pinned)
+#   infra/tofu/bootstrap/*/main.tf          (already pinned)
+#
+# No required_providers block below: labels.tf is a locals-only fragment and this
+# root uses no provider. Declaring providers here installed and locked six of them
+# for a configuration with zero resources — a required_providers entry is fetched
+# even when nothing references it.
+#
+# If this directory ever gains resources, add the providers it actually uses.
+# Do not restore an estate-wide pin list here; it cannot constrain anything else.
+
 terraform {
   required_version = ">= 1.8.0"
-
-  required_providers {
-    # GCP — used only in envs/gcp-* and modules that explicitly declare provider
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 6.0"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 6.0"
-    }
-    # Provider-agnostic
-    local  = { source = "hashicorp/local", version = "~> 2.5" }
-    null   = { source = "hashicorp/null", version = "~> 3.2" }
-    random = { source = "hashicorp/random", version = "~> 3.6" }
-    tls    = { source = "hashicorp/tls", version = "~> 4.0" }
-  }
 }


### PR DESCRIPTION
## The gap

`infra/tofu/shared/versions.tf` pinned google/google-beta at `~> 6.0` and described them as *"used only in envs/gcp-* and modules that explicitly declare provider"*.

Both halves were false. OpenTofu has no include mechanism for root modules — `required_providers` is read only from the directory `tofu init` runs in. `infra/tofu/shared/` is a **sibling root** with no backend and no resources; the envs reference `../../modules/*` and never that path. So the file was never loaded by any env, and none of `envs/{local,gcp-landing,shared,prod}` declared providers of its own.

A version constraint that constrains nothing, documented as constraining something.

Measured with **OpenTofu 1.8.3** (the `TOFU_VERSION` in `tofu-plan.yml`), clean init, no plugin cache:

| root | before | after |
|---|---|---|
| `envs/local` | `local`/`null`/`random` **unconstrained** | `~> 2.5` / `~> 3.2` / `~> 3.6` → 2.9.0 / 3.3.0 / 3.9.0 |
| `envs/gcp-landing` | no `required_providers` | google + google-beta `~> 6.0` → **6.50.0** |
| `envs/shared` | google + google-beta **7.42.0** (unconstrained) | google + google-beta `~> 6.0` → **6.50.0** |
| `envs/prod` | google + google-beta **7.42.0** (unconstrained) | google + google-beta `~> 6.0` → **6.50.0** |
| `shared/` | 6 providers installed for **zero resources** | 0 providers |

`envs/prod` — the production root — was resolving a full major above the intent written in `shared/versions.tf`. And with `.terraform.lock.hcl` gitignored, every CI run re-resolved from the registry: a green `tofu validate` guaranteed nothing about the next run.

## Strategy: `required_providers` per env root

Not a shared file. OpenTofu offers no native include, and every "shared" alternative is worse:

- **Symlinked / duplicated `versions.tf`** forces every root to carry the *union* of providers. A `required_providers` entry is installed and locked **even when nothing references it** — verified directly: a config whose only resource is `random_password` still downloaded and locked google 6.50.0 when google was listed. `envs/local` is documented as *"No cloud provider required"*; a shared file would have made the local k3d dev loop depend on the google provider.
- Symlinks add a Windows-checkout failure mode for zero benefit.

Per-root files also match what `environments/*/versions.tf` and `bootstrap/*/main.tf` **already do**, so this makes `envs/*` consistent with the rest of the tree rather than introducing a second pattern. And the pins are self-enforcing — OpenTofu fails init if they're violated — so no drift-guard job is needed to give them teeth.

6.x matches `environments/gcp-{gke,ephemeral,persistent}`, which were already pinned there.

`shared/versions.tf` keeps `required_version` and **drops** `required_providers`: that root has no resources. The comment now states what the directory is and is not, and points at the files carrying the real pins.

## Lock files: stop gitignoring them

**Recommendation taken: commit them.** The pins bound a *range*; the lock is what makes resolution reproducible, and it carries registry checksums so `init` verifies what it downloads.

Tradeoff:
- **Cost** — churn on every intentional provider bump (`tofu providers lock` must be re-run), and PR conflicts when two branches bump the same provider. Multi-arch entries are required or `init` fails on the platform you forgot.
- **Mitigation** — locks generated with **OpenTofu 1.8.3** via `tofu providers lock -platform=linux_amd64 -platform=darwin_arm64 -platform=darwin_amd64`, covering CI and both Mac architectures. They are 2–4 KB each. Re-running `init` against them produced **no diff**, so they are stable, not churning.
- Regeneration command is recorded in `infra/tofu/.gitignore` next to the un-ignore, so the next person doesn't have to rediscover it.

Locks are committed for the **4 `envs/*` roots only** — the ones CI validates, where the guarantee is load-bearing. `environments/*` and `bootstrap/*` are deliberately left unlocked in this PR (CI never touches them, and two of those paths belong to other lanes).

## Behaviour change from the major-version move: none observed at `validate`

The 7.42.0 → 6.50.0 move produced **no change in validate output**. Every root clean at 7.42.0 is clean at 6.50.0 — no new errors, no new warnings. `envs/gcp-landing` was checked at **both** majors explicitly (`~> 7.0` and `~> 6.0`) and is clean at both.

**Unmeasured:** `tofu plan` was not run — it needs GCP credentials. Schema-level compatibility is confirmed; apply-time differences between google 6.x and 7.x (changed defaults, new required fields) are **not** covered by this evidence.

**Also unverified: CI itself.** GitHub Actions is at a spend cap (456 queued, 0 running), so no workflow ran for this branch. Everything above is local, with `.terraform` removed and no plugin cache, replicating the CI command sequence — but it is not a CI result.

## Caveat on the `gcp-landing` measurement

`envs/gcp-landing` **cannot `tofu init` on `main` at all** — `main.tf:215` has invalid HCL (`threshold_rules { threshold_percent = 0.8  spend_basis = ... }`, a single-line block with two arguments). That is the bug #1103 fixes. Its post-pin numbers above were therefore measured with #1103's `gcp-landing` hunk applied locally; that hunk is **not** part of this PR. The lock file is unaffected — it is a function of `required_providers`, and the resource bodies introduce no additional providers.

## Unvalidated-root survey (requested; not fixed here)

`tofu-plan.yml` validates **4 of 14** configuration roots. Here is what the other 10 do today under OpenTofu 1.8.3, clean init:

| root | providers resolved | init | validate | note |
|---|---|---|---|---|
| `bootstrap/aws` | aws 5.100.0 (`~> 5.0`) | ok | ok **w/ warning** | `aws_s3_bucket_lifecycle_configuration.tofu_state` has no `filter`/`prefix` — *"will be an error in a future version of the provider"* |
| `bootstrap/azure` | azurerm 3.117.1 (`~> 3.0`) | ok | ok | azurerm **3.x** while `environments/azure-aks` pins `~> 4.0` |
| `bootstrap/gcp` | google 5.45.2 (`~> 5.0`) | ok | ok | google **5.x** — third GCP major in the estate |
| `environments/aws-eks` | aws 5.100.0 + tls/time/null/cloudinit/helm/kubernetes | ok | ok | transitive providers from `terraform-aws-modules/{vpc,eks}` carry **minimum-only** constraints (`>= 3.0.0` etc.) and still float |
| `environments/azure-aks` | azurerm 4.81.0 | ok | ok | |
| `environments/gcp-ephemeral` | google 6.50.0 | ok | ok | |
| `environments/gcp-gke` | google + google-beta 6.50.0 | ok | ok | |
| `environments/gcp-persistent` | google 6.50.0 | ok | ok | |
| `environments/ibm-iks` | — | **FAILS** | — | resolves implicit `hashicorp/ibm`, which does not exist. Fixed by #1103's `modules/ibm-trusted-profile` `required_providers`. Untouched here — another lane owns it. |
| `shared/` | **0** (was 6) | ok | ok | changed by this PR |

Two findings worth their own tickets:

1. **The estate spans three GCP provider majors** — `bootstrap/gcp` at 5.x, `environments/gcp-*` and now `envs/*` at 6.x. Deliberate or not, nothing records which.
2. **`shared/` and `envs/shared` share a name and nothing else.** CI's step is literally labelled `validate — shared` and validates `envs/shared`. Anyone reading the workflow would reasonably conclude `infra/tofu/shared/` was covered. It never was. That naming collision is plausibly why the false comment survived.

Also: `bootstrap/*` set no `required_version`, unlike every other root.

## Recommendation for the `tofu-plan.yml` lane (#1097 — not edited here)

Widen `fmt-and-validate` to all 14 roots, or at minimum add `bootstrap/*` and `environments/gcp-*`. A matrix over root directories would replace the four hand-written steps and stop new roots from landing unvalidated. `environments/ibm-iks` will need #1103 first.

Note `tofu fmt -check -recursive infra/tofu/` **currently fails on `main`** for three files — all owned by #1103 (`environments/aws-eks/main.tf`, `modules/github-oidc-aws/main.tf`, `modules/ibm-trusted-profile/variables.tf`). Everything this PR touches is fmt-clean.

## Lane hygiene

Rebased on `origin/main` @ 55a3d086. `git merge-tree` against **#1103** and **#1097** is clean with **zero overlapping files**. Stayed out of `environments/ibm-iks` and `modules/ibm-trusted-profile` entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
