### PR TITLE
fix(health-twin): the constant-time compare owed a decoy it never had

### DIFF
--- a/apps/health-twin/src/exposure.test.ts
+++ b/apps/health-twin/src/exposure.test.ts
@@ -65,3 +65,37 @@ test('an unset token fails closed with 503, not open', () => {
     503,
   );
 });
+
+/**
+ * The constant-time compare, pinned at the boundary its docstring talks about.
+ *
+ * The first cut of `timingSafeEquals` branched on a length mismatch and ran
+ * `timingSafeEqual(ab, ab)` — the presented value against ITSELF — while claiming in its
+ * docstring to compare against a "same-length decoy". The compare is now done on SHA-256
+ * digests, which are always 32 bytes, so the mismatch branch is gone entirely.
+ *
+ * These pin the observable half of that: a wrong credential is a 401 at ANY length, never
+ * an exception. The distinction matters because the natural "simplification" of this
+ * function — handing the two raw buffers straight to `timingSafeEqual` — throws
+ * ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH on mismatched lengths, which server.ts would surface
+ * as a 500. A crash is not a refusal.
+ */
+test('a credential of the wrong length is refused, never thrown', () => {
+  assert.equal(exposureDenial(authed('Bearer s3'))?.code, 401);
+  assert.equal(exposureDenial(authed('Bearer s3cretttttttttt'))?.code, 401);
+  assert.equal(exposureDenial(authed(`Bearer ${'x'.repeat(4096)}`))?.code, 401);
+  assert.equal(exposureDenial({ ...authed('Bearer x'), token: 'y'.repeat(512) })?.code, 401);
+});
+
+test('a wrong credential of exactly the right length is refused', () => {
+  // 's3cres' is the same six bytes as 's3cret' with one byte changed, so this takes the
+  // equal-length path and must still refuse.
+  assert.equal(exposureDenial(authed('Bearer s3cres'))?.code, 401);
+});
+
+test('multibyte credentials are compared by content, not collapsed by length', () => {
+  // 'é' is two bytes in UTF-8, the same as 'aa': equal byte length, different content.
+  assert.equal(exposureDenial({ ...authed('Bearer é'), token: 'aa' })?.code, 401);
+  // And a correct multibyte secret still authenticates.
+  assert.equal(exposureDenial({ ...authed('Bearer sécret'), token: 'sécret' }), null);
+});

--- a/apps/health-twin/src/exposure.ts
+++ b/apps/health-twin/src/exposure.ts
@@ -18,21 +18,37 @@
 // Pure and parameterised so it is testable without standing up a server; server.ts binds a
 // port at import time, which would otherwise make the gate provable only by running it.
 
-import { timingSafeEqual } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 
 export type Exposure = 'synthetic-only' | 'authenticated';
 
-/** Constant-time string compare. timingSafeEqual throws on a length mismatch, which would
- *  itself leak the length, so unequal lengths are compared against a same-length decoy and
- *  always answer false. */
+/** Constant-time compare whose control flow does not depend on either value's length.
+ *
+ *  `timingSafeEqual` throws on a length mismatch, so something has to handle unequal lengths
+ *  before calling it. The first version of this function guarded that with an early branch —
+ *  correct and necessary — but inside the branch it called `timingSafeEqual(ab, ab)`, the
+ *  presented value against ITSELF, and its docstring described that as comparing "against a
+ *  same-length decoy". It was not a decoy. It compared the attacker's own input to itself,
+ *  discarded the result, and returned false; deleting the line would have changed nothing.
+ *
+ *  The practical leak was negligible: the work is proportional to the presented value in both
+ *  branches, and the attacker already knows how long their own guess is. The defect is that a
+ *  security primitive's comment asserted a mechanism the code did not implement — and comments
+ *  on auth primitives are load-bearing, because the next reader audits the claim rather than
+ *  re-deriving the bytes.
+ *
+ *  Digesting both sides first removes the problem instead of restating it. SHA-256 output is
+ *  always 32 bytes, so the lengths can never differ: there is no throw to dodge, no branch to
+ *  balance, and no decoy to owe anyone. Nothing observable depends on the secret's length or
+ *  its contents. Total work still scales with the PRESENTED value's length, which is the
+ *  attacker's own input — that is unavoidable (it must be read) and discloses nothing.
+ *
+ *  A plain digest rather than an HMAC: the digests are computed and compared inside this
+ *  function and never escape it, so a keyed hash would buy nothing here. */
 function timingSafeEquals(a: string, b: string): boolean {
-  const ab = Buffer.from(a, 'utf8');
-  const bb = Buffer.from(b, 'utf8');
-  if (ab.length !== bb.length) {
-    timingSafeEqual(ab, ab);
-    return false;
-  }
-  return timingSafeEqual(ab, bb);
+  const ad = createHash('sha256').update(a, 'utf8').digest();
+  const bd = createHash('sha256').update(b, 'utf8').digest();
+  return timingSafeEqual(ad, bd);
 }
 
 export interface ExposureDenial {


### PR DESCRIPTION
Stacked on #1086 — **base is `fix/copilot-auth-primitives`, not `main`.** The code this fixes does not exist on `main`; #1086 introduces it. Merge #1086 first, or fold this in.

## The defect

`apps/health-twin/src/exposure.ts` — `timingSafeEquals` documented itself as comparing unequal-length inputs *"against a same-length decoy"*:

```ts
if (ab.length !== bb.length) {
  timingSafeEqual(ab, ab);   // <- the "decoy" is the input itself
  return false;
}
```

`ab` is the presented value. Comparing it to itself always returns true, the result is discarded, and the function returns false. **Deleting that line would have changed nothing.**

The exploitable leak is negligible, and I want to be plain about that rather than dress this up as a vulnerability: the work is proportional to the attacker's own guess in both branches, and they already know how long their guess is. The secret's length never steered anything.

The defect is that **a security primitive asserted a mechanism its code did not implement**. On an auth path the comment is the audit surface — the next reader checks the claim rather than re-deriving the bytes — so a false claim is a defect whether or not it is currently reachable. That is the [declared-unenforced](https://github.com/SocioProphet/prophet-platform) pattern, one line of it.

## The decision: fixed the code, not the comment

The brief allowed either. I fixed the code, because downgrading the comment to *"the dummy compare keeps both paths doing similar work; the secret's length is not concealed"* would be honest but would leave a vacuous self-compare sitting in an auth primitive for the next reader to misread a second time.

Both sides are digested first:

```ts
function timingSafeEquals(a: string, b: string): boolean {
  const ad = createHash('sha256').update(a, 'utf8').digest();
  const bd = createHash('sha256').update(b, 'utf8').digest();
  return timingSafeEqual(ad, bd);
}
```

SHA-256 output is always 32 bytes, so the lengths **can never differ**. That deletes the mismatch branch rather than explaining it, and makes the function's name true for arbitrary-length inputs — which is what every caller already assumes. The docstring now states the property that actually holds, including its residual: total work still scales with the *presented* value's length, which is the attacker's own input and discloses nothing.

Plain digest rather than HMAC: the digests are computed and compared inside the function and never escape it, so a keyed hash buys nothing here.

## One nuance worth recording

The length **branch** was load-bearing — it prevented the throw. Only the self-compare inside it was vacuous. The natural "simplification" to a bare `timingSafeEqual(ab, bb)` raises `ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH` on mismatched lengths, which `server.ts` would surface as a **500 instead of a 401**. A crash is not a refusal.

Three tests pin that boundary. Verified they have teeth **both ways** — reverting to the naive bare-buffer form reddens the new length test *and* #1086's existing `the wrong credential is still refused` (which happens to compare `wrong` against `s3cret`, different lengths):

```
✖ the wrong credential is still refused          code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH'
✖ a credential of the wrong length is refused, never thrown
ℹ pass 14  ℹ fail 2
```

## Evidence

Local only — Actions is spend-capped. `apps/health-twin` → `npm test`:

```
ℹ tests 16   ℹ pass 16   ℹ fail 0
```

Scope: **`exposure.ts` and `exposure.test.ts` only.** No change to `server.ts`, `grantauth.ts`, `gate.ts`, `predict.ts`, `deident.ts` or `invariants.ts` — those lanes are live. Rebased on `origin/fix/copilot-auth-primitives` immediately before pushing; no drift, no conflicts.

Found in the suppressed Copilot channel on #1086.