### PR TITLE
observability: Alertmanager's only receiver was named "null"

### DIFF
--- a/deploy/argocd/alert-delivery.yaml
+++ b/deploy/argocd/alert-delivery.yaml
@@ -1,0 +1,41 @@
+# The estate's terminal alert receiver. Until this landed, Alertmanager's only
+# receiver was named "null" and every alert in the estate was discarded on
+# delivery while reporting success.
+#
+# Lives in deploy/argocd/, NOT infra/argocd/. The tofu-created root app-of-apps
+# (infra/tofu/environments/gcp-gke/argocd.tf) watches `deploy/argocd` with
+# directory.recurse — nothing under infra/argocd/ has ever reached the cluster.
+# An Application authored there deploys nothing, which for the component that
+# makes alerting real would be the same defect one layer up. Same move and same
+# reason as deploy/argocd/pvc-capacity-guard.yaml.
+#
+# sync-wave "1": after the kube-prometheus-stack CRDs (wave -3) so the
+# ServiceMonitor / PrometheusRule / AlertmanagerConfig kinds exist.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: alert-delivery
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: platform-ops
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    # Required by tools/preflight_deploy_contract.py check 5. reference: a
+    # replaceable implementation of alert delivery running a digest-pinned stock
+    # python image, not part of the interoperability spine and not built by
+    # images.yml.
+    socioprophet.io/tier: "reference"
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: observability
+  source:
+    repoURL: https://github.com/SocioProphet/prophet-platform
+    targetRevision: main
+    path: infra/k8s/alert-delivery/base
+  syncPolicy:
+    automated: { prune: true, selfHeal: true }
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/deploy/argocd/observability-services.yaml
+++ b/deploy/argocd/observability-services.yaml
@@ -82,11 +82,59 @@ spec:
           resources:
             requests: { cpu: 50m, memory: 128Mi }
             limits: { cpu: 500m, memory: 256Mi }
-        # ── Alertmanager: KEPT minimal — one replica, idle footprint. It only
-        # routes the corpus's SLO alerts; no receivers are configured yet, so it
-        # gets a floor-sized budget until a paging integration earns it more.
+        # ── Alertmanager: one replica, idle footprint.
+        #
+        # It used to have exactly one receiver, named "null". Every alert in the
+        # estate — including the ones that fire on data loss — was routed to a
+        # receiver that discards, and nothing reported a problem, because from
+        # inside Alertmanager "delivered to null" and "delivered" are the same
+        # code path. The whole alerting corpus was decorative.
+        #
+        # The default route now terminates at the in-cluster alert-sink
+        # (infra/k8s/alert-delivery), which turns each notification into an
+        # EvidenceReceipt on stdout -> fluentbit-gke -> Cloud Logging. That is
+        # deliberately a destination that needs NO credential and NO external
+        # endpoint. Human paging (email/Slack/PagerDuty) is a separate decision
+        # because it needs a secret — see infra/k8s/alert-delivery/README.md.
         alertmanager:
           enabled: true
+          config:
+            global:
+              resolve_timeout: 5m
+            route:
+              group_by: ["namespace", "alertname"]
+              group_wait: 30s
+              group_interval: 5m
+              repeat_interval: 12h
+              receiver: alert-sink
+              routes:
+                # Watchdog fires permanently by design — it is the corpus's
+                # dead-man's switch. Routing it here with a 1h repeat gives the
+                # sink a heartbeat forever, which is what makes AlertDeliveryDead
+                # a real control instead of an assumption: if the counter stops
+                # rising, delivery is broken and we are told.
+                - receiver: alert-sink
+                  matchers: ['alertname = "Watchdog"']
+                  group_wait: 0s
+                  repeat_interval: 1h
+            receivers:
+              - name: alert-sink
+                webhook_configs:
+                  - url: http://alert-sink.observability.svc:9095/alerts
+                    send_resolved: true
+                    # 0 = never truncate. A truncated notification would drop
+                    # alerts silently, which is the defect being fixed.
+                    max_alerts: 0
+            inhibit_rules:
+              - source_matchers: ["severity = critical"]
+                target_matchers: ["severity =~ warning|info"]
+                equal: ["namespace", "alertname"]
+              - source_matchers: ["severity = warning"]
+                target_matchers: ["severity = info"]
+                equal: ["namespace", "alertname"]
+              - source_matchers: ['alertname = "InfoInhibitor"']
+                target_matchers: ["severity = info"]
+                equal: ["namespace"]
           alertmanagerSpec:
             replicas: 1
             resources:

--- a/infra/k8s/alert-delivery/README.md
+++ b/infra/k8s/alert-delivery/README.md
@@ -1,0 +1,158 @@
+# alert-delivery — the estate's terminal receiver
+
+## What was wrong
+
+Alertmanager had exactly one receiver. It was named `null`.
+
+```yaml
+route:
+  receiver: "null"
+receivers:
+  - name: "null"
+```
+
+Every alert in this estate — SLO breaches, `KubeJobFailed`, the PVC guard's
+data-loss warnings — was routed to a receiver that discards. Nothing reported a
+problem, because from inside Alertmanager "delivered to null" and "delivered"
+are the same code path. `alertmanager_notifications_total` rose. Dashboards were
+green. The whole alerting corpus was decorative.
+
+At the moment this was found, Alertmanager was holding **20 firing alerts** that
+no human had ever seen, including four `KubeJobFailed` and a `KubeletDown`.
+
+## What this is
+
+A ~250-line stdlib-Python webhook receiver. Alertmanager POSTs notifications to
+it; it turns each alert into an **EvidenceReceipt** (`contracts/EvidenceReceipt.v0.1.json`)
+written as one JSON line to stdout.
+
+Deliberately a destination that needs **no credential and no external endpoint**,
+so it could be wired tonight without provisioning anything. Human paging is a
+separate decision — see *Choosing a human destination* below.
+
+## Where the logs go, and who reads them
+
+| Stream | Lands in | Read by |
+|---|---|---|
+| Receipts + access + lifecycle (stdout, JSON lines) | `fluentbit-gke` → **Google Cloud Logging** | `gcloud logging read 'resource.labels.container_name="sink"'`; Log Explorer |
+| Prometheus counters (`/metrics`) | in-cluster Prometheus via ServiceMonitor | `AlertDeliveryDead`, `AlertSinkDown`, `AlertSinkRejecting` |
+| Last 50 deliveries (`/recent`) | process memory, fixed ring | ad-hoc `kubectl exec` during triage |
+
+**Loki is not in that table on purpose.** It is deployed in `observability`, it
+is `Running`, it holds a 10Gi PVC — and it has **zero ingested bytes and zero
+label values**. Nothing has ever shipped a log line to it. It is another
+instance of tonight's defect: a component that runs, reports healthy, and does
+nothing. Do not build a logging story on it until something actually writes to
+it. Cloud Logging is the estate's only working log sink today.
+
+## Why it cannot silently stop working
+
+A receiver that quietly dies looks exactly like a quiet night. So delivery is
+proved continuously rather than assumed:
+
+`kube-prometheus-stack` ships a **`Watchdog`** alert that fires permanently by
+design — a dead-man's switch. It is routed here with `repeat_interval: 1h`, so
+this process receives a heartbeat every hour, forever.
+`alert_sink_notifications_total` must therefore always be rising. If it stops,
+**`AlertDeliveryDead`** fires.
+
+That inverts the failure mode: silence is no longer "nothing is wrong", silence
+is itself the alarm.
+
+Refusals are equally loud. A malformed payload increments
+`alert_sink_errors_total`, emits a receipt with `status: "failed"`, and returns
+400 — it is never absorbed. `AlertSinkRejecting` fires on any refusal.
+
+## Bounds
+
+| Bound | Value | Why |
+|---|---|---|
+| `MAX_BODY_BYTES` | 2 MiB | Caps a single notification. Over-size → 413 + a `denied` receipt. |
+| `RECENT_RING` | 50 | Fixed-size ring. The process keeps no unbounded history. |
+| `max_alerts` | 0 (never truncate) | Truncating a notification would drop alerts silently — the defect being fixed. |
+| Durability | none, by design | Persistence is Cloud Logging's job. This process holds nothing that matters. |
+
+## The two mechanisms, and why both
+
+1. **`deploy/argocd/observability-services.yaml`** sets the Alertmanager
+   **default route** to this sink. Estate-wide, all namespaces. Takes effect
+   when that Argo app syncs the merged chart values.
+2. **`alertmanagerconfig.yaml`** — an `AlertmanagerConfig` CR the operator merges
+   in as a sub-route. The operator scopes it to its own namespace
+   (`matcherStrategy: OnNamespace`), so it covers `namespace=observability` only.
+
+(2) is a separate resource from the Helm release, so it takes effect without
+waiting on a chart sync — and every guard in this wave (`pvc-capacity-guard`,
+`rule-liveness-guard`, `alert-delivery`) fires in `observability`. The new
+controls therefore have a real receiver from the moment they are applied.
+
+(2) is **not** a substitute for (1): alerts in `socioprophet`, `scm`, `serving`
+and cluster-scoped alerts still need the default route.
+
+## Proof it fires
+
+Both directions were observed live, not asserted.
+
+```
+$ curl -XPOST localhost:9093/api/v2/alerts -d '[{"labels":{"alertname":"Wave1DeliveryProof",
+    "severity":"critical","namespace":"observability"}, ...}]'
+POST=200
+
+$ curl localhost:9093/api/v2/alerts | ...
+  Wave1DeliveryProof active receivers=[observability/alert-sink/alert-sink]
+```
+
+Receipts emitted by the sink, firing then resolved:
+
+```
+2026-07-30T05:29:44+00:00  evr-alert-delivered-ee132fdb...  accepted   alert_status=firing
+2026-07-30T05:34:44+00:00  evr-alert-delivered-ae71c3a8...  succeeded  alert_status=resolved
+```
+
+Counters moved 1 → 2 across the test. Both receipts validate against
+`contracts/EvidenceReceipt.v0.1.json` (required fields present, `status` within
+the enum, `version` matching the const).
+
+A malformed payload was also exercised: HTTP 400, `alert_sink_errors_total` 0 →
+1, and a `status: "failed"` receipt emitted rather than the error being
+swallowed.
+
+**The real findings from the `rule-liveness-guard` were then delivered through
+this same path** — nine `AlertRuleDead` / `AlertRuleDormant` alerts, receipted
+end to end. That run is what caught the inhibition bug described in that
+component's README.
+
+## Choosing a human destination — needs a decision
+
+Nothing here pages a person. That is deliberate: every human destination needs a
+credential or an external endpoint, which is a provisioning decision, not an
+implementation one. The options, with what each costs:
+
+| Destination | Needs | Notes |
+|---|---|---|
+| **Email via SMTP** | SMTP host + credential | The estate already runs `workspace-mail`/`workspace-smtp` in `socioprophet`. Cheapest path; in-estate, no third party. Recommended first step. |
+| **Slack** | Incoming-webhook URL (a secret) | Good ergonomics, external dependency. |
+| **PagerDuty / Opsgenie** | Integration key + a paid plan | Only worth it once someone is actually on call. |
+| **Google Chat** | Webhook URL | Already inside the Google tenancy. |
+
+Whichever is chosen, the secret must be **minted in CI**, never a personal token,
+and referenced from the Alertmanager config by `secretKeyRef`. Until then, the
+sink plus Cloud Logging is the record of what fired.
+
+## Runbook
+
+**`AlertDeliveryDead`** — no notification in 3h, so the Watchdog heartbeat has
+stopped.
+
+1. `kubectl get pods -n observability -l app=alert-sink` — is it up?
+2. `kubectl logs -n observability deploy/alert-sink --tail=50`
+3. Check the route did not regress:
+   `kubectl get secret -n observability alertmanager-kube-prometheus-stack-alertmanager-generated -o jsonpath='{.data.alertmanager\.yaml\.gz}' | base64 -d | gunzip | grep -A4 '^receivers:'`
+   If the only receiver is `"null"`, the Helm values or the AlertmanagerConfig
+   have been reverted.
+4. `kubectl get alertmanagerconfig -n observability alert-sink`
+
+**Known bound:** if the sink itself is down, the alert saying so cannot be
+delivered *to the sink*. It is still visible in Prometheus and Alertmanager, and
+`AlertSinkDown` fires there. Closing that loop properly requires an out-of-cluster
+receiver — which is the credentialed decision above.

--- a/infra/k8s/alert-delivery/README.md
+++ b/infra/k8s/alert-delivery/README.md
@@ -56,6 +56,15 @@ this process receives a heartbeat every hour, forever.
 `alert_sink_notifications_total` must therefore always be rising. If it stops,
 **`AlertDeliveryDead`** fires.
 
+> **Status today:** the heartbeat is NOT yet flowing, and that is visible rather
+> than hidden. `Watchdog` carries no `namespace` label, so the AlertmanagerConfig
+> sub-route (scoped `OnNamespace` by the operator) cannot match it — it still
+> routes to `null`. Only the **default route** in the Helm values catches it, and
+> that lands when the `kube-prometheus-stack` Argo app syncs this change.
+> Until then `AlertDeliveryDead` fires, correctly reporting that estate-wide
+> delivery is not wired. Measured live: 19 firing alerts still reaching `null`,
+> 0 reaching the sink, because none of them carry `namespace=observability`.
+
 That inverts the failure mode: silence is no longer "nothing is wrong", silence
 is itself the alarm.
 

--- a/infra/k8s/alert-delivery/base/alertmanagerconfig.yaml
+++ b/infra/k8s/alert-delivery/base/alertmanagerconfig.yaml
@@ -1,0 +1,51 @@
+# Immediate delivery coverage for the `observability` namespace.
+#
+# Two mechanisms ship together, deliberately:
+#
+#  1. deploy/argocd/observability-services.yaml sets the Alertmanager DEFAULT
+#     route to the sink. That is the estate-wide fix, and it lands when that
+#     Argo app next syncs.
+#
+#  2. This AlertmanagerConfig, which the operator merges in as a sub-route. The
+#     operator scopes routes from an AlertmanagerConfig to the CR's own
+#     namespace (matcherStrategy OnNamespace, the default), so this covers
+#     alerts labelled namespace=observability only.
+#
+# Why both: (2) is a separate resource from the Helm release, so it takes effect
+# without waiting on a chart sync — and every guard added in this wave
+# (pvc-capacity-guard, rule-liveness-guard, alert-delivery itself) fires in the
+# observability namespace. So the new controls have a real receiver from the
+# moment they are applied, rather than being wired to `null` until a merge.
+#
+# It is NOT a substitute for (1). Alerts in socioprophet/, scm/, serving/ etc.
+# still need the default route, which is why the Helm change ships too.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: alert-sink
+  namespace: observability
+  labels:
+    bundle: observability
+    release: kube-prometheus-stack
+spec:
+  route:
+    receiver: alert-sink
+    groupBy: ["alertname"]
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 12h
+    routes:
+      # The dead-man's switch. Watchdog fires forever by design; a 1h repeat
+      # keeps alert_sink_notifications_total rising, which is the fact that
+      # AlertDeliveryDead watches for.
+      - receiver: alert-sink
+        matchers:
+          - name: alertname
+            value: Watchdog
+        groupWait: 0s
+        repeatInterval: 1h
+  receivers:
+    - name: alert-sink
+      webhookConfigs:
+        - url: http://alert-sink.observability.svc:9095/alerts
+          sendResolved: true

--- a/infra/k8s/alert-delivery/base/deployment.yaml
+++ b/infra/k8s/alert-delivery/base/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alert-sink
+  namespace: observability
+  labels:
+    app: alert-sink
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alert-sink
+  template:
+    metadata:
+      labels:
+        app: alert-sink
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: sink
+          # Pulled DIRECTLY from docker.io, deliberately not through
+          # registry.socioprophet.ai — same rule the PVC guard states. This is the
+          # terminal receiver for every alert in the estate, including the alerts
+          # that fire when the registry is broken. Routing its image through the
+          # registry would silence alerting in exactly the situation that needs it.
+          # Stdlib-only script, so a bare python image needs no pip install.
+          image: python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
+          command: ["python3", "/opt/sink/sink.py"]
+          env:
+            - name: PORT
+              value: "9095"
+            - name: CLUSTER_NAME
+              value: prophet-platform
+            # Fixed-size ring; the sink keeps no unbounded history. Durability is
+            # Cloud Logging's job, not this process's.
+            - name: RECENT_RING
+              value: "50"
+            - name: MAX_BODY_BYTES
+              value: "2097152"
+          ports:
+            - name: http
+              containerPort: 9095
+          volumeMounts:
+            - name: sink
+              mountPath: /opt/sink/sink.py
+              subPath: sink.py
+              readOnly: true
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            periodSeconds: 20
+          readinessProbe:
+            httpGet: { path: /healthz, port: http }
+            periodSeconds: 10
+          resources:
+            # 250m is GKE Autopilot's floor for a single-container pod. Asking
+            # for less makes Autopilot mutate the spec on admission, which shows
+            # up as permanent ArgoCD drift — so the manifest states what the
+            # platform will actually grant.
+            requests:
+              cpu: 250m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: sink
+          configMap:
+            name: alert-sink
+            defaultMode: 0555

--- a/infra/k8s/alert-delivery/base/kustomization.yaml
+++ b/infra/k8s/alert-delivery/base/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: observability
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - servicemonitor.yaml
+  - prometheusrule-delivery.yaml
+
+configMapGenerator:
+  - name: alert-sink
+    files:
+      - sink.py
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+labels:
+  - includeSelectors: false
+    pairs:
+      bundle: observability

--- a/infra/k8s/alert-delivery/base/kustomization.yaml
+++ b/infra/k8s/alert-delivery/base/kustomization.yaml
@@ -7,6 +7,11 @@ resources:
   - service.yaml
   - servicemonitor.yaml
   - prometheusrule-delivery.yaml
+  # The namespace-scoped receiver route. Was authored but never listed here, so the
+  # Argo app that syncs this base never applied it — the CR shipped orphaned and the
+  # immediate observability-namespace delivery path did not exist. Wiring it in is the
+  # whole point of the file existing.
+  - alertmanagerconfig.yaml
 
 configMapGenerator:
   - name: alert-sink

--- a/infra/k8s/alert-delivery/base/prometheusrule-delivery.yaml
+++ b/infra/k8s/alert-delivery/base/prometheusrule-delivery.yaml
@@ -9,6 +9,19 @@
 # fires permanently BY DESIGN, as a dead-man's switch. It is routed to the sink,
 # so the sink receives a notification every repeat_interval, forever. That turns
 # "the delivery path works" from an assertion into a continuously re-proved fact.
+#
+# The heartbeat only flows once the Alertmanager DEFAULT route points here
+# (deploy/argocd/observability-services.yaml). `Watchdog` carries no `namespace`
+# label, so the AlertmanagerConfig sub-route — which the operator scopes
+# OnNamespace — cannot match it. Until that chart change syncs, Watchdog still
+# goes to `null` and AlertDeliveryDead will fire. That is correct: estate-wide
+# delivery genuinely is not wired yet, and the alert saying so is the point.
+#
+# IMPORTANT — every alert below carries an explicit `namespace: observability`
+# label. Without it these rules emit alerts with no namespace label and the
+# sub-route would not match them either, so the alert reporting "delivery is
+# dead" would itself be delivered to `null`. That is the failure this component
+# exists to prevent, and it would have shipped inside the fix.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -31,7 +44,7 @@ spec:
             increase(alert_sink_notifications_total[3h]) == 0
             or absent(alert_sink_notifications_total)
           for: 15m
-          labels: { severity: critical }
+          labels: { severity: critical, namespace: observability }
           annotations:
             summary: "Alert delivery is dead — no notification reached the sink in 3h"
             description: >-
@@ -46,7 +59,7 @@ spec:
         - alert: AlertSinkDown
           expr: up{job="alert-sink"} == 0 or absent(up{job="alert-sink"})
           for: 5m
-          labels: { severity: critical }
+          labels: { severity: critical, namespace: observability }
           annotations:
             summary: "alert-sink is down — Alertmanager has nowhere to deliver"
 
@@ -54,7 +67,7 @@ spec:
         - alert: AlertSinkRejecting
           expr: increase(alert_sink_errors_total[15m]) > 0
           for: 0m
-          labels: { severity: warning }
+          labels: { severity: warning, namespace: observability }
           annotations:
             summary: "alert-sink refused {{ $value }} malformed deliveries in 15m"
             description: >-
@@ -73,7 +86,7 @@ spec:
             increase(alertmanager_notifications_total{integration="webhook"}[3h]) == 0
             or absent(alertmanager_notifications_total{integration="webhook"})
           for: 15m
-          labels: { severity: critical }
+          labels: { severity: critical, namespace: observability }
           annotations:
             summary: "Alertmanager has sent zero webhook notifications in 3h"
             description: >-

--- a/infra/k8s/alert-delivery/base/prometheusrule-delivery.yaml
+++ b/infra/k8s/alert-delivery/base/prometheusrule-delivery.yaml
@@ -1,0 +1,81 @@
+# Meta-monitoring for the alert delivery path itself.
+#
+# The estate's alerts were routed to a receiver named "null" for the life of the
+# cluster and nothing reported a problem, because "delivered to null" and
+# "delivered" are indistinguishable from inside Alertmanager. These rules make
+# the delivery path observable so that failure is loud rather than quiet.
+#
+# The load-bearing trick: kube-prometheus-stack ships a `Watchdog` alert that
+# fires permanently BY DESIGN, as a dead-man's switch. It is routed to the sink,
+# so the sink receives a notification every repeat_interval, forever. That turns
+# "the delivery path works" from an assertion into a continuously re-proved fact.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: alert-delivery
+  namespace: observability
+  labels:
+    bundle: observability
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: alert-delivery.liveness
+      rules:
+        # THE dead-man's switch. Watchdog fires forever and repeats every
+        # repeat_interval (12h by default, cut to 1h for the heartbeat route),
+        # so this counter must keep moving. If it stops, alerts are no longer
+        # being delivered anywhere and every other alert in this estate has
+        # gone quiet without saying so.
+        - alert: AlertDeliveryDead
+          expr: |
+            increase(alert_sink_notifications_total[3h]) == 0
+            or absent(alert_sink_notifications_total)
+          for: 15m
+          labels: { severity: critical }
+          annotations:
+            summary: "Alert delivery is dead — no notification reached the sink in 3h"
+            description: >-
+              The Watchdog heartbeat routes to alert-sink every hour, so
+              alert_sink_notifications_total must always be rising. It is not.
+              Either Alertmanager stopped notifying, the route regressed to a
+              null receiver, or the sink is down. Every alert in the estate is
+              currently going nowhere.
+            runbook: infra/k8s/alert-delivery/README.md
+
+        # The sink process being gone is itself an alert, not an absence.
+        - alert: AlertSinkDown
+          expr: up{job="alert-sink"} == 0 or absent(up{job="alert-sink"})
+          for: 5m
+          labels: { severity: critical }
+          annotations:
+            summary: "alert-sink is down — Alertmanager has nowhere to deliver"
+
+        # Refusals must never accumulate quietly.
+        - alert: AlertSinkRejecting
+          expr: increase(alert_sink_errors_total[15m]) > 0
+          for: 0m
+          labels: { severity: warning }
+          annotations:
+            summary: "alert-sink refused {{ $value }} malformed deliveries in 15m"
+            description: >-
+              The sink returned 4xx for at least one Alertmanager delivery. Each
+              refusal emitted an EvidenceReceipt with status=failed to Cloud
+              Logging. A refusal means an alert was NOT receipted.
+
+    - name: alert-delivery.config
+      rules:
+        # Guards the regression that started all of this: if Alertmanager is
+        # reconfigured back to a null-only receiver set, notifications stop and
+        # AlertDeliveryDead catches it within 3h. This catches it in 5m by
+        # watching Alertmanager's own delivery counter for the sink integration.
+        - alert: AlertmanagerNotNotifying
+          expr: |
+            increase(alertmanager_notifications_total{integration="webhook"}[3h]) == 0
+            or absent(alertmanager_notifications_total{integration="webhook"})
+          for: 15m
+          labels: { severity: critical }
+          annotations:
+            summary: "Alertmanager has sent zero webhook notifications in 3h"
+            description: >-
+              Alertmanager is not delivering to any webhook receiver. If the
+              receiver list has regressed to `null`, this is the signal.

--- a/infra/k8s/alert-delivery/base/service.yaml
+++ b/infra/k8s/alert-delivery/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alert-sink
+  namespace: observability
+  labels:
+    app: alert-sink
+spec:
+  selector:
+    app: alert-sink
+  ports:
+    - name: http
+      port: 9095
+      targetPort: http

--- a/infra/k8s/alert-delivery/base/servicemonitor.yaml
+++ b/infra/k8s/alert-delivery/base/servicemonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: alert-sink
+  namespace: observability
+  labels:
+    bundle: observability
+    release: kube-prometheus-stack   # picked up by the stack's serviceMonitorSelector
+spec:
+  selector:
+    matchLabels:
+      app: alert-sink
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s

--- a/infra/k8s/alert-delivery/base/sink.py
+++ b/infra/k8s/alert-delivery/base/sink.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Alertmanager webhook sink: the estate's terminal receiver.
+
+Until this existed, Alertmanager's only receiver was literally named "null".
+Every alert in the estate -- including the ones that page for data loss --
+was routed to a receiver that discards. The stack reported healthy the whole
+time, because "delivered to null" and "delivered" are the same code path.
+
+What this does
+--------------
+Accepts Alertmanager webhook POSTs and turns each one into an EvidenceReceipt
+(contracts/EvidenceReceipt.v0.1.json) written as one JSON line to stdout.
+Pod stdout is collected by fluentbit-gke and lands in Google Cloud Logging,
+which is the estate's only working log sink -- Loki is deployed but has zero
+ingested bytes and nothing ships to it.
+
+Why this is not just another silent hop
+---------------------------------------
+Delivery is proven continuously, not asserted. kube-prometheus-stack ships a
+`Watchdog` alert that fires permanently by design. It is routed here, so this
+process receives a heartbeat every repeat_interval forever. The counter
+`alert_sink_notifications_total` therefore MUST keep rising. If it stops, the
+delivery path is broken, and `AlertDeliveryDead` fires on that absence.
+
+That inverts the failure mode. A silent sink is not "no alerts today" -- it is
+itself an alert.
+
+Bounds
+------
+No unbounded state. Counters are integers; the /recent buffer is a fixed-size
+ring (RING_MAX). Request bodies are capped at MAX_BODY bytes. Nothing is
+retained on disk by this process; durability is Cloud Logging's job.
+
+Refusals are loud
+-----------------
+A malformed payload is NOT swallowed. It increments alert_sink_errors_total,
+emits a receipt with status="failed", and returns 400. An error the sink
+absorbs quietly would reproduce the defect this exists to fix.
+"""
+
+from __future__ import annotations
+
+import collections
+import hashlib
+import json
+import os
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+VERSION = "0.1"
+SERVICE_REF = "infra/k8s/alert-delivery"
+PORT = int(os.environ.get("PORT", "9095"))
+MAX_BODY = int(os.environ.get("MAX_BODY_BYTES", str(2 * 1024 * 1024)))
+RING_MAX = int(os.environ.get("RECENT_RING", "50"))
+CLUSTER = os.environ.get("CLUSTER_NAME", "unknown")
+
+_lock = threading.Lock()
+_counters = {
+    "notifications_total": 0,
+    "alerts_total": 0,
+    "receipts_total": 0,
+    "errors_total": 0,
+    "bytes_total": 0,
+}
+_by_severity: dict[tuple[str, str], int] = collections.defaultdict(int)
+_recent: collections.deque = collections.deque(maxlen=RING_MAX)
+_started = time.time()
+_last_notification = 0.0
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def canonical(payload) -> str:
+    """Deterministic JSON. Sorted keys, no incidental whitespace."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def digest(payload) -> str:
+    return hashlib.sha256(canonical(payload).encode("utf-8")).hexdigest()
+
+
+def emit(obj: dict) -> None:
+    """One JSON object per line to stdout -> fluentbit-gke -> Cloud Logging."""
+    sys.stdout.write(canonical(obj) + "\n")
+    sys.stdout.flush()
+
+
+def receipt(action: str, status: str, subject_ref: str, body: dict, **extra) -> dict:
+    """An EvidenceReceipt.v0.1. Fields and enum values come from the contract."""
+    h = digest(body)
+    r = {
+        "version": VERSION,
+        "receipt_id": "evr-%s-%s" % (action, h[:32]),
+        "created_at": utc_now(),
+        "service_ref": SERVICE_REF,
+        "action": action,
+        "status": status,
+        "subject_ref": subject_ref,
+        "hash": h,
+        "hash_algo": "sha256",
+    }
+    r.update(extra)
+    return r
+
+
+def handle_notification(payload: dict) -> dict:
+    """Turn one Alertmanager webhook into receipts. Returns a summary."""
+    alerts = payload.get("alerts")
+    if not isinstance(alerts, list):
+        raise ValueError("payload has no 'alerts' list")
+
+    group_key = str(payload.get("groupKey", ""))
+    receiver = str(payload.get("receiver", ""))
+    seen = []
+
+    for a in alerts:
+        if not isinstance(a, dict):
+            raise ValueError("alert entry is not an object")
+        labels = a.get("labels") or {}
+        annotations = a.get("annotations") or {}
+        name = str(labels.get("alertname", "<unnamed>"))
+        severity = str(labels.get("severity", "none"))
+        status = str(a.get("status", "unknown"))
+
+        # firing -> the condition is live and was delivered here.
+        # resolved -> Alertmanager observed it clear.
+        ev_status = "accepted" if status == "firing" else "succeeded"
+
+        body = {
+            "alertname": name,
+            "severity": severity,
+            "status": status,
+            "labels": labels,
+            "annotations": annotations,
+            "startsAt": a.get("startsAt"),
+            "endsAt": a.get("endsAt"),
+            "generatorURL": a.get("generatorURL"),
+            "fingerprint": a.get("fingerprint"),
+        }
+        subject = "alert/%s/%s" % (labels.get("namespace", "-"), name)
+        r = receipt(
+            "alert-delivered",
+            ev_status,
+            subject,
+            body,
+            metrics={"severity": severity, "alert_status": status},
+            evidence_refs=[x for x in [a.get("generatorURL")] if x],
+            policy_refs=["alertmanager/receiver/%s" % receiver] if receiver else [],
+        )
+        r["alert"] = body
+        r["group_key"] = group_key
+        r["cluster"] = CLUSTER
+        emit(r)
+
+        with _lock:
+            _counters["receipts_total"] += 1
+            _counters["alerts_total"] += 1
+            _by_severity[(severity, status)] += 1
+            _recent.append(
+                {"at": r["created_at"], "alertname": name, "severity": severity, "status": status}
+            )
+        seen.append((name, severity, status))
+
+    return {"count": len(seen), "alerts": seen, "receiver": receiver}
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):  # noqa: A003 - stdlib hook
+        # Access logs go through the same structured stream as everything else.
+        emit(
+            {
+                "stream": "access",
+                "at": utc_now(),
+                "service_ref": SERVICE_REF,
+                "line": fmt % args,
+            }
+        )
+
+    def _send(self, code: int, obj: dict) -> None:
+        body = canonical(obj).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_text(self, code: int, text: str) -> None:
+        body = text.encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "text/plain; version=0.0.4")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802 - stdlib hook
+        if self.path.startswith("/metrics"):
+            return self._send_text(200, self._metrics())
+        if self.path.startswith("/healthz"):
+            return self._send(200, {"ok": True, "uptime_s": int(time.time() - _started)})
+        if self.path.startswith("/recent"):
+            with _lock:
+                return self._send(200, {"recent": list(_recent)})
+        return self._send(404, {"error": "not found"})
+
+    def do_POST(self):  # noqa: N802 - stdlib hook
+        length = int(self.headers.get("Content-Length") or 0)
+        if length > MAX_BODY:
+            with _lock:
+                _counters["errors_total"] += 1
+            emit(
+                receipt(
+                    "alert-delivered",
+                    "denied",
+                    "alert/-/<oversize>",
+                    {"content_length": length, "limit": MAX_BODY},
+                )
+            )
+            return self._send(413, {"error": "body too large", "limit": MAX_BODY})
+
+        raw = self.rfile.read(length) if length else b""
+        with _lock:
+            _counters["bytes_total"] += len(raw)
+
+        try:
+            payload = json.loads(raw.decode("utf-8") or "{}")
+            if not isinstance(payload, dict):
+                raise ValueError("payload is not a JSON object")
+            summary = handle_notification(payload)
+        except Exception as exc:  # noqa: BLE001 - deliberate: every failure is reported
+            with _lock:
+                _counters["errors_total"] += 1
+            emit(
+                receipt(
+                    "alert-delivered",
+                    "failed",
+                    "alert/-/<malformed>",
+                    {"error": str(exc), "bytes": len(raw)},
+                    metrics={"error": type(exc).__name__},
+                )
+            )
+            return self._send(400, {"error": str(exc)})
+
+        global _last_notification
+        with _lock:
+            _counters["notifications_total"] += 1
+            _last_notification = time.time()
+        return self._send(200, {"ok": True, **summary})
+
+    def _metrics(self) -> str:
+        with _lock:
+            c = dict(_counters)
+            sev = dict(_by_severity)
+            last = _last_notification
+        out = [
+            "# HELP alert_sink_notifications_total Alertmanager webhook notifications accepted.",
+            "# TYPE alert_sink_notifications_total counter",
+            "alert_sink_notifications_total %d" % c["notifications_total"],
+            "# HELP alert_sink_alerts_total Individual alerts extracted from notifications.",
+            "# TYPE alert_sink_alerts_total counter",
+            "alert_sink_alerts_total %d" % c["alerts_total"],
+            "# HELP alert_sink_receipts_total EvidenceReceipts emitted to the log stream.",
+            "# TYPE alert_sink_receipts_total counter",
+            "alert_sink_receipts_total %d" % c["receipts_total"],
+            "# HELP alert_sink_errors_total Malformed or refused deliveries.",
+            "# TYPE alert_sink_errors_total counter",
+            "alert_sink_errors_total %d" % c["errors_total"],
+            "# HELP alert_sink_last_notification_timestamp_seconds Unix time of the last accepted notification.",
+            "# TYPE alert_sink_last_notification_timestamp_seconds gauge",
+            "alert_sink_last_notification_timestamp_seconds %f" % last,
+            "# HELP alert_sink_build_info Sink build metadata.",
+            "# TYPE alert_sink_build_info gauge",
+            'alert_sink_build_info{version="%s",cluster="%s"} 1' % (VERSION, CLUSTER),
+            "# HELP alert_sink_alerts_by_severity_total Alerts by severity and firing status.",
+            "# TYPE alert_sink_alerts_by_severity_total counter",
+        ]
+        for (severity, status), n in sorted(sev.items()):
+            out.append(
+                'alert_sink_alerts_by_severity_total{severity="%s",alert_status="%s"} %d'
+                % (severity, status, n)
+            )
+        return "\n".join(out) + "\n"
+
+
+def main() -> None:
+    emit(
+        {
+            "stream": "lifecycle",
+            "at": utc_now(),
+            "service_ref": SERVICE_REF,
+            "event": "start",
+            "port": PORT,
+            "cluster": CLUSTER,
+        }
+    )
+    ThreadingHTTPServer(("", PORT), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/k8s/alert-delivery/base/sink.py
+++ b/infra/k8s/alert-delivery/base/sink.py
@@ -58,6 +58,13 @@ RING_MAX = int(os.environ.get("RECENT_RING", "50"))
 CLUSTER = os.environ.get("CLUSTER_NAME", "unknown")
 
 _lock = threading.Lock()
+# Dedicated stdout lock, separate from _lock (which guards the counters/ring). This
+# server is a ThreadingHTTPServer, so multiple request threads reach emit() at once;
+# an unguarded write+flush can interleave two receipts into one corrupt line and break
+# the JSONL contract the whole sink exists to uphold. A separate lock keeps this off
+# the counter critical section and cannot deadlock against it (emit() is never called
+# while _lock is held).
+_emit_lock = threading.Lock()
 _counters = {
     "notifications_total": 0,
     "alerts_total": 0,
@@ -85,9 +92,17 @@ def digest(payload) -> str:
 
 
 def emit(obj: dict) -> None:
-    """One JSON object per line to stdout -> fluentbit-gke -> Cloud Logging."""
-    sys.stdout.write(canonical(obj) + "\n")
-    sys.stdout.flush()
+    """One JSON object per line to stdout -> fluentbit-gke -> Cloud Logging.
+
+    The write+flush is atomic under _emit_lock: ThreadingHTTPServer can call emit()
+    from several request threads at once, and an unguarded pair of writes interleaves
+    two receipts into one unparseable line — the exact silent corruption a receipt
+    stream must not have. Serialise the line first, hold the lock only for the I/O.
+    """
+    line = canonical(obj) + "\n"
+    with _emit_lock:
+        sys.stdout.write(line)
+        sys.stdout.flush()
 
 
 def receipt(action: str, status: str, subject_ref: str, body: dict, **extra) -> dict:

--- a/infra/k8s/alert-delivery/tests/test_sink_emit_concurrency.py
+++ b/infra/k8s/alert-delivery/tests/test_sink_emit_concurrency.py
@@ -1,0 +1,89 @@
+"""emit() must write one intact JSON line per call, even under ThreadingHTTPServer.
+
+The sink is a ThreadingHTTPServer, so several request threads reach emit() at once.
+Pre-fix, emit() did an unguarded `sys.stdout.write(...) ; flush()`, so two receipts
+could interleave into a single unparseable line — the exact silent corruption a
+receipt stream (its whole reason to exist) must never produce. This test drives the
+race deterministically: a fake stdout whose write() is deliberately NON-atomic (it
+emits the line in two halves with a yield between). Without emit()'s lock the halves
+of concurrent lines interleave and json.loads() fails; with it every line is intact.
+
+Local-only (Actions are spend-capped). Requires: python3 (stdlib only).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+_SINK = Path(__file__).resolve().parents[1] / "base" / "sink.py"
+
+
+def _load_sink():
+    spec = importlib.util.spec_from_file_location("alert_sink_under_test", _SINK)
+    assert spec and spec.loader, f"cannot build an import spec for {_SINK}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class SplittingStdout:
+    """A stdout whose write() is intentionally non-atomic: it appends the line in two
+    pieces with a scheduler yield between them. Any code that does not serialise its
+    write() calls will interleave concurrent lines; correctly-locked code will not."""
+
+    def __init__(self) -> None:
+        self.parts: list[str] = []
+
+    def write(self, s: str) -> int:
+        half = len(s) // 2
+        self.parts.append(s[:half])
+        time.sleep(0)  # yield: invite another thread to interleave here
+        self.parts.append(s[half:])
+        return len(s)
+
+    def flush(self) -> None:  # noqa: D401 - stdlib file protocol
+        pass
+
+    def value(self) -> str:
+        return "".join(self.parts)
+
+
+def _run_concurrent_emits(sink, n: int = 64) -> str:
+    fake = SplittingStdout()
+    real = sys.stdout
+    sys.stdout = fake  # sink.emit() calls sys.stdout.write at call time
+    try:
+        barrier = threading.Barrier(n)
+
+        def one(i: int) -> None:
+            barrier.wait()  # maximise the race window
+            sink.emit({"receipt_id": "evr-%04d" % i, "seq": i, "kind": "test"})
+
+        threads = [threading.Thread(target=one, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        sys.stdout = real
+    return fake.value()
+
+
+def test_concurrent_emit_produces_only_intact_json_lines():
+    """THE regression. 64 threads race emit() through a write-splitting stdout. Every
+    non-empty line must be valid JSON and exactly N lines must appear — pre-fix the
+    unguarded write+flush interleaved halves and this failed with a JSONDecodeError."""
+    sink = _load_sink()
+    out = _run_concurrent_emits(sink, n=64)
+
+    lines = [ln for ln in out.split("\n") if ln]
+    assert len(lines) == 64, f"expected 64 intact lines, got {len(lines)} (interleaving splits/merges lines)"
+    seqs = set()
+    for ln in lines:
+        obj = json.loads(ln)  # raises JSONDecodeError on an interleaved line
+        seqs.add(obj["seq"])
+    assert seqs == set(range(64)), "every receipt must survive exactly once and intact"


### PR DESCRIPTION
## What was wrong

Alertmanager had exactly one receiver:

```yaml
route:
  receiver: "null"
receivers:
  - name: "null"
```

Every alert in this estate — SLO breaches, `KubeJobFailed`, the PVC guard's data-loss warnings — was routed to a receiver that discards. Nothing reported a problem, because from inside Alertmanager **"delivered to null" and "delivered" are the same code path**. `alertmanager_notifications_total` rose. Dashboards were green.

At the moment this was found, Alertmanager was holding **20 firing alerts** that no human had ever seen, including four `KubeJobFailed` and a `KubeletDown`.

This is the first link: every other control in this wave is decorative until it exists.

## What this adds

A ~250-line stdlib-Python webhook sink. Each Alertmanager notification becomes an **EvidenceReceipt** (`contracts/EvidenceReceipt.v0.1.json`) on stdout → `fluentbit-gke` → **Google Cloud Logging**.

Deliberately a destination needing **no credential and no external endpoint**, so it could be wired without provisioning anything. Human paging is a separate decision — options and costs are in the README, and nothing here pages a person.

## Why it cannot silently stop working

`kube-prometheus-stack` ships a **`Watchdog`** alert that fires permanently by design. Routing it here with `repeat_interval: 1h` gives the sink a heartbeat forever, so `alert_sink_notifications_total` must always rise. When it stops, **`AlertDeliveryDead`** fires.

That inverts the failure mode: silence stops meaning "quiet night" and starts meaning "alarm".

Refusals are equally loud — a malformed payload increments `alert_sink_errors_total`, emits a `status: "failed"` receipt, and returns 400. Never absorbed.

## Bounds

| Bound | Value | Why |
|---|---|---|
| `MAX_BODY_BYTES` | 2 MiB | Over-size → 413 + `denied` receipt |
| `RECENT_RING` | 50 | Fixed ring; no unbounded history |
| `max_alerts` | 0 | Never truncate — truncation drops alerts silently |
| Durability | none | Cloud Logging's job, not this process's |

## Proof it fires — observed, not asserted

```
$ curl -XPOST .../api/v2/alerts -d '[{"labels":{"alertname":"Wave1DeliveryProof", ...}}]'
POST=200
  Wave1DeliveryProof active receivers=[observability/alert-sink/alert-sink]
```

Receipts emitted, firing then resolved:

```
05:29:44  evr-alert-delivered-ee132fdb...  accepted   alert_status=firing
05:34:44  evr-alert-delivered-ae71c3a8...  succeeded  alert_status=resolved
```

Counters 1 → 2. Both validate against the contract (required fields, `status` in enum, `version` const).

Malformed payload also exercised: HTTP 400, `errors_total` 0 → 1, `status: "failed"` receipt.

The nine real findings from the companion rule-liveness guard were then delivered through this same path end-to-end.

## Loki

Recorded in the README because it is the same defect in another costume: Loki is deployed, `Running`, holds a 10Gi PVC, and has **zero ingested bytes and zero label values**. Nothing has ever written to it. The logging story here targets Cloud Logging instead. Not addressed in this PR.

## Two mechanisms, on purpose

1. Helm values set the **estate-wide default route** (all namespaces).
2. An `AlertmanagerConfig` CR covers `namespace=observability` without waiting on a chart sync — which is where every guard in this wave fires.

(2) is not a substitute for (1); alerts in `socioprophet`, `scm`, `serving` need the default route.

## Coordination

New paths (`infra/k8s/alert-delivery/**`, `deploy/argocd/alert-delivery.yaml`) plus the Alertmanager block of `deploy/argocd/observability-services.yaml`. No overlap with #1091, #1105, `images.yml`, `infra/k8s/zot/**`, `apps/health-twin/**`, `tools/`, `gitops-promote.yml`, or `validate-target-diagnostics.yml`.

⚠️ **Unverified by CI** — GitHub Actions is at a spend cap (456 queued, 0 running). Validated locally: YAML parse, `kubectl kustomize`, `kubectl apply --dry-run=server`, and the live end-to-end run above.