### PR TITLE
storage: three backup jobs that delete nothing, two of which never ran

### DIFF
--- a/deploy/serving/mesh-xl-a100.yaml
+++ b/deploy/serving/mesh-xl-a100.yaml
@@ -15,6 +15,19 @@ kind: PersistentVolumeClaim
 metadata:
   name: mesh-xl-cache
   namespace: serving
+  annotations:
+    # `kubectl describe pvc mesh-xl-cache` shows `Used By: <none>`, which reads
+    # as an abandoned 120Gi volume to anyone auditing storage. It is not.
+    # Unmounted IS the steady state: mesh-vllm-xl runs at replicas: 0 for $0
+    # idle, and this volume exists precisely so that warming back up re-reads
+    # cached weights (~2-3 min) instead of re-downloading them (~15 min).
+    # Recorded here, on the object itself, so the question does not have to be
+    # re-answered from the manifest every time someone audits PVCs.
+    socioprophet.io/intentionally-unmounted: >-
+      Model-weight cache for the scale-to-zero mesh-vllm-xl seat. Unmounted
+      while that Deployment is at replicas=0, which is its default. Do not
+      reclaim without also accepting ~15min cold-start on the XL seat.
+    socioprophet.io/idle-cost: "~120Gi pd-balanced (~USD 13/mo) while unmounted"
 spec:
   accessModes: [ReadWriteOnce]
   storageClassName: standard-rwo

--- a/infra/datastores/clickhouse/cell/0001_personal_intelligence_cell_analytics.sql
+++ b/infra/datastores/clickhouse/cell/0001_personal_intelligence_cell_analytics.sql
@@ -17,7 +17,8 @@ CREATE TABLE IF NOT EXISTS cell_signal_scores
 )
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(observed_at)
-ORDER BY (cell_id, watch_id, observed_at, signal_id);
+ORDER BY (cell_id, watch_id, observed_at, signal_id)
+TTL toDateTime(observed_at) + INTERVAL 12 MONTH DELETE;
 
 CREATE TABLE IF NOT EXISTS cell_source_quality_facts
 (
@@ -34,7 +35,8 @@ CREATE TABLE IF NOT EXISTS cell_source_quality_facts
 )
 ENGINE = SummingMergeTree
 PARTITION BY toYYYYMM(event_at)
-ORDER BY (cell_id, source_id, event_at);
+ORDER BY (cell_id, source_id, event_at)
+TTL toDateTime(event_at) + INTERVAL 24 MONTH DELETE;
 
 CREATE TABLE IF NOT EXISTS cell_reputation_deltas
 (
@@ -50,7 +52,8 @@ CREATE TABLE IF NOT EXISTS cell_reputation_deltas
 )
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(event_at)
-ORDER BY (cell_id, subject_kind, subject_ref, event_at);
+ORDER BY (cell_id, subject_kind, subject_ref, event_at)
+TTL toDateTime(event_at) + INTERVAL 24 MONTH DELETE;
 
 CREATE TABLE IF NOT EXISTS cell_feedback_outcomes
 (
@@ -64,7 +67,8 @@ CREATE TABLE IF NOT EXISTS cell_feedback_outcomes
 )
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(event_at)
-ORDER BY (cell_id, watch_id, action, event_at);
+ORDER BY (cell_id, watch_id, action, event_at)
+TTL toDateTime(event_at) + INTERVAL 24 MONTH DELETE;
 
 CREATE TABLE IF NOT EXISTS cell_watch_pattern_metrics
 (
@@ -80,7 +84,8 @@ CREATE TABLE IF NOT EXISTS cell_watch_pattern_metrics
 )
 ENGINE = SummingMergeTree
 PARTITION BY toYYYYMM(event_at)
-ORDER BY (cell_id, watch_id, pattern_id, event_at);
+ORDER BY (cell_id, watch_id, pattern_id, event_at)
+TTL toDateTime(event_at) + INTERVAL 24 MONTH DELETE;
 
 CREATE TABLE IF NOT EXISTS cell_notification_metrics
 (
@@ -94,7 +99,8 @@ CREATE TABLE IF NOT EXISTS cell_notification_metrics
 )
 ENGINE = SummingMergeTree
 PARTITION BY toYYYYMM(event_at)
-ORDER BY (cell_id, feed_kind, event_at);
+ORDER BY (cell_id, feed_kind, event_at)
+TTL toDateTime(event_at) + INTERVAL 12 MONTH DELETE;
 
 CREATE TABLE IF NOT EXISTS cell_social_environment_snapshots
 (
@@ -109,4 +115,5 @@ CREATE TABLE IF NOT EXISTS cell_social_environment_snapshots
 )
 ENGINE = MergeTree
 PARTITION BY toYYYYMM(snapshot_at)
-ORDER BY (cell_id, snapshot_at);
+ORDER BY (cell_id, snapshot_at)
+TTL toDateTime(snapshot_at) + INTERVAL 12 MONTH DELETE;

--- a/infra/k8s/mesh-qdrant/base/backup-cronjob.yaml
+++ b/infra/k8s/mesh-qdrant/base/backup-cronjob.yaml
@@ -20,17 +20,93 @@ spec:
           containers:
             - name: qdrant-snapshot
               image: curlimages/curl:8.6.0
-              args:
+              env:
+                # Service is `mesh-qdrant`, not `qdrant` — the old value did not
+                # resolve in this namespace. memoryd already had this right
+                # (infra/k8s/memoryd/base/deployment.yaml: QDRANT_URL).
+                - name: QDRANT_URL
+                  value: http://mesh-qdrant:6333
+                # Keep 7 snapshots per collection. Snapshots are full copies and
+                # they live on the same volume they snapshot, so retention is not
+                # optional here — without it the backup takes out the thing it
+                # is backing up.
+                - name: RETAIN
+                  value: "7"
+              # `command:`, not `args:`. curlimages/curl sets ENTRYPOINT ["curl"],
+              # so `args` left the entrypoint intact and the container ran
+              # `curl /bin/sh -c "<script>"` — curl treating /bin/sh as a URL.
+              # The shell never executed. Combined with the wrong hostname and a
+              # `jq` that is not in this image, this CronJob has never produced a
+              # single snapshot since it was authored, and said nothing.
+              command:
                 - /bin/sh
                 - -c
                 - |
-                  set -e
-                  COLLECTIONS=$(curl -sf http://qdrant:6333/collections | jq -r '.result.collections[].name')
-                  for col in $COLLECTIONS; do
-                    echo "Snapshotting collection: $col"
-                    curl -sf -X POST "http://qdrant:6333/collections/${col}/snapshots"
+                  set -eu
+                  log() { echo "$@" >&2; }
+                  NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                  MADE=0; PRUNED=0; FAILED=0
+
+                  # No jq in curlimages/curl. Extract names with grep, which
+                  # busybox does have. Deliberately not adding a dependency to a
+                  # backup job — fewer moving parts is the whole point.
+                  # Whitespace-tolerant: a pretty-printed `"name" : "x"` must
+                  # parse the same as compact `"name":"x"`. The first version of
+                  # this was anchored to the compact form and silently extracted
+                  # nothing against a spaced response — reporting a clean
+                  # "0 collections" backup. Caught by running it against a mock.
+                  names() { grep -oE '"name"[[:space:]]*:[[:space:]]*"[^"]*"' | cut -d'"' -f4; }
+
+                  COLLECTIONS=$(curl -sf --max-time 30 "${QDRANT_URL}/collections" | names || true)
+                  if [ -z "${COLLECTIONS}" ]; then
+                    # "zero collections" and "qdrant is unreachable" look
+                    # identical unless checked separately. Refuse rather than
+                    # report a successful no-op backup.
+                    if ! curl -sf --max-time 10 "${QDRANT_URL}/readyz" >/dev/null 2>&1; then
+                      log "REFUSED: qdrant unreachable at ${QDRANT_URL}"
+                      printf '{"version":"0.1","receipt_id":"evr-qdrant-snapshot-unreachable-%s","created_at":"%s","service_ref":"infra/k8s/mesh-qdrant","action":"qdrant-snapshot","status":"denied","subject_ref":"pvc/qdrant-storage","hash":"","hash_algo":"sha256","metrics":{"collections":0}}\n' \
+                        "$(date -u +%Y%m%dT%H%M%SZ)" "${NOW}"
+                      exit 1
+                    fi
+                    log "qdrant reachable but reports zero collections — nothing to snapshot"
+                  fi
+
+                  for col in ${COLLECTIONS}; do
+                    log "snapshotting collection: ${col}"
+                    if curl -sf --max-time 300 -X POST "${QDRANT_URL}/collections/${col}/snapshots" >/dev/null; then
+                      MADE=$((MADE + 1))
+                    else
+                      log "FAILED: snapshot of ${col}"
+                      FAILED=$((FAILED + 1))
+                      continue
+                    fi
+
+                    # --- retention ------------------------------------------
+                    # The old job only ever POSTed. It never called
+                    # DELETE /collections/{c}/snapshots/{s}, so snapshots would
+                    # have accumulated forever had it ever run. Snapshot names
+                    # carry a timestamp and sort chronologically.
+                    SNAPS=$(curl -sf --max-time 30 "${QDRANT_URL}/collections/${col}/snapshots" | names || true)
+                    TOTAL=$(printf '%s\n' "${SNAPS}" | grep -c . || true)
+                    if [ "${TOTAL}" -gt "${RETAIN}" ]; then
+                      DROP=$((TOTAL - RETAIN))
+                      printf '%s\n' "${SNAPS}" | sort | head -n "${DROP}" | while read -r s; do
+                        [ -z "${s}" ] && continue
+                        log "retention: deleting ${col}/${s}"
+                        curl -sf --max-time 60 -X DELETE "${QDRANT_URL}/collections/${col}/snapshots/${s}" >/dev/null \
+                          || log "WARN: could not delete ${col}/${s}"
+                      done
+                      PRUNED=$((PRUNED + DROP))
+                    fi
                   done
-                  echo "All snapshots created"
+
+                  STATUS=succeeded
+                  [ "${FAILED}" -gt 0 ] && STATUS=partial
+                  printf '{"version":"0.1","receipt_id":"evr-qdrant-snapshot-%s","created_at":"%s","service_ref":"infra/k8s/mesh-qdrant","action":"qdrant-snapshot","status":"%s","subject_ref":"pvc/qdrant-storage","hash":"","hash_algo":"sha256","metrics":{"snapshots_made":%s,"pruned":%s,"failed":%s,"retain":%s}}\n' \
+                    "$(date -u +%Y%m%dT%H%M%SZ)" "${NOW}" "${STATUS}" "${MADE}" "${PRUNED}" "${FAILED}" "${RETAIN}"
+                  log "done: made=${MADE} pruned=${PRUNED} failed=${FAILED}"
+                  [ "${FAILED}" -gt 0 ] && exit 1
+                  exit 0
               resources:
                 requests:
                   cpu: 10m

--- a/infra/k8s/mesh-qdrant/base/statefulset.yaml
+++ b/infra/k8s/mesh-qdrant/base/statefulset.yaml
@@ -20,6 +20,19 @@ spec:
       containers:
         - name: qdrant
           image: qdrant/qdrant:v1.9.4
+          env:
+            # Without this, qdrant defaults snapshots_path to ./snapshots
+            # relative to /qdrant — i.e. /qdrant/snapshots, which is NOT on the
+            # PVC. Snapshots then accumulate on the pod's ephemeral writable
+            # layer: they eat node ephemeral storage until eviction and vanish
+            # on every restart. A backup that does not survive a restart is not
+            # a backup, and nothing said so.
+            #
+            # Putting them under the mounted volume makes them durable AND makes
+            # them count against the same 20Gi the guard watches, so unbounded
+            # snapshot growth becomes visible instead of invisible.
+            - name: QDRANT__STORAGE__SNAPSHOTS_PATH
+              value: /qdrant/storage/snapshots
           ports:
             - name: http
               containerPort: 6333

--- a/infra/k8s/observability/base/kustomization.yaml
+++ b/infra/k8s/observability/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - otel-collector-service.yaml
   - servicemonitor.yaml
   - prometheusrule-slos.yaml
+  - prometheusrule-cronjob-staleness.yaml

--- a/infra/k8s/observability/base/prometheusrule-cronjob-staleness.yaml
+++ b/infra/k8s/observability/base/prometheusrule-cronjob-staleness.yaml
@@ -1,0 +1,66 @@
+# CronJob staleness -- fires for a scheduled CronJob that has not SUCCEEDED in
+# too long, INCLUDING one that has never succeeded even once.
+#
+# The obvious rule is silently wrong. The canonical form
+#     time() - kube_cronjob_status_last_successful_time > <threshold>
+# returns ZERO series for a job that has NEVER succeeded, because
+# kube_cronjob_status_last_successful_time has no series for that job at all --
+# so the jobs most in need of an alert (broken since creation: mail-backup and
+# minio-sync are both failing nightly and unalerted) are exactly the ones it
+# cannot see. Verified against live Prometheus: both are absent from that metric.
+#
+# The second, `unless`, arm is the fix: kube_cronjob_status_last_schedule_time
+# exists for every job that has ever been scheduled, so
+#     kube_cronjob_status_last_schedule_time * 0 unless kube_cronjob_status_last_successful_time
+# emits a 0-valued marker for every scheduled-but-never-succeeded job. `and on
+# (namespace,cronjob) (kube_cronjob_spec_suspend == 0)` drops deliberately
+# suspended jobs. A lane confirmed this expression returns both mail-backup and
+# minio-sync today.
+#
+# DELIVERY (read before assuming this pages anyone): the alert carries the
+# metric's own namespace label -- namespace=socioprophet for mail-backup. The
+# alert-sink AlertmanagerConfig added in #1112 is operator-scoped OnNamespace
+# and matches namespace=observability ONLY. Estate-wide delivery for
+# socioprophet/ instead depends on #1112's Alertmanager DEFAULT-route change
+# (deploy/argocd/observability-services.yaml), which is still `null` until that
+# Argo app syncs. So this rule is LIVE in Prometheus immediately (visible in the
+# UI and API) but is NOT delivered to a human until #1112 lands -- it fires into
+# the null sink today. It is intentionally NOT relabelled into observability:
+# that would misattribute a socioprophet CronJob to the observability namespace
+# just to borrow #1112's sub-route. Reference #1112's routing; do not fork it here.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cronjob-staleness
+  namespace: observability
+  labels:
+    bundle: observability
+    release: kube-prometheus-stack   # adopted by the stack's ruleSelector (ruleSelectorNilUsesHelmValues: false)
+spec:
+  groups:
+    - name: cronjob.staleness
+      rules:
+        - alert: CronJobNotSucceeding
+          # Arm (a): succeeded at least once, but not within 2 days -> stale.
+          # Arm (b): scheduled at least once but NEVER succeeded -> the `unless`
+          #          marker the naive last_successful_time rule is blind to.
+          # Both intersected with spec_suspend == 0 so a suspended job is silent.
+          expr: |
+            (
+              (time() - kube_cronjob_status_last_successful_time > 86400 * 2)
+              or
+              (kube_cronjob_status_last_schedule_time * 0 unless kube_cronjob_status_last_successful_time)
+            )
+            and on(namespace, cronjob) (kube_cronjob_spec_suspend == 0)
+          for: 1h
+          labels: { severity: warning }
+          annotations:
+            summary: "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} has not succeeded in over 2 days (or has never succeeded)"
+            description: >-
+              A scheduled, non-suspended CronJob has no successful completion in
+              the staleness window -- the never-succeeded case included, which the
+              naive `time() - kube_cronjob_status_last_successful_time` expression
+              cannot see because the metric has no series for a job that never
+              succeeded. Inspect the Job's pods and logs; a backup/sync job here
+              has been failing silently every night.
+            runbook: infra/k8s/observability/README.md

--- a/infra/k8s/workspace-mail/base/backup-cronjob.yaml
+++ b/infra/k8s/workspace-mail/base/backup-cronjob.yaml
@@ -24,6 +24,56 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
+          # Make ONLY the backup DESTINATION writable by uid 1000. The
+          # workspace-mail-backup PVC is a freshly provisioned PD whose root is
+          # root:root 0755, so the unprivileged backup container cannot create the
+          # tarball in it (EACCES). This initContainer chowns that one mount.
+          #
+          # This deliberately does NOT use a pod-level `fsGroup`: fsGroup applies
+          # to EVERY volume the pod mounts, so it would also rewrite the read-only
+          # mail SOURCE volume's root group ownership (to root:1000) — and even
+          # `fsGroupChangePolicy: OnRootMismatch` re-applies it on the next run
+          # after the ownership is restored, so it would fight the lane restoring
+          # /var/mail/vhosts and dirty the source every night. This container
+          # never mounts the mail source, so the source's ownership is provably
+          # untouched by the backup job.
+          initContainers:
+            - name: init-backup-perms
+              image: registry.socioprophet.ai/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  # Non-recursive: the backup only needs to CREATE new tarballs in
+                  # the destination root. Existing backups keep their ownership;
+                  # the destination's own lost+found is left alone.
+                  chown 1000:1000 /backup
+                  echo "init: /backup now owned by 1000:1000 (destination only; mail source untouched)"
+              volumeMounts:
+                # DESTINATION ONLY. The mail source is intentionally absent here.
+                - name: backup-target
+                  mountPath: /backup
+              securityContext:
+                # Root ONLY to chown, with just CAP_CHOWN. The pod default is
+                # runAsNonRoot: true; it is overridden here for this one step. The
+                # main backup container still runs unprivileged as uid 1000.
+                runAsNonRoot: false
+                runAsUser: 0
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+                  add: ["CHOWN"]
+                seccompProfile:
+                  type: RuntimeDefault
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi
+                limits:
+                  cpu: 50m
+                  memory: 32Mi
           containers:
             - name: mail-backup
               # Stock alpine, mirrored in our sovereign zot and pinned BY DIGEST.
@@ -34,9 +84,15 @@ spec:
               # one-liner, so it needs no first-party image at all — only a shell and tar.
               # Digest, not tag: zot carries library/alpine as :latest only, and a moving
               # tag on a backup job means the backup silently changes underfoot.
-              # Probe-verified in-cluster before this change (socioprophet namespace, this
-              # exact digest, uid 1000, caps dropped, seccomp RuntimeDefault): the pull
-              # succeeds and the one-liner produces a real, listable .tar.gz.
+              # PULL probe only (socioprophet namespace, this exact digest, uid 1000, caps
+              # dropped, seccomp RuntimeDefault): the pull succeeds and the shell+tar payload
+              # executes. Corrected from an earlier "produces a real, listable .tar.gz" claim:
+              # that could NOT have run against the real backup PVC. uid 1000 gets EACCES
+              # writing to a freshly provisioned destination PD (root:root 0755); any listable
+              # archive the probe produced was written to a throwaway writable dir, not
+              # workspace-mail-backup. A real archive is produced only after the
+              # init-backup-perms container below chowns the destination, and the size gate in
+              # the command rejects the trivially small (empty-maildir) case.
               image: registry.socioprophet.ai/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
               env:
                 # Keep 7 dailies. The source is a 10Gi mail volume against a 20Gi
@@ -51,6 +107,13 @@ spec:
                 # Refuse to start a backup that cannot fit. See below.
                 - name: MIN_FREE_MB
                   value: "3000"
+                # Floor for a NON-TRIVIAL archive, in bytes. An empty maildir tars
+                # to ~130 bytes and lists fine, so "readable" (step 5) is not
+                # enough to call it a backup. Below this the job FAILS instead of
+                # recording a meaningless green run. Raise once the maildir has a
+                # known floor of real mail.
+                - name: MIN_BACKUP_BYTES
+                  value: "1024"
               command:
                 - /bin/sh
                 - -c
@@ -112,7 +175,14 @@ spec:
                   fi
 
                   # --- 4. write ----------------------------------------------
-                  if ! tar czf "${OUT}" /maildata; then
+                  # Archive the maildir contents from inside the mount and skip
+                  # ext4's lost+found (root:root 0700 on a fresh PD). Excluding it
+                  # means the job never needs group access to the mount root just
+                  # to traverse lost+found, so the write does not lean on volume
+                  # ownership to READ the source -- only the destination needs the
+                  # initContainer chown to WRITE. `-C /maildata .` also drops the
+                  # /maildata/ prefix so a restore lands straight in the maildir root.
+                  if ! tar czf "${OUT}" -C /maildata --exclude=./lost+found .; then
                     log "FAILED: tar returned non-zero"
                     rm -f "${OUT}"
                     RC=1
@@ -126,6 +196,23 @@ spec:
                     log "FAILED: ${OUT} is not a readable gzip archive — removing"
                     rm -f "${OUT}"
                     RC=1
+                  fi
+
+                  # --- 5b. non-triviality gate -------------------------------
+                  # A readable archive can still be an EMPTY one. The maildir is
+                  # currently empty, and an empty maildir tars to ~130 bytes that
+                  # step 5 lists happily -- a green backup of nothing. Treat a
+                  # trivially small archive as a FAILURE so "the check that cannot
+                  # fail" cannot pass here either. Byte-precise (wc -c), unlike the
+                  # receipt's du -m which rounds a 130-byte file to 1MB.
+                  if [ "${RC}" -eq 0 ]; then
+                    BYTES=$(wc -c < "${OUT}" | tr -d ' ')
+                    log "size-gate: ${OUT} is ${BYTES} bytes, floor MIN_BACKUP_BYTES=${MIN_BACKUP_BYTES}"
+                    if [ "${BYTES}" -lt "${MIN_BACKUP_BYTES}" ]; then
+                      log "FAILED: ${OUT} is ${BYTES} bytes (< ${MIN_BACKUP_BYTES}) -- empty/near-empty maildir, refusing to record a trivial backup"
+                      rm -f "${OUT}"
+                      RC=1
+                    fi
                   fi
 
                   # --- 6. receipt --------------------------------------------

--- a/infra/k8s/workspace-mail/base/backup-cronjob.yaml
+++ b/infra/k8s/workspace-mail/base/backup-cronjob.yaml
@@ -38,14 +38,114 @@ spec:
               # exact digest, uid 1000, caps dropped, seccomp RuntimeDefault): the pull
               # succeeds and the one-liner produces a real, listable .tar.gz.
               image: registry.socioprophet.ai/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+              env:
+                # Keep 7 dailies. The source is a 10Gi mail volume against a 20Gi
+                # target, so 7 compressed fulls is the most that fits with room to
+                # write the next one before pruning.
+                - name: RETAIN
+                  value: "7"
+                # Hard ceiling on what backups may occupy, independent of RETAIN.
+                # Whichever binds first wins.
+                - name: MAX_TOTAL_MB
+                  value: "14000"
+                # Refuse to start a backup that cannot fit. See below.
+                - name: MIN_FREE_MB
+                  value: "3000"
               command:
                 - /bin/sh
                 - -c
                 - |
-                  set -e
+                  # Retention, verification and a receipt.
+                  #
+                  # This job previously wrote a new full tarball every night and
+                  # deleted NOTHING. It never actually ran (the image did not
+                  # exist), which is the only reason the 20Gi volume is not
+                  # already full — the retention bug was latent, not fixed. It is
+                  # fixed here BEFORE the job is allowed to schedule.
+                  #
+                  # Order matters: prune first, then check free space, then write,
+                  # then verify, then receipt. Writing first and pruning after
+                  # would need headroom for N+1 backups, which is exactly the
+                  # margin that does not exist.
+                  set -eu
                   STAMP=$(date -u +%Y%m%dT%H%M%SZ)
-                  tar czf /backup/mail-${STAMP}.tar.gz /maildata
-                  echo "Mail backup complete: mail-${STAMP}.tar.gz"
+                  OUT="/backup/mail-${STAMP}.tar.gz"
+                  RC=0
+
+                  log() { echo "$@" >&2; }
+
+                  # --- 1. prune by count -------------------------------------
+                  # Oldest first; names are lexically sortable by construction.
+                  COUNT=$(ls -1 /backup/mail-*.tar.gz 2>/dev/null | wc -l | tr -d ' ')
+                  log "retention: ${COUNT} existing backup(s), keeping ${RETAIN}"
+                  if [ "${COUNT}" -ge "${RETAIN}" ]; then
+                    DROP=$((COUNT - RETAIN + 1))
+                    ls -1 /backup/mail-*.tar.gz 2>/dev/null | sort | head -n "${DROP}" | \
+                      while read -r f; do
+                        log "retention: pruning $(basename "$f")"
+                        rm -f "$f"
+                      done
+                  fi
+
+                  # --- 2. prune by total size --------------------------------
+                  while :; do
+                    USED=$(du -sm /backup 2>/dev/null | awk '{print $1}')
+                    [ -z "${USED}" ] && USED=0
+                    [ "${USED}" -le "${MAX_TOTAL_MB}" ] && break
+                    OLDEST=$(ls -1 /backup/mail-*.tar.gz 2>/dev/null | sort | head -n1)
+                    [ -z "${OLDEST}" ] && break
+                    log "retention: ${USED}MB over ${MAX_TOTAL_MB}MB budget, pruning $(basename "${OLDEST}")"
+                    rm -f "${OLDEST}"
+                  done
+
+                  # --- 3. refuse rather than fill the disk -------------------
+                  # A backup that fills the volume takes out the next backup AND
+                  # anything else on it. Refusing is the safe failure, and it is
+                  # loud: exit 1 -> Job failure -> KubeJobFailed (a live alert).
+                  FREE=$(df -Pm /backup | awk 'NR==2 {print $4}')
+                  log "preflight: ${FREE}MB free, need >= ${MIN_FREE_MB}MB"
+                  if [ "${FREE}" -lt "${MIN_FREE_MB}" ]; then
+                    log "REFUSED: only ${FREE}MB free on /backup, below MIN_FREE_MB=${MIN_FREE_MB}"
+                    printf '{"version":"0.1","receipt_id":"evr-mail-backup-refused-%s","created_at":"%s","service_ref":"infra/k8s/workspace-mail","action":"mail-backup","status":"denied","subject_ref":"pvc/workspace-mail-backup","hash":"","hash_algo":"sha256","metrics":{"free_mb":%s,"min_free_mb":%s,"retained":%s}}\n' \
+                      "${STAMP}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${FREE}" "${MIN_FREE_MB}" "${COUNT}"
+                    exit 1
+                  fi
+
+                  # --- 4. write ----------------------------------------------
+                  if ! tar czf "${OUT}" /maildata; then
+                    log "FAILED: tar returned non-zero"
+                    rm -f "${OUT}"
+                    RC=1
+                  fi
+
+                  # --- 5. verify ---------------------------------------------
+                  # An unreadable archive is not a backup. Listing it is cheap
+                  # and catches a truncated write, which is the failure mode a
+                  # nearly-full volume actually produces.
+                  if [ "${RC}" -eq 0 ] && ! tar tzf "${OUT}" >/dev/null 2>&1; then
+                    log "FAILED: ${OUT} is not a readable gzip archive — removing"
+                    rm -f "${OUT}"
+                    RC=1
+                  fi
+
+                  # --- 6. receipt --------------------------------------------
+                  # One EvidenceReceipt line to stdout -> fluentbit-gke -> Cloud
+                  # Logging. `hash` is the archive digest, so the receipt proves
+                  # WHICH bytes were produced, not merely that something ran.
+                  NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                  KEPT=$(ls -1 /backup/mail-*.tar.gz 2>/dev/null | wc -l | tr -d ' ')
+                  USED=$(du -sm /backup 2>/dev/null | awk '{print $1}')
+                  if [ "${RC}" -eq 0 ]; then
+                    SIZE=$(du -m "${OUT}" | awk '{print $1}')
+                    SHA=$(sha256sum "${OUT}" | awk '{print $1}')
+                    printf '{"version":"0.1","receipt_id":"evr-mail-backup-%s","created_at":"%s","service_ref":"infra/k8s/workspace-mail","action":"mail-backup","status":"succeeded","subject_ref":"pvc/workspace-mail-backup","hash":"%s","hash_algo":"sha256","output_refs":["%s"],"metrics":{"size_mb":%s,"retained":%s,"used_mb":%s,"retain_policy":%s,"max_total_mb":%s}}\n' \
+                      "${STAMP}" "${NOW}" "${SHA}" "${OUT}" "${SIZE}" "${KEPT}" "${USED}" "${RETAIN}" "${MAX_TOTAL_MB}"
+                    log "Mail backup complete: $(basename "${OUT}") ${SIZE}MB; ${KEPT} retained, ${USED}MB used"
+                  else
+                    printf '{"version":"0.1","receipt_id":"evr-mail-backup-failed-%s","created_at":"%s","service_ref":"infra/k8s/workspace-mail","action":"mail-backup","status":"failed","subject_ref":"pvc/workspace-mail-backup","hash":"","hash_algo":"sha256","metrics":{"retained":%s,"used_mb":%s}}\n' \
+                      "${STAMP}" "${NOW}" "${KEPT}" "${USED}"
+                  fi
+                  exit "${RC}"
               volumeMounts:
                 - name: mail-data
                   mountPath: /maildata

--- a/infra/k8s/workspace-mail/tests/backup-nontrivial.test.sh
+++ b/infra/k8s/workspace-mail/tests/backup-nontrivial.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Proof that the mail-backup non-triviality gate fails a trivial (empty-maildir)
+# archive and passes a real one.
+#
+# It does NOT re-implement the backup logic. It renders the SHIPPED manifest
+# (kubectl kustomize), extracts the mail-backup container's command script and
+# its env defaults verbatim, and runs THAT against two synthesized maildir
+# fixtures. The only transformation is localizing the two mount paths
+# (/maildata, /backup) to temp dirs so it can run unprivileged off-cluster; the
+# tar invocation, the tar-tzf verify and the wc -c size gate are the real ones.
+#
+# Local-only (Actions are spend-capped). Requires: kubectl, python3, tar.
+# Provides a sha256sum shim (-> shasum -a 256) so the receipt step runs on macOS.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BASE="$(cd "$HERE/../base" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# sha256sum shim for macOS (Linux/alpine already have it).
+mkdir -p "$WORK/shim"
+if ! command -v sha256sum >/dev/null 2>&1; then
+  cat >"$WORK/shim/sha256sum" <<'EOF'
+#!/bin/sh
+exec shasum -a 256 "$@"
+EOF
+  chmod +x "$WORK/shim/sha256sum"
+fi
+export PATH="$WORK/shim:$PATH"
+
+# --- extract the shipped script + env defaults from the rendered manifest ----
+kubectl kustomize "$BASE" >"$WORK/rendered.yaml"
+python3 - "$WORK/rendered.yaml" "$WORK/script.sh" "$WORK/env.sh" <<'PY'
+import sys, yaml
+rendered, script_out, env_out = sys.argv[1], sys.argv[2], sys.argv[3]
+docs = list(yaml.safe_load_all(open(rendered)))
+cj = [d for d in docs if d and d.get("kind") == "CronJob" and d["metadata"]["name"] == "mail-backup"][0]
+c = cj["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"][0]
+open(script_out, "w").write(c["command"][2])
+with open(env_out, "w") as f:
+    for e in c["env"]:
+        f.write('export %s=%s\n' % (e["name"], e.get("value", "")))
+PY
+
+# Localize ONLY the mount paths. Logic (tar/verify/size-gate/receipt) untouched.
+SRC="$WORK/src"; DST="$WORK/dst"
+mkdir -p "$SRC" "$DST"
+sed "s#/maildata#$SRC#g; s#/backup#$DST#g" "$WORK/script.sh" >"$WORK/script.local.sh"
+
+run_backup() { ( set -a; . "$WORK/env.sh"; set +a; sh "$WORK/script.local.sh" ); }
+
+pass=0; fail=0
+ok()   { echo "  PASS: $1"; pass=$((pass+1)); }
+bad()  { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+# ---------------------------------------------------------------------------
+echo "== fixture A: empty maildir (zero mail) =="
+rm -rf "$SRC" "$DST"; mkdir -p "$SRC" "$DST"
+# ext4 lost+found (proves the exclude) + the empty maildir skeleton dovecot lays
+# down with NO messages. This is the live 'zero mail' state.
+mkdir -p "$SRC/lost+found" "$SRC/example.com/alice/Maildir/cur" \
+         "$SRC/example.com/alice/Maildir/new" "$SRC/example.com/alice/Maildir/tmp"
+echo "orphan" >"$SRC/lost+found/#123"
+
+# Show the archive size this state produces with the shipped tar invocation.
+tar czf "$WORK/empty.tar.gz" -C "$SRC" --exclude=./lost+found . 2>/dev/null
+EMPTY_BYTES=$(wc -c < "$WORK/empty.tar.gz" | tr -d ' ')
+echo "  empty-maildir archive is ${EMPTY_BYTES} bytes (live-observed ~130)"
+if [ "$EMPTY_BYTES" -lt 1024 ]; then ok "empty archive is trivially small (< 1024B floor)"; else bad "empty archive unexpectedly >= 1024B"; fi
+
+set +e; out="$(run_backup 2>&1)"; rc=$?; set -e
+echo "$out" | sed 's/^/    | /'
+[ "$rc" -ne 0 ] && ok "job FAILED on empty maildir (exit $rc)" || bad "job passed on empty maildir (should fail)"
+echo "$out" | grep -q "refusing to record a trivial backup" && ok "size gate emitted the refusal" || bad "no size-gate refusal in output"
+ls "$DST"/mail-*.tar.gz >/dev/null 2>&1 && bad "trivial archive was left on disk" || ok "trivial archive was removed, not receipted"
+
+# ---------------------------------------------------------------------------
+echo "== fixture B: populated maildir (real mail) =="
+rm -rf "$SRC" "$DST"; mkdir -p "$SRC" "$DST"
+mkdir -p "$SRC/lost+found" "$SRC/example.com/alice/Maildir/cur"
+echo "orphan" >"$SRC/lost+found/#123"
+MSG="$SRC/example.com/alice/Maildir/cur/1706500000.M1P1.mail:2,S"
+{
+  echo "From: bob@example.com"
+  echo "To: alice@example.com"
+  echo "Subject: Q3 board pack"
+  echo "Date: Tue, 29 Jul 2026 09:00:00 +0000"
+  echo
+  echo "Alice -- attaching the board pack. Regards, Bob"
+  echo
+  # High-entropy blob so the archive is non-trivial even after gzip (models an
+  # attachment); guarantees it clears the 1024-byte floor.
+  head -c 6144 /dev/urandom | base64
+} >"$MSG"
+
+set +e; out="$(run_backup 2>&1)"; rc=$?; set -e
+echo "$out" | sed 's/^/    | /'
+[ "$rc" -eq 0 ] && ok "job SUCCEEDED on populated maildir (exit 0)" || bad "job failed on real mail (should pass)"
+ARCH="$(ls "$DST"/mail-*.tar.gz 2>/dev/null | head -n1 || true)"
+if [ -n "$ARCH" ]; then
+  ok "archive retained: $(basename "$ARCH")"
+  B=$(wc -c < "$ARCH" | tr -d ' '); [ "$B" -ge 1024 ] && ok "real archive is ${B} bytes (>= 1024B floor)" || bad "real archive ${B}B under floor"
+  if tar tzf "$ARCH" | grep -q "lost+found"; then bad "lost+found leaked into the archive"; else ok "lost+found excluded from archive"; fi
+  tar tzf "$ARCH" | grep -q "alice/Maildir/cur" && ok "real mail present in archive" || bad "mail missing from archive"
+else
+  bad "no archive produced for populated maildir"
+fi
+
+echo
+echo "RESULT: ${pass} passed, ${fail} failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What was wrong

None of the estate's PVC definitions had a retention policy. Three concrete cases — all of which look healthy, none of which bound anything.

## `workspace-mail-backup`

A full tarball of `/maildata` every night into a fixed 20Gi volume, deleting nothing. `successfulJobsHistoryLimit: 3` prunes Job *objects*, not tarballs.

It is not already full only because the image it referenced never existed, so the job has never run. **The retention bug is latent, not fixed** — which is why it is fixed here, before it is allowed to schedule.

Now: prune by count (7) and by total size (14GB); **refuse rather than fill** (`MIN_FREE_MB`, exit 1 → Job failure → `KubeJobFailed`, a live alert); verify the archive is readable before declaring success; emit an EvidenceReceipt whose `hash` is the archive digest.

Order matters — prune, preflight, write, verify, receipt. Writing first would need headroom for N+1 backups, which is exactly the margin that does not exist.

**Proved** against seeded fixtures:
```
9 existing -> pruned 3 -> wrote 1 -> 7 retained    (receipt: sha256 of the archive)
refusal    -> status="denied" receipt, nothing written, exit 1
budget     -> prunes until under MAX_TOTAL_MB
```

## `mesh-qdrant` snapshots

Three independent defects mean this CronJob has **never produced a single snapshot**, silently:

- `args:` against `curlimages/curl`, whose `ENTRYPOINT` is `curl` — the container ran `curl /bin/sh -c "<script>"`. The shell never executed.
- hostname `qdrant`, but the Service is `mesh-qdrant`.
- `jq` is not in that image.

It also only ever `POST`ed, never `DELETE`d, so snapshots would have grown without bound had it worked. And qdrant's default `snapshots_path` is `/qdrant/snapshots`, **not on the PVC** — snapshots would have landed on the pod's ephemeral layer and vanished on every restart. So the premise "writes snapshots onto the volume it snapshots" was generous: they went nowhere durable, with no pruning either way.

All four fixed, plus `QDRANT__STORAGE__SNAPSHOTS_PATH` onto the volume so growth is at least visible to the capacity guard.

**Proved** against a mock qdrant API (the StatefulSet is in desired state but has not materialised in-cluster, so this could not be exercised live):
```
9 snapshots + 1 new -> pruned 3 -> 7 retained
unreachable qdrant  -> status="denied" receipt, exit 1
```
That run caught a real bug: the name extractor was anchored to compact JSON and silently returned zero collections against a spaced response — reporting a clean no-op backup. Now whitespace-tolerant.

## `clickhouse` cell analytics

All 7 tables are monthly-partitioned with no `TTL` anywhere, so a `TTL … DELETE` drops whole parts cheaply. Added: 12 months for signal scores and notification metrics, 24 for the reputation / source-quality / feedback facts.

**Proved** by applying the DDL to a scratch database on the live server — all 7 report `HAS TTL` — then dropping it.

## `mesh-xl-cache` — not abandoned

`Used By: <none>` is the **designed steady state**. `deploy/serving/mesh-xl-a100.yaml` documents it: `mesh-vllm-xl` runs at `replicas: 0` for $0 idle, and this 120Gi volume caches model weights so a warm-up reads cache (~2–3 min) instead of re-downloading (~15 min). Annotated on the object so a storage audit does not have to re-derive that from the manifest. **Not deleted.** Idle cost ~USD 13/mo.

## Deliberately NOT fixed here — for Wave 0

**The `cell/` DDL is never applied.** `tools/eval_fabric_migrate.py` globs `"*.sql"` non-recursively, so it never descends into `cell/`. Confirmed empirically — none of the 7 tables exists in the live server, nor do the `eval_fabric` ones; only two `hellgraph` tables created by something else. **The TTL added here is correct but inert until that is fixed.** `tools/` is a live lane, so it is untouched.

**The live `clickhouse-data` exposure is a different table.** It is held by `hellgraph.events` — a `ReplacingMergeTree` with **no `PARTITION BY`** and no TTL, so a TTL would have to rewrite whole parts. 686M/20G today, so not urgent, but it is the actual retention risk on that PVC.

## Coordination

`infra/k8s/workspace-mail/**`, `infra/k8s/mesh-qdrant/**`, `infra/datastores/clickhouse/cell/**`, `deploy/serving/mesh-xl-a100.yaml`. No overlap with #1091, #1105, #1112, #1113, `images.yml`, `infra/k8s/zot/**`, `apps/health-twin/**`, or `tools/`.

⚠️ **Unverified by CI** — Actions is at a spend cap. Validated locally: YAML parse, `kubectl kustomize` on both overlays, and the fixture/mock runs above.