### PR TITLE
iac(tofu): bring environments/* and bootstrap/* to the same offline-validated bar as envs/*

### DIFF
--- a/infra/tofu/bootstrap/aws/.terraform.lock.hcl
+++ b/infra/tofu/bootstrap/aws/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}

--- a/infra/tofu/bootstrap/aws/main.tf
+++ b/infra/tofu/bootstrap/aws/main.tf
@@ -2,12 +2,7 @@
 # Creates the S3 bucket + DynamoDB lock table used by aws-* backend blocks.
 # Uses a local backend here; mirrors infra/terraform/bootstrap/main.tf for the Tofu layer.
 # Never destroy without migrating state first.
-
-terraform {
-  required_providers {
-    aws = { source = "hashicorp/aws", version = "~> 5.0" }
-  }
-}
+# Version pins live in versions.tf.
 
 provider "aws" {
   region = var.region
@@ -46,6 +41,17 @@ resource "aws_s3_bucket_lifecycle_configuration" "tofu_state" {
   rule {
     id     = "expire-old-versions"
     status = "Enabled"
+
+    # An empty filter means "every object in the bucket" — which is what this
+    # rule always intended. Without it aws 5.100.0 emits:
+    #   Warning: Invalid Attribute Combination — No attribute specified when one
+    #   (and only one) of [rule[0].filter, rule[0].prefix] is required.
+    #   This will be an error in a future version of the provider.
+    # bootstrap/aws was the only root in the tree validating with a warning.
+    # `filter {}` is the provider's documented way to say "all objects", so this
+    # records the existing scope rather than narrowing it.
+    filter {}
+
     noncurrent_version_expiration { noncurrent_days = 90 }
   }
 }

--- a/infra/tofu/bootstrap/aws/versions.tf
+++ b/infra/tofu/bootstrap/aws/versions.tf
@@ -1,0 +1,20 @@
+# Version pins for the `bootstrap/aws` root.
+#
+# Moved out of main.tf so every root under infra/tofu/ declares its versions in
+# the same file: envs/*/versions.tf, environments/*/versions.tf, shared/versions.tf.
+#
+# `required_version` was absent here. It was set on all six environments/* roots
+# and, since #1108, on all four envs/* roots — bootstrap/* was the only tier
+# without it, so these three were the only roots an older OpenTofu would happily
+# parse. >= 1.8.0 matches every other root and the TOFU_VERSION (1.8.3) in
+# .github/workflows/tofu-plan.yml.
+#
+# aws stays at 5.x, matching environments/aws-eks. One aws major in the estate.
+
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+  }
+}

--- a/infra/tofu/bootstrap/azure/.terraform.lock.hcl
+++ b/infra/tofu/bootstrap/azure/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/azurerm" {
+  version     = "4.81.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:aV5LUZ6xHHowYZ9tTk0KeMzaDfwrQC4SBntjq+OQIZk=",
+    "h1:oEUfYv79aNXEMu5FhiTgwo9lpHcvKtU1pBNY2rjOCeM=",
+    "h1:v+SZNctpFiplpLtyKK14QfUo+nTOx2TChVGkhMcP4EQ=",
+    "zh:00039b380b581a6a2ceb9f6caf2a9f6a963b50d0cbb63effa6faf7933b4b9324",
+    "zh:0cf3daf3aed4dfc8c3ad9a92113303799ef6977b61e23077173ada1d2355520c",
+    "zh:3244bb91bcb5b5f4bd8f18a149cbb53cee2b286fda33e3934e363bd15360b5c2",
+    "zh:3d2aaf5f8085f5c6514353525c2e60e82942d4fa5c0dca51e461b737468d47c5",
+    "zh:3f93ee9f6066ed22ff1f2fa90bfa0b2a6521bb3c38675b5bc83f217689963a0c",
+    "zh:44f67168d661504c18da6e00c2cc87cd2c57c1d171a348e4e8e5d18953a8a193",
+    "zh:5712823959db99c11f56215afa059cc6fc791ae927fce8ecebba454d9f32c240",
+    "zh:5a85351f237b72e6c2f417e4ff70b96d1f7090012d20cb7655230b60e266e4cf",
+    "zh:63529f04136918ccfa1bb3e081d33e5cbd9d217efb5376d09179f07d5392b1d3",
+    "zh:7a8c870fa01019586065094ed96409836c5e03b4e6d9b8a01623f2632173e880",
+    "zh:a510081c7da2e086cbda0261e86190e7988eb2f078ccac5b3b8d838cbac85c40",
+    "zh:a6ae0f84089f7f86f0a5db29afb35e84804b61cba1413c2fee1af45d450479f2",
+    "zh:d25410d042051ce4f3f35d9eb7127a6693d1969e165ecc12fea7b059b562f2a8",
+    "zh:faf96f32e7bd9bf4886a34635c93e80f512214228531e7548ac5b2e3b93a525d",
+    "zh:fc915f76beaf9afd0934057a5c5a460846dabfeb5a9a1f4d8b7c7f0aacbfffc8",
+  ]
+}

--- a/infra/tofu/bootstrap/azure/main.tf
+++ b/infra/tofu/bootstrap/azure/main.tf
@@ -1,12 +1,7 @@
 # Azure state bootstrap — run once before any other Azure tofu envs.
 # Creates the Storage Account + container that backs the azurerm backend.
 # Never destroy without migrating state first.
-
-terraform {
-  required_providers {
-    azurerm = { source = "hashicorp/azurerm", version = "~> 3.0" }
-  }
-}
+# Version pins live in versions.tf.
 
 provider "azurerm" {
   features {}

--- a/infra/tofu/bootstrap/azure/versions.tf
+++ b/infra/tofu/bootstrap/azure/versions.tf
@@ -1,0 +1,41 @@
+# Version pins for the `bootstrap/azure` root.
+#
+# Moved out of main.tf so every root under infra/tofu/ declares its versions in
+# the same file: envs/*/versions.tf, environments/*/versions.tf, shared/versions.tf.
+#
+# `required_version` was absent here — see the note in bootstrap/aws/versions.tf.
+#
+# azurerm moved ~> 3.0 -> ~> 4.0 (3.117.1 -> 4.81.0), matching
+# environments/azure-aks, which was already on 4.x. Same class of split as the
+# google majors: two azurerm majors in one estate, nothing recording why.
+#
+# Verified at BOTH majors with OpenTofu 1.8.3, clean init, no plugin cache:
+# `tofu validate` returns "Success! The configuration is valid." on 3.117.1 and
+# on 4.81.0, no warnings either side. azurerm 4.0 made provider `subscription_id`
+# mandatory; this root already sets it from var.subscription_id, which is why the
+# move is clean.
+#
+# ⚠️ Surfaced by the move, NOT fixed here: azurerm_storage_container in main.tf
+# sets `storage_account_name`, which 4.x marks deprecated in favour of
+# `storage_account_id` and 5.x is expected to remove. Read off the real schema
+# (`tofu providers schema -json`, azurerm 4.81.0):
+#     storage_account_name -> {"deprecated": true, "optional": true}
+#     storage_account_id   -> {"optional": true}
+# It still validates clean, so this is a dated obligation rather than a break.
+# Swapping the attribute changes which identifier addresses an existing container
+# and can produce a diff on a state that already exists — an apply-time question
+# this offline-validation PR has no way to answer. Left as a follow-up, stated
+# rather than hidden. The deprecation exists in 4.x whether or not this root
+# points at it; the bump surfaces it, it does not create it.
+#
+# Not covered by the evidence above: `tofu plan`/`apply`, which need Azure
+# credentials. Schema compatibility across the major is confirmed; apply-time
+# behaviour is not.
+
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    azurerm = { source = "hashicorp/azurerm", version = "~> 4.0" }
+  }
+}

--- a/infra/tofu/bootstrap/gcp/.terraform.lock.hcl
+++ b/infra/tofu/bootstrap/gcp/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "h1:O5jnIJXJcM6QWNYDPJAeR/yD01GfvrX4q4X6yLg9Afg=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}

--- a/infra/tofu/bootstrap/gcp/main.tf
+++ b/infra/tofu/bootstrap/gcp/main.tf
@@ -2,14 +2,7 @@
 # Creates the GCS bucket that backs all gcp-* backend blocks.
 # Uses a local backend here; migrate to GCS after first apply if desired.
 # Never destroy without migrating state first.
-
-terraform {
-  required_providers {
-    google = { source = "hashicorp/google", version = "~> 5.0" }
-  }
-  # Intentional: this bootstrap itself uses a local state file.
-  # Once applied, all OTHER envs use the GCS bucket we create here.
-}
+# Version pins live in versions.tf.
 
 provider "google" {
   project = var.project_id

--- a/infra/tofu/bootstrap/gcp/versions.tf
+++ b/infra/tofu/bootstrap/gcp/versions.tf
@@ -1,0 +1,34 @@
+# Version pins for the `bootstrap/gcp` root.
+#
+# Moved out of main.tf so every root under infra/tofu/ declares its versions in
+# the same file: envs/*/versions.tf, environments/*/versions.tf, shared/versions.tf.
+#
+# `required_version` was absent here — see the note in bootstrap/aws/versions.tf.
+#
+# google moved ~> 5.0 -> ~> 6.0 (5.45.2 -> 6.50.0).
+#
+# The estate was running three google majors at once with nothing recording why:
+# bootstrap/gcp on 5.x, environments/gcp-{gke,ephemeral,persistent} on 6.x, and
+# envs/* unconstrained and resolving 7.42.0 until #1108 held them at 6.x. Two of
+# those three were accidents rather than decisions. 6.x is the estate's majority
+# and the one #1108 settled on, so bootstrap follows it: one google major, in one
+# place, on purpose.
+#
+# Verified at BOTH majors with OpenTofu 1.8.3, clean init, no plugin cache:
+# `tofu validate` returns "Success! The configuration is valid." on 5.45.2 and on
+# 6.50.0, with no warnings either side. This root creates two resources —
+# google_storage_bucket and google_storage_bucket_iam_member — both long-stable.
+#
+# Not covered by that evidence: `tofu plan`/`apply`, which need GCP credentials.
+# Schema compatibility across the major is confirmed; apply-time behaviour is not.
+
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    google = { source = "hashicorp/google", version = "~> 6.0" }
+  }
+
+  # Intentional: this bootstrap itself uses a local state file.
+  # Once applied, all OTHER envs use the GCS bucket we create here.
+}

--- a/infra/tofu/environments/aws-eks/.terraform.lock.hcl
+++ b/infra/tofu/environments/aws-eks/.terraform.lock.hcl
@@ -1,0 +1,161 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = ">= 4.33.0, ~> 5.0, >= 5.79.0, >= 5.95.0, < 6.0.0"
+  hashes = [
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/cloudinit" {
+  version     = "2.4.0"
+  constraints = ">= 2.0.0, ~> 2.4"
+  hashes = [
+    "h1:84gXpW/AIh12UlZdwGbS9nVubf+p7yF9PqHPtIgyGko=",
+    "h1:Jvn+nE7fuyWfsXcJWCP1OhG1ohzuYs776U4UdjPf59c=",
+    "h1:PMRgZR+2rkcyYT4GTZ6aQN0YWGRGXX/mk+cq6m6pZac=",
+    "zh:1100d08add4583fa0c72ae61a4d90fe7e0e4c912800e8ce40736d5491cca6b94",
+    "zh:25671e5909082cdf564476a309ab958f4948a50819a6faea7f4768d77d4b2866",
+    "zh:27036ecde32c5f2fae4c965938554fc9085e4c04dc9a74f5aae6a91c06f3d738",
+    "zh:2eabfb9a357e21d906e6a4a3cba1299a4494694e90816c5d1c94253161244e4d",
+    "zh:46aff469c48be99db25a17b8aceff980d3253b5c43fe90e11df710d01ed15ef5",
+    "zh:58381b46c91f4dfea37c701896f1b7144373e9bd6fd1a2aaec561f9b69573156",
+    "zh:5e93d4b1600c3af7929eefccf092bf9a4f2a94bd2f29f5a2cebc98eede3fd88c",
+    "zh:67ad0360d17d5a2ade305bd3083caddd3c63b6d692434d249d3b71c6f7fcd0e4",
+    "zh:6e51f558aeb4271923f8822d900f2c8fe56f155f56f022366c22ec80c633e05e",
+    "zh:8be11e71a35964eecbcc36ad47a82dde0f51425567658cb21c9c6d5a9fce0494",
+    "zh:90de8354c3fffb6d0b9b663312652c98011022d0ccfac52900ce148bb263d200",
+    "zh:94c409a472d76e8a90f634dd804ff8399301bca103a7456f74d007d1fb22913f",
+    "zh:9e24975b2c085e1aee74b83799f9f0a3644ffcd9ae0c7d2840929d82153be167",
+    "zh:d24742682a35b618b4012c52a6201fda845dd706fe46e6c08a4611ea6abd6fc4",
+    "zh:ed6b04017882f68e0342b951e5c008e4852c7ed32c7d6fb81ced0437fa0a9742",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.13"
+  hashes = [
+    "h1:69PnHoYrrDrm7C8+8PiSvRGPI55taqL14SvQR/FGM+g=",
+    "h1:ShIag7wqd5Rs+zYpVMpjAh+T0ozr4XGYfSTKWqceQBY=",
+    "h1:ojHGbVqPy4ShrUnNL7jif6AnEwgc8vC8sP7f37/VBC8=",
+    "zh:02690815e35131a42cb9851f63a3369c216af30ad093d05b39001d43da04b56b",
+    "zh:27a62f12b29926387f4d71aeeee9f7ffa0ccb81a1b6066ee895716ad050d1b7a",
+    "zh:2d0a5babfa73604b3fefc9dab9c87f91c77fce756c2e32b294e9f1290aed26c0",
+    "zh:3976400ceba6dda4636e1d297e3097e1831de5628afa534a166de98a70d1dcbe",
+    "zh:54440ef14f342b41d75c1aded7487bfcc3f76322b75894235b47b7e89ac4bfa4",
+    "zh:6512e2ab9f2fa31cbb90d9249647b5c5798f62eb1215ec44da2cdaa24e38ad25",
+    "zh:795f327ca0b8c5368af0ed03d5d4f6da7260692b4b3ca0bd004ed542e683464d",
+    "zh:ba659e1d94f224bc3f1fd34cbb9d2663e3a8e734108e5a58eb49eda84b140978",
+    "zh:c5c8575c4458835c2acbc3d1ed5570589b14baa2525d8fbd04295c097caf41eb",
+    "zh:e0877a5dac3de138e61eefa26b2f5a13305a17259779465899880f70e11314e0",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.30"
+  hashes = [
+    "h1:ems+O2dA7atxMWpbtqIrsH7Oa+u+ERWSfpMaFnZPbh0=",
+    "h1:iEDf790HE0h3kz58zfj5IhTVODCDqWF1hISPHz210Uw=",
+    "h1:nY7J9jFXcsRINog0KYagiWZw1GVYF9D2JmtIB7Wnrao=",
+    "zh:1096b41c4e5b2ee6c1980916fb9a8579bc1892071396f7a9432be058aabf3cbc",
+    "zh:2959fde9ae3d1deb5e317df0d7b02ea4977951ee6b9c4beb083c148ca8f3681c",
+    "zh:5082f98fcb3389c73339365f7df39fc6912bf2bd1a46d5f97778f441a67fd337",
+    "zh:620fd5d0fbc2d7a24ac6b420a4922e6093020358162a62fa8cbd37b2bac1d22e",
+    "zh:7f47c2de179bba35d759147c53082cad6c3449d19b0ec0c5a4ca8db5b06393e1",
+    "zh:89c3aa2a87e29febf100fd21cead34f9a4c0e6e7ae5f383b5cef815c677eb52a",
+    "zh:96eecc9f94938a0bc35b8a63d2c4a5f972395e44206620db06760b730d0471fc",
+    "zh:e15567c1095f898af173c281b66bffdc4f3068afdd9f84bb5b5b5521d9f29584",
+    "zh:ecc6b912629734a9a41a7cf1c4c73fb13b4b510afc9e7b2e0011d290bcd6d77f",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = ">= 3.0.0, ~> 3.2"
+  hashes = [
+    "h1:0r7+t8CqzjfBgHgEiJGBCw+McEUdRXliMdF+Hk29d8o=",
+    "h1:eODLdk/pARc4yxChAFtwseVmBr+r5fF9yGOvUhwGEyM=",
+    "h1:mdu+qpyVmjDDLMrcL1JFy+cSyF58I3TFJwB5NssCZ58=",
+    "zh:083dcc0bec53f8abfa3f2aa2ce9d732a9675338fd60ae7d61162e25db7cb08bf",
+    "zh:19f7456b5a2ad16595860974714bfdb25b87bc16356ea9d5c7453892aaa27864",
+    "zh:222c0ed1fed4e4c677ebe626104dbfdba66763e264de0d9c27c58ce60104ee69",
+    "zh:271711d6caa7dd5a4e9b79fe8c679fab61a840bcf80040a0f5ebb425d1b27d97",
+    "zh:5adcf35f30baaea13f80c2a2c774deb9369892719493049687e23476c9dff40f",
+    "zh:5bcfd19df16e73d7f0ad75bd09e2b3b86cf6700d09822d585d68304b71de1d97",
+    "zh:604edecf263e38674decb35bb4e0e048fdc951f26fa103c33065ff9728f0313b",
+    "zh:782acbfb4fa4807e273e588fe45b4aaea9dd0fd1136f76ec3200f6f4db3af8d6",
+    "zh:84411a596d528fe67294e5c1cfd0c2036b08802497bcc4215ce518924f3c9a4a",
+    "zh:85e79eecf3f5348975cffec3016b0eba3baf605646102d4348796ccd2df2e5f6",
+    "zh:95669535ca17aeefef307ebfd59ce6930953173baae5637e8cbbf0297ec7ad58",
+    "zh:d04d9b177747bfd66b4a45b5d911a2a7822aa8451f5e35621971fb7a4206b530",
+    "zh:e6d9c924475283e90833450a14a732f4deb6d9bb131db8f86ab856e894270836",
+    "zh:ebcab0c8a1334c86ed7cfa53f571a17ad6d27e9901f27a8854ea622a74b54bb6",
+    "zh:ef9c757bb2c83d2103811a3d86b6ec5be06b0ffc337b84db1582d023bce7cdcd",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = ">= 0.9.0, ~> 0.14"
+  hashes = [
+    "h1:CQIlkT9lxTbVH4cxqXCx82pZKQEzOkLpT46RsxD/HYk=",
+    "h1:nXb/PVTFSacCYD6BQnTsgKPEUOGIVOgociSAE2iWN/c=",
+    "h1:sHruA5X0bMk1a9152XBk0E6F1TMsOwXcqMEIDm4dk4Y=",
+    "zh:155688768de4c53bc6523c5fed46aa4a74c8fc8cab25ea808ce2ff24e2f5ae83",
+    "zh:1af6716fa8e7c4fd8be408ff2ff6ee12759171bb128d162f9926ad32cb0ffa49",
+    "zh:1be2795c86651fd1d87fffba6013086d56890ce6db1f541ae2ba9404db24d4a6",
+    "zh:2fb4a1dfaf37d452ce5981925215dd0e0f6c89733a3c97c8f78307a05765939a",
+    "zh:5986f66d98602017953257ef51bb6396d2bc648ebcaf8feb9c088b3585ff2195",
+    "zh:6047a3daafe8ce495aef249a128ba4002aca334b811bafddea521ebca03b11dc",
+    "zh:6e0be9e14223fe21bf38ba723026d2eee2dc1e5dfab6f7fc4d31bfa8c19a7543",
+    "zh:7d391e37de3043bc4aad2a51146154ac9a63022527524136880807cf8addc719",
+    "zh:7d9726369f062243ffc474068f56cb315911250f73e03fa3d63833293e092d1a",
+    "zh:905790b553654aa66db59d5efda57ae207f72ade11677983c0849a83f4f7969b",
+    "zh:a24165685313941779a0be04c36ddbc33836f26b8a5a9198eb01dbb1e339dda8",
+    "zh:a4228f0edd34868696077710200409936963ae93f3cf108bce3ec6b936e458b6",
+    "zh:b82a35e7b7ef55bc329a6dc084d19d034ff9cc9372d904f4134c6ec9cc3a1ca3",
+    "zh:c00432d129e4ddfa5e986aa872d442e918496c118a04b3b259b167ca40257575",
+    "zh:f804b662a4c82dfa241ae9ddc9cb35b7c197e7e97a578cef4dc425a4002eadf1",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/tls" {
+  version     = "4.3.0"
+  constraints = ">= 3.0.0, ~> 4.0"
+  hashes = [
+    "h1:SGBiqFFxGryTOiaNNWlC7CCba1hjSsSwcJeg6rOLJrc=",
+    "h1:ZxKvDInYHzss9rv75M778pInFm08ME6hY31XMyFP4IA=",
+    "h1:mmFJoeY9KBishP/zH8vvtpDekcqiYucgUGUnErhECAY=",
+    "zh:07bb8c6e64124dada7dff57a38a46f2f323b3fd77920404c0c550293d1cf6188",
+    "zh:0b3bfda2df39c52f1c5452d05cf3107bedd5d20ab6977c90ede540c695fb6c3e",
+    "zh:110a055289f0400a63ac172bedb0e671d059b7a5ba22d4a3f5f246ccac0ad676",
+    "zh:15e532d8c711377499dece832e60170a8bef39830125b8154f4bda81d9721d29",
+    "zh:22ca65d96e9fc1be5605372d855c9e1eba2d86d510f7ac8593968f5649435e47",
+    "zh:36df38dfd03e8c1298c5704fd85e28b69a3927ed0b339f9628d0b56dac99c6b5",
+    "zh:429e2bfcb81656e1fe90b7b284767d1453c1a4100b16d27e4b29c34aa12f0ce1",
+    "zh:5b6679953065f0279bf018426c6fb06dd93a851a7a9369f2e3a1fec5bc417e83",
+    "zh:6a72c88d5aa945ddb32041350755377c96681563136decfe7e05c7cdea7988f1",
+    "zh:6f05757c50da9f8354a735b5756bd63a71126fcd142129525b90c56bfd081d61",
+    "zh:751703b7a4d40c3a111c4ed0d5da3ec91c14f880faf6f010a5000a2eb5366011",
+    "zh:87a5279e61b8198798a2fe86cfe3b74e5340bb486f4e148bb5b4d46f860cf1db",
+    "zh:942af95e9fd73327a7e9ab0803c4d701b782ddacd78c9b7ce9c91e38b3051522",
+    "zh:a457d0efea3c404178a182d240ba21cdeb0c620ffabeeb9a8977b024a85e1360",
+    "zh:d5eac8f4f0ae1ff41cbcc1008e6a74a8491dc27f4c6e5a0c32c5c4b6ef2e4087",
+  ]
+}

--- a/infra/tofu/environments/aws-eks/versions.tf
+++ b/infra/tofu/environments/aws-eks/versions.tf
@@ -4,6 +4,18 @@ terraform {
     aws        = { source = "hashicorp/aws", version = "~> 5.0" }
     helm       = { source = "hashicorp/helm", version = "~> 2.13" }
     kubernetes = { source = "hashicorp/kubernetes", version = "~> 2.30" }
+
+    # Pulled in transitively by terraform-aws-modules/{vpc,eks}, which constrain
+    # them with a floor and no ceiling: tls >= 3.0.0, time >= 0.9.0,
+    # cloudinit >= 2.0.0, null >= 3.0.0. A floor-only constraint is not a pin —
+    # tls was resolving 4.3.0, a full major above its stated minimum, and would
+    # have crossed into 5.x unannounced the day it shipped. Declaring them here
+    # adds the missing ceiling; the committed lock then fixes the exact build.
+    # tls and null match the constraints already written in shared/versions.tf.
+    cloudinit = { source = "hashicorp/cloudinit", version = "~> 2.4" }
+    null      = { source = "hashicorp/null", version = "~> 3.2" }
+    time      = { source = "hashicorp/time", version = "~> 0.14" }
+    tls       = { source = "hashicorp/tls", version = "~> 4.0" }
   }
   # backend "s3" { ... }  # configure per your state bucket, or run local first
 }

--- a/infra/tofu/environments/azure-aks/.terraform.lock.hcl
+++ b/infra/tofu/environments/azure-aks/.terraform.lock.hcl
@@ -1,0 +1,66 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/azurerm" {
+  version     = "4.81.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:aV5LUZ6xHHowYZ9tTk0KeMzaDfwrQC4SBntjq+OQIZk=",
+    "h1:oEUfYv79aNXEMu5FhiTgwo9lpHcvKtU1pBNY2rjOCeM=",
+    "h1:v+SZNctpFiplpLtyKK14QfUo+nTOx2TChVGkhMcP4EQ=",
+    "zh:00039b380b581a6a2ceb9f6caf2a9f6a963b50d0cbb63effa6faf7933b4b9324",
+    "zh:0cf3daf3aed4dfc8c3ad9a92113303799ef6977b61e23077173ada1d2355520c",
+    "zh:3244bb91bcb5b5f4bd8f18a149cbb53cee2b286fda33e3934e363bd15360b5c2",
+    "zh:3d2aaf5f8085f5c6514353525c2e60e82942d4fa5c0dca51e461b737468d47c5",
+    "zh:3f93ee9f6066ed22ff1f2fa90bfa0b2a6521bb3c38675b5bc83f217689963a0c",
+    "zh:44f67168d661504c18da6e00c2cc87cd2c57c1d171a348e4e8e5d18953a8a193",
+    "zh:5712823959db99c11f56215afa059cc6fc791ae927fce8ecebba454d9f32c240",
+    "zh:5a85351f237b72e6c2f417e4ff70b96d1f7090012d20cb7655230b60e266e4cf",
+    "zh:63529f04136918ccfa1bb3e081d33e5cbd9d217efb5376d09179f07d5392b1d3",
+    "zh:7a8c870fa01019586065094ed96409836c5e03b4e6d9b8a01623f2632173e880",
+    "zh:a510081c7da2e086cbda0261e86190e7988eb2f078ccac5b3b8d838cbac85c40",
+    "zh:a6ae0f84089f7f86f0a5db29afb35e84804b61cba1413c2fee1af45d450479f2",
+    "zh:d25410d042051ce4f3f35d9eb7127a6693d1969e165ecc12fea7b059b562f2a8",
+    "zh:faf96f32e7bd9bf4886a34635c93e80f512214228531e7548ac5b2e3b93a525d",
+    "zh:fc915f76beaf9afd0934057a5c5a460846dabfeb5a9a1f4d8b7c7f0aacbfffc8",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.13"
+  hashes = [
+    "h1:69PnHoYrrDrm7C8+8PiSvRGPI55taqL14SvQR/FGM+g=",
+    "h1:ShIag7wqd5Rs+zYpVMpjAh+T0ozr4XGYfSTKWqceQBY=",
+    "h1:ojHGbVqPy4ShrUnNL7jif6AnEwgc8vC8sP7f37/VBC8=",
+    "zh:02690815e35131a42cb9851f63a3369c216af30ad093d05b39001d43da04b56b",
+    "zh:27a62f12b29926387f4d71aeeee9f7ffa0ccb81a1b6066ee895716ad050d1b7a",
+    "zh:2d0a5babfa73604b3fefc9dab9c87f91c77fce756c2e32b294e9f1290aed26c0",
+    "zh:3976400ceba6dda4636e1d297e3097e1831de5628afa534a166de98a70d1dcbe",
+    "zh:54440ef14f342b41d75c1aded7487bfcc3f76322b75894235b47b7e89ac4bfa4",
+    "zh:6512e2ab9f2fa31cbb90d9249647b5c5798f62eb1215ec44da2cdaa24e38ad25",
+    "zh:795f327ca0b8c5368af0ed03d5d4f6da7260692b4b3ca0bd004ed542e683464d",
+    "zh:ba659e1d94f224bc3f1fd34cbb9d2663e3a8e734108e5a58eb49eda84b140978",
+    "zh:c5c8575c4458835c2acbc3d1ed5570589b14baa2525d8fbd04295c097caf41eb",
+    "zh:e0877a5dac3de138e61eefa26b2f5a13305a17259779465899880f70e11314e0",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.30"
+  hashes = [
+    "h1:ems+O2dA7atxMWpbtqIrsH7Oa+u+ERWSfpMaFnZPbh0=",
+    "h1:iEDf790HE0h3kz58zfj5IhTVODCDqWF1hISPHz210Uw=",
+    "h1:nY7J9jFXcsRINog0KYagiWZw1GVYF9D2JmtIB7Wnrao=",
+    "zh:1096b41c4e5b2ee6c1980916fb9a8579bc1892071396f7a9432be058aabf3cbc",
+    "zh:2959fde9ae3d1deb5e317df0d7b02ea4977951ee6b9c4beb083c148ca8f3681c",
+    "zh:5082f98fcb3389c73339365f7df39fc6912bf2bd1a46d5f97778f441a67fd337",
+    "zh:620fd5d0fbc2d7a24ac6b420a4922e6093020358162a62fa8cbd37b2bac1d22e",
+    "zh:7f47c2de179bba35d759147c53082cad6c3449d19b0ec0c5a4ca8db5b06393e1",
+    "zh:89c3aa2a87e29febf100fd21cead34f9a4c0e6e7ae5f383b5cef815c677eb52a",
+    "zh:96eecc9f94938a0bc35b8a63d2c4a5f972395e44206620db06760b730d0471fc",
+    "zh:e15567c1095f898af173c281b66bffdc4f3068afdd9f84bb5b5b5521d9f29584",
+    "zh:ecc6b912629734a9a41a7cf1c4c73fb13b4b510afc9e7b2e0011d290bcd6d77f",
+  ]
+}

--- a/infra/tofu/environments/gcp-ephemeral/.gitignore
+++ b/infra/tofu/environments/gcp-ephemeral/.gitignore
@@ -1,4 +1,9 @@
 .terraform/
-.terraform.lock.hcl
 *.tfstate
 *.tfstate.*
+
+# .terraform.lock.hcl was ignored here as well as in infra/tofu/.gitignore.
+# A nested .gitignore overrides its parent, so un-ignoring the lock at
+# infra/tofu/.gitignore (#1108) does NOT reach this directory — the lock would
+# have been dropped silently by `git add`. Removed so the committed lock sticks.
+# Ephemeral state stays ignored: the lock pins the provider build, not the state.

--- a/infra/tofu/environments/gcp-ephemeral/.terraform.lock.hcl
+++ b/infra/tofu/environments/gcp-ephemeral/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "h1:O5jnIJXJcM6QWNYDPJAeR/yD01GfvrX4q4X6yLg9Afg=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.13"
+  hashes = [
+    "h1:69PnHoYrrDrm7C8+8PiSvRGPI55taqL14SvQR/FGM+g=",
+    "h1:ShIag7wqd5Rs+zYpVMpjAh+T0ozr4XGYfSTKWqceQBY=",
+    "h1:ojHGbVqPy4ShrUnNL7jif6AnEwgc8vC8sP7f37/VBC8=",
+    "zh:02690815e35131a42cb9851f63a3369c216af30ad093d05b39001d43da04b56b",
+    "zh:27a62f12b29926387f4d71aeeee9f7ffa0ccb81a1b6066ee895716ad050d1b7a",
+    "zh:2d0a5babfa73604b3fefc9dab9c87f91c77fce756c2e32b294e9f1290aed26c0",
+    "zh:3976400ceba6dda4636e1d297e3097e1831de5628afa534a166de98a70d1dcbe",
+    "zh:54440ef14f342b41d75c1aded7487bfcc3f76322b75894235b47b7e89ac4bfa4",
+    "zh:6512e2ab9f2fa31cbb90d9249647b5c5798f62eb1215ec44da2cdaa24e38ad25",
+    "zh:795f327ca0b8c5368af0ed03d5d4f6da7260692b4b3ca0bd004ed542e683464d",
+    "zh:ba659e1d94f224bc3f1fd34cbb9d2663e3a8e734108e5a58eb49eda84b140978",
+    "zh:c5c8575c4458835c2acbc3d1ed5570589b14baa2525d8fbd04295c097caf41eb",
+    "zh:e0877a5dac3de138e61eefa26b2f5a13305a17259779465899880f70e11314e0",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.30"
+  hashes = [
+    "h1:ems+O2dA7atxMWpbtqIrsH7Oa+u+ERWSfpMaFnZPbh0=",
+    "h1:iEDf790HE0h3kz58zfj5IhTVODCDqWF1hISPHz210Uw=",
+    "h1:nY7J9jFXcsRINog0KYagiWZw1GVYF9D2JmtIB7Wnrao=",
+    "zh:1096b41c4e5b2ee6c1980916fb9a8579bc1892071396f7a9432be058aabf3cbc",
+    "zh:2959fde9ae3d1deb5e317df0d7b02ea4977951ee6b9c4beb083c148ca8f3681c",
+    "zh:5082f98fcb3389c73339365f7df39fc6912bf2bd1a46d5f97778f441a67fd337",
+    "zh:620fd5d0fbc2d7a24ac6b420a4922e6093020358162a62fa8cbd37b2bac1d22e",
+    "zh:7f47c2de179bba35d759147c53082cad6c3449d19b0ec0c5a4ca8db5b06393e1",
+    "zh:89c3aa2a87e29febf100fd21cead34f9a4c0e6e7ae5f383b5cef815c677eb52a",
+    "zh:96eecc9f94938a0bc35b8a63d2c4a5f972395e44206620db06760b730d0471fc",
+    "zh:e15567c1095f898af173c281b66bffdc4f3068afdd9f84bb5b5b5521d9f29584",
+    "zh:ecc6b912629734a9a41a7cf1c4c73fb13b4b510afc9e7b2e0011d290bcd6d77f",
+  ]
+}

--- a/infra/tofu/environments/gcp-gke/.terraform.lock.hcl
+++ b/infra/tofu/environments/gcp-gke/.terraform.lock.hcl
@@ -1,0 +1,81 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "h1:O5jnIJXJcM6QWNYDPJAeR/yD01GfvrX4q4X6yLg9Afg=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:+hUxBwXLP3XadzrFEtVYM7qZ/0wChqJHQbtacAWw76s=",
+    "h1:MklYYZlCefCzM5jrAUYHdY+4nOsyCDIvygcL1u79e94=",
+    "h1:t5b8qSJkvi4QALUqqDf17y9e7OBXd1liUyOebVst0YM=",
+    "zh:29d310cfbc3ff8c5c7b3c18d713ced4b4fa66efaffeefc948702771f3723b90d",
+    "zh:41dcd4804b25e396970ba93f898835d2044cde4afc3d3fb4f727d48be5f6df7c",
+    "zh:41f8082aacd9cc6b3d0f3b9f9c9c8ce3337d3d55060c50e92a0ccc695047c494",
+    "zh:552daf0e06d5ab4f7ebc4fb4783d2f408ed9d077cd1ee051edcbeda5f5da65cf",
+    "zh:6de2ba0d713bdc02e13e261cc71cd083cdc7532135749e53595b7b709f668125",
+    "zh:6fdfdeabcdaa7f8edb7311f4edf50ba67904628117567957c17a3cc68a78b113",
+    "zh:753fab77e80f24f066e0a1f8c9a00f6a85c9e428f7c45c27ca91d6d8240f357c",
+    "zh:813905d3b03839fdc11218e3e384cb80e7de753549ed7857e32007a20fbca4c5",
+    "zh:8e75bf1b6b8e48be515c27248f7e70f9c833456b6bf6acd89613d7ef98d48e19",
+    "zh:e723909015b30d930a8ebf7242c463af332aa09b11c6892aedbe79e2f8b2647c",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.13"
+  hashes = [
+    "h1:69PnHoYrrDrm7C8+8PiSvRGPI55taqL14SvQR/FGM+g=",
+    "h1:ShIag7wqd5Rs+zYpVMpjAh+T0ozr4XGYfSTKWqceQBY=",
+    "h1:ojHGbVqPy4ShrUnNL7jif6AnEwgc8vC8sP7f37/VBC8=",
+    "zh:02690815e35131a42cb9851f63a3369c216af30ad093d05b39001d43da04b56b",
+    "zh:27a62f12b29926387f4d71aeeee9f7ffa0ccb81a1b6066ee895716ad050d1b7a",
+    "zh:2d0a5babfa73604b3fefc9dab9c87f91c77fce756c2e32b294e9f1290aed26c0",
+    "zh:3976400ceba6dda4636e1d297e3097e1831de5628afa534a166de98a70d1dcbe",
+    "zh:54440ef14f342b41d75c1aded7487bfcc3f76322b75894235b47b7e89ac4bfa4",
+    "zh:6512e2ab9f2fa31cbb90d9249647b5c5798f62eb1215ec44da2cdaa24e38ad25",
+    "zh:795f327ca0b8c5368af0ed03d5d4f6da7260692b4b3ca0bd004ed542e683464d",
+    "zh:ba659e1d94f224bc3f1fd34cbb9d2663e3a8e734108e5a58eb49eda84b140978",
+    "zh:c5c8575c4458835c2acbc3d1ed5570589b14baa2525d8fbd04295c097caf41eb",
+    "zh:e0877a5dac3de138e61eefa26b2f5a13305a17259779465899880f70e11314e0",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.30"
+  hashes = [
+    "h1:ems+O2dA7atxMWpbtqIrsH7Oa+u+ERWSfpMaFnZPbh0=",
+    "h1:iEDf790HE0h3kz58zfj5IhTVODCDqWF1hISPHz210Uw=",
+    "h1:nY7J9jFXcsRINog0KYagiWZw1GVYF9D2JmtIB7Wnrao=",
+    "zh:1096b41c4e5b2ee6c1980916fb9a8579bc1892071396f7a9432be058aabf3cbc",
+    "zh:2959fde9ae3d1deb5e317df0d7b02ea4977951ee6b9c4beb083c148ca8f3681c",
+    "zh:5082f98fcb3389c73339365f7df39fc6912bf2bd1a46d5f97778f441a67fd337",
+    "zh:620fd5d0fbc2d7a24ac6b420a4922e6093020358162a62fa8cbd37b2bac1d22e",
+    "zh:7f47c2de179bba35d759147c53082cad6c3449d19b0ec0c5a4ca8db5b06393e1",
+    "zh:89c3aa2a87e29febf100fd21cead34f9a4c0e6e7ae5f383b5cef815c677eb52a",
+    "zh:96eecc9f94938a0bc35b8a63d2c4a5f972395e44206620db06760b730d0471fc",
+    "zh:e15567c1095f898af173c281b66bffdc4f3068afdd9f84bb5b5b5521d9f29584",
+    "zh:ecc6b912629734a9a41a7cf1c4c73fb13b4b510afc9e7b2e0011d290bcd6d77f",
+  ]
+}

--- a/infra/tofu/environments/gcp-persistent/.gitignore
+++ b/infra/tofu/environments/gcp-persistent/.gitignore
@@ -1,5 +1,10 @@
 # Local tofu state (durable — back up terraform.tfstate out-of-band, e.g. to the backups bucket)
 .terraform/
-.terraform.lock.hcl
 *.tfstate
 *.tfstate.*
+
+# .terraform.lock.hcl was ignored here as well as in infra/tofu/.gitignore.
+# A nested .gitignore overrides its parent, so un-ignoring the lock at
+# infra/tofu/.gitignore (#1108) does NOT reach this directory — the lock would
+# have been dropped silently by `git add`. Removed so the committed lock sticks.
+# Local state stays ignored; the lock pins the provider build, not the state.

--- a/infra/tofu/environments/gcp-persistent/.terraform.lock.hcl
+++ b/infra/tofu/environments/gcp-persistent/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:IH3uigEekXZECc3XgxC771MS1u32uWq5RHmZtVBsau8=",
+    "h1:MAAe4zFFdqS9M5rpmJK/vKgdb6ZMD/s/0Xd97yTDipA=",
+    "h1:O5jnIJXJcM6QWNYDPJAeR/yD01GfvrX4q4X6yLg9Afg=",
+    "zh:1d4695f807d998f11fcdcfa174766287b82a8093513af857bcdad2d81c642480",
+    "zh:3173ac5df0294624d113812e49e2a55714aff7db617488168cecdf4168df9e29",
+    "zh:34d2b3d44c23bd6354fc4ab5917b302872ea1ab8de107034567f955b1717fa5b",
+    "zh:3a77f3cc2f3664cd5aaeeef4d044e6ec1695a079588fffec3ca03953664e5f04",
+    "zh:6b444e4b629ea8dc8cb112a39dde098dc5584d26d6de4177558f556a9a226696",
+    "zh:96545c8cd4d3a57069c5d1799eab5aedd887e16d98b5559a195f6d2c2d9bc674",
+    "zh:ba464caafde95ee16671d6b5ec90f053ed77a9d06c567456db6efd9160fa3165",
+    "zh:d876938e5b0d3f57a984d9be72467995f87fef6569968623415dc51d9f54d30b",
+    "zh:dfd908d873e314ab807d0abc9cfd42d2611cd06dc1b9ec719ebdbb738e8e68d6",
+    "zh:f9f16819a7738d564afd45fd169ba61004ec4e4e7089d2a4950cb8895be1fe1f",
+  ]
+}


### PR DESCRIPTION
Stacked on **#1108** (`fix/tofu-provider-pinning`). Retarget to `main` once that lands.

> The stack is not optional. #1108 removes `.terraform.lock.hcl` from `infra/tofu/.gitignore`; without that line gone, every lock file in this PR is silently dropped by `git add`. Basing on `main` would have meant either editing `.gitignore` too — a direct conflict with #1108's only shared file — or `git add -f`, which leaves eight tracked files that `.gitignore` still claims to ignore. Stacking avoids both.

## The decision this implements

> *"we should have the 4 providers on same ground, but we don't need to run live connections to their clouds."* — Michael

So the bar is **offline-validated IaC**, uniformly: `required_version` present, `required_providers` pinned, lock committed, `tofu init -backend=false && tofu validate` clean. Live `plan`/`apply`, credentials, and federation are explicitly out of scope, and **no credential path needs to work.**

#1108 met that bar for the four `envs/*` roots CI validates and deliberately left the other nine unlocked. This is the remaining gap: six `environments/*` and three `bootstrap/*`.

## Parity matrix

All measurement with **OpenTofu 1.8.3** — the `TOFU_VERSION` in `tofu-plan.yml` — from a clean `.terraform`, no plugin cache, `tofu init -backend=false && tofu validate`.

**Before** (`origin/main` @ `55a3d086`):

| root | `required_version` | `required_providers` | lock committed | init | validate |
|---|---|---|---|---|---|
| `envs/gcp-landing` | ❌ | ❌ | ❌ | **FAIL** | **FAIL** |
| `envs/shared` | ❌ | ❌ | ❌ | ok | ok |
| `envs/prod` | ❌ | ❌ | ❌ | ok | ok |
| `environments/aws-eks` | ✅ | ⚠️ partial | ❌ | ok | ok |
| `environments/azure-aks` | ✅ | ✅ | ❌ | ok | ok |
| `environments/gcp-ephemeral` | ✅ | ✅ | ❌ | ok | ok |
| `environments/gcp-gke` | ✅ | ✅ | ❌ | ok | ok |
| `environments/gcp-persistent` | ✅ | ✅ | ❌ | ok | ok |
| `environments/ibm-iks` | ✅ | ✅ | ❌ | **FAIL** | **FAIL** |
| `bootstrap/aws` | ❌ | ✅ | ❌ | ok | **ok + warning** |
| `bootstrap/azure` | ❌ | ✅ | ❌ | ok | ok |
| `bootstrap/gcp` | ❌ | ✅ | ❌ | ok | ok |

`aws-eks` is "partial" because three of its seven providers were undeclared — see the transitive section.

**After** (this PR, on top of #1108):

| root | `required_version` | `required_providers` | lock committed | init | validate |
|---|---|---|---|---|---|
| `envs/gcp-landing` | ✅ | ✅ | ✅ | FAIL *(#1103)* | FAIL *(#1103)* |
| `envs/shared` | ✅ | ✅ | ✅ | ok | ok |
| `envs/prod` | ✅ | ✅ | ✅ | ok | ok |
| `environments/aws-eks` | ✅ | ✅ | ✅ **new** | ok | ok |
| `environments/azure-aks` | ✅ | ✅ | ✅ **new** | ok | ok |
| `environments/gcp-ephemeral` | ✅ | ✅ | ✅ **new** | ok | ok |
| `environments/gcp-gke` | ✅ | ✅ | ✅ **new** | ok | ok |
| `environments/gcp-persistent` | ✅ | ✅ | ✅ **new** | ok | ok |
| `environments/ibm-iks` | ✅ | ✅ | ❌ *(#1107)* | FAIL *(#1103)* | FAIL *(#1107)* |
| `bootstrap/aws` | ✅ **new** | ✅ | ✅ **new** | ok | **ok, warning gone** |
| `bootstrap/azure` | ✅ **new** | ✅ | ✅ **new** | ok | ok |
| `bootstrap/gcp` | ✅ **new** | ✅ | ✅ **new** | ok | ok |

The two remaining FAILs are inherited, not caused: `gcp-landing` is #1103's parse error and `ibm-iks` is #1103 + #1107. Neither is touched here.

**End state, all four lanes merged locally** (#1103 + #1107 + #1108 + this, merged clean, measured, then discarded):

| root | init | validate | | root | init | validate |
|---|---|---|---|---|---|---|
| `envs/local` | ok | ok | | `environments/gcp-ephemeral` | ok | ok |
| `envs/gcp-landing` | ok | ok | | `environments/gcp-gke` | ok | ok |
| `envs/shared` | ok | ok | | `environments/gcp-persistent` | ok | ok |
| `envs/prod` | ok | ok | | `environments/ibm-iks` | ok | ok |
| `shared/` | ok | ok | | `bootstrap/aws` | ok | ok |
| `environments/aws-eks` | ok | ok | | `bootstrap/azure` | ok | ok |
| `environments/azure-aks` | ok | ok | | `bootstrap/gcp` | ok | ok |

**14 of 14 roots clean, zero warnings**, and `tofu fmt -check -recursive infra/tofu/` → **exit 0**. That is the parity Michael asked for, and it needs all four PRs.

## The four asymmetries

### 1. Three google majors — decided: one, at 6.x

`bootstrap/gcp` was on `~> 5.0`, `environments/gcp-*` on `~> 6.0`, `envs/*` unconstrained and resolving **7.42.0** until #1108 held them at 6.x. Nothing recorded whether any of that was intended. Two of the three were clearly accidents: `envs/*` had no constraint at all, and `shared/versions.tf` documented a `~> 6.0` pin it could not apply to anything.

**`bootstrap/gcp` moves to `~> 6.0`.** 6.x is the majority and the version #1108 settled on, so bootstrap follows rather than the estate splitting the difference.

⚠️ **This changes a resolved major: google 5.45.2 → 6.50.0.** Validated at **both**, clean init, no plugin cache:

```
bootstrap/gcp @ ~> 5.0  → hashicorp/google v5.45.2 → Success! The configuration is valid.  exit 0
bootstrap/gcp @ ~> 6.0  → hashicorp/google v6.50.0 → Success! The configuration is valid.  exit 0
```

No warnings either side. The root creates two long-stable resources (`google_storage_bucket`, `google_storage_bucket_iam_member`).

### 2. Two azurerm majors — same call, same evidence

Not on the brief's list, but it is the identical defect: `bootstrap/azure` on `~> 3.0` while `environments/azure-aks` was already on `~> 4.0`. **Moves to `~> 4.0`.**

⚠️ **Also a resolved-major change: azurerm 3.117.1 → 4.81.0.** Validated at both:

```
bootstrap/azure @ ~> 3.0  → hashicorp/azurerm v3.117.1 → Success! The configuration is valid.  exit 0
bootstrap/azure @ ~> 4.0  → hashicorp/azurerm v4.81.0  → Success! The configuration is valid.  exit 0
```

azurerm 4.0 made provider `subscription_id` mandatory; this root already sets it from `var.subscription_id`, which is why the move is clean.

**Surfaced by the bump, deliberately not fixed:** `azurerm_storage_container` sets `storage_account_name`, which 4.x deprecates and 5.x is expected to remove. Read off the real schema rather than from memory — `tofu providers schema -json`, azurerm 4.81.0:

```
storage_account_name -> {"deprecated": true, "optional": true}
storage_account_id   -> {"optional": true}
```

Swapping the attribute changes which identifier addresses an existing container and can produce a diff against state that already exists — an apply-time question this PR has no way to answer offline. The deprecation exists in 4.x whether or not this root points at it; the bump surfaces it, it does not create it. Filed, not hidden.

### 3. `bootstrap/*` had no `required_version`

It was the only tier without one — all six `environments/*` had it, and #1108 gave it to all four `envs/*`. These three were the only roots an older OpenTofu would happily parse.

The `terraform {}` block moves out of `main.tf` into a **`versions.tf`** in each bootstrap root, carrying `required_version = ">= 1.8.0"`. That is not cosmetic: after this, **all 14 roots declare versions in the same filename**, which is what makes the matrix above checkable by looking rather than by grepping. `provider` blocks stay in `main.tf`, matching `envs/*` post-#1108.

### 4. `environments/aws-eks` transitive constraints — the sharpest one

`terraform-aws-modules/{vpc,eks}` require four providers the root never declared, all with a **floor and no ceiling**. Straight from `init`:

```
- Finding hashicorp/tls versions matching ">= 3.0.0"...        → installed 4.3.0
- Finding hashicorp/time versions matching ">= 0.9.0"...       → installed 0.14.0
- Finding hashicorp/cloudinit versions matching ">= 2.0.0"...  → installed 2.4.0
- Finding hashicorp/null versions matching ">= 3.0.0"...       → installed 3.3.0
```

**`tls` was resolving 4.3.0 against a floor of 3.0.0** — already a full major above its stated minimum, and it would have crossed into 5.x unannounced on the day 5.0 shipped. A floor without a ceiling is not a pin, and no amount of local pinning of `aws`/`helm`/`kubernetes` constrained these.

All four are now declared at the root with ceilings. `tls = "~> 4.0"` and `null = "~> 3.2"` are not new inventions — they are the constraints already written in `shared/versions.tf`, finally applied somewhere they load. The lock now records the intersection:

```
hashicorp/tls        4.3.0   constraints = ">= 3.0.0, ~> 4.0"
hashicorp/time       0.14.0  constraints = ">= 0.9.0, ~> 0.14"
hashicorp/cloudinit  2.4.0   constraints = ">= 2.0.0, ~> 2.4"
hashicorp/null       3.3.0   constraints = ">= 3.0.0, ~> 3.2"
```

**No resolved version changed** — the ceiling was added above where resolution already sat. `aws-eks` goes from 3 declared / 7 resolved to 7 / 7.

## `bootstrap/aws` was the only root validating with a warning

```
Warning: Invalid Attribute Combination
  with aws_s3_bucket_lifecycle_configuration.tofu_state, on main.tf line 44
No attribute specified when one (and only one) of [rule[0].filter, rule[0].prefix] is required
This will be an error in a future version of the provider
```

Fixed with `filter {}` — the provider's documented way to say "every object in the bucket", which is what the rule already meant, so this records the existing scope rather than narrowing it. `bootstrap/aws` now returns a bare `Success! The configuration is valid.`

## A hole #1108's un-ignore does not reach

`environments/gcp-ephemeral/` and `environments/gcp-persistent/` each carry **their own `.gitignore`** that also lists `.terraform.lock.hcl`. A nested `.gitignore` overrides its parent, so #1108 removing the line from `infra/tofu/.gitignore` does **not** un-ignore these two — both locks would have been dropped silently by `git add`, and the matrix above would have quietly shown ten locks instead of twelve.

Both lines removed. `*.tfstate` stays ignored in both: the lock pins the provider build, not the state.

## Locks

Same platform set as #1108 — `-platform=linux_amd64 -platform=darwin_arm64 -platform=darwin_amd64` (CI plus both Mac architectures), generated with 1.8.3.

**Verified, not assumed:** all **21** provider entries across the eight new locks carry exactly **3** `h1:` hashes. And they are stable — a second clean `init` from a deleted `.terraform` leaves all eight **byte-identical** (sha256 compared before/after):

| root | providers | root | providers |
|---|---|---|---|
| `environments/aws-eks` | 7 | `environments/gcp-persistent` | 1 |
| `environments/azure-aks` | 3 | `bootstrap/aws` | 1 |
| `environments/gcp-ephemeral` | 3 | `bootstrap/azure` | 1 |
| `environments/gcp-gke` | 4 | `bootstrap/gcp` | 1 |

`environments/aws-eks` and `environments/azure-aks` need `tofu init -backend=false` **before** `providers lock` — `providers lock` does not install modules, and both roots take providers from module blocks. Worth knowing before anyone regenerates them.

---

## `environments/ibm-iks` — untouched, and the lock is here for #1107

Not modified. #1103 fixes its `init`, #1107 its `validate` errors, and both are open against exactly these paths. Nothing in this PR touches `environments/ibm-iks/` or `modules/ibm-trusted-profile/`.

Its lock is the one piece of the matrix I cannot land, because it cannot be generated on this branch — `init` fails until #1103's provider-source declaration exists. I generated it on a throwaway merge of all four lanes and verified it:

```
provider "registry.opentofu.org/ibm-cloud/ibm"        version = "1.89.0"  constraints = "~> 1.70"
provider "registry.opentofu.org/hashicorp/helm"       version = "2.17.0"  constraints = "~> 2.13"
provider "registry.opentofu.org/hashicorp/kubernetes" version = "2.38.0"  constraints = "~> 2.30"
```
3 providers, 9 `h1:` hashes (3 x 3 platforms), 2840 bytes, sha256 `f9ef4b7e8c8aa7b675cba1870da60d6d54eccce2672f0af9ea98bd7daaa11dbc`.

**Recommendation:** whichever of #1103/#1107 lands last adds it with
`tofu providers lock -platform=linux_amd64 -platform=darwin_arm64 -platform=darwin_amd64`.
`ibm-iks` has no nested `.gitignore`, so #1108's un-ignore is sufficient there.

## Recommendation: the IBM auth pieces

**Keep `modules/ibm-trusted-profile` and `environments/ibm-iks`. Inert, and labelled.** Do not remove.

The brief is right that they exist only to enable live connections, and under this decision that purpose is gone. But removal is still the wrong move:

1. **Deleting the module deletes the fourth lane.** `environments/ibm-iks` is a validating root only because that module exists. Removing it to achieve parity would remove IBM from the set being brought to parity.
2. **#1107 already does exactly the right thing** and is open. It removes the invalid `Profile-OIDC` claim rule rather than swapping in one that passes the validator and federates nothing, keeps the profile, and labels the non-federation in four places plus the IBM console description string. That is "inert and clearly labelled", already written. Deleting the module would throw that work away and collide with an open PR.
3. **Offline-validated IaC is a real deliverable.** The module's job under this posture is to be valid HCL that records intent. It does that without ever authenticating.

One amendment I would suggest to #1107's owner, not a blocker: its README and comments frame the non-federation as an **IBM limitation** ("IBM Cloud cannot federate GitHub Actions OIDC"). Both are true, but the operative reason is now the **decision** — we are not running live connections against any of the four clouds. Saying "out of scope by decision, and also not possible on IBM" is the honest ordering, and it stops the note reading as a blocked item someone should go fix.

## Recommendation: the drift workflow's cloud-auth jobs

⚠️ `.github/workflows/infra-drift-detect.yml` is **#1090**'s lane (`fix/drift-exit1-is-failure`, open). Not touched here. This is a recommendation for its owner.

**The important point: this is not an IBM problem.** `infra-drift-detect.yml` has four jobs — `gcp-landing`, `aws-eks`, `azure-aks`, `ibm-iks` — and **every one runs `tofu plan` against a live cloud.** Under a no-live-connections posture the whole workflow has no purpose, not just its IBM step. Removing only the `cr-token` block would be inconsistent, and worse, it would imply the other three are fine.

The IBM step is independently broken regardless of posture — it posts a GitHub OIDC JWT to `grant_type=urn:ibm:params:oauth:grant-type:cr-token`, a grant that expects a platform-injected compute-resource token (#1107 documents this in detail) — but fixing it is now moot.

**Recommend: make the whole workflow inert rather than delete the file.**

- Drop the `schedule:` trigger; leave `workflow_dispatch:` so it can be run deliberately if live access is ever wanted.
- Header comment stating the posture and pointing at this decision.
- **Keep the file.** Lines 17-23 are the only written inventory of which `tofu output` feeds which CI variable (`GCP_WIF_PROVIDER`, `AWS_TOFU_ROLE_ARN`, `AZURE_CLIENT_ID`, `IBM_TRUSTED_PROFILE_ID`, ...). Deleting it loses reference material that is genuinely useful the day live connections come back into scope, and costs nothing to keep once the schedule is gone.

Nothing is lost by doing this: per #1097's audit the workflow has **27 runs, 26 `startup_failure`, and has never once succeeded.** It has never detected drift. Making that explicit is strictly better than leaving a scheduled job that looks like a control and is not one — the same defect class #1107 declined to create.

## Recommendation for `tofu-plan.yml` (#1097's lane — not edited)

⚠️ Not touched. #1097 owns that file.

#1107 named nine roots to add and verified eight pass locally. **With this PR the count is twelve, and all twelve pass.** `fmt -check -recursive` already walks all of `infra/tofu/`, but `validate` covers 4 of 14 roots, which is precisely why a root that had *never* validated survived indefinitely.

Add these eight to `fmt-and-validate` (`tofu init -backend=false && tofu validate` each) — all verified clean here:

```
infra/tofu/environments/aws-eks
infra/tofu/environments/azure-aks
infra/tofu/environments/gcp-ephemeral
infra/tofu/environments/gcp-gke
infra/tofu/environments/gcp-persistent
infra/tofu/bootstrap/aws
infra/tofu/bootstrap/azure
infra/tofu/bootstrap/gcp
```

Plus `infra/tofu/environments/ibm-iks` once #1103 + #1107 land — verified clean on the combined merge above — and `infra/tofu/shared`, which validates clean and costs nothing.

**A matrix over root directories beats twelve hand-written steps**, and is the only version of this that stops a *new* root landing unvalidated. That is the failure mode that actually happened here; enumerating roots by hand just resets the clock.

## Lane hygiene

`git merge-tree --write-tree` against all four open PRs, from this branch head:

| against | result | overlapping files |
|---|---|---|
| #1103 `fix/tofu-fmt-validate-blackout` | clean | none |
| #1107 `fix/ibm-iks-tofu-validate` | clean | none |
| #1108 `fix/tofu-provider-pinning` | clean | none *(it is this branch's base)* |
| #1097 `fix/tofu-plan-setup-opentofu-blocked` | clean | none |

Zero conflicts, zero overlapping files with any lane. The four lanes also merge cleanly with each other and with this branch — that is how the end-state matrix above was measured.

Every change is inside `infra/tofu/`.

## ⚠️ Evidence is local only

**GitHub Actions is at a spend cap — hundreds of jobs queued, zero running.** No workflow ran for this branch, and none will until the cap clears. Everything above is a local OpenTofu **1.8.3** binary with `.terraform` deleted and no plugin cache, replicating the CI command sequence. **It is not a CI result and should not be read as one.**

Specifically **not** covered, and deliberately so under the no-live-connections decision:

- `tofu plan` / `tofu apply` anywhere. Schema compatibility across the two major bumps is confirmed; apply-time differences (changed defaults, newly-required fields) are not.
- Any credential path, on any of the four clouds.
- Whether the committed locks resolve on `linux_amd64`. The hashes are in the lock and were fetched from the registry for that platform, but only `darwin_arm64` was actually initialised from them here.
