### PR TITLE
scaling: bound the estate's autoscaling, and turn off the five HPAs that split state

### DIFF
--- a/charts/socioprophet-service/templates/_helpers.tpl
+++ b/charts/socioprophet-service/templates/_helpers.tpl
@@ -31,6 +31,25 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s/%s:%s" $reg $repo $tag -}}
 {{- end -}}
 
+{{/*
+The GUARANTEED replica floor — what the cluster will always be running once things
+settle. With an HPA the deployment's own `replicas` field is not authoritative (the
+chart deliberately omits it, deployment.yaml:7), so the floor is the autoscaler's
+minReplicas; without one it is replicaCount.
+
+This is what a PodDisruptionBudget must be reasoned about against. A PDB whose budget
+cannot be satisfied by the floor does not "protect" the workload — it wedges every
+voluntary eviction, which on Autopilot means node upgrades, repairs and consolidation
+all stall against it indefinitely. See pdb.yaml.
+*/}}
+{{- define "svc.replicaFloor" -}}
+{{- if .Values.autoscaling.enabled -}}
+{{- .Values.autoscaling.minReplicas -}}
+{{- else -}}
+{{- .Values.replicaCount -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "svc.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "svc.fullname" .) .Values.serviceAccount.name -}}

--- a/charts/socioprophet-service/templates/hpa.yaml
+++ b/charts/socioprophet-service/templates/hpa.yaml
@@ -1,4 +1,19 @@
 {{- if .Values.autoscaling.enabled }}
+{{/*
+FAIL-CLOSED GUARD — a CPU-utilisation HPA is meaningless without a CPU request.
+
+`averageUtilization` is a percentage OF THE POD'S CPU REQUEST. With no request there is
+no denominator: the HPA reports `<unknown>` for the metric, never computes a desired
+replica count, and sits at minReplicas forever while looking installed. That is an
+autoscaler that cannot fire — the same shape as a probe that always returns 200.
+
+The chart ships a default request (values.yaml `resources.requests.cpu`), so this only
+trips if a service file explicitly blanks it. Refuse to render rather than ship a
+decorative autoscaler.
+*/}}
+{{- if not (dig "requests" "cpu" "" .Values.resources) }}
+{{- fail (printf "autoscaling.enabled=true for %s but resources.requests.cpu is unset — a CPU-utilisation HPA has no denominator and would never scale. Set a CPU request or disable autoscaling." (include "svc.fullname" .)) }}
+{{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -18,4 +33,38 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    # Opt-in second signal. The HPA takes the MAX of the per-metric recommendations, so
+    # memory can only ever scale UP relative to the CPU decision — set it only where
+    # memory genuinely tracks load, never for a runtime whose heap simply grows to its
+    # ceiling and stays there (that pins the autoscaler at maxReplicas permanently).
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+  behavior:
+    scaleUp:
+      # React within a scrape interval, but bounded: at most N pods/min, so a traffic
+      # spike — or a metrics blip — cannot mint a node pool's worth of pods.
+      stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleUp.stabilizationWindowSeconds }}
+      selectPolicy: Max
+      policies:
+        - type: Pods
+          value: {{ .Values.autoscaling.behavior.scaleUp.podsPerMinute }}
+          periodSeconds: 60
+    scaleDown:
+      # THE ANTI-THRASH CONTROL. The HPA holds the highest recommendation seen in this
+      # window before it will shrink, so a workload that dips between bursts does not
+      # flap. On Autopilot a scale-down also has a cost tail: the pod stops billing
+      # immediately, but the node it vacated only bills out once the cluster autoscaler
+      # consolidates — so rapid up/down churn pays for capacity it never used.
+      stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleDown.stabilizationWindowSeconds }}
+      selectPolicy: Max
+      policies:
+        - type: Pods
+          value: {{ .Values.autoscaling.behavior.scaleDown.podsPerMinute }}
+          periodSeconds: 60
 {{- end }}

--- a/charts/socioprophet-service/templates/pdb.yaml
+++ b/charts/socioprophet-service/templates/pdb.yaml
@@ -1,0 +1,39 @@
+{{/*
+PodDisruptionBudget — VOLUNTARY-disruption protection only.
+
+WHY THIS IS GUARDED BY THE REPLICA FLOOR
+A PDB constrains voluntary evictions: `kubectl drain`, node upgrades, autoscaler
+consolidation, node auto-repair. On GKE Autopilot every one of those is Google's to
+initiate, not ours. A single-replica workload with `minAvailable: 1` (or the equivalent
+`maxUnavailable: 0`) therefore has a budget that CAN NEVER BE MET: evicting the only pod
+drops availability to zero, so the eviction API refuses forever and the node drain hangs.
+That is the classic Autopilot footgun — a "safety" object that converts a routine node
+upgrade into a stuck cluster, and it is worse than having no PDB at all.
+
+So: this template renders ONLY when the guaranteed replica floor is >= 2
+(include "svc.replicaFloor"), and it always expresses the budget as `maxUnavailable: 1`.
+At a floor of 2 that permits exactly one pod to be evicted at a time — the drain always
+makes progress, one node at a time, while the service never drops below one live pod.
+Singletons get no PDB and are documented as accepting restart-length downtime, which is
+the honest position rather than a budget that lies.
+
+Disable per-service with `podDisruptionBudget.enabled: false`.
+*/}}
+{{- $floor := int (include "svc.replicaFloor" .) -}}
+{{- if and .Values.podDisruptionBudget.enabled (ge $floor 2) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "svc.fullname" . }}
+  labels: {{- include "svc.labels" . | nindent 4 }}
+  annotations:
+    # Recorded so the floor this budget was reasoned against is auditable at read time:
+    # if a later change drops the floor to 1 the template stops rendering the PDB, and
+    # this annotation is how you tell that happened deliberately rather than by drift.
+    socioprophet.io/replica-floor: {{ $floor | quote }}
+spec:
+  # Never minAvailable — see the header. maxUnavailable: 1 is satisfiable at any floor >= 2.
+  maxUnavailable: 1
+  selector:
+    matchLabels: {{- include "svc.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/socioprophet-service/values.yaml
+++ b/charts/socioprophet-service/values.yaml
@@ -114,11 +114,51 @@ metrics:
   # Scrape port name; "" = the main service.portName (http).
   portName: ""
 
+# Horizontal autoscaling. CPU-utilisation based, DELIBERATELY — not a custom/external
+# metric. The estate has no HTTP request metric with emitters today (`metrics.enabled:
+# false` chart-wide, above, overridden nowhere), so a request-rate or latency HPA would
+# be an autoscaler wired to a series that does not exist: permanently `<unknown>`,
+# permanently pinned at minReplicas, and green. CPU comes from metrics-server, which is
+# on by default on GKE and already serves every HPA in this cluster.
+#
+# ⚠️ BEFORE YOU SET enabled: true — THE STATEFULNESS TEST.
+# An HPA is only correct for a workload whose replicas are INTERCHANGEABLE. Ask what a
+# second replica would split. Disqualifying, every time:
+#   - a PVC, a SQLite file, or any local-disk write a later request must read back
+#   - a module-level dict/list/set/counter that survives between requests and shapes
+#     responses (ledgers, stores-of-record, session/grant/revocation tables)
+#   - a background loop, poller, ticker or scheduler — two replicas do the work twice
+#   - a single-writer cursor, checkpoint or sequence (the materializer/market-replay shape)
+#   - any follow-up request that must land on the SAME process to succeed
+# These fail SILENTLY: pods Ready, dashboards green, and the damage is a wrong answer
+# served to whoever happened to hit the other replica. Services that fail this test
+# carry an explicit `autoscaling: { enabled: false }` with the reason written beside it
+# in deploy/values/<name>.yaml — that is the pattern; keep it.
 autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 75
+  # Optional second Resource metric. Unset by default — see hpa.yaml on why heap-shaped
+  # memory pins an autoscaler at maxReplicas.
+  targetMemoryUtilizationPercentage: null
+  behavior:
+    scaleUp:
+      # 0 = act on the current recommendation (k8s' own scale-up default).
+      stabilizationWindowSeconds: 0
+      podsPerMinute: 2
+    scaleDown:
+      # 300s matches the k8s default, but is set EXPLICITLY so the anti-thrash window is
+      # a decision on the record rather than an inherited value an API default could
+      # move underneath us.
+      stabilizationWindowSeconds: 300
+      podsPerMinute: 1
+
+# Voluntary-disruption budget. Rendered ONLY when the guaranteed replica floor is >= 2 —
+# a PDB on a singleton wedges Autopilot node drains forever. Full reasoning in
+# templates/pdb.yaml; the floor is computed by the `svc.replicaFloor` helper.
+podDisruptionBudget:
+  enabled: true
 
 ingress:
   enabled: false

--- a/deploy/values/academy-board.yaml
+++ b/deploy/values/academy-board.yaml
@@ -9,3 +9,8 @@ image: { repository: academy-board, tag: sha-f59cf2c937bad042565eeed561ba9a11af9
 service: { port: 8095, portName: http }
 # tsx/esbuild needs a writable /tmp under the chart's readOnlyRootFilesystem.
 tmpDir: { enabled: true }
+# Autoscaling: SAFE — the only module state is a frozen ANSWER_KEY lookup table
+# (apps/academy-board/src/keys.ts:19) plus pure grading functions; handlers
+# (src/server.ts:37,51) derive everything from the request body. Courseware traffic is
+# classroom-shaped (idle, then a cohort arrives at once), which is what max 3 covers.
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 3 }

--- a/deploy/values/agentic-os-api.yaml
+++ b/deploy/values/agentic-os-api.yaml
@@ -6,3 +6,6 @@ service: { port: 8080, portName: http }
 # 2 days on a missing "z".
 probes:
   path: /health
+# Autoscaling: SAFE — all five routes return module constants from app/data.py
+# (OPPORTUNITIES/PODS/READINESS/CADENCE) and never mutate them (app/main.py:24-44).
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 3 }

--- a/deploy/values/algo-engine.yaml
+++ b/deploy/values/algo-engine.yaml
@@ -3,4 +3,17 @@
 # gitops-promote after the first image build (same pattern as owl-reasoner / entity-resolution).
 image: { repository: algo-engine, tag: sha-32f5996a06f6b6d971e6717ca5f3cf5b0661cda2 }
 service: { port: 8080, portName: http }
-autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
+# ⚠️ AUTOSCALING OFF — the paper-execution ledger is process-local.
+# `_LEDGER` (apps/algo-engine/src/algo_engine/server.py:243) is a module-global dict
+# holding cash, positions and the order log. POST /paper/order mutates it; GET
+# /paper/state reads it back. Each replica boots its own copy at $1,000,000 cash.
+#
+# At 2 replicas: a user places a BUY on replica A and sees the position, then the next
+# /paper/state lands on B and shows an empty book with the full $1M still uncommitted.
+# The order history flickers between two disjoint versions on refresh, /paper/reset only
+# resets whichever pod it reaches, and because each replica independently believes it has
+# the whole budget, total exposure can exceed the notional cap. Backtests are pure and
+# would scale fine — the ledger is what makes this service a singleton.
+# Re-enabling is gated on moving _LEDGER to a shared store, not on load.
+autoscaling: { enabled: false }
+replicaCount: 1

--- a/deploy/values/api.yaml
+++ b/deploy/values/api.yaml
@@ -7,3 +7,16 @@ config:
   TRITRPC_ALLOW_INSECURE_DEV_KEY: "1"   # DEV ONLY — provision a real TRITRPC_KEY_HEX secret for prod
 secretEnv:
   TRITRPC_KEY_HEX: { secretName: tritrpc-shared-key, key: TRITRPC_KEY_HEX, optional: true }
+# Autoscaling: SAFE — verified stateless. Each accepted connection is handled
+# independently (apps/api/cmd/socioprophet-api/main.go:112,116) and the response is built
+# purely from the decoded request (:182); the only package-level var is a stateless
+# fixture client (:90). No disk writes, no session table, no background loop.
+#
+# minReplicas: 2 is a DELIBERATE availability floor, not headroom. This is the tritRPC
+# core — the platform's primary service contract — and `gateway` (itself 2-6) proxies
+# every call to it and health-checks it with a real HealthPing round-trip
+# (apps/gateway/cmd/tritrpc-gateway/main.go:43). At one replica, an api restart takes
+# EVERY gateway replica unhealthy simultaneously. Two replicas also earn this workload a
+# PodDisruptionBudget (floor >= 2), so Autopilot node drains stop being full outages.
+# Cost of the second replica at the 50m/128Mi request: ~$0.09/day.
+autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 4 }

--- a/deploy/values/embeddings.yaml
+++ b/deploy/values/embeddings.yaml
@@ -16,3 +16,12 @@ probes:
 resources:
   requests: { cpu: 250m, memory: 1Gi }
   limits:   { cpu: "2", memory: 2Gi }
+# Autoscaling: SAFE — one SentenceTransformer loaded at import (apps/embeddings/app.py:19)
+# and used read-only per request (:40). No cache, no accumulation; replicas are
+# interchangeable.
+# maxReplicas: 2 is DELIBERATELY TIGHT. This pod requests 250m/1Gi — roughly 5x a default
+# service — so each replica is ~$0.50/day, not ~$0.09. It also carries a 40s
+# initialDelaySeconds because the model loads before uvicorn binds, so a scale-up is not
+# fast relief: it is capacity for a sustained load, not a spike. Widen only with a
+# measured queue-depth argument.
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }

--- a/deploy/values/eval-fabric-api.yaml
+++ b/deploy/values/eval-fabric-api.yaml
@@ -1,3 +1,12 @@
 # eval-fabric-api
 image: { repository: eval-fabric-api, tag: latest }
 service: { port: 8080, portName: http }
+# Autoscaling: SAFE — every route opens a fresh per-call connection to ClickHouse/Postgres
+# (app/db.py:59,82); the only in-process state is a 10s readiness-probe result cache where
+# a miss is harmless.
+# ⚠️ CONDITION: app/receipts.py writes .payload/.event/.receipt JSON to the POD'S OWN
+# filesystem, gated on EVAL_FABRIC_EMIT_RECEIPTS == "1" (receipts.py:135). That env var is
+# deliberately not set here. If it is ever set, receipts scatter across replicas and the
+# X-Evidence-Receipt-Ref header points at a file:// path that exists on only one pod —
+# disable autoscaling in the same change that enables emission.
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 3 }

--- a/deploy/values/evidence-console.yaml
+++ b/deploy/values/evidence-console.yaml
@@ -1,3 +1,8 @@
 # evidence-console
 image: { repository: evidence-console, tag: sha-dcfa461391ff888aef29d7361f61ab63586a7a5b }
 service: { port: 8080, portName: http }
+# Autoscaling: SAFE — a pure HTTP proxy. Every function in app/service.py calls
+# evidence-receipts over a per-request httpx client (app/client.py:14); there is no
+# module-level state at all and nothing is written locally. Replicas are interchangeable.
+# min 1 so idle costs nothing; max 3 is the budget.
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 3 }

--- a/deploy/values/evidence-receipts.yaml
+++ b/deploy/values/evidence-receipts.yaml
@@ -1,3 +1,15 @@
 # evidence-receipts
 image: { repository: evidence-receipts, tag: latest }
 service: { port: 8080, portName: http }
+# Autoscaling: SAFE TODAY, AND THE CONDITION IS WRITTEN DOWN.
+# All five routes are @app.get (apps/evidence-receipts/app/main.py:10-36) and main.py
+# imports only from .store — every replica serves the same read-only tree, so they are
+# interchangeable.
+# ⚠️ THE LATENT TRAP: the receipt store is the pod's OWN FILESYSTEM under
+# ~/.local/state/prophet-platform (app/store.py:19-22), not an external service. A writer
+# exists in the same package (app/telemetry_runtime.py:239-258) and is simply not imported
+# by main.py. The moment anything writes into this pod — a sidecar, an in-pod producer, or
+# a new POST route — replicas diverge instantly and silently, and this HPA turns a
+# read-only surface into a split store of record. If that writer is ever wired up, set
+# autoscaling.enabled back to false in the SAME change.
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 3 }

--- a/deploy/values/grl-mesh.yaml
+++ b/deploy/values/grl-mesh.yaml
@@ -6,5 +6,19 @@
 # stay open (aggregate, non-identifying). tag:latest → sha-pinned after the first CI build (preflight).
 image: { repository: grl-mesh, tag: sha-e69549d48820c5ff34f0dd03c1ceadc9967c9ed7 }
 service: { port: 8080, portName: http }
-autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
+# ⚠️ AUTOSCALING OFF — the mesh aggregator IS the shared prior.
+# `_agg = MeshAggregator()` (apps/grl-mesh/src/grl_mesh/server.py:30) holds `_stats`
+# (reward statistics per policy/action/context) and `_contributors` in process memory.
+# POST /grl/publish folds observations in; GET /grl/prior serves them back.
+#
+# The whole point of the service is that publishes ACCUMULATE into one community prior.
+# At 2 replicas each pod aggregates roughly half the estate's observations, and a node
+# warm-starting its policy gets whichever partition the load balancer picked —
+# `mean_reward` and `n` differ between consecutive identical calls, and
+# `total_observations`/`contributors` visibly jump. This is silent statistical
+# corruption: the caller receives a well-formed prior computed from a subset of the
+# evidence, with nothing in the response indicating it is incomplete.
+# Re-enabling is gated on a shared aggregation store, not on load.
+autoscaling: { enabled: false }
+replicaCount: 1
 # Internal (ClusterIP) — nodes reach it in-cluster / via the sovereign edge; no public ingress yet.

--- a/deploy/values/holmes.yaml
+++ b/deploy/values/holmes.yaml
@@ -11,3 +11,7 @@ service: { port: 8091, portName: http }
 extraEnv:
   - name: HOLMES_HELLGRAPH
     value: http://hellgraph-service.socioprophet.svc.cluster.local:8090
+# Autoscaling: SAFE — handlers (apps/holmes/main.go:281-324) forward to hellgraph over a
+# shared http.Client and compute their verdict from the response; the only package vars
+# are build-info strings (:136-140). No local writes.
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 3 }

--- a/deploy/values/memoryd.yaml
+++ b/deploy/values/memoryd.yaml
@@ -14,4 +14,24 @@ config:
   # falls back to the hashing embedder — never mixes vector spaces. See infra/k8s/embeddings/base.
   EMBEDDINGS_URL: "http://embeddings.socioprophet.svc.cluster.local:8080/v1/embeddings"
   EMBEDDINGS_MODEL: "nomic-embed-text"
-autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
+# ⚠️ AUTOSCALING OFF — memoryd IS the state it serves.
+# MEMORYMESH_STORE_URI above is `memory://`, which selects InMemoryStore
+# (apps/memoryd/src/memoryd/store.py:38): resources, the event log, `_memories` and the
+# `_revoked` tombstone set are all plain dicts in ONE process's heap. A second replica is
+# a second, disjoint memory plane.
+#
+# The recall miss is the mild failure: write to replica A, recall from B, and the agent
+# has amnesia about its own writes. The SERIOUS one is governance. store.py:96 filters
+# recall on `_revoked` and calls it "Read-enforced revocation: a tombstoned memory never
+# surfaces in recall" — but revoke_memory (store.py:122) only tombstones in the replica
+# that received the call. At 2 replicas a revoked memory KEEPS BEING SERVED by the other
+# pod, with no error anywhere. That is the revocation contract failing silently, which is
+# the one thing it exists to prevent.
+#
+# This HPA was live for ~13 days and never fired (idle CPU ~6% against a 75% target), so
+# the split had not yet happened in production — it was one traffic spike away.
+# RE-ENABLING IS GATED ON A SHARED STORE, NOT ON LOAD: point MEMORYMESH_STORE_URI at the
+# Postgres DSN (apps/memoryd/src/memoryd/postgres_store.py already implements that
+# backend), confirm revocation is enforced in the store rather than in-process, then scale.
+autoscaling: { enabled: false }
+replicaCount: 1

--- a/deploy/values/osm-map-api.yaml
+++ b/deploy/values/osm-map-api.yaml
@@ -2,3 +2,8 @@
 image: { repository: osm-map-api, tag: latest }
 service: { port: 8088, portName: http }  # app binds 8088 (uvicorn); chart uses this for containerPort + probes
 enableServiceLinks: false   # k8s injects OSM_MAP_API_PORT=tcp://<svc> otherwise → app int() crash
+# Autoscaling: SAFE — app.state.repository (osm_map_api/main.py:57) is a frozen dataclass
+# over read-only mounted fixture JSON (repository.py:66-76) and every route is a GET.
+# Nothing writes. Tile/lookup traffic is the burstiest shape on the platform, which is
+# what the headroom is for.
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 3 }

--- a/deploy/values/portfolio-agent.yaml
+++ b/deploy/values/portfolio-agent.yaml
@@ -9,3 +9,7 @@ image: { repository: portfolio-agent, tag: sha-a6d8311383ca91a2f56ec99c8070bbe7e
 service: { port: 8094, portName: http }
 # tsx/esbuild needs a writable /tmp under the chart's readOnlyRootFilesystem.
 tmpDir: { enabled: true }
+# Autoscaling: SAFE — POST /analyze runs runPortfolioAgent purely on the request body
+# (apps/portfolio-agent/src/server.ts:34); every list in src/agent.ts is function-local.
+# Analysis is CPU-bound per request, so replicas are the right lever.
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 3 }

--- a/deploy/values/regis-acr-api.yaml
+++ b/deploy/values/regis-acr-api.yaml
@@ -3,4 +3,18 @@
 # but was never scheduled — this wires it into the ApplicationSet. tag:latest → sha-pinned after next build.
 image: { repository: regis-acr-api, tag: latest }
 service: { port: 8080, portName: http }
-autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
+# ⚠️ AUTOSCALING OFF — proofs and the event log are in-process.
+# `_PROOFS` and `_EVENT_LOG` (apps/regis-acr-api/src/regis_acr_api/er_spine.py:68-69) are
+# module dicts; the comment directly above them says so ("Proofs + the event log are
+# receipts, not graph atoms, so they stay in-process here"). The default graph backend is
+# likewise an in-memory backend (graph_backend.py:132).
+#
+# At 2 replicas: POST /v1/resolve/entities mints a proof into replica A and returns
+# `proof_ref` to the caller; the follow-up GET /v1/proof/{proof_ref} has a coin-flip
+# chance of hitting B and 404-ing on a certificate the service issued seconds earlier.
+# For a plane whose contract is proof-carrying, replayable entity resolution, a randomly
+# unverifiable proof is a correctness failure, not a cache miss.
+# Re-enabling is gated on HELLGRAPH_SUPERPEER_URL (the shared-backend opt-in already in
+# graph_backend.get_backend()) plus a shared proof store — not on load.
+autoscaling: { enabled: false }
+replicaCount: 1

--- a/deploy/values/search-orchestrator.yaml
+++ b/deploy/values/search-orchestrator.yaml
@@ -1,7 +1,25 @@
 # search-orchestrator — search/index daemon
 image: { repository: search-orchestrator, tag: sha-d2b483f26f85e1550c6b229a123109c311c50aae }
 service: { port: 8080, portName: http }
-autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 4 }
+# ⚠️ AUTOSCALING OFF — runtime-ingested academy records live in one replica's heap.
+# `academy_repository` (services/search-orchestrator/app/repositories.py:200) resolves via
+# build_academy_repository(), which falls through to InMemoryAcademySearchRepository
+# (repositories.py:24) unless SEARCH_ORCHESTRATOR_ACADEMY_STORE / _LAMPSTAND_JSONL /
+# _LAMPSTAND_CARRIER_DIR is set. None of them is set here — only the boot SEED below,
+# which is per-replica and therefore consistent.
+#
+# So the bundled 8.01 corpus is identical everywhere, but ANYTHING INGESTED AT RUNTIME is
+# not: a record POSTed to /v1/search/ingest/academy lands in one pod's `_records` dict and
+# is invisible to queries served by the others. This HPA ran at maxReplicas: 4 — the
+# widest fan-out in the estate — so the cockpit tutor would show a newly ingested Commons
+# record on one refresh and not the next, and /v1/search/debug/metrics would report ~1/4
+# of true traffic, making it useless for the debugging it exists for.
+# TO RE-ENABLE: set SEARCH_ORCHESTRATOR_ACADEMY_STORE (or a Lampstand carrier dir) to a
+# shared location so all replicas read one corpus. That is a store decision, not a load one.
+# NOTE: the same values file backs the fogstack-federal and fogstack-standard overlays,
+# which carried the identical max-4 HPA.
+autoscaling: { enabled: false }
+replicaCount: 1
 # Boot-seed the academy ingest with the bundled 8.01 corpus so the cockpit tutor's Cloud engine
 # returns real Commons records (idempotent; in-memory repo re-seeds each boot).
 extraEnv:

--- a/deploy/values/socbase-auth.yaml
+++ b/deploy/values/socbase-auth.yaml
@@ -54,3 +54,10 @@ ingress:
           pathType: ImplementationSpecific
 
 replicaCount: 2
+# Autoscaling: SAFE — GoTrue is stateless by construction. GOTRUE_DB_DRIVER=postgres with
+# DATABASE_URL above: users, sessions and refresh tokens live in the Postgres `auth`
+# schema, never in the pod. This is the identity door, so the floor stays at 2.
+# minReplicas supersedes replicaCount once an HPA exists (the chart omits the Deployment's
+# `replicas` field when autoscaling is on) — the floor is unchanged at 2, so this adds
+# NO baseline cost, only burst headroom for a login stampede.
+autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 4 }

--- a/deploy/values/socbase-rest.yaml
+++ b/deploy/values/socbase-rest.yaml
@@ -56,3 +56,8 @@ ingress:
           pathType: ImplementationSpecific
 
 replicaCount: 2
+# Autoscaling: SAFE — PostgREST is a stateless JWT-verifying translator over PGRST_DB_URI
+# with a per-request connection pool; it holds no cross-request state. This is the data
+# door, so the floor stays at 2. As with socbase-auth, minReplicas supersedes replicaCount
+# and the floor is unchanged — NO baseline cost, burst headroom only.
+autoscaling: { enabled: true, minReplicas: 2, maxReplicas: 4 }

--- a/deploy/values/synapse-bridge.yaml
+++ b/deploy/values/synapse-bridge.yaml
@@ -9,3 +9,7 @@ image: { repository: synapse-bridge, tag: sha-8ad02c53edde7779e10a741a26d2257025
 service: { port: 8092, portName: http }
 # tsx/esbuild needs a writable /tmp under the chart's readOnlyRootFilesystem.
 tmpDir: { enabled: true }
+# Autoscaling: SAFE — two pure transforms over the request body
+# (apps/synapse-bridge/src/server.ts:28,32); src/enrichment.ts holds no mutable module
+# state.
+autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 3 }

--- a/infra/k8s/observability/base/prometheusrule-slos.yaml
+++ b/infra/k8s/observability/base/prometheusrule-slos.yaml
@@ -44,3 +44,62 @@ spec:
           labels: { severity: warning }
           annotations:
             summary: "{{ $labels.job }} 5xx ratio > 5% (SLO breach) — blocks canary promotion"
+    # ------------------------------------------------------------------------
+    # Autoscaling signals.
+    #
+    # DELIBERATELY BUILT ON kube-state-metrics, NOT on the app metrics plane. The
+    # request-slo group above depends on `http_server_request_duration_seconds`, which
+    # currently has ZERO emitters estate-wide (the shared chart ships `metrics.enabled:
+    # false` and no service overrides it), so those rules cannot fire. The
+    # `kube_horizontalpodautoscaler_*` series below are published by the
+    # kube-state-metrics deployment that is already running in this namespace and were
+    # confirmed present in Prometheus before these rules were written — 22 current-replica
+    # series and 198 condition series across the estate's HPAs. These alerts can fire today.
+    # ------------------------------------------------------------------------
+    - name: socioprophet.autoscaling
+      rules:
+        # THE "STOPPED AT THE CEILING" SIGNAL. An HPA pinned at maxReplicas is not healthy
+        # — it is a workload that wanted more capacity and was refused. Without this the
+        # cap is silent: pods are Ready, CPU sits at 100%, latency climbs, and nothing
+        # anywhere says the autoscaler ran out of room. 15m avoids paging on a burst that
+        # legitimately touches the ceiling and recedes.
+        - alert: HPAAtMaxReplicas
+          expr: |
+            kube_horizontalpodautoscaler_status_current_replicas
+              >= on (namespace, horizontalpodautoscaler)
+            kube_horizontalpodautoscaler_spec_max_replicas
+          for: 15m
+          labels: { severity: warning }
+          annotations:
+            summary: "HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler }} has been at maxReplicas for 15m"
+            description: >-
+              The autoscaler is capped and cannot add capacity. Decide deliberately: raise
+              maxReplicas (each replica is direct Autopilot spend), or accept the cap as the
+              budget. Do NOT raise it past what regional CPU quota can actually satisfy — a
+              max nobody can reach is a false bound.
+        # THE "DECORATIVE AUTOSCALER" DETECTOR. ScalingActive=false means the HPA cannot
+        # compute a desired replica count at all — almost always a missing metric
+        # (no CPU request on the pods, metrics-server down, or a custom metric with no
+        # emitters). This is the exact failure mode where an autoscaler LOOKS installed,
+        # reports `<unknown>`, sits at minReplicas forever, and everything reads green.
+        # The chart refuses to render a CPU HPA without a CPU request
+        # (charts/socioprophet-service/templates/hpa.yaml), and this catches the rest.
+        - alert: HPACannotComputeMetric
+          expr: kube_horizontalpodautoscaler_status_condition{condition="ScalingActive",status="false"} == 1
+          for: 15m
+          labels: { severity: warning }
+          annotations:
+            summary: "HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler }} cannot compute its metric — it is not autoscaling anything"
+            description: >-
+              ScalingActive=false for 15m. The autoscaler exists but is inert. Check that the
+              target pods declare a resource request for the metric being scaled on.
+        # A budget that can never be met blocks every voluntary eviction, which on Autopilot
+        # means node upgrades, repairs and consolidation stall indefinitely. The chart
+        # guards against authoring one (templates/pdb.yaml renders only at floor >= 2, and
+        # always as maxUnavailable: 1); this catches any that arrive by another path.
+        - alert: PDBBlocksAllDisruption
+          expr: kube_poddisruptionbudget_status_expected_pods > 0 and kube_poddisruptionbudget_status_pod_disruptions_allowed == 0
+          for: 30m
+          labels: { severity: warning }
+          annotations:
+            summary: "PDB {{ $labels.namespace }}/{{ $labels.poddisruptionbudget }} has allowed 0 disruptions for 30m — node drains will hang"


### PR DESCRIPTION
## What this is

Basic, bounded scaling automation for the estate — plus the removal of five autoscalers that were already live and already wrong.

**DO NOT MERGE without reading "What is still live" at the bottom.** The five unsafe HPAs described here are running in production *right now*; this PR is the only thing that turns them off.

---

## Recon first: the premise was wrong, and the truth is worse

The brief expected "no HPAs, or one that can't fire." Actual state of `deploy/argocd/platform-services.yaml` (44 services):

| | count |
|---|---|
| HPAs already live | **18** |
| …reading a real metric (`cpu: N%/75%`, never `<unknown>`) | 18 / 18 |
| …on a workload that **splits state at 2 replicas** | **5** |
| PodDisruptionBudgets estate-wide | **0** |
| Workloads with CPU+memory requests *and* limits | 44 / 44 (chart default `50m/128Mi` → `1/512Mi`) |
| HTTP health endpoints that assert anything real | **1 / 17** |

Two things worth correcting up front:

- **Autopilot does not rewrite requests to equal limits.** Verified against live pods: requests stay as declared (`50m/128Mi`), limits sit above them. The feared "billed at the limit" cost blow-up is not happening.
- **The CPU metric plane is real.** Every HPA reports genuine utilisation because metrics-server is on by default on GKE. This is *not* the `http_server_request_duration_seconds` situation — that series has zero emitters, which is why nothing here depends on it.

## The actual defect: nobody asked what a second replica would split

Five of the eighteen live HPAs are on services holding request-spanning state in process memory. All five verified by reading the store and handler code, not inferred from names.

| service | max | the state | what a user sees at 2 replicas |
|---|---|---|---|
| **memoryd** | 2 | `InMemoryStore` — `_memories` **and the `_revoked` tombstone set** (`store.py:38,96,122`), because `MEMORYMESH_STORE_URI=memory://` | **A revoked memory keeps being served.** `store.py:96` calls this "read-enforced revocation"; revocation only tombstones on the pod that received it |
| **algo-engine** | 2 | `_LEDGER` — cash/positions/orders (`server.py:243`) | Order placed on A, gone on B. Each replica independently believes it holds the whole $1,000,000 |
| **grl-mesh** | 2 | `MeshAggregator._stats` / `_contributors` (`server.py:30`) | The community prior *is* the state. Each pod serves half the evidence as though it were whole — silent statistical corruption |
| **regis-acr-api** | 2 | `_PROOFS` / `_EVENT_LOG` (`er_spine.py:68`) | A proof minted seconds ago 404s on the follow-up GET. On a plane whose contract is *proof-carrying* resolution |
| **search-orchestrator** | **4** | `academy_repository` falls through to the in-memory repo (`repositories.py:200`) | Ingested records visible on one refresh, gone the next. Debug metrics report ~1/4 of true traffic |

**None had ever fired.** Idle CPU sits near 6% against a 75% target, so the split has not happened in production — it was one traffic spike away. That is the whole point: an autoscaler nobody has watched scale is not "working," it is untested.

Each is now disabled with the reason *and the re-enablement condition* written beside it. Every condition is a shared-store change (`memoryd` → the Postgres backend that already exists in `postgres_store.py`; `search-orchestrator` → `SEARCH_ORCHESTRATOR_ACADEMY_STORE`). **None is "wait for more load."**

## Chart changes

- **`hpa.yaml` gains a `behavior` block** — 300s scale-down stabilisation, +2 pods/min up, −1 pod/min down. 300s matches the k8s default but is now *on the record*, so a future API default can't move it silently.
- **`hpa.yaml` fails rendering** when `autoscaling.enabled` is true and `resources.requests.cpu` is unset. `averageUtilization` is a percentage *of the request*; with no denominator the HPA reports `<unknown>` and sits at min forever while looking installed. Proven to fail: `--set resources.requests.cpu=null` → template error.
- **New `pdb.yaml`**, rendered **only at a guaranteed replica floor ≥ 2**, always as `maxUnavailable: 1`. A `minAvailable` PDB on a singleton can never be satisfied and wedges Autopilot node upgrades, repairs and consolidation *indefinitely* — strictly worse than no PDB. Six workloads qualify; the estate had zero PDBs before this.
- **The statefulness test is written into `values.yaml`** where the next person adding a service will read it.

## What gained an autoscaler

Thirteen services, each verified stateless by reading its handlers and stores.

- **Twelve at `minReplicas: 1`** — no baseline cost, burst headroom only.
- **`api` moves its floor to 2.** It is the tritRPC core; `gateway` (2-6) proxies every call and health-checks it with a real `HealthPing` round-trip, so at one replica an `api` restart took *every* gateway replica unhealthy simultaneously.
- **`socbase-auth` / `socbase-rest`** were already `replicaCount: 2`, so their floor is unchanged — pure burst headroom, no new spend.

Bounds are budgets, not round numbers. `max: 3` for default-sized services; **`max: 2` for `embeddings`**, which requests `250m/1Gi` (~$0.50/day/replica, ~5x a normal pod) and loads its model before binding — a scale-up there is capacity for sustained load, not spike relief.

Two services carry a **documented condition** rather than a clean bill of health: `evidence-receipts` is safe *only because* its local-disk writer (`telemetry_runtime.py`) is not imported by `main.py`, and `eval-fabric-api` is safe *only while* `EVAL_FABRIC_EMIT_RECEIPTS` stays unset. Both notes say to disable autoscaling in the same change that flips those.

## Alerting

New `socioprophet.autoscaling` group, built **entirely on kube-state-metrics** — deliberately not on the app metrics plane. Both series were confirmed present in Prometheus *before* the rules were written (22 current-replica series, 198 condition series).

- `HPAAtMaxReplicas` — the ceiling becomes audible instead of silent.
- `HPACannotComputeMetric` (`ScalingActive=false`) — the decorative-autoscaler detector; catches the case the chart guard can't.
- `PDBBlocksAllDisruption` — catches an unsatisfiable budget arriving by any other path.

The existing `request-slo` rules are **untouched** — that metric decision belongs to another lane.

## Proof it fires, both directions

Run on the live cluster in an isolated `scaling-proof` namespace (Argo self-heals `socioprophet`, so proving there would have fought the controller). Real service, real values file, real chart.

```
02:01:29  cpu 224%/75%   replicas 1→3    SuccessfulRescale: "cpu utilization above target"
02:01:51  cpu 631%/75%   3/3 ready
          ScalingLimited = True   reason=TooManyReplicas     ← capped, and it says so
          ScalingActive  = True   reason=ValidMetricFound    ← the metric is real
02:03:03  load removed
02:03:57  cpu  48%   desired=3   ← stabilisation window holding
02:05:10  cpu   8%   desired=3   ← still holding
02:06:23  cpu   4%   desired=3   ← still holding; 300s not yet elapsed
02:08:46  cpu   4%   desired=2   ← window elapsed → first step down
02:08:58              2/2 ready
02:10:02  cpu   4%   desired=1   ← second step down
02:10:15              1/1         ← back to minReplicas. Full round trip: 1 → 3 → 2 → 1
```

Scale-down began **343s after load was removed** — the 300s stabilisation window plus a sync interval — and stepped down one pod per minute exactly as the `scaleDown` policy specifies. It did not thrash: CPU sat at 4-8% for five straight minutes without the autoscaler flinching.

**At-max is a signal, not a silent cap.** The exact `HPAAtMaxReplicas` expression, evaluated against live Prometheus *while capped*, returned **exactly one firing series** — `scaling-proof/academy-board current=3` — with no false positives across the other 21 HPAs in the estate.

⚠️ The alert **fires but currently goes nowhere** — Alertmanager receivers are owned by a parallel lane and are not wired yet. Noted, not fixed here.

## Left deliberately alone — every one verified stateful

Not scaled, and each will stay unscaled until its state moves somewhere shared:

- **`hellgraph-service`** — the graph is a per-process AtomSpace on an *ephemeral* pod-local dir (`server.ts:42`; no PVC in its values, and `server.ts:486` says so outright). `GET /api/graph/log` reads that in-process atom set, so a load-balanced materializer tailing `?since=` would skip or replay depending on which pod answered.
- **`health-twin`** — in-memory consult ledger (`consult.ts:49`) *and* a grant ledger (`server.ts:66`) where **revocation only applies to the pod that received it** — an authorization failure, same shape as memoryd.
- **`compute-gateway`** — SQLite on an RWO PVC + in-process grants. Already correctly pinned; its own source comment admits "a 2-replica gateway already returns different chains per pod."
- **`clickhouse`, `arcticdb-gateway`** — PVCs.
- **Six single-writer loops** — `market-replay`, `prophet-materializer-clickhouse`, `lifecycle-warden`, `device-service`, `nugget-extractor`, `reporting-watcher`. These were already correct, with the reasoning already in their values files.
- **`sherlock-engine`** — carries a bare `autoscaling: { enabled: false }` with no stated reason. My audit says it would be safe (and its serving loop is single-threaded, which argues *for* replicas), but I am not flipping someone else's undocumented decision. Owner should confirm.

## Cost

Autopilot bills on requests. A default pod (`50m/128Mi/1Gi eph`) is ~**$0.089/day**.

- **Baseline delta: +$0.089/day (~$2.72/month)** — the single second `api` replica. Nothing else raises the floor.
- **Theoretical maximum**, only if every new autoscaler saturated simultaneously: **~$3.00/day (~$90/month)**. Realistically unreachable — these services idle at 4-8% CPU.
- Disabling the five unsafe HPAs saves nothing (all were at `min: 1` running one replica) — it is a correctness fix, not a cost fix.

## Verification status

- Helm renders clean for **all 44** live-tree services; HPA count 18 → 26, PDB count 0 → 6 (exactly the floor-≥2 set).
- `tools/preflight_deploy_contract.py` **passes (exit 0)**. Its warnings are pre-existing `latest`-tag ratchet entries, untouched here.
- ⚠️ **GitHub Actions is at a spend cap — hundreds queued, zero running. CI has NOT verified this branch.** Everything above was verified locally and against the live cluster by hand.

## What is still live (needs a merge, not a follow-up)

Argo tracks `main` with `selfHeal: true`. **Until this merges, all five unsafe HPAs remain active in production.** Deleting them by hand would just be recreated by Argo, so the merge *is* the fix. Current risk is bounded — all five sit at one replica under light load — but it is a latent split waiting on a traffic spike.

`search-orchestrator`, `eval-fabric-api` and `hellgraph-service` also deploy through `deploy/argocd/fogstack/fogstack-appset.yaml`, which reads the **same** values files. The `search-orchestrator` fix therefore reaches all three namespaces (it carried the identical max-4 HPA in each).
