### PR TITLE
fix(gateway): bound int fields in _guard_exhaust to close digit-encoded-payload door

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/engine.py
+++ b/apps/compute-gateway/src/compute_gateway/engine.py
@@ -59,6 +59,15 @@ _MAX_REASON_LEN = 512         # bounded free-text
 _MAX_ITEMS = 10_000           # DoS safeguard on the ledger
 _MAX_SPEC_VERSION_LEN = 64    # a version string ("2.0", "2026-07-29"), not a field
 _MAX_COUNT_KEYS = 256         # a counts map is a tally, not a key-value store
+# Upper bound on any non-negative integer field. Python ints are arbitrary
+# precision, so "must be a non-negative int" is not by itself a bound at all — a
+# 1.9-million-digit int passes `isinstance(v, int)` just fine and only trips the
+# aggregate-serialisation cap on the way out. That means the per-field check
+# was declarative, not enforcing: exactly the "dimension nobody enumerated"
+# shape #1071 warned about. int64 max (~9.22e18) sits above any real byte count
+# (this exceeds exabyte-scale) and above any conceivable count of events, but
+# refuses to store a digit-encoded blob as a "number".
+_MAX_NONNEG_INT = 2**63 - 1
 
 # Aggregate backstop. Every bound above is per-field, and per-field bounds only
 # close the dimensions someone remembered to enumerate — `specVersion` and the
@@ -87,7 +96,13 @@ def _bad_ref(v) -> bool:
 
 
 def _bad_nonneg_int(v) -> bool:
-    return isinstance(v, bool) or not isinstance(v, int) or v < 0
+    # bool subclasses int; excluded first so True/False are rejected as types.
+    # The upper bound is what makes this a real gate: without it, an adapter can
+    # smuggle a 1.9-MB decimal blob as a "count" and only the aggregate
+    # backstop catches it — see the module docstring for the exhaust guard.
+    if isinstance(v, bool) or not isinstance(v, int) or v < 0:
+        return True
+    return v > _MAX_NONNEG_INT
 
 
 def _validate_exhaust(exhaust) -> str | None:
@@ -110,7 +125,7 @@ def _validate_exhaust(exhaust) -> str | None:
         return f"specVersion must be a version string (<= {_MAX_SPEC_VERSION_LEN} chars)"
     for count_key in ("bytesIn", "bytesOut"):
         if count_key in exhaust and _bad_nonneg_int(exhaust[count_key]):
-            return f"{count_key} must be a non-negative int"
+            return f"{count_key} must be a bounded non-negative int (<= {_MAX_NONNEG_INT})"
     if "counts" in exhaust:
         c = exhaust["counts"]
         if not isinstance(c, dict):
@@ -121,7 +136,7 @@ def _validate_exhaust(exhaust) -> str | None:
             if not isinstance(k, str) or len(k) > _MAX_LABEL_LEN:
                 return f"counts.{k!r} label out of range"
             if _bad_nonneg_int(v):
-                return f"counts.{k} must be a non-negative int"
+                return f"counts.{k} must be a bounded non-negative int (<= {_MAX_NONNEG_INT})"
     if "items" in exhaust:
         items = exhaust["items"]
         if not isinstance(items, list):
@@ -139,7 +154,7 @@ def _validate_exhaust(exhaust) -> str | None:
             if "sha256" in it and _bad_ref(it["sha256"]):
                 return f"items[{i}].sha256 must be a 64-hex digest or sha256:/urn: ref"
             if "size" in it and _bad_nonneg_int(it["size"]):
-                return f"items[{i}].size must be a non-negative int"
+                return f"items[{i}].size must be a bounded non-negative int (<= {_MAX_NONNEG_INT})"
             if "ref" in it and _bad_ref(it["ref"]):
                 return f"items[{i}].ref must be a digest/URN reference"
     # Aggregate backstop — last, so it catches whatever the per-field checks

--- a/apps/compute-gateway/tests/test_gateway_hardening.py
+++ b/apps/compute-gateway/tests/test_gateway_hardening.py
@@ -277,3 +277,90 @@ def test_exhaust_guard_accepts_a_large_but_legitimate_ref_ledger():
     good = {"type": "ExhaustRecord", "source": "compute",
             "items": [{"kind": "candidate", "sha256": "a" * 64} for _ in range(10_000)]}
     assert engine._guard_exhaust(good) == good
+
+
+# ── #1104 follow-up: digit-encoded-payload door on the int fields ─────────
+# Python ints are arbitrary precision. `isinstance(v, int) and v >= 0` is a
+# type/sign check, not a size bound — a 1.9-MB-of-decimal-digits int satisfies
+# both, so an adapter could smuggle payload as `bytesIn`/`bytesOut`/a `counts`
+# value/an `items[i].size` and only trip the 2 MiB aggregate cap on the way out.
+# The adversarial audit that produced #1104 called this the "dimension nobody
+# enumerated"; these tests pin the per-field bound that closes it, and assert
+# it fires *ahead* of the aggregate backstop (so a caller sees a specific,
+# actionable reason instead of the catch-all).
+
+def _giant_int_from_digits(mb: float) -> int:
+    """Return an int whose decimal representation is ~mb megabytes long.
+
+    The whole point of the attack is a payload dressed as a number, so the
+    fixture has to actually construct one; a plain `10**N` uses N+1 characters
+    to encode but this constructs an int whose *digit string* is huge, which
+    is what the smuggler's serialiser would produce.
+
+    Python 3.11+ caps int/str conversion at PYTHONINTMAXSTRDIGITS (default
+    4300) as its own DoS guard; that default already blocks the exact wire
+    payload this test asserts against, so raising it here models the "what if
+    that ceiling is lifted" scenario the per-field bound exists to defend.
+    """
+    import sys as _sys
+    digits = int(mb * 1_000_000)
+    # Bump above the default (4300) with headroom for both construction and
+    # json.dumps' own int-to-str call inside the aggregate check.
+    if _sys.get_int_max_str_digits() < digits + 64:
+        _sys.set_int_max_str_digits(digits + 64)
+    return int("9" * digits)
+
+
+def test_bytesIn_rejects_digit_encoded_payload():
+    """A 1.9-MB-of-decimal-digits int passes isinstance(v, int) and v >= 0.
+    Must be rejected by the per-field bound, NOT incidentally by the aggregate
+    backstop — a caller who sees the aggregate reason has no idea which field
+    is wrong."""
+    smuggled = {"type": "ExhaustRecord", "bytesIn": _giant_int_from_digits(1.9)}
+    out = engine._guard_exhaust(smuggled)
+    assert out is not None
+    assert "bytesIn" not in out, "raw digit payload survived the guard via bytesIn"
+    assert "exhaust rejected" in out["reason"]
+    assert "bytesIn must be a bounded non-negative int" in out["reason"], (
+        "must be rejected BY THE bytesIn BOUND, not incidentally by the "
+        f"aggregate backstop; got: {out['reason']}")
+
+
+def test_counts_value_rejects_digit_encoded_payload():
+    """The same door on counts values: `counts` bounds *keys* by length and
+    the map by cardinality, but each value was only checked for
+    type/non-negativity. A giant-int value slips through both."""
+    smuggled = {"type": "ExhaustRecord",
+                "counts": {"dropped": _giant_int_from_digits(1.9)}}
+    out = engine._guard_exhaust(smuggled)
+    assert out is not None
+    assert "counts" not in out or "dropped" not in out.get("counts", {})
+    assert "exhaust rejected" in out["reason"]
+    assert "counts.dropped must be a bounded non-negative int" in out["reason"], (
+        "must be rejected BY THE counts-value BOUND, not incidentally by the "
+        f"aggregate backstop; got: {out['reason']}")
+
+
+def test_items_size_rejects_digit_encoded_payload():
+    """Same door on items[i].size — bounded to non-negative int only,
+    which is not a size bound at all when ints are arbitrary precision."""
+    smuggled = {"type": "ExhaustRecord",
+                "items": [{"kind": "candidate", "sha256": "a" * 64,
+                           "size": _giant_int_from_digits(1.9)}]}
+    out = engine._guard_exhaust(smuggled)
+    assert out is not None
+    assert "items" not in out, "raw digit payload survived the guard via items[0].size"
+    assert "exhaust rejected" in out["reason"]
+    assert "items[0].size must be a bounded non-negative int" in out["reason"], (
+        "must be rejected BY THE items-size BOUND, not incidentally by the "
+        f"aggregate backstop; got: {out['reason']}")
+
+
+def test_bytesIn_accepts_a_reasonable_petabyte_int():
+    """The fix must not break the real thing it is bounding. 10**15 is
+    petabyte-scale — well over any realistic byte tally, well under the int64
+    ceiling — and must still be accepted so the guard does not become a limit
+    on legitimate usage."""
+    good = {"type": "ExhaustRecord", "bytesIn": 10**15, "bytesOut": 10**15,
+            "counts": {"dropped": 10**12}}
+    assert engine._guard_exhaust(good) == good


### PR DESCRIPTION
## What the audit caught

The adversarial review on #1104 flagged that `_guard_exhaust` on `main` closes only the *type* of every int field. `_bad_nonneg_int`:

```python
def _bad_nonneg_int(v) -> bool:
    return isinstance(v, bool) or not isinstance(v, int) or v < 0
```

is a type/sign check, not a size bound. Python ints are arbitrary precision, so a 1.9-MB decimal-digit blob dressed as `bytesIn` sails past `isinstance(v, int) and v >= 0` and only trips the 2 MiB aggregate cap on the way out.

That is exactly the "dimension nobody enumerated" the exhaust guard's own docstring warns about — the aggregate is designed to be the **last** line of defence, not the first. A caller who only trips the aggregate has no idea which field is misusing bytes; the failure reason is a catch-all rather than the specific field-scoped diagnostic the other bounds return.

Same door is open on:

- `bytesIn` and `bytesOut` at the top level
- every value in `counts`
- every `items[i].size`

## Fix

Add `_MAX_NONNEG_INT = 2**63 - 1` (int64 max) and gate every field that flows through `_bad_nonneg_int` on it. int64 max is above any realistic byte count (exceeds exabyte-scale) and above any conceivable event tally, but refuses a digit-encoded blob-as-number.

Reason strings updated to read `"<field> must be a bounded non-negative int (<= 9223372036854775807)"` so a caller sees which field regressed instead of a catch-all.

## Tests (four new)

Appended to `apps/compute-gateway/tests/test_gateway_hardening.py`. Each one asserts the failure fires by the per-field bound and NOT incidentally by the aggregate:

- `test_bytesIn_rejects_digit_encoded_payload` — 1.9-MB-of-decimal-digits int as `bytesIn`, must be rejected with `"bytesIn must be a bounded non-negative int"`.
- `test_counts_value_rejects_digit_encoded_payload` — same shape smuggled as a counts value; asserts the counts-value bound is what fires.
- `test_items_size_rejects_digit_encoded_payload` — same shape smuggled as `items[0].size`; asserts the items-size bound is what fires.
- `test_bytesIn_accepts_a_reasonable_petabyte_int` — `10**15` (petabyte scale) still passes, so the fix does not become a limit on legitimate usage.

Note on the fixture: Python 3.11+'s own `PYTHONINTMAXSTRDIGITS` DoS guard (default 4300) already blocks the exact wire payload the first three tests construct, so the fixture bumps `sys.set_int_max_str_digits` locally. That is deliberate — it models the exact scenario the per-field bound exists to defend (CPython's guard lifted, disabled, or absent in a future runtime) and proves the guard is not silently relying on it.

## Test plan

- [x] `pytest tests/test_gateway_hardening.py` — 26/26 pass, including the 4 new tests.
- [x] Full compute-gateway suite — 177/177 pass, no adjacent regressions.
- [ ] Copilot review requested.