### PR TITLE
fix(workspace-minio): make minio-sync backup run and mirror real data

### DIFF
--- a/infra/k8s/workspace-minio/base/backup-cronjob.yaml
+++ b/infra/k8s/workspace-minio/base/backup-cronjob.yaml
@@ -15,24 +15,69 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
+            # fsGroup applies ONLY to mounted volumes. The one mounted volume here is the
+            # backup-target PVC (the DESTINATION). The MinIO source is read over S3
+            # (workspace-minio:9000) and is NEVER mounted, so this fsGroup cannot touch the
+            # source's ownership — writes land only on the backup PVC. Required because a fresh
+            # GCE PD mounts root:root 0755 and uid 1000 otherwise cannot create /backup/minio.
+            fsGroup: 1000
             seccompProfile:
               type: RuntimeDefault
           containers:
             - name: mc-mirror
               image: minio/mc:RELEASE.2024-03-30T15-29-52Z
+              # The minio/mc image ENTRYPOINT is `mc`. The previous manifest set `args:` only, so
+              # Kubernetes ran `mc /bin/sh -c "<script>"` — mc treated `/bin/sh` as a subcommand
+              # and the shell NEVER executed. (Running as uid 1000 it died even earlier, at
+              # `mkdir /.mc: permission denied`.) The job has therefore failed on every single
+              # run since it was authored. Override `command:` so the shell actually runs.
+              command: ["/bin/sh", "-c"]
+              env:
+                # mc writes its config to $HOME/.mc. Under runAsUser 1000, HOME defaults to `/`
+                # (unwritable) → `mc: Unable to save new mc config. mkdir /.mc: permission
+                # denied` on the first mc call. Point HOME at a writable path.
+                - name: HOME
+                  value: /tmp
+                # minio-credentials stores hyphenated keys (access-key / secret-key), which are
+                # NOT valid env-var identifiers, so `envFrom` silently dropped them and
+                # $MINIO_ROOT_USER/$MINIO_ROOT_PASSWORD were always empty. Map them explicitly,
+                # exactly as the workspace-minio Deployment already does.
+                - name: MINIO_ROOT_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-credentials
+                      key: access-key
+                - name: MINIO_ROOT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-credentials
+                      key: secret-key
               args:
-                - /bin/sh
-                - -c
                 - |
-                  set -e
-                  mc alias set local http://workspace-minio:9000 \
-                    "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
-                  # Mirror workspace data to the backup bucket
-                  mc mirror --overwrite --remove local/workspace s3/prophet-workspace-backup/ || true
-                  echo "MinIO mirror complete"
-              envFrom:
-                - secretRef:
-                    name: minio-credentials
+                  set -eu
+                  # Source is read over S3 (never mounted); destination is the backup PVC.
+                  mc alias set local http://workspace-minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+                  mkdir -p /backup/minio
+                  # Mirror EVERY real bucket to the dedicated backup PVC. The old command mirrored
+                  # `local/workspace` (a bucket that does not exist) to `s3/prophet-workspace-backup`
+                  # (an alias never configured — there is no S3 backup secret anywhere in the
+                  # namespace), the whole line masked by `|| true`, so it could only ever exit
+                  # green having moved nothing. There is deliberately no `|| true` below: a mirror
+                  # failure now fails the job loudly.
+                  # NOTE: the minio/mc image ships no awk/find, so bucket parsing is POSIX shell only.
+                  mc ls local > /tmp/buckets.txt
+                  buckets=0
+                  while read -r line; do
+                    b=${line##* }; b=${b%/}
+                    [ -n "$b" ] || continue
+                    echo "mirroring bucket: $b"
+                    mc mirror --overwrite --remove "local/$b" "/backup/minio/$b"
+                    buckets=$((buckets + 1))
+                  done < /tmp/buckets.txt
+                  echo "MinIO mirror complete: ${buckets} bucket(s); backup now $(du -sh /backup/minio | cut -f1) at /backup/minio"
+              volumeMounts:
+                - name: backup-target
+                  mountPath: /backup
               resources:
                 requests:
                   cpu: 50m
@@ -45,3 +90,23 @@ spec:
                 readOnlyRootFilesystem: false
                 capabilities:
                   drop: ["ALL"]
+          volumes:
+            - name: backup-target
+              persistentVolumeClaim:
+                claimName: workspace-minio-backup
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: workspace-minio-backup
+  annotations:
+    # Never prune on ArgoCD sync — this PVC holds the backups.
+    argocd.argoproj.io/sync-options: Prune=false
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      # Matches the workspace-minio source PVC (100Gi). A backup volume smaller than its source
+      # is a latent silent failure — the mirror starts hitting ENOSPC the moment the source
+      # grows past it. Matching capacity keeps the nightly mirror from ever failing on space.
+      storage: 100Gi


### PR DESCRIPTION
## Summary
`minio-sync` (the nightly `workspace-minio` backup CronJob) has **failed on every run since it was authored and never once succeeded** — it is absent from `kube_cronjob_status_last_successful_time`, and its CronJob status carries only `lastScheduleTime`, no `lastSuccessfulTime`. Nothing alerted, same class as the `mail-backup` regression.

## Root cause (all confirmed in-cluster with disposable probe Jobs, socioprophet ns)
Three stacked defects, plus a phantom destination:

1. **Entrypoint vs command.** The `minio/mc` image `ENTRYPOINT` is `mc`. The manifest set `args:` but not `command:`, so Kubernetes ran `mc /bin/sh -c "<script>"` — mc treats `/bin/sh` as a subcommand and **the shell never runs**. As uid 1000 it failed even earlier: `mc: <ERROR> Unable to save new mc config. mkdir /.mc: permission denied` (HOME defaults to `/`).
2. **Unwritable HOME.** mc writes config to `$HOME/.mc`; uid 1000 cannot write `/`. Fixed with `HOME=/tmp` (verified writable by uid 1000).
3. **Credentials silently empty.** Creds came via `envFrom` on `minio-credentials`, whose keys are hyphenated (`access-key` / `secret-key`) — invalid env-var identifiers, silently dropped — so `$MINIO_ROOT_USER`/`$MINIO_ROOT_PASSWORD` were always empty. The `workspace-minio` Deployment already maps them correctly via `secretKeyRef`; this now does the same.
4. **Phantom source & destination.** The mirror targeted `local/workspace` (no such bucket — real buckets are `zot` ~20G and `lifecycle-warden`) and `s3/prophet-workspace-backup` (an `s3` alias **never configured**; there is no S3 backup secret anywhere in the namespace), all masked by `|| true`. Even a credential-fixed job would have exited green having copied nothing.

## Fix
- Override `command: ["/bin/sh","-c"]` so the shell runs.
- `HOME=/tmp`.
- Map creds via explicit `secretKeyRef` (`access-key`→`MINIO_ROOT_USER`, `secret-key`→`MINIO_ROOT_PASSWORD`).
- Mirror **every real bucket** to a dedicated `workspace-minio-backup` PVC; POSIX-shell bucket loop (the image ships no `awk`/`find`).
- **Remove `|| true`** so a mirror failure fails the job loudly, and print bucket count + `du -sh` of the backup so a green-over-nothing run is impossible.
- `fsGroup: 1000` scoped to the **destination PVC only** — the MinIO source is read over S3 and never mounted, so fsGroup cannot rewrite source ownership.
- New `workspace-minio-backup` PVC sized 100Gi to match the source PVC (a backup smaller than its source is a latent ENOSPC/silent-fail as the source grows).

## Verification (cluster evidence; CI is spend-capped)
Disposable probe Jobs (all deleted afterward) reproduced the failure and proved the fix:
- Original config → `mkdir /.mc: permission denied`.
- `command:` override + `HOME=/tmp` + `secretKeyRef` creds → `mc alias set ... Added 'local' successfully`, enumerated real buckets (`zot`, `lifecycle-warden`), and **mirrored real objects S3→filesystem** (`lifecycle-warden/audit/chunk-*.json`, `Total: 70.50 KiB, Transferred: 70.50 KiB`).
- The full ~20G `zot` copy onto the 100Gi PVC was **not** run in-session, to keep the cluster clean and within the spend cap. The transfer mechanism is identical to the verified run; `fsGroup:1000` writability on a fresh GCE PD is independently proven by the sibling `mail-backup` job on this same cluster.
- `kubectl kustomize` builds for base + `p0-lab`, and `kubectl apply --dry-run=server` accepts the CronJob and the new PVC.

## Notes for reviewers
- **Do not merge without deciding PVC size** — 100Gi matches the source; dial down if the registry backup footprint should be capped instead.
- Coupling with the `mail-backup` lane: that lane must keep its `fsGroup` off the **source** (mount source read-only, write only to the destination PVC). This minio-sync design already follows that rule (source via S3, never mounted).