### PR TITLE
workspace-mail: mail-backup can write (source untouched), rejects empty backups, + never-succeeded CronJob alert

### DIFF
--- a/infra/k8s/observability/base/kustomization.yaml
+++ b/infra/k8s/observability/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - otel-collector-service.yaml
   - servicemonitor.yaml
   - prometheusrule-slos.yaml
+  - prometheusrule-cronjob-staleness.yaml

--- a/infra/k8s/observability/base/prometheusrule-cronjob-staleness.yaml
+++ b/infra/k8s/observability/base/prometheusrule-cronjob-staleness.yaml
@@ -1,0 +1,66 @@
+# CronJob staleness -- fires for a scheduled CronJob that has not SUCCEEDED in
+# too long, INCLUDING one that has never succeeded even once.
+#
+# The obvious rule is silently wrong. The canonical form
+#     time() - kube_cronjob_status_last_successful_time > <threshold>
+# returns ZERO series for a job that has NEVER succeeded, because
+# kube_cronjob_status_last_successful_time has no series for that job at all --
+# so the jobs most in need of an alert (broken since creation: mail-backup and
+# minio-sync are both failing nightly and unalerted) are exactly the ones it
+# cannot see. Verified against live Prometheus: both are absent from that metric.
+#
+# The second, `unless`, arm is the fix: kube_cronjob_status_last_schedule_time
+# exists for every job that has ever been scheduled, so
+#     kube_cronjob_status_last_schedule_time * 0 unless kube_cronjob_status_last_successful_time
+# emits a 0-valued marker for every scheduled-but-never-succeeded job. `and on
+# (namespace,cronjob) (kube_cronjob_spec_suspend == 0)` drops deliberately
+# suspended jobs. A lane confirmed this expression returns both mail-backup and
+# minio-sync today.
+#
+# DELIVERY (read before assuming this pages anyone): the alert carries the
+# metric's own namespace label -- namespace=socioprophet for mail-backup. The
+# alert-sink AlertmanagerConfig added in #1112 is operator-scoped OnNamespace
+# and matches namespace=observability ONLY. Estate-wide delivery for
+# socioprophet/ instead depends on #1112's Alertmanager DEFAULT-route change
+# (deploy/argocd/observability-services.yaml), which is still `null` until that
+# Argo app syncs. So this rule is LIVE in Prometheus immediately (visible in the
+# UI and API) but is NOT delivered to a human until #1112 lands -- it fires into
+# the null sink today. It is intentionally NOT relabelled into observability:
+# that would misattribute a socioprophet CronJob to the observability namespace
+# just to borrow #1112's sub-route. Reference #1112's routing; do not fork it here.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cronjob-staleness
+  namespace: observability
+  labels:
+    bundle: observability
+    release: kube-prometheus-stack   # adopted by the stack's ruleSelector (ruleSelectorNilUsesHelmValues: false)
+spec:
+  groups:
+    - name: cronjob.staleness
+      rules:
+        - alert: CronJobNotSucceeding
+          # Arm (a): succeeded at least once, but not within 2 days -> stale.
+          # Arm (b): scheduled at least once but NEVER succeeded -> the `unless`
+          #          marker the naive last_successful_time rule is blind to.
+          # Both intersected with spec_suspend == 0 so a suspended job is silent.
+          expr: |
+            (
+              (time() - kube_cronjob_status_last_successful_time > 86400 * 2)
+              or
+              (kube_cronjob_status_last_schedule_time * 0 unless kube_cronjob_status_last_successful_time)
+            )
+            and on(namespace, cronjob) (kube_cronjob_spec_suspend == 0)
+          for: 1h
+          labels: { severity: warning }
+          annotations:
+            summary: "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} has not succeeded in over 2 days (or has never succeeded)"
+            description: >-
+              A scheduled, non-suspended CronJob has no successful completion in
+              the staleness window -- the never-succeeded case included, which the
+              naive `time() - kube_cronjob_status_last_successful_time` expression
+              cannot see because the metric has no series for a job that never
+              succeeded. Inspect the Job's pods and logs; a backup/sync job here
+              has been failing silently every night.
+            runbook: infra/k8s/observability/README.md

--- a/infra/k8s/workspace-mail/base/backup-cronjob.yaml
+++ b/infra/k8s/workspace-mail/base/backup-cronjob.yaml
@@ -24,6 +24,56 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
+          # Make ONLY the backup DESTINATION writable by uid 1000. The
+          # workspace-mail-backup PVC is a freshly provisioned PD whose root is
+          # root:root 0755, so the unprivileged backup container cannot create the
+          # tarball in it (EACCES). This initContainer chowns that one mount.
+          #
+          # This deliberately does NOT use a pod-level `fsGroup`: fsGroup applies
+          # to EVERY volume the pod mounts, so it would also rewrite the read-only
+          # mail SOURCE volume's root group ownership (to root:1000) — and even
+          # `fsGroupChangePolicy: OnRootMismatch` re-applies it on the next run
+          # after the ownership is restored, so it would fight the lane restoring
+          # /var/mail/vhosts and dirty the source every night. This container
+          # never mounts the mail source, so the source's ownership is provably
+          # untouched by the backup job.
+          initContainers:
+            - name: init-backup-perms
+              image: registry.socioprophet.ai/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  # Non-recursive: the backup only needs to CREATE new tarballs in
+                  # the destination root. Existing backups keep their ownership;
+                  # the destination's own lost+found is left alone.
+                  chown 1000:1000 /backup
+                  echo "init: /backup now owned by 1000:1000 (destination only; mail source untouched)"
+              volumeMounts:
+                # DESTINATION ONLY. The mail source is intentionally absent here.
+                - name: backup-target
+                  mountPath: /backup
+              securityContext:
+                # Root ONLY to chown, with just CAP_CHOWN. The pod default is
+                # runAsNonRoot: true; it is overridden here for this one step. The
+                # main backup container still runs unprivileged as uid 1000.
+                runAsNonRoot: false
+                runAsUser: 0
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+                  add: ["CHOWN"]
+                seccompProfile:
+                  type: RuntimeDefault
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 16Mi
+                limits:
+                  cpu: 50m
+                  memory: 32Mi
           containers:
             - name: mail-backup
               # Stock alpine, mirrored in our sovereign zot and pinned BY DIGEST.
@@ -34,9 +84,15 @@ spec:
               # one-liner, so it needs no first-party image at all — only a shell and tar.
               # Digest, not tag: zot carries library/alpine as :latest only, and a moving
               # tag on a backup job means the backup silently changes underfoot.
-              # Probe-verified in-cluster before this change (socioprophet namespace, this
-              # exact digest, uid 1000, caps dropped, seccomp RuntimeDefault): the pull
-              # succeeds and the one-liner produces a real, listable .tar.gz.
+              # PULL probe only (socioprophet namespace, this exact digest, uid 1000, caps
+              # dropped, seccomp RuntimeDefault): the pull succeeds and the shell+tar payload
+              # executes. Corrected from an earlier "produces a real, listable .tar.gz" claim:
+              # that could NOT have run against the real backup PVC. uid 1000 gets EACCES
+              # writing to a freshly provisioned destination PD (root:root 0755); any listable
+              # archive the probe produced was written to a throwaway writable dir, not
+              # workspace-mail-backup. A real archive is produced only after the
+              # init-backup-perms container below chowns the destination, and the size gate in
+              # the command rejects the trivially small (empty-maildir) case.
               image: registry.socioprophet.ai/library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
               env:
                 # Keep 7 dailies. The source is a 10Gi mail volume against a 20Gi

--- a/infra/k8s/workspace-mail/base/backup-cronjob.yaml
+++ b/infra/k8s/workspace-mail/base/backup-cronjob.yaml
@@ -107,6 +107,13 @@ spec:
                 # Refuse to start a backup that cannot fit. See below.
                 - name: MIN_FREE_MB
                   value: "3000"
+                # Floor for a NON-TRIVIAL archive, in bytes. An empty maildir tars
+                # to ~130 bytes and lists fine, so "readable" (step 5) is not
+                # enough to call it a backup. Below this the job FAILS instead of
+                # recording a meaningless green run. Raise once the maildir has a
+                # known floor of real mail.
+                - name: MIN_BACKUP_BYTES
+                  value: "1024"
               command:
                 - /bin/sh
                 - -c
@@ -168,7 +175,14 @@ spec:
                   fi
 
                   # --- 4. write ----------------------------------------------
-                  if ! tar czf "${OUT}" /maildata; then
+                  # Archive the maildir contents from inside the mount and skip
+                  # ext4's lost+found (root:root 0700 on a fresh PD). Excluding it
+                  # means the job never needs group access to the mount root just
+                  # to traverse lost+found, so the write does not lean on volume
+                  # ownership to READ the source -- only the destination needs the
+                  # initContainer chown to WRITE. `-C /maildata .` also drops the
+                  # /maildata/ prefix so a restore lands straight in the maildir root.
+                  if ! tar czf "${OUT}" -C /maildata --exclude=./lost+found .; then
                     log "FAILED: tar returned non-zero"
                     rm -f "${OUT}"
                     RC=1
@@ -182,6 +196,23 @@ spec:
                     log "FAILED: ${OUT} is not a readable gzip archive — removing"
                     rm -f "${OUT}"
                     RC=1
+                  fi
+
+                  # --- 5b. non-triviality gate -------------------------------
+                  # A readable archive can still be an EMPTY one. The maildir is
+                  # currently empty, and an empty maildir tars to ~130 bytes that
+                  # step 5 lists happily -- a green backup of nothing. Treat a
+                  # trivially small archive as a FAILURE so "the check that cannot
+                  # fail" cannot pass here either. Byte-precise (wc -c), unlike the
+                  # receipt's du -m which rounds a 130-byte file to 1MB.
+                  if [ "${RC}" -eq 0 ]; then
+                    BYTES=$(wc -c < "${OUT}" | tr -d ' ')
+                    log "size-gate: ${OUT} is ${BYTES} bytes, floor MIN_BACKUP_BYTES=${MIN_BACKUP_BYTES}"
+                    if [ "${BYTES}" -lt "${MIN_BACKUP_BYTES}" ]; then
+                      log "FAILED: ${OUT} is ${BYTES} bytes (< ${MIN_BACKUP_BYTES}) -- empty/near-empty maildir, refusing to record a trivial backup"
+                      rm -f "${OUT}"
+                      RC=1
+                    fi
                   fi
 
                   # --- 6. receipt --------------------------------------------

--- a/infra/k8s/workspace-mail/tests/backup-nontrivial.test.sh
+++ b/infra/k8s/workspace-mail/tests/backup-nontrivial.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Proof that the mail-backup non-triviality gate fails a trivial (empty-maildir)
+# archive and passes a real one.
+#
+# It does NOT re-implement the backup logic. It renders the SHIPPED manifest
+# (kubectl kustomize), extracts the mail-backup container's command script and
+# its env defaults verbatim, and runs THAT against two synthesized maildir
+# fixtures. The only transformation is localizing the two mount paths
+# (/maildata, /backup) to temp dirs so it can run unprivileged off-cluster; the
+# tar invocation, the tar-tzf verify and the wc -c size gate are the real ones.
+#
+# Local-only (Actions are spend-capped). Requires: kubectl, python3, tar.
+# Provides a sha256sum shim (-> shasum -a 256) so the receipt step runs on macOS.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BASE="$(cd "$HERE/../base" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# sha256sum shim for macOS (Linux/alpine already have it).
+mkdir -p "$WORK/shim"
+if ! command -v sha256sum >/dev/null 2>&1; then
+  cat >"$WORK/shim/sha256sum" <<'EOF'
+#!/bin/sh
+exec shasum -a 256 "$@"
+EOF
+  chmod +x "$WORK/shim/sha256sum"
+fi
+export PATH="$WORK/shim:$PATH"
+
+# --- extract the shipped script + env defaults from the rendered manifest ----
+kubectl kustomize "$BASE" >"$WORK/rendered.yaml"
+python3 - "$WORK/rendered.yaml" "$WORK/script.sh" "$WORK/env.sh" <<'PY'
+import sys, yaml
+rendered, script_out, env_out = sys.argv[1], sys.argv[2], sys.argv[3]
+docs = list(yaml.safe_load_all(open(rendered)))
+cj = [d for d in docs if d and d.get("kind") == "CronJob" and d["metadata"]["name"] == "mail-backup"][0]
+c = cj["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"][0]
+open(script_out, "w").write(c["command"][2])
+with open(env_out, "w") as f:
+    for e in c["env"]:
+        f.write('export %s=%s\n' % (e["name"], e.get("value", "")))
+PY
+
+# Localize ONLY the mount paths. Logic (tar/verify/size-gate/receipt) untouched.
+SRC="$WORK/src"; DST="$WORK/dst"
+mkdir -p "$SRC" "$DST"
+sed "s#/maildata#$SRC#g; s#/backup#$DST#g" "$WORK/script.sh" >"$WORK/script.local.sh"
+
+run_backup() { ( set -a; . "$WORK/env.sh"; set +a; sh "$WORK/script.local.sh" ); }
+
+pass=0; fail=0
+ok()   { echo "  PASS: $1"; pass=$((pass+1)); }
+bad()  { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+# ---------------------------------------------------------------------------
+echo "== fixture A: empty maildir (zero mail) =="
+rm -rf "$SRC" "$DST"; mkdir -p "$SRC" "$DST"
+# ext4 lost+found (proves the exclude) + the empty maildir skeleton dovecot lays
+# down with NO messages. This is the live 'zero mail' state.
+mkdir -p "$SRC/lost+found" "$SRC/example.com/alice/Maildir/cur" \
+         "$SRC/example.com/alice/Maildir/new" "$SRC/example.com/alice/Maildir/tmp"
+echo "orphan" >"$SRC/lost+found/#123"
+
+# Show the archive size this state produces with the shipped tar invocation.
+tar czf "$WORK/empty.tar.gz" -C "$SRC" --exclude=./lost+found . 2>/dev/null
+EMPTY_BYTES=$(wc -c < "$WORK/empty.tar.gz" | tr -d ' ')
+echo "  empty-maildir archive is ${EMPTY_BYTES} bytes (live-observed ~130)"
+if [ "$EMPTY_BYTES" -lt 1024 ]; then ok "empty archive is trivially small (< 1024B floor)"; else bad "empty archive unexpectedly >= 1024B"; fi
+
+set +e; out="$(run_backup 2>&1)"; rc=$?; set -e
+echo "$out" | sed 's/^/    | /'
+[ "$rc" -ne 0 ] && ok "job FAILED on empty maildir (exit $rc)" || bad "job passed on empty maildir (should fail)"
+echo "$out" | grep -q "refusing to record a trivial backup" && ok "size gate emitted the refusal" || bad "no size-gate refusal in output"
+ls "$DST"/mail-*.tar.gz >/dev/null 2>&1 && bad "trivial archive was left on disk" || ok "trivial archive was removed, not receipted"
+
+# ---------------------------------------------------------------------------
+echo "== fixture B: populated maildir (real mail) =="
+rm -rf "$SRC" "$DST"; mkdir -p "$SRC" "$DST"
+mkdir -p "$SRC/lost+found" "$SRC/example.com/alice/Maildir/cur"
+echo "orphan" >"$SRC/lost+found/#123"
+MSG="$SRC/example.com/alice/Maildir/cur/1706500000.M1P1.mail:2,S"
+{
+  echo "From: bob@example.com"
+  echo "To: alice@example.com"
+  echo "Subject: Q3 board pack"
+  echo "Date: Tue, 29 Jul 2026 09:00:00 +0000"
+  echo
+  echo "Alice -- attaching the board pack. Regards, Bob"
+  echo
+  # High-entropy blob so the archive is non-trivial even after gzip (models an
+  # attachment); guarantees it clears the 1024-byte floor.
+  head -c 6144 /dev/urandom | base64
+} >"$MSG"
+
+set +e; out="$(run_backup 2>&1)"; rc=$?; set -e
+echo "$out" | sed 's/^/    | /'
+[ "$rc" -eq 0 ] && ok "job SUCCEEDED on populated maildir (exit 0)" || bad "job failed on real mail (should pass)"
+ARCH="$(ls "$DST"/mail-*.tar.gz 2>/dev/null | head -n1 || true)"
+if [ -n "$ARCH" ]; then
+  ok "archive retained: $(basename "$ARCH")"
+  B=$(wc -c < "$ARCH" | tr -d ' '); [ "$B" -ge 1024 ] && ok "real archive is ${B} bytes (>= 1024B floor)" || bad "real archive ${B}B under floor"
+  if tar tzf "$ARCH" | grep -q "lost+found"; then bad "lost+found leaked into the archive"; else ok "lost+found excluded from archive"; fi
+  tar tzf "$ARCH" | grep -q "alice/Maildir/cur" && ok "real mail present in archive" || bad "mail missing from archive"
+else
+  bad "no archive produced for populated maildir"
+fi
+
+echo
+echo "RESULT: ${pass} passed, ${fail} failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What this makes durable

Three fixes a cluster lane verified live for the `mail-backup` CronJob. ArgoCD runs
`selfHeal: true`, so the live `kubectl` patches get reverted — this lands them in git.

**Stacked on #1114** (`feat/storage-retention`), not `main`. #1114 rewrites this exact
command block (retention + `tar tzf` verify + receipt). Rebuilding the fix beside it on
`main` would produce a third divergent `backup-cronjob.yaml`. Stacking makes the change
strictly additive on #1114 instead (see Overlap). **Do not merge before #1114.**

### 1. Backup can't write — fixed WITHOUT touching the mail source
`mail-backup` runs as uid 1000; `workspace-mail-backup` is a fresh PD (`root:root 0755`),
so the container gets `EACCES` creating the tarball.

The obvious fix — a pod-level `fsGroup: 1000` — is **wrong here**. `fsGroup` applies to
*every* mounted volume, including the read-only mail **source**, and rewrites its root
group to `1000` (this is what dirtied `/var/mail/vhosts` to `root:1000 2775` during live
verification). `fsGroupChangePolicy: OnRootMismatch` does **not** save you: it re-applies
on the next run after the ownership is restored, so it would fight the parallel lane
restoring `/var/mail/vhosts` and re-dirty the source every night.

Instead: an **`init-backup-perms` initContainer** (root, `CAP_CHOWN` only) chowns
**only** the destination mount. **The mail source is never mounted into it, so the source
volume's ownership is provably untouched by this job.** Verified in the rendered manifest:
the initContainer's only `volumeMount` is `backup-target`.

Also corrected the image comment (from `dc7344cd`): its "produces a real, listable
.tar.gz" claim could not have run against the real backup PVC (it `EACCES`es on a fresh
PD). Reworded to "pull probe only", not deleted.

### 2. Skip `lost+found`, and reject an empty backup as a FAILURE
- `tar -C /maildata --exclude=./lost+found .` — skips ext4's `root:root 0700` `lost+found`,
  so the job never needs group access to the mount root just to traverse it. The read side
  no longer leans on volume ownership; only the destination needs the chown to write.
- **Non-triviality gate** (`MIN_BACKUP_BYTES`, default `1024`): the maildir is empty, so the
  verified artifact was **130 bytes** — a readable `.tar.gz` of nothing that #1114's
  `tar tzf` verify passes happily. The gate makes a trivially small archive a failure
  (`rm` it, receipt `status=failed`, exit 1), closing the "check that cannot fail" here too.

### 3. `PrometheusRule` for CronJobs that never succeed
`infra/k8s/observability/base/prometheusrule-cronjob-staleness.yaml`. Nothing watched for a
CronJob that stopped succeeding, and the **canonical rule is silently wrong**:
`time() - kube_cronjob_status_last_successful_time > N` returns **zero series** for a job
that *never* succeeded (the metric has no series for it) — so the broken-since-creation jobs
(`mail-backup`, `minio-sync`) are exactly the ones it can't see. The shipped expression adds
the `unless` arm that emits a marker for every scheduled-but-never-succeeded job, `and`ed
with `spec_suspend == 0`.

## Routing — reaches the null sink until #1112 (stated plainly)
The alert keeps its metric namespace (`namespace=socioprophet` for `mail-backup`). #1112's
`alert-sink` AlertmanagerConfig is operator-scoped `OnNamespace` and matches
`namespace=observability` **only**; estate-wide delivery for `socioprophet/` depends on
#1112's Alertmanager **default-route** change (`deploy/argocd/observability-services.yaml`),
still `null` until it syncs. So this rule is **live in Prometheus immediately but delivered
to no human until #1112 lands.** It is intentionally **not** relabelled into `observability`
(that would misattribute a `socioprophet` CronJob just to borrow #1112's sub-route).
Referencing #1112's routing, not forking it — I did not touch any `alert-delivery/**` file.

## Overlap (`merge-tree` vs the live lanes)
My 4-file delta intersects the live lanes on exactly **one** file:

| Lane | Overlap |
|------|---------|
| #1112 alert-delivery | none |
| #1113 rule-liveness-guard | none |
| #1114 storage-retention | `infra/k8s/workspace-mail/base/backup-cronjob.yaml` only |

Resolved by stacking: `git diff feat/storage-retention..HEAD` is additive (the only
in-place edits are the corrected comment and adding `--exclude` to #1114's `tar` line;
its retention/verify/receipt are untouched). Proof:
- `merge-tree` of an equivalent **main-based** edit × #1114 → **CONFLICT** in
  `backup-cronjob.yaml` (the third-divergent-block outcome, avoided).
- `merge-tree` of **this branch** × #1114 → **clean** (descendant).

## Proof (local only — Actions are spend-capped, so no CI run here)
- `kubectl kustomize` renders clean for all five affected kustomizations
  (workspace-mail base + p0-lab + p1-single-site; observability base + p0-lab).
- **Staleness expr, inverted vs correct** — faithful PromQL set-semantics model over
  representative kube-state-metrics series: naive form returns only the once-succeeded stale
  job (blind to `mail-backup`/`minio-sync`); shipped form returns `mail-backup` **and**
  `minio-sync`, suppressing suspended + healthy jobs. Corroborates the live-Prometheus lane
  confirmation.
- **Size gate** — `infra/k8s/workspace-mail/tests/backup-nontrivial.test.sh` runs the
  *shipped* script (extracted from `kubectl kustomize`, mount paths localized) against
  synthesized fixtures: empty maildir → 215-byte archive → **exit 1**, archive removed,
  receipt `status=failed`; populated maildir → 6755-byte archive → **exit 0**, retained,
  `lost+found` excluded, mail present. 9/9.

## Deviations / notes
- The brief asked for `fsGroup: 1000` + `fsGroupChangePolicy: OnRootMismatch`. Replaced with
  the initContainer per the source-untouched requirement (fsGroup can't be scoped to one
  volume). Same intent ("the backup can't write without it"), without dirtying the source.
- Stacked off #1114, not `origin/main` — the only way to ship the size gate as code without
  a third divergent command block.
- Out of scope by instruction: no mail-volume `chown` restore (separate flagged decision);
  no autoscaling/HPA/PDB; no edits to `alert-delivery/**` (#1112) or `infra/k8s/zot/**` (#1091).

Do not merge.
