### PR TITLE
docs+tools(devsecops): retrospective v0.1 + runaway-timeout / single-copy / hermeticity guards

### DIFF
--- a/docs/architecture/devsecops-retrospective-and-recovery-v0.1.md
+++ b/docs/architecture/devsecops-retrospective-and-recovery-v0.1.md
@@ -1,0 +1,560 @@
+# DevSecOps Retrospective and Recovery v0.1
+
+Status: post-mortem + recovery program (design doc with shipped guards)
+Plane: Prophet Platform DevSecOps Intelligence Workroom
+Umbrella: `SocioProphet/prophet-platform#519`
+Companion: the Wave-0 DevSecOps design produced this session (recon + architecture;
+live plane `apps/devsecops-intelligence/`, receipts on the
+`contracts/EvidenceReceipt.v0.1.json` spine, meta-control = the **Control Teeth
+Register**). This document is the reflective half of that work: it names what
+broke while the estate was being built and turns each failure into a durable guard.
+
+Prior lineage (committed): `docs/architecture/devsecops-intelligence-workroom-v0.1.md`
+and the `docs/architecture/devsecops-workroom-*-v0.1.md` scope notes, closed under
+`devsecops-workroom-v0.1-status.md`.
+
+> **Provenance note (a live class-D instance — read this first).** The Wave-0
+> design and the Control Teeth Register it defines are, at the time of writing,
+> **not committed to `origin/main`**. A content sweep of the whole prophet-platform
+> tree (8,471 files, node walker — not shimmed grep) finds zero occurrences of
+> "Control Teeth Register" or the path `apps/devsecops-intelligence/`. The design
+> that specifies our recovery program is itself single-copy, in-flight work. That
+> is not an aside; it is Failure Class D happening to the very artifact meant to
+> cure it, and it is why this document cross-links Wave-0 by *intent* rather than
+> by a committed SHA. **Proof obligation:** this doc is not "done" until the Wave-0
+> design is pushed and this note can be replaced with its commit/PR reference.
+
+## How to read this
+
+This is a post-mortem, not a victory lap. One build cycle produced real
+capability and a long tail of silent failures; the failures are the subject here.
+
+Two of the seven classes — **F (verified commands, not artifacts)** and **G
+(instruments lied silently)** — are substantially *the operator's own mistakes*:
+claims accepted because a command exited zero, conclusions built on a `grep` that
+silently returned empty. They are written that way on purpose. A retrospective
+that launders operator error into "tooling gaps" learns nothing.
+
+Each class below has the same shape:
+
+- **What happened** — the observed incident(s).
+- **Root cause** — the mechanism, not the symptom.
+- **Program change + proof obligation** — the durable guard, and the crisp test
+  that means it is real: *done when X is observed failing, then passing.* A guard
+  with no red-then-green proof is exactly the disease it is meant to cure.
+
+---
+
+## The seven failure classes
+
+### A. Controls that cannot fail — *the keystone*
+
+**What happened.** 22+ instances in one cycle of a control that structurally
+could not report the failure it existed to catch:
+
+- an alert with `health=ok` computed over a **zero-length** metric series (no data
+  read as healthy);
+- a required check that emitted **no verdict for three commits** — six-hour runs
+  ending in `cancelled`, which a rollup renders as absent, not failed;
+- a provenance checker that **printed its own success line** regardless of what it
+  read (a receipt invariant that computed its own sha256, built the string, and
+  asserted the string it had just built);
+- `assert`-based validation that **vanishes under `python -O`**;
+- a `.sourceos/manifest.json` **nothing reads**;
+- provider pins **nothing loads**;
+- `track-minor` implemented as `track-major`;
+- a trust-floor a caller **sets for itself**;
+- `tools/validate_manifest_declarations.py`, whose own `KNOWN_UNIMPLEMENTED` string
+  literals entered its `git ls-files` corpus at commit time, so **every deferred
+  item matched itself** and the check went green the moment it was tracked
+  (correct on the authoring branch, silently vacuous forever after merge).
+
+**Root cause.** A check that inspects an *artifact* ("does it import?", "is there a
+PROVENANCE.md?", "does the string match?") passes trivially while the *connection*
+it was supposed to prove is absent. Only a check of the connection can fail. This
+is the estate's first rule — *ask what calls this* — living inside the verification
+layer: the guard was built correctly and wired to nothing, and every gate that
+inspected the guard reported green.
+
+**Program change + proof obligation.** The **Control Teeth Register** (Wave 2, the
+keystone; scoped below, not built here). Every control is an entry with a
+mandatory `red_proof`: a committed mutation that makes it fail, exercised on a
+cadence. A control with no green→red→green transition on record is `SUSPECT` and
+does not count as coverage.
+*Done when* a scheduled mutation flips each registered control red and the register
+records the transition; a control that cannot be made to fail is quarantined, not
+trusted. Cross-ref: `feedback_self_validating_checker`, `feedback_ask_what_calls_this`,
+`project_declared_unenforced_register`, `project_blueprint_audit_verdict`.
+
+### B. Substrate ate itself
+
+**What happened.**
+
+- A laptop disk reached **0 bytes**; `ENOSPC` silently killed a `git commit`
+  mid-write and hard-blocked every lane (see Class D for what was lost with it).
+- An **agent-machine test suite wrote through modules that resolved paths under the
+  real `~/.noetica`** and destroyed the operator's live A2A trust ledger —
+  *unrecoverably* — leaving **921 residue directories**. The test "passed".
+- Registry MinIO hit **100% full** and silently failed image pushes.
+
+**Root cause.** Non-hermetic execution against operator state. Tests and jobs ran
+with write authority over the real `$HOME` and shared substrate, and nothing
+distinguished "sandbox scratch" from "the live ledger". Disk and quota exhaustion
+presented as unrelated command failures instead of a named substrate state.
+
+**Program change + proof obligation.** (1) **Ephemeral cloud execution** for
+suites that can mutate substrate (scoped below — its own wave). (2) **Test-
+hermeticity gate** — *built this wave*, see `tools/check_test_hermeticity.py`: a
+test-reachable module that resolves a non-redirectable **write** path under real
+`$HOME` fails the gate. (3) **Backup-before-mutate** for any op that overwrites
+operator state (scoped: hook, below).
+*Done when* the hermeticity gate flags a planted `Path.home()/…` write and stays
+green on the env-redirectable form — **observed both ways this wave** (6/6 selftest
+cases). Cross-ref: Noetica #585 (the specific `lib/` fix this generalises).
+
+### C. Budget masqueraded as failure
+
+**What happened.** The GitHub Actions **spend cap** was reached; ~**456 runs
+queued**; for hours this read as "runner saturation" and blocked merges. Because a
+capped/queued job presents as `action_required` or as an absent verdict — never as
+an explicit "you are out of budget" — the required check simply never reported and
+PRs blocked *silently*. The proximate burn: **unbounded 6-hour test hangs** that
+consumed the allowance and held runners the whole time.
+
+**Root cause.** Two compounding gaps. (1) Billing/quota is not a monitored state,
+so exhaustion is indistinguishable from infrastructure failure. (2) **Not one job
+in the repo declared a `timeout-minutes` bound**, so any hung step ran to
+GitHub's 360-minute (6h) default — a budget bomb on every job.
+
+**Program change + proof obligation.** (1) **Billing/quota as a first-class
+monitored state** (scoped below — do not conflate a bill with an outage). (2)
+**Runaway-job hard-timeout policy**, enforced by the **timeout auditor** — *built
+this wave*, `tools/check_workflow_timeout_bounds.py`. (3) **Absent-verdict
+detector**: a required check that reports *nothing* for N commits is treated as
+red, not neutral (scoped below).
+*Done when* the auditor fails on any unbounded job and the count of unbounded jobs
+trends to zero. **Measured today: 122 of 123 jobs across 105 workflows are
+unbounded** (the 123rd is a reusable-workflow call, exempt-but-surfaced). See the
+guards ledger. Cross-ref: `project_ci_throughput_path_filters` (PR #1045/#1101).
+
+### D. Recovery fragile — single-copy work
+
+**What happened.** **47 + 43 + 33 unpushed commits** across three repos, plus a
+`git stash` holding the **sole copy** of the ST018 sovereign-Gitea manifest — all
+on the one disk that hit zero (Class B). Work that exists in exactly one place is
+one `ENOSPC` from gone. (Estate-wide, a later audit found **184 stranded
+branches / 783 commits** with no route to main — though note that `ahead_by` alone
+over-counts strandedness ~4×; only a blob-level test is truth. See Class G.)
+
+**Root cause.** No visibility of single-copy work before the disk died, and no
+push-early discipline. The cost is asymmetric: pushing is cheap and constant;
+reconstructing lost uncommitted work is impossible.
+
+**Program change + proof obligation.** (1) **Unpushed-work / single-copy detector**
+— *built this wave*, `tools/detect_unpushed_single_copy.py`: reports commits,
+stashes, and dirty worktrees that exist on no remote, across the dev roots. (2)
+**Push-early doctrine** + a commit/stop hook that surfaces single-copy work
+(scoped: hook, below).
+*Done when* the detector flags a planted local-only commit and clears the instant
+it is pushed — **observed both ways this wave** (4/4 selftest cases, full
+lifecycle). Cross-ref: `project_stranded_work_register`.
+
+### E. Resume-from-intent
+
+**What happened.** Lanes died mid-`chown`, mid-delete, and mid-canary. On resume,
+work restarted from the *intended* end state rather than the *actual* partial
+state, so operations double-applied — re-running a half-finished `chown`, deleting
+what a prior half-run had already moved, promoting a canary that was already half-
+promoted. A related shape: an ordered rollback (boot #50 then source-os #305) where
+resuming out of order was a silent no-op because the order was load-bearing.
+
+**Root cause.** Operations assumed a clean starting point and were not idempotent.
+Recovery read the plan, not the ground.
+
+**Program change + proof obligation.** **Idempotent, state-re-reading ops**: every
+recovery step re-derives current state and computes the delta, so re-running is a
+no-op, not a double-apply. Ordered sequences carry an explicit precondition check
+per step.
+*Done when* each recovery runbook step passes a re-entrancy test — run it, kill it
+mid-way, run it again, and assert the end state is identical and side-effect-free.
+(Design this wave; enforcement scoped.) Cross-ref: `project_rollback_silent_noop`.
+
+### F. Verified the command, not the artifact — *operator error*
+
+**What happened.** Repeatedly this cycle, a claim was accepted because a *command*
+succeeded, while the *artifact* told a different story. These were the operator's
+own calls, and they are logged as such:
+
+- **"pushed, nothing lost"** — the `git push` ran; the commit it was meant to carry
+  had never landed (the `git commit` had died on `ENOSPC`). `git ls-remote` would
+  have shown the SHA absent.
+- **"Copilot triggered"** — a comment was posted; Copilot was never a *registered
+  reviewer* on the PR, so no review ran. A comment is not a reviewer.
+- **`0F/8P` read as green** — the required context was *absent* from the rollup, not
+  passing; "no failures shown" was read as "no failures".
+- **stale memory passed as a live constraint** — a remembered fact was quoted as a
+  current blocker without re-checking the artifact it described.
+
+**Root cause.** Confusing an action's *exit status* with its *effect*. A zero exit
+proves the command ran, never that the world changed the way intended.
+
+**Program change + proof obligation.** **Every claimed action is verified against
+its artifact**, and ChatOps must *show its warrant* rather than report intent:
+"pushed" ships the `git ls-remote` line; "reviewer requested" ships the reviewer
+list; "green" ships the list of *required* contexts present, not the absence of red.
+*Done when* the Workroom report surface refuses to render a claim without its
+artifact reference (ties to the `EvidenceReceipt.v0.1.json` spine: a claim with no
+`evidence_refs` is not a claim). Cross-ref: `feedback_ask_what_calls_this`,
+`feedback_subagent_verification`, `project_copilot_review_backlog`.
+
+### G. Instruments lied silently — *operator error, compounded by shimmed tools*
+
+**What happened.** Load-bearing conclusions were built on tools that returned empty
+or wrong *without erroring*. The operator trusted a clean result from an instrument
+that could silently return nothing:
+
+- **`grep`/`rg`/`find` are shimmed here.** `rg` runs via a shim (`ARGV0=rg`) that
+  inherits gitignore/hidden defaults; `grep` is a shell function routing to a
+  `ugrep` shim that honours `.gitignore` (so `dist/`, `target/`, venvs are
+  invisible); even real BSD `grep` classifies invalid-UTF-8 files as binary and
+  returns **no match, silently**. A whole wrong blocker ("the super-peer deploy is
+  blocked on a missing engine symbol") was reported and acted on — worktree torn
+  down, a version bump reverted — because `grep` returned empty for a symbol that
+  `node -e 'Object.keys(require(p))'` and the Read tool showed was present the
+  whole time.
+- **`diff -rq` under-reports**; a `zsh` `:a` modifier corrupted a ref; **`RC=$?`
+  caught `tail`, not `npm`** (last-command-in-pipeline); stale worktrees gave
+  false-clean; `gh` `issues/N/comments` had **~3% recall** and "no new comments"
+  carried **25 findings**; a scanner reported "fixed" having read nothing.
+- The stranded-work audit itself (Class D) was initially **4× too high** because
+  `ahead_by` counts squash-merge residue as loss; and its first blob-audit reported
+  *every* branch unique because a `git rev-list --objects` pipe was fed `sha path`
+  and resolved nothing — an **empty control set read as "all unique"**.
+
+**Root cause.** Trusting a *clean/empty* result from a tool that can return empty
+for reasons unrelated to truth. An empty grep is not evidence of absence; it is
+untrusted until a second, independent instrument agrees.
+
+**Program change + proof obligation.** (1) A **tooling-trust register** (see Config
+Reoptimization): for each instrument, its known silent-failure mode and the
+verified alternative. (2) **Load-bearing scans use verified methods** — a node
+walker sanity-checked against a *known positive*, blob-hash comparison with
+positive **and** negative controls — never a bare `grep`. (3) Never conclude
+absence from one instrument.
+*Done when* every load-bearing presence/absence claim in the Workroom is produced
+by a method that was first shown to *find the thing it is looking for* on a control
+(the walker in this very doc's guards was sanity-checked against a known-positive
+string before its zero results were trusted). Cross-ref:
+`feedback_grep_false_negatives_verify_with_node`, `project_stranded_work_register`.
+
+---
+
+## Config reoptimization — recommendations (propose; operator applies)
+
+> **These are recommendations, not changes.** Nothing in `~/.claude/`, `CLAUDE.md`,
+> `settings.json`, or the permission set has been modified by this work — the
+> harness executes hooks and enforces permissions, so an *agent* cannot and must
+> not self-authorize them. Each row names **who applies**. This is the durable
+> half of the retrospective: memory reminds; hooks and permissions *enforce*.
+
+### Summary table
+
+| Change | Rationale (class) | Who applies |
+|---|---|---|
+| **CLAUDE.md:** "Prove every gate goes red before you trust it green — push a deliberate failure, watch the required check fail, then fix. An unwired or unfailing gate is worse than none." | A — controls that cannot fail get quoted instead of run | Michael (edit `CLAUDE.md`) |
+| **CLAUDE.md:** "Verify the artifact, not the command. `pushed`→`git ls-remote` shows the SHA; `reviewer requested`→the reviewer is listed on the PR; `green`→the *required* contexts are present, not merely un-red." | F — exit status ≠ effect | Michael |
+| **CLAUDE.md:** "A control that has never failed is a suspect, not a success. If you cannot make it go red, it cannot go green." | A | Michael |
+| **CLAUDE.md tooling-trust list:** `grep`/`rg`/`find` are shimmed and silently return empty → use the node walker (sanity-checked vs a known positive) or Read; when grep and node/Read disagree, node/Read wins. | G | Michael |
+| **CLAUDE.md tooling-trust list:** `gh pr list` / `gh api …/comments` truncate and under-report (~3% recall seen) → page explicitly and cross-check counts before concluding "no new comments". | G | Michael |
+| **CLAUDE.md tooling-trust list:** pipelines hide failures — `RC=$?` captures the *last* command (`tail`, not `npm`). Use `set -o pipefail` or check `PIPESTATUS`. | G | Michael |
+| **CLAUDE.md tooling-trust list:** read `origin/main`, not a worktree — stale worktrees give false-clean. `git fetch` then compare against `origin/<base>`. | E, G | Michael |
+| **Hook (PreToolUse/Bash):** block `git commit` when free disk `< 1 GiB` — an `ENOSPC` mid-commit hard-blocks all lanes. | B, D | Michael (merge into `settings.json`) |
+| **Hook (PreToolUse/Bash):** before a test-runner command, run `check_test_hermeticity.py`; block if it finds a real-`$HOME` write sink. | B | Michael |
+| **Hook (Stop / PostToolUse):** run `detect_unpushed_single_copy.py` and surface single-copy work at session end and after commits. | D | Michael |
+| **Permissions:** allowlist read-only recovery diagnostics (`df`, `du`, `git status/log/ls-remote/stash list`, `kubectl get/describe`, `gh pr view`). | B, D, E | Michael (`settings.json` permissions) |
+| **Permissions:** allowlist the bounded recovery ops that were classifier-blocked mid-incident (`kubectl patch pvc …`, ownership-restore `chown` on operator paths) so recovery is not blocked when it is most needed. | B, E | Michael (review threat model, then allow) |
+
+### CLAUDE.md — exact lines to add
+
+```md
+## Verification discipline (earned, 2026-07)
+- Prove every gate goes RED before you trust it green: push a deliberate failure,
+  watch the required check fail, then fix. An unwired/unfailing gate is worse than
+  none — it gets quoted instead of run.
+- A control that has never failed is a SUSPECT, not a success.
+- Verify the artifact, not the command: `pushed`→`git ls-remote` shows the SHA;
+  `Copilot triggered`→the reviewer is registered on the PR; `green`→the *required*
+  contexts are present, not merely absent.
+## Tooling trust (instruments that lie silently here)
+- grep/rg/find are shimmed and return EMPTY silently → use the node walker
+  (sanity-checked against a known positive) or Read; node/Read wins ties.
+- gh pr list / gh api …/comments truncate (~3% recall seen) → page + cross-check.
+- Pipelines: RC=$? catches the LAST command (tail, not npm) → set -o pipefail.
+- Read origin/main, not a worktree (stale worktrees read false-clean).
+```
+
+### Hooks — concrete `settings.json` blocks (merge, don't overwrite)
+
+`grep` is avoided inside the hooks themselves (it is shimmed) — matching is done
+with shell `case`. A PreToolUse hook that exits non-zero **blocks** the tool call.
+
+```jsonc
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "comment": "Class B/D: refuse git commit under low disk (ENOSPC hard-blocks all lanes).",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); case \"$cmd\" in *'git commit'*) avail=$(df -Pk . | awk 'NR==2{print $4}'); if [ \"${avail:-0}\" -lt 1048576 ]; then echo 'BLOCK: <1GiB free — a commit can die on ENOSPC and hard-block every lane (retro class B). Free space first.' >&2; exit 2; fi;; esac"
+          },
+          {
+            "type": "command",
+            "comment": "Class B: block a test run if the repo has a real-$HOME write sink.",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); case \"$cmd\" in *pytest*|*'python -m pytest'*|*'npm test'*) python3 tools/check_test_hermeticity.py >/tmp/herm.$$ 2>&1 || { echo 'BLOCK: non-hermetic write under real $HOME (retro class B) — see:' >&2; cat /tmp/herm.$$ >&2; exit 2; };; esac"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "comment": "Class D: surface single-copy work at session end.",
+            "command": "python3 tools/detect_unpushed_single_copy.py --roots \"$HOME/dev\" || true"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Notes for the operator: PreToolUse `exit 2` blocks the call and shows stderr; the
+hermeticity hook assumes the tool is run from a repo that vendors
+`tools/check_test_hermeticity.py` (or point it at an absolute path). The `Stop`
+hook is advisory (`|| true`) so it informs without blocking session close.
+
+---
+
+## The feedback loop — failures become recurring detectors
+
+The point of this cycle, in Michael's framing: *"make sure the lessons reoptimize
+our configurations and learning/feedback loops."* A taxonomy that sits in a
+document is a one-time list. The mechanism below makes cycle N's failures
+**auto-arm** cycle N+1's guards. It reuses the estate's existing machinery — the
+Self-Improving Loop (`project_self_improving_loop`) and the Learning Apparatus
+(`project_learning_apparatus`) — rather than inventing a parallel one.
+
+### The register as a living detector set
+
+The **Control Teeth Register** (Wave 2) is not a checklist; it is a table of
+**detectors**, each seeded from one of the seven classes and each carrying a
+lifecycle state:
+
+```
+SEED      — a class from this taxonomy, with an example incident, no detector yet.
+SUSPECT   — a detector exists but has never been proven to fire (no red_proof).
+PROVEN    — a committed mutation makes it go red, and a normal case keeps it green.
+DECAYING  — a PROVEN detector whose red_proof has not been re-exercised this period.
+```
+
+Only **PROVEN** counts as coverage. A `SUSPECT` detector is treated exactly like
+the Class-A controls that started this document: present, green, and worthless.
+
+### Seeding from this cycle
+
+Each class becomes one or more seed detectors:
+
+| Class | Seed detector | Initial state |
+|---|---|---|
+| A | "every registered control has a red_proof exercised this period" | SUSPECT → the register bootstraps itself |
+| B | `check_test_hermeticity.py` (real-`$HOME` write sinks) | **PROVEN** (shipped this wave) |
+| C | `check_workflow_timeout_bounds.py` (unbounded jobs) | **PROVEN** (shipped this wave) |
+| C | absent-verdict detector (required check silent N commits = red) | SEED |
+| D | `detect_unpushed_single_copy.py` (single-copy work) | **PROVEN** (shipped this wave) |
+| E | recovery-step re-entrancy test (kill mid-run, re-run, assert no double-apply) | SEED |
+| F | "Workroom claim without `evidence_refs` is rejected" | SEED |
+| G | tooling-trust register + "load-bearing scan proven on a known positive" | SUSPECT |
+
+### Append-on-incident
+
+Every new incident closes its own loop:
+
+1. **Classify** the incident into A–G (extend the taxonomy if it fits none — that
+   is itself signal).
+2. **Append** a detector to the register, seeded from that class, in state
+   `SUSPECT`.
+3. **Prove it** — add the red_proof (a mutation test, in the shape of the
+   `selftest_*` scripts shipped this wave) and promote to `PROVEN`, or the detector
+   does not count.
+4. The Learning Apparatus records the incident→detector edge; the Self-Improving
+   Loop schedules the detector's red_proof into the cadence below.
+
+The timeout auditor is the worked example: it exists *because* an unbounded job
+burned the Actions budget this cycle (Class C). The incident seeded the detector;
+the detector shipped with a red_proof; the class is now armed for every future
+cycle. Cycle N's failure armed cycle N+1's guard — that is the whole loop.
+
+### Cadence
+
+- **Per PR:** PROVEN detectors relevant to the changed paths run as gates.
+- **Weekly:** a scheduled **mutation sweep** re-exercises every detector's
+  red_proof. Any detector that no longer goes red on its mutation drops to
+  `DECAYING` and pages. This is the upgrade path SUSPECT→PROVEN and the decay path
+  PROVEN→DECAYING; it is what keeps the register from rotting into Class A.
+- **Per cycle (retrospective):** new incidents append seeds; this document's
+  taxonomy is the seed corpus, versioned alongside the register.
+
+---
+
+## Guards shipped this wave (Part 2)
+
+All three are **new files** under `tools/`; none edits a contested file. Each ships
+with a `selftest_*` that proves it fires **both ways** (red on a planted defect,
+green on the clean case) — the Class-A discipline applied to the guards themselves.
+Evidence below is **local only** (Actions is spend-capped this cycle; nothing was
+run in CI — see wiring note).
+
+### 1. Runaway-job timeout auditor — `tools/check_workflow_timeout_bounds.py` (BUILT)
+
+Fails if any job in `.github/workflows/**` can run unbounded. A job with no
+`timeout-minutes` inherits GitHub's 360-minute (6h) default — the exact budget
+bomb that burned the Actions allowance (Class C). Parses real YAML (PyYAML, already
+a `tools/` dependency), not line-1 regex — the path-filter auditor shipped that
+bug (PR #1101). Jobs that call a reusable workflow (`uses:`) may not legally carry
+`timeout-minutes`; they are **exempt but surfaced**, never silently assumed. An
+empty scan or a parse error is a **failure**, not a pass.
+
+**Prove-it-fires (local):** `selftest_check_workflow_timeout_bounds.py` — **7/7**:
+unbounded→RED, bounded→GREEN, `timeout-minutes: 0`→RED, reusable-call→GREEN+listed,
+broken YAML→RED (fail-closed), empty dir→RED (no green from nothing), mixed→RED and
+names the offender.
+
+**Measured on `origin/main` today (`873433c5`):**
+
+```
+scanned_workflows=105  total_jobs=123  bounded_jobs=0
+UNBOUNDED_JOBS=122  reusable_exempt=1  parse_errors=0
+```
+
+**122 of 123 jobs are unbounded** — every non-exempt job is a 6h budget bomb. This
+is the count the class-C policy must drive to zero.
+
+### 2. Unpushed-work / single-copy detector — `tools/detect_unpushed_single_copy.py` (BUILT)
+
+A **local operator tool** (not CI). Across the dev roots it reports git work that
+exists on no remote: repos with no remote at all, unpushed commits (`rev-list
+--branches --tags --not --remotes`), stashes, and dirty worktrees — including
+linked worktrees parked outside the roots (e.g. in `/tmp`). Honest about its
+instrument: "on no remote" is judged against remote-tracking refs, which can be
+stale; `--fetch` refreshes first, and without it results over-approximate (never
+under-report genuinely-local work).
+
+**Prove-it-fires (local):** `selftest_detect_unpushed_single_copy.py` — **4/4**:
+a planted local-only commit is flagged and **clears the instant it is pushed**
+(full lifecycle); stashes flagged; no-remote repo flagged; a clean pushed clone
+reads **zero** (the negative control).
+
+### 3. Test-hermeticity gate — `tools/check_test_hermeticity.py` (BUILT; one part scoped)
+
+Generalises Noetica #585. Fails if importable code writes under the real `$HOME`
+without an environment redirect. AST-based (not regex — Class G): it flags
+`open(…, 'w')`, `write_text`/`write_bytes`/`touch`, `mkdir`/`os.makedirs`,
+`Path.open('w')`, `sqlite3.connect`, and `shutil` destinations whose path derives
+from `Path.home()` / `expanduser('~…')` / `os.environ['HOME']` / a `~/` literal —
+**unless** the path flows through `os.environ.get(KEY, …)` (KEY≠HOME), the
+redirectable idiom already used across the estate that makes a hermetic test point
+it at tmp.
+
+**Estate-generic vs per-repo (the task's question):** the **mechanism** is fully
+estate-generic — this file carries no Noetica-specific rule and ran clean over
+prophet-platform's 416 `tools/` modules. The **policy** — *which* `$HOME`
+subdirectories count as sacred operator state — is per-repo; v0.1 takes the strict
+default (any non-redirectable real-`$HOME` write is a violation) with an
+`--allow-subpath` escape hatch. **Scoped, not built:** true *test-reachability*
+(proving a specific test imports the offending module via import-graph tracing) is
+a later wave; this guard is a static over-approximation and says so.
+
+**Prove-it-fires (local):** `selftest_check_test_hermeticity.py` — **6/6**: five
+distinct raw-`$HOME` write patterns all flagged (RED); env-redirectable, tmp, and
+read-under-`$HOME` forms all clean (GREEN), each as an individual negative control.
+(The negative controls caught a real bug during development: `os.makedirs(path)`
+takes its path as an argument while `Path.mkdir()` takes it as a receiver — the
+first version conflated them and missed `os.makedirs`. Fixed; both now covered.)
+
+### Self-tests
+
+Named `selftest_*` (not `test_*`) so no `pytest` run auto-collects them; each is
+directly runnable and exits non-zero on failure:
+
+```
+python3 tools/selftest_check_workflow_timeout_bounds.py
+python3 tools/selftest_detect_unpushed_single_copy.py
+python3 tools/selftest_check_test_hermeticity.py
+```
+
+### Wiring (recommended, not done)
+
+`tools/` (#1111) and `validate-target-diagnostics.yml` (#1080/#1082) are contested
+lanes this cycle, so the auditor ships **standalone** — no existing workflow was
+edited, avoiding a collision. Recommended wiring, for the operator to apply when
+the lanes settle: add `python tools/check_workflow_timeout_bounds.py` as a step in
+an already-required job (it is fast, has no network dependency, and fails closed).
+Because the estate runs `strict_required_status_checks_policy: false` with a single
+required check (`diagnostics-gate`, held by `validate-target-diagnostics`), wiring
+it there makes it enforcing; wiring it into a non-required workflow makes it
+advisory only.
+
+---
+
+## Scoped for later waves (designed here, not built)
+
+Per the task, these are real engineering with their own waves — named with proof
+obligations, deliberately **not** implemented in this wave:
+
+- **Control Teeth Register (Wave 2 — keystone, Class A).** The living detector set
+  above. *Done when* a scheduled mutation makes each registered control go red and
+  the register records the transition; SUSPECT controls are quarantined from
+  counting as coverage.
+- **Billing/quota ingest as a monitored state (Class C).** *Done when* Actions
+  budget exhaustion raises a distinct `budget_exhausted` state, visibly different
+  from `runner_saturated` and from `check_failed`, so a bill never again reads as
+  an outage.
+- **Absent-verdict detector (Class C).** *Done when* a required check that reports
+  nothing for N commits is surfaced as red, not neutral — a `cancelled`/never-
+  reported required check must not render as absence.
+- **Ephemeral cloud execution for substrate-mutating suites (Class B).** *Done
+  when* the destructive-test class runs with no write authority over the
+  operator's real `$HOME`/substrate, proven by running the known-destructive suite
+  and observing the operator's `~/.noetica` unchanged.
+- **Import-graph test-reachability (Class B, refinement of guard 3).** *Done when*
+  the hermeticity gate can attribute a violation to the specific test(s) that
+  import the offending module, upgrading the static over-approximation to true
+  reachability.
+- **Recovery-step re-entrancy harness (Class E).** *Done when* each recovery
+  runbook step passes a kill-mid-run-then-rerun test with identical, side-effect-
+  free end state.
+
+---
+
+## Cross-reference index
+
+- **Wave-0 DevSecOps design** (this session; live plane `apps/devsecops-intelligence/`,
+  Control Teeth Register) — cross-linked by intent; see the provenance note (not yet
+  on `origin/main`).
+- **Prior committed lineage:** `docs/architecture/devsecops-intelligence-workroom-v0.1.md`,
+  `docs/architecture/devsecops-workroom-*-v0.1.md`, `…-v0.1-status.md`; umbrella #519.
+- **Receipt spine:** `contracts/EvidenceReceipt.v0.1.json` (a claim needs
+  `evidence_refs`; Class F).
+- **PRs:** #1045 / #1101 (CI path-filter auditor and its adversarial self-review —
+  Class A/C/G), Noetica #585 (test-hermeticity in `lib/` — Class B), #519 (DevSecOps
+  Workroom umbrella). `origin/main` at authoring: `873433c5` (#1104).
+- **Memory:** `feedback_ask_what_calls_this`, `feedback_self_validating_checker`,
+  `feedback_grep_false_negatives_verify_with_node`, `project_stranded_work_register`,
+  `project_ci_throughput_path_filters`, `project_rollback_silent_noop`,
+  `project_self_improving_loop`, `project_learning_apparatus`,
+  `project_declared_unenforced_register`, `project_blueprint_audit_verdict`.

--- a/tools/check_test_hermeticity.py
+++ b/tools/check_test_hermeticity.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Fail if importable code writes under the operator's real $HOME without a redirect.
+
+Class B of `docs/architecture/devsecops-retrospective-and-recovery-v0.1.md`:
+this session an agent-machine test suite wrote through modules that resolved
+paths under the *real* `~/.noetica` and destroyed the operator's live A2A trust
+ledger -- unrecoverably -- plus 921 residue directories.  The test "passed".
+The defect was not the assertion; it was that a test-reachable module computed a
+**write** path under the real HOME, so running the test mutated the operator's
+machine.  PR #585 fixed the specific case in Noetica `lib/`; this generalises the
+pattern into a reusable static gate.
+
+What it flags: a filesystem WRITE (`open(..., 'w'|'a'|'x')`, `write_text`,
+`write_bytes`, `mkdir`, `makedirs`, `touch`, `Path.open('w')`, `sqlite3.connect`,
+`shutil.copy*/move` destination) whose target path is derived from the real HOME
+(`Path.home()`, `os.path.expanduser('~...')`, `os.environ['HOME']`, a `~/` literal)
+**and is not redirectable** through an environment variable.
+
+What it deliberately allows -- the redirectable idiom already used across the
+estate, which is what makes a test hermetic:
+
+    DB = Path(os.environ.get("PROMETHEUSD_DB", Path.home() / ".noetica" / "x.db"))
+
+Here a hermetic test sets `PROMETHEUSD_DB` to a tmp path and the HOME default is
+never taken.  Because the write path flows through `os.environ.get(KEY, ...)`
+(KEY != HOME), we treat it as safe and prune it.  A raw `Path.home() / ...` with
+no such indirection is the violation.
+
+Estate-generic vs per-repo (an explicit answer, per the task):
+
+* The **mechanism** -- "a write sink fed by a non-redirectable HOME-derived
+  path" -- is fully estate-generic; this file carries no Noetica-specific rule.
+* The **policy** -- *which* HOME subdirectories count as sacred operator state
+  (`~/.noetica`, `~/.config/...`, `~/.ssh`) -- is per-repo.  v0.1 takes the
+  strict stance that ANY non-redirectable write under real HOME is a violation
+  (the safest default); `--allow-subpath` can whitelist specific dirs a repo
+  has decided are legitimately operator-scoped.
+
+Honesty about altitude (this doc's own class G):
+
+* This is a STATIC over-approximation of "test-reachable": it flags the pattern
+  anywhere in the scanned source, without proving a specific test imports it.
+  True import-graph reachability from each test is scoped as a later wave in the
+  retrospective doc -- it is more engineering than this cheap guard.
+* A file we cannot parse is reported (visible), never silently treated as clean.
+* Non-constant `open` modes and dynamically-built paths are conservatively NOT
+  flagged (we prefer a missed edge over a false alarm that gets the gate muted);
+  this limitation is stated, not hidden.
+
+Exit status: 0 iff no violations; 1 if any; 2 on usage error.
+
+Prove-it-fires: `tools/selftest_check_test_hermeticity.py` plants a raw-HOME
+write (must go RED) and the env-redirectable + tmp forms (must stay GREEN).
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SCAN = ["tools", "apps", "libs", "src", "services", "packages"]
+
+# Pure Path-method write sinks: the path is the *receiver* (`p.write_text(...)`).
+# `mkdir`/`makedirs` are handled separately because `os.makedirs(path)` /
+# `os.mkdir(path)` take the path as an *argument*, not a receiver.
+WRITE_ATTR_SINKS = {"write_text", "write_bytes", "touch"}
+SHUTIL_WRITE = {"copy", "copy2", "copyfile", "copytree", "move"}
+WRITE_OPEN_CHARS = set("wax+")
+
+
+# --------------------------------------------------------------------------- #
+# Home-derivation and redirect detection
+# --------------------------------------------------------------------------- #
+def _attr_chain(node: ast.AST) -> str:
+    """Dotted name for Attribute/Name chains, e.g. os.path.expanduser."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def _const_str(node: ast.AST) -> str | None:
+    return node.value if isinstance(node, ast.Constant) and isinstance(node.value, str) else None
+
+
+def is_safe_env_getter(node: ast.AST) -> bool:
+    """os.environ.get(KEY, ...) or os.getenv(KEY, ...) with KEY != 'HOME' -> the
+    value is redirectable by setting KEY, so the subtree is hermetic-capable."""
+    if not isinstance(node, ast.Call):
+        return False
+    name = _attr_chain(node.func)
+    if not (name.endswith("environ.get") or name.endswith("os.getenv") or name == "getenv"):
+        return False
+    if not node.args:
+        return False
+    key = _const_str(node.args[0])
+    # Unknown/dynamic key: still redirectable in principle; treat as safe.
+    return key != "HOME"
+
+
+def is_home_derivation(node: ast.AST) -> bool:
+    if isinstance(node, ast.Call):
+        name = _attr_chain(node.func)
+        # `Path.home()` / `pathlib.Path.home()`: zero-arg .home() on a Path receiver.
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "home" and not node.args:
+            recv = _attr_chain(node.func.value)
+            if recv == "Path" or recv.endswith(".Path") or recv == "pathlib":
+                return True
+        if name.endswith("expanduser"):
+            s = _const_str(node.args[0]) if node.args else None
+            if s is not None and s.startswith("~"):
+                return True
+        # os.environ.get('HOME') / os.getenv('HOME')
+        if (name.endswith("environ.get") or name.endswith("getenv") or name == "getenv") and node.args:
+            if _const_str(node.args[0]) == "HOME":
+                return True
+    if isinstance(node, ast.Subscript):
+        # os.environ['HOME']
+        if _attr_chain(node.value).endswith("environ"):
+            key = _const_str(node.slice)
+            if key == "HOME":
+                return True
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        if node.value == "~" or node.value.startswith("~/"):
+            return True
+    return False
+
+
+def subtree_has_raw_home(node: ast.AST) -> bool:
+    """True if the expression contains a HOME-derivation not shielded by a safe
+    env getter.  We prune at safe env getters so their HOME *default* is ignored."""
+    if is_safe_env_getter(node):
+        return False
+    if is_home_derivation(node):
+        return True
+    for child in ast.iter_child_nodes(node):
+        if subtree_has_raw_home(child):
+            return True
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Scan
+# --------------------------------------------------------------------------- #
+class Violation:
+    __slots__ = ("path", "line", "sink", "detail")
+
+    def __init__(self, path: str, line: int, sink: str, detail: str) -> None:
+        self.path, self.line, self.sink, self.detail = path, line, sink, detail
+
+
+def collect_home_bound_names(tree: ast.AST) -> set[str]:
+    """Names assigned a value that carries a raw HOME-derivation.
+    `_DB = Path.home() / '.noetica' / 'x.db'` -> {'_DB'}."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and subtree_has_raw_home(node.value):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name):
+                    names.add(tgt.id)
+        elif isinstance(node, ast.AnnAssign) and node.value is not None \
+                and subtree_has_raw_home(node.value) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return names
+
+
+def references_home_bound(node: ast.AST, home_names: set[str]) -> bool:
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Name) and sub.id in home_names:
+            return True
+    return False
+
+
+def target_is_home(node: ast.AST, home_names: set[str]) -> bool:
+    return subtree_has_raw_home(node) or references_home_bound(node, home_names)
+
+
+def _open_is_write(call: ast.Call) -> bool:
+    mode: str | None = None
+    if len(call.args) >= 2:
+        mode = _const_str(call.args[1])
+    for kw in call.keywords:
+        if kw.arg == "mode":
+            mode = _const_str(kw.value)
+    if mode is None:
+        return False  # default 'r' or dynamic; conservatively not a write sink
+    return any(c in WRITE_OPEN_CHARS for c in mode)
+
+
+def scan_tree(path: str, tree: ast.AST) -> list[Violation]:
+    home_names = collect_home_bound_names(tree)
+    out: list[Violation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        line = getattr(node, "lineno", 0)
+
+        # builtin open(path, mode) with a write mode
+        if isinstance(func, ast.Name) and func.id == "open" and node.args:
+            if _open_is_write(node) and target_is_home(node.args[0], home_names):
+                out.append(Violation(path, line, "open(w)", "write path derived from real $HOME"))
+            continue
+
+        if isinstance(func, ast.Attribute):
+            attr = func.attr
+            full = _attr_chain(func)
+            recv_chain = _attr_chain(func.value)
+            recv_is_os = recv_chain == "os" or recv_chain.endswith(".os") or recv_chain == "os.path"
+
+            # os.makedirs(path) / os.mkdir(path) -- path is the ARGUMENT
+            if attr in ("makedirs", "mkdir") and recv_is_os:
+                if node.args and target_is_home(node.args[0], home_names):
+                    out.append(Violation(path, line, f"os.{attr}()", "dir path derived from real $HOME"))
+                continue
+            # p.write_text(...) / p.write_bytes(...) / p.touch() / p.mkdir() -- RECEIVER is the path
+            if attr in WRITE_ATTR_SINKS or attr == "mkdir":
+                if target_is_home(func.value, home_names):
+                    out.append(Violation(path, line, f".{attr}()", "receiver path derived from real $HOME"))
+                continue
+            # Path(...).open('w')
+            if attr == "open":
+                if _open_is_write(node) and target_is_home(func.value, home_names):
+                    out.append(Violation(path, line, "Path.open(w)", "receiver path derived from real $HOME"))
+                continue
+            # sqlite3.connect(path) creates the file
+            if full.endswith("sqlite3.connect"):
+                if node.args and target_is_home(node.args[0], home_names):
+                    out.append(Violation(path, line, "sqlite3.connect()", "db path derived from real $HOME"))
+                continue
+            # shutil.copy*/move(src, dst) -> dst is the write
+            if attr in SHUTIL_WRITE and full.endswith(f"shutil.{attr}"):
+                if len(node.args) >= 2 and target_is_home(node.args[1], home_names):
+                    out.append(Violation(path, line, f"shutil.{attr}()", "destination derived from real $HOME"))
+                continue
+    return out
+
+
+def iter_python_files(base: Path, scan_dirs: list[str], exclude: set[str]) -> list[Path]:
+    files: list[Path] = []
+    roots = [base / d for d in scan_dirs] if scan_dirs else [base]
+    for r in roots:
+        if not r.exists():
+            continue
+        stack = [r]
+        while stack:
+            d = stack.pop()
+            try:
+                entries = list(d.iterdir())
+            except OSError:
+                continue
+            for p in entries:
+                if p.is_symlink():
+                    continue
+                if p.is_dir():
+                    if p.name in exclude:
+                        continue
+                    stack.append(p)
+                elif p.is_file() and p.suffix == ".py":
+                    files.append(p)
+    return sorted(set(files))
+
+
+def run(base: Path, scan_dirs: list[str], as_json: bool, exclude: set[str]) -> int:
+    files = iter_python_files(base, scan_dirs, exclude)
+    violations: list[Violation] = []
+    unparsed: list[str] = []
+    for f in files:
+        try:
+            src = f.read_text(encoding="utf-8")
+            tree = ast.parse(src, filename=str(f))
+        except (OSError, SyntaxError) as exc:
+            unparsed.append(f"{f}: {exc.__class__.__name__}")
+            continue
+        rel = str(f.relative_to(base)) if str(f).startswith(str(base)) else str(f)
+        violations.extend(scan_tree(rel, tree))
+
+    if as_json:
+        import json
+        print(json.dumps({
+            "ok": not violations,
+            "scanned_files": len(files),
+            "violations": [{"path": v.path, "line": v.line, "sink": v.sink, "detail": v.detail} for v in violations],
+            "unparsed": unparsed,
+        }, indent=2))
+        return 1 if violations else 0
+
+    print(f"Scanned {len(files)} python file(s) under {base}")
+    if unparsed:
+        print(f"  (could not parse {len(unparsed)} file(s) -- reported, not assumed clean):")
+        for u in unparsed[:20]:
+            print(f"    ? {u}")
+    if not violations:
+        print("RESULT: PASS -- no non-redirectable writes under real $HOME")
+        return 0
+    print(f"\nVIOLATIONS ({len(violations)}) -- tests reaching these mutate the operator's real HOME:")
+    for v in violations:
+        print(f"  {v.path}:{v.line}  {v.sink}  -- {v.detail}")
+    print("\nFix: route the path through os.environ.get(KEY, <default>) so a hermetic")
+    print("test can redirect KEY to a tmp dir; or write under a tmp/base-dir argument.")
+    print("RESULT: FAIL")
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Fail if importable code writes under real $HOME without an env redirect.")
+    ap.add_argument("--base", type=Path, default=ROOT, help="repo root to scan (default: this repo)")
+    ap.add_argument("--scan", nargs="*", default=None,
+                    help=f"subdirs to scan (default: {DEFAULT_SCAN} that exist)")
+    ap.add_argument("--exclude", nargs="*", default=[".git", "node_modules", ".venv", "venv", "__pycache__", "dist", "build"],
+                    help="directory names to skip")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+    scan_dirs = args.scan if args.scan is not None else DEFAULT_SCAN
+    return run(args.base, scan_dirs, args.json, set(args.exclude))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_workflow_timeout_bounds.py
+++ b/tools/check_workflow_timeout_bounds.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Prove that every GitHub Actions job declares a runaway bound (`timeout-minutes`).
+
+An Actions job with no `timeout-minutes` inherits GitHub's default of **360
+minutes (6 hours)**.  A single hung step therefore burns six hours of the
+shared, spend-capped Actions allowance before the platform kills it — and while
+it burns, the runner it holds is unavailable to every other PR, so the queue
+reads as "saturation" and merges stall behind a bill, not a bug.  That is the
+class-C failure ("budget masqueraded as failure") in
+`docs/architecture/devsecops-retrospective-and-recovery-v0.1.md`: the 6h hang
+did not just cost money, it *caused* the queue that looked like an outage.
+
+A bound is cheap insurance.  This checker fails if any job can run unbounded.
+
+Design notes (each earned from a real defect in this estate):
+
+* We parse real YAML (PyYAML, already a `tools/` dependency), not line-1 regex.
+  A checker that reads only the first physical line of a block vouches for what
+  it never saw — that exact bug shipped in the path-filter auditor (PR #1101).
+* A file that will not parse is an ERROR, never a silent skip.  "Unparseable ->
+  ignored" is how a scan reports green over ground it never read.
+* An **empty** scan is an ERROR, not a pass.  A checker that reports success
+  because it found nothing to check is the "control that cannot fail" disease
+  (class A).  Point us at a dir with no workflows and we exit non-zero.
+* Jobs that *call a reusable workflow* (`uses:` at job level) may not legally
+  carry `timeout-minutes` (GitHub rejects it).  We do not fail them — but we
+  list them explicitly so the bound owed by the called workflow stays visible,
+  rather than being silently assumed.
+
+Exit status: 0 iff every non-exempt job declares a positive `timeout-minutes`
+and at least one workflow was scanned; 1 otherwise.
+
+Prove-it-fires: `tools/selftest_check_workflow_timeout_bounds.py` drives a
+known-unbounded fixture (must go RED) and a known-bounded fixture (must go
+GREEN).  Never trust this green until you have watched it go red.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_WORKFLOWS = ROOT / ".github" / "workflows"
+
+# GitHub's implicit job timeout when `timeout-minutes` is absent.
+GITHUB_DEFAULT_TIMEOUT_MINUTES = 360
+
+
+class Finding:
+    __slots__ = ("workflow", "job", "kind", "detail")
+
+    def __init__(self, workflow: str, job: str, kind: str, detail: str) -> None:
+        self.workflow = workflow
+        self.job = job
+        self.kind = kind  # "unbounded" | "bad-value" | "parse-error" | "empty-scan"
+        self.detail = detail
+
+    def as_dict(self) -> dict[str, str]:
+        return {"workflow": self.workflow, "job": self.job, "kind": self.kind, "detail": self.detail}
+
+
+def _is_reusable_call(job: dict[str, Any]) -> bool:
+    """A job that is `uses: org/repo/.github/workflows/x.yml@ref` calls a reusable
+    workflow.  GitHub forbids `timeout-minutes` on such a job; the bound must live
+    in the called workflow.  We exempt but surface these, never assume them."""
+    return isinstance(job.get("uses"), str)
+
+
+def _valid_timeout(value: Any) -> bool:
+    # Accept positive ints; reject 0, negatives, strings, floats-as-str, None.
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 1
+
+
+def audit_file(path: Path) -> tuple[list[Finding], list[str], int]:
+    """Return (findings, exempt_reusable_jobs, bounded_job_count) for one workflow."""
+    rel = path.name
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:  # unreadable file is a hard error, not a pass
+        return [Finding(rel, "-", "parse-error", f"unreadable: {exc}")], [], 0
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        return [Finding(rel, "-", "parse-error", f"yaml: {exc}")], [], 0
+
+    if not isinstance(doc, dict):
+        return [Finding(rel, "-", "parse-error", "top-level is not a mapping")], [], 0
+
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict) or not jobs:
+        # A workflow file with no jobs mapping is malformed for our purposes.
+        return [Finding(rel, "-", "parse-error", "no `jobs:` mapping")], [], 0
+
+    findings: list[Finding] = []
+    exempt: list[str] = []
+    bounded = 0
+    for job_name, job in jobs.items():
+        if not isinstance(job, dict):
+            findings.append(Finding(rel, str(job_name), "parse-error", "job is not a mapping"))
+            continue
+        if _is_reusable_call(job):
+            exempt.append(f"{rel}:{job_name}")
+            continue
+        if "timeout-minutes" not in job:
+            findings.append(
+                Finding(rel, str(job_name), "unbounded",
+                        f"no timeout-minutes -> inherits GitHub default {GITHUB_DEFAULT_TIMEOUT_MINUTES}m (6h)")
+            )
+            continue
+        value = job["timeout-minutes"]
+        if not _valid_timeout(value):
+            findings.append(
+                Finding(rel, str(job_name), "bad-value",
+                        f"timeout-minutes={value!r} is not a positive integer")
+            )
+            continue
+        bounded += 1
+    return findings, exempt, bounded
+
+
+def discover_workflows(workflows_dir: Path) -> list[Path]:
+    if not workflows_dir.is_dir():
+        return []
+    out: list[Path] = []
+    for p in sorted(workflows_dir.iterdir()):
+        if p.is_file() and p.suffix in (".yml", ".yaml"):
+            out.append(p)
+    return out
+
+
+def run(workflows_dir: Path, as_json: bool) -> int:
+    files = discover_workflows(workflows_dir)
+    all_findings: list[Finding] = []
+    all_exempt: list[str] = []
+    total_bounded = 0
+
+    if not files:
+        # Empty scan is a failure, not a pass (a green from nothing is a lie).
+        finding = Finding(str(workflows_dir), "-", "empty-scan",
+                          "no *.yml/*.yaml workflow files found -- refusing to report green")
+        if as_json:
+            print(json.dumps({"ok": False, "scanned_workflows": 0, "findings": [finding.as_dict()]}, indent=2))
+        else:
+            print(f"ERROR: {finding.detail} (looked in {workflows_dir})")
+        return 1
+
+    for f in files:
+        findings, exempt, bounded = audit_file(f)
+        all_findings.extend(findings)
+        all_exempt.extend(exempt)
+        total_bounded += bounded
+
+    total_jobs = total_bounded + len(all_exempt) + sum(
+        1 for x in all_findings if x.kind in ("unbounded", "bad-value")
+    )
+    unbounded = [x for x in all_findings if x.kind == "unbounded"]
+    bad_value = [x for x in all_findings if x.kind == "bad-value"]
+    parse_errors = [x for x in all_findings if x.kind == "parse-error"]
+    ok = not all_findings
+
+    if as_json:
+        print(json.dumps({
+            "ok": ok,
+            "scanned_workflows": len(files),
+            "total_jobs": total_jobs,
+            "bounded_jobs": total_bounded,
+            "unbounded_jobs": len(unbounded),
+            "bad_value_jobs": len(bad_value),
+            "reusable_exempt_jobs": len(all_exempt),
+            "parse_errors": len(parse_errors),
+            "findings": [x.as_dict() for x in all_findings],
+            "reusable_exempt": all_exempt,
+        }, indent=2))
+        return 0 if ok else 1
+
+    print(f"Scanned {len(files)} workflow file(s) in {workflows_dir}")
+    print(f"  jobs total (non-exempt + exempt): {total_jobs}")
+    print(f"  bounded (declare timeout-minutes): {total_bounded}")
+    print(f"  reusable-workflow calls (exempt, bound owed by callee): {len(all_exempt)}")
+    print(f"  UNBOUNDED jobs (inherit {GITHUB_DEFAULT_TIMEOUT_MINUTES}m default): {len(unbounded)}")
+    if bad_value:
+        print(f"  BAD timeout-minutes values: {len(bad_value)}")
+    if parse_errors:
+        print(f"  PARSE ERRORS (fail-closed): {len(parse_errors)}")
+    if unbounded:
+        print("\nUnbounded jobs (each a 6h budget bomb):")
+        for x in unbounded:
+            print(f"  - {x.workflow}:{x.job}")
+    if bad_value:
+        print("\nInvalid timeout-minutes:")
+        for x in bad_value:
+            print(f"  - {x.workflow}:{x.job}  ({x.detail})")
+    if parse_errors:
+        print("\nParse errors (treated as failures, never skipped):")
+        for x in parse_errors:
+            print(f"  - {x.workflow}:{x.job}  ({x.detail})")
+    if all_exempt:
+        print("\nReusable-workflow calls (exempt; verify the callee is bounded):")
+        for e in all_exempt:
+            print(f"  - {e}")
+    print("\nRESULT:", "PASS -- every job is bounded" if ok else "FAIL -- unbounded/invalid jobs above")
+    return 0 if ok else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Audit GitHub Actions jobs for a runaway `timeout-minutes` bound.")
+    ap.add_argument("--workflows-dir", type=Path, default=DEFAULT_WORKFLOWS,
+                    help="directory of workflow YAML files (default: .github/workflows)")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args(argv)
+    return run(args.workflows_dir, args.json)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/detect_unpushed_single_copy.py
+++ b/tools/detect_unpushed_single_copy.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Report git work that exists on NO remote -- i.e. single copies a dead disk erases.
+
+Class D of `docs/architecture/devsecops-retrospective-and-recovery-v0.1.md`:
+when a laptop disk hit zero this session it took with it 47+43+33 unpushed
+commits and a stash holding the *sole* copy of a sovereign-Gitea manifest.  None
+of it was recoverable because none of it existed anywhere but that disk.  The
+cure is not heroics after the fact; it is *visibility before* -- a cheap sweep
+that makes single-copy work impossible to forget.
+
+This is a LOCAL OPERATOR tool, not a CI gate.  It shells out to `git` and, for
+each repository under the given roots, reports four kinds of single-copy work:
+
+  1. repositories with **no remote at all** (every commit is single-copy);
+  2. **unpushed commits** -- reachable from a local branch/tag but from no
+     remote-tracking ref;
+  3. **stashes** -- which never leave the local disk;
+  4. **uncommitted changes** in any (linked) worktree.
+
+Honesty about the instrument (this doc's own class G):
+
+* "On no remote" is judged against **remote-tracking refs** (`refs/remotes/*`),
+  which can be STALE.  A branch you pushed from another machine may still look
+  unpushed here until you fetch.  Pass `--fetch` to refresh first (slower, hits
+  the network); without it, results are a safe over-approximation -- it may over-
+  report, it will not under-report work that is genuinely only local.
+* We never conclude "all clear" from a git command that errored; a repo we
+  cannot interrogate is listed as `unknown`, not as safe.
+
+Exit status: 0 iff no single-copy work was found in any scanned repo; 1 if any
+was found; 2 on usage error.  As an operator pre-flight ("is it safe to let this
+disk sleep?"), non-zero means "push something first".
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_ROOTS = [Path.home() / "dev"]
+
+
+def git(repo: Path, *args: str) -> tuple[int, str]:
+    try:
+        cp = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 255, f"<git invocation failed: {exc}>"
+    return cp.returncode, (cp.stdout or "").strip()
+
+
+def find_repos(roots: list[Path], max_depth: int) -> list[Path]:
+    """A git repo is a directory whose `.git` exists (dir for a normal clone,
+    file for a linked worktree).  We stop descending into a repo once found."""
+    seen: set[Path] = set()
+    out: list[Path] = []
+
+    def walk(d: Path, depth: int) -> None:
+        try:
+            resolved = d.resolve()
+        except OSError:
+            return
+        if resolved in seen:
+            return
+        if (d / ".git").exists():
+            seen.add(resolved)
+            out.append(d)
+            return  # do not descend into a repo's own subtree
+        if depth >= max_depth:
+            return
+        try:
+            children = sorted(p for p in d.iterdir() if p.is_dir() and not p.is_symlink())
+        except OSError:
+            return
+        for c in children:
+            if c.name in (".git", "node_modules", ".venv", "venv", "__pycache__"):
+                continue
+            walk(c, depth + 1)
+
+    for r in roots:
+        if r.is_dir():
+            walk(r, 0)
+    return out
+
+
+class RepoReport:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.no_remote = False
+        self.unknown: list[str] = []
+        self.unpushed: list[str] = []     # short commit lines
+        self.total_local_commits = 0      # only meaningful when no_remote
+        self.stashes: list[str] = []
+        self.dirty: list[str] = []        # "<worktree>: N files"
+
+    @property
+    def has_single_copy(self) -> bool:
+        return bool(self.no_remote or self.unpushed or self.stashes or self.dirty
+                    or (self.no_remote and self.total_local_commits))
+
+    @property
+    def any_finding(self) -> bool:
+        return self.has_single_copy or bool(self.unknown)
+
+
+def inspect(repo: Path, do_fetch: bool) -> RepoReport:
+    rep = RepoReport(repo)
+
+    rc, remotes = git(repo, "remote")
+    if rc != 0:
+        rep.unknown.append("could not list remotes")
+        return rep
+    has_remote = bool(remotes.strip())
+
+    if do_fetch and has_remote:
+        git(repo, "fetch", "--all", "--quiet")
+
+    # Stashes -- always single-copy.
+    rc, stash = git(repo, "stash", "list")
+    if rc == 0 and stash:
+        rep.stashes = stash.splitlines()
+
+    # Uncommitted changes, this worktree.
+    rc, porc = git(repo, "status", "--porcelain")
+    if rc == 0 and porc:
+        rep.dirty.append(f"{repo.name}: {len(porc.splitlines())} file(s)")
+
+    # Linked worktrees share this repo's object store but each has its own index
+    # and HEAD.  A dirty linked worktree (often parked in /tmp, outside the
+    # scanned roots) is single-copy work that would otherwise be invisible.
+    rc, wl = git(repo, "worktree", "list", "--porcelain")
+    if rc == 0 and wl:
+        for line in wl.splitlines():
+            if not line.startswith("worktree "):
+                continue
+            wt = Path(line[len("worktree "):])
+            try:
+                if wt.resolve() == repo.resolve():
+                    continue  # primary worktree already covered above
+            except OSError:
+                continue
+            wrc, wporc = git(wt, "status", "--porcelain")
+            if wrc == 0 and wporc:
+                rep.dirty.append(f"{wt} (linked worktree): {len(wporc.splitlines())} file(s)")
+
+    if not has_remote:
+        rep.no_remote = True
+        rc, cnt = git(repo, "rev-list", "--all", "--count")
+        if rc == 0 and cnt.isdigit():
+            rep.total_local_commits = int(cnt)
+        return rep
+
+    # Commits on local branches/tags that no remote-tracking ref contains.
+    rc, out = git(repo, "rev-list", "--branches", "--tags", "--not", "--remotes",
+                  "--pretty=oneline", "--max-count=200")
+    if rc != 0:
+        rep.unknown.append("rev-list for unpushed commits failed")
+    elif out:
+        # --pretty=oneline prints "<sha> <subject>" lines; keep them as-is.
+        rep.unpushed = [ln for ln in out.splitlines() if ln.strip()]
+
+    return rep
+
+
+def render(reports: list[RepoReport], scanned: int) -> None:
+    flagged = [r for r in reports if r.any_finding]
+    print(f"Scanned {scanned} repo(s); {len(flagged)} with single-copy work or unknown state.\n")
+    tot_unpushed = tot_stash = tot_dirty = tot_noremote = 0
+    for r in flagged:
+        print(f"### {r.path}")
+        if r.no_remote:
+            tot_noremote += 1
+            print(f"  NO REMOTE configured -- all {r.total_local_commits} commit(s) are single-copy")
+        if r.unpushed:
+            tot_unpushed += len(r.unpushed)
+            print(f"  {len(r.unpushed)} unpushed commit(s) (on no remote):")
+            for ln in r.unpushed[:8]:
+                print(f"    - {ln[:100]}")
+            if len(r.unpushed) > 8:
+                print(f"    ... and {len(r.unpushed) - 8} more")
+        if r.stashes:
+            tot_stash += len(r.stashes)
+            print(f"  {len(r.stashes)} stash(es) (never leave this disk):")
+            for ln in r.stashes[:5]:
+                print(f"    - {ln[:100]}")
+        if r.dirty:
+            for d in r.dirty:
+                tot_dirty += 1
+                print(f"  uncommitted: {d}")
+        for u in r.unknown:
+            print(f"  UNKNOWN (not proven safe): {u}")
+        print()
+    print("TOTALS:")
+    print(f"  repos with no remote : {tot_noremote}")
+    print(f"  unpushed commits     : {tot_unpushed}")
+    print(f"  stashes              : {tot_stash}")
+    print(f"  dirty worktrees      : {tot_dirty}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Report git commits/stashes/worktrees that exist on no remote (single-copy work).")
+    ap.add_argument("--roots", type=Path, nargs="*", default=DEFAULT_ROOTS,
+                    help="directories to scan for repositories (default: ~/dev)")
+    ap.add_argument("--max-depth", type=int, default=2,
+                    help="how deep under each root to look for repos (default: 2)")
+    ap.add_argument("--fetch", action="store_true",
+                    help="git fetch --all before judging (accurate but slow; default off)")
+    args = ap.parse_args(argv)
+
+    repos = find_repos([Path(r).expanduser() for r in args.roots], args.max_depth)
+    reports = [inspect(r, args.fetch) for r in repos]
+    render(reports, len(repos))
+    return 1 if any(r.any_finding for r in reports) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/selftest_check_test_hermeticity.py
+++ b/tools/selftest_check_test_hermeticity.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Prove-it-fires for check_test_hermeticity.py.
+
+Teeth in both directions: raw writes under real $HOME must go RED; the
+env-redirectable idiom, tmp writes, and reads under HOME must stay GREEN (the
+negative controls that catch a scanner which flags everything, or nothing).
+
+Run directly:  python3 tools/selftest_check_test_hermeticity.py
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCANNER = HERE / "check_test_hermeticity.py"
+
+# Each of these is a genuine, distinct way to write under the real HOME.
+BAD_FILES = {
+    "b_open.py": (
+        "from pathlib import Path\n"
+        "def go():\n"
+        "    open(Path.home() / '.noetica' / 'x', 'w').write('hi')\n"
+    ),
+    "b_sqlite.py": (
+        "import sqlite3\n"
+        "from pathlib import Path\n"
+        "_DB = Path.home() / '.noetica' / 'hellgraph.db'\n"
+        "def go():\n"
+        "    return sqlite3.connect(str(_DB))\n"
+    ),
+    "b_writetext.py": (
+        "from pathlib import Path\n"
+        "def go():\n"
+        "    (Path.home() / '.config' / 'f').write_text('x')\n"
+    ),
+    "b_makedirs.py": (
+        "import os\n"
+        "def go():\n"
+        "    os.makedirs(os.path.expanduser('~/.noetica/z'), exist_ok=True)\n"
+    ),
+    "b_environ.py": (
+        "import os\n"
+        "def go():\n"
+        "    open(os.environ['HOME'] + '/.secret', 'a').write('x')\n"
+    ),
+}
+
+# Each of these MUST NOT be flagged.
+GOOD_FILES = {
+    "g_env_redirect.py": (
+        "import os\n"
+        "from pathlib import Path\n"
+        "DB = Path(os.environ.get('APP_DB', str(Path.home() / '.noetica' / 'x.db')))\n"
+        "def go():\n"
+        "    open(DB, 'w').write('ok')\n"           # redirectable via APP_DB -> hermetic
+    ),
+    "g_tmp.py": (
+        "import tempfile, os\n"
+        "def go():\n"
+        "    d = tempfile.mkdtemp()\n"
+        "    open(os.path.join(d, 'x'), 'w').write('ok')\n"
+    ),
+    "g_read_only.py": (
+        "from pathlib import Path\n"
+        "def go():\n"
+        "    return open(Path.home() / '.gitconfig').read()\n"  # READ under HOME is fine
+    ),
+    "g_getenv_default.py": (
+        "import os\n"
+        "from pathlib import Path\n"
+        "def go():\n"
+        "    p = os.getenv('OUT_DIR', str(Path.home() / '.noetica'))\n"
+        "    (Path(p) / 'f').write_text('ok')\n"     # OUT_DIR redirect -> hermetic
+    ),
+}
+
+
+def run(base: Path, scan: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCANNER), "--base", str(base), "--scan", scan],
+        capture_output=True, text=True,
+    )
+
+
+def write(d: Path, files: dict[str, str]) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    for name, body in files.items():
+        (d / name).write_text(body, encoding="utf-8")
+
+
+def main() -> int:
+    results: list[bool] = []
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        write(base / "bad", BAD_FILES)
+        write(base / "good", GOOD_FILES)
+
+        # KNOWN POSITIVE: bad dir -> RED, and every planted file must be named.
+        cp_bad = run(base, "bad")
+        named = all(fn.split(".")[0] in cp_bad.stdout for fn in BAD_FILES)
+        bad_ok = cp_bad.returncode == 1 and named
+        print(f"[{'PASS' if bad_ok else 'FAIL'}] bad dir -> RED and all {len(BAD_FILES)} patterns flagged "
+              f"(rc={cp_bad.returncode}, all_named={named})")
+        if not bad_ok:
+            print(cp_bad.stdout, cp_bad.stderr)
+        results.append(bad_ok)
+
+        # KNOWN NEGATIVE: good dir -> GREEN (no false positives).
+        cp_good = run(base, "good")
+        good_ok = cp_good.returncode == 0
+        print(f"[{'PASS' if good_ok else 'FAIL'}] good dir -> GREEN (redirectable/tmp/read) rc={cp_good.returncode}")
+        if not good_ok:
+            print(cp_good.stdout, cp_good.stderr)
+        results.append(good_ok)
+
+        # Per-pattern negative controls: confirm each good file individually clears.
+        for fn in GOOD_FILES:
+            one = base / "one"
+            write(one, {fn: GOOD_FILES[fn]})
+            cp = run(base, "one")
+            ok = cp.returncode == 0
+            print(f"[{'PASS' if ok else 'FAIL'}]   negative control {fn} clean (rc={cp.returncode})")
+            results.append(ok)
+            for p in one.iterdir():
+                p.unlink()
+
+    passed = sum(results)
+    print(f"\n{passed}/{len(results)} checks passed")
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/selftest_check_workflow_timeout_bounds.py
+++ b/tools/selftest_check_workflow_timeout_bounds.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Prove-it-fires for check_workflow_timeout_bounds.py.
+
+Teeth in BOTH directions (the estate's first rule): we make the auditor go RED
+on a planted unbounded job before we trust it GREEN on a bounded one.  An
+auditor only ever observed passing is indistinguishable from one that cannot
+fail.  Named `selftest_*` so no pytest run auto-collects it; run directly:
+
+    python3 tools/selftest_check_workflow_timeout_bounds.py
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+AUDITOR = HERE / "check_workflow_timeout_bounds.py"
+
+UNBOUNDED = """\
+name: unbounded
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"""
+
+BOUNDED = """\
+name: bounded
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - run: echo hi
+"""
+
+BAD_VALUE = """\
+name: bad
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 0
+    steps:
+      - run: echo hi
+"""
+
+REUSABLE = """\
+name: reusable-caller
+on: [push]
+jobs:
+  call:
+    uses: org/repo/.github/workflows/x.yml@main
+"""
+
+BROKEN_YAML = """\
+name: broken
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+    this: [is: not: valid
+"""
+
+
+def run_auditor(workflows_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(AUDITOR), "--workflows-dir", str(workflows_dir)],
+        capture_output=True, text=True,
+    )
+
+
+def case(name: str, files: dict[str, str], expect_rc: int, expect_substr: str) -> bool:
+    with tempfile.TemporaryDirectory() as td:
+        wd = Path(td)
+        for fn, body in files.items():
+            (wd / fn).write_text(body, encoding="utf-8")
+        cp = run_auditor(wd)
+        ok = cp.returncode == expect_rc and expect_substr in (cp.stdout + cp.stderr)
+        status = "PASS" if ok else "FAIL"
+        print(f"[{status}] {name}: rc={cp.returncode} (want {expect_rc}), "
+              f"substr {'found' if expect_substr in (cp.stdout+cp.stderr) else 'MISSING'!r}={expect_substr!r}")
+        if not ok:
+            print("---- captured output ----")
+            print(cp.stdout)
+            print(cp.stderr)
+            print("-------------------------")
+        return ok
+
+
+def main() -> int:
+    results = [
+        # KNOWN POSITIVE: an unbounded job MUST turn the auditor red.
+        case("known-positive: unbounded job -> RED",
+             {"unbounded.yml": UNBOUNDED}, 1, "UNBOUNDED jobs"),
+        # KNOWN NEGATIVE: a bounded job MUST be green.
+        case("known-negative: bounded job -> GREEN",
+             {"bounded.yml": BOUNDED}, 0, "every job is bounded"),
+        # timeout-minutes: 0 is not a real bound.
+        case("bad value: timeout-minutes 0 -> RED",
+             {"bad.yml": BAD_VALUE}, 1, "not a positive integer"),
+        # reusable-workflow call is exempt (green) but surfaced.
+        case("reusable-workflow call -> GREEN but listed",
+             {"reusable.yml": REUSABLE}, 0, "reusable-workflow calls"),
+        # unparseable YAML fails closed, never silently skipped.
+        case("broken YAML -> RED (fail-closed)",
+             {"broken.yml": BROKEN_YAML}, 1, "PARSE ERRORS"),
+        # empty scan is a failure, not a pass.
+        case("empty dir -> RED (no green from nothing)",
+             {}, 1, "refusing to report green"),
+        # mixed: one bounded, one unbounded -> RED, and names the unbounded one.
+        case("mixed set -> RED and names offender",
+             {"a.yml": BOUNDED, "b.yml": UNBOUNDED}, 1, "b.yml:build"),
+    ]
+    passed = sum(results)
+    print(f"\n{passed}/{len(results)} cases passed")
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/selftest_detect_unpushed_single_copy.py
+++ b/tools/selftest_detect_unpushed_single_copy.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Prove-it-fires for detect_unpushed_single_copy.py.
+
+Teeth in both directions: the detector must FLAG a planted local-only commit
+and CLEAR the moment it is pushed -- and a fully-pushed clean clone must read as
+zero (the negative control that catches a detector which flags everything).
+
+Run directly (named selftest_* so no pytest run collects it):
+
+    python3 tools/selftest_detect_unpushed_single_copy.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+DETECTOR = HERE / "detect_unpushed_single_copy.py"
+
+ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def g(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, env=ENV,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def detect(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(DETECTOR), "--roots", str(root), "--max-depth", "2"],
+        capture_output=True, text=True, env=ENV,
+    )
+
+
+def make_pushed_clone(base: Path, name: str) -> tuple[Path, Path]:
+    """Return (remote_bare, working_clone) with one commit already pushed."""
+    remote = base / f"{name}.git"
+    subprocess.run(["git", "init", "--bare", "-b", "main", str(remote)], check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    work = base / name
+    subprocess.run(["git", "clone", str(remote), str(work)], check=True, env=ENV,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    (work / "a.txt").write_text("hello\n")
+    g(work, "add", "-A")
+    g(work, "commit", "-m", "base")
+    g(work, "push", "-u", "origin", "main")
+    return remote, work
+
+
+def case_unpushed_then_push() -> bool:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        _, work = make_pushed_clone(base, "repoA")
+        # Negative baseline: everything pushed and clean -> rc 0.
+        cp0 = detect(base)
+        baseline_clean = cp0.returncode == 0
+        # KNOWN POSITIVE: plant a local-only commit.
+        (work / "b.txt").write_text("local only\n")
+        g(work, "add", "-A")
+        g(work, "commit", "-m", "PLANTED local-only work")
+        cp1 = detect(base)
+        flagged = cp1.returncode == 1 and "unpushed commit" in cp1.stdout and "PLANTED" in cp1.stdout
+        # CLEARS: push it.
+        g(work, "push", "origin", "main")
+        cp2 = detect(base)
+        cleared = cp2.returncode == 0
+
+        ok = baseline_clean and flagged and cleared
+        print(f"[{'PASS' if ok else 'FAIL'}] unpushed-commit lifecycle: "
+              f"baseline_clean={baseline_clean} flagged_when_local={flagged} cleared_when_pushed={cleared}")
+        if not ok:
+            for label, cp in (("baseline", cp0), ("planted", cp1), ("pushed", cp2)):
+                print(f"---- {label} rc={cp.returncode} ----\n{cp.stdout}\n{cp.stderr}")
+        return ok
+
+
+def case_stash() -> bool:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        _, work = make_pushed_clone(base, "repoS")
+        (work / "a.txt").write_text("dirty change\n")
+        g(work, "stash", "push", "-m", "PLANTED stash")
+        cp = detect(base)
+        ok = cp.returncode == 1 and "stash" in cp.stdout and "PLANTED stash" in cp.stdout
+        print(f"[{'PASS' if ok else 'FAIL'}] stash flagged: rc={cp.returncode}")
+        if not ok:
+            print(cp.stdout, cp.stderr)
+        return ok
+
+
+def case_no_remote() -> bool:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        repo = base / "orphan"
+        subprocess.run(["git", "init", "-b", "main", str(repo)], check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        (repo / "x.txt").write_text("never pushed anywhere\n")
+        g(repo, "add", "-A")
+        g(repo, "commit", "-m", "sole copy")
+        cp = detect(base)
+        ok = cp.returncode == 1 and "NO REMOTE" in cp.stdout
+        print(f"[{'PASS' if ok else 'FAIL'}] no-remote repo flagged: rc={cp.returncode}")
+        if not ok:
+            print(cp.stdout, cp.stderr)
+        return ok
+
+
+def case_clean_negative_control() -> bool:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        make_pushed_clone(base, "clean1")
+        make_pushed_clone(base, "clean2")
+        cp = detect(base)
+        ok = cp.returncode == 0
+        print(f"[{'PASS' if ok else 'FAIL'}] clean pushed repos -> zero findings: rc={cp.returncode}")
+        if not ok:
+            print(cp.stdout, cp.stderr)
+        return ok
+
+
+def main() -> int:
+    results = [
+        case_unpushed_then_push(),
+        case_stash(),
+        case_no_remote(),
+        case_clean_negative_control(),
+    ]
+    passed = sum(results)
+    print(f"\n{passed}/{len(results)} cases passed")
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Persists the session **DevSecOps retrospective** and ships three self-contained
**stability/recovery guards**. Extends the Wave-0 DevSecOps design (receipts on the
`contracts/EvidenceReceipt.v0.1.json` spine; meta-control = the Control Teeth
Register). New files only — no contested file edited.

**Doc:** `docs/architecture/devsecops-retrospective-and-recovery-v0.1.md` — the seven
failure classes (A controls-that-can't-fail · B substrate-ate-itself · C budget-as-
failure · D single-copy recovery · E resume-from-intent · F verify-command-not-
artifact · G instruments-lie), each with *what happened / root cause / program change
+ proof obligation*. Classes F and G are written honestly as the operator's own
mistakes. Plus two program sections: **config reoptimization** (CLAUDE.md rules,
`settings.json` hooks, permission-allowlist — proposed, not applied) and the
**feedback loop** that turns the taxonomy into recurring Control-Teeth detectors.

## Guards (each with a red-then-green selftest)

| Guard | Class | Prove-it-fires (local) |
|---|---|---|
| `tools/check_workflow_timeout_bounds.py` | C | selftest 7/7; **origin/main: 122 of 123 jobs unbounded** (1 reusable-exempt). Repo-level red→green: patch one real job with `timeout-minutes` → count 122→121, job leaves the list. |
| `tools/detect_unpushed_single_copy.py` | D | selftest 4/4; planted local-only commit flagged, **clears on push**; stash + no-remote flagged; clean clone reads zero. |
| `tools/check_test_hermeticity.py` | B | selftest 6/6; five raw-`$HOME` write patterns flagged; env-redirectable/tmp/read stay green. Generalises Noetica #585. |

The timeout auditor exists because an unbounded 6h hang burned the Actions budget
this cycle. **122 unbounded jobs** is the actionable red baseline.

## Scoped for later waves (not built)

Control Teeth Register (keystone), billing/quota ingest, absent-verdict detector,
ephemeral-runner migration, import-graph test-reachability, recovery re-entrancy
harness — each with a proof obligation in the doc.

## Safety / verification

- **New files only.** `git merge-tree` clean against #1111 / #1080 / #1082 (0 conflicts); no path overlap.
- Guard ships **standalone** (not wired into `validate-target-diagnostics.yml`, a contested lane); wiring recommendation is in the doc.
- **Local evidence only** — Actions was spend-capped this cycle; CI results here are not awaited/verified.
- Config/permission/hook changes are **recommendations**; nothing in `~/.claude/` was modified.

**Do not merge yet** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
