### PR TITLE
fix(nugget-extractor): degraded refusal attributes the real stalled dependency (follow-up to #1106)

### DIFF
--- a/apps/compute-gateway/tests/test_sub_tier_hardening.py
+++ b/apps/compute-gateway/tests/test_sub_tier_hardening.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import base64
 import importlib
 import os
+import sys
 import threading
 
 os.environ["GATEWAY_TOKEN"] = "t"
@@ -205,3 +206,68 @@ def test_healthz_reports_signed_ratio_when_key_is_valid():
         if prev is None: os.environ.pop("GATEWAY_SIGNING_KEY", None)
         else: os.environ["GATEWAY_SIGNING_KEY"] = prev
         importlib.reload(server)
+
+
+# ── #4: /healthz signed-ratio aggregation vs concurrent seal() ───────────
+
+def test_healthz_survives_concurrent_seals_on_new_projects():
+    """/healthz aggregates signed_ratio over every chain. A concurrent seal() on a NEW
+    project runs receipts._CHAINS.setdefault(project, []), mutating the dict — iterating
+    it BARE raises `RuntimeError: dictionary changed size during iteration` and 500s the
+    health endpoint under load, a liveness probe that flaps exactly when the gateway is
+    busiest. server.healthz() now reads receipts.snapshot_all() (snapshot under the locks)
+    instead. This drives the race directly: one thread hammers /healthz while another
+    seals into ever-new projects. Pre-fix it 500s; post-fix every call is 200."""
+    prev_key = os.environ.get("GATEWAY_SIGNING_KEY")
+    # A valid key so seeded receipts are SIGNED: /healthz then runs signing.verify_signature
+    # (an Ed25519 C call that RELEASES the GIL) once per receipt, which is exactly the
+    # window a concurrent _CHAINS mutation needs to land mid-iteration. Unsigned receipts
+    # short-circuit that call and the outer loop is too fast to observe the race.
+    os.environ["GATEWAY_SIGNING_KEY"] = base64.b64encode(b"9" * 32).decode()
+    _reset_receipts()
+    # Seed a fixed set of signed projects so the aggregation's outer loop has real work.
+    for p in range(40):
+        receipts.seal(f"seed-{p}", kind="notebook", backend="forge", runtime="python3",
+                      inputs={"p": p}, outputs=[{"p": p}], status="ok", actor="t",
+                      epistemic_status="derived")
+
+    client = TestClient(server.app, raise_server_exceptions=False)
+    errors: list = []
+    stop = threading.Event()
+
+    def churner() -> None:
+        # Add a NEW project then drop it, so _CHAINS keeps CHANGING SIZE throughout the run
+        # while staying bounded (~41 keys) — snapshot_all() stays O(projects) and the test
+        # stays fast, but the dict is mutating on every pass, which is what the bare
+        # `for chain in _CHAINS.values()` cannot survive.
+        i = 0
+        while not stop.is_set():
+            receipts.seal(f"churn-{i}", kind="notebook", backend="forge", runtime="python3",
+                          inputs={"i": i}, outputs=[{"i": i}], status="ok", actor="t",
+                          epistemic_status="derived")
+            receipts._CHAINS.pop(f"churn-{i}", None)   # size oscillates 40 <-> 41
+            i += 1
+
+    def healther() -> None:
+        for _ in range(150):
+            r = client.get("/healthz")   # raise_server_exceptions=False -> a handler crash is a 500
+            if r.status_code != 200:
+                errors.append(r.status_code)
+                return
+
+    prev_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-5)  # force frequent thread switches to widen the race window
+    st = threading.Thread(target=churner)
+    ht = threading.Thread(target=healther)
+    try:
+        st.start(); ht.start()
+        ht.join()
+    finally:
+        stop.set(); st.join()
+        sys.setswitchinterval(prev_interval)
+        if prev_key is None:
+            os.environ.pop("GATEWAY_SIGNING_KEY", None)
+        else:
+            os.environ["GATEWAY_SIGNING_KEY"] = prev_key
+
+    assert not errors, f"/healthz returned non-200 while _CHAINS was mutating concurrently: {errors[:3]}"

--- a/apps/nugget-extractor/src/nugget_extractor/emitter.py
+++ b/apps/nugget-extractor/src/nugget_extractor/emitter.py
@@ -176,6 +176,12 @@ class NuggetEmitter:
     # RLock, not Lock: submit() drains while already holding it. One writer at a time is
     # the whole point — see the CONCURRENCY note in the module docstring.
     _lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
+    # Last drain's observed dependency health. A back-pressure refusal (queue at the cap)
+    # contacts NOTHING, so it must not invent an attribution — it reports the last real
+    # drain observation instead of hardcoding "hellgraph down". Updated only by a drain
+    # that actually attempted work.
+    _last_hellgraph_ok: bool = field(default=True, repr=False)
+    _last_gateway_ok: bool = field(default=True, repr=False)
 
     # ── boot ──
     def startup_check(self) -> None:
@@ -213,17 +219,28 @@ class NuggetEmitter:
         # upstream outage into an OOM crash. Match device-service's skip-with-reason
         # posture — no partial batch, no counted work, an explicit reason string.
         if len(self._pending) >= MAX_PENDING:
+            # A refusal contacts NOTHING (attempted stays False), so it must not claim a
+            # fresh observation. Attribute the stall to whichever dependency the LAST drain
+            # saw fail — the queue fills at the compute-gateway receipt step just as readily
+            # as at a hellgraph write, and hardcoding "hellgraph down" misdirects the
+            # operator when the gateway is the wedged side.
+            stalled = []
+            if not self._last_hellgraph_ok:
+                stalled.append("hellgraph")
+            if not self._last_gateway_ok:
+                stalled.append("the compute-gateway receipt step")
+            who = " and ".join(stalled) if stalled else "the drain target (hellgraph or the gateway)"
             reason = (
                 "nugget-extractor pending queue full "
-                f"({len(self._pending)}/{MAX_PENDING}) — hellgraph downstream may be "
-                "unavailable; retry after drain")
+                f"({len(self._pending)}/{MAX_PENDING}) — {who} is not keeping up; retry after drain")
             log.warning("submit REFUSED — %s (doc=%s)", reason, doc_ref)
             return BatchResult(
                 documents=0, extracted=0, emitted=0, validation_failures=0,
                 pending=sum(len(b.nuggets) for b in self._pending),
                 status="degraded", reason=reason,
-                hellgraph_ok=False,   # the cap only trips when drain is stalled
-                gateway_ok=False,
+                attempted=False,   # explicit: this refusal observed nothing
+                hellgraph_ok=self._last_hellgraph_ok,
+                gateway_ok=self._last_gateway_ok,
             )
         built = nugget_builder.build(
             extraction, doc_ref=doc_ref, run_ref=run_ref, clock=self.clock,
@@ -351,6 +368,11 @@ class NuggetEmitter:
             self._pending.pop(0)
 
         result.pending = sum(len(b.nuggets) for b in self._pending)
+        if result.attempted:
+            # Remember which dependency (if any) was observed stalling, so a later
+            # back-pressure refusal attributes the outage from a real observation.
+            self._last_hellgraph_ok = result.hellgraph_ok
+            self._last_gateway_ok = result.gateway_ok
         return result
 
     @property

--- a/apps/nugget-extractor/src/nugget_extractor/server.py
+++ b/apps/nugget-extractor/src/nugget_extractor/server.py
@@ -237,8 +237,11 @@ def extract_endpoint(req: ExtractRequest, _: None = Depends(require_token)) -> d
     # counted, nothing was extracted, no state was mutated below this point.
     if result.status == "degraded":
         with _LOCK:
-            STATE["hellgraph_ok"] = result.hellgraph_ok
-            STATE["gateway_ok"] = result.gateway_ok
+            # A degraded refusal attempted no drain (result.attempted is False), so it is
+            # NOT a fresh observation of dependency health — do not overwrite
+            # hellgraph_ok/gateway_ok here (the success path applies the same attempted
+            # rule). Record only the back-pressure error; the 503 body still carries the
+            # emitter's last-observed dependency health for accurate client attribution.
             STATE["last_error"] = result.reason or "pending queue full"
             STATE["last_error_at"] = time.time()
         raise HTTPException(status_code=503, detail={

--- a/apps/nugget-extractor/tests/test_pending_cap.py
+++ b/apps/nugget-extractor/tests/test_pending_cap.py
@@ -16,7 +16,7 @@ from unittest import mock
 import pytest
 
 from nugget_extractor import emitter as em, extract as ex
-from nugget_extractor.clients import EmitError
+from nugget_extractor.clients import EmitError, GatewayError
 
 TEXT = b"Network sales grew 22.6% to AUD 1,138.9 million.\n\nStore rollout continued."
 DOC = "urn:srcos:document:cap-test"
@@ -58,10 +58,14 @@ def test_submit_refuses_with_degraded_status_when_pending_at_ceiling():
         assert r3.status == "degraded"
         assert r3.reason is not None
         assert "pending queue full" in r3.reason
-        assert "hellgraph downstream may be unavailable" in r3.reason
-        # No work was counted — a degraded submit is a pure no-op.
+        # Attribution comes from the LAST observed drain, not a hardcoded guess: here the
+        # wedged dependency really is hellgraph, so it is named — and the gateway, never
+        # reached, is NOT falsely reported down.
+        assert "hellgraph is not keeping up" in r3.reason
+        # No work was counted — a degraded submit is a pure no-op that contacted nothing.
         assert r3.documents == 0 and r3.extracted == 0 and r3.emitted == 0
-        assert r3.hellgraph_ok is False and r3.gateway_ok is False
+        assert r3.attempted is False
+        assert r3.hellgraph_ok is False and r3.gateway_ok is True
         # _pending did NOT grow past the cap.
         assert len(e._pending) == 2
 
@@ -130,3 +134,53 @@ def test_max_pending_env_override_is_respected():
             os.environ["NUGGET_EXTRACTOR_MAX_PENDING"] = prev
         from importlib import reload
         reload(em)
+
+
+class _HealthyGraph:
+    def post_node(self, *_a, **_kw):
+        pass
+
+    def post_edge(self, *_a, **_kw):
+        pass
+
+
+class _WedgedGateway:
+    """Graph writes land, but the receipt step is down — the OTHER way the queue fills."""
+
+    def mint(self, **_kw):
+        raise GatewayError("gateway receipt refused")
+
+
+def test_degraded_refusal_attributes_the_gateway_when_it_is_the_stalled_side():
+    """The misattribution fix. When the queue fills because the compute-gateway receipt
+    step is wedged (graph writes succeed), the refusal must name the GATEWAY and report
+    gateway_ok False / hellgraph_ok True — from the last real drain observation. Pre-fix
+    every degraded refusal hardcoded a hellgraph-centric reason and both deps False, so an
+    operator chasing a gateway outage was pointed at hellgraph."""
+    with mock.patch.object(em, "MAX_PENDING", 2):
+        e = em.NuggetEmitter(writer=_HealthyGraph(), gateway=_WedgedGateway(),
+                             clock=lambda: "2026-07-29T00:00:00.000Z")
+        r1 = e.submit(_extraction(), doc_ref=DOC + "-g1", run_ref=RUN)
+        r2 = e.submit(_extraction(), doc_ref=DOC + "-g2", run_ref=RUN)
+        assert r1.status == "ok" and r2.status == "ok"
+        # The drain reached the gateway and it failed; hellgraph was fine.
+        assert r1.gateway_ok is False and r1.hellgraph_ok is True
+        assert len(e._pending) == 2
+
+        r3 = e.submit(_extraction(), doc_ref=DOC + "-g3", run_ref=RUN)
+        assert r3.status == "degraded"
+        assert "compute-gateway receipt step" in r3.reason, r3.reason
+        assert "hellgraph is not keeping up" not in r3.reason  # NOT misattributed to hellgraph
+        assert r3.gateway_ok is False and r3.hellgraph_ok is True
+        assert r3.attempted is False  # a refusal observed nothing this call
+
+
+def test_max_pending_rejects_non_int_and_clamps_negative():
+    """The OOM guard must not itself become a boot-time outage or a permanent kill.
+    A non-int env falls back to the default; a negative env clamps to 0 (never a
+    negative cap, which would refuse every submit forever)."""
+    assert em._parse_max_pending("off", default=1000) == 1000      # non-int -> default
+    assert em._parse_max_pending("", default=1000) == 1000         # empty -> default
+    assert em._parse_max_pending(None, default=1000) == 1000       # unset -> default
+    assert em._parse_max_pending("-5", default=1000) == 0          # negative -> clamped
+    assert em._parse_max_pending("42", default=1000) == 42         # valid honoured


### PR DESCRIPTION
Follow-up to #1106, which merged with three of its four sub-tier findings resolved. This lands the last one: the degraded (queue-full) back-pressure refusal misreported which dependency was stalled.

## The defect (now in main)

A back-pressure refusal contacts **nothing** (`attempted` stays `False`), yet `_submit` hardcoded `hellgraph_ok=False` / `gateway_ok=False` and a hellgraph-centric reason. The pending queue fills just as readily when the **compute-gateway receipt step** is the wedged side (graph writes fine), so an operator chasing a gateway outage was pointed at hellgraph. The server then overwrote `STATE["hellgraph_ok"]/["gateway_ok"]` from a call that observed no dependency at all.

## The fix

- **emitter**: the emitter remembers the **last drain's** observed health and the degraded refusal reports *that* — naming hellgraph and/or the gateway receipt step accurately — instead of guessing. `attempted` is explicitly `False`.
- **server**: the degraded branch no longer overwrites `hellgraph_ok`/`gateway_ok` (the same `if result.attempted` rule the success path already applies); it records only the back-pressure error, and the 503 body carries the last-observed health.

## Tests (red → green proven locally)

- A **gateway-wedged** case asserts the refusal names the gateway (not hellgraph) and reports `gateway_ok False` / `hellgraph_ok True`; the existing hellgraph-wedged case is updated to the accurate attribution.
- A `_parse_max_pending` guard test pins non-int → default and negative → 0.
- A **concurrent seal-during-`/healthz`** test reproduces the `dictionary changed size during iteration` 500 on bare `_CHAINS.values()` iteration and passes on `snapshot_all()` — locking in the race fix that landed in #1106.

`pytest tests/test_sub_tier_hardening.py` (8) and `tests/test_pending_cap.py` (6) green.
