### PR TITLE
feat(contracts): land New Hope + Slash Topics semantic-BI integration

### DIFF
--- a/.github/workflows/newhope-slashtopics-integration.yml
+++ b/.github/workflows/newhope-slashtopics-integration.yml
@@ -1,0 +1,55 @@
+name: New Hope + Slash Topics Integration
+
+# Validates the New Hope + Slash Topics semantic-BI integration contracts.
+# Read-only: inspects the mirrored slash-topics schema subset, the landed
+# integration examples, and the import manifest already in the tree. No
+# network calls, no writes.
+on:
+  pull_request:
+    paths:
+      - 'contracts/imported/slash-topics/**'
+      - 'contracts/imported/IMPORT_MANIFEST.yaml'
+      - 'contracts/imported/CANONICAL_SOURCES.yaml'
+      - 'examples/newhope-slash-topics/**'
+      - 'tools/validate_newhope_slashtopics_integration.py'
+      - 'tools/tests/test_validate_newhope_slashtopics_integration.py'
+      - 'docs/INTEGRATION_NewHope_SlashTopics_SemanticBI.md'
+      - '.github/workflows/newhope-slashtopics-integration.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'contracts/imported/slash-topics/**'
+      - 'contracts/imported/IMPORT_MANIFEST.yaml'
+      - 'contracts/imported/CANONICAL_SOURCES.yaml'
+      - 'examples/newhope-slash-topics/**'
+      - 'tools/validate_newhope_slashtopics_integration.py'
+      - 'tools/tests/test_validate_newhope_slashtopics_integration.py'
+      - 'docs/INTEGRATION_NewHope_SlashTopics_SemanticBI.md'
+      - '.github/workflows/newhope-slashtopics-integration.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  newhope-slashtopics-validate:
+    name: Validate New Hope + Slash Topics integration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install validator dependencies
+        run: pip install jsonschema pyyaml pytest
+
+      - name: Validate integration contracts (non-mutating)
+        run: python3 tools/validate_newhope_slashtopics_integration.py
+
+      - name: Run integration validator tests
+        run: pytest tools/tests/test_validate_newhope_slashtopics_integration.py -q

--- a/.github/workflows/newhope-slashtopics-integration.yml
+++ b/.github/workflows/newhope-slashtopics-integration.yml
@@ -45,8 +45,8 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install validator dependencies
-        run: pip install jsonschema pyyaml pytest
+      - name: Install validator dependencies (pinned for reproducibility)
+        run: pip install jsonschema==4.23.0 PyYAML==6.0.2 pytest==8.3.4
 
       - name: Validate integration contracts (non-mutating)
         run: python3 tools/validate_newhope_slashtopics_integration.py

--- a/contracts/imported/CANONICAL_SOURCES.yaml
+++ b/contracts/imported/CANONICAL_SOURCES.yaml
@@ -1,0 +1,28 @@
+# Canonical Sources Registry (platform-level)
+# v0.1 — single source of truth per namespace
+
+namespaces:
+  newhope:
+    canonical_repo: new-hope-main
+    owns:
+      - carrier_wire_format
+      - receptor_mindset
+      - membrane_input_semantics
+  slash_topics:
+    canonical_repo: slash-topics-main
+    owns:
+      - slash-topics.pack.v0.1
+      - MembraneDecision.v0.1
+      - model-selection.policy.v0.1
+  semantic_search_bi:
+    canonical_repo: sociosphere-main
+    owns:
+      - caps/semantic-search-bi
+
+mirrors:
+  sourceos-main:
+    allowed_to_mirror:
+      - semantic_search_bi
+      - slash_topics
+      - newhope
+    rule: "mirrors must be generated or hash-locked; no hand edits"

--- a/contracts/imported/IMPORT_MANIFEST.yaml
+++ b/contracts/imported/IMPORT_MANIFEST.yaml
@@ -43,10 +43,10 @@ imports:
     import_mode: mirror_schema_subset
     local_path: contracts/imported/slash-topics/
     required_objects:
-      - SlashTopics_Schema_v0.1.json
-      - Membrane_Decision_v0.1.json
-      - Membrane_Decision_v0.2.json
-      - Model_Selection_Policy_v0.1.json
+      - specs/SlashTopics_Schema_v0.1.json
+      - specs/Membrane_Decision_v0.1.json
+      - specs/Membrane_Decision_v0.2.json
+      - specs/Model_Selection_Policy_v0.1.json
     pin: "9037a91959706e4cef07d0b55edfea8e9487baf1"
     validation:
       - jsonschema

--- a/contracts/imported/IMPORT_MANIFEST.yaml
+++ b/contracts/imported/IMPORT_MANIFEST.yaml
@@ -38,6 +38,20 @@ imports:
       - openapi-validate
       - client-smoke
 
+  - repo: SocioProphet/slash-topics
+    role: governed signed topic scopes — topic-pack + membrane-decision + model-selection semantics
+    import_mode: mirror_schema_subset
+    local_path: contracts/imported/slash-topics/
+    required_objects:
+      - SlashTopics_Schema_v0.1.json
+      - Membrane_Decision_v0.1.json
+      - Membrane_Decision_v0.2.json
+      - Model_Selection_Policy_v0.1.json
+    pin: "9037a91959706e4cef07d0b55edfea8e9487baf1"
+    validation:
+      - jsonschema
+      - newhope-slashtopics-integration
+
 references:
   - repo: SocioProphet/ontogenesis
     role: semantic governance, SHACL gates, registry

--- a/contracts/imported/slash-topics/SOURCE_MANIFEST.yaml
+++ b/contracts/imported/slash-topics/SOURCE_MANIFEST.yaml
@@ -1,0 +1,10 @@
+repo: SocioProphet/slash-topics
+pin: "9037a91959706e4cef07d0b55edfea8e9487baf1"
+imported_by: prophet-platform
+import_mode: mirror_schema_subset
+role: governed signed topic scopes — topic-pack, membrane-decision, and model-selection semantics
+mirrored_objects:
+  - specs/SlashTopics_Schema_v0.1.json
+  - specs/Membrane_Decision_v0.1.json
+  - specs/Membrane_Decision_v0.2.json
+  - specs/Model_Selection_Policy_v0.1.json

--- a/contracts/imported/slash-topics/specs/Membrane_Decision_v0.1.json
+++ b/contracts/imported/slash-topics/specs/Membrane_Decision_v0.1.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "audit": {
+      "properties": {
+        "egress": {
+          "properties": {
+            "allowed_domains": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "attempted": {
+              "type": "boolean"
+            },
+            "blocked_domains": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "policy_ref": {
+          "description": "content hash of the policy bundle",
+          "type": "string"
+        },
+        "reasons": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "redactions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "required_signers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ts": {
+          "description": "ISO-8601 timestamp",
+          "type": "string"
+        }
+      },
+      "required": [
+        "policy_ref",
+        "ts",
+        "reasons"
+      ],
+      "type": "object"
+    },
+    "decision": {
+      "enum": [
+        "ALLOW",
+        "DENY",
+        "QUARANTINE",
+        "REDACT",
+        "REQUIRE_SIGNATURE"
+      ],
+      "type": "string"
+    }
+  },
+  "required": [
+    "decision",
+    "audit"
+  ],
+  "title": "MembraneDecision",
+  "type": "object"
+}

--- a/contracts/imported/slash-topics/specs/Membrane_Decision_v0.2.json
+++ b/contracts/imported/slash-topics/specs/Membrane_Decision_v0.2.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "slash-topics.membrane-decision.v0.2",
+  "title": "Membrane Decision Schema v0.2",
+  "type": "object",
+  "required": ["decision", "audit", "model_family", "scope"],
+  "properties": {
+    "decision": {
+      "type": "string",
+      "enum": ["ALLOW", "DENY", "QUARANTINE", "REDACT", "REQUIRE_SIGNATURE"]
+    },
+    "audit": {
+      "type": "object",
+      "required": ["policy_ref", "ts", "reasons"],
+      "properties": {
+        "policy_ref": {
+          "description": "Content hash of the policy bundle",
+          "type": "string"
+        },
+        "reasons": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "ts": {
+          "description": "ISO-8601 timestamp",
+          "type": "string"
+        },
+        "redactions": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "required_signers": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "model_family": {
+      "type": "string",
+      "enum": ["lsa", "lsi", "lda"]
+    },
+    "scope": {
+      "type": "string",
+      "enum": ["user_local", "global_platform"]
+    },
+    "artifacts": {
+      "type": "object",
+      "properties": {
+        "input_hash": { "type": "string" },
+        "output_hash": { "type": "string" },
+        "receipt_ref": { "type": "string" }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/imported/slash-topics/specs/Model_Selection_Policy_v0.1.json
+++ b/contracts/imported/slash-topics/specs/Model_Selection_Policy_v0.1.json
@@ -1,0 +1,71 @@
+{
+  "schema": "model-selection.policy.v0.1",
+  "scope": [
+    "slash-topics"
+  ],
+  "tiers": [
+    "user",
+    "global"
+  ],
+  "families": {
+    "lsa": {
+      "enabled": true,
+      "representation": "tfidf->svd",
+      "determinism": "deterministic",
+      "notes": "Fast, stable baseline for topic projection and similarity."
+    },
+    "lsi": {
+      "enabled": true,
+      "representation": "tfidf->svd (IR-oriented)",
+      "determinism": "deterministic",
+      "notes": "LSI aligned with retrieval semantics; often same math as LSA but treated as IR pipeline."
+    },
+    "lda": {
+      "enabled": true,
+      "representation": "bag-of-words->topic distribution",
+      "determinism": "bounded_nondeterministic",
+      "notes": "Requires seed control; sampling may vary unless fixed RNG + deterministic backend."
+    }
+  },
+  "training": {
+    "user": {
+      "data_sources": [
+        "user-local-corpus",
+        "user-interactions (opt-in)"
+      ],
+      "privacy_posture": "local-first",
+      "update_schedule": "incremental",
+      "retention": "user-controlled",
+      "export": "signed pack + receipt"
+    },
+    "global": {
+      "data_sources": [
+        "commons-corpus",
+        "curated-feeds",
+        "federated packs"
+      ],
+      "privacy_posture": "minimized",
+      "update_schedule": "batched",
+      "retention": "policy-bound",
+      "export": "signed pack + receipt"
+    }
+  },
+  "encoder_policy": {
+    "allowed": false,
+    "review_required": true,
+    "notes": "We default to classical (LSA/LSI/LDA). Encoder/hybrid models require explicit governance + reproducibility receipts."
+  },
+  "receipts": {
+    "must_emit": true,
+    "fields_required": [
+      "model_family",
+      "tier",
+      "corpus_ref",
+      "preprocess_ref",
+      "hyperparams",
+      "rng_seed",
+      "artifact_hashes",
+      "timestamp"
+    ]
+  }
+}

--- a/contracts/imported/slash-topics/specs/SlashTopics_Schema_v0.1.json
+++ b/contracts/imported/slash-topics/specs/SlashTopics_Schema_v0.1.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "slash-topics.schema.v0.1",
+  "title": "SlashTopics Pack Schema v0.1",
+  "type": "object",
+  "required": [
+    "schema",
+    "pack",
+    "version",
+    "snapshot",
+    "topics"
+  ],
+  "properties": {
+    "schema": {
+      "const": "slash-topics.pack.v0.1"
+    },
+    "pack": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "snapshot": {
+      "type": "string",
+      "minLength": 1
+    },
+    "canonicalization": {
+      "type": "object",
+      "required": [
+        "format",
+        "ordering",
+        "encoding",
+        "hash"
+      ],
+      "properties": {
+        "format": {
+          "enum": [
+            "json"
+          ]
+        },
+        "ordering": {
+          "enum": [
+            "lexicographic"
+          ]
+        },
+        "encoding": {
+          "enum": [
+            "utf-8"
+          ]
+        },
+        "hash": {
+          "enum": [
+            "blake3"
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "topics": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "slash",
+          "name",
+          "category",
+          "source"
+        ],
+        "properties": {
+          "slash": {
+            "type": "string",
+            "pattern": "^/"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "category": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "derived": {
+            "type": "boolean"
+          },
+          "source": {
+            "type": "object",
+            "required": [
+              "origin",
+              "snapshot"
+            ],
+            "properties": {
+              "origin": {
+                "type": "string",
+                "minLength": 1
+              },
+              "snapshot": {
+                "type": "string",
+                "minLength": 1
+              },
+              "kind": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          },
+          "policy": {
+            "type": "object",
+            "properties": {
+              "default_posture": {
+                "enum": [
+                  "allow",
+                  "redact",
+                  "quarantine",
+                  "deny",
+                  "require-signature"
+                ]
+              },
+              "labels": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/INTEGRATION_NewHope_SlashTopics_SemanticBI.md
+++ b/docs/INTEGRATION_NewHope_SlashTopics_SemanticBI.md
@@ -1,0 +1,41 @@
+# New Hope + Slash Topics + Semantic BI — Platform Integration v0.1
+
+## Scope
+This document defines how **New Hope** (semantic runtime) and **Slash Topics** (governed, signed scopes) integrate to support **semantic BI** as a *platform capability*.
+
+We treat this as a platform concern (SocioSphere domain), not an OS concern (SourceOS domain).
+
+## Core idea
+- **New Hope Carriers** are the event envelope: signed, content-addressed, policy-contextualized.
+- **Slash Topic Packs** are the governed scope objects: signed artifacts that define what `/topic` means and which policies attach.
+- **Semantic BI** consumes the resulting event stream + indexes and produces audited, replayable “lens outputs.”
+
+## Canonicality (single source of truth)
+- Canonical **Carrier / Membrane input semantics**: New Hope spec
+- Canonical **Topic Pack schema + MembraneDecision schema**: Slash Topics specs
+- Canonical **semantic-search-bi** capability contract: SocioSphere (platform)
+- SourceOS may *mirror* platform contracts for packaging/ops, but is not canonical for platform meaning.
+
+## Mapping: Slash Topics → New Hope policy_context
+We map a slash scope into New Hope’s policy context:
+- `policy_context.tenant`: `commons | org:<id> | team:<id>`
+- `policy_context.community`: `topic:/<slash>` (example: `topic:/science`)
+- `policy_context.ruleset_ref`: content hash of the policy bundle attached to the topic pack
+- `policy_context.labels`: safety + routing labels (e.g., `contains_pii:false`, `source:social:x`, `egress:blocked`)
+
+## Event flow (minimum viable vertical slice)
+1) **Social ingest** → `MessagePosted` carrier
+2) **Membrane** evaluates carrier → emits `MembraneDecision` (ALLOW / DENY / QUARANTINE / REDACT / REQUIRE_SIGNATURE)
+3) **Topic projection** assigns one or more slash topics → emits `TopicAssigned` carrier(s)
+4) **Vectorization** computes topic-aligned vectors (default deterministic classical methods) → emits `EmbeddingComputed` carrier + receipt
+5) **Semantic BI** runs lens pipelines over scoped data → emits `LensOutput` carriers + receipts
+
+## Safety posture
+- Default to deterministic representations (LSA/LSI) unless governance explicitly enables encoder models.
+- Prefer “downgrade fidelity” flows: keep embeddings/receipts when raw text is not allowed.
+- Enforce explicit egress: no silent third-party calls.
+
+## Canonicalization
+- For TritRPC-transported carriers: hash/sign **canonical TritRPC frame bytes**.
+- For JSON topic packs/manifests/policies: hash/sign **canonical JSON bytes** (RFC 8785/JCS recommended) + BLAKE3 naming.
+

--- a/examples/newhope-slash-topics/embedding_receipt_lsi.example.json
+++ b/examples/newhope-slash-topics/embedding_receipt_lsi.example.json
@@ -1,0 +1,13 @@
+{
+  "schema": "embedding.receipt.v0.1",
+  "model_family": "lsi",
+  "tier": "global",
+  "corpus_ref": "hash://blake3/<corpus-hash>",
+  "preprocess_ref": "hash://blake3/<preprocess-hash>",
+  "hyperparams": {"k": 256, "tfidf": {"min_df": 2}},
+  "rng_seed": 0,
+  "artifact_hashes": ["hash://blake3/<svd-matrix>", "hash://blake3/<vocab>"],
+  "timestamp": "2026-02-11T22:00:05Z",
+  "input_carriers": ["hash://blake3/<carrier-hash>"],
+  "output_embeddings": {"vector_dim": 256, "ref": "hash://blake3/<embedding-artifact>"}
+}

--- a/examples/newhope-slash-topics/membrane_decision_allow.example.json
+++ b/examples/newhope-slash-topics/membrane_decision_allow.example.json
@@ -1,0 +1,15 @@
+{
+  "decision": "ALLOW",
+  "audit": {
+    "policy_ref": "hash://blake3/<policy-bundle-hash>",
+    "ts": "2026-02-11T00:00:00Z",
+    "reasons": ["topic:/science default allow"],
+    "redactions": [],
+    "required_signers": [],
+    "egress": {
+      "attempted": false,
+      "allowed_domains": [],
+      "blocked_domains": []
+    }
+  }
+}

--- a/examples/newhope-slash-topics/newhope_message_posted.example.json
+++ b/examples/newhope-slash-topics/newhope_message_posted.example.json
@@ -1,0 +1,33 @@
+{
+  "carrier_version": "1",
+  "protocol_ref": "hash://blake3/<protocol-hash-message-v0>",
+  "signal": {
+    "type": "MessagePosted",
+    "ts": "2026-02-11T22:00:00Z",
+    "id": "hash://blake3/<signal-hash>",
+    "parents": [],
+    "thread_root": "hash://blake3/<thread-root>",
+    "derived_from": ["hash://blake3/<source-social-id>"]
+  },
+  "payload": {
+    "text": "NASA announces a new public dataset release.",
+    "links": ["https://example.invalid/nasa"],
+    "language": "en",
+    "visibility": "public",
+    "source": {"platform": "social:x", "post_id": "<id>"}
+  },
+  "provenance": {
+    "emitter": {"kind": "service", "id": "did:key:<ingestor>"},
+    "signatures": [
+      {"alg": "ed25519", "sig": "base64...", "covers": "hash://blake3/<canonical-carrier-hash>"}
+    ],
+    "inputs": [],
+    "transforms": []
+  },
+  "policy_context": {
+    "tenant": "commons",
+    "community": "topic:/science",
+    "ruleset_ref": "hash://blake3/<ruleset-hash>",
+    "labels": ["public", "contains_pii:false", "source:social:x", "egress:blocked"]
+  }
+}

--- a/examples/newhope-slash-topics/slash_topics_pack_min.example.json
+++ b/examples/newhope-slash-topics/slash_topics_pack_min.example.json
@@ -1,0 +1,30 @@
+{
+  "schema": "slash-topics.pack.v0.1",
+  "pack": "commons_default",
+  "version": "0.1.0",
+  "snapshot": "2026-02-11",
+  "canonicalization": {
+    "format": "json",
+    "ordering": "lexicographic",
+    "encoding": "utf-8",
+    "hash": "blake3"
+  },
+  "topics": [
+    {
+      "slash": "/science",
+      "name": "Science",
+      "category": "reference",
+      "description": "High-signal science and research sources.",
+      "derived": false,
+      "source": {
+        "origin": "seed:blekko",
+        "snapshot": "2012-10-15",
+        "kind": "bootstrap"
+      },
+      "policy": {
+        "default_posture": "allow",
+        "labels": ["safe-default", "no-egress-default"]
+      }
+    }
+  ]
+}

--- a/tools/tests/test_validate_newhope_slashtopics_integration.py
+++ b/tools/tests/test_validate_newhope_slashtopics_integration.py
@@ -1,0 +1,35 @@
+"""Test the New Hope + Slash Topics integration validator against the landed tree."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = ROOT / "tools" / "validate_newhope_slashtopics_integration.py"
+
+
+def test_validator_passes_on_landed_tree():
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"validator failed (rc={result.returncode})\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "all checks passed" in result.stdout.lower()
+
+
+def test_mirrored_schemas_and_examples_present():
+    specs = ROOT / "contracts" / "imported" / "slash-topics" / "specs"
+    examples = ROOT / "examples" / "newhope-slash-topics"
+    for name in (
+        "SlashTopics_Schema_v0.1.json",
+        "Membrane_Decision_v0.1.json",
+        "Membrane_Decision_v0.2.json",
+        "Model_Selection_Policy_v0.1.json",
+    ):
+        assert (specs / name).is_file(), f"missing mirrored schema: {name}"
+    assert (examples / "slash_topics_pack_min.example.json").is_file()
+    assert (examples / "membrane_decision_allow.example.json").is_file()

--- a/tools/validate_newhope_slashtopics_integration.py
+++ b/tools/validate_newhope_slashtopics_integration.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import yaml
 from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
 
 ROOT = Path(__file__).resolve().parents[1]
 SLASH = ROOT / "contracts" / "imported" / "slash-topics"
@@ -65,8 +66,15 @@ def assert_no_junk() -> None:
 
 
 def assert_import_provenance() -> None:
-    manifest = yaml.safe_load(IMPORT_MANIFEST.read_text(encoding="utf-8"))
-    by_repo = {i.get("repo"): i for i in manifest.get("imports", [])}
+    try:
+        manifest = yaml.safe_load(IMPORT_MANIFEST.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"Required file missing: {IMPORT_MANIFEST.relative_to(ROOT)}")
+    except yaml.YAMLError as e:
+        fail(f"Could not parse {IMPORT_MANIFEST.relative_to(ROOT)}: {e}")
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("imports"), list):
+        fail("IMPORT_MANIFEST malformed: expected a mapping with an 'imports' list")
+    by_repo = {i.get("repo"): i for i in manifest["imports"] if isinstance(i, dict)}
     for repo in ("SocioProphet/new-hope", "SocioProphet/slash-topics"):
         entry = by_repo.get(repo)
         if not entry:
@@ -102,16 +110,34 @@ def assert_schema_invariants() -> None:
     ok("Model selection policy defaults to classical methods (encoder disabled)")
 
 
+def _schema_validate(instance: dict, schema: dict, label: str) -> None:
+    try:
+        Draft202012Validator(schema).validate(instance)
+    except ValidationError as e:
+        loc = "/".join(str(p) for p in e.absolute_path) or "<root>"
+        fail(f"{label} failed schema validation at {loc}: {e.message}")
+
+
 def validate_examples() -> None:
+    # All four landed fixtures must at least parse as JSON.
+    all_fixtures = [
+        "slash_topics_pack_min.example.json",
+        "membrane_decision_allow.example.json",
+        "newhope_message_posted.example.json",
+        "embedding_receipt_lsi.example.json",
+    ]
+    for name in all_fixtures:
+        load_json(EXAMPLES / name)
+
+    # The two fixtures with a mirrored slash-topics schema are validated against it.
+    # newhope_message_posted / embedding_receipt_lsi bind to New Hope schemas, which
+    # the platform imports by pinned manifest only (not mirrored), so they are
+    # parse-checked above rather than schema-validated here.
     schema = load_json(SPECS / "SlashTopics_Schema_v0.1.json")
     md_schema = load_json(SPECS / "Membrane_Decision_v0.1.json")
-
-    pack_example = load_json(EXAMPLES / "slash_topics_pack_min.example.json")
-    md_example = load_json(EXAMPLES / "membrane_decision_allow.example.json")
-
-    Draft202012Validator(schema).validate(pack_example)
-    Draft202012Validator(md_schema).validate(md_example)
-    ok("Landed example fixtures validate against the mirrored Slash Topics schemas")
+    _schema_validate(load_json(EXAMPLES / "slash_topics_pack_min.example.json"), schema, "slash_topics_pack_min")
+    _schema_validate(load_json(EXAMPLES / "membrane_decision_allow.example.json"), md_schema, "membrane_decision_allow")
+    ok("All 4 fixtures parse; the 2 with mirrored schemas validate against them")
 
 
 def main() -> int:

--- a/tools/validate_newhope_slashtopics_integration.py
+++ b/tools/validate_newhope_slashtopics_integration.py
@@ -83,6 +83,14 @@ def assert_import_provenance() -> None:
             fail(f"IMPORT_MANIFEST entry for {repo} has no pin (provenance required)")
     ok("IMPORT_MANIFEST declares new-hope + slash-topics, both pinned")
 
+    # Enforce slash-topics required_objects: each must resolve under its local_path.
+    st = by_repo["SocioProphet/slash-topics"]
+    local_path = ROOT / st.get("local_path", "contracts/imported/slash-topics/")
+    for obj in st.get("required_objects", []):
+        if not (local_path / obj).is_file():
+            fail(f"slash-topics required_object not mirrored: {(local_path / obj)}")
+    ok("slash-topics required_objects all resolve under local_path")
+
 
 def assert_schema_invariants() -> None:
     schema = load_json(SPECS / "SlashTopics_Schema_v0.1.json")

--- a/tools/validate_newhope_slashtopics_integration.py
+++ b/tools/validate_newhope_slashtopics_integration.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Self-contained CI gate for the New Hope + Slash Topics integration.
+
+The platform mirrors a schema subset of SocioProphet/slash-topics under
+``contracts/imported/slash-topics/`` (see SOURCE_MANIFEST.yaml, pinned) rather
+than vendoring the whole repo, so this validator runs against the mirrored
+files already present in the tree. It makes no network calls and writes nothing.
+
+Checks:
+- No .DS_Store / __MACOSX junk under the landed integration paths.
+- IMPORT_MANIFEST declares new-hope AND slash-topics, each with a pin
+  (the platform's provenance invariant — replaces the cross-repo LICENSE check).
+- Slash Topics pack schema, MembraneDecision schema, and Model Selection policy
+  hold their expected invariants.
+- The landed integration example fixtures validate against the mirrored schemas.
+
+Exit non-zero on any violation.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+SLASH = ROOT / "contracts" / "imported" / "slash-topics"
+SPECS = SLASH / "specs"
+EXAMPLES = ROOT / "examples" / "newhope-slash-topics"
+IMPORT_MANIFEST = ROOT / "contracts" / "imported" / "IMPORT_MANIFEST.yaml"
+LANDED_PATHS = [SLASH, EXAMPLES, ROOT / "docs" / "INTEGRATION_NewHope_SlashTopics_SemanticBI.md"]
+
+
+def fail(msg: str) -> None:
+    print(f"[FAIL] {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def ok(msg: str) -> None:
+    print(f"[OK] {msg}")
+
+
+def load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"Required file missing: {path.relative_to(ROOT)}")
+    except Exception as e:  # noqa: BLE001
+        fail(f"Could not parse JSON: {path} ({e})")
+
+
+def assert_no_junk() -> None:
+    junk = []
+    for base in LANDED_PATHS:
+        if base.is_dir():
+            for p in base.rglob("*"):
+                if p.name == ".DS_Store" or "__MACOSX" in p.parts:
+                    junk.append(str(p.relative_to(ROOT)))
+    if junk:
+        fail("Junk artifacts present (must be deleted):\n" + "\n".join(junk[:50]))
+    ok("No .DS_Store/__MACOSX junk under landed paths")
+
+
+def assert_import_provenance() -> None:
+    manifest = yaml.safe_load(IMPORT_MANIFEST.read_text(encoding="utf-8"))
+    by_repo = {i.get("repo"): i for i in manifest.get("imports", [])}
+    for repo in ("SocioProphet/new-hope", "SocioProphet/slash-topics"):
+        entry = by_repo.get(repo)
+        if not entry:
+            fail(f"IMPORT_MANIFEST does not declare {repo}")
+        if not entry.get("pin"):
+            fail(f"IMPORT_MANIFEST entry for {repo} has no pin (provenance required)")
+    ok("IMPORT_MANIFEST declares new-hope + slash-topics, both pinned")
+
+
+def assert_schema_invariants() -> None:
+    schema = load_json(SPECS / "SlashTopics_Schema_v0.1.json")
+    md = load_json(SPECS / "Membrane_Decision_v0.1.json")
+    model = load_json(SPECS / "Model_Selection_Policy_v0.1.json")
+
+    required = set(schema.get("required", []))
+    for k in ["schema", "pack", "version", "snapshot", "topics"]:
+        if k not in required:
+            fail(f"SlashTopics schema missing required field: {k}")
+    ok("SlashTopics pack schema required fields look sane")
+
+    md_required = set(md.get("required", []))
+    if not {"decision", "audit"}.issubset(md_required):
+        fail("MembraneDecision v0.1 schema must require decision + audit")
+    decision_enum = set(md.get("properties", {}).get("decision", {}).get("enum", []))
+    expected = {"ALLOW", "DENY", "QUARANTINE", "REDACT", "REQUIRE_SIGNATURE"}
+    if decision_enum != expected:
+        fail(f"MembraneDecision enum mismatch. Expected {sorted(expected)}, got {sorted(decision_enum)}")
+    ok("MembraneDecision enum + required fields look sane")
+
+    encoder_allowed = model.get("encoder_policy", {}).get("allowed")
+    if encoder_allowed is not False:
+        fail("Model_Selection_Policy_v0.1 must default encoder_policy.allowed=false")
+    ok("Model selection policy defaults to classical methods (encoder disabled)")
+
+
+def validate_examples() -> None:
+    schema = load_json(SPECS / "SlashTopics_Schema_v0.1.json")
+    md_schema = load_json(SPECS / "Membrane_Decision_v0.1.json")
+
+    pack_example = load_json(EXAMPLES / "slash_topics_pack_min.example.json")
+    md_example = load_json(EXAMPLES / "membrane_decision_allow.example.json")
+
+    Draft202012Validator(schema).validate(pack_example)
+    Draft202012Validator(md_schema).validate(md_example)
+    ok("Landed example fixtures validate against the mirrored Slash Topics schemas")
+
+
+def main() -> int:
+    assert_no_junk()
+    assert_import_provenance()
+    assert_schema_invariants()
+    validate_examples()
+    ok("New Hope + Slash Topics integration: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/validate_repo.py
+++ b/tools/validate_repo.py
@@ -112,6 +112,7 @@ for rel in [
     "contracts/imported/semantic-serdes/SOURCE_MANIFEST.yaml",
     "contracts/imported/new-hope/SOURCE_MANIFEST.yaml",
     "contracts/imported/memory-mesh/SOURCE_MANIFEST.yaml",
+    "contracts/imported/slash-topics/SOURCE_MANIFEST.yaml",
 ]:
     if not (ROOT / rel).exists():
         fail(f"missing imported source manifest: {rel}")


### PR DESCRIPTION
## What & why

Lands the **New Hope × Slash Topics × Semantic BI** integration into the platform and closes a real gap: `slash-topics` was referenced by the integration but **never imported** (new-hope, memory-mesh, semantic-serdes were). Sourced from the `newhope-slash-topics-integration` pack that previously lived only on a local machine (no remote).

## Changes
- **Import slash-topics as a first-class pinned contract** — `contracts/imported/slash-topics/SOURCE_MANIFEST.yaml` (pinned to `9037a91`) + mirrored schema subset (SlashTopics pack v0.1, MembraneDecision v0.1/v0.2, Model Selection policy v0.1), parity with the existing imports.
- **Declare *and* enforce** — added to `IMPORT_MANIFEST.yaml` and to `validate_repo.py`'s required-manifest gate.
- **Integration spec** — `docs/INTEGRATION_NewHope_SlashTopics_SemanticBI.md` + `contracts/imported/CANONICAL_SOURCES.yaml` (single-source-of-truth registry).
- **Fixtures** — `examples/newhope-slash-topics/` (the 4 vertical-slice examples).
- **Self-contained CI gate** — `tools/validate_newhope_slashtopics_integration.py` (+ test) validates junk-freeness, import provenance/pins, schema invariants (MembraneDecision enum, encoder-disabled-by-default posture), and that fixtures validate against the mirrored schemas. Wired via `.github/workflows/newhope-slashtopics-integration.yml`.

## Verification (local)
- `validate_newhope_slashtopics_integration.py` → all 6 checks pass (rc=0)
- `pytest tools/tests/test_validate_newhope_slashtopics_integration.py` → 2 passed
- `tools/validate_repo.py` (umbrella) → `OK: validate passed`

## Follow-on (not in this PR)
Standing up the **runtime services** for the event flow (Membrane → TopicProjection → Vectorization → Semantic BI lens). Adapters already exist (`apps/knowledge-reason/service/new_hope_adapter.py`, `newHopeMembrane.ts`, `slashTopicsScope.ts`); this PR lands the contracts they bind to.