### PR TITLE
fix(security): bump golang.org/x/crypto to v0.52.0 (clears all 21 critical Dependabot alerts)

### DIFF
--- a/apps/api/go.mod
+++ b/apps/api/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require github.com/SocioProphet/prophet-platform/libs/go/tritrpcbridge v0.0.0
 
 require (
-	golang.org/x/crypto v0.49.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 )
 
 replace github.com/SocioProphet/prophet-platform/libs/go/tritrpcbridge => ../../libs/go/tritrpcbridge

--- a/apps/api/go.sum
+++ b/apps/api/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
-golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/apps/gateway/go.mod
+++ b/apps/gateway/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require github.com/SocioProphet/prophet-platform/libs/go/tritrpcbridge v0.0.0
 
 require (
-	golang.org/x/crypto v0.49.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 )
 
 replace github.com/SocioProphet/prophet-platform/libs/go/tritrpcbridge => ../../libs/go/tritrpcbridge

--- a/apps/gateway/go.sum
+++ b/apps/gateway/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
-golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/libs/go/tritrpcbridge/go.mod
+++ b/libs/go/tritrpcbridge/go.mod
@@ -2,6 +2,6 @@ module github.com/SocioProphet/prophet-platform/libs/go/tritrpcbridge
 
 go 1.25.0
 
-require golang.org/x/crypto v0.49.0
+require golang.org/x/crypto v0.52.0
 
-require golang.org/x/sys v0.42.0 // indirect
+require golang.org/x/sys v0.45.0 // indirect

--- a/libs/go/tritrpcbridge/go.sum
+++ b/libs/go/tritrpcbridge/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
-golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## What & why
Bumps `golang.org/x/crypto` **v0.49.0 → v0.52.0** in all three Go modules. This clears **every open Dependabot alert against x/crypto — 39 total (21 critical, 6 high, 12 medium)** — which is the *entire critical surface* on prophet-platform.

## Modules
- `apps/api/go.mod` (indirect → v0.52.0)
- `apps/gateway/go.mod` (indirect → v0.52.0)
- `libs/go/tritrpcbridge/go.mod` (direct require → v0.52.0)

Also pulls `golang.org/x/sys` 0.42.0 → 0.45.0 (transitive requirement).

## Verification (local, go 1.25 toolchain)
- `go build ./...` → rc=0 in all three modules
- `go vet ./...` → rc=0 in all three modules
- `go work sync` clean
- diff is go.mod/go.sum only

## Plan context
First of the security-remediation tranche (Phase 2, ahead of feature merges so nothing stacks on a vulnerable base). Follow-ups queued: **pip** (starlette, pypdf, pyjwt, protobuf, sentencepiece) and **npm** (undici + small deps). Dev-only `pytest` batched separately.