### PR TITLE
fix(lattice-studio): URL-encode the subgraph label param (query injection)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -27,6 +27,7 @@ import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 import jwt
@@ -138,7 +139,7 @@ async def studio(project: str = "default", _auth: dict[str, Any] | None = Depend
             _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/stats"),
             _req(client, "GET", f"{TRITFABRIC_URL}/v1/registry"),
             _req(client, "POST", f"{SEARCH_ORCH_URL}/v0/search/query", json=_sherlock_request(project)),
-            _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit=300"),
+            _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit=300"),
             _req(client, "GET", f"{EVIDENCE_RECEIPTS_URL}/v1/receipts/recent?service=hellgraph-service&limit=10"),
         )
     degraded = {k: v for k, v in {"graph": gerr, "models": rerr, "extraction": serr}.items() if v}
@@ -333,7 +334,7 @@ async def query(req: QueryRequest, _auth: dict[str, Any] | None = Depends(requir
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
         (res, err), (subg, _s) = await asyncio.gather(
             _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/{lang}", json=body),
-            _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit=500"),
+            _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit=500"),
         )
     if not isinstance(res, dict):
         raise HTTPException(status_code=400, detail=f"query failed: {err or 'no result from kernel'}")
@@ -370,7 +371,7 @@ def _safe_json(s: Any) -> Any:
 async def _fetch_raw_nodes(coll: str, limit: int = 500) -> tuple[list[dict[str, Any]], str | None]:
     """Raw project nodes (properties preserved — unlike _map_node, which projects to a fixed field set)."""
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit={limit}")
+        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}")
     raw = (res.get("nodes") if isinstance(res, dict) else None) or []
     return (raw if isinstance(raw, list) else []), err
 
@@ -1129,7 +1130,7 @@ async def perspectives(project: str = "default",
 async def _fetch_graph(coll: str, limit: int = 2000) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str | None]:
     """Project subgraph as (nodes, edges, err). Edges carry {from, to, label} — used for lineage walks."""
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit={limit}")
+        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}")
     nodes = (res.get("nodes") if isinstance(res, dict) else None) or []
     edges = (res.get("edgeList") if isinstance(res, dict) else None) or []
     return (nodes if isinstance(nodes, list) else []), (edges if isinstance(edges, list) else []), err
@@ -3020,7 +3021,7 @@ async def _fetch_subgraph(coll: str, limit: int = 200) -> tuple[list[dict[str, A
     explorer draws real topology — not a chip-cloud — and every node still carries its provenance.
     """
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit={limit}")
+        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}")
     raw_nodes = res.get("nodes", []) if isinstance(res, dict) else []
     raw_edges = res.get("edgeList", []) if isinstance(res, dict) else []
     nodes = [_map_node(n) for n in (raw_nodes if isinstance(raw_nodes, list) else [])[:limit]]
@@ -3048,7 +3049,7 @@ async def documents(project: str = "default", limit: int = 500, doc_sha: str = "
     not a node soup. Pass doc_sha to get one document's node ids (the explorer filter)."""
     coll = proj_collection(project)
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={coll}&limit={limit}")
+        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}")
     raw_nodes = res.get("nodes", []) if isinstance(res, dict) else []
     raw_edges = res.get("edgeList", []) if isinstance(res, dict) else []
     docs: dict[str, dict[str, Any]] = {}

--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -111,6 +111,14 @@ async def _req(client: httpx.AsyncClient, method: str, url: str, json: Any | Non
         return None, str(exc)
 
 
+def _subgraph_url(coll: str, limit: int) -> str:
+    """The ONE place a subgraph query string is built. proj_collection() only strips dashes
+    and truncates -- it does not reject '&'/'=', so `coll` must be percent-encoded here, not
+    at each call site. A future subgraph call importing this instead of hand-interpolating
+    `?label={coll}&limit=...` cannot reintroduce the query-injection this function closed."""
+    return f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}"
+
+
 def _sherlock_request(project: str) -> dict[str, Any]:
     """A schema-valid sherlock_search_request (see schemas/search/sherlock_search_request.schema.json)."""
     return {
@@ -139,7 +147,7 @@ async def studio(project: str = "default", _auth: dict[str, Any] | None = Depend
             _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/stats"),
             _req(client, "GET", f"{TRITFABRIC_URL}/v1/registry"),
             _req(client, "POST", f"{SEARCH_ORCH_URL}/v0/search/query", json=_sherlock_request(project)),
-            _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit=300"),
+            _req(client, "GET", _subgraph_url(coll, 300)),
             _req(client, "GET", f"{EVIDENCE_RECEIPTS_URL}/v1/receipts/recent?service=hellgraph-service&limit=10"),
         )
     degraded = {k: v for k, v in {"graph": gerr, "models": rerr, "extraction": serr}.items() if v}
@@ -334,7 +342,7 @@ async def query(req: QueryRequest, _auth: dict[str, Any] | None = Depends(requir
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
         (res, err), (subg, _s) = await asyncio.gather(
             _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/{lang}", json=body),
-            _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit=500"),
+            _req(client, "GET", _subgraph_url(coll, 500)),
         )
     if not isinstance(res, dict):
         raise HTTPException(status_code=400, detail=f"query failed: {err or 'no result from kernel'}")
@@ -371,7 +379,7 @@ def _safe_json(s: Any) -> Any:
 async def _fetch_raw_nodes(coll: str, limit: int = 500) -> tuple[list[dict[str, Any]], str | None]:
     """Raw project nodes (properties preserved — unlike _map_node, which projects to a fixed field set)."""
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}")
+        res, err = await _req(client, "GET", _subgraph_url(coll, limit))
     raw = (res.get("nodes") if isinstance(res, dict) else None) or []
     return (raw if isinstance(raw, list) else []), err
 
@@ -1130,7 +1138,7 @@ async def perspectives(project: str = "default",
 async def _fetch_graph(coll: str, limit: int = 2000) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str | None]:
     """Project subgraph as (nodes, edges, err). Edges carry {from, to, label} — used for lineage walks."""
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}")
+        res, err = await _req(client, "GET", _subgraph_url(coll, limit))
     nodes = (res.get("nodes") if isinstance(res, dict) else None) or []
     edges = (res.get("edgeList") if isinstance(res, dict) else None) or []
     return (nodes if isinstance(nodes, list) else []), (edges if isinstance(edges, list) else []), err
@@ -3021,7 +3029,7 @@ async def _fetch_subgraph(coll: str, limit: int = 200) -> tuple[list[dict[str, A
     explorer draws real topology — not a chip-cloud — and every node still carries its provenance.
     """
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}")
+        res, err = await _req(client, "GET", _subgraph_url(coll, limit))
     raw_nodes = res.get("nodes", []) if isinstance(res, dict) else []
     raw_edges = res.get("edgeList", []) if isinstance(res, dict) else []
     nodes = [_map_node(n) for n in (raw_nodes if isinstance(raw_nodes, list) else [])[:limit]]
@@ -3049,7 +3057,7 @@ async def documents(project: str = "default", limit: int = 500, doc_sha: str = "
     not a node soup. Pass doc_sha to get one document's node ids (the explorer filter)."""
     coll = proj_collection(project)
     async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-        res, err = await _req(client, "GET", f"{HELLGRAPH_URL}/api/graph/subgraph?label={quote(coll, safe='')}&limit={limit}")
+        res, err = await _req(client, "GET", _subgraph_url(coll, limit))
     raw_nodes = res.get("nodes", []) if isinstance(res, dict) else []
     raw_edges = res.get("edgeList", []) if isinstance(res, dict) else []
     docs: dict[str, dict[str, Any]] = {}

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -1,6 +1,8 @@
 """Studio BFF smoke: healthz + the studio bundle (live fabric services unreachable in test → graceful degrade)."""
 from __future__ import annotations
 
+from urllib.parse import urlparse, parse_qs
+
 from fastapi.testclient import TestClient
 
 from lattice_studio.server import app, proj_collection
@@ -36,11 +38,14 @@ def test_subgraph_label_is_url_encoded_not_injected(monkeypatch):
     r = client.get("/api/studio", params={"project": "evil&limit=99999"})
     assert r.status_code == 200
     assert seen_urls, "subgraph call should have fired"
-    url = seen_urls[0]
-    # the injected '&limit=' must be percent-encoded INSIDE the label value, not become a
-    # second real query param — i.e. the URL must still carry exactly one real 'limit='.
-    assert url.count("limit=") == 1
-    assert "label=proj-evil%26limit%3D9" in url
+    parsed = urlparse(seen_urls[0])
+    qs = parse_qs(parsed.query)
+    # Structured parsing, not substring counting: exactly two real query keys, and the
+    # injected '&limit=' must have landed INSIDE the label value (decoded), not spawned a
+    # second 'limit' key that would override the real one.
+    assert set(qs.keys()) == {"label", "limit"}
+    assert qs["label"] == ["proj-evil&limit=9"]
+    assert qs["limit"] == ["300"]
 
 
 def test_studio_bundle_project_scoped_and_complete():

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -18,6 +18,31 @@ def test_project_collection_matches_noetica():
     assert proj_collection("a1b2-c3d4-e5f6-7890") == "proj-a1b2c3d4e5f6"
 
 
+def test_subgraph_label_is_url_encoded_not_injected(monkeypatch):
+    # proj_collection only strips dashes — it does not reject '&'/'=' etc. A project id
+    # carrying those must not let the caller inject extra query params into the upstream
+    # hellgraph-service request (the label value has to stay a single opaque value).
+    import lattice_studio.server as srv
+
+    seen_urls: list[str] = []
+
+    async def fake_req(client, method, url, json=None):
+        if "subgraph" in url:
+            seen_urls.append(url)
+            return ({"nodes": [], "edgeList": []}, None)
+        return (None, "unreachable")
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.get("/api/studio", params={"project": "evil&limit=99999"})
+    assert r.status_code == 200
+    assert seen_urls, "subgraph call should have fired"
+    url = seen_urls[0]
+    # the injected '&limit=' must be percent-encoded INSIDE the label value, not become a
+    # second real query param — i.e. the URL must still carry exactly one real 'limit='.
+    assert url.count("limit=") == 1
+    assert "label=proj-evil%26limit%3D9" in url
+
+
 def test_studio_bundle_project_scoped_and_complete():
     r = client.get("/api/studio?project=my-proj-42")
     assert r.status_code == 200


### PR DESCRIPTION
Closes out the still-open finding from Copilot's review on #964 (merged 2026-07-22).

`proj_collection()` only strips dashes and truncates to 12 chars — it never rejected other characters. A `project` id containing `&`/`=` was interpolated verbatim into `.../api/graph/subgraph?label={coll}&limit=...` at 6 call sites, letting a caller inject extra query params into the internal hellgraph-service request.

Fix: percent-encode the label value at all 6 sites (`urllib.parse.quote(coll, safe='')`). Normal hex/dash ids are unaffected. Added a regression test asserting an injected `&limit=` lands as a single opaque label value, not a second real query param.

87/87 tests pass (`pytest tests/test_server.py`).