### PR TITLE
fix(health-twin): readJson must settle its promise on oversized payload

### DIFF
--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -270,9 +270,19 @@ const publicGrant = (g: Grant) => {
 };
 function readJson(req: http.IncomingMessage): Promise<any> {
   return new Promise((resolve, reject) => {
-    let raw = ''; req.on('data', (c) => { raw += c; if (raw.length > 2_000_000) req.destroy(); });
-    req.on('end', () => { try { resolve(raw ? JSON.parse(raw) : {}); } catch (e) { reject(e); } });
-    req.on('error', reject);
+    let raw = '';
+    let tooLarge = false;
+    req.on('data', (c) => {
+      if (tooLarge) return;
+      raw += c;
+      // destroy() with no error arg doesn't reliably emit 'error' -- the stream can just
+      // go quiet, and this promise would never settle. Reject explicitly instead of
+      // waiting on an event that isn't guaranteed to fire, so an oversized body fails
+      // the request instead of hanging the connection open forever.
+      if (raw.length > 2_000_000) { tooLarge = true; req.destroy(); reject(new Error('payload too large')); }
+    });
+    req.on('end', () => { if (!tooLarge) { try { resolve(raw ? JSON.parse(raw) : {}); } catch (e) { reject(e); } } });
+    req.on('error', (e) => { if (!tooLarge) reject(e); });
   });
 }
 

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -268,6 +268,9 @@ const publicGrant = (g: Grant) => {
   const { holderDigest: _verifier, ...rest } = g;
   return { ...rest, active: !g.revoked && new Date(g.expires_at) > new Date() };
 };
+
+const MAX_BODY_BYTES = 2_000_000;
+
 function readJson(req: http.IncomingMessage): Promise<any> {
   return new Promise((resolve, reject) => {
     let raw = '';
@@ -279,7 +282,7 @@ function readJson(req: http.IncomingMessage): Promise<any> {
       // go quiet, and this promise would never settle. Reject explicitly instead of
       // waiting on an event that isn't guaranteed to fire, so an oversized body fails
       // the request instead of hanging the connection open forever.
-      if (raw.length > 2_000_000) { tooLarge = true; req.destroy(); reject(new Error('payload too large')); }
+      if (raw.length > MAX_BODY_BYTES) { tooLarge = true; req.destroy(); reject(new Error(`payload too large (max ${MAX_BODY_BYTES} bytes)`)); }
     });
     req.on('end', () => { if (!tooLarge) { try { resolve(raw ? JSON.parse(raw) : {}); } catch (e) { reject(e); } } });
     req.on('error', (e) => { if (!tooLarge) reject(e); });


### PR DESCRIPTION
Closes out a finding from Copilot's review on #932 (merged 2026-07-21).

`req.destroy()` with no error argument does not reliably emit `'error'`, so on a >2MB body the `readJson` promise never resolved or rejected — the request handler awaited it forever, a hung connection / resource leak on every oversized POST.

Fix: reject explicitly at the point of `destroy()` instead of waiting on an event that isn't guaranteed to fire. All call sites already wrap `readJson` in try/catch, so this turns a silent hang into the 400 those handlers already know how to send.

No automated test added: `server.ts` calls `server.listen()` at import time with no test-mode guard, so importing it in a `node:test` file would leave an open server handle and hang the test runner — a preexisting testability gap Copilot separately flagged on the same PR (no e2e coverage).