### PR TITLE
fix(workspace-minio): sovereign digest pin + clear the permanent OutOfSync

### DIFF
--- a/infra/k8s/workspace-minio/base/deployment.yaml
+++ b/infra/k8s/workspace-minio/base/deployment.yaml
@@ -14,7 +14,11 @@ spec:
     spec:
       containers:
         - name: minio
-          image: minio/minio:latest
+          # Pinned to an immutable digest (was minio/minio:latest — a moving tag that re-pulls
+          # unpredictably and can never be reproduced). This digest == the release running live at
+          # pin time. Sovereign follow-up: mirror into registry.socioprophet.ai via the
+          # fogstack-registry publication workflow and repoint here (tracked in the PR).
+          image: minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
           args:
             - server
             - /data

--- a/infra/k8s/workspace-minio/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/workspace-minio/overlays/p0-lab/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
   - ../../base
+# PVC size must be >= the provisioned capacity: a PersistentVolumeClaim can grow but never shrink.
+# The live workspace-minio-pvc is 100Gi, so the earlier 20Gi request here left ws-workspace-minio
+# permanently OutOfSync ("storage: can not be less than status.capacity"). Held at 100Gi to match.
 patches:
   - target:
       kind: PersistentVolumeClaim
@@ -9,4 +12,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/resources/requests/storage
-        value: 20Gi
+        value: 100Gi


### PR DESCRIPTION
Live-path hardening for the sovereign workspace plane (mail/cal/drive is running in \`ns/socioprophet\` off zot; MinIO was the one gap).

## Two live issues, both fixed
1. **`minio/minio:latest` → immutable digest.** A moving `:latest` tag re-pulls unpredictably and can never be reproduced (our moving-tag/IfNotPresent trap). Pinned to `@sha256:14cea493…`, which **is** the release running live at pin time — zero behavior change, just reproducibility.
2. **`ws-workspace-minio` was permanently OutOfSync.** The `p0-lab` overlay requested a **20Gi** PVC while the live volume is **100Gi**. A PVC can grow but never shrink, so every sync failed with `storage: can not be less than status.capacity`. Overlay held at **100Gi** to match, with a comment so it can't regress.

## Verified
- `kubectl kustomize overlays/p0-lab` renders `storage: 100Gi` + the digest-pinned image.
- Digest confirmed against the running pod's `imageID`.

## Sovereign follow-up (separate PR)
Mirror MinIO into `registry.socioprophet.ai` via the `fogstack-registry` publication workflow and repoint the image, so the last Docker Hub dependency in the workspace plane is closed. Tracked as part of the progressive-delivery / convergence workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)