### PR TITLE
fix(security): safe in-major pip bumps (PyJWT, pypdf, sentencepiece)

### DIFF
--- a/apps/lattice-studio/requirements.txt
+++ b/apps/lattice-studio/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.115.0
 uvicorn==0.30.6
 httpx==0.27.2
 rdflib==7.0.0
-PyJWT==2.9.0
+PyJWT==2.13.0
 pyshacl>=0.26.0
 pypdf==5.1.0
 python-docx==1.1.2

--- a/apps/noetica-impair/requirements.txt
+++ b/apps/noetica-impair/requirements.txt
@@ -28,4 +28,4 @@ pyyaml==6.0.2
 accelerate==1.10.1
 
 # Loading a SentencePiece-tokenizer model (Gemma, Llama) needs this at load time.
-sentencepiece==0.2.0
+sentencepiece==0.2.1

--- a/apps/nugget-extractor/pyproject.toml
+++ b/apps/nugget-extractor/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "uvicorn==0.30.6",
   "httpx==0.27.2",
   "jsonschema==4.26.0",
-  "pypdf==6.13.1",
+  "pypdf==6.14.2",
 ]
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/apps/nugget-extractor/requirements.txt
+++ b/apps/nugget-extractor/requirements.txt
@@ -15,7 +15,7 @@ fastapi==0.115.0
 uvicorn==0.30.6
 httpx==0.27.2
 jsonschema==4.26.0
-pypdf==6.13.1
+pypdf==6.14.2
 annotated-types==0.8.0
 anyio==4.14.2
 attrs==26.1.0


### PR DESCRIPTION
Second Dependabot tranche (after #1130 cleared the go criticals). Bumps the pip alerts that patch **within the current major line** — no API breakage:

| Package | From → To | App |
|---|---|---|
| PyJWT | 2.9.0 → 2.13.0 | lattice-studio |
| pypdf | 6.13.1 → 6.14.2 | nugget-extractor (req + pyproject) |
| sentencepiece | 0.2.0 → 0.2.1 | noetica-impair |

All three verified present on PyPI.

### Deliberately held (would regress — need dedicated migration)
- **starlette 0.38.6 → 1.3.1** (×5 apps): 0.x→1.x **breaks `fastapi==0.115.0`** (requires starlette <0.42). Needs a FastAPI-coupled migration + tests.
- **protobuf 4.25.9 → 5.29.6** (arcticdb-gateway): the only patched version is 5.x, which **violates arcticdb 4.4.3's declared `protobuf<5` bound**. Needs an arcticdb upgrade first.
- **pypdf 5.1.0 → 6.x** (lattice-studio): 5→6 major.
- **pytest → 9.0.3**: dev-only (`requirements-test.txt`), batched separately.

npm tranche (undici + transitive lockfile deps in socioprophet-web) is a separate PR.