### PR TITLE
feat(infra/dns): DNS-as-code portfolio — Cloud DNS + Namecheap NS delegation

### DIFF
--- a/.github/workflows/tofu-plan.yml
+++ b/.github/workflows/tofu-plan.yml
@@ -56,6 +56,14 @@ jobs:
           tofu init -backend=false
           tofu validate
 
+      - name: validate — dns
+        run: |
+          cd infra/tofu/envs/dns
+          tofu init -backend=false
+          tofu validate
+        env:
+          TF_VAR_project: "validate-placeholder"
+
   gcp-plan-readiness:
     name: Check gcp-plan secret readiness
     runs-on: ubuntu-latest
@@ -145,3 +153,79 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check for provider leakage
         run: python3 tools/validate_no_provider_leakage.py
+
+  dns-plan-readiness:
+    name: Check dns-plan secret readiness
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      ready: ${{ steps.ready.outputs.ready }}
+    steps:
+      - id: ready
+        name: Determine whether dns-plan secrets are configured
+        env:
+          WIF_PROVIDER: ${{ secrets.WIF_PROVIDER }}
+          WIF_SERVICE_ACCOUNT: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+          GCP_DNS_PROJECT: ${{ secrets.GCP_DNS_PROJECT }}
+        run: |
+          if [ -n "$WIF_PROVIDER" ] && [ -n "$WIF_SERVICE_ACCOUNT" ] && [ -n "$GCP_DNS_PROJECT" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "dns-plan secrets are not configured; skipping live DNS plan. Static OpenTofu validation still runs."
+          fi
+
+  plan-dns:
+    name: Plan dns
+    runs-on: ubuntu-latest
+    needs: dns-plan-readiness
+    if: github.event_name == 'pull_request' && needs.dns-plan-readiness.outputs.ready == 'true'
+    permissions:
+      contents: read
+      id-token: write   # for Workload Identity Federation
+    environment: gcp-plan
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: ${{ env.TOFU_VERSION }}
+
+      - name: Authenticate to GCP via WIF
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Init dns
+        run: tofu init
+        working-directory: infra/tofu/envs/dns
+
+      - name: Plan dns
+        run: tofu plan -out=plan.out -no-color 2>&1 | tee plan.txt
+        working-directory: infra/tofu/envs/dns
+        env:
+          TF_VAR_project: ${{ secrets.GCP_DNS_PROJECT }}
+
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tofu-plan-dns-${{ github.sha }}
+          path: |
+            infra/tofu/envs/dns/plan.out
+            infra/tofu/envs/dns/plan.txt
+          retention-days: 30
+
+      - name: Post plan summary to PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('infra/tofu/envs/dns/plan.txt', 'utf8');
+            const truncated = plan.length > 60000 ? plan.slice(0, 60000) + '\n...(truncated)' : plan;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## OpenTofu Plan — dns\n\`\`\`hcl\n${truncated}\n\`\`\``
+            });

--- a/infra/tofu/envs/dns/BOOTSTRAP.md
+++ b/infra/tofu/envs/dns/BOOTSTRAP.md
@@ -54,13 +54,17 @@ tofu output name_servers                              # per-domain NS to delegat
 Namecheap's API requires the **calling IP to be pre-allowlisted**, and CI runner IPs are
 dynamic. Pick one:
 
-- **Cloud NAT with a reserved static IP** (recommended): route the registrar apply through a
-  GCP egress with a fixed IP.
+- **Cloud NAT with a reserved static IP** (recommended, and codified): the `egress-nat`
+  module provisions a reserved external IP + Cloud Router + Cloud NAT. Enable it in this env:
   ```bash
-  gcloud compute addresses create dns-egress-ip --region <region> --project "$PROJECT"
-  # attach to a Cloud NAT / router used by a self-hosted runner or a Cloud Run job
+  TF_VAR_project="$PROJECT" TF_VAR_create_egress_nat=true \
+    TF_VAR_egress_network=<vpc-name-or-self-link> TF_VAR_egress_region=<region> \
+    tofu apply
+  tofu output egress_ips        # -> the IP(s) to allowlist and use as namecheap_client_ip
   ```
-- **Small bastion / self-hosted runner** with a fixed public IP.
+  Whatever performs the registrar call (self-hosted runner / Cloud Run job / GCE) must
+  egress through that VPC to inherit the fixed IP.
+- **Small bastion / self-hosted runner** with a fixed public IP (alternative to the module).
 
 Then, in the Namecheap dashboard: Profile → Tools → **API Access** → enable, and add that IP
 to the **whitelist**. (API access is available with 20+ domains — met.)

--- a/infra/tofu/envs/dns/BOOTSTRAP.md
+++ b/infra/tofu/envs/dns/BOOTSTRAP.md
@@ -1,0 +1,116 @@
+# envs/dns — bootstrap to live
+
+Turns the plan-only `envs/dns` PR into an applied DNS plane. Follow in order. Nothing
+here is auto-run; each step is a deliberate, reviewable action. Doctrine: secrets are
+**minted in CI / stored in a secret manager, never committed, never long-lived PATs**.
+
+## 0. Prerequisites
+
+- The `feat/dns-portfolio-iac` PR is merged (code on `main`).
+- WIF is already wired for CI (`WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT` secrets exist — the
+  `gcp-landing` plan job uses them).
+- Decide which GCP project hosts the zones (a dedicated `…-dns` project is cleanest; a
+  shared prod project is fine to start).
+
+## 1. GCP project + API + state
+
+```bash
+PROJECT=<your-dns-project>            # e.g. socioprophet-dns
+gcloud config set project "$PROJECT"
+gcloud services enable dns.googleapis.com --project "$PROJECT"
+
+# State bucket already exists (prophet-tofu-state-prod); prefix dns/ is set in versions.tf.
+# Grant the CI service account DNS admin on the project:
+gcloud projects add-iam-policy-binding "$PROJECT" \
+  --member="serviceAccount:<WIF_SERVICE_ACCOUNT>" \
+  --role="roles/dns.admin"
+```
+
+Add the CI secret so the WIF-gated `plan-dns` job activates:
+
+```bash
+gh secret set GCP_DNS_PROJECT --body "$PROJECT" --repo SocioProphet/prophet-platform
+```
+
+Optional: override the DMARC reporting mailbox (defaults to `dmarc@socioprophet.ai`) by
+setting `TF_VAR_dmarc_rua` in the `gcp-plan` environment.
+
+## 2. First apply — the security baseline (no registrar changes yet)
+
+`manage_registrar` stays `false`, so this creates **zones + baseline records only**. It
+does **not** touch the registrar, so nothing goes live until you delegate NS in step 4.
+
+```bash
+cd infra/tofu/envs/dns
+tofu init
+TF_VAR_project="$PROJECT" tofu plan -out=plan.out    # review carefully
+# apply follows the gcp-landing apply-gate: manual GH environment approval + signed plan
+TF_VAR_project="$PROJECT" tofu apply plan.out
+tofu output name_servers                              # per-domain NS to delegate
+```
+
+## 3. Namecheap API — creds + the static-IP allowlist (the real gate)
+
+Namecheap's API requires the **calling IP to be pre-allowlisted**, and CI runner IPs are
+dynamic. Pick one:
+
+- **Cloud NAT with a reserved static IP** (recommended): route the registrar apply through a
+  GCP egress with a fixed IP.
+  ```bash
+  gcloud compute addresses create dns-egress-ip --region <region> --project "$PROJECT"
+  # attach to a Cloud NAT / router used by a self-hosted runner or a Cloud Run job
+  ```
+- **Small bastion / self-hosted runner** with a fixed public IP.
+
+Then, in the Namecheap dashboard: Profile → Tools → **API Access** → enable, and add that IP
+to the **whitelist**. (API access is available with 20+ domains — met.)
+
+Mint the creds as CI secrets (never commit):
+
+```bash
+gh secret set NAMECHEAP_API_USER   --body "<api_user>"   --repo SocioProphet/prophet-platform
+gh secret set NAMECHEAP_USER_NAME  --body "<username>"   --repo SocioProphet/prophet-platform
+gh secret set NAMECHEAP_API_KEY    --body "<api_key>"    --repo SocioProphet/prophet-platform
+gh secret set NAMECHEAP_CLIENT_IP  --body "<static_ip>"  --repo SocioProphet/prophet-platform
+```
+
+Wire them into the `plan-dns` / apply job as `TF_VAR_namecheap_*` (sandbox first via
+`TF_VAR_namecheap_sandbox=true`).
+
+## 4. Delegate NS (go live, per domain)
+
+Flip delegation on, ideally a few domains at a time (set `manage_ns: true` on those in
+`domains.yaml`), starting with **parked/reserved** domains — never a live-mail canonical
+until its baseline is confirmed.
+
+```bash
+TF_VAR_project="$PROJECT" TF_VAR_manage_registrar=true \
+  TF_VAR_namecheap_api_user=... TF_VAR_namecheap_user_name=... \
+  TF_VAR_namecheap_api_key=... TF_VAR_namecheap_client_ip=<static_ip> \
+  tofu apply
+```
+
+Verify: `dig NS <domain> +short` should return the Cloud DNS nameservers; then
+`dig TXT <domain>` / `dig TXT _dmarc.<domain>` to confirm the baseline.
+
+## 5. Promote DMARC on mail domains (observe → enforce)
+
+`socioprophet.com` / `.ai` start at `p=none` (observe). After ~1–2 weeks of clean `rua`
+reports (all legit senders aligned), tighten per-domain in `domains.yaml`:
+
+```yaml
+- domain: socioprophet.ai
+  role: canonical
+  mail: true
+  dmarc_policy: quarantine   # then reject
+```
+
+Only touch SPF/MX on a mail domain by setting explicit `spf:` / `mx:` in `domains.yaml`
+(e.g. Google Workspace) — the module never guesses them.
+
+## Rollback
+
+- Baseline records: `tofu destroy -target=module.zone["<domain>"]` (or remove from
+  `domains.yaml`). Registrar NS: set `manage_ns: false` and re-point at the registrar, or
+  restore the previous NS in the Namecheap dashboard. Keep TTLs (3600s) in mind for
+  propagation.

--- a/infra/tofu/envs/dns/BOOTSTRAP.md
+++ b/infra/tofu/envs/dns/BOOTSTRAP.md
@@ -112,6 +112,30 @@ reports (all legit senders aligned), tighten per-domain in `domains.yaml`:
 Only touch SPF/MX on a mail domain by setting explicit `spf:` / `mx:` in `domains.yaml`
 (e.g. Google Workspace) — the module never guesses them.
 
+## Adversarial review — operational risks (read before delegating)
+
+The safe first apply (zones + baseline, `manage_registrar=false`) has no known failure
+mode. The following bite only at **delegation** time and are gated off by default:
+
+1. **Redirect/canonical domains go dark if delegated before they have records.** Delegating
+   NS to Cloud DNS replaces Namecheap DNS entirely — any current Namecheap URL-redirect or
+   email-forwarding stops. Only delegate `reserved`/parked domains first; do not flip
+   `manage_ns: true` on a `redirect`/`canonical` domain until its A/redirect records exist in
+   `domains.yaml`. (The redirect target service — GCLB URL map — is not built yet.)
+2. **DNSSEC needs a DS record at the registrar.** The zone is signed (`dnssec on`), but the
+   chain of trust is inert until you upload the zone's DS record to Namecheap *after*
+   delegation. Until then resolution works but is unvalidated. Do the DS upload as the final
+   go-live step per domain (verify with `dig DS <domain> +short`).
+3. **Cross-domain DMARC reports need authorization.** All domains report to
+   `dmarc@socioprophet.ai`. Per RFC 7489 §7.1, a receiver only sends aggregate reports to an
+   out-of-domain mailbox if the reporting domain publishes an authorization record, e.g.
+   `sourceos.org._report._dmarc.socioprophet.ai TXT "v=DMARC1"`. Without it, `p=reject` still
+   protects the domain — you just won't receive its `rua` reports. Add these authorization
+   records in the `socioprophet.ai` zone (via `records:` in `domains.yaml`) if you want the
+   reports, or set a per-domain `dmarc_rua`.
+4. **null-MX / CAA formats** (`0 .`, `0 issue "…"`) are validated at `tofu plan` against
+   Cloud DNS — review the first plan output before applying.
+
 ## Rollback
 
 - Baseline records: `tofu destroy -target=module.zone["<domain>"]` (or remove from

--- a/infra/tofu/envs/dns/README.md
+++ b/infra/tofu/envs/dns/README.md
@@ -1,0 +1,53 @@
+# envs/dns — domain portfolio DNS-as-code
+
+One Cloud DNS managed zone per owned domain, driven by [`domains.yaml`](./domains.yaml).
+Namecheap stays the **registrar**; DNS is served by **Google Cloud DNS**. This is the
+repeatable, automatable replacement for the manual `infra/terraform/modules/dns` stub.
+
+## What it does
+
+- Creates a `google_dns_managed_zone` (DNSSEC on) per domain in `domains.yaml`.
+- Applies a **safety-aware email-security baseline** to every zone:
+  - **Parked / non-mail** (`mail: false`, the default): hard anti-spoof lockdown —
+    `SPF -all`, **null-MX** (`0 .`, RFC 7505), `DMARC p=reject`, `CAA`.
+  - **Mail** (`mail: true`): never auto-guessed — SPF/MX left unmanaged, `DMARC p=none`
+    (observe) with `rua` reporting, so live deliverability cannot be broken. Move to
+    `quarantine`/`reject` per-domain via `dmarc_policy` once reports look clean.
+- Optionally delegates nameservers at Namecheap (`registrar-namecheap` module), OFF by default.
+
+## Add / change a domain
+
+Edit `domains.yaml` and open a PR. CI runs `tofu fmt` + `validate`; the plan is posted to
+the PR. That is the whole workflow — no console clicks.
+
+## Apply gate (same doctrine as envs/gcp-landing)
+
+Plan-only in CI. Apply requires manual GitHub Actions environment approval + a signed plan.
+Registrar NS delegation (`var.manage_registrar = true`) stays OFF until:
+
+1. A plan is reviewed, and
+2. The **Namecheap API `client_ip` is allowlisted**. Namecheap's API requires the calling
+   IP to be pre-authorized; GitHub runner IPs are dynamic, so run registrar changes from a
+   **static egress IP / bastion** (or a self-hosted runner with a fixed NAT). API access is
+   enabled once the account has 20+ domains (met).
+
+## Variables / secrets (mint in CI, never commit)
+
+| Variable | Source |
+|---|---|
+| `project` | GCP project hosting the zones (`TF_VAR_project` / secret) |
+| `dmarc_rua` | reporting mailbox (default `dmarc@socioprophet.ai`) |
+| `manage_registrar` | keep `false` until the plan is reviewed |
+| `namecheap_api_key` (sensitive), `namecheap_api_user`, `namecheap_user_name`, `namecheap_client_ip` | Namecheap API creds, minted in CI |
+
+## First-run bootstrap
+
+```bash
+cd infra/tofu/envs/dns
+# comment out the gcs backend in versions.tf for the very first local run, or:
+tofu init
+TF_VAR_project=<gcp-project> tofu plan
+```
+
+After apply, read `terraform output name_servers` for the per-domain Cloud DNS nameservers
+to delegate at the registrar (or flip `manage_registrar` once the client_ip is allowlisted).

--- a/infra/tofu/envs/dns/README.md
+++ b/infra/tofu/envs/dns/README.md
@@ -49,5 +49,5 @@ tofu init
 TF_VAR_project=<gcp-project> tofu plan
 ```
 
-After apply, read `terraform output name_servers` for the per-domain Cloud DNS nameservers
+After apply, read `tofu output name_servers` for the per-domain Cloud DNS nameservers
 to delegate at the registrar (or flip `manage_registrar` once the client_ip is allowlisted).

--- a/infra/tofu/envs/dns/domains.yaml
+++ b/infra/tofu/envs/dns/domains.yaml
@@ -1,0 +1,97 @@
+# Domain portfolio — single source of truth for the DNS-as-code plane.
+#
+# Fields per domain:
+#   domain      (required) apex, no trailing dot
+#   role        (required) canonical | redirect | reserved | mail
+#   mail        (optional, default false) SAFETY FLAG. false = hard anti-spoof lockdown
+#               (SPF -all, null-MX, DMARC p=reject). true = never auto-guess live mail;
+#               SPF/MX unmanaged, DMARC observe-mode (p=none) unless overridden.
+#   dnssec      (optional, default true)
+#   dmarc_policy(optional) override: none | quarantine | reject
+#   spf         (optional) override SPF value (only needed for mail domains)
+#   mx          (optional) list of MX rrdatas (only for mail domains)
+#   manage_ns   (optional, default false) delegate NS at Namecheap (needs var.manage_registrar)
+#   records     (optional) extra records: [{name,type,ttl,rrdatas}]; name '@' = apex
+#   notes       (optional) free text
+#
+# NOTE: roles below are a best-guess starting point — confirm/adjust. The security
+# baseline applies regardless of role, so this file is safe to plan as-is.
+domains:
+  # ── canonical product surfaces ────────────────────────────────────────────
+  - domain: socioprophet.com
+    role: canonical
+    mail: true
+    notes: "marketing / product home. mail:true = observe-mode DMARC, SPF/MX left as-is."
+  - domain: socioprophet.ai
+    role: canonical
+    mail: true
+    notes: "search / AI surface. mail:true = observe-mode."
+  - domain: socioprophet.id
+    role: canonical
+    notes: "identity plane (DigitalSoulIdentity / ProofOfSelf). confirm if it sends mail."
+  - domain: sourceos.org
+    role: canonical
+    notes: "SourceOS / SociOS Linux project home."
+  - domain: socioslinux.com
+    role: canonical
+    notes: "SociOS Linux distro. confirm vs redirect to sourceos.org."
+  - domain: truthorbot.net
+    role: canonical
+    notes: "truthorbot product. confirm."
+
+  # ── dev / docs ──────────────────────────────────────────────────────────────
+  - domain: socioprophet.dev
+    role: redirect
+  - domain: socioprophet.io
+    role: redirect
+  - domain: socios.dev
+    role: redirect
+  - domain: socioprophet.sh
+    role: reserved
+    notes: "dev/tools; reserved."
+  - domain: socioprophet.wiki
+    role: redirect
+    notes: "candidate: docs surface."
+
+  # ── infra ─────────────────────────────────────────────────────────────────
+  - domain: socioprophet.cloud
+    role: reserved
+    notes: "hosted infra; reserved."
+
+  # ── redirects / reserved (defensive + brand) ────────────────────────────────
+  - domain: socioprophet.org
+    role: redirect
+  - domain: socioprophet.academy
+    role: redirect
+    notes: "candidate: learning surface."
+  - domain: socioprophet.digital
+    role: redirect
+  - domain: socioprophet.info
+    role: redirect
+  - domain: socioprophet.exchange
+    role: reserved
+  - domain: socioprophet.law
+    role: reserved
+  - domain: socioprophet.live
+    role: reserved
+    notes: "candidate: events/streaming."
+  - domain: socioprophet.review
+    role: reserved
+  - domain: socioprophet.space
+    role: reserved
+  - domain: socioprophet.support
+    role: reserved
+    notes: "candidate: helpdesk surface."
+  - domain: socioslinux.org
+    role: redirect
+  - domain: sourceos.digital
+    role: redirect
+  - domain: sourceos.software
+    role: redirect
+  - domain: sourceos.systems
+    role: redirect
+  - domain: truthorbot.org
+    role: redirect
+  - domain: socioprofit.com
+    role: reserved
+    notes: "SPELLING: socioPROFIT, not prophet. Defensive/typo reg or a separate product? CONFIRM."

--- a/infra/tofu/envs/dns/domains.yaml
+++ b/infra/tofu/envs/dns/domains.yaml
@@ -2,7 +2,7 @@
 #
 # Fields per domain:
 #   domain      (required) apex, no trailing dot
-#   role        (required) canonical | redirect | reserved | mail
+#   role        (required) canonical | redirect | reserved  (taxonomy only; mail behavior = the `mail` flag)
 #   mail        (optional, default false) SAFETY FLAG. false = hard anti-spoof lockdown
 #               (SPF -all, null-MX, DMARC p=reject). true = never auto-guess live mail;
 #               SPF/MX unmanaged, DMARC observe-mode (p=none) unless overridden.

--- a/infra/tofu/envs/dns/main.tf
+++ b/infra/tofu/envs/dns/main.tf
@@ -1,0 +1,47 @@
+# DNS portfolio — one Cloud DNS zone per owned domain, driven by domains.yaml.
+#
+# APPLY GATE (same doctrine as envs/gcp-landing):
+#   plan-only in CI; no apply without manual GH Actions environment approval + signed plan.
+#   Registrar NS delegation stays OFF (var.manage_registrar=false) until a plan is reviewed
+#   and the Namecheap API client_ip is allowlisted (see README).
+
+provider "google" {
+  project = var.project
+}
+
+provider "namecheap" {
+  user_name   = var.namecheap_user_name
+  api_user    = var.namecheap_api_user
+  api_key     = var.namecheap_api_key
+  client_ip   = var.namecheap_client_ip
+  use_sandbox = var.namecheap_sandbox
+}
+
+locals {
+  cfg     = yamldecode(file("${path.module}/domains.yaml"))
+  domains = { for d in local.cfg.domains : d.domain => d }
+}
+
+module "zone" {
+  source   = "../../modules/dns-zone"
+  for_each = local.domains
+
+  domain       = each.value.domain
+  role         = each.value.role
+  mail         = try(each.value.mail, false)
+  dnssec       = try(each.value.dnssec, true)
+  dmarc_rua    = var.dmarc_rua
+  dmarc_policy = try(each.value.dmarc_policy, "")
+  spf          = try(each.value.spf, "")
+  mx_records   = try(each.value.mx, [])
+  app_records  = try(each.value.records, [])
+}
+
+module "registrar" {
+  source   = "../../modules/registrar-namecheap"
+  for_each = { for k, d in local.domains : k => d if try(d.manage_ns, false) }
+
+  domain       = each.value.domain
+  name_servers = module.zone[each.key].name_servers
+  enabled      = var.manage_registrar
+}

--- a/infra/tofu/envs/dns/main.tf
+++ b/infra/tofu/envs/dns/main.tf
@@ -45,3 +45,11 @@ module "registrar" {
   name_servers = module.zone[each.key].name_servers
   enabled      = var.manage_registrar
 }
+
+module "egress_nat" {
+  source  = "../../modules/egress-nat"
+  count   = var.create_egress_nat ? 1 : 0
+  project = var.project
+  region  = var.egress_region
+  network = var.egress_network
+}

--- a/infra/tofu/envs/dns/outputs.tf
+++ b/infra/tofu/envs/dns/outputs.tf
@@ -1,0 +1,9 @@
+output "name_servers" {
+  description = "Per-domain Cloud DNS name servers. Delegate each domain to these at the registrar (or set var.manage_registrar=true to do it via Namecheap)."
+  value       = { for k, m in module.zone : k => m.name_servers }
+}
+
+output "zones" {
+  description = "Managed zone resource names, keyed by domain."
+  value       = { for k, m in module.zone : k => m.zone_name }
+}

--- a/infra/tofu/envs/dns/outputs.tf
+++ b/infra/tofu/envs/dns/outputs.tf
@@ -7,3 +7,8 @@ output "zones" {
   description = "Managed zone resource names, keyed by domain."
   value       = { for k, m in module.zone : k => m.zone_name }
 }
+
+output "egress_ips" {
+  description = "Static egress IP(s) to allowlist in Namecheap and set as namecheap_client_ip. Empty unless create_egress_nat=true."
+  value       = var.create_egress_nat ? module.egress_nat[0].egress_ips : []
+}

--- a/infra/tofu/envs/dns/variables.tf
+++ b/infra/tofu/envs/dns/variables.tf
@@ -15,6 +15,24 @@ variable "manage_registrar" {
   description = "When true, delegate NS at Namecheap for domains with manage_ns:true. Keep false until a plan is reviewed and the API client_ip is allowlisted."
 }
 
+variable "create_egress_nat" {
+  type        = bool
+  default     = false
+  description = "When true, provision a reserved static egress IP + Cloud NAT (module egress-nat) so the registrar API can be called from an allowlistable fixed IP. Requires egress_network."
+}
+
+variable "egress_network" {
+  type        = string
+  default     = ""
+  description = "VPC network (name or self_link) for the egress NAT. Required when create_egress_nat=true."
+}
+
+variable "egress_region" {
+  type        = string
+  default     = "us-central1"
+  description = "Region for the egress NAT."
+}
+
 variable "namecheap_user_name" {
   type        = string
   default     = ""

--- a/infra/tofu/envs/dns/variables.tf
+++ b/infra/tofu/envs/dns/variables.tf
@@ -1,0 +1,47 @@
+variable "project" {
+  type        = string
+  description = "GCP project that hosts the Cloud DNS managed zones."
+}
+
+variable "dmarc_rua" {
+  type        = string
+  default     = "dmarc@socioprophet.ai"
+  description = "Mailbox for DMARC reports and CAA iodef notices across the portfolio."
+}
+
+variable "manage_registrar" {
+  type        = bool
+  default     = false
+  description = "When true, delegate NS at Namecheap for domains with manage_ns:true. Keep false until a plan is reviewed and the API client_ip is allowlisted."
+}
+
+variable "namecheap_user_name" {
+  type        = string
+  default     = ""
+  description = "Namecheap account username."
+}
+
+variable "namecheap_api_user" {
+  type        = string
+  default     = ""
+  description = "Namecheap API user."
+}
+
+variable "namecheap_api_key" {
+  type        = string
+  default     = ""
+  sensitive   = true
+  description = "Namecheap API key. Mint in CI; never commit."
+}
+
+variable "namecheap_client_ip" {
+  type        = string
+  default     = ""
+  description = "The public IP calling the Namecheap API. MUST be allowlisted in the Namecheap API settings (use a static egress IP / bastion — CI runner IPs are dynamic)."
+}
+
+variable "namecheap_sandbox" {
+  type        = bool
+  default     = false
+  description = "Use the Namecheap sandbox API."
+}

--- a/infra/tofu/envs/dns/versions.tf
+++ b/infra/tofu/envs/dns/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    namecheap = {
+      source  = "namecheap/namecheap"
+      version = "~> 2.1"
+    }
+  }
+
+  # First run: comment this out for a local backend, then migrate to GCS.
+  backend "gcs" {
+    bucket = "prophet-tofu-state-prod"
+    prefix = "dns/terraform.tfstate"
+  }
+}

--- a/infra/tofu/envs/dns/versions.tf
+++ b/infra/tofu/envs/dns/versions.tf
@@ -13,8 +13,9 @@ terraform {
   }
 
   # First run: comment this out for a local backend, then migrate to GCS.
+  # prefix is a directory-like prefix (GCS appends the state object under it).
   backend "gcs" {
     bucket = "prophet-tofu-state-prod"
-    prefix = "dns/terraform.tfstate"
+    prefix = "dns"
   }
 }

--- a/infra/tofu/modules/dns-zone/main.tf
+++ b/infra/tofu/modules/dns-zone/main.tf
@@ -1,0 +1,85 @@
+# One Cloud DNS managed zone per domain, with a safety-aware email-security baseline.
+# Parked/non-mail domains are locked down hard (they are spoofable otherwise); mail
+# domains are never auto-guessed (see variable "mail").
+
+locals {
+  zone_id  = replace(var.domain, ".", "-")
+  dns_name = "${var.domain}."
+
+  # SPF: hard reject for parked; unmanaged for mail unless explicitly provided.
+  spf_value  = var.spf != "" ? var.spf : (var.mail ? "" : "v=spf1 -all")
+  manage_spf = local.spf_value != ""
+
+  # MX: null-MX (RFC 7505) for parked; unmanaged for mail unless explicitly provided.
+  mx_rrdatas = length(var.mx_records) > 0 ? var.mx_records : (var.mail ? [] : ["0 ."])
+  manage_mx  = length(local.mx_rrdatas) > 0
+
+  # DMARC: reject for parked; observe (none) for mail unless overridden.
+  dmarc_policy = var.dmarc_policy != "" ? var.dmarc_policy : (var.mail ? "none" : "reject")
+  dmarc_value  = "v=DMARC1; p=${local.dmarc_policy}; rua=mailto:${var.dmarc_rua}; ruf=mailto:${var.dmarc_rua}; fo=1; adkim=s; aspf=s"
+
+  caa_rrdatas = concat(
+    [for ca in var.caa_issuers : "0 issue \"${ca}\""],
+    ["0 iodef \"mailto:${var.dmarc_rua}\""],
+  )
+}
+
+resource "google_dns_managed_zone" "this" {
+  name        = local.zone_id
+  dns_name    = local.dns_name
+  description = "Managed by tofu envs/dns — role=${var.role}"
+  labels = merge({
+    role       = var.role
+    managed_by = "tofu-dns-portfolio"
+  }, var.labels)
+
+  dynamic "dnssec_config" {
+    for_each = var.dnssec ? [1] : []
+    content {
+      state = "on"
+    }
+  }
+}
+
+resource "google_dns_record_set" "spf" {
+  count        = local.manage_spf ? 1 : 0
+  name         = local.dns_name
+  type         = "TXT"
+  ttl          = 3600
+  managed_zone = google_dns_managed_zone.this.name
+  rrdatas      = ["\"${local.spf_value}\""]
+}
+
+resource "google_dns_record_set" "mx" {
+  count        = local.manage_mx ? 1 : 0
+  name         = local.dns_name
+  type         = "MX"
+  ttl          = 3600
+  managed_zone = google_dns_managed_zone.this.name
+  rrdatas      = local.mx_rrdatas
+}
+
+resource "google_dns_record_set" "dmarc" {
+  name         = "_dmarc.${local.dns_name}"
+  type         = "TXT"
+  ttl          = 3600
+  managed_zone = google_dns_managed_zone.this.name
+  rrdatas      = ["\"${local.dmarc_value}\""]
+}
+
+resource "google_dns_record_set" "caa" {
+  name         = local.dns_name
+  type         = "CAA"
+  ttl          = 3600
+  managed_zone = google_dns_managed_zone.this.name
+  rrdatas      = local.caa_rrdatas
+}
+
+resource "google_dns_record_set" "app" {
+  for_each     = { for r in var.app_records : "${r.type}:${r.name}" => r }
+  name         = each.value.name == "@" ? local.dns_name : "${each.value.name}.${local.dns_name}"
+  type         = each.value.type
+  ttl          = each.value.ttl
+  managed_zone = google_dns_managed_zone.this.name
+  rrdatas      = each.value.rrdatas
+}

--- a/infra/tofu/modules/dns-zone/main.tf
+++ b/infra/tofu/modules/dns-zone/main.tf
@@ -10,6 +10,15 @@ locals {
   spf_value  = var.spf != "" ? var.spf : (var.mail ? "" : "v=spf1 -all")
   manage_spf = local.spf_value != ""
 
+  # Cloud DNS keeps ALL TXT strings for a name in ONE record set. Fold SPF together with
+  # any apex TXT supplied via app_records (e.g. a domain-verification token) so they don't
+  # collide as two record sets at the apex.
+  apex_txt_extra   = flatten([for r in var.app_records : r.rrdatas if r.name == "@" && upper(r.type) == "TXT"])
+  spf_rrdata       = local.manage_spf ? ["\"${local.spf_value}\""] : []
+  apex_txt_all     = concat(local.spf_rrdata, local.apex_txt_extra)
+  manage_apex_txt  = length(local.apex_txt_all) > 0
+  app_records_rest = [for r in var.app_records : r if !(r.name == "@" && upper(r.type) == "TXT")]
+
   # MX: null-MX (RFC 7505) for parked; unmanaged for mail unless explicitly provided.
   mx_rrdatas = length(var.mx_records) > 0 ? var.mx_records : (var.mail ? [] : ["0 ."])
   manage_mx  = length(local.mx_rrdatas) > 0
@@ -41,13 +50,13 @@ resource "google_dns_managed_zone" "this" {
   }
 }
 
-resource "google_dns_record_set" "spf" {
-  count        = local.manage_spf ? 1 : 0
+resource "google_dns_record_set" "apex_txt" {
+  count        = local.manage_apex_txt ? 1 : 0
   name         = local.dns_name
   type         = "TXT"
   ttl          = 3600
   managed_zone = google_dns_managed_zone.this.name
-  rrdatas      = ["\"${local.spf_value}\""]
+  rrdatas      = local.apex_txt_all
 }
 
 resource "google_dns_record_set" "mx" {
@@ -76,7 +85,7 @@ resource "google_dns_record_set" "caa" {
 }
 
 resource "google_dns_record_set" "app" {
-  for_each     = { for r in var.app_records : "${r.type}:${r.name}" => r }
+  for_each     = { for r in local.app_records_rest : "${r.type}:${r.name}" => r }
   name         = each.value.name == "@" ? local.dns_name : "${each.value.name}.${local.dns_name}"
   type         = each.value.type
   ttl          = each.value.ttl

--- a/infra/tofu/modules/dns-zone/outputs.tf
+++ b/infra/tofu/modules/dns-zone/outputs.tf
@@ -1,0 +1,14 @@
+output "name_servers" {
+  description = "Cloud DNS name servers to delegate this domain to at the registrar."
+  value       = google_dns_managed_zone.this.name_servers
+}
+
+output "zone_name" {
+  description = "The managed zone resource name."
+  value       = google_dns_managed_zone.this.name
+}
+
+output "dns_name" {
+  description = "The zone dns_name (with trailing dot)."
+  value       = google_dns_managed_zone.this.dns_name
+}

--- a/infra/tofu/modules/dns-zone/variables.tf
+++ b/infra/tofu/modules/dns-zone/variables.tf
@@ -5,10 +5,10 @@ variable "domain" {
 
 variable "role" {
   type        = string
-  description = "Portfolio role: canonical | redirect | reserved | mail."
+  description = "Portfolio taxonomy only: canonical | redirect | reserved. Mail behavior is controlled solely by var.mail (kept separate so a role can never contradict the mail safety switch)."
   validation {
-    condition     = contains(["canonical", "redirect", "reserved", "mail"], var.role)
-    error_message = "role must be one of: canonical, redirect, reserved, mail."
+    condition     = contains(["canonical", "redirect", "reserved"], var.role)
+    error_message = "role must be one of: canonical, redirect, reserved."
   }
 }
 

--- a/infra/tofu/modules/dns-zone/variables.tf
+++ b/infra/tofu/modules/dns-zone/variables.tf
@@ -1,0 +1,76 @@
+variable "domain" {
+  type        = string
+  description = "Apex domain for this zone, e.g. socioprophet.ai (no trailing dot)."
+}
+
+variable "role" {
+  type        = string
+  description = "Portfolio role: canonical | redirect | reserved | mail."
+  validation {
+    condition     = contains(["canonical", "redirect", "reserved", "mail"], var.role)
+    error_message = "role must be one of: canonical, redirect, reserved, mail."
+  }
+}
+
+variable "mail" {
+  type        = bool
+  default     = false
+  description = <<-DESC
+    Whether this domain sends email. SAFETY: when false (parked/non-mail), the module
+    applies a hard anti-spoof lockdown (SPF -all, null-MX, DMARC p=reject). When true, it
+    NEVER guesses live mail records: SPF/MX are left unmanaged unless explicitly provided,
+    and DMARC defaults to observe mode (p=none) so deliverability cannot be broken.
+  DESC
+}
+
+variable "dnssec" {
+  type        = bool
+  default     = true
+  description = "Enable DNSSEC on the managed zone."
+}
+
+variable "dmarc_rua" {
+  type        = string
+  description = "Mailbox that receives DMARC aggregate/forensic reports and CAA iodef notices."
+}
+
+variable "dmarc_policy" {
+  type        = string
+  default     = ""
+  description = "Override DMARC policy (none|quarantine|reject). Empty = derive from role: reject when mail=false, none when mail=true."
+}
+
+variable "spf" {
+  type        = string
+  default     = ""
+  description = "Override SPF value. Empty = derive: 'v=spf1 -all' when mail=false; unmanaged when mail=true."
+}
+
+variable "mx_records" {
+  type        = list(string)
+  default     = []
+  description = "MX rrdatas (e.g. ['1 aspmx.l.google.com.']). Empty = null-MX when mail=false; unmanaged when mail=true."
+}
+
+variable "caa_issuers" {
+  type        = list(string)
+  default     = ["pki.goog", "letsencrypt.org"]
+  description = "CAA authorized issuers."
+}
+
+variable "app_records" {
+  type = list(object({
+    name    = string
+    type    = string
+    ttl     = optional(number, 300)
+    rrdatas = list(string)
+  }))
+  default     = []
+  description = "Additional records. name '@' = apex; otherwise a subdomain label (module appends the zone dns_name)."
+}
+
+variable "labels" {
+  type        = map(string)
+  default     = {}
+  description = "Extra labels merged onto the managed zone."
+}

--- a/infra/tofu/modules/dns-zone/versions.tf
+++ b/infra/tofu/modules/dns-zone/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/infra/tofu/modules/egress-nat/main.tf
+++ b/infra/tofu/modules/egress-nat/main.tf
@@ -1,0 +1,36 @@
+# Fixed egress IP for outbound API calls that require an allowlisted source (e.g. the
+# Namecheap API). Reserved external address(es) + Cloud Router + Cloud NAT with MANUAL_ONLY
+# allocation so the egress IP is stable and can be pre-authorized at the registrar.
+
+resource "google_compute_address" "egress" {
+  count        = var.num_static_ips
+  name         = "${var.name_prefix}-ip-${count.index}"
+  project      = var.project
+  region       = var.region
+  address_type = "EXTERNAL"
+}
+
+resource "google_compute_router" "egress" {
+  name    = "${var.name_prefix}-router"
+  project = var.project
+  region  = var.region
+  network = var.network
+}
+
+resource "google_compute_router_nat" "egress" {
+  name                               = "${var.name_prefix}-nat"
+  project                            = var.project
+  region                             = var.region
+  router                             = google_compute_router.egress.name
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            = google_compute_address.egress[*].self_link
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  dynamic "log_config" {
+    for_each = var.log_nat ? [1] : []
+    content {
+      enable = true
+      filter = "ERRORS_ONLY"
+    }
+  }
+}

--- a/infra/tofu/modules/egress-nat/outputs.tf
+++ b/infra/tofu/modules/egress-nat/outputs.tf
@@ -1,0 +1,14 @@
+output "egress_ips" {
+  description = "Reserved static egress IP(s). Allowlist in the Namecheap API settings and set as namecheap_client_ip."
+  value       = google_compute_address.egress[*].address
+}
+
+output "router_name" {
+  description = "Cloud Router name."
+  value       = google_compute_router.egress.name
+}
+
+output "nat_name" {
+  description = "Cloud NAT name."
+  value       = google_compute_router_nat.egress.name
+}

--- a/infra/tofu/modules/egress-nat/variables.tf
+++ b/infra/tofu/modules/egress-nat/variables.tf
@@ -1,0 +1,32 @@
+variable "project" {
+  type        = string
+  description = "GCP project for the egress NAT."
+}
+
+variable "region" {
+  type        = string
+  description = "Region for the router, NAT, and reserved address."
+}
+
+variable "network" {
+  type        = string
+  description = "VPC network (name or self_link) the router attaches to. Whatever runs the registrar call (self-hosted runner / Cloud Run job / GCE) must egress through this network to get the fixed IP."
+}
+
+variable "name_prefix" {
+  type        = string
+  default     = "dns-egress"
+  description = "Name prefix for the address, router, and NAT."
+}
+
+variable "num_static_ips" {
+  type        = number
+  default     = 1
+  description = "Number of reserved external IPs to allocate for NAT egress."
+}
+
+variable "log_nat" {
+  type        = bool
+  default     = true
+  description = "Enable Cloud NAT error logging."
+}

--- a/infra/tofu/modules/egress-nat/versions.tf
+++ b/infra/tofu/modules/egress-nat/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/infra/tofu/modules/registrar-namecheap/main.tf
+++ b/infra/tofu/modules/registrar-namecheap/main.tf
@@ -1,0 +1,10 @@
+# Delegates a Namecheap domain's nameservers to Cloud DNS. Registrar-only: this module
+# never manages host records (those live in Cloud DNS). Custom nameservers and host
+# records are mutually exclusive at Namecheap, so setting NS here hands DNS to Cloud DNS.
+
+resource "namecheap_domain_records" "delegation" {
+  count       = var.enabled ? 1 : 0
+  domain      = var.domain
+  mode        = "OVERWRITE"
+  nameservers = var.name_servers
+}

--- a/infra/tofu/modules/registrar-namecheap/outputs.tf
+++ b/infra/tofu/modules/registrar-namecheap/outputs.tf
@@ -1,0 +1,9 @@
+output "delegated" {
+  description = "Whether NS delegation was applied for this domain."
+  value       = var.enabled
+}
+
+output "name_servers" {
+  description = "The nameservers requested for this domain."
+  value       = var.name_servers
+}

--- a/infra/tofu/modules/registrar-namecheap/variables.tf
+++ b/infra/tofu/modules/registrar-namecheap/variables.tf
@@ -1,0 +1,15 @@
+variable "domain" {
+  type        = string
+  description = "The domain whose nameservers are delegated, e.g. socioprophet.ai."
+}
+
+variable "name_servers" {
+  type        = list(string)
+  description = "Nameservers to set at the registrar (from the Cloud DNS zone output)."
+}
+
+variable "enabled" {
+  type        = bool
+  default     = false
+  description = "Guard: only touch the registrar when true. Setting NS is a hard-to-reverse, prod-affecting change; keep false until a plan is reviewed and the Namecheap API client_ip is allowlisted."
+}

--- a/infra/tofu/modules/registrar-namecheap/variables.tf
+++ b/infra/tofu/modules/registrar-namecheap/variables.tf
@@ -1,6 +1,6 @@
 variable "domain" {
   type        = string
-  description = "The domain whose nameservers are delegated, e.g. socioprophet.ai."
+  description = "The registrable domain whose nameservers are delegated (no trailing dot), for example socioprophet.ai"
 }
 
 variable "name_servers" {

--- a/infra/tofu/modules/registrar-namecheap/versions.tf
+++ b/infra/tofu/modules/registrar-namecheap/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    namecheap = {
+      source  = "namecheap/namecheap"
+      version = "~> 2.1"
+    }
+  }
+}


### PR DESCRIPTION
## DNS-as-code portfolio — Cloud DNS + Namecheap NS delegation

Replaces the manual `infra/terraform/modules/dns` stub (which only wrote a `dns-records.txt` for hand-import) with a repeatable, automatable plane for all owned domains. Namecheap stays **registrar**; DNS is served by **Google Cloud DNS**, bound to the existing `infra/tofu` + WIF/GCS setup.

### What's here
- **`modules/dns-zone`** — one `google_dns_managed_zone` (DNSSEC on) per domain + a **safety-aware email-security baseline**:
  - **Parked / non-mail** (default): hard anti-spoof lockdown — `SPF -all`, **null-MX** (`0 .`, RFC 7505), `DMARC p=reject`, `CAA`. (Every parked domain is spoofable today; this closes it.)
  - **Mail** (`mail: true`, currently `socioprophet.com` + `.ai`): never auto-guessed — SPF/MX left unmanaged, `DMARC p=none` observe-mode with `rua` reporting, so live deliverability can't break. Tighten per-domain via `dmarc_policy` once reports are clean.
- **`modules/registrar-namecheap`** — delegates NS at Namecheap (registrar-only), **OFF by default** (`manage_registrar=false`) until a plan is reviewed and the API `client_ip` is allowlisted.
- **`envs/dns`** — `for_each` over [`domains.yaml`](infra/tofu/envs/dns/domains.yaml) (28 domains, `role` + `mail`), GCS backend prefix `dns/`, outputs per-domain nameservers to delegate.
- **CI** — `tofu-plan.yml` gains a static `validate — dns` step + a WIF-gated `plan-dns` job mirroring `gcp-landing` (skips cleanly when secrets absent).

### Workflow (repeatable)
Add/change a domain = edit `domains.yaml` → PR → CI posts the plan. No console clicks.

### Verification
- `tofu fmt -check` ✅ · `tofu init -backend=false` + `tofu validate` ✅ (google + namecheap providers resolve) · workflow + `domains.yaml` parse ✅.
- **Plan-only. No apply.** Apply follows the `gcp-landing` gate (manual environment approval + signed plan).

### Decisions still open (don't block the security baseline)
- `domains.yaml` roles are a best-guess — confirm canonical/redirect/reserved mapping.
- **`socioprofit.com`** — note the spelling (*profit*, not *prophet*): defensive reg or a separate product?
- Secrets to mint for live plan/apply: `GCP_DNS_PROJECT`, Namecheap API creds, and a **static egress IP** for the allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
