### PR TITLE
fix(workspace): Recreate strategy on RWO deployments (stop rollout deadlock)

### DIFF
--- a/infra/k8s/workspace-caldav/base/deployment.yaml
+++ b/infra/k8s/workspace-caldav/base/deployment.yaml
@@ -4,6 +4,11 @@ metadata:
   name: workspace-caldav
 spec:
   replicas: 1
+  # RWO PVC + single replica: Recreate terminates the old pod before starting the new one,
+  # so the volume is released first. RollingUpdate deadlocks (new pod can't Multi-Attach the
+  # ReadWriteOnce volume held by the old pod on another node) — which wedged this exact deploy.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: workspace-caldav

--- a/infra/k8s/workspace-mail/base/deployment.yaml
+++ b/infra/k8s/workspace-mail/base/deployment.yaml
@@ -4,6 +4,11 @@ metadata:
   name: workspace-mail
 spec:
   replicas: 1
+  # RWO PVC + single replica: Recreate terminates the old pod before starting the new one,
+  # so the volume is released first. RollingUpdate deadlocks (new pod can't Multi-Attach the
+  # ReadWriteOnce volume held by the old pod on another node) — which wedged this exact deploy.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: workspace-mail

--- a/infra/k8s/workspace-minio/base/deployment.yaml
+++ b/infra/k8s/workspace-minio/base/deployment.yaml
@@ -4,6 +4,11 @@ metadata:
   name: workspace-minio
 spec:
   replicas: 1
+  # RWO PVC + single replica: Recreate terminates the old pod before starting the new one,
+  # so the volume is released first. RollingUpdate deadlocks (new pod can't Multi-Attach the
+  # ReadWriteOnce volume held by the old pod on another node) — which wedged this exact deploy.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: workspace-minio


### PR DESCRIPTION
**Live fix** — `ws-workspace-minio` is Degraded right now from this exact bug (a rollout wedged mid-flight; the old pod still serves, so no outage).

## Root cause
`workspace-minio`, `workspace-mail`, and `workspace-caldav` are single-replica with **ReadWriteOnce** PVCs but use the default **RollingUpdate** strategy. Any pod-spec change starts a new pod that lands on a different node and **can't Multi-Attach** the RWO volume the old pod holds → stuck `ContainerCreating` indefinitely.

## Fix
`strategy: { type: Recreate }` on all three (the pattern gitea already uses for its RWO volume). Recreate terminates the old pod first, releasing the volume, so the replacement attaches cleanly.

## Impact
- Unwedges the stuck `workspace-minio` rollout (digest-pin from #1135 finally lands).
- Prevents `workspace-mail` from deadlocking on the imminent `ssl=required` / TLS-mount change.
- Directly serves the "recover gracefully" goal — stateful rollouts complete instead of hanging.
- Trade-off: a few seconds of single-pod downtime during a rollout, which is inherent to single-replica RWO anyway (RollingUpdate couldn't avoid it — it just hung instead). True zero-downtime needs multi-replica + RWX/clustering (separate, future).

## Verified
`kubectl kustomize` renders `strategy: Recreate` on all three overlays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)