### PR TITLE
fix(mail-lb): externalTrafficPolicy Local->Cluster (Autopilot L4 wouldn't forward)

### DIFF
--- a/infra/k8s/workspace-mail/base/service-lb.yaml
+++ b/infra/k8s/workspace-mail/base/service-lb.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   type: LoadBalancer
   loadBalancerIP: "130.211.115.191" # ws-smtp — mail.socioprophet.ai (MX target); set PTR on this IP
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster  # INTERIM: Local didn't forward on Autopilot L4 (healthy node, still no datapath). Cluster gets it reachable; revisit source-IP preservation (PROXY-proto / fixed Local) before MX cutover.
   selector:
     app: workspace-smtp
   ports:
@@ -38,7 +38,7 @@ metadata:
 spec:
   type: LoadBalancer
   loadBalancerIP: "136.116.203.17" # ws-imap — imap.socioprophet.ai
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster  # INTERIM: Local didn't forward on Autopilot L4 (healthy node, still no datapath). Cluster gets it reachable; revisit source-IP preservation (PROXY-proto / fixed Local) before MX cutover.
   selector:
     app: workspace-mail
   ports:


### PR DESCRIPTION
Local left SMTP/IMAPS unreachable 30+ min despite firewall + forwarding rule + a healthy target-pool node, with Postfix verified listening in-pod. Known GKE Autopilot L4/Local quirk. Cluster restores the datapath. Trade-off: SNAT hides client source IP — re-solve (PROXY-proto or fixed Local) before MX cutover; harmless now (MX still on Google).

🤖 Generated with [Claude Code](https://claude.com/claude-code)