### PR TITLE
fix(iac/gke): drop ForceNew description on mail IPs (would destroy 130.211.115.191)

### DIFF
--- a/infra/tofu/environments/gcp-gke/workspace-mail.tf
+++ b/infra/tofu/environments/gcp-gke/workspace-mail.tf
@@ -7,17 +7,19 @@
 #   tofu import google_compute_address.ws_smtp projects/socioprophet-platform/regions/us-central1/addresses/ws-smtp
 #   tofu import google_compute_address.ws_imap projects/socioprophet-platform/regions/us-central1/addresses/ws-imap
 
+# ws-smtp = mail.socioprophet.ai (SMTP 25/587 + MX target; PTR set on the mail VM). NOTE: no
+# `description` — it is a ForceNew field and these IPs already exist (imported), so setting one
+# would destroy+recreate the address and lose 130.211.115.191.
 resource "google_compute_address" "ws_smtp" {
   name         = "ws-smtp"
-  description  = "mail.socioprophet.ai — SMTP LoadBalancer (25/587) + MX target. Set PTR on this IP."
   region       = var.region
   address_type = "EXTERNAL"
   labels       = local.labels
 }
 
+# ws-imap = spare since mail+imap now share the VM IP (kept reserved; free to release later).
 resource "google_compute_address" "ws_imap" {
   name         = "ws-imap"
-  description  = "imap.socioprophet.ai — IMAPS LoadBalancer (993)."
   region       = var.region
   address_type = "EXTERNAL"
   labels       = local.labels


### PR DESCRIPTION
`google_compute_address.description` is ForceNew; the imported IPs would be destroyed+recreated if a description is set — losing the mail IP. Kept as comments. Plan verified 0-destroy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)