### PR TITLE
fix(mail): root-own opendkim key dir (bootstrap aborted, Postfix/Dovecot never configured)

### DIFF
--- a/infra/tofu/environments/gcp-gke/mail-vm-startup.sh.tftpl
+++ b/infra/tofu/environments/gcp-gke/mail-vm-startup.sh.tftpl
@@ -24,12 +24,12 @@ apt-get install -y postfix postfix-pgsql dovecot-imapd dovecot-lmtpd \
 mkdir -p /etc/opendkim/keys/$DOMAIN
 gcloud secrets versions access latest --secret="${dkim_secret_name}" > /etc/opendkim/keys/$DOMAIN/$SELECTOR.private
 ADMIN_HASH="$(gcloud secrets versions access latest --secret="${admin_pass_secret_name}")"
-# opendkim's pre-start check (as root) rejects (a) key dirs owned by a non-root
-# uid, and (b) a private key readable by a group with >1 member. So: dirs
-# root:opendkim 750, and the key owned by opendkim mode 600 (owner-only — the
-# daemon runs as opendkim and reads it as owner).
-chown -R root:opendkim /etc/opendkim/keys
-chown opendkim:opendkim /etc/opendkim/keys/$DOMAIN/$SELECTOR.private
+# opendkim runs its pre-start safety check AS ROOT and requires the private key
+# and its ancestor dirs to be (a) owned by root — the executing uid — and (b)
+# not group/world-readable. opendkim loads the key while still root, before
+# dropping to the opendkim user, so root:600 is both correct and most secure.
+# (Owning the key by opendkim, or making it group-readable, both fail the check.)
+chown -R root:opendkim /etc/opendkim
 chmod 750 /etc/opendkim/keys /etc/opendkim/keys/$DOMAIN && chmod 600 /etc/opendkim/keys/$DOMAIN/$SELECTOR.private
 
 # --- TLS via Let's Encrypt (HTTP-01; the A record mail.$DOMAIN must already point here) ---

--- a/infra/tofu/environments/gcp-gke/mail-vm-startup.sh.tftpl
+++ b/infra/tofu/environments/gcp-gke/mail-vm-startup.sh.tftpl
@@ -24,7 +24,10 @@ apt-get install -y postfix postfix-pgsql dovecot-imapd dovecot-lmtpd \
 mkdir -p /etc/opendkim/keys/$DOMAIN
 gcloud secrets versions access latest --secret="${dkim_secret_name}" > /etc/opendkim/keys/$DOMAIN/$SELECTOR.private
 ADMIN_HASH="$(gcloud secrets versions access latest --secret="${admin_pass_secret_name}")"
-chown -R opendkim:opendkim /etc/opendkim/keys && chmod 600 /etc/opendkim/keys/$DOMAIN/$SELECTOR.private
+# dirs owned by root (opendkim's pre-start check runs as root and rejects key
+# dirs owned by a non-root uid); key readable by the opendkim group only.
+chown -R root:opendkim /etc/opendkim/keys
+chmod 750 /etc/opendkim/keys /etc/opendkim/keys/$DOMAIN && chmod 640 /etc/opendkim/keys/$DOMAIN/$SELECTOR.private
 
 # --- TLS via Let's Encrypt (HTTP-01; the A record mail.$DOMAIN must already point here) ---
 if [ ! -d "/etc/letsencrypt/live/$HOST" ]; then

--- a/infra/tofu/environments/gcp-gke/mail-vm-startup.sh.tftpl
+++ b/infra/tofu/environments/gcp-gke/mail-vm-startup.sh.tftpl
@@ -24,10 +24,13 @@ apt-get install -y postfix postfix-pgsql dovecot-imapd dovecot-lmtpd \
 mkdir -p /etc/opendkim/keys/$DOMAIN
 gcloud secrets versions access latest --secret="${dkim_secret_name}" > /etc/opendkim/keys/$DOMAIN/$SELECTOR.private
 ADMIN_HASH="$(gcloud secrets versions access latest --secret="${admin_pass_secret_name}")"
-# dirs owned by root (opendkim's pre-start check runs as root and rejects key
-# dirs owned by a non-root uid); key readable by the opendkim group only.
+# opendkim's pre-start check (as root) rejects (a) key dirs owned by a non-root
+# uid, and (b) a private key readable by a group with >1 member. So: dirs
+# root:opendkim 750, and the key owned by opendkim mode 600 (owner-only — the
+# daemon runs as opendkim and reads it as owner).
 chown -R root:opendkim /etc/opendkim/keys
-chmod 750 /etc/opendkim/keys /etc/opendkim/keys/$DOMAIN && chmod 640 /etc/opendkim/keys/$DOMAIN/$SELECTOR.private
+chown opendkim:opendkim /etc/opendkim/keys/$DOMAIN/$SELECTOR.private
+chmod 750 /etc/opendkim/keys /etc/opendkim/keys/$DOMAIN && chmod 600 /etc/opendkim/keys/$DOMAIN/$SELECTOR.private
 
 # --- TLS via Let's Encrypt (HTTP-01; the A record mail.$DOMAIN must already point here) ---
 if [ ! -d "/etc/letsencrypt/live/$HOST" ]; then

--- a/infra/tofu/environments/gcp-gke/workspace-mail.tf
+++ b/infra/tofu/environments/gcp-gke/workspace-mail.tf
@@ -7,17 +7,19 @@
 #   tofu import google_compute_address.ws_smtp projects/socioprophet-platform/regions/us-central1/addresses/ws-smtp
 #   tofu import google_compute_address.ws_imap projects/socioprophet-platform/regions/us-central1/addresses/ws-imap
 
+# ws-smtp = mail.socioprophet.ai (SMTP 25/587 + MX target; PTR set on the mail VM). NOTE: no
+# `description` — it is a ForceNew field and these IPs already exist (imported), so setting one
+# would destroy+recreate the address and lose 130.211.115.191.
 resource "google_compute_address" "ws_smtp" {
   name         = "ws-smtp"
-  description  = "mail.socioprophet.ai — SMTP LoadBalancer (25/587) + MX target. Set PTR on this IP."
   region       = var.region
   address_type = "EXTERNAL"
   labels       = local.labels
 }
 
+# ws-imap = spare since mail+imap now share the VM IP (kept reserved; free to release later).
 resource "google_compute_address" "ws_imap" {
   name         = "ws-imap"
-  description  = "imap.socioprophet.ai — IMAPS LoadBalancer (993)."
   region       = var.region
   address_type = "EXTERNAL"
   labels       = local.labels


### PR DESCRIPTION
The mail VM's startup script chowned /etc/opendkim/keys to opendkim:opendkim. opendkim's root pre-start check rejects a non-root-owned key dir (exit 78/CONFIG); with `set -euo pipefail` that aborted the bootstrap, leaving Dovecot and Postfix unconfigured. Verified from the live `prophet-mail` serial log. Fix: key dirs root:opendkim 750, key 640.