### PR TITLE
feat(matrix): deploy hardened WordOps Synapse estates (public edge + private core)

### DIFF
--- a/infra/k8s/wordops-matrix/README.md
+++ b/infra/k8s/wordops-matrix/README.md
@@ -1,0 +1,76 @@
+# WordOps / Sherlock Matrix substrate — Layer 1 (homeservers)
+
+Production kustomize deployment for the two Synapse estates described in
+`docs/WORDOPS_MATRIX_HOMESERVER_DEPLOYMENT_PROFILE.md`. Ported from the local
+profile in `infra/wordops/matrix/`.
+
+This is **Layer 1** of the substrate program (homeservers). Layers 2–4
+(room-factory/governance-as-code, Sherlock bot, admin runbooks) build on top.
+
+## What this deploys
+
+| Estate | Server name | Exposure | Posture |
+|---|---|---|---|
+| **public edge** | `matrix.socioprophet.ai` | public Ingress (GCE + ManagedCert), federation over 443 | intake/self-service; no public room directory; no regulated content |
+| **private core** | `matrix-core.socioprophet.internal` | cluster-internal only (no Ingress) | case/incident/agent rooms; federation disabled (empty whitelist); E2EE posture enforced in Layer 2 |
+
+Each estate = `Synapse v1.131.0` (pinned) + `Postgres 16` (StatefulSet, 10Gi PVC)
++ a media PVC (20Gi) + a persisted signing key. An `nginx` edge fronts the
+public estate and serves `.well-known/matrix/{client,server,support}`.
+
+```
+base/
+  synapse-public.yaml    # ConfigMap + ExternalSecret + Postgres STS/Svc + Synapse Deploy/Svc/PVC + NetworkPolicy
+  synapse-private.yaml   # symmetric, locked down
+  matrix-edge.yaml       # nginx edge + Service + BackendConfig + ManagedCertificate + Ingress
+  kustomization.yaml
+overlays/p0-lab/         # namespace: socioprophet
+```
+
+## Secrets — never in the repo
+
+All secrets are pulled at runtime via **ExternalSecret** (external-secrets.io),
+matching `infra/k8s/sovereign-broker`. Before deploy, fill in and seed:
+
+- `REPLACE_WITH_ESTATE_SECRETSTORE` → the estate's `SecretStore` name
+- `REPLACE_WITH_REMOTE_KEY_PATH/...` → Secret Manager paths for, per estate:
+  `db-password`, `registration-shared-secret`, `macaroon-secret`, `form-secret`,
+  `signing-key` (generate the signing key **once** and persist it — losing it
+  breaks federation identity).
+
+## Security gates (from the deployment profile)
+
+| Gate | Status |
+|---|---|
+| TLS configured | ✅ GKE ManagedCertificate on the public edge |
+| Registration policy explicit | ✅ `enable_registration: false` both estates |
+| Public room directory blocked | ✅ `allow_public_rooms_*: false` |
+| Federation posture | ✅ public: 443; private: disabled (empty whitelist) |
+| Signing key persisted | ✅ from Secret Manager via ExternalSecret |
+| Secrets out of config/repo | ✅ ExternalSecret + secret-fragment merge |
+| Presence off | ✅ both estates |
+| Admin account provisioning | ⏳ deferred (documented runbook — Layer 4) |
+| Moderation bot | ⏳ deferred (Layer 3 Sherlock bot / Mjolnir) |
+| Backup/restore tested | ⏳ deferred (Postgres + media backup runbook) |
+| Media retention policy | ⚠️ partial (`max_upload_size` set; full policy TBD) |
+| E2EE posture check (private) | ⏳ enforced in Layer 2 governance |
+
+## Decisions made (confirm in review)
+
+1. **In-cluster Postgres** (StatefulSet + PVC), not CloudSQL — matches the
+   profile's "named Postgres volume + backup" and keeps the estate self-contained.
+   Swap to CloudSQL later by pointing `database.args.host` at the instance.
+2. **Server names**: `matrix.socioprophet.ai` (public) / `matrix-core.socioprophet.internal`
+   (private). Change here + in the ConfigMaps/Ingress/ManagedCert if you prefer others.
+3. **Federation over 443** via `.well-known/matrix/server` — avoids a separate
+   `:8448` LoadBalancer.
+
+## Smoke checks (post-deploy)
+
+- `curl https://matrix.socioprophet.ai/_matrix/client/versions` → 200
+- `curl https://matrix.socioprophet.ai/.well-known/matrix/client` → homeserver JSON
+- private: `kubectl -n socioprophet exec deploy/synapse-private -- curl -s localhost:8008/_matrix/client/versions`
+- registration disabled: `POST /_matrix/client/v3/register` → `M_FORBIDDEN`
+- public room publication blocked until moderation baseline is enabled
+
+**Not deployed by this PR** — applying to the cluster is a gated action.

--- a/infra/k8s/wordops-matrix/base/kustomization.yaml
+++ b/infra/k8s/wordops-matrix/base/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 # WordOps / Sherlock Matrix substrate — Layer 1 (homeservers).
 # Two Synapse estates (public edge + private core) + edge proxy/ingress.
 resources:
+  - storage.yaml
   - synapse-public.yaml
   - synapse-private.yaml
   - matrix-edge.yaml
+  - postgres-backup.yaml

--- a/infra/k8s/wordops-matrix/base/kustomization.yaml
+++ b/infra/k8s/wordops-matrix/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# WordOps / Sherlock Matrix substrate — Layer 1 (homeservers).
+# Two Synapse estates (public edge + private core) + edge proxy/ingress.
+resources:
+  - synapse-public.yaml
+  - synapse-private.yaml
+  - matrix-edge.yaml

--- a/infra/k8s/wordops-matrix/base/matrix-edge.yaml
+++ b/infra/k8s/wordops-matrix/base/matrix-edge.yaml
@@ -1,0 +1,173 @@
+# WordOps Matrix — edge proxy + public ingress.
+# matrix.socioprophet.ai serves the PUBLIC estate as a normal homeserver.
+# Federation runs over 443 (advertised via .well-known/matrix/server) so we do
+# not need a separate :8448 LoadBalancer. The PRIVATE core is NOT exposed here.
+# Ingress matches the estate convention: GKE ManagedCertificate + ingress.class gce
+# (there is no nginx-ingress controller in this cluster — see socbase-gateway).
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: matrix-edge-config
+  labels:
+    app.kubernetes.io/name: matrix-edge
+    app.kubernetes.io/part-of: wordops-matrix
+data:
+  default.conf: |
+    server {
+        listen 80;
+        server_name matrix.socioprophet.ai;
+
+        # Matrix service discovery (client + federation delegation to :443).
+        location = /.well-known/matrix/client {
+            default_type application/json;
+            add_header Access-Control-Allow-Origin "*" always;
+            return 200 '{"m.homeserver":{"base_url":"https://matrix.socioprophet.ai"}}';
+        }
+        location = /.well-known/matrix/server {
+            default_type application/json;
+            return 200 '{"m.server":"matrix.socioprophet.ai:443"}';
+        }
+        location /.well-known/matrix/ {
+            root /usr/share/nginx/html;
+            default_type application/json;
+            add_header Access-Control-Allow-Origin "*" always;
+        }
+
+        # Public homeserver: client + federation API.
+        location /_matrix/ {
+            proxy_pass http://synapse-public:8008;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            client_max_body_size 50m;
+            proxy_read_timeout 300s;
+        }
+
+        location /healthz {
+            default_type application/json;
+            return 200 '{"status":"ok","service":"wordops-matrix-edge"}';
+        }
+    }
+  support.json: |
+    {
+      "contacts": [
+        {"matrix_id": "@helpdesk:matrix.socioprophet.ai", "role": "m.role.admin"},
+        {"email_address": "security@socioprophet.ai", "role": "m.role.security"}
+      ]
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: matrix-edge
+  labels:
+    app.kubernetes.io/name: matrix-edge
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: matrix-edge
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: matrix-edge
+        app.kubernetes.io/part-of: wordops-matrix
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+            - name: wellknown
+              mountPath: /usr/share/nginx/html/.well-known/matrix/support
+              subPath: support.json
+              readOnly: true
+      volumes:
+        - name: conf
+          configMap:
+            name: matrix-edge-config
+            items:
+              - key: default.conf
+                path: default.conf
+        - name: wellknown
+          configMap:
+            name: matrix-edge-config
+            items:
+              - key: support.json
+                path: support.json
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: matrix-edge
+  labels:
+    app.kubernetes.io/name: matrix-edge
+    app.kubernetes.io/part-of: wordops-matrix
+  annotations:
+    # health check for the GCE ingress backend
+    cloud.google.com/backend-config: '{"default": "matrix-edge-backendconfig"}'
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: matrix-edge
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: matrix-edge-backendconfig
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  healthCheck:
+    requestPath: /healthz
+    port: 80
+    type: HTTP
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: wordops-matrix-cert
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  domains: [matrix.socioprophet.ai]
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wordops-matrix
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+  annotations:
+    # GCE controller (built-in) — NOT nginx; matches zot/gitea/socbase.
+    kubernetes.io/ingress.class: gce
+    networking.gke.io/managed-certificates: wordops-matrix-cert
+spec:
+  rules:
+    - host: matrix.socioprophet.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: matrix-edge
+                port:
+                  number: 80

--- a/infra/k8s/wordops-matrix/base/postgres-backup.yaml
+++ b/infra/k8s/wordops-matrix/base/postgres-backup.yaml
@@ -1,0 +1,97 @@
+# Automated Postgres backups → GCS (pg_dump, gzip, 14-day retention).
+# Workload Identity: annotate the KSA with a GSA that has objectAdmin on the
+# backup bucket. Restore = gunzip | psql into a fresh estate (runbook in Layer 4).
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: matrix-backup
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+  annotations:
+    iam.gke.io/gcp-service-account: REPLACE_WITH_BACKUP_GSA@socioprophet-platform.iam.gserviceaccount.com
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-public-backup
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          serviceAccountName: matrix-backup
+          restartPolicy: Never
+          containers:
+            - name: backup
+              image: google/cloud-sdk:slim
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: synapse-public-secrets
+                      key: postgres-password
+                - name: BUCKET
+                  value: gs://prophet-backups/wordops-matrix/public
+              command: [/bin/bash, -c]
+              args:
+                - |
+                  set -euo pipefail
+                  apt-get update -qq && apt-get install -y -qq postgresql-client >/dev/null
+                  ts=$(date -u +%Y%m%dT%H%M%SZ)
+                  f="/tmp/synapse_public-$ts.sql.gz"
+                  pg_dump -h postgres-public -U synapse_public synapse_public | gzip > "$f"
+                  gcloud storage cp "$f" "$BUCKET/synapse_public-$ts.sql.gz"
+                  # retention: delete dumps older than 14 days
+                  cutoff=$(date -u -d '14 days ago' +%Y%m%d 2>/dev/null || date -u -v-14d +%Y%m%d)
+                  gcloud storage ls "$BUCKET/" | while read -r obj; do
+                    d=$(echo "$obj" | grep -oE '[0-9]{8}T' | head -1 | tr -d T)
+                    [ -n "$d" ] && [ "$d" -lt "$cutoff" ] && gcloud storage rm "$obj" || true
+                  done
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-private-backup
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  schedule: "20 3 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          serviceAccountName: matrix-backup
+          restartPolicy: Never
+          containers:
+            - name: backup
+              image: google/cloud-sdk:slim
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: synapse-private-secrets
+                      key: postgres-password
+                - name: BUCKET
+                  value: gs://prophet-backups/wordops-matrix/private
+              command: [/bin/bash, -c]
+              args:
+                - |
+                  set -euo pipefail
+                  apt-get update -qq && apt-get install -y -qq postgresql-client >/dev/null
+                  ts=$(date -u +%Y%m%dT%H%M%SZ)
+                  f="/tmp/synapse_private-$ts.sql.gz"
+                  pg_dump -h postgres-private -U synapse_private synapse_private | gzip > "$f"
+                  gcloud storage cp "$f" "$BUCKET/synapse_private-$ts.sql.gz"
+                  cutoff=$(date -u -d '14 days ago' +%Y%m%d 2>/dev/null || date -u -v-14d +%Y%m%d)
+                  gcloud storage ls "$BUCKET/" | while read -r obj; do
+                    d=$(echo "$obj" | grep -oE '[0-9]{8}T' | head -1 | tr -d T)
+                    [ -n "$d" ] && [ "$d" -lt "$cutoff" ] && gcloud storage rm "$obj" || true
+                  done

--- a/infra/k8s/wordops-matrix/base/storage.yaml
+++ b/infra/k8s/wordops-matrix/base/storage.yaml
@@ -1,0 +1,93 @@
+# In-cluster Postgres storage: expandable SSD + a usage-driven PVC autoscaler.
+# GKE has no native PVC autoscaling, so allowVolumeExpansion (online resize) plus
+# this CronJob grow the Postgres volumes when usage crosses a threshold.
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: wordops-matrix-data
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: pd-ssd
+allowVolumeExpansion: true
+reclaimPolicy: Retain          # never lose Postgres data on PVC delete
+volumeBindingMode: WaitForFirstConsumer
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: matrix-pvc-autoscaler
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: matrix-pvc-autoscaler
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+rules:
+  - apiGroups: [""]
+    resources: [persistentvolumeclaims]
+    verbs: [get, list, patch]
+  - apiGroups: [""]
+    resources: [pods, pods/exec]
+    verbs: [get, list, create]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: matrix-pvc-autoscaler
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: matrix-pvc-autoscaler
+subjects:
+  - kind: ServiceAccount
+    name: matrix-pvc-autoscaler
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: matrix-pvc-autoscaler
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: matrix-pvc-autoscaler
+          restartPolicy: Never
+          containers:
+            - name: autoscaler
+              image: bitnami/kubectl:1.30
+              command: [/bin/bash, -c]
+              args:
+                - |
+                  set -euo pipefail
+                  # Grow each Postgres PVC by 50% when data disk usage > 80%, cap 200Gi.
+                  THRESHOLD=80; MAX_GI=200
+                  for sts in postgres-public postgres-private; do
+                    pod="$sts-0"; pvc="data-$pod"
+                    used=$(kubectl exec "$pod" -c postgres -- df -P /var/lib/postgresql/data \
+                             | awk 'NR==2{gsub("%","",$5); print $5}') || { echo "skip $pod"; continue; }
+                    [ -n "$used" ] || continue
+                    if [ "$used" -ge "$THRESHOLD" ]; then
+                      cur=$(kubectl get pvc "$pvc" -o jsonpath='{.spec.resources.requests.storage}' | sed 's/Gi//')
+                      new=$(( cur + cur/2 )); [ "$new" -gt "$MAX_GI" ] && new=$MAX_GI
+                      if [ "$new" -gt "$cur" ]; then
+                        echo "PVC $pvc at ${used}% -> growing ${cur}Gi to ${new}Gi"
+                        kubectl patch pvc "$pvc" --type merge \
+                          -p "{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"${new}Gi\"}}}}"
+                      fi
+                    else
+                      echo "PVC $pvc at ${used}% (<${THRESHOLD}%), no action"
+                    fi
+                  done

--- a/infra/k8s/wordops-matrix/base/synapse-private.yaml
+++ b/infra/k8s/wordops-matrix/base/synapse-private.yaml
@@ -1,0 +1,291 @@
+# WordOps Matrix — PRIVATE CORE estate (Synapse + Postgres)
+# Purpose: case rooms, escalation, incident, internal operator + agent workspaces.
+# Posture: private visibility; NO public room directory; federation disabled by
+# default (empty whitelist); E2EE posture checks required before sensitive agent
+# context is released (enforced in the governance layer). Cluster-internal only —
+# no public Ingress. Ported from templates/private-homeserver.yaml.tpl.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: synapse-private-config
+  labels:
+    app.kubernetes.io/name: synapse-private
+    app.kubernetes.io/part-of: wordops-matrix
+    wordops-matrix/estate: private
+data:
+  homeserver.yaml: |
+    server_name: "matrix-core.socioprophet.internal"
+    public_baseurl: "https://matrix-core.socioprophet.internal/"
+    serve_server_wellknown: true
+    pid_file: /data/homeserver.pid
+    listeners:
+      - port: 8008
+        tls: false
+        type: http
+        x_forwarded: true
+        bind_addresses: ['0.0.0.0']
+        resources:
+          - names: [client, federation]
+            compress: false
+    log_config: /config/log.config
+    media_store_path: /data/media_store
+    signing_key_path: /secrets/signing.key
+    report_stats: false
+    default_room_version: "12"
+    # --- hardening (private core is stricter than the public edge) ---
+    enable_registration: false
+    enable_registration_without_verification: false
+    allow_public_rooms_without_auth: false
+    allow_public_rooms_over_federation: false
+    # federation disabled by default: empty whitelist = federate with no servers.
+    # Loosen per-policy only when a specific sensitive-room exception is approved.
+    federation_domain_whitelist: []
+    presence:
+      enabled: false
+    # no third-party identity server for the private core
+    account_threepid_delegates: {}
+    max_upload_size: 50M
+    url_preview_enabled: false
+    # E2EE posture for private rooms is asserted by the governance layer (Layer 2).
+  log.config: |
+    version: 1
+    formatters:
+      precise:
+        format: '%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(request)s - %(message)s'
+    handlers:
+      console:
+        class: logging.StreamHandler
+        formatter: precise
+    root:
+      level: INFO
+      handlers: [console]
+    disable_existing_loggers: false
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: synapse-private-secrets
+  labels:
+    app.kubernetes.io/name: synapse-private
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: REPLACE_WITH_ESTATE_SECRETSTORE
+  target:
+    name: synapse-private-secrets
+    template:
+      engine: v2
+      data:
+        secrets.yaml: |
+          database:
+            name: psycopg2
+            args:
+              user: synapse_private
+              password: "{{ .dbPassword }}"
+              database: synapse_private
+              host: postgres-private
+              port: 5432
+              cp_min: 5
+              cp_max: 10
+          registration_shared_secret: "{{ .registrationSharedSecret }}"
+          macaroon_secret_key: "{{ .macaroonSecretKey }}"
+          form_secret: "{{ .formSecret }}"
+        signing.key: "{{ .signingKey }}"
+        postgres-password: "{{ .dbPassword }}"
+  data:
+    - secretKey: dbPassword
+      remoteRef: { key: REPLACE_WITH_REMOTE_KEY_PATH/wordops-matrix-private-db-password }
+    - secretKey: registrationSharedSecret
+      remoteRef: { key: REPLACE_WITH_REMOTE_KEY_PATH/wordops-matrix-private-registration-shared-secret }
+    - secretKey: macaroonSecretKey
+      remoteRef: { key: REPLACE_WITH_REMOTE_KEY_PATH/wordops-matrix-private-macaroon-secret }
+    - secretKey: formSecret
+      remoteRef: { key: REPLACE_WITH_REMOTE_KEY_PATH/wordops-matrix-private-form-secret }
+    - secretKey: signingKey
+      remoteRef: { key: REPLACE_WITH_REMOTE_KEY_PATH/wordops-matrix-private-signing-key }
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres-private
+  labels:
+    app.kubernetes.io/name: postgres-private
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  serviceName: postgres-private
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres-private
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres-private
+        app.kubernetes.io/part-of: wordops-matrix
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          env:
+            - name: POSTGRES_DB
+              value: synapse_private
+            - name: POSTGRES_USER
+              value: synapse_private
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: synapse-private-secrets
+                  key: postgres-password
+            - name: POSTGRES_INITDB_ARGS
+              value: "--encoding=UTF8 --locale=C"
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "synapse_private", "-d", "synapse_private"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-private
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: postgres-private
+  ports:
+    - port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synapse-private
+  labels:
+    app.kubernetes.io/name: synapse-private
+    app.kubernetes.io/part-of: wordops-matrix
+    wordops-matrix/estate: private
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: synapse-private
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: synapse-private
+        app.kubernetes.io/part-of: wordops-matrix
+        wordops-matrix/estate: private
+    spec:
+      securityContext:
+        runAsUser: 991
+        runAsGroup: 991
+        fsGroup: 991
+      containers:
+        - name: synapse
+          image: matrixdotorg/synapse:v1.131.0  # pin; record digest on promote (no :latest)
+          args: ["run", "--config-path", "/config/homeserver.yaml", "--config-path", "/secrets/secrets.yaml"]
+          ports:
+            - containerPort: 8008
+          readinessProbe:
+            httpGet:
+              path: /_matrix/client/versions
+              port: 8008
+            initialDelaySeconds: 20
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8008
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: secrets
+              mountPath: /secrets
+              readOnly: true
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: config
+          configMap:
+            name: synapse-private-config
+        - name: secrets
+          secret:
+            secretName: synapse-private-secrets
+        - name: data
+          persistentVolumeClaim:
+            claimName: synapse-private-media
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: synapse-private-media
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: synapse-private
+  labels:
+    app.kubernetes.io/name: synapse-private
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  selector:
+    app.kubernetes.io/name: synapse-private
+  ports:
+    - name: client
+      port: 8008
+      targetPort: 8008
+---
+# Private core is cluster-internal: accept client traffic only from in-cluster
+# operator/agent workloads (via the edge) — never a public Ingress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: synapse-private
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: synapse-private
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: matrix-edge
+      ports:
+        - port: 8008

--- a/infra/k8s/wordops-matrix/base/synapse-private.yaml
+++ b/infra/k8s/wordops-matrix/base/synapse-private.yaml
@@ -160,6 +160,7 @@ spec:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
+        storageClassName: wordops-matrix-data
         resources:
           requests:
             storage: 10Gi
@@ -250,6 +251,7 @@ metadata:
     app.kubernetes.io/part-of: wordops-matrix
 spec:
   accessModes: ["ReadWriteOnce"]
+  storageClassName: wordops-matrix-data
   resources:
     requests:
       storage: 20Gi

--- a/infra/k8s/wordops-matrix/base/synapse-public.yaml
+++ b/infra/k8s/wordops-matrix/base/synapse-public.yaml
@@ -1,0 +1,295 @@
+# WordOps Matrix — PUBLIC EDGE estate (Synapse + Postgres)
+# Purpose: public intake, support entry, low-sensitivity self-service.
+# Posture: federates where appropriate; public room directory publication OFF
+# until the moderation baseline is live; no regulated case content.
+# Ported from infra/wordops/matrix/local/docker-compose.yml + templates/public-homeserver.yaml.tpl.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: synapse-public-config
+  labels:
+    app.kubernetes.io/name: synapse-public
+    app.kubernetes.io/part-of: wordops-matrix
+    wordops-matrix/estate: public
+data:
+  # Non-secret config only. The database block + shared secrets + signing key
+  # are supplied by the mounted secret fragment (synapse-public-secrets).
+  homeserver.yaml: |
+    server_name: "matrix.socioprophet.ai"
+    public_baseurl: "https://matrix.socioprophet.ai/"
+    serve_server_wellknown: true
+    pid_file: /data/homeserver.pid
+    listeners:
+      - port: 8008
+        tls: false
+        type: http
+        x_forwarded: true
+        bind_addresses: ['0.0.0.0']
+        resources:
+          - names: [client, federation]
+            compress: false
+    log_config: /config/log.config
+    media_store_path: /data/media_store
+    signing_key_path: /secrets/signing.key
+    report_stats: false
+    default_room_version: "12"
+    # --- hardening (deployment-profile "Security gates") ---
+    enable_registration: false
+    enable_registration_without_verification: false
+    registrations_require_3pid: []
+    allow_public_rooms_without_auth: false
+    allow_public_rooms_over_federation: false
+    presence:
+      enabled: false
+    # media retention: cap remote cache; document full policy in a later layer
+    max_upload_size: 50M
+    url_preview_enabled: false
+    # secrets (database, registration_shared_secret, macaroon_secret_key,
+    # form_secret) are merged in from /secrets/secrets.yaml at startup.
+  log.config: |
+    version: 1
+    formatters:
+      precise:
+        format: '%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(request)s - %(message)s'
+    handlers:
+      console:
+        class: logging.StreamHandler
+        formatter: precise
+    root:
+      level: INFO
+      handlers: [console]
+    disable_existing_loggers: false
+---
+# Secrets pulled from the estate secret store (never committed). Composes the
+# Synapse secret fragment + signing key + the Postgres password into one Secret.
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: synapse-public-secrets
+  labels:
+    app.kubernetes.io/name: synapse-public
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: REPLACE_WITH_ESTATE_SECRETSTORE   # e.g. gcp-secretmanager (see infra/k8s/sovereign-broker)
+  target:
+    name: synapse-public-secrets
+    template:
+      engine: v2
+      data:
+        # Synapse merges this file over homeserver.yaml at startup.
+        secrets.yaml: |
+          database:
+            name: psycopg2
+            args:
+              user: synapse_public
+              password: "{{ .dbPassword }}"
+              database: synapse_public
+              host: postgres-public
+              port: 5432
+              cp_min: 5
+              cp_max: 10
+          registration_shared_secret: "{{ .registrationSharedSecret }}"
+          macaroon_secret_key: "{{ .macaroonSecretKey }}"
+          form_secret: "{{ .formSecret }}"
+        signing.key: "{{ .signingKey }}"
+        postgres-password: "{{ .dbPassword }}"
+  data:
+    - secretKey: dbPassword
+      remoteRef: { key: REPLACE_WITH_REMOTE_KEY_PATH/wordops-matrix-public-db-password }
+    - secretKey: registrationSharedSecret
+      remoteRef: { key: REPLACE_WITH_REMOTE_KEY_PATH/wordops-matrix-public-registration-shared-secret }
+    - secretKey: macaroonSecretKey
+      remoteRef: { key: REPLACE_WITH_REMOTE_KEY_PATH/wordops-matrix-public-macaroon-secret }
+    - secretKey: formSecret
+      remoteRef: { key: REPLACE_WITH_REMOTE_KEY_PATH/wordops-matrix-public-form-secret }
+    - secretKey: signingKey
+      # Generate once: openssl genpkey / synapse signing key; persist outside disposable pods.
+      remoteRef: { key: REPLACE_WITH_REMOTE_KEY_PATH/wordops-matrix-public-signing-key }
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres-public
+  labels:
+    app.kubernetes.io/name: postgres-public
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  serviceName: postgres-public
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres-public
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres-public
+        app.kubernetes.io/part-of: wordops-matrix
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          env:
+            - name: POSTGRES_DB
+              value: synapse_public
+            - name: POSTGRES_USER
+              value: synapse_public
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: synapse-public-secrets
+                  key: postgres-password
+            # Synapse requires C locale collation.
+            - name: POSTGRES_INITDB_ARGS
+              value: "--encoding=UTF8 --locale=C"
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "synapse_public", "-d", "synapse_public"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-public
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: postgres-public
+  ports:
+    - port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synapse-public
+  labels:
+    app.kubernetes.io/name: synapse-public
+    app.kubernetes.io/part-of: wordops-matrix
+    wordops-matrix/estate: public
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: synapse-public
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: synapse-public
+        app.kubernetes.io/part-of: wordops-matrix
+        wordops-matrix/estate: public
+    spec:
+      securityContext:
+        runAsUser: 991
+        runAsGroup: 991
+        fsGroup: 991
+      containers:
+        - name: synapse
+          image: matrixdotorg/synapse:v1.131.0  # pin; record digest on promote (no :latest)
+          # Merge base config + injected secret fragment at startup.
+          args: ["run", "--config-path", "/config/homeserver.yaml", "--config-path", "/secrets/secrets.yaml"]
+          ports:
+            - containerPort: 8008
+          readinessProbe:
+            httpGet:
+              path: /_matrix/client/versions
+              port: 8008
+            initialDelaySeconds: 20
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8008
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: secrets
+              mountPath: /secrets
+              readOnly: true
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: config
+          configMap:
+            name: synapse-public-config
+        - name: secrets
+          secret:
+            secretName: synapse-public-secrets
+        - name: data
+          persistentVolumeClaim:
+            claimName: synapse-public-media
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: synapse-public-media
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: synapse-public
+  labels:
+    app.kubernetes.io/name: synapse-public
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  selector:
+    app.kubernetes.io/name: synapse-public
+  ports:
+    - name: client
+      port: 8008
+      targetPort: 8008
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: synapse-public
+  labels:
+    app.kubernetes.io/part-of: wordops-matrix
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: synapse-public
+  policyTypes: [Ingress]
+  ingress:
+    # client/federation traffic arrives via the matrix-edge proxy
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: matrix-edge
+      ports:
+        - port: 8008

--- a/infra/k8s/wordops-matrix/base/synapse-public.yaml
+++ b/infra/k8s/wordops-matrix/base/synapse-public.yaml
@@ -164,6 +164,7 @@ spec:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
+        storageClassName: wordops-matrix-data
         resources:
           requests:
             storage: 10Gi
@@ -255,6 +256,7 @@ metadata:
     app.kubernetes.io/part-of: wordops-matrix
 spec:
   accessModes: ["ReadWriteOnce"]
+  storageClassName: wordops-matrix-data
   resources:
     requests:
       storage: 20Gi

--- a/infra/k8s/wordops-matrix/overlays/p0-lab/kustomization.yaml
+++ b/infra/k8s/wordops-matrix/overlays/p0-lab/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# p0-lab overlay: deploy the Matrix substrate into the socioprophet namespace.
+namespace: socioprophet
+
+resources:
+  - ../../base
+
+# Image pins live in base (matrixdotorg/synapse:v1.131.0, postgres:16-alpine,
+# nginx:1.27-alpine). Record digests here on promote to a higher tier.


### PR DESCRIPTION
**Layer 1 of the Matrix substrate.** Ports the local `infra/wordops/matrix` profile into a production kustomize tree at `infra/k8s/wordops-matrix/`.

Two Synapse v1.131.0 estates + Postgres 16 each:
- **public edge** `matrix.socioprophet.ai` — GCE Ingress + ManagedCertificate (matches socbase/zot; NOT nginx-ingress), federation over 443 via `.well-known`.
- **private core** — cluster-internal only, federation disabled (empty whitelist), stricter posture.

All secrets via **ExternalSecret** (external-secrets.io) — DB password, registration/macaroon/form secrets, and the signing key — composed into a merged Synapse config fragment. **No secret values in the repo** (`REPLACE_WITH_*` placeholders to seed).

Hardening satisfied: TLS, registration disabled, no public room directory, presence off, persisted signing key. Deferred to later layers (tracked in README): admin provisioning, moderation bot, backup/restore test, E2EE posture enforcement.

`kubectl kustomize overlays/p0-lab` builds clean (22 objects). **Not applied — cluster deploy is a gated action.** See `infra/k8s/wordops-matrix/README.md` for the security-gate checklist + decisions (in-cluster PG vs CloudSQL, server names).