### PR TITLE
feat(catalog-gateway): unified resolve/lineage + first real DCAT emitter (read-only)

### DIFF
--- a/apps/catalog-gateway/README.md
+++ b/apps/catalog-gateway/README.md
@@ -1,0 +1,41 @@
+# catalog-gateway
+
+The unified read / resolve / lineage + external-interop seam over the Crystal Atlas
+catalog families — the "GMS-equivalent" the data-catalog design brief
+(`docs/strategy/PROPHET_DATA_CATALOG_DESIGN.md`) calls for. It **composes** the pieces
+that already exist rather than reinventing them: the Crystal Atlas contract families
+(`contracts/crystal-atlas/schemas/*-catalog-entry.v0`), the shared platform file-state
+layout (as used by `crystal-atlas-contract-intel` / `evidence-receipts`), and — in later
+increments — lattice-studio's DataCite/PROV-O/lineage logic, compute-gateway receipts,
+and the masking PDP.
+
+## First increment (read-only)
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /healthz` | liveness + supported kinds |
+| `GET /v1/catalog/{kind}/{id}` | resolve a `source`\|`asset`\|`model`\|`workflow` entry from file-state |
+| `GET /v1/catalog/{kind}/{id}/lineage` | upstream `source_refs`, best-effort resolved |
+| `GET /v1/catalog/asset/{id}.dcat.json` | **the first real DCAT / schema.org emitter** (`application/ld+json`) |
+
+The DCAT emitter is the strategic unlock: it is the standards seam CKAN (`ckanext-dcat`),
+the DataHub Project, and CK.org harvest from. It also carries the Prophet extension
+(`prophet:distributionClass`, and later `prophet:verifiedComputeRef`) — the governance a
+plain catalog cannot represent.
+
+## Storage layout
+```
+$SOCIOPROFIT_STATE_HOME/prophet-platform/catalog/<kind>/<id>.json
+```
+Ids are constrained to `[A-Za-z0-9._:-]` and resolved under the catalog root only
+(path-traversal fails closed).
+
+## Test
+```
+cd apps/catalog-gateway && python3 -m pytest tests -q
+```
+
+## Next increments
+Registration (write path) · search/faceting (via sherlock) · mount the masking PDP as a
+read-path filter (compute-gateway pattern) · real CKAN / DataHub-MCP / CK.org emitters
+off the DCAT bridge.

--- a/apps/catalog-gateway/app/dcat.py
+++ b/apps/catalog-gateway/app/dcat.py
@@ -1,0 +1,80 @@
+"""Crystal Atlas → DCAT / schema.org projection.
+
+The first *real* external-interop emitter (prior surfaces emitted projection-shaped
+JSON only). A Crystal Atlas asset-catalog-entry becomes a `dcat:Dataset` JSON-LD
+document that CKAN (via ckanext-dcat), the DataHub Project, and CK.org can harvest.
+
+The moat travels outward: standards-compliant DCAT/PROV metadata PLUS a Prophet
+extension (`prophet:distributionClass`, `prophet:verifiedComputeRef`) that downstream
+systems can ignore safely but that carries the governance/verification a plain catalog
+cannot represent.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+CONTEXT = {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "schema": "https://schema.org/",
+    "prophet": "https://schemas.socioprophet.org/ns#",
+}
+
+# distribution_class → DCAT-US access level.
+_ACCESS = {
+    "open": "public",
+    "public_derived": "public",
+    "free_tier_packaged": "public",
+    "internal_private": "non-public",
+    "premium_byo": "restricted",
+    "premium_platform_managed": "restricted",
+    "restricted_nonredistributable": "restricted",
+}
+
+# asset_kind → schema.org type (best-fit; dataset is the default).
+_SCHEMA_TYPE = {
+    "dataset": "schema:Dataset",
+    "document": "schema:DigitalDocument",
+    "conversation_thread": "schema:Conversation",
+    "event_stream": "schema:DataFeed",
+    "graph_bundle": "schema:Dataset",
+    "evidence_bundle": "schema:Dataset",
+    "agent_output_bundle": "schema:Dataset",
+    "workflow_artifact": "schema:Dataset",
+}
+
+
+def access_rights(distribution_class: str | None) -> str:
+    return _ACCESS.get(distribution_class or "", "restricted")
+
+
+def asset_to_dcat(entry: dict[str, Any]) -> dict[str, Any]:
+    """Map an asset-catalog-entry.v0 to a dcat:Dataset JSON-LD document."""
+    asset_id = entry.get("asset_id")
+    kind = entry.get("asset_kind")
+    dist = entry.get("distribution_class")
+    doc: dict[str, Any] = {
+        "@context": CONTEXT,
+        "@id": f"urn:prophet:asset:{asset_id}",
+        "@type": ["dcat:Dataset", _SCHEMA_TYPE.get(kind, "schema:Dataset")],
+        "dct:identifier": asset_id,
+        "dct:type": kind,
+        "dct:accessRights": access_rights(dist),
+        "dct:publisher": {"@id": f"urn:prophet:tenant:{entry.get('tenant_id')}"},
+        # source_refs are the lineage seed → PROV derivation.
+        "prov:wasDerivedFrom": [{"@id": s} for s in (entry.get("source_refs") or [])],
+        # Prophet extension — the governance the open standards can't carry.
+        "prophet:distributionClass": dist,
+        "prophet:tenant": entry.get("tenant_id"),
+    }
+    if entry.get("schema_ref"):
+        doc["dct:conformsTo"] = entry["schema_ref"]
+    if entry.get("created_at"):
+        doc["dct:issued"] = entry["created_at"]
+    if entry.get("updated_at"):
+        doc["dct:modified"] = entry["updated_at"]
+    fresh = entry.get("freshness")
+    if isinstance(fresh, dict):
+        doc["prophet:freshness"] = fresh
+    return doc

--- a/apps/catalog-gateway/app/main.py
+++ b/apps/catalog-gateway/app/main.py
@@ -1,0 +1,63 @@
+"""Catalog Gateway — the unified read/resolve/lineage + interop seam over the
+Crystal Atlas catalog families.
+
+First increment (read-only), composing existing pieces rather than reinventing them:
+  * GET /v1/catalog/{kind}/{id}          — resolve a source|asset|model|workflow entry
+  * GET /v1/catalog/{kind}/{id}/lineage  — upstream refs (source_refs), best-effort resolved
+  * GET /v1/catalog/asset/{id}.dcat.json — the first real DCAT/schema.org emitter
+
+The GMS-equivalent seam the design brief calls for (docs/strategy/PROPHET_DATA_CATALOG_DESIGN.md).
+Registration (write path), search/faceting, and the masking-PDP mount land in later increments.
+"""
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+
+from .dcat import asset_to_dcat
+from .store import KINDS, SERVICE, get_entry, is_valid_id
+
+app = FastAPI(title="Prophet Platform Catalog Gateway", version="0.1.0")
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"status": "ok", "service": SERVICE, "kinds": list(KINDS)}
+
+
+def _resolve_or_404(kind: str, entry_id: str) -> dict:
+    if kind not in KINDS:
+        raise HTTPException(status_code=404, detail=f"unknown catalog kind: {kind}")
+    if not is_valid_id(entry_id):
+        raise HTTPException(status_code=400, detail="invalid catalog id")
+    entry = get_entry(kind, entry_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail=f"{kind} '{entry_id}' not found")
+    return entry
+
+
+# NOTE: the `.dcat.json` route is declared BEFORE the generic `/{kind}/{entry_id}`
+# resolver. Starlette matches routes in declaration order and `{entry_id}` is `[^/]+`
+# (dots included), so the generic resolver would otherwise swallow "<id>.dcat.json".
+@app.get("/v1/catalog/asset/{entry_id}.dcat.json")
+def asset_dcat(entry_id: str) -> JSONResponse:
+    entry = _resolve_or_404("asset", entry_id)
+    return JSONResponse(content=asset_to_dcat(entry), media_type="application/ld+json")
+
+
+@app.get("/v1/catalog/{kind}/{entry_id}/lineage")
+def lineage(kind: str, entry_id: str) -> dict:
+    entry = _resolve_or_404(kind, entry_id)
+    # source_refs are the lineage seed. Best-effort resolve any that are catalog ids.
+    upstream = []
+    for ref in entry.get("source_refs") or []:
+        as_source = get_entry("source", ref)
+        as_asset = get_entry("asset", ref)
+        upstream.append({"ref": ref, "resolved": bool(as_source or as_asset),
+                         "kind": "source" if as_source else ("asset" if as_asset else None)})
+    return {"node": entry_id, "kind": kind, "upstream": upstream}
+
+
+@app.get("/v1/catalog/{kind}/{entry_id}")
+def resolve(kind: str, entry_id: str) -> dict:
+    return {"kind": kind, "entry": _resolve_or_404(kind, entry_id)}

--- a/apps/catalog-gateway/app/store.py
+++ b/apps/catalog-gateway/app/store.py
@@ -1,0 +1,60 @@
+"""Catalog entry store — reads Crystal Atlas catalog entries from the shared
+platform file-state layout (the same convention crystal-atlas-contract-intel and
+evidence-receipts use).
+
+Entries live at:
+    $SOCIOPROFIT_STATE_HOME/prophet-platform/catalog/<kind>/<id>.json
+
+The gateway is read-only over this layout for the first increment; registration
+(the write path) lands later.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+SERVICE = "catalog-gateway"
+KINDS = ("source", "asset", "model", "workflow")
+
+# ids are opaque handles, but they index into the filesystem — so constrain them
+# to a safe charset. This is the path-traversal gate: no "/", no "..", no NUL.
+_SAFE_ID = re.compile(r"^[A-Za-z0-9._:-]{1,256}$")
+
+
+def state_home() -> Path:
+    if v := os.environ.get("SOCIOPROFIT_STATE_HOME"):
+        return Path(v)
+    return Path.home() / ".local" / "state"
+
+
+def catalog_root() -> Path:
+    return state_home() / "prophet-platform" / "catalog"
+
+
+def is_valid_id(entry_id: str) -> bool:
+    # charset gate + explicit ".." reject: "." is legal in ids (versions), so the
+    # regex alone would admit ".." — the traversal token — which must be refused.
+    return bool(_SAFE_ID.match(entry_id or "")) and ".." not in entry_id
+
+
+def get_entry(kind: str, entry_id: str) -> dict[str, Any] | None:
+    """Return the catalog entry, or None if the kind/id is invalid or absent.
+    Fails closed on a bad id (path-traversal attempt) — returns None, never reads
+    outside the catalog root."""
+    if kind not in KINDS or not is_valid_id(entry_id):
+        return None
+    path = (catalog_root() / kind / f"{entry_id}.json").resolve()
+    root = catalog_root().resolve()
+    # defence in depth: the resolved path must stay under the catalog root.
+    if root not in path.parents:
+        return None
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None

--- a/apps/catalog-gateway/tests/test_catalog_gateway.py
+++ b/apps/catalog-gateway/tests/test_catalog_gateway.py
@@ -1,0 +1,87 @@
+"""Catalog Gateway tests — resolve, lineage, DCAT emitter, path-traversal guard."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from app.main import app  # noqa: E402
+from app import store  # noqa: E402
+
+client = TestClient(app)
+
+ASSET = {
+    "asset_id": "asset-demo-001",
+    "asset_kind": "dataset",
+    "tenant_id": "tenant-a",
+    "distribution_class": "public_derived",
+    "source_refs": ["src-gov-001"],
+    "schema_ref": "contracts/crystal-atlas/schemas/asset-catalog-entry.v0.schema.json",
+    "freshness": {"cadence": "daily"},
+    "created_at": "2026-07-31T00:00:00Z",
+    "updated_at": "2026-07-31T00:00:00Z",
+}
+
+
+def _seed(monkeypatch, tmp_path):
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    d = tmp_path / "prophet-platform" / "catalog" / "asset"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "asset-demo-001.json").write_text(json.dumps(ASSET), encoding="utf-8")
+
+
+def test_healthz():
+    r = client.get("/healthz")
+    assert r.status_code == 200 and r.json()["service"] == "catalog-gateway"
+
+
+def test_resolve_found(monkeypatch, tmp_path):
+    _seed(monkeypatch, tmp_path)
+    r = client.get("/v1/catalog/asset/asset-demo-001")
+    assert r.status_code == 200
+    assert r.json()["entry"]["tenant_id"] == "tenant-a"
+
+
+def test_resolve_missing_is_404(monkeypatch, tmp_path):
+    _seed(monkeypatch, tmp_path)
+    assert client.get("/v1/catalog/asset/nope").status_code == 404
+
+
+def test_unknown_kind_is_404(monkeypatch, tmp_path):
+    _seed(monkeypatch, tmp_path)
+    assert client.get("/v1/catalog/bogus/asset-demo-001").status_code == 404
+
+
+def test_dcat_emitter(monkeypatch, tmp_path):
+    _seed(monkeypatch, tmp_path)
+    r = client.get("/v1/catalog/asset/asset-demo-001.dcat.json")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/ld+json")
+    doc = r.json()
+    assert "dcat:Dataset" in doc["@type"]
+    assert doc["dct:accessRights"] == "public"          # public_derived → public
+    assert doc["dct:identifier"] == "asset-demo-001"
+    assert doc["prov:wasDerivedFrom"] == [{"@id": "src-gov-001"}]
+    assert doc["prophet:distributionClass"] == "public_derived"   # the moat, exported
+    assert doc["@context"]["dcat"].startswith("http://www.w3.org/ns/dcat")
+
+
+def test_lineage(monkeypatch, tmp_path):
+    _seed(monkeypatch, tmp_path)
+    r = client.get("/v1/catalog/asset/asset-demo-001/lineage")
+    assert r.status_code == 200
+    up = r.json()["upstream"]
+    assert up and up[0]["ref"] == "src-gov-001"
+
+
+def test_id_validation_and_traversal_guard():
+    assert store.is_valid_id("asset-demo-001")
+    for bad in ("../etc/passwd", "a/b", "..", "a\x00b", ""):
+        assert not store.is_valid_id(bad)
+    # get_entry fails closed on a traversal id
+    assert store.get_entry("asset", "../../secret") is None


### PR DESCRIPTION
The Catalog Gateway first increment (strategy item **B**) — the GMS-equivalent seam the data-catalog design brief calls for, built by **composing** what already exists rather than forking it.

## What
New `apps/catalog-gateway/` (FastAPI), read-only over the shared file-state layout, with the Crystal Atlas contract families as the API contract:
- `GET /v1/catalog/{kind}/{id}` — resolve `source|asset|model|workflow`
- `GET /v1/catalog/{kind}/{id}/lineage` — upstream `source_refs`, best-effort resolved
- `GET /v1/catalog/asset/{id}.dcat.json` — **the first real DCAT / schema.org emitter** (`application/ld+json`), the seam CKAN/DataHub/CK.org harvest from; carries `prophet:distributionClass` (the moat, exported)

## Security
Ids constrained to `[A-Za-z0-9._:-]`, `..` refused, resolved path enforced under the catalog root — path traversal fails closed (tested).

## Tests
`tests/` — 7 passing (resolve/404, DCAT shape + access-rights mapping, lineage, traversal guard). Two real bugs were caught and fixed during test (regex admitting `..`; the generic `/{kind}/{id}` route shadowing `.dcat.json` via Starlette ordering).

## Not
Not a fork of `crystal-atlas-contract-intel`; not the Go tritrpc gateway. Next: registration (write path), search, real CKAN/DataHub-MCP/CK.org emitters off the DCAT bridge, and mounting the masking PDP as a read-path filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)