### PR TITLE
ci: wire validate_mesh_deployment.py, close appset path-filter gap

### DIFF
--- a/.github/workflows/personal-intelligence-cell.yml
+++ b/.github/workflows/personal-intelligence-cell.yml
@@ -15,6 +15,11 @@ on:
       - 'infra/datastores/**/cell/**'
       - 'fixtures/cell/**'
       - 'docs/PERSONAL_INTELLIGENCE_CELL*.md'
+      # tools/validate_repo.py (run by this workflow, see below) reads this
+      # appset file directly. Closes docs/CI_PATH_FILTER_DEBT.md's
+      # "validate_repo.py reads infra/k8s/argo-cd/appsets/socioprophet-appset.yaml,
+      # not matched by paths: filter" item.
+      - 'infra/k8s/argo-cd/appsets/socioprophet-appset.yaml'
       - '.github/workflows/personal-intelligence-cell.yml'
   push:
     branches:
@@ -30,6 +35,7 @@ on:
       - 'infra/datastores/**/cell/**'
       - 'fixtures/cell/**'
       - 'docs/PERSONAL_INTELLIGENCE_CELL*.md'
+      - 'infra/k8s/argo-cd/appsets/socioprophet-appset.yaml'
       - '.github/workflows/personal-intelligence-cell.yml'
 
 permissions:

--- a/.github/workflows/validate-mesh-deployment.yml
+++ b/.github/workflows/validate-mesh-deployment.yml
@@ -1,0 +1,58 @@
+# tools/validate_mesh_deployment.py checks that the prophet-mesh + SocioSphere
+# deployment tree stays internally consistent: k8s manifests exist for every
+# mesh/sociosphere service, the Argo CD appset at
+# infra/k8s/argo-cd/appsets/socioprophet-appset.yaml includes every bundle,
+# the two docker-compose files declare every service with correct dependency
+# ordering and unique ports, and no manifest carries a plaintext secret. See
+# docs/WAVE0_SUPPLY_CHAIN_PROMOTION.md for why this tree's sync-wave ordering
+# is genuinely live, and the script's own docstring for the 2026-07-29
+# phantom-deploy audit that motivated it.
+#
+# The script existed and is well-written, but was never wired into CI —
+# confirmed 2026-07-31 via `grep -rl validate_mesh_deployment .github/workflows/`
+# returning nothing. This workflow closes that gap.
+#
+# ADVISORY ONLY on first landing (`continue-on-error: true` below). The script
+# has never run in CI before; a manual run against the current tree at wiring
+# time surfaced 2 pre-existing failures (k8s/hellgraph/base/deployment.yaml
+# missing — hellgraph ships a StatefulSet, not a Deployment, and the checker
+# doesn't know that; k8s/lattice-forge/base/ missing entirely) that need
+# separate triage. Do not flip this to a blocking/required check until those
+# are resolved or the script is corrected, and a clean run is confirmed.
+#
+# No `pip install` step: the script only imports sys, re, and pathlib (checked
+# against tools/validate_mesh_deployment.py directly) — unlike
+# preflight_deploy_contract.py's workflow, it has no pyyaml dependency.
+name: validate-mesh-deployment
+
+on:
+  pull_request:
+    paths:
+      - 'infra/k8s/**'
+      - 'infra/local/docker-compose.mesh.yml'
+      - 'infra/local/docker-compose.sociosphere.yml'
+      - 'tools/validate_mesh_deployment.py'
+      - '.github/workflows/validate-mesh-deployment.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'infra/k8s/**'
+      - 'infra/local/docker-compose.mesh.yml'
+      - 'infra/local/docker-compose.sociosphere.yml'
+      - 'tools/validate_mesh_deployment.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-mesh-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Mesh + SocioSphere deployment alignment (advisory — not yet a required check, see header)
+        continue-on-error: true
+        run: python3 tools/validate_mesh_deployment.py

--- a/docs/CI_PATH_FILTER_DEBT.md
+++ b/docs/CI_PATH_FILTER_DEBT.md
@@ -85,7 +85,6 @@ the check stays green because it is never asked.
   - tools/validate_repo.py reads docs/TRITRPC_PLATFORM_BINDING.md, not matched by paths: filter
   - tools/validate_repo.py reads docs/TRITRPC_SPEC.md, not matched by paths: filter
   - tools/validate_repo.py reads docs/ZONE_MODEL.md, not matched by paths: filter
-  - tools/validate_repo.py reads infra/k8s/argo-cd/appsets/socioprophet-appset.yaml, not matched by paths: filter
   - tools/validate_repo.py reads tools/run_prophet_understand_vertical_slice.py, not matched by paths: filter
   - tools/validate_repo.py reads tools/validate_professional_intelligence.py, not matched by paths: filter
   - tools/validate_repo.py reads tools/validate_prophet_understand.py, not matched by paths: filter


### PR DESCRIPTION
## Why

`tools/validate_mesh_deployment.py` checks k8s manifest coverage, ArgoCD appset bundle coverage, docker-compose alignment, and plaintext-secret scanning for the prophet-mesh + SocioSphere deployment tree (`infra/k8s/argo-cd/appsets/socioprophet-appset.yaml` — confirmed genuinely live via `docs/WAVE0_SUPPLY_CHAIN_PROMOTION.md`'s sync-wave doctrine, not stranded). It existed with real fixtures and was never invoked by any CI workflow — the same "library nobody calls" pattern as other findings in this estate.

Separately, `docs/CI_PATH_FILTER_DEBT.md` already logged that `tools/validate_repo.py` reads the appset file but `personal-intelligence-cell.yml`'s path filter didn't cover it.

## What changed

- New `.github/workflows/validate-mesh-deployment.yml`, modeled on `preflight-deploy-contract.yml`. **Advisory-only** (`continue-on-error: true`) for first landing: a live run surfaces 2 pre-existing failures (hellgraph ships a StatefulSet, not the `deployment.yaml` the script expects; `lattice-forge/base/` is missing) that need separate triage before this becomes a required check.
- Closed the logged path-filter gap in `personal-intelligence-cell.yml`; removed the resolved line from `CI_PATH_FILTER_DEBT.md`.

## Verification

- Negative-tested: temporarily dropped a bundle line from the live appset and confirmed the new check flags it; confirmed via the checker's own `covered()` fnmatch logic that the old path filter misses the appset path and the new one matches.
- `helm`/script dependency check: no `pip install` needed, script only imports stdlib.

## Follow-ups (not in scope here)

- Triage the 2 pre-existing failures this surfaces before flipping to a required check.