### PR TITLE
ci: adopt git-ops-standards pr-merge-gate

### DIFF
--- a/.github/workflows/git-ops-standards.yml
+++ b/.github/workflows/git-ops-standards.yml
@@ -5,4 +5,7 @@ on:
 
 jobs:
   gate:
+    permissions:
+      contents: read
+      pull-requests: read
     uses: SocioProphet/git-ops-standards/.github/workflows/pr-merge-gate.yml@main

--- a/.github/workflows/git-ops-standards.yml
+++ b/.github/workflows/git-ops-standards.yml
@@ -1,0 +1,8 @@
+name: git-ops-standards
+
+on:
+  pull_request:
+
+jobs:
+  gate:
+    uses: SocioProphet/git-ops-standards/.github/workflows/pr-merge-gate.yml@main


### PR DESCRIPTION
Adopts SocioProphet/git-ops-standards' reusable pr-merge-gate.yml (unpinned cross-repo path deps, unresolved changes-requested reviews, stale/conflicting mergeable state). Not yet required in branch protection — deliberate follow-up, not bundled here.