### PR TITLE
fix(mesh): make the Gateway's GatewayClass a per-cloud overlay, not hardcoded to GKE

### DIFF
--- a/deploy/argocd/progressive-delivery-services.yaml
+++ b/deploy/argocd/progressive-delivery-services.yaml
@@ -29,10 +29,15 @@
 # both; google-cloud.md explicitly says GKE Gateway API integration is "available with the
 # Argo Rollouts Gateway API plugin" too). There is no trafficRouting.gatewayAPI key to
 # switch to — the argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi plugin below is the
-# only path to weighted-HTTPRoute canaries, on Cilium OR on GKE's native Gateway alike; only
-# the GatewayClass underneath changed (infra/k8s/mesh/base/gateway.yaml: cilium → gke-l7-rilb,
-# the internal regional GatewayClass — matches the Gateway's namespace-internal-only intent
-# and was confirmed available via `kubectl get gatewayclass` on this cluster).
+# only path to weighted-HTTPRoute canaries, on Cilium OR on GKE's native Gateway alike.
+#
+# PORTABILITY FIX (2026-07-31, same day): the path below now points at
+# infra/k8s/mesh/overlays/gcp-gke-autopilot, not infra/k8s/mesh/base directly. The GatewayClass
+# is a per-cloud overlay concern, not something to hardcode into the shared base — a future
+# AWS/Azure/self-managed environment's own app-of-apps should point this same Application shape
+# at overlays/cilium-portable instead (see that overlay's README for the companion Cilium
+# install). No change to what's actually live on THIS cluster — gke-l7-rilb either way, matching
+# GKE Autopilot's Dataplane V2 constraint (no user-facing Cilium Gateway API surface here).
 #
 # hellgraph-service (deploy/values/hellgraph-service.yaml) does NOT use the AnalysisTemplate
 # below yet — no /metrics exist for it (separate, unresolved prerequisite) — it runs a
@@ -102,7 +107,7 @@ spec:
   source:
     repoURL: https://github.com/SocioProphet/prophet-platform.git
     targetRevision: main
-    path: infra/k8s/mesh/base
+    path: infra/k8s/mesh/overlays/gcp-gke-autopilot
   syncPolicy:
     automated: { prune: true, selfHeal: true }
     syncOptions:

--- a/infra/k8s/mesh/base/gateway.yaml
+++ b/infra/k8s/mesh/base/gateway.yaml
@@ -4,23 +4,27 @@
 # native support for this in Argo Rollouts as of v1.9.1, confirmed against the project's own
 # docs source).
 #
-# gatewayClassName: gke-l7-rilb (2026-07-31, was `cilium` — dropped; this cluster has no
-# separate Cilium Helm install and no CiliumNetworkPolicy CRD, only GKE's native Gateway API
-# implementation). Confirmed via `kubectl get gatewayclass` against the live cluster:
-# gke-l7-rilb/-gxlb/-regional-external-managed/-global-external-managed all exist.
-# gke-l7-rilb (regional INTERNAL LB) chosen to match this Gateway's `allowedRoutes: from:
-# Same` intent (in-namespace only, no internet exposure) — NOT a lightweight in-cluster
-# proxy the way Cilium's own Gateway controller would have been: GKE's Gateway controller
-# provisions a REAL regional internal Google Cloud load balancer for this. That's a cost +
-# behavior difference from the original Cilium design worth a second look before this ships
-# broadly (fine for a single pilot service; reconsider if many services adopt this pattern).
+# gatewayClassName is deliberately a placeholder here (2026-07-31, corrected same-day) — this
+# base must stay portable across clouds (GKE/EKS/AKS/self-managed), not hardcoded to the one
+# GKE cluster that happens to exist today. Every consumer selects an overlay:
+#   overlays/gcp-gke-autopilot — gke-l7-rilb (GKE's native Gateway controller; matches this
+#     cluster's Dataplane V2, which doesn't expose a user-facing Cilium Gateway API surface —
+#     see networkpolicy.yaml's header for the same Autopilot constraint). Provisions a REAL
+#     regional internal Google Cloud load balancer — a cost + behavior difference from the
+#     portable overlay worth a second look if many services adopt this.
+#   overlays/cilium-portable — cilium (real Cilium install required — see that overlay's
+#     README for the companion Application spec). Identical on EKS/AKS/self-managed/bare-metal.
+# deploy/argocd/progressive-delivery-services.yaml currently points at gcp-gke-autopilot,
+# matching the one live cluster today. A future AWS/Azure/self-managed environment's own
+# app-of-apps should point at cilium-portable instead — identical HTTPRoute/plugin wiring,
+# only this one field differs.
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: socioprophet-gateway
   namespace: socioprophet
 spec:
-  gatewayClassName: gke-l7-rilb
+  gatewayClassName: REPLACE_ME_VIA_OVERLAY
   listeners:
     - name: http
       protocol: HTTP

--- a/infra/k8s/mesh/base/kustomization.yaml
+++ b/infra/k8s/mesh/base/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-# Mesh policy + Gateway. Requires the Gateway API CRDs (GKE's native implementation on this
-# cluster — confirmed already installed, no CNI chart needed here; see
-# deploy/argocd/progressive-delivery-services.yaml for the 2026-07-31 Cilium-drop rationale).
+# Mesh policy + Gateway. Cloud-agnostic base — requires Gateway API CRDs (any provider) and
+# does NOT set a GatewayClass; pick an overlay under ../overlays/ for that (gcp-gke-autopilot
+# or cilium-portable). Do not apply this base directly.
 resources:
   - networkpolicy.yaml
   - gateway.yaml

--- a/infra/k8s/mesh/overlays/cilium-portable/README.md
+++ b/infra/k8s/mesh/overlays/cilium-portable/README.md
@@ -1,0 +1,23 @@
+# cilium-portable overlay
+
+For any environment that is NOT GKE Autopilot (EKS, AKS, self-managed, bare-metal). The
+`gcp-gke-autopilot` overlay is what the one live cluster today actually uses — this one exists
+so the same workload-facing manifests (HTTPRoute, NetworkPolicy, the Argo Rollouts Gateway API
+traffic-shaped canary) don't have to be rewritten per cloud, only re-pointed.
+
+## To adopt this in a new environment
+
+1. Point that environment's ArgoCD app-of-apps at `infra/k8s/mesh/overlays/cilium-portable`
+   instead of `overlays/gcp-gke-autopilot` (see how
+   `deploy/argocd/progressive-delivery-services.yaml` does this for GKE today).
+2. Sync `cilium-application.yaml` in this directory FIRST (or add it to that environment's own
+   app-of-apps) — real Cilium must be installed and its Gateway API controller running before
+   the `gatewayClassName: cilium` Gateway in this overlay can bind to anything.
+3. Everything else (the Argo Rollouts `argoproj-labs/gatewayAPI` plugin, HTTPRoute weight
+   shifting, `charts/socioprophet-service`'s `rollout.*` values block) is identical to the GKE
+   path — no per-cloud changes needed beyond the GatewayClass + the CNI install.
+
+Not yet exercised against a real AWS/Azure cluster — this is a designed, not yet
+operationally-verified, portability path. Verify `kubectl get gatewayclass` shows `cilium`
+and the Cilium controller pods are Healthy before trusting a canary through it, same discipline
+as was applied to the GKE path.

--- a/infra/k8s/mesh/overlays/cilium-portable/cilium-application.yaml
+++ b/infra/k8s/mesh/overlays/cilium-portable/cilium-application.yaml
@@ -1,0 +1,42 @@
+# NOT applied on the current GKE Autopilot environment — see overlays/gcp-gke-autopilot
+# instead. This is the companion Cilium install for a future AWS/Azure/self-managed
+# environment's own app-of-apps to reference alongside this overlay's kustomization.
+# Restored 2026-07-31 from the original infra/argocd/progressive-delivery.yaml design
+# (pre-dated this repo's app-of-apps ever actually reconciling it), with its own original
+# rationale intact: real Cilium as CNI/Gateway API provider, install at cluster bootstrap
+# on self-managed/edge clusters; identical behavior on EKS/AKS.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cilium
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  source:
+    repoURL: https://helm.cilium.io
+    chart: cilium
+    targetRevision: 1.16.5
+    helm:
+      releaseName: cilium
+      values: |
+        # mTLS between endpoints (transparent encryption).
+        encryption:
+          enabled: true
+          type: wireguard
+        hubble:
+          enabled: true
+          relay: { enabled: true }
+          ui: { enabled: true }
+        gatewayAPI:
+          enabled: true
+        kubeProxyReplacement: true
+  syncPolicy:
+    automated: { prune: true, selfHeal: true }
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/infra/k8s/mesh/overlays/cilium-portable/kustomization.yaml
+++ b/infra/k8s/mesh/overlays/cilium-portable/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# For EKS/AKS/self-managed/bare-metal — anywhere that isn't GKE Autopilot. Requires the
+# companion Cilium Application in this directory (cilium-application.yaml) to actually be
+# synced by that environment's own app-of-apps FIRST — this overlay only patches the
+# GatewayClass reference, it does not install Cilium itself (ArgoCD Applications aren't
+# expressible as a kustomize resource in a way that composes with a Gateway/HTTPRoute
+# resource list, so keep them as separate concerns: this overlay for the workload-facing
+# Gateway API objects, the Application spec for the cluster-level CNI/controller install).
+resources:
+  - ../../base
+patches:
+  - target:
+      group: gateway.networking.k8s.io
+      version: v1
+      kind: Gateway
+      name: socioprophet-gateway
+    patch: |-
+      - op: replace
+        path: /spec/gatewayClassName
+        value: cilium

--- a/infra/k8s/mesh/overlays/gcp-gke-autopilot/kustomization.yaml
+++ b/infra/k8s/mesh/overlays/gcp-gke-autopilot/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# GKE Autopilot: Dataplane V2 doesn't expose a user-facing Cilium Gateway API surface (only
+# its own internal bookkeeping CRDs), so this overlay uses GKE's native Gateway controller
+# instead. See ../../base/gateway.yaml's header for the full rationale.
+resources:
+  - ../../base
+patches:
+  - target:
+      group: gateway.networking.k8s.io
+      version: v1
+      kind: Gateway
+      name: socioprophet-gateway
+    patch: |-
+      - op: replace
+        path: /spec/gatewayClassName
+        value: gke-l7-rilb


### PR DESCRIPTION
## Why

#1163 (merged today) hardcoded `gatewayClassName: gke-l7-rilb` directly into `infra/k8s/mesh/base/gateway.yaml`. Correct for this specific GKE Autopilot cluster, but makes the manifest cross-cloud-incompatible — `gke-l7-rilb` doesn't exist on AWS or Azure at all, and clients need to be deployable there.

Caught before any real damage: the live `Gateway` resource existed but had not provisioned an actual GCP load balancer yet (`kubectl get gateway` showed no ADDRESS/PROGRAMMED) when this fix was drafted.

(Note: an earlier PR #1166 for this same fix was closed — it got accidentally built on an unrelated in-progress commit due to a concurrent process switching the shared local clone's checkout mid-session, entangling unrelated diffs. This PR was built in an isolated `git worktree` off a freshly-fetched `origin/main` specifically to avoid that class of mistake; verified clean — `git diff origin/main...HEAD --stat` shows exactly these 7 files, nothing else.)

## What changed

- `base/gateway.yaml`: no longer sets a real `gatewayClassName` — placeholder only, "do not apply this base directly."
- `overlays/gcp-gke-autopilot/`: patches in `gke-l7-rilb` — matches what's live today exactly.
- `overlays/cilium-portable/`: patches in `cilium`, for EKS/AKS/self-managed — includes a restored companion Cilium `Application` (recovered from the original pre-pivot design) and a README for how a future non-GKE environment adopts it.
- `deploy/argocd/progressive-delivery-services.yaml` now points at the `gcp-gke-autopilot` overlay instead of `base` directly.

## Why GKE stays native (not "just always use Cilium")

This cluster is GKE **Autopilot** (confirmed via `gcloud container clusters describe ... --format="value(autopilot.enabled)"` → `True`). Autopilot's Dataplane V2 is internally Cilium-based but does not expose a user-facing Cilium Gateway API surface, and Autopilot restricts privileged CNI-level installs — forcing a separate Cilium install here would likely just fail. GKE-native is the correct choice for *this* cluster; the fix is making that a per-environment overlay decision instead of the only option.

## Verified

`kubectl kustomize` on both overlays: `gcp-gke-autopilot` renders byte-identical to what's live (`gke-l7-rilb`) — **no change to the running cluster from this fix**. `cilium-portable` renders `gatewayClassName: cilium` correctly. Not yet operationally verified against a real AWS/Azure cluster — flagged as such in that overlay's README; this is a designed, not yet exercised, path.