### PR TITLE
feat(workspace): zero-touch mail autoconfig (Thunderbird + Apple + Outlook)

### DIFF
--- a/services/workspace-autoconfig/.well-known/autoconfig/mail/config-v1.1.xml
+++ b/services/workspace-autoconfig/.well-known/autoconfig/mail/config-v1.1.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Mozilla ISPDB autoconfig (Thunderbird, K-9/FairEmail, GNOME Evolution, and others).
+     Discovered at:  https://autoconfig.socioprophet.ai/mail/config-v1.1.xml?emailaddress=<addr>
+     and (fallback)  https://socioprophet.ai/.well-known/autoconfig/mail/config-v1.1.xml
+     %EMAILADDRESS% / %EMAILLOCALPART% are substituted by the client, so one file serves every user. -->
+<clientConfig version="1.1">
+  <emailProvider id="socioprophet.ai">
+    <domain>socioprophet.ai</domain>
+    <displayName>SocioProphet Workspace</displayName>
+    <displayShortName>SocioProphet</displayShortName>
+
+    <incomingServer type="imap">
+      <hostname>mail.socioprophet.ai</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+
+    <outgoingServer type="smtp">
+      <hostname>mail.socioprophet.ai</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+
+    <documentation url="https://socioprophet.ai/help/mail">
+      <descr lang="en">SocioProphet Workspace mail setup</descr>
+    </documentation>
+  </emailProvider>
+</clientConfig>

--- a/services/workspace-autoconfig/README.md
+++ b/services/workspace-autoconfig/README.md
@@ -1,0 +1,51 @@
+# workspace-autoconfig — zero-touch mail setup ("type email + password, done")
+
+The make-or-break of the SME promise: a user enters `you@socioprophet.ai` + password and every client
+configures itself. This directory holds the static discovery documents for all three ecosystems.
+
+## Canonical mail settings (single hostname — cert-clean)
+
+| | Host | Port | Security | Auth | Username |
+|---|---|---|---|---|---|
+| IMAP | `mail.socioprophet.ai` | 993 | implicit TLS (SSL) | password | full email |
+| SMTP submission | `mail.socioprophet.ai` | 587 | STARTTLS | password | full email |
+
+One hostname for both so the certbot cert (`-d mail.socioprophet.ai`) matches exactly — no `imap.`/`smtp.`
+hostname-vs-cert mismatch. `imap.socioprophet.ai` may later be added as a cert SAN + CNAME if desired.
+
+## Discovery mechanisms (what each client probes, in order)
+
+- **Thunderbird / K-9 / FairEmail / Evolution** → `https://autoconfig.socioprophet.ai/mail/config-v1.1.xml?emailaddress=<addr>`
+  then `https://socioprophet.ai/.well-known/autoconfig/mail/config-v1.1.xml`, then the DB, then SRV.
+  Served by: [`autoconfig/mail/config-v1.1.xml`](autoconfig/mail/config-v1.1.xml) (+ mirrored under `.well-known/`).
+- **Outlook / Windows Mail** → `https://autodiscover.socioprophet.ai/autodiscover/autodiscover.xml` (POST),
+  then `https://socioprophet.ai/autodiscover/...`, then SRV `_autodiscover._tcp`.
+  Served by: [`autodiscover/autodiscover.xml`](autodiscover/autodiscover.xml).
+- **Apple Mail (iOS/macOS)** → also reads the Mozilla autoconfig, OR install the one-tap profile
+  [`apple/socioprophet-mail.mobileconfig`](apple/socioprophet-mail.mobileconfig).
+- **DNS SRV** (already published by the `dns` module, PR #1137): `_imaps._tcp`, `_submission._tcp` — the
+  universal fallback so even clients that skip HTTP discovery land on the right host/port.
+
+## Serving (deployment — next step)
+
+A tiny static web layer over HTTPS. Two options, both sovereign:
+1. **On the mail VM** — add nginx to the VM cloud-init, add `autoconfig`/`autodiscover` to the certbot `-d`
+   list (both A records → the VM IP), serve this dir. Fewest moving parts; co-located with mail.
+2. **In-cluster** — a small nginx Deployment + Ingress + ManagedCertificate for `autoconfig.` / `autodiscover.`.
+
+Required DNS: `A autoconfig → <mail VM IP>`, `A autodiscover → <mail VM IP>` (or the ingress IP for option 2).
+Serve `.mobileconfig` as `Content-Type: application/x-apple-aspen-config`.
+
+## Hardening before GA
+
+- **Sign the `.mobileconfig`** (`openssl smime -sign` with a trusted cert) so iOS shows "Verified", not a warning.
+- **Dynamic autodiscover** responder that echoes the posted `<LoginName>` (a ~20-line handler) for the smoothest
+  Outlook path; the static file already covers the common case.
+- Add `autoconfig`/`autodiscover` (and optionally `imap`/`smtp`) as **cert SANs**.
+
+## Verify
+
+- Thunderbird: New Account → type address+password → should auto-fill `mail.socioprophet.ai` 993/587.
+- iOS: open the `.mobileconfig` URL in Safari → Install → enter address+password.
+- Outlook: Add Account → email → should discover IMAP/SMTP automatically.
+- `dig SRV _imaps._tcp.socioprophet.ai` → `mail.socioprophet.ai:993`.

--- a/services/workspace-autoconfig/apple/socioprophet-mail.mobileconfig
+++ b/services/workspace-autoconfig/apple/socioprophet-mail.mobileconfig
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Apple configuration profile: iPhone/iPad/Mac Mail in one tap.
+     EmailAddress + usernames are left EMPTY so Mail prompts the user (one profile fits all users).
+     NOTE: sign this profile (e.g. `openssl smime -sign` with a trusted cert) before serving, or
+     iOS shows "Unverified". Serve as application/x-apple-aspen-config over HTTPS. -->
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadType</key>                          <string>com.apple.mail.managed</string>
+      <key>PayloadVersion</key>                       <integer>1</integer>
+      <key>PayloadIdentifier</key>                    <string>ai.socioprophet.workspace.mail</string>
+      <key>PayloadUUID</key>                          <string>28DDFD3D-934D-45BF-89F9-B1ED87FE06BD</string>
+      <key>PayloadDisplayName</key>                   <string>SocioProphet Mail</string>
+
+      <key>EmailAccountType</key>                     <string>EmailTypeIMAP</string>
+      <key>EmailAccountName</key>                     <string>SocioProphet Workspace</string>
+      <key>EmailAccountDescription</key>              <string>SocioProphet</string>
+      <key>EmailAddress</key>                         <string></string>
+      <key>PreventMove</key>                          <false/>
+      <key>PreventAppSheet</key>                      <false/>
+      <key>SMIMEEnabled</key>                         <false/>
+
+      <key>IncomingMailServerHostName</key>           <string>mail.socioprophet.ai</string>
+      <key>IncomingMailServerPortNumber</key>         <integer>993</integer>
+      <key>IncomingMailServerUseSSL</key>             <true/>
+      <key>IncomingMailServerAuthentication</key>     <string>EmailAuthPassword</string>
+      <key>IncomingMailServerUsername</key>           <string></string>
+
+      <key>OutgoingMailServerHostName</key>           <string>mail.socioprophet.ai</string>
+      <key>OutgoingMailServerPortNumber</key>         <integer>587</integer>
+      <key>OutgoingMailServerUseSSL</key>             <true/>
+      <key>OutgoingMailServerAuthentication</key>     <string>EmailAuthPassword</string>
+      <key>OutgoingMailServerUsername</key>           <string></string>
+      <key>OutgoingPasswordSameAsIncomingPassword</key><true/>
+    </dict>
+  </array>
+  <key>PayloadType</key>            <string>Configuration</string>
+  <key>PayloadVersion</key>         <integer>1</integer>
+  <key>PayloadIdentifier</key>      <string>ai.socioprophet.workspace.mail.profile</string>
+  <key>PayloadUUID</key>            <string>EC0520AC-14C4-497D-BF4B-2AC32D4E5CD2</string>
+  <key>PayloadDisplayName</key>     <string>SocioProphet Workspace Mail</string>
+  <key>PayloadDescription</key>     <string>Configures Mail for your socioprophet.ai account.</string>
+  <key>PayloadOrganization</key>    <string>SocioProphet</string>
+  <key>PayloadRemovalDisallowed</key><false/>
+</dict>
+</plist>

--- a/services/workspace-autoconfig/autoconfig/mail/config-v1.1.xml
+++ b/services/workspace-autoconfig/autoconfig/mail/config-v1.1.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Mozilla ISPDB autoconfig (Thunderbird, K-9/FairEmail, GNOME Evolution, and others).
+     Discovered at:  https://autoconfig.socioprophet.ai/mail/config-v1.1.xml?emailaddress=<addr>
+     and (fallback)  https://socioprophet.ai/.well-known/autoconfig/mail/config-v1.1.xml
+     %EMAILADDRESS% / %EMAILLOCALPART% are substituted by the client, so one file serves every user. -->
+<clientConfig version="1.1">
+  <emailProvider id="socioprophet.ai">
+    <domain>socioprophet.ai</domain>
+    <displayName>SocioProphet Workspace</displayName>
+    <displayShortName>SocioProphet</displayShortName>
+
+    <incomingServer type="imap">
+      <hostname>mail.socioprophet.ai</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </incomingServer>
+
+    <outgoingServer type="smtp">
+      <hostname>mail.socioprophet.ai</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILADDRESS%</username>
+    </outgoingServer>
+
+    <documentation url="https://socioprophet.ai/help/mail">
+      <descr lang="en">SocioProphet Workspace mail setup</descr>
+    </documentation>
+  </emailProvider>
+</clientConfig>

--- a/services/workspace-autoconfig/autodiscover/autodiscover.xml
+++ b/services/workspace-autoconfig/autodiscover/autodiscover.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Microsoft Autodiscover (POX) for Outlook / Windows Mail.
+     Outlook POSTs the account email to:
+       https://autodiscover.socioprophet.ai/autodiscover/autodiscover.xml
+       (and https://socioprophet.ai/autodiscover/autodiscover.xml, and the SRV _autodiscover._tcp)
+     A static response works for IMAP; the serving layer (see README) should echo the posted
+     <LoginName> into <LoginName> below when it can, but Outlook falls back to prompting. -->
+<Autodiscover xmlns="http://schemas.microsoft.com/exchange/autodiscover/responseschema/2006">
+  <Response xmlns="http://schemas.microsoft.com/exchange/autodiscover/outlook/responseschema/2006a">
+    <Account>
+      <AccountType>email</AccountType>
+      <Action>settings</Action>
+      <Protocol>
+        <Type>IMAP</Type>
+        <Server>mail.socioprophet.ai</Server>
+        <Port>993</Port>
+        <DomainRequired>off</DomainRequired>
+        <SPA>off</SPA>
+        <SSL>on</SSL>
+        <Encryption>SSL</Encryption>
+        <AuthRequired>on</AuthRequired>
+      </Protocol>
+      <Protocol>
+        <Type>SMTP</Type>
+        <Server>mail.socioprophet.ai</Server>
+        <Port>587</Port>
+        <DomainRequired>off</DomainRequired>
+        <SPA>off</SPA>
+        <SSL>on</SSL>
+        <Encryption>TLS</Encryption>
+        <AuthRequired>on</AuthRequired>
+        <UsePOPAuth>off</UsePOPAuth>
+        <SMTPLast>off</SMTPLast>
+      </Protocol>
+    </Account>
+  </Response>
+</Autodiscover>


### PR DESCRIPTION
The 'type email + password, done' SME UX — static discovery docs for all three ecosystems, single cert-clean hostname (`mail.socioprophet.ai` for IMAP 993 + SMTP 587).

- **Mozilla ISPDB** `config-v1.1.xml` (Thunderbird/K-9/FairEmail/Evolution) + `.well-known` mirror
- **Microsoft Autodiscover** POX (Outlook/Windows Mail)
- **Apple** `.mobileconfig` one-tap profile (empty address → prompts, so one profile fits every user)
- **README** — discovery order, serving plan (nginx on the mail VM or in-cluster + `autoconfig`/`autodiscover` A records/SANs), and hardening (sign the profile, dynamic autodiscover responder)

Complements the SRV records the `dns` module already publishes (#1137). Validated: XML well-formed + `plutil -lint`. Serving deployment is the next step (README option 1 = fewest moving parts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)