### PR TITLE
feat(wordops): complete lease fabric — broker + JWT/DPoP gateway + containment + room-factory

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -85,6 +85,8 @@ jobs:
           - { image: agent-activity-ledger, context: apps/agent-activity-ledger, dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: gbrg-containment,      context: apps/gbrg-containment,      dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: wordops-mcp-gateway,   context: apps/wordops-mcp-gateway,   dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
+          - { image: wordops-capability-broker, context: apps/wordops-capability-broker, dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
+          - { image: wordops-room-factory,  context: apps/wordops-room-factory,  dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: portfolio-agent,       context: apps/portfolio-agent,       dockerfile: Dockerfile }
           - { image: academy-board,         context: apps/academy-board,         dockerfile: Dockerfile }
           - { image: health-twin,           context: apps/health-twin,           dockerfile: Dockerfile }

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -84,6 +84,7 @@ jobs:
           - { image: holmes,                context: apps/holmes,                dockerfile: Dockerfile }
           - { image: agent-activity-ledger, context: apps/agent-activity-ledger, dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: gbrg-containment,      context: apps/gbrg-containment,      dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
+          - { image: wordops-mcp-gateway,   context: apps/wordops-mcp-gateway,   dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: portfolio-agent,       context: apps/portfolio-agent,       dockerfile: Dockerfile }
           - { image: academy-board,         context: apps/academy-board,         dockerfile: Dockerfile }
           - { image: health-twin,           context: apps/health-twin,           dockerfile: Dockerfile }

--- a/apps/agent-activity-ledger/main.go
+++ b/apps/agent-activity-ledger/main.go
@@ -6,19 +6,25 @@
 //
 // Endpoints (bind 0.0.0.0:$PORT, default 8080):
 //
-//	GET /healthz     — liveness/readiness (chart probe path)
-//	GET /executions  — the ledger (trailing window); shape mirrors ExecutionReceipt
+//	GET  /healthz     — liveness/readiness (chart probe path)
+//	GET  /executions  — the ledger (trailing window); shape mirrors ExecutionReceipt
+//	POST /executions  — append a receipt (used by the WordOps MCP gateway); the
+//	                    ledger is the DURABLE sink, so governed side effects land
+//	                    here, not in a Matrix room. Malformed / self-contradictory
+//	                    receipts are rejected (the ledger has teeth).
 //
-// Fixture-backed for now (system-of-record store is the follow-on): the endpoint
-// returns governed, schema-shaped receipts so the cockpit renders REAL warrants
-// against a live service rather than a client fixture.
+// Store is in-memory for now (a persistent system-of-record is the follow-on);
+// POSTed receipts are hash-chained onto the fixture spine so the cockpit renders
+// REAL warrants against a live service.
 package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -34,6 +40,8 @@ type executionReceipt struct {
 	CapabilitiesHeld   []string `json:"capabilities_held"`
 	CapabilitiesUsed   []string `json:"capabilities_used"`
 	ProofArtifact      proof    `json:"proof_artifact"`
+	Blast              *blast   `json:"blast,omitempty"`
+	PreviousHash       string   `json:"previous_receipt_hash,omitempty"`
 	ReceiptHash        string   `json:"receipt_hash"`
 }
 type agent struct {
@@ -59,31 +67,95 @@ type proof struct {
 	SignedBy   string `json:"signed_by,omitempty"`
 	Replayable bool   `json:"replayable"`
 }
+type blast struct {
+	TargetNode     string `json:"target_node"`
+	ReachableCount int    `json:"reachable_count"`
+	Hops           int    `json:"hops"`
+}
 
-// ledger is the fixture spine until a persistent system-of-record store lands.
-var ledger = []executionReceipt{
-	{
-		SchemaVersion: "0.1.0", ExecutionReceiptID: "exec_hybrid_investigation_wiz_verified", ExecutedAt: "2026-07-31T15:09:04Z",
-		Agent:            agent{Name: "Hybrid Investigation Agent", Version: "1.1.0", Category: "investigation"},
-		Input:            input{Type: "external_alert", Ref: "alert_wiz_372688"},
-		Decision:         decision{Verdict: "allow", AuthorityBand: "recommend", LatencyMs: 12},
-		Verdict:          verdict{State: "verified", EpistemicLevel: "bounded"},
-		CapabilitiesHeld: []string{"cap_read_alerts", "cap_read_baseline", "cap_read_reputation"},
-		CapabilitiesUsed: []string{"cap_read_alerts", "cap_read_baseline", "cap_read_reputation"},
-		ProofArtifact:    proof{SHA256: "sha256:4f8b0c11a2e7d9f0", SignedBy: "warden", Replayable: true},
-		ReceiptHash:      "sha256:exec-hybrid-investigation-wiz-verified",
-	},
-	{
-		SchemaVersion: "0.1.0", ExecutionReceiptID: "exec_investigation_agent_denied", ExecutedAt: "2026-07-31T13:38:49Z",
-		Agent:            agent{Name: "Investigation Agent", Version: "1.0.2", Category: "investigation"},
-		Input:            input{Type: "event", Ref: "event_16517"},
-		Decision:         decision{Verdict: "block", AuthorityBand: "observe", LatencyMs: 8},
-		Verdict:          verdict{State: "denied", EpistemicLevel: "rejected"},
-		CapabilitiesHeld: []string{"cap_read_events"},
-		CapabilitiesUsed: []string{},
-		ProofArtifact:    proof{SHA256: "sha256:a0f12277b3c4d5e6", SignedBy: "warden", Replayable: true},
-		ReceiptHash:      "sha256:exec-investigation-agent-denied",
-	},
+var (
+	mu     sync.RWMutex
+	ledger = []executionReceipt{
+		{
+			SchemaVersion: "0.1.0", ExecutionReceiptID: "exec_hybrid_investigation_wiz_verified", ExecutedAt: "2026-07-31T15:09:04Z",
+			Agent:            agent{Name: "Hybrid Investigation Agent", Version: "1.1.0", Category: "investigation"},
+			Input:            input{Type: "external_alert", Ref: "alert_wiz_372688"},
+			Decision:         decision{Verdict: "allow", AuthorityBand: "recommend", LatencyMs: 12},
+			Verdict:          verdict{State: "verified", EpistemicLevel: "bounded"},
+			CapabilitiesHeld: []string{"cap_read_alerts", "cap_read_baseline", "cap_read_reputation"},
+			CapabilitiesUsed: []string{"cap_read_alerts", "cap_read_baseline", "cap_read_reputation"},
+			ProofArtifact:    proof{SHA256: "sha256:4f8b0c11a2e7d9f0", SignedBy: "warden", Replayable: true},
+			ReceiptHash:      "sha256:exec-hybrid-investigation-wiz-verified",
+		},
+		{
+			SchemaVersion: "0.1.0", ExecutionReceiptID: "exec_investigation_agent_denied", ExecutedAt: "2026-07-31T13:38:49Z",
+			Agent:            agent{Name: "Investigation Agent", Version: "1.0.2", Category: "investigation"},
+			Input:            input{Type: "event", Ref: "event_16517"},
+			Decision:         decision{Verdict: "block", AuthorityBand: "observe", LatencyMs: 8},
+			Verdict:          verdict{State: "denied", EpistemicLevel: "rejected"},
+			CapabilitiesHeld: []string{"cap_read_events"},
+			CapabilitiesUsed: []string{},
+			ProofArtifact:    proof{SHA256: "sha256:a0f12277b3c4d5e6", SignedBy: "warden", Replayable: true},
+			ReceiptHash:      "sha256:exec-investigation-agent-denied",
+		},
+	}
+)
+
+var (
+	validVerdict   = map[string]bool{"allow": true, "block": true, "require_approval": true, "degrade": true, "transform": true}
+	validState     = map[string]bool{"verified": true, "pending": true, "denied": true}
+	validAuthority = map[string]bool{"observe": true, "recommend": true, "queue": true, "execute_local": true, "execute_remote": true, "admin_override": true}
+)
+
+// validate enforces the ExecutionReceipt required fields, the critical enums, and
+// the contract's semantic invariants (the same ones the prophet-core-contracts
+// validator rejects). Returns a non-nil error naming the first violation.
+func validate(r executionReceipt) error {
+	switch {
+	case r.SchemaVersion != "0.1.0":
+		return fmt.Errorf("schema_version must be 0.1.0")
+	case r.ExecutionReceiptID == "":
+		return fmt.Errorf("execution_receipt_id is required")
+	case r.ExecutedAt == "":
+		return fmt.Errorf("executed_at is required")
+	case r.Agent.Name == "" || r.Agent.Version == "":
+		return fmt.Errorf("agent.name and agent.version are required")
+	case r.Input.Type == "":
+		return fmt.Errorf("input.type is required")
+	case !validVerdict[r.Decision.Verdict]:
+		return fmt.Errorf("decision.verdict %q is not a valid policy decision", r.Decision.Verdict)
+	case !validAuthority[r.Decision.AuthorityBand]:
+		return fmt.Errorf("decision.authority_band %q is not a valid authority band", r.Decision.AuthorityBand)
+	case !validState[r.Verdict.State]:
+		return fmt.Errorf("verdict.state %q is not verified|pending|denied", r.Verdict.State)
+	case r.ProofArtifact.SHA256 == "":
+		return fmt.Errorf("proof_artifact.sha256 is required")
+	case r.ReceiptHash == "":
+		return fmt.Errorf("receipt_hash is required")
+	}
+	// INV1: capabilities_used must be a subset of capabilities_held.
+	held := map[string]bool{}
+	for _, c := range r.CapabilitiesHeld {
+		held[c] = true
+	}
+	for _, c := range r.CapabilitiesUsed {
+		if !held[c] {
+			return fmt.Errorf("capabilities_used %q not in capabilities_held (INV1)", c)
+		}
+	}
+	// INV2: a verified verdict must be backed by a replayable artifact.
+	if r.Verdict.State == "verified" && !r.ProofArtifact.Replayable {
+		return fmt.Errorf("verified verdict requires a replayable proof_artifact (INV2)")
+	}
+	// INV3: block <=> denied.
+	if (r.Decision.Verdict == "block") != (r.Verdict.State == "denied") {
+		return fmt.Errorf("decision.verdict=block iff verdict.state=denied (INV3)")
+	}
+	// INV4: require_approval => pending.
+	if r.Decision.Verdict == "require_approval" && r.Verdict.State != "pending" {
+		return fmt.Errorf("require_approval requires verdict.state=pending (INV4)")
+	}
+	return nil
 }
 
 func writeJSON(w http.ResponseWriter, code int, v any) {
@@ -92,25 +164,65 @@ func writeJSON(w http.ResponseWriter, code int, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
+func handleExecutions(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		mu.RLock()
+		snapshot := make([]executionReceipt, len(ledger))
+		copy(snapshot, ledger)
+		mu.RUnlock()
+		writeJSON(w, http.StatusOK, map[string]any{
+			"generated_at": time.Now().UTC().Format(time.RFC3339),
+			"count":        len(snapshot),
+			"receipts":     snapshot,
+		})
+	case http.MethodPost:
+		var rec executionReceipt
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&rec); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid JSON: " + err.Error()})
+			return
+		}
+		if err := validate(rec); err != nil {
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{"error": err.Error(), "accepted": false})
+			return
+		}
+		mu.Lock()
+		if rec.PreviousHash == "" && len(ledger) > 0 {
+			rec.PreviousHash = ledger[len(ledger)-1].ReceiptHash // hash-chain onto the tip
+		}
+		ledger = append(ledger, rec)
+		count := len(ledger)
+		mu.Unlock()
+		writeJSON(w, http.StatusCreated, map[string]any{
+			"accepted":     true,
+			"receipt_hash": rec.ReceiptHash,
+			"count":        count,
+		})
+	default:
+		w.Header().Set("Allow", "GET, POST")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": "method not allowed"})
+	}
+}
+
+func newMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		mu.RLock()
+		n := len(ledger)
+		mu.RUnlock()
+		writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "service": "agent-activity-ledger", "receipts": n})
+	})
+	mux.HandleFunc("/executions", handleExecutions)
+	return mux
+}
+
 func main() {
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
 	}
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "service": "agent-activity-ledger", "receipts": len(ledger)})
-	})
-	mux.HandleFunc("/executions", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, http.StatusOK, map[string]any{
-			"generated_at": time.Now().UTC().Format(time.RFC3339),
-			"count":        len(ledger),
-			"receipts":     ledger,
-		})
-	})
-
-	log.Printf("agent-activity-ledger serving on :%s (/healthz /executions)", port)
-	if err := http.ListenAndServe("0.0.0.0:"+port, mux); err != nil {
+	log.Printf("agent-activity-ledger serving on :%s (GET/POST /executions, /healthz)", port)
+	if err := http.ListenAndServe("0.0.0.0:"+port, newMux()); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/apps/agent-activity-ledger/main_test.go
+++ b/apps/agent-activity-ledger/main_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func validReceipt() executionReceipt {
+	return executionReceipt{
+		SchemaVersion: "0.1.0", ExecutionReceiptID: "exec_test_ok", ExecutedAt: "2026-07-31T16:00:00Z",
+		Agent:            agent{Name: "WordOps MCP Gateway", Version: "0.1.0", Category: "response"},
+		Input:            input{Type: "detection", Ref: "CASE-1"},
+		Decision:         decision{Verdict: "allow", AuthorityBand: "execute_remote", LatencyMs: 20},
+		Verdict:          verdict{State: "verified", EpistemicLevel: "empirical"},
+		CapabilitiesHeld: []string{"cap_containment_sever"},
+		CapabilitiesUsed: []string{"cap_containment_sever"},
+		ProofArtifact:    proof{SHA256: "sha256:abc123", SignedBy: "wordops-mcp-gateway", Replayable: true},
+		ReceiptHash:      "sha256:exec-test-ok",
+	}
+}
+
+func post(t *testing.T, srv http.Handler, r executionReceipt) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(r)
+	req := httptest.NewRequest(http.MethodPost, "/executions", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestPostValidReceiptAccepted(t *testing.T) {
+	mux := newMux()
+	before := len(ledger)
+	rr := post(t, mux, validReceipt())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(ledger) != before+1 {
+		t.Fatalf("ledger not appended: before=%d after=%d", before, len(ledger))
+	}
+}
+
+func TestPostRejectsInvariantViolations(t *testing.T) {
+	cases := map[string]func(executionReceipt) executionReceipt{
+		"INV1 used-not-subset":         func(r executionReceipt) executionReceipt { r.CapabilitiesUsed = []string{"cap_not_held"}; return r },
+		"INV2 verified-not-replayable": func(r executionReceipt) executionReceipt { r.ProofArtifact.Replayable = false; return r },
+		"INV3 block-not-denied":        func(r executionReceipt) executionReceipt { r.Decision.Verdict = "block"; return r },
+		"INV4 approval-not-pending":    func(r executionReceipt) executionReceipt { r.Decision.Verdict = "require_approval"; return r },
+		"bad-verdict-enum":             func(r executionReceipt) executionReceipt { r.Verdict.State = "great"; return r },
+		"bad-authority-enum":           func(r executionReceipt) executionReceipt { r.Decision.AuthorityBand = "god_mode"; return r },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			mux := newMux()
+			before := len(ledger)
+			rr := post(t, mux, mutate(validReceipt()))
+			if rr.Code != http.StatusUnprocessableEntity {
+				t.Fatalf("%s: want 422, got %d: %s", name, rr.Code, rr.Body.String())
+			}
+			if len(ledger) != before {
+				t.Fatalf("%s: a rejected receipt must not be appended", name)
+			}
+		})
+	}
+}
+
+func TestGetReturnsLedger(t *testing.T) {
+	mux := newMux()
+	req := httptest.NewRequest(http.MethodGet, "/executions", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	var out struct {
+		Count    int                `json:"count"`
+		Receipts []executionReceipt `json:"receipts"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if out.Count != len(out.Receipts) || out.Count < 2 {
+		t.Fatalf("unexpected count=%d len=%d", out.Count, len(out.Receipts))
+	}
+}

--- a/apps/wordops-capability-broker/Dockerfile
+++ b/apps/wordops-capability-broker/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7
+# wordops-capability-broker — WordOps service (Go, stdlib-only, single main.go). Binds 0.0.0.0:8080.
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go.mod ./
+COPY *.go ./
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /wordops-capability-broker .
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /wordops-capability-broker /wordops-capability-broker
+ENV PORT=8080
+EXPOSE 8080
+ENTRYPOINT ["/wordops-capability-broker"]

--- a/apps/wordops-capability-broker/go.mod
+++ b/apps/wordops-capability-broker/go.mod
@@ -1,0 +1,3 @@
+module wordops-capability-broker
+
+go 1.22

--- a/apps/wordops-capability-broker/main.go
+++ b/apps/wordops-capability-broker/main.go
@@ -1,0 +1,300 @@
+// wordops-capability-broker — mints down-scoped, signed capability-leases (Go, stdlib-only).
+//
+// The issuance side of the WordOps lease fabric. It runs the A0–A4 approval-to-lease
+// policy (allow_issue — the estate's own autonomy ladder, mirroring
+// infra/wordops/opa/lease_policy.rego) and, on allow, mints a short-lived RS256-signed
+// capability-lease JWT. The wordops-mcp-gateway verifies these against this broker's
+// JWKS, so a lease can no longer be spoofed by hand-crafting JSON.
+//
+// Endpoints (bind 0.0.0.0:$PORT, default 8080):
+//
+//	GET  /healthz              — liveness/readiness
+//	GET  /.well-known/jwks.json — public verify key(s) (RFC 7517)
+//	POST /lease                — run allow_issue; on allow, mint a signed lease JWT
+//
+// Signing key: WORDOPS_BROKER_SIGNING_KEY (PEM PKCS#8 or PKCS#1 RSA private key). If
+// unset, an ephemeral key is generated at boot (dev only — the JWKS still lets the
+// gateway verify within the process lifetime). Production mounts a Secret.
+package main
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"math/big"
+	"net/http"
+	"os"
+	"time"
+)
+
+const issuer = "https://auth.socioprophet.ai/realms/wordops/wordops-capability-broker"
+
+// ---------------------------------------------------------------------------
+// A0–A4 issuance policy (mirror of wordops.authz.allow_issue)
+// ---------------------------------------------------------------------------
+
+type issueRequest struct {
+	User struct {
+		ID    string   `json:"id"`
+		Roles []string `json:"roles"`
+	} `json:"user"`
+	Agent struct {
+		ID string `json:"id"`
+	} `json:"agent"`
+	Request struct {
+		Aud                 string   `json:"aud"`
+		Scope               []string `json:"scope"`
+		RiskClass           string   `json:"risk_class"`
+		CaseID              string   `json:"case_id"`
+		TaskID              string   `json:"task_id"`
+		TTLSeconds          int      `json:"ttl_seconds"`
+		ApprovalID          string   `json:"approval_id"`
+		StepUpSatisfied     bool     `json:"step_up_satisfied"`
+		BreakGlass          bool     `json:"break_glass"`
+		BreakGlassPolicyRef string   `json:"break_glass_policy_ref"`
+		DPoPJKT             string   `json:"dpop_jkt"`
+	} `json:"request"`
+}
+
+var ttlCeiling = map[string]int{"A0": 900, "A1": 900, "A2": 120, "A3": 60, "A4": 30}
+
+func hasRole(roles []string, allowed map[string]bool) bool {
+	for _, r := range roles {
+		if allowed[r] {
+			return true
+		}
+	}
+	return false
+}
+
+func allPrefixed(scopes []string, prefixes ...string) bool {
+	for _, s := range scopes {
+		ok := false
+		for _, p := range prefixes {
+			if len(s) >= len(p) && s[:len(p)] == p {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	return len(scopes) > 0
+}
+
+func isContainmentScope(scopes []string) bool {
+	for _, s := range scopes {
+		if len(s) >= 17 && s[:17] == "containment:sever" {
+			return true
+		}
+	}
+	return false
+}
+
+// allowIssue returns (true,"") when the broker may mint, else (false, reason).
+func allowIssue(r issueRequest) (bool, string) {
+	rc := r.Request.RiskClass
+	ceil, known := ttlCeiling[rc]
+	if !known {
+		return false, "unknown risk_class " + rc
+	}
+	if r.Request.TTLSeconds <= 0 || r.Request.TTLSeconds > ceil {
+		return false, fmt.Sprintf("ttl_seconds must be 1..%d for %s", ceil, rc)
+	}
+	if isContainmentScope(r.Request.Scope) && rc != "A4" {
+		return false, "containment sever is intrinsically risk_class A4"
+	}
+	switch rc {
+	case "A0":
+		if !allPrefixed(r.Request.Scope, "read:") {
+			return false, "A0 permits only read: scopes"
+		}
+	case "A1":
+		if !allPrefixed(r.Request.Scope, "draft:", "propose:") {
+			return false, "A1 permits only draft:/propose: scopes"
+		}
+	case "A2":
+		if !hasRole(r.User.Roles, map[string]bool{"ops-operator": true, "ops-admin": true}) {
+			return false, "A2 requires ops-operator/ops-admin"
+		}
+	case "A3":
+		if !hasRole(r.User.Roles, map[string]bool{"change-approver": true, "ops-admin": true}) {
+			return false, "A3 requires change-approver/ops-admin"
+		}
+		if r.Request.ApprovalID == "" || !r.Request.StepUpSatisfied {
+			return false, "A3 requires approval_id and satisfied step-up"
+		}
+	case "A4":
+		if !hasRole(r.User.Roles, map[string]bool{"responder": true, "incident-commander": true, "ops-admin": true}) {
+			return false, "A4 requires responder/incident-commander/ops-admin"
+		}
+		authorized := r.Request.ApprovalID != "" || (r.Request.BreakGlass && r.Request.BreakGlassPolicyRef != "")
+		if !authorized || !r.Request.StepUpSatisfied {
+			return false, "A4 requires approval_id (or documented break-glass) and satisfied step-up"
+		}
+	}
+	if r.Request.CaseID == "" || r.Request.TaskID == "" {
+		return false, "case_id and task_id binding required"
+	}
+	return true, ""
+}
+
+// ---------------------------------------------------------------------------
+// JOSE (RS256) — stdlib
+// ---------------------------------------------------------------------------
+
+func b64url(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+
+// jwkThumbprint is the RFC 7638 SHA-256 thumbprint of an RSA public key.
+func jwkThumbprint(pub *rsa.PublicKey) string {
+	e := big.NewInt(int64(pub.E)).Bytes()
+	canon := fmt.Sprintf(`{"e":%q,"kty":"RSA","n":%q}`, b64url(e), b64url(pub.N.Bytes()))
+	sum := sha256.Sum256([]byte(canon))
+	return b64url(sum[:])
+}
+
+func publicJWK(pub *rsa.PublicKey, kid string) map[string]any {
+	e := big.NewInt(int64(pub.E)).Bytes()
+	return map[string]any{
+		"kty": "RSA", "use": "sig", "alg": "RS256", "kid": kid,
+		"n": b64url(pub.N.Bytes()), "e": b64url(e),
+	}
+}
+
+func signJWT(key *rsa.PrivateKey, kid string, claims map[string]any) (string, error) {
+	header := map[string]any{"alg": "RS256", "typ": "JWT", "kid": kid}
+	hb, _ := json.Marshal(header)
+	cb, _ := json.Marshal(claims)
+	signingInput := b64url(hb) + "." + b64url(cb)
+	sum := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, sum[:])
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + b64url(sig), nil
+}
+
+// ---------------------------------------------------------------------------
+// server
+// ---------------------------------------------------------------------------
+
+type broker struct {
+	key *rsa.PrivateKey
+	kid string
+}
+
+func loadOrGenerateKey() (*rsa.PrivateKey, error) {
+	pemStr := os.Getenv("WORDOPS_BROKER_SIGNING_KEY")
+	if pemStr == "" {
+		log.Printf("WARNING: no WORDOPS_BROKER_SIGNING_KEY set — generating an EPHEMERAL dev key")
+		return rsa.GenerateKey(rand.Reader, 2048)
+	}
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, fmt.Errorf("WORDOPS_BROKER_SIGNING_KEY is not valid PEM")
+	}
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return k, nil
+	}
+	k, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("unsupported private key: %w", err)
+	}
+	rk, ok := k.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("signing key must be RSA")
+	}
+	return rk, nil
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func (b *broker) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"keys": []map[string]any{publicJWK(&b.key.PublicKey, b.kid)}})
+}
+
+func (b *broker) handleLease(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": "method not allowed"})
+		return
+	}
+	var req issueRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+	if ok, reason := allowIssue(req); !ok {
+		writeJSON(w, http.StatusForbidden, map[string]any{"issued": false, "reason": reason})
+		return
+	}
+	now := time.Now().UTC()
+	exp := now.Add(time.Duration(req.Request.TTLSeconds) * time.Second)
+	jti := newJTI()
+	claims := map[string]any{
+		"iss": issuer, "sub": req.Agent.ID, "act": req.User.ID,
+		"aud": req.Request.Aud, "scope": req.Request.Scope,
+		"case_id": req.Request.CaseID, "task_id": req.Request.TaskID,
+		"risk_class": req.Request.RiskClass, "approval_id": req.Request.ApprovalID,
+		"nbf": now.Unix(), "exp": exp.Unix(), "iat": now.Unix(), "jti": jti,
+	}
+	if req.Request.DPoPJKT != "" {
+		claims["dpop_jkt"] = req.Request.DPoPJKT // bind the lease to the caller's DPoP key
+	}
+	token, err := signJWT(b.key, b.kid, claims)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "sign failed"})
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"issued": true, "lease_token": token, "jti": jti,
+		"expires_at": exp.Format(time.RFC3339), "risk_class": req.Request.RiskClass,
+	})
+}
+
+func newJTI() string {
+	var b [12]byte
+	_, _ = rand.Read(b[:])
+	var n uint64
+	n = binary.BigEndian.Uint64(b[:8])
+	return "lease_" + fmt.Sprintf("%x", n)
+}
+
+func (b *broker) mux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "service": "wordops-capability-broker", "kid": b.kid})
+	})
+	mux.HandleFunc("/.well-known/jwks.json", b.handleJWKS)
+	mux.HandleFunc("/lease", b.handleLease)
+	return mux
+}
+
+func main() {
+	key, err := loadOrGenerateKey()
+	if err != nil {
+		log.Fatal(err)
+	}
+	b := &broker{key: key, kid: jwkThumbprint(&key.PublicKey)}
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Printf("wordops-capability-broker serving on :%s (kid=%s)", port, b.kid)
+	if err := http.ListenAndServe("0.0.0.0:"+port, b.mux()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/apps/wordops-capability-broker/main_test.go
+++ b/apps/wordops-capability-broker/main_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func testBroker(t *testing.T) *broker {
+	t.Helper()
+	k, err := loadOrGenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &broker{key: k, kid: jwkThumbprint(&k.PublicKey)}
+}
+
+func a4IssueReq() issueRequest {
+	var r issueRequest
+	r.User.ID = "user:responder"
+	r.User.Roles = []string{"responder"}
+	r.Agent.ID = "agent:containment"
+	r.Request.Aud = "mcp://gbrg-containment"
+	r.Request.Scope = []string{"containment:sever:full"}
+	r.Request.RiskClass = "A4"
+	r.Request.CaseID = "CASE-INC-1"
+	r.Request.TaskID = "TASK-1"
+	r.Request.TTLSeconds = 30
+	r.Request.ApprovalID = "APR-INC-1"
+	r.Request.StepUpSatisfied = true
+	r.Request.DPoPJKT = "thumb-abc"
+	return r
+}
+
+func TestAllowIssueMatrix(t *testing.T) {
+	ok := func(mut func(*issueRequest)) bool {
+		r := a4IssueReq()
+		mut(&r)
+		allow, _ := allowIssue(r)
+		return allow
+	}
+	if !ok(func(r *issueRequest) {}) {
+		t.Fatal("valid A4 must issue")
+	}
+	if ok(func(r *issueRequest) { r.Request.RiskClass = "A2" }) {
+		t.Fatal("containment below A4 must be denied")
+	}
+	if ok(func(r *issueRequest) { r.Request.TTLSeconds = 31 }) {
+		t.Fatal("A4 ttl over 30 must be denied")
+	}
+	if ok(func(r *issueRequest) { r.Request.ApprovalID = ""; r.Request.BreakGlass = false }) {
+		t.Fatal("A4 without approval or break-glass must be denied")
+	}
+	if !ok(func(r *issueRequest) {
+		r.Request.ApprovalID = ""
+		r.Request.BreakGlass = true
+		r.Request.BreakGlassPolicyRef = "policy://break-glass/v1"
+	}) {
+		t.Fatal("A4 break-glass with policy ref must issue")
+	}
+	if ok(func(r *issueRequest) { r.User.Roles = []string{"intern"} }) {
+		t.Fatal("A4 without responder role must be denied")
+	}
+	if ok(func(r *issueRequest) { r.Request.CaseID = "" }) {
+		t.Fatal("missing case binding must be denied")
+	}
+}
+
+// verifyWithJWKS reconstructs the RSA key from the broker's JWKS and verifies the JWT.
+func verifyWithJWKS(t *testing.T, b *broker, token string) map[string]any {
+	t.Helper()
+	jwks := httptest.NewRecorder()
+	b.mux().ServeHTTP(jwks, httptest.NewRequest(http.MethodGet, "/.well-known/jwks.json", nil))
+	var ks struct {
+		Keys []struct{ N, E, Kid string } `json:"keys"`
+	}
+	if err := json.Unmarshal(jwks.Body.Bytes(), &ks); err != nil || len(ks.Keys) == 0 {
+		t.Fatalf("bad jwks: %v", err)
+	}
+	nb, _ := base64.RawURLEncoding.DecodeString(ks.Keys[0].N)
+	eb, _ := base64.RawURLEncoding.DecodeString(ks.Keys[0].E)
+	pub := &rsa.PublicKey{N: new(big.Int).SetBytes(nb), E: int(new(big.Int).SetBytes(eb).Int64())}
+
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("token not a JWS: %q", token)
+	}
+	sum := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	sig, _ := base64.RawURLEncoding.DecodeString(parts[2])
+	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, sum[:], sig); err != nil {
+		t.Fatalf("signature does NOT verify against JWKS: %v", err)
+	}
+	cb, _ := base64.RawURLEncoding.DecodeString(parts[1])
+	var claims map[string]any
+	_ = json.Unmarshal(cb, &claims)
+	return claims
+}
+
+func TestLeaseMintedTokenVerifies(t *testing.T) {
+	b := testBroker(t)
+	body, _ := json.Marshal(a4IssueReq())
+	rr := httptest.NewRecorder()
+	b.mux().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/lease", bytes.NewReader(body)))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var out struct {
+		Issued     bool   `json:"issued"`
+		LeaseToken string `json:"lease_token"`
+	}
+	_ = json.Unmarshal(rr.Body.Bytes(), &out)
+	if !out.Issued || out.LeaseToken == "" {
+		t.Fatalf("no token issued: %s", rr.Body.String())
+	}
+	claims := verifyWithJWKS(t, b, out.LeaseToken)
+	if claims["aud"] != "mcp://gbrg-containment" || claims["risk_class"] != "A4" || claims["dpop_jkt"] != "thumb-abc" {
+		t.Fatalf("claims wrong: %v", claims)
+	}
+	if claims["case_id"] != "CASE-INC-1" {
+		t.Fatalf("case binding lost: %v", claims)
+	}
+}
+
+func TestLeaseDeniedBelowA4(t *testing.T) {
+	b := testBroker(t)
+	r := a4IssueReq()
+	r.Request.RiskClass = "A2"
+	body, _ := json.Marshal(r)
+	rr := httptest.NewRecorder()
+	b.mux().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/lease", bytes.NewReader(body)))
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", rr.Code)
+	}
+}

--- a/apps/wordops-mcp-gateway/Dockerfile
+++ b/apps/wordops-mcp-gateway/Dockerfile
@@ -5,7 +5,7 @@
 FROM golang:1.22-alpine AS build
 WORKDIR /src
 COPY go.mod ./
-COPY main.go ./
+COPY *.go ./
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /wordops-mcp-gateway .
 
 FROM gcr.io/distroless/static-debian12:nonroot

--- a/apps/wordops-mcp-gateway/Dockerfile
+++ b/apps/wordops-mcp-gateway/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.7
+# wordops-mcp-gateway — WordOps lease-enforcing MCP gateway (Go, stdlib-only, single main.go).
+# Authorizes capability-leases (audience/scope/case/task/expiry; containment ⇒ A4), calls
+# gbrg-containment, and writes the durable ExecutionReceipt to agent-activity-ledger. Binds 0.0.0.0:8080.
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go.mod ./
+COPY main.go ./
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /wordops-mcp-gateway .
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /wordops-mcp-gateway /wordops-mcp-gateway
+ENV PORT=8080
+EXPOSE 8080
+ENTRYPOINT ["/wordops-mcp-gateway"]

--- a/apps/wordops-mcp-gateway/README.md
+++ b/apps/wordops-mcp-gateway/README.md
@@ -54,11 +54,19 @@ cd apps/wordops-mcp-gateway && GOWORK=off go test ./...
 Sessions are **not** authentication (they are bound to the authenticated caller);
 durable workflow state lives outside MCP, in the ledger and the case kernel.
 
-## Security scope (honest)
+## Security
 
-This increment enforces the lease **claims** (audience/scope/case/task/expiry,
-containment ⇒ A4). It does **not** yet verify the lease's cryptographic
-authenticity — JWT signature + issuer (Keycloak JWKS) and DPoP proof-of-possession
-(`dpop_jkt`) are the next hardening step. Until then, treat the gateway as
-claim-enforcing, not identity-verifying, and keep it reachable only from inside the
-mesh. The token schema already carries `dpop_jkt` for the binding.
+The gateway verifies the lease's **cryptographic authenticity before** enforcing its
+claims (`jose.go`):
+
+1. `lease_token` is a broker-signed **RS256 JWT**, verified against the
+   `wordops-capability-broker` **JWKS** by `kid`, with `iss` and the `nbf`/`exp`
+   window checked. Wrong-key, expired, or tampered tokens are rejected `401` and
+   audited as denied.
+2. If the lease is sender-constrained (`dpop_jkt`), the caller must send a **DPoP**
+   proof header (RFC 9449) that self-signs with the bound key, whose JWK thumbprint
+   equals `dpop_jkt`, and whose `htm`/`htu`/`iat` bind it to this request.
+3. Only then are the claims (audience/scope/case/task, containment ⇒ A4) enforced.
+
+RSA/RS256 throughout (broker + DPoP). EC/ES256 is a mechanical addition. Configure
+`BROKER_JWKS_URL` + `BROKER_ISSUER`.

--- a/apps/wordops-mcp-gateway/README.md
+++ b/apps/wordops-mcp-gateway/README.md
@@ -1,0 +1,64 @@
+# wordops-mcp-gateway
+
+The WordOps lease-enforcing MCP gateway — the enforcement point where a
+capability-lease is checked and a durable `ExecutionReceipt` is written. Matrix
+rooms are collaboration context; **this gateway + the ledger are the authorization
+sink**, never a room.
+
+See [`docs/WORDOPS_REFERENCE_FLOW.md`](../../docs/WORDOPS_REFERENCE_FLOW.md) for the
+end-to-end incident → containment flow.
+
+## Endpoints
+
+| Method + path | Purpose |
+|---|---|
+| `GET /healthz` | liveness/readiness |
+| `GET /.well-known/oauth-protected-resource` | Protected Resource Metadata (RFC 9728): resource + Keycloak authorization server + scopes |
+| `POST /mcp/invoke` | privileged tool call under a capability-lease |
+| `DELETE /mcp/session` | explicit session teardown (`MCP-Session-Id`) |
+
+## Enforcement (`POST /mcp/invoke`)
+
+Body: `{ "lease": <capability-lease>, "tool": {name, audience, required_scope}, "params": {scope} }`.
+The gateway authorizes the lease — mirroring OPA `wordops.authz.allow_action` plus
+expiry and case/task binding:
+
+- lease active (now within `[not_before, expires_at]`; malformed window → fail closed)
+- `tool.audience` ∈ lease `aud` (string or array)
+- `tool.required_scope` ∈ lease `scope`
+- `case_id` + `task_id` present
+- a `containment:sever*` scope is intrinsically **risk_class A4**
+
+On **allow**: calls `gbrg-containment`, maps the `ContainmentProofArtifact` to a
+verdict (`PROVED` → `verified`; a no-op `INCONCLUSIVE` sever → `pending`, never
+verified), and `POST`s an `ExecutionReceipt` to the ledger.
+On **deny**: fails closed **and** writes a `block`/`denied` receipt — A4 is heavily
+audited (teeth both ways).
+
+## Config (env)
+
+| Var | Default |
+|---|---|
+| `PORT` | `8080` |
+| `GBRG_CONTAINMENT_URL` | `http://gbrg-containment:8080` |
+| `LEDGER_URL` | `http://agent-activity-ledger:8080` |
+| `AUTH_SERVER` | `https://auth.socioprophet.ai/realms/wordops` |
+| `RESOURCE_URL` | `https://agents.socioprophet.ai/mcp/wordops` |
+
+## Test
+
+```sh
+cd apps/wordops-mcp-gateway && GOWORK=off go test ./...
+```
+
+Sessions are **not** authentication (they are bound to the authenticated caller);
+durable workflow state lives outside MCP, in the ledger and the case kernel.
+
+## Security scope (honest)
+
+This increment enforces the lease **claims** (audience/scope/case/task/expiry,
+containment ⇒ A4). It does **not** yet verify the lease's cryptographic
+authenticity — JWT signature + issuer (Keycloak JWKS) and DPoP proof-of-possession
+(`dpop_jkt`) are the next hardening step. Until then, treat the gateway as
+claim-enforcing, not identity-verifying, and keep it reachable only from inside the
+mesh. The token schema already carries `dpop_jkt` for the binding.

--- a/apps/wordops-mcp-gateway/a2a/extended-agent-card.json
+++ b/apps/wordops-mcp-gateway/a2a/extended-agent-card.json
@@ -1,0 +1,40 @@
+{
+  "name": "WordOps Containment Agent",
+  "description": "Authenticated containment agent. Privileged skills (endpoint sever) require a short-lived A4 capability-lease and are enforced at the WordOps MCP gateway; every action produces an ExecutionReceipt in the ledger.",
+  "version": "0.1.0",
+  "url": "https://agents.socioprophet.ai/a2a/wordops-containment",
+  "provider": { "organization": "SocioProphet", "url": "https://socioprophet.ai" },
+  "capabilities": { "streaming": true, "pushNotifications": true, "extendedAgentCard": true },
+  "securitySchemes": {
+    "oidc": { "type": "openIdConnect", "openIdConnectUrl": "https://auth.socioprophet.ai/realms/wordops/.well-known/openid-configuration" }
+  },
+  "security": [{ "oidc": [] }],
+  "defaultInputModes": ["text/plain", "application/json"],
+  "defaultOutputModes": ["text/plain", "application/json"],
+  "skills": [
+    {
+      "id": "containment.explain",
+      "name": "Explain containment posture",
+      "description": "Describe how endpoint isolation / blast-radius containment works and what governance applies. Read-only.",
+      "tags": ["public", "read-only", "discovery"]
+    },
+    {
+      "id": "executions.read",
+      "name": "Read the executions ledger",
+      "description": "Return recent governed agent-execution receipts (verdict + warrant). Read-only.",
+      "tags": ["authenticated", "read-only", "ledger"]
+    },
+    {
+      "id": "containment.preview-blast-radius",
+      "name": "Preview blast radius",
+      "description": "Compute the reachable set and residual-after-sever for an endpoint via gbrg-containment. Read-only; no network is severed.",
+      "tags": ["authenticated", "read-only", "gbrg"]
+    },
+    {
+      "id": "containment.sever-endpoint",
+      "name": "Sever endpoint (isolate)",
+      "description": "Isolate an endpoint (full or selective). Intrinsically risk_class A4: requires an approved, step-up capability-lease bound to case + task; enforced at the MCP gateway and audited to the ledger.",
+      "tags": ["authenticated", "regulated", "lease-required", "A4", "step-up"]
+    }
+  ]
+}

--- a/apps/wordops-mcp-gateway/a2a/public-agent-card.json
+++ b/apps/wordops-mcp-gateway/a2a/public-agent-card.json
@@ -1,0 +1,28 @@
+{
+  "name": "WordOps Containment Agent",
+  "description": "Public, read-only view of the governed containment agent. Privileged actions are not exposed here — they live in the extended card and require a capability-lease.",
+  "version": "0.1.0",
+  "url": "https://agents.socioprophet.ai/a2a/wordops-containment",
+  "provider": { "organization": "SocioProphet", "url": "https://socioprophet.ai" },
+  "capabilities": { "streaming": true, "pushNotifications": true, "extendedAgentCard": true },
+  "securitySchemes": {
+    "oidc": { "type": "openIdConnect", "openIdConnectUrl": "https://auth.socioprophet.ai/realms/wordops/.well-known/openid-configuration" }
+  },
+  "security": [{ "oidc": [] }],
+  "defaultInputModes": ["text/plain", "application/json"],
+  "defaultOutputModes": ["text/plain", "application/json"],
+  "skills": [
+    {
+      "id": "containment.explain",
+      "name": "Explain containment posture",
+      "description": "Describe how endpoint isolation / blast-radius containment works and what governance applies. Read-only.",
+      "tags": ["public", "read-only", "discovery"]
+    },
+    {
+      "id": "executions.read",
+      "name": "Read the executions ledger",
+      "description": "Return recent governed agent-execution receipts (verdict + warrant). Read-only.",
+      "tags": ["public", "read-only", "ledger"]
+    }
+  ]
+}

--- a/apps/wordops-mcp-gateway/go.mod
+++ b/apps/wordops-mcp-gateway/go.mod
@@ -1,0 +1,3 @@
+module wordops-mcp-gateway
+
+go 1.22

--- a/apps/wordops-mcp-gateway/jose.go
+++ b/apps/wordops-mcp-gateway/jose.go
@@ -1,0 +1,270 @@
+package main
+
+// jose.go — lease-token (JWS) verification against the broker JWKS, plus DPoP
+// proof-of-possession (RFC 9449). This is the identity layer that makes the
+// gateway's claim enforcement trustworthy: a lease is a broker-signed RS256 JWT,
+// and (when the lease is DPoP-bound) the caller must prove possession of the key.
+//
+// stdlib-only. RSA/RS256 throughout (the estate's broker signs RSA; DPoP proofs
+// are RSA here too). EC/ES256 is a mechanical addition if a client needs it.
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+func b64urlDecode(s string) ([]byte, error) { return base64.RawURLEncoding.DecodeString(s) }
+func b64urlEncode(b []byte) string          { return base64.RawURLEncoding.EncodeToString(b) }
+
+type jwk struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+func (k jwk) rsaPublic() (*rsa.PublicKey, error) {
+	if k.Kty != "RSA" {
+		return nil, fmt.Errorf("unsupported kty %q", k.Kty)
+	}
+	nb, err := b64urlDecode(k.N)
+	if err != nil {
+		return nil, fmt.Errorf("bad n: %w", err)
+	}
+	eb, err := b64urlDecode(k.E)
+	if err != nil {
+		return nil, fmt.Errorf("bad e: %w", err)
+	}
+	return &rsa.PublicKey{N: new(big.Int).SetBytes(nb), E: int(new(big.Int).SetBytes(eb).Int64())}, nil
+}
+
+// rfc7638Thumbprint is the SHA-256 JWK thumbprint of an RSA JWK (must match the
+// broker's jwkThumbprint and the `dpop_jkt` claim).
+func (k jwk) rfc7638Thumbprint() string {
+	canon := fmt.Sprintf(`{"e":%q,"kty":"RSA","n":%q}`, k.E, k.N)
+	sum := sha256.Sum256([]byte(canon))
+	return b64urlEncode(sum[:])
+}
+
+func verifyRS256(pub *rsa.PublicKey, signingInput, sigB64 string) error {
+	sig, err := b64urlDecode(sigB64)
+	if err != nil {
+		return fmt.Errorf("bad signature encoding: %w", err)
+	}
+	sum := sha256.Sum256([]byte(signingInput))
+	return rsa.VerifyPKCS1v15(pub, crypto.SHA256, sum[:], sig)
+}
+
+func splitJWS(token string) (header, payload, sig string, err error) {
+	p := strings.Split(token, ".")
+	if len(p) != 3 {
+		return "", "", "", fmt.Errorf("not a compact JWS")
+	}
+	return p[0], p[1], p[2], nil
+}
+
+func decodeJSON(seg string, v any) error {
+	b, err := b64urlDecode(seg)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
+}
+
+// ---------------------------------------------------------------------------
+// JWKS cache
+// ---------------------------------------------------------------------------
+
+type jwksCache struct {
+	url     string
+	client  *http.Client
+	mu      sync.Mutex
+	keys    map[string]*rsa.PublicKey
+	fetched time.Time
+}
+
+func newJWKSCache(url string, client *http.Client) *jwksCache {
+	return &jwksCache{url: url, client: client, keys: map[string]*rsa.PublicKey{}}
+}
+
+func (c *jwksCache) refresh() error {
+	resp, err := c.client.Get(c.url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("jwks endpoint returned %d", resp.StatusCode)
+	}
+	var set struct {
+		Keys []jwk `json:"keys"`
+	}
+	if err := json.Unmarshal(body, &set); err != nil {
+		return err
+	}
+	next := map[string]*rsa.PublicKey{}
+	for _, k := range set.Keys {
+		if pub, err := k.rsaPublic(); err == nil {
+			next[k.Kid] = pub
+		}
+	}
+	c.mu.Lock()
+	c.keys, c.fetched = next, time.Now()
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *jwksCache) keyFor(kid string) (*rsa.PublicKey, error) {
+	c.mu.Lock()
+	pub, ok := c.keys[kid]
+	stale := time.Since(c.fetched) > 5*time.Minute
+	c.mu.Unlock()
+	if ok && !stale {
+		return pub, nil
+	}
+	if err := c.refresh(); err != nil && !ok {
+		return nil, err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if pub, ok := c.keys[kid]; ok {
+		return pub, nil
+	}
+	return nil, fmt.Errorf("no verify key for kid %q", kid)
+}
+
+// ---------------------------------------------------------------------------
+// lease-token verification
+// ---------------------------------------------------------------------------
+
+type leaseClaims struct {
+	Iss        string   `json:"iss"`
+	Sub        string   `json:"sub"`
+	Act        string   `json:"act"`
+	Aud        string   `json:"aud"`
+	Scope      []string `json:"scope"`
+	CaseID     string   `json:"case_id"`
+	TaskID     string   `json:"task_id"`
+	RiskClass  string   `json:"risk_class"`
+	ApprovalID string   `json:"approval_id"`
+	DPoPJKT    string   `json:"dpop_jkt"`
+	Nbf        int64    `json:"nbf"`
+	Exp        int64    `json:"exp"`
+	JTI        string   `json:"jti"`
+}
+
+// verifyLeaseToken checks signature (against the broker JWKS by kid), issuer, and
+// the nbf/exp window, and returns the verified claims.
+func (c *jwksCache) verifyLeaseToken(token, wantIssuer string, now time.Time) (*leaseClaims, error) {
+	h, p, s, err := splitJWS(token)
+	if err != nil {
+		return nil, err
+	}
+	var hdr struct{ Alg, Kid, Typ string }
+	if err := decodeJSON(h, &hdr); err != nil {
+		return nil, fmt.Errorf("bad header: %w", err)
+	}
+	if hdr.Alg != "RS256" {
+		return nil, fmt.Errorf("unexpected alg %q (want RS256)", hdr.Alg)
+	}
+	pub, err := c.keyFor(hdr.Kid)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyRS256(pub, h+"."+p, s); err != nil {
+		return nil, fmt.Errorf("lease signature does not verify: %w", err)
+	}
+	var cl leaseClaims
+	if err := decodeJSON(p, &cl); err != nil {
+		return nil, fmt.Errorf("bad claims: %w", err)
+	}
+	if wantIssuer != "" && cl.Iss != wantIssuer {
+		return nil, fmt.Errorf("unexpected issuer %q", cl.Iss)
+	}
+	nowU := now.Unix()
+	if cl.Nbf != 0 && nowU < cl.Nbf {
+		return nil, fmt.Errorf("lease not yet valid (nbf)")
+	}
+	if cl.Exp == 0 || nowU >= cl.Exp {
+		return nil, fmt.Errorf("lease expired")
+	}
+	return &cl, nil
+}
+
+// ---------------------------------------------------------------------------
+// DPoP proof-of-possession (RFC 9449)
+// ---------------------------------------------------------------------------
+
+// verifyDPoP checks a DPoP proof header: typ=dpop+jwt, self-signed by the embedded
+// JWK, the JWK thumbprint equals wantJKT, htm/htu bind it to THIS request, and iat
+// is fresh. Returns nil when the caller has proven possession of the bound key.
+func verifyDPoP(proof, wantJKT, htm, htu string, now time.Time) error {
+	if proof == "" {
+		return fmt.Errorf("DPoP header required: lease is sender-constrained (dpop_jkt)")
+	}
+	h, p, s, err := splitJWS(proof)
+	if err != nil {
+		return fmt.Errorf("malformed DPoP proof: %w", err)
+	}
+	var hdr struct {
+		Typ string `json:"typ"`
+		Alg string `json:"alg"`
+		JWK jwk    `json:"jwk"`
+	}
+	if err := decodeJSON(h, &hdr); err != nil {
+		return fmt.Errorf("bad DPoP header: %w", err)
+	}
+	if hdr.Typ != "dpop+jwt" {
+		return fmt.Errorf("DPoP proof typ must be dpop+jwt")
+	}
+	if hdr.Alg != "RS256" {
+		return fmt.Errorf("DPoP alg %q unsupported (want RS256)", hdr.Alg)
+	}
+	pub, err := hdr.JWK.rsaPublic()
+	if err != nil {
+		return fmt.Errorf("bad DPoP jwk: %w", err)
+	}
+	if err := verifyRS256(pub, h+"."+p, s); err != nil {
+		return fmt.Errorf("DPoP proof self-signature invalid: %w", err)
+	}
+	if got := hdr.JWK.rfc7638Thumbprint(); got != wantJKT {
+		return fmt.Errorf("DPoP key thumbprint %q does not match lease dpop_jkt %q", got, wantJKT)
+	}
+	var cl struct {
+		Htm string `json:"htm"`
+		Htu string `json:"htu"`
+		Iat int64  `json:"iat"`
+		Jti string `json:"jti"`
+	}
+	if err := decodeJSON(p, &cl); err != nil {
+		return fmt.Errorf("bad DPoP claims: %w", err)
+	}
+	if !strings.EqualFold(cl.Htm, htm) {
+		return fmt.Errorf("DPoP htm %q != request method %q", cl.Htm, htm)
+	}
+	if !strings.HasSuffix(cl.Htu, htu) {
+		return fmt.Errorf("DPoP htu %q does not bind this endpoint (%q)", cl.Htu, htu)
+	}
+	if cl.Iat == 0 || abs64(now.Unix()-cl.Iat) > 300 {
+		return fmt.Errorf("DPoP proof iat not fresh")
+	}
+	return nil
+}
+
+func abs64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/apps/wordops-mcp-gateway/main.go
+++ b/apps/wordops-mcp-gateway/main.go
@@ -24,13 +24,12 @@
 //	POST   /mcp/invoke                           — privileged tool call under a lease
 //	DELETE /mcp/session                          — explicit session teardown (MCP-Session-Id)
 //
-// SECURITY — honest scope of this increment: the gateway enforces the lease's
-// CLAIMS (audience/scope/case/task/expiry, containment⇒A4) but does NOT yet verify
-// the lease's cryptographic authenticity. Real deployment MUST front this with, or
-// add here, JWT signature + issuer (Keycloak JWKS) verification and DPoP
-// proof-of-possession (`dpop_jkt`) — otherwise the claims are spoofable by anyone
-// who can reach the gateway. That verification is the next hardening step; the
-// token schema (capability-lease-token) already carries `dpop_jkt` for it.
+// SECURITY: the gateway verifies the lease's cryptographic authenticity BEFORE
+// enforcing its claims. A lease is a broker-signed RS256 JWT (`lease_token`),
+// verified against the broker JWKS by kid, with issuer + nbf/exp checked. A
+// DPoP-bound lease (`dpop_jkt`) additionally requires a valid DPoP proof header
+// (RFC 9449) proving the caller holds the bound key. Only then are the claims
+// (audience/scope/case/task, containment⇒A4) enforced. See jose.go.
 package main
 
 import (
@@ -190,17 +189,40 @@ type config struct {
 	ledgerURL      string
 	authServer     string // Keycloak realm issuer for Protected Resource Metadata
 	resource       string
+	brokerJWKSURL  string // where the lease-signing broker publishes its verify keys
+	brokerIssuer   string // expected `iss` on a lease token ("" = skip issuer check)
+	invokePath     string // htu suffix a DPoP proof must bind to
 }
 
 type server struct {
 	cfg      config
 	client   *http.Client
+	jwks     *jwksCache
 	mu       sync.Mutex
 	sessions map[string]string // session-id -> subject (sessions are NOT authentication)
 }
 
 func newServer(cfg config) *server {
-	return &server{cfg: cfg, client: &http.Client{Timeout: 5 * time.Second}, sessions: map[string]string{}}
+	if cfg.invokePath == "" {
+		cfg.invokePath = "/mcp/invoke"
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	return &server{cfg: cfg, client: client, jwks: newJWKSCache(cfg.brokerJWKSURL, client), sessions: map[string]string{}}
+}
+
+// leaseFromClaims maps verified lease-token claims onto the internal lease shape so
+// the existing claim-authorization (audience/scope/case/task/expiry, containment⇒A4)
+// runs unchanged.
+func leaseFromClaims(cl *leaseClaims) lease {
+	return lease{
+		LeaseID: cl.JTI, Sub: cl.Sub, Act: cl.Act,
+		Aud:    json.RawMessage(fmt.Sprintf("%q", cl.Aud)),
+		Scope:  cl.Scope,
+		CaseID: cl.CaseID, TaskID: cl.TaskID, ApprovalID: cl.ApprovalID, RiskClass: cl.RiskClass,
+		NotBefore: time.Unix(cl.Nbf, 0).UTC().Format(time.RFC3339),
+		ExpiresAt: time.Unix(cl.Exp, 0).UTC().Format(time.RFC3339),
+		JTI:       cl.JTI,
+	}
 }
 
 func newID(prefix string) string {
@@ -264,9 +286,26 @@ func (s *server) sessionFor(r *http.Request, sub string) string {
 }
 
 type invokeReq struct {
-	Lease  lease          `json:"lease"`
-	Tool   toolReq        `json:"tool"`
-	Params map[string]any `json:"params"`
+	LeaseToken string         `json:"lease_token"`
+	Tool       toolReq        `json:"tool"`
+	Params     map[string]any `json:"params"`
+}
+
+// denyReceipt builds (and the caller emits) a governed block/denied receipt so every
+// refused attempt is audited — teeth fire both ways.
+func denyReceipt(caseRef string, heldScopes []string, reason string, latencyMs int, now time.Time) executionReceipt {
+	rec := executionReceipt{
+		SchemaVersion: "0.1.0", ExecutionReceiptID: newID("exec_deny_"), ExecutedAt: now.Format(time.RFC3339),
+		Agent:            agentRec{Name: "WordOps Containment Agent", Version: "0.1.0", Category: "response"},
+		Input:            inputRec{Type: "detection", Ref: caseRef},
+		Decision:         decRec{Verdict: "block", AuthorityBand: "observe", LatencyMs: latencyMs},
+		Verdict:          verRec{State: "denied", EpistemicLevel: "rejected"},
+		CapabilitiesHeld: heldScopes,
+		CapabilitiesUsed: []string{},
+		ProofArtifact:    proofRec{SHA256: "sha256:" + sha256Hex([]byte("deny:"+reason))},
+	}
+	sealReceipt(&rec)
+	return rec
 }
 
 func (s *server) handleInvoke(w http.ResponseWriter, r *http.Request) {
@@ -281,24 +320,41 @@ func (s *server) handleInvoke(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid JSON: " + err.Error()})
 		return
 	}
-	sid := s.sessionFor(r, req.Lease.Sub)
-	w.Header().Set("MCP-Session-Id", sid)
 	now := time.Now().UTC()
 
-	ok, reason := req.Lease.authorize(req.Tool, now)
-	if !ok {
-		// Fail closed, but audit the denial (A4 is heavily audited).
-		rec := executionReceipt{
-			SchemaVersion: "0.1.0", ExecutionReceiptID: newID("exec_deny_"), ExecutedAt: now.Format(time.RFC3339),
-			Agent:            agentRec{Name: "WordOps Containment Agent", Version: "0.1.0", Category: "response"},
-			Input:            inputRec{Type: "detection", Ref: req.Lease.CaseID},
-			Decision:         decRec{Verdict: "block", AuthorityBand: "observe", LatencyMs: int(time.Since(start).Milliseconds())},
-			Verdict:          verRec{State: "denied", EpistemicLevel: "rejected"},
-			CapabilitiesHeld: req.Lease.Scope,
-			CapabilitiesUsed: []string{},
-			ProofArtifact:    proofRec{SHA256: "sha256:" + sha256Hex([]byte("deny:"+reason))},
+	// 1. Verify the lease is a genuine, unexpired broker-signed token.
+	claims, err := s.jwks.verifyLeaseToken(req.LeaseToken, s.cfg.brokerIssuer, now)
+	if err != nil {
+		rec := denyReceipt("", nil, "lease-token invalid: "+err.Error(), int(time.Since(start).Milliseconds()), now)
+		emitted, _ := s.emit(rec)
+		writeJSON(w, http.StatusUnauthorized, map[string]any{
+			"admitted": false, "reason": "lease-token invalid: " + err.Error(),
+			"receipt_hash": rec.ReceiptHash, "ledger_recorded": emitted,
+		})
+		return
+	}
+
+	// 2. If the lease is sender-constrained, the caller must prove key possession.
+	if claims.DPoPJKT != "" {
+		if err := verifyDPoP(r.Header.Get("DPoP"), claims.DPoPJKT, http.MethodPost, s.cfg.invokePath, now); err != nil {
+			rec := denyReceipt(claims.CaseID, claims.Scope, "DPoP verification failed: "+err.Error(), int(time.Since(start).Milliseconds()), now)
+			emitted, _ := s.emit(rec)
+			writeJSON(w, http.StatusUnauthorized, map[string]any{
+				"admitted": false, "reason": "DPoP verification failed: " + err.Error(),
+				"receipt_hash": rec.ReceiptHash, "ledger_recorded": emitted,
+			})
+			return
 		}
-		sealReceipt(&rec)
+	}
+
+	lease := leaseFromClaims(claims)
+	sid := s.sessionFor(r, lease.Sub)
+	w.Header().Set("MCP-Session-Id", sid)
+
+	// 3. Enforce the (now-authentic) claims.
+	ok, reason := lease.authorize(req.Tool, now)
+	if !ok {
+		rec := denyReceipt(lease.CaseID, lease.Scope, reason, int(time.Since(start).Milliseconds()), now)
 		emitted, _ := s.emit(rec)
 		writeJSON(w, http.StatusForbidden, map[string]any{
 			"admitted": false, "reason": reason, "session_id": sid,
@@ -331,10 +387,10 @@ func (s *server) handleInvoke(w http.ResponseWriter, r *http.Request) {
 	rec := executionReceipt{
 		SchemaVersion: "0.1.0", ExecutionReceiptID: newID("exec_sever_"), ExecutedAt: now.Format(time.RFC3339),
 		Agent:            agentRec{Name: "WordOps Containment Agent", Version: "0.1.0", Category: "response"},
-		Input:            inputRec{Type: "detection", Ref: req.Lease.CaseID},
+		Input:            inputRec{Type: "detection", Ref: lease.CaseID},
 		Decision:         decRec{Verdict: "allow", AuthorityBand: "execute_remote", LatencyMs: int(time.Since(start).Milliseconds())},
 		Verdict:          verRec{State: state, EpistemicLevel: level},
-		CapabilitiesHeld: req.Lease.Scope,
+		CapabilitiesHeld: lease.Scope,
 		CapabilitiesUsed: []string{req.Tool.RequiredScope},
 		ProofArtifact:    proofRec{SHA256: "sha256:" + sha256Hex(artBytes)},
 	}
@@ -407,6 +463,9 @@ func main() {
 		ledgerURL:      env("LEDGER_URL", "http://agent-activity-ledger:8080"),
 		authServer:     env("AUTH_SERVER", "https://auth.socioprophet.ai/realms/wordops"),
 		resource:       env("RESOURCE_URL", "https://agents.socioprophet.ai/mcp/wordops"),
+		brokerJWKSURL:  env("BROKER_JWKS_URL", "http://wordops-capability-broker:8080/.well-known/jwks.json"),
+		brokerIssuer:   env("BROKER_ISSUER", "https://auth.socioprophet.ai/realms/wordops/wordops-capability-broker"),
+		invokePath:     "/mcp/invoke",
 	})
 	log.Printf("wordops-mcp-gateway serving on :%s (containment=%s ledger=%s)", port, s.cfg.containmentURL, s.cfg.ledgerURL)
 	if err := http.ListenAndServe("0.0.0.0:"+port, s.mux()); err != nil {

--- a/apps/wordops-mcp-gateway/main.go
+++ b/apps/wordops-mcp-gateway/main.go
@@ -1,0 +1,415 @@
+// wordops-mcp-gateway — the WordOps lease-enforcing MCP gateway (Go, stdlib-only).
+//
+// Front door for privileged agent tool calls in the WordOps Matrix fabric. It is
+// the enforcement point named in the reference pack ("the gateway enforces
+// audience, scope, case, task, expiry"; "durable workflow state lives outside
+// MCP"). Matrix rooms are collaboration context — they are NOT the authorization
+// ledger. This gateway is where a capability-lease is checked and where the
+// durable ExecutionReceipt is written to the ledger.
+//
+// Reference flow for a containment action:
+//
+//	incident room  ->  broker mints an A4 capability-lease  ->  POST /mcp/invoke
+//	   -> gateway authorizes the lease (audience/scope/case/task/expiry; a
+//	      containment sever is intrinsically risk_class A4)
+//	   -> on ALLOW: call gbrg-containment, build a governed ExecutionReceipt,
+//	      POST it to agent-activity-ledger, return a room-safe summary
+//	   -> on DENY: fail closed AND still write a denied ExecutionReceipt (A4 is
+//	      heavily audited — teeth fire both ways).
+//
+// Endpoints (bind 0.0.0.0:$PORT, default 8080):
+//
+//	GET    /healthz                              — liveness/readiness
+//	GET    /.well-known/oauth-protected-resource — Protected Resource Metadata (RFC 9728)
+//	POST   /mcp/invoke                           — privileged tool call under a lease
+//	DELETE /mcp/session                          — explicit session teardown (MCP-Session-Id)
+//
+// SECURITY — honest scope of this increment: the gateway enforces the lease's
+// CLAIMS (audience/scope/case/task/expiry, containment⇒A4) but does NOT yet verify
+// the lease's cryptographic authenticity. Real deployment MUST front this with, or
+// add here, JWT signature + issuer (Keycloak JWKS) verification and DPoP
+// proof-of-possession (`dpop_jkt`) — otherwise the claims are spoofable by anyone
+// who can reach the gateway. That verification is the next hardening step; the
+// token schema (capability-lease-token) already carries `dpop_jkt` for it.
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// capability-lease (the estate's canonical shape; aud may be string or []string)
+// ---------------------------------------------------------------------------
+
+type lease struct {
+	LeaseID    string          `json:"lease_id"`
+	Sub        string          `json:"sub"`
+	Act        string          `json:"act"`
+	Aud        json.RawMessage `json:"aud"`
+	Scope      []string        `json:"scope"`
+	CaseID     string          `json:"case_id"`
+	TaskID     string          `json:"task_id"`
+	ApprovalID string          `json:"approval_id"`
+	RiskClass  string          `json:"risk_class"`
+	NotBefore  string          `json:"not_before"`
+	ExpiresAt  string          `json:"expires_at"`
+	JTI        string          `json:"jti"`
+}
+
+func (l lease) audiences() []string {
+	if len(l.Aud) == 0 {
+		return nil
+	}
+	var one string
+	if err := json.Unmarshal(l.Aud, &one); err == nil {
+		return []string{one}
+	}
+	var many []string
+	_ = json.Unmarshal(l.Aud, &many)
+	return many
+}
+
+func (l lease) activeAt(now time.Time) bool {
+	nb, err1 := time.Parse(time.RFC3339, l.NotBefore)
+	exp, err2 := time.Parse(time.RFC3339, l.ExpiresAt)
+	if err1 != nil || err2 != nil {
+		return false // unparseable window => fail closed
+	}
+	return !now.Before(nb) && now.Before(exp)
+}
+
+type toolReq struct {
+	Name          string `json:"name"`
+	Audience      string `json:"audience"`
+	RequiredScope string `json:"required_scope"`
+}
+
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+func isContainment(scope string) bool { return len(scope) >= 17 && scope[:17] == "containment:sever" }
+
+// authorize mirrors OPA wordops.authz.allow_action plus expiry and case/task
+// binding. Returns (false, reason) on the first failed check so denials are legible.
+func (l lease) authorize(t toolReq, now time.Time) (bool, string) {
+	switch {
+	case !l.activeAt(now):
+		return false, "lease not active (expired, not yet valid, or malformed window)"
+	case !contains(l.audiences(), t.Audience):
+		return false, "audience mismatch: lease not scoped to " + t.Audience
+	case !contains(l.Scope, t.RequiredScope):
+		return false, "scope not covered: lease lacks " + t.RequiredScope
+	case l.CaseID == "" || l.TaskID == "":
+		return false, "case/task binding required"
+	case isContainment(t.RequiredScope) && l.RiskClass != "A4":
+		return false, "containment sever is intrinsically risk_class A4"
+	}
+	return true, ""
+}
+
+// ---------------------------------------------------------------------------
+// ExecutionReceipt (mirrors prophet-core-contracts/schemas/execution-receipt)
+// ---------------------------------------------------------------------------
+
+type executionReceipt struct {
+	SchemaVersion      string   `json:"schema_version"`
+	ExecutionReceiptID string   `json:"execution_receipt_id"`
+	ExecutedAt         string   `json:"executed_at"`
+	Agent              agentRec `json:"agent"`
+	Input              inputRec `json:"input"`
+	Decision           decRec   `json:"decision"`
+	Verdict            verRec   `json:"verdict"`
+	CapabilitiesHeld   []string `json:"capabilities_held"`
+	CapabilitiesUsed   []string `json:"capabilities_used"`
+	ProofArtifact      proofRec `json:"proof_artifact"`
+	ReceiptHash        string   `json:"receipt_hash"`
+}
+type agentRec struct {
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Category string `json:"category,omitempty"`
+}
+type inputRec struct {
+	Type string `json:"type"`
+	Ref  string `json:"ref,omitempty"`
+}
+type decRec struct {
+	Verdict       string `json:"verdict"`
+	AuthorityBand string `json:"authority_band"`
+	LatencyMs     int    `json:"latency_ms,omitempty"`
+}
+type verRec struct {
+	State          string `json:"state"`
+	EpistemicLevel string `json:"epistemic_level,omitempty"`
+}
+type proofRec struct {
+	SHA256     string `json:"sha256"`
+	SignedBy   string `json:"signed_by,omitempty"`
+	Replayable bool   `json:"replayable"`
+}
+
+func sha256Hex(b []byte) string { s := sha256.Sum256(b); return hex.EncodeToString(s[:]) }
+
+func sealReceipt(r *executionReceipt) {
+	r.ProofArtifact.SignedBy = "wordops-mcp-gateway"
+	r.ProofArtifact.Replayable = true
+	canon, _ := json.Marshal(struct {
+		ID   string   `json:"id"`
+		At   string   `json:"at"`
+		Dec  decRec   `json:"dec"`
+		Ver  verRec   `json:"ver"`
+		Used []string `json:"used"`
+		P    string   `json:"p"`
+	}{r.ExecutionReceiptID, r.ExecutedAt, r.Decision, r.Verdict, r.CapabilitiesUsed, r.ProofArtifact.SHA256})
+	r.ReceiptHash = "sha256:" + sha256Hex(canon)
+}
+
+// ---------------------------------------------------------------------------
+// server
+// ---------------------------------------------------------------------------
+
+type config struct {
+	containmentURL string
+	ledgerURL      string
+	authServer     string // Keycloak realm issuer for Protected Resource Metadata
+	resource       string
+}
+
+type server struct {
+	cfg      config
+	client   *http.Client
+	mu       sync.Mutex
+	sessions map[string]string // session-id -> subject (sessions are NOT authentication)
+}
+
+func newServer(cfg config) *server {
+	return &server{cfg: cfg, client: &http.Client{Timeout: 5 * time.Second}, sessions: map[string]string{}}
+}
+
+func newID(prefix string) string {
+	b := make([]byte, 12)
+	_, _ = rand.Read(b)
+	return prefix + hex.EncodeToString(b)
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// callContainment invokes gbrg-containment and returns the ContainmentProofArtifact.
+func (s *server) callContainment(scope string) (map[string]any, error) {
+	if scope != "selective" {
+		scope = "full"
+	}
+	resp, err := s.client.Get(s.cfg.containmentURL + "/containment?scope=" + scope)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("gbrg-containment returned %d", resp.StatusCode)
+	}
+	var art map[string]any
+	if err := json.Unmarshal(body, &art); err != nil {
+		return nil, err
+	}
+	return art, nil
+}
+
+// emit posts a receipt to the durable ledger. Best-effort: a ledger outage must
+// not turn a DENY into an ALLOW, so the caller's decision already stands.
+func (s *server) emit(r executionReceipt) (bool, error) {
+	body, _ := json.Marshal(r)
+	resp, err := s.client.Post(s.cfg.ledgerURL+"/executions", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	return resp.StatusCode == http.StatusCreated, nil
+}
+
+func (s *server) sessionFor(r *http.Request, sub string) string {
+	sid := r.Header.Get("MCP-Session-Id")
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if sid != "" {
+		if _, ok := s.sessions[sid]; ok {
+			return sid
+		}
+	}
+	sid = newID("mcp-sess-")
+	s.sessions[sid] = sub // bound to the authenticated caller (session != auth)
+	return sid
+}
+
+type invokeReq struct {
+	Lease  lease          `json:"lease"`
+	Tool   toolReq        `json:"tool"`
+	Params map[string]any `json:"params"`
+}
+
+func (s *server) handleInvoke(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": "method not allowed"})
+		return
+	}
+	start := time.Now()
+	var req invokeReq
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+	sid := s.sessionFor(r, req.Lease.Sub)
+	w.Header().Set("MCP-Session-Id", sid)
+	now := time.Now().UTC()
+
+	ok, reason := req.Lease.authorize(req.Tool, now)
+	if !ok {
+		// Fail closed, but audit the denial (A4 is heavily audited).
+		rec := executionReceipt{
+			SchemaVersion: "0.1.0", ExecutionReceiptID: newID("exec_deny_"), ExecutedAt: now.Format(time.RFC3339),
+			Agent:            agentRec{Name: "WordOps Containment Agent", Version: "0.1.0", Category: "response"},
+			Input:            inputRec{Type: "detection", Ref: req.Lease.CaseID},
+			Decision:         decRec{Verdict: "block", AuthorityBand: "observe", LatencyMs: int(time.Since(start).Milliseconds())},
+			Verdict:          verRec{State: "denied", EpistemicLevel: "rejected"},
+			CapabilitiesHeld: req.Lease.Scope,
+			CapabilitiesUsed: []string{},
+			ProofArtifact:    proofRec{SHA256: "sha256:" + sha256Hex([]byte("deny:"+reason))},
+		}
+		sealReceipt(&rec)
+		emitted, _ := s.emit(rec)
+		writeJSON(w, http.StatusForbidden, map[string]any{
+			"admitted": false, "reason": reason, "session_id": sid,
+			"receipt_hash": rec.ReceiptHash, "ledger_recorded": emitted,
+		})
+		return
+	}
+
+	// ALLOW: execute the tool. Only sever_endpoint is wired today.
+	if req.Tool.Name != "sever_endpoint" {
+		writeJSON(w, http.StatusNotImplemented, map[string]any{"error": "unknown tool: " + req.Tool.Name, "session_id": sid})
+		return
+	}
+	scope, _ := req.Params["scope"].(string)
+	art, err := s.callContainment(scope)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]any{"error": "containment backend: " + err.Error(), "session_id": sid})
+		return
+	}
+
+	// Honest verdict mapping: a no-op sever (INCONCLUSIVE / speculative) is PENDING,
+	// never a verified containment.
+	level, _ := art["epistemicLevel"].(string)
+	status, _ := art["status"].(string)
+	state := "pending"
+	if status == "PROVED" {
+		state = "verified"
+	}
+	artBytes, _ := json.Marshal(art)
+	rec := executionReceipt{
+		SchemaVersion: "0.1.0", ExecutionReceiptID: newID("exec_sever_"), ExecutedAt: now.Format(time.RFC3339),
+		Agent:            agentRec{Name: "WordOps Containment Agent", Version: "0.1.0", Category: "response"},
+		Input:            inputRec{Type: "detection", Ref: req.Lease.CaseID},
+		Decision:         decRec{Verdict: "allow", AuthorityBand: "execute_remote", LatencyMs: int(time.Since(start).Milliseconds())},
+		Verdict:          verRec{State: state, EpistemicLevel: level},
+		CapabilitiesHeld: req.Lease.Scope,
+		CapabilitiesUsed: []string{req.Tool.RequiredScope},
+		ProofArtifact:    proofRec{SHA256: "sha256:" + sha256Hex(artBytes)},
+	}
+	sealReceipt(&rec)
+	emitted, emitErr := s.emit(rec)
+	if emitErr != nil {
+		log.Printf("ledger emit failed (decision stands): %v", emitErr)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"admitted":        true,
+		"session_id":      sid,
+		"verdict":         state,
+		"summary":         fmt.Sprintf("severed %s scope on %v; %v of %v reachable nodes contained", art["severedScope"], art["source"], art["containedCount"], art["baselineReachableCount"]),
+		"receipt_hash":    rec.ReceiptHash,
+		"ledger_recorded": emitted,
+		"containment": map[string]any{
+			"severedScope":           art["severedScope"],
+			"containedCount":         art["containedCount"],
+			"residualReachableCount": art["residualReachableCount"],
+			"epistemicLevel":         level,
+		},
+	})
+}
+
+func (s *server) handleSessionDelete(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		w.Header().Set("Allow", "DELETE")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": "method not allowed"})
+		return
+	}
+	sid := r.Header.Get("MCP-Session-Id")
+	s.mu.Lock()
+	_, existed := s.sessions[sid]
+	delete(s.sessions, sid)
+	s.mu.Unlock()
+	writeJSON(w, http.StatusOK, map[string]any{"closed": existed, "session_id": sid})
+}
+
+func (s *server) handlePRM(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"resource":                 s.cfg.resource,
+		"authorization_servers":    []string{s.cfg.authServer},
+		"scopes_supported":         []string{"containment:sever:full", "containment:sever:selective", "read:executions"},
+		"bearer_methods_supported": []string{"header"},
+	})
+}
+
+func (s *server) mux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "service": "wordops-mcp-gateway"})
+	})
+	mux.HandleFunc("/.well-known/oauth-protected-resource", s.handlePRM)
+	mux.HandleFunc("/mcp/invoke", s.handleInvoke)
+	mux.HandleFunc("/mcp/session", s.handleSessionDelete)
+	return mux
+}
+
+func env(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	port := env("PORT", "8080")
+	s := newServer(config{
+		containmentURL: env("GBRG_CONTAINMENT_URL", "http://gbrg-containment:8080"),
+		ledgerURL:      env("LEDGER_URL", "http://agent-activity-ledger:8080"),
+		authServer:     env("AUTH_SERVER", "https://auth.socioprophet.ai/realms/wordops"),
+		resource:       env("RESOURCE_URL", "https://agents.socioprophet.ai/mcp/wordops"),
+	})
+	log.Printf("wordops-mcp-gateway serving on :%s (containment=%s ledger=%s)", port, s.cfg.containmentURL, s.cfg.ledgerURL)
+	if err := http.ListenAndServe("0.0.0.0:"+port, s.mux()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/apps/wordops-mcp-gateway/main_test.go
+++ b/apps/wordops-mcp-gateway/main_test.go
@@ -2,7 +2,14 @@ package main
 
 import (
 	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -10,7 +17,62 @@ import (
 	"time"
 )
 
-// fakeContainment returns a ContainmentProofArtifact; proved controls verified vs pending.
+const testIssuer = "https://auth.test/realms/wordops/wordops-capability-broker"
+
+// --- tiny JOSE signer (test-side broker) ---
+
+func be(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+
+func rsaJWK(pub *rsa.PublicKey, kid string) map[string]any {
+	e := big.NewInt(int64(pub.E)).Bytes()
+	m := map[string]any{"kty": "RSA", "n": be(pub.N.Bytes()), "e": be(e)}
+	if kid != "" {
+		m["kid"] = kid
+	}
+	return m
+}
+
+func kidOf(pub *rsa.PublicKey) string {
+	e := big.NewInt(int64(pub.E)).Bytes()
+	canon := fmt.Sprintf(`{"e":%q,"kty":"RSA","n":%q}`, be(e), be(pub.N.Bytes()))
+	s := sha256.Sum256([]byte(canon))
+	return be(s[:])
+}
+
+func signJWS(key *rsa.PrivateKey, header, claims map[string]any) string {
+	hb, _ := json.Marshal(header)
+	cb, _ := json.Marshal(claims)
+	in := be(hb) + "." + be(cb)
+	sum := sha256.Sum256([]byte(in))
+	sig, _ := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, sum[:])
+	return in + "." + be(sig)
+}
+
+func mintLease(key *rsa.PrivateKey, kid string, claims map[string]any) string {
+	base := map[string]any{"iss": testIssuer, "sub": "agent:containment", "act": "user:responder"}
+	for k, v := range claims {
+		base[k] = v
+	}
+	return signJWS(key, map[string]any{"alg": "RS256", "typ": "JWT", "kid": kid}, base)
+}
+
+func a4Claims() map[string]any {
+	now := time.Now().UTC()
+	return map[string]any{
+		"aud": "mcp://gbrg-containment", "scope": []string{"containment:sever:full"},
+		"case_id": "CASE-INC-1", "task_id": "TASK-1", "risk_class": "A4", "approval_id": "APR-1",
+		"nbf": now.Add(-time.Minute).Unix(), "exp": now.Add(25 * time.Second).Unix(), "jti": "lease_test",
+	}
+}
+
+func dpopProof(key *rsa.PrivateKey, htm, htu string, iat int64) string {
+	return signJWS(key,
+		map[string]any{"typ": "dpop+jwt", "alg": "RS256", "jwk": rsaJWK(&key.PublicKey, "")},
+		map[string]any{"htm": htm, "htu": htu, "iat": iat, "jti": "dpop-1"})
+}
+
+// --- backends ---
+
 func fakeContainment(proved bool) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		level, status, contained := "empirical", "PROVED", 3
@@ -25,7 +87,6 @@ func fakeContainment(proved bool) *httptest.Server {
 	}))
 }
 
-// capturingLedger records posted receipts and applies the block<=>denied invariant.
 type capturingLedger struct {
 	srv  *httptest.Server
 	mu   sync.Mutex
@@ -41,10 +102,10 @@ func newCapturingLedger(t *testing.T) *capturingLedger {
 			return
 		}
 		if (rec.Decision.Verdict == "block") != (rec.Verdict.State == "denied") {
-			t.Errorf("gateway emitted INV3-violating receipt: verdict=%s state=%s", rec.Decision.Verdict, rec.Verdict.State)
+			t.Errorf("gateway emitted INV3-violating receipt: %s/%s", rec.Decision.Verdict, rec.Verdict.State)
 		}
 		if rec.ReceiptHash == "" {
-			t.Errorf("gateway emitted receipt with no receipt_hash")
+			t.Errorf("emitted receipt with no receipt_hash")
 		}
 		cl.mu.Lock()
 		cl.recs = append(cl.recs, rec)
@@ -64,43 +125,51 @@ func (cl *capturingLedger) last() executionReceipt {
 	return cl.recs[len(cl.recs)-1]
 }
 
-func a4Lease() lease {
-	now := time.Now().UTC()
-	return lease{
-		LeaseID: "lease_test", Sub: "agent:containment", Act: "user:responder",
-		Aud:    json.RawMessage(`"mcp://gbrg-containment"`),
-		Scope:  []string{"containment:sever:full"},
-		CaseID: "CASE-INC-1", TaskID: "TASK-1", ApprovalID: "APR-INC-1", RiskClass: "A4",
-		NotBefore: now.Add(-time.Minute).Format(time.RFC3339),
-		ExpiresAt: now.Add(25 * time.Second).Format(time.RFC3339),
-	}
+// harness wires a gateway to a broker key + JWKS + containment + ledger.
+type harness struct {
+	s    *server
+	key  *rsa.PrivateKey
+	kid  string
+	led  *capturingLedger
+	jwks *httptest.Server
+	cont *httptest.Server
+}
+
+func newHarness(t *testing.T, proved bool) *harness {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	kid := kidOf(&key.PublicKey)
+	jwks := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"keys": []map[string]any{rsaJWK(&key.PublicKey, kid)}})
+	}))
+	cont := fakeContainment(proved)
+	led := newCapturingLedger(t)
+	s := newServer(config{
+		containmentURL: cont.URL, ledgerURL: led.srv.URL,
+		brokerJWKSURL: jwks.URL, brokerIssuer: testIssuer, invokePath: "/mcp/invoke",
+	})
+	t.Cleanup(func() { jwks.Close(); cont.Close(); led.srv.Close() })
+	return &harness{s: s, key: key, kid: kid, led: led, jwks: jwks, cont: cont}
 }
 
 func severTool() toolReq {
 	return toolReq{Name: "sever_endpoint", Audience: "mcp://gbrg-containment", RequiredScope: "containment:sever:full"}
 }
 
-func invoke(t *testing.T, s *server, body invokeReq) *httptest.ResponseRecorder {
+func (h *harness) invoke(t *testing.T, token, dpop string) *httptest.ResponseRecorder {
 	t.Helper()
-	b, _ := json.Marshal(body)
+	b, _ := json.Marshal(invokeReq{LeaseToken: token, Tool: severTool(), Params: map[string]any{"scope": "full"}})
 	req := httptest.NewRequest(http.MethodPost, "/mcp/invoke", bytes.NewReader(b))
+	if dpop != "" {
+		req.Header.Set("DPoP", dpop)
+	}
 	rr := httptest.NewRecorder()
-	s.mux().ServeHTTP(rr, req)
+	h.s.mux().ServeHTTP(rr, req)
 	return rr
 }
 
-func newTestServer(cont, ledger string) *server {
-	return newServer(config{containmentURL: cont, ledgerURL: ledger, authServer: "https://auth.test/realms/wordops", resource: "https://agents.test/mcp"})
-}
-
 func TestAllowSeverProducesVerifiedReceipt(t *testing.T) {
-	cont := fakeContainment(true)
-	defer cont.Close()
-	led := newCapturingLedger(t)
-	defer led.srv.Close()
-	s := newTestServer(cont.URL, led.srv.URL)
-
-	rr := invoke(t, s, invokeReq{Lease: a4Lease(), Tool: severTool(), Params: map[string]any{"scope": "full"}})
+	h := newHarness(t, true)
+	rr := h.invoke(t, mintLease(h.key, h.kid, a4Claims()), "")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
 	}
@@ -109,62 +178,110 @@ func TestAllowSeverProducesVerifiedReceipt(t *testing.T) {
 	if out["admitted"] != true || out["verdict"] != "verified" {
 		t.Fatalf("want admitted+verified, got %v", out)
 	}
-	if led.last().Decision.Verdict != "allow" || led.last().Verdict.State != "verified" {
-		t.Fatalf("ledger did not record an allow/verified receipt: %+v", led.last())
-	}
-	if rr.Header().Get("MCP-Session-Id") == "" {
-		t.Fatalf("gateway must return an MCP-Session-Id")
+	if h.led.last().Decision.Verdict != "allow" || h.led.last().Verdict.State != "verified" {
+		t.Fatalf("ledger did not record allow/verified: %+v", h.led.last())
 	}
 }
 
 func TestNoOpSeverIsPendingNotVerified(t *testing.T) {
-	cont := fakeContainment(false) // INCONCLUSIVE
-	defer cont.Close()
-	led := newCapturingLedger(t)
-	defer led.srv.Close()
-	s := newTestServer(cont.URL, led.srv.URL)
-
-	rr := invoke(t, s, invokeReq{Lease: a4Lease(), Tool: severTool(), Params: map[string]any{"scope": "full"}})
+	h := newHarness(t, false)
+	rr := h.invoke(t, mintLease(h.key, h.kid, a4Claims()), "")
 	var out map[string]any
 	_ = json.Unmarshal(rr.Body.Bytes(), &out)
 	if out["verdict"] != "pending" {
-		t.Fatalf("a no-op sever must be pending, got %v", out["verdict"])
+		t.Fatalf("no-op sever must be pending, got %v", out["verdict"])
 	}
 }
 
-func TestDenials(t *testing.T) {
-	cont := fakeContainment(true)
-	defer cont.Close()
+func TestUnauthenticatedTokensRejected(t *testing.T) {
+	h := newHarness(t, true)
+	// wrong signing key
+	badKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	// expired
+	exp := a4Claims()
+	exp["exp"] = time.Now().Add(-time.Second).Unix()
+	// wrong issuer
+	wi := a4Claims()
+	tok := mintLease(h.key, h.kid, wi)
+	// tamper: flip last char of signature
+	tampered := tok[:len(tok)-1] + map[bool]string{true: "A", false: "B"}[tok[len(tok)-1] != 'A']
 
-	mk := func(mut func(lease) lease) invokeReq {
-		return invokeReq{Lease: mut(a4Lease()), Tool: severTool(), Params: map[string]any{"scope": "full"}}
+	cases := map[string]string{
+		"wrong key":    mintLease(badKey, kidOf(&badKey.PublicKey), a4Claims()),
+		"expired":      mintLease(h.key, h.kid, exp),
+		"tampered sig": tampered,
+		"not a jws":    "not-a-token",
 	}
-	cases := map[string]invokeReq{
-		"containment below A4": mk(func(l lease) lease { l.RiskClass = "A2"; return l }),
-		"expired lease":        mk(func(l lease) lease { l.ExpiresAt = time.Now().UTC().Add(-time.Second).Format(time.RFC3339); return l }),
-		"audience mismatch":    mk(func(l lease) lease { l.Aud = json.RawMessage(`"mcp://openproject"`); return l }),
-		"scope not covered":    mk(func(l lease) lease { l.Scope = []string{"read:executions"}; return l }),
-		"missing case binding": mk(func(l lease) lease { l.CaseID = ""; return l }),
-	}
-	for name, req := range cases {
+	for name, token := range cases {
 		t.Run(name, func(t *testing.T) {
-			led := newCapturingLedger(t)
-			defer led.srv.Close()
-			s := newTestServer(cont.URL, led.srv.URL)
-			rr := invoke(t, s, req)
-			if rr.Code != http.StatusForbidden {
-				t.Fatalf("%s: want 403, got %d: %s", name, rr.Code, rr.Body.String())
+			rr := h.invoke(t, token, "")
+			if rr.Code != http.StatusUnauthorized {
+				t.Fatalf("%s: want 401, got %d: %s", name, rr.Code, rr.Body.String())
 			}
-			// Denial must be audited as a block/denied receipt (teeth both ways).
-			if led.last().Decision.Verdict != "block" || led.last().Verdict.State != "denied" {
-				t.Fatalf("%s: denial not audited as block/denied: %+v", name, led.last())
+			if h.led.last().Verdict.State != "denied" {
+				t.Fatalf("%s: invalid token must be audited as denied", name)
 			}
 		})
 	}
 }
 
+func TestAuthorizationDenials(t *testing.T) {
+	h := newHarness(t, true)
+	mut := func(f func(map[string]any)) string {
+		c := a4Claims()
+		f(c)
+		return mintLease(h.key, h.kid, c)
+	}
+	cases := map[string]string{
+		"containment below A4": mut(func(c map[string]any) { c["risk_class"] = "A2" }),
+		"audience mismatch":    mut(func(c map[string]any) { c["aud"] = "mcp://openproject" }),
+		"scope not covered":    mut(func(c map[string]any) { c["scope"] = []string{"read:executions"} }),
+		"missing case binding": mut(func(c map[string]any) { c["case_id"] = "" }),
+	}
+	for name, token := range cases {
+		t.Run(name, func(t *testing.T) {
+			rr := h.invoke(t, token, "")
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("%s: want 403, got %d: %s", name, rr.Code, rr.Body.String())
+			}
+			if h.led.last().Decision.Verdict != "block" || h.led.last().Verdict.State != "denied" {
+				t.Fatalf("%s: denial not audited: %+v", name, h.led.last())
+			}
+		})
+	}
+}
+
+func TestDPoPBinding(t *testing.T) {
+	h := newHarness(t, true)
+	dpopKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	jkt := kidOf(&dpopKey.PublicKey)
+	claims := a4Claims()
+	claims["dpop_jkt"] = jkt
+	token := mintLease(h.key, h.kid, claims)
+	htu := "https://gw.test/mcp/invoke"
+	now := time.Now().Unix()
+
+	// no DPoP header → 401
+	if rr := h.invoke(t, token, ""); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("missing DPoP must 401, got %d", rr.Code)
+	}
+	// valid DPoP → 200
+	if rr := h.invoke(t, token, dpopProof(dpopKey, "POST", htu, now)); rr.Code != http.StatusOK {
+		t.Fatalf("valid DPoP must 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	// DPoP signed by a DIFFERENT key (thumbprint mismatch) → 401
+	otherKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	if rr := h.invoke(t, token, dpopProof(otherKey, "POST", htu, now)); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("mismatched DPoP key must 401, got %d", rr.Code)
+	}
+	// DPoP with stale iat → 401
+	if rr := h.invoke(t, token, dpopProof(dpopKey, "POST", htu, now-1000)); rr.Code != http.StatusUnauthorized {
+		t.Fatalf("stale DPoP iat must 401, got %d", rr.Code)
+	}
+}
+
 func TestSessionTeardown(t *testing.T) {
-	s := newTestServer("http://unused", "http://unused")
+	s := newServer(config{brokerJWKSURL: "http://unused"})
 	s.sessions["mcp-sess-x"] = "agent:y"
 	req := httptest.NewRequest(http.MethodDelete, "/mcp/session", nil)
 	req.Header.Set("MCP-Session-Id", "mcp-sess-x")
@@ -174,12 +291,12 @@ func TestSessionTeardown(t *testing.T) {
 		t.Fatalf("want 200, got %d", rr.Code)
 	}
 	if _, ok := s.sessions["mcp-sess-x"]; ok {
-		t.Fatalf("session was not torn down")
+		t.Fatal("session not torn down")
 	}
 }
 
 func TestProtectedResourceMetadata(t *testing.T) {
-	s := newTestServer("http://unused", "http://unused")
+	s := newServer(config{resource: "https://agents.test/mcp", authServer: "https://auth.test/realms/wordops", brokerJWKSURL: "http://unused"})
 	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
 	rr := httptest.NewRecorder()
 	s.mux().ServeHTTP(rr, req)
@@ -188,6 +305,6 @@ func TestProtectedResourceMetadata(t *testing.T) {
 		t.Fatalf("bad json: %v", err)
 	}
 	if out["authorization_servers"] == nil || out["resource"] == nil {
-		t.Fatalf("PRM missing required fields: %v", out)
+		t.Fatalf("PRM missing fields: %v", out)
 	}
 }

--- a/apps/wordops-mcp-gateway/main_test.go
+++ b/apps/wordops-mcp-gateway/main_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeContainment returns a ContainmentProofArtifact; proved controls verified vs pending.
+func fakeContainment(proved bool) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		level, status, contained := "empirical", "PROVED", 3
+		if !proved {
+			level, status, contained = "speculative", "INCONCLUSIVE", 0
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"schemaVersion": "0.1.0", "source": "vvv-648e9d56f1a", "severedScope": r.URL.Query().Get("scope"),
+			"epistemicLevel": level, "status": status, "containedCount": contained,
+			"baselineReachableCount": 4, "residualReachableCount": 4 - contained,
+		})
+	}))
+}
+
+// capturingLedger records posted receipts and applies the block<=>denied invariant.
+type capturingLedger struct {
+	srv  *httptest.Server
+	mu   sync.Mutex
+	recs []executionReceipt
+}
+
+func newCapturingLedger(t *testing.T) *capturingLedger {
+	cl := &capturingLedger{}
+	cl.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var rec executionReceipt
+		if err := json.NewDecoder(r.Body).Decode(&rec); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if (rec.Decision.Verdict == "block") != (rec.Verdict.State == "denied") {
+			t.Errorf("gateway emitted INV3-violating receipt: verdict=%s state=%s", rec.Decision.Verdict, rec.Verdict.State)
+		}
+		if rec.ReceiptHash == "" {
+			t.Errorf("gateway emitted receipt with no receipt_hash")
+		}
+		cl.mu.Lock()
+		cl.recs = append(cl.recs, rec)
+		cl.mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"accepted": true, "receipt_hash": rec.ReceiptHash})
+	}))
+	return cl
+}
+
+func (cl *capturingLedger) last() executionReceipt {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	if len(cl.recs) == 0 {
+		return executionReceipt{}
+	}
+	return cl.recs[len(cl.recs)-1]
+}
+
+func a4Lease() lease {
+	now := time.Now().UTC()
+	return lease{
+		LeaseID: "lease_test", Sub: "agent:containment", Act: "user:responder",
+		Aud:    json.RawMessage(`"mcp://gbrg-containment"`),
+		Scope:  []string{"containment:sever:full"},
+		CaseID: "CASE-INC-1", TaskID: "TASK-1", ApprovalID: "APR-INC-1", RiskClass: "A4",
+		NotBefore: now.Add(-time.Minute).Format(time.RFC3339),
+		ExpiresAt: now.Add(25 * time.Second).Format(time.RFC3339),
+	}
+}
+
+func severTool() toolReq {
+	return toolReq{Name: "sever_endpoint", Audience: "mcp://gbrg-containment", RequiredScope: "containment:sever:full"}
+}
+
+func invoke(t *testing.T, s *server, body invokeReq) *httptest.ResponseRecorder {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/invoke", bytes.NewReader(b))
+	rr := httptest.NewRecorder()
+	s.mux().ServeHTTP(rr, req)
+	return rr
+}
+
+func newTestServer(cont, ledger string) *server {
+	return newServer(config{containmentURL: cont, ledgerURL: ledger, authServer: "https://auth.test/realms/wordops", resource: "https://agents.test/mcp"})
+}
+
+func TestAllowSeverProducesVerifiedReceipt(t *testing.T) {
+	cont := fakeContainment(true)
+	defer cont.Close()
+	led := newCapturingLedger(t)
+	defer led.srv.Close()
+	s := newTestServer(cont.URL, led.srv.URL)
+
+	rr := invoke(t, s, invokeReq{Lease: a4Lease(), Tool: severTool(), Params: map[string]any{"scope": "full"}})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var out map[string]any
+	_ = json.Unmarshal(rr.Body.Bytes(), &out)
+	if out["admitted"] != true || out["verdict"] != "verified" {
+		t.Fatalf("want admitted+verified, got %v", out)
+	}
+	if led.last().Decision.Verdict != "allow" || led.last().Verdict.State != "verified" {
+		t.Fatalf("ledger did not record an allow/verified receipt: %+v", led.last())
+	}
+	if rr.Header().Get("MCP-Session-Id") == "" {
+		t.Fatalf("gateway must return an MCP-Session-Id")
+	}
+}
+
+func TestNoOpSeverIsPendingNotVerified(t *testing.T) {
+	cont := fakeContainment(false) // INCONCLUSIVE
+	defer cont.Close()
+	led := newCapturingLedger(t)
+	defer led.srv.Close()
+	s := newTestServer(cont.URL, led.srv.URL)
+
+	rr := invoke(t, s, invokeReq{Lease: a4Lease(), Tool: severTool(), Params: map[string]any{"scope": "full"}})
+	var out map[string]any
+	_ = json.Unmarshal(rr.Body.Bytes(), &out)
+	if out["verdict"] != "pending" {
+		t.Fatalf("a no-op sever must be pending, got %v", out["verdict"])
+	}
+}
+
+func TestDenials(t *testing.T) {
+	cont := fakeContainment(true)
+	defer cont.Close()
+
+	mk := func(mut func(lease) lease) invokeReq {
+		return invokeReq{Lease: mut(a4Lease()), Tool: severTool(), Params: map[string]any{"scope": "full"}}
+	}
+	cases := map[string]invokeReq{
+		"containment below A4": mk(func(l lease) lease { l.RiskClass = "A2"; return l }),
+		"expired lease":        mk(func(l lease) lease { l.ExpiresAt = time.Now().UTC().Add(-time.Second).Format(time.RFC3339); return l }),
+		"audience mismatch":    mk(func(l lease) lease { l.Aud = json.RawMessage(`"mcp://openproject"`); return l }),
+		"scope not covered":    mk(func(l lease) lease { l.Scope = []string{"read:executions"}; return l }),
+		"missing case binding": mk(func(l lease) lease { l.CaseID = ""; return l }),
+	}
+	for name, req := range cases {
+		t.Run(name, func(t *testing.T) {
+			led := newCapturingLedger(t)
+			defer led.srv.Close()
+			s := newTestServer(cont.URL, led.srv.URL)
+			rr := invoke(t, s, req)
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("%s: want 403, got %d: %s", name, rr.Code, rr.Body.String())
+			}
+			// Denial must be audited as a block/denied receipt (teeth both ways).
+			if led.last().Decision.Verdict != "block" || led.last().Verdict.State != "denied" {
+				t.Fatalf("%s: denial not audited as block/denied: %+v", name, led.last())
+			}
+		})
+	}
+}
+
+func TestSessionTeardown(t *testing.T) {
+	s := newTestServer("http://unused", "http://unused")
+	s.sessions["mcp-sess-x"] = "agent:y"
+	req := httptest.NewRequest(http.MethodDelete, "/mcp/session", nil)
+	req.Header.Set("MCP-Session-Id", "mcp-sess-x")
+	rr := httptest.NewRecorder()
+	s.mux().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	if _, ok := s.sessions["mcp-sess-x"]; ok {
+		t.Fatalf("session was not torn down")
+	}
+}
+
+func TestProtectedResourceMetadata(t *testing.T) {
+	s := newTestServer("http://unused", "http://unused")
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rr := httptest.NewRecorder()
+	s.mux().ServeHTTP(rr, req)
+	var out map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if out["authorization_servers"] == nil || out["resource"] == nil {
+		t.Fatalf("PRM missing required fields: %v", out)
+	}
+}

--- a/apps/wordops-room-factory/Dockerfile
+++ b/apps/wordops-room-factory/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7
+# wordops-room-factory — WordOps service (Go, stdlib-only, single main.go). Binds 0.0.0.0:8080.
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go.mod ./
+COPY *.go ./
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /wordops-room-factory .
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /wordops-room-factory /wordops-room-factory
+ENV PORT=8080
+EXPOSE 8080
+ENTRYPOINT ["/wordops-room-factory"]

--- a/apps/wordops-room-factory/go.mod
+++ b/apps/wordops-room-factory/go.mod
@@ -1,0 +1,3 @@
+module wordops-room-factory
+
+go 1.22

--- a/apps/wordops-room-factory/main.go
+++ b/apps/wordops-room-factory/main.go
@@ -1,0 +1,180 @@
+// wordops-room-factory — creates governed Matrix rooms (Go, stdlib-only).
+//
+// Implements the room-factory named in the WordOps reference flow: a dedicated
+// service account that opens PRIVATE case/incident rooms in the private Synapse
+// estate with the taxonomy from docs/room-taxonomy.md — encryption ON, join by
+// invite only, federation OFF. Rooms are collaboration context; the durable
+// authorization record lives in the ledger/case-kernel, never in the room.
+//
+// Endpoints (bind 0.0.0.0:$PORT, default 8080):
+//
+//	GET  /healthz — liveness/readiness
+//	POST /rooms   — create an incident/case room and invite participants
+//
+// Config: MATRIX_HS_URL (private homeserver base, e.g. https://ops.socioprophet.ai)
+// and MATRIX_ACCESS_TOKEN (the room-factory service-account token).
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type createReq struct {
+	Type     string   `json:"type"`     // "incident" | "case"
+	Ref      string   `json:"ref"`      // e.g. INC-123 / CASE-9
+	Topic    string   `json:"topic"`    // optional
+	Invitees []string `json:"invitees"` // Matrix user ids
+}
+
+// roomSpec is the Matrix CS-API createRoom body. The taxonomy (encryption, invite,
+// no federation) is NOT caller-controlled — it is fixed by room type so a private
+// case room can never be opened federated or unencrypted by a bad request.
+func roomSpec(req createReq) (map[string]any, string, error) {
+	if req.Type != "incident" && req.Type != "case" {
+		return nil, "", fmt.Errorf("type must be incident|case")
+	}
+	if strings.TrimSpace(req.Ref) == "" {
+		return nil, "", fmt.Errorf("ref is required")
+	}
+	alias := req.Type + "-" + sanitize(req.Ref)
+	name := "#" + alias
+	topic := req.Topic
+	if topic == "" {
+		topic = fmt.Sprintf("WordOps %s room for %s (private, encrypted, invite-only)", req.Type, req.Ref)
+	}
+	spec := map[string]any{
+		"preset":          "private_chat",
+		"visibility":      "private",
+		"name":            name,
+		"topic":           topic,
+		"room_alias_name": alias,
+		"invite":          req.Invitees,
+		// federation OFF — a private case/incident room must never federate.
+		"creation_content": map[string]any{"m.federate": false},
+		"initial_state": []map[string]any{
+			{"type": "m.room.encryption", "state_key": "", "content": map[string]any{"algorithm": "m.megolm.v1.aes-sha2"}},
+			{"type": "m.room.join_rules", "state_key": "", "content": map[string]any{"join_rule": "invite"}},
+			{"type": "m.room.history_visibility", "state_key": "", "content": map[string]any{"history_visibility": "invited"}},
+			{"type": "m.room.guest_access", "state_key": "", "content": map[string]any{"guest_access": "forbidden"}},
+		},
+	}
+	return spec, alias, nil
+}
+
+func sanitize(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
+type factory struct {
+	hsURL  string
+	token  string
+	client *http.Client
+}
+
+func (f *factory) createRoom(spec map[string]any) (string, error) {
+	body, _ := json.Marshal(spec)
+	req, _ := http.NewRequest(http.MethodPost, strings.TrimRight(f.hsURL, "/")+"/_matrix/client/v3/createRoom", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+f.token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("homeserver createRoom returned %d: %s", resp.StatusCode, string(rb))
+	}
+	var out struct {
+		RoomID string `json:"room_id"`
+	}
+	if err := json.Unmarshal(rb, &out); err != nil || out.RoomID == "" {
+		return "", fmt.Errorf("homeserver did not return a room_id")
+	}
+	return out.RoomID, nil
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func (f *factory) handleRooms(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]any{"error": "method not allowed"})
+		return
+	}
+	var req createReq
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid JSON: " + err.Error()})
+		return
+	}
+	spec, alias, err := roomSpec(req)
+	if err != nil {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]any{"error": err.Error()})
+		return
+	}
+	roomID, err := f.createRoom(spec)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]any{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"room_id": roomID, "alias": alias, "type": req.Type,
+		"encrypted": true, "federated": false, "join_rule": "invite",
+		"invited": req.Invitees, "created_at": time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func (f *factory) mux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"status": "ok", "service": "wordops-room-factory"})
+	})
+	mux.HandleFunc("/rooms", f.handleRooms)
+	return mux
+}
+
+func env(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	f := &factory{
+		hsURL:  env("MATRIX_HS_URL", "http://synapse-private.socioprophet.svc.cluster.local:8008"),
+		token:  os.Getenv("MATRIX_ACCESS_TOKEN"),
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+	if f.token == "" {
+		log.Printf("WARNING: MATRIX_ACCESS_TOKEN is empty — createRoom will be rejected by the homeserver")
+	}
+	port := env("PORT", "8080")
+	log.Printf("wordops-room-factory serving on :%s (hs=%s)", port, f.hsURL)
+	if err := http.ListenAndServe("0.0.0.0:"+port, f.mux()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/apps/wordops-room-factory/main_test.go
+++ b/apps/wordops-room-factory/main_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeSynapse asserts the createRoom body enforces the taxonomy and returns a room_id.
+func fakeSynapse(t *testing.T, gotToken *string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_matrix/client/v3/createRoom" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		*gotToken = r.Header.Get("Authorization")
+		var spec map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&spec)
+
+		// federation OFF
+		cc, _ := spec["creation_content"].(map[string]any)
+		if cc == nil || cc["m.federate"] != false {
+			t.Errorf("federation must be disabled, got creation_content=%v", cc)
+		}
+		// encryption + invite join rule present in initial_state
+		wantState := map[string]bool{"m.room.encryption": false, "m.room.join_rules": false}
+		st, _ := spec["initial_state"].([]any)
+		for _, e := range st {
+			m, _ := e.(map[string]any)
+			if _, ok := wantState[m["type"].(string)]; ok {
+				wantState[m["type"].(string)] = true
+			}
+			if m["type"] == "m.room.join_rules" {
+				c, _ := m["content"].(map[string]any)
+				if c["join_rule"] != "invite" {
+					t.Errorf("join_rule must be invite, got %v", c["join_rule"])
+				}
+			}
+		}
+		for typ, seen := range wantState {
+			if !seen {
+				t.Errorf("initial_state missing %s", typ)
+			}
+		}
+		if spec["visibility"] != "private" {
+			t.Errorf("visibility must be private, got %v", spec["visibility"])
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"room_id": "!abc123:ops.socioprophet.ai"})
+	}))
+}
+
+func TestCreateIncidentRoomEnforcesTaxonomy(t *testing.T) {
+	var gotToken string
+	hs := fakeSynapse(t, &gotToken)
+	defer hs.Close()
+	f := &factory{hsURL: hs.URL, token: "syt_factory_token", client: hs.Client()}
+
+	body, _ := json.Marshal(createReq{Type: "incident", Ref: "INC-42", Invitees: []string{"@ic:ops.socioprophet.ai"}})
+	rr := httptest.NewRecorder()
+	f.mux().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/rooms", bytes.NewReader(body)))
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var out map[string]any
+	_ = json.Unmarshal(rr.Body.Bytes(), &out)
+	if out["room_id"] != "!abc123:ops.socioprophet.ai" || out["alias"] != "incident-inc-42" {
+		t.Fatalf("unexpected response: %v", out)
+	}
+	if out["encrypted"] != true || out["federated"] != false {
+		t.Fatalf("response must advertise encrypted + non-federated: %v", out)
+	}
+	if gotToken != "Bearer syt_factory_token" {
+		t.Fatalf("service-account token not forwarded: %q", gotToken)
+	}
+}
+
+func TestBadTypeRejected(t *testing.T) {
+	f := &factory{hsURL: "http://unused", token: "x", client: http.DefaultClient}
+	body, _ := json.Marshal(createReq{Type: "public-lobby", Ref: "X"})
+	rr := httptest.NewRecorder()
+	f.mux().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/rooms", bytes.NewReader(body)))
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422 for bad type, got %d", rr.Code)
+	}
+}
+
+func TestRoomSpecTaxonomyIsFixed(t *testing.T) {
+	// Even if a caller tried to smuggle federation on, roomSpec fixes it.
+	spec, alias, err := roomSpec(createReq{Type: "case", Ref: "CASE 9!"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if alias != "case-case-9-" {
+		t.Fatalf("alias sanitize wrong: %q", alias)
+	}
+	cc := spec["creation_content"].(map[string]any)
+	if cc["m.federate"] != false {
+		t.Fatalf("federation must be forced off")
+	}
+}

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -49,6 +49,7 @@ spec:
           - { name: holmes, tier: reference }                    # language-intelligence impl
           - { name: agent-activity-ledger, tier: foundation }    # Executions Ledger — receipt spine / system-of-record for agent runs
           - { name: gbrg-containment, tier: reference }          # governed blast-radius/containment engine impl
+          - { name: wordops-mcp-gateway, tier: foundation }      # WordOps lease-enforcing MCP gateway — authz sink for containment/ledger
           - { name: portfolio-agent, tier: reference }           # product agent
           - { name: academy-board, tier: reference }             # academy courseware surface
           - { name: health-twin, tier: reference }               # health-twin product surface

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -50,6 +50,8 @@ spec:
           - { name: agent-activity-ledger, tier: foundation }    # Executions Ledger — receipt spine / system-of-record for agent runs
           - { name: gbrg-containment, tier: reference }          # governed blast-radius/containment engine impl
           - { name: wordops-mcp-gateway, tier: foundation }      # WordOps lease-enforcing MCP gateway — authz sink for containment/ledger
+          - { name: wordops-capability-broker, tier: foundation } # WordOps lease issuance — signs A0-A4 leases + publishes JWKS
+          - { name: wordops-room-factory, tier: reference }      # WordOps room-factory — governed Matrix incident/case rooms
           - { name: portfolio-agent, tier: reference }           # product agent
           - { name: academy-board, tier: reference }             # academy courseware surface
           - { name: health-twin, tier: reference }               # health-twin product surface

--- a/deploy/values/wordops-capability-broker.yaml
+++ b/deploy/values/wordops-capability-broker.yaml
@@ -1,0 +1,18 @@
+# wordops-capability-broker — mints down-scoped, signed capability-leases (Go), on the SOVEREIGN registry (zot).
+#
+# The issuance side of the WordOps lease fabric: runs the A0-A4 allow_issue policy and,
+# on allow, mints a short-lived RS256-signed lease JWT the gateway verifies via /.well-known/jwks.json.
+#
+# New-service bootstrap: tag starts at `latest`; gitops-promote pins the immutable sha- tag on first build.
+# Signing key: mount an RSA private key as the secret below to make the JWKS stable across restarts. If the
+# secret is absent the broker boots an EPHEMERAL key (dev) — leases still verify within a pod's lifetime.
+image: { registry: registry.socioprophet.ai, repository: wordops-capability-broker, tag: latest }
+imagePullSecrets: [{ name: zot-pull }]
+service: { port: 8080, portName: http }
+extraEnv:
+  - name: WORDOPS_BROKER_SIGNING_KEY
+    valueFrom:
+      secretKeyRef:
+        name: wordops-broker-signing
+        key: private.pem
+        optional: true

--- a/deploy/values/wordops-mcp-gateway.yaml
+++ b/deploy/values/wordops-mcp-gateway.yaml
@@ -1,0 +1,25 @@
+# wordops-mcp-gateway — WordOps lease-enforcing MCP gateway (Go), on the SOVEREIGN registry (zot).
+#
+# Registry: registry.socioprophet.ai (zot), NOT GAR — images.yml builds+pushes it there
+# (registry: registry.socioprophet.ai, basic auth), so the deploy MUST pull from there too via the
+# `zot-pull` dockerconfigjson secret (namespace socioprophet).
+#
+# New-service bootstrap: tag starts at `latest`; gitops-promote pins the immutable `sha-<commit>` tag
+# on the first successful build+merge (same pattern as agent-activity-ledger / gbrg-containment).
+#
+# The enforcement point of the WordOps agentic chat-ops fabric: it authorizes a capability-lease
+# (audience/scope/case/task/expiry; a containment sever is intrinsically risk_class A4), calls
+# gbrg-containment, and writes the durable ExecutionReceipt to agent-activity-ledger — the ledger,
+# NOT the Matrix room, is the authorization sink. Serves /healthz (chart probe default) on :8080.
+image: { registry: registry.socioprophet.ai, repository: wordops-mcp-gateway, tag: latest }
+imagePullSecrets: [{ name: zot-pull }]
+service: { port: 8080, portName: http }
+extraEnv:
+  - name: GBRG_CONTAINMENT_URL
+    value: http://gbrg-containment.socioprophet.svc.cluster.local:8080
+  - name: LEDGER_URL
+    value: http://agent-activity-ledger.socioprophet.svc.cluster.local:8080
+  - name: AUTH_SERVER
+    value: https://auth.socioprophet.ai/realms/wordops
+  - name: RESOURCE_URL
+    value: https://agents.socioprophet.ai/mcp/wordops

--- a/deploy/values/wordops-mcp-gateway.yaml
+++ b/deploy/values/wordops-mcp-gateway.yaml
@@ -23,3 +23,7 @@ extraEnv:
     value: https://auth.socioprophet.ai/realms/wordops
   - name: RESOURCE_URL
     value: https://agents.socioprophet.ai/mcp/wordops
+  - name: BROKER_JWKS_URL
+    value: http://wordops-capability-broker.socioprophet.svc.cluster.local:8080/.well-known/jwks.json
+  - name: BROKER_ISSUER
+    value: https://auth.socioprophet.ai/realms/wordops/wordops-capability-broker

--- a/deploy/values/wordops-room-factory.yaml
+++ b/deploy/values/wordops-room-factory.yaml
@@ -1,0 +1,20 @@
+# wordops-room-factory — creates governed Matrix rooms (Go), on the SOVEREIGN registry (zot).
+#
+# Dedicated service account that opens PRIVATE case/incident rooms in the private Synapse estate:
+# encryption ON, join by invite only, federation OFF (docs/room-taxonomy.md). The taxonomy is fixed
+# by room type, never caller-controlled.
+#
+# New-service bootstrap: tag starts at `latest`; gitops-promote pins the immutable sha- tag on first build.
+# Mount the room-factory service-account token as the secret below; without it the homeserver rejects createRoom.
+image: { registry: registry.socioprophet.ai, repository: wordops-room-factory, tag: latest }
+imagePullSecrets: [{ name: zot-pull }]
+service: { port: 8080, portName: http }
+extraEnv:
+  - name: MATRIX_HS_URL
+    value: http://synapse-private.socioprophet.svc.cluster.local:8008
+  - name: MATRIX_ACCESS_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: wordops-room-factory
+        key: access_token
+        optional: true

--- a/docs/WORDOPS_REFERENCE_FLOW.md
+++ b/docs/WORDOPS_REFERENCE_FLOW.md
@@ -19,7 +19,9 @@ room.
 | Autonomy classes A0–A4 | `docs/WORDOPS_APPROVAL_TO_LEASE_GOVERNANCE.md` | ✅ present |
 | Lease issuance/action policy | `infra/wordops/opa/lease_policy.rego` | ✅ new, `opa test` green (14/14) |
 | Canonical lease record / wire token | `schemas/wordops/capability-lease.schema.json` · `…-token.schema.json` | ✅ record + ✅ new token |
-| Lease-enforcing MCP gateway | `apps/wordops-mcp-gateway/` | ✅ new, `go test` green |
+| Capability broker (lease issuance + JWKS) | `apps/wordops-capability-broker/` | ✅ new, signs RS256 leases, `go test` green |
+| Lease-enforcing MCP gateway (+JWT/DPoP verify) | `apps/wordops-mcp-gateway/` (`jose.go`) | ✅ new, verifies broker JWKS + DPoP, `go test` green |
+| Room-factory (governed Matrix rooms) | `apps/wordops-room-factory/` | ✅ new, encrypted/invite/no-federate, `go test` green |
 | Containment / blast-radius engine | `apps/gbrg-containment/` (Go front door for `gbrg-core::containment`) | ✅ present |
 | Executions ledger (durable receipt sink) | `apps/agent-activity-ledger/` (`POST /executions`) | ✅ new POST + teeth |
 | Containment agent cards | `apps/wordops-mcp-gateway/a2a/{public,extended}-agent-card.json` | ✅ new |
@@ -80,13 +82,20 @@ sequenceDiagram
 
 ## Maturity / honesty
 
-- ✅ **Real + tested now:** the OPA policy (A0–A4), the gateway lease enforcement and
-  fail-closed denial audit, the containment call, the ExecutionReceipt emission, and
-  the ledger's invariant checks — all covered by `opa test` and `go test`.
+- ✅ **Real + tested now:** the OPA policy (A0–A4); the **capability broker** (runs
+  allow_issue, mints RS256-signed leases, publishes JWKS); the gateway's **JWT
+  verification against the broker JWKS + DPoP proof-of-possession** (RFC 9449),
+  followed by claim enforcement and fail-closed denial audit; the containment call;
+  the ExecutionReceipt emission; the ledger's invariant checks; and the
+  **room-factory** (creates encrypted, invite-only, non-federated Matrix rooms). All
+  covered by `opa test` and `go test` (including invalid-token, DPoP-mismatch, and
+  taxonomy-enforcement cases).
 - 🟡 **Interface / fixture:** `gbrg-containment` computes over a fixture topology
   (the authoritative algorithm is `gbrg-core::containment` in sociosphere); the
-  ledger store is in-memory. Both are documented as follow-ons in their own headers.
-- ⬜ **Next increment:** the room-factory service (Synapse admin API) and broker
-  token-exchange service are specified here and by the OPA policy + token schema, but
-  are not yet live services in this PR — they are the next step, wired to the same
-  contracts so no interface churn.
+  ledger store is in-memory. The broker's signing key is an ephemeral dev key until
+  the `wordops-broker-signing` Secret is mounted; the room-factory needs the
+  `wordops-room-factory` service-account token Secret to talk to a live homeserver.
+  All documented in their headers / values files.
+- ⬜ **Next increment:** mount the broker signing-key + room-factory token Secrets in
+  the cluster, and add EC/ES256 support to the JOSE layer if a client needs it (the
+  code is RSA/RS256 throughout today).

--- a/docs/WORDOPS_REFERENCE_FLOW.md
+++ b/docs/WORDOPS_REFERENCE_FLOW.md
@@ -1,0 +1,92 @@
+# WordOps Reference Flow — Incident → Containment
+
+This is the estate realization of the Phase-0 reference pack's implementation-order
+step 10 ("first reference flow"). It threads a real incident from a public Matrix
+room to a governed, audited endpoint-containment action, using components that now
+exist in this repo.
+
+Governing rule (from the reference pack, kept verbatim in spirit): **Matrix rooms
+are collaboration context, not the authorization ledger.** The authorization
+decision and its durable receipt live at the gateway and the ledger — never in a
+room.
+
+## Components (all in-repo)
+
+| Role | Component | Status |
+|---|---|---|
+| Public edge + private core Matrix estates | `infra/k8s/wordops-matrix/`, `infra/wordops/matrix/` | ✅ deployed (#1156) |
+| Case kernel (durable orchestration outside MCP) | `apps/matrix-qes-operator/` | ✅ present |
+| Autonomy classes A0–A4 | `docs/WORDOPS_APPROVAL_TO_LEASE_GOVERNANCE.md` | ✅ present |
+| Lease issuance/action policy | `infra/wordops/opa/lease_policy.rego` | ✅ new, `opa test` green (14/14) |
+| Canonical lease record / wire token | `schemas/wordops/capability-lease.schema.json` · `…-token.schema.json` | ✅ record + ✅ new token |
+| Lease-enforcing MCP gateway | `apps/wordops-mcp-gateway/` | ✅ new, `go test` green |
+| Containment / blast-radius engine | `apps/gbrg-containment/` (Go front door for `gbrg-core::containment`) | ✅ present |
+| Executions ledger (durable receipt sink) | `apps/agent-activity-ledger/` (`POST /executions`) | ✅ new POST + teeth |
+| Containment agent cards | `apps/wordops-mcp-gateway/a2a/{public,extended}-agent-card.json` | ✅ new |
+
+## The flow
+
+1. **Public intake** — a report lands in `#welcome:public.socioprophet.ai` (federation on,
+   encryption off, no regulated details). The public agent card exposes only
+   read-only/discovery skills.
+2. **Human handoff** — an operator triages in `#support-lobby` and, if a real threat,
+   opens a **private case/incident room** `#incident-<id>:ops.socioprophet.ai`
+   (encryption on, invite-only, federation off), created by the room-factory service
+   account. Case state changes mirror to the **case kernel** (`matrix-qes-operator`).
+3. **Lease request** — to isolate an endpoint, the incident commander requests a
+   capability from the broker. A sever is **intrinsically A4** (urgent containment):
+   the broker calls OPA `allow_issue`, which requires a responder/IC role, an
+   `approval_id` **or** a documented break-glass ref, satisfied step-up, and the
+   **shortest TTL (≤30s)**. On allow, the broker mints a down-scoped
+   **capability-lease token** (audience `mcp://gbrg-containment`, scope
+   `containment:sever:full|selective`, bound to `case_id` + `task_id`).
+4. **Controlled MCP action** — the agent calls `POST /mcp/invoke` on the
+   **wordops-mcp-gateway** with the lease + tool. The gateway enforces
+   audience/scope/case/task/expiry and re-asserts *containment ⇒ A4*. On allow it
+   calls `gbrg-containment`, receives a `ContainmentProofArtifact`, and maps it
+   **honestly**: a no-op sever (INCONCLUSIVE / `speculative`) is `pending`, never a
+   verified containment.
+5. **Durable receipt** — the gateway writes an **ExecutionReceipt** (conforming to
+   `prophet-core-contracts`) to the **ledger**. The ledger rejects self-contradictory
+   receipts (INV1–INV4). A **denied** attempt is *also* written (A4 is heavily
+   audited — teeth fire both ways).
+6. **Room summary** — only a room-safe summary returns to `#incident-<id>` (verdict +
+   `receipt_hash` + contained/residual counts). The warrant itself is in the ledger,
+   surfaced in the cockpit's Executions Ledger — not pasted into the room.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    participant R as #incident room
+    participant B as Capability broker (OPA allow_issue)
+    participant G as wordops-mcp-gateway (allow_action)
+    participant C as gbrg-containment
+    participant L as agent-activity-ledger
+    R->>B: request A4 lease (containment:sever, case+task, approval/break-glass)
+    B-->>R: capability-lease token (≤30s, audience-bound) or DENY
+    R->>G: POST /mcp/invoke {lease, tool: sever_endpoint}
+    G->>G: authorize (audience/scope/case/task/expiry; containment⇒A4)
+    alt admitted
+        G->>C: GET /containment?scope=full|selective
+        C-->>G: ContainmentProofArtifact (epistemicLevel, contained/residual)
+        G->>L: POST /executions (allow; verified|pending)
+        G-->>R: summary + receipt_hash
+    else denied
+        G->>L: POST /executions (block/denied) — audited
+        G-->>R: 403 + reason + receipt_hash
+    end
+```
+
+## Maturity / honesty
+
+- ✅ **Real + tested now:** the OPA policy (A0–A4), the gateway lease enforcement and
+  fail-closed denial audit, the containment call, the ExecutionReceipt emission, and
+  the ledger's invariant checks — all covered by `opa test` and `go test`.
+- 🟡 **Interface / fixture:** `gbrg-containment` computes over a fixture topology
+  (the authoritative algorithm is `gbrg-core::containment` in sociosphere); the
+  ledger store is in-memory. Both are documented as follow-ons in their own headers.
+- ⬜ **Next increment:** the room-factory service (Synapse admin API) and broker
+  token-exchange service are specified here and by the OPA policy + token schema, but
+  are not yet live services in this PR — they are the next step, wired to the same
+  contracts so no interface churn.

--- a/infra/wordops/opa/lease_policy.rego
+++ b/infra/wordops/opa/lease_policy.rego
@@ -1,0 +1,122 @@
+# WordOps capability-lease policy.
+#
+# Encodes the estate's OWN autonomy ladder (A0..A4) from
+# docs/WORDOPS_APPROVAL_TO_LEASE_GOVERNANCE.md — NOT the generic
+# low/medium/high/regulated of the external reference pack.
+#
+# Two decision points:
+#   allow_issue  — may the broker MINT a lease for this request?
+#   allow_action — may the gateway ADMIT a tool call under this lease?
+#
+# Invariant: approval is not capability. A0/A1 need no approval; A2 is policy-only;
+# A3 needs explicit human approval + step-up; A4 (urgent containment / break-glass)
+# needs approval OR a documented break-glass path, always with step-up-where-feasible
+# and the shortest possible TTL. Every A3/A4 issuance is heavily audited downstream
+# (the gateway emits an ExecutionReceipt to the ledger).
+package wordops.authz
+
+import rego.v1
+
+default allow_issue := false
+
+default allow_action := false
+
+# Per-class TTL ceilings (seconds). A4 is the shortest.
+ttl_ceiling := {"A0": 900, "A1": 900, "A2": 120, "A3": 60, "A4": 30}
+
+within_ttl(rc) if input.request.ttl_seconds <= ttl_ceiling[rc]
+
+# ---------------------------------------------------------------------------
+# allow_issue — lease minting
+# ---------------------------------------------------------------------------
+
+# A0 Observe-only: read:* scopes, no approval.
+allow_issue if {
+	input.request.risk_class == "A0"
+	within_ttl("A0")
+	every s in input.request.scope {
+		startswith(s, "read:")
+	}
+}
+
+# A1 Draft-only: non-mutating draft:/propose: scopes, no approval.
+allow_issue if {
+	input.request.risk_class == "A1"
+	within_ttl("A1")
+	every s in input.request.scope {
+		non_mutating(s)
+	}
+}
+
+# A2 Low-risk execute: policy-only. Requires an operator role; step-up recommended not required.
+# Containment sever is intrinsically A4 and can never be minted here.
+allow_issue if {
+	input.request.risk_class == "A2"
+	within_ttl("A2")
+	has_role({"ops-operator", "ops-admin"})
+	not containment_request
+}
+
+# A3 High-risk execute: explicit human approval + satisfied step-up.
+allow_issue if {
+	input.request.risk_class == "A3"
+	within_ttl("A3")
+	has_role({"change-approver", "ops-admin"})
+	input.request.approval_id != ""
+	input.request.step_up_satisfied == true
+	not containment_request
+}
+
+# A4 Emergency constrained action (e.g. urgent containment / break-glass).
+# Either an explicit approval, OR a documented break-glass path — both with step-up.
+allow_issue if {
+	input.request.risk_class == "A4"
+	within_ttl("A4")
+	responder_role
+	a4_authorized
+	input.request.step_up_satisfied == true
+}
+
+responder_role if has_role({"responder", "incident-commander", "ops-admin"})
+
+a4_authorized if input.request.approval_id != ""
+
+a4_authorized if {
+	input.request.break_glass == true
+	input.request.break_glass_policy_ref != ""
+}
+
+# A containment sever is intrinsically A4; the lower-class rules exclude it via
+# `not containment_request`, so it can only ever be minted through the A4 path.
+containment_request if {
+	some s in input.request.scope
+	startswith(s, "containment:sever")
+}
+
+# ---------------------------------------------------------------------------
+# allow_action — gateway admission of a tool call under a live lease
+# ---------------------------------------------------------------------------
+
+allow_action if {
+	input.action == "invoke"
+	input.lease.active == true
+	audience_matches
+	scope_covers(input.resource.required_scope)
+}
+
+audience_matches if input.lease.aud == input.resource.audience
+
+scope_covers(req) if input.lease.scope[_] == req
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+non_mutating(s) if startswith(s, "draft:")
+
+non_mutating(s) if startswith(s, "propose:")
+
+has_role(allowed) if {
+	some r in input.user.roles
+	allowed[r]
+}

--- a/infra/wordops/opa/lease_policy_test.rego
+++ b/infra/wordops/opa/lease_policy_test.rego
@@ -1,0 +1,110 @@
+package wordops.authz
+
+import rego.v1
+
+# ---- allow_issue: happy paths per class ----
+
+test_a0_read_only_allowed if {
+	allow_issue with input as {
+		"user": {"id": "svc", "roles": []},
+		"request": {"risk_class": "A0", "ttl_seconds": 300, "scope": ["read:rooms", "read:tickets"]},
+	}
+}
+
+test_a1_draft_allowed if {
+	allow_issue with input as {
+		"user": {"id": "svc", "roles": []},
+		"request": {"risk_class": "A1", "ttl_seconds": 600, "scope": ["draft:case-update"]},
+	}
+}
+
+test_a2_low_risk_execute_requires_operator if {
+	allow_issue with input as {
+		"user": {"id": "op", "roles": ["ops-operator"]},
+		"request": {"risk_class": "A2", "ttl_seconds": 60, "scope": ["ticket:create"]},
+	}
+}
+
+test_a3_high_risk_requires_approval_and_stepup if {
+	allow_issue with input as {
+		"user": {"id": "boss", "roles": ["change-approver"]},
+		"request": {"risk_class": "A3", "ttl_seconds": 60, "scope": ["platform:mutate"], "approval_id": "APR-9", "step_up_satisfied": true},
+	}
+}
+
+test_a4_containment_with_approval_allowed if {
+	allow_issue with input as {
+		"user": {"id": "resp", "roles": ["responder"]},
+		"request": {"risk_class": "A4", "ttl_seconds": 30, "scope": ["containment:sever:full"], "approval_id": "APR-INC-1", "step_up_satisfied": true},
+	}
+}
+
+test_a4_containment_break_glass_allowed if {
+	allow_issue with input as {
+		"user": {"id": "ic", "roles": ["incident-commander"]},
+		"request": {"risk_class": "A4", "ttl_seconds": 15, "scope": ["containment:sever:selective"], "approval_id": "", "break_glass": true, "break_glass_policy_ref": "policy://break-glass/v1", "step_up_satisfied": true},
+	}
+}
+
+# ---- allow_issue: denials (teeth) ----
+
+test_containment_below_a4_denied if {
+	not allow_issue with input as {
+		"user": {"id": "resp", "roles": ["responder", "ops-admin"]},
+		"request": {"risk_class": "A2", "ttl_seconds": 30, "scope": ["containment:sever:full"], "approval_id": "APR-1", "step_up_satisfied": true},
+	}
+}
+
+test_a4_without_approval_or_breakglass_denied if {
+	not allow_issue with input as {
+		"user": {"id": "resp", "roles": ["responder"]},
+		"request": {"risk_class": "A4", "ttl_seconds": 30, "scope": ["containment:sever:full"], "approval_id": "", "break_glass": false, "step_up_satisfied": true},
+	}
+}
+
+test_a3_without_approval_denied if {
+	not allow_issue with input as {
+		"user": {"id": "boss", "roles": ["change-approver"]},
+		"request": {"risk_class": "A3", "ttl_seconds": 60, "scope": ["platform:mutate"], "approval_id": "", "step_up_satisfied": true},
+	}
+}
+
+test_ttl_over_ceiling_denied if {
+	not allow_issue with input as {
+		"user": {"id": "resp", "roles": ["responder"]},
+		"request": {"risk_class": "A4", "ttl_seconds": 31, "scope": ["containment:sever:full"], "approval_id": "APR-1", "step_up_satisfied": true},
+	}
+}
+
+test_a0_non_read_scope_denied if {
+	not allow_issue with input as {
+		"user": {"id": "svc", "roles": []},
+		"request": {"risk_class": "A0", "ttl_seconds": 60, "scope": ["read:rooms", "ticket:create"]},
+	}
+}
+
+# ---- allow_action ----
+
+test_action_admitted_when_scope_and_audience_match if {
+	allow_action with input as {
+		"action": "invoke",
+		"lease": {"active": true, "aud": "mcp://gbrg-containment", "scope": ["containment:sever:full"]},
+		"resource": {"kind": "mcp_tool", "name": "sever_endpoint", "audience": "mcp://gbrg-containment", "required_scope": "containment:sever:full"},
+	}
+}
+
+test_action_denied_on_audience_mismatch if {
+	not allow_action with input as {
+		"action": "invoke",
+		"lease": {"active": true, "aud": "mcp://openproject", "scope": ["containment:sever:full"]},
+		"resource": {"kind": "mcp_tool", "name": "sever_endpoint", "audience": "mcp://gbrg-containment", "required_scope": "containment:sever:full"},
+	}
+}
+
+test_action_denied_when_lease_inactive if {
+	not allow_action with input as {
+		"action": "invoke",
+		"lease": {"active": false, "aud": "mcp://gbrg-containment", "scope": ["containment:sever:full"]},
+		"resource": {"kind": "mcp_tool", "name": "sever_endpoint", "audience": "mcp://gbrg-containment", "required_scope": "containment:sever:full"},
+	}
+}

--- a/schemas/wordops/capability-lease-token.schema.json
+++ b/schemas/wordops/capability-lease-token.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/wordops/capability-lease-token.schema.json",
+  "title": "CapabilityLeaseToken",
+  "description": "The WIRE representation of a WordOps capability-lease: the down-scoped JWT-claims form minted by the capability broker via OAuth token exchange and presented at the MCP/A2A boundary. This is NOT the canonical lease record (capability-lease.schema.json) — it is the on-the-wire token derived from it. Timestamps are NumericDate (epoch seconds) per RFC 7519; `risk` is the coarse public band, while the canonical record carries the estate's A0-A4 `risk_class`. Reconciles the external Phase-0 reference pack into the estate without overwriting the richer internal record.",
+  "type": "object",
+  "required": ["sub", "act", "aud", "scope", "risk", "exp", "nbf", "jti"],
+  "properties": {
+    "sub": { "type": "string", "description": "Subject principal receiving the lease" },
+    "act": { "type": "string", "description": "Actor on whose behalf the lease is issued (acting-party)" },
+    "aud": {
+      "description": "Target service or gateway audience",
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+      ]
+    },
+    "scope": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+    "case_id": { "type": "string" },
+    "task_id": { "type": "string" },
+    "risk": {
+      "type": "string",
+      "description": "Coarse public risk band. Maps to the canonical risk_class: low→A0/A1, medium→A2, high→A3, regulated→A4.",
+      "enum": ["low", "medium", "high", "regulated"]
+    },
+    "risk_class": {
+      "type": "string",
+      "description": "The estate's fine-grained autonomy class, carried through when present (authoritative over `risk`).",
+      "enum": ["A0", "A1", "A2", "A3", "A4"]
+    },
+    "approval_id": { "type": "string" },
+    "exp": { "type": "integer", "description": "Expiry (NumericDate, epoch seconds)" },
+    "nbf": { "type": "integer", "description": "Not-before (NumericDate, epoch seconds)" },
+    "jti": { "type": "string", "description": "Unique token id; correlates to the canonical lease_id" },
+    "dpop_jkt": { "type": "string", "description": "DPoP JWK SHA-256 thumbprint binding the token to a key" },
+    "traceparent": { "type": "string" },
+    "policy_version": { "type": "string" },
+    "workflow_version": { "type": "string" }
+  },
+  "additionalProperties": true
+}

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -182,6 +182,11 @@ KNOWN_BROKEN = {
         "TwinEventEnvelope stream; Cybernetic Agentic Genesis & Inception Phase-1 read-only skeleton) added to CI "
         "this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
     ),
+    "wordops-mcp-gateway:moving-tag": (
+        "New service — WordOps lease-enforcing MCP gateway (apps/wordops-mcp-gateway: authorizes A0-A4 "
+        "capability-leases, containment=>A4, and writes ExecutionReceipts to the ledger) added to CI this PR. "
+        "Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
+    ),
     # health-twin pinned to a sha- tag by gitops-promote after its first CI build (#932) → removed
     # from the ratchet (it only shrinks).
     # portfolio-agent pinned to a sha- tag by gitops-promote after its first CI build (#925,

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -177,15 +177,20 @@ KNOWN_BROKEN = {
         "declarations -> fail-closed-validated DeviceReadings) added to CI this PR. Pin tag:latest -> the sha- "
         "tag after the first CI build; no sha exists until merge."
     ),
-    "cloud-twin:moving-tag": (
-        "New service — Cloud-Twin as a Service (apps/cloud-twin: GenesisSeed -> verified Twin -> replayable "
-        "TwinEventEnvelope stream; Cybernetic Agentic Genesis & Inception Phase-1 read-only skeleton) added to CI "
-        "this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
-    ),
     "wordops-mcp-gateway:moving-tag": (
         "New service — WordOps lease-enforcing MCP gateway (apps/wordops-mcp-gateway: authorizes A0-A4 "
         "capability-leases, containment=>A4, and writes ExecutionReceipts to the ledger) added to CI this PR. "
         "Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
+    ),
+    "wordops-capability-broker:moving-tag": (
+        "New service — WordOps capability broker (apps/wordops-capability-broker: runs A0-A4 allow_issue and "
+        "mints RS256-signed lease JWTs + publishes JWKS) added to CI this PR. Pin tag:latest -> the sha- tag "
+        "after the first CI build; no sha exists until merge."
+    ),
+    "wordops-room-factory:moving-tag": (
+        "New service — WordOps room-factory (apps/wordops-room-factory: opens encrypted invite-only "
+        "non-federated Matrix incident/case rooms) added to CI this PR. Pin tag:latest -> the sha- tag after "
+        "the first CI build; no sha exists until merge."
     ),
     # health-twin pinned to a sha- tag by gitops-promote after its first CI build (#932) → removed
     # from the ratchet (it only shrinks).


### PR DESCRIPTION
The complete **WordOps** agentic chat-ops lease fabric: governed containment + executions-ledger back-ends, cryptographic lease issuance/verification, and governed Matrix room creation — all in prophet-platform. **Matrix rooms stay collaboration context; the gateway + ledger are the authorization sink.**

## Services (all Go stdlib, all `go test`-green)
- **`wordops-capability-broker`** — issuance: runs A0–A4 `allow_issue`, mints **RS256-signed** capability-lease JWTs, publishes `/.well-known/jwks.json`. Sign→verify round-trip tested.
- **`wordops-mcp-gateway`** (`jose.go`) — **verifies lease authenticity before enforcing claims**: RS256 JWS vs broker JWKS (kid/iss/nbf/exp) + **DPoP** proof-of-possession (RFC 9449). Invalid tokens / DPoP mismatches → `401`, audited as denied. Then audience/scope/case/task + containment⇒A4. Calls `gbrg-containment`, writes an `ExecutionReceipt` to the ledger. Tests: wrong-key/expired/tampered, DPoP present/valid/mismatch/stale.
- **`wordops-room-factory`** — opens PRIVATE Matrix incident/case rooms with a **fixed taxonomy** (encryption on, invite-only, federation off) regardless of caller input. Tested against a fake Synapse.
- **`agent-activity-ledger`** — `POST /executions` durable sink enforcing INV1–INV4.
- **`gbrg-containment`** — governed sever/residual engine (fixture topology; authoritative algo = `gbrg-core::containment` in sociosphere).

## Governance
- **`infra/wordops/opa/lease_policy.rego`** — A0–A4 ladder; containment sever intrinsically A4 (approval or documented break-glass + step-up + ≤30s). `opa test` **14/14**.
- **`schemas/wordops/capability-lease-token.schema.json`** — JWT wire form (canonical A0–A4 record untouched).
- A2A containment agent cards; **`docs/WORDOPS_REFERENCE_FLOW.md`** (incident→containment, maturity-labeled).

## Deploy
Dockerfiles (gateway copies `*.go`), `images.yml` rows, `deploy/values` (zot + `zot-pull`; broker signing-key + room-factory token as **optional** Secrets; gateway BROKER_JWKS_URL/ISSUER), appset entries, preflight ratchet.

## Honest remaining
- Broker uses an ephemeral dev signing key until the `wordops-broker-signing` Secret is mounted; room-factory needs the `wordops-room-factory` token Secret for a live homeserver. Containment/ledger stores are fixture/in-memory. RSA/RS256 throughout (EC/ES256 is a mechanical add).

## Verification
`opa test` 14/14 · `go test` (4 services, non-cached) green · `preflight` exit 0 · `go vet`/`gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)