### PR TITLE
feat(web-intel): owned Web Intelligence lane — governed metrics for self and competitors

### DIFF
--- a/.github/workflows/web-intel-lane.yml
+++ b/.github/workflows/web-intel-lane.yml
@@ -1,5 +1,8 @@
 name: web-intel-lane
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/web-intel-lane.yml
+++ b/.github/workflows/web-intel-lane.yml
@@ -1,0 +1,42 @@
+name: web-intel-lane
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'contracts/web-intel/**'
+      - 'apps/web-intel-metrics/**'
+      - 'tools/emit_web_intel_scorecard.py'
+      - 'tools/validate_web_intel_contracts.py'
+      - 'tools/tests/test_web_intel.py'
+      - '.github/workflows/web-intel-lane.yml'
+  pull_request:
+    paths:
+      - 'contracts/web-intel/**'
+      - 'apps/web-intel-metrics/**'
+      - 'tools/emit_web_intel_scorecard.py'
+      - 'tools/validate_web_intel_contracts.py'
+      - 'tools/tests/test_web_intel.py'
+      - '.github/workflows/web-intel-lane.yml'
+
+jobs:
+  web-intel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema pytest fastapi httpx
+      - name: Validate contracts (schemas + examples)
+        run: python tools/validate_web_intel_contracts.py
+      - name: Tools tests (emitter meet-logic + validator)
+        run: pytest -q tools/tests/test_web_intel.py
+      - name: App tests (service endpoints)
+        working-directory: apps/web-intel-metrics
+        run: PYTHONPATH=. pytest -q tests
+      - name: Emitter smoke (governed scorecard from examples)
+        run: python tools/emit_web_intel_scorecard.py --in contracts/web-intel/examples --subject socioprophet.com --relation self

--- a/apps/web-intel-metrics/README.md
+++ b/apps/web-intel-metrics/README.md
@@ -1,0 +1,41 @@
+# Web Intelligence metrics app
+
+Deployable consumer for the **Web Intelligence** lane (`contracts/web-intel`).
+Serves governed web-intelligence metric bundles — site audit, backlink profile,
+AI-search visibility, SERP/rank, content gap, and the unified scorecard —
+**symmetrically for our own domains and for competitors**.
+
+## Responsibilities
+
+- expose liveness
+- expose the lane's event types
+- expose recent metric/scorecard bundles
+- expose bundles filtered **by subject domain** (self or competitor)
+- expose bundle detail by correlation id
+
+## Endpoints
+
+- `GET /healthz`
+- `GET /v1/web-intel/event-types`
+- `GET /v1/web-intel/recent?limit=`
+- `GET /v1/web-intel/by-subject/{subject}?limit=`
+- `GET /v1/web-intel/{correlation_id}`
+
+## Service name
+
+`web-intel-metrics`
+
+## State layout
+
+Reads the platform state conventions used elsewhere in `prophet-platform`:
+`~/.local/state/prophet-platform/{payloads,events,receipts}/web-intel-metrics/`
+(overridable via `SOCIOPROFIT_STATE_HOME`). Scorecard bundles are written there
+by `tools/emit_web_intel_scorecard.py --emit`.
+
+## Test
+
+```bash
+python3 -m venv .venv && . .venv/bin/activate
+pip install -r requirements-test.txt
+PYTHONPATH=. pytest -q tests
+```

--- a/apps/web-intel-metrics/app/main.py
+++ b/apps/web-intel-metrics/app/main.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException, Query
+
+from .store import EVENT_TYPES, SERVICE, get_bundle, list_recent
+
+app = FastAPI(title="Prophet Platform Web Intelligence Metrics", version="0.1.0")
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"status": "ok", "service": SERVICE}
+
+
+@app.get("/v1/web-intel/event-types")
+def event_types() -> dict:
+    return {"service": SERVICE, "event_types": EVENT_TYPES}
+
+
+@app.get("/v1/web-intel/recent")
+def recent(limit: int = Query(20, ge=1, le=200)) -> dict:
+    return {"service": SERVICE, "items": list_recent(limit=limit)}
+
+
+@app.get("/v1/web-intel/by-subject/{subject}")
+def by_subject(subject: str, limit: int = Query(20, ge=1, le=200)) -> dict:
+    # Symmetric: works for our own domains and for competitors alike.
+    return {"service": SERVICE, "subject": subject, "items": list_recent(limit=limit, subject=subject)}
+
+
+@app.get("/v1/web-intel/{correlation_id}")
+def detail(correlation_id: str) -> dict:
+    bundle = get_bundle(correlation_id)
+    if bundle is None:
+        raise HTTPException(status_code=404, detail="bundle not found")
+    return bundle

--- a/apps/web-intel-metrics/app/store.py
+++ b/apps/web-intel-metrics/app/store.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+SERVICE = "web-intel-metrics"
+EVENT_TYPES = [
+    "webintel.site_audit.completed.v0",
+    "webintel.backlink_profile.assessed.v0",
+    "webintel.ai_visibility.probed.v0",
+    "webintel.serp_rank.tracked.v0",
+    "webintel.content_gap.analyzed.v0",
+    "webintel.scorecard.generated.v0",
+]
+
+
+def state_home() -> Path:
+    if v := os.environ.get("SOCIOPROFIT_STATE_HOME"):
+        return Path(v)
+    return Path.home() / ".local" / "state"
+
+
+def platform_state_root() -> Path:
+    return state_home() / "prophet-platform"
+
+
+def _payload_dir() -> Path:
+    return platform_state_root() / "payloads" / SERVICE
+
+
+def _event_dir() -> Path:
+    return platform_state_root() / "events" / SERVICE
+
+
+def _receipt_dir() -> Path:
+    return platform_state_root() / "receipts" / SERVICE
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def get_bundle(correlation_id: str) -> dict[str, Any] | None:
+    receipt_path = _receipt_dir() / f"{correlation_id}.receipt.json"
+    event_path = _event_dir() / f"{correlation_id}.event.json"
+    payload_path = _payload_dir() / f"{correlation_id}.payload.json"
+    if not receipt_path.exists():
+        return None
+    return {
+        "service": SERVICE,
+        "correlation_id": correlation_id,
+        "receipt_ref": f"file://{receipt_path.resolve()}",
+        "event_ref": f"file://{event_path.resolve()}" if event_path.exists() else None,
+        "payload_ref": f"file://{payload_path.resolve()}" if payload_path.exists() else None,
+        "receipt": _read_json(receipt_path),
+        "event": _read_json(event_path),
+        "payload": _read_json(payload_path),
+    }
+
+
+def _item(correlation_id: str) -> dict[str, Any] | None:
+    bundle = get_bundle(correlation_id)
+    if bundle is None:
+        return None
+    receipt = bundle.get("receipt") or {}
+    event = bundle.get("event") or {}
+    payload = bundle.get("payload") or {}
+    return {
+        "correlation_id": correlation_id,
+        "created_at": receipt.get("created_at") or event.get("created_at"),
+        "action": receipt.get("action"),
+        "status": receipt.get("status"),
+        "event_type": event.get("event_type"),
+        "subject": payload.get("subject") or receipt.get("subject_ref") or event.get("subject_ref"),
+        "relation": payload.get("relation"),
+        "overall_epistemic_level": payload.get("overall_epistemic_level") or payload.get("epistemic_level"),
+    }
+
+
+def list_recent(limit: int = 20, subject: str | None = None) -> list[dict[str, Any]]:
+    if not _receipt_dir().exists():
+        return []
+    files = sorted(_receipt_dir().glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    items: list[dict[str, Any]] = []
+    for path in files:
+        correlation_id = path.name.removesuffix(".receipt.json")
+        item = _item(correlation_id)
+        if item is None:
+            continue
+        if subject is not None and item.get("subject") != subject:
+            continue
+        items.append(item)
+        if len(items) >= limit:
+            break
+    return items

--- a/apps/web-intel-metrics/requirements-test.txt
+++ b/apps/web-intel-metrics/requirements-test.txt
@@ -1,0 +1,3 @@
+fastapi>=0.110
+httpx>=0.27
+pytest>=8.0

--- a/apps/web-intel-metrics/tests/test_http_main.py
+++ b/apps/web-intel-metrics/tests/test_http_main.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import app.main as main  # type: ignore
+
+client = TestClient(main.app)
+
+
+def _seed(tmp_path: Path, subject: str, corr: str) -> None:
+    base = tmp_path / "prophet-platform"
+    for kind in ("payloads", "events", "receipts"):
+        (base / kind / "web-intel-metrics").mkdir(parents=True, exist_ok=True)
+    payload = base / "payloads" / "web-intel-metrics" / f"{corr}.payload.json"
+    event = base / "events" / "web-intel-metrics" / f"{corr}.event.json"
+    receipt = base / "receipts" / "web-intel-metrics" / f"{corr}.receipt.json"
+    payload.write_text(
+        '{"subject":"' + subject + '","relation":"self","overall_epistemic_level":"empirical",'
+        '"headline":{"site_health_score":61.5}}\n',
+        encoding="utf-8",
+    )
+    event.write_text(
+        '{"event_type":"webintel.scorecard.generated.v0","created_at":"2026-07-31T00:00:00+00:00","subject_ref":"'
+        + subject + '"}\n',
+        encoding="utf-8",
+    )
+    receipt.write_text(
+        '{"status":"succeeded","action":"GenerateWebIntelScorecard","subject_ref":"' + subject
+        + '","created_at":"2026-07-31T00:00:00+00:00"}\n',
+        encoding="utf-8",
+    )
+
+
+def test_healthz():
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json()["service"] == "web-intel-metrics"
+
+
+def test_event_types():
+    resp = client.get("/v1/web-intel/event-types")
+    assert resp.status_code == 200
+    types = resp.json()["event_types"]
+    assert "webintel.scorecard.generated.v0" in types
+    assert "webintel.ai_visibility.probed.v0" in types
+
+
+def test_recent_by_subject_and_detail(monkeypatch, tmp_path):
+    _seed(tmp_path, "socioprophet.com", "wi-self-1")
+    _seed(tmp_path, "a-competitor.example", "wi-comp-1")
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+
+    recent = client.get("/v1/web-intel/recent", params={"limit": 10})
+    assert recent.status_code == 200
+    assert len(recent.json()["items"]) == 2
+
+    # Symmetric: query a competitor's subject just like our own.
+    comp = client.get("/v1/web-intel/by-subject/a-competitor.example")
+    assert comp.status_code == 200
+    comp_items = comp.json()["items"]
+    assert len(comp_items) == 1
+    assert comp_items[0]["subject"] == "a-competitor.example"
+
+    detail = client.get("/v1/web-intel/wi-self-1")
+    assert detail.status_code == 200
+    payload = detail.json()
+    assert payload["payload"]["subject"] == "socioprophet.com"
+    assert payload["event"]["event_type"] == "webintel.scorecard.generated.v0"
+
+
+def test_detail_404():
+    assert client.get("/v1/web-intel/does-not-exist").status_code == 404

--- a/contracts/web-intel/README.md
+++ b/contracts/web-intel/README.md
@@ -1,0 +1,48 @@
+# Web Intelligence lane — platform contracts
+
+Governed, contract-first event schemas for the **Web Intelligence** lane of the
+intelligence program. This lane evaluates industry-standard web-intelligence
+metrics — the kind vendors like Semrush charge for — **for our own domains and
+for competitors, symmetrically**, and emits every metric as a governed claim.
+
+We do not consume a vendor here. This lane is the specification for our own
+owned engine (crawler + AI-visibility probes + SERP probes). Vendor tools are
+the *bar*, not a dependency.
+
+## What makes this beat the industry bar
+
+Every event carries the same **warrant envelope** — so a competitor metric is as
+auditable as one about ourselves:
+
+- `subject` — the domain evaluated (ours or a competitor's).
+- `relation` — `self | competitor | prospect | partner` (the lane is symmetric).
+- `epistemic_level` — `proved | bounded | empirical | synthetic | speculative | rejected`.
+- `provenance` — `source` (`owned_crawler | ai_probe | serp_probe | link_graph`),
+  `method`, `sample_size`, `collected_at`.
+
+Two differentiators the standard vendors do not offer:
+
+1. **AI-search-native** — `webintel.ai_visibility.probed.v0` measures visibility
+   and citation across ChatGPT, Perplexity, Google AI, Gemini, and Grok.
+2. **Warranted + composable** — the scorecard's `overall_epistemic_level` is the
+   **meet** of its component levels (one weak input caps the whole), and it
+   carries a **value-driver** breakdown so intel findings arrive with quantified,
+   equity-weighted impact rather than raw numbers.
+
+## Event families
+
+### Upstream (owned-engine measurements)
+- `webintel.site_audit.completed.v0`
+- `webintel.backlink_profile.assessed.v0`
+- `webintel.ai_visibility.probed.v0`
+- `webintel.serp_rank.tracked.v0`
+- `webintel.content_gap.analyzed.v0`
+
+### Downstream (synthesis)
+- `webintel.scorecard.generated.v0`
+
+## Notes
+
+Contract-first: schemas land before runtime. The deployable consumer is
+`apps/web-intel-metrics`; schemas are validated by
+`tools/validate_web_intel_contracts.py` against the committed examples.

--- a/contracts/web-intel/events/webintel.ai_visibility.probed.v0.schema.json
+++ b/contracts/web-intel/events/webintel.ai_visibility.probed.v0.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/web-intel/ai_visibility_probed.v0.schema.json",
+  "title": "webintel.ai_visibility.probed.v0",
+  "description": "AI-search visibility for a subject domain across generative engines. The axis the standard vendors do not cover.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id", "emitted_at", "tenant_id", "producer", "subject", "relation",
+    "epistemic_level", "provenance", "query", "visibility_score", "engines"
+  ],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 8 },
+    "emitted_at": { "type": "string" },
+    "tenant_id": { "type": "string" },
+    "producer": { "type": "string" },
+    "subject": { "type": "string" },
+    "relation": { "enum": ["self", "competitor", "prospect", "partner"] },
+    "epistemic_level": { "enum": ["proved", "bounded", "empirical", "synthetic", "speculative", "rejected"] },
+    "provenance": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source", "method", "collected_at"],
+      "properties": {
+        "source": { "enum": ["owned_crawler", "ai_probe", "serp_probe", "link_graph"] },
+        "method": { "type": "string" },
+        "sample_size": { "type": "integer", "minimum": 0 },
+        "collected_at": { "type": "string" }
+      }
+    },
+    "query": { "type": "string" },
+    "visibility_score": { "type": "number", "minimum": 0, "maximum": 100, "description": "Share of probed engines that cited the subject." },
+    "engines": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["engine", "cited"],
+        "properties": {
+          "engine": { "enum": ["chatgpt", "perplexity", "google_ai", "gemini", "grok"] },
+          "cited": { "type": "boolean" },
+          "position": { "type": ["integer", "null"], "minimum": 1 },
+          "sentiment": { "enum": ["positive", "neutral", "negative", null] },
+          "snippet_ref": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/contracts/web-intel/events/webintel.backlink_profile.assessed.v0.schema.json
+++ b/contracts/web-intel/events/webintel.backlink_profile.assessed.v0.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/web-intel/backlink_profile_assessed.v0.schema.json",
+  "title": "webintel.backlink_profile.assessed.v0",
+  "description": "Owned link-graph backlink profile + toxicity for a subject domain.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id", "emitted_at", "tenant_id", "producer", "subject", "relation",
+    "epistemic_level", "provenance", "referring_domains", "backlinks_total",
+    "toxic_domains", "toxic_share_pct", "anchor_concentration_pct", "authority_score"
+  ],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 8 },
+    "emitted_at": { "type": "string" },
+    "tenant_id": { "type": "string" },
+    "producer": { "type": "string" },
+    "subject": { "type": "string" },
+    "relation": { "enum": ["self", "competitor", "prospect", "partner"] },
+    "epistemic_level": { "enum": ["proved", "bounded", "empirical", "synthetic", "speculative", "rejected"] },
+    "provenance": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source", "method", "collected_at"],
+      "properties": {
+        "source": { "enum": ["owned_crawler", "ai_probe", "serp_probe", "link_graph"] },
+        "method": { "type": "string" },
+        "sample_size": { "type": "integer", "minimum": 0 },
+        "collected_at": { "type": "string" }
+      }
+    },
+    "referring_domains": { "type": "integer", "minimum": 0 },
+    "backlinks_total": { "type": "integer", "minimum": 0 },
+    "toxic_domains": { "type": "integer", "minimum": 0 },
+    "potentially_toxic_domains": { "type": "integer", "minimum": 0 },
+    "toxic_share_pct": { "type": "number", "minimum": 0, "maximum": 100 },
+    "anchor_concentration_pct": { "type": "number", "minimum": 0, "maximum": 100 },
+    "authority_score": { "type": "number", "minimum": 0, "maximum": 100 },
+    "link_farm_clusters": { "type": "integer", "minimum": 0 },
+    "disavow_candidates": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Referring domains recommended for disavow (post human review)."
+    }
+  }
+}

--- a/contracts/web-intel/events/webintel.content_gap.analyzed.v0.schema.json
+++ b/contracts/web-intel/events/webintel.content_gap.analyzed.v0.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/web-intel/content_gap_analyzed.v0.schema.json",
+  "title": "webintel.content_gap.analyzed.v0",
+  "description": "Keywords a competitor ranks for that the reference domain does not — the symmetric, competitor-facing metric.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id", "emitted_at", "tenant_id", "producer", "subject", "relation",
+    "epistemic_level", "provenance", "reference_domain", "gap_keywords"
+  ],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 8 },
+    "emitted_at": { "type": "string" },
+    "tenant_id": { "type": "string" },
+    "producer": { "type": "string" },
+    "subject": { "type": "string", "description": "The competitor whose coverage is analyzed." },
+    "relation": { "enum": ["self", "competitor", "prospect", "partner"] },
+    "epistemic_level": { "enum": ["proved", "bounded", "empirical", "synthetic", "speculative", "rejected"] },
+    "provenance": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source", "method", "collected_at"],
+      "properties": {
+        "source": { "enum": ["owned_crawler", "ai_probe", "serp_probe", "link_graph"] },
+        "method": { "type": "string" },
+        "sample_size": { "type": "integer", "minimum": 0 },
+        "collected_at": { "type": "string" }
+      }
+    },
+    "reference_domain": { "type": "string", "description": "The domain compared against the subject (usually ours)." },
+    "gap_keywords": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["keyword", "subject_position"],
+        "properties": {
+          "keyword": { "type": "string" },
+          "subject_position": { "type": ["integer", "null"], "minimum": 1 },
+          "reference_position": { "type": ["integer", "null"], "minimum": 1 },
+          "search_volume": { "type": "integer", "minimum": 0 }
+        }
+      }
+    }
+  }
+}

--- a/contracts/web-intel/events/webintel.scorecard.generated.v0.schema.json
+++ b/contracts/web-intel/events/webintel.scorecard.generated.v0.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/web-intel/scorecard_generated.v0.schema.json",
+  "title": "webintel.scorecard.generated.v0",
+  "description": "Unified web-intelligence scorecard for a subject domain. overall_epistemic_level is the MEET of contributing component levels (one weak input caps the whole); value_drivers carry equity-weighted impact.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id", "emitted_at", "tenant_id", "producer", "subject", "relation",
+    "overall_epistemic_level", "component_event_ids", "headline", "value_drivers"
+  ],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 8 },
+    "emitted_at": { "type": "string" },
+    "tenant_id": { "type": "string" },
+    "producer": { "type": "string" },
+    "subject": { "type": "string" },
+    "relation": { "enum": ["self", "competitor", "prospect", "partner"] },
+    "overall_epistemic_level": {
+      "enum": ["proved", "bounded", "empirical", "synthetic", "speculative", "rejected"],
+      "description": "The meet (lowest) of the epistemic_level of every contributing component event."
+    },
+    "component_event_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "event_id of each metric event that fed this scorecard (the lineage)."
+    },
+    "headline": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "site_health_score": { "type": "number", "minimum": 0, "maximum": 100 },
+        "authority_score": { "type": "number", "minimum": 0, "maximum": 100 },
+        "ai_visibility_score": { "type": "number", "minimum": 0, "maximum": 100 },
+        "share_of_voice_pct": { "type": "number", "minimum": 0, "maximum": 100 }
+      }
+    },
+    "value_drivers": {
+      "type": "array",
+      "description": "Value-driver breakdown: each web-intel dimension mapped to a driver + equity-weighted impact score. Generalizes the VDT scorecard into the intelligence program.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["driver", "kpi", "score", "equity_weight"],
+        "properties": {
+          "driver": { "type": "string" },
+          "kpi": { "type": "string" },
+          "score": { "type": "number" },
+          "equity_weight": { "type": "number", "minimum": 0, "maximum": 1 },
+          "notes": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/contracts/web-intel/events/webintel.serp_rank.tracked.v0.schema.json
+++ b/contracts/web-intel/events/webintel.serp_rank.tracked.v0.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/web-intel/serp_rank_tracked.v0.schema.json",
+  "title": "webintel.serp_rank.tracked.v0",
+  "description": "Organic SERP position + share-of-voice for a subject domain on a keyword.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id", "emitted_at", "tenant_id", "producer", "subject", "relation",
+    "epistemic_level", "provenance", "keyword", "position", "share_of_voice_pct"
+  ],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 8 },
+    "emitted_at": { "type": "string" },
+    "tenant_id": { "type": "string" },
+    "producer": { "type": "string" },
+    "subject": { "type": "string" },
+    "relation": { "enum": ["self", "competitor", "prospect", "partner"] },
+    "epistemic_level": { "enum": ["proved", "bounded", "empirical", "synthetic", "speculative", "rejected"] },
+    "provenance": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source", "method", "collected_at"],
+      "properties": {
+        "source": { "enum": ["owned_crawler", "ai_probe", "serp_probe", "link_graph"] },
+        "method": { "type": "string" },
+        "sample_size": { "type": "integer", "minimum": 0 },
+        "collected_at": { "type": "string" }
+      }
+    },
+    "keyword": { "type": "string" },
+    "position": { "type": ["integer", "null"], "minimum": 1 },
+    "previous_position": { "type": ["integer", "null"], "minimum": 1 },
+    "search_volume": { "type": "integer", "minimum": 0 },
+    "share_of_voice_pct": { "type": "number", "minimum": 0, "maximum": 100 },
+    "serp_features": { "type": "array", "items": { "type": "string" } },
+    "url": { "type": "string" }
+  }
+}

--- a/contracts/web-intel/events/webintel.site_audit.completed.v0.schema.json
+++ b/contracts/web-intel/events/webintel.site_audit.completed.v0.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/web-intel/site_audit_completed.v0.schema.json",
+  "title": "webintel.site_audit.completed.v0",
+  "description": "Owned-crawler site audit for a subject domain. Semrush-parity site-health detail, warranted.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id", "emitted_at", "tenant_id", "producer", "subject", "relation",
+    "epistemic_level", "provenance", "site_health_score", "ai_search_health_score",
+    "pages_crawled", "status_buckets", "duplicates", "internal_link", "control_files"
+  ],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 8 },
+    "emitted_at": { "type": "string" },
+    "tenant_id": { "type": "string" },
+    "producer": { "type": "string" },
+    "subject": { "type": "string" },
+    "relation": { "enum": ["self", "competitor", "prospect", "partner"] },
+    "epistemic_level": { "enum": ["proved", "bounded", "empirical", "synthetic", "speculative", "rejected"] },
+    "provenance": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source", "method", "collected_at"],
+      "properties": {
+        "source": { "enum": ["owned_crawler", "ai_probe", "serp_probe", "link_graph"] },
+        "method": { "type": "string" },
+        "sample_size": { "type": "integer", "minimum": 0 },
+        "collected_at": { "type": "string" }
+      }
+    },
+    "site_health_score": { "type": "number", "minimum": 0, "maximum": 100 },
+    "ai_search_health_score": { "type": "number", "minimum": 0, "maximum": 100 },
+    "pages_crawled": { "type": "integer", "minimum": 0 },
+    "status_buckets": {
+      "type": "object", "additionalProperties": false,
+      "required": ["ok_2xx", "redirect_3xx", "broken_4xx", "server_5xx"],
+      "properties": {
+        "ok_2xx": { "type": "integer", "minimum": 0 },
+        "redirect_3xx": { "type": "integer", "minimum": 0 },
+        "broken_4xx": { "type": "integer", "minimum": 0 },
+        "server_5xx": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "duplicates": {
+      "type": "object", "additionalProperties": false,
+      "required": ["titles", "meta_descriptions", "content"],
+      "properties": {
+        "titles": { "type": "integer", "minimum": 0 },
+        "meta_descriptions": { "type": "integer", "minimum": 0 },
+        "content": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "thin_pages": { "type": "integer", "minimum": 0 },
+    "redirect_chains_max": { "type": "integer", "minimum": 0 },
+    "internal_link": {
+      "type": "object", "additionalProperties": false,
+      "required": ["single_inbound_pages", "no_anchor_links", "orphan_pages"],
+      "properties": {
+        "single_inbound_pages": { "type": "integer", "minimum": 0 },
+        "no_anchor_links": { "type": "integer", "minimum": 0 },
+        "orphan_pages": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "control_files": {
+      "type": "object", "additionalProperties": false,
+      "required": ["robots_present", "sitemap_present", "llms_present"],
+      "properties": {
+        "robots_present": { "type": "boolean" },
+        "sitemap_present": { "type": "boolean" },
+        "llms_present": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/contracts/web-intel/examples/ai_visibility.probed.json
+++ b/contracts/web-intel/examples/ai_visibility.probed.json
@@ -1,0 +1,19 @@
+{
+  "event_id": "wi-ai-0001",
+  "emitted_at": "2026-07-31T00:00:00+00:00",
+  "tenant_id": "socioprophet",
+  "producer": "web-intel-ai-probe",
+  "subject": "socioprophet.com",
+  "relation": "self",
+  "epistemic_level": "empirical",
+  "provenance": { "source": "ai_probe", "method": "five-engine-citation-probe", "sample_size": 5, "collected_at": "2026-07-31T00:00:00+00:00" },
+  "query": "governed AI orchestration platform",
+  "visibility_score": 40.0,
+  "engines": [
+    { "engine": "chatgpt", "cited": true, "position": 3, "sentiment": "neutral", "snippet_ref": "s-1" },
+    { "engine": "perplexity", "cited": true, "position": 2, "sentiment": "positive", "snippet_ref": "s-2" },
+    { "engine": "google_ai", "cited": false, "position": null, "sentiment": null, "snippet_ref": "" },
+    { "engine": "gemini", "cited": false, "position": null, "sentiment": null, "snippet_ref": "" },
+    { "engine": "grok", "cited": false, "position": null, "sentiment": null, "snippet_ref": "" }
+  ]
+}

--- a/contracts/web-intel/examples/backlink_profile.assessed.json
+++ b/contracts/web-intel/examples/backlink_profile.assessed.json
@@ -1,0 +1,19 @@
+{
+  "event_id": "wi-bl-0001",
+  "emitted_at": "2026-07-31T00:00:00+00:00",
+  "tenant_id": "socioprophet",
+  "producer": "web-intel-linkgraph",
+  "subject": "socioprophet.com",
+  "relation": "self",
+  "epistemic_level": "empirical",
+  "provenance": { "source": "link_graph", "method": "owned-crawl+commoncrawl-merge", "sample_size": 1200, "collected_at": "2026-07-31T00:00:00+00:00" },
+  "referring_domains": 130,
+  "backlinks_total": 1200,
+  "toxic_domains": 37,
+  "potentially_toxic_domains": 17,
+  "toxic_share_pct": 42.0,
+  "anchor_concentration_pct": 78.3,
+  "authority_score": 34.0,
+  "link_farm_clusters": 1,
+  "disavow_candidates": ["spam-farm-01.example", "aged-domain-seller.example"]
+}

--- a/contracts/web-intel/examples/content_gap.analyzed.json
+++ b/contracts/web-intel/examples/content_gap.analyzed.json
@@ -1,0 +1,15 @@
+{
+  "event_id": "wi-cg-0001",
+  "emitted_at": "2026-07-31T00:00:00+00:00",
+  "tenant_id": "socioprophet",
+  "producer": "web-intel-serp-probe",
+  "subject": "a-competitor.example",
+  "relation": "competitor",
+  "epistemic_level": "empirical",
+  "provenance": { "source": "serp_probe", "method": "keyword-set-diff", "sample_size": 2, "collected_at": "2026-07-31T00:00:00+00:00" },
+  "reference_domain": "socioprophet.com",
+  "gap_keywords": [
+    { "keyword": "ai model risk attestation", "subject_position": 4, "reference_position": null, "search_volume": 320 },
+    { "keyword": "provable ai audit trail", "subject_position": 6, "reference_position": 41, "search_volume": 210 }
+  ]
+}

--- a/contracts/web-intel/examples/scorecard.generated.json
+++ b/contracts/web-intel/examples/scorecard.generated.json
@@ -1,0 +1,17 @@
+{
+  "event_id": "wi-sc-0001",
+  "emitted_at": "2026-07-31T00:00:00+00:00",
+  "tenant_id": "socioprophet",
+  "producer": "web-intel-metrics",
+  "subject": "socioprophet.com",
+  "relation": "self",
+  "overall_epistemic_level": "empirical",
+  "component_event_ids": ["wi-sa-0001", "wi-bl-0001", "wi-ai-0001", "wi-sr-0001"],
+  "headline": { "site_health_score": 61.5, "authority_score": 34.0, "ai_visibility_score": 40.0, "share_of_voice_pct": 6.2 },
+  "value_drivers": [
+    { "driver": "Discoverability", "kpi": "site_health_score", "score": 61.5, "equity_weight": 0.3, "notes": "Owned crawl; duplicates + thin pages drag it." },
+    { "driver": "Authority", "kpi": "authority_score", "score": 34.0, "equity_weight": 0.25, "notes": "42% toxic referring share caps this." },
+    { "driver": "AI-Search Presence", "kpi": "ai_visibility_score", "score": 40.0, "equity_weight": 0.25, "notes": "Cited by 2 of 5 engines." },
+    { "driver": "Demand Capture", "kpi": "share_of_voice_pct", "score": 6.2, "equity_weight": 0.2, "notes": "Organic SoV on tracked keyword set." }
+  ]
+}

--- a/contracts/web-intel/examples/serp_rank.tracked.json
+++ b/contracts/web-intel/examples/serp_rank.tracked.json
@@ -1,0 +1,17 @@
+{
+  "event_id": "wi-sr-0001",
+  "emitted_at": "2026-07-31T00:00:00+00:00",
+  "tenant_id": "socioprophet",
+  "producer": "web-intel-serp-probe",
+  "subject": "socioprophet.com",
+  "relation": "self",
+  "epistemic_level": "empirical",
+  "provenance": { "source": "serp_probe", "method": "owned-serp-fetch", "sample_size": 1, "collected_at": "2026-07-31T00:00:00+00:00" },
+  "keyword": "governed ai orchestration",
+  "position": 8,
+  "previous_position": 12,
+  "search_volume": 480,
+  "share_of_voice_pct": 6.2,
+  "serp_features": ["ai_overview", "people_also_ask"],
+  "url": "https://socioprophet.com/"
+}

--- a/contracts/web-intel/examples/site_audit.completed.json
+++ b/contracts/web-intel/examples/site_audit.completed.json
@@ -1,0 +1,19 @@
+{
+  "event_id": "wi-sa-0001",
+  "emitted_at": "2026-07-31T00:00:00+00:00",
+  "tenant_id": "socioprophet",
+  "producer": "web-intel-crawler",
+  "subject": "socioprophet.com",
+  "relation": "self",
+  "epistemic_level": "empirical",
+  "provenance": { "source": "owned_crawler", "method": "playwright+lxml+simhash", "sample_size": 15, "collected_at": "2026-07-31T00:00:00+00:00" },
+  "site_health_score": 61.5,
+  "ai_search_health_score": 40.0,
+  "pages_crawled": 15,
+  "status_buckets": { "ok_2xx": 9, "redirect_3xx": 4, "broken_4xx": 4, "server_5xx": 0 },
+  "duplicates": { "titles": 30, "meta_descriptions": 30, "content": 30 },
+  "thin_pages": 28,
+  "redirect_chains_max": 2,
+  "internal_link": { "single_inbound_pages": 18, "no_anchor_links": 46, "orphan_pages": 2 },
+  "control_files": { "robots_present": true, "sitemap_present": true, "llms_present": true }
+}

--- a/contracts/web-intel/schemas/metric-claim-envelope.v0.schema.json
+++ b/contracts/web-intel/schemas/metric-claim-envelope.v0.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/web-intel/metric_claim_envelope.v0.schema.json",
+  "title": "metric-claim-envelope.v0",
+  "description": "Shared warrant envelope carried by every Web Intelligence event. Makes a competitor metric as auditable as one about ourselves.",
+  "type": "object",
+  "required": [
+    "event_id",
+    "emitted_at",
+    "tenant_id",
+    "producer",
+    "subject",
+    "relation",
+    "epistemic_level",
+    "provenance"
+  ],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 8 },
+    "emitted_at": { "type": "string", "description": "ISO-8601 timestamp" },
+    "tenant_id": { "type": "string" },
+    "producer": { "type": "string" },
+    "subject": { "type": "string", "description": "The domain evaluated (ours or a competitor's)." },
+    "relation": { "enum": ["self", "competitor", "prospect", "partner"] },
+    "epistemic_level": {
+      "enum": ["proved", "bounded", "empirical", "synthetic", "speculative", "rejected"]
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "method", "collected_at"],
+      "properties": {
+        "source": { "enum": ["owned_crawler", "ai_probe", "serp_probe", "link_graph"] },
+        "method": { "type": "string" },
+        "sample_size": { "type": "integer", "minimum": 0 },
+        "collected_at": { "type": "string" }
+      }
+    }
+  }
+}

--- a/docs/WEB_INTEL_LANE.md
+++ b/docs/WEB_INTEL_LANE.md
@@ -1,0 +1,59 @@
+# Web Intelligence lane
+
+The Web Intelligence lane makes industry-standard web-intelligence metrics — the
+kind vendors like Semrush sell — a **first-class, owned capability of the
+intelligence program**, evaluable **for our own domains and for competitors**,
+with every metric emitted as a governed claim.
+
+We do not consume a vendor. Vendor tooling is the *bar* we match and beat.
+
+## Where it sits
+
+Third lane of the intelligence program, alongside:
+
+1. **Contract / competitive intel** — Crystal Atlas (`contracts/crystal-atlas`, `apps/crystal-atlas-contract-intel`).
+2. **Value-driver / valuation** — the value-projection tooling.
+3. **Web intelligence** — this lane (`contracts/web-intel`, `apps/web-intel-metrics`).
+
+The scorecard integrates the value-driver mechanism directly: each web-intel
+dimension is mapped to a driver with an equity-weighted impact score, so
+findings arrive quantified rather than raw.
+
+## Owned engine (the sources behind the metrics)
+
+- **owned_crawler** — Playwright/Scrapy + lxml + simhash/minhash → site health,
+  crawl buckets, duplicate/thin detection, internal-link graph, control files.
+- **link_graph** — owned crawl merged with Common Crawl → backlink profile,
+  toxicity, anchor concentration, authority, disavow candidates.
+- **serp_probe** — owned SERP fetch → rank, share-of-voice, content gaps.
+- **ai_probe** — five-engine citation probe (ChatGPT, Perplexity, Google AI,
+  Gemini, Grok) → AI-search visibility. This is the axis standard vendors miss.
+
+## How it beats the bar
+
+- **Symmetric.** Every event carries `subject` + `relation` (`self | competitor |
+  prospect | partner`); a competitor metric is as first-class and auditable as
+  one about ourselves.
+- **Warranted.** Every metric carries `epistemic_level` + `provenance`
+  (source/method/sample_size/collected_at). The scorecard's
+  `overall_epistemic_level` is the **meet** of its components — one weak input
+  caps the whole.
+- **AI-search-native.** First-class visibility across five generative engines.
+- **Composable.** Scorecards feed the value-driver breakdown and the broader
+  intelligence program on one evidence spine.
+
+## Event families
+
+Upstream: `webintel.site_audit.completed.v0`,
+`webintel.backlink_profile.assessed.v0`, `webintel.ai_visibility.probed.v0`,
+`webintel.serp_rank.tracked.v0`, `webintel.content_gap.analyzed.v0`.
+
+Downstream: `webintel.scorecard.generated.v0`.
+
+## Runtime
+
+- Service: `apps/web-intel-metrics` (FastAPI). Endpoints under `/v1/web-intel`.
+- Emitter: `tools/emit_web_intel_scorecard.py` synthesizes a governed scorecard
+  from component metric events and writes it to the state spine.
+- Validation: `tools/validate_web_intel_contracts.py` checks every schema and
+  its committed example (the lane CI gate).

--- a/tools/emit_web_intel_scorecard.py
+++ b/tools/emit_web_intel_scorecard.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Emit a governed Web Intelligence scorecard from component metric events.
+
+Synthesizes `webintel.scorecard.generated.v0` from upstream metric events. The
+scorecard's `overall_epistemic_level` is the **meet** (lowest) of its components'
+levels — one weak input caps the whole, per the governance thesis — and it
+carries a value-driver breakdown so intel arrives with equity-weighted impact.
+
+Actionable: with `--emit` it writes an event/receipt/payload bundle to the
+platform state spine, the same layout `apps/web-intel-metrics` reads.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Epistemic lattice, lowest to highest. meet = the lower of two.
+_LEVELS = ["rejected", "speculative", "synthetic", "empirical", "bounded", "proved"]
+
+SERVICE = "web-intel-metrics"
+
+
+def meet_all(levels: list[str]) -> str:
+    """The meet (lowest) of a set of epistemic levels; empty -> 'speculative'."""
+    ranks = [_LEVELS.index(x) for x in levels if x in _LEVELS]
+    if not ranks:
+        return "speculative"
+    return _LEVELS[min(ranks)]
+
+
+def _headline(components: list[dict[str, Any]]) -> dict[str, float]:
+    head: dict[str, float] = {}
+    for c in components:
+        if "site_health_score" in c:
+            head["site_health_score"] = float(c["site_health_score"])
+        if "authority_score" in c:
+            head["authority_score"] = float(c["authority_score"])
+        if "visibility_score" in c:
+            head["ai_visibility_score"] = float(c["visibility_score"])
+        if "share_of_voice_pct" in c:
+            head["share_of_voice_pct"] = float(c["share_of_voice_pct"])
+    return head
+
+
+def _value_drivers(head: dict[str, float]) -> list[dict[str, Any]]:
+    spec = [
+        ("Discoverability", "site_health_score", 0.30),
+        ("Authority", "authority_score", 0.25),
+        ("AI-Search Presence", "ai_visibility_score", 0.25),
+        ("Demand Capture", "share_of_voice_pct", 0.20),
+    ]
+    drivers = []
+    for driver, kpi, weight in spec:
+        if kpi in head:
+            drivers.append({"driver": driver, "kpi": kpi, "score": head[kpi], "equity_weight": weight})
+    return drivers
+
+
+def compute_scorecard(
+    components: list[dict[str, Any]],
+    *,
+    subject: str,
+    relation: str,
+    tenant_id: str = "socioprophet",
+    producer: str = SERVICE,
+) -> dict[str, Any]:
+    """Build a scorecard payload from component metric events (pure function)."""
+    head = _headline(components)
+    return {
+        "event_id": f"wi-sc-{uuid.uuid4().hex[:12]}",
+        "emitted_at": datetime.now(timezone.utc).isoformat(),
+        "tenant_id": tenant_id,
+        "producer": producer,
+        "subject": subject,
+        "relation": relation,
+        "overall_epistemic_level": meet_all([c.get("epistemic_level", "speculative") for c in components]),
+        "component_event_ids": [c["event_id"] for c in components if "event_id" in c],
+        "headline": head,
+        "value_drivers": _value_drivers(head),
+    }
+
+
+def _state_root() -> Path:
+    home = os.environ.get("SOCIOPROFIT_STATE_HOME")
+    base = Path(home) if home else Path.home() / ".local" / "state"
+    return base / "prophet-platform"
+
+
+def emit(scorecard: dict[str, Any]) -> str:
+    """Write event/receipt/payload bundle to the state spine. Returns correlation id."""
+    corr = scorecard["event_id"]
+    root = _state_root()
+    for kind, payload in (
+        ("payloads", scorecard),
+        ("events", {"event_type": "webintel.scorecard.generated.v0", "created_at": scorecard["emitted_at"], "subject_ref": scorecard["subject"]}),
+        ("receipts", {"status": "succeeded", "action": "GenerateWebIntelScorecard", "subject_ref": scorecard["subject"], "created_at": scorecard["emitted_at"]}),
+    ):
+        d = root / kind / SERVICE
+        d.mkdir(parents=True, exist_ok=True)
+        suffix = {"payloads": "payload", "events": "event", "receipts": "receipt"}[kind]
+        (d / f"{corr}.{suffix}.json").write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return corr
+
+
+def _load_components(in_dir: Path) -> list[dict[str, Any]]:
+    comps = []
+    for p in sorted(in_dir.glob("*.json")):
+        if p.name.startswith("scorecard"):
+            continue
+        comps.append(json.loads(p.read_text(encoding="utf-8")))
+    return comps
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Emit a governed Web Intelligence scorecard.")
+    ap.add_argument("--in", dest="in_dir", required=True, help="Directory of component metric event JSON files.")
+    ap.add_argument("--subject", required=True, help="Subject domain.")
+    ap.add_argument("--relation", default="self", choices=["self", "competitor", "prospect", "partner"])
+    ap.add_argument("--emit", action="store_true", help="Write the bundle to the state spine.")
+    args = ap.parse_args()
+
+    components = _load_components(Path(args.in_dir))
+    scorecard = compute_scorecard(components, subject=args.subject, relation=args.relation)
+    print(json.dumps(scorecard, indent=2, sort_keys=True))
+    if args.emit:
+        corr = emit(scorecard)
+        print(f"emitted: {corr}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_web_intel.py
+++ b/tools/tests/test_web_intel.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+TOOLS = Path(__file__).resolve().parents[1]
+ROOT = TOOLS.parent
+sys.path.insert(0, str(TOOLS))
+
+import emit_web_intel_scorecard as em  # type: ignore
+import validate_web_intel_contracts as vc  # type: ignore
+
+LANE = ROOT / "contracts" / "web-intel"
+
+
+def test_meet_is_lowest_level():
+    assert em.meet_all(["proved", "empirical", "synthetic"]) == "synthetic"
+    assert em.meet_all(["proved", "bounded"]) == "bounded"
+
+
+def test_rejected_absorbs():
+    assert em.meet_all(["proved", "rejected"]) == "rejected"
+
+
+def test_empty_meet_is_speculative():
+    assert em.meet_all([]) == "speculative"
+
+
+def test_compute_scorecard_conforms_and_meets():
+    components = [
+        json.loads((LANE / "examples" / "site_audit.completed.json").read_text()),
+        json.loads((LANE / "examples" / "backlink_profile.assessed.json").read_text()),
+        json.loads((LANE / "examples" / "ai_visibility.probed.json").read_text()),
+        json.loads((LANE / "examples" / "serp_rank.tracked.json").read_text()),
+    ]
+    sc = em.compute_scorecard(components, subject="socioprophet.com", relation="self")
+
+    # overall level is the meet of components (all empirical here).
+    assert sc["overall_epistemic_level"] == "empirical"
+    # headline was extracted from the heterogeneous components.
+    assert sc["headline"]["site_health_score"] == 61.5
+    assert sc["headline"]["ai_visibility_score"] == 40.0
+    assert sc["headline"]["share_of_voice_pct"] == 6.2
+    assert len(sc["value_drivers"]) == 4
+
+    # and it validates against the committed scorecard schema.
+    schema = json.loads((LANE / "events" / "webintel.scorecard.generated.v0.schema.json").read_text())
+    errors = list(Draft202012Validator(schema).iter_errors(sc))
+    assert errors == [], [e.message for e in errors]
+
+
+def test_one_weak_component_caps_the_scorecard():
+    components = [
+        {"event_id": "a", "epistemic_level": "proved", "site_health_score": 90},
+        {"event_id": "b", "epistemic_level": "synthetic", "authority_score": 50},
+    ]
+    sc = em.compute_scorecard(components, subject="x.example", relation="competitor")
+    assert sc["overall_epistemic_level"] == "synthetic"  # capped by the weakest
+
+
+def test_contracts_validator_passes():
+    assert vc.main() == 0

--- a/tools/validate_web_intel_contracts.py
+++ b/tools/validate_web_intel_contracts.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Validate the Web Intelligence lane contracts.
+
+For every event schema under contracts/web-intel/events:
+  * the schema itself is a valid JSON Schema (Draft 2020-12); and
+  * the committed example payload validates against it.
+
+Also validates the shared metric-claim envelope schema. Exits non-zero on any
+failure so the lane's CI gate fails closed.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+LANE = ROOT / "contracts" / "web-intel"
+EVENTS = LANE / "events"
+EXAMPLES = LANE / "examples"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _example_name(schema_path: Path) -> str:
+    # webintel.site_audit.completed.v0.schema.json -> site_audit.completed.json
+    stem = schema_path.name
+    stem = stem.removeprefix("webintel.").removesuffix(".v0.schema.json")
+    return f"{stem}.json"
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    envelope = LANE / "schemas" / "metric-claim-envelope.v0.schema.json"
+    if not envelope.exists():
+        errors.append("missing metric-claim-envelope.v0.schema.json")
+    else:
+        Draft202012Validator.check_schema(_load(envelope))
+
+    schema_files = sorted(EVENTS.glob("*.schema.json"))
+    if not schema_files:
+        errors.append("no event schemas found under contracts/web-intel/events")
+
+    for schema_path in schema_files:
+        schema = _load(schema_path)
+        try:
+            Draft202012Validator.check_schema(schema)
+        except Exception as exc:  # noqa: BLE001 - report any invalid schema
+            errors.append(f"{schema_path.name}: invalid schema: {exc}")
+            continue
+
+        example_path = EXAMPLES / _example_name(schema_path)
+        if not example_path.exists():
+            errors.append(f"{schema_path.name}: missing example {example_path.name}")
+            continue
+
+        validator = Draft202012Validator(schema)
+        for e in sorted(validator.iter_errors(_load(example_path)), key=lambda e: list(e.path)):
+            errors.append(f"{example_path.name}: {list(e.path)}: {e.message}")
+
+    if errors:
+        print("Web Intelligence contract validation FAILED:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    print(f"Web Intelligence contracts OK: {len(schema_files)} event schemas validated against examples.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Web Intelligence lane — owned, governed, symmetric

Adds the intelligence program's **third lane**: an owned web-intelligence engine that matches industry-standard (Semrush-parity) metric detail and **beats** it on the axes vendors miss. **No vendor dependency** — vendor tooling is the bar, not a source.

### Where it sits
1. Contract/competitive intel — **Crystal Atlas** (exists)
2. Value-driver / valuation — value-projection tooling (exists)
3. **Web intelligence — this lane** (was previously outsourced + self-only + one-off; now owned, repeatable, symmetric)

### Contracts (`contracts/web-intel`, contract-first)
5 upstream metric families + downstream scorecard, each carrying a **warrant envelope**: `subject` + `relation` (`self|competitor|prospect|partner`), `epistemic_level`, `provenance`.
- **AI-search-native**: `ai_visibility` spans ChatGPT/Perplexity/Google-AI/Gemini/Grok — the axis standard vendors don't cover.
- **Warranted + composable**: `scorecard.overall_epistemic_level` = **meet** of component levels (one weak input caps the whole); a `value_drivers` breakdown integrates the VDT mechanism so findings arrive equity-weighted.
- Committed examples for every family (real socioprophet.com Tier-A numbers).

### Runtime (actionable services/apps)
- `apps/web-intel-metrics` — FastAPI service; `/v1/web-intel` recent, **by-subject** (symmetric self/competitor), detail, event-types.
- `tools/emit_web_intel_scorecard.py` — synthesizes a governed scorecard (meet + value drivers) and writes event/receipt/payload to the state spine.
- `tools/validate_web_intel_contracts.py` — schema + example validation.

### Evidence
Contracts validator **6/6**; tools tests **6**; app tests **4**; emitter smoke green. Path-filtered CI at `.github/workflows/web-intel-lane.yml`. No `validate_repo` suspect patterns.

### Scope note
Contract-first lane + deployable consumer + emitter. The owned crawler / AI-probe / SERP-probe collectors that *populate* these events are the next increment (the schemas are their target contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
