### PR TITLE
feat(secrets): mint wordops broker-signing + sync room-factory token in CI

### DIFF
--- a/.github/workflows/provision-secrets.yml
+++ b/.github/workflows/provision-secrets.yml
@@ -10,7 +10,9 @@ name: provision-secrets
 #   • Variables:  GKE_CLUSTER, GKE_LOCATION  (the prophet-platform GKE Autopilot cluster)
 #   • Secrets:    GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT  (already set),
 #                 plus the token values: SPARK_RUNNER_TOKEN, LATTICE_FORGE_TOKEN,
-#                 COMPUTE_GATEWAY_TOKEN, STUDIO_WRITE_TOKEN, ARCTICDB_GATEWAY_TOKEN
+#                 COMPUTE_GATEWAY_TOKEN, STUDIO_WRITE_TOKEN, ARCTICDB_GATEWAY_TOKEN,
+#                 WORDOPS_ROOM_FACTORY_TOKEN (the Synapse-issued room-factory service-account token).
+#                 wordops-broker-signing needs NO GitHub secret — it is MINTED here.
 #
 # Run: Actions → provision-secrets → Run workflow (optionally scope with `only`).
 # Rotate a token = update the GitHub secret, re-run. A missing value is skipped, not errored.
@@ -66,6 +68,7 @@ jobs:
           COMPUTE_GATEWAY_TOKEN: ${{ secrets.COMPUTE_GATEWAY_TOKEN }}
           STUDIO_WRITE_TOKEN: ${{ secrets.STUDIO_WRITE_TOKEN }}
           ARCTICDB_GATEWAY_TOKEN: ${{ secrets.ARCTICDB_GATEWAY_TOKEN }}
+          WORDOPS_ROOM_FACTORY_TOKEN: ${{ secrets.WORDOPS_ROOM_FACTORY_TOKEN }}
           ONLY: ${{ inputs.only }}
         run: |
           set -euo pipefail
@@ -90,6 +93,10 @@ jobs:
           sync compute-gateway-token token "$COMPUTE_GATEWAY_TOKEN" socioprophet
           sync studio-write-token    token "$STUDIO_WRITE_TOKEN"    socioprophet
           sync arcticdb-gateway-token token "$ARCTICDB_GATEWAY_TOKEN" socioprophet
+          # wordops-room-factory holds the Synapse service-account access token the room-factory
+          # uses to createRoom. Synapse ISSUES it, so it originates in a GitHub secret and is
+          # synced (not minted). The deploy marks it optional: until present, /rooms fails closed.
+          sync wordops-room-factory access_token "$WORDOPS_ROOM_FACTORY_TOKEN" socioprophet
 
           echo "done."
 
@@ -215,3 +222,49 @@ jobs:
           kubectl create secret generic "$NAME" -n "$NS" \
             --from-literal=token="$TOK" --dry-run=client -o yaml | kubectl apply -f -
           echo "✔ $NAME → namespace/$NS (minted in CI; the value exists nowhere else)"
+
+      # wordops-broker-signing is the RSA private key the wordops-capability-broker signs lease
+      # JWTs with. NOBODY should ever know it — CI generates it and it never leaves the cluster.
+      # The gateway verifies leases via the broker's PUBLIC JWKS, so only the private half is secret.
+      #
+      # CREATE-IF-ABSENT with plain rotation: rotating swaps the signing key, so leases signed by
+      # the OLD key (all ≤30s TTL) fail verification until they expire and the broker republishes
+      # its JWKS — a brief, self-healing window. Restart wordops-capability-broker after a rotation
+      # so it loads the new key and serves the new JWKS. Until this Secret exists the broker boots an
+      # EPHEMERAL key (deploy marks the secret optional) — fine for dev, but the key then changes on
+      # every pod restart, so mint this for stable verification.
+      - name: Mint wordops-broker-signing (create-if-absent)
+        env:
+          ONLY: ${{ inputs.only }}
+          ROTATE: ${{ inputs.rotate }}
+        run: |
+          set -euo pipefail
+          NAME=wordops-broker-signing NS=socioprophet
+          if [ -n "$ONLY" ] && ! printf ',%s,' "$ONLY" | grep -q ",$NAME,"; then
+            echo "· skip $NAME (not in 'only' filter)"; exit 0
+          fi
+
+          EXISTS=$(kubectl get secret "$NAME" -n "$NS" --ignore-not-found -o name || true)
+          FORCE=false
+          if printf ',%s,' "$ROTATE" | grep -q ",$NAME,"; then FORCE=true; fi
+
+          if [ -n "$EXISTS" ] && [ "$FORCE" != true ]; then
+            echo "✔ $NAME already present in $NS — left untouched (minted secrets are never silently regenerated)"
+            exit 0
+          fi
+          if [ -n "$EXISTS" ] && [ "$FORCE" = true ]; then
+            echo "⚠ ROTATING $NAME. Leases signed by the old key (≤30s TTL) fail verification until they"
+            echo "⚠ expire; restart wordops-capability-broker so it serves the new JWKS."
+          fi
+
+          KEY_FILE=$(mktemp)
+          trap 'rm -f "$KEY_FILE"' EXIT
+          # 2048-bit RSA. `openssl genrsa` emits PKCS#1 or PKCS#8 PEM depending on the openssl
+          # version; the broker's loadOrGenerateKey accepts either, so no -traditional needed.
+          openssl genrsa -out "$KEY_FILE" 2048
+          openssl rsa -in "$KEY_FILE" -noout -check >/dev/null 2>&1 || { echo "✗ generated key failed openssl check"; exit 1; }
+
+          # --from-file keeps the multi-line PEM off the command line and out of any log.
+          kubectl create secret generic "$NAME" -n "$NS" \
+            --from-file=private.pem="$KEY_FILE" --dry-run=client -o yaml | kubectl apply -f -
+          echo "✔ $NAME → namespace/$NS (RSA private key minted in CI; the value exists nowhere else)"


### PR DESCRIPTION
Provisions the two remaining WordOps Secrets **through CI** (the estate rule: secrets are minted/synced in CI, never hand-generated or applied out-of-band), added to the canonical `provision-secrets.yml`.

- **`wordops-broker-signing`** — **MINTED**: CI runs `openssl genrsa 2048`, validates it, and applies it create-if-absent. The RSA private key the `wordops-capability-broker` signs lease JWTs with exists nowhere else (no GitHub secret, no human, no terminal history); the gateway only ever needs the public JWKS. Rotation is opt-in via the `rotate` input and self-heals because leases are ≤30s.
- **`wordops-room-factory`** (`access_token`) — **SYNCED** from `WORDOPS_ROOM_FACTORY_TOKEN`: Synapse *issues* this service-account token, so it originates in a GitHub secret and CI materializes it (same class as spark-runner-token et al.).

Both target namespace `socioprophet`; the deploys mark them `optional: true`, so services stay fail-closed until provisioned. Verified: the minted PEM parses in the broker's key loader (PKCS#1/#8); workflow YAML valid.

**To go live after merge:** set the `WORDOPS_ROOM_FACTORY_TOKEN` repo secret (from the Synapse service account), then run Actions → provision-secrets (optionally `only: wordops-broker-signing,wordops-room-factory`), and restart the two services so they pick up the Secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)