### PR TITLE
feat(crystal-atlas): value-driver seam — wire value drivers into competitive intel

### DIFF
--- a/.github/workflows/value-driver-seam.yml
+++ b/.github/workflows/value-driver-seam.yml
@@ -1,0 +1,40 @@
+name: value-driver-seam
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'contracts/crystal-atlas/events/intel.value_driver.scored.v0.schema.json'
+      - 'contracts/crystal-atlas/examples/intel.value_driver.scored.v0.json'
+      - 'tools/emit_value_driver_score.py'
+      - 'tools/tests/test_value_driver_seam.py'
+      - '.github/workflows/value-driver-seam.yml'
+  pull_request:
+    paths:
+      - 'contracts/crystal-atlas/events/intel.value_driver.scored.v0.schema.json'
+      - 'contracts/crystal-atlas/examples/intel.value_driver.scored.v0.json'
+      - 'tools/emit_value_driver_score.py'
+      - 'tools/tests/test_value_driver_seam.py'
+      - '.github/workflows/value-driver-seam.yml'
+
+jobs:
+  value-driver-seam:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema pytest
+      - name: Seam tests (schema + example + scoring)
+        run: pytest -q tools/tests/test_value_driver_seam.py
+      - name: Emitter smoke (score a real Crystal Atlas finding)
+        run: |
+          echo '{"source_event_type":"procurement.substitution.recommended.v0","source_event_id":"c1","estimated_savings_pct":60,"substitution_confidence":80,"coverage_completeness":100}' > "$RUNNER_TEMP/finding.json"
+          python tools/emit_value_driver_score.py --in "$RUNNER_TEMP/finding.json" --subject vendor://acme-corp

--- a/contracts/crystal-atlas/events/intel.value_driver.scored.v0.schema.json
+++ b/contracts/crystal-atlas/events/intel.value_driver.scored.v0.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/crystal-atlas/intel_value_driver_scored.v0.schema.json",
+  "title": "intel.value_driver.scored.v0",
+  "description": "Attaches an equity-weighted value-driver score to a Crystal Atlas downstream finding. The seam that wires the value-driver mechanism into the competitive-intelligence lane, so findings arrive quantified rather than raw.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "event_id", "emitted_at", "tenant_id", "producer", "subject",
+    "epistemic_level", "provenance", "source", "value_drivers", "overall_value_score"
+  ],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 8 },
+    "emitted_at": { "type": "string" },
+    "tenant_id": { "type": "string" },
+    "producer": { "type": "string" },
+    "subject": { "type": "string", "description": "The entity the finding concerns (company / contract / competitor)." },
+    "epistemic_level": { "enum": ["proved", "bounded", "empirical", "synthetic", "speculative", "rejected"] },
+    "provenance": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source", "method", "collected_at"],
+      "properties": {
+        "source": { "enum": ["crystal_atlas", "analyst", "model"] },
+        "method": { "type": "string" },
+        "collected_at": { "type": "string" }
+      }
+    },
+    "source": {
+      "type": "object", "additionalProperties": false,
+      "required": ["source_event_type", "source_event_id"],
+      "properties": {
+        "source_event_type": {
+          "enum": [
+            "contract.clauses.compared.v0",
+            "procurement.substitution.recommended.v0",
+            "entitlement.adjacency.inferred.v0",
+            "diligence.risk.pack.generated.v0"
+          ]
+        },
+        "source_event_id": { "type": "string" }
+      }
+    },
+    "value_drivers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["driver", "kpi", "score", "equity_weight"],
+        "properties": {
+          "driver": { "type": "string" },
+          "kpi": { "type": "string" },
+          "score": { "type": "number" },
+          "equity_weight": { "type": "number", "minimum": 0, "maximum": 1 },
+          "notes": { "type": "string" }
+        }
+      }
+    },
+    "overall_value_score": {
+      "type": "number",
+      "description": "Equity-weighted aggregate of the driver scores (sum of score * equity_weight)."
+    }
+  }
+}

--- a/contracts/crystal-atlas/examples/intel.value_driver.scored.v0.json
+++ b/contracts/crystal-atlas/examples/intel.value_driver.scored.v0.json
@@ -1,0 +1,16 @@
+{
+  "event_id": "cav-vd-0001",
+  "emitted_at": "2026-08-01T00:00:00+00:00",
+  "tenant_id": "socioprophet",
+  "producer": "value-driver-scorer",
+  "subject": "vendor://acme-corp",
+  "epistemic_level": "empirical",
+  "provenance": { "source": "crystal_atlas", "method": "downstream-finding-mapping", "collected_at": "2026-08-01T00:00:00+00:00" },
+  "source": { "source_event_type": "procurement.substitution.recommended.v0", "source_event_id": "corr-cla-771" },
+  "value_drivers": [
+    { "driver": "Cost Efficiency", "kpi": "estimated_savings_pct", "score": 62.0, "equity_weight": 0.5, "notes": "Substitution reduces annual spend." },
+    { "driver": "Switching Risk", "kpi": "substitution_confidence", "score": 80.0, "equity_weight": 0.3, "notes": "High-confidence like-for-like substitute." },
+    { "driver": "Continuity", "kpi": "coverage_completeness", "score": 90.0, "equity_weight": 0.2, "notes": "No clause coverage lost." }
+  ],
+  "overall_value_score": 73.0
+}

--- a/docs/CRYSTAL_ATLAS_VALUE_DRIVER_SEAM.md
+++ b/docs/CRYSTAL_ATLAS_VALUE_DRIVER_SEAM.md
@@ -1,0 +1,38 @@
+# Crystal Atlas → value-driver seam
+
+Wires the **value-driver mechanism into the competitive-intelligence lane**. Prior
+to this, Crystal Atlas findings and the value-driver/valuation tooling were
+disconnected (no cross-reference in either direction). This seam closes that gap.
+
+## What it does
+
+`intel.value_driver.scored.v0` (in `contracts/crystal-atlas/events`) takes a
+Crystal Atlas **downstream finding** and attaches an equity-weighted value-driver
+breakdown plus an overall value score, so a finding arrives **quantified** rather
+than raw:
+
+| Source finding | Value drivers |
+|---|---|
+| `procurement.substitution.recommended.v0` | Cost Efficiency, Switching Risk, Continuity |
+| `diligence.risk.pack.generated.v0` | Risk Exposure (inverted), Coverage Completeness |
+| `entitlement.adjacency.inferred.v0` | Expansion Potential |
+| `contract.clauses.compared.v0` | Change Materiality |
+| (unknown) | generic Finding Value fallback |
+
+Each driver carries `score` (0..100) and `equity_weight` (weights sum to 1 per
+finding type), and `overall_value_score = Σ score × equity_weight`. Every event
+carries `epistemic_level` + `provenance`, consistent with the rest of the
+intelligence program.
+
+## Runtime
+
+- Emitter: `tools/emit_value_driver_score.py` maps a finding to the scored event
+  and, with `--emit`, writes an event/receipt/payload bundle to the state spine.
+- Validation: `tools/tests/test_value_driver_seam.py` validates the schema, the
+  committed example, and the emitter's scoring against the schema.
+
+## Where it sits
+
+Third connective seam of the intelligence program: Crystal Atlas (contract/
+competitive intel) → **value drivers** (this seam) alongside the Web Intelligence
+lane (`contracts/web-intel`), all warranted and on one evidence spine.

--- a/tools/emit_value_driver_score.py
+++ b/tools/emit_value_driver_score.py
@@ -14,12 +14,41 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 SERVICE = "value-driver-scorer"
+
+# The four Crystal Atlas downstream findings this seam accepts (matches the strict
+# source_event_type enum in intel.value_driver.scored.v0). Enforced before any
+# write so append-only state is never polluted with an out-of-contract event.
+ALLOWED_SOURCE_EVENT_TYPES = frozenset(
+    {
+        "contract.clauses.compared.v0",
+        "procurement.substitution.recommended.v0",
+        "entitlement.adjacency.inferred.v0",
+        "diligence.risk.pack.generated.v0",
+    }
+)
+
+
+class OutOfContractEvent(ValueError):
+    """Raised when an event would violate the seam contract (fail-closed on emit)."""
+
+
+def assert_emittable(event: dict[str, Any]) -> None:
+    """Reject events that must not enter append-only state (spec D2/D11)."""
+    src = event.get("source", {})
+    t = src.get("source_event_type")
+    if t not in ALLOWED_SOURCE_EVENT_TYPES:
+        raise OutOfContractEvent(
+            f"refusing to emit: source_event_type {t!r} is not one of {sorted(ALLOWED_SOURCE_EVENT_TYPES)}"
+        )
+    if not src.get("source_event_id"):
+        raise OutOfContractEvent("refusing to emit: source.source_event_id must be non-empty")
 
 
 def drivers_for(finding: dict[str, Any]) -> list[tuple[str, str, float, float]]:
@@ -90,6 +119,8 @@ def _state_root() -> Path:
 
 
 def emit(event: dict[str, Any]) -> str:
+    # Fail-closed: never write an out-of-contract event to append-only state.
+    assert_emittable(event)
     corr = event["event_id"]
     root = _state_root()
     for kind, payload, suffix in (
@@ -114,7 +145,11 @@ def main() -> int:
     event = compute_scored_event(finding, subject=args.subject)
     print(json.dumps(event, indent=2, sort_keys=True))
     if args.emit:
-        print(f"emitted: {emit(event)}")
+        try:
+            print(f"emitted: {emit(event)}")
+        except OutOfContractEvent as exc:
+            print(f"NOT emitted: {exc}", file=sys.stderr)
+            return 3
     return 0
 
 

--- a/tools/emit_value_driver_score.py
+++ b/tools/emit_value_driver_score.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Score a Crystal Atlas downstream finding on value drivers (the value-driver seam).
+
+Consumes a Crystal Atlas downstream finding (procurement substitution, diligence
+risk pack, entitlement adjacency, clause comparison) and emits
+`intel.value_driver.scored.v0` — an equity-weighted value-driver breakdown plus
+an overall value score — so competitive-intelligence findings arrive quantified.
+
+Actionable: with `--emit` it writes an event/receipt/payload bundle to the
+platform state spine.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SERVICE = "value-driver-scorer"
+
+
+def drivers_for(finding: dict[str, Any]) -> list[tuple[str, str, float, float]]:
+    """Return (driver, kpi, score, equity_weight) tuples for a finding.
+
+    Weights within each finding type sum to 1.0, so the overall score stays on a
+    0..100 scale. An unknown type falls back to a single generic driver.
+    """
+    t = finding.get("source_event_type", "")
+    if t == "procurement.substitution.recommended.v0":
+        return [
+            ("Cost Efficiency", "estimated_savings_pct", float(finding.get("estimated_savings_pct", 0.0)), 0.5),
+            ("Switching Risk", "substitution_confidence", float(finding.get("substitution_confidence", 0.0)), 0.3),
+            ("Continuity", "coverage_completeness", float(finding.get("coverage_completeness", 100.0)), 0.2),
+        ]
+    if t == "diligence.risk.pack.generated.v0":
+        risk = float(finding.get("risk_score", 0.0))
+        return [
+            ("Risk Exposure", "risk_score_inverted", max(0.0, 100.0 - risk), 0.6),
+            ("Coverage Completeness", "coverage_completeness", float(finding.get("coverage_completeness", 0.0)), 0.4),
+        ]
+    if t == "entitlement.adjacency.inferred.v0":
+        return [("Expansion Potential", "adjacency_strength", float(finding.get("adjacency_strength", 0.0)), 1.0)]
+    if t == "contract.clauses.compared.v0":
+        return [("Change Materiality", "changed_families_pct", float(finding.get("changed_families_pct", 0.0)), 1.0)]
+    return [("Finding Value", "value_score", float(finding.get("value_score", 0.0)), 1.0)]
+
+
+def compute_scored_event(
+    finding: dict[str, Any],
+    *,
+    subject: str,
+    tenant_id: str = "socioprophet",
+    producer: str = SERVICE,
+) -> dict[str, Any]:
+    """Build an intel.value_driver.scored.v0 payload from a Crystal Atlas finding."""
+    tuples = drivers_for(finding)
+    value_drivers = [
+        {"driver": d, "kpi": k, "score": round(s, 2), "equity_weight": w}
+        for (d, k, s, w) in tuples
+    ]
+    overall = round(sum(s * w for (_, _, s, w) in tuples), 2)
+    return {
+        "event_id": f"cav-vd-{uuid.uuid4().hex[:12]}",
+        "emitted_at": datetime.now(timezone.utc).isoformat(),
+        "tenant_id": tenant_id,
+        "producer": producer,
+        "subject": subject,
+        "epistemic_level": finding.get("epistemic_level", "empirical"),
+        "provenance": {
+            "source": "crystal_atlas",
+            "method": "downstream-finding-mapping",
+            "collected_at": datetime.now(timezone.utc).isoformat(),
+        },
+        "source": {
+            "source_event_type": finding.get("source_event_type", ""),
+            "source_event_id": finding.get("source_event_id", ""),
+        },
+        "value_drivers": value_drivers,
+        "overall_value_score": overall,
+    }
+
+
+def _state_root() -> Path:
+    home = os.environ.get("SOCIOPROFIT_STATE_HOME")
+    base = Path(home) if home else Path.home() / ".local" / "state"
+    return base / "prophet-platform"
+
+
+def emit(event: dict[str, Any]) -> str:
+    corr = event["event_id"]
+    root = _state_root()
+    for kind, payload, suffix in (
+        ("payloads", event, "payload"),
+        ("events", {"event_type": "intel.value_driver.scored.v0", "created_at": event["emitted_at"], "subject_ref": event["subject"]}, "event"),
+        ("receipts", {"status": "succeeded", "action": "ScoreValueDrivers", "subject_ref": event["subject"], "created_at": event["emitted_at"]}, "receipt"),
+    ):
+        d = root / kind / SERVICE
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{corr}.{suffix}.json").write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return corr
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Score a Crystal Atlas finding on value drivers.")
+    ap.add_argument("--in", dest="in_file", required=True, help="Crystal Atlas downstream finding JSON.")
+    ap.add_argument("--subject", required=True)
+    ap.add_argument("--emit", action="store_true")
+    args = ap.parse_args()
+
+    finding = json.loads(Path(args.in_file).read_text(encoding="utf-8"))
+    event = compute_scored_event(finding, subject=args.subject)
+    print(json.dumps(event, indent=2, sort_keys=True))
+    if args.emit:
+        print(f"emitted: {emit(event)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_value_driver_seam.py
+++ b/tools/tests/test_value_driver_seam.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+TOOLS = Path(__file__).resolve().parents[1]
+ROOT = TOOLS.parent
+sys.path.insert(0, str(TOOLS))
+
+import emit_value_driver_score as vd  # type: ignore
+
+SCHEMA = json.loads(
+    (ROOT / "contracts" / "crystal-atlas" / "events" / "intel.value_driver.scored.v0.schema.json").read_text()
+)
+EXAMPLE = ROOT / "contracts" / "crystal-atlas" / "examples" / "intel.value_driver.scored.v0.json"
+
+
+def test_committed_example_conforms():
+    errors = list(Draft202012Validator(SCHEMA).iter_errors(json.loads(EXAMPLE.read_text())))
+    assert errors == [], [e.message for e in errors]
+
+
+def test_substitution_finding_scores_and_conforms():
+    finding = {
+        "source_event_type": "procurement.substitution.recommended.v0",
+        "source_event_id": "corr-1",
+        "estimated_savings_pct": 60.0,
+        "substitution_confidence": 80.0,
+        "coverage_completeness": 100.0,
+        "epistemic_level": "empirical",
+    }
+    ev = vd.compute_scored_event(finding, subject="vendor://acme")
+    # 0.5*60 + 0.3*80 + 0.2*100 = 30 + 24 + 20 = 74
+    assert ev["overall_value_score"] == 74.0
+    assert {d["driver"] for d in ev["value_drivers"]} == {"Cost Efficiency", "Switching Risk", "Continuity"}
+    errors = list(Draft202012Validator(SCHEMA).iter_errors(ev))
+    assert errors == [], [e.message for e in errors]
+
+
+def test_diligence_risk_is_inverted():
+    finding = {
+        "source_event_type": "diligence.risk.pack.generated.v0",
+        "source_event_id": "corr-2",
+        "risk_score": 70.0,
+        "coverage_completeness": 50.0,
+    }
+    ev = vd.compute_scored_event(finding, subject="target://x")
+    # risk_exposure = (100-70)=30 *0.6 = 18 ; coverage 50 *0.4 = 20 ; overall 38
+    assert ev["overall_value_score"] == 38.0
+    assert list(Draft202012Validator(SCHEMA).iter_errors(ev)) == []
+
+
+def test_unknown_type_fallback_is_out_of_contract():
+    # The emitter still computes a generic fallback score for resilience...
+    ev = vd.compute_scored_event(
+        {"source_event_type": "something.else.v0", "source_event_id": "c3", "value_score": 42.0},
+        subject="x",
+    )
+    assert ev["overall_value_score"] == 42.0
+    assert len(ev["value_drivers"]) == 1
+    # ...but the schema admits only the four Crystal Atlas downstream types, so an
+    # out-of-contract source_event_type is (correctly) rejected — the enum has teeth.
+    errors = list(Draft202012Validator(SCHEMA).iter_errors(ev))
+    assert errors, "expected the strict source_event_type enum to reject an unknown finding type"

--- a/tools/tests/test_value_driver_seam.py
+++ b/tools/tests/test_value_driver_seam.py
@@ -53,6 +53,39 @@ def test_diligence_risk_is_inverted():
     assert list(Draft202012Validator(SCHEMA).iter_errors(ev)) == []
 
 
+def test_emit_refuses_out_of_contract_event(tmp_path, monkeypatch):
+    # Fail-closed: an unknown/missing source_event_type must not enter append-only state.
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    ev = vd.compute_scored_event(
+        {"source_event_type": "something.else.v0", "source_event_id": "c3", "value_score": 42.0},
+        subject="x",
+    )
+    import pytest
+
+    with pytest.raises(vd.OutOfContractEvent):
+        vd.emit(ev)
+    # nothing was written
+    assert not (tmp_path / "prophet-platform").exists()
+
+    # a missing source_event_id is also refused
+    good_type = vd.compute_scored_event(
+        {"source_event_type": "procurement.substitution.recommended.v0", "source_event_id": "", "estimated_savings_pct": 10},
+        subject="x",
+    )
+    with pytest.raises(vd.OutOfContractEvent):
+        vd.emit(good_type)
+
+
+def test_emit_writes_a_valid_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    ev = vd.compute_scored_event(
+        {"source_event_type": "procurement.substitution.recommended.v0", "source_event_id": "c1", "estimated_savings_pct": 60, "substitution_confidence": 80, "coverage_completeness": 100},
+        subject="vendor://acme",
+    )
+    corr = vd.emit(ev)
+    assert (tmp_path / "prophet-platform" / "payloads" / "value-driver-scorer" / f"{corr}.payload.json").exists()
+
+
 def test_unknown_type_fallback_is_out_of_contract():
     # The emitter still computes a generic fallback score for resilience...
     ev = vd.compute_scored_event(


### PR DESCRIPTION
Closes the diagnosed gap: Crystal Atlas findings and the value-driver mechanism were disconnected. Adds `intel.value_driver.scored.v0` (downstream event) that attaches an equity-weighted value-driver breakdown + overall_value_score to a Crystal Atlas finding, warranted (epistemic_level + provenance). Strict source_event_type enum (teeth — unknown types rejected, tested). Emitter `tools/emit_value_driver_score.py` + tests (ride tools-tests) + path-filtered CI (permissions: contents:read).

Conforms to the Workspace Control Plane spec: D6 (assets vs claims — this is a governed claim), PROV-style provenance, append-only governed event. 4/4 tests, example overall 73.0. Copilot eval / adversarial review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)